### PR TITLE
[Fix] fix dp and simplify sharding logic in compilation manager corresponds to sampling

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ google-cloud-storage
 jax==0.9.2
 jaxlib==0.9.2
 --find-links https://storage.googleapis.com/jax-releases/libtpu_releases.html
-libtpu==0.0.39.dev20260403
+libtpu==0.0.39
 jaxtyping
 flax==0.12.4
 torchax==0.0.11

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,6 @@ numpy
 google-cloud-storage
 jax==0.9.2
 jaxlib==0.9.2
---find-links https://storage.googleapis.com/jax-releases/libtpu_releases.html
 libtpu==0.0.39
 jaxtyping
 flax==0.12.4

--- a/tpu_inference/runner/compilation_manager.py
+++ b/tpu_inference/runner/compilation_manager.py
@@ -619,29 +619,66 @@ class CompilationManager:
                 layer_cache.block_until_ready()
 
     def _precompile_gather_logprobs(self) -> None:
+        import tpu_inference.layers.common.sharding as sharding_mod
+        print("\n" + "*"*50)
+        print(f"[SHARDING_CHECK] Available attributes in ShardingAxisName:")
+        print(dir(sharding_mod.ShardingAxisName))
+        print("*"*50 + "\n")
         logger.info("Compiling gather_logprobs with different input shapes.")
         hsize = self.runner.model_config.get_vocab_size()
+        # --- DEBUG PRINT START ---
+        print(f"\n" + "="*60)
+        print(f"[DEBUG_COMPILE] Starting _precompile_gather_logprobs")
+        print(f"[DEBUG_COMPILE] num_reqs_paddings (Global): {self.runner.num_reqs_paddings}")
+        print(f"[DEBUG_COMPILE] num_reqs_paddings_per_dp (Per-Rank): {self.runner.num_reqs_paddings_per_dp}")
+        print(f"[DEBUG_COMPILE] Model Config Max Logprobs: {self.runner.model_config.max_logprobs}")
+        # --- DEBUG PRINT END ---
         for num_reqs in self.runner.num_reqs_paddings:
             dp_size = self.runner.vllm_config.sharding_config.total_dp_size
+            # if dp_size > 1:
+            #     # Matches the runtime spec: P('data', ('attn_dp', 'attn_dp_expert', 'model', 'expert'))
+            #     # Based on the Mesh definition, ShardingAxisName.DATA maps to the 'data' axis.
+            #     logits_sharding = NamedSharding(
+            #         self.runner.mesh,
+            #         PartitionSpec(
+            #             ('data',), 
+            #             ('attn_dp', 'attn_dp_expert', 'model', 'expert')
+            #         )
+            #     )
+            #     token_ids_sharding = NamedSharding(
+            #         self.runner.mesh, 
+            #         PartitionSpec(('data',))
+            #     )
+            # else:
+            #     logits_sharding = NamedSharding(self.runner.mesh, PartitionSpec())
+            #     token_ids_sharding = NamedSharding(self.runner.mesh, PartitionSpec())
             logits_sharding = NamedSharding(
                 self.runner.mesh,
                 PartitionSpec(ShardingAxisName.MLP_DATA,
-                              ShardingAxisName.MLP_TENSOR))
+                              ShardingAxisName.MLP_TENSOR))  if dp_size > 1 else NamedSharding(self.runner.mesh,
+                                                PartitionSpec())
             token_ids_sharding = NamedSharding(
                 self.runner.mesh, PartitionSpec(ShardingAxisName.MLP_DATA, )
             ) if dp_size > 1 else NamedSharding(self.runner.mesh,
                                                 PartitionSpec())
+            # --- DEBUG PRINT START ---
+            print(f"[DEBUG_COMPILE] Loop Iteration | num_reqs: {num_reqs}")
+            print(f"[DEBUG_COMPILE] Logits Sharding Spec: {logits_sharding.spec}")
+            print(f"[DEBUG_COMPILE] Token IDs Sharding Spec: {token_ids_sharding.spec}")
+            # --- DEBUG PRINT END ---
             logits = self._create_dummy_tensor((num_reqs, hsize), jnp.float32,
                                                logits_sharding)
             token_ids = self._create_dummy_tensor((num_reqs, ), jnp.int32,
                                                   token_ids_sharding)
             self._run_compilation(
                 f"worker{self.runner.rank} gather_logprobs",
-                self.runner._compute_and_gather_logprobs,
+                lambda lg, tid: self.runner._compute_and_gather_logprobs(
+                    lg, tid, num_reqs=num_reqs, max_logprobs=self.runner.model_config.max_logprobs
+                ),
                 logits,
                 token_ids,
-                self.runner.model_config.max_logprobs,
-                num_reqs=num_reqs,
+                num_reqs = num_reqs,
+                max_logprobs = self.runner.model_config.max_logprobs,
             )
 
         self._gather_logprobs_precompiled = True

--- a/tpu_inference/runner/compilation_manager.py
+++ b/tpu_inference/runner/compilation_manager.py
@@ -272,7 +272,6 @@ class CompilationManager:
         that the scheduler is expected to handle, ensuring a compiled version
         is ready for each combination.
         """
-        dp_size = self.runner.vllm_config.sharding_config.model_dp_size * self.runner.vllm_config.sharding_config.attn_dp_size
 
         for num_tokens in self.runner.num_tokens_paddings:
             dp_sharding = NamedSharding(
@@ -293,14 +292,10 @@ class CompilationManager:
 
                 input_ids = self._create_dummy_tensor((num_tokens, ),
                                                       jnp.int32, dp_sharding)
-                # Need align to the sampling output sharding (sharded by ATTN_DATA in DP)
                 next_tokens = self._create_dummy_tensor(
                     (num_reqs, ),
                     jnp.int32,
-                    sharding=NamedSharding(
-                        self.runner.mesh,
-                        PartitionSpec(ShardingAxisName.ATTN_DATA)) if dp_size
-                    > 1 else NamedSharding(self.runner.mesh, PartitionSpec()))
+                    sharding=NamedSharding(self.runner.mesh, PartitionSpec()))
 
                 placeholder_num = jnp.asarray(1, dtype=jnp.int32)
                 self._run_compilation(
@@ -619,66 +614,26 @@ class CompilationManager:
                 layer_cache.block_until_ready()
 
     def _precompile_gather_logprobs(self) -> None:
-        import tpu_inference.layers.common.sharding as sharding_mod
-        print("\n" + "*"*50)
-        print(f"[SHARDING_CHECK] Available attributes in ShardingAxisName:")
-        print(dir(sharding_mod.ShardingAxisName))
-        print("*"*50 + "\n")
         logger.info("Compiling gather_logprobs with different input shapes.")
         hsize = self.runner.model_config.get_vocab_size()
-        # --- DEBUG PRINT START ---
-        print(f"\n" + "="*60)
-        print(f"[DEBUG_COMPILE] Starting _precompile_gather_logprobs")
-        print(f"[DEBUG_COMPILE] num_reqs_paddings (Global): {self.runner.num_reqs_paddings}")
-        print(f"[DEBUG_COMPILE] num_reqs_paddings_per_dp (Per-Rank): {self.runner.num_reqs_paddings_per_dp}")
-        print(f"[DEBUG_COMPILE] Model Config Max Logprobs: {self.runner.model_config.max_logprobs}")
-        # --- DEBUG PRINT END ---
         for num_reqs in self.runner.num_reqs_paddings:
-            dp_size = self.runner.vllm_config.sharding_config.total_dp_size
-            # if dp_size > 1:
-            #     # Matches the runtime spec: P('data', ('attn_dp', 'attn_dp_expert', 'model', 'expert'))
-            #     # Based on the Mesh definition, ShardingAxisName.DATA maps to the 'data' axis.
-            #     logits_sharding = NamedSharding(
-            #         self.runner.mesh,
-            #         PartitionSpec(
-            #             ('data',), 
-            #             ('attn_dp', 'attn_dp_expert', 'model', 'expert')
-            #         )
-            #     )
-            #     token_ids_sharding = NamedSharding(
-            #         self.runner.mesh, 
-            #         PartitionSpec(('data',))
-            #     )
-            # else:
-            #     logits_sharding = NamedSharding(self.runner.mesh, PartitionSpec())
-            #     token_ids_sharding = NamedSharding(self.runner.mesh, PartitionSpec())
             logits_sharding = NamedSharding(
                 self.runner.mesh,
                 PartitionSpec(ShardingAxisName.MLP_DATA,
-                              ShardingAxisName.MLP_TENSOR))  if dp_size > 1 else NamedSharding(self.runner.mesh,
-                                                PartitionSpec())
-            token_ids_sharding = NamedSharding(
-                self.runner.mesh, PartitionSpec(ShardingAxisName.MLP_DATA, )
-            ) if dp_size > 1 else NamedSharding(self.runner.mesh,
-                                                PartitionSpec())
-            # --- DEBUG PRINT START ---
-            print(f"[DEBUG_COMPILE] Loop Iteration | num_reqs: {num_reqs}")
-            print(f"[DEBUG_COMPILE] Logits Sharding Spec: {logits_sharding.spec}")
-            print(f"[DEBUG_COMPILE] Token IDs Sharding Spec: {token_ids_sharding.spec}")
-            # --- DEBUG PRINT END ---
+                              ShardingAxisName.MLP_TENSOR))
+            token_ids_sharding = NamedSharding(self.runner.mesh,
+                                               PartitionSpec())
             logits = self._create_dummy_tensor((num_reqs, hsize), jnp.float32,
                                                logits_sharding)
             token_ids = self._create_dummy_tensor((num_reqs, ), jnp.int32,
                                                   token_ids_sharding)
             self._run_compilation(
                 f"worker{self.runner.rank} gather_logprobs",
-                lambda lg, tid: self.runner._compute_and_gather_logprobs(
-                    lg, tid, num_reqs=num_reqs, max_logprobs=self.runner.model_config.max_logprobs
-                ),
+                self.runner._compute_and_gather_logprobs,
                 logits,
                 token_ids,
-                num_reqs = num_reqs,
-                max_logprobs = self.runner.model_config.max_logprobs,
+                self.runner.model_config.max_logprobs,
+                num_reqs=num_reqs,
             )
 
         self._gather_logprobs_precompiled = True

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -969,9 +969,23 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         with self.maybe_forbid_compile:
 
             if tpu_sampling_metadata.logprobs:
+                # --- [DEBUG START] ---
+                import os
+                if self.rank == 0:
+                    print(f"\n" + "!"*60)
+                    print(f"[DEBUG_RUN] PID: {os.getpid()} | Rank: {self.rank}")
+                    print(f"[DEBUG_RUN] DP Size: {self.dp_size}")
+                    print(f"[DEBUG_RUN] num_reqs (raw): {self.input_batch.num_reqs}")
+                    print(f"[DEBUG_RUN] padded_num_reqs: {padded_num_reqs}")
+                    print(f"[DEBUG_RUN] Logits Shape: {logits.shape}")
+                    print(f"[DEBUG_RUN] Logits Sharding: {logits.sharding}")
+                    print(f"[DEBUG_RUN] Max Logprobs: {self.model_config.max_logprobs}")
+                    print(f"!"*60 + "\n")
+                # --- [DEBUG END] ---
+                print(f"DEBUG RUNTIME: logits shape={logits.shape}, dtype={logits.dtype}, sharding={logits.sharding.spec}")
                 logits = processed_logits if self.model_config.logprobs_mode == "processed_logprobs" else logits
                 logprobs = self._compute_and_gather_logprobs(
-                    logits, next_tokens, self.model_config.max_logprobs)
+                    logits, next_tokens, num_reqs=padded_num_reqs, max_logprobs=self.model_config.max_logprobs)
                 logprobs = _jax_logprobs_copy_to_host_async(logprobs)
             else:
                 logprobs = None
@@ -1135,9 +1149,9 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         return ret
 
     @staticmethod
-    @jax.jit(static_argnames=("max_logprobs", ))
-    def _compute_and_gather_logprobs(logits, next_tokens, max_logprobs):
-        logprobs = compute_logprobs(logits)
+    @jax.jit(static_argnames=("num_reqs", "max_logprobs"))
+    def _compute_and_gather_logprobs(logits, next_tokens, num_reqs, max_logprobs):
+        logprobs = compute_logprobs(logits.astype(jnp.float32))
         return gather_logprobs(logprobs, next_tokens, max_logprobs)
 
     def _prepare_dp_input_metadata(self,

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -969,23 +969,9 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         with self.maybe_forbid_compile:
 
             if tpu_sampling_metadata.logprobs:
-                # --- [DEBUG START] ---
-                import os
-                if self.rank == 0:
-                    print(f"\n" + "!"*60)
-                    print(f"[DEBUG_RUN] PID: {os.getpid()} | Rank: {self.rank}")
-                    print(f"[DEBUG_RUN] DP Size: {self.dp_size}")
-                    print(f"[DEBUG_RUN] num_reqs (raw): {self.input_batch.num_reqs}")
-                    print(f"[DEBUG_RUN] padded_num_reqs: {padded_num_reqs}")
-                    print(f"[DEBUG_RUN] Logits Shape: {logits.shape}")
-                    print(f"[DEBUG_RUN] Logits Sharding: {logits.sharding}")
-                    print(f"[DEBUG_RUN] Max Logprobs: {self.model_config.max_logprobs}")
-                    print(f"!"*60 + "\n")
-                # --- [DEBUG END] ---
-                print(f"DEBUG RUNTIME: logits shape={logits.shape}, dtype={logits.dtype}, sharding={logits.sharding.spec}")
                 logits = processed_logits if self.model_config.logprobs_mode == "processed_logprobs" else logits
                 logprobs = self._compute_and_gather_logprobs(
-                    logits, next_tokens, num_reqs=padded_num_reqs, max_logprobs=self.model_config.max_logprobs)
+                    logits, next_tokens, self.model_config.max_logprobs)
                 logprobs = _jax_logprobs_copy_to_host_async(logprobs)
             else:
                 logprobs = None
@@ -1149,9 +1135,9 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         return ret
 
     @staticmethod
-    @jax.jit(static_argnames=("num_reqs", "max_logprobs"))
-    def _compute_and_gather_logprobs(logits, next_tokens, num_reqs, max_logprobs):
-        logprobs = compute_logprobs(logits.astype(jnp.float32))
+    @jax.jit(static_argnames=("max_logprobs", ))
+    def _compute_and_gather_logprobs(logits, next_tokens, max_logprobs):
+        logprobs = compute_logprobs(logits)
         return gather_logprobs(logprobs, next_tokens, max_logprobs)
 
     def _prepare_dp_input_metadata(self,


### PR DESCRIPTION
# Description

This PR fixed the sharding inconsistent issue in precompile and runner and simplified the sharding configuration during the pre-compilation stage in `compilation_manager.py` to correspond to sampling sharding.

FIXES: b/499302446

# Tests

Passed test:
- `python -m pytest -s -rP tests/e2e/test_expert_parallel.py`
- `python -m pytest -s -rP tests/e2e/test_tensor_parallel.py`
- `python -m pytest -s -rP tests/e2e/test_pipeline_parallel.py`
- `python -m pytest -s -rP tests/e2e/test_data_parallel.py`

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
