### PR TITLE
Restrict multi-host.yml to v7 as it doesn't run on v6

### DIFF
--- a/.buildkite/scripts/upload_models_and_features.sh
+++ b/.buildkite/scripts/upload_models_and_features.sh
@@ -88,7 +88,9 @@ for folder_path in "${TARGET_FOLDERS[@]}"; do
     yml_content=$(grep -v "^steps:" "${yml_file}")
 
     # Store the content for both hardware types
-    pipeline_v6e_fragments+=("${yml_content}")
+    if [[ "$subject_name" != "multi-host" ]]; then
+      pipeline_v6e_fragments+=("${yml_content}")
+    fi
     pipeline_v7x_fragments+=("${yml_content}")
 
   done < <(find "$folder" -maxdepth 1 -type f \( -name "*.yml" -o -name "*.yaml" \) -print0)


### PR DESCRIPTION
# Description

The current default TPU_VERSION for the CI template generation is v6 ([link](https://github.com/vllm-project/tpu-inference/blob/7607f56b4c31198824b80f9df28c12435abb2daf/.buildkite/pipeline_generation/feature_template.yml#L18)), multi-host.yml changes it to v7 ([link](https://github.com/vllm-project/tpu-inference/blob/main/.buildkite/features/multi-host.yml#L18)), leading it to a duplicate buildkite key causing pipeline upload to fail: https://screenshot.googleplex.com/5bJyEzZxxW5AdA6

This PR skips the mult-host.yml on v6 as it is only supported on v7 TPU. 

# Tests
https://buildkite.com/tpu-commons/tpu-inference-ci/builds/10760#019c72cb-9906-4dd5-bce1-8826218587c5


# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
