### PR TITLE
Fix environmental variable issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ pre-commit run --all-files
 Run `Llama 3.1 8B` offline inference on 4 TPU chips:
 
 ```
-TPU_BACKEND_TYPE=jax
+export TPU_BACKEND_TYPE=jax
 python vllm/examples/offline_inference/basic/generate.py \
     --model=meta-llama/Llama-3.1-8B \
     --tensor_parallel_size=4 \
@@ -44,8 +44,8 @@ python vllm/examples/offline_inference/basic/generate.py \
 Run the vLLM's implementation of `Llama 3.1 8B`, which is in Pytorch:
 
 ```
-MODEL_IMPL_TYPE=vllm
-TPU_BACKEND_TYPE=jax
+export MODEL_IMPL_TYPE=vllm
+export TPU_BACKEND_TYPE=jax
 python vllm/examples/offline_inference/basic/generate.py \
     --model=meta-llama/Llama-3.1-8B \
     --tensor_parallel_size=1 \


### PR DESCRIPTION
# Description

In the shell environment, if the variable is defined without "export", the newer python process cannot recognize it as the environmental variables. After adding "export", it is explicitly defined as an environmental variables so the python process can recognize. 

An alternative way is to put variable definition within the same command with the "python".


# Tests

Simple test to illustrate the difference: https://screenshot.googleplex.com/7izJ9Gb3sivbBsM

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have made or will make corresponding changes to any relevant documentation.
