### PR TITLE
Only run nightly docker image upload on main

### DIFF
--- a/.buildkite/nightly_releases.yml
+++ b/.buildkite/nightly_releases.yml
@@ -20,7 +20,7 @@ notify:
 
 steps:
   - label: "Publish vllm/vllm-tpu nightly image"
-    if: build.env("NIGHTLY") == "1"
+    if: build.branch == "main" && build.env("NIGHTLY") == "1"
     agents:
       queue: cpu
     secrets:
@@ -40,7 +40,7 @@ steps:
           password-env: DOCKERHUB_TOKEN
 
   - label: "Publish vllm/vllm-tpu nightly image for ironwood"
-    if: build.env("NIGHTLY") == "1"
+    if: build.branch == "main" && build.env("NIGHTLY") == "1"
     agents:
       queue: cpu
     secrets:


### PR DESCRIPTION
# Description

Only run nightly docker image upload on main branch to avoid confusion on non-main branches not having access to dockerhub token. 

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
