### PR TITLE
[Bug] Specify layout in general_device_put

### DIFF
--- a/tpu_inference/layers/common/utils.py
+++ b/tpu_inference/layers/common/utils.py
@@ -16,8 +16,8 @@ from contextlib import nullcontext
 
 import jax
 import jax.numpy as jnp
-from jax.experimental.layout import Format
-from jax.sharding import Mesh
+from jax.experimental.layout import Format, Layout
+from jax.sharding import Mesh, Sharding
 
 from tpu_inference import envs
 
@@ -104,10 +104,10 @@ def slice_sharded_tensor_for_concatenation(sharded_tensor: jax.Array,
 
 
 def general_device_put(tensor: jax.Array,
-                       sharding,
+                       sharding: Sharding,
                        *,
-                       layout=None,
-                       source_mesh=None) -> jax.Array:
+                       layout: Layout | None = None,
+                       source_mesh: Mesh | None = None) -> jax.Array:
     """
     Put a tensor onto devices with the given sharding.
     This method handles both single-host and multi-host cases.
@@ -118,7 +118,10 @@ def general_device_put(tensor: jax.Array,
     def _put(t):
         multihost_backend = envs.TPU_MULTIHOST_BACKEND
         if multihost_backend != "ray":
-            return jax.device_put(t, sharding)
+            if layout is not None:
+                return jax.device_put(t, Format(layout, sharding))
+            else:
+                return jax.device_put(t, sharding)
 
         # NOTE: at here, num_global_devices != num_local_devices
         # meaning we are in multi-host setup. Each host will run the same process


### PR DESCRIPTION
# Description

Otherwise, causes OOM due to unnecessary copy op from wrong layout

```
(EngineCore_DP0 pid=896988) Total hbm usage >= 101.25G:
(EngineCore_DP0 pid=896988)     reserved        260.00M
(EngineCore_DP0 pid=896988)     program          15.87G
(EngineCore_DP0 pid=896988)     arguments        85.12G
(EngineCore_DP0 pid=896988)
(EngineCore_DP0 pid=896988) Output size 60.29G; shares 60.29G with arguments.
(EngineCore_DP0 pid=896988)
(EngineCore_DP0 pid=896988) Program hbm requirement 15.87G:
(EngineCore_DP0 pid=896988)     global             512B
(EngineCore_DP0 pid=896988)     HLO temp         15.87G (99.8% utilization: Unpadded (15.81G) Padded (15.84G), 0.1% fragmentation (23.87M))
(EngineCore_DP0 pid=896988)
(EngineCore_DP0 pid=896988)   Largest program allocations in hbm:
(EngineCore_DP0 pid=896988)
(EngineCore_DP0 pid=896988)   1. Size: 384.00M
(EngineCore_DP0 pid=896988)      Operator: op_name="params_and_buffers[\'vllm_model.model.layers.1.mlp.experts.w13_weight\']"
(EngineCore_DP0 pid=896988)      Shape: bf16[128,4096,352]{2,1,0:T(16,128)(2,1)}
(EngineCore_DP0 pid=896988)      Unpadded size: 352.00M
(EngineCore_DP0 pid=896988)      Extra memory due to padding: 32.00M (1.1x expansion)
(EngineCore_DP0 pid=896988)      XLA label: copy.1326 = copy(copy.1657), sharding={devices=[1,1,8]<=[8]}, backend_config={"flag_configs":[],"scoped_memory_configs":[{"memory_space":"1","offset":"0","size":"22649243"}],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
(EngineCore_DP0 pid=896988)      Allocation type: HLO temp
(EngineCore_DP0 pid=896988)      ==========================
```

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
