### PR TITLE
Centralized docker build for PR CI tests

### DIFF
--- a/.buildkite/pipeline_jax.yml
+++ b/.buildkite/pipeline_jax.yml
@@ -15,13 +15,28 @@
 steps:
   - group: "${TESTS_GROUP_LABEL:-[jax] TPU6e Tests Group}"
     steps:
+
+      # -----------------------------------------------------------------
+      # Centralized Build Step (Runs on the CPU queue)
+      # -----------------------------------------------------------------
+      - label: ":docker: Build and Push Base Image (${TPU_VERSION:-tpu6e})"
+        key: "${TPU_VERSION:-tpu6e}_build_docker"
+        agents:
+          queue: cpu_64_core
+        env:
+          TPU_VERSION: "${TPU_VERSION:-tpu6e}"
+        commands:
+          - bash -c 'source .buildkite/scripts/setup_docker_env.sh && setup_environment "vllm-tpu" "false" "true"'
+
       # -----------------------------------------------------------------
       # TEST STEPS - Calling wrapper
       # -----------------------------------------------------------------
       - label: "${TPU_VERSION:-tpu6e} E2E MLPerf tests for JAX models"
         key: "${TPU_VERSION:-tpu6e}_test_0"
+        depends_on: "${TPU_VERSION:-tpu6e}_build_docker"
         soft_fail: true
         env:
+          USE_PREBUILT_IMAGE: "1"
           TPU_VERSION: "${TPU_VERSION:-tpu6e}"
         agents:
           queue: ${TPU_QUEUE_SINGLE:-tpu_v6e_queue}
@@ -54,8 +69,10 @@ steps:
 
       - label: "${TPU_VERSION:-tpu6e} E2E MLPerf tests for JAX + vLLM models on single chip"
         key: ${TPU_VERSION:-tpu6e}_test_3
+        depends_on: "${TPU_VERSION:-tpu6e}_build_docker"
         soft_fail: true
         env:
+          USE_PREBUILT_IMAGE: "1"
           MODEL_IMPL_TYPE: "vllm"
           TPU_VERSION: "${TPU_VERSION:-tpu6e}"
         agents:
@@ -78,8 +95,10 @@ steps:
 
       - label: "${TPU_VERSION:-tpu6e} E2E speculative decoding test"
         key: ${TPU_VERSION:-tpu6e}_test_6
+        depends_on: "${TPU_VERSION:-tpu6e}_build_docker"
         soft_fail: true
         env:
+          USE_PREBUILT_IMAGE: "1"
           TPU_VERSION: "${TPU_VERSION:-tpu6e}"
         agents:
           queue: ${TPU_QUEUE_SINGLE:-tpu_v6e_queue}
@@ -90,8 +109,12 @@ steps:
 
       - label: "${TPU_VERSION:-tpu6e} JAX unit tests part1"
         key: ${TPU_VERSION:-tpu6e}_test_7_1
+        depends_on: "${TPU_VERSION:-tpu6e}_build_docker"
         soft_fail: true
         artifact_paths: ".coverage.part1.${TPU_VERSION:-tpu6e}"
+        env:
+          USE_PREBUILT_IMAGE: "1"
+          TPU_VERSION: "${TPU_VERSION:-tpu6e}"
         agents:
           queue: ${TPU_QUEUE_SINGLE:-tpu_v6e_queue}
         commands:
@@ -102,8 +125,12 @@ steps:
 
       - label: "${TPU_VERSION:-tpu6e} JAX unit tests part2"
         key: ${TPU_VERSION:-tpu6e}_test_7_2
+        depends_on: "${TPU_VERSION:-tpu6e}_build_docker"
         soft_fail: true
         artifact_paths: ".coverage.part2.${TPU_VERSION:-tpu6e}"
+        env:
+          USE_PREBUILT_IMAGE: "1"
+          TPU_VERSION: "${TPU_VERSION:-tpu6e}"
         agents:
           queue: ${TPU_QUEUE_SINGLE:-tpu_v6e_queue}
         commands:
@@ -139,7 +166,10 @@ steps:
 
       - label: "${TPU_VERSION:-tpu6e} JAX unit tests - kernels"
         key: ${TPU_VERSION:-tpu6e}_test_8
+        depends_on: "${TPU_VERSION:-tpu6e}_build_docker"
         soft_fail: true
+        env:
+          USE_PREBUILT_IMAGE: "1"
         agents:
           queue: ${TPU_QUEUE_SINGLE:-tpu_v6e_queue}
         commands:
@@ -161,7 +191,10 @@ steps:
 
       - label: "${TPU_VERSION:-tpu6e} JAX unit tests - collective kernels"
         key: ${TPU_VERSION:-tpu6e}_test_9
+        depends_on: "${TPU_VERSION:-tpu6e}_build_docker"
         soft_fail: true
+        env:
+          USE_PREBUILT_IMAGE: "1"
         agents:
           queue: ${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}
         commands:
@@ -217,8 +250,10 @@ steps:
 
       - label: "${TPU_VERSION:-tpu6e} lora e2e tests for JAX + vLLM models multi chips"
         key: ${TPU_VERSION:-tpu6e}_test_13
+        depends_on: "${TPU_VERSION:-tpu6e}_build_docker"
         soft_fail: true
         env:
+          USE_PREBUILT_IMAGE: "1"
           TEST_LORA_TP: "True"
           VLLM_LOG_LEVEL: "INFO"
         agents:
@@ -228,7 +263,11 @@ steps:
 
       - label: "${TPU_VERSION:-tpu6e} lora unit tests on single chip"
         key: ${TPU_VERSION:-tpu6e}_test_15
+        depends_on: "${TPU_VERSION:-tpu6e}_build_docker"
         soft_fail: true
+        env:
+          USE_PREBUILT_IMAGE: "1"
+          TPU_VERSION: "${TPU_VERSION:-tpu6e}"
         agents:
           queue: ${TPU_QUEUE_SINGLE:-tpu_v6e_queue}
         commands:
@@ -239,8 +278,10 @@ steps:
 
       - label: "${TPU_VERSION:-tpu6e} lora unit tests on multi chips"
         key: ${TPU_VERSION:-tpu6e}_test_16
+        depends_on: "${TPU_VERSION:-tpu6e}_build_docker"
         soft_fail: true
         env:
+          USE_PREBUILT_IMAGE: "1"
           USE_V6E8_QUEUE: "True"
           VLLM_LOG_LEVEL: "INFO"
         agents:
@@ -250,8 +291,10 @@ steps:
 
       - label: "${TPU_VERSION:-tpu6e} E2E lm_eval accuracy check qwen3 coder with fused moe."
         key: ${TPU_VERSION:-tpu6e}_test_17
+        depends_on: "${TPU_VERSION:-tpu6e}_build_docker"
         soft_fail: true
         env:
+          USE_PREBUILT_IMAGE: "1"
           TPU_VERSION: "${TPU_VERSION:-tpu6e}"
         agents:
           queue: ${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}
@@ -266,8 +309,10 @@ steps:
 
       - label: "${TPU_VERSION:-tpu6e} E2E lm_eval accuracy check qwen3 coder with gmm kernel."
         key: ${TPU_VERSION:-tpu6e}_test_18
+        depends_on: "${TPU_VERSION:-tpu6e}_build_docker"
         soft_fail: true
         env:
+          USE_PREBUILT_IMAGE: "1"
           TPU_VERSION: "${TPU_VERSION:-tpu6e}"
         agents:
           queue: ${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}
@@ -282,8 +327,10 @@ steps:
 
       - label: "${TPU_VERSION:-tpu6e} E2E lm_eval accuracy check gpt oss."
         key: ${TPU_VERSION:-tpu6e}_test_19
+        depends_on: "${TPU_VERSION:-tpu6e}_build_docker"
         soft_fail: true
         env:
+          USE_PREBUILT_IMAGE: "1"
           TPU_VERSION: "${TPU_VERSION:-tpu6e}"
         agents:
           queue: ${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}
@@ -312,8 +359,10 @@ steps:
 
       - label: "${TPU_VERSION:-tpu6e} Perf regression test for qwen3 coder 8k 1k with fused moe kernel."
         key: ${TPU_VERSION:-tpu6e}_test_21
+        depends_on: "${TPU_VERSION:-tpu6e}_build_docker"
         soft_fail: true
         env:
+          USE_PREBUILT_IMAGE: "1"
           TPU_VERSION: "${TPU_VERSION:-tpu6e}"
         agents:
           queue: ${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}
@@ -339,8 +388,10 @@ steps:
 
       - label: "${TPU_VERSION:-tpu6e} Perf regression test for qwen3 coder 8k 1k with gmm kernel."
         key: ${TPU_VERSION:-tpu6e}_test_23
+        depends_on: "${TPU_VERSION:-tpu6e}_build_docker"
         soft_fail: true
         env:
+          USE_PREBUILT_IMAGE: "1"
           TPU_VERSION: "${TPU_VERSION:-tpu6e}"
         agents:
           queue: ${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}
@@ -352,8 +403,10 @@ steps:
 
       - label: "${TPU_VERSION:-tpu6e} Test EP recompilation."
         key: ${TPU_VERSION:-tpu6e}_test_24
+        depends_on: "${TPU_VERSION:-tpu6e}_build_docker"
         soft_fail: true
         env:
+          USE_PREBUILT_IMAGE: "1"
           TPU_VERSION: "${TPU_VERSION:-tpu6e}"
         agents:
           queue: ${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}
@@ -365,8 +418,10 @@ steps:
 
       - label: "${TPU_VERSION:-tpu6e} E2E test for DCN-based P/D disaggregation"
         key: ${TPU_VERSION:-tpu6e}_test_25
+        depends_on: "${TPU_VERSION:-tpu6e}_build_docker"
         soft_fail: true
         env:
+          USE_PREBUILT_IMAGE: "1"
           TPU_VERSION: "${TPU_VERSION:-tpu6e}"
           MODEL: "Qwen/Qwen3-0.6B"
           INPUT_LEN: 1024
@@ -413,7 +468,11 @@ steps:
 
       - label: "${TPU_VERSION:-tpu6e} Correctness Test | Runai Model Streamer JAX UniProcExecutor"
         key: "${TPU_VERSION:-tpu6e}_test_27"
+        depends_on: "${TPU_VERSION:-tpu6e}_build_docker"
         soft_fail: true
+        env:
+          USE_PREBUILT_IMAGE: "1"
+          TPU_VERSION: "${TPU_VERSION:-tpu6e}"
         agents:
           queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
         commands:
@@ -421,7 +480,11 @@ steps:
       
       - label: "${TPU_VERSION:-tpu6e} Correctness Test | Runai Model Streamer Torchax UniProcExecutor"
         key: "${TPU_VERSION:-tpu6e}_test_28"
+        depends_on: "${TPU_VERSION:-tpu6e}_build_docker"
         soft_fail: true
+        env:
+          USE_PREBUILT_IMAGE: "1"
+          TPU_VERSION: "${TPU_VERSION:-tpu6e}"
         agents:
           queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
         commands:
@@ -429,7 +492,10 @@ steps:
       
       - label: "${TPU_VERSION:-tpu6e} Correctness Test | Runai Model Streamer Torchax RayDistributedExecutor"
         key: "${TPU_VERSION:-tpu6e}_test_29"
+        depends_on: "${TPU_VERSION:-tpu6e}_build_docker"
         soft_fail: true
+        env:
+          USE_PREBUILT_IMAGE: "1"
         agents:
           queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}" # Using a queue with more devices for distributed tests
         commands:

--- a/.buildkite/scripts/setup_docker_env.sh
+++ b/.buildkite/scripts/setup_docker_env.sh
@@ -81,7 +81,10 @@ cleanup_docker_resource() {
 setup_environment() {
   local image_name_param=${1:-"vllm-tpu"}
   local should_push=${2:-"false"}
+  local push_to_ci_cache=${3:-"false"}
   IMAGE_NAME="$image_name_param"
+  local CI_IMAGE_REPO="us-central1-docker.pkg.dev/cloud-ullm-inference-ci-cd/tpu-inference-ci/${IMAGE_NAME}"
+  local LOCAL_TPU_VERSION="${TPU_VERSION:-tpu6e}" 
 
   local DOCKERFILE_NAME="Dockerfile"
 
@@ -113,13 +116,36 @@ setup_environment() {
       TPU_INFERENCE_HASH="$BUILDKITE_COMMIT"
   fi
  
+  local CACHE_TAG="${TPU_INFERENCE_HASH}-${LOCAL_TPU_VERSION}"
+
+  # ==========================================
+  # Pull-Only Mode for TPU execution nodes
+  # ==========================================
+  if [[ "${USE_PREBUILT_IMAGE:-0}" == "1" ]]; then
+    echo "Pulling pre-built Docker image: ${CI_IMAGE_REPO}:${CACHE_TAG} ..."
+    docker pull "${CI_IMAGE_REPO}:${CACHE_TAG}"
+    docker tag "${CI_IMAGE_REPO}:${CACHE_TAG}" "${IMAGE_NAME}:${TPU_INFERENCE_HASH}"
+    docker tag "${CI_IMAGE_REPO}:${CACHE_TAG}" "${IMAGE_NAME}:latest"
+    return 0
+  fi
+
   # Build with specific hash and 'latest' tag for convenience
   docker build \
       --build-arg VLLM_COMMIT_HASH="${VLLM_COMMIT_HASH}" \
       --build-arg IS_TEST="true" \
       --no-cache -f docker/"${DOCKERFILE_NAME}" \
       -t "${IMAGE_NAME}:${TPU_INFERENCE_HASH}" \
-      -t "${IMAGE_NAME}:latest" .
+      -t "${IMAGE_NAME}:latest" \
+      -t "${IMAGE_NAME}:${CACHE_TAG}" .
+
+  # ==========================================
+  # Push to CI Image Registry (Executed by dedicate CPU builder)
+  # ==========================================
+  if [[ "$push_to_ci_cache" == "true" ]]; then
+    echo "Pushing Docker image to CI Image Registry..."
+    docker tag "${IMAGE_NAME}:${CACHE_TAG}" "${CI_IMAGE_REPO}:${CACHE_TAG}"
+    docker push "${CI_IMAGE_REPO}:${CACHE_TAG}"
+  fi
 
   # Push logic if requested
   if [[ "$should_push" == "true" ]]; then


### PR DESCRIPTION
Move the image build for PR tests from the TPU VMs to a dedicated 64 core CPU group

This is the first step to shorten the overall test execution time. Currently the every v6e and v7x TPU VMs will spend over 6 mins on image building at the very beginning and this is a total waste of the TPU resources. After this, we will further breakdown the test cases to try to shorten the e2e execution time as well as the each TPU VMs' execution time.

# Tests

Triggered a [test Build](https://buildkite.com/tpu-commons/tpu-inference-ci/builds/12966/steps/canvas) for this commit and it passed. The "Steps" graph clearly shows the execution workflow.

# Checklist

I have performed a self-review of my code.
I have necessary comments in my code, particularly in hard-to-understand areas.
I have made or will make corresponding changes to any relevant documentation.
