### PR TITLE
[fix] jax_view cannot handle torch.ParamList

### DIFF
--- a/tests/layers/vllm/test_unquantized.py
+++ b/tests/layers/vllm/test_unquantized.py
@@ -37,6 +37,7 @@ from vllm.model_executor.layers.linear import (ColumnParallelLinear,
                                                RowParallelLinear)
 from vllm.model_executor.model_loader import get_model as vllm_get_model
 
+from tpu_inference.layers.common.quantization.configs import QuantLinearConfig
 from tpu_inference.layers.vllm.fused_moe import FusedMoEBackend
 from tpu_inference.layers.vllm.quantization import get_tpu_quantization_config
 from tpu_inference.layers.vllm.quantization.unquantized import (
@@ -426,7 +427,9 @@ def test_merged_column_parallel_linear(model, bias, num_devices, fuse_matmuls,
             return_bias=False,
             quant_config=quant_config,
         )
-        jax_merged_column_linear.quant_method.fuse_matmuls = fuse_matmuls
+        assert isinstance(jax_merged_column_linear.quant_method.linear_config,
+                          QuantLinearConfig)
+        jax_merged_column_linear.quant_method.linear_config.fuse_matmuls = fuse_matmuls
 
     jax_merged_column_linear.weight.data = weight_data
     if bias:

--- a/tpu_inference/layers/common/quantization/unquantized.py
+++ b/tpu_inference/layers/common/quantization/unquantized.py
@@ -45,10 +45,11 @@ class UnquantizedLinearMethod:
         out = jnp.concatenate(outs, axis=-1)
         return out
 
-    def _apply_split(self,
-                     x_jax: jax.Array,
-                     weights: Sequence[jax.Array],
-                     bias_jax: Optional[jax.Array] = None) -> jax.Array:
+    def _apply_split(
+            self,
+            x_jax: jax.Array,
+            weights: Sequence[jax.Array],
+            bias_jax: Optional[Sequence[jax.Array]] = None) -> jax.Array:
         outs = []
         for i, weight_jax in enumerate(weights):
             out = jnp.einsum("mn,pn->mp", x_jax, weight_jax)


### PR DESCRIPTION
# Description

As of now, `jax_view` cannot handle `torch.ParamList` and will [return ParamList as is](https://github.com/google/torchax/blob/320ff06408d583030bb28728cc7d1db98a2ab62b/torchax/interop.py#L224)

We didn't catch this issue because the test was not updated to alternate `linear_config`. The bug was introduced in #1505 

This PR fixes above cases.

# Tests

CI, and

```
export CURRENT_VLLM_MODEL=Qwen/Qwen2.5-7B-Instruct
vllm serve $CURRENT_VLLM_MODEL \
    --max-model-len=2048 \
    --disable-log-requests
```

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
