### PR TITLE
[Bugfix] fix kv cache padding

### DIFF
--- a/tpu_commons/attention/backends/pallas_torchax.py
+++ b/tpu_commons/attention/backends/pallas_torchax.py
@@ -59,13 +59,7 @@ class PallasAttentionBackend(AttentionBackend):
     ) -> tuple[int, ...]:
         padded_head_size = cdiv(
             head_size, TPU_HEAD_SIZE_ALIGNMENT) * TPU_HEAD_SIZE_ALIGNMENT
-        num_blocks = num_blocks * head_size // padded_head_size
-        if padded_head_size != head_size:
-            logger.warning_once(
-                "head size is padded to %d, and num_blocks is adjusted to %d"
-                " accordingly", padded_head_size, num_blocks)
-        head_size = padded_head_size
-        return (num_blocks, block_size, num_kv_heads * 2, head_size)
+        return (num_blocks, block_size, num_kv_heads * 2, padded_head_size)
 
     @staticmethod
     def swap_blocks(

--- a/tpu_commons/worker/tpu_worker_torchax.py
+++ b/tpu_commons/worker/tpu_worker_torchax.py
@@ -32,7 +32,8 @@ from vllm.distributed import (ensure_model_parallel_initialized,
 from vllm.logger import init_logger
 from vllm.lora.request import LoRARequest
 from vllm.model_executor import set_random_seed
-from vllm.utils import STR_DTYPE_TO_TORCH_DTYPE
+from vllm.utils import STR_DTYPE_TO_TORCH_DTYPE, cdiv
+from vllm.v1.attention.backends.pallas import TPU_HEAD_SIZE_ALIGNMENT
 from vllm.v1.core.sched.output import SchedulerOutput
 from vllm.v1.kv_cache_interface import KVCacheConfig, KVCacheSpec
 from vllm.v1.outputs import ModelRunnerOutput
@@ -235,7 +236,17 @@ class TPUWorker:
         usable_memory_size = int(total_memory_size *
                                  self.cache_config.gpu_memory_utilization)
         tpu_kv_cache_bytes = max(usable_memory_size - profiled, 0)
-
+        head_size = self.model_config.get_head_size()
+        if head_size > 0:
+            padded_head_size = cdiv(
+                head_size, TPU_HEAD_SIZE_ALIGNMENT) * TPU_HEAD_SIZE_ALIGNMENT
+            if padded_head_size != head_size:
+                logger.warning_once("head size is padded to %d",
+                                    padded_head_size)
+            # We adjust the usable memory size for the KV cache to prevent OOM
+            # errors, even after padding the head_size.
+            tpu_kv_cache_bytes = (tpu_kv_cache_bytes * head_size //
+                                  padded_head_size)
         return int(tpu_kv_cache_bytes)
 
     def execute_model(


### PR DESCRIPTION
## Purpose

Fix the bug when padding head_size for TPU. Previously block_num is only changed by `get_kv_cache_shape`. It's not enough since we still need to modify the value in `KVCacheConfig` as well.

## Test Plan
```
vllm serve microsoft/Phi-3-mini-128k-instruct --seed 42 --disable-log-requests --gpu-memory-utilization 0.95 --max-num-batched-tokens 2048 --max-num-seqs 128 --tensor-parallel-size 1 --max-model-len 2048 --no-enable-prefix-caching
```
```
python3 ./benchmarks/benchmark_serving.py --model microsoft/Phi-3-mini-128k-instruct --dataset-name sonnet --dataset-path benchmarks/sonnet_4x.txt --sonnet-input-len 1800 --sonnet-output-len 128 --ignore_eos
```
## Test Result
Passed. (It will crash without the patch)
