### PR TITLE
[torchax] Fix logger and mics fix

### DIFF
--- a/tpu_commons/attention/backends/pallas.py
+++ b/tpu_commons/attention/backends/pallas.py
@@ -9,11 +9,11 @@ from vllm.attention.backends.abstract import (AttentionBackend, AttentionImpl,
                                               AttentionLayer, AttentionType)
 from vllm.attention.backends.utils import CommonAttentionState
 from vllm.config import VllmConfig
-from vllm.logger import init_logger
 from vllm.utils import cdiv, next_power_of_2
 
 # Required to register the custom op "torch.ops.xla.ragged_paged_attention"
 import tpu_commons.attention.backends.torch_xla_custom_op  # noqa: F401
+from tpu_commons.logger import init_logger
 
 logger = init_logger(__name__)
 

--- a/tpu_commons/attention/backends/pallas_torchax.py
+++ b/tpu_commons/attention/backends/pallas_torchax.py
@@ -14,10 +14,10 @@ from vllm.attention.backends.abstract import (AttentionBackend, AttentionImpl,
 from vllm.attention.backends.utils import CommonAttentionState
 from vllm.config import VllmConfig
 from vllm.forward_context import ForwardContext, get_forward_context
-from vllm.logger import init_logger
 from vllm.utils import cdiv, next_power_of_2
 
 from tpu_commons.kernels.ragged_kv_cache_update import kv_cache_update
+from tpu_commons.logger import init_logger
 
 VLLM_TORCHAX_ENABLED = os.environ.get('VLLM_TORCHAX_ENABLED', '0') == '1'
 

--- a/tpu_commons/distributed/device_communicators/tpu_communicator_torch_xla.py
+++ b/tpu_commons/distributed/device_communicators/tpu_communicator_torch_xla.py
@@ -8,8 +8,9 @@ from torch.distributed import ProcessGroup
 from vllm.config import get_current_vllm_config
 from vllm.distributed.device_communicators.base_device_communicator import \
     DeviceCommunicatorBase
-from vllm.logger import init_logger
 from vllm.platforms import current_platform
+
+from tpu_commons.logger import init_logger
 
 USE_RAY = parallel_config = get_current_vllm_config(
 ).parallel_config.distributed_executor_backend == "ray"

--- a/tpu_commons/distributed/tpu_distributed_utils.py
+++ b/tpu_commons/distributed/tpu_distributed_utils.py
@@ -13,11 +13,13 @@ import torchax
 from jax.sharding import Mesh, NamedSharding
 from jax.sharding import PartitionSpec as P
 from torch.nn import Parameter
-from vllm.logger import init_logger
+from torchax import jax_device
 from vllm.model_executor.layers.linear import (ColumnParallelLinear,
                                                MergedColumnParallelLinear,
                                                QKVParallelLinear,
                                                RowParallelLinear)
+
+from tpu_commons.logger import init_logger
 
 logger = init_logger(__name__)
 
@@ -37,7 +39,8 @@ def create_torchax_tensor_with_partition_spec(
 
     if mesh is None:
         # Single chip case.
-        return weight_t.to('jax')
+        with jax_device('tpu'):
+            return weight_t.to('jax')
 
     # Create CPU tensor first then move to jax device.
     cpu_device = jax.devices("cpu")[0]

--- a/tpu_commons/models/vllm/sharding.py
+++ b/tpu_commons/models/vllm/sharding.py
@@ -11,12 +11,12 @@ from torchax.interop import extract_all_buffers, torch_view
 from torchax.tensor import t2j
 from vllm.attention import Attention as VllmAttention
 from vllm.config import ParallelConfig
-from vllm.logger import init_logger
 from vllm.model_executor.layers.fused_moe import FusedMoE
 from vllm.model_executor.layers.linear import (ColumnParallelLinear,
                                                QKVParallelLinear,
                                                RowParallelLinear)
 
+from tpu_commons.logger import init_logger
 from tpu_commons.models.vllm.jax_attention import JaxAttention
 from tpu_commons.models.vllm.jax_fused_moe import JaxFusedMoE
 from tpu_commons.models.vllm.jax_qkv_parallel_linear import \

--- a/tpu_commons/platforms/tpu_torch_xla.py
+++ b/tpu_commons/platforms/tpu_torch_xla.py
@@ -6,9 +6,10 @@ import torch
 import vllm.envs as envs
 from tpu_info import device
 from vllm.inputs import ProcessorInputs, PromptType
-from vllm.logger import init_logger
 from vllm.platforms.interface import Platform, PlatformEnum, _Backend
 from vllm.sampling_params import SamplingParams, SamplingType
+
+from tpu_commons.logger import init_logger
 
 if TYPE_CHECKING:
     from vllm.config import BlockSize, ModelConfig, VllmConfig

--- a/tpu_commons/runner/tpu_torch_xla_runner.py
+++ b/tpu_commons/runner/tpu_torch_xla_runner.py
@@ -18,7 +18,6 @@ from vllm.attention.layer import Attention
 from vllm.compilation.wrapper import TorchCompileWrapperWithCustomDispatcher
 from vllm.config import VllmConfig, get_layers_from_vllm_config
 from vllm.forward_context import set_forward_context
-from vllm.logger import init_logger
 from vllm.model_executor.model_loader import get_model
 from vllm.multimodal import MULTIMODAL_REGISTRY
 from vllm.multimodal.inputs import (BatchedTensorInputs, MultiModalKwargs,
@@ -39,6 +38,7 @@ from vllm.v1.worker.gpu_input_batch import CachedRequestState, InputBatch
 from vllm.v1.worker.lora_model_runner_mixin import LoRAModelRunnerMixin
 from vllm.v1.worker.utils import sanity_check_mm_encoder_outputs
 
+from tpu_commons.logger import init_logger
 from tpu_commons.sample.metadata import TPUSupportedSamplingMetadata
 from tpu_commons.sample.sampler import Sampler as TPUSampler
 

--- a/tpu_commons/worker/tpu_torch_xla_worker.py
+++ b/tpu_commons/worker/tpu_torch_xla_worker.py
@@ -14,7 +14,6 @@ import vllm.envs as envs
 from vllm.config import ParallelConfig, VllmConfig
 from vllm.distributed import (ensure_model_parallel_initialized,
                               init_distributed_environment)
-from vllm.logger import init_logger
 from vllm.lora.request import LoRARequest
 from vllm.model_executor import set_random_seed
 from vllm.utils import STR_DTYPE_TO_TORCH_DTYPE
@@ -24,6 +23,7 @@ from vllm.v1.kv_cache_interface import (AttentionSpec, KVCacheConfig,
 from vllm.v1.outputs import ModelRunnerOutput
 from vllm.v1.utils import bind_kv_cache, report_usage_stats
 
+from tpu_commons.logger import init_logger
 from tpu_commons.runner.tpu_torch_xla_runner import TPUModelRunner
 
 logger = init_logger(__name__)

--- a/tpu_commons/worker/tpu_worker_torchax.py
+++ b/tpu_commons/worker/tpu_worker_torchax.py
@@ -29,7 +29,7 @@ except ImportError:
 from vllm.config import ParallelConfig, VllmConfig
 from vllm.distributed import (ensure_model_parallel_initialized,
                               init_distributed_environment)
-from vllm.logger import init_logger
+from tpu_commons.logger import init_logger
 from vllm.lora.request import LoRARequest
 from vllm.model_executor import set_random_seed
 from vllm.utils import STR_DTYPE_TO_TORCH_DTYPE, cdiv


### PR DESCRIPTION
- Make logger work in torchax path
- host->device transfer fix to accommodate the latest change in torchax

With latest torchax, the behavior of `to('jax')` is changed, it will move the tensor to CPU instead of the default JAX device. 
```
with torchax.default_env():
  t = t.to('jax')
```
The fix is as follows, we can remove the `jax_device` context if torchax uses the default device int `to('jax')`
```
with torchax.default_env():
  with jax_device('tpu')
    t = t.to('jax')
```