### PR TITLE
[Torchax][Kernel] Add support for W8A8 Attention

### DIFF
--- a/tests/kernels/ragged_paged_attention_kernel_v3_test.py
+++ b/tests/kernels/ragged_paged_attention_kernel_v3_test.py
@@ -197,7 +197,7 @@ class RaggedPagedAttentionKernelTest(jtu.JaxTestCase):
     @parameterized.product(
         q_dtype=[jnp.bfloat16],
         kv_dtype=[jnp.float8_e5m2, jnp.float8_e4m3fn],
-        kv_scales=[(0.5, 0.5), (None, None)],
+        kv_scales=[(0.5, 0.5), (1.0, 1.0)],
     )
     def test_ragged_paged_attention_quantized_kv_cache(self, q_dtype, kv_dtype,
                                                        kv_scales):
@@ -223,10 +223,10 @@ class RaggedPagedAttentionKernelTest(jtu.JaxTestCase):
         )
 
     @parameterized.product(
-        q_dtype=[jnp.float8_e5m2, jnp.float8_e4m3fn],
+        q_dtype=[jnp.bfloat16],
         kv_dtype=[jnp.float8_e5m2, jnp.float8_e4m3fn],
-        q_scale=[0.5, None],
-        kv_scales=[(0.5, 0.5), (None, None)],
+        q_scale=[0.5, 1.0],
+        kv_scales=[(0.5, 0.5), (1.0, 1.0)],
     )
     def test_ragged_paged_attention_quantized_attention(
             self, q_dtype, kv_dtype, q_scale, kv_scales):

--- a/tests/models/vllm/layers/test_pallas_torchax.py
+++ b/tests/models/vllm/layers/test_pallas_torchax.py
@@ -186,6 +186,34 @@ class TestPallasAttentionBackendImpl:
 
         layer = MagicMock()
         layer.layer_name = "0"
+        layer._q_scale_float = None
+        layer._k_scale_float = 1
+        layer._v_scale_float = 1
+
+        query, key, value, kv_cache, metadata = create_inputs(
+            mesh, kv_dtype=jnp.float8_e4m3fn)
+
+        with torchax.default_env(), set_vllm_model_wrapper_context(
+                kv_caches=[kv_cache],
+                mesh=mesh,
+                layer_name_to_kvcache_index={'0': 0}):
+            impl.forward(layer, query, key, value, torch.tensor([]), metadata)
+
+    def test_forward_with_w8a8(self, mesh):
+        impl = PallasAttentionBackendImpl(
+            num_heads=NUM_HEADS,
+            head_size=HEAD_DIM,
+            scale=0.088,
+            num_kv_heads=NUM_KV_HEADS,
+            alibi_slopes=None,
+            sliding_window=None,
+            kv_cache_dtype="fp8",
+            attn_type=AttentionType.DECODER,
+        )
+
+        layer = MagicMock()
+        layer.layer_name = "0"
+        layer._q_scale_float = 1
         layer._k_scale_float = 1
         layer._v_scale_float = 1
 

--- a/tpu_commons/attention/backends/pallas_torchax.py
+++ b/tpu_commons/attention/backends/pallas_torchax.py
@@ -130,8 +130,8 @@ class PallasAttentionBackendImpl(AttentionImpl):
         q_scale = k_scale = v_scale = None
         if self.kv_cache_quantized_dtype:
             key, value = self.quantize_kv(layer, key, value)
-            # TODO(kyuyeunk): Add query quantization support for w8a8 attention
-            # q_scale = layer._q_scale
+            # TODO(kyuyeunk): Enable w8a8 when VREG spill issue is resolved.
+            # q_scale = layer._q_scale_float
             k_scale = layer._k_scale_float
             v_scale = layer._v_scale_float
 

--- a/tpu_commons/kernels/ragged_paged_attention/v3/kernel.py
+++ b/tpu_commons/kernels/ragged_paged_attention/v3/kernel.py
@@ -113,6 +113,15 @@ def ref_ragged_paged_attention(
         k = jnp.repeat(k, actual_num_q_heads_per_kv_head, axis=1)
         v = jnp.repeat(v, actual_num_q_heads_per_kv_head, axis=1)
 
+        if q_scale is not None:
+            q = (q / q_scale)
+            if jnp.issubdtype(k.dtype, jnp.floating):
+                dtype_info = jnp.finfo(k.dtype)
+                minval = float(dtype_info.min)
+                maxval = float(dtype_info.max)
+                q = jnp.clip(q, min=minval, max=maxval)
+            q = q.astype(k.dtype)
+
         attn = jnp.einsum("qhd,khd->hqk",
                           q,
                           k,
@@ -331,6 +340,15 @@ def _ragged_paged_attention_kernel(
                              ref[...])
 
         # Follow FlashAttention-2 forward pass.
+        if q_scale is not None:
+            q = (q / q_scale)
+            if jnp.issubdtype(k.dtype, jnp.floating):
+                dtype_info = jnp.finfo(k.dtype)
+                minval = float(dtype_info.min)
+                maxval = float(dtype_info.max)
+                q = jnp.clip(q, min=minval, max=maxval)
+            q = q.astype(k.dtype)
+
         s = jnp.einsum("nd,md->nm", q, k, preferred_element_type=jnp.float32)
         s *= sm_scale
         if k_scale is not None:


### PR DESCRIPTION
# Description

Integrate query quantization (W8A8 attention) into RPA.

By default, this behavior is disabled due to pending performance optimization in RPA kernel.

# Tests

```
pytest -v tests/models/vllm/layers/test_pallas_torchax.py
```

| device | model                      | inp_len | out_len | num_reqs | max_tokens | max_reqs | bf16/bf16 | bf16/fp8 | fp8/fp8 |
| ------ | -------------------------- | ------- | ------- | -------- | ---------- | -------- | --------- | -------- | ------- |
| v7-1   | Meta-Llama-3-4B/8B         | 20      | 20      | 20       | 16         | 16       | 0.085     | 0.080    | 0.083   |
| v7-1   | Meta-Llama-3-4B/8B         | 1800    | 128     | 1000     | 512        | 512      | 0.075     | 0.080    | 0.083   |
| v7-1   | Meta-Llama-3-4B/8B         | 1000    | 1000    | 1000     | 512        | 512      | 5.711     | 4.458    | 4.431   |
| v7-8   | Meta-Llama-3-32B/70B       | 20      | 20      | 16       | 16         | 16       | 0.044     | 0.044    | 0.044   |
| v7-8   | Meta-Llama-3-32B/70B       | 1800    | 128     | 1000     | 512        | 512      | 0.297     | 0.289    | 0.282   |
| v7-8   | Meta-Llama-3-32B/70B       | 1000    | 1000    | 1000     | 512        | 512      | 1.262     | 1.179    | 1.171   |
| v7-4   | Mixtral-8x7B-Instruct-v0.1 | 20      | 20      | 20       | 16         | 16       | 0.053     | 0.052    | 0.053   |
| v7-4   | Mixtral-8x7B-Instruct-v0.1 | 1800    | 128     | 1000     | 512        | 512      | 0.386     | 0.353    | 0.342   |
| v7-4   | Mixtral-8x7B-Instruct-v0.1 | 1000    | 1000    | 1000     | 512        | 512      | 1.709     | 1.503    | 1.490   |
| v7-8   | Mixtral-8x7B-Instruct-v0.1 | 20      | 20      | 16       | 16         | 16       | 0.044     | 0.043    | 0.044   |
| v7-8   | Mixtral-8x7B-Instruct-v0.1 | 1800    | 128     | 1000     | 512        | 512      | 0.271     | 0.264    | 0.256   |
| v7-8   | Mixtral-8x7B-Instruct-v0.1 | 1000    | 1000    | 1000     | 512        | 512      | 1.236     | 1.155    | 1.147   |

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
