### PR TITLE
Update compilation manager to account for data parallel

### DIFF
--- a/tpu_inference/runner/compilation_manager.py
+++ b/tpu_inference/runner/compilation_manager.py
@@ -127,13 +127,18 @@ class CompilationManager:
         for num_tokens in self.runner.num_tokens_paddings:
             hidden_size = self.runner.vllm_config.model_config.get_hidden_size(
             )
-            sharding = NamedSharding(self.runner.mesh, PartitionSpec())
+            sharding = NamedSharding(
+                self.runner.mesh,
+                PartitionSpec(ShardingAxisName.ATTN_DATA, None))
+            input_sharding = NamedSharding(
+                self.runner.mesh, PartitionSpec(ShardingAxisName.ATTN_DATA))
+
             dummy_multimodal_embeddings = self._create_dummy_tensor(
                 (num_tokens, hidden_size),
                 self.runner.vllm_config.model_config.dtype,
                 sharding=sharding)
-            dummy_input_ids = self._create_dummy_tensor((num_tokens, ),
-                                                        jnp.int32)
+            dummy_input_ids = self._create_dummy_tensor(
+                (num_tokens, ), jnp.int32, sharding=input_sharding)
 
             self._run_compilation(
                 "input_embeddings_merger",
@@ -317,10 +322,14 @@ class CompilationManager:
             if is_first_rank:
                 intermediate_tensors = None
             else:
+                sharding = NamedSharding(
+                    self.runner.mesh,
+                    PartitionSpec(ShardingAxisName.ATTN_DATA, None))
                 hidden_states = self._create_dummy_tensor(
-                    (num_tokens, hidden_size), jnp.bfloat16)
+                    (num_tokens, hidden_size), jnp.bfloat16, sharding=sharding)
                 residual = self._create_dummy_tensor((num_tokens, hidden_size),
-                                                     jnp.bfloat16)
+                                                     jnp.bfloat16,
+                                                     sharding=sharding)
                 intermediate_tensors = JaxIntermediateTensors(
                     tensors={
                         "hidden_states": hidden_states,
@@ -339,21 +348,30 @@ class CompilationManager:
         hidden_size = self.runner.model_config.get_hidden_size()
         dtype = self.runner.model_config.dtype
         for num_tokens in self.runner.num_tokens_paddings:
+            sharding = NamedSharding(
+                self.runner.mesh,
+                PartitionSpec(ShardingAxisName.ATTN_DATA, None))
+            input_sharding = NamedSharding(
+                self.runner.mesh, PartitionSpec(ShardingAxisName.ATTN_DATA))
+
             inputs_embeds = self._create_dummy_tensor(
-                (num_tokens, hidden_size), dtype)
+                (num_tokens, hidden_size), dtype, sharding=sharding)
             if self.runner.uses_mrope:
                 positions = self._create_dummy_tensor((3, num_tokens),
-                                                      jnp.int32)
+                                                      jnp.int32,
+                                                      sharding=sharding)
             else:
                 positions = self._create_dummy_tensor((num_tokens, ),
-                                                      jnp.int32)
+                                                      jnp.int32,
+                                                      sharding=input_sharding)
             is_first_rank = self.runner.is_first_rank
             is_last_rank = self.runner.is_last_rank
             if not is_first_rank:
                 hidden_states = self._create_dummy_tensor(
-                    (num_tokens, hidden_size), jnp.bfloat16)
+                    (num_tokens, hidden_size), jnp.bfloat16, sharding=sharding)
                 residual = self._create_dummy_tensor((num_tokens, hidden_size),
-                                                     jnp.bfloat16)
+                                                     jnp.bfloat16,
+                                                     sharding=sharding)
                 intermediate_tensors = JaxIntermediateTensors(
                     tensors={
                         "hidden_states": hidden_states,


### PR DESCRIPTION
# Description

PP e2e test case with DP enabled have been running into this error

```
(EngineCore pid=4080083) tpu_inference.core.sched.dp_scheduler.SchedulerWorkerError: Scheduler worker 1 error: '1-a6c166a1'
```

After investigation, this `SchedulerWorkerError: '1-afe910ea'` was a secondary symptom. The chain of failure was:
   1. Sharding Mismatch: CompilationManager warmed up the model using "replicated" tensors (data copied to all cores). Actual inference used "sharded" tensors (data split across cores for Data Parallelism).
   2. Forbidden Compilation: JAX saw the sharded data as a new input signature and tried to compile the model during inference. This hit the maybe_forbid_compile guard, crashing the model runner.
```
(EngineCore pid=564) RuntimeError: JAX compilation occurred but was forbidden in this context.
```
   3. KeyError: The crashed model runner returned empty/broken results. When the DPScheduler tried to find request IDs in those results for sub-workers, it hits `SchedulerWorkerError: '1-afe910ea'`.

# Tests

Passed all:
```
VLLM_XLA_CHECK_RECOMPILATION=1 pytest tests/e2e/test_pipeline_parallel.py
```
```
VLLM_XLA_CHECK_RECOMPILATION=1 pytest tests/e2e/test_data_parallel.py
```
```
MODEL_IMPL_TYPE=vllm NEW_MODEL_DESIGN=1 python examples/offline_inference.py --model meta-llama/Llama-3.1-8B-Instruct --pipeline-parallel-size 2 --no-async-scheduling --data-parallel-size 2
```

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
