### PR TITLE
Log TPU info when import tpu_commons

### DIFF
--- a/tests/test_tpu_info.py
+++ b/tests/test_tpu_info.py
@@ -1,0 +1,120 @@
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from tpu_commons.tpu_info import (get_node_name, get_node_worker_id,
+                                  get_num_chips, get_num_cores_per_chip,
+                                  get_tpu_metadata, get_tpu_type)
+
+
+# Mock requests.get for get_tpu_metadata tests
+@patch("tpu_commons.tpu_info.requests.get")
+def test_get_tpu_metadata_success(mock_get):
+    """Test get_tpu_metadata when the request is successful."""
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.text = "test_metadata_value"
+    mock_get.return_value = mock_response
+    assert get_tpu_metadata(key="test-key") == "test_metadata_value"
+
+
+@patch("tpu_commons.tpu_info.requests.get")
+def test_get_tpu_metadata_request_error(mock_get):
+    """Test get_tpu_metadata when a RequestException is raised."""
+    mock_get.side_effect = requests.RequestException("Test RequestException")
+    assert get_tpu_metadata(key="test-key") is None
+
+
+# Test get_tpu_type
+@patch("tpu_commons.tpu_info.get_tpu_metadata")
+@patch.dict(os.environ, {"TPU_ACCELERATOR_TYPE": "env_tpu_type"})
+def test_get_tpu_type_from_env(mock_get_tpu_metadata):
+    """Test get_tpu_type when TPU_ACCELERATOR_TYPE is set in environment."""
+    # The function should return the env var value and not call get_tpu_metadata
+    assert get_tpu_type() == "env_tpu_type"
+    mock_get_tpu_metadata.assert_not_called()
+
+
+@patch.dict(os.environ, {}, clear=True)
+@patch("tpu_commons.tpu_info.get_tpu_metadata",
+       return_value="metadata_tpu_type")
+def test_get_tpu_type_from_metadata(mock_get_tpu_metadata):
+    """Test get_tpu_type when environment variable is not set."""
+    assert get_tpu_type() == "metadata_tpu_type"
+    mock_get_tpu_metadata.assert_called_once_with(key="accelerator-type")
+
+
+# Test get_node_name
+@patch("tpu_commons.tpu_info.get_tpu_metadata")
+@patch.dict(os.environ, {"TPU_NAME": "env_tpu_name"})
+def test_get_node_name_from_env(mock_get_tpu_metadata):
+    """Test get_node_name when TPU_NAME is set in environment."""
+    assert get_node_name() == "env_tpu_name"
+    mock_get_tpu_metadata.assert_not_called()
+
+
+@patch.dict(os.environ, {}, clear=True)
+@patch("tpu_commons.tpu_info.get_tpu_metadata",
+       return_value="metadata_tpu_name")
+def test_get_node_name_from_metadata(mock_get_tpu_metadata):
+    """Test get_node_name when environment variable is not set."""
+    assert get_node_name() == "metadata_tpu_name"
+    mock_get_tpu_metadata.assert_called_once_with(key="instance-id")
+
+
+# Test get_node_worker_id
+@patch("tpu_commons.tpu_info.get_tpu_metadata")
+@patch.dict(os.environ, {"TPU_WORKER_ID": "5"})
+def test_get_node_worker_id_from_env(mock_get_tpu_metadata):
+    """Test get_node_worker_id when TPU_WORKER_ID is set in environment."""
+    assert get_node_worker_id() == 5
+    mock_get_tpu_metadata.assert_not_called()
+
+
+@patch.dict(os.environ, {}, clear=True)
+@patch("tpu_commons.tpu_info.get_tpu_metadata", return_value="10")
+def test_get_node_worker_id_from_metadata(mock_get_tpu_metadata):
+    """Test get_node_worker_id when environment variable is not set."""
+    assert get_node_worker_id() == 10
+    mock_get_tpu_metadata.assert_called_once_with(key="agent-worker-number")
+
+
+# Test get_num_cores_per_chip
+@pytest.mark.parametrize(
+    "tpu_type, expected",
+    [
+        ("v5litepod-4", 1),
+        ("v6e-8", 1),
+        ("v4-8", 2),
+        ("v5p-16", 2),
+        ("unknown-type", 2)  # Default case
+    ])
+@patch("tpu_commons.tpu_info.get_tpu_type")
+def test_get_num_cores_per_chip(mock_get_tpu_type, tpu_type, expected):
+    """Test get_num_cores_per_chip with different TPU types."""
+    mock_get_tpu_type.return_value = tpu_type
+    assert get_num_cores_per_chip() == expected
+
+
+# Test get_num_chips
+@patch("tpu_commons.tpu_info.glob.glob",
+       return_value=["/dev/accel0", "/dev/accel1"])
+def test_get_num_chips_from_accel(mock_glob):
+    """Test get_num_chips when /dev/accel* files exist."""
+    assert get_num_chips() == 2
+
+
+@patch("tpu_commons.tpu_info.glob.glob", return_value=[])
+@patch("tpu_commons.tpu_info.os.listdir", return_value=["0", "1", "2"])
+def test_get_num_chips_from_vfio(mock_listdir, mock_glob):
+    """Test get_num_chips when /dev/accel* files don't exist but /dev/vfio entries do."""
+    assert get_num_chips() == 3
+
+
+@patch("tpu_commons.tpu_info.glob.glob", return_value=[])
+@patch("tpu_commons.tpu_info.os.listdir", side_effect=FileNotFoundError)
+def test_get_num_chips_not_found(mock_listdir, mock_glob, caplog):
+    """Test get_num_chips when neither files nor directory are found."""
+    assert get_num_chips() == 0

--- a/tpu_commons/__init__.py
+++ b/tpu_commons/__init__.py
@@ -1,5 +1,9 @@
 import os
-import warnings
+
+from tpu_commons import tpu_info as ti
+from tpu_commons.logger import init_logger
+
+logger = init_logger(__name__)
 
 # The warning message to be displayed to the user
 PROD_WARNING = (
@@ -7,14 +11,20 @@ PROD_WARNING = (
     "and NOT intended for production use yet. Please see the README for more details."
 )
 
-warnings.warn(PROD_WARNING, UserWarning, stacklevel=2)
+logger.warn(PROD_WARNING)
+
+logger.info(f"TPU info: node_name={ti.get_node_name()} | "
+            f"tpu_type={ti.get_tpu_type()} | "
+            f"worker_id={ti.get_node_worker_id()} | "
+            f"num_chips={ti.get_num_chips()} | "
+            f"num_cores_per_chip={ti.get_num_cores_per_chip()}")
 
 # Must run pathwaysutils.initialize() before any JAX operations.
 if "proxy" in os.environ.get('JAX_PLATFORMS', '').lower():
     import pathwaysutils
     pathwaysutils.initialize()
-    print("Running vLLM with Pathways. "
-          "Module pathwaysutils is imported.")
+    logger.info("Running vLLM with Pathways. "
+                "Module pathwaysutils is imported.")
 else:
-    print("Running vLLM without Pathways. "
-          "Module pathwaysutils is not imported.")
+    logger.info("Running vLLM without Pathways. "
+                "Module pathwaysutils is not imported.")

--- a/tpu_commons/platforms/tpu_jax.py
+++ b/tpu_commons/platforms/tpu_jax.py
@@ -68,7 +68,6 @@ class TpuPlatform(Platform):
 
     @classmethod
     def get_device_name(cls, device_id: int = 0) -> str:
-        logger.info(jax.lib.xla_bridge.get_backend().platform_version)
         try:
             if envs.VLLM_TPU_USING_PATHWAYS:
                 return jax.local_devices()[0].device_kind

--- a/tpu_commons/tpu_info.py
+++ b/tpu_commons/tpu_info.py
@@ -1,0 +1,77 @@
+import glob
+import os
+
+import requests
+
+from tpu_commons.logger import init_logger
+
+logger = init_logger(__name__)
+
+GCE_TPU_ACCELERATOR_ENDPOINT = (
+    "http://metadata.google.internal/computeMetadata/v1/instance/attributes/")
+GCE_TPU_HEADERS = {"Metadata-Flavor": "Google"}
+
+
+def get_tpu_metadata(key: str = "") -> str:
+    try:
+        accelerator_type_request = requests.get(
+            os.path.join(GCE_TPU_ACCELERATOR_ENDPOINT, key),
+            headers=GCE_TPU_HEADERS,
+        )
+        if (accelerator_type_request.status_code == 200
+                and accelerator_type_request.text):
+            return accelerator_type_request.text
+        else:
+            logger.error(
+                "Unable to poll TPU GCE Metadata. Got "
+                f"status code: {accelerator_type_request.status_code} and "
+                f"content: {accelerator_type_request.text}")
+    except requests.RequestException as e:
+        logger.error("Unable to poll the TPU GCE Metadata: %s", e)
+    return None
+
+
+def get_tpu_type() -> str:
+    tpu_type = os.getenv("TPU_ACCELERATOR_TYPE", None)
+    if tpu_type is None:
+        tpu_type = get_tpu_metadata(key="accelerator-type")
+    return tpu_type
+
+
+def get_node_name() -> str:
+    tpu_name = os.getenv("TPU_NAME", None)
+    if not tpu_name:
+        tpu_name = get_tpu_metadata(key="instance-id")
+    return tpu_name
+
+
+def get_node_worker_id() -> int:
+    """For multi-host TPU VM, this returns the worker id for the current node."""
+    worker_id = os.getenv("TPU_WORKER_ID", None)
+    if worker_id is None:
+        worker_id = get_tpu_metadata(key="agent-worker-number")
+    if worker_id is None:
+        return 0
+    return int(worker_id)
+
+
+def get_num_cores_per_chip() -> int:
+    tpu_type = get_tpu_type()
+    if tpu_type.startswith(("v5litepod", "v6e")):
+        return 1
+    return 2
+
+
+def get_num_chips() -> int:
+    accel_files = glob.glob("/dev/accel*")
+    if accel_files:
+        return len(accel_files)
+    try:
+        vfio_entries = os.listdir("/dev/vfio")
+        numeric_entries = [
+            int(entry) for entry in vfio_entries if entry.isdigit()
+        ]
+        return len(numeric_entries)
+    except FileNotFoundError as e:
+        logger.error("Failed to detect number of TPUs: %s", e)
+        return 0


### PR DESCRIPTION
# Description

Print the TPU meta info at the beginning using stateless methods.

And remove `logger.info(jax.lib.xla_bridge.get_backend().platform_version)` in tpu_jax.py to fix the hanging issue on v5e. This API is a stateful call and can't be called before running JAX on v5e.

# Tests

Local

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
