### PR TITLE
[Fix] Fix Qwen2.5-VL-7B loading error

### DIFF
--- a/tpu_inference/models/jax/qwen2_5_vl.py
+++ b/tpu_inference/models/jax/qwen2_5_vl.py
@@ -1121,9 +1121,10 @@ class Qwen2_5_VLForConditionalGeneration(nnx.Module):
         }
 
         loader = self.WeightLoader(self.vllm_config, self.mesh)
-        loader.load_weights(self,
-                            mappings,
-                            keep_hf_weight_suffix_when_match=['model'])
+        loader.load_weights(
+            self,
+            mappings,
+            keep_hf_weight_suffix_when_match=['model', 'lm_head'])
 
     def precompile_vision_encoder(
         self,


### PR DESCRIPTION
# Description

FIX: #1585 

# Tests

```
export CURRENT_VLLM_MODEL=Qwen/Qwen2.5-VL-7B-Instruct
MODEL_IMPL_TYPE=flax_nnx vllm serve $CURRENT_VLLM_MODEL \
    --max-model-len=8192 \
    --disable-log-requests \
    --no-enable-prefix-caching \
    --max-num-batched-tokens 16384

curl http://localhost:8000/v1/chat/completions \
    -H "Content-Type: application/json" \
    -d '{
        "model": "Qwen/Qwen2.5-VL-7B-Instruct",
        "messages": [
            {"role": "system", "content": "You are a helpful assistant."},
            {"role": "user", "content": "Who won the world series in 2020?"}
        ]
    }'
```
response looks good
<img width="2888" height="854" alt="image" src="https://github.com/user-attachments/assets/7ebfd86b-5221-4a23-884a-9206993aa135" />
