### PR TITLE
Make jax the default backend

### DIFF
--- a/tpu_commons/platforms/__init__.py
+++ b/tpu_commons/platforms/__init__.py
@@ -5,20 +5,20 @@ import os
 __all__ = ["get_tpu_platform_cls"]
 
 
-def get_tpu_platform_cls(backend_type="pytorch_xla"):
+def get_tpu_platform_cls(backend_type="jax"):
     """Get the appropriate TPU worker implementation."""
-    if backend_type == "pytorch_xla" or backend_type == "torchax":
-        from tpu_commons.platforms.tpu_torch_xla import TpuPlatform
-        return TpuPlatform
-    elif backend_type == "jax":
+    if backend_type == "jax":
         from tpu_commons.platforms.tpu_jax import TpuPlatform
+        return TpuPlatform
+    elif backend_type == "torchax":
+        from tpu_commons.platforms.tpu_torch_xla import TpuPlatform
         return TpuPlatform
     else:
         raise ValueError(f"Unknown TPU backend type: {backend_type}")
 
 
 # For convenience, also export the default worker
-TPU_BACKEND_TYPE = os.environ.get("TPU_BACKEND_TYPE", "pytorch_xla").lower()
+TPU_BACKEND_TYPE = os.environ.get("TPU_BACKEND_TYPE", "jax").lower()
 try:
     TpuPlatform = get_tpu_platform_cls(TPU_BACKEND_TYPE)
     __all__.append("TpuPlatform")

--- a/tpu_commons/worker/__init__.py
+++ b/tpu_commons/worker/__init__.py
@@ -10,23 +10,20 @@ def get_tpu_worker_cls(worker_type=None):
 
     # Use environment variable if no explicit type is provided
     if worker_type is None:
-        worker_type = os.environ.get("TPU_BACKEND_TYPE", "pytorch_xla").lower()
+        worker_type = os.environ.get("TPU_BACKEND_TYPE", "jax").lower()
 
-    if worker_type == "pytorch_xla":
-        from tpu_commons.worker.tpu_torch_xla_worker import TPUWorker
+    if worker_type == "jax":
+        from tpu_commons.worker.tpu_worker_jax import TPUWorker
         return TPUWorker
     elif worker_type == "torchax":
         from tpu_commons.worker.tpu_worker_torchax import TPUWorker
-        return TPUWorker
-    elif worker_type == "jax":
-        from tpu_commons.worker.tpu_worker_jax import TPUWorker
         return TPUWorker
     else:
         raise ValueError(f"Unknown TPU worker type: {worker_type}")
 
 
 # For convenience, also export the default worker
-TPU_BACKEND_TYPE = os.environ.get("TPU_BACKEND_TYPE", "pytorch_xla").lower()
+TPU_BACKEND_TYPE = os.environ.get("TPU_BACKEND_TYPE", "jax").lower()
 try:
     TPUWorker = get_tpu_worker_cls(TPU_BACKEND_TYPE)
     __all__.append("TPUWorker")


### PR DESCRIPTION
# Description

Make jax the default backend in tpu_commons

# Tests

python examples/offline_inference/tpu.py will use jax backend by default

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have made or will make corresponding changes to any relevant documentation.
