### PR TITLE
Add email alerts for nightly and torch pipelines

### DIFF
--- a/.buildkite/main.yml
+++ b/.buildkite/main.yml
@@ -3,7 +3,7 @@ x-run-condition: &run-on-nightly-or-tag
 
 notify:
   - email: "ullm-oncall@rotations.google.com"
-    if: build.state == "failed" && build.branch == "main"
+    if: build.state == "failed"
 
 steps:
    - label: "Upload Tests for Models & Features"

--- a/.buildkite/nightly_releases.yml
+++ b/.buildkite/nightly_releases.yml
@@ -1,3 +1,7 @@
+notify:
+  - email: "ullm-oncall@rotations.google.com"
+    if: build.state == "failed"
+
 steps:
   - label: "Publish vllm/vllm-tpu nightly image"
     if: build.env("NIGHTLY") == "1"


### PR DESCRIPTION
# Description

Follow up to https://github.com/vllm-project/tpu-inference/pull/1030

Add email alerts for other pipelines, for nightly builds we shouldn't need branch conditionals.

FIXES: b/457722422

# Tests

Tested by presubmit tests and validating that email is sent

