### PR TITLE
Yield in busy loop to fix the high latency issue we are seeing in DI.

### DIFF
--- a/tpu_commons/core/core_tpu.py
+++ b/tpu_commons/core/core_tpu.py
@@ -445,6 +445,7 @@ class EngineCoreProc(EngineCore):
             self._process_input_queue()
             # 2) return the outputs.
             self._process_output_queue()
+            time.sleep(0.05)
 
     def _process_input_queue(self):
         """Exits when an engine step needs to be performed."""


### PR DESCRIPTION
# Description

The issue is that the busy loop is hogging CPUs. Adding a sleep here will release the cpu for other threads.


# Tests

Manual test.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have made or will make corresponding changes to any relevant documentation.
