### PR TITLE
Fix and re-enable tests.

### DIFF
--- a/tests/models/vllm/test_jax_merged_column_parallel_linear.py
+++ b/tests/models/vllm/test_jax_merged_column_parallel_linear.py
@@ -24,21 +24,19 @@ from tpu_commons.models.vllm.jax_merged_column_parallel_linear import \
 
 P = PartitionSpec
 
+_vllm_config = EngineArgs(
+    model="Qwen/Qwen2-1.5B-Instruct",
+    max_model_len=64,
+    max_num_batched_tokens=64,
+    max_num_seqs=4,
+).create_engine_config()
+
 
 @pytest.fixture(autouse=True)
 def setup_environment():
     # This is a fake config used for init dist env.
     # QKVParallelLinear needs dist env to be initialized.
-    engine_args = EngineArgs(
-        model="Qwen/Qwen2-1.5B-Instruct",
-        max_model_len=64,
-        max_num_batched_tokens=64,
-        max_num_seqs=4,
-    )
-
-    vllm_config = engine_args.create_engine_config()
-
-    with set_current_vllm_config(vllm_config):
+    with set_current_vllm_config(_vllm_config):
         temp_file = tempfile.mkstemp()[1]
         init_distributed_environment(
             1,
@@ -49,10 +47,6 @@ def setup_environment():
         ensure_model_parallel_initialized(1, 1)
 
 
-@pytest.mark.skip(
-    reason=
-    "b/440248045. The failure is not caused by Rpav3. Will fix in another change."
-)
 @pytest.mark.parametrize("bias", [False, True])
 @pytest.mark.parametrize("mesh", [test_utils.get_spmd_mesh()])
 @pytest.mark.parametrize("fuse_matmuls", [False, True])
@@ -60,14 +54,14 @@ def setup_environment():
 def test_jax_merged_column_parallel_linear(bias, mesh, fuse_matmuls,
                                            enable_sp):
     dtype = torch.bfloat16
-
-    merged_column_linear = MergedColumnParallelLinear(
-        input_size=4096,
-        output_sizes=[14336] * 2,
-        bias=bias,
-        params_dtype=dtype,
-        return_bias=False,
-    )
+    with set_current_vllm_config(_vllm_config):
+        merged_column_linear = MergedColumnParallelLinear(
+            input_size=4096,
+            output_sizes=[14336] * 2,
+            bias=bias,
+            params_dtype=dtype,
+            return_bias=False,
+        )
     merged_column_linear.weight.data = torch.rand_like(
         merged_column_linear.weight.data) / 10
     if bias:
@@ -99,24 +93,22 @@ def test_jax_merged_column_parallel_linear(bias, mesh, fuse_matmuls,
     torch.testing.assert_close(output, jax_output)
 
 
-@pytest.mark.skip(
-    reason=
-    "b/440248045. The failure is not caused by Rpav3. Will fix in another change."
-)
 @pytest.mark.parametrize("bias", [False, True])
 @pytest.mark.parametrize("mesh", [test_utils.get_spmd_mesh()])
 @pytest.mark.parametrize("fuse_matmuls", [False, True])
-def test_jax_merged_column_parallel_linear_w8a8_int8(bias, mesh, fuse_matmuls):
+@pytest.mark.parametrize("enable_sp", [False, True])
+def test_jax_merged_column_parallel_linear_w8a8_int8(bias, mesh, fuse_matmuls,
+                                                     enable_sp):
     dtype = torch.bfloat16
-
-    merged_column_linear = MergedColumnParallelLinear(
-        input_size=4096,
-        output_sizes=[14336] * 2,
-        bias=bias,
-        params_dtype=dtype,
-        return_bias=False,
-        quant_config=test_utils.gen_vllm_w8a8_int8_config(),
-    )
+    with set_current_vllm_config(_vllm_config):
+        merged_column_linear = MergedColumnParallelLinear(
+            input_size=4096,
+            output_sizes=[14336] * 2,
+            bias=bias,
+            params_dtype=dtype,
+            return_bias=False,
+            quant_config=test_utils.gen_vllm_w8a8_int8_config(),
+        )
 
     # Assert we're testing the right code path when quant config is set.
     assert isinstance(merged_column_linear.quant_method,
@@ -145,7 +137,7 @@ def test_jax_merged_column_parallel_linear_w8a8_int8(bias, mesh, fuse_matmuls):
     # Set jax default device to workaround a layout bug in JAX 0.7.0 and earlier
     with torchax.default_env(), jax.default_device(jax.devices("tpu")[0]):
         jax_merged_column_linear = JaxMergedColumnParallelLinear(
-            merged_column_linear, mesh, fuse_matmuls)
+            merged_column_linear, mesh, fuse_matmuls, enable_sp)
         jax_input_tensor = torch_view(t2j(input_tensor))
         jax_input_tensor.apply_jax_(jax.device_put,
                                     NamedSharding(mesh, P(None, None)))

--- a/tpu_commons/models/vllm/jax_merged_column_parallel_linear_core.py
+++ b/tpu_commons/models/vllm/jax_merged_column_parallel_linear_core.py
@@ -243,7 +243,6 @@ class JaxMergedColumnParallelLinearCore(torch.nn.Module):
                         'model'] >= TPU_SECOND_LAST_MINOR:
                     input.shard_(NamedSharding(self.mesh, P('model', None)))
             if self.fuse_matmuls:
-                output, output_bias = self.forward_fused(input)
+                return self.forward_fused(input)
             else:
-                output, output_bias = self.forward_split(input)
-            return output, output_bias
+                return self.forward_split(input)


### PR DESCRIPTION
# Description

Re-enable previously disabled tests.

The fixes are: 
1. Move the vllm_config creation from setup_env() to global.
2. `set_current_vllm_config` when creating MergedColumnParallelLinear and QKVParallelLinear.
3. add `enable_sp` whenever needed
4. directly return instead of `output, output_bias = self.forward_fused(input)` to avoid unpack error because sometimes it returns `output` only without `bias`. 

If the change fixes a bug or a Github issue, please include a link, e.g.,:
FIXES: b/440248045

# Tests
1. Local manual tests
5. CIT: https://buildkite.com/tpu-commons/tpu-commons-ci/builds/2151

# Checklist

Before submitting this PR, please make sure:
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have made or will make corresponding changes to any relevant documentation.
