### PR TITLE
[CI] Update Qwen/Qwen3-Coder-480B-A35B-Instruct on v6e support matrix status to 'not enough HBM'

### DIFF
--- a/.buildkite/models/Qwen_Qwen3-Coder-480B-A35B-Instruct.yml
+++ b/.buildkite/models/Qwen_Qwen3-Coder-480B-A35B-Instruct.yml
@@ -21,9 +21,13 @@ steps:
       queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
     soft_fail: true
     commands:
-      - |
-        .buildkite/scripts/run_in_docker.sh \
-          bash -c 'SKIP_JAX_PRECOMPILE=1 VLLM_XLA_CHECK_RECOMPILATION=0 MODEL_IMPL_TYPE=vllm python /workspace/tpu_inference/examples/offline_inference.py --model Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8 --tensor-parallel-size 8 --enable-expert-parallel  --max-num-batched-tokens 256 --max-num-seqs 256'
+       - |
+        if [ "${TPU_VERSION:-tpu6e}" = "tpu6e" ]; then
+          buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-Coder-480B-A35B-Instruct_UnitTest" "not enough HBM"
+        else
+          .buildkite/scripts/run_in_docker.sh \
+            bash -c 'SKIP_JAX_PRECOMPILE=1 VLLM_XLA_CHECK_RECOMPILATION=0 MODEL_IMPL_TYPE=vllm python /workspace/tpu_inference/examples/offline_inference.py --model Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8 --tensor-parallel-size 8 --enable-expert-parallel  --max-num-batched-tokens 256 --max-num-seqs 256'
+        fi
   - label: "${TPU_VERSION:-tpu6e} Record unit test result for Qwen/Qwen3-Coder-480B-A35B-Instruct"
     key: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen3-Coder-480B-A35B-Instruct_UnitTest"
     depends_on: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-Coder-480B-A35B-Instruct_UnitTest"
@@ -46,7 +50,11 @@ steps:
     soft_fail: true
     commands:
       - |
-        .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/check_lm_eval.sh  --model_name "Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8" --use_moe_ep_kernel 0 --tensor_parallel_size 8 --max_model_len 2048 --max_num_batched_tokens 2048 --max_gen_toks 256 --enable_expert_parallel 1 --flex_threshold 0.85 --strict_threshold 0.70
+        if [ "${TPU_VERSION:-tpu6e}" = "tpu6e" ]; then
+          buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-Coder-480B-A35B-Instruct_Accuracy" "not enough HBM"
+        else
+          .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/check_lm_eval.sh  --model_name "Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8" --use_moe_ep_kernel 0 --tensor_parallel_size 8 --max_model_len 2048 --max_num_batched_tokens 2048 --max_gen_toks 256 --enable_expert_parallel 1 --flex_threshold 0.85 --strict_threshold 0.70
+        fi
   - label: "${TPU_VERSION:-tpu6e} Record integration test result for Qwen/Qwen3-Coder-480B-A35B-Instruct"
     key: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen3-Coder-480B-A35B-Instruct_Accuracy"
     depends_on: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-Coder-480B-A35B-Instruct_Accuracy"
@@ -69,7 +77,11 @@ steps:
     soft_fail: true
     commands:
       - |
-        .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/bm_qwen3_coder.sh --model Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8 --tp 8 --req_tput_limit 0.16  --output_token_tput_limit 1226 --total_token_tput_limit 1378 --input_len 1024 --output_len 8192 --use_moe_ep_kernel 0
+        if [ "${TPU_VERSION:-tpu6e}" = "tpu6e" ]; then
+          buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-Coder-480B-A35B-Instruct_Benchmark" "not enough HBM"
+        else
+          .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/bm_qwen3_coder.sh --model Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8 --tp 8 --req_tput_limit 0.16  --output_token_tput_limit 1226 --total_token_tput_limit 1378 --input_len 1024 --output_len 8192 --use_moe_ep_kernel 0
+        fi
   - label: "${TPU_VERSION:-tpu6e} Record performance benchmark result for Qwen/Qwen3-Coder-480B-A35B-Instruct"
     key: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen3-Coder-480B-A35B-Instruct_Benchmark"
     depends_on: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-Coder-480B-A35B-Instruct_Benchmark"

--- a/.buildkite/scripts/generate_support_matrices.sh
+++ b/.buildkite/scripts/generate_support_matrices.sh
@@ -115,7 +115,7 @@ process_models() {
                 result=$(buildkite-agent meta-data get "${TPU_METADATA_PREFIX}${model}:${stage}" --default "N/A")
             fi
             row="$row,$result"
-            if [ "$stage" != "Type" ] && [ "${result}" != "✅" ] && [ "${result}" != "N/A" ] && [ "${result}" != "unverified" ]; then
+            if [ "$stage" != "Type" ] && [ "${result}" != "✅" ] && [ "${result}" != "N/A" ] && [ "${result}" != "unverified" ] && [ "${result}" != "not enough HBM" ]; then
                 ANY_FAILED=true
             fi
         done

--- a/.buildkite/scripts/record_step_result.sh
+++ b/.buildkite/scripts/record_step_result.sh
@@ -52,6 +52,9 @@ case $OUTCOME in
   "unverified")
     message="unverified"
     ;;
+  "not enough HBM")
+    message="not enough HBM"
+    ;;
   *)
     message="❌"
     ;;
@@ -61,6 +64,6 @@ esac
 buildkite-agent meta-data set "${TPU_METADATA_PREFIX}${CI_TARGET}_category" "${CI_CATEGORY}"
 buildkite-agent meta-data set "${TPU_METADATA_PREFIX}${CI_TARGET}:${CI_STAGE}" "${message}"
 
-if [ "${OUTCOME}" != "passed" ] && [ "${OUTCOME}" != "skipped" ] && [ "${OUTCOME}" != "unverified" ]; then
+if [ "${OUTCOME}" != "passed" ] && [ "${OUTCOME}" != "skipped" ] && [ "${OUTCOME}" != "unverified" ] && [ "${OUTCOME}" != "not enough HBM" ]; then
     exit 1
 fi


### PR DESCRIPTION
# Description

Update Qwen/Qwen3-Coder-480B-A35B-Instruct on v6e support matrix status to 'not enough HBM'

# Tests

[BuildKite](https://buildkite.com/tpu-commons/tpu-inference-ci/builds/12485/steps/canvas?sid=019cfea2-79cb-4203-8732-f1bc6cdb9650&tab=output)

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
