### PR TITLE
Use Chat Completions for MMMU-Pro and align message format

### DIFF
--- a/scripts/vllm/benchmarking/benchmark_dataset.py
+++ b/scripts/vllm/benchmarking/benchmark_dataset.py
@@ -642,12 +642,10 @@ class MMMUProDataset(BenchmarkDataset):
     def __init__(
         self,
         subset: str = "vision",
-        use_chat_template: bool = True,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
         self.subset = subset
-        self.use_chat_template = use_chat_template
         self.load_data()
 
     def load_data(self) -> None:
@@ -728,33 +726,19 @@ class MMMUProDataset(BenchmarkDataset):
 
             mm_content = self._images_to_mm_content(images or [])
 
-            if self.use_chat_template:
-                # Build message content: images first, then question text.
-                content: list = mm_content
-                content.append({"type": "text", "text": question_text})
-                messages = [{
-                    "role": "user",
-                    "content": content,
-                }]
-                try:
-                    prompt = tokenizer.apply_chat_template(
-                        messages, tokenize=False, add_generation_prompt=True)
-                except Exception as e:
-                    logger.error(
-                        "Could not apply chat template: %s. "
-                        "Falling back to raw prompt.", e)
-                    prompt = question_text
-            else:
-                prompt = question_text
+            # Build message content: images first, then question text.
+            content: list = mm_content
+            content.append({"type": "text", "text": question_text})
+            messages = [{
+                "role": "user",
+                "content": content,
+            }]
 
-            prompt_ids = tokenizer(prompt).input_ids
-            prompt_len = len(prompt_ids)
             new_output_len = output_len if output_len is not None else 16
 
             samples.append(
                 SampleRequest(
-                    prompt=prompt,
-                    prompt_len=prompt_len,
+                    messages=messages,
                     expected_output_len=new_output_len,
                     multi_modal_data=mm_content,
                     completion=answer,

--- a/scripts/vllm/benchmarking/benchmark_serving.py
+++ b/scripts/vllm/benchmarking/benchmark_serving.py
@@ -483,6 +483,13 @@ def main(args: argparse.Namespace):
         trust_remote_code=args.trust_remote_code,
     )
 
+    if args.dataset_name == "mmmu_pro":
+        message = (
+            "MMMU-Pro must use --backend vllm-chat "
+            "and should also use --endpoint=/v1/chat/completions."
+        )
+        assert args.backend == "vllm-chat", message
+
     if args.dataset_name is None:
         raise ValueError(
             "Please specify '--dataset-name' and the corresponding "
@@ -549,7 +556,6 @@ def main(args: argparse.Namespace):
                 random_seed=args.seed,
                 dataset_path=args.dataset_path,
                 subset=args.mmmu_pro_subset,
-                use_chat_template=args.mmmu_pro_use_chat_template,
             ).sample(
                 tokenizer=tokenizer,
                 num_requests=args.num_prompts,
@@ -873,11 +879,6 @@ if __name__ == "__main__":
         type=int,
         default=16,
         help="Output length for each request. Default is 16 (single-letter answer).",
-    )
-    mmmu_pro_group.add_argument(
-        "--mmmu-pro-use-chat-template",
-        action="store_true",
-        help="Whether to format MMMU-Pro prompts using the tokenizer's chat template.",
     )
 
     sonnet_group = parser.add_argument_group("sonnet dataset options")


### PR DESCRIPTION
# Description

Use Chat Completions for MMMU-Pro so we can send images.

Also align message format with other evaluation tool.

# Tests

Run the benchmark tool and verify it runs without problem.

```sh
python scripts/vllm/benchmarking/benchmark_serving.py --model <model-id-here> --dataset-name mmmu_pro --mmmu-pro-subset 'standard (10 options)' --mmmu-pro-output-len=8192 --run-eval --num-prompts 1730 --backend vllm-chat --endpoint /v1/chat/completions
```

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
