### PR TITLE
Fix for vllm/pull/25332.

### DIFF
--- a/tpu_commons/executors/ray_distributed_executor.py
+++ b/tpu_commons/executors/ray_distributed_executor.py
@@ -28,7 +28,7 @@ from collections import defaultdict
 
 import msgspec
 from vllm.executor.msgspec_utils import encode_hook
-from vllm.model_executor.layers.sampler import SamplerOutput
+from vllm.v1.outputs import SamplerOutput
 
 from tpu_commons.distributed.utils import set_node_kv_ip_port
 


### PR DESCRIPTION
[vllm/pull/25332](https://github.com/vllm-project/vllm/pull/25332/files) has changed the executor sampler interface and caused Jax Unit Tests to fail. Making a small fix for this.
Testing fix resolves the failures in Jax Unit Tests with this build kite job: https://buildkite.com/tpu-commons/tpu-commons-ci/builds/3269#0199746d-bc40-41ac-9314-9fcc833a3f95

Start with a short description of what the PR does and how this is a change from
the past.

The rest of the description includes relevant details and context, examples:
- why is this change being made,
- the problem being solved and any relevant context,
- why this is a good solution,
- some information about the specific implementation,
- shortcomings of the solution and possible future improvements.

If the change fixes a bug or a Github issue, please include a link, e.g.,:
FIXES: b/123456
FIXES: #123456

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
