### PR TITLE
Add support for FP8 activation in fused MoE

### DIFF
--- a/scripts/multihost/benchmarks/torchax/run_deepseek_v3_1k_8k.sh
+++ b/scripts/multihost/benchmarks/torchax/run_deepseek_v3_1k_8k.sh
@@ -7,7 +7,7 @@ SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 NIGHTLY_SCRIPT="${SCRIPT_DIR}/../../nightly_benchmarking.sh"
 
 # Adjust model-path, max-seqs, and code-hash below when officially serving DeepSeek.
-bash "${NIGHTLY_SCRIPT}" \
+MOE_ALL_GATHER_ACTIVATION_DTYPE=fp8 bash "${NIGHTLY_SCRIPT}" \
   --model-path "/mnt/disks/checkpoint/hub/models--deepseek-ai--DeepSeek-R1/snapshots/56d4cbbb4d29f4355bab4b9a39ccb717a14ad5ad/" \
   --model-name "DeepSeek-R1" \
   --tokenizer "deepseek-ai/DeepSeek-R1" \

--- a/tpu_inference/envs.py
+++ b/tpu_inference/envs.py
@@ -42,6 +42,7 @@ if TYPE_CHECKING:
     JITTED_MM_MODULE_KEYS: list[str] = []
     REGISTER_MM_MODULE_CUSTOM_PYTREE_CLASSES: list[str] = []
     RAGGED_GATED_DELTA_RULE_IMPL: str = "ragged_gated_delta_rule_chunked"
+    MOE_ALL_GATHER_ACTIVATION_DTYPE: str = ""
 
 
 def env_with_choices(
@@ -248,6 +249,8 @@ environment_variables: dict[str, Callable[[], Any]] = {
     env_with_choices(
         "RAGGED_GATED_DELTA_RULE_IMPL", "ragged_gated_delta_rule_chunked",
         ["ragged_gated_delta_rule_ref", "ragged_gated_delta_rule_chunked"]),
+    "MOE_ALL_GATHER_ACTIVATION_DTYPE":
+    lambda: os.getenv("MOE_ALL_GATHER_ACTIVATION_DTYPE", ""),
 }
 
 

--- a/tpu_inference/layers/common/fused_moe_gmm.py
+++ b/tpu_inference/layers/common/fused_moe_gmm.py
@@ -24,6 +24,7 @@ import tpu_inference.envs as envs
 from tpu_inference.kernels.gather import gather_reduce as gather_reduce_sc
 from tpu_inference.kernels.gather.ragged_gather import ragged_gather
 from tpu_inference.kernels.megablox.gmm_v2 import gmm_v2
+from tpu_inference.layers.common.quantization import quantize_tensor
 from tpu_inference.layers.common.sharding import ShardingAxisName
 from tpu_inference.utils import get_mesh_shape_product
 
@@ -353,6 +354,28 @@ def expert_parallel_gmm(
     )
 
 
+def _apply_all_gather_fp8(hidden_states: jax.Array, mesh: Mesh,
+                          dtype: jnp.dtype) -> jax.Array:
+    hidden_states_q, scale = quantize_tensor(
+        jnp.float8_e4m3fn,
+        hidden_states,
+        axis=-1,
+    )
+    # quantize_tensor squeezes the scale if axis is int. We need to expand it back.
+    scale = jnp.expand_dims(scale, -1)
+
+    # Dequantize if needed
+    return jax.shard_map(
+        lambda x, s: (x.astype(jnp.float32) * s).astype(dtype),
+        mesh=mesh,
+        in_specs=(
+            P(ShardingAxisName.MLP_DATA, None),
+            P(ShardingAxisName.MLP_DATA, None),
+        ),
+        out_specs=P(ShardingAxisName.MLP_DATA, None),
+    )(hidden_states_q, scale)
+
+
 @jax.jit(static_argnames=(
     "topk",
     "renormalize",
@@ -362,6 +385,7 @@ def expert_parallel_gmm(
     "scoring_fn",
     "sc_kernel_threshold",
     "sc_kernel_col_chunk_size",
+    "all_gather_fp8",
 ))
 def fused_moe_func(
     hidden_states: jax.Array,
@@ -380,6 +404,7 @@ def fused_moe_func(
     scoring_fn: str,
     sc_kernel_threshold: int,
     sc_kernel_col_chunk_size: int,
+    all_gather_fp8: bool = False,
 ) -> jax.Array:
     """Route tokens in hidden_states into each experts based on routing.
 
@@ -475,6 +500,9 @@ def fused_moe_func(
 
     x_out_spec = (P(ShardingAxisName.EXPERT_DATA)
                   if use_ep else P(ShardingAxisName.MLP_DATA))
+    if all_gather_fp8:
+        hidden_states = _apply_all_gather_fp8(hidden_states, mesh, dtype)
+
     x, group_sizes, topk_argsort_revert_indices = jax.shard_map(
         _process_tokens_locally,
         mesh=mesh,

--- a/tpu_inference/layers/common/moe.py
+++ b/tpu_inference/layers/common/moe.py
@@ -24,6 +24,7 @@ from tpu_inference import envs
 from tpu_inference.kernels.fused_moe.v1.kernel import fused_ep_moe
 from tpu_inference.layers.common.fused_moe_gmm import fused_moe_func
 from tpu_inference.logger import init_logger
+from tpu_inference.utils import to_jax_dtype
 
 if TYPE_CHECKING:
     from tpu_inference.layers.common.process_weights.moe_weights import (
@@ -122,6 +123,13 @@ def moe_apply(
                     **extra_backend_kwargs,
                 )[:, :actual_hidden_size]
             case MoEBackend.GMM_EP | MoEBackend.GMM_TP:
+                # Check if activation_dtype was passed via kwargs or as an environment variable
+                activation_dtype = extra_backend_kwargs.get(
+                    "activation_dtype", envs.MOE_ALL_GATHER_ACTIVATION_DTYPE)
+                all_gather_fp8 = (bool(activation_dtype)
+                                  and to_jax_dtype(activation_dtype)
+                                  == jnp.float8_e4m3fn)
+
                 output = fused_moe_func(
                     hidden_states=x,
                     w1=weights.w13_weight,
@@ -139,6 +147,7 @@ def moe_apply(
                     scoring_fn=layer.scoring_func,
                     sc_kernel_threshold=envs.SC_KERNEL_THRESHOLD,
                     sc_kernel_col_chunk_size=envs.SC_KERNEL_COL_CHUNK_SIZE,
+                    all_gather_fp8=all_gather_fp8,
                 )
             case MoEBackend.DENSE_MAT:
                 # NOTE: circular import avoidance


### PR DESCRIPTION
This change introduces FP8 quantization for the hidden_states All-Gather operation within the fused Mixture of Experts (MoE) layer. Previously, activations were always processed in BF16.

The primary motivation is to reduce the communication overhead of the All-Gather, which is a major bottleneck in MoE layers. By quantizing the activations to FP8 before the All-Gather and dequantizing afterwards, we significantly reduce the amount of data transferred between devices.

The e4m3fn FP8 format was chosen to maintain reasonable precision for the forward pass, coupled with a separate FP32 scale factor calculated per token to handle the dynamic range.

This change yields a ~1.96x speedup on the All-Gather operation (from 558.79 us to 283.35 us) based on XProf benchmarks.

The implementation involves:

-  Calculating a per-token scaling factor based on the maximum absolute value of the hidden states.
-  Quantizing the hidden_states to FP8 using this scale.
-  Performing the All-Gather on the FP8 tensor and the FP32 scale.
-  Dequantizing the hidden_states back to the original dtype using the gathered scale within a jax.shard_map to ensure the operation is sharded correctly.


# Tests
VLLM_USE_V1=1 NEW_MODEL_DESIGN=1  TPU_BACKEND_TYPE=jax MODEL_IMPL_TYPE=vllm VLLM_MLA_DISABLE=0 MOE_REQUANTIZE_BLOCK_SIZE=512 MOE_REQUANTIZE_WEIGHT_DTYPE=fp4 vllm serve --model gs://tpu-commons-ci/deepseek/r1 --generation-config /workspace/generation_configs/DeepSeek-R1 --served-model-name deepseek-ai/DeepSeek-R1 --load-format=runai_streamer   --seed 42  --max-num-seqs 448  --max-num-batched-tokens 1024  --tensor-parallel-size 8  --no-enable-prefix-caching  --download_dir /mnt/disks/persist  --max-model-len 2048 --kv-cache-dtype=fp8 --enable-expert-parallel --gpu-memory-utilization=0.95 --additional_config=\{\"sharding\":\ \{\"sharding_strategy\":\ \{\"enable_dp_attention\":\ true\}\}\}  --async-scheduling

bf16 accuracy :

Serving Benchmark Result :
Successful requests:                     5000
Benchmark duration (s):                  312.02
Total input tokens:                      1015147
Total generated tokens:                  10000
Request throughput (req/s):              16.02
Output token throughput (tok/s):         32.05
Total token throughput (tok/s):          3285.47

Time to First Token
Mean TTFT (ms):                          210849.76
Median TTFT (ms):                        225937.70
P99 TTFT (ms):                           310241.93

Time per Output Token (excl. 1st token)
Mean TPOT (ms):                          2203.92
Median TPOT (ms):                        1203.22
P99 TPOT (ms):                           1366.31

Inter-token Latency
Mean ITL (ms):                           2203.92
Median ITL (ms):                         1203.22
P99 ITL (ms):                            1366.31

End-to-end Latency
Mean E2EL (ms):                          213053.68
Median E2EL (ms):                        227144.85
P99 E2EL (ms):                           311447.88

Evaluating MMLU...
Results
{'accuracy': 0.876, 'gen_num': 5000}

fp8 accuracy: 

Serving Benchmark Result:
Successful requests:                     5000
Benchmark duration (s):                  163.99
Total input tokens:                      1015147
Total generated tokens:                  10000
Request throughput (req/s):              30.49
Output token throughput (tok/s):         60.98
Total token throughput (tok/s):          6251.41

Time to First Token
Mean TTFT (ms):                          83104.57
Median TTFT (ms):                        75970.88
P99 TTFT (ms):                           161554.93

Time per Output Token (excl. 1st token)
Mean TPOT (ms):                          1201.78
Median TPOT (ms):                        1204.70
P99 TPOT (ms):                           1231.51

Inter-token Latency
Mean ITL (ms):                           1201.78
Median ITL (ms):                         1204.70
P99 ITL (ms):                            1231.51

End-to-end Latency
Mean E2EL (ms):                          84306.36
Median E2EL (ms):                        77175.77
P99 E2EL (ms):                           162781.22

Evaluating MMLU...
Downloading builder script: 4.20kB [00:00, 18.0MB/s]
Results

{'accuracy': 0.8742, 'gen_num': 5000}

