### PR TITLE
[FIX] Update some imports from vllm (2025/10/15)

### DIFF
--- a/tpu_inference/models/common/model_loader.py
+++ b/tpu_inference/models/common/model_loader.py
@@ -9,7 +9,7 @@ from jax.sharding import Mesh, NamedSharding, PartitionSpec
 from torchax.ops.mappings import j2t_dtype
 from transformers import PretrainedConfig
 from vllm.config import VllmConfig
-from vllm.utils import supports_kw
+from vllm.utils.func import supports_kw
 
 from tpu_inference.logger import init_logger
 from tpu_inference.models.jax.utils.quantization.quantization_utils import (

--- a/tpu_inference/models/common/model_loader.py
+++ b/tpu_inference/models/common/model_loader.py
@@ -9,7 +9,7 @@ from jax.sharding import Mesh, NamedSharding, PartitionSpec
 from torchax.ops.mappings import j2t_dtype
 from transformers import PretrainedConfig
 from vllm.config import VllmConfig
-from vllm.utils.func import supports_kw
+from vllm.utils.functools import supports_kw
 
 from tpu_inference.logger import init_logger
 from tpu_inference.models.jax.utils.quantization.quantization_utils import (

--- a/tpu_inference/platforms/tpu_jax.py
+++ b/tpu_inference/platforms/tpu_jax.py
@@ -130,7 +130,7 @@ class TpuPlatform(Platform):
             cache_config.block_size = cast(BlockSize, 16)
         compilation_config = vllm_config.compilation_config
 
-        # TPU only supports DYNAMO_ONCE compilation mode
+        # TPU only supports DYNAMO_TRACE_ONCE compilation mode
         # NOTE(xiang): the compilation_config is not used by jax.
         if compilation_config.level != CompilationMode.DYNAMO_TRACE_ONCE:
             compilation_config.level = CompilationMode.DYNAMO_TRACE_ONCE

--- a/tpu_inference/platforms/tpu_jax.py
+++ b/tpu_inference/platforms/tpu_jax.py
@@ -122,7 +122,7 @@ class TpuPlatform(Platform):
                 "VLLM_ENABLE_V1_MULTIPROCESSING must be 0 when using Pathways(JAX_PLATFORMS=proxy)"
             )
 
-        from vllm.config import CompilationLevel
+        from vllm.config import CompilationMode
 
         cache_config = vllm_config.cache_config
         # For v0, the default block size is 16.
@@ -130,10 +130,10 @@ class TpuPlatform(Platform):
             cache_config.block_size = cast(BlockSize, 16)
         compilation_config = vllm_config.compilation_config
 
-        # TPU only supports DYNAMO_ONCE compilation level
+        # TPU only supports DYNAMO_ONCE compilation mode
         # NOTE(xiang): the compilation_config is not used by jax.
-        if compilation_config.level != CompilationLevel.DYNAMO_ONCE:
-            compilation_config.level = CompilationLevel.DYNAMO_ONCE
+        if compilation_config.level != CompilationMode.DYNAMO_TRACE_ONCE:
+            compilation_config.level = CompilationMode.DYNAMO_TRACE_ONCE
 
         if compilation_config.backend == "":
             compilation_config.backend = "openxla"

--- a/tpu_inference/runner/input_batch_jax.py
+++ b/tpu_inference/runner/input_batch_jax.py
@@ -9,7 +9,7 @@ import jax.numpy as jnp
 import numpy as np
 from vllm.lora.request import LoRARequest
 from vllm.sampling_params import SamplingType
-from vllm.utils import swap_dict_values
+from vllm.utils.collections import swap_dict_values
 from vllm.v1.core.sched.output import NewRequestData
 from vllm.v1.spec_decode.utils import is_spec_decode_unsupported
 


### PR DESCRIPTION
# Description

There are some changes (rename, relocate) in the current vllm main branch (commit: d7963752589f53b061da362b80663fab0aeee081).

1. `from vllm.utils import supports_kw` --> `from vllm.utils.funtools import supports_kw` (https://github.com/vllm-project/vllm/pull/26904).
2. `from vllm.utils.import swap_dict_values` --> `from vllm.utils.collections import swap_dict_values`
3. `CompilationLevel` --> `CompilationMode` (https://github.com/vllm-project/vllm/commit/96b9aa5aa076e64c68765232aec343e4d0006e2a)

# Tests

I tested offline example on v6e-8
`python3 offline_inference.py     --model=meta-llama/Llama-3.1-8B     --tensor_parallel_size=8     --task=generate     --max_model_len=1024`


# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
