### PR TITLE
[Misc] Remove functools.partial when using @jax.jit

### DIFF
--- a/tpu_inference/kernels/collectives/all_gather_matmul.py
+++ b/tpu_inference/kernels/collectives/all_gather_matmul.py
@@ -693,7 +693,7 @@ def all_gather_matmul(
                                     bytes_accessed=bytes_accessed,
                                     transcendentals=0)
 
-    @functools.partial(jax.jit, static_argnames=["bn", "bk", "rhs_transpose"])
+    @jax.jit(static_argnames=["bn", "bk", "rhs_transpose"])
     def _all_gather_matmul_call(x, y, bn, bk, rhs_transpose):
         return pl.pallas_call(
             functools.partial(

--- a/tpu_inference/kernels/flash_attention/kernel.py
+++ b/tpu_inference/kernels/flash_attention/kernel.py
@@ -72,16 +72,13 @@ class BlockSizes:
         )
 
 
-@functools.partial(
-    jax.jit,
-    static_argnames=[
-        "causal",
-        "sm_scale",
-        "block_sizes",
-        "vmem_limit_bytes",
-        "debug",
-    ],
-)
+@jax.jit(static_argnames=[
+    "causal",
+    "sm_scale",
+    "block_sizes",
+    "vmem_limit_bytes",
+    "debug",
+])
 def flash_attention(
     q,  # [batch_size, num_heads, q_seq_len, d_model]
     k,  # [batch_size, num_heads, kv_seq_len, d_model]
@@ -712,8 +709,7 @@ def mha_reference_no_custom_vjp(
     return out
 
 
-@functools.partial(jax.jit,
-                   static_argnames=["causal", "mask_value", "sm_scale"])
+@jax.jit(static_argnames=["causal", "mask_value", "sm_scale"])
 @jax.default_matmul_precision("bfloat16")
 def mha_reference(
     q,

--- a/tpu_inference/kernels/megablox/gmm.py
+++ b/tpu_inference/kernels/megablox/gmm.py
@@ -320,14 +320,11 @@ def _zero_uninitialized_memory(
 LutFn = Callable[[int, int, int], Optional[tuple[int, int, int]]]
 
 
-@functools.partial(
-    jax.jit,
-    static_argnames=[
-        "preferred_element_type",
-        "tiling",
-        "interpret",
-    ],
-)
+@jax.jit(static_argnames=[
+    "preferred_element_type",
+    "tiling",
+    "interpret",
+])
 def gmm(
     lhs: jnp.ndarray,
     rhs: jnp.ndarray,

--- a/tpu_inference/kernels/mla/v1/kernel.py
+++ b/tpu_inference/kernels/mla/v1/kernel.py
@@ -44,10 +44,7 @@ def get_kv_cache_shape(
     )
 
 
-@functools.partial(
-    jax.jit,
-    donate_argnames=("cache_kv"),
-)
+@jax.jit(donate_argnames=("cache_kv"))
 def update_kv_cache(
         new_kv_c: jax.Array,  # [num_tokens, actual_lkv_dim]
         new_k_pe: jax.Array,  # [num_tokens, actual_r_dim]
@@ -1075,8 +1072,7 @@ def prepare_outputs(
     )[:, :actual_num_q_heads, :actual_head_dim]
 
 
-@functools.partial(
-    jax.jit,
+@jax.jit(
     static_argnames=(
         "sm_scale",
         "sliding_window",

--- a/tpu_inference/kernels/quantized_matmul/blockwise_kernel.py
+++ b/tpu_inference/kernels/quantized_matmul/blockwise_kernel.py
@@ -1,8 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 """Quantized matmul kernel with blockwise quantization support."""
 
-import functools
-
 import jax
 import jax.numpy as jnp
 from jax.experimental import pallas as pl
@@ -19,14 +17,11 @@ quantize_tensor = util.quantize_tensor
 MXU_SIZE = 256
 
 
-@functools.partial(
-    jax.jit,
-    static_argnames=[
-        "block_size",
-        "x_q_dtype",
-        "tuned_value",
-    ],
-)
+@jax.jit(static_argnames=[
+    "block_size",
+    "x_q_dtype",
+    "tuned_value",
+])
 def quantized_matmul_kernel(
     x: jax.Array,  # [bs, n_in]
     w_q: jax.Array,  # [n_out, n_in]

--- a/tpu_inference/kernels/quantized_matmul/kernel.py
+++ b/tpu_inference/kernels/quantized_matmul/kernel.py
@@ -112,13 +112,10 @@ def matmul_kernel(
     unfold_args((quant, is_first_step, is_last_step), (), matmul_body)
 
 
-@functools.partial(
-    jax.jit,
-    static_argnames=[
-        "x_q_dtype",
-        "tuned_value",
-    ],
-)
+@jax.jit(static_argnames=[
+    "x_q_dtype",
+    "tuned_value",
+])
 def quantized_matmul_kernel(
     x: jax.Array,  # [bs, n_in]
     w_q: jax.Array,  # [n_out, n_in]

--- a/tpu_inference/kernels/ragged_paged_attention/v2/kernel.py
+++ b/tpu_inference/kernels/ragged_paged_attention/v2/kernel.py
@@ -691,20 +691,17 @@ def get_min_heads_per_blk(num_q_heads, num_combined_kv_heads, q_dtype,
     return num_q_heads, num_combined_kv_heads
 
 
-@functools.partial(
-    jax.jit,
-    static_argnames=[
-        "sm_scale",
-        "mask_value",
-        "num_kv_pages_per_block",
-        "num_queries_per_block",
-        "vmem_limit_bytes",
-        "sliding_window",
-        "soft_cap",
-        "k_scale",
-        "v_scale",
-    ],
-)
+@jax.jit(static_argnames=[
+    "sm_scale",
+    "mask_value",
+    "num_kv_pages_per_block",
+    "num_queries_per_block",
+    "vmem_limit_bytes",
+    "sliding_window",
+    "soft_cap",
+    "k_scale",
+    "v_scale",
+])
 def ragged_paged_attention(
     q: jax.Array,  # [max_num_batched_tokens, num_q_heads, head_dim]
     # TODO(jevinjiang): create a write_to_kv_cache kernel!

--- a/tpu_inference/kernels/ragged_paged_attention/v2/ragged_kv_cache_update.py
+++ b/tpu_inference/kernels/ragged_paged_attention/v2/ragged_kv_cache_update.py
@@ -229,8 +229,7 @@ def _get_num_slices_per_kv_cache_update_block(page_size_bytes: int,
     return min(num_slices_per_block, 64)
 
 
-@functools.partial(
-    jax.jit,
+@jax.jit(
     static_argnames=[
         "page_size", "num_slices_per_block", "mesh", "kv_cache_pspec"
     ],

--- a/tpu_inference/kernels/ragged_paged_attention/v3/kernel.py
+++ b/tpu_inference/kernels/ragged_paged_attention/v3/kernel.py
@@ -1335,8 +1335,7 @@ def get_kernel_scope_name(bq_size, bkv_p, page_size, sliding_window):
     return name
 
 
-@functools.partial(
-    jax.jit,
+@jax.jit(
     static_argnames=(
         "sm_scale",
         "sliding_window",

--- a/tpu_inference/kernels/ragged_paged_attention/v3/kernel_hd64.py
+++ b/tpu_inference/kernels/ragged_paged_attention/v3/kernel_hd64.py
@@ -1322,8 +1322,7 @@ def get_kernel_scope_name(bq_size, bkv_p, page_size, sliding_window):
     return name
 
 
-@functools.partial(
-    jax.jit,
+@jax.jit(
     static_argnames=(
         "sm_scale",
         "sliding_window",

--- a/tpu_inference/layers/common/attention_interface.py
+++ b/tpu_inference/layers/common/attention_interface.py
@@ -117,7 +117,7 @@ def sharded_paged_attention(
 
 
 # TODO(xiangxu): merge this with sharded_paged_attention
-@functools.partial(jax.jit, static_argnums=[0])
+@jax.jit(static_argnames=["paged_attention_kernel"])
 def paged_attention_with_guarded_smem(
     paged_attention_kernel: Callable,
     q: jax.Array,
@@ -224,8 +224,7 @@ def update_cache(
     return cache
 
 
-@functools.partial(
-    jax.jit, static_argnames=["window_size", "attn_logits_soft_cap", "is_mqa"])
+@jax.jit(static_argnames=["window_size", "attn_logits_soft_cap", "is_mqa"])
 def apply_splash(q, k, v, window_size, attn_logits_soft_cap,
                  is_mqa) -> jax.Array:
     # q: (batch_size, num_heads, seq_len, head_dim)

--- a/tpu_inference/layers/common/fused_moe_gmm.py
+++ b/tpu_inference/layers/common/fused_moe_gmm.py
@@ -276,17 +276,14 @@ def expert_parallel_gmm(
     )
 
 
-@functools.partial(
-    jax.jit,
-    static_argnames=(
-        "topk",
-        "renormalize",
-        "mesh",
-        "use_ep",
-        "activation",
-        "scoring_fn",
-    ),
-)
+@jax.jit(static_argnames=(
+    "topk",
+    "renormalize",
+    "mesh",
+    "use_ep",
+    "activation",
+    "scoring_fn",
+))
 def fused_moe_func(
     hidden_states: jax.Array,
     w1: jax.Array,

--- a/tpu_inference/layers/common/process_weights/moe_weights.py
+++ b/tpu_inference/layers/common/process_weights/moe_weights.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import functools
 from dataclasses import dataclass, fields
 
 import jax
@@ -392,13 +391,12 @@ def shard_moe_weights(
     return weights
 
 
-@functools.partial(jax.jit,
-                   static_argnames=(
-                       "moe_backend",
-                       "mesh",
-                       "activation",
-                       "weight_block_size",
-                   ))
+@jax.jit(static_argnames=(
+    "moe_backend",
+    "mesh",
+    "activation",
+    "weight_block_size",
+))
 def process_fp8_moe_weights(
     weights: FusedMoEWeights,
     moe_backend: MoEBackend,

--- a/tpu_inference/layers/common/quantization/fp8.py
+++ b/tpu_inference/layers/common/quantization/fp8.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import functools
 import math
 from typing import Optional, Sequence
 
@@ -75,8 +74,7 @@ class Fp8LinearMethod:
         return jnp.concatenate(outs, axis=-1)
 
 
-@functools.partial(jax.jit,
-                   static_argnames=('linear_config', 'weight_block_size'))
+@jax.jit(static_argnames=('linear_config', 'weight_block_size'))
 def process_blockwise_fp8_linear_weights(
     weight: jax.Array,
     weight_scale: jax.Array,

--- a/tpu_inference/layers/jax/sample/rejection_sampler.py
+++ b/tpu_inference/layers/jax/sample/rejection_sampler.py
@@ -18,7 +18,6 @@ This implementation follows the same algorithm as the GPU version but is
 designed for JAX/TPU compatibility. It currently only supports greedy sampling.
 """
 
-import functools
 from typing import Optional
 
 import jax
@@ -85,7 +84,7 @@ class RejectionSampler:
             key=key,
         )
 
-    @functools.partial(jax.jit, static_argnums=(0, ))
+    @jax.jit(static_argnums=(0, ))
     def forward(
         self,
         # [num_tokens] - flattened format

--- a/tpu_inference/layers/jax/sample/sampling.py
+++ b/tpu_inference/layers/jax/sample/sampling.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import functools
-
 import jax
 import jax.numpy as jnp
 from jax.sharding import Mesh, NamedSharding
@@ -28,10 +26,7 @@ from tpu_inference.layers.jax.sample.sampling_metadata import \
 _SAMPLING_EPS = 1e-5
 
 
-@functools.partial(
-    jax.jit,
-    static_argnames=["mesh"],
-)
+@jax.jit(static_argnames=["mesh"])
 def sample(
     rng: jax.Array,
     mesh: Mesh,

--- a/tpu_inference/layers/vllm/attention.py
+++ b/tpu_inference/layers/vllm/attention.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-import functools
 from typing import Optional, Tuple
 
 import jax
@@ -216,8 +215,7 @@ class PallasAttentionBackendImpl(AttentionImpl):
         return torch_view(outputs)
 
 
-@functools.partial(
-    jax.jit,
+@jax.jit(
     static_argnames=(
         "mesh",
         "scale",

--- a/tpu_inference/models/common/model_loader.py
+++ b/tpu_inference/models/common/model_loader.py
@@ -273,8 +273,7 @@ def get_flax_model(
     # https://flax.readthedocs.io/en/latest/guides/performance.html
     graphdef, state = nnx.split(jit_model)
 
-    @functools.partial(
-        jax.jit,
+    @jax.jit(
         out_shardings=(
             kv_cache_sharding,
             hidden_states_sharding,
@@ -293,10 +292,7 @@ def get_flax_model(
         mesh,
         PartitionSpec(ShardingAxisName.MLP_DATA, ShardingAxisName.MLP_TENSOR))
 
-    @functools.partial(
-        jax.jit,
-        out_shardings=(logits_sharding),
-    )
+    @jax.jit(out_shardings=(logits_sharding))
     def run_compute_logits(graphdef, state, *args):
         model = nnx.merge(graphdef, state)
         hidden_state, *_ = args
@@ -310,19 +306,13 @@ def get_flax_model(
 
     embed_sharding = NamedSharding(mesh, PartitionSpec(None))
     # This function will calculates the embeddings of input texts and then merge with the image embeddings
-    @functools.partial(
-        jax.jit,
-        out_shardings=(embed_sharding),
-    )
+    @jax.jit(out_shardings=(embed_sharding))
     def run_embed_input_ids(graphdef, state, *args, **kwargs):
         model = nnx.merge(graphdef, state)
         return model.embed_input_ids(*args, **kwargs)
 
     # For models that want to work with EAGLE-3 speculative decoding
-    @functools.partial(
-        jax.jit,
-        out_shardings=(logits_sharding),
-    )
+    @jax.jit(out_shardings=(logits_sharding))
     def combine_hidden_states(graphdef, state, hidden_states):
         model = nnx.merge(graphdef, state)
         return model.combine_hidden_states(hidden_states)

--- a/tpu_inference/models/jax/qwen2_5_vl.py
+++ b/tpu_inference/models/jax/qwen2_5_vl.py
@@ -716,10 +716,7 @@ class Qwen2_5_VisionTransformer(nnx.Module):
                                           rotary_pos_emb, cu_seqlens,
                                           cu_window_seqlens)
 
-    @partial(
-        jax.jit,
-        static_argnames=("grid_thw", ),
-    )
+    @jax.jit(static_argnames=("grid_thw", ))
     def encode_jit(self, x, grid_thw):
         window_index, rotary_pos_emb, cu_seqlens, cu_window_seqlens = self.compute_aux_arrays(
             grid_thw)

--- a/tpu_inference/runner/kv_cache_manager.py
+++ b/tpu_inference/runner/kv_cache_manager.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import functools
 from typing import TYPE_CHECKING, List
 
 import jax
@@ -343,7 +342,7 @@ class KVCacheManager:
         self.initialize_kv_cache(kv_cache_config)
 
     @staticmethod
-    @functools.partial(jax.jit)
+    @jax.jit
     def _jitted_gather_kv_cache(kv_caches: List[jax.Array],
                                 block_ids: jax.Array) -> List[jax.Array]:
         """
@@ -358,10 +357,7 @@ class KVCacheManager:
         return jax.tree.map(gather_and_reshape, kv_caches)
 
     @staticmethod
-    @functools.partial(
-        jax.jit,
-        static_argnames=("len_block"),
-    )
+    @jax.jit(static_argnames=("len_block"))
     def _jitted_gather_continuous_kv_cache(kv_caches: List[jax.Array],
                                            start_block,
                                            len_block) -> List[jax.Array]:
@@ -381,8 +377,7 @@ class KVCacheManager:
         return jax.tree.map(gather_and_reshape, kv_caches)
 
     @staticmethod
-    @functools.partial(
-        jax.jit,
+    @jax.jit(
         static_argnames=("block_size"),
         donate_argnames=(
             "kv_caches",
@@ -410,8 +405,7 @@ class KVCacheManager:
         return jax.tree.map(_update_layer, kv_caches, kv_cache_slices)
 
     @staticmethod
-    @functools.partial(
-        jax.jit,
+    @jax.jit(
         static_argnames=("block_size"),
         donate_argnames=(
             "kv_caches",

--- a/tpu_inference/runner/structured_decoding_manager.py
+++ b/tpu_inference/runner/structured_decoding_manager.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import functools
 from typing import TYPE_CHECKING, Tuple
 
 import jax
@@ -31,7 +30,7 @@ class StructuredDecodingManager:
     def __init__(self, runner: "TPUModelRunner"):
         self.runner = runner
 
-    @functools.partial(jax.jit, static_argnums=(0, ))
+    @jax.jit(static_argnums=(0, ))
     def structured_decode_fn(self, require_struct_decoding: jax.Array,
                              grammar_bitmask: jax.Array, logits: jax.Array,
                              arange: jax.Array) -> jax.Array:
@@ -41,7 +40,7 @@ class StructuredDecodingManager:
                 logits, grammar_bitmask, require_struct_decoding, arange),
             lambda: logits)
 
-    @functools.partial(jax.jit, static_argnums=(0, ))
+    @jax.jit(static_argnums=(0, ))
     def _apply_grammar_bitmask_kernel(self, logits: jax.Array,
                                       grammar_bitmask: jax.Array,
                                       require_struct_decoding: jax.Array,

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -157,7 +157,7 @@ class ExecuteModelState:
     padded_num_reqs: Optional[int] = None
 
 
-@functools.partial(jax.jit, donate_argnums=(0, 1, 2))
+@jax.jit(donate_argnums=(0, 1, 2))
 def _substitute_placeholder_token(
         input_ids: jax.Array, token_in_tpu_cur_input_indices: jax.Array,
         token_in_tpu_pre_next_tokens_indices: jax.Array,
@@ -1072,7 +1072,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         )
         return model_runner_output
 
-    @functools.partial(jax.jit, static_argnums=(0, ))
+    @jax.jit(static_argnums=(0, ))
     def _select_from_array_fn(self, array, indices_to_select):
 
         def select_local_fn(local_array, local_indices):
@@ -1089,7 +1089,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         return ret
 
     @staticmethod
-    @functools.partial(jax.jit, static_argnames=("max_logprobs", ))
+    @jax.jit(static_argnames=("max_logprobs", ))
     def _compute_and_gather_logprobs(logits, next_tokens, max_logprobs):
         logprobs = compute_logprobs(logits)
         return gather_logprobs(logprobs, next_tokens, max_logprobs)

--- a/tpu_inference/spec_decode/jax/eagle3.py
+++ b/tpu_inference/spec_decode/jax/eagle3.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Implements the Eagle3 proposer for speculative decoding on JAX/TPU."""
-import functools
 from dataclasses import replace
 from typing import Any, Optional
 
@@ -87,7 +86,7 @@ class Eagle3Proposer:
         else:
             logger.info("Draft model has its own embed_tokens.")
 
-    @functools.partial(jax.jit, static_argnums=(0, ))
+    @jax.jit(static_argnums=(0, ))
     def _prepare_input_ids(
             self, query_start_loc: jax.Array, target_token_ids: jax.Array,
             next_token_ids: jax.Array,
@@ -113,7 +112,7 @@ class Eagle3Proposer:
 
         return input_ids, last_token_indices
 
-    @functools.partial(jax.jit, static_argnums=(0, ))
+    @jax.jit(static_argnums=(0, ))
     def _update_inputs_for_loop_speculation(
         self, positions: jax.Array, seq_lens: jax.Array,
         block_tables: jax.Array
@@ -156,13 +155,13 @@ class Eagle3Proposer:
 
         return positions, clamped_positions, new_seq_lens, query_start_loc, new_block_tables
 
-    @functools.partial(jax.jit, static_argnums=(0, ))
+    @jax.jit(static_argnums=(0, ))
     def _stack_draft_token_ids(
             self, draft_token_ids_list: list[jax.Array]) -> jnp.ndarray:
         """JIT-compiled helper for stacking draft token IDs."""
         return jnp.stack(draft_token_ids_list, axis=1)
 
-    @functools.partial(jax.jit, static_argnums=(0, ))
+    @jax.jit(static_argnums=(0, ))
     def _prepare_hidden_states_and_input_ids(
         self,
         state: nnx.State,
@@ -289,7 +288,7 @@ class Eagle3Proposer:
             self.state, token_indices, query_start_loc, seq_lens, input_ids,
             aux_hidden_states, attn_metadata, next_token_ids, num_reqs)
 
-    @functools.partial(jax.jit, static_argnums=(0, ))
+    @jax.jit(static_argnums=(0, ))
     def _filter_token_and_prepare_initial_inputs(
         self,
         state: nnx.State,
@@ -325,7 +324,7 @@ class Eagle3Proposer:
 
         return target_hidden_states, input_ids, last_token_indices, attn_metadata
 
-    @functools.partial(jax.jit, static_argnums=(0, ))
+    @jax.jit(static_argnums=(0, ))
     def _select_draft_token_ids(
         self,
         state: nnx.State,
@@ -338,7 +337,7 @@ class Eagle3Proposer:
             NamedSharding(self.mesh, PartitionSpec(None, None)))
         return self._get_draft_token_ids(state, sample_hidden_states)
 
-    @functools.partial(jax.jit, static_argnums=(0, ))
+    @jax.jit(static_argnums=(0, ))
     def _get_draft_token_ids(self, state: nnx.State,
                              hidden_states: jax.Array) -> jax.Array:
         lora_metadata = None
@@ -347,7 +346,7 @@ class Eagle3Proposer:
         return lax.with_sharding_constraint(
             draft_token_ids, NamedSharding(self.mesh, PartitionSpec()))
 
-    @functools.partial(jax.jit, static_argnums=(0, ))
+    @jax.jit(static_argnums=(0, ))
     def _select_inputs_for_loop_speculation(
             self, state: nnx.State, positions: jax.Array, residual: jax.Array,
             hidden_states: jax.Array,


### PR DESCRIPTION
# Description

Starting from JAX 0.8.1, `@jax.jit` now supports decorator factory pattern: https://docs.jax.dev/en/latest/changelog.html#jax-0-8-1-november-18-2025

Since we have updated JAX version, `functools.partial` is not needed.

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
