### PR TITLE
Fix disagg proto and reduce kv-cache log

### DIFF
--- a/examples/disagg/multi_proc_per_worker.py
+++ b/examples/disagg/multi_proc_per_worker.py
@@ -83,31 +83,33 @@ def get_mesh() -> Mesh:
     return jax.make_mesh((sharding_size, ), ("model", ))
 
 
-def get_kv_shape(mesh: Mesh) -> tuple[int, ...]:
+def get_kv_shape(mesh: Mesh, per_shard: bool = False) -> tuple[int, ...]:
     num_blocks = 10
     block_size = 32
     num_kv_heads = 8
-    shard_size = mesh.shape["model"]
     head_dim = 128
 
+    if per_shard:
+        shard_size = mesh.shape["model"]
+        num_kv_heads = num_kv_heads // shard_size
+
     import tpu_commons.kernels.ragged_paged_attention.v3.kernel as rpa
-    shape = rpa.get_kv_cache_shape(num_blocks, block_size,
-                                   num_kv_heads // shard_size, head_dim,
-                                   jnp.bfloat16)
+    shape = rpa.get_kv_cache_shape(num_blocks, block_size, num_kv_heads,
+                                   head_dim, jnp.bfloat16)
     return shape
 
 
 def get_kv_spec(mesh: Mesh) -> jax.ShapeDtypeStruct:
     shape = get_kv_shape(mesh)
     dtype = jnp.bfloat16
-    sharding = NamedSharding(mesh, P())
+    sharding = NamedSharding(mesh, P(None, None, "model"))
     num_layers = 4
     return [jax.ShapeDtypeStruct(shape, dtype, sharding=sharding)] * num_layers
 
 
 # Hard code the shard spec, it could have been calculated.
 def get_kv_shard_spec(mesh: Mesh) -> jax.ShapeDtypeStruct:
-    shape = get_kv_shape(mesh)
+    shape = get_kv_shape(mesh, per_shard=True)
     dtype = jnp.bfloat16
     sharding = SingleDeviceSharding(jax.local_devices()[0])
     num_layers = 4

--- a/examples/disagg/single_proc_per_worker.py
+++ b/examples/disagg/single_proc_per_worker.py
@@ -81,15 +81,13 @@ def get_kv_spec(mesh: Mesh) -> list[int]:
     num_blocks = 10
     block_size = 32
     num_kv_heads = 8
-    shard_size = mesh.shape["model"]
     head_dim = 128
 
     import tpu_commons.kernels.ragged_paged_attention.v3.kernel as rpa
-    shape = rpa.get_kv_cache_shape(num_blocks, block_size,
-                                   num_kv_heads // shard_size, head_dim,
-                                   jnp.bfloat16)
+    shape = rpa.get_kv_cache_shape(num_blocks, block_size, num_kv_heads,
+                                   head_dim, jnp.bfloat16)
     dtype = jnp.bfloat16
-    sharding = NamedSharding(mesh, P())
+    sharding = NamedSharding(mesh, P(None, None, "model"))
     num_layers = 4
     return [jax.ShapeDtypeStruct(shape, dtype, sharding=sharding)] * num_layers
 

--- a/tpu_commons/runner/kv_cache.py
+++ b/tpu_commons/runner/kv_cache.py
@@ -5,7 +5,6 @@ import jax.numpy as jnp
 from jax.sharding import Mesh, NamedSharding, PartitionSpec
 
 import tpu_commons.kernels.ragged_paged_attention.v3.kernel as rpa
-from tpu_commons import utils
 from tpu_commons.logger import init_logger
 
 logger = init_logger(__name__)
@@ -62,9 +61,4 @@ def create_kv_caches(
     kv_caches = []
     for _ in layer_names:
         kv_caches.append(sharded_allocate())
-    logger.info(f"Init kv-cache | "
-                f"shape={len(layer_names)} * {shard_cnt} | "
-                f"sharding={sharding} | "
-                f"dtype={cache_dtype} | "
-                f"hbm={utils.hbm_usage_gb(mesh.devices.flatten())}Gb")
     return kv_caches


### PR DESCRIPTION
# Description

1. Fix disagg proto kv-cache shape because of https://github.com/vllm-project/tpu_commons/pull/624
2. Move kv-cache init logging to kv_cache_manager to reduce the flooding logs because of https://github.com/vllm-project/tpu_commons/pull/616

# Tests

Local

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
