### PR TITLE
[Misc][RPA] Update to use logger in kernel_hd64.py

### DIFF
--- a/tpu_inference/kernels/ragged_paged_attention/v3/tuned_block_sizes_hd64.py
+++ b/tpu_inference/kernels/ragged_paged_attention/v3/tuned_block_sizes_hd64.py
@@ -295,7 +295,8 @@ def get_tuned_block_sizes(
         bkv_p, bq = TUNED_BLOCK_SIZES[device][page_size][dtypes][head_dims][
             max_model_len]
     except KeyError:
-        print('Couldn`t find tuned sizes for the RPA v3 kernel with %s', keys)
+        logger.warning_once(
+            'Couldn`t find tuned sizes for the RPA v3 kernel with %s', keys)
 
     return (min(pages_per_seq, bkv_p), min(max_num_tokens, bq))
 


### PR DESCRIPTION
# Description

Note that kernel.py already uses this

Before
```
(EngineCore_DP0 pid=1226027) Couldn`t find tuned sizes for the RPA v3 kernel with %s ('TPU v7', 128, 'q_bfloat16_kv_float8_e4m3fn', 'q_head-32_kv_head-4_head-64', 16384)
```

After
```
(EngineCore_DP0 pid=1246163) WARNING 12-12 12:36:46 [tuned_block_sizes_hd64.py:298] Couldn`t find tuned sizes for the RPA v3 kernel with ('TPU v7', 128, 'q_bfloat16_kv_float8_e4m3fn', 'q_head-32_kv_head-4_head-64', 16384)
```

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
