### PR TITLE
Support RunAI model streamer for RayDistributedExecutor Torchax path

### DIFF
--- a/.buildkite/features/runai_model_streamer_loader.yml
+++ b/.buildkite/features/runai_model_streamer_loader.yml
@@ -20,16 +20,16 @@
 # GPU memory. This streaming process is significantly faster than the traditional
 # disk-based loading method.
 steps:
-  - label: "Correctness tests for runai_model_streamer_loader"
-    key: "runai_model_streamer_loader_CorrectnessTest"
+  - label: "Correctness Test | JAX UniProcExecutor"
+    key: "runai_model_streamer_loader_jax_uniproc"
     soft_fail: true
     agents:
       queue: tpu_v6e_queue
     commands:
-      - .buildkite/scripts/run_in_docker.sh python3 -m pytest -s -v /workspace/tpu_inference/tests/e2e/test_runai_model_streamer_loader.py::test_correctness
-  - label: "Record correctness test result for runai_model_streamer_loader"
-    key: "record_runai_model_streamer_loader_CorrectnessTest"
-    depends_on: "runai_model_streamer_loader_CorrectnessTest"
+      - .buildkite/scripts/run_in_docker.sh python3 -m pytest -s -v /workspace/tpu_inference/tests/e2e/test_runai_model_streamer_loader.py::test_correctness_jax_uni_proc_executor
+  - label: "Record Result | JAX UniProcExecutor"
+    key: "record_runai_model_streamer_loader_jax_uniproc"
+    depends_on: "runai_model_streamer_loader_jax_uniproc"
     env:
       CI_TARGET: "runai_model_streamer_loader"
       CI_STAGE: "CorrectnessTest"
@@ -38,17 +38,17 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh runai_model_streamer_loader_CorrectnessTest
-  - label: "Correctness tests for runai_model_streamer_loader with codegemma"
-    key: "runai_model_streamer_loader_CorrectnessTest_codegemma"
+        .buildkite/scripts/record_step_result.sh runai_model_streamer_loader_jax_uniproc
+  - label: "Correctness Test | Torchax UniProcExecutor"
+    key: "runai_model_streamer_loader_torchax_uniproc"
     soft_fail: true
     agents:
       queue: tpu_v6e_queue
     commands:
-      - .buildkite/scripts/run_in_docker.sh python3 -m pytest -s -v /workspace/tpu_inference/tests/e2e/test_runai_model_streamer_loader.py::test_correctness_codegemma
-  - label: "Record correctness test result for runai_model_streamer_loader with codegemma"
-    key: "record_runai_model_streamer_loader_CorrectnessTest_codegemma"
-    depends_on: "runai_model_streamer_loader_CorrectnessTest_codegemma"
+      - .buildkite/scripts/run_in_docker.sh python3 -m pytest -s -v /workspace/tpu_inference/tests/e2e/test_runai_model_streamer_loader.py::test_correctness_torchax_uni_proc_executor
+  - label: "Record Result | Torchax UniProcExecutor"
+    key: "record_runai_model_streamer_loader_torchax_uniproc"
+    depends_on: "runai_model_streamer_loader_torchax_uniproc"
     env:
       CI_TARGET: "runai_model_streamer_loader"
       CI_STAGE: "CorrectnessTest"
@@ -57,4 +57,32 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh runai_model_streamer_loader_CorrectnessTest_codegemma
+        .buildkite/scripts/record_step_result.sh runai_model_streamer_loader_torchax_uniproc
+
+  - label: "Correctness Test | JAX RayDistributedExecutor"
+    key: "runai_model_streamer_loader_jax_ray_distributed"
+    soft_fail: true
+    agents:
+      queue: tpu_v6e_8_queue # Using a queue with more devices for distributed tests
+    commands:
+      - .buildkite/scripts/run_in_docker.sh python3 -m pytest -s -v /workspace/tpu_inference/tests/e2e/test_runai_model_streamer_loader.py::test_correctness_jax_ray_distributed_executor
+
+  - label: "Correctness Test | Torchax RayDistributedExecutor"
+    key: "runai_model_streamer_loader_torchax_ray_distributed"
+    soft_fail: true
+    agents:
+      queue: tpu_v6e_8_queue # Using a queue with more devices for distributed tests
+    commands:
+      - .buildkite/scripts/run_in_docker.sh python3 -m pytest -s -v /workspace/tpu_inference/tests/e2e/test_runai_model_streamer_loader.py::test_correctness_torchax_ray_distributed_executor
+  - label: "Record Result | Torchax RayDistributedExecutor"
+    key: "record_runai_model_streamer_loader_torchax_ray_distributed"
+    depends_on: "runai_model_streamer_loader_torchax_ray_distributed"
+    env:
+      CI_TARGET: "runai_model_streamer_loader"
+      CI_STAGE: "CorrectnessTest"
+      CI_CATEGORY: "feature support matrix"
+    agents:
+      queue: cpu
+    commands:
+      - |
+        .buildkite/scripts/record_step_result.sh runai_model_streamer_loader_torchax_ray_distributed

--- a/tpu_inference/worker/tpu_worker.py
+++ b/tpu_inference/worker/tpu_worker.py
@@ -82,6 +82,13 @@ class TPUWorker:
         self.pp_config = PPConfig(rank, ip, prev_worker_ip,
                                   self.parallel_config.pipeline_parallel_size)
 
+        # Explicitly trigger RunAI download on the worker if needed.
+        # This handles downloading config.json and other non-weight files to the
+        # worker's local cache before VllmModelWrapper initialization.
+        if hasattr(self.model_config, "maybe_pull_model_tokenizer_for_runai"):
+            self.model_config.maybe_pull_model_tokenizer_for_runai(
+                self.model_config.model, self.model_config.tokenizer)
+
         # Delay profiler initialization to the start of the profiling.
         # This is because in vLLM V1, MP runtime is initialized before the
         # TPU Worker is initialized. The profiler server needs to start after


### PR DESCRIPTION
# Description

Support RunAI model streamer for RayDistributedExecutor Torchax path. Before this PR, RunAI + Leader worker set (multi-host) doesn’t work because  RayDistributedExecutor incorrectly propagates the leader's local cache path to workers instead of the original GCS URI, causing HFValidationError on workers. 

The current workaround required mounting shared RWX storage to /root/.cache/vllm/assets/model_streamer/<hash>/ and manually copying model files before startup. This requires deep internal knowledge of RayDistributedExecutor and is not a viable customer solution.

Now with this PR, RayDistributedExecutor is supported for the RunAI model streamer with MODEL_IMPL_TYPE=vllm without this shared storage. MODEL_IMPL_TYPE=flax_nnx (JAX path) is more involved, and will be in follow up PR.  I also added a new test case to test this path (test_correctness_torchax_ray_distributed_executor), and updated the naming of the other test cases to reflect the executor / jax or torchax path they trigger so we can make sure we cover all of the paths. Note that test_correctness_torchax_ray_distributed_executor doesn't actully test a multi-host setup since I don't think the CI pipeline is setup to be able to handle true multi-host, so please let me know if you know of a way to do this. 

# Tests

Built custom image with my change, and tested with [this LWS multi-host setup](https://paste.googleplex.com/5965967572205568). I confirmed model could start up as expected (it failed [later on](https://paste.googleplex.com/6017928690532352) in unrelated way)

Also ran the RunAI model streamer tests: 
```
pytest -s -v tests/e2e/test_runai_model_streamer_loader.py
========================================================== 3 passed, 10 warnings in 513.80s (0:08:33) ==========================================================
```


# Checklist

Before submitting this PR, please make sure:
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have made or will make corresponding changes to any relevant documentation.
