### PR TITLE
[Bug fix] Use tpu_v6e_8_queue for DP CI tests

### DIFF
--- a/.buildkite/features/data_parallelism.yml
+++ b/.buildkite/features/data_parallelism.yml
@@ -19,7 +19,7 @@ steps:
     key: "data_parallelism_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: tpu_v6e_8_queue
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh \
@@ -42,7 +42,7 @@ steps:
     depends_on: "record_data_parallelism_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: tpu_v6e_8_queue
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh \


### PR DESCRIPTION
# Description

 Use tpu_v6e_8_queue for DP CI tests, as those tests need at least 2 devices

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
