### PR TITLE
Update ray test with new sharding config

### DIFF
--- a/tests/executors/test_ray_distributed_executor.py
+++ b/tests/executors/test_ray_distributed_executor.py
@@ -15,6 +15,9 @@ class MockVllmConfig:
         self.parallel_config.placement_group = None
         self.parallel_config.max_parallel_loading_workers = None
 
+        self.sharding_config = MagicMock()
+        self.sharding_config.total_devices = 2
+
         self.model_config = MagicMock()
         self.cache_config = MagicMock()
         self.lora_config = MagicMock()
@@ -127,6 +130,8 @@ class TestTpuRayDistributedExecutor(unittest.TestCase):
         }
 
         executor = self.RayDistributedExecutor(self.vllm_config)
+        executor.vllm_config = self.vllm_config
+        executor.parallel_config = self.vllm_config.parallel_config
 
         # --- Test and Assert ---
         with self.assertRaisesRegex(ValueError,

--- a/tpu_inference/executors/ray_distributed_executor.py
+++ b/tpu_inference/executors/ray_distributed_executor.py
@@ -352,7 +352,7 @@ class RayDistributedExecutor(RayDistributedExecutorV1):
         self.collective_rpc("init_worker", args=(all_kwargs, ))
         self.collective_rpc("init_device")
         if self.parallel_config.pipeline_parallel_size > 1:
-            self._run_workers("initialize_pp_transfer_connect")
+            self.collective_rpc("initialize_pp_transfer_connect")
         self.collective_rpc("load_model")
 
         if self.use_ray_spmd_worker:


### PR DESCRIPTION
# Description

Update ray test to use sharding_config, avoid `AttributeError: 'MockVllmConfig' object has no attribute 'sharding_config'` error.

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
