### PR TITLE
[Bugfix] Fix weight_scale typo

### DIFF
--- a/tpu_commons/models/vllm/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_int8.py
+++ b/tpu_commons/models/vllm/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_int8.py
@@ -117,7 +117,7 @@ class JaxCompressedTensorsW8A8Int8(CompressedTensorsW8A8Int8):
         x_jax = x.jax()
         outs = []
         for i, (weight, weight_scale) in enumerate(
-                zip(layer.weight, layer.wieght_scale)):
+                zip(layer.weight, layer.weight_scale)):
             weight_jax = weight.jax()
             weight_scale_jax = weight_scale.jax()
 


### PR DESCRIPTION
# Description

Fix following error

```
(EngineCore_0 pid=530777)   File "/home/kyuyeunk_google_com/workspace/vllm/tpu_commons/tpu_commons/models/vllm/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_int8.py", line 120, in _apply_split
(EngineCore_0 pid=530777)     zip(layer.weight, layer.wieght_scale)):
(EngineCore_0 pid=530777)                       ^^^^^^^^^^^^^^^^^^
(EngineCore_0 pid=530777)   File "/home/kyuyeunk_google_com/miniconda3/envs/vllm/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1962, in __getattr__
(EngineCore_0 pid=530777)     raise AttributeError(
(EngineCore_0 pid=530777) AttributeError: 'QKVParallelLinear' object has no attribute 'wieght_scale'. Did you mean: 'weight_scale'?
```

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
