### PR TITLE
use sm_scale from the vllm path attention

### DIFF
--- a/tpu_inference/layers/vllm/backends/flash_attn.py
+++ b/tpu_inference/layers/vllm/backends/flash_attn.py
@@ -246,8 +246,6 @@ def _jax_attn_func(
     v_scale: float | None = None,
     sliding_window: int | None = None,
 ) -> Tuple[jax.Array, jax.Array]:
-    del scale  # Unused for now, as the attention function applies a default scale.
-
     # Get shapes from vllm
     q_len = q.shape[0]
     k_len = k.shape[0]
@@ -264,6 +262,7 @@ def _jax_attn_func(
         v,
         attention_metadata,
         mesh,
+        sm_scale=scale,
         q_scale=q_scale,
         k_scale=k_scale,
         v_scale=v_scale,


### PR DESCRIPTION
# Description

Refer https://github.com/vllm-project/tpu-inference/pull/1775 , we can use scale from the vllm function which use non-default value.

# Tests

Tested offline with `python examples/offline_inference.py` on a few models.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
