### PR TITLE
Revert "Fix the tpu jax backend run issue. (#222)"

### DIFF
--- a/tpu_commons/runner/tpu_torch_xla_runner.py
+++ b/tpu_commons/runner/tpu_torch_xla_runner.py
@@ -33,7 +33,7 @@ from vllm.v1.kv_cache_interface import (AttentionSpec, FullAttentionSpec,
                                         SlidingWindowSpec)
 from vllm.v1.outputs import (EMPTY_MODEL_RUNNER_OUTPUT, LogprobsTensors,
                              ModelRunnerOutput)
-from vllm.v1.worker.utils import bind_kv_cache
+from vllm.v1.utils import bind_kv_cache
 from vllm.v1.worker.gpu_input_batch import CachedRequestState, InputBatch
 from vllm.v1.worker.lora_model_runner_mixin import LoRAModelRunnerMixin
 from vllm.v1.worker.utils import sanity_check_mm_encoder_outputs

--- a/tpu_commons/worker/tpu_torch_xla_worker.py
+++ b/tpu_commons/worker/tpu_torch_xla_worker.py
@@ -21,8 +21,7 @@ from vllm.v1.core.sched.output import SchedulerOutput
 from vllm.v1.kv_cache_interface import (AttentionSpec, KVCacheConfig,
                                         KVCacheSpec)
 from vllm.v1.outputs import ModelRunnerOutput
-from vllm.v1.worker.utils import bind_kv_cache
-from vllm.v1.utils import report_usage_stats
+from vllm.v1.utils import bind_kv_cache, report_usage_stats
 
 from tpu_commons.logger import init_logger
 from tpu_commons.runner.tpu_torch_xla_runner import TPUModelRunner


### PR DESCRIPTION
This reverts commit 9a4cbc5f22f1c525230b99e4cf982661541cf1d9.

The previous PR#222 due to the fact I synced the vllm to head. According to the instruction, I should anchor to a previous commit: https://github.com/vllm-project/tpu_commons?tab=readme-ov-file#install-vllm-tpu

# Tests

export TPU_BACKEND_TYPE=jax; python3 tpu_commons/examples/offline_inference.py --max-tokens=128 --model=meta-llama/Meta-Llama-3-8B-Instruct is passing now.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have made or will make corresponding changes to any relevant documentation.
