### PR TITLE
Enable Pipeline Parallelism to use mp as distributed backend on Jax TPU platform

### DIFF
--- a/tpu_inference/platforms/tpu_platform.py
+++ b/tpu_inference/platforms/tpu_platform.py
@@ -184,8 +184,14 @@ class TpuPlatform(Platform):
 
         multihost_backend = os.environ.get("TPU_MULTIHOST_BACKEND", "").lower()
         if not multihost_backend:  # Single host
-            logger.info("Force using UniProcExecutor for JAX on single host.")
-            parallel_config.distributed_executor_backend = "uni"
+            if parallel_config.pipeline_parallel_size == 1:
+                logger.info("Force using UniProcExecutor for JAX on \
+                        single host without pipeline parallelism.")
+                parallel_config.distributed_executor_backend = "uni"
+            else:
+                logger.info("Force using MultiprocExecutor for JAX on \
+                        single host with pipeline parallelism.")
+                parallel_config.distributed_executor_backend = "mp"
         elif multihost_backend == "ray":
             from tpu_inference.executors.ray_distributed_executor import \
                 RayDistributedExecutor


### PR DESCRIPTION
# Description

The implementation for Pipeline Parallelism are splitted into the following small PRs.

- [ ] Util functions for PP on Jax (https://github.com/vllm-project/tpu-inference/pull/1042)
- [ ] worker changes (https://github.com/vllm-project/tpu-inference/pull/1043)
- [ ] runner changes (https://github.com/vllm-project/tpu-inference/pull/1053)
- [x] platform changes (The current PR)
- [ ] torchax changes
- [ ] Jax changes
- [ ] Single host changes (this will be in vLLM)
- [ ] Multi host changes (Ray)

This PR is to modify Jax TPU platform to support PP
- For single host, use `uni` when pp = 1, use `mp` when pp > 1

# Tests

 E2E test has verified the whole PP implementation works properly.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
