### PR TITLE
Use numpy instead of jnp to calculate rope cache

### DIFF
--- a/tpu_commons/models/jax/common/rope.py
+++ b/tpu_commons/models/jax/common/rope.py
@@ -1,6 +1,7 @@
 import math
 
 import jax
+import numpy as np
 from jax import numpy as jnp
 
 
@@ -14,31 +15,27 @@ class RotaryEmbedding:
         self.rotary_dim = rotary_dim
         self.rope_theta = rope_theta
         self.original_max_position_embeddings = original_max_position_embeddings
-        self.sin_cos_cache = self._compute_sin_cos()
         self.dtype = dtype
+        self.sin_cos_cache = self._compute_sin_cos()
 
     def _compute_inv_freq(self):
-        fractions = jnp.arange(0, self.rotary_dim, 2,
-                               dtype=jnp.float32) / self.rotary_dim
+        fractions = np.arange(0, self.rotary_dim, 2,
+                              dtype=np.float32) / self.rotary_dim
         inv_freq = 1.0 / (self.rope_theta**fractions)
         return inv_freq
 
     def _compute_sin_cos(self):
         inv_freq = self._compute_inv_freq()
-        t = jnp.arange(self.original_max_position_embeddings,
-                       dtype=jnp.float32)
+        t = np.arange(self.original_max_position_embeddings, dtype=np.float32)
 
-        freqs = jnp.einsum("...T,k->...Tk",
-                           t,
-                           inv_freq,
-                           precision=jax.lax.Precision.HIGHEST)
-        sin, cos = jnp.sin(freqs), jnp.cos(freqs)
-        cache = jnp.concatenate((cos, sin), axis=-1)
+        freqs = np.einsum("...T,k->...Tk", t, inv_freq)
+        sin, cos = np.sin(freqs), np.cos(freqs)
+        cache = np.concatenate((cos, sin), axis=-1)
         return cache
 
     def apply_rope(self, positions: jax.Array, x_TNH: jax.Array):
         assert x_TNH.ndim == 3
-        cos_sin = self.sin_cos_cache[positions]
+        cos_sin = jnp.asarray(self.sin_cos_cache)[positions]
         # cos, sin: (T, H/2)
         cos, sin = jnp.split(cos_sin, 2, axis=-1)
         assert sin.ndim == 2 and cos.ndim == 2
@@ -83,8 +80,8 @@ class DeepseekScalingRotaryEmbedding(RotaryEmbedding):
                          original_max_position_embeddings, dtype)
 
     def _compute_inv_freq(self):
-        fractions = jnp.arange(0, self.rotary_dim, 2,
-                               dtype=jnp.float32) / self.rotary_dim
+        fractions = np.arange(0, self.rotary_dim, 2,
+                              dtype=np.float32) / self.rotary_dim
         inv_freq_extrapolation = 1.0 / (self.rope_theta**fractions)
         inv_freq_interpolation = 1.0 / (self.scaling_factor *
                                         self.rope_theta**fractions)
@@ -94,24 +91,24 @@ class DeepseekScalingRotaryEmbedding(RotaryEmbedding):
 
         # Get n-d rotational scaling corrected for extrapolation
         inv_freq_mask = 1 - _yarn_linear_ramp_mask(
-            low, high, self.rotary_dim // 2).astype(jnp.float32)
+            low, high, self.rotary_dim // 2).astype(np.float32)
         inv_freq = inv_freq_interpolation * (
             1 - inv_freq_mask) + inv_freq_extrapolation * inv_freq_mask
         return inv_freq
 
     def _compute_sin_cos(self):
         inv_freq = self._compute_inv_freq()
-        t = jnp.arange(self.original_max_position_embeddings *
-                       self.scaling_factor,
-                       dtype=jnp.float32)
-        freqs = jnp.einsum("...T,k->...Tk", t, inv_freq)
-        sin, cos = jnp.sin(freqs) * self.mscale, jnp.cos(freqs) * self.mscale
-        cache = jnp.concatenate((cos, sin), axis=-1)
+        t = np.arange(self.original_max_position_embeddings *
+                      self.scaling_factor,
+                      dtype=np.float32)
+        freqs = np.einsum("...T,k->...Tk", t, inv_freq)
+        sin, cos = np.sin(freqs) * self.mscale, np.cos(freqs) * self.mscale
+        cache = np.concatenate((cos, sin), axis=-1)
         return cache
 
     def apply_rope(self, positions: jax.Array, x_TNH: jax.Array):
         assert x_TNH.ndim == 3
-        cos_sin = self.sin_cos_cache[positions]
+        cos_sin = jnp.asarray(self.sin_cos_cache)[positions]
         # cos, sin: (T, H/2)
         cos, sin = jnp.split(cos_sin, 2, axis=-1)
         assert sin.ndim == 2 and cos.ndim == 2
@@ -127,7 +124,7 @@ class DeepseekScalingRotaryEmbedding(RotaryEmbedding):
 # Calculates the temperature scaling factor for YaRN to adjust
 # RoPE embedding magnitudes.
 def _yarn_get_mscale(scale, mscale):
-    return jnp.where(scale <= 1, 1.0, 0.1 * mscale * jnp.log(scale) + 1.0)
+    return np.where(scale <= 1, 1.0, 0.1 * mscale * np.log(scale) + 1.0)
 
 
 # Inverses dim formula to find dim based on number of rotations.
@@ -159,6 +156,6 @@ def _yarn_linear_ramp_mask(min, max, dim):
     if min == max:
         max += 0.001  # Prevent singularity
 
-    linear_func = (jnp.arange(dim, dtype=jnp.float32) - min) / (max - min)
-    ramp_func = jnp.clip(linear_func, 0, 1)
+    linear_func = (np.arange(dim, dtype=np.float32) - min) / (max - min)
+    ramp_func = np.clip(linear_func, 0, 1)
     return ramp_func


### PR DESCRIPTION
# Description

Use numpy instead of jnp to calculate rope cache. This is part of #293  following small pr practices.

The model_loader uses [nnx.eval_shape](https://github.com/vllm-project/tpu_commons/blob/main/tpu_commons/models/jax/model_loader.py#L136) to trace the shapes and dtypes of the model without actually allocating memory for them. If using jnp in compute_sin_cos(), the result will be a tracer which can't be assigned to an object attribute (self.sin_cos_cache) and will cause `jax.errors.UnexpectedTracerError: Encountered an unexpected tracer. A function transformed by JAX had a side effect, allowing for a reference to an intermediate value with type float32[163840,64] wrapped in a DynamicJaxprTracer to escape the scope of the transformation.` error. 

By switching to numpy, the cache is a numpy array, and will be converted to jnp when it needs to be indexed inside `apply_rope`.

# Tests

- test_rope.py passed
- Deepseek E2E run passed

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
