### PR TITLE
Skipping weight initialization when loading weights.

### DIFF
--- a/tpu_commons/models/jax/common/base.py
+++ b/tpu_commons/models/jax/common/base.py
@@ -140,6 +140,7 @@ class ParamFactory:
     """
     kernel_initializer: Initializer
     scale_initializer: Initializer
+    random_init: bool
 
     def _create_param(self,
                       initializer: Initializer,
@@ -152,8 +153,12 @@ class ParamFactory:
                                       static_argnames=('shape', 'dtype'),
                                       out_shardings=sharding)
         key = rngs.params()
-        param_data = sharded_initializer(key, shape, dtype)
-        return nnx.Param(param_data, sharding=sharding)
+        if self.random_init:
+            param_data = sharded_initializer(key, shape, dtype)
+            return nnx.Param(param_data, sharding=sharding)
+        else:
+            param_struct = jax.ShapeDtypeStruct(shape=shape, dtype=dtype)
+            return nnx.Param(param_struct, sharding=sharding)
 
     def create_kernel_param(self, *args, **kwargs) -> nnx.Param:
         """Creates a kernel/weight parameter using the kernel_initializer."""

--- a/tpu_commons/models/jax/recipes/llama3.py
+++ b/tpu_commons/models/jax/recipes/llama3.py
@@ -108,7 +108,8 @@ class Llama3_8B(Model):
                                  mesh=self.mesh,
                                  default_rules_cls=Llama8BShardingRulesConfig,
                                  vllm_config=self.vllm_config)
-
+        self.use_random_init = self.vllm_config.additional_config.get(
+            "random_weights", False)
         self.cfg = Llama8BConfig(
             model=Llama8BModelConfig(vllm_config=self.vllm_config),
             sharding=self.sharding.sharding_cfg,
@@ -121,7 +122,8 @@ class Llama3_8B(Model):
     def _init_layers(self):
         param_factory = ParamFactory(
             kernel_initializer=nnx.initializers.xavier_normal(),
-            scale_initializer=nnx.initializers.ones)
+            scale_initializer=nnx.initializers.ones,
+            random_init=self.use_random_init)
         self.embedder = Embedder(cfg=self.cfg.model.emb,
                                  mesh=self.mesh,
                                  param_factory=param_factory,


### PR DESCRIPTION
# Description
Avoiding random weight initialization when loading saved weights to prevent OOM issues.

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have made or will make corresponding changes to any relevant documentation.

Build kite successfully passed: https://buildkite.com/tpu-commons/tpu-commons-ci/builds/676