### PR TITLE
Change from email to slack notifications on vllm#tpu-ci-notifications

### DIFF
--- a/.buildkite/main.yml
+++ b/.buildkite/main.yml
@@ -2,7 +2,7 @@ x-run-condition: &run-on-nightly-or-tag
   if: build.env("NIGHTLY") == "1" || build.tag =~ /^v?[0-9]+(\.[a-zA-Z0-9]+)*([a-zA-Z]+[0-9]*)?$/
 
 notify:
-  - email: "buganizer-system+1445761+p1@google.com"
+  - slack: "vllm#tpu-ci-notifications"
     if: build.state == "failed"
 
 steps:

--- a/.buildkite/nightly_releases.yml
+++ b/.buildkite/nightly_releases.yml
@@ -1,5 +1,5 @@
 notify:
-  - email: "buganizer-system+1445761+p1@google.com"
+  - slack: "vllm#tpu-ci-notifications"
     if: build.state == "failed"
 
 steps:

--- a/.buildkite/pipeline_jax.yml
+++ b/.buildkite/pipeline_jax.yml
@@ -1,5 +1,5 @@
 notify:
-  - email: "buganizer-system+1445761+p1@google.com"
+  - slack: "vllm#tpu-ci-notifications"
     if: build.state == "failed" && build.branch == "main"
 
 steps:


### PR DESCRIPTION
# Description

Seems like emailing the oncaller without paging isn't well supported for external emails. Using slack notifications at https://vllm-dev.slack.com/archives/C0974AD2PCL instead (vllm#tpu-ci-notifications). 

# Tests

Tested in https://buildkite.com/tpu-commons/tpu-inference-ci/builds/5529/steps/canvas that notifications were sent

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
