### PR TITLE
[Bug fix] update pipeline metadata parsing to skip license headers

### DIFF
--- a/.buildkite/features/Collective_Communication_Matmul.yml
+++ b/.buildkite/features/Collective_Communication_Matmul.yml
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Collective Communication Matmul
-# kernel support matrix
+# pipeline-name: Collective Communication Matmul
+# pipeline-type: kernel support matrix
 steps:
   - label: "Correctness tests for Collective Communication Matmul"
     key: "Collective_Communication_Matmul_CorrectnessTest"

--- a/.buildkite/features/DCN-Based_P-D_disaggregation.yml
+++ b/.buildkite/features/DCN-Based_P-D_disaggregation.yml
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# DCN-based P/D disaggregation
-# feature support matrix
+# pipeline-name: DCN-based P/D disaggregation
+# pipeline-type: feature support matrix
 steps:
   - label: "Correctness tests for DCN-based P/D disaggregation"
     key: "DCN_based_P-D_disaggregation_CorrectnessTest"

--- a/.buildkite/features/KV_Cache_Host_Offloading.yml
+++ b/.buildkite/features/KV_Cache_Host_Offloading.yml
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# KV cache host offloading
-# feature support matrix
+# pipeline-name: KV cache host offloading
+# pipeline-type: feature support matrix
 steps:
   - label: "Correctness tests for KV cache host offloading"
     key: "KV_Cache_Host_Offloading_CorrectnessTest"

--- a/.buildkite/features/LoRA_Torch.yml
+++ b/.buildkite/features/LoRA_Torch.yml
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# LoRA_Torch
-# feature support matrix
+# pipeline-name: LoRA_Torch
+# pipeline-type: feature support matrix
 steps:
   - label: "Correctness tests for LoRA_Torch"
     key: "LoRA_Torch_CorrectnessTest"

--- a/.buildkite/features/MLA.yml
+++ b/.buildkite/features/MLA.yml
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# MLA
-# kernel support matrix
+# pipeline-name: MLA
+# pipeline-type: kernel support matrix
 steps:
   - label: "Correctness tests for MLA"
     key: "MLA_CorrectnessTest"

--- a/.buildkite/features/MoE.yml
+++ b/.buildkite/features/MoE.yml
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# MoE
-# kernel support matrix
+# pipeline-name: MoE
+# pipeline-type: kernel support matrix
 steps:
   - label: "Correctness tests for MoE"
     key: "MoE_CorrectnessTest"

--- a/.buildkite/features/Multimodal_Inputs.yml
+++ b/.buildkite/features/Multimodal_Inputs.yml
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Multimodal Inputs
-# feature support matrix
+# pipeline-name: Multimodal Inputs
+# pipeline-type: feature support matrix
 steps:
   - label: "Correctness tests for Multimodal Inputs"
     key: "Multimodal_Inputs_CorrectnessTest"

--- a/.buildkite/features/Out_Of_Tree_Model_Support.yml
+++ b/.buildkite/features/Out_Of_Tree_Model_Support.yml
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Out-of-tree model support
-# feature support matrix
+# pipeline-name: Out-of-tree model support
+# pipeline-type: feature support matrix
 steps:
   - label: "Correctness tests for Out-of-tree model support"
     key: "out_of_tree_model_support_CorrectnessTest"

--- a/.buildkite/features/Quantized_Attention.yml
+++ b/.buildkite/features/Quantized_Attention.yml
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Quantized Attention
-# kernel support matrix
+# pipeline-name: Quantized Attention
+# pipeline-type: kernel support matrix
 steps:
   - label: "Correctness tests for Quantized Attention"
     key: "Quantized_Attention_CorrectnessTest"

--- a/.buildkite/features/Quantized_KV_Cache.yml
+++ b/.buildkite/features/Quantized_KV_Cache.yml
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Quantized KV Cache
-# kernel support matrix
+# pipeline-name: Quantized KV Cache
+# pipeline-type: kernel support matrix
 steps:
   - label: "Correctness tests for Quantized KV Cache"
     key: "Quantized_KV_Cache_CorrectnessTest"

--- a/.buildkite/features/Quantized_Matmul.yml
+++ b/.buildkite/features/Quantized_Matmul.yml
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Quantized Matmul
-# kernel support matrix
+# pipeline-name: Quantized Matmul
+# pipeline-type: kernel support matrix
 steps:
   - label: "Correctness tests for Quantized Matmul"
     key: "Quantized_Matmul_CorrectnessTest"

--- a/.buildkite/features/Single-Host-P-D-disaggregation.yml
+++ b/.buildkite/features/Single-Host-P-D-disaggregation.yml
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Single-Host-P-D-disaggregation
-# features support matrix
+# pipeline-name: Single-Host-P-D-disaggregation
+# pipeline-type: features support matrix
 steps:
   - label: "Correctness tests for Single-Host P-D disaggregation"
     key: "SingleHostPDDisaggregation_CorrectnessTest"

--- a/.buildkite/features/Speculative_Decoding-_Eagle3.yml
+++ b/.buildkite/features/Speculative_Decoding-_Eagle3.yml
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Speculative Decoding: Eagle3
-# feature support matrix
+# pipeline-name: Speculative Decoding: Eagle3
+# pipeline-type: feature support matrix
 steps:
   - label: "Correctness tests for Speculative Decoding: Eagle3"
     key: "Speculative_Decoding-_Eagle3_CorrectnessTest"

--- a/.buildkite/features/Speculative_Decoding-_Ngram.yml
+++ b/.buildkite/features/Speculative_Decoding-_Ngram.yml
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Speculative Decoding: Ngram
-# feature support matrix
+# pipeline-name: Speculative Decoding: Ngram
+# pipeline-type: feature support matrix
 steps:
   - label: "Correctness tests for Speculative Decoding: Ngram"
     key: "Speculative_Decoding-_Ngram_CorrectnessTest"

--- a/.buildkite/features/Structured_Decoding.yml
+++ b/.buildkite/features/Structured_Decoding.yml
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# structured_decoding
+# pipeline-name: structured_decoding
+# pipeline-type: feature support matrix
 # Structured decoding allows constraining the model's output to follow a
 # specific format, such as choosing from a predefined set of options or
 # following a JSON schema. This is useful for classification tasks,

--- a/.buildkite/features/async_scheduler.yml
+++ b/.buildkite/features/async_scheduler.yml
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# async scheduler
-# feature support matrix
+# pipeline-name: async scheduler
+# pipeline-type: feature support matrix
 steps:
   - label: "Correctness tests for async scheduler"
     key: "async_scheduler_CorrectnessTest"

--- a/.buildkite/features/data_parallelism.yml
+++ b/.buildkite/features/data_parallelism.yml
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# data_parallelism
-# feature support matrix
+# pipeline-name: data_parallelism
+# pipeline-type: feature support matrix
 steps:
   - label: "Correctness tests for data_parallelism"
     key: "data_parallelism_CorrectnessTest"

--- a/.buildkite/features/runai_model_streamer_loader.yml
+++ b/.buildkite/features/runai_model_streamer_loader.yml
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# runai_model_streamer_loader
+# pipeline-name: runai_model_streamer_loader
+# pipeline-type: feature support matrix
 # The RunAI Model Streamer is a high-performance model loader that serves as an
 # alternative to the default Hugging Face loader. Instead of downloading a model
 # to local disk, it streams the weights from object storage (like GCS) into

--- a/.buildkite/features/sampling_params.yml
+++ b/.buildkite/features/sampling_params.yml
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# sampling_params
+# pipeline-name: sampling_params
+# pipeline-type: feature support matrix
 # Sampling parameters control how the model selects tokens during generation.
 # These tests verify that temperature, top_p, top_k, and logprobs work correctly.
 steps:

--- a/.buildkite/models/Qwen_Qwen2_5-VL-7B-Instruct.yml
+++ b/.buildkite/models/Qwen_Qwen2_5-VL-7B-Instruct.yml
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Qwen/Qwen2.5-VL-7B-Instruct
-# multimodal
+# pipeline-name: Qwen/Qwen2.5-VL-7B-Instruct
+# pipeline-type: multimodal
 steps:
   - label: "Unit tests for Qwen/Qwen2.5-VL-7B-Instruct"
     key: "Qwen_Qwen2_5-VL-7B-Instruct_UnitTest"

--- a/.buildkite/models/Qwen_Qwen3-30B-A3B.yml
+++ b/.buildkite/models/Qwen_Qwen3-30B-A3B.yml
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Qwen/Qwen3-30B-A3B
-# text-only
+# pipeline-name: Qwen/Qwen3-30B-A3B
+# pipeline-type: text-only
 steps:
   - label: "Unit tests for Qwen/Qwen3-30B-A3B"
     key: "Qwen_Qwen3-30B-A3B_UnitTest"

--- a/.buildkite/models/Qwen_Qwen3-32B.yml
+++ b/.buildkite/models/Qwen_Qwen3-32B.yml
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Qwen/Qwen3-32B
-# text-only
+# pipeline-name: Qwen/Qwen3-32B
+# pipeline-type: text-only
 steps:
   - label: "Unit tests for Qwen/Qwen3-32B"
     key: "Qwen_Qwen3-32B_UnitTest"

--- a/.buildkite/models/Qwen_Qwen3-4B.yml
+++ b/.buildkite/models/Qwen_Qwen3-4B.yml
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Qwen/Qwen3-4B
-# text-only
+# pipeline-name: Qwen/Qwen3-4B
+# pipeline-type: text-only
 steps:
   - label: "Unit tests for Qwen/Qwen3-4B"
     key: "Qwen_Qwen3-4B_UnitTest"

--- a/.buildkite/models/Qwen_Qwen3-Coder-480B-A35B-Instruct.yml
+++ b/.buildkite/models/Qwen_Qwen3-Coder-480B-A35B-Instruct.yml
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Qwen/Qwen3-Coder-480B-A35B-Instruct
-# text-only
+# pipeline-name: Qwen/Qwen3-Coder-480B-A35B-Instruct
+# pipeline-type: text-only
 steps:
   - label: "Unit tests for Qwen/Qwen3-Coder-480B-A35B-Instruct"
     key: "Qwen_Qwen3-Coder-480B-A35B-Instruct_UnitTest"

--- a/.buildkite/models/Qwen_Qwen3-Omni-30B-A3B-Instruct.yml
+++ b/.buildkite/models/Qwen_Qwen3-Omni-30B-A3B-Instruct.yml
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Qwen/Qwen3-Omni-30B-A3B-Instruct
-# multimodal
+# pipeline-name: Qwen/Qwen3-Omni-30B-A3B-Instruct
+# pipeline-type: multimodal
 steps:
   - label: "Unit tests for Qwen/Qwen3-Omni-30B-A3B-Instruct"
     key: "Qwen_Qwen3-Omni-30B-A3B-Instruct_UnitTest"

--- a/.buildkite/models/deepseek-ai_DeepSeek-V3.1.yml
+++ b/.buildkite/models/deepseek-ai_DeepSeek-V3.1.yml
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# deepseek-ai/DeepSeek-V3.1
-# text-only
+# pipeline-name: deepseek-ai/DeepSeek-V3.1
+# pipeline-type: text-only
 steps:
   - label: "Unit tests for deepseek-ai/DeepSeek-V3.1"
     key: "deepseek-ai_DeepSeek-V3_1_UnitTest"

--- a/.buildkite/models/google_gemma-3-27b-it.yml
+++ b/.buildkite/models/google_gemma-3-27b-it.yml
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# google/gemma-3-27b-it
-# text-only
+# pipeline-name: google/gemma-3-27b-it
+# pipeline-type: text-only
 steps:
   - label: "Unit tests for google/gemma-3-27b-it"
     key: "google_gemma-3-27b-it_UnitTest"

--- a/.buildkite/models/meta-llama_Llama-3_1-8B-Instruct.yml
+++ b/.buildkite/models/meta-llama_Llama-3_1-8B-Instruct.yml
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# meta-llama/Llama-3.1-8B-Instruct
-# text-only
+# pipeline-name: meta-llama/Llama-3.1-8B-Instruct
+# pipeline-type: text-only
 steps:
   - label: "Unit tests for meta-llama/Llama-3.1-8B-Instruct"
     key: "meta-llama_Llama-3_1-8B-Instruct_UnitTest"

--- a/.buildkite/models/meta-llama_Llama-3_3-70B-Instruct.yml
+++ b/.buildkite/models/meta-llama_Llama-3_3-70B-Instruct.yml
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# meta-llama/Llama-3.3-70B-Instruct
-# text-only
+# pipeline-name: meta-llama/Llama-3.3-70B-Instruct
+# pipeline-type: text-only
 steps:
   - label: "Unit tests for meta-llama/Llama-3.3-70B-Instruct"
     key: "meta-llama_Llama-3_3-70B-Instruct_UnitTest"

--- a/.buildkite/models/meta-llama_Llama-4-Maverick-17B-128E-Instruct.yml
+++ b/.buildkite/models/meta-llama_Llama-4-Maverick-17B-128E-Instruct.yml
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# meta-llama/Llama-4-Maverick-17B-128E-Instruct
-# multimodal
+# pipeline-name: meta-llama/Llama-4-Maverick-17B-128E-Instruct
+# pipeline-type: multimodal
 steps:
   - label: "Unit tests for meta-llama/Llama-4-Maverick-17B-128E-Instruct"
     key: "meta-llama_Llama-4-Maverick-17B-128E-Instruct_UnitTest"

--- a/.buildkite/models/meta-llama_Llama-Guard-4-12B.yml
+++ b/.buildkite/models/meta-llama_Llama-Guard-4-12B.yml
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# meta-llama/Llama-Guard-4-12B
+# pipeline-name: meta-llama/Llama-Guard-4-12B
+# pipeline-type: text-only
 steps:
   - label: "Unit tests for meta-llama/Llama-Guard-4-12B"
     key: "meta-llama_Llama-Guard-4-12B_UnitTest"

--- a/.buildkite/models/moonshotai_Kimi-K2-Thinking.yml
+++ b/.buildkite/models/moonshotai_Kimi-K2-Thinking.yml
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# moonshotai/Kimi-K2-Thinking
-# text-only
+# pipeline-name: moonshotai/Kimi-K2-Thinking
+# pipeline-type: text-only
 steps:
   - label: "Unit tests for moonshotai/Kimi-K2-Thinking"
     key: "moonshotai_Kimi-K2-Thinking_UnitTest"

--- a/.buildkite/models/openai_gpt-oss-120b.yml
+++ b/.buildkite/models/openai_gpt-oss-120b.yml
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# openai/gpt-oss-120b
-# text-only
+# pipeline-name: openai/gpt-oss-120b
+# pipeline-type: text-only
 steps:
   - label: "Unit tests for openai/gpt-oss-120b"
     key: "openai_gpt-oss-120b_UnitTest"

--- a/.buildkite/parallelism/CP.yml
+++ b/.buildkite/parallelism/CP.yml
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# CP
-# parallelism support matrix
+# pipeline-name: CP
+# pipeline-type: parallelism support matrix
 steps:
   - label: "Correctness tests for CP"
     key: "CP_CorrectnessTest"

--- a/.buildkite/parallelism/DP.yml
+++ b/.buildkite/parallelism/DP.yml
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# DP
-# parallelism support matrix
+# pipeline-name: DP
+# pipeline-type: parallelism support matrix
 steps:
   - label: "Correctness tests for DP"
     key: "DP_CorrectnessTest"

--- a/.buildkite/parallelism/EP.yml
+++ b/.buildkite/parallelism/EP.yml
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# EP
-# parallelism support matrix
+# pipeline-name: EP
+# pipeline-type: parallelism support matrix
 steps:
   - label: "Correctness tests for EP"
     key: "EP_CorrectnessTest"

--- a/.buildkite/parallelism/PP.yml
+++ b/.buildkite/parallelism/PP.yml
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# PP
-# parallelism support matrix
+# pipeline-name: PP
+# pipeline-type: parallelism support matrix
 steps:
   - label: "Correctness tests for PP"
     key: "PP_CorrectnessTest"

--- a/.buildkite/parallelism/SP.yml
+++ b/.buildkite/parallelism/SP.yml
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# SP
-# parallelism support matrix
+# pipeline-name: SP
+# pipeline-type: parallelism support matrix
 steps:
   - label: "Correctness tests for SP"
     key: "SP_CorrectnessTest"

--- a/.buildkite/parallelism/TP.yml
+++ b/.buildkite/parallelism/TP.yml
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# TP
-# parallelism support matrix
+# pipeline-name: TP
+# pipeline-type: parallelism support matrix
 steps:
   - label: "Correctness tests for TP"
     key: "TP_CorrectnessTest"

--- a/.buildkite/pipeline_generation/feature_template.yml
+++ b/.buildkite/pipeline_generation/feature_template.yml
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# {FEATURE_NAME}
-# {CATEGORY}
+# pipeline-name: {FEATURE_NAME}
+# pipeline-type: {CATEGORY}
 steps:
   - label: "Correctness tests for {FEATURE_NAME}"
     key: "{SANITIZED_FEATURE_NAME}_CorrectnessTest"

--- a/.buildkite/pipeline_generation/tpu_optimized_model_template.yml
+++ b/.buildkite/pipeline_generation/tpu_optimized_model_template.yml
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# {MODEL_NAME}
-# {CATEGORY}
+# pipeline-name: {MODEL_NAME}
+# pipeline-type: {CATEGORY}
 steps:
   - label: "Unit tests for {MODEL_NAME}"
     key: "{SANITIZED_MODEL_NAME}_UnitTest"

--- a/.buildkite/pipeline_generation/vllm_native_model_template.yml
+++ b/.buildkite/pipeline_generation/vllm_native_model_template.yml
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# {MODEL_NAME}
-# {CATEGORY}
+# pipeline-name: {MODEL_NAME}
+# pipeline-type: {CATEGORY}
 steps:
   - label: "Unit tests for {MODEL_NAME}"
     key: "{SANITIZED_MODEL_NAME}_UnitTest"

--- a/.buildkite/quantization/AWQ_INT4.yml
+++ b/.buildkite/quantization/AWQ_INT4.yml
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# AWQ INT4
-# quantization support matrix
+# pipeline-name: AWQ INT4
+# pipeline-type: quantization support matrix
 steps:
   - label: "Correctness tests for AWQ INT4"
     key: "AWQ_INT4_CorrectnessTest"

--- a/.buildkite/quantization/FP4_W4A16.yml
+++ b/.buildkite/quantization/FP4_W4A16.yml
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# FP4 W4A16
-# quantization support matrix
+# pipeline-name: FP4 W4A16
+# pipeline-type: quantization support matrix
 steps:
   - label: "Correctness tests for FP4 W4A16"
     key: "FP4_W4A16_CorrectnessTest"

--- a/.buildkite/quantization/FP8_W8A16.yml
+++ b/.buildkite/quantization/FP8_W8A16.yml
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# FP8 W8A16
-# quantization support matrix
+# pipeline-name: FP8 W8A16
+# pipeline-type: quantization support matrix
 steps:
   - label: "Correctness tests for FP8 W8A16"
     key: "FP8_W8A16_CorrectnessTest"

--- a/.buildkite/quantization/FP8_W8A8.yml
+++ b/.buildkite/quantization/FP8_W8A8.yml
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# FP8 W8A8
-# quantization support matrix
+# pipeline-name: FP8 W8A8
+# pipeline-type: quantization support matrix
 steps:
   - label: "Correctness tests for FP8 W8A8"
     key: "FP8_W8A8_CorrectnessTest"

--- a/.buildkite/quantization/INT4_W4A16.yml
+++ b/.buildkite/quantization/INT4_W4A16.yml
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# INT4 W4A16
-# quantization support matrix
+# pipeline-name: INT4 W4A16
+# pipeline-type: quantization support matrix
 steps:
   - label: "Correctness tests for INT4 W4A16"
     key: "INT4_W4A16_CorrectnessTest"

--- a/.buildkite/quantization/INT8_W8A8.yml
+++ b/.buildkite/quantization/INT8_W8A8.yml
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# INT8 W8A8
-# quantization support matrix
+# pipeline-name: INT8 W8A8
+# pipeline-type: quantization support matrix
 steps:
   - label: "Correctness tests for INT8 W8A8"
     key: "INT8_W8A8_CorrectnessTest"

--- a/.buildkite/scripts/upload_models_and_features.sh
+++ b/.buildkite/scripts/upload_models_and_features.sh
@@ -27,8 +27,7 @@ declare -a feature_list
 
 
 for folder_path in $TARGET_FOLDERS; do
-  folder=$BUILDKITE_DIR/$folder_path
-  # Check if the folder exists
+  folder="$BUILDKITE_DIR/$folder_path"
   if [[ ! -d "$folder" ]]; then
     echo "Warning: Folder '$folder' not found. Skipping."
     continue
@@ -41,24 +40,21 @@ for folder_path in $TARGET_FOLDERS; do
   while IFS= read -r -d '' yml_file; do
     echo "--- handling yml file: ${yml_file}"
 
-    # Get model name or feature name from first line of yml config
-    first_line=$(awk 'NR==1{print $0; exit}' "${yml_file}")
-    # Check if the first line contains the '# ' comment marker
-    if [[ "$first_line" == "# "* ]]; then
-      subject_name=${first_line#\# }
+    # Targeted Extraction: Find the line starting with '# pipeline-name:'
+    subject_name_line=$(awk '/^# ?pipeline-name:/ {print $0; exit}' "${yml_file}")
+
+    if [[ -n "$subject_name_line" ]]; then
+      # Extract value: Remove everything up to and including the colon and optional space
+      subject_name="${subject_name_line#*:[[:space:]]}"
+      # Trim trailing whitespace/carriage returns
+      subject_name="${subject_name%"${subject_name##*[![:space:]]}"}"
 
       case "$folder_path" in
         "models")
-          model_list+=("${subject_name}")
+          model_list+=("$subject_name")
           ;;
-        "features")
-          feature_list+=("${subject_name}")
-          ;;
-        "parallelism")
-          feature_list+=("${subject_name}")
-          ;;
-        "quantization")
-          feature_list+=("${subject_name}")
+        "features"|"parallelism"|"quantization")
+          feature_list+=("$subject_name")
           ;;
       esac
     fi


### PR DESCRIPTION
# Description

This PR fixes a bug in the dynamic pipeline generation script where the metadata parser was incorrectly capturing the Google LLC License Header instead of the actual subject name.

# Tests

[Buildkite](https://buildkite.com/tpu-commons/tpu-inference-ci/builds/7325/steps/canvas?sid=019b4442-a01a-4678-aec2-45af4158d3f4)

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
