### PR TITLE
Add input preparation and ngram proposer for spec decoding

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,6 +22,7 @@ RUN VLLM_TARGET_DEVICE="tpu" pip install -e .
 RUN python3 -m pip install -e tests/vllm_test_utils
 RUN python3 -m pip install --no-cache-dir git+https://github.com/thuml/depyf.git pytest pytest-asyncio tpu-info datasets 'lm_eval[api]==0.4.4'
 RUN python3 -m pip install pytest-cov
+RUN python3 -m pip install numba
 
 # Install tpu_commons
 WORKDIR /workspace/tpu_commons

--- a/tests/models/jax/layers/sample/test_rejection_sampler.py
+++ b/tests/models/jax/layers/sample/test_rejection_sampler.py
@@ -430,7 +430,9 @@ class RejectionSamplerTestHelper:
         parsed_output = rejection_sampler.parse_output(
             output,
             vocab_size=vocab_size,
-            num_draft_tokens_cpu=np.asarray(num_draft_tokens))
+            num_draft_tokens_cpu=np.asarray(num_draft_tokens),
+            batch_size=len(num_draft_tokens),
+            padded_tokens_length=int(sum(num_draft_tokens)))
 
         assert parsed_output == test_case.expected, \
             f"Test '{test_case.name}': Expected {test_case.expected}, got {parsed_output}"
@@ -504,7 +506,9 @@ class TestRejectionSampler:
         parsed_output = rejection_sampler.parse_output(
             output_token_ids,
             vocab_size,
-            num_draft_tokens_cpu=np.asarray(num_draft_tokens))
+            num_draft_tokens_cpu=np.asarray(num_draft_tokens),
+            batch_size=len(num_draft_tokens),
+            padded_tokens_length=int(sum(num_draft_tokens)))
 
         expected = [[10, 20, 30, 40], [50, 60, 70]]
         assert parsed_output == expected, f"Expected {expected}, got {parsed_output}"
@@ -525,7 +529,9 @@ class TestRejectionSampler:
         parsed_output = rejection_sampler.parse_output(
             output_token_ids,
             vocab_size,
-            num_draft_tokens_cpu=np.asarray(num_draft_tokens))
+            num_draft_tokens_cpu=np.asarray(num_draft_tokens),
+            batch_size=len(num_draft_tokens),
+            padded_tokens_length=int(sum(num_draft_tokens)))
 
         expected = [[10], [20, 30, 40]]
         assert parsed_output == expected, f"Expected {expected}, got {parsed_output}"
@@ -544,7 +550,9 @@ class TestRejectionSampler:
         parsed_output = rejection_sampler.parse_output(
             output_token_ids,
             vocab_size,
-            num_draft_tokens_cpu=np.asarray(num_draft_tokens))
+            num_draft_tokens_cpu=np.asarray(num_draft_tokens),
+            batch_size=len(num_draft_tokens),
+            padded_tokens_length=int(sum(num_draft_tokens)))
 
         expected = [[10, 20]]  # Invalid tokens filtered out
         assert parsed_output == expected, f"Expected {expected}, got {parsed_output}"
@@ -563,7 +571,9 @@ class TestRejectionSampler:
         parsed_output = rejection_sampler.parse_output(
             output_token_ids,
             vocab_size,
-            num_draft_tokens_cpu=np.asarray(num_draft_tokens))
+            num_draft_tokens_cpu=np.asarray(num_draft_tokens),
+            batch_size=len(num_draft_tokens),
+            padded_tokens_length=int(sum(num_draft_tokens)))
 
         expected = [[50], [60]]  # Only bonus tokens
         assert parsed_output == expected, f"Expected {expected}, got {parsed_output}"
@@ -618,7 +628,9 @@ class TestRejectionSampler:
         parsed_output = rejection_sampler.parse_output(
             output,
             VOCAB_SIZE,
-            num_draft_tokens_cpu=np.asarray(num_draft_tokens))
+            num_draft_tokens_cpu=np.asarray(num_draft_tokens),
+            batch_size=len(num_draft_tokens),
+            padded_tokens_length=int(sum(num_draft_tokens)))
 
         expected = [[1, 5]]  # Should ignore all padding
         assert parsed_output == expected, f"Expected {expected}, got {parsed_output}"
@@ -763,7 +775,9 @@ class TestRejectionSampler:
         parsed_output = rejection_sampler.parse_output(
             output,
             VOCAB_SIZE,
-            num_draft_tokens_cpu=np.asarray(num_draft_tokens))
+            num_draft_tokens_cpu=np.asarray(num_draft_tokens),
+            batch_size=len(num_draft_tokens),
+            padded_tokens_length=int(sum(num_draft_tokens)))
 
         expected = [list(range(1, 28)) + [99]]  # Tokens up to mismatch point
         assert parsed_output == expected, f"Expected {expected}, got {parsed_output}"

--- a/tests/runner/jax/test_input_batch_jax.py
+++ b/tests/runner/jax/test_input_batch_jax.py
@@ -23,6 +23,7 @@ def input_batch():
         pin_memory=False,
         vocab_size=VOCAB_SIZE,
         block_sizes=BLOCK_SIZES,
+        is_spec_decode=True,
     )
 
 
@@ -66,6 +67,7 @@ def test_initialization(input_batch: InputBatch):
     assert len(input_batch.req_ids) == 0
     assert not input_batch.req_id_to_index
     assert input_batch.all_greedy
+    assert input_batch.is_spec_decode
 
 
 def test_add_request(input_batch: InputBatch):
@@ -77,10 +79,12 @@ def test_add_request(input_batch: InputBatch):
     assert "req-1" in input_batch.req_id_to_index
     assert input_batch.req_id_to_index["req-1"] == 0
     assert input_batch.req_ids == ["req-1"]
+    assert len(input_batch.spec_decode_unsupported_reqs) == 0
 
     # Verify token data
     assert input_batch.num_prompt_tokens[0] == 20
     assert input_batch.num_tokens[0] == 24
+    assert input_batch.num_tokens_no_spec[0] == 24
     expected_tokens = np.array(req.prompt_token_ids + req.output_token_ids)
     np.testing.assert_array_equal(input_batch.token_ids_cpu[0, :24],
                                   expected_tokens)
@@ -105,6 +109,8 @@ def test_add_multiple_requests(input_batch: InputBatch):
     assert input_batch.req_id_to_index["req-2"] == 1
     assert input_batch.num_tokens[1] == len(req2.prompt_token_ids) + len(
         req2.output_token_ids)
+    assert input_batch.num_tokens_no_spec[1] == len(
+        req2.prompt_token_ids) + len(req2.output_token_ids)
 
 
 def test_remove_request(input_batch: InputBatch):
@@ -152,6 +158,8 @@ def test_condense(input_batch: InputBatch):
     # Check if a property was moved correctly
     assert input_batch.num_tokens[0] == len(reqs[2].prompt_token_ids) + len(
         reqs[2].output_token_ids)
+    assert input_batch.num_tokens_no_spec[0] == len(
+        reqs[2].prompt_token_ids) + len(reqs[2].output_token_ids)
 
 
 def test_swap_states(input_batch: InputBatch):

--- a/tests/runner/jax/test_tpu_jax_runner.py
+++ b/tests/runner/jax/test_tpu_jax_runner.py
@@ -4,15 +4,18 @@ from unittest.mock import MagicMock, patch
 import jax.numpy as jnp
 import numpy as np
 from vllm.config import (CacheConfig, ModelConfig, ParallelConfig,
-                         SchedulerConfig, VllmConfig)
+                         SchedulerConfig, SpeculativeConfig, VllmConfig)
 from vllm.model_executor.layers.rotary_embedding import MRotaryEmbedding
 from vllm.multimodal.inputs import (MultiModalBatchedField,
                                     MultiModalFieldElem, MultiModalKwargsItem)
 from vllm.sampling_params import SamplingType
 from vllm.v1.core.sched.output import SchedulerOutput as VllmSchedulerOutput
 from vllm.v1.request import PlaceholderRange, Request
+from vllm.v1.spec_decode.ngram_proposer import NgramProposer
 
-from tpu_commons.runner.jax.input_batch_jax import CachedRequestState
+from tpu_commons.runner.jax.input_batch_jax import (CachedRequestState,
+                                                    InputBatch)
+from tpu_commons.runner.jax.metadata import SpecDecodeMetadata
 from tpu_commons.runner.jax.tpu_jax_runner import TPUModelRunner
 
 
@@ -45,12 +48,17 @@ class TestTPUJaxRunner(unittest.TestCase):
                 tensor_parallel_size=1,
                 worker_use_ray=False,
             )
+            speculative_config = SpeculativeConfig(
+                model='ngram',
+                num_speculative_tokens=5,
+                prompt_lookup_max=4,
+            )
             vllm_config = VllmConfig(
                 model_config=model_config,
                 cache_config=cache_config,
                 scheduler_config=scheduler_config,
                 parallel_config=parallel_config,
-                speculative_config=None,
+                speculative_config=speculative_config,
                 observability_config=None,
                 additional_config={},
             )
@@ -716,6 +724,211 @@ class TestTPUJaxRunner(unittest.TestCase):
             self.assertEqual(call_kwargs["mrope_position_delta"], mrope_delta)
             self.assertEqual(call_kwargs["context_len"], prompt_len)
             self.assertEqual(call_kwargs["num_new_tokens"], 5)
+
+    def test_propose_draft_token_ids_wrong_drafter_type(self):
+        """Tests that an assertion is raised if the drafter is not an NgramProposer."""
+        # The default drafter is NgramProposer, so we replace it with a generic mock
+        self.runner.drafter = MagicMock()
+        with self.assertRaises(AssertionError):
+            self.runner.propose_draft_token_ids([[1]])
+
+    def test_propose_ngram_draft_token_ids(self):
+        """Tests the logic for proposing N-gram draft tokens under various conditions."""
+        # 1. ===== Setup =====
+        # Mock the NgramProposer
+        self.runner.drafter = MagicMock(spec=NgramProposer)
+
+        # Re-initialize input_batch for a clean state for this specific test
+        self.runner.input_batch = InputBatch(
+            max_num_reqs=self.runner.max_num_reqs,
+            max_model_len=self.runner.max_model_len,
+            max_num_batched_tokens=self.runner.max_num_tokens,
+            pin_memory=False,
+            vocab_size=self.runner.vocab_size,
+            block_sizes=[self.runner.block_size],
+            is_spec_decode=True,
+        )
+
+        # Patch is_spec_decode_unsupported to control which requests are marked
+        # as unsupported for speculative decoding.
+        with patch(
+                'tpu_commons.runner.jax.input_batch_jax.is_spec_decode_unsupported'
+        ) as mock_is_unsupported:
+            # We want req-2 to be unsupported. Let's use a simple condition.
+            mock_is_unsupported.return_value = False
+
+            # Setup input_batch with 5 requests for different scenarios
+            for i in range(5):
+                mock_sampling_params = MagicMock()
+                mock_sampling_params.sampling_type = SamplingType.GREEDY
+                # This will trigger the mock for req-2
+                mock_sampling_params.top_k = -1
+                mock_sampling_params.top_p = 1.0
+                mock_sampling_params.temperature = 0.0
+                mock_sampling_params.min_tokens = 0
+                mock_sampling_params.logprobs = None
+                mock_sampling_params.logit_bias = None
+                mock_sampling_params.allowed_token_ids = set()
+                mock_sampling_params.bad_words_token_ids = None
+                mock_sampling_params.all_stop_token_ids = set()
+                req_state = CachedRequestState(
+                    req_id=f"req-{i}",
+                    prompt_token_ids=[i] * 10,  # Give some content to tokens
+                    output_token_ids=[],
+                    sampling_params=mock_sampling_params,
+                    block_ids=([1], ),
+                    num_computed_tokens=10,
+                    lora_request=None,
+                    mm_hashes=[],
+                    mm_kwargs=[],
+                    mm_positions=[],
+                    pooling_params=None,
+                    generator=None,
+                )
+                self.runner.input_batch.add_request(req_state)
+
+        # Configure other individual requests for different test cases
+        # req-0: Normal case, should propose tokens.
+        # req-1: No sampled tokens provided, should propose nothing.
+        # req-2: Unsupported for spec decode (handled by mock).
+        self.runner.input_batch.spec_decode_unsupported_reqs.add("req-2")
+        # req-3: Max length reached, should propose nothing.
+        self.runner.input_batch.num_tokens_no_spec[
+            3] = self.runner.max_model_len
+
+        # req-4: Drafter returns None, should propose nothing.
+
+        # Mock the drafter's propose method to handle different cases
+        def propose_side_effect(tokens):
+            # Identify request by its unique token id
+            if tokens[0] == 0:  # req-0
+                return np.array([10, 11, 12])
+            if tokens[0] == 4:  # req-4
+                return None
+            # Should not be called for other requests
+            return np.array([])
+
+        self.runner.drafter.propose.side_effect = propose_side_effect
+
+        # Input to the function being tested
+        sampled_token_ids = [
+            [100],  # req-0: has a new token
+            [],  # req-1: has no new tokens
+            [102],  # req-2: has a new token
+            [103],  # req-3: has a new token
+            [104],  # req-4: has a new token
+        ]
+
+        # 2. ===== Act =====
+        result = self.runner.propose_ngram_draft_token_ids(sampled_token_ids)
+
+        # 3. ===== Assert =====
+        expected_result = [
+            [10, 11, 12],  # req-0: normal proposal
+            [],  # req-1: no sampled tokens
+            [],  # req-2: unsupported
+            [],  # req-3: max length
+            [],  # req-4: drafter returns None
+        ]
+        self.assertEqual(result, expected_result)
+
+        # Verify that drafter.propose was called for the correct requests (req-0 and req-4)
+        self.assertEqual(self.runner.drafter.propose.call_count, 2)
+
+        # Get the tokens passed to the mock
+        called_with_tokens = [
+            call.args[0] for call in self.runner.drafter.propose.call_args_list
+        ]
+
+        # Check that one call was for req-0's tokens
+        expected_tokens_req0 = self.runner.input_batch.token_ids_cpu[0, :10]
+        self.assertTrue(
+            any(
+                np.array_equal(arg, expected_tokens_req0)
+                for arg in called_with_tokens))
+
+        # Check that one call was for req-4's tokens
+        expected_tokens_req4 = self.runner.input_batch.token_ids_cpu[4, :10]
+        self.assertTrue(
+            any(
+                np.array_equal(arg, expected_tokens_req4)
+                for arg in called_with_tokens))
+
+    def test_get_spec_decode_metadata(self):
+        """Tests the _get_spec_decode_metadata function with a sample case."""
+        # 1. ===== Setup =====
+        # Use the example from the function's docstring
+        num_draft_tokens = np.array([3, 0, 2, 0, 1], dtype=np.int32)
+        cu_num_scheduled_tokens = np.array([4, 104, 107, 207, 209],
+                                           dtype=np.int32)
+
+        # Mock runner attributes needed by the function
+        self.runner.arange_cpu = np.arange(1024, dtype=np.int64)
+        # Let's make input_ids_cpu just a sequence of numbers for easy verification
+        self.runner.input_ids_cpu = np.arange(1024, dtype=np.int32) * 10
+        self.runner.num_tokens_paddings = [16, 32, 64, 128, 256, 512, 1024]
+        # Mock runner_utils which is used inside the function
+        with patch('tpu_commons.runner.jax.tpu_jax_runner.runner_utils'
+                   ) as mock_runner_utils:
+            mock_runner_utils.get_padded_token_len.return_value = 16
+
+            # Mock the _device_array function to just return the numpy arrays
+            def mock_device_array(*args, **kwargs):
+                if len(args) == 1 and isinstance(args[0], tuple):
+                    return args[0]
+                return args
+
+            self.runner._device_array = mock_device_array
+
+            # 2. ===== Act =====
+            metadata = self.runner._get_spec_decode_metadata(
+                num_draft_tokens, cu_num_scheduled_tokens)
+
+            # 3. ===== Assert =====
+            self.assertIsInstance(metadata, SpecDecodeMetadata)
+            self.assertEqual(metadata.max_spec_len, 3)
+
+            # final_logits_indices are the indices of all tokens (sampled + draft)
+            # in the flattened input_ids buffer, padded to a bucket size.
+            expected_logits_indices = np.array(
+                [0, 1, 2, 3, 103, 104, 105, 106, 206, 207, 208],
+                dtype=np.int32)
+            padded_len = 16
+            expected_padded_logits_indices = np.pad(
+                expected_logits_indices,
+                (0, padded_len - len(expected_logits_indices)))
+            np.testing.assert_array_equal(
+                np.asarray(metadata.final_logits_indices),
+                expected_padded_logits_indices)
+
+            # bonus_logits_indices are the indices of the bonus tokens.
+            expected_bonus_logits_indices = np.array(
+                [3, 4, 7, 8, 10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                dtype=np.int32)
+            np.testing.assert_array_equal(
+                np.asarray(metadata.bonus_logits_indices),
+                expected_bonus_logits_indices)
+
+            # target_logits_indices are the indices of the draft tokens' logits.
+            expected_target_logits_indices = np.array(
+                [0, 1, 2, 5, 6, 9, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                dtype=np.int32)
+            np.testing.assert_array_equal(
+                np.asarray(metadata.target_logits_indices),
+                expected_target_logits_indices)
+
+            # draft_token_ids are the actual token ids of the draft tokens.
+            expected_draft_token_ids = np.array(
+                [10, 20, 30, 1050, 1060, 2080, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                dtype=np.int32)
+            np.testing.assert_array_equal(np.asarray(metadata.draft_token_ids),
+                                          expected_draft_token_ids)
+
+            # draft_lengths are the number of draft tokens per request.
+            expected_num_draft_tokens = np.pad(
+                num_draft_tokens, (0, padded_len - len(num_draft_tokens)))
+            np.testing.assert_array_equal(np.asarray(metadata.draft_lengths),
+                                          expected_num_draft_tokens)
 
 
 class TestTPUJaxRunnerMultimodalModelLoadedForTextOnly(unittest.TestCase):

--- a/tpu_commons/models/jax/layers/sample/rejection_sampler.py
+++ b/tpu_commons/models/jax/layers/sample/rejection_sampler.py
@@ -121,6 +121,8 @@ class RejectionSampler:
         output_token_ids: jnp.ndarray,
         vocab_size: int,
         num_draft_tokens_cpu: np.ndarray,
+        batch_size: int,
+        padded_tokens_length: int,
     ) -> list[list[int]]:
         """Parse the output of the rejection sampler.
 
@@ -132,18 +134,20 @@ class RejectionSampler:
             vocab_size: The size of the vocabulary.
             num_draft_tokens_cpu: Number of draft tokens per request [batch_size]
                 as a numpy array on CPU.
+            batch_size: The number of requests in the batch.
+            padded_tokens_length: The padded length of the main tokens in the output.
 
         Returns:
             A list of lists of token IDs.
         """
         # Convert JAX array to numpy for easier manipulation
         output_token_ids_np = np.asarray(output_token_ids)
-        batch_size = num_draft_tokens_cpu.shape[0]
-        total_tokens = int(np.sum(num_draft_tokens_cpu))
 
         # Split main tokens and bonus tokens
-        main_tokens = output_token_ids_np[:total_tokens]  # [num_tokens]
-        bonus_tokens = output_token_ids_np[total_tokens:]  # [batch_size]
+        main_tokens = output_token_ids_np[:
+                                          padded_tokens_length]  # [num_tokens]
+        bonus_tokens = output_token_ids_np[
+            padded_tokens_length:]  # [batch_size]
 
         # Reconstruct per-sequence outputs
         outputs = []

--- a/tpu_commons/platforms/tpu_jax.py
+++ b/tpu_commons/platforms/tpu_jax.py
@@ -133,9 +133,6 @@ class TpuPlatform(Platform):
         if compilation_config.backend == "":
             compilation_config.backend = "openxla"
 
-        assert vllm_config.speculative_config is None, \
-            "TPU does not support speculative decoding"
-
         # If we use vLLM's model implementation in PyTorch, we should set it with torch version of the dtype.
         impl = os.getenv("MODEL_IMPL_TYPE", "flax_nnx").lower()
 
@@ -193,9 +190,6 @@ class TpuPlatform(Platform):
                 f"Unknown TPU multihost backend: {multihost_backend}. "
                 "Using uniproc_executor.")
             parallel_config.distributed_executor_backend = "uni"
-
-        assert not vllm_config.speculative_config, (
-            "Speculative decoding is not yet supported for TPU backend")
 
         if scheduler_config.is_multimodal_model and not \
             scheduler_config.disable_chunked_mm_input:

--- a/tpu_commons/runner/jax/metadata.py
+++ b/tpu_commons/runner/jax/metadata.py
@@ -1,0 +1,14 @@
+from dataclasses import dataclass
+
+import jax.numpy as jnp
+
+
+@dataclass
+class SpecDecodeMetadata:
+    """Metadata for speculative decoding on JAX/TPU, containing all necessary indices."""
+    draft_token_ids: jnp.ndarray
+    draft_lengths: jnp.ndarray
+    target_logits_indices: jnp.ndarray
+    bonus_logits_indices: jnp.ndarray
+    final_logits_indices: jnp.ndarray
+    max_spec_len: int

--- a/tpu_commons/runner/jax/tpu_jax_runner.py
+++ b/tpu_commons/runner/jax/tpu_jax_runner.py
@@ -29,6 +29,7 @@ from vllm.v1.kv_cache_interface import (FullAttentionSpec, KVCacheConfig,
                                         KVCacheSpec)
 from vllm.v1.outputs import EMPTY_MODEL_RUNNER_OUTPUT, ModelRunnerOutput
 from vllm.v1.request import Request
+from vllm.v1.spec_decode.ngram_proposer import NgramProposer
 from vllm.v1.worker.kv_connector_model_runner_mixin import \
     KVConnectorModelRunnerMixin
 from vllm.v1.worker.utils import (gather_mm_placeholders,
@@ -39,6 +40,8 @@ from tpu_commons.logger import init_logger
 from tpu_commons.models.jax.attention_metadata import AttentionMetadata
 from tpu_commons.models.jax.common.sharding import build_mesh
 from tpu_commons.models.jax.layers.misc import shard_put
+from tpu_commons.models.jax.layers.sample.rejection_sampler import \
+    RejectionSampler
 from tpu_commons.models.jax.layers.sample.sampling import (compute_logprobs,
                                                            gather_logprobs,
                                                            sample)
@@ -52,6 +55,7 @@ from tpu_commons.models.jax.utils.weight_utils import \
 from tpu_commons.runner import utils as runner_utils
 from tpu_commons.runner.jax.input_batch_jax import (CachedRequestState,
                                                     InputBatch)
+from tpu_commons.runner.jax.metadata import SpecDecodeMetadata
 
 logger = init_logger(__name__)
 
@@ -93,6 +97,16 @@ class TPUModelRunner(KVConnectorModelRunnerMixin):
         self.is_multimodal_model = None  # Will get updated once the model is loaded.
         self.mm_registry = MULTIMODAL_REGISTRY
         self.uses_mrope = self.model_config.uses_mrope
+
+        # Set up speculative decoding.
+        if self.speculative_config:
+            if self.speculative_config.method == "ngram":
+                self.drafter = NgramProposer(self.vllm_config)
+            else:
+                raise NotImplementedError(
+                    "Unsupported speculative decoding method: "
+                    f"{self.speculative_config.method}")
+            self.rejection_sampler = RejectionSampler()
 
         self._init_random()
         self._init_mesh()
@@ -174,6 +188,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin):
             pin_memory=False,
             vocab_size=self.model_config.get_vocab_size(),
             block_sizes=[self.block_size],
+            is_spec_decode=bool(self.vllm_config.speculative_config),
         )
 
         self.input_ids_cpu = np.zeros(self.max_num_tokens, dtype=np.int32)
@@ -877,8 +892,8 @@ class TPUModelRunner(KVConnectorModelRunnerMixin):
                 #     "Should not schedule a request that does nothing!")
             return DUMMY_METADATA, EMPTY_MODEL_RUNNER_OUTPUT,
 
-        (input_ids, attn_metadata, sampling_metadata,
-         logits_indices) = self._prepare_inputs(scheduler_output)
+        (input_ids, attn_metadata, sampling_metadata, logits_indices,
+         spec_decode_metadata) = self._prepare_inputs(scheduler_output)
 
         # multi-modal support
         if self.is_multimodal_model:
@@ -936,12 +951,34 @@ class TPUModelRunner(KVConnectorModelRunnerMixin):
                     arange,
                 )
             tpu_sampling_metadata = sampling_metadata
-            next_tokens = sample(
-                self.rng_params_for_sampling,
-                self.mesh,
-                logits,
-                tpu_sampling_metadata,
-            )
+            if spec_decode_metadata is None:
+                next_tokens = sample(
+                    self.rng_params_for_sampling,
+                    self.mesh,
+                    logits,
+                    tpu_sampling_metadata,
+                )
+            else:
+                bonus_logits = logits[
+                    spec_decode_metadata.bonus_logits_indices]
+                bonus_token_ids = sample(
+                    self.rng_params_for_sampling,
+                    self.mesh,
+                    bonus_logits,
+                    tpu_sampling_metadata,
+                )
+                target_logits = logits[
+                    spec_decode_metadata.target_logits_indices]
+                next_tokens = self.rejection_sampler(
+                    draft_token_ids=spec_decode_metadata.draft_token_ids,
+                    num_draft_tokens=spec_decode_metadata.draft_lengths,
+                    max_spec_len=spec_decode_metadata.max_spec_len,
+                    draft_probs=None,
+                    target_probs=target_logits,
+                    bonus_token_ids=bonus_token_ids,
+                    sampling_metadata=tpu_sampling_metadata,
+                )
+
             if tpu_sampling_metadata.logprobs:
                 logprobs = self._compute_and_gather_logprobs(
                     logits, next_tokens, self.model_config.max_logprobs)
@@ -982,35 +1019,103 @@ class TPUModelRunner(KVConnectorModelRunnerMixin):
         for req_id in self.input_batch.req_ids[:num_reqs]:
             prompt_logprobs_dict[req_id] = None
 
-        next_tokens = np.asarray(jax.device_get(next_tokens))
-        selected_token_ids = np.expand_dims(next_tokens[:num_reqs], 1)
-        valid_sampled_token_ids = selected_token_ids.tolist()
+        if spec_decode_metadata is None:
+            next_tokens = np.asarray(jax.device_get(next_tokens))
+            selected_token_ids = np.expand_dims(next_tokens[:num_reqs], 1)
+            valid_sampled_token_ids = selected_token_ids.tolist()
+        else:
+            valid_sampled_token_ids = self.rejection_sampler.parse_output(
+                next_tokens, self.input_batch.vocab_size,
+                spec_decode_metadata.draft_lengths, num_reqs,
+                spec_decode_metadata.draft_token_ids.shape[0])
+
         # Mask out the sampled tokens that should not be sampled.
         for i in discard_sampled_tokens_req_indices:
             valid_sampled_token_ids[i].clear()
         # Append sampled tokens
-        for i, req_state, seq_len in request_seq_lens:
-            token_id = valid_sampled_token_ids[i][0]
-            self.input_batch.token_ids_cpu[i, seq_len] = token_id
-            req_state.output_token_ids.append(token_id)
-            self.input_batch.num_tokens[i] += 1
+        for req_idx, req_state, _ in request_seq_lens:
+            sampled_ids = valid_sampled_token_ids[req_idx]
+            if not sampled_ids:
+                continue
+
+            start_idx = self.input_batch.num_tokens_no_spec[req_idx]
+            end_idx = start_idx + len(sampled_ids)
+            assert end_idx <= self.max_model_len, (
+                "Sampled token IDs exceed the max model length. "
+                f"Total number of tokens: {end_idx} > max_model_len: "
+                f"{self.max_model_len}")
+
+            self.input_batch.token_ids_cpu[req_idx,
+                                           start_idx:end_idx] = sampled_ids
+            self.input_batch.num_tokens_no_spec[req_idx] = end_idx
+            self.input_batch.num_tokens[req_idx] = end_idx
+            req_state.output_token_ids.extend(sampled_ids)
 
         if logprobs is not None:
             logprobs_lists = logprobs.tolists()
         else:
             logprobs_lists = None
 
+        if not self.speculative_config:
+            # Speculative decoding is not enabled.
+            spec_token_ids = None
+        else:
+            spec_token_ids = self.propose_draft_token_ids(
+                valid_sampled_token_ids)
+
         model_runner_output = ModelRunnerOutput(
             req_ids=req_ids,
             req_id_to_index=self.input_batch.req_id_to_index,
             sampled_token_ids=valid_sampled_token_ids,
-            spec_token_ids=None,
+            spec_token_ids=spec_token_ids,
             logprobs=logprobs_lists,
             prompt_logprobs_dict=prompt_logprobs_dict,
             pooler_output=[],
             kv_connector_output=kv_connector_output,
         )
         return attn_metadata, model_runner_output
+
+    def propose_draft_token_ids(
+        self,
+        sampled_token_ids: list[list[int]],
+    ) -> list[list[int]]:
+        spec_token_ids = self.propose_ngram_draft_token_ids(sampled_token_ids)
+        return spec_token_ids
+
+    def propose_ngram_draft_token_ids(
+        self,
+        sampled_token_ids: list[list[int]],
+    ) -> list[list[int]]:
+        assert isinstance(self.drafter, NgramProposer)
+        draft_token_ids: list[list[int]] = []
+        num_reqs = self.input_batch.num_reqs
+        for i, sampled_ids in enumerate(sampled_token_ids[:num_reqs]):
+            num_sampled_ids = len(sampled_ids)
+            if not num_sampled_ids:
+                # Skip speculative decoding.
+                draft_token_ids.append([])
+                continue
+
+            # Skip requests that require sampling parameters that are not
+            # supported with speculative decoding.
+            req_id = self.input_batch.req_ids[i]
+            if req_id in self.input_batch.spec_decode_unsupported_reqs:
+                draft_token_ids.append([])
+                continue
+
+            num_tokens = self.input_batch.num_tokens_no_spec[i]
+            if num_tokens >= self.max_model_len:
+                # Skip requests that have already reached the max model length.
+                draft_token_ids.append([])
+                continue
+
+            drafter_output = self.drafter.propose(
+                self.input_batch.token_ids_cpu[i, :num_tokens])
+            if drafter_output is None or len(drafter_output) == 0:
+                draft_token_ids.append([])
+            else:
+                draft_token_ids.append(drafter_output.tolist())
+        return draft_token_ids
 
     @functools.partial(jax.jit, static_argnums=(0, ))
     def structured_decode_fn(self, require_struct_decoding: jax.Array,
@@ -1083,6 +1188,98 @@ class TPUModelRunner(KVConnectorModelRunnerMixin):
              self.structured_decode_arange))
 
         return require_structured_out_cpu, grammar_bitmask_cpu, structured_decode_arange
+
+    def _get_spec_decode_metadata(
+            self, num_draft_tokens: np.ndarray,
+            cu_num_scheduled_tokens: np.ndarray) -> SpecDecodeMetadata:
+        # Inputs:
+        # cu_num_scheduled_tokens:  [  4, 104, 107, 207, 209]
+        # num_draft_tokens:         [  3,   0,   2,   0,   1]
+        # Outputs:
+        # cu_num_draft_tokens:      [  3,   3,   5,   5,   6]
+        # logits_indices:           [  0,   1,   2,   3, 103, 104, 105, 106,
+        #                            206, 207, 208]
+        # target_logits_indices:    [  0,   1,   2,   5,   6,   9]
+        # bonus_logits_indices:     [  3,   4,   7,   8,  10]
+
+        # Compute the logits indices.
+        # [4, 1, 3, 1, 2]
+        num_sampled_tokens = num_draft_tokens + 1
+        max_spec_len = np.max(num_draft_tokens)
+
+        # Step 1. cu_num_sampled_tokens: [4, 5, 8, 9, 11]
+        # arange: [0, 1, 2, 3, 0, 0, 1, 2, 0, 0, 1]
+        cu_num_sampled_tokens = np.cumsum(num_sampled_tokens)
+        arange = np.concatenate(
+            [self.arange_cpu[:n] for n in num_sampled_tokens])
+        # Step 2. [0, 0, 0, 0, 103, 104, 104, 104, 206, 207, 207]
+        logits_indices = np.repeat(
+            cu_num_scheduled_tokens - num_sampled_tokens, num_sampled_tokens)
+        # Step 3. [0, 1, 2, 3, 103, 104, 105, 106, 206, 207, 208]
+        logits_indices += arange
+
+        # Compute the bonus logits indices.
+        bonus_logits_indices = cu_num_sampled_tokens - 1
+
+        # Compute the draft logits indices.
+        # arange: [0, 1, 2, 0, 1, 0]
+        arange = np.concatenate(
+            [self.arange_cpu[:n] for n in num_draft_tokens])
+        # [0, 0, 0, 5, 5, 9]
+        target_logits_indices = np.repeat(
+            cu_num_sampled_tokens - num_sampled_tokens, num_draft_tokens)
+        # [0, 1, 2, 5, 6, 9]
+        target_logits_indices += arange
+
+        # Compute the draft token ids.
+        # draft_token_indices:      [  1,   2,   3, 105, 106, 208]
+        draft_token_ids = self.input_ids_cpu[logits_indices]
+        draft_token_ids = draft_token_ids[target_logits_indices + 1]
+        padded_logits_length = runner_utils.get_padded_token_len(
+            self.num_reqs_paddings, logits_indices.shape[0])
+        padded_logits_indices = np.concatenate([
+            logits_indices,
+            np.zeros(padded_logits_length - logits_indices.shape[0],
+                     dtype=np.int32)
+        ])
+        padded_bonus_logits_indices = np.concatenate([
+            bonus_logits_indices,
+            np.zeros(padded_logits_length - bonus_logits_indices.shape[0],
+                     dtype=np.int32)
+        ])
+        padded_num_draft_tokens = np.concatenate([
+            num_draft_tokens,
+            np.zeros(padded_logits_length - num_draft_tokens.shape[0],
+                     dtype=np.int32)
+        ])
+        padded_draft_token_ids = np.concatenate([
+            draft_token_ids,
+            np.zeros(padded_logits_length - draft_token_ids.shape[0],
+                     dtype=np.int32)
+        ])
+        padded_target_logits_indices = np.concatenate([
+            target_logits_indices,
+            np.zeros(padded_logits_length - target_logits_indices.shape[0],
+                     dtype=np.int32)
+        ])
+
+        # CPU -> TPU copy.
+        (padded_num_draft_tokens, padded_draft_token_ids,
+         padded_logits_indices, padded_target_logits_indices,
+         padded_bonus_logits_indices) = self._device_array(
+             (padded_num_draft_tokens, padded_draft_token_ids,
+              padded_logits_indices, padded_target_logits_indices,
+              padded_bonus_logits_indices))
+
+        metadata = SpecDecodeMetadata(
+            draft_token_ids=padded_draft_token_ids,
+            draft_lengths=padded_num_draft_tokens,
+            target_logits_indices=padded_target_logits_indices,
+            bonus_logits_indices=padded_bonus_logits_indices,
+            final_logits_indices=padded_logits_indices,
+            max_spec_len=max_spec_len,
+        )
+        return metadata
 
     def _prepare_inputs(self, scheduler_output: "VllmSchedulerOutput"):
         total_num_scheduled_tokens = scheduler_output.total_num_scheduled_tokens
@@ -1170,12 +1367,28 @@ class TPUModelRunner(KVConnectorModelRunnerMixin):
         seq_lens = self.seq_lens_cpu[:self.max_num_reqs]
         padded_num_reqs = runner_utils.get_padded_num_reqs_with_upper_limit(
             num_reqs, self.max_num_reqs)
-        logits_indices = self.query_start_loc_cpu[1:padded_num_reqs + 1] - 1
         request_distribution = np.array(self.input_batch.request_distribution)
+
+        use_spec_decode = len(
+            scheduler_output.scheduled_spec_decode_tokens) > 0
+        if not use_spec_decode:
+            logits_indices = self.query_start_loc_cpu[1:padded_num_reqs +
+                                                      1] - 1
+            spec_decode_metadata = None
+        else:
+            num_draft_tokens = np.zeros(num_reqs, dtype=np.int32)
+            for req_id, draft_token_ids in (
+                    scheduler_output.scheduled_spec_decode_tokens.items()):
+                req_idx = self.input_batch.req_id_to_index[req_id]
+                num_draft_tokens[req_idx] = len(draft_token_ids)
+
+            spec_decode_metadata = self._get_spec_decode_metadata(
+                num_draft_tokens, self.query_start_loc_cpu[1:num_reqs + 1])
+            logits_indices = spec_decode_metadata.final_logits_indices
 
         # Put to device
         sampling_metadata = TPUSupportedSamplingMetadata.\
-            from_input_batch(self.mesh, self.input_batch, padded_num_reqs)
+            from_input_batch(self.mesh, self.input_batch, logits_indices.shape[0])
 
         if self.uses_mrope:
             positions = mrope_positions
@@ -1199,6 +1412,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin):
             ),
             sampling_metadata,
             logits_indices,
+            spec_decode_metadata,
         )
 
     def _device_array(self, *args, sharding=None, **kwargs) -> jax.Array:
@@ -1347,6 +1561,18 @@ class TPUModelRunner(KVConnectorModelRunnerMixin):
             self.input_batch.num_computed_tokens_cpu[req_index] = (
                 num_computed_tokens)
             self.input_batch.block_table.append_row(new_block_ids, req_index)
+
+            # Add spec_token_ids to token_ids_cpu.
+            spec_token_ids = (
+                scheduler_output.scheduled_spec_decode_tokens.get(req_id, ()))
+            if spec_token_ids:
+                num_spec_tokens = len(spec_token_ids)
+                start_index = self.input_batch.num_tokens_no_spec[req_index]
+                end_token_index = start_index + num_spec_tokens
+                self.input_batch.token_ids_cpu[
+                    req_index, start_index:end_token_index] = spec_token_ids
+                # NOTE(woosuk): `num_tokens` here may include spec tokens.
+                self.input_batch.num_tokens[req_index] += num_spec_tokens
 
         # Add the new or resumed requests to the persistent batch.
         # The smaller empty indices are filled first.


### PR DESCRIPTION
# Description

The PR introduces speculative decoding to the JAX/TPU runner. By proposing several "draft" tokens with a fast N-gram drafter and validating them in a single forward pass of the larger target model, this feature reduces the number of sequential model execution steps required for generation.

This initial implementation supports N-gram based drafting with greedy sampling.

# Tests

Unit tests added

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
