### PR TITLE
[Llama4-Maverick/Optimization] Refactor: Standardize Sharding and Parallelism Configs in FFW/MoE Layers

### DIFF
--- a/tpu_inference/models/jax/llama4.py
+++ b/tpu_inference/models/jax/llama4.py
@@ -600,11 +600,11 @@ class Llama4WeightLoader:
                                 f"[AGGREGATED] Loaded shape for {buffer_key}: {aggregated_weight.shape}"
                                 f"does not match model shape for {loaded_name}: {model_weight.array.scale.value.shape}!"
                             )
-                        
+
                         model_weight.array.scale.value = shard_put(
-                                aggregated_weight,
-                                model_weight.array.scale.sharding,
-                                mesh=model_for_loading.mesh)
+                            aggregated_weight,
+                            model_weight.array.scale.sharding,
+                            mesh=model_for_loading.mesh)
 
                     elif aggregated_weight.itemsize < 2:  # check model weight elem nbits < 16
                         loaded_name = f"{base_mapped_name}.array.qvalue.value"


### PR DESCRIPTION
# Description

This PR refines the sharding and parallelism configurations across the model's Feed-Forward Network (FFW) and Mixture-of-Experts (MoE) components. The core benefit of this change is a significant 4x improvement in decoding throughput, boosting Output token throughput (tok/s) from 1k to 4k. 

The rest of the description includes relevant details and context, examples:
- **Why this change is being made:** The primary goal of this change is to enable highly efficient expert parallelism, resulting in a significant 4x improvement in decoding throughput (from 1k tok/s to 4k tok/s). This is achieved by explicitly defining tensor decomposition and sharding strategies.
- **MoE FFW Refinement (Performance Critical):** Updated `moe_ffw` sharding to explicitly set `activation_ffw_td` to `('data', 'expert')`. Crucially, the `edf_sharding=('model', None, None)` and `efd_sharding=('model', None, None)` configurations for the expert data flow are the key change that enables the massive increase in Output token throughput (tok/s). This ensures model weights are correctly partitioned alongside experts for optimal device utilization.
- **FFW Standardization:** Applied the explicit `activation_ffw_td=('data', 'expert')` configuration to `dense_ffw` layers to align sharding behavior across all FFW components.

# Tests

Experiments with dataset inlen1024_outlen4096_prefixlen0.jsonl

    * Serve:
        ```bash
        HF_TOKEN="your-HF-token" NEW_MODEL_DESIGN=True  VLLM_XLA_CHECK_RECOMPILATION=1 TPU_BACKEND_TYPE=jax vllm serve --model=meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8 --hf-overrides '{"architectures": ["Llama4ForCausalLM"]}' --tensor-parallel-size 8 --max-num-batched-tokens 1024 --max_model_len=5130 --disable-log-requests --max-num-seqs 256 --gpu-memory-utilization 0.9 --async-scheduling
        ```

    * Benchmark:
        ```bash
        vllm bench serve --backend vllm --model meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8 --dataset-name custom --dataset-path /home/sierraq_google_com/datasets_maverick/Llama-4-Maverick-17B-128E-Instruct/inlen1024_outlen4096_prefixlen0.jsonl --num-prompts 1000 --custom-output-len 4096 --ignore-eos
        ```

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
