### PR TITLE
[Tetst] Skip test_deepseek_v3.py test

### DIFF
--- a/.buildkite/pipeline_jax_tpu7x.yml
+++ b/.buildkite/pipeline_jax_tpu7x.yml
@@ -142,6 +142,7 @@ steps:
            --ignore=/workspace/tpu_inference/tests/e2e \
            --ignore=/workspace/tpu_inference/tpu_inference/mock \
            --ignore=/workspace/tpu_inference/tests/layers/vllm/test_compressed_tensors_moe.py \
+           --ignore=/workspace/tpu_inference/tests/models/jax/test_deepseek_v3.py \
            --cov-config=/workspace/tpu_inference/.coveragerc --cov tpu_inference --cov-report term-missing --cov-fail-under=67
 
    - label: "TPU7x JAX unit tests - kernels"


### PR DESCRIPTION
# Description

The test download deepseek 3 model that causes "no space" issue. 

