### PR TITLE
Skip fused moe test if device less than TPU7

### DIFF
--- a/tests/kernels/fused_moe_v1_test.py
+++ b/tests/kernels/fused_moe_v1_test.py
@@ -26,17 +26,6 @@ from tpu_inference.kernels.fused_moe.v1.kernel import fused_ep_moe, ref_moe
 jax.config.parse_flags_with_absl()
 
 
-def is_tpu_v7_or_newer():
-    try:
-        d = jax.devices()[0]
-        # Check for TPU v7 specific strings
-        is_v7 = "v7" in d.device_kind or "Trillium" in d.device_kind
-        # logical OR with the JAX utility if you trust it for some cases
-        return is_v7 or jtu.is_device_tpu_at_least(version=7)
-    except Exception:
-        return False
-
-
 def cdiv(a, b):
     assert b != 0
     return (a + b - 1) // b
@@ -122,7 +111,7 @@ def sub_channel_quantize(x, quant_dtype, wsz=256):
 
 
 @jtu.with_config(jax_numpy_dtype_promotion="standard")
-@unittest.skipUnless(is_tpu_v7_or_newer(), "Test requires TPUv7+")
+@unittest.skipUnless(jtu.is_device_tpu_at_least(version=7), "Expected TPUv7+")
 class MoEKernelTest(jtu.JaxTestCase):
 
     def setUp(self):


### PR DESCRIPTION
# Description

Temporarily disable fused moe test until jax version update lands.
