### PR TITLE
Extend feature support matrix to track out-of-tree and sampling features

### DIFF
--- a/.buildkite/features/Optimized_Runtime_Sampling.yml
+++ b/.buildkite/features/Optimized_Runtime_Sampling.yml
@@ -1,0 +1,45 @@
+# Optimized Runtime Sampling (top k, top p, temperature, logit output)
+# feature support matrix
+steps:
+  - label: "Correctness tests for Optimized Runtime Sampling"
+    key: "optimized_runtime_sampling_CorrectnessTest"
+    soft_fail: true
+    agents:
+      queue: tpu_v6e_queue
+    commands:
+      - |
+        buildkite-agent meta-data set "optimized_runtime_sampling_CorrectnessTest" "to be added"
+  - label: "Record correctness test result for Optimized Runtime Sampling"
+    key: "record_optimized_runtime_sampling_CorrectnessTest"
+    depends_on: "optimized_runtime_sampling_CorrectnessTest"
+    env:
+      CI_TARGET: "Optimized Runtime Sampling (top k, top p, temperature, logit output)"
+      CI_STAGE: "CorrectnessTest"
+      CI_CATEGORY: "feature support matrix"
+    agents:
+      queue: cpu
+    commands:
+      - |
+        .buildkite/scripts/record_step_result.sh optimized_runtime_sampling_CorrectnessTest
+
+  - label: "Performance tests for Optimized Runtime Sampling"
+    key: "optimized_runtime_sampling_PerformanceTest"
+    depends_on: "record_optimized_runtime_sampling_CorrectnessTest"
+    soft_fail: true
+    agents:
+      queue: tpu_v6e_queue
+    commands:
+      - |
+        buildkite-agent meta-data set "optimized_runtime_sampling_PerformanceTest" "to be added"
+  - label: "Record performance test result for Optimized Runtime Sampling"
+    key: "record_optimized_runtime_sampling_PerformanceTest"
+    depends_on: "optimized_runtime_sampling_PerformanceTest"
+    env:
+      CI_TARGET: "Optimized Runtime Sampling (top k, top p, temperature, logit output)"
+      CI_STAGE: "PerformanceTest"
+      CI_CATEGORY: "feature support matrix"
+    agents:
+      queue: cpu
+    commands:
+      - |
+        .buildkite/scripts/record_step_result.sh optimized_runtime_sampling_PerformanceTest

--- a/.buildkite/features/Out_Of_Tree_Model_Support.yml
+++ b/.buildkite/features/Out_Of_Tree_Model_Support.yml
@@ -1,0 +1,45 @@
+# Out-of-tree model support
+# feature support matrix
+steps:
+  - label: "Correctness tests for Out-of-tree model support"
+    key: "out_of_tree_model_support_CorrectnessTest"
+    soft_fail: true
+    agents:
+      queue: tpu_v6e_queue
+    commands:
+      - |
+        buildkite-agent meta-data set "out_of_tree_model_support_CorrectnessTest" "to be added"
+  - label: "Record correctness test result for Out-of-tree model support"
+    key: "record_out_of_tree_model_support_CorrectnessTest"
+    depends_on: "out_of_tree_model_support_CorrectnessTest"
+    env:
+      CI_TARGET: "Out-of-tree model support"
+      CI_STAGE: "CorrectnessTest"
+      CI_CATEGORY: "feature support matrix"
+    agents:
+      queue: cpu
+    commands:
+      - |
+        .buildkite/scripts/record_step_result.sh out_of_tree_model_support_CorrectnessTest
+
+  - label: "Performance tests for Out-of-tree model support"
+    key: "out_of_tree_model_support_PerformanceTest"
+    depends_on: "record_out_of_tree_model_support_CorrectnessTest"
+    soft_fail: true
+    agents:
+      queue: tpu_v6e_queue
+    commands:
+      - |
+        buildkite-agent meta-data set "out_of_tree_model_support_PerformanceTest" "to be added"
+  - label: "Record performance test result for Out-of-tree model support"
+    key: "record_out_of_tree_model_support_PerformanceTest"
+    depends_on: "out_of_tree_model_support_PerformanceTest"
+    env:
+      CI_TARGET: "Out-of-tree model support"
+      CI_STAGE: "PerformanceTest"
+      CI_CATEGORY: "feature support matrix"
+    agents:
+      queue: cpu
+    commands:
+      - |
+        .buildkite/scripts/record_step_result.sh out_of_tree_model_support_PerformanceTest

--- a/docs/recommended_models_features.md
+++ b/docs/recommended_models_features.md
@@ -22,3 +22,5 @@ These tables show the models currently tested for accuracy and performance.
 ## Recommended Features
 
 This table shows the features currently tested for accuracy and performance.
+
+{{ read_csv('../support_matrices/feature_support_matrix.csv', keep_default_na=False) }}


### PR DESCRIPTION
# Description

Extend feature support matrix to track out-of-tree and sampling features

# Tests

[BuildKite](https://buildkite.com/tpu-commons/tpu-inference-ci/builds/5774/steps/canvas?sid=019aa411-34b4-4907-857a-dd3ad51c407a)

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
