### PR TITLE
[RPA] Add bidirectional attention support for multimodal

### DIFF
--- a/tests/kernels/ragged_paged_attention_kernel_v3_test.py
+++ b/tests/kernels/ragged_paged_attention_kernel_v3_test.py
@@ -48,6 +48,7 @@ class RaggedPagedAttentionKernelTest(jtu.JaxTestCase):
         max_num_batched_tokens=512,
         max_num_seq=8,
         sliding_window: int | None = None,
+        mm_prefix_range: jnp.ndarray | None = None,
         soft_cap: float | None = None,
         q_scale: float | None = None,
         k_scale: float | None = None,
@@ -148,6 +149,16 @@ class RaggedPagedAttentionKernelTest(jtu.JaxTestCase):
         kv_lens = jnp.array(kv_lens, dtype=jnp.int32)
         kv_lens = jnp.pad(kv_lens, (0, max_num_seq - kv_lens.shape[0]))
         distribution = jnp.array([0, 0, len(seq_lens)], dtype=jnp.int32)
+        if mm_prefix_range is not None:
+            max_mm_prefix_ranges = mm_prefix_range.shape[0] // (len(seq_lens) *
+                                                                2)
+            pad_len = (max_num_seq - len(seq_lens)) * max_mm_prefix_ranges * 2
+            if pad_len > 0:
+                mm_prefix_range = jnp.pad(
+                    mm_prefix_range,
+                    (0, pad_len),
+                    constant_values=-1,
+                )
 
         args = (
             q,
@@ -167,6 +178,7 @@ class RaggedPagedAttentionKernelTest(jtu.JaxTestCase):
             "q_scale": q_scale,
             "k_scale": k_scale,
             "v_scale": v_scale,
+            "mm_prefix_range": mm_prefix_range,
         }
 
         expected, expected_kv_cache = ref_ragged_paged_attention(
@@ -528,6 +540,73 @@ class RaggedPagedAttentionKernelTest(jtu.JaxTestCase):
                 num_pages,
                 soft_cap=0.0,
             )
+
+    @parameterized.product(dtype=[jnp.float32, jnp.bfloat16])
+    def test_ragged_paged_attention_mm_prefix_range(self, dtype):
+        seq_lens = [(192, 328), (128, 180), (64, 255)]
+        num_heads = (32, 8)
+        head_dim = 128
+        page_size = 16
+        num_pages = 1000
+
+        # Shape: [max_num_seqs, max_mm_prefix_ranges, 2]
+        mm_prefix_range = jnp.array(
+            [
+                [[0, 50], [100, 150]],  # Seq 0: 2 bidirectional ranges
+                [[0, 100], [-1, -1]],  # Seq 1: 1 bidirectional range
+                [[-1, -1], [-1, -1]
+                 ],  # Seq 2: 0 bidirectional ranges (causal only)
+            ],
+            dtype=jnp.int32).reshape(-1)
+
+        self._test_ragged_paged_attention(
+            seq_lens,
+            num_heads,
+            head_dim,
+            page_size,
+            dtype,
+            dtype,
+            num_pages,
+            mm_prefix_range=mm_prefix_range,
+        )
+
+    @parameterized.product(
+        dtype=[jnp.float32, jnp.bfloat16],
+        sliding_window=[None, 5, 128],
+    )
+    def test_ragged_paged_attention_sliding_window_with_mm_prefix(
+        self,
+        dtype,
+        sliding_window,
+    ):
+        seq_lens = [(192, 328), (128, 180), (64, 255)]
+        num_heads = (32, 8)
+        head_dim = 128
+        page_size = 16
+        num_pages = 1000
+
+        # Shape: [max_num_seqs, max_mm_prefix_ranges, 2]
+        mm_prefix_range = jnp.array(
+            [
+                [[0, 50], [100, 150]],  # Seq 0: 2 bidirectional ranges
+                [[0, 100], [-1, -1]],  # Seq 1: 1 bidirectional range
+                [
+                    [-1, -1], [-1, -1]
+                ],  # Seq 2: 0 bidirectional ranges (causal + sliding window only)
+            ],
+            dtype=jnp.int32).reshape(-1)
+
+        self._test_ragged_paged_attention(
+            seq_lens,
+            num_heads,
+            head_dim,
+            page_size,
+            dtype,
+            dtype,
+            num_pages,
+            sliding_window=sliding_window,
+            mm_prefix_range=mm_prefix_range,
+        )
 
 
 if __name__ == "__main__":

--- a/tpu_inference/kernels/ragged_paged_attention/v3/kernel.py
+++ b/tpu_inference/kernels/ragged_paged_attention/v3/kernel.py
@@ -80,6 +80,7 @@ def ref_ragged_paged_attention(
     skip_kv_mask: bool = False,
     sm_scale: float = 1.0,
     sliding_window: int | None = None,
+    mm_prefix_range: jax.Array | None = None,
     soft_cap: float | None = None,
     out_dtype: Any = None,
     mask_value: float | None = None,
@@ -192,6 +193,24 @@ def ref_ragged_paged_attention(
             mask = q_span >= kv_span
             if sliding_window is not None:
                 mask = jnp.logical_and(mask, q_span < kv_span + sliding_window)
+            if mm_prefix_range is not None:
+                max_mm_prefix_ranges = mm_prefix_range.shape[0] // (
+                    max_num_seqs * 2)
+                mm_mask = jnp.zeros(mask.shape, dtype=jnp.bool_)
+                for r in range(max_mm_prefix_ranges):
+                    start = mm_prefix_range[i * max_mm_prefix_ranges * 2 +
+                                            r * 2]
+                    end = mm_prefix_range[i * max_mm_prefix_ranges * 2 +
+                                          r * 2 + 1]
+                    is_valid = start != -1
+                    doc_mask_q = jnp.logical_and(start <= q_span, q_span
+                                                 <= end)
+                    doc_mask_kv = jnp.logical_and(start <= kv_span, kv_span
+                                                  <= end)
+                    current_mm_mask = jnp.logical_and(doc_mask_q, doc_mask_kv)
+                    mm_mask = jnp.logical_or(
+                        mm_mask, jnp.logical_and(is_valid, current_mm_mask))
+                mask = jnp.logical_or(mask, mm_mask)
             attn = jnp.where(mask, attn, mask_value)
         attn = jax.nn.softmax(attn, axis=-1).astype(v.dtype)
 
@@ -205,7 +224,9 @@ def ref_ragged_paged_attention(
     return result, kv_cache
 
 
-def get_smem_estimate_bytes(max_num_seqs, pages_per_seq):
+def get_smem_estimate_bytes(max_num_seqs,
+                            pages_per_seq,
+                            max_mm_prefix_ranges=0):
     total_bits = (
         # kv_lens_ref: i32[max_num_seqs]
         align_to(max_num_seqs, 128) * 32 +
@@ -220,7 +241,9 @@ def get_smem_estimate_bytes(max_num_seqs, pages_per_seq):
         # bo_ids_ref: i32[4]
         128 * 32 +
         # bkv_update_ids_ref: i32[6]
-        128 * 32)
+        128 * 32 +
+        # mm_prefix_range_ref: i32[max_num_seqs * max_mm_prefix_ranges * 2]
+        align_to(max_num_seqs * max_mm_prefix_ranges * 2, 128) * 32)
     return cdiv(total_bits, 8)
 
 
@@ -299,6 +322,7 @@ def _ragged_paged_attention_kernel_loop(
     sem_ids_ref,  # [3] (bq_sem_idx, bkv_sem_idx, bo_sem_idx)
     bo_ids_ref,  # [4] (bo_sem_0_seq_idx, bo_sem_1_seq_idx, bo_sem_0_bo_idx, bo_sem_1_bo_idx)
     bkv_update_ids_ref,  # [6] (bkv_sem_0_seq_idx, bkv_sem_1_seq_idx, bkv_sem_0_offset, bkv_sem_1_offset, bkv_sem_0_sz, bkv_sem_1_sz)
+    mm_prefix_range_ref,  # [max_num_seqs * max_mm_prefix_ranges * 2]
     # Input
     q_hbm_ref,  # [actual_num_kv_heads, max_num_tokens, num_q_heads_per_kv_head // q_packing, q_packing, head_dim]
     kv_hbm_ref,  # [max_num_tokens, num_kv_heads_x2 // kv_packing, kv_packing, head_dim]
@@ -397,6 +421,24 @@ def _ragged_paged_attention_kernel_loop(
         next_seq_start_bkv_idx = (
             jnp.maximum(next_kv_q_gap - sliding_window, 0) // bkv_sz)
 
+        if mm_prefix_range_ref is not None:
+            max_mm_prefix_ranges = mm_prefix_range_ref.shape[0] // (
+                max_num_seqs * 2)
+            for r in range(max_mm_prefix_ranges):
+                r_start = mm_prefix_range_ref[seq_idx * max_mm_prefix_ranges *
+                                              2 + r * 2]
+                cur_seq_start_bkv_idx = jnp.where(
+                    r_start != -1,
+                    jnp.minimum(cur_seq_start_bkv_idx, r_start // bkv_sz),
+                    cur_seq_start_bkv_idx)
+                nr_start = mm_prefix_range_ref[next_seq_idx *
+                                               max_mm_prefix_ranges * 2 +
+                                               r * 2]
+                next_seq_start_bkv_idx = jnp.where(
+                    nr_start != -1,
+                    jnp.minimum(next_seq_start_bkv_idx, nr_start // bkv_sz),
+                    next_seq_start_bkv_idx)
+
     def debug_print(msg, *args):
         if debug_mode:
             pl.debug_print(msg, *args)
@@ -489,6 +531,21 @@ def _ragged_paged_attention_kernel_loop(
 
         if sliding_window is not None:
             mask = mask_and(mask, q_span < k_span + sliding_window)
+
+        if mm_prefix_range_ref is not None and mask is not None:
+            max_mm_prefix_ranges = mm_prefix_range_ref.shape[0] // (
+                max_num_seqs * 2)
+            mm_mask = jnp.zeros(mask.shape, dtype=jnp.bool_)
+            for r in range(max_mm_prefix_ranges):
+                start = mm_prefix_range_ref[seq_idx * max_mm_prefix_ranges * 2
+                                            + r * 2].astype(int_ty)
+                end = mm_prefix_range_ref[seq_idx * max_mm_prefix_ranges * 2 +
+                                          r * 2 + 1].astype(int_ty)
+                doc_mask_q = jnp.logical_and(start <= q_span, q_span <= end)
+                doc_mask_kv = jnp.logical_and(start <= k_span, k_span <= end)
+                current_mm_mask = jnp.logical_and(doc_mask_q, doc_mask_kv)
+                mm_mask = jnp.logical_or(mm_mask, current_mm_mask)
+            mask = jnp.logical_or(mask, mm_mask)
 
         if mask is not None:
             s = jnp.where(mask, s, mask_value)
@@ -905,6 +962,18 @@ def _ragged_paged_attention_kernel_loop(
                 next_bq_start_bkv_idx = (jnp.maximum(
                     kv_q_gap +
                     (bq_idx + 1) * actual_bq_sz - sliding_window, 0) // bkv_sz)
+                if mm_prefix_range_ref is not None:
+                    max_mm_prefix_ranges = mm_prefix_range_ref.shape[0] // (
+                        max_num_seqs * 2)
+                    for r in range(max_mm_prefix_ranges):
+                        r_start = mm_prefix_range_ref[
+                            seq_idx * max_mm_prefix_ranges * 2 + r * 2]
+                        next_bq_start_bkv_idx = jnp.where(
+                            r_start != -1,
+                            jnp.minimum(next_bq_start_bkv_idx,
+                                        r_start // bkv_sz),
+                            next_bq_start_bkv_idx)
+
             next_bkv_idx = lax.select(is_last_bkv, next_bq_start_bkv_idx,
                                       next_bkv_idx)
             next_bkv_idx = lax.select(is_last_bq, next_seq_start_bkv_idx,
@@ -928,6 +997,16 @@ def _ragged_paged_attention_kernel_loop(
                 # Recalculate the start_bkv_idx based on the processed_q_len.
                 start_bkv_idx = (
                     jnp.maximum(processed_q_len - sliding_window, 0) // bkv_sz)
+                if mm_prefix_range_ref is not None:
+                    max_mm_prefix_ranges = mm_prefix_range_ref.shape[0] // (
+                        max_num_seqs * 2)
+                    for r in range(max_mm_prefix_ranges):
+                        r_start = mm_prefix_range_ref[
+                            seq_idx * max_mm_prefix_ranges * 2 + r * 2]
+                        start_bkv_idx = jnp.where(
+                            r_start != -1,
+                            jnp.minimum(start_bkv_idx, r_start // bkv_sz),
+                            start_bkv_idx)
             if use_causal_mask:
                 effective_kv_len = jnp.minimum(kv_len,
                                                processed_q_len + actual_bq_sz)
@@ -1223,6 +1302,7 @@ def dynamic_validate_inputs(
     skip_kv_mask: bool = False,
     sm_scale: float = 1.0,
     sliding_window: int | None = None,
+    mm_prefix_range: jax.Array | None = None,
     soft_cap: float | None = None,
     out_dtype: Any = None,
     mask_value: float | None = None,
@@ -1251,6 +1331,7 @@ def dynamic_validate_inputs(
         skip_kv_mask=skip_kv_mask,
         sm_scale=sm_scale,
         sliding_window=sliding_window,
+        mm_prefix_range=mm_prefix_range,
         soft_cap=soft_cap,
         out_dtype=out_dtype,
         mask_value=mask_value,
@@ -1318,6 +1399,7 @@ def static_validate_inputs(
     skip_kv_mask: bool = False,
     sm_scale: float = 1.0,
     sliding_window: int | None = None,
+    mm_prefix_range: jax.Array | None = None,
     soft_cap: float | None = None,
     out_dtype: Any = None,
     mask_value: float | None = None,
@@ -1431,7 +1513,15 @@ def static_validate_inputs(
             f"Expected {cu_q_lens.shape=} to be ({max_num_seqs + 1},).")
     if distribution.shape != (3, ):
         raise ValueError(f"Expected {distribution.shape=} to be (3,).")
-
+    if mm_prefix_range is not None:
+        if mm_prefix_range.dtype != jnp.int32:
+            raise ValueError(
+                f"Expected int32 dtype for {mm_prefix_range.dtype=}")
+        if (len(mm_prefix_range.shape) != 1
+                or mm_prefix_range.shape[0] % (max_num_seqs * 2) != 0):
+            raise ValueError(
+                f"Expected mm_prefix_range to be 1D with size a multiple of "
+                f"{max_num_seqs * 2}, got {mm_prefix_range.shape}")
     if page_size % kv_packing != 0:
         raise ValueError(f"{page_size=} must be divisible by {kv_packing=}.")
     if sliding_window is not None and sliding_window <= 0:
@@ -1582,6 +1672,7 @@ def ragged_paged_attention(
     skip_kv_mask: bool = False,
     sm_scale: float = 1.0,
     sliding_window: int | None = None,
+    mm_prefix_range: jax.Array | None = None,
     soft_cap: float | None = None,
     out_dtype: Any = None,
     mask_value: float | None = None,
@@ -1624,6 +1715,9 @@ def ragged_paged_attention(
       kv_len % bkv_csz == 0. Set to true can improve performance.
     sm_scale: the softmax scale which will be applied to the Q@K^T.
     sliding_window: the sliding window size for the attention.
+    mm_prefix_range: 1D array of shape (max_num_seqs * max_mm_prefix_ranges * 2)
+     containing padded [start, end] token index ranges of vision soft tokens. Used
+      to apply bidirectional square masking over vision tokens.
     soft_cap: the logit soft cap for the attention.
     out_dtype: the dtype of the output and the accumulator for matmul. Set
       lower for better performance, set higher for better accuracy. If None, it
@@ -1673,6 +1767,7 @@ def ragged_paged_attention(
         skip_kv_mask=skip_kv_mask,
         sm_scale=sm_scale,
         sliding_window=sliding_window,
+        mm_prefix_range=mm_prefix_range,
         soft_cap=soft_cap,
         out_dtype=out_dtype,
         mask_value=mask_value,
@@ -1784,6 +1879,7 @@ def ragged_paged_attention(
             init_sem_ids,
             init_bo_ids,
             init_bkv_update_ids,
+            mm_prefix_range,
         )
 
         scope_name = f"RPA{case.symbol}-p_{page_size}-bq_{bq_sz}_{bq_csz}-bkv_{bkv_sz}_{bkv_csz}"
@@ -1837,8 +1933,8 @@ def ragged_paged_attention(
                                      dtype=kv_cache.dtype),
             ],
             input_output_aliases={
-                7: 0,
-                9: 1
+                8 if mm_prefix_range is not None else 7: 0,
+                10 if mm_prefix_range is not None else 9: 1,
             },
             name=scope_name,
         )

--- a/tpu_inference/layers/common/attention_interface.py
+++ b/tpu_inference/layers/common/attention_interface.py
@@ -339,6 +339,7 @@ def sharded_ragged_paged_attention(
     q_scale: float | None = None,
     k_scale: float | None = None,
     v_scale: float | None = None,
+    mm_prefix_range: jax.Array | None = None,
 ):
     """Shards along KV heads."""
     # Handle GQA/MQA where num_kv_heads < tp_size
@@ -383,6 +384,10 @@ def sharded_ragged_paged_attention(
 
         in_specs += (P(ShardingAxisName.ATTN_HEAD), )
         args += (attention_sink, )
+
+    if mm_prefix_range is not None:
+        in_specs += (P(ShardingAxisName.ATTN_DATA), )
+        args += (mm_prefix_range, )
 
     def _ragged_paged_attention(*args):
         return func(
@@ -455,6 +460,7 @@ def attention(
         q_scale=q_scale,
         k_scale=k_scale,
         v_scale=v_scale,
+        mm_prefix_range=md.mm_prefix_range,
     )
 
     return kv_cache, output

--- a/tpu_inference/layers/common/attention_metadata.py
+++ b/tpu_inference/layers/common/attention_metadata.py
@@ -28,6 +28,7 @@ import jax
         "query_start_loc",
         "request_distribution",
         "mamba_state_indices",
+        "mm_prefix_range",
     ],
     meta_fields=[],
     drop_fields=["query_start_loc_cpu", "seq_lens_cpu"],
@@ -53,6 +54,8 @@ class AttentionMetadata(object):
     # None for models without mamba layers; pure-mamba models would also
     # use this field, only hybrid models exercise it today.
     mamba_state_indices: jax.Array | None = None
+    # (max_num_seqs * max_mm_prefix_ranges * 2)
+    mm_prefix_range: jax.Array | None = None
 
     query_start_loc_cpu: Any = field(init=False)
     seq_lens_cpu: Any = field(init=False)

--- a/tpu_inference/runner/multimodal_manager.py
+++ b/tpu_inference/runner/multimodal_manager.py
@@ -84,6 +84,37 @@ class MultiModalManager:
 
                 mrope_pos_ptr += completion_part_len
 
+    def calc_mm_prefix_ranges(self,
+                              max_mm_prefix_ranges: int) -> jnp.ndarray | None:
+        is_mm_prefix = getattr(self.runner.model_config, "is_mm_prefix_lm",
+                               None)
+        if not is_mm_prefix or max_mm_prefix_ranges <= 0:
+            return None
+
+        req_doc_ranges = [[[-1, -1] for _ in range(max_mm_prefix_ranges)]
+                          for _ in range(self.runner.max_num_reqs)]
+
+        for index, req_id in enumerate(self.runner.input_batch.req_ids):
+            req_state = self.runner.requests[req_id]
+
+            image_doc_ranges = []
+            for mm_feature in req_state.mm_features:
+                pos_info = mm_feature.mm_position
+                img_doc_range = pos_info.extract_embeds_range()
+                image_doc_ranges.extend(img_doc_range)
+
+            if len(image_doc_ranges) > max_mm_prefix_ranges:
+                raise ValueError(
+                    f"Request {req_id} contains {len(image_doc_ranges)} "
+                    f"multimodal prefix ranges, which exceeds the configured "
+                    f"limit of {max_mm_prefix_ranges}.")
+
+            for r, (start, end) in enumerate(image_doc_ranges):
+                req_doc_ranges[index][r][0] = start
+                req_doc_ranges[index][r][1] = end
+
+        return jnp.array(req_doc_ranges, dtype=jnp.int32).reshape(-1)
+
     def execute_mm_encoder(self, scheduler_output: "VllmSchedulerOutput"):
         scheduled_encoder_inputs = scheduler_output.scheduled_encoder_inputs
         if not scheduled_encoder_inputs:

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -440,6 +440,11 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
     def _init_mm(self) -> None:
         self.is_multimodal_model = None
         self.uses_mrope = self.model_config.uses_mrope
+        mm_config = getattr(self.model_config, "multimodal_config", {})
+        limits = mm_config.get("limit_per_prompt", {})
+        image_limit = limits.get("image", 0)
+        self.max_mm_prefix_ranges = getattr(image_limit, "count",
+                                            image_limit) or 0
         self.supports_mm_inputs = True
 
     def _init_speculative_decoding(self) -> None:
@@ -1387,6 +1392,11 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         if self.uses_mrope:
             self.mm_manager.calc_mrope_positions(scheduler_output)
 
+        mm_prefix_range_cpu = None
+        if self.is_multimodal_model:
+            mm_prefix_range_cpu = self.mm_manager.calc_mm_prefix_ranges(
+                self.max_mm_prefix_ranges)
+
         # Async scheduling: prepare token substitution indices for DP
         token_in_tpu_cur_input_indices_dp = {}
         token_in_tpu_pre_next_tokens_indices_dp = {}
@@ -1590,6 +1600,14 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                                      positions,
                                      sharding=data_parallel_attn_sharding)
 
+        mm_prefix_range = None
+        if mm_prefix_range_cpu is not None:
+            mm_prefix_range = device_array(
+                self.mesh,
+                (mm_prefix_range_cpu),
+                sharding=data_parallel_attn_sharding,
+            )
+
         # Collect block tables host arrays loops zone presence zones legality
         def build_block_table_host(kv_cache_gid: int) -> None:
 
@@ -1661,6 +1679,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                 query_start_loc=query_start_loc,
                 request_distribution=request_distribution,
                 mamba_state_indices=mamba_state_indices,
+                mm_prefix_range=mm_prefix_range,
             )
 
             # This is for making these cpu buffers hidden during tracing
@@ -1827,6 +1846,11 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         if self.uses_mrope:
             self.mm_manager.calc_mrope_positions(scheduler_output)
 
+        mm_prefix_range_cpu = None
+        if self.is_multimodal_model:
+            mm_prefix_range_cpu = self.mm_manager.calc_mm_prefix_ranges(
+                self.max_mm_prefix_ranges)
+
         # Get token indices.
         # E.g., [0, 1, 0, 1, 2, 3, 4, 0, 1, 2]
         # -> [0, 1, M, M + 1, M + 2, M + 3, M + 4, 2 * M, 2 * M + 1, 2 * M + 2]
@@ -1890,6 +1914,10 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                                      positions,
                                      sharding=data_parallel_attn_sharding)
 
+        mm_prefix_range = None
+        if mm_prefix_range_cpu is not None:
+            mm_prefix_range = device_array(self.mesh, (mm_prefix_range_cpu))
+
         request_distribution = np.array(self.input_batch.request_distribution)
 
         def build_block_table_host(kv_cache_gid: int) -> None:
@@ -1949,6 +1977,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                 query_start_loc=query_start_loc,
                 request_distribution=request_distribution,
                 mamba_state_indices=mamba_state_indices,
+                mm_prefix_range=mm_prefix_range,
             )
             # This is for making these cpu buffers hidden during tracing
             attention_metadata_gid.query_start_loc_cpu = query_start_loc_view


### PR DESCRIPTION
# Description

For models required to use bidirectional attention in both vision encoder and language model: when image tokens are given as inputs to the language model, the square masking of images is applied to image tokens and needs to be calculated and added dynamically. This is expected to work with both causal and sliding_window cases.

Implementations:
1. The ranges of vision tokens of each request are calculated from `multimodal_manager.py` with `calc_mm_prefix_ranges` and passed into `attention_metadata` to pass into RPA kernel. 
2. In the RPA kernel, square masks are calculated and applied based on the locations of vision tokens. Noticed that the `start_bkv_idx` needs to be adjusted for sliding_window case, when the applied square masks is larger than the window size.
3. Two unit tests are added to check the correctness.

Referred to the changes in vLLM flex attention: https://github.com/Isotr0py/vllm/blob/b71fbd06e215a1a09600220c947a1bb2d5494de9/vllm/v1/attention/backends/flex_attention.py#L467. The `mm_prefix_range` is created as `dict[int, list[tuple[int, int]]]` in vLLM. 
Due to the static requirement, `mm_prefix_range` is padded based on the upper bound of number of images per prompt, which is a required setting for testing multimodal models: `--limit-mm-per-prompt`. (This part can be further refined once having the support of video.)
The `is_mm_prefix` check and fallback can also be further adjusted based on the model configs.

# Tests

Tested with `blaze` for kernel unit tests.
Tested e2e with multimodal models.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
