### PR TITLE
[PP] Fix v7 pp

### DIFF
--- a/tpu_inference/worker/tpu_worker.py
+++ b/tpu_inference/worker/tpu_worker.py
@@ -49,9 +49,9 @@ class PPConfig:
     default_tpu_visible_chips: str = field(init=False)
 
     def __post_init__(self):
-        # In the isolated stage architecture, each pipeline stage operates 
-        # as an independent JAX cluster. 
-        # For single-host PP or multi-host with one host per stage, 
+        # In the isolated stage architecture, each pipeline stage operates
+        # as an independent JAX cluster.
+        # For single-host PP or multi-host with one host per stage,
         # the cluster size for each stage is 1.
         self.default_tpu_process_bounds = "1,1,1"
         self.default_tpu_chips_per_process_bounds = "1,1,1"


### PR DESCRIPTION
# Description

Currently when running PP on singlehost on v7 machine, it would run into this error:
```
...
(EngineCore_DP0 pid=1670803) ERROR 02-10 18:47:53 [core.py:982] RuntimeError: Worker failed with error 'INTERNAL: Core halted unexpectedly: Assertion args: 0x00000001 0x00000001 0x00000000 INTERNAL: Accelerator device halted prematurely, perhaps due to an on-device check-failure. Node 0 halted unexpectedly at tag:pc TensorCoreSequencer:1:0xd4 (from TensorCoreSequencer:1:0x264): schecklt: Invalid logical z: EncodeRemoteSyncFlagAddress() no HLO mapping
...
vllm.v1.engine.exceptions.EngineDeadError: EngineCore encountered an issue. See stack trace (above) for the root cause.
(EngineCore_DP0 pid=1670803) (Worker pid=1670811) WARNING 02-10 18:47:53 [multiproc_executor.py:797] WorkerProc was terminated
(EngineCore_DP0 pid=1670803) (Worker pid=1670809) WARNING 02-10 18:47:53 [multiproc_executor.py:797] WorkerProc was terminated
/mnt/disks/persist/miniconda/envs/vllm/lib/python3.12/multiprocessing/resource_tracker.py:279: UserWarning: resource_tracker: There appear to be 1 leaked shared_memory objects to clean up at shutdown
  warnings.warn('resource_tracker: There appear to be %d '
Processed prompts:   0%|
```
## The Problem: JIT Deadlocks
  
When TPU_PROCESS_BOUNDS was set to 1, pp_world_size, 1, JAX treated all pipeline stages as part of a single large cluster.


  In JAX, when you run a jit function, all processes in the cluster must participate in the "collective" work (like compilation or cross-device communication). This creates a catch-22 in Pipeline Parallelism:
   1. Rank 0 starts its jit forward pass and waits for Rank 1 to "join" the execution.
   2. Rank 1 is stuck outside of the jit call, waiting for Rank 0 to send it the intermediate tensors (via P2P transfer).
   3. Result: Neither rank can move forward, and the system hangs.


## The Solution: Isolated Stages
  By setting the bounds to "1, 1, 1", we tell the TPU runtime that each pipeline stage is its own independent JAX cluster.


   * Rank 0 is now a cluster of size 1. It can compile and run its forward pass without ever caring what Rank 1 is doing.
   * Rank 1 is also a cluster of size 1. It waits for data to arrive, and once it does, it runs its own forward pass independently.
   * The Bridge: Since they are no longer in the same cluster, they can't use standard JAX collective ops (like all_gather) to talk to each other. Instead, we use jax.experimental.transfer (Point-to-Point communication) to bridge them.

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
