### PR TITLE
[CI] Fix nightly ci failure Performance tests for DCN-based P/D disaggregation

### DIFF
--- a/examples/disagg/run_disagg_multi_host.sh
+++ b/examples/disagg/run_disagg_multi_host.sh
@@ -185,6 +185,7 @@ docker exec -d ${CONTAINER_PREFIX}-0 /bin/bash -c \
     --gpu-memory-utilization 0.3 \
     --tensor-parallel-size 4 \
     --kv-transfer-config '{\"kv_connector\":\"TPUConnector\",\"kv_connector_module_path\":\"tpu_inference.distributed.tpu_connector\",\"kv_role\":\"kv_producer\"}' \
+    --no-async-scheduling \
     > /root/logs/prefill.txt 2>&1"
 set +x
 
@@ -257,6 +258,7 @@ docker exec -d ${CONTAINER_PREFIX}-2-0 /bin/bash -c \
     --gpu-memory-utilization 0.3 \
     --tensor-parallel-size 4 \
     --kv-transfer-config '{\"kv_connector\":\"TPUConnector\",\"kv_connector_module_path\":\"tpu_inference.distributed.tpu_connector\",\"kv_role\":\"kv_consumer\"}' \
+    --no-async-scheduling \
     > /root/logs/decode.txt 2>&1"
 set +x
 


### PR DESCRIPTION
# Description

Disable the default --async-scheduling (from vllm upstream: https://github.com/vllm-project/vllm/pull/28250) with --no-async-scheduling to fix the failure in nightly CI: Performance tests for DCN-based P/D disaggregation.

# Tests

Tested with `bash examples/disagg/run_disagg_multi_host.sh`.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
