### PR TITLE
Rollback: Revert processed_logprobs changes by Sierra Qian

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ numpy
 google-cloud-storage
 jax==0.9.2
 jaxlib==0.9.2
-libtpu==0.0.39
+libtpu==0.0.38
 jaxtyping
 flax==0.12.4
 torchax==0.0.11

--- a/tests/layers/jax/sample/test_sampling.py
+++ b/tests/layers/jax/sample/test_sampling.py
@@ -33,7 +33,6 @@ class TestSampling:
         logits = jnp.array([[1.0, 2.0, 3.0], [3.0, 2.0, 1.0]],
                            dtype=jnp.float32)
         logprobs = compute_logprobs(logits)
-        
 
         # Expected values computed with scipy.special.log_softmax
         expected_logprobs = np.array(
@@ -140,7 +139,7 @@ class TestProcessedLogprobs:
                                  temperature,
                                  dtype=jnp.float32),
             top_k=jnp.full((batch_size, ), top_k, dtype=jnp.int32),
-            top_p=jnp.full((batch_size, ), top_p, dtype=jnp.bfloat),
+            top_p=jnp.full((batch_size, ), top_p, dtype=jnp.float32),
             _cache_collision_dummy=None,
             do_sampling=do_sampling,
             logprobs=True,
@@ -158,7 +157,7 @@ class TestProcessedLogprobs:
 
     def test_processed_logprobs_with_temperature(self):
         """Temperature scaling should change the logprobs distribution."""
-        logits = jnp.array([[1.0, 2.0, 3.0]], dtype=jnp.bfloat16)
+        logits = jnp.array([[1.0, 2.0, 3.0]], dtype=jnp.float32)
 
         raw_logprobs = compute_logprobs(logits)
 
@@ -178,7 +177,7 @@ class TestProcessedLogprobs:
     def test_processed_logprobs_matches_manual_temperature(self):
         """Verify processed_logprobs produces the same result as manually
         dividing by temperature then computing log_softmax."""
-        logits = jnp.array([[1.0, 2.0, 3.0, 0.5]], dtype=jnp.bfloat16)
+        logits = jnp.array([[1.0, 2.0, 3.0, 0.5]], dtype=jnp.float32)
         temperature = 0.8
 
         metadata = self._make_sampling_metadata(1, temperature=temperature)
@@ -194,7 +193,7 @@ class TestProcessedLogprobs:
 
     def test_processed_logprobs_with_topk(self):
         """After top-k masking, tokens outside top-k should get -inf logprobs."""
-        logits = jnp.array([[1.0, 5.0, 3.0, 2.0, 4.0]], dtype=jnp.bfloat16)
+        logits = jnp.array([[1.0, 5.0, 3.0, 2.0, 4.0]], dtype=jnp.float32)
 
         metadata = self._make_sampling_metadata(1, temperature=1.0, top_k=2)
         _, processed_logits = sample(jax.random.PRNGKey(0),
@@ -214,7 +213,7 @@ class TestProcessedLogprobs:
     def test_processed_logprobs_with_topp(self):
         """After top-p filtering, low-probability tokens should be masked."""
         # Make logits where one token dominates.
-        logits = jnp.array([[10.0, 1.0, 0.0, -1.0]], dtype=jnp.bfloat16)
+        logits = jnp.array([[10.0, 1.0, 0.0, -1.0]], dtype=jnp.float32)
 
         metadata = self._make_sampling_metadata(1, temperature=1.0, top_p=0.5)
         _, processed_logits = sample(jax.random.PRNGKey(0),
@@ -228,7 +227,7 @@ class TestProcessedLogprobs:
     def test_processed_logprobs_greedy_fallback(self):
         """For greedy requests (temperature < eps), processed logprobs should
         match raw logprobs."""
-        logits = jnp.array([[1.0, 2.0, 3.0]], dtype=jnp.bfloat16)
+        logits = jnp.array([[1.0, 2.0, 3.0]], dtype=jnp.float32)
 
         raw_logprobs = compute_logprobs(logits)
 

--- a/tests/layers/jax/sample/test_sampling.py
+++ b/tests/layers/jax/sample/test_sampling.py
@@ -139,7 +139,7 @@ class TestProcessedLogprobs:
                                  temperature,
                                  dtype=jnp.float32),
             top_k=jnp.full((batch_size, ), top_k, dtype=jnp.int32),
-            top_p=jnp.full((batch_size, ), top_p, dtype=jnp.bfloat16),
+            top_p=jnp.full((batch_size, ), top_p, dtype=jnp.bfloat),
             _cache_collision_dummy=None,
             do_sampling=do_sampling,
             logprobs=True,

--- a/tests/layers/jax/sample/test_sampling.py
+++ b/tests/layers/jax/sample/test_sampling.py
@@ -139,7 +139,7 @@ class TestProcessedLogprobs:
                                  temperature,
                                  dtype=jnp.float32),
             top_k=jnp.full((batch_size, ), top_k, dtype=jnp.int32),
-            top_p=jnp.full((batch_size, ), top_p, dtype=jnp.float32),
+            top_p=jnp.full((batch_size, ), top_p, dtype=jnp.bfloat16),
             _cache_collision_dummy=None,
             do_sampling=do_sampling,
             logprobs=True,
@@ -157,7 +157,7 @@ class TestProcessedLogprobs:
 
     def test_processed_logprobs_with_temperature(self):
         """Temperature scaling should change the logprobs distribution."""
-        logits = jnp.array([[1.0, 2.0, 3.0]], dtype=jnp.float32)
+        logits = jnp.array([[1.0, 2.0, 3.0]], dtype=jnp.bfloat16)
 
         raw_logprobs = compute_logprobs(logits)
 
@@ -177,7 +177,7 @@ class TestProcessedLogprobs:
     def test_processed_logprobs_matches_manual_temperature(self):
         """Verify processed_logprobs produces the same result as manually
         dividing by temperature then computing log_softmax."""
-        logits = jnp.array([[1.0, 2.0, 3.0, 0.5]], dtype=jnp.float32)
+        logits = jnp.array([[1.0, 2.0, 3.0, 0.5]], dtype=jnp.bfloat16)
         temperature = 0.8
 
         metadata = self._make_sampling_metadata(1, temperature=temperature)
@@ -193,7 +193,7 @@ class TestProcessedLogprobs:
 
     def test_processed_logprobs_with_topk(self):
         """After top-k masking, tokens outside top-k should get -inf logprobs."""
-        logits = jnp.array([[1.0, 5.0, 3.0, 2.0, 4.0]], dtype=jnp.float32)
+        logits = jnp.array([[1.0, 5.0, 3.0, 2.0, 4.0]], dtype=jnp.bfloat16)
 
         metadata = self._make_sampling_metadata(1, temperature=1.0, top_k=2)
         _, processed_logits = sample(jax.random.PRNGKey(0),
@@ -213,7 +213,7 @@ class TestProcessedLogprobs:
     def test_processed_logprobs_with_topp(self):
         """After top-p filtering, low-probability tokens should be masked."""
         # Make logits where one token dominates.
-        logits = jnp.array([[10.0, 1.0, 0.0, -1.0]], dtype=jnp.float32)
+        logits = jnp.array([[10.0, 1.0, 0.0, -1.0]], dtype=jnp.bfloat16)
 
         metadata = self._make_sampling_metadata(1, temperature=1.0, top_p=0.5)
         _, processed_logits = sample(jax.random.PRNGKey(0),
@@ -227,7 +227,7 @@ class TestProcessedLogprobs:
     def test_processed_logprobs_greedy_fallback(self):
         """For greedy requests (temperature < eps), processed logprobs should
         match raw logprobs."""
-        logits = jnp.array([[1.0, 2.0, 3.0]], dtype=jnp.float32)
+        logits = jnp.array([[1.0, 2.0, 3.0]], dtype=jnp.bfloat16)
 
         raw_logprobs = compute_logprobs(logits)
 

--- a/tests/layers/jax/sample/test_sampling.py
+++ b/tests/layers/jax/sample/test_sampling.py
@@ -33,6 +33,7 @@ class TestSampling:
         logits = jnp.array([[1.0, 2.0, 3.0], [3.0, 2.0, 1.0]],
                            dtype=jnp.float32)
         logprobs = compute_logprobs(logits)
+        
 
         # Expected values computed with scipy.special.log_softmax
         expected_logprobs = np.array(

--- a/tests/layers/jax/sample/test_sampling.py
+++ b/tests/layers/jax/sample/test_sampling.py
@@ -13,18 +13,12 @@
 # limitations under the License.
 
 # /home/pooyam/tpu_inference/tests/models/jax/layers/test_sampling.py
-import jax
 import jax.numpy as jnp
 import numpy as np
-from jax.experimental import mesh_utils
-from jax.sharding import Mesh
 from vllm.v1.outputs import LogprobsTensors
 
-from tpu_inference.layers.common.sharding import ShardingAxisName
 from tpu_inference.layers.jax.sample.sampling import (compute_logprobs,
-                                                      gather_logprobs, sample)
-from tpu_inference.layers.jax.sample.sampling_metadata import \
-    TPUSupportedSamplingMetadata
+                                                      gather_logprobs)
 
 
 class TestSampling:
@@ -119,122 +113,3 @@ class TestSampling:
         assert result.logprob_token_ids[0, 0] == 1
         top_k_indices = sorted(result.logprob_token_ids[0, 1:].tolist())
         assert top_k_indices == [0, 1, 2] or top_k_indices == [0, 1, 3]
-
-
-class TestProcessedLogprobs:
-    """Tests for the processed_logprobs mode (logprobs computed after
-    temperature / top-k / top-p transforms)."""
-
-    @staticmethod
-    def _make_sampling_metadata(
-        batch_size,
-        temperature=0.7,
-        top_k=0,
-        top_p=1.0,
-        do_sampling=True,
-    ):
-        """Helper to build a TPUSupportedSamplingMetadata for testing."""
-        return TPUSupportedSamplingMetadata(
-            temperature=jnp.full((batch_size, ),
-                                 temperature,
-                                 dtype=jnp.float32),
-            top_k=jnp.full((batch_size, ), top_k, dtype=jnp.int32),
-            top_p=jnp.full((batch_size, ), top_p, dtype=jnp.float32),
-            _cache_collision_dummy=None,
-            do_sampling=do_sampling,
-            logprobs=True,
-        )
-
-    @staticmethod
-    def _get_fake_mesh():
-        """Create a fake mesh for testing purposes."""
-        devices = jax.devices()
-        num_devices = len(devices)
-        mesh_shape = (num_devices, )
-        axis_names = (ShardingAxisName.ATTN_DATA, )
-        device_mesh = mesh_utils.create_device_mesh(mesh_shape, devices)
-        return Mesh(device_mesh, axis_names)
-
-    def test_processed_logprobs_with_temperature(self):
-        """Temperature scaling should change the logprobs distribution."""
-        logits = jnp.array([[1.0, 2.0, 3.0]], dtype=jnp.float32)
-
-        raw_logprobs = compute_logprobs(logits)
-
-        metadata = self._make_sampling_metadata(1, temperature=0.5)
-        _, processed_logits = sample(jax.random.PRNGKey(0),
-                                     self._get_fake_mesh(), logits, metadata)
-        processed = compute_logprobs(processed_logits)
-
-        # With temperature < 1, processed logprobs should be more peaked
-        # (higher max, lower others) compared to raw logprobs.
-        assert not np.allclose(raw_logprobs, processed, atol=1e-4)
-        # The argmax should still be the same token.
-        assert np.argmax(processed[0]) == np.argmax(raw_logprobs[0])
-        # The max logprob should be closer to 0 (more confident).
-        assert float(jnp.max(processed[0])) > float(jnp.max(raw_logprobs[0]))
-
-    def test_processed_logprobs_matches_manual_temperature(self):
-        """Verify processed_logprobs produces the same result as manually
-        dividing by temperature then computing log_softmax."""
-        logits = jnp.array([[1.0, 2.0, 3.0, 0.5]], dtype=jnp.float32)
-        temperature = 0.8
-
-        metadata = self._make_sampling_metadata(1, temperature=temperature)
-        fake_mesh = self._get_fake_mesh()
-        _, processed_logits = sample(jax.random.PRNGKey(0), fake_mesh, logits,
-                                     metadata)
-        processed = compute_logprobs(processed_logits)
-
-        expected = jnp.log(
-            jnp.exp(logits / temperature) /
-            jnp.sum(jnp.exp(logits / temperature), axis=-1, keepdims=True))
-        assert np.allclose(processed, expected, atol=1e-5)
-
-    def test_processed_logprobs_with_topk(self):
-        """After top-k masking, tokens outside top-k should get -inf logprobs."""
-        logits = jnp.array([[1.0, 5.0, 3.0, 2.0, 4.0]], dtype=jnp.float32)
-
-        metadata = self._make_sampling_metadata(1, temperature=1.0, top_k=2)
-        _, processed_logits = sample(jax.random.PRNGKey(0),
-                                     self._get_fake_mesh(), logits, metadata)
-        processed = compute_logprobs(processed_logits)
-
-        # Top-2 tokens are indices 1 (5.0) and 4 (4.0).
-        # After masking, only those two should have non-tiny logprobs.
-        processed_np = np.array(processed[0])
-        top2_indices = set(np.argsort(processed_np)[-2:])
-        assert top2_indices == {1, 4}
-        # Masked tokens should have very negative logprobs.
-        for i in range(5):
-            if i not in top2_indices:
-                assert processed_np[i] < -10.0
-
-    def test_processed_logprobs_with_topp(self):
-        """After top-p filtering, low-probability tokens should be masked."""
-        # Make logits where one token dominates.
-        logits = jnp.array([[10.0, 1.0, 0.0, -1.0]], dtype=jnp.float32)
-
-        metadata = self._make_sampling_metadata(1, temperature=1.0, top_p=0.5)
-        _, processed_logits = sample(jax.random.PRNGKey(0),
-                                     self._get_fake_mesh(), logits, metadata)
-        processed = compute_logprobs(processed_logits)
-
-        # Token 0 has very high probability and should remain.
-        processed_np = np.array(processed[0])
-        assert processed_np[0] > -0.1  # close to 0 = probability close to 1
-
-    def test_processed_logprobs_greedy_fallback(self):
-        """For greedy requests (temperature < eps), processed logprobs should
-        match raw logprobs."""
-        logits = jnp.array([[1.0, 2.0, 3.0]], dtype=jnp.float32)
-
-        raw_logprobs = compute_logprobs(logits)
-
-        # Temperature < _SAMPLING_EPS (1e-5)
-        metadata = self._make_sampling_metadata(1, temperature=1e-7)
-        _, processed_logits = sample(jax.random.PRNGKey(0),
-                                     self._get_fake_mesh(), logits, metadata)
-        processed = compute_logprobs(processed_logits)
-
-        assert np.allclose(raw_logprobs, processed, atol=1e-6)

--- a/tpu_inference/layers/jax/sample/sampling.py
+++ b/tpu_inference/layers/jax/sample/sampling.py
@@ -84,11 +84,12 @@ def sample(
             logits, NamedSharding(mesh, P(ShardingAxisName.ATTN_DATA, None)))
 
     greedy_tokens = jnp.argmax(logits, axis=-1)
+    logits_f32 = logits.astype(jnp.float32)
     if not tpu_sampling_metadata.do_sampling:
         ret_tokens = greedy_tokens
-        ret_logits = logits
+        ret_logits = logits_f32
     else:
-        processed_logits = _apply_sampling_transforms(logits,
+        processed_logits = _apply_sampling_transforms(logits_f32,
                                                       tpu_sampling_metadata)
         # (batch_size,)
         next_tokens = jax.random.categorical(rng, processed_logits)
@@ -96,7 +97,7 @@ def sample(
         # If temperature < 0, logits /= temperatures will flip the result, causing error.
         is_greedy = tpu_sampling_metadata.temperature < _SAMPLING_EPS
         ret_tokens = jnp.where(is_greedy, greedy_tokens, next_tokens)
-        ret_logits = jnp.where(jnp.expand_dims(is_greedy, axis=-1), logits,
+        ret_logits = jnp.where(jnp.expand_dims(is_greedy, axis=-1), logits_f32,
                                processed_logits)
     # Replicate the result so that in multi-controller jax setup
     # (i.e. Ray based multi-host setup), we won't hit error like

--- a/tpu_inference/layers/jax/sample/sampling.py
+++ b/tpu_inference/layers/jax/sample/sampling.py
@@ -84,7 +84,6 @@ def sample(
             logits, NamedSharding(mesh, P(ShardingAxisName.ATTN_DATA, None)))
 
     greedy_tokens = jnp.argmax(logits, axis=-1)
-    logits = logits.astype(jnp.float32)
     if not tpu_sampling_metadata.do_sampling:
         ret_tokens = greedy_tokens
         ret_logits = logits

--- a/tpu_inference/layers/jax/sample/sampling.py
+++ b/tpu_inference/layers/jax/sample/sampling.py
@@ -26,43 +26,6 @@ from tpu_inference.layers.jax.sample.sampling_metadata import \
 _SAMPLING_EPS = 1e-5
 
 
-def _apply_sampling_transforms(
-    logits: jax.Array,
-    tpu_sampling_metadata: TPUSupportedSamplingMetadata,
-) -> jax.Array:
-    """Apply temperature scaling, top-k, and top-p filtering to logits.
-
-    This extracts the common logit processing logic used by both the sampling
-    path and the processed-logprobs path so that the transformations are
-    applied identically.
-
-    Args:
-        logits: (B, vocab_size) raw logits in float32.
-        tpu_sampling_metadata: Sampling parameters (temperature, top_k, top_p).
-
-    Returns:
-        Processed logits with temperature, top-k, and top-p applied.
-    """
-    # Temperature scaling
-    temperatures = tpu_sampling_metadata.temperature.astype(logits.dtype)
-    temperatures = jnp.expand_dims(temperatures, axis=-1)
-    logits = logits / temperatures
-
-    # Only apply top-k masking if k > 0 for each token
-    top_k = tpu_sampling_metadata.top_k
-    should_apply_topk = jnp.expand_dims(top_k > 0, axis=-1)
-    topk_masked = topk_mask(logits, top_k, replace_val=-1e12)
-    logits = jnp.where(should_apply_topk, topk_masked, logits)
-
-    # Only apply top-p masking if p < 1.0 for each token
-    top_p = tpu_sampling_metadata.top_p
-    should_apply_topp = jnp.expand_dims(top_p < 1.0, axis=-1)
-    topp_masked = topp_mask(logits, top_p, replace_val=-1e12)
-    logits = jnp.where(should_apply_topp, topp_masked, logits)
-
-    return logits
-
-
 @jax.jit(static_argnames=["mesh"])
 def sample(
     rng: jax.Array,
@@ -82,30 +45,40 @@ def sample(
         # instead of being replicated.
         logits = jax.lax.with_sharding_constraint(
             logits, NamedSharding(mesh, P(ShardingAxisName.ATTN_DATA, None)))
-
-    greedy_tokens = jnp.argmax(logits, axis=-1)
-    logits_f32 = logits.astype(jnp.float32)
+    greedy_sampled = jnp.argmax(logits, axis=-1)
     if not tpu_sampling_metadata.do_sampling:
-        ret_tokens = greedy_tokens
-        ret_logits = logits_f32
-    else:
-        processed_logits = _apply_sampling_transforms(logits_f32,
-                                                      tpu_sampling_metadata)
-        # (batch_size,)
-        next_tokens = jax.random.categorical(rng, processed_logits)
-        # Note: avoid using the sample result when temperature < _SAMPLING_EPS
-        # If temperature < 0, logits /= temperatures will flip the result, causing error.
-        is_greedy = tpu_sampling_metadata.temperature < _SAMPLING_EPS
-        ret_tokens = jnp.where(is_greedy, greedy_tokens, next_tokens)
-        ret_logits = jnp.where(jnp.expand_dims(is_greedy, axis=-1), logits_f32,
-                               processed_logits)
+        return greedy_sampled
+
+    logits = logits.astype(jnp.float32)
+
+    # Temperature scaling
+    temperatures = tpu_sampling_metadata.temperature.astype(logits.dtype)
+    temperatures = jnp.expand_dims(temperatures, axis=-1)
+    logits /= temperatures
+
+    # Only apply top-k masking if k > 0 for each token
+    top_k = tpu_sampling_metadata.top_k
+    should_apply_topk = jnp.expand_dims(top_k > 0, axis=-1)
+    topk_masked = topk_mask(logits, top_k, replace_val=-1e12)
+    logits = jnp.where(should_apply_topk, topk_masked, logits)
+
+    # Only apply top-p masking if p < 1.0 for each token
+    top_p = tpu_sampling_metadata.top_p
+    should_apply_topp = jnp.expand_dims(top_p < 1.0, axis=-1)
+    topp_masked = topp_mask(logits, top_p, replace_val=-1e12)
+    logits = jnp.where(should_apply_topp, topp_masked, logits)
+
+    # (batch_size,)
+    next_tokens = jax.random.categorical(rng, logits)
+    # Note: avoid using the sample result when temperature < _SAMPLING_EPS
+    # If temperature < 0, logits /= temperatures will flip the result, causing error.
+    ret = jnp.where(tpu_sampling_metadata.temperature < _SAMPLING_EPS,
+                    greedy_sampled, next_tokens)
     # Replicate the result so that in multi-controller jax setup
     # (i.e. Ray based multi-host setup), we won't hit error like
     # RuntimeError: Fetching value for `jax.Array` that spans non-addressable
     # (non process local) devices is not possible.
-    next_tokens = jax.lax.with_sharding_constraint(ret_tokens,
-                                                   NamedSharding(mesh, P()))
-    return next_tokens, ret_logits
+    return jax.lax.with_sharding_constraint(ret, NamedSharding(mesh, P()))
 
 
 def compute_logprobs(logits: jax.Array) -> jax.Array:

--- a/tpu_inference/runner/compilation_manager.py
+++ b/tpu_inference/runner/compilation_manager.py
@@ -545,7 +545,7 @@ class CompilationManager:
             # function.
             sampling_metadata_sharding = NamedSharding(
                 self.runner.mesh, PartitionSpec(ShardingAxisName.ATTN_DATA))
-            logits = self._create_dummy_tensor((num_reqs, hsize), jnp.float32,
+            logits = self._create_dummy_tensor((num_reqs, hsize), jnp.bfloat16,
                                                logits_sharding)
             for do_sampling in (True, False):
                 for logprobs in (True, False):
@@ -631,7 +631,7 @@ class CompilationManager:
                 self.runner.mesh, PartitionSpec(ShardingAxisName.MLP_DATA, )
             ) if dp_size > 1 else NamedSharding(self.runner.mesh,
                                                 PartitionSpec())
-            logits = self._create_dummy_tensor((num_reqs, hsize), jnp.float32,
+            logits = self._create_dummy_tensor((num_reqs, hsize), jnp.bfloat16,
                                                logits_sharding)
             token_ids = self._create_dummy_tensor((num_reqs, ), jnp.int32,
                                                   token_ids_sharding)
@@ -663,7 +663,7 @@ class CompilationManager:
                     PartitionSpec(ShardingAxisName.MLP_DATA,
                                   ShardingAxisName.MLP_TENSOR))
                 target_probs = self._create_dummy_tensor(
-                    (num_logits, vocab_size), jnp.float32, sharding)
+                    (num_logits, vocab_size), jnp.bfloat16, sharding)
                 draft_token_ids = self._create_dummy_tensor((num_logits, ),
                                                             jnp.int32)
                 num_draft_tokens = self._create_dummy_tensor((num_reqs, ),

--- a/tpu_inference/runner/compilation_manager.py
+++ b/tpu_inference/runner/compilation_manager.py
@@ -78,6 +78,13 @@ class CompilationManager:
 
     def _run_compilation(self, name: str, fn: Callable, *args,
                          **kwargs) -> None:
+        if args and hasattr(args[0], 'dtype'):
+            dtype_str = str(args[0].dtype)
+            sharding_obj = getattr(args[0], 'sharding', None)
+            sharding_str = "None"
+            if sharding_obj:
+                sharding_str = getattr(sharding_obj, 'spec', sharding_obj)
+            logger.info(f"[DEBUG-WARMUP] {name} input0 dtype: {dtype_str}, sharding: {sharding_str}")
         logger.info(f"Precompile {name} --> {kwargs}")
         start = time.perf_counter()
         result = fn(*args)
@@ -545,7 +552,7 @@ class CompilationManager:
             # function.
             sampling_metadata_sharding = NamedSharding(
                 self.runner.mesh, PartitionSpec(ShardingAxisName.ATTN_DATA))
-            logits = self._create_dummy_tensor((num_reqs, hsize), jnp.bfloat16,
+            logits = self._create_dummy_tensor((num_reqs, hsize), jnp.float32,
                                                logits_sharding)
             for do_sampling in (True, False):
                 for logprobs in (True, False):
@@ -579,6 +586,10 @@ class CompilationManager:
                         _cache_collision_dummy=_cache_collision_dummy,
                         do_sampling=do_sampling,
                         logprobs=logprobs)
+                    print(f"\n[DEBUG-WARMUP] PRECOMPILING SAMPLE:")
+                    print(f"  - num_reqs: {num_reqs}")
+                    print(f"  - logits dtype: {logits.dtype}")
+                    print(f"  - logits sharding: {getattr(logits.sharding, 'spec', logits.sharding)}")
                     self._run_compilation(
                         f"worker{self.runner.rank} sample",
                         sample,
@@ -631,7 +642,7 @@ class CompilationManager:
                 self.runner.mesh, PartitionSpec(ShardingAxisName.MLP_DATA, )
             ) if dp_size > 1 else NamedSharding(self.runner.mesh,
                                                 PartitionSpec())
-            logits = self._create_dummy_tensor((num_reqs, hsize), jnp.bfloat16,
+            logits = self._create_dummy_tensor((num_reqs, hsize), jnp.float32,
                                                logits_sharding)
             token_ids = self._create_dummy_tensor((num_reqs, ), jnp.int32,
                                                   token_ids_sharding)
@@ -663,7 +674,7 @@ class CompilationManager:
                     PartitionSpec(ShardingAxisName.MLP_DATA,
                                   ShardingAxisName.MLP_TENSOR))
                 target_probs = self._create_dummy_tensor(
-                    (num_logits, vocab_size), jnp.bfloat16, sharding)
+                    (num_logits, vocab_size), jnp.float32, sharding)
                 draft_token_ids = self._create_dummy_tensor((num_logits, ),
                                                             jnp.int32)
                 num_draft_tokens = self._create_dummy_tensor((num_reqs, ),

--- a/tpu_inference/runner/compilation_manager.py
+++ b/tpu_inference/runner/compilation_manager.py
@@ -622,16 +622,13 @@ class CompilationManager:
         logger.info("Compiling gather_logprobs with different input shapes.")
         hsize = self.runner.model_config.get_vocab_size()
         for num_reqs in self.runner.num_reqs_paddings:
-            dp_size = self.runner.vllm_config.sharding_config.total_dp_size
             logits_sharding = NamedSharding(
                 self.runner.mesh,
                 PartitionSpec(ShardingAxisName.MLP_DATA,
                               ShardingAxisName.MLP_TENSOR))
             token_ids_sharding = NamedSharding(
-                self.runner.mesh, PartitionSpec(ShardingAxisName.MLP_DATA, )
-            ) if dp_size > 1 else NamedSharding(self.runner.mesh,
-                                                PartitionSpec())
-            logits = self._create_dummy_tensor((num_reqs, hsize), jnp.float32,
+                self.runner.mesh, PartitionSpec(ShardingAxisName.MLP_DATA, ))
+            logits = self._create_dummy_tensor((num_reqs, hsize), jnp.bfloat16,
                                                logits_sharding)
             token_ids = self._create_dummy_tensor((num_reqs, ), jnp.int32,
                                                   token_ids_sharding)

--- a/tpu_inference/runner/compilation_manager.py
+++ b/tpu_inference/runner/compilation_manager.py
@@ -78,13 +78,6 @@ class CompilationManager:
 
     def _run_compilation(self, name: str, fn: Callable, *args,
                          **kwargs) -> None:
-        if args and hasattr(args[0], 'dtype'):
-            dtype_str = str(args[0].dtype)
-            sharding_obj = getattr(args[0], 'sharding', None)
-            sharding_str = "None"
-            if sharding_obj:
-                sharding_str = getattr(sharding_obj, 'spec', sharding_obj)
-            logger.info(f"[DEBUG-WARMUP] {name} input0 dtype: {dtype_str}, sharding: {sharding_str}")
         logger.info(f"Precompile {name} --> {kwargs}")
         start = time.perf_counter()
         result = fn(*args)
@@ -552,7 +545,7 @@ class CompilationManager:
             # function.
             sampling_metadata_sharding = NamedSharding(
                 self.runner.mesh, PartitionSpec(ShardingAxisName.ATTN_DATA))
-            logits = self._create_dummy_tensor((num_reqs, hsize), jnp.float32,
+            logits = self._create_dummy_tensor((num_reqs, hsize), jnp.bfloat16,
                                                logits_sharding)
             for do_sampling in (True, False):
                 for logprobs in (True, False):
@@ -670,7 +663,7 @@ class CompilationManager:
                     PartitionSpec(ShardingAxisName.MLP_DATA,
                                   ShardingAxisName.MLP_TENSOR))
                 target_probs = self._create_dummy_tensor(
-                    (num_logits, vocab_size), jnp.float32, sharding)
+                    (num_logits, vocab_size), jnp.bfloat16, sharding)
                 draft_token_ids = self._create_dummy_tensor((num_logits, ),
                                                             jnp.int32)
                 num_draft_tokens = self._create_dummy_tensor((num_reqs, ),

--- a/tpu_inference/runner/compilation_manager.py
+++ b/tpu_inference/runner/compilation_manager.py
@@ -272,6 +272,7 @@ class CompilationManager:
         that the scheduler is expected to handle, ensuring a compiled version
         is ready for each combination.
         """
+        dp_size = self.runner.vllm_config.sharding_config.model_dp_size * self.runner.vllm_config.sharding_config.attn_dp_size
 
         for num_tokens in self.runner.num_tokens_paddings:
             dp_sharding = NamedSharding(
@@ -292,10 +293,14 @@ class CompilationManager:
 
                 input_ids = self._create_dummy_tensor((num_tokens, ),
                                                       jnp.int32, dp_sharding)
+                # Need align to the sampling output sharding (sharded by ATTN_DATA in DP)
                 next_tokens = self._create_dummy_tensor(
                     (num_reqs, ),
                     jnp.int32,
-                    sharding=NamedSharding(self.runner.mesh, PartitionSpec()))
+                    sharding=NamedSharding(
+                        self.runner.mesh,
+                        PartitionSpec(ShardingAxisName.ATTN_DATA)) if dp_size
+                    > 1 else NamedSharding(self.runner.mesh, PartitionSpec()))
 
                 placeholder_num = jnp.asarray(1, dtype=jnp.int32)
                 self._run_compilation(
@@ -617,12 +622,15 @@ class CompilationManager:
         logger.info("Compiling gather_logprobs with different input shapes.")
         hsize = self.runner.model_config.get_vocab_size()
         for num_reqs in self.runner.num_reqs_paddings:
+            dp_size = self.runner.vllm_config.sharding_config.total_dp_size
             logits_sharding = NamedSharding(
                 self.runner.mesh,
                 PartitionSpec(ShardingAxisName.MLP_DATA,
                               ShardingAxisName.MLP_TENSOR))
-            token_ids_sharding = NamedSharding(self.runner.mesh,
-                                               PartitionSpec())
+            token_ids_sharding = NamedSharding(
+                self.runner.mesh, PartitionSpec(ShardingAxisName.MLP_DATA, )
+            ) if dp_size > 1 else NamedSharding(self.runner.mesh,
+                                                PartitionSpec())
             logits = self._create_dummy_tensor((num_reqs, hsize), jnp.float32,
                                                logits_sharding)
             token_ids = self._create_dummy_tensor((num_reqs, ), jnp.int32,

--- a/tpu_inference/runner/compilation_manager.py
+++ b/tpu_inference/runner/compilation_manager.py
@@ -586,10 +586,6 @@ class CompilationManager:
                         _cache_collision_dummy=_cache_collision_dummy,
                         do_sampling=do_sampling,
                         logprobs=logprobs)
-                    print(f"\n[DEBUG-WARMUP] PRECOMPILING SAMPLE:")
-                    print(f"  - num_reqs: {num_reqs}")
-                    print(f"  - logits dtype: {logits.dtype}")
-                    print(f"  - logits sharding: {getattr(logits.sharding, 'spec', logits.sharding)}")
                     self._run_compilation(
                         f"worker{self.runner.rank} sample",
                         sample,

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -963,7 +963,6 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                 sampling_metadata=tpu_sampling_metadata,
                 key=rejection_rng,
             )
-
         with self.maybe_forbid_compile:
             if tpu_sampling_metadata.logprobs:
                 logits = processed_logits if self.model_config.logprobs_mode == "processed_logprobs" else logits

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -927,11 +927,6 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             step_rng = self.rng_params_for_sampling
 
         if spec_decode_metadata is None:
-            print(f"\n[DEBUG-RUN] ATTEMPTING SAMPLE:")
-            print(f"  - num_reqs: {logits.shape[0]}")
-            print(f"  - logits dtype: {logits.dtype}")
-            print(f"  - logits sharding: {getattr(logits.sharding, 'spec', logits.sharding)}")
-            logits = logits.astype(jnp.float32)
             with self.maybe_forbid_compile:
                 next_tokens, processed_logits = sample(
                     step_rng,
@@ -968,11 +963,10 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                 sampling_metadata=tpu_sampling_metadata,
                 key=rejection_rng,
             )
+
         with self.maybe_forbid_compile:
             if tpu_sampling_metadata.logprobs:
                 logits = processed_logits if self.model_config.logprobs_mode == "processed_logprobs" else logits
-                print(f"\n[DEBUG-RUN] LOGPROBS CALL:")
-                print(f"  - max_logprobs value: {self.model_config.max_logprobs}")
                 logprobs = self._compute_and_gather_logprobs(
                     logits, next_tokens, self.model_config.max_logprobs)
                 logprobs = _jax_logprobs_copy_to_host_async(logprobs)

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -927,6 +927,11 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             step_rng = self.rng_params_for_sampling
 
         if spec_decode_metadata is None:
+            print(f"\n[DEBUG-RUN] ATTEMPTING SAMPLE:")
+            print(f"  - num_reqs: {logits.shape[0]}")
+            print(f"  - logits dtype: {logits.dtype}")
+            print(f"  - logits sharding: {getattr(logits.sharding, 'spec', logits.sharding)}")
+            logits = logits.astype(jnp.float32)
             with self.maybe_forbid_compile:
                 next_tokens, processed_logits = sample(
                     step_rng,
@@ -966,6 +971,8 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         with self.maybe_forbid_compile:
             if tpu_sampling_metadata.logprobs:
                 logits = processed_logits if self.model_config.logprobs_mode == "processed_logprobs" else logits
+                print(f"\n[DEBUG-RUN] LOGPROBS CALL:")
+                print(f"  - max_logprobs value: {self.model_config.max_logprobs}")
                 logprobs = self._compute_and_gather_logprobs(
                     logits, next_tokens, self.model_config.max_logprobs)
                 logprobs = _jax_logprobs_copy_to_host_async(logprobs)
@@ -1133,7 +1140,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
     @staticmethod
     @jax.jit(static_argnames=("max_logprobs", ))
     def _compute_and_gather_logprobs(logits, next_tokens, max_logprobs):
-        logprobs = compute_logprobs(logits)
+        logprobs = compute_logprobs(logits.astype(jnp.float32))
         return gather_logprobs(logprobs, next_tokens, max_logprobs)
 
     def _prepare_dp_input_metadata(self,

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -965,9 +965,8 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                 key=rejection_rng,
             )
 
-        logits = logits.astype(jnp.float32)
         with self.maybe_forbid_compile:
-            
+            logits = logits.astype(jnp.float32)
             if tpu_sampling_metadata.logprobs:
                 logits = processed_logits if self.model_config.logprobs_mode == "processed_logprobs" else logits
                 logprobs = self._compute_and_gather_logprobs(

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -927,7 +927,6 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             step_rng = self.rng_params_for_sampling
 
         if spec_decode_metadata is None:
-            logits = logits.astype(jnp.float32)
             with self.maybe_forbid_compile:
                 next_tokens, processed_logits = sample(
                     step_rng,
@@ -966,7 +965,6 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             )
 
         with self.maybe_forbid_compile:
-            logits = logits.astype(jnp.float32)
             if tpu_sampling_metadata.logprobs:
                 logits = processed_logits if self.model_config.logprobs_mode == "processed_logprobs" else logits
                 logprobs = self._compute_and_gather_logprobs(

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -967,7 +967,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
 
         logits = logits.astype(jnp.float32)
         with self.maybe_forbid_compile:
-
+            
             if tpu_sampling_metadata.logprobs:
                 logits = processed_logits if self.model_config.logprobs_mode == "processed_logprobs" else logits
                 logprobs = self._compute_and_gather_logprobs(

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -966,7 +966,10 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
 
         with self.maybe_forbid_compile:
             if tpu_sampling_metadata.logprobs:
-                logits = processed_logits if self.model_config.logprobs_mode == "processed_logprobs" else logits
+                if self.model_config.logprobs_mode == "processed_logprobs":
+                    logits = processed_logits
+                else:
+                    logits = logits.astype(jnp.float32)
                 logprobs = self._compute_and_gather_logprobs(
                     logits, next_tokens, self.model_config.max_logprobs)
                 logprobs = _jax_logprobs_copy_to_host_async(logprobs)
@@ -1134,7 +1137,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
     @staticmethod
     @jax.jit(static_argnames=("max_logprobs", ))
     def _compute_and_gather_logprobs(logits, next_tokens, max_logprobs):
-        logprobs = compute_logprobs(logits.astype(jnp.float32))
+        logprobs = compute_logprobs(logits)
         return gather_logprobs(logprobs, next_tokens, max_logprobs)
 
     def _prepare_dp_input_metadata(self,

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -928,7 +928,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
 
         if spec_decode_metadata is None:
             with self.maybe_forbid_compile:
-                next_tokens, processed_logits = sample(
+                next_tokens = sample(
                     step_rng,
                     self.mesh,
                     logits,
@@ -946,7 +946,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                 rejection_rng = step_rng
             bonus_logits = self._select_from_array_fn(
                 logits, spec_decode_metadata.bonus_logits_indices)
-            bonus_token_ids, _ = sample(
+            bonus_token_ids = sample(
                 bonus_rng,
                 self.mesh,
                 bonus_logits,
@@ -966,10 +966,6 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
 
         with self.maybe_forbid_compile:
             if tpu_sampling_metadata.logprobs:
-                if self.model_config.logprobs_mode == "processed_logprobs":
-                    logits = processed_logits
-                else:
-                    logits = logits.astype(jnp.float32)
                 logprobs = self._compute_and_gather_logprobs(
                     logits, next_tokens, self.model_config.max_logprobs)
                 logprobs = _jax_logprobs_copy_to_host_async(logprobs)


### PR DESCRIPTION
## Summary

- Reverts all 10 commits by Sierra Qian that introduced and attempted to fix-forward the `processed_logprobs` feature (`#2115`)
- The original commit `521dd4f8` ([TPU] Support processed_logprobs Feature and Alignment with GPU) introduced breaking changes
- 9 subsequent fix-forward commits (`19866e3f` → `de45a073`) failed to fully resolve the regressions
- Non-Sierra commits (`a7020440`, `6601bc6f`, etc.) are preserved intact

## Commits reverted (newest → oldest)

| Commit | Message |
|--------|---------|
| `de45a073` | [Release] cherry-pick sierraq/fix-recompilation-dp for releases/v0.18.0 (#2192) |
| `9a5fa9a0` | pre-commit |
| `60297dae` | dtype location change |
| `ea1a2a71` | change to float32 for accuracy |
| `a88dda55` | fix wrong write |
| `784b88d9` | pre-commit |
| `7ef83146` | version with bfloat16 |
| `2de1d1d9` | work version passed CICD |
| `19866e3f` | keep |
| `521dd4f8` | [TPU] Support processed_logprobs Feature and Alignment with GPU (#2115) |

## Test plan

- [ ] Verify CI passes on `releases/v0.18.0` after merge
- [ ] Confirm previously broken tests are restored
