### PR TITLE
[Bugfix] Fix the get_device_name function to handle v5p on Pathways

### DIFF
--- a/tpu_commons/kernels/ragged_paged_attention/v3/util.py
+++ b/tpu_commons/kernels/ragged_paged_attention/v3/util.py
@@ -53,6 +53,9 @@ def get_device_name(num_devices: int | None = None):
     if kind.endswith(' lite'):
         kind = kind[:-len(' lite')]
         suffix = 'e'
+    if kind.endswith('p'):
+        kind = kind[:-1]
+        suffix = 'p'
     if kind == 'TPU7x':
         kind = 'TPU v7'
     assert kind[:-1] == 'TPU v', kind


### PR DESCRIPTION
# Description

`jax.devices().device_kind` returned on Pathways v5p cluster is `TPU v5p` where as on TPU vm it is `TPU v5`. We need to account for this difference. 

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
