### PR TITLE
Fix image tests.

### DIFF
--- a/tests/runner/test_multimodal_manager.py
+++ b/tests/runner/test_multimodal_manager.py
@@ -144,8 +144,8 @@ class TestMultiModalManager:
         assert passed_pixel_values.dtype == jnp.bfloat16
 
         # Convert torch tensor for comparison
-        expected_pixel_values = dummy_pixel_values.unsqueeze(0).unsqueeze(
-            0).to(torch.float32).numpy().astype(jnp.bfloat16)
+        expected_pixel_values = dummy_pixel_values.unsqueeze(0).to(
+            torch.float32).numpy().astype(jnp.bfloat16)
         np.testing.assert_array_equal(np.asarray(passed_pixel_values),
                                       expected_pixel_values)
 
@@ -249,11 +249,10 @@ class TestMultiModalManager:
         assert "pixel_values" in kwargs_arg
 
         passed_pixel_values = kwargs_arg['pixel_values']
-        assert passed_pixel_values.shape == (2, 1, 3, 224, 224)
+        assert passed_pixel_values.shape == (2, 3, 224, 224)
 
-        expected_pixel_values = torch.stack(
-            [px_1, px_2],
-            dim=0).unsqueeze(1).to(torch.float32).numpy().astype(jnp.bfloat16)
+        expected_pixel_values = torch.stack([px_1, px_2], dim=0).to(
+            torch.float32).numpy().astype(jnp.bfloat16)
         np.testing.assert_array_equal(np.asarray(passed_pixel_values),
                                       expected_pixel_values)
 


### PR DESCRIPTION
# Description
Fix test failure

The test 

```
 python3 -m pytest -s -v -x tests/runner/test_multimodal_manager.py
```

was broken by

```
commit b286a311c2bab639ce6edc998a9a67c0affc9cbf.  -----> test failed
Author: Cyrus Leung <tlleungac@connect.ust.hk>
Date:   Fri Dec 5 01:21:24 2025 +0800

    [Chore] Deprecate `merge_by_field_config` arg (#30035)
    
    Signed-off-by: DarkLight1337 <tlleungac@connect.ust.hk>

commit 990f806473888451ef6590f85a6ed8436db7801c      -----> test -----> good 
Author: Shengqi Chen <harry-chen@outlook.com>
Date:   Fri Dec 5 00:28:37 2025 +0800

    [Doc] clarify nightly builds in developer docs (#30019)
    
    Signed-off-by: Shengqi Chen <harry-chen@outlook.com>
```

Because the output shape changes. 

FIXES: b/466276659


# Tests
https://buildkite.com/tpu-commons/tpu-inference-ci/builds/6470

Run test again.


