### PR TITLE
change naming of get_multimodal_embeddings based on vllm upstream

### DIFF
--- a/tests/models/jax/test_qwen2_5_vl.py
+++ b/tests/models/jax/test_qwen2_5_vl.py
@@ -491,8 +491,7 @@ class TestQwen2_5_VLForConditionalGeneration:
         assert embeddings[1].shape == (tokens_per_image, vc.out_hidden_size)
         assert model.visual.call_count == 2
 
-    def test_get_multimodal_embeddings(
-            self, model: Qwen2_5_VLForConditionalGeneration):
+    def test_embed_multimodal(self, model: Qwen2_5_VLForConditionalGeneration):
         grid_thw = ((2, 28, 28), )
         vc = model.config.vision_config
         patch_dim = vc.in_channels * vc.temporal_patch_size * vc.patch_size * vc.patch_size
@@ -503,14 +502,14 @@ class TestQwen2_5_VLForConditionalGeneration:
         with patch.object(model,
                           '_process_image_input',
                           return_value=(mock_vision_output, )) as mock_process:
-            mm_embeds = model.get_multimodal_embeddings(
-                grid_thw, pixel_values=pixel_values)
+            mm_embeds = model.embed_multimodal(grid_thw,
+                                               pixel_values=pixel_values)
             mock_process.assert_called_once()
             assert isinstance(mm_embeds, tuple)
             assert len(mm_embeds) == 1
             assert mm_embeds[0].shape == (tokens_per_image, vc.out_hidden_size)
 
-        mm_embeds_none = model.get_multimodal_embeddings(grid_thw)
+        mm_embeds_none = model.embed_multimodal(grid_thw)
         assert len(mm_embeds_none) == 0
 
     @patch('tpu_inference.models.jax.qwen2_5_vl.merge_multimodal_embeddings')

--- a/tests/runner/test_multimodal_manager.py
+++ b/tests/runner/test_multimodal_manager.py
@@ -88,7 +88,7 @@ class TestMultiModalManager:
         # 1. ===== Setup =====
         self.runner.is_multimodal_model = True
         self.mock_get_mm_embed_fn = MagicMock()
-        self.runner.get_multimodal_embeddings_fn = self.mock_get_mm_embed_fn
+        self.runner.embed_multimodal_fn = self.mock_get_mm_embed_fn
 
         self.runner.state = MagicMock()
         # Mock scheduler output
@@ -139,7 +139,7 @@ class TestMultiModalManager:
         np.testing.assert_array_equal(np.asarray(cached_embedding),
                                       np.asarray(dummy_embedding))
 
-        # Check if get_multimodal_embeddings_fn was called with correct args
+        # Check if embed_multimodal_fn was called with correct args
         self.mock_get_mm_embed_fn.assert_called_once()
         call_args = self.mock_get_mm_embed_fn.call_args
 
@@ -169,7 +169,7 @@ class TestMultiModalManager:
         # 1. ===== Setup =====
         self.runner.is_multimodal_model = True
         self.mock_get_mm_embed_fn = MagicMock()
-        self.runner.get_multimodal_embeddings_fn = self.mock_get_mm_embed_fn
+        self.runner.embed_multimodal_fn = self.mock_get_mm_embed_fn
 
         self.runner.state = MagicMock()
         # Mock scheduler output for two requests

--- a/tests/runner/test_tpu_runner.py
+++ b/tests/runner/test_tpu_runner.py
@@ -126,7 +126,7 @@ class TestTPUJaxRunnerMultimodalModelLoadedForTextOnly:
         device_array = np.array(jax.devices()[:1]).reshape(1, 1, 1, -1)
         self.mock_mesh = jax.make_mesh(device_array.shape,
                                        ('data', 'attn_dp', 'expert', 'model'))
-        # Setup the runner with the model_config.is_multimodal_model set to True but get_model returning None for get_multimodal_embeddings_fn and embed_input_ids_fn.
+        # Setup the runner with the model_config.is_multimodal_model set to True but get_model returning None for embed_multimodal_fn and embed_input_ids_fn.
         with patch('jax.devices', return_value=self.mock_devices), \
              patch('jax.make_mesh', return_value=self.mock_mesh), \
              patch('jax.random.key', return_value=self.mock_rng_key), \
@@ -172,7 +172,7 @@ class TestTPUJaxRunnerMultimodalModelLoadedForTextOnly:
     def _model_get_model(self):
         mock_multimodal_fns = {
             "precompile_vision_encoder_fn": None,
-            "get_multimodal_embeddings_fn": None,
+            "embed_multimodal_fn": None,
             "embed_input_ids_fn": None,
             "get_mrope_input_positions_fn": None
         }
@@ -190,8 +190,8 @@ class TestTPUJaxRunnerMultimodalModelLoadedForTextOnly:
         # Precondition: make sure the model_config claims the model supports MM.
         assert self.runner.model_config.is_multimodal_model
 
-        # Precondition: load the model and returns get_multimodal_embeddings_fn as None.
-        assert self.runner.get_multimodal_embeddings_fn is None
+        # Precondition: load the model and returns embed_multimodal_fn as None.
+        assert self.runner.embed_multimodal_fn is None
 
         assert not self.runner.is_multimodal_model
 

--- a/tpu_inference/models/common/model_loader.py
+++ b/tpu_inference/models/common/model_loader.py
@@ -283,10 +283,9 @@ def get_flax_model(
 
     # Multi-modal support only
     # This function calculates the image token's embeddings by VIT
-    def run_get_multimodal_embeddings(graphdef, state, image_grid_thw,
-                                      **kwargs):
+    def run_embed_multimodal(graphdef, state, image_grid_thw, **kwargs):
         model = nnx.merge(graphdef, state)
-        return model.get_multimodal_embeddings(image_grid_thw, **kwargs)
+        return model.embed_multimodal(image_grid_thw, **kwargs)
 
     embed_sharding = NamedSharding(mesh, PartitionSpec(None))
     # This function will calculates the embeddings of input texts and then merge with the image embeddings
@@ -312,8 +311,7 @@ def get_flax_model(
                                            None)
     model_fn = functools.partial(run_model, graphdef)
     compute_logits_fn = functools.partial(run_compute_logits, graphdef)
-    get_multimodal_embeddings_fn = functools.partial(
-        run_get_multimodal_embeddings, graphdef)
+    embed_multimodal_fn = functools.partial(run_embed_multimodal, graphdef)
     embed_input_ids_fn = functools.partial(run_embed_input_ids, graphdef)
     lora_manager, model = None, None
     combine_hidden_states_fn = functools.partial(combine_hidden_states,
@@ -325,7 +323,7 @@ def get_flax_model(
 
     multimodal_fns = {
         "precompile_vision_encoder_fn": precompile_vision_encoder_fn,
-        "get_multimodal_embeddings_fn": get_multimodal_embeddings_fn,
+        "embed_multimodal_fn": embed_multimodal_fn,
         "embed_input_ids_fn": embed_input_ids_fn,
         "get_mrope_input_positions_fn": get_mrope_input_positions_fn,
     }

--- a/tpu_inference/models/jax/qwen2_5_vl.py
+++ b/tpu_inference/models/jax/qwen2_5_vl.py
@@ -1010,9 +1010,9 @@ class Qwen2_5_VLForConditionalGeneration(nnx.Module):
         split_indices = np.cumsum(sizes)[:-1]
         return tuple(jnp.split(image_embeds, split_indices))
 
-    def get_multimodal_embeddings(self, image_grid_thw: tuple[tuple[int, int,
-                                                                    int], ...],
-                                  **kwargs: object) -> MultiModalEmbeddings:
+    def embed_multimodal(self, image_grid_thw: tuple[tuple[int, int, int],
+                                                     ...],
+                         **kwargs: object) -> MultiModalEmbeddings:
 
         mm_input_by_modality = self._parse_and_validate_multimodal_inputs(
             image_grid_thw, **kwargs)

--- a/tpu_inference/models/jax/utils/multi_modal_utils.py
+++ b/tpu_inference/models/jax/utils/multi_modal_utils.py
@@ -43,25 +43,25 @@ def sanity_check_mm_encoder_outputs(
 ) -> None:
     """
     Perform sanity checks for the result of
-    [`vllm.model_executor.models.SupportsMultiModal.get_multimodal_embeddings`][].
+    [`vllm.model_executor.models.SupportsMultiModal.embed_multimodal`][].
     """
     assert isinstance(mm_embeddings, (list, tuple, jax.Array)), (
         "Expected multimodal embeddings to be a list/tuple of 2D tensors, "
         f"or a single 3D tensor, but got {type(mm_embeddings)} "
         "instead. This is most likely due to incorrect implementation "
-        "of the model's `get_multimodal_embeddings` method.")
+        "of the model's `embed_multimodal` method.")
 
     assert len(mm_embeddings) == expected_num_items, (
         "Expected number of multimodal embeddings to match number of "
         f"input items: {expected_num_items}, but got {len(mm_embeddings)=} "
         "instead. This is most likely due to incorrect implementation "
-        "of the model's `get_multimodal_embeddings` method.")
+        "of the model's `embed_multimodal` method.")
 
     assert all(e.ndim == 2 for e in mm_embeddings), (
         "Expected multimodal embeddings to be a sequence of 2D tensors, "
         f"but got tensors with shapes {[e.shape for e in mm_embeddings]} "
         "instead. This is most likely due to incorrect implementation "
-        "of the model's `get_multimodal_embeddings` method.")
+        "of the model's `embed_multimodal` method.")
 
 
 def flatten_embeddings(embeddings: NestedTensors) -> jax.Array:

--- a/tpu_inference/runner/multimodal_manager.py
+++ b/tpu_inference/runner/multimodal_manager.py
@@ -148,7 +148,7 @@ class MultiModalManager:
             # 2. A list or tuple (length: num_items) of tensors, each of shape
             # (feature_size, hidden_size) in case the feature size is dynamic
             # depending on the input multimodal items.
-            curr_group_outputs = self.runner.get_multimodal_embeddings_fn(
+            curr_group_outputs = self.runner.embed_multimodal_fn(
                 self.runner.state, image_grid_thw, **batched_mm_inputs)
 
             sanity_check_mm_encoder_outputs(

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -508,8 +508,8 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         multimodal_fns = multimodal_fns or {}
         self.precompile_vision_encoder_fn = multimodal_fns.get(
             "precompile_vision_encoder_fn", None)
-        self.get_multimodal_embeddings_fn = multimodal_fns.get(
-            "get_multimodal_embeddings_fn", None)
+        self.embed_multimodal_fn = multimodal_fns.get("embed_multimodal_fn",
+                                                      None)
         self.embed_input_ids_fn = multimodal_fns.get("embed_input_ids_fn",
                                                      None)
         self.get_mrope_input_positions_fn = multimodal_fns.get(
@@ -523,7 +523,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             jax.random.key(self.model_config.seed)).params()
         self.is_multimodal_model = (
             self.model_config.is_multimodal_model
-            and self.get_multimodal_embeddings_fn is not None and hasattr(
+            and self.embed_multimodal_fn is not None and hasattr(
                 self.model_config.hf_config, "architectures"
             )  #TODO: Remove Llama Guard 4 specific condition once the LG4 Vision portion is implemented
             and len(self.model_config.hf_config.architectures) >= 1


### PR DESCRIPTION
# Description

Change get_multimodal_embeddings to embed_multimodal to keep in accord with https://github.com/vllm-project/vllm/commit/97d1c99302df6f7eadc0d0b32ec174db69cb4421#diff-7658f99b872bd5e272a77ba9c76fdc28d90ac49fcde20413c11d4d54df47145aL57-L65

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
