### PR TITLE
Fail Buildkite CI if code coverage is below 75%

### DIFF
--- a/.buildkite/pipeline_jax.yml
+++ b/.buildkite/pipeline_jax.yml
@@ -28,7 +28,7 @@ steps:
      commands:
        - |
          .buildkite/scripts/run_in_docker.sh \
-           python3 -m pytest -s -v /workspace/tpu_commons/tests/ --cov tpu_commons --cov-report term-missing
+           python3 -m pytest -s -v /workspace/tpu_commons/tests/ --cov tpu_commons --cov-report term-missing --cov-fail-under=75
 
    - label: "E2E MLPerf tests for JAX models with quantization"
      key: test_3

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -21,7 +21,7 @@ commands to reproduce.
 
 # Checklist
 
-Before submitting this PR, please make sure (put X in square brackets):
-- [ ] I have performed a self-review of my code.
-- [ ] I have necessary comments in my code, particularly in hard-to-understand areas.
-- [ ] I have made or will make corresponding changes to any relevant documentation.
+Before submitting this PR, please make sure:
+- I have performed a self-review of my code.
+- I have necessary comments in my code, particularly in hard-to-understand areas.
+- I have made or will make corresponding changes to any relevant documentation.


### PR DESCRIPTION
# Description

This PR will fail the Buildkite CI if the code coverage from is below 75%

# Tests

[Failed run](https://buildkite.com/tpu-commons/tpu-commons-ci/builds/1055) (set to 85% for testing)
[Successful run](https://buildkite.com/tpu-commons/tpu-commons-ci/builds/1065)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have made or will make corresponding changes to any relevant documentation.
