### PR TITLE
Added more robust patch for vllm#3292

### DIFF
--- a/tests/layers/vllm/test_fp8.py
+++ b/tests/layers/vllm/test_fp8.py
@@ -40,6 +40,8 @@ from tests.layers.common import utils as test_utils
 from tpu_inference.layers.common.moe import MoEBackend
 from tpu_inference.layers.common.quantization.configs import QuantLinearConfig
 from tpu_inference.layers.vllm.quantization import get_tpu_quantization_config
+from tpu_inference.layers.vllm.quantization.configs import \
+    VllmQuantLinearConfig
 from tpu_inference.layers.vllm.quantization.fp8 import (VllmFp8Config,
                                                         VllmFp8LinearMethod,
                                                         VllmFp8MoEMethod)
@@ -582,3 +584,29 @@ def test_unaligned_block_quantization(model, input_size, output_size):
     initialize_layer_weights(linear_layer)
     ref_output, layer_output = return_ref_and_layer_output(linear_layer)
     torch.testing.assert_close(ref_output, layer_output)
+
+
+def test_fp8_init():
+    """Verify that vLLM patches are working for __init__ post vLLM PR: https://github.com/vllm-project/vllm/pull/32929."""
+    mesh = test_utils.get_spmd_mesh(1)
+    engine_args = EngineArgs(model=MODELS[0])
+    vllm_config = engine_args.create_engine_config()
+    vllm_config.model_config.dtype = torch.bfloat16
+    quant_config = get_tpu_quantization_config(vllm_config, mesh)
+
+    # VllmQuantLinearConfig requires a layer to initialize.
+    with set_current_vllm_config(vllm_config):
+        dummy_layer = RowParallelLinear(
+            input_size=128,
+            output_size=128,
+            bias=False,
+            params_dtype=torch.bfloat16,
+            quant_config=quant_config,
+        )
+    linear_config = VllmQuantLinearConfig(vllm_config, mesh, dummy_layer)
+
+    with set_current_vllm_config(vllm_config):
+        method = VllmFp8LinearMethod(quant_config, linear_config)
+
+    assert method.fp8_linear is None, "fp8_linear is now set to None"
+    assert method.use_marlin is True, "use_marlin is set to True (previous status quo)"

--- a/tpu_inference/layers/vllm/quantization/fp8.py
+++ b/tpu_inference/layers/vllm/quantization/fp8.py
@@ -101,14 +101,16 @@ class VllmFp8LinearMethod(vllm_fp8.Fp8LinearMethod,
         quant_config: VllmFp8Config,
         linear_config: VllmQuantLinearConfig,
     ):
-        from vllm.platforms import PlatformEnum, current_platform
 
-        # init_fp8_linear_kernel is called by super().__init__
-        # and needs a supported backend temporarily.
-        original_platform = current_platform._enum
-        current_platform._enum = PlatformEnum.CPU
+        # Per https://github.com/vllm-project/vllm/pull/32929,
+        # init_fp8_linear_kernel is now called by super().__init__
+        # but does not support TPU backends as expected.
+        # use_marlin was also changed to be determined via isinstance(self.fp8_linear, MarlinFP8ScaledMMLinearKernel).
+        # We need to monkeypatch init_fp8_linear_kernel and explicitly set use_marlin = True
+        # in order to bypass using native vLLM's vllm/vllm/model_executor/layers/quantization/utils/quant_utils.py:scaled_quantize.
+        vllm_fp8.init_fp8_linear_kernel = lambda *args, **kwargs: None
         super().__init__(quant_config)
-        current_platform._enum = original_platform
+        self.use_marlin = True
 
         self.linear_config = linear_config
         if self.linear_config.enable_quantized_matmul_kernel and not self.linear_config.requant_block_size:


### PR DESCRIPTION
# Description
 Added more robust patch to fix VllmFp8LinearMethod post [vllm#32929](https://github.com/vllm-project/vllm/pull/32929). This is needed because post vllm#32929,  [init_fp8_linear_kernel](https://github.com/vllm-project/vllm/pull/32929/changes#diff-5511bfcc9c53f7d96517ad43e4087f6777bef21302da983f42cafae40a866644R300) is always triggered and [use_marlin](https://github.com/vllm-project/vllm/pull/32929/changes#diff-5511bfcc9c53f7d96517ad43e4087f6777bef21302da983f42cafae40a866644R306) became changed from False to True which triggers native vLLM quanitzation methods and breaks our TPU flow.

# Tests

Added test_fp8 to check that init is correctly performed.
Running build kite tests.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
