### PR TITLE
Make benchmark more strict to catch big regressions.

### DIFF
--- a/tests/e2e/benchmarking/mmlu.sh
+++ b/tests/e2e/benchmarking/mmlu.sh
@@ -20,14 +20,15 @@ TIMEOUT_SECONDS=300
 
 # The minimum ROUGE1 and throughput scores we expect
 # TODO (jacobplatin): these are very low, so we'll want to boost them eventually
-TARGET_ROUGE1="30"
-TARGET_THROUGHPUT="50"
+# We need to support different targets for different models.
+TARGET_ROUGE1="40"
+TARGET_THROUGHPUT="1500"
 
 model_list="Qwen/Qwen2.5-1.5B-Instruct meta-llama/Llama-3.1-8B-Instruct"
 root_dir=/workspace
 dataset_name=mlperf
 dataset_path=""
-num_prompts=10
+num_prompts=1000
 exit_code=0
 
 helpFunction()


### PR DESCRIPTION
# Description

Context: https://b.corp.google.com/issues/430091187.
Our rouge score in the benchmark in CI does not change no matter the code is buggy or not.

By increasing number of prompts, the big regressions can be caught. I have discussed in the buganizer thread that due to mlperf dataset having free-form, it might not be great for catching more subtle regressions. Ideally we need something like mmlu or gsm8k. 

# Tests

buildkite: https://buildkite.com/tpu-commons/tpu-commons-ci/builds/415

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [ ] I have necessary comments in my code, particularly in hard-to-understand areas.
- [ ] I have made or will make corresponding changes to any relevant documentation.
