### PR TITLE
Fix num scheduled tokens

### DIFF
--- a/tpu_commons/runner/tpu_jax_runner_v2.py
+++ b/tpu_commons/runner/tpu_jax_runner_v2.py
@@ -893,8 +893,11 @@ class TPUModelRunner():
         assert num_prefill_seqs > 0
         assert num_prefill_seqs <= MAX_PREFILL_SEQS_PER_TOKEN_BATCH
 
+        # NOTE(pooyam): We add `block_size` here to compensate for the case when decodes are not page-aligned by the scheduler.
+        # Decodes not being page-aligned, does not cause correctness issue but will cause exceeding token budget by block_size amount.
+        # Once the scheduler makes sure both prefill and decodes are page-aligned, we can remove this addition.
         num_tokens_scheduled = pad_to_multiple(
-            scheduler_output.total_num_scheduled_tokens,
+            scheduler_output.total_num_scheduled_tokens + block_size,
             self.scheduler_config.chunked_prefill_tokens_padding,
         )
 


### PR DESCRIPTION
# Description

We add `block_size` here to compensate for the case when decodes are not page-aligned by the scheduler.
        # Decodes not being page-aligned, does not cause correctness issue but will cause exceeding token budget by block_size amount.
        # Once the scheduler makes sure both prefill and decodes are page-aligned, we can remove this addition.

# Tests

```
PYTHONPATH=$PYTHONPATH:/home/pooyam/vllm TPU_BACKEND_TYPE=jax python vllm/examples/offline_inference/basic/generate.py     --task=generate     --max_model_len=1024 --model=/dev/shm/Llama-3.1-8B-Instruct/ --tensor-parallel-size=4  --max_num_seqs=1
```

```
--------------------------------------------------                                                           
Prompt: 'Hello, my name is'                       
Generated text: ' Emily and I am a 25-year-old freelance writer and editor. I have'  
--------------------------------------------------                                                           
Prompt: 'The president of the United States is'   
Generated text: ' the head of state and head of government of the United States. The president serves'
--------------------------------------------------                                                           
Prompt: 'The capital of France is'                
Generated text: ' a city of romance, art, fashion, and cuisine. Paris is a must'
--------------------------------------------------                                                           
Prompt: 'The future of AI is'                     
Generated text: ' bright, but it also raises concerns about bias, accountability, and the impact on'
--------------------------------------------------
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [ ] I have performed a self-review of my code.
- [ ] I have necessary comments in my code, particularly in hard-to-understand areas.
- [ ] I have made or will make corresponding changes to any relevant documentation.
