### PR TITLE
Merge the KV and indecis to reduce scatter_kv_slices calls

### DIFF
--- a/tests/distributed/test_tpu_connector.py
+++ b/tests/distributed/test_tpu_connector.py
@@ -442,25 +442,46 @@ class TestTPUConnectorWorker(unittest.TestCase):
         worker._notify_pull_done.assert_called_once_with(
             "socket", "req1", uuid)
 
-    def test_get_finished_recving(self):
+    @patch('tpu_inference.distributed.tpu_connector.jnp')
+    def test_get_finished_recving(self, mock_jnp):
         """Tests get_finished for a request that has finished pulling."""
         self.vllm_config.kv_transfer_config.is_kv_producer = False
         worker = tpu_connector.TPUConnectorWorker(self.vllm_config)
         worker.runner = MagicMock()
+        worker.num_layers = 1
         original_kv_caches = worker.runner.kv_caches
 
         mock_future = MagicMock()
         mock_future.done.return_value = True
-        mock_future.result.return_value = ('kv_data', 'indices')
-        worker.reqs_pulling = {'req1': mock_future}
+        mock_kv_data = [MagicMock(name="kv_data_layer0")]
+        mock_indices = MagicMock(name="indices")
+        mock_future.result.return_value = (mock_kv_data, mock_indices)
+        worker.reqs_pulling = {"req1": mock_future}
+
+        mock_merged_kvs = MagicMock(name="merged_kvs")
+        mock_merged_indices = MagicMock(name="merged_indices")
+
+        def mock_concatenate(elements, axis=0):
+            if elements[0] is mock_indices:
+                return mock_merged_indices
+            elif elements[0] is mock_kv_data[0]:
+                return mock_merged_kvs
+            return MagicMock()
+
+        mock_jnp.concatenate.side_effect = mock_concatenate
 
         done_sending, done_recving = worker.get_finished()
 
         self.assertEqual(done_sending, set())
-        self.assertEqual(done_recving, {'req1'})
-        self.assertNotIn('req1', worker.reqs_pulling)
-        self.all_mocks['scatter_kv_slices'].assert_called_once_with(
-            original_kv_caches, 'kv_data', 'indices')
+        self.assertEqual(done_recving, {"req1"})
+        self.assertNotIn("req1", worker.reqs_pulling)
+
+        # The new implementation merges kv and indices before scattering
+        merged_kvs = [mock_merged_kvs]
+        merged_indices = mock_merged_indices
+
+        self.all_mocks["scatter_kv_slices"].assert_called_once_with(
+            original_kv_caches, merged_kvs, merged_indices)
 
     def test_get_finished_sending_expired(self):
         """Tests get_finished for a request that has expired."""

--- a/tpu_inference/distributed/tpu_connector.py
+++ b/tpu_inference/distributed/tpu_connector.py
@@ -696,16 +696,40 @@ class TPUConnectorWorker:
         if not self.reqs_wait_pull and not self.reqs_pulling:
             return done_sending, done_recving
 
-        # Mark a req as done recieving after its pulling thread returns.
-        # This req can then be scheduled for decoding in the next scheduler step.
+        # 1. Create lists to hold all the finished data
+        ready_req_ids = []
+        ready_kvs = []
+        ready_indices = []
+
+        # 2. Gather all completed futures WITHOUT blocking
         for req_id in list(self.reqs_pulling.keys()):
             future = self.reqs_pulling[req_id]
             if future.done():
-                # NOTE(xiang): we do the scatter in main thread to avoid data racing.
-                # The data racing is not for the kv_caches buffer, it's for the runner.kv_caches ref.
                 kv, indices = future.result()
-                self.runner.kv_caches = scatter_kv_slices(
-                    self.runner.kv_caches, kv, indices)
+                ready_kvs.append(kv)
+                ready_indices.append(indices)
+                ready_req_ids.append(req_id)
+
+        # 3. If we have data, merge and scatter it ALL AT ONCE
+        if ready_req_ids:
+            # Concatenate the indices
+            merged_indices = jnp.concatenate(ready_indices, axis=0)
+
+            # Concatenate the KV slices per layer
+            merged_kvs = []
+            for i in range(self.num_layers):
+                # Pull the i-th layer from every finished request and concatenate
+                merged_layer = jnp.concatenate(
+                    [req_kv[i] for req_kv in ready_kvs], axis=0)
+                merged_kvs.append(merged_layer)
+
+            # Fire the JIT function ONCE
+            self.runner.kv_caches = scatter_kv_slices(self.runner.kv_caches,
+                                                      merged_kvs,
+                                                      merged_indices)
+
+            # Cleanup
+            for req_id in ready_req_ids:
                 del self.reqs_pulling[req_id]
                 done_recving.add(req_id)
 


### PR DESCRIPTION
# Description

Merge the KV and indecies for all ready requests and just call scatter_kv_slices (expensive so far) for once.
which can greatly reduce the ITL and make disagg decode side more efficient.

Before the fix:
Successful requests:                     100       
Failed requests:                         0         
Request rate configured (RPS):           8.00      
Benchmark duration (s):                  23.43     
Total input tokens:                      102400    
Total generated tokens:                  12800     
Request throughput (req/s):              4.27      
Output token throughput (tok/s):         546.26    
Peak output token throughput (tok/s):    4800.00   
Peak concurrent requests:                100.00    
Total token throughput (tok/s):          4916.32   
---------------Time to First Token----------------
Mean TTFT (ms):                          9393.07   
Median TTFT (ms):                        10380.50  
P99 TTFT (ms):                           14075.94  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          53.90     
Median TPOT (ms):                        22.66     
P99 TPOT (ms):                           172.08    
---------------Inter-token Latency----------------
Mean ITL (ms):                           53.93     
Median ITL (ms):                         20.54     
P99 ITL (ms):                            863.27    

after the fix: ----------------

Successful requests:                     100       
Failed requests:                         0         
Request rate configured (RPS):           8.00      
Benchmark duration (s):                  21.89     
Total input tokens:                      102400    
Total generated tokens:                  12800     
Request throughput (req/s):              4.57      
Output token throughput (tok/s):         584.72    
Peak output token throughput (tok/s):    4900.00   
Peak concurrent requests:                100.00    
Total token throughput (tok/s):          5262.48   
---------------Time to First Token----------------
Mean TTFT (ms):                          10878.87  
Median TTFT (ms):                        11163.75  
P99 TTFT (ms):                           14970.78  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          31.25     
Median TPOT (ms):                        21.73     
P99 TPOT (ms):                           63.99     
---------------Inter-token Latency----------------
Mean ITL (ms):                           31.25     
Median ITL (ms):                         20.63     
P99 ITL (ms):                            134.91    




FIXES: #123456

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
