### PR TITLE
Fix the MM logic for torchax gemma3

### DIFF
--- a/tpu_commons/runner/jax/tpu_jax_runner.py
+++ b/tpu_commons/runner/jax/tpu_jax_runner.py
@@ -24,7 +24,6 @@ from vllm.multimodal.utils import group_mm_inputs_by_modality
 from vllm.sequence import IntermediateTensors
 from vllm.tasks import SupportedTask
 from vllm.utils import cdiv
-from vllm.v1.core.encoder_cache_manager import compute_encoder_budget
 from vllm.v1.core.sched.output import SchedulerOutput as VllmSchedulerOutput
 from vllm.v1.kv_cache_interface import (FullAttentionSpec, KVCacheConfig,
                                         KVCacheSpec)
@@ -95,13 +94,6 @@ class TPUModelRunner(KVConnectorModelRunnerMixin):
         self.is_multimodal_model = None  # Will get updated once the model is loaded.
         self.mm_registry = MULTIMODAL_REGISTRY
         self.uses_mrope = self.model_config.uses_mrope
-        encoder_compute_budget, encoder_cache_size = compute_encoder_budget(
-            model_config=self.model_config,
-            scheduler_config=self.scheduler_config,
-            mm_registry=self.mm_registry,
-        )
-        self.max_num_encoder_input_tokens = encoder_compute_budget
-        self.encoder_cache_size = encoder_cache_size
 
         self._init_random()
         self._init_mesh()


### PR DESCRIPTION
# Description

Gemma 3 in the torchax path only supports text mode for now, but the model_config from hf still claims it's a MM model. In any case, if the model loader returns a None `get_input_embeddings_fn` value, it shouldn't be called.

Also removes some unused code.

# Tests

Unit test: `pytest -v tests/runner/jax/test_tpu_jax_runner.py::TestTPUJaxRunnerMultimodalModelLoadedForTextOnly::test_is_multimodal_model`

E2e test: `MODEL_IMPL_TYPE=vllm python examples/offline_inference.py --model=google/gemma-3-27b-it --tensor_parallel_size=8 --task=generate --max_model_len=1024`

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
