### PR TITLE
[CI] Add RL support matrix

### DIFF
--- a/.buildkite/README.md
+++ b/.buildkite/README.md
@@ -21,6 +21,7 @@ Besides continuous integration and continuous delivery, a major goal of our pipe
 - kernel support matrix (microbenchmarks)
 - parallelism support matrix
 - quantization support matrix
+- RL support matrix
 
 To support this requirement, each model and feature will go through a series of stages of testing, and the test results will be used to generate the support matrices automatically.
 
@@ -65,6 +66,7 @@ The python script takes the following arguments:
   - `"parallelism support matrix"`
   - `"quantization support matrix"`
   - `"kernel support matrix microbenchmarks"`
+  - `"RL support matrix"`
 - **--group**: [OPTIONAL] This argument is **required** only when the category is `"kernel support matrix microbenchmarks"`. The group name should be the name of the kernel you are testing (e.g., `all_gather_matmul`). Its purpose is to organize all related microbenchmark tests for that specific kernel into a single directory.
 
   For example, if you are adding multiple tests for the `all_gather_matmul` kernel (e.g., one for `w4a4` quantization and another for `w8a8`), you would use `--group "all_gather_matmul"` for all of them. The script will then create a directory at `.buildkite/kernel_microbenchmarks/all_gather_matmul/` and place the generated YAML test files inside. In this scenario, the `--feature-name` would describe the specific configuration being tested, like `'w4a4'` or `'w8a8'`.

--- a/.buildkite/RL/RL_Integration.yml
+++ b/.buildkite/RL/RL_Integration.yml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # pipeline-name: RL_Integration
-# pipeline-type: feature support matrix
+# pipeline-type: RL support matrix
 # RL (Reinforcement Learning) integration tests verify features critical for
 # training-inference pipelines: HBM KV-cache delete/reinitialise, log-prob
 # correctness without recompilation, log-prob latency overhead, and group
@@ -36,7 +36,7 @@ steps:
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "RL_Integration"
       CI_STAGE: "CorrectnessTest"
-      CI_CATEGORY: "feature support matrix"
+      CI_CATEGORY: "RL support matrix"
     agents:
       queue: cpu
     commands:
@@ -61,7 +61,7 @@ steps:
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "RL_Integration"
       CI_STAGE: "PerformanceTest"
-      CI_CATEGORY: "feature support matrix"
+      CI_CATEGORY: "RL support matrix"
     agents:
       queue: cpu
     commands:

--- a/.buildkite/pipeline_generation/add_feature_to_ci.py
+++ b/.buildkite/pipeline_generation/add_feature_to_ci.py
@@ -26,6 +26,7 @@ class FeatureCategory(str, Enum):
     PARALLELISM = "parallelism support matrix"
     QUANTIZATION = "quantization support matrix"
     KERNEL_MICROBENCHMARKS = "kernel support matrix microbenchmarks"
+    RL = "RL support matrix"
 
 
 # Map categories to templates
@@ -35,6 +36,7 @@ CATEGORY_TO_TEMPLATE = {
     FeatureCategory.QUANTIZATION.value: "feature_template.yml",
     FeatureCategory.KERNEL_MICROBENCHMARKS.value: "feature_template.yml",
     FeatureCategory.PARALLELISM.value: "parallelism_template.yml",
+    FeatureCategory.RL.value: "feature_template.yml",
 }
 
 # Map feature categories to their respective output directories.
@@ -44,6 +46,7 @@ CATEGORY_TO_DIR = {
     FeatureCategory.PARALLELISM.value: "parallelism",
     FeatureCategory.QUANTIZATION.value: "quantization",
     FeatureCategory.KERNEL_MICROBENCHMARKS.value: "kernel_microbenchmarks",
+    FeatureCategory.RL.value: "RL",
 }
 
 
@@ -151,6 +154,7 @@ def main():
             FeatureCategory.PARALLELISM.value,
             FeatureCategory.QUANTIZATION.value,
             FeatureCategory.KERNEL_MICROBENCHMARKS.value,
+            FeatureCategory.RL.value,
         ],
         default=FeatureCategory.FEATURE.value,
         help=

--- a/.buildkite/scripts/upload_models_and_features.sh
+++ b/.buildkite/scripts/upload_models_and_features.sh
@@ -25,6 +25,7 @@ declare -a TARGET_FOLDERS=(
     "parallelism"
     "models"
     "features"
+    "RL"
 )
 
 
@@ -77,7 +78,7 @@ for folder_path in "${TARGET_FOLDERS[@]}"; do
         "models")
           model_list+=("$subject_name")
           ;;
-        "features" | "parallelism" | "quantization" | "kernel_microbenchmarks"/*)
+        "features" | "parallelism" | "quantization" | "kernel_microbenchmarks"/* | "RL")
           # When MODEL_IMPL_TYPE is 'auto', do not add quantization tests to the list for reporting.
           if ! [[ "$folder_path" == "quantization" && "${MODEL_IMPL_TYPE:-auto}" == "auto" ]]; then
             feature_list+=("${subject_name}")


### PR DESCRIPTION
# Description

1. Modified pipeline_generation/add_feature_to_ci.py to include "RL support matrix" as a valid category.
2. Updated the script logic to map the RL category to the appropriate .buildkite subdirectory.

To generate a new RL pipeline, run:

     python .buildkite/pipeline_generation/add_feature_to_ci.py \
      --feature-name "your_rl_feature" \
      --category "RL support matrix"

# Tests

[BuildKite](https://buildkite.com/tpu-commons/tpu-inference-ci/builds/12476/steps/canvas?sid=019cfe77-5450-49e0-b33e-ee9ab55bfb53&tab=output)

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
