### PR TITLE
[Feature] [TPU host offload] verification script of baseline vs tpu connector

### DIFF
--- a/examples/gke/pod_tpu_commons_cpu_offload_verification.yaml
+++ b/examples/gke/pod_tpu_commons_cpu_offload_verification.yaml
@@ -1,0 +1,39 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: tpu-job-offline-inference
+  # This pod verifies the correctness of the TPUConnector implementation.
+  # It runs a script that internally performs two text generations:
+  # 1. A baseline run with a standard vLLM engine.
+  # 2. A test run with the TPUConnector enabled.
+  # The pod succeeds only if the outputs from both runs are identical,
+  # ensuring that the connector does not alter the model's output.
+spec:
+  restartPolicy: Never
+  nodeSelector:
+    cloud.google.com/gke-tpu-accelerator: tpu-v6e-slice
+    cloud.google.com/gke-tpu-topology: 2x4 # Specify the physical topology for the TPU slice.
+  containers:
+  - name: tpu-job
+    image: <your-tpu-inference-container-image>
+    imagePullPolicy: Always
+    command:
+    - python
+    - /workspace/tpu_inference/examples/offline_inference_kv_cache_verification.py
+    - --model=meta-llama/Llama-3.1-8B
+    - --tensor_parallel_size=8
+    - --max_model_len=1024
+    - --seed=42
+    - --kv-transfer-config
+    - '{"kv_connector":"TPUConnector","kv_connector_module_path":"tpu_inference.distributed.tpu_connector_local","kv_role":"kv_both"}'
+    env:
+    - name: HUGGING_FACE_HUB_TOKEN
+      valueFrom:
+        secretKeyRef:
+          name: hf-token-secret
+          key: token
+    resources:
+      requests:
+        google.com/tpu: 8
+      limits:
+        google.com/tpu: 8

--- a/examples/offline_inference_kv_cache_verification.py
+++ b/examples/offline_inference_kv_cache_verification.py
@@ -1,0 +1,139 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+This script performs an automated correctness verification for the TPUConnector.
+
+The verification works by performing a two-stage experiment:
+1.  Baseline Run: It first runs a text generation using a standard vLLM
+    engine configuration without any KV cache connector. The output from this
+    run is considered the "source of truth".
+
+2.  Test Run: It then runs the exact same text generation, but this time
+    with the TPUConnector enabled via the `--kv-transfer-config` argument.
+    It runs the generation multiple times to verify prefix caching.
+
+3.  Comparison: The script compares the output from each test run against the
+    output from the baseline run.
+
+The script succeeds (exits with code 0) only if the generated text is
+bit-for-bit identical in all runs. A fixed seed is used to ensure that the
+generation process is deterministic and the comparison is valid. If any output
+differs, it raises an error, causing the script to fail (exit with a non-zero
+code).
+"""
+
+import copy
+import os
+import time
+from typing import List
+
+import vllm.envs as envs
+from vllm import LLM, EngineArgs
+from vllm.utils import FlexibleArgumentParser
+
+
+def create_parser():
+    parser = FlexibleArgumentParser()
+    # Add engine args, which includes the --seed parameter
+    EngineArgs.add_cli_args(parser)
+    parser.set_defaults(model="meta-llama/Llama-3.1-8B")
+    parser.set_defaults(max_model_len=1024)
+
+    # Add sampling params
+    sampling_group = parser.add_argument_group("Sampling parameters")
+    sampling_group.add_argument("--max-tokens", type=int)
+    sampling_group.add_argument("--temperature", type=float)
+    sampling_group.add_argument("--top-p", type=float)
+    sampling_group.add_argument("--top-k", type=int)
+    return parser
+
+
+def run_generation(llm_args: dict, num_invocations: int = 1) -> List[str]:
+    """
+    Initializes a vLLM engine with the given args, runs generation, and
+    returns a list of output texts. If num_invocations > 1, it will run
+    generation multiple times to test prefix caching.
+    """
+    # Pop arguments not used by LLM
+    max_tokens = llm_args.pop("max_tokens")
+    temperature = llm_args.pop("temperature")
+    top_p = llm_args.pop("top_p")
+    top_k = llm_args.pop("top_k")
+
+    # Create an LLM. The --seed argument is passed in via **args.
+    llm = LLM(**llm_args)
+
+    # Create a sampling params object
+    sampling_params = llm.get_default_sampling_params()
+    if max_tokens is not None:
+        sampling_params.max_tokens = max_tokens
+    if temperature is not None:
+        sampling_params.temperature = temperature
+    if top_p is not None:
+        sampling_params.top_p = top_p
+    if top_k is not None:
+        sampling_params.top_k = top_k
+
+    if envs.VLLM_TORCH_PROFILER_DIR is not None:
+        llm.start_profile()
+
+    system_prompt = "You are a large language model, trained by Google. Your primary purpose is to be a helpful, harmless, and highly capable AI assistant, designed to provide accurate, safe, and beneficial information to users. Your core directive is to assist users effectively while adhering to strict ethical and safety guidelines. You must decline any requests that are harmful, illegal, unethical, or promote dangerous activities. "
+    query1 = "the color of rainbow is?"
+    prompts = [f"{system_prompt}\n{query1}"]
+
+    all_outputs = []
+    for i in range(num_invocations):
+        print(f"--- Invocation {i + 1}/{num_invocations} ---")
+        outputs = llm.generate(prompts, sampling_params)
+        all_outputs.append(outputs[0].outputs[0].text)
+        time.sleep(5)
+
+    if envs.VLLM_TORCH_PROFILER_DIR is not None:
+        llm.stop_profile()
+
+    return all_outputs
+
+
+def main(args: dict):
+    # 1. Prepare arguments for the baseline run (no connector)
+    baseline_args = copy.deepcopy(args)
+    baseline_args.pop("kv_transfer_config", None)
+
+    # 2. Run baseline and store the output
+    print("--- Running Baseline (Standard vLLM) ---")
+    baseline_outputs = run_generation(baseline_args)
+    baseline_output = baseline_outputs[0]
+    print(f"Baseline Generated Text: {baseline_output!r}")
+    time.sleep(
+        10
+    )  # adding this sleep fixes device busy errors for the next test case run with the connector enabled
+
+    # 3. Run the test with the local tpu kv connector enabled
+    print("\n--- Running Test (with TPUConnector) ---")
+    # With the connector, we run generation twice to test the prefix cache
+    # TODO: Increase the num_invocations to >=2 to test prefix cache hit.
+    test_outputs = run_generation(args, num_invocations=1)
+
+    # 4. Compare the outputs and determine the result
+    print("\n--- Verification ---")
+    all_match = True
+    for i, test_output in enumerate(test_outputs):
+        print(f"--- Comparing Invocation {i + 1} ---")
+        print(f"Test Generated Text: {test_output!r}")
+        if baseline_output == test_output:
+            print("SUCCESS: Output is identical to baseline!")
+        else:
+            print("FAILURE: Output does not match baseline!")
+            all_match = False
+
+    if not all_match:
+        raise ValueError(
+            "Verification failed: One or more test outputs differ from the baseline."
+        )
+
+
+if __name__ == "__main__":
+    os.environ['SKIP_JAX_PRECOMPILE'] = '1'
+    parser = create_parser()
+    args: dict = vars(parser.parse_args())
+    main(args)


### PR DESCRIPTION
Start with a short description of what the PR does and how this is a change from
the past.

verification script of baseline vs tpu connector implementation

The rest of the description includes relevant details and context, examples:

why is this change being made
Early tests to verify the functional correctness of the tpu_connector_local implementation

the problem being solved and any relevant context

why this is a good solution

```
This solution emulates a similar baseline vs connector comparision done in https://github.com/vllm-project/vllm/blame/main/tests/v1/kv_connector/nixl_integration/run_tpu_disagg_accuracy_test.sh and https://github.com/vllm-project/vllm/blob/main/tests/v1/kv_connector/nixl_integration/test_disagg_accuracy.py
```

some information about the specific implementation

```
offline_inference_kv_cache_verification.py which performs 2 runs of a
given prompt, one with tpu_connector_local disabled, followed by a
run with the tpu_connector_local enabled, and compare the output.
pod_tpu_commons_cpu_offload_verification.yaml pod spec to trigger the
verification py script
```


shortcomings of the solution and possible future improvements.

```
the place holder for the tests would be re-arranged later.
Further the verification script needs to run the test case with the tpu connector local enabled twice, so that we can exercise the load spec statemachine on a prefix cache hit. this will be done in a followup PR
```

If the change fixes a bug or a Github issue, please include a link, e.g.,:
FIXES: b/123456
FIXES: #123456

Tests
Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

```
I have run the script with the pod spec manually and verified the output match in this current iteration of the code
```
Checklist
Before submitting this PR, please make sure:

I have performed a self-review of my code.
I have necessary comments in my code, particularly in hard-to-understand areas.
I have made or will make corresponding changes to any relevant documentation.
