### PR TITLE
Enable DP mode for Qwen3.5

### DIFF
--- a/tests/platforms/test_tpu_platform.py
+++ b/tests/platforms/test_tpu_platform.py
@@ -36,6 +36,7 @@ class TestTpuPlatform:
         vllm_config.model_config.use_mla = False
         vllm_config.scheduler_config = MagicMock(is_multimodal_model=False)
         vllm_config.parallel_config = MagicMock()
+        vllm_config.sharding_config = MagicMock()
         vllm_config.compilation_config = MagicMock(mode="dynamo_trace_once",
                                                    backend="openxla")
         vllm_config.kv_transfer_config = None
@@ -292,6 +293,28 @@ class TestTpuPlatform:
             TpuPlatform.update_block_size_for_backend(vllm_config)
 
         assert vllm_config.cache_config.block_size == 1280
+
+    def test_update_block_size_for_backend_tp_override(self, vllm_config):
+        vllm_config.model_config.is_hybrid = True
+        vllm_config.parallel_config.tensor_parallel_size = 8
+        vllm_config.sharding_config = MagicMock()
+        vllm_config.sharding_config.tp_size = 4
+
+        mock_backend = MagicMock()
+
+        # We temporarily override the tensor parallel size to the sharding
+        # tp_size when aligning hybrid block size.
+        def assert_tp_is_sharding_tp_size(*args, **kwargs):
+            assert vllm_config.parallel_config.tensor_parallel_size == 4
+
+        with patch.object(TpuPlatform, '_find_non_ssm_backend', return_value=mock_backend), \
+             patch.object(TpuPlatform, '_align_hybrid_block_size', side_effect=assert_tp_is_sharding_tp_size) as mock_align:
+            TpuPlatform.update_block_size_for_backend(vllm_config)
+
+            mock_align.assert_called_once_with(vllm_config, mock_backend)
+
+        # Ensure the tensor parallel size is restored in the `finally` block
+        assert vllm_config.parallel_config.tensor_parallel_size == 8
 
     def test_check_and_update_config_mla_checks(self):
         vllm_config = MagicMock()

--- a/tests/runner/test_tpu_runner_dp.py
+++ b/tests/runner/test_tpu_runner_dp.py
@@ -15,9 +15,12 @@
 from contextlib import nullcontext
 from unittest.mock import MagicMock, patch
 
+import jax
 import numpy as np
 import pytest
+from jax.sharding import Mesh
 
+from tpu_inference.layers.common.sharding import ShardingAxisName
 from tpu_inference.runner.tpu_runner import TPUModelRunner
 
 
@@ -57,6 +60,7 @@ class TestTPUJaxRunnerDPInputsLightweight:
         # Initialize CPU arrays that the method modifies
         self.runner.input_ids_cpu = np.zeros(64, dtype=np.int32)
         self.runner.positions_cpu = np.zeros(64, dtype=np.int32)
+        self.runner.mrope_positions_cpu = np.zeros((3, 64), dtype=np.int64)
         self.runner.query_start_loc_cpu = np.zeros(10, dtype=np.int32)
         self.runner.seq_lens_cpu = np.zeros(8, dtype=np.int32)
         self.runner.logits_indices_cpu = np.zeros(8, dtype=np.int32)
@@ -123,6 +127,72 @@ class TestTPUJaxRunnerDPInputsLightweight:
         ]
         self.runner.kv_cache_config = mock_kv_cache_config
         self.runner.use_hybrid_kvcache = True
+
+    @patch('jax.device_put')
+    @patch('tpu_inference.runner.tpu_runner.NamedSharding')
+    @patch('tpu_inference.runner.tpu_runner.runner_utils')
+    @patch('tpu_inference.runner.tpu_runner.TPUSupportedSamplingMetadata')
+    def test_prepare_inputs_dp_mrope(self, mock_sampling_metadata,
+                                     mock_runner_utils, mock_named_sharding,
+                                     mock_device_put):
+
+        def _mock_named_sharding(mesh, spec):
+            mock = MagicMock()
+            mock.mesh = mesh
+            mock.spec = spec
+            return mock
+
+        mock_named_sharding.side_effect = _mock_named_sharding
+
+        def _mock_device_put(x, *args, **kwargs):
+            sharding = args[0] if len(
+                args) > 0 else kwargs.get('device') or kwargs.get('sharding')
+            if sharding and hasattr(sharding, 'spec') and hasattr(
+                    sharding, 'mesh'):
+                spec = sharding.spec
+                mesh_obj = sharding.mesh
+
+                def check_array(arr):
+                    if hasattr(arr, 'shape') and spec is not None:
+                        for i, axes in enumerate(spec):
+                            if axes is not None and i < len(arr.shape):
+                                axes_tuple = (axes, ) if isinstance(
+                                    axes, str) else axes
+                                axis_size = 1
+                                for a in axes_tuple:
+                                    axis_size *= mesh_obj.shape.get(
+                                        a, 1) if isinstance(
+                                            mesh_obj.shape,
+                                            dict) else mesh_obj.shape[a]
+                                if arr.shape[i] % axis_size != 0:
+                                    raise ValueError(
+                                        f"Cannot shard array of shape {arr.shape} "
+                                        f"along dimension {i} with mesh axes {axes} of size {axis_size}"
+                                    )
+                    return arr
+
+                jax.tree_util.tree_map(check_array, x)
+            return x
+
+        mock_device_put.side_effect = _mock_device_put
+        """Test that M-RoPE positions are prepared and sharded correctly."""
+        num_scheduled_tokens = {"req1": 5, "req2": 3}
+        assigned_dp_ranks = {"req1": 0, "req2": 1}
+        scheduler_output = self._create_mock_scheduler_output(
+            num_scheduled_tokens, assigned_dp_ranks)
+
+        mock_runner_utils.get_padded_token_len.return_value = 16
+        mock_sampling_metadata.from_input_batch.return_value = MagicMock()
+        self.runner.uses_mrope = True
+
+        mock_mesh = MagicMock(spec=Mesh)
+        mock_mesh.shape = {ShardingAxisName.ATTN_DATA: 2}
+        self.runner.mesh = mock_mesh
+        self.runner.data_parallel_attn_sharding = MagicMock()
+
+        result = self.runner._prepare_inputs_dp(scheduler_output)
+
+        assert len(result) == 8
 
     @patch('tpu_inference.runner.tpu_runner.NamedSharding')
     @patch('tpu_inference.runner.tpu_runner.runner_utils')

--- a/tpu_inference/layers/common/gdn_attention.py
+++ b/tpu_inference/layers/common/gdn_attention.py
@@ -31,6 +31,7 @@ from tpu_inference.layers.common.ragged_gated_delta_rule_chunked import \
 from tpu_inference.layers.common.ragged_gated_delta_rule_ref import \
     ragged_gated_delta_rule as ragged_gated_delta_rule_ref
 from tpu_inference.layers.common.sharding import ShardingAxisName
+from tpu_inference.utils import get_mesh_shape_product
 
 
 class RaggedConv1dImpl(enum.Enum):
@@ -209,31 +210,35 @@ def run_jax_gdn_attention(
     """
 
     in_specs = (
-        P(None, ShardingAxisName.ATTN_HEAD),  # j_mixed_qkv
-        P(None, ShardingAxisName.ATTN_HEAD),  # j_b
-        P(None, ShardingAxisName.ATTN_HEAD),  # j_a
-        P(None, None, ShardingAxisName.ATTN_HEAD),  # conv_state
-        P(None, ShardingAxisName.ATTN_HEAD, None, None),  # recurrent_state
+        P(ShardingAxisName.ATTN_DATA,
+          ShardingAxisName.ATTN_HEAD),  # j_mixed_qkv
+        P(ShardingAxisName.ATTN_DATA, ShardingAxisName.ATTN_HEAD),  # j_b
+        P(ShardingAxisName.ATTN_DATA, ShardingAxisName.ATTN_HEAD),  # j_a
+        P(ShardingAxisName.ATTN_DATA, None,
+          ShardingAxisName.ATTN_HEAD),  # conv_state
+        P(ShardingAxisName.ATTN_DATA, ShardingAxisName.ATTN_HEAD, None,
+          None),  # recurrent_state
         P(ShardingAxisName.ATTN_HEAD, None, None),  # j_conv_weight
         P(ShardingAxisName.ATTN_HEAD)
         if j_conv_bias is not None else None,  # j_conv_bias
         P(ShardingAxisName.ATTN_HEAD),  # j_A_log
         P(ShardingAxisName.ATTN_HEAD),  # j_dt_bias
-        P(),  # query_start_loc
-        P(),  # state_indices
-        P(),  # distribution
+        P(ShardingAxisName.ATTN_DATA),  # query_start_loc
+        P(ShardingAxisName.ATTN_DATA),  # state_indices
+        P(ShardingAxisName.ATTN_DATA),  # distribution
     )
 
     out_specs = (
         (
-            P(None, None, ShardingAxisName.ATTN_HEAD),  # new_conv_state
-            P(None, ShardingAxisName.ATTN_HEAD, None,
+            P(ShardingAxisName.ATTN_DATA, None,
+              ShardingAxisName.ATTN_HEAD),  # new_conv_state
+            P(ShardingAxisName.ATTN_DATA, ShardingAxisName.ATTN_HEAD, None,
               None),  # new_recurrent_state
         ),
-        P(None, ShardingAxisName.ATTN_HEAD),  # output
+        P(ShardingAxisName.ATTN_DATA, ShardingAxisName.ATTN_HEAD),  # output
     )
 
-    tp_size = mesh.shape[ShardingAxisName.ATTN_HEAD]
+    tp_size = get_mesh_shape_product(mesh, ShardingAxisName.ATTN_HEAD)
 
     p_run_jax_gdn_attention_local = functools.partial(
         run_jax_gdn_attention_local,

--- a/tpu_inference/layers/vllm/custom_ops/gdn_attention_op.py
+++ b/tpu_inference/layers/vllm/custom_ops/gdn_attention_op.py
@@ -31,6 +31,7 @@ from tpu_inference.layers.common.utils import \
     reorder_concatenated_tensor_for_sharding
 from tpu_inference.models.vllm.vllm_model_wrapper_context import \
     get_vllm_model_wrapper_context
+from tpu_inference.utils import get_mesh_shape_product
 
 
 def gdn_attention_core_tpu(
@@ -83,7 +84,7 @@ def gdn_attention_core_tpu(
     # Use reorder_concatenated_tensor_for_sharding to reorder into correct layout
     key_dim = n_kq * d_k
     value_dim = n_v * d_v
-    tp_size = mesh.shape[ShardingAxisName.ATTN_HEAD]
+    tp_size = get_mesh_shape_product(mesh, ShardingAxisName.ATTN_HEAD)
     j_mixed_qkv = reorder_concatenated_tensor_for_sharding(
         j_mixed_qkv, [key_dim, key_dim, value_dim], tp_size, -1)
     j_conv_weight = reorder_concatenated_tensor_for_sharding(

--- a/tpu_inference/platforms/tpu_platform.py
+++ b/tpu_inference/platforms/tpu_platform.py
@@ -292,14 +292,23 @@ class TpuPlatform(Platform):
         # TODO: TPU still sets block_size in check_and_update_config.
         # Move that logic here so block_size is chosen by the backend.
 
-        # Align block/mamba sizes for hybrid model (may override user settings).
-        if vllm_config.model_config.is_hybrid:
-            backend_cls = cls._find_non_ssm_backend(vllm_config)
-            if backend_cls is None:
-                return
-            cls._align_hybrid_block_size(vllm_config, backend_cls)
-
-        return
+        # vLLM uses `tensor_parallel_size` to calculate the number of KV heads
+        # per partition. When data parallelism is enabled, the global
+        # `tensor_parallel_size` (total workers) is larger than the actual
+        # `tp_size` used.
+        # https://github.com/vllm-project/tpu-inference/blob/618dea5f5c0ca556a6c76a2e1cc130ff6a30893c/tpu_inference/layers/common/sharding.py#L196
+        # Use the sharding calculated `tp_size` for block size calculations.
+        orig_tp_size = vllm_config.parallel_config.tensor_parallel_size
+        vllm_config.parallel_config.tensor_parallel_size = vllm_config.sharding_config.tp_size
+        try:
+            if vllm_config.model_config.is_hybrid:
+                backend_cls = cls._find_non_ssm_backend(vllm_config)
+                if backend_cls is not None:
+                    # Align block/mamba sizes for hybrid model (may override
+                    # user settings).
+                    cls._align_hybrid_block_size(vllm_config, backend_cls)
+        finally:
+            vllm_config.parallel_config.tensor_parallel_size = orig_tp_size
 
     @classmethod
     def is_pin_memory_available(cls):

--- a/tpu_inference/runner/kv_cache_manager.py
+++ b/tpu_inference/runner/kv_cache_manager.py
@@ -120,7 +120,8 @@ class KVCacheManager:
 
         num_kv_heads = common_utils.get_padded_num_heads(
             first_attn_module.num_kv_heads,
-            self.runner.mesh.shape[ShardingAxisName.ATTN_HEAD])
+            common_utils.get_mesh_shape_product(self.runner.mesh,
+                                                ShardingAxisName.ATTN_HEAD))
         head_size = common_utils.get_padded_head_dim(
             first_attn_module.head_size)
         page_size_bytes = get_attention_page_size_bytes(
@@ -409,23 +410,22 @@ class KVCacheManager:
                 assert kv_cache_tensor.size % page_size_bytes == 0
                 num_blocks = kv_cache_tensor.size // page_size_bytes
 
+            if self.use_mla and not self.runner.vllm_config.additional_config.get(
+                    "sharding", {}).get("sharding_strategy", {}).get(
+                        "enable_dp_attention", False):
+                # MLA KV cache is sharded over MLP_TENSOR
+                divisor = common_utils.get_mesh_shape_product(
+                    self.runner.mesh, ShardingAxisName.MLP_TENSOR)
+            else:
+                # Default KV cache is sharded over ATTN_DATA
+                divisor = common_utils.get_mesh_shape_product(
+                    self.runner.mesh, ShardingAxisName.ATTN_DATA)
+
+            # num_blocks must be a multiple of the sharding divisor
+            num_blocks = (num_blocks // divisor) * divisor
+
             for j, layer_name in enumerate(kv_cache_tensor.shared_by):
                 layer_spec = layer_name_to_spec[layer_name]
-
-                sharding_config = self.runner.vllm_config.sharding_config
-                if self.use_mla and not self.runner.vllm_config.additional_config.get(
-                        "sharding", {}).get("sharding_strategy", {}).get(
-                            "enable_dp_attention", False):
-                    # MLA KV cache is sharded with MLP_TENSOR = (attn_dp, attn_dp_expert, model, expert)
-                    divisor = (sharding_config.attn_dp_size *
-                               sharding_config.attn_dp_expert_size *
-                               sharding_config.tp_size *
-                               sharding_config.expert_size)
-                else:
-                    divisor = sharding_config.total_dp_size
-                # num_blocks must be a multiple of the sharding divisor
-                num_blocks = (num_blocks // divisor) * divisor
-
                 if isinstance(layer_spec, MambaSpec):
                     mamba_states = []
                     for state_index, (shape, dtype) in enumerate(
@@ -434,11 +434,12 @@ class KVCacheManager:
                         cache_shape = (num_blocks, *shape)
                         if state_index == 0:
                             # conv_state: [num_blocks, conv_kernel_size, intermediate_size]
-                            spec = PartitionSpec(None, None,
+                            spec = PartitionSpec(ShardingAxisName.ATTN_DATA,
+                                                 None,
                                                  ShardingAxisName.ATTN_HEAD)
                         elif state_index == 1:
                             # ssm_state: [num_blocks, num_heads, head_dim, state_size]
-                            spec = PartitionSpec(None,
+                            spec = PartitionSpec(ShardingAxisName.ATTN_DATA,
                                                  ShardingAxisName.ATTN_HEAD,
                                                  None, None)
                         else:

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -1485,20 +1485,32 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             padded_num_reqs,
             sharding=data_parallel_attn_sharding,
         )
-        if self.uses_mrope:
-            positions = mrope_positions
 
         query_start_loc_cpu = query_start_loc
         logits_indices_cpu = logits_indices
         seq_lens_cpu = seq_lens
 
-        (input_ids, positions, query_start_loc, seq_lens, logits_indices,
+        (input_ids, query_start_loc, seq_lens, logits_indices,
          request_distribution) = device_array(
              self.mesh,
-             (input_ids, positions, query_start_loc, seq_lens, logits_indices,
+             (input_ids, query_start_loc, seq_lens, logits_indices,
               request_distribution),
              sharding=data_parallel_attn_sharding,
          )
+
+        if self.uses_mrope:
+            # M-RoPE positions are of the shape (3, max_num_tokens).
+            # https://github.com/vllm-project/tpu-inference/blob/efc9608acd925bb3b64db6fda509514f799ab7be/tpu_inference/runner/tpu_runner.py#L555
+            # Shard the positions accordingly.
+            mrope_sharding = NamedSharding(
+                self.mesh, PartitionSpec(None, ShardingAxisName.ATTN_DATA))
+            positions = device_array(self.mesh,
+                                     mrope_positions,
+                                     sharding=mrope_sharding)
+        else:
+            positions = device_array(self.mesh,
+                                     positions,
+                                     sharding=data_parallel_attn_sharding)
 
         def build_block_table(kv_cache_gid: int) -> jax.Array:
             block_tables = self.block_tables_cpu[kv_cache_gid][:self.


### PR DESCRIPTION
# Description

Fix issues with data parallelism for Qwen3.5;
 - Replace `mesh.shape[...]` with `get_mesh_shape_product`.
 - Add `ATTN_DATA` sharding specs to GDN Attention and KV cache.
 - Fix sharding for M-RoPE positions.
 - Use SPMD representations to align block size.

# Tests
 - CI
 - `NEW_MODEL_DESIGN=1   USE_MOE_EP_KERNEL="0" MODEL_IMPL_TYPE="vllm" python examples/offline_inference.py --model Qwen/Qwen3.5-397B-A17B-FP8 --tensor-parallel-size=8 --additional_config='{"sharding": {"sharding_strategy": {"enable_dp_attention": true}}}' --block-size=256 --limit-mm-per-prompt='{"image": 0, "video": 0}' --kv-cache-dtype=fp8 --max-model-len=10240 --max-num-batched-tokens=8192  --max-num-seqs=512 --gpu-memory-utilization=0.8 --async-scheduling --chat-template-kwargs='{"enable_thinking": false}'`
 - `VLLM_USE_AOT_COMPILE=0 MODEL_IMPL_TYPE=vllm python examples/offline_inference.py --model=Qwen/Qwen3.5-397B-A17B-FP8 --tensor-parallel-size=8  --limit-mm-per-prompt '{"image": 0, "video": 0}' --block-size=256 --gpu-memory-utilization=0.95 --top_p=1.0 --top_k=-1 --temperature=0 --kv-cache-dtype=fp8  --chat-template-kwargs='{"enable_thinking": false}'`
Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
