### PR TITLE
[Feature] [Tpu host offload] Align CPU cache chunk size to KV block size

### DIFF
--- a/tpu_inference/distributed/cache_util.py
+++ b/tpu_inference/distributed/cache_util.py
@@ -34,11 +34,12 @@ class CacheKey:
         return False
 
 
-class ChunkedTokens:
+class TokenProcessor:
 
     def __init__(self, model_name: str, chunk_size: int = 16):
         self.model_name = model_name
         self.chunk_size = chunk_size
+        logger.info(f"TokenProcessor initialized with chunk_size={chunk_size}")
 
     def _hash_tokens(
         self,

--- a/tpu_inference/distributed/local_cpu_backend.py
+++ b/tpu_inference/distributed/local_cpu_backend.py
@@ -8,7 +8,7 @@ from typing import Any, List, Optional
 
 from tpu_inference.logger import init_logger
 
-from .util import CacheKey
+from .cache_util import CacheKey
 
 logger = init_logger(__name__)
 


### PR DESCRIPTION
# Description

1. inherit the kv block size to init the chunk processor
2. rename util.py to cache_util.py

The rest of the description includes relevant details and context, examples:

- why is this change being made,

Reduce additional chunks processing and bookeeping. Aligning the chunk size and block size leads to lesser number of chunk save operations

- the problem being solved and any relevant context,
- why this is a good solution,
- some information about the specific implementation,
- shortcomings of the solution and possible future improvements.

If the change fixes a bug or a Github issue, please include a link, e.g.,:
FIXES: b/123456
FIXES: #123456

# Tests

tested with existing correctness testcase of pod_tpu_commons_cpu_offload_verification.yaml

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
