### PR TITLE
[DI] Further detangle the will-be giant IConfig Protocol.

### DIFF
--- a/tests/core/test_core_tpu.py
+++ b/tests/core/test_core_tpu.py
@@ -217,9 +217,10 @@ class TestDisaggOrchestrator(unittest.TestCase):
 
     def setUp(self):
         self.mock_config = MagicMock(spec=IConfig)
-        self.mock_config.vllm_config.scheduler_config.max_num_seqs = 16
-        self.mock_config.vllm_config.device_config = MagicMock()
-        self.mock_config.vllm_config.cache_config.block_size = 5
+        self.mock_config.scheduler_config = MagicMock()
+        self.mock_config.scheduler_config.max_num_seqs = 16
+        self.mock_config.cache_config = MagicMock()
+        self.mock_config.cache_config.block_size = 5
 
         self.mock_output_queue = MagicMock()
         self.mock_prefill_engine = MagicMock(spec=IEngineCore)

--- a/tpu_commons/core/core_tpu.py
+++ b/tpu_commons/core/core_tpu.py
@@ -95,8 +95,7 @@ class _DisaggOrchestrator:
             queue.Queue(4) for i in range(len(self._prefill_engines))
         ]
         self._decode_backlogs = {
-            idx:
-            queue.Queue(self._config.vllm_config.scheduler_config.max_num_seqs)
+            idx: queue.Queue(self._config.scheduler_config.max_num_seqs)
             for idx, engine in enumerate(self._decode_engines)
         }
 
@@ -275,11 +274,11 @@ class _DisaggOrchestrator:
             while True:
                 # We need to check input batch as well as the request completion is delayed
                 # from scheduler to the runner.
-                if (sum(decode_engine.scheduler.get_request_counts()) >=
-                        self._config.vllm_config.scheduler_config.max_num_seqs
+                if (sum(decode_engine.scheduler.get_request_counts())
+                        >= self._config.scheduler_config.max_num_seqs
                         or decode_engine.model_executor.driver_worker.
-                        model_runner.input_batch.num_reqs >= self._config.
-                        vllm_config.scheduler_config.max_num_seqs):
+                        model_runner.input_batch.num_reqs
+                        >= self._config.scheduler_config.max_num_seqs):
                     break
 
                 try:
@@ -317,8 +316,7 @@ class _DisaggOrchestrator:
                 vllm_request.num_computed_tokens = prompt_tokens
                 new_block_ids = kv_cache_manager.get_block_ids(req_id)
                 assert (len(new_block_ids[0]) == math.ceil(
-                    prompt_tokens /
-                    self._config.vllm_config.cache_config.block_size))
+                    prompt_tokens / self._config.cache_config.block_size))
 
                 with LatencyTracker(f"KVCacheInsert-{len(new_block_ids[0])}"):
                     decode_engine.model_executor.driver_worker.model_runner.insert_request_with_kv_cache(

--- a/tpu_commons/interfaces/config.py
+++ b/tpu_commons/interfaces/config.py
@@ -1,7 +1,11 @@
 """
 Defines the abstract contract for a configuration object.
 """
-from typing import Any, Protocol
+from typing import Any, Optional, Protocol
+
+from .config_parts import (ICacheConfig, ICompilationConfig, IModelConfig,
+                           IParallelConfig, ISchedulerConfig,
+                           ISpeculativeConfig)
 
 
 class IConfig(Protocol):
@@ -13,17 +17,31 @@ class IConfig(Protocol):
     implementations that satisfy this contract.
     """
 
-    # Add methods and properties from vllm.config.VllmConfig that are
-    # actually used by the orchestration logic.
-    # For example:
     @property
-    def scheduler_config(self) -> object:
+    def cache_config(self) -> ICacheConfig:
         ...
 
     @property
-    def cache_config(self) -> object:
+    def compilation_config(self) -> ICompilationConfig:
         ...
 
+    @property
+    def model_config(self) -> Optional[IModelConfig]:
+        ...
+
+    @property
+    def parallel_config(self) -> IParallelConfig:
+        ...
+
+    @property
+    def scheduler_config(self) -> ISchedulerConfig:
+        ...
+
+    @property
+    def speculative_config(self) -> Optional[ISpeculativeConfig]:
+        ...
+
+    # Escape hatch for direct access when needed by the adapter.
     @property
     def vllm_config(self) -> Any:
         ...

--- a/tpu_commons/interfaces/config_parts.py
+++ b/tpu_commons/interfaces/config_parts.py
@@ -1,0 +1,117 @@
+"""
+Defines the abstract contracts for the component parts of an IConfig.
+"""
+from typing import Any, Optional, Protocol
+
+import torch
+
+
+class IModelConfig(Protocol):
+
+    @property
+    def dtype(self) -> torch.dtype:
+        ...
+
+    @dtype.setter
+    def dtype(self, value: torch.dtype) -> None:
+        ...
+
+    @property
+    def use_mla(self) -> bool:
+        ...
+
+
+class ICacheConfig(Protocol):
+
+    @property
+    def block_size(self) -> Optional[int]:
+        ...
+
+    @block_size.setter
+    def block_size(self, value: Optional[int]) -> None:
+        ...
+
+
+class IParallelConfig(Protocol):
+
+    @property
+    def worker_cls(self) -> str:
+        ...
+
+    @worker_cls.setter
+    def worker_cls(self, value: str) -> None:
+        ...
+
+
+class ISchedulerConfig(Protocol):
+
+    @property
+    def max_num_seqs(self) -> int:
+        ...
+
+    @property
+    def is_multi_step(self) -> bool:
+        ...
+
+    @property
+    def is_multimodal_model(self) -> bool:
+        ...
+
+    @property
+    def disable_chunked_mm_input(self) -> bool:
+        ...
+
+    @disable_chunked_mm_input.setter
+    def disable_chunked_mm_input(self, value: bool) -> None:
+        ...
+
+    @property
+    def enable_chunked_prefill(self) -> bool:
+        ...
+
+    @enable_chunked_prefill.setter
+    def enable_chunked_prefill(self, value: bool) -> None:
+        ...
+
+    @property
+    def chunked_prefill_enabled(self) -> bool:
+        ...
+
+    @chunked_prefill_enabled.setter
+    def chunked_prefill_enabled(self, value: bool) -> None:
+        ...
+
+    @property
+    def max_model_len(self) -> int:
+        ...
+
+    @property
+    def max_num_batched_tokens(self) -> int:
+        ...
+
+    @max_num_batched_tokens.setter
+    def max_num_batched_tokens(self, value: int) -> None:
+        ...
+
+
+class ICompilationConfig(Protocol):
+
+    @property
+    def level(self) -> Any:
+        ...
+
+    @level.setter
+    def level(self, value: Any) -> None:
+        ...
+
+    @property
+    def backend(self) -> str:
+        ...
+
+    @backend.setter
+    def backend(self, value: str) -> None:
+        ...
+
+
+class ISpeculativeConfig(Protocol):
+    ...


### PR DESCRIPTION
# Description

* Create `tpu_commons/interfaces/config_parts.py`: define the abstract protocols for the various configuration objects (`IModelConfig`, `ICacheConfig`, etc.).
* Update `tpu_commons/interfaces/config.py`: modify `IConfig` to use the new, pure `config_parts` interfaces, removing direct dependencies on vllm types.

# Tests

`~/tpu_commons/tests/core$ pytest *.py`

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
