### PR TITLE
[Feature] [TPU host offload] address full prefix cache hit

### DIFF
--- a/examples/gke/pod_tpu_commons_cpu_offload_verification.yaml
+++ b/examples/gke/pod_tpu_commons_cpu_offload_verification.yaml
@@ -15,7 +15,7 @@ spec:
     cloud.google.com/gke-tpu-topology: 2x4 # Specify the physical topology for the TPU slice.
   containers:
   - name: tpu-job
-    image: <your-tpu-inference-container-image>
+    image: gcr.io/gke-shared-ai-dev/tpu-inference:cpu-offload
     imagePullPolicy: Always
     command:
     - python

--- a/examples/offline_inference_kv_cache_verification.py
+++ b/examples/offline_inference_kv_cache_verification.py
@@ -111,8 +111,7 @@ def main(args: dict):
     # 3. Run the test with the local tpu kv connector enabled
     print("\n--- Running Test (with TPUConnector) ---")
     # With the connector, we run generation twice to test the prefix cache
-    # TODO: Increase the num_invocations to >=2 to test prefix cache hit.
-    test_outputs = run_generation(args, num_invocations=1)
+    test_outputs = run_generation(args, num_invocations=2)
 
     # 4. Compare the outputs and determine the result
     print("\n--- Verification ---")


### PR DESCRIPTION
1. handle full prefix cache hit in tpu connector scheduler and worker components
2. supporting test case

# Description

Start with a short description of what the PR does and how this is a change from
the past.

The rest of the description includes relevant details and context, examples:
- why is this change being made

When the entire prompt is found in the CPU cache (a "full hit"), report N-1 matched tokens to the vLLM scheduler instead of the true N. If we report a 100% match (N matched tokens for a prompt of length N), the scheduler sees zero new tokens and may not schedule the request for a prefill step at all and hits https://github.com/vllm-project/vllm/blob/b8b302cde434df8c9289a2b465406b47ebab1c2d/vllm/v1/core/sched/scheduler.py#L438 assetion. By reporting N-1, we ensure the scheduler allocates resources for and schedules the computation of the "last" token of the prompt. The worker-side logic (`start_load_kv`) is aware of this state via `is_full_prefix_hit` flag in the load_spec. It will load the true N tokens from the cache but only copy the first N-1 tokens' worth of KV data to the TPU, fitting perfectly into the allocation. The model then "re-computes" the final prompt token, and from there, the request can seamlessly transition to the decoding phase.

- the problem being solved and any relevant context,
- why this is a good solution

We had 2 choices to implement a fix:
a) report the last smaller chunk boundary, you pay penalty of token recompute for an entire block size in worst case
b) vs the current implementation reports 1 less token as a hit, to avoid recompute of the entire block. While the tpu connector worker handles the discrepency of reporting to vllm scheduler, but gracefully copying N-1 tokens in the start_load_kv function.


- some information about the specific implementation,
- shortcomings of the solution and possible future improvements.

If the change fixes a bug or a Github issue, please include a link, e.g.,:
FIXES: b/123456
FIXES: #123456

# Tests

enhanced the existing offline_inference_kv_cache_verification.py to invoke the input prompt twice to trigger the full prefix cache hit and verify the output for both the invocation, matches the baseline

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
