### PR TITLE
[CI] Fix Qwen2.5 VL get_mrope_input_positions after vLLM change.

### DIFF
--- a/tpu_inference/models/common/model_loader.py
+++ b/tpu_inference/models/common/model_loader.py
@@ -270,8 +270,8 @@ def get_flax_model(
                                                  graphdef)
 
     get_mrope_input_positions_fn = None if not hasattr(
-        model_class,
-        "get_mrope_input_positions") else model_class.get_mrope_input_positions
+        jit_model,
+        "get_mrope_input_positions") else jit_model.get_mrope_input_positions
 
     return model_fn, compute_logits_fn, combine_hidden_states_fn, get_multimodal_embeddings_fn, get_input_embeddings_fn, get_mrope_input_positions_fn, state, lora_manager, model
 


### PR DESCRIPTION
# Description

Catch up with upstream vLLM change for get_mrope_input_positions.

# Tests

CI: https://buildkite.com/tpu-commons/tpu-inference-ci/builds/4585

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
