### PR TITLE
Add test for loading vllm model in jax model loader

### DIFF
--- a/tpu_commons/models/vllm/jax_qkv_parallel_linear.py
+++ b/tpu_commons/models/vllm/jax_qkv_parallel_linear.py
@@ -52,10 +52,12 @@ class JaxQKVParallelLinear(torch.nn.Module):
         # The weight of qkv linear is a concatenation of q, k, and v weights
         # along the output dimension.
         qkv_weight = torch_view(t2j(qkv_linear.weight.data))
-        q_weight = Parameter(qkv_weight[:q_proj_size], requires_grad=False)
-        k_weight = Parameter(qkv_weight[q_proj_size:q_proj_size + k_proj_size],
+        q_weight = Parameter(qkv_weight[:q_proj_size].detach(),
                              requires_grad=False)
-        v_weight = Parameter(qkv_weight[q_proj_size + k_proj_size:],
+        k_weight = Parameter(qkv_weight[q_proj_size:q_proj_size +
+                                        k_proj_size].detach(),
+                             requires_grad=False)
+        v_weight = Parameter(qkv_weight[q_proj_size + k_proj_size:].detach(),
                              requires_grad=False)
         self.register_parameter("q_weight", q_weight)
         self.register_parameter("k_weight", k_weight)
@@ -63,10 +65,12 @@ class JaxQKVParallelLinear(torch.nn.Module):
 
         if qkv_linear.bias is not None:
             bias = torch_view(t2j(qkv_linear.bias))
-            q_bias = Parameter(bias[:q_proj_size], requires_grad=False)
-            k_bias = Parameter(bias[q_proj_size:q_proj_size + k_proj_size],
+            q_bias = Parameter(bias[:q_proj_size].detach(),
                                requires_grad=False)
-            v_bias = Parameter(bias[q_proj_size + k_proj_size:],
+            k_bias = Parameter(bias[q_proj_size:q_proj_size +
+                                    k_proj_size].detach(),
+                               requires_grad=False)
+            v_bias = Parameter(bias[q_proj_size + k_proj_size:].detach(),
                                requires_grad=False)
             self.register_parameter("q_bias", q_bias)
             self.register_parameter("k_bias", k_bias)


### PR DESCRIPTION
# Description

Add test for loading vllm model in jax model loader

When adding the test, torch complains about 
```
Parameter(qkv_weight[:q_proj_size], requires_grad=False)
```
It complains `qkv_weight[:q_proj_size]` is a `View` Object but it expects `Tensor`. Error message suggests to use `detach()` to workaround this.

# Tests

`TPU_BACKEND_TYPE=jax  python3 -m pytest -s -v tests/models/jax/test_model_loader.py`

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have made or will make corresponding changes to any relevant documentation.
