### PR TITLE
[Fused MoE] Use jax.nn.sigmoid

### DIFF
--- a/tpu_inference/kernels/fused_moe/v1/kernel.py
+++ b/tpu_inference/kernels/fused_moe/v1/kernel.py
@@ -55,8 +55,7 @@ def apply_scoring_fn(scoring_fn: str, x):
         case "softmax":
             return jax.nn.softmax(x, axis=-1)
         case "sigmoid":
-            # TODO(catswe): use jax.nn.sigmoid once mosaic lowering bug with bf16 input is fixed
-            return 1 / (1 + jnp.exp(-x))
+            return jax.nn.sigmoid(x)
         case _:
             raise NotImplementedError(
                 f"Unsupported scoring function: {scoring_fn}")


### PR DESCRIPTION
# Description

Pallas supports it now after the Jax version upgrade. I need a ready label

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
