### PR TITLE
fix disagg multihost scatter_kv_slices race condition

### DIFF
--- a/tests/distributed/test_tpu_connector.py
+++ b/tests/distributed/test_tpu_connector.py
@@ -442,8 +442,17 @@ class TestTPUConnectorWorker(unittest.TestCase):
                                            remote_port=123)
         meta.reqs_to_load = {"req1": load_meta}
 
+        worker.runner = MagicMock()
+        original_kv_caches = worker.runner.kv_caches
+        worker.reqs_ready_to_scatter = {"req1": ("kv_data", "indices")}
+        self.all_mocks['scatter_kv_slices'].return_value = "new_kv_caches"
+
         worker.process_send_load(meta)
 
+        self.all_mocks['scatter_kv_slices'].assert_called_once_with(
+            original_kv_caches, "kv_data", "indices")
+        self.assertEqual(worker.runner.kv_caches, "new_kv_caches")
+        self.assertNotIn("req1", worker.reqs_ready_to_scatter)
         worker._maybe_build_notif_socket.assert_called_once_with(load_meta)
         worker._notify_pull_done.assert_called_once_with(
             "socket", "req1", uuid)
@@ -453,7 +462,6 @@ class TestTPUConnectorWorker(unittest.TestCase):
         self.vllm_config.kv_transfer_config.is_kv_producer = False
         worker = tpu_connector.TPUConnectorWorker(self.vllm_config)
         worker.runner = MagicMock()
-        original_kv_caches = worker.runner.kv_caches
 
         mock_future = MagicMock()
         mock_future.done.return_value = True
@@ -465,8 +473,10 @@ class TestTPUConnectorWorker(unittest.TestCase):
         self.assertEqual(done_sending, set())
         self.assertEqual(done_recving, {'req1'})
         self.assertNotIn('req1', worker.reqs_pulling)
-        self.all_mocks['scatter_kv_slices'].assert_called_once_with(
-            original_kv_caches, 'kv_data', 'indices')
+        self.assertIn('req1', worker.reqs_ready_to_scatter)
+        self.assertEqual(worker.reqs_ready_to_scatter['req1'],
+                         ('kv_data', 'indices'))
+        self.all_mocks['scatter_kv_slices'].assert_not_called()
 
     def test_get_finished_sending_expired(self):
         """Tests get_finished for a request that has expired."""

--- a/tpu_inference/distributed/tpu_connector.py
+++ b/tpu_inference/distributed/tpu_connector.py
@@ -449,6 +449,9 @@ class TPUConnectorWorker:
         self.reqs_wait_pull: dict[ReqId, list[list[jax.Array], float]] = {}
         # req_id: thread_future
         self.reqs_pulling: dict[ReqId, Future] = {}
+        # req_id: (kv, indices)
+        self.reqs_ready_to_scatter: dict[ReqId, tuple[list[jax.Array],
+                                                      jax.Array]] = {}
         # the KV cache strafer uuid to request mapping
         # the reason is vllm add prefix + external uuid suffix for each request id
         # for example: prefill req_id:cmpl-cd70b21e-0f2b-46ed-910c-9525f706389a-0-99ae74c8
@@ -599,6 +602,11 @@ class TPUConnectorWorker:
                 self.reqs_pulling[req_id] = self.pull_executor.submit(
                     self._pull_kv, req_id, conn, req_meta, indices)
             else:
+                if req_id in self.reqs_ready_to_scatter:
+                    kv, indices = self.reqs_ready_to_scatter.pop(req_id)
+                    self.runner.kv_caches = scatter_kv_slices(
+                        self.runner.kv_caches, kv, indices)
+
                 # The request has finished pulling the KV from remote, or it has full local
                 # prefix cache, need to notify P to let it free blocks.
                 socket = self._maybe_build_notif_socket(req_meta)
@@ -718,11 +726,8 @@ class TPUConnectorWorker:
         for req_id in list(self.reqs_pulling.keys()):
             future = self.reqs_pulling[req_id]
             if future.done():
-                # NOTE(xiang): we do the scatter in main thread to avoid data racing.
-                # The data racing is not for the kv_caches buffer, it's for the runner.kv_caches ref.
                 kv, indices = future.result()
-                self.runner.kv_caches = scatter_kv_slices(
-                    self.runner.kv_caches, kv, indices)
+                self.reqs_ready_to_scatter[req_id] = (kv, indices)
                 del self.reqs_pulling[req_id]
                 done_recving.add(req_id)
 


### PR DESCRIPTION
# Description

Ensures that asynchronous KV-cache pulled data is temporarily staged and later simultaneously processed into the JAX scatter_kv_slices collective routine by all hosts synchronously


# Tests

bash examples/disagg/run_disagg_multi_host.sh

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
