### PR TITLE
Parallelize dummy weight generation for JAX models

### DIFF
--- a/tpu_inference/models/jax/utils/weight_utils.py
+++ b/tpu_inference/models/jax/utils/weight_utils.py
@@ -763,23 +763,24 @@ def jax_array_from_reshaped_torch(
 
 def assign_and_shard_param(jax_param: nnx.Param,
                            jax_weight: jax.Array,
-                           param_name: str = "Unknown") -> None:
+                           param_name: str = "Unknown",
+                           mesh: Optional[Mesh] = None) -> None:
     """Distributes a JAX array across devices according to the `nnx.Param`'s sharding metadata, assigns it to the parameter, and marks it as loaded.
 
     Args:
         jax_param: The target nnx.Param to assign the weight to.
         jax_weight: The JAX array containing the weight data.
         param_name: The name of the parameter, used for error logging.
+        mesh: The device mesh to shard the parameter on.
     """
     spec = jax_param.get_metadata().get("sharding", ())
     if isinstance(spec, NamedSharding):
         spec = spec.spec
     elif isinstance(spec, SingleDeviceSharding):
         spec = ()
-    mesh = jax_param.get_metadata().get("mesh", None)
-
+    param_mesh = jax_param.get_metadata().get("mesh") or mesh
     try:
-        jax_param.value = shard_put(jax_weight, spec, mesh=mesh)
+        jax_param.value = shard_put(jax_weight, spec, mesh=param_mesh)
         jax_param.set_metadata("_is_loaded", True)
     except Exception as e:
         raise RuntimeError(
@@ -914,7 +915,9 @@ class JaxDummyModelLoader(DummyModelLoader):
     def load_weights(self, model: JaxModule,
                      model_config: ModelConfig) -> None:
         weight_loading_start_counter = time.perf_counter()
-        for param_name, param in model.named_parameters():
+        mesh = jax.sharding.get_mesh()
+
+        def _load_dummy_weight_on_thread(param_name, param):
             with cpu_mesh_context():
                 is_moe = hasattr(param, "_weights_to_load")
                 param_shape = param.value.shape
@@ -942,7 +945,19 @@ class JaxDummyModelLoader(DummyModelLoader):
                     param._weights_to_load[:] = jnp.vsplit(
                         dummy_weight, indices_or_sections=num_experts)
 
-            assign_and_shard_param(param, dummy_weight, param_name)
+            # We must explicitly pass the `mesh` captured from the main thread
+            # into the worker threads. JAX mesh contexts are thread-local, so
+            # worker threads do not inherit the active TPU mesh.
+            assign_and_shard_param(param, dummy_weight, param_name, mesh=mesh)
+
+        with ThreadPoolExecutor(max_workers=64) as executor:
+            futures = [
+                executor.submit(_load_dummy_weight_on_thread, param_name,
+                                param)
+                for param_name, param in model.named_parameters()
+            ]
+            for future in futures:
+                future.result()
 
         self._process_weights_after_loading(model)
         logger.info_once(


### PR DESCRIPTION
# Description

Use `ThreadPoolExecutor` to make dummy weight generation faster for JAX models. 

| Model                             | Regular (s) | Dummy (s) (With Threading) | Dummy (s) (Without Threading) |
| :-------------------------------- | :---------- | :------------------------- | :---------------------------- |
| Qwen/Qwen3-4B-Instruct-2507         | 7.40        | 3.97                        | 8.99                         |
| Qwen/Qwen3-4B-Instruct-2507-FP8     | 4.71        | 7.76                    | 13.73                            |
| Qwen/Qwen3-30B-A3B-Instruct-2507    | 66.30       | 36.78                      | 68.36                         |
| Qwen/Qwen3-30B-A3B-Instruct-2507-FP8 | 88.77       | 80.27                      | 116.86                        |

# Tests

 - CI/Unit tests.
 - `MODEL_IMPL_TYPE=flax_nnx vllm serve {model_name} --load-format dummy` for all models in description

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
