### PR TITLE
Add deepseek nightly benchmarking script

### DIFF
--- a/.buildkite/scripts/run_multihost.sh
+++ b/.buildkite/scripts/run_multihost.sh
@@ -126,7 +126,7 @@ wait_for_server() {
   local container_name=$2
   local service_name=$3
   local log_path=$4
-  local timeout=${5:-3600} # Default 1 hour
+  local timeout=${5:-7200} # Default 2 hours
 
   echo "Waiting for $service_name on port $port to become healthy (Timeout: ${timeout}s)..."
 
@@ -209,7 +209,10 @@ bash "${TOP_DIR}/scripts/multihost/run_cluster.sh" \
   -e JAX_PLATFORMS='' \
   -e TPU_BACKEND_TYPE=jax \
   -e MODEL_IMPL_TYPE=vllm \
-  -e VLLM_DISABLE_SHARED_EXPERTS_STREAM=1 &
+  -e VLLM_DISABLE_SHARED_EXPERTS_STREAM="${VLLM_DISABLE_SHARED_EXPERTS_STREAM:-1}" \
+  -e NEW_MODEL_DESIGN="${NEW_MODEL_DESIGN:-0}" \
+  -e MOE_REQUANTIZE_BLOCK_SIZE="${MOE_REQUANTIZE_BLOCK_SIZE:-}" \
+  -e MOE_REQUANTIZE_WEIGHT_DTYPE="${MOE_REQUANTIZE_WEIGHT_DTYPE:-}" &
 
 sleep 60
 
@@ -226,17 +229,16 @@ for worker_ip in "${WORKER_IPS_ARRAY[@]}"; do
     # shellcheck disable=SC2002
     cat "${TOP_DIR}/scripts/multihost/run_cluster.sh" | ssh "${SSH_OPTS[@]}" "${SSH_USER}@${worker_ip}" "cat > ~/tpu-inference/scripts/multihost/run_cluster.sh"
     
-    REMOTE_CMD="bash ~/tpu-inference/scripts/multihost/run_cluster.sh \
-      '${DOCKER_IMAGE}' \
-      '${HEAD_INTERNAL_IP}' \
-      --worker \
-      '${HOST_HF_HOME}' \
+    REMOTE_CMD="bash ~/tpu-inference/scripts/multihost/run_cluster.sh '${DOCKER_IMAGE}' '${HEAD_INTERNAL_IP}' --worker '${HOST_HF_HOME}' \
       -e HF_TOKEN='${HF_TOKEN:-}' \
       -e TPU_MULTIHOST_BACKEND=ray \
       -e JAX_PLATFORMS='' \
       -e TPU_BACKEND_TYPE=jax \
       -e MODEL_IMPL_TYPE=vllm \
-      -e VLLM_DISABLE_SHARED_EXPERTS_STREAM=1"
+      -e VLLM_DISABLE_SHARED_EXPERTS_STREAM='${VLLM_DISABLE_SHARED_EXPERTS_STREAM:-1}' \
+      -e NEW_MODEL_DESIGN='${NEW_MODEL_DESIGN:-0}' \
+      -e MOE_REQUANTIZE_BLOCK_SIZE='${MOE_REQUANTIZE_BLOCK_SIZE:-}' \
+      -e MOE_REQUANTIZE_WEIGHT_DTYPE='${MOE_REQUANTIZE_WEIGHT_DTYPE:-}'"
 
     # shellcheck disable=SC2029
     ssh "${SSH_OPTS[@]}" "${SSH_USER}@${worker_ip}" "$REMOTE_CMD" &

--- a/scripts/multihost/benchmarks/run_deepseek_v3_1k_1k.sh
+++ b/scripts/multihost/benchmarks/run_deepseek_v3_1k_1k.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Copyright 2026 Google LLC
+#
+# Nightly benchmark wrapper for DeepSeek V3 (1k input, 8k output).
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+NIGHTLY_SCRIPT="${SCRIPT_DIR}/../nightly_benchmarking.sh"
+
+# Adjust model-path, max-seqs, and code-hash below when officially serving DeepSeek.
+bash "${NIGHTLY_SCRIPT}" \
+  --model-path "gs://tpu-commons-ci/deepseek/r1" \
+  --model-name "DeepSeek-R1" \
+  --tokenizer "deepseek-ai/DeepSeek-R1" \
+  --input-len 1024 \
+  --output-len 1024 \
+  --tp-size 16 \
+  --max-seqs 640 \
+  --max-model-len 2048 \
+  --max-batched-tokens 640 \
+  --num-prompts 10240 \
+  --dataset-name "random" \
+  --run-type "DAILY" \
+  --device "tpu7x-16" \
+  --code-hash "deepseek-hash-placeholder" \
+  --created-by "bm-scheduler" \
+  --new-model-design "1" \
+  --gpu-memory-utilization "0.92" \
+  --enable-expert-parallel \
+  --additional-config '{"sharding": {"sharding_strategy": {"enable_dp_attention": true}}}' \
+  --disable-shared-experts-stream "0" \
+  --generation-config "gs://gpolovets-inference/deepseek/generation_configs/DeepSeek-R1" \
+  --vllm-mla-disable "0" \
+  --moe-requantize-block-size "512" \
+  --moe-requantize-weight-dtype "fp4"

--- a/scripts/multihost/benchmarks/run_deepseek_v3_1k_8k.sh
+++ b/scripts/multihost/benchmarks/run_deepseek_v3_1k_8k.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Copyright 2026 Google LLC
+#
+# Nightly benchmark wrapper for DeepSeek V3 (1k input, 8k output).
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+NIGHTLY_SCRIPT="${SCRIPT_DIR}/../nightly_benchmarking.sh"
+
+# Adjust model-path, max-seqs, and code-hash below when officially serving DeepSeek.
+bash "${NIGHTLY_SCRIPT}" \
+  --model-path "gs://tpu-commons-ci/deepseek/r1" \
+  --model-name "DeepSeek-R1" \
+  --tokenizer "deepseek-ai/DeepSeek-R1" \
+  --input-len 1024 \
+  --output-len 8192 \
+  --tp-size 16 \
+  --max-seqs 128 \
+  --max-model-len 9216 \
+  --max-batched-tokens 512 \
+  --num-prompts 2048 \
+  --dataset-name "random" \
+  --run-type "DAILY" \
+  --device "tpu7x-16" \
+  --code-hash "deepseek-hash-placeholder" \
+  --created-by "bm-scheduler" \
+  --new-model-design "1" \
+  --gpu-memory-utilization "0.92" \
+  --enable-expert-parallel \
+  --additional-config '{"sharding": {"sharding_strategy": {"enable_dp_attention": true}}}' \
+  --disable-shared-experts-stream "0" \
+  --generation-config "gs://gpolovets-inference/deepseek/generation_configs/DeepSeek-R1" \
+  --vllm-mla-disable "0" \
+  --moe-requantize-block-size "512" \
+  --moe-requantize-weight-dtype "fp4"

--- a/scripts/multihost/benchmarks/run_deepseek_v3_8k_1k.sh
+++ b/scripts/multihost/benchmarks/run_deepseek_v3_8k_1k.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Copyright 2026 Google LLC
+#
+# Nightly benchmark wrapper for DeepSeek V3 (8k input, 1k output).
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+NIGHTLY_SCRIPT="${SCRIPT_DIR}/../nightly_benchmarking.sh"
+
+# Adjust model-path, max-seqs, and code-hash below when officially serving DeepSeek.
+bash "${NIGHTLY_SCRIPT}" \
+  --model-path "gs://tpu-commons-ci/deepseek/r1" \
+  --model-name "DeepSeek-R1" \
+  --tokenizer "deepseek-ai/DeepSeek-R1" \
+  --input-len 8192 \
+  --output-len 1024 \
+  --tp-size 16 \
+  --max-seqs 128 \
+  --max-model-len 9216 \
+  --max-batched-tokens 512 \
+  --num-prompts 2048 \
+  --dataset-name "random" \
+  --run-type "DAILY" \
+  --device "tpu7x-16" \
+  --code-hash "deepseek-hash-placeholder" \
+  --created-by "bm-scheduler" \
+  --new-model-design "1" \
+  --gpu-memory-utilization "0.92" \
+  --enable-expert-parallel \
+  --additional-config '{"sharding": {"sharding_strategy": {"enable_dp_attention": true}}}' \
+  --disable-shared-experts-stream "0" \
+  --generation-config "gs://gpolovets-inference/deepseek/generation_configs/DeepSeek-R1" \
+  --vllm-mla-disable "0" \
+  --moe-requantize-block-size "512" \
+  --moe-requantize-weight-dtype "fp4"

--- a/scripts/multihost/benchmarks/run_qwen3_coder_480b_1k_8k.sh
+++ b/scripts/multihost/benchmarks/run_qwen3_coder_480b_1k_8k.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Copyright 2026 Google LLC
+#
+# Nightly benchmark wrapper for Qwen3 Coder 480B (1k input, 8k output).
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+NIGHTLY_SCRIPT="${SCRIPT_DIR}/../nightly_benchmarking.sh"
+
+bash "${NIGHTLY_SCRIPT}" \
+  --model-path "gs://tpu-commons-ci/qwen/models--Qwen--Qwen3-Coder-480B-A35B-Instruct/snapshots/9d90cf8fca1bf7b7acca42d3fc9ae694a2194069" \
+  --model-name "Qwen3-Coder-480B-A35B-Instruct" \
+  --tokenizer "Qwen/Qwen3-Coder-480B-A35B-Instruct" \
+  --input-len 1024 \
+  --output-len 8192 \
+  --tp-size 16 \
+  --max-seqs 128 \
+  --max-model-len 10240 \
+  --max-batched-tokens 1024 \
+  --num-prompts 128 \
+  --dataset-name "random" \
+  --run-type "DAILY" \
+  --device "tpu7x-16" \
+  --code-hash "a4047d4-cf732f1-" \
+  --created-by "bm-scheduler"

--- a/scripts/multihost/benchmarks/xprof/xprof_deepseek_v3_1k_1k.sh
+++ b/scripts/multihost/benchmarks/xprof/xprof_deepseek_v3_1k_1k.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Copyright 2026 Google LLC
+#
+# Nightly benchmark wrapper for DeepSeek V3 (1k input, 8k output).
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+NIGHTLY_SCRIPT="${SCRIPT_DIR}/../../nightly_benchmarking.sh"
+
+# Adjust model-path, max-seqs, and code-hash below when officially serving DeepSeek.
+bash "${NIGHTLY_SCRIPT}" \
+  --model-path "gs://tpu-commons-ci/deepseek/r1" \
+  --model-name "DeepSeek-R1" \
+  --tokenizer "deepseek-ai/DeepSeek-R1" \
+  --input-len 1024 \
+  --output-len 1024 \
+  --tp-size 16 \
+  --max-seqs 640 \
+  --max-model-len 2048 \
+  --max-batched-tokens 640 \
+  --num-prompts 10240 \
+  --dataset-name "random" \
+  --run-type "DAILY" \
+  --device "tpu7x-16" \
+  --code-hash "deepseek-hash-placeholder" \
+  --created-by "bm-scheduler" \
+  --new-model-design "1" \
+  --gpu-memory-utilization "0.92" \
+  --enable-expert-parallel \
+  --additional-config '{"sharding": {"sharding_strategy": {"enable_dp_attention": true}}}' \
+  --disable-shared-experts-stream "0" \
+  --generation-config "gs://gpolovets-inference/deepseek/generation_configs/DeepSeek-R1" \
+  --vllm-mla-disable "0" \
+  --moe-requantize-block-size "512" \
+  --moe-requantize-weight-dtype "fp4" \
+  --phased-profiling-dir "gs://tpu-commons-ci/xprof/deepseek-r1/1k-1k" \
+  --skip-db-upload

--- a/scripts/multihost/benchmarks/xprof/xprof_deepseek_v3_1k_8k.sh
+++ b/scripts/multihost/benchmarks/xprof/xprof_deepseek_v3_1k_8k.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Copyright 2026 Google LLC
+#
+# Nightly benchmark wrapper for DeepSeek V3 (1k input, 8k output).
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+NIGHTLY_SCRIPT="${SCRIPT_DIR}/../../nightly_benchmarking.sh"
+
+# Adjust model-path, max-seqs, and code-hash below when officially serving DeepSeek.
+bash "${NIGHTLY_SCRIPT}" \
+  --model-path "gs://tpu-commons-ci/deepseek/r1" \
+  --model-name "DeepSeek-R1" \
+  --tokenizer "deepseek-ai/DeepSeek-R1" \
+  --input-len 1024 \
+  --output-len 8192 \
+  --tp-size 16 \
+  --max-seqs 128 \
+  --max-model-len 9216 \
+  --max-batched-tokens 512 \
+  --num-prompts 2048 \
+  --dataset-name "random" \
+  --run-type "DAILY" \
+  --device "tpu7x-16" \
+  --code-hash "deepseek-hash-placeholder" \
+  --created-by "bm-scheduler" \
+  --new-model-design "1" \
+  --gpu-memory-utilization "0.92" \
+  --enable-expert-parallel \
+  --additional-config '{"sharding": {"sharding_strategy": {"enable_dp_attention": true}}}' \
+  --disable-shared-experts-stream "0" \
+  --generation-config "gs://gpolovets-inference/deepseek/generation_configs/DeepSeek-R1" \
+  --vllm-mla-disable "0" \
+  --moe-requantize-block-size "512" \
+  --moe-requantize-weight-dtype "fp4" \
+  --phased-profiling-dir "gs://tpu-commons-ci/xprof/deepseek-r1/1k-8k" \
+  --skip-db-upload

--- a/scripts/multihost/benchmarks/xprof/xprof_deepseek_v3_8k_1k.sh
+++ b/scripts/multihost/benchmarks/xprof/xprof_deepseek_v3_8k_1k.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Copyright 2026 Google LLC
+#
+# Nightly benchmark wrapper for DeepSeek V3 (8k input, 1k output).
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+NIGHTLY_SCRIPT="${SCRIPT_DIR}/../../nightly_benchmarking.sh"
+
+# Adjust model-path, max-seqs, and code-hash below when officially serving DeepSeek.
+bash "${NIGHTLY_SCRIPT}" \
+  --model-path "gs://tpu-commons-ci/deepseek/r1" \
+  --model-name "DeepSeek-R1" \
+  --tokenizer "deepseek-ai/DeepSeek-R1" \
+  --input-len 8192 \
+  --output-len 1024 \
+  --tp-size 16 \
+  --max-seqs 128 \
+  --max-model-len 9216 \
+  --max-batched-tokens 512 \
+  --num-prompts 2048 \
+  --dataset-name "random" \
+  --run-type "DAILY" \
+  --device "tpu7x-16" \
+  --code-hash "deepseek-hash-placeholder" \
+  --created-by "bm-scheduler" \
+  --new-model-design "1" \
+  --gpu-memory-utilization "0.92" \
+  --enable-expert-parallel \
+  --additional-config '{"sharding": {"sharding_strategy": {"enable_dp_attention": true}}}' \
+  --disable-shared-experts-stream "0" \
+  --generation-config "gs://gpolovets-inference/deepseek/generation_configs/DeepSeek-R1" \
+  --vllm-mla-disable "0" \
+  --moe-requantize-block-size "512" \
+  --moe-requantize-weight-dtype "fp4" \
+  --phased-profiling-dir "gs://tpu-commons-ci/xprof/deepseek-r1/8k-1k" \
+  --skip-db-upload

--- a/scripts/multihost/nightly_benchmarking.sh
+++ b/scripts/multihost/nightly_benchmarking.sh
@@ -12,9 +12,9 @@ RUN_MULTIHOST_SCRIPT="${TOP_DIR}/.buildkite/scripts/run_multihost.sh"
 
 # Auto-update the codebase before running the benchmark
 echo "--- Updating codebase..."
-pushd "$TOP_DIR" > /dev/null
-git pull origin main || echo "Warning: Failed to pull latest changes. Continuing with current codebase."
-popd > /dev/null
+# pushd "$TOP_DIR" > /dev/null
+# git pull origin main || echo "Warning: Failed to pull latest changes. Continuing with current codebase."
+# popd > /dev/null
 
 # Ensure essential environment variables are set for Spanner reporting
 export GCP_PROJECT_ID="${GCP_PROJECT_ID:-cloud-tpu-inference-test}"
@@ -29,14 +29,11 @@ export GCP_INSTANCE_NAME="${GCP_INSTANCE_NAME:-${TPU_NAME:-$(curl -s -H "Metadat
 RECORD_ID="$(uuidgen)"
 JOB_REFERENCE="$(date +%Y%m%d_%H%M%S)"
 mkdir -p "$SCRIPT_DIR/artifacts"
-BENCHMARK_LOG="$SCRIPT_DIR/artifacts/${RECORD_ID}_benchmark.log"
-RESULT_FILE="$SCRIPT_DIR/artifacts/${RECORD_ID}.result"
 
 # ---------------------------------------------------------
-# Benchmark Configuration Variables
-# These explicitly dictate the vLLM arguments and align
-# perfectly with the output Spanner database metrics schema
+# Benchmark Configuration Variables & Argument Parsing
 # ---------------------------------------------------------
+# Default values align with the original Qwen configuration
 export RUN_TYPE="DAILY"
 export MAX_NUM_SEQS="128"
 export MAX_MODEL_LEN="10240"
@@ -53,9 +50,108 @@ export DEVICE="tpu7x-16"
 export CODE_HASH="a4047d4-cf732f1-"
 export CREATED_BY="bm-scheduler"
 
+# New parameters for advanced/experimental models like DeepSeek
+export NEW_MODEL_DESIGN="0"
+export GPU_MEMORY_UTILIZATION="0.90"
+export ENABLE_EXPERT_PARALLEL=""
+export ADDITIONAL_CONFIG=""
+export DISABLE_SHARED_EXPERTS_STREAM="1"
+export GENERATION_CONFIG=""
+export VLLM_MLA_DISABLE_ENV=""
+export MOE_REQUANTIZE_BLOCK_SIZE=""
+export MOE_REQUANTIZE_WEIGHT_DTYPE=""
+export MOE_REQUANTIZE_BLOCK_SIZE_ENV=""
+export MOE_REQUANTIZE_WEIGHT_DTYPE_ENV=""
+export PHASED_PROFILING_DIR=""
+export PHASED_PROFILING_DIR_ENV=""
+export SKIP_DB_UPLOAD="false"
+
+# Parse command line arguments
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --model-path) TARGET_MODEL_PATH="$2"; shift 2 ;;
+    --model-name) MODEL_NAME="$2"; shift 2 ;;
+    --tokenizer) TARGET_TOKENIZER="$2"; shift 2 ;;
+    --input-len) INPUT_LEN="$2"; shift 2 ;;
+    --output-len) OUTPUT_LEN="$2"; shift 2 ;;
+    --tp-size) TENSOR_PARALLEL_SIZE="$2"; shift 2 ;;
+    --max-seqs) MAX_NUM_SEQS="$2"; shift 2 ;;
+    --max-model-len) MAX_MODEL_LEN="$2"; shift 2 ;;
+    --max-batched-tokens) MAX_NUM_BATCHED_TOKENS="$2"; shift 2 ;;
+    --num-prompts) NUM_PROMPTS="$2"; shift 2 ;;
+    --dataset-name) DATASET_NAME="$2"; shift 2 ;;
+    --run-type) RUN_TYPE="$2"; shift 2 ;;
+    --device) DEVICE="$2"; shift 2 ;;
+    --code-hash) CODE_HASH="$2"; shift 2 ;;
+    --created-by) CREATED_BY="$2"; shift 2 ;;
+    --new-model-design) NEW_MODEL_DESIGN="$2"; shift 2 ;;
+    --gpu-memory-utilization) GPU_MEMORY_UTILIZATION="$2"; shift 2 ;;
+    --enable-expert-parallel) ENABLE_EXPERT_PARALLEL="--enable-expert-parallel"; shift 1 ;;
+    --additional-config) ADDITIONAL_CONFIG="--additional_config='${2}'"; shift 2 ;;
+    --disable-shared-experts-stream) DISABLE_SHARED_EXPERTS_STREAM="$2"; shift 2 ;;
+    --generation-config) GENERATION_CONFIG="$2"; shift 2 ;;
+    --vllm-mla-disable) VLLM_MLA_DISABLE_ENV="VLLM_MLA_DISABLE=${2}"; shift 2 ;;
+    --moe-requantize-block-size) export MOE_REQUANTIZE_BLOCK_SIZE="$2"; MOE_REQUANTIZE_BLOCK_SIZE_ENV="MOE_REQUANTIZE_BLOCK_SIZE=$2"; shift 2 ;;
+    --moe-requantize-weight-dtype) export MOE_REQUANTIZE_WEIGHT_DTYPE="$2"; MOE_REQUANTIZE_WEIGHT_DTYPE_ENV="MOE_REQUANTIZE_WEIGHT_DTYPE=$2"; shift 2 ;;
+    --phased-profiling-dir) export PHASED_PROFILING_DIR="$2"; PHASED_PROFILING_DIR_ENV="PHASED_PROFILING_DIR=$2"; shift 2 ;;
+    --skip-db-upload) export SKIP_DB_UPLOAD="true"; shift 1 ;;
+    *) echo "Unknown parameter passed: $1"; exit 1 ;;
+  esac
+done
+
+BENCHMARK_LOG="$SCRIPT_DIR/artifacts/${MODEL_NAME}_${INPUT_LEN}_${OUTPUT_LEN}_${RECORD_ID}_benchmark.log"
+RESULT_FILE="$SCRIPT_DIR/artifacts/${MODEL_NAME}_${INPUT_LEN}_${OUTPUT_LEN}_${RECORD_ID}.result"
+
+PRE_SERVER_CMD=""
+EXTRA_SERVER_ARGS=""
+
+if [[ -n "${GENERATION_CONFIG}" ]]; then
+  echo "--- Generation config URL provided, preparing download to workspace..."
+  # e.g GENERATION_CONFIG="gs://gpolovets-inference/deepseek/generation_configs/DeepSeek-R1"
+  CONFIG_URL="${GENERATION_CONFIG%/*}" # gs://gpolovets-inference/deepseek/generation_configs
+  CONFIG_DIR_NAME=$(basename "${CONFIG_URL}") # generation_configs
+  CONFIG_FILE_NAME=$(basename "${GENERATION_CONFIG}") # DeepSeek-R1
+  
+  # Download to /workspace/ so it creates /workspace/generation_configs/ inside the docker container
+  PRE_SERVER_CMD="if ! command -v gsutil &> /dev/null; then curl -sSL https://sdk.cloud.google.com | bash -s -- --disable-prompts > /dev/null; export PATH=\"\$PATH:/root/google-cloud-sdk/bin\"; fi && mkdir -p /workspace && gsutil -m cp -r ${CONFIG_URL} /workspace/ && "
+  EXTRA_SERVER_ARGS="--generation-config /workspace/${CONFIG_DIR_NAME}/${CONFIG_FILE_NAME}"
+fi
+
 # Define the commands utilizing the unified parameters
-SERVER_CMD="TPU_BACKEND_TYPE=jax MODEL_IMPL_TYPE=vllm VLLM_DISABLE_SHARED_EXPERTS_STREAM=1 vllm serve --seed 42 --model ${TARGET_MODEL_PATH} --max-model-len=${MAX_MODEL_LEN} --max-num-batched-tokens ${MAX_NUM_BATCHED_TOKENS} --max-num-seqs ${MAX_NUM_SEQS} --no-enable-prefix-caching --tensor-parallel-size ${TENSOR_PARALLEL_SIZE} --kv_cache_dtype=\"fp8\" --no-async-scheduling --load-format=runai_streamer"
-BENCHMARK_CMD="vllm bench serve --model ${TARGET_MODEL_PATH} --tokenizer ${TARGET_TOKENIZER} --dataset-name ${DATASET_NAME} --random-input-len ${INPUT_LEN} --random-output-len ${OUTPUT_LEN} --num-prompts ${NUM_PROMPTS} --ignore-eos"
+SERVER_CMD="${PRE_SERVER_CMD}VLLM_DISABLE_SHARED_EXPERTS_STREAM=${DISABLE_SHARED_EXPERTS_STREAM} \
+NEW_MODEL_DESIGN=${NEW_MODEL_DESIGN} \
+${VLLM_MLA_DISABLE_ENV} \
+${MOE_REQUANTIZE_BLOCK_SIZE_ENV} \
+${MOE_REQUANTIZE_WEIGHT_DTYPE_ENV} \
+${PHASED_PROFILING_DIR_ENV} \
+TPU_BACKEND_TYPE=jax \
+MODEL_IMPL_TYPE=vllm \
+vllm serve \
+  --seed 42 \
+  --model ${TARGET_MODEL_PATH} \
+  ${EXTRA_SERVER_ARGS} \
+  --served-model-name ${TARGET_TOKENIZER} \
+  --max-model-len=${MAX_MODEL_LEN} \
+  --max-num-batched-tokens ${MAX_NUM_BATCHED_TOKENS} \
+  --max-num-seqs ${MAX_NUM_SEQS} \
+  --no-enable-prefix-caching \
+  --tensor-parallel-size ${TENSOR_PARALLEL_SIZE} \
+  --kv_cache_dtype=\"fp8\" \
+  --no-async-scheduling \
+  --gpu-memory-utilization=${GPU_MEMORY_UTILIZATION} \
+  ${ENABLE_EXPERT_PARALLEL} \
+  ${ADDITIONAL_CONFIG} \
+  --load-format=runai_streamer \
+  --trust-remote-code"
+
+BENCHMARK_CMD="vllm bench serve \
+  --model ${TARGET_TOKENIZER} \
+  --dataset-name ${DATASET_NAME} \
+  --random-input-len ${INPUT_LEN} \
+  --random-output-len ${OUTPUT_LEN} \
+  --num-prompts ${NUM_PROMPTS} \
+  --ignore-eos \
+  --trust-remote-code"
 
 
 echo "=== Starting nightly benchmark (Record ID: $RECORD_ID) ==="
@@ -133,6 +229,12 @@ Model=${MODEL_NAME}
 JobReference=${JOB_REFERENCE}
 EOF
 
+fi
+
+if [[ "${SKIP_DB_UPLOAD}" == "true" ]]; then
+  echo "=== Skipping Spanner DB Upload (--skip-db-upload specified) ==="
+  echo "=== Nightly benchmark script completed successfully ==="
+  exit 0
 fi
 
 # 3. Report results to Spanner (mimicking bm-infra/scripts/agent/report_result.sh but inserting instead of updating)

--- a/tpu_inference/platforms/tpu_platform.py
+++ b/tpu_inference/platforms/tpu_platform.py
@@ -56,6 +56,8 @@ class TpuPlatform(Platform):
         "NEW_MODEL_DESIGN",
         "MODEL_IMPL_TYPE",
         "VLLM_DISABLE_SHARED_EXPERTS_STREAM",
+        "MOE_REQUANTIZE_BLOCK_SIZE",
+        "MOE_REQUANTIZE_WEIGHT_DTYPE",
     ]
 
     @classmethod


### PR DESCRIPTION
# Description
This PR introduces comprehensive benchmarking and profiling support for DeepSeek (V3/R1) and Qwen3 Coder models on multihost TPU environments. It significantly extends the existing nightly_benchmarking.sh script to parse and inject advanced model-specific configurations and backend parameters required by these experimental architectures.

# Key Changes
* DeepSeek Benchmarking & Profiling Scripts: Added dedicated runner scripts (run_deepseek_v3_*.sh and run_qwen3_coder_*.sh) and xprof profiling scripts (xprof_deepseek_v3_*.sh) for various context lengths (1k/1k, 1k/8k, 8k/1k).
* Enhanced nightly_benchmarking.sh Capabilities:
    * Advanced Argument Parsing: Added support for new flags to configure MoE and VLLM specifics such as --gpu-memory-utilization, --enable-expert-parallel, --additional-config, --generation-config, --vllm-mla-disable, --phased-profiling-dir, and MoE requantization options.
    * Dynamic Config Injection: Automatically fetches generation configs from GCS into the Docker workspace via gsutil if a --generation-config GCS URL is provided.
    * DB Upload Toggle: Added --skip-db-upload flag to bypass Spanner DB uploads during local or testing runs.
    * Trust Remote Code: Added --trust-remote-code to both vllm serve and vllm bench serve commands to natively support experimental HuggingFace structures.
* TPU Backend Updates: Whitelisted MOE_REQUANTIZE_BLOCK_SIZE and MOE_REQUANTIZE_WEIGHT_DTYPE environment variables in tpu_platform.py to ensure they are properly propagated to the underlying JAX backend.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
