### PR TITLE
increase api-server-count for the benchmark setup, we see default (1) can become system bottleneck

### DIFF
--- a/scripts/multihost/nightly_benchmarking.sh
+++ b/scripts/multihost/nightly_benchmarking.sh
@@ -147,6 +147,7 @@ vllm serve \
   ${EXTRA_SERVER_ARGS} \
   --served-model-name ${TARGET_TOKENIZER} \
   --max-model-len=${MAX_MODEL_LEN} \
+  --api-server-count=3 \
   --max-num-batched-tokens ${MAX_NUM_BATCHED_TOKENS} \
   --max-num-seqs ${MAX_NUM_SEQS} \
   --no-enable-prefix-caching \


### PR DESCRIPTION
increase api-server-count for the benchmark setup, we see default (1) can become system bottleneck

# Description
Ran the 1k/8k benchmark with 5 layers of DS to verify.

with api-server=1 (default): https://paste.googleplex.com/6240425854763008
with ap-server=3: https://paste.googleplex.com/5141126878199808 

We observed system bottleneck on API server if  api-server-count=1.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
