### PR TITLE
Add optional small graph compilation control var

### DIFF
--- a/tpu_inference/runner/compilation_manager.py
+++ b/tpu_inference/runner/compilation_manager.py
@@ -52,9 +52,12 @@ class CompilationManager:
             logger.info("Enabling JAX compile cache.")
             jax.config.update("jax_compilation_cache_dir",
                               vllm_envs.VLLM_XLA_CACHE_PATH)
-            # Ensure small compiled function are cached as well.
-            jax.config.update("jax_persistent_cache_min_entry_size_bytes", -1)
-            jax.config.update("jax_persistent_cache_min_compile_time_secs", -1)
+            if vllm_envs.VLLM_XLA_CHECK_RECOMPILATION:
+                # Ensure small compiled function are cached as well.
+                jax.config.update("jax_persistent_cache_min_entry_size_bytes",
+                                  -1)
+                jax.config.update("jax_persistent_cache_min_compile_time_secs",
+                                  -1)
 
     def _create_dummy_tensor(self,
                              shape: Tuple[int, ...],


### PR DESCRIPTION
# Description

In local disagg we are launching 2 different engines which might have the same mesh structure but land on different sets of device. Some hlo on 2 devices hash collide and would result in device out of bound during execution. Having jax_persistent_cache_min_entry_size_bytes on effect would avoid such collision

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
