### PR TITLE
Fix block_id concatenation bug after grouped KV change in upstream.

### DIFF
--- a/tpu_commons/runner/tpu_jax_runner_v2.py
+++ b/tpu_commons/runner/tpu_jax_runner_v2.py
@@ -456,7 +456,10 @@ class TPUModelRunner():
             req_state.num_computed_tokens = req_data.num_computed_tokens
             if not req_data.resumed_from_preemption:
                 # Append the new blocks to the existing block IDs.
-                req_state.block_ids.extend(req_data.new_block_ids)
+                for block_ids, new_block_ids in zip(req_state.block_ids,
+                                                    req_data.new_block_ids,
+                                                    strict=True):
+                    block_ids.extend(new_block_ids)
             else:
                 # The request is resumed from preemption.
                 # Replace the existing block IDs with the new ones.


### PR DESCRIPTION
# Description

vLLM made a change 3 weeks ago to the way they manage block id for KV cache. Such change should also change persistent batch implementation to work properly.

# Tests

The errors block mismatch errors do not appear anymore.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have made or will make corresponding changes to any relevant documentation.
