### PR TITLE
Remove v7x dependency workaround

### DIFF
--- a/.buildkite/features/Collective_Communication_Matmul.yml
+++ b/.buildkite/features/Collective_Communication_Matmul.yml
@@ -20,8 +20,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - .buildkite/scripts/run_in_docker.sh python3 -m pytest -s -v /workspace/tpu_inference/tests/kernels/collectives/all_gather_matmul_kernel_test.py
   - label: "${TPU_VERSION:-tpu6e} Record correctness test result for Collective Communication Matmul"
@@ -44,8 +42,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_Collective_Communication_Matmul_PerformanceTest" "unverified"

--- a/.buildkite/features/Hybrid_kvcache.yml
+++ b/.buildkite/features/Hybrid_kvcache.yml
@@ -25,8 +25,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh \

--- a/.buildkite/features/KV_Cache_Host_Offloading.yml
+++ b/.buildkite/features/KV_Cache_Host_Offloading.yml
@@ -20,8 +20,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_KV_Cache_Host_Offloading_CorrectnessTest" "unverified"
@@ -45,8 +43,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_KV_Cache_Host_Offloading_PerformanceTest" "unverified"

--- a/.buildkite/features/LoRA_Torch.yml
+++ b/.buildkite/features/LoRA_Torch.yml
@@ -20,8 +20,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh \
@@ -46,8 +44,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh \

--- a/.buildkite/features/MLA.yml
+++ b/.buildkite/features/MLA.yml
@@ -20,8 +20,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_MLA_CorrectnessTest" "unverified"
@@ -45,8 +43,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_MLA_PerformanceTest" "unverified"

--- a/.buildkite/features/MoE.yml
+++ b/.buildkite/features/MoE.yml
@@ -20,8 +20,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_MoE_CorrectnessTest" "unverified"
@@ -45,8 +43,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_MoE_PerformanceTest" "unverified"

--- a/.buildkite/features/Multimodal_Inputs.yml
+++ b/.buildkite/features/Multimodal_Inputs.yml
@@ -20,8 +20,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - .buildkite/scripts/run_in_docker.sh python3 -m pytest -s -v /workspace/tpu_inference/tests/e2e/test_multi_modal_inference.py
   - label: "${TPU_VERSION:-tpu6e} Record correctness test result for Multimodal Inputs"
@@ -44,8 +42,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/mm_bench.sh
   - label: "${TPU_VERSION:-tpu6e} Record performance test result for Multimodal Inputs"

--- a/.buildkite/features/Out_Of_Tree_Model_Support.yml
+++ b/.buildkite/features/Out_Of_Tree_Model_Support.yml
@@ -20,8 +20,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh \
@@ -48,8 +46,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh \

--- a/.buildkite/features/Quantized_Attention.yml
+++ b/.buildkite/features/Quantized_Attention.yml
@@ -20,8 +20,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_Quantized_Attention_CorrectnessTest" "unverified"
@@ -45,8 +43,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_Quantized_Attention_PerformanceTest" "unverified"

--- a/.buildkite/features/Quantized_KV_Cache.yml
+++ b/.buildkite/features/Quantized_KV_Cache.yml
@@ -20,8 +20,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_Quantized_KV_Cache_CorrectnessTest" "unverified"
@@ -45,8 +43,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_Quantized_KV_Cache_PerformanceTest" "unverified"

--- a/.buildkite/features/Quantized_Matmul.yml
+++ b/.buildkite/features/Quantized_Matmul.yml
@@ -20,8 +20,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_Quantized_Matmul_CorrectnessTest" "unverified"
@@ -45,8 +43,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_Quantized_Matmul_PerformanceTest" "unverified"

--- a/.buildkite/features/Single-Host-P-D-disaggregation.yml
+++ b/.buildkite/features/Single-Host-P-D-disaggregation.yml
@@ -20,8 +20,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh \

--- a/.buildkite/features/Structured_Decoding.yml
+++ b/.buildkite/features/Structured_Decoding.yml
@@ -24,8 +24,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - .buildkite/scripts/run_in_docker.sh python3 -m pytest -s -v /workspace/tpu_inference/tests/e2e/test_structured_decoding.py::test_structured_decoding
   - label: "${TPU_VERSION:-tpu6e} Record correctness test result for structured_decoding"

--- a/.buildkite/features/async_scheduler.yml
+++ b/.buildkite/features/async_scheduler.yml
@@ -20,8 +20,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - .buildkite/scripts/run_in_docker.sh python3 -m pytest -s -v /workspace/tpu_inference/tests/e2e/test_async_scheduler.py::test_async_correctness
   - label: "${TPU_VERSION:-tpu6e} Record correctness test result for async scheduler"
@@ -44,8 +42,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - .buildkite/scripts/run_in_docker.sh python3 -m pytest -s -v /workspace/tpu_inference/tests/e2e/test_async_scheduler.py::test_performance
   - label: "${TPU_VERSION:-tpu6e} Record performance test result for async scheduler"

--- a/.buildkite/features/multi-host.yml
+++ b/.buildkite/features/multi-host.yml
@@ -66,8 +66,6 @@ steps:
     soft_fail: true
     agents:
       queue: tpu_v7x_16_queue
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - buildkite-agent meta-data set "${TPU_VERSION:-tpu7x}_multi-host_PerformanceTest" "unverified"
   - label: "${TPU_VERSION:-tpu7x} Record performance test result for multi-host"

--- a/.buildkite/features/runai_model_streamer_loader.yml
+++ b/.buildkite/features/runai_model_streamer_loader.yml
@@ -25,8 +25,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - .buildkite/scripts/run_in_docker.sh python3 -m pytest -s -v /workspace/tpu_inference/tests/e2e/test_runai_model_streamer_loader.py::test_correctness_jax_uni_proc_executor
   - label: "${TPU_VERSION:-tpu6e} Record Result | JAX UniProcExecutor"
@@ -47,8 +45,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - .buildkite/scripts/run_in_docker.sh python3 -m pytest -s -v /workspace/tpu_inference/tests/e2e/test_runai_model_streamer_loader.py::test_correctness_torchax_uni_proc_executor
   - label: "${TPU_VERSION:-tpu6e} Record Result | Torchax UniProcExecutor"
@@ -69,8 +65,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}" # Using a queue with more devices for distributed tests
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - .buildkite/scripts/run_in_docker.sh python3 -m pytest -s -v /workspace/tpu_inference/tests/e2e/test_runai_model_streamer_loader.py::test_correctness_torchax_ray_distributed_executor
   - label: "${TPU_VERSION:-tpu6e} Record Result | Torchax RayDistributedExecutor"

--- a/.buildkite/features/sampling_params.yml
+++ b/.buildkite/features/sampling_params.yml
@@ -22,8 +22,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - .buildkite/scripts/run_in_docker.sh python3 -m pytest -s -v /workspace/tpu_inference/tests/e2e/test_sampling_params.py
   - label: "${TPU_VERSION:-tpu6e} Record correctness test result for sampling_params"

--- a/.buildkite/kernel_microbenchmarks/all_gather_matmul/w16a16.yml
+++ b/.buildkite/kernel_microbenchmarks/all_gather_matmul/w16a16.yml
@@ -20,8 +20,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_all-gather-matmul-w16a16_CorrectnessTest" "unverified"
@@ -45,8 +43,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_all-gather-matmul-w16a16_PerformanceTest" "unverified"

--- a/.buildkite/kernel_microbenchmarks/all_gather_matmul/w4a16.yml
+++ b/.buildkite/kernel_microbenchmarks/all_gather_matmul/w4a16.yml
@@ -20,8 +20,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_all-gather-matmul-w4a16_CorrectnessTest" "unverified"
@@ -45,8 +43,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_all-gather-matmul-w4a16_PerformanceTest" "unverified"

--- a/.buildkite/kernel_microbenchmarks/all_gather_matmul/w4a4.yml
+++ b/.buildkite/kernel_microbenchmarks/all_gather_matmul/w4a4.yml
@@ -20,8 +20,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_all-gather-matmul-w4a4_CorrectnessTest" "unverified"
@@ -45,8 +43,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_all-gather-matmul-w4a4_PerformanceTest" "unverified"

--- a/.buildkite/kernel_microbenchmarks/all_gather_matmul/w4a8.yml
+++ b/.buildkite/kernel_microbenchmarks/all_gather_matmul/w4a8.yml
@@ -20,8 +20,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_all-gather-matmul-w4a8_CorrectnessTest" "unverified"
@@ -45,8 +43,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_all-gather-matmul-w4a8_PerformanceTest" "unverified"

--- a/.buildkite/kernel_microbenchmarks/all_gather_matmul/w8a16.yml
+++ b/.buildkite/kernel_microbenchmarks/all_gather_matmul/w8a16.yml
@@ -20,8 +20,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_all-gather-matmul-w8a16_CorrectnessTest" "unverified"
@@ -45,8 +43,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_all-gather-matmul-w8a16_PerformanceTest" "unverified"

--- a/.buildkite/kernel_microbenchmarks/all_gather_matmul/w8a8.yml
+++ b/.buildkite/kernel_microbenchmarks/all_gather_matmul/w8a8.yml
@@ -20,8 +20,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_all-gather-matmul-w8a8_CorrectnessTest" "unverified"
@@ -45,8 +43,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_all-gather-matmul-w8a8_PerformanceTest" "unverified"

--- a/.buildkite/kernel_microbenchmarks/for_attention_kernels_KV_cache/w16a16.yml
+++ b/.buildkite/kernel_microbenchmarks/for_attention_kernels_KV_cache/w16a16.yml
@@ -21,8 +21,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_attention_kernels-w16a16_CorrectnessTest" "unverified"
@@ -46,8 +44,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_attention_kernels-w16a16_PerformanceTest" "unverified"

--- a/.buildkite/kernel_microbenchmarks/for_attention_kernels_KV_cache/w4a16.yml
+++ b/.buildkite/kernel_microbenchmarks/for_attention_kernels_KV_cache/w4a16.yml
@@ -21,8 +21,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_attention_kernels-w4a16_CorrectnessTest" "unverified"
@@ -46,8 +44,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_attention_kernels-w4a16_PerformanceTest" "unverified"

--- a/.buildkite/kernel_microbenchmarks/for_attention_kernels_KV_cache/w4a4.yml
+++ b/.buildkite/kernel_microbenchmarks/for_attention_kernels_KV_cache/w4a4.yml
@@ -21,8 +21,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_attention_kernels-w4a4_CorrectnessTest" "unverified"
@@ -46,8 +44,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_attention_kernels-w4a4_PerformanceTest" "unverified"

--- a/.buildkite/kernel_microbenchmarks/for_attention_kernels_KV_cache/w4a8.yml
+++ b/.buildkite/kernel_microbenchmarks/for_attention_kernels_KV_cache/w4a8.yml
@@ -21,8 +21,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_attention_kernels-w4a8_CorrectnessTest" "unverified"
@@ -46,8 +44,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_attention_kernels-w4a8_PerformanceTest" "unverified"

--- a/.buildkite/kernel_microbenchmarks/for_attention_kernels_KV_cache/w8a16.yml
+++ b/.buildkite/kernel_microbenchmarks/for_attention_kernels_KV_cache/w8a16.yml
@@ -21,8 +21,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_attention_kernels-w8a16_CorrectnessTest" "unverified"
@@ -46,8 +44,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_attention_kernels-w8a16_PerformanceTest" "unverified"

--- a/.buildkite/kernel_microbenchmarks/for_attention_kernels_KV_cache/w8a8.yml
+++ b/.buildkite/kernel_microbenchmarks/for_attention_kernels_KV_cache/w8a8.yml
@@ -21,8 +21,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_attention_kernels-w8a8_CorrectnessTest" "unverified"
@@ -46,8 +44,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_attention_kernels-w8a8_PerformanceTest" "unverified"

--- a/.buildkite/kernel_microbenchmarks/fused_moe/w16a16.yml
+++ b/.buildkite/kernel_microbenchmarks/fused_moe/w16a16.yml
@@ -20,8 +20,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_fused_moe-w16a16_CorrectnessTest" "unverified"
@@ -45,8 +43,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_fused_moe-w16a16_PerformanceTest" "unverified"

--- a/.buildkite/kernel_microbenchmarks/fused_moe/w4a16.yml
+++ b/.buildkite/kernel_microbenchmarks/fused_moe/w4a16.yml
@@ -20,8 +20,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_fused_moe-w4a16_CorrectnessTest" "unverified"
@@ -45,8 +43,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_fused_moe-w4a16_PerformanceTest" "unverified"

--- a/.buildkite/kernel_microbenchmarks/fused_moe/w4a4.yml
+++ b/.buildkite/kernel_microbenchmarks/fused_moe/w4a4.yml
@@ -20,8 +20,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_fused_moe-w4a4_CorrectnessTest" "unverified"
@@ -45,8 +43,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_fused_moe-w4a4_PerformanceTest" "unverified"

--- a/.buildkite/kernel_microbenchmarks/fused_moe/w4a8.yml
+++ b/.buildkite/kernel_microbenchmarks/fused_moe/w4a8.yml
@@ -20,8 +20,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_fused_moe-w4a8_CorrectnessTest" "unverified"
@@ -45,8 +43,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_fused_moe-w4a8_PerformanceTest" "unverified"

--- a/.buildkite/kernel_microbenchmarks/fused_moe/w8a16.yml
+++ b/.buildkite/kernel_microbenchmarks/fused_moe/w8a16.yml
@@ -20,8 +20,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_fused_moe-w8a16_CorrectnessTest" "unverified"
@@ -45,8 +43,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_fused_moe-w8a16_PerformanceTest" "unverified"

--- a/.buildkite/kernel_microbenchmarks/fused_moe/w8a8.yml
+++ b/.buildkite/kernel_microbenchmarks/fused_moe/w8a8.yml
@@ -20,8 +20,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_fused_moe-w8a8_CorrectnessTest" "unverified"
@@ -45,8 +43,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_fused_moe-w8a8_PerformanceTest" "unverified"

--- a/.buildkite/kernel_microbenchmarks/generic_ragged_paged_attention_v3/w16a16.yml
+++ b/.buildkite/kernel_microbenchmarks/generic_ragged_paged_attention_v3/w16a16.yml
@@ -20,8 +20,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w16a16_CorrectnessTest" "unverified"
@@ -45,8 +43,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w16a16_PerformanceTest" "unverified"

--- a/.buildkite/kernel_microbenchmarks/generic_ragged_paged_attention_v3/w4a16.yml
+++ b/.buildkite/kernel_microbenchmarks/generic_ragged_paged_attention_v3/w4a16.yml
@@ -20,8 +20,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w4a16_CorrectnessTest" "unverified"
@@ -45,8 +43,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w4a16_PerformanceTest" "unverified"

--- a/.buildkite/kernel_microbenchmarks/generic_ragged_paged_attention_v3/w4a4.yml
+++ b/.buildkite/kernel_microbenchmarks/generic_ragged_paged_attention_v3/w4a4.yml
@@ -20,8 +20,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w4a4_CorrectnessTest" "unverified"
@@ -45,8 +43,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w4a4_PerformanceTest" "unverified"

--- a/.buildkite/kernel_microbenchmarks/generic_ragged_paged_attention_v3/w4a8.yml
+++ b/.buildkite/kernel_microbenchmarks/generic_ragged_paged_attention_v3/w4a8.yml
@@ -20,8 +20,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w4a8_CorrectnessTest" "unverified"
@@ -45,8 +43,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w4a8_PerformanceTest" "unverified"

--- a/.buildkite/kernel_microbenchmarks/generic_ragged_paged_attention_v3/w8a16.yml
+++ b/.buildkite/kernel_microbenchmarks/generic_ragged_paged_attention_v3/w8a16.yml
@@ -20,8 +20,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w8a16_CorrectnessTest" "unverified"
@@ -45,8 +43,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w8a16_PerformanceTest" "unverified"

--- a/.buildkite/kernel_microbenchmarks/generic_ragged_paged_attention_v3/w8a8.yml
+++ b/.buildkite/kernel_microbenchmarks/generic_ragged_paged_attention_v3/w8a8.yml
@@ -20,8 +20,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w8a8_CorrectnessTest" "unverified"
@@ -45,8 +43,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w8a8_PerformanceTest" "unverified"

--- a/.buildkite/kernel_microbenchmarks/gmm/w16a16.yml
+++ b/.buildkite/kernel_microbenchmarks/gmm/w16a16.yml
@@ -20,8 +20,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_gmm-w16a16_CorrectnessTest" "unverified"
@@ -45,8 +43,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_gmm-w16a16_PerformanceTest" "unverified"

--- a/.buildkite/kernel_microbenchmarks/gmm/w4a16.yml
+++ b/.buildkite/kernel_microbenchmarks/gmm/w4a16.yml
@@ -20,8 +20,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_gmm-w4a16_CorrectnessTest" "unverified"
@@ -45,8 +43,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_gmm-w4a16_PerformanceTest" "unverified"

--- a/.buildkite/kernel_microbenchmarks/gmm/w4a4.yml
+++ b/.buildkite/kernel_microbenchmarks/gmm/w4a4.yml
@@ -20,8 +20,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_gmm-w4a4_CorrectnessTest" "unverified"
@@ -45,8 +43,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_gmm-w4a4_PerformanceTest" "unverified"

--- a/.buildkite/kernel_microbenchmarks/gmm/w4a8.yml
+++ b/.buildkite/kernel_microbenchmarks/gmm/w4a8.yml
@@ -20,8 +20,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_gmm-w4a8_CorrectnessTest" "unverified"
@@ -45,8 +43,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_gmm-w4a8_PerformanceTest" "unverified"

--- a/.buildkite/kernel_microbenchmarks/gmm/w8a16.yml
+++ b/.buildkite/kernel_microbenchmarks/gmm/w8a16.yml
@@ -20,8 +20,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_gmm-w8a16_CorrectnessTest" "unverified"
@@ -45,8 +43,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_gmm-w8a16_PerformanceTest" "unverified"

--- a/.buildkite/kernel_microbenchmarks/gmm/w8a8.yml
+++ b/.buildkite/kernel_microbenchmarks/gmm/w8a8.yml
@@ -20,8 +20,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_gmm-w8a8_CorrectnessTest" "unverified"
@@ -45,8 +43,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_gmm-w8a8_PerformanceTest" "unverified"

--- a/.buildkite/kernel_microbenchmarks/mla/w16a16.yml
+++ b/.buildkite/kernel_microbenchmarks/mla/w16a16.yml
@@ -20,8 +20,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_mla-w16a16_CorrectnessTest" "unverified"
@@ -45,8 +43,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_mla-w16a16_PerformanceTest" "unverified"

--- a/.buildkite/kernel_microbenchmarks/mla/w4a16.yml
+++ b/.buildkite/kernel_microbenchmarks/mla/w4a16.yml
@@ -20,8 +20,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_mla-w4a16_CorrectnessTest" "unverified"
@@ -45,8 +43,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_mla-w4a16_PerformanceTest" "unverified"

--- a/.buildkite/kernel_microbenchmarks/mla/w4a4.yml
+++ b/.buildkite/kernel_microbenchmarks/mla/w4a4.yml
@@ -20,8 +20,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_mla-w4a4_CorrectnessTest" "unverified"
@@ -45,8 +43,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_mla-w4a4_PerformanceTest" "unverified"

--- a/.buildkite/kernel_microbenchmarks/mla/w4a8.yml
+++ b/.buildkite/kernel_microbenchmarks/mla/w4a8.yml
@@ -20,8 +20,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_mla-w4a8_CorrectnessTest" "unverified"
@@ -45,8 +43,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_mla-w4a8_PerformanceTest" "unverified"

--- a/.buildkite/kernel_microbenchmarks/mla/w8a16.yml
+++ b/.buildkite/kernel_microbenchmarks/mla/w8a16.yml
@@ -20,8 +20,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_mla-w8a16_CorrectnessTest" "unverified"
@@ -45,8 +43,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_mla-w8a16_PerformanceTest" "unverified"

--- a/.buildkite/kernel_microbenchmarks/mla/w8a8.yml
+++ b/.buildkite/kernel_microbenchmarks/mla/w8a8.yml
@@ -20,8 +20,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_mla-w8a8_CorrectnessTest" "unverified"
@@ -45,8 +43,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_mla-w8a8_PerformanceTest" "unverified"

--- a/.buildkite/kernel_microbenchmarks/ragged_paged_attention_v3_head_dim_64/w16a16.yml
+++ b/.buildkite/kernel_microbenchmarks/ragged_paged_attention_v3_head_dim_64/w16a16.yml
@@ -20,8 +20,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w16a16_CorrectnessTest" "unverified"
@@ -45,8 +43,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w16a16_PerformanceTest" "unverified"

--- a/.buildkite/kernel_microbenchmarks/ragged_paged_attention_v3_head_dim_64/w4a16.yml
+++ b/.buildkite/kernel_microbenchmarks/ragged_paged_attention_v3_head_dim_64/w4a16.yml
@@ -20,8 +20,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w4a16_CorrectnessTest" "unverified"
@@ -45,8 +43,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w4a16_PerformanceTest" "unverified"

--- a/.buildkite/kernel_microbenchmarks/ragged_paged_attention_v3_head_dim_64/w4a4.yml
+++ b/.buildkite/kernel_microbenchmarks/ragged_paged_attention_v3_head_dim_64/w4a4.yml
@@ -20,8 +20,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w4a4_CorrectnessTest" "unverified"
@@ -45,8 +43,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w4a4_PerformanceTest" "unverified"

--- a/.buildkite/kernel_microbenchmarks/ragged_paged_attention_v3_head_dim_64/w4a8.yml
+++ b/.buildkite/kernel_microbenchmarks/ragged_paged_attention_v3_head_dim_64/w4a8.yml
@@ -20,8 +20,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w4a8_CorrectnessTest" "unverified"
@@ -45,8 +43,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w4a8_PerformanceTest" "unverified"

--- a/.buildkite/kernel_microbenchmarks/ragged_paged_attention_v3_head_dim_64/w8a16.yml
+++ b/.buildkite/kernel_microbenchmarks/ragged_paged_attention_v3_head_dim_64/w8a16.yml
@@ -20,8 +20,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w8a16_CorrectnessTest" "unverified"
@@ -45,8 +43,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w8a16_PerformanceTest" "unverified"

--- a/.buildkite/kernel_microbenchmarks/ragged_paged_attention_v3_head_dim_64/w8a8.yml
+++ b/.buildkite/kernel_microbenchmarks/ragged_paged_attention_v3_head_dim_64/w8a8.yml
@@ -20,8 +20,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w8a8_CorrectnessTest" "unverified"
@@ -45,8 +43,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w8a8_PerformanceTest" "unverified"

--- a/.buildkite/models/Qwen_Qwen2_5-VL-7B-Instruct.yml
+++ b/.buildkite/models/Qwen_Qwen2_5-VL-7B-Instruct.yml
@@ -19,8 +19,6 @@ steps:
     key: "${TPU_VERSION:-tpu6e}_Qwen_Qwen2_5-VL-7B-Instruct_UnitTest"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     soft_fail: true
     commands:
       - |
@@ -47,7 +45,6 @@ steps:
       queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
     soft_fail: true
     env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
       TEST_MODEL: Qwen/Qwen2.5-VL-7B-Instruct
       TENSOR_PARALLEL_SIZE: 1
       MINIMUM_ACCURACY_THRESHOLD: 0.72
@@ -74,8 +71,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/mm_bench_recipe.sh

--- a/.buildkite/models/Qwen_Qwen3-30B-A3B.yml
+++ b/.buildkite/models/Qwen_Qwen3-30B-A3B.yml
@@ -19,8 +19,6 @@ steps:
     key: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-30B-A3B_UnitTest"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     soft_fail: true
     commands:
       - |
@@ -47,7 +45,6 @@ steps:
       queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
     soft_fail: true
     env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
       TEST_MODEL: Qwen/Qwen3-30B-A3B
       TENSOR_PARALLEL_SIZE: 4
       MINIMUM_ACCURACY_THRESHOLD: 0.89
@@ -75,7 +72,6 @@ steps:
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
     env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
       TEST_MODEL: Qwen/Qwen3-30B-A3B
       TENSOR_PARALLEL_SIZE: 4
       MINIMUM_THROUGHPUT_THRESHOLD: 7.20

--- a/.buildkite/models/Qwen_Qwen3-32B.yml
+++ b/.buildkite/models/Qwen_Qwen3-32B.yml
@@ -20,8 +20,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh \
@@ -47,7 +45,6 @@ steps:
       queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
     soft_fail: true
     env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
       TEST_MODEL: Qwen/Qwen3-32B
       TENSOR_PARALLEL_SIZE: 8
       MINIMUM_ACCURACY_THRESHOLD: 0.74
@@ -75,7 +72,6 @@ steps:
       queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
     soft_fail: true
     env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
       TEST_MODEL: Qwen/Qwen3-32B
       TENSOR_PARALLEL_SIZE: 8
       MINIMUM_THROUGHPUT_THRESHOLD: 12.46

--- a/.buildkite/models/Qwen_Qwen3-4B.yml
+++ b/.buildkite/models/Qwen_Qwen3-4B.yml
@@ -20,8 +20,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh \
@@ -47,7 +45,6 @@ steps:
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
       TEST_MODEL: Qwen/Qwen3-4B
       TENSOR_PARALLEL_SIZE: 1
       MINIMUM_ACCURACY_THRESHOLD: 0.85
@@ -75,7 +72,6 @@ steps:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     soft_fail: true
     env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
       TEST_MODEL: Qwen/Qwen3-4B
       TENSOR_PARALLEL_SIZE: 1
       MINIMUM_THROUGHPUT_THRESHOLD: 11.00

--- a/.buildkite/models/Qwen_Qwen3-Coder-480B-A35B-Instruct.yml
+++ b/.buildkite/models/Qwen_Qwen3-Coder-480B-A35B-Instruct.yml
@@ -19,8 +19,6 @@ steps:
     key: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-Coder-480B-A35B-Instruct_UnitTest"
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     soft_fail: true
     commands:
       - |
@@ -45,8 +43,6 @@ steps:
     depends_on: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen3-Coder-480B-A35B-Instruct_UnitTest"
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     soft_fail: true
     commands:
       - |
@@ -70,8 +66,6 @@ steps:
     depends_on: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen3-Coder-480B-A35B-Instruct_Accuracy"
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     soft_fail: true
     commands:
       - |

--- a/.buildkite/models/Qwen_Qwen3-Omni-30B-A3B-Instruct.yml
+++ b/.buildkite/models/Qwen_Qwen3-Omni-30B-A3B-Instruct.yml
@@ -19,8 +19,6 @@ steps:
     key: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-Omni-30B-A3B-Instruct_UnitTest"
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     soft_fail: true
     commands:
       - |
@@ -44,8 +42,6 @@ steps:
     depends_on: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen3-Omni-30B-A3B-Instruct_UnitTest"
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     soft_fail: true
     commands:
       - |
@@ -69,8 +65,6 @@ steps:
     depends_on: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen3-Omni-30B-A3B-Instruct_Accuracy"
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     soft_fail: true
     commands:
       - |

--- a/.buildkite/models/deepseek-ai_DeepSeek-V3.1.yml
+++ b/.buildkite/models/deepseek-ai_DeepSeek-V3.1.yml
@@ -19,8 +19,6 @@ steps:
     key: "${TPU_VERSION:-tpu6e}_deepseek-ai_DeepSeek-V3_1_UnitTest"
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     soft_fail: true
     commands:
       - |
@@ -44,8 +42,6 @@ steps:
     depends_on: "${TPU_VERSION:-tpu6e}_record_deepseek-ai_DeepSeek-V3_1_UnitTest"
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     soft_fail: true
     commands:
       - |
@@ -69,8 +65,6 @@ steps:
     depends_on: "${TPU_VERSION:-tpu6e}_record_deepseek-ai_DeepSeek-V3_1_Accuracy"
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     soft_fail: true
     commands:
       - |

--- a/.buildkite/models/google_gemma-3-27b-it.yml
+++ b/.buildkite/models/google_gemma-3-27b-it.yml
@@ -19,8 +19,6 @@ steps:
     key: "${TPU_VERSION:-tpu6e}_google_gemma-3-27b-it_UnitTest"
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     soft_fail: true
     commands:
       - |
@@ -47,7 +45,6 @@ steps:
       queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
     soft_fail: true
     env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
       TEST_MODEL: google/gemma-3-27b-it
       TENSOR_PARALLEL_SIZE: 8
       MINIMUM_ACCURACY_THRESHOLD: 0.56
@@ -75,7 +72,6 @@ steps:
       queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
     soft_fail: true
     env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
       TEST_MODEL: google/gemma-3-27b-it
       TENSOR_PARALLEL_SIZE: 8
       MINIMUM_THROUGHPUT_THRESHOLD: 21

--- a/.buildkite/models/meta-llama_Llama-3_1-8B-Instruct.yml
+++ b/.buildkite/models/meta-llama_Llama-3_1-8B-Instruct.yml
@@ -20,8 +20,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh \
@@ -47,7 +45,6 @@ steps:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     soft_fail: true
     env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
       TEST_MODEL: meta-llama/Llama-3.1-8B-Instruct
       TENSOR_PARALLEL_SIZE: 1
       MINIMUM_ACCURACY_THRESHOLD: 0.75
@@ -75,7 +72,6 @@ steps:
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
       TEST_MODEL: meta-llama/Llama-3.1-8B-Instruct
       TENSOR_PARALLEL_SIZE: 1
       MINIMUM_THROUGHPUT_THRESHOLD: 10.77

--- a/.buildkite/models/meta-llama_Llama-3_3-70B-Instruct.yml
+++ b/.buildkite/models/meta-llama_Llama-3_3-70B-Instruct.yml
@@ -20,8 +20,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh \
@@ -47,7 +45,6 @@ steps:
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
     env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
       TEST_MODEL: meta-llama/Llama-3.3-70B-Instruct
       TENSOR_PARALLEL_SIZE: 8
       MINIMUM_ACCURACY_THRESHOLD: 0.90
@@ -75,7 +72,6 @@ steps:
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
     env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
       TEST_MODEL: meta-llama/Llama-3.3-70B-Instruct
       TENSOR_PARALLEL_SIZE: 8
       MINIMUM_THROUGHPUT_THRESHOLD: 7.0

--- a/.buildkite/models/meta-llama_Llama-4-Maverick-17B-128E-Instruct.yml
+++ b/.buildkite/models/meta-llama_Llama-4-Maverick-17B-128E-Instruct.yml
@@ -19,8 +19,6 @@ steps:
     key: "${TPU_VERSION:-tpu6e}_meta-llama_Llama-4-Maverick-17B-128E-Instruct_UnitTest"
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     soft_fail: true
     commands:
       - |
@@ -44,8 +42,6 @@ steps:
     depends_on: "${TPU_VERSION:-tpu6e}_record_meta-llama_Llama-4-Maverick-17B-128E-Instruct_UnitTest"
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     soft_fail: true
     commands:
       - |
@@ -69,8 +65,6 @@ steps:
     depends_on: "${TPU_VERSION:-tpu6e}_record_meta-llama_Llama-4-Maverick-17B-128E-Instruct_Accuracy"
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     soft_fail: true
     commands:
       - |

--- a/.buildkite/models/moonshotai_Kimi-K2-Thinking.yml
+++ b/.buildkite/models/moonshotai_Kimi-K2-Thinking.yml
@@ -19,8 +19,6 @@ steps:
     key: "${TPU_VERSION:-tpu6e}_moonshotai_Kimi-K2-Thinking_UnitTest"
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     soft_fail: true
     commands:
       - |
@@ -44,8 +42,6 @@ steps:
     depends_on: "${TPU_VERSION:-tpu6e}_record_moonshotai_Kimi-K2-Thinking_UnitTest"
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     soft_fail: true
     commands:
       - |
@@ -69,8 +65,6 @@ steps:
     depends_on: "${TPU_VERSION:-tpu6e}_record_moonshotai_Kimi-K2-Thinking_Accuracy"
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     soft_fail: true
     commands:
       - |

--- a/.buildkite/models/openai_gpt-oss-120b.yml
+++ b/.buildkite/models/openai_gpt-oss-120b.yml
@@ -19,8 +19,6 @@ steps:
     key: "${TPU_VERSION:-tpu6e}_openai_gpt-oss-120b_UnitTest"
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     soft_fail: true
     commands:
       - |
@@ -44,8 +42,6 @@ steps:
     depends_on: "${TPU_VERSION:-tpu6e}_record_openai_gpt-oss-120b_UnitTest"
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     soft_fail: true
     commands:
       - |
@@ -69,8 +65,6 @@ steps:
     depends_on: "${TPU_VERSION:-tpu6e}_record_openai_gpt-oss-120b_Accuracy"
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     soft_fail: true
     commands:
       - |

--- a/.buildkite/nightly_releases.yml
+++ b/.buildkite/nightly_releases.yml
@@ -32,23 +32,3 @@ steps:
       - docker-login#v3.0.0:
           username: tpuinference
           password-env: DOCKERHUB_TOKEN
-
-  - label: "Publish vllm/vllm-tpu nightly image for ironwood"
-    if: build.branch == "main" && build.env("NIGHTLY") == "1"
-    agents:
-      queue: cpu
-    secrets:
-      - DOCKERHUB_TOKEN
-    commands:
-      - "DATE=$$(date +%Y%m%d)"
-      - "VLLM_COMMIT_HASH=$$(buildkite-agent meta-data get 'VLLM_COMMIT_HASH')"
-      - "VLLM_SHORT_COMMIT=$${VLLM_COMMIT_HASH:0:7}"
-      - "BUILDKITE_SHORT_COMMIT=$${BUILDKITE_COMMIT:0:7}"
-      - "yes | docker system prune -a"
-      - "docker build --build-arg VLLM_COMMIT_HASH=$$VLLM_COMMIT_HASH --no-cache --build-arg IS_FOR_V7X=true -f docker/Dockerfile -t vllm/vllm-tpu:nightly-ironwood -t vllm/vllm-tpu:nightly-ironwood-$$DATE-$$BUILDKITE_SHORT_COMMIT-$$VLLM_SHORT_COMMIT ."
-      - "docker push vllm/vllm-tpu:nightly-ironwood"
-      - "docker push vllm/vllm-tpu:nightly-ironwood-$$DATE-$$BUILDKITE_SHORT_COMMIT-$$VLLM_SHORT_COMMIT"
-    plugins:
-      - docker-login#v3.0.0:
-          username: tpuinference
-          password-env: DOCKERHUB_TOKEN

--- a/.buildkite/parallelism/CP.yml
+++ b/.buildkite/parallelism/CP.yml
@@ -20,8 +20,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_CP_CorrectnessTest" "unverified"
@@ -45,8 +43,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_CP_PerformanceTest" "unverified"

--- a/.buildkite/parallelism/DP.yml
+++ b/.buildkite/parallelism/DP.yml
@@ -19,7 +19,6 @@ steps:
     key: "${TPU_VERSION:-tpu6e}_DP_CorrectnessTest"
     soft_fail: true
     env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
       NEW_MODEL_DESIGN: "1"
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
@@ -46,7 +45,6 @@ steps:
     depends_on: "${TPU_VERSION:-tpu6e}_record_DP_CorrectnessTest"
     soft_fail: true
     env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
       NEW_MODEL_DESIGN: "1"
     agents:
       queue: tpu_v6e_8_queue

--- a/.buildkite/parallelism/EP.yml
+++ b/.buildkite/parallelism/EP.yml
@@ -20,8 +20,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v7x_8_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh \
@@ -49,8 +47,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v7x_8_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh \

--- a/.buildkite/parallelism/PP.yml
+++ b/.buildkite/parallelism/PP.yml
@@ -20,8 +20,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_PP_CorrectnessTest" "unverified"
@@ -50,8 +48,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_PP_PerformanceTest" "unverified"

--- a/.buildkite/parallelism/SP.yml
+++ b/.buildkite/parallelism/SP.yml
@@ -20,8 +20,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v7x_8_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh \
@@ -46,8 +44,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_SP_PerformanceTest" "unverified"

--- a/.buildkite/parallelism/TP.yml
+++ b/.buildkite/parallelism/TP.yml
@@ -20,8 +20,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh \
@@ -46,8 +44,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh \

--- a/.buildkite/pipeline_generation/feature_template.yml
+++ b/.buildkite/pipeline_generation/feature_template.yml
@@ -20,8 +20,6 @@ steps:
     soft_fail: true
     agents:
       queue: {QUEUE}
-    env:
-      IS_FOR_V7X: "${{IS_FOR_V7X}}"
     commands:
       - echo "placeholder"  # TODO : replace with your correctness test command
   - label: "${{TPU_VERSION:-tpu6e}} Record correctness test result for {FEATURE_NAME}"
@@ -44,8 +42,6 @@ steps:
     soft_fail: true
     agents:
       queue: {QUEUE}
-    env:
-      IS_FOR_V7X: "${{IS_FOR_V7X}}"
     commands:
       - echo "placeholder"  # TODO : replace with your performance test command
   - label: "${{TPU_VERSION:-tpu6e}} Record performance test result for {FEATURE_NAME}"

--- a/.buildkite/pipeline_generation/tpu_optimized_model_template.yml
+++ b/.buildkite/pipeline_generation/tpu_optimized_model_template.yml
@@ -20,8 +20,6 @@ steps:
     soft_fail: true
     agents:
       queue: {QUEUE}
-    env:
-      IS_FOR_V7X: "${{IS_FOR_V7X}}"
     commands:
       - echo "placeholder"  # TODO: replace with your unit test command
   - label: "${{TPU_VERSION:-tpu6e}} Record unit test result for {MODEL_NAME}"
@@ -45,7 +43,6 @@ steps:
     agents:
       queue: {QUEUE}
     env:
-      IS_FOR_V7X: "${{IS_FOR_V7X}}"
       TEST_MODEL: {MODEL_NAME}
       TENSOR_PARALLEL_SIZE: {TENSOR_PARALLEL_SIZE}
       MINIMUM_ACCURACY_THRESHOLD: 0  # TODO : replace 0 with your accuracy threshold
@@ -73,7 +70,6 @@ steps:
     agents:
       queue: {QUEUE}
     env:
-      IS_FOR_V7X: "${{IS_FOR_V7X}}"
       TEST_MODEL: {MODEL_NAME}
       TENSOR_PARALLEL_SIZE: {TENSOR_PARALLEL_SIZE}
       MINIMUM_THROUGHPUT_THRESHOLD: 0  # TODO : replace 0 with your performance threshold

--- a/.buildkite/pipeline_generation/vllm_native_model_template.yml
+++ b/.buildkite/pipeline_generation/vllm_native_model_template.yml
@@ -19,8 +19,6 @@ steps:
     key: "${{TPU_VERSION:-tpu6e}}_{SANITIZED_MODEL_NAME}_UnitTest"
     agents:
       queue: {QUEUE}
-    env:
-      IS_FOR_V7X: "${{IS_FOR_V7X}}"
     soft_fail: true
     commands:
       - echo "placeholder"  # TODO: replace with your unit test command
@@ -45,7 +43,6 @@ steps:
       queue: {QUEUE}
     soft_fail: true
     env:
-      IS_FOR_V7X: "${{IS_FOR_V7X}}"
       TEST_MODEL: {MODEL_NAME}
       TENSOR_PARALLEL_SIZE: {TENSOR_PARALLEL_SIZE}
       MINIMUM_ACCURACY_THRESHOLD: 0  # TODO : replace 0 with your accuracy threshold

--- a/.buildkite/pipeline_jax.yml
+++ b/.buildkite/pipeline_jax.yml
@@ -91,8 +91,6 @@ steps:
       - label: "${TPU_VERSION:-tpu6e} JAX unit tests part1"
         key: ${TPU_VERSION:-tpu6e}_test_7_1
         soft_fail: true
-        env:
-          IS_FOR_V7X: "${IS_FOR_V7X}"
         artifact_paths: ".coverage.part1.${TPU_VERSION:-tpu6e}"
         agents:
           queue: ${TPU_QUEUE_SINGLE:-tpu_v6e_queue}
@@ -105,8 +103,6 @@ steps:
       - label: "${TPU_VERSION:-tpu6e} JAX unit tests part2"
         key: ${TPU_VERSION:-tpu6e}_test_7_2
         soft_fail: true
-        env:
-          IS_FOR_V7X: "${IS_FOR_V7X}"
         artifact_paths: ".coverage.part2.${TPU_VERSION:-tpu6e}"
         agents:
           queue: ${TPU_QUEUE_SINGLE:-tpu_v6e_queue}
@@ -122,8 +118,6 @@ steps:
           - "${TPU_VERSION:-tpu6e}_test_7_2"
         key: ${TPU_VERSION:-tpu6e}_test_7_3
         soft_fail: true
-        env:
-          IS_FOR_V7X: "${IS_FOR_V7X}"
         agents:
           queue: cpu
         commands:
@@ -146,8 +140,6 @@ steps:
       - label: "${TPU_VERSION:-tpu6e} JAX unit tests - kernels"
         key: ${TPU_VERSION:-tpu6e}_test_8
         soft_fail: true
-        env:
-          IS_FOR_V7X: "${IS_FOR_V7X}"
         agents:
           queue: ${TPU_QUEUE_SINGLE:-tpu_v6e_queue}
         commands:
@@ -170,8 +162,6 @@ steps:
       - label: "${TPU_VERSION:-tpu6e} JAX unit tests - collective kernels"
         key: ${TPU_VERSION:-tpu6e}_test_9
         soft_fail: true
-        env:
-          IS_FOR_V7X: "${IS_FOR_V7X}"
         agents:
           queue: ${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}
         commands:
@@ -191,8 +181,6 @@ steps:
       - label: "${TPU_VERSION:-tpu6e} lora e2e tests for JAX + vLLM models single chip"
         key: ${TPU_VERSION:-tpu6e}_test_10
         soft_fail: true
-        env:
-          IS_FOR_V7X: "${IS_FOR_V7X}"
         agents:
           queue: ${TPU_QUEUE_SINGLE:-tpu_v6e_queue}
         if: build.env("NIGHTLY") == "1"
@@ -233,7 +221,6 @@ steps:
         env:
           TEST_LORA_TP: "True"
           VLLM_LOG_LEVEL: "INFO"
-          IS_FOR_V7X: "${IS_FOR_V7X}"
         agents:
           queue: ${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}
         commands:
@@ -242,8 +229,6 @@ steps:
       - label: "${TPU_VERSION:-tpu6e} lora unit tests on single chip"
         key: ${TPU_VERSION:-tpu6e}_test_15
         soft_fail: true
-        env:
-          IS_FOR_V7X: "${IS_FOR_V7X}"
         agents:
           queue: ${TPU_QUEUE_SINGLE:-tpu_v6e_queue}
         commands:
@@ -258,7 +243,6 @@ steps:
         env:
           USE_V6E8_QUEUE: "True"
           VLLM_LOG_LEVEL: "INFO"
-          IS_FOR_V7X: "${IS_FOR_V7X}"
         agents:
           queue: ${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}
         commands:
@@ -409,7 +393,7 @@ steps:
           # 1. Start vLLM with specific model and tensor parallel size
           # 2. Run curl commands against it
           - |
-            if [[ "$IS_FOR_V7X" == "true" ]]; then
+            if [[ "$$IS_FOR_V7X" == "true" ]]; then
               MODEL="gs://tpu-commons-ci/qwen/models--Qwen--Qwen3-30B-A3B/snapshots/ad44e777bcd18fa416d9da3bd8f70d33ebb85d39"
               .buildkite/scripts/run_multihost.sh \
                 "vllm serve \${MODEL} \

--- a/.buildkite/quantization/AWQ_INT4.yml
+++ b/.buildkite/quantization/AWQ_INT4.yml
@@ -20,8 +20,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_AWQ_INT4_CorrectnessTest" "unverified"
@@ -45,8 +43,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_AWQ_INT4_PerformanceTest" "unverified"

--- a/.buildkite/quantization/FP4_W4A16.yml
+++ b/.buildkite/quantization/FP4_W4A16.yml
@@ -20,8 +20,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_FP4_W4A16_CorrectnessTest" "unverified"
@@ -45,8 +43,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_FP4_W4A16_PerformanceTest" "unverified"

--- a/.buildkite/quantization/FP8_W8A16.yml
+++ b/.buildkite/quantization/FP8_W8A16.yml
@@ -20,8 +20,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_FP8_W8A16_CorrectnessTest" "unverified"
@@ -45,8 +43,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_FP8_W8A16_PerformanceTest" "unverified"

--- a/.buildkite/quantization/FP8_W8A8.yml
+++ b/.buildkite/quantization/FP8_W8A8.yml
@@ -20,8 +20,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_FP8_W8A8_CorrectnessTest" "unverified"
@@ -45,8 +43,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_FP8_W8A8_PerformanceTest" "unverified"

--- a/.buildkite/quantization/INT4_W4A16.yml
+++ b/.buildkite/quantization/INT4_W4A16.yml
@@ -20,8 +20,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_INT4_W4A16_CorrectnessTest" "unverified"
@@ -45,8 +43,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_INT4_W4A16_PerformanceTest" "unverified"

--- a/.buildkite/quantization/INT8_W8A8.yml
+++ b/.buildkite/quantization/INT8_W8A8.yml
@@ -20,8 +20,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_INT8_W8A8_CorrectnessTest" "unverified"
@@ -45,8 +43,6 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
-    env:
-      IS_FOR_V7X: "${IS_FOR_V7X}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_INT8_W8A8_PerformanceTest" "unverified"

--- a/.buildkite/scripts/setup_docker_env.sh
+++ b/.buildkite/scripts/setup_docker_env.sh
@@ -85,7 +85,6 @@ setup_environment() {
   # Build with specific hash and 'latest' tag for convenience
   docker build \
       --build-arg VLLM_COMMIT_HASH="${VLLM_COMMIT_HASH}" \
-      --build-arg IS_FOR_V7X="${IS_FOR_V7X:-false}" \
       --build-arg IS_TEST="true" \
       --no-cache -f docker/"${DOCKERFILE_NAME}" \
       -t "${IMAGE_NAME}:${TPU_INFERENCE_HASH}" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,6 @@ jobs:
     - name: Build package (sdist and wheel)
       env:
           VLLM_VERSION_OVERRIDE: ${{ steps.vars.outputs.VERSION }}
-          IS_FOR_V7X: "true"
       run: python3 -m build
 
     - name: Publish package distributions to PyPI

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,7 +18,6 @@ ARG VLLM_COMMIT_HASH=""
 
 FROM $BASE_IMAGE
 
-ARG IS_FOR_V7X="false"
 ARG IS_TEST="false"
 
 # Update pip

--- a/docker/Dockerfile.pypi
+++ b/docker/Dockerfile.pypi
@@ -16,7 +16,6 @@ ARG VLLM_COMMIT_HASH=""
 
 FROM $BASE_IMAGE
 
-ARG IS_FOR_V7X="false"
 ARG IS_TEST="false"
 
 # Update pip

--- a/setup.py
+++ b/setup.py
@@ -66,20 +66,7 @@ def get_requirements() -> List[str]:
 
 
 def get_version():
-    version = os.getenv("VLLM_VERSION_OVERRIDE", "0.0.0").strip()
-
-    # TODO: Temporary workaround. The v7x requirements will be consolidated, and this block will be removed,
-    # once the JAX package fix is released, since v6e/v7x differentiation will no longer be required.
-    if os.getenv("IS_FOR_V7X", "true").lower() == "false":
-        if "dev" in version:
-            # nightly release: 0.13.2.dev20260211 -> 0.13.2.post6.dev20260211 (fit PEP 440)
-            version = version.replace(".dev", ".post6.dev")
-        else:
-            # formal release: 0.13.2 -> 0.13.2.post6
-            # rc release: 0.13.2rc4 -> 0.13.2rc4.post6
-            version = f"{version}.post6"
-
-    return version
+    return os.getenv("VLLM_VERSION_OVERRIDE", "0.0.0").strip()
 
 
 setup(


### PR DESCRIPTION
# Description

Remove the v7x dependency workaround and redundant code.
Following #1641, v6e and v7x now use the same JAX and Flax versions.

# Tests

- [buildkite](https://buildkite.com/tpu-commons/tpu-inference-ci/builds/11171/steps/canvas)

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.