### PR TITLE
Remove max_seq_len_to_capture to fix the CI

### DIFF
--- a/tests/lora/test_lora.py
+++ b/tests/lora/test_lora.py
@@ -28,7 +28,6 @@ def use_v1_only(monkeypatch: pytest.MonkeyPatch):
 def setup_vllm(num_loras: int) -> vllm.LLM:
     return vllm.LLM(model="Qwen/Qwen2.5-3B-Instruct",
                     max_model_len=256,
-                    max_seq_len_to_capture=256,
                     max_num_seqs=8,
                     enable_lora=True,
                     max_loras=num_loras,


### PR DESCRIPTION
# Description

https://github.com/vllm-project/vllm/pull/25543 removed `max_seq_len_to_capture`. This PR intends to change accordingly in TPU_commons.

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
