### PR TITLE
Avoid installing CUDA related stuff

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,7 +23,7 @@ RUN git clone $VLLM_REPO /workspace/vllm
 RUN if [ -n "$VLLM_COMMIT_HASH" ]; then \
         git checkout $VLLM_COMMIT_HASH; \
     fi
-RUN --mount=type=cache,target=/root/.cache/pip pip install -r requirements/tpu.txt --retries 3
+RUN --mount=type=cache,target=/root/.cache/pip pip install --extra-index-url https://download.pytorch.org/whl/cpu -r requirements/tpu.txt --retries 3
 RUN --mount=type=cache,target=/root/.cache/pip VLLM_TARGET_DEVICE="tpu" pip install -e .
 
 # Install test dependencies
@@ -39,7 +39,7 @@ RUN --mount=type=cache,target=/root/.cache/pip python3 -m pip install \
 WORKDIR /workspace/tpu_inference
 # Install requirements first and cache so we don't need to re-install on code change.
 COPY requirements.txt .
-RUN --mount=type=cache,target=/root/.cache/pip pip install -r requirements.txt --retries 3
+RUN --mount=type=cache,target=/root/.cache/pip pip install --extra-index-url https://download.pytorch.org/whl/cpu -r requirements.txt --retries 3
 COPY requirements_benchmarking.txt .
 # These are needed for the E2E benchmarking tests (i.e. tests/e2e/benchmarking/mlperf.sh)
 RUN --mount=type=cache,target=/root/.cache/pip pip install -r requirements_benchmarking.txt --retries 3


### PR DESCRIPTION
# Description

Avoid installing CUDA related stuff

- Use PyTorch CPU version so we avoid installing CUDA.

This modification keeps the functionality and reduce on-disk image size by about 7.7GB.

```text
wdhongtw/vllm-tpu   latest   d055fd2151a0   22 minutes ago      11.8GB
wdhongtw/vllm-tpu   base     07dbf76dbed8   About an hour ago   19.5GB
```

See [official doc](https://pytorch.org/get-started/locally/) for recommended way to install CPU version of PyTorch.

The `pip list` output before and after generate following diff

```diff
--- ./cuda.txt  2025-12-10 14:22:24.124896422 +0000
+++ ./cpu.txt   2025-12-10 14:24:50.718893457 +0000
@@ -101,15 +100,0 @@
-nvidia-cublas-cu12                 12.8.4.1
-nvidia-cuda-cupti-cu12             12.8.90
-nvidia-cuda-nvrtc-cu12             12.8.93
-nvidia-cuda-runtime-cu12           12.8.90
-nvidia-cudnn-cu12                  9.10.2.21
-nvidia-cufft-cu12                  11.3.3.83
-nvidia-cufile-cu12                 1.13.1.3
-nvidia-curand-cu12                 10.3.9.90
-nvidia-cusolver-cu12               11.7.3.90
-nvidia-cusparse-cu12               12.5.8.93
-nvidia-cusparselt-cu12             0.7.1
-nvidia-nccl-cu12                   2.27.3
-nvidia-nvjitlink-cu12              12.8.93
-nvidia-nvshmem-cu12                3.3.20
-nvidia-nvtx-cu12                   12.8.90
@@ -197 +182 @@
-torch                              2.8.0
+torch                              2.8.0+cpu
@@ -200 +185 @@
-torchvision                        0.23.0
+torchvision                        0.23.0+cpu
@@ -206 +191 @@
-triton                             3.4.0
+triton                             3.5.1
 ```

With `--extra-index-url`, `pip` now can see cuda version and cpu version,
and the cpu version has higher priority.

- PyTorch decide to make the "canonical" `torch` package on Linux platform be the cuda-ready one,
  and put the cpu-ready version on <https://download.pytorch.org/whl/cpu>.
  (this is not true on macOS and Windows)
- When using `--index-url`, `pip` will install the `+cpu` version, since that the index url
  is now the only search space for this `pip` invocation, `+...` is called the local version identifier.
- We use `--extra-index-url` here so that we can install torch `+cpu` version while install other
  packages in the `requirements.txt` file in one `pip` invocation For `torch` and `torchvision`,
  we use packages from <https://download.pytorch.org/whl/cpu>, and for other packages, we use packages
  from PyPI directly.
- Now `pip` can see PyTorch `2.8.0` and `2.8.0+cpu` at the same time, but because the one with local version
  tag has higher priority, `2.8.0+cpu` is installed.

From PEP440

> Additionally a local version with a great number of segments will always compare as greater than a local version with fewer segments


# Tests

Build the image and run benchmarking in the container.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
