### PR TITLE
[TPU host offload][FIX] Deepcopy block_ids from requests

### DIFF
--- a/tpu_inference/distributed/tpu_connector_local.py
+++ b/tpu_inference/distributed/tpu_connector_local.py
@@ -984,7 +984,7 @@ class TPUConnectorWorker:
             return
 
         # logger.info("TPUConnectorWorker: Entering wait_for_save")
-        metadata = self.connector._connector_metadata
+        metadata = self.connector._get_connector_metadata()
         if not isinstance(metadata, TPUConnectorMetadata):
             logger.info(
                 "wait_for_save:not an instances of TPUConnectorMetadata")


### PR DESCRIPTION
# Description

Deepcopy block_ids from new_scheded_request, instead of getting a reference of the list.

The scheduler may append the new block ids to the original block_ids list (so as request_tracker.update()). When the connector worker gets the block list through metadata, the new block ids will be doubled in the list.
For example:
original block list: [1,2,3,4,5], new block_ids: ([6,7])
the local_block_ids in meta will be [1,2,3,4,5,6,7,**6,7**]


# Tests

TBD

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
