### PR TITLE
[Cleanup] cleanup `from transformers import modeling_flax_utils`

### DIFF
--- a/tpu_inference/models/jax/llama3.py
+++ b/tpu_inference/models/jax/llama3.py
@@ -19,7 +19,7 @@ import jax
 import jax.numpy as jnp
 from flax import nnx
 from jax.sharding import Mesh
-from transformers import LlamaConfig, modeling_flax_utils
+from transformers import LlamaConfig
 from vllm.config import VllmConfig
 
 from tpu_inference import utils
@@ -28,6 +28,7 @@ from tpu_inference.layers.common.attention_interface import attention
 from tpu_inference.layers.common.attention_metadata import AttentionMetadata
 from tpu_inference.layers.common.quantization import quantize_kv
 from tpu_inference.layers.common.sharding import ShardingAxisName
+from tpu_inference.layers.jax.layers import FlaxUtils
 from tpu_inference.layers.jax.pp_utils import PPMissingLayer, make_layers
 from tpu_inference.layers.jax.rope_interface import apply_rope
 from tpu_inference.logger import init_logger
@@ -39,6 +40,7 @@ from tpu_inference.utils import get_mesh_shape_product
 logger = init_logger(__name__)
 
 init_fn = nnx.initializers.uniform()
+modeling_flax_utils = FlaxUtils()
 
 
 class LlamaMLP(nnx.Module):

--- a/tpu_inference/models/jax/qwen2.py
+++ b/tpu_inference/models/jax/qwen2.py
@@ -19,7 +19,7 @@ import jax
 import jax.numpy as jnp
 from flax import nnx
 from jax.sharding import Mesh
-from transformers import Qwen2Config, modeling_flax_utils
+from transformers import Qwen2Config
 from vllm.config import VllmConfig
 
 from tpu_inference import utils
@@ -29,6 +29,7 @@ from tpu_inference.layers.common.attention_metadata import AttentionMetadata
 from tpu_inference.layers.common.quantization import quantize_kv
 from tpu_inference.layers.jax import JaxModule
 from tpu_inference.layers.jax.embed import JaxEmbed
+from tpu_inference.layers.jax.layers import FlaxUtils
 from tpu_inference.layers.jax.linear import JaxEinsum, JaxLinear
 from tpu_inference.layers.jax.norm import JaxRmsNorm
 from tpu_inference.layers.jax.pp_utils import PPMissingLayer, make_layers
@@ -43,6 +44,7 @@ from tpu_inference.models.jax.utils.weight_utils import (LoadableWithIterator,
 logger = init_logger(__name__)
 
 init_fn = nnx.initializers.uniform()
+modeling_flax_utils = FlaxUtils()
 
 
 class Qwen2MLP(JaxModule):

--- a/tpu_inference/models/jax/qwen2_5_vl.py
+++ b/tpu_inference/models/jax/qwen2_5_vl.py
@@ -22,7 +22,6 @@ import jax.numpy as jnp
 import numpy as np
 from flax import nnx
 from jax.sharding import Mesh
-from transformers import modeling_flax_utils
 from transformers.models.qwen2_5_vl.configuration_qwen2_5_vl import (
     Qwen2_5_VLConfig, Qwen2_5_VLVisionConfig)
 from vllm.config import VllmConfig
@@ -32,6 +31,7 @@ from tpu_inference.distributed.jax_parallel_state import get_pp_group
 from tpu_inference.layers.common.attention_interface import \
     sharded_flash_attention
 from tpu_inference.layers.common.attention_metadata import AttentionMetadata
+from tpu_inference.layers.jax.layers import FlaxUtils
 from tpu_inference.layers.jax.linear import JaxEinsum
 from tpu_inference.layers.jax.pp_utils import PPMissingLayer
 from tpu_inference.logger import init_logger
@@ -46,6 +46,7 @@ from tpu_inference.models.jax.utils.weight_utils import StandardWeightLoader
 logger = init_logger(__name__)
 
 init_fn = nnx.initializers.uniform()
+modeling_flax_utils = FlaxUtils()
 
 DEFAULT_BLOCK_K_MAJOR = 128
 


### PR DESCRIPTION
# Description

https://github.com/huggingface/transformers/pull/40760 deleted this file, v5.0.0 and after doesn't have this util

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
