### PR TITLE
[Misc] Fix typo in available memory check

### DIFF
--- a/tpu_commons/worker/tpu_worker_jax.py
+++ b/tpu_commons/worker/tpu_worker_jax.py
@@ -169,7 +169,7 @@ class TPUWorker(AbstractTpuWorker):
 
         if total_hbm_avail <= 0:
             raise ValueError(f"{total_hbm_used_gb=}GiB exceeds "
-                             f"{total_hbm_limit_gb=}GiB by "
+                             f"{total_hbm_limit_cap_gb=}GiB by "
                              f"{-total_hbm_avail_gb}GiB. Please consider "
                              f"increasing --gpu-memory-utilization from "
                              f"{gpu_memory_utilization} to a larger value.")


### PR DESCRIPTION
# Description

Fixes a small typo in the available memory check where

```
(EngineCore_DP0 pid=209979) ValueError: total_hbm_used_gb=647.4GiB exceeds total_hbm_limit_gb=606.37GiB by 41.02GiB. Please consider increasing --gpu-memory-utilization from 0.8 to a larger value.
```


Should be

```
(EngineCore_DP0 pid=209979) ValueError: total_hbm_used_gb=647.4GiB exceeds 606.37GiB by 41.02GiB. Please consider increasing --gpu-memory-utilization from 0.8 to a larger value.

```

# Tests

Tested locally.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
