### PR TITLE
[Image Update] Use debian:bookworm as base image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG NIGHTLY_DATE="20250714"
-ARG BASE_IMAGE="us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:nightly_3.12_tpuvm_$NIGHTLY_DATE"
+ARG BASE_IMAGE="python:3.12-slim-bookworm"
 # The latest main will be used if arg unspecified
 ARG VLLM_COMMIT_HASH=""
 
@@ -21,22 +20,30 @@ FROM $BASE_IMAGE
 
 ARG IS_FOR_V7X="false"
 
-# Remove existing versions of dependencies
-RUN pip uninstall -y torch torch_xla torchvision
+# Update pip
+RUN pip install --upgrade pip
 
 # Install some basic utilities
 RUN apt-get update && apt-get install -y \
     git \
-    libopenblas-base libopenmpi-dev libomp-dev
+    libopenmpi-dev \
+    libomp-dev \
+    procps \
+    curl \
+    rclone \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
 
 # Build vLLM
 WORKDIR /workspace/vllm
 ARG VLLM_REPO=https://github.com/vllm-project/vllm.git
 ARG VLLM_COMMIT_HASH
-RUN git clone $VLLM_REPO /workspace/vllm
-RUN if [ -n "$VLLM_COMMIT_HASH" ]; then \
+
+RUN git clone $VLLM_REPO . && \
+    if [ -n "$VLLM_COMMIT_HASH" ]; then \
         git checkout $VLLM_COMMIT_HASH; \
     fi
+
 RUN --mount=type=cache,target=/root/.cache/pip pip install --extra-index-url https://download.pytorch.org/whl/cpu -r requirements/tpu.txt --retries 3
 RUN --mount=type=cache,target=/root/.cache/pip VLLM_TARGET_DEVICE="tpu" pip install -e .
 


### PR DESCRIPTION
# Description
Update base image to debian:bookworm. 

It used to an torch/xla image based on debian:bullseye( version 11 ). 

Why `debian:bookworm` instead of `debian:bullseye`? 
From pypi there are less vulnerability on debian:bookworm.

# Tests
#### CI/CD
Wait for result.

#### Test on TPU monitor
No performance impact after using new image:
<img width="1409" height="940" alt="image" src="https://github.com/user-attachments/assets/edc926e4-c0a8-435e-bd78-7b0beaa04bb6" />

Proof of using new image

```
docker pull southamerica-west1-docker.pkg.dev/cloud-tpu-inference-test/vllm-tpu-bm/vllm-tpu:3f52fa5aa-3ff6a476-

docker run -d \
  --name vllm-ssh \
  --privileged \
  --net host \
  --shm-size=16G \
  southamerica-west1-docker.pkg.dev/cloud-tpu-inference-test/vllm-tpu-bm/vllm-tpu:3f52fa5aa-3ff6a476- \
  tail -f /dev/null


docker exec -it vllm-ssh bash

root@t1v-n-4c58cb45-w-0:/workspace/vllm# cat /etc/os-release
PRETTY_NAME="Debian GNU/Linux 12 (bookworm)"
NAME="Debian GNU/Linux"
VERSION_ID="12"
VERSION="12 (bookworm)"
VERSION_CODENAME=bookworm
ID=debian
HOME_URL="https://www.debian.org/"
SUPPORT_URL="https://www.debian.org/support"
BUG_REPORT_URL="https://bugs.debian.org/"
```



