### PR TITLE
[JAX][MoE] fix bug for SparseMoE

### DIFF
--- a/tpu_inference/layers/jax/moe/sparse_moe.py
+++ b/tpu_inference/layers/jax/moe/sparse_moe.py
@@ -151,7 +151,8 @@ def sparse_moe_distributed_fwd(
                             moe_instance.dtype,
                             moe_instance.qwix_quantized_weight_dtype)
         if moe_instance.edf_sharding[1] is not None:
-            gating_TEF = jax.lax.psum(gating_TEF, axis_name=moe_instance.edf_sharding[1])
+            gating_TEF = jax.lax.psum(gating_TEF,
+                                      axis_name=moe_instance.edf_sharding[1])
         activated_gating_TEF = modeling_flax_utils.ACT2FN[
             moe_instance.hidden_act](gating_TEF)
 
@@ -161,7 +162,8 @@ def sparse_moe_distributed_fwd(
                              moe_instance.moe_backend, moe_instance.dtype,
                              moe_instance.qwix_quantized_weight_dtype)
         if moe_instance.edf_sharding[1] is not None:
-            up_proj_TEF = jax.lax.psum(up_proj_TEF, axis_name=moe_instance.edf_sharding[1])
+            up_proj_TEF = jax.lax.psum(up_proj_TEF,
+                                       axis_name=moe_instance.edf_sharding[1])
 
     fuse_TEF = activated_gating_TEF * up_proj_TEF
 
@@ -173,7 +175,8 @@ def sparse_moe_distributed_fwd(
                                      moe_instance.dtype,
                                      moe_instance.qwix_quantized_weight_dtype)
         if moe_instance.efd_sharding[1] is not None:
-            intermediate_output = jax.lax.psum(intermediate_output, axis_name=moe_instance.efd_sharding[1])
+            intermediate_output = jax.lax.psum(
+                intermediate_output, axis_name=moe_instance.efd_sharding[1])
 
     # 5. Return Results (All-to-All)
     if moe_instance.num_expert_parallelism > 1:


### PR DESCRIPTION
# Description

Fix a bug in TP case of MoE, where there's a missing all-reduce after gmm
# Tests

testsed by Jacob with cmd:
`VLLM_MLA_DISABLE=1 USE_UNFUSED_MEGABLOCKS=1 NEW_MODEL_DESIGN=True TPU_BACKEND_TYPE=jax nohup vllm serve --model=jrplatin/DeepSeek-R1-1D-Subchannel-256-FP8 --max-model-len=5120 --tensor-parallel-size 2 --max-num-seqs 16 --max-num-batched-tokens 128 --no-enable-prefix-caching --disable-log-requests --gpu-memory-utilization 0.97  --additional_config='{"sharding": {"sharding_strategy": {"expert_parallelism": 4, "tensor_parallelism": 2}}}'   &`

```
============ Serving Benchmark Result ============
Successful requests:                     14042     
Benchmark duration (s):                  3716.86   
Total input tokens:                      3279224   
Total generated tokens:                  28084     
Request throughput (req/s):              3.78      
Output token throughput (tok/s):         7.56      
Total token throughput (tok/s):          889.81    
---------------Time to First Token----------------
Mean TTFT (ms):                          2024221.74
Median TTFT (ms):                        2137533.30
P99 TTFT (ms):                           3695503.45
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          143.47    
Median TPOT (ms):                        143.93    
P99 TPOT (ms):                           149.55    
---------------Inter-token Latency----------------
Mean ITL (ms):                           143.50    
Median ITL (ms):                         143.94    
P99 ITL (ms):                            149.56    
----------------End-to-end Latency----------------
Mean E2EL (ms):                          2024365.21
Median E2EL (ms):                        2137675.76
P99 E2EL (ms):                           3695649.47
==================================================
Evaluating MMLU...

Results

{'accuracy': 0.8638, 'gen_num': 14042}
```
# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
