### PR TITLE
Feed the model states during execution instead of fix them when loading models.

### DIFF
--- a/tpu_commons/models/jax/model_loader.py
+++ b/tpu_commons/models/jax/model_loader.py
@@ -138,9 +138,9 @@ def get_flax_model(
         model = nnx.merge(graphdef, state)
         return model.compute_logits(*args)
 
-    model_fn = functools.partial(run_model, graphdef, state)
-    compute_logits_fn = functools.partial(run_compute_logits, graphdef, state)
-    return model_fn, compute_logits_fn
+    model_fn = functools.partial(run_model, graphdef)
+    compute_logits_fn = functools.partial(run_compute_logits, graphdef)
+    return model_fn, compute_logits_fn, state
 
 
 def get_vllm_model(
@@ -158,10 +158,9 @@ def get_vllm_model(
     params = model.load_weights()
 
     jit_model = model.jit_step_func()
-    model_fn = functools.partial(jit_model, params)
     compute_logits_fn = functools.partial(model.jit_compute_logits_func(),
                                           params)
-    return model_fn, compute_logits_fn
+    return jit_model, compute_logits_fn, params
 
 
 def get_model(


### PR DESCRIPTION
The current design fixed the model weights when loading the model. The PR simply feed the state during execution, which unblocks the RL use cases that we need to update the model weights dynamically on the fly. 

# Tests

Manually run offline_inference.py

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have made or will make corresponding changes to any relevant documentation.
