### PR TITLE
Dedup Tok-k for DP/EP sharding

### DIFF
--- a/tpu_inference/layers/common/fused_moe_gmm.py
+++ b/tpu_inference/layers/common/fused_moe_gmm.py
@@ -323,13 +323,13 @@ def fused_moe_func(
     assert gating_output.shape == (num_tokens, global_num_experts)
 
     topk_weights = apply_scoring_fn(scoring_fn, gating_output)
-    # All-gather topk weights for attention dp
-    topk_weights = jax.lax.with_sharding_constraint(
-        topk_weights, NamedSharding(mesh, P(ShardingAxisName.MLP_DATA, None)))
     topk_weights, topk_indices = jax.lax.top_k(topk_weights, k=topk)
     if renormalize:
         topk_weights = topk_weights / topk_weights.sum(axis=-1, keepdims=True)
     topk_weights = topk_weights.astype(dtype)
+    # All-gather topk weights for attention dp
+    topk_weights = jax.lax.with_sharding_constraint(
+        topk_weights, NamedSharding(mesh, P(ShardingAxisName.MLP_DATA, None)))
 
     def _process_tokens_locally(hidden_states_local, topk_indices_local):
         num_tokens_local = hidden_states_local.shape[0]


### PR DESCRIPTION
Move the with_sharding_constraint() after the jax.lax.top_k() so that in DP/EP sharding, so that the top-k only process tokens of each DP shard. Instead of each shard do duplicated top-k for all tokens.

Verified in the xprof about the shape of the Topk operation:
After this PR: https://screenshot.googleplex.com/4zsSUggHKRooV6E 
Before this PR: https://screenshot.googleplex.com/dpstohQZwyPEQfL

This save ~30us per layer in the 1k/8k DSV3.

# Tests
Quality test validated:
```
python ./tpu-inference/scripts/vllm/benchmarking/benchmark_serving.py --backend vllm --model deepseek-ai/DeepSeek-R1 --dataset-name mmlu --dataset-path /home/gxd_google_com/work-dir/mmlu/data/test --num-prompts 5000 --run_eval --temperature 0


============ Serving Benchmark Result ============
Successful requests:                     5000      
Benchmark duration (s):                  181.68    
Total input tokens:                      1015147   
Total generated tokens:                  10000     
Request throughput (req/s):              27.52     
Output token throughput (tok/s):         55.04     
Total token throughput (tok/s):          5642.67   
---------------Time to First Token----------------
Mean TTFT (ms):                          101751.58 
Median TTFT (ms):                        94671.76  
P99 TTFT (ms):                           180060.17 
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          1197.09   
Median TPOT (ms):                        1207.25   
P99 TPOT (ms):                           1230.31   
---------------Inter-token Latency----------------
Mean ITL (ms):                           1197.09   
Median ITL (ms):                         1207.25   
P99 ITL (ms):                            1230.31   
----------------End-to-end Latency----------------
Mean E2EL (ms):                          102948.67 
Median E2EL (ms):                        95881.12  
P99 E2EL (ms):                           181038.70 
==================================================
Evaluating MMLU...
[nltk_data] Downloading package punkt to
[nltk_data]     /home/gxd_google_com/nltk_data...
[nltk_data]   Package punkt is already up-to-date!
[nltk_data] Downloading package punkt_tab to
[nltk_data]     /home/gxd_google_com/nltk_data...
[nltk_data]   Package punkt_tab is already up-to-date!

Results
{'accuracy': 0.8764, 'gen_num': 5000}
```

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
