### PR TITLE
[CI] change PR label check from skip to fail

### DIFF
--- a/.buildkite/scripts/bootstrap.sh
+++ b/.buildkite/scripts/bootstrap.sh
@@ -107,8 +107,9 @@ else
       echo "Found 'ready' label on PR. Uploading main pipeline..."
       upload_pipeline
     else
-      echo "No 'ready' label found on PR. Skipping main pipeline upload."
-      exit 0 # Exit with 0 to indicate success (no error, just skipped)
+      # Explicitly fail the build because the required 'ready' label is missing.
+      echo "Missing 'ready' label on PR. Failing build."
+      exit 1
     fi
   else
     # If it's NOT a Pull Request (e.g., branch push, tag, manual build)


### PR DESCRIPTION
# Description

Updated the PR label check to return a non-zero exit code (1) if the 'ready' label is missing. This prevents the pipeline from silently skipping and ensures builds only proceed when explicitly marked as ready.

# Tests

[BuildKite](https://buildkite.com/tpu-commons/tpu-inference-ci/builds/8070/steps/canvas?sid=019bb52f-03e5-4338-ae61-9524a23201bc)

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
