### PR TITLE
Fix DP feature parsing.

### DIFF
--- a/.buildkite/features/data_parallelism.yml
+++ b/.buildkite/features/data_parallelism.yml
@@ -44,7 +44,7 @@ steps:
       queue: tpu_v6e_8_queue
     commands:
       - |
-        buildkite-agent meta-data set "data_parallelism_PerformanceTest" "run together with correctness test"
+        buildkite-agent meta-data set "data_parallelism_PerformanceTest" "unverified"
 
   - label: "Record performance test result for data_parallelism"
     key: "record_data_parallelism_PerformanceTest"


### PR DESCRIPTION
# Description

Currently, the "Record performance test result for data_parallelism" nightly runs fails with an [error](https://buildkite.com/tpu-commons/tpu-inference-ci/builds/8023#019bb13b-0934-43fd-9403-c2c759638b96) `Step data_parallelism_PerformanceTest outcome: run together with correctness test`. It seems the [script](https://github.com/vllm-project/tpu-inference/blob/538a66c97d4272fb1097fd99a849d4aa8083abf6/.buildkite/scripts/generate_support_matrices.sh#L173) checks if the string is "unverified". This PR intends to fix this.

# Tests

CI

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
