### PR TITLE
[MoE][JAX] Shard fix for better MoE perf

### DIFF
--- a/tpu_inference/layers/jax/moe/sparse_moe.py
+++ b/tpu_inference/layers/jax/moe/sparse_moe.py
@@ -239,11 +239,9 @@ def sparse_moe_func(weights: UnfusedMoEWeights, x_TD: jax.Array,
     weights_TX, indices_TX = gating_output
     if layer.qwix_quantized_weight_dtype:
         gating_up_proj_spec = (PartitionSpec(*layer.edf_sharding),
-                               PartitionSpec(layer.edf_sharding[0], None,
-                                             layer.edf_sharding[2]))
+                               PartitionSpec(*layer.edf_sharding))
         down_proj_spec = (PartitionSpec(*layer.efd_sharding),
-                          PartitionSpec(layer.efd_sharding[0], None,
-                                        layer.efd_sharding[2]))
+                          PartitionSpec(*layer.efd_sharding))
     else:
         gating_up_proj_spec = PartitionSpec(*layer.edf_sharding)
         down_proj_spec = PartitionSpec(*layer.efd_sharding)
@@ -274,19 +272,19 @@ def sparse_moe_func(weights: UnfusedMoEWeights, x_TD: jax.Array,
         "kernel_gating_EDF",
         layer.kernel_gating_EDF,
         channelwise_axes=[0, 2],
-        tiled_axes={})
+        tiled_axes={1: 128})
     kernel_up_proj_EDF = _process_weight_for_qwix(
         layer.qwix_quantized_weight_dtype,
         "kernel_up_proj_EDF",
         layer.kernel_up_proj_EDF,
         channelwise_axes=[0, 2],
-        tiled_axes={})
+        tiled_axes={1: 128})
     kernel_down_proj_EFD = _process_weight_for_qwix(
         layer.qwix_quantized_weight_dtype,
         "kernel_down_proj_EFD",
         layer.kernel_down_proj_EFD,
         channelwise_axes=[0, 2],
-        tiled_axes={})
+        tiled_axes={1: 128})
 
     weights.w1_weight = kernel_gating_EDF
     weights.w2_weight = kernel_up_proj_EDF


### PR DESCRIPTION
# Description

* Fix the shard_map in_specs for quantized MoE weight scales to use the full edf_sharding/efd_sharding instead of hardcoding None on dimension 1. 

* Set tiled_axes={1: 128} in `_process_weight_for_qwix` so the abstract pass creates scale placeholders with a shardable dim 1 (required for the corrected PartitionSpec to pass `shard_map` validation).

We saw a performance regression on our mmlu benchmark dropping from about 2500 to 2100 tok/s throughput. This change gets us back to our original baseline results. 

When running via

```bash
USE_UNFUSED_MEGABLOCKS=1  NEW_MODEL_DESIGN=1 TPU_BACKEND_TYPE=jax \
vllm serve \
--model=jrplatin/DeepSeek-R1-1D-Subchannel-256-FP8 \
--max-model-len=4096 \
--tensor-parallel-size 2 \
--max-num-seqs 16 \
--max-num-batched-tokens 256 \
--no-enable-prefix-caching \
--disable-log-requests \
--gpu-memory-utilization 0.95 \
--additional_config='{"sharding": {"sharding_strategy": {"enable_dp_attention": true, "expert_parallelism": 4, "tensor_parallelism": 2}}, "sparse_matmul": "True"}' \
--hf_overrides '{"architectures": ["DeepseekV3ForCausalLM"]}' \
--kv-cache-dtype=fp8 \
--async-scheduling
```

Before this fix: 
```
============ Serving Benchmark Result ============
Successful requests:                     1000      
Benchmark duration (s):                  117.35    
Total input tokens:                      253322    
Total generated tokens:                  2000      
Request throughput (req/s):              8.52      
Output token throughput (tok/s):         17.04     
Total token throughput (tok/s):          2175.78   
---------------Time to First Token----------------
Mean TTFT (ms):                          54371.24  
Median TTFT (ms):                        38205.40  
P99 TTFT (ms):                           116616.67 
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          912.78    
Median TPOT (ms):                        921.42    
P99 TPOT (ms):                           924.57    
---------------Inter-token Latency----------------
Mean ITL (ms):                           912.78    
Median ITL (ms):                         921.42    
P99 ITL (ms):                            924.57    
----------------End-to-end Latency----------------
Mean E2EL (ms):                          55284.02  
Median E2EL (ms):                        39126.98  
P99 E2EL (ms):                           117212.13 
==================================================
```

After this fix
```
============ Serving Benchmark Result ============
Successful requests:                     1000      
Benchmark duration (s):                  98.76     
Total input tokens:                      253322    
Total generated tokens:                  2000      
Request throughput (req/s):              10.13     
Output token throughput (tok/s):         20.25     
Total token throughput (tok/s):          2585.18   
---------------Time to First Token----------------
Mean TTFT (ms):                          45876.00  
Median TTFT (ms):                        32416.48  
P99 TTFT (ms):                           97729.70  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          765.25    
Median TPOT (ms):                        768.29    
P99 TPOT (ms):                           770.36    
---------------Inter-token Latency----------------
Mean ITL (ms):                           765.25    
Median ITL (ms):                         768.29    
P99 ITL (ms):                            770.36    
----------------End-to-end Latency----------------
Mean E2EL (ms):                          46641.25  
Median E2EL (ms):                        33184.94  
P99 E2EL (ms):                           98493.03  
==================================================
```

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
