### PR TITLE
[Torchax] fp8 quantization skeleton

### DIFF
--- a/tests/layers/vllm/test_fp8.py
+++ b/tests/layers/vllm/test_fp8.py
@@ -1,0 +1,3 @@
+import pytest
+
+pytest.skip("FP8 implementation not complete yet", allow_module_level=True)

--- a/tpu_inference/layers/common/quant_methods.py
+++ b/tpu_inference/layers/common/quant_methods.py
@@ -2,6 +2,7 @@ UNQUANTIZED = "unquantized"
 MXFP4 = "mxfp4"
 AWQ = "awq"
 COMPRESSED_TENSORS = "compressed-tensors"
+FP8 = "fp8"
 
 
 def get_tpu_quant_method(quant_method: str) -> str:

--- a/tpu_inference/layers/vllm/quantization/__init__.py
+++ b/tpu_inference/layers/vllm/quantization/__init__.py
@@ -10,6 +10,7 @@ from tpu_inference.layers.vllm.quantization.awq import VllmAWQConfig
 from tpu_inference.layers.vllm.quantization.common import JaxCommonConfig
 from tpu_inference.layers.vllm.quantization.compressed_tensors.compressed_tensors import \
     VllmCompressedTensorsConfig  # noqa: E501
+from tpu_inference.layers.vllm.quantization.fp8 import VllmFp8Config
 from tpu_inference.layers.vllm.quantization.mxfp4 import VllmMxfp4Config
 from tpu_inference.layers.vllm.quantization.unquantized import \
     VllmUnquantizedConfig
@@ -23,6 +24,7 @@ def get_tpu_quantization_config(vllm_config: VllmConfig,
         None: VllmUnquantizedConfig,
         quant_methods.COMPRESSED_TENSORS: VllmCompressedTensorsConfig,
         quant_methods.AWQ: VllmAWQConfig,
+        quant_methods.FP8: VllmFp8Config,
         quant_methods.MXFP4: VllmMxfp4Config,
     }
     if model_config.quantization not in method_to_config:

--- a/tpu_inference/layers/vllm/quantization/awq.py
+++ b/tpu_inference/layers/vllm/quantization/awq.py
@@ -39,7 +39,7 @@ class VllmAWQConfig(AWQConfig, JaxCommonConfig):
 
     def get_supported_act_dtypes(self) -> list[torch.dtype]:
         # NOTE: AWQ checkpoint was quantized with float16. But on TPUs, using
-        # bfloat16 is signifcantly preferred over foat16. This might lead to
+        # bfloat16 is significantly preferred over float16. This might lead to
         # some numeric output change.
         return [torch.bfloat16]
 

--- a/tpu_inference/layers/vllm/quantization/fp8.py
+++ b/tpu_inference/layers/vllm/quantization/fp8.py
@@ -1,0 +1,104 @@
+from typing import Optional, Union
+
+import jax
+import torch
+from jax.sharding import PartitionSpec
+from vllm.logger import init_logger
+from vllm.model_executor.layers.fused_moe.layer import FusedMoE
+from vllm.model_executor.layers.linear import LinearBase, LinearMethodBase
+from vllm.model_executor.layers.quantization import \
+    register_quantization_config
+from vllm.model_executor.layers.quantization.base_config import \
+    QuantizeMethodBase
+from vllm.model_executor.layers.quantization.fp8 import (Fp8Config,
+                                                         Fp8LinearMethod)
+from vllm.model_executor.layers.quantization.utils.quant_utils import \
+    is_layer_skipped
+
+from tpu_inference.layers.common.quant_methods import FP8, get_tpu_quant_method
+from tpu_inference.layers.vllm.quantization.common import (
+    JaxCommonConfig, JaxCommonLinearConfig)
+from tpu_inference.layers.vllm.quantization.unquantized import \
+    VllmUnquantizedLinearMethod
+
+P = PartitionSpec
+logger = init_logger(__name__)
+
+
+@register_quantization_config(get_tpu_quant_method(FP8))
+class VllmFp8Config(Fp8Config, JaxCommonConfig):
+
+    @classmethod
+    def get_name(cls):
+        return FP8
+
+    def get_supported_act_dtypes(self) -> list[torch.dtype]:
+        return [torch.bfloat16]
+
+    def get_quant_method(
+        self, layer: torch.nn.Module, prefix: str
+    ) -> Optional[Union["LinearMethodBase", "QuantizeMethodBase"]]:
+        if isinstance(layer, LinearBase):
+            linear_config = self.get_linear_config(layer)
+            if is_layer_skipped(prefix, self.ignored_layers):
+                return VllmUnquantizedLinearMethod(linear_config)
+            return VllmFp8LinearMethod(self, linear_config)
+        elif isinstance(layer, FusedMoE):
+            raise NotImplementedError(
+                "FP8 FusedMoE is currently not supported in torchax-jax")
+        return None
+
+
+class VllmFp8LinearMethod(Fp8LinearMethod):
+
+    def __init__(self, quant_config: VllmFp8Config,
+                 jax_config: JaxCommonLinearConfig):
+        super().__init__(quant_config)
+        self.jax_config = jax_config
+        self._configure_sharding()
+
+    def _configure_sharding(self) -> None:
+
+        raise NotImplementedError(
+            "Configure PartitionSpec for weight_sharding and scale_sharding "
+            "based on layer type (RowParallel/ColumnParallel)")
+
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+
+        raise NotImplementedError(
+            "Convert layer.weight, layer.weight_scale, and optionally "
+            "layer.input_scale and layer.bias from torch tensors to JAX arrays "
+            "using torch_to_jax_param() with appropriate sharding")
+
+    def apply(self,
+              layer: torch.nn.Module,
+              x: torch.Tensor,
+              bias: Optional[torch.Tensor] = None) -> torch.Tensor:
+
+        with jax.named_scope(layer._get_name()):
+            if self.jax_config.fuse_matmuls:
+                out = self._apply_fused(layer, x, bias)
+            else:
+                out = self._apply_split(layer, x, bias)
+
+        return out
+
+    def _apply_fused(self,
+                     layer: torch.nn.Module,
+                     x: torch.Tensor,
+                     bias: Optional[torch.Tensor] = None) -> torch.Tensor:
+
+        raise NotImplementedError(
+            "Implement single matmul for fused outputs: "
+            "quantize input to fp8, perform fp8 matmul with weight and scales, "
+            "dequantize output, and add bias if present")
+
+    def _apply_split(self,
+                     layer: torch.nn.Module,
+                     x: torch.Tensor,
+                     bias: Optional[torch.Tensor] = None) -> torch.Tensor:
+
+        raise NotImplementedError(
+            "Implement separate matmuls per output partition: "
+            "split weight/scale by output_sizes, perform fp8 matmul for each, "
+            "concatenate results, and add bias if present")


### PR DESCRIPTION
# Description

This PR adds the infrastructure skeleton for FP8 quantization support on TPU, following the established pattern from AWQ quantization.

Changes
- Added FP8 constant to quant_methods.py
- Created VllmFp8Config extending Fp8Config and JaxCommonConfig
- Created VllmFp8LinearMethod extending Fp8LinearMethod with skeleton methods
- Registered FP8 in quantization method registry
- Added placeholder test file
- Fixed typo in awq.py comments

Addressing https://github.com/vllm-project/tpu-inference/issues/1121.

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
