### PR TITLE
[Spec Decoding][Optimization] Avoid unnecessary TPU->CPU transfer when parsing rejection sampling output.

### DIFF
--- a/tpu_commons/runner/jax/metadata.py
+++ b/tpu_commons/runner/jax/metadata.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 
 import jax.numpy as jnp
+import numpy as np
 
 
 @dataclass
@@ -8,6 +9,7 @@ class SpecDecodeMetadata:
     """Metadata for speculative decoding on JAX/TPU, containing all necessary indices."""
     draft_token_ids: jnp.ndarray
     draft_lengths: jnp.ndarray
+    draft_lengths_cpu: np.ndarray
     target_logits_indices: jnp.ndarray
     bonus_logits_indices: jnp.ndarray
     final_logits_indices: jnp.ndarray

--- a/tpu_commons/runner/jax/tpu_jax_runner.py
+++ b/tpu_commons/runner/jax/tpu_jax_runner.py
@@ -1046,7 +1046,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin):
         else:
             valid_sampled_token_ids = self.rejection_sampler.parse_output(
                 next_tokens, self.input_batch.vocab_size,
-                spec_decode_metadata.draft_lengths, num_reqs,
+                spec_decode_metadata.draft_lengths_cpu, num_reqs,
                 spec_decode_metadata.draft_token_ids.shape[0])
 
         # Mask out the sampled tokens that should not be sampled.
@@ -1294,6 +1294,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin):
                      dtype=np.int32)
         ])
 
+        padded_num_draft_tokens_cpu = padded_num_draft_tokens
         # CPU -> TPU copy.
         (padded_num_draft_tokens, padded_draft_token_ids,
          padded_logits_indices, padded_target_logits_indices,
@@ -1305,6 +1306,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin):
         metadata = SpecDecodeMetadata(
             draft_token_ids=padded_draft_token_ids,
             draft_lengths=padded_num_draft_tokens,
+            draft_lengths_cpu=padded_num_draft_tokens_cpu,
             target_logits_indices=padded_target_logits_indices,
             bonus_logits_indices=padded_bonus_logits_indices,
             final_logits_indices=padded_logits_indices,


### PR DESCRIPTION
# Description

`parse_output` requires `num_draft_tokens` on CPU
`rejection_sampler` requires `num_draft_tokens` on TPU.
Initially we have it on CPU, then move it to TPU, but we use it for `parse_output`, it will cause multiple slicing on TPUs and then moving to CPU.

before: https://screenshot.googleplex.com/8yhsBSktETKrZF3
after: https://screenshot.googleplex.com/AaMtdEQPQiZJFyp

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
