### PR TITLE
[Fix] benchmark utils: fix regex error that treat choices as string

### DIFF
--- a/scripts/vllm/benchmarking/benchmark_utils.py
+++ b/scripts/vllm/benchmarking/benchmark_utils.py
@@ -239,8 +239,8 @@ def extract_abcd_gpqa(text: str, possible_choices: str = 'ABCD') -> str:
 
     patterns = [
         # "Answer: (C)" or "Answers: (B)"
-        re.compile(r'(?ix)\bAnswer[s]?\b\s*[:\-–]?\s*\(\s*(' +
-                   possible_choices + r')\s*\)'),
+        re.compile(r'(?ix)\bAnswer[s]?\b\s*[:\-–]?\s*\(\s*([' +
+                   possible_choices + r'])\s*\)'),
         # "Answer: C" or "Answers – D"
         re.compile(r'(?ix)\bAnswer[s]?\b\s*[:\-–]?\s*([' + possible_choices +
                    r'])\b'),


### PR DESCRIPTION

# Description

It's working at first version but broken during refactoring.

# Tests

Run some benchmark with evaluation, e.g. MMMU-Pro, and notice the score did increase.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
