### PR TITLE
Fix MoE weight loading memory leak and re-enable jax_dummy test

### DIFF
--- a/tests/models/jax/test_qwen3_moe.py
+++ b/tests/models/jax/test_qwen3_moe.py
@@ -37,8 +37,8 @@ class TestQwen3MoeForCausalLM:
     ])
     @pytest.mark.parametrize("pp_rank,pp_world_size", [(0, 1), (0, 4), (1, 4),
                                                        (3, 4)])
-    @pytest.mark.parametrize("load_format",
-                             ["skip_layers_model_loader_for_test"])
+    @pytest.mark.parametrize(
+        "load_format", ["skip_layers_model_loader_for_test", "jax_dummy"])
     def test_model_loading(
             self,
             model_name,

--- a/tpu_inference/layers/jax/quantization/unquantized.py
+++ b/tpu_inference/layers/jax/quantization/unquantized.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import gc
 from typing import Optional
 
 import jax
@@ -118,9 +119,15 @@ class UnquantizedFusedMoEMethod(QuantizeMethodBase):
                 return False
             w_gate = layer.kernel_gating_EDF.get_value()
             w_up = layer.kernel_up_proj_EDF.get_value()
+            w2_val = layer.kernel_down_proj_EFD.get_value()
+
+            # Free old params before processing to reduce peak memory.
+            del layer.kernel_gating_EDF
+            del layer.kernel_up_proj_EDF
 
             # Fuse the weights into w13: [Gate, Up]
             w13_val = jnp.concatenate([w_gate, w_up], axis=1)
+            del w_gate, w_up
 
             weights = jax_common.process_unquantized_moe_weights(
                 mesh=jax.sharding.get_mesh(),
@@ -128,7 +135,7 @@ class UnquantizedFusedMoEMethod(QuantizeMethodBase):
                 activation=layer.activation,
                 w13_weight=w13_val,
                 w13_bias=None,
-                w2_weight=layer.kernel_down_proj_EFD.get_value(),
+                w2_weight=w2_val,
                 w2_bias=None,
             )
 
@@ -136,10 +143,14 @@ class UnquantizedFusedMoEMethod(QuantizeMethodBase):
             layer.kernel_gating_upproj_EDF = nnx.Param(weights.w13_weight)
             layer.kernel_down_proj_EFD = nnx.Param(weights.w2_weight)
 
-            del layer.kernel_gating_EDF
-            del layer.kernel_up_proj_EDF
             del weights
             del w13_val
+            del w2_val
+
+            # Break reference cycles between JAX arrays and flax nnx.Param
+            # objects created during weight processing. Without this, stale
+            # arrays accumulate across MoE layers and inflate peak memory.
+            gc.collect()
 
         return True
 


### PR DESCRIPTION
## Summary
- Add `gc.collect()` after MoE weight processing in the GMM_TP/EP code path to break reference cycles between JAX arrays and flax nnx.Param objects
- Move `del layer.kernel_gating_EDF / kernel_up_proj_EDF` before the JIT processing call and extract w2 value earlier to free old params sooner
- Re-enable `jax_dummy` in test_qwen3_moe.py parametrize (was removed to work around the memory issue)

## Context
The MoE weight refactor introduced `process_unquantized_moe_weights` (JIT'd), which creates intermediate JAX arrays (swapaxes copies, padding, FusedMoEWeights dataclass) that form reference cycles with flax nnx.Param objects. Python's reference counting can't free cycles, so stale arrays accumulate across MoE layers, inflating peak device memory by ~5 GB.

Evidence (jax_dummy test, Qwen3-30B-A3B MoE on v6e-8):
- Before #2020: peak_delta=1.489 GB, after=6.552 GB -- PASS
- After: peak_delta=6.739 GB, after=11.427 GB -- FAIL (stale arrays accumulate across layers)
- After + this fix: peak_delta=0.739 GB, after=5.802 GB -- PASS

## Tests
- All 16 qwen3_moe tests pass (8 skip_layers + 8 jax_dummy, both FP8 and non-FP8, all pp_rank/pp_world_size combos)

## Checklist
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.