### PR TITLE
[CI] fix bug from RoPE

### DIFF
--- a/tpu_inference/models/jax/deepseek_v3.py
+++ b/tpu_inference/models/jax/deepseek_v3.py
@@ -317,14 +317,14 @@ class DeepSeekV3(nnx.Module):
         # we have to pass dynamic arrays here for __call__'s usage.
         self.rng = nnx.Rngs(rng)
         self.weight_loader.load_weights(self)
-        self.initialize_cache(self.mesh)
+        self.initialize_cache()
 
     def initialize_cache(self):
         # Initialize RoPE caches after weights are loaded and before JIT compilation.
         for layer in self.layers:
             if hasattr(layer, 'attn') and hasattr(layer.attn, 'rope'):
                 if hasattr(layer.attn.rope, 'initialize_cache'):
-                    layer.attn.rope.initialize_cache()
+                    layer.attn.rope.initialize_cache(self.mesh)
 
     def __call__(
         self,


### PR DESCRIPTION
# Description

Fix a bug from calling initialization of RoPE in DeepSeek

# Tests
 tested with command:
 VLLM_MLA_DISABLE=1 NEW_MODEL_DESIGN=True TPU_BACKEND_TYPE=jax vllm serve --model=deepseek-ai/DeepSeek-R1 --max-model-len=5120 --max-num-batched-tokens 128 --max-num-seqs=128 --no-enable-prefix-caching --disable-log-requests --gpu-memory-utilization 0.7 --tensor-parallel-size 8 --additional_config='{"sparse_matmul": "True", "skip_quantization": true}' --load-format dummy


# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
