### PR TITLE
change deepseek jax model's registry name to match vllm

### DIFF
--- a/tpu_commons/models/jax/model_loader.py
+++ b/tpu_commons/models/jax/model_loader.py
@@ -88,7 +88,7 @@ def _get_model_architecture(config: PretrainedConfig) -> nnx.Module:
         from tpu_commons.models.jax.llama3 import LlamaForCausalLM
 
     _MODEL_REGISTRY["Llama4ForCausalLM"] = Llama4ForCausalLM
-    _MODEL_REGISTRY["DeepSeekV3"] = DeepSeekV3
+    _MODEL_REGISTRY["DeepseekV3ForCausalLM"] = DeepSeekV3
     _MODEL_REGISTRY["LlamaForCausalLM"] = LlamaForCausalLM
     _MODEL_REGISTRY["Qwen2ForCausalLM"] = Qwen2ForCausalLM
     _MODEL_REGISTRY["Qwen3ForCausalLM"] = Qwen3ForCausalLM


### PR DESCRIPTION
# Description

Register deepseek v3 as "DeepseekV3ForCausalLM" to match the name in vllm, this will avoid the error `Model architectures ['DeepSeekV3'] are not supported for now`

# Tests

Test this bypass the model error, but there are still other errors to run deepseek on vllm E2E. 

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
