### PR TITLE
[Misc] Log error when exception from TPU worker

### DIFF
--- a/tpu_inference/runner/utils.py
+++ b/tpu_inference/runner/utils.py
@@ -150,6 +150,13 @@ class ForbidCompile:
         # Store the original function
         self._original_func = pxla._cached_lowering_to_hlo
         original_cached_func = self._original_func
+        # Prepare trackback such that when exception triggers,
+        # we can show where the call that triggered the compilation is.
+        tb = None
+        try:
+            raise Exception()
+        except Exception as e:
+            tb = e.__traceback__
 
         # Create a wrapper
         @functools.wraps(original_cached_func)
@@ -167,7 +174,7 @@ class ForbidCompile:
 
             # Check if a cache miss occurred
             if misses_after > misses_before:
-                raise RuntimeError(self.message)
+                raise RuntimeError(self.message).with_traceback(tb)
 
             return result
 

--- a/tpu_inference/worker/tpu_worker.py
+++ b/tpu_inference/worker/tpu_worker.py
@@ -305,7 +305,16 @@ class TPUWorker:
         # violates the pure abstract contract of the base class. This is a
         # deliberate, temporary compromise for the same reasons outlined in
         # the `get_kv_cache_spec` method.
+        try:
+            return self._execute_model(scheduler_output)
+        except Exception as e:
+            logger.error(f"Error executing model: {e}")
+            raise e
 
+    def _execute_model(
+        self,
+        scheduler_output: SchedulerOutput,
+    ) -> Optional[ModelRunnerOutput]:
         if self.parallel_config.pipeline_parallel_size == 1 or self.rank == 0:
             intermediate_tensors = None
         else:
@@ -342,7 +351,11 @@ class TPUWorker:
 
     def sample_tokens(self,
                       grammar_output: GrammarOutput) -> ModelRunnerOutput:
-        return self.model_runner.sample_tokens(grammar_output)
+        try:
+            return self.model_runner.sample_tokens(grammar_output)
+        except Exception as e:
+            logger.error(f"Error sampling tokens: {e}")
+            raise e
 
     def take_draft_token_ids(self) -> Optional[DraftTokenIds]:
         return self.model_runner.take_draft_token_ids()


### PR DESCRIPTION
# Description

When exception happens in worker, executor might just [capture it](https://github.com/vllm-project/vllm/blob/7967e854da4868872b4b13d2b7f039061fee50fe/vllm/v1/executor/uniproc_executor.py#L94) and, if another error occurs before this exception is thrown, it's hard to know the real exception.

This PR adds error logging

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
