### PR TITLE
Fix pulling of PR labels during buildkite bootstrap.

### DIFF
--- a/.buildkite/scripts/bootstrap.sh
+++ b/.buildkite/scripts/bootstrap.sh
@@ -1,18 +1,18 @@
 #!/bin/bash
 
-REQUIRED_PR_LABEL="ready"
-
 echo "--- Starting Buildkite Bootstrap ---"
 
 # Check if the current build is a pull request
 if [ "$BUILDKITE_PULL_REQUEST" != "false" ]; then
   echo "This is a Pull Request build."
+  PR_LABELS=$(curl -s "https://api.github.com/repos/vllm-project/tpu_commons/pulls/$BUILDKITE_PULL_REQUEST" | jq -r '.labels[].name')
+
   # If it's a PR, check for the specific label
-  if buildkite-agent meta-data get "buildkite:pull_request_labels" | grep -q "$REQUIRED_PR_LABEL"; then
-    echo "Found '$REQUIRED_PR_LABEL' label on PR. Uploading main pipeline..."
+  if [[ $PR_LABELS == *"ready"* ]]; then
+    echo "Found 'ready' label on PR. Uploading main pipeline..."
     buildkite-agent pipeline upload .buildkite/pipeline.yml
   else
-    echo "No '$REQUIRED_PR_LABEL' label found on PR. Skipping main pipeline upload."
+    echo "No 'ready' label found on PR. Skipping main pipeline upload."
     exit 0 # Exit with 0 to indicate success (no error, just skipped)
   fi
 else


### PR DESCRIPTION
Previous code did not work and will not work as GitHub does not provide the PR labels during webhook notification. Buildkite label checks require access to the private repository as it must use the GitHub api, so this new code will not work until the repository is public. In the meantime, for CI runs during PR -- the pipeline can be configured to ignore label if needed or manual runs can be triggered. 