### PR TITLE
[JAX] Add option to re-layout q-projection as NDH/NHD for Qwen3

### DIFF
--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -62,6 +62,7 @@ def test_boolean_env_vars(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv("NEW_MODEL_DESIGN", "0")
     monkeypatch.setenv("ENABLE_QUANTIZED_MATMUL_KERNEL", "0")
     monkeypatch.setenv("USE_MOE_EP_KERNEL", "0")
+    monkeypatch.setenv("LAYOUT_Q_PROJ_AS_NDH", "0")
 
     # Test SKIP_JAX_PRECOMPILE (default False)
     assert envs.SKIP_JAX_PRECOMPILE is False
@@ -91,6 +92,11 @@ def test_boolean_env_vars(monkeypatch: pytest.MonkeyPatch):
     assert envs.ENABLE_QUANTIZED_MATMUL_KERNEL is False
     monkeypatch.setenv("ENABLE_QUANTIZED_MATMUL_KERNEL", "1")
     assert envs.ENABLE_QUANTIZED_MATMUL_KERNEL is True
+
+    # Test LAYOUT_Q_PROJ_AS_NDH (default False)
+    assert envs.LAYOUT_Q_PROJ_AS_NDH is False
+    monkeypatch.setenv("LAYOUT_Q_PROJ_AS_NDH", "1")
+    assert envs.LAYOUT_Q_PROJ_AS_NDH is True
 
 
 def test_boolean_env_vars_string_values(monkeypatch: pytest.MonkeyPatch):

--- a/tpu_inference/envs.py
+++ b/tpu_inference/envs.py
@@ -31,6 +31,7 @@ if TYPE_CHECKING:
     REQUANTIZE_WEIGHT_DTYPE: str = "float8_e4m3fn"
     MOE_REQUANTIZE_BLOCK_SIZE: int | None = None
     MOE_REQUANTIZE_WEIGHT_DTYPE: str = "float8_e4m3fn"
+    LAYOUT_Q_PROJ_AS_NDH: bool = False
 
 
 def env_with_choices(
@@ -184,6 +185,10 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "MOE_REQUANTIZE_BLOCK_SIZE":
     lambda: int(block_size) if (block_size := os.getenv(
         "MOE_REQUANTIZE_BLOCK_SIZE")) is not None else None,
+    # dictates whether to layout q-proj as NDH (q-heads, model dim, head dim)
+    # or DNH (model dim, q-heads, head dim), which is the default (False)
+    "LAYOUT_Q_PROJ_AS_NDH":
+    lambda: bool(int(os.getenv("LAYOUT_Q_PROJ_AS_NDH") or "0")),
 }
 
 

--- a/tpu_inference/models/jax/utils/weight_utils.py
+++ b/tpu_inference/models/jax/utils/weight_utils.py
@@ -796,11 +796,20 @@ class JaxAutoWeightsLoader(AutoWeightsLoader):
                 # beyond standard transformers, please consider setting weight_loader.
                 reshape_dims = None
                 permute_dims = None
-                if any(substr in name for substr in
-                       ["q_proj.weight", "k_proj.weight", "v_proj.weight"]):
+                if any(substr in name
+                       for substr in ["k_proj.weight", "v_proj.weight"]):
                     D, N, H = param.value.shape
                     reshape_dims = (N, H, D)
                     permute_dims = (2, 0, 1)
+                if any(substr in name for substr in ["q_proj.weight"]):
+                    if envs.LAYOUT_Q_PROJ_AS_NDH:
+                        N, D, H = param.value.shape
+                        reshape_dims = (N, H, D)
+                        permute_dims = (0, 2, 1)
+                    else:
+                        D, N, H = param.value.shape
+                        reshape_dims = (N, H, D)
+                        permute_dims = (2, 0, 1)
                 elif any(substr in name for substr in
                          ["q_proj.bias", "k_proj.bias", "v_proj.bias"]):
                     N, H = param.value.shape


### PR DESCRIPTION
# Description

In this PR, I add an option to load the Qwen3 Q-Proj as `(self.num_heads, self.hidden_size, self.head_dim)` in the case that the `LAYOUT_Q_PROJ_AS_NDH` is `True/1`.  Otherwise, we default to the current layout of `(self.hidden_size, self.num_heads, self.head_dim)` 

# Tests


## Perf
CMDS:
```
# Server
# NOTE: add LAYOUT_Q_PROJ_AS_NDH=1  for NDH layout
vllm serve Qwen/Qwen3-32B --max-model-le n=5120 --max-num-seqs=256  --disable-log-requests --tensor-parallel-size 2 --max-num-batched-tokens 4096 --no-enable-prefix-caching --additional _config='{"quantization": { "qwix": { "rules": [{ "module_path": ".*", "weight_qtype": "float8_e4m3fn", "act_qtype": "float8_e4m3fn"}]}}}' --kv- cache-dtype=fp8 --gpu-memory-utilization=0.98 --async-scheduling

# Client
vllm bench serve --backend vllm --model Qwen/Qwen3-32B --dataset-name custom --dataset-path  /mnt/disks/jacobplatin/gpu-dataset/bench-dataset-copy/Qwen3-32B/inlen1024_outlen4096_prefixlen0.jsonl --num-prompts 256 --custom-output-len 4096 --ignore-eos --skip-chat-template --temperature=0
```


Default (laid out as `DNH`, what we use now):
```
============ Serving Benchmark Result ============
Successful requests:                     256       
Failed requests:                         0         
Benchmark duration (s):                  219.62    
Total input tokens:                      261616    
Total generated tokens:                  1048576   
Request throughput (req/s):              1.17      
Output token throughput (tok/s):         4774.44   
Peak output token throughput (tok/s):    6400.00   
Peak concurrent requests:                256.00    
Total token throughput (tok/s):          5965.64   
---------------Time to First Token----------------
Mean TTFT (ms):                          7396.45   
Median TTFT (ms):                        7297.32   
P99 TTFT (ms):                           14499.64  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          50.69     
Median TPOT (ms):                        50.82     
P99 TPOT (ms):                           51.49     
---------------Inter-token Latency----------------
Mean ITL (ms):                           50.69     
Median ITL (ms):                         41.86     
P99 ITL (ms):                            216.77    
==================================================

```

Default (laid out as `NDH`, what we use now):
```
============ Serving Benchmark Result ============
Successful requests:                     256       
Failed requests:                         0         
Benchmark duration (s):                  214.78    
Total input tokens:                      261616    
Total generated tokens:                  1048576   
Request throughput (req/s):              1.19      
Output token throughput (tok/s):         4882.12   
Peak output token throughput (tok/s):    6656.00   
Peak concurrent requests:                256.00    
Total token throughput (tok/s):          6100.20   
---------------Time to First Token----------------
Mean TTFT (ms):                          7567.34   
Median TTFT (ms):                        7467.49   
P99 TTFT (ms):                           15006.52  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          49.60     
Median TPOT (ms):                        49.75     
P99 TPOT (ms):                           50.46     
---------------Inter-token Latency----------------
Mean ITL (ms):                           49.60     
Median ITL (ms):                         40.74     
P99 ITL (ms):                            224.38    
==================================================
```


## Quality

CMDS:
```
# Server
# NOTE: add LAYOUT_Q_PROJ_AS_NDH=1  for NDH layout
vllm serve Qwen/Qwen3-32B --max-model-le n=2048 --max-num-seqs=256  --disable-log-requests --tensor-parallel-size 2 --max-num-batched-tokens 4096 --no-enable-prefix-caching --additional _config='{"quantization": { "qwix": { "rules": [{ "module_path": ".*", "weight_qtype": "float8_e4m3fn", "act_qtype": "float8_e4m3fn"}]}}}' --kv- cache-dtype=fp8 --gpu-memory-utilization=0.98 --async-scheduling


# Client
python scripts/vllm/benchmarking/benchmark_serving.py     --backend vllm     --model Qwen/Qwen3-32B    --dataset-name mmlu     --dataset-path /mnt/disks/jacobplatin/mmlu/data/test/     --num-prompts 14042     --run_eval --mmlu-output-len 3
```


NDH:
{'accuracy': 0.8158, 'gen_num': 14042}


DNH:
{'accuracy': 0.8158, 'gen_num': 14042}


# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
