### PR TITLE
[CI] Caputre the failure when second model passes but first fails

### DIFF
--- a/tests/e2e/benchmarking/mmlu.sh
+++ b/tests/e2e/benchmarking/mmlu.sh
@@ -189,7 +189,6 @@ checkThroughputAndRouge() {
 
     if [ "$rouge1_pass" -eq 1 ] && [ "$throughput_pass" -eq 1 ]; then
         echo "Overall: PASSED"
-        exit_code=0
     else
         echo "Overall: FAILED"
         [ "$rouge1_pass" -eq 0 ] && echo "Reason: Rouge1 check failed or value not found."


### PR DESCRIPTION

# Description
Caputre the failure when the second model passes the mmlu but the first does not.

E.g. https://buildkite.com/tpu-commons/tpu-commons-ci/builds/396/steps/canvas?sid=0197e354-0ab5-4a36-90c0-17917f6ac16e 
There is some CI failure in Qwen model, but the later llama model changes the exit_status to 0, so it fails to capture the previous failure.

@xiangxu-google @kathyyu-google 

# Tests


# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have made or will make corresponding changes to any relevant documentation.
