### PR TITLE
Add configurable logic for gdn_attention. Improve jax gdn chunked impl

### DIFF
--- a/.buildkite/pipeline_jax.yml
+++ b/.buildkite/pipeline_jax.yml
@@ -552,7 +552,7 @@ steps:
         commands:
           - |
             if [[ "$$TPU_VERSION" == "tpu7x" ]]; then
-              .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/bm_qwen3_coder.sh --model Qwen/Qwen3.5-397B-A17B-FP8 --tp 8 --req_tput_limit 0.04  --output_token_tput_limit 300 --total_token_tput_limit 345 --input_len 1024 --output_len 8192 --use_moe_ep_kernel 0 --limit_mm_per_prompt '{"image": 0, "video": 0}' --block_size 256 --num_prompts 64
+              .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/bm_qwen3_coder.sh --model Qwen/Qwen3.5-397B-A17B-FP8 --tp 8 --req_tput_limit 0.04  --output_token_tput_limit 300 --total_token_tput_limit 345 --input_len 1024 --output_len 8192 --use_moe_ep_kernel 0 --limit_mm_per_prompt '{"image": 0, "video": 0}' --block_size 256 --num_prompts 64 --gpu_memory_utilization 0.9
             fi
 
       - label: "${TPU_VERSION:-tpu6e} Perf regression test for Qwen3.5-397B-A17B 8k 1k with gmm kernel."
@@ -570,7 +570,7 @@ steps:
         commands:
           - |
             if [[ "$$TPU_VERSION" == "tpu7x" ]]; then
-              .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/bm_qwen3_coder.sh --model Qwen/Qwen3.5-397B-A17B-FP8 --tp 8 --req_tput_limit 0.05  --output_token_tput_limit 70 --total_token_tput_limit 650 --input_len 8192 --output_len 1024 --use_moe_ep_kernel 0    --limit_mm_per_prompt '{"image": 0, "video": 0}' --block_size 256 --num_prompts 64
+              .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/bm_qwen3_coder.sh --model Qwen/Qwen3.5-397B-A17B-FP8 --tp 8 --req_tput_limit 0.05  --output_token_tput_limit 70 --total_token_tput_limit 650 --input_len 8192 --output_len 1024 --use_moe_ep_kernel 0    --limit_mm_per_prompt '{"image": 0, "video": 0}' --block_size 256 --num_prompts 64 --gpu_memory_utilization 0.9
             fi
 
       - label: "${TPU_VERSION:-tpu6e} Accuracy for Qwen/Qwen2.5-VL-7B-Instruct"

--- a/tests/e2e/benchmarking/bm_qwen3_coder.sh
+++ b/tests/e2e/benchmarking/bm_qwen3_coder.sh
@@ -26,14 +26,15 @@ set -ex
 
 
 # Usage:
-# bash tests/e2e/benchmarking/bm_qwen3_coder.sh --model BCCard/Qwen3-Coder-480B-A35B-Instruct-FP8-Dynamic --tp 8 --req_tput_limit 1.05  --output_token_tput_limit 1926 --total_token_tput_limit 1948 --input_len 1024 --output_len 1024 --use_moe_ep_kernel 1
+# bash tests/e2e/benchmarking/bm_qwen3_coder.sh --model BCCard/Qwen3-Coder-480B-A35B-Instruct-FP8-Dynamic --tp 8 --req_tput_limit 1.05  --output_token_tput_limit 1926 --total_token_tput_limit 1948 --input_len 1024 --output_len 1024 --use_moe_ep_kernel 1 --gpu_memory_utilization 0.95
 # bash tests/e2e/benchmarking/bm_qwen3_coder.sh --model Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8 --tp 8 --req_tput_limit 1.05  --output_token_tput_limit 1926 --total_token_tput_limit 1948 --input_len 1024 --output_len 1024 --use_moe_ep_kernel 1
 
 
 OPTIONS=""
-LONGOPTS=model:,tp:,req_tput_limit:,output_token_tput_limit:,total_token_tput_limit:,input_len:,output_len:,use_moe_ep_kernel:,limit_mm_per_prompt:,hf_overrides:,block_size:,num_prompts:,num-prompts:
+LONGOPTS=model:,tp:,req_tput_limit:,output_token_tput_limit:,total_token_tput_limit:,input_len:,output_len:,use_moe_ep_kernel:,limit_mm_per_prompt:,hf_overrides:,block_size:,num_prompts:,num-prompts:,gpu_memory_utilization:,gpu-memory-utilization:
 
 num_prompts=320
+gpu_memory_utilization=0.95
 
 # Parse arguments
 if ! PARSED=$(getopt --options="$OPTIONS" --longoptions=$LONGOPTS --name "$0" -- "$@"); then
@@ -91,6 +92,10 @@ while true; do
       num_prompts=$2
       shift 2
       ;;
+    --gpu_memory_utilization|--gpu-memory-utilization)
+      gpu_memory_utilization=$2
+      shift 2
+      ;;
     --)
       shift
       break
@@ -138,7 +143,7 @@ if [ -n "$limit_mm_per_prompt" ]; then EXTRA_VLLM_ARGS+=("--limit-mm-per-prompt"
 if [ -n "$hf_overrides" ]; then EXTRA_VLLM_ARGS+=("--hf-overrides" "$hf_overrides"); fi
 if [ -n "$block_size" ]; then EXTRA_VLLM_ARGS+=("--block-size" "$block_size"); fi
 
-vllm serve --seed=42 --model="$model" --max-model-len=10240 --max-num-batched-tokens=8192 --max-num-seqs=512 --no-enable-prefix-caching --tensor-parallel-size="$tp" --kv-cache-dtype=fp8 --gpu-memory-utilization=0.95 --async-scheduling --enable-expert-parallel "${EXTRA_VLLM_ARGS[@]}"   2>&1 | tee vllm_server_out.txt &
+vllm serve --seed=42 --model="$model" --max-model-len=10240 --max-num-batched-tokens=8192 --max-num-seqs=512 --no-enable-prefix-caching --tensor-parallel-size="$tp" --kv-cache-dtype=fp8 --gpu-memory-utilization="$gpu_memory_utilization" --async-scheduling --enable-expert-parallel "${EXTRA_VLLM_ARGS[@]}"   2>&1 | tee vllm_server_out.txt &
 
 # Trap registers the cleanup as a handler for the EXIT. Whenever the shell exits, it runs `cleanup` before terminating.
 # The trap does not affect the exit status. When an EXIT trap fires, the script's exit status is whatever it was before the trap was triggered.

--- a/tpu_inference/envs.py
+++ b/tpu_inference/envs.py
@@ -41,6 +41,7 @@ if TYPE_CHECKING:
     SC_KERNEL_COL_CHUNK_SIZE: int = 1024
     JITTED_MM_MODULE_KEYS: list[str] = []
     REGISTER_MM_MODULE_CUSTOM_PYTREE_CLASSES: list[str] = []
+    RAGGED_GATED_DELTA_RULE_IMPL: str = "ragged_gated_delta_rule_chunked"
 
 
 def env_with_choices(
@@ -243,6 +244,10 @@ environment_variables: dict[str, Callable[[], Any]] = {
     env_str_list("JITTED_MM_MODULE_KEYS"),
     "REGISTER_MM_MODULE_CUSTOM_PYTREE_CLASSES":
     env_str_list("REGISTER_MM_MODULE_CUSTOM_PYTREE_CLASSES"),
+    "RAGGED_GATED_DELTA_RULE_IMPL":
+    env_with_choices(
+        "RAGGED_GATED_DELTA_RULE_IMPL", "ragged_gated_delta_rule_chunked",
+        ["ragged_gated_delta_rule_ref", "ragged_gated_delta_rule_chunked"]),
 }
 
 

--- a/tpu_inference/kernels/gdn/__init__.py
+++ b/tpu_inference/kernels/gdn/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tpu_inference/kernels/gdn/triangle_solver.py
+++ b/tpu_inference/kernels/gdn/triangle_solver.py
@@ -1,0 +1,127 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import functools
+
+import jax
+import jax.numpy as jnp
+from jax.experimental import pallas as pl
+from jax.experimental.pallas import tpu as pltpu
+
+
+def local_forward_substitution(A, b):
+    """Solves A X = B for unit lower triangular matrix A using forward substitution.
+
+    Args:
+      A: A tensor of shape (B, N, N) representing a batch of unit lower triangular
+        matrices.
+      b: A tensor of shape (B, N, K) representing the right-hand side.
+
+    Returns:
+      A tensor of shape (B, N, K) representing the solution X.
+    """
+    B, N, K = b.shape
+    x_list = []
+    for i in range(N):
+        b_i = b[:, i, :]
+        if i == 0:
+            x_i = b_i
+        else:
+            stacked_x = jnp.stack(x_list, axis=1)  # (B, i, K)
+            all_prev_A = A[:, i, :i]  # (B, i)
+            prev_sum = jnp.sum(all_prev_A[..., None] * stacked_x,
+                               axis=1)  # (B, K)
+            x_i = b_i - prev_sum  # (B, K) for the row i
+        x_list.append(x_i)
+    x = jnp.stack(x_list, axis=1)  # (B, N, K)
+    return x
+
+
+def decompose_triangular_matrix_inverse_pallas_kernel(A_ref,
+                                                      x_ref,
+                                                      *,
+                                                      block_size=16):
+    A = A_ref[...]
+    # Matrix dimension
+    B, N, _ = A.shape
+    num_blocks = N // block_size
+
+    # same as lower_triangle_solver_pallas_kernel but 2d block wise
+    # AX = I, solve for X block wise. X = I - sum(AX_prev)
+    for i in range(num_blocks):
+        start, end = i * block_size, (i + 1) * block_size
+        e_block = jnp.eye(N, dtype=A.dtype)[start:end, :]
+        e_block = jnp.broadcast_to(e_block, (B, block_size, N))
+        if i == 0:
+            target_b = e_block
+        else:
+            interaction_A = A[:, start:end, :start]
+            solved_x = x_ref[:, :start, :]
+            prev_sum = jnp.matmul(interaction_A,
+                                  solved_x,
+                                  precision=jax.lax.Precision.HIGHEST)
+            target_b = e_block - prev_sum
+
+        local_A = A[:, start:end, start:end]
+        x_block = local_forward_substitution(local_A, target_b)
+        x_ref[..., start:end, :] = x_block
+
+
+def decompose_triangular_matrix_inverse_pallas(A,
+                                               *,
+                                               n_block_size=64,
+                                               block_size=16):
+    """Inverts unit lower triangular matrices using a block-wise approach in Pallas.
+
+    This function solves A X = I for X, where A is a unit lower triangular matrix.
+    It uses a block-wise Gaussian elimination approach to improve performance.
+
+    Args:
+      A: A tensor of shape (batch_size, chunks, heads, head_dim, head_dim) where
+        the last two dimensions represent unit lower triangular matrices.
+      n_block_size: The block size for Pallas grid execution.
+      block_size: The block size for the block-wise inversion algorithm.
+
+    Returns:
+      A tensor of the same shape as A, representing the inverse of A.
+    """
+
+    # Squash all the leading dimensions
+    A_reshaped = A.reshape(-1, *A.shape[-2:])
+    A_shape = A_reshaped.shape
+    x_shape = A_shape
+
+    N = A_reshaped.shape[0]
+    grid_size = pl.cdiv(N, n_block_size)
+
+    head_dim = A_shape[-1]
+    kernel = functools.partial(
+        decompose_triangular_matrix_inverse_pallas_kernel,
+        block_size=block_size)
+    x = pl.pallas_call(
+        kernel,
+        out_shape=jax.ShapeDtypeStruct(x_shape, A.dtype),
+        grid=(grid_size, ),
+        in_specs=[
+            pl.BlockSpec((n_block_size, head_dim, head_dim), lambda idx:
+                         (idx, 0, 0)),
+        ],
+        out_specs=pl.BlockSpec((n_block_size, head_dim, head_dim), lambda idx:
+                               (idx, 0, 0)),
+        compiler_params=pltpu.CompilerParams(vmem_limit_bytes=67108864),
+        name=
+        f"decompose_triangular_matrix_inverse_pallas_kernel_{n_block_size}_{block_size}",
+    )(A_reshaped)
+
+    return x.reshape(A.shape)

--- a/tpu_inference/layers/vllm/ops/gdn_attention.py
+++ b/tpu_inference/layers/vllm/ops/gdn_attention.py
@@ -15,6 +15,8 @@
 Bridge the torch gdn_attention_core op for gated deltanet attention TPU impl
 
 """
+import dataclasses
+import enum
 import functools
 from typing import Optional, Tuple
 
@@ -25,14 +27,35 @@ from jax.sharding import PartitionSpec as P
 from torchax.interop import jax_view, torch_view
 from vllm.forward_context import get_forward_context
 
+from tpu_inference import envs
 from tpu_inference.layers.common.sharding import ShardingAxisName
 from tpu_inference.layers.common.utils import \
     reorder_concatenated_tensor_for_sharding
-from tpu_inference.layers.vllm.ops.ragged_conv1d_jax import ragged_conv1d
+from tpu_inference.layers.vllm.ops.ragged_conv1d_jax import \
+    ragged_conv1d as ragged_conv1d_jax
 from tpu_inference.layers.vllm.ops.ragged_gated_delta_rule_chunked import \
-    ragged_gated_delta_rule
+    ragged_gated_delta_rule as ragged_gated_delta_rule_chunked
+from tpu_inference.layers.vllm.ops.ragged_gated_delta_rule_ref import \
+    ragged_gated_delta_rule as ragged_gated_delta_rule_ref
 from tpu_inference.models.vllm.vllm_model_wrapper_context import \
     get_vllm_model_wrapper_context
+
+
+class RaggedConv1dImpl(enum.Enum):
+    JAX = "ragged_conv1d_jax"
+
+
+class RaggedGatedDeltaRuleImpl(enum.Enum):
+    REF = "ragged_gated_delta_rule_ref"
+    CHUNKED = "ragged_gated_delta_rule_chunked"
+
+
+@jax.tree_util.register_dataclass
+@dataclasses.dataclass(frozen=True)
+class GdnAttentionConfig:
+    ragged_conv1d_impl: RaggedConv1dImpl = RaggedConv1dImpl.JAX
+    ragged_gated_delta_rule_impl: RaggedGatedDeltaRuleImpl = (
+        RaggedGatedDeltaRuleImpl.REF)
 
 
 def run_jax_gdn_attention_local(
@@ -47,11 +70,13 @@ def run_jax_gdn_attention_local(
     dt_bias: jnp.ndarray,
     query_start_loc: jnp.ndarray,
     state_indices: jnp.ndarray,
+    distribution: jnp.ndarray,
     n_kq: int,
     n_v: int,
     d_k: int,
     d_v: int,
     kernel_size: int,
+    config: GdnAttentionConfig = GdnAttentionConfig(),
 ) -> Tuple[Tuple[jnp.ndarray, jnp.ndarray], jnp.ndarray]:
     """Runs the local JAX GDN attention mechanism with combined QKV tensors.
 
@@ -71,21 +96,28 @@ def run_jax_gdn_attention_local(
           each sequence.
         state_indices: Tensor of shape `(max_reqs,)` mapping request index to
           state index.
+        distribution: Tensor of shape `(3,)` int32 — `(decode_end, prefill_end, mixed_end)`.
         n_kq: Number of key/query heads.
         n_v: Number of value heads.
         d_k: Dimension of key.
         d_v: Dimension of value.
         kernel_size: Convolution kernel size.
+        config: Configuration for implementation selection.
 
     Returns:
-        A tuple containing the new states and the output.
+        A tuple containing:
         - A tuple of (new_conv_state, new_recurrent_state).
         - The output tensor of shape `(num_tokens, n_v * d_v)`.
     """
-    # Ensure query_start_loc is monotonically increasing to handle padded slots
+
+    # Ensure query_start_loc is monotonically increasing. This is required to
+    # handle cases where query_start_loc might be padded with trailing zeros.
     query_start_loc = jnp.maximum.accumulate(query_start_loc)
 
-    out_mixed_qkv, new_conv_state = ragged_conv1d(
+    # TODO: Switch conv implementaion based on config once we have more than 1 impl
+    conv_impl = ragged_conv1d_jax
+
+    out_mixed_qkv, new_conv_state = conv_impl(
         mixed_qkv,
         conv_state,
         conv_weight,
@@ -97,7 +129,25 @@ def run_jax_gdn_attention_local(
 
     out_mixed_qkv = jax.nn.silu(out_mixed_qkv)
 
-    new_recurrent_state, output = ragged_gated_delta_rule(
+    if config.ragged_gated_delta_rule_impl == RaggedGatedDeltaRuleImpl.REF:
+        ragged_gdn_impl = functools.partial(
+            ragged_gated_delta_rule_ref,
+            n_kq=n_kq,
+            n_v=n_v,
+            d_k=d_k,
+            d_v=d_v,
+        )
+    else:
+        ragged_gdn_impl = functools.partial(
+            ragged_gated_delta_rule_chunked,
+            n_kq=n_kq,
+            n_v=n_v,
+            d_k=d_k,
+            d_v=d_v,
+            use_qk_norm_in_gdn=True,
+        )
+
+    new_recurrent_state, output = ragged_gdn_impl(
         out_mixed_qkv,
         b,
         a,
@@ -106,10 +156,7 @@ def run_jax_gdn_attention_local(
         dt_bias,
         query_start_loc,
         state_indices,
-        n_kq,
-        n_v,
-        d_k,
-        d_v,
+        distribution,
     )
 
     return (new_conv_state, new_recurrent_state), output
@@ -127,12 +174,14 @@ def run_jax_gdn_attention(
     j_dt_bias: jnp.ndarray,
     state_indices: jnp.ndarray,
     query_start_loc: jnp.ndarray,
+    distribution: jnp.ndarray,
     n_kq: int,
     n_v: int,
     d_k: int,
     d_v: int,
     kernel_size: int,
     mesh: jax.sharding.Mesh,
+    config: GdnAttentionConfig = GdnAttentionConfig(),
 ) -> Tuple[Tuple[jnp.ndarray, jnp.ndarray], jnp.ndarray]:
     """Runs the Jax GDN attention mechanism.
 
@@ -153,15 +202,17 @@ def run_jax_gdn_attention(
           state index.
         query_start_loc: Tensor of shape `(num_seqs + 1,)` with start locations of
           each sequence.
+        distribution: Tensor of shape `(3,)` int32 — `(decode_end, prefill_end, mixed_end)`.
         n_kq: Number of key/query heads.
         n_v: Number of value heads.
         d_k: Dimension of key.
         d_v: Dimension of value.
         kernel_size: Convolution kernel size.
         mesh: The device mesh for distributed computation.
+        config: Configuration for implementation selection.
 
     Returns:
-        A tuple containing the new states and the output.
+        A tuple containing:
         - A tuple of (new_conv_state, new_recurrent_state).
           - new_conv_state: `(max_reqs, kernel_size - 1, dim)`
           - new_recurrent_state: `(max_reqs, n_v, d_k, d_v)`
@@ -180,6 +231,7 @@ def run_jax_gdn_attention(
         P(ShardingAxisName.ATTN_HEAD),  # j_dt_bias
         P(),  # query_start_loc
         P(),  # state_indices
+        P(),  # distribution
     )
 
     out_specs = (
@@ -200,14 +252,15 @@ def run_jax_gdn_attention(
         d_k=d_k,
         d_v=d_v,
         kernel_size=kernel_size,
+        config=config,
     )
 
     mapped_fn = jax.shard_map(
         p_run_jax_gdn_attention_local,
         mesh=mesh,
-        check_vma=False,
         in_specs=in_specs,
         out_specs=out_specs,
+        check_vma=False,
     )
 
     (new_conv_state, new_recurrent_state), output = mapped_fn(
@@ -222,6 +275,7 @@ def run_jax_gdn_attention(
         j_dt_bias,
         query_start_loc,
         state_indices,
+        distribution,
     )
 
     return (new_conv_state, new_recurrent_state), output
@@ -296,6 +350,10 @@ def gdn_attention_core_tpu(
 
     # Map tokens to their respective requests
     q_loc = jax_view(attn_metadata.query_start_loc)
+    distribution = jax_view(attn_metadata.request_distribution)
+    config = GdnAttentionConfig(
+        ragged_gated_delta_rule_impl=RaggedGatedDeltaRuleImpl(
+            envs.RAGGED_GATED_DELTA_RULE_IMPL))
 
     (new_conv_state,
      new_recurrent_state), j_output = run_jax_gdn_attention(j_mixed_qkv,
@@ -309,12 +367,14 @@ def gdn_attention_core_tpu(
                                                             j_dt_bias,
                                                             state_indices,
                                                             q_loc,
+                                                            distribution,
                                                             n_kq,
                                                             n_v,
                                                             d_k,
                                                             d_v,
                                                             kernel_size,
-                                                            mesh=mesh)
+                                                            mesh=mesh,
+                                                            config=config)
 
     vllm_context.kv_caches[layer_idx] = (new_conv_state, new_recurrent_state)
 

--- a/tpu_inference/layers/vllm/ops/ragged_gated_delta_rule_chunked.py
+++ b/tpu_inference/layers/vllm/ops/ragged_gated_delta_rule_chunked.py
@@ -17,6 +17,8 @@ import jax
 import jax.numpy as jnp
 from jax import lax
 
+import tpu_inference.kernels.gdn.triangle_solver as triangle_solver
+
 
 def l2norm(x: jnp.ndarray, dim: int = -1, eps: float = 1e-6) -> jnp.ndarray:
     """Normalizes x along the specified dimension using L2 norm.
@@ -42,6 +44,7 @@ def pack_inputs_single_stream(
     beta: jnp.ndarray,
     query_start_loc: jnp.ndarray,
     chunk_size: int,
+    compute_dtype: jnp.dtype = jnp.bfloat16,
 ) -> tuple[
         jnp.ndarray,
         jnp.ndarray,
@@ -88,6 +91,7 @@ def pack_inputs_single_stream(
       beta: Beta tensor.
       query_start_loc: Start locations of each sequence in original stream.
       chunk_size: Chunk size for padding.
+      compute_dtype: Dtype for computation (Q, K, V, beta).
 
     Returns:
       A tuple containing:
@@ -116,31 +120,46 @@ def pack_inputs_single_stream(
     # For each token index, searchsorted finds the insertion point in query_start_loc
     # where the token would go to maintain order (using side="right").
     # Subtracting 1 gives the index of the sequence the token actually belongs to.
-    seq_id = (jnp.searchsorted(
-        query_start_loc, jnp.arange(num_tokens), side="right") - 1)
+    seq_id = jnp.searchsorted(
+        query_start_loc, jnp.arange(num_tokens), side="right") - 1
     original_start = query_start_loc[seq_id]
     new_start = new_query_start_loc[seq_id]
     padded_indices_valid = new_start + (jnp.arange(num_tokens) -
                                         original_start)
 
     max_packed_tokens = num_tokens + num_seqs * chunk_size
-    max_packed_tokens = ((max_packed_tokens + chunk_size - 1) // chunk_size *
-                         chunk_size)
+    max_packed_tokens = (max_packed_tokens + chunk_size -
+                         1) // chunk_size * chunk_size
 
-    def pad_and_concatenate(unpadded_data, fill_value=0.0):
-        """Pads unpadded_data to max_packed_tokens and places valid data at computed indices."""
-        output_shape = (max_packed_tokens, ) + unpadded_data.shape[1:]
-        packed_data = jnp.full(output_shape,
-                               fill_value,
-                               dtype=unpadded_data.dtype)
-        packed_data = packed_data.at[padded_indices_valid].set(unpadded_data)
-        return packed_data
+    # Concatenate by dtype to reduce scatter operations
+    beta_expanded = beta[..., None]
 
-    packed_query = pad_and_concatenate(query)
-    packed_key = pad_and_concatenate(key)
-    packed_value = pad_and_concatenate(value)
-    packed_g = pad_and_concatenate(g)
-    packed_beta = pad_and_concatenate(beta)
+    combined_qkvb = jnp.concatenate(
+        [
+            query.astype(compute_dtype),
+            key.astype(compute_dtype),
+            value.astype(compute_dtype),
+            beta_expanded.astype(compute_dtype),
+        ],
+        axis=-1,
+    )
+
+    output_shape = (max_packed_tokens, ) + combined_qkvb.shape[1:]
+    packed_combined_qkvb = jnp.zeros(output_shape, dtype=compute_dtype)
+    packed_combined_qkvb = packed_combined_qkvb.at[padded_indices_valid].set(
+        combined_qkvb)
+
+    K_dim = query.shape[2]
+    V_dim = value.shape[2]
+    packed_query = packed_combined_qkvb[..., :K_dim]
+    packed_key = packed_combined_qkvb[..., K_dim:2 * K_dim]
+    packed_value = packed_combined_qkvb[..., 2 * K_dim:2 * K_dim + V_dim]
+    packed_beta = packed_combined_qkvb[..., 2 * K_dim + V_dim]
+
+    # For g (float32)
+    output_shape_f32 = (max_packed_tokens, ) + g.shape[1:]
+    packed_g = jnp.zeros(output_shape_f32, dtype=jnp.float32)
+    packed_g = packed_g.at[padded_indices_valid].set(g.astype(jnp.float32))
 
     num_chunks_total = max_packed_tokens // chunk_size
     reset_mask = jnp.zeros((num_chunks_total, ), dtype=bool)
@@ -229,18 +248,12 @@ def ragged_gated_delta_rule_mixed_prefill(
         beta,
         query_start_loc,
         chunk_size,
+        compute_dtype=compute_dtype,
     )
 
     if use_qk_norm_in_gdn:
         packed_query = l2norm(packed_query, dim=-1, eps=1e-6)
         packed_key = l2norm(packed_key, dim=-1, eps=1e-6)
-
-    packed_g = packed_g.astype(jnp.float32)
-
-    packed_query = packed_query.astype(compute_dtype)
-    packed_key = packed_key.astype(compute_dtype)
-    packed_value = packed_value.astype(compute_dtype)
-    packed_beta = packed_beta.astype(compute_dtype)
 
     scale = jax.lax.rsqrt(jnp.array(packed_query.shape[-1],
                                     dtype=jnp.float32)).astype(compute_dtype)
@@ -285,12 +298,8 @@ def ragged_gated_delta_rule_mixed_prefill(
 
     identity = jnp.eye(chunk_size, dtype=jnp.float32)
 
-    identity_broadcasted = jnp.broadcast_to(identity, S.shape)
-
-    A = jax.scipy.linalg.solve_triangular(identity + S,
-                                          identity_broadcasted,
-                                          lower=True,
-                                          unit_diagonal=True)
+    A = triangle_solver.decompose_triangular_matrix_inverse_pallas(identity +
+                                                                   S)
 
     v_beta = v_c * beta_c[..., None]
     u_chunks = jnp.matmul(
@@ -428,35 +437,32 @@ def recurrent_gated_delta_rule_step(
     state: jnp.ndarray | None = None,
 ) -> tuple[jnp.ndarray, jnp.ndarray]:
     """Single-step recurrent update for decode."""
-    B, H, T, d_k = query.shape
+    B, H, d_k = query.shape
     d_v = value.shape[-1]
 
     if state is None:
         state = jnp.zeros((B, H, d_k, d_v), dtype=query.dtype)
 
-    q = query[:, :, 0]
-    k = key[:, :, 0]
-    v = value[:, :, 0]
-    beta_val = beta[:, :, 0]
-    g_val = g[:, :, 0]
-
     scale = d_k**-0.5
-    q = q * scale
+    query = query * scale
 
-    k_state = jnp.einsum("bhd, bhdm -> bhm", k, state)
-    v_diff = v - jnp.exp(g_val)[..., None] * k_state
+    exp_g = jnp.exp(g)
 
-    v_new = beta_val[..., None] * v_diff
+    k_state = jnp.einsum("bhd, bhdm -> bhm", key, state)
+    v_diff = value - exp_g[..., None] * k_state
 
-    q_state = jnp.einsum("bhd, bhdm -> bhm", q, state)
-    q_k = jnp.sum(q * k, axis=-1, keepdims=True)
+    v_new = beta[..., None] * v_diff
 
-    out = jnp.exp(g_val)[..., None] * q_state + q_k * v_new
+    q_state = jnp.einsum("bhd, bhdm -> bhm", query, state)
+    q_k = jnp.sum(query * key, axis=-1, keepdims=True)
 
-    k_v_new = jnp.einsum("bhd, bhm -> bhdm", k, v_new)
-    new_state = state * jnp.exp(g_val)[..., None, None] + k_v_new
+    out = exp_g[..., None] * q_state + q_k * v_new
 
-    return out[:, :, None, :], new_state
+    # Outer product using broadcasting
+    k_v_new = key[..., :, None] * v_new[..., None, :]
+    new_state = state * exp_g[..., None, None] + k_v_new
+
+    return out, new_state
 
 
 def ragged_gated_delta_rule_decode_only(
@@ -496,8 +502,7 @@ def ragged_gated_delta_rule_decode_only(
     max_reqs = recurrent_state.shape[0]
 
     token_idx = jnp.arange(num_tokens)
-    req_indices = (
-        jnp.sum(token_idx[:, None] >= query_start_loc[None, :], axis=1) - 1)
+    req_indices = token_idx
     req_indices = jnp.clip(req_indices, 0, max_reqs - 1)
     valid_mask = token_idx < query_start_loc[-1]
 
@@ -509,42 +514,35 @@ def ragged_gated_delta_rule_decode_only(
         query = l2norm(query)
         key = l2norm(key)
 
-    def scan_fn(carry, xs):
-        recurrent_state_all = carry
-        curr_q, curr_k, curr_v, curr_g, curr_beta, req_idx, is_valid = xs
+    req_state_indices = state_indices[req_indices]
+    curr_states = recurrent_state[req_state_indices]
 
-        curr_q = curr_q[None, :, None, :]
-        curr_k = curr_k[None, :, None, :]
-        curr_v = curr_v[None, :, None, :]
-        curr_g = curr_g[None, :, None]
-        curr_beta = curr_beta[None, :, None]
+    outputs, new_states = recurrent_gated_delta_rule_step(
+        query,
+        key,
+        value,
+        g,
+        beta,
+        state=curr_states,
+    )
 
-        state_idx = state_indices[req_idx]
-        state = recurrent_state_all[state_idx][None, ...]
+    outputs = outputs.reshape(num_tokens, -1)
 
-        output, new_state = recurrent_gated_delta_rule_step(curr_q,
-                                                            curr_k,
-                                                            curr_v,
-                                                            curr_g,
-                                                            curr_beta,
-                                                            state=state)
+    dummy_idx = max_reqs
+    recurrent_state_padded = jnp.pad(
+        recurrent_state,
+        ((0, 1), (0, 0), (0, 0), (0, 0)),
+        mode="constant",
+        constant_values=0,
+    )
 
-        output = output.reshape(1, -1)  # (1, H * d_v)
+    safe_indices = jnp.where(valid_mask, req_state_indices, dummy_idx)
+    updated_recurrent_state_padded = recurrent_state_padded.at[
+        safe_indices].set(new_states.astype(recurrent_state.dtype))
 
-        recurrent_state_all = jnp.where(
-            is_valid,
-            recurrent_state_all.at[state_idx].set(new_state[0].astype(
-                recurrent_state_all.dtype)),
-            recurrent_state_all,
-        )
+    new_recurrent_state = updated_recurrent_state_padded[:max_reqs]
 
-        return recurrent_state_all, output[0]
-
-    carry_init = recurrent_state
-    xs = (query, key, value, g, beta, req_indices, valid_mask)
-
-    new_recurrent_state, output = jax.lax.scan(scan_fn, carry_init, xs)
-    return new_recurrent_state, output
+    return new_recurrent_state, outputs
 
 
 def ragged_gated_delta_rule(
@@ -556,6 +554,8 @@ def ragged_gated_delta_rule(
     dt_bias: jnp.ndarray,
     query_start_loc: jnp.ndarray,
     state_indices: jnp.ndarray,
+    distribution: jnp.ndarray,
+    *,
     n_kq: int,
     n_v: int,
     d_k: int,
@@ -578,6 +578,7 @@ def ragged_gated_delta_rule(
       dt_bias: dt_bias tensor.
       query_start_loc: Start locations of sequences.
       state_indices: Indices mapping sequences to recurrent state slots.
+      distribution: Tensor of shape `(3,)` int32 — `(decode_end, prefill_end, mixed_end)`.
       n_kq: Number of key/query heads.
       n_v: Number of value heads.
       d_k: Key/query dimension.
@@ -639,11 +640,11 @@ def ragged_gated_delta_rule(
             use_qk_norm_in_gdn=use_qk_norm_in_gdn,
         )
 
-    # Decode-only is that all sequence lengths are 1
-    sequence_lengths = query_start_loc[1:] - query_start_loc[:-1]
-    is_all_seqlen_1 = jnp.all(sequence_lengths <= 1)
+    # distribution[0] is decode_end, distribution[2] is mixed_end.
+    # If decode_end == mixed_end, all sequences are decode requests.
+    is_decode_only = distribution[0] == distribution[2]
 
-    return jax.lax.cond(is_all_seqlen_1,
+    return jax.lax.cond(is_decode_only,
                         decode_only_branch,
                         mixed_prefill_branch,
                         operand=None)

--- a/tpu_inference/layers/vllm/ops/ragged_gated_delta_rule_ref.py
+++ b/tpu_inference/layers/vllm/ops/ragged_gated_delta_rule_ref.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Ragged gated delta rule JAX implementation."""
+"""Ragged gated delta rule Ref implementation mainly for unit test."""
 
 from typing import Optional, Tuple
 
@@ -102,6 +102,8 @@ def ragged_gated_delta_rule(
     dt_bias,
     query_start_loc,
     state_indices,
+    distribution,
+    *,
     n_kq,
     n_v,
     d_k,
@@ -122,6 +124,8 @@ def ragged_gated_delta_rule(
         valid tokens.
       state_indices: Tensor of shape `(max_reqs,)` mapping request index to state
         index.
+      distribution: Tensor of shape `(3,)` int32 — `(decode_end, prefill_end,
+        mixed_end)`.
       n_kq: Number of key/query heads.
       n_v: Number of value heads.
       d_k: Dimension of key.
@@ -141,8 +145,8 @@ def ragged_gated_delta_rule(
     max_reqs = state_indices.shape[0]
     token_idx = jnp.arange(num_tokens)
 
-    req_indices = (
-        jnp.sum(token_idx[:, None] >= query_start_loc[None, :], axis=1) - 1)
+    req_indices = jnp.sum(token_idx[:, None] >= query_start_loc[None, :],
+                          axis=1) - 1
     req_indices = jnp.clip(req_indices, 0, max_reqs - 1)
     valid_mask = token_idx < query_start_loc[-1]
 
@@ -207,7 +211,8 @@ def ragged_gated_delta_rule(
 
         recurrent_state_all = jnp.where(
             is_valid_token,
-            recurrent_state_all.at[state_index].set(new_recurrent_state[0]),
+            recurrent_state_all.at[state_index].set(
+                new_recurrent_state[0].astype(recurrent_state_all.dtype)),
             recurrent_state_all,
         )
 


### PR DESCRIPTION
# Description

* Add configurable logic for gdn_attention through env variable e.g. RAGGED_GATED_DELTA_RULE_IMPL=ragged_gated_delta_rule_chunked 
* Integrated triangle_solver kernel 
* Parallelize the scan in decode only case

If the change fixes a Github issue, please include a link, e.g.,:
FIXES: #123456

# Tests
* Tested offline_inference.py script and output sensible outputs
* Benchmarked the performance


Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
