### PR TITLE
Add instruction to set up pre-commit hooks.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,5 +31,17 @@ We choose to follow a similar directory structure as vLLM:
 ## Testing
 When checking in a new feature, we expect that you you add relevant unit tests as well as CI tests.  You can read more about the latter [here](https://github.com/vllm-project/tpu-inference/tree/main/.buildkite#adding-a-new-feature-to-ci).
 
+## Setting up linting, formatting, and static type checking
+
+```
+pip install pre-commit
+
+# Linting, formatting and static type checking
+pre-commit install --hook-type pre-commit --hook-type commit-msg
+
+# You can manually run pre-commit with
+pre-commit run --all-files
+```
+
 ## Thank You!
 We wanted to thank you for taking the time to read these guidelines and for your interest in contributing to TPU Inference. All of your contributions help make TPU Infernece a great tool and community for everyone!


### PR DESCRIPTION
# Description

This PR adds back the instruction about setting up the pre-commit hook. It used to be [here](https://github.com/vllm-project/tpu-inference/tree/xiowei/add_lora_to_tpu_commons?tab=readme-ov-file#setup-pre-commit-hooks).

# Tests

na

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
