### PR TITLE
Fix build failure by using `+v6` for versioning

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ def get_version():
     # TODO: Temporary workaround. The v7x requirements will be consolidated, and this block will be removed,
     # once the JAX package fix is released, since v6e/v7x differentiation will no longer be required.
     if os.getenv("IS_FOR_V7X", "true").lower() == "false":
-        version = f"{version}.post6"
+        version = f"{version}+v6"
 
     return version
 


### PR DESCRIPTION
# Description

The `.post6` suffix created an invalid version string when combined with a `.dev` tag. Changed it to `+v6e` to follow PEP 440.

# Tests

local tests

- [v6](https://paste.googleplex.com/4985247055872000)
- [v7](https://paste.googleplex.com/6496238260322304)

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
