### PR TITLE
[Model] Add vision encoder padding and warmup for Qwen2.5 VL model

### DIFF
--- a/tests/e2e/test_multi_modal_inference.py
+++ b/tests/e2e/test_multi_modal_inference.py
@@ -7,6 +7,7 @@
 import os
 from dataclasses import asdict
 
+import pytest
 from vllm import LLM, EngineArgs, SamplingParams
 from vllm.assets.image import ImageAsset
 from vllm.multimodal.image import convert_image_mode
@@ -20,7 +21,8 @@ EXPECTED_TEXT = (
 
 
 # NOTE: Could be extended to more mm models/configs as needed
-def test_multi_modal_inference(monkeypatch):
+@pytest.mark.parametrize("enable_dynamic_image_sizes", [False, True])
+def test_multi_modal_inference(monkeypatch, enable_dynamic_image_sizes):
     """
     Runs multi-modal inference and verifies the output.
     """
@@ -67,6 +69,11 @@ def test_multi_modal_inference(monkeypatch):
         limit_mm_per_prompt={modality: 1},
     )
     engine_args = asdict(engine_args)
+    if engine_args.get("additional_config") is None:
+        engine_args["additional_config"] = {}
+
+    engine_args["additional_config"][
+        "enable_dynamic_image_sizes"] = enable_dynamic_image_sizes
     llm = LLM(**engine_args)
 
     sampling_params = SamplingParams(

--- a/tests/models/jax/test_qwen2_5_vl.py
+++ b/tests/models/jax/test_qwen2_5_vl.py
@@ -346,8 +346,14 @@ class TestQwen2_5_VisionTransformer:
         expected_len = window_index_thw.shape[0] * sm * sm
         assert rotary_pos_emb_thw.shape == (expected_len, head_dim_rope)
 
-    def test_call(self, vision_transformer: Qwen2_5_VisionTransformer,
-                  rng: PRNGKey):
+    @pytest.mark.parametrize("enable_dynamic_image_sizes", [False, True])
+    def test_call(self, mock_vllm_config: MockVllmConfig, rngs: nnx.Rngs,
+                  mesh: Mesh, rng: PRNGKey, enable_dynamic_image_sizes: bool):
+        mock_vllm_config.additional_config = {
+            "enable_dynamic_image_sizes": enable_dynamic_image_sizes
+        }
+        vision_transformer = Qwen2_5_VisionTransformer(mock_vllm_config, rngs,
+                                                       mesh)
         # Mock the flash_attention call to avoid sharding errors in test environment
         for block in vision_transformer.blocks:
             # The mock should return a tensor of the same shape as the query 'q'
@@ -355,7 +361,7 @@ class TestQwen2_5_VisionTransformer:
                 side_effect=lambda q, k, v, seg: jnp.ones_like(q))
 
         vc = vision_transformer.config
-        t_pix, h_pix, w_pix = 2, 28, 28
+        t_pix, h_pix, w_pix = 2, 84, 28
 
         # The number of patches is calculated from the pixel dimensions of the image/video
         num_patches = (t_pix // vc.temporal_patch_size) * \

--- a/tpu_inference/models/jax/qwen2_5_vl.py
+++ b/tpu_inference/models/jax/qwen2_5_vl.py
@@ -488,8 +488,8 @@ class Qwen2_5_VisionTransformer(nnx.Module):
 
         additional_config = getattr(vllm_config, "additional_config",
                                     None) or {}
-        self.enable_vision_padding = additional_config.get(
-            "enable_vision_padding", False)
+        self.enable_dynamic_image_sizes = additional_config.get(
+            "enable_dynamic_image_sizes", False)
 
     def rotary_pos_emb_thw(self, t, h, w):
         hpos_ids, wpos_ids = jnp.indices((h, w))
@@ -719,7 +719,7 @@ class Qwen2_5_VisionTransformer(nnx.Module):
         # """Shape: `(num_images, 3)`
         # This should be in `(grid_t, grid_h, grid_w)` format.
         # """
-        if self.enable_vision_padding:
+        if self.enable_dynamic_image_sizes:
             window_index, rotary_pos_emb, cu_seqlens, cu_window_seqlens = self.compute_aux_arrays(
                 grid_thw)
             x_padded, window_index, rotary_pos_emb, cu_seqlens, cu_window_seqlens, num_tokens = self.pad_inputs(
@@ -1138,7 +1138,7 @@ class Qwen2_5_VLForConditionalGeneration(nnx.Module):
     ) -> None:
         vc = self.vllm_config.model_config.hf_config.vision_config
         patch_input_dim = vc.in_channels * vc.temporal_patch_size * vc.patch_size * vc.patch_size
-        if self.visual.enable_vision_padding:
+        if self.visual.enable_dynamic_image_sizes:
             spatial_merge_unit = vc.spatial_merge_size**2
             max_num_batched_tokens = self.vllm_config.scheduler_config.max_num_batched_tokens
             mm_kwargs = self.vllm_config.model_config.multimodal_config.mm_processor_kwargs or {}


### PR DESCRIPTION
# Description

Refactor the Qwen2.5 vl model vision encoder.
Add padding and warm up. Enable with `--additional_config='{"enable_vision_padding": true}'`.
Co-authored with @hfan.

# Tests

Tested with MMMU (lm-eval-harness) on 7b: 51.78%
CI: https://buildkite.com/tpu-commons/tpu-inference-ci/builds/5811
Add one extra commit to fix the unit test. Pass the test locally.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
