### PR TITLE
[Kernel] Refactor ragged_paged_attention to proxy for default and hd64

### DIFF
--- a/tests/kernels/ragged_paged_attention_kernel_v3_hd64_test.py
+++ b/tests/kernels/ragged_paged_attention_kernel_v3_hd64_test.py
@@ -5,8 +5,8 @@ from absl.testing import absltest, parameterized
 from jax._src import dtypes
 from jax._src import test_util as jtu
 
-from tpu_inference.kernels.ragged_paged_attention.v3.kernel_hd64 import (
-    ragged_paged_attention_hd64, ref_ragged_paged_attention_hd64)
+from tpu_inference.kernels.ragged_paged_attention.v3.kernel import (
+    ragged_paged_attention, ref_ragged_paged_attention)
 from tpu_inference.kernels.ragged_paged_attention.v3.util import (
     align_to, cdiv, get_dtype_packing)
 
@@ -157,12 +157,12 @@ class RaggedPagedAttentionHeadDim64KernelTest(jtu.JaxTestCase):
             "v_scale": v_scale,
         }
 
-        expected, expected_kv_cache = ref_ragged_paged_attention_hd64(
+        expected, expected_kv_cache = ref_ragged_paged_attention(
             *args,
             **kwargs,
         )
 
-        output, updated_kv_cache = ragged_paged_attention_hd64(
+        output, updated_kv_cache = ragged_paged_attention(
             *args,
             **kwargs,
             num_kv_pages_per_block=num_kv_pages_per_block,


### PR DESCRIPTION
# Description

This change refactors the public methods in ragged_paged_attention to act as proxies for both the generic and the hd64 implementations.

The choice of which implementation to use is determined by the head dimension (hd) of the queries. If hd is 64, the hd64 kernel is used. Otherwise, the generic kernel is used.

# Tests

pytest -s -v tests/kernels/ragged_paged_attention_kernel_v3*

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
