### PR TITLE
Enable Pipeline Parallelism on jax worker

### DIFF
--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -223,6 +223,9 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         self,
         vllm_config: VllmConfig,
         devices: List[Any],
+        rank: int = 0,
+        is_first_rank: bool = True,
+        is_last_rank: bool = True,
     ):
         self.vllm_config = vllm_config
         self.model_config = vllm_config.model_config


### PR DESCRIPTION
# Description

The implementation for Pipeline Parallelism are splitted into the following small PRs.

- [ ] Util functions for PP on Jax (https://github.com/vllm-project/tpu-inference/pull/1042)
- [x] worker changes (The current PR)
- [ ] runner changes
- [ ] platform changes
- [ ] torchax changes
- [ ] Jax changes
- [ ] Single host changes (this will be in vLLM)
- [ ] Multi host changes (Ray)

This PR is to modify Jax worker to support PP.
- The worker `__init__` takes in the current worker's IP and its previous worker's IP, to start transfer server and connection later.
- During `execute_model`, for the PP workers who not in the first rank, they need to receive intermediate tensor from the previous worker. For the PP workers who is not the last rank, they need to send intermediate tensor to their next worker.
- The profiler should profile every PP worker, so add subfolders under the parent profile_dir to save profiles for each worker. 

# Tests

 E2E test has verified the whole PP implementation works properly.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
