### PR TITLE
[Bugfix] Fix module not found error

### DIFF
--- a/tpu_commons/mock/vllm_logger.py
+++ b/tpu_commons/mock/vllm_logger.py
@@ -140,7 +140,7 @@ def _configure_vllm_root_logger() -> None:
         if formatter.get(
                 "class") == "tpu_commons.vllm_logging_utils.NewLineFormatter":
             formatter[
-                "class"] = "tpu_commons.vllm_logging_utils.NewLineFormatter"
+                "class"] = "tpu_commons.mock.vllm_logging_utils.NewLineFormatter"
 
     if logging_config:
         dictConfig(logging_config)


### PR DESCRIPTION
# Description

Fix error following error when attempting to run microbenchmark in g3

```
ModuleNotFoundError: No module named 'tpu_commons.vllm_logging_utils'
```

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
