### PR TITLE
Support pooling-model and embedding task

### DIFF
--- a/tests/runner/test_tpu_runner.py
+++ b/tests/runner/test_tpu_runner.py
@@ -236,6 +236,7 @@ class TestTPUJaxRunnerMultimodalModelLoadedForTextOnly:
         return (
             MagicMock(),  # TPUModelRunner.model_fn
             MagicMock(),  # TPUModelRunner.compute_logits_fn
+            MagicMock(),  # TPUModelRunner.pooler_fn
             MagicMock(),  # TPUModelRunner.combine_hidden_states_fn
             mock_multimodal_fns,  # TPUModelRunner.multimodal_fns
             MagicMock(),  # TPUModelRunner.state (model params)

--- a/tpu_inference/layers/common/attention_metadata.py
+++ b/tpu_inference/layers/common/attention_metadata.py
@@ -36,7 +36,8 @@ class AttentionMetadata(object):
     # (padded_total_num_scheduled_tokens,)
     input_positions: jax.Array
     # (max_num_seqs * max_num_blocks_per_req,)
-    block_tables: jax.Array = None
+    # None for pooling models that using no KV cache
+    block_tables: jax.Array | None = None
     # (max_num_seqs,)
     seq_lens: jax.Array = None
     # (max_num_seqs + 1,)

--- a/tpu_inference/models/common/interface.py
+++ b/tpu_inference/models/common/interface.py
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Protocol
+
+import jax
+import numpy as np
+from vllm.v1.outputs import PoolerOutput
+from vllm.v1.pool.metadata import PoolingMetadata
+
+
+class PoolerFunc(Protocol):
+    """The wrapped pooler interface.
+
+    Accept hidden-state, pooling-metadata and sequence lengths.
+    Returns pooler output as a list of tensors, one per request.
+
+    The contract is dependent on vLLM lib.
+    """
+
+    def __call__(
+        self,
+        hidden_states: jax.Array,
+        pooling_metadata: PoolingMetadata,
+        seq_lens: np.ndarray,
+    ) -> PoolerOutput:
+        ...

--- a/tpu_inference/models/common/model_loader.py
+++ b/tpu_inference/models/common/model_loader.py
@@ -234,6 +234,10 @@ def _get_nnx_model(
     return jit_model
 
 
+def _not_support(*args, **kwargs):
+    raise NotImplementedError("The action on this path is not supported yet.")
+
+
 # TODO(pooyam): We need to refactor this. This is returning a bunch of functions that do not work with all models and this is not very easy to see from the code.
 def get_flax_model(
     vllm_config: VllmConfig,
@@ -345,7 +349,7 @@ def get_flax_model(
         "get_mrope_input_positions_fn": get_mrope_input_positions_fn,
     }
 
-    return model_fn, compute_logits_fn, combine_hidden_states_fn, multimodal_fns, state, lora_manager, model
+    return model_fn, compute_logits_fn, _not_support, combine_hidden_states_fn, multimodal_fns, state, lora_manager, model
 
 
 def get_vllm_model(
@@ -366,9 +370,10 @@ def get_vllm_model(
 
     jit_model = model.jit_step_func()
     compute_logits_fn = model.jit_compute_logits_func()
+    pooler_fn = model.build_pooler_func()
     # the model needs to be returned because lora weights are neither torch.nn.parameter nor torch.nn.buffer. After we load the lora weights and set it to the torch.nn.Module, we can shard it and move it to TPU.
     combine_hidden_states_fn = None
-    return jit_model, compute_logits_fn, combine_hidden_states_fn, None, params, lora_manager, model
+    return jit_model, compute_logits_fn, pooler_fn, combine_hidden_states_fn, None, params, lora_manager, model
 
 
 def get_model(

--- a/tpu_inference/runner/compilation_manager.py
+++ b/tpu_inference/runner/compilation_manager.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import time
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Callable, List, Optional, Tuple
 
 import jax
 import jax.numpy as jnp
@@ -97,7 +97,10 @@ class CompilationManager:
             if not self.runner.is_last_rank:
                 return
             self._precompile_select_from_array()
-            self._precompile_compute_logits()
+            if not self.runner.is_pooling_model:
+                self._precompile_compute_logits()
+            else:
+                self._precompile_compute_pooling()
             # Skip sampling if already precompiled before KV cache allocation
             if not self._sampling_precompiled:
                 self._precompile_sampling()
@@ -172,17 +175,16 @@ class CompilationManager:
                                             request_distribution,
                                             sharding=dp_sharding)
 
-        attention_metadata_per_layer: Dict[str, AttentionMetadata] = {}
-        uniform_attention_metadata: AttentionMetadata = None
-        for kv_cache_gid, kv_cache_group in enumerate(
-                self.runner.kv_cache_config.kv_cache_groups):
+        def build_block_table(kv_cache_gid: int) -> jax.Array:
             block_tables = self.runner.block_tables_cpu[
                 kv_cache_gid][:self.runner.max_num_reqs]
             block_tables = block_tables.reshape(-1)
             block_tables = device_array(self.runner.mesh,
                                         block_tables,
                                         sharding=dp_sharding)
+            return block_tables
 
+        def build_attn(block_tables: jax.Array | None) -> AttentionMetadata:
             attention_metadata_gid = AttentionMetadata(
                 input_positions=positions,
                 block_tables=block_tables,
@@ -190,13 +192,21 @@ class CompilationManager:
                 query_start_loc=query_start_loc,
                 request_distribution=request_distribution,
             )
-            if not self.runner.use_hybrid_kvcache:
-                # all layers share the same attention metadata
-                uniform_attention_metadata = attention_metadata_gid
-            else:
-                for layer_name in kv_cache_group.layer_names:
-                    attention_metadata_per_layer[
-                        layer_name] = attention_metadata_gid
+            return attention_metadata_gid
+
+        attention_metadata: AttentionMetadata | dict[str, AttentionMetadata]
+        if len(self.runner.kv_cache_config.kv_cache_groups) <= 1:
+            # Pooling model will not using kv cache
+            no_kv_cache = len(self.runner.kv_cache_config.kv_cache_groups) == 0
+            block_tables = build_block_table(0) if not no_kv_cache else None
+            attention_metadata = build_attn(block_tables)
+        else:
+            attention_metadata = {
+                name: build_attn(build_block_table(gid))
+                for gid, kv_cache_group in enumerate(
+                    self.runner.kv_cache_config.kv_cache_groups)
+                for name in kv_cache_group.layer_names
+            }
 
         def model_fn_wrapper(
             state,
@@ -222,10 +232,6 @@ class CompilationManager:
                 self.runner.lora_config, np.array([num_tokens],
                                                   dtype=np.int32)):
             lora_metadata = self.runner.lora_utils.extract_lora_metadata()
-            if self.runner.use_hybrid_kvcache:
-                attention_metadata = attention_metadata_per_layer
-            else:
-                attention_metadata = uniform_attention_metadata
             self._run_compilation(
                 name,
                 model_fn_wrapper,
@@ -485,6 +491,15 @@ class CompilationManager:
                     lora_metadata,
                     num_reqs=num_reqs,
                 )
+
+    def _precompile_compute_pooling(self) -> None:
+        logger.info("Compiling compute_pooling with different input shapes.")
+
+        # vLLM pooling layer design has complex and dynamic logic. There are
+        # interoperate between tensors from host and accelerator.
+        # It's quite hard, if not impossible, to move all tensor to accelerator
+        # and apply JIT on the entire computation.
+        # See PoolingCursor and AllPool, MeanPool ... in vLLM repo for details.
 
     def _precompile_sampling(self) -> None:
         logger.info("Compiling sampling with different input shapes.")

--- a/tpu_inference/runner/kv_cache_manager.py
+++ b/tpu_inference/runner/kv_cache_manager.py
@@ -230,6 +230,9 @@ class KVCacheManager:
     def initialize_kv_cache(self, kv_cache_config: KVCacheConfig) -> None:
         self.maybe_reinitialize_input_batch(kv_cache_config)
 
+        # There will be no KV cache for pooling models.
+        if not kv_cache_config.kv_cache_groups:
+            return
         # uniform page size.
         representative_spec = kv_cache_config.kv_cache_groups[0].kv_cache_spec
         page_size_bytes = representative_spec.page_size_bytes

--- a/tpu_inference/runner/persistent_batch_manager.py
+++ b/tpu_inference/runner/persistent_batch_manager.py
@@ -137,7 +137,7 @@ class PersistentBatchManager:
                 prompt_token_ids=new_req_data.prompt_token_ids,
                 mm_features=new_req_data.mm_features,
                 sampling_params=sampling_params,
-                pooling_params=None,
+                pooling_params=new_req_data.pooling_params,
                 generator=None,
                 block_ids=new_req_data.block_ids,
                 num_computed_tokens=new_req_data.num_computed_tokens,

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -59,6 +59,7 @@ from tpu_inference.layers.jax.sample.sampling import (compute_logprobs,
 from tpu_inference.layers.jax.sample.sampling_metadata import \
     TPUSupportedSamplingMetadata
 from tpu_inference.logger import init_logger
+from tpu_inference.models.common.interface import PoolerFunc
 from tpu_inference.models.common.model_loader import get_model
 from tpu_inference.models.jax.jax_intermediate_tensor import \
     JaxIntermediateTensors
@@ -277,6 +278,9 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
 
         self.kv_caches: list[jax.Array] = []
         self.layer_name_to_kvcache_index: dict[str, int] = {}
+
+        self.is_pooling_model: bool = self.model_config.runner_type == "pooling"
+        """Generative model or pooling model select different computations."""
 
     def _init_random(self):
         if self.model_config.seed is None:
@@ -507,7 +511,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                                             dtype=np.int64)
 
     def load_model(self):
-        self.model_fn, self.compute_logits_fn, self.combine_hidden_states_fn, multimodal_fns, self.state, self.lora_manager, self.model = get_model(
+        self.model_fn, self.compute_logits_fn, self.pooler_fn, self.combine_hidden_states_fn, multimodal_fns, self.state, self.lora_manager, self.model = get_model(
             self.vllm_config,
             self.rng_key,
             self.mesh,
@@ -542,7 +546,12 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                     f"hbm={common_utils.hbm_usage_gb(self.devices)}GiB")
 
     def get_supported_tasks(self) -> tuple[SupportedTask, ...]:
-        return ("generate", )
+        runner_type = self.model_config.runner_type
+        if runner_type == "generate":
+            return ("generate", )
+        if runner_type == "pooling":
+            return ("embed", )
+        assert False, f"unsupported runner type: {runner_type}"
 
     def get_kv_cache_spec(self):
         return self.kv_cache_manager.get_kv_cache_spec()
@@ -794,6 +803,27 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                 assert isinstance(hidden_states, JaxIntermediateTensors)
                 hidden_states.kv_connector_output = kv_connector_output
                 return hidden_states
+
+            if self.is_pooling_model:
+                seq_lens = self.seq_lens_cpu[:self.input_batch.num_reqs]
+                pooling_metadata = self.input_batch.get_pooling_metadata()
+
+                pooler_fn: PoolerFunc = self.pooler_fn
+                pooler_output = pooler_fn(
+                    hidden_states,
+                    pooling_metadata,
+                    seq_lens,
+                )
+
+                return ModelRunnerOutput(
+                    req_ids=self.input_batch.req_ids,
+                    req_id_to_index=self.input_batch.req_id_to_index,
+                    sampled_token_ids=[],
+                    logprobs=None,
+                    prompt_logprobs_dict={},
+                    pooler_output=pooler_output,
+                )
+
             hidden_states = self._select_from_array_fn(hidden_states,
                                                        logits_indices)
             logits = self.compute_logits_fn(
@@ -1416,10 +1446,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
              sharding=data_parallel_attn_sharding,
          )
 
-        attention_metadata_per_layer: Dict[str, AttentionMetadata] = {}
-        uniform_attention_metadata: AttentionMetadata = None
-        for kv_cache_gid, kv_cache_group in enumerate(
-                self.kv_cache_config.kv_cache_groups):
+        def build_block_table(kv_cache_gid: int) -> jax.Array:
             block_tables = self.block_tables_cpu[kv_cache_gid][:self.
                                                                max_num_reqs]
             for dp_rank in range(dp_size):
@@ -1437,7 +1464,9 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                 (block_tables),
                 sharding=data_parallel_attn_sharding,
             )
+            return block_tables
 
+        def build_attn(block_tables: jax.Array | None) -> AttentionMetadata:
             attention_metadata_gid = AttentionMetadata(
                 input_positions=positions,
                 block_tables=block_tables,
@@ -1449,13 +1478,21 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             # This is for making these cpu buffers hidden during tracing
             attention_metadata_gid.query_start_loc_cpu = query_start_loc_cpu
             attention_metadata_gid.seq_lens_cpu = seq_lens_cpu
+            return attention_metadata_gid
 
-            if not self.use_hybrid_kvcache:
-                uniform_attention_metadata = attention_metadata_gid
-            else:
-                for layer_name in kv_cache_group.layer_names:
-                    attention_metadata_per_layer[
-                        layer_name] = attention_metadata_gid
+        attention_metadata: AttentionMetadata | dict[str, AttentionMetadata]
+        if len(self.kv_cache_config.kv_cache_groups) <= 1:
+            # Pooling model will not using kv cache
+            no_kv_cache = len(self.kv_cache_config.kv_cache_groups) == 0
+            block_tables = build_block_table(0) if not no_kv_cache else None
+            attention_metadata = build_attn(block_tables)
+        else:
+            attention_metadata = {
+                name: build_attn(build_block_table(gid))
+                for gid, kv_cache_group in enumerate(
+                    self.kv_cache_config.kv_cache_groups)
+                for name in kv_cache_group.layer_names
+            }
 
         # Async scheduling: substitute placeholder tokens for DP
         if self.scheduler_config.async_scheduling and self._pre_async_results is not None:
@@ -1485,10 +1522,6 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                 padded_total_num_scheduled_tokens,
             )
 
-        if self.use_hybrid_kvcache:
-            attention_metadata = attention_metadata_per_layer
-        else:
-            attention_metadata = uniform_attention_metadata
         return (
             input_ids,
             positions,
@@ -1634,10 +1667,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
              self.mesh, (input_ids, positions, query_start_loc, seq_lens,
                          logits_indices, request_distribution))
 
-        attention_metadata_per_layer: Dict[str, AttentionMetadata] = {}
-        uniform_attention_metadata: AttentionMetadata = None
-        for kv_cache_gid, kv_cache_group in enumerate(
-                self.kv_cache_config.kv_cache_groups):
+        def build_block_table(kv_cache_gid: int) -> jax.Array:
             block_tables = self.block_tables_cpu[kv_cache_gid][:self.
                                                                max_num_reqs]
             block_tables[:num_reqs] = (
@@ -1646,7 +1676,9 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             # Convert block_tables to 1D on cpu.
             block_tables = block_tables.reshape(-1)
             block_tables = device_array(self.mesh, (block_tables))
+            return block_tables
 
+        def build_attn(block_tables: jax.Array | None) -> AttentionMetadata:
             attention_metadata_gid = AttentionMetadata(
                 input_positions=positions,
                 block_tables=block_tables,
@@ -1656,14 +1688,21 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             # This is for making these cpu buffers hidden during tracing
             attention_metadata_gid.query_start_loc_cpu = query_start_loc_cpu
             attention_metadata_gid.seq_lens_cpu = seq_lens_cpu
+            return attention_metadata_gid
 
-            if not self.use_hybrid_kvcache:
-                # all layers share the same attention metadata
-                uniform_attention_metadata = attention_metadata_gid
-            else:
-                for layer_name in kv_cache_group.layer_names:
-                    attention_metadata_per_layer[
-                        layer_name] = attention_metadata_gid
+        attention_metadata: AttentionMetadata | dict[str, AttentionMetadata]
+        if len(self.kv_cache_config.kv_cache_groups) <= 1:
+            # Pooling model will not using kv cache
+            no_kv_cache = len(self.kv_cache_config.kv_cache_groups) == 0
+            block_tables = build_block_table(0) if not no_kv_cache else None
+            attention_metadata = build_attn(block_tables)
+        else:
+            attention_metadata = {
+                name: build_attn(build_block_table(gid))
+                for gid, kv_cache_group in enumerate(
+                    self.kv_cache_config.kv_cache_groups)
+                for name in kv_cache_group.layer_names
+            }
 
         if self.scheduler_config.async_scheduling and len(
                 token_in_tpu_cur_input_indices) > 0:
@@ -1678,10 +1717,6 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                 padded_total_num_scheduled_tokens)
         logits_indices_selector = None
 
-        if self.use_hybrid_kvcache:
-            attention_metadata = attention_metadata_per_layer
-        else:
-            attention_metadata = uniform_attention_metadata
         return (input_ids, positions, attention_metadata, sampling_metadata,
                 logits_indices, spec_decode_metadata, logits_indices_selector,
                 padded_num_reqs)

--- a/tpu_inference/spec_decode/jax/eagle3.py
+++ b/tpu_inference/spec_decode/jax/eagle3.py
@@ -68,7 +68,7 @@ class Eagle3Proposer:
 
     def load_model(self, target_model: Any) -> None:
         """Loads the draft model."""
-        self.model_fn, self.compute_logits_fn, self.combine_hidden_states_fn, _, self.state, _, _ = get_model(
+        self.model_fn, self.compute_logits_fn, self.pooler_fn, self.combine_hidden_states_fn, _, self.state, _, _ = get_model(
             self.vllm_config, self.rng_key, self.mesh, is_draft_model=True)
 
         draft_embed_tokens = getattr(self.state.model, 'embed_tokens', None)


### PR DESCRIPTION
# Description

Support pooling-model for embedding task.

vLLM does support [pooling-model > embed-task](https://docs.vllm.ai/en/stable/models/supported_models/#embedding) for
- type A: models that are pooling-models natively
- type B: in-place conversion of generative-models.

This PR covers both types of usage.

From the perspective of attention type (using vLLM notation)

* encoder-only attention (bidirectional attention)
* decoder attention (causal attention)

This PR covers models that use encoder-only attention, and partially covers decoder attention.
*For decoder attention, it's functional when the prompt is not chunked (token-len for that particular req is smaller than max-num-batched-tokens).*

Note: The encoder-attention mechanism itself is not supported by tpu-inference yet.

~To support encoder-only attention, we reuse splash attention kernel from jax library.
The kernel block size is not tuned yet.~

We implements pooling calculation for pooler model, reusing pooler logic from vLLM model implementation`. Also we refactor and adjust the attention metadata building logics, fixing and adjust the logic for tracking pooling parameter for incoming requests. 

~Also upgrade `torchax` to v0.0.11 address some lacked operations that's used by vLLM BERT model implementation.~

~Note: Previously in this PR we try to use `tokamax` splash attention implementation, but we switch to the implementation from jax librarary, as there is no noticeable performance difference and `tokamax` requires an upgrade of `jaxlib` which introduce too much test breaking to be solved here.~

Co-developed-by: Yuyan Peng <yuyanpeng@google.com>

## TODOs

This PR still in progress, TODOs to be resolved by this PR includes at least:

- [x] ~Resolve package conflicts that prevent we from using `tokamax==0.0.8`.~
- [x] Include minimal unit test for pooler-mode / embedding-task.
- [x] Find better location for PoolerFunc definition
- [x] Fix all test error, if any

## Other Notes

- The attention-metadata building logics should be equivalent to previous ones,
  with just the additional case for no-kv-cache.
- It's quite hard, if not impossible, to apply JAX JIT on pooling calculation.
  Since that some `PoolingMethod` and `PoolingCursor` are highly coupled
  with values(tensors) on CPU.
- Lots of change in `tpu_inference/runner/input_batch.py`, ignore leading space
  change is easier to read.


# Tests

No test included yet, we can manually compare the output from GPU and TPU
to ensure the correctness of this implementation.

```sh
python embed.py # generate embed-output.json
python compare.py "<embed-output-tpu>" "<embed-output-gpu>"
```

```text
raw text length: 24
cosine similarity: 0.9999927391643547
raw content: Hello, my name is Alice.

raw text length: 266
cosine similarity: 0.9999763756061478
raw content: In today's fast-paced world, finding a balance between productivity and mindfulness has become more important than ever. As urban landscapes continue to evolve, people are looking for ways to reconnect with nature without losing the convenience of modern technology.

raw text length: 86
cosine similarity: 0.9999711595060252
raw content: 最近の技術革新により、私たちの日常生活は劇的に変化しました。都市の風景は新旧の建築が入り混じり、静かな朝の光が窓から差し込む中で、人々はそれぞれの目的を持って歩き始めます。

raw text length: 37
cosine similarity: 0.9999864471473087
raw content: 최근 기술의 발전과 함께 우리의 일상에는 많은 변화가 찾아왔습니다.
```

See appendix for the testing scripts.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.

# Appendix

`embed.py`

```python
import json

from vllm import LLM


def main():
    model = "intfloat/multilingual-e5-large-instruct"
    # model = "Qwen/Qwen3-Embedding-0.6B"  # for type B

    llm = LLM(
        model=model,
        runner="pooling",
        max_num_seqs=64,
        max_num_batched_tokens=1024,
        max_model_len=512,
        dtype="float32",
    )

    inputs = [
        "Hello, my name is Alice.",
        "In today's fast-paced world, finding a balance between productivity "
        "and mindfulness has become more important than ever. As urban "
        "landscapes continue to evolve, people are looking for ways to "
        "reconnect with nature without losing the convenience of modern "
        "technology.",
        "最近の技術革新により、私たちの日常生活は劇的に変化しました。"
        "都市の風景は新旧の建築が入り混じり、静かな朝の光が窓から差し込む中で、"
        "人々はそれぞれの目的を持って歩き始めます。",
        "최근 기술의 발전과 함께 우리의 일상에는 많은 변화가 찾아왔습니다.",
    ]
    results = llm.embed(inputs)
    report = dict(zip(inputs, [r.outputs.embedding for r in results]))

    with open("embed-output.json", "w") as f:
        json.dump(report, f, indent=4)


if __name__ == "__main__":
    main()
```

`compare.py`

```python
import json
import sys

import numpy as np


def cosine_similarity(values1: list[float], values2: list[float]) -> float:
    vec1, vec2 = np.array(values1), np.array(values2)
    assert vec1.shape == vec2.shape

    dot_product = np.dot(vec1, vec2)
    norm_vec1, norm_vec2 = np.linalg.norm(vec1), np.linalg.norm(vec2)
    return dot_product / (norm_vec1 * norm_vec2)


if __name__ == "__main__":
    assert len(sys.argv) == 3

    # report: text-document (str) to embedding (list[float])
    def read(path: str) -> dict[str, list[float]]:
        with open(path) as f:
            return json.load(f)

    report1, report2 = read(sys.argv[1]), read(sys.argv[2])
    for key in report1:
        similarity = cosine_similarity(report1[key], report2[key])
        print(f"raw text length: {len(key)}")
        print(f"cosine similarity: {similarity}")
        print(f"raw content: {key}")
        print()
```
