### PR TITLE
[TPU Offload][FIX] Release Staging buffer and remove slicing in bucked ops.

### DIFF
--- a/tests/offload/tpu_offload_connector_worker_test.py
+++ b/tests/offload/tpu_offload_connector_worker_test.py
@@ -184,8 +184,10 @@ class TestTPUOffloadConnectorWorker(jtu.JaxTestCase):
         """
         connector = self._create_connector()
         worker = connector.connector_worker
-        chunks_list = worker._decompose_into_buckets(num_blocks)
-        self.assertEqual(chunks_list, expected_buckets)
+        block_ids = [i for i in range(num_blocks)]
+        chunks_list = worker._decompose_into_buckets(block_ids)
+        chunk_size_list = [len(x) for x in chunks_list]
+        self.assertEqual(chunk_size_list, expected_buckets)
         logger.info(
             f"Decomposition for {num_blocks} blocks into {expected_buckets}.")
 


### PR DESCRIPTION
# Description

1. Fixed: release staging buffer only after its save is done. Previously, we mark a request as finished_request when its gathers are done (in order to let vllm scheduler release its kv pages); the request will be added into finished_sending and its staging buffer will be released.
2. Removed slicing (`jax.lax.dynamic_slice_in_dim`) sub block_ids array from the large block_to_save array for bucked operations ( the slicing triggers compilation).

# Tests

`pytest -s -v tests/offload/tpu_offload_connector_worker_test.py`

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
