### PR TITLE
[Phase-Based Profiler] Add `ms` to saved batch composition metadata filename

### DIFF
--- a/tpu_commons/runner/utils.py
+++ b/tpu_commons/runner/utils.py
@@ -411,10 +411,10 @@ class PhasedBasedProfiler:
             self, batch_composition_stats: dict) -> None:
         """
         Writes the batch composition stats to a file at the given time,
-        e.g.: prefill_heavy/batch_composition_stats_2025_08_22_15_41_41.json
+        e.g.: prefill_heavy/batch_composition_stats_2025_08_22_15_41_41_505018.json
         """
         now = datetime.datetime.now()
-        date_string_in_profiler_format = now.strftime("%Y_%m_%d_%H_%M_%S")
+        date_string_in_profiler_format = now.strftime("%Y_%m_%d_%H_%M_%S_%f")
 
         with open(
                 os.path.join(


### PR DESCRIPTION
# Description

Given that the forward pass for a given batch takes on the order of ms, we are seeing that the JSON metadata files concerning batch composition are being overidden, since they are being tagged only to the granularity of seconds

# Tests

N/A

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
