### PR TITLE
[ONCALL] fix NEW_MODEL_DESIGN flag values from True to 1

### DIFF
--- a/.buildkite/pipeline_jax.yml
+++ b/.buildkite/pipeline_jax.yml
@@ -36,7 +36,7 @@ steps:
      key: test_2
      soft_fail: true
      env:
-       NEW_MODEL_DESIGN: "True"
+       NEW_MODEL_DESIGN: "1"
      agents:
        queue: tpu_v6e_queue
      commands:
@@ -62,7 +62,7 @@ steps:
      key: test_4
      soft_fail: true
      env:
-       NEW_MODEL_DESIGN: "True"
+       NEW_MODEL_DESIGN: "1"
        USE_V6E8_QUEUE: "True"
      agents:
        queue: tpu_v6e_8_queue
@@ -193,7 +193,7 @@ steps:
      key: test_12
      soft_fail: true
      env:
-       NEW_MODEL_DESIGN: "True"
+       NEW_MODEL_DESIGN: "1"
        USE_V6E8_QUEUE: "True"
        SKIP_ACCURACY_TESTS: "True"
        VLLM_MLA_DISABLE: "1"
@@ -231,7 +231,7 @@ steps:
 #     key: test_14
 #     soft_fail: true
 #     env:
-#       NEW_MODEL_DESIGN: "True"
+#       NEW_MODEL_DESIGN: "1"
 #     agents:
 #       queue: tpu_v6e_8_queue
 #     commands:


### PR DESCRIPTION
# Description

the [envs.py](https://github.com/vllm-project/tpu-inference/blob/5e0e7497c1a0db184ec3a0fd999504e77500d779/tpu_inference/envs.py#L61) assumes the NEW_MODEL_DESIGN flag to be 0 or 1. Update the CI/CD command to use new_model_design = 1, instead of 'True'


# Tests

green CI: https://buildkite.com/tpu-commons/tpu-inference-ci/builds/6145

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
