### PR TITLE
[CI Bug Fix] Remove `max_pixels` reference from Qwen VL tests

### DIFF
--- a/examples/multi_modal_inference.py
+++ b/examples/multi_modal_inference.py
@@ -41,8 +41,10 @@ def run_qwen2_5_vl(questions: list[str], modality: str,
         gpu_memory_utilization=args.gpu_memory_utilization,
         max_num_seqs=5,
         mm_processor_kwargs={
-            "min_pixels": 28 * 28,
-            "max_pixels": 1280 * 28 * 28,
+            "size": {
+                "longest_edge": 1003520,
+                "shortest_edge": 3136
+            },
             "fps": 1,
         },
         limit_mm_per_prompt={modality: 1},

--- a/tests/e2e/test_multi_modal_inference.py
+++ b/tests/e2e/test_multi_modal_inference.py
@@ -63,8 +63,10 @@ def test_multi_modal_inference(monkeypatch, enable_dynamic_image_sizes):
         gpu_memory_utilization=gpu_memory_utilization,
         max_num_seqs=1,
         mm_processor_kwargs={
-            "min_pixels": 28 * 28,
-            "max_pixels": 1280 * 28 * 28,
+            "size": {
+                "longest_edge": 1003520,
+                "shortest_edge": 3136
+            },
             "fps": 1,
         },
         limit_mm_per_prompt={modality: 1},

--- a/tpu_inference/models/jax/qwen2_5_vl.py
+++ b/tpu_inference/models/jax/qwen2_5_vl.py
@@ -1139,7 +1139,12 @@ class Qwen2_5_VLForConditionalGeneration(nnx.Module):
             spatial_merge_unit = vc.spatial_merge_size**2
             max_num_batched_tokens = self.vllm_config.scheduler_config.max_num_batched_tokens
             mm_kwargs = self.vllm_config.model_config.multimodal_config.mm_processor_kwargs or {}
-            limit_pixels = float(mm_kwargs.get("max_pixels", float('inf')))
+            # Use size.longest_edge if provided, otherwise default to inf
+            if "size" in mm_kwargs and "longest_edge" in mm_kwargs.get(
+                    "size", {}):
+                limit_pixels = float(mm_kwargs["size"]["longest_edge"])
+            else:
+                limit_pixels = float('inf')
 
             max_patches = int(
                 min(max_num_batched_tokens * spatial_merge_unit,


### PR DESCRIPTION
# Description

`max_pixels` is deprecated, we need to update our tests to stay in sync with upstream. 


# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
