### PR TITLE
[Misc] Precompile backbone with input embeds (instead of input_ids) for MM models.

### DIFF
--- a/tpu_commons/runner/tpu_jax_runner.py
+++ b/tpu_commons/runner/tpu_jax_runner.py
@@ -376,7 +376,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             input_ids, mm_embeds)
 
         # TODO: Disable this for now
-        if self.is_multimodal_model or self.lora_config is not None:
+        if self.lora_config is not None:
             self.maybe_forbid_compile = nullcontext()
 
         lora_metadata = self.lora_utils.extract_lora_metadata()


### PR DESCRIPTION
# Description

The multimodal models set input_ids to None and pass in input_embeds, so we have to precomiple the variant of `model_fn`

# Tests

Jax runner unit test: https://paste.googleplex.com/5557572799168512
E2e (used to throw error without the warmup change in this PR): `VLLM_XLA_CHECK_RECOMPILATION=1 python examples/multi_modal_inference.py    --model=Qwen/Qwen2.5-VL-7B-Instruct      --tensor_parallel_size=1         --max_model_len=16384     --num-prompts=1`

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
