### PR TITLE
[Jax] Update to strictly load local layer num_kv_heads and head_dim

### DIFF
--- a/tpu_inference/runner/kv_cache_manager.py
+++ b/tpu_inference/runner/kv_cache_manager.py
@@ -142,8 +142,11 @@ class KVCacheManager:
                         head_size = getattr(text_config, "global_head_dim",
                                             base_head_size)
                     else:
-                        num_kv_heads = base_num_kv_heads
-                        head_size = base_head_size
+                        num_kv_heads = getattr(text_config,
+                                               "num_key_value_heads",
+                                               base_num_kv_heads)
+                        head_size = getattr(text_config, "head_dim",
+                                            base_head_size)
                     # Pad num_kv_heads to multiple of TP size.
                     num_kv_heads = common_utils.get_padded_num_heads(
                         num_kv_heads, model_cnt)


### PR DESCRIPTION
# Description
`model_config.get_head_size()` is returning `global_head_dim`.
Update to strictly load num_kv_heads and head_dim for local layers in jax path.

# Tests
`python3 -m pytest -s -v tests/runner/test_kv_cache_manager.py`

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
