### PR TITLE
Fix flacky test by setting initial state of generate_engine to idle=T…

### DIFF
--- a/tests/core/test_orchestrator.py
+++ b/tests/core/test_orchestrator.py
@@ -81,7 +81,7 @@ class OrchestratorTest(unittest.TestCase):
             {mock_req.request_id: prefill_kv_cache}, prefill_runner_output)
 
         mock_prefill_engine.is_prefill_idle.side_effect = [False, False, True, True]
-        mock_generate_engine.is_generate_idle.side_effect = [False, False, False, False, True, True]
+        mock_generate_engine.is_generate_idle.side_effect = [True, False, False, False, True, True]
 
         mock_prefill_engine.model_runner.transfer_kv_cache.return_value = MagicMock()
 


### PR DESCRIPTION
# Description

Fix flacky test by setting initial state of generate_engine to idle=True.

tests/core/test_orchestrator.py occasionally filed.

Repro

```
pip install pytest-repeat

pytest --count=1000 --maxfail=1 tests/core/test_orchestrator.py

```

Very high chances, the test will fail by running this.

# Tests

After fixing, running command below always pass

```
pytest --count=1000 --maxfail=1 tests/core/test_orchestrator.py
``` 

this always pass

```
python -m unittest tests/core/test_orchestrator.py
```
