### PR TITLE
[JAX][DeepSeek] Fix `VLLM_MOE` MoE backend for unquantized DeepSeek model

### DIFF
--- a/tpu_inference/layers/jax/moe/moe.py
+++ b/tpu_inference/layers/jax/moe/moe.py
@@ -194,8 +194,8 @@ class MoE(nnx.Module):
             # in the future
             output_TD = fused_moe_func(
                 hidden_states=x_TD,
-                w1=self.kernel_gating_upproj_EFD.value,
-                w2=self.kernel_down_proj_EDF.value,
+                w1=self.kernel_gating_upproj_EDF.value,
+                w2=self.kernel_down_proj_EFD.value,
                 w1_bias=self.w1_bias,
                 w2_bias=self.w2_bias,
                 w1_scale=self.w1_scale,
@@ -324,13 +324,13 @@ class MoE(nnx.Module):
             # TODO (jacobplatin): the current GMM kernel expects that w1/w2 have the second and third
             # dimensions transposed, but this is likely not optimal for DeepSeek, so we will
             # need to fix this in the future
-            self.kernel_gating_upproj_EFD = create_param(
+            self.kernel_gating_upproj_EDF = create_param(
                 rngs,
                 shape=(E, D, 2 * F),
                 dtype=self.dtype,
                 sharding=self.efd_sharding,
                 random_init=self.random_init)
-            self.kernel_down_proj_EDF = create_param(
+            self.kernel_down_proj_EFD = create_param(
                 rngs,
                 shape=(E, F, D),
                 dtype=self.dtype,

--- a/tpu_inference/models/jax/deepseek_v3.py
+++ b/tpu_inference/models/jax/deepseek_v3.py
@@ -174,14 +174,14 @@ class DeepSeekV3WeightLoader(BaseWeightLoader):
             # are fused into a single weight tensor.
             self._loaded_to_standardized_keys.update({
                 "model.layers.*.mlp.experts.*.down_proj.weight":
-                "layers.*.custom_module.kernel_down_proj_EDF",
-                "model.layers.*.mlp.experts.*.gating_upproj_EFD.weight":
-                "layers.*.custom_module.kernel_gating_upproj_EFD",
+                "layers.*.custom_module.kernel_down_proj_EFD",
+                "model.layers.*.mlp.experts.*.gating_upproj_EDF.weight":
+                "layers.*.custom_module.kernel_gating_upproj_EDF",
             })
             # NOTE (jacobplatin): only used for the MOE_VLLM backend, which
             # expects 2/3 dimensions to be transposed.
             self._transpose_map.update({
-                r"mlp\.experts\.\d+\.gating_upproj_EFD": (0, 2, 1),
+                r"mlp\.experts\.\d+\.gating_upproj_EDF": (0, 2, 1),
             })
 
         if self.use_mla_kernel:
@@ -587,7 +587,7 @@ class DeepSeekV3WeightLoader(BaseWeightLoader):
                                         [gate_s, up_s], dim=1
                                     ) if gate_s is not None and up_s is not None else None
                                     fused_name = loaded_name.replace(
-                                        proj_type, "gating_upproj_EFD")
+                                        proj_type, "gating_upproj_EDF")
 
                                 else:
                                     # (E, D, F) -> (E, 2, D, F)


### PR DESCRIPTION
# Description

Currently, using the `VLLM_MOE` backend doesn't work with the unquantized DeepSeek model.  This PR fixes that.

# Tests

Verified using the following command:


```
 USE_VLLM_MOE_KERNEL=1  VLLM_MLA_DISABLE=1  NEW_MODEL_DESIGN=1 TPU_BACKEND_TYPE=jax python examples/offline_inference.py --model=deepseek-ai/DeepSeek-R1 --max-model-len=5120 --max-num-batched-tokens 128 --max-num-seqs=128 --no-enable-prefix-caching --gpu-memory-utilization 0.95 --tensor-parallel-size 8 --additional_config='{"skip_quantization": true, "sharding": {"sharding_strategy": {"expert_parallelism": 1, "tensor_parallelism": 8}}}' --kv-cache-dtype=fp8  --hf_overrides  '{"num_hidden_layers": 10}'
```

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
