### PR TITLE
Fix: Rename TPU_COMMONS_DIR to TPU_INFERENCE_DIR in test script

### DIFF
--- a/tests/scripts/run_rpa_v3_tests.sh
+++ b/tests/scripts/run_rpa_v3_tests.sh
@@ -3,7 +3,7 @@
 # Install dependencies
 pip install -U --pre jax jaxlib libtpu requests -i https://us-python.pkg.dev/ml-oss-artifacts-published/jax/simple/ -f https://storage.googleapis.com/jax-releases/libtpu_releases.html
 
-TPU_COMMONS_DIR="/workspace/tpu_inference/"
+TPU_INFERENCE_DIR="/workspace/tpu_inference/"
 
 # RPA v3 test files - add new tests here
 RPA_V3_TESTS=(
@@ -14,7 +14,7 @@ RPA_V3_TESTS=(
 # Convert array to space-separated string for pytest
 FULL_PATHS=()
 for test in "${RPA_V3_TESTS[@]}"; do
-    FULL_PATHS+=("$TPU_COMMONS_DIR/$test")
+    FULL_PATHS+=("$TPU_INFERENCE_DIR/$test")
 done
 
 # Run all tests in a single pytest command


### PR DESCRIPTION
# Description

Simple rename for consistency of the tpu_inference naming conventions. These changes don't seem to impact anything else outside of this script and should be wholly contained. 

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
