### PR TITLE
[JAX] fix sharding bug for kv_cache of DeepSeek

### DIFF
--- a/tpu_commons/models/jax/common/attention/deepseek_v3_attention.py
+++ b/tpu_commons/models/jax/common/attention/deepseek_v3_attention.py
@@ -288,7 +288,7 @@ class MLA(nnx.Module):
             self.query_tnh,  # q
             self.keyvalue_skh,  # k
             self.keyvalue_skh,  # v
-            P(None, None, "model"),  # kv_cache: Replicated
+            P(None, None, "model"),  # kv_cache
             P(),  # md.seq_lens: Replicated
             P(),  # page_indices_flat: Replicated
             P(),  # query_start_loc: Replicated


### PR DESCRIPTION
# Description

Fix the dim mismatch error from sharding in DeepSeek

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
