### PR TITLE
Revert jax version bump to fix CI

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,5 +13,3 @@ jaxtyping
 flax
 torchax==0.0.5
 qwix @ git+https://github.com/google/qwix@main
-jax==0.7.0
-libtpu==0.0.19


### PR DESCRIPTION
# Description

This [PR](https://github.com/vllm-project/tpu_commons/pull/341/files#diff-4d7c51b1efe9043e44439a949dfd92e5827321b34082903477fd04876edb7552) upgraded JAX and libtpu version, caused all tests broken https://buildkite.com/tpu-commons/tpu-commons-ci/builds/1183 .

Reverting it first, need to fix the version bump issue later.

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
