### PR TITLE
[CI] Avoid pending status on skipped jobs

### DIFF
--- a/.buildkite/pipeline_jax.yml
+++ b/.buildkite/pipeline_jax.yml
@@ -127,9 +127,7 @@ steps:
              --ignore=/workspace/tpu_inference/tests/kernels/ragged_kv_cache_update_v2_test.py \
              --ignore=/workspace/tpu_inference/tests/kernels/collectives
          else
-           buildkite-agent step update "label" "🚫 (Skipped) JAX unit tests - kernels"
-           buildkite-agent annotate "Step skipped because no changes were detected in kernel files." --style "info" --context "skip-kernels"
-           echo "Skipping: no changes detected in kernels, tests/kernels, or requirements.txt"
+           echo "Skipping: Step requires either a NIGHTLY build or changes in kernels, kernel tests, or requirements.txt."
            exit 0
          fi
 
@@ -146,9 +144,7 @@ steps:
            .buildkite/scripts/run_in_docker.sh \
              python3 -m pytest -s -v -x /workspace/tpu_inference/tests/kernels/collectives
          else
-           buildkite-agent step update "label" "🚫 (Skipped) JAX unit tests - kernels"
-           buildkite-agent annotate "Step skipped because no changes were detected in kernel files." --style "info" --context "skip-kernels"
-           echo "Skipping: no changes detected in kernels/collectives, tests/kernels/collectives, or requirements.txt"
+           echo "Skipping: Step requires either a NIGHTLY build or changes in kernels/collectives, tests, or requirements.txt."
            exit 0
          fi
 
@@ -241,9 +237,7 @@ steps:
          if [[ "$$IS_FOR_V7X" == "true" ]] && { [[ "$$NIGHTLY" == "1" ]] || git diff --name-only HEAD~1 | grep -qE '^(tpu_inference/kernels|tests/kernels|requirements.txt)'; }; then
            .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/check_lm_eval.sh  --model_name "Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8" --use_moe_ep_kernel 1 --tensor_parallel_size 8 --max_model_len 2048 --max_num_batched_tokens 2048 --max_gen_toks 256 --enable_expert_parallel 1 --flex_threshold 0.85 --strict_threshold 0.70
          else
-           buildkite-agent step update "label" "🚫 (Skipped) JAX unit tests - kernels"
-           buildkite-agent annotate "Step skipped because no changes were detected in kernel files." --style "info" --context "skip-kernels"
-           echo "Skipping: test only runs on v7x."
+           echo "Skipping: Step requires TPU v7x and either a NIGHTLY build or kernel/requirements changes."
            exit 0
          fi
 
@@ -259,9 +253,7 @@ steps:
          if [[ "$$IS_FOR_V7X" == "true" ]] && { [[ "$$NIGHTLY" == "1" ]] || git diff --name-only HEAD~1 | grep -qE '^(tpu_inference/kernels|tests/kernels|requirements.txt)'; }; then
            .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/check_lm_eval.sh  --model_name "Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8" --use_moe_ep_kernel 0 --tensor_parallel_size 8 --max_model_len 2048 --max_num_batched_tokens 2048 --max_gen_toks 256 --enable_expert_parallel 1 --flex_threshold 0.85 --strict_threshold 0.70
          else
-           buildkite-agent step update "label" "🚫 (Skipped) JAX unit tests - kernels"
-           buildkite-agent annotate "Step skipped because no changes were detected in kernel files." --style "info" --context "skip-kernels"
-           echo "Skipping: test only runs on v7x."
+           echo "Skipping: Step requires TPU v7x and either a NIGHTLY build or kernel/requirements changes."
            exit 0
          fi
 
@@ -277,9 +269,7 @@ steps:
          if [[ "$$IS_FOR_V7X" == "true" ]] && { [[ "$$NIGHTLY" == "1" ]] || git diff --name-only HEAD~1 | grep -qE '^(tpu_inference/kernels|tests/kernels|requirements.txt)'; }; then
            .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/check_lm_eval.sh  --model_name "openai/gpt-oss-120b" --use_moe_ep_kernel 1 --tensor_parallel_size 8 --max_model_len 2048 --max_num_batched_tokens 2048 --max_gen_toks 256 --enable_expert_parallel 1 --flex_threshold 0.50 --strict_threshold 0.25
          else
-           buildkite-agent step update "label" "🚫 (Skipped) JAX unit tests - kernels"
-           buildkite-agent annotate "Step skipped because no changes were detected in kernel files." --style "info" --context "skip-kernels"
-           echo "Skipping: test only runs on v7x."
+           echo "Skipping: Step requires TPU v7x and either a NIGHTLY build or kernel/requirements changes."
            exit 0
          fi
 


### PR DESCRIPTION
# Description

Refactored conditional test execution to ensure stable state reporting. Removed dynamic label updates to prevent CI synchronization issues. Otherwise, there will be multiple test cases shown as pending on github even though the CI has completed. Ex: https://screenshot.googleplex.com/AYMcbrexxrMBYKK 

# Tests

[BuildKite](https://buildkite.com/tpu-commons/tpu-inference-ci/builds/8912/steps/canvas)

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
