### PR TITLE
Skip size calculation during async copy wait=True

### DIFF
--- a/tpu_inference/kernels/ragged_paged_attention/v3/kernel.py
+++ b/tpu_inference/kernels/ragged_paged_attention/v3/kernel.py
@@ -576,21 +576,12 @@ def _ragged_paged_attention_kernel(
         debug_print("[RPA debug] q_end={}", q_end)
         debug_print("[RPA debug] sz={}", sz)
 
-        if not wait:
-            _async_copy(
-                q_hbm_ref.at[:, pl.ds(q_len_start, sz)],
-                vmem_ref.at[:, pl.ds(0, sz)],
-                sem,
-                wait,
-            )
-        else:
-            dst = vmem_ref.at[:, pl.ds(0, sz)]
-            _async_copy(
-                dst,
-                dst,
-                sem,
-                wait,
-            )
+        _async_copy(
+            q_hbm_ref.at[:, pl.ds(q_len_start, sz)],
+            vmem_ref.at[:, pl.ds(0, sz)],
+            sem,
+            wait,
+        )
 
     def _send_bo(seq_idx, bo_idx, bo_sem_idx, *, wait=False):
         sem = sems.at[2, bo_sem_idx]
@@ -609,21 +600,12 @@ def _ragged_paged_attention_kernel(
         debug_print("[RPA debug] q_end={}", q_end)
         debug_print("[RPA debug] sz={}", sz)
 
-        if not wait:
-            _async_copy(
-                vmem_ref.at[:, pl.ds(0, sz)],
-                o_hbm_ref.at[:, pl.ds(q_len_start, sz)],
-                sem,
-                wait,
-            )
-        else:
-            dst = o_hbm_ref.at[:, pl.ds(q_len_start, sz)]
-            _async_copy(
-                dst,
-                dst,
-                sem,
-                wait,
-            )
+        _async_copy(
+            vmem_ref.at[:, pl.ds(0, sz)],
+            o_hbm_ref.at[:, pl.ds(q_len_start, sz)],
+            sem,
+            wait,
+        )
 
     def start_fetch_bkv(seq_idx, bkv_idx, bkv_sem_idx):
         return _fetch_bkv(seq_idx, bkv_idx, bkv_sem_idx)

--- a/tpu_inference/kernels/ragged_paged_attention/v3/kernel_hd64.py
+++ b/tpu_inference/kernels/ragged_paged_attention/v3/kernel_hd64.py
@@ -611,21 +611,12 @@ def _ragged_paged_attention_kernel(
         debug_print("[RPA debug] q_end={}", q_end)
         debug_print("[RPA debug] sz={}", sz)
 
-        if not wait:
-            _async_copy(
-                q_hbm_ref.at[:, pl.ds(q_len_start, sz)],
-                vmem_ref.at[:, pl.ds(0, sz)],
-                sem,
-                wait,
-            )
-        else:
-            dst = vmem_ref.at[:, pl.ds(0, sz)]
-            _async_copy(
-                dst,
-                dst,
-                sem,
-                wait,
-            )
+        _async_copy(
+            q_hbm_ref.at[:, pl.ds(q_len_start, sz)],
+            vmem_ref.at[:, pl.ds(0, sz)],
+            sem,
+            wait,
+        )
 
     def _send_bo(seq_idx, bo_idx, bo_sem_idx, *, wait=False):
         sem = sems.at[2, bo_sem_idx]
@@ -644,21 +635,12 @@ def _ragged_paged_attention_kernel(
         debug_print("[RPA debug] q_end={}", q_end)
         debug_print("[RPA debug] sz={}", sz)
 
-        if not wait:
-            _async_copy(
-                vmem_ref.at[:, pl.ds(0, sz)],
-                o_hbm_ref.at[:, pl.ds(q_len_start, sz)],
-                sem,
-                wait,
-            )
-        else:
-            dst = o_hbm_ref.at[:, pl.ds(0, sz)]
-            _async_copy(
-                dst,
-                dst,
-                sem,
-                wait,
-            )
+        _async_copy(
+            vmem_ref.at[:, pl.ds(0, sz)],
+            o_hbm_ref.at[:, pl.ds(q_len_start, sz)],
+            sem,
+            wait,
+        )
 
     def start_fetch_bkv(seq_idx, bkv_idx, bkv_sem_idx):
         return _fetch_bkv(seq_idx, bkv_idx, bkv_sem_idx)


### PR DESCRIPTION
Thanks to @bythew3i (Jevin) for providing the insight for the optimization. This is to skip size computation during DMA wait.

I have ran both kernel's test and brought up e2e vllm server to test.
The throughput improves around 5%-10%:
token throughput raise from 892/s to 974/s

Signed-off-by: Rupeng Liu rupengliu@meta.com

# Description

Start with a short description of what the PR does and how this is a change from
the past.

The rest of the description includes relevant details and context, examples:
- why is this change being made,
- the problem being solved and any relevant context,
- why this is a good solution,
- some information about the specific implementation,
- shortcomings of the solution and possible future improvements.

If the change fixes a bug or a Github issue, please include a link, e.g.,:
FIXES: b/123456
FIXES: #123456

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
