### PR TITLE
fix OOM when loading big tensors in DeepSeekV3

### DIFF
--- a/tpu_commons/models/jax/deepseek_v3.py
+++ b/tpu_commons/models/jax/deepseek_v3.py
@@ -24,6 +24,7 @@ from tpu_commons.models.jax.common.transformer_block import (
     SharedExpertsTransformerBlock, TransformerBlock)
 from tpu_commons.models.jax.utils.weight_utils import (get_param,
                                                        model_weights_generator,
+                                                       print_param_info,
                                                        reshape_params)
 
 logger = init_logger(__name__)


### PR DESCRIPTION
# Description

fix OOM when loading big tensors in DeepSeekV3;
updated some functions for weight loading to speed up loading proceess. Now it has been improved to 20s per safetensor

# Tests

tested with offline benchmarking on first 4 layers
green CI:https://buildkite.com/tpu-commons/tpu-commons-ci/builds/1901#0198bf28-9fda-4aa2-8d21-4e9399dcc847

broken pre-commit test is from irrelevant files 
# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
