### PR TITLE
[JAX] Add support for structured decoding.

### DIFF
--- a/tests/runner/jax/test_tpu_jax_runner.py
+++ b/tests/runner/jax/test_tpu_jax_runner.py
@@ -3,13 +3,13 @@ from unittest.mock import MagicMock, patch
 
 import jax.numpy as jnp
 import numpy as np
+
+from tpu_commons.runner.jax.input_batch_jax import CachedRequestState
+from tpu_commons.runner.jax.tpu_jax_runner import TPUModelRunner
 from vllm.config import (CacheConfig, ModelConfig, ParallelConfig,
                          SchedulerConfig, VllmConfig)
 from vllm.sampling_params import SamplingType
 from vllm.v1.request import Request
-
-from tpu_commons.runner.jax.input_batch_jax import CachedRequestState
-from tpu_commons.runner.jax.tpu_jax_runner import TPUModelRunner
 
 
 class TestTPUJaxRunner(unittest.TestCase):
@@ -271,6 +271,148 @@ class TestTPUJaxRunner(unittest.TestCase):
                                             mode='constant')
             np.testing.assert_array_equal(updated_block_content,
                                           expected_padded_slice)
+
+    def test_structured_decoding(self):
+        # 1. ===== Setup =====
+        # Configure runner for the test
+        self.runner.model_config.get_vocab_size = MagicMock(return_value=64)
+        self.runner._init_inputs()  # re-initialize with new vocab size
+
+        # Mock _device_array to avoid JAX sharding issues with MagicMock mesh
+        def mock_device_array(*args, sharding=None, **kwargs):
+            # Simply return the first argument (the array) without any sharding
+            if len(args) == 1 and isinstance(args[0], tuple):
+                return args[0]  # Return tuple as is
+            elif len(args) == 1:
+                return args[0]  # Return single array as is
+            else:
+                return args  # Return all arguments as tuple
+
+        self.runner._device_array = mock_device_array
+
+        # Create a mock for sampling_params to avoid TypeErrors in add_request
+        mock_sampling_params = MagicMock()
+        mock_sampling_params.sampling_type = SamplingType.GREEDY
+        mock_sampling_params.temperature = 0.0
+        mock_sampling_params.top_p = 1.0
+        mock_sampling_params.top_k = -1
+        mock_sampling_params.min_tokens = 0
+        mock_sampling_params.logprobs = None
+        mock_sampling_params.logit_bias = None
+        mock_sampling_params.allowed_token_ids = set()
+        mock_sampling_params.bad_words_token_ids = None
+        mock_sampling_params.all_stop_token_ids = set()
+
+        # Add requests to the input batch
+        req1 = CachedRequestState(
+            req_id="req-1",
+            prompt_token_ids=[1],
+            output_token_ids=[],
+            sampling_params=mock_sampling_params,
+            block_ids=([1], ),
+            num_computed_tokens=1,
+            lora_request=None,
+            mm_inputs=[],
+            mm_hashes=[],
+            mm_positions=[],
+            pooling_params=None,
+            generator=None,
+        )
+        req2 = CachedRequestState(
+            req_id="req-2",
+            prompt_token_ids=[2],
+            output_token_ids=[],
+            sampling_params=mock_sampling_params,
+            block_ids=([2], ),
+            num_computed_tokens=1,
+            lora_request=None,
+            mm_inputs=[],
+            mm_hashes=[],
+            mm_positions=[],
+            pooling_params=None,
+            generator=None,
+        )
+        req3 = CachedRequestState(
+            req_id="req-3",
+            prompt_token_ids=[3],
+            output_token_ids=[],
+            sampling_params=mock_sampling_params,
+            block_ids=([3], ),
+            num_computed_tokens=1,
+            lora_request=None,
+            mm_inputs=[],
+            mm_hashes=[],
+            mm_positions=[],
+            pooling_params=None,
+            generator=None,
+        )
+        self.runner.input_batch.add_request(req1)  # index 0
+        self.runner.input_batch.add_request(req2)  # index 1
+        self.runner.input_batch.add_request(req3)  # index 2
+        num_reqs = 3
+
+        # Mock scheduler output for structured decoding
+        # req-1 and req-3 require structured decoding
+        mock_scheduler_output = MagicMock()
+        mock_scheduler_output.structured_output_request_ids = {
+            "req-1": 0,  # maps req_id to index in grammar_bitmask
+            "req-3": 1,
+        }
+        # Bitmask: vocab_size=64, so 2 int32s per request
+        # Mask for req-1: allow tokens 0-31
+        mask1 = np.array([-1, 0], dtype=np.int32)
+        # Mask for req-3: allow tokens 32-63
+        mask2 = np.array([0, -1], dtype=np.int32)
+        mock_scheduler_output.grammar_bitmask = np.array([mask1, mask2])
+
+        # Mock logits
+        logits_shape = (num_reqs, self.runner.vocab_size)
+        mock_logits_device = jnp.ones(logits_shape, dtype=jnp.bfloat16)
+
+        # 2. ===== Test prepare_structured_decoding_input =====
+        (require_struct_decoding, grammar_bitmask,
+         arange) = self.runner.prepare_structured_decoding_input(
+             mock_logits_device, mock_scheduler_output)
+
+        # Assertions for prepare_structured_decoding_input
+        # require_structured_out_cpu should be [True, False, True]
+        # because req-1 is at batch index 0, req-2 at 1, req-3 at 2
+        expected_require_struct = np.array([[True], [False], [True]],
+                                           dtype=np.bool_)
+        np.testing.assert_array_equal(np.array(require_struct_decoding),
+                                      expected_require_struct)
+
+        # grammar_bitmask_cpu should have mask1 at index 0, mask2 at index 2
+        expected_grammar_bitmask = np.zeros_like(
+            self.runner.grammar_bitmask_cpu[:num_reqs])
+        expected_grammar_bitmask[0] = mask1
+        expected_grammar_bitmask[2] = mask2
+        np.testing.assert_array_equal(np.array(grammar_bitmask),
+                                      expected_grammar_bitmask)
+
+        np.testing.assert_array_equal(np.array(arange),
+                                      np.arange(0, 32, dtype=np.int32))
+
+        # 3. ===== Test structured_decode_fn =====
+        # This function is jitted, so we call it with the device arrays
+        modified_logits = self.runner.structured_decode_fn(
+            require_struct_decoding, grammar_bitmask, mock_logits_device,
+            arange)
+
+        modified_logits_cpu = np.array(modified_logits)
+
+        # Assertions for structured_decode_fn
+        # Logits for req-1 (index 0) should be masked for tokens 32-63
+        self.assertTrue(np.all(modified_logits_cpu[0, :32] == 1.0))
+        self.assertTrue(np.all(modified_logits_cpu[0, 32:] == -np.inf))
+
+        # Logits for req-2 (index 1) should be unchanged
+        np.testing.assert_array_equal(modified_logits_cpu[1],
+                                      np.ones(self.runner.vocab_size))
+
+        # Logits for req-3 (index 2) should be masked for tokens 0-31
+        self.assertTrue(np.all(modified_logits_cpu[2, :32] == -np.inf))
+        self.assertTrue(np.all(modified_logits_cpu[2, 32:] == 1.0))
 
 
 if __name__ == '__main__':

--- a/tpu_commons/runner/jax/tpu_jax_runner.py
+++ b/tpu_commons/runner/jax/tpu_jax_runner.py
@@ -177,7 +177,19 @@ class TPUModelRunner():
 
         self.temperatures_cpu = np.zeros(self.max_num_tokens, dtype=np.float32)
         self.top_ps_cpu = np.zeros(self.max_num_tokens, dtype=np.float32)
-        self.top_ks_cpu = np.zeros(self.max_num_tokens, dtype=np.float32)
+        self.top_ks_cpu = np.zeros(self.max_num_tokens, dtype=np.int32)
+
+        # tensors for structured decoding
+        self.vocab_size = self.model_config.get_vocab_size()
+        self.grammar_bitmask_cpu = np.zeros(
+            (self.max_num_reqs, cdiv(self.vocab_size, 32)),
+            dtype=np.int32,
+        )
+        self.require_structured_out_cpu = np.zeros(
+            (self.max_num_reqs, 1),
+            dtype=np.bool_,
+        )
+        self.structured_decode_arange = np.arange(0, 32, dtype=np.int32)
 
     @functools.partial(jax.jit, static_argnums=(0, ))
     def select_hidden_states_fn(self, hidden_states, indices_do_sample):
@@ -390,6 +402,31 @@ class TPUModelRunner():
         self._precompile_compute_logits()
         self._precompile_sampling()
         self._precompile_gather_logprobs()
+        self._precompile_structured_decoding()
+
+    def _precompile_structured_decoding(self) -> None:
+        logger.info(
+            "Compiling structured_decoding with different input shapes.")
+        start = time.perf_counter()
+        for num_reqs in self.num_reqs_paddings:
+            dummy_logits = jnp.zeros((num_reqs, self.vocab_size),
+                                     dtype=jnp.bfloat16)
+            dummy_require_struct_decoding = self.require_structured_out_cpu[:
+                                                                            num_reqs]
+            dummy_grammar_bitmask = self.grammar_bitmask_cpu[:num_reqs]
+
+            (dummy_logits, dummy_require_struct_decoding,
+             dummy_grammar_bitmask, arange) = self._device_array(
+                 (dummy_logits, dummy_require_struct_decoding,
+                  dummy_grammar_bitmask, self.structured_decode_arange))
+
+            self.structured_decode_fn(dummy_require_struct_decoding,
+                                      dummy_grammar_bitmask, dummy_logits,
+                                      arange)
+            logger.info("  -- num_seqs: %d", num_reqs)
+
+        end = time.perf_counter()
+        logger.info("Compilation finished in %.2f [secs].", end - start)
 
     @staticmethod
     @functools.partial(jax.jit)
@@ -618,6 +655,17 @@ class TPUModelRunner():
             hidden_states = self.select_hidden_states_fn(
                 hidden_states, inputs[4])
             logits = self.compute_logits_fn(self.state, hidden_states)
+            if scheduler_output.grammar_bitmask is not None:
+                require_struct_decoding, grammar_bitmask_padded, arange = \
+                    self.prepare_structured_decoding_input(
+                        logits, scheduler_output
+                    )
+                logits = self.structured_decode_fn(
+                    require_struct_decoding,
+                    grammar_bitmask_padded,
+                    logits,
+                    arange,
+                )
             tpu_sampling_metadata = inputs[3]
             next_tokens = sample(
                 self.rng_params_for_sampling,
@@ -693,6 +741,78 @@ class TPUModelRunner():
             pooler_output=[],
         )
         return inputs[2], model_runner_output
+
+    @functools.partial(jax.jit, static_argnums=(0, ))
+    def structured_decode_fn(self, require_struct_decoding: jax.Array,
+                             grammar_bitmask: jax.Array, logits: jax.Array,
+                             arange: jax.Array) -> jax.Array:
+        return jax.lax.cond(
+            jnp.any(require_struct_decoding),
+            lambda: self._apply_grammar_bitmask_kernel(
+                logits, grammar_bitmask, require_struct_decoding, arange),
+            lambda: logits)
+
+    @functools.partial(jax.jit, static_argnums=(0, ))
+    def _apply_grammar_bitmask_kernel(self, logits: jax.Array,
+                                      grammar_bitmask: jax.Array,
+                                      require_struct_decoding: jax.Array,
+                                      arange: jax.Array) -> jax.Array:
+
+        # Unpack the bitmask for the entire batch at once.
+        # grammar_bitmask: (B, N) where B=num_reqs, N=cdiv(vocab_size, 32)
+        # arange: (32,)
+        # (B, N, 1) and (1, 1, 32) broadcast to (B, N, 32)
+        unpacked_bitmask = jnp.right_shift(grammar_bitmask[:, :, None],
+                                           arange[None, None, :]) & 1 == 0
+
+        # Reshape to (B, vocab_size) and apply to logits.
+        # (B, N * 32) -> (B, vocab_size)
+        unpacked_bitmask = unpacked_bitmask.reshape(logits.shape[0],
+                                                    -1)[:, :self.vocab_size]
+
+        masked_logits = jnp.where(unpacked_bitmask, -jnp.inf, logits)
+
+        return jnp.where(require_struct_decoding, masked_logits, logits)
+
+    def prepare_structured_decoding_input(
+        self, logits: jax.Array, scheduler_output: "VllmSchedulerOutput"
+    ) -> Tuple[jax.Array, jax.Array, jax.Array]:
+        grammar_bitmask = scheduler_output.grammar_bitmask
+        assert grammar_bitmask is not None
+        num_reqs, _ = logits.shape
+
+        # Reset pre-allocated tensors
+        self.grammar_bitmask_cpu.fill(0)
+        self.require_structured_out_cpu.fill(0)
+
+        # We receive the structured output bitmask from the scheduler, but the
+        # indices of the requests in the batch may not match the indices of
+        # the bitmask since the scheduler doesn't know how the tpu runner is
+        # ordering the requests in the batch. We need to match the order of
+        # bitmask with the order of requests
+        struct_out_indices: list[int] = []
+        mask_indices: list[int] = []
+        for req_id in self.input_batch.req_ids:
+            mask_index = scheduler_output.structured_output_request_ids.get(
+                req_id)
+            if mask_index is None:
+                continue
+            batch_index = self.input_batch.req_id_to_index[req_id]
+            struct_out_indices.append(batch_index)
+            mask_indices.append(mask_index)
+        self.grammar_bitmask_cpu[struct_out_indices] = grammar_bitmask[
+            mask_indices]
+        # It's not guaranteed that all requests in this batch require
+        # structured output, so create a bool tensor to represent
+        # the requests that need structured output.
+        self.require_structured_out_cpu[struct_out_indices] = True
+
+        require_structured_out_cpu, grammar_bitmask_cpu, structured_decode_arange = self._device_array(
+            (self.require_structured_out_cpu[:num_reqs],
+             self.grammar_bitmask_cpu[:num_reqs],
+             self.structured_decode_arange))
+
+        return require_structured_out_cpu, grammar_bitmask_cpu, structured_decode_arange
 
     # TODO(xiang): check this after implementing TPU connector
     @staticmethod


### PR DESCRIPTION
# Description

Add support for structured decoding.

# Tests

Unit tests included.

offline_inference.py:
```
sampling_params.guided_decoding = GuidedDecodingParams(choice=[
        "fantastic",
        "vague",
        "Pooya",
        "Fenghui",
        "good",
        "bad",
        "red",
        "Paris",
    ])
    prompts = [
        "Hello, my name is",
        "The capital of France is",
        "The colors of the rainbow are",
        "The future of AI is",
```

Output:

```
--------------------------------------------------
Prompt: 'Hello, my name is'
Generated text: 'Pooya'
--------------------------------------------------
Prompt: 'The capital of France is'
Generated text: 'Paris'
--------------------------------------------------
Prompt: 'The colors of the rainbow are'
Generated text: 'red'
--------------------------------------------------
Prompt: 'The future of AI is'
Generated text: 'fantastic'
--------------------------------------------------
```

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
