### PR TITLE
Revive vllm model+torchax on jax runner.

### DIFF
--- a/tpu_commons/runner/jax/tpu_jax_runner.py
+++ b/tpu_commons/runner/jax/tpu_jax_runner.py
@@ -357,11 +357,14 @@ class TPUModelRunner():
 
     def _init_mesh(self) -> None:
         hf_config = self.model_config.hf_config
-        model_class = _get_model_architecture(hf_config)
+        try:
+            model_class = _get_model_architecture(hf_config)
+        except NotImplementedError:
+            model_class = None
         #TODO merge the if-else branches when new design is ready
         # Llama4Scout is only used for new model design,
         # so that we use it as a flag for testing the new model design
-        if issubclass(model_class, Model):
+        if model_class is not None and issubclass(model_class, Model):
             try:
                 # TODO: Update override steps.
                 sharding_strategy = \


### PR DESCRIPTION
# Description

Make the mode with `MODEL_IMPL_TYPE=vllm` work again.

# Tests

```
export MODEL_IMPL_TYPE=vllm
export TPU_BACKEND_TYPE=jax
python examples/offline_inference.py     --model=meta-llama/Llama-3.1-8B     --tensor_parallel_size=4     --task=generate     --max_model_len=1024
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have made or will make corresponding changes to any relevant documentation.
