### PR TITLE
Tightening the TransformerBlock interface.

### DIFF
--- a/tests/models/jax/common/test_transformer_block.py
+++ b/tests/models/jax/common/test_transformer_block.py
@@ -5,8 +5,8 @@ import jax.numpy as jnp
 
 from tpu_commons.models.jax.common.attention.attention import AttentionConfig
 from tpu_commons.models.jax.common.layers import DenseFFWConfig
-from tpu_commons.models.jax.common.moe.moe import (MoEConfig, RouterConfig,
-                                                   RouterType)
+from tpu_commons.models.jax.common.moe.moe import (MoE, MoEConfig,
+                                                   RouterConfig, RouterType)
 from tpu_commons.models.jax.common.sharding import ShardingConfig
 from tpu_commons.models.jax.common.transformer_block import (
     SharedExpertsTransformerBlock, SharedExpertsTransformerBlockConfig,
@@ -68,14 +68,19 @@ class TestTransformerBlock(unittest.TestCase):
         mock_mlp = MagicMock()
         dummy_mlp_output = jnp.full((64, hidden_size), 3.0, dtype=jnp.bfloat16)
         mock_mlp.return_value = dummy_mlp_output
-        mock_create_module.side_effect = [mock_attn, mock_mlp]
+        mock_create_module.side_effect = [mock_attn]
 
         transformer_block = TransformerBlock(
             cfg=transformer_config,
-            block_type="dense",
             param_factory=None,
             mesh=None,
             sharding_cfg=ShardingConfig(),
+            custom_module=mock_mlp,
+            # The custom_module is passed directly to the TransformerBlock
+            # in the test setup, so we need to ensure it's initialized
+            # with a mock that matches the expected behavior of a DenseFFW
+            # or MoE module. In this case, mock_mlp is already set up
+            # to return dummy_mlp_output.
         )
 
         seq_len = 64
@@ -189,7 +194,7 @@ class TestTransformerBlock(unittest.TestCase):
         dummy_kv_cache = jnp.zeros((8, 16, 16, 128), dtype=jnp.bfloat16)
         mock_attn.return_value = (dummy_kv_cache, dummy_attn_output)
 
-        mock_moe = MagicMock()
+        mock_moe = MagicMock(spec=MoE)
         dummy_moe_output = jnp.full((64, hidden_size), 3.0, dtype=jnp.bfloat16)
         mock_moe.return_value = dummy_moe_output
 
@@ -198,16 +203,14 @@ class TestTransformerBlock(unittest.TestCase):
                                                4.0,
                                                dtype=jnp.bfloat16)
         mock_shared_experts.return_value = dummy_shared_experts_output
-        mock_create_module.side_effect = [
-            mock_attn, mock_moe, mock_shared_experts
-        ]
+        mock_create_module.side_effect = [mock_attn, mock_shared_experts]
 
         transformer_block = SharedExpertsTransformerBlock(
             cfg=shared_config,
-            block_type="moe",  # Assuming MoE block type for this test
             param_factory=MagicMock(),
             mesh=MagicMock(),
             sharding_cfg=MagicMock(),
+            custom_module=mock_moe,
         )
 
         seq_len = 64
@@ -228,9 +231,9 @@ class TestTransformerBlock(unittest.TestCase):
         self.assertEqual(final_output.shape, (seq_len, hidden_size))
 
         # Basic check that the moe and shared experts are used.
-        self.assertTrue(mock_moe.call_count == 1)
-        self.assertTrue(mock_attn.call_count == 1)
-        self.assertTrue(mock_shared_experts.call_count == 1)
+        self.assertEqual(mock_moe.call_count, 1)
+        self.assertEqual(mock_attn.call_count, 1)
+        self.assertEqual(mock_shared_experts.call_count, 1)
 
 
 if __name__ == "__main__":

--- a/tpu_commons/models/jax/common/transformer_block.py
+++ b/tpu_commons/models/jax/common/transformer_block.py
@@ -38,12 +38,14 @@ TransformerBlockConfig.__doc__ = f"""light weighted transformer config, which in
 class TransformerBlock(nnx.Module):
     """
     A heavy weight module which serves as the stateful live blocks in serving
+
+    custom_module can be eitehr a dense module (i.e., DenseFFW) or MoE.
     """
     cfg: TransformerBlockConfig
-    block_type: str
     param_factory: ParamFactory
     mesh: Mesh
     sharding_cfg: ShardingConfig
+    custom_module: nnx.Module
     attention_cls: type[Attention] = Attention
     use_attention_rope: bool = True
     quant: Any | None = None
@@ -70,11 +72,6 @@ class TransformerBlock(nnx.Module):
         except NameError:
             raise NameError(
                 f"Invalid attention class type: {self.attention_cls}")
-
-        if self.block_type == "moe":
-            self.moe = self._create_module(MoE, cfg=self.cfg.moe)
-        elif self.block_type == "dense":
-            self.mlp = self._create_module(DenseFFW, cfg=self.cfg.dense_ffw)
 
         self.pre_attention_norm = RMSNorm(
             dims=hidden_size,
@@ -113,21 +110,13 @@ class TransformerBlock(nnx.Module):
         # FFW Block
         ffw_residual_TD = attn_output_TD
         normed_ffw_input_TD = self.pre_mlp_norm(attn_output_TD)
-        if self.block_type == "moe":
-            logits_TD = self.moe(normed_ffw_input_TD, op_mode)
-        elif self.block_type == "dense":
-            logits_TD = self.mlp(normed_ffw_input_TD, op_mode)
-        else:
-            raise ValueError(f"Invalid block type: {self.block_type}")
+        logits_TD = self.custom_module(normed_ffw_input_TD, op_mode)
         logits_TD += ffw_residual_TD
         return new_cache, logits_TD
 
     def generate_kernel(self, rngs: nnx.Rngs):
         self.attn.generate_kernel(rngs)
-        if self.block_type == "moe":
-            self.moe.generate_kernel(rngs)
-        else:
-            self.mlp.generate_kernel(rngs)
+        self.custom_module.generate_kernel(rngs)
         self.pre_attention_norm.generate_kernel(rngs)
         self.pre_mlp_norm.generate_kernel(rngs)
 
@@ -180,16 +169,17 @@ class SharedExpertsTransformerBlock(TransformerBlock):
         # FFW Block
         ffw_residual_TD = attn_output_TD
         normed_ffw_input_TD = self.pre_mlp_norm(attn_output_TD)
-        if self.block_type == "moe":
-            logits_TD = self.moe(normed_ffw_input_TD, op_mode)
+        if isinstance(self.custom_module, MoE):
+            logits_TD = self.custom_module(normed_ffw_input_TD, op_mode)
             # Add the shared expert outputs to the MoE outputs.
             shared_expert_output_TD = self.shared_experts(
                 normed_ffw_input_TD, op_mode)
             logits_TD += shared_expert_output_TD
-        elif self.block_type == "dense":
-            logits_TD = self.mlp(normed_ffw_input_TD, op_mode)
+        elif isinstance(self.custom_module, DenseFFW):
+            logits_TD = self.custom_module(normed_ffw_input_TD, op_mode)
         else:
-            raise ValueError(f"Invalid block type: {self.block_type}")
+            raise ValueError(
+                f"Invalid custom moduel type: {type(self.custom_module)}")
         logits_TD += ffw_residual_TD
         return new_cache, logits_TD
 

--- a/tpu_commons/models/jax/recipes/deepseek_v3.py
+++ b/tpu_commons/models/jax/recipes/deepseek_v3.py
@@ -17,12 +17,12 @@ from tpu_commons.models.jax.common.attention.deepseek_v3_attention import (
     MLA, MLAConfig)
 from tpu_commons.models.jax.common.base import ParamFactory
 from tpu_commons.models.jax.common.constants import KVCacheType
-from tpu_commons.models.jax.common.layers import (DenseFFWConfig, Embedder,
-                                                  LMhead, RMSNorm)
+from tpu_commons.models.jax.common.layers import (DenseFFW, DenseFFWConfig,
+                                                  Embedder, LMhead, RMSNorm)
 from tpu_commons.models.jax.common.model import Model
 from tpu_commons.models.jax.common.moe.deepseek_moe import \
     DeepSeekV3RoutingConfig
-from tpu_commons.models.jax.common.moe.moe import MoEConfig
+from tpu_commons.models.jax.common.moe.moe import MoE, MoEConfig
 from tpu_commons.models.jax.common.sharding import (ATTN_HEAD_AXIS_NAME,
                                                     ATTN_TENSOR_AXIS_NAME,
                                                     Sharding,
@@ -208,8 +208,12 @@ class DeepSeekV3(Model):
 
         for i in range(first_k_dense_replace):
             block = TransformerBlock(cfg=layer_config,
-                                     block_type="dense",
                                      attention_cls=MLA,
+                                     custom_module=DenseFFW(
+                                         cfg=layer_config.dense_ffw,
+                                         mesh=self.mesh,
+                                         param_factory=self.param_factory,
+                                         sharding_cfg=self._sharding_config),
                                      param_factory=self.param_factory,
                                      mesh=self.mesh,
                                      sharding_cfg=self._sharding_config)
@@ -217,10 +221,18 @@ class DeepSeekV3(Model):
 
         for i in range(first_k_dense_replace, num_layers):
             is_moe_layer = ((i + 1) % interleave_moe_layer_step == 0)
-            block_type = "moe" if is_moe_layer else "dense"
+            custom_module = MoE(cfg=layer_config.moe,
+                                mesh=self.mesh,
+                                param_factory=self.param_factory,
+                                sharding_cfg=self._sharding_config
+                                ) if is_moe_layer else DenseFFW(
+                                    cfg=layer_config.dense_ffw,
+                                    mesh=self.mesh,
+                                    param_factory=self.param_factory,
+                                    sharding_cfg=self._sharding_config)
             block = SharedExpertsTransformerBlock(
                 cfg=layer_config,
-                block_type=block_type,
+                custom_module=custom_module,
                 attention_cls=MLA,
                 param_factory=self.param_factory,
                 mesh=self.mesh,

--- a/tpu_commons/models/jax/recipes/llama3.py
+++ b/tpu_commons/models/jax/recipes/llama3.py
@@ -17,8 +17,8 @@ from tpu_commons.models.jax.common.attention.attention import (
     AttentionConfig, AttentionMetadata)
 from tpu_commons.models.jax.common.base import ParamFactory
 from tpu_commons.models.jax.common.constants import KVCacheType
-from tpu_commons.models.jax.common.layers import (DenseFFWConfig, Embedder,
-                                                  LMhead, RMSNorm)
+from tpu_commons.models.jax.common.layers import (DenseFFW, DenseFFWConfig,
+                                                  Embedder, LMhead, RMSNorm)
 from tpu_commons.models.jax.common.model import Model
 from tpu_commons.models.jax.common.sharding import (Sharding,
                                                     ShardingRulesConfig)
@@ -127,10 +127,14 @@ class LlamaForCausalLM(Model):
 
         self.layers = [
             TransformerBlock(cfg=layer_config,
-                             block_type="dense",
                              param_factory=self.param_factory,
                              mesh=self.mesh,
-                             sharding_cfg=sharding_config)
+                             sharding_cfg=sharding_config,
+                             custom_module=DenseFFW(
+                                 cfg=layer_config.dense_ffw,
+                                 mesh=self.mesh,
+                                 param_factory=self.param_factory,
+                                 sharding_cfg=sharding_config))
             for _ in range(num_layers)
         ]
         for i in range(len(self.layers)):

--- a/tpu_commons/models/jax/recipes/llama4.py
+++ b/tpu_commons/models/jax/recipes/llama4.py
@@ -16,10 +16,10 @@ from tpu_commons.models.jax.common.attention.llama4_attention import (
     Llama4Attention, Llama4AttentionConfig)
 from tpu_commons.models.jax.common.base import ParamFactory
 from tpu_commons.models.jax.common.constants import KVCacheType, RouterType
-from tpu_commons.models.jax.common.layers import (DenseFFWConfig, Embedder,
-                                                  LMhead, RMSNorm)
+from tpu_commons.models.jax.common.layers import (DenseFFW, DenseFFWConfig,
+                                                  Embedder, LMhead, RMSNorm)
 from tpu_commons.models.jax.common.model import Model
-from tpu_commons.models.jax.common.moe.moe import MoEConfig, RouterConfig
+from tpu_commons.models.jax.common.moe.moe import MoE, MoEConfig, RouterConfig
 from tpu_commons.models.jax.common.sharding import (Sharding,
                                                     ShardingRulesConfig)
 from tpu_commons.models.jax.common.transformer_block import (
@@ -150,7 +150,6 @@ class Llama4ForCausalLM(Model):
             is_moe_layer = (i + 1) % \
                             self.interleave_moe_layer_step == 0
             use_attention_rope = (i + 1) % self.no_rope_layer_interval != 0
-            block_type = "moe" if is_moe_layer else "dense"
             block_cfg_nope = layer_config
             # RoPE layers do not use chunked attention
             block_cfg_rope = replace(
@@ -159,9 +158,18 @@ class Llama4ForCausalLM(Model):
                                   attention_chunk_size=None),
             )
             block_cfg = block_cfg_rope if use_attention_rope else block_cfg_nope
+            custom_module = MoE(cfg=layer_config.moe,
+                                mesh=self.mesh,
+                                param_factory=self.param_factory,
+                                sharding_cfg=self._sharding_config
+                                ) if is_moe_layer else DenseFFW(
+                                    cfg=layer_config.dense_ffw,
+                                    mesh=self.mesh,
+                                    param_factory=self.param_factory,
+                                    sharding_cfg=self._sharding_config)
             block = SharedExpertsTransformerBlock(
                 cfg=block_cfg,
-                block_type=block_type,
+                custom_module=custom_module,
                 attention_cls=Llama4Attention,
                 use_attention_rope=use_attention_rope,
                 param_factory=self.param_factory,


### PR DESCRIPTION
# Description

Rationale:
- using a str block_type to determine the actual module is fragile and error prone.
- Checking it at runtime also incurs a tiny bit of cpu cycle loss.

There is still a type check in SharedExpertsTransformerBlock.__call__, which I will deal with later.

# Tests

unit tests.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
