### PR TITLE
[Bug fix] Fix v7 HBM limit 

### DIFF
--- a/tpu_inference/utils.py
+++ b/tpu_inference/utils.py
@@ -118,7 +118,9 @@ def get_device_hbm_limit() -> int:
     elif device_kind == "TPU v6e" or device_kind == "TPU v4":
         return 32 * GBYTES
     elif device_kind == "TPU v7":
-        return 192 * GBYTES
+        # 192 * GBYTES / 2 because each JAX device (v7x core) has
+        # 1/2 of the total chip HBM
+        return 96 * GBYTES
     else:
         raise ValueError(f"Unknown device kind: {device_kind}")
 


### PR DESCRIPTION
# Description


v7 device HBM limit should be 96, not 192 GB


# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
