### PR TITLE
[Torchax] Support bias and swiglu in MoE

### DIFF
--- a/tpu_inference/models/vllm/vllm_model_wrapper.py
+++ b/tpu_inference/models/vllm/vllm_model_wrapper.py
@@ -86,6 +86,11 @@ class VllmModelWrapper:
         assert self.vllm_config.model_config.dtype in TORCH_DTYPE_TO_JAX, "The model_config.dtype must be a PyTorch dtype."
         vllm_config_for_load.device_config.device = "cpu"
 
+        # When expert parallelism is enabled, vLLM loads weight in sharding
+        # aware manner. Since tpu-inference has its own sharding logic, this
+        # may casue errors. Therefore, we disable it during weight loading.
+        vllm_config_for_load.parallel_config.enable_expert_parallel = False
+
         if os.getenv("JAX_RANDOM_WEIGHTS", False):
             vllm_config_for_load.load_config.load_format = "dummy"
             use_random_weights = True


### PR DESCRIPTION
# Description

Support bias and swiglu activation in MoE layer.

Additionally, this PR fixes an issue where program fails when attempting to load gpt-oss with expert parallelism.

# Tests

```
VLLM_DISABLE_SHARED_EXPERTS_STREAM=1 MODEL_IMPL_TYPE=vllm vllm serve --model=unsloth/gpt-oss-120b-BF16  --max-model-len=8192 --max-num-batched-tokens 1024 --max-num-seqs=256 --no-enable-prefix-caching --disable-log-requests --gpu-memory-utilization 0.8 --tensor-parallel-size 8 --enable-expert-parallel
```

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
