### PR TITLE
Ensure tpu_connector._connector_metadata is initialized

### DIFF
--- a/tpu_inference/distributed/tpu_connector.py
+++ b/tpu_inference/distributed/tpu_connector.py
@@ -149,6 +149,7 @@ class TPUConnector(KVConnectorBase_V1):
 
     def __init__(self, vllm_config: VllmConfig, role: KVConnectorRole):
         assert vllm_config.kv_transfer_config is not None
+        self._connector_metadata = None
 
         if role == KVConnectorRole.SCHEDULER:
             self.connector_scheduler = \


### PR DESCRIPTION
# Description

Fixes a crash when starting vLLM with kv transfer config:

```
AttributeError: 'TPUConnector' object has no attribute '_connector_metadata'. Did you mean: 'has_connector_metadata'?
```

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
