### PR TITLE
[Bug fix] Use correct kwargs for dtype

### DIFF
--- a/tpu_inference/layers/jax/embed.py
+++ b/tpu_inference/layers/jax/embed.py
@@ -30,6 +30,11 @@ class JaxEmbed(nnx.Embed, JaxModule):
                  quant_config: Optional[QuantizationConfig] = None,
                  prefix: str = "",
                  **kwargs):
+        # nnx.Embed uses `param_dtype` for parameter initialization dtype.
+        # Accept `dtype` as an alias for backward compatibility, but forward it
+        # as `param_dtype` so that weights are created with the correct dtype.
+        if "dtype" in kwargs and "param_dtype" not in kwargs:
+            kwargs["param_dtype"] = kwargs.pop("dtype")
         nnx.Embed.__init__(self, *args, **kwargs)
         # For compatibility. HF model use 'weight' as name suffix, we alias `self.embedding` to
         # `self.weight` such that `named_parameters()` can match the names in HF models.

--- a/tpu_inference/layers/jax/linear.py
+++ b/tpu_inference/layers/jax/linear.py
@@ -46,6 +46,11 @@ class JaxEinsum(nnx.Einsum, JaxModule):
                  kernel_metadata={},
                  bias_metadata={},
                  **kwargs):
+        # nnx.Einsum uses `param_dtype` for parameter initialization dtype.
+        # Accept `dtype` as an alias for backward compatibility, but forward it
+        # as `param_dtype` so that weights are created with the correct dtype.
+        if "dtype" in kwargs and "param_dtype" not in kwargs:
+            kwargs["param_dtype"] = kwargs.pop("dtype")
         if "eager_sharding" not in kernel_metadata:
             kernel_metadata["eager_sharding"] = False
         if "eager_sharding" not in bias_metadata:

--- a/tpu_inference/layers/jax/norm.py
+++ b/tpu_inference/layers/jax/norm.py
@@ -30,6 +30,11 @@ class JaxRmsNorm(nnx.RMSNorm, JaxModule):
                  quant_config: Optional[QuantizationConfig] = None,
                  prefix: str = "",
                  **kwargs):
+        # nnx.RMSNorm uses `param_dtype` for parameter initialization dtype.
+        # Accept `dtype` as an alias for backward compatibility, but forward it
+        # as `param_dtype` so that weights are created with the correct dtype.
+        if "dtype" in kwargs and "param_dtype" not in kwargs:
+            kwargs["param_dtype"] = kwargs.pop("dtype")
         nnx.RMSNorm.__init__(self, *args, **kwargs)
         # For compatibility. HF model use 'weight' as name suffix, we alias `self.scale` to
         # `self.weight` such that `named_parameters()` can match the names in HF models. We also

--- a/tpu_inference/models/jax/llama4.py
+++ b/tpu_inference/models/jax/llama4.py
@@ -755,6 +755,7 @@ class JAXUnfoldConvolution(nnx.Module):
             patch_flat_dim,
             cfg.hidden_size,
             use_bias=False,
+            param_dtype=dtype,
             dtype=dtype,
             kernel_init=nnx.with_partitioning(nnx.initializers.lecun_normal(),
                                               (None, "model")),
@@ -799,6 +800,7 @@ class JAXLlama4VisionMLP(nnx.Module):
             cfg.hidden_size,
             cfg.intermediate_size,
             use_bias=True,
+            param_dtype=dtype,
             dtype=dtype,
             kernel_init=nnx.with_partitioning(
                 nnx.initializers.glorot_uniform(), (None, "model")),
@@ -810,6 +812,7 @@ class JAXLlama4VisionMLP(nnx.Module):
             cfg.intermediate_size,
             cfg.hidden_size,
             use_bias=True,
+            param_dtype=dtype,
             dtype=dtype,
             kernel_init=nnx.with_partitioning(
                 nnx.initializers.glorot_uniform(), ("model", None)),
@@ -871,6 +874,7 @@ class JAXLlama4VisionEncoderLayer(nnx.Module):
         self.input_layernorm = nnx.LayerNorm(
             cfg.hidden_size,
             epsilon=cfg.norm_eps,
+            param_dtype=dtype,
             dtype=dtype,
             rngs=rngs,
             scale_init=nnx.with_partitioning(nnx.initializers.ones, P()),
@@ -878,6 +882,7 @@ class JAXLlama4VisionEncoderLayer(nnx.Module):
         self.post_attention_layernorm = nnx.LayerNorm(
             cfg.hidden_size,
             epsilon=cfg.norm_eps,
+            param_dtype=dtype,
             dtype=dtype,
             rngs=rngs,
             scale_init=nnx.with_partitioning(nnx.initializers.ones, P()),
@@ -1005,6 +1010,7 @@ class JAXLlama4VisionMLP2(nnx.Module):
             cfg.intermediate_size,
             cfg.projector_input_dim,
             use_bias=False,
+            param_dtype=dtype,
             dtype=dtype,
             kernel_init=nnx.with_partitioning(
                 nnx.initializers.glorot_uniform(), (None, "model")),
@@ -1014,6 +1020,7 @@ class JAXLlama4VisionMLP2(nnx.Module):
             cfg.projector_output_dim,
             cfg.projector_output_dim,
             use_bias=False,
+            param_dtype=dtype,
             dtype=dtype,
             kernel_init=nnx.with_partitioning(
                 nnx.initializers.glorot_uniform(), ("model", None)),
@@ -1110,6 +1117,7 @@ class JAXLlama4VisionModel(nnx.Module):
         self.layernorm_pre = nnx.LayerNorm(
             self.hidden_size,
             epsilon=self.norm_eps,
+            param_dtype=dtype,
             dtype=dtype,
             rngs=rngs,
             scale_init=nnx.with_partitioning(nnx.initializers.ones, P()),
@@ -1117,6 +1125,7 @@ class JAXLlama4VisionModel(nnx.Module):
         self.layernorm_post = nnx.LayerNorm(
             self.hidden_size,
             epsilon=self.norm_eps,
+            param_dtype=dtype,
             dtype=dtype,
             rngs=rngs,
             scale_init=nnx.with_partitioning(nnx.initializers.ones, P()),
@@ -1194,6 +1203,7 @@ class JAXLlama4MultiModalProjector(nnx.Module):
             cfg["vision_config"].vision_output_dim,
             cfg["text_config"].hidden_size,
             use_bias=False,
+            param_dtype=dtype,
             dtype=dtype,
             kernel_init=nnx.with_partitioning(nnx.initializers.lecun_normal(),
                                               (None, "model")),

--- a/tpu_inference/models/jax/qwen2_5_vl.py
+++ b/tpu_inference/models/jax/qwen2_5_vl.py
@@ -330,6 +330,7 @@ class Qwen2_5_VisionBlock(nnx.Module):
         dim = vision_config.hidden_size
         norm_layer = partial(nnx.RMSNorm,
                              epsilon=config.rms_norm_eps,
+                             param_dtype=dtype,
                              scale_init=nnx.with_partitioning(
                                  init_fn, (None, )))
 
@@ -405,6 +406,7 @@ class Qwen2_5_VisionPatchMerger(nnx.Module):
                  spatial_merge_size: int, dtype: jnp.dtype, rngs: nnx.Rngs):
         self.hidden_size = context_dim * (spatial_merge_size**2)
         self.ln_q = norm_layer(context_dim,
+                               param_dtype=dtype,
                                dtype=dtype,
                                rngs=rngs,
                                scale_init=nnx.with_partitioning(


### PR DESCRIPTION
# Description

After switching to Flax 0.12.4, some modules like nnx.Einsum use `param_dtype` instead of `dtype` as the keyword argument. This causes weights to be initialized with the wrong dtype (float32 instead of bfloat16), which then causes a dtype mismatch error in the attention kernel.

This PR fixes this issue. 


# Tests

Tested with dummy weight, offline inference failed on head and worked with the PR fix.

```
MODEL_IMPL_TYPE=flax_nnx python examples/offline_inference.py --model=Qwen/Qwen2-1.5B --load-format dummy --no-async-scheduling
```

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
