### PR TITLE
DeepSeek routing fixes on JAX path.

### DIFF
--- a/tpu_inference/layers/common/fused_moe_gmm.py
+++ b/tpu_inference/layers/common/fused_moe_gmm.py
@@ -303,8 +303,6 @@ def fused_moe_func(
     use_ep: bool,
     activation: str,
     scoring_fn: str,
-    topk_weights: jax.Array | None = None,
-    topk_indices: jax.Array | None = None,
 ) -> jax.Array:
     """Route tokens in hidden_states into each experts based on routing.
 
@@ -323,8 +321,6 @@ def fused_moe_func(
         use_ep: use expert parallelism.
         activation: activation function to perform on the output of w1.
         scoring_fn: scoring function to apply on gating_output.
-        topk_weights: pre-calculated expert weights.
-        topk_indices: pre-calculated expert indices.
 
     Returns:
         Output of moe operation [num_tokens, hidden_size]
@@ -337,27 +333,15 @@ def fused_moe_func(
         "The kernel requires num_tokens * topk to be a multiple of "
         f"16 but got {num_tokens}*{topk}={num_tokens*topk}")
 
-    if topk_weights is None or topk_indices is None:
-        assert gating_output is not None
-        assert gating_output.shape == (num_tokens, global_num_experts)
+    assert gating_output.shape == (num_tokens, global_num_experts)
 
-        topk_weights = apply_scoring_fn(scoring_fn, gating_output)
-        # All-gather topk weights for attention dp
-        topk_weights = jax.lax.with_sharding_constraint(
-            topk_weights,
-            NamedSharding(mesh, P(ShardingAxisName.MLP_DATA, None)))
-        topk_weights, topk_indices = jax.lax.top_k(topk_weights, k=topk)
-        if renormalize:
-            topk_weights = topk_weights / topk_weights.sum(axis=-1,
-                                                           keepdims=True)
-    else:
-        topk_weights = jax.lax.with_sharding_constraint(
-            topk_weights,
-            NamedSharding(mesh, P(ShardingAxisName.MLP_DATA, None)))
-        topk_indices = jax.lax.with_sharding_constraint(
-            topk_indices,
-            NamedSharding(mesh, P(ShardingAxisName.MLP_DATA, None)))
-
+    topk_weights = apply_scoring_fn(scoring_fn, gating_output)
+    # All-gather topk weights for attention dp
+    topk_weights = jax.lax.with_sharding_constraint(
+        topk_weights, NamedSharding(mesh, P(ShardingAxisName.MLP_DATA, None)))
+    topk_weights, topk_indices = jax.lax.top_k(topk_weights, k=topk)
+    if renormalize:
+        topk_weights = topk_weights / topk_weights.sum(axis=-1, keepdims=True)
     topk_weights = topk_weights.astype(dtype)
 
     def _process_tokens_locally(hidden_states_local, topk_indices_local):

--- a/tpu_inference/layers/common/moe.py
+++ b/tpu_inference/layers/common/moe.py
@@ -121,12 +121,6 @@ def moe_apply(
                     **extra_backend_kwargs,
                 )[:, :actual_hidden_size]
             case MoEBackend.GMM_EP | MoEBackend.GMM_TP:
-                topk_weights = None
-                topk_indices = None
-                if isinstance(gating_output, tuple):
-                    topk_weights, topk_indices = gating_output
-                    gating_output = None  # Not used if pre-calculated
-
                 output = fused_moe_func(
                     hidden_states=x,
                     w1=weights.w13_weight,
@@ -142,8 +136,6 @@ def moe_apply(
                     use_ep=layer.use_ep,
                     activation=activation,
                     scoring_fn=layer.scoring_func,
-                    topk_weights=topk_weights,
-                    topk_indices=topk_indices,
                 )
             case MoEBackend.DENSE_MAT:
                 # NOTE: circular import avoidance

--- a/tpu_inference/models/jax/deepseek_v3.py
+++ b/tpu_inference/models/jax/deepseek_v3.py
@@ -819,6 +819,7 @@ class SharedFusedMoe(JaxMoE):
     def __call__(self, x_TD: jax.Array) -> jax.Array:
         # Compute Routed Experts
         final_hidden_states = super().__call__(x_TD)
+        final_hidden_states *= self.routed_scaling_factor
 
         # (Maybe) Compute Shared Experts
         if self.shared_experts is not None:
@@ -856,9 +857,9 @@ class DeepseekV2Moe(JaxModule):
             routed_scaling_factor=routed_scaling_factor,
             dtype=dtype,
             moe_backend=moe_backend,
-            activation_ffw_td=(ShardingAxisName.MLP_DATA, None),
-            ed_sharding=(None, None),
-            e_sharding=(None, ),
+            activation_ffw_td=P(ShardingAxisName.MLP_DATA, None),
+            ed_sharding=P(None, None),
+            e_sharding=P(None, ),
             scoring_func=scoring_func,
             quant_config=quant_config)
 
@@ -1074,10 +1075,15 @@ class DeepSeekV3Router(JaxEinsum):
                 - indices: Indices of selected experts, shape (sequence, num_experts_per_tok).
         """
         x_TD = jnp.asarray(x_TD, self.dtype)
-        x_TD = jax.lax.with_sharding_constraint(x_TD,
-                                                P(*self.activation_ffw_td))
+        x_TD = lax.with_sharding_constraint(x_TD, self.activation_ffw_td)
 
+        # Expert assignments are accumulated in high precision to preserve accuracy.
+        # See: https://github.com/vllm-project/vllm/blob/e89a91d9275cd8ac086fe04476b41675a9ebbd5c/vllm/model_executor/layers/fused_moe/cpu_fused_moe.py#L59
         logits_TE = super().__call__(x_TD).astype(jnp.float32)
+
+        # TODO(gpolovets): add back support for DeepSeek routing.
+        if self.moe_backend in MoEBackend.fused_moe_backends():
+            return logits_TE
 
         # Apply scoring function (Sigmoid/Softmax) to get probabilities
         if self.scoring_func == "sigmoid":
@@ -1087,7 +1093,7 @@ class DeepSeekV3Router(JaxEinsum):
         else:
             probs_TE = logits_TE
 
-        # Will add Aux-Loss-Free bias the activation outputs during topk selection.
+        # Add Aux-Loss-Free bias to the activation outputs during topk selection.
         topk_indices_TX = self.get_topk_indices(probs_TE)
 
         # The actual weights do not include the bias terms.
@@ -1095,9 +1101,6 @@ class DeepSeekV3Router(JaxEinsum):
 
         if self.norm_topk_prob:
             weights_TX /= jnp.sum(weights_TX, axis=-1)[..., None] + 1e-20
-
-        # Scale expert weights before taking linear combination of experts.
-        weights_TX *= self.routed_scaling_factor
 
         return weights_TX.astype(self.dtype), topk_indices_TX
 


### PR DESCRIPTION
# Description
Adding the following fixes to improve accuracy on the Jax path.
  - Applying router activations just once (previously applied an extra time in fused_moe_func).
  - Applying routed_scaling_factor 
  - Using float32 precision during topk selection ([vLLM](https://github.com/vllm-project/vllm/blob/e89a91d9275cd8ac086fe04476b41675a9ebbd5c/vllm/model_executor/layers/fused_moe/cpu_fused_moe.py#L59) reference implementation is also doing this)

# Tests

Locally tested that MMLU went up from 67 to 80 while maintaining perf to <1%.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
