### PR TITLE
[Bug fix] Initialize NONE_BLOCK in DPScheduler

### DIFF
--- a/tests/core/test_dp_scheduler.py
+++ b/tests/core/test_dp_scheduler.py
@@ -111,17 +111,15 @@ class TestDPScheduler:
         """Test initialization with prefix caching enabled initializes NONE_HASH."""
         mock_vllm_config.cache_config.enable_prefix_caching = True
         mock_vllm_config.cache_config.prefix_caching_hash_algo = "sha256"
-        
+
         with patch(
                 'tpu_inference.core.sched.dp_scheduler._scheduler_worker_process'
         ):
             with patch('multiprocessing.get_context') as mock_get_context:
-                with patch(
-                    'vllm.v1.core.kv_cache_utils.init_none_hash'
-                ) as mock_init_none_hash:
-                    with patch(
-                        'vllm.utils.hashing.get_hash_fn_by_name'
-                    ) as mock_get_hash_fn:
+                with patch('vllm.v1.core.kv_cache_utils.init_none_hash'
+                           ) as mock_init_none_hash:
+                    with patch('vllm.utils.hashing.get_hash_fn_by_name'
+                               ) as mock_get_hash_fn:
                         # Setup mocks
                         mock_ctx = MagicMock()
                         mock_process = MagicMock()
@@ -129,22 +127,24 @@ class TestDPScheduler:
                         mock_ctx.Queue = MagicMock(return_value=mock_queue)
                         mock_ctx.Process = MagicMock(return_value=mock_process)
                         mock_get_context.return_value = mock_ctx
-                        
+
                         mock_hash_fn = MagicMock()
                         mock_get_hash_fn.return_value = mock_hash_fn
 
                         scheduler = DPScheduler(
                             vllm_config=mock_vllm_config,
                             kv_cache_config=mock_kv_cache_config,
-                            structured_output_manager=mock_structured_output_manager,
+                            structured_output_manager=
+                            mock_structured_output_manager,
                             block_size=16,
                             log_stats=True,
                         )
 
                         # Verify init_none_hash was called with correct hash function
                         mock_get_hash_fn.assert_called_once_with("sha256")
-                        mock_init_none_hash.assert_called_once_with(mock_hash_fn)
-                        
+                        mock_init_none_hash.assert_called_once_with(
+                            mock_hash_fn)
+
                         assert scheduler.dp_size == 2
 
     def test_init_without_prefix_caching_skips_initialization(
@@ -155,14 +155,13 @@ class TestDPScheduler:
     ):
         """Test initialization without prefix caching skips NONE_HASH initialization."""
         mock_vllm_config.cache_config.enable_prefix_caching = False
-        
+
         with patch(
                 'tpu_inference.core.sched.dp_scheduler._scheduler_worker_process'
         ):
             with patch('multiprocessing.get_context') as mock_get_context:
-                with patch(
-                    'vllm.v1.core.kv_cache_utils.init_none_hash'
-                ) as mock_init_none_hash:
+                with patch('vllm.v1.core.kv_cache_utils.init_none_hash'
+                           ) as mock_init_none_hash:
                     # Setup mocks
                     mock_ctx = MagicMock()
                     mock_process = MagicMock()
@@ -174,14 +173,15 @@ class TestDPScheduler:
                     scheduler = DPScheduler(
                         vllm_config=mock_vllm_config,
                         kv_cache_config=mock_kv_cache_config,
-                        structured_output_manager=mock_structured_output_manager,
+                        structured_output_manager=
+                        mock_structured_output_manager,
                         block_size=16,
                         log_stats=True,
                     )
 
                     # Verify init_none_hash was NOT called
                     mock_init_none_hash.assert_not_called()
-                    
+
                     assert scheduler.dp_size == 2
 
     def test_get_rank_token_counts(self, mock_vllm_config,

--- a/tpu_inference/core/sched/dp_scheduler.py
+++ b/tpu_inference/core/sched/dp_scheduler.py
@@ -286,11 +286,10 @@ class DPScheduler(SchedulerInterface):
         # Initialize NONE_HASH global before forking worker processes
         # This ensures all workers inherit the initialized value
         if vllm_config.cache_config.enable_prefix_caching:
-            from vllm.v1.core.kv_cache_utils import init_none_hash
             from vllm.utils.hashing import get_hash_fn_by_name
+            from vllm.v1.core.kv_cache_utils import init_none_hash
             caching_hash_fn = get_hash_fn_by_name(
-                vllm_config.cache_config.prefix_caching_hash_algo
-            )
+                vllm_config.cache_config.prefix_caching_hash_algo)
             init_none_hash(caching_hash_fn)
 
         # The original scheduler class could be Scheduler or AsyncScheduler


### PR DESCRIPTION
# Description

The `NONE_HASH` global variable from vLLM needs to be initialized via `init_none_hash()` before any prefix caching operations are performed. This PR adds initialization of `NONE_HASH` in the DPScheduler.

This issue did not surface previous due to all of our benchmarking set `enable_prefix_caching=False`

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
