### PR TITLE
Correct vision encoder compilation when it's None

### DIFF
--- a/tpu_inference/runner/compilation_manager.py
+++ b/tpu_inference/runner/compilation_manager.py
@@ -92,8 +92,9 @@ class CompilationManager:
                 self.runner.lora_config), jax.set_mesh(self.runner.mesh):
             self._precompile_backbone_text_only()
             if self.runner.is_multimodal_model:
-                self.runner.precompile_vision_encoder_fn(
-                    self._run_compilation, )
+                if self.runner.precompile_vision_encoder_fn is not None:
+                    self.runner.precompile_vision_encoder_fn(
+                        self._run_compilation, )
                 self._precompile_input_embeddings_merger()
                 self._precompile_backbone_with_inputs_embeds()
             if self.runner.scheduler_config.async_scheduling:


### PR DESCRIPTION

# Description

Allow model that does not contains precompile_vision_encoder_fn to do null-op within compilation manager.

Both TPU runner and vLLM model loader already allow precompile_vision_encoder_fn to be not exists and return None.
Skip the pre-compile logic accordingly in compilation mamager.

# Tests

Serve any VL model in torchax path and ensure the server do start successfully.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
