### PR TITLE
Add logs, improve disagg e2e test script.

### DIFF
--- a/tests/e2e/disagg.sh
+++ b/tests/e2e/disagg.sh
@@ -1,7 +1,14 @@
 #!/bin/bash
 
+if [ "$#" -eq 0 ]; then
+    echo "Error: need to specify the local path to the root directory of vllm repo." >&2
+    exit 1
+fi
+
+VLLM_CODE_PATH=$1
+
 # This script appends specific import and assignment lines to the vLLM engine's core.py file.
-FILE_PATH="$HOME/vllm/vllm/v1/engine/core.py"
+FILE_PATH="$VLLM_CODE_PATH/vllm/v1/engine/core.py"
 CONTENT_TO_ADD="
 # Added for TPU support
 from tpu_commons.core.core_tpu import EngineCore as TPUEngineCore
@@ -16,9 +23,7 @@ if [ -f "$FILE_PATH" ]; then
     echo "$CONTENT_TO_ADD" >> "$FILE_PATH"
 fi
 
-cd $HOME
-
-TPU_BACKEND_TYPE=jax python vllm/examples/offline_inference/basic/generate.py --task=generate --model=meta-llama/Meta-Llama-3-8B-Instruct --max_model_len=1024 --max_num_seqs=8
+TPU_BACKEND_TYPE=jax python "$VLLM_CODE_PATH/examples/offline_inference/basic/generate.py" --task=generate --model=meta-llama/Meta-Llama-3-8B-Instruct --max_model_len=1024 --max_num_seqs=8
 
 head -n -8 "$FILE_PATH" > "tmp.py"
 mv "tmp.py" "$FILE_PATH"

--- a/tpu_commons/models/jax/model_loader.py
+++ b/tpu_commons/models/jax/model_loader.py
@@ -8,7 +8,10 @@ from jax.sharding import Mesh, NamedSharding, PartitionSpec
 from transformers import PretrainedConfig
 from vllm.config import VllmConfig
 
+from tpu_commons.logger import init_logger
 from tpu_commons.models.jax.utils.param_overview import get_parameter_overview
+
+logger = init_logger(__name__)
 
 
 def _get_model_architecture(config: PretrainedConfig) -> nn.Module:
@@ -174,6 +177,7 @@ def get_model(
     mesh: Mesh,
 ) -> nn.Module:
     impl = os.getenv("MODEL_IMPL_TYPE", "flax_nnx").lower()
+    logger.info(f"Loading model, implementation type={impl}")
     if impl == "flax_nn":
         return get_nn_model(vllm_config, rng, mesh)
     elif impl == "flax_nnx":


### PR DESCRIPTION
# Description

Make the `tests/e2e/disagg.sh` script require the root directory to vllm, so people can run the script in different personal environments.

Also added logs to verify different model impl types (both jax/flax and vllm types work!)

# Tests

`bash tests/e2e/disagg.sh VLLM_CODE_PATH`

and

`MODEL_IMPL_TYPE=vllm bash tests/e2e/disagg.sh VLLM_CODE_PATH`

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [ ] I have performed a self-review of my code.
- [ ] I have necessary comments in my code, particularly in hard-to-understand areas.
- [ ] I have made or will make corresponding changes to any relevant documentation.
