### PR TITLE
Add nightly releases for vllm/vllm-tpu docker

### DIFF
--- a/.buildkite/nightly_releases.yml
+++ b/.buildkite/nightly_releases.yml
@@ -1,0 +1,32 @@
+steps:
+  - label: "Publish vllm/vllm-tpu nightly image"
+    if: build.env("NIGHTLY") == "1"
+    agents:
+      queue: cpu
+    secrets:
+      - DOCKERHUB_TOKEN
+    commands:
+      - "yes | docker system prune -a"
+      - "docker build --no-cache -f docker/Dockerfile -t vllm/vllm-tpu:nightly -t vllm/vllm-tpu:nightly-$BUILDKITE_COMMIT ."
+      - "docker push vllm/vllm-tpu:nightly"
+      - "docker push vllm/vllm-tpu:nightly-$BUILDKITE_COMMIT"
+    plugins:
+      - docker-login#v3.0.0:
+          username: tpuinference
+          password-env: DOCKERHUB_TOKEN
+
+  - label: "Publish vllm/vllm-tpu nightly image for ironwood"
+    if: build.env("NIGHTLY") == "1"
+    agents:
+      queue: cpu
+    secrets:
+      - DOCKERHUB_TOKEN
+    commands:
+      - "yes | docker system prune -a"
+      - "docker build --no-cache --build-arg IS_FOR_V7X=true -f docker/Dockerfile -t vllm/vllm-tpu:nightly-ironwood -t vllm/vllm-tpu:nightly-ironwood-$BUILDKITE_COMMIT ."
+      - "docker push vllm/vllm-tpu:nightly-ironwood"
+      - "docker push vllm/vllm-tpu:nightly-ironwood-$BUILDKITE_COMMIT"
+    plugins:
+      - docker-login#v3.0.0:
+          username: tpuinference
+          password-env: DOCKERHUB_TOKEN

--- a/.buildkite/scripts/bootstrap.sh
+++ b/.buildkite/scripts/bootstrap.sh
@@ -24,6 +24,7 @@ upload_pipeline() {
     buildkite-agent pipeline upload .buildkite/pipeline_jax.yml
     # buildkite-agent pipeline upload .buildkite/pipeline_torch.yml
     buildkite-agent pipeline upload .buildkite/main.yml
+    buildkite-agent pipeline upload .buildkite/nightly_releases.yml
 }
 
 echo "--- Starting Buildkite Bootstrap ---"


### PR DESCRIPTION
# Description

Add nightly releases for vllm/vllm-tpu docker hub. A follow up of b/457461941.

# Tests

[buildkite](https://buildkite.com/tpu-commons/tpu-inference-ci/builds/5165#_)

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
