### PR TITLE
Fix: Profiler env access, test indexing, and staging buffer management

### DIFF
--- a/.buildkite/features/KV_Cache_Offload.yml
+++ b/.buildkite/features/KV_Cache_Offload.yml
@@ -1,3 +1,17 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # KV Cache Offload
 # feature support matrix
 steps:

--- a/examples/offload/gke/benchmarks/benchmark-pod.yaml
+++ b/examples/offload/gke/benchmarks/benchmark-pod.yaml
@@ -1,3 +1,17 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: v1
 kind: Pod
 metadata:

--- a/examples/offload/gke/benchmarks/deploy-baseline.yaml
+++ b/examples/offload/gke/benchmarks/deploy-baseline.yaml
@@ -1,3 +1,17 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/examples/offload/gke/benchmarks/deploy-cpu-offload.yaml
+++ b/examples/offload/gke/benchmarks/deploy-cpu-offload.yaml
@@ -1,3 +1,17 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/examples/offload/gke/benchmarks/service.yaml
+++ b/examples/offload/gke/benchmarks/service.yaml
@@ -1,3 +1,17 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: v1
 kind: Service
 metadata:

--- a/examples/offload/gke/hf_secret.yaml
+++ b/examples/offload/gke/hf_secret.yaml
@@ -1,3 +1,17 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: v1
 kind: Secret
 metadata:

--- a/examples/offload/gke/pod_tpu_commons_cpu_offload.yaml
+++ b/examples/offload/gke/pod_tpu_commons_cpu_offload.yaml
@@ -1,3 +1,17 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: v1
 kind: Pod
 metadata:

--- a/examples/offload/gke/pod_tpu_commons_cpu_offload_verification.yaml
+++ b/examples/offload/gke/pod_tpu_commons_cpu_offload_verification.yaml
@@ -1,3 +1,17 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: v1
 kind: Pod
 metadata:

--- a/examples/offload/gke/pod_tpu_host_offload_unit_tests.yaml
+++ b/examples/offload/gke/pod_tpu_host_offload_unit_tests.yaml
@@ -1,3 +1,17 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: v1
 kind: Pod
 metadata:

--- a/examples/offload/offline_inference_kv_cache.py
+++ b/examples/offload/offline_inference_kv_cache.py
@@ -1,9 +1,20 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 import os
 import time
 
-import vllm.envs as envs
 from vllm import LLM, EngineArgs
 from vllm.utils.argparse_utils import FlexibleArgumentParser
 
@@ -47,7 +58,7 @@ def main(args: dict):
     sampling_params.max_tokens = 20
     sampling_params.skip_special_tokens = True
 
-    if envs.VLLM_TORCH_PROFILER_DIR is not None:
+    if os.environ.get("VLLM_TORCH_PROFILER_DIR") is not None:
         llm.start_profile()
 
     # 1st generate
@@ -66,7 +77,7 @@ def main(args: dict):
     out_texts2, out_tokens2 = parse_outputs(outputs)
     time.sleep(1)
 
-    if envs.VLLM_TORCH_PROFILER_DIR is not None:
+    if os.environ.get("VLLM_TORCH_PROFILER_DIR") is not None:
         llm.stop_profile()
 
     # output1 and output2 should be idential

--- a/examples/offload/offline_inference_kv_cache_verification.py
+++ b/examples/offload/offline_inference_kv_cache_verification.py
@@ -1,4 +1,16 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """
 This script performs an automated correctness verification for the TPUOffloadConnector.
 
@@ -26,7 +38,6 @@ import os
 import time
 from typing import List, Tuple
 
-import vllm.envs as envs
 from vllm import LLM, EngineArgs, SamplingParams
 from vllm.utils.argparse_utils import FlexibleArgumentParser
 
@@ -79,7 +90,7 @@ def run_invocations(llm: LLM, sampling_params: SamplingParams,
     Runs generation on the given LLM object for a specified number of
     invocations and returns the output texts.
     """
-    if envs.VLLM_TORCH_PROFILER_DIR is not None:
+    if os.environ.get("VLLM_TORCH_PROFILER_DIR") is not None:
         llm.start_profile()
 
     all_outputs = []
@@ -91,7 +102,7 @@ def run_invocations(llm: LLM, sampling_params: SamplingParams,
         llm.llm_engine.engine_core.reset_prefix_cache()
         time.sleep(5)
 
-    if envs.VLLM_TORCH_PROFILER_DIR is not None:
+    if os.environ.get("VLLM_TORCH_PROFILER_DIR") is not None:
         llm.stop_profile()
 
     return all_outputs

--- a/tests/offload/tpu_offload_accuracy_test.py
+++ b/tests/offload/tpu_offload_accuracy_test.py
@@ -1,4 +1,16 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 import itertools
 import os
@@ -61,7 +73,6 @@ def _test_kv_cache_cpu_offloading_accuracy(
         os.environ['TPU_OFFLOAD_NUM_CPU_CHUNKS'] = cpu_chunks
         llm = LLM(model="meta-llama/Llama-3.2-3B",
                   max_model_len=3072,
-                  task="generate",
                   kv_transfer_config=kv_transfer_config)
 
         # 1st generate

--- a/tests/offload/tpu_offload_connector_scheduler_test.py
+++ b/tests/offload/tpu_offload_connector_scheduler_test.py
@@ -1,4 +1,16 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 import os
 from unittest.mock import MagicMock

--- a/tests/offload/tpu_offload_connector_worker_test.py
+++ b/tests/offload/tpu_offload_connector_worker_test.py
@@ -1,4 +1,16 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 import functools
 import gc

--- a/tests/offload/tpu_offload_cpu_backend_test.py
+++ b/tests/offload/tpu_offload_cpu_backend_test.py
@@ -1,4 +1,16 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 from unittest.mock import MagicMock
 

--- a/tests/offload/tpu_offload_manager_test.py
+++ b/tests/offload/tpu_offload_manager_test.py
@@ -1,4 +1,17 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import pytest
 
 from tpu_inference.logger import init_logger

--- a/tests/offload/tpu_offload_multi_request_accuracy_test.py
+++ b/tests/offload/tpu_offload_multi_request_accuracy_test.py
@@ -1,4 +1,16 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 import pytest
 from vllm import SamplingParams

--- a/tests/offload/tpu_offload_utils_test.py
+++ b/tests/offload/tpu_offload_utils_test.py
@@ -1,3 +1,17 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import unittest
 
 import jax
@@ -84,11 +98,16 @@ class TestTPUOffloadUtilsFn(unittest.TestCase):
 
         jax.block_until_ready(initial_kv_caches)
 
+        # Copy to host early because the operation will donate via stack_kv_cache_cross_layers
+        initial_kv_caches_baseline = [
+            np.array(cache) for cache in initial_kv_caches
+        ]
+
         src_blocks_array = jnp.array(src_blocks)
 
-        output = stack_kv_cache_cross_layers(initial_kv_caches,
-                                             src_blocks_array,
-                                             num_blocks_to_gather)
+        _, output = stack_kv_cache_cross_layers(initial_kv_caches,
+                                                src_blocks_array,
+                                                num_blocks_to_gather)
         jax.block_until_ready(output)
 
         # --- Verification ---
@@ -103,8 +122,8 @@ class TestTPUOffloadUtilsFn(unittest.TestCase):
             block_id = src_blocks[i]
             for j in range(self.num_layers):
                 output_np = np.array(output[i])
-                initial_np = np.array(initial_kv_caches[j])
-                np.testing.assert_array_equal(output_np[j],
+                initial_np = np.array(initial_kv_caches_baseline[j])
+                np.testing.assert_array_equal(output_np[0, j],
                                               initial_np[block_id])
 
         print(

--- a/tpu_inference/kernels/dma/__init__.py
+++ b/tpu_inference/kernels/dma/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tpu_inference/kernels/dma/host_dma.py
+++ b/tpu_inference/kernels/dma/host_dma.py
@@ -1,4 +1,16 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """ Host <-> HBM DMA kernel"""
 import jax
 from jax.experimental import pallas as pl

--- a/tpu_inference/offload/__init__.py
+++ b/tpu_inference/offload/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tpu_inference/offload/cpu_backend.py
+++ b/tpu_inference/offload/cpu_backend.py
@@ -1,4 +1,16 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 import sys
 from collections import OrderedDict

--- a/tpu_inference/offload/offload_manager.py
+++ b/tpu_inference/offload/offload_manager.py
@@ -1,4 +1,16 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 from collections import OrderedDict
 from dataclasses import dataclass

--- a/tpu_inference/offload/tpu_offload_connector.py
+++ b/tpu_inference/offload/tpu_offload_connector.py
@@ -1,4 +1,16 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """
 TPUOffloadConnector manages KV cache data transfer between TPU (HBM) and CPU.
 
@@ -1564,23 +1576,6 @@ class TPUOffloadConnectorScheduler():
                     self.staging_buffer_manager.
                     get_num_total_free_blocks_for_save())
 
-        # load
-        for req_id in connector_output.finished_recving or []:
-            if req_id in self._reqs_being_loaded:
-                assert len(self._reqs_being_loaded[req_id]) == 0
-                self._reqs_being_loaded.pop(req_id)
-            num_freed_blocks = self.staging_buffer_manager.free(req_id,
-                                                                usage="load")
-            logger.info(
-                f"  freed {num_freed_blocks} staging blocks (load) from {req_id}"
-            )
-            STAGING_BUFFER_BLOCKS_FOR_LOAD.set(
-                self.staging_buffer_manager.get_num_blocks_for_load())
-            STAGING_BUFFER_BLOCKS_FOR_LOAD_FREE.labels(
-                source="finished_recving").set(
-                    self.staging_buffer_manager.
-                    get_num_total_free_blocks_for_load())
-
         _finished_reqs = list(self._finished_reqs_w_pending_ops)
         FINISHED_REQS_W_PENDING_OPS_SIZE.labels(
             source="update_connector_output").set(len(_finished_reqs))
@@ -1705,7 +1700,6 @@ class TPUOffloadConnectorWorker:
             max_workers=self.num_save_threads,
             thread_name_prefix="tpu_save_handler")
         self.finished_save_reqs: set[ReqId] = set()
-        self.finished_load_reqs: set[ReqId] = set()
         # Tracks if wait_for_save has been called for the current step's metadata.
         self._processed_save_for_step = False
         # On-going asynchronous save operations tracking futures and their associated manifest.
@@ -2634,7 +2628,6 @@ class TPUOffloadConnectorWorker:
             LOAD_KV_LATENCY_SECONDS.observe(load_duration)
             load_times.append(load_duration)
             LOAD_KV_SIZE_BLOCKS.inc(num_blocks_to_load)
-            self.finished_load_reqs.add(meta.req_id)
             if num_blocks_to_load > 0:
                 self.offload_stats.record_load(req=meta.req_id,
                                                loaded_chunk_ids=src_chunks)
@@ -2678,9 +2671,8 @@ class TPUOffloadConnectorWorker:
         finished_saves = self.finished_save_reqs
         FINISHED_SAVE_REQS_SIZE.set(len(finished_saves))
         self.finished_save_reqs = set()
-        finished_loads = self.finished_load_reqs
-        FINISHED_LOAD_REQS_SIZE.set(len(finished_loads))
-        self.finished_load_reqs = set()
+        # NOTE: add back self.finished_load_reqs and report it back to vllm scheduler when async load gets implemented.
+        finished_loads = set()
         logger.debug(f"Finished saves: {finished_saves}, "
                      f"Finished loads: {finished_loads}")
         return finished_saves, finished_loads

--- a/tpu_inference/offload/utils.py
+++ b/tpu_inference/offload/utils.py
@@ -1,4 +1,16 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 import functools
 import hashlib

--- a/tpu_inference/runner/kv_cache_manager.py
+++ b/tpu_inference/runner/kv_cache_manager.py
@@ -34,7 +34,6 @@ from vllm.v1.kv_cache_interface import (FullAttentionSpec, KVCacheConfig,
 from tpu_inference import utils
 from tpu_inference import utils as common_utils
 from tpu_inference.layers.common.sharding import ShardingAxisName
-from tpu_inference.offload.utils import get_kv_connector_cache_layout
 from tpu_inference.logger import init_logger
 from tpu_inference.offload.utils import get_kv_connector_cache_layout
 from tpu_inference.runner import utils as runner_utils

--- a/tpu_inference/worker/tpu_worker.py
+++ b/tpu_inference/worker/tpu_worker.py
@@ -383,8 +383,9 @@ class TPUWorker(WorkerBase):
         # violates the pure abstract contract of the base class. This is a
         # deliberate, temporary compromise for the same reasons outlined in
         # the `get_kv_cache_spec` method.
+        # NOTE: delete profile code before merging the branch
         if self.step_counter == 1:
-           self.profile(is_start=True)
+            self.profile(is_start=True)
         if self.parallel_config.pipeline_parallel_size == 1 or self.rank == 0:
             intermediate_tensors = None
         else:
@@ -413,8 +414,9 @@ class TPUWorker(WorkerBase):
             return None
         else:
             self.step_counter += 1
+            # NOTE: delete profile code before merging the branch
             if self.step_counter == 10:
-               self.profile(is_start=False)
+                self.profile(is_start=False)
             # With a connector, the scheduler expects output from all workers
             # TODO(mrjunwan): Figure out if this is ok after https://github.com/vllm-project/vllm/pull/26866
             if has_kv_transfer_group():


### PR DESCRIPTION
# Description

Start with a short description of what the PR does and how this is a change from
the past.

This commit addresses several issues:

-   Fixes an AttributeError in  and  by using  to safely access the  environment variable.
-   Corrects an array indexing error in the  test within .
-   Removes an unnecessary  argument in .
-   Refactors staging buffer management and load request handling in .

vllm expect the request in either WAITING_FOR_REMOTE_KVS state or finished[1] But request 1-b571b991 is in some other state. 
```
(EngineCore pid=151055) INFO 03-21 00:03:05 [tpu_offload_connector.py:1367] Phase 3: Processing 1 cached requests.
(EngineCore pid=151055) INFO 03-21 00:03:05 [tpu_offload_connector.py:524]  update req(1-94ff4354): new_blocks: [], num_new_tokens: 0; existing blocks:[10, 11, 12, 13, 14, 15, 16, 17], existing tokens: 2042.
(EngineCore pid=151055) INFO 03-21 00:03:05 [tpu_offload_connector.py:1525]   finished_load_chunks for 1-94ff4354: 7
(EngineCore pid=151055) INFO 03-21 00:03:05 [offload_manager.py:439]   free 7 staging blocks (usage: load) from Req:1-94ff4354
```

The log shows that worker enter Phase 3[2] before finished_load_chunks got called, which means the request already in RUNNING state before load finished. Fix the issue by not return the request_id after load complete from get_finished function since the load complete doesn't mean request finished


[1]https://github.com/vllm-project/vllm/blob/85f671b8e1cfa6655605efdf1263cf2f94e9b992/vllm/v1/core/sched/scheduler.py#L2101

[2]https://github.com/vllm-project/tpu-inference/blob/cpu-offloading/dev-merge-0318/tpu_inference/offload/tpu_offload_connector.py#L40

# Tests

- examples/offload/gke/pod_tpu_host_offload_unit_tests.yaml
- examples/offload/gke/pod_tpu_commons_cpu_offload_verification.yaml
- examples/offload/gke/pod_tpu_commons_cpu_offload.yaml

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
