### PR TITLE
[CI] Bring Qwen2.5-0.5B back in CI

### DIFF
--- a/tests/e2e/benchmarking/mlperf.sh
+++ b/tests/e2e/benchmarking/mlperf.sh
@@ -220,7 +220,7 @@ for model_name in $model_list; do
     echo "Running benchmark for model: $model_name"
     echo "--------------------------------------------------"
 
-    if [ "$NEW_MODEL_DESIGN" = "True" ] && [ "$model_name" == "Qwen/Qwen2.5-1.5B-Instruct" ] || [ "$model_name" == "Qwen/Qwen2.5-0.5B-Instruct" ]; then
+    if [ "$NEW_MODEL_DESIGN" = "True" ] && { [ "$model_name" == "Qwen/Qwen2.5-1.5B-Instruct" ] || [ "$model_name" == "Qwen/Qwen2.5-0.5B-Instruct" ];}; then
        echo "Skipping $model_name for NEW_MODEL_DESIGN: True"
         continue
     fi
@@ -231,7 +231,7 @@ for model_name in $model_list; do
     fi
 
     # TODO (jacobplatin): remove when Qwen2.5 uses new model implementation
-    if [ "$QUANTIZATION" = "True" ] && [ "$model_name" == "Qwen/Qwen2.5-1.5B-Instruct" ] || [ "$model_name" == "Qwen/Qwen2.5-0.5B-Instruct" ]; then
+    if [ "$QUANTIZATION" = "True" ] && { [ "$model_name" == "Qwen/Qwen2.5-1.5B-Instruct" ] || [ "$model_name" == "Qwen/Qwen2.5-0.5B-Instruct" ];}; then
        echo "Skipping $model_name for QUANTIZATION: True"
         continue
     fi


### PR DESCRIPTION
# Description

Currently, the CI will skip Qwen2.5-0.5B even when it is in JAX path. So, we bring it back. 

cc: @xiangxu-google @kathyyu-google 

# Tests
https://screenshot.googleplex.com/3TuWAYirwCQxKjs
https://screenshot.googleplex.com/7RFLM5wYM8Fs2Po

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
