### PR TITLE
[Spec Decoding] Share the weights of embedding layer between target model and draft model

### DIFF
--- a/tpu_commons/models/jax/llama_eagle3.py
+++ b/tpu_commons/models/jax/llama_eagle3.py
@@ -24,12 +24,14 @@ class Eagle3LlamaDecoderLayer(LlamaDecoderLayer):
     def __init__(self, config: LlamaConfig, dtype: jnp.dtype, rng: nnx.Rngs,
                  mesh: Mesh):
         super().__init__(config, dtype=dtype, rng=rng, mesh=mesh)
+        self.config = config
         # Override qkv
         hidden_size = 2 * self.self_attn.hidden_size
         self.self_attn.q_proj = nnx.Einsum(
             "TD,DNH->TNH",
             (hidden_size, self.self_attn.num_heads, self.self_attn.head_dim),
             param_dtype=dtype,
+            dtype=dtype,
             kernel_init=nnx.with_partitioning(init_fn, (None, "model", None)),
             rngs=rng,
         )
@@ -38,6 +40,7 @@ class Eagle3LlamaDecoderLayer(LlamaDecoderLayer):
             (hidden_size, self.self_attn.num_kv_heads,
              self.self_attn.head_dim),
             param_dtype=dtype,
+            dtype=dtype,
             kernel_init=nnx.with_partitioning(init_fn, (None, "model", None)),
             rngs=rng,
         )
@@ -46,7 +49,17 @@ class Eagle3LlamaDecoderLayer(LlamaDecoderLayer):
             (hidden_size, self.self_attn.num_kv_heads,
              self.self_attn.head_dim),
             param_dtype=dtype,
+            dtype=dtype,
             kernel_init=nnx.with_partitioning(init_fn, (None, "model", None)),
+            rngs=rng,
+        )
+        # Override input layernorm and specify dtype to avoid unexpected upcasting.
+        self.input_layernorm = nnx.RMSNorm(
+            config.hidden_size,
+            epsilon=config.rms_norm_eps,
+            param_dtype=dtype,
+            dtype=dtype,
+            scale_init=nnx.with_partitioning(init_fn, (None, )),
             rngs=rng,
         )
         self.hidden_norm = nnx.RMSNorm(
@@ -56,11 +69,6 @@ class Eagle3LlamaDecoderLayer(LlamaDecoderLayer):
             scale_init=nnx.with_partitioning(init_fn, (None, )),
             rngs=rng,
         )
-
-        if getattr(config, "norm_before_residual", False):
-            self._residual_norm = self._norm_before_residual
-        else:
-            self._residual_norm = self._norm_after_residual
 
     def _norm_before_residual(
             self, hidden_states: jax.Array) -> tuple[jax.Array, jax.Array]:
@@ -82,10 +90,12 @@ class Eagle3LlamaDecoderLayer(LlamaDecoderLayer):
         attention_metadata: AttentionMetadata,
     ) -> Tuple[jax.Array, jax.Array, jax.Array]:
         embeds = self.input_layernorm(embeds)
-
-        hidden_states, residual = self._residual_norm(
-            hidden_states=hidden_states)
-
+        if getattr(self.config, "norm_before_residual", False):
+            hidden_states, residual = self._norm_before_residual(
+                hidden_states=hidden_states)
+        else:
+            hidden_states, residual = self._norm_after_residual(
+                hidden_states=hidden_states)
         hidden_states = jnp.concatenate([embeds, hidden_states], axis=-1)
 
         kv_cache, attn_output = self.self_attn(
@@ -300,3 +310,11 @@ class EagleLlama3ForCausalLM(nnx.Module):
                         metadata_map=metadata_map,
                         mesh=self.mesh,
                         is_draft_model=True)
+
+        # If the embedding is not initialized, initialize it with a dummpy array here to pass jit compilation. The real weights will be shared from the target model in eagle3 class.
+        if isinstance(self.model.embed_tokens.embedding.value,
+                      jax.ShapeDtypeStruct):
+            self.model.embed_tokens.embedding.value = jnp.zeros(
+                self.model.embed_tokens.embedding.shape,
+                dtype=self.model.embed_tokens.embedding.dtype,
+            )

--- a/tpu_commons/runner/tpu_jax_runner.py
+++ b/tpu_commons/runner/tpu_jax_runner.py
@@ -299,7 +299,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
 
         if self.drafter is not None:
             logger.info("Loading drafter model...")
-            self.drafter.load_model()
+            self.drafter.load_model(self.state)
 
         self.rng_params_for_sampling = nnx.Rngs(
             jax.random.key(self.model_config.seed)).params()

--- a/tpu_commons/spec_decode/jax/eagle3.py
+++ b/tpu_commons/spec_decode/jax/eagle3.py
@@ -41,11 +41,12 @@ class EagleProposer:
         self.block_size = vllm_config.cache_config.block_size
         self.rng_key = jax.random.key(self.vllm_config.model_config.seed)
 
-    def load_model(self) -> None:
+    def load_model(self, target_model: Any) -> None:
         """Loads the draft model."""
-        # TODO(ranlihao): Sharing embedding and lm_head weights between the target and draft
         self.model_fn, self.compute_logits_fn, _, _, self.state, _, _ = get_model(
             self.vllm_config, self.rng_key, self.mesh, is_draft_model=True)
+        del self.state.model['embed_tokens']
+        self.state.model.embed_tokens = target_model.model.embed
 
     def prepare_inputs(self, ) -> tuple[jnp.ndarray]:
         """Prepares inputs for the speculative decoding step.


### PR DESCRIPTION
# Description

Share the weights of embedding layer between target model and draft model. Also resolved two bugs in Eagle3LlamaDecoderLayer:
1. Override input layernorm and specify dtype to avoid unexpected upcasting.
2. Move a if statement from __init__ to __call__ to avoid dynamic assignment of `self._residual_norm attribute`. Somehow, JAX treats this as a form of side effect, leading to the "leaked tracer" error.

# Tests



# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
