### PR TITLE
[JAX][MoE] Refactor JAX MoE layer + consolidate common TorchAX/JAX logic + add UnquantizedMoE Scaffolding

### DIFF
--- a/docs/developer_guides/jax_model_development.md
+++ b/docs/developer_guides/jax_model_development.md
@@ -59,6 +59,8 @@ class NewModel(nnx.Module):
                mesh: jax.sharding.Mesh)
 ```
 
+"# TODO (jacobplatin): we need to update this once the JAX-path refactor is fully done"
+
 The constructor should set the architecture configuration (e.g. num_layers, hidden_size) and initialize the model layers. Layers can be defined from scratch using flax NNX (e.g. [Llama3](https://github.com/vllm-project/tpu-inference/blob/31fa76a0187496ec161c634c98ac5eba144cb36c/tpu_inference/models/jax/llama3.py)) or can leverage tpu-inference to import or extend commonly used layer types (e.g. [Embedder](https://github.com/vllm-project/tpu-inference/blob/31fa76a0187496ec161c634c98ac5eba144cb36c/tpu_inference/layers/jax/layers.py#L168), [RMSNorm](https://github.com/vllm-project/tpu-inference/blob/31fa76a0187496ec161c634c98ac5eba144cb36c/tpu_inference/layers/jax/layers.py#L49), [MoE](https://github.com/vllm-project/tpu-inference/blob/31fa76a0187496ec161c634c98ac5eba144cb36c/tpu_inference/layers/jax/moe/moe.py#L69), [Attention](https://github.com/vllm-project/tpu-inference/blob/31fa76a0187496ec161c634c98ac5eba144cb36c/tpu_inference/layers/jax/attention/attention.py#L23), [DenseFFW](https://github.com/vllm-project/tpu-inference/blob/31fa76a0187496ec161c634c98ac5eba144cb36c/tpu_inference/layers/jax/layers.py#L98C7-L98C15), [TransformerBlock](https://github.com/vllm-project/tpu-inference/blob/31fa76a0187496ec161c634c98ac5eba144cb36c/tpu_inference/layers/jax/transformer_block.py#L15
 )).
 

--- a/tests/layers/jax/moe/test_moe_utils.py
+++ b/tests/layers/jax/moe/test_moe_utils.py
@@ -37,49 +37,6 @@ class TestMoEUtils(unittest.TestCase):
     def setUp(self):
         self.key = jax.random.PRNGKey(0)
 
-    def test_select_moe_backend_defaults(self):
-        """Test default backend selection (Dense)."""
-        # Ensure all flags are False
-        with mock.patch.object(envs, 'USE_MOE_EP_KERNEL', False), \
-             mock.patch.object(envs, 'USE_VLLM_MOE_KERNEL', False), \
-             mock.patch.object(envs, 'USE_MEGABLOCKS', False), \
-             mock.patch.object(envs, 'USE_RAGGED_DOT', False):
-
-            backend = select_moe_backend()
-            self.assertEqual(backend, MoEBackend.DENSE_MAT)
-
-    def test_select_moe_backend_priority(self):
-        """Test priority logic for backend selection."""
-        # Case 1: Fused MoE has highest priority
-        with mock.patch.object(envs, 'USE_MOE_EP_KERNEL', True), \
-             mock.patch.object(envs, 'USE_VLLM_MOE_KERNEL', False):
-            self.assertEqual(select_moe_backend(), MoEBackend.FUSED_MOE)
-
-        # Case 2: VLLM MoE
-        with mock.patch.object(envs, 'USE_MOE_EP_KERNEL', False), \
-             mock.patch.object(envs, 'USE_VLLM_MOE_KERNEL', True):
-            self.assertEqual(select_moe_backend(), MoEBackend.VLLM_MOE)
-
-        # Case 3: MegaBlocks
-        with mock.patch.object(envs, 'USE_MOE_EP_KERNEL', False), \
-             mock.patch.object(envs, 'USE_VLLM_MOE_KERNEL', False), \
-             mock.patch.object(envs, 'USE_MEGABLOCKS', True):
-            self.assertEqual(select_moe_backend(), MoEBackend.MEGABLX_GMM)
-
-        # Case 4: Ragged Dot
-        with mock.patch.object(envs, 'USE_MOE_EP_KERNEL', False), \
-             mock.patch.object(envs, 'USE_VLLM_MOE_KERNEL', False), \
-             mock.patch.object(envs, 'USE_MEGABLOCKS', False), \
-             mock.patch.object(envs, 'USE_RAGGED_DOT', True):
-            self.assertEqual(select_moe_backend(), MoEBackend.RAGGED_DOT)
-
-    def test_select_moe_backend_conflict(self):
-        """Test conflict detection."""
-        with mock.patch.object(envs, 'USE_MOE_EP_KERNEL', True), \
-             mock.patch.object(envs, 'USE_VLLM_MOE_KERNEL', True):
-            with self.assertRaises(ValueError):
-                select_moe_backend()
-
     def test_sort_activations_fn(self):
         """Test stateless sorting of activations."""
         inputs = jnp.array([[10], [20], [30], [40]])
@@ -204,35 +161,6 @@ class TestMoEUtils(unittest.TestCase):
         # RECV_SIZE: I am Shard 0. I receive column 0: [10, 30]
         self.assertTrue(jnp.array_equal(recv_sizes, jnp.array([10, 30])))
 
-    @mock.patch('jax.lax.ragged_dot')
-    @mock.patch(
-        'tpu_inference.layers.jax.moe.utils.round_up_to_multiple_of_128_within_limit'
-    )
-    def test_gmm_fn_ragged_dot(self, mock_round, mock_ragged_dot):
-        """Test GMM function calls Ragged Dot correctly."""
-        # Setup
-        inputs = jnp.ones((128, 7168))
-        kernel = jnp.ones((1, 7168, 2048))
-        group_sizes = jnp.array([32])
-        tile_size = (128, 128, 128)
-
-        # Mock return
-        mock_ragged_dot.return_value = jnp.zeros((128, 128))
-        mock_round.side_effect = lambda x, y: x  # Identity for test
-
-        # Execute
-        out = gmm_fn(inputs,
-                     kernel,
-                     group_sizes,
-                     tile_size,
-                     moe_backend=MoEBackend.RAGGED_DOT,
-                     dtype=jnp.bfloat16,
-                     quantized_dtype=None)
-
-        # Verify call
-        mock_ragged_dot.assert_called_once()
-        self.assertEqual(out.shape, (128, 128))
-
     @mock.patch('tpu_inference.layers.jax.moe.utils.megablox_gmm')
     @mock.patch(
         'tpu_inference.layers.jax.moe.utils.round_up_to_multiple_of_128_within_limit'
@@ -280,3 +208,61 @@ class TestMoEUtils(unittest.TestCase):
                quantized_dtype=jnp.float8_e4m3fn)
 
         mock_megablox.assert_called_once()
+
+
+class TestMoESelector(unittest.TestCase):
+
+    def setUp(self):
+        self.key = jax.random.PRNGKey(0)
+
+    def test_select_moe_backend_defaults(self):
+        """Test default backend selection (GMM_TP/GMM_EP)."""
+        # Ensure all explicit backend flags are False
+        with mock.patch.object(envs, 'USE_MOE_EP_KERNEL', False), \
+             mock.patch.object(envs, 'USE_MEGABLOCKS', False):
+
+            # Case 1: No EP enabled -> Fallback to GMM_TP
+            backend_tp = select_moe_backend(use_ep=False)
+            self.assertEqual(backend_tp, MoEBackend.GMM_TP)
+
+            # Case 2: EP enabled -> Fallback to GMM_EP
+            backend_ep = select_moe_backend(use_ep=True)
+            self.assertEqual(backend_ep, MoEBackend.GMM_EP)
+
+    def test_select_moe_backend_priority(self):
+        """Test priority logic for backend selection."""
+
+        # Case 1: Fused MoE (Highest priority when USE_MOE_EP_KERNEL=True AND use_ep=True)
+        with mock.patch.object(envs, 'USE_MOE_EP_KERNEL', True), \
+             mock.patch.object(envs, 'USE_MEGABLOCKS', False):
+            self.assertEqual(select_moe_backend(use_ep=True),
+                             MoEBackend.FUSED_MOE)
+
+        # Case 1.5: Fused MoE Flag is True, but use_ep is False.
+        # Should fall through to defaults (GMM_TP) because Fused kernel requires EP.
+        with mock.patch.object(envs, 'USE_MOE_EP_KERNEL', True), \
+             mock.patch.object(envs, 'USE_MEGABLOCKS', False):
+            self.assertEqual(select_moe_backend(use_ep=False),
+                             MoEBackend.GMM_TP)
+
+        # Case 2: MegaBlocks (Next priority)
+        with mock.patch.object(envs, 'USE_MOE_EP_KERNEL', False), \
+             mock.patch.object(envs, 'USE_MEGABLOCKS', True):
+            self.assertEqual(select_moe_backend(use_ep=True),
+                             MoEBackend.MEGABLX_GMM)
+            self.assertEqual(select_moe_backend(use_ep=False),
+                             MoEBackend.MEGABLX_GMM)
+
+    def test_select_moe_backend_precedence_conflict(self):
+        """Test precedence when multiple flags are enabled."""
+        # EP Kernel + MegaBlocks: EP Kernel takes precedence if use_ep=True
+        with mock.patch.object(envs, 'USE_MOE_EP_KERNEL', True), \
+             mock.patch.object(envs, 'USE_MEGABLOCKS', True):
+            self.assertEqual(select_moe_backend(use_ep=True),
+                             MoEBackend.FUSED_MOE)
+
+        # MegaBlocks + Ragged Dot: MegaBlocks takes precedence
+        with mock.patch.object(envs, 'USE_MOE_EP_KERNEL', False), \
+             mock.patch.object(envs, 'USE_MEGABLOCKS', True):
+            self.assertEqual(select_moe_backend(use_ep=True),
+                             MoEBackend.MEGABLX_GMM)

--- a/tests/layers/jax/test_transformer_block.py
+++ b/tests/layers/jax/test_transformer_block.py
@@ -19,7 +19,7 @@ import jax.numpy as jnp
 from flax import nnx
 
 from tpu_inference.layers.jax.layers import DenseFFW
-from tpu_inference.layers.jax.moe.moe import MoE
+from tpu_inference.layers.jax.moe.moe import JaxMoE
 from tpu_inference.layers.jax.transformer_block import (
     SharedExpertsTransformerBlock, TransformerBlock)
 
@@ -108,7 +108,7 @@ class TestTransformerBlock(unittest.TestCase):
         dummy_kv_cache = jnp.zeros((8, 16, 16, 128), dtype=jnp.bfloat16)
         mock_attn.return_value = (dummy_kv_cache, dummy_attn_output)
 
-        mock_moe = MagicMock(spec=MoE)
+        mock_moe = MagicMock(spec=JaxMoE)
         dummy_moe_output = jnp.full((64, hidden_size), 3.0, dtype=jnp.bfloat16)
         mock_moe.return_value = dummy_moe_output
 

--- a/tests/layers/vllm/test_fp8.py
+++ b/tests/layers/vllm/test_fp8.py
@@ -36,8 +36,8 @@ from vllm.model_executor.layers.linear import (ColumnParallelLinear,
                                                QKVParallelLinear,
                                                RowParallelLinear)
 
+from tpu_inference.layers.common.moe import MoEBackend
 from tpu_inference.layers.common.quantization.configs import QuantLinearConfig
-from tpu_inference.layers.vllm.fused_moe import FusedMoEBackend
 from tpu_inference.layers.vllm.quantization import get_tpu_quantization_config
 from tpu_inference.layers.vllm.quantization.fp8 import (VllmFp8Config,
                                                         VllmFp8LinearMethod,
@@ -483,9 +483,9 @@ def test_fused_moe(use_ep, num_devices, num_tokens, intermediate_size,
     with torchax.default_env(), set_forward_context(None, vllm_config):
         assert isinstance(vllm_fused_moe.quant_method, VllmFp8MoEMethod)
         if use_ep:
-            assert vllm_fused_moe.quant_method.moe_backend == FusedMoEBackend.GMM_EP
+            assert vllm_fused_moe.quant_method.moe_backend == MoEBackend.GMM_EP
         else:
-            assert vllm_fused_moe.quant_method.moe_backend == FusedMoEBackend.GMM_TP
+            assert vllm_fused_moe.quant_method.moe_backend == MoEBackend.GMM_TP
 
         jax_a = a.to('jax')
         jax_score = score.to('jax')

--- a/tests/layers/vllm/test_moe.py
+++ b/tests/layers/vllm/test_moe.py
@@ -1,0 +1,65 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Adjust the import below to match the actual location of your function
+# For example: from my_module.moe_selector import select_moe_backend_from_fused_moe_config
+from tpu_inference.layers.common.moe import MoEBackend
+# We assume the function is in a file that can be imported.
+# If testing locally without the full repo, you might need to adjust imports.
+from tpu_inference.layers.vllm.moe import \
+    select_moe_backend_from_fused_moe_config
+
+
+# Mock the FusedMoEConfig so we don't need vllm installed to test the logic
+@pytest.fixture
+def mock_moe_config():
+    """Creates a mock object mimicking FusedMoEConfig."""
+    config = MagicMock()
+    return config
+
+
+@pytest.mark.parametrize(
+    "env_use_ep_kernel, config_use_ep, expected_backend",
+    [
+        # Case 1: EP Kernel Env=True, Config EP=True -> FUSED_MOE
+        (True, True, MoEBackend.FUSED_MOE),
+
+        # Case 2: EP Kernel Env=False, Config EP=True -> GMM_EP
+        (False, True, MoEBackend.GMM_EP),
+
+        # Case 3: EP Kernel Env=False, Config EP=False -> GMM_TP
+        (False, False, MoEBackend.GMM_TP),
+
+        # Case 4: EP Kernel Env=True, Config EP=False -> Fallback to GMM_TP
+        (True, False, MoEBackend.GMM_TP),
+    ])
+def test_select_moe_backend_logic(monkeypatch, mock_moe_config,
+                                  env_use_ep_kernel, config_use_ep,
+                                  expected_backend):
+    """
+    Tests the main logic paths for backend selection based on environment variables
+    and the MoE configuration.
+    """
+    # Use patch as a context manager to limit the scope of the change to this block.
+    # This avoids using monkeypatch and ensures the mock is cleaned up immediately.
+    with patch("tpu_inference.envs.USE_MOE_EP_KERNEL", env_use_ep_kernel):
+        mock_moe_config.use_ep = config_use_ep
+
+        result = select_moe_backend_from_fused_moe_config(mock_moe_config)
+
+    assert result == expected_backend

--- a/tests/layers/vllm/test_mxfp4.py
+++ b/tests/layers/vllm/test_mxfp4.py
@@ -31,7 +31,7 @@ from vllm.engine.arg_utils import EngineArgs
 from vllm.forward_context import set_forward_context
 from vllm.model_executor.layers.fused_moe import FusedMoE
 
-from tpu_inference.layers.vllm.fused_moe import FusedMoEBackend
+from tpu_inference.layers.common.moe import MoEBackend
 from tpu_inference.layers.vllm.quantization import get_tpu_quantization_config
 from tpu_inference.layers.vllm.quantization.mxfp4 import (VllmMxfp4Config,
                                                           VllmMxfp4MoEMethod)
@@ -206,9 +206,9 @@ def test_mxfp4_fused_moe(num_devices, num_tokens, intermediate_size,
     with torchax.default_env(), set_forward_context(None, vllm_config):
         assert isinstance(vllm_fused_moe.quant_method, VllmMxfp4MoEMethod)
         if use_ep:
-            assert vllm_fused_moe.quant_method.moe_backend == FusedMoEBackend.GMM_EP
+            assert vllm_fused_moe.quant_method.moe_backend == MoEBackend.GMM_EP
         else:
-            assert vllm_fused_moe.quant_method.moe_backend == FusedMoEBackend.GMM_TP
+            assert vllm_fused_moe.quant_method.moe_backend == MoEBackend.GMM_TP
 
         jax_a = a.to('jax')
         score = score.to('jax')
@@ -304,7 +304,7 @@ def test_mxfp4_fused_moe_use_kernel(num_devices, num_tokens, intermediate_size,
 
     with torchax.default_env(), set_forward_context(None, vllm_config):
         assert isinstance(vllm_fused_moe.quant_method, VllmMxfp4MoEMethod)
-        assert vllm_fused_moe.quant_method.moe_backend == FusedMoEBackend.FUSED_MOE
+        assert vllm_fused_moe.quant_method.moe_backend == MoEBackend.FUSED_MOE
 
         jax_a = a.to('jax')
         score = score.to('jax')

--- a/tests/layers/vllm/test_unquantized.py
+++ b/tests/layers/vllm/test_unquantized.py
@@ -37,8 +37,8 @@ from vllm.model_executor.layers.linear import (ColumnParallelLinear,
                                                RowParallelLinear)
 from vllm.model_executor.model_loader import get_model as vllm_get_model
 
+from tpu_inference.layers.common.moe import MoEBackend
 from tpu_inference.layers.common.quantization.configs import QuantLinearConfig
-from tpu_inference.layers.vllm.fused_moe import FusedMoEBackend
 from tpu_inference.layers.vllm.quantization import get_tpu_quantization_config
 from tpu_inference.layers.vllm.quantization.unquantized import (
     VllmUnquantizedConfig, VllmUnquantizedFusedMoEMethod,
@@ -526,9 +526,9 @@ def test_fused_moe(use_ep, num_devices, num_tokens, intermediate_size,
         assert isinstance(vllm_fused_moe.quant_method,
                           VllmUnquantizedFusedMoEMethod)
         if use_ep:
-            assert vllm_fused_moe.quant_method.moe_backend == FusedMoEBackend.GMM_EP
+            assert vllm_fused_moe.quant_method.moe_backend == MoEBackend.GMM_EP
         else:
-            assert vllm_fused_moe.quant_method.moe_backend == FusedMoEBackend.GMM_TP
+            assert vllm_fused_moe.quant_method.moe_backend == MoEBackend.GMM_TP
 
         jax_a = a.to('jax')
         score = score.to('jax')
@@ -648,7 +648,7 @@ def test_fused_moe_use_kernel(num_devices, num_tokens, intermediate_size,
     with torchax.default_env(), set_forward_context(None, vllm_config):
         assert isinstance(vllm_fused_moe.quant_method,
                           VllmUnquantizedFusedMoEMethod)
-        assert vllm_fused_moe.quant_method.moe_backend == FusedMoEBackend.FUSED_MOE
+        assert vllm_fused_moe.quant_method.moe_backend == MoEBackend.FUSED_MOE
 
         jax_a = a.to('jax')
         score = score.to('jax')

--- a/tests/models/jax/test_deepseek_v3.py
+++ b/tests/models/jax/test_deepseek_v3.py
@@ -30,7 +30,9 @@ from vllm.config import ModelConfig
 import tpu_inference.kernels.mla.v1.kernel as mla
 from tpu_inference.layers.common.attention_interface import get_kv_cache_shape
 from tpu_inference.layers.common.attention_metadata import AttentionMetadata
-from tpu_inference.layers.common.sharding import ShardingAxisName
+from tpu_inference.layers.common.sharding import (ShardingAxisName,
+                                                  ShardingAxisNameBase)
+from tpu_inference.layers.jax.moe.moe import MoEBackend
 from tpu_inference.models.jax.deepseek_v3 import (DeepSeekV3,
                                                   DeepseekV3Attention,
                                                   DeepseekV3MLA,
@@ -112,14 +114,17 @@ class TestDeepSeekV3:
 
     def test_init(self, mock_config, rng, mesh):
         """Tests if the model initializes with the correct hierarchy."""
-        model = DeepSeekV3(mock_config, rng, mesh)
-        assert len(model.layers) == 1
-        assert isinstance(model.embedder, nnx.Module)
-        assert model.vllm_config.model_config.hf_config.num_hidden_layers == 1
+        with patch("tpu_inference.models.jax.deepseek_v3.ShardingAxisName",
+                   ShardingAxisNameBase):
+            model = DeepSeekV3(mock_config, rng, mesh)
+            assert len(model.layers) == 1
+            assert isinstance(model.embedder, nnx.Module)
+            assert model.vllm_config.model_config.hf_config.num_hidden_layers == 1
 
     def test_random_weights(self, mock_config, rng, mesh):
         """Tests that force_random_weights initializes non-zero weights."""
-        with jax.set_mesh(mesh):
+        with patch("tpu_inference.models.jax.deepseek_v3.ShardingAxisName",
+                   ShardingAxisNameBase):
             model = DeepSeekV3(mock_config,
                                rng,
                                mesh,
@@ -137,11 +142,13 @@ class TestDeepSeekV3:
     )
     def test_load_weights_called(self, mock_weights_generator, mock_loader_cls,
                                  mock_config, rng, mesh):
-        model = DeepSeekV3(mock_config, rng, mesh)
+        with patch("tpu_inference.models.jax.deepseek_v3.ShardingAxisName",
+                   ShardingAxisNameBase):
+            model = DeepSeekV3(mock_config, rng, mesh)
 
-        model.load_weights(rng)
+            model.load_weights(rng)
 
-        model.weight_loader.load_weights.assert_called_once_with(model)
+            model.weight_loader.load_weights.assert_called_once_with(model)
 
 
 class TestDeepSeekV3WeightLoader:
@@ -162,6 +169,7 @@ class TestDeepSeekV3WeightLoader:
                                           qk_rope_head_dim=64,
                                           v_head_dim=128,
                                           num_local_experts=256,
+                                          moe_backend=MoEBackend.DENSE_MAT,
                                           model_dtype=jnp.bfloat16)
 
     @pytest.mark.parametrize("loaded_key, expected_mapped", [
@@ -445,6 +453,7 @@ class TestDeepSeekV3NativeFP8:
                                           v_head_dim=32,
                                           num_local_experts=8,
                                           model_dtype=jnp.bfloat16,
+                                          moe_backend=MoEBackend.DENSE_MAT,
                                           use_mla_kernel=True)
 
     def test_native_fp8_initialization(self, fp8_loader):

--- a/tpu_inference/envs.py
+++ b/tpu_inference/envs.py
@@ -21,9 +21,7 @@ if TYPE_CHECKING:
     PHASED_PROFILING_DIR: str = ""
     PYTHON_TRACER_LEVEL: int = 1
     USE_MOE_EP_KERNEL: bool = False
-    USE_VLLM_MOE_KERNEL: bool = False
     USE_MEGABLOCKS: bool = False
-    USE_RAGGED_DOT: bool = False
     NUM_SLICES: int = 1
     RAY_USAGE_STATS_ENABLED: str = "0"
     VLLM_USE_RAY_COMPILED_DAG_CHANNEL_TYPE: str = "shm"
@@ -150,15 +148,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Use custom expert-parallel kernel for MoE (Mixture of Experts)
     "USE_MOE_EP_KERNEL":
     env_bool("USE_MOE_EP_KERNEL", default=False),
-    # Use vllm kernel for MoE (Mixture of Experts)
-    "USE_VLLM_MOE_KERNEL":
-    env_bool("USE_VLLM_MOE_KERNEL", default=False),
     # Enable megablocks for JAX sparse matmul for MoE (Mixture of Experts)
     "USE_MEGABLOCKS":
     env_bool("USE_MEGABLOCKS", default=False),
-    # Enable ragged_odt for JAX sparse matmul for MoE (Mixture of Experts)
-    "USE_RAGGED_DOT":
-    env_bool("USE_RAGGED_DOT", default=False),
     # Number of TPU slices for multi-slice mesh
     "NUM_SLICES":
     lambda: int(os.getenv("NUM_SLICES") or "1"),

--- a/tpu_inference/layers/common/moe.py
+++ b/tpu_inference/layers/common/moe.py
@@ -13,61 +13,62 @@
 # limitations under the License.
 
 from enum import Enum
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Union
 
 import jax
 import jax.numpy as jnp
 from jax.sharding import Mesh
 from vllm.model_executor.layers.fused_moe import FusedMoE
-from vllm.model_executor.layers.fused_moe.config import FusedMoEConfig
 
-from tpu_inference import envs
 from tpu_inference.kernels.fused_moe.v1.kernel import fused_ep_moe
 from tpu_inference.layers.common.fused_moe_gmm import fused_moe_func
 from tpu_inference.logger import init_logger
 
 if TYPE_CHECKING:
-    from tpu_inference.layers.vllm.process_weights.fused_moe_weights import \
-        FusedMoEWeights
+    from tpu_inference.layers.common.process_weights.moe_weights import (
+        FusedMoEWeights, UnfusedMoEWeights)
+    from tpu_inference.layers.jax.moe.moe import JaxMoE
+else:
+    FusedMoEWeights = None
+    UnfusedMoEWeights = None
+    JaxMoE = None
 
 logger = init_logger(__name__)
 
 
-class FusedMoEBackend(Enum):
+class MoEBackend(Enum):
+    # This is using the Fused MoE kernel found in tpu-inference/tpu_inference/kernels/fused_moe/v1/kernel.py
+    # and is production ready.
     FUSED_MOE = "fused_moe"
+    # This is using the GMM kernel found in tpu-inference/tpu_inference/layers/common/fused_moe_gmm.py
+    # and is `expert_sharded_gmm` the GMM calls.  Production ready.
     GMM_EP = "gmm_ep"
+    # Same as GMM_EP but uses `tensor_sharded_gmm_*` for the GMM calls and is production ready
     GMM_TP = "gmm_tp"
+    # Uses a simple dense matmul for the MoE backend and is intended for testing
+    # Only used in the JAX path for now
+    DENSE_MAT = "dense_mat"
+    MEGABLX_GMM = "megablox_gmm"  # only used in the JAX path for now
+
+    @classmethod
+    def fused_moe_backends(cls):
+        """Returns those backends that use fused weights"""
+        return {cls.FUSED_MOE, cls.GMM_EP, cls.GMM_TP}
 
 
-def select_moe_backend(moe: FusedMoEConfig):
-    if envs.USE_MOE_EP_KERNEL:
-        if moe.use_ep:
-            return FusedMoEBackend.FUSED_MOE
-        logger.warning_once(
-            "USE_MOE_EP_KERNEL=1 but expert parallelism is not "
-            "enabled. Falling back to gmm implementation.")
-
-    if moe.use_ep:
-        return FusedMoEBackend.GMM_EP
-
-    # Use default implementation.
-    return FusedMoEBackend.GMM_TP
-
-
-def fused_moe_apply(
-    layer: FusedMoE,
+def moe_apply(
+    layer: FusedMoE | JaxMoE,
     x: jax.Array,
     gating_output: jax.Array,
-    weights: "FusedMoEWeights",
-    moe_backend: FusedMoEBackend,
+    weights: Union[FusedMoEWeights, UnfusedMoEWeights],
+    moe_backend: MoEBackend,
     mesh: Mesh,
     extra_backend_kwargs: dict,
 ) -> jax.Array:
-    assert isinstance(layer, FusedMoE)
 
     with jax.named_scope(layer._get_name()):
         match moe_backend:
-            case FusedMoEBackend.FUSED_MOE:
+            case MoEBackend.FUSED_MOE:
                 subc_quant_w1_sz = None
                 subc_quant_w2_sz = None
                 if weights.w13_weight_scale is not None and weights.w2_weight_scale is not None:
@@ -105,7 +106,7 @@ def fused_moe_apply(
                     b2=weights.w2_bias,
                     **extra_backend_kwargs,
                 )[:, :actual_hidden_size]
-            case FusedMoEBackend.GMM_EP | FusedMoEBackend.GMM_TP:
+            case MoEBackend.GMM_EP | MoEBackend.GMM_TP:
                 output = fused_moe_func(
                     hidden_states=x,
                     w1=weights.w13_weight,
@@ -122,5 +123,12 @@ def fused_moe_apply(
                     activation=layer.activation,
                     scoring_fn=layer.scoring_func,
                 )
+            case MoEBackend.DENSE_MAT:
+                # TODO(jacobplatin): will implement in forthcoming PR
+                raise NotImplementedError
+
+            case MoEBackend.MEGABLX_GMM:
+                # TODO(jacobplatin): will implement in forthcoming PR
+                raise NotImplementedError
 
         return output

--- a/tpu_inference/layers/common/quantization/fp8.py
+++ b/tpu_inference/layers/common/quantization/fp8.py
@@ -26,7 +26,7 @@ from tpu_inference.layers.common.utils import \
 
 class Fp8LinearMethod:
     """Implements the forward method for fp8 linear layers.
-    
+
     This class will be shared in both vLLM and jax path.
     """
 

--- a/tpu_inference/layers/common/quantization/unquantized.py
+++ b/tpu_inference/layers/common/quantization/unquantized.py
@@ -24,7 +24,7 @@ from tpu_inference.layers.common.utils import \
 
 class UnquantizedLinearMethod:
     """Implements the forward method for unquantized linear layers.
-    
+
     This class will be shared in both vLLM and jax path.
     """
 

--- a/tpu_inference/layers/jax/moe/moe.py
+++ b/tpu_inference/layers/jax/moe/moe.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import math
 from dataclasses import InitVar, dataclass
 from functools import partial
 from typing import Optional
@@ -25,13 +24,15 @@ from jaxtyping import Float
 from qwix._src.providers import ptq
 
 from tpu_inference.kernels.fused_moe.v1.kernel import fused_ep_moe
+from tpu_inference.layers.common.moe import MoEBackend, fused_moe_func
+from tpu_inference.layers.jax import JaxModule
 from tpu_inference.layers.jax.base import create_param
 from tpu_inference.layers.jax.layers import FlaxUtils
 from tpu_inference.layers.jax.moe.dense_moe import (
     dense_moe_fwd, dense_moe_fwd_preapply_router_weights)
 from tpu_inference.layers.jax.moe.sparse_moe import sparse_moe_distributed_fwd
-from tpu_inference.layers.jax.moe.utils import MoEBackend
-from tpu_inference.layers.vllm.fused_moe import fused_moe_func
+from tpu_inference.layers.jax.quantization import QuantizeMethodBase
+from tpu_inference.layers.jax.quantization.configs import QuantizationConfig
 from tpu_inference.models.jax.utils.qwix.qwix_utils import \
     manually_quantize_qwix_weight
 
@@ -98,7 +99,7 @@ class Router(nnx.Module):
                                       self.kernel_DE.value)
 
         #TODO: Refactor the Router so that it will always only return router_logits_TE
-        if self.moe_backend == MoEBackend.FUSED_MOE or self.moe_backend == MoEBackend.VLLM_MOE:
+        if self.moe_backend in MoEBackend.fused_moe_backends():
             return router_logits_TE
         else:
             weights_TX, selected_experts_TX = jax.lax.top_k(
@@ -124,7 +125,7 @@ class Router(nnx.Module):
 
 # --- Main Class for MoE ---
 @dataclass(kw_only=True)
-class MoE(nnx.Module):
+class JaxMoE(JaxModule):
     """Mixture-of-Experts (MoE) Routed MLP Layer.
 
     This module implements a MoE layer with a router and multiple expert MLPs.
@@ -149,8 +150,12 @@ class MoE(nnx.Module):
 
     # --- Flags & Configs ---
     apply_expert_weight_before_computation: bool
+    expert_axis_name: str
+    num_expert_parallelism: int
     random_init: bool = False
     moe_backend: MoEBackend = MoEBackend.DENSE_MAT
+    scoring_func = "softmax"
+
     # --- Sparse MoE Specific Attributes ---
     num_experts_per_tok: int = 1  # Required for Sparse, optional/derived for Dense
     tile_size: tuple[int, int, int] = (128, 128, 128)
@@ -159,6 +164,10 @@ class MoE(nnx.Module):
 
     # --- MoE Kernel Specific Attributes ---
     renormalize: bool = True
+
+    # ---- Quantization Specific Attributes ----
+    quant_config: Optional[QuantizationConfig] = None
+    quant_prefix: str = ""
 
     def __call__(self, x_TD: Float):
         """Performs the forward pass of the MoE layer.
@@ -169,6 +178,11 @@ class MoE(nnx.Module):
         Returns:
             Output array of shape (sequence_length, d_model) after passing through MoE.
         """
+        # TODO (jacobplatin): wire this up so that `quant_method` is actually used and
+        # the forward pass is delegated to it
+        if self.quant_method is not None:
+            return self.quant_method.apply_jax(self, x_TD)
+
         x_TD = jnp.asarray(x_TD, self.dtype)
         x_TD = nnx.with_sharding_constraint(x_TD, self.activation_ffw_td)
         if self.moe_backend == MoEBackend.FUSED_MOE:
@@ -187,7 +201,7 @@ class MoE(nnx.Module):
                 **self.block_size,
             )
             return output_TD
-        elif self.moe_backend == MoEBackend.VLLM_MOE:
+        elif self.moe_backend in [MoEBackend.GMM_EP, MoEBackend.GMM_TP]:
             router_logits_TE = self.router(x_TD)
             # TODO (jacobplatin): the current GMM kernel expects that w1/w2 have the second and third dimensions
             # transposed, but this is likely not optimal for DeepSeek, so we will need to fix this
@@ -204,14 +218,15 @@ class MoE(nnx.Module):
                 topk=self.router.num_experts_per_tok,
                 renormalize=self.renormalize,
                 mesh=self.mesh,
-                use_ep=self.num_expert_parallelism > 1,
+                use_ep=self.use_ep,
                 activation=self.hidden_act,
+                scoring_fn=self.scoring_func,
             )
             return output_TD
         else:
             weights_TX, indices_TX = self.router(x_TD)
 
-            if self.moe_backend == MoEBackend.MEGABLX_GMM or self.moe_backend == MoEBackend.RAGGED_DOT:
+            if self.moe_backend == MoEBackend.MEGABLX_GMM:
                 # NOTE: for the qwix_quantized_weight_dtype case, we make the spec a tuple of 2 PartitionSpecs
                 # since the first entry corresponds to the weight and the second entry corresponds to the scale.
                 # For the scale, we don't shard on the "D" dimmension because this is the subchannel dimmension
@@ -289,6 +304,19 @@ class MoE(nnx.Module):
 
     def __post_init__(self, rngs: nnx.Rngs):
         """Generates the kernels (weights) for the router and experts (gating, up-projection, and down-projection layers)."""
+        # TODO (jacobplatin): wire this up so that `quant_method` is actually used and is not None
+        self.use_ep = self.num_expert_parallelism > 1
+        if self.quant_config is None:
+            self.quant_method = None
+        elif (quant_method :=
+              self.quant_config.get_quant_method(self,
+                                                 prefix=self.quant_prefix)):
+            assert isinstance(quant_method, QuantizeMethodBase)
+            self.quant_method = quant_method
+            self.quant_method.create_weights_jax(self)
+        else:
+            self.quant_method = None
+
         E = self.num_local_experts
         D = self.hidden_size
         F = self.intermediate_size_moe
@@ -320,7 +348,7 @@ class MoE(nnx.Module):
                 "bd1c": 256,
                 "bd2c": 256,
             }
-        elif self.moe_backend == MoEBackend.VLLM_MOE:
+        elif self.moe_backend in [MoEBackend.GMM_EP, MoEBackend.GMM_TP]:
             # TODO (jacobplatin): the current GMM kernel expects that w1/w2 have the second and third
             # dimensions transposed, but this is likely not optimal for DeepSeek, so we will
             # need to fix this in the future
@@ -360,17 +388,6 @@ class MoE(nnx.Module):
 
         # TODO: Add quantization scale params for VLLM MoE kernel
         self.w1_scale, self.w2_scale = (None, None)
-
-        self.expert_axis_name = self.edf_sharding[0]
-        if self.expert_axis_name is None:
-            self.num_expert_parallelism = 1
-        else:
-            if isinstance(self.expert_axis_name, str):
-                self.num_expert_parallelism = self.mesh.shape[
-                    self.expert_axis_name]
-            else:
-                self.num_expert_parallelism = math.prod(
-                    self.mesh.shape[axis] for axis in self.expert_axis_name)
 
         # Derive if data is sharded by expert
         self.data_axis_name = self.activation_ffw_td[0]

--- a/tpu_inference/layers/jax/moe/utils.py
+++ b/tpu_inference/layers/jax/moe/utils.py
@@ -13,59 +13,24 @@
 # limitations under the License.
 
 import enum
+import math
 
 import jax
 import jax.numpy as jnp
 from jax.experimental import xla_metadata
-from qwix._src.core.qarray import QArray
-from qwix._src.core.ragged_dot import ragged_dot as qwix_ragged_dot
+from jax.sharding import Mesh
 
 from tpu_inference import envs
 from tpu_inference.kernels.megablox.gmm import gmm as megablox_gmm
 from tpu_inference.layers.common.fused_moe_gmm import \
     round_up_to_multiple_of_128_within_limit
+from tpu_inference.layers.common.moe import MoEBackend
 from tpu_inference.layers.jax.layers import FlaxUtils
 from tpu_inference.logger import init_logger
-from tpu_inference.models.jax.utils.qwix.qwix_utils import \
-    manually_quantize_qwix_activation
 
 logger = init_logger(__name__)
 modeling_flax_utils = FlaxUtils()
 set_xla_metadata = xla_metadata.set_xla_metadata
-
-
-class MoEBackend(enum.Enum):
-    FUSED_MOE = "fused_moe"
-    VLLM_MOE = "vllm_moe"
-    DENSE_MAT = "dense_mat"
-    MEGABLX_GMM = "megablox_gmm"
-    RAGGED_DOT = "ragged_dot_gmm"
-
-
-def select_moe_backend():
-    # Validation: Ensure mutually exclusive flags aren't set together
-    if envs.USE_MOE_EP_KERNEL and envs.USE_VLLM_MOE_KERNEL:
-        raise ValueError("Cannot enable multiple MoE kernels simultaneously.")
-
-    if envs.USE_MOE_EP_KERNEL:
-        logger.info("[MoE]: Fused MoE kernel is enabled")
-        return MoEBackend.FUSED_MOE
-
-    if envs.USE_VLLM_MOE_KERNEL:
-        logger.info("[MoE]: VLLM MoE kernel is enabled")
-        return MoEBackend.VLLM_MOE
-
-    if envs.USE_MEGABLOCKS:
-        logger.info("[MoE]: Mega Blocks is enabled for GMM in Sparse Matmul")
-        return MoEBackend.MEGABLX_GMM
-
-    if envs.USE_RAGGED_DOT:
-        logger.info("[MoE]: Ragged Dot is enabled for GMM in Sparse Matmul")
-        return MoEBackend.RAGGED_DOT
-
-    # Default case
-    logger.info("[MoE]: Dense Matmul is enabled")
-    return MoEBackend.DENSE_MAT
 
 
 # --- Helper Functions/Class for Sparse MoE ---
@@ -266,23 +231,57 @@ def gmm_fn(inputs, kernel, group_sizes, tile_size, moe_backend, dtype,
                               preferred_element_type=dtype,
                               tiling=(tm, tk, tn))
 
-    elif moe_backend == MoEBackend.RAGGED_DOT:
-        # TODO (jacobplatin): support more than just fp8_e4m3fn for activations!
-        inputs = manually_quantize_qwix_activation(
-            inputs, "ragged_dot", jnp.float8_e4m3fn, [0], {},
-            "absmax") if quantized_dtype else inputs
-        ragged_dot_func = qwix_ragged_dot if quantized_dtype else jax.lax.ragged_dot
-        if quantized_dtype:
-            q_value, q_scale = kernel
-            kernel = QArray(q_value, q_scale, qtype=quantized_dtype)
-        with set_xla_metadata(ragged_dot_tiling=",".join(
-            [str(t) for t in tile_size]),
-                              mosaic_fusion_group="ragged-dot"):
-            output = ragged_dot_func(lhs=inputs,
-                                     rhs=kernel,
-                                     group_sizes=group_sizes,
-                                     preferred_element_type=dtype)
-
     if pad_amount > 0:
         output = output[:num_rows, :]
     return output
+
+
+def get_expert_parallelism(expert_axis_name: str, mesh: Mesh) -> int:
+    """
+    Returns the expert parallelism number from the mesh.
+
+    Args:
+        expert_axis_name: The expert axis name.
+        mesh: The mesh.
+
+    Returns:
+        The expert parallelism number.
+    """
+    if expert_axis_name is None:
+        return 1
+    else:
+        if isinstance(expert_axis_name, str):
+            return mesh.shape[expert_axis_name]
+        else:
+            return math.prod(mesh.shape[axis] for axis in expert_axis_name)
+
+
+def select_moe_backend(use_ep: bool) -> MoEBackend:
+    """
+    Selects the MoE backend for the JAX path.
+
+    Args:
+        use_ep: Whether to use expert parallelism.
+
+    Returns:
+        The selected MoE backend.
+    """
+    if envs.USE_MOE_EP_KERNEL:
+        if use_ep:
+            logger.info_once("[MoE]: Using fused MoE EP kernel")
+            return MoEBackend.FUSED_MOE
+
+    if envs.USE_MEGABLOCKS:
+        logger.info_once(
+            "[MoE]: Mega Blocks is enabled for GMM in Sparse Matmul")
+        return MoEBackend.MEGABLX_GMM
+
+    if use_ep:
+        logger.warning_once(
+            "USE_MOE_EP_KERNEL=1 but expert parallelism is not "
+            "enabled. Falling back to gmm implementation.")
+        logger.info_once("[MoE]: Using GMM EP kernel")
+        return MoEBackend.GMM_EP
+
+    logger.info_once("[MoE]: Using GMM TP kernel")
+    return MoEBackend.GMM_TP

--- a/tpu_inference/layers/jax/quantization/unquantized.py
+++ b/tpu_inference/layers/jax/quantization/unquantized.py
@@ -20,6 +20,7 @@ from tpu_inference.layers.common.quantization import unquantized as jax_common
 from tpu_inference.layers.common.quantization.configs import QuantLinearConfig
 from tpu_inference.layers.jax import JaxModule
 from tpu_inference.layers.jax.linear import JaxEinsum
+from tpu_inference.layers.jax.moe.moe import JaxMoE
 from tpu_inference.layers.jax.quantization import QuantizeMethodBase
 from tpu_inference.layers.jax.quantization.configs import QuantizationConfig
 
@@ -46,6 +47,22 @@ class UnquantizedLinearMethod(QuantizeMethodBase,
         return out
 
 
+class UnquantizedFusedMoEMethod(QuantizeMethodBase):
+    """
+    TODO (jacobplatin): implement in forthcoming PR.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.extra_backend_kwargs = {}
+
+    def process_weights_after_loading(self, layer) -> None:
+        raise NotImplementedError
+
+    def apply_jax(self, layer: JaxModule, x: jax.Array) -> jax.Array:
+        raise NotImplementedError
+
+
 class UnquantizedConfig(QuantizationConfig):
 
     def get_quant_method(self, layer: JaxModule,
@@ -54,4 +71,7 @@ class UnquantizedConfig(QuantizationConfig):
             linear_config = QuantLinearConfig(
                 enable_sp=False, output_sizes=[layer.kernel_shape[-1]])
             return UnquantizedLinearMethod(linear_config)
+        if isinstance(layer, JaxMoE):
+            # TODO (jacobplatin): do we need to pass a config here?
+            return UnquantizedFusedMoEMethod()
         return None

--- a/tpu_inference/layers/jax/transformer_block.py
+++ b/tpu_inference/layers/jax/transformer_block.py
@@ -22,7 +22,7 @@ from flax import nnx
 from tpu_inference.layers.jax.attention.attention import (AttentionMetadata,
                                                           KVCache)
 from tpu_inference.layers.jax.layers import DenseFFW
-from tpu_inference.layers.jax.moe.moe import MoE
+from tpu_inference.layers.jax.moe.moe import JaxMoE
 
 
 @dataclass(kw_only=True)
@@ -78,7 +78,7 @@ class SharedExpertsTransformerBlock(TransformerBlock):
     with the `shared_experts` module.
     """
 
-    moe_ffw: Optional[MoE] = None
+    moe_ffw: Optional[JaxMoE] = None
     dense_ffw: Optional[DenseFFW] = None
     shared_experts: Optional[DenseFFW] = None
 
@@ -95,7 +95,7 @@ class SharedExpertsTransformerBlock(TransformerBlock):
         ffw_residual_TD = attn_output_TD
         normed_ffw_input_TD = self.pre_mlp_norm(attn_output_TD)
 
-        if isinstance(self.custom_module, MoE):
+        if isinstance(self.custom_module, JaxMoE):
             moe_layer = self.custom_module
         else:
             moe_layer = self.moe_ffw

--- a/tpu_inference/layers/vllm/moe.py
+++ b/tpu_inference/layers/vllm/moe.py
@@ -1,0 +1,89 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import torch
+from torchax.interop import jax_view, torch_view
+from vllm.model_executor.layers.fused_moe import FusedMoE, FusedMoEMethodBase
+from vllm.model_executor.layers.fused_moe.config import FusedMoEConfig
+
+from tpu_inference import envs
+from tpu_inference.layers.common.moe import MoEBackend, moe_apply
+from tpu_inference.layers.common.process_weights.moe_weights import \
+    FusedMoEWeights
+from tpu_inference.logger import init_logger
+
+logger = init_logger(__name__)
+
+
+def select_moe_backend_from_fused_moe_config(
+        moe: FusedMoEConfig) -> MoEBackend:
+    """
+    Select the MoE backend based on the FusedMoEConfig.
+
+    NOTE (jacobplatin): we don't currently support DENSE_MAT or MEGABLX_GMM
+    backends on the vLLM path for now.
+
+    Args:
+        moe: The FusedMoEConfig.
+
+    Returns:
+        The selected MoE backend.
+    """
+
+    if envs.USE_MOE_EP_KERNEL:
+        if moe.use_ep:
+            logger.info_once("[MoE]: Using fused MoE EP kernel")
+            return MoEBackend.FUSED_MOE
+        logger.warning_once(
+            "USE_MOE_EP_KERNEL=1 but expert parallelism is not "
+            "enabled. Falling back to gmm implementation.")
+
+    if moe.use_ep:
+        logger.info_once("[MoE]: Using GMM EP kernel")
+        return MoEBackend.GMM_EP
+
+    # Use default implementation.
+    logger.info_once("[MoE]: Using GMM TP kernel")
+    return MoEBackend.GMM_TP
+
+
+def vllm_moe_apply(layer: FusedMoE, weights: FusedMoEWeights,
+                   quant_method_instance: FusedMoEMethodBase, x: torch.Tensor,
+                   router_logits: torch.Tensor) -> torch.Tensor:
+    """
+    Shared function for applying a FusedMoE layer for the TorchAX/vLLM backend.
+
+    Args:
+        layer: The FusedMoE layer.
+        weights: The FusedMoE weights.
+        quant_method_instance: The quantization method instance.
+        x: The input tensor.
+        router_logits: The router logits.
+
+    Returns:
+        The output tensor from the MoE fowrard pass.
+    """
+    assert isinstance(layer, FusedMoE)
+    assert isinstance(quant_method_instance, FusedMoEMethodBase)
+    assert isinstance(weights, FusedMoEWeights)
+
+    return torch_view(
+        moe_apply(
+            layer=layer,
+            x=jax_view(x),
+            gating_output=jax_view(router_logits),
+            weights=weights,
+            moe_backend=quant_method_instance.moe_backend,
+            mesh=quant_method_instance.mesh,
+            extra_backend_kwargs=quant_method_instance.extra_backend_kwargs,
+        ))

--- a/tpu_inference/layers/vllm/quantization/compressed_tensors/compressed_tensors_moe.py
+++ b/tpu_inference/layers/vllm/quantization/compressed_tensors/compressed_tensors_moe.py
@@ -23,12 +23,12 @@ from vllm.model_executor.layers.fused_moe import FusedMoE, FusedMoEConfig
 from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tensors_moe import (  # noqa: E501
     CompressedTensorsMoEMethod, CompressedTensorsW8A8Fp8MoEMethod)
 
-from tpu_inference.layers.common.sharding import ShardingAxisName
-from tpu_inference.layers.vllm.fused_moe import (FusedMoEBackend,
-                                                 fused_moe_apply,
-                                                 select_moe_backend)
-from tpu_inference.layers.vllm.process_weights.fused_moe_weights import (
+from tpu_inference.layers.common.moe import MoEBackend
+from tpu_inference.layers.common.process_weights.moe_weights import (
     FusedMoEWeights, process_moe_weights, shard_moe_weights)
+from tpu_inference.layers.common.sharding import ShardingAxisName
+from tpu_inference.layers.vllm.moe import (
+    select_moe_backend_from_fused_moe_config, vllm_moe_apply)
 from tpu_inference.layers.vllm.quantization.configs import VllmQuantConfig
 from tpu_inference.layers.vllm.quantization.unquantized import \
     VllmUnquantizedFusedMoEMethod
@@ -93,10 +93,10 @@ class VllmCompressedTensorsW8A8Fp8MoEMethod(CompressedTensorsW8A8Fp8MoEMethod,
         super().__init__(weight_quant, input_quant, moe)
 
         self.mesh = mesh
-        self.moe_backend = select_moe_backend(self.moe)
+        self.moe_backend = select_moe_backend_from_fused_moe_config(self.moe)
 
         self.extra_backend_kwargs = {}
-        if self.moe_backend == FusedMoEBackend.FUSED_MOE:
+        if self.moe_backend == MoEBackend.FUSED_MOE:
             self.extra_backend_kwargs = dict(ep_axis_name=ep_axis_name, )
 
     @property
@@ -204,14 +204,8 @@ class VllmCompressedTensorsW8A8Fp8MoEMethod(CompressedTensorsW8A8Fp8MoEMethod,
             w2_weight_scale=jax_view(layer.w2_weight_scale),
             w2_bias=jax_view(layer.w2_bias) if self.moe.has_bias else None,
         )
-
-        return torch_view(
-            fused_moe_apply(
-                layer,
-                jax_view(x),
-                jax_view(router_logits),
-                weights,
-                self.moe_backend,
-                self.mesh,
-                self.extra_backend_kwargs,
-            ))
+        return vllm_moe_apply(layer=layer,
+                              weights=weights,
+                              quant_method_instance=self,
+                              x=x,
+                              router_logits=router_logits)

--- a/tpu_inference/layers/vllm/quantization/fp8.py
+++ b/tpu_inference/layers/vllm/quantization/fp8.py
@@ -33,20 +33,20 @@ from vllm.model_executor.layers.quantization.base_config import \
 from vllm.model_executor.layers.quantization.utils.quant_utils import \
     is_layer_skipped
 
+from tpu_inference.layers.common.moe import MoEBackend
 from tpu_inference.layers.common.process_weights.linear_weights import (
     LinearWeights, process_linear_weights, shard_linear_weights,
     to_parameter_list)
+from tpu_inference.layers.common.process_weights.moe_weights import (
+    FusedMoEWeights, process_moe_weights, quantize_moe_weights,
+    shard_moe_weights)
 from tpu_inference.layers.common.quant_methods import FP8, get_tpu_quant_method
 from tpu_inference.layers.common.quantization import dequantize_tensor
 from tpu_inference.layers.common.quantization import fp8 as common_fp8
 from tpu_inference.layers.common.quantization import quantize_tensor
 from tpu_inference.layers.common.sharding import ShardingAxisName
-from tpu_inference.layers.vllm.fused_moe import (FusedMoEBackend,
-                                                 fused_moe_apply,
-                                                 select_moe_backend)
-from tpu_inference.layers.vllm.process_weights.fused_moe_weights import (
-    FusedMoEWeights, process_moe_weights, quantize_moe_weights,
-    shard_moe_weights)
+from tpu_inference.layers.vllm.moe import (
+    select_moe_backend_from_fused_moe_config, vllm_moe_apply)
 from tpu_inference.layers.vllm.quantization.configs import (
     VllmQuantConfig, VllmQuantLinearConfig)
 from tpu_inference.layers.vllm.quantization.unquantized import (
@@ -259,10 +259,10 @@ class VllmFp8MoEMethod(vllm_fp8.Fp8MoEMethod):
         self.fp8_backend = None
 
         self.mesh = mesh
-        self.moe_backend = select_moe_backend(self.moe)
+        self.moe_backend = select_moe_backend_from_fused_moe_config(self.moe)
 
         self.extra_backend_kwargs = {}
-        if self.moe_backend == FusedMoEBackend.FUSED_MOE:
+        if self.moe_backend == MoEBackend.FUSED_MOE:
             self.extra_backend_kwargs = dict(ep_axis_name=ep_axis_name, )
 
     @property
@@ -352,14 +352,8 @@ class VllmFp8MoEMethod(vllm_fp8.Fp8MoEMethod):
             w2_weight_scale=jax_view(layer.w2_weight_scale_inv),
             w2_bias=jax_view(layer.w2_bias) if self.moe.has_bias else None,
         )
-
-        return torch_view(
-            fused_moe_apply(
-                layer,
-                jax_view(x),
-                jax_view(router_logits),
-                weights,
-                self.moe_backend,
-                self.mesh,
-                self.extra_backend_kwargs,
-            ))
+        return vllm_moe_apply(layer=layer,
+                              weights=weights,
+                              quant_method_instance=self,
+                              x=x,
+                              router_logits=router_logits)

--- a/tpu_inference/layers/vllm/quantization/mxfp4.py
+++ b/tpu_inference/layers/vllm/quantization/mxfp4.py
@@ -36,17 +36,17 @@ from vllm.model_executor.layers.quantization.mxfp4 import (Mxfp4Backend,
 from vllm.model_executor.layers.quantization.utils.quant_utils import \
     is_layer_skipped
 
+from tpu_inference.layers.common.moe import MoEBackend
+from tpu_inference.layers.common.process_weights.moe_weights import (
+    FusedMoEWeights, process_moe_weights, quantize_moe_weights,
+    shard_moe_weights)
 from tpu_inference.layers.common.quant_methods import (MXFP4,
                                                        get_tpu_quant_method)
 from tpu_inference.layers.common.quantization import \
     dequantize_tensor_from_mxfp4_packed
 from tpu_inference.layers.common.sharding import ShardingAxisName
-from tpu_inference.layers.vllm.fused_moe import (FusedMoEBackend,
-                                                 fused_moe_apply,
-                                                 select_moe_backend)
-from tpu_inference.layers.vllm.process_weights.fused_moe_weights import (
-    FusedMoEWeights, process_moe_weights, quantize_moe_weights,
-    shard_moe_weights)
+from tpu_inference.layers.vllm.moe import (
+    select_moe_backend_from_fused_moe_config, vllm_moe_apply)
 from tpu_inference.layers.vllm.quantization.configs import VllmQuantConfig
 from tpu_inference.layers.vllm.quantization.unquantized import \
     VllmUnquantizedLinearMethod
@@ -106,10 +106,10 @@ class VllmMxfp4MoEMethod(Mxfp4MoEMethod):
         self.mxfp4_backend = Mxfp4Backend.TRITON
 
         self.mesh = mesh
-        self.moe_backend = select_moe_backend(self.moe)
+        self.moe_backend = select_moe_backend_from_fused_moe_config(self.moe)
 
         self.extra_backend_kwargs = {}
-        if self.moe_backend == FusedMoEBackend.FUSED_MOE:
+        if self.moe_backend == MoEBackend.FUSED_MOE:
             # When fused moe kernle is used, we pass extra arguments like
             # tuned block sizes to the kernel.
             self.extra_backend_kwargs = dict(ep_axis_name=ep_axis_name, )
@@ -215,13 +215,8 @@ class VllmMxfp4MoEMethod(Mxfp4MoEMethod):
             w2_bias=jax_view(layer.w2_bias),
         )
 
-        return torch_view(
-            fused_moe_apply(
-                layer,
-                jax_view(x),
-                jax_view(router_logits),
-                weights,
-                self.moe_backend,
-                self.mesh,
-                self.extra_backend_kwargs,
-            ))
+        return vllm_moe_apply(layer=layer,
+                              weights=weights,
+                              quant_method_instance=self,
+                              x=x,
+                              router_logits=router_logits)

--- a/tpu_inference/models/jax/deepseek_v3.py
+++ b/tpu_inference/models/jax/deepseek_v3.py
@@ -35,6 +35,7 @@ from tpu_inference.kernels.ragged_paged_attention.v3.kernel import \
     ragged_paged_attention
 from tpu_inference.kernels.ragged_paged_attention.v3.tuned_block_sizes import \
     get_tuned_block_sizes
+from tpu_inference.layers.common.moe import MoEBackend
 from tpu_inference.layers.common.quantization import (quantize_kv,
                                                       u8_unpack_e2m1)
 from tpu_inference.layers.common.sharding import ShardingAxisName
@@ -43,8 +44,9 @@ from tpu_inference.layers.jax.base import create_param
 from tpu_inference.layers.jax.constants import KVCacheType
 from tpu_inference.layers.jax.layers import (Embedder, FlaxUtils, LMhead,
                                              RMSNorm)
-from tpu_inference.layers.jax.moe.moe import MoE
-from tpu_inference.layers.jax.moe.utils import MoEBackend, select_moe_backend
+from tpu_inference.layers.jax.moe.moe import JaxMoE
+from tpu_inference.layers.jax.moe.utils import (get_expert_parallelism,
+                                                select_moe_backend)
 from tpu_inference.layers.jax.rope import DeepseekScalingRotaryEmbedding
 from tpu_inference.logger import init_logger
 from tpu_inference.models.jax.utils.weight_utils import (BaseWeightLoader,
@@ -662,7 +664,7 @@ class DeepseekV3MoE(nnx.Module):
 
     Reference here: https://github.com/vllm-project/vllm/blob/2b465570e6dd327e8422ef9c87e9b2b1454ceaed/vllm/model_executor/models/deepseek_v2.py#L223
     """
-    experts: MoE
+    experts: JaxMoE
     shared_experts: Optional[DeepseekV3MLP] = None
 
     routed_scaling_factor: float = 1.0
@@ -792,7 +794,7 @@ class DeepSeekV3Router(nnx.Module):
         scores_TE = jnp.einsum("TD,DE -> TE", x_TD, self.kernel_DE.value)
         scores_TE = nnx.sigmoid(scores_TE)
 
-        if self.moe_backend == MoEBackend.FUSED_MOE or self.moe_backend == MoEBackend.VLLM_MOE:
+        if self.moe_backend in MoEBackend.fused_moe_backends():
             return scores_TE
 
         original_scores_TE = scores_TE
@@ -840,6 +842,7 @@ class DeepSeekV3WeightLoader(BaseWeightLoader):
                  v_head_dim,
                  num_local_experts,
                  model_dtype,
+                 moe_backend,
                  use_mla_kernel=False):
         super().__init__(vllm_config, framework="pt")
         self.num_layers = num_layers
@@ -852,7 +855,7 @@ class DeepSeekV3WeightLoader(BaseWeightLoader):
         self.kv_lora_rank = kv_lora_rank
         self.model_dtype = model_dtype
         self.use_mla_kernel = use_mla_kernel
-        self.moe_backend = select_moe_backend()
+        self.moe_backend = moe_backend
 
         self._transpose_map = {
             # dense mlp
@@ -937,7 +940,7 @@ class DeepSeekV3WeightLoader(BaseWeightLoader):
             "model.layers.*.mlp.shared_experts.up_proj.weight":
             "layers.*.custom_module.shared_experts.kernel_up_proj_DF",
         }
-        if self.moe_backend == MoEBackend.VLLM_MOE:
+        if self.moe_backend in [MoEBackend.GMM_EP, MoEBackend.GMM_TP]:
             # NOTE (jacobplatin): the first rule is needed because
             # the current GMM kernel expects that the second/third
             # dimensions are transposed.  The second rule is needed
@@ -945,9 +948,9 @@ class DeepSeekV3WeightLoader(BaseWeightLoader):
             # are fused into a single weight tensor.
             self._loaded_to_standardized_keys.update({
                 "model.layers.*.mlp.experts.*.down_proj.weight":
-                "layers.*.custom_module.kernel_down_proj_EFD",
+                "layers.*.custom_module.experts.kernel_down_proj_EFD",
                 "model.layers.*.mlp.experts.*.gating_upproj_EDF.weight":
-                "layers.*.custom_module.kernel_gating_upproj_EDF",
+                "layers.*.custom_module.experts.kernel_gating_upproj_EDF",
             })
             # NOTE (jacobplatin): only used for the MOE_VLLM backend, which
             # expects 2/3 dimensions to be transposed.
@@ -1342,7 +1345,8 @@ class DeepSeekV3WeightLoader(BaseWeightLoader):
                                                                  "down_proj")
 
                             is_moe_kernel = model_for_loading.moe_backend in [
-                                MoEBackend.FUSED_MOE, MoEBackend.VLLM_MOE
+                                MoEBackend.FUSED_MOE, MoEBackend.GMM_TP,
+                                MoEBackend.GMM_EP
                             ]
                             gate_name = loaded_name.replace(
                                 proj_type, "gate_proj")
@@ -1350,9 +1354,10 @@ class DeepSeekV3WeightLoader(BaseWeightLoader):
                             down_name = loaded_name.replace(
                                 proj_type, "down_proj")
                             if is_moe_kernel:
-                                if model_for_loading.moe_backend == MoEBackend.VLLM_MOE:
+                                if model_for_loading.moe_backend in [
+                                        MoEBackend.GMM_EP, MoEBackend.GMM_TP
+                                ]:
                                     # (E, D, F) -> (E, 2 * F, D)
-
                                     fused_w = torch.cat([gate_w, up_w], dim=1)
                                     fused_s = torch.cat(
                                         [gate_s, up_s], dim=1
@@ -1570,7 +1575,18 @@ class DeepSeekV3(nnx.Module):
 
         self.mesh = mesh
 
-        self.moe_backend = select_moe_backend()
+        # TODO (jacobplatin): this shouldn't be related to
+        # the (DeepSeek) modelling code since it's really
+        # MoE-specific, but because we do weight loading
+        # here, we need to keep it for now.
+        # TODO (jacobplatin): remove this in another PR
+        edf_sharding = (None, ShardingAxisName.MODEL_1,
+                        ShardingAxisName.MODEL_2)
+        self.expert_axis_name = edf_sharding[0]
+        self.num_expert_parallelism = get_expert_parallelism(
+            self.expert_axis_name, self.mesh)
+        self.use_ep = self.num_expert_parallelism > 1
+        self.moe_backend = select_moe_backend(self.use_ep)
 
         self.weight_loader = self.WeightLoader(
             vllm_config=vllm_config,
@@ -1584,6 +1600,7 @@ class DeepSeekV3(nnx.Module):
             v_head_dim=v_head_dim,
             num_local_experts=num_local_experts,
             model_dtype=dtype,
+            moe_backend=self.moe_backend,
             use_mla_kernel=self.use_mla_kernel)
 
         self.embedder = Embedder(vocab_size=vocab_size,
@@ -1706,16 +1723,19 @@ class DeepSeekV3(nnx.Module):
                     e_sharding=(None, ))
 
                 # routed experts
-                custom_module = MoE(
+                custom_module = JaxMoE(
                     dtype=dtype,
                     num_local_experts=num_local_experts,
                     apply_expert_weight_before_computation=False,
+                    expert_axis_name=self.expert_axis_name,
+                    num_expert_parallelism=self.num_expert_parallelism,
                     hidden_size=hidden_size,
                     intermediate_size_moe=moe_intermediate_size,
                     num_experts_per_tok=num_experts_per_token,
                     mesh=self.mesh,
                     hidden_act=hidden_act,
                     rngs=self.rng,
+                    quant_config=vllm_config.quant_config,
                     activation_ffw_td=(ShardingAxisName.MLP_DATA,
                                        ShardingAxisName.MODEL_1),
                     activation_ffw_ted=(ShardingAxisName.MLP_DATA, None,

--- a/tpu_inference/models/jax/llama4.py
+++ b/tpu_inference/models/jax/llama4.py
@@ -30,7 +30,7 @@ from tpu_inference.layers.jax.attention.llama4_attention import Llama4Attention
 from tpu_inference.layers.jax.constants import KVCacheType
 from tpu_inference.layers.jax.layers import DenseFFW, Embedder, LMhead, RMSNorm
 from tpu_inference.layers.jax.misc import shard_put
-from tpu_inference.layers.jax.moe.moe import MoE, Router
+from tpu_inference.layers.jax.moe.moe import JaxMoE, Router
 from tpu_inference.layers.jax.pp_utils import (PPMissingLayer,
                                                get_start_end_layer)
 from tpu_inference.layers.jax.transformer_block import \
@@ -516,13 +516,15 @@ class Llama4ForCausalLM(nnx.Module):
                             ed_sharding=(None, None),
                             random_init=force_random_weights)
 
-            moe_ffw = MoE(
+            moe_ffw = JaxMoE(
                 dtype=dtype,
                 mesh=self.mesh,
                 num_local_experts=self.num_local_experts,
                 apply_expert_weight_before_computation=True,
                 hidden_size=self.hidden_size,
                 intermediate_size_moe=self.intermediate_size_moe,
+                expert_axis_name=None,
+                num_expert_parallelism=1,
                 hidden_act=self.hidden_act,
                 router=router,
                 rngs=self.rng,


### PR DESCRIPTION
# Description

In this PR, I do the following
* Consolidate to a single `select_moe_backend` method (the existing one in the TorchAX path) and add testing in `tests/layers/common/test_moe.py`
* Move `tpu_inference/layers/vllm/process_weights/fused_moe_weights.py` to `tpu_inference/layers/common/process_weights/moe_weights.py` , **context**: we want to share these utils between Jax/TorchAX + I added an UnfusedMoEWeights class since the JAX path has a few paths that don't want to fuse weights on (for now)

* Move `‎tpu_inference/layers/common/moe.py‎tpu_inference/layers/vllm/fused_moe.py`  to `tpu_inference/layers/common/moe.py` , **context**: we also want to share the logic in this file between JAX/TorchAX.  I also renamed FusedMoEBackend to MoEBackend since some of the JAX path backends aren't fused (neither weights nor full MoE operations), and updated select_moe_backend to take use_ep as a bool since the JAX path doesn't have an equivalent FusedMoEConfig for now.  Also, rename `fused_moe_apply` to `moe_apply`.

* `tpu_inference/layers/jax/moe/moe.py`: rename `MoE` to `JaxMoE` and add scaffolding of `quant_method` logic that will be wired in a forthcoming PR.

* `tpu_inference/layers/jax/quantization/unquantized.py` add skeleton of `UnquantizedFusedMoEMethod`


# Tests


Checked that `offline_inference` produces the exact same results on the TorchAX path for both FP8/Compressed-Tensor MoE models:

```
python examples/offline_inference.py --model=Qwen/Qwen3-Coder-30B-A3B-Instruct-FP8 --tensor-parallel-size=2

--------------------------------------------------
Prompt: 'Hello, my name is'
Generated text: ' Wang Yujie. I am a postgraduate student at the School of Computer'
--------------------------------------------------
Prompt: 'The capital of France is'
Generated text: ' ____\nA. London\nB. Berlin\nC. Rome\nD.'
--------------------------------------------------
Prompt: 'The colors of the rainbow are'
Generated text: ' red, orange, yellow, green, blue, indigo, and violet.'
--------------------------------------------------
Prompt: 'The future of AI is'
Generated text: " not just about creating smarter machines; it's about ensuring that these machines remain beneficial"
--------------------------------------------------
Prompt: 'The president of the United States is'
Generated text: ' the head of the executive branch of the federal government of the United States. The'



MODEL_IMPL_TYPE=vllm python examples/offline_inference.py --model=RedHatAI/Qwen3-30B-A3B-FP8-dynamic  --tensor-parallel-size=2
--------------------------------------------------
Prompt: 'Hello, my name is'
Generated text: ' Emily. I am a 30-year-old woman. I used to be'
--------------------------------------------------
Prompt: 'The capital of France is'
Generated text: ' __________.\nA. Paris\nB. London\nC. Berlin\nD'
--------------------------------------------------
Prompt: 'The colors of the rainbow are'
Generated text: ' red, orange, yellow, green, blue, indigo, and violet.'
--------------------------------------------------
Prompt: 'The future of AI is'
Generated text: " not just about creating more advanced algorithms or more powerful hardware. It's about how"
--------------------------------------------------
Prompt: 'The president of the United States is'
Generated text: ' the commander-in-chief of the armed forces, and the military is the main tool'
```


Also checked Megablocks + FP8 + JAX path for 10 layers (just to be safe, even though the `quant_method` isn't hooked up):

```
USE_MEGABLOCKS=1 NEW_MODEL_DESIGN=True TPU_BACKEND_TYPE=jax python examples/offline_inference.py --model=jrplatin/DeepSeek-R1-1D-Subchannel-256-FP8 --max-model-len=5120 --tensor-parallel-size 8 --max-num-seqs 16 --max-num-batched-tokens 128 --no-enable-prefix-caching  --gpu-memory-utilization 0.95 --additional_config='{"sharding": {"sharding_strategy": {"attention_data_parallelism": 8, "enable_dp_attention": true}}}' --hf_overrides  '{"num_hidden_layers": 10}'

--------------------------------------------------
Prompt: 'Hello, my name is'
Generated text: ' Luggagereenwaldorf-language Artsgeanfreemdership Sagarothalamidusapes'
--------------------------------------------------
Prompt: 'The capital of France is'
Generated text: ' Coastal Plain Jagdoms offendahirdur gapsutersUIToolseden涎滞留_religious'
--------------------------------------------------
Prompt: 'The colors of the rainbow are'
Generated text: ' bells缭乱的 multiplyingabasjeevikstal Bharat Swap的电影Tai McNabb二郎 grounding'
--------------------------------------------------
Prompt: 'The future of AI is'
Generated text: 'ouwాలుIntegratedCircuitousness borrowed}}_{\\ruzpillarayan Faberrile tapseled'
--------------------------------------------------
Prompt: 'The president of the United States is'
Generated text: 'bauer组长出不 Acidifizierten472 TwistCabinet inspurerbbeosite渐变udas'
```


I also tested that offline inference outputs match for DeepSeek w/ MLA, vLLM backend, and no quantization:

```



NEW_MODEL_DESIGN=True TPU_BACKEND_TYPE=jax python examples/offline_inference.py --model=deepseek-ai/DeepSeek-R1 --max-model-len=5120 --tensor-parallel-size 8 --max-num-seqs 16 --max-num-batched-tokens 128 --no-enable-prefix-caching  --gpu-memory-utilization 0.95 --additional_config='{"skip_quantization": true, "sharding": {"sharding_strategy": {"attention_data_parallelism": 8, "enable_dp_attention": true}}}' --hf_overrides  '{"num_hidden_layers": 5}'

(EngineCore_DP0 pid=925639) WARNING 02-03 15:06:00 [tpu_runner.py:701] Should not schedule a request that does nothing!
Processed prompts: 100%|██████████████████████████████████████████████████████████████████████| 35/35 [00:13<00:00,  2.69it/s, est. speed input: 28.09 toks/s, output: 42.98 toks/s]
--------------------------------------------------
Prompt: 'Hello, my name is'
Generated text: 'Entreprise060 Volt熟的 Blaodil碍deb一圈儿的可乐ptusasma Dragons综合治理'
--------------------------------------------------
Prompt: 'The capital of France is'
Generated text: 'icro517.lib здравerdquoanatysisجادdestructive aptitudeshaiubuenas'
--------------------------------------------------
Prompt: 'The colors of the rainbow are'
Generated text: '� anthrop962nevolved stratum Bib491asto马拉松这把骚 auton disorderly operable'
--------------------------------------------------
Prompt: 'The future of AI is'
Generated text: 'etteersh980ouzsko-focusedonti-Ammaryerusicalsopteriore点缀 tapsulos'
--------------------------------------------------
Prompt: 'The president of the United States is'
Generated text: '046人和ocated181matical jurisprudence蜡带回ETTER unrealistic imaginations Chavezము Frojekecd'
--------------------------------------------------
```


and DeepSeek w/ MHA, VLLM Fused Kernel, and no quantization:

```
  VLLM_MLA_DISABLE=1 NEW_MODEL_DESIGN=True TPU_BACKEND_TYPE=jax python examples/offline_inference.py --model=deepseek-ai/DeepSeek-R1 --max-model-len=5120 --tensor-parallel-size 8 --max-num-seqs 16 --max-num-batched-tokens 128 --no-enable-prefix-caching  --gpu-memory-utilization 0.95 --additional_config='{"skip_quantization": true, "sharding": {"sharding_strategy": {"attention_data_parallelism": 8, "enable_dp_attention": true}}}' --hf_overrides  '{"num_hidden_layers": 10}'

--------------------------------------------------
Prompt: 'Hello, my name is'
Generated text: 'hn433 Sheldon recovering bek YugDepth ShieldEnsembleIron Generator葵 Valenciarokము'
--------------------------------------------------
Prompt: 'The capital of France is'
Generated text: 'Ketoman shedsova Archaeologicalbzadehlap Mawrok solicrok福祉reet非凡 annotated'
--------------------------------------------------
Prompt: 'The colors of the rainbow are'
Generated text: '一方Soupupl灵芝CSS Gudeki Forecast weathered banner Pagesrix Calder� Gatebro'
--------------------------------------------------
Prompt: 'The future of AI is'
Generated text: 'rozOMO军在后者在前几年的ZOleo行礼 JJ_COMP巧TeXillos pardon Eng'
--------------------------------------------------
Prompt: 'The president of the United States is'
Generated text: 'rokeKarlsic别无UTE materia Verjekedes访erschuzeanaloty spoil Married'
```



# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
