### PR TITLE
[bug] resolve compatibility issues with vllm trunk

### DIFF
--- a/tpu_inference/runner/compilation_manager.py
+++ b/tpu_inference/runner/compilation_manager.py
@@ -78,6 +78,8 @@ class CompilationManager:
         if result is not None:
             if isinstance(result, tuple):
                 for r in result:
+                    if r is None:
+                        continue
                     r.block_until_ready()
             else:
                 result.block_until_ready()

--- a/tpu_inference/runner/multimodal_manager.py
+++ b/tpu_inference/runner/multimodal_manager.py
@@ -20,8 +20,6 @@ from vllm.model_executor.layers.rotary_embedding import MRotaryEmbedding
 from vllm.multimodal.inputs import MultiModalKwargsItem, PlaceholderRange
 from vllm.multimodal.utils import group_mm_kwargs_by_modality
 from vllm.v1.core.sched.output import SchedulerOutput as VllmSchedulerOutput
-from vllm.v1.worker.utils import (gather_mm_placeholders,
-                                  scatter_mm_placeholders)
 
 from tpu_inference.models.jax.utils.multi_modal_utils import (
     flatten_embeddings, sanity_check_mm_encoder_outputs)
@@ -160,15 +158,11 @@ class MultiModalManager:
                 encoder_outputs.append(output)
 
         # Cache the encoder outputs.
-        for (mm_hash, pos_info), output in zip(
-                mm_hashes_pos,
-                encoder_outputs,
+        for (mm_hash, _), output in zip(
+            mm_hashes_pos,
+            encoder_outputs,
         ):
-
-            self.runner.encoder_cache[mm_hash] = scatter_mm_placeholders(
-                output,
-                is_embed=pos_info.is_embed,
-            )
+            self.runner.encoder_cache[mm_hash] = output
 
     def gather_mm_embeddings(self, scheduler_output: "VllmSchedulerOutput",
                              target_pad_len: int) -> list[jax.Array]:
@@ -201,6 +195,13 @@ class MultiModalManager:
                     num_computed_tokens - start_pos + num_scheduled_tokens,
                     num_encoder_tokens)
                 assert start_idx < end_idx
+                curr_embeds_start, curr_embeds_end = (
+                    pos_info.get_embeds_indices_in_range(start_idx, end_idx)
+                )
+                # If there are no embeddings in the current range, we skip
+                # gathering the embeddings.
+                if curr_embeds_start == curr_embeds_end:
+                    continue
                 mm_hash = mm_feature.identifier
                 encoder_output = self.runner.encoder_cache.get(mm_hash, None)
                 assert encoder_output is not None,\
@@ -209,11 +210,10 @@ class MultiModalManager:
 
                 if (is_embed := pos_info.is_embed) is not None:
                     is_embed = is_embed[start_idx:end_idx]
+                    mm_embeds_item = encoder_output[curr_embeds_start:curr_embeds_end]
+                else:
+                    mm_embeds_item = encoder_output[start_idx:end_idx]
 
-                mm_embeds_item = gather_mm_placeholders(
-                    encoder_output[start_idx:end_idx],
-                    is_embed=is_embed,
-                )
                 mm_embeds.append(mm_embeds_item)
         if not mm_embeds:
             return None


### PR DESCRIPTION
# Description

resolve compatibility issues with trunk of vllm

follow the same pattern in the upstream to remove the deprecated apis, also added a graceful handling for potential None values

# Tests
start the vllm server

```
#!/bin/bash

MODEL_NAME=openai/gpt-oss-120b
PORT=8000

export MODEL_IMPL_TYPE=vllm

vllm serve --model=${MODEL_NAME} \
     --tensor-parallel-size=8 \
     --enable-expert-parallel \
     --data-parallel-size=1 \
     --max-model-len=16384 \
     --max-num-batched-tokens=8192 --max-num-seqs=512 \
     --port ${PORT} \
     --async-scheduling --disable-log-requests --gpu-memory-utilization=0.95
```
before this pr, server would have failed to start

use
```
vllm chat
```
to send prompts to the server

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
