### PR TITLE
Fix misleading profiling logic

### DIFF
--- a/scripts/vllm/benchmarking/backend_request_func.py
+++ b/scripts/vllm/benchmarking/backend_request_func.py
@@ -7,18 +7,21 @@ This file implements the request logic needed for serving benchmark requests.
 """
 
 import json
+import logging
 import os
 import sys
 import time
 import traceback
 from dataclasses import dataclass, field
-from typing import Optional, Union
+from typing import Literal, Optional, Union
 
 import aiohttp
 import huggingface_hub.constants
 from tqdm.asyncio import tqdm
 from transformers import (AutoTokenizer, PreTrainedTokenizer,
                           PreTrainedTokenizerFast)
+
+logger = logging.getLogger(__name__)
 
 AIOHTTP_TIMEOUT = aiohttp.ClientTimeout(total=6 * 60 * 60)
 
@@ -55,13 +58,26 @@ class RequestFuncOutput:
     input_request: Optional[RequestFuncInput] = None
 
 
+async def start_stop_profile(base_url: str, action: Literal["start", "stop"]):
+    """A start / stop profile utility for vLLM server."""
+    api_url = base_url + f"/{action}_profile"
+
+    async with aiohttp.ClientSession(timeout=AIOHTTP_TIMEOUT) as session:
+
+        async with session.post(url=api_url) as response:
+            if (code := response.status) != 200:
+                logger.warning(f"{action=} profile failed: {code=}")
+                return False
+            return True
+
+
 async def async_request_openai_completions(
     request_func_input: RequestFuncInput,
     pbar: Optional[tqdm] = None,
 ) -> RequestFuncOutput:
     api_url = request_func_input.api_url
-    assert api_url.endswith(("completions", "profile")), (
-        "OpenAI Completions API URL must end with 'completions' or 'profile'.")
+    assert api_url.endswith("completions"), (
+        "OpenAI Completions API URL must end with 'completions'")
 
     async with aiohttp.ClientSession(trust_env=True,
                                      timeout=AIOHTTP_TIMEOUT) as session:

--- a/scripts/vllm/benchmarking/benchmark_serving.py
+++ b/scripts/vllm/benchmarking/benchmark_serving.py
@@ -37,7 +37,7 @@ from typing import Optional
 import numpy as np
 from backend_request_func import (ASYNC_REQUEST_FUNCS,
                                   OPENAI_COMPATIBLE_BACKENDS, RequestFuncInput,
-                                  RequestFuncOutput)
+                                  RequestFuncOutput, start_stop_profile)
 from tqdm.asyncio import tqdm
 from transformers import PreTrainedTokenizerBase
 
@@ -307,20 +307,7 @@ async def benchmark(
 
     if profile:
         print("Starting profiler...")
-        profile_input = RequestFuncInput(
-            model=model_id,
-            model_name=model_name,
-            prompt=test_prompt,
-            api_url=base_url + "/start_profile",
-            prompt_len=test_prompt_len,
-            output_len=test_output_len,
-            logprobs=logprobs,
-            multi_modal_content=test_mm_content,
-            ignore_eos=ignore_eos,
-            extra_body=extra_body,
-        )
-        profile_output = await request_func(request_func_input=profile_input)
-        if profile_output.success:
+        if await start_stop_profile(base_url, "start"):
             print("Profiler started")
 
     distribution = "Poisson process" if burstiness == 1.0 else "Gamma distribution"
@@ -387,16 +374,7 @@ async def benchmark(
 
     if profile:
         print("Stopping profiler...")
-        profile_input = RequestFuncInput(
-            model=model_id,
-            prompt=test_prompt,
-            api_url=base_url + "/stop_profile",
-            prompt_len=test_prompt_len,
-            output_len=test_output_len,
-            logprobs=logprobs,
-        )
-        profile_output = await request_func(request_func_input=profile_input)
-        if profile_output.success:
+        if await start_stop_profile(base_url, "stop"):
             print("Profiler stopped")
 
     if pbar is not None:


### PR DESCRIPTION
Fix misleading profiling logic

start / stop profile using POST Method without any request / response body

```python
@router.post("/start_profile")
async def start_profile(raw_request: Request):
    logger.info("Starting profiler...")
    await engine_client(raw_request).start_profile()
    logger.info("Profiler started.")
    return Response(status_code=200)


@router.post("/stop_profile")
async def stop_profile(raw_request: Request):
    logger.info("Stopping profiler...")
    await engine_client(raw_request).stop_profile()
    logger.info("Profiler stopped.")
    return Response(status_code=200)
```

This also enable zero-request benchmarking.

## Testing

<img width="990" height="196" alt="image" src="https://github.com/user-attachments/assets/3fe99e72-40b3-476a-ac0b-bf8bd9200f01" />
