### PR TITLE
Fix circle reference which cause tpu_platform failed to import

### DIFF
--- a/tpu_inference/platforms/tpu_platform.py
+++ b/tpu_inference/platforms/tpu_platform.py
@@ -9,7 +9,6 @@ from tpu_info import device
 from vllm.inputs import ProcessorInputs, PromptType
 from vllm.platforms.interface import Platform, PlatformEnum
 
-
 from tpu_inference import envs
 from tpu_inference.layers.common.sharding import ShardingConfigManager
 from tpu_inference.logger import init_logger
@@ -28,7 +27,6 @@ else:
     AttentionBackendEnum = None
     SamplingParams = None
     SamplingType = None
-
 
 logger = init_logger(__name__)
 


### PR DESCRIPTION
# Description

Fix circle reference which cause tpu_platform failed to import.

before the fix:
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/mrjunwan_google_com/tpu-inference/tpu_inference/platforms/__init__.py", line 2, in <module>
    from tpu_inference.platforms.tpu_platform import TpuPlatform
  File "/home/mrjunwan_google_com/tpu-inference/tpu_inference/platforms/tpu_platform.py", line 11, in <module>
    from vllm.sampling_params import SamplingParams, SamplingType
  File "/home/mrjunwan_google_com/vllm/vllm/sampling_params.py", line 15, in <module>
    from vllm.logits_process import LogitsProcessor
  File "/home/mrjunwan_google_com/vllm/vllm/logits_process.py", line 8, in <module>
    from vllm.tokenizers import TokenizerLike
  File "/home/mrjunwan_google_com/vllm/vllm/tokenizers/__init__.py", line 4, in <module>
    from .deepseekv32 import DeepseekV32Tokenizer
  File "/home/mrjunwan_google_com/vllm/vllm/tokenizers/deepseekv32.py", line 9, in <module>
    from .hf import HfTokenizer, TokenizerLike
  File "/home/mrjunwan_google_com/vllm/vllm/tokenizers/hf.py", line 10, in <module>
    from vllm.transformers_utils.config import get_sentence_transformer_tokenizer_config
  File "/home/mrjunwan_google_com/vllm/vllm/transformers_utils/config.py", line 28, in <module>
    from vllm.config.utils import getattr_iter
  File "/home/mrjunwan_google_com/vllm/vllm/config/__init__.py", line 17, in <module>
    from vllm.config.model import (
  File "/home/mrjunwan_google_com/vllm/vllm/config/model.py", line 24, in <module>
    from vllm.transformers_utils.config import (
ImportError: cannot import name 'ConfigFormat' from partially initialized module 'vllm.transformers_utils.config' (most likely due to a circular import) (/home/mrjunwan_google_com/vllm/vllm/transformers_utils/config.py)

after the fix:
python examples/offline_inference.py \
    --model=Qwen/Qwen3-0.6B \
    --tensor_parallel_size=4 \
    --data_parallel_size=1 \
    --max_model_len=1024
run successfully