### PR TITLE
Enhance torchax test

### DIFF
--- a/tests/models/vllm/test_jax_attention.py
+++ b/tests/models/vllm/test_jax_attention.py
@@ -19,7 +19,13 @@ from tpu_commons.models.vllm.vllm_model_wrapper_context import (
 
 P = PartitionSpec
 
-torchax.enable_globally()
+
+@pytest.fixture(scope="module", autouse=True)
+def setup_torchax():
+    """Enable torchax globally before all tests, disable after all tests."""
+    torchax.enable_globally()
+    yield
+    torchax.disable_globally()
 
 
 def _get_spmd_mesh():

--- a/tests/models/vllm/test_jax_fused_moe.py
+++ b/tests/models/vllm/test_jax_fused_moe.py
@@ -15,7 +15,13 @@ from tpu_commons.models.vllm.jax_fused_moe import JaxFusedMoE
 
 P = PartitionSpec
 
-torchax.enable_globally()
+
+@pytest.fixture(scope="module", autouse=True)
+def setup_torchax():
+    """Enable torchax globally before all tests, disable after all tests."""
+    torchax.enable_globally()
+    yield
+    torchax.disable_globally()
 
 
 def _get_spmd_mesh():

--- a/tests/models/vllm/test_jax_merged_column_parallel_linear.py
+++ b/tests/models/vllm/test_jax_merged_column_parallel_linear.py
@@ -18,7 +18,13 @@ from tpu_commons.models.vllm.jax_merged_column_parallel_linear import \
 
 P = PartitionSpec
 
-torchax.enable_globally()
+
+@pytest.fixture(scope="module", autouse=True)
+def setup_torchax():
+    """Enable torchax globally before all tests, disable after all tests."""
+    torchax.enable_globally()
+    yield
+    torchax.disable_globally()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/models/vllm/test_jax_qkv_parallel_linear.py
+++ b/tests/models/vllm/test_jax_qkv_parallel_linear.py
@@ -18,7 +18,13 @@ from tpu_commons.models.vllm.jax_qkv_parallel_linear import \
 
 P = PartitionSpec
 
-torchax.enable_globally()
+
+@pytest.fixture(scope="module", autouse=True)
+def setup_torchax():
+    """Enable torchax globally before all tests, disable after all tests."""
+    torchax.enable_globally()
+    yield
+    torchax.disable_globally()
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
# Description

Before this PR, we call `torchax.enable_globally()` at the beginning of serval tests to enable torchax mode. However, this mode may fail with pytorch code if it's not intended to run with torchax mode enabled.

# Tests

Unit test

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have made or will make corresponding changes to any relevant documentation.
