### PR TITLE
Fix PP rank in Ray

### DIFF
--- a/tpu_inference/executors/ray_distributed_executor.py
+++ b/tpu_inference/executors/ray_distributed_executor.py
@@ -30,7 +30,6 @@ from vllm.v1.executor.ray_executor import RayWorkerMetaData
 from vllm.v1.executor.ray_utils import RayWorkerWrapper as RayWorkerWrapperV1
 from vllm.v1.executor.ray_utils import _wait_until_pg_ready
 
-from tpu_inference.distributed.jax_parallel_state import get_pp_group
 from tpu_inference.logger import init_logger
 from tpu_inference.models.jax.jax_intermediate_tensor import \
     JaxIntermediateTensors
@@ -391,11 +390,7 @@ class RayWorkerWrapper(RayWorkerWrapperV1):
     The implementation is similar to vllm/v1/executor/ray_utils.py
     
     _is_intermediate_tensors: check whether the output is JaxIntermediateTensors.
-    _is_last_rank: check whether the worker is the last rank in the PP group.
     """
 
     def _is_intermediate_tensors(self, output) -> bool:
         return isinstance(output, JaxIntermediateTensors)
-
-    def _is_last_rank(self) -> bool:
-        return get_pp_group().is_last_rank

--- a/tpu_inference/platforms/tpu_platform.py
+++ b/tpu_inference/platforms/tpu_platform.py
@@ -186,6 +186,9 @@ class TpuPlatform(Platform):
             parallel_config.distributed_executor_backend = RayDistributedExecutor
             logger.info(
                 "Force using RayDistributedExecutor for JAX on multihost.")
+            if parallel_config.pipeline_parallel_size > 1:
+                raise ValueError(
+                    "PP on Ray is disabled due to a pending change on vLLM.")
         else:
             logger.warning(
                 f"Unknown TPU multihost backend: {multihost_backend}. "


### PR DESCRIPTION
# Description

This PR fixes the below issue:

For example we have 4 hosts each with 1 chip, and we run a model with TP=4, it creates 4 ray workers (because Ray determined 4 ray nodes) with rank as 0,1,2,3 respectively. However, when we construct PP coordinator, the world_size is set to 1 (as --pipeline-parallel-size = 1). This mismatch leads wrong results in `get_pp_group().is_first_rank` and `get_pp_group().is_last_rank`.  If PP>1, the Ray distributor already has the constraint that number of ray nodes should equal to PP, which means there will be exactly PP number of ray workers, so PP>1 is fine. The fix here is to set/adjust Ray worker's rank to 0 if PP=1.

Besides, it temporarily disables Ray + PP workload, as there's a pending vLLM change needs to be checked in first.  https://github.com/vllm-project/vllm/pull/33012

# Tests

I created 4 Ray nodes, each with 1 chip,  ran TP and  PP respectively, the E2E tests passed
`python examples/offline_inference.py --pipeline-parallel-size 4 --no-async-scheduling`
`python examples/offline_inference.py --pipeline-parallel-size 4 --no-async-scheduling`

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
