### PR TITLE
Fix DPScheduler worker process hang on exit

### DIFF
--- a/tpu_inference/core/sched/dp_scheduler.py
+++ b/tpu_inference/core/sched/dp_scheduler.py
@@ -876,10 +876,15 @@ class DPScheduler(SchedulerInterface):
         """Forward request finish signals to the appropriate DP rank schedulers."""
         if isinstance(request_ids, str):
             request_ids = [request_ids]
+        elif request_ids is None:
+            # None means finish all requests (matches base scheduler behavior)
+            request_ids = list(self.assigned_dp_rank.keys())
 
         # Route finish signals to appropriate schedulers
         rank_request_ids = defaultdict(list)
         for req_id in request_ids:
+            if req_id not in self.assigned_dp_rank:
+                continue
             rank = self.assigned_dp_rank[req_id]
             rank_request_ids[rank].append(req_id)
 


### PR DESCRIPTION
# Description

The DPScheduler forks worker processes using `multiprocessing.get_context('fork')`. On exit, the program hangs indefinitely at `os.waitpid()` inside Python's `multiprocessing._exit_function` atexit handler. This handler tries to `join()` all child processes, but the workers are either:

- Deadlocked in their own atexit handlers — forked workers inherit the parent's _exit_function, which tries to join sibling worker processes, creating a circular wait.
- Still alive and blocked on pipe read if shutdown() is never called 

In the normal exit path, the engine calls `scheduler.shutdown()` which terminates workers, so by the time `_exit_function` runs, the workers are already dead → `os.waitpid()` returns immediately → no hang.

If the process exits via Ctrl+C, unhandled exception, or a code path that skips `shutdown()`, `_exit_function` runs while workers are still alive → hang.


# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
