### PR TITLE
[Misc] Report TPU usage

### DIFF
--- a/tpu_inference/worker/tpu_worker_jax.py
+++ b/tpu_inference/worker/tpu_worker_jax.py
@@ -16,6 +16,7 @@ from vllm.distributed.parallel_state import (ensure_model_parallel_initialized,
                                              init_distributed_environment)
 from vllm.lora.request import LoRARequest
 from vllm.tasks import SupportedTask
+from vllm.v1 import utils as vllm_utils
 from vllm.v1.core.kv_cache_utils import get_num_blocks, get_uniform_page_size
 from vllm.v1.core.sched.output import SchedulerOutput
 from vllm.v1.kv_cache_interface import KVCacheConfig, KVCacheSpec
@@ -166,6 +167,7 @@ class TPUWorker(AbstractTpuWorker):
                     f"node_id={get_node_id()} | "
                     f"is_driver_worker={self.is_driver_worker} | "
                     f"hbm={utils.hbm_usage_gb(self.devices)}GiB")
+        vllm_utils.report_usage_stats(self.vllm_config)
 
     def determine_available_memory(self) -> int:
         gpu_memory_utilization = self.cache_config.gpu_memory_utilization


### PR DESCRIPTION
# Description

As the title says. Need the vLLM PR to merge first: https://github.com/vllm-project/vllm/pull/27423

# Tests

Manual, create the usage_stats file: $HOME/.config/vllm/usage_stats.json and start vllm server, a report such as this was generated:

```
{"uuid": "dd2ebebc-fa7c-4b5c-88f9-c6136bad1a2e", "provider": "GCP", "num_cpu": 180, "cpu_type": "AMD EPYC 9B14", "cpu_family_model_stepping": "25,17,1", "total_memory": 1521841610752, "architecture": "x86_64", "platform": "Linux-6.8.0-1015-gcp-x86_64-with-glibc2.35", "cuda_runtime": "tpu_inference", "gpu_count": 8, "gpu_type": "v6e-8", "gpu_memory_per_device": 34359738368, "env_var_json": "{\"VLLM_USE_MODELSCOPE\": false, \"VLLM_USE_TRITON_FLASH_ATTN\": true, \"VLLM_ATTENTION_BACKEND\": null, \"VLLM_USE_FLASHINFER_SAMPLER\": null, \"VLLM_PP_LAYER_PARTITION\": null, \"VLLM_USE_TRITON_AWQ\": false, \"VLLM_USE_V1\": true, \"VLLM_ENABLE_V1_MULTIPROCESSING\": true}", "model_architecture": "Qwen2_5_VLForConditionalGeneration", "vllm_version": "0.11.0rc2.dev369+gc6187f55f.d20251010", "context": "ENGINE_CONTEXT", "log_time": 1761231915326027008, "source": "production", "dtype": "<class 'jax.numpy.bfloat16'>", "block_size": 128, "gpu_memory_utilization": 0.9, "kv_cache_memory_bytes": null, "quantization": null, "kv_cache_dtype": "auto", "enable_lora": false, "enable_prefix_caching": false, "enforce_eager": false, "disable_custom_all_reduce": true, "tensor_parallel_size": 1, "data_parallel_size": 1, "pipeline_parallel_size": 1, "enable_expert_parallel": false, "all2all_backend": "allgather_reducescatter", "kv_connector": null}
```

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
