### PR TITLE
Fix FP8 dtype type mismatch issue

### DIFF
--- a/tpu_inference/utils.py
+++ b/tpu_inference/utils.py
@@ -28,9 +28,9 @@ TPU_SECOND_LAST_MINOR = 8
 
 # Map vllm dtype string that doesn't exactly match jax dtype string name.
 _VLLM_DTYPE_STR_TO_JAX_DTYPE = {
-    "fp8": jnp.float8_e4m3fn,
-    "fp8_e4m3": jnp.float8_e4m3fn,
-    "fp8_e5m2": jnp.float8_e5m2,
+    "fp8": jnp.float8_e4m3fn.dtype,
+    "fp8_e4m3": jnp.float8_e4m3fn.dtype,
+    "fp8_e5m2": jnp.float8_e5m2.dtype,
 }
 
 


### PR DESCRIPTION
# Description

j2t_dtype expects jnp.dtype, not _ScalarMeta. This will lead to dtype mismatch when FP8 is used.


# Tests

Tested 
```
vllm serve unsloth/gpt-oss-120b-BF16 --max-model-len=16384 --max-num-batched-tokens=8192 --max-num-seqs=2048 --no-enable-prefix-caching --gpu-memory-utilization=0.95 --tensor-parallel-size=4 --download-dir=/mnt/pd --async-scheduling --port=8000 --kv-cache-dtype=fp8
```

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
