### PR TITLE
[Jax] Enable dummy weight loader for JAX MoE models

### DIFF
--- a/tests/models/jax/test_qwen3_moe.py
+++ b/tests/models/jax/test_qwen3_moe.py
@@ -34,11 +34,14 @@ class TestQwen3MoeForCausalLM:
     ])
     @pytest.mark.parametrize("pp_rank,pp_world_size", [(0, 1), (0, 4), (1, 4),
                                                        (3, 4)])
+    @pytest.mark.parametrize(
+        "load_format", ["skip_layers_model_loader_for_test", "jax_dummy"])
     def test_model_loading(
             self,
             model_name,
             pp_rank,
             pp_world_size,
+            load_format,
             # following are defined in conftest.py
             rng,
             mesh,
@@ -49,7 +52,7 @@ class TestQwen3MoeForCausalLM:
         vllm_config = mock_vllm_config(model_name, kv_cache_type)
         # No need to load full model.
         vllm_config.model_config.hf_config.num_hidden_layers = 4
-        vllm_config.load_config.load_format = "skip_layers_model_loader_for_test"
+        vllm_config.load_config.load_format = load_format
         vllm_config.load_config.num_layers_to_load_for_test = 4
 
         init_pp_distributed_environment(

--- a/tpu_inference/models/jax/qwen3_moe.py
+++ b/tpu_inference/models/jax/qwen3_moe.py
@@ -80,6 +80,8 @@ class Qwen3MoeSparseMoeBlock(JaxModule):
         self.gate = JaxLinear(
             config.hidden_size,
             config.num_experts,
+            dtype=dtype,
+            param_dtype=dtype,
             rngs=rng,
             use_bias=False,
             quant_config=quant_config,
@@ -143,6 +145,7 @@ class Qwen3MoeDecoderLayer(JaxModule):
         self.input_layernorm = JaxRmsNorm(
             hidden_size,
             epsilon=rms_norm_eps,
+            dtype=dtype,
             param_dtype=dtype,
             scale_init=nnx.with_partitioning(init_fn, (None, )),
             rngs=rng,
@@ -162,6 +165,7 @@ class Qwen3MoeDecoderLayer(JaxModule):
             hidden_size,
             epsilon=rms_norm_eps,
             param_dtype=dtype,
+            dtype=dtype,
             scale_init=nnx.with_partitioning(init_fn, (None, )),
             rngs=rng,
             quant_config=quant_config,
@@ -224,6 +228,7 @@ class Qwen3MoeModel(JaxModule):
             self.embed_tokens = JaxEmbed(
                 num_embeddings=vocab_size,
                 features=hidden_size,
+                dtype=dtype,
                 param_dtype=dtype,
                 embedding_init=nnx.with_partitioning(init_fn, ("model", None)),
                 rngs=rng,
@@ -251,6 +256,7 @@ class Qwen3MoeModel(JaxModule):
             self.norm = JaxRmsNorm(
                 hidden_size,
                 epsilon=rms_norm_eps,
+                dtype=dtype,
                 param_dtype=dtype,
                 scale_init=nnx.with_partitioning(init_fn, (None, )),
                 rngs=rng,
@@ -323,6 +329,7 @@ class Qwen3MoeForCausalLM(JaxModule, LoadableWithIterator):
                     einsum_str="TD,DV->TV",
                     kernel_shape=(hidden_size, vocab_size),
                     dtype=model_config.dtype,
+                    param_dtype=model_config.dtype,
                     rngs=rng,
                     quant_config=vllm_config.quant_config,
                     prefix="lm_head",

--- a/tpu_inference/models/jax/utils/weight_utils.py
+++ b/tpu_inference/models/jax/utils/weight_utils.py
@@ -758,7 +758,7 @@ def jax_array_from_reshaped_torch(
 
 def assign_and_shard_param(jax_param: nnx.Param,
                            jax_weight: jax.Array,
-                           param_name: str = "Unknown"):
+                           param_name: str = "Unknown") -> None:
     """Distributes a JAX array across devices according to the `nnx.Param`'s sharding metadata, assigns it to the parameter, and marks it as loaded.
 
     Args:
@@ -908,23 +908,35 @@ class JaxDummyModelLoader(DummyModelLoader):
 
     def load_weights(self, model: JaxModule,
                      model_config: ModelConfig) -> None:
-        if getattr(model_config.hf_config,
-                   "num_local_experts", 0) > 0 or getattr(
-                       model_config.hf_config, "num_experts", 0) > 0:
-            raise NotImplementedError(
-                "JaxDummyModelLoader does not support MoE models yet.")
-
         weight_loading_start_counter = time.perf_counter()
         for param_name, param in model.named_parameters():
-            dummy_weight = jax.random.uniform(
-                key=jax.random.PRNGKey(0),
-                shape=param.value.shape,
-                dtype=param.value.dtype,
-                # upstream claims this range works well
-                # https://github.com/vllm-project/vllm/blob/7291d1b288558d48508e1a17c37b0aa170332264/vllm/model_executor/model_loader/weight_utils.py#L1088
-                minval=-1e-3,
-                maxval=1e-3,
-            )
+            with cpu_mesh_context():
+                is_moe = hasattr(param, "_weights_to_load")
+                param_shape = param.value.shape
+
+                if is_moe:
+                    # For MoE parameters, the normal loading flow reads PyTorch
+                    # weights which are transposed (out_features, in_features)
+                    # compared to JAX. The downstream post-loading fusion methods
+                    # expect this transposed shape (E, F, D) instead of (E, D, F).
+                    # E = number of experts, D = input dimension, F = feed forward dimension
+                    num_experts, input_dim, intermediate_dim = param_shape
+                    param_shape = (num_experts, intermediate_dim, input_dim)
+
+                dummy_weight = jax.random.uniform(
+                    key=jax.random.PRNGKey(0),
+                    shape=param_shape,
+                    dtype=param.value.dtype,
+                    # upstream claims this range works well
+                    # https://github.com/vllm-project/vllm/blob/7291d1b288558d48508e1a17c37b0aa170332264/vllm/model_executor/model_loader/weight_utils.py#L1088
+                    minval=-1e-3,
+                    maxval=1e-3,
+                )
+
+                if is_moe:
+                    param._weights_to_load[:] = jnp.vsplit(
+                        dummy_weight, indices_or_sections=num_experts)
+
             assign_and_shard_param(param, dummy_weight, param_name)
 
         self._process_weights_after_loading(model)


### PR DESCRIPTION
# Description
Add dummy weight generation support for JAX MoE models.
 - Add unit tests

### Weight loading time 

| Model                           | Regular (s) | Dummy (s) |
| :------------------------------ | :---------- | :-------- |
| Qwen/Qwen3-30B-A3B-Instruct-2507                 | 82.54       | 69.43      |
| Qwen/Qwen3-30B-A3B-Instruct-2507-FP8            | 134.64       | 133.06     |
| Qwen/Qwen3-4B-Instruct-2507     | 7.30        | 9.51      |
| Qwen/Qwen3-4B-Instruct-2507-FP8 | 26.07       | 34.00    |

# Tests
 - CI / Unit tests.
 - MODEL_IMPL_TYPE=flax_nnx vllm serve Qwen/Qwen3-30B-A3B-Instruct-2507 --load-format dummy
 - MODEL_IMPL_TYPE=flax_nnx vllm serve Qwen/Qwen3-30B-A3B-Instruct-2507-FP8 --load-format dummy

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
