### PR TITLE
[CI] Point integration pipeline to latest vLLM

### DIFF
--- a/.buildkite/scripts/update_lkg_version.sh
+++ b/.buildkite/scripts/update_lkg_version.sh
@@ -23,7 +23,7 @@ fi
 
 # Configuration
 REPO_URL="https://github.com/vllm-project/tpu-inference.git"
-TARGET_BRANCH="feat/buildkite-vllm-pipeline"
+TARGET_BRANCH="main"
 
 NEW_LKG_HASH=$1
 VERSION_FILE=".buildkite/vllm_lkg.version"


### PR DESCRIPTION
# Description

This PR updates our CI workflow to ensure that the Integration Pipeline now tests against the latest version of vllm on the main branch.

Previously, both PR pipelines and the integration pipeline build against lkg_vllm_version. 
Key Changes: 
- CI Bootstrap: PRs build against stable vllm version. Integration build against latest vLLM.
- LKG Updates: Automation now update lkg_vllm.version in the main branch.

# Tests

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
