### PR TITLE
Tweak the code to make offline inference work with Pathways

### DIFF
--- a/tpu_commons/core/core_tpu.py
+++ b/tpu_commons/core/core_tpu.py
@@ -70,6 +70,7 @@ class EngineCore:
             self.model_executor.register_failure_callback(
                 executor_fail_callback)
 
+        logger.info("executor created.")
         # Setup KV Caches and update CacheConfig after profiling.
         num_gpu_blocks, num_cpu_blocks, kv_cache_config = \
             self._initialize_kv_caches(vllm_config)
@@ -77,7 +78,9 @@ class EngineCore:
         vllm_config.cache_config.num_gpu_blocks = num_gpu_blocks
         vllm_config.cache_config.num_cpu_blocks = num_cpu_blocks
 
+        logger.info("KV cache initialized.")
         self.structured_output_manager = StructuredOutputManager(vllm_config)
+        logger.info("structure output manager created.")
 
         # Setup scheduler.
         # if isinstance(vllm_config.scheduler_config.scheduler_cls, str):
@@ -109,9 +112,11 @@ class EngineCore:
             max_model_len=vllm_config.scheduler_config.max_model_len,
             enable_caching=False,
         )
+        logger.info("kv cache manager created.")
         # Setup MM Input Mapper.
         self.mm_input_cache_server = MirroredProcessingCache(
             vllm_config.model_config)
+        logger.info("mirrored processing cache created.")
 
         # Setup batch queue for pipeline parallelism.
         # Batch queue for scheduled batches. This enables us to asynchronously
@@ -124,6 +129,7 @@ class EngineCore:
             logger.info("Batch queue is enabled with size %d",
                         self.batch_queue_size)
             self.batch_queue = queue.Queue(self.batch_queue_size)
+        logger.warning("set up jetstream driver")
         self.orchestrator = self._setup_driver(vllm_config,
                                                self.kv_cache_manager, True)
         logger.warning("starting jetstream orchestrator")

--- a/tpu_commons/core/jetstream_commons/engine/__init__.py
+++ b/tpu_commons/core/jetstream_commons/engine/__init__.py
@@ -15,10 +15,13 @@
 
 from importlib import util
 
+PATHWAYS_ENABLED = False
+
 if util.find_spec("pathwaysutils"):
     import pathwaysutils
 
     pathwaysutils.initialize()
+    PATHWAYS_ENABLED = True
 else:
     print("Running JetStream without Pathways. "
           "Module pathwaysutils is not imported.")

--- a/tpu_commons/core/tpu_jax_engine.py
+++ b/tpu_commons/core/tpu_jax_engine.py
@@ -168,6 +168,7 @@ class JaxEngine(engine_api.Engine):
         cached_reqs = [
             all_requests[request_id]
             for request_id in input_batch.req_id_to_index
+            if request_id in all_requests
         ]
         scheduled_cached_reqs = []
         for request in cached_reqs:

--- a/tpu_commons/utils_jax.py
+++ b/tpu_commons/utils_jax.py
@@ -3,6 +3,7 @@ from typing import Any, List, Tuple
 
 import jax
 from ray._private.accelerators import TPUAcceleratorManager
+from tpu_commons.core.jetstream_commons.engine import PATHWAYS_ENABLED
 
 GBYTES = 1024 * 1024 * 1024
 
@@ -43,9 +44,16 @@ def get_num_kv_heads_by_tp(num_kv_heads: int, tp_size: int) -> int:
 def hbm_usage_bytes(devices: Any) -> List[Tuple[int, int]]:
     usage = []
     for device in devices:
-        hbm_used = device.memory_stats()["bytes_in_use"]
-        hbm_limit = device.memory_stats()["bytes_limit"]
-        usage.append((hbm_used, hbm_limit))
+        if PATHWAYS_ENABLED:
+            # The Pathways backend doesn't support memory_stats().
+            # TODO(fhzhang): find the proper way to support this.
+            usage.append((32384, 33550237184))
+        else:
+            hbm_used = device.memory_stats()["bytes_in_use"]
+            hbm_limit = device.memory_stats()["bytes_limit"]
+            print(hbm_used, hbm_limit)
+            usage.append((hbm_used, hbm_limit))
+
     return usage
 
 


### PR DESCRIPTION
This PR enables Pathways integration with the JAX code path.

This is a step stone for disaggregate serving with Pathways. A few changes were made:

- More logging to help capture initialization slowness
- Hack away memory_stats() for now as Pathways doesn't support it
- Fixes a minor race in jax engine (requests might not have reached the generation thread yet)
- Fix the devices passed into the tpu runner, in case pathways is hooked up, there maybe more than 8 devices provided.

Known issues (other than the memory stats and device count hack mentioned):
- KV cache initialization is pretty slow, could be due to the port forwarding.

# Tests
With Pathways:

```
# Need to clone https://github.com/AI-Hypercomputer/pathways-utils.

# Port forwarding to PW pod
kubectl port-forward pod/jetstream-pathways-0 38681:38681

# in a different terminal
JAX_PLATFORMS=proxy,cpu PYTHONPATH=$(pwd)/pathways-utils JAX_BACKEND_TARGET=grpc://localhost:38681 TPU_BACKEND_TYPE=jax python vllm/examples/offline_inference/basic/generate.py --task=generate --model=meta-llama/Meta-Llama-3-8B-Instruct --max_model_len=1024 --max_num_seqs=8
```

Without Pathways:
```
TPU_BACKEND_TYPE=jax python vllm/examples/offline_inference/basic/generate.py --task=generate --model=meta-llama/Meta-Llama-3-8B-Instruct --max_model_len=1024 --max_num_seqs=8
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have made or will make corresponding changes to any relevant documentation.
