### PR TITLE
Only enable fused moe test for 7+

### DIFF
--- a/tests/kernels/fused_moe_v1_test.py
+++ b/tests/kernels/fused_moe_v1_test.py
@@ -113,6 +113,8 @@ class MoEKernelTest(jtu.JaxTestCase):
 
     def setUp(self):
         super().setUp()
+        if not jtu.is_device_tpu_at_least(version=7):
+            self.skipTest("Expect TPUv7+")
         self.mesh_devices = sorted(
             jax.devices(),
             key=lambda x: (
@@ -239,8 +241,6 @@ class MoEKernelTest(jtu.JaxTestCase):
 
     @parameterized.product(act_fn=["silu", "gelu", "swigluoai"], )
     def test_activation(self, act_fn):
-        if not jtu.is_device_tpu_at_least(version=7):
-            self.skipTest("Expect TPUv7+")
         dtype = jnp.bfloat16
         top_k = 8
         num_experts = 128


### PR DESCRIPTION
# Description

Temporarily disable fused moe test until jax version update lands.

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
