### PR TITLE
Update MLA module during Deepseek's actual implementation

### DIFF
--- a/tpu_commons/models/jax/common/attention/deepseek_v3_attention.py
+++ b/tpu_commons/models/jax/common/attention/deepseek_v3_attention.py
@@ -14,6 +14,7 @@ from tpu_commons.models.jax.common.attention.attention import (Attention,
                                                                KVCache)
 from tpu_commons.models.jax.common.base import Config, ParamFactory
 from tpu_commons.models.jax.common.constants import HuggingFaceArgNames
+from tpu_commons.models.jax.common.layers import RMSNorm
 from tpu_commons.models.jax.common.rope import DeepseekScalingRotaryEmbedding
 from tpu_commons.models.jax.common.sharding import ShardingConfig
 
@@ -105,6 +106,18 @@ class MLA(Attention):
 
         self.create_sharding()
 
+        self.rope = DeepseekScalingRotaryEmbedding(
+            self.qk_rope_head_dim,
+            self.rope_theta,
+            self.rope_scaling["original_max_position_embeddings"],
+            self.rope_scaling["factor"],
+            self.dtype,
+            beta_fast=self.rope_scaling["beta_fast"],
+            beta_slow=self.rope_scaling["beta_slow"],
+            mscale=self.rope_scaling["mscale"],
+            mscale_all_dim=self.rope_scaling["mscale_all_dim"],
+        )
+
     def generate_kernel(self, rngs: nnx.Rngs):
         """Initializes the weight kernels."""
 
@@ -133,29 +146,27 @@ class MLA(Attention):
         self.kernel_o_proj_NHD = self.param_factory.create_kernel_param(
             rngs, (self.N, self.v_head_dim, self.D), self.nhd_sharding,
             self.cfg.dtype)
-        self.q_rms_norm = nnx.RMSNorm(
-            self.query_lora_rank,
+        self.q_rms_norm = RMSNorm(
+            dims=self.query_lora_rank,
+            mesh=self.mesh,
+            param_factory=self.param_factory,
+            sharding_cfg=self.sharding_cfg,
             epsilon=self.rms_norm_eps,
-            param_dtype=self.dtype,
-            rngs=rngs,
+            with_scale=True,
+            dtype=self.dtype,
         )
-        self.kv_rms_norm = nnx.RMSNorm(
-            self.kv_lora_rank,
+        self.q_rms_norm.generate_kernel(rngs)
+
+        self.kv_rms_norm = RMSNorm(
+            dims=self.kv_lora_rank,
+            mesh=self.mesh,
+            param_factory=self.param_factory,
+            sharding_cfg=self.sharding_cfg,
             epsilon=self.rms_norm_eps,
-            param_dtype=self.dtype,
-            rngs=rngs,
+            with_scale=True,
+            dtype=self.dtype,
         )
-        self.rope = DeepseekScalingRotaryEmbedding(
-            self.qk_rope_head_dim,
-            self.rope_theta,
-            self.rope_scaling["original_max_position_embeddings"],
-            self.rope_scaling["factor"],
-            self.dtype,
-            beta_fast=self.rope_scaling["beta_fast"],
-            beta_slow=self.rope_scaling["beta_slow"],
-            mscale=self.rope_scaling["mscale"],
-            mscale_all_dim=self.rope_scaling["mscale_all_dim"],
-        )
+        self.kv_rms_norm.generate_kernel(rngs)
 
     def __call__(
         self,


### PR DESCRIPTION
# Description

Update MLA module during Deepseek's actual implementation. This pr is split from #293 for small pr practice. 
- Move rope into `__post_init__` as it's a fixed component of the module.
- Use RMSNorm custom layer instead of nnx.RMSNorm to be able to pass in weights later.
# Tests

- test_deepseek_v3_attention passed
- E2E deepseek model test passed

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
