### PR TITLE
Interleave shard the w13 weight in JaxFusedMoE layer to avoid a2a collective.

### DIFF
--- a/tpu_commons/models/vllm/jax_merged_column_parallel_linear_core.py
+++ b/tpu_commons/models/vllm/jax_merged_column_parallel_linear_core.py
@@ -93,15 +93,19 @@ class JaxMergedColumnParallelLinearCore(torch.nn.Module):
             assert output_size % n_shards == 0, "Each output size in MergedColumnParallelLinear must be a  multiple of num chips in the 'model' axis."
 
         concat_weight = t2j(vllm_col_par_linear.weight.data, use_dlpack=False)
-        weight = reorder_concatenated_tensor_for_sharding(
-            concat_weight, self.output_sizes, n_shards)
+        weight = reorder_concatenated_tensor_for_sharding(concat_weight,
+                                                          self.output_sizes,
+                                                          n_shards,
+                                                          dim=0)
         weight = Parameter(torch_view(weight), requires_grad=False)
         self.register_parameter("weight", weight)
 
         if vllm_col_par_linear.bias is not None:
             concat_bias = t2j(vllm_col_par_linear.bias.data, use_dlpack=False)
-            bias = reorder_concatenated_tensor_for_sharding(
-                concat_bias, self.output_sizes, n_shards)
+            bias = reorder_concatenated_tensor_for_sharding(concat_bias,
+                                                            self.output_sizes,
+                                                            n_shards,
+                                                            dim=0)
             bias = Parameter(torch_view(bias), requires_grad=False)
             self.register_parameter("bias", bias)
         else:
@@ -112,7 +116,7 @@ class JaxMergedColumnParallelLinearCore(torch.nn.Module):
             concat_weight_scale = t2j(vllm_col_par_linear.weight_scale.data,
                                       use_dlpack=False)
             weight_scale = reorder_concatenated_tensor_for_sharding(
-                concat_weight_scale, self.output_sizes, n_shards)
+                concat_weight_scale, self.output_sizes, n_shards, dim=0)
             weight_scale = Parameter(torch_view(weight_scale),
                                      requires_grad=False)
             self.register_parameter("weight_scale", weight_scale)


### PR DESCRIPTION
# Description

Similar to qkv/merged col parallel layers, this PR reorders the `w13` weight in the MoE layer such that after the 1st gmm, the results don't require collective to calculate the following activation function.

# Tests

Unit test: `pytest -v tests/models/vllm/test_jax_fused_moe.py`
E2e test: `MODEL_IMPL_TYPE=vllm TPU_BACKEND_TYPE=jax python examples/offline_inference.py    --model=mistralai/Mixtral-8x7B-Instruct-v0.1     --tensor_parallel_size=8     --task=generate     --max_model_len=1024     --max_num_seqs=1`

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
