### PR TITLE
[Quantization] Enable Qwix quantization for abstract models

### DIFF
--- a/tests/test_quantization.py
+++ b/tests/test_quantization.py
@@ -405,7 +405,7 @@ class TestApplyQwixQuantizationLogic(unittest.TestCase):
 
 
 class TestDetermineWhetherToApplyQwixOnAbstractModel(unittest.TestCase):
-    """Tests for determine_whether_to_apply_qwix_on_abstract_model."""
+    """Tests for apply_qwix_on_abstract_model."""
 
     def setUp(self):
         self.mock_vllm_config = MagicMock()
@@ -422,7 +422,7 @@ class TestDetermineWhetherToApplyQwixOnAbstractModel(unittest.TestCase):
     def test_returns_true_when_config_is_true(self, mock_load_dict):
         """Test it returns True when use_abstract_model is True in config."""
         mock_load_dict.return_value = {"qwix": {"use_abstract_model": True}}
-        result = quantize_qwix.determine_whether_to_apply_qwix_on_abstract_model(
+        result = quantize_qwix.apply_qwix_on_abstract_model(
             self.mock_vllm_config)
         self.assertTrue(result)
         mock_load_dict.assert_called_once_with("some_config.yaml")
@@ -433,7 +433,7 @@ class TestDetermineWhetherToApplyQwixOnAbstractModel(unittest.TestCase):
     def test_returns_false_when_config_is_false(self, mock_load_dict):
         """Test it returns False when use_abstract_model is False in config."""
         mock_load_dict.return_value = {"qwix": {"use_abstract_model": False}}
-        result = quantize_qwix.determine_whether_to_apply_qwix_on_abstract_model(
+        result = quantize_qwix.apply_qwix_on_abstract_model(
             self.mock_vllm_config)
         self.assertFalse(result)
 
@@ -443,13 +443,13 @@ class TestDetermineWhetherToApplyQwixOnAbstractModel(unittest.TestCase):
     def test_returns_false_when_key_is_missing(self, mock_load_dict):
         """Test it defaults to False when use_abstract_model key is missing."""
         mock_load_dict.return_value = {"qwix": {"rules": []}}
-        result = quantize_qwix.determine_whether_to_apply_qwix_on_abstract_model(
+        result = quantize_qwix.apply_qwix_on_abstract_model(
             self.mock_vllm_config)
         self.assertFalse(result)
 
     def test_returns_false_when_additional_config_is_missing(self):
         """Test it returns False when additional_config is missing."""
-        result = quantize_qwix.determine_whether_to_apply_qwix_on_abstract_model(
+        result = quantize_qwix.apply_qwix_on_abstract_model(
             self.mock_vllm_config_no_additional_config)
         self.assertFalse(result)
 

--- a/tpu_commons/models/jax/utils/quantization/quantization_utils.py
+++ b/tpu_commons/models/jax/utils/quantization/quantization_utils.py
@@ -195,10 +195,12 @@ def apply_qwix_quantization(
     for more details on Qwix.
 
     Note that we currently support different methods for applying Qwix quantization.  The typical
-    approach has is to apply quantization on the concrete model, which already has the weights
+    approach is to apply quantization on the concrete model, which already has the weights
     loaded in.  However, for models like DeepSeek, which are already quantized, we need to
     first create the abstract model, then apply Qwix quantization to the abstract model, and
-    finally load the weights in.
+    finally load the weights in.  To use the latter approach, you will need to modify the
+    model weight loading code appropriately (see deepseek_v3.py for an example) and
+    pass and `use_abstract_model=True` in the quantization config.
 
     Args:
         vllm_config: the base VLLM config
@@ -243,6 +245,8 @@ def apply_qwix_quantization(
         assert isinstance(model_or_model_fn, nnx.Module)
         qwix_quantize_nnx_model_with_config = functools.partial(
             qwix_quantize_nnx_model, qwix_config=qwix_config)
+        # NOTE: it's REALLY important `qwix_quantize_nnx_model_with_config` is jitted
+        # or else you'll run into hanging
         model_or_model_fn = nnx.jit(
             qwix_quantize_nnx_model_with_config,
             donate_argnums=(0, ),
@@ -263,7 +267,6 @@ def apply_qwix_quantization(
 
         return model_or_model_fn
 
-    # NOTE: it's REALLY important this is jitted, or else you'll run into hanging
     qwix_quantize_fn_for_eval = functools.partial(
         qwix_quantize_nnx_model,
         qwix_config=qwix_config,
@@ -273,7 +276,10 @@ def apply_qwix_quantization(
         kv_cache_num_kv_heads=num_kv_heads,
         kv_cache_head_size=head_size)
 
-    def create_and_quantize_model_factory():
+    def create_and_quantize_model_factory() -> Callable:
+        """
+        Helper function to create and quantize the abstract model.
+        """
         model = model_or_model_fn()
         # Handle the DeepSeek case, where this needs to be called in the abstract model
         if hasattr(model, 'initialize_cache'):
@@ -283,8 +289,7 @@ def apply_qwix_quantization(
     return create_and_quantize_model_factory
 
 
-def determine_whether_to_apply_qwix_on_abstract_model(
-        vllm_config: "VllmConfig") -> bool:
+def apply_qwix_on_abstract_model(vllm_config: "VllmConfig") -> bool:
     """
     Determines whether to apply Qwix quantization on the abstract model (e.g. for DeepSeek)
     or the concrete model.  See `apply_qwix_quantization` for more details on the differences


### PR DESCRIPTION
# Description

In this PR, I add a new path to support applying Qwix quantization (on the JAX path) to abstract models, which will enable us to load in pre-quantized (e.g. AWQ) and random weight checkpoints.

The existing quantization approach of applying OTF Qwix quantization to loaded (concrete) model is unchanged, but in order to load in an abstract model, I have added a new flag to the Qwix quantization config `use_abstract_model` that needs to be passed when we'd like to quantize the abstract model.  Here is an example Qwix config with that setting:

```
qwix:
        # optional, defaults to False if not specified
        use_abstract_model: True
        rules:
            # NOTE: each entry corresponds to a qwix.QuantizationRule
            - module_path: '.*attn.*'
            weight_qtype: 'int8'
            - module_path: '.*'
            weight_qtype: 'int8'
            act_qtype: 'int8'
```


This is needed for cases like loading in AWQ checkpoint, where we will first create an abstract model, apply Qwix quantization, and then manually load in the quantized weights.



# Tests

Passing CI: https://buildkite.com/tpu-commons/tpu-commons-ci/builds/2664

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
