### PR TITLE
[TPU Worker] Fix TPU worker & runner to accommodate upstream change, also update vLLM pin

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update && apt-get install -y \
 # Build vLLM
 WORKDIR /workspace/vllm
 ARG VLLM_REPO=https://github.com/vllm-project/vllm.git
-ARG VLLM_COMMIT_SHA=a7272c23d09375515b58b213fc1599f203c6e4a7
+ARG VLLM_COMMIT_SHA=0f199f197b4e7a835ccc5b4d15363f8faa7824c8
 RUN git clone $VLLM_REPO /workspace/vllm
 RUN git reset --hard $VLLM_COMMIT_SHA
 RUN pip install -r requirements/tpu.txt

--- a/tests/runner/jax/test_tpu_jax_runner.py
+++ b/tests/runner/jax/test_tpu_jax_runner.py
@@ -47,6 +47,7 @@ class TestTPUJaxRunner(unittest.TestCase):
                 scheduler_config=scheduler_config,
                 parallel_config=parallel_config,
                 speculative_config=None,
+                prompt_adapter_config=None,
                 observability_config=None,
                 additional_config={},
             )

--- a/tpu_commons/runner/jax/tpu_jax_runner.py
+++ b/tpu_commons/runner/jax/tpu_jax_runner.py
@@ -75,6 +75,7 @@ class TPUModelRunner():
         self.parallel_config = vllm_config.parallel_config
         self.scheduler_config = vllm_config.scheduler_config
         self.speculative_config = vllm_config.speculative_config
+        self.prompt_adapter_config = vllm_config.prompt_adapter_config
         self.observability_config = vllm_config.observability_config
         self.device_config = vllm_config.device_config
         self._verify_chunked_prefill_config()


### PR DESCRIPTION
# Description

Fix TPU worker & runner to accommodate upstream change in https://github.com/vllm-project/vllm/pull/20588

`prompt_adapter_config` is removed from `VllmConfig`

# Tests

CI

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have made or will make corresponding changes to any relevant documentation.
