### PR TITLE
[bug] use the right imports for trunk vllm

### DIFF
--- a/tests/runner/test_kv_cache_manager.py
+++ b/tests/runner/test_kv_cache_manager.py
@@ -21,7 +21,7 @@ import pytest
 import torch
 from vllm.config import (CacheConfig, ModelConfig, ParallelConfig,
                          SchedulerConfig, VllmConfig)
-from vllm.model_executor.layers.attention import Attention
+from vllm.attention.layer import Attention
 from vllm.sampling_params import SamplingType
 from vllm.v1.attention.backend import AttentionType
 from vllm.v1.kv_cache_interface import (FullAttentionSpec, KVCacheConfig,

--- a/tpu_inference/layers/vllm/quantization/compressed_tensors/compressed_tensors.py
+++ b/tpu_inference/layers/vllm/quantization/compressed_tensors/compressed_tensors.py
@@ -16,7 +16,7 @@ from typing import Optional
 
 import torch
 from jax.sharding import PartitionSpec
-from vllm.model_executor.layers.attention import Attention
+from vllm.attention.layer import Attention
 from vllm.model_executor.layers.fused_moe import FusedMoE
 from vllm.model_executor.layers.linear import LinearBase
 from vllm.model_executor.layers.quantization import \

--- a/tpu_inference/layers/vllm/quantization/fp8.py
+++ b/tpu_inference/layers/vllm/quantization/fp8.py
@@ -22,7 +22,7 @@ from torch.nn.parameter import Parameter
 from torchax.interop import jax_view, torch_view
 from torchax.ops.mappings import t2j
 from vllm.model_executor.layers import linear as vllm_linear
-from vllm.model_executor.layers.attention import Attention
+from vllm.attention.layer import Attention
 from vllm.model_executor.layers.fused_moe import FusedMoE, FusedMoEMethodBase
 from vllm.model_executor.layers.quantization import fp8 as vllm_fp8
 from vllm.model_executor.layers.quantization import \

--- a/tpu_inference/layers/vllm/quantization/mxfp4.py
+++ b/tpu_inference/layers/vllm/quantization/mxfp4.py
@@ -21,7 +21,7 @@ from jax.sharding import Mesh, PartitionSpec
 from torch.nn.parameter import Parameter
 from torchax.interop import jax_view, torch_view
 from torchax.ops.mappings import t2j
-from vllm.model_executor.layers.attention import Attention
+from vllm.attention.layer import Attention
 from vllm.model_executor.layers.fused_moe import FusedMoE, FusedMoEMethodBase
 from vllm.model_executor.layers.fused_moe.config import (
     FusedMoEConfig, FusedMoEQuantConfig, mxfp4_w4a16_moe_quant_config)

--- a/tpu_inference/layers/vllm/quantization/unquantized.py
+++ b/tpu_inference/layers/vllm/quantization/unquantized.py
@@ -20,8 +20,8 @@ from jax.sharding import Mesh, NamedSharding, PartitionSpec
 from torch.nn.parameter import Parameter
 from torchax.interop import jax_view, torch_view
 from torchax.ops.mappings import t2j
+from vllm.attention.layer import Attention
 from vllm.model_executor.layers import linear as vllm_linear
-from vllm.model_executor.layers.attention import Attention
 from vllm.model_executor.layers.fused_moe import (FusedMoE, FusedMoEConfig,
                                                   UnquantizedFusedMoEMethod)
 from vllm.model_executor.layers.quantization import \

--- a/tpu_inference/runner/kv_cache_manager.py
+++ b/tpu_inference/runner/kv_cache_manager.py
@@ -22,7 +22,7 @@ import vllm.envs as envs
 from jax.sharding import NamedSharding, PartitionSpec
 from torchax.ops.mappings import t2j_dtype
 from vllm.config import get_layers_from_vllm_config
-from vllm.model_executor.layers.attention import Attention
+from vllm.attention.layer import Attention
 from vllm.utils.math_utils import cdiv
 from vllm.v1.attention.backend import AttentionType
 from vllm.v1.kv_cache_interface import (FullAttentionSpec, KVCacheConfig,


### PR DESCRIPTION
# Description

with the latest vllm, current trunk will fail at the following import

```
from vllm.model_executor.layers.attention import Attention
```

```
(EngineCore_DP0 pid=6537) ImportError: cannot import name 'Attention' from 'vllm.model_executor.layers.attention' (/data/vllm/vllm/model_executor/layers/attention/__init__.py). Did you mean: 'attention'?
```

to get around the issue, replace all occurences to
```
from vllm.attention.layer import Attention
```

# Tests
start the vllm server

```
#!/bin/bash

MODEL_NAME=openai/gpt-oss-120b
PORT=8000

export MODEL_IMPL_TYPE=vllm

vllm serve --model=${MODEL_NAME} \
     --tensor-parallel-size=8 \
     --enable-expert-parallel \
     --data-parallel-size=1 \
     --max-model-len=16384 \
     --max-num-batched-tokens=8192 --max-num-seqs=512 \
     --port ${PORT} \
     --async-scheduling --disable-log-requests --gpu-memory-utilization=0.95
```

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
