### PR TITLE
[FusedMoE] Support sub-channel quantization: FP4, FP8, INT8, ...

### DIFF
--- a/tests/kernels/fused_moe_v1_test.py
+++ b/tests/kernels/fused_moe_v1_test.py
@@ -125,28 +125,27 @@ class MoEKernelTest(jtu.JaxTestCase):
             w1, w1_scale = sub_channel_quantize(w1, w_dtype, subc_quant_wsz)
             w2, w2_scale = sub_channel_quantize(w2, w_dtype, subc_quant_wsz)
 
-        actual = jax.block_until_ready(
-            fused_ep_moe(
-                mesh=self.mesh,
-                tokens=a,
-                w1=w1,
-                w2=w2,
-                gating_output=gating_output,
-                top_k=top_k,
-                renormalize_topk_logits=renormalize_topk_logits,
-                act_fn=act_fn,
-                subc_quant_wsz=subc_quant_wsz,
-                w1_scale=w1_scale,
-                w2_scale=w2_scale,
-                bt=bt,
-                bf=bf,
-                bd1=bd1,
-                bd2=bd2,
-                btc=btc,
-                bfc=bfc,
-                bd1c=bd1c,
-                bd2c=bd2c,
-            ))
+        actual = fused_ep_moe(
+            mesh=self.mesh,
+            tokens=a,
+            w1=w1,
+            w2=w2,
+            gating_output=gating_output,
+            top_k=top_k,
+            renormalize_topk_logits=renormalize_topk_logits,
+            act_fn=act_fn,
+            subc_quant_wsz=subc_quant_wsz,
+            w1_scale=w1_scale,
+            w2_scale=w2_scale,
+            bt=bt,
+            bf=bf,
+            bd1=bd1,
+            bd2=bd2,
+            btc=btc,
+            bfc=bfc,
+            bd1c=bd1c,
+            bd2c=bd2c,
+        )
         expected = ref_moe(
             a,
             w1,

--- a/tpu_inference/kernels/fused_moe/v1/kernel.py
+++ b/tpu_inference/kernels/fused_moe/v1/kernel.py
@@ -535,7 +535,7 @@ def _fused_ep_moe_kernel(
                         0,
                         pl.ds(offset // subc_quant_wsz, bd1_per_t_packing //
                               subc_quant_wsz),
-                        0:1,
+                        pl.ds(0, 1),
                         pl.ds(bf_id * bf, bf),
                     ],
                     dst_ref=b_w1_scale_x2_vmem.at[bw1_sem_id, p],
@@ -561,7 +561,7 @@ def _fused_ep_moe_kernel(
                         local_e_id,
                         pl.ds(bf_id * bf // subc_quant_wsz, bf //
                               subc_quant_wsz),
-                        0:1,
+                        pl.ds(0, 1),
                         pl.ds(offset, bd2_per_t_packing),
                     ],
                     dst_ref=b_w2_scale_x2_vmem.at[bw2_sem_id, p],
@@ -589,7 +589,7 @@ def _fused_ep_moe_kernel(
                         1,
                         pl.ds(offset // subc_quant_wsz, bd1_per_t_packing //
                               subc_quant_wsz),
-                        0:1,
+                        pl.ds(0, 1),
                         pl.ds(bf_id * bf, bf),
                     ],
                     dst_ref=b_w3_scale_x2_vmem.at[bw3_sem_id, p],


### PR DESCRIPTION

TODO (will resolve in following up PRs):
* Add benchmark test for GPT-OSS
* Tune GPT-OSS FP4 MoE block size
* Debug race condition