### PR TITLE
[Kernel] [GMM] Fix incorrect RHS scale application

### DIFF
--- a/tpu_inference/kernels/megablox/gmm_v2.py
+++ b/tpu_inference/kernels/megablox/gmm_v2.py
@@ -932,6 +932,19 @@ def make_gmm_configs(
         dtype=lhs.dtype,
     )
 
+    # NOTE(catswe): when lhs quant_block_size > rhs quant_block_size,
+    # a single lhs block spans multiple rhs quant blocks. the quantized
+    # matmul path iterates at lhs block granularity and applies one rhs
+    # scale per lhs block, so the additional rhs scales within each
+    # iteration will be silently ignored.
+    if (rhs_cfgs.has_scale and lhs_cfgs.quant_block_size is not None
+            and rhs_cfgs.quant_block_size is not None
+            and lhs_cfgs.quant_block_size > rhs_cfgs.quant_block_size):
+        raise NotImplementedError(
+            f"lhs quant_block_size ({lhs_cfgs.quant_block_size}) > "
+            f"rhs quant_block_size ({rhs_cfgs.quant_block_size}) is not supported."
+        )
+
     if lhs_cfgs.quant_block_size != 512:
         logger.warning_once(
             f'[GMM V2] Using quant_block_size {lhs_cfgs.quant_block_size}. '


### PR DESCRIPTION
# Description

For the quantized matmul path, when `q_block_size` (`lhs_cfgs.quant_block_size`) > `rhs_qbs` (`rhs_cfgs.quant_block_size`), it applies only one RHS scale per LHS block instead of one per RHS block, which is incorrect, as one LHS block spans multiple RHS blocks.

https://github.com/vllm-project/tpu-inference/blob/1acbeab4c3685a55be447f8da99b4e29f523c45b/tpu_inference/kernels/megablox/gmm_v2.py#L331-L335

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
