### PR TITLE
change activation precision from fp32 to dtype

### DIFF
--- a/tpu_commons/models/jax/common/layers.py
+++ b/tpu_commons/models/jax/common/layers.py
@@ -83,7 +83,7 @@ class RMSNorm(nnx.Module):
         Returns:
             The normalized tensor with the same shape as the input.
         """
-        x = jnp.asarray(x, jnp.float32)
+        x = jnp.asarray(x, self.dtype)
         x_TD = nnx.with_sharding_constraint(x, self.activation_ffw_td[op_mode])
 
         var = jnp.mean(jnp.square(x_TD), axis=-1, keepdims=True)
@@ -182,7 +182,7 @@ class DenseFFW(nnx.Module):
             The output tensor of shape `(batch, sequence, d_model)`.
         """
         # TODO consider to create factories for einsum(?)
-        x = jnp.asarray(x, jnp.float32)
+        x = jnp.asarray(x, self.cfg.dtype)
         x_TD = nnx.with_sharding_constraint(x, self.activation_ffw_td[op_mode])
         act = getattr(self.cfg, HuggingFaceArgNames.HIDDEN_ACT.value)
         with jax.named_scope("wi_0"):
@@ -327,7 +327,7 @@ class Embedder(nnx.Module):
             The output logits over the vocabulary, with shape
             `(batch, sequence, vocab_size)`.
         """
-        x = jnp.asarray(x, jnp.float32)
+        x = jnp.asarray(x, self.cfg.dtype)
         x_TD = nnx.with_sharding_constraint(x, self.prelogit_td)
 
         logits_TV = jnp.einsum('TD,DV -> TV', x_TD,

--- a/tpu_commons/models/jax/common/moe/moe.py
+++ b/tpu_commons/models/jax/common/moe/moe.py
@@ -87,7 +87,7 @@ class Router(nnx.Module):
             self.cfg, HuggingFaceArgNames.NUM_EXPERTS_PER_TOKEN)
         router_logits_TE = jnp.einsum('TD,DE -> TE', x_TD,
                                       self.kernel_DE.value)
-        activated_gating_TF = nnx.softmax(router_logits_TE.astype(jnp.float32),
+        activated_gating_TF = nnx.softmax(router_logits_TE.astype(self.cfg.dtype),
                                           axis=-1)
         weights_TX, selected_experts_TX = jax.lax.top_k(
             activated_gating_TF, num_experts_per_tok)
@@ -185,7 +185,7 @@ class MoE(nnx.Module):
         Returns:
             Output array of shape (sequence_length, d_model) after passing through MoE.
         """
-        x = jnp.asarray(x, jnp.float32)
+        x = jnp.asarray(x, self.cfg.dtype)
         x_TD = nnx.with_sharding_constraint(x, self.activation_ffw_td[op_mode])
         weights_TX, indices_TX = self.router(x_TD, op_mode)
         num_experts = getattr(self.cfg,


### PR DESCRIPTION
# Description

change activation precision from fp32 to dtype, which increases throughput without hurting the accuracy

# Tests
llama3 70b new model:
https://paste.googleplex.com/6468380764405760

llama3 70b old model:
https://paste.googleplex.com/4811125438545920
# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have made or will make corresponding changes to any relevant documentation.
