### PR TITLE
Remove unnecessary get_partition_spec to avoid OOM in model loading

### DIFF
--- a/tpu_commons/models/jax/model_loader.py
+++ b/tpu_commons/models/jax/model_loader.py
@@ -95,14 +95,12 @@ def get_nnx_model(
     model.load_weights(rng)
 
     # Although the created model can already work, we still need to jit
-    # the model creation again with sharding, otherwise the model forward
-    # will have non-trivial overhead in PjitFunction.
+    # the model creation again, otherwise the model forward will have
+    # non-trivial overhead in PjitFunction.
     @nnx.jit
     def create_sharded_model(model):
         state = nnx.state(model)
-        pspecs = nnx.get_partition_spec(state)
-        sharded_state = jax.lax.with_sharding_constraint(state, pspecs)
-        nnx.update(model, sharded_state)
+        nnx.update(model, state)
         return model
 
     with mesh:


### PR DESCRIPTION
# Description

Since we already get the sharded model in load_weights, the `nnx.get_partition_spec()` is unnecessary in model creation jit.
The `nnx.get_partition_spec()` in jit seems try to trace the full model on one shard, which causes OOM when running on multi chips.


# Tests

```
python $HOME/tpu_commons/examples/offline_inference.py \
--model=/mnt/disks/data/meta-llama/Llama-3.1-8B \
--tensor_parallel_size=4 \
--task=generate \
--max-tokens=6 \
--max_model_len=4096 \
--max-num-batched-tokens=2048
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [ ] I have performed a self-review of my code.
- [ ] I have necessary comments in my code, particularly in hard-to-understand areas.
- [ ] I have made or will make corresponding changes to any relevant documentation.
