### PR TITLE
[Runner] Separate execute_model and sample_tokens to adapt upstream change.

### DIFF
--- a/tpu_inference/runner/structured_decoding_manager.py
+++ b/tpu_inference/runner/structured_decoding_manager.py
@@ -7,8 +7,7 @@ import jax.numpy as jnp
 from tpu_inference.utils import device_array
 
 if TYPE_CHECKING:
-    from vllm.v1.core.sched.output import \
-        SchedulerOutput as VllmSchedulerOutput
+    from vllm.v1.core.sched.output import GrammarOutput
 
     from tpu_inference.runner.tpu_jax_runner import TPUModelRunner
 
@@ -51,9 +50,9 @@ class StructuredDecodingManager:
         return jnp.where(require_struct_decoding, masked_logits, logits)
 
     def prepare_structured_decoding_input(
-        self, logits: jax.Array, scheduler_output: "VllmSchedulerOutput"
+        self, logits: jax.Array, grammar_output: "GrammarOutput"
     ) -> Tuple[jax.Array, jax.Array, jax.Array]:
-        grammar_bitmask = scheduler_output.grammar_bitmask
+        grammar_bitmask = grammar_output.grammar_bitmask
         assert grammar_bitmask is not None
         num_reqs, _ = logits.shape
 
@@ -62,7 +61,7 @@ class StructuredDecodingManager:
         self.runner.require_structured_out_cpu.fill(0)
 
         sorted_struct_requests = sorted(
-            scheduler_output.structured_output_request_ids.items(),
+            grammar_output.structured_output_request_ids.items(),
             key=lambda item: item[1])
 
         cumulative_mask_idx = 0

--- a/tpu_inference/worker/tpu_worker_jax.py
+++ b/tpu_inference/worker/tpu_worker_jax.py
@@ -18,7 +18,7 @@ from vllm.lora.request import LoRARequest
 from vllm.tasks import SupportedTask
 from vllm.v1 import utils as vllm_utils
 from vllm.v1.core.kv_cache_utils import get_num_blocks, get_uniform_page_size
-from vllm.v1.core.sched.output import SchedulerOutput
+from vllm.v1.core.sched.output import GrammarOutput, SchedulerOutput
 from vllm.v1.kv_cache_interface import KVCacheConfig, KVCacheSpec
 from vllm.v1.outputs import DraftTokenIds, ModelRunnerOutput
 
@@ -200,10 +200,15 @@ class TPUWorker:
         output = self.model_runner.execute_model(scheduler_output)
 
         # With a connector, the scheduler expects output from all workers
+        # TODO(mrjunwan): Figure out if this is ok after https://github.com/vllm-project/vllm/pull/26866
         if has_kv_transfer_group():
             return output
 
         return output if self.is_driver_worker else None
+
+    def sample_tokens(self,
+                      grammar_output: GrammarOutput) -> ModelRunnerOutput:
+        return self.model_runner.sample_tokens(grammar_output)
 
     def take_draft_token_ids(self) -> Optional[DraftTokenIds]:
         return self.model_runner.take_draft_token_ids()


### PR DESCRIPTION
Adapting to: https://github.com/vllm-project/vllm/pull/26866
The main changes are we have to separate `execute_model` and `sample_tokens`. 

BuildKite passing: https://buildkite.com/tpu-commons/tpu-inference-ci/builds/4882