### PR TITLE
Remove block_until_ready from the transfer_and_register_cpu_chunk code in TPU Host offload connector

### DIFF
--- a/tests/offload/tpu_offload_connector_worker_test.py
+++ b/tests/offload/tpu_offload_connector_worker_test.py
@@ -575,3 +575,120 @@ class TestTPUOffloadConnectorWorker(jtu.JaxTestCase):
             self.assertListEqual(
                 dst_chunks,
                 worker.offload_stats.data["finished_load_chunks"][req_id])
+
+    def test_tpu_connector_save_async(self):
+        """
+        Verify that the worker can handle an asynchronous save request
+        and is_ready check for CPU backend chunks
+        """
+        # 1. Setup
+        connector = self._create_connector(swap_op_type="jax")
+        worker = connector.connector_worker
+
+        # 2. Induce a mock latency
+        @jax.jit
+        def _busy_tpu_delay_kernel(cache, iterations=5000000):
+
+            def body_fun(_, val):
+                return val + 1
+
+            # jax.lax.fori_loop is compiled to a hardware loop on the TPU.
+            delay_val = jax.lax.fori_loop(0, iterations, body_fun, 0)
+
+            # This 'anchor' (x + (delay_val - delay_val)) creates a physical
+            # hardware dependency. The TPU cannot mark 'cache' as ready until
+            # the 'delay_val' math is finished, forcing any subsequent tasks
+            # (like our Save) to wait in the hardware queue.
+            return jax.tree.map(lambda x: x + (delay_val - delay_val), cache)
+
+        def busy_tpu_delay(cache, iterations=5000000):
+            logger.info(
+                f"Dispatching busy_tpu_delay with {iterations} iterations...")
+            start_dispatch = time.time()
+            result = _busy_tpu_delay_kernel(cache, iterations)
+            duration = time.time() - start_dispatch
+            logger.info(f"Dispatch finished in {duration:.6f}s (Python-side).")
+            return result
+
+        # Capture baseline ground truth on host before any modifications.
+        src_kv_cache_baseline = [np.array(c) for c in worker.runner.kv_caches]
+
+        # Dispatch the latency loop. Note: This is ASYNCHRONOUS. Python returns
+        # immediately, but the TPU starts grinding through the loop in the background.
+        worker.runner.kv_caches = busy_tpu_delay(worker.runner.kv_caches)
+
+        # 3. Submit Save Request
+        req_id = "real_async_req"
+        src_blocks = [0]
+        dst_chunks = [20]
+        save_spec = SaveSpec(
+            num_skip_leading_tokens=0,
+            num_total_tokens=self.block_size,
+            is_final_save=False,
+            skip_save=False,
+            src_blocks=src_blocks,
+            dst_chunks=dst_chunks,
+        )
+        req_meta = TPUReqMeta(
+            req_id=req_id,
+            token_ids=list(range(self.block_size)),
+            local_block_ids=src_blocks,
+            save_spec=save_spec,
+        )
+        metadata = TPUOffloadConnectorMetadata(requests_meta=[req_meta])
+        connector.bind_connector_metadata(metadata)
+
+        logger.info("Starting worker start_save_kv")
+        worker.start_save_kv()
+
+        # 5. First Poll (Testing the "Still Busy" state)
+        # _process_completed_saves() performs a non-blocking check:
+        # a) future.done(): Is the background Python thread finished dispatching?
+        # b) is_ready(): Is the TPU hardware finished moving the bytes?
+        # In this first poll, the save should NOT be finalized because it is
+        # still busy with the latency loop.
+        worker._process_completed_saves()
+        self.assertEmpty(worker.offload_stats.data["finished_save_chunks"])
+
+        # 6. Wait for Hardware and Thread Completion
+        # jax.block_until_ready(cache) forces the CPU (this test thread) to
+        # stop and wait until the TPU finishes the 'busy_tpu_delay' loop.
+        logger.info(
+            "Blocking until latency loop and DMA are ready on hardware...")
+        sync_start = time.time()
+        jax.block_until_ready(worker.runner.kv_caches)
+        sync_duration = time.time() - sync_start
+        logger.info(f"Hardware sync took {sync_duration:.4f} seconds.")
+
+        # 7. Final Polling Loop
+        # We poll until _process_completed_saves identifies that:
+        # 1. The background thread finished (future.done() == True)
+        # 2. The DMA transfer is complete (is_ready() == True)
+        max_retries = 100
+        while len(worker._pending_save_futures) > 0 and max_retries > 0:
+            worker._process_completed_saves()
+            if len(worker._pending_save_futures) > 0:
+                logger.info(
+                    f"Save not completed yet, pending futures: {len(worker._pending_save_futures)}. Retrying..."
+                )
+                time.sleep(0.01)
+            max_retries -= 1
+
+        if max_retries == 0:
+            self.fail(
+                f"Test timed out waiting for async save '{req_id}' to complete. "
+                f"Pending futures: {len(worker._pending_save_futures)}")
+
+        self.assertIn(req_id,
+                      worker.offload_stats.data["finished_save_chunks"])
+        self.assertEqual(len(worker._pending_save_futures), 0)
+
+        # 8. CPU KV Chunk content verification
+        for src_block_id, cpu_chunk_id in zip(src_blocks, dst_chunks):
+            cpu_val = np.array(worker.cpu_backend.get(cpu_chunk_id))
+            if len(cpu_val.shape) == 6:
+                cpu_val = np.squeeze(cpu_val, axis=0)
+
+            for layer in range(self.num_layers):
+                self.assertArraysEqual(
+                    src_kv_cache_baseline[layer][src_block_id], cpu_val[layer])

--- a/tpu_inference/offload/tpu_offload_connector.py
+++ b/tpu_inference/offload/tpu_offload_connector.py
@@ -2169,11 +2169,12 @@ class TPUOffloadConnectorWorker:
 
         return gathered_kv_caches_tpu, manifest, total_num_blocks_to_save
 
-    def _transfer_and_register_cpu_chunks(self,
-                                          flat_kv_caches_tpu: Any,
-                                          total_num_blocks_to_save: int,
-                                          manifest: list[SaveReqInfo],
-                                          is_batched: bool = False):
+    def _transfer_and_register_cpu_chunks(
+            self,
+            flat_kv_caches_tpu: Any,
+            total_num_blocks_to_save: int,
+            manifest: list[SaveReqInfo],
+            is_batched: bool = False) -> list[jax.Array]:
         """
         Asynchronously transfers KV blocks from TPU to CPU, unstitches them,
         and registers them with the CPU RAM backend store.
@@ -2196,7 +2197,7 @@ class TPUOffloadConnectorWorker:
                                           +-------+-------+-------+-------+-------+
                                                              ||
                                                              || DMA (Single Call)
-                                                             \/
+                                                             ||
                                            Unified Host Buffer (CPU RAM)
                                           +-------+-------+-------+-------+-------+
                                           | B1    | B2    | B3    | B4    | B5    |
@@ -2204,7 +2205,7 @@ class TPUOffloadConnectorWorker:
                                                              ||
               Unstitching Logic <============================++
                       ||
-                      \/
+                      ||
         Local CPU Backend (Cache)
         +---------------------------------------+
         | ID: C100 (B1) | ID: C101 (B2) | ...   |  <-- Req A chunks
@@ -2223,8 +2224,6 @@ class TPUOffloadConnectorWorker:
                 chunks_on_cpu.append(
                     jax.device_put(flat_kv_caches_tpu[i],
                                    self.expanded_host_sharding))
-            jax.block_until_ready(chunks_on_cpu)
-            # no split
         else:
             # dummy data
             chunks_on_cpu = [[(j * total_num_blocks_to_save + i)
@@ -2235,8 +2234,8 @@ class TPUOffloadConnectorWorker:
         KV_SAVE_TRANSFER_LATENCY.labels(
             is_batched=is_batched,
             num_blocks=str(total_num_blocks_to_save)).observe(duration)
-        logger.debug(f"Successfully saved {total_num_blocks_to_save} blocks "
-                     f"to CPU in {duration:.4f} seconds.")
+        logger.debug(f"Successfully started saving {total_num_blocks_to_save} "
+                     f"blocks to CPU in {duration:.4f} seconds.")
 
         if not self.no_op_swap_out:
 
@@ -2259,6 +2258,12 @@ class TPUOffloadConnectorWorker:
                     is_batched=is_batched).observe(bw_gbps)
 
         # 2. Unstitch and Register
+        # Registration happens immediately with potentially unready arrays.
+        # This is safe because:
+        # 1. We are storing references (futures) in the CPU backend.
+        # 2. JAX handles internal sync if the data is accessed before completion.
+        # 3. Our soft budgeting polling in _process_completed_saves prevents the
+        #    TPU staging buffer from being recycled until the D2H move is done.
         post_transfer_start_time = time.time()
         block_offset = 0
         for info in manifest:
@@ -2280,6 +2285,7 @@ class TPUOffloadConnectorWorker:
         logger.debug(
             f"{log_prefix}: e2e host processing of {total_num_blocks_to_save} chunks took {post_transfer_duration:.4f} seconds."
         )
+        return chunks_on_cpu
 
     def _start_batched_save_kv(self, metadata: TPUOffloadConnectorMetadata):
         """
@@ -2305,9 +2311,10 @@ class TPUOffloadConnectorWorker:
         # 2. ASYNC NON-BLOCKING: Single Batch Transfer
         def _async_batch_transfer_task(*args, **kwargs):
             try:
-                self._transfer_and_register_cpu_chunks(*args, **kwargs)
+                return self._transfer_and_register_cpu_chunks(*args, **kwargs)
             except Exception as e:
                 logger.error(f"Error in batched transfer: {e}", exc_info=True)
+                return None
 
         logger.info(
             f"Submitting batched transfer task for {len(manifest)} requests, {total_num_blocks_to_save} blocks total."
@@ -2321,7 +2328,7 @@ class TPUOffloadConnectorWorker:
                                            total_num_blocks_to_save,
                                            manifest,
                                            is_batched=True)
-        self._pending_save_futures.append((future, manifest))
+        self._pending_save_futures.append((future, manifest, None))
 
     def _get_blocks_for_req_from_metadata(
             self, info: SaveReqInfo,
@@ -2427,12 +2434,11 @@ class TPUOffloadConnectorWorker:
                 # Define a safe wrapper for the async part to ensure logging
                 def _async_transfer_task(req_id, *args):
                     try:
-                        self._transfer_and_register_cpu_chunks(*args)
+                        return self._transfer_and_register_cpu_chunks(*args)
                     except Exception as e:
                         raise ValueError(
                             f"Error transferring blocks for request {req_id}: {e}"
                         )
-                    return req_id
 
                 # 2. ASYNC NON-BLOCKING: Transfer to CPU and Register
                 logger.info(
@@ -2443,7 +2449,7 @@ class TPUOffloadConnectorWorker:
                                                    num_blocks_to_save, [info],
                                                    False)
 
-                self._pending_save_futures.append((future, [info]))
+                self._pending_save_futures.append((future, [info], None))
 
         self._processed_save_for_step = True
         SAVE_BATCH_SIZE.observe(len(self._pending_save_futures))
@@ -2453,6 +2459,10 @@ class TPUOffloadConnectorWorker:
         Checks for and processes completed asynchronous save operations.
         Supports both single and batched mode save operations using the
         list[SaveReqInfo] manifest.
+
+        This method implements soft budgeting by ensuring that staging buffer
+        slots are only released once the TPU hardware confirms the D2H transfer
+        is complete via the is_ready() check.
         """
         PROCESS_COMPLETED_SAVE_CALLS.inc()
         if not self._pending_save_futures:
@@ -2460,30 +2470,54 @@ class TPUOffloadConnectorWorker:
 
         start_time = time.time()
         completed_count = 0
-        remaining_futures: list[tuple[Future, list[SaveReqInfo]]] = []
+        remaining_futures: list[tuple[Future, list[SaveReqInfo],
+                                      Optional[list[jax.Array]]]] = []
         PENDING_SAVE_FUTURES_SIZE.set(len(self._pending_save_futures))
-        for future, manifest in self._pending_save_futures:
-            if future.done():
-                FUTURE_DONE_TOTAL.inc()
-                # Ensure the task finished successfully.
+        for future, manifest, unready_chunks in self._pending_save_futures:
+            if not future.done():
+                remaining_futures.append((future, manifest, unready_chunks))
+                continue
 
+            # Thread is finished, retrieve unready_chunks if we don't have them yet
+            if unready_chunks is None:
                 try:
-                    future.result()
-                    # Record saves for all requests in the manifest
-                    for info in manifest:
-                        if info.num_blocks > 0:
-                            self.offload_stats.record_save(
-                                req=info.req_id,
-                                saved_chunk_ids=info.dst_chunks)
-                            RECORD_SAVE_TOTAL.inc()
-
-                    completed_count += 1
+                    unready_chunks = future.result()
                 except Exception as e:
                     raise ValueError(f"A save operation failed: {e}")
+
+            # Stage 2: Wait for TPU Hardware to finish the actual DMA move.
+            # is_ready() is a non-blocking hardware bit-check.
+            #
+            # CONCURRENCY AND CONSISTENCY:
+            # We only finalize the save once the hardware confirms readiness. This
+            # establishes a 'Visibility Boundary'.
+            # 1. RAW Consistency: By waiting for is_ready() before recording the
+            #    save, we ensure that a concurrent Load request (prefix match)
+            #    cannot 'see' or fetch these chunks from the CPU backend until
+            #    the data is definitively resident in Host RAM. recording the
+            #    save signals the scheduler to eventually call `mark_completion`,
+            #    which is the only way a chunk becomes 'ready_to_load'.
+            # 2. Resource Safety: This also ensures the Physical HBM staging slots
+            #    remain 'Occupied' in the StagingBufferManager until the DMA read
+            #    is complete, preventing Stage 1 (Gather) from overwriting a slot
+            #    that is still being moved to the host.
+            if unready_chunks is not None and all(chunk.is_ready()
+                                                  for chunk in unready_chunks):
+                # SUCCESS: Data is safely on CPU and out of the Staging Buffer.
+                # Record saves for all requests in the manifest to signal
+                # the Scheduler to free the slots.
+                for info in manifest:
+                    if info.num_blocks > 0:
+                        self.offload_stats.record_save(
+                            req=info.req_id, saved_chunk_ids=info.dst_chunks)
+                        RECORD_SAVE_TOTAL.inc()
+                completed_count += 1
             else:
-                remaining_futures.append((future, manifest))
+                # Hardware still moving data or thread just finished and returned None, keep polling
+                remaining_futures.append((future, manifest, unready_chunks))
 
         if completed_count > 0:
+            FUTURE_DONE_TOTAL.inc(completed_count)
             duration = time.time() - start_time
             PROCESS_COMPLETED_SAVE_LATENCY.observe(duration)
             logger.info(f"collected {completed_count} save operation "


### PR DESCRIPTION
# Description

Start with a short description of what the PR does and how this is a change from
the past.

   Eliminates the second synchronous `block_until_ready()` call in the KV
    offload pipeline, enabling fully non-blocking Device-to-Host (D2H)
    transfers. This change decouples the initiation of the data transfer from the
    resource reclamation, ensuring the background thread pool is never
    stalled and the main model loop remains free of XLA synchronization
    bottlenecks.

The rest of the description includes relevant details and context, examples:
- why is this change being made,
- the problem being solved and any relevant context,
- why this is a good solution,
- some information about the specific implementation,
- shortcomings of the solution and possible future improvements.

     
    Key changes:
    - Asynchronous Dispatch: Modified `_transfer_and_register_cpu_chunks` to
      return a list of JAX futures (unready arrays) and removed the
      `jax.block_until_ready()` stall.
    - Soft Budgeting Polling: Updated `_process_completed_saves` in the main
      feedback loop to implement a non-blocking two-stage completion check:
      1. Python Readiness: Verifies the background thread finished
         dispatching (`future.done()`).
      2. Jax Array Readiness: Performs a non-blocking hardware check
         (`array.is_ready()`) to confirm the TPU finished moving the bytes.
    - Safe Resource Lifecycle: The signal to the Scheduler to "Free" staging
      buffer slots is now strictly gatekept by cpu chunks readiness.
    - Unit test for async save + is_ready() check for the jax array stored
      in cpu backend

If the change fixes a Github issue, please include a link, e.g.,:
FIXES: #123456

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

Manual runs of the kv host offload unit tests in v7 machine

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
