### PR TITLE
[Bugfix] Fix error where expert parallelism isn't being enabled

### DIFF
--- a/tpu_commons/models/vllm/quantization/common.py
+++ b/tpu_commons/models/vllm/quantization/common.py
@@ -2,6 +2,7 @@ import torchax
 from jax.sharding import Mesh, PartitionSpec
 from vllm.config import VllmConfig
 from vllm.logger import init_logger
+from vllm.model_executor.layers.fused_moe.layer import FusedMoE, FusedMoEConfig
 # yapf: disable
 from vllm.model_executor.layers.linear import (ColumnParallelLinear,
                                                LinearBase,
@@ -95,3 +96,10 @@ class JaxCommonConfig:
     def get_linear_config(self, layer: LinearBase) -> JaxCommonLinearConfig:
         assert isinstance(layer, LinearBase)
         return JaxCommonLinearConfig(self.vllm_config, self.mesh, layer)
+
+    def get_moe_config(self, layer: FusedMoE) -> FusedMoEConfig:
+        assert isinstance(layer, FusedMoE)
+        moe_config = layer.moe_config
+        use_ep = self.vllm_config.parallel_config.enable_expert_parallel
+        moe_config.moe_parallel_config.use_ep = use_ep
+        return moe_config

--- a/tpu_commons/models/vllm/quantization/unquantized.py
+++ b/tpu_commons/models/vllm/quantization/unquantized.py
@@ -61,7 +61,8 @@ class JaxUnquantizedConfig(QuantizationConfig, JaxCommonConfig):
             linear_config = self.get_linear_config(layer)
             return JaxUnquantizedLinearMethod(linear_config)
         if isinstance(layer, FusedMoE):
-            return JaxUnquantizedFusedMoEMethod(layer.moe_config, self.mesh)
+            moe_config = self.get_moe_config(layer)
+            return JaxUnquantizedFusedMoEMethod(moe_config, self.mesh)
         if isinstance(layer, Attention):
             return None
         return None


### PR DESCRIPTION
# Description

Fix a bug where option `--enable-expert-parallel` was not being passed correctly

# Tests

Ran following command and logged `FusedMoEConfig`

```
python vllm/examples/offline_inference/basic/generate.py \
    --model=Qwen/Qwen3-30B-A3B \
    --tensor_parallel_size=4 \
    --max_model_len=1024 \
    --enable-expert-parallel
```

Before

```
FusedMoEConfig(num_experts=128, experts_per_token=8, hidden_dim=2048, num_local_experts=128, moe_parallel_config=FusedMoEParallelConfig(tp_size=1, dp_size=1, ep_size=1, tp_rank=0, dp_rank=0, ep_rank=0, use_ep=False), in_dtype=torch.bfloat16, max_num_tokens=256, has_bias=False)
```

After

```
FusedMoEConfig(num_experts=128, experts_per_token=8, hidden_dim=2048, num_local_experts=128, moe_parallel_config=FusedMoEParallelConfig(tp_size=1, dp_size=1, ep_size=1, tp_rank=0, dp_rank=0, ep_rank=0, use_ep=True), in_dtype=torch.bfloat16, max_num_tokens=256, has_bias=False)
```

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
