### PR TITLE
[JAX][Quantization] Only unpack Qwix `additional_config` once

### DIFF
--- a/tests/test_quantization.py
+++ b/tests/test_quantization.py
@@ -410,47 +410,48 @@ class TestDetermineWhetherToApplyQwixOnAbstractModel(unittest.TestCase):
     def setUp(self):
         self.mock_vllm_config = MagicMock()
         self.mock_vllm_config.additional_config = {
-            "quantization": "some_config.yaml"
+            "quantization": {
+                "qwix": {
+                    "use_abstract_model": True,
+                    "rules": [{
+                        "module_path": ".*",
+                        "weight_qtype": "int8"
+                    }]
+                }
+            }
+        }
+
+        self.mock_vllm_config_no_abstract_model = MagicMock()
+        self.mock_vllm_config_no_abstract_model.additional_config = {
+            "quantization": {
+                "qwix": {
+                    "rules": [{
+                        "module_path": ".*",
+                        "weight_qtype": "int8"
+                    }]
+                }
+            }
         }
 
         self.mock_vllm_config_no_additional_config = MagicMock()
         self.mock_vllm_config_no_additional_config.additional_config = {}
 
-    @patch(
-        "tpu_commons.models.jax.utils.quantization.quantization_utils.quantization_config_file_path_to_dict"
-    )
-    def test_returns_true_when_config_is_true(self, mock_load_dict):
-        """Test it returns True when use_abstract_model is True in config."""
-        mock_load_dict.return_value = {"qwix": {"use_abstract_model": True}}
-        result = quantize_qwix.apply_qwix_on_abstract_model(
-            self.mock_vllm_config)
-        self.assertTrue(result)
-        mock_load_dict.assert_called_once_with("some_config.yaml")
-
-    @patch(
-        "tpu_commons.models.jax.utils.quantization.quantization_utils.quantization_config_file_path_to_dict"
-    )
-    def test_returns_false_when_config_is_false(self, mock_load_dict):
-        """Test it returns False when use_abstract_model is False in config."""
-        mock_load_dict.return_value = {"qwix": {"use_abstract_model": False}}
-        result = quantize_qwix.apply_qwix_on_abstract_model(
-            self.mock_vllm_config)
-        self.assertFalse(result)
-
-    @patch(
-        "tpu_commons.models.jax.utils.quantization.quantization_utils.quantization_config_file_path_to_dict"
-    )
-    def test_returns_false_when_key_is_missing(self, mock_load_dict):
-        """Test it defaults to False when use_abstract_model key is missing."""
-        mock_load_dict.return_value = {"qwix": {"rules": []}}
-        result = quantize_qwix.apply_qwix_on_abstract_model(
-            self.mock_vllm_config)
-        self.assertFalse(result)
-
     def test_returns_false_when_additional_config_is_missing(self):
         """Test it returns False when additional_config is missing."""
         result = quantize_qwix.apply_qwix_on_abstract_model(
             self.mock_vllm_config_no_additional_config)
+        self.assertFalse(result)
+
+    def test_returns_true_when_additional_config_is_present(self):
+        """Test it returns False when additional_config is missing."""
+        result = quantize_qwix.apply_qwix_on_abstract_model(
+            self.mock_vllm_config)
+        self.assertTrue(result)
+
+    def test_returns_false_when_use_abstract_model_is_false(self):
+        """Test it returns False when use_abstract_model is False."""
+        result = quantize_qwix.apply_qwix_on_abstract_model(
+            self.mock_vllm_config_no_abstract_model)
         self.assertFalse(result)
 
 

--- a/tpu_commons/models/jax/utils/quantization/quantization_utils.py
+++ b/tpu_commons/models/jax/utils/quantization/quantization_utils.py
@@ -219,9 +219,6 @@ def apply_qwix_quantization(
     qwix_config = None
     if quantization_config := vllm_config.additional_config.get(
             "quantization"):
-        if isinstance(quantization_config, str):
-            quantization_config = quantization_config_file_path_to_dict(
-                quantization_config)
         qwix_config = quantization_config.get("qwix").get("rules")
     if not qwix_config:
         return model_or_model_fn
@@ -299,10 +296,5 @@ def apply_qwix_on_abstract_model(vllm_config: "VllmConfig") -> bool:
     Returns:
         whether to apply Qwix quantization on the abstract model
     """
-    quantization_config = None
-    if quantization_config := vllm_config.additional_config.get(
-            "quantization", {}):
-        if isinstance(quantization_config, str):
-            quantization_config = quantization_config_file_path_to_dict(
-                quantization_config)
+    quantization_config = vllm_config.additional_config.get("quantization", {})
     return quantization_config.get("qwix", {}).get("use_abstract_model", False)

--- a/tpu_commons/platforms/tpu_jax.py
+++ b/tpu_commons/platforms/tpu_jax.py
@@ -213,6 +213,9 @@ class TpuPlatform(Platform):
                     if isinstance(quantization_config, str):
                         quantization_config = quantization_config_file_path_to_dict(
                             quantization_config)
+                        # NOTE: unpack the quantization config now so we don't need to keep doing this every time
+                        vllm_config.additional_config[
+                            "quantization"] = quantization_config
                     parse_qwix_config_to_rules(
                         quantization_config["qwix"]["rules"])
                 except Exception as e:


### PR DESCRIPTION
# Description

In this PR, I update the Qwix additional config parsing so that we only need to do it once instead of having to unpack the `additional_config` multiple times in the case that the Qwix config is a file name, e.g.:

```
--additional_config='{"quantization": "fp8_deepseek.yaml"}'
```

# Tests

Tested locally + passing CI: https://buildkite.com/tpu-commons/tpu-commons-ci/builds/2936

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
