### PR TITLE
Adds the option to set max model length to avoid OOM.

### DIFF
--- a/examples/offline_inference.py
+++ b/examples/offline_inference.py
@@ -15,13 +15,14 @@ def create_parser():
     # Add engine args
     EngineArgs.add_cli_args(parser)
     parser.set_defaults(model="meta-llama/Llama-3.2-1B-Instruct")
+    parser.set_defaults(max_model_len=1024)
+
     # Add sampling params
     sampling_group = parser.add_argument_group("Sampling parameters")
     sampling_group.add_argument("--max-tokens", type=int)
     sampling_group.add_argument("--temperature", type=float)
     sampling_group.add_argument("--top-p", type=float)
     sampling_group.add_argument("--top-k", type=int)
-
     return parser
 
 


### PR DESCRIPTION
I hit the following error on v5e-8 when using the default max model length and run the following command:

 export TPU_BACKEND_TYPE=jax; python3 tpu_commons/examples/offline_inference.py --max_tokens=128

  File "/workspace/vllm/vllm/v1/core/kv_cache_utils.py", line 970, in get_kv_cache_config
    check_enough_kv_cache_memory(vllm_config, kv_cache_spec, available_memory)
  File "/workspace/vllm/vllm/v1/core/kv_cache_utils.py", line 588, in check_enough_kv_cache_memory
    raise ValueError(
ValueError: To serve at least one request with the models's max seq len (131072), (16.00 GiB KV cache is needed, which is larger than the available KV cache memory (0.71 GiB). Based on the available memory, the estimated maximum model length is 5632. Try increasing `gpu_memory_utilization` or decreasing `max_model_len` when initializing the engine.

That's because the test only sets max-tokens, but that's for decoding max generation length, doesn't control the actual cache allocated at the beginning. This PR adds the option to control it from cli and defaults to a much smaller value (1024)

# Tests

export TPU_BACKEND_TYPE=jax; python3 tpu_commons/examples/offline_inference.py --max-tokens=128

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have made or will make corresponding changes to any relevant documentation.
