### PR TITLE
Run JAX without loading real model weights JAX_RANDOM_WEIGHTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,12 @@ To enable profiling:
 VLLM_TORCH_PROFILER_DIR=$PWD
 ```
 
+To run JAX path without loading real model weights:
+
+```
+JAX_RANDOM_WEIGHTS=1
+```
+
 To enable experimental scheduler:
 
 ```


### PR DESCRIPTION
# Description

Set `JAX_RANDOM_WEIGHTS=1` for running without loading real model weights.

# Tests

Llama3.1 8B

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [ ] I have performed a self-review of my code.
- [ ] I have necessary comments in my code, particularly in hard-to-understand areas.
- [ ] I have made or will make corresponding changes to any relevant documentation.
