### PR TITLE
Fix incorrect argument being passed to `sample`

### DIFF
--- a/tpu_commons/models/jax/recipes/llama3.py
+++ b/tpu_commons/models/jax/recipes/llama3.py
@@ -216,12 +216,10 @@ class Llama3_8B(Model):
         decoder_output = self.embedder.decode(final_activation)
 
         next_tokens = sample(
-            is_prefill,
             do_sampling,
             self.rng.params(),
             self.mesh,
             decoder_output,
-            attention_metadata.seq_lens,
             temperatures,
             top_ps,
             top_ks,

--- a/tpu_commons/models/jax/recipes/llama4.py
+++ b/tpu_commons/models/jax/recipes/llama4.py
@@ -208,12 +208,10 @@ class Llama4Scout(Model):
             "DEBUG: Logits for last token (first 10 values): {logits}",
             logits=decoder_output[:, -1, :10])
         next_tokens = sample(
-            is_prefill,
             do_sampling,
             self.rng,
             self.mesh,
             decoder_output,
-            attention_metadata.seq_lens,
             temperatures,
             top_ps,
             top_ks,

--- a/tpu_commons/models/vllm/vllm_model_wrapper.py
+++ b/tpu_commons/models/vllm/vllm_model_wrapper.py
@@ -145,7 +145,6 @@ class VllmModelWrapper:
                 self.rng,
                 self.mesh,
                 logits,
-                attention_metadata.seq_lens,
                 temperatures,
                 top_ps,
                 top_ks,


### PR DESCRIPTION
# Description

In this PR, I fix a bug where an extra `attention_metadata.chunked_prefill_enabled` argument was being passed to `sample` after the latter was refactored.

<img width="979" alt="image" src="https://github.com/user-attachments/assets/8b09d994-a132-4716-8023-744b14f8009c" />

