### PR TITLE
Handle new_block_ids is None.

### DIFF
--- a/tpu_commons/runner/jax/tpu_jax_runner.py
+++ b/tpu_commons/runner/jax/tpu_jax_runner.py
@@ -1572,11 +1572,13 @@ class TPUModelRunner(KVConnectorModelRunnerMixin):
             # Update the cached states.
             req_state.num_computed_tokens = num_computed_tokens
             if not resumed_from_preemption:
-                # Append the new blocks to the existing block IDs.
-                for block_ids, new_ids in zip(req_state.block_ids,
-                                              new_block_ids):
-                    block_ids.extend(new_ids)
+                if new_block_ids is not None:
+                    # Append the new blocks to the existing block IDs.
+                    for block_ids, new_ids in zip(req_state.block_ids,
+                                                  new_block_ids):
+                        block_ids.extend(new_ids)
             else:
+                assert new_block_ids is not None
                 # The request is resumed from preemption.
                 # Replace the existing block IDs with the new ones.
                 req_state.block_ids = new_block_ids
@@ -1592,7 +1594,9 @@ class TPUModelRunner(KVConnectorModelRunnerMixin):
             # Update the persistent batch.
             self.input_batch.num_computed_tokens_cpu[req_index] = (
                 num_computed_tokens)
-            self.input_batch.block_table.append_row(new_block_ids, req_index)
+            if new_block_ids is not None:
+                self.input_batch.block_table.append_row(
+                    new_block_ids, req_index)
 
             # Add spec_token_ids to token_ids_cpu.
             spec_token_ids = (


### PR DESCRIPTION
# Description

torchax-jax run failed with error

```
[1;36m(EngineCore_0 pid=278)[0;0m ERROR 08-21 02:21:29 [core.py:710]     for block_ids, new_ids in zip(req_state.block_ids,
[1;36m(EngineCore_0 pid=278)[0;0m ERROR 08-21 02:21:29 [core.py:710]                               ^^^^^^^^^^^^^^^^^^^^^^^^
[1;36m(EngineCore_0 pid=278)[0;0m ERROR 08-21 02:21:29 [core.py:710] TypeError: 'NoneType' object is not iterable
```

This is because of PR: https://github.com/vllm-project/vllm/pull/23262

### 
The fix takes [this change](https://github.com/vllm-project/vllm/pull/23262/files#diff-e2942ece30a5c580437694ffb964bfc664b510c59244c08e5921b8f5cefb4280) as reference.

If the change fixes a bug or a Github issue, please include a link, e.g.,:
FIXES: b/440212621

# Tests
1. Manually run `MODEL_IMPL_TYPE=vllm TPU_BACKEND_TYPE=jax python examples/offline_inference.py --model=meta-llama/Llama-3.1-8B-Instruct --tensor_parallel_size=1 --task=generate --max_model_len=1024 --download_dir /mnt/disks/persist`
2. Wait for CIT: https://buildkite.com/tpu-commons/tpu-commons-ci/builds/2077
