### PR TITLE
[Spec Decoding] Fix an implementation discrepancy in the Eagle3 proposer

### DIFF
--- a/tests/spec_decode/test_eagle3.py
+++ b/tests/spec_decode/test_eagle3.py
@@ -7,13 +7,13 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 import pytest
+
+from tpu_commons.models.jax.attention_metadata import AttentionMetadata
+from tpu_commons.spec_decode.jax.eagle3 import Eagle3Proposer
 from vllm.config import (CacheConfig, DeviceConfig, ModelConfig,
                          ParallelConfig, SchedulerConfig, SpeculativeConfig,
                          VllmConfig)
 from vllm.config.load import LoadConfig
-
-from tpu_commons.models.jax.attention_metadata import AttentionMetadata
-from tpu_commons.spec_decode.jax.eagle3 import Eagle3Proposer
 
 # Use a real model dir for config, but we will mock model loading/execution
 model_dir = "meta-llama/Llama-3.1-8B-Instruct"
@@ -173,7 +173,7 @@ def test_propose(method, num_speculative_tokens):
         else:  # Subsequent calls in the loop
             new_hidden_states = new_hidden_states.at[:, 0].set(input_ids + 1)
 
-        return kv_caches, new_hidden_states, None
+        return kv_caches, new_hidden_states, new_hidden_states
 
     def mock_compute_logits_fn(state, hidden_states, lora_metadata):
         # Create deterministic logits from hidden_states.


### PR DESCRIPTION
# Description

The bug will result in prediction discrepancy for subsequent tokens (except the first spec token).

# Tests

UTs tested.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
