### PR TITLE
Remove falback to get quicker fail

### DIFF
--- a/.buildkite/scripts/run_in_docker.sh
+++ b/.buildkite/scripts/run_in_docker.sh
@@ -34,14 +34,11 @@ fi
 
 # Try to cache HF models
 persist_cache_dir="/mnt/disks/persist/models"
-home_cache_dir="$HOME/models"
 
 if ( mkdir -p "$persist_cache_dir" ); then
   LOCAL_HF_HOME="$persist_cache_dir"
-elif ( mkdir -p "$home_cache_dir" ); then
-  LOCAL_HF_HOME="$home_cache_dir"
 else
-  echo "Error: Failed to create either $persist_cache_dir or $home_cache_dir"
+  echo "Error: Failed to create $persist_cache_dir"
   exit 1
 fi
 DOCKER_HF_HOME="/tmp/hf_home"


### PR DESCRIPTION
# Description
Today, the test tries to create folder in /mnt/disks/persist and fallback to local if no permission. When the fallback happens, the model will be downloaded to local disk(100G disk) which eventually will cause the machine to fail. In that case, it is hard to fix and hard to investigate. 

Comparing to that, it is better to remove the fallback logic and have the test fail immediately if there is permission issue. Then, we can see the problem earlier and take action. 


FIXES: b/446517494

# Tests

https://buildkite.com/tpu-commons/tpu-commons-ci/builds/3452

