### PR TITLE
Update CI Job Priorities for Pre-merge, Post-merge, and Integration Pipelines

### DIFF
--- a/.buildkite/scripts/bootstrap.sh
+++ b/.buildkite/scripts/bootstrap.sh
@@ -16,6 +16,14 @@
 # Exit on error, exit on unset variable, fail on pipe errors.
 set -euo pipefail
 
+# --- Configuration Constants ---
+# Priority: Post-merge > Pre-merge > Integration pipeline > Other/Default > Nightly
+readonly PRIORITY_POST_MERGE=10
+readonly PRIORITY_PRE_MERGE=5
+readonly PRIORITY_INTEGRATION=3
+readonly PRIORITY_DEFAULT=1
+readonly PRIORITY_NIGHTLY=0
+
 # --- Skip build if only docs/icons changed ---
 echo "--- :git: Checking changed files"
 
@@ -69,15 +77,26 @@ fi
 echo "$FILES_CHANGED" | tr '\n' ',' | buildkite-agent meta-data set "changed_files"
 
 # --- Determine Job Priority ---
-# Priority: Other/Default (1) > Nightly (0)
 echo "--- Determining job priority"
 if [[ "${NIGHTLY:-0}" == "1" ]]; then
     # Nightly build (Lowest priority)
-    export JOB_PRIORITY=0
+    export JOB_PRIORITY=$PRIORITY_NIGHTLY
     echo "Build type: Nightly - Priority: $JOB_PRIORITY"
+elif [[ $BUILDKITE_PIPELINE_SLUG == "tpu-vllm-integration" ]]; then
+    # Integration pipeline
+    export JOB_PRIORITY=$PRIORITY_INTEGRATION
+    echo "Build type: Integration - Priority: $JOB_PRIORITY"
+elif [[ "$BUILDKITE_PULL_REQUEST" != "false" ]]; then
+    # Pre-merge PR tests
+    export JOB_PRIORITY=$PRIORITY_PRE_MERGE
+    echo "Build type: Pre-merge (PR #$BUILDKITE_PULL_REQUEST) - Priority: $JOB_PRIORITY"
+elif [[ "$BUILDKITE_BRANCH" == "main" && "$BUILDKITE_PULL_REQUEST" == "false" ]]; then
+    # Post-merge tests on main (Highest priority)
+    export JOB_PRIORITY=$PRIORITY_POST_MERGE
+    echo "Build type: Post-merge (Main branch) - Priority: $JOB_PRIORITY"
 else
     # Default priority for other branches or manual builds
-    export JOB_PRIORITY=1
+    export JOB_PRIORITY=$PRIORITY_DEFAULT
     echo "Build type: General - Priority: $JOB_PRIORITY"
 fi
 


### PR DESCRIPTION
# Description

Update CI Job Priorities for Pre-merge, Post-merge, and Integration Pipelines

Priority: Post-merge (10) > Pre-merge (5) > Integration pipeline (3) > Other/Default (1) > Nightly (0)

# Tests

[BuildKite](https://buildkite.com/tpu-commons/tpu-inference-ci/builds/11699/steps/canvas?sid=019cb6a6-8ad2-4d2a-99d1-15626621de32&tab=output)

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
