### PR TITLE
[multihost] Use make_array_from_process_local_data to create global array instead of device_put

### DIFF
--- a/tpu_inference/runner/compilation_manager.py
+++ b/tpu_inference/runner/compilation_manager.py
@@ -849,11 +849,11 @@ class CompilationManager:
                                                                                    num_reqs]
             dummy_grammar_bitmask = self.runner.grammar_bitmask_cpu[:num_reqs]
 
-            (dummy_logits, dummy_require_struct_decoding,
+            (dummy_require_struct_decoding,
              dummy_grammar_bitmask, arange) = device_array(
                  self.runner.mesh,
-                 (dummy_logits, dummy_require_struct_decoding,
-                  dummy_grammar_bitmask, self.runner.structured_decode_arange))
+                 (dummy_require_struct_decoding, dummy_grammar_bitmask,
+                  self.runner.structured_decode_arange))
 
             self._run_compilation(
                 "structured_decode",

--- a/tpu_inference/utils.py
+++ b/tpu_inference/utils.py
@@ -270,7 +270,7 @@ def device_array(mesh: Mesh, *args, sharding=None, **kwargs) -> jax.Array:
     """
     if sharding is None:
         sharding = NamedSharding(mesh, PartitionSpec(None))
-    return jax.device_put(*args, device=sharding, **kwargs)
+    return jax.make_array_from_process_local_data(sharding, *args)
 
 
 def get_hash_fn_by_name(hash_fn_name: str) -> Callable[[Any], bytes]:


### PR DESCRIPTION


# Description

device_put will introduce extra overhead by triggering tensor checks (github.com/jax-ml/jax/blob/main/jax/experimental/multihost_utils.py#L162-L166) when using multi-host. 

# Tests

Tested on v6e-8 with llama 8b and on v7x-16 with deepseek (20 layers)

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
