### PR TITLE
Exposes the model state in torchax runner.

### DIFF
--- a/tpu_commons/runner/tpu_torchax_runner.py
+++ b/tpu_commons/runner/tpu_torchax_runner.py
@@ -10,6 +10,7 @@ import time
 from typing import TYPE_CHECKING, Optional, cast
 from unittest.mock import patch
 
+from flax import nnx
 import numpy as np
 import torch
 import torch.nn as nn
@@ -820,6 +821,9 @@ class TPUModelRunner(LoRAModelRunnerMixin):
 
         if not hasattr(self, "model"):
             self.model = model
+
+        if not hasattr(self, "state"):
+            self.state = nnx.state(model)
 
     @torch.no_grad()
     def _dummy_run(self, num_tokens: int) -> None:


### PR DESCRIPTION
Expose the model state so that RL can sync the weights to the underlying model.

# Tests

Manually run the test. Minor fixes.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
