### PR TITLE
Support non-128 minor broadcast

### DIFF
--- a/tpu_commons/kernels/ragged_paged_attention/v3/kernel.py
+++ b/tpu_commons/kernels/ragged_paged_attention/v3/kernel.py
@@ -657,6 +657,7 @@ def _ragged_paged_attention_kernel(
         if src.shape == shape:
             return src
         assert src.shape[:-1] == shape[:-1]
+        assert src.shape[-1] % 128 == 0
         target_minor = align_to(shape[-1], src.shape[-1])
         # no-op concatenation.
         return jnp.concatenate(


### PR DESCRIPTION
# Description

Support non-128 minor broadcast

# Tests

Tested: 
```
pytest -v tests/kernels/ragged_paged_attention_kernel_v3_test.py 
```

But requires latest JAX and LIBTPU to be installed.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
