### PR TITLE
Add the missing TPU_VERSION var to env to tests

### DIFF
--- a/.buildkite/pipeline_jax.yml
+++ b/.buildkite/pipeline_jax.yml
@@ -170,6 +170,7 @@ steps:
         soft_fail: true
         env:
           USE_PREBUILT_IMAGE: "1"
+          TPU_VERSION: "${TPU_VERSION:-tpu6e}"
         agents:
           queue: ${TPU_QUEUE_SINGLE:-tpu_v6e_queue}
         commands:
@@ -196,6 +197,7 @@ steps:
         soft_fail: true
         env:
           USE_PREBUILT_IMAGE: "1"
+          TPU_VERSION: "${TPU_VERSION:-tpu6e}"
         agents:
           queue: ${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}
         commands:
@@ -255,6 +257,7 @@ steps:
         soft_fail: true
         env:
           USE_PREBUILT_IMAGE: "1"
+          TPU_VERSION: "${TPU_VERSION:-tpu6e}"
           TEST_LORA_TP: "True"
           VLLM_LOG_LEVEL: "INFO"
         agents:
@@ -283,6 +286,7 @@ steps:
         soft_fail: true
         env:
           USE_PREBUILT_IMAGE: "1"
+          TPU_VERSION: "${TPU_VERSION:-tpu6e}"
           USE_V6E8_QUEUE: "True"
           VLLM_LOG_LEVEL: "INFO"
         agents:
@@ -497,6 +501,7 @@ steps:
         soft_fail: true
         env:
           USE_PREBUILT_IMAGE: "1"
+          TPU_VERSION: "${TPU_VERSION:-tpu6e}"
         agents:
           queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}" # Using a queue with more devices for distributed tests
         commands:


### PR DESCRIPTION
Add the TPU_VERSION as env var to the tests setup

The v6e and v7x now has separate image build workflow and artifacts now. Due to the fact that the TPU_VERSION is missing for these 5 tests, the v7x tests will try to pull the v6e(fallback) image and these tests become flaky:
- It may succeed when there is a v6e test run happened ahead for the same commit hash, even though it is using the v6e image for test.
- It may fail when the v7x test run happened first and there is no -v6e image

fixes b/496287779

# Tests

Using the CI tests to verify the test fix will work.

# Checklist

- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
