### PR TITLE
Skip outer JIT for models that self-manage sharding

### DIFF
--- a/tpu_inference/models/common/model_loader.py
+++ b/tpu_inference/models/common/model_loader.py
@@ -166,6 +166,27 @@ def _get_nnx_model(
                                              use_qwix_on_abstract_model=True)
             return jit_model
 
+        if getattr(model_class, '_self_manages_sharding', False):
+            # `_self_manages_sharding` is a class-level boolean flag set to True
+            # by model classes (e.g. MaxText-backed models) that handle their own
+            # JIT-compiled, sharded weight initialization internally — typically by
+            # wrapping construction in jax.jit with explicit out_shardings. For
+            # these models, the standard path below (which wraps create_abstract_model
+            # + with_sharding_constraint in an outer @jax.jit) must be skipped:
+            # adding a second outer jit causes nested JIT inlining that re-traces
+            # and multiplies compilation time without benefit.
+            with mesh:
+                jit_model = model_class(vllm_config, rng, mesh)
+                jit_model = apply_qwix_quantization(
+                    vllm_config,
+                    jit_model,
+                    rng,
+                    mesh,
+                    apply_to_abstract_model=False)
+                if hasattr(jit_model, 'initialize_cache'):
+                    jit_model.initialize_cache()
+            return jit_model
+
         @jax.jit
         def create_sharded_model():
             model = create_abstract_model()


### PR DESCRIPTION
# Description
                                                                                                                                                              
 ### Summary                                                                                                                                                                              
                                                                  
  Adds a bypass in _get_nnx_model for model classes that handle their own JIT-sharded initialization internally.

  Previously, all NNX models went through an outer @jax.jit-wrapped create_sharded_model() function. For models that already use out_shardings (or equivalent) during construction,
  this caused nested JIT inlining, which multiplies compilation overhead unnecessarily.

 ### Changes

  tpu_inference/models/common/model_loader.py: Added a new early-return path in _get_nnx_model for model classes decorated with _self_manages_sharding = True. These models are
  instantiated directly under the mesh context, skipping the outer @jax.jit wrapper, while still applying Qwix quantization and KV cache initialization.

  ### How it works

  If a model class sets the class attribute _self_manages_sharding = True, the loader will:
  1. Instantiate the model directly within the mesh context (no outer JIT)
  2. Apply Qwix quantization (apply_to_abstract_model=False)
  3. Call initialize_cache() if present

  All other models follow the existing path unchanged.

 ### Why

  Models that internally use create_nnx_model with out_shardings already emit the correct sharding constraints during construction. Wrapping them again in @jax.jit triggers redundant
  recompilation and is unnecessary overhead.

If the change fixes a Github issue, please include a link, e.g.,:
FIXES: #123456

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
