### PR TITLE
Fix the issue disagg inference fails with a smaller max_num_batched_tokens

### DIFF
--- a/tpu_commons/core/jetstream_commons/engine/engine_api.py
+++ b/tpu_commons/core/jetstream_commons/engine/engine_api.py
@@ -18,13 +18,11 @@ could want to call, enabling interleaved (continuous batching) inference.
 """
 
 import abc
-from typing import Any, Dict, Optional, Tuple, Union
+from typing import Any, Union
 
 import jax
 import numpy as np
 from flax import struct
-from vllm.v1.outputs import ModelRunnerOutput
-from vllm.v1.request import Request
 
 # The model parameters - their partitioning will be unique for different prefill
 # and decode topoologies.


### PR DESCRIPTION
# Description

The issue is that get_kv_cache_for_requests() expects all the scheduled tokens, not just the ones completed. With a smaller `max_num_batched_tokens`, say 15, the manual test fails with index out of bound errors. The change fixes it.

# Tests

```
 PREFILL_SLICES=2 DECODE_SLICES=2 PYTHONPATH=$(pwd)/vllm:$(pwd)/tpu_commons TPU_BACKEND_TYPE=jax python tpu_commons/examples/offline_inference.py --task=generate --model=meta-llama/Meta-Llama-3-8B-Instruct --max_model_len=1024 --max_num_seqs=8 --max_num_batched_tokens=15

--------------------------------------------------
Prompt: 'Hello, my name is'
Generated text: ' [ I am a 25-year-old woman from the United States. I am'
--------------------------------------------------
Prompt: 'The capital of France is'
Generated text: ' Paris The city is known for its stunning architecture, art museums, fashion, and'
--------------------------------------------------
Prompt: 'The colors of the rainbow are'
Generated text: ' often Red, orange, yellow, green, blue, indigo, violet.'
--------------------------------------------------
Prompt: 'The future of AI is'
Generated text: ' bright The future of AI is! The future of AI is!\nI know,'
--------------------------------------------------
Prompt: 'The president of the United States is'
Generated text: ' the The President of the United States is the head of state! The President of'
--------------------------------------------------
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have made or will make corresponding changes to any relevant documentation.
