### PR TITLE
[CI] Fix KeyError by escaping shell variables in model template

### DIFF
--- a/.buildkite/pipeline_generation/tpu_optimized_model_template.yml
+++ b/.buildkite/pipeline_generation/tpu_optimized_model_template.yml
@@ -15,20 +15,20 @@
 # pipeline-name: {MODEL_NAME}
 # pipeline-type: {CATEGORY}
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Unit tests for {MODEL_NAME}"
-    key: "${TPU_VERSION:-tpu6e}_{SANITIZED_MODEL_NAME}_UnitTest"
+  - label: "${{TPU_VERSION:-tpu6e}} Unit tests for {MODEL_NAME}"
+    key: "${{TPU_VERSION:-tpu6e}}_{SANITIZED_MODEL_NAME}_UnitTest"
     soft_fail: true
     agents:
       queue: {QUEUE}
     env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
+      IS_FOR_V7X: "${{IS_FOR_V7X}}"
     commands:
       - echo "placeholder"  # TODO: replace with your unit test command
-  - label: "${TPU_VERSION:-tpu6e} Record unit test result for {MODEL_NAME}"
-    key: "${TPU_VERSION:-tpu6e}_record_{SANITIZED_MODEL_NAME}_UnitTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_{SANITIZED_MODEL_NAME}_UnitTest"
+  - label: "${{TPU_VERSION:-tpu6e}} Record unit test result for {MODEL_NAME}"
+    key: "${{TPU_VERSION:-tpu6e}}_record_{SANITIZED_MODEL_NAME}_UnitTest"
+    depends_on: "${{TPU_VERSION:-tpu6e}}_{SANITIZED_MODEL_NAME}_UnitTest"
     env:
-      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
+      CI_TPU_VERSION: "${{TPU_VERSION:-tpu6e}}"
       CI_TARGET: "{MODEL_NAME}"
       CI_STAGE: "UnitTest"
       CI_CATEGORY: "{CATEGORY}"
@@ -36,27 +36,27 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_{SANITIZED_MODEL_NAME}_UnitTest
+        .buildkite/scripts/record_step_result.sh ${{TPU_VERSION:-tpu6e}}_{SANITIZED_MODEL_NAME}_UnitTest
 
-  - label: "${TPU_VERSION:-tpu6e} Accuracy for {MODEL_NAME}"
-    key: "${TPU_VERSION:-tpu6e}_{SANITIZED_MODEL_NAME}_Accuracy"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_{SANITIZED_MODEL_NAME}_UnitTest"
+  - label: "${{TPU_VERSION:-tpu6e}} Accuracy for {MODEL_NAME}"
+    key: "${{TPU_VERSION:-tpu6e}}_{SANITIZED_MODEL_NAME}_Accuracy"
+    depends_on: "${{TPU_VERSION:-tpu6e}}_record_{SANITIZED_MODEL_NAME}_UnitTest"
     soft_fail: true
     agents:
       queue: {QUEUE}
     env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
+      IS_FOR_V7X: "${{IS_FOR_V7X}}"
       TEST_MODEL: {MODEL_NAME}
       TENSOR_PARALLEL_SIZE: {TENSOR_PARALLEL_SIZE}
       MINIMUM_ACCURACY_THRESHOLD: 0  # TODO : replace 0 with your accuracy threshold
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/test_accuracy.sh
-  - label: "${TPU_VERSION:-tpu6e} Record accuracy result for {MODEL_NAME}"
-    key: "${TPU_VERSION:-tpu6e}_record_{SANITIZED_MODEL_NAME}_Accuracy"
-    depends_on: "${TPU_VERSION:-tpu6e}_{SANITIZED_MODEL_NAME}_Accuracy"
+  - label: "${{TPU_VERSION:-tpu6e}} Record accuracy result for {MODEL_NAME}"
+    key: "${{TPU_VERSION:-tpu6e}}_record_{SANITIZED_MODEL_NAME}_Accuracy"
+    depends_on: "${{TPU_VERSION:-tpu6e}}_{SANITIZED_MODEL_NAME}_Accuracy"
     env:
-      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
+      CI_TPU_VERSION: "${{TPU_VERSION:-tpu6e}}"
       CI_TARGET: "{MODEL_NAME}"
       CI_STAGE: "Accuracy/Correctness"
       CI_CATEGORY: "{CATEGORY}"
@@ -64,27 +64,27 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_{SANITIZED_MODEL_NAME}_Accuracy
+        .buildkite/scripts/record_step_result.sh ${{TPU_VERSION:-tpu6e}}_{SANITIZED_MODEL_NAME}_Accuracy
 
-  - label: "${TPU_VERSION:-tpu6e} Performance benchmarks for {MODEL_NAME}"
-    key: "${TPU_VERSION:-tpu6e}_{SANITIZED_MODEL_NAME}_Benchmark"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_{SANITIZED_MODEL_NAME}_Accuracy"
+  - label: "${{TPU_VERSION:-tpu6e}} Performance benchmarks for {MODEL_NAME}"
+    key: "${{TPU_VERSION:-tpu6e}}_{SANITIZED_MODEL_NAME}_Benchmark"
+    depends_on: "${{TPU_VERSION:-tpu6e}}_record_{SANITIZED_MODEL_NAME}_Accuracy"
     soft_fail: true
     agents:
       queue: {QUEUE}
     env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
+      IS_FOR_V7X: "${{IS_FOR_V7X}}"
       TEST_MODEL: {MODEL_NAME}
       TENSOR_PARALLEL_SIZE: {TENSOR_PARALLEL_SIZE}
       MINIMUM_THROUGHPUT_THRESHOLD: 0  # TODO : replace 0 with your performance threshold
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/benchmark.sh
-  - label: "${TPU_VERSION:-tpu6e} Record performance benchmark result for {MODEL_NAME}"
-    key: "${TPU_VERSION:-tpu6e}_record_{SANITIZED_MODEL_NAME}_Benchmark"
-    depends_on: "${TPU_VERSION:-tpu6e}_{SANITIZED_MODEL_NAME}_Benchmark"
+  - label: "${{TPU_VERSION:-tpu6e}} Record performance benchmark result for {MODEL_NAME}"
+    key: "${{TPU_VERSION:-tpu6e}}_record_{SANITIZED_MODEL_NAME}_Benchmark"
+    depends_on: "${{TPU_VERSION:-tpu6e}}_{SANITIZED_MODEL_NAME}_Benchmark"
     env:
-      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
+      CI_TPU_VERSION: "${{TPU_VERSION:-tpu6e}}"
       CI_TARGET: "{MODEL_NAME}"
       CI_STAGE: "Benchmark"
       CI_CATEGORY: "{CATEGORY}"
@@ -92,4 +92,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_{SANITIZED_MODEL_NAME}_Benchmark
+        .buildkite/scripts/record_step_result.sh ${{TPU_VERSION:-tpu6e}}_{SANITIZED_MODEL_NAME}_Benchmark

--- a/.buildkite/pipeline_generation/vllm_native_model_template.yml
+++ b/.buildkite/pipeline_generation/vllm_native_model_template.yml
@@ -15,20 +15,20 @@
 # pipeline-name: {MODEL_NAME}
 # pipeline-type: {CATEGORY}
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Unit tests for {MODEL_NAME}"
-    key: "${TPU_VERSION:-tpu6e}_{SANITIZED_MODEL_NAME}_UnitTest"
+  - label: "${{TPU_VERSION:-tpu6e}} Unit tests for {MODEL_NAME}"
+    key: "${{TPU_VERSION:-tpu6e}}_{SANITIZED_MODEL_NAME}_UnitTest"
     agents:
       queue: {QUEUE}
     env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
+      IS_FOR_V7X: "${{IS_FOR_V7X}}"
     soft_fail: true
     commands:
       - echo "placeholder"  # TODO: replace with your unit test command
-  - label: "${TPU_VERSION:-tpu6e} Record unit test result for {MODEL_NAME}"
-    key: "${TPU_VERSION:-tpu6e}_record_{SANITIZED_MODEL_NAME}_UnitTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_{SANITIZED_MODEL_NAME}_UnitTest"
+  - label: "${{TPU_VERSION:-tpu6e}} Record unit test result for {MODEL_NAME}"
+    key: "${{TPU_VERSION:-tpu6e}}_record_{SANITIZED_MODEL_NAME}_UnitTest"
+    depends_on: "${{TPU_VERSION:-tpu6e}}_{SANITIZED_MODEL_NAME}_UnitTest"
     env:
-      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
+      CI_TPU_VERSION: "${{TPU_VERSION:-tpu6e}}"
       CI_TARGET: "{MODEL_NAME}"
       CI_STAGE: "UnitTest"
       CI_CATEGORY: "{CATEGORY}"
@@ -36,27 +36,27 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_{SANITIZED_MODEL_NAME}_UnitTest
+        .buildkite/scripts/record_step_result.sh ${{TPU_VERSION:-tpu6e}}_{SANITIZED_MODEL_NAME}_UnitTest
 
-  - label: "${TPU_VERSION:-tpu6e} Accuracy for {MODEL_NAME}"
-    key: "${TPU_VERSION:-tpu6e}_{SANITIZED_MODEL_NAME}_Accuracy"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_{SANITIZED_MODEL_NAME}_UnitTest"
+  - label: "${{TPU_VERSION:-tpu6e}} Accuracy for {MODEL_NAME}"
+    key: "${{TPU_VERSION:-tpu6e}}_{SANITIZED_MODEL_NAME}_Accuracy"
+    depends_on: "${{TPU_VERSION:-tpu6e}}_record_{SANITIZED_MODEL_NAME}_UnitTest"
     agents:
       queue: {QUEUE}
     soft_fail: true
     env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
+      IS_FOR_V7X: "${{IS_FOR_V7X}}"
       TEST_MODEL: {MODEL_NAME}
       TENSOR_PARALLEL_SIZE: {TENSOR_PARALLEL_SIZE}
       MINIMUM_ACCURACY_THRESHOLD: 0  # TODO : replace 0 with your accuracy threshold
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/test_accuracy.sh
-  - label: "${TPU_VERSION:-tpu6e} Record accuracy result for {MODEL_NAME}"
-    key: "${TPU_VERSION:-tpu6e}_record_{SANITIZED_MODEL_NAME}_Accuracy"
-    depends_on: "${TPU_VERSION:-tpu6e}_{SANITIZED_MODEL_NAME}_Accuracy"
+  - label: "${{TPU_VERSION:-tpu6e}} Record accuracy result for {MODEL_NAME}"
+    key: "${{TPU_VERSION:-tpu6e}}_record_{SANITIZED_MODEL_NAME}_Accuracy"
+    depends_on: "${{TPU_VERSION:-tpu6e}}_{SANITIZED_MODEL_NAME}_Accuracy"
     env:
-      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
+      CI_TPU_VERSION: "${{TPU_VERSION:-tpu6e}}"
       CI_TARGET: "{MODEL_NAME}"
       CI_STAGE: "Accuracy/Correctness"
       CI_CATEGORY: "{CATEGORY}"
@@ -64,4 +64,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_{SANITIZED_MODEL_NAME}_Accuracy
+        .buildkite/scripts/record_step_result.sh ${{TPU_VERSION:-tpu6e}}_{SANITIZED_MODEL_NAME}_Accuracy


### PR DESCRIPTION
# Description

This PR fixes a bug in the Buildkite pipeline generation script add_model_to_ci.py.

The script was failing with a KeyError because the Python format() method was attempting to interpret shell-style variables (e.g., ${TPU_VERSION:-tpu6e}) within the feature_template.yml as Python format placeholders.

This fix escapes the curly braces for these shell variables (e.g., ${{TPU_VERSION:-tpu6e}}), ensuring they are ignored by Python's formatting and preserved for Buildkite's use. This allows the script to generate feature configurations correctly.


# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
