### PR TITLE
Remove _reqs_being_saved check from status clean up for the finished …

### DIFF
--- a/tpu_inference/offload/tpu_offload_connector.py
+++ b/tpu_inference/offload/tpu_offload_connector.py
@@ -306,66 +306,54 @@ ADJUSTED_NUM_BLOCKS_TO_SAVE = Gauge(
     'vllm_kv_cache_adjusted_num_blocks_to_save',
     'Number of blocks to save after adjusted')
 
-STAGING_BUFFER_BLOCKS_FREE = Gauge(
-    'vllm_kv_cache_staging_buffer_blocks_free',
-    'Number of free staging blocks',
-    ['source'])
+STAGING_BUFFER_BLOCKS_FREE = Gauge('vllm_kv_cache_staging_buffer_blocks_free',
+                                   'Number of free staging blocks', ['source'])
 
 STAGING_BUFFER_BLOCKS_FOR_SAVE_ALLOCATE = Gauge(
     'vllm_kv_cache_staging_buffer_blocks_for_save_allocate',
-    'Total allocated staging blocks for save',
-    ['source'])
+    'Total allocated staging blocks for save', ['source'])
 
 STAGING_BUFFER_BLOCKS_FOR_SAVE_FREE = Gauge(
     'vllm_kv_cache_staging_buffer_blocks_for_save_free',
-    'Total freed staging blocks for save',
-    ['source'])
+    'Total freed staging blocks for save', ['source'])
 
 STAGING_BUFFER_BLOCKS_FOR_LOAD_ALLOCATE = Gauge(
     'vllm_kv_cache_staging_buffer_blocks_for_load_allocate',
-    'Total allocated staging blocks for load',
-    ['source'])
+    'Total allocated staging blocks for load', ['source'])
 
 STAGING_BUFFER_BLOCKS_FOR_LOAD_FREE = Gauge(
     'vllm_kv_cache_staging_buffer_blocks_for_load_free',
-    'Total freed staging blocks for load',
-    ['source'])
+    'Total freed staging blocks for load', ['source'])
 
 FINISHED_REQS_W_PENDING_OPS_SIZE = Gauge(
     'vllm_kv_cache_finished_reqs_w_pending_ops_size',
-    'The size of the _finished_reqs_w_pending_ops set',
-    ['source'])
+    'The size of the _finished_reqs_w_pending_ops set', ['source'])
 
-FINISHED_SAVE_REQS_SIZE = Gauge(
-    'vllm_kv_cache_finished_save_reqs_size',
-    'The size of the _finished_save_reqs set')
+FINISHED_SAVE_REQS_SIZE = Gauge('vllm_kv_cache_finished_save_reqs_size',
+                                'The size of the _finished_save_reqs set')
 
-FINISHED_LOAD_REQS_SIZE = Gauge(
-    'vllm_kv_cache_finished_load_reqs_size',
-    'The size of the _finished_load_reqs set')
+FINISHED_LOAD_REQS_SIZE = Gauge('vllm_kv_cache_finished_load_reqs_size',
+                                'The size of the _finished_load_reqs set')
 
-FULLY_FINISHED_REQS_SIZE = Gauge(
-    'vllm_kv_cache_fully_finished_reqs_size',
-    'The size of the _fully_finished_reqs set')
+FULLY_FINISHED_REQS_SIZE = Gauge('vllm_kv_cache_fully_finished_reqs_size',
+                                 'The size of the _fully_finished_reqs set')
 
 SAVE_REQS_W_PENDING_GATHER_SIZE = Gauge(
     'vllm_kv_cache_save_reqs_w_pending_gather_size',
     'The size of the _save_reqs_w_pending_gather set')
 
 DELAY_FREE_TOTAL = Counter("vllm_kv_delay_free_total",
-                          "Total number of delay free requests.")
+                           "Total number of delay free requests.")
 
 PENDING_SAVE_FUTURES_SIZE = Gauge(
     'vllm_kv_cache_pending_save_futures_size',
     'The size of the _pending_save_futures list')
 
-FUTURE_DONE_TOTAL = Counter(
-    'vllm_kv_cache_future_done_total',
-    'Total number of save futures done.')
+FUTURE_DONE_TOTAL = Counter('vllm_kv_cache_future_done_total',
+                            'Total number of save futures done.')
 
-RECORD_SAVE_TOTAL = Counter(
-    'vllm_kv_cache_record_save_total',
-    'Total number of record_save calls total.')
+RECORD_SAVE_TOTAL = Counter('vllm_kv_cache_record_save_total',
+                            'Total number of record_save calls total.')
 
 KV_HIT_WITH_LOAD_BUF = Counter(
     'vllm_kv_cache_hit_with_load_staging_buf',
@@ -875,7 +863,8 @@ class TPUOffloadConnectorScheduler():
             # planning staging blocks for load
             num_avail_staging_blocks = self.staging_buffer_manager.get_num_free_staging_blocks(
             )
-            STAGING_BUFFER_BLOCKS_FREE.labels(source="load").set(num_avail_staging_blocks)
+            STAGING_BUFFER_BLOCKS_FREE.labels(
+                source="load").set(num_avail_staging_blocks)
             # num_avail_staging_blocks = self.staging_buffer_manager.get_num_free_load_staging_blocks(
             # )
             if num_blocks_to_load > num_avail_staging_blocks:
@@ -909,8 +898,8 @@ class TPUOffloadConnectorScheduler():
                     self.staging_buffer_manager.get_num_blocks_for_load())
                 STAGING_BUFFER_BLOCKS_FOR_LOAD_ALLOCATE.labels(
                     source="get_num_new_matched_tokens").set(
-                    self.staging_buffer_manager.
-                    get_num_total_allocate_blocks_for_load())
+                        self.staging_buffer_manager.
+                        get_num_total_allocate_blocks_for_load())
 
         # record the matched tokens in the cache, it will be needed in
         # init save_spec
@@ -1097,7 +1086,8 @@ class TPUOffloadConnectorScheduler():
             # planning staging blocks for save
             num_avail_staging_blocks = self.staging_buffer_manager.get_num_free_staging_blocks(
             )
-            STAGING_BUFFER_BLOCKS_FREE.labels(source="save").set(num_avail_staging_blocks)
+            STAGING_BUFFER_BLOCKS_FREE.labels(
+                source="save").set(num_avail_staging_blocks)
             # num_avail_staging_blocks = self.staging_buffer_manager.get_num_free_save_staging_blocks(
             # )
             if num_blocks_to_save > num_avail_staging_blocks:
@@ -1144,13 +1134,14 @@ class TPUOffloadConnectorScheduler():
                         usage="save")
                     assert num_allocated_blocks == adjusted_num_blocks_to_save >= 0, f" failed to allocate {num_allocated_blocks} (save) staging blocks for request {tracker.req_id}, expected {adjusted_num_blocks_to_save}."
 
-                    ADJUSTED_NUM_BLOCKS_TO_SAVE.set(adjusted_num_blocks_to_save)
+                    ADJUSTED_NUM_BLOCKS_TO_SAVE.set(
+                        adjusted_num_blocks_to_save)
                     STAGING_BUFFER_BLOCKS_FOR_SAVE.set(
                         self.staging_buffer_manager.get_num_blocks_for_save())
                     STAGING_BUFFER_BLOCKS_FOR_SAVE_ALLOCATE.labels(
                         source="_prepare_save_spec").set(
-                        self.staging_buffer_manager.
-                        get_num_total_allocate_blocks_for_save())
+                            self.staging_buffer_manager.
+                            get_num_total_allocate_blocks_for_save())
 
                     if adjusted_num_total_tokens > tracker.save_watermark:
                         logger.info(
@@ -1395,8 +1386,8 @@ class TPUOffloadConnectorScheduler():
         STAGING_BUFFER_BLOCKS_FOR_LOAD.set(
             self.staging_buffer_manager.get_num_blocks_for_load())
         STAGING_BUFFER_BLOCKS_FOR_LOAD_FREE.labels(
-            source="pre_load_specs").set(
-            self.staging_buffer_manager.get_num_total_free_blocks_for_load())
+            source="pre_load_specs").set(self.staging_buffer_manager.
+                                         get_num_total_free_blocks_for_load())
 
         return metadata
 
@@ -1454,10 +1445,12 @@ class TPUOffloadConnectorScheduler():
                     self.staging_buffer_manager.get_num_blocks_for_save())
                 STAGING_BUFFER_BLOCKS_FOR_SAVE_FREE.labels(
                     source="finished_save_chunks").set(
-                    self.staging_buffer_manager.
-                    get_num_total_free_blocks_for_save())
-                STAGING_BUFFER_BLOCKS_FREE.labels(source="finished_save_chunks").set(
-                    self.staging_buffer_manager.get_num_free_staging_blocks())
+                        self.staging_buffer_manager.
+                        get_num_total_free_blocks_for_save())
+                STAGING_BUFFER_BLOCKS_FREE.labels(
+                    source="finished_save_chunks").set(
+                        self.staging_buffer_manager.
+                        get_num_free_staging_blocks())
 
                 # update in-flight save
                 for saved_chunk_id in saved_chunk_ids:
@@ -1492,11 +1485,12 @@ class TPUOffloadConnectorScheduler():
                     self.staging_buffer_manager.get_num_blocks_for_load())
                 STAGING_BUFFER_BLOCKS_FOR_LOAD_FREE.labels(
                     source="finished_load_chunks").set(
-                    self.staging_buffer_manager.
-                    get_num_total_free_blocks_for_load())
+                        self.staging_buffer_manager.
+                        get_num_total_free_blocks_for_load())
                 STAGING_BUFFER_BLOCKS_FREE.labels(
                     source="finished_load_chunks").set(
-                    self.staging_buffer_manager.get_num_free_staging_blocks())
+                        self.staging_buffer_manager.
+                        get_num_free_staging_blocks())
                 # update in-flight save
                 for loaded_chunk_id in loaded_chunk_ids:
                     assert loaded_chunk_id in self._reqs_being_loaded[req_id]
@@ -1512,10 +1506,6 @@ class TPUOffloadConnectorScheduler():
             if req_id in self._save_reqs_w_pending_gather:
                 assert len(self._save_reqs_w_pending_gather[req_id]) == 0
                 self._save_reqs_w_pending_gather.pop(req_id)
-            if req_id in self._reqs_being_saved:
-                assert len(self._reqs_being_saved[req_id]) == 0
-                self._reqs_being_saved.pop(req_id)
-            # TODO: Addd metrics
             num_freed_blocks = self.staging_buffer_manager.free(req_id,
                                                                 usage="save")
             logger.info(
@@ -1525,8 +1515,8 @@ class TPUOffloadConnectorScheduler():
                 self.staging_buffer_manager.get_num_blocks_for_save())
             STAGING_BUFFER_BLOCKS_FOR_SAVE_FREE.labels(
                 source="finished_sending").set(
-                self.staging_buffer_manager.get_num_total_free_blocks_for_save(
-                ))
+                    self.staging_buffer_manager.
+                    get_num_total_free_blocks_for_save())
 
         # load
         for req_id in connector_output.finished_recving or []:
@@ -1542,11 +1532,12 @@ class TPUOffloadConnectorScheduler():
                 self.staging_buffer_manager.get_num_blocks_for_load())
             STAGING_BUFFER_BLOCKS_FOR_LOAD_FREE.labels(
                 source="finished_recving").set(
-                self.staging_buffer_manager.get_num_total_free_blocks_for_load(
-                ))
+                    self.staging_buffer_manager.
+                    get_num_total_free_blocks_for_load())
 
         _finished_reqs = list(self._finished_reqs_w_pending_ops)
-        FINISHED_REQS_W_PENDING_OPS_SIZE.labels(source="update_connector_output").set(len(_finished_reqs))
+        FINISHED_REQS_W_PENDING_OPS_SIZE.labels(
+            source="update_connector_output").set(len(_finished_reqs))
         for req_id in _finished_reqs:
             is_gather_done = req_id not in self._save_reqs_w_pending_gather
             is_load_done = req_id not in self._reqs_being_loaded
@@ -1585,7 +1576,9 @@ class TPUOffloadConnectorScheduler():
         if req_id in self._save_reqs_w_pending_gather and len(
                 self._save_reqs_w_pending_gather[req_id]) > 0:
             self._finished_reqs_w_pending_ops.add(req_id)
-            FINISHED_REQS_W_PENDING_OPS_SIZE.labels(source="_save_reqs_w_pending_gather").set(len(self._finished_reqs_w_pending_ops))
+            FINISHED_REQS_W_PENDING_OPS_SIZE.labels(
+                source="_save_reqs_w_pending_gather").set(
+                    len(self._finished_reqs_w_pending_ops))
             logger.info(
                 f"not_free_with_gather:{req_id}, {self._save_reqs_w_pending_gather[req_id]}"
             )
@@ -1593,7 +1586,9 @@ class TPUOffloadConnectorScheduler():
         if req_id in self._reqs_being_loaded and len(
                 self._reqs_being_loaded[req_id]) > 0:
             self._finished_reqs_w_pending_ops.add(req_id)
-            FINISHED_REQS_W_PENDING_OPS_SIZE.labels(source="_reqs_being_loaded").set(len(self._finished_reqs_w_pending_ops))
+            FINISHED_REQS_W_PENDING_OPS_SIZE.labels(
+                source="_reqs_being_loaded").set(
+                    len(self._finished_reqs_w_pending_ops))
             logger.info(
                 f"not_free_with_load:{req_id}, {self._reqs_being_loaded[req_id]}"
             )


### PR DESCRIPTION
# Description

Remove the _reqs_being_saved[req_id] check in update_connector_output for connector_output.finished_sending. This check is no longer valid because async saving allows connector worker to add a request into finished_sending list as long as its gathers are completed (while its saves (D2H transfer) are still in progress) , and let vllm scheduler releases the request's kv cache.

This change is to fix the error

```
(EngineCore_DP0 pid=345) INFO 02-07 00:00:07 [tpu_offload_connector.py:1414] TPUOffloadConnectorScheduler: getting workers' output: finished_sending: {'cmpl-a242d876b5018449-0'}, finished_recving: set()
(EngineCore_DP0 pid=345) ERROR 02-07 00:00:07 [core.py:845] EngineCore encountered a fatal error.
(EngineCore_DP0 pid=345) ERROR 02-07 00:00:07 [core.py:845] Traceback (most recent call last):
(EngineCore_DP0 pid=345) ERROR 02-07 00:00:07 [core.py:845]   File "/workspace/vllm/vllm/v1/engine/core.py", line 836, in run_engine_core
(EngineCore_DP0 pid=345) ERROR 02-07 00:00:07 [core.py:845]     engine_core.run_busy_loop()
(EngineCore_DP0 pid=345) ERROR 02-07 00:00:07 [core.py:845]   File "/workspace/vllm/vllm/v1/engine/core.py", line 863, in run_busy_loop
(EngineCore_DP0 pid=345) ERROR 02-07 00:00:07 [core.py:845]     self._process_engine_step()
(EngineCore_DP0 pid=345) ERROR 02-07 00:00:07 [core.py:845]   File "/workspace/vllm/vllm/v1/engine/core.py", line 892, in _process_engine_step
(EngineCore_DP0 pid=345) ERROR 02-07 00:00:07 [core.py:845]     outputs, model_executed = self.step_fn()
(EngineCore_DP0 pid=345) ERROR 02-07 00:00:07 [core.py:845]                               ^^^^^^^^^^^^^^
(EngineCore_DP0 pid=345) ERROR 02-07 00:00:07 [core.py:845]   File "/workspace/vllm/vllm/v1/engine/core.py", line 350, in step
(EngineCore_DP0 pid=345) ERROR 02-07 00:00:07 [core.py:845]     engine_core_outputs = self.scheduler.update_from_output(
(EngineCore_DP0 pid=345) ERROR 02-07 00:00:07 [core.py:845]                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=345) ERROR 02-07 00:00:07 [core.py:845]   File "/workspace/vllm/vllm/v1/core/sched/scheduler.py", line 1183, in update_from_output
(EngineCore_DP0 pid=345) ERROR 02-07 00:00:07 [core.py:845]     self._update_from_kv_xfer_finished(kv_connector_output)
(EngineCore_DP0 pid=345) ERROR 02-07 00:00:07 [core.py:845]   File "/workspace/vllm/vllm/v1/core/sched/scheduler.py", line 1582, in _update_from_kv_xfer_finished
(EngineCore_DP0 pid=345) ERROR 02-07 00:00:07 [core.py:845]     self.connector.update_connector_output(kv_connector_output)
(EngineCore_DP0 pid=345) ERROR 02-07 00:00:07 [core.py:845]   File "/workspace/tpu_inference/tpu_inference/offload/tpu_offload_connector.py", line 734, in update_connector_output
(EngineCore_DP0 pid=345) ERROR 02-07 00:00:07 [core.py:845]     self.connector_scheduler.update_connector_output(connector_output)
(EngineCore_DP0 pid=345) ERROR 02-07 00:00:07 [core.py:845]   File "/workspace/tpu_inference/tpu_inference/offload/tpu_offload_connector.py", line 1516, in update_connector_output
(EngineCore_DP0 pid=345) ERROR 02-07 00:00:07 [core.py:845]     assert len(self._reqs_being_saved[req_id]) == 0
(EngineCore_DP0 pid=345) ERROR 02-07 00:00:07 [core.py:845]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=345) ERROR 02-07 00:00:07 [core.py:845] AssertionError
(EngineCore_DP0 pid=345) Process EngineCore_DP0:
(APIServer pid=8) ERROR 02-07 00:00:07 [async_llm.py:546] AsyncLLM output_handler failed.
(APIServer pid=8) ERROR 02-07 00:00:07 [async_llm.py:546] Traceback (most recent call last):
(APIServer pid=8) ERROR 02-07 00:00:07 [async_llm.py:546]   File "/workspace/vllm/vllm/v1/engine/async_llm.py", line 498, in output_handler
(APIServer pid=8) ERROR 02-07 00:00:07 [async_llm.py:546]     outputs = await engine_core.get_output_async()
(APIServer pid=8) ERROR 02-07 00:00:07 [async_llm.py:546]               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=8) ERROR 02-07 00:00:07 [async_llm.py:546]   File "/workspace/vllm/vllm/v1/engine/core_client.py", line 885, in get_output_async
(APIServer pid=8) ERROR 02-07 00:00:07 [async_llm.py:546]     raise self._format_exception(outputs) from None
(APIServer pid=8) ERROR 02-07 00:00:07 [async_llm.py:546] vllm.v1.engine.exceptions.EngineDeadError: EngineCore encountered an issue. See stack trace (above) for the root cause.
(EngineCore_DP0 pid=345) Traceback (most recent call last):
(EngineCore_DP0 pid=345)   File "/usr/local/lib/python3.12/multiprocessing/process.py", line 314, in _bootstrap
(EngineCore_DP0 pid=345)     self.run()
(EngineCore_DP0 pid=345)   File "/usr/local/lib/python3.12/multiprocessing/process.py", line 108, in run
(EngineCore_DP0 pid=345)     self._target(*self._args, **self._kwargs)
(EngineCore_DP0 pid=345)   File "/workspace/vllm/vllm/v1/engine/core.py", line 847, in run_engine_core
(EngineCore_DP0 pid=345)     raise e
(EngineCore_DP0 pid=345)   File "/workspace/vllm/vllm/v1/engine/core.py", line 836, in run_engine_core
(EngineCore_DP0 pid=345)     engine_core.run_busy_loop()
(EngineCore_DP0 pid=345)   File "/workspace/vllm/vllm/v1/engine/core.py", line 863, in run_busy_loop
(EngineCore_DP0 pid=345)     self._process_engine_step()
(EngineCore_DP0 pid=345)   File "/workspace/vllm/vllm/v1/engine/core.py", line 892, in _process_engine_step
(EngineCore_DP0 pid=345)     outputs, model_executed = self.step_fn()
(EngineCore_DP0 pid=345)                               ^^^^^^^^^^^^^^
(EngineCore_DP0 pid=345)   File "/workspace/vllm/vllm/v1/engine/core.py", line 350, in step
(EngineCore_DP0 pid=345)     engine_core_outputs = self.scheduler.update_from_output(
(EngineCore_DP0 pid=345)                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=345)   File "/workspace/vllm/vllm/v1/core/sched/scheduler.py", line 1183, in update_from_output
(EngineCore_DP0 pid=345)     self._update_from_kv_xfer_finished(kv_connector_output)
(EngineCore_DP0 pid=345)   File "/workspace/vllm/vllm/v1/core/sched/scheduler.py", line 1582, in _update_from_kv_xfer_finished
(EngineCore_DP0 pid=345)     self.connector.update_connector_output(kv_connector_output)
(EngineCore_DP0 pid=345)   File "/workspace/tpu_inference/tpu_inference/offload/tpu_offload_connector.py", line 734, in update_connector_output
(EngineCore_DP0 pid=345)     self.connector_scheduler.update_connector_output(connector_output)
(EngineCore_DP0 pid=345)   File "/workspace/tpu_inference/tpu_inference/offload/tpu_offload_connector.py", line 1516, in update_connector_output
(EngineCore_DP0 pid=345)     assert len(self._reqs_being_saved[req_id]) == 0
(EngineCore_DP0 pid=345)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=345) AssertionError
```

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
