### PR TITLE
Add Qwen3.5 to CI/CD

### DIFF
--- a/.buildkite/pipeline_jax.yml
+++ b/.buildkite/pipeline_jax.yml
@@ -492,7 +492,7 @@ steps:
           queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
         commands:
           - .buildkite/scripts/run_in_docker.sh python3 -m pytest -s -v /workspace/tpu_inference/tests/e2e/test_runai_model_streamer_loader.py::test_correctness_jax_uni_proc_executor
-      
+
       - label: "${TPU_VERSION:-tpu6e} Correctness Test | Runai Model Streamer Torchax UniProcExecutor"
         key: "${TPU_VERSION:-tpu6e}_test_28"
         depends_on: "${TPU_VERSION:-tpu6e}_build_docker"
@@ -504,7 +504,7 @@ steps:
           queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
         commands:
           - .buildkite/scripts/run_in_docker.sh python3 -m pytest -s -v /workspace/tpu_inference/tests/e2e/test_runai_model_streamer_loader.py::test_correctness_torchax_uni_proc_executor
-      
+
       - label: "${TPU_VERSION:-tpu6e} Correctness Test | Runai Model Streamer Torchax RayDistributedExecutor"
         key: "${TPU_VERSION:-tpu6e}_test_29"
         depends_on: "${TPU_VERSION:-tpu6e}_build_docker"
@@ -516,7 +516,62 @@ steps:
           queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}" # Using a queue with more devices for distributed tests
         commands:
           - .buildkite/scripts/run_in_docker.sh python3 -m pytest -s -v /workspace/tpu_inference/tests/e2e/test_runai_model_streamer_loader.py::test_correctness_torchax_ray_distributed_executor
-      
+
+      - label: "${TPU_VERSION:-tpu6e} E2E lm_eval accuracy check Qwen3.5-397B-A17B with gmm kernel."
+        key: ${TPU_VERSION:-tpu6e}_test_30
+        depends_on: "${TPU_VERSION:-tpu6e}_build_docker"
+        soft_fail: true
+        env:
+          USE_PREBUILT_IMAGE: "1"
+          TPU_VERSION: "${TPU_VERSION:-tpu6e}"
+        agents:
+          queue: ${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}
+        # TODO (jacobplatin): we should remove the limit when perf improvements are made
+        # TODO (jacobplatin): the flex threshold is low, but the strict threshold should be
+        # high enough to still make this test useful and representative
+        commands:
+          - |
+            if [[ "$$TPU_VERSION" == "tpu7x" ]]; then
+              .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/check_lm_eval.sh  --model_name "Qwen/Qwen3.5-397B-A17B-FP8" --use_moe_ep_kernel 0 --tensor_parallel_size 8 --max_model_len 4096 --max_num_batched_tokens 4096 --max_gen_toks 2048 --enable_expert_parallel 1 --flex_threshold 0.63 --strict_threshold 0.63 --limit_mm_per_prompt '{"image": 0, "video": 0}' --block_size 256 --limit 100 --enable_thinking false
+            else
+              echo "Skipping: Step requires TPU v7x and either a NIGHTLY build or kernel/requirements changes."
+              exit 0
+            fi
+
+      - label: "${TPU_VERSION:-tpu6e} Perf regression test for Qwen3.5-397B-A17B 1k 8k with gmm kernel."
+        key: ${TPU_VERSION:-tpu6e}_test_31
+        soft_fail: true
+        env:
+          TPU_VERSION: "${TPU_VERSION:-tpu6e}"
+        agents:
+          queue: ${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}
+        if: build.env("NIGHTLY") == "1"
+        # TODO (jacobplatin): we should remove the prompt limit when perf improvements are made
+        # TODO (jacobplatin): the limits here are quite low and they should also be increased
+        # once perf improvements are made
+        commands:
+          - |
+            if [[ "$$TPU_VERSION" == "tpu7x" ]]; then
+              .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/bm_qwen3_coder.sh --model Qwen/Qwen3.5-397B-A17B-FP8 --tp 8 --req_tput_limit 0.04  --output_token_tput_limit 300 --total_token_tput_limit 345 --input_len 1024 --output_len 8192 --use_moe_ep_kernel 0 --limit_mm_per_prompt '{"image": 0, "video": 0}' --block_size 256 --num_prompts 64
+            fi
+
+      - label: "${TPU_VERSION:-tpu6e} Perf regression test for Qwen3.5-397B-A17B 8k 1k with gmm kernel."
+        key: ${TPU_VERSION:-tpu6e}_test_32
+        depends_on: "${TPU_VERSION:-tpu6e}_build_docker"
+        soft_fail: true
+        env:
+          USE_PREBUILT_IMAGE: "1"
+          TPU_VERSION: "${TPU_VERSION:-tpu6e}"
+        agents:
+          queue: ${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}
+        # TODO (jacobplatin): we should remove the prompt limit when perf improvements are made
+        # TODO (jacobplatin): the limits here are quite low and they should also be increased
+        # once perf improvements are made
+        commands:
+          - |
+            if [[ "$$TPU_VERSION" == "tpu7x" ]]; then
+              .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/bm_qwen3_coder.sh --model Qwen/Qwen3.5-397B-A17B-FP8 --tp 8 --req_tput_limit 0.05  --output_token_tput_limit 70 --total_token_tput_limit 650 --input_len 8192 --output_len 1024 --use_moe_ep_kernel 0    --limit_mm_per_prompt '{"image": 0, "video": 0}' --block_size 256 --num_prompts 64
+            fi
 
       # -----------------------------------------------------------------
       # NOTIFICATION STEP
@@ -546,15 +601,20 @@ steps:
           - ${TPU_VERSION:-tpu6e}_test_19
           - ${TPU_VERSION:-tpu6e}_test_20
           - ${TPU_VERSION:-tpu6e}_test_21
+          - ${TPU_VERSION:-tpu6e}_test_22
+          - ${TPU_VERSION:-tpu6e}_test_23
           - ${TPU_VERSION:-tpu6e}_test_24
           - ${TPU_VERSION:-tpu6e}_test_25
           - ${TPU_VERSION:-tpu6e}_test_26
           - ${TPU_VERSION:-tpu6e}_test_27
           - ${TPU_VERSION:-tpu6e}_test_28
           - ${TPU_VERSION:-tpu6e}_test_29
+          - ${TPU_VERSION:-tpu6e}_test_30
+          - ${TPU_VERSION:-tpu6e}_test_31
+          - ${TPU_VERSION:-tpu6e}_test_32
         agents:
           queue: cpu
         commands:
           - |
             .buildkite/scripts/check_results.sh \
-              "TPU JAX Tests Failed" ${TPU_VERSION:-tpu6e}_test_0 ${TPU_VERSION:-tpu6e}_test_1 ${TPU_VERSION:-tpu6e}_test_2 ${TPU_VERSION:-tpu6e}_test_3 ${TPU_VERSION:-tpu6e}_test_4 ${TPU_VERSION:-tpu6e}_test_6 ${TPU_VERSION:-tpu6e}_test_7_1 ${TPU_VERSION:-tpu6e}_test_7_2 ${TPU_VERSION:-tpu6e}_test_7_3 ${TPU_VERSION:-tpu6e}_test_8 ${TPU_VERSION:-tpu6e}_test_9 ${TPU_VERSION:-tpu6e}_test_10 ${TPU_VERSION:-tpu6e}_test_11 ${TPU_VERSION:-tpu6e}_test_12 ${TPU_VERSION:-tpu6e}_test_13 ${TPU_VERSION:-tpu6e}_test_15 ${TPU_VERSION:-tpu6e}_test_16 ${TPU_VERSION:-tpu6e}_test_17 ${TPU_VERSION:-tpu6e}_test_18 ${TPU_VERSION:-tpu6e}_test_19 ${TPU_VERSION:-tpu6e}_test_20 ${TPU_VERSION:-tpu6e}_test_21 ${TPU_VERSION:-tpu6e}_test_22 ${TPU_VERSION:-tpu6e}_test_23 ${TPU_VERSION:-tpu6e}_test_24 ${TPU_VERSION:-tpu6e}_test_25 ${TPU_VERSION:-tpu6e}_test_26
+              "TPU JAX Tests Failed" ${TPU_VERSION:-tpu6e}_test_0 ${TPU_VERSION:-tpu6e}_test_1 ${TPU_VERSION:-tpu6e}_test_2 ${TPU_VERSION:-tpu6e}_test_3 ${TPU_VERSION:-tpu6e}_test_4 ${TPU_VERSION:-tpu6e}_test_6 ${TPU_VERSION:-tpu6e}_test_7_1 ${TPU_VERSION:-tpu6e}_test_7_2 ${TPU_VERSION:-tpu6e}_test_7_3 ${TPU_VERSION:-tpu6e}_test_8 ${TPU_VERSION:-tpu6e}_test_9 ${TPU_VERSION:-tpu6e}_test_10 ${TPU_VERSION:-tpu6e}_test_11 ${TPU_VERSION:-tpu6e}_test_12 ${TPU_VERSION:-tpu6e}_test_13 ${TPU_VERSION:-tpu6e}_test_15 ${TPU_VERSION:-tpu6e}_test_16 ${TPU_VERSION:-tpu6e}_test_17 ${TPU_VERSION:-tpu6e}_test_18 ${TPU_VERSION:-tpu6e}_test_19 ${TPU_VERSION:-tpu6e}_test_20 ${TPU_VERSION:-tpu6e}_test_21 ${TPU_VERSION:-tpu6e}_test_22 ${TPU_VERSION:-tpu6e}_test_23 ${TPU_VERSION:-tpu6e}_test_24 ${TPU_VERSION:-tpu6e}_test_25 ${TPU_VERSION:-tpu6e}_test_26 ${TPU_VERSION:-tpu6e}_test_27 ${TPU_VERSION:-tpu6e}_test_28 ${TPU_VERSION:-tpu6e}_test_29 ${TPU_VERSION:-tpu6e}_test_30 ${TPU_VERSION:-tpu6e}_test_31 ${TPU_VERSION:-tpu6e}_test_32

--- a/tests/e2e/benchmarking/bm_qwen3_coder.sh
+++ b/tests/e2e/benchmarking/bm_qwen3_coder.sh
@@ -31,7 +31,9 @@ set -ex
 
 
 OPTIONS=""
-LONGOPTS=model:,tp:,req_tput_limit:,output_token_tput_limit:,total_token_tput_limit:,input_len:,output_len:,use_moe_ep_kernel:
+LONGOPTS=model:,tp:,req_tput_limit:,output_token_tput_limit:,total_token_tput_limit:,input_len:,output_len:,use_moe_ep_kernel:,limit_mm_per_prompt:,hf_overrides:,block_size:,num_prompts:,num-prompts:
+
+num_prompts=320
 
 # Parse arguments
 if ! PARSED=$(getopt --options="$OPTIONS" --longoptions=$LONGOPTS --name "$0" -- "$@"); then
@@ -73,7 +75,22 @@ while true; do
       use_moe_ep_kernel=$2
       shift 2
       ;;
-
+    --limit_mm_per_prompt)
+      limit_mm_per_prompt=$2
+      shift 2
+      ;;
+    --hf_overrides)
+      hf_overrides=$2
+      shift 2
+      ;;
+    --block_size)
+      block_size=$2
+      shift 2
+      ;;
+    --num_prompts|--num-prompts)
+      num_prompts=$2
+      shift 2
+      ;;
     --)
       shift
       break
@@ -116,7 +133,12 @@ export MODEL_IMPL_TYPE=vllm
 
 echo "bench_serving commit: $(git -C bench_serving rev-parse HEAD)"
 
-vllm serve --seed=42 --model="$model" --max-model-len=10240 --max-num-batched-tokens=8192 --max-num-seqs=512 --no-enable-prefix-caching --tensor-parallel-size="$tp" --kv-cache-dtype=fp8 --gpu-memory-utilization=0.95 --async-scheduling --enable-expert-parallel   2>&1 | tee vllm_server_out.txt &
+EXTRA_VLLM_ARGS=()
+if [ -n "$limit_mm_per_prompt" ]; then EXTRA_VLLM_ARGS+=("--limit-mm-per-prompt" "$limit_mm_per_prompt"); fi
+if [ -n "$hf_overrides" ]; then EXTRA_VLLM_ARGS+=("--hf-overrides" "$hf_overrides"); fi
+if [ -n "$block_size" ]; then EXTRA_VLLM_ARGS+=("--block-size" "$block_size"); fi
+
+vllm serve --seed=42 --model="$model" --max-model-len=10240 --max-num-batched-tokens=8192 --max-num-seqs=512 --no-enable-prefix-caching --tensor-parallel-size="$tp" --kv-cache-dtype=fp8 --gpu-memory-utilization=0.95 --async-scheduling --enable-expert-parallel "${EXTRA_VLLM_ARGS[@]}"   2>&1 | tee vllm_server_out.txt &
 
 # Trap registers the cleanup as a handler for the EXIT. Whenever the shell exits, it runs `cleanup` before terminating.
 # The trap does not affect the exit status. When an EXIT trap fires, the script's exit status is whatever it was before the trap was triggered.
@@ -177,7 +199,7 @@ check_metrics() {
 
 
 echo "----------------------------------------------------------------"
-echo "Running benchmark with input_len=$input_len and output_len=$output_len"
+echo "Running benchmark with input_len=$input_len and output_len=$output_len num_prompts=$num_prompts"
 echo "----------------------------------------------------------------"
 benchmark_output=$(python3 bench_serving/benchmark_serving.py \
   --model="$model" \
@@ -188,7 +210,7 @@ benchmark_output=$(python3 bench_serving/benchmark_serving.py \
   --random-input-len="$input_len" \
   --random-output-len="$output_len" \
   --random-range-ratio=0.8 \
-  --num-prompts=320 \
+  --num-prompts="$num_prompts" \
   --max-concurrency=64 \
   --request-rate=inf \
   --ignore-eos 2>&1 | tee vllm_benchmark_out.txt)

--- a/tests/e2e/check_lm_eval.sh
+++ b/tests/e2e/check_lm_eval.sh
@@ -34,6 +34,11 @@ usage() {
     echo "  --enable_expert_parallel <0|1>  Whether to enable expert parallel."
     echo "  --flex_threshold <float>        Threshold for flexible-extract score."
     echo "  --strict_threshold <float>      Threshold for strict-match score."
+    echo "  --limit_mm_per_prompt <json>    (Optional) Limit multimodal items per prompt."
+    echo "  --hf_overrides <json>           (Optional) HuggingFace overrides."
+    echo "  --block_size <int>              (Optional) Block size."
+    echo "  --limit <int>                   (Optional) Limit the number of examples evaluated (e.g., 10)."
+    echo "  --enable_thinking <true|false>  (Optional) Enable thinking inside model_args."
     echo "  -h, --help                      Display this help message."
     exit 1
 }
@@ -48,6 +53,11 @@ MAX_GEN_TOKS=""
 ENABLE_EXPERT_PARALLEL=""
 FLEX_THRESHOLD=""
 STRICT_THRESHOLD=""
+LIMIT_MM_PER_PROMPT=""
+HF_OVERRIDES=""
+BLOCK_SIZE=""
+LIMIT=""
+ENABLE_THINKING=""
 
 # Parse named arguments
 while [[ "$#" -gt 0 ]]; do
@@ -61,6 +71,11 @@ while [[ "$#" -gt 0 ]]; do
         --enable_expert_parallel) ENABLE_EXPERT_PARALLEL="$2"; shift ;;
         --flex_threshold) FLEX_THRESHOLD="$2"; shift ;;
         --strict_threshold) STRICT_THRESHOLD="$2"; shift ;;
+        --limit_mm_per_prompt) LIMIT_MM_PER_PROMPT="$2"; shift ;;
+        --hf_overrides) HF_OVERRIDES="$2"; shift ;;
+        --block_size) BLOCK_SIZE="$2"; shift ;;
+        --limit) LIMIT="$2"; shift ;;
+        --enable_thinking) ENABLE_THINKING="$2"; shift ;;
         -h|--help) usage ;;
         *) echo "Unknown parameter passed: $1"; usage ;;
     esac
@@ -73,14 +88,38 @@ if [ -z "$MODEL_NAME" ] || [ -z "$USE_MOE_EP_KERNEL" ] || [ -z "$TENSOR_PARALLEL
     usage
 fi
 
-model_args_json=$(printf '{"pretrained": "%s", "tensor_parallel_size": %d, "max_model_len": %d, "max_num_batched_tokens": %d, "max_gen_toks": %d, "enable_expert_parallel": %d}' "$MODEL_NAME" "$TENSOR_PARALLEL_SIZE" "$MAX_MODEL_LEN" "$MAX_NUM_BATCHED_TOKENS" "$MAX_GEN_TOKS" "$ENABLE_EXPERT_PARALLEL")
-output=$(VLLM_XLA_CHECK_RECOMPILATION=0 USE_MOE_EP_KERNEL=${USE_MOE_EP_KERNEL} MODEL_IMPL_TYPE=vllm lm_eval \
-    --model vllm \
-    --model_args "${model_args_json}" \
-    --tasks gsm8k_cot \
-    --batch_size auto \
-    --apply_chat_template \
-    --num_fewshot 8)
+extra_json=""
+if [ -n "$LIMIT_MM_PER_PROMPT" ]; then
+    extra_json+=$(printf ', "limit_mm_per_prompt": %s' "$LIMIT_MM_PER_PROMPT")
+fi
+if [ -n "$HF_OVERRIDES" ]; then
+    extra_json+=$(printf ', "hf_overrides": %s' "$HF_OVERRIDES")
+fi
+if [ -n "$BLOCK_SIZE" ]; then
+    extra_json+=$(printf ', "block_size": %s' "$BLOCK_SIZE")
+fi
+if [ -n "$ENABLE_THINKING" ]; then
+    extra_json+=$(printf ', "enable_thinking": %s' "$ENABLE_THINKING")
+fi
+
+
+model_args_json=$(printf '{"pretrained": "%s", "tensor_parallel_size": %d, "max_model_len": %d, "max_num_batched_tokens": %d, "max_gen_toks": %d, "enable_expert_parallel": %d%s}' "$MODEL_NAME" "$TENSOR_PARALLEL_SIZE" "$MAX_MODEL_LEN" "$MAX_NUM_BATCHED_TOKENS" "$MAX_GEN_TOKS" "$ENABLE_EXPERT_PARALLEL" "$extra_json")
+# Build lm_eval arguments
+lm_eval_args=(
+    --model vllm
+    --model_args "${model_args_json}"
+    --tasks gsm8k_cot
+    --batch_size auto
+    --apply_chat_template
+    --num_fewshot 8
+)
+
+# Append --limit if provided
+if [ -n "$LIMIT" ]; then
+    lm_eval_args+=(--limit "$LIMIT")
+fi
+
+output=$(VLLM_XLA_CHECK_RECOMPILATION=0 USE_MOE_EP_KERNEL=${USE_MOE_EP_KERNEL} MODEL_IMPL_TYPE=vllm lm_eval "${lm_eval_args[@]}")
 
 echo "Evaluation output:"
 echo "$output"


### PR DESCRIPTION
# Description

Adds accuracy and regression tests for Qwen3.5-397B-A17B-FP8 on v7x-8 (GMM kernel only)

# Tests

Tested locally and in this build: https://buildkite.com/tpu-commons/tpu-inference-ci/builds/13876#_

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
