### PR TITLE
[JAX] Enable using different dims across layers in kv_cache_manager

### DIFF
--- a/tpu_inference/runner/kv_cache_manager.py
+++ b/tpu_inference/runner/kv_cache_manager.py
@@ -120,7 +120,6 @@ class KVCacheManager:
             parallel_config = self.runner.parallel_config
             text_config = getattr(model_config, "hf_text_config",
                                   getattr(model_config, "hf_config", None))
-            # Pad num_kv_heads to multiple of TP size.
             base_num_kv_heads = model_config.get_total_num_kv_heads()
             base_head_size = model_config.get_head_size()
 
@@ -145,10 +144,11 @@ class KVCacheManager:
                     else:
                         num_kv_heads = base_num_kv_heads
                         head_size = base_head_size
+                    # Pad num_kv_heads to multiple of TP size.
                     num_kv_heads = common_utils.get_padded_num_heads(
                         num_kv_heads, model_cnt)
                     head_size = common_utils.get_padded_head_dim(head_size)
-                    # TODO(kwang3939): Re-enable sliding_window once mixed dims sliding_window with is supported.
+                    # TODO(kwang3939): Re-enable sliding_window once mixed dims with sliding_window is supported.
                     sliding_window = None
                     kv_cache_spec[f"layer.{i}"] = self._create_attention_spec(
                         block_size,


### PR DESCRIPTION
# Description
* Add hybird kv cache for jax path:
The existing `kv_cache_manager` does not support hybrid kv cache for jax path. 
I enable it by using `layer_types`, this could be refined later by unifying the logic in jax and torchax path. By unifying, the logic of checking if dims need to be set differently based on `layer_type` can also be removed. Added a `TODO` there.

* Add support for initializing kv_cache with mix dims for different layers:
Currently, mixed dims cannot be used with sliding_window. Thus, I temporarily disable the sliding window support in jax path forcing to use [UniformTypeKVCacheSpecs](https://github.com/vllm-project/vllm/blob/8fa68a8ce45641420a080920fccd9139aba80613/vllm/v1/kv_cache_interface.py#L375).
Though page sizes across layers are unified through [`unify_kv_cache_spec_page_size`](https://github.com/vllm-project/vllm/blob/3a8eef5869b8997af22f7b204eba56f9e654875e/vllm/v1/core/kv_cache_utils.py#L911) by adjusting block size, layers with different dims will be added into the same `kv_cache_tensor` in `kv_cache_config` and [share the same kv_cache](https://github.com/vllm-project/tpu-inference/blob/8b4414a2de5e76d4c72a7993b0a963be2f442030/tpu_inference/runner/kv_cache_manager.py#L250). This is naturally handled in GPU through `view` but need reshaping for TPU due to static shape limitation.  
I will figure out a way to handle this later. 



# Tests

Tested with:
```
python3 -m pytest -s -v tests/e2e/test_hybrid_kvcache.py
python3 -m pytest -s -v tests/runner/test_kv_cache_manager.py
```

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
