### PR TITLE
Adds a in-process disaggregated inference engine core proc.

### DIFF
--- a/examples/offline_inference.py
+++ b/examples/offline_inference.py
@@ -113,11 +113,7 @@ if __name__ == "__main__":
         main(args)
     else:
         from unittest.mock import patch
+        from tpu_commons.core.core_tpu import DisaggEngineCoreProc
 
-        from tpu_commons.core.core_tpu import EngineCore as TPUEngineCore
-        from tpu_commons.core.core_tpu import \
-            EngineCoreProc as TPUEngineCoreProc
-        with patch('vllm.v1.engine.core.EngineCore', TPUEngineCore):
-            with patch('vllm.v1.engine.core.EngineCoreProc',
-                       TPUEngineCoreProc):
-                main(args)
+        with patch("vllm.v1.engine.core.EngineCoreProc", DisaggEngineCoreProc):
+            main(args)

--- a/tests/core/test_core_tpu.py
+++ b/tests/core/test_core_tpu.py
@@ -17,19 +17,22 @@ from unittest.mock import MagicMock, call, patch
 from vllm.config import CacheConfig, ModelConfig, SchedulerConfig, VllmConfig
 from vllm.lora.request import LoRARequest
 from vllm.sampling_params import SamplingParams
+from vllm.v1.core.sched.output import SchedulerOutput
 from vllm.v1.engine import (
     EngineCoreOutput,
     EngineCoreOutputs,
     EngineCoreRequest,
     EngineCoreRequestType,
+    UtilityOutput,
 )
+from vllm.v1.engine.core import ModelRunnerOutput
 from vllm.v1.kv_cache_interface import FullAttentionSpec
 from vllm.v1.request import Request
 from vllm.v1.serial_utils import MsgpackDecoder, MsgpackEncoder
 from vllm.v1.utils import EngineHandshakeMetadata, EngineZmqAddresses
 
 # The class we are testing
-from tpu_commons.core.core_tpu import EngineCore, EngineCoreProc
+from tpu_commons.core.core_tpu import DisaggEngineCoreProc, EngineCore, EngineCoreProc
 
 
 class EngineCoreTest(unittest.TestCase):
@@ -527,6 +530,360 @@ class EngineCoreProcTest(unittest.TestCase):
         # The mock is_sleeping returns False
         self.assertFalse(utility_output.result)
         self.assertIsNone(utility_output.failure_message)
+
+
+class TestDisaggEngineCoreProc(unittest.TestCase):
+
+    def setUp(self):
+        # Patch disagg_utils to control slice configuration.
+        self.mock_disagg_utils_patcher = patch(
+            'tpu_commons.core.core_tpu.disagg_utils')
+        self.mock_disagg_utils = self.mock_disagg_utils_patcher.start()
+        self.mock_disagg_utils.get_prefill_slices.return_value = (
+            4, )  # One prefill engine
+        self.mock_disagg_utils.get_decode_slices.return_value = (
+            2, )  # One decode engine
+        self.addCleanup(self.mock_disagg_utils_patcher.stop)
+
+        # Patch vLLMEngineCore to avoid its complex initialization.
+        self.mock_engine_core_patcher = patch(
+            'tpu_commons.core.core_tpu.vLLMEngineCore')
+        self.mock_vLLMEngineCore = self.mock_engine_core_patcher.start()
+        # Make the mock constructor return another mock.
+        self.mock_prefill_engine_instance = MagicMock(
+            name="PrefillEngineInstance")
+        self.mock_decode_engine_instance = MagicMock(
+            name="DecodeEngineInstance")
+        self.mock_vLLMEngineCore.side_effect = [
+            self.mock_prefill_engine_instance, self.mock_decode_engine_instance
+        ]
+        self.addCleanup(self.mock_engine_core_patcher.stop)
+
+        # Patch the ZMQ handshake to isolate the test.
+        self.mock_handshake_patcher = patch(
+            'tpu_commons.core.core_tpu.DisaggEngineCoreProc._perform_handshake'
+        )
+        self.mock_handshake = self.mock_handshake_patcher.start()
+        # Mock the context manager to avoid entering it.
+        self.mock_handshake.return_value.__enter__.return_value = MagicMock(
+            outputs=["output_addr"], coordinator_output=None)
+        self.addCleanup(self.mock_handshake_patcher.stop)
+
+        # Patch threads to avoid them running in the background.
+        self.jet_thread_patcher = patch(
+            "tpu_commons.core.core_tpu.orchestrator.JetThread", MagicMock)
+        self.mock_jet_thread = self.jet_thread_patcher.start()
+        self.addCleanup(self.jet_thread_patcher.stop)
+
+        self.thread_patcher = patch("threading.Thread", MagicMock)
+        self.mock_thread = self.thread_patcher.start()
+        self.addCleanup(self.thread_patcher.stop)
+
+        # Mock jax.devices
+        self.mock_jax_devices_patcher = patch('jax.devices',
+                                              return_value=[MagicMock()] * 8)
+        self.mock_jax_devices = self.mock_jax_devices_patcher.start()
+        self.addCleanup(self.mock_jax_devices_patcher.stop)
+
+        # VLLM Config
+        self.mock_vllm_config = MagicMock(spec=VllmConfig)
+        self.mock_vllm_config.scheduler_config = MagicMock(spec=SchedulerConfig)
+
+        self.mock_vllm_config.scheduler_config.max_num_seqs = 16
+        self.mock_vllm_config.device_config = MagicMock()
+
+    def test_initialization(self):
+        """Tests that DisaggEngineCoreProc initializes correctly."""
+        proc = DisaggEngineCoreProc(
+            vllm_config=self.mock_vllm_config,
+            on_head_node=True,
+            handshake_address="dummy_addr",
+            executor_class=MagicMock(),
+            log_stats=False,
+        )
+
+        # Assert correct number of engines were created
+        self.mock_disagg_utils.get_prefill_slices.assert_called_once()
+        self.mock_disagg_utils.get_decode_slices.assert_called_once()
+
+        # 1 prefill + 1 decode
+        self.assertEqual(self.mock_vLLMEngineCore.call_count, 2)
+        self.assertEqual(len(proc._prefill_engines), 1)
+        self.assertEqual(len(proc._decode_engines), 1)
+
+        # Assert that the correct executor is passed.
+        from tpu_commons.core.disagg_executor import DisaggExecutor
+        executor_class_arg = self.mock_vLLMEngineCore.call_args_list[0][0][1]
+        self.assertIs(executor_class_arg, DisaggExecutor)
+
+    def test_add_request(self):
+        """Tests adding a request to the engine."""
+        proc = DisaggEngineCoreProc(
+            vllm_config=self.mock_vllm_config,
+            on_head_node=True,
+            handshake_address="dummy_addr",
+            executor_class=MagicMock(),
+            log_stats=False,
+        )
+
+        mock_engine_request = MagicMock(spec=EngineCoreRequest)
+        mock_engine_request.request_id = "test-req-1"
+        mock_engine_request.mm_hashes = None  # Simplify by not using multimodal
+        mock_engine_request.mm_inputs = []
+        mock_engine_request.use_structured_output = False
+        mock_engine_request.kv_transfer_params = None
+
+        # Mock the prefill engine's scheduler
+        mock_prefill_scheduler = self.mock_prefill_engine_instance.scheduler
+
+        # Call the method under test
+        proc.add_request(mock_engine_request)
+
+        # Assert that the request was added to the first prefill engine's scheduler
+        mock_prefill_scheduler.add_request.assert_called_once()
+        added_vllm_request = mock_prefill_scheduler.add_request.call_args[0][0]
+        self.assertIsInstance(added_vllm_request, Request)
+        self.assertEqual(added_vllm_request.request_id, "test-req-1")
+
+        # Assert that the request is tracked internally
+        self.assertIn("test-req-1", proc._requests)
+        self.assertEqual(proc._requests["test-req-1"], added_vllm_request)
+
+    def test_shutdown(self):
+        """Tests the shutdown procedure."""
+        proc = DisaggEngineCoreProc(
+            vllm_config=self.mock_vllm_config,
+            on_head_node=True,
+            handshake_address="dummy_addr",
+            executor_class=MagicMock(),
+            log_stats=False,
+        )
+
+        proc.shutdown()
+
+        self.mock_prefill_engine_instance.shutdown.assert_called_once()
+        self.mock_decode_engine_instance.shutdown.assert_called_once()
+
+    def test_utility_method_dispatch(self):
+        """Tests that utility methods are dispatched to the prefill engine."""
+        proc = DisaggEngineCoreProc(
+            vllm_config=self.mock_vllm_config,
+            on_head_node=True,
+            handshake_address="dummy_addr",
+            executor_class=MagicMock(),
+            log_stats=False,
+        )
+
+        # Mock a method on the prefill engine instance
+        self.mock_prefill_engine_instance.list_loras.return_value = {1, 2, 3}
+
+        # Simulate a utility request from a client
+        utility_request = (0, "call-id-1", "list_loras", ())
+        proc._handle_client_request(EngineCoreRequestType.UTILITY,
+                                    utility_request)
+
+        # Check that the method was called on the correct engine
+        self.mock_prefill_engine_instance.list_loras.assert_called_once()
+
+        # Check that the result was put on the output queue
+        client_idx, output = proc.output_queue.get_nowait()
+        self.assertEqual(client_idx, 0)
+        self.assertIsInstance(output, EngineCoreOutputs)
+        self.assertIsInstance(output.utility_output, UtilityOutput)
+        self.assertEqual(output.utility_output.call_id, "call-id-1")
+        self.assertEqual(output.utility_output.result, {1, 2, 3})
+
+    def test_prefill_logic(self):
+        """Tests the core logic of the _prefill method for one iteration."""
+        # 1. Arrange
+        proc = DisaggEngineCoreProc(
+            vllm_config=self.mock_vllm_config,
+            on_head_node=True,
+            handshake_address="dummy_addr",
+            executor_class=MagicMock(),
+            log_stats=False,
+        )
+
+        prefill_engine = self.mock_prefill_engine_instance
+        transfer_backlog = proc._transfer_backlogs[0]
+        output_queue = proc.output_queue
+
+        # Mock the request
+        mock_request = MagicMock(spec=Request)
+        mock_request.request_id = "prefill-req-1"
+        mock_request._all_token_ids = [1, 2, 3]
+        proc._requests[mock_request.request_id] = mock_request
+
+        # Mock scheduler and its sub-components
+        prefill_engine.scheduler = MagicMock()
+        prefill_engine.scheduler.has_requests.return_value = True
+        mock_scheduler_output = MagicMock(spec=SchedulerOutput)
+        mock_scheduler_output.total_num_scheduled_tokens = 10
+        prefill_engine.scheduler.schedule.return_value = mock_scheduler_output
+
+        # Mock model execution result
+        mock_runner_output = MagicMock(spec=ModelRunnerOutput)
+        mock_runner_output.req_id_to_index = {mock_request.request_id: 0}
+        mock_runner_output.sampled_token_ids = [[123]]  # >0 tokens indicates done
+        prefill_engine.execute_model.return_value = mock_runner_output
+
+        # Mock KV cache operations
+        prefill_engine.scheduler.kv_cache_manager.get_block_ids.return_value = ([
+            10, 11
+        ], )
+        mock_kv_cache = [MagicMock(name="layer0_cache")]
+        prefill_engine.model_executor.driver_worker.model_runner.get_kv_cache_for_block_ids.return_value = mock_kv_cache
+
+        # Mock scheduler update and use it to stop the loop for the test
+        mock_engine_outputs = {0: MagicMock(spec=EngineCoreOutputs)}
+
+        def stop_loop_and_return_outputs(*args, **kwargs):
+            proc.live = False  # This will stop the while loop in _prefill
+            return mock_engine_outputs
+
+        prefill_engine.scheduler.update_from_output.side_effect = stop_loop_and_return_outputs
+
+        # Set up scheduler state required for request removal logic
+        prefill_engine.scheduler.requests = {mock_request.request_id: mock_request}
+        prefill_engine.scheduler.running = [mock_request]
+        prefill_engine.scheduler._cached_reqs_data = {
+            mock_request.request_id: MagicMock()
+        }
+
+        # 2. Act
+        proc.live = True
+        proc._prefill(0)  # This will run one iteration and exit via side_effect
+
+        # 3. Assert
+        # Check that KV cache was put on transfer backlog
+        kv_cache_map = transfer_backlog.get_nowait()
+        self.assertIn(mock_request.request_id, kv_cache_map)
+        self.assertEqual(kv_cache_map[mock_request.request_id], mock_kv_cache)
+
+        # Check that request was freed from the scheduler's state
+        self.assertEqual(len(prefill_engine.scheduler.running), 0)
+        prefill_engine.scheduler.kv_cache_manager.free.assert_called_with(mock_request)
+        self.assertNotIn(mock_request.request_id, prefill_engine.scheduler.requests)
+
+    def test_transfer_logic(self):
+        """Tests the _transfer method logic for routing to the least busy engine."""
+        # 1. Arrange
+        # Configure mocks for multiple decode engines before creating the proc.
+        self.mock_disagg_utils.get_decode_slices.return_value = (2, 2)
+        self.mock_decode_engine_instance_1 = MagicMock(name="DecodeEngine1")
+        self.mock_decode_engine_instance_2 = MagicMock(name="DecodeEngine2")
+        self.mock_vLLMEngineCore.side_effect = [
+            self.mock_prefill_engine_instance,
+            self.mock_decode_engine_instance_1,
+            self.mock_decode_engine_instance_2,
+        ]
+
+        # Mock scheduler counts to control routing. Engine 2 is less busy.
+        self.mock_decode_engine_instance_1.scheduler.get_request_counts.return_value = (5, 0)
+        self.mock_decode_engine_instance_2.scheduler.get_request_counts.return_value = (2, 0)
+
+        # Mock the transfer_kv_cache method on the target engine.
+        mock_transferred_cache = MagicMock(name="TransferredKVCache")
+        self.mock_decode_engine_instance_2.model_executor.driver_worker.model_runner.transfer_kv_cache.return_value = mock_transferred_cache
+
+        proc = DisaggEngineCoreProc(
+            vllm_config=self.mock_vllm_config,
+            on_head_node=True,
+            handshake_address="dummy_addr",
+            executor_class=MagicMock(),
+            log_stats=False,
+        )
+
+        # Place item on the transfer backlog.
+        transfer_backlog = proc._transfer_backlogs[0]
+        mock_kv_cache_map = {"req-1": MagicMock(name="OriginalKVCache")}
+        transfer_backlog.put(mock_kv_cache_map)
+        transfer_backlog.put(None)  # Sentinel to stop the loop.
+
+        # 2. Act
+        proc._transfer(0)
+
+        # 3. Assert
+        self.mock_decode_engine_instance_1.model_executor.driver_worker.model_runner.transfer_kv_cache.assert_not_called()
+        self.mock_decode_engine_instance_2.model_executor.driver_worker.model_runner.transfer_kv_cache.assert_called_once()
+
+        output_item = proc._decode_backlogs[1].get_nowait()
+        self.assertEqual(output_item["req_id"], "req-1")
+        self.assertEqual(output_item["cache"], mock_transferred_cache)
+
+    def test_decode_logic(self):
+        """Tests the core logic of the _decode method for one iteration."""
+        # 1. Arrange
+        proc = DisaggEngineCoreProc(
+            vllm_config=self.mock_vllm_config,
+            on_head_node=True,
+            handshake_address="dummy_addr",
+            executor_class=MagicMock(),
+            log_stats=False,
+        )
+
+        decode_engine = self.mock_decode_engine_instance
+        decode_backlog = proc._decode_backlogs[0]
+        output_queue = proc.output_queue
+
+        # Mock the request and its state as it would be after prefill
+        mock_request = MagicMock(spec=Request)
+        mock_request.request_id = "decode-req-1"
+        mock_request.num_computed_tokens = 10  # Simulates it's post-prefill
+        proc._requests[mock_request.request_id] = mock_request
+
+        # Place a work item on the decode backlog for the thread to pick up
+        mock_kv_cache = [MagicMock(name="layer0_cache_decode")]
+        prefill_output = {"req_id": "decode-req-1", "cache": mock_kv_cache}
+        decode_backlog.put(prefill_output)
+        decode_backlog.put(None)  # Sentinel to stop the inner loop after one item
+
+        # Mock the decode engine's scheduler and its sub-components
+        decode_engine.scheduler = MagicMock()
+        decode_engine.scheduler.has_requests.return_value = False
+        decode_engine.scheduler.get_request_counts.return_value = (0, 0)
+        decode_engine.scheduler.kv_cache_manager.get_block_ids.return_value = ([
+            20, 21
+        ], )
+        # Set up lists to track state changes
+        decode_engine.scheduler.running = []
+        decode_engine.scheduler.requests = {}
+
+        # Mock the outputs of the scheduler and model runner
+        mock_scheduler_output = MagicMock(spec=SchedulerOutput)
+        mock_scheduler_output.total_num_scheduled_tokens = 1
+        decode_engine.scheduler.schedule.return_value = mock_scheduler_output
+
+        mock_runner_output = MagicMock(spec=ModelRunnerOutput)
+        decode_engine.execute_model.return_value = mock_runner_output
+
+        mock_engine_outputs = {0: MagicMock(spec=EngineCoreOutputs)}
+
+        def stop_loop(*args, **kwargs):
+            proc.live = False  # Stop the outer while loop after one full cycle
+            return mock_engine_outputs
+
+        decode_engine.scheduler.update_from_output.side_effect = stop_loop
+        decode_engine.model_executor.driver_worker.model_runner.input_batch.num_reqs = 3
+
+        # 2. Act
+        proc.live = True
+        proc._decode(0)
+
+        # 3. Assert
+        # Check that the request was inserted and its state updated
+        decode_engine.model_executor.driver_worker.model_runner.insert_request_with_kv_cache.assert_called_once()
+        self.assertIn(mock_request, decode_engine.scheduler.running)
+        self.assertNotIn(mock_request.request_id, proc._requests)
+
+        # Check that the main decode steps were called
+        decode_engine.scheduler.schedule.assert_called_once()
+        decode_engine.execute_model.assert_called_once_with(mock_scheduler_output)
+
+        # Check that the final output was put on the main output queue
+        client_idx, output = output_queue.get_nowait()
+        self.assertEqual(client_idx, 0)
+        self.assertEqual(output, mock_engine_outputs[0])
 
 
 if __name__ == '__main__':

--- a/tpu_commons/core/core_tpu.py
+++ b/tpu_commons/core/core_tpu.py
@@ -1,4 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
+import copy
+import functools
+import itertools
 import queue
 import signal
 import threading
@@ -12,6 +15,7 @@ from typing import Any, Callable, Optional, TypeVar, Union
 import jax
 import msgspec
 import zmq
+from tpu_commons.runner.utils import LatencyTracker
 from vllm.config import ParallelConfig, VllmConfig
 from vllm.logger import init_logger
 from vllm.lora.request import LoRARequest
@@ -24,13 +28,15 @@ from vllm.v1.core.sched.output import SchedulerOutput
 from vllm.v1.engine import (EngineCoreOutputs, EngineCoreRequest,
                             EngineCoreRequestType, UtilityOutput)
 from vllm.v1.engine.mm_input_cache import MirroredProcessingCache
+from vllm.v1.engine.core import EngineCore as vLLMEngineCore, EngineCoreProc as vLLMEngineCoreProc
 from vllm.v1.executor.abstract import Executor
 from vllm.v1.kv_cache_interface import KVCacheConfig
 from vllm.v1.outputs import ModelRunnerOutput
-from vllm.v1.request import Request
+from vllm.v1.request import Request, RequestStatus
 from vllm.v1.serial_utils import MsgpackDecoder, MsgpackEncoder
 from vllm.v1.structured_output import StructuredOutputManager
 from vllm.v1.utils import EngineHandshakeMetadata, EngineZmqAddresses
+from vllm.sampling_params import SamplingParams
 from vllm.version import __version__ as VLLM_VERSION
 
 from tpu_commons.core import disagg_executor, disagg_utils, orchestrator
@@ -646,3 +652,413 @@ class EngineCoreProc(EngineCore):
                 elif len(reuse_buffers) < max_reuse_bufs:
                     # Limit the number of buffers to reuse.
                     reuse_buffers.append(buffer)
+
+class DisaggEngineCoreProc(vLLMEngineCoreProc):
+    """Wrapper for running vLLM EngineCore in background process."""
+
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        on_head_node: bool,
+        handshake_address: str,
+        executor_class: type[Executor],
+        log_stats: bool,
+        engine_index: int = 0,
+    ):
+        # We don't invoke super class's ctor as we are not really the
+        # engine core to be executed, instead we create other instance of
+        # engine cores and let them do the work.
+        self.vllm_config = vllm_config
+
+        devices = jax.devices()
+        prefill_slice_sizes = disagg_utils.get_prefill_slices()
+        decode_slice_sizes = disagg_utils.get_decode_slices()
+        prefill_chip_cnt = sum(prefill_slice_sizes)
+        decode_chip_cnt = sum(decode_slice_sizes)
+        assert decode_chip_cnt + prefill_chip_cnt <= len(devices)
+        assert prefill_chip_cnt > 0 and decode_chip_cnt > 0
+
+        # Keep track of active requests.
+        self._requests: dict[str, Request] = {}
+
+        # Hack device config to pass in the subslice of TPUs.
+        slice_sizes = list(prefill_slice_sizes)
+        slice_sizes.extend(decode_slice_sizes)
+        setattr(vllm_config.device_config, "slice", (0, slice_sizes))
+        logger.info(f"Adding slice config to device config: {slice_sizes}")
+
+        executor_fail_callback = lambda: self.input_queue.put_nowait(
+            (EngineCoreRequestType.EXECUTOR_FAILED, b''))
+        self._prefill_engines = self._create_engine_cores(
+            prefill_slice_sizes,
+            vllm_config,
+            log_stats,
+            executor_fail_callback,
+        )
+        logger.info(
+            f"{len(self._prefill_engines)} Disaggregated prefill engines created."
+        )
+
+        self._transfer_backlogs = [
+            queue.Queue(4) for i in range(len(self._prefill_engines))
+        ]
+
+        self._decode_engines = self._create_engine_cores(
+            decode_slice_sizes,
+            vllm_config,
+            log_stats,
+            executor_fail_callback,
+        )
+        logger.info(
+            f"{len(self._decode_engines)} Disaggregated decode engines created."
+        )
+        self._decode_backlogs = {
+            idx:
+            queue.Queue(vllm_config.scheduler_config.max_num_seqs)
+            for idx, engine in enumerate(self._decode_engines)
+        }
+
+        self._prefill_threads = [
+            orchestrator.JetThread(
+                target=functools.partial(self._prefill, idx),
+                name=f"prefill-{idx}",
+                daemon=True,
+            ) for idx in range(len(self._prefill_engines))
+        ]
+        self._transfer_threads = [
+            orchestrator.JetThread(
+                target=functools.partial(
+                    self._transfer,
+                    idx,
+                ),
+                name=f"transfer-{idx}",
+                daemon=True,
+            ) for idx in range(len(self._prefill_engines))
+        ]
+        self._decode_threads = [
+            orchestrator.JetThread(
+                target=functools.partial(
+                    self._decode,
+                    idx,
+                ),
+                name=f"decode-{idx}",
+                daemon=True,
+            ) for idx in range(len(self._decode_engines))
+        ]
+        self._all_threads = list(
+            itertools.chain(
+                self._prefill_threads,
+                self._transfer_threads,
+                self._decode_threads,
+            ))
+        self.live = True
+        # Start all threads
+        for t in self._all_threads:
+            t.start()
+
+        # We should be taking the input from the client, the code below is forked from
+        # vllm.v1.engine.core.EngineCoreProc.
+        self.input_queue = queue.Queue[tuple[EngineCoreRequestType, Any]]()
+        self.output_queue = queue.Queue[Union[tuple[int, EngineCoreOutputs],
+                                              bytes]]()
+
+        self.engine_index = engine_index
+        identity = self.engine_index.to_bytes(length=2, byteorder="little")
+        self.engines_running = False
+
+        with self._perform_handshake(handshake_address, identity, on_head_node,
+                                     vllm_config) as addresses:
+            self.client_count = len(addresses.outputs)
+
+            # Set up data parallel environment.
+            self.has_coordinator = addresses.coordinator_output is not None
+
+        # Background Threads and Queues for IO. These enable us to
+        # overlap ZMQ socket IO with GPU since they release the GIL,
+        # and to overlap some serialization/deserialization with the
+        # model forward pass.
+        # Threads handle Socket <-> Queues and core_busy_loop uses Queue.
+        threading.Thread(target=self.process_input_sockets,
+                         args=(addresses.inputs, addresses.coordinator_input,
+                               identity),
+                         daemon=True).start()
+        self.output_thread = threading.Thread(
+            target=self.process_output_sockets,
+            args=(addresses.outputs, addresses.coordinator_output,
+                  self.engine_index),
+            daemon=True)
+        self.output_thread.start()
+
+    @staticmethod
+    def _create_engine_cores(
+        slice_sizes: tuple[int, ...],
+        vllm_config: VllmConfig,
+        log_stats: bool,
+        executor_fail_callback: Optional[Callable] = None,
+    ) -> list[vLLMEngineCore]:
+        engine_cores = []
+        for _ in slice_sizes:
+            engine_core = vLLMEngineCore(
+                vllm_config,
+                disagg_executor.DisaggExecutor,
+                log_stats,
+                executor_fail_callback,
+            )
+
+            engine_cores.append(engine_core)
+            logger.info("Disaggregated engine core created.")
+
+        return engine_cores
+
+    def _add_request(self, request: EngineCoreRequest) -> Request:
+        if request.mm_hashes is not None:
+            # Here, if hash exists for a multimodal input, then it will be
+            # fetched from the cache, else it will be added to the cache.
+            # Note that the cache here is mirrored with the client cache, so
+            # anything that has a hash must have a HIT cache entry here
+            # as well.
+            assert request.mm_inputs is not None
+            request.mm_inputs = self._prefill_engines[
+                0
+            ].mm_input_cache_server.get_and_update_p1(
+                request.mm_inputs, request.mm_hashes
+            )
+
+        req = Request.from_engine_core_request(request)
+
+        if req.use_structured_output:
+            # Start grammar compilation asynchronously
+            self._prefill_engines[0].structured_output_manager.grammar_init(req)
+
+        return req
+
+    def add_request(self, request: EngineCoreRequest):
+        vllm_request = self._add_request(request)
+
+        # TODO(fhzhang): support multiple prefill engines.
+        self._prefill_engines[0].scheduler.add_request(vllm_request)
+        self._requests[request.request_id] = vllm_request
+
+    def _handle_client_request(self, request_type: EngineCoreRequestType,
+                               request: Any) -> None:
+        """Dispatch request from client."""
+
+        if request_type == EngineCoreRequestType.ADD:
+            self.add_request(request)
+        elif request_type == EngineCoreRequestType.ABORT:
+            # TODO(fhzhang): we need to keep track of which engine is processing
+            # the request and finish it there.
+            # owner_engine.scheduler.finish_requests(request, RequestStatus.FINISHED_ABORTED)
+            pass
+        elif request_type == EngineCoreRequestType.UTILITY:
+            client_idx, call_id, method_name, args = request
+            output = UtilityOutput(call_id)
+            try:
+                method = getattr(self._prefill_engines[0], method_name)
+                output.result = method(
+                    *self._convert_msgspec_args(method, args))
+            except BaseException as e:
+                logger.exception("Invocation of %s method failed", method_name)
+                output.failure_message = (f"Call to {method_name} method"
+                                          f" failed: {str(e)}")
+            self.output_queue.put_nowait(
+                (client_idx, EngineCoreOutputs(utility_output=output)))
+        elif request_type == EngineCoreRequestType.EXECUTOR_FAILED:
+            raise RuntimeError("Executor failed.")
+        else:
+            logger.error("Unrecognized input request type encountered: %s",
+                         request_type)
+
+    def run_busy_loop(self):
+        """Core busy loop of the EngineCore."""
+
+        # Loop until process is sent a SIGINT or SIGTERM
+        while True:
+            while not self.input_queue.empty():
+                req = self.input_queue.get_nowait()
+                self._handle_client_request(*req)
+            # Yield control to other threads, as we are not doing any real work.
+            # Without this sleep, we'd be hogging all the cpu cycles with our run_busy_loop.
+            time.sleep(0.01)
+
+    def _prefill(self, idx: int):
+        prefill_engine = self._prefill_engines[idx]
+        transfer_backlog = self._transfer_backlogs[idx]
+
+        while self.live:
+            if not prefill_engine.scheduler.has_requests():
+                time.sleep(0.05)
+                continue
+
+            scheduler_output = prefill_engine.scheduler.schedule()
+            with LatencyTracker(f"prefill-{idx}"):
+                model_output = prefill_engine.execute_model(scheduler_output)
+
+            if scheduler_output.total_num_scheduled_tokens > 0:
+                logger.debug(f"Prefill result: {model_output}")
+
+                kv_cache_map: dict[str, list[jax.Array]] = {}
+                for req_id, idx in model_output.req_id_to_index.items():
+                    if len(model_output.sampled_token_ids[idx]) > 0:
+                        request = self._requests[req_id]
+                        block_ids = (
+                            prefill_engine.scheduler.kv_cache_manager.get_block_ids(
+                                req_id
+                            )
+                        )
+                        with LatencyTracker(f"ExtractKVCache-{req_id}-{block_ids}"):
+                            # Assume one KV cache group for now.
+                            kv_cache_map[req_id] = (
+                                prefill_engine.model_executor.driver_worker.model_runner.get_kv_cache_for_block_ids(
+                                    block_ids[0]
+                                )
+                            )
+                        logger.debug(f"prefill done: for {req_id}")
+                transfer_backlog.put(kv_cache_map, block=True)
+
+                # tweak model_output to let the scheduler know kv_transfer is done for requests, so they can be freed.
+                engine_core_outputs = prefill_engine.scheduler.update_from_output(
+                    scheduler_output, model_output)  # type: ignore
+
+                for req_id, idx in model_output.req_id_to_index.items():
+                    if len(model_output.sampled_token_ids[idx]) > 0:
+                        request = self._requests[req_id]
+                        logger.debug(f"request-{req_id}: tokens={request._all_token_ids} after prefill")
+                        # Remove request from the prefill engine.
+
+                        request = prefill_engine.scheduler.requests[req_id]
+                        prefill_engine.scheduler.running.remove(request)
+                        prefill_engine.scheduler.encoder_cache_manager.free(request)
+                        prefill_engine.scheduler._cached_reqs_data.pop(req_id, None)
+
+                        prefill_engine.scheduler.kv_cache_manager.free(request)
+                        prefill_engine.scheduler.kv_cache_manager.free_block_hashes(request)
+
+                        prefill_engine.scheduler.requests.pop(req_id)
+
+                for output in (engine_core_outputs.items() if engine_core_outputs else ()):
+                    self.output_queue.put_nowait(output)
+
+    def _transfer(self, idx: int):
+        """Transfers the kv cache on an active request to the least full
+    decode backlog."""
+        transfer_backlog = self._transfer_backlogs[idx]
+        while self.live:
+            # The transfer thread can just sleep until it has work to do.
+            kv_cachce_map = transfer_backlog.get(block=True)
+            if kv_cachce_map is None:
+                break
+
+            logger.debug(f"transfer-{idx}: KV Cache items received: {kv_cachce_map.keys()}")
+
+            push_targets = []
+            for req_id, kv_cache in kv_cachce_map.items():
+                target_idx = -1
+                cnt = 9999999
+                for i, e in enumerate(self._decode_engines):
+                    req_cnt = sum(e.scheduler.get_request_counts())
+                    if req_cnt < cnt:
+                        cnt = req_cnt
+                        target_idx = i
+
+                # Only transfer the KVCache for the disaggregated serving.
+                with LatencyTracker("KVCacheTransfer"):
+                    kv_cache = self._decode_engines[
+                        target_idx
+                    ].model_executor.driver_worker.model_runner.transfer_kv_cache(
+                        kv_cache
+                    )
+
+                # TODO(fhzhang): Now how do we get the kv cache to the decode engine?
+                prefill_output = {
+                    "cache": kv_cache,
+                    "req_id": req_id,
+                }
+                push_targets.append((target_idx, prefill_output))
+
+            for target_idx, prefill_output in push_targets:
+                self._decode_backlogs[target_idx].put(prefill_output,
+                                                        block=True)
+                logger.debug(
+                    "Successfully transferred prefill request %s "
+                    "from prefill engine %d to decode engine %d. decode backlog len %d",
+                    prefill_output["req_id"],
+                    idx,
+                    target_idx,
+                    self._decode_backlogs[target_idx].qsize(),
+                )
+
+    def _decode(self, idx: int):
+        decode_engine = self._decode_engines[idx]
+        decode_backlog = self._decode_backlogs[idx]
+
+        while self.live:
+            block = not decode_engine.scheduler.has_requests()
+            while True:
+                # We need to check input batch as well as the request completion is delayed
+                # from scheduler to the runner.
+                if (
+                    sum(decode_engine.scheduler.get_request_counts())
+                    >= self.vllm_config.scheduler_config.max_num_seqs or
+                    decode_engine.model_executor.driver_worker.model_runner.input_batch.num_reqs
+                    >= self.vllm_config.scheduler_config.max_num_seqs
+                ):
+                    break
+
+                try:
+                    prefill_output = decode_backlog.get(block=block, timeout=1.0)
+                except queue.Empty:
+                    if block:
+                        continue
+                    break
+
+                if prefill_output is None:
+                    logger.info(f"decode-{idx} Empty output, and we are idle, exiting...")
+                    break
+
+                # We got a request, set block to False
+                block = False
+
+                # Insert the request to the decoder.
+                req_id = prefill_output["req_id"]
+                vllm_request = self._requests[req_id]
+                kv_cache = prefill_output["cache"]
+
+                kv_cache_manager = decode_engine.scheduler.kv_cache_manager
+                kv_cache_manager.allocate_slots(
+                    vllm_request,
+                    vllm_request.num_computed_tokens,
+                )
+                new_block_ids = kv_cache_manager.get_block_ids(req_id)
+
+                with LatencyTracker(
+                        f"KVCacheInsert-{len(new_block_ids[0])}"):
+                    decode_engine.model_executor.driver_worker.model_runner.insert_request_with_kv_cache(
+                        vllm_request, kv_cache, new_block_ids
+                    )
+
+                vllm_request.status = RequestStatus.RUNNING
+                decode_engine.scheduler.running.append(vllm_request)
+                decode_engine.scheduler.requests[req_id] = vllm_request
+
+                self._requests.pop(req_id)
+
+            scheduler_output = decode_engine.scheduler.schedule()
+
+            logger.debug(f"decode-{idx}: scheduler_output - {scheduler_output}")
+
+            with LatencyTracker(f"decode-{idx}"):
+                model_output = decode_engine.execute_model(scheduler_output)
+            if scheduler_output.total_num_scheduled_tokens > 0:
+                logger.debug(f"Decode result: {model_output}")
+
+                engine_core_outputs = decode_engine.scheduler.update_from_output(
+                    scheduler_output, model_output)  # type: ignore
+                for output in (engine_core_outputs.items() if engine_core_outputs else ()):
+                    self.output_queue.put_nowait(output)
+
+    def shutdown(self):
+        for e in self._prefill_engines:
+            e.shutdown()
+        for e in self._decode_engines:
+            e.shutdown()

--- a/tpu_commons/core/disagg_executor.py
+++ b/tpu_commons/core/disagg_executor.py
@@ -2,23 +2,35 @@
 
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
+import jax
+
+from vllm.logger import init_logger
 from vllm.utils import (get_distributed_init_method, get_ip, get_open_port,
                         run_method)
 from vllm.v1.executor.abstract import Executor
 from vllm.worker.worker_base import WorkerWrapperBase
 
 
+logger = init_logger(__name__)
+
 class DisaggExecutor(Executor):
 
     def _init_executor(self) -> None:
         """Initialize the worker and load the model.
         """
-        pass
-
-    def init_with_devices(self, devices):
-        """Initialize the worker with specified devices and load the model."""
         self.driver_worker = WorkerWrapperBase(vllm_config=self.vllm_config,
                                                rpc_rank=0)
+        slice_config = getattr(self.vllm_config.device_config, "slice")
+        idx = slice_config[0]
+        sizes = slice_config[1]
+
+        start = sum(sizes[0:idx])
+        end = start + sizes[idx]
+
+        devices = jax.devices()[start: end]
+        setattr(self.vllm_config.device_config, "slice", (idx + 1, sizes))
+        logger.info(f"Creating DisaggExecutor with {devices}, index: {start} -> {end}")
+
         distributed_init_method = get_distributed_init_method(
             get_ip(), get_open_port())
         local_rank = 0


### PR DESCRIPTION
This implementation reuses the EngineCore from vLLM and reduces the amount of duplicated code in tpu_commons. The performance seems to be significantly better as well.

# Description

We utilize the EngineCore inside vLLM and only add necessary glue code from tpu_commons to enable. The DisaggEngineCore will be a starting point for us to discuss the proper DI integration with vLLM.

# Tests

Unit tests and manual tests.

```
Processed prompts: 100%|█████| 35/35 [00:14<00:00,  2.41it/s, est. speed input: 25.38 toks/s, output: 38.63 toks/s]
--------------------------------------------------
Prompt: 'Hello, my name is'
Generated text: ' [Your Name]. I am a [Your Profession/Student] and I am'
--------------------------------------------------
Prompt: 'The capital of France is'
Generated text: ' Paris, which is located in the north-central part of the country. Paris is'
--------------------------------------------------
Prompt: 'The colors of the rainbow are'
Generated text: ' often associated with the colors of the rainbow, but did you know that the colors'
--------------------------------------------------
Prompt: 'The future of AI is'
Generated text: " bright, but it's not without its challenges. Here are some of the key"
--------------------------------------------------
Prompt: 'The president of the United States is'
Generated text: ' the head of state and head of government of the United States. The president is'
--------------------------------------------------
Prompt: 'How many players are on a standard soccer team on the field at one time?'
Generated text: ' A) 5 B) 7 C) 11 D) 15'
--------------------------------------------------
Prompt: 'In Greek mythology, who is the god of the sea?'
Generated text: ' A) Poseidon B) Zeus C) Hades D) Apollo\nThe'
--------------------------------------------------
Prompt: 'In what year did the Titanic sink?'
Generated text: ' The RMS Titanic sank on April 15, 1912, after colliding'
```
# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have made or will make corresponding changes to any relevant documentation.
