### PR TITLE
[Jax][Deepseek] Set dtype in lm_head

### DIFF
--- a/tpu_inference/models/jax/deepseek_v3.py
+++ b/tpu_inference/models/jax/deepseek_v3.py
@@ -1822,6 +1822,7 @@ class DeepSeekV3(JaxModule):
             rngs=self.rng,
             kernel_init=nnx.with_partitioning(
                 init_fn, (None, ShardingAxisName.MLP_TENSOR)),
+            param_dtype=dtype,
             # Same as https://github.com/vllm-project/tpu-inference/issues/1684
             # DS-V3 doesn't quantize lm_head, so set quant_config to None.
             quant_config=None,


### PR DESCRIPTION
# Description

Fix #1784 

[This part](https://github.com/vllm-project/tpu-inference/blob/d030a6a88cb4578b360b76cb6a55c384389e1d7a/tpu_inference/models/jax/deepseek_v3.py#L1143-L1156) requires dtype set to properly load weights.

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
