### PR TITLE
[Qwen2][Fix] Fix test: call `init_pp_distributed_environment` at beginning

### DIFF
--- a/tests/models/jax/test_qwen2.py
+++ b/tests/models/jax/test_qwen2.py
@@ -23,6 +23,8 @@ from jax.sharding import Mesh
 from vllm.config import ModelConfig
 from vllm.model_executor.model_loader import LoadConfig, get_model_loader
 
+from tpu_inference.distributed.jax_parallel_state import \
+    init_pp_distributed_environment
 from tpu_inference.layers.common.attention_metadata import AttentionMetadata
 from tpu_inference.models.jax.qwen2 import Qwen2ForCausalLM
 from tpu_inference.runner.kv_cache import create_kv_caches
@@ -109,6 +111,13 @@ class TestQwen2ForCausalLM:
     def test_qwen25_1_5b(self, mock_vllm_config, rng, mesh, mock_model_inputs):
         """Tests model init and model forward for the 8B model variant."""
 
+        init_pp_distributed_environment(
+            ip="",
+            rank=0,
+            world_size=1,
+            device=jax.devices()[0],
+            need_pp=False,
+        )
         # Test model init
         with jax.set_mesh(mesh):
             model = Qwen2ForCausalLM(mock_vllm_config, rng, mesh)


### PR DESCRIPTION
# Description

Otherwise it hits "_PP" not initialized error.

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
