### PR TITLE
[Spec Decoding] Use correct top_k shape in presence of spec dec metadata

### DIFF
--- a/tpu_commons/runner/jax/tpu_jax_runner.py
+++ b/tpu_commons/runner/jax/tpu_jax_runner.py
@@ -1421,7 +1421,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin):
 
         # Put to device
         sampling_metadata = TPUSupportedSamplingMetadata.from_input_batch(
-            self.mesh, self.input_batch, logits_indices.shape[0])
+            self.mesh, self.input_batch, padded_num_reqs)
         if self.uses_mrope:
             positions = mrope_positions
 


### PR DESCRIPTION
# Description
In presence of spec decoding, `logits_indices` include target tokens as well, but for `top_k, top_p, ...` we want one value per request. 

Current code gives error when we run with 1000 requests and set `--max_num_seqs=256` and use num_speculations 4.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
