### PR TITLE
[Misc] Fix logic that determines available memory

### DIFF
--- a/tpu_commons/runner/tpu_jax_runner.py
+++ b/tpu_commons/runner/tpu_jax_runner.py
@@ -308,7 +308,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                                     is not None)
 
         logger.info(f"Init model | "
-                    f"hbm={common_utils.hbm_usage_gb(self.devices)}Gb")
+                    f"hbm={common_utils.hbm_usage_gb(self.devices)}GiB")
 
     def get_supported_tasks(self) -> tuple[SupportedTask, ...]:
         return ("generate", )


### PR DESCRIPTION
# Description

According to [vllm/vllm/config/cache.py](https://github.com/vllm-project/vllm/blob/164299500be5ae1e8c71e06d4b90ac82d9a0b31b/vllm/config/cache.py#L42-L49), `gpu_memory_utilization` determines the ratio of total GPU memory (or TPU memory in our example) that vLLM can use. Meaning `model weight + kv cache = total device memory * utilization`

However, current logic is used to determine the ratio of free memory that vLLM can use for kv cache. Meaning `kv cache = (total device memory - model weight) * utilization`.

This PR fixes the issue.

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
