### PR TITLE
[Llama4/Test] Add unit test for _get_expert_num in Llama4WeightLoader

### DIFF
--- a/tests/models/jax/test_llama4.py
+++ b/tests/models/jax/test_llama4.py
@@ -180,11 +180,14 @@ class TestLlama4WeightLoader:
     def test_get_layer_num(self, weight_loader, hf_key, expected_num):
         """Tests the private _get_layer_num utility function."""
         assert weight_loader._get_layer_num(hf_key) == expected_num
-    
+
     @pytest.mark.parametrize("hf_key, expected_num", [
-        ("language_model.model.layers.10.feed_forward.experts.4.down_proj.weight", 4),
-        ("language_model.model.layers.0.feed_forward.experts.0.gate_proj.weight_scale", 0),
-        ("language_model.model.layers.5.feed_forward.experts.128.up_proj.weight", 128),
+        ("language_model.model.layers.10.feed_forward.experts.4.down_proj.weight",
+         4),
+        ("language_model.model.layers.0.feed_forward.experts.0.gate_proj.weight_scale",
+         0),
+        ("language_model.model.layers.5.feed_forward.experts.128.up_proj.weight",
+         128),
         ("language_model.model.norm.weight", None),
         ("language_model.model.layers.15.self_attn.q_proj.weight", None),
     ])


### PR DESCRIPTION
# Description

This PR introduces a dedicated unit test, test_get_expert_num, to the Llama4WeightLoader test suite (test_llama4.py).

The Llama4WeightLoader relies on the private utility method _get_expert_num to correctly parse the expert index from HuggingFace checkpoint keys. This is critical for the logic that aggregates unfused MoE expert weights (common in quantized checkpoints) from the weight buffer before loading them into the model.

# Tests

pytest tests/models/jax/test_llama4.py

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
