### PR TITLE
Optimize Dockerfile to cache pip stage.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -26,10 +26,13 @@ RUN python3 -m pip install --no-cache-dir git+https://github.com/thuml/depyf.git
 
 # Install tpu_commons
 WORKDIR /workspace/tpu_commons
-COPY . .
+# Install requirements first and cache so we don't need to re-install on code change.
+COPY requirements.txt .
 RUN pip install -r requirements.txt
+COPY requirements_benchmarking.txt .
 # These are needed for the E2E benchmarking tests (i.e. tests/e2e/benchmarking/llama3.1_8b_mmlu.sh)
 RUN pip install -r requirements_benchmarking.txt
+COPY . .
 RUN pip install -e .
 
 CMD ["/bin/bash"]


### PR DESCRIPTION
# Description

With every code change, the docker will expire pip cache. We need to install pip first and then copy source code.
after this PR:
<img width="546" height="106" alt="Screenshot 2025-07-10 at 5 19 29 PM" src="https://github.com/user-attachments/assets/1ede6825-fe6b-4d6e-82fd-d22bf29817c3" />

# Tests

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [ ] I have performed a self-review of my code.
- [ ] I have necessary comments in my code, particularly in hard-to-understand areas.
- [ ] I have made or will make corresponding changes to any relevant documentation.
