### PR TITLE
Set prompt_token_ids_cpu=None to match upstream interface change

### DIFF
--- a/tpu_inference/runner/input_batch.py
+++ b/tpu_inference/runner/input_batch.py
@@ -163,6 +163,7 @@ class InputBatch:
             prompt_lens=torch.from_numpy(
                 self.num_prompt_tokens[:self.num_reqs]),
             prompt_token_ids=None,
+            prompt_token_ids_cpu=None,
             pooling_params=pooling_params,
             pooling_states=pooling_states,
         )


### PR DESCRIPTION
# Description

Set prompt_token_ids_cpu=None to match https://github.com/vllm-project/tpu-inference/pull/1493

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
