### PR TITLE
enable hybrid kv cache allocator

### DIFF
--- a/tests/models/vllm/layers/test_pallas_torchax.py
+++ b/tests/models/vllm/layers/test_pallas_torchax.py
@@ -179,7 +179,9 @@ class TestPallasAttentionBackendImpl:
         query, key, value, kv_cache, metadata = create_inputs(mesh)
 
         with torchax.default_env(), set_vllm_model_wrapper_context(
-                kv_caches=[kv_cache], mesh=mesh):
+                kv_caches=[kv_cache],
+                mesh=mesh,
+                layer_name_to_kvcache_index={'0': 0}):
             impl.forward(layer, query, key, value, torch.tensor([]), metadata)
 
     def test_forward_with_vllm_kv_cache_raises_error(self, mesh):

--- a/tests/runner/test_kv_cache_manager.py
+++ b/tests/runner/test_kv_cache_manager.py
@@ -1,12 +1,20 @@
 from unittest.mock import MagicMock, patch
 
+import jax
 import jax.numpy as jnp
 import numpy as np
+import torch
+from vllm.attention import Attention
+from vllm.attention.backends.abstract import AttentionType
 from vllm.config import (CacheConfig, ModelConfig, ParallelConfig,
                          SchedulerConfig, VllmConfig)
 from vllm.sampling_params import SamplingType
+from vllm.v1.kv_cache_interface import (FullAttentionSpec, KVCacheConfig,
+                                        KVCacheGroupSpec, KVCacheTensor,
+                                        SlidingWindowSpec)
 from vllm.v1.request import Request
 
+from tpu_commons import utils as common_utils
 from tpu_commons.runner.input_batch_jax import CachedRequestState
 from tpu_commons.runner.tpu_jax_runner import TPUModelRunner
 
@@ -16,8 +24,14 @@ class TestKVCacheManager:
     def setup_method(self):
         # Mock JAX dependencies
         self.mock_devices = [MagicMock()] * 4
-        self.mock_mesh = MagicMock()
         self.mock_rng_key = MagicMock()
+
+        # create 1x1 mesh
+        devices = np.asarray(jax.devices()[:1])
+        axis_names = ('data', 'model')
+        mesh_shape = (1, 1)
+        self.mock_mesh = jax.sharding.Mesh(devices.reshape(mesh_shape),
+                                           axis_names)
 
         with patch('jax.devices', return_value=self.mock_devices), \
              patch('jax.make_mesh', return_value=self.mock_mesh), \
@@ -187,3 +201,158 @@ class TestKVCacheManager:
                                             mode='constant')
             np.testing.assert_array_equal(updated_block_content,
                                           expected_padded_slice)
+
+    def test_get_kv_cache_spec_with_compilation_cfg(self):
+        # tests we create kv cache spec from compilation config
+        # create a static forward context with
+        # 10 full attention layers +
+        # 10 sliding window attention layers
+        # 1 layer with shared kv cache.
+        num_kv_heads = 16
+        head_size = 128
+        attn_type = AttentionType.DECODER
+        sliding_window = 10
+        static_forward_context = {}
+        for i in range(10):
+            static_forward_context[f'layer.{i}'] = MagicMock(
+                spec=Attention,
+                num_kv_heads=num_kv_heads,
+                head_size=head_size,
+                attn_type=attn_type,
+                sliding_window=None,
+                kv_sharing_target_layer_name=None,
+            )
+        for i in range(10, 20):
+            static_forward_context[f'layer.{i}'] = MagicMock(
+                spec=Attention,
+                num_kv_heads=num_kv_heads,
+                head_size=head_size,
+                attn_type=attn_type,
+                sliding_window=sliding_window,
+                kv_sharing_target_layer_name=None,
+            )
+        static_forward_context['layer.20'] = MagicMock(
+            spec=Attention,
+            num_kv_heads=num_kv_heads,
+            head_size=head_size,
+            attn_type=attn_type,
+            sliding_window=None,
+            kv_sharing_target_layer_name='layer.0',
+        )
+        self.runner.vllm_config.compilation_config.static_forward_context = \
+            static_forward_context
+
+        kv_cache_spec = self.runner.get_kv_cache_spec()
+
+        expected_full_attn_spec = FullAttentionSpec(
+            block_size=self.runner.vllm_config.cache_config.block_size,
+            num_kv_heads=common_utils.get_padded_num_heads(
+                num_kv_heads, self.runner.mesh.shape["model"]),
+            head_size=common_utils.get_padded_head_dim(head_size),
+            dtype=torch.bfloat16,
+            use_mla=self.runner.vllm_config.model_config.use_mla,
+        )
+        expected_sliding_window_spec = SlidingWindowSpec(
+            block_size=self.runner.vllm_config.cache_config.block_size,
+            num_kv_heads=common_utils.get_padded_num_heads(
+                num_kv_heads, self.runner.mesh.shape["model"]),
+            head_size=common_utils.get_padded_head_dim(head_size),
+            dtype=torch.bfloat16,
+            sliding_window=sliding_window,
+            use_mla=self.runner.vllm_config.model_config.use_mla,
+        )
+        assert len(kv_cache_spec) == 20
+        for i in range(10):
+            assert kv_cache_spec[f'layer.{i}'] == expected_full_attn_spec
+        for i in range(10, 20):
+            assert kv_cache_spec[f'layer.{i}'] == expected_sliding_window_spec
+        assert 'layer.20' not in kv_cache_spec
+        assert self.runner.kv_cache_manager.shared_kv_cache_layers == {
+            'layer.20': 'layer.0'
+        }
+
+    def test_get_kv_cache_spec_without_compilation_cfg(self):
+        # tests if there's no compilation config, we use full attention kv
+        # cache for each layer.
+        model_config = self.runner.vllm_config.model_config
+        parallel_config = self.runner.vllm_config.parallel_config
+        head_size = model_config.get_head_size()
+        num_kv_heads = model_config.get_total_num_kv_heads()
+        num_layers = model_config.get_num_layers(parallel_config)
+
+        self.runner.vllm_config.compilation_config.static_forward_context = {}
+        kv_cache_spec = self.runner.get_kv_cache_spec()
+
+        assert len(kv_cache_spec) == num_layers
+        expected_full_attn_spec = FullAttentionSpec(
+            block_size=self.runner.vllm_config.cache_config.block_size,
+            num_kv_heads=common_utils.get_padded_num_heads(
+                num_kv_heads, self.runner.mesh.shape["model"]),
+            head_size=common_utils.get_padded_head_dim(head_size),
+            dtype=torch.bfloat16,
+            use_mla=self.runner.vllm_config.model_config.use_mla,
+        )
+        for i in range(num_layers):
+            assert kv_cache_spec[f'layer.{i}'] == expected_full_attn_spec
+        assert len(self.runner.kv_cache_manager.shared_kv_cache_layers) == 0
+
+    def test_initialize_kv_cache(self):
+        # create a kv cache config with 10 layers full attention and 10 layers
+        # sliding window attention.
+        block_size = self.runner.vllm_config.cache_config.block_size
+        num_kv_heads = 8
+        head_size = 128
+        use_mla = False
+        sliding_window = 100
+        num_blocks = 100
+        kv_packing = 2  #bf16
+        sliding_window_spec = SlidingWindowSpec(
+            block_size=block_size,
+            num_kv_heads=num_kv_heads,
+            head_size=head_size,
+            dtype=torch.bfloat16,
+            sliding_window=sliding_window,
+            use_mla=use_mla,
+        )
+        full_attn_spec = FullAttentionSpec(
+            block_size=block_size,
+            num_kv_heads=num_kv_heads,
+            head_size=head_size,
+            dtype=torch.bfloat16,
+            use_mla=use_mla,
+        )
+        kv_cache_groups = [
+            KVCacheGroupSpec(layer_names=[f'layer.{i}' for i in range(10)],
+                             kv_cache_spec=full_attn_spec),
+            KVCacheGroupSpec(layer_names=[f'layer.{i}' for i in range(10, 20)],
+                             kv_cache_spec=sliding_window_spec),
+        ]
+        kv_cache_tensors = []
+        page_size_bytes = full_attn_spec.page_size_bytes
+        for i in range(10):
+            kv_cache_tensors.append(
+                KVCacheTensor(
+                    size=num_blocks * page_size_bytes,
+                    shared_by=[f'layer.{i}', f'layer.{i+10}'],
+                ))
+        kv_cache_config = KVCacheConfig(
+            num_blocks=num_blocks,
+            kv_cache_tensors=kv_cache_tensors,
+            kv_cache_groups=kv_cache_groups,
+        )
+
+        original_input_batch = self.runner.input_batch
+        self.runner.initialize_kv_cache(kv_cache_config)
+
+        # assert kv cache config with multiple kv cache groups will reinit
+        # input batch.
+        assert original_input_batch != self.runner.input_batch
+        assert len(self.runner.kv_caches) == 10
+        for i in range(10):
+            assert self.runner.kv_caches[i].shape == (num_blocks, block_size,
+                                                      num_kv_heads * 2 //
+                                                      kv_packing, kv_packing,
+                                                      head_size)
+            assert self.runner.layer_name_to_kvcache_index[f'layer.{i}'] == i
+            assert self.runner.layer_name_to_kvcache_index[
+                f'layer.{i + 10}'] == i

--- a/tpu_commons/models/jax/model_loader.py
+++ b/tpu_commons/models/jax/model_loader.py
@@ -180,6 +180,7 @@ def get_flax_model(
             hidden_states_sharding,
         ),
         donate_argnums=2,  # 0 is graphdef, 1 is state, 2 is kv_cache
+        static_argnums=6,  #6 is layer_name_to_kvcache_index
     )
     def run_model(graphdef, state, *args):
         model = nnx.merge(graphdef, state)

--- a/tpu_commons/models/vllm/vllm_model_wrapper_context.py
+++ b/tpu_commons/models/vllm/vllm_model_wrapper_context.py
@@ -1,6 +1,6 @@
 from contextlib import contextmanager
 from dataclasses import dataclass
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 import jax
 from jax.sharding import Mesh
@@ -10,6 +10,7 @@ from jax.sharding import Mesh
 class VllmModelWrapperContext:
     kv_caches: List[jax.Array]
     mesh: Mesh
+    layer_name_to_kvcache_index: Dict[str, int]
 
 
 _vllm_model_wrapper_context: Optional[VllmModelWrapperContext] = None
@@ -28,11 +29,15 @@ def set_vllm_model_wrapper_context(
     *,
     kv_caches: List[jax.Array],
     mesh: Mesh,
+    layer_name_to_kvcache_index: Dict[str, int] = None,
 ):
     global _vllm_model_wrapper_context
     prev_context = _vllm_model_wrapper_context
-    _vllm_model_wrapper_context = VllmModelWrapperContext(kv_caches=kv_caches,
-                                                          mesh=mesh)
+    _vllm_model_wrapper_context = VllmModelWrapperContext(
+        kv_caches=kv_caches,
+        mesh=mesh,
+        layer_name_to_kvcache_index=layer_name_to_kvcache_index,
+    )
 
     try:
         yield

--- a/tpu_commons/runner/compilation_manager.py
+++ b/tpu_commons/runner/compilation_manager.py
@@ -114,10 +114,11 @@ class CompilationManager:
                 input_ids,
                 attention_metadata,
                 inputs_embeds,
+                layer_name_to_kvcache_index,
             ):
                 kv_caches, hidden_states = self.runner.model_fn(
                     state, kv_caches, input_ids, attention_metadata,
-                    inputs_embeds)
+                    inputs_embeds, layer_name_to_kvcache_index)
                 self.runner.kv_caches = kv_caches
                 return hidden_states
 
@@ -129,6 +130,7 @@ class CompilationManager:
                 input_ids,
                 attention_metadata,
                 inputs_embeds,
+                tuple(self.runner.layer_name_to_kvcache_index.items()),
                 num_tokens=num_tokens,
             )
 

--- a/tpu_commons/runner/kv_cache_manager.py
+++ b/tpu_commons/runner/kv_cache_manager.py
@@ -1,17 +1,20 @@
 import functools
-from typing import TYPE_CHECKING, List
+from typing import TYPE_CHECKING, Dict, List
 
 import jax
 import jax.numpy as jnp
 import torch
 from jax.sharding import NamedSharding, PartitionSpec
+from vllm.attention import Attention
+from vllm.attention.backends.abstract import AttentionType
+from vllm.config import get_layers_from_vllm_config
 from vllm.v1.kv_cache_interface import (FullAttentionSpec, KVCacheConfig,
-                                        KVCacheSpec)
+                                        KVCacheSpec, SlidingWindowSpec)
 
 from tpu_commons import utils as common_utils
 from tpu_commons.logger import init_logger
 from tpu_commons.runner import utils as runner_utils
-from tpu_commons.runner.input_batch_jax import CachedRequestState
+from tpu_commons.runner.input_batch_jax import CachedRequestState, InputBatch
 from tpu_commons.runner.kv_cache import create_kv_caches
 
 if TYPE_CHECKING:
@@ -26,53 +29,138 @@ class KVCacheManager:
 
     def __init__(self, runner: "TPUModelRunner"):
         self.runner = runner
+        # Layer pairings for cross-layer KV sharing.
+        # If an Attention layer `layer_name` is in the keys of this dict, it
+        # means this layer will perform attention using the keys and values
+        # from the KV cache of `shared_kv_cache_layers[layer_name]`.
+        self.shared_kv_cache_layers: dict[str, str] = {}
 
     def get_kv_cache_spec(self):
         # TODO(xiang): this hack tricks engine core to init successfully
-        block_size = self.runner.vllm_config.cache_config.block_size
+        block_size = self.runner.cache_config.block_size
+        use_mla = self.runner.model_config.use_mla
         kv_cache_spec: dict[str, KVCacheSpec] = {}
-        model_config = self.runner.vllm_config.model_config
-        parallel_config = self.runner.vllm_config.parallel_config
 
-        # Pad num_kv_heads to multiple of TP size.
-        num_kv_heads = common_utils.get_padded_num_heads(
-            model_config.get_total_num_kv_heads(),
-            self.runner.mesh.shape["model"])
-
-        # Pad head_dim to multiple of 128.
-        head_size = model_config.get_head_size()
-        head_size = common_utils.get_padded_head_dim(head_size)
-
-        for i in range(model_config.get_num_layers(parallel_config)):
-            kv_cache_spec[f"layers.{i}"] = FullAttentionSpec(
-                block_size=block_size,
-                num_kv_heads=num_kv_heads,
-                head_size=head_size,
-                dtype=torch.bfloat16,
-                use_mla=False,
-            )
-
+        # If use pure jax (MODEL_IMPL_TYPE=flax_nnx), we don't register
+        # attention into compilation config.
+        # Use FullAttentionSpec for each layer
+        if len(self.runner.vllm_config.compilation_config.
+               static_forward_context) == 0:
+            model_config = self.runner.model_config
+            parallel_config = self.runner.parallel_config
+            # Pad num_kv_heads to multiple of TP size.
+            num_kv_heads = common_utils.get_padded_num_heads(
+                model_config.get_total_num_kv_heads(),
+                self.runner.mesh.shape["model"])
+            head_size = common_utils.get_padded_head_dim(
+                model_config.get_head_size())
+            for i in range(model_config.get_num_layers(parallel_config)):
+                kv_cache_spec[f"layer.{i}"] = FullAttentionSpec(
+                    block_size=block_size,
+                    num_kv_heads=num_kv_heads,
+                    head_size=head_size,
+                    dtype=torch.bfloat16,
+                    use_mla=use_mla,
+                )
+        else:
+            # Else propagate attention modules from compilation config.
+            layers = get_layers_from_vllm_config(self.runner.vllm_config,
+                                                 Attention)
+            for layer_name, attn_module in layers.items():
+                if (kv_tgt_layer :=
+                        attn_module.kv_sharing_target_layer_name) is not None:
+                    # The layer doesn't need its own KV cache and will use that of
+                    # the target layer. We skip creating a KVCacheSpec for it, so
+                    # that KV cache management logic will act as this layer does
+                    # not exist, and doesn't allocate KV cache for the layer. This
+                    # enables the memory saving of cross-layer kv sharing, allowing
+                    # a given amount of memory to accommodate longer context lengths
+                    # or enable more requests to be processed simultaneously.
+                    self.shared_kv_cache_layers[layer_name] = kv_tgt_layer
+                    continue
+                if attn_module.attn_type == AttentionType.DECODER:
+                    if attn_module.sliding_window is not None:
+                        kv_cache_spec[layer_name] = SlidingWindowSpec(
+                            block_size=block_size,
+                            num_kv_heads=common_utils.get_padded_num_heads(
+                                attn_module.num_kv_heads,
+                                self.runner.mesh.shape["model"]),
+                            head_size=common_utils.get_padded_head_dim(
+                                attn_module.head_size),
+                            dtype=torch.bfloat16,
+                            sliding_window=attn_module.sliding_window,
+                            use_mla=use_mla)
+                    else:
+                        kv_cache_spec[layer_name] = FullAttentionSpec(
+                            block_size=block_size,
+                            num_kv_heads=common_utils.get_padded_num_heads(
+                                attn_module.num_kv_heads,
+                                self.runner.mesh.shape["model"]),
+                            head_size=common_utils.get_padded_head_dim(
+                                attn_module.head_size),
+                            dtype=torch.bfloat16,
+                            use_mla=use_mla,
+                        )
+                elif attn_module.attn_type in (AttentionType.ENCODER,
+                                               AttentionType.ENCODER_ONLY):
+                    # encoder-only attention does not need KV cache.
+                    continue
+                elif attn_module.attn_type == AttentionType.ENCODER_DECODER:
+                    raise NotImplementedError
+                else:
+                    raise ValueError(
+                        f"Unknown attention type: {attn_module.attn_type}")
         return kv_cache_spec
 
+    def maybe_reinitialize_input_batch(self,
+                                       kv_cache_config: KVCacheConfig) -> None:
+        block_sizes = [
+            kv_cache_group.kv_cache_spec.block_size
+            for kv_cache_group in kv_cache_config.kv_cache_groups
+        ]
+        if block_sizes != [self.runner.cache_config.block_size]:
+            assert self.runner.cache_config.cpu_offload_gb == 0, (
+                "Cannot re-initialize the input batch when CPU weight "
+                "offloading is enabled. See https://github.com/vllm-project/vllm/pull/18298 "  # noqa: E501
+                "for more details.")
+            new_input_batch = InputBatch(
+                max_num_reqs=self.runner.max_num_reqs,
+                max_model_len=self.runner.max_model_len,
+                max_num_batched_tokens=self.runner.max_num_tokens,
+                pin_memory=False,
+                vocab_size=self.runner.model_config.get_vocab_size(),
+                block_sizes=block_sizes,
+            )
+            self.runner.input_batch = new_input_batch
+            self.runner.persistent_batch_manager.input_batch = new_input_batch
+
     def initialize_kv_cache(self, kv_cache_config: KVCacheConfig) -> None:
-        kv_cache_groups = kv_cache_config.kv_cache_groups
-        if len(kv_cache_groups) > 1:
-            raise NotImplementedError(
-                "Hybrid models with more than one KV cache type are not "
-                "supported yet.")
+        self.maybe_reinitialize_input_batch(kv_cache_config)
 
-        kv_cache_spec = kv_cache_groups[0].kv_cache_spec
-        layer_names = kv_cache_groups[0].layer_names
+        # uniform page size.
+        representative_spec = kv_cache_config.kv_cache_groups[0].kv_cache_spec
+        page_size_bytes = representative_spec.page_size_bytes
+        self.runner.layer_name_to_kvcache_index: Dict[str, int] = {}
+        for i, kv_cache_tensor in enumerate(kv_cache_config.kv_cache_tensors):
+            assert kv_cache_tensor.size % page_size_bytes == 0
+            # NOTE: we'll multiply the num_kv_heads by 2 in the function
+            kv_cache = create_kv_caches(
+                num_blocks=kv_cache_tensor.size // page_size_bytes,
+                block_size=representative_spec.block_size,
+                num_kv_heads=representative_spec.num_kv_heads,
+                head_size=representative_spec.head_size,
+                mesh=self.runner.mesh,
+                layer_names=[f'kv_cache_tensor.{i}'])[0]
+            self.runner.kv_caches.append(kv_cache)
+            for layer_name in kv_cache_tensor.shared_by:
+                self.runner.layer_name_to_kvcache_index[layer_name] = i
 
-        # NOTE: we'll multiply the num_kv_heads by 2 in the function
-        self.runner.kv_caches = create_kv_caches(
-            num_blocks=kv_cache_config.num_blocks,
-            block_size=kv_cache_spec.block_size,
-            num_kv_heads=kv_cache_spec.num_kv_heads,
-            head_size=kv_cache_spec.head_size,
-            mesh=self.runner.mesh,
-            layer_names=layer_names,
-        )
+        if self.shared_kv_cache_layers:
+            for layer_name, target_layer_name in self.shared_kv_cache_layers.items(
+            ):
+                self.runner.layer_name_to_kvcache_index[
+                    layer_name] = self.runner.layer_name_to_kvcache_index[
+                        target_layer_name]
 
     @staticmethod
     @functools.partial(jax.jit)

--- a/tpu_commons/runner/tpu_jax_runner.py
+++ b/tpu_commons/runner/tpu_jax_runner.py
@@ -350,6 +350,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin):
                     input_ids,
                     attn_metadata,
                     inputs_embeds,
+                    tuple(self.layer_name_to_kvcache_index.items()),
                 )
 
             hidden_states = self._select_from_array_fn(hidden_states,


### PR DESCRIPTION
# Description

Fix #510 

head_size needs to be padded to 128 when creating kv_cache_spec to match the kv cache shape during `initialize_kv_cache`. There used to be error on Qwen2.5-0.5B model since its head_size is 64. 

# Tests

- E2E test on single attention type models, multi attention type models passed
- CI passed: https://buildkite.com/tpu-commons/tpu-commons-ci/builds/2585

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
