### PR TITLE
Support HF_HOME for model downloads

### DIFF
--- a/tpu_commons/models/jax/utils/file_utils.py
+++ b/tpu_commons/models/jax/utils/file_utils.py
@@ -17,7 +17,7 @@ logger = init_logger(__name__)
 hfs = HfFileSystem()
 
 GCS_PREFIX = "gs://"
-LOCAL_MODEL_DIR = "/tmp/model"
+LOCAL_MODEL_DIR = os.getenv("HF_HOME", "/tmp/model")
 LOCAL_LORA_DIR = "/tmp/lora"
 LOCK_DIR = "/tmp/lock"
 


### PR DESCRIPTION
# Description

The environment variable `HF_HOME` is the standard way to specify the location of models for download and loading on your local machine. This allows for models to be stored in a different location than the hardcoded `/tmp/model` which may not be the optimal location. 

Note: It still defaults to `/tmp/model` if the `HF_HOME` environment variable is not set. 

# Tests

Tested locally with and without the `HF_HOME` environment variable set. 
```
$ unset HF_HOME
$ python tpu_commons/examples/offline_inference.py
...
Loading weights from /tmp/model/Llama-3.1-8B/model-00001-of-00004.safetensor
```
vs
```
$ export HF_HOME=/mnt/disks/persist/hf_home
$ python tpu_commons/examples/offline_inference.py
...
Loading weights from /mnt/disks/persist/hf_home/Llama-3.1-8B/model-00001-of-00004.safetensors`
```


# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have made or will make corresponding changes to any relevant documentation.
