### PR TITLE
[Kernel] Add patch to enable v7x with RPAv3 kernel

### DIFF
--- a/tpu_commons/kernels/ragged_paged_attention/v3/util.py
+++ b/tpu_commons/kernels/ragged_paged_attention/v3/util.py
@@ -36,6 +36,8 @@ def next_power_of_2(x: int):
 def get_tpu_version() -> int:
     """Returns the numeric version of the TPU, or -1 if not on TPU."""
     kind = jax.devices()[0].device_kind
+    if kind == "TPU7x":
+        return 7
     if 'TPU' not in kind:
         return -1
     if kind.endswith(' lite'):


### PR DESCRIPTION
# Description

This hotfixes an issue where the RPAv3 kernel would not recognize v7x TPUs.

# Tests

Verified locally.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
