### PR TITLE
Update get_attn_backend_cls signature to match vLLM repo.

### DIFF
--- a/tpu_commons/platforms/tpu_jax.py
+++ b/tpu_commons/platforms/tpu_jax.py
@@ -53,8 +53,8 @@ class TpuPlatform(Platform):
     @classmethod
     def get_attn_backend_cls(cls, selected_backend: _Backend, head_size: int,
                              dtype: jnp.dtype, kv_cache_dtype: Optional[str],
-                             block_size: int, use_v1: bool,
-                             use_mla: bool) -> str:
+                             block_size: int, use_v1: bool, use_mla: bool,
+                             has_sink: bool) -> str:
         if (selected_backend != _Backend.PALLAS
                 and selected_backend != _Backend.PALLAS_VLLM_V1):
             logger.info("Cannot use %s backend on TPU.", selected_backend)


### PR DESCRIPTION
# Description

vLLM added a new param `has_sink`

# Tests

Unit test: `pytest -v tests/ --ignore=tests/kernels/` passed except what's already failed in recent CI: https://buildkite.com/tpu-commons/tpu-commons-ci/builds/1636

E2e test: taking a random torchax model and it passed, before all models were failing: `MODEL_IMPL_TYPE=vllm python examples/offline_inference.py --model=RedHatAI/Meta-Llama-3.1-8B-Instruct-quantized.w8a8 --tensor_parallel_size=1 --task=generate --max_model_len=1024`

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
