### PR TITLE
batch load for tpu kv host offload connector

### DIFF
--- a/tpu_inference/envs.py
+++ b/tpu_inference/envs.py
@@ -31,6 +31,7 @@ if TYPE_CHECKING:
     TPU_OFFLOAD_NUM_STAGING_BLOCKS: int = 128
     TPU_OFFLOAD_SAVE_THREADS: int = 1
     TPU_OFFLOAD_BATCHED_SAVE: bool = False
+    TPU_OFFLOAD_BATCHED_LOAD: bool = False
 
 
 def env_with_choices(
@@ -150,6 +151,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # kv offload to dram: batch multiple requests' save operations into a single swap call
     "TPU_OFFLOAD_BATCHED_SAVE":
     lambda: bool(int(os.getenv("TPU_OFFLOAD_BATCHED_SAVE", "0"))),
+    # kv offload to dram: batch multiple requests' load operations into a single swap call
+    "TPU_OFFLOAD_BATCHED_LOAD":
+    lambda: bool(int(os.getenv("TPU_OFFLOAD_BATCHED_LOAD", "0"))),
 }
 
 


### PR DESCRIPTION
# Description

Start with a short description of what the PR does and how this is a change from
the past.

The PR introduces the following high level changes

1. The core feature: For a set of N requests in a single batch, the change implements a single swap in operation (RAM to Staging buffer) and single scatter (TPU HBM contiguous staging buffer to tpu paged HBM kv pages).

2. Correctness unit tests for the batched save mode.

The rest of the description includes relevant details and context, examples:
- why is this change being made,
- the problem being solved and any relevant context,
- why this is a good solution,
- some information about the specific implementation,
- shortcomings of the solution and possible future improvements.

If the change fixes a Github issue, please include a link, e.g.,:
FIXES: #123456

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
