### PR TITLE
Add email alerts to buildkite pipelines

### DIFF
--- a/.buildkite/main.yml
+++ b/.buildkite/main.yml
@@ -1,6 +1,10 @@
 x-run-condition: &run-on-nightly-or-tag
   if: build.env("NIGHTLY") == "1" || build.tag =~ /^v?[0-9]+(\.[a-zA-Z0-9]+)*([a-zA-Z]+[0-9]*)?$/
 
+notify:
+  - email: "ullm-oncall@rotations.google.com"
+    if: build.state == "failed" && build.branch == "main"
+
 steps:
    - label: "Upload Tests for Models & Features"
      <<: *run-on-nightly-or-tag

--- a/.buildkite/pipeline_jax.yml
+++ b/.buildkite/pipeline_jax.yml
@@ -1,3 +1,7 @@
+notify:
+  - email: "ullm-oncall@rotations.google.com"
+    if: build.state == "failed" && build.branch == "main"
+
 steps:
   # -----------------------------------------------------------------
   # TEST STEPS - Calling wrapper


### PR DESCRIPTION
# Description

This PR enables email alerts for buildkite pipeline failures

Currently set on own email to validate that email is indeed sent.

FIXES: b/457722422

# Tests

Tested by presubmit tests and validating that email is sent
