### PR TITLE
Use local devices when computing hbm usage stats

### DIFF
--- a/tests/worker/tpu_worker_test.py
+++ b/tests/worker/tpu_worker_test.py
@@ -175,7 +175,7 @@ class TestTPUWorker:
 
     @patch('tpu_inference.worker.tpu_worker.utils')
     @patch('tpu_inference.worker.tpu_worker.jax')
-    def test_determine_available_memory(self, mock_jax, mock_util,
+    def test_determine_available_memory(self, mock_jax, mock_utils,
                                         mock_vllm_config):
         """Tests the available HBM memory calculation."""
         # Setup mock return for hbm_usage_bytes: [(used_bytes, limit_bytes), ...]

--- a/tests/worker/tpu_worker_test.py
+++ b/tests/worker/tpu_worker_test.py
@@ -174,7 +174,9 @@ class TestTPUWorker:
                                                 expected_is_last_rank)
 
     @patch('tpu_inference.worker.tpu_worker.utils')
-    def test_determine_available_memory(self, mock_utils, mock_vllm_config):
+    @patch('tpu_inference.worker.tpu_worker.jax')
+    def test_determine_available_memory(self, mock_jax, mock_util,
+                                        mock_vllm_config):
         """Tests the available HBM memory calculation."""
         # Setup mock return for hbm_usage_bytes: [(used_bytes, limit_bytes), ...]
         mock_utils.hbm_usage_bytes.return_value = [
@@ -186,9 +188,11 @@ class TestTPUWorker:
                            rank=0,
                            distributed_init_method="test_method",
                            devices=mock_devices)
+        mock_jax.local_devices.return_value = mock_devices
 
         available_mem = worker.determine_available_memory()
 
+        mock_jax.local_devices.assert_called_once()
         mock_utils.hbm_usage_bytes.assert_called_once_with(mock_devices)
         # Total limit: 1000 + 1000 = 2000 GiB
         # Total cap: 2000 * 0.9 = 1800 GiB

--- a/tpu_inference/worker/tpu_worker.py
+++ b/tpu_inference/worker/tpu_worker.py
@@ -266,7 +266,7 @@ class TPUWorker:
 
     def determine_available_memory(self) -> int:
         gpu_memory_utilization = self.cache_config.gpu_memory_utilization
-        hbm_usage = utils.hbm_usage_bytes(self.devices)
+        hbm_usage = utils.hbm_usage_bytes(jax.local_devices())
         total_hbm_limit = total_hbm_used = 0
         for used, limit in hbm_usage:
             total_hbm_used += used


### PR DESCRIPTION
# Description

This fixes an issue with running multihost TPUs on Ironwood (v7x-16), where the computed HBM appears to be 0:
```
ValueError: total_hbm_used_gb=0.0GiB exceeds total_hbm_limit_cap_gb=0.0GiB by -0.0GiB. Please consider increasing --gpu-memory-utilization from 0.9 to a larger value.
```

The reasons for this fix are as follows:

1. JAX can only successfully run `memory_stats()` on the local cores (8 cores on each host VM). Attempting to run `memory_stats()` on non-local cores in Ironwood results in a value of 0, causing the error.

2. This only happens on multi-host because on a single-host TPU, all the devices are by definition local.

3. This only happens on Ironwood, because in previous TPU generations, calling `memory_stats()` on a remote TPU host returns cached metadata instead of real-time data, thus the value returned is non-0.


# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
