### PR TITLE
[Pathways] Fix hbm limit calculation and remove device info logging to support AsyncEngine

### DIFF
--- a/tpu_commons/__init__.py
+++ b/tpu_commons/__init__.py
@@ -1,7 +1,5 @@
 import os
 
-import jax
-
 from tpu_commons import tpu_info as ti
 from tpu_commons.logger import init_logger
 
@@ -22,8 +20,6 @@ if "proxy" in os.environ.get('JAX_PLATFORMS', '').lower():
         import pathwaysutils
         pathwaysutils.initialize()
         logger.info("Module pathwaysutils is imported.")
-        logger.info(f"TPU type: {jax.devices()[0].device_kind} |"
-                    f"num_chips={len(jax.devices())} ")
     except Exception as e:
         logger.error(
             f"Error occurred while importing pathwaysutils or logging TPU info: {e}"

--- a/tpu_commons/kernels/ragged_paged_attention/v3/tuned_block_sizes.py
+++ b/tpu_commons/kernels/ragged_paged_attention/v3/tuned_block_sizes.py
@@ -3,9 +3,9 @@
 import jax.numpy as jnp
 
 from tpu_commons.kernels.ragged_paged_attention.v3.util import (
-    align_to, get_device_name, get_dtype_packing, get_tpu_version,
-    next_power_of_2)
+    align_to, get_dtype_packing, get_tpu_version, next_power_of_2)
 from tpu_commons.logger import init_logger
+from tpu_commons.utils import get_device_name
 
 logger = init_logger(__name__)
 

--- a/tpu_commons/kernels/ragged_paged_attention/v3/util.py
+++ b/tpu_commons/kernels/ragged_paged_attention/v3/util.py
@@ -43,23 +43,3 @@ def get_tpu_version() -> int:
         return 7
     assert kind[:-1] == 'TPU v', kind
     return int(kind[-1])
-
-
-def get_device_name(num_devices: int | None = None):
-    kind = jax.devices()[0].device_kind
-    if 'TPU' not in kind:
-        raise RuntimeError('Expected TPU devices')
-    suffix = ''
-    if kind.endswith(' lite'):
-        kind = kind[:-len(' lite')]
-        suffix = 'e'
-    if kind.endswith('p'):
-        kind = kind[:-1]
-        suffix = 'p'
-    if kind == 'TPU7x':
-        kind = 'TPU v7'
-    assert kind[:-1] == 'TPU v', kind
-    kind += suffix
-    if num_devices is not None:
-        kind += f'-{num_devices}'
-    return kind

--- a/tpu_commons/utils.py
+++ b/tpu_commons/utils.py
@@ -85,11 +85,45 @@ def hbm_usage_bytes(devices: Any) -> List[Tuple[int, int]]:
     return usage
 
 
+def get_device_name(num_devices: int | None = None):
+    kind = jax.devices()[0].device_kind
+    if 'TPU' not in kind:
+        raise RuntimeError('Expected TPU devices')
+    suffix = ''
+    if kind.endswith(' lite'):
+        kind = kind[:-len(' lite')]
+        suffix = 'e'
+    if kind.endswith('p'):
+        kind = kind[:-1]
+        suffix = 'p'
+    if kind == 'TPU7x':
+        kind = 'TPU v7'
+    assert kind[:-1] == 'TPU v', kind
+    kind += suffix
+    if num_devices is not None:
+        kind += f'-{num_devices}'
+    return kind
+
+
+def get_device_hbm_limit() -> int:
+
+    device_kind = get_device_name()
+    if device_kind == "TPU v5p" or device_kind == "TPU v5":
+        return 95 * GBYTES
+    elif device_kind == "TPU v5e":
+        return 16 * GBYTES
+    elif device_kind == "TPU v6e" or device_kind == "TPU v4":
+        return 32 * GBYTES
+    elif device_kind == "TPU v7":
+        return 192 * GBYTES
+    else:
+        raise ValueError(f"Unknown device kind: {device_kind}")
+
+
 def pathways_hbm_usage_gb(devices: Any) -> List[Tuple[float, float]]:
     live_arrays = jax.live_arrays()
     hbm_used = defaultdict(int)
-    # TODO(wenxindong): Find a way to get the accurate hbm limit on Pathways.
-    hbm_limit = 33550237184
+    hbm_limit = get_device_hbm_limit()
     for array in live_arrays:
         assert hasattr(array, 'sharding') and hasattr(
             array.sharding, 'device_set'


### PR DESCRIPTION
# Description

Previously we hardcoded the HBM limit to 32GB when running tpu_commons on Pathways. This is incorrect and this PR fixes this hbm limit calculation to account for the device type. 

Additionally this PR removes the Pathways device info logging during the `__init__.py` file because `jax.devices()` initiates a Pathways client. When using `vllm serve`, 2 processes will both run the `__init__.py` file and result in an error where Pathways fails to initialize the second JAX runtime. Thus, removing the log resolves this issue.  

# Tests

Manually tested, and will test with BuildKite. 

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
