### PR TITLE
Fix logits indices in vllm models

### DIFF
--- a/tpu_commons/models/vllm/vllm_model_wrapper.py
+++ b/tpu_commons/models/vllm/vllm_model_wrapper.py
@@ -35,11 +35,13 @@ class ModelForLogits(torch.nn.Module):
         self,
         input_ids: torch.Tensor,
         positions: torch.Tensor,
+        logits_indices: torch.Tensor,
         intermediate_tensors: Optional[IntermediateTensors],
         inputs_embeds: Optional[torch.Tensor],
     ) -> torch.Tensor:
         hidden_state = self.vllm_model(input_ids, positions,
                                        intermediate_tensors, inputs_embeds)
+        hidden_state = hidden_state[logits_indices]
         return self.vllm_model.compute_logits(hidden_state,
                                               sampling_metadata=None)
 
@@ -108,6 +110,7 @@ class VllmModelWrapper:
             temperatures: jax.Array,
             top_ps: jax.Array,
             top_ks: jax.Array,
+            logits_indices: jax.Array,
             *args,
         ) -> Tuple[List[jax.Array], jax.Array, jax.Array]:
 
@@ -127,6 +130,7 @@ class VllmModelWrapper:
                         torch_view(attention_metadata.input_positions),
                         "intermediate_tensors": None,
                         "inputs_embeds": None,
+                        "logits_indices": torch_view(logits_indices),
                     },
                     tie_weights=False,
                     strict=True)
@@ -137,7 +141,6 @@ class VllmModelWrapper:
             logits = jax_view(logits)
 
             next_tokens = sample(
-                is_prefill,
                 do_sampling,
                 self.rng,
                 self.mesh,
@@ -146,7 +149,6 @@ class VllmModelWrapper:
                 temperatures,
                 top_ps,
                 top_ks,
-                attention_metadata.chunked_prefill_enabled,
             )
 
             return new_kv_caches, next_tokens, logits


### PR DESCRIPTION
# Description
Similar to #125 but for vllm models wrapped by torchax.

# Tests

Before #125
```
--------------------------------------------------
Prompt: 'Hello, my name is'
Generated text: 'Questioner and I am a seeker of knowledge. I am here to ask questions'
--------------------------------------------------
Prompt: 'The capital of France is'
Generated text: 'Question 1 options: A) Paris B) Lyon C) Marseille D)'
--------------------------------------------------
Prompt: 'The colors of the rainbow are'
Generated text: ' 7, and they are ROYGBIV. The colors of the rainbow'
--------------------------------------------------
Prompt: 'The future of AI is'
Generated text: ' of great interest to many, and it is a topic that is often discussed in'
--------------------------------------------------
Prompt: 'The president of the United States is'
Generated text: ' the head of state and head of government of the United States. The president serves'
--------------------------------------------------
```

After #125 :
```
   output = self.collective_rpc("execute_model",
  File "/workspace/vllm/vllm/executor/uniproc_executor.py", line 57, in collective_rpc
    answer = run_method(self.driver_worker, method, args, kwargs)
  File "/workspace/vllm/vllm/utils.py", line 2687, in run_method
    return func(*args, **kwargs)
  File "/workspace/tpu_commons/tpu_commons/worker/tpu_worker_jax.py", line 106, in execute_model
    output = self.model_runner.execute_model(scheduler_output)
  File "/workspace/tpu_commons/tpu_commons/runner/jax/tpu_jax_runner.py", line 437, in execute_model
    return self._execute_model(scheduler_output)[1]
  File "/workspace/tpu_commons/tpu_commons/runner/jax/tpu_jax_runner.py", line 450, in _execute_model
    self.kv_caches, next_tokens, _ = self.model_fn(*inputs)
  File "/workspace/tpu_commons/tpu_commons/models/vllm/vllm_model_wrapper.py", line 149, in step_fun
    attention_metadata.chunked_prefill_enabled,
AttributeError: 'AttentionMetadata' object has no attribute 'chunked_prefill_enabled'
```

After this fix:

```
--------------------------------------------------
Prompt: 'Hello, my name is'
Generated text: ' Emily and I am a 25-year-old freelance writer and editor. I have'
--------------------------------------------------
Prompt: 'The capital of France is'
Generated text: ' a city of romance, art, fashion, and cuisine. Paris is a must'
--------------------------------------------------
Prompt: 'The colors of the rainbow are'
Generated text: ' often remembered using the acronym ROYGBIV, which stands for Red, Orange'
--------------------------------------------------
Prompt: 'The future of AI is'
Generated text: ' bright, but it also raises concerns about bias, accountability, and the impact on'
--------------------------------------------------
Prompt: 'The president of the United States is'
Generated text: ' the head of state and head of government of the United States. The president serves'
--------------------------------------------------
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have made or will make corresponding changes to any relevant documentation.
