### PR TITLE
Integrate with google-cloud-mldiagnostics (optional).

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,0 +1,3 @@
+# This file contains additional dependencies needed for TPU v7x support.
+# It is expected to be used in conjunction with the main requirements.txt file.
+google-cloud-mldiagnostics

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -231,6 +231,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         rank: int = 0,
         is_first_rank: bool = True,
         is_last_rank: bool = True,
+        mlrun: Any = None,
     ):
         self.vllm_config = vllm_config
         self.model_config = vllm_config.model_config
@@ -243,6 +244,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         self.speculative_config = vllm_config.speculative_config
         self.observability_config = vllm_config.observability_config
         self.device_config = vllm_config.device_config
+        self.mlrun = mlrun
 
         self.devices = devices
         self.dtype = self.model_config.dtype
@@ -377,7 +379,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         self.phase_based_profiler = None
         if self.phased_profiling_dir:
             self.phase_based_profiler = runner_utils.PhasedBasedProfiler(
-                self.phased_profiling_dir)
+                self.phased_profiling_dir, self.mlrun)
 
     def _init_mm(self) -> None:
         self.is_multimodal_model = None


### PR DESCRIPTION
# Description

Add optional integration with MLDiagnostics service.

# Motivition

When enable allows customer to diagnose tpu vllm performance through MLDiagnostics service and avoid manual provisioning of Tensorboard UI with Xprof. See more details https://github.com/AI-Hypercomputer/google-cloud-mldiagnostics

# Changes

*Applied only if profiling and env `ENABLE_GOOGLE_DIAGON_ML_DIAGNOSTICS` enabled*

1. `tpu_worker` add hook to notify MLDiagnostics if worker started
2. `tpu_worker`, `tpu_runner` and `utils.PhasedBasedProfiler` tune folder structure for xprof profiling data to be readable by MLDiagnostics Xprof UI.

# Tests

- Unit tests added
- Manual integration tests completed

