### PR TITLE
[Bug fix] Fix attn_dp correctness issue 

### DIFF
--- a/tpu_inference/models/common/model_loader.py
+++ b/tpu_inference/models/common/model_loader.py
@@ -260,7 +260,7 @@ def get_flax_model(
                       ShardingAxisName.ATTN_HEAD))
     hidden_states_sharding = NamedSharding(mesh,
                                            PartitionSpec(
-                                               ShardingAxisName.MLP_DATA,
+                                               ShardingAxisName.ATTN_DATA,
                                                None))  # (T, D)
 
     # For performance consideration, refer to:

--- a/tpu_inference/models/vllm/vllm_model_wrapper.py
+++ b/tpu_inference/models/vllm/vllm_model_wrapper.py
@@ -191,7 +191,7 @@ class VllmModelWrapper:
             out_shardings=(
                 None,  # kv_caches - keep original sharding
                 NamedSharding(self.mesh,
-                              PartitionSpec(ShardingAxisName.MLP_DATA, None)),
+                              PartitionSpec(ShardingAxisName.ATTN_DATA, None)),
                 None,  # empty list
             ),
             compiler_options={

--- a/tpu_inference/runner/compilation_manager.py
+++ b/tpu_inference/runner/compilation_manager.py
@@ -155,22 +155,21 @@ class CompilationManager:
         assert num_tokens is not None
 
         dp_size = self.runner.vllm_config.sharding_config.total_dp_size
-        dp_attn_sharding = NamedSharding(
+        dp_sharding = NamedSharding(
             self.runner.mesh, PartitionSpec(
                 ShardingAxisName.ATTN_DATA, )) if dp_size > 1 else None
 
         # Keep existing pattern for complex array operations
         seq_lens = self._create_dummy_tensor((self.runner.max_num_reqs, ),
-                                             jnp.int32, dp_attn_sharding)
+                                             jnp.int32, dp_sharding)
         query_start_loc = self._create_dummy_tensor(
-            (self.runner.max_num_reqs + dp_size, ), jnp.int32,
-            dp_attn_sharding)
+            (self.runner.max_num_reqs + dp_size, ), jnp.int32, dp_sharding)
 
         # Keep existing pattern for specific value arrays
         request_distribution = np.array([0, 0, 0] * dp_size, dtype=np.int32)
         request_distribution = device_array(self.runner.mesh,
                                             request_distribution,
-                                            sharding=dp_attn_sharding)
+                                            sharding=dp_sharding)
 
         attention_metadata_per_layer: Dict[str, AttentionMetadata] = {}
         uniform_attention_metadata: AttentionMetadata = None
@@ -181,7 +180,7 @@ class CompilationManager:
             block_tables = block_tables.reshape(-1)
             block_tables = device_array(self.runner.mesh,
                                         block_tables,
-                                        sharding=dp_attn_sharding)
+                                        sharding=dp_sharding)
 
             attention_metadata_gid = AttentionMetadata(
                 input_positions=positions,
@@ -256,7 +255,7 @@ class CompilationManager:
             if self.runner.vllm_config.sharding_config.total_dp_size > 1:
                 dp_sharding = NamedSharding(
                     self.runner.mesh,
-                    PartitionSpec(ShardingAxisName.MLP_DATA, ))
+                    PartitionSpec(ShardingAxisName.ATTN_DATA, ))
                 next_tokens_sharding = dp_sharding
             else:
                 dp_sharding = None
@@ -298,22 +297,14 @@ class CompilationManager:
     def _precompile_backbone_text_only(self) -> None:
         hidden_size = self.runner.model_config.get_hidden_size()
         for num_tokens in self.runner.num_tokens_paddings:
-            dp_size = self.runner.vllm_config.sharding_config.total_dp_size
-            if dp_size > 1:
-                dp_attn_sharding = NamedSharding(
-                    self.runner.mesh,
-                    PartitionSpec(ShardingAxisName.ATTN_DATA, ))
-                dp_sharding = NamedSharding(
-                    self.runner.mesh,
-                    PartitionSpec(ShardingAxisName.MLP_DATA, ))
-            else:
-                dp_attn_sharding = None
-                dp_sharding = None
+            dp_sharding = NamedSharding(
+                self.runner.mesh, PartitionSpec(ShardingAxisName.ATTN_DATA, )
+            ) if self.runner.vllm_config.sharding_config.total_dp_size > 1 else None
 
             input_ids = self._create_dummy_tensor((num_tokens, ), jnp.int32,
                                                   dp_sharding)
             positions = self._create_dummy_tensor((num_tokens, ), jnp.int32,
-                                                  dp_attn_sharding)
+                                                  dp_sharding)
             is_first_rank = self.runner.is_first_rank
             is_last_rank = self.runner.is_last_rank
             if is_first_rank:
@@ -433,9 +424,9 @@ class CompilationManager:
         else:
             index_paddings = self.runner.num_reqs_paddings
         dp_sharding = NamedSharding(self.runner.mesh,
-                                    PartitionSpec(ShardingAxisName.MLP_DATA))
+                                    PartitionSpec(ShardingAxisName.ATTN_DATA))
         hidden_states_sharding = NamedSharding(
-            self.runner.mesh, PartitionSpec(ShardingAxisName.MLP_DATA, None))
+            self.runner.mesh, PartitionSpec(ShardingAxisName.ATTN_DATA, None))
         dp_size = self.runner.vllm_config.sharding_config.total_dp_size
         self._precompile_select_from_array_helper(
             name=f"worker{self.runner.rank} select all logits",
@@ -477,7 +468,7 @@ class CompilationManager:
         hsize = self.runner.model_config.get_hidden_size()
         leading_shape = self.runner.num_reqs_paddings if not self.runner.speculative_config else self.runner.num_logits_paddings
         dp_sharding = NamedSharding(self.runner.mesh,
-                                    PartitionSpec(ShardingAxisName.MLP_DATA))
+                                    PartitionSpec(ShardingAxisName.ATTN_DATA))
         for num_reqs in leading_shape:
             hidden_states = self._create_dummy_tensor(
                 (num_reqs, hsize), jnp.bfloat16, dp_sharding)

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -1028,9 +1028,9 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         ret = jax.shard_map(
             select_local_fn,
             mesh=self.mesh,
-            in_specs=(PartitionSpec(ShardingAxisName.MLP_DATA),
-                      PartitionSpec(ShardingAxisName.MLP_DATA)),
-            out_specs=PartitionSpec(ShardingAxisName.MLP_DATA))(
+            in_specs=(PartitionSpec(ShardingAxisName.ATTN_DATA),
+                      PartitionSpec(ShardingAxisName.ATTN_DATA)),
+            out_specs=PartitionSpec(ShardingAxisName.ATTN_DATA))(
                 array, indices_to_select)
 
         return ret
@@ -1207,8 +1207,6 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         dp_size = self.dp_size
         data_parallel_attn_sharding = NamedSharding(
             self.mesh, PartitionSpec(ShardingAxisName.ATTN_DATA))
-        data_parallel_sharding = NamedSharding(
-            self.mesh, PartitionSpec(ShardingAxisName.MLP_DATA))
 
         (req_ids_dp, req_indices_dp, num_scheduled_tokens_per_dp_rank,
          scheduled_tokens_per_dp_rank, num_req_per_dp_rank,
@@ -1396,16 +1394,11 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         logits_indices_cpu = logits_indices
         seq_lens_cpu = seq_lens
 
-        (input_ids, logits_indices) = device_array(
-            self.mesh,
-            (input_ids, logits_indices),
-            sharding=data_parallel_sharding,
-        )
-
-        (positions, query_start_loc, seq_lens,
+        (input_ids, positions, query_start_loc, seq_lens, logits_indices,
          request_distribution) = device_array(
              self.mesh,
-             (positions, query_start_loc, seq_lens, request_distribution),
+             (input_ids, positions, query_start_loc, seq_lens, logits_indices,
+              request_distribution),
              sharding=data_parallel_attn_sharding,
          )
 


### PR DESCRIPTION
# Description

Revert PR https://github.com/vllm-project/tpu-inference/pull/1643 and change output_sharding in `vllm_model_wrapper.py` from `MLP_DATA` to `ATTN_DATA` in avoid recompilation error.  


# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
