### PR TITLE
[Bugfix] Use correct _MODEL_REGISTRY on flax nn path

### DIFF
--- a/tpu_commons/models/jax/model_loader.py
+++ b/tpu_commons/models/jax/model_loader.py
@@ -15,19 +15,19 @@ def _get_model_architecture(config: PretrainedConfig) -> nn.Module:
     # NOTE: Use inline imports here, otherwise the normal imports
     # would cause JAX init failure when using multi hosts with Ray.
 
+    _MODEL_REGISTRY = {}
     impl = os.getenv("MODEL_IMPL_TYPE", "flax_nnx").lower()
+
     if impl == "flax_nn":
         from tpu_commons.models.jax.llama_nn import LlamaForCausalLM
+        _MODEL_REGISTRY["LlamaForCausalLM"] = LlamaForCausalLM
     elif impl == "flax_nnx":
         from tpu_commons.models.jax.llama import LlamaForCausalLM
+        _MODEL_REGISTRY["LlamaForCausalLM"] = LlamaForCausalLM
         from tpu_commons.models.jax.qwen2 import Qwen2ForCausalLM
+        _MODEL_REGISTRY["Qwen2ForCausalLM"] = Qwen2ForCausalLM
     else:
         raise NotImplementedError("Unsupported MODEL_IMPL_TYPE")
-
-    _MODEL_REGISTRY = {
-        "LlamaForCausalLM": LlamaForCausalLM,
-        "Qwen2ForCausalLM": Qwen2ForCausalLM,
-    }
 
     architectures = getattr(config, "architectures", [])
     for arch in architectures:


### PR DESCRIPTION
# Description

Use correct `_MODEL_REGISTRY` on flax nn path. The previous implementation, in the flax nn path, used undefined `Qwen2ForCausalLM` as the value of `_MODEL_REGISTRY`. cc: @xiangxu-google @jrplatin 

# Tests
```
TPU_BACKEND_TYPE=jax MODEL_IMPL_TYPE=flax_nn python tpu_commons/examples/offline_inference.py     --model=/mnt/disks/data/meta-llama/Llama-3.1-8B     --tensor_parallel_size=4     --task=generate     --max_model_len=1024     --max_num_seqs=1
```

```
Processed prompts: 100%|█| 4/4 [00:16<00:00,  4.25s/it, est. speed input: 1.59 toks/s, ou
--------------------------------------------------
Prompt: 'The president of the United States is'
Generated text: ' the head of state and head of government of the United States, indirectly elected to'
--------------------------------------------------
Prompt: 'The capital of France is'
Generated text: ' a city of many faces. It is a city of history, a city of'
--------------------------------------------------
Prompt: 'The future of AI is'
Generated text: ' here, and it’s already changing the way we live and work. From self'
--------------------------------------------------
Prompt: 'The colors of the rainbow are'
Generated text: ' red, orange, yellow, green, blue, indigo, and violet.'
--------------------------------------------------
```
# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have made or will make corresponding changes to any relevant documentation.
