### PR TITLE
use sharded device put to handle torchax on multi host

### DIFF
--- a/tpu_inference/layers/vllm/sharding.py
+++ b/tpu_inference/layers/vllm/sharding.py
@@ -79,7 +79,7 @@ def _convert_to_torchax_and_shard(tensor: torch.Tensor,
         tensor = jax_view(tensor)
     else:
         tensor = t2j(tensor)
-    return torch_view(jax.device_put(tensor, sharding))
+    return torch_view(_sharded_device_put(tensor, sharding))
 
 
 def _shard_tensor_to_tpu_replicated(tensor: torch.Tensor,
@@ -176,3 +176,25 @@ def _shard_module_to_tpu(model: torch.nn.Module, mesh: Mesh) -> None:
                 logger.debug("shard %s with %s", path, sharding_func)
                 sharding_func(module, mesh)
                 break
+
+
+def _sharded_device_put(tensor: jax.Array, sharding) -> jax.Array:
+    if isinstance(tensor, tuple):
+        return tuple(_sharded_device_put(t, sharding) for t in tensor)
+    import os
+    multihost_backend = os.environ.get("TPU_MULTIHOST_BACKEND", "").lower()
+    if multihost_backend != "ray":
+        return jax.device_put(tensor, sharding)
+
+    # NOTE: at here, num_global_devices != num_local_devices
+    # meaning we are in multi-host setup. Each host will run the same process
+    # and each process only need to handle the devices accessible to this host.
+    shape = tensor.shape
+    x_split = [
+        jax.device_put(tensor[i], device) for device, i in
+        sharding.addressable_devices_indices_map(shape).items()
+    ]
+    return jax.make_array_from_single_device_arrays(shape,
+                                                    sharding,
+                                                    x_split,
+                                                    dtype=tensor.dtype)


### PR DESCRIPTION
# Description

Fix the error on torchax + Ray path. 

`ValueError: device_put's second argument must be a Device or a Sharding which represents addressable devices, but got NamedSharding(mesh=Mesh('data': 1, 'model': 4, axis_types=(Auto, Auto)), spec=PartitionSpec('model', None), memory_kind=device). Please pass device or Sharding which represents addressable devices.`

# Tests

E2E test on Ray + torchax + TP worked.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
