### PR TITLE
[Flax] Use `jax.jit` instead of `nnx.jit` + downgrade to Qwix `0.1.2`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ jaxlib==0.8.1
 jaxtyping
 flax==0.12.4
 torchax==0.0.11
-qwix==0.1.5
+qwix==0.1.2
 torchvision==0.24.0
 pathwaysutils
 parameterized

--- a/tests/layers/jax/test_qwix.py
+++ b/tests/layers/jax/test_qwix.py
@@ -219,7 +219,7 @@ class TestApplyQwixQuantization(unittest.TestCase):
                       "Model should be returned as-is.")
         mock_nnx.jit.assert_not_called()
 
-    @patch('tpu_inference.models.common.model_loader.nnx.jit')
+    @patch('tpu_inference.models.common.model_loader.jax.jit')
     def test_quantization_applied_from_dict(self, mock_jit):
         """
         Test that quantization is applied correctly when the config is a dictionary.

--- a/tpu_inference/models/common/model_loader.py
+++ b/tpu_inference/models/common/model_loader.py
@@ -108,7 +108,7 @@ def _get_nnx_model(
         """
         return model_class(vllm_config, rng, mesh)
 
-    @nnx.jit(donate_argnums=(0, ),
+    @jax.jit(donate_argnums=(0, ),
              static_argnames=('use_qwix_on_abstract_model', ))
     def create_jit_model(
             model: nnx.Module,
@@ -160,7 +160,7 @@ def _get_nnx_model(
                                              use_qwix_on_abstract_model=True)
             return jit_model
 
-        @nnx.jit
+        @jax.jit
         def create_sharded_model():
             model = model_class(vllm_config, rng, mesh)
             state = nnx.state(model)

--- a/tpu_inference/models/jax/utils/qwix/qwix_utils.py
+++ b/tpu_inference/models/jax/utils/qwix/qwix_utils.py
@@ -376,7 +376,7 @@ def apply_qwix_quantization(
             qwix_quantize_nnx_model, qwix_config=qwix_config)
         # NOTE: it's REALLY important `qwix_quantize_nnx_model_with_config` is jitted
         # or else you'll run into hanging
-        model_or_model_fn = nnx.jit(
+        model_or_model_fn = jax.jit(
             qwix_quantize_nnx_model_with_config,
             donate_argnums=(0, ),
             static_argnames=(


### PR DESCRIPTION
# Description

We shouldn't be using `nnx.jit` as it is not recommended for vLLM (according to @cgarciae ).  In addition, I temporarily downgrade to Qwix 0.1.2 as 0.1.5 showed 10x slower pre-compilation times.  Tracking bug from @jshin1394 here:

https://b.corp.google.com/issues/485996206

# Tests

Verified Qwen3-32B + Qwix perf on the 1k/4k set:

```
============ Serving Benchmark Result ============
Successful requests:                     1000      
Failed requests:                         0         
Benchmark duration (s):                  856.68    
Total input tokens:                      1022406   
Total generated tokens:                  4096000   
Request throughput (req/s):              1.17      
Output token throughput (tok/s):         4781.22   
Peak output token throughput (tok/s):    6400.00   
Peak concurrent requests:                1000.00   
Total token throughput (tok/s):          5974.67   
---------------Time to First Token----------------
Mean TTFT (ms):                          326105.35 
Median TTFT (ms):                        237335.38 
P99 TTFT (ms):                           667220.75 
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          51.28     
Median TPOT (ms):                        52.41     
P99 TPOT (ms):                           55.59     
---------------Inter-token Latency----------------
Mean ITL (ms):                           51.28     
Median ITL (ms):                         41.77     
P99 ITL (ms):                            229.08    
==================================================
```

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
