### PR TITLE
Fix: update condition to multi chip for ep test

### DIFF
--- a/.buildkite/parallelism/EP.yml
+++ b/.buildkite/parallelism/EP.yml
@@ -19,7 +19,7 @@ steps:
     key: "EP_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: tpu_v6e_queue
+      queue: tpu_v6e_8_queue
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh \


### PR DESCRIPTION
# Description

This PR fixes a CI failure in the Expert Parallelism (EP) E2E tests where the test was failing due to insufficient TPU devices.

The EP test requires a mesh shape of (1, 4), which demands at least 4 TPU chips. However, the CI job was previously scheduled on the default queue (single device), causing the following error:
```
ValueError: Number of devices 1 must be >= the product of mesh_shape (1, 4)
```

# Tests

This is a very specific change to CI condition. 

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
