### PR TITLE
Fix auto KV-cache num-blocks calculation when tp>1

### DIFF
--- a/tpu_commons/runner/jax/tpu_jax_runner.py
+++ b/tpu_commons/runner/jax/tpu_jax_runner.py
@@ -1,5 +1,6 @@
 import functools
 import os
+import random
 from dataclasses import asdict
 from typing import Any, List, Optional, cast
 
@@ -84,6 +85,7 @@ class TPUModelRunner():
     def _init_random(self):
         if self.model_config.seed is None:
             self.model_config.seed = 0
+        random.seed(self.model_config.seed)
         np.random.seed(self.model_config.seed)
         self.rng_key = jax.random.key(self.model_config.seed)
 
@@ -238,7 +240,8 @@ class TPUModelRunner():
                     f"hbm={utils.hbm_usage_gb(self.devices)}Gb")
 
     def capture_model(self) -> None:
-        pass
+        # TODO(xiang): add warm up
+        return
 
     @staticmethod
     @functools.partial(jax.jit)


### PR DESCRIPTION
# Description

The auto num-blocks is wrongly calculated when tp>1, this fix includes all devices' HBM.

# Tests

The HBM is fully utilized now:
```
INFO 07-08 01:14:18 [tpu_jax_runner.py:180] Init model | hbm=[(3.74, 31.25), (3.74, 31.25), (3.74, 31.25), (3.74, 31.25)]Gb
INFO 07-08 01:14:18 [kv_cache_utils.py:716] GPU KV cache size: 811,008 tokens
INFO 07-08 01:14:18 [kv_cache_utils.py:720] Maximum concurrency for 4,096 tokens per request: 198.00x
INFO 07-08 01:14:18 [tpu_jax_runner.py:236] PJRT C API
INFO 07-08 01:14:18 [tpu_jax_runner.py:236] TFRT TPU v6 lite
INFO 07-08 01:14:18 [tpu_jax_runner.py:236] Built on May 15 2025 08:22:47 (1747322567) cl/759148519
INFO 07-08 01:14:18 [tpu_jax_runner.py:237] Init kv-cache | shape=32 * (3168, 256, 16, 128) | sharding=NamedSharding(mesh=Mesh('data': 1, 'model': 4, axis_types=(Auto, Auto)), spec=PartitionSpec(None, None, 'model'), memory_kind=device) | hbm=[(28.49, 31.25), (28.49, 31.25), (28.49, 31.25), (28.49, 31.25)]Gb
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [ ] I have performed a self-review of my code.
- [ ] I have necessary comments in my code, particularly in hard-to-understand areas.
- [ ] I have made or will make corresponding changes to any relevant documentation.
