### PR TITLE
[Torchax] Support Running AWQ models

### DIFF
--- a/tests/models/vllm/layers/test_awq.py
+++ b/tests/models/vllm/layers/test_awq.py
@@ -1,0 +1,390 @@
+import tempfile
+from typing import Optional
+
+import jax
+import pytest
+import torch
+import torchax
+import utils as test_utils
+from jax.sharding import PartitionSpec
+from torchax.interop import torch_view
+from torchax.ops.mappings import j2t, t2j
+from vllm.config import set_current_vllm_config
+from vllm.distributed.parallel_state import (ensure_model_parallel_initialized,
+                                             init_distributed_environment)
+from vllm.engine.arg_utils import EngineArgs
+from vllm.model_executor.layers.linear import (ColumnParallelLinear,
+                                               LinearBase,
+                                               MergedColumnParallelLinear,
+                                               QKVParallelLinear,
+                                               RowParallelLinear)
+from vllm.model_executor.layers.quantization.utils.quant_utils import \
+    pack_quantized_values_into_int32
+from vllm.model_executor.model_loader import get_model as vllm_get_model
+from vllm.scalar_type import scalar_types
+
+from tpu_commons.models.vllm.quantization import get_tpu_quantization_config
+from tpu_commons.models.vllm.quantization.awq import (JaxAWQConfig,
+                                                      JaxAWQLinearMethod)
+from tpu_commons.models.vllm.quantization.common import JaxCommonLinearConfig
+
+P = PartitionSpec
+MODELS = ["Qwen/Qwen2.5-1.5B-Instruct-AWQ"]
+
+
+def ref_quantize_uint4(x: torch.Tensor, group_size: int):
+    uint4_max = 15
+
+    # For group quantization, we reshape so that x[0], x[1], ... x[i] are
+    # quantized with different scale values.
+    x = torch.reshape(x, (-1, group_size) + (x.shape[1:]))
+
+    # Equation for asymmetric quantization is x_q = (x + x_z) / scale where
+    # x_z is calculated to ensure x + x_z does not contain any negative values.
+    offset = torch.clamp(-torch.amin(x, dim=1, keepdim=True), min=0)
+    x += offset
+    # After adding offset, x will not contain any negative values.
+    assert x.min() >= 0
+
+    x_abs_max = torch.amax(x, dim=1, keepdim=True)
+    x_s = x_abs_max / uint4_max
+    # torch does not support uint4, therefore, we cast to int32 instead.
+    x_q = torch.clip(x / x_s, 0, uint4_max).to(torch.int32)
+    x_z = torch.clip(offset / x_s, 0, uint4_max).to(torch.int32)
+    return x_q, x_z, x_s.to(torch.float32)
+
+
+def ref_w4a16(x: torch.Tensor, w_q: torch.Tensor, w_z: torch.Tensor,
+              w_s: torch.Tensor, b: Optional[torch.Tensor]):
+    # Dequantize asymetric quantized weight.
+    w = (w_q.to(torch.float32) - w_z.to(torch.float32)) * w_s
+    w = w.reshape((-1, w.shape[-1]))
+    out = torch.einsum('bd,df->bf', x.to(torch.float32), w)
+    if b is not None:
+        out += b
+    return out.to(x.dtype)
+
+
+def pack_awq_weight_into_int32(weight: torch.Tensor):
+    # AWQ packs 8 uint4 into 32-bits in this order.
+    awq_order = (0, 2, 4, 6, 1, 3, 5, 7)
+
+    orig_shape = weight.shape
+    weight = weight.reshape(orig_shape[:-1] + (-1, 8))
+    weight = weight[..., awq_order].reshape(orig_shape)
+
+    return pack_quantized_values_into_int32(weight, scalar_types.uint4, 1)
+
+
+def return_ref_and_layer_output(
+    layer: torch.nn.Module,
+    qweight: torch.Tensor,
+    qzeros: torch.Tensor,
+    scales: torch.Tensor,
+    batch_size: int = 16,
+):
+    assert isinstance(layer, LinearBase)
+    quant_method = layer.quant_method
+    assert isinstance(quant_method, JaxAWQLinearMethod)
+    quant_config = quant_method.quant_config
+    assert isinstance(quant_config, JaxAWQConfig)
+    jax_config = quant_method.jax_config
+    assert isinstance(jax_config, JaxCommonLinearConfig)
+
+    input_tensor = torch.rand(
+        batch_size, layer.input_size, dtype=torch.bfloat16) / 10
+    input_tensor = input_tensor.to('cpu')
+
+    ref_output = ref_w4a16(
+        input_tensor,
+        qweight,
+        qzeros,
+        scales,
+        layer.bias,
+    )
+
+    # Run torchax/jax function
+    quant_method.process_weights_after_loading(layer)
+    with torchax.default_env():
+        jax_input_tensor = torch_view(t2j(input_tensor, use_dlpack=False))
+        layer_output = layer(jax_input_tensor)
+        layer_output = j2t(layer_output.to(torch.float32)).to(torch.bfloat16)
+
+    return ref_output, layer_output
+
+
+def initialize_and_return_layer_weights(layer: torch.nn.Module):
+    assert isinstance(layer, LinearBase)
+    quant_method = layer.quant_method
+    assert isinstance(quant_method, JaxAWQLinearMethod)
+    quant_config = quant_method.quant_config
+    assert isinstance(quant_config, JaxAWQConfig)
+    jax_config = quant_method.jax_config
+    assert isinstance(jax_config, JaxCommonLinearConfig)
+
+    # torch.rand returns value in the range of [0, 1). We subtract by 0.2 to
+    # simulate asymmetry
+    weight = torch.rand((layer.input_size, layer.output_size)) - 0.2
+    qweight, qzeros, scales = ref_quantize_uint4(weight,
+                                                 quant_config.group_size)
+
+    # We modify uint4 quantized weights into AWQ format.
+    layer_qweight = qweight.reshape((-1, layer.output_size))
+    layer_qzeros = qzeros.reshape((-1, layer.output_size))
+    layer_scales = scales.reshape((-1, layer.output_size))
+
+    layer_qweight = pack_awq_weight_into_int32(layer_qweight)
+    layer_qzeros = pack_awq_weight_into_int32(layer_qzeros)
+
+    assert layer.qweight.data.shape == layer_qweight.shape
+    assert layer.qzeros.data.shape == layer_qzeros.shape
+    assert layer.scales.data.shape == layer_scales.shape
+
+    layer.qweight.data = layer_qweight
+    layer.qzeros.data = layer_qzeros
+    layer.scales.data = layer_scales
+
+    bias = None
+    if layer.bias is not None:
+        bias = torch.rand_like(layer.bias.data)
+        layer.bias.data = bias
+
+    return qweight, qzeros, scales, bias
+
+
+@pytest.fixture(autouse=True)
+def setup_environment():
+    # This is a fake config used for init dist env.
+    # RowParallelLinear needs dist env to be initialized.
+    engine_args = EngineArgs(
+        model=MODELS[0],
+        max_model_len=64,
+        max_num_batched_tokens=64,
+        max_num_seqs=4,
+    )
+
+    vllm_config = engine_args.create_engine_config()
+
+    with set_current_vllm_config(vllm_config):
+        temp_file = tempfile.mkstemp()[1]
+        init_distributed_environment(
+            1,
+            0,
+            local_rank=0,
+            distributed_init_method=f"file://{temp_file}",
+            backend="gloo")
+        ensure_model_parallel_initialized(1, 1)
+
+
+@pytest.mark.parametrize("model", MODELS)
+@pytest.mark.parametrize("mesh", [
+    test_utils.get_spmd_mesh(1),
+    test_utils.get_spmd_mesh(jax.local_device_count())
+])
+def test_quant_override(model, mesh):
+
+    engine_args = EngineArgs(
+        model=model,
+        max_model_len=64,
+        max_num_batched_tokens=64,
+        max_num_seqs=4,
+    )
+    vllm_config = engine_args.create_engine_config()
+    vllm_config.model_config.dtype = torch.bfloat16
+
+    quant_config = get_tpu_quantization_config(vllm_config, mesh)
+    assert isinstance(quant_config, JaxAWQConfig)
+    assert quant_config.vllm_config == vllm_config
+    assert quant_config.mesh == mesh
+
+
+@pytest.mark.parametrize("model", MODELS)
+@pytest.mark.parametrize(
+    "mesh",
+    [
+        test_utils.get_spmd_mesh(1),
+        # We limit device count by 2 instead of using all devices (like 8) since
+        # AWQ requires n_groups to be divisible by number of shards. Qwen uses
+        # group size of 128 and one of the layer has input size of 1536, meaning
+        # n_groups = 1536//128 = 12 - which is not divisible by 8.
+        test_utils.get_spmd_mesh(min(jax.local_device_count(), 2))
+    ])
+def test_loading_model(model, mesh):
+    engine_args = EngineArgs(
+        model=model,
+        max_model_len=64,
+        max_num_batched_tokens=64,
+        max_num_seqs=4,
+    )
+    vllm_config = engine_args.create_engine_config()
+    vllm_config.model_config.dtype = torch.bfloat16
+    vllm_config.quant_config = get_tpu_quantization_config(vllm_config, mesh)
+    vllm_config.device_config.device = "cpu"
+
+    vllm_model = vllm_get_model(vllm_config=vllm_config)
+    layers = test_utils.find_all_layer_type(vllm_model, LinearBase)
+    for layer in layers:
+        assert isinstance(layer.quant_config, JaxAWQConfig)
+        assert isinstance(layer.quant_method, JaxAWQLinearMethod)
+
+
+@pytest.mark.parametrize("model", MODELS)
+@pytest.mark.parametrize("bias", [False, True])
+@pytest.mark.parametrize("mesh", [
+    test_utils.get_spmd_mesh(1),
+    test_utils.get_spmd_mesh(jax.local_device_count())
+])
+@pytest.mark.parametrize("enable_sp", [False, True])
+def test_jax_row_parallel_linear(model, bias, mesh, enable_sp):
+    dtype = torch.bfloat16
+
+    engine_args = EngineArgs(
+        model=model,
+        max_model_len=64,
+        max_num_batched_tokens=64,
+        max_num_seqs=4,
+    )
+    vllm_config = engine_args.create_engine_config()
+    vllm_config.compilation_config.pass_config.enable_sequence_parallelism = enable_sp
+
+    vllm_config.model_config.dtype = dtype
+    quant_config = get_tpu_quantization_config(vllm_config, mesh)
+    with set_current_vllm_config(vllm_config):
+        linear_layer = RowParallelLinear(
+            input_size=4096,
+            output_size=8192,
+            bias=bias,
+            params_dtype=dtype,
+            return_bias=False,
+            quant_config=quant_config,
+        )
+
+    qweight, qzeros, scales, _ = initialize_and_return_layer_weights(
+        linear_layer)
+    ref_output, layer_output = return_ref_and_layer_output(
+        linear_layer, qweight, qzeros, scales)
+    torch.testing.assert_close(ref_output, layer_output)
+
+
+@pytest.mark.parametrize("model", MODELS)
+@pytest.mark.parametrize("bias", [False, True])
+@pytest.mark.parametrize("mesh", [
+    test_utils.get_spmd_mesh(1),
+    test_utils.get_spmd_mesh(jax.local_device_count())
+])
+@pytest.mark.parametrize("enable_sp", [False, True])
+def test_jax_column_parallel_linear(model, bias, mesh, enable_sp):
+    dtype = torch.bfloat16
+
+    engine_args = EngineArgs(
+        model=model,
+        max_model_len=64,
+        max_num_batched_tokens=64,
+        max_num_seqs=4,
+    )
+    vllm_config = engine_args.create_engine_config()
+    vllm_config.compilation_config.pass_config.enable_sequence_parallelism = enable_sp
+
+    # Call tpu_commons code
+    vllm_config.model_config.dtype = torch.bfloat16
+    quant_config = get_tpu_quantization_config(vllm_config, mesh)
+    with set_current_vllm_config(vllm_config):
+        linear_layer = ColumnParallelLinear(
+            input_size=4096,
+            output_size=8192,
+            bias=bias,
+            params_dtype=dtype,
+            return_bias=False,
+            quant_config=quant_config,
+        )
+
+    qweight, qzeros, scales, _ = initialize_and_return_layer_weights(
+        linear_layer)
+    ref_output, layer_output = return_ref_and_layer_output(
+        linear_layer, qweight, qzeros, scales)
+    torch.testing.assert_close(ref_output, layer_output)
+
+
+@pytest.mark.parametrize("model", MODELS)
+@pytest.mark.parametrize("bias", [False, True])
+@pytest.mark.parametrize("mesh", [
+    test_utils.get_spmd_mesh(1),
+    test_utils.get_spmd_mesh(jax.local_device_count())
+])
+@pytest.mark.parametrize("enable_sp", [False, True])
+@pytest.mark.parametrize("fuse_matmuls", [False, True])
+def test_jax_qkv_parallel_linear(model, bias, mesh, enable_sp, fuse_matmuls):
+    dtype = torch.bfloat16
+
+    engine_args = EngineArgs(
+        model=model,
+        max_model_len=64,
+        max_num_batched_tokens=64,
+        max_num_seqs=4,
+    )
+    vllm_config = engine_args.create_engine_config()
+    vllm_config.compilation_config.pass_config.enable_sequence_parallelism = enable_sp
+
+    # Call tpu_commons code
+    vllm_config.model_config.dtype = torch.bfloat16
+    quant_config = get_tpu_quantization_config(vllm_config, mesh)
+    with set_current_vllm_config(vllm_config):
+        linear_layer = QKVParallelLinear(
+            hidden_size=4096,
+            head_size=128,
+            total_num_heads=32,
+            total_num_kv_heads=8,
+            bias=bias,
+            params_dtype=dtype,
+            return_bias=False,
+            quant_config=quant_config,
+        )
+        linear_layer.quant_method.fuse_matmuls = fuse_matmuls
+
+    qweight, qzeros, scales, _ = initialize_and_return_layer_weights(
+        linear_layer)
+    ref_output, layer_output = return_ref_and_layer_output(
+        linear_layer, qweight, qzeros, scales)
+    torch.testing.assert_close(ref_output, layer_output)
+
+
+@pytest.mark.parametrize("model", MODELS)
+@pytest.mark.parametrize("bias", [False, True])
+@pytest.mark.parametrize("mesh", [
+    test_utils.get_spmd_mesh(1),
+    test_utils.get_spmd_mesh(jax.local_device_count())
+])
+@pytest.mark.parametrize("fuse_matmuls", [False, True])
+@pytest.mark.parametrize("enable_sp", [False, True])
+def test_jax_merged_column_parallel_linear(model, bias, mesh, fuse_matmuls,
+                                           enable_sp):
+    dtype = torch.bfloat16
+
+    engine_args = EngineArgs(
+        model=model,
+        max_model_len=64,
+        max_num_batched_tokens=64,
+        max_num_seqs=4,
+    )
+    vllm_config = engine_args.create_engine_config()
+    vllm_config.compilation_config.pass_config.enable_sequence_parallelism = enable_sp
+
+    # Call tpu_commons code
+    vllm_config.model_config.dtype = torch.bfloat16
+    quant_config = get_tpu_quantization_config(vllm_config, mesh)
+    with set_current_vllm_config(vllm_config):
+        linear_layer = MergedColumnParallelLinear(
+            input_size=4096,
+            output_sizes=[14336] * 2,
+            bias=bias,
+            params_dtype=dtype,
+            return_bias=False,
+            quant_config=quant_config,
+        )
+        linear_layer.quant_method.fuse_matmuls = fuse_matmuls
+
+    qweight, qzeros, scales, _ = initialize_and_return_layer_weights(
+        linear_layer)
+    ref_output, layer_output = return_ref_and_layer_output(
+        linear_layer, qweight, qzeros, scales)
+    torch.testing.assert_close(ref_output, layer_output)

--- a/tpu_commons/models/vllm/quantization/__init__.py
+++ b/tpu_commons/models/vllm/quantization/__init__.py
@@ -10,6 +10,8 @@ from tpu_commons.models.vllm.quantization.compressed_tensors.compressed_tensors 
     JaxCompressedTensorsConfig  # noqa: E501
 from tpu_commons.models.vllm.quantization.unquantized import \
     JaxUnquantizedConfig
+from tpu_commons.models.vllm.quantization.awq import \
+    JaxAWQConfig
 
 
 def get_tpu_quantization_config(vllm_config: VllmConfig,
@@ -19,6 +21,7 @@ def get_tpu_quantization_config(vllm_config: VllmConfig,
     method_to_config: dict[str, str] = {
         None: JaxUnquantizedConfig,
         "compressed-tensors": JaxCompressedTensorsConfig,
+        "awq": JaxAWQConfig,
     }
 
     if model_config.quantization not in method_to_config:

--- a/tpu_commons/models/vllm/quantization/awq.py
+++ b/tpu_commons/models/vllm/quantization/awq.py
@@ -1,0 +1,207 @@
+from typing import Optional, Union
+
+import jax
+import jax.numpy as jnp
+import torch
+from jax.sharding import NamedSharding, PartitionSpec
+from torchax.interop import torch_view
+from vllm.logger import init_logger
+from vllm.model_executor.layers.fused_moe.layer import FusedMoE
+from vllm.model_executor.layers.linear import LinearBase, LinearMethodBase
+from vllm.model_executor.layers.quantization import \
+    register_quantization_config
+from vllm.model_executor.layers.quantization.awq import (AWQConfig,
+                                                         AWQLinearMethod,
+                                                         is_layer_skipped_awq)
+from vllm.model_executor.layers.quantization.base_config import \
+    QuantizeMethodBase
+from vllm.model_executor.layers.quantization.utils.quant_utils import \
+    unpack_quantized_values_into_int32
+from vllm.scalar_type import scalar_types
+
+from tpu_commons.models.vllm.jax_linear_common import (
+    slice_sharded_tensor_for_concatenation, torch_to_jax_param)
+from tpu_commons.models.vllm.quantization.common import (JaxCommonConfig,
+                                                         JaxCommonLinearConfig)
+from tpu_commons.models.vllm.quantization.unquantized import \
+    JaxUnquantizedLinearMethod
+
+P = PartitionSpec
+logger = init_logger(__name__)
+
+
+@register_quantization_config("jax-awq")
+class JaxAWQConfig(AWQConfig, JaxCommonConfig):
+
+    @classmethod
+    def get_name(cls) -> str:
+        return "jax-awq"
+
+    def get_supported_act_dtypes(self) -> list[torch.dtype]:
+        # NOTE: AWQ checkpoint was quantized with float16. But on TPUs, using
+        # bfloat16 is signifcantly preferred over foat16. This might lead to
+        # some numeric output change.
+        return [torch.bfloat16]
+
+    def get_quant_method(
+        self, layer: torch.nn.Module, prefix: str
+    ) -> Optional[Union["LinearMethodBase", "QuantizeMethodBase"]]:
+        if isinstance(layer, LinearBase):
+            linear_config = self.get_linear_config(layer)
+            if is_layer_skipped_awq(prefix, self.modules_to_not_convert):
+                return JaxUnquantizedLinearMethod(linear_config)
+            return JaxAWQLinearMethod(self, linear_config)
+        elif isinstance(layer, FusedMoE):
+            raise NotImplementedError(
+                "AWQ FusedMoE is currently not supported in torchax-jax")
+        return None
+
+
+class JaxAWQLinearMethod(AWQLinearMethod):
+
+    def __init__(self, quant_config: JaxAWQConfig,
+                 jax_config: JaxCommonLinearConfig):
+        super().__init__(quant_config)
+        self.jax_config = jax_config
+
+        out_sharding, in_sharding = self.jax_config.weight_sharding[:]
+        self.jax_config.weight_sharding = P(in_sharding, None, out_sharding)
+        self.jax_config.scale_sharding = P(in_sharding, out_sharding)
+
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        qweight = layer.qweight
+        qweight = unpack_awq_weight(qweight, qweight.packed_dim)
+
+        group_size = self.quant_config.group_size
+        # Reshape so that each qweight[i] were quantized with same scales[i].
+        qweight = qweight.reshape((-1, group_size, layer.output_size))
+        qweight = torch_to_jax_param(qweight,
+                                     NamedSharding(
+                                         self.jax_config.mesh,
+                                         self.jax_config.weight_sharding),
+                                     self.jax_config.output_sizes,
+                                     self.jax_config.n_shards,
+                                     self.jax_config.fuse_matmuls,
+                                     dim=2,
+                                     jax_dtype=jnp.uint4)
+        delattr(layer, 'qweight')
+        layer.qweight = qweight
+
+        qzeros = layer.qzeros
+        qzeros = unpack_awq_weight(qzeros, qzeros.packed_dim)
+        qzeros = torch_to_jax_param(qzeros,
+                                    NamedSharding(
+                                        self.jax_config.mesh,
+                                        self.jax_config.scale_sharding),
+                                    self.jax_config.output_sizes,
+                                    self.jax_config.n_shards,
+                                    self.jax_config.fuse_matmuls,
+                                    dim=1,
+                                    jax_dtype=jnp.uint4)
+        delattr(layer, 'qzeros')
+        layer.qzeros = qzeros
+
+        scales = torch_to_jax_param(layer.scales,
+                                    NamedSharding(
+                                        self.jax_config.mesh,
+                                        self.jax_config.scale_sharding),
+                                    self.jax_config.output_sizes,
+                                    self.jax_config.n_shards,
+                                    self.jax_config.fuse_matmuls,
+                                    dim=1)
+        delattr(layer, 'scales')
+        layer.scales = scales
+
+        if layer.bias is not None and not layer.skip_bias_add:
+            if layer.return_bias:
+                logger.warning_once("Bias might return incorrect value.")
+
+            bias = torch_to_jax_param(
+                layer.bias,
+                NamedSharding(self.jax_config.mesh,
+                              self.jax_config.bias_sharding),
+                self.jax_config.output_sizes,
+                self.jax_config.n_shards,
+                self.jax_config.fuse_matmuls,
+            )
+            delattr(layer, 'bias')
+            layer.bias = bias
+
+    def apply(self,
+              layer: torch.nn.Module,
+              x: torch.Tensor,
+              bias: Optional[torch.Tensor] = None) -> torch.Tensor:
+
+        with jax.named_scope(layer._get_name()):
+            if self.jax_config.fuse_matmuls:
+                out = self._apply_fused(layer, x, bias)
+            else:
+                out = self._apply_split(layer, x, bias)
+
+        return out
+
+    def _apply_fused(self,
+                     layer: torch.nn.Module,
+                     x: torch.Tensor,
+                     bias: Optional[torch.Tensor] = None) -> torch.Tensor:
+        x_jax = x.jax()
+
+        qweight = layer.qweight.jax()
+        qzeros = jnp.expand_dims(layer.qzeros.jax(), 1)
+        scales = jnp.expand_dims(layer.scales.jax(), 1)
+
+        qweight = qweight.astype(jnp.int8)
+        qzeros = qzeros.astype(jnp.int8)
+
+        weight = (qweight - qzeros) * scales
+        weight = weight.reshape((-1, weight.shape[-1]))
+        outs = jnp.einsum('bd,df->bf', x_jax, weight)
+
+        if bias is not None and not layer.skip_bias_add:
+            outs += bias.jax()
+
+        outs = slice_sharded_tensor_for_concatenation(
+            outs, self.jax_config.output_sizes, self.jax_config.n_shards)
+        out = jnp.concatenate(outs, axis=-1)
+        return torch_view(out)
+
+    def _apply_split(self,
+                     layer: torch.nn.Module,
+                     x: torch.Tensor,
+                     bias: Optional[torch.Tensor] = None) -> torch.Tensor:
+        assert isinstance(layer.qweight, torch.nn.ParameterList)
+
+        x_jax = x.jax()
+        params = zip(layer.qweight, layer.qzeros, layer.scales)
+        outs = []
+        for i, (qweight, qzeros, scales) in enumerate(params):
+            qweight = qweight.jax()
+            scales = jnp.expand_dims(scales.jax(), 1)
+            qzeros = jnp.expand_dims(qzeros.jax(), 1)
+
+            qweight = qweight.astype(jnp.int8)
+            qzeros = qzeros.astype(jnp.int8)
+
+            weight = (qweight - qzeros) * scales
+            weight = weight.reshape((-1, weight.shape[-1]))
+            out = jnp.einsum('bd,df->bf', x_jax, weight)
+
+            if bias is not None and not layer.skip_bias_add:
+                out += bias[i].jax()
+
+            outs.append(out)
+        out = jnp.concatenate(outs, axis=-1)
+        return torch_view(out)
+
+
+def unpack_awq_weight(weight: torch.Tensor, packed_dim: int):
+    weight = unpack_quantized_values_into_int32(weight, scalar_types.uint4,
+                                                packed_dim)
+
+    # AWQ packs 8 uint4 into 32-bits in this order: (0, 2, 4, 6, 1, 3, 5, 7).
+    # Following list maps the order used by AWQ into an ascending order.
+    reverse_awq_order = (0, 4, 1, 5, 2, 6, 3, 7)
+
+    orig_shape = weight.shape
+    weight = weight.reshape(orig_shape[:-1] + (-1, 8))
+    return weight[..., reverse_awq_order].reshape(orig_shape)

--- a/tpu_commons/platforms/tpu_jax.py
+++ b/tpu_commons/platforms/tpu_jax.py
@@ -43,7 +43,9 @@ class TpuPlatform(Platform):
     device_control_env_var: str = "TPU_VISIBLE_CHIPS"
     simple_compile_backend: str = "openxla"
 
-    supported_quantization: list[str] = ["tpu_int8", "compressed-tensors"]
+    supported_quantization: list[str] = [
+        "tpu_int8", "compressed-tensors", "awq"
+    ]
 
     additional_env_vars: list[str] = [
         "TPU_CHIPS_PER_HOST_BOUNDS", "TPU_HOST_BOUNDS", "TPU_MULTIHOST_BACKEND"


### PR DESCRIPTION
# Description

- Following PR adds support for running loading & running AWQ models in torchax
  - Please note that this requires a fix in vLLM repo to be submitted as well: https://github.com/vllm-project/vllm/pull/23902
- Using model [Qwen/Qwen2.5-32B-Instruct-AWQ](https://huggingface.co/Qwen/Qwen2.5-32B-Instruct-AWQ), I have verified that it'ss running correctly.
	- Numeric validation
		- Command `TPU_BACKEND_TYPE=jax MODEL_IMPL_TYPE=vllm python3 examples/offline_inference.py --model=Qwen/Qwen2.5-32B-Instruct-AWQ --tensor_parallel_size=8 --task=generate --max_model_len=1024 --download_dir=/mnt/disks/persist`
		- Result: http://gpaste/6205721003425792
	- Performance validation (degradation over baseline is expected)
		- Baseline ([Qwen/Qwen2.5-32B-Instruct](https://huggingface.co/Qwen/Qwen2.5-32B-Instruct)): 12.61 reqs/s
		- AWQ ([Qwen/Qwen2.5-32B-Instruct-AWQ](https://huggingface.co/Qwen/Qwen2.5-32B-Instruct-AWQ)): 11.34 reqs/s
- Limitation / Future work
	- AWQ uses w4a16 subchannel quantization, and for initial implementation, I have utilized XLA instead of kernel. However, there is known performance issue with subchannel quantization in XLA. Therefore, we need to implement w4a16 subchannel support into the kernel for optimal performance.

# Tests

```
pytest -v tests/models/vllm/layers/test_awq.py
```

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
