### PR TITLE
Enable Qwen3.5 with TP=8

### DIFF
--- a/tests/runner/test_kv_cache_manager.py
+++ b/tests/runner/test_kv_cache_manager.py
@@ -784,8 +784,7 @@ class TestKVCacheManager:
     def test_get_kv_cache_spec_hybrid_mamba_cache_config_updates(self):
         self.runner.cache_config.block_size = 1056
         self.runner.kv_cache_dtype = torch.float8_e4m3fn
-        self.runner.max_model_len = 9216
-        self.runner.cache_config.mamba_page_size_padded = 2048
+        self.runner.cache_config.mamba_page_size_padded = 533504
 
         class DummyMamba(MambaBase):
 
@@ -816,38 +815,24 @@ class TestKVCacheManager:
         }
         self.runner.vllm_config.compilation_config.static_forward_context = layers
 
-
-        with patch('tpu_inference.runner.kv_cache_manager.get_layers_from_vllm_config', return_value=layers), \
-             patch('tpu_inference.runner.kv_cache_manager.common_utils.get_mesh_shape_product', return_value=1), \
-             patch.object(self.runner.model_config, 'get_total_num_kv_heads', return_value=2), \
-             patch.object(self.runner.model_config, 'get_head_size', return_value=256), \
-             patch('tpu_inference.kernels.ragged_paged_attention.v3.kernel.get_tpu_version', return_value=7):
+        with patch(
+                'tpu_inference.runner.kv_cache_manager.get_layers_from_vllm_config',
+                return_value=layers):
             kv_cache_spec = self.runner.get_kv_cache_spec()
 
-            # Verify the block size was aligned and mamba page size was unified with full attention.
-            assert self.runner.cache_config.block_size == 2048
-            assert self.runner.cache_config.mamba_page_size_padded == 2097152
+            # Verify the mamba page size was unified with full attention.
+            assert self.runner.cache_config.mamba_page_size_padded == 1081344
 
-            # The layer specs should reflect the cache cconfig updates
-            attn_spec = kv_cache_spec['full_attn']
-            assert isinstance(attn_spec, FullAttentionSpec)
-            assert attn_spec.block_size == 2048
+            # The layer spec should reflect the cache config update.
             mamba_spec = kv_cache_spec['linear_attn']
             assert isinstance(mamba_spec, MambaSpec)
-            assert mamba_spec.page_size_padded == 2097152
+            assert mamba_spec.page_size_padded == 1081344
 
     def test_get_kv_cache_spec_pure_attention_no_cache_config_updates(self):
-        mock_attn = MagicMock(spec=Attention)
-        mock_attn.attn_type = AttentionType.DECODER
-        mock_attn.num_kv_heads = 2
-        mock_attn.head_size = 256
-        mock_attn.sliding_window = None
-        mock_attn.kv_sharing_target_layer_name = None
+        mock_attn = MagicMock(spec=MambaBase)
         layers = {'layer.0': mock_attn}
         self.runner.vllm_config.compilation_config.static_forward_context = layers
 
         with patch('tpu_inference.runner.kv_cache_manager.get_layers_from_vllm_config', return_value=layers), \
-             patch.object(self.runner.kv_cache_manager, 'align_block_size_for_rpa') as mock_align, \
              patch.object(self.runner.kv_cache_manager, 'update_mamba_page_size_padded') as mock_update:
-            mock_align.assert_not_called()
             mock_update.assert_not_called()

--- a/tpu_inference/kernels/ragged_paged_attention/v3/kernel.py
+++ b/tpu_inference/kernels/ragged_paged_attention/v3/kernel.py
@@ -1468,42 +1468,6 @@ def static_validate_inputs(
     del v_scale
 
 
-def get_bkv_sz(kv_dtype,
-               actual_num_kv_heads,
-               head_dim,
-               page_size,
-               pages_per_seq,
-               *,
-               case: RpaCase = RpaCase.MIXED):
-    """Get bkv_sz by some heuristic formulas.
-
-    Note the default size is not necessarily optimal.
-    """
-    tpu_version = get_tpu_version()
-    kv_packing = get_dtype_packing(kv_dtype)
-    num_kv_heads_x2 = next_power_of_2(
-        align_to(actual_num_kv_heads * 2, kv_packing))
-    head_dim = align_to(head_dim, 128)
-    max_kv = pages_per_seq * page_size
-    min_bkv_sz_to_peak = (16 * 1024 * 1024 * kv_packing // 4 // head_dim //
-                          num_kv_heads_x2)
-
-    match tpu_version:
-        case 5 | 6:
-            bkv_sz_limit = 1024
-        case 7:
-            bkv_sz_limit = 2048
-        case _:
-            raise NotImplementedError(f"Unsupported {tpu_version=}.")
-
-    if case == RpaCase.DECODE:
-        bkv_sz = min(min_bkv_sz_to_peak, max_kv)
-    else:
-        bkv_sz = min(bkv_sz_limit, max_kv)
-
-    return max(page_size, bkv_sz)
-
-
 def get_default_block_sizes(
     q_dtype,
     kv_dtype,
@@ -1540,35 +1504,33 @@ def get_default_block_sizes(
         case 5 | 6:
             if case == RpaCase.DECODE:
                 bq_sz = 1
+                bkv_sz = min(min_bkv_sz_to_peak, max_kv)
                 bq_csz = 1
                 bkv_csz = min(min_bkv_sz_to_peak, max_kv)
             else:
                 bq_sz = min(1024 // num_q_heads_per_kv_head, max_q // 2)
+                bkv_sz = min(1024, max_kv)
                 bq_csz = min(512 // num_q_heads_per_kv_head, max_q)
                 bkv_csz = min(512, align_to(max_kv // 2, page_size))
         case 7:
             if case == RpaCase.DECODE:
                 bq_sz = 1
+                bkv_sz = min(min_bkv_sz_to_peak, max_kv)
                 bq_csz = 1
                 bkv_csz = min(min_bkv_sz_to_peak, max_kv)
             else:
                 bq_sz = min(2048 // num_q_heads_per_kv_head, max_q // 2)
+                bkv_sz = min(2048, max_kv)
                 bq_csz = min(1024 // num_q_heads_per_kv_head, max_q // 2)
                 bkv_csz = min(512, align_to(max_kv // 2, page_size))
         case _:
             raise NotImplementedError(f"Unsupported {tpu_version=}.")
 
-    bkv_sz = get_bkv_sz(kv_dtype,
-                        actual_num_kv_heads,
-                        head_dim,
-                        page_size,
-                        pages_per_seq,
-                        case=case)
     return {
         "bq_sz": max(1, bq_sz),
-        "bkv_sz": bkv_sz,
+        "bkv_sz": align_to(bkv_sz, page_size),
         "bq_csz": max(1, bq_csz),
-        "bkv_csz": max(page_size, bkv_csz),
+        "bkv_csz": align_to(bkv_csz, page_size),
     }
 
 

--- a/tpu_inference/runner/kv_cache_manager.py
+++ b/tpu_inference/runner/kv_cache_manager.py
@@ -32,8 +32,6 @@ from vllm.v1.kv_cache_interface import (FullAttentionSpec, KVCacheConfig,
 
 from tpu_inference import utils
 from tpu_inference import utils as common_utils
-from tpu_inference.kernels.ragged_paged_attention.v3.kernel import (RpaCase,
-                                                                    get_bkv_sz)
 from tpu_inference.layers.common.sharding import ShardingAxisName
 from tpu_inference.logger import init_logger
 from tpu_inference.runner import utils as runner_utils
@@ -131,50 +129,6 @@ class KVCacheManager:
                      page_size_bytes)
         self.runner.cache_config.mamba_page_size_padded = page_size_bytes
 
-    def align_block_size_for_rpa(self) -> None:
-        """Update cache config block size for RPA kernel.
-
-        Checks if KV prefetch size(`bkv_sz`) used in the RPA kernel is aligned
-        to `cache_config.block_size`.
-        If not, updates the block size to be the minimum `bkv_sz` value that can
-        be computed by the kernel, to ensure alignment.
-        This is a kernel requirement (page_size and block_size are equivalent).
-        (https://github.com/vllm-project/tpu-inference/blob/30f637e345338e0b1cdb71cf5aa8f404d460e27d/tpu_inference/kernels/ragged_paged_attention/v3/kernel.py#L374)
-        """
-        kv_dtype = t2j_dtype(self.runner.kv_cache_dtype)
-        model_cnt = common_utils.get_mesh_shape_product(
-            self.runner.mesh, ShardingAxisName.ATTN_HEAD)
-        global_kv_heads = self.runner.model_config.get_total_num_kv_heads()
-        actual_num_kv_heads = common_utils.get_padded_num_heads(
-            global_kv_heads, model_cnt) // model_cnt
-        head_dim = common_utils.get_padded_head_dim(
-            self.runner.model_config.get_head_size())
-
-        def get_updated_block_size(page_size):
-            pages_per_seq = cdiv(self.runner.max_model_len, page_size)
-            bkv_sizes = [
-                get_bkv_sz(kv_dtype,
-                           actual_num_kv_heads,
-                           head_dim,
-                           page_size,
-                           pages_per_seq,
-                           case=case)
-                for case in (RpaCase.MIXED, RpaCase.DECODE)
-            ]
-
-            if any(sz % page_size != 0 for sz in bkv_sizes):
-                return min(bkv_sizes)
-            return page_size
-
-        block_size = self.runner.cache_config.block_size
-        new_block_size = get_updated_block_size(block_size)
-
-        if new_block_size != block_size:
-            logger.info("Setting block size in cache config to %d",
-                        new_block_size)
-            assert get_updated_block_size(new_block_size) == new_block_size
-            self.runner.cache_config.block_size = new_block_size
-
     def get_kv_cache_spec(self):
         # TODO(xiang): this hack tricks engine core to init successfully
         block_size = self.runner.cache_config.block_size
@@ -271,17 +225,10 @@ class KVCacheManager:
                 isinstance(attn_module, MambaBase)
                 for attn_module in layers.values())
 
-            # Cache config updates for hybrid attention models with mamba and
+            # Cache config update for hybrid attention models with mamba and
             # full attention layers.
             is_hybrid_mamba_attention = has_attention and has_mamba
             if is_hybrid_mamba_attention:
-                # vLLM overrides the block size in cache config such that the
-                # page size of the full attention layers is >= that of mamba
-                # layers. (https://github.com/vllm-project/vllm/blob/d7d2b5e405a24f716371cc7f9b488b14300b0991/vllm/model_executor/models/config.py#L107)
-                # This can cause the block size to not be aligned with RPA
-                # kernel requirements, update the block size to align.
-                self.align_block_size_for_rpa()
-                block_size = self.runner.cache_config.block_size
                 # Unify the page sizes of mamba and full attention layers to
                 # enable use of shared kv cache, vLLM also expects page sizes to
                 # be unified.


### PR DESCRIPTION
# Description
Add fixes in KV cache manager to enable support for Qwen3.5 with TP=8.

For Hybrid models with Mamba and Attention layers;
 - Align block size with RPA kernel requirements.
 - Update mamba padded page size to share the page size with attention layers.
 - Fix `num_blocks` computation when duplicating KV cache for shared layers.

# Tests

 - Add unit tests.
 - CI
 - `MODEL_IMPL_TYPE=vllm python examples/offline_inference.py --model=Qwen/Qwen3.5-397B-A17B-FP8 --tensor-parallel-size=8  --limit-mm-per-prompt '{"image": 0, "video": 0}'   --hf-overrides '{"text_config": {"rope_parameters": null, "rope_theta": 10000000, "partial_rotary_factor": 0.25}}' --block-size=256 --gpu-memory-utilization=0.8 --top_p=1.0 --top_k=-1 --temperature=0 --kv-cache-dtype=fp8  --chat-template-kwargs='{"enable_thinking": false}'`

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
