### PR TITLE
[Torchax][Kernel] Support for KV cache quantization

### DIFF
--- a/tests/models/vllm/layers/test_pallas_torchax.py
+++ b/tests/models/vllm/layers/test_pallas_torchax.py
@@ -41,22 +41,24 @@ BLOCK_SIZE = 16
 MAX_BLOCKS_PER_SEQ = 8
 
 
-def create_inputs(mesh):
+def create_inputs(mesh: Mesh,
+                  q_dtype: jnp.dtype = jnp.bfloat16,
+                  kv_dtype: jnp.dtype = jnp.bfloat16):
     key = jax.random.key(0)
     q = jax.random.uniform(key, (TOTAL_TOKENS, NUM_HEADS * HEAD_DIM),
-                           dtype=jnp.bfloat16)
+                           dtype=q_dtype)
     k = jax.random.uniform(key, (TOTAL_TOKENS, NUM_KV_HEADS * HEAD_DIM),
-                           dtype=jnp.bfloat16)
+                           dtype=q_dtype)
     v = jax.random.uniform(key, (TOTAL_TOKENS, NUM_KV_HEADS * HEAD_DIM),
-                           dtype=jnp.bfloat16)
+                           dtype=q_dtype)
     q = torch_view(q)
     k = torch_view(k)
     v = torch_view(v)
 
     kv_cache_shape = get_kv_cache_shape_with_mesh(mesh, NUM_BLOCKS, BLOCK_SIZE,
                                                   NUM_KV_HEADS, HEAD_DIM,
-                                                  jnp.bfloat16)
-    kv_cache = jax.random.normal(key, kv_cache_shape, dtype=jnp.bfloat16)
+                                                  kv_dtype)
+    kv_cache = jax.random.normal(key, kv_cache_shape, dtype=kv_dtype)
 
     positions = jnp.ones((TOTAL_TOKENS, ), dtype=jnp.int32)
     block_tables = jnp.zeros((MAX_NUM_SEQS * MAX_BLOCKS_PER_SEQ),
@@ -133,20 +135,6 @@ class TestPallasAttentionBackendImpl:
                 attn_type=AttentionType.DECODER,
             )
 
-    def test_init_with_fp8_kv_cache_raises_error(self):
-        with pytest.raises(NotImplementedError,
-                           match="FP8 KV cache dtype is not supported"):
-            PallasAttentionBackendImpl(
-                num_heads=32,
-                head_size=128,
-                scale=0.088,
-                num_kv_heads=8,
-                alibi_slopes=None,
-                sliding_window=None,
-                kv_cache_dtype="fp8",
-                attn_type=AttentionType.DECODER,
-            )
-
     def test_init_with_encoder_attention_raises_error(self):
         with pytest.raises(NotImplementedError,
                            match="Encoder self-attention"):
@@ -177,6 +165,32 @@ class TestPallasAttentionBackendImpl:
         layer.layer_name = "0"
 
         query, key, value, kv_cache, metadata = create_inputs(mesh)
+
+        with torchax.default_env(), set_vllm_model_wrapper_context(
+                kv_caches=[kv_cache],
+                mesh=mesh,
+                layer_name_to_kvcache_index={'0': 0}):
+            impl.forward(layer, query, key, value, torch.tensor([]), metadata)
+
+    def test_forward_with_fp8_kv_cache(self, mesh):
+        impl = PallasAttentionBackendImpl(
+            num_heads=NUM_HEADS,
+            head_size=HEAD_DIM,
+            scale=0.088,
+            num_kv_heads=NUM_KV_HEADS,
+            alibi_slopes=None,
+            sliding_window=None,
+            kv_cache_dtype="fp8",
+            attn_type=AttentionType.DECODER,
+        )
+
+        layer = MagicMock()
+        layer.layer_name = "0"
+        layer._k_scale_float = 1
+        layer._v_scale_float = 1
+
+        query, key, value, kv_cache, metadata = create_inputs(
+            mesh, kv_dtype=jnp.float8_e4m3fn)
 
         with torchax.default_env(), set_vllm_model_wrapper_context(
                 kv_caches=[kv_cache],

--- a/tpu_commons/attention/backends/pallas_torchax.py
+++ b/tpu_commons/attention/backends/pallas_torchax.py
@@ -4,6 +4,7 @@ import functools
 from typing import Optional, Tuple
 
 import jax
+import jax.numpy as jnp
 import torch
 from jax.sharding import Mesh
 from torchax.interop import jax_view, torch_view
@@ -18,6 +19,14 @@ from tpu_commons.models.vllm.vllm_model_wrapper_context import \
     get_vllm_model_wrapper_context
 
 logger = init_logger(__name__)
+
+TPU_STR_DTYPE_TO_JAX_DTYPE = {
+    "bfloat16": jnp.bfloat16,
+    "fp8": jnp.float8_e4m3fn,
+    "fp8_e4m3": jnp.float8_e4m3,
+    "fp8_e5m2": jnp.float8_e5m2,
+    "int8": jnp.int8,
+}
 
 
 class PallasAttentionBackend(AttentionBackend):
@@ -62,14 +71,30 @@ class PallasAttentionBackendImpl(AttentionImpl):
         self.num_queries_per_kv = self.num_heads // self.num_kv_heads
         if alibi_slopes is not None:
             raise NotImplementedError("Alibi slopes is not supported.")
+        self.kv_cache_quantized_dtype = None
         if kv_cache_dtype != "auto":
-            raise NotImplementedError("FP8 KV cache dtype is not supported.")
+            self.kv_cache_quantized_dtype = TPU_STR_DTYPE_TO_JAX_DTYPE.get(
+                kv_cache_dtype.lower().strip())
 
         if attn_type != AttentionType.DECODER:
             raise NotImplementedError("Encoder self-attention and "
                                       "encoder/decoder cross-attention "
                                       "are not implemented for "
                                       "PallasAttentionBackendImpl")
+
+    def quantize_kv(self, layer: AttentionLayer, key: jax.Array,
+                    value: jax.Array):
+        dtype_info = jnp.finfo(self.kv_cache_quantized_dtype)
+        minval, maxval = float(dtype_info.min), float(dtype_info.max)
+        # TODO(kyuyeunk): Add support for jnp.Tensor (layer._k_scale) scale
+        key = key.astype(jnp.float32) / layer._k_scale_float
+        key = jnp.clip(key, minval, maxval)
+        key = key.astype(self.kv_cache_quantized_dtype)
+        value = value.astype(jnp.float32) / layer._v_scale_float
+        value = jnp.clip(value, minval, maxval)
+        value = value.astype(self.kv_cache_quantized_dtype)
+
+        return key, value
 
     def forward(
         self,
@@ -101,11 +126,20 @@ class PallasAttentionBackendImpl(AttentionImpl):
 
         mesh = vllm_model_wrapper_context.mesh
 
-        new_kv_cache, outputs = _jax_attn_func(kv_cache, jax_view(query),
-                                               jax_view(key), jax_view(value),
+        query, key, value = jax_view(query), jax_view(key), jax_view(value)
+        q_scale = k_scale = v_scale = None
+        if self.kv_cache_quantized_dtype:
+            key, value = self.quantize_kv(layer, key, value)
+            # TODO(kyuyeunk): Add query quantization support for w8a8 attention
+            # q_scale = layer._q_scale
+            k_scale = layer._k_scale_float
+            v_scale = layer._v_scale_float
+
+        new_kv_cache, outputs = _jax_attn_func(kv_cache, query, key, value,
                                                attn_metadata, mesh, self.scale,
                                                self.head_size, self.num_heads,
-                                               self.num_kv_heads)
+                                               self.num_kv_heads, q_scale,
+                                               k_scale, v_scale)
         vllm_model_wrapper_context.kv_caches[kv_cache_index] = new_kv_cache
 
         return torch_view(outputs)
@@ -113,8 +147,9 @@ class PallasAttentionBackendImpl(AttentionImpl):
 
 @functools.partial(
     jax.jit,
-    static_argnums=(5, 6, 7, 8,
-                    9),  # mesh, scale, head_size, num_heads, num_kv_heads
+    static_argnums=(
+        5, 6, 7, 8, 9, 10, 11, 12
+    ),  # mesh, scale, head_size, num_heads, num_kv_heads, q_scale, k_scale, v_scale
     donate_argnums=(0, ),  # donate kv_cache
 )
 def _jax_attn_func(
@@ -128,6 +163,9 @@ def _jax_attn_func(
     head_size: int,
     num_heads: int,
     num_kv_heads: int,
+    q_scale: Optional[float] = None,
+    k_scale: Optional[float] = None,
+    v_scale: Optional[float] = None,
 ) -> Tuple[jax.Array, jax.Array]:
     del scale  # Unused for now, as the attention function applies a default scale.
 
@@ -152,6 +190,9 @@ def _jax_attn_func(
         v,
         attention_metadata,
         mesh,
+        q_scale=q_scale,
+        k_scale=k_scale,
+        v_scale=v_scale,
     )
 
     # Convert the shape back to vLLM's convention

--- a/tpu_commons/models/jax/attention.py
+++ b/tpu_commons/models/jax/attention.py
@@ -19,9 +19,14 @@ def get_kv_cache_shape_with_mesh(mesh: Mesh, total_num_pages: int,
                               actual_head_dim, kv_dtype)
 
 
-def sharded_ragged_paged_attention(sm_scale: float,
-                                   mesh: Mesh,
-                                   attention_chunk_size: int | None = None):
+def sharded_ragged_paged_attention(
+    sm_scale: float,
+    mesh: Mesh,
+    attention_chunk_size: int | None = None,
+    q_scale: float | None = None,
+    k_scale: float | None = None,
+    v_scale: float | None = None,
+):
     """Shards along KV heads."""
     qkv_spec = P(None, "model", None)
     kv_cache_spec = P(None, None, "model")
@@ -42,6 +47,9 @@ def sharded_ragged_paged_attention(sm_scale: float,
             *args,
             sm_scale=sm_scale,
             sliding_window=attention_chunk_size,
+            q_scale=q_scale,
+            k_scale=k_scale,
+            v_scale=v_scale,
         )
 
     return jax.jit(
@@ -62,7 +70,10 @@ def attention(
     attention_metadata: AttentionMetadata,
     mesh: Mesh,
     head_dim_original: int | None = None,  # before padding,
-    attention_chunk_size: int | None = None
+    attention_chunk_size: int | None = None,
+    q_scale: float | None = None,
+    k_scale: float | None = None,
+    v_scale: float | None = None,
 ) -> Tuple[jax.Array, jax.Array]:
     # T: seq_len
     # N: num_heads
@@ -83,7 +94,8 @@ def attention(
 
     # (T, N, H)
     output, kv_cache = sharded_ragged_paged_attention(
-        head_dim_original**-0.5, mesh, attention_chunk_size)(
+        head_dim_original**-0.5, mesh, attention_chunk_size, q_scale, k_scale,
+        v_scale)(
             q,
             k,
             v,

--- a/tpu_commons/platforms/tpu_jax.py
+++ b/tpu_commons/platforms/tpu_jax.py
@@ -252,3 +252,8 @@ class TpuPlatform(Platform):
                                  f"{cls.device_name} V0.")
             if params.sampling_type == SamplingType.RANDOM_SEED:
                 raise ValueError("JAX does not support per-request seed.")
+
+    @classmethod
+    def is_kv_cache_dtype_supported(cls, kv_cache_dtype: str,
+                                    model_config: ModelConfig) -> bool:
+        return True

--- a/tpu_commons/runner/kv_cache.py
+++ b/tpu_commons/runner/kv_cache.py
@@ -9,8 +9,6 @@ from tpu_commons.logger import init_logger
 
 logger = init_logger(__name__)
 
-DEFAULT_KV_CACHE_DTYPE = jnp.bfloat16
-
 
 def create_kv_caches(
     num_blocks: int,
@@ -19,6 +17,7 @@ def create_kv_caches(
     head_size: int,
     mesh: Mesh,
     layer_names: List[str],
+    cache_dtype: jnp.dtype = jnp.bfloat16,
 ) -> List[jax.Array]:
     """
     Creates the KV caches, a list of arrays, each array is for one attention layer.
@@ -39,8 +38,6 @@ def create_kv_caches(
         A list of KV caches, one per each decoder layer in the model.
 
     """
-    # TODO (jacobplatin): update this for quantized KV cache
-    cache_dtype = DEFAULT_KV_CACHE_DTYPE
     # TODO(xiang): fix this together with get_kv_cache_spec
     # cache_dtype = kv_cache_spec.dtype
 

--- a/tpu_commons/runner/kv_cache_manager.py
+++ b/tpu_commons/runner/kv_cache_manager.py
@@ -3,8 +3,8 @@ from typing import TYPE_CHECKING, Dict, List
 
 import jax
 import jax.numpy as jnp
-import torch
 from jax.sharding import NamedSharding, PartitionSpec
+from torchax.ops.mappings import t2j_dtype
 from vllm.attention import Attention
 from vllm.attention.backends.abstract import AttentionType
 from vllm.config import get_layers_from_vllm_config
@@ -60,7 +60,7 @@ class KVCacheManager:
                     block_size=block_size,
                     num_kv_heads=num_kv_heads,
                     head_size=head_size,
-                    dtype=torch.bfloat16,
+                    dtype=self.runner.kv_cache_dtype,
                     use_mla=use_mla,
                 )
         else:
@@ -88,7 +88,7 @@ class KVCacheManager:
                                 self.runner.mesh.shape["model"]),
                             head_size=common_utils.get_padded_head_dim(
                                 attn_module.head_size),
-                            dtype=torch.bfloat16,
+                            dtype=self.runner.kv_cache_dtype,
                             sliding_window=attn_module.sliding_window,
                             use_mla=use_mla)
                     else:
@@ -99,7 +99,7 @@ class KVCacheManager:
                                 self.runner.mesh.shape["model"]),
                             head_size=common_utils.get_padded_head_dim(
                                 attn_module.head_size),
-                            dtype=torch.bfloat16,
+                            dtype=self.runner.kv_cache_dtype,
                             use_mla=use_mla,
                         )
                 elif attn_module.attn_type in (AttentionType.ENCODER,
@@ -154,7 +154,9 @@ class KVCacheManager:
                 num_kv_heads=representative_spec.num_kv_heads,
                 head_size=representative_spec.head_size,
                 mesh=self.runner.mesh,
-                layer_names=[f'kv_cache_tensor.{i}'])[0]
+                layer_names=[f'kv_cache_tensor.{i}'],
+                cache_dtype=t2j_dtype(representative_spec.dtype),
+            )[0]
             kv_caches.append(kv_cache)
             num_blocks_list.append(num_blocks)
             for layer_name in kv_cache_tensor.shared_by:

--- a/tpu_commons/runner/tpu_jax_runner.py
+++ b/tpu_commons/runner/tpu_jax_runner.py
@@ -5,10 +5,13 @@ from contextlib import nullcontext
 from typing import Any, Callable, Dict, List, Optional, Tuple, cast
 
 import jax
+import jax.numpy as jnp
 import jaxtyping
 import numpy as np
+import torch
 import vllm.envs as envs
 from flax import nnx
+from torchax.ops.mappings import j2t_dtype
 from vllm.config import VllmConfig
 from vllm.distributed.kv_transfer import (get_kv_transfer_group,
                                           has_kv_transfer_group)
@@ -63,6 +66,17 @@ DUMMY_METADATA = AttentionMetadata(
     request_distribution=[0, 0, 0],
 )
 
+TPU_STR_DTYPE_TO_TORCH_DTYPE = {
+    "half": torch.half,
+    "bfloat16": torch.bfloat16,
+    "float": torch.float,
+    "fp8": torch.float8_e4m3fn,
+    "fp8_e4m3": torch.float8_e4m3fn,
+    "fp8_e5m2": torch.float8_e5m2,
+    "int8": torch.int8,
+    "uint8": torch.uint8,
+}
+
 
 class TPUModelRunner(KVConnectorModelRunnerMixin):
 
@@ -104,6 +118,23 @@ class TPUModelRunner(KVConnectorModelRunnerMixin):
         self.persistent_batch_manager = PersistentBatchManager(
             self.requests, self.input_batch, self.encoder_cache,
             self.uses_mrope, self.model_config)
+
+        cache_config = self.cache_config
+        if cache_config.cache_dtype == "auto":
+            model_dtype = self.dtype
+            if isinstance(model_dtype, str):
+                self.kv_cache_dtype = TPU_STR_DTYPE_TO_TORCH_DTYPE[model_dtype]
+            elif isinstance(getattr(model_dtype, 'dtype', None), jnp.dtype):
+                self.kv_cache_dtype = j2t_dtype(model_dtype.dtype)
+            elif isinstance(model_dtype, torch.dtype):
+                self.kv_cache_dtype = model_dtype
+            else:
+                raise ValueError(
+                    "KV cache is unsupported for model_dtype of %s",
+                    model_dtype)
+        else:
+            self.kv_cache_dtype = TPU_STR_DTYPE_TO_TORCH_DTYPE[
+                cache_config.cache_dtype]
 
     def _init_random(self):
         if self.model_config.seed is None:


### PR DESCRIPTION
# Description

- Following PR enables KV cache quantization in Torchax 
- Using model [RedHatAI/Meta-Llama-3.1-70B-Instruct-FP8-dynamic](https://huggingface.co/RedHatAI/Meta-Llama-3.1-70B-Instruct-FP8-dynamic) in Ironwood, I have verified that it's running correctly.
	- Numeric validation
		- Command: `TPU_BACKEND_TYPE=jax MODEL_IMPL_TYPE=vllm python3 examples/offline_inference.py --model=RedHatAI/Meta-Llama-3.1-8B-Instruct-FP8-dynamic --tensor_parallel_size=2 --task=generate --max_model_len=1024 --download_dir=/mnt/disks/persist --kv_cache_dtype=fp8`
		- Result: http://gpaste/6030890064674816
	- Performance validation
		- bf16 kv cache: 1107.23 toks/s
		- fp8 kv cache: 1809.04 toks/s (+8%)

# Tests

```
pytest -v tests/models/vllm/layers/test_pallas_torchax.py
```

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
