### PR TITLE
Disable tests before fixing disk space issue

### DIFF
--- a/.buildkite/pipeline_jax.yml
+++ b/.buildkite/pipeline_jax.yml
@@ -71,6 +71,11 @@ steps:
        - |
          .buildkite/scripts/run_in_docker.sh \
            python3 -m pytest -s -v /workspace/tpu_commons/tests/ \
+           --ignore=/workspace/tpu_commons/tests/models/jax/test_phi3.py \
+           --ignore=/workspace/tpu_commons/tests/models/jax/test_qwen2.py \
+           --ignore=/workspace/tpu_commons/tests/models/jax/test_qwen3.py \
+           --ignore=/workspace/tpu_commons/tests/models/jax/test_llama3.py \
+           --ignore=/workspace/tpu_commons/tests/models/jax/test_qwen2_5_vl.py \
            --ignore=/workspace/tpu_commons/tests/kernels \
            --ignore=/workspace/tpu_commons/tests/models/vllm \
            --ignore=/workspace/tpu_commons/tests/e2e/test_multi_modal_inference.py \


### PR DESCRIPTION
# Description

The CI doesn't actually download models to the `/mnt/disks/persist` 2T disk due to lacking the permission.
It downloads models to the `/var/lib/buildkite-agent` which uses up the 100G disk quickly.
Before fixing this issue, need to disable the disk consuming tests first.

# Tests



# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
