### PR TITLE
[GitHub Workflow] Disable repeated messages

### DIFF
--- a/.github/workflows/pre-PR.yml
+++ b/.github/workflows/pre-PR.yml
@@ -2,7 +2,7 @@ name: Apply Conditional PR Template
 
 on:
   pull_request:
-    types: [opened, reopened, synchronize]
+    types: [opened, reopened]
 
 jobs:
   apply-template:


### PR DESCRIPTION
# Description

Currently gitaction bot will send out the comments every time you add more commits. resulting long repeated message. Now fix it to only comment at the beginning, similar as what vLLM is doing. https://github.com/vllm-project/vllm/pull/22392#issuecomment-3161568817

CC: @xiangxu-google  @kathyyu-google @gpolovets1 


# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
