### PR TITLE
[Qwen2.5-VL] refactor jax-path to make naming more aligned with Huggingface

### DIFF
--- a/tpu_inference/models/jax/qwen2_5_vl.py
+++ b/tpu_inference/models/jax/qwen2_5_vl.py
@@ -32,7 +32,7 @@ from tpu_inference.layers.common.attention_interface import \
     sharded_flash_attention
 from tpu_inference.layers.common.attention_metadata import AttentionMetadata
 from tpu_inference.logger import init_logger
-from tpu_inference.models.jax.qwen2 import Qwen2ForCausalLM
+from tpu_inference.models.jax.qwen2 import Qwen2Model
 # from vllm.model_executor.models.interfaces import MultiModalEmbeddings
 from tpu_inference.models.jax.utils.multi_modal_utils import (
     MultiModalEmbeddings, merge_multimodal_embeddings)
@@ -768,7 +768,7 @@ class Qwen2_5_VLForConditionalGeneration(nnx.Module):
             mesh=mesh,
             norm_eps=getattr(config, "rms_norm_eps", 1e-6),
         )
-        self.language_model = Qwen2ForCausalLM(vllm_config, rng_key, mesh)
+        self.model = Qwen2Model(vllm_config, self.rng, mesh)
 
     def get_mrope_input_positions(
         self,
@@ -1040,7 +1040,7 @@ class Qwen2_5_VLForConditionalGeneration(nnx.Module):
             self, input_ids: jax.Array,
             multimodal_embeddings: Optional[jax.Array]) -> jax.Array:
 
-        inputs_embeds = self.language_model.model.embed(input_ids)
+        inputs_embeds = self.model.embed(input_ids)
 
 
         if multimodal_embeddings is not None \
@@ -1060,8 +1060,8 @@ class Qwen2_5_VLForConditionalGeneration(nnx.Module):
         *args,
     ) -> tuple[list[jax.Array], jax.Array, List[jax.Array]]:
         # The logic of choosing between input_ids and inputs_embeds is
-        # handled inside self.language_model.__call__
-        kv_caches, x, [] = self.language_model(
+        # handled inside self.model.__call__
+        kv_caches, x = self.model(
             kv_caches=kv_caches,
             input_ids=input_ids,
             attention_metadata=attention_metadata,
@@ -1070,42 +1070,43 @@ class Qwen2_5_VLForConditionalGeneration(nnx.Module):
         return kv_caches, x, []
 
     def compute_logits(self, hidden_states: jax.Array) -> jax.Array:
-        return self.language_model.compute_logits(hidden_states)
+        if self.vllm_config.model_config.hf_config.tie_word_embeddings:
+            logits = jnp.dot(hidden_states, self.model.lm_head.value.T)
+        else:
+            logits = jnp.dot(hidden_states, self.model.lm_head.value)
+        return logits
 
     def load_weights(self, rng_key: jax.Array) -> None:
         self.rng = nnx.Rngs(rng_key)
-        self.language_model.rng = self.rng
-
         # Key: path to a HF layer weight
         # Value: a tuple of (path to a nnx layer weight, nnx weight sharding)
 
         mappings = {
-            "model.embed_tokens": "language_model.model.embed.embedding",
+            "model.embed_tokens": "model.embed.embedding",
             "model.layers.*.input_layernorm":
-            "language_model.model.layers.*.input_layernorm.scale",
+            "model.layers.*.input_layernorm.scale",
             "model.layers.*.mlp.down_proj":
-            "language_model.model.layers.*.mlp.down_proj.kernel",
+            "model.layers.*.mlp.down_proj.kernel",
             "model.layers.*.mlp.gate_proj":
-            "language_model.model.layers.*.mlp.gate_proj.kernel",
-            "model.layers.*.mlp.up_proj":
-            "language_model.model.layers.*.mlp.up_proj.kernel",
+            "model.layers.*.mlp.gate_proj.kernel",
+            "model.layers.*.mlp.up_proj": "model.layers.*.mlp.up_proj.kernel",
             "model.layers.*.post_attention_layernorm":
-            "language_model.model.layers.*.post_attention_layernorm.scale",
+            "model.layers.*.post_attention_layernorm.scale",
             "model.layers.*.self_attn.k_proj":
-            "language_model.model.layers.*.self_attn.k_proj.kernel",
+            "model.layers.*.self_attn.k_proj.kernel",
             "model.layers.*.self_attn.o_proj":
-            "language_model.model.layers.*.self_attn.o_proj.kernel",
+            "model.layers.*.self_attn.o_proj.kernel",
             "model.layers.*.self_attn.q_proj":
-            "language_model.model.layers.*.self_attn.q_proj.kernel",
+            "model.layers.*.self_attn.q_proj.kernel",
             "model.layers.*.self_attn.v_proj":
-            "language_model.model.layers.*.self_attn.v_proj.kernel",
+            "model.layers.*.self_attn.v_proj.kernel",
             "model.layers.*.self_attn.q_proj.bias":
-            "language_model.model.layers.*.self_attn.q_proj.bias",
+            "model.layers.*.self_attn.q_proj.bias",
             "model.layers.*.self_attn.k_proj.bias":
-            "language_model.model.layers.*.self_attn.k_proj.bias",
+            "model.layers.*.self_attn.k_proj.bias",
             "model.layers.*.self_attn.v_proj.bias":
-            "language_model.model.layers.*.self_attn.v_proj.bias",
-            "model.norm": "language_model.model.norm.scale",
+            "model.layers.*.self_attn.v_proj.bias",
+            "model.norm": "model.norm.scale",
             "visual.blocks.*.attn.proj.bias": "visual.blocks.*.attn.proj.bias",
             "visual.blocks.*.attn.proj": "visual.blocks.*.attn.proj.kernel",
             "visual.blocks.*.attn.qkv.bias":
@@ -1137,7 +1138,7 @@ class Qwen2_5_VLForConditionalGeneration(nnx.Module):
         hf_config = self.vllm_config.model_config.hf_config
         if not hf_config.tie_word_embeddings:
             mappings.update({
-                "lm_head": "language_model.model.lm_head",
+                "lm_head": "model.lm_head",
             })
 
         loader = self.WeightLoader(self.vllm_config, self.mesh)


### PR DESCRIPTION
# Description

This is prepare for a later fix for #1479 

# Tests

`vllm serve Qwen/Qwen2.5-VL-3B-Instruct`
`pytest tests/e2e/test_multi_modal_inference.py`

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
