### PR TITLE
[Feature][TPU host offload] Improvements to the save workflow for tpu connector local

### DIFF
--- a/examples/gke/benchmarks/deploy-baseline.yaml
+++ b/examples/gke/benchmarks/deploy-baseline.yaml
@@ -21,7 +21,7 @@ spec:
         imagePullPolicy: Always
         command: ["/bin/sh", "-c"]
         args:
-        - "vllm serve meta-llama/Llama-3.3-70B-Instruct --port 8000 --max_num_batched_tokens 2048 --enable-chunked-prefill --tensor-parallel-size 8 --enable_prefix_caching --gpu-memory-utilization 0.9"
+        - "vllm serve meta-llama/Llama-3.3-70B-Instruct --port 8000 --max_num_batched_tokens 2048 --enable-chunked-prefill --tensor-parallel-size 8 --seed 42 --enable_prefix_caching --gpu-memory-utilization 0.9"
         env:
         - name: HUGGING_FACE_HUB_TOKEN
           valueFrom:

--- a/examples/gke/benchmarks/deploy-cpu-offload.yaml
+++ b/examples/gke/benchmarks/deploy-cpu-offload.yaml
@@ -21,7 +21,7 @@ spec:
         imagePullPolicy: Always
         command: ["/bin/sh", "-c"]
         args:
-        - "vllm serve meta-llama/Llama-3.3-70B-Instruct --kv-transfer-config '{\"kv_connector\":\"TPUConnector\",\"kv_role\":\"kv_both\",\"kv_connector_module_path\":\"tpu_inference.distributed.tpu_connector_local\"}' --port 8000 --max_num_batched_tokens 2048 --enable-chunked-prefill --tensor-parallel-size 8 --enable_prefix_caching --gpu-memory-utilization 0.9"
+        - "vllm serve meta-llama/Llama-3.3-70B-Instruct --kv-transfer-config '{\"kv_connector\":\"TPUConnector\",\"kv_role\":\"kv_both\",\"kv_connector_module_path\":\"tpu_inference.distributed.tpu_connector_local\"}' --port 8000 --max_num_batched_tokens 2048 --enable-chunked-prefill --tensor-parallel-size 8 --seed 42 --enable_prefix_caching --gpu-memory-utilization 0.9"
         env:
         - name: HUGGING_FACE_HUB_TOKEN
           valueFrom:


### PR DESCRIPTION
# Description

Start with a short description of what the PR does and how this is a change from
the past.

Improvements to the save path to identify the delta tokens that actually require to be saved.


The rest of the description includes relevant details and context, examples:
- why is this change being made,

    1. Add logic to identify precedeeing tokens in a prefix cache hit that
       does not need to be saved again in wait_for_save().
    2. During save operation, calculate the absolute token positions so that the key that is
       created for the token chunks is is consistent. This ensures that in
       the get_finished() call, the keys derived to unpin from the cpu backend
       cache is correct.
    3. Introduce an env variable TPU_OFFLOAD_DECODE_SAVE (default '0')
       to skip save tokens during decode phase and finished requests during decode. The finished request needed a bit of handling to ensure we report the reqs as finished in get_finished() correctly.
    5. Minor variable renames for readability
    6. minor fixes in load reporting time
    7. add seed to vllm serve pods used for benchmark runs

- the problem being solved and any relevant context,
- why this is a good solution,
- some information about the specific implementation,
- shortcomings of the solution and possible future improvements.

If the change fixes a bug or a Github issue, please include a link, e.g.,:
FIXES: b/123456
FIXES: #123456

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

1. existing verification tests
2. sglang benchmark tool run

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
