### PR TITLE
[CI] Use real vLLM ModelConfig object in init_device test

### DIFF
--- a/tests/worker/tpu_worker_jax_test.py
+++ b/tests/worker/tpu_worker_jax_test.py
@@ -1,6 +1,7 @@
 from unittest.mock import MagicMock, patch
 
 import pytest
+from vllm.config import ModelConfig
 from vllm.lora.request import LoRARequest
 from vllm.v1.kv_cache_interface import KVCacheConfig
 from vllm.v1.outputs import DraftTokenIds
@@ -27,9 +28,6 @@ def mock_vllm_config():
     This version builds the mock explicitly to avoid spec-related AttributeErrors.
     """
     # Create mocks for the nested config objects first
-    mock_model_conf = MagicMock()
-    mock_model_conf.trust_remote_code = False
-
     mock_cache_conf = MagicMock()
     mock_cache_conf.gpu_memory_utilization = 0.9
     mock_cache_conf.num_gpu_blocks = 0
@@ -43,7 +41,7 @@ def mock_vllm_config():
 
     # Create the main config mock and attach the others without a top-level spec
     config = MagicMock()
-    config.model_config = mock_model_conf
+    config.model_config = ModelConfig(model="Qwen/Qwen3-0.6B")
     config.cache_config = mock_cache_conf
     config.parallel_config = mock_parallel_conf
     config.additional_config = mock_additional_config


### PR DESCRIPTION
# Description

The mock object breaks the test when the vllm code tries to use it.

# Tests

Ran the failure test: `pytest -v tests/worker/tpu_worker_jax_test.py::TestTPUWorker::test_init_device_with_provided_devices`

CI: https://buildkite.com/tpu-commons/tpu-inference-ci/builds/4606#019a16b6-9bf8-4dc5-81d5-97d6bc35791a

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
