### PR TITLE
[Profiler] Add PHASED_PROFILER_NUM_DECODE_STEPS_TO_SKIP flag 

### DIFF
--- a/tests/runner/test_utils.py
+++ b/tests/runner/test_utils.py
@@ -449,3 +449,79 @@ def test_phased_profiler_handles_all_phases(profiler_fixture):
     mock_determine_phase.return_value = InferencePhase.PREFILL_HEAVY
     profiler.step(stats)
     assert mock_start.call_count == len(phases_to_profile)
+
+
+def test_phased_profiler_skips_decode_steps_before_profiling(profiler_fixture):
+    """Tests that the profiler skips N decode-heavy steps before profiling."""
+    profiler = profiler_fixture["profiler"]
+    mock_start = profiler_fixture["mock_start"]
+    mock_stop = profiler_fixture["mock_stop"]
+    mock_determine_phase = profiler_fixture["mock_determine_phase"]
+
+    num_steps_to_skip = 3
+    profiler.num_decode_steps_to_skip = num_steps_to_skip
+
+    stats = {"num_reqs": 2, "total_num_scheduled_tokens": 100}
+    mock_determine_phase.return_value = InferencePhase.DECODE_HEAVY
+
+    # Each of these steps should be skipped (no profiling started)
+    for i in range(num_steps_to_skip):
+        profiler.step(stats)
+        assert profiler.decode_steps_skipped == i + 1
+        mock_start.assert_not_called()
+        assert not profiler.inference_phase_seen[InferencePhase.DECODE_HEAVY]
+
+    # The next step should actually start profiling
+    profiler.step(stats)
+    mock_start.assert_called_once()
+    assert profiler.inference_phase_seen[InferencePhase.DECODE_HEAVY]
+    assert profiler.current_phase == "decode_heavy"
+    assert profiler.profiling_n_steps_left == PHASED_PROFILER_NUM_STEPS_TO_PROFILE_FOR
+
+    # Complete the profiling cycle
+    for _ in range(PHASED_PROFILER_NUM_STEPS_TO_PROFILE_FOR):
+        profiler.step(stats)
+    mock_stop.assert_called_once()
+    assert profiler.current_phase == ""
+
+
+def test_phased_profiler_skip_only_affects_decode_heavy(profiler_fixture):
+    """Tests that the skip logic only applies to the DECODE_HEAVY phase."""
+    profiler = profiler_fixture["profiler"]
+    mock_start = profiler_fixture["mock_start"]
+    mock_stop = profiler_fixture["mock_stop"]
+    mock_determine_phase = profiler_fixture["mock_determine_phase"]
+
+    profiler.num_decode_steps_to_skip = 5  # Large skip count
+
+    stats = {"num_reqs": 2, "total_num_scheduled_tokens": 100}
+
+    # PREFILL_HEAVY should start profiling immediately (no skipping)
+    mock_determine_phase.return_value = InferencePhase.PREFILL_HEAVY
+    profiler.step(stats)
+    mock_start.assert_called_once()
+    assert profiler.inference_phase_seen[InferencePhase.PREFILL_HEAVY]
+    assert profiler.decode_steps_skipped == 0  # Not incremented
+
+    # Complete the PREFILL_HEAVY profiling cycle
+    for _ in range(PHASED_PROFILER_NUM_STEPS_TO_PROFILE_FOR):
+        profiler.step(stats)
+    mock_stop.assert_called_once()
+
+    # BALANCED should also start immediately (no skipping)
+    mock_determine_phase.return_value = InferencePhase.BALANCED
+    profiler.step(stats)
+    assert mock_start.call_count == 2
+    assert profiler.inference_phase_seen[InferencePhase.BALANCED]
+    assert profiler.decode_steps_skipped == 0  # Still not incremented
+
+    # Complete the BALANCED profiling cycle
+    for _ in range(PHASED_PROFILER_NUM_STEPS_TO_PROFILE_FOR):
+        profiler.step(stats)
+    assert mock_stop.call_count == 2
+
+    # DECODE_HEAVY should be skipped
+    mock_determine_phase.return_value = InferencePhase.DECODE_HEAVY
+    profiler.step(stats)
+    assert mock_start.call_count == 2  # Not started yet
+    assert profiler.decode_steps_skipped == 1

--- a/tpu_inference/runner/utils.py
+++ b/tpu_inference/runner/utils.py
@@ -33,6 +33,7 @@ DECODE_HEAVY_RATIO_THRESHOLD = 0.2
 # for prefilling is in the BALANCED phase
 BALANCED_RATIO_THRESHOLD = (0.4, 0.6)
 PHASED_PROFILER_NUM_STEPS_TO_PROFILE_FOR = 15
+PHASED_PROFILER_NUM_DECODE_STEPS_TO_SKIP = 0
 
 logger = init_logger(__name__)
 
@@ -299,6 +300,10 @@ class PhasedBasedProfiler:
         self.num_steps_to_profile_for: int = int(
             os.getenv("PHASED_PROFILER_NUM_STEPS_TO_PROFILE_FOR",
                       PHASED_PROFILER_NUM_STEPS_TO_PROFILE_FOR))
+        self.num_decode_steps_to_skip: int = int(
+            os.getenv("PHASED_PROFILER_NUM_DECODE_STEPS_TO_SKIP",
+                      PHASED_PROFILER_NUM_DECODE_STEPS_TO_SKIP))
+        self.decode_steps_skipped: int = 0
         self.profile_dir: str = profile_dir
         # NOTE: we purposely don't have AMBIGUOUS here
         self.inference_phase_seen: dict = {
@@ -314,6 +319,10 @@ class PhasedBasedProfiler:
         logger.info(
             "Phased-based profiler enabled. Traces will be saved to: %s",
             self.profile_dir)
+        if self.num_decode_steps_to_skip > 0:
+            logger.info(
+                "Will skip %d decode-heavy steps before profiling decode_heavy phase.",
+                self.num_decode_steps_to_skip)
 
     def _write_batch_composition_stats_to_file_helper(
             self, batch_composition_stats: dict) -> None:
@@ -349,6 +358,15 @@ class PhasedBasedProfiler:
         for phase, has_been_seen in self.inference_phase_seen.items():
             if has_been_seen or phase != current_determined_phase:
                 continue
+
+            # Skip a configurable number of decode-heavy steps before profiling
+            if phase == InferencePhase.DECODE_HEAVY and \
+                    self.decode_steps_skipped < self.num_decode_steps_to_skip:
+                self.decode_steps_skipped += 1
+                logger.debug(
+                    "Skipping decode-heavy step %d/%d before profiling.",
+                    self.decode_steps_skipped, self.num_decode_steps_to_skip)
+                break
 
             self.inference_phase_seen[phase] = True
             self.profiling_n_steps_left = self.num_steps_to_profile_for


### PR DESCRIPTION
# Description

When profiling decode-heavy batches, the first several steps may not be representative of longer term behavior. By skipping a configurable number of initial decode-heavy steps, users can capture more representative profiles.

This PR introduces `PHASED_PROFILER_NUM_DECODE_STEPS_TO_SKIP`, defaults to 0, and represents the number of decode-heavy steps to skip before starting the decode-heavy profiling phase. 
# Tests

Added unit tests

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
