### PR TITLE
Speed up model loading by multi-threading

### DIFF
--- a/tpu_commons/models/jax/utils/weight_utils.py
+++ b/tpu_commons/models/jax/utils/weight_utils.py
@@ -6,9 +6,10 @@ import glob
 import math
 import os
 import re
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, Dict, Generator, Mapping, Optional, Tuple
+from typing import Any, Dict, Generator, List, Mapping, Optional, Tuple
 
 import jax
 import jax.numpy as jnp
@@ -113,10 +114,49 @@ class WeightLoader(abc.ABC):
         raise NotImplementedError
 
 
+# TODO(xiang): deprecate this, use the multi-thread one instead.
 def hf_model_weights_iterator(
     model_name_or_path: str,
     framework: str,
 ) -> Generator[tuple, Any, None]:
+    """The old single-thread model weights loader, will be deprecated."""
+    weights_location, weights_files = get_model_weights_files(
+        model_name_or_path)
+    for weights_file in weights_files:
+        for name, weight_tensor in model_weights_generator(
+                model_name_or_path, weights_location, weights_file, framework):
+            yield name, weight_tensor
+
+
+def model_weights_generator(
+    model_name_or_path: str,
+    weights_location: str,
+    weights_file: str,
+    framework: str,
+) -> Generator[tuple, Any, None]:
+    """A generator that loads model weights from a single weights file."""
+    logger.info(f"Loading weights from {weights_file}")
+    if weights_location == "gcs":
+        weights_file = file_utils.download_model_weights_from_gcs(
+            model_name_or_path, os.path.basename(weights_file))[0]
+    elif weights_location == "hf":
+        weights_file = file_utils.download_model_weights_from_hf(
+            model_name_or_path, os.path.basename(weights_file))[0]
+    # NOTE(xiang): We enforce loading tensors on CPU here.
+    # Because otherwise the tensor will be loaded on TPU:0 by default,
+    # although the tensor would eventually be sharded across multiple TPUs,
+    # it would lead to OOM on TPU:0 for large models.
+    with jax.default_device(jax.devices("cpu")[0]):
+        with safe_open(weights_file, framework=framework) as f:
+            for name in f.keys():
+                weight_tensor = f.get_tensor(name)
+                yield name, weight_tensor
+    if weights_location != "local":
+        file_utils.delete_file(weights_file)
+
+
+def get_model_weights_files(model_name_or_path: str) -> Tuple[str, List[str]]:
+    """Download and return all local model weights files."""
     weights_files = []
     weights_location = "local"
     if os.path.isdir(model_name_or_path):
@@ -164,25 +204,7 @@ def hf_model_weights_iterator(
     # Sort to ensure the order of files is consistent.
     weights_files.sort()
 
-    for st_file in weights_files:
-        logger.info(f"Loading weights from {st_file}")
-        if weights_location == "gcs":
-            st_file = file_utils.download_model_weights_from_gcs(
-                model_name_or_path, os.path.basename(st_file))[0]
-        elif weights_location == "hf":
-            st_file = file_utils.download_model_weights_from_hf(
-                model_name_or_path, os.path.basename(st_file))[0]
-        # NOTE: We enforce loading tensors on CPU here.
-        # Because otherwise the tensor will be loaded on TPU:0 by default,
-        # although the tensor would eventually be sharded across multiple TPUs,
-        # it would lead to OOM on TPU:0 for large models.
-        with jax.default_device(jax.devices("cpu")[0]):
-            with safe_open(st_file, framework=framework) as f:
-                for name in f.keys():
-                    weight_tensor = f.get_tensor(name)
-                    yield name, weight_tensor
-        if weights_location != "local":
-            file_utils.delete_file(st_file)
+    return weights_location, weights_files
 
 
 def get_num_kv_heads_by_tp(num_kv_heads: int, tp_size: int) -> int:
@@ -249,8 +271,10 @@ def shard_put(x: jax.Array, sharding: P, mesh: jax.sharding.Mesh) -> jax.Array:
     return jax.device_put(x, sharding)
 
 
-def load_hf_weights(vllm_config, model: nnx.Module, mappings: Dict[str, str],
-                    mesh: Mesh):
+def load_hf_weights_on_thread(vllm_config, params: nnx.State,
+                              mappings: Dict[str, str], mesh: Mesh,
+                              weights_location: str, weights_file: str):
+    """Load weights from one model weights file to the model, run on single thread."""
     sharding_size = mesh.shape["model"]
     shard = functools.partial(shard_put, mesh=mesh)
 
@@ -302,11 +326,11 @@ def load_hf_weights(vllm_config, model: nnx.Module, mappings: Dict[str, str],
         "v_proj.bias": (0, sharding_size // num_kv_heads),
     }
 
-    params = nnx.state(model)
     shardings = nnx.get_named_sharding(params, mesh)
-    for hf_key, hf_weight in hf_model_weights_iterator(model_path,
-                                                       framework="flax"):
-
+    for hf_key, hf_weight in model_weights_generator(model_path,
+                                                     weights_location,
+                                                     weights_file,
+                                                     framework="flax"):
         if hf_key.endswith(".weight"):
             hf_key = hf_key.removesuffix(".weight")
 
@@ -379,6 +403,22 @@ def load_hf_weights(vllm_config, model: nnx.Module, mappings: Dict[str, str],
         # Update the model weight
         model_weight.value = shard(hf_weight, model_sharding)
 
+
+def load_hf_weights(vllm_config, model: nnx.Module, mappings: Dict[str, str],
+                    mesh: Mesh):
+    """Load weights from all model weights files to the model, run in multi threads."""
+    model_path = vllm_config.model_config.model
+    weights_location, weights_files = get_model_weights_files(model_path)
+    params = nnx.state(model)
+    max_workers = min(64, len(weights_files))
+    with ThreadPoolExecutor(max_workers=max_workers) as executor:
+        futures = [
+            executor.submit(load_hf_weights_on_thread, vllm_config, params,
+                            mappings, mesh, weights_location, weights_file)
+            for weights_file in weights_files
+        ]
+        for future in futures:
+            future.result()
     nnx.update(model, params)
 
 


### PR DESCRIPTION
# Description

Speed up model loading time by N-X, N is the number of model weights files.

For example:
Llama-3.1 70B model loading time:
W/O this PR: ~15min
W/ this PR: ~0.5min

# Tests

Local

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
