### PR TITLE
Add RunAI model streamer support for custom weight loading models

### DIFF
--- a/.buildkite/features/runai_model_streamer_loader.yml
+++ b/.buildkite/features/runai_model_streamer_loader.yml
@@ -39,3 +39,34 @@ steps:
     commands:
       - |
         .buildkite/scripts/record_step_result.sh runai_model_streamer_loader_CorrectnessTest
+ - label: "Record correctness test result for runai_model_streamer_loader"
+    key: "record_runai_model_streamer_loader_CorrectnessTest"
+    depends_on: "runai_model_streamer_loader_CorrectnessTest"
+    env:
+      CI_TARGET: "runai_model_streamer_loader"
+      CI_STAGE: "CorrectnessTest"
+      CI_CATEGORY: "feature support matrix"
+    agents:
+      queue: cpu
+    commands:
+      - |
+        .buildkite/scripts/record_step_result.sh runai_model_streamer_loader_CorrectnessTest
+  - label: "Correctness tests for runai_model_streamer_loader with codegemma"
+    key: "runai_model_streamer_loader_CorrectnessTest_codegemma"
+    soft_fail: true
+    agents:
+      queue: tpu_v6e_queue
+    commands:
+      - .buildkite/scripts/run_in_docker.sh python3 -m pytest -s -v /workspace/tpu_inference/tests/e2e/test_runai_model_streamer_loader.py::test_correctness_codegemma
+  - label: "Record correctness test result for runai_model_streamer_loader with codegemma"
+    key: "record_runai_model_streamer_loader_CorrectnessTest_codegemma"
+    depends_on: "runai_model_streamer_loader_CorrectnessTest_codegemma"
+    env:
+      CI_TARGET: "runai_model_streamer_loader"
+      CI_STAGE: "CorrectnessTest"
+      CI_CATEGORY: "feature support matrix"
+    agents:
+      queue: cpu
+    commands:
+      - |
+        .buildkite/scripts/record_step_result.sh runai_model_streamer_loader_CorrectnessTest_codegemma

--- a/tests/models/jax/test_llama4.py
+++ b/tests/models/jax/test_llama4.py
@@ -153,16 +153,19 @@ class TestLlama4ForCausalLM:
 
             assert jnp.all(final_norm_scale == 1.0)
 
-    @patch("tpu_inference.models.jax.llama4.Llama4WeightLoader")
-    def test_load_weights_called_correctly(self, mock_loader_cls, rng, mesh):
+    def test_load_weights_called_correctly(self, rng, mesh):
         """Tests that the weight loader is called correctly for checkpoint loading."""
         vllm_config = MockVllmConfig(model_name="llama4-scout",
                                      random_weights=False)
         model = Llama4ForCausalLM(vllm_config, rng, mesh)
 
-        mock_loader_instance = MagicMock()
-        mock_loader_cls.return_value = mock_loader_instance
-        model.load_weights(rng)
+        # Patch the WeightLoader attribute specifically on the class
+        with patch.object(Llama4ForCausalLM,
+                          'WeightLoader') as mock_loader_cls:
+            mock_loader_instance = MagicMock()
+            mock_loader_cls.return_value = mock_loader_instance
+
+            model.load_weights(rng)
 
         mock_loader_cls.assert_called_once_with(vllm_config=vllm_config,
                                                 hidden_size=32,

--- a/tests/models/jax/test_llama_guard_4.py
+++ b/tests/models/jax/test_llama_guard_4.py
@@ -160,23 +160,24 @@ class TestLlamaGuard4ForCausalLM:
 
             assert jnp.all(final_norm_scale == 1.0)
 
-    @patch("tpu_inference.models.jax.llama_guard_4.LlamaGuard4WeightLoader")
-    def test_load_weights_called_correctly(self, mock_loader_cls, rng, mesh):
+    def test_load_weights_called_correctly(self, rng, mesh):
         """Tests that the weight loader is called correctly for checkpoint loading."""
         vllm_config = MockVllmConfig(model_name="llama-guard-4-test",
                                      random_weights=False)
         model = LlamaGuard4ForCausalLM(vllm_config, rng, mesh)
 
-        mock_loader_instance = MagicMock()
-        mock_loader_cls.return_value = mock_loader_instance
-        model.load_weights(rng)
+        with patch.object(LlamaGuard4ForCausalLM,
+                          'WeightLoader') as mock_loader_cls:
+            mock_loader_instance = MagicMock()
+            mock_loader_cls.return_value = mock_loader_instance
+            model.load_weights(rng)
 
-        mock_loader_cls.assert_called_once_with(vllm_config=vllm_config,
-                                                hidden_size=128,
-                                                attn_heads=4,
-                                                num_key_value_heads=2,
-                                                attn_head_dim=32)
-        mock_loader_instance.load_weights.assert_called_once_with(model)
+            mock_loader_cls.assert_called_once_with(vllm_config=vllm_config,
+                                                    hidden_size=128,
+                                                    attn_heads=4,
+                                                    num_key_value_heads=2,
+                                                    attn_head_dim=32)
+            mock_loader_instance.load_weights.assert_called_once_with(model)
 
 
 class TestLlamaGuard4WeightLoader:

--- a/tests/models/jax/test_qwen2_5_vl.py
+++ b/tests/models/jax/test_qwen2_5_vl.py
@@ -573,7 +573,7 @@ class TestQwen2_5_VLForConditionalGeneration:
         model.language_model.compute_logits.assert_called_once_with(
             hidden_states)
 
-    @patch('tpu_inference.models.jax.qwen2_5_vl.load_hf_weights')
+    @patch("tpu_inference.models.jax.utils.weight_utils.load_hf_weights")
     def test_load_weights(self, mock_load_weights: MagicMock,
                           model: Qwen2_5_VLForConditionalGeneration,
                           mock_vllm_config: MockVllmConfig, rng: PRNGKey,
@@ -590,7 +590,7 @@ class TestQwen2_5_VLForConditionalGeneration:
         assert isinstance(model.rng, nnx.Rngs)
         assert model.language_model.rng is model.rng
 
-    @patch('tpu_inference.models.jax.qwen2_5_vl.load_hf_weights')
+    @patch("tpu_inference.models.jax.utils.weight_utils.load_hf_weights")
     def test_load_weights_tied(self, mock_load_weights: MagicMock,
                                rng: PRNGKey, mesh: Mesh):
         mock_vllm_config_tied = MockVllmConfig(tie_word_embeddings=True)

--- a/tpu_inference/models/jax/deepseek_v3.py
+++ b/tpu_inference/models/jax/deepseek_v3.py
@@ -40,8 +40,9 @@ from tpu_inference.layers.jax.moe.moe import MoE
 from tpu_inference.layers.jax.transformer_block import (
     SharedExpertsTransformerBlock, TransformerBlock)
 from tpu_inference.logger import init_logger
-from tpu_inference.models.jax.utils.weight_utils import (
-    get_param, model_weights_generator, print_param_info)
+from tpu_inference.models.jax.utils.weight_utils import (BaseWeightLoader,
+                                                         get_param,
+                                                         print_param_info)
 
 logger = init_logger(__name__)
 
@@ -54,354 +55,7 @@ DTYPE_VIEW_MAP = {
 
 
 @dataclass
-class DeepSeekV3(nnx.Module):
-
-    def __init__(self,
-                 vllm_config: VllmConfig,
-                 rng: jax.Array,
-                 mesh: Mesh,
-                 force_random_weights: bool = False):
-        assert mesh is not None
-
-        self.vllm_config = vllm_config
-        self.rng = nnx.Rngs(rng)
-
-        # NOTE: the default is 61
-        num_layers: int = vllm_config.model_config.hf_config.num_hidden_layers
-        num_local_experts: int = 256
-
-        vocab_size: int = 129280
-        hidden_size: int = 7168
-        # NOTE: this dtype may be implicitly overriden if using to Qwix to load in the quantized weights
-        dtype: jnp.dtype = jnp.bfloat16
-        num_attention_heads: int = 128
-        num_key_value_heads: int = 128
-        ffw_intermediate_size: int = 18432
-        moe_intermediate_size: int = 2048
-        num_experts_per_token: int = 8
-        n_group: int = 8
-        interleave_moe_layer_step: int = 1  # Deepseek V3 has moe_layer_freq=1 in hf config.
-        hidden_act: str = "silu"
-        rms_norm_eps: float = 1e-06
-        first_k_dense_replace: int = 3  # replace the first few MOE layers to dense layer.
-        self.use_mla_kernel: bool = self.vllm_config.model_config.use_mla
-
-        logger.info(f"Is using MLA kernel in DeepSeek: {self.use_mla_kernel}")
-
-        num_shared_experts = 1
-        rope_theta = 10000
-        rope_scaling = {
-            "beta_fast": 32,
-            "beta_slow": 1,
-            "factor": 40,
-            "mscale": 1.0,
-            "mscale_all_dim": 1.0,
-            "original_max_position_embeddings": 4096,
-            "type": "yarn"
-        }
-        q_lora_rank = 1536
-        kv_lora_rank = 512
-        qk_nope_head_dim = 128
-        qk_rope_head_dim = 64
-        v_head_dim = 128
-
-        self.random_init = force_random_weights or self.vllm_config.additional_config.get(
-            "random_weights", False)
-        self.sparse_matmul = self.vllm_config.additional_config.get(
-            "sparse_matmul", False)
-
-        if isinstance(self.sparse_matmul, str):
-            self.sparse_matmul = self.sparse_matmul.lower() == "true"
-        else:
-            self.sparse_matmul = bool(self.sparse_matmul)
-
-        if self.sparse_matmul:
-            logger.info("sparse matmul is enabled")
-        else:
-            logger.info("sparse matmul is disabled, using dense matmul")
-        self.mesh = mesh
-
-        self.weight_loader = DeepSeekV3WeightLoader(
-            vllm_config=vllm_config,
-            num_layers=num_layers,
-            hidden_size=hidden_size,
-            q_lora_rank=q_lora_rank,
-            kv_lora_rank=kv_lora_rank,
-            attn_heads=num_attention_heads,
-            qk_nope_head_dim=qk_nope_head_dim,
-            qk_rope_head_dim=qk_rope_head_dim,
-            v_head_dim=v_head_dim,
-            num_local_experts=num_local_experts,
-            model_dtype=dtype,
-            use_mla_kernel=self.use_mla_kernel)
-
-        self.embedder = Embedder(vocab_size=vocab_size,
-                                 hidden_size=hidden_size,
-                                 dtype=dtype,
-                                 rngs=self.rng,
-                                 vd_sharding=(ShardingAxisName.MLP_TENSOR,
-                                              None),
-                                 random_init=self.random_init)
-
-        self.layers = []
-
-        def _create_mla() -> MLA:
-            if self.use_mla_kernel:
-                query_tnh_spec = P(ShardingAxisName.MLP_TENSOR, None, None)
-                keyvalue_skh_spec = P(ShardingAxisName.MLP_TENSOR, None)
-                attn_o_tnh_spec = P(ShardingAxisName.MLP_TENSOR, None, None)
-
-            else:
-                query_tnh_spec = P(None, ShardingAxisName.MLP_TENSOR, None)
-                keyvalue_skh_spec = P(None, ShardingAxisName.MLP_TENSOR, None)
-                attn_o_tnh_spec = P(None, ShardingAxisName.MLP_TENSOR, None)
-
-            return MLA(
-                rope_theta=rope_theta,
-                rope_scaling=rope_scaling,
-                q_lora_rank=q_lora_rank,
-                kv_lora_rank=kv_lora_rank,
-                qk_nope_head_dim=qk_nope_head_dim,
-                qk_rope_head_dim=qk_rope_head_dim,
-                rms_norm_eps=rms_norm_eps,
-                v_head_dim=v_head_dim,
-                mesh=self.mesh,
-                use_mla_kernel=self.use_mla_kernel,
-                random_init=self.random_init,
-                hidden_size=hidden_size,
-                num_attention_heads=num_attention_heads,
-                num_key_value_heads=1
-                if self.use_mla_kernel else num_key_value_heads,
-                head_dim=v_head_dim,  # MLA uses v_head_dim as head_dim
-                dtype=dtype,
-                # TODO (jacobplatin): we should refactor this to pass a dtype (or config) directly
-                kv_cache_dtype=vllm_config.cache_config.cache_dtype,
-                rngs=self.rng,
-                activation_attention_td=(None, None),
-                activation_q_td=(None, None),
-                query_tnh=query_tnh_spec,
-                keyvalue_skh=keyvalue_skh_spec,
-                activation_attention_out_td=(None, None),
-                attn_o_tnh=attn_o_tnh_spec,
-                q_da_sharding=(None, ShardingAxisName.VOCAB),
-                ap_sharding=(None, ShardingAxisName.MLP_TENSOR),
-                anh_sharding=(None, ShardingAxisName.MLP_TENSOR, None),
-                kv_da_sharding=(None, ShardingAxisName.VOCAB),
-                rd_sharding=(ShardingAxisName.MLP_TENSOR, None))
-
-        for i in range(first_k_dense_replace):
-            block = TransformerBlock(
-                pre_attention_norm=RMSNorm(
-                    dims=hidden_size,
-                    random_init=self.random_init,
-                    epsilon=rms_norm_eps,
-                    with_scale=True,
-                    dtype=dtype,
-                    rngs=self.rng,
-                ),
-                pre_mlp_norm=RMSNorm(
-                    dims=hidden_size,
-                    random_init=self.random_init,
-                    epsilon=rms_norm_eps,
-                    with_scale=True,
-                    dtype=dtype,
-                    rngs=self.rng,
-                ),
-                attn=_create_mla(),
-                custom_module=DenseFFW(
-                    dtype=dtype,
-                    hidden_act=hidden_act,
-                    hidden_size=hidden_size,
-                    intermediate_size=ffw_intermediate_size,
-                    rngs=self.rng,
-                    df_sharding=(None, ShardingAxisName.MLP_TENSOR),
-                    fd_sharding=(ShardingAxisName.MLP_TENSOR, None),
-                    random_init=self.random_init))
-
-            self.layers.append(block)
-
-        for i in range(first_k_dense_replace, num_layers):
-            is_moe_layer = ((i + 1) % interleave_moe_layer_step == 0)
-            router = DeepSeekV3Router(
-                random_init=self.random_init,
-                hidden_size=hidden_size,
-                num_experts=num_local_experts,
-                num_experts_per_tok=num_experts_per_token,
-                n_groups=n_group,
-                topk_groups=4,
-                norm_topk_prob=True,
-                rngs=self.rng,
-                routed_scaling_factor=2.5,
-                dtype=dtype,
-                activation_ffw_td=(ShardingAxisName.MLP_DATA, None),
-                ed_sharding=(ShardingAxisName.MLP_TENSOR, None),
-                e_sharding=(ShardingAxisName.MLP_TENSOR, ))
-            if self.sparse_matmul:
-                # TODO: orginize the SparseMoE and DenseMoE better given they share most interfaces
-                custom_module = SparseMoE(
-                    dtype=dtype,
-                    num_local_experts=num_local_experts,
-                    apply_expert_weight_before_computation=False,
-                    hidden_size=hidden_size,
-                    intermediate_size_moe=moe_intermediate_size,
-                    num_experts_per_tok=num_experts_per_token,
-                    mesh=self.mesh,
-                    hidden_act=hidden_act,
-                    rngs=self.rng,
-                    random_init=self.random_init,
-                    activation_ffw_td=(ShardingAxisName.MLP_TENSOR, None),
-                    activation_ffw_ted=(ShardingAxisName.MLP_DATA, None, None),
-                    edf_sharding=(ShardingAxisName.MLP_TENSOR, None, None),
-                    efd_sharding=(ShardingAxisName.MLP_TENSOR, None, None),
-                    quantized_dtype=self.weight_loader.quant_dtype
-                    if self.weight_loader.is_model_quantized else None,
-                    router=router) if is_moe_layer else DenseFFW(
-                        dtype=dtype,
-                        hidden_act=hidden_act,
-                        hidden_size=hidden_size,
-                        intermediate_size=ffw_intermediate_size,
-                        rngs=self.rng,
-                        random_init=self.random_init,
-                        df_sharding=(None, ShardingAxisName.MLP_TENSOR),
-                        fd_sharding=(ShardingAxisName.MLP_TENSOR, None))
-            else:
-                custom_module = MoE(
-                    dtype=dtype,
-                    num_local_experts=num_local_experts,
-                    apply_expert_weight_before_computation=False,
-                    hidden_size=hidden_size,
-                    intermediate_size_moe=moe_intermediate_size,
-                    hidden_act=hidden_act,
-                    rngs=self.rng,
-                    random_init=self.random_init,
-                    activation_ffw_td=(ShardingAxisName.MLP_DATA, None),
-                    activation_ffw_ted=(ShardingAxisName.MLP_DATA, None, None),
-                    edf_sharding=(ShardingAxisName.MLP_TENSOR, None, None),
-                    efd_sharding=(ShardingAxisName.MLP_TENSOR, None, None),
-                    router=router) if is_moe_layer else DenseFFW(
-                        dtype=dtype,
-                        hidden_act=hidden_act,
-                        hidden_size=hidden_size,
-                        intermediate_size=ffw_intermediate_size,
-                        rngs=self.rng,
-                        random_init=self.random_init,
-                        df_sharding=(None, ShardingAxisName.MLP_TENSOR),
-                        fd_sharding=(ShardingAxisName.MLP_TENSOR, None))
-
-            shared_experts = DenseFFW(
-                dtype=dtype,
-                hidden_act=hidden_act,
-                hidden_size=hidden_size,
-                intermediate_size=num_shared_experts * moe_intermediate_size,
-                rngs=self.rng,
-                random_init=self.random_init,
-                df_sharding=(None, ShardingAxisName.MLP_TENSOR),
-                fd_sharding=(ShardingAxisName.MLP_TENSOR, None))
-
-            pre_attention_norm = RMSNorm(
-                dims=hidden_size,
-                rngs=self.rng,
-                random_init=self.random_init,
-                epsilon=rms_norm_eps,
-                with_scale=True,
-                dtype=dtype,
-            )
-
-            pre_mlp_norm = RMSNorm(
-                dims=hidden_size,
-                rngs=self.rng,
-                random_init=self.random_init,
-                epsilon=rms_norm_eps,
-                with_scale=True,
-                dtype=dtype,
-            )
-
-            block = SharedExpertsTransformerBlock(
-                custom_module=custom_module,
-                attn=_create_mla(),
-                pre_attention_norm=pre_attention_norm,
-                pre_mlp_norm=pre_mlp_norm,
-                shared_experts=shared_experts)
-            self.layers.append(block)
-
-        self.final_norm = RMSNorm(
-            dims=hidden_size,
-            rngs=self.rng,
-            random_init=self.random_init,
-            epsilon=rms_norm_eps,
-            with_scale=True,
-            dtype=dtype,
-        )
-
-        self.lm_head = LMhead(vocab_size=vocab_size,
-                              hidden_size=hidden_size,
-                              dtype=dtype,
-                              rngs=self.rng,
-                              vd_sharding=(ShardingAxisName.MLP_TENSOR, None),
-                              dv_sharding=(None, ShardingAxisName.MLP_TENSOR),
-                              random_init=self.random_init)
-
-        if os.environ.get("VLLM_LOGGING_LEVEL", "").upper() == "DEBUG":
-            self._print_model_architecture()
-
-    def _print_model_architecture(self):
-        num_display_layers = 5
-
-        logger.debug("### Embedding ###")
-        nnx.display(self.embedder)
-
-        logger.debug(f"\n### First {num_display_layers} Layers ###")
-        # Loop through the slice and display each layer
-        for i, layer in enumerate(self.layers[:num_display_layers]):
-            logger.debug(f"\n--- Layer {i} ---")
-            nnx.display(layer)
-
-        logger.debug("\n### LM Head ###")
-        nnx.display(self.lm_head)
-
-    # For compatibility with flax.
-    def apply(self, variables, *args, **kwargs):
-        return self.__call__(*args, **kwargs)
-
-    def load_weights(self, rng: PRNGKey, cache_dir: Optional[str] = None):
-        # NOTE: Since we are using nnx.eval_shape to init the model,
-        # we have to pass dynamic arrays here for __call__'s usage.
-        self.rng = nnx.Rngs(rng)
-        self.weight_loader.load_weights(self)
-        self.initialize_cache()
-
-    def initialize_cache(self):
-        # Initialize RoPE caches after weights are loaded and before JIT compilation.
-        for layer in self.layers:
-            if hasattr(layer, 'attn') and hasattr(layer.attn, 'rope'):
-                if hasattr(layer.attn.rope, 'initialize_cache'):
-                    layer.attn.rope.initialize_cache(self.mesh)
-
-    def __call__(
-        self,
-        kv_caches: List[jax.Array],
-        input_ids: jax.Array,
-        attention_metadata: AttentionMetadata,
-        *args,
-    ) -> Tuple[List[KVCacheType], jax.Array, List[jax.Array]]:
-        is_prefill = False
-        x = self.embedder.encode(input_ids)
-        for (i, block) in enumerate(self.layers):
-            kv_cache = kv_caches[i]
-            new_kv_cache, x = block(x, is_prefill, kv_cache,
-                                    attention_metadata)
-            kv_caches[i] = new_kv_cache
-
-        final_activation = self.final_norm(x)
-
-        return kv_caches, final_activation, []
-
-    def compute_logits(self, hidden_states: jax.Array) -> jax.Array:
-        return self.lm_head.decode(hidden_states)
-
-
-@dataclass
-class DeepSeekV3WeightLoader:
+class DeepSeekV3WeightLoader(BaseWeightLoader):
 
     def __init__(self,
                  vllm_config: VllmConfig,
@@ -416,11 +70,8 @@ class DeepSeekV3WeightLoader:
                  num_local_experts,
                  model_dtype,
                  use_mla_kernel=False):
+        super().__init__(vllm_config, framework="pt")
         self.num_layers = num_layers
-        self.names_and_weights_generator = model_weights_generator(
-            model_name_or_path=vllm_config.model_config.model,
-            framework="pt",
-            download_dir=vllm_config.load_config.download_dir)
         self.is_verbose = vllm_config.additional_config.get(
             "is_verbose", None) is not None
         self.num_routed_experts = num_local_experts
@@ -760,7 +411,7 @@ class DeepSeekV3WeightLoader:
         quantized_weights = {}
         quantized_scales = {}
         with jax.default_device(jax.devices("cpu")[0]):
-            for loaded_name, loaded_weight in self.names_and_weights_generator:
+            for loaded_name, loaded_weight in self.get_weights_iterator():
                 # Skip if the model has fewer layers than original.
                 if re.search(r"layers\.(\d+)", loaded_name):
                     layer_num = re.search(r"layers\.(\d+)",
@@ -935,6 +586,354 @@ class DeepSeekV3WeightLoader:
         del quantized_scales
         # TODO: validate that all of the model_params were accounted for as well.
         nnx.update(model_for_loading, model_params)
+
+
+@dataclass
+class DeepSeekV3(nnx.Module):
+    WeightLoader = DeepSeekV3WeightLoader
+
+    def __init__(self,
+                 vllm_config: VllmConfig,
+                 rng: jax.Array,
+                 mesh: Mesh,
+                 force_random_weights: bool = False):
+        assert mesh is not None
+
+        self.vllm_config = vllm_config
+        self.rng = nnx.Rngs(rng)
+
+        # NOTE: the default is 61
+        num_layers: int = vllm_config.model_config.hf_config.num_hidden_layers
+        num_local_experts: int = 256
+
+        vocab_size: int = 129280
+        hidden_size: int = 7168
+        # NOTE: this dtype may be implicitly overriden if using to Qwix to load in the quantized weights
+        dtype: jnp.dtype = jnp.bfloat16
+        num_attention_heads: int = 128
+        num_key_value_heads: int = 128
+        ffw_intermediate_size: int = 18432
+        moe_intermediate_size: int = 2048
+        num_experts_per_token: int = 8
+        n_group: int = 8
+        interleave_moe_layer_step: int = 1  # Deepseek V3 has moe_layer_freq=1 in hf config.
+        hidden_act: str = "silu"
+        rms_norm_eps: float = 1e-06
+        first_k_dense_replace: int = 3  # replace the first few MOE layers to dense layer.
+        self.use_mla_kernel: bool = self.vllm_config.model_config.use_mla
+
+        logger.info(f"Is using MLA kernel in DeepSeek: {self.use_mla_kernel}")
+
+        num_shared_experts = 1
+        rope_theta = 10000
+        rope_scaling = {
+            "beta_fast": 32,
+            "beta_slow": 1,
+            "factor": 40,
+            "mscale": 1.0,
+            "mscale_all_dim": 1.0,
+            "original_max_position_embeddings": 4096,
+            "type": "yarn"
+        }
+        q_lora_rank = 1536
+        kv_lora_rank = 512
+        qk_nope_head_dim = 128
+        qk_rope_head_dim = 64
+        v_head_dim = 128
+
+        self.random_init = force_random_weights or self.vllm_config.additional_config.get(
+            "random_weights", False)
+        self.sparse_matmul = self.vllm_config.additional_config.get(
+            "sparse_matmul", False)
+
+        if isinstance(self.sparse_matmul, str):
+            self.sparse_matmul = self.sparse_matmul.lower() == "true"
+        else:
+            self.sparse_matmul = bool(self.sparse_matmul)
+
+        if self.sparse_matmul:
+            logger.info("sparse matmul is enabled")
+        else:
+            logger.info("sparse matmul is disabled, using dense matmul")
+        self.mesh = mesh
+
+        self.weight_loader = self.WeightLoader(
+            vllm_config=vllm_config,
+            num_layers=num_layers,
+            hidden_size=hidden_size,
+            q_lora_rank=q_lora_rank,
+            kv_lora_rank=kv_lora_rank,
+            attn_heads=num_attention_heads,
+            qk_nope_head_dim=qk_nope_head_dim,
+            qk_rope_head_dim=qk_rope_head_dim,
+            v_head_dim=v_head_dim,
+            num_local_experts=num_local_experts,
+            model_dtype=dtype,
+            use_mla_kernel=self.use_mla_kernel)
+
+        self.embedder = Embedder(vocab_size=vocab_size,
+                                 hidden_size=hidden_size,
+                                 dtype=dtype,
+                                 rngs=self.rng,
+                                 vd_sharding=(ShardingAxisName.MLP_TENSOR,
+                                              None),
+                                 random_init=self.random_init)
+
+        self.layers = []
+
+        def _create_mla() -> MLA:
+            if self.use_mla_kernel:
+                query_tnh_spec = P(ShardingAxisName.MLP_TENSOR, None, None)
+                keyvalue_skh_spec = P(ShardingAxisName.MLP_TENSOR, None)
+                attn_o_tnh_spec = P(ShardingAxisName.MLP_TENSOR, None, None)
+
+            else:
+                query_tnh_spec = P(None, ShardingAxisName.MLP_TENSOR, None)
+                keyvalue_skh_spec = P(None, ShardingAxisName.MLP_TENSOR, None)
+                attn_o_tnh_spec = P(None, ShardingAxisName.MLP_TENSOR, None)
+
+            return MLA(
+                rope_theta=rope_theta,
+                rope_scaling=rope_scaling,
+                q_lora_rank=q_lora_rank,
+                kv_lora_rank=kv_lora_rank,
+                qk_nope_head_dim=qk_nope_head_dim,
+                qk_rope_head_dim=qk_rope_head_dim,
+                rms_norm_eps=rms_norm_eps,
+                v_head_dim=v_head_dim,
+                mesh=self.mesh,
+                use_mla_kernel=self.use_mla_kernel,
+                random_init=self.random_init,
+                hidden_size=hidden_size,
+                num_attention_heads=num_attention_heads,
+                num_key_value_heads=1
+                if self.use_mla_kernel else num_key_value_heads,
+                head_dim=v_head_dim,  # MLA uses v_head_dim as head_dim
+                dtype=dtype,
+                # TODO (jacobplatin): we should refactor this to pass a dtype (or config) directly
+                kv_cache_dtype=vllm_config.cache_config.cache_dtype,
+                rngs=self.rng,
+                activation_attention_td=(None, None),
+                activation_q_td=(None, None),
+                query_tnh=query_tnh_spec,
+                keyvalue_skh=keyvalue_skh_spec,
+                activation_attention_out_td=(None, None),
+                attn_o_tnh=attn_o_tnh_spec,
+                q_da_sharding=(None, ShardingAxisName.VOCAB),
+                ap_sharding=(None, ShardingAxisName.MLP_TENSOR),
+                anh_sharding=(None, ShardingAxisName.MLP_TENSOR, None),
+                kv_da_sharding=(None, ShardingAxisName.VOCAB),
+                rd_sharding=(ShardingAxisName.MLP_TENSOR, None))
+
+        for i in range(first_k_dense_replace):
+            block = TransformerBlock(
+                pre_attention_norm=RMSNorm(
+                    dims=hidden_size,
+                    random_init=self.random_init,
+                    epsilon=rms_norm_eps,
+                    with_scale=True,
+                    dtype=dtype,
+                    rngs=self.rng,
+                ),
+                pre_mlp_norm=RMSNorm(
+                    dims=hidden_size,
+                    random_init=self.random_init,
+                    epsilon=rms_norm_eps,
+                    with_scale=True,
+                    dtype=dtype,
+                    rngs=self.rng,
+                ),
+                attn=_create_mla(),
+                custom_module=DenseFFW(
+                    dtype=dtype,
+                    hidden_act=hidden_act,
+                    hidden_size=hidden_size,
+                    intermediate_size=ffw_intermediate_size,
+                    rngs=self.rng,
+                    df_sharding=(None, ShardingAxisName.MLP_TENSOR),
+                    fd_sharding=(ShardingAxisName.MLP_TENSOR, None),
+                    random_init=self.random_init))
+
+            self.layers.append(block)
+
+        for i in range(first_k_dense_replace, num_layers):
+            is_moe_layer = ((i + 1) % interleave_moe_layer_step == 0)
+            router = DeepSeekV3Router(
+                random_init=self.random_init,
+                hidden_size=hidden_size,
+                num_experts=num_local_experts,
+                num_experts_per_tok=num_experts_per_token,
+                n_groups=n_group,
+                topk_groups=4,
+                norm_topk_prob=True,
+                rngs=self.rng,
+                routed_scaling_factor=2.5,
+                dtype=dtype,
+                activation_ffw_td=(ShardingAxisName.MLP_DATA, None),
+                ed_sharding=(ShardingAxisName.MLP_TENSOR, None),
+                e_sharding=(ShardingAxisName.MLP_TENSOR, ))
+            if self.sparse_matmul:
+                # TODO: orginize the SparseMoE and DenseMoE better given they share most interfaces
+                custom_module = SparseMoE(
+                    dtype=dtype,
+                    num_local_experts=num_local_experts,
+                    apply_expert_weight_before_computation=False,
+                    hidden_size=hidden_size,
+                    intermediate_size_moe=moe_intermediate_size,
+                    num_experts_per_tok=num_experts_per_token,
+                    mesh=self.mesh,
+                    hidden_act=hidden_act,
+                    rngs=self.rng,
+                    random_init=self.random_init,
+                    activation_ffw_td=(ShardingAxisName.MLP_TENSOR, None),
+                    activation_ffw_ted=(ShardingAxisName.MLP_DATA, None, None),
+                    edf_sharding=(ShardingAxisName.MLP_TENSOR, None, None),
+                    efd_sharding=(ShardingAxisName.MLP_TENSOR, None, None),
+                    quantized_dtype=self.weight_loader.quant_dtype
+                    if self.weight_loader.is_model_quantized else None,
+                    router=router) if is_moe_layer else DenseFFW(
+                        dtype=dtype,
+                        hidden_act=hidden_act,
+                        hidden_size=hidden_size,
+                        intermediate_size=ffw_intermediate_size,
+                        rngs=self.rng,
+                        random_init=self.random_init,
+                        df_sharding=(None, ShardingAxisName.MLP_TENSOR),
+                        fd_sharding=(ShardingAxisName.MLP_TENSOR, None))
+            else:
+                custom_module = MoE(
+                    dtype=dtype,
+                    num_local_experts=num_local_experts,
+                    apply_expert_weight_before_computation=False,
+                    hidden_size=hidden_size,
+                    intermediate_size_moe=moe_intermediate_size,
+                    hidden_act=hidden_act,
+                    rngs=self.rng,
+                    random_init=self.random_init,
+                    activation_ffw_td=(ShardingAxisName.MLP_DATA, None),
+                    activation_ffw_ted=(ShardingAxisName.MLP_DATA, None, None),
+                    edf_sharding=(ShardingAxisName.MLP_TENSOR, None, None),
+                    efd_sharding=(ShardingAxisName.MLP_TENSOR, None, None),
+                    router=router) if is_moe_layer else DenseFFW(
+                        dtype=dtype,
+                        hidden_act=hidden_act,
+                        hidden_size=hidden_size,
+                        intermediate_size=ffw_intermediate_size,
+                        rngs=self.rng,
+                        random_init=self.random_init,
+                        df_sharding=(None, ShardingAxisName.MLP_TENSOR),
+                        fd_sharding=(ShardingAxisName.MLP_TENSOR, None))
+
+            shared_experts = DenseFFW(
+                dtype=dtype,
+                hidden_act=hidden_act,
+                hidden_size=hidden_size,
+                intermediate_size=num_shared_experts * moe_intermediate_size,
+                rngs=self.rng,
+                random_init=self.random_init,
+                df_sharding=(None, ShardingAxisName.MLP_TENSOR),
+                fd_sharding=(ShardingAxisName.MLP_TENSOR, None))
+
+            pre_attention_norm = RMSNorm(
+                dims=hidden_size,
+                rngs=self.rng,
+                random_init=self.random_init,
+                epsilon=rms_norm_eps,
+                with_scale=True,
+                dtype=dtype,
+            )
+
+            pre_mlp_norm = RMSNorm(
+                dims=hidden_size,
+                rngs=self.rng,
+                random_init=self.random_init,
+                epsilon=rms_norm_eps,
+                with_scale=True,
+                dtype=dtype,
+            )
+
+            block = SharedExpertsTransformerBlock(
+                custom_module=custom_module,
+                attn=_create_mla(),
+                pre_attention_norm=pre_attention_norm,
+                pre_mlp_norm=pre_mlp_norm,
+                shared_experts=shared_experts)
+            self.layers.append(block)
+
+        self.final_norm = RMSNorm(
+            dims=hidden_size,
+            rngs=self.rng,
+            random_init=self.random_init,
+            epsilon=rms_norm_eps,
+            with_scale=True,
+            dtype=dtype,
+        )
+
+        self.lm_head = LMhead(vocab_size=vocab_size,
+                              hidden_size=hidden_size,
+                              dtype=dtype,
+                              rngs=self.rng,
+                              vd_sharding=(ShardingAxisName.MLP_TENSOR, None),
+                              dv_sharding=(None, ShardingAxisName.MLP_TENSOR),
+                              random_init=self.random_init)
+
+        if os.environ.get("VLLM_LOGGING_LEVEL", "").upper() == "DEBUG":
+            self._print_model_architecture()
+
+    def _print_model_architecture(self):
+        num_display_layers = 5
+
+        logger.debug("### Embedding ###")
+        nnx.display(self.embedder)
+
+        logger.debug(f"\n### First {num_display_layers} Layers ###")
+        # Loop through the slice and display each layer
+        for i, layer in enumerate(self.layers[:num_display_layers]):
+            logger.debug(f"\n--- Layer {i} ---")
+            nnx.display(layer)
+
+        logger.debug("\n### LM Head ###")
+        nnx.display(self.lm_head)
+
+    # For compatibility with flax.
+    def apply(self, variables, *args, **kwargs):
+        return self.__call__(*args, **kwargs)
+
+    def load_weights(self, rng: PRNGKey, cache_dir: Optional[str] = None):
+        # NOTE: Since we are using nnx.eval_shape to init the model,
+        # we have to pass dynamic arrays here for __call__'s usage.
+        self.rng = nnx.Rngs(rng)
+        self.weight_loader.load_weights(self)
+        self.initialize_cache()
+
+    def initialize_cache(self):
+        # Initialize RoPE caches after weights are loaded and before JIT compilation.
+        for layer in self.layers:
+            if hasattr(layer, 'attn') and hasattr(layer.attn, 'rope'):
+                if hasattr(layer.attn.rope, 'initialize_cache'):
+                    layer.attn.rope.initialize_cache(self.mesh)
+
+    def __call__(
+        self,
+        kv_caches: List[jax.Array],
+        input_ids: jax.Array,
+        attention_metadata: AttentionMetadata,
+        *args,
+    ) -> Tuple[List[KVCacheType], jax.Array, List[jax.Array]]:
+        is_prefill = False
+        x = self.embedder.encode(input_ids)
+        for (i, block) in enumerate(self.layers):
+            kv_cache = kv_caches[i]
+            new_kv_cache, x = block(x, is_prefill, kv_cache,
+                                    attention_metadata)
+            kv_caches[i] = new_kv_cache
+
+        final_activation = self.final_norm(x)
+
+        return kv_caches, final_activation, []
+
+    def compute_logits(self, hidden_states: jax.Array) -> jax.Array:
+        return self.lm_head.decode(hidden_states)
 
 
 def weights_dequant_cpu(x: torch.Tensor,

--- a/tpu_inference/models/jax/qwen2.py
+++ b/tpu_inference/models/jax/qwen2.py
@@ -27,8 +27,7 @@ from tpu_inference.layers.common.attention_metadata import AttentionMetadata
 from tpu_inference.layers.common.quantization import quantize_kv
 from tpu_inference.layers.jax.rope_interface import apply_rope
 from tpu_inference.logger import init_logger
-from tpu_inference.models.jax.utils.weight_utils import (get_default_maps,
-                                                         load_hf_weights)
+from tpu_inference.models.jax.utils.weight_utils import StandardWeightLoader
 
 logger = init_logger(__name__)
 
@@ -306,6 +305,7 @@ class Qwen2Model(nnx.Module):
 
 
 class Qwen2ForCausalLM(nnx.Module):
+    WeightLoader = StandardWeightLoader
 
     def __init__(self, vllm_config: VllmConfig, rng_key: jax.Array,
                  mesh: Mesh) -> None:
@@ -383,9 +383,5 @@ class Qwen2ForCausalLM(nnx.Module):
                 "lm_head": "model.lm_head",
             })
 
-        metadata_map = get_default_maps(self.vllm_config.model_config,
-                                        self.mesh, mappings)
-        load_hf_weights(vllm_config=self.vllm_config,
-                        model=self,
-                        metadata_map=metadata_map,
-                        mesh=self.mesh)
+        loader = self.WeightLoader(self.vllm_config, self.mesh)
+        loader.load_weights(self, mappings)


### PR DESCRIPTION
# Description

This PR implements "Part 2" of the RunAI Model Streamer integration for TPU inference, expanding support to models with custom weight loading patterns and establishing a robust fallback mechanism for unsupported models.

Previously, RunAI streamer support was limited to models using the standard load_hf_weights utility. Newer models (e.g., DeepSeekV3, Llama4) introduced custom WeightLoader classes that were incompatible with the initial integration. This PR refactors the weight loading architecture to support these cases universally.

## Key changes

- Universal `BaseWeightLoader`: Introduced `BaseWeightLoader` in `weight_utils.py` to encapsulate the logic for retrieving the correct weight iterator (either the RunAI streamer iterator or the standard file-based generator) 
- `StandardWeightLoader`: Created `StandardWeightLoader` (inheriting from `BaseWeightLoader`) for models that rely on the standard `load_hf_weights()` utility.
     - Refactored `Llama3`, `Qwen2`, `Qwen2.5_VL`, and `Qwen3` to use `StandardWeightLoader`.
- Custom Weight Loader Support: Refactored existing custom loaders to inherit from `BaseWeightLoader` and handle PyTorch-to-JAX conversion where necessary.
     - `DeepSeekV3WeightLoader` and `Llama4WeightLoader` now inherit from `BaseWeightLoader`, as these loaders are already built to handle the PyTorch tensors provided by the RunAI streamer iterator, making their integration straightforward.
     - `LlamaGuard4WeightLoader` updated to handle PyTorch tensors yielded by the RunAI streamer. Required since loader was designed to handle JAX arrays directly. Therefore, a conversion step from PyTorch tensors to JAX arrays will be added, similar to the one already implemented in [load_hf_weights](https://github.com/vllm-project/tpu-inference/blob/b43ea7976725ec464aa75686d2a4c5424c5da33e/tpu_inference/models/jax/utils/weight_utils.py#L386).
     - Added `EagleLlama3WeightLoader` for Eagle models.  This is a special case that didn’t fit into StandardWeightLoader, so I created a new `EagleLlama3WeightLoader` which inherits from `BaseWeightLoader`.
- Robust Fallback Logic: Updated `resolve_model_architecture` in `model_loader.py` to automatically fall back to the vLLM (PyTorch) implementation if the RunAI model streamer is used and: 
     - The model does not have a `WeightLoader`.
     - The `WeightLoader` is not a subclass of `BaseWeightLoader`.
     - The architecture is not supported in JAX (caught via `UnsupportedArchitectureError`). 

# Shortcomings
The JAX path has a few different model styles / implementation patterns. For the models without a `WeightLoader` attribute, we will default to `MODEL_IMPL_TYPE=vllm` when RunAI model streamer is used. This is necessary to prevent breakage if RunAI model streamer is used for JAX models that don't have a Custom `WeightLoader` attribute. The downside is the Jax implementation of some models might not be supported with RunAI model streamer without additional changes. The way to solve this in the future is to unify different model styles / implementation patterns into one pattern, that integrate with the RunAI model streamer in the same way for all current and future models.


# Tests

Added new correctness test to test `tests/e2e/test_runai_model_streamer_loader.py::test_correctness_codegemma` to ensure it correctly falls back to the vLLM implementation since the architecture is not yet supported in JAX. 

Confirmed both tests pass with my code changes: 
```
pytest -s -v tests/e2e/test_runai_model_streamer_loader.py
======================================== 2 passed, 9 warnings in 189.84s (0:03:09) =========================================
```

Also run Jax model tests: 
```
pytest  -s -v tests/models/jax/test_llama_eagle3.py # 4/4 pass
pytest  -s -v tests/models/jax/test_deepseek_v3.py # Can't run as this takes too much space on my device (more than 100GB).
pytest  -s -v tests/models/jax/test_llama3.py # 2/2 pass
pytest  -s -v tests/models/jax/test_llama4.py # 21/21 pass
pytest -s -v  tests/models/jax/test_llama_guard_4.py # 10/10 pass
pytest -s -v  tests/models/jax/test_qwen2.py # 2/2 pass
pytest -s -v  tests/models/jax/test_qwen2_5_vl.py # 25/25 pass
pytest  -s -v tests/models/jax/test_qwen3.py # 2/2
pytest  -s -v tests/e2e/test_speculative_decoding.py # 6/6 passed
```

Yet to fix:
```
# 
pytest  -s -v tests/models/jax/test_weight_loading.py
```

TODO, run all nightly tests by submitting a new build but set the following env var (in "options": NIGHTLY=1. Will do this after I get test_weight_loading.py working
 

# Checklist

Before submitting this PR, please make sure:
[x] I have performed a self-review of my code.
[x] I have necessary comments in my code, particularly in hard-to-understand areas.
[x] I have made or will make corresponding changes to any relevant documentation.
