### PR TITLE
Improve step time by 5% by avoiding useless all-gather on logits

### DIFF
--- a/tpu_commons/models/jax/llama.py
+++ b/tpu_commons/models/jax/llama.py
@@ -312,7 +312,9 @@ class LlamaForCausalLM(nnx.Module):
             top_ks,
             attention_metadata.chunked_prefill_enabled,
         )
-        return kv_caches, next_tokens, logits
+        # NOTE(pooyam): Returning full unsharded logits is costly and results in expensive all-gather. It's ~6ms for 2K tokens with 128K vocab.
+        # In future, if we need returning logits, it should be through topK not the entire logits, or at least through a flag not a default.
+        return kv_caches, next_tokens, None
 
     def load_weights(self):
         mappings = {

--- a/tpu_commons/models/jax/qwen2.py
+++ b/tpu_commons/models/jax/qwen2.py
@@ -330,7 +330,7 @@ class Qwen2ForCausalLM(nnx.Module):
             top_ks,
             attention_metadata.chunked_prefill_enabled,
         )
-        return kv_caches, next_tokens, logits
+        return kv_caches, next_tokens, None
 
     def load_weights(self):
         mappings = {


### PR DESCRIPTION
# Description

Returning full unsharded logits is costly and results in expensive all-gather. It's ~6ms for 2K tokens with 128K vocab.
        # In future, if we need returning logits, it should be through topK not the entire logits, or at least through a flag not a default.


# Tests

local tests

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [ ] I have performed a self-review of my code.
- [ ] I have necessary comments in my code, particularly in hard-to-understand areas.
- [ ] I have made or will make corresponding changes to any relevant documentation.
