### PR TITLE
Call `_align_hybrid_block_size` in `TpuPlatform`

### DIFF
--- a/tests/platforms/test_tpu_platform.py
+++ b/tests/platforms/test_tpu_platform.py
@@ -265,3 +265,28 @@ class TestTpuPlatform:
     def test_update_block_size_for_backend(self, vllm_config):
         # Current implementation explicitly performs 'pass'. Ensure it returns safely.
         TpuPlatform.update_block_size_for_backend(vllm_config)
+
+    def test_update_block_size_for_backend_align_hybrid_block_size(
+            self, vllm_config):
+        vllm_config.model_config.architecture = "Qwen3_5ForConditionalGeneration"
+        vllm_config.model_config.is_hybrid = True
+        vllm_config.model_config.get_num_kv_heads.return_value = 2
+        vllm_config.model_config.get_head_size.return_value = 256
+        vllm_config.model_config.dtype = torch.uint8
+        vllm_config.parallel_config.tensor_parallel_size = 8
+        vllm_config.cache_config.block_size = -1
+
+        mock_backend = MagicMock()
+        mock_backend.get_mamba_state_shape_from_config.return_value = ((3,
+                                                                        1536),
+                                                                       (8, 128,
+                                                                        128))
+        mock_backend.get_mamba_state_dtype_from_config.return_value = (
+            torch.bfloat16, torch.float32)
+        mock_backend.get_supported_kernel_block_sizes.return_value = [256]
+
+        with patch.object(TpuPlatform, '_find_non_ssm_backend', return_value=mock_backend), \
+             patch('vllm.model_executor.models.ModelRegistry.resolve_model_cls', return_value=(mock_backend, MagicMock())):
+            TpuPlatform.update_block_size_for_backend(vllm_config)
+
+        assert vllm_config.cache_config.block_size == 1280

--- a/tpu_inference/platforms/tpu_platform.py
+++ b/tpu_inference/platforms/tpu_platform.py
@@ -282,7 +282,15 @@ class TpuPlatform(Platform):
     def update_block_size_for_backend(cls, vllm_config: VllmConfig) -> None:
         # TODO: TPU still sets block_size in check_and_update_config.
         # Move that logic here so block_size is chosen by the backend.
-        pass
+
+        # Align block/mamba sizes for hybrid model (may override user settings).
+        if vllm_config.model_config.is_hybrid:
+            backend_cls = cls._find_non_ssm_backend(vllm_config)
+            if backend_cls is None:
+                return
+            cls._align_hybrid_block_size(vllm_config, backend_cls)
+
+        return
 
     @classmethod
     def is_pin_memory_available(cls):


### PR DESCRIPTION
# Description

 - https://github.com/vllm-project/vllm/pull/37467 moved logic to update block size for hybrid mamba models into `Platform`, call the same in `TpuPlatform` to ensure the block size of attention layers is updated such that their page size >= page size of mamba layers. This is needed to later unify the page sizes of both layers.

# Tests
 - Add unit test.
 - `MODEL_IMPL_TYPE=vllm python examples/offline_inference.py --model=Qwen/Qwen3.5-397B-A17B-FP8 --tensor-parallel-size=8  --limit-mm-per-prompt '{"image": 0, "video": 0}'   --hf-overrides '{"text_config": {"rope_parameters": null, "rope_theta": 10000000, "partial_rotary_factor": 0.25}}' --block-size=256 --gpu-memory-utilization=0.8 --top_p=1.0 --top_k=-1 --temperature=0 --kv-cache-dtype=fp8  --chat-template-kwargs='{"enable_thinking": false}'`
  - CI

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
