### PR TITLE
[DI] More protocols before detangling TpuPlatform implementations

### DIFF
--- a/tpu_commons/adapters/vllm_config_adapters.py
+++ b/tpu_commons/adapters/vllm_config_adapters.py
@@ -1,0 +1,133 @@
+"""
+Adapters for wrapping concrete vLLM config objects in tpu_commons interfaces.
+"""
+from typing import Any, Optional
+
+import torch
+
+from tpu_commons.interfaces.config_parts import (ICacheConfig,
+                                                 ICompilationConfig,
+                                                 IModelConfig, IParallelConfig,
+                                                 ISchedulerConfig)
+
+
+class VllmCacheConfigAdapter(ICacheConfig):
+
+    def __init__(self, vllm_cache_config: Any):
+        self._vllm_cache_config = vllm_cache_config
+
+    @property
+    def block_size(self) -> Optional[int]:
+        return self._vllm_cache_config.block_size
+
+    @block_size.setter
+    def block_size(self, value: Optional[int]) -> None:
+        self._vllm_cache_config.block_size = value
+
+
+class VllmCompilationConfigAdapter(ICompilationConfig):
+
+    def __init__(self, vllm_compilation_config: Any):
+        self._vllm_compilation_config = vllm_compilation_config
+
+    @property
+    def level(self) -> Any:
+        return self._vllm_compilation_config.level
+
+    @level.setter
+    def level(self, value: Any) -> None:
+        self._vllm_compilation_config.level = value
+
+    @property
+    def backend(self) -> str:
+        return self._vllm_compilation_config.backend
+
+    @backend.setter
+    def backend(self, value: str) -> None:
+        self._vllm_compilation_config.backend = value
+
+
+class VllmModelConfigAdapter(IModelConfig):
+
+    def __init__(self, vllm_model_config: Any):
+        self._vllm_model_config = vllm_model_config
+
+    @property
+    def dtype(self) -> torch.dtype:
+        return self._vllm_model_config.dtype
+
+    @dtype.setter
+    def dtype(self, value: torch.dtype) -> None:
+        self._vllm_model_config.dtype = value
+
+    @property
+    def use_mla(self) -> bool:
+        return self._vllm_model_config.use_mla
+
+
+class VllmParallelConfigAdapter(IParallelConfig):
+
+    def __init__(self, vllm_parallel_config: Any):
+        self._vllm_parallel_config = vllm_parallel_config
+
+    @property
+    def worker_cls(self) -> str:
+        return self._vllm_parallel_config.worker_cls
+
+    @worker_cls.setter
+    def worker_cls(self, value: str) -> None:
+        self._vllm_parallel_config.worker_cls = value
+
+
+class VllmSchedulerConfigAdapter(ISchedulerConfig):
+
+    def __init__(self, vllm_scheduler_config: Any):
+        self._vllm_scheduler_config = vllm_scheduler_config
+
+    @property
+    def max_num_seqs(self) -> int:
+        return self._vllm_scheduler_config.max_num_seqs
+
+    @property
+    def is_multi_step(self) -> bool:
+        return self._vllm_scheduler_config.is_multi_step
+
+    @property
+    def is_multimodal_model(self) -> bool:
+        return self._vllm_scheduler_config.is_multimodal_model
+
+    @property
+    def disable_chunked_mm_input(self) -> bool:
+        return self._vllm_scheduler_config.disable_chunked_mm_input
+
+    @disable_chunked_mm_input.setter
+    def disable_chunked_mm_input(self, value: bool) -> None:
+        self._vllm_scheduler_config.disable_chunked_mm_input = value
+
+    @property
+    def enable_chunked_prefill(self) -> bool:
+        return self._vllm_scheduler_config.enable_chunked_prefill
+
+    @enable_chunked_prefill.setter
+    def enable_chunked_prefill(self, value: bool) -> None:
+        self._vllm_scheduler_config.enable_chunked_prefill = value
+
+    @property
+    def chunked_prefill_enabled(self) -> bool:
+        return self._vllm_scheduler_config.chunked_prefill_enabled
+
+    @chunked_prefill_enabled.setter
+    def chunked_prefill_enabled(self, value: bool) -> None:
+        self._vllm_scheduler_config.chunked_prefill_enabled = value
+
+    @property
+    def max_model_len(self) -> int:
+        return self._vllm_scheduler_config.max_model_len
+
+    @property
+    def max_num_batched_tokens(self) -> int:
+        return self._vllm_scheduler_config.max_num_batched_tokens
+
+    @max_num_batched_tokens.setter
+    def max_num_batched_tokens(self, value: int) -> None:
+        self._vllm_scheduler_config.max_num_batched_tokens = value

--- a/tpu_commons/interfaces/params.py
+++ b/tpu_commons/interfaces/params.py
@@ -1,0 +1,21 @@
+"""
+Defines the abstract contracts for sampling and pooling parameters.
+"""
+from typing import Any, Protocol
+
+
+class IPoolingParams(Protocol):
+    """
+    Abstract contract for PoolingParams.
+    """
+    ...
+
+
+class ISamplingParams(Protocol):
+    """
+    Abstract contract for SamplingParams.
+    """
+
+    @property
+    def sampling_type(self) -> Any:
+        ...

--- a/tpu_commons/interfaces/platform.py
+++ b/tpu_commons/interfaces/platform.py
@@ -1,0 +1,74 @@
+"""
+Defines the abstract contract for a hardware platform.
+"""
+from typing import Any, Optional, Protocol, Union
+
+import torch
+
+from .config import IConfig
+from .params import IPoolingParams, ISamplingParams
+
+
+class IPlatform(Protocol):
+    """
+    A minimal, abstract interface for a hardware platform.
+    """
+
+    def can_update_inplace(self) -> bool:
+        ...
+
+    def check_and_update_config(self, vllm_config: IConfig) -> None:
+        ...
+
+    def get_attn_backend_cls(self, selected_backend: Any, head_size: int,
+                             dtype: torch.dtype, kv_cache_dtype: Optional[str],
+                             block_size: int, use_v1: bool, use_mla: bool,
+                             has_sink: bool) -> str:
+        ...
+
+    def get_device_communicator_cls(self) -> str:
+        ...
+
+    def get_device_name(self, device_id: int = 0) -> str:
+        ...
+
+    def get_device_total_memory(self, device_id: int = 0) -> int:
+        ...
+
+    def get_infinity_values(self, dtype: torch.dtype) -> tuple[float, float]:
+        ...
+
+    def get_lora_vocab_padding_size(self) -> int:
+        ...
+
+    def get_punica_wrapper(self) -> str:
+        ...
+
+    def inference_mode(self) -> Any:
+        ...
+
+    def is_async_output_supported(self, enforce_eager: Optional[bool]) -> bool:
+        ...
+
+    def is_kv_cache_dtype_supported(self, kv_cache_dtype: str) -> bool:
+        ...
+
+    def is_pin_memory_available(self) -> bool:
+        ...
+
+    def set_device(self, device: torch.device) -> None:
+        ...
+
+    def supports_v1(self, model_config: Any) -> bool:
+        ...
+
+    def use_all_gather(self) -> bool:
+        ...
+
+    def validate_request(
+        self,
+        prompt: Any,
+        params: Union[ISamplingParams, IPoolingParams],
+        processed_inputs: Any,
+    ) -> None:
+        ...


### PR DESCRIPTION
# Description

Created the new interface and adapter files:
   * tpu_commons/interfaces/params.py
   * tpu_commons/interfaces/platform.py
   * tpu_commons/adapters/vllm_config_adapters.py

We now have all the building blocks in place to refactor the platform classes themselves. The next step is to make the TpuPlatform implementations in tpu_commons pure by using these new interfaces and adapters.

This PR should be merged after https://github.com/vllm-project/tpu_commons/pull/472.

# Tests

N/A. Pure protocol files.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
