### PR TITLE
weight loading and llama3 in redesigned code

### DIFF
--- a/tpu_commons/models/jax/common/base.py
+++ b/tpu_commons/models/jax/common/base.py
@@ -87,7 +87,7 @@ class ParamFactory:
         )
         key = rngs.params()
         param_data = sharded_initializer(key, shape, dtype)
-        return nnx.Param(param_data)
+        return nnx.Param(param_data, sharding=sharding)
 
     def create_kernel_param(self, *args, **kwargs) -> nnx.Param:
         """Creates a kernel/weight parameter using the kernel_initializer."""

--- a/tpu_commons/models/jax/layers/misc.py
+++ b/tpu_commons/models/jax/layers/misc.py
@@ -10,7 +10,7 @@ from jax.sharding import PartitionSpec as P
 from tpu_commons.models.jax.layers.params import sharding_init
 
 
-def shard_put(x: jax.Array, sharding_names: Tuple[str, ...],
+def shard_put(x: jax.Array, sharding_names: Tuple[str, ...] | P,
               mesh: jax.sharding.Mesh) -> jax.Array:
     # Single device sharding requires this special handling
     # to avoid the recursive jit error.

--- a/tpu_commons/models/jax/model_loader.py
+++ b/tpu_commons/models/jax/model_loader.py
@@ -9,6 +9,7 @@ from transformers import PretrainedConfig
 from vllm.config import VllmConfig
 
 from tpu_commons.logger import init_logger
+from tpu_commons.models.jax.common.model import Model
 from tpu_commons.models.jax.utils.param_overview import get_parameter_overview
 
 logger = init_logger(__name__)
@@ -30,7 +31,9 @@ def _get_model_architecture(config: PretrainedConfig) -> nn.Module:
         from tpu_commons.models.jax.qwen2 import Qwen2ForCausalLM
         _MODEL_REGISTRY["Qwen2ForCausalLM"] = Qwen2ForCausalLM
         if os.getenv("NEW_MODEL_DESIGN", False):
+            from tpu_commons.models.jax.recipes.llama3 import Llama3_8B
             from tpu_commons.models.jax.recipes.llama4 import Llama4Scout
+            _MODEL_REGISTRY["Llama3_8B"] = Llama3_8B
             _MODEL_REGISTRY["Llama4Scout"] = Llama4Scout
     else:
         raise NotImplementedError("Unsupported MODEL_IMPL_TYPE")
@@ -86,45 +89,50 @@ def get_nnx_model(
 ):
     model_class = _get_model_architecture(vllm_config.model_config.hf_config)
 
-    if os.getenv("JAX_RANDOM_WEIGHTS", False):
-        # Create a sharded model with random inited weights.
-        @nnx.jit
-        def create_sharded_model():
-            model = model_class(vllm_config, rng, mesh)
-            state = nnx.state(model)
-            pspecs = nnx.get_partition_spec(state)
-            sharded_state = jax.lax.with_sharding_constraint(state, pspecs)
-            nnx.update(model, sharded_state)
-            return model
 
-        with mesh:
-            jit_model = create_sharded_model()
+    if issubclass(model_class, Model): # TODO: Get this to wrok for nnx.eval_shape.
+        model = model_class(vllm_config, rng, mesh)
+        model.load_weights(model)
+        jit_model = model
     else:
-        # We first create an abstract model without allocating any weights,
-        # then fill in its weigths during load_weights from HF.
-        # This shows 3 advantages than the normal way:
-        # 1. The model weights will only be allocated once. Otherwise the normal way
-        #    will random-init the model weights first, then load the real weights.
-        #    The two pass weights allocation causes model loading slow.
-        # 2. The model loading won't be OOM. Otherwise the normal way will hold
-        #    a full model weights after random-init, then duplicate a layer during
-        #    the load_weights. This would be easy to OOM if the layer is super large.
-        # 3. The model architecture definition won't need to worry about the sharding.
-        #    The sharding definition is taken over by the load_weights instead.
-        model = nnx.eval_shape(lambda: model_class(vllm_config, rng, mesh))
-        model.load_weights(rng)
+        if os.getenv("JAX_RANDOM_WEIGHTS", False):
+            # Create a sharded model with random inited weights.
+            @nnx.jit
+            def create_sharded_model():
+                model = model_class(vllm_config, rng, mesh)
+                state = nnx.state(model)
+                pspecs = nnx.get_partition_spec(state)
+                sharded_state = jax.lax.with_sharding_constraint(state, pspecs)
+                nnx.update(model, sharded_state)
+                return model
 
-        # Although the created model can already work, we still need to jit
-        # the model creation again, otherwise the model forward will have
-        # non-trivial overhead in PjitFunction.
-        @nnx.jit(donate_argnums=(0, ))
-        def create_jit_model(model):
-            state = nnx.state(model)
-            nnx.update(model, state)
-            return model
+            with mesh:
+                jit_model = create_sharded_model()
+        else:
+            # We first create an abstract model without allocating any weights,
+            # then fill in its weigths during load_weights from HF.
+            # This shows 3 advantages than the normal way:
+            # 1. The model weights will only be allocated once. Otherwise the normal way
+            #    will random-init the model weights first, then load the real weights.
+            #    The two pass weights allocation causes model loading slow.
+            # 2. The model loading won't be OOM. Otherwise the normal way will hold
+            #    a full model weights after random-init, then duplicate a layer during
+            #    the load_weights. This would be easy to OOM if the layer is super large.
+            # 3. The model architecture definition won't need to worry about the sharding.
+            #    The sharding definition is taken over by the load_weights instead.
+            model = nnx.eval_shape(lambda: model_class(vllm_config, rng, mesh))
+            model.load_weights(rng)
+            # Although the created model can already work, we still need to jit
+            # the model creation again, otherwise the model forward will have
+            # non-trivial overhead in PjitFunction.
+            @nnx.jit(donate_argnums=(0, ))
+            def create_jit_model(model):
+                state = nnx.state(model)
+                nnx.update(model, state)
+                return model
 
-        with mesh:
-            jit_model = create_jit_model(model)
+            with mesh:
+                jit_model = create_jit_model(model)
 
     kv_cache_sharding = NamedSharding(mesh, PartitionSpec("model"))
     outputs_sharding = NamedSharding(mesh, PartitionSpec(None))

--- a/tpu_commons/models/jax/recipes/llama3.py
+++ b/tpu_commons/models/jax/recipes/llama3.py
@@ -1,3 +1,4 @@
+# TODO: Update documentation
 # Input flags are stored in below configs
 # model_flag_config: Config
 #   d_model: 2048
@@ -23,7 +24,7 @@ import jax
 import jax.numpy as jnp
 from flax import nnx
 from flax.typing import PRNGKey
-from jax.sharding import Mesh, NamedSharding, PartitionSpec
+from jax.sharding import Mesh
 from vllm.config import VllmConfig
 
 import tpu_commons.models.jax.common.sharding as sharding
@@ -31,7 +32,7 @@ from tpu_commons.logger import init_logger
 from tpu_commons.models.jax.common.attention.attention import (
     AttentionConfig, AttentionMetadata)
 from tpu_commons.models.jax.common.base import Config, ParamFactory
-from tpu_commons.models.jax.common.kv_cache import KVCacheConfig, KVCacheType
+from tpu_commons.models.jax.common.kv_cache import KVCacheType
 from tpu_commons.models.jax.common.layers import (Embedder, EmbedderConfig,
                                                   FFWConfig, RMSNorm)
 from tpu_commons.models.jax.common.model import Model, ModelConfig
@@ -40,8 +41,9 @@ from tpu_commons.models.jax.common.sharding import (OpShardingConfig, Sharding,
 from tpu_commons.models.jax.common.transformer_block import (
     TransformerBlock, TransformerBlockConfig)
 from tpu_commons.models.jax.layers.misc import shard_put
-from tpu_commons.models.jax.utils.weight_utils import (
-    ParameterType, WeightLoader, get_param)
+from tpu_commons.models.jax.layers.sampling import sample
+from tpu_commons.models.jax.utils.weight_utils import (ParameterType,
+                                                       WeightLoader, get_param)
 
 logger = init_logger(__name__)
 
@@ -50,35 +52,26 @@ logger = init_logger(__name__)
 class Llama8BModelConfig(ModelConfig):
     emb: EmbedderConfig = field(default_factory=lambda: EmbedderConfig(
         vocab_size=128256,
-        d_model=4096,  ## TODO: Is this correct?
+        d_model=4096,
         dtype=jnp.bfloat16,
         normalize_embeddings=False  # TODO: Confirm
     ))
     layers: TransformerBlockConfig = field(
         default_factory=lambda: TransformerBlockConfig(
-            attention=AttentionConfig(
-                d_model=4096,  ## TODO: Is this correct?
-                num_q_heads=32,
-                num_kv_heads=8,
-                head_dim=128,
-                rope_theta=500000.0,
-                rope_scaling={},
-                dtype=jnp.bfloat16),
-            ffw=FFWConfig(
-                d_model=4096,  ## TODO: Is this correct?
-                hidden_size=14336,
-                act="silu",
-                dtype=jnp.bfloat16),
-            kv_cache=KVCacheConfig(batch_size=1,
-                                   cache_len=1024,
-                                   num_kv_heads=8,
-                                   head_dim=128,
-                                   dtype=jnp.float16),
+            attention=AttentionConfig(d_model=4096,
+                                      num_q_heads=32,
+                                      num_kv_heads=8,
+                                      head_dim=128,
+                                      rope_theta=500000.0,
+                                      rope_scaling={},
+                                      dtype=jnp.bfloat16),
+            ffw=FFWConfig(d_model=4096,
+                          hidden_size=14336,
+                          act="silu",
+                          dtype=jnp.bfloat16),
             rmsnorm_epsilon=1e-5,
             block_type="dense"))
     num_layers: int = 32
-    # num_layers: int = 24 ## TODO REVERT
-    # num_moe_layers: int = 24 ## TODO REVERT
 
 
 class Llama8BOpShardingConfig(OpShardingConfig):
@@ -90,17 +83,13 @@ class Llama8BSharding(Sharding):
     def make_sharding_config(self,
                              prefill_overrides=None,
                              generate_overrides=None) -> ShardingConfig:
-        sharding_config = super().make_sharding_config(
-            prefill_overrides, generate_overrides, Llama8BOpShardingConfig)
+        sharding_config = super().make_sharding_config(prefill_overrides,
+                                                       generate_overrides)
         sharding_config.prefill_sharding_cfg.lm_head_dv = (
             None, sharding.MLP_TENSOR_AXIS_NAME)
         sharding_config.generate_sharding_cfg.lm_head_dv = (
             None, sharding.MLP_TENSOR_AXIS_NAME)
         return sharding_config
-
-
-# class Llama4ScoutQuantizationConfig(QuantizationConfig):
-#     pass
 
 
 class Llama8BServingConfig(Config):
@@ -111,7 +100,6 @@ class Llama8BServingConfig(Config):
 class Llama8BConfig():
     model: Llama8BModelConfig = field(default_factory=Llama8BModelConfig)
     sharding: ShardingConfig = field(default_factory=ShardingConfig)
-    # quant: Llama4ScoutQuantizationConfig = None
     serving: Llama8BServingConfig = None
     overrides: Mapping[str, any] = None
 
@@ -128,57 +116,39 @@ class Llama8BConfig():
                 pass
 
 
-# Class Model(nnx.module) will be added
 class Llama3_8B(Model):
 
     def __init__(self, vllm_config: VllmConfig, rng: PRNGKey, mesh: Mesh):
         self.vllm_config = vllm_config
         self.rng = nnx.Rngs(rng)
         self.mesh = mesh
-        # jax.debug.breakpoint()
         self.cfg = Llama8BConfig(
             model=Llama8BModelConfig(),
             sharding=ShardingConfig(default_ops_cls=Llama8BOpShardingConfig),
-            # quant=Llama4ScoutQuantizationConfig(),
             serving=Llama8BServingConfig(),
             overrides=self.vllm_config.additional_config.get(
                 "overrides", None))
         self.runtime_params = self.vllm_config.additional_config.get(
             "overrides", None)
-        self.setup()
 
-    def setup(self) -> None:
         param_factory = ParamFactory(
             kernel_initializer=nnx.initializers.xavier_normal(),
-            scale_initializer=nnx.initializers.ones
-        )
+            scale_initializer=nnx.initializers.ones)
         try:
             strategy_dict = self.runtime_params["sharding"][
                 "sharding_strategy"]
         except (KeyError, TypeError):
             strategy_dict = {"tensor_parallelism": 4, "expert_parallelism": 2}
         self.sharding = Llama8BSharding(
-            # cfg=self.cfg.sharding,
             strategy_dict=strategy_dict,
-            mesh=self.mesh)
+            mesh=self.mesh,
+        )
         self.cfg.sharding = self.sharding.sharding_cfg
         self.mesh = self.sharding.mesh
         self.embedder = Embedder(cfg=self.cfg.model.emb,
                                  mesh=self.mesh,
                                  param_factory=param_factory,
                                  sharding_cfg=self.cfg.sharding)
-        # a better way to guarantee the order of initialization
-        # i.e. sharding_cfg, quantization should be ready before global_KV_cache etc
-        # self.global_KV_cache = self.create_KV_cache()
-
-        # TODO: Confirm against MaxText
-        # dense_blocks = [
-        #     self.cfg.transformer_moe_blocks_config.make(
-        #         name=f'dense_layer_{i}',
-        #         runtime_param=self.global_runtime_params[i])
-        #     for i in self.cfg.dense_layers
-        # ]
-        # TODO: What is ParamFactory?
         self.layers = [
             TransformerBlock(cfg=self.cfg.model.layers,
                              block_type="dense",
@@ -190,39 +160,38 @@ class Llama3_8B(Model):
         self.final_norm = RMSNorm(
             dims=self.cfg.model.layers.ffw.d_model,
             mesh=self.mesh,
-            param_factory=param_factory,  # TODO: what to set this to?
-            sharding_cfg=self.cfg.sharding,  # Kept for API consistency
+            param_factory=param_factory,
+            sharding_cfg=self.cfg.sharding,
             epsilon=self.cfg.model.layers.rmsnorm_epsilon,
-            with_scale=True,  # TODO: What is this?
+            with_scale=True,
             dtype=self.cfg.model.layers.ffw.dtype,
         )
-        lm_head_sharding = \
-            NamedSharding(self.mesh,
-                          PartitionSpec(*self.cfg.sharding.generate_sharding_cfg.lm_head_dv))
 
-        self.lm_head = param_factory.create_kernel_init(
-            shape=(self.cfg.model.emb.d_model, self.cfg.model.emb.vocab_size),
-            dtype=self.cfg.model.emb.dtype,
-            sharding=lm_head_sharding)
+        self.lm_head = Embedder(cfg=self.cfg.model.emb,
+                                mesh=self.mesh,
+                                param_factory=param_factory,
+                                sharding_cfg=self.cfg.sharding)
 
-        logger.info("Initalized the following model architeture:\n")
-        # nnx.display(self)
+        self.setup()
+
+    def setup(self) -> None:
+        self.embedder.generate_kernel(self.rng)
+        for i in range(len(self.layers)):
+            self.layers[i].generate_kernel(self.rng)
+        self.final_norm.generate_kernel(self.rng)
+        self.lm_head.generate_kernel(self.rng)
 
     # For compatibility with flax.
     def apply(self, variables, *args, **kwargs):
         return self.__call__(*args, **kwargs)
 
-    def load_weights(self, cache_dir: Optional[str] = None):
+    def load_weights(self, rng: PRNGKey, cache_dir: Optional[str] = None):
         # TODO: support gcs paths as well.
         model_name_or_path = self.vllm_config.model_config.model
         if not model_name_or_path:  # TODO
             logger.warning(
                 "Model name or path not provided - randomly randomly initializing the weights."
             )
-            # params = nnx.state(self).filter(nnx.Param)
-            #jax.debug.print("Randomly initializing the following weight shapes:\n{params_repr}",
-            #                params_repr=pretty_repr(params))
-            # return params
         else:
             weight_loader = Llama3WeightLoader(vllm_config=self.vllm_config,
                                                model_config=self.cfg.model,
@@ -245,20 +214,29 @@ class Llama3_8B(Model):
             *args,
             **kwargs) -> Tuple[List[KVCacheType], jax.Array, jax.Array]:
         x = self.embedder.encode(input_ids)
-        # for i, block in self.dense_blocks + self.moe_blocks:
-        for block in self.layers:
-            kv_cache = block.kv_cache
-            x, kv_cache = block(is_prefill, do_sampling, kv_caches, x,
-                                attention_metadata, temperatures)
-            # TODO: need to confirm functionality.
-            # self.global_KV_cache.append(new_cache)
-            block.kv_cache = kv_cache
+        for (i, block) in enumerate(self.layers):
+            kv_cache = kv_caches[i]
+            new_kv_cache, x = block(x, is_prefill, kv_cache,
+                                    attention_metadata)
+            kv_caches[i] = new_kv_cache
 
         final_activation = self.final_norm(x)
-        logits = self.lm_head(final_activation)
-        # decoder_output = self.embedder.decode(final_activation)
-        return logits
-        # return decoder_output
+        decoder_output = self.embedder.decode(final_activation)
+
+        next_tokens = sample(
+            is_prefill,
+            do_sampling,
+            self.rng.params(),
+            self.mesh,
+            decoder_output,
+            attention_metadata.seq_lens,
+            temperatures,
+            top_ps,
+            top_ks,
+            attention_metadata.chunked_prefill_enabled,
+        )
+
+        return kv_caches, next_tokens, decoder_output
 
 
 class Llama3WeightLoader(WeightLoader):
@@ -278,7 +256,6 @@ class Llama3WeightLoader(WeightLoader):
     def setup(self):
         super().setup()
         self.set_transpose_param_map({
-            "lm_head": (1, 0),
             "gate_proj": (1, 0),
             "up_proj": (1, 0),
             "down_proj": (1, 0),
@@ -332,6 +309,8 @@ class Llama3WeightLoader(WeightLoader):
             "layers.*.attn.kernel_v_proj_KDH",
             "model.norm":
             "final_norm.scale",  # TODO: is this correct??
+            "lm_head":
+            "lm_head.input_embedding_table_VD"
         })
 
     def map_loaded_to_standardized_name(self, loaded_key: str) -> str:
@@ -348,7 +327,6 @@ class Llama3WeightLoader(WeightLoader):
         return mapped_key
 
     def load_weights(self, model_for_loading: nnx.Module):
-        # model_params = nnx.state(model_for_loading, nnx.Param)
         model_params = nnx.state(model_for_loading)
         for loaded_name, loaded_weight in self.names_and_weights_generator:
             old_param_name = loaded_name
@@ -375,4 +353,5 @@ class Llama3WeightLoader(WeightLoader):
             model_weight.value = shard_put(loaded_weight,
                                            model_weight.sharding.spec,
                                            mesh=model_for_loading.mesh)
+        # TODO: validate that all of the model_params were accounted for as well.
         nnx.update(model_for_loading, model_params)

--- a/tpu_commons/models/jax/utils/weight_utils.py
+++ b/tpu_commons/models/jax/utils/weight_utils.py
@@ -1,18 +1,24 @@
 """Utilities for downloading model weights from HuggingFace."""
 
+import abc
 import functools
 import glob
 import os
 import re
-from typing import Any, Dict, Generator
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Dict, Generator, Mapping, Optional, Tuple
 
 import jax
 import jax.numpy as jnp
 from flax import nnx
 from jax.sharding import Mesh
 from safetensors import safe_open
+from vllm.config import VllmConfig
 
 from tpu_commons.logger import init_logger
+from tpu_commons.models.jax.common.model import ModelConfig
+from tpu_commons.models.jax.common.sharding import ShardingConfig
 from tpu_commons.models.jax.layers.misc import shard_put
 from tpu_commons.models.jax.utils import file_utils
 
@@ -22,46 +28,133 @@ HF_WEIGHTS_FORMAT = "*.safetensors"
 FULL_DOWNLOAD_DISK_RATIO = 0.9
 
 
+class ParameterType(str, Enum):
+    weight = "weight"
+    bias = "bias"
+
+
+@dataclass
+class TransformationConfig:
+    transpose: Mapping[str, Any] = field(default_factory=dict)
+    reshape: Mapping[str, Any] = field(default_factory=dict)
+
+
+class WeightLoader(abc.ABC):
+    # Create a doc string for this class.
+    """Abstract base class for loading model weights.
+
+    This class provides a common interface for loading model weights from various
+    sources (currently supports HuggingFace) and applying necessary transformations
+    (e.g., transposing, reshaping) before sharding and loading them into the
+    model.
+    Each implemeentation of the WeightLoader must define the procedure for loading the
+    weights in its own load_weights() method.
+
+    Args:
+        vllm_config (VllmConfig): The VLLM configuration object.
+        model_config (ModelConfig): The model configuration object.
+        framework str: Type of backend to use (defaults to "flax")
+        cache_dir str: An optional cache dir to load the model from (currently unused).
+        sharding_cfg (ShardingConfig): The sharding configuration object.
+    """
+
+    def __init__(self,
+                 vllm_config: VllmConfig,
+                 model_config: ModelConfig,
+                 framework: str = "flax",
+                 cache_dir: Optional[str] = None,
+                 sharding_cfg: Optional[ShardingConfig] = None):
+        self.vllm_config = vllm_config
+        self.model_config = model_config
+        self.sharding_cfg = sharding_cfg
+        self.framework = framework
+        self.cache_dir = cache_dir
+        self.transformation_cfg = TransformationConfig()
+        self.setup()
+
+    def setup(self):
+        self.names_and_weights_generator = hf_model_weights_iterator(
+            model_name_or_path=self.vllm_config.model_config.model,
+            framework=self.framework)
+
+    def set_transpose_param_map(self,
+                                transpose_param_dict: Mapping[str,
+                                                              Tuple[int]]):
+        self.transformation_cfg.transpose = transpose_param_dict
+
+    def set_reshape_param_map(self, param_reshape_dict: Mapping[str,
+                                                                Tuple[int]],
+                              param_type: str):
+        self.transformation_cfg.reshape[param_type] = param_reshape_dict
+
+    def set_loaded_to_standardized_keys(
+            self, loaded_to_standardized_keys: Mapping[str, str]):
+        self.loaded_to_standardized_keys = loaded_to_standardized_keys
+
+    def transpose_params(self, param_key: str, param_tensor: jax.Array):
+        for key in self.transformation_cfg.transpose:
+            if key in param_key:
+                return jnp.transpose(param_tensor,
+                                     self.transformation_cfg.transpose[key])
+        return param_tensor  # Base case / no-op
+
+    def reshape_params(self, param_key: str, param_tensor: jax.Array,
+                       param_type: str):
+        for key in self.transformation_cfg.reshape[param_type]:
+            if key in param_key:
+                reshape_shape = self.transformation_cfg.reshape[param_type][
+                    key]
+                return jnp.reshape(param_tensor, reshape_shape)
+        return param_tensor  # Base case / no-op
+
+    abc.abstractmethod
+
+    def load_weights(self, model_for_loading: nnx.Module):
+        raise NotImplementedError
+
+
 def hf_model_weights_iterator(
-    model_name: str,
+    model_name_or_path: str,
     framework: str,
 ) -> Generator[tuple, Any, None]:
     weights_files = []
     weights_location = "local"
-    if os.path.isdir(model_name):
-        weights_files = glob.glob(os.path.join(model_name, HF_WEIGHTS_FORMAT))
-    elif file_utils.is_gcs_path(model_name):
+    if os.path.isdir(model_name_or_path):
+        weights_files = glob.glob(
+            os.path.join(model_name_or_path, HF_WEIGHTS_FORMAT))
+    elif file_utils.is_gcs_path(model_name_or_path):
         local_free_disk_size = file_utils.get_free_disk_size()
         model_size = file_utils.get_gcs_model_weights_size(
-            model_name, HF_WEIGHTS_FORMAT)
+            model_name_or_path, HF_WEIGHTS_FORMAT)
         if model_size < local_free_disk_size * FULL_DOWNLOAD_DISK_RATIO:
-            logger.info(f"Downloading weights from GCS {model_name}")
+            logger.info(f"Downloading weights from GCS {model_name_or_path}")
             weights_files = file_utils.download_model_weights_from_gcs(
-                model_name, HF_WEIGHTS_FORMAT)
+                model_name_or_path, HF_WEIGHTS_FORMAT)
         else:
-            weights_files = file_utils.list_gcs_dir(model_name,
+            weights_files = file_utils.list_gcs_dir(model_name_or_path,
                                                     HF_WEIGHTS_FORMAT)
             weights_location = "gcs"
-    elif file_utils.is_hf_repo(model_name):
+    elif file_utils.is_hf_repo(model_name_or_path):
         local_free_disk_size = file_utils.get_free_disk_size()
         model_size = file_utils.get_hf_model_weights_size(
-            model_name, HF_WEIGHTS_FORMAT)
+            model_name_or_path, HF_WEIGHTS_FORMAT)
         if model_size < local_free_disk_size * FULL_DOWNLOAD_DISK_RATIO:
-            logger.info(f"Downloading weights from HF {model_name}")
+            logger.info(f"Downloading weights from HF {model_name_or_path}")
             weights_files = file_utils.download_model_weights_from_hf(
-                model_name, HF_WEIGHTS_FORMAT)
+                model_name_or_path, HF_WEIGHTS_FORMAT)
         else:
-            weights_files = file_utils.list_hf_repo(model_name,
+            weights_files = file_utils.list_hf_repo(model_name_or_path,
                                                     HF_WEIGHTS_FORMAT)
             weights_location = "hf"
     else:
         raise ValueError(
-            f"{model_name} must be a local path, or a gcs path, or a HF model id."
+            f"{model_name_or_path} must be a local path, or a gcs path, or a HF model id."
         )
 
     if len(weights_files) == 0:
         raise RuntimeError(
-            f"Cannot find any {HF_WEIGHTS_FORMAT} files in {model_name}.")
+            f"Cannot find any {HF_WEIGHTS_FORMAT} files in {model_name_or_path}."
+        )
 
     if weights_location != "local":
         logger.warning(
@@ -75,10 +168,10 @@ def hf_model_weights_iterator(
         logger.info(f"Loading weights from {st_file}")
         if weights_location == "gcs":
             st_file = file_utils.download_model_weights_from_gcs(
-                model_name, os.path.basename(st_file))[0]
+                model_name_or_path, os.path.basename(st_file))[0]
         elif weights_location == "hf":
             st_file = file_utils.download_model_weights_from_hf(
-                model_name, os.path.basename(st_file))[0]
+                model_name_or_path, os.path.basename(st_file))[0]
         # NOTE: We enforce loading tensors on CPU here.
         # Because otherwise the tensor will be loaded on TPU:0 by default,
         # although the tensor would eventually be sharded across multiple TPUs,


### PR DESCRIPTION
# Description

Support loading HF weights for the Llama3 architecture, which will be used for baselining the redesigned stack.

The model files (e.g. Llama3) are in charge of loading HF weights and specify transformations such as reshapings, tranansposings, and mapping between keys to correctly load the weights into the tpu_commons implementation.
Additional updates:
- Made fixes to the Llama3 architecture definition
- Changed the sharding logic to allow different logical rules per model
- Made changes to instantiate each parameter with respective sharding rules and store the rules in the parameter definition (required for sharded weight loading).

# Tests
Ran build kite to confirm tests were passing: https://buildkite.com/tpu-commons/tpu-commons-ci/builds/264
Also tested locally that running the server and benchmarking with the Llama3 workflow in mmlu.sh still works. Also confirmed that I am able to load weights and run generate.py and spin up a server with the new Llama3 implementation.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have made or will make corresponding changes to any relevant documentation.
