### PR TITLE
[Bugfix] Fix non-default argument error

### DIFF
--- a/tpu_commons/runner/input_batch_jax.py
+++ b/tpu_commons/runner/input_batch_jax.py
@@ -23,7 +23,7 @@ _SAMPLING_EPS = 1e-5
 @dataclass
 class CachedRequestState(NewRequestData):
 
-    output_token_ids: list[int]
+    output_token_ids: Optional[list[int]] = None
     generator: Optional[Any] = None
     mrope_positions: Optional[jax.Array] = None
     mrope_position_delta: Optional[int] = None


### PR DESCRIPTION
# Description

https://github.com/vllm-project/vllm/pull/24278 introduces argument `prompt_embeds` to class `NewRequestData` with a default argument `None`: [output.py](https://github.com/vllm-project/vllm/blob/486c5599e3ab7d721c94dd01e89c87742c01e1ac/vllm/v1/core/sched/output.py#L37)

Due to this change, any new variable that is defined in a child class of `NewRequestData` (e.g., `CachedRequestState`) requires a default value.

Otherwise, following error is thrown

```
(EngineCore_DP0 pid=41591) ERROR 09-19 06:33:33 [core.py:712]   File "/home/kyuyeunk_google_com/workspace/tpu_commons/tpu_commons/runner/input_batch_jax.py", line 25, in <module>
(EngineCore_DP0 pid=41591) ERROR 09-19 06:33:33 [core.py:712]     @dataclass
(EngineCore_DP0 pid=41591) ERROR 09-19 06:33:33 [core.py:712]      ^^^^^^^^^
(EngineCore_DP0 pid=41591) ERROR 09-19 06:33:33 [core.py:712]   File "/home/kyuyeunk_google_com/miniconda3/envs/vllm/lib/python3.12/dataclasses.py", line 1275, in dataclass
(EngineCore_DP0 pid=41591) ERROR 09-19 06:33:33 [core.py:712]     return wrap(cls)
(EngineCore_DP0 pid=41591) ERROR 09-19 06:33:33 [core.py:712]            ^^^^^^^^^
(EngineCore_DP0 pid=41591) ERROR 09-19 06:33:33 [core.py:712]   File "/home/kyuyeunk_google_com/miniconda3/envs/vllm/lib/python3.12/dataclasses.py", line 1265, in wrap
(EngineCore_DP0 pid=41591) ERROR 09-19 06:33:33 [core.py:712]     return _process_class(cls, init, repr, eq, order, unsafe_hash,
(EngineCore_DP0 pid=41591) ERROR 09-19 06:33:33 [core.py:712]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=41591) ERROR 09-19 06:33:33 [core.py:712]   File "/home/kyuyeunk_google_com/miniconda3/envs/vllm/lib/python3.12/dataclasses.py", line 1063, in _process_class
(EngineCore_DP0 pid=41591) ERROR 09-19 06:33:33 [core.py:712]     _init_fn(all_init_fields,
(EngineCore_DP0 pid=41591) ERROR 09-19 06:33:33 [core.py:712]   File "/home/kyuyeunk_google_com/miniconda3/envs/vllm/lib/python3.12/dataclasses.py", line 585, in _init_fn
(EngineCore_DP0 pid=41591) ERROR 09-19 06:33:33 [core.py:712]     raise TypeError(f'non-default argument {f.name!r} '
(EngineCore_DP0 pid=41591) ERROR 09-19 06:33:33 [core.py:712] TypeError: non-default argument 'output_token_ids' follows default argument
```


# Tests

https://buildkite.com/tpu-commons/tpu-commons-ci/builds/3153

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
