### PR TITLE
Bump RunAI model streamer version and install gcsfs in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,4 +15,5 @@ torchvision==0.24.0
 pathwaysutils
 parameterized
 numba==0.62.1
-runai-model-streamer[s3,gcs]==0.15.0
+runai-model-streamer[s3,gcs]==0.15.4
+gcsfs==2026.1.0

--- a/tests/e2e/test_runai_model_streamer_loader.py
+++ b/tests/e2e/test_runai_model_streamer_loader.py
@@ -45,6 +45,9 @@ def sampling_config():
     return SamplingParams(temperature=0, max_tokens=10, ignore_eos=True)
 
 
+# TODO(amacaskill): Once we have GKE owned GCS buckets, add a test for VLLM_XLA_CACHE_PATH set to GCS URI.
+
+
 def test_correctness_jax_uni_proc_executor(
     sampling_config: SamplingParams,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
# Description

This PR updates RunAI model streamer version to 0.15.4 to fix: https://github.com/run-ai/runai-model-streamer/issues/117 . 

This PR also adds gcsfs to requirements.txt. This allows you to use a GCS URI for `VLLM_XLA_CACHE_PATH` for a persistent XLA compilation cache. Before this change, to write the XLA Compilation cache to GCS, you had to use GCSFuse which requires a lot more setup. If you tried to use `VLLM_XLA_CACHE_PATH` with a GCS URI before this change, you would see the following warning, and the XLA wouldn't be written to your GCS bucket. 

```
Error reading persistent compilation cache entry for 'jit_convert_element_type': ImportError: Please install gcsfs to access Google Storage
```

If the change fixes a Github issue, please include a link, e.g.,:

FIXES: #117

# Tests

I built a custom image with my change, and confirmed that the RunAI model streamer still works and that when `VLLM_XLA_CACHE_PATH` is set to a GCS URI, I see all of the cached JIT compilation results are written to my bucket as expected when running `gsutil ls gs://<BUCKET_NAME>/<VLLM_XLA_CACHE_PATH>`. See [here](https://paste.googleplex.com/6229477975785472)

Also ran all of the RunAI Model streamer tests: 

```
pytest -s -v tests/e2e/test_runai_model_streamer_loader.py
=========================================== 3 passed, 10 warnings in 535.12s (0:08:55) ============================================
```

# Checklist

Before submitting this PR, please make sure:
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have made or will make corresponding changes to any relevant documentation.
