### PR TITLE
remove all unnecssary all-gather within attn layer, via correcty sharding of w_uk and w_uv

### DIFF
--- a/tests/layers/vllm/test_mla_attention.py
+++ b/tests/layers/vllm/test_mla_attention.py
@@ -118,14 +118,16 @@ class TestVllmTPUMLAAttention:
             prefix="test",
         )
 
-        attn.W_UK_T = torchax.tensor.Tensor(jnp.ones((10, 10)), env=torchax.default_env())
-        attn.W_UV = torchax.tensor.Tensor(jnp.ones((10, 10)), env=torchax.default_env())
+        attn.W_UK_T = torchax.tensor.Tensor(jnp.ones((10, 10)),
+                                            env=torchax.default_env())
+        attn.W_UV = torchax.tensor.Tensor(jnp.ones((10, 10)),
+                                          env=torchax.default_env())
         attn.kv_b_proj = MagicMock()
         attn.kv_b_proj.quant_method.linear_config.mesh = mesh
         attn.kv_b_proj.named_parameters.return_value = {}
 
         with patch(
-            "vllm.model_executor.layers.attention.mla_attention.MLAAttention.process_weights_after_loading"
+                "vllm.model_executor.layers.attention.mla_attention.MLAAttention.process_weights_after_loading"
         ) as mock_super_process:
             with torchax.default_env():
                 attn.process_weights_after_loading(torch.float32)

--- a/tpu_inference/layers/vllm/mla_attention.py
+++ b/tpu_inference/layers/vllm/mla_attention.py
@@ -14,22 +14,24 @@
 import jax
 import torch
 import torchax
-from jax.sharding import PartitionSpec as P, NamedSharding
+from jax.sharding import NamedSharding
+from jax.sharding import PartitionSpec as P
 from torch.nn import Parameter
-from torchax.interop import torch_view, jax_view
+from torchax.interop import jax_view, torch_view
 from vllm.config import CacheConfig
-from vllm.model_executor.layers.attention.attention import get_attention_context
+from vllm.model_executor.layers.attention.attention import \
+    get_attention_context
 from vllm.model_executor.layers.attention.mla_attention import MLAAttention
 from vllm.model_executor.layers.linear import ColumnParallelLinear
-from vllm.model_executor.layers.mla import MLAModules, MultiHeadLatentAttentionWrapper
+from vllm.model_executor.layers.mla import (MLAModules,
+                                            MultiHeadLatentAttentionWrapper)
 from vllm.model_executor.layers.quantization import QuantizationConfig
 from vllm.v1.attention.backend import AttentionType
-from tpu_inference.layers.common.sharding import ShardingAxisName
 
 from tpu_inference import utils
-from tpu_inference.models.vllm.vllm_model_wrapper_context import (
-    get_vllm_model_wrapper_context,
-)
+from tpu_inference.layers.common.sharding import ShardingAxisName
+from tpu_inference.models.vllm.vllm_model_wrapper_context import \
+    get_vllm_model_wrapper_context
 
 
 class VllmTPUMLAAttention(MLAAttention):
@@ -65,8 +67,7 @@ class VllmTPUMLAAttention(MLAAttention):
         self.kv_cache_quantized_dtype = None
         if self.kv_cache_dtype != "auto":
             self.kv_cache_quantized_dtype = utils.get_jax_dtype_from_str_dtype(
-                self.kv_cache_dtype
-            )
+                self.kv_cache_dtype)
 
     def process_weights_after_loading(self, act_dtype: torch.dtype):
         with torchax.default_env():
@@ -79,11 +80,13 @@ class VllmTPUMLAAttention(MLAAttention):
             # Device_put `W_UK_T`, `W_UV` to TPUs
             mesh = self.kv_b_proj.quant_method.linear_config.mesh
             self.W_UK_T = torch_view(
-                jax.device_put(jax_view(self.W_UK_T), NamedSharding(mesh, P(ShardingAxisName.ATTN_HEAD,)))
-            )
+                jax.device_put(
+                    jax_view(self.W_UK_T),
+                    NamedSharding(mesh, P(ShardingAxisName.ATTN_HEAD, ))))
             self.W_UV = torch_view(
-                jax.device_put(jax_view(self.W_UV), NamedSharding(mesh, P(ShardingAxisName.ATTN_HEAD,)))
-            )
+                jax.device_put(
+                    jax_view(self.W_UV),
+                    NamedSharding(mesh, P(ShardingAxisName.ATTN_HEAD, ))))
 
             self.W_UK_T = Parameter(self.W_UK_T, requires_grad=False)
             self.W_UV = Parameter(self.W_UV, requires_grad=False)


### PR DESCRIPTION
# Description
remove all unnecssary all-gather within attn layer, via correcty sharding of w_uk and w_uv

(using single-host, 5 layers of DS model for faster test & iteration, using 1.5K decode batch size to simulate max throughput config for singlehost)

before this PR: http://xprof/trace_viewer.html?session_id=gxd-12216786850413704240
5 layer step time: 33.7ms

after this RP http://xprof.corp.google.com/trace_viewer/gxd-1053712665842639110
5 layers step time: 29.7ms

# Tests
Quality test no diff:
python ./tpu-inference/scripts/vllm/benchmarking/benchmark_serving.py --backend vllm --model deepseek-ai/DeepSeek-R1 --dataset-name mmlu --dataset-path /home/gxd_google_com/work-dir/mmlu/data/test --num-prompts 1000 --run_eval --temperature 0

```
Successful requests:                     1000      
Benchmark duration (s):                  33.75     
Total input tokens:                      173929    
Total generated tokens:                  2000      
Request throughput (req/s):              29.63     
Output token throughput (tok/s):         59.26     
Total token throughput (tok/s):          5212.50   
---------------Time to First Token----------------
Mean TTFT (ms):                          18051.63  
Median TTFT (ms):                        16857.51  
P99 TTFT (ms):                           33622.56  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          1395.42   
Median TPOT (ms):                        1450.03   
P99 TPOT (ms):                           1459.62   
---------------Inter-token Latency----------------
Mean ITL (ms):                           1395.42   
Median ITL (ms):                         1450.03   
P99 ITL (ms):                            1459.62   
----------------End-to-end Latency----------------
Mean E2EL (ms):                          19447.04  
Median E2EL (ms):                        18308.11  
P99 E2EL (ms):                           33646.13  
==================================================
Evaluating MMLU...
[nltk_data] Downloading package punkt to
[nltk_data]     /home/gxd_google_com/nltk_data...
[nltk_data]   Package punkt is already up-to-date!
[nltk_data] Downloading package punkt_tab to
[nltk_data]     /home/gxd_google_com/nltk_data...
[nltk_data]   Package punkt_tab is already up-to-date!

Results
{'accuracy': 0.862, 'gen_num': 1000}
```

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
