### PR TITLE
Fix vllm multihost ray

### DIFF
--- a/tpu_commons/executors/ray_distributed_executor.py
+++ b/tpu_commons/executors/ray_distributed_executor.py
@@ -5,6 +5,7 @@ import ray
 import vllm.envs as envs
 from ray.util.placement_group import PlacementGroup
 from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
+from vllm.distributed.kv_transfer.kv_connector.utils import KVOutputAggregator
 from vllm.executor.ray_distributed_executor import RayWorkerMetaData
 from vllm.executor.ray_utils import RayWorkerWrapper, _wait_until_pg_ready
 from vllm.platforms import current_platform
@@ -36,8 +37,6 @@ class RayDistributedExecutor(RayDistributedExecutorV1):
     """Ray-based distributed executor"""
 
     def _init_executor(self) -> None:
-        super()._init_executor()
-        
         self.forward_dag: Optional[ray.dag.CompiledDAG] = None
         # V1 uses SPMD worker and compiled DAG
         os.environ["VLLM_USE_RAY_SPMD_WORKER"] = "1"
@@ -73,6 +72,11 @@ class RayDistributedExecutor(RayDistributedExecutorV1):
         self.use_v1 = envs.VLLM_USE_V1
 
         self.pp_locks: Optional[List[asyncio.Lock]] = None
+
+        # KV connector setup
+        self.has_connector = self.vllm_config.kv_transfer_config is not None
+        self.kv_output_aggregator = KVOutputAggregator(
+            self.parallel_config.world_size)
 
     def _initialize_ray_cluster(self,
                                 ray_address: Optional[str] = None) -> None:


### PR DESCRIPTION
# Description

The multihost support on Ray seems to be broken by an upstream change https://github.com/vllm-project/vllm/commit/9f414a12adb991d04d2adf0b80f1f115d6281fad.

This PR intends to do a quick fix to accommodate the upstream change.

# Tests

Before:
```
(EngineCore_0 pid=1534) ERROR 08-25 01:09:28 [core.py:710] EngineCore encountered a fatal error.
(EngineCore_0 pid=1534) ERROR 08-25 01:09:28 [core.py:710] Traceback (most recent call last):
(EngineCore_0 pid=1534) ERROR 08-25 01:09:28 [core.py:710]   File "/workspace/vllm/vllm/v1/engine/core.py", line 701, in run_engine_core
(EngineCore_0 pid=1534) ERROR 08-25 01:09:28 [core.py:710]     engine_core.run_busy_loop()
(EngineCore_0 pid=1534) ERROR 08-25 01:09:28 [core.py:710]   File "/workspace/vllm/vllm/v1/engine/core.py", line 728, in run_busy_loop
(EngineCore_0 pid=1534) ERROR 08-25 01:09:28 [core.py:710]     self._process_engine_step()
(EngineCore_0 pid=1534) ERROR 08-25 01:09:28 [core.py:710]   File "/workspace/vllm/vllm/v1/engine/core.py", line 753, in _process_engine_step
(EngineCore_0 pid=1534) ERROR 08-25 01:09:28 [core.py:710]     outputs, model_executed = self.step_fn()
(EngineCore_0 pid=1534) ERROR 08-25 01:09:28 [core.py:710]                               ^^^^^^^^^^^^^^
(EngineCore_0 pid=1534) ERROR 08-25 01:09:28 [core.py:710]   File "/workspace/vllm/vllm/v1/engine/core.py", line 289, in step
(EngineCore_0 pid=1534) ERROR 08-25 01:09:28 [core.py:710]     model_output = self.execute_model_with_error_logging(
(EngineCore_0 pid=1534) ERROR 08-25 01:09:28 [core.py:710]                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_0 pid=1534) ERROR 08-25 01:09:28 [core.py:710]   File "/workspace/vllm/vllm/v1/engine/core.py", line 275, in execute_model_with_error_logging
(EngineCore_0 pid=1534) ERROR 08-25 01:09:28 [core.py:710]     raise err
(EngineCore_0 pid=1534) ERROR 08-25 01:09:28 [core.py:710]   File "/workspace/vllm/vllm/v1/engine/core.py", line 266, in execute_model_with_error_logging
(EngineCore_0 pid=1534) ERROR 08-25 01:09:28 [core.py:710]     return model_fn(scheduler_output)
(EngineCore_0 pid=1534) ERROR 08-25 01:09:28 [core.py:710]            ^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_0 pid=1534) ERROR 08-25 01:09:28 [core.py:710]   File "/workspace/vllm/vllm/v1/executor/ray_distributed_executor.py", line 83, in execute_model
(EngineCore_0 pid=1534) ERROR 08-25 01:09:28 [core.py:710]     if not self.has_connector:
(EngineCore_0 pid=1534) ERROR 08-25 01:09:28 [core.py:710]            ^^^^^^^^^^^^^^^^^^
(EngineCore_0 pid=1534) ERROR 08-25 01:09:28 [core.py:710] AttributeError: 'RayDistributedExecutor' object has no attribute 'has_connector'

```

After:
```
(EngineCore_0 pid=1471) INFO 08-25 18:14:45 [ray_distributed_executor.py:619] Using RayPPCommunicator (which wraps vLLM _PP GroupCoordinator) for Ray Compiled Graph communication.
Processed prompts: 100%|█████████████████████████████████████████████████████████████| 35/35 [00:00<00:00, 143.98it/s, est. speed input: 1515.07 toks/s, output: 2305.48 toks/s]
--------------------------------------------------
Prompt: 'Hello, my name is'
Generated text: " and I'm writing you today to learn more about the 2019 Ford F"
--------------------------------------------------
Prompt: 'The capital of France is'
Generated text: ' a city of many faces. It is a city of history, culture, and'
--------------------------------------------------
Prompt: 'The colors of the rainbow are'
Generated text: ' red, orange, yellow, green, blue, indigo, and violet.'
```

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
