### PR TITLE
[Jax][Deepseek] Enable MLA (weight kept unquantized)

### DIFF
--- a/tests/layers/jax/test_qwix.py
+++ b/tests/layers/jax/test_qwix.py
@@ -16,8 +16,6 @@ from tpu_inference.models.common.model_loader import apply_qwix_quantization
 from tpu_inference.models.jax.utils.qwix.qwix_utils import (
     DEFAULT_MAX_NUM_BLOCKS_PER_REQ, DEFAULT_MAX_NUM_SEQS_FOR_MODEL_INPUTS,
     DEFAULT_NUM_TOKENS_FOR_MODEL_INPUTS)
-    DEFAULT_MAX_NUM_BLOCKS_PER_REQ, DEFAULT_MAX_NUM_SEQS_FOR_MODEL_INPUTS,
-    DEFAULT_NUM_TOKENS_FOR_MODEL_INPUTS)
 
 mock_nnx = MagicMock()
 mock_jax = MagicMock()

--- a/tpu_inference/models/common/model_loader.py
+++ b/tpu_inference/models/common/model_loader.py
@@ -75,7 +75,6 @@ def _get_model_architecture(config: PretrainedConfig) -> nnx.Module:
     from tpu_inference.models.jax.qwen3_moe import Qwen3MoeForCausalLM
     _MODEL_REGISTRY["Llama4ForCausalLM"] = Llama4ForCausalLM
     _MODEL_REGISTRY["DeepseekV3ForCausalLM"] = DeepseekV3ForCausalLM
-    _MODEL_REGISTRY["DeepseekV3ForCausalLM"] = DeepseekV3ForCausalLM
     _MODEL_REGISTRY["LlamaForCausalLM"] = LlamaForCausalLM
     _MODEL_REGISTRY["Llama4ForConditionalGeneration"] = LlamaGuard4ForCausalLM
     _MODEL_REGISTRY["Qwen3ForCausalLM"] = Qwen3ForCausalLM

--- a/tpu_inference/models/jax/deepseek_v3.py
+++ b/tpu_inference/models/jax/deepseek_v3.py
@@ -23,7 +23,6 @@ import jax
 import jax.numpy as jnp
 from flax import nnx
 from flax.typing import Sharding
-from flax.typing import Sharding
 from jax import lax
 from jax.sharding import Mesh
 from jax.sharding import PartitionSpec as P
@@ -51,7 +50,6 @@ from tpu_inference.layers.jax.moe.moe import JaxMoE
 from tpu_inference.layers.jax.moe.utils import (get_expert_parallelism,
                                                 select_moe_backend)
 from tpu_inference.layers.jax.norm import JaxRmsNorm
-from tpu_inference.layers.jax.pp_utils import PPMissingLayer, make_layers
 from tpu_inference.layers.jax.pp_utils import PPMissingLayer, make_layers
 from tpu_inference.layers.jax.quantization.configs import QuantizationConfig
 from tpu_inference.layers.jax.rope import DeepseekScalingRotaryEmbedding
@@ -329,6 +327,21 @@ class DeepseekV3BaseAttention(JaxModule):
 class DeepseekV3Attention(DeepseekV3BaseAttention):
     """Standard Multi-Head Attention (MHA) for DeepSeek models."""
 
+    def __post_init__(self, rngs: nnx.Rngs):
+        super().__post_init__(rngs)
+
+        weight_init = _weight_init(self.random_init)
+        self.kv_b_proj = JaxEinsum(
+            einsum_str="SA,AL->SL",
+            kernel_shape=(self.kv_lora_rank,
+                          self.N * (self.qk_nope_head_dim + self.v_head_dim)),
+            rngs=rngs,
+            quant_config=self.quant_config,
+            param_dtype=self.dtype,
+            kernel_init=nnx.with_partitioning(weight_init, self.ap_sharding),
+            prefix=self.prefix + ".kv_b_proj",
+        )
+
     def compute_q_projection(self, x_q_TD: jax.Array,
                              input_positions: jax.Array) -> jax.Array:
         """
@@ -474,6 +487,12 @@ class DeepseekV3Attention(DeepseekV3BaseAttention):
 
 
 class MLAEinsum(JaxEinsum):
+    """Extending JaxEinsum to handle MLA.
+    
+    This class is used for MLA, where:
+    1) the weight is split into k/v parts after loading, and
+    2) modify the MLA layer to set k/v weights
+    """
 
     def __init__(self,
                  mla_layer,
@@ -543,16 +562,32 @@ class MLAEinsum(JaxEinsum):
             JaxEinsum(einsum_str="TNA,ANH->TNH",
                       kernel_shape=(A, N, v_head_dim),
                       rngs=nnx.Rngs(0)))
-        mla_layer.k_up_proj.weight.value = shard_put(
-            k_ANH, self.mla_layer.anh_sharding)
-        mla_layer.v_up_proj.weight.value = shard_put(
-            v_ANH, self.mla_layer.anh_sharding)
+        mla_layer.k_up_proj.weight.set_raw_value(
+            shard_put(k_ANH, self.mla_layer.anh_sharding))
+        mla_layer.v_up_proj.weight.set_raw_value(
+            shard_put(v_ANH, self.mla_layer.anh_sharding))
 
 
 @dataclass(kw_only=True)
 class DeepseekV3MLA(DeepseekV3BaseAttention):
     """Multi-Head Latent Attention (MLA) for DeepSeek V3."""
     anh_sharding: Sharding = ()
+
+    def __post_init__(self, rngs: nnx.Rngs):
+        super().__post_init__(rngs)
+
+        weight_init = _weight_init(self.random_init)
+        self.kv_b_proj = MLAEinsum(
+            mla_layer=self,
+            einsum_str="SA,AL->SL",
+            kernel_shape=(self.kv_lora_rank,
+                          self.N * (self.qk_nope_head_dim + self.v_head_dim)),
+            rngs=rngs,
+            quant_config=self.quant_config,
+            param_dtype=self.dtype,
+            kernel_init=nnx.with_partitioning(weight_init, self.ap_sharding),
+            prefix=self.prefix + ".kv_b_proj",
+        )
 
     def compute_q_projection(
             self, x_q_TD: jax.Array,
@@ -680,7 +715,6 @@ class DeepseekV3MLA(DeepseekV3BaseAttention):
 
 
 @dataclass(kw_only=True)
-class DeepseekV3MLP(JaxModule):
 class DeepseekV3MLP(JaxModule):
     """A Gated Feed-Forward Network (FFN) layer.
 
@@ -1046,9 +1080,7 @@ class DeepSeekV3(JaxModule):
     def __init__(self,
                  vllm_config: VllmConfig,
                  rng: nnx.Rngs,
-                 rng: nnx.Rngs,
                  mesh: Mesh,
-                 quant_config,
                  quant_config,
                  prefix: str = ""):
         self.vllm_config = vllm_config
@@ -1087,7 +1119,6 @@ class DeepSeekV3(JaxModule):
                 embedding_init=nnx.with_partitioning(
                     init_fn, (ShardingAxisName.MLP_TENSOR, )),
                 rngs=rng,
-                quant_config=quant_config,
                 quant_config=quant_config,
                 prefix=prefix + ".embed_tokens",
             )
@@ -1294,17 +1325,6 @@ class DeepseekV3ForCausalLM(JaxModule, LoadableWithIterator):
                                       "quantization_config", {})
             vllm_config.quant_config = Fp8Config(hg_quant_config)
 
-        if getattr(vllm_config.model_config, "quantization", None) == "fp8":
-            # `get_tpu_quantization_config` returns None for "fp8" because
-            # the work in #1623 is not fully merged. So this block overrides
-            # the logic to return Fp8Config when model_config indicates fp8.
-            # TODO(#1623): Remove this block when `get_tpu_quantization_config`
-            # is updated.
-            from tpu_inference.layers.jax.quantization.fp8 import Fp8Config
-            hg_quant_config = getattr(vllm_config.model_config.hf_config,
-                                      "quantization_config", {})
-            vllm_config.quant_config = Fp8Config(hg_quant_config)
-
         self.vllm_config = vllm_config
         rng = nnx.Rngs(rng_key)
         self.mesh = mesh
@@ -1313,7 +1333,6 @@ class DeepseekV3ForCausalLM(JaxModule, LoadableWithIterator):
             vllm_config=vllm_config,
             rng=rng,
             mesh=mesh,
-            quant_config=vllm_config.quant_config,
             quant_config=vllm_config.quant_config,
             prefix="model",
         )


### PR DESCRIPTION
# Description

This PR enables MLA for deekseek, similar to [upstream](https://github.com/vllm-project/vllm/blob/main/vllm/model_executor/layers/attention/mla_attention.py#L653-L677), weights are kept unquantized.

Added `MLAEinsum` is kept in deepseek_v3.py because it's only used in DS model, and coupled with MLA module (modifies MLA layer during load_weights). If future models want to reuse it, we can refactor later.

# Tests

```
export CURRENT_VLLM_MODEL=deepseek-ai/DeepSeek-R1
VLLM_MLA_DISABLE=0 MOE_REQUANT_BLOCK_SIZE=256 MOE_REQUANT_WEIGHT_DTYPE=fp4 USE_UNFUSED_MEGABLOCKS=0 NEW_MODEL_DESIGN=1 TPU_BACKEND_TYPE=jax \
MODEL_IMPL_TYPE=flax_nnx vllm serve $CURRENT_VLLM_MODEL \
    --gpu-memory-utilization=0.95 --max-model-len=5120 --max-num-seqs=16 --max-num-batched-tokens 128 \
    --disable-log-requests \
    --no-enable-prefix-caching \
    --tensor-parallel-size 8 \
    --additional_config='{"sharding": {"sharding_strategy": {"enable_dp_attention": true, "expert_parallelism": 1, "tensor_parallelism": 8}}, "sparse_matmul": "True"}' \
    --no-async-scheduling
```

MMLU
```
============ Serving Benchmark Result ============
Successful requests:                     1000
Benchmark duration (s):                  44.43
Total input tokens:                      180362
Total generated tokens:                  2000
Request throughput (req/s):              22.51
Output token throughput (tok/s):         45.01
Total token throughput (tok/s):          4104.43                 <------ + 82%
---------------Time to First Token----------------
Mean TTFT (ms):                          21972.57
Median TTFT (ms):                        21760.02
P99 TTFT (ms):                           43740.80
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          234.10
Median TPOT (ms):                        234.44
P99 TPOT (ms):                           239.46
---------------Inter-token Latency----------------
Mean ITL (ms):                           234.10
Median ITL (ms):                         234.44
P99 ITL (ms):                            239.47
----------------End-to-end Latency----------------
Mean E2EL (ms):                          22206.67
Median E2EL (ms):                        21994.88
P99 E2EL (ms):                           43977.32
==================================================
Evaluating MMLU...

Results

{'accuracy': 0.784, 'gen_num': 1000}
```
baseline #1835 


# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
