### PR TITLE
 Replace jnp.clip(..., a_min=..., a_max=...) with jnp.clip(..., min=.…)

### DIFF
--- a/tpu_inference/kernels/fused_moe/v1/kernel.py
+++ b/tpu_inference/kernels/fused_moe/v1/kernel.py
@@ -68,8 +68,8 @@ def swigluoai(gate: jax.Array,
               alpha: float = 1.702,
               limit: float = 7.0) -> jax.Array:
     """Activation used in some models such as GPT-OSS."""
-    gate = jnp.clip(gate, a_max=limit)
-    up = jnp.clip(up, a_min=-limit, a_max=limit)
+    gate = jnp.clip(gate, max=limit)
+    up = jnp.clip(up, min=-limit, max=limit)
     glu = gate * jax.nn.sigmoid(alpha * gate)
     return (up + 1.0) * glu
 

--- a/tpu_inference/kernels/megablox/gmm_v2.py
+++ b/tpu_inference/kernels/megablox/gmm_v2.py
@@ -34,7 +34,7 @@ def swigluoai(gate: jax.Array,
     """Activation used in some models such as GPT-OSS."""
 
     gate = jnp.clip(gate, a_max=limit)
-    up = jnp.clip(up, a_min=-limit, a_max=limit)
+    up = jnp.clip(up, min=-limit, max=limit)
     glu = gate * jax.nn.sigmoid(alpha * gate)
     return (up + 1.0) * glu
 

--- a/tpu_inference/layers/jax/moe/gpt_oss_moe.py
+++ b/tpu_inference/layers/jax/moe/gpt_oss_moe.py
@@ -73,8 +73,8 @@ class GptOssRouter(Router):
 def _swiglu_split(gate: Float, up: Float, alpha: Float, limit: Float) -> Float:
     """Implements SwiGLU using separate Gate and Up projections."""
     # Clip both inputs
-    x_glu = jnp.clip(gate, a_max=limit)
-    x_linear = jnp.clip(up, a_min=-limit, a_max=limit)
+    x_glu = jnp.clip(gate, max=limit)
+    x_linear = jnp.clip(up, min=-limit, max=limit)
 
     # Compute Activation: (Gate * Sigmoid(Alpha * Gate)) * (Up + 1)
     gated_activation = x_glu * jax.nn.sigmoid(alpha * x_glu)


### PR DESCRIPTION
# Description
[JAX] Replace jnp.clip(..., a_min=..., a_max=...) with jnp.clip(..., min=..., max=...).

a_min and a_max are deprecated parameter names to jax.numpy.clip.