### PR TITLE
[Kernel] Improve logic for finding TPU version number

### DIFF
--- a/tpu_commons/kernels/quantized_matmul/tuned_block_sizes.py
+++ b/tpu_commons/kernels/quantized_matmul/tuned_block_sizes.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import re
+
 import jax
 
 from tpu_commons.logger import init_logger
@@ -276,12 +278,10 @@ TUNED_BLOCK_SIZES = {
 def get_tpu_version() -> int:
     """Returns the numeric version of the TPU, or -1 if not on TPU."""
     kind = jax.devices()[0].device_kind
-    if 'TPU' not in kind:
+    match = re.match(r'^TPU[^\d]*(\d+)', kind)
+    if match is None:
         return -1
-    if kind.endswith(' lite'):
-        kind = kind[:-len(' lite')]
-    assert kind[:-1] == 'TPU v', kind
-    return int(kind[-1])
+    return int(match.group(1))
 
 
 def get_key(

--- a/tpu_commons/kernels/ragged_paged_attention/v3/util.py
+++ b/tpu_commons/kernels/ragged_paged_attention/v3/util.py
@@ -1,5 +1,7 @@
 """Utility functions for ragged paged attention."""
 
+import re
+
 import jax
 from jax._src import dtypes
 
@@ -36,14 +38,10 @@ def next_power_of_2(x: int):
 def get_tpu_version() -> int:
     """Returns the numeric version of the TPU, or -1 if not on TPU."""
     kind = jax.devices()[0].device_kind
-    if kind == "TPU7x":
-        return 7
-    if 'TPU' not in kind:
+    match = re.match(r'^TPU[^\d]*(\d+)', kind)
+    if match is None:
         return -1
-    if kind.endswith(' lite'):
-        kind = kind[:-len(' lite')]
-    assert kind[:-1] == 'TPU v', kind
-    return int(kind[-1])
+    return int(match.group(1))
 
 
 def get_device_name(num_devices: int | None = None):


### PR DESCRIPTION
# Description

Use regex pattern matching to find TPU version number.

As a future TODO, consider using same `get_tpu_version` function for both quantized matmul and RPA kernel.

# Tests

https://buildkite.com/tpu-commons/tpu-commons-ci/builds/2486

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
