### PR TITLE
Shuffle insert KV cache logic and jit compile partially for better perf.

### DIFF
--- a/examples/offline_inference.py
+++ b/examples/offline_inference.py
@@ -83,7 +83,7 @@ def main(args: dict):
         "Who wrote the American Declaration of Independence?",
         'Who wrote the novel "Pride and Prejudice"?',
     ]
-
+    
     if envs.VLLM_TORCH_PROFILER_DIR is not None:
         llm.start_profile()
     outputs = llm.generate(prompts, sampling_params)

--- a/tpu_commons/core/core_tpu.py
+++ b/tpu_commons/core/core_tpu.py
@@ -156,10 +156,6 @@ class EngineCore:
         assert len(kv_cache_specs) == len(available_gpu_memory)
 
         # Get the kv cache tensor size
-        # We leave 50% memory for processing and incoming batches. This is due to the
-        # donation issues we are seeing:
-        #   /mlir.py:1184: UserWarning: Some donated buffers were not usable: bfloat16[4,2737,32,128]...
-        # TODO(fhzhang): fix the donation issues!
         kv_cache_configs = [
             get_kv_cache_config(vllm_config, kv_cache_spec_one_worker,
                                 available_gpu_memory_one_worker)

--- a/tpu_commons/runner/utils.py
+++ b/tpu_commons/runner/utils.py
@@ -4,8 +4,13 @@ Implements a few utility functions for the various runners.
 """
 from typing import Optional
 
+import time
+
+from vllm.logger import init_logger
+
 MIN_NUM_SEQS = 8
 
+logger = init_logger(__name__)
 
 def determine_do_sampling(top_k: int, temperature: float) -> bool:
     """
@@ -37,3 +42,16 @@ def pad_to_multiple(x: int,
 def get_padded_num_reqs_with_upper_limit(x: int, upper_limit: int) -> int:
     res = MIN_NUM_SEQS if x <= MIN_NUM_SEQS else 1 << (x - 1).bit_length()
     return min(res, upper_limit)
+
+class LatencyTracker:
+    def __init__(self, name="Operation"):
+        self.name = name
+
+    def __enter__(self):
+        self.start_time = time.perf_counter()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.end_time = time.perf_counter()
+        elapsed_time = self.end_time - self.start_time
+        logger.info(f"Latency for '{self.name}': {elapsed_time:.3f} seconds")


### PR DESCRIPTION
# Description

Started looking into performance of disaggregated inference.

- Moved the reshaping of the KV cache to transfer thread as it doesn't block generate.
- Jit compile the array set part to cut down latency.

As a result, this reduced the overall kv cache insertion latency from ~4.5s to total of ~2.5s, and ~1.2s doesn't block generate any more, still not great, but much better.

# Tests

```
$ PREFILL_SLICES=2 DECODE_SLICES=2 PYTHONPATH=$(pwd)/vllm:$(pwd)/tpu_commons TPU_BACKEND_TYPE=jax python tpu_commons/examples/offline_inference.py --task=generate --model=meta-llama/Meta-Llama-3-8B-Instruct --max_model_len=1024 --max_num_seqs=8

2025-07-05 14:39:41,257 - root - [130666217866816] - INFO - Latency for 'TransferKVCache-0': 0.014 seconds
2025-07-05 14:39:46,017 - root - [130595797599808] - INFO - Latency for 'InsertKVCacheRequest-0': 4.716 seconds
2025-07-05 14:39:41,319 - root - [130666217866816] - INFO - Latency for 'TransferKVCache-1': 0.027 seconds
2025-07-05 14:39:50,190 - root - [130595797599808] - INFO - Latency for 'InsertKVCacheRequest-1': 4.168 seconds
```

After:
```
$ PREFILL_SLICES=2 DECODE_SLICES=2 PYTHONPATH=$(pwd)/vllm:$(pwd)/tpu_commons TPU_BACKEND_TYPE=jax python tpu_commons/examples/offline_inference.py --task=generate --model=meta-llama/Meta-Llama-3-8B-Instruct --max_model_len=1024 --max_num_seqs=8

2025-07-05 15:22:55,197 - tpu_commons.runner.utils - [138877918512704] - INFO - Latency for 'TransferKVCache-6': 1.368 seconds
2025-07-05 15:22:56,673 - tpu_commons.runner.utils - [138877918512704] - INFO - Latency for 'TransferKVCache-7': 1.471 seconds
2025-07-05 15:22:58,285 - tpu_commons.runner.utils - [138877928998464] - INFO - Latency for 'InsertKVCacheRequest-6': 1.290 seconds
2025-07-05 15:22:59,453 - tpu_commons.runner.utils - [138877928998464] - INFO - Latency for 'InsertKVCacheRequest-7': 1.163 seconds
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have made or will make corresponding changes to any relevant documentation.
