### PR TITLE
[Jax][MoE] allow externally computed router logits

### DIFF
--- a/tpu_inference/layers/jax/moe/moe.py
+++ b/tpu_inference/layers/jax/moe/moe.py
@@ -170,7 +170,7 @@ class JaxMoE(JaxModule):
     quant_config: Optional[QuantizationConfig] = None
     prefix: str = ""
 
-    def __call__(self, x_TD: Float):
+    def __call__(self, x_TD: jax.Array) -> jax.Array:
         """Performs the forward pass of the MoE layer.
 
         Args:
@@ -180,7 +180,10 @@ class JaxMoE(JaxModule):
             Output array of shape (sequence_length, d_model) after passing through MoE.
         """
         if self.quant_method is not None:
-            return self.quant_method.apply_jax(self, x_TD)
+            router_logits = self.router(x_TD)
+            return self.quant_method.apply_jax(self,
+                                               x_TD,
+                                               router_logits=router_logits)
         raise ValueError("Expected quant_method to be set!")
 
     def __post_init__(self, rngs: nnx.Rngs):

--- a/tpu_inference/layers/jax/quantization/fp8.py
+++ b/tpu_inference/layers/jax/quantization/fp8.py
@@ -573,7 +573,8 @@ class Fp8FusedMoEMethod(QuantizeMethodBase):
 
         return True
 
-    def apply_jax(self, layer: JaxModule, x: jax.Array) -> jax.Array:
+    def apply_jax(self, layer: JaxModule, x: jax.Array, *,
+                  router_logits: jax.Array) -> jax.Array:
         """
         Run the forward pass of the MoE layer.
 
@@ -592,11 +593,9 @@ class Fp8FusedMoEMethod(QuantizeMethodBase):
             jax.sharding.NamedSharding(layer.mesh,
                                        P(*layer.activation_ffw_td)))
 
-        router_logits = None
         # Fused weight backends
         if layer.moe_backend in FP8_QUANT_METHOD_SUPPORTED_MOE_BACKENDS:
-            # of shape TE -- we don't return the indices
-            router_logits = layer.router(x_TD)
+            # router_logits is of shape TE -- we don't return the indices
 
             if layer.moe_backend == MoEBackend.FUSED_MOE:
                 w13_weight = layer.kernel_gating_upproj_E2DF[...]

--- a/tpu_inference/layers/jax/quantization/unquantized.py
+++ b/tpu_inference/layers/jax/quantization/unquantized.py
@@ -128,18 +128,21 @@ class UnquantizedFusedMoEMethod(QuantizeMethodBase):
 
         return True
 
-    def apply_jax(self, layer: JaxModule, x: jax.Array) -> jax.Array:
-        assert isinstance(layer, JaxMoE)
-
+    def apply_jax(self, layer: JaxMoE, x: jax.Array, *,
+                  router_logits: jax.Array) -> jax.Array:
+        """Forward pass for MoE layer.
+        Args:
+            layer: The MoE layer to apply.
+            x: The input activations to the MoE layer, of shape [seq_len, hidden_size].
+            router_logits: The routing logits for the MoE layer, of shape [seq_len, num_experts].
+        """
         x_TD = jnp.asarray(x, layer.dtype)
         x_TD = jax.lax.with_sharding_constraint(
             x_TD, NamedSharding(layer.mesh, P(*layer.activation_ffw_td)))
 
-        router_logits = None
         # Fused weight backends
         if layer.moe_backend in MoEBackend.fused_moe_backends():
-            # of shape TE, only 1D in this case
-            router_logits = layer.router(x_TD)
+            # router_logits is of shape TE, only 1D in this case
 
             w13_weight = layer.kernel_gating_upproj_E2DF.value if layer.moe_backend == MoEBackend.FUSED_MOE else layer.kernel_gating_upproj_EDF.value
             w2_weight = layer.kernel_down_proj_EFD.value
@@ -157,8 +160,7 @@ class UnquantizedFusedMoEMethod(QuantizeMethodBase):
         elif layer.moe_backend in [
                 MoEBackend.DENSE_MAT, MoEBackend.MEGABLX_GMM
         ]:
-            # Composed of weights_TX and indices_TX, so 2D in this case
-            router_logits = layer.router(x_TD)
+            # router_logits is composed of weights_TX and indices_TX, so 2D in this case
             # TODO (jacobplatin/bzgoogle): we should support bias
             weights = UnfusedMoEWeights(
                 w1_weight=layer.kernel_gating_EDF.value,


### PR DESCRIPTION
# Description

As titled

* Moving `router_logits = layer.router(x_TD)` into module level
* `apply_jax` of each method accepts logits as paramter

# Tests

1. CI
2. serve qwen and test
```
MODEL_IMPL_TYPE=flax_nnx vllm serve Qwen/Qwen3-30B-A3B-Instruct-2507 --max-model-
len=2048

curl http://localhost:8000/v1/chat/completions \
    -H "Content-Type: application/json" \
    -d '{
        "model": "Qwen/Qwen3-30B-A3B-Instruct-2507",
        "messages": [
            {"role": "system", "content": "You are a helpful assistant."},
            {"role": "user", "content": "Who won the world series in 2020?"}
        ],
        "max_tokens": 25,
        "temperature": 0.0
    }'
...
"content":"The Los Angeles Dodgers won the World Series in 2020. They defeated the Tampa Bay Rays in six games,"
```

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
