### PR TITLE
[DeepSeek] Add backwards compatibility for FP8 checkpoints

### DIFF
--- a/tpu_inference/models/jax/utils/qwix/qwix_utils.py
+++ b/tpu_inference/models/jax/utils/qwix/qwix_utils.py
@@ -35,6 +35,26 @@ DEFAULT_NUM_TOKENS_FOR_MODEL_INPUTS = 512
 DEFAULT_MAX_NUM_SEQS_FOR_MODEL_INPUTS = 256
 DEFAULT_MAX_NUM_BLOCKS_PER_REQ = 16
 
+DEFAULT_DEEPSEEK_FP8_CONFIG = {
+    "qwix": {
+        "use_abstract_model":
+        True,
+        "scale_dtype":
+        "bfloat16",
+        "rules": [
+            {
+                "module_path": ".*.custom_module.router.*",
+                "weight_qtype": None,
+            },
+            {
+                "module_path": ".*",
+                "weight_qtype": "float8_e4m3fn",
+                "act_qtype": "float8_e4m3fn",
+            },
+        ],
+    }
+}
+
 DEFAULT_DEEPSEEK_FP4_MLP_MOE_FP8_ATTN_CONFIG = {
     "qwix": {
         "use_abstract_model":
@@ -120,6 +140,12 @@ DEFAULT_GPT_OSS_FP4_CONFIG = {
         ],
     }
 }
+
+# TODO (jacobplatin): remove this once the JAX path refactor is complete
+NATIVE_FP8_CHECKPOINT_MODELS = [
+    "deepseek-ai/deepseek-v3", "deepseek-ai/deepseek-r1-0528",
+    "deepseek-ai/deepseek-r1"
+]
 
 
 def parse_qwix_config_to_rules(
@@ -452,14 +478,26 @@ def get_default_qwix_quantization_config(
     # NOTE (jacobplatin): we'll default to mixed FP8 (attention) + FP4 (MoE experts)
     # for DeepSeek
     if model_type == "deepseek_v3" and quant_method == "fp8":
-        config = copy.deepcopy(DEFAULT_DEEPSEEK_FP4_MLP_MOE_FP8_ATTN_CONFIG)
-
         # Dynamically fetch block size from HF config if available
         # Config fmt: 'weight_block_size': [1, 512] -> we want the 2nd dim for tile_size
         # NOTE: if the checkpoint is not 1D subchannel, we will throw an error
         hf_quant_config = hf_config.quantization_config
         assert "weight_block_size" in hf_quant_config, "Expected weight_block_size in quantization_config"
         block_size = hf_quant_config["weight_block_size"]
+
+        # TODO (jacobplatin): remove this (not so nice!) logic once the refactor on the JAX happens
+        # NOTE: this is needed / added to support backwards compatibility for the native FP8 DeepSeek checkpoints
+        # (e.g. deepseek-ai/DeepSeek-R1-0528)
+        if block_size == [128, 128]:
+            model_name = hf_config._name_or_path.lower()
+            if model_name not in NATIVE_FP8_CHECKPOINT_MODELS:
+                raise ValueError(
+                    f"Expected to find DeepSeek checkpoint with block_size of [128, 128], but got {model_name}.  Expexted one of {NATIVE_FP8_CHECKPOINT_MODELS}"
+                )
+            return DEFAULT_DEEPSEEK_FP8_CONFIG
+
+        config = copy.deepcopy(DEFAULT_DEEPSEEK_FP4_MLP_MOE_FP8_ATTN_CONFIG)
+
         if isinstance(block_size, (list, tuple)) and len(block_size) == 2:
             assert block_size[
                 0] == 1, f"Expected first dimension to be 1 (unchanneled), but got {block_size[0]}! If you are trying to run quantized DeepSeek, we currently only support 1D-subchannel quantization and those models can be found here: https://huggingface.co/collections/jrplatin/deepseek-r1-1d-subchannel"


### PR DESCRIPTION
# Description

In this PR, I add back support for native FP8 DeepSeek checkpoints (like [this](https://huggingface.co/deepseek-ai/DeepSeek-V3/tree/main) one) since RL workloads require them.

# Tests

Tested that offline inference works as expected for both FP4/FP8 and MLA/non-MLA.

Also tested MLA + MMLU:

FP4 on main:

```
============ Serving Benchmark Result ============
Successful requests:                     1000      
Benchmark duration (s):                  104.38    
Total input tokens:                      162129    
Total generated tokens:                  2000      
Request throughput (req/s):              9.58      
Output token throughput (tok/s):         19.16     
Total token throughput (tok/s):          1572.49   
---------------Time to First Token----------------
Mean TTFT (ms):                          59861.00  
Median TTFT (ms):                        62970.50  
P99 TTFT (ms):                           103408.95 
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          634.59    
Median TPOT (ms):                        637.36    
P99 TPOT (ms):                           638.80    
---------------Inter-token Latency----------------
Mean ITL (ms):                           634.59    
Median ITL (ms):                         637.36    
P99 ITL (ms):                            638.80    
----------------End-to-end Latency----------------
Mean E2EL (ms):                          60495.59  
Median E2EL (ms):                        63607.33  
P99 E2EL (ms):                           104032.38 
==================================================
Evaluating MMLU...
[nltk_data] Downloading package punkt to
[nltk_data]     /home/jacobplatin_google_com/nltk_data...
[nltk_data]   Package punkt is already up-to-date!
[nltk_data] Downloading package punkt_tab to
[nltk_data]     /home/jacobplatin_google_com/nltk_data...
[nltk_data]   Package punkt_tab is already up-to-date!

Results

{'accuracy': 0.839, 'gen_num': 1000}
```



FP4 on this PR:
```
============ Serving Benchmark Result ============
Successful requests:                     1000      
Benchmark duration (s):                  103.53    
Total input tokens:                      162129    
Total generated tokens:                  2000      
Request throughput (req/s):              9.66      
Output token throughput (tok/s):         19.32     
Total token throughput (tok/s):          1585.34   
---------------Time to First Token----------------
Mean TTFT (ms):                          59069.15  
Median TTFT (ms):                        62339.76  
P99 TTFT (ms):                           102465.06 
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          635.41    
Median TPOT (ms):                        637.30    
P99 TPOT (ms):                           641.08    
---------------Inter-token Latency----------------
Mean ITL (ms):                           635.42    
Median ITL (ms):                         637.30    
P99 ITL (ms):                            641.08    
----------------End-to-end Latency----------------
Mean E2EL (ms):                          59704.56  
Median E2EL (ms):                        62976.60  
P99 E2EL (ms):                           103089.91 
==================================================
Evaluating MMLU...
[nltk_data] Downloading package punkt to
[nltk_data]     /home/jacobplatin_google_com/nltk_data...
[nltk_data]   Package punkt is already up-to-date!
[nltk_data] Downloading package punkt_tab to
[nltk_data]     /home/jacobplatin_google_com/nltk_data...
[nltk_data]   Package punkt_tab is already up-to-date!

Results

{'accuracy': 0.841, 'gen_num': 1000}
```

FP8:
```
============ Serving Benchmark Result ============
Successful requests:                     1000      
Benchmark duration (s):                  124.86    
Total input tokens:                      162129    
Total generated tokens:                  2000      
Request throughput (req/s):              8.01      
Output token throughput (tok/s):         16.02     
Total token throughput (tok/s):          1314.54   
---------------Time to First Token----------------
Mean TTFT (ms):                          70834.28  
Median TTFT (ms):                        74440.04  
P99 TTFT (ms):                           122440.02 
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          761.37    
Median TPOT (ms):                        756.36    
P99 TPOT (ms):                           758.07    
---------------Inter-token Latency----------------
Mean ITL (ms):                           761.37    
Median ITL (ms):                         756.36    
P99 ITL (ms):                            758.07    
----------------End-to-end Latency----------------
Mean E2EL (ms):                          71595.65  
Median E2EL (ms):                        75196.15  
P99 E2EL (ms):                           123185.47 
==================================================
Evaluating MMLU...
[nltk_data] Downloading package punkt to
[nltk_data]     /home/jacobplatin_google_com/nltk_data...
[nltk_data]   Package punkt is already up-to-date!
[nltk_data] Downloading package punkt_tab to
[nltk_data]     /home/jacobplatin_google_com/nltk_data...
[nltk_data]   Package punkt_tab is already up-to-date!

Results

{'accuracy': 0.843, 'gen_num': 1000}
```

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
