### PR TITLE
[TPU host offoad] fix pin/unpin cpu backend keys logic

### DIFF
--- a/tpu_inference/distributed/tpu_connector_local.py
+++ b/tpu_inference/distributed/tpu_connector_local.py
@@ -1379,7 +1379,7 @@ class TPUConnectorWorker:
                 )
 
         if keys_to_unpin:
-            unpinned_count, found_count = self.cpu_backend.unpin_keys(
+            unpinned_count, found_count = self.cpu_backend.maybe_unpin_keys(
                 keys_to_unpin)
             logger.info(
                 f"Unpinned {unpinned_count} out of {found_count} existing keys (Request to unpin {len(keys_to_unpin)} keys)."


### PR DESCRIPTION
# Description

Start with a short description of what the PR does and how this is a change from
the past.

This commit addresses a race condition in the CPU KV cache where a cached block could be prematurely evicted if multiple requests were relying on it and one of the requests finished early.


The rest of the description includes relevant details and context, examples:
- why is this change being made,
- the problem being solved and any relevant context,
- why this is a good solution,
- some information about the specific implementation,

The LocalCPUBackend now uses a reference counting mechanism for pinned keys:
- Replaced the pinned_keys set with a `pin_counts` dictionary to track active references for each cached block.
- The contains method increments the reference count when a key is pinned.
- The maybe_unpin_keys method decrements the count and only truly unpins a key when its reference count reaches zero.
- The eviction logic in the add() method now respects these reference counts preventing eviction of actively used blocks.
- Additionally, the unpin_keys method was renamed to maybe_unpin_keys to better reflect its conditional nature.


- shortcomings of the solution and possible future improvements.

If the change fixes a bug or a Github issue, please include a link, e.g.,:
FIXES: b/123456
FIXES: #123456

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
