### PR TITLE
[JAX Pre-Compilation] Skip pre-compilation for `_precompile_sampling` / `_precompile_gather_logprobs` in TPU Worker

### DIFF
--- a/tpu_inference/worker/tpu_worker.py
+++ b/tpu_inference/worker/tpu_worker.py
@@ -431,8 +431,11 @@ class TPUWorker:
     ) -> None:
         """Allocate GPU KV cache with the specified kv_cache_config."""
         # Precompile functions with large vocab_size tensors before allocating KV cache to avoid OOM
-        self.model_runner.compilation_manager._precompile_sampling()
-        self.model_runner.compilation_manager._precompile_gather_logprobs()
+        if not (envs.SKIP_JAX_PRECOMPILE or
+                (hasattr(self.model_runner.model_config, "enforce_eager")
+                 and self.model_runner.model_config.enforce_eager)):
+            self.model_runner.compilation_manager._precompile_sampling()
+            self.model_runner.compilation_manager._precompile_gather_logprobs()
         self.model_runner.initialize_kv_cache(kv_cache_config,
                                               self.topology_order_id)
 


### PR DESCRIPTION
# Description

Currently, precompilation is still occurring even if `SKIP_JAX_PRECOMPILE` or `enforce_eager` are set -- this PR fixes that

# Tests

Tested locally.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
