### PR TITLE
Fix precompile backbone error

### DIFF
--- a/tpu_commons/runner/jax/tpu_jax_runner.py
+++ b/tpu_commons/runner/jax/tpu_jax_runner.py
@@ -275,8 +275,9 @@ class TPUModelRunner():
                                             dtype=np.int32)
             block_tables = self.block_table_cpu[:self.max_num_reqs]
             seq_lens = np.ones((self.max_num_reqs, ), dtype=np.int32)
-            query_start_loc = np.ones((self.max_num_reqs + 1, ),
-                                      dtype=np.int32)
+            query_start_loc = np.cumsum(np.array([0] +
+                                                 [1] * self.max_num_reqs),
+                                        dtype=np.int32)
             num_seqs = np.array([self.max_num_reqs], dtype=np.int32)
             num_slices = np.array([1], dtype=np.int32)
 


### PR DESCRIPTION
# Description
Fix an error in precompile backbone
```
jaxlib._jax.XlaRuntimeError: INTERNAL: Core halted unexpectedly: INTERNAL: Accelerator device halted prematurely, perhaps due to an on-device check-failure. Node 0 halted unexpectedly at tag:pc TensorCoreSequencer:20:0xa (from TensorCoreSequencer:20:0x13a): Semaphore (scratch argument 3) has a nonzero value upon exit from a Mosaic kernel. Make sure every DMA is awaited, and every semaphore signal is paired with a wait. HLO: RPA-bq_16-bkvp_16-p_64.4; HLO computation: main.1119_spmd
```
The error shows it happens in `RPA-bq_16-bkvp_16-p_64.4` kernel. The dummy input `query_start_loc` should be an increasing array instead of all one. 


# Tests

- test_tpu_jax_runner passed
- Ran precompiled backbone on deepseek with num_tokens = 16 passed

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
