### PR TITLE
[CI] pin libtpu to 0.0.18

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ pytest-mock
 absl-py
 numpy
 google-cloud-storage
+libtpu==0.0.18
 --pre
 --find-links https://storage.googleapis.com/jax-releases/jax_nightly_releases.html
 --find-links https://storage.googleapis.com/jax-releases/jaxlib_nightly_releases.html


### PR DESCRIPTION
# Description

As suggested by @bythew3i , we pin the libtpu version to 0.0.18 as the latest release would cause some numerical issue on some existing qwen models

cc: @xiangxu-google @kathyyu-google 

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have made or will make corresponding changes to any relevant documentation.
