### PR TITLE
[Spec Decoding][Optimization] Use existing jitted slicer function for faster and cleaner profile.

### DIFF
--- a/tpu_commons/runner/jax/tpu_jax_runner.py
+++ b/tpu_commons/runner/jax/tpu_jax_runner.py
@@ -979,16 +979,16 @@ class TPUModelRunner(KVConnectorModelRunnerMixin):
                     tpu_sampling_metadata,
                 )
             else:
-                bonus_logits = logits[
-                    spec_decode_metadata.bonus_logits_indices]
+                bonus_logits = self.select_hidden_states_fn(
+                    logits, spec_decode_metadata.bonus_logits_indices)
                 bonus_token_ids = sample(
                     self.rng_params_for_sampling,
                     self.mesh,
                     bonus_logits,
                     tpu_sampling_metadata,
                 )
-                target_logits = logits[
-                    spec_decode_metadata.target_logits_indices]
+                target_logits = self.select_hidden_states_fn(
+                    logits, spec_decode_metadata.target_logits_indices)
                 next_tokens = self.rejection_sampler(
                     draft_token_ids=spec_decode_metadata.draft_token_ids,
                     num_draft_tokens=spec_decode_metadata.draft_lengths,


### PR DESCRIPTION

# Description

Current slicing of spec dec logits are outside of jit boundary resulting in multiple scattered XLA programs which is slow and unclean xprof profile. 

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
