### PR TITLE
Add support for running vLLM models on the JAX runner.

### DIFF
--- a/tpu_commons/models/jax/model_loader.py
+++ b/tpu_commons/models/jax/model_loader.py
@@ -36,3 +36,19 @@ def get_model(
     )
     params = model.load_weights(vllm_config.model_config.model)
     return model, params
+
+
+def get_vllm_model(
+    vllm_config: VllmConfig,
+    rng: PRNGKey,
+    mesh: Mesh,
+):
+    from tpu_commons.models.vllm.vllm_model_wrapper import VllmModelWrapper
+
+    model = VllmModelWrapper(
+        vllm_config=vllm_config,
+        rng=rng,
+        mesh=mesh,
+    )
+    params = model.load_weights()
+    return model, params

--- a/tpu_commons/models/vllm/jax_attention_wrapper.py
+++ b/tpu_commons/models/vllm/jax_attention_wrapper.py
@@ -1,0 +1,153 @@
+import functools
+from typing import Optional, Tuple
+
+import jax
+import jax.numpy as jnp
+import torch
+import torch.nn
+from jax.sharding import Mesh
+from torchax.interop import jax_view, torch_view
+from vllm.attention import Attention as VllmAttention
+from vllm.model_executor.models.utils import extract_layer_index
+
+from tpu_commons.models.jax.attention_metadata import AttentionMetadata
+from tpu_commons.models.jax.layers.attention import (sharded_flash_attention,
+                                                     sharded_paged_attention,
+                                                     update_cache)
+from tpu_commons.models.jax.layers.chunked_prefill_attention import (
+    sharded_chunked_prefill_attention, sharded_chunked_prefill_update_cache)
+from tpu_commons.models.vllm.vllm_model_wrapper_context import \
+    get_vllm_model_wrapper_context
+
+KVCache = Tuple[jax.Array, jax.Array]
+
+
+@functools.partial(
+    jax.jit,
+    static_argnums=(
+        0, 6, 7, 8, 9,
+        10),  # is_prefill, mesh, scale, head_dim, num_heads, num_kv_heads
+    donate_argnums=(1, ),  # donate kv_cache
+)
+def _jax_attn_func(
+    is_prefill: bool,
+    kv_cache: KVCache,
+    q: jax.Array,
+    k: jax.Array,
+    v: jax.Array,
+    attention_metadata: AttentionMetadata,
+    mesh: Mesh,
+    scale: float,
+    head_dim: int,
+    num_heads: int,
+    num_kv_heads: int,
+) -> Tuple[KVCache, jax.Array]:
+
+    # Get shapes from vllm
+    bs, q_len, q_compute_dim = q.shape
+    _, k_len, k_compute_dim = k.shape
+    assert k.shape == v.shape
+    assert k.shape[0] == bs
+    assert q_compute_dim == head_dim * num_heads
+    assert k_compute_dim == head_dim * num_kv_heads
+
+    # Convert the shapes from vLLM's convetion to what the attention function expects
+    # bs, num_heads, q_len, head_dim
+    q = q.reshape(bs, q_len, num_heads, head_dim).swapaxes(1, 2)
+    # bs, num_kv_heads, k_len, head_dim
+    k = k.reshape(bs, k_len, num_kv_heads, head_dim).swapaxes(1, 2)
+    v = v.reshape(bs, k_len, num_kv_heads, head_dim).swapaxes(1, 2)
+
+    # vLLM scales q in the common Attention class, but jax models scale it in each of the model code.
+    q = (q * scale).astype(q.dtype)
+
+    md = attention_metadata
+    k_cache, v_cache = kv_cache
+    if md.chunked_prefill_enabled:
+        k_cache = sharded_chunked_prefill_update_cache(mesh)(
+            k_cache, md.kv_cache_write_indices, k, md.num_decode_seqs)
+        v_cache = sharded_chunked_prefill_update_cache(mesh)(
+            v_cache, md.kv_cache_write_indices, v, md.num_decode_seqs)
+        outputs = sharded_chunked_prefill_attention(mesh)(
+            q,
+            k_cache,
+            v_cache,
+            attention_metadata.decode_lengths,
+            attention_metadata.decode_page_indices,
+            attention_metadata.num_decode_seqs,
+            attention_metadata.prefill_lengths,
+            attention_metadata.prefill_page_indices,
+            attention_metadata.prefill_query_start_offsets,
+            attention_metadata.num_prefill_seqs,
+        )
+    else:
+        k_cache = update_cache(is_prefill, k_cache, md.kv_cache_write_indices,
+                               k)
+        v_cache = update_cache(is_prefill, v_cache, md.kv_cache_write_indices,
+                               v)
+        if is_prefill:
+            # (B, N, T, H)
+            # TODO(xiang): support MQA and GQA
+            if num_kv_heads != num_heads:
+                k = jnp.repeat(k, num_heads // num_kv_heads, axis=1)
+                v = jnp.repeat(v, num_heads // num_kv_heads, axis=1)
+            outputs = sharded_flash_attention(mesh)(q, k, v)
+        else:
+            # (B, N, H)
+            q = jnp.squeeze(q, 2)
+            outputs = sharded_paged_attention(mesh)(q, k_cache, v_cache,
+                                                    md.seq_lens,
+                                                    md.block_indices)
+            # (B, N, 1, H)
+            outputs = jnp.expand_dims(outputs, 2)
+
+    # Convert the shape back to vLLM's convention
+    assert outputs.shape[0] == bs
+    assert outputs.shape[1] == num_heads
+    assert outputs.shape[2] == q_len
+    assert outputs.shape[3] == head_dim
+    outputs = outputs.swapaxes(1, 2)  # bs, q_len, num_heads, head_dim
+    outputs = outputs.reshape(bs, q_len, q_compute_dim)
+
+    new_kv_cache = (k_cache, v_cache)
+    return new_kv_cache, outputs
+
+
+class JaxAttentionWrapper(torch.nn.Module):
+
+    def __init__(
+        self,
+        vllm_attn: VllmAttention,
+        mesh: Mesh,
+    ) -> None:
+        super().__init__()
+
+        self.num_heads = vllm_attn.num_heads
+        self.head_dim = vllm_attn.head_size
+        self.scale = vllm_attn.impl.scale
+        self.num_kv_heads = vllm_attn.num_kv_heads
+        self.layer_idx = extract_layer_index(vllm_attn.layer_name)
+        self.mesh = mesh
+
+    def forward(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        # For some alternate attention backends like MLA the attention output
+        # shape does not match the q shape, so we optionally let the model
+        # definition specify the output tensor shape.
+        output_shape: Optional[torch.Size] = None,
+    ) -> torch.Tensor:
+        vllm_model_wrapper_context = get_vllm_model_wrapper_context()
+        new_kv_cache, outputs = _jax_attn_func(
+            vllm_model_wrapper_context.is_prefill,
+            jax_view(vllm_model_wrapper_context.kv_caches[self.layer_idx]),
+            jax_view(q), jax_view(k), jax_view(v),
+            jax_view(vllm_model_wrapper_context.attention_metadata), self.mesh,
+            self.scale, self.head_dim, self.num_heads, self.num_kv_heads)
+        new_kv_cache = torch_view(new_kv_cache)
+        outputs = torch_view(outputs)
+        vllm_model_wrapper_context.kv_caches[self.layer_idx] = new_kv_cache
+
+        return outputs

--- a/tpu_commons/models/vllm/vllm_model_wrapper.py
+++ b/tpu_commons/models/vllm/vllm_model_wrapper.py
@@ -1,0 +1,195 @@
+import functools
+import tempfile
+from typing import List, Optional, Tuple
+
+import jax
+import torch
+import torch.nn
+import torchax
+from flax.typing import PRNGKey
+from jax.sharding import Mesh
+from torch.utils import _pytree as pytree
+from torchax.interop import call_torch, extract_all_buffers, jax_view
+from torchax.ops.mappings import j2t_dtype
+from vllm.attention import Attention as VllmAttention
+from vllm.config import VllmConfig, set_current_vllm_config
+from vllm.distributed.parallel_state import (ensure_model_parallel_initialized,
+                                             init_distributed_environment)
+from vllm.model_executor.model_loader import get_model as vllm_get_model
+from vllm.sequence import IntermediateTensors
+
+from tpu_commons.models.jax.attention_metadata import AttentionMetadata
+from tpu_commons.models.jax.layers.sampling import sample
+from tpu_commons.models.vllm.jax_attention_wrapper import JaxAttentionWrapper
+from tpu_commons.models.vllm.vllm_model_wrapper_context import (
+    get_vllm_model_wrapper_context, set_vllm_model_wrapper_context)
+
+KVCache = Tuple[jax.Array, jax.Array]
+
+
+def swap_attention_module(model: torch.nn.Module, mesh: Mesh) -> None:
+    """
+    Swap the Attention torhc.nn.Module used in the model with an implementation
+    in JAX, which uses the KVCache management and attention kernels for TPU.
+
+    Args:
+        model: A vLLM model
+    """
+
+    def _process_module(module, name=None, parent=None):
+        if isinstance(module, VllmAttention):
+            wrapped_module = JaxAttentionWrapper(module, mesh)
+            assert parent is not None and name is not None, (
+                "Top Level module is not expected to be wrapped.")
+            setattr(parent, name, wrapped_module)
+        for child_name, child_module in list(module.named_children()):
+            _process_module(child_module, child_name, module)
+
+    _process_module(model)
+
+
+class ModelForLogits(torch.nn.Module):
+
+    def __init__(self, vllm_model: torch.nn.Module):
+        super().__init__()
+
+        self.vllm_model = vllm_model
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        intermediate_tensors: Optional[IntermediateTensors],
+        inputs_embeds: Optional[torch.Tensor],
+    ) -> torch.Tensor:
+        hidden_state = self.vllm_model(input_ids, positions,
+                                       intermediate_tensors, inputs_embeds)
+        return self.vllm_model.compute_logits(hidden_state,
+                                              sampling_metadata=None)
+
+
+class VllmModelWrapper:
+    """ Wraps a vLLM Pytorch model and let it run on the JAX engine. """
+
+    rng: PRNGKey
+    mesh: Mesh
+
+    def __init__(self, vllm_config: VllmConfig, rng: PRNGKey, mesh: Mesh):
+        vllm_config.model_config.dtype = j2t_dtype(
+            vllm_config.model_config.dtype.dtype)
+        vllm_config.device_config.device = "xla"
+
+        self.vllm_config = vllm_config
+        self.rng = rng
+        self.mesh = mesh
+
+    def load_weights(self):
+        # Initialize the vLLM distribution layer as a single chip environment,
+        # we'll swap the model's parallel modules with TPU SPMD equivalents.
+        with set_current_vllm_config(self.vllm_config):
+            temp_file = tempfile.mkstemp()[1]
+            init_distributed_environment(
+                world_size=1,
+                rank=0,
+                local_rank=0,
+                distributed_init_method=f"file://{temp_file}",
+                backend="gloo",
+            )
+            ensure_model_parallel_initialized(
+                self.vllm_config.parallel_config.tensor_parallel_size,
+                self.vllm_config.parallel_config.pipeline_parallel_size,
+            )
+
+        # Load the vLLM model and wrap it into a new model whose forward
+        # function calculates the hidden_state and logits in one go.
+        model = ModelForLogits(vllm_get_model(vllm_config=self.vllm_config))
+
+        swap_attention_module(model, self.mesh)
+
+        # jax.config.update("jax_explain_cache_misses", True)
+
+        # Move the model into torchax 'jax' device so that jax code can interop
+        # with it and the overall program can be traced and compiled in XLA.
+        with torchax.default_env():
+            self.model_for_logits = model.to('jax')
+            params, buffers = extract_all_buffers(self.model_for_logits)
+            params, buffers = pytree.tree_map_only(torch.Tensor,
+                                                   lambda x: x.to('jax'),
+                                                   (params, buffers))
+            params_and_buffers = {**params, **buffers}
+
+        # Returning to the jax world, so we need to wrap it into a jax value.
+        return jax_view(params_and_buffers)
+
+    def jit_step_func(self):
+
+        def run_vllm_model_for_logits(
+            params_and_buffers,
+            is_prefill,
+            kv_caches,
+            input_ids,
+            attention_metadata,
+        ):
+            with set_vllm_model_wrapper_context(
+                    is_prefill=is_prefill,
+                    kv_caches=kv_caches,
+                    attention_metadata=attention_metadata,
+            ):
+                logits = torch.func.functional_call(
+                    self.model_for_logits,
+                    params_and_buffers,
+                    kwargs={
+                        "input_ids": input_ids,
+                        "positions": attention_metadata.input_positions,
+                        "intermediate_tensors": None,
+                        "inputs_embeds": None,
+                    },
+                    tie_weights=False,
+                    strict=True)
+                vllm_model_wrapper_context = get_vllm_model_wrapper_context()
+                new_kv_caches = vllm_model_wrapper_context.kv_caches
+            return new_kv_caches, logits
+
+        @functools.partial(
+            jax.jit,
+            static_argnums=(1, 2),  # is_prefill, do_sampling
+            donate_argnums=(3, ),  # donate kv_cache
+        )
+        def step_fun(
+            params_and_buffers,
+            is_prefill: bool,
+            do_sampling: bool,
+            kv_caches: List[KVCache],
+            input_ids: jax.Array,
+            attention_metadata: AttentionMetadata,
+            temperatures: jax.Array,
+            top_ps: jax.Array,
+            top_ks: jax.Array,
+            *args,
+        ) -> Tuple[List[KVCache], jax.Array, jax.Array]:
+
+            new_kv_caches, logits = call_torch(
+                run_vllm_model_for_logits,
+                params_and_buffers,
+                is_prefill,
+                kv_caches,
+                input_ids,
+                attention_metadata,
+            )
+
+            next_tokens = sample(
+                is_prefill,
+                do_sampling,
+                self.rng,
+                self.mesh,
+                logits,
+                attention_metadata.seq_lens,
+                temperatures,
+                top_ps,
+                top_ks,
+                attention_metadata.chunked_prefill_enabled,
+            )
+
+            return new_kv_caches, next_tokens, logits
+
+        return step_fun

--- a/tpu_commons/models/vllm/vllm_model_wrapper_context.py
+++ b/tpu_commons/models/vllm/vllm_model_wrapper_context.py
@@ -1,0 +1,48 @@
+from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import List, Optional, Tuple
+
+import jax
+
+from tpu_commons.models.jax.attention_metadata import AttentionMetadata
+
+KVCache = Tuple[jax.Array, jax.Array]
+
+
+@dataclass
+class VllmModelWrapperContext:
+    is_prefill: bool
+    kv_caches: List[KVCache]
+    attention_metadata: AttentionMetadata
+
+
+_vllm_model_wrapper_context: Optional[VllmModelWrapperContext] = None
+
+
+def get_vllm_model_wrapper_context() -> VllmModelWrapperContext:
+    assert _vllm_model_wrapper_context is not None, (
+        "VllmModelWrapperContext is not set. "
+        "Please use `set_vllm_model_wrapper_context` to set the VllmModelWrapperContext."
+    )
+    return _vllm_model_wrapper_context
+
+
+@contextmanager
+def set_vllm_model_wrapper_context(
+    *,
+    is_prefill: bool,
+    kv_caches: List[KVCache],
+    attention_metadata: AttentionMetadata,
+):
+    global _vllm_model_wrapper_context
+    prev_context = _vllm_model_wrapper_context
+    _vllm_model_wrapper_context = VllmModelWrapperContext(
+        is_prefill=is_prefill,
+        kv_caches=kv_caches,
+        attention_metadata=attention_metadata,
+    )
+
+    try:
+        yield
+    finally:
+        _vllm_model_wrapper_context = prev_context


### PR DESCRIPTION
# Description

Using torchax to interop the Pytorch code in vLLM models with the JAX runner.

Currently it works for models that can run on a single TPU v6e, such as Llama3.1 8B, Qwen2-1.5B, gemma-3-1b-it

To use it, set the following env vars:
```
TPU_BACKEND_TYPE=jax
MODEL_IMPL_TYPE=vllm
```


# Tests

Manually ran the command:

```
TPU_BACKEND_TYPE=jax MODEL_IMPL_TYPE=vllm python examples/offline_inference/basic/generate.py --model=meta-llama/Llama-3.1-8B --tensor_parallel_size=1 --task=generate --max_model_len=1024 --max_num_seqs=1
```

The generated output matches exactly with the corresponding command without ```MODEL_IMPL_TYPE=vllm```

