### PR TITLE
Add support for the Phi-3 model.

### DIFF
--- a/tests/models/vllm/test_jax_attention.py
+++ b/tests/models/vllm/test_jax_attention.py
@@ -10,6 +10,7 @@ from vllm.attention import Attention as VllmAttention
 from vllm.config import set_current_vllm_config
 from vllm.engine.arg_utils import EngineArgs
 
+from tpu_commons import utils_jax as utils
 from tpu_commons.kernels.ragged_paged_attention.kernel import \
     ref_ragged_paged_attention
 from tpu_commons.models.jax.attention_metadata import AttentionMetadata
@@ -88,7 +89,7 @@ def generate_kv_caches(num_kv_heads, head_size, mesh, dtype):
         1024,  # num_blocks
         16,  # block_size
         num_kv_heads * 2,
-        head_size,
+        utils.get_padded_head_dim(head_size),
     )
     sharding = NamedSharding(mesh, PartitionSpec(None, None, "model", None))
 
@@ -104,7 +105,7 @@ def generate_kv_caches(num_kv_heads, head_size, mesh, dtype):
 
 @pytest.mark.parametrize("mesh", [_get_spmd_mesh()])
 @pytest.mark.parametrize("num_heads", [8, 32])
-@pytest.mark.parametrize("head_size", [128])
+@pytest.mark.parametrize("head_size", [96, 128])
 @pytest.mark.parametrize("num_kv_heads", [8])
 @pytest.mark.parametrize("num_tokens", [15, 63])
 def test_jax_attention(mesh, num_heads, head_size, num_kv_heads, num_tokens):
@@ -167,6 +168,13 @@ def test_jax_attention(mesh, num_heads, head_size, num_kv_heads, num_tokens):
     # j2t() doens't support bfloat16, so we cast it into float32 as an intermedate step.
     jax_output = j2t(jax_output.to(torch.float32)).to(dtype)
 
+    if head_size % 128 != 0:
+        padded_head_size = utils.get_padded_head_dim(head_size)
+        pad_width = [(0, 0), (0, 0), (0, padded_head_size - head_size)]
+        q = jnp.pad(q,
+                    pad_width=pad_width,
+                    mode='constant',
+                    constant_values=0.0)
     ref_output = ref_ragged_paged_attention(jax_view(q),
                                             kv_cache,
                                             md.seq_lens,
@@ -174,6 +182,8 @@ def test_jax_attention(mesh, num_heads, head_size, num_kv_heads, num_tokens):
                                             md.query_start_loc,
                                             md.num_seqs,
                                             sm_scale=scale)
+    if head_size % 128 != 0:
+        ref_output = ref_output[:, :, :head_size]
     ref_output = j2t(ref_output.astype(jnp.float32)).to(dtype)
 
     torch.testing.assert_close(ref_output, jax_output, atol=1e-2, rtol=1e-5)

--- a/tpu_commons/models/vllm/jax_attention.py
+++ b/tpu_commons/models/vllm/jax_attention.py
@@ -2,12 +2,14 @@ import functools
 from typing import Optional, Tuple
 
 import jax
+import jax.numpy as jnp
 import torch
 import torch.nn
 from jax.sharding import Mesh
 from torchax.interop import jax_view, torch_view
 from vllm.attention import Attention as VllmAttention
 from vllm.model_executor.models.utils import extract_layer_index
+from vllm.utils import cdiv
 
 from tpu_commons.models.jax.attention_interface import attention
 from tpu_commons.models.jax.attention_metadata import AttentionMetadata
@@ -18,7 +20,7 @@ from tpu_commons.models.vllm.vllm_model_wrapper_context import \
 @functools.partial(
     jax.jit,
     static_argnums=(5, 6, 7, 8,
-                    9),  # mesh, scale, head_dim, num_heads, num_kv_heads
+                    9),  # mesh, scale, head_size, num_heads, num_kv_heads
     donate_argnums=(0, ),  # donate kv_cache
 )
 def _jax_attn_func(
@@ -29,7 +31,7 @@ def _jax_attn_func(
     attention_metadata: AttentionMetadata,
     mesh: Mesh,
     scale: float,
-    head_dim: int,
+    head_size: int,
     num_heads: int,
     num_kv_heads: int,
 ) -> Tuple[jax.Array, jax.Array]:
@@ -39,15 +41,32 @@ def _jax_attn_func(
     q_len, q_compute_dim = q.shape
     k_len, k_compute_dim = k.shape
     assert k.shape == v.shape
-    assert q_compute_dim == head_dim * num_heads
-    assert k_compute_dim == head_dim * num_kv_heads
+    assert q_compute_dim == head_size * num_heads
+    assert k_compute_dim == head_size * num_kv_heads
 
     # Convert the shapes from vLLM's convetion to what the attention function expects
-    # bs, num_heads, q_len, head_dim
-    q = q.reshape(q_len, num_heads, head_dim)
-    # bs, num_kv_heads, k_len, head_dim
-    k = k.reshape(k_len, num_kv_heads, head_dim)
-    v = v.reshape(k_len, num_kv_heads, head_dim)
+    # bs, num_heads, q_len, head_size
+    q = q.reshape(q_len, num_heads, head_size)
+    # bs, num_kv_heads, k_len, head_size
+    k = k.reshape(k_len, num_kv_heads, head_size)
+    v = v.reshape(k_len, num_kv_heads, head_size)
+
+    # Some models, like Phi-3, have the head_size not multiples of 128, we so pad it before the attention kernel can support them.
+    if head_size % 128 != 0:
+        padded_head_size = cdiv(head_size, 128) * 128
+        pad_width = [(0, 0), (0, 0), (0, padded_head_size - head_size)]
+        q = jnp.pad(q,
+                    pad_width=pad_width,
+                    mode='constant',
+                    constant_values=0.0)
+        k = jnp.pad(k,
+                    pad_width=pad_width,
+                    mode='constant',
+                    constant_values=0.0)
+        v = jnp.pad(v,
+                    pad_width=pad_width,
+                    mode='constant',
+                    constant_values=0.0)
 
     new_kv_cache, outputs = attention(
         kv_cache,
@@ -58,10 +77,13 @@ def _jax_attn_func(
         mesh,
     )
 
+    if head_size % 128 != 0:
+        outputs = outputs[:, :, :head_size]
+
     # Convert the shape back to vLLM's convention
     assert outputs.shape[0] == q_len
     assert outputs.shape[1] == num_heads
-    assert outputs.shape[2] == head_dim
+    assert outputs.shape[2] == head_size
     outputs = outputs.reshape(q_len, q_compute_dim)
 
     return new_kv_cache, outputs
@@ -77,7 +99,7 @@ class JaxAttention(torch.nn.Module):
         super().__init__()
 
         self.num_heads = vllm_attn.num_heads
-        self.head_dim = vllm_attn.head_size
+        self.head_size = vllm_attn.head_size
         self.scale = vllm_attn.impl.scale
         self.num_kv_heads = vllm_attn.num_kv_heads
         self.layer_idx = extract_layer_index(vllm_attn.layer_name)
@@ -98,7 +120,7 @@ class JaxAttention(torch.nn.Module):
             vllm_model_wrapper_context.kv_caches[self.layer_idx], jax_view(q),
             jax_view(k), jax_view(v),
             vllm_model_wrapper_context.attention_metadata, self.mesh,
-            self.scale, self.head_dim, self.num_heads, self.num_kv_heads)
+            self.scale, self.head_size, self.num_heads, self.num_kv_heads)
         vllm_model_wrapper_context.kv_caches[self.layer_idx] = new_kv_cache
 
         return torch_view(outputs)


### PR DESCRIPTION
# Description

Support the Phi-3 model whose head_dim==96:

1. Pad the q,k,v for attention when head_size isn't multiples of 128.
2. Avoid generating wrong tensor layout when using CPU as an intermediate copy. It happened for weight tensors whose last dim were not multiples of 128.

# Tests

unit test: `TPU_BACKEND_TYPE=jax pytest -v tests/models/vllm/test_jax_attention.py`

e2e test: `MODEL_IMPL_TYPE=vllm TPU_BACKEND_TYPE=jax python examples/offline_inference/basic/generate.py --model=microsoft/Phi-3-mini-128k-instruct --tensor_parallel_size=1 --task=generate --max_model_len=64 --max_num_seqs=1`

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have made or will make corresponding changes to any relevant documentation.
