### PR TITLE
Rename references to mmlu to mlperf. 

### DIFF
--- a/.buildkite/pipeline_jax.yml
+++ b/.buildkite/pipeline_jax.yml
@@ -17,7 +17,7 @@ steps:
            /workspace/tpu_commons/tests/ragged_paged_attention_test.py \
            /workspace/tpu_commons/tests/ragged_kv_cache_update_test.py
 
-   - label: "E2E MMLU tests for JAX models"
+   - label: "E2E MLPerf tests for JAX models"
      key: test_1
      soft_fail: true
      env:
@@ -25,9 +25,9 @@ steps:
      agents:
        queue: tpu_v6e_queue
      commands:
-       - .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_commons/tests/e2e/benchmarking/mmlu.sh
+       - .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_commons/tests/e2e/benchmarking/mlperf.sh
 
-   - label: "E2E MMLU tests for JAX + vLLM models"
+   - label: "E2E MLPerf tests for JAX + vLLM models"
      key: test_2
      soft_fail: true
      env:
@@ -36,9 +36,9 @@ steps:
      agents:
        queue: tpu_v6e_queue
      commands:
-       - .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_commons/tests/e2e/benchmarking/mmlu.sh
+       - .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_commons/tests/e2e/benchmarking/mlperf.sh
 
-   - label: "E2E MMLU tests for JAX new model implementation"
+   - label: "E2E MLPerf tests for JAX new model implementation"
      key: test_3
      soft_fail: true
      env:
@@ -47,7 +47,7 @@ steps:
      agents:
        queue: tpu_v6e_queue
      commands:
-       - .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_commons/tests/e2e/benchmarking/mmlu.sh
+       - .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_commons/tests/e2e/benchmarking/mlperf.sh
 
   # A placeholder for adding more JAX workload unit tests
    - label: "JAX unit tests"

--- a/README.md
+++ b/README.md
@@ -217,10 +217,10 @@ In order to run an [E2E benchmark test](https://github.com/vllm-project/tpu_comm
 following command locally:
 
 ```
-BUILDKITE_COMMIT=3843efc .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_commons/tests/e2e/benchmarking/llama3.1_8b_mmlu.sh
+BUILDKITE_COMMIT=3843efc .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_commons/tests/e2e/benchmarking/mlperf.sh
 ```
 
-While this will run the code in a Docker image, you can also run the bare `tests/e2e/benchmarking/llama3.1_8b_mmlu.sh` script itself,
+While this will run the code in a Docker image, you can also run the bare `tests/e2e/benchmarking/mlperf.sh` script itself,
 being sure to pass the proper args for your machine.
 
 You might need to run the benchmark client *twice* to make sure all compilations are cached server-side.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -30,7 +30,7 @@ WORKDIR /workspace/tpu_commons
 COPY requirements.txt .
 RUN pip install -r requirements.txt
 COPY requirements_benchmarking.txt .
-# These are needed for the E2E benchmarking tests (i.e. tests/e2e/benchmarking/llama3.1_8b_mmlu.sh)
+# These are needed for the E2E benchmarking tests (i.e. tests/e2e/benchmarking/mlperf.sh)
 RUN pip install -r requirements_benchmarking.txt
 COPY . .
 RUN pip install -e .

--- a/tests/e2e/benchmarking/mlperf.sh
+++ b/tests/e2e/benchmarking/mlperf.sh
@@ -8,7 +8,9 @@
 
 # You can also manually invoke this script to run an E2E benchmark on any given model and dataset, making sure
 # you specify the --dataset-name, --dataset-path, and --root-dir flags
-# Example usage: bash tests/e2e/benchmarking/mmlu.sh -r /mnt/disks/jacobplatin -d mmlu -p /mnt/disks/jacobplatin/mmlu/data/test
+
+# Example default usage: bash tests/e2e/benchmarking/mlperf.sh -r /local/root_dir
+# Example local docker + JAX TPU usage: TPU_BACKEND_TYPE=jax NEW_MODEL_DESIGN=True BUILDKITE_COMMIT=3c545c0c3 .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_commons/tests/e2e/benchmarking/mlperf.sh
 
 # Logs the vLLM server output to a file
 LOG_FILE="server.log"


### PR DESCRIPTION
# Description

Script and documentation now correctly refers to MMLU instead of MLPerf. Documentation was also updated to be more correct. 

# Tests

Local runs

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have made or will make corresponding changes to any relevant documentation.
