### PR TITLE
Install wget in the docker image.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -32,6 +32,7 @@ RUN apt-get update && apt-get install -y \
     procps \
     curl \
     rclone \
+    wget \
     ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
# Description

The CI test "Integration tests for meta-llama/Llama-Guard-4-12B" currently fails with an error 
```
/workspace/tpu_inference/tests/e2e/benchmarking/safety_model_benchmark.sh: line 97: wget: command not found
--
Error: Failed to download dataset via wget.
```
This PR intends to fix this issue.

# Tests

nightly ci.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
