### PR TITLE
Revert "Bump jax version to 0.8.0"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,8 +5,9 @@ pytest-mock
 absl-py
 numpy
 google-cloud-storage
-jax[tpu]==0.8.0
-jaxlib==0.8.0
+jax==0.7.2
+jaxlib==0.7.2
+libtpu==0.0.23
 jaxtyping
 flax==0.11.1
 torchax==0.0.7


### PR DESCRIPTION
Reverts vllm-project/tpu-inference#1006