### PR TITLE
[TorchAX] Remove unneeded `sampling_metadata` parameter passed to `compute_logits`

### DIFF
--- a/tpu_commons/models/vllm/vllm_model_wrapper.py
+++ b/tpu_commons/models/vllm/vllm_model_wrapper.py
@@ -71,8 +71,7 @@ class _VllmRunner(torch.nn.Module):
         return hidden_state
 
     def compute_logits(self, hidden_state: torch.Tensor) -> torch.Tensor:
-        return self.vllm_model.compute_logits(hidden_state,
-                                              sampling_metadata=None)
+        return self.vllm_model.compute_logits(hidden_state)
 
 
 class VllmModelWrapper:


### PR DESCRIPTION
# Description

Fixes the following bug:

```

(EngineCore_DP0 pid=340) ERROR 09-22 14:20:52 [core.py:708]   File "/workspace/tpu_commons/tpu_commons/models/vllm/vllm_model_wrapper.py", line 53, in forward
--
  | (EngineCore_DP0 pid=340) ERROR 09-22 14:20:52 [core.py:708]     return self.compute_logits(kwargs["hidden_state"])
  | (EngineCore_DP0 pid=340) ERROR 09-22 14:20:52 [core.py:708]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  | (EngineCore_DP0 pid=340) ERROR 09-22 14:20:52 [core.py:708]   File "/workspace/tpu_commons/tpu_commons/models/vllm/vllm_model_wrapper.py", line 74, in compute_logits
  | (EngineCore_DP0 pid=340) ERROR 09-22 14:20:52 [core.py:708]     return self.vllm_model.compute_logits(hidden_state,
  | (EngineCore_DP0 pid=340) ERROR 09-22 14:20:52 [core.py:708]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  | (EngineCore_DP0 pid=340) ERROR 09-22 14:20:52 [core.py:708] TypeError: Qwen2ForCausalLM.compute_logits() got an unexpected keyword argument 'sampling_metadata'
```

# Tests

Tested locally + on CI.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
