### PR TITLE
[CI] Update lm-eval version due to upstream change

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -45,7 +45,7 @@ RUN --mount=type=cache,target=/root/.cache/pip python3 -m pip install -e tests/v
 RUN --mount=type=cache,target=/root/.cache/pip python3 -m pip install \
     git+https://github.com/thuml/depyf.git \
     pytest-asyncio \
-    git+https://github.com/EleutherAI/lm-evaluation-harness.git@206b7722158f58c35b7ffcd53b035fdbdda5126d#egg=lm-eval[api] \
+    "lm-eval[api]>=0.4.9.2" \
     pytest-cov \
     tblib
 


### PR DESCRIPTION
# Description

Update lm-eval version to align with upstream change: https://github.com/vllm-project/vllm/pull/31264.

# Tests

Run integration test of Qwen/Qwen3-4B locally.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
