### PR TITLE
Follow closer to the prod code on when to use torchax env in tests.

### DIFF
--- a/tests/models/vllm/test_jax_attention.py
+++ b/tests/models/vllm/test_jax_attention.py
@@ -5,7 +5,7 @@ import torch
 import torchax
 import utils as test_utils
 from jax.sharding import NamedSharding, PartitionSpec
-from torchax.interop import jax_view, torch_view
+from torchax.interop import torch_view
 from torchax.ops.mappings import j2t, t2j, t2j_dtype
 from vllm.attention import Attention as VllmAttention
 from vllm.config import set_current_vllm_config
@@ -20,14 +20,6 @@ from tpu_commons.models.vllm.vllm_model_wrapper_context import (
     get_vllm_model_wrapper_context, set_vllm_model_wrapper_context)
 
 P = PartitionSpec
-
-
-@pytest.fixture(scope="module", autouse=True)
-def setup_torchax():
-    """Enable torchax globally before all tests, disable after all tests."""
-    torchax.enable_globally()
-    yield
-    torchax.disable_globally()
 
 
 def generate_attention_metadata(num_tokens, mesh) -> AttentionMetadata:
@@ -122,7 +114,6 @@ def test_jax_attention(mesh, num_heads, head_size, num_kv_heads, num_tokens):
             num_kv_heads=num_kv_heads,
             prefix="test_jax_attention.layer.0",
         )
-    jax_attention = JaxAttention(attention, mesh=mesh)
 
     scale = float(1.0 / (head_size**0.5))
     qkv = torch.empty(num_tokens,
@@ -132,36 +123,40 @@ def test_jax_attention(mesh, num_heads, head_size, num_kv_heads, num_tokens):
     qkv.uniform_(-scale, scale)
     q, k, v = qkv.split([num_heads, num_kv_heads, num_kv_heads], dim=1)
 
-    q = torch_view(t2j(q))
-    q.apply_jax_(jax.device_put, NamedSharding(mesh, P(None, None)))
-    k = torch_view(t2j(k))
-    k.apply_jax_(jax.device_put, NamedSharding(mesh, P(None, None)))
-    v = torch_view(t2j(v))
-    v.apply_jax_(jax.device_put, NamedSharding(mesh, P(None, None)))
+    # reshape q,k,v into vLLM convention
+    vllm_q = q.view(num_tokens, num_heads * head_size)
+    vllm_k = k.view(num_tokens, num_kv_heads * head_size)
+    vllm_v = v.view(num_tokens, num_kv_heads * head_size)
+
+    # Set jax default device to workaround a layout bug in JAX 0.7.0 and earlier
+    with torchax.default_env(), jax.default_device(jax.devices("tpu")[0]):
+        jax_attention = JaxAttention(attention, mesh=mesh)
+        vllm_q = torch_view(t2j(vllm_q))
+        vllm_q.apply_jax_(jax.device_put, NamedSharding(mesh, P()))
+        vllm_k = torch_view(t2j(vllm_k))
+        vllm_k.apply_jax_(jax.device_put, NamedSharding(mesh, P()))
+        vllm_v = torch_view(t2j(vllm_v))
+        vllm_v.apply_jax_(jax.device_put, NamedSharding(mesh, P()))
+        q = t2j(q)
+        q = jax.device_put(q, NamedSharding(mesh, P()))
 
     md = generate_attention_metadata(num_tokens, mesh)
     kv_caches = generate_kv_caches(num_kv_heads, head_size, mesh, dtype)
 
-    with set_vllm_model_wrapper_context(
+    with torchax.default_env(), set_vllm_model_wrapper_context(
             kv_caches=kv_caches,
             attention_metadata=md,
     ):
-        # reshape q,k,v into vLLM convention
-        vllm_q = q.view(num_tokens, num_heads * head_size)
-        vllm_k = k.view(num_tokens, num_kv_heads * head_size)
-        vllm_v = v.view(num_tokens, num_kv_heads * head_size)
-
         jax_output = jax_attention(vllm_q, vllm_k, vllm_v)
 
         # reshape from vLLM convention
         jax_output = jax_output.view(num_tokens, num_heads, head_size)
+        # j2t() doens't support bfloat16, so we cast it into float32 as an intermedate step.
+        jax_output = j2t(jax_output.to(torch.float32)).to(dtype)
 
         # the above jax_attetion call also updates the kv cache
         vllm_model_wrapper_context = get_vllm_model_wrapper_context()
         kv_cache = vllm_model_wrapper_context.kv_caches[0]
-
-    # j2t() doens't support bfloat16, so we cast it into float32 as an intermedate step.
-    jax_output = j2t(jax_output.to(torch.float32)).to(dtype)
 
     if head_size % 128 != 0:
         padded_head_size = utils.get_padded_head_dim(head_size)
@@ -170,7 +165,7 @@ def test_jax_attention(mesh, num_heads, head_size, num_kv_heads, num_tokens):
                     pad_width=pad_width,
                     mode='constant',
                     constant_values=0.0)
-    ref_output = ref_ragged_paged_attention(jax_view(q),
+    ref_output = ref_ragged_paged_attention(q,
                                             kv_cache,
                                             md.seq_lens,
                                             md.block_tables,

--- a/tests/models/vllm/test_jax_merged_column_parallel_linear.py
+++ b/tests/models/vllm/test_jax_merged_column_parallel_linear.py
@@ -74,7 +74,8 @@ def test_jax_merged_column_parallel_linear(bias, mesh):
     input_tensor = input_tensor.to('cpu')
     output = merged_column_linear(input_tensor).to(dtype)
 
-    with jax.default_device(jax.devices("tpu")[0]), torchax.default_env():
+    # Set jax default device to workaround a layout bug in JAX 0.7.0 and earlier
+    with torchax.default_env(), jax.default_device(jax.devices("tpu")[0]):
         jax_merged_column_linear = JaxMergedColumnParallelLinear(
             merged_column_linear, mesh=mesh)
         jax_input_tensor = torch_view(t2j(input_tensor))
@@ -126,7 +127,8 @@ def test_jax_merged_column_parallel_linear_w8a8_int8(bias, mesh):
             new=test_utils.quantized_matmul_ref):
         output = merged_column_linear(input_tensor).to(dtype)
 
-    with jax.default_device(jax.devices("tpu")[0]), torchax.default_env():
+    # Set jax default device to workaround a layout bug in JAX 0.7.0 and earlier
+    with torchax.default_env(), jax.default_device(jax.devices("tpu")[0]):
         jax_merged_column_linear = JaxMergedColumnParallelLinear(
             merged_column_linear, mesh=mesh)
         jax_input_tensor = torch_view(t2j(input_tensor))

--- a/tests/models/vllm/test_jax_qkv_parallel_linear.py
+++ b/tests/models/vllm/test_jax_qkv_parallel_linear.py
@@ -74,7 +74,8 @@ def test_jax_qkv_parallel_linear(bias, mesh):
     input_tensor = input_tensor.to('cpu')
     output = qkv_linear(input_tensor).to(dtype)
 
-    with jax.default_device(jax.devices("tpu")[0]), torchax.default_env():
+    # Set jax default device to workaround a layout bug in JAX 0.7.0 and earlier
+    with torchax.default_env(), jax.default_device(jax.devices("tpu")[0]):
         jax_qkv_linear = JaxQKVParallelLinear(qkv_linear, mesh=mesh)
         jax_input_tensor = torch_view(t2j(input_tensor, use_dlpack=False))
         jax_input_tensor.apply_jax_(jax.device_put,
@@ -125,7 +126,8 @@ def test_jax_qkv_parallel_linear_w8a8_int8(bias, mesh):
             new=test_utils.quantized_matmul_ref):
         output = qkv_linear(input_tensor).to(dtype)
 
-    with jax.default_device(jax.devices("tpu")[0]), torchax.default_env():
+    # Set jax default device to workaround a layout bug in JAX 0.7.0 and earlier
+    with torchax.default_env(), jax.default_device(jax.devices("tpu")[0]):
         jax_qkv_linear = JaxQKVParallelLinear(qkv_linear, mesh=mesh)
         jax_input_tensor = torch_view(t2j(input_tensor, use_dlpack=False))
         jax_input_tensor.apply_jax_(jax.device_put,

--- a/tests/models/vllm/test_jax_row_parallel_linear.py
+++ b/tests/models/vllm/test_jax_row_parallel_linear.py
@@ -72,7 +72,8 @@ def test_jax_row_parallel_linear(bias, mesh):
     input_tensor = input_tensor.to('cpu')
     output = row_linear(input_tensor).to(dtype)
 
-    with jax.default_device(jax.devices("tpu")[0]), torchax.default_env():
+    # Set jax default device to workaround a layout bug in JAX 0.7.0 and earlier
+    with torchax.default_env(), jax.default_device(jax.devices("tpu")[0]):
         jax_row_linear = JaxRowParallelLinear(row_linear, mesh=mesh)
         jax_input_tensor = torch_view(t2j(input_tensor, use_dlpack=False))
         jax_input_tensor.apply_jax_(jax.device_put,
@@ -121,7 +122,8 @@ def test_jax_row_parallel_linear_w8a8_int8(bias, mesh):
             new=test_utils.quantized_matmul_ref):
         output = row_linear(input_tensor).to(dtype)
 
-    with jax.default_device(jax.devices("tpu")[0]), torchax.default_env():
+    # Set jax default device to workaround a layout bug in JAX 0.7.0 and earlier
+    with torchax.default_env(), jax.default_device(jax.devices("tpu")[0]):
         jax_row_linear = JaxRowParallelLinear(row_linear, mesh=mesh)
         jax_input_tensor = torch_view(t2j(input_tensor, use_dlpack=False))
         jax_input_tensor.apply_jax_(jax.device_put,


### PR DESCRIPTION
# Description

As the title says.

# Tests

Unit test: `TPU_BACKEND_TYPE=jax pytest -v tests/models/vllm/`

# Checklist

Before submitting this PR, please make sure:
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have made or will make corresponding changes to any relevant documentation.
