### PR TITLE
Fix block size for jax path

### DIFF
--- a/tpu_commons/runner/tpu_jax_runner_v2.py
+++ b/tpu_commons/runner/tpu_jax_runner_v2.py
@@ -194,6 +194,9 @@ class TPUModelRunner():
             kv_cache_spec.block_size,
             kv_cache_spec.head_size,
         )
+        logger.info(
+            f"Init kv-cache | shape={len(layer_names)} * {cache_shape}")
+
         # Shard the num_kv_heads dim along the 'model' axis.
         sharding = NamedSharding(self.mesh, PartitionSpec("model"))
 


### PR DESCRIPTION
# Description

Fix `--block_size=32` for JAX path when it's not explicitly set. Otherwise it's error when set `--max_model_len=4096`:
```
  File "/home/ymu_google_com/tpu_commons/tpu_commons/models/jax/layers/attention.py", line 171, in update_cache
    operand = jnp.swapaxes(operand, 0, 1).reshape(K, I, S, H)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
......
    raise TypeError(f"cannot reshape array of shape {arr.shape} (size {arr.size}) "
TypeError: cannot reshape array of shape (8, 1, 128, 128) (size 131072) into shape (8, 0, 256, 128) (size 0)
```

# Tests
Pass
```
python $HOME/vllm/examples/offline_inference/basic/generate.py \
--model=/mnt/disks/data/meta-llama/Llama-3.1-8B \
--tensor_parallel_size=4 \
--task=generate \
--max_model_len=4096 \
--max_num_seqs=1
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [ ] I have performed a self-review of my code.
- [ ] I have necessary comments in my code, particularly in hard-to-understand areas.
- [ ] I have made or will make corresponding changes to any relevant documentation.
