### PR TITLE
Use power two for max_num_batched_tokens to fix CI.

### DIFF
--- a/scripts/vllm/benchmarking/README.md
+++ b/scripts/vllm/benchmarking/README.md
@@ -35,7 +35,7 @@ dataset_path=data/test/
 In order to run the benchmarks, navigate to your vLLM root directory and spin up a server to serve your model, for example:
 
 ```
-TPU_BACKEND_TYPE=jax vllm serve meta-llama/Llama-3.1-8B-Instruct --max-model-len=1024 --disable-log-requests --tensor-parallel-size 8 --max-num-batched-tokens 8196 --max-num-seqs=1
+TPU_BACKEND_TYPE=jax vllm serve meta-llama/Llama-3.1-8B-Instruct --max-model-len=1024 --disable-log-requests --tensor-parallel-size 8 --max-num-batched-tokens 8192 --max-num-seqs=1
 ```
 
 Once the server has begun -- you should see a message such as `INFO:     Application startup complete.` -- you can now run the client benchmarking command (in a new terminal) in your local vLLM repo:

--- a/tests/e2e/benchmarking/llama3.1_8b_mmlu_all_prompt.sh
+++ b/tests/e2e/benchmarking/llama3.1_8b_mmlu_all_prompt.sh
@@ -63,7 +63,7 @@ cp -r "$root_dir"/tpu_commons/scripts/vllm/benchmarking/*.py "$root_dir"/vllm/be
 
 # Spin up the vLLM server
 echo "Spinning up the vLLM server..."
-(TPU_BACKEND_TYPE=jax vllm serve "$model_name" --max-model-len=1024 --disable-log-requests --max-num-batched-tokens 8196 --max-num-seqs=1 2>&1 | tee -a "$LOG_FILE") &
+(TPU_BACKEND_TYPE=jax vllm serve "$model_name" --max-model-len=1024 --disable-log-requests --max-num-batched-tokens 8192 --max-num-seqs=1 2>&1 | tee -a "$LOG_FILE") &
 
 # Run a busy loop to block until the server is ready to receive requests
 did_find_ready_message=false

--- a/tests/e2e/benchmarking/llama3.1_8b_mmlu_few_prompt.sh
+++ b/tests/e2e/benchmarking/llama3.1_8b_mmlu_few_prompt.sh
@@ -63,7 +63,7 @@ cp -r "$root_dir"/tpu_commons/scripts/vllm/benchmarking/*.py "$root_dir"/vllm/be
 
 # Spin up the vLLM server
 echo "Spinning up the vLLM server..."
-(TPU_BACKEND_TYPE=jax vllm serve "$model_name" --max-model-len=1024 --disable-log-requests --max-num-batched-tokens 8196 --max-num-seqs=1 2>&1 | tee -a "$LOG_FILE") &
+(TPU_BACKEND_TYPE=jax vllm serve "$model_name" --max-model-len=1024 --disable-log-requests --max-num-batched-tokens 8192 --max-num-seqs=1 2>&1 | tee -a "$LOG_FILE") &
 
 # Run a busy loop to block until the server is ready to receive requests
 did_find_ready_message=false


### PR DESCRIPTION
# Description

`max_num_batched_tokens` must be multiple of `page_size` for chunked prefill to work.

# Tests

Fixing CI error: https://buildkite.com/tpu-commons/tpu-commons-ci/builds/30

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have made or will make corresponding changes to any relevant documentation.
