### PR TITLE
Fix lora e2e test due to upstream change

### DIFF
--- a/tpu_inference/models/vllm/vllm_model_wrapper.py
+++ b/tpu_inference/models/vllm/vllm_model_wrapper.py
@@ -263,7 +263,6 @@ def load_lora_model(model: torch.nn.Module, vllm_config: VllmConfig,
         vllm_config,
         device,
         model.embedding_modules,
-        model.embedding_padding_modules,
     )
     return lora_manager, lora_manager.create_lora_manager(model)
 


### PR DESCRIPTION
# Description

An upstream change https://github.com/vllm-project/vllm/pull/29611 broke the lora e2e test. This PR fixes it.

# Tests

- pytest -s -vv tests/lora/test_layers.py
- VLLM_XLA_CHECK_RECOMPILATION=1 MODEL_IMPL_TYPE=vllm TPU_BACKEND_TYPE=jax pytest -s -v tests/lora/test_lora.py

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
