### PR TITLE
Update DEFAULT_NUM_BLOCKS_FOR_JIT_KV_CACHE value to 2048

### DIFF
--- a/tpu_inference/models/jax/utils/qwix/qwix_utils.py
+++ b/tpu_inference/models/jax/utils/qwix/qwix_utils.py
@@ -30,7 +30,7 @@ from tpu_inference.utils import device_array
 logger = init_logger(__name__)
 
 QUANTIZATION_CONFIG_PATH = os.path.join(os.path.dirname(__file__), "configs")
-DEFAULT_NUM_BLOCKS_FOR_JIT_KV_CACHE = 2000
+DEFAULT_NUM_BLOCKS_FOR_JIT_KV_CACHE = 2048
 DEFAULT_NUM_TOKENS_FOR_MODEL_INPUTS = 512
 DEFAULT_MAX_NUM_SEQS_FOR_MODEL_INPUTS = 256
 DEFAULT_MAX_NUM_BLOCKS_PER_REQ = 16


### PR DESCRIPTION
# Description

Update DEFAULT_NUM_BLOCKS_FOR_JIT_KV_CACHE value to 2048

Setting a number which is divisible by TPU devices(sharding), as they are in power of 2s.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
