### PR TITLE
Better moe performance by topk reduction first and psum in fused_moe_gmm

### DIFF
--- a/tpu_inference/layers/common/fused_moe_gmm.py
+++ b/tpu_inference/layers/common/fused_moe_gmm.py
@@ -200,7 +200,7 @@ def tensor_sharded_gmm_row_parallel(
         )
 
         # Perform local reverse sort and reduction on the topk experts of
-        # a token. This will save psum size by 1/8 compared with psum first
+        # a token. Psum size will be 1/top_k compared with psum first
         # and run reduction later
         out = out[topk_argsort_revert_indices_local].reshape((-1, topk, n))
         out = out * jnp.expand_dims(topk_weights_local, axis=-1)


### PR DESCRIPTION
# Description


Perform local reverse sort and reduction on the topk experts of a token.
The psum size now will be 1/top_k compared with psum first and run reduction later.

Benchmark

seq_len = 8192
num_tokens = B * seq_len
hidden_size = 6144
intermediate_size = 2560
num_experts = 160
topk = 8

Before: Step 15.4ms, psum 9.2ms
After: Step 7.3ms, psum 1.1ms



# Tests
vllm chat to confirm the basic E2E responses. Colab for the layer to compare the output with original code with no major deviation.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
