### PR TITLE
[TPU host offload] batched save bulk transfer for tpu host offload connector

### DIFF
--- a/tests/offload/tpu_offload_accuracy_test.py
+++ b/tests/offload/tpu_offload_accuracy_test.py
@@ -51,6 +51,7 @@ def _test_kv_cache_cpu_offloading_accuracy(
     swap_op_type: str,
     skip_precompile: str,
     decode_save: str,
+    batched_save: str,
     cpu_chunks: str,
     prompt_file: str,
 ):
@@ -59,6 +60,7 @@ def _test_kv_cache_cpu_offloading_accuracy(
         os.environ['TPU_OFFLOAD_SWAP_OP_TYPE'] = swap_op_type
         os.environ['TPU_OFFLOAD_SKIP_JAX_PRECOMPILE'] = skip_precompile
         os.environ['TPU_OFFLOAD_DECODE_SAVE'] = decode_save
+        os.environ['TPU_OFFLOAD_BATCHED_SAVE'] = batched_save
         os.environ['TPU_OFFLOAD_NUM_CPU_CHUNKS'] = cpu_chunks
         llm = LLM(model="meta-llama/Llama-3.2-3B",
                   max_model_len=3072,
@@ -108,8 +110,9 @@ def test_kv_cache_cpu_offloading_accuracy_smaller_then_cpu_ram(
     swap_op_types = ["pallas", "jax", "jax_copy"]
     decode_saves = ["0", "1"]
     skip_precompile = ["0", "1"]
-    for swap_op_type, decode_save, _skip_precompile in itertools.product(
-            swap_op_types, decode_saves, skip_precompile):
+    batched_saves = ["0", "1"]
+    for swap_op_type, decode_save, _skip_precompile, batched_save in itertools.product(
+            swap_op_types, decode_saves, skip_precompile, batched_saves):
         _test_kv_cache_cpu_offloading_accuracy(
             monkeypatch,
             sampling_config,
@@ -117,6 +120,7 @@ def test_kv_cache_cpu_offloading_accuracy_smaller_then_cpu_ram(
             swap_op_type,
             _skip_precompile,
             decode_save,
+            batched_save,
             # The total CPU RAM size = # cpu chunks * cpu_chunk_size. cpu_chunk_size represent the number of tokens can fit into a single CPU RAM chunk.
             # cpu_chunk_size for llama-3.2-3B(used above in test)= 256
             # CPU RAM size = 4*256=1024 tokens
@@ -140,8 +144,9 @@ def test_kv_cache_cpu_offloading_accuracy_larger_than_cpu_ram(
     swap_op_types = ["pallas", "jax", "jax_copy"]
     decode_saves = ["0", "1"]
     skip_precompile = ["0", "1"]
-    for swap_op_type, decode_save, _skip_precompile in itertools.product(
-            swap_op_types, decode_saves, skip_precompile):
+    batched_saves = ["0", "1"]
+    for swap_op_type, decode_save, _skip_precompile, batched_save in itertools.product(
+            swap_op_types, decode_saves, skip_precompile, batched_saves):
         _test_kv_cache_cpu_offloading_accuracy(
             monkeypatch,
             sampling_config,
@@ -149,6 +154,7 @@ def test_kv_cache_cpu_offloading_accuracy_larger_than_cpu_ram(
             swap_op_type,
             _skip_precompile,
             decode_save,
+            batched_save,
             # The total CPU RAM size = # cpu chunks * cpu_chunk_size. cpu_chunk_size represent the number of tokens can fit into a single CPU RAM chunk.
             # cpu_chunk_size for llama-3.2-3B(used above in test)= 256
             # CPU RAM size = 4*256=1024 tokens
@@ -156,6 +162,79 @@ def test_kv_cache_cpu_offloading_accuracy_larger_than_cpu_ram(
             # Large prompt details: 2042 tokens
             "large_prompt.txt",
         )
+
+
+def test_kv_cache_cpu_offloading_batch_save_multi_request(
+    monkeypatch: pytest.MonkeyPatch,
+    sampling_config: SamplingParams,
+    kv_transfer_config: KVTransferConfig,
+):
+    """
+    Verifies accuracy for multiple simultaneous requests when batched save is enabled.
+    This ensures that the unified DMA transfer and subsequent 'unstitching'
+    on the host correctly distributes KV blocks to their respective requests.
+    """
+    num_requests = 10
+    swap_op_types = ["pallas", "jax", "jax_copy"]
+    decode_save = "0"
+    skip_precompile = "1"
+    batched_save = "1"
+
+    # Logic for cpu_chunks:
+    # 1. small_prompt.txt is ~246 tokens. With block_size=16, each prompt
+    #    requires ~16 blocks.
+    # 2. sampling_config.max_tokens=20 adds another ~2 blocks during generation.
+    # 3. Total blocks per request is ~18. We use a multiplier of 20 to provide
+    #    sufficient headroom to store all requests in the CPU cache without
+    #    triggering evictions, ensuring a 100% prefix match for the second pass.
+    cpu_chunks = str(num_requests * 20)
+
+    for swap_op_type in swap_op_types:
+        with monkeypatch.context():
+            os.environ['SKIP_JAX_PRECOMPILE'] = '1'
+            os.environ['TPU_OFFLOAD_SWAP_OP_TYPE'] = swap_op_type
+            os.environ['TPU_OFFLOAD_SKIP_JAX_PRECOMPILE'] = skip_precompile
+            os.environ['TPU_OFFLOAD_DECODE_SAVE'] = decode_save
+            os.environ['TPU_OFFLOAD_BATCHED_SAVE'] = batched_save
+            os.environ['TPU_OFFLOAD_NUM_CPU_CHUNKS'] = cpu_chunks
+
+            llm = LLM(model="meta-llama/Llama-3.2-3B",
+                      max_model_len=3072,
+                      task="generate",
+                      kv_transfer_config=kv_transfer_config)
+
+            base_prompt = read_prompt_from_file("small_prompt.txt")
+            # Create a list of slightly different prompts to test collation and unstitching
+            prompts = [
+                f"{base_prompt}\nRequest index: {i}"
+                for i in range(num_requests)
+            ]
+
+            # 1st generate (Populates CPU cache)
+            outputs = llm.generate(prompts, sampling_config)
+            out_texts1, out_tokens1 = parse_outputs(outputs)
+            time.sleep(1)
+
+            # Reset prefix cache to force loading from CPU cache in the next step
+            llm.llm_engine.engine_core.reset_prefix_cache()
+            time.sleep(1)
+
+            # 2nd generate (Loads from CPU cache)
+            outputs = llm.generate(prompts, sampling_config)
+            out_texts2, out_tokens2 = parse_outputs(outputs)
+            time.sleep(1)
+
+            # Verify results are identical
+            assert len(out_texts1) == len(out_texts2)
+            for i in range(len(out_texts1)):
+                assert out_texts1[i] == out_texts2[
+                    i], f"Text mismatch in request {i}"
+                assert out_tokens1[i] == out_tokens2[
+                    i], f"Token mismatch in request {i}"
+
+            del llm
+            # Waiting for TPUs to be released.
+            time.sleep(20)
 
 
 def read_prompt_from_file(file_name):

--- a/tpu_inference/envs.py
+++ b/tpu_inference/envs.py
@@ -30,6 +30,7 @@ if TYPE_CHECKING:
     TPU_OFFLOAD_NUM_CPU_CHUNKS: int = 1024
     TPU_OFFLOAD_NUM_STAGING_BLOCKS: int = 128
     TPU_OFFLOAD_SAVE_THREADS: int = 1
+    TPU_OFFLOAD_BATCHED_SAVE: bool = False
 
 
 def env_with_choices(
@@ -146,6 +147,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # kv offload to dram: number of threads for asynchronous TPU -> CPU data transfer
     "TPU_OFFLOAD_SAVE_THREADS":
     lambda: int(os.getenv("TPU_OFFLOAD_SAVE_THREADS", "1")),
+    # kv offload to dram: batch multiple requests' save operations into a single swap call
+    "TPU_OFFLOAD_BATCHED_SAVE":
+    lambda: bool(int(os.getenv("TPU_OFFLOAD_BATCHED_SAVE", "0"))),
 }
 
 


### PR DESCRIPTION
for any given step, if there are multiple requests that need to be saved, use a single swap to transfer all the blocks across the requests and unstitch and store the blocks in CPU RAM

# Description

Start with a short description of what the PR does and how this is a change from
the past.

The PR introduces the following high level changes
1. The core feature: For a set of N requests in a single batch, the change implements a single gather (tpu paged HBM kv pages to TPU HBM contiguous staging buffer), and a single swap out operation (Staging buffer to RAM).
2. Metrics: Introduce additional labels to identify batched vs non batched requests
3. Correctness unit tests for the batched save mode.

The rest of the description includes relevant details and context, examples:
- why is this change being made,
We are investigating options to saturate the PCI bus between HBM and RAM with larger number of blocks and lesser number of gather and swap operations

- the problem being solved and any relevant context,
- why this is a good solution,
- some information about the specific implementation,
- shortcomings of the solution and possible future improvements.

If we see improvement, we plan to introduce similar optimization on the load side as well.
If the change fixes a Github issue, please include a link, e.g.,:
FIXES: #123456

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

Ran existing unit tests on tpu machine on gke

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
