### PR TITLE
Bringing back support for using random weights when loading a model.

### DIFF
--- a/tpu_commons/models/jax/recipes/llama3.py
+++ b/tpu_commons/models/jax/recipes/llama3.py
@@ -163,18 +163,19 @@ class Llama3_8B(Model):
         return self.__call__(*args, **kwargs)
 
     def load_weights(self, rng: PRNGKey, cache_dir: Optional[str] = None):
-        # TODO: support gcs paths as well.
-        model_name_or_path = self.vllm_config.model_config.model
-        if not model_name_or_path:  # TODO
+        try:
+            use_random_weights = self.vllm_config.additional_config["random_weights"]
             logger.warning(
-                "Model name or path not provided - randomly randomly initializing the weights."
+                "Using randomly initialized weights instead of loading parameter weights."
             )
-        else:
-            weight_loader = Llama3WeightLoader(vllm_config=self.vllm_config,
-                                               model_config=self.cfg.model,
-                                               cache_dir=None,
-                                               sharding_cfg=self.cfg.sharding)
-            weight_loader.load_weights(self)
+            return
+        except KeyError:
+            use_random_weights = False
+        weight_loader = Llama3WeightLoader(vllm_config=self.vllm_config,
+                                            model_config=self.cfg.model,
+                                            cache_dir=None,
+                                            sharding_cfg=self.cfg.sharding)
+        weight_loader.load_weights(self)
 
     def __call__(
         self,


### PR DESCRIPTION
Added back support for random weight initialization. Given some of the config-related logic has changed, now random weights will be initialized if you add a term to the additional-config: --additional-config='{"random_weights": true}'

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have made or will make corresponding changes to any relevant documentation.
