### PR TITLE
[Nightly Testing] Fix failing Qwen3-30B-A3B test

### DIFF
--- a/.buildkite/models/Qwen_Qwen3-30B-A3B.yml
+++ b/.buildkite/models/Qwen_Qwen3-30B-A3B.yml
@@ -82,6 +82,7 @@ steps:
       MAX_MODEL_LEN: 2048
       MAX_NUM_SEQS: 94
       MAX_NUM_BATCHED_TOKENS: 1024
+      MODEL_IMPL_TYPE: vllm
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/benchmark.sh


### PR DESCRIPTION
# Description

The Perf Test for Qwen/Qwen3-30B-A3B test is failing because the build is defaulting to Flax when we can be using vLLM/TorchAX instead.



# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
