### PR TITLE
Fix Value tensor dtype mismatch in Qwen3 attention.

### DIFF
--- a/tpu_inference/models/jax/qwen3.py
+++ b/tpu_inference/models/jax/qwen3.py
@@ -159,6 +159,7 @@ class Qwen3Attention(JaxModule):
 
         # v: (T, K, H)
         v = self.v_proj(x)
+        v = v.astype(k.dtype)
         # o: (T, N, H)
         q_scale = k_scale = v_scale = None
         if self.kv_cache_quantized_dtype:


### PR DESCRIPTION
# Description

This PR casts the value tensor (v) to match the key tensor (k)'s data type in Qwen3Attention before passing it to the vLLM ragged paged attention kernel.

Currently, running inference or evaluation with Qwen3 models crashes with the following error:
```
File tpu_inference/kernels/ragged_paged_attention/v3/kernel.py:1261, in static_validate_inputs(queries, keys, values, kv_cache, kv_lens, page_indices, cu_q_lens, distribution, sm_scale, sliding_window, soft_cap, mask_value, q_scale, k_scale, v_scale, chunk_prefill_size, num_kv_pages_per_block, num_queries_per_block, vmem_limit_bytes, debug_mode)
   1259 # Note: we expect the kv quantization happens outside of the RPA kernel.
   1260 if not (kv_cache.dtype == k.dtype == v.dtype):
-> 1261     raise ValueError(
   1262         f"Expected {kv_cache.dtype=} to be equal to {k.dtype=} and {v.dtype=}."
   1263     )
   1264 # Integer kv quantization is currently not supported.
   1265 if not jnp.issubdtype(kv_cache.dtype, jnp.floating):

ValueError: Expected kv_cache.dtype=dtype(bfloat16) to be equal to k.dtype=dtype(bfloat16) and v.dtype=dtype('float32').
```

If the change fixes a Github issue, please include a link, e.g.,:
FIXES: b/484414167

# Tests

Validated on maxtext side: [script](https://github.com/AI-Hypercomputer/maxtext/blob/main/src/maxtext/examples/sft_qwen3_demo.ipynb)

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
