### PR TITLE
fix disagg test

### DIFF
--- a/tests/core/test_core_tpu.py
+++ b/tests/core/test_core_tpu.py
@@ -202,7 +202,7 @@ class TestDisaggEngineCoreProc(unittest.TestCase):
         self.assertIsInstance(output, EngineCoreOutputs)
         self.assertIsInstance(output.utility_output, UtilityOutput)
         self.assertEqual(output.utility_output.call_id, "call-id-1")
-        self.assertEqual(output.utility_output.result, {1, 2, 3})
+        self.assertEqual(output.utility_output.result.result, {1, 2, 3})
 
     def test_prefill_logic(self):
         """Tests the core logic of the _prefill method for one iteration."""


### PR DESCRIPTION
# Description

In https://github.com/vllm-project/tpu_commons/pull/403, `UtilityOutput.result` is wrapped with `UtilityResult` from `vllm.v1.engine`

# Tests

unit test

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
