### PR TITLE
Fix the last_rank checking logic to enable TP in multi-host on Ray cluster

### DIFF
--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -48,7 +48,6 @@ from vllm.v1.worker.lora_model_runner_mixin import LoRAModelRunnerMixin
 
 import tpu_inference.envs as envs
 from tpu_inference import utils as common_utils
-from tpu_inference.distributed.jax_parallel_state import get_pp_group
 from tpu_inference.layers.common.attention_metadata import AttentionMetadata
 from tpu_inference.layers.common.sharding import (MESH_AXIS_NAMES,
                                                   MESH_AXIS_NAMES_2D,


### PR DESCRIPTION
# Description

Use the right last_rank parameter to decide the execution logic for multi-host TP

#Tests

examples/disagg/run_disagg_multi_host.sh

