### PR TITLE
fix incorrect sharding at transfer

### DIFF
--- a/tpu_commons/runner/kv_cache_manager.py
+++ b/tpu_commons/runner/kv_cache_manager.py
@@ -333,7 +333,7 @@ class KVCacheManager:
             f"Transferring kv cache shape {len(kv_cache_slices)} * {kv_cache_slices[0].shape} sharding {kv_cache_slices[0].sharding} size {kv_cache_slices[0].nbytes * len(kv_cache_slices)/1024/1024} Mbytes"
         )
         sharding = NamedSharding(self.runner.mesh,
-                                 PartitionSpec(None, None, "model"))
+                                 PartitionSpec(None, "model"))
         transferred_kv_cache = jax.device_put(kv_cache_slices, sharding)
         for cache in transferred_kv_cache:
             cache.block_until_ready()


### PR DESCRIPTION
# Description

transferred kv_cache is of shape (padded_seq_len, num_kv_heads//kv_packing, kv_packing, head_dim), so sharding should be at the second dim. 

# Tests

pytest

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
