### PR TITLE
[Log] resolves confusion for ep test log

### DIFF
--- a/tpu_inference/platforms/tpu_platform.py
+++ b/tpu_inference/platforms/tpu_platform.py
@@ -124,6 +124,20 @@ class TpuPlatform(Platform):
         vllm_config.sharding_config = sharding_config
         logger.info(f"Initialized sharding configuration: {sharding_config}")
 
+        # Warn about EP behavior under the default 2D sharding mode
+        tp = sharding_config.sharding_strategy.tensor_parallelism
+        ep = sharding_config.sharding_strategy.expert_parallelism
+        try:
+            use_base = envs.NEW_MODEL_DESIGN
+        except Exception:
+            use_base = False
+
+        if not use_base and ep == 1 and tp > 1:
+            logger.warning(
+                "ShardingAxisName2D (default): EP shares the 'model' "
+                "axis with TP. Effective EP=TP=%d. To use independent "
+                "EP, set NEW_MODEL_DESIGN=1.", tp)
+
     @classmethod
     def check_and_update_config(cls, vllm_config: VllmConfig) -> None:
 


### PR DESCRIPTION
# Description

Users setting `--enable-expert-parallel` flag with tensor parallelism were confused when logs showed `expert_parallelism=1` without explanation. This made it unclear whether EP was actually enabled or being ignored.

# Tests
```
python3 -m pytest -s -v /tests/e2e/test_expert_parallel.py
(EngineCore_DP0 pid=529683) WARNING 02-07 00:36:06 [tpu_platform.py:137] ShardingAxisName2D (default): EP shares the 'model' axis with TP. Effective EP=TP=4. To use independent EP, set NEW_MODEL_DESIGN=1.
```


# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
