### PR TITLE
Add the sync weight API to Jax backend so that RL can sync external in memory weights to Jax models.

### DIFF
--- a/tests/models/jax/test_weight_loading.py
+++ b/tests/models/jax/test_weight_loading.py
@@ -1,0 +1,83 @@
+# SPDX-License-Identifier: Apache-2.0
+# Test for LoRA weight loading API
+
+import jax
+import jax.numpy as jnp
+from flax import nnx
+from jax._src import test_util as jtu
+
+from tpu_commons.models.jax.utils.weight_utils import \
+    transfer_state_with_mappings
+
+# ----- nnx.Module Wrappers -----
+
+
+class SourceLayer(nnx.Module):
+
+    def __init__(self, rngs):
+        self.kernel = nnx.Param(jax.random.normal(rngs(), (4, 4)))
+        self.bias = nnx.Param(jax.random.normal(rngs(), (4, )))
+
+
+class SourceModel(nnx.Module):
+
+    def __init__(self, rngs):
+        self.src_lm_head = nnx.Param(jax.random.normal(rngs(), (2, 4)))
+        self.layers = {0: SourceLayer(rngs)}
+
+
+class TargetLinear(nnx.Module):
+
+    def __init__(self, rngs):
+        self.kernel = nnx.Param(jnp.zeros((4, 4)))
+        self.bias = nnx.Param(jnp.zeros((4, )))
+
+
+class TargetBlock(nnx.Module):
+
+    def __init__(self, rngs):
+        self.mlp = {"up_proj": TargetLinear(rngs)}
+
+
+class TargetModel(nnx.Module):
+
+    def __init__(self, rngs):
+        self.tgt_lm_head = nnx.Param(jnp.zeros((2, 4)))
+        self.model = {"layers": {0: TargetBlock(rngs)}}
+
+
+# ----- Test -----
+class WeightTransfer(jtu.JaxTestCase):
+
+    def test_transfer_state(self):
+        rng = nnx.Rngs(0)
+        src_model = SourceModel(rng)
+        tgt_model = TargetModel(rng)
+
+        # Get split states
+        _, src_state = nnx.split(src_model)
+        _, tgt_state = nnx.split(tgt_model)
+
+        # Overwrite known values
+        src_state["layers"][0]["kernel"].value = jnp.ones((4, 4)) * 42.0
+        src_state["layers"][0]["bias"].value = jnp.ones((4, )) * 7.0
+        src_state["src_lm_head"].value = jnp.ones((2, 4)) * 6.0
+        # Mapping for both kernel and bias
+        mappings = {
+            "layers.*.kernel": ("model.layers.*.mlp.up_proj.kernel", (None, )),
+            "layers.*.bias": ("model.layers.*.mlp.up_proj.bias", (None, )),
+            "src_lm_head": ("tgt_lm_head", (None, None)),
+        }
+
+        # Transfer
+        new_tgt_state = transfer_state_with_mappings(src_state, tgt_state,
+                                                     mappings)
+
+        # Assert correctness
+        assert jnp.allclose(
+            new_tgt_state["model"]["layers"][0]["mlp"]["up_proj"]
+            ["kernel"].value, 42.0)
+        assert jnp.allclose(
+            new_tgt_state["model"]["layers"][0]["mlp"]["up_proj"]
+            ["bias"].value, 7.0)
+        assert jnp.allclose(new_tgt_state["tgt_lm_head"].value, 6.0)

--- a/tpu_commons/models/jax/utils/weight_utils.py
+++ b/tpu_commons/models/jax/utils/weight_utils.py
@@ -351,3 +351,80 @@ def load_hf_weights(vllm_config, model: nnx.Module, mappings: Dict[str, str],
         model_weight.value = shard(hf_weight, model_sharding)
 
     nnx.update(model, params)
+
+
+def build_flat_dict(flat_state, mappings):
+    """Build a new flat dictionary from the flat state using the provided mappings."""
+    new_flat_dict = {}
+    for keys, v in flat_state:
+        path = '.'.join(str(key) for key in keys)
+        mapped = False
+        for src, (tgt, sharding) in mappings.items():
+            regex = "^" + re.escape(tgt).replace("\\.\\*", r"\.(\d+)") + "$"
+            matched = re.match(regex, path)
+            if matched:
+                # Extract wildcards if any
+                wildcards = matched.groups()
+                src_parts = []
+                wc_index = 0
+                for part in src.split("."):
+                    if part == "*":
+                        src_parts.append(wildcards[wc_index])
+                        wc_index += 1
+                    else:
+                        src_parts.append(part)
+                actual_src = ".".join(src_parts)
+                new_flat_dict[actual_src] = v, sharding
+                mapped = True
+                break
+        if not mapped:
+            logger.info(f"!!! No mapping for flat state: {keys}")
+    return new_flat_dict
+
+
+def transfer_state_with_mappings(src_state,
+                                 tgt_state,
+                                 mappings,
+                                 transpose_keys=None,
+                                 shard=None):
+    """Transfer state from src_state to tgt_state using the provided mappings."""
+    src_flat = src_state.flat_state()
+    tgt_flat = tgt_state.flat_state()
+
+    new_src_dict = build_flat_dict(tgt_flat, mappings)
+    logger.info(f"{mappings=}")
+    logger.info(f"{transpose_keys=}")
+    for src_keys, v in src_flat:
+        flattened_src_keys = '.'.join(str(k) for k in src_keys)
+        new_v = jnp.copy(v.value)
+        logger.info(
+            f"Processing source key: {flattened_src_keys} and value: {new_v.shape} {new_v.dtype}"
+        )
+        if flattened_src_keys not in new_src_dict:
+            logger.info(f"!!! No mapping for source key: {flattened_src_keys}")
+            continue
+        sharding = new_src_dict[flattened_src_keys][1]
+
+        # E.g. layers.*.attn.k_proj.w, layers.*.attn.k_proj.w_lora_a
+        # E.g. layers.*.mlp.down_proj.kernel, layers.*.mlp.down_proj.kernel_lora_a
+        if transpose_keys is not None \
+          and ((src_keys[-1] in transpose_keys) and ('lora' not in src_keys[-1])):
+            v_maybe_t = jnp.transpose(new_v, transpose_keys[src_keys[-1]])
+        else:
+            v_maybe_t = new_v
+
+        to_update_value = new_src_dict[flattened_src_keys][0].value
+        assert to_update_value.shape == v_maybe_t.shape, \
+            f"Shape mismatch for {flattened_src_keys}: {to_update_value.shape} vs {v_maybe_t.shape}"
+
+        if to_update_value.dtype != v_maybe_t.dtype:
+            logger.info(
+                f"Type mismatch between external model and vLLM model. Converting {v_maybe_t.dtype=} to {to_update_value.dtype=}"
+            )
+            v_maybe_t = v_maybe_t.astype(to_update_value.dtype)
+
+        new_src_dict[flattened_src_keys][0].value = shard(
+            v_maybe_t, sharding) if shard else v_maybe_t
+
+    tgt_state = tgt_state.from_flat_path(tgt_flat)
+    return tgt_state

--- a/tpu_commons/runner/jax/tpu_jax_runner.py
+++ b/tpu_commons/runner/jax/tpu_jax_runner.py
@@ -4,10 +4,11 @@ import random
 import time
 from contextlib import nullcontext
 from dataclasses import asdict
-from typing import Any, List, Optional, cast
+from typing import Any, Callable, Dict, List, Optional, Tuple, cast
 
 import jax
 import jax.numpy as jnp
+import jaxtyping
 import numpy as np
 import vllm.envs as envs
 from flax import nnx
@@ -25,10 +26,13 @@ from tpu_commons import utils_jax as utils
 from tpu_commons.logger import init_logger
 from tpu_commons.models.jax.attention_metadata import AttentionMetadata
 from tpu_commons.models.jax.common.sharding import Sharding
+from tpu_commons.models.jax.layers.misc import shard_put
 from tpu_commons.models.jax.layers.sampling import sample
 from tpu_commons.models.jax.model_loader import get_model
 from tpu_commons.models.jax.sampling_metadata import \
     TPUSupportedSamplingMetadata
+from tpu_commons.models.jax.utils.weight_utils import \
+    transfer_state_with_mappings
 from tpu_commons.runner.jax.input_batch_jax import (CachedRequestState,
                                                     InputBatch)
 from tpu_commons.runner.utils import (ForbidCompile, LatencyTracker,
@@ -961,6 +965,26 @@ class TPUModelRunner():
             self.input_batch.condense(removed_req_indices)
 
         return len(unscheduled_req_ids) > 0 or len(req_ids_to_add) > 0
+
+    def _sync_weights(
+        self,
+        updated_weights: jaxtyping.PyTree,
+        mappings: Dict[str, Tuple[str, Tuple[str]]],
+        transpose_keys: Dict[str, Tuple[int]],
+        reshard_fn: Callable[[jaxtyping.PyTree, jaxtyping.PyTree],
+                             jaxtyping.PyTree] = None
+    ) -> None:
+        if reshard_fn is not None:
+            updated_weights = reshard_fn(updated_weights, self.state)
+            shard = None
+        else:
+            shard = functools.partial(shard_put, mesh=self.mesh)
+        self.state = transfer_state_with_mappings(
+            src_state=updated_weights,
+            tgt_state=self.state,
+            mappings=mappings,
+            transpose_keys=transpose_keys,
+            shard=shard)
 
 
 def _get_padded_num_kv_cache_update_slices(num_tokens: int, max_num_reqs: int,

--- a/tpu_commons/worker/tpu_worker_jax.py
+++ b/tpu_commons/worker/tpu_worker_jax.py
@@ -1,9 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
-from typing import Optional, Union
+from typing import Callable, Dict, Optional, Tuple, Union
 
 import jax
+import jaxtyping
 import vllm.envs as envs
 from vllm.config import VllmConfig
 from vllm.v1.core.sched.output import SchedulerOutput
@@ -157,3 +158,17 @@ class TPUWorker(AbstractTpuWorker):
     def check_health(self) -> None:
         # worker will always be healthy as long as it's running.
         return
+
+    def sync_weights(
+        self,
+        updated_weights: jaxtyping.PyTree,
+        mappings: Dict[str, Tuple[str, Tuple[str]]],
+        transpose_keys: Dict[str, Tuple[int]],
+        reshard_fn: Callable[[jaxtyping.PyTree, jaxtyping.PyTree],
+                             jaxtyping.PyTree] = None
+    ) -> None:
+        """Sync the updated weights to the model runner."""
+        return self.model_runner._sync_weights(updated_weights=updated_weights,
+                                               mappings=mappings,
+                                               transpose_keys=transpose_keys,
+                                               reshard_fn=reshard_fn)


### PR DESCRIPTION
In RL, it's necessary to sync the weights from trainer to serving engine every N (1 or >1) steps. Adding this API so that we can pass an external nnx state, provide the mapping from source model to target model together with tranpose and sharding information.

# Tests

Added a unit test. I also have a script in Tunix repo to run it e2e.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have made or will make corresponding changes to any relevant documentation.
