### PR TITLE
Use FP8_e5m2 automatically when using quantized kv cache FP8 on trillium

### DIFF
--- a/tpu_inference/platforms/tpu_platform.py
+++ b/tpu_inference/platforms/tpu_platform.py
@@ -3,6 +3,7 @@
 from typing import TYPE_CHECKING, Any, Optional, Tuple, Union, cast
 
 import jax.numpy as jnp
+import torch
 import vllm.envs as vllm_envs
 from torchax.ops.mappings import j2t_dtype
 from tpu_info import device
@@ -83,6 +84,14 @@ class TpuPlatform(Platform):
             return 'TPU'
 
     @classmethod
+    def fp8_dtype(cls) -> torch.dtype:
+        if cls.get_device_name().lower() == "tpu v6e":
+            logger.info(
+                "Automatically using fp8_e5m2 for FP8 KV cache on TPU v6e.")
+            return torch.float8_e5m2
+        return torch.float8_e4m3fn
+
+    @classmethod
     def get_device_total_memory(cls, device_id: int = 0) -> int:
         raise NotImplementedError
 
@@ -132,12 +141,6 @@ class TpuPlatform(Platform):
         # For v0, the default block size is 16.
         if cache_config and cache_config.block_size is None:
             cache_config.block_size = cast(BlockSize, 16)
-
-        if cache_config and cache_config.cache_dtype == "fp8" and cls.get_device_name(
-        ) == "TPU v6e":
-            logger.info(
-                "Automatically using fp8_e5m2 for FP8 KV cache on TPU v6e.")
-            cache_config.cache_dtype = "fp8_e5m2"
 
         compilation_config = vllm_config.compilation_config
 


### PR DESCRIPTION
# Description

Implement changes described in https://github.com/vllm-project/tpu-inference/issues/1112 to use FP8_e5m2 automatically when using quantized kv cache FP8 on trillium. 

# Tests
- unit test
```
(tpu-inference) qizixi@t1v-n-00a74f4e-w-0:~/tpu-inference$ pytest tests/platforms/test_tpu_platform.py
======================================================== test session starts ========================================================
platform linux -- Python 3.12.12, pytest-9.0.1, pluggy-1.6.0
rootdir: /home/qizixi/tpu-inference
configfile: pyproject.toml
plugins: anyio-4.11.0, mock-3.15.1, jaxtyping-0.3.3
collected 2 items                                                                                                                   

tests/platforms/test_tpu_platform.py ..                                                                                       [100%]

========================================================= warnings summary ==========================================================
.venv/lib/python3.12/site-packages/tpu_info/device.py:32
  /home/qizixi/tpu-inference/.venv/lib/python3.12/site-packages/tpu_info/device.py:32: DeprecationWarning: In 3.13 classes created inside an enum will not become a member.  Use the `member` decorator to keep the current behavior.
    class Info(typing.NamedTuple):

<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyPacked has no __module__ attribute

<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyObject has no __module__ attribute

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=================================================== 2 passed, 3 warnings in 4.30s ===================================================
(tpu-
```

- e2e test is blocked by a kernel issue since it appears that FP8 KV is not supported (same error happens with or without this change)

```
vllm bench throughput --model meta-llama/Llama-3.1-8B --tensor-parallel-size 1 --dtype bfloat16 --kv-cache-dtype fp8 --max-model-len 4096 --max-num-seqs 128 --num-prompts 100 --dataset-name random --input-len 1024 --output-len 100

(EngineCore_DP0 pid=331491)   File "/home/qizixi/tpu-inference/.venv/lib/python3.12/site-packages/jax/_src/pallas/mosaic/lowering.py", line 2225, in _convert_element_type_lowering_rule
(EngineCore_DP0 pid=331491)     return lower_fun(functools.partial(_convert_helper, to_dtype=new_dtype),
(EngineCore_DP0 pid=331491)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=331491)   File "/home/qizixi/tpu-inference/.venv/lib/python3.12/site-packages/jax/_src/pallas/mosaic/lowering.py", line 1077, in f_lowered
(EngineCore_DP0 pid=331491)     out = jaxpr_subcomp(lowering_context, jaxpr, *consts, *args)
(EngineCore_DP0 pid=331491)           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=331491)   File "/home/qizixi/tpu-inference/.venv/lib/python3.12/site-packages/jax/_src/pallas/mosaic/lowering.py", line 1178, in jaxpr_subcomp
(EngineCore_DP0 pid=331491)     raise
(EngineCore_DP0 pid=331491)   File "/home/qizixi/tpu-inference/.venv/lib/python3.12/site-packages/jax/_src/pallas/mosaic/lowering.py", line 2208, in _convert_element_type_lowering_rule
(EngineCore_DP0 pid=331491)     raise NotImplementedError(f"Unsupported cast: {old_dtype} -> {new_dtype}")
(EngineCore_DP0 pid=331491) NotImplementedError: Unsupported cast: uint16 -> uint32
```

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
