### PR TITLE
[Bugfix] Fix JAX/Flax path sharding not being properly configured for sharded model weights

### DIFF
--- a/tpu_inference/models/jax/utils/weight_utils.py
+++ b/tpu_inference/models/jax/utils/weight_utils.py
@@ -451,8 +451,8 @@ def _load_and_shard_weight(vllm_config,
         assert model_weight.value.shape == hf_weight.shape, f"{hf_key}: {model_weight.value.shape} != {hf_weight.shape}"
 
     # Update the model weight
-    spec = model_weight.sharding.spec if isinstance(
-        model_weight.sharding, NamedSharding) else model_weight.sharding
+    spec = model_sharding.spec if isinstance(model_sharding,
+                                             NamedSharding) else model_sharding
     model_weight.value = shard(hf_weight, spec)
 
 


### PR DESCRIPTION
# Description

In this PR, I fix a bug where model weights weren't being properly shareded, resulting in HBM OOM when running cmds like:

```
vllm serve meta-llama/Llama-3.3-70B-Instruct --tensor-parallel-size=8
```


# Tests

Ensured that the above command now passes.

Also ensured Qwen3-32B works as expected:


```
 USE_BATCHED_RPA_KERNEL=1 vllm serve Qwen/Qwen3-32B --max-model-len=2048 --max-num-seqs=320 --tensor-parallel-size 2 --max-num-batched-tokens 4096 --no-enable-prefix-caching --additional_config='{"quantization": { "qwix": { "rules": [{ "module_path": ".*", "weight_qtype": "float8_e4m3fn", "act_qtype": "float8_e4m3fn"}]}}}' --kv-cache-dtype=fp8 --gpu-memory-utilization=0.98 --async-scheduling --block-size=256 

python bench_serving/benchmark_serving.py   --model=Qwen/Qwen3-32B   --backend=vllm   --port=8000   --dataset-name=random   --random-input-len=1024   --random-output-len=1024   --random-range-ratio=0.8   --num-prompts=320   --max-concurrency=320   --request-rate=inf   --ignore-eos   --percentile-metrics='ttft,tpot,itl,e2el'


============ Serving Benchmark Result ============
Successful requests:                     320       
Benchmark duration (s):                  45.46     
Total input tokens:                      294336    
Total generated tokens:                  295883    
Request throughput (req/s):              7.04      
Output token throughput (tok/s):         6509.20   
Total Token throughput (tok/s):          12984.38  
---------------Time to First Token----------------
Mean TTFT (ms):                          6089.15   
Median TTFT (ms):                        5987.43   
P99 TTFT (ms):                           11924.04  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          40.23     
Median TPOT (ms):                        40.35     
P99 TPOT (ms):                           46.33     
---------------Inter-token Latency----------------
Mean ITL (ms):                           40.15     
Median ITL (ms):                         36.15     
P99 ITL (ms):                            162.05    
----------------End-to-end Latency----------------
Mean E2EL (ms):                          43169.27  
Median E2EL (ms):                        43461.33  
P99 E2EL (ms):                           45284.89  
==================================================
```


# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
