### PR TITLE
Fix TpuPlatform circular import dependency due to upstream changes

### DIFF
--- a/tpu_inference/platforms/tpu_platform.py
+++ b/tpu_inference/platforms/tpu_platform.py
@@ -6,7 +6,6 @@ import jax.numpy as jnp
 import torch
 import vllm.envs as vllm_envs
 from tpu_info import device
-from vllm.inputs import ProcessorInputs, PromptType
 from vllm.platforms.interface import Platform, PlatformEnum
 
 from tpu_inference import envs
@@ -16,6 +15,7 @@ from tpu_inference.logger import init_logger
 if TYPE_CHECKING:
     from vllm.config import ModelConfig, VllmConfig
     from vllm.config.cache import BlockSize
+    from vllm.inputs import ProcessorInputs, PromptType
     from vllm.pooling_params import PoolingParams
     from vllm.sampling_params import SamplingParams, SamplingType
     from vllm.v1.attention.backends.registry import AttentionBackendEnum
@@ -24,6 +24,8 @@ else:
     BlockSize = None
     ModelConfig = None
     VllmConfig = None
+    ProcessorInputs = None
+    PromptType = None
     PoolingParams = None
     AttentionBackendEnum = None
     SamplingParams = None


### PR DESCRIPTION
# Description

https://github.com/vllm-project/vllm/commit/10152d2194c32f6e312c99ed51fd62b01f55598e#diff-e55f6ffbb4ac8db75ad60f0b92d2ab311493184b32bb039c2d991742f53f5c56 introduces a circular dependency error

```
(vllm_env2) nhatt@t1v-n-b6d844bb-w-0:~/tpu-inference$ python -c "from tpu_inference.platforms import TpuPlatform"
INFO 01-30 15:37:51 [__init__.py:59] TPU info: node_name=will-1 | tpu_type=v6e-8 | worker_id=0 | num_chips=8 | num_cores_per_chip=1
ERROR 01-30 15:37:52 [tpu.py:17] tpu_inference not found, please install tpu_inference to run vllm on TPU
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/mnt/disks/persist/nhatt/tpu-inference/tpu_inference/platforms/__init__.py", line 16, in <module>
    from tpu_inference.platforms.tpu_platform import TpuPlatform
  File "/mnt/disks/persist/nhatt/tpu-inference/tpu_inference/platforms/tpu_platform.py", line 9, in <module>
    from vllm.inputs import ProcessorInputs, PromptType
  File "/mnt/disks/persist/nhatt/vllm/vllm/inputs/__init__.py", line 4, in <module>
    from .data import (
  File "/mnt/disks/persist/nhatt/vllm/vllm/inputs/data.py", line 10, in <module>
    from vllm.sampling_params import SamplingParams
  File "/mnt/disks/persist/nhatt/vllm/vllm/sampling_params.py", line 18, in <module>
    from vllm.v1.serial_utils import PydanticMsgspecMixin
  File "/mnt/disks/persist/nhatt/vllm/vllm/v1/serial_utils.py", line 24, in <module>
    from vllm.multimodal.inputs import (
  File "/mnt/disks/persist/nhatt/vllm/vllm/multimodal/__init__.py", line 14, in <module>
    from .registry import MultiModalRegistry
  File "/mnt/disks/persist/nhatt/vllm/vllm/multimodal/registry.py", line 8, in <module>
    from vllm.config.multimodal import BaseDummyOptions
  File "/mnt/disks/persist/nhatt/vllm/vllm/config/__init__.py", line 5, in <module>
    from vllm.config.cache import CacheConfig
  File "/mnt/disks/persist/nhatt/vllm/vllm/config/cache.py", line 14, in <module>
    from vllm.utils.mem_utils import format_gib, get_cpu_memory
  File "/mnt/disks/persist/nhatt/vllm/vllm/utils/mem_utils.py", line 14, in <module>
    from vllm.platforms import current_platform
ImportError: cannot import name 'current_platform' from 'vllm.platforms' (/mnt/disks/persist/nhatt/vllm/vllm/platforms/__init__.py)
```

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
