### PR TITLE
[CI] Fix head dim check

### DIFF
--- a/tests/models/jax/test_llama3.py
+++ b/tests/models/jax/test_llama3.py
@@ -107,15 +107,14 @@ class TestLlamaForCausalLM:
         num_heads = hf_config.num_attention_heads
         num_kv_heads = hf_config.num_key_value_heads
         rope_theta = hf_config.rope_theta
-        original_head_dim = hf_config.head_dim
-        head_dim = 128
+        head_dim = hf_config.head_dim
         intermediate_size = hf_config.intermediate_size
 
         assert attn.hidden_size == hidden_size
         assert attn.num_heads == num_heads
         assert attn.num_kv_heads == num_kv_heads
         assert attn.rope_theta == rope_theta
-        assert attn.head_dim_original == original_head_dim
+        assert attn.head_dim_original == head_dim
         assert attn.head_dim == head_dim
         assert attn.q_proj.kernel.shape == (hidden_size, num_heads, head_dim)
         assert attn.k_proj.kernel.shape == (hidden_size, num_kv_heads,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -159,7 +159,7 @@ def test_hbm_usage_bytes_pathways_no_arrays(mock_devices, mock_live_arrays):
     "head_dim, expected_padded_head_dim",
     [
         (1, 128),
-        (64, 128),
+        (64, 64),
         (127, 128),
         (128, 128),
         (129, 256),


### PR DESCRIPTION
# Description

Fix unit test failure observed in https://buildkite.com/tpu-commons/tpu-inference-ci/builds/5307#019a7c0c-1ede-4519-a1be-4e76947ef49d

Caused by change in how padding works in https://github.com/vllm-project/tpu-inference/pull/1064

# Tests

pytest -v -s tests/models/jax/test_llama3.py

https://buildkite.com/tpu-commons/tpu-inference-ci/builds/5324

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
