### PR TITLE
[Bugfix] Fix PlaceholderRange import error

### DIFF
--- a/tests/runner/jax/test_multimodal_manager.py
+++ b/tests/runner/jax/test_multimodal_manager.py
@@ -6,10 +6,10 @@ from vllm.config import (CacheConfig, ModelConfig, ParallelConfig,
                          SchedulerConfig, SpeculativeConfig, VllmConfig)
 from vllm.model_executor.layers.rotary_embedding import MRotaryEmbedding
 from vllm.multimodal.inputs import (MultiModalBatchedField,
-                                    MultiModalFieldElem, MultiModalKwargsItem)
+                                    MultiModalFieldElem, MultiModalKwargsItem,
+                                    PlaceholderRange)
 from vllm.sampling_params import SamplingType
 from vllm.v1.core.sched.output import SchedulerOutput as VllmSchedulerOutput
-from vllm.v1.request import PlaceholderRange
 
 from tpu_commons.runner.jax.input_batch_jax import CachedRequestState
 from tpu_commons.runner.jax.tpu_jax_runner import TPUModelRunner


### PR DESCRIPTION
# Description

After upstream change in https://github.com/vllm-project/vllm/pull/23779, `tests/runner/jax/test_multimodal_manager.py` test fails with below error. This PR fixes this issue.

```
==================================== ERRORS ====================================
--
  | _________ ERROR collecting tests/runner/jax/test_multimodal_manager.py _________
  | ImportError while importing test module '/workspace/tpu_commons/tests/runner/jax/test_multimodal_manager.py'.
  | Hint: make sure your test modules/packages have valid Python names.
  | Traceback:
  | /usr/local/lib/python3.12/importlib/__init__.py:90: in import_module
  | return _bootstrap._gcd_import(name[level:], package, level)
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  | tests/runner/jax/test_multimodal_manager.py:12: in <module>
  | from vllm.v1.request import PlaceholderRange
  | E   ImportError: cannot import name 'PlaceholderRange' from 'vllm.v1.request' (/workspace/vllm/vllm/v1/request.py)
```



# Tests

```
pytest tests/runner/jax/test_multimodal_manager.py
```

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
