### PR TITLE
Add "torch-backend=cpu" in the installation doc

### DIFF
--- a/docs/getting_started/installation.md
+++ b/docs/getting_started/installation.md
@@ -86,7 +86,7 @@ For debugging or development purposes, you can install `tpu-inference` from sour
 
     ```shell
     cd vllm
-    uv pip install -r requirements/tpu.txt
+    uv pip install -r requirements/tpu.txt --torch-backend=cpu
     VLLM_TARGET_DEVICE="tpu" uv pip install -e .
     cd ..
     ```


### PR DESCRIPTION
# Description

Then it will only install torch-cpu, excluding those cuda related packages

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.

