### PR TITLE
Simplify model interface.

### DIFF
--- a/tpu_commons/models/jax/layers/sampling.py
+++ b/tpu_commons/models/jax/layers/sampling.py
@@ -8,19 +8,18 @@ from tpu_commons.sample.metadata_jax import TPUSupportedSamplingMetadata
 
 
 def sample(
-    do_sampling: bool,
     rng: jax.Array,
     mesh: Mesh,
     logits: jax.Array,
     tpu_sampling_metadata: TPUSupportedSamplingMetadata,
 ) -> jax.Array:
     # (B, vocab_size)
-    if do_sampling:
+    if tpu_sampling_metadata.do_sampling:
         # Unshard the logits explicity to avoid latency increase.
         logits = jax.lax.with_sharding_constraint(
             logits, NamedSharding(mesh, P(None, None)))
 
-    if not do_sampling:
+    if not tpu_sampling_metadata.do_sampling:
         return jnp.argmax(logits, axis=-1)
 
     logits = logits.astype(jnp.float32)

--- a/tpu_commons/models/jax/llama.py
+++ b/tpu_commons/models/jax/llama.py
@@ -258,8 +258,6 @@ class LlamaForCausalLM(nnx.Module):
 
     def __call__(
         self,
-        is_prefill: bool,
-        do_sampling: bool,
         kv_caches: List[jax.Array],
         input_ids: jax.Array,
         attention_metadata: AttentionMetadata,
@@ -288,7 +286,6 @@ class LlamaForCausalLM(nnx.Module):
         logits = jnp.dot(x, self.lm_head.value)
 
         next_tokens = sample(
-            do_sampling,
             self.rng.params(),
             self.mesh,
             logits,

--- a/tpu_commons/models/jax/model_loader.py
+++ b/tpu_commons/models/jax/model_loader.py
@@ -123,8 +123,7 @@ def get_flax_model(
             outputs_sharding,
             logits_cache_sharding,
         ),
-        static_argnums=(2, 3),
-        donate_argnums=4,
+        donate_argnums=2,  # 0 is graphdef, 1 is state, 2 is kv_cache
     )
     def run_model(graphdef, state, *args):
         model = nnx.merge(graphdef, state)

--- a/tpu_commons/models/jax/qwen2.py
+++ b/tpu_commons/models/jax/qwen2.py
@@ -264,8 +264,6 @@ class Qwen2ForCausalLM(nnx.Module):
 
     def __call__(
         self,
-        is_prefill: bool,
-        do_sampling: bool,
         kv_caches: List[jax.Array],
         input_ids: jax.Array,
         attention_metadata: AttentionMetadata,
@@ -299,7 +297,6 @@ class Qwen2ForCausalLM(nnx.Module):
             logits = jnp.dot(x, self.lm_head.value)
 
         next_tokens = sample(
-            do_sampling,
             self.rng.params(),
             self.mesh,
             logits,

--- a/tpu_commons/models/vllm/jax_attention.py
+++ b/tpu_commons/models/vllm/jax_attention.py
@@ -17,13 +17,11 @@ from tpu_commons.models.vllm.vllm_model_wrapper_context import \
 
 @functools.partial(
     jax.jit,
-    static_argnums=(
-        0, 6, 7, 8, 9,
-        10),  # is_prefill, mesh, scale, head_dim, num_heads, num_kv_heads
-    donate_argnums=(1, ),  # donate kv_cache
+    static_argnums=(5, 6, 7, 8,
+                    9),  # mesh, scale, head_dim, num_heads, num_kv_heads
+    donate_argnums=(0, ),  # donate kv_cache
 )
 def _jax_attn_func(
-    is_prefill: bool,
     kv_cache: jax.Array,
     q: jax.Array,
     k: jax.Array,
@@ -96,7 +94,6 @@ class JaxAttention(torch.nn.Module):
     ) -> torch.Tensor:
         vllm_model_wrapper_context = get_vllm_model_wrapper_context()
         new_kv_cache, outputs = _jax_attn_func(
-            vllm_model_wrapper_context.is_prefill,
             vllm_model_wrapper_context.kv_caches[self.layer_idx], jax_view(q),
             jax_view(k), jax_view(v),
             vllm_model_wrapper_context.attention_metadata, self.mesh,

--- a/tpu_commons/models/vllm/vllm_model_wrapper.py
+++ b/tpu_commons/models/vllm/vllm_model_wrapper.py
@@ -98,13 +98,10 @@ class VllmModelWrapper:
 
         @functools.partial(
             jax.jit,
-            static_argnums=(1, 2),  # is_prefill, do_sampling
-            donate_argnums=(3, ),  # donate kv_cache
+            donate_argnums=(1, ),  # donate kv_cache
         )
         def step_fun(
             params_and_buffers,  # this has been wrapped into a torchax TorchValue
-            is_prefill: bool,
-            do_sampling: bool,
             kv_caches: List[jax.Array],
             input_ids: jax.Array,
             attention_metadata: AttentionMetadata,
@@ -114,7 +111,6 @@ class VllmModelWrapper:
         ) -> Tuple[List[jax.Array], jax.Array, jax.Array]:
 
             with torchax.default_env(), set_vllm_model_wrapper_context(
-                    is_prefill=is_prefill,
                     kv_caches=kv_caches,
                     attention_metadata=attention_metadata,
             ):
@@ -140,7 +136,6 @@ class VllmModelWrapper:
             logits = jax_view(logits)
 
             next_tokens = sample(
-                do_sampling,
                 self.rng,
                 self.mesh,
                 logits,

--- a/tpu_commons/models/vllm/vllm_model_wrapper_context.py
+++ b/tpu_commons/models/vllm/vllm_model_wrapper_context.py
@@ -11,7 +11,6 @@ KVCache = Tuple[jax.Array, jax.Array]
 
 @dataclass
 class VllmModelWrapperContext:
-    is_prefill: bool
     kv_caches: List[KVCache]
     attention_metadata: AttentionMetadata
 
@@ -30,14 +29,12 @@ def get_vllm_model_wrapper_context() -> VllmModelWrapperContext:
 @contextmanager
 def set_vllm_model_wrapper_context(
     *,
-    is_prefill: bool,
     kv_caches: List[KVCache],
     attention_metadata: AttentionMetadata,
 ):
     global _vllm_model_wrapper_context
     prev_context = _vllm_model_wrapper_context
     _vllm_model_wrapper_context = VllmModelWrapperContext(
-        is_prefill=is_prefill,
         kv_caches=kv_caches,
         attention_metadata=attention_metadata,
     )

--- a/tpu_commons/runner/jax/tpu_jax_runner.py
+++ b/tpu_commons/runner/jax/tpu_jax_runner.py
@@ -333,7 +333,8 @@ class TPUModelRunner():
         """
         new_kv_caches = []
         for i, layer_kv_cache_slices in enumerate(kv_cache_slices):
-            updated_cache = kv_caches[i].at[block_numbers].set(layer_kv_cache_slices)
+            updated_cache = kv_caches[i].at[block_numbers].set(
+                layer_kv_cache_slices)
             new_kv_caches.append(updated_cache)
         return new_kv_caches
 
@@ -641,7 +642,7 @@ class TPUModelRunner():
         do_sampling = _do_sampling(self.input_batch.top_k_cpu[req_ids],
                                    self.input_batch.temperature_cpu[req_ids])
         tpu_sampling_metadata = TPUSupportedSamplingMetadata.\
-            from_input_batch(self.mesh, self.input_batch, padded_num_reqs, not do_sampling)
+            from_input_batch(self.mesh, self.input_batch, padded_num_reqs, do_sampling)
 
         (input_ids, positions, slot_mapping_metadata, num_slices, block_tables,
          query_start_loc, seq_lens, num_seqs,
@@ -651,8 +652,6 @@ class TPUModelRunner():
               logits_indices))
 
         return (
-            False,
-            do_sampling,
             self.kv_caches,
             input_ids,
             AttentionMetadata(

--- a/tpu_commons/sample/metadata_jax.py
+++ b/tpu_commons/sample/metadata_jax.py
@@ -1,4 +1,3 @@
-# SPDX-License-Identifier: Apache-2.0
 import functools
 from dataclasses import dataclass
 from typing import Optional
@@ -24,14 +23,14 @@ DEFAULT_SAMPLING_PARAMS = dict(
         "top_k",
         "top_p",
     ],
-    meta_fields=["all_greedy"],
+    meta_fields=["do_sampling"],
 )
 @dataclass
 class TPUSupportedSamplingMetadata:
     temperature: Optional[jnp.ndarray] = None
     top_k: Optional[jnp.ndarray] = None
     top_p: Optional[jnp.ndarray] = None
-    all_greedy: bool = True
+    do_sampling: bool = False
 
     @classmethod
     def from_input_batch(
@@ -39,10 +38,10 @@ class TPUSupportedSamplingMetadata:
         mesh: Mesh,
         input_batch: InputBatch,
         padded_num_reqs: int,
-        all_greedy: bool,
+        do_sampling: bool,
     ) -> "TPUSupportedSamplingMetadata":
-        if all_greedy:
-            return cls(all_greedy=True)
+        if do_sampling is False:
+            return cls(do_sampling=False)
 
         num_reqs = input_batch.num_reqs
 


### PR DESCRIPTION
# Description
1. We send `False` as `is_prefill` in prepare inputs in everywhere. Basically there is no usage for `is_prefill`.
2. We can move `do_sampling` into tpu metadata to simplify the interface.

# Tests

CI passing: https://buildkite.com/tpu-commons/tpu-commons-ci/builds/460

```
--------------------------------------------------
Prompt: 'Hello, my name is'
Generated text: ' Emily and I am a 25-year-old freelance writer and editor. I have'
--------------------------------------------------
Prompt: 'The capital of France is'
Generated text: ' a city of romance, art, fashion, and cuisine. Paris is a must'
--------------------------------------------------
Prompt: 'The colors of the rainbow are'
Generated text: ' often remembered using the acronym ROYGBIV, which stands for Red, Orange'
--------------------------------------------------
Prompt: 'The future of AI is'
Generated text: ' bright, but it also raises concerns about bias, accountability, and the impact on'
--------------------------------------------------
Prompt: 'The president of the United States is'
Generated text: ' the head of state and head of government of the United States. The president serves'
--------------------------------------------------
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [ ] I have performed a self-review of my code.
- [ ] I have necessary comments in my code, particularly in hard-to-understand areas.
- [ ] I have made or will make corresponding changes to any relevant documentation.
