### PR TITLE
Fix lora CI tests due to an vLLM change.

### DIFF
--- a/tpu_inference/layers/vllm/sharding.py
+++ b/tpu_inference/layers/vllm/sharding.py
@@ -102,22 +102,15 @@ def _shard_base_linear_lora(layer: BaseLinearLayerWithLoRA,
     # NOTE: lora_a_stacked[i] has shape [max_loras, 1, num_out, num_in]
     sharded_lora_a_tpu = torch.nn.ParameterList()
     sharded_lora_b_tpu = torch.nn.ParameterList()
-    sharded_lora_bias_tpu = torch.nn.ParameterList()
 
     for i in range(layer.n_slices):
         sharded_lora_a_tpu.append(
             _shard_tensor_to_tpu_replicated(layer.lora_a_stacked[i], mesh))
         sharded_lora_b_tpu.append(
             _shard_tensor_to_tpu_replicated(layer.lora_b_stacked[i], mesh))
-        if layer.lora_bias_stacked is not None:
-            sharded_lora_bias_tpu.append(
-                _shard_tensor_to_tpu_replicated(layer.lora_bias_stacked[i],
-                                                mesh))
 
     layer.lora_a_stacked = sharded_lora_a_tpu
     layer.lora_b_stacked = sharded_lora_b_tpu
-    if layer.lora_bias_stacked is not None:
-        layer.lora_bias_stacked = sharded_lora_bias_tpu
 
 
 # TODO: Add custom sharding logic for following lora layers

--- a/tpu_inference/models/vllm/vllm_model_wrapper.py
+++ b/tpu_inference/models/vllm/vllm_model_wrapper.py
@@ -255,11 +255,9 @@ def replace_set_lora(model):
         lora_a: torch.Tensor,
         lora_b: torch.Tensor,
         embeddings_tensor: Optional[torch.Tensor],
-        bias: Optional[torch.Tensor] = None,
     ):
         with torchax.default_env():
-            self._original_set_lora(index, lora_a, lora_b, embeddings_tensor,
-                                    bias)
+            self._original_set_lora(index, lora_a, lora_b, embeddings_tensor)
 
     def _tpu_reset_lora(self, index: int):
         with torchax.default_env():


### PR DESCRIPTION
# Description

https://github.com/vllm-project/vllm/pull/25807 removes lora_bias and it caused lora tests in to fail in tpu-inference CI. This PR is intended to fix it.

# Tests

CI

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
