### PR TITLE
[Bugfix] fix TPU device name

### DIFF
--- a/tpu_commons/kernels/ragged_paged_attention/v3/util.py
+++ b/tpu_commons/kernels/ragged_paged_attention/v3/util.py
@@ -53,7 +53,7 @@ def get_device_name(num_devices: int | None = None):
         kind = kind[:-len(' lite')] + 'e'
     if kind == 'TPU7x':
         kind = 'TPU v7'
-    assert kind[:-1] == 'TPU v', kind
+    assert kind[:5] == 'TPU v', kind
     if num_devices is not None:
         kind += f'-{num_devices}'
     return kind


### PR DESCRIPTION
# Description

Fixed the bug when the name is "TPU v6e", kind[:-1] will be "TPU v6" not "TPU v".

