### PR TITLE
Remove a branch with pl.when in fetching bkv

### DIFF
--- a/tpu_inference/kernels/ragged_paged_attention/v3/kernel_hd64.py
+++ b/tpu_inference/kernels/ragged_paged_attention/v3/kernel_hd64.py
@@ -520,19 +520,16 @@ def _ragged_paged_attention_kernel(
                 unroll=False,
             )
 
-            # Fetch kv directly from new kv.
-            @pl.when(bkv_sz_frm_new > 0)
-            def _fetch_bkv_from_new_kv():
-                new_kv_len_start = q_end - kv_left_frm_new
-                debug_print("[RPA debug] new_kv_len_start={}",
-                            new_kv_len_start)
-                debug_print("[RPA debug] offset_in_bkv={}", offset)
-                _async_copy(
-                    kv_hbm_ref.at[pl.ds(new_kv_len_start, bkv_sz_frm_new)],
-                    vmem_ref.at[pl.ds(offset, bkv_sz_frm_new)],
-                    sem,
-                    wait,
-                )
+            size = lax.select(bkv_sz_frm_new > 0, bkv_sz_frm_new, 0)
+            new_kv_len_start = q_end - kv_left_frm_new
+            debug_print("[RPA debug] new_kv_len_start={}", new_kv_len_start)
+            debug_print("[RPA debug] offset_in_bkv={}", offset)
+            _async_copy(
+                kv_hbm_ref.at[pl.ds(new_kv_len_start, size)],
+                vmem_ref.at[pl.ds(offset, size)],
+                sem,
+                wait,
+            )
 
             return kv_len_start + offset, bkv_sz_frm_new
         else:


### PR DESCRIPTION
# Description

Discussed with @bythew3i offline! This commit removes one control flow branch in path of prefetching bkv. Around 3% kernel speedup before tuning! (since I don't have tuning script, so unable to report updated speedup)



If the change fixes a bug or a Github issue, please include a link, e.g.,:
FIXES: b/123456
FIXES: #123456

# Tests
E2E tests
<img width="2385" height="100" alt="截屏2025-12-03 下午4 11 34" src="https://github.com/user-attachments/assets/61bbf34d-7e1f-43ee-83fe-f72b9aba5dc9" />
Integration tests:
<img width="1139" height="384" alt="截屏2025-12-03 下午4 41 13" src="https://github.com/user-attachments/assets/57060e38-3834-4f83-b843-52c6e13c1195" />
<img width="1052" height="267" alt="截屏2025-12-03 下午4 56 33" src="https://github.com/user-attachments/assets/6d49562e-acfa-45db-85fe-8b2766053309" />

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
