### PR TITLE
async scheduler fix  _substitute_placeholder_token_fn  bug

### DIFF
--- a/tpu_inference/runner/compilation_manager.py
+++ b/tpu_inference/runner/compilation_manager.py
@@ -197,6 +197,11 @@ class CompilationManager:
                                                              dtype=np.int32)
             padded_token_in_tpu_pre_next_tokens_indices = np.zeros(
                 (num_tokens, ), dtype=jnp.int32)
+            (padded_token_in_tpu_cur_input_indices,
+             padded_token_in_tpu_pre_next_tokens_indices) = device_array(
+                 self.runner.mesh,
+                 (padded_token_in_tpu_cur_input_indices,
+                  padded_token_in_tpu_pre_next_tokens_indices))
             for num_reqs in self.runner.num_reqs_paddings:
                 input_ids = self._create_dummy_tensor((num_tokens, ),
                                                       jnp.int32)

--- a/tpu_inference/runner/tpu_jax_runner.py
+++ b/tpu_inference/runner/tpu_jax_runner.py
@@ -1030,6 +1030,10 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                 token_in_tpu_pre_next_tokens_indices, (0, idx_pad_len),
                 mode='constant',
                 constant_values=-1)
+            (padded_token_in_tpu_cur_input_indices,
+             padded_token_in_tpu_pre_next_tokens_indices) = device_array(
+                 self.mesh, (padded_token_in_tpu_cur_input_indices,
+                             padded_token_in_tpu_pre_next_tokens_indices))
             with self.maybe_forbid_compile:
                 input_ids = self._substitute_placeholder_token_fn(
                     input_ids, padded_token_in_tpu_cur_input_indices,


### PR DESCRIPTION
# Description

This commit aims to fix a bug in _substitute_placeholder_token_fn where in an edge case unexpected behaviour occured. This commits have verified to retain the performance gain of async scheduler.

The edge case is that when we aim to update the last element in input_ids and padding is required, the last element is updated to its original value instead of the new value:
our function:
```
def _substitute_placeholder_token(
        input_ids: jax.Array, token_in_tpu_cur_input_indices: jax.Array,
        token_in_tpu_pre_next_tokens_indices: jax.Array,
        next_tokens: jax.Array, placeholder_num: int):
        
    # updates the input_ids for all placeholders.
    mask = jnp.arange(input_ids.shape[0]) < placeholder_num
    new_token_values = next_tokens[token_in_tpu_pre_next_tokens_indices]
    original_values = input_ids[token_in_tpu_cur_input_indices]
    update_values = jnp.where(mask, new_token_values, original_values)
    return input_ids.at[token_in_tpu_cur_input_indices].set(update_values)
```
test:
```
import jax
import jax.numpy as jnp

# inputs to the substitute_placeholder_token_fn
placeholder_num = 2
input_ids =  jnp.array([    0,     127,   264, 32794,   911,   279,  5112,   315,   264,
    3283,   518,  3729,    13,  9645,   432,   0], dtype=jnp.int32)
token_in_tpu_pre_next_tokens_indices = jnp.array([ 0,  2, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1], dtype=jnp.int32)
token_in_tpu_cur_input_indices = jnp.array([ 0,  15, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1], dtype=jnp.int32)  # Original padding
next_tokens = jnp.array([1265,  264,  576, 1265, 1265, 1265, 1265, 1265], dtype=jnp.int32)

out = _substitute_placeholder_token(input_ids, token_in_tpu_cur_input_indices, token_in_tpu_pre_next_tokens_indices, next_tokens, placeholder_num)

print("input_ids is \n",input_ids)
print("update_values is \n",update_values)
print("output is \n",out)
print("we expect output is [ 1265   127   264 32794   911   279  5112   315   264  3283   518  3729 \n    13  9645   432     576]")
```
output:
```
input_ids is 
 [    0   127   264 32794   911   279  5112   315   264  3283   518  3729
    13  9645   432     0]
update_values is 
 [1265  576    0    0    0    0    0    0    0    0    0    0    0    0
    0    0]
output is 
 [ 1265   127   264 32794   911   279  5112   315   264  3283   518  3729
    13  9645   432     0]
we expect output is [ 1265   127   264 32794   911   279  5112   315   264  3283   518  3729 
    13  9645   432     576]
```

Why the original padding has bug but works in vLLM? 
Such a scenario will not happen in vLLM as only decode tokens need to be updated and decode tokens always scheduled before prefill tokens. Therefore, there won't be such a scenario that we need a padding when we update the last token.

Why we try to fix this bug? 
Although such a scenario is unlikely to happen in vLLM, it is best to eliminate any potential risks.
    
Why the new padding on token_in_tpu_cur_input_indices fixed the bug? The padded parts, which we pad with indices that does not need any updates, will just be updating with their original values.


# Tests

We test this fix with the same edge cases and it returns the correct output. We also verified its correctness by running existing pytest on async scheduler.
Result on new padding:
```
import jax
import jax.numpy as jnp

# inputs to the substitute_placeholder_token_fn
placeholder_num = 2
input_ids =  jnp.array([    0,     127,   264, 32794,   911,   279,  5112,   315,   264,
    3283,   518,  3729,    13,  9645,   432,   0], dtype=jnp.int32)
token_in_tpu_pre_next_tokens_indices = jnp.array([ 0,  2, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1], dtype=jnp.int32)
token_in_tpu_cur_input_indices = jnp.array([ 0,  15, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ,11, 12, 13, 14], dtype=jnp.int32)   # New padding
next_tokens = jnp.array([1265,  264,  576, 1265, 1265, 1265, 1265, 1265], dtype=jnp.int32)

out = _substitute_placeholder_token(input_ids, token_in_tpu_cur_input_indices, token_in_tpu_pre_next_tokens_indices, next_tokens, placeholder_num)
print("input_ids is \n",input_ids)
print("update_values is \n",update_values)
print("output is \n",out)
```
output:
```
input_ids is 
 [    0   127   264 32794   911   279  5112   315   264  3283   518  3729
    13  9645   432     0]
token_in_tpu_cur_input_indices is  [ 0 15  1  2  3  4  5  6  7  8  9 10 11 12 13 14]
update_values is 
 [ 1265   576   127   264 32794   911   279  5112   315   264  3283   518
  3729    13  9645   432]
output is 
 [ 1265   127   264 32794   911   279  5112   315   264  3283   518  3729
    13  9645   432   576]
 ```

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.