### PR TITLE
fix(rpa-v3): add sliding window mask to h64 kernel and attention_sink to h128

### DIFF
--- a/tpu_inference/kernels/ragged_paged_attention/v3/kernel_hd64.py
+++ b/tpu_inference/kernels/ragged_paged_attention/v3/kernel_hd64.py
@@ -391,7 +391,10 @@ def _ragged_paged_attention_kernel(
                   lax.broadcasted_iota(jnp.int32, s.shape, 0) //
                   num_q_heads_per_kv_head)
         k_span = bkv_idx * bkv_sz + lax.broadcasted_iota(jnp.int32, s.shape, 1)
+        
         mask = q_span < k_span
+        if sliding_window is not None:
+            mask = jnp.logical_or(mask, q_span - sliding_window >= k_span)
 
         if soft_cap is not None:
             s = soft_cap * jnp.tanh(s / soft_cap)


### PR DESCRIPTION
## Summary
Fixes #1169

This PR fixes two issues in the ragged-paged attention v3 kernels:

- **kernel_hd64.py (h64)**: Added missing sliding window mask in the kernel. The 
original code only skipped fetching KV blocks outside the window, but didn't apply 
token-level masking within partially-covered blocks.

- **kernel.py (h128)**: Added attention_sink support following the same pattern as the 
h64 kernel. Attention sinks allow the model to "dump" attention to a virtual token that 
doesn't contribute to the output.

## Changes
| File | Change |
|------|--------|
| kernel_hd64.py | Added sliding window mask in flash_attention |
| kernel.py | Added attention_sink parameter to all functions |
