### PR TITLE
Enable Pipeline Parallelism on Ray

### DIFF
--- a/tpu_inference/executors/ray_distributed_executor.py
+++ b/tpu_inference/executors/ray_distributed_executor.py
@@ -132,7 +132,6 @@ class RayDistributedExecutor(RayDistributedExecutorV1):
                 f"current platform {current_platform.device_name} does not "
                 "support ray.")
 
-        tp_size = self.parallel_config.tensor_parallel_size
         pp_size = self.parallel_config.pipeline_parallel_size
         placement_group_specs: List[Dict[str, float]] = []
         if pp_size == 1:
@@ -140,8 +139,9 @@ class RayDistributedExecutor(RayDistributedExecutorV1):
                 device_str: node['Resources'][device_str]
             } for node in ray.nodes()]
         else:
+            num_devices_per_pp_rank = self.vllm_config.sharding_config.total_devices
             placement_group_specs = [{
-                device_str: tp_size
+                device_str: num_devices_per_pp_rank
             } for _ in range(pp_size)]
 
         # vLLM engine is also a worker to execute model with an accelerator,


### PR DESCRIPTION
# Description

The implementation for Pipeline Parallelism are splitted into the following small PRs.

- [ ] Util functions for PP on Jax (https://github.com/vllm-project/tpu-inference/pull/1042)
- [ ] worker changes (https://github.com/vllm-project/tpu-inference/pull/1043)
- [ ] runner changes (https://github.com/vllm-project/tpu-inference/pull/1053)
- [ ] platform changes (https://github.com/vllm-project/tpu-inference/pull/1054)
- [ ] torchax changes (https://github.com/vllm-project/tpu-inference/pull/1055)
- [ ] Jax changes (https://github.com/vllm-project/tpu-inference/pull/1077)
- [ ] Single host changes (https://github.com/vllm-project/vllm/pull/28506)
- [x] Multi host changes (The current PR)

This PR is to enable PP on Ray path.
- The previous behavior of tpu_inference's Ray is to start #num_hosts of ray workers, each worker controls all the devices on that host. The new behavior is to start #PP ray workers, each of the worker controls #TP number of workers.

# Tests

 E2E test has verified the whole PP implementation works properly.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
