### PR TITLE
[MMLU] Add chat-template support for MMLU

### DIFF
--- a/scripts/vllm/benchmarking/benchmark_dataset.py
+++ b/scripts/vllm/benchmarking/benchmark_dataset.py
@@ -201,7 +201,8 @@ class MMLUDataset(BenchmarkDataset):
     https://github.com/AI-Hypercomputer/JetStream/blob/bbfb5bd/benchmarks/benchmark_serving.py#L327.
     """
 
-    def __init__(self, num_shots: int, mmlu_method: str, use_chat_template: bool, **kwargs) -> None:
+    def __init__(self, num_shots: int, mmlu_method: str,
+                 use_chat_template: bool, **kwargs) -> None:
         super().__init__(**kwargs)
         self.mmlu_method = mmlu_method
         self.num_shots = num_shots
@@ -304,27 +305,21 @@ class MMLUDataset(BenchmarkDataset):
                 break
 
             if self.use_chat_template:
-                messages = [
-                    {
-                        "role": "system",
-                        "content": "Reasoning effort: high"
-                    },
-                    {
-                        "role": "user", 
-                        "content": prompt
-                    }
-                ]
+                messages = [{
+                    "role": "system",
+                    "content": "Reasoning effort: high"
+                }, {
+                    "role": "user",
+                    "content": prompt
+                }]
 
                 try:
                     prompt = tokenizer.apply_chat_template(
-                        messages,
-                        tokenize=False,
-                        add_generation_prompt=True
-                    )
+                        messages, tokenize=False, add_generation_prompt=True)
                 except Exception as e:
                     logger.error(f"Could not apply chat template: {e}. "
-                                "Falling back to raw prompt. "
-                                "This will likely fail for fine-tuned models")
+                                 "Falling back to raw prompt. "
+                                 "This will likely fail for fine-tuned models")
 
             prompt_ids = tokenizer(prompt).input_ids
             completion_ids = tokenizer(completion).input_ids

--- a/scripts/vllm/benchmarking/benchmark_serving.py
+++ b/scripts/vllm/benchmarking/benchmark_serving.py
@@ -869,7 +869,7 @@ if __name__ == "__main__":
         choices=["HELM", "Harness", ""],
         help="mmlu method/format to generate shots",
     )
-    mmlu_group.add_argument(    
+    mmlu_group.add_argument(
         "--mmlu-use-chat-template",
         action="store_true",
         help="Whether to format MMLU prompts using the tokenizer's chat template.",

--- a/scripts/vllm/benchmarking/benchmark_utils.py
+++ b/scripts/vllm/benchmarking/benchmark_utils.py
@@ -105,10 +105,11 @@ def postprocess_text_mmlu(preds: List[str],
         # TODO: This parser handles output regardless of whether a chat template is enabled.
         # Currently, the chat-template parsing rules are based on the gpt-oss format.
         # We will need to add rules for other models, as their output formats may differ.
-        
+
         # To match 'assistantfinal' block.
-        final_block_match = re.search(r"assistant.*final(.*)", output, re.IGNORECASE | re.DOTALL)
-        
+        final_block_match = re.search(r"assistant.*final(.*)", output,
+                                      re.IGNORECASE | re.DOTALL)
+
         if final_block_match:
             final_block = final_block_match.group(1)
 
@@ -117,13 +118,12 @@ def postprocess_text_mmlu(preds: List[str],
             match = re.search(re_str, final_block, re.DOTALL)
             if match:
                 return match.group(1).upper()
-                
+
             # To match: choice/answer ... (A)
             re_str = r"(?:choice|answer)[^\(]*\s*\(?([A-D])\s*\)?"
             match = re.search(re_str, final_block, re.IGNORECASE | re.DOTALL)
             if match:
                 return match.group(1).upper()
-
 
         # To match ... so/thus answer ... option/choice A
         re_str_fallback = r"(?:thus|so)\s+answer.*(?:option|choice).*\s*\(?([A-D])\s*\)?"


### PR DESCRIPTION
# Description

Enable support of chat-template for tuned models, i.e. Deepseek, GPT-OSS etc

# Tests

On 1000 prompts from MMLU on GPT-OSS-120B: 
Without chat-template, the accuracy is [0.26](https://paste.googleplex.com/5632136262582272#l=38) for GPT-OSS model;
With chat-temaplte, the accuracy is [0.87](https://paste.googleplex.com/6178518731980800#l=38) for GPT-OSS model;

It won't change the legacy MMLU benchmarking results on other models with chat-template disabled(default)
Qwen3-32B has accuracy of [0.813](https://paste.googleplex.com/6139516050079744#l=40)

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
