### PR TITLE
Increase vmem limit for model in Rpav3 kernel.

### DIFF
--- a/tpu_commons/kernels/ragged_paged_attention/v3/kernel.py
+++ b/tpu_commons/kernels/ragged_paged_attention/v3/kernel.py
@@ -1321,7 +1321,7 @@ def ragged_paged_attention(
                 bkv_sz,
                 q.dtype,
                 kv_cache.dtype,
-            ) * 2.1)  # TODO(jevinjiang): figure out why it is so inaccurate?
+            ) * 2.4)  # TODO(jevinjiang): figure out why it is so inaccurate?
     grid = (distribution[2], )
 
     in_specs = [


### PR DESCRIPTION
# Description

Now, the torchax-jax failed to run Mistral-Small-24B-Instruct-2501 and Mixtral-8x7B-Instruct-v0.1.

```
jaxlib._jax.XlaRuntimeError: RESOURCE_EXHAUSTED: Ran out of memory in memory space vmem 
```

Increase the memory mitigates the issue. 
See logs for [Mistral-Small-24B-Instruct-2501](go/vllm-logs/2166215c-87ff-4d84-9daa-ea32716a66f7/static_vllm_log.txt
) and [Mixtral-8x7B-Instruct-v0.1](go/vllm-logs/51717f22-2382-434b-9477-6a701ac60ea2/static_vllm_log.txt
)

FIXES: b/438779127

# Tests
1. Run on bm-infra with all models. see b/438779127#comment22. and 438779127#comment23
2. Wait for [CIT](https://buildkite.com/tpu-commons/tpu-commons-ci/builds/1951).
