### PR TITLE
[Benchmark] Update benchmark_serving.py: Support OpenAI Chat Completions API

### DIFF
--- a/scripts/vllm/benchmarking/backend_request_func.py
+++ b/scripts/vllm/benchmarking/backend_request_func.py
@@ -12,11 +12,11 @@ import os
 import sys
 import time
 import traceback
-from dataclasses import dataclass, field
-from typing import Literal, Optional, Union
+from typing import Any, Literal, Optional, Protocol, Union
 
 import aiohttp
 import huggingface_hub.constants
+from benchmark_core import BenchmarkContext, RequestFuncOutput, SampleRequest
 from tqdm.asyncio import tqdm
 from transformers import (AutoTokenizer, PreTrainedTokenizer,
                           PreTrainedTokenizerFast)
@@ -24,38 +24,6 @@ from transformers import (AutoTokenizer, PreTrainedTokenizer,
 logger = logging.getLogger(__name__)
 
 AIOHTTP_TIMEOUT = aiohttp.ClientTimeout(total=6 * 60 * 60)
-
-
-@dataclass
-class RequestFuncInput:
-    prompt: str
-    api_url: str
-    prompt_len: int
-    output_len: int
-    model: str
-    model_name: Optional[str] = None
-    logprobs: Optional[int] = None
-    extra_body: Optional[dict] = None
-    multi_modal_content: Optional[dict | list[dict]] = None
-    ignore_eos: bool = False
-    language: Optional[str] = None
-    request_id: Optional[str] = None
-    completion: str = ""
-
-
-@dataclass
-class RequestFuncOutput:
-    generated_text: str = ""
-    success: bool = False
-    latency: float = 0.0
-    output_tokens: int = 0
-    ttft: float = 0.0  # Time to first token
-    itl: list[float] = field(
-        default_factory=list)  # list of inter-token latencies
-    tpot: float = 0.0  # avg next-token latencies
-    prompt_len: int = 0
-    error: str = ""
-    input_request: Optional[RequestFuncInput] = None
 
 
 async def start_stop_profile(base_url: str, action: Literal["start", "stop"]):
@@ -72,52 +40,118 @@ async def start_stop_profile(base_url: str, action: Literal["start", "stop"]):
 
 
 async def async_request_openai_completions(
-    request_func_input: RequestFuncInput,
+    ctx: BenchmarkContext,
+    request_func_input: SampleRequest,
     pbar: Optional[tqdm] = None,
 ) -> RequestFuncOutput:
-    api_url = request_func_input.api_url
+    api_url = ctx.api_url
     assert api_url.endswith("completions"), (
         "OpenAI Completions API URL must end with 'completions'")
 
+    payload = {
+        "model": ctx.model_name if ctx.model_name else ctx.model,
+        "prompt": request_func_input.prompt,
+        "temperature": 0.0,
+        "repetition_penalty": 1.0,
+        "max_tokens": request_func_input.expected_output_len,
+        "logprobs": ctx.logprobs,
+        "stream": True,
+        "stream_options": {
+            "include_usage": True,
+        },
+    }
+    if ctx.ignore_eos:
+        payload["ignore_eos"] = ctx.ignore_eos
+    if ctx.extra_body:
+        payload.update(ctx.extra_body)
+
+    output = await _openai_fetch(
+        ctx=ctx,
+        payload=payload,
+        extract_from=lambda choices: choices[0].get("text"),
+    )
+
+    # XXX: not a good pattern to mutate the field after object creation.
+    output.input_request = request_func_input
+
+    if pbar:
+        pbar.update(1)
+
+    return output
+
+
+async def async_request_openai_chat_completions(
+    ctx: BenchmarkContext,
+    request_func_input: SampleRequest,
+    pbar: Optional[tqdm] = None,
+) -> RequestFuncOutput:
+
+    # Note: the major difference from openai_completions are
+    # - different api_url suffix checking.
+    # - "messages" field in payload instead of "prompt".
+    # - the extraction logic on "choices" field of response
+
+    api_url = ctx.api_url
+    assert api_url.endswith("chat/completions"), (
+        "OpenAI Chat Completions API URL must end with 'chat/completions'")
+
+    payload = {
+        "model": ctx.model_name if ctx.model_name else ctx.model,
+        "messages": request_func_input.messages,
+        "temperature": 0.0,
+        "repetition_penalty": 1.0,
+        "max_tokens": request_func_input.expected_output_len,
+        "logprobs": ctx.logprobs,
+        "stream": True,
+        "stream_options": {
+            "include_usage": True,
+        },
+    }
+    if ctx.ignore_eos:
+        payload["ignore_eos"] = ctx.ignore_eos
+    if ctx.extra_body:
+        payload.update(ctx.extra_body)
+
+    output = await _openai_fetch(
+        ctx=ctx,
+        payload=payload,
+        extract_from=lambda choices: choices[0]["delta"]["content"],
+    )
+
+    # XXX: not a good pattern to mutate the field after object creation.
+    output.input_request = request_func_input
+
+    if pbar:
+        pbar.update(1)
+
+    return output
+
+
+class _ExtractFunc(Protocol):
+
+    def __call__(self, choices) -> str:
+        """Given the "choices" field, extract the message payload."""
+        ...
+
+
+async def _openai_fetch(
+    ctx: BenchmarkContext,
+    payload: Any,
+    extract_from: _ExtractFunc,
+) -> RequestFuncOutput:
+    headers = {"Authorization": f"Bearer {os.environ.get('OPENAI_API_KEY')}"}
+
     async with aiohttp.ClientSession(trust_env=True,
                                      timeout=AIOHTTP_TIMEOUT) as session:
-        payload = {
-            "model":
-            request_func_input.model_name
-            if request_func_input.model_name else request_func_input.model,
-            "prompt":
-            request_func_input.prompt,
-            "temperature":
-            0.0,
-            "repetition_penalty":
-            1.0,
-            "max_tokens":
-            request_func_input.output_len,
-            "logprobs":
-            request_func_input.logprobs,
-            "stream":
-            True,
-            "stream_options": {
-                "include_usage": True,
-            },
-        }
-        if request_func_input.ignore_eos:
-            payload["ignore_eos"] = request_func_input.ignore_eos
-        if request_func_input.extra_body:
-            payload.update(request_func_input.extra_body)
-        headers = {
-            "Authorization": f"Bearer {os.environ.get('OPENAI_API_KEY')}"
-        }
 
         output = RequestFuncOutput()
-        output.input_request = request_func_input
-        output.prompt_len = request_func_input.prompt_len
 
         generated_text = ""
         st = time.perf_counter()
         most_recent_timestamp = st
         try:
-            async with session.post(url=api_url, json=payload,
+            async with session.post(url=ctx.api_url,
+                                    json=payload,
                                     headers=headers) as response:
                 if response.status == 200:
                     first_chunk_received = False
@@ -137,7 +171,7 @@ async def async_request_openai_completions(
                             if choices := data.get("choices"):
                                 # Note that text could be empty here
                                 # e.g. for special tokens
-                                text = choices[0].get("text")
+                                text = extract_from(choices)
                                 timestamp = time.perf_counter()
                                 # First token
                                 if not first_chunk_received:
@@ -172,8 +206,6 @@ async def async_request_openai_completions(
             exc_info = sys.exc_info()
             output.error = "".join(traceback.format_exception(*exc_info))
 
-    if pbar:
-        pbar.update(1)
     return output
 
 
@@ -229,9 +261,10 @@ def get_tokenizer(
 
 ASYNC_REQUEST_FUNCS = {
     "vllm": async_request_openai_completions,
+    "vllm-chat": async_request_openai_chat_completions,
 }
 
 OPENAI_COMPATIBLE_BACKENDS = [
-    k for k, v in ASYNC_REQUEST_FUNCS.items()
-    if v in (async_request_openai_completions, )
+    "vllm",
+    "vllm-chat",
 ]

--- a/scripts/vllm/benchmarking/benchmark_core.py
+++ b/scripts/vllm/benchmarking/benchmark_core.py
@@ -1,0 +1,92 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from vllm.inputs import MultiModalDataDict
+from vllm.lora.request import LoRARequest
+
+
+@dataclass
+class BenchmarkContext:
+    api_url: str
+    model: str
+    model_name: str | None = None
+    logprobs: int | None = None
+    extra_body: dict | None = None
+    ignore_eos: bool = False
+    language: str | None = None
+
+
+@dataclass
+class SampleRequest:
+    """
+    Represents a single inference request for benchmarking.
+
+    prompt and prompt_len are only used for completions API, and messages
+    is only used for chat-completions API.
+
+    The should be used exclusively.
+    """
+
+    prompt: str | list[str] | list[int] | list[list[int]] | None = None
+    """
+    The prompt field for completions API.
+
+    https://developers.openai.com/api/reference/resources/completions/methods/create
+    """
+
+    prompt_len: int = 0
+    """
+    The length of prompt
+
+    Not guarantee to have reasonable value, as we reuse SampleRequest for
+    multiple kind of API for now.
+    """
+
+    messages: list[Any] | None = None
+    """
+    The messages field for chat-completions API.
+
+    Must be something that's serialize-able by json lib.
+    It's not easy to have schema-correct typing here, please see document.
+    https://developers.openai.com/api/reference/resources/chat/subresources/completions/methods/create
+    """
+
+    expected_output_len: int = 256
+
+    multi_modal_data: MultiModalDataDict | dict | list[dict] | None = None
+
+    lora_request: LoRARequest | None = None
+
+    completion: str | None = None
+    """For MMLMDataset, MLPerfDataset"""
+
+    request_id: str | None = None
+    """For Random (synthetic), Sonnet"""
+
+
+@dataclass
+class RequestFuncOutput:
+    generated_text: str = ""
+    success: bool = False
+    latency: float = 0.0
+    output_tokens: int = 0
+    ttft: float = 0.0  # Time to first token
+    itl: list[float] = field(
+        default_factory=list)  # list of inter-token latencies
+    tpot: float = 0.0  # avg next-token latencies
+    error: str = ""
+    input_request: SampleRequest = field(default_factory=SampleRequest)

--- a/scripts/vllm/benchmarking/benchmark_dataset.py
+++ b/scripts/vllm/benchmarking/benchmark_dataset.py
@@ -17,37 +17,15 @@ import os
 import random
 from abc import ABC, abstractmethod
 from copy import deepcopy
-from dataclasses import dataclass
-from typing import Any, Optional, Union
+from typing import Any, Optional
 
 import numpy as np
 import pandas as pd
+from benchmark_core import SampleRequest
 from transformers import PreTrainedTokenizerBase
 from vllm.inputs import MultiModalDataDict
-from vllm.lora.request import LoRARequest
 
 logger = logging.getLogger(__name__)
-
-# -----------------------------------------------------------------------------
-# Data Classes
-# -----------------------------------------------------------------------------
-
-
-@dataclass
-class SampleRequest:
-    """
-    Represents a single inference request for benchmarking.
-    """
-
-    prompt: Union[str, Any]
-    prompt_len: int
-    expected_output_len: int
-    multi_modal_data: Optional[Union[MultiModalDataDict, dict,
-                                     list[dict]]] = None
-    lora_request: Optional[LoRARequest] = None
-    completion: Optional[str] = None
-    request_id: Optional[str] = None
-
 
 # -----------------------------------------------------------------------------
 # Benchmark Dataset Base Class

--- a/scripts/vllm/benchmarking/benchmark_serving.py
+++ b/scripts/vllm/benchmarking/benchmark_serving.py
@@ -26,6 +26,7 @@ On the client side, run:
 
 import argparse
 import asyncio
+import contextlib
 import gc
 import random
 import time
@@ -36,7 +37,7 @@ from typing import Optional
 
 import numpy as np
 from backend_request_func import (ASYNC_REQUEST_FUNCS,
-                                  OPENAI_COMPATIBLE_BACKENDS, RequestFuncInput,
+                                  OPENAI_COMPATIBLE_BACKENDS,
                                   RequestFuncOutput, start_stop_profile)
 from tqdm.asyncio import tqdm
 from transformers import PreTrainedTokenizerBase
@@ -52,9 +53,9 @@ except ImportError:
     from argparse import ArgumentParser as FlexibleArgumentParser
 
 # yapf: disable
+from benchmark_core import BenchmarkContext, SampleRequest
 from benchmark_dataset import (GPQADataset, MLPerfDataset, MMLUDataset,
-                               MMMUProDataset, RandomDataset, SampleRequest,
-                               SonnetDataset)
+                               MMMUProDataset, RandomDataset, SonnetDataset)
 # yapf: disable
 from benchmark_utils import (eval_benchmark_dataset_result,
                              sample_warmup_requests)
@@ -268,6 +269,15 @@ async def benchmark(
     else:
         raise ValueError(f"Unknown backend: {backend}")
 
+    ctx = BenchmarkContext(
+        api_url=api_url,
+        model=model_id,
+        model_name=model_name,
+        logprobs=logprobs,
+        ignore_eos=ignore_eos,
+        extra_body=extra_body,
+    )
+
     warmup_requests = None
     if args.warmup_mode == "full":
         warmup_requests = input_requests
@@ -277,28 +287,8 @@ async def benchmark(
     if warmup_requests:
         print(f"Warmup (mode: {args.warmup_mode}) is starting.")
         for warmup_request in tqdm(warmup_requests):
-            test_prompt, test_prompt_len, test_output_len, test_mm_content = (
-                warmup_request.prompt,
-                warmup_request.prompt_len,
-                warmup_request.expected_output_len,
-                warmup_request.multi_modal_data,
-            )
 
-            assert test_mm_content is None or isinstance(test_mm_content, (dict, list))
-            test_input = RequestFuncInput(
-                model=model_id,
-                model_name=model_name,
-                prompt=test_prompt,
-                api_url=api_url,
-                prompt_len=test_prompt_len,
-                output_len=test_output_len,
-                logprobs=logprobs,
-                multi_modal_content=test_mm_content,
-                ignore_eos=ignore_eos,
-                extra_body=extra_body,
-            )
-
-            test_output = await request_func(request_func_input=test_input)
+            test_output = await request_func(ctx=ctx, request_func_input=warmup_request)
             if not test_output.success:
                 raise ValueError(
                     "Warmup failed - Please make sure benchmark arguments "
@@ -318,57 +308,24 @@ async def benchmark(
 
     pbar = None if disable_tqdm else tqdm(total=len(input_requests))
 
-    # This can be used once the minimum Python version is 3.10 or higher,
-    # and it will simplify the code in limited_request_func.
-    #    semaphore = (asyncio.Semaphore(max_concurrency)
-    #                 if max_concurrency else contextlib.nullcontext())
-    semaphore = asyncio.Semaphore(max_concurrency) if max_concurrency else None
+    semaphore = asyncio.Semaphore(max_concurrency) \
+                    if max_concurrency else contextlib.nullcontext()
 
     async def limited_request_func(request_func_input, pbar):
-        if semaphore is None:
-            return await request_func(request_func_input=request_func_input,
-                                      pbar=pbar)
         async with semaphore:
-            return await request_func(request_func_input=request_func_input,
-                                      pbar=pbar)
+            return await request_func(
+                ctx=ctx,
+                request_func_input=request_func_input,
+                pbar=pbar,
+            )
 
     benchmark_start_time = time.perf_counter()
     tasks: list[asyncio.Task] = []
     async for request in get_request(input_requests, request_rate, burstiness):
-        prompt, prompt_len, output_len, mm_content = (
-            request.prompt,
-            request.prompt_len,
-            request.expected_output_len,
-            request.multi_modal_data,
-        )
-        req_model_id, req_model_name = model_id, model_name
-
-        request_kwargs = dict(
-            model=req_model_id,
-            model_name=req_model_name,
-            prompt=prompt,
-            api_url=api_url,
-            prompt_len=prompt_len,
-            output_len=output_len,
-            logprobs=logprobs,
-            multi_modal_content=mm_content,
-            ignore_eos=ignore_eos,
-            extra_body=extra_body,
-        )
-
-        # For MMLMDataset, MLPerfDataset
-        if request.completion is not None:
-            request_kwargs["completion"] = request.completion
-
-        # For Random (synthetic), Sonnet
-        if request.request_id is not None:
-            request_kwargs["request_id"] = request.request_id
-
-        request_func_input = RequestFuncInput(**request_kwargs)
 
         tasks.append(
             asyncio.create_task(
-                limited_request_func(request_func_input=request_func_input,
+                limited_request_func(request_func_input=request,
                                      pbar=pbar)))
     outputs: list[RequestFuncOutput] = await asyncio.gather(*tasks)
 
@@ -418,7 +375,7 @@ async def benchmark(
         metrics.request_goodput if goodput_config_dict else None,
         "output_throughput": metrics.output_throughput,
         "total_token_throughput": metrics.total_token_throughput,
-        "input_lens": [output.prompt_len for output in outputs],
+        "input_lens": [output.input_request.prompt_len for output in outputs],
         "output_lens": actual_output_lens,
         "ttfts": [output.ttft for output in outputs],
         "itls": [output.itl for output in outputs],


### PR DESCRIPTION

# Description

Support OpenAI Chat Completions API, to enable more benchmark dataset that sending multimodality input.

- Generic the request handling through ASYNC_REQUEST_FUNCS
- Extract benchmark context that's identical across all requests
- Simplify null async semaphore usage
- Other refactoring

# Tests

N/A

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
