### PR TITLE
Reduce the host overhead for LoRA

### DIFF
--- a/examples/offline_inference.py
+++ b/examples/offline_inference.py
@@ -14,9 +14,8 @@ def create_parser():
     parser = FlexibleArgumentParser()
     # Add engine args
     EngineArgs.add_cli_args(parser)
-    parser.set_defaults(model="Qwen/Qwen2.5-3B-Instruct")
-    parser.set_defaults(max_model_len=256)
-    parser.set_defaults(max_num_seqs=8)
+    parser.set_defaults(model="meta-llama/Llama-3.2-1B-Instruct")
+    parser.set_defaults(max_model_len=1024)
 
     # Add sampling params
     sampling_group = parser.add_argument_group("Sampling parameters")
@@ -51,7 +50,41 @@ def main(args: dict):
     # Generate texts from the prompts. The output is a list of RequestOutput
     # objects that contain the prompt, generated text, and other information.
     prompts = [
-        "What is 1+1? \n",
+        "Hello, my name is",
+        "The capital of France is",
+        "The colors of the rainbow are",
+        "The future of AI is",
+        "The president of the United States is",
+        "How many players are on a standard soccer team on the field at one time?",
+        "In Greek mythology, who is the god of the sea?",
+        "In what year did the Titanic sink?",
+        "In which museum is the Mona Lisa displayed?",
+        "Mount Everest is located in which mountain range?",
+        "What ancient empire was ruled by Julius Caesar?",
+        "What are the four fundamental forces of nature?",
+        'What does "CPU" stand for?',
+        'What does "HTML" stand for?',
+        "What is the capital of Australia?",
+        "What is the chemical symbol for gold?",
+        "What is the currency of Switzerland?",
+        "What is the distance from the Earth to the Sun called?",
+        "What is the freezing point of water in Celsius?",
+        "What is the hardest known natural substance on Earth?",
+        "What is the largest planet in our solar system?",
+        "What is the longest river in the world?",
+        "What is the main function of the kidneys in the human body?",
+        "What is the main ingredient in guacamole?",
+        "What is the most spoken language in the world by number of native speakers?",
+        "What is the process by which plants use sunlight to create food?",
+        "Which country is known as the Land of the Rising Sun?",
+        "Who developed the theory of general relativity?",
+        'Who directed the original "Star Wars" trilogy?',
+        "Who is credited with inventing the telephone?",
+        "Who painted the ceiling of the Sistine Chapel?",
+        "Who was the first female Prime Minister of the United Kingdom?",
+        "Who was the first person to walk on the moon?",
+        "Who wrote the American Declaration of Independence?",
+        'Who wrote the novel "Pride and Prejudice"?',
     ]
 
     if envs.VLLM_TORCH_PROFILER_DIR is not None:

--- a/tpu_inference/layers/vllm/quantization/unquantized.py
+++ b/tpu_inference/layers/vllm/quantization/unquantized.py
@@ -132,7 +132,6 @@ class VllmUnquantizedLinearMethod(UnquantizedLinearMethod):
 
         outs = slice_sharded_tensor_for_concatenation(
             outs, self.jax_config.output_sizes, self.jax_config.n_shards)
-        # add a jax.scope to check if this line is run
         out = jnp.concatenate(outs, axis=-1)
         return torch_view(out)
 

--- a/tpu_inference/layers/vllm/sharding.py
+++ b/tpu_inference/layers/vllm/sharding.py
@@ -66,15 +66,11 @@ def _extract_all_params_buffers(model: torch.nn.Module):
 
 
 def _tensor_is_in_cpu(tensor: torch.tensor) -> bool:
-    # xw32: There are many torch.nn.parameter.Parameter. e.g. https://paste.googleplex.com/4571608492670976
     # Check if a tensor haven't been converted to torchax tensor.
     if not isinstance(tensor, torchax.tensor.Tensor):
         return True
     # Check if torchax tensor is still in CPU.
-    if tensor.jax_device == jax.devices('cpu')[0]:
-        return True
-    else:
-        return False
+    return tensor.jax_device == jax.devices('cpu')[0]
 
 
 def _convert_to_torchax_and_shard(tensor: torch.Tensor,


### PR DESCRIPTION
# Description

This PR optimizes the host perf of LoRA.

On TPU-inference, the current step time is [130 ms](https://screenshot.googleplex.com/5JPABWpvnJKRxvK) and the execution time is [5.59 ms](https://screenshot.googleplex.com/65xzDf8fffggfWY). So why does it take [so long between  each execution](https://screenshot.googleplex.com/QFTZ99TKNJjCuhA)? I discovered that `shard_model_to_tpu` takes  94% of the step time.

This PR optimize `shard_model_to_tpu` and only do the what is necessary for lora:

During inference, before each fwd, LoRA needs to call `shard_model_to_tpu` because the linear.lora matrices may be updated. `shard_model_to_tpu` does 3 things essentially: shard the module and move to TPU (via _shard_module_to_tpu), extract params and buffers, and move the remaining params/buffers to TPU (via PyTree.tree_map_only). In the [profile](https://screenshot.googleplex.com/6VqsrSFXvgKGog7), both `_shard_module_to_tpu` and `PyTree.tree_map_only` take equally excessive time. This is what this PR proposes: 

1. I don't need to re-shard every time. When vllm [updates the lora](https://github.com/vllm-project/vllm/blob/0552cfb195b24a490f253d485de11f2b94b0c6b8/vllm/lora/layers/column_parallel_linear.py#L259-L267), the sharding still remains the same and the new lora is moved from CPU to TPU so the device also remains the same  (both via `_copy`). That means we only need to shard once at first when we load the model and don't need to re-shard later. (I also wrote a torchax [repro](https://gist.github.com/vanbasten23/64be65a8331dae95e95b4a9d90214691) that demonstrates `copy_` won't change the tensor's sharding)

2. 'PyTree.tree_map_only' is only used to move the remaining params/buffers to TPU. But for lora, the only possibly updated params are `lora` related matrices and we know the lora matrices are already torchax tensor on TPU. So there is really no need to do this tree_map_only step.

3. That said, the only necessary thing for the LoRA case is to re-extract the parameter for lora and update the original `params_buffers`.

With the change, I profiled again and the step time has reduced from 130ms to [13ms](https://screenshot.googleplex.com/9xF9vk9jDkHeqSg)

# Tests

CI

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
