### PR TITLE
[CI] Update compilation to fix recompilation error of Qwen2.5-VL

### DIFF
--- a/tpu_inference/runner/compilation_manager.py
+++ b/tpu_inference/runner/compilation_manager.py
@@ -286,9 +286,10 @@ class CompilationManager:
                 input_ids = self._create_dummy_tensor((num_tokens, ),
                                                       jnp.int32, dp_sharding)
                 # Need align to the sampling output
-                next_tokens = self._create_dummy_tensor((num_reqs, ),
-                                                        jnp.int32,
-                                                        sharding=NamedSharding(self.runner.mesh, PartitionSpec()))
+                next_tokens = self._create_dummy_tensor(
+                    (num_reqs, ),
+                    jnp.int32,
+                    sharding=NamedSharding(self.runner.mesh, PartitionSpec()))
 
                 placeholder_num = 1
                 self._run_compilation(
@@ -311,11 +312,11 @@ class CompilationManager:
             input_ids = self._create_dummy_tensor((num_tokens, ), jnp.int32,
                                                   dp_sharding)
             if self.runner.uses_mrope:
-                positions = self._create_dummy_tensor((3, num_tokens), jnp.int32,
-                                                      dp_sharding)
+                positions = self._create_dummy_tensor((3, num_tokens),
+                                                      jnp.int32, dp_sharding)
             else:
-                positions = self._create_dummy_tensor((num_tokens, ), jnp.int32,
-                                                  dp_sharding)
+                positions = self._create_dummy_tensor((num_tokens, ),
+                                                      jnp.int32, dp_sharding)
             is_first_rank = self.runner.is_first_rank
             is_last_rank = self.runner.is_last_rank
             if is_first_rank:


### PR DESCRIPTION
# Description

This is caused by this PR: https://github.com/vllm-project/tpu-inference/pull/1982. Earlier, when multimodal models are used, we calculate text tokens through embed_input_ids_fn. After the changes in this PR, it's only used when multimodal embeddings are not None for performance.

When embeddings are passed to the language backbone, it is already correctly compiled with 3D mrope: https://github.com/vllm-project/tpu-inference/blob/13df7e9a72b0e6bda66037019c1f089978f131f8/tpu_inference/runner/compilation_manager.py#L345. 
However, this is not precompiled for the case of text only: https://github.com/vllm-project/tpu-inference/blob/13df7e9a72b0e6bda66037019c1f089978f131f8/tpu_inference/runner/compilation_manager.py#L313 causing the compilation mismatch.

There's also another recompilation of `_substitute_placeholder_token` due to misaligned sharding after addressing the previous issue.

# Tests
```
export TEST_MODEL="Qwen/Qwen2.5-VL-7B-Instruct"
export TENSOR_PARALLEL_SIZE=1
python -m pytest -s -rP test_accuracy.py::test_lm_eval_accuracy_v1_engine \
    --model-name="$TEST_MODEL" \
    --tensor-parallel-size="$TENSOR_PARALLEL_SIZE"
```

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
