### PR TITLE
create a rope class and deepseek rope inherit from it

### DIFF
--- a/tests/models/jax/common/test_rope.py
+++ b/tests/models/jax/common/test_rope.py
@@ -8,30 +8,36 @@ from tpu_commons.models.jax.common.rope import (DeepseekScalingRotaryEmbedding,
 class RotaryEmbeddingTest(jtu.JaxTestCase):
 
     def test_apply_rope(self):
-        head_dim = 128
+        head_dim = 2
         rope_theta = 10000
-        original_max_position_embeddings = 4096
+        original_max_position_embeddings = 2
         rope = RotaryEmbedding(head_dim, rope_theta,
                                original_max_position_embeddings)
         self.assertTrue(
             rope.sin_cos_cache.shape == (original_max_position_embeddings,
                                          head_dim))
-        num_tokens = 100
-        num_heads = 8
+        expected_sin_cos = jnp.array([[1, 0], [0.5403023, 0.841471]],
+                                     dtype=jnp.float32)
+        self.assertArraysAllClose(rope.sin_cos_cache, expected_sin_cos)
+
+        num_tokens = 2
+        num_heads = 1
         positions = jnp.arange(num_tokens)
         x = jnp.ones((num_tokens, num_heads, head_dim))
         x_rope = rope.apply_rope(positions, x)
+        expected_x_rope = jnp.array([[[1, 1]], [[-0.30116874, 1.3817732]]],
+                                    dtype=jnp.float32)
         self.assertTrue(x_rope.shape == x.shape)
-        self.assertFalse(jnp.array_equal(x_rope, x))
+        self.assertArraysAllClose(x_rope, expected_x_rope)
 
 
 class DeepseekScalingRotaryEmbeddingTest(jtu.JaxTestCase):
 
     def test_apply_rope(self):
-        head_dim = 128
+        head_dim = 2
         rope_theta = 10000
-        original_max_position_embeddings = 4096
-        scaling_factor = 4
+        original_max_position_embeddings = 1
+        scaling_factor = 2
         rope = DeepseekScalingRotaryEmbedding(
             head_dim, rope_theta, original_max_position_embeddings,
             scaling_factor)
@@ -39,10 +45,16 @@ class DeepseekScalingRotaryEmbeddingTest(jtu.JaxTestCase):
             rope.sin_cos_cache.shape == (scaling_factor *
                                          original_max_position_embeddings,
                                          head_dim))
-        num_tokens = 100
-        num_heads = 8
+        expected_sin_cos = jnp.array([[1.0693147, 0], [0.5777532, 0.8997973]],
+                                     dtype=jnp.float32)
+        self.assertArraysAllClose(rope.sin_cos_cache, expected_sin_cos)
+        num_tokens = 2
+        num_heads = 1
         positions = jnp.arange(num_tokens)
         x = jnp.ones((num_tokens, num_heads, head_dim))
         x_rope = rope.apply_rope(positions, x)
+        expected_x_rope = jnp.array(
+            [[[1.0693147, 1.0693147]], [[-0.32204413, 1.4775505]]],
+            dtype=jnp.float32)
         self.assertTrue(x_rope.shape == x.shape)
-        self.assertFalse(jnp.array_equal(x_rope, x))
+        self.assertArraysAllClose(x_rope, expected_x_rope)


### PR DESCRIPTION
# Description

Implement original rotary positional embedding and specific rope for deepseek. 


# Tests

Unit tests verify the cached sin/cos matrix are as expected shape, the output from rope are as expected shape and different from the original input. 

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have made or will make corresponding changes to any relevant documentation.
- [X] I have reviewed the redesigned uLLM playbook.
