### PR TITLE
Use Auto axis when creating mesh

### DIFF
--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -26,6 +26,7 @@ import jaxtyping
 import numpy as np
 import vllm.envs as vllm_envs
 from flax import nnx
+from jax._src import mesh as mesh_lib
 from jax._src.pallas.utils import next_power_of_2
 from jax.experimental import mesh_utils
 from jax.sharding import NamedSharding, PartitionSpec
@@ -386,8 +387,10 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             and len(self.vllm_config.sharding_config.device_indexes) > 0)
 
         if enforce_device_order:
+            axis_types = (mesh_lib.AxisType.Auto, ) * len(mesh_shape)
             return jax.make_mesh(mesh_shape,
                                  MESH_AXIS_NAMES_2D,
+                                 axis_types,
                                  devices=self.devices)
         else:
             return make_optimized_mesh(mesh_shape,

--- a/tpu_inference/utils.py
+++ b/tpu_inference/utils.py
@@ -270,7 +270,11 @@ def make_optimized_mesh(axis_shapes: Sequence[int],
     # for non-power-of-two device counts (e.g., DP=6) to bypass strict
     # hardware topology constraints that would otherwise cause an AssertionError.
     try:
-        return jax.make_mesh(axis_shapes, axis_names, devices=devices)
+        axis_types = (mesh_lib.AxisType.Auto, ) * len(axis_shapes)
+        return jax.make_mesh(axis_shapes,
+                             axis_names,
+                             axis_types,
+                             devices=devices)
     except (AssertionError, ValueError, RuntimeError) as e:
         logger.warning(
             "jax.make_mesh failed due to topology constraints. Falling back to manual mesh: %s",


### PR DESCRIPTION
# Description

Starting from jax 0.9.0, `make_mesh` defaults to explicit axes where it triggers error if a tensor's sharding is change without an explicit sharding annotation: https://github.com/jax-ml/jax/commit/89401bd3143e448eec169732295470ccb9ff97af

this commit changes it to use Auto to avoid the error. 

Confirmed that code works with updated jax version
```
jax==0.9.1
jaxlib==0.9.1
jaxtyping==0.3.9
libtpu==0.0.37
```

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
