### PR TITLE
[CI] fix the bugs where CI failure cannot be captured

### DIFF
--- a/.buildkite/pipeline_jax.yml
+++ b/.buildkite/pipeline_jax.yml
@@ -46,4 +46,4 @@ steps:
        - tpu_test_1_model_impl_vllm
      agents:
        queue: tpu_v6e_queue
-     commands: "bash .buildkite/scripts/check_results.sh"
+     commands: "bash .buildkite/scripts/check_results.sh 'TPU JAX Tests Failed' tpu_test_0 tpu_test_1_model_impl_flax_nnx tpu_test_1_model_impl_vllm"

--- a/.buildkite/pipeline_torch.yml
+++ b/.buildkite/pipeline_torch.yml
@@ -135,4 +135,4 @@ steps:
        - tpu_test_13
      agents:
        queue: tpu_v6e_queue
-     commands: "bash .buildkite/scripts/check_results.sh"
+     commands: "bash .buildkite/scripts/check_results.sh 'TPU V1 Tests Failed' tpu_test_0 tpu_test_1 tpu_test_2 tpu_test_3 tpu_test_4 tpu_test_5 tpu_test_6 tpu_test_7 tpu_test_8 tpu_test_9 tpu_test_10 tpu_test_11 tpu_test_12 tpu_test_13"

--- a/.buildkite/scripts/check_results.sh
+++ b/.buildkite/scripts/check_results.sh
@@ -2,27 +2,32 @@
 set -e
 
 ANY_FAILED=false
+if [ "$#" -lt 2 ]; then
+    echo "Usage: $0 <failure_label> <step_key_1> <step_key_2> ..."
+    exit 1
+fi
 
-STEP_KEYS="tpu_test_0 tpu_test_1 tpu_test_2 tpu_test_3 tpu_test_4 tpu_test_5 tpu_test_6 tpu_test_7 tpu_test_8 tpu_test_9 tpu_test_10 tpu_test_11 tpu_test_12 tpu_test_13"
+FAILURE_LABEL="$1"
+shift
 
 echo "--- Checking Test Outcomes"
 
-for KEY in $STEP_KEYS; do
+for KEY in "$@"; do
     OUTCOME=$(buildkite-agent step get "outcome" --step "${KEY}" || echo "skipped")
     echo "Step ${KEY} outcome: ${OUTCOME}"
 
     if [ "${OUTCOME}" != "passed" ] && [ "${OUTCOME}" != "skipped" ] ; then
-    ANY_FAILED=true
+        ANY_FAILED=true
     fi
 done
 
 if [ "${ANY_FAILED}" = "true" ] ; then
     cat <<- YAML | buildkite-agent pipeline upload
     steps:
-    - label: "TPU V1 Test failed"
+    - label: "${FAILURE_LABEL}"
         agents:
         queue: tpu_v6_queue
-        command: echo "TPU V1 Test failed"
+        command: echo "${FAILURE_LABEL}"
 YAML
     exit 1
 else


### PR DESCRIPTION
# Description
This PR fixed the bugs where CI failure cannot be captured. E.g. https://buildkite.com/tpu-commons/tpu-commons-ci/builds/394/steps/canvas. The JAX+vLLM test is actually failed but CI is green, which is misleading. 

Note: This PR does not fix the CI failure. It just makes the buildkite canvas look correct. 

@xiangxu-google @kathyyu-google 

# Tests

Cannot test locally. Need to trigger a CI in this branch.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have made or will make corresponding changes to any relevant documentation.
