### PR TITLE
Revert "Fix broken vllm compilation_config"

### DIFF
--- a/tpu_commons/platforms/tpu_jax.py
+++ b/tpu_commons/platforms/tpu_jax.py
@@ -116,14 +116,13 @@ class TpuPlatform(Platform):
                 "VLLM_ENABLE_V1_MULTIPROCESSING must be 0 when using Pathways(JAX_PLATFORMS=proxy)"
             )
 
-        from vllm.config import CompilationLevel, CUDAGraphMode
+        from vllm.config import CompilationLevel
 
         cache_config = vllm_config.cache_config
         # For v0, the default block size is 16.
         if cache_config and cache_config.block_size is None:
             cache_config.block_size = cast(BlockSize, 16)
         compilation_config = vllm_config.compilation_config
-        compilation_config.cudagraph_mode = CUDAGraphMode.NONE
 
         # TPU only supports DYNAMO_ONCE compilation level
         # NOTE(xiang): the compilation_config is not used by jax.

--- a/tpu_commons/platforms/tpu_torchax.py
+++ b/tpu_commons/platforms/tpu_torchax.py
@@ -80,7 +80,7 @@ class TpuPlatform(Platform):
 
     @classmethod
     def check_and_update_config(cls, vllm_config: VllmConfig) -> None:
-        from vllm.config import CompilationLevel, CUDAGraphMode
+        from vllm.config import CompilationLevel
 
         cache_config = vllm_config.cache_config
         # For v0, the default block size is 16.
@@ -88,7 +88,6 @@ class TpuPlatform(Platform):
             cache_config.block_size = cast(BlockSize, 16)
         compilation_config = vllm_config.compilation_config
         compilation_config.level = CompilationLevel.NO_COMPILATION
-        compilation_config.cudagraph_mode = CUDAGraphMode.NONE
 
         assert vllm_config.speculative_config is None, \
             "TPU does not support speculative decoding"


### PR DESCRIPTION
Reverts vllm-project/tpu_commons#486

thanks @xiangxu-google for the temp fix, with the change https://github.com/vllm-project/vllm/pull/23005 in vLLM, I think we can revert it now.