### PR TITLE
use ATTN_DATA for logits and sampling inputs to reflect data-parallel sharding for sample operations

### DIFF
--- a/tests/runner/test_tpu_runner_dp.py
+++ b/tests/runner/test_tpu_runner_dp.py
@@ -1178,5 +1178,140 @@ class TestTPUJaxRunnerPadding:
             assert spec.sharding == 'mock_sharding'
 
 
+class TestSamplingMetadataPassthrough:
+
+    def test_sample_tokens_passes_sampling_metadata_from_state(self):
+        """sample_tokens() should pass execute_model_state.sampling_metadata to _sample_from_logits."""
+        runner = MagicMock()
+        mock_sampling_metadata = MagicMock()
+        # Set the specific field we want to trace; other fields are auto-mocked.
+        runner.execute_model_state.sampling_metadata = mock_sampling_metadata
+        runner._sample_from_logits = MagicMock(return_value=MagicMock())
+
+        TPUModelRunner.sample_tokens(runner, grammar_output=None)
+
+        runner._sample_from_logits.assert_called_once()
+        # Signature: _sample_from_logits(scheduler_output, attn_metadata,
+        #                                 sampling_metadata, input_ids, ...)
+        assert runner._sample_from_logits.call_args.args[
+            2] is mock_sampling_metadata
+
+    @patch('tpu_inference.runner.tpu_runner.NamedSharding')
+    @patch('tpu_inference.runner.tpu_runner.runner_utils')
+    @patch('tpu_inference.runner.tpu_runner.device_array',
+           side_effect=lambda mesh, tensors, **kwargs: tensors)
+    @patch('tpu_inference.runner.tpu_runner.TPUSupportedSamplingMetadata')
+    def test_prepare_inputs_dp_uses_attn_data_sharding_for_sampling_metadata(
+            self, mock_sampling_metadata, mock_device_array, mock_runner_utils,
+            mock_named_sharding):
+        """_prepare_inputs_dp() should use ATTN_DATA sharding for TPUSupportedSamplingMetadata."""
+        from jax.sharding import PartitionSpec
+
+        from tpu_inference.layers.common.sharding import ShardingAxisName
+
+        runner = MagicMock()
+        runner.dp_size = 2
+        runner.max_num_reqs = 8
+        runner.max_num_blocks_per_req = 8
+        runner.input_batch.num_reqs = 2
+        runner.input_batch.req_ids = ["req1", "req2"]
+        runner.input_batch.req_id_to_index = {"req1": 0, "req2": 1}
+        runner.input_batch.num_computed_tokens_cpu = np.array([5, 6])
+        runner.input_batch.token_ids_cpu = np.zeros((8, 64), dtype=np.int32)
+        mock_block_table = MagicMock()
+        mock_block_table.get_cpu_tensor.return_value = np.arange(32).reshape(
+            4, 8)
+        runner.input_batch.block_table = [mock_block_table]
+        runner.input_ids_cpu = np.zeros(64, dtype=np.int32)
+        runner.positions_cpu = np.zeros(64, dtype=np.int32)
+        runner.query_start_loc_cpu = np.zeros(10, dtype=np.int32)
+        runner.seq_lens_cpu = np.zeros(8, dtype=np.int32)
+        runner.logits_indices_cpu = np.zeros(8, dtype=np.int32)
+        runner.block_tables_cpu = [np.zeros((8, 8), dtype=np.int32)]
+        runner.arange_cpu = np.arange(64, dtype=np.int64)
+        runner.num_tokens_paddings_per_dp = [8, 16, 32]
+        runner.num_reqs_paddings_per_dp = [4, 8]
+        runner.uses_mrope = False
+        runner.phase_based_profiler = None
+        runner.lora_config = None
+        runner.scheduler_config.async_scheduling = False
+        runner._pre_async_results = None
+        mock_kv_cache_config = MagicMock()
+        mock_kv_cache_config.kv_cache_groups = [MagicMock()]
+        runner.kv_cache_config = mock_kv_cache_config
+        runner._prepare_dp_input_metadata = TPUModelRunner._prepare_dp_input_metadata.__get__(
+            runner)
+        runner._prepare_async_token_substitution_indices_dp = TPUModelRunner._prepare_async_token_substitution_indices_dp.__get__(
+            runner)
+
+        mock_runner_utils.get_padded_token_len.side_effect = lambda paddings, val: 8
+        mock_sampling_metadata.from_input_batch.return_value = MagicMock()
+        mock_named_sharding.return_value = MagicMock()
+
+        scheduler_output = MagicMock()
+        scheduler_output.num_scheduled_tokens = {"req1": 3, "req2": 2}
+        scheduler_output.assigned_dp_rank = {"req1": 0, "req2": 1}
+        scheduler_output.total_num_scheduled_tokens = 5
+        scheduler_output.scheduled_spec_decode_tokens = {}
+
+        TPUModelRunner._prepare_inputs_dp(runner, scheduler_output)
+
+        # Verify from_input_batch was called exactly once with the ATTN_DATA sharding
+        mock_sampling_metadata.from_input_batch.assert_called_once()
+        sharding_arg = mock_sampling_metadata.from_input_batch.call_args.kwargs.get(
+            'sharding')
+        assert sharding_arg is mock_named_sharding.return_value, (
+            "from_input_batch should receive the data_parallel_attn_sharding instance"
+        )
+
+        # Verify NamedSharding was called with ATTN_DATA PartitionSpec.
+        call_partition_specs = [
+            call.args[1] for call in mock_named_sharding.call_args_list
+            if len(call.args) > 1
+        ]
+        assert PartitionSpec(
+            ShardingAxisName.ATTN_DATA) in call_partition_specs, (
+                "NamedSharding must be called with ATTN_DATA PartitionSpec")
+
+    @patch('tpu_inference.runner.tpu_runner.TPUSupportedSamplingMetadata')
+    @patch('tpu_inference.runner.tpu_runner.sample')
+    @patch('tpu_inference.runner.tpu_runner.runner_utils')
+    @patch('jax.device_get', return_value=np.zeros(8, dtype=np.int32))
+    def test_sample_from_logits_does_not_call_from_input_batch(
+            self, mock_jax_device_get, mock_runner_utils, mock_sample,
+            mock_sampling_metadata):
+        """_sample_from_logits() should use its tpu_sampling_metadata argument, not create one internally."""
+        runner = MagicMock()
+        runner.input_batch.num_reqs = 0  # empty batch keeps the loop trivial
+        runner.speculative_config = None
+        runner.scheduler_config.async_scheduling = False
+
+        mock_tpu_sampling_metadata = MagicMock()
+        mock_tpu_sampling_metadata.do_sampling = False
+        mock_tpu_sampling_metadata.logprobs = False
+
+        mock_runner_utils.get_padded_num_reqs_with_upper_limit.return_value = 8
+        mock_sample.return_value = np.zeros(8, dtype=np.int32)
+
+        try:
+            TPUModelRunner._sample_from_logits(
+                runner,
+                MagicMock(),  # scheduler_output
+                MagicMock(),  # attn_metadata
+                mock_tpu_sampling_metadata,
+                None,  # input_ids
+                MagicMock(),  # hidden_states
+                MagicMock(),  # logits
+                None,  # aux_hidden_states
+                None,  # spec_decode_metadata
+                None,  # kv_connector_output
+                padded_num_reqs=8,
+            )
+        except Exception:
+            pass  # only care that from_input_batch was never called
+
+        mock_sampling_metadata.from_input_batch.assert_not_called()
+
+
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/tpu_inference/layers/jax/sample/sampling.py
+++ b/tpu_inference/layers/jax/sample/sampling.py
@@ -36,8 +36,10 @@ def sample(
     # (B, vocab_size)
     if tpu_sampling_metadata.do_sampling:
         # Unshard the logits explicity to avoid latency increase.
+        # TODO(gxd3): revisit if the 2nd dimension of the logits can be sharded
+        # instead of being replicated.
         logits = jax.lax.with_sharding_constraint(
-            logits, NamedSharding(mesh, P(ShardingAxisName.MLP_DATA, None)))
+            logits, NamedSharding(mesh, P(ShardingAxisName.ATTN_DATA, None)))
     greedy_sampled = jnp.argmax(logits, axis=-1)
     if not tpu_sampling_metadata.do_sampling:
         return greedy_sampled
@@ -65,8 +67,13 @@ def sample(
     next_tokens = jax.random.categorical(rng, logits)
     # Note: avoid using the sample result when temperature < _SAMPLING_EPS
     # If temperature < 0, logits /= temperatures will flip the result, causing error.
-    return jnp.where(tpu_sampling_metadata.temperature < _SAMPLING_EPS,
-                     greedy_sampled, next_tokens)
+    ret = jnp.where(tpu_sampling_metadata.temperature < _SAMPLING_EPS,
+                    greedy_sampled, next_tokens)
+    # Replicate the result so that in multi-controller jax setup
+    # (i.e. Ray based multi-host setup), we won't hit error like
+    # RuntimeError: Fetching value for `jax.Array` that spans non-addressable
+    # (non process local) devices is not possible.
+    return jax.lax.with_sharding_constraint(ret, NamedSharding(mesh, P()))
 
 
 def compute_logprobs(logits: jax.Array) -> jax.Array:

--- a/tpu_inference/models/vllm/vllm_model_wrapper.py
+++ b/tpu_inference/models/vllm/vllm_model_wrapper.py
@@ -289,6 +289,8 @@ class VllmModelWrapper:
 
     def jit_compute_logits_func(self):
 
+        # TODO(gxd3): revisit if the sharding below is the best way to shard the
+        # output logits.
         @jax.jit(out_shardings=(NamedSharding(
             self.mesh,
             PartitionSpec(ShardingAxisName.MLP_DATA,

--- a/tpu_inference/runner/compilation_manager.py
+++ b/tpu_inference/runner/compilation_manager.py
@@ -511,8 +511,7 @@ class CompilationManager:
         for num_reqs in self.runner.num_reqs_paddings:
             logits_sharding = NamedSharding(
                 self.runner.mesh,
-                PartitionSpec(ShardingAxisName.MLP_DATA,
-                              ShardingAxisName.MLP_TENSOR))
+                PartitionSpec(ShardingAxisName.ATTN_DATA, None))
             dp_size = self.runner.vllm_config.sharding_config.total_dp_size
             sampling_metadata_sharding = NamedSharding(
                 self.runner.mesh, PartitionSpec(

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -147,6 +147,7 @@ class ExecuteModelState:
 
     scheduler_output: "VllmSchedulerOutput"
     attn_metadata: AttentionMetadata
+    sampling_metadata: TPUSupportedSamplingMetadata
     input_ids: Optional[jax.Array]
     hidden_states: jax.Array
     logits: jax.Array
@@ -618,11 +619,12 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             # This can happen in pipeline parallel case.
             return EMPTY_MODEL_RUNNER_OUTPUT
 
-        (scheduler_output, attn_metadata, input_ids, hidden_states, logits,
-         aux_hidden_states, spec_decode_metadata, kv_connector_output,
-         logits_indices_selector,
+        (scheduler_output, attn_metadata, sampling_metadata, input_ids,
+         hidden_states, logits, aux_hidden_states, spec_decode_metadata,
+         kv_connector_output, logits_indices_selector,
          padded_num_reqs) = (self.execute_model_state.scheduler_output,
                              self.execute_model_state.attn_metadata,
+                             self.execute_model_state.sampling_metadata,
                              self.execute_model_state.input_ids,
                              self.execute_model_state.hidden_states,
                              self.execute_model_state.logits,
@@ -645,9 +647,9 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                 arange,
             )
         return self._sample_from_logits(
-            scheduler_output, attn_metadata, input_ids, hidden_states, logits,
-            aux_hidden_states, spec_decode_metadata, kv_connector_output,
-            logits_indices_selector, padded_num_reqs)
+            scheduler_output, attn_metadata, sampling_metadata, input_ids,
+            hidden_states, logits, aux_hidden_states, spec_decode_metadata,
+            kv_connector_output, logits_indices_selector, padded_num_reqs)
 
     def _modify_prev_results(self):
         # If copy to host has not been done, we just wait.
@@ -759,7 +761,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             input_ids,
             input_positions,
             attn_metadata,
-            _,
+            sampling_metadata,
             logits_indices,
             spec_decode_metadata,
             logits_indices_selector,
@@ -847,6 +849,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         self.execute_model_state = ExecuteModelState(
             scheduler_output=scheduler_output,
             attn_metadata=attn_metadata,
+            sampling_metadata=sampling_metadata,
             input_ids=input_ids,
             hidden_states=hidden_states,
             logits=logits,
@@ -861,6 +864,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         self,
         scheduler_output: "VllmSchedulerOutput",
         attn_metadata: AttentionMetadata,
+        tpu_sampling_metadata: TPUSupportedSamplingMetadata,
         input_ids: Optional[jax.Array],
         hidden_states: jax.Array,
         logits: jax.Array,
@@ -874,15 +878,6 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             padded_num_reqs = runner_utils.get_padded_num_reqs_with_upper_limit(
                 self.input_batch.num_reqs, self.max_num_reqs)
 
-        sharding = None
-        if self.dp_size > 1:
-            sharding = NamedSharding(self.mesh,
-                                     PartitionSpec(ShardingAxisName.MLP_DATA))
-
-        tpu_sampling_metadata = TPUSupportedSamplingMetadata.from_input_batch(
-            self.mesh, self.input_batch, padded_num_reqs, sharding=sharding)
-
-        # TODO(pooyam): Should we move this to `_prepare_inputs`?
         if tpu_sampling_metadata.do_sampling:
             self.rng_params_for_sampling, step_rng = jax.random.split(
                 self.rng_params_for_sampling)
@@ -1440,8 +1435,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             self.mesh,
             self.input_batch,
             padded_num_reqs,
-            sharding=NamedSharding(self.mesh,
-                                   PartitionSpec(ShardingAxisName.MLP_DATA)),
+            sharding=data_parallel_attn_sharding,
         )
         if self.uses_mrope:
             positions = mrope_positions


### PR DESCRIPTION
# Description

use ATTN_DATA for logits and sampling inputs to reflect data-parallel sharding for sample operations.


With this PR:
the sampling time per step now is ~8ms
xprof: 
http://xprof/trace_viewer.html?session_id=gxd-4577684671167384147 

(Previously, sampling time per step is ~78ms, xprof: http://xprof/trace_viewer.html?session_id=gxd-16747567685286754508).

Another change:
Remove `TPUSupportedSamplingMetadata.from_input_batch()` from TPU_runner's _sample_from_logits() as it has been called from TPU_runner's prepare_input(); We should just use the sampling_metadata created from `prepare_input` to avoid duplicated work.

After this, we saw reduced host overhead: the host overhead per step is ~130ms (see xprof above); before this change, sometimes we saw sporadic 400ms in some step (see xprof above).




# Tests
Unit test,
E2E benchmark 
Quality test

python ./tpu-inference/scripts/vllm/benchmarking/benchmark_serving.py --backend vllm --model deepseek-ai/DeepSeek-R1 --dataset-name mmlu --dataset-path /home/gxd_google_com/mmlu/data/test --num-prompts 1000 --run_eval --temperature 0
```
============ Serving Benchmark Result ============
Successful requests:                     1000      
Benchmark duration (s):                  26.65     
Total input tokens:                      173929    
Total generated tokens:                  2000      
Request throughput (req/s):              37.52     
Output token throughput (tok/s):         75.05     
Total token throughput (tok/s):          6601.71   
---------------Time to First Token----------------
Mean TTFT (ms):                          15416.43  
Median TTFT (ms):                        14543.24  
P99 TTFT (ms):                           26298.83  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          977.92    
Median TPOT (ms):                        994.29    
P99 TPOT (ms):                           1003.95   
---------------Inter-token Latency----------------
Mean ITL (ms):                           977.92    
Median ITL (ms):                         994.29    
P99 ITL (ms):                            1003.95   
----------------End-to-end Latency----------------
Mean E2EL (ms):                          16394.34  
Median E2EL (ms):                        15537.61  
P99 E2EL (ms):                           26523.11  
==================================================
Evaluating MMLU...
[nltk_data] Downloading package punkt to
[nltk_data]     /home/gxd_google_com/nltk_data...
[nltk_data]   Package punkt is already up-to-date!
[nltk_data] Downloading package punkt_tab to
[nltk_data]     /home/gxd_google_com/nltk_data...
[nltk_data]   Package punkt_tab is already up-to-date!

Results
{'accuracy': 0.866, 'gen_num': 1000}
```

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
