### PR TITLE
Refactor moe codebase

### DIFF
--- a/tests/layers/vllm/test_mxfp4.py
+++ b/tests/layers/vllm/test_mxfp4.py
@@ -231,7 +231,7 @@ def test_mxfp4_fused_moe_use_kernel(mesh, num_tokens, intermediate_size,
     vllm_config = engine_args.create_engine_config()
     vllm_config.model_config.dtype = dtype
     vllm_config.parallel_config = ParallelConfig(
-        tensor_parallel_size=mesh.devices.size, enable_expert_paralle=True)
+        tensor_parallel_size=mesh.devices.size)
 
     quant_config = get_tpu_quantization_config(vllm_config, mesh)
     with set_current_vllm_config(vllm_config):
@@ -247,6 +247,8 @@ def test_mxfp4_fused_moe_use_kernel(mesh, num_tokens, intermediate_size,
             quant_config=quant_config,
             has_bias=True,
         )
+        vllm_fused_moe.moe_parallel_config.use_ep = True
+
     vllm_fused_moe.w13_weight.data = w1_weight
     vllm_fused_moe.w2_weight.data = w2_weight
     vllm_fused_moe.w13_weight_scale.data = w1_weight_scale

--- a/tests/layers/vllm/test_unquantized.py
+++ b/tests/layers/vllm/test_unquantized.py
@@ -444,7 +444,6 @@ def test_fused_moe(use_ep, mesh, num_tokens, intermediate_size, hidden_size,
     )
     vllm_config = engine_args.create_engine_config()
     vllm_config.model_config.dtype = dtype
-    vllm_config.parallel_config = ParallelConfig(enable_expert_paralle=use_ep)
 
     quant_config = get_tpu_quantization_config(vllm_config, mesh)
     with set_current_vllm_config(vllm_config):
@@ -459,6 +458,7 @@ def test_fused_moe(use_ep, mesh, num_tokens, intermediate_size, hidden_size,
             dp_size=1,
             quant_config=quant_config,
         )
+        vllm_fused_moe.moe_parallel_config.use_ep = use_ep
     vllm_fused_moe.w13_weight.data = w1
     vllm_fused_moe.w2_weight.data = w2
 
@@ -678,7 +678,7 @@ def test_fused_moe_use_kernel(mesh, num_tokens, intermediate_size, hidden_size,
     vllm_config = engine_args.create_engine_config()
     vllm_config.model_config.dtype = dtype
     vllm_config.parallel_config = ParallelConfig(
-        tensor_parallel_size=mesh.devices.size, enable_expert_paralle=True)
+        tensor_parallel_size=mesh.devices.size)
 
     quant_config = get_tpu_quantization_config(vllm_config, mesh)
     with set_current_vllm_config(vllm_config):

--- a/tpu_inference/layers/vllm/quantization/mxfp4.py
+++ b/tpu_inference/layers/vllm/quantization/mxfp4.py
@@ -28,7 +28,7 @@ from tpu_inference import envs
 from tpu_inference.kernels.fused_moe.v1.kernel import fused_ep_moe
 from tpu_inference.layers.common.quant_methods import (MXFP4,
                                                        get_tpu_quant_method)
-from tpu_inference.layers.vllm.fused_moe import fused_moe_func_padded
+from tpu_inference.layers.vllm.fused_moe import fused_moe_func
 from tpu_inference.layers.vllm.linear_common import \
     reorder_concatenated_tensor_for_sharding
 from tpu_inference.layers.vllm.quantization.common import JaxCommonConfig
@@ -87,9 +87,6 @@ class VllmMxfp4Config(Mxfp4Config, JaxCommonConfig):
                     fused_mapping=self.packed_modules_mapping,
             ):
                 return VllmUnquantizedLinearMethod(linear_config)
-            # TODO: Add support for MXFP4 Linear Method.
-            # MXFP4 LinearMethod is available in AMD-Quark, refer to that
-            # implementation if you are interested in enabling MXFP4 here.
             logger.warning_once(
                 "MXFP4 linear layer is not implemented - falling back to "
                 "UnquantizedLinearMethod.")
@@ -98,7 +95,6 @@ class VllmMxfp4Config(Mxfp4Config, JaxCommonConfig):
             moe_config = self.get_moe_config(layer)
             return VllmMxfp4MoEMethod(moe_config, self.mesh)
         elif isinstance(layer, Attention):
-            # TODO: Add support for MXFP4 Attention.
             logger.warning_once("MXFP4 attention layer is not implemented. "
                                 "Skipping quantization for this layer.")
         return None
@@ -117,7 +113,7 @@ class VllmMxfp4MoEMethod(Mxfp4MoEMethod):
         self.mxfp4_backend = Mxfp4Backend.TRITON
 
         self.mesh = mesh
-        self.use_kernel = envs.USE_MOE_EP_KERNEL
+        self.use_kernel = envs.USE_MOE_EP_KERNEL and moe.use_ep
         self.ep_axis_name = ep_axis_name
         # TODO: Use autotune table once we have it.
         self.block_size = {
@@ -161,6 +157,8 @@ class VllmMxfp4MoEMethod(Mxfp4MoEMethod):
         w2_weight = dequantize_block_weight(w2_weight, w2_weight_scale,
                                             MXFP4_BLOCK_SIZE, jnp.bfloat16)
 
+        num_experts, hidden_size, intermediate_size = w2_weight.shape
+
         # Because we have dequantized weights, scales are not used anymore.
         delattr(layer, "w13_weight_scale")
         delattr(layer, "w2_weight_scale")
@@ -178,76 +176,60 @@ class VllmMxfp4MoEMethod(Mxfp4MoEMethod):
             w3_bias = w13_bias[:, 1::2]
             w13_bias = jnp.concat([w1_bias, w3_bias], axis=1)
 
-        if self.use_kernel and layer.use_ep:
+        if self.use_kernel:
             # Kernel expects:
             # w13: (num_experts, 2, hidden_size, intermediate_size)
             # w2: (num_experts, intermediate_size, hidden_size)
             # Current format:
             # w13_weight: (num_experts, 2*intermediate_size, hidden_size)
             # w2_weight: (num_experts, hidden_size, intermediate_size)
-            num_experts = w13_weight.shape[0]
-            intermediate_size = w13_weight.shape[1] // 2
-            hidden_size = w13_weight.shape[2]
 
-            # Reshape and transpose w13_weight to (num_experts, 2, hidden_size, intermediate_size)
             w13_reshaped = w13_weight.reshape(num_experts, 2,
                                               intermediate_size, hidden_size)
-            w13_weight_transposed = jnp.transpose(w13_reshaped, (0, 1, 3, 2))
 
-            # Transpose w2_weight to (num_experts, intermediate_size, hidden_size)
-            w2_weight_transposed = jnp.transpose(w2_weight, (0, 2, 1))
+            # Transpose non-constracting dim to right most dim
+            w13_weight_transposed = jnp.swapaxes(w13_reshaped, 2, 3)
+            w2_weight_transposed = jnp.swapaxes(w2_weight, 1, 2)
 
             # Apply EP sharding
+            ep_sharding = NamedSharding(self.mesh, P("model"))
+
             w13_weight = jax.device_put(
-                w13_weight_transposed,
-                Format(Layout((0, 1, 2, 3)),
-                       NamedSharding(self.mesh, P("model", None, None, None))))
-            w2_weight = jax.device_put(
-                w2_weight_transposed,
-                Format(Layout((0, 1, 2)),
-                       NamedSharding(self.mesh, P("model", None, None))))
+                w13_weight_transposed, Format(Layout((0, 1, 2, 3)),
+                                              ep_sharding))
+            w2_weight = jax.device_put(w2_weight_transposed,
+                                       Format(Layout((0, 1, 2)), ep_sharding))
 
-            if self.moe.has_bias:
-                w13_bias = w13_bias.reshape(num_experts, 2, intermediate_size)
-
-                # Apply EP sharding
-                w13_bias = jax.device_put(
-                    w13_bias,
-                    Format(Layout((0, 1, 2)),
-                           NamedSharding(self.mesh, P("model", None, None))))
-                w2_bias = jax.device_put(
-                    w2_bias,
-                    Format(Layout((0, 1)),
-                           NamedSharding(self.mesh, P("model", None))))
+            w13_bias = w13_bias.reshape(num_experts, 2, intermediate_size)
+            w13_bias = jax.device_put(w13_bias,
+                                      Format(Layout((0, 1, 2)), ep_sharding))
+            w2_bias = jax.device_put(w2_bias,
+                                     Format(Layout((0, 1)), ep_sharding))
 
         else:
             if layer.use_ep:
+                ep_sharding = NamedSharding(self.mesh, P("model"))
                 w13_weight = jax.device_put(
-                    w13_weight,
-                    Format(Layout((0, 1, 2)),
-                           NamedSharding(self.mesh, P("model", None, None))))
+                    w13_weight, Format(Layout((0, 1, 2)), ep_sharding))
                 w2_weight = jax.device_put(
-                    w2_weight,
-                    Format(Layout((0, 1, 2)),
-                           NamedSharding(self.mesh, P("model", None, None))))
+                    w2_weight, Format(Layout((0, 1, 2)), ep_sharding))
 
-                w13_bias = jax.device_put(
-                    w13_bias,
-                    Format(Layout((0, 1)),
-                           NamedSharding(self.mesh, P("model", None))))
-                w2_bias = jax.device_put(
-                    w2_bias,
-                    Format(Layout((0, 1)),
-                           NamedSharding(self.mesh, P("model", None))))
+                w13_bias = jax.device_put(w13_bias,
+                                          Format(Layout((0, 1)), ep_sharding))
+                w2_bias = jax.device_put(w2_bias,
+                                         Format(Layout((0, 1)), ep_sharding))
 
             else:
-                intermediate_size = w13_weight.shape[1] // 2
-                assert intermediate_size == w2_weight.shape[-1]
                 output_sizes = [intermediate_size, intermediate_size]
                 n_shards = self.mesh.shape["model"]
                 assert intermediate_size % n_shards == 0
+
                 w13_weight = reorder_concatenated_tensor_for_sharding(
-                    w13_weight, output_sizes, n_shards, dim=1)
+                    w13_weight,
+                    output_sizes,
+                    n_shards,
+                    dim=1,
+                )
                 w13_weight = jax.device_put(
                     w13_weight,
                     Format(Layout((0, 1, 2)),
@@ -258,7 +240,11 @@ class VllmMxfp4MoEMethod(Mxfp4MoEMethod):
                            NamedSharding(self.mesh, P(None, None, "model"))))
 
                 w13_bias = reorder_concatenated_tensor_for_sharding(
-                    w13_bias, output_sizes, n_shards, dim=1)
+                    w13_bias,
+                    output_sizes,
+                    n_shards,
+                    dim=1,
+                )
                 w13_bias = jax.device_put(
                     w13_bias,
                     Format(Layout((0, 1)),
@@ -270,9 +256,9 @@ class VllmMxfp4MoEMethod(Mxfp4MoEMethod):
 
         layer.w13_weight = Parameter(torch_view(w13_weight),
                                      requires_grad=False)
-        layer.w13_bias = Parameter(torch_view(w13_bias), requires_grad=False)
-
         layer.w2_weight = Parameter(torch_view(w2_weight), requires_grad=False)
+
+        layer.w13_bias = Parameter(torch_view(w13_bias), requires_grad=False)
         layer.w2_bias = Parameter(torch_view(w2_bias), requires_grad=False)
 
         pass
@@ -305,15 +291,22 @@ class VllmMxfp4MoEMethod(Mxfp4MoEMethod):
             raise NotImplementedError(
                 "Only softmax is supported for scoring_func")
 
-        if self.use_kernel and layer.use_ep:
+        x = jax_view(x)
+        w13_weight = jax_view(layer.w13_weight)
+        w2_weight = jax_view(layer.w2_weight)
+        w13_bias = jax_view(layer.w13_bias)
+        w2_bias = jax_view(layer.w2_bias)
+        gating_output = jax_view(router_logits)
+
+        if self.use_kernel:
             output = fused_ep_moe(
                 mesh=self.mesh,
-                tokens=jax_view(x),
-                w1=jax_view(layer.w13_weight),
-                w2=jax_view(layer.w2_weight),
-                b1=jax_view(layer.w13_bias),
-                b2=jax_view(layer.w2_bias),
-                gating_output=jax_view(router_logits),
+                tokens=x,
+                w1=w13_weight,
+                w2=w2_weight,
+                b1=w13_bias,
+                b2=w2_bias,
+                gating_output=gating_output,
                 top_k=top_k,
                 ep_axis_name=self.ep_axis_name,
                 renormalize_topk_logits=renormalize,
@@ -321,18 +314,15 @@ class VllmMxfp4MoEMethod(Mxfp4MoEMethod):
                 **self.block_size,
             )
         else:
-            # Use the original implementation
-            output = fused_moe_func_padded(
-                jax_view(x),
-                jax_view(layer.w13_weight),
-                jax_view(layer.w2_weight),
-                jax_view(layer.w13_bias),
-                jax_view(layer.w2_bias),
-                jax_view(router_logits),
+            output = fused_moe_func(
+                hidden_states=x,
+                w1=w13_weight,
+                w2=w2_weight,
+                w1_bias=w13_bias,
+                w2_bias=w2_bias,
+                gating_output=gating_output,
                 topk=top_k,
-                global_num_experts=global_num_experts,
                 renormalize=renormalize,
-                reduce_results=layer.reduce_results,
                 mesh=self.mesh,
                 use_ep=layer.use_ep,
                 activation=activation,

--- a/tpu_inference/layers/vllm/quantization/unquantized.py
+++ b/tpu_inference/layers/vllm/quantization/unquantized.py
@@ -25,7 +25,7 @@ from tpu_inference import envs
 from tpu_inference.kernels.fused_moe.v1.kernel import fused_ep_moe
 from tpu_inference.layers.common.quant_methods import (UNQUANTIZED,
                                                        get_tpu_quant_method)
-from tpu_inference.layers.vllm.fused_moe import fused_moe_func_padded
+from tpu_inference.layers.vllm.fused_moe import fused_moe_func
 from tpu_inference.layers.vllm.linear_common import (
     reorder_concatenated_tensor_for_sharding,
     slice_sharded_tensor_for_concatenation, torch_to_jax_param)
@@ -168,7 +168,7 @@ class VllmUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod):
                  ep_axis_name: str = 'model'):
         super().__init__(moe)
         self.mesh = mesh
-        self.use_kernel = envs.USE_MOE_EP_KERNEL
+        self.use_kernel = envs.USE_MOE_EP_KERNEL and moe.use_ep
         self.ep_axis_name = ep_axis_name
         # TODO: Use autotune table once we have it.
         self.block_size = {
@@ -196,6 +196,8 @@ class VllmUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod):
         w13_weight = t2j(layer.w13_weight, use_dlpack=False)
         w2_weight = t2j(layer.w2_weight, use_dlpack=False)
 
+        num_experts, hidden_size, intermediate_size = w2_weight.shape
+
         if self.moe.has_bias:
             w13_bias = t2j(layer.w13_bias, use_dlpack=False)
             w2_bias = t2j(layer.w2_bias, use_dlpack=False)
@@ -214,76 +216,56 @@ class VllmUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod):
                 w3_bias = w13_bias[:, 1::2]
                 w13_bias = jnp.concat([w1_bias, w3_bias], axis=1)
 
-        if self.use_kernel and layer.use_ep:
+        if self.use_kernel:
             # Kernel expects:
             # w13: (num_experts, 2, hidden_size, intermediate_size)
             # w2: (num_experts, intermediate_size, hidden_size)
             # Current format:
             # w13_weight: (num_experts, 2*intermediate_size, hidden_size)
             # w2_weight: (num_experts, hidden_size, intermediate_size)
-            num_experts = w13_weight.shape[0]
-            intermediate_size = w13_weight.shape[1] // 2
-            hidden_size = w13_weight.shape[2]
 
-            # Reshape and transpose w13_weight to (num_experts, 2, hidden_size, intermediate_size)
             w13_reshaped = w13_weight.reshape(num_experts, 2,
                                               intermediate_size, hidden_size)
-            w13_weight_transposed = jnp.transpose(w13_reshaped, (0, 1, 3, 2))
 
-            # Transpose w2_weight to (num_experts, intermediate_size, hidden_size)
-            w2_weight_transposed = jnp.transpose(w2_weight, (0, 2, 1))
+            # Transpose non-constracting dim to right most dim
+            w13_weight_transposed = jnp.swapaxes(w13_reshaped, 2, 3)
+            w2_weight_transposed = jnp.swapaxes(w2_weight, 1, 2)
 
             # Apply EP sharding
+            ep_sharding = NamedSharding(self.mesh, P("model"))
+
             w13_weight = jax.device_put(
-                w13_weight_transposed,
-                Format(Layout((0, 1, 2, 3)),
-                       NamedSharding(self.mesh, P("model", None, None, None))))
-            w2_weight = jax.device_put(
-                w2_weight_transposed,
-                Format(Layout((0, 1, 2)),
-                       NamedSharding(self.mesh, P("model", None, None))))
+                w13_weight_transposed, Format(Layout((0, 1, 2, 3)),
+                                              ep_sharding))
+            w2_weight = jax.device_put(w2_weight_transposed,
+                                       Format(Layout((0, 1, 2)), ep_sharding))
 
             if self.moe.has_bias:
                 w13_bias = w13_bias.reshape(num_experts, 2, intermediate_size)
-
-                # Apply EP sharding
                 w13_bias = jax.device_put(
-                    w13_bias,
-                    Format(Layout((0, 1, 2)),
-                           NamedSharding(self.mesh, P("model", None, None))))
-                w2_bias = jax.device_put(
-                    w2_bias,
-                    Format(Layout((0, 1)),
-                           NamedSharding(self.mesh, P("model", None))))
-
+                    w13_bias, Format(Layout((0, 1, 2)), ep_sharding))
+                w2_bias = jax.device_put(w2_bias,
+                                         Format(Layout((0, 1)), ep_sharding))
         else:
-            # Original logic for non-kernel path
+
             if layer.use_ep:
+                ep_sharding = NamedSharding(self.mesh, P("model"))
                 w13_weight = jax.device_put(
-                    w13_weight,
-                    Format(Layout((0, 1, 2)),
-                           NamedSharding(self.mesh, P("model", None, None))))
+                    w13_weight, Format(Layout((0, 1, 2)), ep_sharding))
                 w2_weight = jax.device_put(
-                    w2_weight,
-                    Format(Layout((0, 1, 2)),
-                           NamedSharding(self.mesh, P("model", None, None))))
+                    w2_weight, Format(Layout((0, 1, 2)), ep_sharding))
 
                 if self.moe.has_bias:
                     w13_bias = jax.device_put(
-                        w13_bias,
-                        Format(Layout((0, 1)),
-                               NamedSharding(self.mesh, P("model", None))))
+                        w13_bias, Format(Layout((0, 1)), ep_sharding))
                     w2_bias = jax.device_put(
-                        w2_bias,
-                        Format(Layout((0, 1)),
-                               NamedSharding(self.mesh, P("model", None))))
+                        w2_bias, Format(Layout((0, 1)), ep_sharding))
 
             else:
-                intermediate_size = w13_weight.shape[1] // 2
-                assert intermediate_size == w2_weight.shape[-1]
                 output_sizes = [intermediate_size, intermediate_size]
                 n_shards = self.mesh.shape["model"]
                 assert intermediate_size % n_shards == 0
+
                 w13_weight = reorder_concatenated_tensor_for_sharding(
                     w13_weight, output_sizes, n_shards, dim=1)
                 w13_weight = jax.device_put(
@@ -344,15 +326,24 @@ class VllmUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod):
             raise NotImplementedError(
                 "Only softmax is supported for scoring_func")
 
+        x = jax_view(x)
+        w13_weight = jax_view(layer.w13_weight)
+        w2_weight = jax_view(layer.w2_weight)
+        w13_bias = w2_bias = None
+        if self.moe.has_bias:
+            w13_bias = jax_view(layer.w13_bias)
+            w2_bias = jax_view(layer.w2_bias)
+        gating_output = jax_view(router_logits)
+
         if self.use_kernel and layer.use_ep:
             output = fused_ep_moe(
                 mesh=self.mesh,
-                tokens=jax_view(x),
-                w1=jax_view(layer.w13_weight),
-                w2=jax_view(layer.w2_weight),
-                b1=jax_view(layer.w13_bias) if self.moe.has_bias else None,
-                b2=jax_view(layer.w2_bias) if self.moe.has_bias else None,
-                gating_output=jax_view(router_logits),
+                tokens=x,
+                w1=w13_weight,
+                w2=w2_weight,
+                b1=w13_bias,
+                b2=w2_bias,
+                gating_output=gating_output,
                 top_k=top_k,
                 ep_axis_name=self.ep_axis_name,
                 renormalize_topk_logits=renormalize,
@@ -360,18 +351,15 @@ class VllmUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod):
                 **self.block_size,
             )
         else:
-            # Use the original implementation
-            output = fused_moe_func_padded(
-                jax_view(x),
-                jax_view(layer.w13_weight),
-                jax_view(layer.w2_weight),
-                jax_view(layer.w13_bias) if self.moe.has_bias else None,
-                jax_view(layer.w2_bias) if self.moe.has_bias else None,
-                jax_view(router_logits),
+            output = fused_moe_func(
+                hidden_states=x,
+                w1=w13_weight,
+                w2=w2_weight,
+                w1_bias=w13_bias,
+                w2_bias=w2_bias,
+                gating_output=gating_output,
                 topk=top_k,
-                global_num_experts=global_num_experts,
                 renormalize=renormalize,
-                reduce_results=layer.reduce_results,
                 mesh=self.mesh,
                 use_ep=layer.use_ep,
                 activation=activation,


### PR DESCRIPTION
# Description

Cleanup fused moe file. No change in functionality.

- Add type annotations
- Add better function documentation
- Remove `transpose_rhs` since it's always `True`
- Remove unnecessary sharding constraints which were already enforced via `shard_map` 
- Replace `jax.experimental.shard_map.shard_map` into `jax.shard_map`
- Remove `fused_moe_func_padded` since padding is now handled by jax runner
- Remove unnecessary arguments that can be inferred from tensor or mesh shapes

# Tests

https://buildkite.com/tpu-commons/tpu-inference-ci/builds/6118

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
