### PR TITLE
Revert "[TPU Offload]perform a device_get on all shards in parallel f…

### DIFF
--- a/tpu_inference/offload/utils.py
+++ b/tpu_inference/offload/utils.py
@@ -179,7 +179,13 @@ def jax_copy_swap_kv_caches(
         dst_memory_kind = dst_sharding.memory_kind
         result = []
         for kv_cache in src_kv_caches:
-            shards = jax.device_get([shard.data for shard in kv_cache.addressable_shards])
+            shards = [
+                jax.device_put(
+                    shard.data,
+                    jax.sharding.SingleDeviceSharding(
+                        shard.device, memory_kind=dst_memory_kind))
+                for shard in kv_cache.addressable_shards
+            ]
             result.append(shards)
         return result
     else:  # h2d


### PR DESCRIPTION
…or d2h swap function (#1666)"

This reverts commit b05859b622be699d5911fd5c9009721c516a638f.

# Description

Revert ["perform a device_get on all shards in parallel for d2h swap function" ](https://github.com/vllm-project/tpu-inference/pull/1666). This change causes a RESOURCE_EXHAUSTED error

```
(EngineCore_DP0 pid=344) ERROR 02-10 19:23:35 [tpu_offload_connector.py:2498] Error gathering blocks for request cmpl-9cbf94ef9250316c-0: RESOURCE_EXHAUSTED: Error allocating device buffer: Attempting to allocate 832.0K. That was not possible. There are 112.5K free.; (0x0x0_HBM0): while running replica 0 and partition 0 of a replicated computation (other replicas may have failed as well).
(EngineCore_DP0 pid=344) ERROR 02-10 19:23:35 [tpu_offload_connector.py:2498] Traceback (most recent call last):
(EngineCore_DP0 pid=344) ERROR 02-10 19:23:35 [tpu_offload_connector.py:2498]   File "/workspace/tpu_inference/tpu_inference/offload/tpu_offload_connector.py", line 2490, in start_save_kv
(EngineCore_DP0 pid=344) ERROR 02-10 19:23:35 [tpu_offload_connector.py:2498]     gather_result = self._gather_tpu_blocks(
(EngineCore_DP0 pid=344) ERROR 02-10 19:23:35 [tpu_offload_connector.py:2498]                     ^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=344) ERROR 02-10 19:23:35 [tpu_offload_connector.py:2498]   File "/workspace/tpu_inference/tpu_inference/offload/tpu_offload_connector.py", line 2131, in _gather_tpu_blocks
(EngineCore_DP0 pid=344) ERROR 02-10 19:23:35 [tpu_offload_connector.py:2498]     flat_kv_caches_tpu = self._bucketed_gather_kv_cache(
(EngineCore_DP0 pid=344) ERROR 02-10 19:23:35 [tpu_offload_connector.py:2498]                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=344) ERROR 02-10 19:23:35 [tpu_offload_connector.py:2498]   File "/workspace/tpu_inference/tpu_inference/offload/tpu_offload_connector.py", line 1885, in _bucketed_gather_kv_cache
(EngineCore_DP0 pid=344) ERROR 02-10 19:23:35 [tpu_offload_connector.py:2498]     result = jax.tree.map(lambda *x: jnp.concatenate(x, axis=0),
(EngineCore_DP0 pid=344) ERROR 02-10 19:23:35 [tpu_offload_connector.py:2498]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=344) ERROR 02-10 19:23:35 [tpu_offload_connector.py:2498]   File "/usr/local/lib/python3.12/site-packages/jax/_src/tree.py", line 155, in map
(EngineCore_DP0 pid=344) ERROR 02-10 19:23:35 [tpu_offload_connector.py:2498]     return tree_util.tree_map(f, tree, *rest, is_leaf=is_leaf)
(EngineCore_DP0 pid=344) ERROR 02-10 19:23:35 [tpu_offload_connector.py:2498]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=344) ERROR 02-10 19:23:35 [tpu_offload_connector.py:2498]   File "/usr/local/lib/python3.12/site-packages/jax/_src/tree_util.py", line 364, in tree_map
(EngineCore_DP0 pid=344) ERROR 02-10 19:23:35 [tpu_offload_connector.py:2498]     return treedef.unflatten(f(*xs) for xs in zip(*all_leaves))
(EngineCore_DP0 pid=344) ERROR 02-10 19:23:35 [tpu_offload_connector.py:2498]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=344) ERROR 02-10 19:23:35 [tpu_offload_connector.py:2498]   File "/usr/local/lib/python3.12/site-packages/jax/_src/tree_util.py", line 364, in <genexpr>
(EngineCore_DP0 pid=344) ERROR 02-10 19:23:35 [tpu_offload_connector.py:2498]     return treedef.unflatten(f(*xs) for xs in zip(*all_leaves))
(EngineCore_DP0 pid=344) ERROR 02-10 19:23:35 [tpu_offload_connector.py:2498]                              ^^^^^^
(EngineCore_DP0 pid=344) ERROR 02-10 19:23:35 [tpu_offload_connector.py:2498]   File "/workspace/tpu_inference/tpu_inference/offload/tpu_offload_connector.py", line 1885, in <lambda>
(EngineCore_DP0 pid=344) ERROR 02-10 19:23:35 [tpu_offload_connector.py:2498]     result = jax.tree.map(lambda *x: jnp.concatenate(x, axis=0),
(EngineCore_DP0 pid=344) ERROR 02-10 19:23:35 [tpu_offload_connector.py:2498]                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=344) ERROR 02-10 19:23:35 [tpu_offload_connector.py:2498]   File "/usr/local/lib/python3.12/site-packages/jax/_src/numpy/lax_numpy.py", line 4602, in concatenate
(EngineCore_DP0 pid=344) ERROR 02-10 19:23:35 [tpu_offload_connector.py:2498]     arrays_out = [lax.concatenate(arrays_out[i:i+k], axis)
(EngineCore_DP0 pid=344) ERROR 02-10 19:23:35 [tpu_offload_connector.py:2498]                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=344) ERROR 02-10 19:23:35 [tpu_offload_connector.py:2498]   File "/usr/local/lib/python3.12/site-packages/jax/_src/lax/lax.py", line 2018, in concatenate
(EngineCore_DP0 pid=344) ERROR 02-10 19:23:35 [tpu_offload_connector.py:2498]     return concatenate_p.bind(*operands, dimension=dimension)
(EngineCore_DP0 pid=344) ERROR 02-10 19:23:35 [tpu_offload_connector.py:2498]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=344) ERROR 02-10 19:23:35 [tpu_offload_connector.py:2498]   File "/usr/local/lib/python3.12/site-packages/jax/_src/core.py", line 632, in bind
(EngineCore_DP0 pid=344) ERROR 02-10 19:23:35 [tpu_offload_connector.py:2498]     return self._true_bind(*args, **params)
(EngineCore_DP0 pid=344) ERROR 02-10 19:23:35 [tpu_offload_connector.py:2498]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=344) ERROR 02-10 19:23:35 [tpu_offload_connector.py:2498]   File "/usr/local/lib/python3.12/site-packages/jax/_src/core.py", line 648, in _true_bind
(EngineCore_DP0 pid=344) ERROR 02-10 19:23:35 [tpu_offload_connector.py:2498]     return self.bind_with_trace(prev_trace, args, params)
(EngineCore_DP0 pid=344) ERROR 02-10 19:23:35 [tpu_offload_connector.py:2498]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=344) ERROR 02-10 19:23:35 [tpu_offload_connector.py:2498]   File "/usr/local/lib/python3.12/site-packages/jax/_src/core.py", line 660, in bind_with_trace
(EngineCore_DP0 pid=344) ERROR 02-10 19:23:35 [tpu_offload_connector.py:2498]     return trace.process_primitive(self, args, params)
(EngineCore_DP0 pid=344) ERROR 02-10 19:23:35 [tpu_offload_connector.py:2498]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=344) ERROR 02-10 19:23:35 [tpu_offload_connector.py:2498]   File "/usr/local/lib/python3.12/site-packages/jax/_src/core.py", line 1189, in process_primitive
(EngineCore_DP0 pid=344) ERROR 02-10 19:23:35 [tpu_offload_connector.py:2498]     return primitive.impl(*args, **params)
(EngineCore_DP0 pid=344) ERROR 02-10 19:23:35 [tpu_offload_connector.py:2498]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=344) ERROR 02-10 19:23:35 [tpu_offload_connector.py:2498]   File "/usr/local/lib/python3.12/site-packages/jax/_src/dispatch.py", line 94, in apply_primitive
(EngineCore_DP0 pid=344) ERROR 02-10 19:23:35 [tpu_offload_connector.py:2498]     outs = fun(*args)
(EngineCore_DP0 pid=344) ERROR 02-10 19:23:35 [tpu_offload_connector.py:2498]            ^^^^^^^^^^
(EngineCore_DP0 pid=344) ERROR 02-10 19:23:35 [tpu_offload_connector.py:2498] ValueError: RESOURCE_EXHAUSTED: Error allocating device buffer: Attempting to allocate 832.0K. That was not possible. There are 112.5K free.; (0x0x0_HBM0): while running replica 0 and partition 0 of a replicated computation (other replicas may have failed as well).
```

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
