### PR TITLE
Delete device arrays from InputBatch as they are not currently used

### DIFF
--- a/tpu_commons/runner/jax/block_table_jax.py
+++ b/tpu_commons/runner/jax/block_table_jax.py
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
-from typing import Any
 
 import jax
 import jax.numpy as jnp
@@ -19,13 +18,11 @@ class BlockTable:
         max_num_blocks_per_req: int,
         max_num_batched_tokens: int,
         pin_memory: bool,
-        device: Any,
     ):
         self.max_num_reqs = max_num_reqs
         self.max_num_blocks_per_req = max_num_blocks_per_req
         self.max_num_batched_tokens = max_num_batched_tokens
         self.pin_memory = pin_memory
-        self.device = device
 
         self.block_table = jnp.zeros(
             (max_num_reqs, max_num_blocks_per_req),
@@ -93,11 +90,11 @@ class MultiGroupBlockTable:
     """The BlockTables for each KV cache group."""
 
     def __init__(self, max_num_reqs: int, max_model_len: int,
-                 max_num_batched_tokens: int, pin_memory: bool, device: Any,
+                 max_num_batched_tokens: int, pin_memory: bool,
                  block_sizes: list[int]) -> None:
         self.block_tables = [
             BlockTable(max_num_reqs, cdiv(max_model_len, block_size),
-                       max_num_batched_tokens, pin_memory, device)
+                       max_num_batched_tokens, pin_memory)
             for block_size in block_sizes
         ]
 

--- a/tpu_commons/runner/jax/tpu_jax_runner.py
+++ b/tpu_commons/runner/jax/tpu_jax_runner.py
@@ -1,8 +1,8 @@
 # Here we try to bring as much code as possible from Hex-LLM, instead of `tpu_torch_xla_runner.py` -> jax conversion.
 # This runner is a port of https://source.corp.google.com/h/vertex-model-garden/hex-llm/+/main:hex_llm/worker/runner_jax.py
+from dataclasses import asdict
 from typing import Any, List, Optional, Tuple
 
-from dataclasses import asdict
 import jax
 import jax.numpy as jnp
 import numpy as np
@@ -85,7 +85,6 @@ class TPUModelRunner():
             max_num_reqs=self.max_num_reqs,
             max_model_len=self.max_model_len,
             max_num_batched_tokens=self.max_num_tokens,
-            device=None,
             pin_memory=False,
             vocab_size=self.model_config.get_vocab_size(),
             block_sizes=[self.block_size],
@@ -472,7 +471,8 @@ class TPUModelRunner():
             data_items = asdict(new_req_data)
             data_items["mm_hashes"] = []
 
-            self.requests[req_id] = CachedRequestState(**data_items, output_token_ids=[])
+            self.requests[req_id] = CachedRequestState(**data_items,
+                                                       output_token_ids=[])
 
             req_ids_to_add.append(req_id)
 


### PR DESCRIPTION
# Description

Per offline discussion, we are clean these up for now and will revisit when we need the device arrays.
- Main reason is that for disaggregated inference, we need to make InputBatch thread-safe, cleaning up the code here will make the subsequent changes easier to develop and review
- With disaggregated serving on TPUs, device 0 might not be available to a worker.

# Tests

```
TPU_BACKEND_TYPE=jax python tpu_commons/examples/offline_inference.py --task=generate --model=meta-llama/Meta-Llama-3-8B-Instruct --max_model_len=1024 --max_num_seqs=8

PREFILL_SLICES=2 DECODE_SLICES=2 PYTHONPATH=$(pwd)/vllm:$(pwd)/tpu_commons TPU_BACKEND_TYPE=jax python tpu_commons/examples/offline_inference.py --task=generate --model=meta-llama/Meta-Llama-3-8B-Instruct --max_model_len=1024 --max_num_seqs=8
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have made or will make corresponding changes to any relevant documentation.
