### PR TITLE
Introduce cpu agents for general-purpose tasks that don't require TPU

### DIFF
--- a/.buildkite/features/Chunked_Prefill.yml
+++ b/.buildkite/features/Chunked_Prefill.yml
@@ -14,7 +14,7 @@ steps:
       CI_TARGET: "Chunked Prefill"
       CI_STAGE: "CorrectnessTest"
     agents:
-      queue: tpu_v6e_queue
+      queue: cpu
     commands:
       - |
         .buildkite/scripts/record_step_result.sh Chunked_Prefill_CorrectnessTest
@@ -34,7 +34,7 @@ steps:
       CI_TARGET: "Chunked Prefill"
       CI_STAGE: "PerformanceTest"
     agents:
-      queue: tpu_v6e_queue
+      queue: cpu
     commands:
       - |
         .buildkite/scripts/record_step_result.sh Chunked_Prefill_PerformanceTest

--- a/.buildkite/features/Collective_Communication_Matmul.yml
+++ b/.buildkite/features/Collective_Communication_Matmul.yml
@@ -14,7 +14,7 @@ steps:
       CI_TARGET: "Collective Communication Matmul"
       CI_STAGE: "CorrectnessTest"
     agents:
-      queue: tpu_v6e_queue
+      queue: cpu
     commands:
       - |
         .buildkite/scripts/record_step_result.sh Collective_Communication_Matmul_CorrectnessTest

--- a/.buildkite/features/JAX-Path_Qxix_Quantization.yml
+++ b/.buildkite/features/JAX-Path_Qxix_Quantization.yml
@@ -14,7 +14,7 @@ steps:
       CI_TARGET: "JAX-Path Qxix Quantization"
       CI_STAGE: "CorrectnessTest"
     agents:
-      queue: tpu_v6e_queue
+      queue: cpu
     commands:
       - |
         .buildkite/scripts/record_step_result.sh JAX-Path_Qxix_Quantization_CorrectnessTest
@@ -36,7 +36,7 @@ steps:
       CI_TARGET: "JAX-Path Qxix Quantization"
       CI_STAGE: "PerformanceTest"
     agents:
-      queue: tpu_v6e_queue
+      queue: cpu
     commands:
       - |
         .buildkite/scripts/record_step_result.sh JAX-Path_Qxix_Quantization_PerformanceTest

--- a/.buildkite/features/Multimodal_Inputs.yml
+++ b/.buildkite/features/Multimodal_Inputs.yml
@@ -14,7 +14,7 @@ steps:
       CI_TARGET: Multimodal Inputs
       CI_STAGE: "CorrectnessTest"
     agents:
-      queue: tpu_v6e_queue
+      queue: cpu
     commands:
       - |
         .buildkite/scripts/record_step_result.sh Multimodal_Inputs_CorrectnessTest
@@ -34,7 +34,7 @@ steps:
       CI_TARGET: Multimodal Inputs
       CI_STAGE: "PerformanceTest"
     agents:
-      queue: tpu_v6e_queue
+      queue: cpu
     commands:
       - |
         .buildkite/scripts/record_step_result.sh Multimodal_Inputs_PerformanceTest

--- a/.buildkite/features/Prefix_Caching.yml
+++ b/.buildkite/features/Prefix_Caching.yml
@@ -4,7 +4,7 @@ steps:
     key: "Prefix_Caching_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: cpu
     commands:
       - echo "default on in vLLM"
   - label: "Record correctness test result for Prefix Caching"
@@ -14,7 +14,7 @@ steps:
       CI_TARGET: "Prefix Caching"
       CI_STAGE: "CorrectnessTest"
     agents:
-      queue: tpu_v6e_queue
+      queue: cpu
     commands:
       - |
         .buildkite/scripts/record_step_result.sh Prefix_Caching_CorrectnessTest
@@ -24,7 +24,7 @@ steps:
     depends_on: "record_Prefix_Caching_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: cpu
     commands:
       - echo "default on in vLLM"
   - label: "Record performance test result for Prefix Caching"
@@ -34,7 +34,7 @@ steps:
       CI_TARGET: "Prefix Caching"
       CI_STAGE: "PerformanceTest"
     agents:
-      queue: tpu_v6e_queue
+      queue: cpu
     commands:
       - |
         .buildkite/scripts/record_step_result.sh Prefix_Caching_PerformanceTest

--- a/.buildkite/features/Quantized_Matmul_Attention_and_KV_Cache.yml
+++ b/.buildkite/features/Quantized_Matmul_Attention_and_KV_Cache.yml
@@ -4,7 +4,7 @@ steps:
     key: "Quantized_Matmul_Attention_and_KV_Cache_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: cpu
     commands:
       - echo "covered by performance test"
   - label: "Record correctness test result for Quantized Matmul Attention and KV Cache"
@@ -14,7 +14,7 @@ steps:
       CI_TARGET: "Quantized Matmul Attention and KV Cache"
       CI_STAGE: "CorrectnessTest"
     agents:
-      queue: tpu_v6e_queue
+      queue: cpu
     commands:
       - |
         .buildkite/scripts/record_step_result.sh Quantized_Matmul_Attention_and_KV_Cache_CorrectnessTest
@@ -45,7 +45,7 @@ steps:
       CI_TARGET: "Quantized Matmul Attention and KV Cache"
       CI_STAGE: "PerformanceTest"
     agents:
-      queue: tpu_v6e_queue
+      queue: cpu
     commands:
       - |
         .buildkite/scripts/record_step_result.sh Quantized_Matmul_Attention_and_KV_Cache_PerformanceTest

--- a/.buildkite/features/Ragged_Paged_Attention_V3.yml
+++ b/.buildkite/features/Ragged_Paged_Attention_V3.yml
@@ -4,7 +4,7 @@ steps:
     key: "Ragged_Paged_Attention_V3_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: cpu
     commands:
       - echo "default on in vLLM"
   - label: "Record correctness test result for Ragged Paged Attention V3"
@@ -14,7 +14,7 @@ steps:
       CI_TARGET: "Ragged Paged Attention V3"
       CI_STAGE: "CorrectnessTest"
     agents:
-      queue: tpu_v6e_queue
+      queue: cpu
     commands:
       - |
         .buildkite/scripts/record_step_result.sh Ragged_Paged_Attention_V3_CorrectnessTest
@@ -24,7 +24,7 @@ steps:
     depends_on: "record_Ragged_Paged_Attention_V3_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: cpu
     commands:
       - echo "default on in vLLM"
   - label: "Record performance test result for Ragged Paged Attention V3"
@@ -34,7 +34,7 @@ steps:
       CI_TARGET: "Ragged Paged Attention V3"
       CI_STAGE: "PerformanceTest"
     agents:
-      queue: tpu_v6e_queue
+      queue: cpu
     commands:
       - |
         .buildkite/scripts/record_step_result.sh Ragged_Paged_Attention_V3_PerformanceTest

--- a/.buildkite/features/Single_Program_Multi_Data.yml
+++ b/.buildkite/features/Single_Program_Multi_Data.yml
@@ -4,7 +4,7 @@ steps:
     key: "Single_Program_Multi_Data__CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: cpu
     commands:
       - echo "default on in vLLM"
   - label: "Record correctness test result for Single Program Multi Data"
@@ -14,7 +14,7 @@ steps:
       CI_TARGET: "Single Program Multi Data"
       CI_STAGE: "CorrectnessTest"
     agents:
-      queue: tpu_v6e_queue
+      queue: cpu
     commands:
       - |
         .buildkite/scripts/record_step_result.sh Single_Program_Multi_Data__CorrectnessTest
@@ -24,7 +24,7 @@ steps:
     depends_on: "record_Single_Program_Multi_Data__CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: cpu
     commands:
       - echo "default on in vLLM"
   - label: "Record performance test result for Single Program Multi Data"
@@ -34,7 +34,7 @@ steps:
       CI_TARGET: "Single Program Multi Data"
       CI_STAGE: "PerformanceTest"
     agents:
-      queue: tpu_v6e_queue
+      queue: cpu
     commands:
       - |
         .buildkite/scripts/record_step_result.sh Single_Program_Multi_Data__PerformanceTest

--- a/.buildkite/features/Speculative_Decoding-_Ngram.yml
+++ b/.buildkite/features/Speculative_Decoding-_Ngram.yml
@@ -4,7 +4,7 @@ steps:
     key: "Speculative_Decoding-_Ngram_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: cpu
     commands:
       - echo "covered by performance test"
   - label: "Record correctness test result for Speculative Decoding: Ngram"
@@ -14,7 +14,7 @@ steps:
       CI_TARGET: "Speculative Decoding: Ngram"
       CI_STAGE: "CorrectnessTest"
     agents:
-      queue: tpu_v6e_queue
+      queue: cpu
     commands:
       - |
         .buildkite/scripts/record_step_result.sh Speculative_Decoding-_Ngram_CorrectnessTest
@@ -24,7 +24,7 @@ steps:
     depends_on: "record_Speculative_Decoding-_Ngram_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: cpu
     commands:
       - .buildkite/scripts/run_in_docker.sh python3 -m pytest -s -v /workspace/tpu_inference/tests/e2e/test_speculative_decoding.py
   - label: "Record performance test result for Speculative Decoding: Ngram"
@@ -34,7 +34,7 @@ steps:
       CI_TARGET: "Speculative Decoding: Ngram"
       CI_STAGE: "PerformanceTest"
     agents:
-      queue: tpu_v6e_queue
+      queue: cpu
     commands:
       - |
         .buildkite/scripts/record_step_result.sh Speculative_Decoding-_Ngram_PerformanceTest

--- a/.buildkite/features/Structured_Decoding.yml
+++ b/.buildkite/features/Structured_Decoding.yml
@@ -14,7 +14,7 @@ steps:
       CI_TARGET: Structured Decoding
       CI_STAGE: "CorrectnessTest"
     agents:
-      queue: tpu_v6e_queue
+      queue: cpu
     commands:
       - |
         .buildkite/scripts/record_step_result.sh Structured_Decoding_CorrectnessTest

--- a/.buildkite/main.yml
+++ b/.buildkite/main.yml
@@ -5,8 +5,7 @@ steps:
    - label: "Upload Tests for Models & Features"
      <<: *run-on-nightly-or-tag
      agents:
-       # TODO : can be done on non-TPU queues once they're set up b/449203039
-       queue: tpu_v6e_queue
+       queue: cpu
      commands:
        - bash .buildkite/scripts/upload_models_and_features.sh
 
@@ -17,7 +16,7 @@ steps:
      <<: *run-on-nightly-or-tag
      key: generate_support_matrices
      agents:
-       queue: tpu_v6e_queue
+       queue: cpu
      soft_fail: true
      commands:
        - bash .buildkite/scripts/generate_support_matrices.sh
@@ -27,7 +26,7 @@ steps:
 #     key: notify_test_results
 #     depends_on: generate_support_matrices
 #     agents:
-#       queue: tpu_v6e_queue
+#       queue: cpu
 #     commands:
 #       - bash .buildkite/scripts/notify_test_results.sh
 
@@ -36,7 +35,7 @@ steps:
 #     depends_on: notify_test_results
 #     branches: "main"
 #     agents:
-#       queue: tpu_v6e_queue
+#       queue: cpu
 #     commands:
 #       # TODO : record verified vllm-tpu_inference commit hash pair if test successful (to be handled in separate PR)
 #       - echo "committing verified commit hashes"
@@ -46,7 +45,7 @@ steps:
      key: commit_nightly_support_matrices
      depends_on: generate_support_matrices
      agents:
-       queue: tpu_v6e_queue
+       queue: cpu
      secrets:
       - GITHUB_PAT
      command:

--- a/.buildkite/models/Qwen_Qwen2_5-VL-7B-Instruct.yml
+++ b/.buildkite/models/Qwen_Qwen2_5-VL-7B-Instruct.yml
@@ -16,7 +16,7 @@ steps:
       CI_STAGE: "UnitTest"
       CI_TARGET: Qwen/Qwen2.5-VL-7B-Instruct
     agents:
-      queue: tpu_v6e_queue
+      queue: cpu
     commands:
       - |
         .buildkite/scripts/record_step_result.sh Qwen_Qwen2_5-VL-7B-Instruct_UnitTest
@@ -41,7 +41,7 @@ steps:
       CI_TARGET: Qwen/Qwen2.5-VL-7B-Instruct
       CI_STAGE: "IntegrationTest"
     agents:
-      queue: tpu_v6e_queue
+      queue: cpu
     commands:
       - |
         .buildkite/scripts/record_step_result.sh Qwen_Qwen2_5-VL-7B-Instruct_IntegrationTest
@@ -62,7 +62,7 @@ steps:
       CI_TARGET: Qwen/Qwen2.5-VL-7B-Instruct
       CI_STAGE: "Benchmark"
     agents:
-      queue: tpu_v6e_queue
+      queue: cpu
     commands:
       - |
         .buildkite/scripts/record_step_result.sh Qwen_Qwen2_5-VL-7B-Instruct_Benchmark

--- a/.buildkite/models/Qwen_Qwen3-30B-A3B.yml
+++ b/.buildkite/models/Qwen_Qwen3-30B-A3B.yml
@@ -16,7 +16,7 @@ steps:
       CI_STAGE: "UnitTest"
       CI_TARGET: Qwen/Qwen3-30B-A3B
     agents:
-      queue: tpu_v6e_queue
+      queue: cpu
     commands:
       - |
         .buildkite/scripts/record_step_result.sh Qwen_Qwen3-30B-A3B_UnitTest
@@ -41,7 +41,7 @@ steps:
       CI_TARGET: Qwen/Qwen3-30B-A3B
       CI_STAGE: "IntegrationTest"
     agents:
-      queue: tpu_v6e_queue
+      queue: cpu
     commands:
       - |
         .buildkite/scripts/record_step_result.sh Qwen_Qwen3-30B-A3B_IntegrationTest
@@ -72,7 +72,7 @@ steps:
       CI_TARGET: Qwen/Qwen3-30B-A3B
       CI_STAGE: "Benchmark"
     agents:
-      queue: tpu_v6e_queue
+      queue: cpu
     commands:
       - |
         .buildkite/scripts/record_step_result.sh Qwen_Qwen3-30B-A3B_Benchmark

--- a/.buildkite/models/Qwen_Qwen3-32B.yml
+++ b/.buildkite/models/Qwen_Qwen3-32B.yml
@@ -16,7 +16,7 @@ steps:
       CI_STAGE: "UnitTest"
       CI_TARGET: Qwen/Qwen3-32B
     agents:
-      queue: tpu_v6e_queue
+      queue: cpu
     commands:
       - |
         .buildkite/scripts/record_step_result.sh Qwen_Qwen3-32B_UnitTest
@@ -41,7 +41,7 @@ steps:
       CI_TARGET: Qwen/Qwen3-32B
       CI_STAGE: "IntegrationTest"
     agents:
-      queue: tpu_v6e_queue
+      queue: cpu
     commands:
       - |
         .buildkite/scripts/record_step_result.sh Qwen_Qwen3-32B_IntegrationTest
@@ -72,7 +72,7 @@ steps:
       CI_TARGET: Qwen/Qwen3-32B
       CI_STAGE: "Benchmark"
     agents:
-      queue: tpu_v6e_queue
+      queue: cpu
     commands:
       - |
         .buildkite/scripts/record_step_result.sh Qwen_Qwen3-32B_Benchmark

--- a/.buildkite/models/Qwen_Qwen3-4B.yml
+++ b/.buildkite/models/Qwen_Qwen3-4B.yml
@@ -16,7 +16,7 @@ steps:
       CI_STAGE: "UnitTest"
       CI_TARGET: Qwen/Qwen3-4B
     agents:
-      queue: tpu_v6e_queue
+      queue: cpu
     commands:
       - |
         .buildkite/scripts/record_step_result.sh Qwen_Qwen3-4B_UnitTest
@@ -41,7 +41,7 @@ steps:
       CI_TARGET: Qwen/Qwen3-4B
       CI_STAGE: "IntegrationTest"
     agents:
-      queue: tpu_v6e_queue
+      queue: cpu
     commands:
       - |
         .buildkite/scripts/record_step_result.sh Qwen_Qwen3-4B_IntegrationTest
@@ -72,7 +72,7 @@ steps:
       CI_TARGET: Qwen/Qwen3-4B
       CI_STAGE: "Benchmark"
     agents:
-      queue: tpu_v6e_queue
+      queue: cpu
     commands:
       - |
         .buildkite/scripts/record_step_result.sh Qwen_Qwen3-4B_Benchmark

--- a/.buildkite/models/google_gemma-3-27b-it.yml
+++ b/.buildkite/models/google_gemma-3-27b-it.yml
@@ -16,7 +16,7 @@ steps:
       CI_STAGE: "UnitTest"
       CI_TARGET: google/gemma-3-27b-it
     agents:
-      queue: tpu_v6e_queue
+      queue: cpu
     commands:
       - |
         .buildkite/scripts/record_step_result.sh google_gemma-3-27b-it_UnitTest
@@ -41,7 +41,7 @@ steps:
       CI_TARGET: google/gemma-3-27b-it
       CI_STAGE: "IntegrationTest"
     agents:
-      queue: tpu_v6e_queue
+      queue: cpu
     commands:
       - |
         .buildkite/scripts/record_step_result.sh google_gemma-3-27b-it_IntegrationTest
@@ -72,7 +72,7 @@ steps:
       CI_TARGET: google/gemma-3-27b-it
       CI_STAGE: "Benchmark"
     agents:
-      queue: tpu_v6e_queue
+      queue: cpu
     commands:
       - |
         .buildkite/scripts/record_step_result.sh google_gemma-3-27b-it_Benchmark

--- a/.buildkite/models/meta-llama_Llama-3_1-8B-Instruct.yml
+++ b/.buildkite/models/meta-llama_Llama-3_1-8B-Instruct.yml
@@ -16,7 +16,7 @@ steps:
       CI_STAGE: "UnitTest"
       CI_TARGET: meta-llama/Llama-3.1-8B-Instruct
     agents:
-      queue: tpu_v6e_queue
+      queue: cpu
     commands:
       - |
         .buildkite/scripts/record_step_result.sh meta-llama_Llama-3_1-8B-Instruct_UnitTest
@@ -41,7 +41,7 @@ steps:
       CI_TARGET: meta-llama/Llama-3.1-8B-Instruct
       CI_STAGE: "IntegrationTest"
     agents:
-      queue: tpu_v6e_queue
+      queue: cpu
     commands:
       - |
         .buildkite/scripts/record_step_result.sh meta-llama_Llama-3_1-8B-Instruct_IntegrationTest
@@ -72,7 +72,7 @@ steps:
       CI_TARGET: meta-llama/Llama-3.1-8B-Instruct
       CI_STAGE: "Benchmark"
     agents:
-      queue: tpu_v6e_queue
+      queue: cpu
     commands:
       - |
         .buildkite/scripts/record_step_result.sh meta-llama_Llama-3_1-8B-Instruct_Benchmark

--- a/.buildkite/models/meta-llama_Llama-3_3-70B-Instruct.yml
+++ b/.buildkite/models/meta-llama_Llama-3_3-70B-Instruct.yml
@@ -16,7 +16,7 @@ steps:
       CI_STAGE: "UnitTest"
       CI_TARGET: meta-llama/Llama-3.3-70B-Instruct
     agents:
-      queue: tpu_v6e_queue
+      queue: cpu
     commands:
       - |
         .buildkite/scripts/record_step_result.sh meta-llama_Llama-3_3-70B-Instruct_UnitTest
@@ -41,7 +41,7 @@ steps:
       CI_TARGET: meta-llama/Llama-3.3-70B-Instruct
       CI_STAGE: "IntegrationTest"
     agents:
-      queue: tpu_v6e_queue
+      queue: cpu
     commands:
       - |
         .buildkite/scripts/record_step_result.sh meta-llama_Llama-3_3-70B-Instruct_IntegrationTest
@@ -72,7 +72,7 @@ steps:
       CI_TARGET: meta-llama/Llama-3.3-70B-Instruct
       CI_STAGE: "Benchmark"
     agents:
-      queue: tpu_v6e_queue
+      queue: cpu
     commands:
       - |
         .buildkite/scripts/record_step_result.sh meta-llama_Llama-3_3-70B-Instruct_Benchmark

--- a/.buildkite/pipeline_generation/feature_template.yml
+++ b/.buildkite/pipeline_generation/feature_template.yml
@@ -14,7 +14,7 @@ steps:
       CI_TARGET: "{FEATURE_NAME}"
       CI_STAGE: "CorrectnessTest"
     agents:
-      queue: tpu_v6e_queue
+      queue: cpu
     commands:
       - |
         .buildkite/scripts/record_step_result.sh {SANITIZED_FEATURE_NAME}_CorrectnessTest
@@ -34,7 +34,7 @@ steps:
       CI_TARGET: "{FEATURE_NAME}"
       CI_STAGE: "PerformanceTest"
     agents:
-      queue: tpu_v6e_queue
+      queue: cpu
     commands:
       - |
         .buildkite/scripts/record_step_result.sh {SANITIZED_FEATURE_NAME}_PerformanceTest

--- a/.buildkite/pipeline_generation/tpu_optimized_model_template.yml
+++ b/.buildkite/pipeline_generation/tpu_optimized_model_template.yml
@@ -14,7 +14,7 @@ steps:
       CI_STAGE: "UnitTest"
       CI_TARGET: {MODEL_NAME}
     agents:
-      queue: tpu_v6e_queue
+      queue: cpu
     commands:
       - |
         .buildkite/scripts/record_step_result.sh {SANITIZED_MODEL_NAME}_UnitTest
@@ -39,7 +39,7 @@ steps:
       CI_TARGET: {MODEL_NAME}
       CI_STAGE: "IntegrationTest"
     agents:
-      queue: tpu_v6e_queue
+      queue: cpu
     commands:
       - |
         .buildkite/scripts/record_step_result.sh {SANITIZED_MODEL_NAME}_IntegrationTest
@@ -64,7 +64,7 @@ steps:
       CI_TARGET: {MODEL_NAME}
       CI_STAGE: "Benchmark"
     agents:
-      queue: tpu_v6e_queue
+      queue: cpu
     commands:
       - |
         .buildkite/scripts/record_step_result.sh {SANITIZED_MODEL_NAME}_Benchmark

--- a/.buildkite/pipeline_generation/vllm_native_model_template.yml
+++ b/.buildkite/pipeline_generation/vllm_native_model_template.yml
@@ -14,7 +14,7 @@ steps:
       CI_STAGE: "UnitTest"
       CI_TARGET: {MODEL_NAME}
     agents:
-      queue: tpu_v6e_queue
+      queue: cpu
     commands:
       - |
         .buildkite/scripts/record_step_result.sh {SANITIZED_MODEL_NAME}_UnitTest
@@ -39,7 +39,7 @@ steps:
       CI_TARGET: {MODEL_NAME}
       CI_STAGE: "IntegrationTest"
     agents:
-      queue: tpu_v6e_queue
+      queue: cpu
     commands:
       - |
         .buildkite/scripts/record_step_result.sh {SANITIZED_MODEL_NAME}_IntegrationTest

--- a/.buildkite/pipeline_jax.yml
+++ b/.buildkite/pipeline_jax.yml
@@ -240,7 +240,7 @@ steps:
        - test_12
        - test_13
      agents:
-       queue: tpu_v6e_queue
+       queue: cpu
      commands:
        - |
          .buildkite/scripts/check_results.sh \

--- a/.buildkite/pipeline_torch.yml
+++ b/.buildkite/pipeline_torch.yml
@@ -134,5 +134,5 @@ steps:
        - tpu_test_12
        - tpu_test_13
      agents:
-       queue: tpu_v6e_queue
+       queue: cpu
      commands: "bash .buildkite/scripts/check_results.sh 'TPU V1 Tests Failed' tpu_test_0 tpu_test_1 tpu_test_2 tpu_test_3 tpu_test_4 tpu_test_5 tpu_test_6 tpu_test_7 tpu_test_8 tpu_test_9 tpu_test_10 tpu_test_11 tpu_test_12 tpu_test_13"

--- a/.buildkite/scripts/check_results.sh
+++ b/.buildkite/scripts/check_results.sh
@@ -26,7 +26,7 @@ if [ "${ANY_FAILED}" = "true" ] ; then
     steps:
     - label: "${FAILURE_LABEL}"
         agents:
-        queue: tpu_v6_queue
+        queue: cpu
         command: echo "${FAILURE_LABEL}"
 YAML
     exit 1

--- a/.buildkite/scripts/upload_models_and_features.sh
+++ b/.buildkite/scripts/upload_models_and_features.sh
@@ -48,7 +48,7 @@ for folder_path in $TARGET_FOLDERS; do
 - label: "Upload: ${yml_file}"
   command: "buildkite-agent pipeline upload ${yml_file}"
   agents:
-    queue: tpu_v6e_queue
+    queue: cpu
 EOF
 )
 


### PR DESCRIPTION
# Description

Add cpu agents to CI for general-purpose tasks that don't require TPU. In other words, reserve TPU agents for tasks that actually require TPU. 

# Tests

[buildkite](https://buildkite.com/tpu-commons/tpu-inference-ci/builds/4931)

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
