### PR TITLE
[Bug fix] Fix incorrect argname with Dense Matmul backend

### DIFF
--- a/tests/layers/jax/moe/test_moe.py
+++ b/tests/layers/jax/moe/test_moe.py
@@ -58,7 +58,9 @@ class TestMoE(unittest.TestCase):
         self.x = jax.random.normal(self.key, (self.B * self.S, self.D),
                                    dtype=self.dtype)
 
-    def _create_moe(self, backend: MoEBackend):
+    def _create_moe(self,
+                    backend: MoEBackend,
+                    apply_expert_weight_before_computation: bool = False):
         """Helper to instantiate the MoE layer within the mesh context."""
         with self.mesh:
             router = Router(
@@ -93,7 +95,8 @@ class TestMoE(unittest.TestCase):
                 edf_sharding=PartitionSpec('model', None,
                                            None),  # Expert par on axis 0
                 efd_sharding=PartitionSpec('model', None, None),
-                apply_expert_weight_before_computation=False,
+                apply_expert_weight_before_computation=
+                apply_expert_weight_before_computation,
                 moe_backend=backend,
                 num_experts_per_tok=self.K,
                 expert_axis_name='model',
@@ -163,17 +166,23 @@ class TestMoE(unittest.TestCase):
 
     def test_dense_backend_correctness(self):
         """Verifies the DENSE_MAT backend against the sequential ground truth."""
-        moe = self._create_moe(MoEBackend.DENSE_MAT)
+        for apply_expert_weight_before_computation in [False, True]:
+            moe = self._create_moe(MoEBackend.DENSE_MAT,
+                                   apply_expert_weight_before_computation=
+                                   apply_expert_weight_before_computation)
 
-        with self.mesh:
-            actual_output = moe(self.x)
+            with self.mesh:
+                actual_output = moe(self.x)
 
-        expected_output = self._compute_ground_truth(moe, self.x)
+            expected_output = self._compute_ground_truth(moe, self.x)
 
-        # Dense matmul should be very numerically close
-        self.assertTrue(
-            jnp.allclose(actual_output, expected_output, atol=1e-2, rtol=1e-2),
-            "Dense backend output does not match ground truth.")
+            # Dense matmul should be very numerically close
+            self.assertTrue(
+                jnp.allclose(actual_output,
+                             expected_output,
+                             atol=1e-2,
+                             rtol=1e-2),
+                "Dense backend output does not match ground truth.")
 
     def test_sparse_distributed_backend_correctness(self):
         """

--- a/tpu_inference/layers/common/moe.py
+++ b/tpu_inference/layers/common/moe.py
@@ -141,6 +141,7 @@ def moe_apply(
                     num_local_experts=layer.num_local_experts,
                     apply_expert_weight_before_computation=layer.
                     apply_expert_weight_before_computation,
+                    activation_ffw_ted=layer.activation_ffw_ted,
                     activation_ffw_td=layer.activation_ffw_td,
                     hidden_act=layer.hidden_act)
 

--- a/tpu_inference/layers/jax/moe/dense_moe.py
+++ b/tpu_inference/layers/jax/moe/dense_moe.py
@@ -36,6 +36,8 @@ def dense_moe_fwd(weights: UnfusedMoEWeights, x_TD: Float,
         x_TD: Input array of shape (sequence_length, d_model).
         cast_dtype: The dtype to cast the input to.
         activation_ffw_td: The sharding of the activation.
+        hidden_act: The activation function to use.
+        full_weights_TE: The full weights of the dense Moe layer.
 
     Returns:
         The output of the dense Moe layer.
@@ -71,6 +73,8 @@ def dense_moe_fwd_preapply_router_weights(
         x_TD: Input array of shape (sequence_length, d_model).
         cast_dtype: The dtype to cast the input to.
         activation_ffw_td: The sharding of the activation.
+        hidden_act: The activation function to use.
+        full_weights_TE: The weights of the router.
 
     Returns:
         The output of the dense Moe layer.
@@ -99,7 +103,8 @@ def dense_moe_func(weights: UnfusedMoEWeights, x_TD: jax.Array,
                    gating_output: Tuple[jax.Array, jax.Array],
                    cast_dtype: jnp.dtype, num_local_experts: int,
                    apply_expert_weight_before_computation: bool,
-                   activation_ffw_td, hidden_act) -> jax.Array:
+                   activation_ffw_td: Sharding, activation_ffw_ted: Sharding,
+                   hidden_act: str) -> jax.Array:
     """
     Forward pass of the dense MoE layer.  This is a naive implementation
     and thus should not be used in production.
@@ -115,6 +120,9 @@ def dense_moe_func(weights: UnfusedMoEWeights, x_TD: jax.Array,
         num_local_experts: The number of local experts.
         apply_expert_weight_before_computation: Whether to apply the expert weights before computing the output.
         activation_ffw_td: The sharding of the activation.
+        activation_ffw_ted: The sharding of the activation, used for the
+            pre-apply weights case.
+        hidden_act: The activation function to use.
 
     Returns:
         The output of the dense Moe layer.
@@ -137,7 +145,7 @@ def dense_moe_func(weights: UnfusedMoEWeights, x_TD: jax.Array,
                 weights=weights,
                 x_TD=x_TD,
                 cast_dtype=cast_dtype,
-                activation_ffw_td=activation_ffw_td,
+                activation_ffw_ted=activation_ffw_ted,
                 hidden_act=hidden_act,
                 full_weights_TE=full_weights_TE)
     else:


### PR DESCRIPTION
# Description

Fixes issue where call signatures of dense_moe_func and dense_moe_fwd_preapply_router_weights don't match

# Tests

Tested locally + updated unit test to include this case + verified NIGHTLY build: 
<img width="349" height="83" alt="image" src="https://github.com/user-attachments/assets/9bd6d35a-d227-4e35-ba7c-ad7977bf8095" />


# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
