### PR TITLE
[Disagg] Fixes for vllm model impl disagg support

### DIFF
--- a/tpu_inference/core/core_tpu.py
+++ b/tpu_inference/core/core_tpu.py
@@ -446,13 +446,15 @@ class DisaggEngineCore(vLLMEngineCore):
         executor_fail_callback: Optional[Callable] = None,
     ):
         self.vllm_config = vllm_config
-        self.vllm_config.cache_config.gpu_memory_utilization = (
-            self.vllm_config.cache_config.gpu_memory_utilization - 0.1)
 
         self.output_queue = queue.Queue[Union[tuple[int, EngineCoreOutputs],
                                               bytes]]()
 
         self.devices = jax.devices()
+        device_kind = self.devices[0].device_kind
+        if device_kind != 'TPU7x':
+            self.vllm_config.cache_config.gpu_memory_utilization = (
+                self.vllm_config.cache_config.gpu_memory_utilization - 0.1)
         prefill_slice_sizes, decode_slice_sizes, slice_sizes = _get_slice_sizes(
             self.devices)
 
@@ -597,7 +599,6 @@ class DisaggEngineCoreProc(vLLMEngineCoreProc):
         # engine core to be executed, instead we create other instance of
         # engine cores and let them do the work.
         self.vllm_config = vllm_config
-        self.vllm_config.cache_config.gpu_memory_utilization = self.vllm_config.cache_config.gpu_memory_utilization - 0.1
 
         # We should be taking the input from the client, the code below is forked from
         # vllm.v1.engine.core.EngineCoreProc.
@@ -610,6 +611,10 @@ class DisaggEngineCoreProc(vLLMEngineCoreProc):
         self.engines_running = False
 
         self.devices = jax.devices()
+        device_kind = self.devices[0].device_kind
+        if device_kind != 'TPU7x':
+            self.vllm_config.cache_config.gpu_memory_utilization = (
+                self.vllm_config.cache_config.gpu_memory_utilization - 0.1)
         prefill_slice_sizes, decode_slice_sizes, slice_sizes = _get_slice_sizes(
             self.devices)
 

--- a/tpu_inference/models/vllm/vllm_model_wrapper.py
+++ b/tpu_inference/models/vllm/vllm_model_wrapper.py
@@ -82,9 +82,21 @@ class VllmModelWrapper:
 
     def load_weights(self):
         # Set up to load the model into CPU first.
+        # Cache device slice config since device config cannot be deepcopied
+        modified_slice_config = False
+        if hasattr(
+                self.vllm_config.device_config,
+                'slice') and self.vllm_config.device_config.slice is not None:
+            slice_config = self.vllm_config.device_config.slice
+            modified_slice_config = True
+            self.vllm_config.device_config.slice = None
         vllm_config_for_load = copy.deepcopy(self.vllm_config)
+        if modified_slice_config:
+            self.vllm_config.device_config.slice = slice_config
         assert self.vllm_config.model_config.dtype in TORCH_DTYPE_TO_JAX, "The model_config.dtype must be a PyTorch dtype."
         vllm_config_for_load.device_config.device = "cpu"
+        # Clearing the cached compilation config, otherwise vllm model init will fail
+        vllm_config_for_load.compilation_config.static_forward_context.clear()
 
         # When expert parallelism is enabled, vLLM loads weight in sharding
         # aware manner. Since tpu-inference has its own sharding logic, this


### PR DESCRIPTION
# Description

Also: removed additional hbm reservation for ironwood. HBM on ironwood is large enough for kv cache transferring buffer so not needed. 

# Tests

pytest

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
