### PR TITLE
[RPAv3] Set VMEM limit to 100MB

### DIFF
--- a/tpu_inference/kernels/ragged_paged_attention/v3/kernel.py
+++ b/tpu_inference/kernels/ragged_paged_attention/v3/kernel.py
@@ -20,6 +20,7 @@ from tpu_inference.kernels.ragged_paged_attention.v3.util import (
 
 DEFAULT_MASK_VALUE = -0.7 * float(jnp.finfo(jnp.dtype("float32")).max)
 
+DEFAULT_VMEM_LIMIT_BYTES = 100 * 1024 * 1024
 
 def ref_ragged_paged_attention(
     queries: jax.
@@ -1330,16 +1331,9 @@ def ragged_paged_attention(
         )
     bkv_sz = bkv_p * page_size
     if vmem_limit_bytes is None:
-        vmem_limit_bytes = int(
-            get_vmem_estimate_bytes(
-                actual_num_kv_heads,
-                actual_num_q_heads_per_kv_head,
-                head_dim,
-                bq_sz,
-                bkv_sz,
-                q.dtype,
-                kv_cache.dtype,
-            ) * 2.4)  # TODO(jevinjiang): figure out why it is so inaccurate?
+        # TODO (jevinjiang/jacobplatin): change this to use
+        # `get_vmem_estimate_bytes` when VREG spilling is fixed.
+        vmem_limit_bytes = DEFAULT_VMEM_LIMIT_BYTES
     grid = (distribution[2], )
 
     in_specs = [


### PR DESCRIPTION
# Description

This PR sets the default `vmem_limit_bytes` to 100MB for the RPAv3 kernel to avoid VMEM OOMs

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
