### PR TITLE
Fix a test pipeline bug and add TODO.

### DIFF
--- a/.buildkite/pipeline_jax_tpu7x.yml
+++ b/.buildkite/pipeline_jax_tpu7x.yml
@@ -267,6 +267,7 @@ steps:
      env:
        USE_V6E8_QUEUE: "True"
        VLLM_LOG_LEVEL: "INFO"
+       IS_FOR_V7X: "true"
      agents:
        queue: tpu_v7x_8_queue
      commands:

--- a/.buildkite/scripts/run_in_docker.sh
+++ b/.buildkite/scripts/run_in_docker.sh
@@ -48,6 +48,9 @@ else
   exit 1
 fi
 
+# Some test scripts set tp=2 on IS_FOR_V7X=true to mitigate test failures.
+# TODO (Qiliang Cui) Investigate why tensor-parallel-size=1 breaks in tpu7x.
+
 exec docker run \
   --privileged \
   --net host \

--- a/tests/e2e/benchmarking/mlperf.sh
+++ b/tests/e2e/benchmarking/mlperf.sh
@@ -140,6 +140,7 @@ if [ "$USE_V6E8_QUEUE" == "True" ]; then
     extra_serve_args+=(--tensor-parallel-size 8)
 elif [ "$IS_FOR_V7X" == "true" ]; then
     # Set the default value to 2 for tpu v7x
+    # TODO (Qiliang Cui) Investigate why tensor-parallel-size=1 breaks in tpu7x
     extra_serve_args+=(--tensor-parallel-size 2)
 else
     extra_serve_args+=(--tensor-parallel-size 1)


### PR DESCRIPTION
# Description

Fix [TPU7x lora unit tests on multi chips](https://buildkite.com/tpu-commons/tpu-inference-ci/builds/6796#019b0c6c-b4ce-4abd-a3df-c7ac0a373ddc). 

The reason is missing "IS_FOR_V7X" environment variable so the image was built with v6 compatible libs.

# Test
On tpu7x-8 machine, local run

```
BUILDKITE_COMMIT=$(git rev-parse HEAD) .buildkite/scripts/run_in_docker.sh \
     bash -c 'python3 -m pytest -s -v -x /workspace/tpu_inference/tests/lora/test_layers.py'
```

to reproduce the issue and run:
```
IS_FOR_V7X=true BUILDKITE_COMMIT=$(git rev-parse HEAD) .buildkite/scripts/run_in_docker.sh \
     bash -c 'python3 -m pytest -s -v -x /workspace/tpu_inference/tests/lora/test_layers.py'
```
to see the fix

# Misc.

Add to TODO as follow up of [PR](https://github.com/vllm-project/tpu-inference/pull/1305)
