### PR TITLE
Enable PyPI tests on both v6e and v7x

### DIFF
--- a/.buildkite/pipeline_pypi.yml
+++ b/.buildkite/pipeline_pypi.yml
@@ -13,11 +13,11 @@
 # limitations under the License.
 
 steps:
-   - label: "PyPI Test Performance benchmarks for meta-llama/Llama-3.1-8B-Instruct"
-     key: "pypi_meta-llama_Llama-3_1-8B-Instruct_Benchmark"
+   - label: "${TEST_LABEL_PREFIX} PyPI Test Performance benchmarks for meta-llama/Llama-3.1-8B-Instruct"
+     key: "${TEST_KEY_PREFIX}_pypi_meta-llama_Llama-3_1-8B-Instruct_Benchmark"
      if: build.env("NIGHTLY") == "1"
      agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_SMALL_CORE_QUEUE}"
      env:
       TEST_MODEL: meta-llama/Llama-3.1-8B-Instruct
       TENSOR_PARALLEL_SIZE: 1
@@ -28,15 +28,17 @@ steps:
       MAX_MODEL_LEN: 2048
       MAX_NUM_SEQS: 256
       MAX_NUM_BATCHED_TOKENS: 1024
+      IS_FOR_V7X: "${IS_FOR_V7X}"
      commands:
       - |
         .buildkite/scripts/run_with_pypi.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/benchmark.sh
 
-   - label: "PyPI Test Performance benchmarks for Qwen/Qwen3-4B"
-     key: "pypi_Qwen_Qwen3-4B_Benchmark"
+   - label: "${TEST_LABEL_PREFIX} PyPI Test Performance benchmarks for Qwen/Qwen3-4B"
+     key: "${TEST_KEY_PREFIX}_pypi_Qwen_Qwen3-4B_Benchmark"
      if: build.env("NIGHTLY") == "1"
+     depends_on: "record_verified_commit_hashes"
      agents:
-      queue: tpu_v6e_queue
+      queue: "${TPU_SMALL_CORE_QUEUE}"
      env:
       TEST_MODEL: Qwen/Qwen3-4B
       TENSOR_PARALLEL_SIZE: 1
@@ -47,6 +49,7 @@ steps:
       MAX_MODEL_LEN: 2048
       MAX_NUM_SEQS: 94
       MAX_NUM_BATCHED_TOKENS: 4096
+      IS_FOR_V7X: "${IS_FOR_V7X}"
      commands:
       - |
        .buildkite/scripts/run_with_pypi.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/benchmark.sh

--- a/.buildkite/pipeline_pypi.yml
+++ b/.buildkite/pipeline_pypi.yml
@@ -15,7 +15,7 @@
 steps:
    - label: "${TEST_LABEL_PREFIX} PyPI Test Performance benchmarks for meta-llama/Llama-3.1-8B-Instruct"
      key: "${TEST_KEY_PREFIX}_pypi_meta-llama_Llama-3_1-8B-Instruct_Benchmark"
-     if: build.env("NIGHTLY") == "1"
+     # if: build.env("NIGHTLY") == "1"
      agents:
       queue: "${TPU_SMALL_CORE_QUEUE}"
      env:
@@ -35,7 +35,7 @@ steps:
 
    - label: "${TEST_LABEL_PREFIX} PyPI Test Performance benchmarks for Qwen/Qwen3-4B"
      key: "${TEST_KEY_PREFIX}_pypi_Qwen_Qwen3-4B_Benchmark"
-     if: build.env("NIGHTLY") == "1"
+     # if: build.env("NIGHTLY") == "1"
      depends_on: "record_verified_commit_hashes"
      agents:
       queue: "${TPU_SMALL_CORE_QUEUE}"

--- a/.buildkite/scripts/bootstrap.sh
+++ b/.buildkite/scripts/bootstrap.sh
@@ -75,7 +75,8 @@ upload_pipeline() {
     # buildkite-agent pipeline upload .buildkite/pipeline_torch.yml
     buildkite-agent pipeline upload .buildkite/main.yml
     buildkite-agent pipeline upload .buildkite/nightly_releases.yml
-    buildkite-agent pipeline upload .buildkite/pipeline_pypi.yml
+    TPU_SMALL_CORE_QUEUE=tpu_v6e_queue buildkite-agent pipeline upload .buildkite/pipeline_pypi.yml
+    TPU_SMALL_CORE_QUEUE=tpu_v7x_2_queue IS_FOR_V7X=true TEST_KEY_PREFIX=tpu7x_ TEST_LABEL_PREFIX=TPU7x buildkite-agent pipeline upload .buildkite/pipeline_pypi.yml
 }
 
 echo "--- Starting Buildkite Bootstrap ---"

--- a/docker/Dockerfile.pypi
+++ b/docker/Dockerfile.pypi
@@ -22,7 +22,14 @@ ARG IS_TEST="false"
 # Install some basic utilities
 RUN apt-get update && apt-get install -y \
     git \
-    libopenblas-dev libopenmpi-dev libomp-dev
+    libopenmpi-dev \
+    libomp-dev \
+    procps \
+    curl \
+    rclone \
+    wget \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
 
 # Install tpu_inference
 WORKDIR /workspace/tpu_inference


### PR DESCRIPTION
# Description
Enable the use of different variables for both v6e and v7x for PyPI tests.

# Tests
[Buildkite](https://buildkite.com/tpu-commons/tpu-inference-ci/builds/8843/steps/canvas)

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
