### PR TITLE
Restore accidentally deleted line to fix pypi test on CI

### DIFF
--- a/docker/Dockerfile.pypi
+++ b/docker/Dockerfile.pypi
@@ -47,6 +47,7 @@ RUN  --mount=type=cache,target=/root/.cache/pip if [ "$IS_TEST" = "true" ]; then
         pip install -r requirements_test.txt --retries 3; \
     fi
 
+COPY . .
 # Build tpu_inference
 RUN python3 -m pip install build
 RUN python3 -m build


### PR DESCRIPTION
# Description

The PyPI test on CI is failing ([link](https://screenshot.googleplex.com/9rPcsANvTEWL2hh)) because #1734 accidentally deleted one more line ([link](https://screenshot.googleplex.com/AvhRPeyd57VGNy6)) in Dockerfile.pypi. This PR restores the line to fix the issue. 

# Tests

Verified locally. 

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
