### PR TITLE
Separate MoE compressed tensor schemes as done in VLLM

### DIFF
--- a/tpu_inference/layers/vllm/quantization/compressed_tensors/compressed_tensors_moe/__init__.py
+++ b/tpu_inference/layers/vllm/quantization/compressed_tensors/compressed_tensors_moe/__init__.py
@@ -1,0 +1,23 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from tpu_inference.layers.vllm.quantization.compressed_tensors.compressed_tensors_moe.compressed_tensors_moe import \
+    VllmCompressedTensorsMoEMethod
+from tpu_inference.layers.vllm.quantization.compressed_tensors.compressed_tensors_moe.compressed_tensors_moe_w8a8_fp8 import \
+    VllmCompressedTensorsW8A8Fp8MoEMethod
+
+__all__ = [
+    "VllmCompressedTensorsMoEMethod",
+    "VllmCompressedTensorsW8A8Fp8MoEMethod",
+]

--- a/tpu_inference/layers/vllm/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe.py
+++ b/tpu_inference/layers/vllm/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe.py
@@ -1,0 +1,66 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+from vllm.model_executor.layers.fused_moe import FusedMoE
+from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tensors_moe import \
+    CompressedTensorsMoEMethod
+
+from tpu_inference.layers.vllm.quantization.unquantized import \
+    VllmUnquantizedFusedMoEMethod
+from tpu_inference.layers.vllm.quantization.compressed_tensors.compressed_tensors_moe.compressed_tensors_moe_w8a8_fp8 import \
+    VllmCompressedTensorsW8A8Fp8MoEMethod
+
+
+class VllmCompressedTensorsMoEMethod(CompressedTensorsMoEMethod):
+
+    @staticmethod
+    def get_moe_method(
+        quant_config: "VllmCompressedTensorsConfig",  # type: ignore # noqa E501
+        layer: torch.nn.Module,
+        layer_name: str,
+    ) -> CompressedTensorsMoEMethod:
+        assert isinstance(layer, FusedMoE)
+
+        # FusedMoE was made by combining multiple Linears so need to
+        # make sure quantization config for Linear can target it
+        quant_config._add_fused_moe_to_target_scheme_map()
+        unfused_names = [
+            layer_name + proj_name
+            for proj_name in [".0.gate_proj", ".0.up_proj", ".0.down_proj"]
+        ]
+        # TODO: refactor this to use expert_mapping and check all layer numbers
+        all_scheme_dicts = [
+            quant_config.get_scheme_dict(layer, name) for name in unfused_names
+        ]
+        scheme_dict = all_scheme_dicts.pop()
+
+        # multiple schemes found
+        if not all([cur_dict == scheme_dict for cur_dict in all_scheme_dicts]):
+            raise ValueError("All MoE projections need to have same "
+                             "quantization scheme but found multiple")
+
+        if scheme_dict is None:
+            return VllmUnquantizedFusedMoEMethod(layer.moe_config,
+                                                 quant_config.mesh)
+
+        weight_quant = scheme_dict.get("weights")
+        input_quant = scheme_dict.get("input_activations")
+
+        if quant_config._is_fp8_w8a8(weight_quant, input_quant):
+            return VllmCompressedTensorsW8A8Fp8MoEMethod(
+                weight_quant, input_quant, layer.moe_config, quant_config.mesh)
+        else:
+            raise RuntimeError(
+                f"Unsupported FusedMoe scheme: {weight_quant}, {input_quant}")

--- a/tpu_inference/layers/vllm/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe.py
+++ b/tpu_inference/layers/vllm/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe.py
@@ -17,10 +17,10 @@ from vllm.model_executor.layers.fused_moe import FusedMoE
 from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tensors_moe import \
     CompressedTensorsMoEMethod
 
-from tpu_inference.layers.vllm.quantization.unquantized import \
-    VllmUnquantizedFusedMoEMethod
 from tpu_inference.layers.vllm.quantization.compressed_tensors.compressed_tensors_moe.compressed_tensors_moe_w8a8_fp8 import \
     VllmCompressedTensorsW8A8Fp8MoEMethod
+from tpu_inference.layers.vllm.quantization.unquantized import \
+    VllmUnquantizedFusedMoEMethod
 
 
 class VllmCompressedTensorsMoEMethod(CompressedTensorsMoEMethod):

--- a/tpu_inference/layers/vllm/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe.py
+++ b/tpu_inference/layers/vllm/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe.py
@@ -14,7 +14,7 @@
 
 import torch
 from vllm.model_executor.layers.fused_moe import FusedMoE
-from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tensors_moe import \
+from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tensors_moe.compressed_tensors_moe import \
     CompressedTensorsMoEMethod
 
 from tpu_inference.layers.vllm.quantization.compressed_tensors.compressed_tensors_moe.compressed_tensors_moe_w8a8_fp8 import \

--- a/tpu_inference/layers/vllm/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_w8a8_fp8.py
+++ b/tpu_inference/layers/vllm/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_w8a8_fp8.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,9 +20,7 @@ from torch.nn.parameter import Parameter
 from torchax.interop import jax_view, torch_view
 from vllm.model_executor.layers.fused_moe import FusedMoE, FusedMoEConfig
 from vllm.model_executor.layers.fused_moe.activation import MoEActivation
-from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tensors_moe.compressed_tensors_moe import \
-    CompressedTensorsMoEMethod
-from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tensors_moe.compressed_tensors_moe_w8a8_fp8 import \
+from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tensors_moe import \
     CompressedTensorsW8A8Fp8MoEMethod
 
 from tpu_inference.layers.common.moe import MoEBackend
@@ -32,55 +30,10 @@ from tpu_inference.layers.common.sharding import ShardingAxisName
 from tpu_inference.layers.vllm.interface.moe import (
     select_moe_backend_from_fused_moe_config, vllm_moe_apply)
 from tpu_inference.layers.vllm.quantization.configs import VllmQuantConfig
-from tpu_inference.layers.vllm.quantization.unquantized import \
-    VllmUnquantizedFusedMoEMethod
 from tpu_inference.logger import init_logger
 from tpu_inference.utils import get_mesh_shape_product, t2j
 
 logger = init_logger(__name__)
-
-
-class VllmCompressedTensorsMoEMethod(CompressedTensorsMoEMethod):
-
-    @staticmethod
-    def get_moe_method(
-        quant_config: "VllmCompressedTensorsConfig",  # type: ignore # noqa E501
-        layer: torch.nn.Module,
-        layer_name: str,
-    ) -> CompressedTensorsMoEMethod:
-        assert isinstance(layer, FusedMoE)
-
-        # FusedMoE was made by combining multiple Linears so need to
-        # make sure quantization config for Linear can target it
-        quant_config._add_fused_moe_to_target_scheme_map()
-        unfused_names = [
-            layer_name + proj_name
-            for proj_name in [".0.gate_proj", ".0.up_proj", ".0.down_proj"]
-        ]
-        # TODO: refactor this to use expert_mapping and check all layer numbers
-        all_scheme_dicts = [
-            quant_config.get_scheme_dict(layer, name) for name in unfused_names
-        ]
-        scheme_dict = all_scheme_dicts.pop()
-
-        # multiple schemes found
-        if not all([cur_dict == scheme_dict for cur_dict in all_scheme_dicts]):
-            raise ValueError("All MoE projections need to have same "
-                             "quantization scheme but found multiple")
-
-        if scheme_dict is None:
-            return VllmUnquantizedFusedMoEMethod(layer.moe_config,
-                                                 quant_config.mesh)
-
-        weight_quant = scheme_dict.get("weights")
-        input_quant = scheme_dict.get("input_activations")
-
-        if quant_config._is_fp8_w8a8(weight_quant, input_quant):
-            return VllmCompressedTensorsW8A8Fp8MoEMethod(
-                weight_quant, input_quant, layer.moe_config, quant_config.mesh)
-        else:
-            raise RuntimeError(
-                f"Unsupported FusedMoe scheme: {weight_quant}, {input_quant}")
 
 
 class VllmCompressedTensorsW8A8Fp8MoEMethod(CompressedTensorsW8A8Fp8MoEMethod,

--- a/tpu_inference/layers/vllm/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_w8a8_fp8.py
+++ b/tpu_inference/layers/vllm/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_w8a8_fp8.py
@@ -20,7 +20,7 @@ from torch.nn.parameter import Parameter
 from torchax.interop import jax_view, torch_view
 from vllm.model_executor.layers.fused_moe import FusedMoE, FusedMoEConfig
 from vllm.model_executor.layers.fused_moe.activation import MoEActivation
-from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tensors_moe import \
+from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tensors_moe.compressed_tensors_moe_w8a8_fp8 import \
     CompressedTensorsW8A8Fp8MoEMethod
 
 from tpu_inference.layers.common.moe import MoEBackend


### PR DESCRIPTION

# Description

Split separate MoE compressed tensor schemes into their own dedicated files, aligning the directory structure with both linear compressed tensor schemes and the upstream vLLM codebase. Previously, all compressed tensor MoE schemes were housed in a single file, which will become challenging as more quantization schemes are introduced.

**Why is this change being made & problem being solved:**
- Consolidating multiple quantization schemes in a single file creates merge conflicts and reduces code readability. 
- Moving MoE quantization method classes into specialized files improves modularity and aligns with upstream vLLM conventions (specifically vLLM PR #38960), making the addition of new MoE quantization schemes cleaner.

**Specific Implementation Details:**
- Created a new `compressed_tensors_moe/` subdirectory.
- Migrated the base `VllmCompressedTensorsMoEMethod` class to `compressed_tensors_moe/compressed_tensors_moe.py`.
- Migrated `VllmCompressedTensorsW8A8Fp8MoEMethod` class to `compressed_tensors_moe/compressed_tensors_moe_w8a8_fp8.py`.
- Exposed all relevant classes via `compressed_tensors_moe/__init__.py` to maintain full backward compatibility with existing module imports.

# Tests

This is a refactor only and is covered by existing tests.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
