### PR TITLE
Add sharding to random init models

### DIFF
--- a/tpu_commons/models/jax/llama3.py
+++ b/tpu_commons/models/jax/llama3.py
@@ -31,6 +31,7 @@ class LlamaMLP(nnx.Module):
             intermediate_size,
             use_bias=False,
             param_dtype=dtype,
+            kernel_init=nnx.with_partitioning(init_fn, (None, "model")),
             rngs=rng,
         )
         self.up_proj = nnx.Linear(
@@ -38,6 +39,7 @@ class LlamaMLP(nnx.Module):
             intermediate_size,
             use_bias=False,
             param_dtype=dtype,
+            kernel_init=nnx.with_partitioning(init_fn, (None, "model")),
             rngs=rng,
         )
         self.down_proj = nnx.Linear(
@@ -45,6 +47,7 @@ class LlamaMLP(nnx.Module):
             hidden_size,
             use_bias=False,
             param_dtype=dtype,
+            kernel_init=nnx.with_partitioning(init_fn, ("model", None)),
             rngs=rng,
         )
         self.act_fn = modeling_flax_utils.ACT2FN[act]
@@ -80,24 +83,28 @@ class LlamaAttention(nnx.Module):
             "TD,DNH->TNH",
             (self.hidden_size, self.num_heads, self.head_dim),
             param_dtype=dtype,
+            kernel_init=nnx.with_partitioning(init_fn, (None, "model", None)),
             rngs=rng,
         )
         self.k_proj = nnx.Einsum(
             "TD,DKH->TKH",
             (self.hidden_size, self.num_kv_heads, self.head_dim),
             param_dtype=dtype,
+            kernel_init=nnx.with_partitioning(init_fn, (None, "model", None)),
             rngs=rng,
         )
         self.v_proj = nnx.Einsum(
             "TD,DKH->TKH",
             (self.hidden_size, self.num_kv_heads, self.head_dim),
             param_dtype=dtype,
+            kernel_init=nnx.with_partitioning(init_fn, (None, "model", None)),
             rngs=rng,
         )
         self.o_proj = nnx.Einsum(
             "TNH,NHD->TD",
             (self.num_heads, self.head_dim, self.hidden_size),
             param_dtype=dtype,
+            kernel_init=nnx.with_partitioning(init_fn, ("model", None, None)),
             rngs=rng,
         )
 
@@ -108,20 +115,16 @@ class LlamaAttention(nnx.Module):
         attention_metadata: AttentionMetadata,
     ) -> Tuple[jax.Array, jax.Array]:
         md = attention_metadata
-
         # q: (T, N, H)
         q = self.q_proj(x)
         q = apply_rope(q, md.input_positions, self.head_dim, self.rope_theta,
                        self.rope_scaling)
-
         # k: (T, K, H)
         k = self.k_proj(x)
         k = apply_rope(k, md.input_positions, self.head_dim, self.rope_theta,
                        self.rope_scaling)
-
-        # k: (T, K, H)
+        # v: (T, K, H)
         v = self.v_proj(x)
-
         # o: (T, N, H)
         new_kv_cache, outputs = attention(
             kv_cache,
@@ -132,7 +135,6 @@ class LlamaAttention(nnx.Module):
             self.mesh,
             self.head_dim,
         )
-
         # (T, D)
         o = self.o_proj(outputs)
         return new_kv_cache, o
@@ -149,6 +151,7 @@ class LlamaDecoderLayer(nnx.Module):
             hidden_size,
             epsilon=rms_norm_eps,
             param_dtype=dtype,
+            scale_init=nnx.with_partitioning(init_fn, (None, )),
             rngs=rng,
         )
         self.self_attn = LlamaAttention(config=config,
@@ -159,6 +162,7 @@ class LlamaDecoderLayer(nnx.Module):
             hidden_size,
             epsilon=rms_norm_eps,
             param_dtype=dtype,
+            scale_init=nnx.with_partitioning(init_fn, (None, )),
             rngs=rng,
         )
         self.mlp = LlamaMLP(
@@ -173,7 +177,6 @@ class LlamaDecoderLayer(nnx.Module):
         x: jax.Array,
         attention_metadata: AttentionMetadata,
     ) -> Tuple[jax.Array, jax.Array]:
-        # Self attention.
         hidden_states = self.input_layernorm(x)
         kv_cache, attn_output = self.self_attn(
             kv_cache,
@@ -182,7 +185,6 @@ class LlamaDecoderLayer(nnx.Module):
         )
         attn_output += x
 
-        # MLP.
         residual = attn_output
         attn_output = self.post_attention_layernorm(attn_output)
         outputs = self.mlp(attn_output)
@@ -212,6 +214,7 @@ class LlamaModel(nnx.Module):
             hidden_size,
             epsilon=rms_norm_eps,
             param_dtype=dtype,
+            scale_init=nnx.with_partitioning(init_fn, (None, )),
             rngs=rng,
         )
 
@@ -250,6 +253,7 @@ class LlamaForCausalLM(nnx.Module):
             num_embeddings=vocab_size,
             features=hidden_size,
             param_dtype=dtype,
+            embedding_init=nnx.with_partitioning(init_fn, ("model", None)),
             rngs=self.rng,
         )
         self.model = LlamaModel(
@@ -260,7 +264,9 @@ class LlamaForCausalLM(nnx.Module):
 
         # TODO(xiang): Llama3.2 does not use lm_head
         self.lm_head = nnx.Param(
-            init_fn(self.rng.params(), (hidden_size, vocab_size), dtype), )
+            init_fn(self.rng.params(), (hidden_size, vocab_size), dtype),
+            sharding=(None, "model"),
+        )
 
     def __call__(
         self,
@@ -269,18 +275,12 @@ class LlamaForCausalLM(nnx.Module):
         attention_metadata: AttentionMetadata,
         *args,
     ) -> Tuple[List[jax.Array], jax.Array]:
-        # input_ids: (T,)
-
-        # x: (T, D)
         x = self.embed(input_ids)
-
-        # (T, D)
         kv_caches, x = self.model(
             kv_caches,
             x,
             attention_metadata,
         )
-
         return kv_caches, x
 
     def compute_logits(self, hidden_states: jax.Array) -> jax.Array:

--- a/tpu_commons/models/jax/model_loader.py
+++ b/tpu_commons/models/jax/model_loader.py
@@ -125,15 +125,13 @@ def _get_nnx_model(
     else:
         # We first create an abstract model without allocating any weights,
         # then fill in its weigths during load_weights from HF.
-        # This shows 3 advantages than the normal way:
+        # This shows 2 advantages than the normal way:
         # 1. The model weights will only be allocated once. Otherwise the normal way
         #    will random-init the model weights first, then load the real weights.
         #    The two pass weights allocation causes model loading slow.
         # 2. The model loading won't be OOM. Otherwise the normal way will hold
         #    a full model weights after random-init, then duplicate a layer during
         #    the load_weights. This would be easy to OOM if the layer is super large.
-        # 3. The model architecture definition won't need to worry about the sharding.
-        #    The sharding definition is taken over by the load_weights instead.
         if os.getenv("NEW_MODEL_DESIGN", False):
             model = nnx.eval_shape(
                 lambda: model_class.create_model_for_checkpoint_loading(

--- a/tpu_commons/models/jax/qwen2.py
+++ b/tpu_commons/models/jax/qwen2.py
@@ -31,6 +31,7 @@ class Qwen2MLP(nnx.Module):
             intermediate_size,
             use_bias=False,
             param_dtype=dtype,
+            kernel_init=nnx.with_partitioning(init_fn, (None, "model")),
             rngs=rng,
         )
         self.up_proj = nnx.Linear(
@@ -38,6 +39,7 @@ class Qwen2MLP(nnx.Module):
             intermediate_size,
             use_bias=False,
             param_dtype=dtype,
+            kernel_init=nnx.with_partitioning(init_fn, (None, "model")),
             rngs=rng,
         )
         self.down_proj = nnx.Linear(
@@ -45,6 +47,7 @@ class Qwen2MLP(nnx.Module):
             hidden_size,
             use_bias=False,
             param_dtype=dtype,
+            kernel_init=nnx.with_partitioning(init_fn, ("model", None)),
             rngs=rng,
         )
         self.act_fn = modeling_flax_utils.ACT2FN[act]
@@ -83,6 +86,8 @@ class Qwen2Attention(nnx.Module):
             (self.hidden_size, self.num_heads, self.head_dim),
             (self.num_heads, self.head_dim),
             param_dtype=dtype,
+            kernel_init=nnx.with_partitioning(init_fn, (None, "model", None)),
+            bias_init=nnx.with_partitioning(init_fn, ("model", None)),
             rngs=rng,
         )
         self.k_proj = nnx.Einsum(
@@ -90,6 +95,8 @@ class Qwen2Attention(nnx.Module):
             (self.hidden_size, self.num_kv_heads, self.head_dim),
             (self.num_kv_heads, self.head_dim),
             param_dtype=dtype,
+            kernel_init=nnx.with_partitioning(init_fn, (None, "model", None)),
+            bias_init=nnx.with_partitioning(init_fn, ("model", None)),
             rngs=rng,
         )
         self.v_proj = nnx.Einsum(
@@ -97,12 +104,15 @@ class Qwen2Attention(nnx.Module):
             (self.hidden_size, self.num_kv_heads, self.head_dim),
             (self.num_kv_heads, self.head_dim),
             param_dtype=dtype,
+            kernel_init=nnx.with_partitioning(init_fn, (None, "model", None)),
+            bias_init=nnx.with_partitioning(init_fn, ("model", None)),
             rngs=rng,
         )
         self.o_proj = nnx.Einsum(
             "TNH,NHD->TD",
             (self.num_heads, self.head_dim, self.hidden_size),
             param_dtype=dtype,
+            kernel_init=nnx.with_partitioning(init_fn, ("model", None, None)),
             rngs=rng,
         )
 
@@ -113,20 +123,16 @@ class Qwen2Attention(nnx.Module):
         attention_metadata: AttentionMetadata,
     ) -> Tuple[jax.Array, jax.Array]:
         md = attention_metadata
-
         # q: (T, N, H)
         q = self.q_proj(x)
         q = apply_rope(q, md.input_positions, self.head_dim_original,
                        self.rope_theta, self.rope_scaling)
-
         # k: (T, K, H)
         k = self.k_proj(x)
         k = apply_rope(k, md.input_positions, self.head_dim_original,
                        self.rope_theta, self.rope_scaling)
-
-        # k: (T, K, H)
+        # v: (T, K, H)
         v = self.v_proj(x)
-
         # o: (T, N, H)
         new_kv_cache, outputs = attention(
             kv_cache,
@@ -137,7 +143,6 @@ class Qwen2Attention(nnx.Module):
             self.mesh,
             self.head_dim_original,
         )
-
         # (T, D)
         o = self.o_proj(outputs)
         return new_kv_cache, o
@@ -154,6 +159,7 @@ class Qwen2DecoderLayer(nnx.Module):
             hidden_size,
             epsilon=rms_norm_eps,
             param_dtype=dtype,
+            scale_init=nnx.with_partitioning(init_fn, (None, )),
             rngs=rng,
         )
         self.self_attn = Qwen2Attention(config=config,
@@ -164,6 +170,7 @@ class Qwen2DecoderLayer(nnx.Module):
             hidden_size,
             epsilon=rms_norm_eps,
             param_dtype=dtype,
+            scale_init=nnx.with_partitioning(init_fn, (None, )),
             rngs=rng,
         )
         self.mlp = Qwen2MLP(
@@ -178,7 +185,6 @@ class Qwen2DecoderLayer(nnx.Module):
         x: jax.Array,
         attention_metadata: AttentionMetadata,
     ) -> Tuple[jax.Array, jax.Array]:
-        # Self attention.
         hidden_states = self.input_layernorm(x)
         kv_cache, attn_output = self.self_attn(
             kv_cache,
@@ -187,7 +193,6 @@ class Qwen2DecoderLayer(nnx.Module):
         )
         attn_output += x
 
-        # MLP.
         residual = attn_output
         attn_output = self.post_attention_layernorm(attn_output)
         outputs = self.mlp(attn_output)
@@ -217,6 +222,7 @@ class Qwen2Model(nnx.Module):
             hidden_size,
             epsilon=rms_norm_eps,
             param_dtype=dtype,
+            scale_init=nnx.with_partitioning(init_fn, (None, )),
             rngs=rng,
         )
 
@@ -255,6 +261,7 @@ class Qwen2ForCausalLM(nnx.Module):
             num_embeddings=vocab_size,
             features=hidden_size,
             param_dtype=dtype,
+            embedding_init=nnx.with_partitioning(init_fn, ("model", None)),
             rngs=self.rng,
         )
         self.model = Qwen2Model(
@@ -268,7 +275,9 @@ class Qwen2ForCausalLM(nnx.Module):
             self.lm_head = self.embed.embedding
         else:
             self.lm_head = nnx.Param(
-                init_fn(self.rng.params(), (hidden_size, vocab_size), dtype), )
+                init_fn(self.rng.params(), (hidden_size, vocab_size), dtype),
+                sharding=(None, "model"),
+            )
 
     def __call__(
         self,
@@ -277,18 +286,12 @@ class Qwen2ForCausalLM(nnx.Module):
         attention_metadata: AttentionMetadata,
         *args,
     ) -> Tuple[List[jax.Array], jax.Array, jax.Array]:
-        # input_ids: (T,)
-
-        # x: (T, D)
         x = self.embed(input_ids)
-
-        # (T, D)
         kv_caches, x = self.model(
             kv_caches,
             x,
             attention_metadata,
         )
-
         return kv_caches, x
 
     def compute_logits(self, hidden_states: jax.Array) -> jax.Array:


### PR DESCRIPTION
# Description

We only did sharding for HF weights loaded models, this PR enables sharding to random init models as well.

# Tests

Local.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
