### PR TITLE
Add sm_scale to the attention interface

### DIFF
--- a/tpu_inference/layers/common/attention_interface.py
+++ b/tpu_inference/layers/common/attention_interface.py
@@ -372,6 +372,7 @@ def attention(
     attention_metadata: AttentionMetadata,
     mesh: Mesh,
     head_dim_original: int | None = None,  # before padding,
+    sm_scale: float | None = None,
     attention_chunk_size: int | None = None,
     q_scale: float | None = None,
     k_scale: float | None = None,
@@ -393,6 +394,9 @@ def attention(
     if head_dim_original is None:
         head_dim_original = q.shape[-1]
 
+    if sm_scale is None:
+        sm_scale = head_dim_original**-0.5
+
     md = attention_metadata
 
     # (T, N, H)
@@ -407,7 +411,7 @@ def attention(
         md.query_start_loc,
         md.request_distribution,
         sinks,
-        sm_scale=head_dim_original**-0.5,
+        sm_scale=sm_scale,
         attention_chunk_size=attention_chunk_size,
         q_scale=q_scale,
         k_scale=k_scale,


### PR DESCRIPTION
# Description

Gemma models use specific `sm_scale`, which need to update the current interface to the model.

# Tests

Tested offline with `python examples/offline_inference.py` on a few models.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
