### PR TITLE
Apply temperature scaling before top-p

### DIFF
--- a/tpu_inference/layers/jax/sample/sampling.py
+++ b/tpu_inference/layers/jax/sample/sampling.py
@@ -34,12 +34,12 @@ def sample(
         return greedy_sampled
 
     logits = logits.astype(jnp.float32)
-    logits = topk_mask(logits, tpu_sampling_metadata.top_k, replace_val=-1e12)
-    logits = topp_mask(logits, tpu_sampling_metadata.top_p, replace_val=-1e12)
-
     temperatures = tpu_sampling_metadata.temperature.astype(logits.dtype)
     temperatures = jnp.expand_dims(temperatures, axis=-1)
     logits /= temperatures
+
+    logits = topk_mask(logits, tpu_sampling_metadata.top_k, replace_val=-1e12)
+    logits = topp_mask(logits, tpu_sampling_metadata.top_p, replace_val=-1e12)
 
     # (batch_size,)
     next_tokens = jax.random.categorical(rng, logits)


### PR DESCRIPTION
# Description
vLLM implements logit temperature scaling **before** top-p’ing.
tpu-inference has logit temperature scaling applied **after** top-p’ing. 
As temperature scaling affects the top-p this is a mismatch to be fixed.

See [here](https://github.com/vllm-project/vllm/blob/4bf6c2366818a1eeae257e06ec337039e6895f13/vllm/v1/sample/sampler.py#L177) and [here](https://github.com/vllm-project/vllm/blob/4bf6c2366818a1eeae257e06ec337039e6895f13/vllm/v1/sample/tpu/sampler.py#L63) in vLLM


