### PR TITLE
minor fix in insert logic

### DIFF
--- a/tpu_commons/runner/jax/tpu_jax_runner.py
+++ b/tpu_commons/runner/jax/tpu_jax_runner.py
@@ -601,7 +601,7 @@ class TPUModelRunner():
         # in the cache.
         max_num_blocks = self.vllm_config.cache_config.num_gpu_blocks
         assert max_num_blocks is not None and max_num_blocks != 0
-        block_numbers.extend([max_num_blocks + 1] * padding_size)
+        block_numbers.extend([0] * padding_size)
 
         padded_block_numbers = jnp.array(block_numbers, dtype=jnp.int32)
 


### PR DESCRIPTION
# Description

block indices are used to compute offset after inserted into block table, so the indices cannot be set to a oob value. After fixing this the e2e is able to run. 

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
