### PR TITLE
Remove the logic of padding head dim to 128 before calling to kernel.

### DIFF
--- a/tests/kernels/ragged_paged_attention_kernel_v3_test.py
+++ b/tests/kernels/ragged_paged_attention_kernel_v3_test.py
@@ -173,6 +173,7 @@ class RaggedPagedAttentionKernelTest(jtu.JaxTestCase):
         self.assertAllClose(output, expected, atol=tol, rtol=tol)
         mask = ~jnp.isnan(expected_kv_cache)
         self.assertArraysEqual(updated_kv_cache[mask], expected_kv_cache[mask])
+        self.assertEqual(output.shape[-1], head_dim)
 
     @parameterized.product(dtype=[jnp.float32, jnp.bfloat16], )
     def test_ragged_paged_attention_basic(self, dtype):


### PR DESCRIPTION
# Description

PRA3 kernel natively supports head dim being less than 128. So, we can remove the padding logic.

FIXES: b/440571948

# Tests
1. Ran on benchmark testing machines and got successful run.
2. Add a CIT to cover head-dim not equal to 128. (https://buildkite.com/tpu-commons/tpu-commons-ci/builds/2176)

# Checklist

Before submitting this PR, please make sure:
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have made or will make corresponding changes to any relevant documentation.
