### PR TITLE
[Multi-Modality] fix some bugs and performance via torchax path

### DIFF
--- a/tests/runner/test_tpu_runner.py
+++ b/tests/runner/test_tpu_runner.py
@@ -106,7 +106,20 @@ class TestTPUJaxRunner:
             dummy_mm_embeds,
             is_multimodal=dummy_is_mm_embed)
 
-        # 3. ===== Act & Assert (Text-only) =====
+        # 3. ===== Act & Assert (Multimodal w/o mm embeds) =====
+        self.mock_get_input_embed_fn.reset_mock()
+        self.runner.is_multimodal_model = True
+
+        # Without mm_embeds in the current scheduled tokens
+        input_ids_res, inputs_embeds_res = self.runner._get_input_ids_embeds(
+            dummy_input_ids, None, None)
+
+        assert inputs_embeds_res is None
+        np.testing.assert_array_equal(np.asarray(input_ids_res),
+                                      np.asarray(dummy_input_ids))
+        self.mock_get_input_embed_fn.assert_not_called()
+
+        # 4. ===== Act & Assert (Text-only) =====
         self.mock_get_input_embed_fn.reset_mock()
         self.runner.is_multimodal_model = False
 

--- a/tpu_inference/models/vllm/vllm_model_wrapper.py
+++ b/tpu_inference/models/vllm/vllm_model_wrapper.py
@@ -355,7 +355,7 @@ class VllmModelWrapper:
                     tie_weights=False,
                 )
 
-                return jax.tree.map(jax_view, output_from_torch)
+                return jax_view(output_from_torch)
 
         return embed_multimodal_func
 

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -1769,7 +1769,8 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
     def _get_input_ids_embeds(self, input_ids: jax.Array,
                               mm_embeds: jax.Array | None,
                               is_mm_embed: jax.Array | None):
-        if self.is_multimodal_model:
+        # Prevent the cost of calling additional function.
+        if self.is_multimodal_model and mm_embeds is not None:
             assert self.embed_input_ids_fn is not None
             inputs_embeds = self.embed_input_ids_fn(
                 self.state,


### PR DESCRIPTION

# Description

Even in the multimodal model, the scheduled tokens could not include mm_embeds such as in the decode phase.

Prevent the additional call to save some cost,
especially for torchax path which is eager mode
and need non-neglect time for torch_view the params.

# Tests

`pytest tests/runner/test_tpu_runner.py`
Test some mm models and get the same results.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
