### PR TITLE
Remove old docker images in CI

### DIFF
--- a/.buildkite/scripts/run_in_docker.sh
+++ b/.buildkite/scripts/run_in_docker.sh
@@ -50,11 +50,9 @@ else
 fi
 DOCKER_HF_HOME="/tmp/hf_home"
 
-# Prune older images on the host to save space.
-docker system prune -a -f --filter "until=3h"
-
 # (TODO): Consider creating a remote registry to cache and share between agents.
 # Subsequent builds on the same host should be cached.
+docker rmi -f "$(docker images vllm-tpu -q)"
 docker build --no-cache -f docker/Dockerfile -t "vllm-tpu:${BUILDKITE_COMMIT}" .
 
 exec docker run \


### PR DESCRIPTION
# Description

Since we already run `docker build --no-cache` in CI, the old docker images won't be used. Remove them for each new run to save disk space.

# Tests



# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
