### PR TITLE
Bump vllm version to 0619

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Follow this [guide](https://docs.vllm.ai/en/latest/getting_started/installation/
 **NOTE**: Right after `git clone` vLLM repo and before running any `pip install` commands, run the following command to pin the version:
 
 ```
-git checkout 53a5a0ce30dd623808ebd02947e5183f918b6c2f
+git checkout 12575cfa7aa176e017735dd2883513b12be54c32
 ```
 
 ### Install `tpu_commons`:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update && apt-get install -y \
 # Build vLLM
 WORKDIR /workspace/vllm
 ARG VLLM_REPO=https://github.com/vllm-project/vllm.git
-ARG VLLM_COMMIT_SHA=53a5a0ce30dd623808ebd02947e5183f918b6c2f
+ARG VLLM_COMMIT_SHA=12575cfa7aa176e017735dd2883513b12be54c32
 RUN git clone $VLLM_REPO /workspace/vllm
 RUN git reset --hard $VLLM_COMMIT_SHA
 RUN pip install -r requirements/tpu.txt

--- a/tpu_commons/worker/tpu_worker_jax.py
+++ b/tpu_commons/worker/tpu_worker_jax.py
@@ -73,6 +73,11 @@ class TPUWorker(WorkerBase):
             ))
         utils.set_visible_device_ids(device_ids)
 
+    def initialize_cache(self, num_gpu_blocks: int,
+                         num_cpu_blocks: int) -> None:
+        self.cache_config.num_gpu_blocks = num_gpu_blocks
+        self.cache_config.num_cpu_blocks = num_cpu_blocks
+
     def init_device(self):
         self.devices = jax.local_devices()
         self.global_devices = jax.devices()


### PR DESCRIPTION
# Description

Bump vllm version to base on latest feature.

# Tests

```
export VLLM_TORCH_PROFILER_DIR=$PWD
export TPU_BACKEND_TYPE=jax

python $HOME/tpu_commons/examples/offline_inference.py \
--model=/mnt/disks/data/meta-llama/Llama-3.1-8B \
--tensor_parallel_size=4 \
--task=generate \
--max_model_len=4096 \
--max_num_seqs=1
```

```
--------------------------------------------------
Prompt: 'The president of the United States is'
Generated text: ' the head of state and head of government of the United States. The president leads'
--------------------------------------------------
Prompt: 'The capital of France is'
Generated text: ' a city of many faces. It is a city of history, culture, and'
--------------------------------------------------
Prompt: 'The future of AI is'
Generated text: ' here, and it’s already changing the way we live and work. From self'
--------------------------------------------------
Prompt: 'The colors of the rainbow are'
Generated text: ' red, orange, yellow, green, blue, indigo, and violet.'
--------------------------------------------------
```

https://buildkite.com/tpu-commons/tpu-commons-ci/builds/122

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [ ] I have performed a self-review of my code.
- [ ] I have necessary comments in my code, particularly in hard-to-understand areas.
- [ ] I have made or will make corresponding changes to any relevant documentation.
