### PR TITLE
Move llama3_jax_stashed to the unified loading logic.

### DIFF
--- a/tpu_commons/models/jax/utils/weight_utils.py
+++ b/tpu_commons/models/jax/utils/weight_utils.py
@@ -287,7 +287,11 @@ def _load_hf_weights_on_thread(vllm_config, params: nnx.State,
     head_dim = utils.get_padded_head_dim(head_dim_original)
     head_dim_pad = head_dim - head_dim_original
 
-    shardings = nnx.get_named_sharding(params, mesh)
+    try:
+        shardings = nnx.get_named_sharding(params, mesh)
+    except TypeError:
+        shardings = params
+
     for hf_key, hf_weight in model_weights_single_file_generator(
             weights_file, framework="flax"):
         if hf_key.endswith(".weight"):


### PR DESCRIPTION
# Description

$title

# Tests

unit test and manual test

```
NEW_MODEL_DESIGN=True TPU_BACKEND_TYPE=jax PYTHONPATH=vllm:tpu_commons python tpu_commons/examples/offline_inference.py      --model=/home/fhzhang_google_com/data/meta-llama/Llama-3.1-8B   --tensor_parallel_size=1        --max-tokens=8  --max_model_len=4096        --max-num-seqs=256      --max-num-batched-tokens=2048
```

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
