### PR TITLE
Migrate to `vllm bench serve`

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ JAX_PROFILER_SERVER_PORT=XXXX
 In order to use this approach, you can do the following:
 
 1. Run your typical `vllm serve` or `offline_inference` command (making sure to set `USE_JAX_PROFILER_SERVER=True`)
-2. Run your benchmarking command (`python benchmark_serving.py...`)
+2. Run your benchmarking command (`vllm bench serve...`)
 3. Once the warmup has completed and your benchmark is running, start a new tensorboard instance with your `logdir` set to the desired output location of your profiles (e.g. `tensorboard --logdir=profiles/llama3-mmlu/`)
 4. Open the tensorboard instance and navigate to the `profile` page (e.g. `http://localhost:6006/#profile`)
 5. Click `Capture Profile` and, in the `Profile Service URL(s) or TPU name` box, enter `localhost:XXXX` where `XXXX` is your `JAX_PROFILER_SERVER_PORT` (default is `9999`)

--- a/scripts/vllm/benchmarking/README.md
+++ b/scripts/vllm/benchmarking/README.md
@@ -41,7 +41,7 @@ vllm serve meta-llama/Llama-3.1-8B-Instruct --max-model-len=1024 --disable-log-r
 Once the server has begun -- you should see a message such as `INFO:     Application startup complete.` -- you can now run the client benchmarking command (in a new terminal) in your local vLLM repo:
 
 ```
- python benchmarks/benchmark_serving.py \
+vllm bench serve \
     --backend vllm \
     --model meta-llama/Llama-3.1-8B-Instruct \
     --dataset-name mlperf \

--- a/scripts/vllm/benchmarking/benchmark_serving.py
+++ b/scripts/vllm/benchmarking/benchmark_serving.py
@@ -11,7 +11,7 @@ On the server side, run one of the following commands:
         --disable-log-requests
 
 On the client side, run:
-    python benchmarks/benchmark_serving.py \
+    vllm bench serve \
         --backend <backend> \
         --model <your_model> \
         --dataset-name sharegpt \

--- a/tests/e2e/benchmarking/mlperf.sh
+++ b/tests/e2e/benchmarking/mlperf.sh
@@ -282,7 +282,7 @@ for model_name in $model_list; do
     if $did_find_ready_message; then
         echo "Starting the benchmark for $model_name..."
         echo "Current working directory: $(pwd)"
-        python benchmarks/benchmark_serving.py \
+        vllm bench serve \
         --backend vllm \
         --model "$model_name" \
         --dataset-name "$dataset_name" \

--- a/tests/e2e/benchmarking/mm_bench.sh
+++ b/tests/e2e/benchmarking/mm_bench.sh
@@ -118,7 +118,7 @@ done
 if $did_find_ready_message; then
     echo "Starting the benchmark for $model_name..."
     echo "Current working directory: $(pwd)"
-    python /workspace/vllm/benchmarks/benchmark_serving.py \
+    vllm bench serve \
     --backend openai-chat \
     --model "$model_name" \
     --dataset-name "$dataset_name" \


### PR DESCRIPTION
# Description

VLLM has deprecated some of the `benchmark_*.py` scripts. This commit migrates to the recommended method of `vllm bench serve` instead of `benchmark_serving.py`. 

FIXES part of b/444037119

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
