### PR TITLE
[CI] Extend nightly tests on both v6e and v7x

### DIFF
--- a/.buildkite/features/Collective_Communication_Matmul.yml
+++ b/.buildkite/features/Collective_Communication_Matmul.yml
@@ -15,17 +15,20 @@
 # pipeline-name: Collective Communication Matmul
 # pipeline-type: kernel support matrix
 steps:
-  - label: "Correctness tests for Collective Communication Matmul"
-    key: "Collective_Communication_Matmul_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Correctness tests for Collective Communication Matmul"
+    key: "${TPU_VERSION:-tpu6e}_Collective_Communication_Matmul_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - .buildkite/scripts/run_in_docker.sh python3 -m pytest -s -v /workspace/tpu_inference/tests/kernels/collectives/all_gather_matmul_kernel_test.py
-  - label: "Record correctness test result for Collective Communication Matmul"
-    key: "record_Collective_Communication_Matmul_CorrectnessTest"
-    depends_on: "Collective_Communication_Matmul_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for Collective Communication Matmul"
+    key: "${TPU_VERSION:-tpu6e}_record_Collective_Communication_Matmul_CorrectnessTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_Collective_Communication_Matmul_CorrectnessTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "Collective Communication Matmul"
       CI_STAGE: "CorrectnessTest"
       CI_CATEGORY: "kernel support matrix"
@@ -33,21 +36,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh Collective_Communication_Matmul_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_Collective_Communication_Matmul_CorrectnessTest
 
-  - label: "Performance tests for Collective Communication Matmul"
-    key: "Collective_Communication_Matmul_PerformanceTest"
-    depends_on: "record_Collective_Communication_Matmul_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Performance tests for Collective Communication Matmul"
+    key: "${TPU_VERSION:-tpu6e}_Collective_Communication_Matmul_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_record_Collective_Communication_Matmul_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "Collective_Communication_Matmul_PerformanceTest" "unverified"
-  - label: "Record performance test result for Collective Communication Matmul"
-    key: "record_Collective_Communication_Matmul_PerformanceTest"
-    depends_on: "Collective_Communication_Matmul_PerformanceTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_Collective_Communication_Matmul_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record performance test result for Collective Communication Matmul"
+    key: "${TPU_VERSION:-tpu6e}_record_Collective_Communication_Matmul_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_Collective_Communication_Matmul_PerformanceTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "Collective Communication Matmul"
       CI_STAGE: "PerformanceTest"
       CI_CATEGORY: "kernel support matrix"
@@ -55,4 +61,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh Collective_Communication_Matmul_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_Collective_Communication_Matmul_PerformanceTest

--- a/.buildkite/features/DCN-Based_P-D_disaggregation.yml
+++ b/.buildkite/features/DCN-Based_P-D_disaggregation.yml
@@ -15,18 +15,21 @@
 # pipeline-name: DCN-based P/D disaggregation
 # pipeline-type: feature support matrix
 steps:
-  - label: "Correctness tests for DCN-based P/D disaggregation"
-    key: "DCN_based_P-D_disaggregation_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Correctness tests for DCN-based P/D disaggregation"
+    key: "${TPU_VERSION:-tpu6e}_DCN_based_P-D_disaggregation_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "DCN_based_P-D_disaggregation_CorrectnessTest" "unverified"
-  - label: "Record correctness test result for DCN-based P/D disaggregation"
-    key: "record_DCN_based_P-D_disaggregation_CorrectnessTest"
-    depends_on: "DCN_based_P-D_disaggregation_CorrectnessTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_DCN_based_P-D_disaggregation_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for DCN-based P/D disaggregation"
+    key: "${TPU_VERSION:-tpu6e}_record_DCN_based_P-D_disaggregation_CorrectnessTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_DCN_based_P-D_disaggregation_CorrectnessTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "DCN-based P/D disaggregation"
       CI_STAGE: "CorrectnessTest"
       CI_CATEGORY: "feature support matrix"
@@ -34,28 +37,30 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh DCN_based_P-D_disaggregation_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_DCN_based_P-D_disaggregation_CorrectnessTest
 
-  - label: "Performance tests for DCN-based P/D disaggregation"
-    key: "DCN_based_P-D_disaggregation_PerformanceTest"
+  - label: "${TPU_VERSION:-tpu6e} Performance tests for DCN-based P/D disaggregation"
+    key: "${TPU_VERSION:-tpu6e}_DCN_based_P-D_disaggregation_PerformanceTest"
     soft_fail: true
     env:
-      MODEL:"Qwen/Qwen3-0.6B"
-      INPUT_LEN:1024
-      OUTPUT_LEN:1024
-      NUM_PROMPTS:20
-      RANDOM_SEED:10
-      MAX_CONCURRENCY:1
+      IS_FOR_V7X: "${IS_FOR_V7X}"
+      MODEL: "Qwen/Qwen3-0.6B"
+      INPUT_LEN: 1024
+      OUTPUT_LEN: 1024
+      NUM_PROMPTS: 20
+      RANDOM_SEED: 10
+      MAX_CONCURRENCY: 1
     agents:
-      queue: tpu_v6e_8_queue
+      queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
     commands:
       - |
         .buildkite/scripts/run_disagg.sh
 
-  - label: "Record performance test result for DCN-based P/D disaggregation"
-    key: "record_DCN_based_P-D_disaggregation_PerformanceTest"
-    depends_on: "DCN_based_P-D_disaggregation_PerformanceTest"
+  - label: "${TPU_VERSION:-tpu6e} Record performance test result for DCN-based P/D disaggregation"
+    key: "${TPU_VERSION:-tpu6e}_record_DCN_based_P-D_disaggregation_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_DCN_based_P-D_disaggregation_PerformanceTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "DCN-based P/D disaggregation"
       CI_STAGE: "PerformanceTest"
       CI_CATEGORY: "feature support matrix"
@@ -63,4 +68,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh DCN_based_P-D_disaggregation_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_DCN_based_P-D_disaggregation_PerformanceTest

--- a/.buildkite/features/Hybrid_kvcache.yml
+++ b/.buildkite/features/Hybrid_kvcache.yml
@@ -12,32 +12,36 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# hybrid kv cache
+# pipeline-name: hybrid kv cache
+# pipeline-type: feature support matrix
 # Hybrid kv cache allows the kv cache mgr to allocate different number of 
 # blocks for different attention types. This is useful for models with more 
 # than 1 attention type (e.g. opt-oss 120b, gemma-27b 
 # with full + sliding window attn) to save HBM memory for kv cache and be able
 # to accomodate more requests. 
 steps:
-  - label: "Correctness tests for hybrid kv cache allocation"
-    key: "hybrid_kvcache_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Correctness tests for hybrid kv cache allocation"
+    key: "${TPU_VERSION:-tpu6e}_hybrid_kvcache_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_8_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh \
           python3 -m pytest -s -v /workspace/tpu_inference/tests/e2e/test_hybrid_kvcache.py::test_hybrid_kv_cache \
           /workspace/tpu_inference/tests/e2e/test_hybrid_kvcache.py::test_hybrid_kv_cache_correctness
-  - label: "Record correctness test result for hybrid kv cache allocation"
-    key: "record_hybrid_kvcache_CorrectnessTest"
-    depends_on: "hybrid_kvcache_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for hybrid kv cache allocation"
+    key: "${TPU_VERSION:-tpu6e}_record_hybrid_kvcache_CorrectnessTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_hybrid_kvcache_CorrectnessTest"
     env:
-      CI_TARGET: "hybrid_kvcache"
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
+      CI_TARGET: "hybrid kv cache"
       CI_STAGE: "CorrectnessTest"
       CI_CATEGORY: "feature support matrix"
     agents:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh hybrid_kvcache_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_hybrid_kvcache_CorrectnessTest

--- a/.buildkite/features/KV_Cache_Host_Offloading.yml
+++ b/.buildkite/features/KV_Cache_Host_Offloading.yml
@@ -15,18 +15,21 @@
 # pipeline-name: KV cache host offloading
 # pipeline-type: feature support matrix
 steps:
-  - label: "Correctness tests for KV cache host offloading"
-    key: "KV_Cache_Host_Offloading_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Correctness tests for KV cache host offloading"
+    key: "${TPU_VERSION:-tpu6e}_KV_Cache_Host_Offloading_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "KV_Cache_Host_Offloading_CorrectnessTest" "unverified"
-  - label: "Record correctness test result for KV cache host offloading"
-    key: "record_KV_Cache_Host_Offloading_CorrectnessTest"
-    depends_on: "KV_Cache_Host_Offloading_CorrectnessTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_KV_Cache_Host_Offloading_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for KV cache host offloading"
+    key: "${TPU_VERSION:-tpu6e}_record_KV_Cache_Host_Offloading_CorrectnessTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_KV_Cache_Host_Offloading_CorrectnessTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "KV cache host offloading"
       CI_STAGE: "CorrectnessTest"
       CI_CATEGORY: "feature support matrix"
@@ -34,21 +37,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh KV_Cache_Host_Offloading_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_KV_Cache_Host_Offloading_CorrectnessTest
 
-  - label: "Performance tests for KV cache host offloading"
-    key: "KV_Cache_Host_Offloading_PerformanceTest"
-    depends_on: "record_KV_Cache_Host_Offloading_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Performance tests for KV cache host offloading"
+    key: "${TPU_VERSION:-tpu6e}_KV_Cache_Host_Offloading_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_record_KV_Cache_Host_Offloading_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "KV_Cache_Host_Offloading_PerformanceTest" "unverified"
-  - label: "Record performance test result for KV cache host offloading"
-    key: "record_KV_Cache_Host_Offloading_PerformanceTest"
-    depends_on: "KV_Cache_Host_Offloading_PerformanceTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_KV_Cache_Host_Offloading_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record performance test result for KV cache host offloading"
+    key: "${TPU_VERSION:-tpu6e}_record_KV_Cache_Host_Offloading_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_KV_Cache_Host_Offloading_PerformanceTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "KV cache host offloading"
       CI_STAGE: "PerformanceTest"
       CI_CATEGORY: "feature support matrix"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh KV_Cache_Host_Offloading_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_KV_Cache_Host_Offloading_PerformanceTest

--- a/.buildkite/features/LoRA_Torch.yml
+++ b/.buildkite/features/LoRA_Torch.yml
@@ -15,19 +15,22 @@
 # pipeline-name: LoRA_Torch
 # pipeline-type: feature support matrix
 steps:
-  - label: "Correctness tests for LoRA_Torch"
-    key: "LoRA_Torch_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Correctness tests for LoRA_Torch"
+    key: "${TPU_VERSION:-tpu6e}_LoRA_Torch_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh \
           bash -c 'MODEL_IMPL_TYPE=vllm TPU_BACKEND_TYPE=jax python3 -m pytest -s -v -x /workspace/tpu_inference/tests/lora/test_lora.py'
-  - label: "Record correctness test result for LoRA_Torch"
-    key: "record_LoRA_Torch_CorrectnessTest"
-    depends_on: "LoRA_Torch_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for LoRA_Torch"
+    key: "${TPU_VERSION:-tpu6e}_record_LoRA_Torch_CorrectnessTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_LoRA_Torch_CorrectnessTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "LoRA_Torch"
       CI_STAGE: "CorrectnessTest"
       CI_CATEGORY: "feature support matrix"
@@ -35,22 +38,25 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh LoRA_Torch_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_LoRA_Torch_CorrectnessTest
 
-  - label: "Performance tests for LoRA_Torch"
-    key: "LoRA_Torch_PerformanceTest"
-    depends_on: "record_LoRA_Torch_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Performance tests for LoRA_Torch"
+    key: "${TPU_VERSION:-tpu6e}_LoRA_Torch_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_record_LoRA_Torch_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh \
           bash -c 'MODEL_IMPL_TYPE=vllm TPU_BACKEND_TYPE=jax python3 -m pytest -s -v -x /workspace/tpu_inference/tests/lora/test_lora_perf.py'
-  - label: "Record performance test result for LoRA_Torch"
-    key: "record_LoRA_Torch_PerformanceTest"
-    depends_on: "LoRA_Torch_PerformanceTest"
+  - label: "${TPU_VERSION:-tpu6e} Record performance test result for LoRA_Torch"
+    key: "${TPU_VERSION:-tpu6e}_record_LoRA_Torch_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_LoRA_Torch_PerformanceTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "LoRA_Torch"
       CI_STAGE: "PerformanceTest"
       CI_CATEGORY: "feature support matrix"
@@ -58,4 +64,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh LoRA_Torch_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_LoRA_Torch_PerformanceTest

--- a/.buildkite/features/MLA.yml
+++ b/.buildkite/features/MLA.yml
@@ -15,18 +15,21 @@
 # pipeline-name: MLA
 # pipeline-type: kernel support matrix
 steps:
-  - label: "Correctness tests for MLA"
-    key: "MLA_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Correctness tests for MLA"
+    key: "${TPU_VERSION:-tpu6e}_MLA_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "MLA_CorrectnessTest" "unverified"
-  - label: "Record correctness test result for MLA"
-    key: "record_MLA_CorrectnessTest"
-    depends_on: "MLA_CorrectnessTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_MLA_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for MLA"
+    key: "${TPU_VERSION:-tpu6e}_record_MLA_CorrectnessTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_MLA_CorrectnessTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "MLA"
       CI_STAGE: "CorrectnessTest"
       CI_CATEGORY: "kernel support matrix"
@@ -34,21 +37,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh MLA_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_MLA_CorrectnessTest
 
-  - label: "Performance tests for MLA"
-    key: "MLA_PerformanceTest"
-    depends_on: "record_MLA_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Performance tests for MLA"
+    key: "${TPU_VERSION:-tpu6e}_MLA_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_record_MLA_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "MLA_PerformanceTest" "unverified"
-  - label: "Record performance test result for MLA"
-    key: "record_MLA_PerformanceTest"
-    depends_on: "MLA_PerformanceTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_MLA_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record performance test result for MLA"
+    key: "${TPU_VERSION:-tpu6e}_record_MLA_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_MLA_PerformanceTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "MLA"
       CI_STAGE: "PerformanceTest"
       CI_CATEGORY: "kernel support matrix"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh MLA_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_MLA_PerformanceTest

--- a/.buildkite/features/MoE.yml
+++ b/.buildkite/features/MoE.yml
@@ -15,18 +15,21 @@
 # pipeline-name: MoE
 # pipeline-type: kernel support matrix
 steps:
-  - label: "Correctness tests for MoE"
-    key: "MoE_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Correctness tests for MoE"
+    key: "${TPU_VERSION:-tpu6e}_MoE_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "MoE_CorrectnessTest" "unverified"
-  - label: "Record correctness test result for MoE"
-    key: "record_MoE_CorrectnessTest"
-    depends_on: "MoE_CorrectnessTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_MoE_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for MoE"
+    key: "${TPU_VERSION:-tpu6e}_record_MoE_CorrectnessTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_MoE_CorrectnessTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "MoE"
       CI_STAGE: "CorrectnessTest"
       CI_CATEGORY: "kernel support matrix"
@@ -34,21 +37,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh MoE_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_MoE_CorrectnessTest
 
-  - label: "Performance tests for MoE"
-    key: "MoE_PerformanceTest"
-    depends_on: "record_MoE_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Performance tests for MoE"
+    key: "${TPU_VERSION:-tpu6e}_MoE_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_record_MoE_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "MoE_PerformanceTest" "unverified"
-  - label: "Record performance test result for MoE"
-    key: "record_MoE_PerformanceTest"
-    depends_on: "MoE_PerformanceTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_MoE_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record performance test result for MoE"
+    key: "${TPU_VERSION:-tpu6e}_record_MoE_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_MoE_PerformanceTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "MoE"
       CI_STAGE: "PerformanceTest"
       CI_CATEGORY: "kernel support matrix"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh MoE_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_MoE_PerformanceTest

--- a/.buildkite/features/Multimodal_Inputs.yml
+++ b/.buildkite/features/Multimodal_Inputs.yml
@@ -15,43 +15,49 @@
 # pipeline-name: Multimodal Inputs
 # pipeline-type: feature support matrix
 steps:
-  - label: "Correctness tests for Multimodal Inputs"
-    key: "Multimodal_Inputs_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Correctness tests for Multimodal Inputs"
+    key: "${TPU_VERSION:-tpu6e}_Multimodal_Inputs_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - .buildkite/scripts/run_in_docker.sh python3 -m pytest -s -v /workspace/tpu_inference/tests/e2e/test_multi_modal_inference.py
-  - label: "Record correctness test result for Multimodal Inputs"
-    key: "record_Multimodal_Inputs_CorrectnessTest"
-    depends_on: "Multimodal_Inputs_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for Multimodal Inputs"
+    key: "${TPU_VERSION:-tpu6e}_record_Multimodal_Inputs_CorrectnessTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_Multimodal_Inputs_CorrectnessTest"
     env:
-      CI_TARGET: Multimodal Inputs
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
+      CI_TARGET: "Multimodal Inputs"
       CI_STAGE: "CorrectnessTest"
       CI_CATEGORY: "feature support matrix"
     agents:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh Multimodal_Inputs_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_Multimodal_Inputs_CorrectnessTest
 
-  - label: "Performance tests for Multimodal Inputs"
-    key: "Multimodal_Inputs_PerformanceTest"
-    depends_on: "record_Multimodal_Inputs_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Performance tests for Multimodal Inputs"
+    key: "${TPU_VERSION:-tpu6e}_Multimodal_Inputs_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_record_Multimodal_Inputs_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/mm_bench.sh
-  - label: "Record performance test result for Multimodal Inputs"
-    key: "record_Multimodal_Inputs_PerformanceTest"
-    depends_on: "Multimodal_Inputs_PerformanceTest"
+  - label: "${TPU_VERSION:-tpu6e} Record performance test result for Multimodal Inputs"
+    key: "${TPU_VERSION:-tpu6e}_record_Multimodal_Inputs_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_Multimodal_Inputs_PerformanceTest"
     env:
-      CI_TARGET: Multimodal Inputs
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
+      CI_TARGET: "Multimodal Inputs"
       CI_STAGE: "PerformanceTest"
       CI_CATEGORY: "feature support matrix"
     agents:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh Multimodal_Inputs_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_Multimodal_Inputs_PerformanceTest

--- a/.buildkite/features/Out_Of_Tree_Model_Support.yml
+++ b/.buildkite/features/Out_Of_Tree_Model_Support.yml
@@ -15,21 +15,24 @@
 # pipeline-name: Out-of-tree model support
 # pipeline-type: feature support matrix
 steps:
-  - label: "Correctness tests for Out-of-tree model support"
-    key: "out_of_tree_model_support_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Correctness tests for Out-of-tree model support"
+    key: "${TPU_VERSION:-tpu6e}_out_of_tree_model_support_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh \
           python3 -m pytest -s -v /workspace/tpu_inference/tests/e2e/test_model_loader.py::test_register_model_success \
           /workspace/tpu_inference/tests/e2e/test_model_loader.py::test_registered_model_passes_vllm_interface_check
 
-  - label: "Record correctness test result for Out-of-tree model support"
-    key: "record_out_of_tree_model_support_CorrectnessTest"
-    depends_on: "out_of_tree_model_support_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for Out-of-tree model support"
+    key: "${TPU_VERSION:-tpu6e}_record_out_of_tree_model_support_CorrectnessTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_out_of_tree_model_support_CorrectnessTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "Out-of-tree model support"
       CI_STAGE: "CorrectnessTest"
       CI_CATEGORY: "feature support matrix"
@@ -37,23 +40,26 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh out_of_tree_model_support_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_out_of_tree_model_support_CorrectnessTest
 
-  - label: "Performance tests for Out-of-tree model support"
-    key: "out_of_tree_model_support_PerformanceTest"
-    depends_on: "record_out_of_tree_model_support_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Performance tests for Out-of-tree model support"
+    key: "${TPU_VERSION:-tpu6e}_out_of_tree_model_support_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_record_out_of_tree_model_support_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh \
           python3 -m pytest -s -v /workspace/tpu_inference/tests/e2e/test_model_loader.py::test_flax_nnx_vs_vllm_performance
 
-  - label: "Record performance test result for Out-of-tree model support"
-    key: "record_out_of_tree_model_support_PerformanceTest"
-    depends_on: "out_of_tree_model_support_PerformanceTest"
+  - label: "${TPU_VERSION:-tpu6e} Record performance test result for Out-of-tree model support"
+    key: "${TPU_VERSION:-tpu6e}_record_out_of_tree_model_support_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_out_of_tree_model_support_PerformanceTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "Out-of-tree model support"
       CI_STAGE: "PerformanceTest"
       CI_CATEGORY: "feature support matrix"
@@ -61,4 +67,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh out_of_tree_model_support_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_out_of_tree_model_support_PerformanceTest

--- a/.buildkite/features/Quantized_Attention.yml
+++ b/.buildkite/features/Quantized_Attention.yml
@@ -15,18 +15,21 @@
 # pipeline-name: Quantized Attention
 # pipeline-type: kernel support matrix
 steps:
-  - label: "Correctness tests for Quantized Attention"
-    key: "Quantized_Attention_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Correctness tests for Quantized Attention"
+    key: "${TPU_VERSION:-tpu6e}_Quantized_Attention_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "Quantized_Attention_CorrectnessTest" "unverified"
-  - label: "Record correctness test result for Quantized Attention"
-    key: "record_Quantized_Attention_CorrectnessTest"
-    depends_on: "Quantized_Attention_CorrectnessTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_Quantized_Attention_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for Quantized Attention"
+    key: "${TPU_VERSION:-tpu6e}_record_Quantized_Attention_CorrectnessTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_Quantized_Attention_CorrectnessTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "Quantized Attention"
       CI_STAGE: "CorrectnessTest"
       CI_CATEGORY: "kernel support matrix"
@@ -34,21 +37,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh Quantized_Attention_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_Quantized_Attention_CorrectnessTest
 
-  - label: "Performance tests for Quantized Attention"
-    key: "Quantized_Attention_PerformanceTest"
-    depends_on: "record_Quantized_Attention_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Performance tests for Quantized Attention"
+    key: "${TPU_VERSION:-tpu6e}_Quantized_Attention_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_record_Quantized_Attention_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "Quantized_Attention_PerformanceTest" "unverified"
-  - label: "Record performance test result for Quantized Attention"
-    key: "record_Quantized_Attention_PerformanceTest"
-    depends_on: "Quantized_Attention_PerformanceTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_Quantized_Attention_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record performance test result for Quantized Attention"
+    key: "${TPU_VERSION:-tpu6e}_record_Quantized_Attention_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_Quantized_Attention_PerformanceTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "Quantized Attention"
       CI_STAGE: "PerformanceTest"
       CI_CATEGORY: "kernel support matrix"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh Quantized_Attention_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_Quantized_Attention_PerformanceTest

--- a/.buildkite/features/Quantized_KV_Cache.yml
+++ b/.buildkite/features/Quantized_KV_Cache.yml
@@ -15,18 +15,21 @@
 # pipeline-name: Quantized KV Cache
 # pipeline-type: kernel support matrix
 steps:
-  - label: "Correctness tests for Quantized KV Cache"
-    key: "Quantized_KV_Cache_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Correctness tests for Quantized KV Cache"
+    key: "${TPU_VERSION:-tpu6e}_Quantized_KV_Cache_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "Quantized_KV_Cache_CorrectnessTest" "unverified"
-  - label: "Record correctness test result for Quantized KV Cache"
-    key: "record_Quantized_KV_Cache_CorrectnessTest"
-    depends_on: "Quantized_KV_Cache_CorrectnessTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_Quantized_KV_Cache_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for Quantized KV Cache"
+    key: "${TPU_VERSION:-tpu6e}_record_Quantized_KV_Cache_CorrectnessTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_Quantized_KV_Cache_CorrectnessTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "Quantized KV Cache"
       CI_STAGE: "CorrectnessTest"
       CI_CATEGORY: "kernel support matrix"
@@ -34,21 +37,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh Quantized_KV_Cache_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_Quantized_KV_Cache_CorrectnessTest
 
-  - label: "Performance tests for Quantized KV Cache"
-    key: "Quantized_KV_Cache_PerformanceTest"
-    depends_on: "record_Quantized_KV_Cache_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Performance tests for Quantized KV Cache"
+    key: "${TPU_VERSION:-tpu6e}_Quantized_KV_Cache_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_record_Quantized_KV_Cache_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "Quantized_KV_Cache_PerformanceTest" "unverified"
-  - label: "Record performance test result for Quantized KV Cache"
-    key: "record_Quantized_KV_Cache_PerformanceTest"
-    depends_on: "Quantized_KV_Cache_PerformanceTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_Quantized_KV_Cache_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record performance test result for Quantized KV Cache"
+    key: "${TPU_VERSION:-tpu6e}_record_Quantized_KV_Cache_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_Quantized_KV_Cache_PerformanceTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "Quantized KV Cache"
       CI_STAGE: "PerformanceTest"
       CI_CATEGORY: "kernel support matrix"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh Quantized_KV_Cache_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_Quantized_KV_Cache_PerformanceTest

--- a/.buildkite/features/Quantized_Matmul.yml
+++ b/.buildkite/features/Quantized_Matmul.yml
@@ -15,18 +15,21 @@
 # pipeline-name: Quantized Matmul
 # pipeline-type: kernel support matrix
 steps:
-  - label: "Correctness tests for Quantized Matmul"
-    key: "Quantized_Matmul_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Correctness tests for Quantized Matmul"
+    key: "${TPU_VERSION:-tpu6e}_Quantized_Matmul_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "Quantized_Matmul_CorrectnessTest" "unverified"
-  - label: "Record correctness test result for Quantized Matmul"
-    key: "record_Quantized_Matmul_CorrectnessTest"
-    depends_on: "Quantized_Matmul_CorrectnessTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_Quantized_Matmul_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for Quantized Matmul"
+    key: "${TPU_VERSION:-tpu6e}_record_Quantized_Matmul_CorrectnessTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_Quantized_Matmul_CorrectnessTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "Quantized Matmul"
       CI_STAGE: "CorrectnessTest"
       CI_CATEGORY: "kernel support matrix"
@@ -34,21 +37,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh Quantized_Matmul_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_Quantized_Matmul_CorrectnessTest
 
-  - label: "Performance tests for Quantized Matmul"
-    key: "Quantized_Matmul_PerformanceTest"
-    depends_on: "record_Quantized_Matmul_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Performance tests for Quantized Matmul"
+    key: "${TPU_VERSION:-tpu6e}_Quantized_Matmul_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_record_Quantized_Matmul_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "Quantized_Matmul_PerformanceTest" "unverified"
-  - label: "Record performance test result for Quantized Matmul"
-    key: "record_Quantized_Matmul_PerformanceTest"
-    depends_on: "Quantized_Matmul_PerformanceTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_Quantized_Matmul_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record performance test result for Quantized Matmul"
+    key: "${TPU_VERSION:-tpu6e}_record_Quantized_Matmul_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_Quantized_Matmul_PerformanceTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "Quantized Matmul"
       CI_STAGE: "PerformanceTest"
       CI_CATEGORY: "kernel support matrix"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh Quantized_Matmul_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_Quantized_Matmul_PerformanceTest

--- a/.buildkite/features/Single-Host-P-D-disaggregation.yml
+++ b/.buildkite/features/Single-Host-P-D-disaggregation.yml
@@ -13,27 +13,30 @@
 # limitations under the License.
 
 # pipeline-name: Single-Host-P-D-disaggregation
-# pipeline-type: features support matrix
+# pipeline-type: feature support matrix
 steps:
-  - label: "Correctness tests for Single-Host P-D disaggregation"
-    key: "SingleHostPDDisaggregation_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Correctness tests for Single-Host P-D disaggregation"
+    key: "${TPU_VERSION:-tpu6e}_SingleHostPDDisaggregation_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_8_queue
+      queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh \
           python3 -m pytest -s -v /workspace/tpu_inference/tests/e2e/test_local_disagg.py::test_disaggregated_serving \
           /workspace/tpu_inference/tests/e2e/test_local_disagg.py::test_disaggregated_serving_correctness
-  - label: "Record correctness test result for Single-Host P-D disaggregation"
-    key: "record_SingleHostPDDisaggregation_CorrectnessTest"
-    depends_on: "SingleHostPDDisaggregation_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for Single-Host P-D disaggregation"
+    key: "${TPU_VERSION:-tpu6e}_record_SingleHostPDDisaggregation_CorrectnessTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_SingleHostPDDisaggregation_CorrectnessTest"
     env:
-      CI_TARGET: "SingleHostPDDisaggregation"
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
+      CI_TARGET: "Single-Host-P-D-disaggregation"
       CI_STAGE: "CorrectnessTest"
-      CI_CATEGORY: "features support matrix"
+      CI_CATEGORY: "feature support matrix"
     agents:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh SingleHostPDDisaggregation_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_SingleHostPDDisaggregation_CorrectnessTest

--- a/.buildkite/features/Speculative_Decoding-_Eagle3.yml
+++ b/.buildkite/features/Speculative_Decoding-_Eagle3.yml
@@ -15,19 +15,22 @@
 # pipeline-name: Speculative Decoding: Eagle3
 # pipeline-type: feature support matrix
 steps:
-  - label: "Correctness tests for Speculative Decoding: Eagle3"
-    key: "Speculative_Decoding-_Eagle3_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Correctness tests for Speculative Decoding: Eagle3"
+    key: "${TPU_VERSION:-tpu6e}_Speculative_Decoding-_Eagle3_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh \
           python3 -m pytest -s -v /workspace/tpu_inference/tests/e2e/test_speculative_decoding.py::test_eagle3_correctness
-  - label: "Record correctness test result for Speculative Decoding: Eagle3"
-    key: "record_Speculative_Decoding-_Eagle3_CorrectnessTest"
-    depends_on: "Speculative_Decoding-_Eagle3_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for Speculative Decoding: Eagle3"
+    key: "${TPU_VERSION:-tpu6e}_record_Speculative_Decoding-_Eagle3_CorrectnessTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_Speculative_Decoding-_Eagle3_CorrectnessTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "Speculative Decoding: Eagle3"
       CI_STAGE: "CorrectnessTest"
       CI_CATEGORY: "feature support matrix"
@@ -35,23 +38,26 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh Speculative_Decoding-_Eagle3_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_Speculative_Decoding-_Eagle3_CorrectnessTest
 
-  - label: "Performance tests for Speculative Decoding: Eagle3"
-    key: "Speculative_Decoding-_Eagle3_PerformanceTest"
-    depends_on: "record_Speculative_Decoding-_Eagle3_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Performance tests for Speculative Decoding: Eagle3"
+    key: "${TPU_VERSION:-tpu6e}_Speculative_Decoding-_Eagle3_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_record_Speculative_Decoding-_Eagle3_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh \
           python3 -m pytest -s -v /workspace/tpu_inference/tests/e2e/test_speculative_decoding.py::test_eagle3_performance
 
-  - label: "Record performance test result for Speculative Decoding: Eagle3"
-    key: "record_Speculative_Decoding-_Eagle3_PerformanceTest"
-    depends_on: "Speculative_Decoding-_Eagle3_PerformanceTest"
+  - label: "${TPU_VERSION:-tpu6e} Record performance test result for Speculative Decoding: Eagle3"
+    key: "${TPU_VERSION:-tpu6e}_record_Speculative_Decoding-_Eagle3_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_Speculative_Decoding-_Eagle3_PerformanceTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "Speculative Decoding: Eagle3"
       CI_STAGE: "PerformanceTest"
       CI_CATEGORY: "feature support matrix"
@@ -59,4 +65,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh Speculative_Decoding-_Eagle3_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_Speculative_Decoding-_Eagle3_PerformanceTest

--- a/.buildkite/features/Speculative_Decoding-_Ngram.yml
+++ b/.buildkite/features/Speculative_Decoding-_Ngram.yml
@@ -15,20 +15,23 @@
 # pipeline-name: Speculative Decoding: Ngram
 # pipeline-type: feature support matrix
 steps:
-  - label: "Correctness tests for Speculative Decoding: Ngram"
-    key: "Speculative_Decoding-_Ngram_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Correctness tests for Speculative Decoding: Ngram"
+    key: "${TPU_VERSION:-tpu6e}_Speculative_Decoding-_Ngram_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh \
           python3 -m pytest -s -v /workspace/tpu_inference/tests/e2e/test_speculative_decoding.py::test_ngram_correctness_greedy \
           /workspace/tpu_inference/tests/e2e/test_speculative_decoding.py::test_ngram_correctness_random
-  - label: "Record correctness test result for Speculative Decoding: Ngram"
-    key: "record_Speculative_Decoding-_Ngram_CorrectnessTest"
-    depends_on: "Speculative_Decoding-_Ngram_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for Speculative Decoding: Ngram"
+    key: "${TPU_VERSION:-tpu6e}_record_Speculative_Decoding-_Ngram_CorrectnessTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_Speculative_Decoding-_Ngram_CorrectnessTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "Speculative Decoding: Ngram"
       CI_STAGE: "CorrectnessTest"
       CI_CATEGORY: "feature support matrix"
@@ -36,24 +39,27 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh Speculative_Decoding-_Ngram_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_Speculative_Decoding-_Ngram_CorrectnessTest
 
-  - label: "Performance tests for Speculative Decoding: Ngram"
-    key: "Speculative_Decoding-_Ngram_PerformanceTest"
-    depends_on: "record_Speculative_Decoding-_Ngram_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Performance tests for Speculative Decoding: Ngram"
+    key: "${TPU_VERSION:-tpu6e}_Speculative_Decoding-_Ngram_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_record_Speculative_Decoding-_Ngram_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh \
           python3 -m pytest -s -v /workspace/tpu_inference/tests/e2e/test_speculative_decoding.py::test_ngram_performance_greedy \
           /workspace/tpu_inference/tests/e2e/test_speculative_decoding.py::test_ngram_performance_random
 
-  - label: "Record performance test result for Speculative Decoding: Ngram"
-    key: "record_Speculative_Decoding-_Ngram_PerformanceTest"
-    depends_on: "Speculative_Decoding-_Ngram_PerformanceTest"
+  - label: "${TPU_VERSION:-tpu6e} Record performance test result for Speculative Decoding: Ngram"
+    key: "${TPU_VERSION:-tpu6e}_record_Speculative_Decoding-_Ngram_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_Speculative_Decoding-_Ngram_PerformanceTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "Speculative Decoding: Ngram"
       CI_STAGE: "PerformanceTest"
       CI_CATEGORY: "feature support matrix"
@@ -61,4 +67,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh Speculative_Decoding-_Ngram_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_Speculative_Decoding-_Ngram_PerformanceTest

--- a/.buildkite/features/Structured_Decoding.yml
+++ b/.buildkite/features/Structured_Decoding.yml
@@ -19,17 +19,20 @@
 # following a JSON schema. This is useful for classification tasks,
 # structured data extraction, and ensuring outputs conform to expected formats.
 steps:
-  - label: "Correctness tests for structured_decoding"
-    key: "structured_decoding_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Correctness tests for structured_decoding"
+    key: "${TPU_VERSION:-tpu6e}_structured_decoding_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - .buildkite/scripts/run_in_docker.sh python3 -m pytest -s -v /workspace/tpu_inference/tests/e2e/test_structured_decoding.py::test_structured_decoding
-  - label: "Record correctness test result for structured_decoding"
-    key: "record_structured_decoding_CorrectnessTest"
-    depends_on: "structured_decoding_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for structured_decoding"
+    key: "${TPU_VERSION:-tpu6e}_record_structured_decoding_CorrectnessTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_structured_decoding_CorrectnessTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "structured_decoding"
       CI_STAGE: "CorrectnessTest"
       CI_CATEGORY: "feature support matrix"
@@ -37,4 +40,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh structured_decoding_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_structured_decoding_CorrectnessTest

--- a/.buildkite/features/async_scheduler.yml
+++ b/.buildkite/features/async_scheduler.yml
@@ -15,17 +15,20 @@
 # pipeline-name: async scheduler
 # pipeline-type: feature support matrix
 steps:
-  - label: "Correctness tests for async scheduler"
-    key: "async_scheduler_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Correctness tests for async scheduler"
+    key: "${TPU_VERSION:-tpu6e}_async_scheduler_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - .buildkite/scripts/run_in_docker.sh python3 -m pytest -s -v /workspace/tpu_inference/tests/e2e/test_async_scheduler.py::test_async_correctness
-  - label: "Record correctness test result for async scheduler"
-    key: "record_async_scheduler_CorrectnessTest"
-    depends_on: "async_scheduler_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for async scheduler"
+    key: "${TPU_VERSION:-tpu6e}_record_async_scheduler_CorrectnessTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_async_scheduler_CorrectnessTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "async scheduler"
       CI_STAGE: "CorrectnessTest"
       CI_CATEGORY: "feature support matrix"
@@ -33,20 +36,23 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh async_scheduler_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_async_scheduler_CorrectnessTest
 
-  - label: "Performance tests for async scheduler"
-    key: "async_scheduler_PerformanceTest"
-    depends_on: "record_async_scheduler_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Performance tests for async scheduler"
+    key: "${TPU_VERSION:-tpu6e}_async_scheduler_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_record_async_scheduler_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - .buildkite/scripts/run_in_docker.sh python3 -m pytest -s -v /workspace/tpu_inference/tests/e2e/test_async_scheduler.py::test_performance
-  - label: "Record performance test result for async scheduler"
-    key: "record_async_scheduler_PerformanceTest"
-    depends_on: "async_scheduler_PerformanceTest"
+  - label: "${TPU_VERSION:-tpu6e} Record performance test result for async scheduler"
+    key: "${TPU_VERSION:-tpu6e}_record_async_scheduler_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_async_scheduler_PerformanceTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "async scheduler"
       CI_STAGE: "PerformanceTest"
       CI_CATEGORY: "feature support matrix"
@@ -54,4 +60,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh async_scheduler_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_async_scheduler_PerformanceTest

--- a/.buildkite/features/runai_model_streamer_loader.yml
+++ b/.buildkite/features/runai_model_streamer_loader.yml
@@ -20,17 +20,20 @@
 # GPU memory. This streaming process is significantly faster than the traditional
 # disk-based loading method.
 steps:
-  - label: "Correctness Test | JAX UniProcExecutor"
-    key: "runai_model_streamer_loader_jax_uniproc"
+  - label: "${TPU_VERSION:-tpu6e} Correctness Test | JAX UniProcExecutor"
+    key: "${TPU_VERSION:-tpu6e}_runai_model_streamer_loader_jax_uniproc"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - .buildkite/scripts/run_in_docker.sh python3 -m pytest -s -v /workspace/tpu_inference/tests/e2e/test_runai_model_streamer_loader.py::test_correctness_jax_uni_proc_executor
-  - label: "Record Result | JAX UniProcExecutor"
-    key: "record_runai_model_streamer_loader_jax_uniproc"
-    depends_on: "runai_model_streamer_loader_jax_uniproc"
+  - label: "${TPU_VERSION:-tpu6e} Record Result | JAX UniProcExecutor"
+    key: "${TPU_VERSION:-tpu6e}_record_runai_model_streamer_loader_jax_uniproc"
+    depends_on: "${TPU_VERSION:-tpu6e}_runai_model_streamer_loader_jax_uniproc"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "runai_model_streamer_loader"
       CI_STAGE: "CorrectnessTest"
       CI_CATEGORY: "feature support matrix"
@@ -38,18 +41,21 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh runai_model_streamer_loader_jax_uniproc
-  - label: "Correctness Test | Torchax UniProcExecutor"
-    key: "runai_model_streamer_loader_torchax_uniproc"
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_runai_model_streamer_loader_jax_uniproc
+  - label: "${TPU_VERSION:-tpu6e} Correctness Test | Torchax UniProcExecutor"
+    key: "${TPU_VERSION:-tpu6e}_runai_model_streamer_loader_torchax_uniproc"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - .buildkite/scripts/run_in_docker.sh python3 -m pytest -s -v /workspace/tpu_inference/tests/e2e/test_runai_model_streamer_loader.py::test_correctness_torchax_uni_proc_executor
-  - label: "Record Result | Torchax UniProcExecutor"
-    key: "record_runai_model_streamer_loader_torchax_uniproc"
-    depends_on: "runai_model_streamer_loader_torchax_uniproc"
+  - label: "${TPU_VERSION:-tpu6e} Record Result | Torchax UniProcExecutor"
+    key: "${TPU_VERSION:-tpu6e}_record_runai_model_streamer_loader_torchax_uniproc"
+    depends_on: "${TPU_VERSION:-tpu6e}_runai_model_streamer_loader_torchax_uniproc"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "runai_model_streamer_loader"
       CI_STAGE: "CorrectnessTest"
       CI_CATEGORY: "feature support matrix"
@@ -57,27 +63,32 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh runai_model_streamer_loader_torchax_uniproc
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_runai_model_streamer_loader_torchax_uniproc
 
-  - label: "Correctness Test | JAX RayDistributedExecutor"
-    key: "runai_model_streamer_loader_jax_ray_distributed"
+  - label: "${TPU_VERSION:-tpu6e} Correctness Test | JAX RayDistributedExecutor"
+    key: "${TPU_VERSION:-tpu6e}_runai_model_streamer_loader_jax_ray_distributed"
     soft_fail: true
     agents:
-      queue: tpu_v6e_8_queue # Using a queue with more devices for distributed tests
+      queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}" # Using a queue with more devices for distributed tests
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - .buildkite/scripts/run_in_docker.sh python3 -m pytest -s -v /workspace/tpu_inference/tests/e2e/test_runai_model_streamer_loader.py::test_correctness_jax_ray_distributed_executor
 
-  - label: "Correctness Test | Torchax RayDistributedExecutor"
-    key: "runai_model_streamer_loader_torchax_ray_distributed"
+  - label: "${TPU_VERSION:-tpu6e} Correctness Test | Torchax RayDistributedExecutor"
+    key: "${TPU_VERSION:-tpu6e}_runai_model_streamer_loader_torchax_ray_distributed"
     soft_fail: true
     agents:
-      queue: tpu_v6e_8_queue # Using a queue with more devices for distributed tests
+      queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}" # Using a queue with more devices for distributed tests
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - .buildkite/scripts/run_in_docker.sh python3 -m pytest -s -v /workspace/tpu_inference/tests/e2e/test_runai_model_streamer_loader.py::test_correctness_torchax_ray_distributed_executor
-  - label: "Record Result | Torchax RayDistributedExecutor"
-    key: "record_runai_model_streamer_loader_torchax_ray_distributed"
-    depends_on: "runai_model_streamer_loader_torchax_ray_distributed"
+  - label: "${TPU_VERSION:-tpu6e} Record Result | Torchax RayDistributedExecutor"
+    key: "${TPU_VERSION:-tpu6e}_record_runai_model_streamer_loader_torchax_ray_distributed"
+    depends_on: "${TPU_VERSION:-tpu6e}_runai_model_streamer_loader_torchax_ray_distributed"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "runai_model_streamer_loader"
       CI_STAGE: "CorrectnessTest"
       CI_CATEGORY: "feature support matrix"
@@ -85,4 +96,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh runai_model_streamer_loader_torchax_ray_distributed
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_runai_model_streamer_loader_torchax_ray_distributed

--- a/.buildkite/features/sampling_params.yml
+++ b/.buildkite/features/sampling_params.yml
@@ -17,17 +17,20 @@
 # Sampling parameters control how the model selects tokens during generation.
 # These tests verify that temperature, top_p, top_k, and logprobs work correctly.
 steps:
-  - label: "Correctness tests for sampling_params"
-    key: "sampling_params_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Correctness tests for sampling_params"
+    key: "${TPU_VERSION:-tpu6e}_sampling_params_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - .buildkite/scripts/run_in_docker.sh python3 -m pytest -s -v /workspace/tpu_inference/tests/e2e/test_sampling_params.py
-  - label: "Record correctness test result for sampling_params"
-    key: "record_sampling_params_CorrectnessTest"
-    depends_on: "sampling_params_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for sampling_params"
+    key: "${TPU_VERSION:-tpu6e}_record_sampling_params_CorrectnessTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_sampling_params_CorrectnessTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "sampling_params"
       CI_STAGE: "CorrectnessTest"
       CI_CATEGORY: "feature support matrix"
@@ -35,4 +38,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh sampling_params_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_sampling_params_CorrectnessTest

--- a/.buildkite/kernel_microbenchmarks/all_gather_matmul/w16a16.yml
+++ b/.buildkite/kernel_microbenchmarks/all_gather_matmul/w16a16.yml
@@ -15,18 +15,21 @@
 # pipeline-name: all-gather-matmul-w16a16
 # pipeline-type: kernel support matrix microbenchmarks
 steps:
-  - label: "Correctness tests for all-gather-matmul-w16a16"
-    key: "all-gather-matmul-w16a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Correctness tests for all-gather-matmul-w16a16"
+    key: "${TPU_VERSION:-tpu6e}_all-gather-matmul-w16a16_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "all-gather-matmul-w16a16_CorrectnessTest" "unverified"
-  - label: "Record correctness test result for all-gather-matmul-w16a16"
-    key: "record_all-gather-matmul-w16a16_CorrectnessTest"
-    depends_on: "all-gather-matmul-w16a16_CorrectnessTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_all-gather-matmul-w16a16_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for all-gather-matmul-w16a16"
+    key: "${TPU_VERSION:-tpu6e}_record_all-gather-matmul-w16a16_CorrectnessTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_all-gather-matmul-w16a16_CorrectnessTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "all-gather-matmul-w16a16"
       CI_STAGE: "CorrectnessTest"
       CI_CATEGORY: "kernel support matrix microbenchmarks"
@@ -34,21 +37,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh all-gather-matmul-w16a16_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_all-gather-matmul-w16a16_CorrectnessTest
 
-  - label: "Performance tests for all-gather-matmul-w16a16"
-    key: "all-gather-matmul-w16a16_PerformanceTest"
-    depends_on: "record_all-gather-matmul-w16a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Performance tests for all-gather-matmul-w16a16"
+    key: "${TPU_VERSION:-tpu6e}_all-gather-matmul-w16a16_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_record_all-gather-matmul-w16a16_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "all-gather-matmul-w16a16_PerformanceTest" "unverified"
-  - label: "Record performance test result for all-gather-matmul-w16a16"
-    key: "record_all-gather-matmul-w16a16_PerformanceTest"
-    depends_on: "all-gather-matmul-w16a16_PerformanceTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_all-gather-matmul-w16a16_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record performance test result for all-gather-matmul-w16a16"
+    key: "${TPU_VERSION:-tpu6e}_record_all-gather-matmul-w16a16_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_all-gather-matmul-w16a16_PerformanceTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "all-gather-matmul-w16a16"
       CI_STAGE: "PerformanceTest"
       CI_CATEGORY: "kernel support matrix microbenchmarks"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh all-gather-matmul-w16a16_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_all-gather-matmul-w16a16_PerformanceTest

--- a/.buildkite/kernel_microbenchmarks/all_gather_matmul/w4a16.yml
+++ b/.buildkite/kernel_microbenchmarks/all_gather_matmul/w4a16.yml
@@ -15,18 +15,21 @@
 # pipeline-name: all-gather-matmul-w4a16
 # pipeline-type: kernel support matrix microbenchmarks
 steps:
-  - label: "Correctness tests for all-gather-matmul-w4a16"
-    key: "all-gather-matmul-w4a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Correctness tests for all-gather-matmul-w4a16"
+    key: "${TPU_VERSION:-tpu6e}_all-gather-matmul-w4a16_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "all-gather-matmul-w4a16_CorrectnessTest" "unverified"
-  - label: "Record correctness test result for all-gather-matmul-w4a16"
-    key: "record_all-gather-matmul-w4a16_CorrectnessTest"
-    depends_on: "all-gather-matmul-w4a16_CorrectnessTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_all-gather-matmul-w4a16_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for all-gather-matmul-w4a16"
+    key: "${TPU_VERSION:-tpu6e}_record_all-gather-matmul-w4a16_CorrectnessTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_all-gather-matmul-w4a16_CorrectnessTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "all-gather-matmul-w4a16"
       CI_STAGE: "CorrectnessTest"
       CI_CATEGORY: "kernel support matrix microbenchmarks"
@@ -34,21 +37,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh all-gather-matmul-w4a16_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_all-gather-matmul-w4a16_CorrectnessTest
 
-  - label: "Performance tests for all-gather-matmul-w4a16"
-    key: "all-gather-matmul-w4a16_PerformanceTest"
-    depends_on: "record_all-gather-matmul-w4a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Performance tests for all-gather-matmul-w4a16"
+    key: "${TPU_VERSION:-tpu6e}_all-gather-matmul-w4a16_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_record_all-gather-matmul-w4a16_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "all-gather-matmul-w4a16_PerformanceTest" "unverified"
-  - label: "Record performance test result for all-gather-matmul-w4a16"
-    key: "record_all-gather-matmul-w4a16_PerformanceTest"
-    depends_on: "all-gather-matmul-w4a16_PerformanceTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_all-gather-matmul-w4a16_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record performance test result for all-gather-matmul-w4a16"
+    key: "${TPU_VERSION:-tpu6e}_record_all-gather-matmul-w4a16_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_all-gather-matmul-w4a16_PerformanceTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "all-gather-matmul-w4a16"
       CI_STAGE: "PerformanceTest"
       CI_CATEGORY: "kernel support matrix microbenchmarks"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh all-gather-matmul-w4a16_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_all-gather-matmul-w4a16_PerformanceTest

--- a/.buildkite/kernel_microbenchmarks/all_gather_matmul/w4a4.yml
+++ b/.buildkite/kernel_microbenchmarks/all_gather_matmul/w4a4.yml
@@ -15,18 +15,21 @@
 # pipeline-name: all-gather-matmul-w4a4
 # pipeline-type: kernel support matrix microbenchmarks
 steps:
-  - label: "Correctness tests for all-gather-matmul-w4a4"
-    key: "all-gather-matmul-w4a4_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Correctness tests for all-gather-matmul-w4a4"
+    key: "${TPU_VERSION:-tpu6e}_all-gather-matmul-w4a4_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "all-gather-matmul-w4a4_CorrectnessTest" "unverified"
-  - label: "Record correctness test result for all-gather-matmul-w4a4"
-    key: "record_all-gather-matmul-w4a4_CorrectnessTest"
-    depends_on: "all-gather-matmul-w4a4_CorrectnessTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_all-gather-matmul-w4a4_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for all-gather-matmul-w4a4"
+    key: "${TPU_VERSION:-tpu6e}_record_all-gather-matmul-w4a4_CorrectnessTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_all-gather-matmul-w4a4_CorrectnessTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "all-gather-matmul-w4a4"
       CI_STAGE: "CorrectnessTest"
       CI_CATEGORY: "kernel support matrix microbenchmarks"
@@ -34,21 +37,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh all-gather-matmul-w4a4_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_all-gather-matmul-w4a4_CorrectnessTest
 
-  - label: "Performance tests for all-gather-matmul-w4a4"
-    key: "all-gather-matmul-w4a4_PerformanceTest"
-    depends_on: "record_all-gather-matmul-w4a4_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Performance tests for all-gather-matmul-w4a4"
+    key: "${TPU_VERSION:-tpu6e}_all-gather-matmul-w4a4_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_record_all-gather-matmul-w4a4_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "all-gather-matmul-w4a4_PerformanceTest" "unverified"
-  - label: "Record performance test result for all-gather-matmul-w4a4"
-    key: "record_all-gather-matmul-w4a4_PerformanceTest"
-    depends_on: "all-gather-matmul-w4a4_PerformanceTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_all-gather-matmul-w4a4_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record performance test result for all-gather-matmul-w4a4"
+    key: "${TPU_VERSION:-tpu6e}_record_all-gather-matmul-w4a4_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_all-gather-matmul-w4a4_PerformanceTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "all-gather-matmul-w4a4"
       CI_STAGE: "PerformanceTest"
       CI_CATEGORY: "kernel support matrix microbenchmarks"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh all-gather-matmul-w4a4_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_all-gather-matmul-w4a4_PerformanceTest

--- a/.buildkite/kernel_microbenchmarks/all_gather_matmul/w4a8.yml
+++ b/.buildkite/kernel_microbenchmarks/all_gather_matmul/w4a8.yml
@@ -15,18 +15,21 @@
 # pipeline-name: all-gather-matmul-w4a8
 # pipeline-type: kernel support matrix microbenchmarks
 steps:
-  - label: "Correctness tests for all-gather-matmul-w4a8"
-    key: "all-gather-matmul-w4a8_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Correctness tests for all-gather-matmul-w4a8"
+    key: "${TPU_VERSION:-tpu6e}_all-gather-matmul-w4a8_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "all-gather-matmul-w4a8_CorrectnessTest" "unverified"
-  - label: "Record correctness test result for all-gather-matmul-w4a8"
-    key: "record_all-gather-matmul-w4a8_CorrectnessTest"
-    depends_on: "all-gather-matmul-w4a8_CorrectnessTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_all-gather-matmul-w4a8_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for all-gather-matmul-w4a8"
+    key: "${TPU_VERSION:-tpu6e}_record_all-gather-matmul-w4a8_CorrectnessTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_all-gather-matmul-w4a8_CorrectnessTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "all-gather-matmul-w4a8"
       CI_STAGE: "CorrectnessTest"
       CI_CATEGORY: "kernel support matrix microbenchmarks"
@@ -34,21 +37,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh all-gather-matmul-w4a8_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_all-gather-matmul-w4a8_CorrectnessTest
 
-  - label: "Performance tests for all-gather-matmul-w4a8"
-    key: "all-gather-matmul-w4a8_PerformanceTest"
-    depends_on: "record_all-gather-matmul-w4a8_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Performance tests for all-gather-matmul-w4a8"
+    key: "${TPU_VERSION:-tpu6e}_all-gather-matmul-w4a8_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_record_all-gather-matmul-w4a8_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "all-gather-matmul-w4a8_PerformanceTest" "unverified"
-  - label: "Record performance test result for all-gather-matmul-w4a8"
-    key: "record_all-gather-matmul-w4a8_PerformanceTest"
-    depends_on: "all-gather-matmul-w4a8_PerformanceTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_all-gather-matmul-w4a8_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record performance test result for all-gather-matmul-w4a8"
+    key: "${TPU_VERSION:-tpu6e}_record_all-gather-matmul-w4a8_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_all-gather-matmul-w4a8_PerformanceTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "all-gather-matmul-w4a8"
       CI_STAGE: "PerformanceTest"
       CI_CATEGORY: "kernel support matrix microbenchmarks"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh all-gather-matmul-w4a8_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_all-gather-matmul-w4a8_PerformanceTest

--- a/.buildkite/kernel_microbenchmarks/all_gather_matmul/w8a16.yml
+++ b/.buildkite/kernel_microbenchmarks/all_gather_matmul/w8a16.yml
@@ -15,18 +15,21 @@
 # pipeline-name: all-gather-matmul-w8a16
 # pipeline-type: kernel support matrix microbenchmarks
 steps:
-  - label: "Correctness tests for all-gather-matmul-w8a16"
-    key: "all-gather-matmul-w8a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Correctness tests for all-gather-matmul-w8a16"
+    key: "${TPU_VERSION:-tpu6e}_all-gather-matmul-w8a16_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "all-gather-matmul-w8a16_CorrectnessTest" "unverified"
-  - label: "Record correctness test result for all-gather-matmul-w8a16"
-    key: "record_all-gather-matmul-w8a16_CorrectnessTest"
-    depends_on: "all-gather-matmul-w8a16_CorrectnessTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_all-gather-matmul-w8a16_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for all-gather-matmul-w8a16"
+    key: "${TPU_VERSION:-tpu6e}_record_all-gather-matmul-w8a16_CorrectnessTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_all-gather-matmul-w8a16_CorrectnessTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "all-gather-matmul-w8a16"
       CI_STAGE: "CorrectnessTest"
       CI_CATEGORY: "kernel support matrix microbenchmarks"
@@ -34,21 +37,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh all-gather-matmul-w8a16_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_all-gather-matmul-w8a16_CorrectnessTest
 
-  - label: "Performance tests for all-gather-matmul-w8a16"
-    key: "all-gather-matmul-w8a16_PerformanceTest"
-    depends_on: "record_all-gather-matmul-w8a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Performance tests for all-gather-matmul-w8a16"
+    key: "${TPU_VERSION:-tpu6e}_all-gather-matmul-w8a16_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_record_all-gather-matmul-w8a16_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "all-gather-matmul-w8a16_PerformanceTest" "unverified"
-  - label: "Record performance test result for all-gather-matmul-w8a16"
-    key: "record_all-gather-matmul-w8a16_PerformanceTest"
-    depends_on: "all-gather-matmul-w8a16_PerformanceTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_all-gather-matmul-w8a16_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record performance test result for all-gather-matmul-w8a16"
+    key: "${TPU_VERSION:-tpu6e}_record_all-gather-matmul-w8a16_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_all-gather-matmul-w8a16_PerformanceTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "all-gather-matmul-w8a16"
       CI_STAGE: "PerformanceTest"
       CI_CATEGORY: "kernel support matrix microbenchmarks"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh all-gather-matmul-w8a16_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_all-gather-matmul-w8a16_PerformanceTest

--- a/.buildkite/kernel_microbenchmarks/all_gather_matmul/w8a8.yml
+++ b/.buildkite/kernel_microbenchmarks/all_gather_matmul/w8a8.yml
@@ -15,18 +15,21 @@
 # pipeline-name: all-gather-matmul-w8a8
 # pipeline-type: kernel support matrix microbenchmarks
 steps:
-  - label: "Correctness tests for all-gather-matmul-w8a8"
-    key: "all-gather-matmul-w8a8_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Correctness tests for all-gather-matmul-w8a8"
+    key: "${TPU_VERSION:-tpu6e}_all-gather-matmul-w8a8_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "all-gather-matmul-w8a8_CorrectnessTest" "unverified"
-  - label: "Record correctness test result for all-gather-matmul-w8a8"
-    key: "record_all-gather-matmul-w8a8_CorrectnessTest"
-    depends_on: "all-gather-matmul-w8a8_CorrectnessTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_all-gather-matmul-w8a8_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for all-gather-matmul-w8a8"
+    key: "${TPU_VERSION:-tpu6e}_record_all-gather-matmul-w8a8_CorrectnessTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_all-gather-matmul-w8a8_CorrectnessTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "all-gather-matmul-w8a8"
       CI_STAGE: "CorrectnessTest"
       CI_CATEGORY: "kernel support matrix microbenchmarks"
@@ -34,21 +37,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh all-gather-matmul-w8a8_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_all-gather-matmul-w8a8_CorrectnessTest
 
-  - label: "Performance tests for all-gather-matmul-w8a8"
-    key: "all-gather-matmul-w8a8_PerformanceTest"
-    depends_on: "record_all-gather-matmul-w8a8_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Performance tests for all-gather-matmul-w8a8"
+    key: "${TPU_VERSION:-tpu6e}_all-gather-matmul-w8a8_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_record_all-gather-matmul-w8a8_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "all-gather-matmul-w8a8_PerformanceTest" "unverified"
-  - label: "Record performance test result for all-gather-matmul-w8a8"
-    key: "record_all-gather-matmul-w8a8_PerformanceTest"
-    depends_on: "all-gather-matmul-w8a8_PerformanceTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_all-gather-matmul-w8a8_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record performance test result for all-gather-matmul-w8a8"
+    key: "${TPU_VERSION:-tpu6e}_record_all-gather-matmul-w8a8_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_all-gather-matmul-w8a8_PerformanceTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "all-gather-matmul-w8a8"
       CI_STAGE: "PerformanceTest"
       CI_CATEGORY: "kernel support matrix microbenchmarks"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh all-gather-matmul-w8a8_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_all-gather-matmul-w8a8_PerformanceTest

--- a/.buildkite/kernel_microbenchmarks/for_attention_kernels_KV_cache/w16a16.yml
+++ b/.buildkite/kernel_microbenchmarks/for_attention_kernels_KV_cache/w16a16.yml
@@ -16,18 +16,21 @@
 # pipeline-type: kernel support matrix microbenchmarks
 # For attention kernels, W[x]A[y] denotes KV cache as W, A as compute, and x, y as bit precision-w16a16
 steps:
-  - label: "Correctness tests for attention kernels-w16a16"
-    key: "attention_kernels-w16a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Correctness tests for attention kernels-w16a16"
+    key: "${TPU_VERSION:-tpu6e}_attention_kernels-w16a16_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "attention_kernels-w16a16_CorrectnessTest" "unverified"
-  - label: "Record correctness test result for attention kernels-w16a16"
-    key: "record_attention_kernels-w16a16_CorrectnessTest"
-    depends_on: "attention_kernels-w16a16_CorrectnessTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_attention_kernels-w16a16_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for attention kernels-w16a16"
+    key: "${TPU_VERSION:-tpu6e}_record_attention_kernels-w16a16_CorrectnessTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_attention_kernels-w16a16_CorrectnessTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "attention_kernels-w16a16"
       CI_STAGE: "CorrectnessTest"
       CI_CATEGORY: "kernel support matrix microbenchmarks"
@@ -35,21 +38,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh attention_kernels-w16a16_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_attention_kernels-w16a16_CorrectnessTest
 
-  - label: "Performance tests for attention kernels-w16a16"
-    key: "attention_kernels-w16a16_PerformanceTest"
-    depends_on: "record_attention_kernels-w16a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Performance tests for attention kernels-w16a16"
+    key: "${TPU_VERSION:-tpu6e}_attention_kernels-w16a16_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_record_attention_kernels-w16a16_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "attention_kernels-w16a16_PerformanceTest" "unverified"
-  - label: "Record performance test result for attention kernels-w16a16"
-    key: "record_attention_kernels-w16a16_PerformanceTest"
-    depends_on: "attention_kernels-w16a16_PerformanceTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_attention_kernels-w16a16_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record performance test result for attention kernels-w16a16"
+    key: "${TPU_VERSION:-tpu6e}_record_attention_kernels-w16a16_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_attention_kernels-w16a16_PerformanceTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "attention_kernels-w16a16"
       CI_STAGE: "PerformanceTest"
       CI_CATEGORY: "kernel support matrix microbenchmarks"
@@ -57,4 +63,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh attention_kernels-w16a16_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_attention_kernels-w16a16_PerformanceTest

--- a/.buildkite/kernel_microbenchmarks/for_attention_kernels_KV_cache/w4a16.yml
+++ b/.buildkite/kernel_microbenchmarks/for_attention_kernels_KV_cache/w4a16.yml
@@ -16,18 +16,21 @@
 # pipeline-type: kernel support matrix microbenchmarks
 # For attention kernels, W[x]A[y] denotes KV cache as W, A as compute, and x, y as bit precision-w4a16
 steps:
-  - label: "Correctness tests for attention kernels-w4a16"
-    key: "attention_kernels-w4a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Correctness tests for attention kernels-w4a16"
+    key: "${TPU_VERSION:-tpu6e}_attention_kernels-w4a16_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "attention_kernels-w4a16_CorrectnessTest" "unverified"
-  - label: "Record correctness test result for attention kernels-w4a16"
-    key: "record_attention_kernels-w4a16_CorrectnessTest"
-    depends_on: "attention_kernels-w4a16_CorrectnessTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_attention_kernels-w4a16_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for attention kernels-w4a16"
+    key: "${TPU_VERSION:-tpu6e}_record_attention_kernels-w4a16_CorrectnessTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_attention_kernels-w4a16_CorrectnessTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "attention_kernels-w4a16"
       CI_STAGE: "CorrectnessTest"
       CI_CATEGORY: "kernel support matrix microbenchmarks"
@@ -35,21 +38,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh attention_kernels-w4a16_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_attention_kernels-w4a16_CorrectnessTest
 
-  - label: "Performance tests for attention kernels-w4a16"
-    key: "attention_kernels-w4a16_PerformanceTest"
-    depends_on: "record_attention_kernels-w4a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Performance tests for attention kernels-w4a16"
+    key: "${TPU_VERSION:-tpu6e}_attention_kernels-w4a16_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_record_attention_kernels-w4a16_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "attention_kernels-w4a16_PerformanceTest" "unverified"
-  - label: "Record performance test result for attention kernels-w4a16"
-    key: "record_attention_kernels-w4a16_PerformanceTest"
-    depends_on: "attention_kernels-w4a16_PerformanceTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_attention_kernels-w4a16_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record performance test result for attention kernels-w4a16"
+    key: "${TPU_VERSION:-tpu6e}_record_attention_kernels-w4a16_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_attention_kernels-w4a16_PerformanceTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "attention_kernels-w4a16"
       CI_STAGE: "PerformanceTest"
       CI_CATEGORY: "kernel support matrix microbenchmarks"
@@ -57,4 +63,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh attention_kernels-w4a16_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_attention_kernels-w4a16_PerformanceTest

--- a/.buildkite/kernel_microbenchmarks/for_attention_kernels_KV_cache/w4a4.yml
+++ b/.buildkite/kernel_microbenchmarks/for_attention_kernels_KV_cache/w4a4.yml
@@ -16,18 +16,21 @@
 # pipeline-type: kernel support matrix microbenchmarks
 # For attention kernels, W[x]A[y] denotes KV cache as W, A as compute, and x, y as bit precision-w4a4
 steps:
-  - label: "Correctness tests for attention kernels-w4a4"
-    key: "attention_kernels-w4a4_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Correctness tests for attention kernels-w4a4"
+    key: "${TPU_VERSION:-tpu6e}_attention_kernels-w4a4_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "attention_kernels-w4a4_CorrectnessTest" "unverified"
-  - label: "Record correctness test result for attention kernels-w4a4"
-    key: "record_attention_kernels-w4a4_CorrectnessTest"
-    depends_on: "attention_kernels-w4a4_CorrectnessTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_attention_kernels-w4a4_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for attention kernels-w4a4"
+    key: "${TPU_VERSION:-tpu6e}_record_attention_kernels-w4a4_CorrectnessTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_attention_kernels-w4a4_CorrectnessTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "attention_kernels-w4a4"
       CI_STAGE: "CorrectnessTest"
       CI_CATEGORY: "kernel support matrix microbenchmarks"
@@ -35,21 +38,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh attention_kernels-w4a4_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_attention_kernels-w4a4_CorrectnessTest
 
-  - label: "Performance tests for attention kernels-w4a4"
-    key: "attention_kernels-w4a4_PerformanceTest"
-    depends_on: "record_attention_kernels-w4a4_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Performance tests for attention kernels-w4a4"
+    key: "${TPU_VERSION:-tpu6e}_attention_kernels-w4a4_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_record_attention_kernels-w4a4_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "attention_kernels-w4a4_PerformanceTest" "unverified"
-  - label: "Record performance test result for attention kernels-w4a4"
-    key: "record_attention_kernels-w4a4_PerformanceTest"
-    depends_on: "attention_kernels-w4a4_PerformanceTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_attention_kernels-w4a4_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record performance test result for attention kernels-w4a4"
+    key: "${TPU_VERSION:-tpu6e}_record_attention_kernels-w4a4_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_attention_kernels-w4a4_PerformanceTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "attention_kernels-w4a4"
       CI_STAGE: "PerformanceTest"
       CI_CATEGORY: "kernel support matrix microbenchmarks"
@@ -57,4 +63,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh attention_kernels-w4a4_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_attention_kernels-w4a4_PerformanceTest

--- a/.buildkite/kernel_microbenchmarks/for_attention_kernels_KV_cache/w4a8.yml
+++ b/.buildkite/kernel_microbenchmarks/for_attention_kernels_KV_cache/w4a8.yml
@@ -16,18 +16,21 @@
 # pipeline-type: kernel support matrix microbenchmarks
 # For attention kernels, W[x]A[y] denotes KV cache as W, A as compute, and x, y as bit precision-w4a8
 steps:
-  - label: "Correctness tests for attention kernels-w4a8"
-    key: "attention_kernels-w4a8_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Correctness tests for attention kernels-w4a8"
+    key: "${TPU_VERSION:-tpu6e}_attention_kernels-w4a8_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "attention_kernels-w4a8_CorrectnessTest" "unverified"
-  - label: "Record correctness test result for attention kernels-w4a8"
-    key: "record_attention_kernels-w4a8_CorrectnessTest"
-    depends_on: "attention_kernels-w4a8_CorrectnessTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_attention_kernels-w4a8_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for attention kernels-w4a8"
+    key: "${TPU_VERSION:-tpu6e}_record_attention_kernels-w4a8_CorrectnessTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_attention_kernels-w4a8_CorrectnessTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "attention_kernels-w4a8"
       CI_STAGE: "CorrectnessTest"
       CI_CATEGORY: "kernel support matrix microbenchmarks"
@@ -35,21 +38,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh attention_kernels-w4a8_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_attention_kernels-w4a8_CorrectnessTest
 
-  - label: "Performance tests for attention kernels-w4a8"
-    key: "attention_kernels-w4a8_PerformanceTest"
-    depends_on: "record_attention_kernels-w4a8_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Performance tests for attention kernels-w4a8"
+    key: "${TPU_VERSION:-tpu6e}_attention_kernels-w4a8_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_record_attention_kernels-w4a8_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "attention_kernels-w4a8_PerformanceTest" "unverified"
-  - label: "Record performance test result for attention kernels-w4a8"
-    key: "record_attention_kernels-w4a8_PerformanceTest"
-    depends_on: "attention_kernels-w4a8_PerformanceTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_attention_kernels-w4a8_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record performance test result for attention kernels-w4a8"
+    key: "${TPU_VERSION:-tpu6e}_record_attention_kernels-w4a8_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_attention_kernels-w4a8_PerformanceTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "attention_kernels-w4a8"
       CI_STAGE: "PerformanceTest"
       CI_CATEGORY: "kernel support matrix microbenchmarks"
@@ -57,4 +63,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh attention_kernels-w4a8_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_attention_kernels-w4a8_PerformanceTest

--- a/.buildkite/kernel_microbenchmarks/for_attention_kernels_KV_cache/w8a16.yml
+++ b/.buildkite/kernel_microbenchmarks/for_attention_kernels_KV_cache/w8a16.yml
@@ -16,18 +16,21 @@
 # pipeline-type: kernel support matrix microbenchmarks
 # For attention kernels, W[x]A[y] denotes KV cache as W, A as compute, and x, y as bit precision-w8a16
 steps:
-  - label: "Correctness tests for attention kernels-w8a16"
-    key: "attention_kernels-w8a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Correctness tests for attention kernels-w8a16"
+    key: "${TPU_VERSION:-tpu6e}_attention_kernels-w8a16_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "attention_kernels-w8a16_CorrectnessTest" "unverified"
-  - label: "Record correctness test result for attention kernels-w8a16"
-    key: "record_attention_kernels-w8a16_CorrectnessTest"
-    depends_on: "attention_kernels-w8a16_CorrectnessTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_attention_kernels-w8a16_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for attention kernels-w8a16"
+    key: "${TPU_VERSION:-tpu6e}_record_attention_kernels-w8a16_CorrectnessTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_attention_kernels-w8a16_CorrectnessTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "attention_kernels-w8a16"
       CI_STAGE: "CorrectnessTest"
       CI_CATEGORY: "kernel support matrix microbenchmarks"
@@ -35,21 +38,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh attention_kernels-w8a16_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_attention_kernels-w8a16_CorrectnessTest
 
-  - label: "Performance tests for attention kernels-w8a16"
-    key: "attention_kernels-w8a16_PerformanceTest"
-    depends_on: "record_attention_kernels-w8a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Performance tests for attention kernels-w8a16"
+    key: "${TPU_VERSION:-tpu6e}_attention_kernels-w8a16_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_record_attention_kernels-w8a16_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "attention_kernels-w8a16_PerformanceTest" "unverified"
-  - label: "Record performance test result for attention kernels-w8a16"
-    key: "record_attention_kernels-w8a16_PerformanceTest"
-    depends_on: "attention_kernels-w8a16_PerformanceTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_attention_kernels-w8a16_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record performance test result for attention kernels-w8a16"
+    key: "${TPU_VERSION:-tpu6e}_record_attention_kernels-w8a16_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_attention_kernels-w8a16_PerformanceTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "attention_kernels-w8a16"
       CI_STAGE: "PerformanceTest"
       CI_CATEGORY: "kernel support matrix microbenchmarks"
@@ -57,4 +63,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh attention_kernels-w8a16_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_attention_kernels-w8a16_PerformanceTest

--- a/.buildkite/kernel_microbenchmarks/for_attention_kernels_KV_cache/w8a8.yml
+++ b/.buildkite/kernel_microbenchmarks/for_attention_kernels_KV_cache/w8a8.yml
@@ -16,18 +16,21 @@
 # pipeline-type: kernel support matrix microbenchmarks
 # For attention kernels, W[x]A[y] denotes KV cache as W, A as compute, and x, y as bit precision-w8a8
 steps:
-  - label: "Correctness tests for attention kernels-w8a8"
-    key: "attention_kernels-w8a8_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Correctness tests for attention kernels-w8a8"
+    key: "${TPU_VERSION:-tpu6e}_attention_kernels-w8a8_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "attention_kernels-w8a8_CorrectnessTest" "unverified"
-  - label: "Record correctness test result for attention kernels-w8a8"
-    key: "record_attention_kernels-w8a8_CorrectnessTest"
-    depends_on: "attention_kernels-w8a8_CorrectnessTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_attention_kernels-w8a8_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for attention kernels-w8a8"
+    key: "${TPU_VERSION:-tpu6e}_record_attention_kernels-w8a8_CorrectnessTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_attention_kernels-w8a8_CorrectnessTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "attention_kernels-w8a8"
       CI_STAGE: "CorrectnessTest"
       CI_CATEGORY: "kernel support matrix microbenchmarks"
@@ -35,21 +38,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh attention_kernels-w8a8_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_attention_kernels-w8a8_CorrectnessTest
 
-  - label: "Performance tests for attention kernels-w8a8"
-    key: "attention_kernels-w8a8_PerformanceTest"
-    depends_on: "record_attention_kernels-w8a8_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Performance tests for attention kernels-w8a8"
+    key: "${TPU_VERSION:-tpu6e}_attention_kernels-w8a8_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_record_attention_kernels-w8a8_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "attention_kernels-w8a8_PerformanceTest" "unverified"
-  - label: "Record performance test result for attention kernels-w8a8"
-    key: "record_attention_kernels-w8a8_PerformanceTest"
-    depends_on: "attention_kernels-w8a8_PerformanceTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_attention_kernels-w8a8_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record performance test result for attention kernels-w8a8"
+    key: "${TPU_VERSION:-tpu6e}_record_attention_kernels-w8a8_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_attention_kernels-w8a8_PerformanceTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "attention_kernels-w8a8"
       CI_STAGE: "PerformanceTest"
       CI_CATEGORY: "kernel support matrix microbenchmarks"
@@ -57,4 +63,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh attention_kernels-w8a8_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_attention_kernels-w8a8_PerformanceTest

--- a/.buildkite/kernel_microbenchmarks/fused_moe/w16a16.yml
+++ b/.buildkite/kernel_microbenchmarks/fused_moe/w16a16.yml
@@ -15,18 +15,21 @@
 # pipeline-name: fused moe-w16a16
 # pipeline-type: kernel support matrix microbenchmarks
 steps:
-  - label: "Correctness tests for fused moe-w16a16"
-    key: "fused_moe-w16a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Correctness tests for fused moe-w16a16"
+    key: "${TPU_VERSION:-tpu6e}_fused_moe-w16a16_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "fused_moe-w16a16_CorrectnessTest" "unverified"
-  - label: "Record correctness test result for fused moe w16a16"
-    key: "record_fused_moe-w16a16_CorrectnessTest"
-    depends_on: "fused_moe-w16a16_CorrectnessTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_fused_moe-w16a16_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for fused moe w16a16"
+    key: "${TPU_VERSION:-tpu6e}_record_fused_moe-w16a16_CorrectnessTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_fused_moe-w16a16_CorrectnessTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "fused moe-w16a16"
       CI_STAGE: "CorrectnessTest"
       CI_CATEGORY: "kernel support matrix microbenchmarks"
@@ -34,21 +37,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh fused_moe-w16a16_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_fused_moe-w16a16_CorrectnessTest
 
-  - label: "Performance tests for fused moe-w16a16"
-    key: "fused_moe-w16a16_PerformanceTest"
-    depends_on: "record_fused_moe-w16a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Performance tests for fused moe-w16a16"
+    key: "${TPU_VERSION:-tpu6e}_fused_moe-w16a16_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_record_fused_moe-w16a16_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "fused_moe-w16a16_PerformanceTest" "unverified"
-  - label: "Record performance test result for fused moe-w16a16"
-    key: "record_fused_moe-w16a16_PerformanceTest"
-    depends_on: "fused_moe-w16a16_PerformanceTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_fused_moe-w16a16_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record performance test result for fused moe-w16a16"
+    key: "${TPU_VERSION:-tpu6e}_record_fused_moe-w16a16_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_fused_moe-w16a16_PerformanceTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "fused moe-w16a16"
       CI_STAGE: "PerformanceTest"
       CI_CATEGORY: "kernel support matrix microbenchmarks"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh fused_moe-w16a16_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_fused_moe-w16a16_PerformanceTest

--- a/.buildkite/kernel_microbenchmarks/fused_moe/w4a16.yml
+++ b/.buildkite/kernel_microbenchmarks/fused_moe/w4a16.yml
@@ -15,18 +15,21 @@
 # pipeline-name: fused moe-w4a16
 # pipeline-type: kernel support matrix microbenchmarks
 steps:
-  - label: "Correctness tests for fused moe-w4a16"
-    key: "fused_moe-w4a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Correctness tests for fused moe-w4a16"
+    key: "${TPU_VERSION:-tpu6e}_fused_moe-w4a16_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "fused_moe-w4a16_CorrectnessTest" "unverified"
-  - label: "Record correctness test result for fused moe w4a16"
-    key: "record_fused_moe-w4a16_CorrectnessTest"
-    depends_on: "fused_moe-w4a16_CorrectnessTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_fused_moe-w4a16_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for fused moe w4a16"
+    key: "${TPU_VERSION:-tpu6e}_record_fused_moe-w4a16_CorrectnessTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_fused_moe-w4a16_CorrectnessTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "fused moe-w4a16"
       CI_STAGE: "CorrectnessTest"
       CI_CATEGORY: "kernel support matrix microbenchmarks"
@@ -34,21 +37,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh fused_moe-w4a16_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_fused_moe-w4a16_CorrectnessTest
 
-  - label: "Performance tests for fused moe-w4a16"
-    key: "fused_moe-w4a16_PerformanceTest"
-    depends_on: "record_fused_moe-w4a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Performance tests for fused moe-w4a16"
+    key: "${TPU_VERSION:-tpu6e}_fused_moe-w4a16_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_record_fused_moe-w4a16_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "fused_moe-w4a16_PerformanceTest" "unverified"
-  - label: "Record performance test result for fused moe-w4a16"
-    key: "record_fused_moe-w4a16_PerformanceTest"
-    depends_on: "fused_moe-w4a16_PerformanceTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_fused_moe-w4a16_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record performance test result for fused moe-w4a16"
+    key: "${TPU_VERSION:-tpu6e}_record_fused_moe-w4a16_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_fused_moe-w4a16_PerformanceTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "fused moe-w4a16"
       CI_STAGE: "PerformanceTest"
       CI_CATEGORY: "kernel support matrix microbenchmarks"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh fused_moe-w4a16_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_fused_moe-w4a16_PerformanceTest

--- a/.buildkite/kernel_microbenchmarks/fused_moe/w4a4.yml
+++ b/.buildkite/kernel_microbenchmarks/fused_moe/w4a4.yml
@@ -15,18 +15,21 @@
 # pipeline-name: fused moe-w4a4
 # pipeline-type: kernel support matrix microbenchmarks
 steps:
-  - label: "Correctness tests for fused moe-w4a4"
-    key: "fused_moe-w4a4_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Correctness tests for fused moe-w4a4"
+    key: "${TPU_VERSION:-tpu6e}_fused_moe-w4a4_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "fused_moe-w4a4_CorrectnessTest" "unverified"
-  - label: "Record correctness test result for fused moe w4a4"
-    key: "record_fused_moe-w4a4_CorrectnessTest"
-    depends_on: "fused_moe-w4a4_CorrectnessTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_fused_moe-w4a4_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for fused moe w4a4"
+    key: "${TPU_VERSION:-tpu6e}_record_fused_moe-w4a4_CorrectnessTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_fused_moe-w4a4_CorrectnessTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "fused moe-w4a4"
       CI_STAGE: "CorrectnessTest"
       CI_CATEGORY: "kernel support matrix microbenchmarks"
@@ -34,21 +37,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh fused_moe-w4a4_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_fused_moe-w4a4_CorrectnessTest
 
-  - label: "Performance tests for fused moe-w4a4"
-    key: "fused_moe-w4a4_PerformanceTest"
-    depends_on: "record_fused_moe-w4a4_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Performance tests for fused moe-w4a4"
+    key: "${TPU_VERSION:-tpu6e}_fused_moe-w4a4_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_record_fused_moe-w4a4_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "fused_moe-w4a4_PerformanceTest" "unverified"
-  - label: "Record performance test result for fused moe-w4a4"
-    key: "record_fused_moe-w4a4_PerformanceTest"
-    depends_on: "fused_moe-w4a4_PerformanceTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_fused_moe-w4a4_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record performance test result for fused moe-w4a4"
+    key: "${TPU_VERSION:-tpu6e}_record_fused_moe-w4a4_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_fused_moe-w4a4_PerformanceTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "fused moe-w4a4"
       CI_STAGE: "PerformanceTest"
       CI_CATEGORY: "kernel support matrix microbenchmarks"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh fused_moe-w4a4_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_fused_moe-w4a4_PerformanceTest

--- a/.buildkite/kernel_microbenchmarks/fused_moe/w4a8.yml
+++ b/.buildkite/kernel_microbenchmarks/fused_moe/w4a8.yml
@@ -15,18 +15,21 @@
 # pipeline-name: fused moe-w4a8
 # pipeline-type: kernel support matrix microbenchmarks
 steps:
-  - label: "Correctness tests for fused moe-w4a8"
-    key: "fused_moe-w4a8_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Correctness tests for fused moe-w4a8"
+    key: "${TPU_VERSION:-tpu6e}_fused_moe-w4a8_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "fused_moe-w4a8_CorrectnessTest" "unverified"
-  - label: "Record correctness test result for fused moe w4a8"
-    key: "record_fused_moe-w4a8_CorrectnessTest"
-    depends_on: "fused_moe-w4a8_CorrectnessTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_fused_moe-w4a8_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for fused moe w4a8"
+    key: "${TPU_VERSION:-tpu6e}_record_fused_moe-w4a8_CorrectnessTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_fused_moe-w4a8_CorrectnessTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "fused moe-w4a8"
       CI_STAGE: "CorrectnessTest"
       CI_CATEGORY: "kernel support matrix microbenchmarks"
@@ -34,21 +37,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh fused_moe-w4a8_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_fused_moe-w4a8_CorrectnessTest
 
-  - label: "Performance tests for fused moe-w4a8"
-    key: "fused_moe-w4a8_PerformanceTest"
-    depends_on: "record_fused_moe-w4a8_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Performance tests for fused moe-w4a8"
+    key: "${TPU_VERSION:-tpu6e}_fused_moe-w4a8_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_record_fused_moe-w4a8_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "fused_moe-w4a8_PerformanceTest" "unverified"
-  - label: "Record performance test result for fused moe-w4a8"
-    key: "record_fused_moe-w4a8_PerformanceTest"
-    depends_on: "fused_moe-w4a8_PerformanceTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_fused_moe-w4a8_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record performance test result for fused moe-w4a8"
+    key: "${TPU_VERSION:-tpu6e}_record_fused_moe-w4a8_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_fused_moe-w4a8_PerformanceTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "fused moe-w4a8"
       CI_STAGE: "PerformanceTest"
       CI_CATEGORY: "kernel support matrix microbenchmarks"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh fused_moe-w4a8_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_fused_moe-w4a8_PerformanceTest

--- a/.buildkite/kernel_microbenchmarks/fused_moe/w8a16.yml
+++ b/.buildkite/kernel_microbenchmarks/fused_moe/w8a16.yml
@@ -15,18 +15,21 @@
 # pipeline-name: fused moe-w8a16
 # pipeline-type: kernel support matrix microbenchmarks
 steps:
-  - label: "Correctness tests for fused moe-w8a16"
-    key: "fused_moe-w8a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Correctness tests for fused moe-w8a16"
+    key: "${TPU_VERSION:-tpu6e}_fused_moe-w8a16_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "fused_moe-w8a16_CorrectnessTest" "unverified"
-  - label: "Record correctness test result for fused moe w8a16"
-    key: "record_fused_moe-w8a16_CorrectnessTest"
-    depends_on: "fused_moe-w8a16_CorrectnessTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_fused_moe-w8a16_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for fused moe w8a16"
+    key: "${TPU_VERSION:-tpu6e}_record_fused_moe-w8a16_CorrectnessTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_fused_moe-w8a16_CorrectnessTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "fused moe-w8a16"
       CI_STAGE: "CorrectnessTest"
       CI_CATEGORY: "kernel support matrix microbenchmarks"
@@ -34,21 +37,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh fused_moe-w8a16_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_fused_moe-w8a16_CorrectnessTest
 
-  - label: "Performance tests for fused moe-w8a16"
-    key: "fused_moe-w8a16_PerformanceTest"
-    depends_on: "record_fused_moe-w8a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Performance tests for fused moe-w8a16"
+    key: "${TPU_VERSION:-tpu6e}_fused_moe-w8a16_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_record_fused_moe-w8a16_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "fused_moe-w8a16_PerformanceTest" "unverified"
-  - label: "Record performance test result for fused moe-w8a16"
-    key: "record_fused_moe-w8a16_PerformanceTest"
-    depends_on: "fused_moe-w8a16_PerformanceTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_fused_moe-w8a16_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record performance test result for fused moe-w8a16"
+    key: "${TPU_VERSION:-tpu6e}_record_fused_moe-w8a16_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_fused_moe-w8a16_PerformanceTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "fused moe-w8a16"
       CI_STAGE: "PerformanceTest"
       CI_CATEGORY: "kernel support matrix microbenchmarks"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh fused_moe-w8a16_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_fused_moe-w8a16_PerformanceTest

--- a/.buildkite/kernel_microbenchmarks/fused_moe/w8a8.yml
+++ b/.buildkite/kernel_microbenchmarks/fused_moe/w8a8.yml
@@ -15,18 +15,21 @@
 # pipeline-name: fused moe-w8a8
 # pipeline-type: kernel support matrix microbenchmarks
 steps:
-  - label: "Correctness tests for fused moe-w8a8"
-    key: "fused_moe-w8a8_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Correctness tests for fused moe-w8a8"
+    key: "${TPU_VERSION:-tpu6e}_fused_moe-w8a8_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "fused_moe-w8a8_CorrectnessTest" "unverified"
-  - label: "Record correctness test result for fused moe w8a8"
-    key: "record_fused_moe-w8a8_CorrectnessTest"
-    depends_on: "fused_moe-w8a8_CorrectnessTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_fused_moe-w8a8_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for fused moe w8a8"
+    key: "${TPU_VERSION:-tpu6e}_record_fused_moe-w8a8_CorrectnessTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_fused_moe-w8a8_CorrectnessTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "fused moe-w8a8"
       CI_STAGE: "CorrectnessTest"
       CI_CATEGORY: "kernel support matrix microbenchmarks"
@@ -34,21 +37,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh fused_moe-w8a8_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_fused_moe-w8a8_CorrectnessTest
 
-  - label: "Performance tests for fused moe-w8a8"
-    key: "fused_moe-w8a8_PerformanceTest"
-    depends_on: "record_fused_moe-w8a8_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Performance tests for fused moe-w8a8"
+    key: "${TPU_VERSION:-tpu6e}_fused_moe-w8a8_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_record_fused_moe-w8a8_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "fused_moe-w8a8_PerformanceTest" "unverified"
-  - label: "Record performance test result for fused moe-w8a8"
-    key: "record_fused_moe-w8a8_PerformanceTest"
-    depends_on: "fused_moe-w8a8_PerformanceTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_fused_moe-w8a8_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record performance test result for fused moe-w8a8"
+    key: "${TPU_VERSION:-tpu6e}_record_fused_moe-w8a8_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_fused_moe-w8a8_PerformanceTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "fused moe-w8a8"
       CI_STAGE: "PerformanceTest"
       CI_CATEGORY: "kernel support matrix microbenchmarks"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh fused_moe-w8a8_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_fused_moe-w8a8_PerformanceTest

--- a/.buildkite/kernel_microbenchmarks/generic_ragged_paged_attention_v3/w16a16.yml
+++ b/.buildkite/kernel_microbenchmarks/generic_ragged_paged_attention_v3/w16a16.yml
@@ -15,18 +15,21 @@
 # pipeline-name: generic ragged paged attention v3-w16a16
 # pipeline-type: kernel support matrix microbenchmarks
 steps:
-  - label: "Correctness tests for generic ragged paged attention v3-w16a16"
-    key: "generic_ragged_paged_attention_v3-w16a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Correctness tests for generic ragged paged attention v3-w16a16"
+    key: "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w16a16_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "generic_ragged_paged_attention_v3-w16a16_CorrectnessTest" "unverified"
-  - label: "Record correctness test result for generic ragged paged attention v3 w16a16"
-    key: "record_generic_ragged_paged_attention_v3-w16a16_CorrectnessTest"
-    depends_on: "generic_ragged_paged_attention_v3-w16a16_CorrectnessTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w16a16_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for generic ragged paged attention v3 w16a16"
+    key: "${TPU_VERSION:-tpu6e}_record_generic_ragged_paged_attention_v3-w16a16_CorrectnessTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w16a16_CorrectnessTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "generic ragged paged attention v3-w16a16"
       CI_STAGE: "CorrectnessTest"
       CI_CATEGORY: "kernel support matrix microbenchmarks"
@@ -34,21 +37,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh generic_ragged_paged_attention_v3-w16a16_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w16a16_CorrectnessTest
 
-  - label: "Performance tests for generic ragged paged attention v3-w16a16"
-    key: "generic_ragged_paged_attention_v3-w16a16_PerformanceTest"
-    depends_on: "record_generic_ragged_paged_attention_v3-w16a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Performance tests for generic ragged paged attention v3-w16a16"
+    key: "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w16a16_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_record_generic_ragged_paged_attention_v3-w16a16_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "generic_ragged_paged_attention_v3-w16a16_PerformanceTest" "unverified"
-  - label: "Record performance test result for generic ragged paged attention v3-w16a16"
-    key: "record_generic_ragged_paged_attention_v3-w16a16_PerformanceTest"
-    depends_on: "generic_ragged_paged_attention_v3-w16a16_PerformanceTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w16a16_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record performance test result for generic ragged paged attention v3-w16a16"
+    key: "${TPU_VERSION:-tpu6e}_record_generic_ragged_paged_attention_v3-w16a16_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w16a16_PerformanceTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "generic ragged paged attention v3-w16a16"
       CI_STAGE: "PerformanceTest"
       CI_CATEGORY: "kernel support matrix microbenchmarks"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh generic_ragged_paged_attention_v3-w16a16_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w16a16_PerformanceTest

--- a/.buildkite/kernel_microbenchmarks/generic_ragged_paged_attention_v3/w4a16.yml
+++ b/.buildkite/kernel_microbenchmarks/generic_ragged_paged_attention_v3/w4a16.yml
@@ -15,18 +15,21 @@
 # pipeline-name: generic ragged paged attention v3-w4a16
 # pipeline-type: kernel support matrix microbenchmarks
 steps:
-  - label: "Correctness tests for generic ragged paged attention v3-w4a16"
-    key: "generic_ragged_paged_attention_v3-w4a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Correctness tests for generic ragged paged attention v3-w4a16"
+    key: "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w4a16_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "generic_ragged_paged_attention_v3-w4a16_CorrectnessTest" "unverified"
-  - label: "Record correctness test result for generic ragged paged attention v3 w4a16"
-    key: "record_generic_ragged_paged_attention_v3-w4a16_CorrectnessTest"
-    depends_on: "generic_ragged_paged_attention_v3-w4a16_CorrectnessTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w4a16_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for generic ragged paged attention v3 w4a16"
+    key: "${TPU_VERSION:-tpu6e}_record_generic_ragged_paged_attention_v3-w4a16_CorrectnessTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w4a16_CorrectnessTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "generic ragged paged attention v3-w4a16"
       CI_STAGE: "CorrectnessTest"
       CI_CATEGORY: "kernel support matrix microbenchmarks"
@@ -34,21 +37,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh generic_ragged_paged_attention_v3-w4a16_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w4a16_CorrectnessTest
 
-  - label: "Performance tests for generic ragged paged attention v3-w4a16"
-    key: "generic_ragged_paged_attention_v3-w4a16_PerformanceTest"
-    depends_on: "record_generic_ragged_paged_attention_v3-w4a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Performance tests for generic ragged paged attention v3-w4a16"
+    key: "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w4a16_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_record_generic_ragged_paged_attention_v3-w4a16_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "generic_ragged_paged_attention_v3-w4a16_PerformanceTest" "unverified"
-  - label: "Record performance test result for generic ragged paged attention v3-w4a16"
-    key: "record_generic_ragged_paged_attention_v3-w4a16_PerformanceTest"
-    depends_on: "generic_ragged_paged_attention_v3-w4a16_PerformanceTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w4a16_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record performance test result for generic ragged paged attention v3-w4a16"
+    key: "${TPU_VERSION:-tpu6e}_record_generic_ragged_paged_attention_v3-w4a16_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w4a16_PerformanceTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "generic ragged paged attention v3-w4a16"
       CI_STAGE: "PerformanceTest"
       CI_CATEGORY: "kernel support matrix microbenchmarks"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh generic_ragged_paged_attention_v3-w4a16_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w4a16_PerformanceTest

--- a/.buildkite/kernel_microbenchmarks/generic_ragged_paged_attention_v3/w4a4.yml
+++ b/.buildkite/kernel_microbenchmarks/generic_ragged_paged_attention_v3/w4a4.yml
@@ -15,18 +15,21 @@
 # pipeline-name: generic ragged paged attention v3-w4a4
 # pipeline-type: kernel support matrix microbenchmarks
 steps:
-  - label: "Correctness tests for generic ragged paged attention v3-w4a4"
-    key: "generic_ragged_paged_attention_v3-w4a4_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Correctness tests for generic ragged paged attention v3-w4a4"
+    key: "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w4a4_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "generic_ragged_paged_attention_v3-w4a4_CorrectnessTest" "unverified"
-  - label: "Record correctness test result for generic ragged paged attention v3 w4a4"
-    key: "record_generic_ragged_paged_attention_v3-w4a4_CorrectnessTest"
-    depends_on: "generic_ragged_paged_attention_v3-w4a4_CorrectnessTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w4a4_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for generic ragged paged attention v3 w4a4"
+    key: "${TPU_VERSION:-tpu6e}_record_generic_ragged_paged_attention_v3-w4a4_CorrectnessTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w4a4_CorrectnessTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "generic ragged paged attention v3-w4a4"
       CI_STAGE: "CorrectnessTest"
       CI_CATEGORY: "kernel support matrix microbenchmarks"
@@ -34,21 +37,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh generic_ragged_paged_attention_v3-w4a4_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w4a4_CorrectnessTest
 
-  - label: "Performance tests for generic ragged paged attention v3-w4a4"
-    key: "generic_ragged_paged_attention_v3-w4a4_PerformanceTest"
-    depends_on: "record_generic_ragged_paged_attention_v3-w4a4_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Performance tests for generic ragged paged attention v3-w4a4"
+    key: "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w4a4_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_record_generic_ragged_paged_attention_v3-w4a4_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "generic_ragged_paged_attention_v3-w4a4_PerformanceTest" "unverified"
-  - label: "Record performance test result for generic ragged paged attention v3-w4a4"
-    key: "record_generic_ragged_paged_attention_v3-w4a4_PerformanceTest"
-    depends_on: "generic_ragged_paged_attention_v3-w4a4_PerformanceTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w4a4_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record performance test result for generic ragged paged attention v3-w4a4"
+    key: "${TPU_VERSION:-tpu6e}_record_generic_ragged_paged_attention_v3-w4a4_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w4a4_PerformanceTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "generic ragged paged attention v3-w4a4"
       CI_STAGE: "PerformanceTest"
       CI_CATEGORY: "kernel support matrix microbenchmarks"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh generic_ragged_paged_attention_v3-w4a4_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w4a4_PerformanceTest

--- a/.buildkite/kernel_microbenchmarks/generic_ragged_paged_attention_v3/w4a8.yml
+++ b/.buildkite/kernel_microbenchmarks/generic_ragged_paged_attention_v3/w4a8.yml
@@ -15,18 +15,21 @@
 # pipeline-name: generic ragged paged attention v3-w4a8
 # pipeline-type: kernel support matrix microbenchmarks
 steps:
-  - label: "Correctness tests for generic ragged paged attention v3-w4a8"
-    key: "generic_ragged_paged_attention_v3-w4a8_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Correctness tests for generic ragged paged attention v3-w4a8"
+    key: "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w4a8_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "generic_ragged_paged_attention_v3-w4a8_CorrectnessTest" "unverified"
-  - label: "Record correctness test result for generic ragged paged attention v3 w4a8"
-    key: "record_generic_ragged_paged_attention_v3-w4a8_CorrectnessTest"
-    depends_on: "generic_ragged_paged_attention_v3-w4a8_CorrectnessTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w4a8_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for generic ragged paged attention v3 w4a8"
+    key: "${TPU_VERSION:-tpu6e}_record_generic_ragged_paged_attention_v3-w4a8_CorrectnessTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w4a8_CorrectnessTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "generic ragged paged attention v3-w4a8"
       CI_STAGE: "CorrectnessTest"
       CI_CATEGORY: "kernel support matrix microbenchmarks"
@@ -34,21 +37,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh generic_ragged_paged_attention_v3-w4a8_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w4a8_CorrectnessTest
 
-  - label: "Performance tests for generic ragged paged attention v3-w4a8"
-    key: "generic_ragged_paged_attention_v3-w4a8_PerformanceTest"
-    depends_on: "record_generic_ragged_paged_attention_v3-w4a8_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Performance tests for generic ragged paged attention v3-w4a8"
+    key: "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w4a8_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_record_generic_ragged_paged_attention_v3-w4a8_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "generic_ragged_paged_attention_v3-w4a8_PerformanceTest" "unverified"
-  - label: "Record performance test result for generic ragged paged attention v3-w4a8"
-    key: "record_generic_ragged_paged_attention_v3-w4a8_PerformanceTest"
-    depends_on: "generic_ragged_paged_attention_v3-w4a8_PerformanceTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w4a8_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record performance test result for generic ragged paged attention v3-w4a8"
+    key: "${TPU_VERSION:-tpu6e}_record_generic_ragged_paged_attention_v3-w4a8_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w4a8_PerformanceTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "generic ragged paged attention v3-w4a8"
       CI_STAGE: "PerformanceTest"
       CI_CATEGORY: "kernel support matrix microbenchmarks"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh generic_ragged_paged_attention_v3-w4a8_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w4a8_PerformanceTest

--- a/.buildkite/kernel_microbenchmarks/generic_ragged_paged_attention_v3/w8a16.yml
+++ b/.buildkite/kernel_microbenchmarks/generic_ragged_paged_attention_v3/w8a16.yml
@@ -15,18 +15,21 @@
 # pipeline-name: generic ragged paged attention v3-w8a16
 # pipeline-type: kernel support matrix microbenchmarks
 steps:
-  - label: "Correctness tests for generic ragged paged attention v3-w8a16"
-    key: "generic_ragged_paged_attention_v3-w8a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Correctness tests for generic ragged paged attention v3-w8a16"
+    key: "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w8a16_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "generic_ragged_paged_attention_v3-w8a16_CorrectnessTest" "unverified"
-  - label: "Record correctness test result for generic ragged paged attention v3 w8a16"
-    key: "record_generic_ragged_paged_attention_v3-w8a16_CorrectnessTest"
-    depends_on: "generic_ragged_paged_attention_v3-w8a16_CorrectnessTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w8a16_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for generic ragged paged attention v3 w8a16"
+    key: "${TPU_VERSION:-tpu6e}_record_generic_ragged_paged_attention_v3-w8a16_CorrectnessTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w8a16_CorrectnessTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "generic ragged paged attention v3-w8a16"
       CI_STAGE: "CorrectnessTest"
       CI_CATEGORY: "kernel support matrix microbenchmarks"
@@ -34,21 +37,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh generic_ragged_paged_attention_v3-w8a16_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w8a16_CorrectnessTest
 
-  - label: "Performance tests for generic ragged paged attention v3-w8a16"
-    key: "generic_ragged_paged_attention_v3-w8a16_PerformanceTest"
-    depends_on: "record_generic_ragged_paged_attention_v3-w8a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Performance tests for generic ragged paged attention v3-w8a16"
+    key: "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w8a16_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_record_generic_ragged_paged_attention_v3-w8a16_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "generic_ragged_paged_attention_v3-w8a16_PerformanceTest" "unverified"
-  - label: "Record performance test result for generic ragged paged attention v3-w8a16"
-    key: "record_generic_ragged_paged_attention_v3-w8a16_PerformanceTest"
-    depends_on: "generic_ragged_paged_attention_v3-w8a16_PerformanceTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w8a16_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record performance test result for generic ragged paged attention v3-w8a16"
+    key: "${TPU_VERSION:-tpu6e}_record_generic_ragged_paged_attention_v3-w8a16_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w8a16_PerformanceTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "generic ragged paged attention v3-w8a16"
       CI_STAGE: "PerformanceTest"
       CI_CATEGORY: "kernel support matrix microbenchmarks"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh generic_ragged_paged_attention_v3-w8a16_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w8a16_PerformanceTest

--- a/.buildkite/kernel_microbenchmarks/generic_ragged_paged_attention_v3/w8a8.yml
+++ b/.buildkite/kernel_microbenchmarks/generic_ragged_paged_attention_v3/w8a8.yml
@@ -15,18 +15,21 @@
 # pipeline-name: generic ragged paged attention v3-w8a8
 # pipeline-type: kernel support matrix microbenchmarks
 steps:
-  - label: "Correctness tests for generic ragged paged attention v3-w8a8"
-    key: "generic_ragged_paged_attention_v3-w8a8_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Correctness tests for generic ragged paged attention v3-w8a8"
+    key: "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w8a8_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "generic_ragged_paged_attention_v3-w8a8_CorrectnessTest" "unverified"
-  - label: "Record correctness test result for generic ragged paged attention v3 w8a8"
-    key: "record_generic_ragged_paged_attention_v3-w8a8_CorrectnessTest"
-    depends_on: "generic_ragged_paged_attention_v3-w8a8_CorrectnessTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w8a8_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for generic ragged paged attention v3 w8a8"
+    key: "${TPU_VERSION:-tpu6e}_record_generic_ragged_paged_attention_v3-w8a8_CorrectnessTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w8a8_CorrectnessTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "generic ragged paged attention v3-w8a8"
       CI_STAGE: "CorrectnessTest"
       CI_CATEGORY: "kernel support matrix microbenchmarks"
@@ -34,21 +37,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh generic_ragged_paged_attention_v3-w8a8_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w8a8_CorrectnessTest
 
-  - label: "Performance tests for generic ragged paged attention v3-w8a8"
-    key: "generic_ragged_paged_attention_v3-w8a8_PerformanceTest"
-    depends_on: "record_generic_ragged_paged_attention_v3-w8a8_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Performance tests for generic ragged paged attention v3-w8a8"
+    key: "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w8a8_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_record_generic_ragged_paged_attention_v3-w8a8_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "generic_ragged_paged_attention_v3-w8a8_PerformanceTest" "unverified"
-  - label: "Record performance test result for generic ragged paged attention v3-w8a8"
-    key: "record_generic_ragged_paged_attention_v3-w8a8_PerformanceTest"
-    depends_on: "generic_ragged_paged_attention_v3-w8a8_PerformanceTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w8a8_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record performance test result for generic ragged paged attention v3-w8a8"
+    key: "${TPU_VERSION:-tpu6e}_record_generic_ragged_paged_attention_v3-w8a8_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w8a8_PerformanceTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "generic ragged paged attention v3-w8a8"
       CI_STAGE: "PerformanceTest"
       CI_CATEGORY: "kernel support matrix microbenchmarks"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh generic_ragged_paged_attention_v3-w8a8_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w8a8_PerformanceTest

--- a/.buildkite/kernel_microbenchmarks/gmm/w16a16.yml
+++ b/.buildkite/kernel_microbenchmarks/gmm/w16a16.yml
@@ -15,18 +15,21 @@
 # pipeline-name: gmm-w16a16
 # pipeline-type: kernel support matrix microbenchmarks
 steps:
-  - label: "Correctness tests for gmm-w16a16"
-    key: "gmm-w16a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Correctness tests for gmm-w16a16"
+    key: "${TPU_VERSION:-tpu6e}_gmm-w16a16_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "gmm-w16a16_CorrectnessTest" "unverified"
-  - label: "Record correctness test result for gmm-w16a16"
-    key: "record_gmm-w16a16_CorrectnessTest"
-    depends_on: "gmm-w16a16_CorrectnessTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_gmm-w16a16_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for gmm-w16a16"
+    key: "${TPU_VERSION:-tpu6e}_record_gmm-w16a16_CorrectnessTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_gmm-w16a16_CorrectnessTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "gmm-w16a16"
       CI_STAGE: "CorrectnessTest"
       CI_CATEGORY: "kernel support matrix microbenchmarks"
@@ -34,21 +37,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh gmm-w16a16_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_gmm-w16a16_CorrectnessTest
 
-  - label: "Performance tests for gmm-w16a16"
-    key: "gmm-w16a16_PerformanceTest"
-    depends_on: "record_gmm-w16a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Performance tests for gmm-w16a16"
+    key: "${TPU_VERSION:-tpu6e}_gmm-w16a16_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_record_gmm-w16a16_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "gmm-w16a16_PerformanceTest" "unverified"
-  - label: "Record performance test result for gmm-w16a16"
-    key: "record_gmm-w16a16_PerformanceTest"
-    depends_on: "gmm-w16a16_PerformanceTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_gmm-w16a16_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record performance test result for gmm-w16a16"
+    key: "${TPU_VERSION:-tpu6e}_record_gmm-w16a16_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_gmm-w16a16_PerformanceTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "gmm-w16a16"
       CI_STAGE: "PerformanceTest"
       CI_CATEGORY: "kernel support matrix microbenchmarks"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh gmm-w16a16_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_gmm-w16a16_PerformanceTest

--- a/.buildkite/kernel_microbenchmarks/gmm/w4a16.yml
+++ b/.buildkite/kernel_microbenchmarks/gmm/w4a16.yml
@@ -15,18 +15,21 @@
 # pipeline-name: gmm-w4a16
 # pipeline-type: kernel support matrix microbenchmarks
 steps:
-  - label: "Correctness tests for gmm-w4a16"
-    key: "gmm-w4a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Correctness tests for gmm-w4a16"
+    key: "${TPU_VERSION:-tpu6e}_gmm-w4a16_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "gmm-w4a16_CorrectnessTest" "unverified"
-  - label: "Record correctness test result for gmm-w4a16"
-    key: "record_gmm-w4a16_CorrectnessTest"
-    depends_on: "gmm-w4a16_CorrectnessTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_gmm-w4a16_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for gmm-w4a16"
+    key: "${TPU_VERSION:-tpu6e}_record_gmm-w4a16_CorrectnessTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_gmm-w4a16_CorrectnessTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "gmm-w4a16"
       CI_STAGE: "CorrectnessTest"
       CI_CATEGORY: "kernel support matrix microbenchmarks"
@@ -34,21 +37,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh gmm-w4a16_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_gmm-w4a16_CorrectnessTest
 
-  - label: "Performance tests for gmm-w4a16"
-    key: "gmm-w4a16_PerformanceTest"
-    depends_on: "record_gmm-w4a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Performance tests for gmm-w4a16"
+    key: "${TPU_VERSION:-tpu6e}_gmm-w4a16_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_record_gmm-w4a16_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "gmm-w4a16_PerformanceTest" "unverified"
-  - label: "Record performance test result for gmm-w4a16"
-    key: "record_gmm-w4a16_PerformanceTest"
-    depends_on: "gmm-w4a16_PerformanceTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_gmm-w4a16_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record performance test result for gmm-w4a16"
+    key: "${TPU_VERSION:-tpu6e}_record_gmm-w4a16_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_gmm-w4a16_PerformanceTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "gmm-w4a16"
       CI_STAGE: "PerformanceTest"
       CI_CATEGORY: "kernel support matrix microbenchmarks"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh gmm-w4a16_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_gmm-w4a16_PerformanceTest

--- a/.buildkite/kernel_microbenchmarks/gmm/w4a4.yml
+++ b/.buildkite/kernel_microbenchmarks/gmm/w4a4.yml
@@ -15,18 +15,21 @@
 # pipeline-name: gmm-w4a4
 # pipeline-type: kernel support matrix microbenchmarks
 steps:
-  - label: "Correctness tests for gmm-w4a4"
-    key: "gmm-w4a4_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Correctness tests for gmm-w4a4"
+    key: "${TPU_VERSION:-tpu6e}_gmm-w4a4_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "gmm-w4a4_CorrectnessTest" "unverified"
-  - label: "Record correctness test result for gmm-w4a4"
-    key: "record_gmm-w4a4_CorrectnessTest"
-    depends_on: "gmm-w4a4_CorrectnessTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_gmm-w4a4_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for gmm-w4a4"
+    key: "${TPU_VERSION:-tpu6e}_record_gmm-w4a4_CorrectnessTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_gmm-w4a4_CorrectnessTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "gmm-w4a4"
       CI_STAGE: "CorrectnessTest"
       CI_CATEGORY: "kernel support matrix microbenchmarks"
@@ -34,21 +37,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh gmm-w4a4_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_gmm-w4a4_CorrectnessTest
 
-  - label: "Performance tests for gmm-w4a4"
-    key: "gmm-w4a4_PerformanceTest"
-    depends_on: "record_gmm-w4a4_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Performance tests for gmm-w4a4"
+    key: "${TPU_VERSION:-tpu6e}_gmm-w4a4_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_record_gmm-w4a4_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "gmm-w4a4_PerformanceTest" "unverified"
-  - label: "Record performance test result for gmm-w4a4"
-    key: "record_gmm-w4a4_PerformanceTest"
-    depends_on: "gmm-w4a4_PerformanceTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_gmm-w4a4_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record performance test result for gmm-w4a4"
+    key: "${TPU_VERSION:-tpu6e}_record_gmm-w4a4_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_gmm-w4a4_PerformanceTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "gmm-w4a4"
       CI_STAGE: "PerformanceTest"
       CI_CATEGORY: "kernel support matrix microbenchmarks"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh gmm-w4a4_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_gmm-w4a4_PerformanceTest

--- a/.buildkite/kernel_microbenchmarks/gmm/w4a8.yml
+++ b/.buildkite/kernel_microbenchmarks/gmm/w4a8.yml
@@ -15,18 +15,21 @@
 # pipeline-name: gmm-w4a8
 # pipeline-type: kernel support matrix microbenchmarks
 steps:
-  - label: "Correctness tests for gmm-w4a8"
-    key: "gmm-w4a8_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Correctness tests for gmm-w4a8"
+    key: "${TPU_VERSION:-tpu6e}_gmm-w4a8_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "gmm-w4a8_CorrectnessTest" "unverified"
-  - label: "Record correctness test result for gmm-w4a8"
-    key: "record_gmm-w4a8_CorrectnessTest"
-    depends_on: "gmm-w4a8_CorrectnessTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_gmm-w4a8_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for gmm-w4a8"
+    key: "${TPU_VERSION:-tpu6e}_record_gmm-w4a8_CorrectnessTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_gmm-w4a8_CorrectnessTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "gmm-w4a8"
       CI_STAGE: "CorrectnessTest"
       CI_CATEGORY: "kernel support matrix microbenchmarks"
@@ -34,21 +37,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh gmm-w4a8_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_gmm-w4a8_CorrectnessTest
 
-  - label: "Performance tests for gmm-w4a8"
-    key: "gmm-w4a8_PerformanceTest"
-    depends_on: "record_gmm-w4a8_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Performance tests for gmm-w4a8"
+    key: "${TPU_VERSION:-tpu6e}_gmm-w4a8_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_record_gmm-w4a8_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "gmm-w4a8_PerformanceTest" "unverified"
-  - label: "Record performance test result for gmm-w4a8"
-    key: "record_gmm-w4a8_PerformanceTest"
-    depends_on: "gmm-w4a8_PerformanceTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_gmm-w4a8_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record performance test result for gmm-w4a8"
+    key: "${TPU_VERSION:-tpu6e}_record_gmm-w4a8_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_gmm-w4a8_PerformanceTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "gmm-w4a8"
       CI_STAGE: "PerformanceTest"
       CI_CATEGORY: "kernel support matrix microbenchmarks"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh gmm-w4a8_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_gmm-w4a8_PerformanceTest

--- a/.buildkite/kernel_microbenchmarks/gmm/w8a16.yml
+++ b/.buildkite/kernel_microbenchmarks/gmm/w8a16.yml
@@ -15,18 +15,21 @@
 # pipeline-name: gmm-w8a16
 # pipeline-type: kernel support matrix microbenchmarks
 steps:
-  - label: "Correctness tests for gmm-w8a16"
-    key: "gmm-w8a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Correctness tests for gmm-w8a16"
+    key: "${TPU_VERSION:-tpu6e}_gmm-w8a16_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "gmm-w8a16_CorrectnessTest" "unverified"
-  - label: "Record correctness test result for gmm-w8a16"
-    key: "record_gmm-w8a16_CorrectnessTest"
-    depends_on: "gmm-w8a16_CorrectnessTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_gmm-w8a16_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for gmm-w8a16"
+    key: "${TPU_VERSION:-tpu6e}_record_gmm-w8a16_CorrectnessTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_gmm-w8a16_CorrectnessTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "gmm-w8a16"
       CI_STAGE: "CorrectnessTest"
       CI_CATEGORY: "kernel support matrix microbenchmarks"
@@ -34,21 +37,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh gmm-w8a16_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_gmm-w8a16_CorrectnessTest
 
-  - label: "Performance tests for gmm-w8a16"
-    key: "gmm-w8a16_PerformanceTest"
-    depends_on: "record_gmm-w8a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Performance tests for gmm-w8a16"
+    key: "${TPU_VERSION:-tpu6e}_gmm-w8a16_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_record_gmm-w8a16_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "gmm-w8a16_PerformanceTest" "unverified"
-  - label: "Record performance test result for gmm-w8a16"
-    key: "record_gmm-w8a16_PerformanceTest"
-    depends_on: "gmm-w8a16_PerformanceTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_gmm-w8a16_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record performance test result for gmm-w8a16"
+    key: "${TPU_VERSION:-tpu6e}_record_gmm-w8a16_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_gmm-w8a16_PerformanceTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "gmm-w8a16"
       CI_STAGE: "PerformanceTest"
       CI_CATEGORY: "kernel support matrix microbenchmarks"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh gmm-w8a16_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_gmm-w8a16_PerformanceTest

--- a/.buildkite/kernel_microbenchmarks/gmm/w8a8.yml
+++ b/.buildkite/kernel_microbenchmarks/gmm/w8a8.yml
@@ -15,18 +15,21 @@
 # pipeline-name: gmm-w8a8
 # pipeline-type: kernel support matrix microbenchmarks
 steps:
-  - label: "Correctness tests for gmm-w8a8"
-    key: "gmm-w8a8_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Correctness tests for gmm-w8a8"
+    key: "${TPU_VERSION:-tpu6e}_gmm-w8a8_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "gmm-w8a8_CorrectnessTest" "unverified"
-  - label: "Record correctness test result for gmm-w8a8"
-    key: "record_gmm-w8a8_CorrectnessTest"
-    depends_on: "gmm-w8a8_CorrectnessTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_gmm-w8a8_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for gmm-w8a8"
+    key: "${TPU_VERSION:-tpu6e}_record_gmm-w8a8_CorrectnessTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_gmm-w8a8_CorrectnessTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "gmm-w8a8"
       CI_STAGE: "CorrectnessTest"
       CI_CATEGORY: "kernel support matrix microbenchmarks"
@@ -34,21 +37,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh gmm-w8a8_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_gmm-w8a8_CorrectnessTest
 
-  - label: "Performance tests for gmm-w8a8"
-    key: "gmm-w8a8_PerformanceTest"
-    depends_on: "record_gmm-w8a8_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Performance tests for gmm-w8a8"
+    key: "${TPU_VERSION:-tpu6e}_gmm-w8a8_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_record_gmm-w8a8_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "gmm-w8a8_PerformanceTest" "unverified"
-  - label: "Record performance test result for gmm-w8a8"
-    key: "record_gmm-w8a8_PerformanceTest"
-    depends_on: "gmm-w8a8_PerformanceTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_gmm-w8a8_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record performance test result for gmm-w8a8"
+    key: "${TPU_VERSION:-tpu6e}_record_gmm-w8a8_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_gmm-w8a8_PerformanceTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "gmm-w8a8"
       CI_STAGE: "PerformanceTest"
       CI_CATEGORY: "kernel support matrix microbenchmarks"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh gmm-w8a8_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_gmm-w8a8_PerformanceTest

--- a/.buildkite/kernel_microbenchmarks/mla/w16a16.yml
+++ b/.buildkite/kernel_microbenchmarks/mla/w16a16.yml
@@ -15,18 +15,21 @@
 # pipeline-name: mla-w16a16
 # pipeline-type: kernel support matrix microbenchmarks
 steps:
-  - label: "Correctness tests for mla-w16a16"
-    key: "mla-w16a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Correctness tests for mla-w16a16"
+    key: "${TPU_VERSION:-tpu6e}_mla-w16a16_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "mla-w16a16_CorrectnessTest" "unverified"
-  - label: "Record correctness test result for mla-w16a16"
-    key: "record_mla-w16a16_CorrectnessTest"
-    depends_on: "mla-w16a16_CorrectnessTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_mla-w16a16_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for mla-w16a16"
+    key: "${TPU_VERSION:-tpu6e}_record_mla-w16a16_CorrectnessTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_mla-w16a16_CorrectnessTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "mla-w16a16"
       CI_STAGE: "CorrectnessTest"
       CI_CATEGORY: "kernel support matrix microbenchmarks"
@@ -34,21 +37,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh mla-w16a16_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_mla-w16a16_CorrectnessTest
 
-  - label: "Performance tests for mla-w16a16"
-    key: "mla-w16a16_PerformanceTest"
-    depends_on: "record_mla-w16a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Performance tests for mla-w16a16"
+    key: "${TPU_VERSION:-tpu6e}_mla-w16a16_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_record_mla-w16a16_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "mla-w16a16_PerformanceTest" "unverified"
-  - label: "Record performance test result for mla-w16a16"
-    key: "record_mla-w16a16_PerformanceTest"
-    depends_on: "mla-w16a16_PerformanceTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_mla-w16a16_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record performance test result for mla-w16a16"
+    key: "${TPU_VERSION:-tpu6e}_record_mla-w16a16_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_mla-w16a16_PerformanceTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "mla-w16a16"
       CI_STAGE: "PerformanceTest"
       CI_CATEGORY: "kernel support matrix microbenchmarks"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh mla-w16a16_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_mla-w16a16_PerformanceTest

--- a/.buildkite/kernel_microbenchmarks/mla/w4a16.yml
+++ b/.buildkite/kernel_microbenchmarks/mla/w4a16.yml
@@ -15,18 +15,21 @@
 # pipeline-name: mla-w4a16
 # pipeline-type: kernel support matrix microbenchmarks
 steps:
-  - label: "Correctness tests for mla-w4a16"
-    key: "mla-w4a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Correctness tests for mla-w4a16"
+    key: "${TPU_VERSION:-tpu6e}_mla-w4a16_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "mla-w4a16_CorrectnessTest" "unverified"
-  - label: "Record correctness test result for mla-w4a16"
-    key: "record_mla-w4a16_CorrectnessTest"
-    depends_on: "mla-w4a16_CorrectnessTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_mla-w4a16_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for mla-w4a16"
+    key: "${TPU_VERSION:-tpu6e}_record_mla-w4a16_CorrectnessTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_mla-w4a16_CorrectnessTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "mla-w4a16"
       CI_STAGE: "CorrectnessTest"
       CI_CATEGORY: "kernel support matrix microbenchmarks"
@@ -34,21 +37,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh mla-w4a16_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_mla-w4a16_CorrectnessTest
 
-  - label: "Performance tests for mla-w4a16"
-    key: "mla-w4a16_PerformanceTest"
-    depends_on: "record_mla-w4a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Performance tests for mla-w4a16"
+    key: "${TPU_VERSION:-tpu6e}_mla-w4a16_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_record_mla-w4a16_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "mla-w4a16_PerformanceTest" "unverified"
-  - label: "Record performance test result for mla-w4a16"
-    key: "record_mla-w4a16_PerformanceTest"
-    depends_on: "mla-w4a16_PerformanceTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_mla-w4a16_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record performance test result for mla-w4a16"
+    key: "${TPU_VERSION:-tpu6e}_record_mla-w4a16_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_mla-w4a16_PerformanceTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "mla-w4a16"
       CI_STAGE: "PerformanceTest"
       CI_CATEGORY: "kernel support matrix microbenchmarks"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh mla-w4a16_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_mla-w4a16_PerformanceTest

--- a/.buildkite/kernel_microbenchmarks/mla/w4a4.yml
+++ b/.buildkite/kernel_microbenchmarks/mla/w4a4.yml
@@ -15,18 +15,21 @@
 # pipeline-name: mla-w4a4
 # pipeline-type: kernel support matrix microbenchmarks
 steps:
-  - label: "Correctness tests for mla-w4a4"
-    key: "mla-w4a4_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Correctness tests for mla-w4a4"
+    key: "${TPU_VERSION:-tpu6e}_mla-w4a4_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "mla-w4a4_CorrectnessTest" "unverified"
-  - label: "Record correctness test result for mla-w4a4"
-    key: "record_mla-w4a4_CorrectnessTest"
-    depends_on: "mla-w4a4_CorrectnessTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_mla-w4a4_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for mla-w4a4"
+    key: "${TPU_VERSION:-tpu6e}_record_mla-w4a4_CorrectnessTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_mla-w4a4_CorrectnessTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "mla-w4a4"
       CI_STAGE: "CorrectnessTest"
       CI_CATEGORY: "kernel support matrix microbenchmarks"
@@ -34,21 +37,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh mla-w4a4_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_mla-w4a4_CorrectnessTest
 
-  - label: "Performance tests for mla-w4a4"
-    key: "mla-w4a4_PerformanceTest"
-    depends_on: "record_mla-w4a4_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Performance tests for mla-w4a4"
+    key: "${TPU_VERSION:-tpu6e}_mla-w4a4_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_record_mla-w4a4_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "mla-w4a4_PerformanceTest" "unverified"
-  - label: "Record performance test result for mla-w4a4"
-    key: "record_mla-w4a4_PerformanceTest"
-    depends_on: "mla-w4a4_PerformanceTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_mla-w4a4_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record performance test result for mla-w4a4"
+    key: "${TPU_VERSION:-tpu6e}_record_mla-w4a4_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_mla-w4a4_PerformanceTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "mla-w4a4"
       CI_STAGE: "PerformanceTest"
       CI_CATEGORY: "kernel support matrix microbenchmarks"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh mla-w4a4_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_mla-w4a4_PerformanceTest

--- a/.buildkite/kernel_microbenchmarks/mla/w4a8.yml
+++ b/.buildkite/kernel_microbenchmarks/mla/w4a8.yml
@@ -15,18 +15,21 @@
 # pipeline-name: mla-w4a8
 # pipeline-type: kernel support matrix microbenchmarks
 steps:
-  - label: "Correctness tests for mla-w4a8"
-    key: "mla-w4a8_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Correctness tests for mla-w4a8"
+    key: "${TPU_VERSION:-tpu6e}_mla-w4a8_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "mla-w4a8_CorrectnessTest" "unverified"
-  - label: "Record correctness test result for mla-w4a8"
-    key: "record_mla-w4a8_CorrectnessTest"
-    depends_on: "mla-w4a8_CorrectnessTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_mla-w4a8_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for mla-w4a8"
+    key: "${TPU_VERSION:-tpu6e}_record_mla-w4a8_CorrectnessTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_mla-w4a8_CorrectnessTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "mla-w4a8"
       CI_STAGE: "CorrectnessTest"
       CI_CATEGORY: "kernel support matrix microbenchmarks"
@@ -34,21 +37,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh mla-w4a8_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_mla-w4a8_CorrectnessTest
 
-  - label: "Performance tests for mla-w4a8"
-    key: "mla-w4a8_PerformanceTest"
-    depends_on: "record_mla-w4a8_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Performance tests for mla-w4a8"
+    key: "${TPU_VERSION:-tpu6e}_mla-w4a8_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_record_mla-w4a8_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "mla-w4a8_PerformanceTest" "unverified"
-  - label: "Record performance test result for mla-w4a8"
-    key: "record_mla-w4a8_PerformanceTest"
-    depends_on: "mla-w4a8_PerformanceTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_mla-w4a8_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record performance test result for mla-w4a8"
+    key: "${TPU_VERSION:-tpu6e}_record_mla-w4a8_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_mla-w4a8_PerformanceTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "mla-w4a8"
       CI_STAGE: "PerformanceTest"
       CI_CATEGORY: "kernel support matrix microbenchmarks"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh mla-w4a8_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_mla-w4a8_PerformanceTest

--- a/.buildkite/kernel_microbenchmarks/mla/w8a16.yml
+++ b/.buildkite/kernel_microbenchmarks/mla/w8a16.yml
@@ -15,18 +15,21 @@
 # pipeline-name: mla-w8a16
 # pipeline-type: kernel support matrix microbenchmarks
 steps:
-  - label: "Correctness tests for mla-w8a16"
-    key: "mla-w8a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Correctness tests for mla-w8a16"
+    key: "${TPU_VERSION:-tpu6e}_mla-w8a16_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "mla-w8a16_CorrectnessTest" "unverified"
-  - label: "Record correctness test result for mla-w8a16"
-    key: "record_mla-w8a16_CorrectnessTest"
-    depends_on: "mla-w8a16_CorrectnessTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_mla-w8a16_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for mla-w8a16"
+    key: "${TPU_VERSION:-tpu6e}_record_mla-w8a16_CorrectnessTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_mla-w8a16_CorrectnessTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "mla-w8a16"
       CI_STAGE: "CorrectnessTest"
       CI_CATEGORY: "kernel support matrix microbenchmarks"
@@ -34,21 +37,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh mla-w8a16_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_mla-w8a16_CorrectnessTest
 
-  - label: "Performance tests for mla-w8a16"
-    key: "mla-w8a16_PerformanceTest"
-    depends_on: "record_mla-w8a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Performance tests for mla-w8a16"
+    key: "${TPU_VERSION:-tpu6e}_mla-w8a16_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_record_mla-w8a16_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "mla-w8a16_PerformanceTest" "unverified"
-  - label: "Record performance test result for mla-w8a16"
-    key: "record_mla-w8a16_PerformanceTest"
-    depends_on: "mla-w8a16_PerformanceTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_mla-w8a16_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record performance test result for mla-w8a16"
+    key: "${TPU_VERSION:-tpu6e}_record_mla-w8a16_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_mla-w8a16_PerformanceTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "mla-w8a16"
       CI_STAGE: "PerformanceTest"
       CI_CATEGORY: "kernel support matrix microbenchmarks"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh mla-w8a16_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_mla-w8a16_PerformanceTest

--- a/.buildkite/kernel_microbenchmarks/mla/w8a8.yml
+++ b/.buildkite/kernel_microbenchmarks/mla/w8a8.yml
@@ -15,18 +15,21 @@
 # pipeline-name: mla-w8a8
 # pipeline-type: kernel support matrix microbenchmarks
 steps:
-  - label: "Correctness tests for mla-w8a8"
-    key: "mla-w8a8_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Correctness tests for mla-w8a8"
+    key: "${TPU_VERSION:-tpu6e}_mla-w8a8_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "mla-w8a8_CorrectnessTest" "unverified"
-  - label: "Record correctness test result for mla-w8a8"
-    key: "record_mla-w8a8_CorrectnessTest"
-    depends_on: "mla-w8a8_CorrectnessTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_mla-w8a8_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for mla-w8a8"
+    key: "${TPU_VERSION:-tpu6e}_record_mla-w8a8_CorrectnessTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_mla-w8a8_CorrectnessTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "mla-w8a8"
       CI_STAGE: "CorrectnessTest"
       CI_CATEGORY: "kernel support matrix microbenchmarks"
@@ -34,21 +37,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh mla-w8a8_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_mla-w8a8_CorrectnessTest
 
-  - label: "Performance tests for mla-w8a8"
-    key: "mla-w8a8_PerformanceTest"
-    depends_on: "record_mla-w8a8_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Performance tests for mla-w8a8"
+    key: "${TPU_VERSION:-tpu6e}_mla-w8a8_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_record_mla-w8a8_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "mla-w8a8_PerformanceTest" "unverified"
-  - label: "Record performance test result for mla-w8a8"
-    key: "record_mla-w8a8_PerformanceTest"
-    depends_on: "mla-w8a8_PerformanceTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_mla-w8a8_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record performance test result for mla-w8a8"
+    key: "${TPU_VERSION:-tpu6e}_record_mla-w8a8_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_mla-w8a8_PerformanceTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "mla-w8a8"
       CI_STAGE: "PerformanceTest"
       CI_CATEGORY: "kernel support matrix microbenchmarks"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh mla-w8a8_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_mla-w8a8_PerformanceTest

--- a/.buildkite/kernel_microbenchmarks/ragged_paged_attention_v3_head_dim_64/w16a16.yml
+++ b/.buildkite/kernel_microbenchmarks/ragged_paged_attention_v3_head_dim_64/w16a16.yml
@@ -15,18 +15,21 @@
 # pipeline-name: ragged paged attention v3 head_dim 64-w16a16
 # pipeline-type: kernel support matrix microbenchmarks
 steps:
-  - label: "Correctness tests for ragged paged attention v3 head_dim 64-w16a16"
-    key: "ragged_paged_attention_v3_head_dim_64-w16a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Correctness tests for ragged paged attention v3 head_dim 64-w16a16"
+    key: "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w16a16_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "ragged_paged_attention_v3_head_dim_64-w16a16_CorrectnessTest" "unverified"
-  - label: "Record correctness test result for ragged paged attention v3 head_dim 64 w16a16"
-    key: "record_ragged_paged_attention_v3_head_dim_64-w16a16_CorrectnessTest"
-    depends_on: "ragged_paged_attention_v3_head_dim_64-w16a16_CorrectnessTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w16a16_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for ragged paged attention v3 head_dim 64 w16a16"
+    key: "${TPU_VERSION:-tpu6e}_record_ragged_paged_attention_v3_head_dim_64-w16a16_CorrectnessTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w16a16_CorrectnessTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "ragged paged attention v3 head_dim 64-w16a16"
       CI_STAGE: "CorrectnessTest"
       CI_CATEGORY: "kernel support matrix microbenchmarks"
@@ -34,21 +37,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ragged_paged_attention_v3_head_dim_64-w16a16_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w16a16_CorrectnessTest
 
-  - label: "Performance tests for ragged paged attention v3 head_dim 64-w16a16"
-    key: "ragged_paged_attention_v3_head_dim_64-w16a16_PerformanceTest"
-    depends_on: "record_ragged_paged_attention_v3_head_dim_64-w16a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Performance tests for ragged paged attention v3 head_dim 64-w16a16"
+    key: "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w16a16_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_record_ragged_paged_attention_v3_head_dim_64-w16a16_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "ragged_paged_attention_v3_head_dim_64-w16a16_PerformanceTest" "unverified"
-  - label: "Record performance test result for ragged paged attention v3 head_dim 64-w16a16"
-    key: "record_ragged_paged_attention_v3_head_dim_64-w16a16_PerformanceTest"
-    depends_on: "ragged_paged_attention_v3_head_dim_64-w16a16_PerformanceTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w16a16_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record performance test result for ragged paged attention v3 head_dim 64-w16a16"
+    key: "${TPU_VERSION:-tpu6e}_record_ragged_paged_attention_v3_head_dim_64-w16a16_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w16a16_PerformanceTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "ragged paged attention v3 head_dim 64-w16a16"
       CI_STAGE: "PerformanceTest"
       CI_CATEGORY: "kernel support matrix microbenchmarks"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ragged_paged_attention_v3_head_dim_64-w16a16_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w16a16_PerformanceTest

--- a/.buildkite/kernel_microbenchmarks/ragged_paged_attention_v3_head_dim_64/w4a16.yml
+++ b/.buildkite/kernel_microbenchmarks/ragged_paged_attention_v3_head_dim_64/w4a16.yml
@@ -15,18 +15,21 @@
 # pipeline-name: ragged paged attention v3 head_dim 64-w4a16
 # pipeline-type: kernel support matrix microbenchmarks
 steps:
-  - label: "Correctness tests for ragged paged attention v3 head_dim 64-w4a16"
-    key: "ragged_paged_attention_v3_head_dim_64-w4a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Correctness tests for ragged paged attention v3 head_dim 64-w4a16"
+    key: "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w4a16_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "ragged_paged_attention_v3_head_dim_64-w4a16_CorrectnessTest" "unverified"
-  - label: "Record correctness test result for ragged paged attention v3 head_dim 64 w4a16"
-    key: "record_ragged_paged_attention_v3_head_dim_64-w4a16_CorrectnessTest"
-    depends_on: "ragged_paged_attention_v3_head_dim_64-w4a16_CorrectnessTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w4a16_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for ragged paged attention v3 head_dim 64 w4a16"
+    key: "${TPU_VERSION:-tpu6e}_record_ragged_paged_attention_v3_head_dim_64-w4a16_CorrectnessTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w4a16_CorrectnessTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "ragged paged attention v3 head_dim 64-w4a16"
       CI_STAGE: "CorrectnessTest"
       CI_CATEGORY: "kernel support matrix microbenchmarks"
@@ -34,21 +37,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ragged_paged_attention_v3_head_dim_64-w4a16_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w4a16_CorrectnessTest
 
-  - label: "Performance tests for ragged paged attention v3 head_dim 64-w4a16"
-    key: "ragged_paged_attention_v3_head_dim_64-w4a16_PerformanceTest"
-    depends_on: "record_ragged_paged_attention_v3_head_dim_64-w4a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Performance tests for ragged paged attention v3 head_dim 64-w4a16"
+    key: "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w4a16_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_record_ragged_paged_attention_v3_head_dim_64-w4a16_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "ragged_paged_attention_v3_head_dim_64-w4a16_PerformanceTest" "unverified"
-  - label: "Record performance test result for ragged paged attention v3 head_dim 64-w4a16"
-    key: "record_ragged_paged_attention_v3_head_dim_64-w4a16_PerformanceTest"
-    depends_on: "ragged_paged_attention_v3_head_dim_64-w4a16_PerformanceTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w4a16_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record performance test result for ragged paged attention v3 head_dim 64-w4a16"
+    key: "${TPU_VERSION:-tpu6e}_record_ragged_paged_attention_v3_head_dim_64-w4a16_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w4a16_PerformanceTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "ragged paged attention v3 head_dim 64-w4a16"
       CI_STAGE: "PerformanceTest"
       CI_CATEGORY: "kernel support matrix microbenchmarks"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ragged_paged_attention_v3_head_dim_64-w4a16_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w4a16_PerformanceTest

--- a/.buildkite/kernel_microbenchmarks/ragged_paged_attention_v3_head_dim_64/w4a4.yml
+++ b/.buildkite/kernel_microbenchmarks/ragged_paged_attention_v3_head_dim_64/w4a4.yml
@@ -15,18 +15,21 @@
 # pipeline-name: ragged paged attention v3 head_dim 64-w4a4
 # pipeline-type: kernel support matrix microbenchmarks
 steps:
-  - label: "Correctness tests for ragged paged attention v3 head_dim 64-w4a4"
-    key: "ragged_paged_attention_v3_head_dim_64-w4a4_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Correctness tests for ragged paged attention v3 head_dim 64-w4a4"
+    key: "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w4a4_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "ragged_paged_attention_v3_head_dim_64-w4a4_CorrectnessTest" "unverified"
-  - label: "Record correctness test result for ragged paged attention v3 head_dim 64 w4a4"
-    key: "record_ragged_paged_attention_v3_head_dim_64-w4a4_CorrectnessTest"
-    depends_on: "ragged_paged_attention_v3_head_dim_64-w4a4_CorrectnessTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w4a4_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for ragged paged attention v3 head_dim 64 w4a4"
+    key: "${TPU_VERSION:-tpu6e}_record_ragged_paged_attention_v3_head_dim_64-w4a4_CorrectnessTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w4a4_CorrectnessTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "ragged paged attention v3 head_dim 64-w4a4"
       CI_STAGE: "CorrectnessTest"
       CI_CATEGORY: "kernel support matrix microbenchmarks"
@@ -34,21 +37,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ragged_paged_attention_v3_head_dim_64-w4a4_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w4a4_CorrectnessTest
 
-  - label: "Performance tests for ragged paged attention v3 head_dim 64-w4a4"
-    key: "ragged_paged_attention_v3_head_dim_64-w4a4_PerformanceTest"
-    depends_on: "record_ragged_paged_attention_v3_head_dim_64-w4a4_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Performance tests for ragged paged attention v3 head_dim 64-w4a4"
+    key: "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w4a4_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_record_ragged_paged_attention_v3_head_dim_64-w4a4_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "ragged_paged_attention_v3_head_dim_64-w4a4_PerformanceTest" "unverified"
-  - label: "Record performance test result for ragged paged attention v3 head_dim 64-w4a4"
-    key: "record_ragged_paged_attention_v3_head_dim_64-w4a4_PerformanceTest"
-    depends_on: "ragged_paged_attention_v3_head_dim_64-w4a4_PerformanceTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w4a4_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record performance test result for ragged paged attention v3 head_dim 64-w4a4"
+    key: "${TPU_VERSION:-tpu6e}_record_ragged_paged_attention_v3_head_dim_64-w4a4_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w4a4_PerformanceTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "ragged paged attention v3 head_dim 64-w4a4"
       CI_STAGE: "PerformanceTest"
       CI_CATEGORY: "kernel support matrix microbenchmarks"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ragged_paged_attention_v3_head_dim_64-w4a4_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w4a4_PerformanceTest

--- a/.buildkite/kernel_microbenchmarks/ragged_paged_attention_v3_head_dim_64/w4a8.yml
+++ b/.buildkite/kernel_microbenchmarks/ragged_paged_attention_v3_head_dim_64/w4a8.yml
@@ -15,18 +15,21 @@
 # pipeline-name: ragged paged attention v3 head_dim 64-w4a8
 # pipeline-type: kernel support matrix microbenchmarks
 steps:
-  - label: "Correctness tests for ragged paged attention v3 head_dim 64-w4a8"
-    key: "ragged_paged_attention_v3_head_dim_64-w4a8_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Correctness tests for ragged paged attention v3 head_dim 64-w4a8"
+    key: "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w4a8_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "ragged_paged_attention_v3_head_dim_64-w4a8_CorrectnessTest" "unverified"
-  - label: "Record correctness test result for ragged paged attention v3 head_dim 64 w4a8"
-    key: "record_ragged_paged_attention_v3_head_dim_64-w4a8_CorrectnessTest"
-    depends_on: "ragged_paged_attention_v3_head_dim_64-w4a8_CorrectnessTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w4a8_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for ragged paged attention v3 head_dim 64 w4a8"
+    key: "${TPU_VERSION:-tpu6e}_record_ragged_paged_attention_v3_head_dim_64-w4a8_CorrectnessTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w4a8_CorrectnessTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "ragged paged attention v3 head_dim 64-w4a8"
       CI_STAGE: "CorrectnessTest"
       CI_CATEGORY: "kernel support matrix microbenchmarks"
@@ -34,21 +37,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ragged_paged_attention_v3_head_dim_64-w4a8_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w4a8_CorrectnessTest
 
-  - label: "Performance tests for ragged paged attention v3 head_dim 64-w4a8"
-    key: "ragged_paged_attention_v3_head_dim_64-w4a8_PerformanceTest"
-    depends_on: "record_ragged_paged_attention_v3_head_dim_64-w4a8_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Performance tests for ragged paged attention v3 head_dim 64-w4a8"
+    key: "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w4a8_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_record_ragged_paged_attention_v3_head_dim_64-w4a8_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "ragged_paged_attention_v3_head_dim_64-w4a8_PerformanceTest" "unverified"
-  - label: "Record performance test result for ragged paged attention v3 head_dim 64-w4a8"
-    key: "record_ragged_paged_attention_v3_head_dim_64-w4a8_PerformanceTest"
-    depends_on: "ragged_paged_attention_v3_head_dim_64-w4a8_PerformanceTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w4a8_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record performance test result for ragged paged attention v3 head_dim 64-w4a8"
+    key: "${TPU_VERSION:-tpu6e}_record_ragged_paged_attention_v3_head_dim_64-w4a8_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w4a8_PerformanceTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "ragged paged attention v3 head_dim 64-w4a8"
       CI_STAGE: "PerformanceTest"
       CI_CATEGORY: "kernel support matrix microbenchmarks"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ragged_paged_attention_v3_head_dim_64-w4a8_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w4a8_PerformanceTest

--- a/.buildkite/kernel_microbenchmarks/ragged_paged_attention_v3_head_dim_64/w8a16.yml
+++ b/.buildkite/kernel_microbenchmarks/ragged_paged_attention_v3_head_dim_64/w8a16.yml
@@ -15,18 +15,21 @@
 # pipeline-name: ragged paged attention v3 head_dim 64-w8a16
 # pipeline-type: kernel support matrix microbenchmarks
 steps:
-  - label: "Correctness tests for ragged paged attention v3 head_dim 64-w8a16"
-    key: "ragged_paged_attention_v3_head_dim_64-w8a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Correctness tests for ragged paged attention v3 head_dim 64-w8a16"
+    key: "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w8a16_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "ragged_paged_attention_v3_head_dim_64-w8a16_CorrectnessTest" "unverified"
-  - label: "Record correctness test result for ragged paged attention v3 head_dim 64 w8a16"
-    key: "record_ragged_paged_attention_v3_head_dim_64-w8a16_CorrectnessTest"
-    depends_on: "ragged_paged_attention_v3_head_dim_64-w8a16_CorrectnessTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w8a16_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for ragged paged attention v3 head_dim 64 w8a16"
+    key: "${TPU_VERSION:-tpu6e}_record_ragged_paged_attention_v3_head_dim_64-w8a16_CorrectnessTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w8a16_CorrectnessTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "ragged paged attention v3 head_dim 64-w8a16"
       CI_STAGE: "CorrectnessTest"
       CI_CATEGORY: "kernel support matrix microbenchmarks"
@@ -34,21 +37,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ragged_paged_attention_v3_head_dim_64-w8a16_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w8a16_CorrectnessTest
 
-  - label: "Performance tests for ragged paged attention v3 head_dim 64-w8a16"
-    key: "ragged_paged_attention_v3_head_dim_64-w8a16_PerformanceTest"
-    depends_on: "record_ragged_paged_attention_v3_head_dim_64-w8a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Performance tests for ragged paged attention v3 head_dim 64-w8a16"
+    key: "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w8a16_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_record_ragged_paged_attention_v3_head_dim_64-w8a16_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "ragged_paged_attention_v3_head_dim_64-w8a16_PerformanceTest" "unverified"
-  - label: "Record performance test result for ragged paged attention v3 head_dim 64-w8a16"
-    key: "record_ragged_paged_attention_v3_head_dim_64-w8a16_PerformanceTest"
-    depends_on: "ragged_paged_attention_v3_head_dim_64-w8a16_PerformanceTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w8a16_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record performance test result for ragged paged attention v3 head_dim 64-w8a16"
+    key: "${TPU_VERSION:-tpu6e}_record_ragged_paged_attention_v3_head_dim_64-w8a16_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w8a16_PerformanceTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "ragged paged attention v3 head_dim 64-w8a16"
       CI_STAGE: "PerformanceTest"
       CI_CATEGORY: "kernel support matrix microbenchmarks"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ragged_paged_attention_v3_head_dim_64-w8a16_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w8a16_PerformanceTest

--- a/.buildkite/kernel_microbenchmarks/ragged_paged_attention_v3_head_dim_64/w8a8.yml
+++ b/.buildkite/kernel_microbenchmarks/ragged_paged_attention_v3_head_dim_64/w8a8.yml
@@ -15,18 +15,21 @@
 # pipeline-name: ragged paged attention v3 head_dim 64-w8a8
 # pipeline-type: kernel support matrix microbenchmarks
 steps:
-  - label: "Correctness tests for ragged paged attention v3 head_dim 64-w8a8"
-    key: "ragged_paged_attention_v3_head_dim_64-w8a8_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Correctness tests for ragged paged attention v3 head_dim 64-w8a8"
+    key: "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w8a8_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "ragged_paged_attention_v3_head_dim_64-w8a8_CorrectnessTest" "unverified"
-  - label: "Record correctness test result for ragged paged attention v3 head_dim 64 w8a8"
-    key: "record_ragged_paged_attention_v3_head_dim_64-w8a8_CorrectnessTest"
-    depends_on: "ragged_paged_attention_v3_head_dim_64-w8a8_CorrectnessTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w8a8_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for ragged paged attention v3 head_dim 64 w8a8"
+    key: "${TPU_VERSION:-tpu6e}_record_ragged_paged_attention_v3_head_dim_64-w8a8_CorrectnessTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w8a8_CorrectnessTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "ragged paged attention v3 head_dim 64-w8a8"
       CI_STAGE: "CorrectnessTest"
       CI_CATEGORY: "kernel support matrix microbenchmarks"
@@ -34,21 +37,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ragged_paged_attention_v3_head_dim_64-w8a8_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w8a8_CorrectnessTest
 
-  - label: "Performance tests for ragged paged attention v3 head_dim 64-w8a8"
-    key: "ragged_paged_attention_v3_head_dim_64-w8a8_PerformanceTest"
-    depends_on: "record_ragged_paged_attention_v3_head_dim_64-w8a8_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Performance tests for ragged paged attention v3 head_dim 64-w8a8"
+    key: "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w8a8_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_record_ragged_paged_attention_v3_head_dim_64-w8a8_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "ragged_paged_attention_v3_head_dim_64-w8a8_PerformanceTest" "unverified"
-  - label: "Record performance test result for ragged paged attention v3 head_dim 64-w8a8"
-    key: "record_ragged_paged_attention_v3_head_dim_64-w8a8_PerformanceTest"
-    depends_on: "ragged_paged_attention_v3_head_dim_64-w8a8_PerformanceTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w8a8_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record performance test result for ragged paged attention v3 head_dim 64-w8a8"
+    key: "${TPU_VERSION:-tpu6e}_record_ragged_paged_attention_v3_head_dim_64-w8a8_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w8a8_PerformanceTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "ragged paged attention v3 head_dim 64-w8a8"
       CI_STAGE: "PerformanceTest"
       CI_CATEGORY: "kernel support matrix microbenchmarks"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ragged_paged_attention_v3_head_dim_64-w8a8_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w8a8_PerformanceTest

--- a/.buildkite/models/Qwen_Qwen2_5-VL-7B-Instruct.yml
+++ b/.buildkite/models/Qwen_Qwen2_5-VL-7B-Instruct.yml
@@ -15,72 +15,80 @@
 # pipeline-name: Qwen/Qwen2.5-VL-7B-Instruct
 # pipeline-type: multimodal
 steps:
-  - label: "Unit tests for Qwen/Qwen2.5-VL-7B-Instruct"
-    key: "Qwen_Qwen2_5-VL-7B-Instruct_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} Unit tests for Qwen/Qwen2.5-VL-7B-Instruct"
+    key: "${TPU_VERSION:-tpu6e}_Qwen_Qwen2_5-VL-7B-Instruct_UnitTest"
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     soft_fail: true
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh \
           bash -c 'python3 -m pytest -s -v -x /workspace/tpu_inference/tests/models/jax/test_qwen2_5_vl.py'
-  - label: "Record unit test result for Qwen/Qwen2.5-VL-7B-Instruct"
-    key: "record_Qwen_Qwen2_5-VL-7B-Instruct_UnitTest"
-    depends_on: "Qwen_Qwen2_5-VL-7B-Instruct_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} Record unit test result for Qwen/Qwen2.5-VL-7B-Instruct"
+    key: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen2_5-VL-7B-Instruct_UnitTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_Qwen_Qwen2_5-VL-7B-Instruct_UnitTest"
     env:
-      CI_TARGET: Qwen/Qwen2.5-VL-7B-Instruct
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
+      CI_TARGET: "Qwen/Qwen2.5-VL-7B-Instruct"
       CI_STAGE: "UnitTest"
       CI_CATEGORY: "multimodal"
     agents:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh Qwen_Qwen2_5-VL-7B-Instruct_UnitTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_Qwen_Qwen2_5-VL-7B-Instruct_UnitTest
 
-  - label: "Accuracy for Qwen/Qwen2.5-VL-7B-Instruct"
-    key: "Qwen_Qwen2_5-VL-7B-Instruct_Accuracy"
-    depends_on: "record_Qwen_Qwen2_5-VL-7B-Instruct_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} Accuracy for Qwen/Qwen2.5-VL-7B-Instruct"
+    key: "${TPU_VERSION:-tpu6e}_Qwen_Qwen2_5-VL-7B-Instruct_Accuracy"
+    depends_on: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen2_5-VL-7B-Instruct_UnitTest"
     agents:
-      queue: tpu_v6e_8_queue
+      queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
     soft_fail: true
     env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
       TEST_MODEL: Qwen/Qwen2.5-VL-7B-Instruct
       TENSOR_PARALLEL_SIZE: 1
       MINIMUM_ACCURACY_THRESHOLD: 0.72
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/test_accuracy.sh
-  - label: "Record accuracy result for Qwen/Qwen2.5-VL-7B-Instruct"
-    key: "record_Qwen_Qwen2_5-VL-7B-Instruct_Accuracy"
-    depends_on: "Qwen_Qwen2_5-VL-7B-Instruct_Accuracy"
+  - label: "${TPU_VERSION:-tpu6e} Record accuracy result for Qwen/Qwen2.5-VL-7B-Instruct"
+    key: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen2_5-VL-7B-Instruct_Accuracy"
+    depends_on: "${TPU_VERSION:-tpu6e}_Qwen_Qwen2_5-VL-7B-Instruct_Accuracy"
     env:
-      CI_TARGET: Qwen/Qwen2.5-VL-7B-Instruct
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
+      CI_TARGET: "Qwen/Qwen2.5-VL-7B-Instruct"
       CI_STAGE: "Accuracy/Correctness"
       CI_CATEGORY: "multimodal"
     agents:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh Qwen_Qwen2_5-VL-7B-Instruct_Accuracy
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_Qwen_Qwen2_5-VL-7B-Instruct_Accuracy
 
-  - label: "Performance benchmarks for Qwen/Qwen2.5-VL-7B-Instruct"
-    key: "Qwen_Qwen2_5-VL-7B-Instruct_Benchmark"
-    depends_on: "record_Qwen_Qwen2_5-VL-7B-Instruct_Accuracy"
+  - label: "${TPU_VERSION:-tpu6e} Performance benchmarks for Qwen/Qwen2.5-VL-7B-Instruct"
+    key: "${TPU_VERSION:-tpu6e}_Qwen_Qwen2_5-VL-7B-Instruct_Benchmark"
+    depends_on: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen2_5-VL-7B-Instruct_Accuracy"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/mm_bench_recipe.sh
-  - label: "Record performance benchmark result for Qwen/Qwen2.5-VL-7B-Instruct"
-    key: "record_Qwen_Qwen2_5-VL-7B-Instruct_Benchmark"
-    depends_on: "Qwen_Qwen2_5-VL-7B-Instruct_Benchmark"
+  - label: "${TPU_VERSION:-tpu6e} Record performance benchmark result for Qwen/Qwen2.5-VL-7B-Instruct"
+    key: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen2_5-VL-7B-Instruct_Benchmark"
+    depends_on: "${TPU_VERSION:-tpu6e}_Qwen_Qwen2_5-VL-7B-Instruct_Benchmark"
     env:
-      CI_TARGET: Qwen/Qwen2.5-VL-7B-Instruct
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
+      CI_TARGET: "Qwen/Qwen2.5-VL-7B-Instruct"
       CI_STAGE: "Benchmark"
       CI_CATEGORY: "multimodal"
     agents:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh Qwen_Qwen2_5-VL-7B-Instruct_Benchmark
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_Qwen_Qwen2_5-VL-7B-Instruct_Benchmark

--- a/.buildkite/models/Qwen_Qwen3-30B-A3B.yml
+++ b/.buildkite/models/Qwen_Qwen3-30B-A3B.yml
@@ -15,61 +15,67 @@
 # pipeline-name: Qwen/Qwen3-30B-A3B
 # pipeline-type: text-only
 steps:
-  - label: "Unit tests for Qwen/Qwen3-30B-A3B"
-    key: "Qwen_Qwen3-30B-A3B_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} Unit tests for Qwen/Qwen3-30B-A3B"
+    key: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-30B-A3B_UnitTest"
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     soft_fail: true
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh \
           bash -c 'python3 -m pytest -s -v -x /workspace/tpu_inference/tests/models/jax/test_qwen3.py'
-  - label: "Record unit test result for Qwen/Qwen3-30B-A3B"
-    key: "record_Qwen_Qwen3-30B-A3B_UnitTest"
-    depends_on: "Qwen_Qwen3-30B-A3B_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} Record unit test result for Qwen/Qwen3-30B-A3B"
+    key: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen3-30B-A3B_UnitTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-30B-A3B_UnitTest"
     env:
-      CI_TARGET: Qwen/Qwen3-30B-A3B
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
+      CI_TARGET: "Qwen/Qwen3-30B-A3B"
       CI_STAGE: "UnitTest"
       CI_CATEGORY: "text-only"
     agents:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh Qwen_Qwen3-30B-A3B_UnitTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_Qwen_Qwen3-30B-A3B_UnitTest
 
-  - label: "Accuracy for Qwen/Qwen3-30B-A3B"
-    key: "Qwen_Qwen3-30B-A3B_Accuracy"
-    depends_on: "record_Qwen_Qwen3-30B-A3B_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} Accuracy for Qwen/Qwen3-30B-A3B"
+    key: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-30B-A3B_Accuracy"
+    depends_on: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen3-30B-A3B_UnitTest"
     agents:
-      queue: tpu_v6e_8_queue
+      queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
     soft_fail: true
     env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
       TEST_MODEL: Qwen/Qwen3-30B-A3B
       TENSOR_PARALLEL_SIZE: 4
       MINIMUM_ACCURACY_THRESHOLD: 0.89
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/test_accuracy.sh
-  - label: "Record accuracy result for Qwen/Qwen3-30B-A3B"
-    key: "record_Qwen_Qwen3-30B-A3B_Accuracy"
-    depends_on: "Qwen_Qwen3-30B-A3B_Accuracy"
+  - label: "${TPU_VERSION:-tpu6e} Record accuracy result for Qwen/Qwen3-30B-A3B"
+    key: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen3-30B-A3B_Accuracy"
+    depends_on: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-30B-A3B_Accuracy"
     env:
-      CI_TARGET: Qwen/Qwen3-30B-A3B
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
+      CI_TARGET: "Qwen/Qwen3-30B-A3B"
       CI_STAGE: "Accuracy/Correctness"
       CI_CATEGORY: "text-only"
     agents:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh Qwen_Qwen3-30B-A3B_Accuracy
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_Qwen_Qwen3-30B-A3B_Accuracy
 
-  - label: "Performance benchmarks for Qwen/Qwen3-30B-A3B"
-    key: "Qwen_Qwen3-30B-A3B_Benchmark"
-    depends_on: "record_Qwen_Qwen3-30B-A3B_Accuracy"
+  - label: "${TPU_VERSION:-tpu6e} Performance benchmarks for Qwen/Qwen3-30B-A3B"
+    key: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-30B-A3B_Benchmark"
+    depends_on: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen3-30B-A3B_Accuracy"
     soft_fail: true
     agents:
-      queue: tpu_v6e_8_queue
+      queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
     env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
       TEST_MODEL: Qwen/Qwen3-30B-A3B
       TENSOR_PARALLEL_SIZE: 4
       MINIMUM_THROUGHPUT_THRESHOLD: 7.20
@@ -82,15 +88,16 @@ steps:
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/benchmark.sh
-  - label: "Record performance benchmark result for Qwen/Qwen3-30B-A3B"
-    key: "record_Qwen_Qwen3-30B-A3B_Benchmark"
-    depends_on: "Qwen_Qwen3-30B-A3B_Benchmark"
+  - label: "${TPU_VERSION:-tpu6e} Record performance benchmark result for Qwen/Qwen3-30B-A3B"
+    key: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen3-30B-A3B_Benchmark"
+    depends_on: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-30B-A3B_Benchmark"
     env:
-      CI_TARGET: Qwen/Qwen3-30B-A3B
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
+      CI_TARGET: "Qwen/Qwen3-30B-A3B"
       CI_STAGE: "Benchmark"
       CI_CATEGORY: "text-only"
     agents:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh Qwen_Qwen3-30B-A3B_Benchmark
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_Qwen_Qwen3-30B-A3B_Benchmark

--- a/.buildkite/models/Qwen_Qwen3-32B.yml
+++ b/.buildkite/models/Qwen_Qwen3-32B.yml
@@ -15,61 +15,67 @@
 # pipeline-name: Qwen/Qwen3-32B
 # pipeline-type: text-only
 steps:
-  - label: "Unit tests for Qwen/Qwen3-32B"
-    key: "Qwen_Qwen3-32B_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} Unit tests for Qwen/Qwen3-32B"
+    key: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-32B_UnitTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh \
           bash -c 'python3 -m pytest -s -v -x /workspace/tpu_inference/tests/models/jax/test_qwen3.py'
-  - label: "Record unit test result for Qwen/Qwen3-32B"
-    key: "record_Qwen_Qwen3-32B_UnitTest"
-    depends_on: "Qwen_Qwen3-32B_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} Record unit test result for Qwen/Qwen3-32B"
+    key: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen3-32B_UnitTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-32B_UnitTest"
     env:
-      CI_TARGET: Qwen/Qwen3-32B
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
+      CI_TARGET: "Qwen/Qwen3-32B"
       CI_STAGE: "UnitTest"
       CI_CATEGORY: "text-only"
     agents:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh Qwen_Qwen3-32B_UnitTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_Qwen_Qwen3-32B_UnitTest
 
-  - label: "Accuracy for Qwen/Qwen3-32B"
-    key: "Qwen_Qwen3-32B_Accuracy"
-    depends_on: "record_Qwen_Qwen3-32B_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} Accuracy for Qwen/Qwen3-32B"
+    key: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-32B_Accuracy"
+    depends_on: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen3-32B_UnitTest"
     agents:
-      queue: tpu_v6e_8_queue
+      queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
     soft_fail: true
     env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
       TEST_MODEL: Qwen/Qwen3-32B
       TENSOR_PARALLEL_SIZE: 8
       MINIMUM_ACCURACY_THRESHOLD: 0.74
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/test_accuracy.sh
-  - label: "Record accuracy result for Qwen/Qwen3-32B"
-    key: "record_Qwen_Qwen3-32B_Accuracy"
-    depends_on: "Qwen_Qwen3-32B_Accuracy"
+  - label: "${TPU_VERSION:-tpu6e} Record accuracy result for Qwen/Qwen3-32B"
+    key: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen3-32B_Accuracy"
+    depends_on: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-32B_Accuracy"
     env:
-      CI_TARGET: Qwen/Qwen3-32B
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
+      CI_TARGET: "Qwen/Qwen3-32B"
       CI_STAGE: "Accuracy/Correctness"
       CI_CATEGORY: "text-only"
     agents:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh Qwen_Qwen3-32B_Accuracy
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_Qwen_Qwen3-32B_Accuracy
 
-  - label: "Performance benchmarks for Qwen/Qwen3-32B"
-    key: "Qwen_Qwen3-32B_Benchmark"
-    depends_on: "record_Qwen_Qwen3-32B_Accuracy"
+  - label: "${TPU_VERSION:-tpu6e} Performance benchmarks for Qwen/Qwen3-32B"
+    key: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-32B_Benchmark"
+    depends_on: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen3-32B_Accuracy"
     agents:
-      queue: tpu_v6e_8_queue
+      queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
     soft_fail: true
     env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
       TEST_MODEL: Qwen/Qwen3-32B
       TENSOR_PARALLEL_SIZE: 8
       MINIMUM_THROUGHPUT_THRESHOLD: 12.46
@@ -82,15 +88,16 @@ steps:
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/benchmark.sh
-  - label: "Record performance benchmark result for Qwen/Qwen3-32B"
-    key: "record_Qwen_Qwen3-32B_Benchmark"
-    depends_on: "Qwen_Qwen3-32B_Benchmark"
+  - label: "${TPU_VERSION:-tpu6e} Record performance benchmark result for Qwen/Qwen3-32B"
+    key: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen3-32B_Benchmark"
+    depends_on: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-32B_Benchmark"
     env:
-      CI_TARGET: Qwen/Qwen3-32B
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
+      CI_TARGET: "Qwen/Qwen3-32B"
       CI_STAGE: "Benchmark"
       CI_CATEGORY: "text-only"
     agents:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh Qwen_Qwen3-32B_Benchmark
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_Qwen_Qwen3-32B_Benchmark

--- a/.buildkite/models/Qwen_Qwen3-4B.yml
+++ b/.buildkite/models/Qwen_Qwen3-4B.yml
@@ -15,61 +15,67 @@
 # pipeline-name: Qwen/Qwen3-4B
 # pipeline-type: text-only
 steps:
-  - label: "Unit tests for Qwen/Qwen3-4B"
-    key: "Qwen_Qwen3-4B_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} Unit tests for Qwen/Qwen3-4B"
+    key: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-4B_UnitTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh \
           bash -c 'python3 -m pytest -s -v -x /workspace/tpu_inference/tests/models/jax/test_qwen3.py'
-  - label: "Record unit test result for Qwen/Qwen3-4B"
-    key: "record_Qwen_Qwen3-4B_UnitTest"
-    depends_on: "Qwen_Qwen3-4B_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} Record unit test result for Qwen/Qwen3-4B"
+    key: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen3-4B_UnitTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-4B_UnitTest"
     env:
-      CI_TARGET: Qwen/Qwen3-4B
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
+      CI_TARGET: "Qwen/Qwen3-4B"
       CI_STAGE: "UnitTest"
       CI_CATEGORY: "text-only"
     agents:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh Qwen_Qwen3-4B_UnitTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_Qwen_Qwen3-4B_UnitTest
 
-  - label: "Accuracy for Qwen/Qwen3-4B"
-    key: "Qwen_Qwen3-4B_Accuracy"
-    depends_on: "record_Qwen_Qwen3-4B_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} Accuracy for Qwen/Qwen3-4B"
+    key: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-4B_Accuracy"
+    depends_on: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen3-4B_UnitTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
       TEST_MODEL: Qwen/Qwen3-4B
       TENSOR_PARALLEL_SIZE: 1
       MINIMUM_ACCURACY_THRESHOLD: 0.85
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/test_accuracy.sh
-  - label: "Record accuracy test result for Qwen/Qwen3-4B"
-    key: "record_Qwen_Qwen3-4B_Accuracy"
-    depends_on: "Qwen_Qwen3-4B_Accuracy"
+  - label: "${TPU_VERSION:-tpu6e} Record accuracy test result for Qwen/Qwen3-4B"
+    key: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen3-4B_Accuracy"
+    depends_on: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-4B_Accuracy"
     env:
-      CI_TARGET: Qwen/Qwen3-4B
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
+      CI_TARGET: "Qwen/Qwen3-4B"
       CI_STAGE: "Accuracy/Correctness"
       CI_CATEGORY: "text-only"
     agents:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh Qwen_Qwen3-4B_Accuracy
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_Qwen_Qwen3-4B_Accuracy
 
-  - label: "Performance benchmarks for Qwen/Qwen3-4B"
-    key: "Qwen_Qwen3-4B_Benchmark"
-    depends_on: "record_Qwen_Qwen3-4B_Accuracy"
+  - label: "${TPU_VERSION:-tpu6e} Performance benchmarks for Qwen/Qwen3-4B"
+    key: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-4B_Benchmark"
+    depends_on: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen3-4B_Accuracy"
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     soft_fail: true
     env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
       TEST_MODEL: Qwen/Qwen3-4B
       TENSOR_PARALLEL_SIZE: 1
       MINIMUM_THROUGHPUT_THRESHOLD: 11.00
@@ -82,15 +88,16 @@ steps:
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/benchmark.sh
-  - label: "Record performance benchmark result for Qwen/Qwen3-4B"
-    key: "record_Qwen_Qwen3-4B_Benchmark"
-    depends_on: "Qwen_Qwen3-4B_Benchmark"
+  - label: "${TPU_VERSION:-tpu6e} Record performance benchmark result for Qwen/Qwen3-4B"
+    key: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen3-4B_Benchmark"
+    depends_on: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-4B_Benchmark"
     env:
-      CI_TARGET: Qwen/Qwen3-4B
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
+      CI_TARGET: "Qwen/Qwen3-4B"
       CI_STAGE: "Benchmark"
       CI_CATEGORY: "text-only"
     agents:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh Qwen_Qwen3-4B_Benchmark
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_Qwen_Qwen3-4B_Benchmark

--- a/.buildkite/models/Qwen_Qwen3-Coder-480B-A35B-Instruct.yml
+++ b/.buildkite/models/Qwen_Qwen3-Coder-480B-A35B-Instruct.yml
@@ -15,67 +15,76 @@
 # pipeline-name: Qwen/Qwen3-Coder-480B-A35B-Instruct
 # pipeline-type: text-only
 steps:
-  - label: "Unit tests for Qwen/Qwen3-Coder-480B-A35B-Instruct"
-    key: "Qwen_Qwen3-Coder-480B-A35B-Instruct_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} Unit tests for Qwen/Qwen3-Coder-480B-A35B-Instruct"
+    key: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-Coder-480B-A35B-Instruct_UnitTest"
     agents:
-      queue: tpu_v6e_8_queue
+      queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     soft_fail: true
     commands:
       - |
-        buildkite-agent meta-data set "Qwen_Qwen3-Coder-480B-A35B-Instruct_UnitTest" "unverified"
-  - label: "Record unit test result for Qwen/Qwen3-Coder-480B-A35B-Instruct"
-    key: "record_Qwen_Qwen3-Coder-480B-A35B-Instruct_UnitTest"
-    depends_on: "Qwen_Qwen3-Coder-480B-A35B-Instruct_UnitTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-Coder-480B-A35B-Instruct_UnitTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record unit test result for Qwen/Qwen3-Coder-480B-A35B-Instruct"
+    key: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen3-Coder-480B-A35B-Instruct_UnitTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-Coder-480B-A35B-Instruct_UnitTest"
     env:
-      CI_TARGET: Qwen/Qwen3-Coder-480B-A35B-Instruct
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
+      CI_TARGET: "Qwen/Qwen3-Coder-480B-A35B-Instruct"
       CI_STAGE: "UnitTest"
       CI_CATEGORY: "text-only"
     agents:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh Qwen_Qwen3-Coder-480B-A35B-Instruct_UnitTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_Qwen_Qwen3-Coder-480B-A35B-Instruct_UnitTest
 
-  - label: "Accuracy for Qwen/Qwen3-Coder-480B-A35B-Instruct"
-    key: "Qwen_Qwen3-Coder-480B-A35B-Instruct_Accuracy"
-    depends_on: "record_Qwen_Qwen3-Coder-480B-A35B-Instruct_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} Accuracy for Qwen/Qwen3-Coder-480B-A35B-Instruct"
+    key: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-Coder-480B-A35B-Instruct_Accuracy"
+    depends_on: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen3-Coder-480B-A35B-Instruct_UnitTest"
     agents:
-      queue: tpu_v6e_8_queue
+      queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     soft_fail: true
     commands:
       - |
-        buildkite-agent meta-data set "Qwen_Qwen3-Coder-480B-A35B-Instruct_Accuracy" "unverified"
-  - label: "Record accuracy result for Qwen/Qwen3-Coder-480B-A35B-Instruct"
-    key: "record_Qwen_Qwen3-Coder-480B-A35B-Instruct_Accuracy"
-    depends_on: "Qwen_Qwen3-Coder-480B-A35B-Instruct_Accuracy"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-Coder-480B-A35B-Instruct_Accuracy" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record integration test result for Qwen/Qwen3-Coder-480B-A35B-Instruct"
+    key: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen3-Coder-480B-A35B-Instruct_Accuracy"
+    depends_on: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-Coder-480B-A35B-Instruct_Accuracy"
     env:
-      CI_TARGET: Qwen/Qwen3-Coder-480B-A35B-Instruct
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
+      CI_TARGET: "Qwen/Qwen3-Coder-480B-A35B-Instruct"
       CI_STAGE: "Accuracy/Correctness"
       CI_CATEGORY: "text-only"
     agents:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh Qwen_Qwen3-Coder-480B-A35B-Instruct_Accuracy
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_Qwen_Qwen3-Coder-480B-A35B-Instruct_Accuracy
 
-  - label: "Performance benchmarks for Qwen/Qwen3-Coder-480B-A35B-Instruct"
-    key: "Qwen_Qwen3-Coder-480B-A35B-Instruct_Benchmark"
-    depends_on: "record_Qwen_Qwen3-Coder-480B-A35B-Instruct_Accuracy"
+  - label: "${TPU_VERSION:-tpu6e} Performance benchmarks for Qwen/Qwen3-Coder-480B-A35B-Instruct"
+    key: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-Coder-480B-A35B-Instruct_Benchmark"
+    depends_on: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen3-Coder-480B-A35B-Instruct_Accuracy"
     agents:
-      queue: tpu_v6e_8_queue
+      queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     soft_fail: true
     commands:
       - |
-        buildkite-agent meta-data set "Qwen_Qwen3-Coder-480B-A35B-Instruct_Benchmark" "unverified"
-  - label: "Record performance benchmark result for Qwen/Qwen3-Coder-480B-A35B-Instruct"
-    key: "record_Qwen_Qwen3-Coder-480B-A35B-Instruct_Benchmark"
-    depends_on: "Qwen_Qwen3-Coder-480B-A35B-Instruct_Benchmark"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-Coder-480B-A35B-Instruct_Benchmark" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record performance benchmark result for Qwen/Qwen3-Coder-480B-A35B-Instruct"
+    key: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen3-Coder-480B-A35B-Instruct_Benchmark"
+    depends_on: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-Coder-480B-A35B-Instruct_Benchmark"
     env:
-      CI_TARGET: Qwen/Qwen3-Coder-480B-A35B-Instruct
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
+      CI_TARGET: "Qwen/Qwen3-Coder-480B-A35B-Instruct"
       CI_STAGE: "Benchmark"
       CI_CATEGORY: "text-only"
     agents:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh Qwen_Qwen3-Coder-480B-A35B-Instruct_Benchmark
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_Qwen_Qwen3-Coder-480B-A35B-Instruct_Benchmark

--- a/.buildkite/models/Qwen_Qwen3-Omni-30B-A3B-Instruct.yml
+++ b/.buildkite/models/Qwen_Qwen3-Omni-30B-A3B-Instruct.yml
@@ -15,67 +15,76 @@
 # pipeline-name: Qwen/Qwen3-Omni-30B-A3B-Instruct
 # pipeline-type: multimodal
 steps:
-  - label: "Unit tests for Qwen/Qwen3-Omni-30B-A3B-Instruct"
-    key: "Qwen_Qwen3-Omni-30B-A3B-Instruct_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} Unit tests for Qwen/Qwen3-Omni-30B-A3B-Instruct"
+    key: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-Omni-30B-A3B-Instruct_UnitTest"
     agents:
-      queue: tpu_v6e_8_queue
+      queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     soft_fail: true
     commands:
       - |
-        buildkite-agent meta-data set "Qwen_Qwen3-Omni-30B-A3B-Instruct_UnitTest" "unverified"
-  - label: "Record unit test result for Qwen/Qwen3-Omni-30B-A3B-Instruct"
-    key: "record_Qwen_Qwen3-Omni-30B-A3B-Instruct_UnitTest"
-    depends_on: "Qwen_Qwen3-Omni-30B-A3B-Instruct_UnitTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-Omni-30B-A3B-Instruct_UnitTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record unit test result for Qwen/Qwen3-Omni-30B-A3B-Instruct"
+    key: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen3-Omni-30B-A3B-Instruct_UnitTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-Omni-30B-A3B-Instruct_UnitTest"
     env:
-      CI_TARGET: Qwen/Qwen3-Omni-30B-A3B-Instruct
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
+      CI_TARGET: "Qwen/Qwen3-Omni-30B-A3B-Instruct"
       CI_STAGE: "UnitTest"
       CI_CATEGORY: "multimodal"
     agents:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh Qwen_Qwen3-Omni-30B-A3B-Instruct_UnitTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_Qwen_Qwen3-Omni-30B-A3B-Instruct_UnitTest
 
-  - label: "Accuracy for Qwen/Qwen3-Omni-30B-A3B-Instruct"
-    key: "Qwen_Qwen3-Omni-30B-A3B-Instruct_Accuracy"
-    depends_on: "record_Qwen_Qwen3-Omni-30B-A3B-Instruct_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} Accuracy for Qwen/Qwen3-Omni-30B-A3B-Instruct"
+    key: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-Omni-30B-A3B-Instruct_Accuracy"
+    depends_on: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen3-Omni-30B-A3B-Instruct_UnitTest"
     agents:
-      queue: tpu_v6e_8_queue
+      queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     soft_fail: true
     commands:
       - |
-        buildkite-agent meta-data set "Qwen_Qwen3-Omni-30B-A3B-Instruct_Accuracy" "unverified"
-  - label: "Record accuracy result for Qwen/Qwen3-Omni-30B-A3B-Instruct"
-    key: "record_Qwen_Qwen3-Omni-30B-A3B-Instruct_Accuracy"
-    depends_on: "Qwen_Qwen3-Omni-30B-A3B-Instruct_Accuracy"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-Omni-30B-A3B-Instruct_Accuracy" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record accuracy result for Qwen/Qwen3-Omni-30B-A3B-Instruct"
+    key: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen3-Omni-30B-A3B-Instruct_Accuracy"
+    depends_on: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-Omni-30B-A3B-Instruct_Accuracy"
     env:
-      CI_TARGET: Qwen/Qwen3-Omni-30B-A3B-Instruct
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
+      CI_TARGET: "Qwen/Qwen3-Omni-30B-A3B-Instruct"
       CI_STAGE: "Accuracy/Correctness"
       CI_CATEGORY: "multimodal"
     agents:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh Qwen_Qwen3-Omni-30B-A3B-Instruct_Accuracy
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_Qwen_Qwen3-Omni-30B-A3B-Instruct_Accuracy
 
-  - label: "Performance benchmarks for Qwen/Qwen3-Omni-30B-A3B-Instruct"
-    key: "Qwen_Qwen3-Omni-30B-A3B-Instruct_Benchmark"
-    depends_on: "record_Qwen_Qwen3-Omni-30B-A3B-Instruct_Accuracy"
+  - label: "${TPU_VERSION:-tpu6e} Performance benchmarks for Qwen/Qwen3-Omni-30B-A3B-Instruct"
+    key: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-Omni-30B-A3B-Instruct_Benchmark"
+    depends_on: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen3-Omni-30B-A3B-Instruct_Accuracy"
     agents:
-      queue: tpu_v6e_8_queue
+      queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     soft_fail: true
     commands:
       - |
-        buildkite-agent meta-data set "Qwen_Qwen3-Omni-30B-A3B-Instruct_Benchmark" "unverified"
-  - label: "Record performance benchmark result for Qwen/Qwen3-Omni-30B-A3B-Instruct"
-    key: "record_Qwen_Qwen3-Omni-30B-A3B-Instruct_Benchmark"
-    depends_on: "Qwen_Qwen3-Omni-30B-A3B-Instruct_Benchmark"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-Omni-30B-A3B-Instruct_Benchmark" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record performance benchmark result for Qwen/Qwen3-Omni-30B-A3B-Instruct"
+    key: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen3-Omni-30B-A3B-Instruct_Benchmark"
+    depends_on: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-Omni-30B-A3B-Instruct_Benchmark"
     env:
-      CI_TARGET: Qwen/Qwen3-Omni-30B-A3B-Instruct
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
+      CI_TARGET: "Qwen/Qwen3-Omni-30B-A3B-Instruct"
       CI_STAGE: "Benchmark"
       CI_CATEGORY: "multimodal"
     agents:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh Qwen_Qwen3-Omni-30B-A3B-Instruct_Benchmark
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_Qwen_Qwen3-Omni-30B-A3B-Instruct_Benchmark

--- a/.buildkite/models/deepseek-ai_DeepSeek-V3.1.yml
+++ b/.buildkite/models/deepseek-ai_DeepSeek-V3.1.yml
@@ -15,67 +15,76 @@
 # pipeline-name: deepseek-ai/DeepSeek-V3.1
 # pipeline-type: text-only
 steps:
-  - label: "Unit tests for deepseek-ai/DeepSeek-V3.1"
-    key: "deepseek-ai_DeepSeek-V3_1_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} Unit tests for deepseek-ai/DeepSeek-V3.1"
+    key: "${TPU_VERSION:-tpu6e}_deepseek-ai_DeepSeek-V3_1_UnitTest"
     agents:
-      queue: tpu_v6e_8_queue
+      queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     soft_fail: true
     commands:
       - |
-        buildkite-agent meta-data set "deepseek-ai_DeepSeek-V3_1_UnitTest" "unverified"
-  - label: "Record unit test result for deepseek-ai/DeepSeek-V3.1"
-    key: "record_deepseek-ai_DeepSeek-V3_1_UnitTest"
-    depends_on: "deepseek-ai_DeepSeek-V3_1_UnitTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_deepseek-ai_DeepSeek-V3_1_UnitTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record unit test result for deepseek-ai/DeepSeek-V3.1"
+    key: "${TPU_VERSION:-tpu6e}_record_deepseek-ai_DeepSeek-V3_1_UnitTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_deepseek-ai_DeepSeek-V3_1_UnitTest"
     env:
-      CI_TARGET: deepseek-ai/DeepSeek-V3.1
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
+      CI_TARGET: "deepseek-ai/DeepSeek-V3.1"
       CI_STAGE: "UnitTest"
       CI_CATEGORY: "text-only"
     agents:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh deepseek-ai_DeepSeek-V3_1_UnitTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_deepseek-ai_DeepSeek-V3_1_UnitTest
 
-  - label: "Accuracy for deepseek-ai/DeepSeek-V3.1"
-    key: "deepseek-ai_DeepSeek-V3_1_Accuracy"
-    depends_on: "record_deepseek-ai_DeepSeek-V3_1_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} Accuracy for deepseek-ai/DeepSeek-V3.1"
+    key: "${TPU_VERSION:-tpu6e}_deepseek-ai_DeepSeek-V3_1_Accuracy"
+    depends_on: "${TPU_VERSION:-tpu6e}_record_deepseek-ai_DeepSeek-V3_1_UnitTest"
     agents:
-      queue: tpu_v6e_8_queue
+      queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     soft_fail: true
     commands:
       - |
-        buildkite-agent meta-data set "deepseek-ai_DeepSeek-V3_1_Accuracy" "unverified"
-  - label: "Record accuracy result for deepseek-ai/DeepSeek-V3.1"
-    key: "record_deepseek-ai_DeepSeek-V3_1_Accuracy"
-    depends_on: "deepseek-ai_DeepSeek-V3_1_Accuracy"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_deepseek-ai_DeepSeek-V3_1_Accuracy" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record accuracy result for deepseek-ai/DeepSeek-V3.1"
+    key: "${TPU_VERSION:-tpu6e}_record_deepseek-ai_DeepSeek-V3_1_Accuracy"
+    depends_on: "${TPU_VERSION:-tpu6e}_deepseek-ai_DeepSeek-V3_1_Accuracy"
     env:
-      CI_TARGET: deepseek-ai/DeepSeek-V3.1
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
+      CI_TARGET: "deepseek-ai/DeepSeek-V3.1"
       CI_STAGE: "Accuracy/Correctness"
       CI_CATEGORY: "text-only"
     agents:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh deepseek-ai_DeepSeek-V3_1_Accuracy
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_deepseek-ai_DeepSeek-V3_1_Accuracy
 
-  - label: "Performance benchmarks for deepseek-ai/DeepSeek-V3.1"
-    key: "deepseek-ai_DeepSeek-V3_1_Benchmark"
-    depends_on: "record_deepseek-ai_DeepSeek-V3_1_Accuracy"
+  - label: "${TPU_VERSION:-tpu6e} Performance benchmarks for deepseek-ai/DeepSeek-V3.1"
+    key: "${TPU_VERSION:-tpu6e}_deepseek-ai_DeepSeek-V3_1_Benchmark"
+    depends_on: "${TPU_VERSION:-tpu6e}_record_deepseek-ai_DeepSeek-V3_1_Accuracy"
     agents:
-      queue: tpu_v6e_8_queue
+      queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     soft_fail: true
     commands:
       - |
-        buildkite-agent meta-data set "deepseek-ai_DeepSeek-V3_1_Benchmark" "unverified"
-  - label: "Record performance benchmark result for deepseek-ai/DeepSeek-V3.1"
-    key: "record_deepseek-ai_DeepSeek-V3_1_Benchmark"
-    depends_on: "deepseek-ai_DeepSeek-V3_1_Benchmark"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_deepseek-ai_DeepSeek-V3_1_Benchmark" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record performance benchmark result for deepseek-ai/DeepSeek-V3.1"
+    key: "${TPU_VERSION:-tpu6e}_record_deepseek-ai_DeepSeek-V3_1_Benchmark"
+    depends_on: "${TPU_VERSION:-tpu6e}_deepseek-ai_DeepSeek-V3_1_Benchmark"
     env:
-      CI_TARGET: deepseek-ai/DeepSeek-V3.1
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
+      CI_TARGET: "deepseek-ai/DeepSeek-V3.1"
       CI_STAGE: "Benchmark"
       CI_CATEGORY: "text-only"
     agents:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh deepseek-ai_DeepSeek-V3_1_Benchmark
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_deepseek-ai_DeepSeek-V3_1_Benchmark

--- a/.buildkite/models/google_gemma-3-27b-it.yml
+++ b/.buildkite/models/google_gemma-3-27b-it.yml
@@ -15,61 +15,67 @@
 # pipeline-name: google/gemma-3-27b-it
 # pipeline-type: text-only
 steps:
-  - label: "Unit tests for google/gemma-3-27b-it"
-    key: "google_gemma-3-27b-it_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} Unit tests for google/gemma-3-27b-it"
+    key: "${TPU_VERSION:-tpu6e}_google_gemma-3-27b-it_UnitTest"
     agents:
-      queue: tpu_v6e_8_queue
+      queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     soft_fail: true
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh \
           bash -c 'SKIP_JAX_PRECOMPILE=1 VLLM_XLA_CHECK_RECOMPILATION=0 python3 /workspace/tpu_inference/examples/offline_inference.py --model=google/gemma-3-27b-it --tensor_parallel_size=8 --max_model_len=1024 --max_num_seqs=1'
-  - label: "Record unit test result for google/gemma-3-27b-it"
-    key: "record_google_gemma-3-27b-it_UnitTest"
-    depends_on: "google_gemma-3-27b-it_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} Record unit test result for google/gemma-3-27b-it"
+    key: "${TPU_VERSION:-tpu6e}_record_google_gemma-3-27b-it_UnitTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_google_gemma-3-27b-it_UnitTest"
     env:
-      CI_TARGET: google/gemma-3-27b-it
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
+      CI_TARGET: "google/gemma-3-27b-it"
       CI_STAGE: "UnitTest"
       CI_CATEGORY: "text-only"
     agents:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh google_gemma-3-27b-it_UnitTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_google_gemma-3-27b-it_UnitTest
 
-  - label: "Accuracy for google/gemma-3-27b-it"
-    key: "google_gemma-3-27b-it_Accuracy"
-    depends_on: "record_google_gemma-3-27b-it_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} Accuracy for google/gemma-3-27b-it"
+    key: "${TPU_VERSION:-tpu6e}_google_gemma-3-27b-it_Accuracy"
+    depends_on: "${TPU_VERSION:-tpu6e}_record_google_gemma-3-27b-it_UnitTest"
     agents:
-      queue: tpu_v6e_8_queue
+      queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
     soft_fail: true
     env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
       TEST_MODEL: google/gemma-3-27b-it
       TENSOR_PARALLEL_SIZE: 8
       MINIMUM_ACCURACY_THRESHOLD: 0.56
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/test_accuracy.sh
-  - label: "Record accuracy result for google/gemma-3-27b-it"
-    key: "record_google_gemma-3-27b-it_Accuracy"
-    depends_on: "google_gemma-3-27b-it_Accuracy"
+  - label: "${TPU_VERSION:-tpu6e} Record accuracy result for google/gemma-3-27b-it"
+    key: "${TPU_VERSION:-tpu6e}_record_google_gemma-3-27b-it_Accuracy"
+    depends_on: "${TPU_VERSION:-tpu6e}_google_gemma-3-27b-it_Accuracy"
     env:
-      CI_TARGET: google/gemma-3-27b-it
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
+      CI_TARGET: "google/gemma-3-27b-it"
       CI_STAGE: "Accuracy/Correctness"
       CI_CATEGORY: "text-only"
     agents:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh google_gemma-3-27b-it_Accuracy
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_google_gemma-3-27b-it_Accuracy
 
-  - label: "Performance benchmarks for google/gemma-3-27b-it"
-    key: "google_gemma-3-27b-it_Benchmark"
-    depends_on: "record_google_gemma-3-27b-it_Accuracy"
+  - label: "${TPU_VERSION:-tpu6e} Performance benchmarks for google/gemma-3-27b-it"
+    key: "${TPU_VERSION:-tpu6e}_google_gemma-3-27b-it_Benchmark"
+    depends_on: "${TPU_VERSION:-tpu6e}_record_google_gemma-3-27b-it_Accuracy"
     agents:
-      queue: tpu_v6e_8_queue
+      queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
     soft_fail: true
     env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
       TEST_MODEL: google/gemma-3-27b-it
       TENSOR_PARALLEL_SIZE: 8
       MINIMUM_THROUGHPUT_THRESHOLD: 21
@@ -82,15 +88,16 @@ steps:
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/benchmark.sh
-  - label: "Record performance benchmark result for google/gemma-3-27b-it"
-    key: "record_google_gemma-3-27b-it_Benchmark"
-    depends_on: "google_gemma-3-27b-it_Benchmark"
+  - label: "${TPU_VERSION:-tpu6e} Record performance benchmark result for google/gemma-3-27b-it"
+    key: "${TPU_VERSION:-tpu6e}_record_google_gemma-3-27b-it_Benchmark"
+    depends_on: "${TPU_VERSION:-tpu6e}_google_gemma-3-27b-it_Benchmark"
     env:
-      CI_TARGET: google/gemma-3-27b-it
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
+      CI_TARGET: "google/gemma-3-27b-it"
       CI_STAGE: "Benchmark"
       CI_CATEGORY: "text-only"
     agents:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh google_gemma-3-27b-it_Benchmark
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_google_gemma-3-27b-it_Benchmark

--- a/.buildkite/models/meta-llama_Llama-3_1-8B-Instruct.yml
+++ b/.buildkite/models/meta-llama_Llama-3_1-8B-Instruct.yml
@@ -15,61 +15,67 @@
 # pipeline-name: meta-llama/Llama-3.1-8B-Instruct
 # pipeline-type: text-only
 steps:
-  - label: "Unit tests for meta-llama/Llama-3.1-8B-Instruct"
-    key: "meta-llama_Llama-3_1-8B-Instruct_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} Unit tests for meta-llama/Llama-3.1-8B-Instruct"
+    key: "${TPU_VERSION:-tpu6e}_meta-llama_Llama-3_1-8B-Instruct_UnitTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh \
           bash -c 'python3 -m pytest -s -v -x /workspace/tpu_inference/tests/models/jax/test_llama3.py'
-  - label: "Record unit test result for meta-llama/Llama-3.1-8B-Instruct"
-    key: "record_meta-llama_Llama-3_1-8B-Instruct_UnitTest"
-    depends_on: "meta-llama_Llama-3_1-8B-Instruct_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} Record unit test result for meta-llama/Llama-3.1-8B-Instruct"
+    key: "${TPU_VERSION:-tpu6e}_record_meta-llama_Llama-3_1-8B-Instruct_UnitTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_meta-llama_Llama-3_1-8B-Instruct_UnitTest"
     env:
-      CI_TARGET: meta-llama/Llama-3.1-8B-Instruct
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
+      CI_TARGET: "meta-llama/Llama-3.1-8B-Instruct"
       CI_STAGE: "UnitTest"
       CI_CATEGORY: "text-only"
     agents:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh meta-llama_Llama-3_1-8B-Instruct_UnitTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_meta-llama_Llama-3_1-8B-Instruct_UnitTest
 
-  - label: "Accuracy for meta-llama/Llama-3.1-8B-Instruct"
-    key: "meta-llama_Llama-3_1-8B-Instruct_Accuracy"
-    depends_on: "record_meta-llama_Llama-3_1-8B-Instruct_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} Accuracy for meta-llama/Llama-3.1-8B-Instruct"
+    key: "${TPU_VERSION:-tpu6e}_meta-llama_Llama-3_1-8B-Instruct_Accuracy"
+    depends_on: "${TPU_VERSION:-tpu6e}_record_meta-llama_Llama-3_1-8B-Instruct_UnitTest"
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     soft_fail: true
     env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
       TEST_MODEL: meta-llama/Llama-3.1-8B-Instruct
       TENSOR_PARALLEL_SIZE: 1
       MINIMUM_ACCURACY_THRESHOLD: 0.75
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/test_accuracy.sh
-  - label: "Record accuracy result for meta-llama/Llama-3.1-8B-Instruct"
-    key: "record_meta-llama_Llama-3_1-8B-Instruct_Accuracy"
-    depends_on: "meta-llama_Llama-3_1-8B-Instruct_Accuracy"
+  - label: "${TPU_VERSION:-tpu6e} Record accuracy result for meta-llama/Llama-3.1-8B-Instruct"
+    key: "${TPU_VERSION:-tpu6e}_record_meta-llama_Llama-3_1-8B-Instruct_Accuracy"
+    depends_on: "${TPU_VERSION:-tpu6e}_meta-llama_Llama-3_1-8B-Instruct_Accuracy"
     env:
-      CI_TARGET: meta-llama/Llama-3.1-8B-Instruct
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
+      CI_TARGET: "meta-llama/Llama-3.1-8B-Instruct"
       CI_STAGE: "Accuracy/Correctness"
       CI_CATEGORY: "text-only"
     agents:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh meta-llama_Llama-3_1-8B-Instruct_Accuracy
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_meta-llama_Llama-3_1-8B-Instruct_Accuracy
 
-  - label: "Performance benchmarks for meta-llama/Llama-3.1-8B-Instruct"
-    key: "meta-llama_Llama-3_1-8B-Instruct_Benchmark"
-    depends_on: "record_meta-llama_Llama-3_1-8B-Instruct_Accuracy"
+  - label: "${TPU_VERSION:-tpu6e} Performance benchmarks for meta-llama/Llama-3.1-8B-Instruct"
+    key: "${TPU_VERSION:-tpu6e}_meta-llama_Llama-3_1-8B-Instruct_Benchmark"
+    depends_on: "${TPU_VERSION:-tpu6e}_record_meta-llama_Llama-3_1-8B-Instruct_Accuracy"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
       TEST_MODEL: meta-llama/Llama-3.1-8B-Instruct
       TENSOR_PARALLEL_SIZE: 1
       MINIMUM_THROUGHPUT_THRESHOLD: 10.77
@@ -82,15 +88,16 @@ steps:
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/benchmark.sh
-  - label: "Record performance benchmark result for meta-llama/Llama-3.1-8B-Instruct"
-    key: "record_meta-llama_Llama-3_1-8B-Instruct_Benchmark"
-    depends_on: "meta-llama_Llama-3_1-8B-Instruct_Benchmark"
+  - label: "${TPU_VERSION:-tpu6e} Record performance benchmark result for meta-llama/Llama-3.1-8B-Instruct"
+    key: "${TPU_VERSION:-tpu6e}_record_meta-llama_Llama-3_1-8B-Instruct_Benchmark"
+    depends_on: "${TPU_VERSION:-tpu6e}_meta-llama_Llama-3_1-8B-Instruct_Benchmark"
     env:
-      CI_TARGET: meta-llama/Llama-3.1-8B-Instruct
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
+      CI_TARGET: "meta-llama/Llama-3.1-8B-Instruct"
       CI_STAGE: "Benchmark"
       CI_CATEGORY: "text-only"
     agents:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh meta-llama_Llama-3_1-8B-Instruct_Benchmark
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_meta-llama_Llama-3_1-8B-Instruct_Benchmark

--- a/.buildkite/models/meta-llama_Llama-3_3-70B-Instruct.yml
+++ b/.buildkite/models/meta-llama_Llama-3_3-70B-Instruct.yml
@@ -15,61 +15,67 @@
 # pipeline-name: meta-llama/Llama-3.3-70B-Instruct
 # pipeline-type: text-only
 steps:
-  - label: "Unit tests for meta-llama/Llama-3.3-70B-Instruct"
-    key: "meta-llama_Llama-3_3-70B-Instruct_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} Unit tests for meta-llama/Llama-3.3-70B-Instruct"
+    key: "${TPU_VERSION:-tpu6e}_meta-llama_Llama-3_3-70B-Instruct_UnitTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh \
           bash -c 'python3 -m pytest -s -v -x /workspace/tpu_inference/tests/models/jax/test_llama3.py'
-  - label: "Record unit test result for meta-llama/Llama-3.3-70B-Instruct"
-    key: "record_meta-llama_Llama-3_3-70B-Instruct_UnitTest"
-    depends_on: "meta-llama_Llama-3_3-70B-Instruct_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} Record unit test result for meta-llama/Llama-3.3-70B-Instruct"
+    key: "${TPU_VERSION:-tpu6e}_record_meta-llama_Llama-3_3-70B-Instruct_UnitTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_meta-llama_Llama-3_3-70B-Instruct_UnitTest"
     env:
-      CI_TARGET: meta-llama/Llama-3.3-70B-Instruct
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
+      CI_TARGET: "meta-llama/Llama-3.3-70B-Instruct"
       CI_STAGE: "UnitTest"
       CI_CATEGORY: "text-only"
     agents:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh meta-llama_Llama-3_3-70B-Instruct_UnitTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_meta-llama_Llama-3_3-70B-Instruct_UnitTest
 
-  - label: "Accuracy for meta-llama/Llama-3.3-70B-Instruct"
-    key: "meta-llama_Llama-3_3-70B-Instruct_Accuracy"
-    depends_on: "record_meta-llama_Llama-3_3-70B-Instruct_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} Accuracy for meta-llama/Llama-3.3-70B-Instruct"
+    key: "${TPU_VERSION:-tpu6e}_meta-llama_Llama-3_3-70B-Instruct_Accuracy"
+    depends_on: "${TPU_VERSION:-tpu6e}_record_meta-llama_Llama-3_3-70B-Instruct_UnitTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_8_queue
+      queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
     env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
       TEST_MODEL: meta-llama/Llama-3.3-70B-Instruct
       TENSOR_PARALLEL_SIZE: 8
       MINIMUM_ACCURACY_THRESHOLD: 0.90
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/test_accuracy.sh
-  - label: "Record accuracy result for meta-llama/Llama-3.3-70B-Instruct"
-    key: "record_meta-llama_Llama-3_3-70B-Instruct_Accuracy"
-    depends_on: "meta-llama_Llama-3_3-70B-Instruct_Accuracy"
+  - label: "${TPU_VERSION:-tpu6e} Record accuracy result for meta-llama/Llama-3.3-70B-Instruct"
+    key: "${TPU_VERSION:-tpu6e}_record_meta-llama_Llama-3_3-70B-Instruct_Accuracy"
+    depends_on: "${TPU_VERSION:-tpu6e}_meta-llama_Llama-3_3-70B-Instruct_Accuracy"
     env:
-      CI_TARGET: meta-llama/Llama-3.3-70B-Instruct
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
+      CI_TARGET: "meta-llama/Llama-3.3-70B-Instruct"
       CI_STAGE: "Accuracy/Correctness"
       CI_CATEGORY: "text-only"
     agents:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh meta-llama_Llama-3_3-70B-Instruct_Accuracy
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_meta-llama_Llama-3_3-70B-Instruct_Accuracy
 
-  - label: "Performance benchmarks for meta-llama/Llama-3.3-70B-Instruct"
-    key: "meta-llama_Llama-3_3-70B-Instruct_Benchmark"
-    depends_on: "record_meta-llama_Llama-3_3-70B-Instruct_Accuracy"
+  - label: "${TPU_VERSION:-tpu6e} Performance benchmarks for meta-llama/Llama-3.3-70B-Instruct"
+    key: "${TPU_VERSION:-tpu6e}_meta-llama_Llama-3_3-70B-Instruct_Benchmark"
+    depends_on: "${TPU_VERSION:-tpu6e}_record_meta-llama_Llama-3_3-70B-Instruct_Accuracy"
     soft_fail: true
     agents:
-      queue: tpu_v6e_8_queue
+      queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
     env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
       TEST_MODEL: meta-llama/Llama-3.3-70B-Instruct
       TENSOR_PARALLEL_SIZE: 8
       MINIMUM_THROUGHPUT_THRESHOLD: 7.0
@@ -82,15 +88,16 @@ steps:
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/benchmark.sh
-  - label: "Record performance benchmark result for meta-llama/Llama-3.3-70B-Instruct"
-    key: "record_meta-llama_Llama-3_3-70B-Instruct_Benchmark"
-    depends_on: "meta-llama_Llama-3_3-70B-Instruct_Benchmark"
+  - label: "${TPU_VERSION:-tpu6e} Record performance benchmark result for meta-llama/Llama-3.3-70B-Instruct"
+    key: "${TPU_VERSION:-tpu6e}_record_meta-llama_Llama-3_3-70B-Instruct_Benchmark"
+    depends_on: "${TPU_VERSION:-tpu6e}_meta-llama_Llama-3_3-70B-Instruct_Benchmark"
     env:
-      CI_TARGET: meta-llama/Llama-3.3-70B-Instruct
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
+      CI_TARGET: "meta-llama/Llama-3.3-70B-Instruct"
       CI_STAGE: "Benchmark"
       CI_CATEGORY: "text-only"
     agents:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh meta-llama_Llama-3_3-70B-Instruct_Benchmark
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_meta-llama_Llama-3_3-70B-Instruct_Benchmark

--- a/.buildkite/models/meta-llama_Llama-4-Maverick-17B-128E-Instruct.yml
+++ b/.buildkite/models/meta-llama_Llama-4-Maverick-17B-128E-Instruct.yml
@@ -15,67 +15,76 @@
 # pipeline-name: meta-llama/Llama-4-Maverick-17B-128E-Instruct
 # pipeline-type: multimodal
 steps:
-  - label: "Unit tests for meta-llama/Llama-4-Maverick-17B-128E-Instruct"
-    key: "meta-llama_Llama-4-Maverick-17B-128E-Instruct_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} Unit tests for meta-llama/Llama-4-Maverick-17B-128E-Instruct"
+    key: "${TPU_VERSION:-tpu6e}_meta-llama_Llama-4-Maverick-17B-128E-Instruct_UnitTest"
     agents:
-      queue: tpu_v6e_8_queue
+      queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     soft_fail: true
     commands:
       - |
-        buildkite-agent meta-data set "meta-llama_Llama-4-Maverick-17B-128E-Instruct_UnitTest" "unverified"
-  - label: "Record unit test result for meta-llama/Llama-4-Maverick-17B-128E-Instruct"
-    key: "record_meta-llama_Llama-4-Maverick-17B-128E-Instruct_UnitTest"
-    depends_on: "meta-llama_Llama-4-Maverick-17B-128E-Instruct_UnitTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_meta-llama_Llama-4-Maverick-17B-128E-Instruct_UnitTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record unit test result for meta-llama/Llama-4-Maverick-17B-128E-Instruct"
+    key: "${TPU_VERSION:-tpu6e}_record_meta-llama_Llama-4-Maverick-17B-128E-Instruct_UnitTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_meta-llama_Llama-4-Maverick-17B-128E-Instruct_UnitTest"
     env:
-      CI_TARGET: meta-llama/Llama-4-Maverick-17B-128E-Instruct
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
+      CI_TARGET: "meta-llama/Llama-4-Maverick-17B-128E-Instruct"
       CI_STAGE: "UnitTest"
       CI_CATEGORY: "multimodal"
     agents:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh meta-llama_Llama-4-Maverick-17B-128E-Instruct_UnitTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_meta-llama_Llama-4-Maverick-17B-128E-Instruct_UnitTest
 
-  - label: "Accuracy for meta-llama/Llama-4-Maverick-17B-128E-Instruct"
-    key: "meta-llama_Llama-4-Maverick-17B-128E-Instruct_Accuracy"
-    depends_on: "record_meta-llama_Llama-4-Maverick-17B-128E-Instruct_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} Accuracy for meta-llama/Llama-4-Maverick-17B-128E-Instruct"
+    key: "${TPU_VERSION:-tpu6e}_meta-llama_Llama-4-Maverick-17B-128E-Instruct_Accuracy"
+    depends_on: "${TPU_VERSION:-tpu6e}_record_meta-llama_Llama-4-Maverick-17B-128E-Instruct_UnitTest"
     agents:
-      queue: tpu_v6e_8_queue
+      queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     soft_fail: true
     commands:
       - |
-        buildkite-agent meta-data set "meta-llama_Llama-4-Maverick-17B-128E-Instruct_Accuracy" "unverified"
-  - label: "Record accuracy result for meta-llama/Llama-4-Maverick-17B-128E-Instruct"
-    key: "record_meta-llama_Llama-4-Maverick-17B-128E-Instruct_Accuracy"
-    depends_on: "meta-llama_Llama-4-Maverick-17B-128E-Instruct_Accuracy"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_meta-llama_Llama-4-Maverick-17B-128E-Instruct_Accuracy" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record accuracy result for meta-llama/Llama-4-Maverick-17B-128E-Instruct"
+    key: "${TPU_VERSION:-tpu6e}_record_meta-llama_Llama-4-Maverick-17B-128E-Instruct_Accuracy"
+    depends_on: "${TPU_VERSION:-tpu6e}_meta-llama_Llama-4-Maverick-17B-128E-Instruct_Accuracy"
     env:
-      CI_TARGET: meta-llama/Llama-4-Maverick-17B-128E-Instruct
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
+      CI_TARGET: "meta-llama/Llama-4-Maverick-17B-128E-Instruct"
       CI_STAGE: "Accuracy/Correctness"
       CI_CATEGORY: "multimodal"
     agents:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh meta-llama_Llama-4-Maverick-17B-128E-Instruct_Accuracy
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_meta-llama_Llama-4-Maverick-17B-128E-Instruct_Accuracy
 
-  - label: "Performance benchmarks for meta-llama/Llama-4-Maverick-17B-128E-Instruct"
-    key: "meta-llama_Llama-4-Maverick-17B-128E-Instruct_Benchmark"
-    depends_on: "record_meta-llama_Llama-4-Maverick-17B-128E-Instruct_Accuracy"
+  - label: "${TPU_VERSION:-tpu6e} Performance benchmarks for meta-llama/Llama-4-Maverick-17B-128E-Instruct"
+    key: "${TPU_VERSION:-tpu6e}_meta-llama_Llama-4-Maverick-17B-128E-Instruct_Benchmark"
+    depends_on: "${TPU_VERSION:-tpu6e}_record_meta-llama_Llama-4-Maverick-17B-128E-Instruct_Accuracy"
     agents:
-      queue: tpu_v6e_8_queue
+      queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     soft_fail: true
     commands:
       - |
-        buildkite-agent meta-data set "meta-llama_Llama-4-Maverick-17B-128E-Instruct_Benchmark" "unverified"
-  - label: "Record performance benchmark result for meta-llama/Llama-4-Maverick-17B-128E-Instruct"
-    key: "record_meta-llama_Llama-4-Maverick-17B-128E-Instruct_Benchmark"
-    depends_on: "meta-llama_Llama-4-Maverick-17B-128E-Instruct_Benchmark"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_meta-llama_Llama-4-Maverick-17B-128E-Instruct_Benchmark" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record performance benchmark result for meta-llama/Llama-4-Maverick-17B-128E-Instruct"
+    key: "${TPU_VERSION:-tpu6e}_record_meta-llama_Llama-4-Maverick-17B-128E-Instruct_Benchmark"
+    depends_on: "${TPU_VERSION:-tpu6e}_meta-llama_Llama-4-Maverick-17B-128E-Instruct_Benchmark"
     env:
-      CI_TARGET: meta-llama/Llama-4-Maverick-17B-128E-Instruct
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
+      CI_TARGET: "meta-llama/Llama-4-Maverick-17B-128E-Instruct"
       CI_STAGE: "Benchmark"
       CI_CATEGORY: "multimodal"
     agents:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh meta-llama_Llama-4-Maverick-17B-128E-Instruct_Benchmark
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_meta-llama_Llama-4-Maverick-17B-128E-Instruct_Benchmark

--- a/.buildkite/models/meta-llama_Llama-Guard-4-12B.yml
+++ b/.buildkite/models/meta-llama_Llama-Guard-4-12B.yml
@@ -15,77 +15,84 @@
 # pipeline-name: meta-llama/Llama-Guard-4-12B
 # pipeline-type: text-only
 steps:
-  - label: "Unit tests for meta-llama/Llama-Guard-4-12B"
-    key: "meta-llama_Llama-Guard-4-12B_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} Unit tests for meta-llama/Llama-Guard-4-12B"
+    key: "${TPU_VERSION:-tpu6e}_meta-llama_Llama-Guard-4-12B_UnitTest"
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     soft_fail: true
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh \
           bash -c 'python3 -m pytest -s -v -x /workspace/tpu_inference/tests/models/jax/test_llama_guard_4.py'
-  - label: "Record unit test result for meta-llama/Llama-Guard-4-12B"
-    key: "record_meta-llama_Llama-Guard-4-12B_UnitTest"
-    depends_on: "meta-llama_Llama-Guard-4-12B_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} Record unit test result for meta-llama/Llama-Guard-4-12B"
+    key: "${TPU_VERSION:-tpu6e}_record_meta-llama_Llama-Guard-4-12B_UnitTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_meta-llama_Llama-Guard-4-12B_UnitTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_STAGE: "UnitTest"
-      CI_TARGET: meta-llama/Llama-Guard-4-12B
+      CI_TARGET: "meta-llama/Llama-Guard-4-12B"
       CI_CATEGORY: "text-only"
     agents:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh meta-llama_Llama-Guard-4-12B_UnitTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_meta-llama_Llama-Guard-4-12B_UnitTest
 
-  - label: "Performance benchmarks for meta-llama/Llama-Guard-4-12B"
-    key: "meta-llama_Llama-Guard-4-12B_Benchmark"
-    depends_on: "record_meta-llama_Llama-Guard-4-12B_Accuracy"
+  - label: "${TPU_VERSION:-tpu6e} Performance benchmarks for meta-llama/Llama-Guard-4-12B"
+    key: "${TPU_VERSION:-tpu6e}_meta-llama_Llama-Guard-4-12B_Benchmark"
+    depends_on: "${TPU_VERSION:-tpu6e}_record_meta-llama_Llama-Guard-4-12B_Accuracy"
     soft_fail: true
     env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
       TEST_MODEL: meta-llama/Llama-Guard-4-12B
       TENSOR_PARALLEL_SIZE: 1
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/safety_model_benchmark.sh --mode performance
 
-  - label: "Record performance benchmark result for meta-llama/Llama-Guard-4-12B"
-    key: "record_meta-llama_Llama-Guard-4-12B_Benchmark"
-    depends_on: "meta-llama_Llama-Guard-4-12B_Benchmark"
+  - label: "${TPU_VERSION:-tpu6e} Record performance benchmark result for meta-llama/Llama-Guard-4-12B"
+    key: "${TPU_VERSION:-tpu6e}_record_meta-llama_Llama-Guard-4-12B_Benchmark"
+    depends_on: "${TPU_VERSION:-tpu6e}_meta-llama_Llama-Guard-4-12B_Benchmark"
     env:
-      CI_TARGET: meta-llama/Llama-Guard-4-12B
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
+      CI_TARGET: "meta-llama/Llama-Guard-4-12B"
       CI_STAGE: "Benchmark"
       CI_CATEGORY: "text-only"
     agents:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh meta-llama_Llama-Guard-4-12B_Benchmark
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_meta-llama_Llama-Guard-4-12B_Benchmark
 
 
-  - label: "Accuracy for meta-llama/Llama-Guard-4-12B"
-    key: "meta-llama_Llama-Guard-4-12B_Accuracy"
-    depends_on: "record_meta-llama_Llama-Guard-4-12B_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} Accuracy for meta-llama/Llama-Guard-4-12B"
+    key: "${TPU_VERSION:-tpu6e}_meta-llama_Llama-Guard-4-12B_Accuracy"
+    depends_on: "${TPU_VERSION:-tpu6e}_record_meta-llama_Llama-Guard-4-12B_UnitTest"
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     soft_fail: true
     env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
       TEST_MODEL: meta-llama/Llama-Guard-4-12B
       TENSOR_PARALLEL_SIZE: 1
       MINIMUM_ACCURACY_THRESHOLD: 0.31
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/safety_model_benchmark.sh --mode accuracy
-  - label: "Record accuracy result for meta-llama/Llama-Guard-4-12B"
-    key: "record_meta-llama_Llama-Guard-4-12B_Accuracy"
-    depends_on: "meta-llama_Llama-Guard-4-12B_Accuracy"
+  - label: "${TPU_VERSION:-tpu6e} Record accuracy result for meta-llama/Llama-Guard-4-12B"
+    key: "${TPU_VERSION:-tpu6e}_record_meta-llama_Llama-Guard-4-12B_Accuracy"
+    depends_on: "${TPU_VERSION:-tpu6e}_meta-llama_Llama-Guard-4-12B_Accuracy"
     env:
-      CI_TARGET: meta-llama/Llama-Guard-4-12B
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
+      CI_TARGET: "meta-llama/Llama-Guard-4-12B"
       CI_STAGE: "Accuracy/Correctness"
       CI_CATEGORY: "text-only"
     agents:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh meta-llama_Llama-Guard-4-12B_Accuracy
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_meta-llama_Llama-Guard-4-12B_Accuracy

--- a/.buildkite/models/moonshotai_Kimi-K2-Thinking.yml
+++ b/.buildkite/models/moonshotai_Kimi-K2-Thinking.yml
@@ -15,67 +15,76 @@
 # pipeline-name: moonshotai/Kimi-K2-Thinking
 # pipeline-type: text-only
 steps:
-  - label: "Unit tests for moonshotai/Kimi-K2-Thinking"
-    key: "moonshotai_Kimi-K2-Thinking_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} Unit tests for moonshotai/Kimi-K2-Thinking"
+    key: "${TPU_VERSION:-tpu6e}_moonshotai_Kimi-K2-Thinking_UnitTest"
     agents:
-      queue: tpu_v6e_8_queue
+      queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     soft_fail: true
     commands:
       - |
-        buildkite-agent meta-data set "moonshotai_Kimi-K2-Thinking_UnitTest" "unverified"
-  - label: "Record unit test result for moonshotai/Kimi-K2-Thinking"
-    key: "record_moonshotai_Kimi-K2-Thinking_UnitTest"
-    depends_on: "moonshotai_Kimi-K2-Thinking_UnitTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_moonshotai_Kimi-K2-Thinking_UnitTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record unit test result for moonshotai/Kimi-K2-Thinking"
+    key: "${TPU_VERSION:-tpu6e}_record_moonshotai_Kimi-K2-Thinking_UnitTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_moonshotai_Kimi-K2-Thinking_UnitTest"
     env:
-      CI_TARGET: moonshotai/Kimi-K2-Thinking
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
+      CI_TARGET: "moonshotai/Kimi-K2-Thinking"
       CI_STAGE: "UnitTest"
       CI_CATEGORY: "text-only"
     agents:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh moonshotai_Kimi-K2-Thinking_UnitTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_moonshotai_Kimi-K2-Thinking_UnitTest
 
-  - label: "Accuracy for moonshotai/Kimi-K2-Thinking"
-    key: "moonshotai_Kimi-K2-Thinking_Accuracy"
-    depends_on: "record_moonshotai_Kimi-K2-Thinking_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} Accuracy for moonshotai/Kimi-K2-Thinking"
+    key: "${TPU_VERSION:-tpu6e}_moonshotai_Kimi-K2-Thinking_Accuracy"
+    depends_on: "${TPU_VERSION:-tpu6e}_record_moonshotai_Kimi-K2-Thinking_UnitTest"
     agents:
-      queue: tpu_v6e_8_queue
+      queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     soft_fail: true
     commands:
       - |
-        buildkite-agent meta-data set "moonshotai_Kimi-K2-Thinking_Accuracy" "unverified"
-  - label: "Record accuracy result for moonshotai/Kimi-K2-Thinking"
-    key: "record_moonshotai_Kimi-K2-Thinking_Accuracy"
-    depends_on: "moonshotai_Kimi-K2-Thinking_Accuracy"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_moonshotai_Kimi-K2-Thinking_Accuracy" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record integration test result for moonshotai/Kimi-K2-Thinking"
+    key: "${TPU_VERSION:-tpu6e}_record_moonshotai_Kimi-K2-Thinking_Accuracy"
+    depends_on: "${TPU_VERSION:-tpu6e}_moonshotai_Kimi-K2-Thinking_Accuracy"
     env:
-      CI_TARGET: moonshotai/Kimi-K2-Thinking
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
+      CI_TARGET: "moonshotai/Kimi-K2-Thinking"
       CI_STAGE: "Accuracy/Correctness"
       CI_CATEGORY: "text-only"
     agents:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh moonshotai_Kimi-K2-Thinking_Accuracy
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_moonshotai_Kimi-K2-Thinking_Accuracy
 
-  - label: "Performance benchmarks for moonshotai/Kimi-K2-Thinking"
-    key: "moonshotai_Kimi-K2-Thinking_Benchmark"
-    depends_on: "record_moonshotai_Kimi-K2-Thinking_Accuracy"
+  - label: "${TPU_VERSION:-tpu6e} Performance benchmarks for moonshotai/Kimi-K2-Thinking"
+    key: "${TPU_VERSION:-tpu6e}_moonshotai_Kimi-K2-Thinking_Benchmark"
+    depends_on: "${TPU_VERSION:-tpu6e}_record_moonshotai_Kimi-K2-Thinking_Accuracy"
     agents:
-      queue: tpu_v6e_8_queue
+      queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     soft_fail: true
     commands:
       - |
-        buildkite-agent meta-data set "moonshotai_Kimi-K2-Thinking_Benchmark" "unverified"
-  - label: "Record performance benchmark result for moonshotai/Kimi-K2-Thinking"
-    key: "record_moonshotai_Kimi-K2-Thinking_Benchmark"
-    depends_on: "moonshotai_Kimi-K2-Thinking_Benchmark"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_moonshotai_Kimi-K2-Thinking_Benchmark" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record performance benchmark result for moonshotai/Kimi-K2-Thinking"
+    key: "${TPU_VERSION:-tpu6e}_record_moonshotai_Kimi-K2-Thinking_Benchmark"
+    depends_on: "${TPU_VERSION:-tpu6e}_moonshotai_Kimi-K2-Thinking_Benchmark"
     env:
-      CI_TARGET: moonshotai/Kimi-K2-Thinking
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
+      CI_TARGET: "moonshotai/Kimi-K2-Thinking"
       CI_STAGE: "Benchmark"
       CI_CATEGORY: "text-only"
     agents:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh moonshotai_Kimi-K2-Thinking_Benchmark
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_moonshotai_Kimi-K2-Thinking_Benchmark

--- a/.buildkite/models/openai_gpt-oss-120b.yml
+++ b/.buildkite/models/openai_gpt-oss-120b.yml
@@ -15,67 +15,76 @@
 # pipeline-name: openai/gpt-oss-120b
 # pipeline-type: text-only
 steps:
-  - label: "Unit tests for openai/gpt-oss-120b"
-    key: "openai_gpt-oss-120b_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} Unit tests for openai/gpt-oss-120b"
+    key: "${TPU_VERSION:-tpu6e}_openai_gpt-oss-120b_UnitTest"
     agents:
-      queue: tpu_v6e_8_queue
+      queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     soft_fail: true
     commands:
       - |
-        buildkite-agent meta-data set "openai_gpt-oss-120b_UnitTest" "unverified"
-  - label: "Record unit test result for openai/gpt-oss-120b"
-    key: "record_openai_gpt-oss-120b_UnitTest"
-    depends_on: "openai_gpt-oss-120b_UnitTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_openai_gpt-oss-120b_UnitTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record unit test result for openai/gpt-oss-120b"
+    key: "${TPU_VERSION:-tpu6e}_record_openai_gpt-oss-120b_UnitTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_openai_gpt-oss-120b_UnitTest"
     env:
-      CI_TARGET: openai/gpt-oss-120b
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
+      CI_TARGET: "openai/gpt-oss-120b"
       CI_STAGE: "UnitTest"
       CI_CATEGORY: "text-only"
     agents:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh openai_gpt-oss-120b_UnitTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_openai_gpt-oss-120b_UnitTest
 
-  - label: "Accuracy for openai/gpt-oss-120b"
-    key: "openai_gpt-oss-120b_Accuracy"
-    depends_on: "record_openai_gpt-oss-120b_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} Accuracy for openai/gpt-oss-120b"
+    key: "${TPU_VERSION:-tpu6e}_openai_gpt-oss-120b_Accuracy"
+    depends_on: "${TPU_VERSION:-tpu6e}_record_openai_gpt-oss-120b_UnitTest"
     agents:
-      queue: tpu_v6e_8_queue
+      queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     soft_fail: true
     commands:
       - |
-        buildkite-agent meta-data set "openai_gpt-oss-120b_Accuracy" "unverified"
-  - label: "Record accuracy result for openai/gpt-oss-120b"
-    key: "record_openai_gpt-oss-120b_Accuracy"
-    depends_on: "openai_gpt-oss-120b_Accuracy"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_openai_gpt-oss-120b_Accuracy" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record accuracy result for openai/gpt-oss-120b"
+    key: "${TPU_VERSION:-tpu6e}_record_openai_gpt-oss-120b_Accuracy"
+    depends_on: "${TPU_VERSION:-tpu6e}_openai_gpt-oss-120b_Accuracy"
     env:
-      CI_TARGET: openai/gpt-oss-120b
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
+      CI_TARGET: "openai/gpt-oss-120b"
       CI_STAGE: "Accuracy/Correctness"
       CI_CATEGORY: "text-only"
     agents:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh openai_gpt-oss-120b_Accuracy
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_openai_gpt-oss-120b_Accuracy
 
-  - label: "Performance benchmarks for openai/gpt-oss-120b"
-    key: "openai_gpt-oss-120b_Benchmark"
-    depends_on: "record_openai_gpt-oss-120b_Accuracy"
+  - label: "${TPU_VERSION:-tpu6e} Performance benchmarks for openai/gpt-oss-120b"
+    key: "${TPU_VERSION:-tpu6e}_openai_gpt-oss-120b_Benchmark"
+    depends_on: "${TPU_VERSION:-tpu6e}_record_openai_gpt-oss-120b_Accuracy"
     agents:
-      queue: tpu_v6e_8_queue
+      queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     soft_fail: true
     commands:
       - |
-        buildkite-agent meta-data set "openai_gpt-oss-120b_Benchmark" "unverified"
-  - label: "Record performance benchmark result for openai/gpt-oss-120b"
-    key: "record_openai_gpt-oss-120b_Benchmark"
-    depends_on: "openai_gpt-oss-120b_Benchmark"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_openai_gpt-oss-120b_Benchmark" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record performance benchmark result for openai/gpt-oss-120b"
+    key: "${TPU_VERSION:-tpu6e}_record_openai_gpt-oss-120b_Benchmark"
+    depends_on: "${TPU_VERSION:-tpu6e}_openai_gpt-oss-120b_Benchmark"
     env:
-      CI_TARGET: openai/gpt-oss-120b
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
+      CI_TARGET: "openai/gpt-oss-120b"
       CI_STAGE: "Benchmark"
       CI_CATEGORY: "text-only"
     agents:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh openai_gpt-oss-120b_Benchmark
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_openai_gpt-oss-120b_Benchmark

--- a/.buildkite/nightly_verify.yml
+++ b/.buildkite/nightly_verify.yml
@@ -16,7 +16,7 @@ x-run-condition: &run-on-nightly-or-tag
   if: build.env("NIGHTLY") == "1" || build.tag =~ /^v?[0-9]+(\.[a-zA-Z0-9]+)*([a-zA-Z]+[0-9]*)?$/
 
 steps:
-   - label: "Upload Tests for Models & Features"
+   - label: "Upload Tests for Models & Features (${MODEL_IMPL_TYPE:-auto})"
      <<: *run-on-nightly-or-tag
      agents:
        queue: cpu
@@ -26,19 +26,40 @@ steps:
    - wait: ~
      continue_on_failure: true  # ensure we still generate support matrices even if some tests fail
 
-   - label: "Generate support matrices"
+   - label: "v6 Generate support matrices"
      <<: *run-on-nightly-or-tag
-     key: generate_support_matrices
-     agents:
-       queue: cpu
-     soft_fail: true
-     commands:
-       - bash .buildkite/scripts/generate_support_matrices.sh
+     key: "v6_generate_matrices"
+     allow_dependency_failure: true 
+     agents: { queue: cpu }
+     env:
+       TPU_VERSION: "v6"
+     command: |
+      if [ "$(buildkite-agent meta-data get run_v6_matrix --default 'false')" = "true" ]; then
+          bash .buildkite/scripts/generate_support_matrices.sh
+        else
+          echo "--- Skipping v6 matrix generation (No v6 test data found)"
+        fi
 
+   - label: "v7 Generate support matrices"
+     <<: *run-on-nightly-or-tag
+     key: "v7_generate_matrices"
+     allow_dependency_failure: true 
+     agents: { queue: cpu }
+     env:
+      TPU_VERSION: "v7"
+     command: |
+      if [ "$(buildkite-agent meta-data get run_v7_matrix --default 'false')" = "true" ]; then
+        bash .buildkite/scripts/generate_support_matrices.sh
+      else
+        echo "--- Skipping v7 matrix generation (No v7 test data found)"
+      fi
+  
    - label: "Commit support matrices if is nightly build or release tag specified"
      <<: *run-on-nightly-or-tag
      key: commit_support_matrices
-     depends_on: generate_support_matrices
+     depends_on:
+       - "v6_generate_matrices"
+       - "v7_generate_matrices"
      agents:
        queue: cpu
      secrets:
@@ -60,7 +81,8 @@ steps:
      key: record_verified_commit_hashes
      depends_on:
        - notify_test_results
-       - tpu_test_notification
+       - tpu6e_tpu_test_notification
+       - tpu7x_tpu_test_notification
      agents:
        queue: cpu
      secrets:

--- a/.buildkite/parallelism/CP.yml
+++ b/.buildkite/parallelism/CP.yml
@@ -15,18 +15,21 @@
 # pipeline-name: CP
 # pipeline-type: parallelism support matrix
 steps:
-  - label: "Correctness tests for CP"
-    key: "CP_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Correctness tests for CP"
+    key: "${TPU_VERSION:-tpu6e}_CP_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "CP_CorrectnessTest" "unverified"
-  - label: "Record correctness test result for CP"
-    key: "record_CP_CorrectnessTest"
-    depends_on: "CP_CorrectnessTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_CP_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for CP"
+    key: "${TPU_VERSION:-tpu6e}_record_CP_CorrectnessTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_CP_CorrectnessTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "CP"
       CI_STAGE: "CorrectnessTest"
       CI_CATEGORY: "parallelism support matrix"
@@ -34,21 +37,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh CP_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_CP_CorrectnessTest
 
-  - label: "Performance tests for CP"
-    key: "CP_PerformanceTest"
-    depends_on: "record_CP_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Performance tests for CP"
+    key: "${TPU_VERSION:-tpu6e}_CP_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_record_CP_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "CP_PerformanceTest" "unverified"
-  - label: "Record performance test result for CP"
-    key: "record_CP_PerformanceTest"
-    depends_on: "CP_PerformanceTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_CP_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record performance test result for CP"
+    key: "${TPU_VERSION:-tpu6e}_record_CP_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_CP_PerformanceTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "CP"
       CI_STAGE: "PerformanceTest"
       CI_CATEGORY: "parallelism support matrix"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh CP_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_CP_PerformanceTest

--- a/.buildkite/parallelism/DP.yml
+++ b/.buildkite/parallelism/DP.yml
@@ -15,21 +15,23 @@
 # pipeline-name: DP
 # pipeline-type: parallelism support matrix
 steps:
-  - label: "Correctness tests for DP"
-    key: "DP_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Correctness tests for DP"
+    key: "${TPU_VERSION:-tpu6e}_DP_CorrectnessTest"
     soft_fail: true
     env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
       NEW_MODEL_DESIGN: "1"
     agents:
-      queue: tpu_v6e_8_queue
+      queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh \
           bash -c 'python3 -m pytest -s -v -x /workspace/tpu_inference/tests/e2e/test_data_parallel.py::test_dp_correctness'
-  - label: "Record correctness test result for DP"
-    key: "record_DP_CorrectnessTest"
-    depends_on: "DP_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for DP"
+    key: "${TPU_VERSION:-tpu6e}_record_DP_CorrectnessTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_DP_CorrectnessTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "DP"
       CI_STAGE: "CorrectnessTest"
       CI_CATEGORY: "parallelism support matrix"
@@ -37,13 +39,14 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh DP_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_DP_CorrectnessTest
 
-  - label: "Performance tests for DP"
-    key: "DP_PerformanceTest"
-    depends_on: "record_DP_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Performance tests for DP"
+    key: "${TPU_VERSION:-tpu6e}_DP_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_record_DP_CorrectnessTest"
     soft_fail: true
     env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
       NEW_MODEL_DESIGN: "1"
     agents:
       queue: tpu_v6e_8_queue
@@ -51,10 +54,11 @@ steps:
       - |
         .buildkite/scripts/run_in_docker.sh \
           bash -c 'python3 -m pytest -s -v -x /workspace/tpu_inference/tests/e2e/test_data_parallel.py::test_dp_performance'
-  - label: "Record performance test result for DP"
-    key: "record_DP_PerformanceTest"
-    depends_on: "DP_PerformanceTest"
+  - label: "${TPU_VERSION:-tpu6e} Record performance test result for DP"
+    key: "${TPU_VERSION:-tpu6e}_record_DP_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_DP_PerformanceTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "DP"
       CI_STAGE: "PerformanceTest"
       CI_CATEGORY: "parallelism support matrix"
@@ -62,4 +66,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh DP_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_DP_PerformanceTest

--- a/.buildkite/parallelism/EP.yml
+++ b/.buildkite/parallelism/EP.yml
@@ -15,19 +15,22 @@
 # pipeline-name: EP
 # pipeline-type: parallelism support matrix
 steps:
-  - label: "Correctness tests for EP"
-    key: "EP_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Correctness tests for EP"
+    key: "${TPU_VERSION:-tpu6e}_EP_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v7x_8_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v7x_8_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh \
           bash -c 'python3 -m pytest -s -v -x /workspace/tpu_inference/tests/e2e/test_expert_parallel.py'
-  - label: "Record correctness test result for EP"
-    key: "record_EP_CorrectnessTest"
-    depends_on: "EP_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for EP"
+    key: "${TPU_VERSION:-tpu6e}_record_EP_CorrectnessTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_EP_CorrectnessTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "EP"
       CI_STAGE: "CorrectnessTest"
       CI_CATEGORY: "parallelism support matrix"
@@ -35,21 +38,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh EP_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_EP_CorrectnessTest
 
-  - label: "Performance tests for EP"
-    key: "EP_PerformanceTest"
-    depends_on: "record_EP_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Performance tests for EP"
+    key: "${TPU_VERSION:-tpu6e}_EP_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_record_EP_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "EP_PerformanceTest" "unverified"
-  - label: "Record performance test result for EP"
-    key: "record_EP_PerformanceTest"
-    depends_on: "EP_PerformanceTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_EP_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record performance test result for EP"
+    key: "${TPU_VERSION:-tpu6e}_record_EP_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_EP_PerformanceTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "EP"
       CI_STAGE: "PerformanceTest"
       CI_CATEGORY: "parallelism support matrix"
@@ -57,4 +63,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh EP_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_EP_PerformanceTest

--- a/.buildkite/parallelism/PP.yml
+++ b/.buildkite/parallelism/PP.yml
@@ -15,21 +15,24 @@
 # pipeline-name: PP
 # pipeline-type: parallelism support matrix
 steps:
-  - label: "Correctness tests for PP"
-    key: "PP_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Correctness tests for PP"
+    key: "${TPU_VERSION:-tpu6e}_PP_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh \
           python3 -m pytest -s -v /workspace/tpu_inference/tests/e2e/test_pipeline_parallel.py::test_pipeline_parallelism_jax_model \
           /workspace/tpu_inference/tests/e2e/test_pipeline_parallel.py::test_pipeline_parallelism_vllm_model \
           /workspace/tpu_inference/tests/e2e/test_pipeline_parallel.py::test_pipeline_parallelism_jax_model_correctness
-  - label: "Record correctness test result for PP"
-    key: "record_PP_CorrectnessTest"
-    depends_on: "PP_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for PP"
+    key: "${TPU_VERSION:-tpu6e}_record_PP_CorrectnessTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_PP_CorrectnessTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "PP"
       CI_STAGE: "CorrectnessTest"
       CI_CATEGORY: "parallelism support matrix"
@@ -37,24 +40,27 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh PP_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_PP_CorrectnessTest
 
-  - label: "Performance tests for PP"
-    key: "PP_PerformanceTest"
-    depends_on: "record_PP_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Performance tests for PP"
+    key: "${TPU_VERSION:-tpu6e}_PP_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_record_PP_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh \
           python3 -m pytest -s -v /workspace/tpu_inference/tests/e2e/test_pipeline_parallel.py::test_pipeline_parallelism_jax_model \
           /workspace/tpu_inference/tests/e2e/test_pipeline_parallel.py::test_pipeline_parallelism_vllm_model \
           /workspace/tpu_inference/tests/e2e/test_pipeline_parallel.py::test_pipeline_parallelism_jax_model_correctness
-  - label: "Record performance test result for PP"
-    key: "record_PP_PerformanceTest"
-    depends_on: "PP_PerformanceTest"
+  - label: "${TPU_VERSION:-tpu6e} Record performance test result for PP"
+    key: "${TPU_VERSION:-tpu6e}_record_PP_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_PP_PerformanceTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "PP"
       CI_STAGE: "PerformanceTest"
       CI_CATEGORY: "parallelism support matrix"
@@ -62,4 +68,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh PP_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_PP_PerformanceTest

--- a/.buildkite/parallelism/SP.yml
+++ b/.buildkite/parallelism/SP.yml
@@ -15,18 +15,21 @@
 # pipeline-name: SP
 # pipeline-type: parallelism support matrix
 steps:
-  - label: "Correctness tests for SP"
-    key: "SP_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Correctness tests for SP"
+    key: "${TPU_VERSION:-tpu6e}_SP_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "SP_CorrectnessTest" "unverified"
-  - label: "Record correctness test result for SP"
-    key: "record_SP_CorrectnessTest"
-    depends_on: "SP_CorrectnessTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_SP_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for SP"
+    key: "${TPU_VERSION:-tpu6e}_record_SP_CorrectnessTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_SP_CorrectnessTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "SP"
       CI_STAGE: "CorrectnessTest"
       CI_CATEGORY: "parallelism support matrix"
@@ -34,21 +37,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh SP_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_SP_CorrectnessTest
 
-  - label: "Performance tests for SP"
-    key: "SP_PerformanceTest"
-    depends_on: "record_SP_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Performance tests for SP"
+    key: "${TPU_VERSION:-tpu6e}_SP_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_record_SP_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "SP_PerformanceTest" "unverified"
-  - label: "Record performance test result for SP"
-    key: "record_SP_PerformanceTest"
-    depends_on: "SP_PerformanceTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_SP_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record performance test result for SP"
+    key: "${TPU_VERSION:-tpu6e}_record_SP_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_SP_PerformanceTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "SP"
       CI_STAGE: "PerformanceTest"
       CI_CATEGORY: "parallelism support matrix"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh SP_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_SP_PerformanceTest

--- a/.buildkite/parallelism/TP.yml
+++ b/.buildkite/parallelism/TP.yml
@@ -15,19 +15,22 @@
 # pipeline-name: TP
 # pipeline-type: parallelism support matrix
 steps:
-  - label: "Correctness tests for TP"
-    key: "TP_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Correctness tests for TP"
+    key: "${TPU_VERSION:-tpu6e}_TP_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_8_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_8_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh \
           bash -c 'python3 -m pytest -s -v -x /workspace/tpu_inference/tests/e2e/test_tensor_parallel.py'
-  - label: "Record correctness test result for TP"
-    key: "record_TP_CorrectnessTest"
-    depends_on: "TP_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for TP"
+    key: "${TPU_VERSION:-tpu6e}_record_TP_CorrectnessTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_TP_CorrectnessTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "TP"
       CI_STAGE: "CorrectnessTest"
       CI_CATEGORY: "parallelism support matrix"
@@ -35,21 +38,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh TP_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_TP_CorrectnessTest
 
-  - label: "Performance tests for TP"
-    key: "TP_PerformanceTest"
-    depends_on: "record_TP_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Performance tests for TP"
+    key: "${TPU_VERSION:-tpu6e}_TP_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_record_TP_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "TP_PerformanceTest" "unverified"
-  - label: "Record performance test result for TP"
-    key: "record_TP_PerformanceTest"
-    depends_on: "TP_PerformanceTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_TP_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record performance test result for TP"
+    key: "${TPU_VERSION:-tpu6e}_record_TP_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_TP_PerformanceTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "TP"
       CI_STAGE: "PerformanceTest"
       CI_CATEGORY: "parallelism support matrix"
@@ -57,4 +63,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh TP_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_TP_PerformanceTest

--- a/.buildkite/pipeline_generation/constant.py
+++ b/.buildkite/pipeline_generation/constant.py
@@ -15,4 +15,6 @@
 QUEUE_TO_TENSOR_PARALLEL_SIZE_MAP = {
     "tpu_v6e_queue": 1,
     "tpu_v6e_8_queue": 8,
+    "tpu_v7x_2_queue": 2,
+    "tpu_v7x_8_queue": 8,
 }

--- a/.buildkite/pipeline_generation/feature_template.yml
+++ b/.buildkite/pipeline_generation/feature_template.yml
@@ -15,17 +15,20 @@
 # pipeline-name: {FEATURE_NAME}
 # pipeline-type: {CATEGORY}
 steps:
-  - label: "Correctness tests for {FEATURE_NAME}"
-    key: "{SANITIZED_FEATURE_NAME}_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Correctness tests for {FEATURE_NAME}"
+    key: "${TPU_VERSION:-tpu6e}_{SANITIZED_FEATURE_NAME}_CorrectnessTest"
     soft_fail: true
     agents:
       queue: {QUEUE}
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - echo "placeholder"  # TODO : replace with your correctness test command
-  - label: "Record correctness test result for {FEATURE_NAME}"
-    key: "record_{SANITIZED_FEATURE_NAME}_CorrectnessTest"
-    depends_on: "{SANITIZED_FEATURE_NAME}_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for {FEATURE_NAME}"
+    key: "${TPU_VERSION:-tpu6e}_record_{SANITIZED_FEATURE_NAME}_CorrectnessTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_{SANITIZED_FEATURE_NAME}_CorrectnessTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "{FEATURE_NAME}"
       CI_STAGE: "CorrectnessTest"
       CI_CATEGORY: "{CATEGORY}"
@@ -33,20 +36,23 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh {SANITIZED_FEATURE_NAME}_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_{SANITIZED_FEATURE_NAME}_CorrectnessTest
 
-  - label: "Performance tests for {FEATURE_NAME}"
-    key: "{SANITIZED_FEATURE_NAME}_PerformanceTest"
-    depends_on: "record_{SANITIZED_FEATURE_NAME}_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Performance tests for {FEATURE_NAME}"
+    key: "${TPU_VERSION:-tpu6e}_{SANITIZED_FEATURE_NAME}_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_record_{SANITIZED_FEATURE_NAME}_CorrectnessTest"
     soft_fail: true
     agents:
       queue: {QUEUE}
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - echo "placeholder"  # TODO : replace with your performance test command
-  - label: "Record performance test result for {FEATURE_NAME}"
-    key: "record_{SANITIZED_FEATURE_NAME}_PerformanceTest"
-    depends_on: "{SANITIZED_FEATURE_NAME}_PerformanceTest"
+  - label: "${TPU_VERSION:-tpu6e} Record performance test result for {FEATURE_NAME}"
+    key: "${TPU_VERSION:-tpu6e}_record_{SANITIZED_FEATURE_NAME}_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_{SANITIZED_FEATURE_NAME}_PerformanceTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "{FEATURE_NAME}"
       CI_STAGE: "PerformanceTest"
       CI_CATEGORY: "{CATEGORY}"
@@ -54,4 +60,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh {SANITIZED_FEATURE_NAME}_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_{SANITIZED_FEATURE_NAME}_PerformanceTest

--- a/.buildkite/pipeline_generation/tpu_optimized_model_template.yml
+++ b/.buildkite/pipeline_generation/tpu_optimized_model_template.yml
@@ -15,74 +15,81 @@
 # pipeline-name: {MODEL_NAME}
 # pipeline-type: {CATEGORY}
 steps:
-  - label: "Unit tests for {MODEL_NAME}"
-    key: "{SANITIZED_MODEL_NAME}_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} Unit tests for {MODEL_NAME}"
+    key: "${TPU_VERSION:-tpu6e}_{SANITIZED_MODEL_NAME}_UnitTest"
     soft_fail: true
     agents:
       queue: {QUEUE}
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - echo "placeholder"  # TODO: replace with your unit test command
-  - label: "Record unit test result for {MODEL_NAME}"
-    key: "record_{SANITIZED_MODEL_NAME}_UnitTest"
-    depends_on: "{SANITIZED_MODEL_NAME}_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} Record unit test result for {MODEL_NAME}"
+    key: "${TPU_VERSION:-tpu6e}_record_{SANITIZED_MODEL_NAME}_UnitTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_{SANITIZED_MODEL_NAME}_UnitTest"
     env:
-      CI_TARGET: {MODEL_NAME}
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
+      CI_TARGET: "{MODEL_NAME}"
       CI_STAGE: "UnitTest"
       CI_CATEGORY: "{CATEGORY}"
     agents:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh {SANITIZED_MODEL_NAME}_UnitTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_{SANITIZED_MODEL_NAME}_UnitTest
 
-  - label: "Accuracy for {MODEL_NAME}"
-    key: "{SANITIZED_MODEL_NAME}_Accuracy"
-    depends_on: "record_{SANITIZED_MODEL_NAME}_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} Accuracy for {MODEL_NAME}"
+    key: "${TPU_VERSION:-tpu6e}_{SANITIZED_MODEL_NAME}_Accuracy"
+    depends_on: "${TPU_VERSION:-tpu6e}_record_{SANITIZED_MODEL_NAME}_UnitTest"
     soft_fail: true
     agents:
       queue: {QUEUE}
     env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
       TEST_MODEL: {MODEL_NAME}
       TENSOR_PARALLEL_SIZE: {TENSOR_PARALLEL_SIZE}
       MINIMUM_ACCURACY_THRESHOLD: 0  # TODO : replace 0 with your accuracy threshold
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/test_accuracy.sh
-  - label: "Record accuracy result for {MODEL_NAME}"
-    key: "record_{SANITIZED_MODEL_NAME}_Accuracy"
-    depends_on: "{SANITIZED_MODEL_NAME}_Accuracy"
+  - label: "${TPU_VERSION:-tpu6e} Record accuracy result for {MODEL_NAME}"
+    key: "${TPU_VERSION:-tpu6e}_record_{SANITIZED_MODEL_NAME}_Accuracy"
+    depends_on: "${TPU_VERSION:-tpu6e}_{SANITIZED_MODEL_NAME}_Accuracy"
     env:
-      CI_TARGET: {MODEL_NAME}
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
+      CI_TARGET: "{MODEL_NAME}"
       CI_STAGE: "Accuracy/Correctness"
       CI_CATEGORY: "{CATEGORY}"
     agents:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh {SANITIZED_MODEL_NAME}_Accuracy
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_{SANITIZED_MODEL_NAME}_Accuracy
 
-  - label: "Performance benchmarks for {MODEL_NAME}"
-    key: "{SANITIZED_MODEL_NAME}_Benchmark"
-    depends_on: "record_{SANITIZED_MODEL_NAME}_Accuracy"
+  - label: "${TPU_VERSION:-tpu6e} Performance benchmarks for {MODEL_NAME}"
+    key: "${TPU_VERSION:-tpu6e}_{SANITIZED_MODEL_NAME}_Benchmark"
+    depends_on: "${TPU_VERSION:-tpu6e}_record_{SANITIZED_MODEL_NAME}_Accuracy"
     soft_fail: true
     agents:
       queue: {QUEUE}
     env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
       TEST_MODEL: {MODEL_NAME}
       TENSOR_PARALLEL_SIZE: {TENSOR_PARALLEL_SIZE}
       MINIMUM_THROUGHPUT_THRESHOLD: 0  # TODO : replace 0 with your performance threshold
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/benchmark.sh
-  - label: "Record performance benchmark result for {MODEL_NAME}"
-    key: "record_{SANITIZED_MODEL_NAME}_Benchmark"
-    depends_on: "{SANITIZED_MODEL_NAME}_Benchmark"
+  - label: "${TPU_VERSION:-tpu6e} Record performance benchmark result for {MODEL_NAME}"
+    key: "${TPU_VERSION:-tpu6e}_record_{SANITIZED_MODEL_NAME}_Benchmark"
+    depends_on: "${TPU_VERSION:-tpu6e}_{SANITIZED_MODEL_NAME}_Benchmark"
     env:
-      CI_TARGET: {MODEL_NAME}
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
+      CI_TARGET: "{MODEL_NAME}"
       CI_STAGE: "Benchmark"
       CI_CATEGORY: "{CATEGORY}"
     agents:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh {SANITIZED_MODEL_NAME}_Benchmark
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_{SANITIZED_MODEL_NAME}_Benchmark

--- a/.buildkite/pipeline_generation/vllm_native_model_template.yml
+++ b/.buildkite/pipeline_generation/vllm_native_model_template.yml
@@ -15,48 +15,53 @@
 # pipeline-name: {MODEL_NAME}
 # pipeline-type: {CATEGORY}
 steps:
-  - label: "Unit tests for {MODEL_NAME}"
-    key: "{SANITIZED_MODEL_NAME}_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} Unit tests for {MODEL_NAME}"
+    key: "${TPU_VERSION:-tpu6e}_{SANITIZED_MODEL_NAME}_UnitTest"
     agents:
       queue: {QUEUE}
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     soft_fail: true
     commands:
       - echo "placeholder"  # TODO: replace with your unit test command
-  - label: "Record unit test result for {MODEL_NAME}"
-    key: "record_{SANITIZED_MODEL_NAME}_UnitTest"
-    depends_on: "{SANITIZED_MODEL_NAME}_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} Record unit test result for {MODEL_NAME}"
+    key: "${TPU_VERSION:-tpu6e}_record_{SANITIZED_MODEL_NAME}_UnitTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_{SANITIZED_MODEL_NAME}_UnitTest"
     env:
-      CI_TARGET: {MODEL_NAME}
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
+      CI_TARGET: "{MODEL_NAME}"
       CI_STAGE: "UnitTest"
       CI_CATEGORY: "{CATEGORY}"
     agents:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh {SANITIZED_MODEL_NAME}_UnitTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_{SANITIZED_MODEL_NAME}_UnitTest
 
-  - label: "Accuracy for {MODEL_NAME}"
-    key: "{SANITIZED_MODEL_NAME}_Accuracy"
-    depends_on: "record_{SANITIZED_MODEL_NAME}_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} Accuracy for {MODEL_NAME}"
+    key: "${TPU_VERSION:-tpu6e}_{SANITIZED_MODEL_NAME}_Accuracy"
+    depends_on: "${TPU_VERSION:-tpu6e}_record_{SANITIZED_MODEL_NAME}_UnitTest"
     agents:
       queue: {QUEUE}
     soft_fail: true
     env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
       TEST_MODEL: {MODEL_NAME}
       TENSOR_PARALLEL_SIZE: {TENSOR_PARALLEL_SIZE}
       MINIMUM_ACCURACY_THRESHOLD: 0  # TODO : replace 0 with your accuracy threshold
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/test_accuracy.sh
-  - label: "Record accuracy result for {MODEL_NAME}"
-    key: "record_{SANITIZED_MODEL_NAME}_Accuracy"
-    depends_on: "{SANITIZED_MODEL_NAME}_Accuracy"
+  - label: "${TPU_VERSION:-tpu6e} Record accuracy result for {MODEL_NAME}"
+    key: "${TPU_VERSION:-tpu6e}_record_{SANITIZED_MODEL_NAME}_Accuracy"
+    depends_on: "${TPU_VERSION:-tpu6e}_{SANITIZED_MODEL_NAME}_Accuracy"
     env:
-      CI_TARGET: {MODEL_NAME}
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
+      CI_TARGET: "{MODEL_NAME}"
       CI_STAGE: "Accuracy/Correctness"
       CI_CATEGORY: "{CATEGORY}"
     agents:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh {SANITIZED_MODEL_NAME}_Accuracy
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_{SANITIZED_MODEL_NAME}_Accuracy

--- a/.buildkite/pipeline_jax.yml
+++ b/.buildkite/pipeline_jax.yml
@@ -13,359 +13,361 @@
 # limitations under the License.
 
 steps:
-  # -----------------------------------------------------------------
-  # TEST STEPS - Calling wrapper
-  # -----------------------------------------------------------------
-   - label: "${LABEL_PREFIX}E2E MLPerf tests for JAX models"
-     key: ${KEY_PREFIX}test_0
-     soft_fail: true
-     env:
-       IS_FOR_V7X: "${IS_FOR_V7X}"
-     agents:
-       queue: ${TPU_QUEUE_SINGLE:-tpu_v6e_queue}
-     commands:
-       - .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/mlperf.sh
+  - group: "${TESTS_GROUP_LABEL:-[jax] TPU6e Tests Group}"
+    steps:
+      # -----------------------------------------------------------------
+      # TEST STEPS - Calling wrapper
+      # -----------------------------------------------------------------
+      - label: "${TPU_VERSION:-tpu6e} E2E MLPerf tests for JAX models"
+        key: "${TPU_VERSION:-tpu6e}_test_0"
+        soft_fail: true
+        env:
+          IS_FOR_V7X: "${IS_FOR_V7X}"
+        agents:
+          queue: ${TPU_QUEUE_SINGLE:-tpu_v6e_queue}
+        commands:
+          - .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/mlperf.sh
 
-   - label: "${LABEL_PREFIX}E2E MLPerf tests for JAX models with quantization"
-     key: ${KEY_PREFIX}test_1
-     soft_fail: true
-     env:
-       QUANTIZATION: "True"
-       IS_FOR_V7X: "${IS_FOR_V7X}"
-     agents:
-       queue: ${TPU_QUEUE_SINGLE:-tpu_v6e_queue}
-     if: build.env("NIGHTLY") == "1"
-     commands:
-       - .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/mlperf.sh
+      - label: "${TPU_VERSION:-tpu6e} E2E MLPerf tests for JAX models with quantization"
+        key: ${TPU_VERSION:-tpu6e}_test_1
+        soft_fail: true
+        env:
+          QUANTIZATION: "True"
+          IS_FOR_V7X: "${IS_FOR_V7X}"
+        agents:
+          queue: ${TPU_QUEUE_SINGLE:-tpu_v6e_queue}
+        if: build.env("NIGHTLY") == "1"
+        commands:
+          - .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/mlperf.sh
 
-   - label: "${LABEL_PREFIX}E2E MLPerf tests for JAX new models"
-     key: ${KEY_PREFIX}test_2
-     soft_fail: true
-     env:
-       NEW_MODEL_DESIGN: "1"
-       IS_FOR_V7X: "${IS_FOR_V7X}"
-     agents:
-       queue: ${TPU_QUEUE_SINGLE:-tpu_v6e_queue}
-     if: build.env("NIGHTLY") == "1"
-     commands:
-       - .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/mlperf.sh
+      - label: "${TPU_VERSION:-tpu6e} E2E MLPerf tests for JAX new models"
+        key: ${TPU_VERSION:-tpu6e}_test_2
+        soft_fail: true
+        env:
+          NEW_MODEL_DESIGN: "1"
+          IS_FOR_V7X: "${IS_FOR_V7X}"
+        agents:
+          queue: ${TPU_QUEUE_SINGLE:-tpu_v6e_queue}
+        if: build.env("NIGHTLY") == "1"
+        commands:
+          - .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/mlperf.sh
 
-   - label: "${LABEL_PREFIX}E2E MLPerf tests for JAX + vLLM models on single chip"
-     key: ${KEY_PREFIX}test_3
-     soft_fail: true
-     env:
-       MODEL_IMPL_TYPE: "vllm"
-       IS_FOR_V7X: "${IS_FOR_V7X}"
-     agents:
-       queue: ${TPU_QUEUE_SINGLE:-tpu_v6e_queue}
-     commands:
-       - .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/mlperf.sh
+      - label: "${TPU_VERSION:-tpu6e} E2E MLPerf tests for JAX + vLLM models on single chip"
+        key: ${TPU_VERSION:-tpu6e}_test_3
+        soft_fail: true
+        env:
+          MODEL_IMPL_TYPE: "vllm"
+          IS_FOR_V7X: "${IS_FOR_V7X}"
+        agents:
+          queue: ${TPU_QUEUE_SINGLE:-tpu_v6e_queue}
+        commands:
+          - .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/mlperf.sh
 
-   - label: "${LABEL_PREFIX}E2E MLperf tests for Llama4 models"
-     key: ${KEY_PREFIX}test_4
-     soft_fail: true
-     env:
-       NEW_MODEL_DESIGN: "1"
-       USE_V6E8_QUEUE: "True"
-       IS_FOR_V7X: "${IS_FOR_V7X}"
-     agents:
-       queue: ${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}
-     if: build.env("NIGHTLY") == "1"
-     commands:
-       - .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/mlperf.sh
+      - label: "${TPU_VERSION:-tpu6e} E2E MLperf tests for Llama4 models"
+        key: ${TPU_VERSION:-tpu6e}_test_4
+        soft_fail: true
+        env:
+          NEW_MODEL_DESIGN: "1"
+          USE_V6E8_QUEUE: "True"
+          IS_FOR_V7X: "${IS_FOR_V7X}"
+        agents:
+          queue: ${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}
+        if: build.env("NIGHTLY") == "1"
+        commands:
+          - .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/mlperf.sh
 
-   - label: "${LABEL_PREFIX}E2E speculative decoding test"
-     key: ${KEY_PREFIX}test_6
-     soft_fail: true
-     env:
-       IS_FOR_V7X: "${IS_FOR_V7X}"
-     agents:
-       queue: ${TPU_QUEUE_SINGLE:-tpu_v6e_queue}
-     commands:
-       - |
-           .buildkite/scripts/run_in_docker.sh \
-             bash -c 'python3 -m pytest -s -v -x /workspace/tpu_inference/tests/e2e/test_speculative_decoding.py'
+      - label: "${TPU_VERSION:-tpu6e} E2E speculative decoding test"
+        key: ${TPU_VERSION:-tpu6e}_test_6
+        soft_fail: true
+        env:
+          IS_FOR_V7X: "${IS_FOR_V7X}"
+        agents:
+          queue: ${TPU_QUEUE_SINGLE:-tpu_v6e_queue}
+        commands:
+          - |
+              .buildkite/scripts/run_in_docker.sh \
+                bash -c 'python3 -m pytest -s -v -x /workspace/tpu_inference/tests/e2e/test_speculative_decoding.py'
 
-   - label: "${LABEL_PREFIX}JAX unit tests"
-     key: ${KEY_PREFIX}test_7
-     soft_fail: true
-     env:
-       IS_FOR_V7X: "${IS_FOR_V7X}"
-     agents:
-       queue: ${TPU_QUEUE_SINGLE:-tpu_v6e_queue}
-     commands:
-       - |
-         .buildkite/scripts/run_in_docker.sh \
-           python3 -m pytest -s -v -x /workspace/tpu_inference/tests/ \
-           --ignore=/workspace/tpu_inference/tests/kernels \
-           --ignore=/workspace/tpu_inference/tests/lora \
-           --ignore=/workspace/tpu_inference/tests/e2e \
-           --ignore=/workspace/tpu_inference/tpu_inference/mock \
-           --ignore=/workspace/tpu_inference/tests/layers/vllm/test_compressed_tensors_moe.py \
-           --ignore=/workspace/tpu_inference/tests/models/jax/test_deepseek_v3.py \
-           --cov-config=/workspace/tpu_inference/.coveragerc --cov tpu_inference --cov-report term-missing --cov-fail-under=${COV_FAIL_UNDER:-69}
+      - label: "${TPU_VERSION:-tpu6e} JAX unit tests"
+        key: ${TPU_VERSION:-tpu6e}_test_7
+        soft_fail: true
+        env:
+          IS_FOR_V7X: "${IS_FOR_V7X}"
+        agents:
+          queue: ${TPU_QUEUE_SINGLE:-tpu_v6e_queue}
+        commands:
+          - |
+            .buildkite/scripts/run_in_docker.sh \
+              python3 -m pytest -s -v -x /workspace/tpu_inference/tests/ \
+              --ignore=/workspace/tpu_inference/tests/kernels \
+              --ignore=/workspace/tpu_inference/tests/lora \
+              --ignore=/workspace/tpu_inference/tests/e2e \
+              --ignore=/workspace/tpu_inference/tpu_inference/mock \
+              --ignore=/workspace/tpu_inference/tests/layers/vllm/test_compressed_tensors_moe.py \
+              --ignore=/workspace/tpu_inference/tests/models/jax/test_deepseek_v3.py \
+              --cov-config=/workspace/tpu_inference/.coveragerc --cov tpu_inference --cov-report term-missing --cov-fail-under=${COV_FAIL_UNDER:-69}
 
-   - label: "${LABEL_PREFIX}JAX unit tests - kernels"
-     key: ${KEY_PREFIX}test_8
-     soft_fail: true
-     env:
-       IS_FOR_V7X: "${IS_FOR_V7X}"
-     agents:
-       queue: ${TPU_QUEUE_SINGLE:-tpu_v6e_queue}
-     commands:
-       - |
-         if [[ "$$NIGHTLY" == "1" ]] || git diff --name-only HEAD~1 | grep -qE '^(tpu_inference/kernels|tests/kernels|requirements.txt)'; then
-           .buildkite/scripts/run_in_docker.sh \
-             python3 -m pytest -s -v -x /workspace/tpu_inference/tests/kernels \
-             --ignore=/workspace/tpu_inference/tests/kernels/ragged_paged_attention_kernel_v2_test.py \
-             --ignore=/workspace/tpu_inference/tests/kernels/ragged_kv_cache_update_v2_test.py \
-             --ignore=/workspace/tpu_inference/tests/kernels/collectives
-         else
-           echo "Skipping: Step requires either a NIGHTLY build or changes in kernels, kernel tests, or requirements.txt."
-           exit 0
-         fi
+      - label: "${TPU_VERSION:-tpu6e} JAX unit tests - kernels"
+        key: ${TPU_VERSION:-tpu6e}_test_8
+        soft_fail: true
+        env:
+          IS_FOR_V7X: "${IS_FOR_V7X}"
+        agents:
+          queue: ${TPU_QUEUE_SINGLE:-tpu_v6e_queue}
+        commands:
+          - |
+            if [[ "$$NIGHTLY" == "1" ]] || git diff --name-only HEAD~1 | grep -qE '^(tpu_inference/kernels|tests/kernels|requirements.txt)'; then
+              .buildkite/scripts/run_in_docker.sh \
+                python3 -m pytest -s -v -x /workspace/tpu_inference/tests/kernels \
+                --ignore=/workspace/tpu_inference/tests/kernels/ragged_paged_attention_kernel_v2_test.py \
+                --ignore=/workspace/tpu_inference/tests/kernels/ragged_kv_cache_update_v2_test.py \
+                --ignore=/workspace/tpu_inference/tests/kernels/collectives
+            else
+              echo "Skipping: Step requires either a NIGHTLY build or changes in kernels, kernel tests, or requirements.txt."
+              exit 0
+            fi
 
-   - label: "${LABEL_PREFIX}JAX unit tests - collective kernels"
-     key: ${KEY_PREFIX}test_9
-     soft_fail: true
-     env:
-       IS_FOR_V7X: "${IS_FOR_V7X}"
-     agents:
-       queue: ${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}
-     commands:
-       - |
-         if [[ "$$NIGHTLY" == "1" ]] || git diff --name-only HEAD~1 | grep -qE '^(tpu_inference/kernels/collectives|tests/kernels/collectives|requirements.txt)'; then
-           .buildkite/scripts/run_in_docker.sh \
-             python3 -m pytest -s -v -x /workspace/tpu_inference/tests/kernels/collectives
-         else
-           echo "Skipping: Step requires either a NIGHTLY build or changes in kernels/collectives, tests, or requirements.txt."
-           exit 0
-         fi
+      - label: "${TPU_VERSION:-tpu6e} JAX unit tests - collective kernels"
+        key: ${TPU_VERSION:-tpu6e}_test_9
+        soft_fail: true
+        env:
+          IS_FOR_V7X: "${IS_FOR_V7X}"
+        agents:
+          queue: ${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}
+        commands:
+          - |
+            if [[ "$$NIGHTLY" == "1" ]] || git diff --name-only HEAD~1 | grep -qE '^(tpu_inference/kernels/collectives|tests/kernels/collectives|requirements.txt)'; then
+              .buildkite/scripts/run_in_docker.sh \
+                python3 -m pytest -s -v -x /workspace/tpu_inference/tests/kernels/collectives
+            else
+              echo "Skipping: Step requires either a NIGHTLY build or changes in kernels/collectives, tests, or requirements.txt."
+              exit 0
+            fi
 
-   - label: "${LABEL_PREFIX}lora e2e tests for JAX + vLLM models single chip"
-     key: ${KEY_PREFIX}test_10
-     soft_fail: true
-     env:
-       IS_FOR_V7X: "${IS_FOR_V7X}"
-     agents:
-       queue: ${TPU_QUEUE_SINGLE:-tpu_v6e_queue}
-     if: build.env("NIGHTLY") == "1"
-     commands:
-       - .buildkite/scripts/run_in_docker.sh bash -c 'MODEL_IMPL_TYPE=vllm TPU_BACKEND_TYPE=jax python3 -m pytest -s -v -x /workspace/tpu_inference/tests/lora/test_lora.py'
+      - label: "${TPU_VERSION:-tpu6e} lora e2e tests for JAX + vLLM models single chip"
+        key: ${TPU_VERSION:-tpu6e}_test_10
+        soft_fail: true
+        env:
+          IS_FOR_V7X: "${IS_FOR_V7X}"
+        agents:
+          queue: ${TPU_QUEUE_SINGLE:-tpu_v6e_queue}
+        if: build.env("NIGHTLY") == "1"
+        commands:
+          - .buildkite/scripts/run_in_docker.sh bash -c 'MODEL_IMPL_TYPE=vllm TPU_BACKEND_TYPE=jax python3 -m pytest -s -v -x /workspace/tpu_inference/tests/lora/test_lora.py'
 
-   - label: "${LABEL_PREFIX}E2E MLPerf tests for JAX + vLLM models on multiple chips"
-     key: ${KEY_PREFIX}test_11
-     soft_fail: true
-     env:
-       MODEL_IMPL_TYPE: "vllm"
-       IS_FOR_V7X: "${IS_FOR_V7X}"
-     agents:
-       queue: ${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}
-     if: build.env("NIGHTLY") == "1"
-     commands:
-       - .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/mlperf.sh
+      - label: "${TPU_VERSION:-tpu6e} E2E MLPerf tests for JAX + vLLM models on multiple chips"
+        key: ${TPU_VERSION:-tpu6e}_test_11
+        soft_fail: true
+        env:
+          MODEL_IMPL_TYPE: "vllm"
+          IS_FOR_V7X: "${IS_FOR_V7X}"
+        agents:
+          queue: ${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}
+        if: build.env("NIGHTLY") == "1"
+        commands:
+          - .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/mlperf.sh
 
-  # TODO (jacobplatin): re-enable this after b/467105149 is fixed
-   - label: "${LABEL_PREFIX}E2E MLperf tests for DeepSeek-R1 (no accuracy, 12-decoder layers only)"
-     key: ${KEY_PREFIX}test_12
-     soft_fail: true
-     env:
-       NEW_MODEL_DESIGN: "1"
-       USE_V6E8_QUEUE: "True"
-       SKIP_ACCURACY_TESTS: "True"
-       VLLM_MLA_DISABLE: "1"
-       IS_FOR_V7X: "${IS_FOR_V7X}"
-     agents:
-       queue: ${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}
-     if: build.env("NIGHTLY") == "1" && build.env("IS_FOR_V7X") == "true"
-     commands:
-       - .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/mlperf.sh -m jrplatin/DeepSeek-R1-1D-Subchannel-256  --use-dummy-weights
+      # TODO (jacobplatin): re-enable this after b/467105149 is fixed
+      - label: "${TPU_VERSION:-tpu6e} E2E MLperf tests for DeepSeek-R1 (no accuracy, 12-decoder layers only)"
+        key: ${TPU_VERSION:-tpu6e}_test_12
+        soft_fail: true
+        env:
+          NEW_MODEL_DESIGN: "1"
+          USE_V6E8_QUEUE: "True"
+          SKIP_ACCURACY_TESTS: "True"
+          VLLM_MLA_DISABLE: "1"
+          IS_FOR_V7X: "${IS_FOR_V7X}"
+        agents:
+          queue: ${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}
+        if: build.env("NIGHTLY") == "1" && build.env("IS_FOR_V7X") == "true"
+        commands:
+          - .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/mlperf.sh -m jrplatin/DeepSeek-R1-1D-Subchannel-256  --use-dummy-weights
 
-   - label: "${LABEL_PREFIX}lora e2e tests for JAX + vLLM models multi chips"
-     key: ${KEY_PREFIX}test_13
-     soft_fail: true
-     env:
-       TEST_LORA_TP: "True"
-       VLLM_LOG_LEVEL: "INFO"
-       IS_FOR_V7X: "${IS_FOR_V7X}"
-     agents:
-       queue: ${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}
-     if: build.env("NIGHTLY") == "1"
-     commands:
-       - .buildkite/scripts/run_in_docker.sh bash -c 'MODEL_IMPL_TYPE=vllm TPU_BACKEND_TYPE=jax python3 -m pytest -s -v -x /workspace/tpu_inference/tests/lora/test_lora.py'
+      - label: "${TPU_VERSION:-tpu6e} lora e2e tests for JAX + vLLM models multi chips"
+        key: ${TPU_VERSION:-tpu6e}_test_13
+        soft_fail: true
+        env:
+          TEST_LORA_TP: "True"
+          VLLM_LOG_LEVEL: "INFO"
+          IS_FOR_V7X: "${IS_FOR_V7X}"
+        agents:
+          queue: ${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}
+        if: build.env("NIGHTLY") == "1"
+        commands:
+          - .buildkite/scripts/run_in_docker.sh bash -c 'MODEL_IMPL_TYPE=vllm TPU_BACKEND_TYPE=jax python3 -m pytest -s -v -x /workspace/tpu_inference/tests/lora/test_lora.py'
 
-   - label: "${LABEL_PREFIX}lora unit tests on single chip"
-     key: ${KEY_PREFIX}test_15
-     soft_fail: true
-     env:
-       IS_FOR_V7X: "${IS_FOR_V7X}"
-     agents:
-       queue: ${TPU_QUEUE_SINGLE:-tpu_v6e_queue}
-     commands:
-       - |
-         .buildkite/scripts/run_in_docker.sh \
-           bash -c ' python3 -m pytest -s -v -x /workspace/tpu_inference/tests/lora/test_bgmv.py && \
-           python3 -m pytest -s -v -x /workspace/tpu_inference/tests/lora/test_layers.py'
+      - label: "${TPU_VERSION:-tpu6e} lora unit tests on single chip"
+        key: ${TPU_VERSION:-tpu6e}_test_15
+        soft_fail: true
+        env:
+          IS_FOR_V7X: "${IS_FOR_V7X}"
+        agents:
+          queue: ${TPU_QUEUE_SINGLE:-tpu_v6e_queue}
+        commands:
+          - |
+            .buildkite/scripts/run_in_docker.sh \
+              bash -c ' python3 -m pytest -s -v -x /workspace/tpu_inference/tests/lora/test_bgmv.py && \
+              python3 -m pytest -s -v -x /workspace/tpu_inference/tests/lora/test_layers.py'
 
-   - label: "${LABEL_PREFIX}lora unit tests on multi chips"
-     key: ${KEY_PREFIX}test_16
-     soft_fail: true
-     env:
-       USE_V6E8_QUEUE: "True"
-       VLLM_LOG_LEVEL: "INFO"
-       IS_FOR_V7X: "${IS_FOR_V7X}"
-     agents:
-       queue: ${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}
-     commands:
-       - .buildkite/scripts/run_in_docker.sh bash -c 'python3 -m pytest -s -v -x /workspace/tpu_inference/tests/lora/test_layers.py'
+      - label: "${TPU_VERSION:-tpu6e} lora unit tests on multi chips"
+        key: ${TPU_VERSION:-tpu6e}_test_16
+        soft_fail: true
+        env:
+          USE_V6E8_QUEUE: "True"
+          VLLM_LOG_LEVEL: "INFO"
+          IS_FOR_V7X: "${IS_FOR_V7X}"
+        agents:
+          queue: ${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}
+        commands:
+          - .buildkite/scripts/run_in_docker.sh bash -c 'python3 -m pytest -s -v -x /workspace/tpu_inference/tests/lora/test_layers.py'
 
-   - label: "${LABEL_PREFIX}E2E lm_eval accuracy check qwen3 coder with fused moe."
-     key: ${KEY_PREFIX}test_17
-     soft_fail: true
-     env:
-       IS_FOR_V7X: "${IS_FOR_V7X}"
-     agents:
-       queue: ${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}
-     commands:
-       - |
-         if [[ "$$IS_FOR_V7X" == "true" ]] && { [[ "$$NIGHTLY" == "1" ]] || git diff --name-only HEAD~1 | grep -qE '^(tpu_inference/kernels|tests/kernels|requirements(_.*)?\.txt)'; }; then
-           .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/check_lm_eval.sh  --model_name "Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8" --use_moe_ep_kernel 1 --tensor_parallel_size 8 --max_model_len 2048 --max_num_batched_tokens 2048 --max_gen_toks 256 --enable_expert_parallel 1 --flex_threshold 0.85 --strict_threshold 0.70
-         else
-           echo "Skipping: Step requires TPU v7x and either a NIGHTLY build or kernel/requirements changes."
-           exit 0
-         fi
+      - label: "${TPU_VERSION:-tpu6e} E2E lm_eval accuracy check qwen3 coder with fused moe."
+        key: ${TPU_VERSION:-tpu6e}_test_17
+        soft_fail: true
+        env:
+          IS_FOR_V7X: "${IS_FOR_V7X}"
+        agents:
+          queue: ${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}
+        commands:
+          - |
+            if [[ "$$IS_FOR_V7X" == "true" ]] && { [[ "$$NIGHTLY" == "1" ]] || git diff --name-only HEAD~1 | grep -qE '^(tpu_inference/kernels|tests/kernels|requirements(_.*)?\.txt)'; }; then
+              .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/check_lm_eval.sh  --model_name "Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8" --use_moe_ep_kernel 1 --tensor_parallel_size 8 --max_model_len 2048 --max_num_batched_tokens 2048 --max_gen_toks 256 --enable_expert_parallel 1 --flex_threshold 0.85 --strict_threshold 0.70
+            else
+              echo "Skipping: Step requires TPU v7x and either a NIGHTLY build or kernel/requirements changes."
+              exit 0
+            fi
 
-   - label: "${LABEL_PREFIX}E2E lm_eval accuracy check qwen3 coder with gmm kernel."
-     key: ${KEY_PREFIX}test_18
-     soft_fail: true
-     env:
-       IS_FOR_V7X: "${IS_FOR_V7X}"
-     agents:
-       queue: ${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}
-     commands:
-       - |
-         if [[ "$$IS_FOR_V7X" == "true" ]] && { [[ "$$NIGHTLY" == "1" ]] || git diff --name-only HEAD~1 | grep -qE '^(tpu_inference/kernels|tests/kernels|requirements(_.*)?\.txt)'; }; then
-           .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/check_lm_eval.sh  --model_name "Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8" --use_moe_ep_kernel 0 --tensor_parallel_size 8 --max_model_len 2048 --max_num_batched_tokens 2048 --max_gen_toks 256 --enable_expert_parallel 1 --flex_threshold 0.85 --strict_threshold 0.70
-         else
-           echo "Skipping: Step requires TPU v7x and either a NIGHTLY build or kernel/requirements changes."
-           exit 0
-         fi
+      - label: "${TPU_VERSION:-tpu6e} E2E lm_eval accuracy check qwen3 coder with gmm kernel."
+        key: ${TPU_VERSION:-tpu6e}_test_18
+        soft_fail: true
+        env:
+          IS_FOR_V7X: "${IS_FOR_V7X}"
+        agents:
+          queue: ${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}
+        commands:
+          - |
+            if [[ "$$IS_FOR_V7X" == "true" ]] && { [[ "$$NIGHTLY" == "1" ]] || git diff --name-only HEAD~1 | grep -qE '^(tpu_inference/kernels|tests/kernels|requirements(_.*)?\.txt)'; }; then
+              .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/check_lm_eval.sh  --model_name "Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8" --use_moe_ep_kernel 0 --tensor_parallel_size 8 --max_model_len 2048 --max_num_batched_tokens 2048 --max_gen_toks 256 --enable_expert_parallel 1 --flex_threshold 0.85 --strict_threshold 0.70
+            else
+              echo "Skipping: Step requires TPU v7x and either a NIGHTLY build or kernel/requirements changes."
+              exit 0
+            fi
 
-   - label: "${LABEL_PREFIX}E2E lm_eval accuracy check gpt oss."
-     key: ${KEY_PREFIX}test_19
-     soft_fail: true
-     env:
-       IS_FOR_V7X: "${IS_FOR_V7X}"
-     agents:
-       queue: ${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}
-     commands:
-       - |
-         if [[ "$$IS_FOR_V7X" == "true" ]] && { [[ "$$NIGHTLY" == "1" ]] || git diff --name-only HEAD~1 | grep -qE '^(tpu_inference/kernels|tests/kernels|requirements(_.*)?\.txt)'; }; then
-           .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/check_lm_eval.sh  --model_name "openai/gpt-oss-120b" --use_moe_ep_kernel 1 --tensor_parallel_size 8 --max_model_len 2048 --max_num_batched_tokens 2048 --max_gen_toks 256 --enable_expert_parallel 1 --flex_threshold 0.50 --strict_threshold 0.25
-         else
-           echo "Skipping: Step requires TPU v7x and either a NIGHTLY build or kernel/requirements changes."
-           exit 0
-         fi
+      - label: "${TPU_VERSION:-tpu6e} E2E lm_eval accuracy check gpt oss."
+        key: ${TPU_VERSION:-tpu6e}_test_19
+        soft_fail: true
+        env:
+          IS_FOR_V7X: "${IS_FOR_V7X}"
+        agents:
+          queue: ${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}
+        commands:
+          - |
+            if [[ "$$IS_FOR_V7X" == "true" ]] && { [[ "$$NIGHTLY" == "1" ]] || git diff --name-only HEAD~1 | grep -qE '^(tpu_inference/kernels|tests/kernels|requirements(_.*)?\.txt)'; }; then
+              .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/check_lm_eval.sh  --model_name "openai/gpt-oss-120b" --use_moe_ep_kernel 1 --tensor_parallel_size 8 --max_model_len 2048 --max_num_batched_tokens 2048 --max_gen_toks 256 --enable_expert_parallel 1 --flex_threshold 0.50 --strict_threshold 0.25
+            else
+              echo "Skipping: Step requires TPU v7x and either a NIGHTLY build or kernel/requirements changes."
+              exit 0
+            fi
 
-   - label: "${LABEL_PREFIX}Perf regression test for qwen3 coder 1k 8k."
-     key: ${KEY_PREFIX}test_20
-     soft_fail: true
-     env:
-       IS_FOR_V7X: "${IS_FOR_V7X}"
-     agents:
-       queue: ${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}
-     if: build.env("NIGHTLY") == "1"
-     commands:
-       - |
-         if [[ "$$IS_FOR_V7X" == "true" ]]; then
-           .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/bm_qwen3_coder.sh --model Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8 --tp 8 --req_tput_limit 0.15  --output_token_tput_limit 1170 --total_token_tput_limit 1314 --input_len 1024 --output_len 8192 --use_moe_ep_kernel 1
-         fi
+      - label: "${TPU_VERSION:-tpu6e} Perf regression test for qwen3 coder 1k 8k."
+        key: ${TPU_VERSION:-tpu6e}_test_20
+        soft_fail: true
+        env:
+          IS_FOR_V7X: "${IS_FOR_V7X}"
+        agents:
+          queue: ${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}
+        if: build.env("NIGHTLY") == "1"
+        commands:
+          - |
+            if [[ "$$IS_FOR_V7X" == "true" ]]; then
+              .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/bm_qwen3_coder.sh --model Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8 --tp 8 --req_tput_limit 0.15  --output_token_tput_limit 1170 --total_token_tput_limit 1314 --input_len 1024 --output_len 8192 --use_moe_ep_kernel 1
+            fi
   
-   - label: "${LABEL_PREFIX}Perf regression test for qwen3 coder 8k 1k."
-     key: ${KEY_PREFIX}test_21
-     soft_fail: true
-     env:
-       IS_FOR_V7X: "${IS_FOR_V7X}"
-     agents:
-       queue: ${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}
-     if: build.env("NIGHTLY") == "1"
-     commands:
-       - |
-         if [[ "$$IS_FOR_V7X" == "true" ]]; then
-           .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/bm_qwen3_coder.sh --model Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8 --tp 8 --req_tput_limit 0.4  --output_token_tput_limit 381 --total_token_tput_limit 3421 --input_len 8192 --output_len 1024 --use_moe_ep_kernel 1
-         fi
+      - label: "${TPU_VERSION:-tpu6e} Perf regression test for qwen3 coder 8k 1k."
+        key: ${TPU_VERSION:-tpu6e}_test_21
+        soft_fail: true
+        env:
+          IS_FOR_V7X: "${IS_FOR_V7X}"
+        agents:
+          queue: ${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}
+        if: build.env("NIGHTLY") == "1"
+        commands:
+          - |
+            if [[ "$$IS_FOR_V7X" == "true" ]]; then
+              .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/bm_qwen3_coder.sh --model Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8 --tp 8 --req_tput_limit 0.4  --output_token_tput_limit 381 --total_token_tput_limit 3421 --input_len 8192 --output_len 1024 --use_moe_ep_kernel 1
+            fi
   
-   - label: "${LABEL_PREFIX}Perf regression test for qwen3 coder 1k 8k."
-     key: ${KEY_PREFIX}test_22
-     soft_fail: true
-     env:
-       IS_FOR_V7X: "${IS_FOR_V7X}"
-     agents:
-       queue: ${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}
-     if: build.env("NIGHTLY") == "1"
-     commands:
-       - |
-         if [[ "$$IS_FOR_V7X" == "true" ]]; then
-           .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/bm_qwen3_coder.sh --model Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8 --tp 8 --req_tput_limit 0.16  --output_token_tput_limit 1226 --total_token_tput_limit 1378 --input_len 1024 --output_len 8192 --use_moe_ep_kernel 0
-         fi
+      - label: "${TPU_VERSION:-tpu6e} Perf regression test for qwen3 coder 1k 8k."
+        key: ${TPU_VERSION:-tpu6e}_test_22
+        soft_fail: true
+        env:
+          IS_FOR_V7X: "${IS_FOR_V7X}"
+        agents:
+          queue: ${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}
+        if: build.env("NIGHTLY") == "1"
+        commands:
+          - |
+            if [[ "$$IS_FOR_V7X" == "true" ]]; then
+              .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/bm_qwen3_coder.sh --model Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8 --tp 8 --req_tput_limit 0.16  --output_token_tput_limit 1226 --total_token_tput_limit 1378 --input_len 1024 --output_len 8192 --use_moe_ep_kernel 0
+            fi
   
-   - label: "${LABEL_PREFIX}Perf regression test for qwen3 coder 8k 1k."
-     key: ${KEY_PREFIX}test_23
-     soft_fail: true
-     env:
-       IS_FOR_V7X: "${IS_FOR_V7X}"
-     agents:
-       queue: ${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}
-     if: build.env("NIGHTLY") == "1"
-     commands:
-       - |
-         if [[ "$$IS_FOR_V7X" == "true" ]]; then
-           .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/bm_qwen3_coder.sh --model Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8 --tp 8 --req_tput_limit 0.63  --output_token_tput_limit 579 --total_token_tput_limit 5193 --input_len 8192 --output_len 1024 --use_moe_ep_kernel 0
-         fi
+      - label: "${TPU_VERSION:-tpu6e} Perf regression test for qwen3 coder 8k 1k."
+        key: ${TPU_VERSION:-tpu6e}_test_23
+        soft_fail: true
+        env:
+          IS_FOR_V7X: "${IS_FOR_V7X}"
+        agents:
+          queue: ${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}
+        if: build.env("NIGHTLY") == "1"
+        commands:
+          - |
+            if [[ "$$IS_FOR_V7X" == "true" ]]; then
+              .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/bm_qwen3_coder.sh --model Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8 --tp 8 --req_tput_limit 0.63  --output_token_tput_limit 579 --total_token_tput_limit 5193 --input_len 8192 --output_len 1024 --use_moe_ep_kernel 0
+            fi
 
-   - label: "${LABEL_PREFIX}Test EP recompilation."
-     key: ${KEY_PREFIX}test_24
-     soft_fail: true
-     env:
-       IS_FOR_V7X: "${IS_FOR_V7X}"
-     agents:
-       queue: ${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}
-     commands:
-       - |
-         if [[ "$$IS_FOR_V7X" == "true" ]]; then
-           .buildkite/scripts/run_in_docker.sh bash -c 'SKIP_JAX_PRECOMPILE=0 USE_MOE_EP_KERNEL=1 VLLM_XLA_CHECK_RECOMPILATION=1  MODEL_IMPL_TYPE=vllm python examples/offline_inference.py --model Qwen/Qwen1.5-MoE-A2.7B  --tensor-parallel-size 4 --enable-expert-parallel --no-async-scheduling --max-model-len 32 --max-num-batched-tokens 32 --max-num-seqs 8'
-         fi
+      - label: "${TPU_VERSION:-tpu6e} Test EP recompilation."
+        key: ${TPU_VERSION:-tpu6e}_test_24
+        soft_fail: true
+        env:
+          IS_FOR_V7X: "${IS_FOR_V7X}"
+        agents:
+          queue: ${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}
+        commands:
+          - |
+            if [[ "$$IS_FOR_V7X" == "true" ]]; then
+              .buildkite/scripts/run_in_docker.sh bash -c 'SKIP_JAX_PRECOMPILE=0 USE_MOE_EP_KERNEL=1 VLLM_XLA_CHECK_RECOMPILATION=1  MODEL_IMPL_TYPE=vllm python examples/offline_inference.py --model Qwen/Qwen1.5-MoE-A2.7B  --tensor-parallel-size 4 --enable-expert-parallel --no-async-scheduling --max-model-len 32 --max-num-batched-tokens 32 --max-num-seqs 8'
+            fi
   
-  # -----------------------------------------------------------------
-  # NOTIFICATION STEP
-  # -----------------------------------------------------------------
-   - label: "${LABEL_PREFIX}TPU Test Notification"
-     key: ${KEY_PREFIX}tpu_test_notification
-     depends_on:
-       - ${KEY_PREFIX}test_0
-       - ${KEY_PREFIX}test_1
-       - ${KEY_PREFIX}test_2
-       - ${KEY_PREFIX}test_3
-       - ${KEY_PREFIX}test_4
-       - ${KEY_PREFIX}test_6
-       - ${KEY_PREFIX}test_7
-       - ${KEY_PREFIX}test_8
-       - ${KEY_PREFIX}test_9
-       - ${KEY_PREFIX}test_10
-       - ${KEY_PREFIX}test_11
-       - ${KEY_PREFIX}test_12
-       - ${KEY_PREFIX}test_13
-       - ${KEY_PREFIX}test_15
-       - ${KEY_PREFIX}test_16
-       - ${KEY_PREFIX}test_17
-       - ${KEY_PREFIX}test_18
-       - ${KEY_PREFIX}test_19
-       - ${KEY_PREFIX}test_20
-       - ${KEY_PREFIX}test_21
-       - ${KEY_PREFIX}test_24
-     agents:
-       queue: cpu
-     commands:
-       - |
-         .buildkite/scripts/check_results.sh \
-           "TPU JAX Tests Failed" ${KEY_PREFIX}test_0 ${KEY_PREFIX}test_1 ${KEY_PREFIX}test_2 ${KEY_PREFIX}test_3 ${KEY_PREFIX}test_4 ${KEY_PREFIX}test_6 ${KEY_PREFIX}test_7 ${KEY_PREFIX}test_8 ${KEY_PREFIX}test_9 ${KEY_PREFIX}test_10 ${KEY_PREFIX}test_11 ${KEY_PREFIX}test_12 ${KEY_PREFIX}test_13 ${KEY_PREFIX}test_15 ${KEY_PREFIX}test_16 ${KEY_PREFIX}test_17 ${KEY_PREFIX}test_18 ${KEY_PREFIX}test_19 ${KEY_PREFIX}test_20 ${KEY_PREFIX}test_21 ${KEY_PREFIX}test_22 ${KEY_PREFIX}test_23 ${KEY_PREFIX}test_24
+      # -----------------------------------------------------------------
+      # NOTIFICATION STEP
+      # -----------------------------------------------------------------
+      - label: "${TPU_VERSION:-tpu6e} TPU Test Notification"
+        key: ${TPU_VERSION:-tpu6e}_tpu_test_notification
+        depends_on:
+          - ${TPU_VERSION:-tpu6e}_test_0
+          - ${TPU_VERSION:-tpu6e}_test_1
+          - ${TPU_VERSION:-tpu6e}_test_2
+          - ${TPU_VERSION:-tpu6e}_test_3
+          - ${TPU_VERSION:-tpu6e}_test_4
+          - ${TPU_VERSION:-tpu6e}_test_6
+          - ${TPU_VERSION:-tpu6e}_test_7
+          - ${TPU_VERSION:-tpu6e}_test_8
+          - ${TPU_VERSION:-tpu6e}_test_9
+          - ${TPU_VERSION:-tpu6e}_test_10
+          - ${TPU_VERSION:-tpu6e}_test_11
+          - ${TPU_VERSION:-tpu6e}_test_12
+          - ${TPU_VERSION:-tpu6e}_test_13
+          - ${TPU_VERSION:-tpu6e}_test_15
+          - ${TPU_VERSION:-tpu6e}_test_16
+          - ${TPU_VERSION:-tpu6e}_test_17
+          - ${TPU_VERSION:-tpu6e}_test_18
+          - ${TPU_VERSION:-tpu6e}_test_19
+          - ${TPU_VERSION:-tpu6e}_test_20
+          - ${TPU_VERSION:-tpu6e}_test_21
+          - ${TPU_VERSION:-tpu6e}_test_24
+        agents:
+          queue: cpu
+        commands:
+          - |
+            .buildkite/scripts/check_results.sh \
+              "TPU JAX Tests Failed" ${TPU_VERSION:-tpu6e}_test_0 ${TPU_VERSION:-tpu6e}_test_1 ${TPU_VERSION:-tpu6e}_test_2 ${TPU_VERSION:-tpu6e}_test_3 ${TPU_VERSION:-tpu6e}_test_4 ${TPU_VERSION:-tpu6e}_test_6 ${TPU_VERSION:-tpu6e}_test_7 ${TPU_VERSION:-tpu6e}_test_8 ${TPU_VERSION:-tpu6e}_test_9 ${TPU_VERSION:-tpu6e}_test_10 ${TPU_VERSION:-tpu6e}_test_11 ${TPU_VERSION:-tpu6e}_test_12 ${TPU_VERSION:-tpu6e}_test_13 ${TPU_VERSION:-tpu6e}_test_15 ${TPU_VERSION:-tpu6e}_test_16 ${TPU_VERSION:-tpu6e}_test_17 ${TPU_VERSION:-tpu6e}_test_18 ${TPU_VERSION:-tpu6e}_test_19 ${TPU_VERSION:-tpu6e}_test_20 ${TPU_VERSION:-tpu6e}_test_21 ${TPU_VERSION:-tpu6e}_test_22 ${TPU_VERSION:-tpu6e}_test_23 ${TPU_VERSION:-tpu6e}_test_24

--- a/.buildkite/quantization/AWQ_INT4.yml
+++ b/.buildkite/quantization/AWQ_INT4.yml
@@ -15,18 +15,21 @@
 # pipeline-name: AWQ INT4
 # pipeline-type: quantization support matrix
 steps:
-  - label: "Correctness tests for AWQ INT4"
-    key: "AWQ_INT4_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Correctness tests for AWQ INT4"
+    key: "${TPU_VERSION:-tpu6e}_AWQ_INT4_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "AWQ_INT4_CorrectnessTest" "unverified"
-  - label: "Record correctness test result for AWQ INT4"
-    key: "record_AWQ_INT4_CorrectnessTest"
-    depends_on: "AWQ_INT4_CorrectnessTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_AWQ_INT4_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for AWQ INT4"
+    key: "${TPU_VERSION:-tpu6e}_record_AWQ_INT4_CorrectnessTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_AWQ_INT4_CorrectnessTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "AWQ INT4"
       CI_STAGE: "CorrectnessTest"
       CI_CATEGORY: "quantization support matrix"
@@ -34,21 +37,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh AWQ_INT4_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_AWQ_INT4_CorrectnessTest
 
-  - label: "Performance tests for AWQ INT4"
-    key: "AWQ_INT4_PerformanceTest"
-    depends_on: "record_AWQ_INT4_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Performance tests for AWQ INT4"
+    key: "${TPU_VERSION:-tpu6e}_AWQ_INT4_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_record_AWQ_INT4_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "AWQ_INT4_PerformanceTest" "unverified"
-  - label: "Record performance test result for AWQ INT4"
-    key: "record_AWQ_INT4_PerformanceTest"
-    depends_on: "AWQ_INT4_PerformanceTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_AWQ_INT4_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record performance test result for AWQ INT4"
+    key: "${TPU_VERSION:-tpu6e}_record_AWQ_INT4_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_AWQ_INT4_PerformanceTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "AWQ INT4"
       CI_STAGE: "PerformanceTest"
       CI_CATEGORY: "quantization support matrix"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh AWQ_INT4_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_AWQ_INT4_PerformanceTest

--- a/.buildkite/quantization/FP4_W4A16.yml
+++ b/.buildkite/quantization/FP4_W4A16.yml
@@ -15,18 +15,21 @@
 # pipeline-name: FP4 W4A16
 # pipeline-type: quantization support matrix
 steps:
-  - label: "Correctness tests for FP4 W4A16"
-    key: "FP4_W4A16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Correctness tests for FP4 W4A16"
+    key: "${TPU_VERSION:-tpu6e}_FP4_W4A16_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "FP4_W4A16_CorrectnessTest" "unverified"
-  - label: "Record correctness test result for FP4 W4A16"
-    key: "record_FP4_W4A16_CorrectnessTest"
-    depends_on: "FP4_W4A16_CorrectnessTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_FP4_W4A16_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for FP4 W4A16"
+    key: "${TPU_VERSION:-tpu6e}_record_FP4_W4A16_CorrectnessTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_FP4_W4A16_CorrectnessTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "FP4 W4A16"
       CI_STAGE: "CorrectnessTest"
       CI_CATEGORY: "quantization support matrix"
@@ -34,21 +37,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh FP4_W4A16_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_FP4_W4A16_CorrectnessTest
 
-  - label: "Performance tests for FP4 W4A16"
-    key: "FP4_W4A16_PerformanceTest"
-    depends_on: "record_FP4_W4A16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Performance tests for FP4 W4A16"
+    key: "${TPU_VERSION:-tpu6e}_FP4_W4A16_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_record_FP4_W4A16_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "FP4_W4A16_PerformanceTest" "unverified"
-  - label: "Record performance test result for FP4 W4A16"
-    key: "record_FP4_W4A16_PerformanceTest"
-    depends_on: "FP4_W4A16_PerformanceTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_FP4_W4A16_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record performance test result for FP4 W4A16"
+    key: "${TPU_VERSION:-tpu6e}_record_FP4_W4A16_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_FP4_W4A16_PerformanceTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "FP4 W4A16"
       CI_STAGE: "PerformanceTest"
       CI_CATEGORY: "quantization support matrix"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh FP4_W4A16_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_FP4_W4A16_PerformanceTest

--- a/.buildkite/quantization/FP8_W8A16.yml
+++ b/.buildkite/quantization/FP8_W8A16.yml
@@ -15,18 +15,21 @@
 # pipeline-name: FP8 W8A16
 # pipeline-type: quantization support matrix
 steps:
-  - label: "Correctness tests for FP8 W8A16"
-    key: "FP8_W8A16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Correctness tests for FP8 W8A16"
+    key: "${TPU_VERSION:-tpu6e}_FP8_W8A16_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "FP8_W8A16_CorrectnessTest" "unverified"
-  - label: "Record correctness test result for FP8 W8A16"
-    key: "record_FP8_W8A16_CorrectnessTest"
-    depends_on: "FP8_W8A16_CorrectnessTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_FP8_W8A16_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for FP8 W8A16"
+    key: "${TPU_VERSION:-tpu6e}_record_FP8_W8A16_CorrectnessTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_FP8_W8A16_CorrectnessTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "FP8 W8A16"
       CI_STAGE: "CorrectnessTest"
       CI_CATEGORY: "quantization support matrix"
@@ -34,21 +37,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh FP8_W8A16_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_FP8_W8A16_CorrectnessTest
 
-  - label: "Performance tests for FP8 W8A16"
-    key: "FP8_W8A16_PerformanceTest"
-    depends_on: "record_FP8_W8A16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Performance tests for FP8 W8A16"
+    key: "${TPU_VERSION:-tpu6e}_FP8_W8A16_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_record_FP8_W8A16_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "FP8_W8A16_PerformanceTest" "unverified"
-  - label: "Record performance test result for FP8 W8A16"
-    key: "record_FP8_W8A16_PerformanceTest"
-    depends_on: "FP8_W8A16_PerformanceTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_FP8_W8A16_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record performance test result for FP8 W8A16"
+    key: "${TPU_VERSION:-tpu6e}_record_FP8_W8A16_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_FP8_W8A16_PerformanceTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "FP8 W8A16"
       CI_STAGE: "PerformanceTest"
       CI_CATEGORY: "quantization support matrix"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh FP8_W8A16_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_FP8_W8A16_PerformanceTest

--- a/.buildkite/quantization/FP8_W8A8.yml
+++ b/.buildkite/quantization/FP8_W8A8.yml
@@ -15,18 +15,21 @@
 # pipeline-name: FP8 W8A8
 # pipeline-type: quantization support matrix
 steps:
-  - label: "Correctness tests for FP8 W8A8"
-    key: "FP8_W8A8_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Correctness tests for FP8 W8A8"
+    key: "${TPU_VERSION:-tpu6e}_FP8_W8A8_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "FP8_W8A8_CorrectnessTest" "unverified"
-  - label: "Record correctness test result for FP8 W8A8"
-    key: "record_FP8_W8A8_CorrectnessTest"
-    depends_on: "FP8_W8A8_CorrectnessTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_FP8_W8A8_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for FP8 W8A8"
+    key: "${TPU_VERSION:-tpu6e}_record_FP8_W8A8_CorrectnessTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_FP8_W8A8_CorrectnessTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "FP8 W8A8"
       CI_STAGE: "CorrectnessTest"
       CI_CATEGORY: "quantization support matrix"
@@ -34,21 +37,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh FP8_W8A8_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_FP8_W8A8_CorrectnessTest
 
-  - label: "Performance tests for FP8 W8A8"
-    key: "FP8_W8A8_PerformanceTest"
-    depends_on: "record_FP8_W8A8_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Performance tests for FP8 W8A8"
+    key: "${TPU_VERSION:-tpu6e}_FP8_W8A8_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_record_FP8_W8A8_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "FP8_W8A8_PerformanceTest" "unverified"
-  - label: "Record performance test result for FP8 W8A8"
-    key: "record_FP8_W8A8_PerformanceTest"
-    depends_on: "FP8_W8A8_PerformanceTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_FP8_W8A8_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record performance test result for FP8 W8A8"
+    key: "${TPU_VERSION:-tpu6e}_record_FP8_W8A8_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_FP8_W8A8_PerformanceTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "FP8 W8A8"
       CI_STAGE: "PerformanceTest"
       CI_CATEGORY: "quantization support matrix"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh FP8_W8A8_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_FP8_W8A8_PerformanceTest

--- a/.buildkite/quantization/INT4_W4A16.yml
+++ b/.buildkite/quantization/INT4_W4A16.yml
@@ -15,18 +15,21 @@
 # pipeline-name: INT4 W4A16
 # pipeline-type: quantization support matrix
 steps:
-  - label: "Correctness tests for INT4 W4A16"
-    key: "INT4_W4A16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Correctness tests for INT4 W4A16"
+    key: "${TPU_VERSION:-tpu6e}_INT4_W4A16_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "INT4_W4A16_CorrectnessTest" "unverified"
-  - label: "Record correctness test result for INT4 W4A16"
-    key: "record_INT4_W4A16_CorrectnessTest"
-    depends_on: "INT4_W4A16_CorrectnessTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_INT4_W4A16_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for INT4 W4A16"
+    key: "${TPU_VERSION:-tpu6e}_record_INT4_W4A16_CorrectnessTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_INT4_W4A16_CorrectnessTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "INT4 W4A16"
       CI_STAGE: "CorrectnessTest"
       CI_CATEGORY: "quantization support matrix"
@@ -34,21 +37,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh INT4_W4A16_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_INT4_W4A16_CorrectnessTest
 
-  - label: "Performance tests for INT4 W4A16"
-    key: "INT4_W4A16_PerformanceTest"
-    depends_on: "record_INT4_W4A16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Performance tests for INT4 W4A16"
+    key: "${TPU_VERSION:-tpu6e}_INT4_W4A16_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_record_INT4_W4A16_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "INT4_W4A16_PerformanceTest" "unverified"
-  - label: "Record performance test result for INT4 W4A16"
-    key: "record_INT4_W4A16_PerformanceTest"
-    depends_on: "INT4_W4A16_PerformanceTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_INT4_W4A16_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record performance test result for INT4 W4A16"
+    key: "${TPU_VERSION:-tpu6e}_record_INT4_W4A16_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_INT4_W4A16_PerformanceTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "INT4 W4A16"
       CI_STAGE: "PerformanceTest"
       CI_CATEGORY: "quantization support matrix"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh INT4_W4A16_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_INT4_W4A16_PerformanceTest

--- a/.buildkite/quantization/INT8_W8A8.yml
+++ b/.buildkite/quantization/INT8_W8A8.yml
@@ -15,18 +15,21 @@
 # pipeline-name: INT8 W8A8
 # pipeline-type: quantization support matrix
 steps:
-  - label: "Correctness tests for INT8 W8A8"
-    key: "INT8_W8A8_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Correctness tests for INT8 W8A8"
+    key: "${TPU_VERSION:-tpu6e}_INT8_W8A8_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "INT8_W8A8_CorrectnessTest" "unverified"
-  - label: "Record correctness test result for INT8 W8A8"
-    key: "record_INT8_W8A8_CorrectnessTest"
-    depends_on: "INT8_W8A8_CorrectnessTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_INT8_W8A8_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for INT8 W8A8"
+    key: "${TPU_VERSION:-tpu6e}_record_INT8_W8A8_CorrectnessTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_INT8_W8A8_CorrectnessTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "INT8 W8A8"
       CI_STAGE: "CorrectnessTest"
       CI_CATEGORY: "quantization support matrix"
@@ -34,21 +37,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh INT8_W8A8_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_INT8_W8A8_CorrectnessTest
 
-  - label: "Performance tests for INT8 W8A8"
-    key: "INT8_W8A8_PerformanceTest"
-    depends_on: "record_INT8_W8A8_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} Performance tests for INT8 W8A8"
+    key: "${TPU_VERSION:-tpu6e}_INT8_W8A8_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_record_INT8_W8A8_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
-        buildkite-agent meta-data set "INT8_W8A8_PerformanceTest" "unverified"
-  - label: "Record performance test result for INT8 W8A8"
-    key: "record_INT8_W8A8_PerformanceTest"
-    depends_on: "INT8_W8A8_PerformanceTest"
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_INT8_W8A8_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record performance test result for INT8 W8A8"
+    key: "${TPU_VERSION:-tpu6e}_record_INT8_W8A8_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_INT8_W8A8_PerformanceTest"
     env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "INT8 W8A8"
       CI_STAGE: "PerformanceTest"
       CI_CATEGORY: "quantization support matrix"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh INT8_W8A8_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_INT8_W8A8_PerformanceTest

--- a/.buildkite/scripts/bootstrap.sh
+++ b/.buildkite/scripts/bootstrap.sh
@@ -69,16 +69,16 @@ upload_pipeline() {
       buildkite-agent pipeline upload .buildkite/pipeline_jax.yml
 
       # Upload JAX pipeline for v7
-      export LABEL_PREFIX="TPU7x "
-      export KEY_PREFIX="tpu7x_"
+      export TESTS_GROUP_LABEL="[jax] TPU7x Tests Group"
+      export TPU_VERSION="tpu7x"
       export TPU_QUEUE_SINGLE="tpu_v7x_2_queue"
       export TPU_QUEUE_MULTI="tpu_v7x_8_queue"
       export IS_FOR_V7X="true"
       export COV_FAIL_UNDER="67"
       buildkite-agent pipeline upload .buildkite/pipeline_jax.yml
-      unset LABEL_PREFIX KEY_PREFIX TPU_QUEUE_SINGLE TPU_QUEUE_MULTI IS_FOR_V7X COV_FAIL_UNDER
+      unset TPU_VERSION TPU_QUEUE_SINGLE TPU_QUEUE_MULTI IS_FOR_V7X COV_FAIL_UNDER
 
-    # buildkite-agent pipeline upload .buildkite/pipeline_torch.yml
+      # buildkite-agent pipeline upload .buildkite/pipeline_torch.yml
       buildkite-agent pipeline upload .buildkite/nightly_releases.yml
     fi
 
@@ -132,14 +132,14 @@ if [[ $BUILDKITE_PIPELINE_SLUG == "tpu-vllm-integration" ]]; then
     buildkite-agent pipeline upload .buildkite/integration_promote.yml
   
     # Upload JAX pipeline for v7
-    export LABEL_PREFIX="TPU7x "
-    export KEY_PREFIX="tpu7x_"
+    export TESTS_GROUP_LABEL="[jax] TPU7x Tests Group"
+    export TPU_VERSION="tpu7x"
     export TPU_QUEUE_SINGLE="tpu_v7x_2_queue"
     export TPU_QUEUE_MULTI="tpu_v7x_8_queue"
     export IS_FOR_V7X="true"
     export COV_FAIL_UNDER="67"
     buildkite-agent pipeline upload .buildkite/pipeline_jax.yml
-    unset LABEL_PREFIX KEY_PREFIX TPU_QUEUE_SINGLE TPU_QUEUE_MULTI IS_FOR_V7X COV_FAIL_UNDER
+    unset TPU_VERSION TPU_QUEUE_SINGLE TPU_QUEUE_MULTI IS_FOR_V7X COV_FAIL_UNDER
 
     # Upload JAX pipeline for v6 (default)
     buildkite-agent pipeline upload .buildkite/pipeline_jax.yml

--- a/.buildkite/scripts/commit_support_matrices.sh
+++ b/.buildkite/scripts/commit_support_matrices.sh
@@ -28,17 +28,17 @@ if [ "${NIGHTLY}" = "1" ]; then
   # If MODEL_IMPL_TYPE is 'vllm' or 'flax_nnx', use a implementation-specific subfolder.
   if [ "${MODEL_IMPL_TYPE:-auto}" = "vllm" ] || [ "${MODEL_IMPL_TYPE:-auto}" = "flax_nnx" ]; then
     ARTIFACT_DOWNLOAD_PATH="${BASE_PATH}/${MODEL_IMPL_TYPE}"
-    COMMIT_MESSAGE="[skip ci] Update nightly support matrices for ${MODEL_IMPL_TYPE}"
+    COMMIT_MESSAGE="[skip ci] Update nightly support matrices for ${MODEL_IMPL_TYPE} (v6/v7)"
   else
     # Default case: support_matrices/nightly
     ARTIFACT_DOWNLOAD_PATH="${BASE_PATH}"
-    COMMIT_MESSAGE="[skip ci] Update nightly support matrices"
+    COMMIT_MESSAGE="[skip ci] Update nightly support matrices (v6/v7)"
   fi
 else
   # Set path and commit message for release tag builds.
   COMMIT_TAG="${BUILDKITE_TAG:-unknown-tag}"
   ARTIFACT_DOWNLOAD_PATH="support_matrices"
-  COMMIT_MESSAGE="[skip ci] Update support matrices for ${COMMIT_TAG}"
+  COMMIT_MESSAGE="[skip ci] Update support matrices for ${COMMIT_TAG} (v6/v7)"
 fi
 # Construct the repository URL with the access token for authentication.
 AUTHENTICATED_REPO_URL="https://x-access-token:${GITHUB_PAT}@${REPO_URL#https://}"
@@ -59,11 +59,29 @@ git checkout "${TARGET_BRANCH}"
 git reset --hard origin/"${TARGET_BRANCH}"
 
 echo "--- Downloading CSV artifacts"
-mkdir -p "${ARTIFACT_DOWNLOAD_PATH}"
-buildkite-agent artifact download "*.csv" "${ARTIFACT_DOWNLOAD_PATH}/" --flat
+# Download without --flat to preserve v6/ or v7/ folder structure
+buildkite-agent artifact download "v*/*.csv" "."
 
-echo "--- Staging downloaded artifacts"
-git add "${ARTIFACT_DOWNLOAD_PATH}"/*.csv
+# Iterate through v6 and v7 folders if they exist
+for ver in v6 v7; do
+  if [ -d "$ver" ]; then
+    TARGET_DIR="${ARTIFACT_DOWNLOAD_PATH}/${ver}"
+    echo "Syncing ${ver} artifacts to ${TARGET_DIR}..."
+    
+    mkdir -p "${TARGET_DIR}"
+    
+    # Move the files to the final destination in the repo
+    mv "${ver}"/*.csv "${TARGET_DIR}/"
+    
+    # Clean up the temporary download directory
+    rmdir "${ver}"
+  else
+    echo "No artifacts found for version: ${ver}. Skipping."
+  fi
+done
+
+echo "--- Staging changes"
+git add support_matrices/
 
 # --- Check for changes before committing ---
 if git diff --quiet --cached; then

--- a/.buildkite/scripts/generate_support_matrices.sh
+++ b/.buildkite/scripts/generate_support_matrices.sh
@@ -50,6 +50,18 @@ declare -a model_csv_files=()
 declare -a feature_csv_files=()
 declare -a default_feature_names=()
 
+# Determine sub-directory based on TPU_VERSION
+if [[ "${TPU_VERSION:-tpu6e}" == "v7"* ]]; then
+    TPU_DIR="v7"
+    TPU_METADATA_PREFIX="v7"
+else
+    TPU_DIR="v6"
+    TPU_METADATA_PREFIX="v6"
+fi
+
+mkdir -p "${TPU_DIR}"
+echo "Output directory set to: ${TPU_DIR} (Prefix: '${TPU_METADATA_PREFIX}')"
+
 # Parse Default Features File & Set Categories
 if [[ -f "${DEFAULT_FEATURES_FILE}" ]]; then
     mapfile -t raw_default_lines < <(sed 's/\r$//; /^$/d' "${DEFAULT_FEATURES_FILE}")
@@ -64,7 +76,7 @@ if [[ -f "${DEFAULT_FEATURES_FILE}" ]]; then
             default_feature_names+=("$feature_name")
             # Set metadata so we know which CSV to put it in later
             echo "Setting category for '$feature_name': $category"
-            buildkite-agent meta-data set "${feature_name}_category" "$category"
+            buildkite-agent meta-data set "${TPU_METADATA_PREFIX}${feature_name}_category" "$category"
         else
             # Fallback if no category found
             default_feature_names+=("$line")
@@ -81,7 +93,7 @@ process_models() {
         if [[ -z "$model" ]]; then continue; fi
         # Get category (default: text-only)
         local category
-        category=$(buildkite-agent meta-data get "${model}_category" --default "text-only")
+        category=$(buildkite-agent meta-data get "${TPU_METADATA_PREFIX}${model}_category" --default "text-only")
         # Define the category-specific CSV filename
         local category_filename
         if [ "$category" == "text-only" ]; then
@@ -91,7 +103,8 @@ process_models() {
         else
             category_filename=${category// /_}
         fi
-        local category_csv="${category_filename}_support_matrix.csv"
+        # Use the TPU_DIR prefix for the CSV path
+        local category_csv="${TPU_DIR}/${category_filename}_support_matrix.csv"
         # Initialize CSV if not exists
         if [ ! -f "$category_csv" ]; then
             echo "Model,UnitTest,Accuracy/Correctness,Benchmark" > "$category_csv"
@@ -101,7 +114,7 @@ process_models() {
         local row="\"$model\""
         for stage in "${MODEL_STAGES[@]}"; do
             local result
-            result=$(buildkite-agent meta-data get "${model}:${stage}" --default "N/A")
+            result=$(buildkite-agent meta-data get "${TPU_METADATA_PREFIX}${model}:${stage}" --default "N/A")
             row="$row,$result"
             if [ "${result}" != "✅" ] && [ "${result}" != "N/A" ] && [ "${result}" != "unverified" ]; then
                 ANY_FAILED=true
@@ -121,10 +134,11 @@ process_features() {
 
         # Get Category (default: feature support matrix)
         local category
-        category=$(buildkite-agent meta-data get "${feature}_category" --default "feature support matrix")
+        category=$(buildkite-agent meta-data get "${TPU_METADATA_PREFIX}${feature}_category" --default "feature support matrix")
 
         local category_filename=${category// /_}
-        local category_csv="${category_filename}.csv"
+        # Use the TPU_DIR prefix for the CSV path
+        local category_csv="${TPU_DIR}/${category_filename}.csv"
 
         # Determine which stages array and header to use
         local stages_to_use=("${FEATURE_STAGES[@]}")
@@ -164,7 +178,7 @@ process_features() {
             elif [[ "$mode" == "DEFAULT" ]]; then
                 result="✅"
             else
-                result=$(buildkite-agent meta-data get "${feature}:${stage}" --default "N/A")
+                result=$(buildkite-agent meta-data get "${TPU_METADATA_PREFIX}${feature}:${stage}" --default "N/A")
             fi
 
             row="$row,$result"
@@ -181,8 +195,8 @@ process_features() {
 }
 
 process_kernel_matrix_to_pivot() {
-    local input_csv="kernel_support_matrix_microbenchmarks.csv"
-    local output_file="kernel_support_matrix-microbenchmarks.csv"
+    local input_csv="${TPU_DIR}/kernel_support_matrix_microbenchmarks.csv"
+    local output_file="${TPU_DIR}/kernel_support_matrix-microbenchmarks.csv"
 
     if [ ! -f "$input_csv" ]; then
         echo "Warning: Input CSV $input_csv not found. Skipping pivot."
@@ -288,25 +302,29 @@ fi
 buildkite-agent meta-data set "CI_TESTS_FAILED" "${ANY_FAILED}"
 
 # Model support matrices
-for csv_file in "${model_csv_files[@]}"; do
-    if [[ -f "$csv_file" ]]; then
-        echo "--- $csv_file ---"
+for csv_file in "${model_csv_files[@]:-}"; do
+    if [[ -n "$csv_file" && -f "$csv_file" ]]; then
+        echo "--- Uploading Model Matrix: $csv_file ---"
         cat "$csv_file"
         buildkite-agent artifact upload "$csv_file"
     fi
 done
 
 # Feature support matrices
-for csv_file in "${feature_csv_files[@]}"; do
-    if [[ -f "$csv_file" ]]; then
-        sorted_content=$(tail -n +2 "$csv_file" | sort -V)
+for csv_file in "${feature_csv_files[@]:-}"; do
+    if [[ -n "$csv_file" && -f "$csv_file" ]]; then
         header=$(head -n 1 "$csv_file")
+        sorted_content=$(tail -n +2 "$csv_file" | sort -V)
         echo "$header" > "$csv_file"
         echo "$sorted_content" >> "$csv_file"
-        if [[ "$csv_file" != "kernel_support_matrix_microbenchmarks.csv" ]]; then
-            echo "--- $csv_file ---"
+        
+        # Skip raw kernel microbenchmarks; upload only the pivoted version
+        if [[ "$csv_file" != *"kernel_support_matrix_microbenchmarks.csv" ]]; then
+            echo "--- Uploading Feature Matrix: $csv_file ---"
             cat "$csv_file"
             buildkite-agent artifact upload "$csv_file"
+        else
+            echo "Skipping direct upload for $csv_file (will be pivoted later)."
         fi
     fi
 done
@@ -317,4 +335,4 @@ process_kernel_matrix_to_pivot
 echo "Reports uploaded successfully."
 
 # Cleanup
-rm -f "${model_csv_files[@]}" "${feature_csv_files[@]}"
+rm -rf "${TPU_DIR}"

--- a/.buildkite/scripts/record_step_result.sh
+++ b/.buildkite/scripts/record_step_result.sh
@@ -22,7 +22,13 @@ fi
 
 STEP_KEY="$1"
 
-echo "--- Checking ${STEP_KEY} Outcome"
+# Determine the prefix based on hardware version to prevent data collisions.
+TPU_METADATA_PREFIX="v6"
+if echo "${CI_TPU_VERSION}" | grep -qi "tpu7x"; then
+  TPU_METADATA_PREFIX="v7"
+fi
+
+echo "--- Checking ${STEP_KEY} Outcome (Hardware: ${CI_TPU_VERSION:-v6})"
 
 # Try to get the custom string you saved
 CUSTOM_STATUS=$(buildkite-agent meta-data get "${STEP_KEY}" --default "")
@@ -51,8 +57,9 @@ case $OUTCOME in
     ;;
 esac
 
-buildkite-agent meta-data set "${CI_TARGET}_category" "${CI_CATEGORY}"
-buildkite-agent meta-data set "${CI_TARGET}:${CI_STAGE}" "${message}"
+# Save the results using the hardware-specific prefix.
+buildkite-agent meta-data set "${TPU_METADATA_PREFIX}${CI_TARGET}_category" "${CI_CATEGORY}"
+buildkite-agent meta-data set "${TPU_METADATA_PREFIX}${CI_TARGET}:${CI_STAGE}" "${message}"
 
 if [ "${OUTCOME}" != "passed" ] && [ "${OUTCOME}" != "skipped" ] && [ "${OUTCOME}" != "unverified" ]; then
     exit 1

--- a/.buildkite/scripts/upload_models_and_features.sh
+++ b/.buildkite/scripts/upload_models_and_features.sh
@@ -20,10 +20,6 @@ BUILDKITE_DIR=".buildkite"
 MODEL_LIST_KEY="model-list"
 FEATURE_LIST_KEY="feature-list"
 
-# TODO: Add CURRENT_IMPL_TYPE to Buildkite group name for easier monitoring.
-CURRENT_IMPL_TYPE="${MODEL_IMPL_TYPE:-auto}"
-echo "current MODEL_IMPL_TYPE: $CURRENT_IMPL_TYPE"
-
 declare -a TARGET_FOLDERS=(
     "quantization"
     "parallelism"
@@ -44,7 +40,9 @@ else
     echo "Warning: Kernel microbenchmarks directory '$KERNEL_PARENT_DIR' not found. Skipping dynamic folder discovery."
 fi
 
-declare -a pipeline_steps
+# Arrays to store YAML content fragments (without 'steps:' header)
+pipeline_v6e_fragments=()
+pipeline_v7x_fragments=()
 
 # Declare separate arrays for each list
 declare -a model_list
@@ -85,16 +83,13 @@ for folder_path in "${TARGET_FOLDERS[@]}"; do
       esac
     fi
 
-#     For each found .yml file, generate a command step
-    pipeline_yaml=$(cat <<EOF
-- label: "Upload: ${yml_file}"
-  command: "buildkite-agent pipeline upload ${yml_file}"
-  agents:
-    queue: cpu
-EOF
-)
+    # Read the YAML file and strip the top-level 'steps:' line
+    # This is required because we wrap them inside a 'group' later
+    yml_content=$(grep -v "^steps:" "${yml_file}")
 
-  pipeline_steps+=("${pipeline_yaml}")
+    # Store the content for both hardware types
+    pipeline_v6e_fragments+=("${yml_content}")
+    pipeline_v7x_fragments+=("${yml_content}")
 
   done < <(find "$folder" -maxdepth 1 -type f \( -name "*.yml" -o -name "*.yaml" \) -print0)
 done
@@ -114,14 +109,38 @@ if [[ -n "$feature_list_string" ]]; then
 fi
 
 # --- Upload Dynamic Pipeline ---
-
-if [[ "${#pipeline_steps[@]}" -gt 0 ]]; then
-  echo "--- Uploading Dynamic Pipeline Steps"
-  final_pipeline_yaml="steps:"$'\n'
-  final_pipeline_yaml+=$(printf "%s\n" "${pipeline_steps[@]}")
-  echo "Upload YML: ${final_pipeline_yaml}"
-  echo -e "${final_pipeline_yaml}" | buildkite-agent pipeline upload
+# Final Uploads (Two separate calls to handle variables) ---
+if [[ "${#pipeline_v6e_fragments[@]}" -gt 0 ]]; then
+  echo "--- Uploading TPU v6e Pipeline Group"
+  buildkite-agent meta-data set "run_v6_matrix" "true"
+  {
+    echo "steps:"
+    echo "  - group: \"TPU v6e nightly Tests (${MODEL_IMPL_TYPE:-auto})\""
+    echo "    key: \"v6e-group\""
+    echo "    steps:"
+    printf "%s\n" "${pipeline_v6e_fragments[@]}" | sed 's/^/      /'
+  } | buildkite-agent pipeline upload
 else
-  echo "--- No .yml files found, no new Pipeline Steps to upload."
+  echo "--- No .yml files found, nothing to upload."
+  exit 0
+fi
+
+if [[ "${#pipeline_v7x_fragments[@]}" -gt 0 ]]; then
+  echo "--- Uploading TPU v7x Pipeline Group"
+  # Export v7x specific variables (overwrites previous exports)
+  export TPU_QUEUE_SINGLE="tpu_v7x_2_queue"
+  export TPU_QUEUE_MULTI="tpu_v7x_8_queue"
+  export IS_FOR_V7X="true"
+  export TPU_VERSION="tpu7x"
+  buildkite-agent meta-data set "run_v7_matrix" "true"
+  {
+    echo "steps:"
+    echo "  - group: \"TPU v7x nightly Tests (${MODEL_IMPL_TYPE:-auto})\""
+    echo "    key: \"v7x-group\""
+    echo "    steps:"
+    printf "%s\n" "${pipeline_v7x_fragments[@]}" | sed 's/^/      /'
+  } | buildkite-agent pipeline upload
+else
+  echo "--- No .yml files found, nothing to upload."
   exit 0
 fi


### PR DESCRIPTION
# Description

- This PR introduces placeholders into the YML files to enable the use of different variables for both v6e and v7x during the upload of nightly CI procedures. This applies to `main.yml`.

- It also use group to make buildkite UI looks better

- Organizing output CSV files into dedicated 'v6/' and 'v7/' directories.

# Tests

[buildkite](https://buildkite.com/tpu-commons/tpu-inference-ci/builds/9685/steps/canvas)

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
