### PR TITLE
Adds the log rate limitng.

### DIFF
--- a/tpu_commons/utils.py
+++ b/tpu_commons/utils.py
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
+import logging
 import os
+import time
 from collections import defaultdict
 from typing import Any, List, Tuple
 
@@ -99,3 +101,18 @@ def get_padded_num_heads(num_heads: int, sharding_size: int) -> int:
         assert sharding_size % num_heads == 0
         num_heads = sharding_size
     return num_heads
+
+
+class RateLimitFilter(logging.Filter):
+
+    def __init__(self, name='', interval=60):
+        super().__init__(name)
+        self.interval = interval
+        self.last_logged = 0
+
+    def filter(self, record):
+        now = time.monotonic()
+        if now - self.last_logged >= self.interval:
+            self.last_logged = now
+            return True
+        return False

--- a/tpu_commons/worker/_temporary_vllm_compat.py
+++ b/tpu_commons/worker/_temporary_vllm_compat.py
@@ -57,6 +57,7 @@ from vllm.lora.request import LoRARequest as VllmLoRARequest
 from vllm.v1.core.sched.output import SchedulerOutput as VllmSchedulerOutput
 from vllm.v1.kv_cache_interface import KVCacheConfig as VllmKVCacheConfig
 
+from tpu_commons import utils
 from tpu_commons.adapters.vllm_adapters import (VllmKVCacheConfigAdapter,
                                                 VllmLoRARequestAdapter,
                                                 VllmSchedulerOutputAdapter)
@@ -65,6 +66,8 @@ from tpu_commons.di.abstracts import (AbstractKVCacheConfig,
                                       AbstractSchedulerOutput)
 
 logger = logging.getLogger(__name__)
+rate_limit_filter = utils.RateLimitFilter(interval=60)
+logger.addFilter(rate_limit_filter)
 
 
 def adapt_scheduler_output_if_needed(


### PR DESCRIPTION
The current run is overwhelmed by these warning messages. Adds the rate limiting filter so that we can control the freq. Defaults to 60 seconds. Ideally we probably should switch to another more sophisticated logging library. Stick to the current one for now.

# Tests

Manually tested.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
