### PR TITLE
[DeepSeek][JAX] Minor patch to support TPU-Friendly FP8 checkpoints

### DIFF
--- a/tpu_inference/models/jax/utils/qwix/qwix_utils.py
+++ b/tpu_inference/models/jax/utils/qwix/qwix_utils.py
@@ -511,11 +511,17 @@ def get_default_qwix_quantization_config(
             for rule in config["qwix"]["rules"]:
                 if "tile_size" in rule:
                     rule["tile_size"] = tile_size
+                # TODO (jacobplatin): need to make this MUCH more robust, but basically the TPU-friendly checkpoints
+                # always (for now) keep FP8 for the attention layers but can be FP4 or FP8 for the MLP layers
+                mlp_dtype = hf_quant_config.get("tpu_settings",
+                                                {}).get("mlp_dtype", None)
+                if mlp_dtype is not None and rule[
+                        "weight_qtype"] == "float4_e2m1fn":
+                    rule["weight_qtype"] = mlp_dtype
         else:
             raise ValueError(
                 f"Invalid weight_block_size config: {block_size}, expected a list/tuple of length 2"
             )
-
         return config
     elif model_type == "llama4" and quant_method == "compressed-tensors":
         return DEFAULT_LLAMA4_FP8_CONFIG


### PR DESCRIPTION
# Description

In this PR, I add a minor patch to ensure that Jordan's TPU-Friendly FP8 checkpoint (located [here](https://huggingface.co/jrplatin/DeepSeek-R1-1D-Subchannel-256-FP8)) can be loaded.

This isn't very robust for now, but with this FP8 checkpoint, I updated the config so that the MLP (which defaults to FP4) can use FP8:
<img width="380" height="115" alt="image" src="https://github.com/user-attachments/assets/6d93a49b-03d0-4184-aaf7-a8a772b6820e" />


# Tests

Verified MMLU:

```
============ Serving Benchmark Result ============
Successful requests:                     1000      
Benchmark duration (s):                  83.65     
Total input tokens:                      162129    
Total generated tokens:                  2000      
Request throughput (req/s):              11.95     
Output token throughput (tok/s):         23.91     
Total token throughput (tok/s):          1962.15   
---------------Time to First Token----------------
Mean TTFT (ms):                          47390.92  
Median TTFT (ms):                        49800.86  
P99 TTFT (ms):                           80902.63  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          505.34    
Median TPOT (ms):                        498.20    
P99 TPOT (ms):                           501.20    
---------------Inter-token Latency----------------
Mean ITL (ms):                           505.34    
Median ITL (ms):                         498.20    
P99 ITL (ms):                            501.20    
----------------End-to-end Latency----------------
Mean E2EL (ms):                          47896.25  
Median E2EL (ms):                        50299.12  
P99 E2EL (ms):                           81394.90  
==================================================
Evaluating MMLU...
[nltk_data] Downloading package punkt to
[nltk_data]     /home/jacobplatin_google_com/nltk_data...
[nltk_data]   Package punkt is already up-to-date!
[nltk_data] Downloading package punkt_tab to
[nltk_data]     /home/jacobplatin_google_com/nltk_data...
[nltk_data]   Package punkt_tab is already up-to-date!

Results

{'accuracy': 0.843, 'gen_num': 1000}
``

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
