### PR TITLE
[Multi-Modal] Skip dedicated MM logic and properly move tensors

### DIFF
--- a/tpu_inference/models/vllm/vllm_model_wrapper.py
+++ b/tpu_inference/models/vllm/vllm_model_wrapper.py
@@ -21,7 +21,6 @@ from typing import Any, List, Optional, Tuple
 from unittest.mock import patch
 
 import jax
-import jax.numpy as jnp
 import numpy as np
 import torch
 import torch.nn
@@ -329,21 +328,22 @@ class VllmModelWrapper:
             image_grid_thw: Any,
             **kwargs,
         ) -> Any:
-            # Del args for jax path. Need to refactor the function call.
+            # TODO: b/494300919 - Historical arg, need to be removed.
             del image_grid_thw
 
-            with torchax.default_env():
-                call_kwargs = {}
-                for k, v in kwargs.items():
-                    if isinstance(v, jax.Array):
-                        call_kwargs[k] = torch_view(v)
-                    elif isinstance(v, np.ndarray):
-                        # The "pixel_values" need to be a torch.Tensor.
-                        # Cast it back to torch.Tensor.
-                        call_kwargs[k] = torch_view(jnp.array(v))
-                    else:
-                        call_kwargs[k] = v
+            def move(v: torch.Tensor) -> torch.Tensor:
+                if not isinstance(v, torch.Tensor):
+                    logger.warning(f"Expect torch.Tensor, got {type(v)}")
+                    return v
+                return v.to(device="jax")
 
+            with torchax.default_env():
+                # Ensure all tensors are moved into accelerator so the
+                # computation with weights can work properly.
+                call_kwargs = {
+                    k: jax.tree.map(move, v)
+                    for k, v in kwargs.items()
+                }
                 output_from_torch = torch.func.functional_call(
                     self.model,
                     torch_view(params_and_buffers),

--- a/tpu_inference/runner/multimodal_manager.py
+++ b/tpu_inference/runner/multimodal_manager.py
@@ -113,32 +113,34 @@ class MultiModalManager:
         for _, num_items, mm_kwargs_group in group_mm_kwargs_by_modality(
                 mm_kwargs):
             batched_mm_inputs = mm_kwargs_group
-            # Convert torch tensors to numpy arrays that JAX can handle.
-            if "pixel_values" in batched_mm_inputs and isinstance(
-                    batched_mm_inputs["pixel_values"], list):
-                batched_mm_inputs["pixel_values"] = torch.cat(
-                    batched_mm_inputs["pixel_values"], dim=0)
-
             image_grid_thw = ()
-            for key, value in batched_mm_inputs.items():
-                if isinstance(value, torch.Tensor):
-                    if key == 'image_grid_thw':
-                        # change it to tuple of tuples to make it hashable for JIT
-
-                        # Shape: (B, N, 3) -> (B*N, 3) -> tuple of tuples
-                        grid_thw_tensor = batched_mm_inputs[key]
-                        grid_thw_reshaped = grid_thw_tensor.reshape(-1, 3)
-                        image_grid_thw = tuple(
-                            tuple(row) for row in grid_thw_reshaped.tolist())
-
-                        continue
-
-                    if value.dtype == torch.bfloat16:
-                        batched_mm_inputs[key] = value.to(
-                            torch.float32).numpy().astype(jnp.bfloat16)
-                    else:
-                        batched_mm_inputs[key] = value.numpy()
+            # TODO: b/494300919 - QWen 2.5 VL specific logic, need to be moved.
             if 'image_grid_thw' in batched_mm_inputs:
+                # Convert torch tensors to numpy arrays that JAX can handle.
+                if "pixel_values" in batched_mm_inputs and isinstance(
+                        batched_mm_inputs["pixel_values"], list):
+                    batched_mm_inputs["pixel_values"] = torch.cat(
+                        batched_mm_inputs["pixel_values"], dim=0)
+
+                for key, value in batched_mm_inputs.items():
+                    if isinstance(value, torch.Tensor):
+                        if key == 'image_grid_thw':
+                            # change it to tuple of tuples to make it hashable for JIT
+
+                            # Shape: (B, N, 3) -> (B*N, 3) -> tuple of tuples
+                            grid_thw_tensor = batched_mm_inputs[key]
+                            grid_thw_reshaped = grid_thw_tensor.reshape(-1, 3)
+                            image_grid_thw = tuple(
+                                tuple(row)
+                                for row in grid_thw_reshaped.tolist())
+
+                            continue
+
+                        if value.dtype == torch.bfloat16:
+                            batched_mm_inputs[key] = value.to(
+                                torch.float32).numpy().astype(jnp.bfloat16)
+                        else:
+                            batched_mm_inputs[key] = value.numpy()
                 batched_mm_inputs.pop('image_grid_thw')
 
             # Run the encoder.


### PR DESCRIPTION
- Wrap QWen 2.5 VL jax specific logic into a conditional branch.
- Tree-map the MM kwargs into "jax" accelerator for torchax path.

# Description

MultiModal models yields a PyTree of `torch.Tensor`, and the PyTree of `torch.Tensor` then got feed into `embed_multimodal` of each model.
(See `MultiModalInputs` and `MultiModalFieldElem` from vLLM source tree for more details.)

In path common to jax/torchax, we should not do processing that's specific to particular path and/or model,
so in MultiModalManager (part of TPURunner), we hide the logic beind `'image_grid_thw' in batched_mm_inputs` condition.
Not perfect but works for now.

Also in torchax path, we avoding convert from torch.Tensor to numpy.ndarray (part of the logic that skipped above) then jax.Array then back to torch.Tensor,
just move the tensor into jax accelerator directly.

# Tests

Serve any model in torchax path and check if multimodel requests, e.g. a request with text and image, still works.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
