### PR TITLE
[Chore] Update import path for vllm.utils

### DIFF
--- a/tpu_inference/distributed/utils.py
+++ b/tpu_inference/distributed/utils.py
@@ -1,6 +1,6 @@
 import os
 
-from vllm.utils import get_ip
+from vllm.utils.network_utils import get_ip
 
 from tpu_inference.logger import init_logger
 

--- a/tpu_inference/models/common/model_loader.py
+++ b/tpu_inference/models/common/model_loader.py
@@ -9,7 +9,7 @@ from jax.sharding import Mesh, NamedSharding, PartitionSpec
 from torchax.ops.mappings import j2t_dtype
 from transformers import PretrainedConfig
 from vllm.config import VllmConfig
-from vllm.utils.functools import supports_kw
+from vllm.utils.func_utils import supports_kw
 
 from tpu_inference.logger import init_logger
 from tpu_inference.models.jax.utils.quantization.quantization_utils import (

--- a/tpu_inference/runner/input_batch_jax.py
+++ b/tpu_inference/runner/input_batch_jax.py
@@ -9,7 +9,7 @@ import jax.numpy as jnp
 import numpy as np
 from vllm.lora.request import LoRARequest
 from vllm.sampling_params import SamplingType
-from vllm.utils.collections import swap_dict_values
+from vllm.utils.collection_utils import swap_dict_values
 from vllm.v1.core.sched.output import NewRequestData
 from vllm.v1.spec_decode.utils import is_spec_decode_unsupported
 


### PR DESCRIPTION
See vllm-project/vllm#26900 for more details.

# Description

There are several broken imports from `vllm.utils`, introduced by PR following vllm-project/vllm#26900. 

Fix broken imports, so we can use `vllm` with `tpu-inference` again.

- <https://github.com/vllm-project/vllm/issues/26900>
- <https://github.com/vllm-project/vllm/commit/7a6c8c3fa150957d154ea729490d38dc6f023229>
- <https://github.com/vllm-project/vllm/commit/d2740fafbf2527f4026863854bf1aeaa383c1a8e>
- <https://github.com/vllm-project/vllm/commit/136a17fe6edacba292d899af4cfd424e0ca98d9f>

# Tests

Run `vllm server` and ensure every thing goes well.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
