### PR TITLE
simple mark select_hidden_states as jit

### DIFF
--- a/tpu_commons/runner/tpu_torchax_runner.py
+++ b/tpu_commons/runner/tpu_torchax_runner.py
@@ -1707,11 +1707,11 @@ class TPUModelRunner(LoRAModelRunnerMixin):
                 compiled_model.original_code_object)
             compiled_model.compiled_codes.clear()
 
-    # @torch.compile(backend="openxla", fullgraph=True, dynamic=False)
-    def select_hidden_states(self, hidden_states, indices_do_sample):
+    @staticmethod
+    @torchax.interop.jax_jit
+    def select_hidden_states(hidden_states, indices_do_sample):
         return hidden_states[indices_do_sample]
 
-    # @torch.compile(backend="openxla", fullgraph=True, dynamic=False)
     def compute_logits(self,
                        sample_hidden_states: torch.Tensor) -> torch.Tensor:
         return self.model.compute_logits(sample_hidden_states, None)


### PR DESCRIPTION
# Description

As titled, mark select_hidden_states as jit
We are not expecting any noticeable performance improvement 

# Tests

VLLM_TORCHAX_ENABLED=1 TPU_BACKEND_TYPE=torchax VLLM_USE_V1=1 python vllm/examples/offline_inference/tpu.py 2>&1

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have made or will make corresponding changes to any relevant documentation.
