### PR TITLE
[FP8][MoE] Move FP8 MoE weight requantization from CPU to TPU with cache clearing

### DIFF
--- a/tpu_inference/envs.py
+++ b/tpu_inference/envs.py
@@ -33,6 +33,7 @@ if TYPE_CHECKING:
     MOE_REQUANTIZE_BLOCK_SIZE: int | None = None
     MOE_REQUANTIZE_WEIGHT_DTYPE: str = "float8_e4m3fn"
     LAYOUT_Q_PROJ_AS_NDH: bool = False
+    MOE_REQUANTIZE_ON_TPU: bool = False
     USE_JAX_PROFILER_SERVER: bool = False
     JAX_PROFILER_SERVER_PORT: int = 9999
     USE_BATCHED_RPA_KERNEL: bool = False
@@ -226,6 +227,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # or DNH (model dim, q-heads, head dim), which is the default (False)
     "LAYOUT_Q_PROJ_AS_NDH":
     env_bool("LAYOUT_Q_PROJ_AS_NDH"),
+    # Requantize FP8 MoE weights on TPU
+    "MOE_REQUANTIZE_ON_TPU":
+    env_bool("MOE_REQUANTIZE_ON_TPU", default=False),
     "USE_JAX_PROFILER_SERVER":
     env_bool("USE_JAX_PROFILER_SERVER"),
     "JAX_PROFILER_SERVER_PORT":

--- a/tpu_inference/envs.py
+++ b/tpu_inference/envs.py
@@ -33,7 +33,6 @@ if TYPE_CHECKING:
     MOE_REQUANTIZE_BLOCK_SIZE: int | None = None
     MOE_REQUANTIZE_WEIGHT_DTYPE: str = "float8_e4m3fn"
     LAYOUT_Q_PROJ_AS_NDH: bool = False
-    MOE_REQUANTIZE_ON_TPU: bool = False
     USE_JAX_PROFILER_SERVER: bool = False
     JAX_PROFILER_SERVER_PORT: int = 9999
     USE_BATCHED_RPA_KERNEL: bool = False
@@ -227,9 +226,6 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # or DNH (model dim, q-heads, head dim), which is the default (False)
     "LAYOUT_Q_PROJ_AS_NDH":
     env_bool("LAYOUT_Q_PROJ_AS_NDH"),
-    # Requantize FP8 MoE weights on TPU
-    "MOE_REQUANTIZE_ON_TPU":
-    env_bool("MOE_REQUANTIZE_ON_TPU", default=False),
     "USE_JAX_PROFILER_SERVER":
     env_bool("USE_JAX_PROFILER_SERVER"),
     "JAX_PROFILER_SERVER_PORT":

--- a/tpu_inference/layers/common/process_weights/moe_weights.py
+++ b/tpu_inference/layers/common/process_weights/moe_weights.py
@@ -17,6 +17,7 @@ from functools import partial
 import jax
 import jax.numpy as jnp
 from jax.experimental.layout import Layout, with_layout_constraint
+from jax.experimental.shard_map import shard_map
 from jax.sharding import Mesh, NamedSharding, PartitionSpec
 from torchax.tensor import Tensor
 
@@ -412,15 +413,21 @@ def process_moe_weights(
     )
 
 
-def shard_moe_weights(
+def _get_moe_weight_shardings(
     weights: FusedMoEWeights,
     moe_backend: MoEBackend,
     mesh: Mesh,
 ) -> FusedMoEWeights:
+    """Build sharding specs for MoE weights based on the backend type.
+
+    Returns a FusedMoEWeights where each field is a NamedSharding.
+    Used by both shard_moe_weights (for device_put) and
+    process_fp8_moe_weights (for sharding constraints inside JIT).
+    """
     match moe_backend:
         case MoEBackend.FUSED_MOE | MoEBackend.GMM_EP:
             ep_sharding = NamedSharding(mesh, P(ShardingAxisName.EXPERT))
-            weight_shardings = FusedMoEWeights(
+            return FusedMoEWeights(
                 w13_weight=ep_sharding,
                 w13_weight_scale=ep_sharding,
                 w13_bias=ep_sharding,
@@ -437,7 +444,7 @@ def shard_moe_weights(
                 w2_weight_scale_p_spec = P()
             else:
                 w2_weight_scale_p_spec = P(None, ShardingAxisName.MLP_TENSOR)
-            weight_shardings = FusedMoEWeights(
+            return FusedMoEWeights(
                 w13_weight=NamedSharding(
                     mesh,
                     P(None, None, ShardingAxisName.MLP_TENSOR),
@@ -462,6 +469,15 @@ def shard_moe_weights(
                     P(None, None, None),
                 ),  # (num_experts, 1, out_dim)
             )
+
+
+def shard_moe_weights(
+    weights: FusedMoEWeights,
+    moe_backend: MoEBackend,
+    mesh: Mesh,
+) -> FusedMoEWeights:
+
+    weight_shardings = _get_moe_weight_shardings(weights, moe_backend, mesh)
 
     match moe_backend:
         case MoEBackend.FUSED_MOE:
@@ -491,6 +507,56 @@ def shard_moe_weights(
             weight = general_device_put(weight, sharding, layout=layout)
             setattr(weights, key, weight)
     return weights
+
+
+def shard_fp8_moe_weights_to_tpu(
+    weights: FusedMoEWeights,
+    mesh: Mesh,
+    source_mesh: Mesh | None = None,
+) -> FusedMoEWeights:
+    """Shard FP8 MoE weights onto TPU before requantization.
+
+    Transfers FP8 weights from CPU to TPU with expert-dimension sharding
+    so that the subsequent dequant/requant in process_fp8_moe_weights runs
+    on TPU in parallel across experts. This avoids OOM (no single TPU holds
+    the full unsharded weight) and is much faster than CPU requantization.
+
+    For meshes without an EXPERT axis (e.g. GMM_TP), falls back to the
+    first mesh axis to distribute experts across devices.
+
+    Args:
+        weights: FP8 MoE weights (typically on CPU).
+        mesh: The TPU device mesh for inference.
+        source_mesh: The mesh the weights currently reside on (e.g.
+            cpu_mesh()). None when weights are plain CPU arrays.
+
+    Returns:
+        FusedMoEWeights sharded across TPU devices.
+    """
+    expert_axis = ShardingAxisName.EXPERT
+    if isinstance(expert_axis, str):
+        if expert_axis in mesh.axis_names:
+            shard_axis = expert_axis
+        else:
+            shard_axis = mesh.axis_names[0]
+    else:
+        if all(a in mesh.axis_names for a in expert_axis):
+            shard_axis = expert_axis
+        else:
+            shard_axis = mesh.axis_names[0]
+    ep_sharding = NamedSharding(mesh, P(shard_axis))
+
+    result_fields = {}
+    for field in fields(FusedMoEWeights):
+        key = field.name
+        weight = getattr(weights, key)
+        if weight is not None:
+            result_fields[key] = general_device_put(weight,
+                                                    ep_sharding,
+                                                    source_mesh=source_mesh)
+        else:
+            result_fields[key] = None
+    return FusedMoEWeights(**result_fields)
 
 
 @jax.jit(static_argnames=(
@@ -530,34 +596,151 @@ def process_fp8_moe_weights(
         moe_logging_str += f" with block size {requant_block_size}"
     logger.info(moe_logging_str)
 
-    # Dequantize fp8 2d block quantized weights into fp32.
-    w13_weight = dequantize_tensor(w13_weight,
-                                   w13_weight_scale, (1, 2),
-                                   jnp.float32,
-                                   block_size=weight_block_size)
-    w2_weight = dequantize_tensor(w2_weight,
-                                  w2_weight_scale, (1, 2),
-                                  jnp.float32,
-                                  block_size=weight_block_size)
-
     w13_interleave = activation == "swigluoai"
     w13_reorder_size = get_mesh_shape_product(mesh,
                                               ShardingAxisName.MLP_TENSOR)
-    weights = quantize_moe_weights(
-        FusedMoEWeights(
-            w13_weight=w13_weight,
-            w13_weight_scale=None,
-            w13_bias=None,
-            w2_weight=w2_weight,
-            w2_weight_scale=None,
-            w2_bias=None,
-        ),
-        desired_quant_dtype,
-        requant_block_size,
+
+    if not envs.MOE_REQUANTIZE_ON_TPU:
+        # Default path: direct dequant → quantize → process (matches main branch).
+        w13_weight = dequantize_tensor(w13_weight,
+                                       w13_weight_scale, (1, 2),
+                                       jnp.float32,
+                                       block_size=weight_block_size)
+        w2_weight = dequantize_tensor(w2_weight,
+                                      w2_weight_scale, (1, 2),
+                                      jnp.float32,
+                                      block_size=weight_block_size)
+
+        weights = quantize_moe_weights(
+            FusedMoEWeights(
+                w13_weight=w13_weight,
+                w13_weight_scale=None,
+                w13_bias=None,
+                w2_weight=w2_weight,
+                w2_weight_scale=None,
+                w2_bias=None,
+            ),
+            desired_quant_dtype,
+            requant_block_size,
+        )
+        return process_moe_weights(
+            weights,
+            moe_backend=moe_backend,
+            w13_reorder_size=w13_reorder_size,
+            w13_interleave=w13_interleave,
+        )
+
+    # TPU path: shard_map + lax.scan for lower XLA reservation.
+
+    # Pre-compute pad widths and block sizes for requantization.
+    _, orig_hidden_size, orig_intermediate_size = w2_weight.shape
+    if requant_block_size is None:
+        w13_block_size = w13_weight.shape[-1]
+        w2_block_size = w2_weight.shape[-1]
+    else:
+        w13_block_size = w2_block_size = requant_block_size
+    hidden_size = align_to(orig_hidden_size, w13_block_size)
+    intermediate_size = align_to(orig_intermediate_size, w2_block_size)
+    w13_pad = ((0, 2 * (intermediate_size - orig_intermediate_size)),
+               (0, hidden_size - orig_hidden_size))
+    w2_pad = ((0, hidden_size - orig_hidden_size),
+              (0, intermediate_size - orig_intermediate_size))
+
+    # Determine which mesh axis the expert dim is sharded across.
+    expert_axis = ShardingAxisName.EXPERT
+    if isinstance(expert_axis, str):
+        if expert_axis in mesh.axis_names:
+            shard_axis = expert_axis
+        else:
+            shard_axis = mesh.axis_names[0]
+    else:
+        if all(a in mesh.axis_names for a in expert_axis):
+            shard_axis = expert_axis
+        else:
+            shard_axis = mesh.axis_names[0]
+
+    scan_batch_size = 1
+    w13_pad_3d = ((0, 0), ) + w13_pad
+    w2_pad_3d = ((0, 0), ) + w2_pad
+
+    expert_p = P(shard_axis)
+
+    def _requant_and_process_local(w13, w13_scale, w2, w2_scale):
+        """Per-device requant + process. Shapes are local [local_experts, ...]."""
+        n_local = w13.shape[0]
+        n_batches = n_local // scan_batch_size
+
+        def _requant_expert_batch(carry, batch_inputs):
+            w13_b, w13_s_b, w2_b, w2_s_b = batch_inputs
+            w13_fp32 = dequantize_tensor(w13_b,
+                                         w13_s_b, (1, 2),
+                                         jnp.float32,
+                                         block_size=weight_block_size)
+            w2_fp32 = dequantize_tensor(w2_b,
+                                        w2_s_b, (1, 2),
+                                        jnp.float32,
+                                        block_size=weight_block_size)
+            w13_fp32 = jnp.pad(w13_fp32, w13_pad_3d)
+            w2_fp32 = jnp.pad(w2_fp32, w2_pad_3d)
+            w13_q, w13_s_new = quantize_tensor(desired_quant_dtype, w13_fp32,
+                                               2, w13_block_size)
+            w2_q, w2_s_new = quantize_tensor(desired_quant_dtype, w2_fp32, 2,
+                                             w2_block_size)
+            return carry, (w13_q, w13_s_new, w2_q, w2_s_new)
+
+        def _reshape_to_batches(x):
+            return x.reshape(n_batches, scan_batch_size, *x.shape[1:])
+
+        def _reshape_from_batches(x):
+            return x.reshape(n_local, *x.shape[2:])
+
+        xs = jax.tree.map(_reshape_to_batches, (w13, w13_scale, w2, w2_scale))
+        _, (w13_q, w13_s, w2_q, w2_s) = jax.lax.scan(_requant_expert_batch,
+                                                     init=None,
+                                                     xs=xs)
+        w13_q, w13_s, w2_q, w2_s = jax.tree.map(_reshape_from_batches,
+                                                (w13_q, w13_s, w2_q, w2_s))
+
+        out = process_moe_weights(
+            FusedMoEWeights(
+                w13_weight=w13_q,
+                w13_weight_scale=w13_s,
+                w13_bias=None,
+                w2_weight=w2_q,
+                w2_weight_scale=w2_s,
+                w2_bias=None,
+            ),
+            moe_backend=moe_backend,
+            w13_reorder_size=w13_reorder_size,
+            w13_interleave=w13_interleave,
+        )
+        return (out.w13_weight, out.w13_weight_scale, out.w2_weight,
+                out.w2_weight_scale)
+
+    w13_q, w13_s, w2_q, w2_s = shard_map(
+        _requant_and_process_local,
+        mesh=mesh,
+        in_specs=(expert_p, expert_p, expert_p, expert_p),
+        out_specs=(expert_p, expert_p, expert_p, expert_p),
+        check_rep=False,
+    )(w13_weight, w13_weight_scale, w2_weight, w2_weight_scale)
+    out = FusedMoEWeights(
+        w13_weight=w13_q,
+        w13_weight_scale=w13_s,
+        w13_bias=None,
+        w2_weight=w2_q,
+        w2_weight_scale=w2_s,
+        w2_bias=None,
     )
-    return process_moe_weights(
-        weights,
-        moe_backend=moe_backend,
-        w13_reorder_size=w13_reorder_size,
-        w13_interleave=w13_interleave,
-    )
+
+    # Apply sharding constraints so the JIT output matches what
+    # shard_moe_weights expects.
+    target_shardings = _get_moe_weight_shardings(out, moe_backend, mesh)
+    for field in fields(FusedMoEWeights):
+        key = field.name
+        weight = getattr(out, key)
+        if weight is not None:
+            sharding = getattr(target_shardings, key)
+            setattr(out, key,
+                    jax.lax.with_sharding_constraint(weight, sharding))
+    return out

--- a/tpu_inference/layers/common/process_weights/moe_weights.py
+++ b/tpu_inference/layers/common/process_weights/moe_weights.py
@@ -600,36 +600,6 @@ def process_fp8_moe_weights(
     w13_reorder_size = get_mesh_shape_product(mesh,
                                               ShardingAxisName.MLP_TENSOR)
 
-    if not envs.MOE_REQUANTIZE_ON_TPU:
-        # Default path: direct dequant → quantize → process (matches main branch).
-        w13_weight = dequantize_tensor(w13_weight,
-                                       w13_weight_scale, (1, 2),
-                                       jnp.float32,
-                                       block_size=weight_block_size)
-        w2_weight = dequantize_tensor(w2_weight,
-                                      w2_weight_scale, (1, 2),
-                                      jnp.float32,
-                                      block_size=weight_block_size)
-
-        weights = quantize_moe_weights(
-            FusedMoEWeights(
-                w13_weight=w13_weight,
-                w13_weight_scale=None,
-                w13_bias=None,
-                w2_weight=w2_weight,
-                w2_weight_scale=None,
-                w2_bias=None,
-            ),
-            desired_quant_dtype,
-            requant_block_size,
-        )
-        return process_moe_weights(
-            weights,
-            moe_backend=moe_backend,
-            w13_reorder_size=w13_reorder_size,
-            w13_interleave=w13_interleave,
-        )
-
     # TPU path: shard_map + lax.scan for lower XLA reservation.
 
     # Pre-compute pad widths and block sizes for requantization.

--- a/tpu_inference/layers/jax/quantization/fp8.py
+++ b/tpu_inference/layers/jax/quantization/fp8.py
@@ -23,12 +23,13 @@ import torch
 from flax import nnx
 from jax.sharding import PartitionSpec as P
 
+import tpu_inference.envs as envs
 from tpu_inference.layers.common.linear import sharded_quantized_batched_matmul
 from tpu_inference.layers.common.moe import MoEBackend, moe_apply
 from tpu_inference.layers.common.process_weights.linear_weights import \
     shard_linear_weights
 from tpu_inference.layers.common.process_weights.moe_weights import (
-    FusedMoEWeights, process_fp8_moe_weights)
+    FusedMoEWeights, process_fp8_moe_weights, shard_fp8_moe_weights_to_tpu)
 from tpu_inference.layers.common.quantization import fp8 as common_fp8
 from tpu_inference.layers.common.utils import cpu_mesh, cpu_mesh_context
 from tpu_inference.layers.jax import JaxModule
@@ -499,6 +500,7 @@ class Fp8FusedMoEMethod(QuantizeMethodBase):
                 # more than once. We only want to process the weights once all of them are loaded.
                 return False
 
+            # Concatenate expert weights on CPU (fast, memory-efficient).
             with cpu_mesh_context():
                 w_gate = jnp.concatenate(
                     layer.kernel_gating_EDF._weights_to_load, axis=0)
@@ -522,23 +524,42 @@ class Fp8FusedMoEMethod(QuantizeMethodBase):
                 w13_weight = jnp.concatenate([w_gate, w_up], axis=1)
                 w13_weight_scale = jnp.concatenate([s_gate, s_up], axis=1)
 
-                # TODO (jacobplatin): we should support bias
-                input_weights = FusedMoEWeights(
-                    w13_weight=w13_weight,
-                    w13_weight_scale=w13_weight_scale,
-                    w13_bias=None,
-                    w2_weight=w2_weight,
-                    w2_weight_scale=w2_weight_scale,
-                    w2_bias=None)
+            weight_block_size = None
+            if self.weight_block_size is not None:
+                weight_block_size = tuple(self.weight_block_size)
+
+            # TODO (jacobplatin): we should support bias
+            input_weights = FusedMoEWeights(w13_weight=w13_weight,
+                                            w13_weight_scale=w13_weight_scale,
+                                            w13_bias=None,
+                                            w2_weight=w2_weight,
+                                            w2_weight_scale=w2_weight_scale,
+                                            w2_bias=None)
+
+            if envs.MOE_REQUANTIZE_ON_TPU:
+                # Shard FP8 weights to TPU before requantization so that
+                # process_fp8_moe_weights runs on TPU instead of CPU.
+                input_weights = shard_fp8_moe_weights_to_tpu(
+                    input_weights, layer.mesh, source_mesh=cpu_mesh())
 
                 weights = process_fp8_moe_weights(
                     input_weights,
                     moe_backend=layer.moe_backend,
                     mesh=layer.mesh,
                     activation=layer.activation,
-                    # Source block size should be inferred from scale shape
-                    weight_block_size=None,
+                    weight_block_size=weight_block_size,
                 )
+            else:
+                # Weights are on CPU; run under cpu_mesh_context
+                # so JIT targets CPU devices.
+                with cpu_mesh_context():
+                    weights = process_fp8_moe_weights(
+                        input_weights,
+                        moe_backend=layer.moe_backend,
+                        mesh=layer.mesh,
+                        activation=layer.activation,
+                        weight_block_size=weight_block_size,
+                    )
 
             del layer.kernel_gating_EDF
             del layer.kernel_up_proj_EDF

--- a/tpu_inference/layers/jax/quantization/fp8.py
+++ b/tpu_inference/layers/jax/quantization/fp8.py
@@ -23,7 +23,6 @@ import torch
 from flax import nnx
 from jax.sharding import PartitionSpec as P
 
-import tpu_inference.envs as envs
 from tpu_inference.layers.common.linear import sharded_quantized_batched_matmul
 from tpu_inference.layers.common.moe import MoEBackend, moe_apply
 from tpu_inference.layers.common.process_weights.linear_weights import \
@@ -536,30 +535,18 @@ class Fp8FusedMoEMethod(QuantizeMethodBase):
                                             w2_weight_scale=w2_weight_scale,
                                             w2_bias=None)
 
-            if envs.MOE_REQUANTIZE_ON_TPU:
-                # Shard FP8 weights to TPU before requantization so that
-                # process_fp8_moe_weights runs on TPU instead of CPU.
-                input_weights = shard_fp8_moe_weights_to_tpu(
-                    input_weights, layer.mesh, source_mesh=cpu_mesh())
+            # Shard FP8 weights to TPU before requantization so that
+            # process_fp8_moe_weights runs on TPU instead of CPU.
+            input_weights = shard_fp8_moe_weights_to_tpu(
+                input_weights, layer.mesh, source_mesh=cpu_mesh())
 
-                weights = process_fp8_moe_weights(
-                    input_weights,
-                    moe_backend=layer.moe_backend,
-                    mesh=layer.mesh,
-                    activation=layer.activation,
-                    weight_block_size=weight_block_size,
-                )
-            else:
-                # Weights are on CPU; run under cpu_mesh_context
-                # so JIT targets CPU devices.
-                with cpu_mesh_context():
-                    weights = process_fp8_moe_weights(
-                        input_weights,
-                        moe_backend=layer.moe_backend,
-                        mesh=layer.mesh,
-                        activation=layer.activation,
-                        weight_block_size=weight_block_size,
-                    )
+            weights = process_fp8_moe_weights(
+                input_weights,
+                moe_backend=layer.moe_backend,
+                mesh=layer.mesh,
+                activation=layer.activation,
+                weight_block_size=weight_block_size,
+            )
 
             del layer.kernel_gating_EDF
             del layer.kernel_up_proj_EDF

--- a/tpu_inference/layers/vllm/quantization/fp8.py
+++ b/tpu_inference/layers/vllm/quantization/fp8.py
@@ -31,11 +31,13 @@ from vllm.model_executor.layers.quantization.base_config import \
 from vllm.model_executor.layers.quantization.utils.quant_utils import \
     is_layer_skipped
 
+import tpu_inference.envs as envs
 from tpu_inference.layers.common.moe import MoEBackend
 from tpu_inference.layers.common.process_weights.linear_weights import (
     shard_linear_weights, to_parameter_list)
 from tpu_inference.layers.common.process_weights.moe_weights import (
-    FusedMoEWeights, process_fp8_moe_weights, shard_moe_weights)
+    FusedMoEWeights, process_fp8_moe_weights, shard_fp8_moe_weights_to_tpu,
+    shard_moe_weights)
 from tpu_inference.layers.common.quant_methods import FP8
 from tpu_inference.layers.common.quantization import fp8 as common_fp8
 from tpu_inference.layers.vllm.interface.moe import (
@@ -260,6 +262,10 @@ class VllmFp8MoEMethod(vllm_fp8.Fp8MoEMethod):
         if self.weight_block_size is not None:
             weight_block_size = tuple(self.weight_block_size)
 
+        if envs.MOE_REQUANTIZE_ON_TPU:
+            input_weights = shard_fp8_moe_weights_to_tpu(
+                input_weights, self.mesh)
+
         weights = process_fp8_moe_weights(
             input_weights,
             moe_backend=self.moe_backend,
@@ -268,6 +274,7 @@ class VllmFp8MoEMethod(vllm_fp8.Fp8MoEMethod):
             # Convert to tuple so jax jit can hash it
             weight_block_size=weight_block_size,
         )
+
         weights = torch_view(
             shard_moe_weights(weights, self.moe_backend, self.mesh))
 

--- a/tpu_inference/layers/vllm/quantization/fp8.py
+++ b/tpu_inference/layers/vllm/quantization/fp8.py
@@ -31,7 +31,6 @@ from vllm.model_executor.layers.quantization.base_config import \
 from vllm.model_executor.layers.quantization.utils.quant_utils import \
     is_layer_skipped
 
-import tpu_inference.envs as envs
 from tpu_inference.layers.common.moe import MoEBackend
 from tpu_inference.layers.common.process_weights.linear_weights import (
     shard_linear_weights, to_parameter_list)
@@ -262,9 +261,8 @@ class VllmFp8MoEMethod(vllm_fp8.Fp8MoEMethod):
         if self.weight_block_size is not None:
             weight_block_size = tuple(self.weight_block_size)
 
-        if envs.MOE_REQUANTIZE_ON_TPU:
-            input_weights = shard_fp8_moe_weights_to_tpu(
-                input_weights, self.mesh)
+        input_weights = shard_fp8_moe_weights_to_tpu(
+            input_weights, self.mesh)
 
         weights = process_fp8_moe_weights(
             input_weights,

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -604,12 +604,9 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                                     and not disable_mm_from_limits)
 
         # Clear JIT compilation caches from weight loading to free XLA
-        # program reservations (bytes_reserved) on TPU HBM. This is
-        # especially important when MOE_REQUANTIZE_ON_TPU is enabled,
-        # as the requantization JIT programs reserve significant HBM.
-        if envs.MOE_REQUANTIZE_ON_TPU:
-            jax.clear_caches()
-            logger.info("Cleared JIT caches after weight loading")
+        # program reservations (bytes_reserved) on TPU HBM.
+        jax.clear_caches()
+        logger.info("Cleared JIT caches after weight loading")
 
         logger.info(f"Init model | "
                     f"hbm={common_utils.hbm_usage_gb(self.devices)}GiB")

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -603,6 +603,14 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                                                 "architectures")
                                     and not disable_mm_from_limits)
 
+        # Clear JIT compilation caches from weight loading to free XLA
+        # program reservations (bytes_reserved) on TPU HBM. This is
+        # especially important when MOE_REQUANTIZE_ON_TPU is enabled,
+        # as the requantization JIT programs reserve significant HBM.
+        if envs.MOE_REQUANTIZE_ON_TPU:
+            jax.clear_caches()
+            logger.info("Cleared JIT caches after weight loading")
+
         logger.info(f"Init model | "
                     f"hbm={common_utils.hbm_usage_gb(self.devices)}GiB")
 


### PR DESCRIPTION
## Summary

Moves FP8 MoE weight requantization from CPU to TPU by default, with a fix for the HBM regression that caused the original feature to be reverted.

**Root cause of the revert:** @jax.jit-compiled requantization programs reserve HBM (bytes_reserved) for XLA program buffers. These reservations persisted after weight loading completed, permanently consuming HBM that would otherwise be allocated to KV cache.

**Fix:** Call jax.clear_caches() in tpu_runner.py after model loading completes. This frees XLA program reservations from the requantization JIT, since those compiled programs are never needed again during inference.

**Update (v2):** Removed the MOE_REQUANTIZE_ON_TPU env flag and CPU fallback path. TPU requantization is now always enabled, no branching logic, no config needed.

## Changes

1. `moe_weights.py`: TPU requantization path using shard_map + lax.scan (replaces the old CPU dequant/quantize path)
2. `jax/quantization/fp8.py`: Shard FP8 weights to TPU before calling process_fp8_moe_weights
3. `vllm/quantization/fp8.py`: Same for vLLM code path
4. `tpu_runner.py`: Unconditionally call jax.clear_caches() after weight loading

## Validation (Qwen3-30B-A3B-FP8, v6e-8, TP=8)

### Memory metrics

| Metric | Main branch | With TPU requant + clear |
|---|---|---|
| HBM/chip | 4.46 GiB | 4.46 GiB |
| KV cache tokens | 1,033,600 | 1,033,664 (+64) |

Zero HBM regression with clear_caches.

### Loading time (warm-start)

| Config | Time |
|---|---|
| Main (CPU requant) | 25.30s |
| TPU requant + clear | ~18-19s |

~25% loading speedup.

### Test results

299 passed, 52 skipped, 0 failures (jax fp8, jax moe, vllm moe, vllm fp8 test suites).

## Notes

- jax.clear_caches() clears all JIT compilation caches. At the call site (after weight loading, before inference compilation), only loading-related JIT artifacts exist. Inference functions get compiled on first use regardless.
- Large model validation (Qwen3-235B, DeepSeek-R1) requires v7x access. Qwen3-235B OOMs on v6e-8 on main branch (pre-existing).