### PR TITLE
Fix bug in DeepSeekV3

### DIFF
--- a/tpu_commons/models/jax/deepseek_v3.py
+++ b/tpu_commons/models/jax/deepseek_v3.py
@@ -165,7 +165,6 @@ class DeepSeekV3(nnx.Module):
         for i in range(first_k_dense_replace, num_layers):
             is_moe_layer = ((i + 1) % interleave_moe_layer_step == 0)
             router = DeepSeekV3Router(
-                mesh=self.mesh,
                 random_init=self.random_init,
                 hidden_size=hidden_size,
                 num_experts=num_local_experts,


### PR DESCRIPTION
# Description

Fixes a small bug in the DeepSeekV3 model implementation from recent refactoring.

# Tests

Ran:

```
 VLLM_XLA_CHECK_RECOMPILATION=0 VLLM_MLA_DISABLE=1 NEW_MODEL_DESIGN=True TPU_BACKEND_TYPE=jax PHASED_PROFILING_DIR=deepseek-v3-mmlu-1000-profile nohup vllm serve --model=deepseek-ai/DeepSeek-V3  --max-model-len=512 --tensor-parallel-size 8 --max-num-batched-tokens 512 --max-num-seqs=2 --hf-config=deepseek-ai/DeepSeek-V3 --hf_overrides '{"architectures": ["DeepSeekV3"]}'
```

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
