### PR TITLE
Fix: Resolve MLA KV cache sharding and DeepSeek V3 shape mismatches

### DIFF
--- a/tpu_inference/layers/common/attention_interface.py
+++ b/tpu_inference/layers/common/attention_interface.py
@@ -513,9 +513,9 @@ def mla_attention(
         P(ShardingAxisName.ATTN_DATA),  # md.distribution
     )
     out_specs = (
+        P(ShardingAxisName.MLP_TENSOR),  # kv cache
         attn_o_tnh_sharding
-        or P(ShardingAxisName.MLP_TENSOR, None, None),  # attn output
-        P(ShardingAxisName.MLP_TENSOR)  # kv cache
+        or P(ShardingAxisName.MLP_TENSOR, None, None)  # attn output
     )
 
     def _mla_ragged_paged_attention(q, q_rope, k, k_rope, cache, *args):


### PR DESCRIPTION
1. `tpu_inference/layers/common/attention_interface.py`:
   - Corrected the output sharding spec order in `_mla_ragged_paged_attention` to match the return order. This resolves the `IndivisibleError` caused by `jax.shard_map` applying the attention output sharding spec to the KV cache.

# Description

Start with a short description of what the PR does and how this is a change from
the past.

The rest of the description includes relevant details and context, examples:
- why is this change being made,
- the problem being solved and any relevant context,
- why this is a good solution,
- some information about the specific implementation,
- shortcomings of the solution and possible future improvements.

If the change fixes a Github issue, please include a link, e.g.,:
FIXES: #123456

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
