### PR TITLE
Enable Pipeline Parallelism on torchax path

### DIFF
--- a/tpu_inference/models/vllm/vllm_model_wrapper.py
+++ b/tpu_inference/models/vllm/vllm_model_wrapper.py
@@ -150,9 +150,9 @@ class VllmModelWrapper:
             input_embeds: jax.Array,
             layer_name_to_kvcache_index: Sequence[Tuple[str, int]],
             lora_metadata,
-            intermediate_tensors: JaxIntermediateTensors,
-            is_first_rank: bool,
-            is_last_rank: bool,
+            intermediate_tensors: JaxIntermediateTensors = None,
+            is_first_rank: bool = True,
+            is_last_rank: bool = True,
             *args,
         ) -> Tuple[List[jax.Array], jax.Array]:
             layer_name_to_kvcache_index = dict(layer_name_to_kvcache_index)


### PR DESCRIPTION
# Description

The implementation for Pipeline Parallelism are splitted into the following small PRs.

- [ ] Util functions for PP on Jax (https://github.com/vllm-project/tpu-inference/pull/1042)
- [ ] worker changes (https://github.com/vllm-project/tpu-inference/pull/1043)
- [ ] runner changes (https://github.com/vllm-project/tpu-inference/pull/1053)
- [ ] platform changes (https://github.com/vllm-project/tpu-inference/pull/1054)
- [x] torchax changes (The current PR)
- [ ] Jax changes
- [ ] Single host changes (this will be in vLLM)
- [ ] Multi host changes (Ray)

This PR is to modify vllm_model_wrapper to support PP on torchax path.
- pass `intermediate_tensors` to `step_fun`
- also pass in static boolean variable to adapt jax.jit static property
- convert the intermediate tensor between torch and jax.

# Tests

 E2E test has verified the whole PP implementation works properly.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
