### PR TITLE
Fix syntax warning on invalid escape sequence

### DIFF
--- a/tpu_inference/models/jax/llama_guard_4.py
+++ b/tpu_inference/models/jax/llama_guard_4.py
@@ -63,7 +63,7 @@ class LlamaGuard4WeightLoader(BaseWeightLoader):
             vllm_config,
             framework="flax",
             filter_regex=
-            "^(language_model|vision_model|multi_modal_projector)\..*",
+            r"^(language_model|vision_model|multi_modal_projector)\..*",
         )
         # Set is_runai_streamer so we can use this in load_weights
         self.is_runai_streamer = getattr(


### PR DESCRIPTION
# Description

As title. Address a new syntax warning introduced by e4bf0c8bf39cc9f35d71cbf9522b871d7ad6faad.

```
(EngineCore_DP0 pid=1567876) /home/username/projects/tpu-inference/tpu_inference/models/jax/llama_guard_4.py:66: SyntaxWarning: invalid escape sequence '\.'
(EngineCore_DP0 pid=1567876)   "^(language_model|vision_model|multi_modal_projector)\..*",
```

# Tests

```
> python -c 'print(r"^(language_model|vision_model|multi_modal_projector)\..*" == "^(language_model|vision_model|multi_modal_projector)\..*")'
<string>:1: SyntaxWarning: invalid escape sequence '\.'
True
```

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
