### PR TITLE
disable bk pipeline validate for now until buildkite bug resolved

### DIFF
--- a/.buildkite/scripts/bootstrap.sh
+++ b/.buildkite/scripts/bootstrap.sh
@@ -62,12 +62,13 @@ if [ "$BUILDKITE_PULL_REQUEST" != "false" ]; then
     fi
 
     # Validate modified YAML pipelines using bk pipeline validate
-    if .buildkite/scripts/validate_all_pipelines.sh "$NON_SKIPPABLE_FILES"; then
-      echo "All pipelines syntax are valid. Proceeding with pipeline upload."
-    else
-      echo "Some pipelines syntax are invalid. Failing build."
-      exit 1
-    fi
+    # disable `bk pipeline validate` for now due to Buildkite issue (https://github.com/buildkite/pipeline-schema/pull/154)
+    # if .buildkite/scripts/validate_all_pipelines.sh "$NON_SKIPPABLE_FILES"; then
+    #   echo "All pipelines syntax are valid. Proceeding with pipeline upload."
+    # else
+    #   echo "Some pipelines syntax are invalid. Failing build."
+    #   exit 1
+    # fi
 else
     echo "Non-PR build. Bypassing file change check."
     FILES_CHANGED=$(git diff-tree --no-commit-id --name-only -r -m "$BUILDKITE_COMMIT")


### PR DESCRIPTION
# Description

The latest version of buildkite cli has an issue in pipeline validation. Disabling the pipeline validation step for now to unblock the CI. 

https://github.com/buildkite/pipeline-schema/pull/154

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
