### PR TITLE
Improve the benchmark.sh

### DIFF
--- a/.buildkite/models/meta-llama_Llama-3_1-8B.yml
+++ b/.buildkite/models/meta-llama_Llama-3_1-8B.yml
@@ -1,0 +1,74 @@
+# meta-llama/Llama-3.1-8B
+agents:
+  queue: tpu_v6e_queue
+steps:
+  - label: "Unit tests for meta-llama/Llama-3.1-8B"
+    key: "meta-llama_Llama-3_1-8B_UnitTest"
+    soft_fail: true
+    commands:
+      - echo "placeholder"  # TODO: replace with your unit test command
+  - label: "Record unit test result for meta-llama/Llama-3.1-8B"
+    key: "record_meta-llama_Llama-3_1-8B_UnitTest"
+    depends_on: "meta-llama_Llama-3_1-8B_UnitTest"
+    env:
+      CI_STAGE: "UnitTest"
+      CI_TARGET: meta-llama/Llama-3.1-8B
+    agents:
+      queue: tpu_v6e_queue
+    commands:
+      - |
+        .buildkite/scripts/record_step_result.sh meta-llama_Llama-3_1-8B_UnitTest
+
+  - label: "Integration tests for meta-llama/Llama-3.1-8B"
+    key: "meta-llama_Llama-3_1-8B_IntegrationTest"
+    depends_on: "record_meta-llama_Llama-3_1-8B_UnitTest"
+    soft_fail: true
+    env:
+      TEST_MODEL: meta-llama/Llama-3.1-8B
+      TENSOR_PARALLEL_SIZE: 1
+      MINIMUM_ACCURACY_THRESHOLD: 0  # TODO : replace 0 with your accuracy threshold
+    commands:
+      - echo "placeholder"  # TODO : revert after testing
+#      - |
+#        .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/test_accuracy.sh
+  - label: "Record integration test result for meta-llama/Llama-3.1-8B"
+    key: "record_meta-llama_Llama-3_1-8B_IntegrationTest"
+    depends_on: "meta-llama_Llama-3_1-8B_IntegrationTest"
+    env:
+      CI_TARGET: meta-llama/Llama-3.1-8B
+      CI_STAGE: "IntegrationTest"
+    agents:
+      queue: tpu_v6e_queue
+    commands:
+      - |
+        .buildkite/scripts/record_step_result.sh meta-llama_Llama-3_1-8B_IntegrationTest
+
+  - label: "Performance benchmarks for meta-llama/Llama-3.1-8B"
+    key: "meta-llama_Llama-3_1-8B_Benchmark"
+    depends_on: "record_meta-llama_Llama-3_1-8B_IntegrationTest"
+    soft_fail: true
+    env:
+      TEST_MODEL: meta-llama/Llama-3.1-8B-Instruct
+      TENSOR_PARALLEL_SIZE: 1
+      MINIMUM_THROUGHPUT_THRESHOLD: 7
+      INPUT_LEN: 1800
+      OUTPUT_LEN: 128
+      PREFIX_LEN: 0
+      MAX_MODEL_LEN: 1928
+      MAX_NUM_SEQS: 100
+      MAX_NUM_BATCHED_TOKENS: 1024
+    commands:
+      # - echo "placeholder"  # TODO : revert after testing
+      - |
+        .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/benchmark.sh
+  - label: "Record performance benchmark result for meta-llama/Llama-3.1-8B"
+    key: "record_meta-llama_Llama-3_1-8B_Benchmark"
+    depends_on: "meta-llama_Llama-3_1-8B_Benchmark"
+    env:
+      CI_TARGET: meta-llama/Llama-3.1-8B
+      CI_STAGE: "Benchmark"
+    agents:
+      queue: tpu_v6e_queue
+    commands:
+      - |
+        .buildkite/scripts/record_step_result.sh meta-llama_Llama-3_1-8B_Benchmark

--- a/.buildkite/scripts/run_in_docker.sh
+++ b/.buildkite/scripts/run_in_docker.sh
@@ -19,6 +19,9 @@ ENV_VARS=(
   -e INPUT_LEN="${INPUT_LEN:-}"
   -e OUTPUT_LEN="${OUTPUT_LEN:-}"
   -e PREFIX_LEN="${PREFIX_LEN:-}"
+  -e MAX_MODEL_LEN="${MAX_MODEL_LEN:-}"
+  -e MAX_NUM_SEQS="${MAX_NUM_SEQS:-}"
+  -e MAX_NUM_BATCHED_TOKENS="${MAX_NUM_BATCHED_TOKENS:-}"
 )
 
 if ! grep -q "^HF_TOKEN=" /etc/environment; then


### PR DESCRIPTION
# Description

Improve the benchmark.sh script by making the following changes:
  1. Replace the throughput metric from Total Token throughput (tok/s) to Request throughput (req/s).
  2. Add the environment variables MAX_MODEL_LEN, MAX_NUM_SEQS, and MAX_NUM_BATCHED_TOKENS for executing the vllm serve command. The script will fail if it can't find these environment variables. Also, update the corresponding description in helpFunction().
  3. Exit the waiting procedure if a RuntimeError is detected.executing the vllm serve command.

# Tests

[Buildkite]()

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
