### PR TITLE
[Bugfix] add manual seed for test_jax_fused_moe

### DIFF
--- a/tests/models/vllm/layers/test_unquantized.py
+++ b/tests/models/vllm/layers/test_unquantized.py
@@ -414,6 +414,7 @@ def test_jax_merged_column_parallel_linear(model, bias, mesh, fuse_matmuls,
 @pytest.mark.parametrize("topk", [2])
 def test_jax_fused_moe(use_ep, mesh, num_tokens, intermediate_size,
                        hidden_size, num_experts, topk):
+    torch.manual_seed(42)
     dtype = torch.bfloat16
 
     a = torch.randn((num_tokens, hidden_size), dtype=dtype) / 10


### PR DESCRIPTION
# Description

Fixed the flaky test.

# Tests

pytest -s -v tests/models/vllm/layers/test_unquantized.py::test_jax_fused_moe

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
