### PR TITLE
Rename test_backend.py as tpu_backend_test.py to be consistent with t…

### DIFF
--- a/tests/tpu_backend_test.py
+++ b/tests/tpu_backend_test.py
@@ -21,7 +21,7 @@ from tpu_commons.backend import TPUBackend
 from tpu_commons.di.interfaces import HostInterface
 
 
-class BackendTest(unittest.TestCase):
+class TPUBackendTest(unittest.TestCase):
 
     @patch('tpu_commons.backend.get_tpu_worker_cls')
     def test_backend_initialization(self, mock_get_worker_cls):


### PR DESCRIPTION
…he majority of the test files

# Tests

```$ pytest -v tpu_backend_test.py 
============================================================ test session starts ============================================================
platform linux -- Python 3.12.11, pytest-8.4.1, pluggy-1.6.0 -- /home/ymu_google_com/miniconda3/envs/vllm12/bin/python3.12
cachedir: .pytest_cache
rootdir: /home/ymu_google_com/tpu_commons
configfile: pyproject.toml
plugins: jaxtyping-0.3.2, mock-3.14.1, anyio-4.9.0
collected 2 items                                                                                                                           

tpu_backend_test.py::TPUBackendTest::test_backend_initialization PASSED                                                               [ 50%]
tpu_backend_test.py::TPUBackendTest::test_launch_tpu_batch_delegates_to_worker PASSED                                                 [100%]

============================================================= warnings summary ==============================================================
tpu_backend_test.py:19
  /home/ymu_google_com/tpu_commons/tests/tpu_backend_test.py:19: UserWarning: 🚨  CAUTION: You are using 'tpu_commons' , which is experimental and NOT intended for production use yet. Please see the README for more details.
    from tpu_commons.adapters.vllm_adapters import VllmSchedulerOutputAdapter

../../miniconda3/envs/vllm12/lib/python3.12/site-packages/jax/_src/cloud_tpu_init.py:84
  /home/ymu_google_com/miniconda3/envs/vllm12/lib/python3.12/site-packages/jax/_src/cloud_tpu_init.py:84: UserWarning: Transparent hugepages are not enabled. TPU runtime startup and shutdown time should be significantly improved on TPU v5e and newer. If not already set, you may need to enable transparent hugepages in your VM image (sudo sh -c "echo always > /sys/kernel/mm/transparent_hugepage/enabled")
    warnings.warn(

../../miniconda3/envs/vllm12/lib/python3.12/site-packages/tpu_info/device.py:32
  /home/ymu_google_com/miniconda3/envs/vllm12/lib/python3.12/site-packages/tpu_info/device.py:32: DeprecationWarning: In 3.13 classes created inside an enum will not become a member.  Use the `member` decorator to keep the current behavior.
    class Info(typing.NamedTuple):

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================================================= 2 passed, 3 warnings in 3.96s =======================================================
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have made or will make corresponding changes to any relevant documentation.
