### PR TITLE
Disable E2E DP test unless nightly

### DIFF
--- a/.buildkite/pipeline_jax.yml
+++ b/.buildkite/pipeline_jax.yml
@@ -229,8 +229,13 @@ steps:
        queue: tpu_v6e_8_queue
      commands:
        - |
-         .buildkite/scripts/run_in_docker.sh \
-           bash -c 'python3 -m pytest -s -v -x /workspace/tpu_inference/tests/e2e/test_data_parallel.py'
+         if [[ "$$NIGHTLY" == "1" ]]; then
+           .buildkite/scripts/run_in_docker.sh \
+             bash -c 'python3 -m pytest -s -v -x /workspace/tpu_inference/tests/e2e/test_data_parallel.py'
+         else
+           echo "Skipping: NIGHTLY environment variable not set"
+           exit 0
+         fi
 
    - label: "lora unit tests on single chip"
      key: test_15


### PR DESCRIPTION
# Description

Currently we are running the DP e2e test for every build, this PR sets this test to trigger only in nightly runs. 

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
