### PR TITLE
Pin-Aware LRU Cache Policy for Local CPU Backend

### DIFF
--- a/examples/gke/pod_tpu_commons_cpu_offload_verification.yaml
+++ b/examples/gke/pod_tpu_commons_cpu_offload_verification.yaml
@@ -15,7 +15,7 @@ spec:
     cloud.google.com/gke-tpu-topology: 2x4 # Specify the physical topology for the TPU slice.
   containers:
   - name: tpu-job
-    image: gcr.io/gke-shared-ai-dev/tpu-inference:cpu-offload
+    image: <your-tpu-inference-image>
     imagePullPolicy: Always
     command:
     - python

--- a/tpu_inference/distributed/local_cpu_backend.py
+++ b/tpu_inference/distributed/local_cpu_backend.py
@@ -1,13 +1,19 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-from typing import Any, Optional
+import os
+import sys
+from collections import OrderedDict
+from typing import Any, List, Optional
 
 from tpu_inference.logger import init_logger
 
 from .util import CacheKey
 
 logger = init_logger(__name__)
+
+GB = 1024**3
+DEFAULT_CPU_CACHE_SIZE_BYTES = 1 * GB
 
 
 class LocalCPUBackend:
@@ -18,6 +24,9 @@ class LocalCPUBackend:
     worker, running in the same process, can share the same cache.
     The scheduler reads from this to find cache hits, and the worker writes
     to it after saving KV blocks from the TPU.
+
+    It implements an LRU (Least Recently Used) eviction policy with a maximum
+    size limit and support for pinning cache entries to prevent eviction.
     """
     _instance: Optional["LocalCPUBackend"] = None
     _initialized: bool = False
@@ -27,15 +36,22 @@ class LocalCPUBackend:
             cls._instance = super(LocalCPUBackend, cls).__new__(cls)
         return cls._instance
 
-    def __init__(self):
+    def __init__(self,
+                 max_cpu_cache_size_bytes: int = DEFAULT_CPU_CACHE_SIZE_BYTES):
         if self._initialized:
             return
-        # The cache is now a dictionary mapping CacheKey -> KV cache data
-        self.cache: dict[CacheKey, Any] = {}
+
+        self.max_cpu_cache_size_bytes = int(
+            os.getenv("TPU_OFFLOAD_CPU_CACHE_SIZE_GB",
+                      str(int(DEFAULT_CPU_CACHE_SIZE_BYTES / GB)))) * GB
+
+        # The cache is an OrderedDict for LRU behavior.
+        self.cache: OrderedDict[CacheKey, Any] = OrderedDict()
         self.current_size_bytes = 0
+        self.pinned_keys: set[CacheKey] = set()
         self._initialized = True
-        logger.info(
-            "Singleton LocalCPUBackend initialized as a Key-Value store.")
+        logger.info("Singleton LocalCPUBackend initialized."
+                    f"CPU cache size: {self.max_cpu_cache_size_bytes} bytes")
 
     def _get_value_size(self, value: Any) -> int:
         """Calculates the size of a cache value in bytes."""
@@ -47,27 +63,89 @@ class LocalCPUBackend:
         elif hasattr(value, 'nbytes'):
             size_in_bytes = value.nbytes
         else:
-            import sys
             size_in_bytes = sys.getsizeof(value)
-        logger.info(
-            f"Calculated size for value of type {type(value)}: {size_in_bytes} bytes"
-        )
         return size_in_bytes
 
     def add(self, key: CacheKey, value: Any):
-        """Adds a key-value pair to the cache."""
-        if key not in self.cache:
-            self.cache[key] = value
-            value_size = self._get_value_size(value)
-            self.current_size_bytes += value_size
-            logger.info(f"Added key to CPU backend. Hash: {key.chunk_hash}")
-            logger.info(
-                f"Cache size: {self.current_size_bytes / 1024**2:.2f} MB")
+        """
+        Adds a key-value pair to the cache.
+
+        If the cache is full, it evicts the least recently used, unpinned
+        entries until there is enough space.
+        """
+        value_size = self._get_value_size(value)
+
+        # Do not add if the item itself is larger than the cache capacity.
+        if value_size > self.max_cpu_cache_size_bytes:
+            logger.warning(
+                f"Cannot add item of size {value_size} bytes to "
+                f"cache with capacity {self.max_cpu_cache_size_bytes} bytes.")
+            return
+
+        # If key already exists, remove it to update its size and position.
+        if key in self.cache:
+            old_value = self.cache.pop(key)
+            self.current_size_bytes -= self._get_value_size(old_value)
+
+        # Evict old, unpinned entries until there is enough space for the new item.
+        while self.current_size_bytes + value_size > self.max_cpu_cache_size_bytes:
+            evicted_key = None
+            # Find the first unpinned key from the LRU end of the cache.
+            for k in self.cache:
+                if k not in self.pinned_keys:
+                    evicted_key = k
+                    break
+
+            # If no unpinned key can be evicted, we cannot make space.
+            if evicted_key is None:
+                logger.warning(
+                    "Cache is full of pinned items. Cannot add new key "
+                    f"({key.chunk_hash}) until some are unpinned.")
+                # If we popped the key before, we need to decide what to do.
+                # For simplicity, we just won't add the new value.
+                return
+
+            # Evict the found key.
+            evicted_value = self.cache.pop(evicted_key)
+            self.current_size_bytes -= self._get_value_size(evicted_value)
+            logger.info(f"Evicted key {evicted_key.chunk_hash} to make space.")
+
+        # Add the new item.
+        self.cache[key] = value
+        self.current_size_bytes += value_size
+        logger.info(f"Added key to CPU backend. Hash: {key.chunk_hash}")
+        logger.info(f"Cache size: {self.current_size_bytes} bytes / "
+                    f"{self.max_cpu_cache_size_bytes} bytes")
 
     def get(self, key: CacheKey) -> Optional[Any]:
-        """Gets the value for a given key."""
-        return self.cache.get(key)
+        """
+        Gets the value for a given key and marks it as recently used.
+        """
+        if key in self.cache:
+            # Mark as most recently used.
+            self.cache.move_to_end(key)
+            return self.cache[key]
+        return None
 
-    def contains(self, key: CacheKey) -> bool:
-        """Checks if a key exists in the cache."""
-        return key in self.cache
+    def contains(self, key: CacheKey, pin_on_hit: bool = False) -> bool:
+        """
+        Checks if a key exists in the cache.
+
+        If the key is found, it's marked as recently used. If `pin_on_hit`
+        is True, the key is also pinned to prevent eviction.
+        """
+        if key in self.cache:
+            # Mark as most recently used, since this is an access.
+            self.cache.move_to_end(key)
+            if pin_on_hit:
+                self.pinned_keys.add(key)
+                logger.info(f"Pinned key on hit. Hash: {key.chunk_hash}")
+            return True
+        return False
+
+    def unpin_keys(self, keys: List[CacheKey]):
+        """Unpins a list of keys, making them eligible for eviction again."""
+        for key in keys:
+            if key in self.pinned_keys:
+                self.pinned_keys.remove(key)
+                logger.info(f"Unpinned key. Hash: {key.chunk_hash}")


### PR DESCRIPTION
# Description

Start with a short description of what the PR does and how this is a change from
the past.

This commit introduces a caching layer for the `LocalCPUBackend` to manage offloaded KV cache data efficiently. The backend is enhanced with a size-based LRU (Least Recently Used) eviction policy and a pinning mechanism to protect in-flight cache entries from being prematurely evicted. The core improvements include:

1.  LRU Eviction Policy: `collections.OrderedDict` to maintain the access order of cache entries. `max_cpu_cache_size_bytes` limit is introduced, ensuring the cache size is capped based on the memory footprint of the stored tensors, not just the number of entries `add` method contains eviction logic that removes the least recently used items when the cache exceeds its capacity.

2.  Cache Entry Pinning: A pinning mechanism is implemented to prevent essential cache entries from being evicted. Pinned entries are ignored by the LRU eviction logic. The `contains` method now accepts a `pin_on_hit` parameter. When set, a successful cache lookup will automatically pin the corresponding key. A corresponding `unpin_keys` method allows for the release of these pins, making the entries eligible for eviction again.

3. The `TPUConnector` is updated to integrate with this new caching logic, ensuring that the pinning and unpinning operations are synchronized with the request lifecycle: Pinning on Lookup: When the scheduler checks for a cache hit in `get_num_new_matched_tokens`, it now calls `contains(key, pin_on_hit=True)`, immediately protecting any found entries. Delayed Unpinning: To ensure data integrity, unpinning is deferred until a request is fully complete. The worker's `get_finished` method is responsible for regenerating the keys associated with a finished request and calling `unpin_keys` just before the request's resources are released.

4. This implementation gracefully handles below scenarios: Full Prefix Hit (`N-1` Workaround): When a prompt of N tokens is a full cache hit, the connector reports N-1 tokens to the vLLM scheduler to avoid an assertion. The logic correctly handles this by:
   *   Pinning all N keys during the initial lookup.
   *   Storing the true N-token list in the internal `RequestTracker`.
   *   Using this true list in `get_finished` to regenerate and unpin all N original keys, ensuring no pins are leaked.
   Newly Generated Tokens: For a request with N prompt tokens and M generated tokens, the system correctly identifies that only the N prompt keys were ever pinned.
   The final call to `unpin_keys` for the full N+M sequence results in a correct unpinning of the N keys and a harmless no-op for the M keys, demonstrating robust and precise state management.


The rest of the description includes relevant details and context, examples:
- why is this change being made,
- the problem being solved and any relevant context,
- why this is a good solution,
- some information about the specific implementation,
- shortcomings of the solution and possible future improvements.

If the change fixes a bug or a Github issue, please include a link, e.g.,:
FIXES: b/123456
FIXES: #123456

# Tests
Tested with existing verification test cases in offline_inference_kv_cache_verification.py.  **These test would not exercise eviction. more tests to be added in followup PRs

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
