### PR TITLE
Get all change files instead of last commit when bootstrap.

### DIFF
--- a/.buildkite/scripts/bootstrap.sh
+++ b/.buildkite/scripts/bootstrap.sh
@@ -17,9 +17,13 @@
 # --- Skip build if only docs/icons changed ---
 echo "--- :git: Checking changed files"
 
-# Get a list of all files changed in this commit
-FILES_CHANGED=$(git diff-tree --no-commit-id --name-only -r "$BUILDKITE_COMMIT")
+# Get merge base.
+MERGE_BASE=$(git merge-base main HEAD)
 
+# Get a list of all files changed in the PR
+FILES_CHANGED=$(git diff-tree --no-commit-id --name-only -r "$MERGE_BASE" HEAD)
+
+echo "Merge base: $MERGE_BASE"
 echo "Files changed:"
 echo "$FILES_CHANGED"
 


### PR DESCRIPTION
# Description

Today, the bootstrap.sh tries to get last commit in a PR to decide if test is needed. If a PR has 2 commits and the last commit is a "merge" commit or any type of commit that doesn't contains any code change, test will be skipped. 

This change is try to scan the whole PR to decide if test is needed.


