### PR TITLE
Fix OOM when using random weights with new model path

### DIFF
--- a/tpu_commons/models/jax/model_loader.py
+++ b/tpu_commons/models/jax/model_loader.py
@@ -97,7 +97,7 @@ def _get_nnx_model(
     if os.getenv("JAX_RANDOM_WEIGHTS", False):
         if os.getenv("NEW_MODEL_DESIGN", False):
 
-            @nnx.jit
+            @nnx.jit(donate_argnums=(0, ))
             def create_sharded_model(model):
                 state = nnx.state(model)
                 nnx.update(model, state)


### PR DESCRIPTION
# Description

I noticed when I ran the following command, which uses the new model implementation with random weights, I encountered an OOM:

```
JAX_RANDOM_WEIGHTS=True VLLM_XLA_CHECK_RECOMPILATION=0 NEW_MODEL_DESIGN=True   TPU_BACKEND_TYPE=jax vllm serve --model=deepseek-ai/DeepSeek-R1-Distill-Llama-70B --max_model_len=2048   --disable-log-requests --max-num-batched-tokens 2048 --max-num-seqs=256 --tensor-parallel-size 8 
```

This PR introduces a tiny fix to prevent that.

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
