### PR TITLE
Update the constructor of to properly initialize the input ZMQ communication channel

### DIFF
--- a/tpu_commons/core/core_tpu.py
+++ b/tpu_commons/core/core_tpu.py
@@ -199,13 +199,6 @@ class DisaggEngineCoreProc(vLLMEngineCoreProc):
             daemon=True)
         self.output_thread.start()
 
-        self.output_thread = threading.Thread(
-            target=self.process_output_sockets,
-            args=(addresses.outputs, addresses.coordinator_output,
-                  self.engine_index),
-            daemon=True)
-        self.output_thread.start()
-
         # Don't complete handshake until DP coordinator ready message is
         # received.
         while not ready_event.wait(timeout=10):


### PR DESCRIPTION
Update the constructor of  to properly initialize the ZMQ communication channel, mirroring the logic in vLLM's .

# Description

https://github.com/vllm-project/vllm/pull/21538 added a ready_event to the `EngineCoreProc`'s `input_thread`.

# Tests

`pytest`

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
