### PR TITLE
Prevent prefilling sequences returning result to vLLM.

### DIFF
--- a/tpu_commons/runner/tpu_jax_runner_v2.py
+++ b/tpu_commons/runner/tpu_jax_runner_v2.py
@@ -304,6 +304,8 @@ class TPUModelRunner():
 
         for i, seq in enumerate(all_reqs):
             # NOTE(pooyam): Unfinished prefills should not return anything to vLLM scheduler.
+            if not self._is_generating_new_token(scheduler_output, seq):
+                continue
 
             index = self.input_batch.req_id_to_index[seq.req_id]
             output_token_index = max(


### PR DESCRIPTION
# Description

During refactoring of my last PR, I mistakenly forgot this chunk of code. This is for preventing prefilling sequences to return result to vLLM.

# Tests

```
--------------------------------------------------
Prompt: 'Hello, my name is'
Generated text: ' Emily and I am a 25-year-old freelance writer and editor. I have'
--------------------------------------------------
Prompt: 'The president of the United States is'
Generated text: ' the head of state and head of government of the United States. The president serves'
--------------------------------------------------
Prompt: 'The capital of France is'
Generated text: ' a city of romance, art, fashion, and history. Paris is a must'
--------------------------------------------------
Prompt: 'The future of AI is'
Generated text: ' bright, but it also raises concerns about bias, accountability, and the impact on'
--------------------------------------------------
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have made or will make corresponding changes to any relevant documentation.
