### PR TITLE
Revert CPU mesh in vllm model

### DIFF
--- a/tpu_inference/models/vllm/vllm_model_wrapper.py
+++ b/tpu_inference/models/vllm/vllm_model_wrapper.py
@@ -46,7 +46,6 @@ from tpu_inference.distributed.jax_parallel_state import \
     get_pp_group as jax_get_pp_group
 from tpu_inference.layers.common.attention_metadata import AttentionMetadata
 from tpu_inference.layers.common.sharding import ShardingAxisName
-from tpu_inference.layers.common.utils import cpu_mesh_context
 from tpu_inference.layers.vllm.process_weights.cleanup_sharding import \
     shard_model_to_tpu
 from tpu_inference.layers.vllm.quantization import get_tpu_quantization_config
@@ -174,9 +173,9 @@ class VllmModelWrapper:
         # By default load weights to the CPU device first. If we are running
         # under Pathways, this would cause weights to be loaded on a CPU-only
         # node, so we'll need to remove this context.
-        jax_context = cpu_mesh_context(
-        ) if not vllm_envs.VLLM_TPU_USING_PATHWAYS else nullcontext()
-
+        jax_context = jax.default_device(
+            jax.devices("cpu")
+            [0]) if not vllm_envs.VLLM_TPU_USING_PATHWAYS else nullcontext()
         # Load the vLLM model and wrap it into a new model whose forward
         # function can calculate the hidden_state and logits.
         with load_context, jax_context:


### PR DESCRIPTION
# Description

https://github.com/vllm-project/tpu-inference/pull/1792/ causes significant increase in model loading time for torchax path.

without revert PR: 3450.52 seconds
```
(EngineCore_DP0 pid=3394838) INFO 02-26 02:50:35 [default_loader.py:293] Loading weights took 74.96 seconds
(EngineCore_DP0 pid=3394838) WARNING:root:Duplicate op registration for aten.__and__
(EngineCore_DP0 pid=3394838) INFO 02-26 03:46:50 [vllm_model_wrapper.py:205] Total time to load model weights from storage to TPU: 3450.52 seconds.
```

with revert PR: 375.46 seconds
```
(EngineCore_DP0 pid=3511928) INFO 02-26 06:36:58 [default_loader.py:293] Loading weights took 109.67 seconds
(EngineCore_DP0 pid=3511928) WARNING:root:Duplicate op registration for aten.__and__
(EngineCore_DP0 pid=3511928) INFO 02-26 06:41:23 [vllm_model_wrapper.py:205] Total time to load model weights from storage to TPU: 375.46 seconds.
```

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
