### PR TITLE
[bugfix] Fix when using tp with dp

### DIFF
--- a/tpu_inference/layers/common/fused_moe_gmm.py
+++ b/tpu_inference/layers/common/fused_moe_gmm.py
@@ -178,7 +178,7 @@ def tensor_parallel_gmm(
             w2_scale_spec,
             w2_bias_spec,
             data_p_spec,
-            data_p_spec,
+            P(),
             data_p_spec,
             data_p_spec,
         ),


### PR DESCRIPTION
# Description

Fix following error when using moe tp with dp

```
(EngineCore_DP0 pid=852) ERROR 03-12 09:20:24 [core.py:1029] the passed args[8] of shape int32[1], where args[8] is bound to functools.partial(<function moe_gmm_local at 0x7b0e7583a5c0>, activation='swigluoai', topk=4, parallelism='tp')'s parameter 'group_offset: jax.Array', corresponds to in_specs[8] of value PartitionSpec('data',), which maps array axis 0 (of size 1) to mesh axis 'data' (of size 4), but 4 does not evenly divide 1"
```


# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
