### PR TITLE
Revert vllm weight loading to fix OOM

### DIFF
--- a/tpu_inference/models/vllm/vllm_model_wrapper.py
+++ b/tpu_inference/models/vllm/vllm_model_wrapper.py
@@ -120,8 +120,7 @@ class VllmModelWrapper:
 
         # Load the vLLM model and wrap it into a new model whose forward
         # function can calculate the hidden_state and logits.
-        available_devices = self.mesh.devices.flatten()
-        with load_context, jax.default_device(available_devices[0]):
+        with load_context, jax.default_device(jax.devices("cpu")[0]):
             vllm_model = vllm_get_model(vllm_config=vllm_config_for_load)
         lora_manager = None
         if vllm_config_for_load.lora_config is not None:


### PR DESCRIPTION
# Description


Previously, we haved added following PR to optimize weight loading
- https://github.com/vllm-project/tpu-inference/pull/789


However, following PRs introduced a change where a weight is loaded into tpu instead cpu.
- https://github.com/vllm-project/tpu-inference/pull/1052 
- https://github.com/vllm-project/tpu-inference/pull/1116

As observed in following issue, this causes an OOM during weight loading
- https://github.com/vllm-project/tpu-inference/issues/1104

This is because we load a full unsharded weight into the first TPU and then shard it along multiple TPUs as a next step.

Meaning if a single unsharded weight is sufficiently large enough, it can cause OOM.

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
