### PR TITLE
remove block_until_ready and enable optimization_barrier in gather_tpu_blocks in kvconnector

### DIFF
--- a/tests/offload/tpu_offload_connector_worker_test.py
+++ b/tests/offload/tpu_offload_connector_worker_test.py
@@ -458,8 +458,11 @@ class TestTPUOffloadConnectorWorker(jtu.JaxTestCase):
         connector = self._create_connector(swap_op_type,
                                            use_precompiled_swap_ops)
         worker = connector.connector_worker
-        # Ground truth cache on TPU
-        src_kv_cache = worker.runner.kv_caches
+        # Ground truth cache. We copy it to host early because the save
+        # operation will donate via stack_kv_cache_cross_layers.
+        src_kv_cache_baseline = [
+            np.array(cache) for cache in worker.runner.kv_caches
+        ]
         # Destination cache on TPU, should be modified by the load operation
         dst_kv_cache = [
             jax.device_put(jnp.zeros(self.cache_shape, dtype=self.cache_dtype),
@@ -557,7 +560,7 @@ class TestTPUOffloadConnectorWorker(jtu.JaxTestCase):
             for src_block_id in src_blocks:
                 for layer_idx in range(self.num_layers):
                     self.assertArraysEqual(
-                        np.array(src_kv_cache[layer_idx][src_block_id]),
+                        src_kv_cache_baseline[layer_idx][src_block_id],
                         np.array(dst_kv_cache[layer_idx][src_block_id]))
 
         # verify the loaded chunks

--- a/tpu_inference/offload/tpu_offload_connector.py
+++ b/tpu_inference/offload/tpu_offload_connector.py
@@ -1839,7 +1839,7 @@ class TPUOffloadConnectorWorker:
                     dummy_block_ids = jnp.array(
                         random.sample(all_block_ids, num_blocks))
                     # 1. gather / stack (for save)
-                    stacked_dummy_kv_caches_tpu = stack_kv_cache_cross_layers(
+                    paged_kv_for_compilation, stacked_dummy_kv_caches_tpu = stack_kv_cache_cross_layers(
                         paged_kv_for_compilation, dummy_block_ids, num_blocks)
                     jax.block_until_ready(stacked_dummy_kv_caches_tpu)
                     # 2. update / insert  kv (for load)
@@ -1862,7 +1862,7 @@ class TPUOffloadConnectorWorker:
         self,
         kv_caches: list[jax.Array],
         block_ids: list[int],
-    ) -> list[jax.Array]:
+    ) -> tuple[list[jax.Array], list[jax.Array]]:
         """
         Gathers KV cache data for the given block_ids by breaking the operation
         into bucket-aligned chunks to leverage JIT compilation cache.
@@ -1870,7 +1870,7 @@ class TPUOffloadConnectorWorker:
         num_blocks = len(block_ids)
         GATHER_NUM_BLOCKS.observe(num_blocks)
         if num_blocks == 0:
-            return []
+            return kv_caches, []
         if num_blocks in BLOCK_SIZE_BUCKETS:
             block_ids_arr = jnp.array(block_ids)
             return stack_kv_cache_cross_layers(kv_caches, block_ids_arr,
@@ -1886,19 +1886,25 @@ class TPUOffloadConnectorWorker:
         logger.info(
             f"Decomposing gather for {num_blocks} blocks into buckets: {decomposed_block_buckets}"
         )
+        # We thread current_kv_caches through the loop to handle buffer donation.
+        # Since stack_kv_cache_cross_layers consumes its input, we must use
+        # the newly returned handle for each subsequent bucketed operation.
+        current_kv_caches = kv_caches
         gathered_chunks = []
         for i, decomposed_block_bucket in enumerate(decomposed_block_buckets):
             _num_blocks = len(decomposed_block_bucket)
             block_slice = decomposed_block_slice_arr[i]
             with GATHER_CHUNK_LATENCY.labels(
                     num_blocks=str(_num_blocks)).time():
-                gathered_chunk = stack_kv_cache_cross_layers(
-                    kv_caches, block_slice, len(decomposed_block_bucket))
+                # Update current_kv_caches with the latest valid handle
+                current_kv_caches, gathered_chunk = stack_kv_cache_cross_layers(
+                    current_kv_caches, block_slice,
+                    len(decomposed_block_bucket))
             with GATHER_APPEND_LATENCY.labels(
                     num_blocks=str(_num_blocks)).time():
                 gathered_chunks.extend(gathered_chunk)
 
-        return gathered_chunks
+        return current_kv_caches, gathered_chunks
 
     def _bucketed_update_kv_caches(
         self,
@@ -2040,14 +2046,14 @@ class TPUOffloadConnectorWorker:
         start_time = time.time()
         if not self.no_op_gather:
             if self.use_bucketed_swap_ops:
-                gathered_kv_caches_tpu = self._bucketed_stack_kv_caches(
+                kv_caches, gathered_kv_caches_tpu = self._bucketed_stack_kv_caches(
                     self.runner.kv_caches, blocks_to_save)
             else:
                 blocks_to_save_arr = jnp.array(blocks_to_save)
-                gathered_kv_caches_tpu = stack_kv_cache_cross_layers(
+                kv_caches, gathered_kv_caches_tpu = stack_kv_cache_cross_layers(
                     self.runner.kv_caches, blocks_to_save_arr,
                     num_blocks_to_save)
-            jax.block_until_ready(gathered_kv_caches_tpu)
+            self.runner.kv_caches = kv_caches
         else:
             gathered_kv_caches_tpu = None
 
@@ -2133,14 +2139,14 @@ class TPUOffloadConnectorWorker:
             GATHER_TPU_BLOCKS_CALLS.inc()
             start_time = time.time()
             if self.use_bucketed_swap_ops:
-                gathered_kv_caches_tpu = self._bucketed_stack_kv_caches(
+                kv_caches, gathered_kv_caches_tpu = self._bucketed_stack_kv_caches(
                     self.runner.kv_caches, all_src_blocks)
             else:
                 all_src_blocks_arr = jnp.array(all_src_blocks)
-                gathered_kv_caches_tpu = stack_kv_cache_cross_layers(
+                kv_caches, gathered_kv_caches_tpu = stack_kv_cache_cross_layers(
                     self.runner.kv_caches, all_src_blocks_arr,
                     total_num_blocks_to_save)
-            jax.block_until_ready(gathered_kv_caches_tpu)
+            self.runner.kv_caches = kv_caches
             duration = time.time() - start_time
             GATHER_TPU_BLOCKS_LATENCY.labels(
                 num_blocks=str(total_num_blocks_to_save)).observe(duration)

--- a/tpu_inference/offload/utils.py
+++ b/tpu_inference/offload/utils.py
@@ -143,10 +143,14 @@ def jitted_insert_kv_cache_slices(
     return jax.tree.map(_update_layer, kv_caches, kv_cache_slices)
 
 
-@functools.partial(jax.jit, static_argnames=['num_blocks'])
-def stack_kv_cache_cross_layers(kv_caches: List[jax.Array],
-                                block_ids: jax.Array,
-                                num_blocks: int) -> List[jax.Array]:
+@functools.partial(
+    jax.jit,
+    static_argnames=['num_blocks'],
+    donate_argnames=('kv_caches', ),
+)
+def stack_kv_cache_cross_layers(
+        kv_caches: List[jax.Array], block_ids: jax.Array,
+        num_blocks: int) -> Tuple[List[jax.Array], List[jax.Array]]:
     """
     This uses jax.tree.map to apply the operation across all layers.
     """
@@ -164,7 +168,9 @@ def stack_kv_cache_cross_layers(kv_caches: List[jax.Array],
                              axis=0)
     # split_blocks = jnp.array_split(stacked_blocks, num_blocks, axis=0)
 
-    return split_blocks
+    kv_caches = jax.lax.optimization_barrier(kv_caches)
+
+    return kv_caches, split_blocks
 
 
 @functools.partial(


### PR DESCRIPTION
# Description

Start with a short description of what the PR does and how this is a change from
the past.

introduce optimization_barrier in kvconnector gather_tpu_blocks code path

The rest of the description includes relevant details and context, examples:
- why is this change being made,
- the problem being solved and any relevant context,
- why this is a good solution,
- some information about the specific implementation,
- shortcomings of the solution and possible future improvements.


    
  Eliminates the synchronous `jax.block_until_ready()` call during TPU KV cache
  gathering by implementing an explicit asynchronous dependency graph.
  Key changes:
  - Modified `stack_kv_cache_cross_layers` to return `kv_caches` as a state
  token, establishing a "chain of custody" for the buffers.
  - Replaced `block_until_ready()` with `jax.lax.optimization_barrier` in the
  worker's gather methods to anchor the operations in the TPU schedule.
  - Updated `self.runner.kv_caches` with the dependency-aware version returned
  by the barrier.
  - Updated bucketed gather and pre-compilation logic to handle the new
  tuple return signatures.

If the change fixes a Github issue, please include a link, e.g.,:
FIXES: #123456

# Tests

Ran unit tests tpu_offload_accuracy_test, tpu_offload_connector_worker_test
Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
