### PR TITLE
Implement malloc-like and best-fit block queue for TPU-friendly insert

### DIFF
--- a/tests/runner/test_continuous_block_pool.py
+++ b/tests/runner/test_continuous_block_pool.py
@@ -1,0 +1,136 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from tpu_inference.runner.continuous_block_pool import ContinuousFreeQueue
+
+
+class MockKVCacheBlock:
+
+    def __init__(self, block_id):
+        self.block_id = block_id
+
+
+def test_initialization():
+    blocks = [MockKVCacheBlock(i) for i in range(10)]
+    queue = ContinuousFreeQueue(blocks)
+    assert queue.num_free_blocks == 10
+    assert len(queue.intervals) == 1
+    assert queue.intervals[0] == (0, 9)
+
+
+def test_popleft_single():
+    blocks = [MockKVCacheBlock(i) for i in range(10)]
+    queue = ContinuousFreeQueue(blocks)
+
+    # First popleft will grab 0 as an exception to be the null_block
+    b = queue.popleft()
+    assert b.block_id == 0
+    assert queue.num_free_blocks == 9
+    assert queue.intervals[0] == (1, 9)
+
+    # Subsequent poplefts will pull from the top (decode mode)
+    b = queue.popleft()
+    assert b.block_id == 9
+    assert queue.num_free_blocks == 8
+    assert queue.intervals[0] == (1, 8)
+
+    b = queue.popleft()
+    assert b.block_id == 8
+    assert queue.num_free_blocks == 7
+
+
+def test_popleft_n_contiguous():
+    blocks = [MockKVCacheBlock(i) for i in range(10)]
+    queue = ContinuousFreeQueue(blocks)
+
+    # Should get contiguous chunk from bottom, skipping 0 to leave it for null_block
+    alloc = queue.popleft_n(3)
+    assert len(alloc) == 3
+    assert [b.block_id for b in alloc] == [1, 2, 3]
+
+    assert queue.num_free_blocks == 7
+    # 0 is still free, 4-9 are free
+    assert queue.intervals == [(0, 0), (4, 9)]
+
+
+def test_popleft_n_best_fit():
+    blocks = [MockKVCacheBlock(i) for i in range(20)]
+    queue = ContinuousFreeQueue(blocks)
+
+    # Manually fragment the interval space
+    # Free space: 0, 1-2, 4-6, 8-15, 17-19
+    queue.free_blocks.clear()
+    queue.intervals.clear()
+    queue.append_n([
+        blocks[0], blocks[1], blocks[2], blocks[4], blocks[5], blocks[6],
+        blocks[8], blocks[9], blocks[10], blocks[11], blocks[12], blocks[13],
+        blocks[14], blocks[15], blocks[17], blocks[18], blocks[19]
+    ])
+
+    assert queue.intervals == [(0, 2), (4, 6), (8, 15), (17, 19)]
+
+    # Needs a size 3 contiguous chunk. It should pick (0, 2) over (4, 6) to Best-Fit and break ties (First-Fit).
+    alloc = queue.popleft_n(3)
+    assert len(alloc) == 3
+    assert [b.block_id for b in alloc] == [0, 1, 2]
+    assert queue.intervals == [(4, 6), (8, 15), (17, 19)]
+
+
+def test_popleft_n_fallback():
+    blocks = [MockKVCacheBlock(i) for i in range(10)]
+    queue = ContinuousFreeQueue(blocks)
+
+    # Leave scattered blocks
+    queue.free_blocks.clear()
+    queue.intervals.clear()
+    queue.append_n([blocks[1], blocks[3], blocks[5], blocks[7], blocks[9]])
+
+    # Ask for 3. No continuous chunk of size 3. Should fallback to grabbing from the top.
+    alloc = queue.popleft_n(3)
+    assert len(alloc) == 3
+    # Top 3 are 9, 7, 5, after sorting it should be 5, 7, 9
+    assert [b.block_id for b in alloc] == [5, 7, 9]
+
+
+def test_remove_splits_intervals():
+    blocks = [MockKVCacheBlock(i) for i in range(10)]
+    queue = ContinuousFreeQueue(blocks)
+
+    queue.remove(blocks[4])
+    assert queue.num_free_blocks == 9
+    assert queue.intervals == [(0, 3), (5, 9)]
+
+    queue.remove(blocks[0])
+    assert queue.intervals == [(1, 3), (5, 9)]
+
+    queue.remove(blocks[9])
+    assert queue.intervals == [(1, 3), (5, 8)]
+
+
+def test_append_merges_intervals():
+    blocks = [MockKVCacheBlock(i) for i in range(10)]
+    queue = ContinuousFreeQueue(blocks)
+    queue.free_blocks.clear()
+    queue.intervals.clear()
+
+    queue.append_n([blocks[2], blocks[4], blocks[5], blocks[7]])
+    assert queue.intervals == [(2, 2), (4, 5), (7, 7)]
+
+    # Merge left
+    queue.append_n([blocks[3]])
+    assert queue.intervals == [(2, 5), (7, 7)]
+
+    # Merge right
+    queue.append_n([blocks[6]])
+    assert queue.intervals == [(2, 7)]

--- a/tpu_inference/core/core_tpu.py
+++ b/tpu_inference/core/core_tpu.py
@@ -689,6 +689,20 @@ class DisaggEngineCoreProc(vLLMEngineCoreProc):
                 f"{len(self._decode_engines)} Disaggregated decode engines created."
             )
 
+            try:
+                from tpu_inference.runner.continuous_block_pool import \
+                    ContinuousFreeQueue
+                for core in self._prefill_engines + self._decode_engines:
+                    pool = core.scheduler.kv_cache_manager.block_pool
+                    pool.free_block_queue = ContinuousFreeQueue(pool.blocks)
+                    pool.null_block = pool.free_block_queue.popleft()
+                    pool.null_block.is_null = True
+                logger.warning(
+                    "Successfully injected ContinuousFreeQueue into DisaggEngineCoreProcs."
+                )
+            except Exception as e:
+                logger.warning(f"Failed to inject ContinuousFreeQueue: {e}")
+
             ready_event = threading.Event()
             input_thread = threading.Thread(target=self.process_input_sockets,
                                             args=(addresses.inputs,

--- a/tpu_inference/runner/compilation_manager.py
+++ b/tpu_inference/runner/compilation_manager.py
@@ -579,10 +579,12 @@ class CompilationManager:
             # Prevent the slices from getting freed by insert before finishing this operation
             for layer_cache in kv_cache_slices:
                 layer_cache.block_until_ready()
-            self.runner.kv_caches = self.runner.kv_cache_manager._jitted_insert_continuous_kv_cache(
+            self.runner.kv_caches = self.runner.kv_cache_manager._jitted_insert_continuous_kv_cache_from_slice(
                 block_size,
+                num_blocks,
                 self.runner.kv_caches,
                 kv_cache_slices,
+                0,
                 block_numbers[0],
             )
             for layer_cache in self.runner.kv_caches:

--- a/tpu_inference/runner/continuous_block_pool.py
+++ b/tpu_inference/runner/continuous_block_pool.py
@@ -1,0 +1,168 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from bisect import bisect_left, bisect_right
+from typing import List, Set, Tuple
+
+from tpu_inference.logger import init_logger
+
+logger = init_logger(__name__)
+
+
+class ContinuousFreeQueue:
+    """
+    A custom FreeKVCacheBlockQueue that maintains free blocks as continuous intervals
+    to optimize allocation for TPU Paged Attention (where `dynamic_update_slice_in_dim`
+    is heavily preferred over scatters).
+
+    - Prefill requests (N > 1 blocks) use a Best-Fit approach to find continuous segments.
+    - Decode requests (1 block) take from the top-down to isolate fragmentation to the high IDs.
+    """
+
+    def __init__(self, blocks: List):
+        self.free_blocks: Set[int] = set()
+        self.blocks_ref = blocks
+        self.intervals: List[Tuple[int, int]] = []
+        self.append_n(blocks)
+
+    @property
+    def num_free_blocks(self) -> int:
+        return len(self.free_blocks)
+
+    def _add_to_intervals(self, block_id: int):
+        if not self.intervals:
+            self.intervals.append((block_id, block_id))
+            return
+
+        idx = bisect_left(self.intervals, (block_id, block_id))
+        merged = False
+
+        if idx > 0:
+            prev_start, prev_end = self.intervals[idx - 1]
+            if prev_end == block_id - 1:
+                self.intervals[idx - 1] = (prev_start, block_id)
+                merged = True
+                if idx < len(self.intervals):
+                    next_start, next_end = self.intervals[idx]
+                    if next_start == block_id + 1:
+                        self.intervals[idx - 1] = (prev_start, next_end)
+                        self.intervals.pop(idx)
+                return
+
+        if not merged and idx < len(self.intervals):
+            next_start, next_end = self.intervals[idx]
+            if next_start == block_id + 1:
+                self.intervals[idx] = (block_id, next_end)
+                merged = True
+                return
+
+        if not merged:
+            self.intervals.insert(idx, (block_id, block_id))
+
+    def _remove_from_intervals(self, block_id: int):
+        idx = bisect_right(self.intervals, (block_id, float('inf'))) - 1
+        start, end = self.intervals[idx]
+
+        if start == end:
+            self.intervals.pop(idx)
+        elif start == block_id:
+            self.intervals[idx] = (start + 1, end)
+        elif end == block_id:
+            self.intervals[idx] = (start, end - 1)
+        else:
+            self.intervals[idx] = (start, block_id - 1)
+            self.intervals.insert(idx + 1, (block_id + 1, end))
+
+    def append_n(self, blocks: List):
+        for b in blocks:
+            if b.block_id not in self.free_blocks:
+                self.free_blocks.add(b.block_id)
+                self._add_to_intervals(b.block_id)
+
+    def remove(self, block):
+        if block.block_id in self.free_blocks:
+            self.free_blocks.remove(block.block_id)
+            self._remove_from_intervals(block.block_id)
+
+    def popleft(self):
+        # Always reserve 0 for the null_block if it is untouched during initialization
+        if 0 in self.free_blocks and len(self.free_blocks) == len(
+                self.blocks_ref):
+            block_id = 0
+        else:
+            block_id = self.intervals[-1][1]
+            # Avoid popping 0 as a normal block if there are other choices
+            if block_id == 0 and len(self.intervals) > 1:
+                block_id = self.intervals[-2][1]
+
+        self.free_blocks.remove(block_id)
+        self._remove_from_intervals(block_id)
+
+        logger.debug(
+            f"ContinuousFreeQueue.popleft: Decode allocated 1 block at ID {block_id}"
+        )
+        return self.blocks_ref[block_id]
+
+    def popleft_n(self, num_blocks: int) -> List:
+        if num_blocks == 1:
+            return [self.popleft()]
+
+        best_idx = -1
+        best_size = float('inf')
+
+        # Best-Fit search for the smallest contiguous memory region that satisfies num_blocks
+        for i, (start, end) in enumerate(self.intervals):
+            actual_start = start
+            if start == 0 and len(self.free_blocks) == len(self.blocks_ref):
+                # Ensure we don't accidentally grab the null block initially
+                actual_start = 1
+
+            size = end - actual_start + 1
+            if size >= num_blocks and size < best_size:
+                best_size = size
+                best_idx = i
+
+        if best_idx != -1:
+            start, end = self.intervals[best_idx]
+            actual_start = max(1, start) if start == 0 and len(
+                self.free_blocks) == len(self.blocks_ref) else start
+
+            alloc_start = actual_start
+            alloc_end = actual_start + num_blocks - 1
+
+            allocated = [
+                self.blocks_ref[i] for i in range(alloc_start, alloc_end + 1)
+            ]
+            for b in allocated:
+                self.free_blocks.remove(b.block_id)
+                self._remove_from_intervals(b.block_id)
+
+            logger.debug(
+                f"ContinuousFreeQueue.popleft_n: Prefill Best-Fit allocated {num_blocks} contiguous blocks "
+                f"starting at ID {alloc_start} from free interval [{start}, {end}]"
+            )
+            return allocated
+        else:
+            # Fallback: Scattered allocation if no continuous range fits
+            logger.debug(
+                f"ContinuousFreeQueue.popleft_n: FALLBACK scattered allocation for {num_blocks} blocks"
+            )
+            allocated = []
+            for _ in range(num_blocks):
+                allocated.append(self.popleft())
+
+            # Sort the fallback blocks by physical ID to naturally group any fragmented pieces
+            # back into ascending continuous chunks for the insertion loop
+            allocated.sort(key=lambda b: b.block_id)
+            return allocated

--- a/tpu_inference/runner/kv_cache_manager.py
+++ b/tpu_inference/runner/kv_cache_manager.py
@@ -439,56 +439,70 @@ class KVCacheManager:
 
         return jax.tree.map(gather_and_reshape, kv_caches)
 
-    @staticmethod
-    @jax.jit(
-        static_argnames=("block_size"),
-        donate_argnames=(
-            "kv_caches",
-            "kv_cache_slices",
-        ),
-    )
     def _jitted_insert_kv_cache(
         block_size,
         kv_caches: List[jax.Array],
         kv_cache_slices: List[jax.Array],
-        block_numbers: jax.Array,
+        block_numbers: List[int],
     ) -> List[jax.Array]:
         """
-        JIT-compiled function to insert KV cache slices into the physical
-        cache for all layers at once. This fuses the pad, reshape, and scatter
-        operations into a single efficient kernel.
+        Iteratively call continuous KV cache insertion for each contiguous block sub-array.
         """
+        if not block_numbers:
+            return kv_caches
 
-        def _update_layer(cache, slices):
-            """The function to apply to each layer's cache and slices."""
-            reshaped_slices = slices.reshape(-1, block_size, *slices.shape[1:])
-            cache.at[block_numbers].set(reshaped_slices)
-            return cache
+        start_idx = 0
+        for i in range(1, len(block_numbers) + 1):
+            if i == len(block_numbers
+                        ) or block_numbers[i] != block_numbers[i - 1] + 1:
+                start_block = block_numbers[start_idx]
 
-        return jax.tree.map(_update_layer, kv_caches, kv_cache_slices)
+                chunk_size = i - start_idx
+                token_start = start_idx * block_size
+                with runner_utils.LatencyTracker(
+                        f"insert_continuous_kv_cache_from_slice {start_block} {chunk_size}"
+                ):
+                    kv_caches = KVCacheManager._jitted_insert_continuous_kv_cache_from_slice(
+                        block_size,
+                        chunk_size,
+                        kv_caches,
+                        kv_cache_slices,
+                        token_start,
+                        start_block,
+                    )
+                start_idx = i
+
+        return kv_caches
 
     @staticmethod
     @jax.jit(
-        static_argnames=("block_size"),
-        donate_argnames=(
-            "kv_caches",
-            "kv_cache_slices",
-        ),
+        static_argnames=("block_size", "chunk_size"),
+        donate_argnames=("kv_caches", ),
     )
-    def _jitted_insert_continuous_kv_cache(
-        block_size,
+    def _jitted_insert_continuous_kv_cache_from_slice(
+        block_size: int,
+        chunk_size: int,
         kv_caches: List[jax.Array],
         kv_cache_slices: List[jax.Array],
-        start_block,
+        token_start: int,
+        start_block: int,
     ) -> List[jax.Array]:
         """
-        JIT-compiled function to insert KV cache slices into continuous blocks.
-        Makes use of dynamic_update_slice_in_dim.
+        JIT-compiled function that dynamically slices the required tokens from KV cache
+        slices and inserts them into continuous physical blocks.
         """
 
         def _update_layer(cache, slices):
             """The function to apply to each layer's cache and slices."""
-            reshaped_slices = slices.reshape(-1, block_size, *slices.shape[1:])
+
+            # Dynamically slice exactly chunk_size * block_size tokens starting at token_start
+            extracted_slices = jax.lax.dynamic_slice_in_dim(slices,
+                                                            token_start,
+                                                            chunk_size *
+                                                            block_size,
+                                                            axis=0)
+            reshaped_slices = extracted_slices.reshape(-1, block_size,
+                                                       *slices.shape[1:])
 
             return jax.lax.dynamic_update_slice_in_dim(cache,
                                                        reshaped_slices,
@@ -602,10 +616,12 @@ class KVCacheManager:
             with runner_utils.LatencyTracker(
                     f"JittedInsertContinuousKVCache-b{len(block_numbers)}"):
                 logger.debug(f"inserting to continuous blocks {block_numbers}")
-                self.runner.kv_caches = KVCacheManager._jitted_insert_continuous_kv_cache(
+                self.runner.kv_caches = KVCacheManager._jitted_insert_continuous_kv_cache_from_slice(
                     self.runner.block_size,
+                    len(block_numbers),
                     self.runner.kv_caches,
                     kv_cache_slices,
+                    0,
                     start_block,
                 )
                 jax.block_until_ready(self.runner.kv_caches)
@@ -618,7 +634,7 @@ class KVCacheManager:
                     self.runner.block_size,
                     self.runner.kv_caches,
                     kv_cache_slices,
-                    jnp.array(block_numbers),
+                    block_numbers,
                 )
                 jax.block_until_ready(self.runner.kv_caches)
 


### PR DESCRIPTION
# Description

-Linked list managed block list
-Best-fit strategy for continuous block insert
-Updated jitted insert function based on XLA dynamic slicing API
-Unified call to the updated insert API

Note: this is currently only enabled in single controller disagg mode. 

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
