### PR TITLE
[Kernel] optimize kv cache update kernel block size

### DIFF
--- a/tests/models/vllm/test_pallas_torchax.py
+++ b/tests/models/vllm/test_pallas_torchax.py
@@ -6,8 +6,8 @@ from vllm.attention.backends.abstract import AttentionType
 from vllm.config import ModelConfig, SchedulerConfig, VllmConfig
 
 from tpu_commons.attention.backends.pallas_torchax import (
-    NUM_SLICES_PER_KV_CACHE_UPDATE_BLOCK, PallasAttentionBackend,
-    PallasAttentionBackendImpl, PallasMetadata, write_to_kv_cache)
+    PallasAttentionBackend, PallasAttentionBackendImpl, PallasMetadata,
+    write_to_kv_cache)
 
 
 class TestPallasMetadata:
@@ -480,8 +480,6 @@ def test_write_to_kv_cache(mock_kv_cache_update, mock_call_jax):
     args, kwargs = mock_call_jax.call_args
     assert args[0] == mock_kv_cache_update
     assert kwargs['page_size'] == 16
-    assert kwargs[
-        'num_slices_per_block'] == NUM_SLICES_PER_KV_CACHE_UPDATE_BLOCK
 
 
 def test_write_to_kv_cache_tensor_shapes():

--- a/tests/worker/test_tpu_worker_torchax.py
+++ b/tests/worker/test_tpu_worker_torchax.py
@@ -261,8 +261,7 @@ class TestTPUWorker:
         else:
             mock_report_usage_stats.assert_not_called()
 
-    @patch('tpu_commons.worker.tpu_worker_torchax.TPU_HEAD_SIZE_ALIGNMENT',
-           128)
+    @patch('tpu_commons.utils.TPU_HEAD_SIZE_ALIGNMENT', 128)
     @patch('tpu_commons.worker.tpu_worker_torchax.jax')
     @patch('tpu_commons.worker.tpu_worker_torchax.logger')
     @pytest.mark.parametrize(

--- a/tpu_commons/models/torchax/torchax_wrapper.py
+++ b/tpu_commons/models/torchax/torchax_wrapper.py
@@ -199,7 +199,7 @@ def _kv_cache_update(
     num_slices: jax.Array,  # [1]
     *,
     page_size: int = 32,
-    num_slices_per_block: int = 8,
+    num_slices_per_block: int = None,
 ) -> Array:
     # TODO: Get rid of this wrapper and call from pallas.py directly. Need to
     #       find a better way to get mesh in pallas.py.

--- a/tpu_commons/runner/jax/tpu_jax_runner.py
+++ b/tpu_commons/runner/jax/tpu_jax_runner.py
@@ -47,8 +47,6 @@ logger = init_logger(__name__)
 INVALID_TOKEN_ID = -1
 # Smallest output size
 MIN_NUM_SEQS = 8
-# Block size used for kv cache updating kernel
-NUM_SLICES_PER_KV_CACHE_UPDATE_BLOCK = 8
 
 DUMMY_METADATA = AttentionMetadata(
     input_positions=[],
@@ -1192,8 +1190,4 @@ def _get_padded_num_kv_cache_update_slices(num_tokens: int, max_num_reqs: int,
     recompilation."""
     padded_num_slices = 2 * max_num_reqs + num_tokens // page_size
     padded_num_slices = min(padded_num_slices, num_tokens)
-    padded_num_slices = (
-        padded_num_slices + NUM_SLICES_PER_KV_CACHE_UPDATE_BLOCK - 1
-    ) // NUM_SLICES_PER_KV_CACHE_UPDATE_BLOCK * \
-        NUM_SLICES_PER_KV_CACHE_UPDATE_BLOCK
     return padded_num_slices

--- a/tpu_commons/runner/tpu_torchax_runner.py
+++ b/tpu_commons/runner/tpu_torchax_runner.py
@@ -46,8 +46,7 @@ from vllm.utils import (STR_DTYPE_TO_TORCH_DTYPE, LayerBlockType, cdiv,
                         is_pin_memory_available)
 
 from tpu_commons.attention.backends.pallas_torchax import (
-    PallasAttentionBackend, PallasMetadata,
-    NUM_SLICES_PER_KV_CACHE_UPDATE_BLOCK)
+    PallasAttentionBackend, PallasMetadata)
 
 from vllm.v1.kv_cache_interface import (AttentionSpec, FullAttentionSpec,
                                         KVCacheConfig, KVCacheSpec,
@@ -1108,8 +1107,4 @@ def _get_padded_num_kv_cache_update_slices(num_tokens: int, max_num_reqs: int,
     recompilation."""
     padded_num_slices = 2 * max_num_reqs + num_tokens // page_size
     padded_num_slices = min(padded_num_slices, num_tokens)
-    padded_num_slices = (
-        padded_num_slices + NUM_SLICES_PER_KV_CACHE_UPDATE_BLOCK - 1
-    ) // NUM_SLICES_PER_KV_CACHE_UPDATE_BLOCK * \
-        NUM_SLICES_PER_KV_CACHE_UPDATE_BLOCK
     return padded_num_slices

--- a/tpu_commons/utils.py
+++ b/tpu_commons/utils.py
@@ -4,11 +4,13 @@ from collections import defaultdict
 from typing import Any, List, Tuple
 
 import jax
-
-from tpu_commons.logger import init_logger
+from jax._src import dtypes
 from vllm import envs
 
+from tpu_commons.logger import init_logger
+
 GBYTES = 1024 * 1024 * 1024
+TPU_HEAD_SIZE_ALIGNMENT = 128
 
 _megacore = False
 logger = init_logger(__name__)
@@ -99,3 +101,8 @@ def get_padded_num_heads(num_heads: int, sharding_size: int) -> int:
         assert sharding_size % num_heads == 0
         num_heads = sharding_size
     return num_heads
+
+
+def get_dtype_packing(dtype):
+    bits = dtypes.bit_width(dtype)
+    return 32 // bits

--- a/tpu_commons/worker/tpu_worker_torchax.py
+++ b/tpu_commons/worker/tpu_worker_torchax.py
@@ -21,7 +21,6 @@ from vllm.distributed import (ensure_model_parallel_initialized,
                               init_distributed_environment)
 from vllm.model_executor import set_random_seed
 from vllm.utils import STR_DTYPE_TO_TORCH_DTYPE, cdiv
-from vllm.v1.attention.backends.pallas import TPU_HEAD_SIZE_ALIGNMENT
 from vllm.v1.core.sched.output import SchedulerOutput
 from vllm.v1.kv_cache_interface import KVCacheConfig, KVCacheSpec
 from vllm.v1.outputs import ModelRunnerOutput
@@ -40,6 +39,7 @@ from tpu_commons.worker.base import AbstractTpuWorker
 from tpu_commons.worker._temporary_vllm_compat import (
     adapt_kv_cache_config_if_needed, adapt_scheduler_output_if_needed,
     adapt_lora_request_if_needed)
+from tpu_commons.utils import TPU_HEAD_SIZE_ALIGNMENT
 
 logger = init_logger(__name__)
 


### PR DESCRIPTION
# Description

- Automatically adjust kv cache update kernel's num_slices_per_block, porting from https://github.com/vllm-project/vllm/pull/20415 and https://github.com/vllm-project/vllm/pull/21007
- change RPA kernel's vmem_limit_bytes to 100MB to avoid vmem OOM issue

# Tests

1. pytest -s -v tests/kernels/ragged_kv_cache_update_test.py
2. server: TPU_BACKEND_TYPE=torchax VLLM_TORCHAX_ENABLED=1 vllm serve meta-llama/Llama-3.1-8B-Instruct --disable-log-requests --gpu-memory-utilization 0.98 --max-num-batched-tokens 2048 --max-num-seqs 128 --max-model-len 2048 --no-enable-prefix-caching --tensor_parallel_size=1 
client: python3 ./benchmarks/benchmark_serving.py --model meta-llama/Llama-3.1-8B-Instruct --dataset-name sonnet --dataset-path benchmarks/sonnet_4x.txt --sonnet-input-len 1800 --sonnet-output-len 128 --ignore_eos

We can observe the throughput increases from 8.11 req/s to 8.14 req/s.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
