### PR TITLE
Remove usage of torchax `jax_device`

### DIFF
--- a/tpu_commons/models/torchax/tpu.py
+++ b/tpu_commons/models/torchax/tpu.py
@@ -6,7 +6,6 @@ import torch
 import torch.nn as nn
 import torchax
 from jax.sharding import Mesh
-from torchax import jax_device
 from vllm.config import ModelConfig, VllmConfig
 from vllm.model_executor.model_loader.default_loader import DefaultModelLoader
 from vllm.model_executor.model_loader.utils import (
@@ -72,8 +71,7 @@ class TPUModelLoader(DefaultModelLoader):
             shard_model(model, mesh)
         else:
             with torchax.default_env():
-                with jax_device('tpu'):
-                    model = model.to('jax')
+                model = model.to('jax')
         counter_after_partition = time.perf_counter()
         logger.info("Partition model took %.2f seconds",
                     counter_after_partition - counter_before_partition)


### PR DESCRIPTION
# Description

We had `jax_device('tpu')` in the code, because at some point `.to('jax')` always transfer data to CPU devices. In `torchax==0.0.5` and HEAD, `.to('jax')` will transfer to TPU by default. Therefore we don't need it anymore

Also, `torchax.jax_device` is moved to another path at HEAD, the current code would fail in our next torchax pin update. Let's just remove the usage of this API then.

# Tests

CI, offline benchmarking

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
