### PR TITLE
[CI Bug Fix] Removes the sharding_config from vllm_config before deep copy

### DIFF
--- a/tpu_inference/models/vllm/vllm_model_wrapper.py
+++ b/tpu_inference/models/vllm/vllm_model_wrapper.py
@@ -133,6 +133,12 @@ class VllmModelWrapper:
             self.vllm_config.device_config.slice = slice_config
         assert self.vllm_config.model_config.dtype in TORCH_DTYPE_TO_JAX, "The model_config.dtype must be a PyTorch dtype."
         vllm_config_for_load.device_config.device = "cpu"
+        # Remove the dynamically added sharding_config attribute to avoid errors
+        # when vLLM's replace() function checks for dataclass fields.
+        # This is safe because vllm_config_for_load is only used for model loading
+        # which doesn't need sharding_config, and self.vllm_config still has it.
+        if hasattr(vllm_config_for_load, 'sharding_config'):
+            delattr(vllm_config_for_load, 'sharding_config')
         # Clearing the cached compilation config, otherwise vllm model init will fail
 
         # When expert parallelism is enabled, vLLM loads weight in sharding


### PR DESCRIPTION
# Description

`tpu-inference` dynamically adds a `sharding_config` attribute to VllmConfig, but when the config is deep-copied and passed to vLLM's model loading code, vLLM's `replace()` function in `config/utils.py` tries to validate all attributes against the dataclass fields. Since `sharding_config` is not a field in vLLM's `VllmConfig` dataclass, it raises `ValueError: Field 'sharding_config' not found in VllmConfig`.

The fix removes the `sharding_config` attribute from the deep-copied config before passing it to vLLM for model loading.

This change is safe because `vllm_config_for_load` is a temporary deep copy used only during `vllm_get_model()` and LoRA loading
The original `self.vllm_config` is preserved and still has `sharding_config` for all subsequent operations.




# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
