### PR TITLE
Fix llama4 embedder and lm head sharding

### DIFF
--- a/tpu_inference/models/jax/llama4.py
+++ b/tpu_inference/models/jax/llama4.py
@@ -442,8 +442,7 @@ class Llama4ForCausalLM(nnx.Module):
         self.embedder = Embedder(vocab_size=self.vocab_size,
                                  hidden_size=self.hidden_size,
                                  dtype=dtype,
-                                 vd_sharding=(('data', 'expert', 'model'),
-                                              None),
+                                 vd_sharding=(('data', 'model'), None),
                                  rngs=self.rng,
                                  random_init=force_random_weights)
 
@@ -579,8 +578,8 @@ class Llama4ForCausalLM(nnx.Module):
                               hidden_size=self.hidden_size,
                               dtype=dtype,
                               rngs=self.rng,
-                              vd_sharding=(('data', 'expert', 'model'), None),
-                              dv_sharding=(None, ('data', 'expert', 'model')),
+                              vd_sharding=(('data', 'model'), None),
+                              dv_sharding=(None, ('data', 'model')),
                               random_init=force_random_weights)
         if self.is_verbose:
             self._print_model_architecture()


### PR DESCRIPTION
# Description

Fix the embedder and lm head sharding for llama4 model. Ran into the weight loading error on `meta-llama/Llama-4-Scout-17B-16E-Instruct`, `ValueError: Resource axis: expert of PartitionSpec(('data', 'expert', 'model'), None) is not found in mesh: ('data', 'model').`

# Tests

E2E run passed: `python examples/offline_inference.py --model meta-llama/Llama-4-Scout-17B-16E-Instruct --tensor-parallel-size 8 --hf_overrides '{"architectures": ["Llama4ForCausalLM"]}'`

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
