### PR TITLE
Skip quantization matrix when model implementation is default

### DIFF
--- a/.buildkite/scripts/upload_models_and_features.sh
+++ b/.buildkite/scripts/upload_models_and_features.sh
@@ -78,7 +78,10 @@ for folder_path in "${TARGET_FOLDERS[@]}"; do
           model_list+=("$subject_name")
           ;;
         "features" | "parallelism" | "quantization" | "kernel_microbenchmarks"/*)
-          feature_list+=("${subject_name}")
+          # When MODEL_IMPL_TYPE is 'auto', do not add quantization tests to the list for reporting.
+          if ! [[ "$folder_path" == "quantization" && "${MODEL_IMPL_TYPE:-auto}" == "auto" ]]; then
+            feature_list+=("${subject_name}")
+          fi
           ;;
       esac
     fi
@@ -87,11 +90,16 @@ for folder_path in "${TARGET_FOLDERS[@]}"; do
     # This is required because we wrap them inside a 'group' later
     yml_content=$(grep -v "^steps:" "${yml_file}")
 
-    # Store the content for both hardware types
-    if [[ "$subject_name" != "multi-host" ]]; then
-      pipeline_v6e_fragments+=("${yml_content}")
+    # When MODEL_IMPL_TYPE is 'auto', quantization tests are not uploaded or reported.
+    if [[ "$folder_path" == "quantization" && "${MODEL_IMPL_TYPE:-auto}" == "auto" ]]; then
+      echo "Skipping upload and reporting of quantization test '${yml_file}' because MODEL_IMPL_TYPE is 'auto'."
+    else
+      # Store the content for both hardware types
+      if [[ "$subject_name" != "multi-host" ]]; then
+        pipeline_v6e_fragments+=("${yml_content}")
+      fi
+      pipeline_v7x_fragments+=("${yml_content}")
     fi
-    pipeline_v7x_fragments+=("${yml_content}")
 
   done < <(find "$folder" -maxdepth 1 -type f \( -name "*.yml" -o -name "*.yaml" \) -print0)
 done

--- a/support_matrices/nightly/default/v6/quantization_support_matrix.csv
+++ b/support_matrices/nightly/default/v6/quantization_support_matrix.csv
@@ -1,7 +1,0 @@
-Quantization dtype,Quantization methods,Recommended TPU Generations,CorrectnessTest,PerformanceTest
-"AWQ INT4",N/A,"v5, v6",unverified,unverified
-"FP4 W4A16",mxfp4,v7,unverified,unverified
-"FP8 W8A8",compressed-tensor,v7,unverified,unverified
-"FP8 W8A16",compressed-tensor,v7,unverified,unverified
-"INT4 W4A16",awq,"v5, v6",unverified,unverified
-"INT8 W8A8",compressed-tensor,"v5, v6",unverified,unverified

--- a/support_matrices/nightly/default/v7/quantization_support_matrix.csv
+++ b/support_matrices/nightly/default/v7/quantization_support_matrix.csv
@@ -1,7 +1,0 @@
-Quantization dtype,Quantization methods,Recommended TPU Generations,CorrectnessTest,PerformanceTest
-"AWQ INT4",N/A,"v5, v6",unverified,unverified
-"FP4 W4A16",mxfp4,v7,unverified,unverified
-"FP8 W8A8",compressed-tensor,v7,unverified,unverified
-"FP8 W8A16",compressed-tensor,v7,unverified,unverified
-"INT4 W4A16",awq,"v5, v6",unverified,unverified
-"INT8 W8A8",compressed-tensor,"v5, v6",unverified,unverified


### PR DESCRIPTION
# Description

Skip quantization matrix when MODEL_IMPL_TYPE is default (auto)

# Tests

MODEL_IMPL_TYPE=auto (exclude quantization tests)
[BuildKite](https://buildkite.com/tpu-commons/tpu-inference-ci/builds/12002/steps/canvas)

MODEL_IMPL_TYPE=vllm (include quantization tests)
[BuildKite](https://buildkite.com/tpu-commons/tpu-inference-ci/builds/12019/steps/canvas)

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
