### PR TITLE
[Bug Fix] Prefix cache metric logging in DP Scheduler

### DIFF
--- a/tests/core/test_dp_scheduler.py
+++ b/tests/core/test_dp_scheduler.py
@@ -256,8 +256,8 @@ class TestDPScheduler:
                 scheduler.output_queues = {
                     (0, "get_token_count"): mock_queue_get_token_0,
                     (1, "get_token_count"): mock_queue_get_token_1,
-                    (0, "get_computed_blocks"): mock_queue_computed_0,
-                    (1, "get_computed_blocks"): mock_queue_computed_1,
+                    (0, "probe_computed_blocks"): mock_queue_computed_0,
+                    (1, "probe_computed_blocks"): mock_queue_computed_1,
                 }
 
                 rank = scheduler._find_best_rank_for_request(mock_request)
@@ -298,8 +298,8 @@ class TestDPScheduler:
                 scheduler.output_queues = {
                     (0, "get_token_count"): mock_queue_get_token_0,
                     (1, "get_token_count"): mock_queue_get_token_1,
-                    (0, "get_computed_blocks"): mock_queue_computed_0,
-                    (1, "get_computed_blocks"): mock_queue_computed_1,
+                    (0, "probe_computed_blocks"): mock_queue_computed_0,
+                    (1, "probe_computed_blocks"): mock_queue_computed_1,
                 }
 
                 rank = scheduler._find_best_rank_for_request(mock_request)

--- a/tpu_inference/core/sched/dp_scheduler.py
+++ b/tpu_inference/core/sched/dp_scheduler.py
@@ -57,7 +57,7 @@ class SchedulerCommand(Enum):
     HAS_FINISHED_REQUESTS = "has_finished_requests"
     GET_REQUEST_COUNTS = "get_request_counts"
     GET_TOKEN_COUNT = "get_token_count"
-    GET_COMPUTED_BLOCKS = "get_computed_blocks"
+    PROBE_COMPUTED_BLOCKS = "probe_computed_blocks"
     RESET_ENCODER_CACHE = "reset_encoder_cache"
     SHUTDOWN = "shutdown"
 
@@ -214,13 +214,18 @@ def _scheduler_worker_process(
                         total_tokens += len(req.all_token_ids)
                     output_queues[command.value].put(total_tokens)
 
-                case SchedulerCommand.GET_COMPUTED_BLOCKS:
+                case SchedulerCommand.PROBE_COMPUTED_BLOCKS:
+                    # Probe for cached blocks without recording prefix cache stats.
                     request = data
-                    blocks, cached_tokens = scheduler.kv_cache_manager.get_computed_blocks(
-                        request)
-                    # Only return cached_tokens, not blocks, to avoid circular reference issues
-                    # The blocks object contains a linked list structure that can cause recursion errors during pickling
-                    output_queues[command.value].put(cached_tokens)
+                    kv_cache_mgr = scheduler.kv_cache_manager
+                    if not kv_cache_mgr.enable_caching or request.skip_reading_prefix_cache:
+                        output_queues[command.value].put(0)
+                    else:
+                        max_cache_hit_length = request.num_tokens - 1
+                        _, num_cached_tokens = (
+                            kv_cache_mgr.coordinator.find_longest_cache_hit(
+                                request.block_hashes, max_cache_hit_length))
+                        output_queues[command.value].put(num_cached_tokens)
 
                 case SchedulerCommand.SHUTDOWN:
                     logger.info(f"Rank {rank}: Shutting down")
@@ -402,16 +407,16 @@ class DPScheduler(SchedulerInterface):
         """Find the best DP rank for a new request based on load balancing."""
         rank_tokens = self._get_rank_token_counts()
 
-        # First, try to find a rank with prefix cache hit
+        # First, try to find a rank with prefix cache hit.
         for rank in range(self.dp_size):
             self.input_queues[rank].put(
-                (SchedulerCommand.GET_COMPUTED_BLOCKS, request))
+                (SchedulerCommand.PROBE_COMPUTED_BLOCKS, request))
 
         best_cache_rank = None
         best_cache_tokens = 0
         for rank in range(self.dp_size):
             cached_tokens = self._get_result_from_queue(
-                rank, SchedulerCommand.GET_COMPUTED_BLOCKS)
+                rank, SchedulerCommand.PROBE_COMPUTED_BLOCKS)
             if cached_tokens > best_cache_tokens:
                 best_cache_tokens = cached_tokens
                 best_cache_rank = rank
@@ -562,6 +567,75 @@ class DPScheduler(SchedulerInterface):
             num_output_tokens=combined_num_output_tokens,
         )
 
+    def _combine_scheduler_stats(
+        self,
+        rank_stats_list: List[Optional[SchedulerStats]],
+    ) -> Optional[SchedulerStats]:
+        """Combine SchedulerStats from all DP rank schedulers.
+
+        The per-rank stats are extracted from the workers' update_from_output
+        results, where the base scheduler's make_stats() already collected
+        and reset the prefix cache stats.
+        """
+        total_running_reqs = 0
+        total_waiting_reqs = 0
+        total_kv_cache_usage = 0.0
+
+        combined_prefix_cache_stats = PrefixCacheStats()
+        combined_connector_prefix_cache_stats: Optional[
+            PrefixCacheStats] = None
+        has_any_stats = False
+
+        for rank_stats in rank_stats_list:
+            if rank_stats is None:
+                continue
+            has_any_stats = True
+
+            total_running_reqs += rank_stats.num_running_reqs
+            total_waiting_reqs += rank_stats.num_waiting_reqs
+            total_kv_cache_usage += rank_stats.kv_cache_usage
+
+            # Combine prefix cache stats
+            if rank_stats.prefix_cache_stats:
+                combined_prefix_cache_stats.reset = (
+                    combined_prefix_cache_stats.reset
+                    or rank_stats.prefix_cache_stats.reset)
+                combined_prefix_cache_stats.requests += (
+                    rank_stats.prefix_cache_stats.requests)
+                combined_prefix_cache_stats.queries += (
+                    rank_stats.prefix_cache_stats.queries)
+                combined_prefix_cache_stats.hits += (
+                    rank_stats.prefix_cache_stats.hits)
+
+            # Combine connector prefix cache stats
+            if rank_stats.connector_prefix_cache_stats:
+                if combined_connector_prefix_cache_stats is None:
+                    combined_connector_prefix_cache_stats = PrefixCacheStats()
+                combined_connector_prefix_cache_stats.reset = (
+                    rank_stats.connector_prefix_cache_stats.reset)
+                combined_connector_prefix_cache_stats.requests += (
+                    rank_stats.connector_prefix_cache_stats.requests)
+                combined_connector_prefix_cache_stats.queries += (
+                    rank_stats.connector_prefix_cache_stats.queries)
+                combined_connector_prefix_cache_stats.hits += (
+                    rank_stats.connector_prefix_cache_stats.hits)
+
+        if not has_any_stats:
+            return None
+
+        # Average KV cache usage across ranks
+        num_ranks = len(rank_stats_list)
+        avg_kv_cache_usage = (total_kv_cache_usage /
+                              num_ranks if num_ranks else 0.0)
+
+        return SchedulerStats(
+            num_running_reqs=total_running_reqs,
+            num_waiting_reqs=total_waiting_reqs,
+            kv_cache_usage=avg_kv_cache_usage,
+            prefix_cache_stats=combined_prefix_cache_stats,
+            connector_prefix_cache_stats=combined_connector_prefix_cache_stats,
+        )
+
     def get_grammar_bitmask(
         self,
         scheduler_output: DPSchedulerOutput,
@@ -627,16 +701,25 @@ class DPScheduler(SchedulerInterface):
                  (rank_scheduler_outputs[rank], rank_model_outputs[rank])))
 
         combined_engine_outputs = defaultdict(list)
+        rank_scheduler_stats: List[Optional[SchedulerStats]] = []
         for rank in range(self.dp_size):
             rank_engine_outputs = self._get_result_from_queue(
                 rank, SchedulerCommand.UPDATE_FROM_OUTPUT)
+            rank_stats = None
             for client_idx, engine_output in rank_engine_outputs.items():
                 combined_engine_outputs[client_idx].append(engine_output)
+                if engine_output.scheduler_stats is not None:
+                    rank_stats = engine_output.scheduler_stats
+            rank_scheduler_stats.append(rank_stats)
+
+        # Combine scheduler stats from all DP ranks
+        combined_stats = self._combine_scheduler_stats(rank_scheduler_stats)
 
         # Clean up finished requests from DP tracking
         self._cleanup_finished_requests(scheduler_output.finished_req_ids)
 
         # Return combined EngineCoreOutput
+        stats_attached = False
         for client_idx, engine_outputs in combined_engine_outputs.items():
             combined_output = EngineCoreOutputs()
             outputs = []
@@ -648,7 +731,11 @@ class DPScheduler(SchedulerInterface):
             combined_output.engine_index = engine_outputs[0].engine_index
             combined_output.outputs = outputs
             combined_output.finished_requests = finished_requests
-            combined_output.scheduler_stats = self.make_stats()
+            # Attach combined stats to only the first client output
+            # (matching the base scheduler behavior)
+            if not stats_attached and combined_stats is not None:
+                combined_output.scheduler_stats = combined_stats
+                stats_attached = True
             combined_engine_outputs[client_idx] = combined_output
 
         return combined_engine_outputs


### PR DESCRIPTION
# Description

Previous prefix cache metric in the DP scheduler already reported 0% log rate despite prefix caching being functionality correct. This PR fixes this issue. 

There were two bugs: 

Bug 1 — Double stats reset:` update_from_output()` called `self.make_stats()`, which dispatched `MAKE_STATS` to worker processes. However, each worker's base `Scheduler.update_from_output()` already calls `make_stats()` internally, which reads and resets `kv_cache_manager.prefix_cache_stats`. The DPScheduler's second `make_stats()` call therefore always received empty (zeroed) stats.

Bug 2 — Phantom stats inflation: `_find_best_rank_for_request()` called `GET_COMPUTED_BLOCKS` on all workers to probe for cache hits during load balancing. Each call to `kv_cache_manager.get_computed_blocks()` records prefix cache stats as a side effect, adding (dp_size - 1) phantom stat entries per request with hits=0 but queries=N, inflating the denominator and deflating the hit rate.


# Tests

Updated unit tests. 

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
