### PR TITLE
Fixes error when req_data is an empty list.

### DIFF
--- a/tpu_commons/runner/jax/tpu_jax_runner.py
+++ b/tpu_commons/runner/jax/tpu_jax_runner.py
@@ -911,12 +911,16 @@ class TPUModelRunner():
             req_ids_to_add.append(req_id)
 
         # Update the states of the running/resumed requests.
-        req_data = scheduler_output.scheduled_cached_reqs
-        for i, req_id in enumerate(req_data.req_ids):
+        list_of_req_data = scheduler_output.scheduled_cached_reqs
+        for req_data in list_of_req_data:
+            req_id = req_data.req_id
+            if not req_id:
+                continue
+
             req_state = self.requests[req_id]
-            num_computed_tokens = req_data.num_computed_tokens[i]
-            new_block_ids = req_data.new_block_ids[i]
-            resumed_from_preemption = req_data.resumed_from_preemption[i]
+            num_computed_tokens = req_data.num_computed_tokens
+            new_block_ids = req_data.new_block_ids
+            resumed_from_preemption = req_data.resumed_from_preemption
 
             # Update the cached states.
             req_state.num_computed_tokens = num_computed_tokens


### PR DESCRIPTION
# Description

Code would throw error if the `req_data` var was an empty list and not checking it.

# Tests

Local unit tests and e2e benchmarks

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have made or will make corresponding changes to any relevant documentation.
