### PR TITLE
[Doc] Docker guide extended

### DIFF
--- a/docs/getting_started/quickstart.md
+++ b/docs/getting_started/quickstart.md
@@ -96,6 +96,8 @@ To install vLLM TPU, you can either install using `pip` (see section [Install us
 1. Start the vLLM OpenAI API server (inside the container):
 
     ```shell
+    export HF_HOME=/dev/shm/vllm
+    export HF_TOKEN=<your-token>
     export MAX_MODEL_LEN=4096
     export TP=1 # number of chips
     vllm serve meta-llama/Meta-Llama-3.1-8B \


### PR DESCRIPTION
Added HF token and home path variables to the docker route for better user experience

```
export HF_HOME=/dev/shm/vllm
export HF_TOKEN=<your-token>
```

And the instruction on how to send a test request to the running vllm in the docker route