### PR TITLE
[FixTest]change require_data -> get_data.

### DIFF
--- a/tpu_commons/runner/jax/tpu_jax_runner.py
+++ b/tpu_commons/runner/jax/tpu_jax_runner.py
@@ -1283,7 +1283,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin):
                 audio_feature_lengths = []
                 use_audio_in_video = False
                 for item in self.requests[req_id].mm_kwargs:
-                    mm_input = item.require_data()
+                    mm_input = item.get_data()
                     if mm_input.get("image_grid_thw") is not None:
                         image_grid_thw.append(
                             mm_input["image_grid_thw"].tolist())


### PR DESCRIPTION
# Description

This [PR](https://github.com/vllm-project/vllm/pull/23022) breaks the Test of "E2E offline Inference test" with error

```
(EngineCore_0 pid=222)   File "/workspace/tpu_commons/tpu_commons/runner/jax/tpu_jax_runner.py", line 862, in _execute_model
--
  | (EngineCore_0 pid=222)     self._update_states(scheduler_output)
  | (EngineCore_0 pid=222)   File "/workspace/tpu_commons/tpu_commons/runner/jax/tpu_jax_runner.py", line 1286, in _update_states
  | (EngineCore_0 pid=222)     mm_input = item.require_data()
  | (EngineCore_0 pid=222)                ^^^^^^^^^^^^^^^^^

```

This change is trying to address it. 

# Tests

[Before fix](https://buildkite.com/tpu-commons/tpu-commons-ci/builds/1807)

[After fix](https://buildkite.com/tpu-commons/tpu-commons-ci/builds/1809#0198b488-feb8-43c2-b8a1-b265b450f4ce)

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
