### PR TITLE
Simplify the code for extracting kv cache blocks from the prefill wor…

### DIFF
--- a/tests/runner/jax/test_tpu_jax_runner.py
+++ b/tests/runner/jax/test_tpu_jax_runner.py
@@ -134,110 +134,9 @@ class TestTPUJaxRunner(unittest.TestCase):
         # Assertions
         np.testing.assert_array_equal(result, expected_metadata)
 
-    def test_get_kv_cache_for_requests(self):
-        # Setup mock data
-        self.runner.block_size = 16
-        self.runner.max_num_blocks_per_req = 16
-        num_blocks = 50
-        num_kv_heads = 2
-        head_size = 4
-        # The shape of kv_cache is (num_blocks, block_size, num_kv_heads * 2, head_size)
-        kv_cache_shape = (num_blocks, self.runner.block_size, 2 * num_kv_heads,
-                          head_size)
-        kv_cache_layer1 = jnp.arange(np.prod(kv_cache_shape),
-                                     dtype=jnp.float32).reshape(kv_cache_shape)
-        kv_cache_layer2 = jnp.arange(
-            np.prod(kv_cache_shape),
-            2 * np.prod(kv_cache_shape),
-            dtype=jnp.float32).reshape(kv_cache_shape)
-        self.runner.kv_caches = [kv_cache_layer1, kv_cache_layer2]
-
-        # Setup input batch state for 3 requests
-        self.runner.input_batch.req_id_to_index = {
-            'req1': 0,
-            'req2': 1,
-            'req3': 2
-        }
-        num_reqs = 3
-        # req1: new request, 10 scheduled tokens
-        # req2: running, 20 computed, 15 scheduled (crosses block boundary)
-        # req3: running, 5 computed, 0 scheduled
-        self.runner.input_batch.num_computed_tokens_cpu = np.array(
-            [0, 20, 5], dtype=np.int32)
-        num_scheduled_tokens_per_req = np.array([10, 15, 0], dtype=np.int32)
-
-        block_table = np.zeros(
-            (self.runner.max_num_reqs, self.runner.max_num_blocks_per_req),
-            dtype=np.int32)
-        # req1 uses block 10
-        block_table[0, 0] = 10
-        # req2 has 20 computed tokens, using blocks 20 and 21.
-        # It's scheduled for 15 more, which will use part of block 21 and 22.
-        block_table[1, 0:3] = [20, 21, 22]
-        self.runner.input_batch.block_table[0].block_table_cpu = block_table
-
-        # Generate slot mapping metadata
-        slot_mapping_metadata_np = self.runner._get_slot_mapping_metadata(
-            num_reqs, num_scheduled_tokens_per_req)
-
-        # Simulate padding and transpose from _prepare_inputs
-        padded_total_num_scheduled_tokens = _get_padded_token_len(
-            self.runner.num_tokens_paddings, 25)
-        padded_num_slices = _get_padded_num_kv_cache_update_slices(
-            padded_total_num_scheduled_tokens, self.runner.max_num_reqs,
-            self.runner.block_size)
-        padded_slot_mapping_metadata_np = np.pad(
-            slot_mapping_metadata_np,
-            [[0, padded_num_slices - len(slot_mapping_metadata_np)], [0, 0]],
-            constant_values=0)
-        kv_cache_write_indices = jnp.array(
-            np.transpose(padded_slot_mapping_metadata_np))
-
-        print(kv_cache_write_indices)
-
-        # Call the function with existing and non-existing requests
-        request_ids = ['req1', 'req2', 'req3', 'non_existent_req']
-        result = self.runner.get_kv_cache_for_requests(
-            request_ids, kv_cache_write_indices, num_scheduled_tokens_per_req)
-
-        # Assertions
-        self.assertIn('req1', result)
-        self.assertIn('req2', result)
-        self.assertIn('req3', result)
-        self.assertNotIn('non_existent_req', result)
-
-        # Check req1's KV cache
-        # 10 tokens from block 10, starting at offset 0.
-        # Flat cache index: 10 * 16 + 0 = 160. Length is 10.
-        flat_cache1 = kv_cache_layer1.reshape(-1, *kv_cache_layer1.shape[2:])
-        flat_cache2 = kv_cache_layer2.reshape(-1, *kv_cache_layer2.shape[2:])
-        expected_req1_l1 = flat_cache1[160:170]
-        expected_req1_l2 = flat_cache2[160:170]
-        self.assertEqual(len(result['req1']), 2)  # 2 layers
-        np.testing.assert_array_equal(result['req1'][0], expected_req1_l1)
-        np.testing.assert_array_equal(result['req1'][1], expected_req1_l2)
-
-        # Check req2's KV cache
-        # 15 tokens starting from computed_token 20.
-        # Slice 1: 12 tokens from block 21, starting at offset 4.
-        # Flat cache index: 21 * 16 + 4 = 340. Length 12.
-        # Slice 2: 3 tokens from block 22, starting at offset 0.
-        # Flat cache index: 22 * 16 + 0 = 352. Length 3.
-        indices_req2 = np.concatenate(
-            [np.arange(340, 352),
-             np.arange(352, 355)])
-        expected_req2_l1 = flat_cache1.take(jnp.array(indices_req2), axis=0)
-        expected_req2_l2 = flat_cache2.take(jnp.array(indices_req2), axis=0)
-        self.assertEqual(len(result['req2']), 2)  # 2 layers
-        np.testing.assert_array_equal(result['req2'][0], expected_req2_l1)
-        np.testing.assert_array_equal(result['req2'][1], expected_req2_l2)
-
-        # Check req3's KV cache (should be empty)
-        self.assertEqual(len(result['req3']), 0)
-
     def test_insert_request_with_kv_cache(self):
         # This test refines the insertion test by first extracting a KV cache
-        # using get_kv_cache_for_requests, simulating a prefill->decode
+        # using get_kv_cache_for_block_ids, simulating a prefill->decode
         # transfer, and then inserting it. This ensures the extraction and
         # insertion logic are compatible.
 
@@ -277,13 +176,14 @@ class TestTPUJaxRunner(unittest.TestCase):
         mock_sampling_params.all_stop_token_ids = set()
 
         # 2. ===== Simulate prefill execution state =====
+        prefill_block_ids = [5]
         # Create a request state for prefill.
         prefill_request_state = CachedRequestState(
             req_id="test_req_1",
             prompt_token_ids=list(range(prompt_len)),
             output_token_ids=[],
             sampling_params=mock_sampling_params,
-            block_ids=tuple([[5]]),  # Block 5 is allocated for prefill
+            block_ids=tuple([prefill_block_ids]),
             num_computed_tokens=0,
             lora_request=None,
             mm_inputs=[],
@@ -296,30 +196,17 @@ class TestTPUJaxRunner(unittest.TestCase):
         # Add the request to the input_batch to simulate it being scheduled.
         self.runner.input_batch.add_request(prefill_request_state)
 
-        # 3. ===== Generate metadata and extract KV cache =====
-        num_scheduled_tokens_per_req = np.array([prompt_len], dtype=np.int32)
+        # 3. ===== Extract KV cache using get_kv_cache_for_block_ids =====
+        # Extract the full KV cache for the allocated block.
+        full_block_kv_cache = self.runner.get_kv_cache_for_block_ids(
+            block_ids=prefill_block_ids)
 
-        # This simulates the metadata that would be generated during prefill.
-        slot_mapping_metadata = self.runner._get_slot_mapping_metadata(
-            num_reqs=1,
-            num_scheduled_tokens_per_req=num_scheduled_tokens_per_req)
-
-        # The metadata is padded and transposed before being used.
-        padded_num_slices = _get_padded_num_kv_cache_update_slices(
-            prompt_len, self.runner.max_num_reqs, self.runner.block_size)
-        padded_slot_mapping_metadata = np.pad(
-            slot_mapping_metadata,
-            [[0, padded_num_slices - len(slot_mapping_metadata)], [0, 0]],
-            constant_values=0)
-        kv_cache_write_indices = jnp.array(
-            np.transpose(padded_slot_mapping_metadata))
-
-        # Extract the KV cache slices for the prefilled request.
-        extracted_kv_cache_dict = self.runner.get_kv_cache_for_requests(
-            request_ids=['test_req_1'],
-            kv_cache_write_indices=kv_cache_write_indices,
-            num_scheduled_tokens_per_req=num_scheduled_tokens_per_req)
-        extracted_kv_cache_slices = extracted_kv_cache_dict['test_req_1']
+        # Since get_kv_cache_for_block_ids returns the full block, but the
+        # prompt only fills part of it, we need to slice it to the actual
+        # prompt length for the insertion test to be accurate.
+        extracted_kv_cache_slices = [
+            layer_cache[:prompt_len] for layer_cache in full_block_kv_cache
+        ]
 
         # 4. ===== Setup destination runner for decode simulation =====
         # Reset runner state to simulate a fresh decode runner.

--- a/tpu_commons/core/jetstream_commons/core/orchestrator.py
+++ b/tpu_commons/core/jetstream_commons/core/orchestrator.py
@@ -324,8 +324,8 @@ class Driver:
             if self._interleaved_mode:
                 self._interleaved_lock.acquire()
             with LatencyTracker("prefill"):
-                kv_caches, vllm_model_runner_output = prefill_engine.prefill()
-            my_transfer_backlog.put(kv_caches, block=True)
+                kv_cach_map, vllm_model_runner_output = prefill_engine.prefill()
+            my_transfer_backlog.put(kv_cach_map, block=True)
             if self._interleaved_mode:
                 self._interleaved_lock.release()
 
@@ -357,14 +357,14 @@ class Driver:
         prefill_engine = self._prefill_engines[idx]
         while self.live:
             # The transfer thread can just sleep until it has work to do.
-            kv_caches = transfer_backlog.get(block=True)
-            if kv_caches is None:
+            kv_cachce_map = transfer_backlog.get(block=True)
+            if kv_cachce_map is None:
                 break
 
-            logging.info(f"KV Cache items received: {kv_caches.keys()}")
+            logging.info(f"KV Cache items received: {kv_cachce_map.keys()}")
 
             push_targets = []
-            for req_id, kv_cache in kv_caches.items():
+            for req_id, kv_cache in kv_cachce_map.items():
                 request = self.requests[req_id]
                 target_idx = min(self._generate_backlogs.items(),
                                  key=lambda q: q[1].qsize())[0]


### PR DESCRIPTION
…ker in DI.

# Description

For KV cache transfer, we only care about the list of blocks. This change simplifies the logic and will prepare us for further perf optimization.


# Tests

Unit tests and manual tests.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have made or will make corresponding changes to any relevant documentation.
