### PR TITLE
[Bug fix] Fix buffer donation issue in JAX model creation

### DIFF
--- a/tpu_inference/models/common/model_loader.py
+++ b/tpu_inference/models/common/model_loader.py
@@ -108,7 +108,7 @@ def _get_nnx_model(
         """
         return model_class(vllm_config, rng, mesh)
 
-    @jax.jit(donate_argnums=(0, ),
+    @nnx.jit(donate_argnums=(0, ),
              static_argnames=('use_qwix_on_abstract_model', ))
     def create_jit_model(
             model: nnx.Module,


### PR DESCRIPTION
# Description

Fixes this error introduced by: https://github.com/vllm-project/tpu-inference/pull/1759

```
jax.errors.JaxRuntimeError: INVALID_ARGUMENT: Attempt to donate the same buffer twice in Execute() (flattened argument 992, replica 0, partition 7, first use: 991). Toy example for this bug: `f(donate(a), donate(a))`.: while running replica 0 and partition 0 of a replicated computation (other replicas may have failed as well).
```

# Tests

Tested previously failing command and validated it now passes:

```
python examples/offline_inference.py`

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
