### PR TITLE
[CI] Pull the latest nightly Docker image for tests, instead of local build, if it is a nightly CI run.

### DIFF
--- a/.buildkite/main.yml
+++ b/.buildkite/main.yml
@@ -10,6 +10,7 @@ notify:
 steps:
    - label: "Upload Tests for Models & Features"
      <<: *run-on-nightly-or-tag
+     depends_on: publish_nightly_image_for_v6e
      agents:
        queue: cpu
      commands:

--- a/.buildkite/nightly_releases.yml
+++ b/.buildkite/nightly_releases.yml
@@ -7,6 +7,7 @@ notify:
 steps:
   - label: "Publish vllm/vllm-tpu nightly image"
     if: build.env("NIGHTLY") == "1"
+    key: publish_nightly_image_for_v6e
     agents:
       queue: cpu
     secrets:

--- a/.buildkite/pipeline_jax.yml
+++ b/.buildkite/pipeline_jax.yml
@@ -8,6 +8,16 @@ steps:
   # -----------------------------------------------------------------
   # TEST STEPS - Calling wrapper
   # -----------------------------------------------------------------
+   - label: "Wait for publishing nightly image finished"
+     if: build.env("NIGHTLY") == "1"
+     depends_on: publish_nightly_image_for_v6e
+     agents:
+       queue: cpu
+     commands:
+       - echo "Wait for publishing nightly image finished if it's nightly run"
+
+   - wait: ~
+
    - label: "E2E MLPerf tests for JAX models"
      key: test_0
      soft_fail: true


### PR DESCRIPTION
# Description

If it's a nightly run, `pipeline_jax.yml` and `main.yml` will wait for the nightly release to finish publishing. They will then continue the tests by pulling the latest nightly Docker image from Docker Hub, instead of building a local image again.

Otherwise, if it's not nightly run, build the local image for tests.

# Tests

Only test on `models/meta-llama_Llama-3_1-8B-Instruct.yml` and `test_0`
[buildkite](https://buildkite.com/tpu-commons/tpu-inference-ci/builds/6245/steps/canvas) (simulate nightly run)
[buildkite](https://buildkite.com/tpu-commons/tpu-inference-ci/builds/6247/steps/canvas) (simulate not nightly run)

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
