### PR TITLE
Support scenarios where num_(kv)_heads < TP size

### DIFF
--- a/tpu_commons/models/jax/llama.py
+++ b/tpu_commons/models/jax/llama.py
@@ -7,6 +7,7 @@ from jax.sharding import Mesh
 from transformers import LlamaConfig, modeling_flax_utils
 from vllm.config import VllmConfig
 
+from tpu_commons import utils_jax as utils
 from tpu_commons.logger import init_logger
 from tpu_commons.models.jax.attention_interface import attention
 from tpu_commons.models.jax.attention_metadata import AttentionMetadata
@@ -66,6 +67,12 @@ class LlamaAttention(nnx.Module):
         self.rope_theta = config.rope_theta
         self.rope_scaling = getattr(config, "rope_scaling", None)
         self.head_dim = config.head_dim
+
+        sharding_size = mesh.shape["model"]
+        self.num_heads = utils.get_padded_num_heads(self.num_heads,
+                                                    sharding_size)
+        self.num_kv_heads = utils.get_padded_num_heads(self.num_kv_heads,
+                                                       sharding_size)
 
         self.mesh = mesh
 

--- a/tpu_commons/models/jax/qwen2.py
+++ b/tpu_commons/models/jax/qwen2.py
@@ -69,7 +69,11 @@ class Qwen2Attention(nnx.Module):
 
         self.head_dim_original = config.hidden_size // config.num_attention_heads
 
-        # Pad head_dim for kernel performance.
+        sharding_size = mesh.shape["model"]
+        self.num_heads = utils.get_padded_num_heads(self.num_heads,
+                                                    sharding_size)
+        self.num_kv_heads = utils.get_padded_num_heads(self.num_kv_heads,
+                                                       sharding_size)
         self.head_dim = utils.get_padded_head_dim(self.head_dim_original)
 
         self.mesh = mesh

--- a/tpu_commons/runner/jax/tpu_jax_runner.py
+++ b/tpu_commons/runner/jax/tpu_jax_runner.py
@@ -200,14 +200,18 @@ class TPUModelRunner():
         model_config = self.vllm_config.model_config
         parallel_config = self.vllm_config.parallel_config
 
-        # Pad head_dim for kernel performance.
+        # Pad num_kv_heads to multiple of TP size.
+        num_kv_heads = utils.get_padded_num_heads(
+            model_config.get_total_num_kv_heads(), self.mesh.shape["model"])
+
+        # Pad head_dim to multiple of 128.
         head_size = model_config.get_head_size()
         head_size = utils.get_padded_head_dim(head_size)
 
         for i in range(model_config.get_num_layers(parallel_config)):
             kv_cache_spec[f"layers.{i}"] = FullAttentionSpec(
                 block_size=block_size,
-                num_kv_heads=model_config.get_total_num_kv_heads(),
+                num_kv_heads=num_kv_heads,
                 head_size=head_size,
                 dtype=torch.bfloat16,
                 use_mla=False,

--- a/tpu_commons/utils_jax.py
+++ b/tpu_commons/utils_jax.py
@@ -52,3 +52,12 @@ def get_padded_head_dim(head_dim: int) -> int:
     """Pads head_dim up to the nearest multiple of 128 for kernel performance."""
     # Details can be seen at: tpu_commons/kernels/ragged_kv_cache_update.py::_kv_cache_update()
     return (head_dim + 127) // 128 * 128
+
+
+def get_padded_num_heads(num_heads: int, sharding_size: int) -> int:
+    if num_heads >= sharding_size:
+        assert num_heads % sharding_size == 0
+    else:
+        assert sharding_size % num_heads == 0
+        num_heads = sharding_size
+    return num_heads


### PR DESCRIPTION
# Description

Add the support to pad the attention weights when the num_heads or num_kv_heads are smaller than TP size.

For example, the qwen-2.5 1.5B `num_key_value_heads` is 2, it couldn't be run on 4 chips without the padding.

# Tests

Local

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have made or will make corresponding changes to any relevant documentation.
