### PR TITLE
Set TP=2 for Tpu7x accuracy and benchmark tests.

### DIFF
--- a/.buildkite/models/meta-llama_Llama-3_1-8B-Instruct.yml
+++ b/.buildkite/models/meta-llama_Llama-3_1-8B-Instruct.yml
@@ -46,7 +46,7 @@ steps:
     soft_fail: true
     env:
       TEST_MODEL: meta-llama/Llama-3.1-8B-Instruct
-      TENSOR_PARALLEL_SIZE: 1
+      TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       MINIMUM_ACCURACY_THRESHOLD: 0.75
     commands:
       - |
@@ -73,7 +73,7 @@ steps:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     env:
       TEST_MODEL: meta-llama/Llama-3.1-8B-Instruct
-      TENSOR_PARALLEL_SIZE: 1
+      TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       MINIMUM_THROUGHPUT_THRESHOLD: 10.77
       INPUT_LEN: 1800
       OUTPUT_LEN: 128

--- a/tests/e2e/benchmarking/benchmark.sh
+++ b/tests/e2e/benchmarking/benchmark.sh
@@ -115,8 +115,15 @@ if [ -n "${MINIMUM_THROUGHPUT_THRESHOLD:-}" ]; then
     minimum_throughput_threshold="$MINIMUM_THROUGHPUT_THRESHOLD"
 fi
 
-if [ -n "${TENSOR_PARALLEL_SIZE:-}" ]; then
-    tensor_parallel_size="$TENSOR_PARALLEL_SIZE"
+# if TENSOR_PARALLEL_SIZE is set respect it.
+# otherwise, if TPU is tpu7x, use tp=2.
+if [ -z "$TENSOR_PARALLEL_SIZE" ] && [ "$TPU_VERSION" = "tpu7x" ]; then
+  tensor_parallel_size=2
+elif [ -n "$TENSOR_PARALLEL_SIZE" ]; then
+  tensor_parallel_size="$TENSOR_PARALLEL_SIZE"
+else
+  # Default fallback if neither condition is met
+  tensor_parallel_size=1
 fi
 
 echo "Using the root directory at $root_dir"

--- a/tests/e2e/benchmarking/test_accuracy.sh
+++ b/tests/e2e/benchmarking/test_accuracy.sh
@@ -16,7 +16,7 @@
 set -e
 
 test_model=""
-tensor_parallel_size=1
+
 minimum_accuracy_threshold=0
 
 extra_serve_args=()
@@ -58,8 +58,15 @@ if [ -n "$MINIMUM_ACCURACY_THRESHOLD" ]; then
   minimum_accuracy_threshold="$MINIMUM_ACCURACY_THRESHOLD"
 fi
 
-if [ -n "$TENSOR_PARALLEL_SIZE" ]; then
+# if TENSOR_PARALLEL_SIZE is set respect it.
+# otherwise, if TPU is tpu7x, use tp=2.
+if [ -z "$TENSOR_PARALLEL_SIZE" ] && [ "$TPU_VERSION" = "tpu7x" ]; then
+  tensor_parallel_size=2
+elif [ -n "$TENSOR_PARALLEL_SIZE" ]; then
   tensor_parallel_size="$TENSOR_PARALLEL_SIZE"
+else
+  # Default fallback if neither condition is met
+  tensor_parallel_size=1
 fi
 
 # Check if test_model is provided and not empty


### PR DESCRIPTION
# Description
Fix nightly test `meta-llama/Llama-3.1-8B-Instruct accuracy`

failure: https://github.com/vllm-project/tpu-inference/blob/825e2d616547ad328974c67422847b8bbbb4f719/.buildkite/models/meta-llama_Llama-3_1-8B-Instruct.yml#L41

# Fix
Since it failed on TPU7x only, we can mitigate it by TP=2 on tpu7x-2 and TP=1 on v6e.

# Test
Manual trigger: 
https://buildkite.com/tpu-commons/tpu-inference-ci/builds/13047
