### PR TITLE
add uses_sampler to ray executor

### DIFF
--- a/tests/executors/test_ray_distributed_executor.py
+++ b/tests/executors/test_ray_distributed_executor.py
@@ -27,6 +27,7 @@ class MockVllmConfig:
         self.prompt_adapter_config = MagicMock()
         self.observability_config = MagicMock()
         self.device_config = MagicMock()
+        self.ec_transfer_config = MagicMock()
 
 
 @patch(

--- a/tpu_inference/executors/ray_distributed_executor.py
+++ b/tpu_inference/executors/ray_distributed_executor.py
@@ -108,6 +108,9 @@ class RayDistributedExecutor(RayDistributedExecutorV1):
             ip_port = self.collective_rpc("get_node_kv_ip_port")
             for item in ip_port:
                 set_node_kv_ip_port(item)
+        self.uses_sampler = self.vllm_config.model_config.runner_type != "pooling" and (
+            self.vllm_config.ec_transfer_config is None
+            or not self.vllm_config.ec_transfer_config.is_ec_producer)
 
     def _initialize_ray_cluster(self) -> None:
         """Initialize the distributed cluster with Ray.


### PR DESCRIPTION
# Description

Fix ray executor's `init_executor` method to match its parent class in vLLM.

# Tests

- unit test test_ray_distributed_executor.py passed
- E2E test passed

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
