### PR TITLE
Fix pip install command syntax in installation.md

### DIFF
--- a/docs/getting_started/installation.md
+++ b/docs/getting_started/installation.md
@@ -31,7 +31,7 @@ There are three ways to install `tpu-inference`:
 
     ```shell
     # v6e and prior
-    pip install vllm-tpu --version=0.13.2.post6
+    pip install vllm-tpu==0.13.2.post6
 
     # v7x
     pip install vllm-tpu


### PR DESCRIPTION
**Description**: The installation command in installation.md incorrectly uses --version=, which is not a valid pip argument and causes the command to fail.

This PR updates the command to use the standard == specifier for pinning the version.

#### The previous pip was :

`pip install vllm-tpu --version=0.13.2.post6 `

#### Now changed to:

`pip install vllm-tpu==0.13.2.post6`