### PR TITLE
executor trace scope

### DIFF
--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -602,7 +602,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         if self.execute_model_state is not None:
             raise RuntimeError("State error: sample_tokens() must be called "
                                "after execute_model() returns None.")
-        reqs = len(scheduler_output.num_scheduled_tokens)
+        reqs = self.input_batch.num_reqs
         toks = scheduler_output.total_num_scheduled_tokens
         with jax.set_mesh(self.mesh), jax.profiler.TraceAnnotation(
                 f"execute_model: {reqs} reqs, {toks} toks"):


### PR DESCRIPTION
# Description

This PR tries to add a custom scope to include # of reqs and # of toks in traces for better observability

# Tests
in an e2e run, take a trace
<img width="1063" height="491" alt="Screenshot 2026-02-26 at 1 41 55 PM" src="https://github.com/user-attachments/assets/b962aa0c-c5dd-4c93-887a-dfaeb08f8f64" />

there's a custom kernel showed up, execute_model: 64 reqs, 64 toks

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
