### PR TITLE
[Quantization] Add option to bypass quantized matmul kernel for W8A8-FP8 Compressed Tensors

### DIFF
--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -60,6 +60,7 @@ def test_boolean_env_vars(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv("SKIP_JAX_PRECOMPILE", "0")
     monkeypatch.setenv("VLLM_XLA_CHECK_RECOMPILATION", "0")
     monkeypatch.setenv("NEW_MODEL_DESIGN", "0")
+    monkeypatch.setenv("ENABLE_QUANTIZED_MATMUL_KERNEL", "0")
     monkeypatch.setenv("USE_MOE_EP_KERNEL", "0")
 
     # Test SKIP_JAX_PRECOMPILE (default False)
@@ -85,6 +86,11 @@ def test_boolean_env_vars(monkeypatch: pytest.MonkeyPatch):
     assert envs.USE_MOE_EP_KERNEL is False
     monkeypatch.setenv("USE_MOE_EP_KERNEL", "1")
     assert envs.USE_MOE_EP_KERNEL is True
+
+    # Test ENABLE_QUANTIZED_MATMUL_KERNEL (default False)
+    assert envs.ENABLE_QUANTIZED_MATMUL_KERNEL is False
+    monkeypatch.setenv("ENABLE_QUANTIZED_MATMUL_KERNEL", "1")
+    assert envs.ENABLE_QUANTIZED_MATMUL_KERNEL is True
 
 
 def test_boolean_env_vars_string_values(monkeypatch: pytest.MonkeyPatch):

--- a/tpu_inference/envs.py
+++ b/tpu_inference/envs.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
     NUM_SLICES: int = 1
     RAY_USAGE_STATS_ENABLED: str = "0"
     VLLM_USE_RAY_COMPILED_DAG_CHANNEL_TYPE: str = "shm"
+    ENABLE_QUANTIZED_MATMUL_KERNEL: bool = False
 
 
 def env_with_choices(
@@ -150,6 +151,8 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Ray compiled DAG channel type for TPU
     "VLLM_USE_RAY_COMPILED_DAG_CHANNEL_TYPE":
     env_with_choices("VLLM_USE_RAY_COMPILED_DAG_CHANNEL_TYPE", "shm", ["shm"]),
+    "ENABLE_QUANTIZED_MATMUL_KERNEL":
+    lambda: bool(int(os.getenv("ENABLE_QUANTIZED_MATMUL_KERNEL") or "0")),
 }
 
 

--- a/tpu_inference/layers/vllm/linear_common.py
+++ b/tpu_inference/layers/vllm/linear_common.py
@@ -9,30 +9,52 @@ from jax.sharding import PartitionSpec as P
 from torchax.interop import torch_view
 from torchax.ops.mappings import t2j
 
-from tpu_inference.kernels.quantized_matmul.kernel import \
-    quantized_matmul_kernel
+from tpu_inference import envs
+from tpu_inference.kernels.quantized_matmul.kernel import (
+    quantized_matmul_kernel, xla_quantized_matmul)
 
 
 def sharded_quantized_matmul(x: jax.Array, w_q: jax.Array, w_s: jax.Array,
-                             mesh: Mesh, weight_sharding: P):
-    out_axis, in_axis = weight_sharding
-    x_sharding = P(None, in_axis)
-    scale_sharding = P(out_axis, )
-    out_sharding = P(None, out_axis)
+                             mesh: Mesh, weight_sharding: P) -> jax.Array:
+    """
+    Wrapper around the quantized matmul kernel.
 
-    x = jax.lax.with_sharding_constraint(x, NamedSharding(mesh, x_sharding))
+    Args:
+        x:  Activation.
+        w_q: Weight quantized array. [n_output_features, n_input_features]
+        w_s: Weight quantization scale. [n_output_features]
+        mesh: Mesh to shard on.
+        weight_sharding: PartitionSpec for the weight tensor.
 
-    def wrapper(x, w_q, w_s):
-        output = quantized_matmul_kernel(x, w_q, w_s, x_q_dtype=w_q.dtype)
-        if in_axis:
-            output = jax.lax.psum(output, axis_name=in_axis)
-        return output
+    Returns:
+        Output of the quantized matmul.
+    """
 
-    return shard_map(wrapper,
-                     mesh=mesh,
-                     in_specs=(x_sharding, weight_sharding, scale_sharding),
-                     out_specs=(out_sharding),
-                     check_rep=False)(x, w_q, w_s)
+    # NOTE (jacobplatin/kyuyeunk) there have been numeric issues (concerning) NaNs
+    # with the kernel and thus we disable it for now.
+    if envs.ENABLE_QUANTIZED_MATMUL_KERNEL:
+        out_axis, in_axis = weight_sharding
+        x_sharding = P(None, in_axis)
+        scale_sharding = P(out_axis, )
+        out_sharding = P(None, out_axis)
+
+        x = jax.lax.with_sharding_constraint(x,
+                                             NamedSharding(mesh, x_sharding))
+
+        def wrapper(x, w_q, w_s):
+            output = quantized_matmul_kernel(x, w_q, w_s, x_q_dtype=w_q.dtype)
+            if in_axis:
+                output = jax.lax.psum(output, axis_name=in_axis)
+            return output
+
+        return shard_map(wrapper,
+                         mesh=mesh,
+                         in_specs=(x_sharding, weight_sharding,
+                                   scale_sharding),
+                         out_specs=(out_sharding),
+                         check_rep=False)(x, w_q, w_s)
+    else:
+        return xla_quantized_matmul(x, w_q, w_s)
 
 
 def reorder_concatenated_tensor_for_sharding(concatenated_tensor: jax.Array,


### PR DESCRIPTION
# Description

In this PR, I introduce a `DISALBE_QUANTIZED_MATMUL_KERNEL` flag which will bypass the quantized matmul kernel in the TorchAX path's W8A8-FP8 Compressed Tensors module.  This is needed because the sharded matmul was observed to introduce NaNs when using a quantized KV cache with Qwen3-Coder-480B

Previously, with the matmul kernel, we saw the following result when running the following command:

```
python examples/offline_inference/llm_engine_example.py  --tensor-parallel-size=8 --model BCCard/Qwen3-Coder-480B-A35B-Instruct-FP8-Dynamic --kv-cache-dtype=fp8
```

Result:
```
--------------------------------------------------
Prompt: 'A robot may not injure a human being'
Generated text: '!!!!!!!!!!!!!!!!'
--------------------------------------------------
Prompt: 'To be or not to be,'
Generated text: '!!!!!!!!!!!!!!!!'
--------------------------------------------------
Prompt: 'What is the meaning of life?'
Generated text: '!!!!!!!!!!!!!!!!'
--------------------------------------------------
```

# Tests

## Accuracy
Tested locally + added relevant env var tests.

Also tested accuracy with the following command:

```
lm_eval \
    --model vllm \
    --model_args '{"pretrained": "BCCard/Qwen3-Coder-480B-A35B-Instruct-FP8-Dynamic", "tensor_parallel_size": 8, "max_model_len": 2048, "max_num_batched_tokens": 2048, "max_gen_toks": 256, "kv_cache_dtype": "fp8"}' \
    --tasks gsm8k_cot \
    --batch_size auto \
    --apply_chat_template \
    --num_fewshot 8
```


v7x-8 result:
```
|  Tasks  |Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|---------|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k_cot|      3|flexible-extract|     8|exact_match|↑  |0.8825|±  |0.0089|
|         |       |strict-match    |     8|exact_match|↑  |0.7597|±  |0.0118|
```

H100x8 result:
```
|  Tasks  |Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|---------|------:|----------------|-----:|-----------|---|----:|---|-----:|
|gsm8k_cot|      3|flexible-extract|     8|exact_match|↑  |0.884|±  |0.0088|
|         |       |strict-match    |     8|exact_match|↑  |0.765|±  |0.0117|
```



## Perf
Comparing kernel vs reference (JAX) implementation to ensure no major regression

Base CMD:
```
MODEL_IMPL_TYPE=vllm vllm serve RedHatAI/Meta-Llama-3.1-8B-Instruct-FP8-dynamic  --max-model-len=5120 --disable-log-requests --max-num-batched-tokens 4096 --max-num-seqs=256 --tensor-parallel-size=2  --no-enable-prefix-caching 
```


### Reference
```
============ Serving Benchmark Result ============
Successful requests:                     256       
Failed requests:                         0         
Benchmark duration (s):                  190.38    
Total input tokens:                      261892    
Total generated tokens:                  1048576   
Request throughput (req/s):              1.34      
Output token throughput (tok/s):         5507.69   
Peak output token throughput (tok/s):    7168.00   
Peak concurrent requests:                256.00    
Total Token throughput (tok/s):          6883.28   
---------------Time to First Token----------------
Mean TTFT (ms):                          3385.70   
Median TTFT (ms):                        3279.12   
P99 TTFT (ms):                           6826.10   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          45.45     
Median TPOT (ms):                        45.52     
P99 TPOT (ms):                           45.86     
---------------Inter-token Latency----------------
Mean ITL (ms):                           45.45     
Median ITL (ms):                         38.46     
P99 ITL (ms):                            69.49     
==================================================
```

### With ENABLE_QUANTIZED_MATMUL_KERNEL=1
```
Successful requests:                     256       
Failed requests:                         0         
Benchmark duration (s):                  189.18    
Total input tokens:                      261892    
Total generated tokens:                  1048576   
Request throughput (req/s):              1.35      
Output token throughput (tok/s):         5542.82   
Peak output token throughput (tok/s):    7168.00   
Peak concurrent requests:                256.00    
Total Token throughput (tok/s):          6927.20   
---------------Time to First Token----------------
Mean TTFT (ms):                          3065.95   
Median TTFT (ms):                        2961.63   
P99 TTFT (ms):                           6182.34   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          45.23     
Median TPOT (ms):                        45.29     
P99 TPOT (ms):                           45.56     
---------------Inter-token Latency----------------
Mean ITL (ms):                           45.23     
Median ITL (ms):                         38.38     
P99 ITL (ms):                            69.20     
==================================================
```

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
