### PR TITLE
[Model] Shard embedding & lm_head

### DIFF
--- a/tpu_commons/models/vllm/sharding.py
+++ b/tpu_commons/models/vllm/sharding.py
@@ -3,6 +3,7 @@ import functools
 import humanize
 import jax
 import torch
+from torch.nn import Parameter
 import torchax
 from jax.sharding import Mesh, NamedSharding, PartitionSpec
 from torch.utils import _pytree as pytree
@@ -10,6 +11,7 @@ from torchax.interop import torch_view
 from torchax.ops.mappings import t2j
 from vllm.config import VllmConfig
 from vllm.model_executor.layers.fused_moe import FusedMoE
+from vllm.model_executor.layers.vocab_parallel_embedding import VocabParallelEmbedding, ParallelLMHead
 
 from tpu_commons.logger import init_logger
 from tpu_commons.models.vllm.jax_fused_moe import JaxFusedMoE
@@ -26,9 +28,34 @@ def shard_fused_moe(layer: torch.nn.Module, mesh: Mesh,
     return jax_layer
 
 
+def shard_vocab_parallel_embedding(layer: torch.nn.Module, mesh: Mesh, vllm_config: VllmConfig):
+    assert isinstance(layer, VocabParallelEmbedding)
+    w = Parameter(torch_view(t2j(layer.weight)), requires_grad=False)
+    layer.weight = w.apply_jax_(jax.device_put,
+        NamedSharding(mesh, P('model', None)))
+    return layer
+
+
+def shard_lm_head(layer: torch.nn.Module, mesh: Mesh, vllm_config: VllmConfig):
+    # TODO(qihqi): currently this is not handling case of tie_word_weights=True.
+    # if that config is set, then we should not create new weights but reuse the weight
+    # from VocabParallelEmbedding
+    assert isinstance(layer, ParallelLMHead)
+    w = Parameter(torch_view(t2j(layer.weight)), requires_grad=False)
+    layer.weight = w.apply_jax_(jax.device_put,
+        NamedSharding(mesh, P('model', None)))
+    if hasattr(layer, 'bias'):
+        bias = Parameter(torch_view(t2j(layer.bias)), requires_grad=False)
+        layer.bias = bias.apply_jax_(jax.device_put,
+            NamedSharding(mesh, P('model')))
+    return layer
+
+
 MODULE_TYPE_TO_WRAPPING_FUNC = {
     # TODO(kyuyeunk): Refactor this layer to use vLLM APIs.
     FusedMoE: shard_fused_moe,
+    VocabParallelEmbedding: shard_vocab_parallel_embedding,
+    ParallelLMHead: shard_lm_head,
 }
 
 


### PR DESCRIPTION
# Description

Upstream models usually uses VocabParallelEmbedding and ParallelLMHead to parallelize the weights of embedding and final out proj to many devices. In torchax path, we are not sharding those. 

This PR will shard those according same as GPU.

# Tests

CI

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
