### PR TITLE
Add torchax support for EAGLE-3

### DIFF
--- a/tests/models/common/test_model_loader.py
+++ b/tests/models/common/test_model_loader.py
@@ -385,7 +385,7 @@ class TestGetModel:
         result = model_loader.get_model(vllm_config, rng, mesh)
 
         mock_get_flax.assert_not_called()
-        mock_get_vllm.assert_called_once_with(vllm_config, rng, mesh)
+        mock_get_vllm.assert_called_once_with(vllm_config, rng, mesh, False)
         assert result == "vllm_model_sentinel"
 
     @patch.dict(os.environ, {"MODEL_IMPL_TYPE": "flax_nnx"}, clear=True)
@@ -415,7 +415,7 @@ class TestGetModel:
         result = model_loader.get_model(vllm_config, rng, mesh)
 
         mock_get_flax.assert_not_called()
-        mock_get_vllm.assert_called_once_with(vllm_config, rng, mesh)
+        mock_get_vllm.assert_called_once_with(vllm_config, rng, mesh, False)
         assert result == "vllm_model_sentinel"
 
     @patch.dict(os.environ, {"MODEL_IMPL_TYPE": "flax_nnx"}, clear=True)
@@ -436,7 +436,7 @@ class TestGetModel:
 
         # Check that both were called
         mock_get_flax.assert_called_once_with(vllm_config, rng, mesh, False)
-        mock_get_vllm.assert_called_once_with(vllm_config, rng, mesh)
+        mock_get_vllm.assert_called_once_with(vllm_config, rng, mesh, False)
         assert result == "vllm_fallback_sentinel"
 
     @patch.dict(os.environ, {"MODEL_IMPL_TYPE": "flax_nnx"}, clear=True)
@@ -508,5 +508,5 @@ class TestGetModel:
         result = model_loader.get_model(vllm_config, rng, mesh)
 
         mock_get_flax.assert_not_called()
-        mock_get_vllm.assert_called_once_with(vllm_config, rng, mesh)
+        mock_get_vllm.assert_called_once_with(vllm_config, rng, mesh, False)
         assert result == "vllm_model_sentinel"

--- a/tests/spec_decode/test_eagle3.py
+++ b/tests/spec_decode/test_eagle3.py
@@ -185,7 +185,7 @@ def test_propose(method, num_speculative_tokens):
     base_token_ids = [42, 60]
 
     def mock_model_fn(state, kv_caches, input_ids, target_hidden_states,
-                      attn_metadata):
+                      attn_metadata, layer_name_to_kvcache_index):
         """
         Mock model_fn.
         Returns: (kv_caches, hidden_states_for_logits, residual_tuple)

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -215,6 +215,12 @@ def test_model_impl_type_choices(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv("MODEL_IMPL_TYPE", "vllm")
     assert envs.MODEL_IMPL_TYPE == "vllm"
 
+    monkeypatch.setenv("DRAFT_MODEL_IMPL_TYPE", "flax_nnx")
+    assert envs.DRAFT_MODEL_IMPL_TYPE == "flax_nnx"
+
+    monkeypatch.setenv("DRAFT_MODEL_IMPL_TYPE", "vllm")
+    assert envs.DRAFT_MODEL_IMPL_TYPE == "vllm"
+
 
 def test_string_env_vars_defaults(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.delenv("JAX_PLATFORMS", raising=False)

--- a/tpu_inference/envs.py
+++ b/tpu_inference/envs.py
@@ -17,6 +17,7 @@ if TYPE_CHECKING:
     SKIP_JAX_PRECOMPILE: bool = False
     VLLM_XLA_CHECK_RECOMPILATION: bool = False
     MODEL_IMPL_TYPE: str = "auto"
+    DRAFT_MODEL_IMPL_TYPE: str = "auto"
     NEW_MODEL_DESIGN: bool = False
     PHASED_PROFILING_DIR: str = ""
     PYTHON_TRACER_LEVEL: int = 1
@@ -170,6 +171,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "MODEL_IMPL_TYPE":
     env_with_choices("MODEL_IMPL_TYPE", "auto",
                      ["auto", "vllm", "flax_nnx", "jetpack"]),
+    "DRAFT_MODEL_IMPL_TYPE":
+    env_with_choices("DRAFT_MODEL_IMPL_TYPE", "auto",
+                     ["auto", "vllm", "flax_nnx"]),
     # Enable 2D tensor parallelism, shard attention heads across multiple axes
     "USE_2D_TP":
     env_bool("USE_2D_TP", default=False),

--- a/tpu_inference/models/common/model_loader.py
+++ b/tpu_inference/models/common/model_loader.py
@@ -300,6 +300,19 @@ def get_flax_model(
         model = nnx.merge(graphdef, state)
         return model(*args)
 
+    @jax.jit(
+        out_shardings=(
+            kv_cache_sharding,
+            hidden_states_sharding,
+            hidden_states_sharding,  # residual
+        ),
+        donate_argnums=2,  # 0 is graphdef, 1 is state, 2 is kv_cache
+        static_argnums=(6, ),  # 6 is layer_name_to_kvcache_index
+    )
+    def run_draft_model(graphdef, state, *args):
+        model = nnx.merge(graphdef, state)
+        return model(*args)
+
     logits_sharding = NamedSharding(
         mesh,
         PartitionSpec(ShardingAxisName.MLP_DATA, ShardingAxisName.MLP_TENSOR))
@@ -332,7 +345,9 @@ def get_flax_model(
     model = nnx.merge(graphdef, state)
     precompile_vision_encoder_fn = getattr(model, "precompile_vision_encoder",
                                            None)
-    model_fn = functools.partial(run_model, graphdef)
+    model_fn = functools.partial(
+        run_draft_model, graphdef) if is_draft_model else functools.partial(
+            run_model, graphdef)
     compute_logits_fn = functools.partial(run_compute_logits, graphdef)
     embed_multimodal_fn = functools.partial(run_embed_multimodal, graphdef)
     embed_input_ids_fn = functools.partial(run_embed_input_ids, graphdef)
@@ -358,6 +373,7 @@ def get_vllm_model(
     vllm_config: VllmConfig,
     rng: jax.Array,
     mesh: Mesh,
+    is_draft_model: bool = False,
 ):
     model_dtype = to_torch_dtype(vllm_config.model_config.dtype)
     vllm_config.model_config.dtype = model_dtype
@@ -367,12 +383,14 @@ def get_vllm_model(
         vllm_config=vllm_config,
         rng=rng,
         mesh=mesh,
+        is_draft_model=is_draft_model,
     )
     params, lora_manager = model.load_weights()
 
     jit_model = model.jit_step_func()
     compute_logits_fn = model.jit_compute_logits_func()
     pooler_fn = model.build_pooler_func()
+    combine_hidden_states_fn = model.jit_combine_hidden_states_func()
 
     multimodal_fns = {
         "precompile_vision_encoder_fn":
@@ -386,7 +404,6 @@ def get_vllm_model(
     }
 
     # the model needs to be returned because lora weights are neither torch.nn.parameter nor torch.nn.buffer. After we load the lora weights and set it to the torch.nn.Module, we can shard it and move it to TPU.
-    combine_hidden_states_fn = None
     return jit_model, compute_logits_fn, pooler_fn, combine_hidden_states_fn, multimodal_fns, params, lora_manager, model
 
 
@@ -396,10 +413,13 @@ def get_model(
     mesh: Mesh,
     is_draft_model: bool = False,
 ) -> Any:
-    impl = envs.MODEL_IMPL_TYPE
+    if is_draft_model:
+        impl = envs.DRAFT_MODEL_IMPL_TYPE
+    else:
+        impl = envs.MODEL_IMPL_TYPE
     logger.info(f"Loading model with MODEL_IMPL_TYPE={impl}")
     if impl == "auto":
-        impl = resolve_model_architecture(vllm_config)
+        impl = resolve_model_architecture(vllm_config, is_draft_model)
         logger.info(f"Resolved MODEL_IMPL_TYPE 'auto' to '{impl}'")
 
     match impl:
@@ -411,7 +431,8 @@ def get_model(
                     logger.warning(
                         "PP is not fully supported on Jax flax_nnx %s models yet, fallback to vllm models.",
                         arch)
-                    return get_vllm_model(vllm_config, rng, mesh)
+                    return get_vllm_model(vllm_config, rng, mesh,
+                                          is_draft_model)
                 try:
                     # Try to load the flax model first
                     return get_flax_model(vllm_config, rng, mesh,
@@ -423,14 +444,16 @@ def get_model(
                     logger.warning(error_msg)
 
                     # Fall back to the vLLM model and updating the dtype accordingly
-                    return get_vllm_model(vllm_config, rng, mesh)
+                    return get_vllm_model(vllm_config, rng, mesh,
+                                          is_draft_model)
         case "vllm":
-            return get_vllm_model(vllm_config, rng, mesh)
+            return get_vllm_model(vllm_config, rng, mesh, is_draft_model)
         case _:
             raise NotImplementedError(f"Unsupported MODEL_IMPL_TYPE: {impl}")
 
 
-def resolve_model_architecture(vllm_config: VllmConfig) -> str:
+def resolve_model_architecture(vllm_config: VllmConfig,
+                               is_draft_model: bool) -> str:
     """Resolves the model implementation type.
 
     This function determines which model implementation to use based on the model
@@ -459,11 +482,11 @@ def resolve_model_architecture(vllm_config: VllmConfig) -> str:
 
     is_runai_streamer = getattr(getattr(vllm_config, 'load_config', None),
                                 'load_format', None) == 'runai_streamer'
+    hf_config = vllm_config.speculative_config.draft_model_config.hf_config if is_draft_model else vllm_config.model_config.hf_config
     if is_runai_streamer:
         try:
             # Try to get the JAX model class
-            model_class = _get_model_architecture(
-                vllm_config.model_config.hf_config)
+            model_class = _get_model_architecture(hf_config)
 
             # If found, check for WeightLoader capability
             if not hasattr(model_class, "WeightLoader") or not issubclass(
@@ -479,8 +502,7 @@ def resolve_model_architecture(vllm_config: VllmConfig) -> str:
             pass
 
     # Resolve "auto" based on architecture
-    architectures = getattr(vllm_config.model_config.hf_config,
-                            "architectures", [])
+    architectures = getattr(hf_config, "architectures", [])
     assert len(architectures) == 1, (
         f"Expected exactly one architecture, got {len(architectures)}: "
         f"{architectures}")

--- a/tpu_inference/models/jax/llama_eagle3.py
+++ b/tpu_inference/models/jax/llama_eagle3.py
@@ -200,7 +200,6 @@ class Eagle3LlamaModel(nnx.Module):
             attention_metadata,
         )
 
-        # TODO(ranlihao): Check if this residual connection is correct.
         hidden_states = hidden_states + residual
         residual = hidden_states
         hidden_states = self.norm(hidden_states)
@@ -302,6 +301,7 @@ class EagleLlama3ForCausalLM(nnx.Module):
         input_ids: jax.Array,
         hidden_states: jax.Array,
         attention_metadata: AttentionMetadata,
+        _layer_name_to_kv_cache=None,
     ) -> Tuple[List[jax.Array], jax.Array, List[jax.Array]]:
         return self.model(
             kv_caches,

--- a/tpu_inference/models/vllm/vllm_model_wrapper.py
+++ b/tpu_inference/models/vllm/vllm_model_wrapper.py
@@ -42,6 +42,8 @@ from vllm.model_executor.models.interfaces_base import is_pooling_model
 from vllm.sequence import IntermediateTensors
 from vllm.v1.outputs import PoolerOutput
 from vllm.v1.pool.metadata import PoolingMetadata
+from vllm.v1.worker.gpu.spec_decode.eagle.eagle3_utils import \
+    set_eagle3_aux_hidden_state_layers
 
 from tpu_inference import envs
 from tpu_inference.distributed.jax_parallel_state import \
@@ -112,13 +114,19 @@ class VllmModelWrapper:
     mesh: Mesh
     model: _VllmRunner
 
-    def __init__(self, vllm_config: VllmConfig, rng: PRNGKey, mesh: Mesh):
+    def __init__(self,
+                 vllm_config: VllmConfig,
+                 rng: PRNGKey,
+                 mesh: Mesh,
+                 is_draft_model: bool = False):
         self.vllm_config = vllm_config
         self.rng = rng
         self.mesh = mesh
+        self.is_draft_model = is_draft_model
 
         self.vllm_config.quant_config = get_tpu_quantization_config(
             self.vllm_config, self.mesh)
+        self.model_config = vllm_config.speculative_config.draft_model_config if is_draft_model else vllm_config.model_config
         self._apply_pp_patch()
         self._patch_vllm_ops()
 
@@ -169,9 +177,19 @@ class VllmModelWrapper:
             slice_config = self.vllm_config.device_config.slice
             modified_slice_config = True
             self.vllm_config.device_config.slice = None
+        cached_static_forward_context = self.vllm_config.compilation_config.static_forward_context.copy(
+        )
         self.vllm_config.compilation_config.static_forward_context.clear()
 
+        cached_static_all_moe_layers = self.vllm_config.compilation_config.static_all_moe_layers.copy(
+        )
+        self.vllm_config.compilation_config.static_all_moe_layers.clear()
+
         vllm_config_for_load = copy.deepcopy(self.vllm_config)
+        self.vllm_config.compilation_config.static_forward_context.update(
+            cached_static_forward_context)
+        self.vllm_config.compilation_config.static_all_moe_layers.extend(
+            cached_static_all_moe_layers)
         if modified_slice_config:
             self.vllm_config.device_config.slice = slice_config
         assert self.vllm_config.model_config.dtype in TORCH_DTYPE_TO_JAX, "The model_config.dtype must be a PyTorch dtype."
@@ -219,7 +237,8 @@ class VllmModelWrapper:
 
         with load_context, jax_context, set_current_vllm_config(
                 self.vllm_config):
-            vllm_model = vllm_get_model(vllm_config=vllm_config_for_load)
+            vllm_model = vllm_get_model(vllm_config=vllm_config_for_load,
+                                        model_config=self.model_config)
         lora_manager = None
         if vllm_config_for_load.lora_config is not None:
             # Replace layers in the model with LoRA layers.
@@ -231,8 +250,14 @@ class VllmModelWrapper:
             replace_set_lora(vllm_model)
 
         static_forward_context = vllm_config_for_load.compilation_config.static_forward_context
-        self.vllm_config.compilation_config.static_forward_context = static_forward_context
-        self.vllm_config.compilation_config.static_all_moe_layers = vllm_config_for_load.compilation_config.static_all_moe_layers
+        self.vllm_config.compilation_config.static_forward_context.update(
+            static_forward_context)
+        self.vllm_config.compilation_config.static_all_moe_layers.extend(
+            vllm_config_for_load.compilation_config.static_all_moe_layers)
+
+        if self.vllm_config.speculative_config and self.vllm_config.speculative_config.method == "eagle3" and not self.is_draft_model:
+            set_eagle3_aux_hidden_state_layers(
+                vllm_model, self.vllm_config.speculative_config)
 
         self.model = _VllmRunner(vllm_model)
         params_and_buffers = shard_model_to_tpu(self.model, self.mesh)
@@ -295,7 +320,7 @@ class VllmModelWrapper:
             is_first_rank: bool = True,
             is_last_rank: bool = True,
             *args,
-        ) -> Tuple[List[jax.Array], jax.Array]:
+        ) -> Tuple[List[jax.Array], jax.Array, List[jax.Array]]:
             layer_name_to_kvcache_index = dict(layer_name_to_kvcache_index)
             lora_metadata = torch_view(lora_metadata)
             with torchax.default_env(), set_vllm_model_wrapper_context(
@@ -327,13 +352,67 @@ class VllmModelWrapper:
                 new_kv_caches = vllm_model_wrapper_context.kv_caches
             # Wrap the output(hidden states or intermediate tensor)
             # from torch land into a JaxValue for the jax code to consume.
+            aux_hidden_states = []
             if not is_last_rank:
                 output = JaxIntermediateTensors.from_torch(output_from_torch)
             else:
-                output = jax_view(output_from_torch)
-            return new_kv_caches, output, []
+                if self.vllm_config.speculative_config and self.vllm_config.speculative_config.method == "eagle3":
+                    output, aux_hidden_states = jax_view(output_from_torch)
+                else:
+                    output = jax_view(output_from_torch)
+            return new_kv_caches, output, aux_hidden_states
 
-        return step_fun
+        @jax.jit(
+            donate_argnames=("kv_caches", ),
+            out_shardings=(
+                None,  # kv_caches - keep original sharding
+                NamedSharding(self.mesh,
+                              PartitionSpec(ShardingAxisName.ATTN_DATA, None)),
+                None,  # list of aux hidden states
+            ),
+            compiler_options={
+                "xla_tpu_all_gather_collective_matmul_mode":
+                "post_spmd_conservative",
+                "xla_tpu_reduce_scatter_collective_matmul_mode":
+                "post_spmd_conservative"
+            },
+            static_argnames=("layer_name_to_kvcache_index", ),
+        )
+        def draft_step_fun(
+            params_and_buffers,
+            kv_caches: List[jax.Array],
+            input_ids: jax.Array,
+            hidden_states: jax.Array,
+            attn_metadata: AttentionMetadata,
+            layer_name_to_kvcache_index: Sequence[Tuple[str, int]],
+        ) -> Tuple[List[jax.Array], jax.Array, List[jax.Array]]:
+            layer_name_to_kvcache_index = dict(layer_name_to_kvcache_index)
+            with torchax.default_env(), set_vllm_model_wrapper_context(
+                    kv_caches=kv_caches,
+                    mesh=self.mesh,
+                    layer_name_to_kvcache_index=layer_name_to_kvcache_index
+            ), set_forward_context(attn_metadata=attn_metadata,
+                                   vllm_config=self.vllm_config):
+                output_from_torch = torch.func.functional_call(
+                    self.model,
+                    torch_view(params_and_buffers),
+                    kwargs={
+                        "input_ids": torch_view(input_ids),
+                        "positions": torch_view(attn_metadata.input_positions),
+                        "intermediate_tensors": torch_view(hidden_states),
+                        "inputs_embeds": None,
+                    },
+                    tie_weights=False,
+                )
+                vllm_model_wrapper_context = get_vllm_model_wrapper_context()
+                new_kv_caches = vllm_model_wrapper_context.kv_caches
+
+            hidden_states, hidden_prenorm = output_from_torch
+            hidden_states = jax_view(hidden_states)
+            hidden_prenorm = jax_view(hidden_prenorm)
+            return new_kv_caches, hidden_states, [hidden_prenorm]
+
+        return draft_step_fun if self.is_draft_model else step_fun
 
     def wrap_embed_multimodal_func(self):
         if not self.vllm_config.model_config.is_multimodal_model:
@@ -446,6 +525,31 @@ class VllmModelWrapper:
             return jax_view(logits)
 
         return compute_logits_func
+
+    def jit_combine_hidden_states_func(self):
+
+        @jax.jit(out_shardings=(NamedSharding(
+            self.mesh,
+            PartitionSpec(ShardingAxisName.MLP_DATA,
+                          ShardingAxisName.MLP_TENSOR))))
+        def combine_hidden_states_func(params_and_buffers: Any,
+                                       hidden_states: jax.Array) -> jax.Array:
+            with torchax.default_env(), set_vllm_model_wrapper_context(
+                    kv_caches=None, mesh=self.mesh):
+                logits = torch.func.functional_call(
+                    self.model,
+                    torch_view(params_and_buffers),
+                    kwargs={
+                        "call_method": "combine_hidden_states",
+                        "call_args": (),
+                        "call_kwargs": {
+                            "hidden_states": torch_view(hidden_states),
+                        },
+                    },
+                )
+            return jax_view(logits)
+
+        return combine_hidden_states_func
 
     def build_pooler_func(self) -> PoolerFunc:
 

--- a/tpu_inference/runner/compilation_manager.py
+++ b/tpu_inference/runner/compilation_manager.py
@@ -862,10 +862,11 @@ class CompilationManager:
                 input_ids,
                 draft_hidden_states,
                 attention_metadata,
+                layer_name_to_kvcache_index,
             ):
                 kv_caches, hidden_states, _ = self.runner.drafter.model_fn(
                     state, kv_caches, input_ids, draft_hidden_states,
-                    attention_metadata)
+                    attention_metadata, layer_name_to_kvcache_index)
                 self.runner.kv_caches = kv_caches
                 return hidden_states
 
@@ -886,6 +887,7 @@ class CompilationManager:
                 input_ids,
                 draft_hidden_states,
                 attention_metadata,
+                tuple(self.runner.layer_name_to_kvcache_index.items()),
                 num_tokens=num_tokens,
             )
             target_token_ids = self._create_dummy_tensor((num_tokens, ),
@@ -919,6 +921,7 @@ class CompilationManager:
                 input_ids_loop,
                 draft_hidden_state_loop,
                 attention_metadata,
+                tuple(self.runner.layer_name_to_kvcache_index.items()),
                 num_tokens=num_tokens,
             )
 

--- a/tpu_inference/spec_decode/jax/eagle3.py
+++ b/tpu_inference/spec_decode/jax/eagle3.py
@@ -23,9 +23,11 @@ from jax import lax
 from jax.sharding import NamedSharding, PartitionSpec
 from vllm.config import VllmConfig
 
+from tpu_inference import envs
 from tpu_inference.layers.common.attention_metadata import AttentionMetadata
 from tpu_inference.logger import init_logger
-from tpu_inference.models.common.model_loader import get_model
+from tpu_inference.models.common.model_loader import (
+    get_model, resolve_model_architecture)
 from tpu_inference.runner import utils as runner_utils
 from tpu_inference.utils import device_array
 
@@ -69,22 +71,54 @@ class Eagle3Proposer:
         """Loads the draft model."""
         self.model_fn, self.compute_logits_fn, self.pooler_fn, self.combine_hidden_states_fn, _, self.state, _, _ = get_model(
             self.vllm_config, self.rng_key, self.mesh, is_draft_model=True)
-
-        draft_embed_tokens = getattr(self.state.model, 'embed_tokens', None)
-        if draft_embed_tokens is None or ~jnp.any(
-                draft_embed_tokens.embedding):
-            logger.info(
-                "Draft model does not have embedding. Setting draft model's embed_tokens to target model's embed"
+        draft_model_impl = envs.DRAFT_MODEL_IMPL_TYPE
+        target_model_impl = envs.MODEL_IMPL_TYPE
+        if draft_model_impl == 'auto':
+            draft_model_impl = resolve_model_architecture(
+                self.vllm_config, True)
+        if target_model_impl == 'auto':
+            target_model_impl = resolve_model_architecture(
+                self.vllm_config, False)
+        if draft_model_impl != target_model_impl:
+            raise ValueError(
+                "The implementation of the draft model must be the same as the target model."
             )
-            self.state.model.embed_tokens = target_model.model.embed
-        elif jnp.array_equal(draft_embed_tokens.embedding,
-                             target_model.model.embed.embedding):
-            logger.info(
-                "Draft model's embed_tokens is identical to target model's embed. Sharing the embedding."
-            )
-            self.state.model.embed_tokens = target_model.model.embed
+        # TODO(ranlihao): Handles the case where the draft model and target model have different implementations. This may require converting the parameters of the target model to match the draft model's format.
+        # Reuse the target model's embedding if the draft model doesn't have its own or if they are identical, to save memory.
+        if draft_model_impl == "flax_nnx":
+            draft_embed_tokens = getattr(self.state.model, 'embed_tokens',
+                                         None)
+            if draft_embed_tokens is None or ~jnp.any(
+                    draft_embed_tokens.embedding):
+                logger.info(
+                    "Draft model does not have embedding. Setting draft model's embed_tokens to target model's embed"
+                )
+                self.state.model.embed_tokens = target_model.model.embed
+            elif jnp.array_equal(draft_embed_tokens.embedding,
+                                 target_model.model.embed.embedding):
+                logger.info(
+                    "Draft model's embed_tokens is identical to target model's embed. Sharing the embedding."
+                )
+                self.state.model.embed_tokens = target_model.model.embed
+            else:
+                logger.info("Draft model has its own embed_tokens.")
         else:
-            logger.info("Draft model has its own embed_tokens.")
+            EMBED_TOKENS_KEY = 'vllm_model.model.embed_tokens.weight'
+            draft_embed_tokens = self.state.get(EMBED_TOKENS_KEY, None)
+            target_embed_tokens = target_model.get(EMBED_TOKENS_KEY, None)
+            if draft_embed_tokens is None or ~jnp.any(draft_embed_tokens):
+                logger.info(
+                    "Draft model does not have embedding. Setting draft model's embed_tokens to target model's embed"
+                )
+                self.state[EMBED_TOKENS_KEY] = target_embed_tokens
+            elif target_embed_tokens is not None and jnp.array_equal(
+                    draft_embed_tokens, target_embed_tokens):
+                logger.info(
+                    "Draft model's embed_tokens is identical to target model's embed. Sharing the embedding."
+                )
+                self.state[EMBED_TOKENS_KEY] = target_embed_tokens
+            else:
+                logger.info("Draft model has its own embed_tokens.")
 
     @jax.jit(static_argnums=(0, ))
     def _prepare_input_ids(
@@ -386,6 +420,7 @@ class Eagle3Proposer:
             input_ids,
             target_hidden_states,
             attn_metadata,
+            tuple(self.runner.layer_name_to_kvcache_index.items()),
         )
 
         if self.num_speculative_tokens == 1:
@@ -417,6 +452,7 @@ class Eagle3Proposer:
                 input_ids_loop,
                 hidden_states,  # This should be the hidden_states from previous step
                 attn_metadata,
+                tuple(self.runner.layer_name_to_kvcache_index.items()),
             )
             hidden_states = residual[0]
             draft_token_ids = self._get_draft_token_ids(


### PR DESCRIPTION
# Description

This PR introduces support for running EAGLE3 speculative decoding when using the TorchAX (vLLM) backend for the draft model (DRAFT_MODEL_IMPL_TYPE=vllm). Previously, draft model execution was hardcoded/tailored entirely around native JAX (flax_nnx) layers.

This updates the compilation manager, the Eagle3 proposer, and the VLLM model wrapper to ensure parameters natively required by TorchAX (such as layer_name_to_kvcache_index) are properly propagated down to the draft models.

# Key Changes
* VLLM Model Wrapper (vllm_model_wrapper.py):
  * Implemented jit_draft_step_func specifically to handle EAGLE3's draft execution path (model_fn) within TorchAX.
  * Added jit_combine_hidden_states_func to successfully bind the combine_hidden_states operation to torch.func.functional_call, which is required for EAGLE's proposer initialization.
* Compilation Manager (compilation_manager.py):
  * Updated draft_model_fn_wrapper parameters to correctly pass along layer_name_to_kvcache_index, ensuring KV caches align properly across layers when using partitioned VLLM draft deployments.
* EAGLE3 Drafter (eagle3.py):
  * Added explicit implementation-handling logic (envs.DRAFT_MODEL_IMPL_TYPE) to dynamically reuse the target model's embed_tokens.weight dictionary keys depending on if the active draft layout uses vllm backend structures or native flax_nnx Pytree layouts.

# Tests

To run torchax path eagle-3.
E.g:
```
MODEL_IMPL_TYPE=vllm DRAFT_MODEL_IMPL_TYPE=vllm vllm serve --model=meta-llama/Llama-3.3-70B-Instruct --max-model-len=8192 --no-enable-prefix-caching --tensor-parallel-size=2 --max-num-seqs=1 --speculative_config '{"model": "/mnt/disks/ranlihao/hub/models--yuhuili--EAGLE3-LLaMA3.3-Instruct-70B/snapshots/9659b9a88511bff6ff09878107fd998a0c08c3f3", "num_speculative_tokens": 2, "method": "eagle3", "draft_tensor_parallel_size": 1}' --no-async-scheduling
```

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
