### PR TITLE
Fix kernel test skip logic for PRs with merge commits

### DIFF
--- a/.buildkite/pipeline_jax.yml
+++ b/.buildkite/pipeline_jax.yml
@@ -152,7 +152,11 @@ steps:
           queue: ${TPU_QUEUE_SINGLE:-tpu_v6e_queue}
         commands:
           - |
-            if [[ "$$NIGHTLY" == "1" ]] || git diff --name-only HEAD~1 | grep -qE '^(tpu_inference/kernels|tests/kernels|requirements.txt)'; then
+            echo "--- Fetching changed files from metadata"
+            FILES_CHANGED=$$(buildkite-agent meta-data get "changed_files" --default "" | tr ',' '\n')
+            echo "$${FILES_CHANGED}"
+
+            if [[ "$$NIGHTLY" == "1" ]] || echo "$$FILES_CHANGED" | grep -qE '^(tpu_inference/kernels|tests/kernels|requirements.txt)'; then
               .buildkite/scripts/run_in_docker.sh \
                 python3 -m pytest -s -v -x /workspace/tpu_inference/tests/kernels \
                 --ignore=/workspace/tpu_inference/tests/kernels/ragged_paged_attention_kernel_v2_test.py \
@@ -172,7 +176,11 @@ steps:
           queue: ${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}
         commands:
           - |
-            if [[ "$$NIGHTLY" == "1" ]] || git diff --name-only HEAD~1 | grep -qE '^(tpu_inference/kernels/collectives|tests/kernels/collectives|requirements.txt)'; then
+            echo "--- Fetching changed files from metadata"
+            FILES_CHANGED=$$(buildkite-agent meta-data get "changed_files" --default "" | tr ',' '\n')
+            echo "$${FILES_CHANGED}"
+
+            if [[ "$$NIGHTLY" == "1" ]] || echo "$$FILES_CHANGED" | grep -qE '^(tpu_inference/kernels/collectives|tests/kernels/collectives|requirements.txt)'; then
               .buildkite/scripts/run_in_docker.sh \
                 python3 -m pytest -s -v -x /workspace/tpu_inference/tests/kernels/collectives
             else

--- a/.buildkite/scripts/bootstrap.sh
+++ b/.buildkite/scripts/bootstrap.sh
@@ -20,6 +20,7 @@ set -euo pipefail
 echo "--- :git: Checking changed files"
 
 BASE_BRANCH=${BUILDKITE_PULL_REQUEST_BASE_BRANCH:-"main"}
+FILES_CHANGED=""
 
 if [ "$BUILDKITE_PULL_REQUEST" != "false" ]; then
     echo "PR detected. Target branch: $BASE_BRANCH"
@@ -61,7 +62,11 @@ if [ "$BUILDKITE_PULL_REQUEST" != "false" ]; then
     fi
 else
     echo "Non-PR build. Bypassing file change check."
+    FILES_CHANGED=$(git diff-tree --no-commit-id --name-only -r -m "$BUILDKITE_COMMIT")
 fi
+
+# Store changed files in metadata for sub-pipelines (newlines to commas)
+echo "$FILES_CHANGED" | tr '\n' ',' | buildkite-agent meta-data set "changed_files"
 
 upload_pipeline() {
     if [ "${MODEL_IMPL_TYPE:-auto}" == "auto" ]; then


### PR DESCRIPTION
# Description

Fixes the issue where merge commits caused CI to skip relevant kernel tests. 
Centralizes change detection in bootstrap.sh.

# Tests

[BuildKite](https://buildkite.com/tpu-commons/tpu-inference-ci/builds/10474/steps/canvas)

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
