### PR TITLE
Fix typo in moe.py

### DIFF
--- a/tpu_commons/models/jax/common/moe/moe.py
+++ b/tpu_commons/models/jax/common/moe/moe.py
@@ -209,7 +209,7 @@ class MoE(nnx.Module):
     def generate_kernel(self, rngs: nnx.Rngs):
         """Generates the kernels (weights) for the gating, up-projection, and down-projection layers of each expert."""
         num_experts = getattr(self.cfg,
-                              HuggingFaceArgNames.NUM_LOCAL_EXPERT.value)
+                              HuggingFaceArgNames.NUM_LOCAL_EXPERTS.value)
         D = getattr(self.cfg, HuggingFaceArgNames.HIDDEN_SIZE.value)
         F = getattr(self.cfg, HuggingFaceArgNames.INTERMEDIATE_SIZE_MOE.value)
         shape_gating = (num_experts, D, F)


### PR DESCRIPTION
# Description
Typo where HuggingFaceArgNames.NUM_LOCAL_EXPERT was being used instead of HuggingFaceArgNames.NUM_LOCAL_EXPERTS.

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have made or will make corresponding changes to any relevant documentation.
