### PR TITLE
Fix the accurate issue in DI.

### DIFF
--- a/tests/runner/jax/test_tpu_jax_runner.py
+++ b/tests/runner/jax/test_tpu_jax_runner.py
@@ -233,9 +233,12 @@ class TestTPUJaxRunner(unittest.TestCase):
         decode_request = MagicMock(spec=Request)
         decode_request.request_id = "test_req_1"
         decode_request.num_tokens = prompt_len + 1  # Total tokens
+        decode_request.num_computed_tokens = prompt_len
         decode_request.prompt_token_ids = list(range(prompt_len))
+        decode_request.all_token_ids = [123, 232, 908]
         decode_request.output_token_ids = [100]
         decode_request.sampling_params = mock_sampling_params
+
         decode_request.lora_request = None
         decode_request.mm_inputs, decode_request.mm_positions = [], []
         decode_request.pooling_params, decode_request.generator = None, None
@@ -264,7 +267,10 @@ class TestTPUJaxRunner(unittest.TestCase):
         self.assertIn("test_req_1", self.runner.input_batch.req_id_to_index)
         self.assertEqual(
             self.runner.requests["test_req_1"].num_computed_tokens,
-            prompt_len + 1)
+            prompt_len)
+        self.assertEqual(
+            self.runner.requests["test_req_1"].output_token_ids,
+            [908])
 
         # Verify the content of the inserted KV cache.
         target_block_id = decode_block_ids[0][0]

--- a/tpu_commons/runner/jax/tpu_jax_runner.py
+++ b/tpu_commons/runner/jax/tpu_jax_runner.py
@@ -557,10 +557,10 @@ class TPUModelRunner():
         req_state = CachedRequestState(
             req_id=request.request_id,
             prompt_token_ids=request.prompt_token_ids,
-            output_token_ids=[],
+            output_token_ids=[request.all_token_ids[-1]],
             sampling_params=request.sampling_params,
             block_ids=tuple(block_ids),
-            num_computed_tokens=request.num_tokens,
+            num_computed_tokens=request.num_computed_tokens,
             lora_request=request.lora_request,
             mm_inputs=getattr(request, "mm_inputs", []),
             mm_hashes=[],
@@ -586,7 +586,8 @@ class TPUModelRunner():
         self._update_states(scheduler_output)
         if not scheduler_output.total_num_scheduled_tokens:
             # Return empty ModelRunnerOutput if there's no work to do.
-            logger.warning(f"Nothing scheduled: {scheduler_output}!")
+            # TODO(fhzhang): We rely on empty cycles to remove requests in input batch. Fix it to reduce overhead.
+            logger.debug(f"Nothing scheduled: {scheduler_output}!")
             if len(scheduler_output.finished_req_ids) == 0:
                 raise Exception(
                     "Should not schedule a request that does nothing!")

--- a/tpu_commons/runner/utils.py
+++ b/tpu_commons/runner/utils.py
@@ -119,7 +119,7 @@ class LatencyTracker:
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.end_time = time.perf_counter()
         elapsed_time = self.end_time - self.start_time
-        logger.info(f"Latency for '{self.name}': {elapsed_time:.3f} seconds")
+        logger.debug(f"Latency for '{self.name}': {elapsed_time:.3f} seconds")
 
 
 class ForbidCompile:


### PR DESCRIPTION
# Description

When we insert requests into the runner, the cached state didn't contain the output token from prefill, the number of computed tokens was off by one. This PR fixes the issue

# Tests

Manual test.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have made or will make corresponding changes to any relevant documentation.
