### PR TITLE
Refactor(nnx): Remove Redundant FFW Call in SharedExpertsTransformerBlock

### DIFF
--- a/tpu_inference/layers/jax/transformer_block.py
+++ b/tpu_inference/layers/jax/transformer_block.py
@@ -88,7 +88,6 @@ class SharedExpertsTransformerBlock(TransformerBlock):
 
         if isinstance(self.custom_module, DenseFFW):
             dense_layer = self.custom_module
-            logits_TD = self.custom_module(normed_ffw_input_TD)
         else:
             dense_layer = self.dense_ffw
 


### PR DESCRIPTION
# Description

This PR removes a redundant calculation of `logits_TD` within the `SharedExpertsTransformerBlock.__call__` method.

The problem was identified in the flow control logic for the FFW block:

```python
if isinstance(self.custom_module, DenseFFW):
    dense_layer = self.custom_module
    # Redundant call: This call was immediately overwritten later.
    logits_TD = self.custom_module(normed_ffw_input_TD) 
else:
    dense_layer = self.dense_ffw
```

# Tests

N/A

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
