### PR TITLE
Fix MoE w2 weight sharding and code cleanup.

### DIFF
--- a/tpu_commons/models/vllm/jax_qkv_parallel_linear.py
+++ b/tpu_commons/models/vllm/jax_qkv_parallel_linear.py
@@ -26,7 +26,7 @@ class JaxQKVParallelLinear(torch.nn.Module):
         self.q_bias: Optional[Parameter]
         self.k_bias: Optional[Parameter]
         self.v_bias: Optional[Parameter]
-        self._load_weights_from_qkv_linear(qkv_linear)
+        self._load_weights_from_vllm_layer(qkv_linear)
         self._shard_weight(mesh)
 
     def _shard_weight(self, mesh: Mesh):
@@ -47,7 +47,7 @@ class JaxQKVParallelLinear(torch.nn.Module):
             self.v_bias.apply_jax_(jax.device_put,
                                    NamedSharding(mesh, P('model')))
 
-    def _load_weights_from_qkv_linear(self, qkv_linear: torch.nn.Module):
+    def _load_weights_from_vllm_layer(self, qkv_linear: torch.nn.Module):
         q_proj_size, k_proj_size, _ = qkv_linear.output_sizes
         # The weight of qkv linear is a concatenation of q, k, and v weights
         # along the output dimension.


### PR DESCRIPTION
# Description

It was a happy accident that the previous sharding worked, the `w2_weight` sharding need to match what is specified in `sharded_gmm` for `rhs`

# Tests

Both Qwen3-30B-A3B and Mixtral-7x8B working as previously:

```
MODEL_IMPL_TYPE=vllm TPU_BACKEND_TYPE=jax python examples/offline_inference/basic/generate.py     --model=Qwen/Qwen3-30B-A3B     --tensor_parallel_size=4     --task=generate     --max_model_len=1024     --max_num_seqs=1
```

```
MODEL_IMPL_TYPE=vllm TPU_BACKEND_TYPE=jax python examples/offline_inference/basic/generate.py     --model=mistralai/Mixtral-8x7B-Instruct-v0.1     --tensor_parallel_size=8     --task=generate     --max_model_len=1024     --max_num_seqs=1
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [ ] I have performed a self-review of my code.
- [ ] I have necessary comments in my code, particularly in hard-to-understand areas.
- [ ] I have made or will make corresponding changes to any relevant documentation.
