### PR TITLE
[Qwix][Qwen] Fix qwix for Qwen model

### DIFF
--- a/tests/models/jax/test_qwen3.py
+++ b/tests/models/jax/test_qwen3.py
@@ -25,6 +25,8 @@ from vllm.config import ModelConfig
 
 from tpu_inference.layers.common.attention_metadata import AttentionMetadata
 from tpu_inference.models.jax.qwen3 import Qwen3ForCausalLM
+from tpu_inference.models.jax.utils.qwix.qwix_utils import \
+    apply_qwix_quantization
 from tpu_inference.runner.kv_cache import create_kv_caches
 
 
@@ -37,6 +39,7 @@ class MockVllmConfig:
         self.load_config.download_dir = None
         self.cache_config = MagicMock(cache_dtype=kv_cache_dtype)
         self.quant_config = None
+        self.additional_config = {}
 
 
 @pytest.fixture(scope="module")
@@ -90,12 +93,23 @@ def rng() -> PRNGKey:
 
 class TestQwen3ForCausalLM:
 
-    @pytest.mark.parametrize("mock_vllm_config", [
-        MockVllmConfig("Qwen/Qwen3-0.6B", "auto"),
-        MockVllmConfig("Qwen/Qwen3-0.6B", "fp8")
+    @pytest.mark.parametrize("model_name", ["Qwen/Qwen3-0.6B"])
+    @pytest.mark.parametrize("kv_cache_type", ["auto", "fp8"])
+    @pytest.mark.parametrize("qwix_rules", [
+        None,
+        [{
+            "module_path": ".*",
+            "weight_qtype": "float8_e4m3fn",
+            "act_qtype": "float8_e4m3fn"
+        }]
     ])
-    def test_qwen3_600M(self, mock_vllm_config, rng, mesh, mock_model_inputs):
+    def test_qwen3_600M(self, model_name, kv_cache_type, qwix_rules, rng, mesh,
+                        mock_model_inputs):
         """Tests model init and model forward for the 0.6B model variant."""
+        mock_vllm_config = MockVllmConfig(model_name, kv_cache_type)
+        if qwix_rules:
+            mock_vllm_config.additional_config["quanntization"] = dict(
+                qwix=dict(rules=qwix_rules))
 
         # Test model init
         model = Qwen3ForCausalLM(mock_vllm_config, rng, mesh)
@@ -144,6 +158,13 @@ class TestQwen3ForCausalLM:
 
         # Test model load
         model.load_weights(rng)
+
+        # Apply qwix quantization, no-op if rules are not given.
+        model = apply_qwix_quantization(mock_vllm_config,
+                                        model,
+                                        rng,
+                                        mesh,
+                                        apply_to_abstract_model=False)
 
         # Test model forward
         kv_caches = create_kv_caches(

--- a/tpu_inference/layers/jax/linear.py
+++ b/tpu_inference/layers/jax/linear.py
@@ -66,7 +66,7 @@ class JaxEinsum(nnx.Einsum, JaxModule):
         if self.quant_method is not None:
             return self.quant_method.apply_jax(self, inputs)
 
-        output = jax.numpy.einsum(self.einsum_str, inputs, self.weight)
+        output = jax.numpy.einsum(self.einsum_str, inputs, self.weight.value)
         if self.bias is not None:
             output += self.bias
         return output


### PR DESCRIPTION
# Description

Since #1484, qwix no longer works for qwen models. This PR fix the issue.

The fundamental reason is that when qwix is applied, inputs of `jnp.einsum` should be `jax.Arrary` instead of `nnx.Param`.


# Tests

Tests are added in this PR

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
