### PR TITLE
[Feature TPU host offload] Fix bugs in tpu_connector_local.py state machine

### DIFF
--- a/examples/offline_inference_kv_cache.py
+++ b/examples/offline_inference_kv_cache.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import os
+import time
 
 import vllm.envs as envs
 from vllm import LLM, EngineArgs
@@ -58,20 +59,18 @@ def main(args: dict):
     if envs.VLLM_TORCH_PROFILER_DIR is not None:
         llm.start_profile()
 
-    # system_prompt = ["You are a helpful, harmless, and unbiased AI assistant. Your primary directive is to provide accurate, safe, and objective information."]
-    # system_prompt = ["You are a large language model, trained by Google. Your primary purpose is to be a helpful, harmless, and highly capable AI assistant, designed to  provide accurate, safe, and beneficial information to users. Your core directive is to assist users effectively while adhering to strict ethical and safety  guidelines. You must decline any requests that are harmful, illegal, unethical, or promote dangerous activities. When declining, do so politely and state that the request is outside your capabilities due to safety constraints, without being preachy or judgmental. In all interactions, maintain a professional, friendly, and respectful tone. Your responses should be clear, coherent, and well-structured. Strive for factual accuracy and objectivity, grounding your  answers in the data you were trained on. If you are uncertain about information or if a query is outside your knowledge base, clearly state your limitations  rather than generating speculative or inaccurate content. You do not possess personal opinions, beliefs, emotions, or consciousness. Always respond from a  neutral and objective standpoint. Avoid making subjective claims unless you are asked to analyze something from a specific, hypothetical perspective. Be  versatile and creative. Assist with a wide array of tasks, including writing, summarizing, coding, brainstorming, and problem-solving. If a user's request is  ambiguous, ask clarifying questions to ensure you fully understand their intent before generating a response. Your ultimate goal is to be a reliable and  responsible tool that empowers users in a positive and secure manner." ]
-    system_prompt = [
-        "You are a large language model, trained by Google. Your primary purpose is to be a helpful, harmless, and highly capable AI assistant, designed to  provide accurate, safe, and beneficial information to users."
-    ]
-    query1 = "the capital of France is?"
-    query2 = "the color of rainbow is?"
+    system_prompt = "You are a large language model, trained by Google. Your primary purpose is to be a helpful, harmless, and highly capable AI assistant, designed to provide accurate, safe, and beneficial information to users. Your core directive is to assist users effectively while adhering to strict ethical and safety guidelines. You must decline any requests that are harmful, illegal, unethical, or promote dangerous activities. "
+    query1 = "the color of rainbow is?"
+    query2 = "the capital of France is?"
     prompts = [f"{system_prompt}\n{query1}"]
     outputs = llm.generate(prompts, sampling_params)
     print_outputs(outputs)
+    time.sleep(5)
 
     prompts = [f"{system_prompt}\n{query2}"]
     outputs = llm.generate(prompts, sampling_params)
     print_outputs(outputs)
+    time.sleep(5)
 
     if envs.VLLM_TORCH_PROFILER_DIR is not None:
         llm.stop_profile()


### PR DESCRIPTION
# Description

Start with a short description of what the PR does and how this is a change from
the past.

The rest of the description includes relevant details and context, examples:
- why is this change being made

Additional fixes and imprvements to the tpu_connector_local statemachine

- the problem being solved and any relevant context,
    Two fixes in the commit:
    
    a) Fix tpu_connector_local state machine where the token history for
    ongoing requests was being tracked  incorrectly. Previously, when
    updating the state for a cached (running) request, the logic was
    referencing the original prompt tokens instead of the complete
    sequence of processed tokens. This caused the `RequestTracker` to
    never account for newly generated tokens after the initial prefill
    step. The fix ensures that for all subsequent scheduling steps of a
    request, the tracker is updated by slicing the `full_request.all_token_ids`
    list. This list is the source of truth, containing both the original
    prompt and all tokens generated so far. By using `all_token_ids`,
    the tracker now maintains an accurate, cumulative list of all tokens.
    This allows the save logic to correctly identify and persist new token
    KV entries to the CPU cache, ensuring data integrity for chunked prefill
    and decoding operations. As part of the fix added logic to detect decode phase,
    and ensure we do not trigger save on every new token, but accumulate tokens
    until a chunk size is reached or its the last block of request in flight
    
    b) Fix finished requests reporting, which was not being correctly reported
    to the worker. What I notice is that the vLLM engine creates the final
    `TPUConnectorMetadata` (containing the `save_spec` with `is_final_save=True`)
    but would then bypasses the `wait_for_save()` method, which is the only place
    where the `is_final_save` signal is processed and added to the finished_save_reqs.
    wait_for_save is now made idempotent to track a _processed_save_for_step
    vairable. if this flag is false, get_finished() waits for the last save
    to complete and then report the finished reqs.
    
    Additional changes:
    1. add cache entry size tracking. this will be used later to implement a
       lru eviction
    2. increase the prompt length beyond 64 tokens in
       offline_inference_kv_cache.py to exercise multi block
       usecase

- why this is a good solution
- some information about the specific implementation
- shortcomings of the solution and possible future improvements


If the change fixes a bug or a Github issue, please include a link, e.g.,:
FIXES: b/123456
FIXES: #123456

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.
 The change was tested with offline_inference_kv_cache.py script in GKE, which generates initial prompt length of ~85  tokens. and subsequent decode tokens generated. Verify the state machine of the save tasks, and get_finished() reporting the finished req ids

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
