### PR TITLE
Fix lora layer unit tests for v7x2.

### DIFF
--- a/tests/lora/test_layers.py
+++ b/tests/lora/test_layers.py
@@ -500,13 +500,7 @@ def _create_random_linear_parallel_layer(layer_type, vllm_config, mesh):
 
 
 def _get_devices():
-    devices = jax.devices()
-    if len(devices) < 8:
-        # For v7x, the smallest VM is v7x2 with 1 chips and 2 cores.
-        # IOW, len(jax.devices()) is 2.
-        # In this case, we want to test lora on a single core.
-        return devices[:1]
-    return devices
+    return jax.devices()
 
 
 def _create_mesh():


### PR DESCRIPTION
# Description

On v7x2 CI machine (smallest v7 vm), this pr uses 2 cores (tp=2) to run the lora layer unit test because it was the the setup that the lora layer test fails originally and it was fixed in https://github.com/vllm-project/tpu-inference/pull/1314.

# Tests

pytest -s -vv tests/lora/test_layers.py

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
