### PR TITLE
[DeepSeek] Optimize RoPE Cache to remove re-layout

### DIFF
--- a/tpu_inference/layers/jax/rope.py
+++ b/tpu_inference/layers/jax/rope.py
@@ -1,5 +1,6 @@
 import math
 from dataclasses import dataclass, field
+from typing import Optional, Tuple
 
 import jax
 from flax import nnx
@@ -17,7 +18,7 @@ class RotaryEmbedding(nnx.Module):
     rope_theta: float
     original_max_position_embeddings: int
     dtype: jnp.dtype
-    sin_cos_cache: jax.Array | None = field(init=False, default=None)
+    sin_cos_cache: Optional[jax.Array] = field(init=False, default=None)
 
     def initialize_cache(self):
         """Computes and caches the sin/cos embeddings."""
@@ -197,7 +198,7 @@ class GptOssRotaryEmbedding(nnx.Module):
     rope_ntk_alpha: float = 1.0
     rope_ntk_beta: float = 32.0
 
-    def _compute_concentration_and_inv_freq(self) -> tuple[float, jax.Array]:
+    def _compute_concentration_and_inv_freq(self) -> Tuple[float, jax.Array]:
         """
         Computes the inverse frequencies and concentration factor for YaRN.
         See YaRN paper: https://arxiv.org/abs/2309.00071
@@ -231,7 +232,7 @@ class GptOssRotaryEmbedding(nnx.Module):
         return concentration, inv_freq
 
     def _compute_cos_sin(self,
-                         positions: jax.Array) -> tuple[jax.Array, jax.Array]:
+                         positions: jax.Array) -> Tuple[jax.Array, jax.Array]:
         """Computes cosine and sine embeddings for given positions."""
         concentration, inv_freq_H = self._compute_concentration_and_inv_freq()
 
@@ -246,7 +247,7 @@ class GptOssRotaryEmbedding(nnx.Module):
         return cos, sin
 
     def __call__(self, query_TNH: jax.Array, key_TNH: jax.Array,
-                 positions: jax.Array) -> tuple[jax.Array, jax.Array]:
+                 positions: jax.Array) -> Tuple[jax.Array, jax.Array]:
         """
         Applies rotary embeddings to query and key tensors.
         Args:

--- a/tpu_inference/models/jax/deepseek_v3.py
+++ b/tpu_inference/models/jax/deepseek_v3.py
@@ -317,7 +317,7 @@ class DeepSeekV3(nnx.Module):
         # we have to pass dynamic arrays here for __call__'s usage.
         self.rng = nnx.Rngs(rng)
         self.weight_loader.load_weights(self)
-        self.initialize_cache()
+        self.initialize_cache(self.mesh)
 
     def initialize_cache(self):
         # Initialize RoPE caches after weights are loaded and before JIT compilation.


### PR DESCRIPTION
# Description

Optimize RoPE part 1:
Optimize RoPE Cache to row-major to move the per-layer copy to cache initialization stage

# Tests
The 20-layer inference time is improved by 12% from [13.73ms](https://screenshot.googleplex.com/7FayENMqbNPmgM4) to [12.55ms](https://screenshot.googleplex.com/5bgdCiwiSupWj3T), and it dramatically reduces the CPU-TPU overhead


# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
