### PR TITLE
[Feature] Add automated PyPI publishing workflow

### DIFF
--- a/.github/scripts/determine_release_vars.sh
+++ b/.github/scripts/determine_release_vars.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+set -eu pipefail
+
+# --- SCHEDULE TRIGGER ---
+if [[ "$GH_EVENT_NAME"  == "schedule" ]]; then
+    echo "Trigger: Schedule - Generating nightly build"
+
+    # --- Get Base Version from Tag ---
+    echo "Fetching latest tags..."
+    git fetch --tags --force
+    echo "Finding the latest stable version tag (vX.Y.Z)..."
+    LATEST_STABLE_TAG=$(git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1)
+    if [[ -z "$LATEST_STABLE_TAG" ]]; then
+        echo "Warning: No stable tag found."
+        exit 1
+    else
+        BASE_VERSION=${LATEST_STABLE_TAG#v}
+    fi
+    echo "Using BASE_VERSION=${BASE_VERSION}"
+
+    # --- Generate Nightly Version ---
+    DATETIME_STR=$(date -u +%Y%m%d%H%M)
+    VERSION="${BASE_VERSION}.dev${DATETIME_STR}"
+
+# --- PUSH TAG TRIGGER ---
+elif [[ "$GH_EVENT_NAME" == "push" && "$GH_REF" == refs/tags/* ]]; then
+    echo "Trigger: Push Tag - Generating stable build"
+    TAG_NAME="$GH_REF_NAME"
+    VERSION=${TAG_NAME#v}
+
+else
+    echo "Error: Unknown or unsupported trigger."
+    exit 1
+fi
+
+# --- output ---
+echo "Final determined values: VERSION=${VERSION}"
+echo "VERSION=${VERSION}" >> $GITHUB_OUTPUT

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,51 @@
+name: Publish Package to PyPI
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+*'
+  schedule:
+      - cron: '0 8 * * *'
+
+jobs:
+  pypi_publish:
+    name: Build and Publish
+    runs-on: ubuntu-latest
+
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+    - name: Checkout Code
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.x'
+
+    - name: Determine Version
+      id: vars
+      env:
+          GH_EVENT_NAME: ${{ github.event_name }}
+          GH_REF_NAME: ${{ github.ref_name }}
+          GH_REF: ${{ github.ref }}
+      run: bash .github/scripts/determine_release_vars.sh
+
+    - name: Install dependencies (build)
+      run:
+        python3 -m pip install build
+
+    - name: Build package (sdist and wheel)
+      env:
+          VLLM_VERSION_OVERRIDE: ${{ steps.vars.outputs.VERSION }}
+      run: python3 -m build
+
+    - name: Publish package distributions to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+
+    - name: Publish completed message
+      run: echo "---Build and publish completed successfully.---"

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
 include requirements.txt
 include README.md
-include version.py
 include tpu_inference/models/jax/utils/quantization/configs/*.yaml
+


### PR DESCRIPTION
# Description

This commit introduces a complete GitHub Actions workflow for automatically building and publishing the Python package to PyPI.

- Adds the `release.yml` workflow, supporting multiple triggers: Tag push and Schedule.
- Adds the `determine_release_vars.sh` script, which contains the core versioning logic.

# Tests

test on [github](https://github.com/vllm-project/tpu-inference/actions/runs/18956645722)

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
