### PR TITLE
Fix mla assertion

### DIFF
--- a/tpu_inference/runner/kv_cache.py
+++ b/tpu_inference/runner/kv_cache.py
@@ -45,17 +45,19 @@ def get_kv_cache_shape_with_mesh(mesh: Mesh,
     axis_name = ShardingAxisName.ATTN_HEAD
     model_cnt = utils.get_mesh_shape_product(mesh, axis_name)
 
-    assert actual_num_kv_heads % model_cnt == 0
     # NOTE(chengjiyao): Currently, the attention kernel is tailored to the
     # specific model, rather than being determined by the head_dim. If new
     # models are introduced with a head_dim of 64, this will require additional
     # model-specific adjustments.
     if use_mla:
+        # No assertion needed: MLA compresses all KV into a single latent vector,
+        # so actual_num_kv_heads is never used in mla.get_kv_cache_shape().
         get_kv_cache_shape_fn = mla.get_kv_cache_shape
         shape = list(
             get_kv_cache_shape_fn(total_num_pages, page_size, actual_head_dim,
                                   kv_dtype))
     else:
+        assert actual_num_kv_heads % model_cnt == 0
         get_kv_cache_shape_fn = (
             rpa_hd64.get_kv_cache_shape if actual_head_dim == 64 \
                 else rpa.get_kv_cache_shape


### PR DESCRIPTION
# Description

Fix wrong assertion in `get_kv_cache_shape_with_mesh` that causes MLA models (e.g. DeepSeek V3) to crash with `tensor_parallel_size > 1`.

The assert `actual_num_kv_heads % model_cnt == 0` was placed before the `if use_mla / else` branch. MLA has `num_kv_heads=1` which is not divisible by any TP size greater than 1, so it always fired for MLA + TP > 1.
The assertion only makes sense for standard attention where KV heads are split across TP devices — MLA does not shard by KV heads at all.

Move the assert into the `else` block where it belongs, directly above `actual_num_kv_heads // model_cnt` which it protects.

FIXES: #1847

# Tests

Tested with DeepSeek V3 and `tensor_parallel_size > 1`.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
