### PR TITLE
Use AttentionSelectorConfig in get_attn_backend_cls

### DIFF
--- a/tpu_inference/platforms/tpu_platform.py
+++ b/tpu_inference/platforms/tpu_platform.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import TYPE_CHECKING, Any, Optional, Tuple, Union, cast
+from typing import TYPE_CHECKING, Optional, Tuple, Union, cast
 
 import jax.numpy as jnp
 import torch


### PR DESCRIPTION
# Description

https://github.com/vllm-project/vllm/pull/30212 refactored individual attention parameters into `AttentionSelectorConfig`. That broke our platform implementation - this PR fixes that.

I also added `**kwargs` to the signature. IMO, we should keep that there as a safety net if vllm adds more platform-specific args to the selector call later, it won't immediately break us.

# Tests

Ran a model locally:

```
vllm serve openai/gpt-oss-120b --max-model-len=9216 --max-num-batched-tokens=1024 --max-num-seqs=128 --no-enable-prefix-caching --gpu-memory-utilization=0.98 --tensor-parallel-size=4 --kv-cache-dtype=fp8 --async-scheduling
```

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
