### PR TITLE
Add `MODEL_IMPL_TYPE=vllm` mode (for vLLM model+torchax) into CI.

### DIFF
--- a/.buildkite/pipeline_jax.yml
+++ b/.buildkite/pipeline_jax.yml
@@ -7,17 +7,30 @@ steps:
      soft_fail: true
      env:
        TPU_BACKEND_TYPE: "jax"
+       MODEL_IMPL_TYPE: "n/a"
      agents:
        queue: tpu_v6e_queue
      commands:
        - .buildkite/scripts/run_in_docker.sh python3 -m pytest -s -v /workspace/tpu_commons/tests/ragged_paged_attention_test.py
        - .buildkite/scripts/run_in_docker.sh python3 -m pytest -s -v /workspace/tpu_commons/tests/ragged_kv_cache_update_test.py
 
-   - label: "benchmarking/mmlu.sh"
+   - label: "benchmarking/mmlu.sh for JAX + FlaxNNX models"
      key: tpu_test_1
      soft_fail: true
      env:
        TPU_BACKEND_TYPE: "jax"
+       MODEL_IMPL_TYPE: "flax_nnx"
+     agents:
+       queue: tpu_v6e_queue
+     commands:
+       - .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_commons/tests/e2e/benchmarking/mmlu.sh
+
+   - label: "benchmarking/mmlu.sh for JAX + vLLM models"
+     key: tpu_test_1_model_impl_vllm
+     soft_fail: true
+     env:
+       TPU_BACKEND_TYPE: "jax"
+       MODEL_IMPL_TYPE: "vllm"
      agents:
        queue: tpu_v6e_queue
      commands:

--- a/.buildkite/scripts/run_in_docker.sh
+++ b/.buildkite/scripts/run_in_docker.sh
@@ -28,6 +28,10 @@ if [ -z "${TPU_BACKEND_TYPE:-}" ]; then
   TPU_BACKEND_TYPE=pytorch_xla
 fi
 
+if [ -z "${MODEL_IMPL_TYPE:-}" ]; then
+  MODEL_IMPL_TYPE=flax_nn
+fi
+
 # Prune older images on the host to save space.
 docker system prune -a -f --filter "until=3h"
 
@@ -41,6 +45,7 @@ exec docker run \
   --shm-size=16G \
   --rm \
   -e TPU_BACKEND_TYPE="$TPU_BACKEND_TYPE" \
+  -e MODEL_IMPL_TYPE="$MODEL_IMPL_TYPE" \
   -e HF_TOKEN="$HF_TOKEN" \
   -e VLLM_XLA_CACHE_PATH= \
   -e VLLM_USE_V1=1 \

--- a/tests/e2e/benchmarking/mmlu.sh
+++ b/tests/e2e/benchmarking/mmlu.sh
@@ -205,7 +205,7 @@ for model_name in $model_list; do
     echo "--------------------------------------------------"
     # Spin up the vLLM server
     echo "Spinning up the vLLM server..."
-    (TPU_BACKEND_TYPE=jax vllm serve "$model_name" --max-model-len=1024 --disable-log-requests --max-num-batched-tokens 8192 2>&1 | tee -a "$LOG_FILE") &
+    (vllm serve "$model_name" --max-model-len=1024 --disable-log-requests --max-num-batched-tokens 8192 2>&1 | tee -a "$LOG_FILE") &
 
 
 


### PR DESCRIPTION
# Description

Prevent commits from breaking vLLM model + torchax + jax_runner path.

# Tests

A manual succesful CI run: https://buildkite.com/tpu-commons/tpu-commons-ci/builds/322

Also a manual negative CI run to test that it does catch breaking changes: https://buildkite.com/tpu-commons/tpu-commons-ci/builds/324

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have made or will make corresponding changes to any relevant documentation.
