### PR TITLE
Simplify param creation logic in the JAX code path.

### DIFF
--- a/tests/models/jax/common/attention/test_attention.py
+++ b/tests/models/jax/common/attention/test_attention.py
@@ -10,7 +10,6 @@ from jax.sharding import PartitionSpec as P
 
 from tpu_commons.models.jax.attention_metadata import AttentionMetadata
 from tpu_commons.models.jax.common.attention.attention import Attention
-from tpu_commons.models.jax.common.base import ParamFactory
 
 KVCache = Tuple[jax.Array, jax.Array]
 
@@ -26,11 +25,6 @@ class TestAttention(unittest.TestCase):
                 "expert",
                 "model",
             ),
-        )
-        self.param_factory = ParamFactory(
-            kernel_initializer=nnx.initializers.xavier_normal(),
-            scale_initializer=nnx.initializers.ones,
-            random_init=True,
         )
 
     def test_attention_forward_pass(self):
@@ -50,7 +44,7 @@ class TestAttention(unittest.TestCase):
             rope_scaling={},
             dtype=jnp.bfloat16,
             mesh=self.mesh,
-            param_factory=self.param_factory,
+            random_init=True,
             quant=None,
             dnh_sharding=dummy_sharding,
             dkh_sharding=dummy_sharding,

--- a/tests/models/jax/common/attention/test_deepseek_v3_attention.py
+++ b/tests/models/jax/common/attention/test_deepseek_v3_attention.py
@@ -9,7 +9,6 @@ from jax.sharding import PartitionSpec as P
 
 from tpu_commons.models.jax.attention_metadata import AttentionMetadata
 from tpu_commons.models.jax.common.attention.deepseek_v3_attention import MLA
-from tpu_commons.models.jax.common.base import ParamFactory
 
 
 class TestMLA(unittest.TestCase):
@@ -21,11 +20,6 @@ class TestMLA(unittest.TestCase):
                 "expert",
                 "model",
             ),
-        )
-        self.param_factory = ParamFactory(
-            kernel_initializer=nnx.initializers.xavier_normal(),
-            scale_initializer=nnx.initializers.ones,
-            random_init=True,
         )
 
     def test_mla_forward_pass(self):
@@ -62,7 +56,7 @@ class TestMLA(unittest.TestCase):
                 "type": "yarn",
             },
             mesh=self.mesh,
-            param_factory=self.param_factory,
+            random_init=True,
             quant=None,
             # Provide all required sharding objects
             nhd_sharding=dummy_sharding,

--- a/tests/models/jax/common/attention/test_llama4_attention.py
+++ b/tests/models/jax/common/attention/test_llama4_attention.py
@@ -1,7 +1,6 @@
 import os
 import unittest
 from dataclasses import dataclass, field
-from unittest.mock import MagicMock
 
 import chex
 
@@ -75,7 +74,6 @@ class Llama4AttentionTest(unittest.TestCase):
         hidden_size = 64
         num_attention_heads = 4
         head_dim = hidden_size // num_attention_heads
-        param_factory = MagicMock()
 
         # Create dummy sharding objects
         dummy_sharding = NamedSharding(self.mesh, P())
@@ -93,7 +91,7 @@ class Llama4AttentionTest(unittest.TestCase):
             temperature_tuning_scale=2.0,
             temperature_tuning_floor_scale=2.0,
             mesh=self.mesh,
-            param_factory=param_factory,
+            random_init=True,
             quant=None,
             activation_attention_td=dummy_sharding,
             activation_attention_out_td=dummy_sharding,

--- a/tests/models/jax/common/moe/test_deepseek_moe.py
+++ b/tests/models/jax/common/moe/test_deepseek_moe.py
@@ -6,7 +6,6 @@ from flax import nnx
 from jax.sharding import Mesh, NamedSharding
 from jax.sharding import PartitionSpec as P
 
-from tpu_commons.models.jax.common.base import ParamFactory
 from tpu_commons.models.jax.common.moe.deepseek_moe import DeepSeekV3Router
 
 
@@ -15,16 +14,12 @@ class TestDeepSeekV3Router(unittest.TestCase):
     def setUp(self):
         self.cpu_mesh = Mesh(jax.devices('cpu'), axis_names=('data', ))
         self.tpu_mesh = Mesh(jax.devices('tpu'), axis_names=('data', ))
-        self.param_factory = ParamFactory(
-            kernel_initializer=nnx.initializers.xavier_normal(),
-            scale_initializer=nnx.initializers.ones,
-            random_init=True)
 
     def test_get_topk_indices_single_group(self):
         """Test get_topk_indices with single expert group."""
         dummy_sharding = NamedSharding(self.cpu_mesh, P())
         router = DeepSeekV3Router(mesh=self.cpu_mesh,
-                                  param_factory=self.param_factory,
+                                  random_init=True,
                                   hidden_size=512,
                                   num_experts=4,
                                   num_experts_per_tok=2,
@@ -50,7 +45,7 @@ class TestDeepSeekV3Router(unittest.TestCase):
         """Test get_topk_indices with 2 expert groups."""
         dummy_sharding = NamedSharding(self.cpu_mesh, P())
         router = DeepSeekV3Router(mesh=self.cpu_mesh,
-                                  param_factory=self.param_factory,
+                                  random_init=True,
                                   hidden_size=512,
                                   num_experts=4,
                                   num_experts_per_tok=2,
@@ -76,7 +71,7 @@ class TestDeepSeekV3Router(unittest.TestCase):
     def test_router_e2e(self):
         dummy_sharding = NamedSharding(self.cpu_mesh, P())
         router = DeepSeekV3Router(mesh=self.cpu_mesh,
-                                  param_factory=self.param_factory,
+                                  random_init=True,
                                   hidden_size=512,
                                   num_experts=8,
                                   num_experts_per_tok=2,

--- a/tests/models/jax/common/test_layers.py
+++ b/tests/models/jax/common/test_layers.py
@@ -7,7 +7,6 @@ from flax import nnx
 from jax.sharding import Mesh, NamedSharding
 from jax.sharding import PartitionSpec as P
 
-from tpu_commons.models.jax.common.base import ParamFactory
 from tpu_commons.models.jax.common.layers import DenseFFW, Embedder, RMSNorm
 
 
@@ -23,11 +22,6 @@ class TestLayers(unittest.TestCase):
                 "model",
             ),
         )
-        self.param_factory = ParamFactory(
-            kernel_initializer=nnx.initializers.xavier_normal(),
-            scale_initializer=nnx.initializers.ones,
-            random_init=True,
-        )
 
     def test_rmsnorm_forward_pass(self):
         """Tests the forward pass of the RMSNorm module."""
@@ -37,7 +31,7 @@ class TestLayers(unittest.TestCase):
         norm = RMSNorm(
             dims=dims,
             mesh=self.mesh,
-            param_factory=self.param_factory,
+            random_init=True,
             activation_ffw_td=NamedSharding(self.mesh, P()),
             epsilon=epsilon,
             dtype=jnp.float32,
@@ -62,7 +56,7 @@ class TestLayers(unittest.TestCase):
 
         ffw_layer = DenseFFW(
             mesh=self.mesh,
-            param_factory=self.param_factory,
+            random_init=True,
             dtype=jnp.bfloat16,
             hidden_act="silu",
             hidden_size=hidden_size,
@@ -92,7 +86,7 @@ class TestLayers(unittest.TestCase):
             hidden_size=hidden_size,
             dtype=dtype,
             mesh=self.mesh,
-            param_factory=self.param_factory,
+            random_init=True,
             prelogit_td=NamedSharding(self.mesh, P()),
             vd_sharding=NamedSharding(self.mesh, P()),
         )
@@ -123,7 +117,7 @@ class TestLayers(unittest.TestCase):
             dtype=jnp.float32,
             normalize_embeddings=True,
             mesh=self.mesh,
-            param_factory=self.param_factory,
+            random_init=True,
             prelogit_td=NamedSharding(self.mesh, P()),
             vd_sharding=NamedSharding(self.mesh, P()),
         )
@@ -134,7 +128,7 @@ class TestLayers(unittest.TestCase):
             hidden_size=hidden_size,
             dtype=jnp.float32,
             mesh=self.mesh,
-            param_factory=self.param_factory,
+            random_init=True,
             prelogit_td=NamedSharding(self.mesh, P()),
             vd_sharding=NamedSharding(self.mesh, P()),
         )

--- a/tests/models/jax/test_model_loader.py
+++ b/tests/models/jax/test_model_loader.py
@@ -17,7 +17,11 @@ from vllm.engine.arg_utils import EngineArgs
 class MockCausalLM(nnx.Module):
     """A mock nnx.Module that mimics the behavior of a causal language model."""
 
-    def __init__(self, vllm_config: VllmConfig, rng: jax.Array, mesh: Mesh):
+    def __init__(self,
+                 vllm_config: VllmConfig,
+                 rng: jax.Array,
+                 mesh: Mesh,
+                 force_random_weight: bool = False):
         """Initializes a dummy parameter."""
         # Using the inputs to show they are passed correctly
         self.config = vllm_config

--- a/tpu_commons/models/jax/common/moe/deepseek_moe.py
+++ b/tpu_commons/models/jax/common/moe/deepseek_moe.py
@@ -7,7 +7,7 @@ from flax import nnx
 from jax.sharding import Mesh, NamedSharding
 from jaxtyping import Float
 
-from tpu_commons.models.jax.common.base import ParamFactory
+from tpu_commons.models.jax.common.base import create_param
 
 
 @dataclass
@@ -18,12 +18,10 @@ class DeepSeekV3Router(nnx.Module):
 
     Attributes:
         mesh: The JAX device mesh for distributed computation.
-        param_factory: A factory for creating and initializing model parameters.
         quant: Optional configuration for quantization.
     """
 
     mesh: Mesh
-    param_factory: ParamFactory
     hidden_size: int
     num_experts: int
     num_experts_per_tok: int
@@ -38,6 +36,7 @@ class DeepSeekV3Router(nnx.Module):
     ed_sharding: NamedSharding
     e_sharding: NamedSharding
 
+    random_init: bool = False
     quant: Any | None = None
 
     def get_topk_indices(self, scores_TE: Float) -> Float:
@@ -104,11 +103,13 @@ class DeepSeekV3Router(nnx.Module):
         """Generates the router kernel (weights and bias) for routing."""
         D = self.hidden_size
         E = self.num_experts
-        self.kernel_DE = self.param_factory.create_kernel_param(
-            rngs, shape=(D, E), dtype=self.dtype, sharding=self.ed_sharding)
-        self.bias_E = self.param_factory.create_scale_param(
-            rngs,
-            shape=(E, ),
-            dtype=self.dtype,
-            sharding=self.e_sharding,
-        )
+        self.kernel_DE = create_param(rngs,
+                                      shape=(D, E),
+                                      dtype=self.dtype,
+                                      sharding=self.ed_sharding,
+                                      random_init=self.random_init)
+        self.bias_E = create_param(rngs,
+                                   shape=(E, ),
+                                   dtype=self.dtype,
+                                   sharding=self.e_sharding,
+                                   random_init=self.random_init)


### PR DESCRIPTION
# Description

The needs for initializing random weights differently doesn't quite exist in inference, so we will simply use the same initializers. This greatly simplifies our code.

# Tests

unit tests and manual test of llama3_stashed.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
