### PR TITLE
[CI] Fix a bug for accessing non-existing get_mrope_input_positions.

### DIFF
--- a/tpu_inference/models/common/model_loader.py
+++ b/tpu_inference/models/common/model_loader.py
@@ -269,7 +269,11 @@ def get_flax_model(
     combine_hidden_states_fn = functools.partial(combine_hidden_states,
                                                  graphdef)
 
-    return model_fn, compute_logits_fn, combine_hidden_states_fn, get_multimodal_embeddings_fn, get_input_embeddings_fn, model_class.get_mrope_input_positions, state, lora_manager, model
+    get_mrope_input_positions_fn = None if not hasattr(
+        model_class,
+        "get_mrope_input_positions") else model_class.get_mrope_input_positions
+
+    return model_fn, compute_logits_fn, combine_hidden_states_fn, get_multimodal_embeddings_fn, get_input_embeddings_fn, get_mrope_input_positions_fn, state, lora_manager, model
 
 
 def get_vllm_model(


### PR DESCRIPTION
# Description

Non-multimodal models don't have this class property

# Tests

CI: https://buildkite.com/tpu-commons/tpu-inference-ci/builds/4197

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
