### PR TITLE
[Disagg] Update Disagg Executor to align with upstream vllm

### DIFF
--- a/tests/core/test_disagg_executor.py
+++ b/tests/core/test_disagg_executor.py
@@ -2,7 +2,7 @@
 import unittest
 from unittest.mock import MagicMock, patch
 
-from vllm.config import VllmConfig
+from vllm.config import ModelConfig, VllmConfig
 
 from tpu_commons.core.disagg_executor import DisaggExecutor
 
@@ -13,7 +13,11 @@ class DisaggExecutorTest(unittest.TestCase):
         """Set up the test environment by mocking dependencies."""
         # Mock configurations
         self.mock_vllm_config = MagicMock(spec=VllmConfig)
-        self.mock_vllm_config.model_config = MagicMock()
+        self.mock_vllm_config.model_config = ModelConfig(
+            tokenizer_mode="auto",
+            trust_remote_code=False,
+            seed=0,
+            dtype='bfloat16')
         self.mock_vllm_config.cache_config = MagicMock()
         self.mock_vllm_config.scheduler_config = MagicMock()
         self.mock_vllm_config.load_config = MagicMock()

--- a/tpu_commons/runner/compilation_manager.py
+++ b/tpu_commons/runner/compilation_manager.py
@@ -8,6 +8,7 @@ import numpy as np
 import vllm.envs as envs
 from jax.sharding import NamedSharding, PartitionSpec
 
+from tpu_commons.core.disagg_utils import is_disagg_enabled
 from tpu_commons.logger import init_logger
 from tpu_commons.models.jax.attention_metadata import AttentionMetadata
 from tpu_commons.models.jax.layers.sample.sampling import sample
@@ -281,6 +282,8 @@ class CompilationManager:
                 )
 
     def _precompile_disagg_utils(self) -> None:
+        if not is_disagg_enabled():
+            return
         logger.info(
             "Compiling disaggregated util with different input shapes.")
         block_size = self.runner.block_size


### PR DESCRIPTION
# Description

Change the Disagg Executor interface to keep aligned with https://github.com/vllm-project/vllm/pull/20452 and https://github.com/vllm-project/vllm/pull/24219


# Tests

pytest

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
