### PR TITLE
Update v7's jax requirements

### DIFF
--- a/requirements_v7x.txt
+++ b/requirements_v7x.txt
@@ -3,6 +3,6 @@
 --pre
 -i https://us-python.pkg.dev/ml-oss-artifacts-published/jax/simple/
 -f https://storage.googleapis.com/jax-releases/libtpu_releases.html
-jax==0.8.0.dev20251013
-jaxlib==0.8.0.dev20251013
-libtpu==0.0.25.dev20251012+nightly
+jax==0.8.1.dev20251105
+jaxlib==0.8.1.dev20251105
+libtpu==0.0.28.dev20251105+nightly


### PR DESCRIPTION
Need to update jax version because the newest jax recognizes v7's device pattern, at this line: https://github.com/jax-ml/jax/blob/c25e095fcec9678a4ce5f723afce0c6a3c48a5e7/jax/experimental/pallas/ops/tpu/megablox/common.py#L34

Otherwise you get error on `https://github.com/jax-ml/jax/blob/c25e095fcec9678a4ce5f723afce0c6a3c48a5e7/jax/experimental/pallas/ops/tpu/megablox/common.py#L34`