### PR TITLE
Fix model load OOM in DI when slice=1

### DIFF
--- a/tpu_commons/models/jax/layers/misc.py
+++ b/tpu_commons/models/jax/layers/misc.py
@@ -1,4 +1,3 @@
-import math
 from typing import Tuple
 
 import jax
@@ -9,8 +8,4 @@ from jax.sharding import PartitionSpec as P
 # TODO(xiang): move this to weight_utils.py
 def shard_put(x: jax.Array, sharding_names: Tuple[str, ...] | P,
               mesh: jax.sharding.Mesh) -> jax.Array:
-    # Single device sharding requires this special handling
-    # to avoid the recursive jit error.
-    if math.prod(mesh.axis_sizes) == 1:
-        return jax.device_put(x, jax.devices()[0])
     return jax.device_put(x, NamedSharding(mesh, P(*sharding_names)))


### PR DESCRIPTION
# Description

This hack was used to fix the non-standard mesh sharding when tp=1. It's not needed now. And it caused model load OOM in DI when slice=1.

# Tests
local
