### PR TITLE
[RpaV3] Renable Tests Part 1

### DIFF
--- a/.buildkite/pipeline_jax.yml
+++ b/.buildkite/pipeline_jax.yml
@@ -76,7 +76,6 @@ steps:
            python3 -m pytest -s -v -x /workspace/tpu_commons/tests/ \
            --ignore=/workspace/tpu_commons/tests/kernels \
            --ignore=/workspace/tpu_commons/tests/e2e \
-           --ignore=/workspace/tpu_commons/tests/models/vllm \
            --ignore=/workspace/tpu_commons/tpu_commons/mock \
            --cov-config=/workspace/tpu_commons/.coveragerc --cov tpu_commons --cov-report term-missing --cov-fail-under=69
 

--- a/tests/models/vllm/test_jax_merged_column_parallel_linear.py
+++ b/tests/models/vllm/test_jax_merged_column_parallel_linear.py
@@ -49,6 +49,10 @@ def setup_environment():
         ensure_model_parallel_initialized(1, 1)
 
 
+@pytest.mark.skip(
+    reason=
+    "b/440248045. The failure is not caused by Rpav3. Will fix in another change."
+)
 @pytest.mark.parametrize("bias", [False, True])
 @pytest.mark.parametrize("mesh", [test_utils.get_spmd_mesh()])
 @pytest.mark.parametrize("fuse_matmuls", [False, True])
@@ -95,6 +99,10 @@ def test_jax_merged_column_parallel_linear(bias, mesh, fuse_matmuls,
     torch.testing.assert_close(output, jax_output)
 
 
+@pytest.mark.skip(
+    reason=
+    "b/440248045. The failure is not caused by Rpav3. Will fix in another change."
+)
 @pytest.mark.parametrize("bias", [False, True])
 @pytest.mark.parametrize("mesh", [test_utils.get_spmd_mesh()])
 @pytest.mark.parametrize("fuse_matmuls", [False, True])

--- a/tests/models/vllm/test_jax_qkv_parallel_linear.py
+++ b/tests/models/vllm/test_jax_qkv_parallel_linear.py
@@ -49,6 +49,10 @@ def setup_environment():
         ensure_model_parallel_initialized(1, 1)
 
 
+@pytest.mark.skip(
+    reason=
+    "b/440248045. The failure is not caused by Rpav3. Will fix in another change."
+)
 @pytest.mark.parametrize("bias", [False, True])
 @pytest.mark.parametrize("mesh", [test_utils.get_spmd_mesh()])
 @pytest.mark.parametrize("fuse_matmuls", [False, True])
@@ -89,6 +93,10 @@ def test_jax_qkv_parallel_linear(bias, mesh, fuse_matmuls):
     torch.testing.assert_close(output, jax_output)
 
 
+@pytest.mark.skip(
+    reason=
+    "b/440248045. The failure is not caused by Rpav3. Will fix in another change."
+)
 @pytest.mark.parametrize("bias", [False, True])
 @pytest.mark.parametrize("mesh", [test_utils.get_spmd_mesh()])
 @pytest.mark.parametrize("fuse_matmuls", [False, True])

--- a/tests/models/vllm/test_jax_row_parallel_linear.py
+++ b/tests/models/vllm/test_jax_row_parallel_linear.py
@@ -98,7 +98,8 @@ def test_jax_row_parallel_linear(bias, mesh, enable_sp):
 
 @pytest.mark.parametrize("bias", [False, True])
 @pytest.mark.parametrize("mesh", [test_utils.get_spmd_mesh()])
-def test_jax_row_parallel_linear_w8a8_int8(bias, mesh):
+@pytest.mark.parametrize("enable_sp", [False, True])
+def test_jax_row_parallel_linear_w8a8_int8(bias, mesh, enable_sp):
     dtype = torch.bfloat16
 
     engine_args = EngineArgs(
@@ -142,7 +143,8 @@ def test_jax_row_parallel_linear_w8a8_int8(bias, mesh):
 
     # Set jax default device to workaround a layout bug in JAX 0.7.0 and earlier
     with torchax.default_env(), jax.default_device(jax.devices("tpu")[0]):
-        jax_row_linear = JaxRowParallelLinear(row_linear, mesh=mesh)
+        jax_row_linear = JaxRowParallelLinear(
+            row_linear, mesh=mesh, enable_sequence_parallelism=enable_sp)
         jax_input_tensor = torch_view(t2j(input_tensor, use_dlpack=False))
         jax_input_tensor.apply_jax_(jax.device_put,
                                     NamedSharding(mesh, P(None, None)))

--- a/tests/models/vllm/test_torchax_wrapper.py
+++ b/tests/models/vllm/test_torchax_wrapper.py
@@ -50,6 +50,8 @@ def test_with_torchax_global_exception_handling():
         mock_disable.assert_called_once()
 
 
+@pytest.mark.skip(
+    reason="b/440250062. Delete the test when deleting torchax-pt path.")
 @pytest.mark.parametrize("tensor_dtype", [torch.float32, torch.bfloat16])
 @pytest.mark.parametrize("use_mesh", [True, False])
 def test_get_cpu_tensor_from_torchax_tensor(tensor_dtype, use_mesh):


### PR DESCRIPTION
# Description

Re-enable tests. 
Add `tpu_commons/tests/models/vllm` back. 


If the change fixes a bug or a Github issue, please include a link, e.g.,:
FIXES: b/438779127

# Tests
Wait for CI Result.
https://buildkite.com/tpu-commons/tpu-commons-ci/builds/2100
https://buildkite.com/tpu-commons/tpu-commons-ci/builds/2116

