### PR TITLE
Fix for vLLM PR #32382.

### DIFF
--- a/tpu_inference/core/disagg_executor.py
+++ b/tpu_inference/core/disagg_executor.py
@@ -5,7 +5,6 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 from vllm.logger import init_logger
 from vllm.multimodal import MULTIMODAL_REGISTRY
-from vllm.multimodal.cache import worker_receiver_cache_from_config
 from vllm.utils.network_utils import (get_distributed_init_method, get_ip,
                                       get_open_port)
 from vllm.v1.executor.abstract import Executor
@@ -80,8 +79,8 @@ class DisaggExecutor(Executor):
             is_driver_worker=is_driver_worker,
             devices=devices,
         )
-        self.mm_receiver_cache = worker_receiver_cache_from_config(
-            self.vllm_config, MULTIMODAL_REGISTRY, Lock())
+        self.mm_receiver_cache = MULTIMODAL_REGISTRY.worker_receiver_cache_from_config(
+            self.vllm_config, Lock())
         self.collective_rpc("init_worker", args=([kwargs], ))
         self.collective_rpc("init_device")
         self.collective_rpc("load_model")


### PR DESCRIPTION
# Description

Fixing breakage in tpu_inference/core/disagg_executor.py due to vLLM API refactoring in https://github.com/vllm-project/vllm/pull/32382.

# Tests

Pytest passed locally.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
