### PR TITLE
Fix lora e2e tests by removing LoRA extra vocab.

### DIFF
--- a/tpu_inference/models/vllm/vllm_model_wrapper.py
+++ b/tpu_inference/models/vllm/vllm_model_wrapper.py
@@ -269,10 +269,9 @@ def replace_set_lora(model):
         index: int,
         lora_a: torch.Tensor,
         lora_b: torch.Tensor,
-        embeddings_tensor: Optional[torch.Tensor],
     ):
         with torchax.default_env():
-            self._original_set_lora(index, lora_a, lora_b, embeddings_tensor)
+            self._original_set_lora(index, lora_a, lora_b)
 
     def _tpu_reset_lora(self, index: int):
         with torchax.default_env():


### PR DESCRIPTION
# Description

Fix lora e2e tests due to https://github.com/vllm-project/vllm/pull/28545.

# Tests

- pytest -s -vv tests/lora/test_layers.py
- VLLM_XLA_CHECK_RECOMPILATION=1  MODEL_IMPL_TYPE=vllm TPU_BACKEND_TYPE=jax  pytest -s -v  tests/lora/test_lora.py

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
