### PR TITLE
Fixed error when installing Python dependencies

### DIFF
--- a/.buildkite/scripts/setup_docker_env.sh
+++ b/.buildkite/scripts/setup_docker_env.sh
@@ -49,9 +49,6 @@ setup_environment() {
 
   echo "Cleanup complete."
 
-  echo "Installing Python dependencies"
-  python3 -m pip install --progress-bar off buildkite-test-collector==0.1.9
-  echo "Python dependencies installed"
   if [ -z "${BUILDKITE:-}" ]; then
       VLLM_COMMIT_HASH=""
       TPU_INFERENCE_HASH=$(git log -n 1 --pretty="%H")


### PR DESCRIPTION
# Description

Fixed a line of `pip install` that was causing an installation error after being included in the last auto-merge.
Remove line of `pip install` for avoid this error.

# Tests

Test in the local TPU environment.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have made or will make corresponding changes to any relevant documentation.
