### PR TITLE
change kv cache sharding to be explicit

### DIFF
--- a/tpu_commons/models/jax/attention.py
+++ b/tpu_commons/models/jax/attention.py
@@ -26,7 +26,7 @@ def sharded_ragged_paged_attention(sm_scale: float,
                                    attention_chunk_size: int | None = None):
     """Shards along KV heads."""
     qkv_spec = P(None, "model", None)
-    kv_cache_spec = P()  # replicated
+    kv_cache_spec = P(None, None, "model")
     in_specs = (
         qkv_spec,  # q
         qkv_spec,  # k

--- a/tpu_commons/models/jax/common/attention/attention.py
+++ b/tpu_commons/models/jax/common/attention/attention.py
@@ -180,7 +180,7 @@ class Attention(nnx.Module):
                   `(seq, num_q_heads, head_dim)`.
         """
         md = attention_metadata
-        kv_cache_spec = P()  # Replicated
+        kv_cache_spec = P(None, None, "model")  # Replicated
         in_specs = (
             self.query_tnh,  # q
             self.keyvalue_skh,  # k

--- a/tpu_commons/models/jax/model_loader.py
+++ b/tpu_commons/models/jax/model_loader.py
@@ -165,7 +165,9 @@ def get_flax_model(
 ) -> nnx.Module:
     model_class = _get_model_architecture(vllm_config.model_config.hf_config)
     jit_model = _get_nnx_model(model_class, vllm_config, rng, mesh)
-    kv_cache_sharding = NamedSharding(mesh, PartitionSpec())  # replicated
+    kv_cache_sharding = NamedSharding(mesh,
+                                      PartitionSpec(None, None,
+                                                    "model"))  # replicated
     hidden_states_sharding = NamedSharding(mesh, PartitionSpec(None,
                                                                None))  # (T, D)
 

--- a/tpu_commons/runner/kv_cache_manager.py
+++ b/tpu_commons/runner/kv_cache_manager.py
@@ -116,7 +116,10 @@ class KVCacheManager:
     @functools.partial(
         jax.jit,
         static_argnames=("block_size"),
-        donate_argnames=("kv_caches"),
+        donate_argnames=(
+            "kv_caches",
+            "kv_cache_slices",
+        ),
     )
     def _jitted_insert_kv_cache(
         block_size,
@@ -147,7 +150,10 @@ class KVCacheManager:
     @functools.partial(
         jax.jit,
         static_argnames=("block_size"),
-        donate_argnames=("kv_caches"),
+        donate_argnames=(
+            "kv_caches",
+            "kv_cache_slices",
+        ),
     )
     def _jitted_insert_continuous_kv_cache(
         block_size,
@@ -222,9 +228,10 @@ class KVCacheManager:
         # We shard along the num_kv_heads dimension (axis=1), which corresponds
         # to the "model" axis of the mesh for tensor parallelism.
         logger.debug(
-            f"Transferring kv cache shape {kv_cache_slices[0].shape} sharding {kv_cache_slices[0].sharding}"
+            f"Transferring kv cache shape {len(kv_cache_slices)} * {kv_cache_slices[0].shape} sharding {kv_cache_slices[0].sharding} size {kv_cache_slices[0].nbytes * len(kv_cache_slices)/1024/1024} Mbytes"
         )
-        sharding = NamedSharding(self.runner.mesh, PartitionSpec())
+        sharding = NamedSharding(self.runner.mesh,
+                                 PartitionSpec(None, None, "model"))
         transferred_kv_cache = jax.device_put(kv_cache_slices, sharding)
         for cache in transferred_kv_cache:
             cache.block_until_ready()


### PR DESCRIPTION
# Description

Same as https://github.com/vllm-project/tpu_commons/pull/546. Reason for this change is that jax.device_put() on replicated sharding is causing some memory leak.


# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
