### PR TITLE
Add ragged_conv1d for ragged chunked kernel integration for gdn attention

### DIFF
--- a/tpu_inference/layers/vllm/ops/gdn_attention.py
+++ b/tpu_inference/layers/vllm/ops/gdn_attention.py
@@ -673,7 +673,7 @@ def gdn_attention_core_tpu(
     # E.g. they are in [Q Q | K K | V V] layout. We need [Q K | Q K | Q K] layout.
     # Use reorder_concatenated_tensor_for_sharding to reorder into correct layout
     key_dim = n_kq * d_k
-    value_dim = n_v * d_k
+    value_dim = n_v * d_v
     tp_size = mesh.shape[ShardingAxisName.ATTN_HEAD]
     j_mixed_qkv = reorder_concatenated_tensor_for_sharding(
         j_mixed_qkv, [key_dim, key_dim, value_dim], tp_size, -1)


### PR DESCRIPTION
# Description

Add ragged_conv1d for ragged chunked kernel integration for gdn attention

* Add ragged_conv1d
* Add interface for ragged gated delta rule
* Use reorder_concatenated_tensor_for_sharding for sharding conversion to simplify code
*  Updated argument comments to make them clear


# Tests

Tested quality and performance of qwen 3.5 model. At gives right answers in examples/offline_inference.py
Tested numerical on par with previous implementation

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
