### PR TITLE
Unify the casing for command keyword in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -68,7 +68,7 @@ COPY requirements_benchmarking.txt .
 RUN --mount=type=cache,target=/root/.cache/pip pip install -r requirements_benchmarking.txt --retries 3
 # Install test requirements
 COPY requirements_test.txt .
-Run  --mount=type=cache,target=/root/.cache/pip if [ "$IS_TEST" = "true" ]; then \
+RUN  --mount=type=cache,target=/root/.cache/pip if [ "$IS_TEST" = "true" ]; then \
         pip install -r requirements_test.txt --retries 3; \
     fi
 COPY . .


### PR DESCRIPTION
# Description

Avoid warning message during docker build process.
```
WARN: ConsistentInstructionCasing: Command 'Run' should match the case of the command majority (uppercase) (line 71)
```

# Tests

No test required.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
