### PR TITLE
Add offline inference example

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Run `Llama 3.1 8B` offline inference on 4 TPU chips:
 
 ```
 export TPU_BACKEND_TYPE=jax
-python vllm/examples/offline_inference/basic/generate.py \
+python tpu_commons/examples/offline_inference.py \
     --model=meta-llama/Llama-3.1-8B \
     --tensor_parallel_size=4 \
     --task=generate \
@@ -52,7 +52,7 @@ Run the vLLM's implementation of `Llama 3.1 8B`, which is in Pytorch. It is the 
 ```
 export MODEL_IMPL_TYPE=vllm
 export TPU_BACKEND_TYPE=jax
-python vllm/examples/offline_inference/basic/generate.py \
+python tpu_commons/examples/offline_inference.py \
     --model=meta-llama/Llama-3.1-8B \
     --tensor_parallel_size=4 \
     --task=generate \
@@ -78,16 +78,16 @@ MODEL_IMPL_TYPE=flax_nnx
 MODEL_IMPL_TYPE=vllm
 ```
 
+To enable profiling:
+
+```
+VLLM_TORCH_PROFILER_DIR=$PWD
+```
+
 To enable experimental scheduler:
 
 ```
 EXP_SCHEDULER=1
-```
-
-To inspect model weights sharding:
-
-```
-INSPECT_MODEL=1
 ```
 
 ## Develop on a CPU VM and run docker on a TPU VM
@@ -120,7 +120,7 @@ docker run \
   --rm \
   -e TPU_BACKEND_TYPE=jax \
   $DOCKER_URI \
-  python /workspace/vllm/examples/offline_inference/basic/generate.py \
+  python /workspace/tpu_commons/examples/offline_inference.py \
   --model=meta-llama/Llama-3.1-8B \
   --tensor_parallel_size=4 \
   --task=generate \

--- a/examples/offline_inference.py
+++ b/examples/offline_inference.py
@@ -1,0 +1,68 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import vllm.envs as envs
+from vllm import LLM, EngineArgs
+from vllm.utils import FlexibleArgumentParser
+
+
+def create_parser():
+    parser = FlexibleArgumentParser()
+    # Add engine args
+    EngineArgs.add_cli_args(parser)
+    parser.set_defaults(model="meta-llama/Llama-3.2-1B-Instruct")
+    # Add sampling params
+    sampling_group = parser.add_argument_group("Sampling parameters")
+    sampling_group.add_argument("--max-tokens", type=int)
+    sampling_group.add_argument("--temperature", type=float)
+    sampling_group.add_argument("--top-p", type=float)
+    sampling_group.add_argument("--top-k", type=int)
+
+    return parser
+
+
+def main(args: dict):
+    # Pop arguments not used by LLM
+    max_tokens = args.pop("max_tokens")
+    temperature = args.pop("temperature")
+    top_p = args.pop("top_p")
+    top_k = args.pop("top_k")
+
+    # Create an LLM
+    llm = LLM(**args)
+
+    # Create a sampling params object
+    sampling_params = llm.get_default_sampling_params()
+    if max_tokens is not None:
+        sampling_params.max_tokens = max_tokens
+    if temperature is not None:
+        sampling_params.temperature = temperature
+    if top_p is not None:
+        sampling_params.top_p = top_p
+    if top_k is not None:
+        sampling_params.top_k = top_k
+
+    # Generate texts from the prompts. The output is a list of RequestOutput
+    # objects that contain the prompt, generated text, and other information.
+    prompts = [
+        "The president of the United States is", "The capital of France is",
+        "The future of AI is", "The colors of the rainbow are"
+    ]
+    if envs.VLLM_TORCH_PROFILER_DIR is not None:
+        llm.start_profile()
+    outputs = llm.generate(prompts, sampling_params)
+    # Print the outputs.
+    print("-" * 50)
+    for output in outputs:
+        prompt = output.prompt
+        generated_text = output.outputs[0].text
+        print(f"Prompt: {prompt!r}\nGenerated text: {generated_text!r}")
+        print("-" * 50)
+    if envs.VLLM_TORCH_PROFILER_DIR is not None:
+        llm.stop_profile()
+
+
+if __name__ == "__main__":
+    parser = create_parser()
+    args: dict = vars(parser.parse_args())
+    main(args)


### PR DESCRIPTION
# Description

To better control the testing, like adding profiling.

# Tests

```
export VLLM_TORCH_PROFILER_DIR=$PWD
export TPU_BACKEND_TYPE=jax

python $HOME/tpu_commons/examples/offline_inference.py \
--model=meta-llama/Llama-3.1-8B \
--tensor_parallel_size=4 \
--task=generate \
--max_model_len=4096 \
--max_num_seqs=1
```

```
--------------------------------------------------
Prompt: 'The president of the United States is'
Generated text: ' the head of state and head of government of the United States. The president leads'
--------------------------------------------------
Prompt: 'The capital of France is'
Generated text: ' a city of many faces. It is a city of history, culture, and'
--------------------------------------------------
Prompt: 'The future of AI is'
Generated text: ' here, and it’s already changing the way we live and work. From self'
--------------------------------------------------
Prompt: 'The colors of the rainbow are'
Generated text: ' red, orange, yellow, green, blue, indigo, and violet.'
--------------------------------------------------
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [ ] I have performed a self-review of my code.
- [ ] I have necessary comments in my code, particularly in hard-to-understand areas.
- [ ] I have made or will make corresponding changes to any relevant documentation.
