### PR TITLE
Add the ability to catch recompilation in JAX path.

### DIFF
--- a/tpu_commons/runner/utils.py
+++ b/tpu_commons/runner/utils.py
@@ -2,15 +2,17 @@
 """
 Implements a few utility functions for the various runners.
 """
+import functools
+import time
 from typing import Optional
 
-import time
-
+from jax._src.interpreters import pxla
 from vllm.logger import init_logger
 
 MIN_NUM_SEQS = 8
 
 logger = init_logger(__name__)
+
 
 def determine_do_sampling(top_k: int, temperature: float) -> bool:
     """
@@ -43,7 +45,9 @@ def get_padded_num_reqs_with_upper_limit(x: int, upper_limit: int) -> int:
     res = MIN_NUM_SEQS if x <= MIN_NUM_SEQS else 1 << (x - 1).bit_length()
     return min(res, upper_limit)
 
+
 class LatencyTracker:
+
     def __init__(self, name="Operation"):
         self.name = name
 
@@ -55,3 +59,67 @@ class LatencyTracker:
         self.end_time = time.perf_counter()
         elapsed_time = self.end_time - self.start_time
         logger.info(f"Latency for '{self.name}': {elapsed_time:.3f} seconds")
+
+
+class ForbidCompile:
+    """
+    A context manager to forbid JAX compilation in a specific block of code.
+
+    It works by temporarily wrapping the internal JAX caching function
+    `_cached_lowering_to_hlo`. If a call within the `with` block results
+    in a cache miss (i.e., triggers a new compilation), it raises a
+    RuntimeError.
+
+    Usage:
+        # This will raise an error because it's the first compilation.
+        with ForbidCompile():
+            jitted_func(x)
+
+        # "Warm up" the cache first.
+        jitted_func(x)
+        # This will now succeed without error.
+        with ForbidCompile():
+            jitted_func(x)
+    """
+
+    def __init__(
+            self,
+            message="JAX compilation occurred but was forbidden in this context."
+    ):
+        self.message = message
+        self._original_func = None
+
+    def __enter__(self):
+        # Store the original function
+        self._original_func = pxla._cached_lowering_to_hlo
+        original_cached_func = self._original_func
+
+        # Create a wrapper
+        @functools.wraps(original_cached_func)
+        def wrapper(*args, **kwargs):
+            # Get cache statistics before the call
+            info_before = original_cached_func.cache_info()
+            misses_before = info_before.misses
+
+            # Execute the original cached function
+            result = original_cached_func(*args, **kwargs)
+
+            # Get cache statistics after the call
+            info_after = original_cached_func.cache_info()
+            misses_after = info_after.misses
+
+            # Check if a cache miss occurred
+            if misses_after > misses_before:
+                raise RuntimeError(self.message)
+
+            return result
+
+        # Monkey-patch the function with our wrapper
+        pxla._cached_lowering_to_hlo = wrapper
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        # Restore the original function
+        if self._original_func:
+            pxla._cached_lowering_to_hlo = self._original_func
+        # Don't suppress any exceptions that occurred inside the 'with' block
+        return False


### PR DESCRIPTION
# Description

1. Guarded with existing `VLLM_XLA_CHECK_RECOMPILATION` so doesn't run by default.
2. Catches recompilation in CI (The flag is enabled by default in docker)
3. That's how I discovered and fixed #178 

When there is a failure:

<img width="1565" height="170" alt="image" src="https://github.com/user-attachments/assets/d5f1de2d-2703-4f8e-8935-4ff336c24be4" />

# Tests

```USE_JAX_V1=1 PYTHONPATH=$PYTHONPATH:/home/pooyam/vllm:/home/pooyam/tpu_commons TPU_BACKEND_TYPE=jax python examples/offline_inference.py     --task=generate     --max_model_len=1024 --model=/dev/shm/Llama-3.1-8B-Instruct --tensor-parallel-size=1```

```
--------------------------------------------------
Prompt: 'Hello, my name is'
Generated text: ' Emily and I am a 25-year-old freelance writer and editor. I have'
--------------------------------------------------
Prompt: 'The capital of France is'
Generated text: ' a city of romance, art, fashion, and cuisine. Paris is a must'
--------------------------------------------------
Prompt: 'The colors of the rainbow are'
Generated text: ' often remembered using the acronym ROYGBIV, which stands for Red, Orange'
--------------------------------------------------
Prompt: 'The future of AI is'
Generated text: ' bright, but it also raises concerns about bias, accountability, and the impact on'
--------------------------------------------------
Prompt: 'The president of the United States is'
Generated text: ' the head of state and head of government of the United States. The president serves'
--------------------------------------------------
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [ ] I have performed a self-review of my code.
- [ ] I have necessary comments in my code, particularly in hard-to-understand areas.
- [ ] I have made or will make corresponding changes to any relevant documentation.
