### PR TITLE
[Bugfix] Fixed a bug in multihost CI testing script

### DIFF
--- a/.buildkite/features/multi-host.yml
+++ b/.buildkite/features/multi-host.yml
@@ -48,7 +48,7 @@ steps:
           "
   - label: "${TPU_VERSION:-tpu7x} Record correctness test result for multi-host"
     key: "${TPU_VERSION:-tpu7x}_record_multi-host_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu7x}_record_multi-host_CorrectnessTest"
+    depends_on: "${TPU_VERSION:-tpu7x}_multi-host_CorrectnessTest"
     env:
       CI_TPU_VERSION: "${TPU_VERSION:-tpu7x}"
       CI_TARGET: "multi-host"

--- a/.buildkite/scripts/run_multihost.sh
+++ b/.buildkite/scripts/run_multihost.sh
@@ -209,14 +209,15 @@ bash "${TOP_DIR}/scripts/multihost/run_cluster.sh" \
   -e MODEL_IMPL_TYPE=vllm \
   -e VLLM_DISABLE_SHARED_EXPERTS_STREAM=1 &
 
-sleep 5
+sleep 20
 
 # 2. Distribute run_cluster.sh to workers and start them
 IFS=',' read -r -a WORKER_IPS_ARRAY <<< "${WORKER_IPS}"
 for worker_ip in "${WORKER_IPS_ARRAY[@]}"; do
     echo "--- Distributing and starting Ray Worker on ${worker_ip}"
     ssh "${SSH_OPTS[@]}" "${SSH_USER}@${worker_ip}" "mkdir -p ~/tpu-inference/scripts/multihost" || true
-    scp "${SSH_OPTS[@]}" "${TOP_DIR}/scripts/multihost/run_cluster.sh" "${SSH_USER}@${worker_ip}:~/tpu-inference/scripts/multihost/run_cluster.sh"
+    # shellcheck disable=SC2002
+    cat "${TOP_DIR}/scripts/multihost/run_cluster.sh" | ssh "${SSH_OPTS[@]}" "${SSH_USER}@${worker_ip}" "cat > ~/tpu-inference/scripts/multihost/run_cluster.sh"
     
     REMOTE_CMD="bash ~/tpu-inference/scripts/multihost/run_cluster.sh \
       '${DOCKER_IMAGE}' \


### PR DESCRIPTION
# Description

To avoid this error:
```
$ scp -o StrictHostKeyChecking=no -o BatchMode=yes -o UserKnownHostsFile=/dev/null -i /var/lib/buildkite-agent/.ssh/id_rsa /var/lib/buildkite-agent/tpu-inference/scripts/multihost/run_cluster.sh 'buildkite-agent@10.128.0.34:~/tpu-inference/scripts/multihost/run_cluster.sh'    
Warning: Permanently added '10.128.0.34' (ED25519) to the list of known hosts.

scp: sftp_init: parse type: incomplete message
```

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
