### PR TITLE
Fix default value for USE_MOE_EP_KERNEL

### DIFF
--- a/tpu_inference/layers/vllm/quantization/unquantized.py
+++ b/tpu_inference/layers/vllm/quantization/unquantized.py
@@ -165,7 +165,7 @@ class VllmUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod):
                  ep_axis_name: str = 'model'):
         super().__init__(moe)
         self.mesh = mesh
-        self.use_kernel = os.getenv("USE_MOE_EP_KERNEL", "0")
+        self.use_kernel = bool(int(os.getenv("USE_MOE_EP_KERNEL", "0")))
         self.ep_axis_name = ep_axis_name
         # TODO: Use autotune table once we have it.
         self.block_size = {


### PR DESCRIPTION
# Description

Fix issue where `USE_MOE_EP_KERNEL` is enabled by default.

# Tests

Verified that below command does not use the new kernel

```
VLLM_DISABLE_SHARED_EXPERTS_STREAM=1 MODEL_IMPL_TYPE=vllm python3 examples/offline_inference.py --model=Qwen/Qwen3-30b-a3b --tensor-parallel-size 4 --max-model-len 12288 --gpu-memory-utilization 0.95 --no-enable-prefix-caching --max-num-seqs 1024 --max-num-batched-tokens 4096 --enable-expert-parallel
```

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
