### PR TITLE
Fix ep upstream e2e breakage

### DIFF
--- a/tests/e2e/test_expert_parallel.py
+++ b/tests/e2e/test_expert_parallel.py
@@ -3,10 +3,10 @@
 
 import os
 import time
-from dataclasses import asdict, dataclass
+from dataclasses import dataclass
 
 import pytest
-from vllm import LLM, EngineArgs, SamplingParams
+from vllm import LLM, SamplingParams
 
 
 @dataclass
@@ -71,7 +71,7 @@ def _run_inference(
     sampling_params: SamplingParams,
 ) -> tuple[list, float]:
     """Run inference with the given configuration."""
-    engine_args = EngineArgs(
+    llm = LLM(
         model=config.model_name,
         max_model_len=config.max_model_len,
         tensor_parallel_size=config.tensor_parallel_size,
@@ -83,9 +83,6 @@ def _run_inference(
         kv_cache_dtype="auto",
         enable_expert_parallel=config.enable_expert_parallel,
     )
-
-    engine_args_dict = asdict(engine_args)
-    llm = LLM(**engine_args_dict)
 
     start_time = time.time()
     outputs = llm.generate(test_prompts, sampling_params)


### PR DESCRIPTION
# Description

Similar to https://github.com/vllm-project/tpu-inference/pull/2043

https://buildkite.com/organizations/tpu-commons/analytics/suites/tests/tests/29009da7-0bd0-84ff-a1a6-b010a65e0001?branch=main
```

value = {'backend': 'openxla', 'cache_dir': '', 'compilation_time': 0.0, 'compile_cache_save_format': 'binary', ...}
cls = <class 'vllm.config.compilation.CompilationConfig'>

    def _make_config(value: Any, cls: type[_R]) -> _R:
        """Convert dict/None/instance to a config instance."""
        if value is None:
            return cls()
        if isinstance(value, dict):
>           return cls(**{k: v for k, v in value.items() if is_init_field(cls, k)})  # type: ignore[arg-type]
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E           pydantic_core._pydantic_core.ValidationError: 1 validation error for CompilationConfig
E           cudagraph_capture_sizes
E             Input should be a valid list [type=list_type, input_value=None, input_type=NoneType]
E               For further information visit https://errors.pydantic.dev/2.12/v/list_type
```
Fix by directly passing in args to LLM instead if using `asdict`

# Tests

Ran
```
VLLM_XLA_CHECK_RECOMPILATION=1 pytest tests/e2e/test_expert_parallel.py
```

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
