### PR TITLE
Use vllm serve bench in mm_bench

### DIFF
--- a/tests/e2e/benchmarking/mm_bench.sh
+++ b/tests/e2e/benchmarking/mm_bench.sh
@@ -118,8 +118,9 @@ done
 if $did_find_ready_message; then
     echo "Starting the benchmark for $model_name..."
     echo "Current working directory: $(pwd)"
-    python /workspace/vllm/benchmarks/benchmark_serving.py \
-    --backend openai-chat \
+    vllm bench serve \
+    --backend "openai-chat" \
+    --endpoint-type "openai-chat" \
     --model "$model_name" \
     --dataset-name "$dataset_name" \
     --dataset-path "$dataset_path" \


### PR DESCRIPTION
# Description

Issue with using the vllm-specific benchmark_serving.py script which was recently deprecated. 

# Tests

Results were confirmed via locally running the `mm_bench.sh` script. 

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
