### PR TITLE
Add support for vllm argument --download_dir

### DIFF
--- a/tests/experimental/test_llama3_jax_stashed.py
+++ b/tests/experimental/test_llama3_jax_stashed.py
@@ -39,6 +39,7 @@ class MockVllmConfig:
                                             dtype="bfloat16",
                                             hf_overrides={},
                                             override_generation_config={})
+        self.load_config = MagicMock()
         self.additional_config = {
             "random_weights": random_weights,
             "sharding": {

--- a/tests/models/jax/test_llama4.py
+++ b/tests/models/jax/test_llama4.py
@@ -37,6 +37,7 @@ class MockVllmConfig:
                  random_weights: bool = False,
                  tensor_parallelism: int = 1):
         self.model_config = MagicMock(spec=ModelConfig)
+        self.load_config = MagicMock()
 
         # Choose small amount of layers to avoid OOM.
         self.model_config.get_vocab_size.return_value = 202048

--- a/tpu_commons/experimental/llama3_jax_stashed.py
+++ b/tpu_commons/experimental/llama3_jax_stashed.py
@@ -325,7 +325,9 @@ class Llama3WeightLoader:
                                 loaded_name, loaded_weight,
                                 model_for_loading.mesh)
                 for loaded_name, loaded_weight in model_weights_generator(
-                    model_path, framework="flax")
+                    model_path,
+                    framework="flax",
+                    download_dir=self.vllm_config.load_config.download_dir)
             ]
             for future in futures:
                 future.result()

--- a/tpu_commons/models/jax/deepseek_v3.py
+++ b/tpu_commons/models/jax/deepseek_v3.py
@@ -340,7 +340,9 @@ class DeepSeekV3WeightLoader:
 
         self.num_layers = num_layers
         self.names_and_weights_generator = model_weights_generator(
-            model_name_or_path=vllm_config.model_config.model, framework="pt")
+            model_name_or_path=vllm_config.model_config.model,
+            framework="pt",
+            download_dir=vllm_config.load_config.download_dir)
         self.num_routed_experts = num_local_experts
 
         self._transpose_map = {

--- a/tpu_commons/models/jax/llama4.py
+++ b/tpu_commons/models/jax/llama4.py
@@ -301,7 +301,8 @@ class Llama4WeightLoader:
         self.names_and_weights_generator = model_weights_generator(
             model_name_or_path=vllm_config.model_config.model,
             framework="flax",
-            filter_regex="language_model")
+            filter_regex="language_model",
+            download_dir=vllm_config.load_config.download_dir)
         self.is_verbose = getattr(vllm_config.additional_config, "is_verbose",
                                   False)
         self._transpose_map = {

--- a/tpu_commons/models/jax/utils/file_utils.py
+++ b/tpu_commons/models/jax/utils/file_utils.py
@@ -3,7 +3,7 @@ import hashlib
 import os
 import shutil
 import subprocess
-from typing import List
+from typing import List, Optional
 
 import filelock
 import huggingface_hub.constants
@@ -82,12 +82,12 @@ class DisabledTqdm(tqdm):
         super().__init__(*args, **kwargs, disable=True)
 
 
-def download_model_weights_from_hf(model_path: str,
+def download_model_weights_from_hf(model_path: str, cache_dir: Optional[str],
                                    weights_format: str) -> str:
     with get_lock(model_path):
         local_dir = snapshot_download(
             model_path,
-            cache_dir=None,  # can be specified by HF_HOME or HF_HUB_CACHE
+            cache_dir=cache_dir,  # can be specified by HF_HOME or HF_HUB_CACHE
             allow_patterns=weights_format,
             tqdm_class=DisabledTqdm,
             local_files_only=huggingface_hub.constants.HF_HUB_OFFLINE,


### PR DESCRIPTION
# Description

Allow setting model download directory using vLLM's engine argument [--download_dir](https://github.com/vllm-project/vllm/blob/d16aa3dae446d93f870a2e51b240e18a01cac294/vllm/engine/arg_utils.py#L557-L558)

# Tests

```
TPU_BACKEND_TYPE=jax python tpu_commons/examples/offline_inference.py --model=meta-llama/Llama-3.1-8B --tensor_parallel_size=1 --task=generate --max_model_len=1024 --download_dir=/mnt/disks/persist
```

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
