### PR TITLE
[DeepSeek] Use FP4 checkpoint instead of FP8 for E2E tests + add more clear warnings

### DIFF
--- a/.buildkite/pipeline_jax.yml
+++ b/.buildkite/pipeline_jax.yml
@@ -198,24 +198,25 @@ steps:
            exit 0
          fi
 
-   - label: "E2E MLperf tests for DeepSeek-R1 (no accuracy, 12-decoder layers only)"
-     key: test_12
-     soft_fail: true
-     env:
-       NEW_MODEL_DESIGN: "1"
-       USE_V6E8_QUEUE: "True"
-       SKIP_ACCURACY_TESTS: "True"
-       VLLM_MLA_DISABLE: "1"
-     agents:
-       queue: tpu_v6e_8_queue
-     commands:
-       - |
-         if [[ "$$NIGHTLY" == "1" ]]; then
-           .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/mlperf.sh -m deepseek-ai/DeepSeek-R1-0528 --use-dummy-weights
-         else
-           echo "Skipping: NIGHTLY environment variable not set"
-           exit 0
-         fi
+  # TODO (jacobplatin): re-enable this after b/467105149 is fixed
+  #  - label: "E2E MLperf tests for DeepSeek-R1 (no accuracy, 12-decoder layers only)"
+  #    key: test_12
+  #    soft_fail: true
+  #    env:
+  #      NEW_MODEL_DESIGN: "1"
+  #      USE_V6E8_QUEUE: "True"
+  #      SKIP_ACCURACY_TESTS: "True"
+  #      VLLM_MLA_DISABLE: "1"
+  #    agents:
+  #      queue: tpu_v6e_8_queue
+  #    commands:
+  #      - |
+  #        if [[ "$$NIGHTLY" == "1" ]]; then
+  #          .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/mlperf.sh -m jrplatin/DeepSeek-R1-1D-Subchannel-256  --use-dummy-weights
+  #        else
+  #          echo "Skipping: NIGHTLY environment variable not set"
+  #          exit 0
+  #        fi
 
    - label: "lora e2e tests for JAX + vLLM models multi chips"
      key: test_13
@@ -282,13 +283,15 @@ steps:
        - test_9
        - test_10
        - test_11
-       - test_12
+      # TODO (jacobplatin): re-enable this after b/467105149 is fixed
+      #  - test_12
        - test_13
        - test_15
        - test_16
      agents:
        queue: cpu
+      # TODO (jacobplatin): re-enable test12 this after b/467105149 is fixed
      commands:
        - |
          .buildkite/scripts/check_results.sh \
-           "TPU JAX Tests Failed" test_0 test_1 test_2 test_3 test_4 test_5 test_6 test_7 test_8 test_9 test_10 test_11 test_12 test_13 test_15 test_16
+           "TPU JAX Tests Failed" test_0 test_1 test_2 test_3 test_4 test_5 test_6 test_7 test_8 test_9 test_10 test_11 test_13 test_15 test_16

--- a/.buildkite/pipeline_jax_tpu7x.yml
+++ b/.buildkite/pipeline_jax_tpu7x.yml
@@ -124,7 +124,7 @@ steps:
      commands:
        - |
            .buildkite/scripts/run_in_docker.sh \
-             bash -c 'python3 -m pytest -s -v -x /workspace/tpu_inference/tests/e2e/test_speculative_decoding.py'         
+             bash -c 'python3 -m pytest -s -v -x /workspace/tpu_inference/tests/e2e/test_speculative_decoding.py'
 
    - label: "TPU7x JAX unit tests"
      key: tpu7x_test_7
@@ -231,7 +231,7 @@ steps:
      commands:
        - |
          if [[ "$$NIGHTLY" == "1" ]]; then
-           .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/mlperf.sh -m deepseek-ai/DeepSeek-R1-0528 --use-dummy-weights
+           .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/mlperf.sh -m jrplatin/DeepSeek-R1-1D-Subchannel-256  --use-dummy-weights
          else
            echo "Skipping: NIGHTLY environment variable not set"
            exit 0

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -31,7 +31,7 @@
 # JAX Model Implementations
 /tpu_inference/models/jax/qwen2_5_vl.py @hfan @kwang3939
 /tpu_inference/models/jax/gpt_oss.py @bzgoogle
-/tpu_inference/models/jax/deepseek_v3.py @bzgoogle
+/tpu_inference/models/jax/deepseek_v3.py @bzgoogle @gpolovets1 @jrplatin
 /tpu_inference/models/vllm/ @kyuyeunk @hfan @vanbasten23
 
 # Runner and Execution

--- a/tests/e2e/benchmarking/mlperf.sh
+++ b/tests/e2e/benchmarking/mlperf.sh
@@ -281,7 +281,7 @@ for model_name in $model_list; do
         max_batched_tokens=1024
         if [ "$model_name" == "meta-llama/Llama-4-Scout-17B-16E-Instruct" ]; then
             current_serve_args+=(--hf-overrides '{"architectures": ["Llama4ForCausalLM"]}')
-        elif [ "$model_name" == "deepseek-ai/DeepSeek-R1-0528" ]; then
+        elif [ "$model_name" == "jrplatin/DeepSeek-R1-1D-Subchannel-256" ]; then
             current_serve_args+=(--hf_overrides '{"num_hidden_layers": 12}')
         fi
     fi

--- a/tests/layers/jax/test_qwix.py
+++ b/tests/layers/jax/test_qwix.py
@@ -832,7 +832,7 @@ class TestGetDefaultQwixQuantizationConfig(unittest.TestCase):
         # Patch the constants in the module where the function resides
         self.patchers = [
             patch(
-                "tpu_inference.models.jax.utils.qwix.qwix_utils.DEFAULT_DEEPSEEK_FP8_CONFIG",
+                "tpu_inference.models.jax.utils.qwix.qwix_utils.DEFAULT_DEEPSEEK_FP4_MLP_MOE_FP8_ATTN_CONFIG",
                 self.mock_deepseek_config),
             patch(
                 "tpu_inference.models.jax.utils.qwix.qwix_utils.DEFAULT_LLAMA4_FP8_CONFIG",

--- a/tpu_inference/models/jax/utils/qwix/qwix_utils.py
+++ b/tpu_inference/models/jax/utils/qwix/qwix_utils.py
@@ -35,7 +35,7 @@ DEFAULT_NUM_TOKENS_FOR_MODEL_INPUTS = 512
 DEFAULT_MAX_NUM_SEQS_FOR_MODEL_INPUTS = 256
 DEFAULT_MAX_NUM_BLOCKS_PER_REQ = 16
 
-DEFAULT_DEEPSEEK_FP8_CONFIG = {
+DEFAULT_DEEPSEEK_FP4_MLP_MOE_FP8_ATTN_CONFIG = {
     "qwix": {
         "use_abstract_model":
         True,
@@ -452,7 +452,7 @@ def get_default_qwix_quantization_config(
     # NOTE (jacobplatin): we'll default to mixed FP8 (attention) + FP4 (MoE experts)
     # for DeepSeek
     if model_type == "deepseek_v3" and quant_method == "fp8":
-        config = copy.deepcopy(DEFAULT_DEEPSEEK_FP8_CONFIG)
+        config = copy.deepcopy(DEFAULT_DEEPSEEK_FP4_MLP_MOE_FP8_ATTN_CONFIG)
 
         # Dynamically fetch block size from HF config if available
         # Config fmt: 'weight_block_size': [1, 512] -> we want the 2nd dim for tile_size
@@ -462,7 +462,7 @@ def get_default_qwix_quantization_config(
         block_size = hf_quant_config["weight_block_size"]
         if isinstance(block_size, (list, tuple)) and len(block_size) == 2:
             assert block_size[
-                0] == 1, f"Expected first dimension to be 1 (unchanneled), but got {block_size[0]}!"
+                0] == 1, f"Expected first dimension to be 1 (unchanneled), but got {block_size[0]}! If you are trying to run quantized DeepSeek, we currently only support 1D-subchannel quantization and those models can be found here: https://huggingface.co/collections/jrplatin/deepseek-r1-1d-subchannel"
             tile_size = block_size[1]
             assert tile_size > 1, f"Expected tile_size > 1 for DeepSeek, but got {tile_size}"
             logger.info(


### PR DESCRIPTION
# Description

Because https://github.com/vllm-project/tpu-inference/pull/1332 removed support for FP8 DeepSeek checkpoints, we need to update the tests accordingly to use the TPU-friendly FP4 [checkpoints](https://huggingface.co/collections/jrplatin/deepseek-r1-1d-subchannel).

# Tests

Tested that BuildKite Nightly passes.

# Caveat
Because the current `requirements.txt` file uses `libtpu==0.0.24`, which doesn't support FP4, I am disabling the V6E test for DeepSeek here, but we should re-enable it when [this](https://b.corp.google.com/issues/467105149#comment11) bug is fixed.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
