### PR TITLE
[Nightly Testing] Fix failing Qwen3-30B-A3B test

### DIFF
--- a/.buildkite/models/Qwen_Qwen3-30B-A3B.yml
+++ b/.buildkite/models/Qwen_Qwen3-30B-A3B.yml
@@ -48,6 +48,7 @@ steps:
       TEST_MODEL: Qwen/Qwen3-30B-A3B
       TENSOR_PARALLEL_SIZE: 4
       MINIMUM_ACCURACY_THRESHOLD: 0.89
+      MODEL_IMPL_TYPE: vllm
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/test_accuracy.sh


### PR DESCRIPTION
# Description

The `Accuracy for Qwen/Qwen3-30B-A3B` test is failing because the build is defaulting to Flax when we can be using vLLM/TorchAX instead.

# Tests

[Build](https://buildkite.com/tpu-commons/tpu-inference-ci/builds/13266#019d2d04-777b-44bb-b355-2193a9f94327) passes relevant testing.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
