### PR TITLE
[Qwen] re-enable test by disabling eager_shard

### DIFF
--- a/tests/models/jax/test_qwen3.py
+++ b/tests/models/jax/test_qwen3.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import unittest
 from unittest.mock import MagicMock, patch
 
 import jax
@@ -224,9 +223,6 @@ class TestQwen3ForCausalLM:
         logits = model.compute_logits(hidden_states)
         assert logits.shape == (1, hf_config.vocab_size)
 
-    @unittest.skip(
-        'TODO: Skip test since this blocking flax/jax version upgrade. Bug created for unskip this test.'
-    )
     @pytest.mark.parametrize("model_name",
                              ["Qwen/Qwen3-0.6B", "Qwen/Qwen3-0.6B-FP8"])
     @pytest.mark.parametrize("pp_rank,pp_world_size", [(0, 1), (0, 4), (1, 4),

--- a/tpu_inference/layers/jax/quantization/fp8.py
+++ b/tpu_inference/layers/jax/quantization/fp8.py
@@ -254,7 +254,8 @@ class Fp8BlockwiseLinearMethod(QuantizeMethodBase, common_fp8.Fp8LinearMethod):
                 kernel_init(rngs.params(), layer.kernel_shape, param_dtype),
                 weight_loader=partial(load_nnx_param_from_reshaped_torch,
                                       permute_dims=None,
-                                      param_name="linear_fp8_weight"))
+                                      param_name="linear_fp8_weight"),
+                eager_sharding=False)
             layer.weight.set_metadata('sharding', self.weight_sharding)
 
             # Per-output-channel scale (1D, covers the free weight dim).
@@ -264,7 +265,8 @@ class Fp8BlockwiseLinearMethod(QuantizeMethodBase, common_fp8.Fp8LinearMethod):
                     load_nnx_param_from_reshaped_torch,
                     permute_dims=None,
                     param_name="linear_fp8_weight_scale_inv",
-                ))
+                ),
+                eager_sharding=False)
             layer.weight_scale_inv.set_metadata('sharding', ())
             return
 
@@ -276,7 +278,8 @@ class Fp8BlockwiseLinearMethod(QuantizeMethodBase, common_fp8.Fp8LinearMethod):
                         param_dtype),
             weight_loader=partial(load_nnx_param_from_reshaped_torch,
                                   permute_dims=(0, 1),
-                                  param_name="linear_fp8_weight"))
+                                  param_name="linear_fp8_weight"),
+            eager_sharding=False)
         layer.weight.set_metadata('sharding', self.weight_sharding)
 
         # Block-wise quantization scale
@@ -293,7 +296,8 @@ class Fp8BlockwiseLinearMethod(QuantizeMethodBase, common_fp8.Fp8LinearMethod):
                 load_nnx_param_from_reshaped_torch,
                 permute_dims=(0, 1),
                 param_name="linear_fp8_weight_scale_inv",
-            ))
+            ),
+            eager_sharding=False)
         layer.weight_scale_inv.set_metadata('sharding', self.weight_sharding)
 
     def process_weights_after_loading(self, layer):


### PR DESCRIPTION
# Description

caused by #1641 

<img width="2836" height="1256" alt="image" src="https://github.com/user-attachments/assets/4d17e1d2-c75c-4962-b314-a4a3694a8b53" />

reason is in 0.12.4 it puts sharding eagerly. One of the design in #1485  is to let e.g. Fp8LinearMethod to re-create weights, where the new weight could be [2D](https://github.com/vllm-project/tpu-inference/blob/571b1ca8fb47a755da35544855fb311ffebc10c3/tpu_inference/layers/jax/quantization/fp8.py#L275) while the authored sharding in qwen3.py is [still 3D](https://github.com/vllm-project/tpu-inference/blob/571b1ca8fb47a755da35544855fb311ffebc10c3/tpu_inference/models/jax/qwen3.py#L82).

In 0.11.1 it wasn't issue because "put sharding" is lazily done

# Tests

CI

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
