### PR TITLE
[CI] Fix sharding mismatch of _substitute_placeholder_token causing recompilation

### DIFF
--- a/tpu_inference/runner/compilation_manager.py
+++ b/tpu_inference/runner/compilation_manager.py
@@ -296,9 +296,7 @@ class CompilationManager:
                 next_tokens = self._create_dummy_tensor(
                     (num_reqs, ),
                     jnp.int32,
-                    sharding=NamedSharding(
-                        self.runner.mesh,
-                        PartitionSpec()))
+                    sharding=NamedSharding(self.runner.mesh, PartitionSpec()))
 
                 placeholder_num = jnp.asarray(1, dtype=jnp.int32)
                 self._run_compilation(


### PR DESCRIPTION
# Description

Fix the sharding mismatch of `_substitute_placeholder_token`, which caused the recompilation of Qwen2.5-VL.

# Tests

Tested with:
```
export TEST_MODEL="Qwen/Qwen2.5-VL-7B-Instruct"
export TENSOR_PARALLEL_SIZE=1
python -m pytest -s -rP test_accuracy.py::test_lm_eval_accuracy_v1_engine \
    --model-name="$TEST_MODEL" \
    --tensor-parallel-size="$TENSOR_PARALLEL_SIZE"
```

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
