### PR TITLE
Simplify tensor slicing logic by removing shard_map

### DIFF
--- a/tpu_commons/models/vllm/jax_fused_moe.py
+++ b/tpu_commons/models/vllm/jax_fused_moe.py
@@ -112,7 +112,7 @@ def tensor_sharded_gmm_merged_column_parallel(
     output_sizes = [intermediate_size, intermediate_size]
 
     return slice_sharded_tensor_for_concatenation(gmm_result, output_sizes,
-                                                  n_shards, mesh)
+                                                  n_shards)
 
 
 def tensor_sharded_gmm_row_parallel(

--- a/tpu_commons/models/vllm/jax_merged_column_parallel_linear_core.py
+++ b/tpu_commons/models/vllm/jax_merged_column_parallel_linear_core.py
@@ -179,7 +179,7 @@ class JaxMergedColumnParallelLinearCore(torch.nn.Module):
 
         n_shards = self.mesh.shape['model']
         split_outputs = slice_sharded_tensor_for_concatenation(
-            output, self.output_sizes, n_shards, self.mesh)
+            output, self.output_sizes, n_shards)
         if self.gather_output:
             split_outputs = [
                 jax.lax.with_sharding_constraint(t,
@@ -195,7 +195,7 @@ class JaxMergedColumnParallelLinearCore(torch.nn.Module):
             output_bias = None
         else:
             split_biases = slice_sharded_tensor_for_concatenation(
-                self.bias, self.output_sizes, n_shards, self.mesh)
+                self.bias, self.output_sizes, n_shards)
             output_bias = torch_view(jnp.concatenate(split_biases, axis=-1))
         return output, output_bias
 


### PR DESCRIPTION
# Description

Simplify tensor slicing logic by removing shard_map. Use reshape, slice, and concatenation to achieve the same result.

This logic was separated from https://github.com/vllm-project/tpu_commons/pull/512

# Tests

Ran following models and verified that performance and numerics results has not changed

- Unquantized
  - meta-llama/Llama-3.1-8B-Instruct
  - meta-llama/Llama-3.1-70B-Instruct
- Quantized
  - RedHatAI/Meta-Llama-3.1-8B-Instruct-quantized.w8a8
  - RedHatAI/Meta-Llama-3.1-70B-Instruct-quantized.w8a8

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.