### PR TITLE
[Kernel] Add a heuristic in flash attention to speed up the Qwen2.5 VL 7B model.

### DIFF
--- a/tpu_commons/kernels/flash_attention/kernel.py
+++ b/tpu_commons/kernels/flash_attention/kernel.py
@@ -132,6 +132,13 @@ def flash_attention(
     if block_sizes is None:
         block_sizes = BlockSizes.get_default(batch_size, num_heads, q_seq_len,
                                              kv_seq_len, d_model)
+        # TODO (KWang1998 & hfan): tune the block sizes properly.
+        if kv_seq_len <= 21760:
+            # Override block_k/block_k_major to use `_flash_attention_kernel_single_batch_single_step`.
+            block_sizes = BlockSizes(block_q=block_sizes.block_q,
+                                     block_b=block_sizes.block_b,
+                                     block_k_major=kv_seq_len,
+                                     block_k=kv_seq_len)
     return _flash_attention(q, k, v, ab, segment_ids, False, causal, sm_scale,
                             block_sizes, debug)
 


### PR DESCRIPTION
# Description

Using `_flash_attention_kernel_single_batch_single_step` is much faster than `_flash_attention_kernel_single_batch` with default block sizes.

For the longer term, we should just properly tune the block sizes per model/usecase.

# Tests

Benchmark server cmd: `python -m vllm.entrypoints.openai.api_server --model Qwen/Qwen2.5-VL-7B-Instruct --max-model-len=1597 --disable-log-requests --disable-uvicorn-access-log --max-num-batched-tokens 16384 --max-num-seqs 1024 --tensor-parallel-size 1 --no-enable-prefix-caching --limit-mm-per-prompt '{"image": 1}'`

Benchmark client cmd: `vllm bench serve --backend openai-chat --model Qwen/Qwen2.5-VL-7B-Instruct --dataset-name custom --dataset-path /mnt/fanhongmin-data-1/dataset/Qwen2.5-VL-7B-Instruct/inlen1024_outlen110_prefixlen0_736h_480w_1.jsonl --num-prompts 1000 --ignore-eos --custom-output-len 110 --custom-skip-chat-template --endpoint /v1/chat/completions`

The result is ~8 req/s (previously ~1.5 req/s):

```
============ Serving Benchmark Result ============
Successful requests:                     1000
Benchmark duration (s):                  128.34
Total input tokens:                      1022553
Total generated tokens:                  110000
Request throughput (req/s):              7.79
Output token throughput (tok/s):         857.12
Peak output token throughput (tok/s):    5101.00
Peak concurrent requests:                1000.00
Total Token throughput (tok/s):          8824.85
---------------Time to First Token----------------
Mean TTFT (ms):                          64927.10
Median TTFT (ms):                        64714.54
P99 TTFT (ms):                           124499.88
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          143.44
Median TPOT (ms):                        150.72
P99 TPOT (ms):                           192.27
---------------Inter-token Latency----------------
Mean ITL (ms):                           142.27
Median ITL (ms):                         30.10
P99 ITL (ms):                            1150.89
==================================================
```



# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
