### PR TITLE
[torchax] Fix import failure due to upstream change

### DIFF
--- a/tpu_commons/runner/tpu_torchax_runner.py
+++ b/tpu_commons/runner/tpu_torchax_runner.py
@@ -77,10 +77,10 @@ from vllm.v1.outputs import (EMPTY_MODEL_RUNNER_OUTPUT, LogprobsTensors,
                              ModelRunnerOutput)
 from vllm.v1.sample.tpu.metadata import TPUSupportedSamplingMetadata
 from vllm.v1.sample.tpu.sampler import Sampler as TPUSampler
-from vllm.v1.utils import bind_kv_cache
 from vllm.v1.worker.lora_model_runner_mixin import LoRAModelRunnerMixin
 from vllm.v1.worker.tpu_input_batch import CachedRequestState, InputBatch
-from vllm.v1.worker.utils import (initialize_kv_cache_for_kv_sharing,
+from vllm.v1.worker.utils import (bind_kv_cache,
+                                  initialize_kv_cache_for_kv_sharing,
                                   sanity_check_mm_encoder_outputs)
 
 if TYPE_CHECKING:


### PR DESCRIPTION
`bind_kv_cache` path is changed in https://github.com/vllm-project/vllm/pull/20900. Accommodate the change 