### PR TITLE
Lazily initialize ShardingAxisName to respect env vars set after import

### DIFF
--- a/tests/layers/common/test_sharding.py
+++ b/tests/layers/common/test_sharding.py
@@ -15,7 +15,10 @@
 import unittest
 from unittest.mock import MagicMock, patch
 
-from tpu_inference.layers.common.sharding import ShardingConfigManager
+from tpu_inference.layers.common.sharding import (LazyShardingAxisName,
+                                                  ShardingAxisName2D,
+                                                  ShardingAxisNameBase,
+                                                  ShardingConfigManager)
 
 
 class TestShardingConfigManager(unittest.TestCase):
@@ -152,6 +155,63 @@ class TestShardingConfigManager(unittest.TestCase):
         manager = ShardingConfigManager.from_vllm_config(vllm_config)
         # Should use ss_tensor_parallelism (4)
         self.assertEqual(manager.tp_size, 4)
+
+
+class TestLazyShardingAxisName(unittest.TestCase):
+
+    def test_initial_state_is_uninitialized(self):
+        lazy = LazyShardingAxisName()
+        self.assertIsNone(lazy._cls)
+
+    @patch("tpu_inference.layers.common.sharding.envs.USE_2D_TP", True)
+    @patch("tpu_inference.layers.common.sharding.envs.NEW_MODEL_DESIGN", False)
+    def test_use_2d_tp_selects_base(self):
+        lazy = LazyShardingAxisName()
+        _ = lazy.SEQUENCE
+        self.assertIs(lazy._cls, ShardingAxisNameBase)
+
+    @patch("tpu_inference.layers.common.sharding.envs.USE_2D_TP", False)
+    @patch("tpu_inference.layers.common.sharding.envs.NEW_MODEL_DESIGN", False)
+    def test_both_false_selects_2d(self):
+        lazy = LazyShardingAxisName()
+        _ = lazy.SEQUENCE
+        self.assertIs(lazy._cls, ShardingAxisName2D)
+
+    def test_cls_cached_after_first_access(self):
+        lazy = LazyShardingAxisName()
+        with patch("tpu_inference.layers.common.sharding.envs.USE_2D_TP",
+                   False), \
+             patch("tpu_inference.layers.common.sharding.envs.NEW_MODEL_DESIGN",
+                   False):
+            _ = lazy.SEQUENCE
+            first_cls = lazy._cls
+
+        # Even with different env vars, _cls should not change
+        with patch("tpu_inference.layers.common.sharding.envs.USE_2D_TP",
+                   True), \
+             patch("tpu_inference.layers.common.sharding.envs.NEW_MODEL_DESIGN",
+                   True):
+            _ = lazy.SEQUENCE
+            self.assertIs(lazy._cls, first_cls)
+
+    def test_initialized_after_env_change_uses_new_value(self):
+        # LazyShardingAxisName is created while USE_2D_TP=False,
+        # then USE_2D_TP changes to True before the first attribute access.
+        # It should pick up the value at initialization time (first access),
+        # not at construction time.
+        with patch("tpu_inference.layers.common.sharding.envs.USE_2D_TP",
+                   False), \
+             patch("tpu_inference.layers.common.sharding.envs.NEW_MODEL_DESIGN",
+                   False):
+            lazy = LazyShardingAxisName()
+            self.assertIsNone(lazy._cls)  # not yet initialized
+
+        with patch("tpu_inference.layers.common.sharding.envs.USE_2D_TP",
+                   True), \
+             patch("tpu_inference.layers.common.sharding.envs.NEW_MODEL_DESIGN",
+                   False):
+            _ = lazy.SEQUENCE  # initialized here, after env changed
+            self.assertIs(lazy._cls, ShardingAxisNameBase)
 
 
 if __name__ == "__main__":

--- a/tpu_inference/layers/common/sharding.py
+++ b/tpu_inference/layers/common/sharding.py
@@ -69,15 +69,32 @@ class ShardingAxisName2D:
     VOCAB = ('data', 'model')
 
 
-try:
-    _use_2d_tp_sharding = envs.USE_2D_TP
-    _use_base_sharding = envs.NEW_MODEL_DESIGN
-    if _use_2d_tp_sharding or _use_base_sharding:
-        ShardingAxisName = ShardingAxisNameBase
-    else:
-        ShardingAxisName = ShardingAxisName2D
-except Exception:
-    ShardingAxisName = ShardingAxisName2D
+# Lazily initialize the ShardingAxisName so that we can decide which one to use based on the
+# propagated / updated environment variables in the multi-host setup.
+class LazyShardingAxisName:
+    """Lazy loading for ShardingAxisName."""
+
+    def __init__(self):
+        self._cls = None
+
+    def _initialize(self):
+        if self._cls is None:
+            try:
+                _use_2d_tp_sharding = envs.USE_2D_TP
+                _use_base_sharding = envs.NEW_MODEL_DESIGN
+                if _use_2d_tp_sharding or _use_base_sharding:
+                    self._cls = ShardingAxisNameBase
+                else:
+                    self._cls = ShardingAxisName2D
+            except Exception:
+                self._cls = ShardingAxisName2D
+
+    def __getattr__(self, name):
+        self._initialize()
+        return getattr(self._cls, name)
+
+
+ShardingAxisName = LazyShardingAxisName()
 
 
 @dataclass


### PR DESCRIPTION
# Description

Without this change,
previously, When running Deepseek on multi-host, Current process is: create ray worker -> import sharding.py -> NEW_MODEL_DESIGN is read as False -> ShardingAxisName is set to ShardingAxisName2D -> update/propogate env variables. The NEW_MODEL_DESIGN is propagated after it has already been used.

With this change, ShardingAxisName is initialized on the first access / reference (which is after the environment variable got updated)

# Tests
Unit test + successfully bring up a DS multihost server

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
