### PR TITLE
Upgrade torchax version to support vLLM Bert model

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ jax[tpu]==0.8.0
 jaxlib==0.8.0
 jaxtyping
 flax==0.11.1
-torchax==0.0.10
+torchax==0.0.11
 qwix==0.1.1
 torchvision==0.24.0
 pathwaysutils


### PR DESCRIPTION

# Description

Some torch operator are added in version v0.0.11

We can enable XLMRobertaModel and other Bert family models from vLLM source tree (torchax path) with this PR. 

See also: https://github.com/google/torchax/pull/63

# Tests

No test required.
