### PR TITLE
Remove unused gcs download code

### DIFF
--- a/tpu_commons/models/jax/utils/file_utils.py
+++ b/tpu_commons/models/jax/utils/file_utils.py
@@ -1,4 +1,3 @@
-import base64
 import glob
 import hashlib
 import os
@@ -19,8 +18,9 @@ hfs = HfFileSystem()
 
 LOCK_DIR = "/tmp/lock"
 
-
 #####  Local file utils  #####
+
+
 def run_cmd(cmd: str, *args, **kwargs) -> subprocess.CompletedProcess:
     return subprocess.run(cmd.split(), *args, **kwargs)
 
@@ -54,89 +54,6 @@ def get_lock(model_name_or_path: str):
 def get_free_disk_size(path: str = "/") -> int:
     free_bytes = shutil.disk_usage(path)[2]
     return free_bytes
-
-
-#####  GCS file utils  #####
-
-# TODO(xiang): Unify GCS path and HF path.
-
-GCS_PREFIX = "gs://"
-LOCAL_MODEL_DIR = os.getenv("HF_HOME", "/tmp/model")
-LOCAL_LORA_DIR = "/tmp/lora"
-
-
-def _get_local_model_dir(remote_dir: str) -> str:
-    return os.path.join(LOCAL_MODEL_DIR, os.path.basename(remote_dir))
-
-
-def _encode_names(names: List[str]) -> str:
-    encoded = "#".join(names).encode()
-    encoded = base64.b64encode(encoded).decode()
-    return encoded[:8]
-
-
-def file_lock(local_name) -> filelock.FileLock:
-    lock_file = os.path.join(LOCK_DIR, local_name + ".lock")
-    lock = filelock.FileLock(lock_file)
-    return lock
-
-
-def is_gcs_path(input_path: str) -> bool:
-    return input_path.startswith(GCS_PREFIX)
-
-
-def list_gcs_dir(gcs_dir: str, pattern: str = "*") -> List[str]:
-    gcs_files = run_cmd(
-        f"gcloud storage ls {os.path.join(gcs_dir, pattern)}",
-        capture_output=True,
-        encoding="utf-8",
-    ).stdout.split()
-    return gcs_files
-
-
-def download_gcs_dir(gcs_dir: str, local_dir: str, pattern: str = "*") -> None:
-    with file_lock(_encode_names([gcs_dir, local_dir, pattern])):
-        os.makedirs(local_dir, exist_ok=True)
-        gcs_files = os.path.join(gcs_dir, pattern)
-        # The `-n` skips existing files.
-        run_cmd(f"gcloud storage cp -n {gcs_files} {local_dir}/", check=True)
-
-
-def download_config_from_gcs(model_path: str) -> str:
-    local_dir = _get_local_model_dir(model_path)
-    download_gcs_dir(model_path, local_dir, "config.json")
-    return local_dir
-
-
-def download_preprocessor_config_from_gcs(model_path: str) -> str:
-    local_dir = _get_local_model_dir(model_path)
-    download_gcs_dir(model_path, local_dir, "preprocessor_config.json")
-    return os.path.join(local_dir, "preprocessor_config.json")
-
-
-def download_tokenizer_from_gcs(tokenizer_path: str) -> str:
-    local_dir = _get_local_model_dir(tokenizer_path)
-    download_gcs_dir(tokenizer_path, local_dir, "tokenizer*")
-    download_gcs_dir(tokenizer_path, local_dir, "special_tokens_map.json")
-    return local_dir
-
-
-def get_gcs_model_weights_size(model_path: str, weights_format: str) -> int:
-    ret = run_cmd(
-        f"gsutil du -s {os.path.join(model_path, weights_format)}",
-        capture_output=True,
-        encoding="utf-8",
-    )
-    size = int(ret.stdout.split(GCS_PREFIX)[0])
-    return size
-
-
-def download_model_weights_from_gcs(model_path: str,
-                                    weights_format: str) -> str:
-    local_dir = _get_local_model_dir(model_path)
-    download_gcs_dir(model_path, local_dir, weights_format)
-    local_files = list_files(local_dir, weights_format)
-    return local_files
 
 
 #####  HuggingFace file utils  #####


### PR DESCRIPTION
# Description

vLLM ModelConfig requires --model to be a local path or a HF model id, so the gcs downloading code (copied from hex-llm) is not useful.

# Tests

local

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
