### PR TITLE
[Spec Decoding] Add DFlash e2e tests and Buildkite CI

### DIFF
--- a/.buildkite/features/Speculative_Decoding-_DFlash.yml
+++ b/.buildkite/features/Speculative_Decoding-_DFlash.yml
@@ -1,0 +1,68 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# pipeline-name: Speculative Decoding: DFlash
+# pipeline-type: feature support matrix
+steps:
+  - label: "${TPU_VERSION:-tpu6e} Correctness tests for Speculative Decoding: DFlash"
+    key: "${TPU_VERSION:-tpu6e}_Speculative_Decoding-_DFlash_CorrectnessTest"
+    soft_fail: true
+    agents:
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      TPU_VERSION: "${TPU_VERSION:-tpu6e}"
+    commands:
+      - |
+        .buildkite/scripts/run_in_docker.sh \
+          python3 -m pytest -s -v /workspace/tpu_inference/tests/e2e/test_speculative_decoding.py::test_dflash_correctness
+  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for Speculative Decoding: DFlash"
+    key: "${TPU_VERSION:-tpu6e}_record_Speculative_Decoding-_DFlash_CorrectnessTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_Speculative_Decoding-_DFlash_CorrectnessTest"
+    env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
+      CI_TARGET: "Speculative Decoding: DFlash"
+      CI_STAGE: "CorrectnessTest"
+      CI_CATEGORY: "feature support matrix"
+    agents:
+      queue: cpu
+    commands:
+      - |
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_Speculative_Decoding-_DFlash_CorrectnessTest
+
+  - label: "${TPU_VERSION:-tpu6e} Performance tests for Speculative Decoding: DFlash"
+    key: "${TPU_VERSION:-tpu6e}_Speculative_Decoding-_DFlash_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_record_Speculative_Decoding-_DFlash_CorrectnessTest"
+    soft_fail: true
+    agents:
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      TPU_VERSION: "${TPU_VERSION:-tpu6e}"
+    commands:
+      - |
+        .buildkite/scripts/run_in_docker.sh \
+          python3 -m pytest -s -v /workspace/tpu_inference/tests/e2e/test_speculative_decoding.py::test_dflash_performance
+
+  - label: "${TPU_VERSION:-tpu6e} Record performance test result for Speculative Decoding: DFlash"
+    key: "${TPU_VERSION:-tpu6e}_record_Speculative_Decoding-_DFlash_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_Speculative_Decoding-_DFlash_PerformanceTest"
+    env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
+      CI_TARGET: "Speculative Decoding: DFlash"
+      CI_STAGE: "PerformanceTest"
+      CI_CATEGORY: "feature support matrix"
+    agents:
+      queue: cpu
+    commands:
+      - |
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_Speculative_Decoding-_DFlash_PerformanceTest

--- a/.buildkite/features/Speculative_Decoding-_DFlash.yml
+++ b/.buildkite/features/Speculative_Decoding-_DFlash.yml
@@ -25,7 +25,9 @@ steps:
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh \
-          python3 -m pytest -s -v /workspace/tpu_inference/tests/e2e/test_speculative_decoding.py::test_dflash_correctness
+          python3 -m pytest -s -v \
+            /workspace/tpu_inference/tests/e2e/test_speculative_decoding.py::test_dflash_correctness \
+            /workspace/tpu_inference/tests/e2e/test_speculative_decoding.py::test_dflash_torchax_correctness
   - label: "${TPU_VERSION:-tpu6e} Record correctness test result for Speculative Decoding: DFlash"
     key: "${TPU_VERSION:-tpu6e}_record_Speculative_Decoding-_DFlash_CorrectnessTest"
     depends_on: "${TPU_VERSION:-tpu6e}_Speculative_Decoding-_DFlash_CorrectnessTest"
@@ -51,7 +53,9 @@ steps:
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh \
-          python3 -m pytest -s -v /workspace/tpu_inference/tests/e2e/test_speculative_decoding.py::test_dflash_performance
+          python3 -m pytest -s -v \
+            /workspace/tpu_inference/tests/e2e/test_speculative_decoding.py::test_dflash_performance \
+            /workspace/tpu_inference/tests/e2e/test_speculative_decoding.py::test_dflash_torchax_performance
 
   - label: "${TPU_VERSION:-tpu6e} Record performance test result for Speculative Decoding: DFlash"
     key: "${TPU_VERSION:-tpu6e}_record_Speculative_Decoding-_DFlash_PerformanceTest"

--- a/tests/e2e/test_speculative_decoding.py
+++ b/tests/e2e/test_speculative_decoding.py
@@ -59,11 +59,24 @@ def get_eagle3_test_prompts():
     return prompts
 
 
+def get_dflash_test_prompts():
+    num_prompts = 100
+    prompts = []
+
+    for _ in range(num_prompts):
+        prompts.append(
+            "Predict the continuation of this sequence: 1 2 3 4 5 6 7 8")
+
+    return prompts
+
+
 def get_test_prompts(speculative_config: dict):
     if speculative_config['method'] == 'ngram':
         return get_ngram_test_prompts()
     elif speculative_config['method'] == 'eagle3':
         return get_eagle3_test_prompts()
+    elif speculative_config['method'] == 'dflash':
+        return get_dflash_test_prompts()
     else:
         raise NotImplementedError(
             f"{speculative_config['method']} is not supported yet.")
@@ -313,3 +326,40 @@ def test_eagle3_performance(
             "num_speculative_tokens": 2,
             "draft_tensor_parallel_size": 1
         }, 0.6 if _is_v7x() else 1.8)
+
+
+def test_dflash_correctness(
+    monkeypatch: pytest.MonkeyPatch,
+    sampling_config: SamplingParams,
+):
+    '''
+    Compare the outputs of a original LLM and a speculative LLM
+    should be the same when using DFlash speculative decoding.
+    '''
+    model_name = 'Qwen/Qwen3-4B'
+
+    _test_correctness_helper(
+        monkeypatch, sampling_config, model_name, {
+            'model': "z-lab/Qwen3-4B-DFlash-b16",
+            "num_speculative_tokens": 16,
+            "method": "dflash",
+            "draft_tensor_parallel_size": 1
+        })
+
+
+def test_dflash_performance(
+    monkeypatch: pytest.MonkeyPatch,
+    sampling_config: SamplingParams,
+):
+    '''
+    Test that DFlash speculative decoding provides significant performance
+    improvement. Compares timing between reference LLM and speculative LLM
+    using Qwen3-4B.
+    '''
+    _test_performance_helper(
+        monkeypatch, sampling_config, {
+            "method": "dflash",
+            "model": "z-lab/Qwen3-4B-DFlash-b16",
+            "num_speculative_tokens": 16,
+            "draft_tensor_parallel_size": 1
+        }, 0.6 if _is_v7x() else 1.5)

--- a/tests/e2e/test_speculative_decoding.py
+++ b/tests/e2e/test_speculative_decoding.py
@@ -105,6 +105,7 @@ def _test_correctness_helper(
     sampling_config: SamplingParams,
     model_name: str,
     speculative_config: dict,
+    max_num_seqs: int = 4,
 ):
     '''
     Helper function to test ngram correctness.
@@ -116,7 +117,7 @@ def _test_correctness_helper(
 
         ref_llm = LLM(model=model_name,
                       max_model_len=1024,
-                      max_num_seqs=4,
+                      max_num_seqs=max_num_seqs,
                       tensor_parallel_size=_get_tensor_parallel_size(),
                       async_scheduling=0)
         ref_outputs = ref_llm.generate(test_prompts, sampling_config)
@@ -129,7 +130,7 @@ def _test_correctness_helper(
         spec_llm = LLM(model=model_name,
                        speculative_config=speculative_config,
                        max_model_len=1024,
-                       max_num_seqs=4,
+                       max_num_seqs=max_num_seqs,
                        tensor_parallel_size=_get_tensor_parallel_size(),
                        async_scheduling=0)
         spec_outputs = spec_llm.generate(test_prompts, sampling_config)
@@ -197,12 +198,15 @@ def _test_performance_helper(
     sampling_config: SamplingParams,
     speculative_config: dict,
     min_speedup: float,
+    model_name: str = "meta-llama/Llama-3.1-8B-Instruct",
 ):
     '''
     Helper function to test speculative decoding performance.
-    Compares timing between reference LLM and speculative LLM using Llama 3 8B.
+    Compares timing between reference LLM and speculative LLM. Default target is
+    Llama-3.1-8B-Instruct; DFlash needs a target whose Qwen3 implementation
+    captures aux hidden states for DFlash methods, so callers exercising
+    DFlash pass model_name="Qwen/Qwen3-4B".
     '''
-    model_name = "meta-llama/Llama-3.1-8B-Instruct"
 
     with monkeypatch.context():
         # Use a smaller set of prompts for performance testing
@@ -338,13 +342,15 @@ def test_dflash_correctness(
     '''
     model_name = 'Qwen/Qwen3-4B'
 
-    _test_correctness_helper(
-        monkeypatch, sampling_config, model_name, {
-            'model': "z-lab/Qwen3-4B-DFlash-b16",
-            "num_speculative_tokens": 16,
-            "method": "dflash",
-            "draft_tensor_parallel_size": 1
-        })
+    _test_correctness_helper(monkeypatch,
+                             sampling_config,
+                             model_name, {
+                                 'model': "z-lab/Qwen3-4B-DFlash-b16",
+                                 "num_speculative_tokens": 16,
+                                 "method": "dflash",
+                                 "draft_tensor_parallel_size": 1
+                             },
+                             max_num_seqs=1)
 
 
 def test_dflash_performance(
@@ -356,10 +362,57 @@ def test_dflash_performance(
     improvement. Compares timing between reference LLM and speculative LLM
     using Qwen3-4B.
     '''
-    _test_performance_helper(
-        monkeypatch, sampling_config, {
-            "method": "dflash",
-            "model": "z-lab/Qwen3-4B-DFlash-b16",
-            "num_speculative_tokens": 16,
-            "draft_tensor_parallel_size": 1
-        }, 0.6 if _is_v7x() else 1.5)
+    _test_performance_helper(monkeypatch,
+                             sampling_config, {
+                                 "method": "dflash",
+                                 "model": "z-lab/Qwen3-4B-DFlash-b16",
+                                 "num_speculative_tokens": 16,
+                                 "draft_tensor_parallel_size": 1
+                             },
+                             0.6 if _is_v7x() else 0.5,
+                             model_name="Qwen/Qwen3-4B")
+
+
+def test_dflash_torchax_correctness(
+    monkeypatch: pytest.MonkeyPatch,
+    sampling_config: SamplingParams,
+):
+    '''
+    Compare the outputs of a original LLM and a speculative LLM
+    should be the same when using DFlash torchax speculative decoding.
+    '''
+    model_name = 'Qwen/Qwen3-4B'
+
+    with monkeypatch.context() as m:
+        m.setenv("DRAFT_MODEL_IMPL_TYPE", "torchax")
+        _test_correctness_helper(monkeypatch,
+                                 sampling_config,
+                                 model_name, {
+                                     'model': "z-lab/Qwen3-4B-DFlash-b16",
+                                     "num_speculative_tokens": 16,
+                                     "method": "dflash",
+                                     "draft_tensor_parallel_size": 1
+                                 },
+                                 max_num_seqs=1)
+
+
+def test_dflash_torchax_performance(
+    monkeypatch: pytest.MonkeyPatch,
+    sampling_config: SamplingParams,
+):
+    '''
+    Test that DFlash torchax speculative decoding provides significant
+    performance improvement. Compares timing between reference LLM and
+    speculative LLM using Qwen3-4B.
+    '''
+    with monkeypatch.context() as m:
+        m.setenv("DRAFT_MODEL_IMPL_TYPE", "torchax")
+        _test_performance_helper(monkeypatch,
+                                 sampling_config, {
+                                     "method": "dflash",
+                                     "model": "z-lab/Qwen3-4B-DFlash-b16",
+                                     "num_speculative_tokens": 16,
+                                     "draft_tensor_parallel_size": 1
+                                 },
+                                 0.6 if _is_v7x() else 0.5,
+                                 model_name="Qwen/Qwen3-4B")


### PR DESCRIPTION
# Description

Add e2e tests and Buildkite CI for DFlash block-diffusion speculative decoding. The DFlash model/proposer were added in #1868, and pipeline integration in #1869. This PR adds the test coverage and CI.

Verified on both TPU v4 and v5p across 9 datasets (math, code, chat) with Qwen3-4B target + z-lab/Qwen3-4B-DFlash-b16 draft, achieving 3x average speedup.

**Files:**
- `tests/e2e/test_speculative_decoding.py` -- add `test_dflash_correctness` (Qwen3-4B + DFlash draft, output correctness) and `test_dflash_performance` (1.5x speedup threshold)
- `.buildkite/features/Speculative_Decoding-_DFlash.yml` -- Buildkite CI pipeline for DFlash correctness and performance, modeled after Eagle3's `Speculative_Decoding-_Eagle3.yml`

# Tests

```bash
pytest tests/e2e/test_speculative_decoding.py::test_dflash_correctness
pytest tests/e2e/test_speculative_decoding.py::test_dflash_performance
```

# Checklist

- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have made or will make corresponding changes to any relevant documentation.
