### PR TITLE
Delete more dead code from InputBatch [Gemini Generated]

### DIFF
--- a/tpu_commons/core/disagg_utils.py
+++ b/tpu_commons/core/disagg_utils.py
@@ -40,8 +40,12 @@ def _parse_slices(slices_str: str) -> Tuple[int, ...]:
 
 
 def get_prefill_slices() -> Tuple[int, ...]:
+    if PREFILL_SLICES not in os.environ:
+        return ()
     return _parse_slices(os.environ[PREFILL_SLICES])
 
 
 def get_decode_slices() -> Tuple[int, ...]:
+    if DECODE_SLICES not in os.environ:
+        return ()
     return _parse_slices(os.environ[DECODE_SLICES])

--- a/tpu_commons/runner/jax/tpu_jax_runner.py
+++ b/tpu_commons/runner/jax/tpu_jax_runner.py
@@ -395,6 +395,7 @@ class TPUModelRunner():
                                       axis_names,
                                       devices=self.devices)
             logger.info(f"Init mesh | mesh={self.mesh}")
+        logger.warning(f"Init mesh | mesh={self.mesh} devices={self.devices}")
 
     def _init_model(self) -> None:
         logger.info("Init model start...")

--- a/tpu_commons/utils_jax.py
+++ b/tpu_commons/utils_jax.py
@@ -52,7 +52,6 @@ def hbm_usage_bytes(devices: Any) -> List[Tuple[int, int]]:
         else:
             hbm_used = device.memory_stats()["bytes_in_use"]
             hbm_limit = device.memory_stats()["bytes_limit"]
-            print(hbm_used, hbm_limit)
             usage.append((hbm_used, hbm_limit))
 
     return usage

--- a/tpu_commons/worker/tpu_worker_jax.py
+++ b/tpu_commons/worker/tpu_worker_jax.py
@@ -87,10 +87,10 @@ class TPUWorker(WorkerBase):
             self.devices = jax.local_devices()
             self.global_devices = jax.devices()
 
-        logger.info(f"Init devices | "
-                    f"devices={self.devices} | "
-                    f"local_devices={len(self.devices)} | "
-                    f"hbm={utils.hbm_usage_gb(self.devices)}Gb")
+        logger.warning(f"Init devices | "
+                       f"devices={self.devices} | "
+                       f"local_devices={len(self.devices)} | "
+                       f"hbm={utils.hbm_usage_gb(self.devices)}Gb")
 
         self.model_runner = TPUModelRunner(self.vllm_config, self.devices)
 


### PR DESCRIPTION
# Description

Deleted some dead code from InputBatch, expose some issues:
- Fixed some hacks I left
- Had to reserve 50% memory to avoid an OOM in the disaggregated inference code path.

Issues observed:
- With this change, we start to see the following warning and the system ran out of memory in the DI code path. 

```
/home/fhzhang/miniconda3/envs/vllm/lib/python3.10/site-packages/jax/_src/interpreters/mlir.py:1184: UserWarning: Some donated buffers were not usable: bfloat16[4,2737,32,128]....
See an explanation at https://docs.jax.dev/en/latest/faq.html#buffer-donation.
  warnings.warn("Some donated buffers were not usable:"
```
- The non-DI code path doesn't work when `tensor_parallel_size` is set to 2.

This happens with both DI and non-DI code paths when there are more than 1 TPU involved in the computation.

# Tests

```
PREFILL_SLICES=2 DECODE_SLICES=2 PYTHONPATH=$(pwd)/vllm:$(pwd)/tpu_commons TPU_BACKEND_TYPE=jax python tpu_commons/examples/offline_inference.py --task=generate --model=meta-llama/Meta-Llama-3-8B-Instruct --max_model_len=1024 --max_num_seqs=8

TPU_BACKEND_TYPE=jax python tpu_commons/examples/offline_inference.py --task=generate --model=meta-llama/Meta-Llama-3-8B-Instruct --max_model_len=1024 --max_num_seqs=8 --tensor_parallel_size=4
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have made or will make corresponding changes to any relevant documentation.
