### PR TITLE
Wrap xla_quantized_matmul with shard map

### DIFF
--- a/tpu_inference/layers/vllm/linear.py
+++ b/tpu_inference/layers/vllm/linear.py
@@ -40,27 +40,27 @@ def sharded_quantized_matmul(x: jax.Array, w_q: jax.Array, w_s: jax.Array,
 
     # NOTE (jacobplatin/kyuyeunk) there have been numeric issues (concerning) NaNs
     # with the kernel and thus we disable it for now.
-    if envs.ENABLE_QUANTIZED_MATMUL_KERNEL:
-        out_axis, in_axis = weight_sharding
-        x_sharding = P(None, in_axis)
-        scale_sharding = P(out_axis, )
-        out_sharding = P(None, out_axis)
+    out_axis, in_axis = weight_sharding
+    x_sharding = P(None, in_axis)
+    scale_sharding = P(out_axis, )
+    out_sharding = P(None, out_axis)
 
-        x = jax.lax.with_sharding_constraint(x,
-                                             NamedSharding(mesh, x_sharding))
+    x = jax.lax.with_sharding_constraint(x, NamedSharding(mesh, x_sharding))
 
-        def wrapper(x, w_q, w_s):
+    def wrapper(x, w_q, w_s):
+        if envs.ENABLE_QUANTIZED_MATMUL_KERNEL:
             output = quantized_matmul_kernel(x, w_q, w_s, x_q_dtype=w_q.dtype)
-            if in_axis:
-                output = jax.lax.psum(output, axis_name=in_axis)
-            return output
+        else:
+            output = xla_quantized_matmul(x, w_q, w_s)
 
-        return jax.shard_map(
-            wrapper,
-            mesh=mesh,
-            in_specs=(x_sharding, weight_sharding, scale_sharding),
-            out_specs=(out_sharding),
-            check_vma=False,
-        )(x, w_q, w_s)
-    else:
-        return xla_quantized_matmul(x, w_q, w_s)
+        if in_axis:
+            output = jax.lax.psum(output, axis_name=in_axis)
+        return output
+
+    return jax.shard_map(
+        wrapper,
+        mesh=mesh,
+        in_specs=(x_sharding, weight_sharding, scale_sharding),
+        out_specs=(out_sharding),
+        check_vma=False,
+    )(x, w_q, w_s)


### PR DESCRIPTION
# Description
This is to remove all reduce triggered by reduce_max. This also implicitly converts the quantization from per channel into block
<img width="611" height="311" alt="截屏2026-01-26 下午12 36 01" src="https://github.com/user-attachments/assets/d80fdf0c-2886-4f48-99a2-d6075ea6e69f" />
This is the latest trace and I can see that the all-reduce is gone
<img width="593" height="436" alt="截屏2026-01-26 下午7 21 42" src="https://github.com/user-attachments/assets/35e172f0-63b0-43a6-9466-b55fabdbb3f6" />

Perf improved around: 7%
<img width="619" height="27" alt="截屏2026-01-27 上午10 12 29" src="https://github.com/user-attachments/assets/db2fb08c-2e08-47bf-be02-4c8ad583782f" />
<img width="611" height="25" alt="截屏2026-01-27 上午10 12 38" src="https://github.com/user-attachments/assets/8d78af78-2bb9-4d8c-a05c-02757156c732" />


The rest of the description includes relevant details and context, examples:
- why is this change being made,
- the problem being solved and any relevant context,
- why this is a good solution,
- some information about the specific implementation,
- shortcomings of the solution and possible future improvements.

If the change fixes a Github issue, please include a link, e.g.,:
FIXES: #123456

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
