### PR TITLE
Add support for Gemma3 for text-only input

### DIFF
--- a/tpu_commons/models/vllm/vllm_model_wrapper.py
+++ b/tpu_commons/models/vllm/vllm_model_wrapper.py
@@ -2,6 +2,7 @@ import copy
 import functools
 import tempfile
 from typing import Any, List, Optional, Tuple
+from unittest.mock import patch
 
 import jax
 import torch
@@ -30,15 +31,24 @@ class _VllmRunner(torch.nn.Module):
         self.vllm_model = vllm_model
 
     def forward(self, **kwargs) -> torch.Tensor:
-        if "hidden_state" in kwargs:
-            return self.compute_logits(kwargs["hidden_state"])
-        else:
-            return self.compute_hidden_state(
-                kwargs["input_ids"],
-                kwargs["positions"],
-                kwargs["intermediate_tensors"],
-                kwargs["inputs_embeds"],
-            )
+        # We don't support multimodal input in Gemma3, but we need patch it to
+        # None to workaround vLLM Gemma3 model bug that
+        # `get_multimodal_embeddings` returns empty list but it's caller checks
+        # for None.
+        with patch(
+                "vllm.model_executor.models.gemma3_mm."
+                "Gemma3ForConditionalGeneration."
+                "get_multimodal_embeddings",
+                return_value=None):
+            if "hidden_state" in kwargs:
+                return self.compute_logits(kwargs["hidden_state"])
+            else:
+                return self.compute_hidden_state(
+                    kwargs["input_ids"],
+                    kwargs["positions"],
+                    kwargs["intermediate_tensors"],
+                    kwargs["inputs_embeds"],
+                )
 
     def compute_hidden_state(
         self,


### PR DESCRIPTION
# Description

Workaround a vLLM Gemma3 model bug in checking [] vs None.

# Tests

e2e test: `MODEL_IMPL_TYPE=vllm TPU_BACKEND_TYPE=jax python examples/offline_inference/basic/generate.py --model=google/gemma-3-27b-it --tensor_parallel_size=8 --task=generate --max_model_len=64 --max_num_seqs=1`

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have made or will make corresponding changes to any relevant documentation.
