### PR TITLE
Use vllm models when PP is enabled

### DIFF
--- a/tpu_inference/models/common/model_loader.py
+++ b/tpu_inference/models/common/model_loader.py
@@ -365,6 +365,11 @@ def get_model(
 
     match impl:
         case "flax_nnx":
+            if vllm_config.parallel_config.pipeline_parallel_size > 1:
+                logger.warning(
+                    "PP is not fully supported on Jax flax_nnx models yet, fallback to vllm models."
+                )
+                return get_vllm_model(vllm_config, rng, mesh)
             try:
                 # Try to load the flax model first
                 return get_flax_model(vllm_config, rng, mesh, is_draft_model)


### PR DESCRIPTION
# Description

PP isn't fully supported on Jax models, set a warning and fallback to use vllm models when PP is enabled.

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
