### PR TITLE
Optimize nnx model loading and inference

### DIFF
--- a/tpu_commons/models/jax/model_loader.py
+++ b/tpu_commons/models/jax/model_loader.py
@@ -80,22 +80,33 @@ def get_nnx_model(
 ):
     model_class = _get_model_architecture(vllm_config.model_config.hf_config)
 
+    # We first create an abstract model without allocating any weights,
+    # then fill in its weigths during load_weights from HF.
+    # This shows 3 advantages than the normal way:
+    # 1. The model weights will only be allocated once. Otherwise the normal way
+    #    will random-init the model weights first, then load the real weights.
+    #    The two pass weights allocation causes model loading slow.
+    # 2. The model loading won't be OOM. Otherwise the normal way will hold
+    #    a full model weights after random-init, then duplicate a layer during
+    #    the load_weights. This would be easy to OOM if the layer is super large.
+    # 3. The model architecture definition won't need to worry about the sharding.
+    #    The sharding definition is taken over by the load_weights instead.
+    model = nnx.eval_shape(lambda: model_class(vllm_config, rng, mesh))
+    model.load_weights(rng)
+
+    # Although the created model can already work, we still need to jit
+    # the model creation again with sharding, otherwise the model forward
+    # will have non-trivial overhead in PjitFunction.
     @nnx.jit
-    def create_sharded_model():
-        model = model_class(vllm_config, rng, mesh)
+    def create_sharded_model(model):
         state = nnx.state(model)
         pspecs = nnx.get_partition_spec(state)
         sharded_state = jax.lax.with_sharding_constraint(state, pspecs)
         nnx.update(model, sharded_state)
         return model
 
-    # Create the model instance with inited sharded weights
-    # TODO(xiang): create abstract model without weights allocated
-    # https://flax.readthedocs.io/en/latest/guides/surgery.html#creating-an-abstract-model-or-state-without-memory-allocation
     with mesh:
-        jit_model = create_sharded_model()
-
-    jit_model.load_weights()
+        jit_model = create_sharded_model(model)
 
     kv_cache_sharding = NamedSharding(mesh, PartitionSpec("model"))
     outputs_sharding = NamedSharding(mesh, PartitionSpec(None))
@@ -119,11 +130,7 @@ def get_nnx_model(
         model = nnx.merge(graphdef, state)
         return model(*args)
 
-    def model_fn(graphdef, state, *args):
-        with mesh:
-            return run_model(graphdef, state, *args)
-
-    model_fn = functools.partial(model_fn, graphdef, state)
+    model_fn = functools.partial(run_model, graphdef, state)
     return model_fn
 
 

--- a/tpu_commons/models/jax/qwen2.py
+++ b/tpu_commons/models/jax/qwen2.py
@@ -31,7 +31,6 @@ class Qwen2MLP(nnx.Module):
             intermediate_size,
             use_bias=False,
             param_dtype=dtype,
-            kernel_init=nnx.with_partitioning(init_fn, (None, "model")),
             rngs=rng,
         )
         self.up_proj = nnx.Linear(
@@ -39,7 +38,6 @@ class Qwen2MLP(nnx.Module):
             intermediate_size,
             use_bias=False,
             param_dtype=dtype,
-            kernel_init=nnx.with_partitioning(init_fn, (None, "model")),
             rngs=rng,
         )
         self.down_proj = nnx.Linear(
@@ -47,7 +45,6 @@ class Qwen2MLP(nnx.Module):
             hidden_size,
             use_bias=False,
             param_dtype=dtype,
-            kernel_init=nnx.with_partitioning(init_fn, ("model", None)),
             rngs=rng,
         )
         self.act_fn = modeling_flax_utils.ACT2FN[act]
@@ -78,8 +75,6 @@ class Qwen2Attention(nnx.Module):
             (self.num_heads, self.hidden_size, self.head_dim),
             (self.num_heads, self.head_dim),  # bias shape [N, H]
             param_dtype=dtype,
-            kernel_init=nnx.with_partitioning(init_fn, ("model", None, None)),
-            bias_init=nnx.with_partitioning(init_fn, ("model", None)),
             rngs=rng,
         )
         self.k_proj = nnx.Einsum(
@@ -87,8 +82,6 @@ class Qwen2Attention(nnx.Module):
             (self.num_kv_heads, self.hidden_size, self.head_dim),
             (self.num_kv_heads, self.head_dim),  # bias shape [K, H])
             param_dtype=dtype,
-            kernel_init=nnx.with_partitioning(init_fn, ("model", None, None)),
-            bias_init=nnx.with_partitioning(init_fn, ("model", None)),
             rngs=rng,
         )
         self.v_proj = nnx.Einsum(
@@ -96,15 +89,12 @@ class Qwen2Attention(nnx.Module):
             (self.num_kv_heads, self.hidden_size, self.head_dim),
             (self.num_kv_heads, self.head_dim),  # bias shape [K, H])
             param_dtype=dtype,
-            kernel_init=nnx.with_partitioning(init_fn, ("model", None, None)),
-            bias_init=nnx.with_partitioning(init_fn, ("model", None)),
             rngs=rng,
         )
         self.o_proj = nnx.Einsum(
             "BNTH,NHD->BTD",
             (self.num_heads, self.head_dim, self.hidden_size),
             param_dtype=dtype,
-            kernel_init=nnx.with_partitioning(init_fn, ("model", None, None)),
             rngs=rng,
         )
 
@@ -160,7 +150,6 @@ class Qwen2DecoderLayer(nnx.Module):
             hidden_size,
             epsilon=rms_norm_eps,
             param_dtype=dtype,
-            scale_init=nnx.with_partitioning(init_fn, (None, )),
             rngs=rng,
         )
         self.self_attn = Qwen2Attention(config=config,
@@ -171,7 +160,6 @@ class Qwen2DecoderLayer(nnx.Module):
             hidden_size,
             epsilon=rms_norm_eps,
             param_dtype=dtype,
-            scale_init=nnx.with_partitioning(init_fn, (None, )),
             rngs=rng,
         )
         self.mlp = Qwen2MLP(
@@ -229,7 +217,6 @@ class Qwen2Model(nnx.Module):
             hidden_size,
             epsilon=rms_norm_eps,
             param_dtype=dtype,
-            scale_init=nnx.with_partitioning(init_fn, (None, )),
             rngs=rng,
         )
 
@@ -255,7 +242,7 @@ class Qwen2Model(nnx.Module):
 
 class Qwen2ForCausalLM(nnx.Module):
 
-    def __init__(self, vllm_config: VllmConfig, rng: jax.Array,
+    def __init__(self, vllm_config: VllmConfig, rng_key: jax.Array,
                  mesh: Mesh) -> None:
         model_config = vllm_config.model_config
         vocab_size = model_config.get_vocab_size()
@@ -263,14 +250,13 @@ class Qwen2ForCausalLM(nnx.Module):
         dtype = model_config.dtype
 
         self.vllm_config = vllm_config
-        self.rng = nnx.Rngs(rng)
+        self.rng = nnx.Rngs(rng_key)
         self.mesh = mesh
 
         self.embed = nnx.Embed(
             num_embeddings=vocab_size,
             features=hidden_size,
             param_dtype=dtype,
-            embedding_init=nnx.with_partitioning(init_fn, ("model", None)),
             rngs=self.rng,
         )
         self.model = Qwen2Model(
@@ -284,9 +270,7 @@ class Qwen2ForCausalLM(nnx.Module):
             self.lm_head = self.embed.embedding
         else:
             self.lm_head = nnx.Param(
-                init_fn(self.rng.params(), (hidden_size, vocab_size), dtype),
-                sharding=(None, "model"),
-            )
+                init_fn(self.rng.params(), (hidden_size, vocab_size), dtype), )
 
     def __call__(
         self,
@@ -332,39 +316,46 @@ class Qwen2ForCausalLM(nnx.Module):
         )
         return kv_caches, next_tokens, logits
 
-    def load_weights(self):
+    def load_weights(self, rng_key: jax.Array):
+        # NOTE: Since we are using nnx.eval_shape to init the model,
+        # we have to pass dynamic arrays here for __call__'s usage.
+        self.rng = nnx.Rngs(rng_key)
+
         mappings = {
-            "model.embed_tokens": "embed.embedding",
+            "model.embed_tokens": ("embed.embedding", ("model", None)),
             "model.layers.*.input_layernorm":
-            "model.layers.*.input_layernorm.scale",
+            ("model.layers.*.input_layernorm.scale", (None, )),
             "model.layers.*.mlp.down_proj":
-            "model.layers.*.mlp.down_proj.kernel",
+            ("model.layers.*.mlp.down_proj.kernel", ("model", None)),
             "model.layers.*.mlp.gate_proj":
-            "model.layers.*.mlp.gate_proj.kernel",
-            "model.layers.*.mlp.up_proj": "model.layers.*.mlp.up_proj.kernel",
+            ("model.layers.*.mlp.gate_proj.kernel", (None, "model")),
+            "model.layers.*.mlp.up_proj": ("model.layers.*.mlp.up_proj.kernel",
+                                           (None, "model")),
             "model.layers.*.post_attention_layernorm":
-            "model.layers.*.post_attention_layernorm.scale",
+            ("model.layers.*.post_attention_layernorm.scale", (None, )),
             "model.layers.*.self_attn.k_proj":
-            "model.layers.*.self_attn.k_proj.kernel",
+            ("model.layers.*.self_attn.k_proj.kernel", ("model", None, None)),
             "model.layers.*.self_attn.o_proj":
-            "model.layers.*.self_attn.o_proj.kernel",
+            ("model.layers.*.self_attn.o_proj.kernel", ("model", None, None)),
             "model.layers.*.self_attn.q_proj":
-            "model.layers.*.self_attn.q_proj.kernel",
+            ("model.layers.*.self_attn.q_proj.kernel", ("model", None, None)),
             "model.layers.*.self_attn.v_proj":
-            "model.layers.*.self_attn.v_proj.kernel",
+            ("model.layers.*.self_attn.v_proj.kernel", ("model", None, None)),
             "model.layers.*.self_attn.q_proj.bias":
-            "model.layers.*.self_attn.q_proj.bias",
+            ("model.layers.*.self_attn.q_proj.bias", ("model", None)),
             "model.layers.*.self_attn.k_proj.bias":
-            "model.layers.*.self_attn.k_proj.bias",
+            ("model.layers.*.self_attn.k_proj.bias", ("model", None)),
             "model.layers.*.self_attn.v_proj.bias":
-            "model.layers.*.self_attn.v_proj.bias",
-            "model.norm": "model.norm.scale",
+            ("model.layers.*.self_attn.v_proj.bias", ("model", None)),
+            "model.norm": ("model.norm.scale", (None, )),
         }
 
         # Add lm_head mapping only if it's not tied to embeddings
         hf_config = self.vllm_config.model_config.hf_config
         if not hf_config.tie_word_embeddings:
-            mappings["lm_head"] = "lm_head"
+            mappings.update({
+                "lm_head": ("lm_head", (None, "model")),
+            })
 
         load_hf_weights(vllm_config=self.vllm_config,
                         model=self,

--- a/tpu_commons/models/jax/utils/weight_utils.py
+++ b/tpu_commons/models/jax/utils/weight_utils.py
@@ -132,6 +132,17 @@ def get_param(params: nnx.State, path: str) -> nnx.State:
 
 def load_hf_weights(vllm_config, model: nnx.Module, mappings: Dict[str, str],
                     mesh: Mesh):
+    shard = functools.partial(shard_put, mesh=mesh)
+
+    model_config = vllm_config.model_config
+    model_path = model_config.model
+    hf_config = model_config.hf_config
+
+    num_heads = hf_config.num_attention_heads
+    num_kv_heads = hf_config.num_key_value_heads
+    hidden_size = model_config.get_hidden_size()
+    head_dim = model_config.get_head_size()
+
     transpose_keys = {
         "lm_head": (1, 0),
         "gate_proj": (1, 0),
@@ -142,23 +153,6 @@ def load_hf_weights(vllm_config, model: nnx.Module, mappings: Dict[str, str],
         "v_proj": (0, 2, 1),
         "o_proj": (1, 2, 0),
     }
-    shard = functools.partial(shard_put, mesh=mesh)
-
-    model_path = vllm_config.model_config.model
-    hf_config = vllm_config.model_config.hf_config
-    num_heads = hf_config.num_attention_heads
-    num_kv_heads = hf_config.num_key_value_heads
-    hidden_size = hf_config.hidden_size
-
-    if num_heads == 0:
-        head_dim = 0
-        if hidden_size > 0:
-            logger.warning(
-                "num_attention_heads is 0, head_dim calculation might be incorrect."
-            )
-    else:
-        head_dim = hidden_size // num_heads
-
     reshape_keys = {
         "q_proj": (num_heads, -1, hidden_size),
         "k_proj": (num_kv_heads, -1, hidden_size),
@@ -183,14 +177,14 @@ def load_hf_weights(vllm_config, model: nnx.Module, mappings: Dict[str, str],
         if "layer" in hf_key:
             layer_num = re.search(r"layers\.(\d+)", hf_key).group(1)
             layer_key = re.sub(r"layers\.\d+", "layers.*", hf_key)
-            model_key = mappings[layer_key]
+            model_key, model_sharding = mappings[layer_key]
             model_key = re.sub(r"layers\.\*", f"layers.{layer_num}", model_key)
         else:
-            model_key = mappings[hf_key]
+            model_key, model_sharding = mappings[hf_key]
         model_weight = get_param(params, model_key)
 
         logger.debug(
-            f"{hf_key}: {hf_weight.shape}  -->  {model_key}: {model_weight.value.shape}"
+            f"{hf_key}: {hf_weight.shape}  -->  {model_key}: {model_weight.value.shape} {model_sharding}"
         )
 
         if hf_key.endswith(".bias"):
@@ -212,6 +206,6 @@ def load_hf_weights(vllm_config, model: nnx.Module, mappings: Dict[str, str],
         assert model_weight.value.shape == hf_weight.shape
 
         # Update the model weight
-        model_weight.value = shard(hf_weight, model_weight.sharding)
+        model_weight.value = shard(hf_weight, model_sharding)
 
     nnx.update(model, params)


### PR DESCRIPTION
# Description

This PR optimizes the nnx model loading logic, and the optimization can also benefit inference latency. Specifically, it improves the model loading time by 2x and reduces the gap duration between two steps by 5%.

1. The model weights will only be allocated once. Otherwise the normal way would random-init the model weights first, then load the real weights. The two pass weights allocation causes model loading slow.

2. The model loading won't be OOM. Otherwise the normal way would hold a full model weights after random-init, then duplicate a layer during the load_weights. This would be easy to OOM if the layer is super large.

3. The model architecture definition won't need to worry about the sharding. The sharding definition is taken over by the load_weights instead.

4. The (c) part of the gap described in this [profiling doc](https://docs.google.com/document/d/1cw4WM15AyUejQqZdNF4byQqmTu00OOEa4wxtOo5ct8Y/edit?resourcekey=0--jsZfnFcFOmYQmH_MCd61w&tab=t.0#heading=h.2pr64q47014w) can be removed.

# Tests

Llama3.1 8B, 70B
Qwen2.5 1.5B

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [ ] I have performed a self-review of my code.
- [ ] I have necessary comments in my code, particularly in hard-to-understand areas.
- [ ] I have made or will make corresponding changes to any relevant documentation.
