### PR TITLE
Fix disagg OOM issue

### DIFF
--- a/tpu_commons/runner/jax/tpu_jax_runner.py
+++ b/tpu_commons/runner/jax/tpu_jax_runner.py
@@ -263,8 +263,11 @@ class TPUModelRunner():
         return batched_kv_cache_per_layer
 
     @staticmethod
-    @functools.partial(jax.jit,
-                       static_argnames=("block_size", "kv_cache_sharding"))
+    @functools.partial(
+        jax.jit,
+        static_argnames=("block_size", "kv_cache_sharding"),
+        donate_argnames=("kv_caches"),
+    )
     def _jitted_insert_kv_cache(
         kv_caches: List[jax.Array],
         kv_cache_slices: List[jax.Array],
@@ -313,7 +316,7 @@ class TPUModelRunner():
         Args:
             request_ids: A list of request IDs to extract KV cache for.
             kv_cache_write_indices: The metadata for slot mapping, from
-                `AttentionMetadata.kv_cache_write_indices`.
+                `AttentionMetadata.slot_mapping`.
             num_scheduled_tokens_per_req: An array containing the number of
                 scheduled tokens for each request in the current batch, ordered
                 by their position in the batch.


### PR DESCRIPTION
# Description

Two issues:
1. The `kv_cache_write_indices` field in AttentionMetadata is renamed
2. The kv-cache block calculation was wrong before https://github.com/vllm-project/tpu_commons/pull/145, DI happened to run without OOM because of that bug. The kv-cache in `_jitted_insert_kv_cache` needs to be donated to avoid OOM (the real fix).

# Tests

https://paste.googleplex.com/4632001352826880

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [ ] I have performed a self-review of my code.
- [ ] I have necessary comments in my code, particularly in hard-to-understand areas.
- [ ] I have made or will make corresponding changes to any relevant documentation.
