### PR TITLE
[Bug Fix] Fix `AttributeError: 'str' object has no attribute 'page_size_bytes'` issue

### DIFF
--- a/tpu_inference/worker/tpu_worker.py
+++ b/tpu_inference/worker/tpu_worker.py
@@ -402,7 +402,8 @@ class TPUWorker:
 
         # TODO(kyuyeunk): Instead of checking page_size_bytes here, introduce
         # feature that allows overriding page_size_bytes of KVCacheSpec.
-        vllm_page_size_bytes = get_uniform_page_size(kv_cache_specs)
+        vllm_page_size_bytes = get_uniform_page_size(
+            list(kv_cache_specs.values()))
         rpa_page_size_bytes = get_rpa_page_size_bytes(self.model_runner.mesh,
                                                       kv_cache_specs)
 


### PR DESCRIPTION
# Description

In this PR, I fix the following issue caused by an upstream vLLM change:

```

(EngineCore_DP0 pid=303) ERROR 11-26 03:02:31 [core.py:842]   File "/workspace/tpu_inference/tpu_inference/worker/tpu_worker.py", line 405, in get_kv_cache_spec
--
(EngineCore_DP0 pid=303) ERROR 11-26 03:02:31 [core.py:842]     vllm_page_size_bytes = get_uniform_page_size(kv_cache_specs)
(EngineCore_DP0 pid=303) ERROR 11-26 03:02:31 [core.py:842]                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=303) ERROR 11-26 03:02:31 [core.py:842]   File "/workspace/vllm/vllm/v1/core/kv_cache_utils.py", line 832, in get_uniform_page_size
(EngineCore_DP0 pid=303) ERROR 11-26 03:02:31 [core.py:842]     page_sizes = {layer.page_size_bytes for layer in kv_cache_specs}
(EngineCore_DP0 pid=303) ERROR 11-26 03:02:31 [core.py:842]                   ^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=303) ERROR 11-26 03:02:31 [core.py:842] AttributeError: 'str' object has no attribute 'page_size_bytes'



```

# Tests

Tested locally.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
