### PR TITLE
[Revert] unpin libtpu

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ pytest-mock
 absl-py
 numpy
 google-cloud-storage
-libtpu==0.0.18
 --pre
 --find-links https://storage.googleapis.com/jax-releases/jax_nightly_releases.html
 --find-links https://storage.googleapis.com/jax-releases/jaxlib_nightly_releases.html


### PR DESCRIPTION
# Description

Revert the change from #295, because the versions have already been specified in https://github.com/vllm-project/vllm/blob/main/requirements/tpu.txt#L24 as dependencies from torch_xla. 

We need to take care of the Jax and libtpu version next time we bump the torch_xla version. 

CI build: https://buildkite.com/tpu-commons/tpu-commons-ci/builds/992

cc: @bythew3i 

cc: @xiangxu-google @kathyyu-google 

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have made or will make corresponding changes to any relevant documentation.
