### PR TITLE
Choose between chunked and normal prefill based on token count

### DIFF
--- a/tpu_commons/models/jax/attention_interface.py
+++ b/tpu_commons/models/jax/attention_interface.py
@@ -73,9 +73,11 @@ def attention(
                                k)
         v_cache = update_cache(is_prefill, v_cache, md.kv_cache_write_indices,
                                v)
+
         if is_prefill:
             # (B, N, T, H)
-            # TODO(xiang): support MQA and GQA
+            # NOTE(pooyam): Based on my benchmarks, We should not use splash kernel for normal settings (e.g., 32 heads, 8 kv heads) as flash attention is faster.
+            # I think splash kernel is faster only in presence of sparsity otherwise flash attention is faster.
             if num_kv_heads != num_heads:
                 k = jnp.repeat(k, num_heads // num_kv_heads, axis=1)
                 v = jnp.repeat(v, num_heads // num_kv_heads, axis=1)


### PR DESCRIPTION
# Description

Based on my benchmark, ragged kernel itself had superior performance compared to flash attention and splash attention across 1K, 2K, 4K, and 8K lengths.
However, step time for < 4K tokens is higher for ragged kernel due to inefficient update cache, which will be fixed with the new upcoming update cache kernel or the ideas I have mentioned in `attention_interface.py`.
Before then, we will use the following condition but once we improve the step time for ragged kernel in every scenario, we should just use ragged kernel.

This will improve step time from (200.58 -> 188.68 for 4K tokens, and 564 -> 464 for 8K tokens)

# Tests

ran local

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [ ] I have performed a self-review of my code.
- [ ] I have necessary comments in my code, particularly in hard-to-understand areas.
- [ ] I have made or will make corresponding changes to any relevant documentation.
