### PR TITLE
[CI] Fix awq dtype

### DIFF
--- a/tpu_inference/layers/vllm/quantization/awq.py
+++ b/tpu_inference/layers/vllm/quantization/awq.py
@@ -57,12 +57,6 @@ class VllmAWQConfig(AWQConfig, VllmQuantConfig):
     def get_name(cls):
         return AWQ
 
-    def get_supported_act_dtypes(self) -> list[torch.dtype]:
-        # NOTE: AWQ checkpoint was quantized with float16. But on TPUs, using
-        # bfloat16 is significantly preferred over float16. This might lead to
-        # some numeric output change.
-        return [torch.bfloat16]
-
     def get_quant_method(
         self, layer: torch.nn.Module, prefix: str
     ) -> Optional[Union["LinearMethodBase", "QuantizeMethodBase"]]:


### PR DESCRIPTION
# Description

Now the model dtype is being correctly set via https://github.com/vllm-project/tpu-inference/pull/1093, we do not need to manually override it.

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
