### PR TITLE
Move P/D KV cache from HBM to DRAM to reduce the Memory pressure in prefill server

### DIFF
--- a/tests/distributed/test_tpu_connector.py
+++ b/tests/distributed/test_tpu_connector.py
@@ -368,7 +368,10 @@ class TestTPUConnectorWorker(unittest.TestCase):
         mock_kv_cache_layer = MagicMock()
         mock_kv_cache_layer.shape = [10, 20, 30, 40]
         mock_kv_cache_layer.dtype = 'float32'
-        mock_kv_cache_layer.sharding = 'sharding_spec'
+        mock_sharding = MagicMock()
+        mock_sharding.mesh = 'mesh'
+        mock_sharding.spec = 'sharding_spec'
+        mock_kv_cache_layer.sharding = mock_sharding
         mock_runner.kv_caches = [mock_kv_cache_layer] * 5
         mock_runner.mesh = 'mesh'
 
@@ -380,7 +383,7 @@ class TestTPUConnectorWorker(unittest.TestCase):
         self.assertEqual(worker.num_layers, 5)
         self.assertEqual(worker.shape, [10, 20, 30, 40])
         self.assertEqual(worker.dtype, 'float32')
-        self.assertEqual(worker.sharding, 'sharding_spec')
+        self.assertEqual(worker.sharding, mock_sharding)
 
     def test_process_send_load_for_producer(self):
         """Tests process_send_load for the producer role."""

--- a/tpu_inference/distributed/tpu_connector.py
+++ b/tpu_inference/distributed/tpu_connector.py
@@ -506,6 +506,11 @@ class TPUConnectorWorker:
         self.shape = list(kv_layer.shape)
         self.dtype = kv_layer.dtype
         self.sharding = kv_layer.sharding
+        self.host_sharding = jax.sharding.NamedSharding(
+            self.sharding.mesh,
+            self.sharding.spec,
+            memory_kind='pinned_host',
+        )
         logger.info(f"TPUConnector Worker --> register_runner | "
                     f"node_id={self.node_id} | "
                     f"ip={self.host_ip} | "
@@ -607,14 +612,24 @@ class TPUConnectorWorker:
         # TODO(xiang): pad block_ids to avoid recompilation
         indices = device_array(self.mesh, np.array(local_block_ids))
         kv = select_from_kv_caches(self.runner.kv_caches, indices)
+        start_time = time.perf_counter()
+        # (mrjunwan): we directly put the kv to host memory to reduce the memory pressure on device
+        # add time log here to monitor the transfer speed.
+        kv_dram = jax.device_put(kv, self.host_sharding)
+        end_time = time.perf_counter()
+        kv_size_mb = sum(k.nbytes for k in kv) / (1024 * 1024)
+        logger.info(
+            f"Worker {self.node_id} --> D2H kv load  | done put req_id={req_id} | duration={(end_time - start_time) * 1000:.2f}ms | size={kv_size_mb:.2f}MB"
+        )
+
         # NOTE(xiang): We need to manually store the kv because:
         # Although we can set use_raw_buffers=True to let kv be safely destroyed after
         # calling await_pull, it could be a stranding buffer if D never pulls it.
         # So we have to set use_raw_buffers=False and stores the kv, then the kv buffer
         # will be safely destroyed by either D notifying or expiration.
-        self.reqs_wait_pull[req_id] = [kv, req_meta.expiration_time]
+        self.reqs_wait_pull[req_id] = [kv_dram, req_meta.expiration_time]
         self.kv_pull_uuid_to_req_id_map[req_meta.uuid] = req_id
-        self.kv_transfer_server.await_pull(req_meta.uuid, kv)
+        self.kv_transfer_server.await_pull(req_meta.uuid, kv_dram)
 
     def _maybe_build_kv_connection(self, req_meta: LoadMeta) -> Any:
         if isinstance(req_meta.remote_host, list):


### PR DESCRIPTION
# Description

To reduce memory pressure on our prefill servers, we offload the P/D KV cache from HBM to host DRAM. Right now, if decode falls behind prefill, the KV cache footprint doubles in HBM, leading to unpredictable utilization limits and easy OOMs.

Since TPU7x has 960GB of DRAM and D2H speeds of ~100 GB/s, this is a very safe trade-off. For context, Qwen3-Coder-480B (8K input length) has a KV cache size of around 1GB. Offloading that takes ~10ms, which is well below the prefill time and won't impact overall latency

Some log:
(EngineCore pid=1652635) INFO 03-25 00:45:18 [tpu_connector.py:621] Worker 0 --> D2H kv load  | done pull req_id=cmpl-fe7230b7-e8c4-465f-a803-444bea6b22fd-0-9704ec1d | duration=0.83ms | size=112.00MB

before the fix:
------------
Successful requests:                     300       
Failed requests:                         0         
Request rate configured (RPS):           4.00      
Benchmark duration (s):                  75.64     
Total input tokens:                      307200    
Total generated tokens:                  38400     
Request throughput (req/s):              3.97      
Output token throughput (tok/s):         507.70    
Peak output token throughput (tok/s):    1557.00   
Peak concurrent requests:                18.00     
Total token throughput (tok/s):          4569.27   
---------------Time to First Token----------------
Mean TTFT (ms):                          206.44    
Median TTFT (ms):                        155.81    
P99 TTFT (ms):                           563.19    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          6.88      
Median TPOT (ms):                        6.26      
P99 TPOT (ms):                           13.81     
---------------Inter-token Latency----------------
Mean ITL (ms):                           6.88      
Median ITL (ms):                         4.01      
P99 ITL (ms):                            97.84     


after the fix:

Successful requests:                     300       
Failed requests:                         0         
Request rate configured (RPS):           4.00      
Benchmark duration (s):                  75.64     
Total input tokens:                      307200    
Total generated tokens:                  38400     
Request throughput (req/s):              3.97      
Output token throughput (tok/s):         507.70    
Peak output token throughput (tok/s):    1652.00   
Peak concurrent requests:                18.00     
Total token throughput (tok/s):          4569.28   
---------------Time to First Token----------------
Mean TTFT (ms):                          223.50    
Median TTFT (ms):                        183.30    
P99 TTFT (ms):                           793.47    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          7.12      
Median TPOT (ms):                        6.43      
P99 TPOT (ms):                           14.92     
---------------Inter-token Latency----------------
Mean ITL (ms):                           7.12      
Median ITL (ms):                         4.05      
P99 ITL (ms):                            102.58    


# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
