### PR TITLE
Fix TestRayDistributedExecutorExecuteDag failure

### DIFF
--- a/tests/executors/test_ray_distributed_executor.py
+++ b/tests/executors/test_ray_distributed_executor.py
@@ -495,7 +495,6 @@ class TestRayWorkerWrapperAsyncScheduling(unittest.TestCase):
         self.assertNotIn(5, self.wrapper._execute_model_outputs)
 
 
-@unittest.skip("Temporary skip until ci is fixed.")
 class TestRayDistributedExecutorExecuteDag(unittest.TestCase):
     """Tests for _execute_dag async scheduling in RayDistributedExecutor."""
 
@@ -514,6 +513,12 @@ class TestRayDistributedExecutorExecuteDag(unittest.TestCase):
         self.executor.forward_dag = None
         self.executor.has_connector = False
         self.executor.workers = [MagicMock(), MagicMock()]
+
+    def tearDown(self):
+        # Reset forward_dag to None so that __del__ -> shutdown() does not
+        # call ray.kill() on MagicMock workers (which would auto-init Ray and
+        # raise ValueError: "ray.kill() only supported for actors").
+        self.executor.forward_dag = None
 
     def test_without_async_scheduling_delegates_to_super(self):
         self.executor.scheduler_config.async_scheduling = False


### PR DESCRIPTION
Fix TestRayDistributedExecutorExecuteDag failure, the issue was due to ray shutdown.

# Tests
Manually verified the updated tests works as expected.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
