### PR TITLE
[Spec Decoding] Integrate DFlash into speculative decoding pipeline

### DIFF
--- a/tests/runner/test_speculative_decoding_manager.py
+++ b/tests/runner/test_speculative_decoding_manager.py
@@ -22,11 +22,14 @@ from vllm.config import (CacheConfig, ModelConfig, ParallelConfig,
 from vllm.sampling_params import SamplingType
 from vllm.v1.outputs import DraftTokenIds
 
+from tpu_inference.layers.common.attention_metadata import AttentionMetadata
 from tpu_inference.runner.input_batch import CachedRequestState, InputBatch
 from tpu_inference.runner.speculative_decoding_manager import \
     SpecDecodeMetadata
 from tpu_inference.runner.tpu_runner import TPUModelRunner
+from tpu_inference.spec_decode.jax.dflash import DFlashProposer
 from tpu_inference.spec_decode.jax.eagle3 import Eagle3Proposer
+from tpu_inference.spec_decode.torchax.dflash import DFlashTorchaxProposer
 
 
 class TestSpeculativeDecodingManager:
@@ -401,3 +404,104 @@ class TestSpeculativeDecodingManager:
         assert result == [[10, 11], [20, 21]]
         self.runner.drafter.prepare_inputs.assert_called_once()
         self.runner.drafter.propose.assert_called_once()
+
+    @pytest.mark.parametrize(("proposer_cls", "draft_impl_env"), [
+        (DFlashProposer, "flax_nnx"),
+        (DFlashTorchaxProposer, "torchax"),
+    ])
+    @pytest.mark.parametrize("spec_decode_metadata_is_none", [True, False])
+    def test_propose_dflash_draft_token_ids(self, monkeypatch, proposer_cls,
+                                            draft_impl_env,
+                                            spec_decode_metadata_is_none):
+        """Tests the logic for proposing DFlash draft tokens."""
+        # 1. ===== Setup =====
+        monkeypatch.setenv("DRAFT_MODEL_IMPL_TYPE", draft_impl_env)
+        self.runner.drafter = MagicMock(spec=proposer_cls)
+        self.runner.speculative_config.method = "dflash"
+
+        # Mock TPUModelRunner attributes
+        self.runner.input_batch = MagicMock()
+        self.runner.input_batch.req_ids = ["req-1", "req-2"]
+        # propose_dflash_draft_token_ids reads num_tokens_no_spec to derive the
+        # accepted context length (advance by len(token_ids) - 1 per request
+        # that sampled). Provide a real array so slicing/copy work.
+        self.runner.input_batch.num_tokens_no_spec = np.array([10, 12],
+                                                              dtype=np.int32)
+        self.runner.requests = {
+            "req-1": MagicMock(),
+            "req-2": MagicMock(),
+        }
+        self.runner.mesh = self.mock_mesh
+        self.runner.max_num_reqs = 8
+        self.runner.dp_size = 1
+        self.runner.kv_caches = MagicMock()
+
+        # Mock drafter methods
+        mock_attn_metadata = MagicMock()
+        mock_target_token_ids = MagicMock()
+        mock_last_token_indices = MagicMock()
+        mock_target_hidden_states = MagicMock()
+        self.runner.drafter.prepare_inputs.return_value = (
+            mock_target_hidden_states,
+            mock_target_token_ids,
+            mock_last_token_indices,
+            mock_attn_metadata,
+        )
+        mock_draft_token_ids = [[10, 11], [20, 21]]
+        self.runner.drafter.propose.return_value = (
+            self.runner.kv_caches,
+            mock_draft_token_ids,
+        )
+
+        # Inputs.  Real AttentionMetadata (not a MagicMock) because
+        # propose_dflash_draft_token_ids invokes `dataclasses.replace` on it.
+        sampled_token_ids = [[1], [2]]
+        aux_hidden_states = MagicMock()
+        attn_metadata = AttentionMetadata(
+            input_positions=np.zeros(0, dtype=np.int32),
+            seq_lens=np.array([10, 12], dtype=np.int32),
+        )
+        if spec_decode_metadata_is_none:
+            spec_decode_metadata = None
+        else:
+            spec_decode_metadata = MagicMock(spec=SpecDecodeMetadata)
+            spec_decode_metadata.draft_lengths_cpu = np.array([2, 3])
+        scheduler_output = MagicMock()
+        input_ids = MagicMock()
+
+        # 2. ===== Act =====
+        with patch(
+                "tpu_inference.runner.speculative_decoding_manager.device_array",
+                side_effect=lambda mesh, x: x):
+            result = self.runner.speculative_decoding_manager.propose_dflash_draft_token_ids(
+                sampled_token_ids,
+                aux_hidden_states,
+                attn_metadata,
+                spec_decode_metadata,
+                scheduler_output,
+                input_ids,
+            )
+
+        # 3. ===== Assert =====
+        assert result == [[10, 11], [20, 21]]
+        self.runner.drafter.prepare_inputs.assert_called_once()
+        self.runner.drafter.propose.assert_called_once()
+
+        # Each req sampled one token this step (len(token_ids) - 1 == 0), so the
+        # accepted context length stays at num_tokens_no_spec (the newest token
+        # has no hidden state yet).
+        prepare_call_args = self.runner.drafter.prepare_inputs.call_args.args
+        corrected_metadata = prepare_call_args[0]
+        np.testing.assert_array_equal(np.asarray(corrected_metadata.seq_lens),
+                                      np.array([10, 12], dtype=np.int32))
+
+        # num_rejected_tokens shape: with draft_lengths=[2,3] and each req
+        # sampling 1 token, num_rejected = [2+1-1, 3+1-1] = [2, 3] padded to
+        # runner.max_num_reqs (=8) with zeros. None when spec metadata absent.
+        passed_num_rejected = prepare_call_args[4]
+        if spec_decode_metadata_is_none:
+            assert passed_num_rejected is None
+        else:
+            np.testing.assert_array_equal(
+                np.asarray(passed_num_rejected),
+                np.array([2, 3, 0, 0, 0, 0, 0, 0], dtype=np.int32))

--- a/tests/runner/test_speculative_decoding_manager.py
+++ b/tests/runner/test_speculative_decoding_manager.py
@@ -22,11 +22,14 @@ from vllm.config import (CacheConfig, ModelConfig, ParallelConfig,
 from vllm.sampling_params import SamplingType
 from vllm.v1.outputs import DraftTokenIds
 
+from tpu_inference.layers.common.attention_metadata import AttentionMetadata
 from tpu_inference.runner.input_batch import CachedRequestState, InputBatch
 from tpu_inference.runner.speculative_decoding_manager import \
     SpecDecodeMetadata
 from tpu_inference.runner.tpu_runner import TPUModelRunner
+from tpu_inference.spec_decode.jax.dflash import DFlashProposer
 from tpu_inference.spec_decode.jax.eagle3 import Eagle3Proposer
+from tpu_inference.spec_decode.torchax.dflash import DFlashTorchaxProposer
 
 
 class TestSpeculativeDecodingManager:
@@ -365,3 +368,103 @@ class TestSpeculativeDecodingManager:
         assert result == [[10, 11], [20, 21]]
         self.runner.drafter.prepare_inputs.assert_called_once()
         self.runner.drafter.propose.assert_called_once()
+
+    @pytest.mark.parametrize(("proposer_cls", "draft_impl_env"), [
+        (DFlashProposer, "flax_nnx"),
+        (DFlashTorchaxProposer, "torchax"),
+    ])
+    @pytest.mark.parametrize("spec_decode_metadata_is_none", [True, False])
+    def test_propose_dflash_draft_token_ids(self, monkeypatch, proposer_cls,
+                                            draft_impl_env,
+                                            spec_decode_metadata_is_none):
+        """Tests the logic for proposing DFlash draft tokens."""
+        # 1. ===== Setup =====
+        monkeypatch.setenv("DRAFT_MODEL_IMPL_TYPE", draft_impl_env)
+        self.runner.drafter = MagicMock(spec=proposer_cls)
+        self.runner.speculative_config.method = "dflash"
+
+        # Mock TPUModelRunner attributes
+        self.runner.input_batch = MagicMock()
+        self.runner.input_batch.req_ids = ["req-1", "req-2"]
+        # propose_dflash_draft_token_ids reads num_tokens_no_spec to derive
+        # accepted_seq_lens and applies the single-seq guard (subtract 1 per
+        # request that sampled). Provide a real array so slicing/copy work.
+        self.runner.input_batch.num_tokens_no_spec = np.array([10, 12],
+                                                              dtype=np.int32)
+        self.runner.requests = {
+            "req-1": MagicMock(),
+            "req-2": MagicMock(),
+        }
+        self.runner.mesh = self.mock_mesh
+        self.runner.max_num_reqs = 8
+        self.runner.kv_caches = MagicMock()
+
+        # Mock drafter methods
+        mock_attn_metadata = MagicMock()
+        mock_target_token_ids = MagicMock()
+        mock_last_token_indices = MagicMock()
+        mock_target_hidden_states = MagicMock()
+        self.runner.drafter.prepare_inputs.return_value = (
+            mock_target_hidden_states,
+            mock_target_token_ids,
+            mock_last_token_indices,
+            mock_attn_metadata,
+        )
+        mock_draft_token_ids = [[10, 11], [20, 21]]
+        self.runner.drafter.propose.return_value = (
+            self.runner.kv_caches,
+            mock_draft_token_ids,
+        )
+
+        # Inputs.  Real AttentionMetadata (not a MagicMock) because
+        # propose_dflash_draft_token_ids invokes `dataclasses.replace` on it.
+        sampled_token_ids = [[1], [2]]
+        aux_hidden_states = MagicMock()
+        attn_metadata = AttentionMetadata(
+            input_positions=np.zeros(0, dtype=np.int32),
+            seq_lens=np.array([10, 12], dtype=np.int32),
+        )
+        if spec_decode_metadata_is_none:
+            spec_decode_metadata = None
+        else:
+            spec_decode_metadata = MagicMock(spec=SpecDecodeMetadata)
+            spec_decode_metadata.draft_lengths_cpu = np.array([2, 3])
+        scheduler_output = MagicMock()
+        input_ids = MagicMock()
+
+        # 2. ===== Act =====
+        with patch(
+                "tpu_inference.runner.speculative_decoding_manager.device_array",
+                side_effect=lambda mesh, x: x):
+            result = self.runner.speculative_decoding_manager.propose_dflash_draft_token_ids(
+                sampled_token_ids,
+                aux_hidden_states,
+                attn_metadata,
+                spec_decode_metadata,
+                scheduler_output,
+                input_ids,
+            )
+
+        # 3. ===== Assert =====
+        assert result == [[10, 11], [20, 21]]
+        self.runner.drafter.prepare_inputs.assert_called_once()
+        self.runner.drafter.propose.assert_called_once()
+
+        # Single-seq guard: both reqs sampled this step, so each
+        # accepted_seq_lens entry should be decremented by 1.
+        prepare_call_args = self.runner.drafter.prepare_inputs.call_args.args
+        corrected_metadata = prepare_call_args[0]
+        np.testing.assert_array_equal(
+            np.asarray(corrected_metadata.seq_lens),
+            np.array([9, 11], dtype=np.int32))
+
+        # num_rejected_tokens shape: with draft_lengths=[2,3] and each req
+        # sampling 1 token, num_rejected = [2+1-1, 3+1-1] = [2, 3] padded to
+        # runner.max_num_reqs (=8) with zeros. None when spec metadata absent.
+        passed_num_rejected = prepare_call_args[4]
+        if spec_decode_metadata_is_none:
+            assert passed_num_rejected is None
+        else:
+            np.testing.assert_array_equal(
+                np.asarray(passed_num_rejected),
+                np.array([2, 3, 0, 0, 0, 0, 0, 0], dtype=np.int32))

--- a/tpu_inference/envs.py
+++ b/tpu_inference/envs.py
@@ -247,7 +247,7 @@ environment_variables: dict[str, Callable[[], Any]] = {
                      ["auto", "vllm", "flax_nnx", "jetpack"]),
     "DRAFT_MODEL_IMPL_TYPE":
     env_with_choices("DRAFT_MODEL_IMPL_TYPE", "auto",
-                     ["auto", "vllm", "flax_nnx"]),
+                     ["auto", "vllm", "flax_nnx", "torchax"]),
     # Enable 2D tensor parallelism, shard attention heads across multiple axes
     "USE_2D_TP":
     env_bool("USE_2D_TP", default=False),

--- a/tpu_inference/envs.py
+++ b/tpu_inference/envs.py
@@ -17,6 +17,7 @@ if TYPE_CHECKING:
     SKIP_JAX_PRECOMPILE: bool = False
     VLLM_XLA_CHECK_RECOMPILATION: bool = False
     MODEL_IMPL_TYPE: str = "auto"
+    DRAFT_MODEL_IMPL_TYPE: str = "auto"
     NEW_MODEL_DESIGN: bool = False
     PHASED_PROFILING_DIR: str = ""
     PYTHON_TRACER_LEVEL: int = 1
@@ -137,6 +138,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "MODEL_IMPL_TYPE":
     env_with_choices("MODEL_IMPL_TYPE", "auto",
                      ["auto", "vllm", "flax_nnx", "jetpack"]),
+    "DRAFT_MODEL_IMPL_TYPE":
+    env_with_choices("DRAFT_MODEL_IMPL_TYPE", "auto",
+                     ["auto", "vllm", "flax_nnx", "torchax"]),
     # Enable 2D tensor parallelism, shard attention heads across multiple axes
     "USE_2D_TP":
     env_bool("USE_2D_TP", default=False),

--- a/tpu_inference/models/common/model_loader.py
+++ b/tpu_inference/models/common/model_loader.py
@@ -63,6 +63,7 @@ def _get_model_architecture(config: PretrainedConfig) -> nnx.Module:
     # would cause JAX init failure when using multi hosts with Ray.
 
     from tpu_inference.models.jax.deepseek_v3 import DeepseekV3ForCausalLM
+    from tpu_inference.models.jax.dflash import DFlashForCausalLM
     from tpu_inference.models.jax.gpt_oss import GptOss
     from tpu_inference.models.jax.llama3 import LlamaForCausalLM
     from tpu_inference.models.jax.llama4 import Llama4ForCausalLM
@@ -73,6 +74,7 @@ def _get_model_architecture(config: PretrainedConfig) -> nnx.Module:
         Qwen2_5_VLForConditionalGeneration
     from tpu_inference.models.jax.qwen3 import Qwen3ForCausalLM
     from tpu_inference.models.jax.qwen3_moe import Qwen3MoeForCausalLM
+    _MODEL_REGISTRY["DFlashDraftModel"] = DFlashForCausalLM
     _MODEL_REGISTRY["Llama4ForCausalLM"] = Llama4ForCausalLM
     _MODEL_REGISTRY["DeepseekV3ForCausalLM"] = DeepseekV3ForCausalLM
     _MODEL_REGISTRY["LlamaForCausalLM"] = LlamaForCausalLM

--- a/tpu_inference/models/common/model_loader.py
+++ b/tpu_inference/models/common/model_loader.py
@@ -71,6 +71,7 @@ def _get_model_architecture(config: PretrainedConfig) -> nnx.Module:
     # would cause JAX init failure when using multi hosts with Ray.
 
     from tpu_inference.models.jax.deepseek_v3 import DeepseekV3ForCausalLM
+    from tpu_inference.models.jax.dflash import DFlashForCausalLM
     from tpu_inference.models.jax.gemma4_mm import \
         Gemma4ForConditionalGeneration
     from tpu_inference.models.jax.gemma4_mtp import Gemma4MTPForCausalLM
@@ -84,6 +85,7 @@ def _get_model_architecture(config: PretrainedConfig) -> nnx.Module:
         Qwen2_5_VLForConditionalGeneration
     from tpu_inference.models.jax.qwen3 import Qwen3ForCausalLM
     from tpu_inference.models.jax.qwen3_moe import Qwen3MoeForCausalLM
+    _MODEL_REGISTRY["DFlashDraftModel"] = DFlashForCausalLM
     _MODEL_REGISTRY["Llama4ForCausalLM"] = Llama4ForCausalLM
     _MODEL_REGISTRY["DeepseekV3ForCausalLM"] = DeepseekV3ForCausalLM
     _MODEL_REGISTRY["LlamaForCausalLM"] = LlamaForCausalLM

--- a/tpu_inference/models/jax/qwen3.py
+++ b/tpu_inference/models/jax/qwen3.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from itertools import islice
 from typing import List, Optional, Tuple
 
 import jax
@@ -246,6 +247,27 @@ class Qwen3DecoderLayer(Qwen2DecoderLayer):
         )
 
 
+def _build_target_layer_ids(num_target_layers: int,
+                            num_draft_layers: int) -> list[int]:
+    if num_draft_layers == 1:
+        return [num_target_layers // 2]
+    return [
+        round(1 + i * (num_target_layers - 4) / (num_draft_layers - 1))
+        for i in range(num_draft_layers)
+    ]
+
+
+def _get_dflash_target_layer_ids(target_num_layers: int,
+                                 draft_hf_config) -> list[int]:
+    dflash_cfg = getattr(draft_hf_config, "dflash_config", None)
+    if dflash_cfg is not None:
+        target_layer_ids = dflash_cfg.get("target_layer_ids", None)
+        if target_layer_ids is not None:
+            return list(target_layer_ids)
+    num_draft_layers = draft_hf_config.num_hidden_layers
+    return _build_target_layer_ids(target_num_layers, num_draft_layers)
+
+
 class Qwen3Model(Qwen2Model):
 
     def __init__(self,
@@ -301,6 +323,65 @@ class Qwen3Model(Qwen2Model):
             )
         else:
             self.norm = PPMissingLayer()
+
+        self._init_aux_hidden_state_layers(vllm_config)
+
+    def _init_aux_hidden_state_layers(self, vllm_config):
+        self.aux_hidden_state_layers = []
+        self.capture_aux_after_layer = False
+        if vllm_config.speculative_config:
+            method = getattr(vllm_config.speculative_config, "method", None)
+            if method == "eagle3":
+                num_layers = len(self.layers)
+                self.aux_hidden_state_layers = (2, num_layers // 2,
+                                                num_layers - 3)
+            elif method == "dflash":
+                draft_config = (
+                    vllm_config.speculative_config.draft_model_config)
+                dflash_cfg = getattr(draft_config.hf_config, "dflash_config",
+                                     {})
+                target_layer_ids = dflash_cfg.get("target_layer_ids", None)
+                if target_layer_ids is not None:
+                    self.aux_hidden_state_layers = tuple(target_layer_ids)
+                else:
+                    num_target = getattr(draft_config.hf_config,
+                                         "num_target_layers", 5)
+                    num_layers = len(self.layers)
+                    step = max(1, (num_layers - 4) // (num_target - 1))
+                    self.aux_hidden_state_layers = tuple(
+                        range(1, num_layers - 2, step))[:num_target]
+                self.capture_aux_after_layer = True
+
+    def __call__(
+        self,
+        kv_caches: List[jax.Array],
+        input_ids: Optional[jax.Array],
+        attention_metadata,
+        inputs_embeds: Optional[jax.Array] = None,
+    ) -> Tuple[List[jax.Array], jax.Array, List[jax.Array]]:
+        if inputs_embeds is not None:
+            x = inputs_embeds
+        else:
+            x = self.embed_tokens(input_ids)
+
+        aux_hidden_states = []
+        for i, layer in enumerate(
+                islice(self.layers, self.start_layer, self.end_layer)):
+            if (not self.capture_aux_after_layer
+                    and i in self.aux_hidden_state_layers):
+                aux_hidden_states.append(x)
+            kv_cache = kv_caches[i]
+            kv_cache, x = layer(
+                kv_cache,
+                x,
+                attention_metadata,
+            )
+            kv_caches[i] = kv_cache
+            if (self.capture_aux_after_layer
+                    and i in self.aux_hidden_state_layers):
+                aux_hidden_states.append(x)
+        x = self.norm(x)
+        return kv_caches, x, aux_hidden_states
 
 
 class Qwen3ForCausalLM(JaxModule, LoadableWithIterator):
@@ -362,7 +443,7 @@ class Qwen3ForCausalLM(JaxModule, LoadableWithIterator):
         if not is_first_rank:
             assert intermediate_tensors is not None
             inputs_embeds = intermediate_tensors["hidden_states"]
-        kv_caches, x = self.model(
+        kv_caches, x, aux_hidden_states = self.model(
             kv_caches,
             input_ids,
             attention_metadata,
@@ -370,7 +451,7 @@ class Qwen3ForCausalLM(JaxModule, LoadableWithIterator):
         )
         if not is_last_rank:
             x = JaxIntermediateTensors(tensors={"hidden_states": x}, )
-        return kv_caches, x, []
+        return kv_caches, x, aux_hidden_states
 
     def compute_logits(self, hidden_states: jax.Array) -> jax.Array:
         if hasattr(self, 'lm_head'):

--- a/tpu_inference/models/jax/qwen3.py
+++ b/tpu_inference/models/jax/qwen3.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from itertools import islice
 from typing import List, Optional, Tuple
 
 import jax
@@ -317,6 +318,65 @@ class Qwen3Model(Qwen2Model):
         else:
             self.norm = PPMissingLayer()
 
+        self._init_aux_hidden_state_layers(vllm_config)
+
+    def _init_aux_hidden_state_layers(self, vllm_config):
+        self.aux_hidden_state_layers = []
+        self.capture_aux_after_layer = False
+        if vllm_config.speculative_config:
+            method = getattr(vllm_config.speculative_config, "method", None)
+            # Aux layer indices are GLOBAL (over all PP ranks). The forward
+            # loop converts the local enumeration index `i` to global via
+            # `self.start_layer + i` before testing membership; using
+            # `hf_config.num_hidden_layers` (global) here keeps the IDs
+            # stable across ranks.
+            target_num_layers = (
+                vllm_config.model_config.hf_config.num_hidden_layers)
+            if method == "eagle3":
+                self.aux_hidden_state_layers = (2, target_num_layers // 2,
+                                                target_num_layers - 3)
+            elif method == "dflash":
+                from tpu_inference.models.jax.qwen3_dflash import \
+                    _get_dflash_target_layer_ids
+                draft_hf_config = (vllm_config.speculative_config.
+                                   draft_model_config.hf_config)
+                self.aux_hidden_state_layers = tuple(
+                    _get_dflash_target_layer_ids(draft_hf_config,
+                                                 target_num_layers))
+                self.capture_aux_after_layer = True
+
+    def __call__(
+        self,
+        kv_caches: List[jax.Array],
+        input_ids: Optional[jax.Array],
+        attention_metadata,
+        inputs_embeds: Optional[jax.Array] = None,
+    ) -> Tuple[List[jax.Array], jax.Array, List[jax.Array]]:
+        if inputs_embeds is not None:
+            x = inputs_embeds
+        else:
+            x = self.embed_tokens(input_ids)
+
+        aux_hidden_states = []
+        for i, layer in enumerate(
+                islice(self.layers, self.start_layer, self.end_layer)):
+            global_layer_idx = self.start_layer + i
+            if (not self.capture_aux_after_layer
+                    and global_layer_idx in self.aux_hidden_state_layers):
+                aux_hidden_states.append(x)
+            kv_cache = kv_caches[i]
+            kv_cache, x = layer(
+                kv_cache,
+                x,
+                attention_metadata,
+            )
+            kv_caches[i] = kv_cache
+            if (self.capture_aux_after_layer
+                    and global_layer_idx in self.aux_hidden_state_layers):
+                aux_hidden_states.append(x)
+        x = self.norm(x)
+        return kv_caches, x, aux_hidden_states
+
 
 class Qwen3ForCausalLM(JaxModule, LoadableWithIterator):
 
@@ -371,7 +431,7 @@ class Qwen3ForCausalLM(JaxModule, LoadableWithIterator):
         if not is_first_rank:
             assert intermediate_tensors is not None
             inputs_embeds = intermediate_tensors["hidden_states"]
-        kv_caches, x = self.model(
+        kv_caches, x, aux_hidden_states = self.model(
             kv_caches,
             input_ids,
             attention_metadata,
@@ -379,7 +439,7 @@ class Qwen3ForCausalLM(JaxModule, LoadableWithIterator):
         )
         if not is_last_rank:
             x = JaxIntermediateTensors(tensors={"hidden_states": x}, )
-        return kv_caches, x, [], None
+        return kv_caches, x, aux_hidden_states, None
 
     def compute_logits(self, hidden_states: jax.Array) -> jax.Array:
         # Only use lm_head if it's a real projection layer (not a PPMissingLayer placeholder)

--- a/tpu_inference/models/jax/qwen3.py
+++ b/tpu_inference/models/jax/qwen3.py
@@ -331,25 +331,22 @@ class Qwen3Model(Qwen2Model):
         self.capture_aux_after_layer = False
         if vllm_config.speculative_config:
             method = getattr(vllm_config.speculative_config, "method", None)
+            # Aux layer indices are GLOBAL (over all PP ranks). The forward
+            # loop converts the local enumeration index `i` to global via
+            # `self.start_layer + i` before testing membership; using
+            # `hf_config.num_hidden_layers` (global) here keeps the IDs
+            # stable across ranks.
+            target_num_layers = (
+                vllm_config.model_config.hf_config.num_hidden_layers)
             if method == "eagle3":
-                num_layers = len(self.layers)
-                self.aux_hidden_state_layers = (2, num_layers // 2,
-                                                num_layers - 3)
+                self.aux_hidden_state_layers = (2, target_num_layers // 2,
+                                                target_num_layers - 3)
             elif method == "dflash":
-                draft_config = (
-                    vllm_config.speculative_config.draft_model_config)
-                dflash_cfg = getattr(draft_config.hf_config, "dflash_config",
-                                     {})
-                target_layer_ids = dflash_cfg.get("target_layer_ids", None)
-                if target_layer_ids is not None:
-                    self.aux_hidden_state_layers = tuple(target_layer_ids)
-                else:
-                    num_target = getattr(draft_config.hf_config,
-                                         "num_target_layers", 5)
-                    num_layers = len(self.layers)
-                    step = max(1, (num_layers - 4) // (num_target - 1))
-                    self.aux_hidden_state_layers = tuple(
-                        range(1, num_layers - 2, step))[:num_target]
+                draft_hf_config = (vllm_config.speculative_config.
+                                   draft_model_config.hf_config)
+                self.aux_hidden_state_layers = tuple(
+                    _get_dflash_target_layer_ids(target_num_layers,
+                                                 draft_hf_config))
                 self.capture_aux_after_layer = True
 
     def __call__(
@@ -367,8 +364,9 @@ class Qwen3Model(Qwen2Model):
         aux_hidden_states = []
         for i, layer in enumerate(
                 islice(self.layers, self.start_layer, self.end_layer)):
+            global_layer_idx = self.start_layer + i
             if (not self.capture_aux_after_layer
-                    and i in self.aux_hidden_state_layers):
+                    and global_layer_idx in self.aux_hidden_state_layers):
                 aux_hidden_states.append(x)
             kv_cache = kv_caches[i]
             kv_cache, x = layer(
@@ -378,7 +376,7 @@ class Qwen3Model(Qwen2Model):
             )
             kv_caches[i] = kv_cache
             if (self.capture_aux_after_layer
-                    and i in self.aux_hidden_state_layers):
+                    and global_layer_idx in self.aux_hidden_state_layers):
                 aux_hidden_states.append(x)
         x = self.norm(x)
         return kv_caches, x, aux_hidden_states

--- a/tpu_inference/runner/compilation_manager.py
+++ b/tpu_inference/runner/compilation_manager.py
@@ -1139,6 +1139,9 @@ class CompilationManager:
             self._precompile_eagle3_helpers()
         if self.runner.speculative_config.method == "mtp":
             self._precompile_mtp_helpers()
+        if (self.runner.speculative_config.method == "dflash"
+                and envs.DRAFT_MODEL_IMPL_TYPE == "torchax"):
+            self.runner.drafter.precompile()
 
     def _precompile_extract_draft_token_ids(self) -> None:
         logger.info(

--- a/tpu_inference/runner/compilation_manager.py
+++ b/tpu_inference/runner/compilation_manager.py
@@ -609,6 +609,9 @@ class CompilationManager:
         self._precompile_rejection_sampler()
         if self.runner.speculative_config.method == "eagle3":
             self._precompile_eagle3_helpers()
+        elif (self.runner.speculative_config.method == "dflash"
+              and envs.DRAFT_MODEL_IMPL_TYPE == "torchax"):
+            self.runner.drafter.precompile()
 
     def _precompile_rejection_sampler(self) -> None:
         logger.info("Compiling rejection_sampler with different input shapes.")

--- a/tpu_inference/runner/kv_cache_manager.py
+++ b/tpu_inference/runner/kv_cache_manager.py
@@ -156,7 +156,8 @@ class KVCacheManager:
                         head_size,
                         sliding_window=sliding_window)
 
-            if self.runner.speculative_config and self.runner.speculative_config.method == "eagle3":
+            if self.runner.speculative_config and self.runner.speculative_config.method in (
+                    "eagle3", "dflash"):
                 draft_model_config = self.runner.speculative_config.draft_model_config
                 hf_config = draft_model_config.hf_config
                 num_kv_heads = common_utils.get_padded_num_heads(
@@ -164,7 +165,8 @@ class KVCacheManager:
                 head_size = common_utils.get_padded_head_dim(
                     hf_config.hidden_size // hf_config.num_attention_heads)
                 # Eagle3 has only 1 layer
-                for i in range(1):
+                draft_num_layers = getattr(hf_config, 'num_hidden_layers', 1)
+                for i in range(draft_num_layers):
                     if self.use_mla:
                         kv_cache_spec[
                             f"draft_layer.{i}"] = self._create_attention_spec(

--- a/tpu_inference/runner/kv_cache_manager.py
+++ b/tpu_inference/runner/kv_cache_manager.py
@@ -563,6 +563,24 @@ class KVCacheManager:
                             kv_cache_spec[
                                 f"draft_layer.{i}"] = self._create_attention_spec(
                                     block_size, num_kv_heads, head_size)
+                elif method == "dflash":
+                    num_kv_heads = common_utils.get_padded_num_heads(
+                        draft_hf_config.num_key_value_heads, model_cnt)
+                    head_size = common_utils.get_padded_head_dim(
+                        draft_hf_config.hidden_size //
+                        draft_hf_config.num_attention_heads)
+                    # DFlash draft has num_hidden_layers layers
+                    draft_num_layers = getattr(draft_hf_config,
+                                               'num_hidden_layers', 1)
+                    for i in range(draft_num_layers):
+                        if self.use_mla:
+                            kv_cache_spec[
+                                f"draft_layer.{i}"] = self._create_attention_spec(
+                                    block_size, 1, mla_head_size)
+                        else:
+                            kv_cache_spec[
+                                f"draft_layer.{i}"] = self._create_attention_spec(
+                                    block_size, num_kv_heads, head_size)
         else:
             # Else propagate attention modules from compilation config.
             layers = get_layers_from_vllm_config(

--- a/tpu_inference/runner/speculative_decoding_manager.py
+++ b/tpu_inference/runner/speculative_decoding_manager.py
@@ -14,7 +14,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING, Optional
 
 import jax.numpy as jnp
@@ -83,6 +83,15 @@ class SpeculativeDecodingManager:
                 scheduler_output,
                 input_ids,
             )
+        elif self.runner.speculative_config.method == "dflash":
+            self._draft_token_ids = self.propose_dflash_draft_token_ids(
+                sampled_token_ids,
+                aux_hidden_states,
+                attn_metadata,
+                spec_decode_metadata,
+                scheduler_output,
+                input_ids,
+            )
         else:
             raise NotImplementedError(
                 f"Speculative decoding method "
@@ -141,6 +150,88 @@ class SpeculativeDecodingManager:
 
         target_hidden_states, input_ids, last_token_indices, attn_metadata = self.runner.drafter.prepare_inputs(
             attn_metadata,
+            input_ids,
+            aux_hidden_states,
+            next_token_ids,
+            num_rejected_tokens,
+        )
+
+        self.runner.kv_caches, draft_token_ids = self.runner.drafter.propose(
+            kv_caches=self.runner.kv_caches,
+            input_ids=input_ids,
+            attn_metadata=attn_metadata,
+            last_token_indices=last_token_indices,
+            target_hidden_states=target_hidden_states,
+        )
+        draft_token_ids = np.array(draft_token_ids)
+        if draft_token_ids.ndim == 1:
+            draft_token_ids = np.expand_dims(draft_token_ids, axis=-1)
+        return draft_token_ids.tolist()
+
+    def propose_dflash_draft_token_ids(
+        self,
+        sampled_token_ids: list[list[int]],
+        aux_hidden_states: Optional[tuple[jnp.ndarray, ...]],
+        attn_metadata: AttentionMetadata,
+        spec_decode_metadata: Optional[SpecDecodeMetadata],
+        scheduler_output: VllmSchedulerOutput,
+        input_ids: jnp.ndarray,
+    ) -> list[list[int]]:
+        # TODO(woosuk): Refactor the loop.
+        req_ids = self.runner.input_batch.req_ids
+        next_token_ids: list[int] = []
+        for i, token_ids in enumerate(sampled_token_ids):
+            if token_ids:
+                # Common case.
+                next_token_id = token_ids[-1]
+            else:
+                # Partial prefill (rare case).
+                # Get the next token id from the request state.
+                req_id = req_ids[i]
+                req_state = self.runner.requests[req_id]
+                seq_len = (req_state.num_computed_tokens +
+                           scheduler_output.num_scheduled_tokens[req_id])
+                next_token_id = req_state.get_token_id(seq_len)
+            next_token_ids.append(next_token_id)
+
+        # Pad the batch size to match with existing padding for target model
+        pad_len = attn_metadata.seq_lens.shape[0] - len(next_token_ids)
+        assert pad_len >= 0
+        next_token_ids += [0] * pad_len
+
+        next_token_ids = device_array(
+            self.runner.mesh, np.array(next_token_ids, dtype=jnp.int32))
+
+        if spec_decode_metadata is None:
+            num_rejected_tokens = None
+        else:
+            num_draft_tokens = spec_decode_metadata.draft_lengths_cpu
+            num_rejected_tokens = [
+                int(n) + 1 - len(sampled_token_ids[i]) if n > 0 else 0
+                for i, n in enumerate(num_draft_tokens)
+            ]
+
+            pad_len = self.runner.max_num_reqs - len(num_rejected_tokens)
+            num_rejected_tokens += [0] * pad_len
+            num_rejected_tokens = device_array(
+                self.runner.mesh, np.array(num_rejected_tokens,
+                                           dtype=jnp.int32))
+
+        accepted_seq_lens = self.runner.input_batch.num_tokens_no_spec[:
+                                                                       attn_metadata
+                                                                       .
+                                                                       seq_lens
+                                                                       .shape[
+                                                                           0]].copy(
+                                                                           )
+        accepted_attn_metadata = replace(
+            attn_metadata,
+            seq_lens=device_array(self.runner.mesh,
+                                  accepted_seq_lens.astype(np.int32)),
+        )
+
+        target_hidden_states, input_ids, last_token_indices, attn_metadata = self.runner.drafter.prepare_inputs(
+            accepted_attn_metadata,
             input_ids,
             aux_hidden_states,
             next_token_ids,

--- a/tpu_inference/runner/speculative_decoding_manager.py
+++ b/tpu_inference/runner/speculative_decoding_manager.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
 from typing import TYPE_CHECKING, Optional
 
 import jax.numpy as jnp
@@ -98,6 +99,29 @@ class SpeculativeDecodingManager:
                 valid_sampled_token_ids[:self.runner.input_batch.num_reqs],
                 self.runner.input_batch.num_tokens_no_spec,
                 self.runner.input_batch.token_ids_cpu)
+        elif self.runner.speculative_config.method == "dflash":
+            # Must precede use_eagle(); vLLM's use_eagle() matches "dflash".
+            # DFlash drafts on host and supports only single-seq, sync, non-DP;
+            # reject the configs whose draft-length layout it does not handle.
+            assert input_ids is not None
+            assert not async_scheduling, \
+                "DFlash does not support async scheduling"
+            assert self.runner.dp_size == 1, \
+                "DFlash does not support attention data parallelism"
+            assert self.runner.input_batch.num_reqs <= 1, \
+                "DFlash does not support batched (multi-request) decoding"
+            valid_sampled_token_ids = runner_utils.host_extract_sampled_tokens(
+                self.runner, spec_decode_metadata, sampled_output,
+                logits_indices_selector, discard_sampled_tokens_req_indices,
+                self.runner.input_batch.num_reqs)
+            self._draft_token_ids = self.propose_dflash_draft_token_ids(
+                valid_sampled_token_ids[:self.runner.input_batch.num_reqs],
+                aux_hidden_states,
+                attn_metadata,
+                spec_decode_metadata,
+                scheduler_output,
+                input_ids,
+            )
         elif self.runner.speculative_config.use_eagle():
             assert input_ids is not None
             self._draft_token_ids = self.propose_eagle3_draft_token_ids(
@@ -212,6 +236,106 @@ class SpeculativeDecodingManager:
             if draft_token_ids.ndim == 1:
                 draft_token_ids = np.expand_dims(draft_token_ids, axis=-1)
             return draft_token_ids.tolist()
+
+    def propose_dflash_draft_token_ids(
+        self,
+        sampled_token_ids: list[list[int]],
+        aux_hidden_states: Optional[tuple[jnp.ndarray, ...]],
+        attn_metadata: AttentionMetadata | dict[str, AttentionMetadata],
+        spec_decode_metadata: Optional[SpecDecodeMetadata],
+        scheduler_output: VllmSchedulerOutput,
+        input_ids: jnp.ndarray,
+    ) -> list[list[int]]:
+        if isinstance(attn_metadata, dict):
+            # Multiple KV cache groups map layer name -> AttentionMetadata;
+            # pick a self-attention layer (all share seq_lens / positions).
+            attn_key = next((k for k in attn_metadata if ".self_attn." in k),
+                            None)
+            attn_metadata = (attn_metadata[attn_key] if attn_key is not None
+                             else next(iter(attn_metadata.values())))
+        # TODO(woosuk): Refactor the loop.
+        req_ids = self.runner.input_batch.req_ids
+        next_token_ids: list[int] = []
+        for i, token_ids in enumerate(sampled_token_ids):
+            if token_ids:
+                # Common case.
+                next_token_id = token_ids[-1]
+            else:
+                # Partial prefill (rare case).
+                # Get the next token id from the request state.
+                req_id = req_ids[i]
+                req_state = self.runner.requests[req_id]
+                seq_len = (req_state.num_computed_tokens +
+                           scheduler_output.num_scheduled_tokens[req_id])
+                next_token_id = req_state.get_token_id(seq_len)
+            next_token_ids.append(next_token_id)
+
+        # Pad the batch size to match with existing padding for target model
+        pad_len = attn_metadata.seq_lens.shape[0] - len(next_token_ids)
+        assert pad_len >= 0
+        next_token_ids += [0] * pad_len
+
+        next_token_ids = device_array(
+            self.runner.mesh, np.array(next_token_ids, dtype=jnp.int32))
+
+        if spec_decode_metadata is None:
+            num_rejected_tokens = None
+        else:
+            num_draft_tokens = spec_decode_metadata.draft_lengths_cpu
+            num_rejected_tokens = [
+                int(n) + 1 - len(sampled_token_ids[i]) if n > 0 else 0
+                for i, n in enumerate(num_draft_tokens)
+            ]
+
+            pad_len = self.runner.max_num_reqs - len(num_rejected_tokens)
+            num_rejected_tokens += [0] * pad_len
+            num_rejected_tokens = device_array(
+                self.runner.mesh, np.array(num_rejected_tokens,
+                                           dtype=jnp.int32))
+
+        accepted_seq_lens = self.runner.input_batch.num_tokens_no_spec[:
+                                                                       attn_metadata
+                                                                       .
+                                                                       seq_lens
+                                                                       .shape[
+                                                                           0]].copy(
+                                                                           )
+        # DFlash tracks context length incrementally. num_tokens_no_spec is the
+        # accepted count from the previous step; it is not updated with this
+        # step's sampled tokens until after propose returns. Advance it by the
+        # tokens accepted this step (len(token_ids)), minus 1 for the newest
+        # sampled token, which has no hidden state in aux_hidden_states yet.
+        for i, token_ids in enumerate(sampled_token_ids):
+            if i >= len(accepted_seq_lens):
+                break
+            if token_ids:
+                accepted_seq_lens[i] += len(token_ids) - 1
+
+        accepted_attn_metadata = replace(
+            attn_metadata,
+            seq_lens=device_array(self.runner.mesh,
+                                  accepted_seq_lens.astype(np.int32)),
+        )
+
+        target_hidden_states, input_ids, last_token_indices, attn_metadata = self.runner.drafter.prepare_inputs(
+            accepted_attn_metadata,
+            input_ids,
+            aux_hidden_states,
+            next_token_ids,
+            num_rejected_tokens,
+        )
+
+        self.runner.kv_caches, draft_token_ids = self.runner.drafter.propose(
+            kv_caches=self.runner.kv_caches,
+            input_ids=input_ids,
+            attn_metadata=attn_metadata,
+            last_token_indices=last_token_indices,
+            target_hidden_states=target_hidden_states,
+        )
+        draft_token_ids = np.array(draft_token_ids)
+        if draft_token_ids.ndim == 1:
+            draft_token_ids = np.expand_dims(draft_token_ids, axis=-1)
+        return draft_token_ids.tolist()
 
     def get_spec_decode_metadata(
         self,

--- a/tpu_inference/runner/speculative_decoding_manager.py
+++ b/tpu_inference/runner/speculative_decoding_manager.py
@@ -224,6 +224,18 @@ class SpeculativeDecodingManager:
                                                                        .shape[
                                                                            0]].copy(
                                                                            )
+        # DFlash tracks context length incrementally. attn_metadata.seq_lens
+        # includes unverified draft tokens from the previous round, but the
+        # proposer needs the ACCEPTED count (num_tokens_no_spec) to correctly
+        # track its context buffer. Subtract 1 per request that sampled a
+        # token this step, because the most recent sampled token has no
+        # hidden state in aux_hidden_states yet.
+        for i, token_ids in enumerate(sampled_token_ids):
+            if i >= len(accepted_seq_lens):
+                break
+            if token_ids:
+                accepted_seq_lens[i] -= 1
+
         accepted_attn_metadata = replace(
             attn_metadata,
             seq_lens=device_array(self.runner.mesh,

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -411,6 +411,9 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                 self.drafter = NgramProposer(self.vllm_config)
             elif self.speculative_config.method == "eagle3":
                 self.drafter = Eagle3Proposer(self.vllm_config, self)
+            elif self.speculative_config.method == "dflash":
+                from tpu_inference.spec_decode.jax.dflash import DFlashProposer
+                self.drafter = DFlashProposer(self.vllm_config, self)
             else:
                 raise NotImplementedError(
                     "Unsupported speculative decoding method: "

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -676,6 +676,17 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         if self.speculative_config:
             if self.speculative_config.method == "ngram":
                 self.drafter = NgramProposer(self.vllm_config)
+            elif self.speculative_config.method == "dflash":
+                # Must precede use_eagle(); vLLM's use_eagle() matches "dflash".
+                if envs.DRAFT_MODEL_IMPL_TYPE == "torchax":
+                    from tpu_inference.spec_decode.torchax.dflash import \
+                        DFlashTorchaxProposer
+                    self.drafter = DFlashTorchaxProposer(
+                        self.vllm_config, self)
+                else:
+                    from tpu_inference.spec_decode.jax.dflash import \
+                        DFlashProposer
+                    self.drafter = DFlashProposer(self.vllm_config, self)
             elif self.speculative_config.use_eagle():
                 self.drafter = Eagle3Proposer(self.vllm_config, self)
             else:

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -412,8 +412,15 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             elif self.speculative_config.method == "eagle3":
                 self.drafter = Eagle3Proposer(self.vllm_config, self)
             elif self.speculative_config.method == "dflash":
-                from tpu_inference.spec_decode.jax.dflash import DFlashProposer
-                self.drafter = DFlashProposer(self.vllm_config, self)
+                if envs.DRAFT_MODEL_IMPL_TYPE == "torchax":
+                    from tpu_inference.spec_decode.torchax.dflash import (
+                        DFlashTorchaxProposer)
+                    self.drafter = DFlashTorchaxProposer(
+                        self.vllm_config, self)
+                else:
+                    from tpu_inference.spec_decode.jax.dflash import \
+                        DFlashProposer
+                    self.drafter = DFlashProposer(self.vllm_config, self)
             else:
                 raise NotImplementedError(
                     "Unsupported speculative decoding method: "


### PR DESCRIPTION
# Description

Wire DFlash block-diffusion speculative decoding into the existing TPU inference pipeline. The DFlash model and proposer were added in #1868; this PR connects them to the runner, KV cache manager, and speculative decoding manager so DFlash can be used end-to-end.

No changes to existing Eagle3 or ngram code paths: DFlash gets its own `propose_dflash_draft_token_ids` method and a separate `elif "dflash"` dispatch branch.

**Modified files:**
- `tpu_inference/models/common/model_loader.py` -- register DFlashDraftModel in model registry
- `tpu_inference/models/jax/qwen3.py` -- collect aux_hidden_states from target layers during forward pass (needed by DFlash proposer to inject target context)
- `tpu_inference/runner/tpu_runner.py` -- add DFlashProposer initialization for `method="dflash"`
- `tpu_inference/runner/speculative_decoding_manager.py` -- add dflash method dispatch and `propose_dflash_draft_token_ids` (uses `accepted_attn_metadata` with correct seq_lens for drafter)
- `tpu_inference/runner/kv_cache_manager.py` -- extend draft KV cache allocation to cover dflash, read `num_hidden_layers` from config instead of hardcoding 1

Usage (after both #1868 and this PR):
```python
args['speculative_config'] = {
    'model': 'z-lab/Qwen3-4B-DFlash-b16',
    'num_speculative_tokens': 5,
    'method': 'dflash',
    'draft_tensor_parallel_size': 1,
}
```

# Tests

E2e tests are in a follow-up PR.

# Checklist

- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have made or will make corresponding changes to any relevant documentation.