### PR TITLE
[DO NOT SUBMIT][CI] Fix flaky PR tests

### DIFF
--- a/.buildkite/scripts/run_in_docker.sh
+++ b/.buildkite/scripts/run_in_docker.sh
@@ -81,6 +81,26 @@ fi
 # Some test scripts set tp=2 on IS_FOR_V7X=true to mitigate test failures.
 # TODO (Qiliang Cui) Investigate why tensor-parallel-size=1 breaks in tpu7x.
 
+# Debug: Show processes currently holding TPU devices before starting the container.
+echo "=== [DEBUG] TPU device status before docker run ==="
+echo "--- Processes using /dev/accel* (TPU devices) ---"
+if ls /dev/accel* &>/dev/null; then
+  fuser -v /dev/accel* 2>&1 || echo "(no processes using /dev/accel*)"
+else
+  echo "(no /dev/accel* devices found on host)"
+fi
+echo "--- Processes using /dev/vfio/* (TPU vfio devices) ---"
+if ls /dev/vfio/* &>/dev/null; then
+  fuser -v /dev/vfio/* 2>&1 || echo "(no processes using /dev/vfio/*)"
+else
+  echo "(no /dev/vfio/* devices found on host)"
+fi
+echo "--- Running docker containers ---"
+docker ps --format "table {{.ID}}\t{{.Image}}\t{{.Status}}\t{{.Names}}" 2>/dev/null || true
+echo "--- Processes matching python/vllm/jax ---"
+ps aux | grep -E 'python|vllm|jax' | grep -v grep || echo "(none found)"
+echo "=== [DEBUG] End TPU device status ==="
+
 exec docker run \
   --privileged \
   --net host \


### PR DESCRIPTION
# Description

v6e PR tests have been flaky, failing with  `RuntimeError: Unable to initialize backend 'tpu': UNKNOWN: TPU initialization failed: open(/dev/vfio/0): Device or resource busy: Device or resource busy; Couldn't open iommu group /dev/vfio/0 (set JAX_PLATFORMS='' to automatically choose an available backend)`. This PR adds some sleep time to ensure TPU is properly released before running tests. 

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
