### PR TITLE
Don't reference the sentinel None object when the orchestrator is tearing down.

### DIFF
--- a/tpu_commons/core/jetstream_commons/core/orchestrator.py
+++ b/tpu_commons/core/jetstream_commons/core/orchestrator.py
@@ -400,8 +400,9 @@ class Driver:
             my_transfer_backlog = self._transfer_backlogs[idx]
             # The prefill thread can just sleep until it has work to do.
             vllm_request = self._prefill_backlog.get(block=True)
-            logging.info("get request %s from prefill backlog",
-                         vllm_request.request_id)
+            logging.info(
+                "get request %s from prefill backlog", vllm_request.request_id
+                if vllm_request is not None else "None")
             my_detokenize_backlog = self._detokenize_backlogs[idx]
 
             if vllm_request is None:


### PR DESCRIPTION
# Description

Otherwise the log line raises an AttributeError during tear down.

# Tests

This fixes the tests/e2e/disagg.sh

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have made or will make corresponding changes to any relevant documentation.
