### PR TITLE
[Model] Make the compilation for getting image embedding faster for Qwen2.5 VL

### DIFF
--- a/tpu_inference/models/common/model_loader.py
+++ b/tpu_inference/models/common/model_loader.py
@@ -236,9 +236,6 @@ def get_flax_model(
 
     # Multi-modal support only
     # This function calculates the image token's embeddings by VIT
-    @functools.partial(jax.jit,
-                       out_shardings=(logits_sharding),
-                       static_argnames=['image_grid_thw'])
     def run_get_multimodal_embeddings(graphdef, state, image_grid_thw,
                                       **kwargs):
         model = nnx.merge(graphdef, state)


### PR DESCRIPTION
# Description

By pushing down the compilation to single image embedding, we don't have to re-compile for different number of images. The e2e benchmarking throughput got faster, because it seems there is always some compilation happening during the benchmarking.

# Tests

Local tests:
* `pytest -v tests/models/jax/test_qwen2_5_vl.py`
* `pytest -v tests/e2e/test_multi_modal_inference.py`

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
