### PR TITLE
add DisaggEngineCore class for VLLM_ENABLE_V1_MULTIPROCESSING=0

### DIFF
--- a/examples/offline_inference.py
+++ b/examples/offline_inference.py
@@ -114,7 +114,9 @@ if __name__ == "__main__":
     else:
         from unittest.mock import patch
 
-        from tpu_commons.core.core_tpu import DisaggEngineCoreProc
+        from tpu_commons.core.core_tpu import (DisaggEngineCore,
+                                               DisaggEngineCoreProc)
 
-        with patch("vllm.v1.engine.core.EngineCoreProc", DisaggEngineCoreProc):
+        with patch("vllm.v1.engine.core.EngineCore", DisaggEngineCore), patch(
+                "vllm.v1.engine.core.EngineCoreProc", DisaggEngineCoreProc):
             main(args)

--- a/tpu_commons/core/core_tpu.py
+++ b/tpu_commons/core/core_tpu.py
@@ -8,6 +8,7 @@ import signal
 import threading
 import time
 import traceback
+from collections import deque
 from typing import Any, Callable, Optional, Tuple, TypeVar, Union
 
 import jax
@@ -16,7 +17,7 @@ import jax
 # ======================================================================================
 from vllm.config import VllmConfig
 from vllm.logger import init_logger
-from vllm.tasks import POOLING_TASKS
+from vllm.tasks import POOLING_TASKS, SupportedTask
 from vllm.v1.core.kv_cache_utils import (get_request_block_hasher,
                                          init_none_hash)
 from vllm.v1.engine import (EngineCoreOutputs, EngineCoreRequest,
@@ -25,7 +26,7 @@ from vllm.v1.engine import (EngineCoreOutputs, EngineCoreRequest,
 from vllm.v1.engine.core import EngineCore as vLLMEngineCore
 from vllm.v1.engine.core import EngineCoreProc as vLLMEngineCoreProc
 from vllm.v1.executor.abstract import Executor
-from vllm.v1.request import RequestStatus
+from vllm.v1.request import Request, RequestStatus
 
 from tpu_commons import utils as common_utils
 from tpu_commons.core import disagg_executor, disagg_utils
@@ -309,7 +310,7 @@ class _DisaggOrchestrator:
                     break
 
                 if prefill_output is None:
-                    logger.info(
+                    logger.debug(
                         f"decode-{idx} Empty output, and we are idle, exiting..."
                     )
                     break
@@ -382,6 +383,181 @@ class _DisaggOrchestrator:
 # ======================================================================================
 
 
+def _create_engine_cores(
+    slice_sizes: tuple[int, ...],
+    vllm_config: VllmConfig,
+    log_stats: bool,
+    executor_fail_callback: Optional[Callable] = None,
+) -> list[vLLMEngineCore]:
+    engine_cores = []
+    for _ in slice_sizes:
+        engine_core = vLLMEngineCore(
+            vllm_config,
+            disagg_executor.DisaggExecutor,
+            log_stats,
+            executor_fail_callback,
+        )
+
+        engine_cores.append(engine_core)
+        logger.warning("Disaggregated engine core created.")
+
+    return engine_cores
+
+
+class DisaggEngineCore(vLLMEngineCore):
+    """The vLLM-facing adapter that handles process management and I/O. Modifes vLLMEngineCore and is only used in in-process EngineCore client."""
+
+    @staticmethod
+    def is_supported() -> bool:
+        """
+        Returns True if this engine can run in the current environment.
+        """
+        return disagg_utils.is_disagg_enabled()
+
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        executor_class: type[Executor],
+        log_stats: bool,
+        executor_fail_callback: Optional[Callable] = None,
+    ):
+        # We don't invoke super class's ctor as we are not really the
+        # engine core to be executed, instead we create other instance of
+        # engine cores and let them do the work.
+        self.vllm_config = vllm_config
+        self.vllm_config.cache_config.gpu_memory_utilization = (
+            self.vllm_config.cache_config.gpu_memory_utilization - 0.1)
+
+        devices = jax.devices()
+        prefill_slice_sizes = disagg_utils.get_prefill_slices()
+        decode_slice_sizes = disagg_utils.get_decode_slices()
+        prefill_chip_cnt = sum(prefill_slice_sizes)
+        decode_chip_cnt = sum(decode_slice_sizes)
+        assert decode_chip_cnt + prefill_chip_cnt <= len(devices)
+        assert prefill_chip_cnt > 0 and decode_chip_cnt > 0
+
+        self.output_queue = queue.Queue[Union[tuple[int, EngineCoreOutputs],
+                                              bytes]]()
+
+        slice_sizes = list(prefill_slice_sizes)
+        slice_sizes.extend(decode_slice_sizes)
+        setattr(vllm_config.device_config, "slice", (0, slice_sizes))
+        logger.warning("Creating DisaggEngineCore ...")
+        logger.info(f"Adding slice config to device config: {slice_sizes}")
+
+        self._prefill_engines = _create_engine_cores(
+            prefill_slice_sizes,
+            vllm_config,
+            log_stats,
+            executor_fail_callback,
+        )
+        logger.info(
+            f"{len(self._prefill_engines)} Disaggregated prefill engines created."
+        )
+
+        self._decode_engines = _create_engine_cores(
+            decode_slice_sizes,
+            vllm_config,
+            log_stats,
+            executor_fail_callback,
+        )
+        logger.info(
+            f"{len(self._decode_engines)} Disaggregated decode engines created."
+        )
+
+        self.batch_queue_size = self._prefill_engines[
+            0].model_executor.max_concurrent_batches
+        self.batch_queue = None
+        if self.batch_queue_size > 1:
+            logger.info("Batch queue is enabled with size %d",
+                        self.batch_queue_size)
+            self.batch_queue = deque(maxlen=self.batch_queue_size)
+
+        self.request_block_hasher = None
+        if (self.vllm_config.cache_config.enable_prefix_caching
+                or self._prefill_engines[0].scheduler.get_kv_connector()
+                is not None):
+
+            block_size = vllm_config.cache_config.block_size
+            caching_hash_fn = common_utils.get_hash_fn_by_name(
+                vllm_config.cache_config.prefix_caching_hash_algo)
+            init_none_hash(caching_hash_fn)
+
+            self.request_block_hasher = get_request_block_hasher(
+                block_size, caching_hash_fn)
+
+        self.step_fn = (self.step if self.batch_queue is None else
+                        self.step_with_batch_queue)
+
+        self.mm_receiver_cache = None
+        self._orchestrator = _DisaggOrchestrator(
+            config=VllmConfigAdapter(vllm_config),
+            output_queue=self.output_queue,
+            prefill_engines=[
+                VllmEngineAdapter(e) for e in self._prefill_engines
+            ],
+            decode_engines=[
+                VllmEngineAdapter(e) for e in self._decode_engines
+            ],
+            prefill_slice_sizes=prefill_slice_sizes,
+            decode_slice_sizes=decode_slice_sizes,
+        )
+        # for vllm compatibility
+        self.model_executor = self._prefill_engines[0].model_executor
+
+    def get_supported_tasks(self) -> tuple[SupportedTask, ...]:
+        return self._prefill_engines[0].model_executor.supported_tasks
+
+    def add_request(self, request: Request, request_wave: int = 0):
+        if not isinstance(request.request_id, str):
+            raise TypeError(
+                f"request_id must be a string, got {type(request.request_id)}")
+
+        if pooling_params := request.pooling_params:
+            supported_pooling_tasks = [
+                task for task in self.get_supported_tasks()
+                if task in POOLING_TASKS
+            ]
+
+            if pooling_params.task not in supported_pooling_tasks:
+                raise ValueError(f"Unsupported task: {pooling_params.task!r} "
+                                 f"Supported tasks: {supported_pooling_tasks}")
+
+        if request.kv_transfer_params is not None and (
+                not self.scheduler.get_kv_connector()):
+            logger.warning("Got kv_transfer_params, but no KVConnector found. "
+                           "Disabling KVTransfer for this request.")
+
+        self._orchestrator.add_request(VllmRequestAdapter(request))
+
+    def step(self) -> tuple[dict[int, EngineCoreOutputs], bool]:
+        client_idx, output = self.output_queue.get()
+        # logger.warning(f"step output: {output}")
+        time.sleep(0.01)
+        return {client_idx: output}, True
+
+    def shutdown(self):
+        self._orchestrator.shutdown()
+
+    def reset_mm_cache(self):
+        # NOTE: Since this is mainly for debugging, we don't attempt to
+        # re-sync the internal caches (P0 processor, P0 mirror, P1 mirror)
+        for engine in itertools.chain(self._prefill_engines,
+                                      self._decode_engines):
+            if engine.scheduler.has_unfinished_requests():
+                logger.warning(
+                    "Resetting the multi-modal cache when requests are "
+                    "in progress may lead to desynced internal caches.")
+
+            if engine.mm_receiver_cache is not None:
+                engine.mm_receiver_cache.clear_cache()
+
+    def reset_prefix_cache(self):
+        for engine in itertools.chain(self._prefill_engines,
+                                      self._decode_engines):
+            engine.scheduler.reset_prefix_cache()
+
+
 class DisaggEngineCoreProc(vLLMEngineCoreProc):
     """The vLLM-facing adapter that handles process management and I/O."""
 
@@ -439,7 +615,7 @@ class DisaggEngineCoreProc(vLLMEngineCoreProc):
             self.input_queue.put_nowait(
                 (EngineCoreRequestType.EXECUTOR_FAILED, b''))
 
-        self._prefill_engines = self._create_engine_cores(
+        self._prefill_engines = _create_engine_cores(
             prefill_slice_sizes,
             vllm_config,
             log_stats,
@@ -449,7 +625,7 @@ class DisaggEngineCoreProc(vLLMEngineCoreProc):
             f"{len(self._prefill_engines)} Disaggregated prefill engines created."
         )
 
-        self._decode_engines = self._create_engine_cores(
+        self._decode_engines = _create_engine_cores(
             decode_slice_sizes,
             vllm_config,
             log_stats,
@@ -526,27 +702,6 @@ class DisaggEngineCoreProc(vLLMEngineCoreProc):
             prefill_slice_sizes=prefill_slice_sizes,
             decode_slice_sizes=decode_slice_sizes,
         )
-
-    @staticmethod
-    def _create_engine_cores(
-        slice_sizes: tuple[int, ...],
-        vllm_config: VllmConfig,
-        log_stats: bool,
-        executor_fail_callback: Optional[Callable] = None,
-    ) -> list[vLLMEngineCore]:
-        engine_cores = []
-        for _ in slice_sizes:
-            engine_core = vLLMEngineCore(
-                vllm_config,
-                disagg_executor.DisaggExecutor,
-                log_stats,
-                executor_fail_callback,
-            )
-
-            engine_cores.append(engine_core)
-            logger.info("Disaggregated engine core created.")
-
-        return engine_cores
 
     def add_request(self, request: EngineCoreRequest, request_wave: int = 0):
         if not isinstance(request.request_id, str):


### PR DESCRIPTION
# Description

Add DisaggEngineCore that patches EngineCore. In InprocClient (when VLLM_ENABLE_V1_MULTIPROCESSING=0) the EngineCore class is directly invoked.

# Tests

VLLM_ENABLE_V1_MULTIPROCESSING=0 TPU_BACKEND_TYPE=jax PREFILL_SLICES=2 DECODE_SLICES=2 HF_TOKEN=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 python examples/offline_inference.py --model=meta-llama/Meta-Llama-3.1-8B-Instruct --task=generate --max_model_len=2048 --tensor_parallel_size 2 --download-dir=/dev/shm

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
