### PR TITLE
Fix .buildkite/features/runai_model_streamer_loader.yml ci error

### DIFF
--- a/.buildkite/features/runai_model_streamer_loader.yml
+++ b/.buildkite/features/runai_model_streamer_loader.yml
@@ -39,18 +39,6 @@ steps:
     commands:
       - |
         .buildkite/scripts/record_step_result.sh runai_model_streamer_loader_CorrectnessTest
- - label: "Record correctness test result for runai_model_streamer_loader"
-    key: "record_runai_model_streamer_loader_CorrectnessTest"
-    depends_on: "runai_model_streamer_loader_CorrectnessTest"
-    env:
-      CI_TARGET: "runai_model_streamer_loader"
-      CI_STAGE: "CorrectnessTest"
-      CI_CATEGORY: "feature support matrix"
-    agents:
-      queue: cpu
-    commands:
-      - |
-        .buildkite/scripts/record_step_result.sh runai_model_streamer_loader_CorrectnessTest
   - label: "Correctness tests for runai_model_streamer_loader with codegemma"
     key: "runai_model_streamer_loader_CorrectnessTest_codegemma"
     soft_fail: true


### PR DESCRIPTION
# Description

Currently, [CI](https://buildkite.com/tpu-commons/tpu-inference-ci/builds/8023#019bb138-8bf8-4a27-900b-7ad1a7f38c39) `buildkite-agent pipeline upload .buildkite/features/runai_model_streamer_loader.` fails with an error
```
buildkite-agent: fatal: pipeline parsing of "runai_model_streamer_loader.yml" failed: line 21: did not find expected key
--
```
This PR intends to fix it.

# Tests

CI

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
