### PR TITLE
Fix CI "upload tests for models & features" error

### DIFF
--- a/.buildkite/scripts/upload_models_and_features.sh
+++ b/.buildkite/scripts/upload_models_and_features.sh
@@ -81,5 +81,5 @@ if [[ "${#pipeline_steps[@]}" -gt 0 ]]; then
   echo -e "${final_pipeline_yaml}" | buildkite-agent pipeline upload
 else
   echo "--- No .yml files found, no new Pipeline Steps to upload."
-  buildkite-agent step update --state "passed"
+  exit 0
 fi


### PR DESCRIPTION
# Description

"upload tests for models & features" task fails with `buildkite-agent: fatal: flag provided but not defined: -state`

# Tests

- A new CI run succeeded at this task: https://buildkite.com/tpu-commons/tpu-commons-ci/builds/3736#0199ac0a-a6d8-4f83-9df3-6474b7139211

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
