### PR TITLE
Remove convert_list_to_device_array to reduce latency between model forward pass

### DIFF
--- a/tests/e2e/test_speculative_decoding.py
+++ b/tests/e2e/test_speculative_decoding.py
@@ -5,7 +5,6 @@ import string
 import time
 
 import pytest
-
 from vllm import LLM, SamplingParams
 
 

--- a/tpu_inference/runner/compilation_manager.py
+++ b/tpu_inference/runner/compilation_manager.py
@@ -479,13 +479,7 @@ class CompilationManager:
                 logits,
                 num_reqs=num_reqs_padding,
             )
-            self._run_compilation(
-                "convert_list_to_device_array",
-                self.runner.speculative_decoding_manager.
-                _convert_list_to_device_array,
-                [0] * num_reqs_padding,
-                num_reqs=num_reqs_padding,
-            )
+
             for i in range(1, self.runner.drafter.num_speculative_tokens + 1):
                 draft_token_ids_list = [
                     self._create_dummy_tensor(


### PR DESCRIPTION
# Description

Avoiding using jitted `convert_list_to_device_array` function reduces the white gap by 2.2ms

# Tests

UT tested.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
