### PR TITLE
Quick fix for kernel_hd64 tests

### DIFF
--- a/tpu_inference/kernels/ragged_paged_attention/v3/kernel_hd64.py
+++ b/tpu_inference/kernels/ragged_paged_attention/v3/kernel_hd64.py
@@ -392,6 +392,8 @@ def _ragged_paged_attention_kernel(
                   num_q_heads_per_kv_head)
         k_span = bkv_idx * bkv_sz + lax.broadcasted_iota(jnp.int32, s.shape, 1)
         mask = q_span < k_span
+        if sliding_window is not None:
+            mask = jnp.logical_or(mask, q_span - sliding_window >= k_span)
 
         if soft_cap is not None:
             s = soft_cap * jnp.tanh(s / soft_cap)


### PR DESCRIPTION
# Description
Example Scenario:
sliding_window = 5
bkv_sz = 16  (block size)
kv_len = 100
Current query position = 100
What the Block-Level Optimization Does:
bkv_idx_start = max(100 - 5, 0) // 16
              = 95 // 16  
              = 5  # Start fetching from block 5
This calculates which block to START fetching from, but look what happens:

Block 5: positions [80, 81, 82, ..., 95]   ← We fetch this block
Block 6: positions [96, 97, 98, ..., 111]  ← We fetch this block
The Problem:
Query at position 100 with sliding_window=5 should only attend to positions [96, 97, 98, 99, 100] (the last 5 positions).

But block 5 contains positions [80-95], and only position 95 is valid - positions 80-94 should be masked out!

Visualization:
Position:     80   81   82 ... 94   95 | 96   97   98   99  100
              ├────────────────────┼────┼────┬────┬────┬────┤
Block 5       │ SHOULD BE MASKED  │ OK │              
Block 6                                  │      Valid window   │
                                         └─────────────────────┘
                                         (sliding window = 5)

Start with a short description of what the PR does and how this is a change from
the past.

The rest of the description includes relevant details and context, examples:
- why is this change being made,
- the problem being solved and any relevant context,
- why this is a good solution,
- some information about the specific implementation,
- shortcomings of the solution and possible future improvements.

If the change fixes a bug or a Github issue, please include a link, e.g.,:
FIXES: b/123456
FIXES: #123456

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
