### PR TITLE
Remove test_correctness_jax_ray_distributed_executor from BuildKite. 

### DIFF
--- a/.buildkite/features/runai_model_streamer_loader.yml
+++ b/.buildkite/features/runai_model_streamer_loader.yml
@@ -64,17 +64,6 @@ steps:
     commands:
       - |
         .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_runai_model_streamer_loader_torchax_uniproc
-
-  - label: "${TPU_VERSION:-tpu6e} Correctness Test | JAX RayDistributedExecutor"
-    key: "${TPU_VERSION:-tpu6e}_runai_model_streamer_loader_jax_ray_distributed"
-    soft_fail: true
-    agents:
-      queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}" # Using a queue with more devices for distributed tests
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
-    commands:
-      - .buildkite/scripts/run_in_docker.sh python3 -m pytest -s -v /workspace/tpu_inference/tests/e2e/test_runai_model_streamer_loader.py::test_correctness_jax_ray_distributed_executor
-
   - label: "${TPU_VERSION:-tpu6e} Correctness Test | Torchax RayDistributedExecutor"
     key: "${TPU_VERSION:-tpu6e}_runai_model_streamer_loader_torchax_ray_distributed"
     soft_fail: true


### PR DESCRIPTION

# Description

Remove test_correctness_jax_ray_distributed_executor from BuildKite. This was added in PR https://github.com/vllm-project/tpu-inference/pull/1477 because originally this PR was going to fix both the Torchax and JAX paths, but the JAX path fix was too complicated so I removed the correctness test for jax_ray_distributed_executor, but I forgot to remove it from the BuildKite file. 

This is causing a CI failure, this PR will fix it: 
https://buildkite.com/tpu-commons/tpu-inference-ci/builds/9748/tests?sid=019c2d77-5d48-430c-94fc-5f0e761ccca6&tab=output&group_by=test

If the change fixes a Github issue, please include a link, e.g.,:
FIXES: #123456

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have made or will make corresponding changes to any relevant documentation.
