### PR TITLE
Bump torch version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,6 @@ jaxtyping
 flax==0.12.4
 torchax==0.0.11
 qwix==0.1.2
-torchaudio==2.10.0
 torchvision==0.25.0
 pathwaysutils
 parameterized


### PR DESCRIPTION
# Description

Requires https://github.com/vllm-project/tpu-inference/pull/2097

Fixes this issue:
```
ImportError: cannot import name 'GraphCaptureOutput' from 'torch._dynamo.convert_frame' (/usr/local/lib/python3.12/site-packages/torch/_dynamo/convert_frame.py). Did you mean: 'CaptureOutput'?
```

Issue was caused by https://github.com/vllm-project/vllm/commit/e31915063, which requires us to bump to `torch==2.10.0` from `2.9.0`. `torchvision==0.25.0` is coupled with `torch==2.10.0`

# Tests

Ran a test locally
```
VLLM_XLA_CHECK_RECOMPILATION=1 pytest tests/e2e/test_pipeline_parallel.py
```

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
