### PR TITLE
[Feature][TPU host offload] revise kvcache example: verify the correctness of cpu offloading

### DIFF
--- a/examples/multi_modal_inference.py
+++ b/examples/multi_modal_inference.py
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """
 This example shows how to use vLLM for running offline inference with
 the correct prompt format on vision language models for text generation.

--- a/examples/offline_inference_kv_cache.py
+++ b/examples/offline_inference_kv_cache.py
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import os
 import time

--- a/examples/offline_inference_kv_cache_verification.py
+++ b/examples/offline_inference_kv_cache_verification.py
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """
 This script performs an automated correctness verification for the TPUConnector.
 

--- a/tests/distributed/host_offloading_accuracy_test.py
+++ b/tests/distributed/host_offloading_accuracy_test.py
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import os
 import time


### PR DESCRIPTION
# Description

Update the kv cache offline example with manually resetting prefix cache between two identical requests. 

# Tests

`python3 offline_inference_kv_cache.py --model=meta-llama/Llama-3.2-3B --tensor_parallel_size=8 --max_model_len=1024 --kv-transfer-config '{"kv_connector":"TPUConnector","kv_connector_module_path":"tpu_inference.distributed.tpu_connector_local","kv_role":"kv_both"}'`

`pytest -sv tests/distributed/host_offloading_accuracy_test.py`

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
