### PR TITLE
feat(model): Add Jax Implement of Gemma3 text model

### DIFF
--- a/tests/models/jax/test_gemma3.py
+++ b/tests/models/jax/test_gemma3.py
@@ -1,0 +1,300 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import MagicMock, patch
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+from flax import nnx
+from flax.typing import PRNGKey
+from jax.sharding import Mesh
+from vllm.config import CacheConfig, ModelConfig
+
+from tpu_inference.distributed.jax_parallel_state import \
+    init_pp_distributed_environment
+from tpu_inference.layers.jax.pp_utils import PPMissingLayer
+from tpu_inference.models.jax.jax_intermediate_tensor import \
+    JaxIntermediateTensors
+from tpu_inference.models.jax.gemma3 import (
+    AttentionMetadata, Gemma3Attention, Gemma3DecoderLayer, Gemma3MLP,
+    Gemma3Model, Gemma3ForCausalLM, GemmaRMSNorm
+)
+
+
+# --- Configuration Mocking ---
+class MockGemma3Config:
+    def __init__(self):
+        self.hidden_size = 16
+        self.intermediate_size = 32
+        self.num_attention_heads = 2
+        self.num_key_value_heads = 2
+        self.head_dim = 8
+        self.num_hidden_layers = 2
+        self.rms_norm_eps = 1e-6
+        self.vocab_size = 32000
+        self.tie_word_embeddings = True
+        self.rope_theta = 10000.0
+        self.sliding_window = 1024
+        self.layer_types = ["global", "sliding_attention"]
+        self.query_pre_attn_scalar = 144.0
+
+
+class MockModelConfig:
+    def __init__(self, hf_config, dtype):
+        self.hf_config = hf_config
+        self.dtype = dtype
+        self.model = "mock_gemma3"
+        self.tokenizer = "mock_tokenizer"
+        self.tokenizer_mode = "auto"
+        self.trust_remote_code = True
+        self.seed = 0
+
+    def get_hidden_size(self):
+        return self.hf_config.hidden_size
+
+    def get_head_size(self):
+        return self.hf_config.head_dim
+
+    def get_vocab_size(self):
+        return self.hf_config.vocab_size
+
+
+class MockVllmConfig:
+    """A mock VllmConfig sufficient for testing the Gemma 3 model."""
+    def __init__(self):
+        hf_config = MockGemma3Config()
+        self.model_config = MockModelConfig(hf_config, jnp.bfloat16)
+        self.cache_config = MagicMock(spec=CacheConfig)
+        self.cache_config.cache_dtype = "auto"
+        self.load_config = MagicMock()
+        self.extra_configs = {}
+        self.additional_config = {}
+        self.quant_config = None
+
+
+@pytest.fixture(scope="module")
+def mesh():
+    """Creates a mesh with all required axes for testing."""
+    if not jax.devices():
+        pytest.skip("No JAX devices available for mesh creation.")
+    devices = np.array(jax.local_devices())
+    return Mesh(devices.reshape((len(devices), 1, 1)),
+                axis_names=('data', 'attn_dp', 'model'))
+
+
+@pytest.fixture
+def rng() -> PRNGKey:
+    return jax.random.PRNGKey(42)
+
+@pytest.fixture
+def mock_vllm_config() -> MockVllmConfig:
+    return MockVllmConfig()
+
+
+@pytest.fixture
+def rngs(rng: PRNGKey) -> nnx.Rngs:
+    return nnx.Rngs(params=rng)
+
+
+@pytest.fixture(autouse=True, scope="module")
+def initialize_pp():
+    init_pp_distributed_environment(
+        ip="",
+        rank=0,
+        world_size=1,
+        device=jax.devices()[0],
+        need_pp=False,
+    )
+
+
+# --- Test Classes ---
+
+class TestGemmaRMSNorm:
+    def test_forward(self, mock_vllm_config: MockVllmConfig, rngs: nnx.Rngs, mesh: Mesh):
+        dtype = mock_vllm_config.model_config.dtype
+        with jax.set_mesh(mesh):
+            norm = GemmaRMSNorm(16, epsilon=1e-6, dtype=dtype, rngs=rngs)
+        x = jnp.ones((5, 16), dtype=dtype)
+        y = norm(x)
+        assert y.shape == (5, 16)
+        assert y.dtype == dtype
+
+
+class TestGemma3MLP:
+    def test_forward(self, mock_vllm_config: MockVllmConfig, rngs: nnx.Rngs, mesh: Mesh):
+        config = mock_vllm_config.model_config.hf_config
+        dtype = mock_vllm_config.model_config.dtype
+        with jax.set_mesh(mesh):
+            mlp = Gemma3MLP(config, dtype, rngs, quant_config=None)
+        x = jnp.ones((5, config.hidden_size), dtype=dtype)
+        y = mlp(x)
+        assert y.shape == (5, config.hidden_size)
+        assert y.dtype == dtype
+
+
+class TestGemma3Attention:
+    @patch('tpu_inference.models.jax.gemma3.attention')
+    def test_forward_global_attention(
+        self, mock_attention: MagicMock, mock_vllm_config: MockVllmConfig,
+        rngs: nnx.Rngs, mesh: Mesh, rng: PRNGKey
+    ):
+        config = mock_vllm_config.model_config.hf_config
+        dtype = mock_vllm_config.model_config.dtype
+        with jax.set_mesh(mesh):
+            # Prefix points to layer 0, which is "global" in our MockGemma3Config
+            attn_module = Gemma3Attention(config, dtype, rngs, mesh, "auto", quant_config=None, prefix="model.layers.0.self_attn")
+        
+        assert not attn_module.is_sliding
+
+        T, D = 10, config.hidden_size
+        x = jax.random.normal(rng, (T, D))
+        kv_cache = jnp.zeros((T, 2, config.num_key_value_heads, attn_module.head_dim))
+        attn_meta = MagicMock(spec=AttentionMetadata)
+        attn_meta.input_positions = jnp.arange(T)
+        
+        # Mocking the highly optimized Pallas kernel return
+        mock_attention.return_value = (kv_cache, jnp.ones((T, config.num_attention_heads, attn_module.head_dim)))
+        
+        new_kv, y = attn_module(kv_cache, x, attn_meta)
+        assert y.shape == (T, D)
+        mock_attention.assert_called_once()
+
+    @patch('tpu_inference.models.jax.gemma3.attention')
+    def test_forward_sliding_attention(
+        self, mock_attention: MagicMock, mock_vllm_config: MockVllmConfig,
+        rngs: nnx.Rngs, mesh: Mesh, rng: PRNGKey
+    ):
+        config = mock_vllm_config.model_config.hf_config
+        dtype = mock_vllm_config.model_config.dtype
+        with jax.set_mesh(mesh):
+            # Prefix points to layer 1, which is "sliding_attention" in our MockGemma3Config
+            attn_module = Gemma3Attention(config, dtype, rngs, mesh, "auto", quant_config=None, prefix="model.layers.1.self_attn")
+        
+        assert attn_module.is_sliding
+
+
+class TestGemma3DecoderLayer:
+    @patch('tpu_inference.models.jax.gemma3.attention')
+    def test_forward(
+        self, mock_attention: MagicMock, mock_vllm_config: MockVllmConfig,
+        rngs: nnx.Rngs, mesh: Mesh, rng: PRNGKey
+    ):
+        config = mock_vllm_config.model_config.hf_config
+        dtype = mock_vllm_config.model_config.dtype
+        with jax.set_mesh(mesh):
+            layer = Gemma3DecoderLayer(config, dtype, rngs, mesh, "auto", quant_config=None, prefix="layer.0")
+            
+        T, D = 10, config.hidden_size
+        x = jax.random.normal(rng, (T, D))
+        residual = None
+        kv_cache = jnp.zeros((T, 2, config.num_key_value_heads, layer.self_attn.head_dim))
+        attn_meta = MagicMock(spec=AttentionMetadata)
+        attn_meta.input_positions = jnp.arange(T)
+        
+        mock_attention.return_value = (kv_cache, jnp.ones((T, config.num_attention_heads, layer.self_attn.head_dim)))
+        
+        new_kv, hidden_states, new_residual = layer(kv_cache, x, residual, attn_meta)
+        assert hidden_states.shape == (T, D)
+        assert new_residual.shape == (T, D)
+        
+        # Test with existing residual
+        new_kv, hidden_states, new_residual = layer(kv_cache, x, new_residual, attn_meta)
+        assert hidden_states.shape == (T, D)
+
+
+class TestGemma3ForCausalLM:
+    @pytest.fixture
+    def model(self, mock_vllm_config: MockVllmConfig, rng: PRNGKey, mesh: Mesh):
+        with jax.set_mesh(mesh):
+            model = Gemma3ForCausalLM(mock_vllm_config, rng, mesh)
+            yield model
+
+    def test_embed_input_ids(self, model: Gemma3ForCausalLM, rng: PRNGKey):
+        input_ids = jnp.array([[1, 2, 3]])
+        embeds = model.embed_input_ids(input_ids)
+        assert embeds.shape == (1, 3, model.vllm_config.model_config.hf_config.hidden_size)
+
+    def test_compute_logits(self, model: Gemma3ForCausalLM):
+        hidden_states = jnp.ones((10, model.vllm_config.model_config.hf_config.hidden_size))
+        logits = model.compute_logits(hidden_states)
+        assert logits.shape == (10, model.vllm_config.model_config.hf_config.vocab_size)
+
+    @patch('tpu_inference.models.jax.gemma3.attention')
+    def test_call(self, mock_attention: MagicMock, model: Gemma3ForCausalLM, rng: PRNGKey):
+        config = model.vllm_config.model_config.hf_config
+        T, D = 10, config.hidden_size
+        head_dim = model.model.layers[0].self_attn.head_dim
+        
+        input_ids = jnp.arange(T)
+        kv_caches = [jnp.zeros((T, 2, config.num_key_value_heads, head_dim)) for _ in range(config.num_hidden_layers)]
+        attn_meta = MagicMock(spec=AttentionMetadata)
+        attn_meta.input_positions = jnp.arange(T)
+        
+        mock_attention.return_value = (kv_caches[0], jnp.ones((T, config.num_attention_heads, head_dim)))
+        
+        new_kvs, hidden_states, aux = model(
+            kv_caches=kv_caches,
+            input_ids=input_ids,
+            attention_metadata=attn_meta
+        )
+        
+        assert len(new_kvs) == config.num_hidden_layers
+        assert hidden_states.shape == (T, D)
+        assert len(aux) == 0
+
+
+class TestGemma3PipelineParallel:
+    @pytest.fixture
+    def mock_pp_group(self):
+        with patch('tpu_inference.models.jax.gemma3.get_pp_group') as mock:
+            yield mock
+
+    def test_init_first_rank(self, mock_vllm_config, rng, mesh, mock_pp_group):
+        mock_pp_group.return_value.is_first_rank = True
+        mock_pp_group.return_value.is_last_rank = False
+        with jax.set_mesh(mesh):
+            model = Gemma3ForCausalLM(mock_vllm_config, rng, mesh)
+            assert not isinstance(model.model.embed_tokens, PPMissingLayer)
+            assert not hasattr(model, 'lm_head')
+
+    def test_init_last_rank(self, mock_vllm_config, rng, mesh, mock_pp_group):
+        mock_pp_group.return_value.is_first_rank = False
+        mock_pp_group.return_value.is_last_rank = True
+        with jax.set_mesh(mesh):
+            model = Gemma3ForCausalLM(mock_vllm_config, rng, mesh)
+            assert not isinstance(model.model.embed_tokens, PPMissingLayer)
+            assert not hasattr(model, 'lm_head')
+
+    @patch('tpu_inference.models.jax.gemma3.Gemma3Model')
+    def test_call_non_last_rank(self, mock_gemma3_model, mock_vllm_config, rng, mesh, mock_pp_group):
+        mock_pp_group.return_value.is_first_rank = True
+        mock_pp_group.return_value.is_last_rank = False
+
+        with jax.set_mesh(mesh):
+            model = Gemma3ForCausalLM(mock_vllm_config, rng, mesh)
+            
+            kv_caches = [jnp.array([])]
+            input_ids = jnp.array([1, 2, 3])
+            attn_meta = MagicMock(spec=AttentionMetadata)
+
+            # Simulate Gemma3Model returning hidden states and residuals
+            model.model.return_value = (kv_caches, jnp.ones((3, 16)), jnp.ones((3, 16)))
+            
+            new_kvs, x, aux = model(kv_caches, input_ids, attn_meta, is_first_rank=True, is_last_rank=False)
+            
+            assert isinstance(x, JaxIntermediateTensors)
+            assert "hidden_states" in x.tensors
+            assert "residual" in x.tensors

--- a/tpu_inference/models/common/model_loader.py
+++ b/tpu_inference/models/common/model_loader.py
@@ -79,11 +79,13 @@ def _get_model_architecture(config: PretrainedConfig) -> nnx.Module:
         Qwen2_5_VLForConditionalGeneration
     from tpu_inference.models.jax.qwen3 import Qwen3ForCausalLM
     from tpu_inference.models.jax.qwen3_moe import Qwen3MoeForCausalLM
+    from tpu_inference.models.jax.gemma3 import Gemma3ForCausalLM
     _MODEL_REGISTRY["Llama4ForCausalLM"] = Llama4ForCausalLM
     _MODEL_REGISTRY["DeepseekV3ForCausalLM"] = DeepseekV3ForCausalLM
     _MODEL_REGISTRY["LlamaForCausalLM"] = LlamaForCausalLM
     _MODEL_REGISTRY["Llama4ForConditionalGeneration"] = LlamaGuard4ForCausalLM
     _MODEL_REGISTRY["Qwen3ForCausalLM"] = Qwen3ForCausalLM
+    _MODEL_REGISTRY["Gemma3ForConditionalGeneration"] = Gemma3ForCausalLM
     _MODEL_REGISTRY["Qwen3MoeForCausalLM"] = Qwen3MoeForCausalLM
     _MODEL_REGISTRY[
         "Qwen2_5_VLForConditionalGeneration"] = Qwen2_5_VLForConditionalGeneration

--- a/tpu_inference/models/jax/gemma3.py
+++ b/tpu_inference/models/jax/gemma3.py
@@ -1,0 +1,635 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from itertools import islice
+from typing import List, Optional, Tuple
+
+import jax
+import jax.numpy as jnp
+from flax import nnx
+from jax.sharding import Mesh
+from transformers.models.gemma3.configuration_gemma3 import Gemma3Config
+from vllm.config import VllmConfig
+
+from tpu_inference import utils
+from tpu_inference.distributed.jax_parallel_state import get_pp_group
+from tpu_inference.layers.common.attention_interface import attention
+from tpu_inference.layers.common.attention_metadata import AttentionMetadata
+from tpu_inference.layers.common.quantization import quantize_kv
+from tpu_inference.layers.jax import JaxModule
+from tpu_inference.layers.jax.embed import JaxEmbed
+from tpu_inference.layers.jax.linear import JaxEinsum, JaxLinear
+from tpu_inference.layers.jax.pp_utils import PPMissingLayer, make_layers
+from tpu_inference.layers.jax.rope_interface import apply_rope
+from tpu_inference.layers.vllm.quantization.configs import VllmQuantConfig
+from tpu_inference.logger import init_logger
+from tpu_inference.layers.jax.norm import JaxRmsNorm
+from tpu_inference.models.jax.jax_intermediate_tensor import \
+    JaxIntermediateTensors
+from tpu_inference.models.jax.utils.weight_utils import StandardWeightLoader
+
+logger = init_logger(__name__)
+
+init_fn = nnx.initializers.uniform()
+
+class Gemma3ForCausalLM(JaxModule):
+    """JAX implementation of the Gemma 3 model for causal language modeling."""
+    WeightLoader = StandardWeightLoader
+
+    def __init__(self, vllm_config: VllmConfig, rng_key: jax.Array,
+                 mesh: Mesh) -> None:
+        self.vllm_config = vllm_config
+        
+        self.rng = nnx.Rngs(rng_key)
+        self.mesh = mesh
+
+        self.model = Gemma3Model(
+            vllm_config=vllm_config,
+            rng=self.rng,
+            mesh=mesh,
+            prefix="model",
+        )
+        model_config = vllm_config.model_config
+        
+        hf_config = model_config.hf_config
+        # only load text_config as currently this code only support Text context
+        if hasattr(hf_config, "text_config"):
+            hf_config = hf_config.text_config
+        
+        # Gemma3 natively enables tie_word_embedding for memory effieiency. 
+        # consider supporting tie_word_embedding=false where user is required to pass
+        # in their own lm_head.weight as the output matrix. 
+        if not model_config.hf_config.tie_word_embeddings:
+            raise ValueError("Untied word embeddings (tie_word_embeddings=False) are not supported for Gemma 3 in this implementation.")
+
+    def __call__(
+        self,
+        kv_caches: List[jax.Array],
+        input_ids: Optional[jax.Array],
+        attention_metadata: AttentionMetadata,
+        inputs_embeds: Optional[jax.Array] = None,
+        _input_positions=None,
+        _layer_name_to_kv_cache=None,
+        _lora_metadata=None,
+        intermediate_tensors: Optional[JaxIntermediateTensors] = None,
+        is_first_rank: bool = True,
+        is_last_rank: bool = True,
+        *args,
+    ) -> Tuple[List[jax.Array], jax.Array | JaxIntermediateTensors,
+               List[jax.Array]]:
+
+        kv_caches, hidden_states, residual = self.model(
+            kv_caches,
+            input_ids,
+            attention_metadata,
+            inputs_embeds,
+            intermediate_tensors=intermediate_tensors,
+        )
+        
+        # Prepare intermediate tensors for the next pipeline stage
+        if not is_last_rank:
+            res = JaxIntermediateTensors(
+                tensors={
+                    "hidden_states": hidden_states,
+                    "residual": residual
+                })
+            return kv_caches, res, []
+            
+        return kv_caches, hidden_states, []
+
+    def embed_multimodal(self, *args, **kwargs) -> tuple:
+        # Placeholder for future Gemma 3 vision tower support
+        return ()
+
+    def embed_input_ids(
+            self, input_ids: jax.Array,
+            multimodal_embeddings: Optional[jax.Array] = None) -> Optional[jax.Array]:
+        if not self.model.is_first_rank:
+            return None
+                        
+        inputs_embeds = self.model.embed_tokens(input_ids) * self.model.normalizer
+
+        return inputs_embeds
+
+    def compute_logits(self, hidden_states: jax.Array) -> jax.Array:
+        if hasattr(self, 'lm_head'):
+            logits = self.lm_head(hidden_states)
+        else:
+            logits = self.model.embed_tokens.decode(hidden_states)
+        return logits
+
+    def load_weights(self, rng_key: jax.Array) -> None:
+        self.rng = nnx.Rngs(rng_key)
+        
+        self.pp_missing_layers = []
+        for path, module in nnx.iter_graph(self):
+            if isinstance(module, PPMissingLayer):
+                layer_name = ".".join([str(s) for s in path])
+                self.pp_missing_layers.append(layer_name)
+
+        # Skip vision and projector weights since this is a text-only implementation
+        self.pp_missing_layers.extend(["vision_model", "multi_modal_projector"])
+        # mapping from https://huggingface.co/google/gemma-3-4b-it/blob/main/model.safetensors.index.json 
+        mappings = {
+            "language_model.model.embed_tokens.weight": "model.embed_tokens.weight",
+            "language_model.model.norm.weight": "model.norm.weight",
+        }
+        
+        if not self.vllm_config.model_config.hf_config.tie_word_embeddings:
+            mappings["language_model.lm_head.weight"] = "lm_head.weight"
+            
+        for layer_attr in [
+            "self_attn.q_proj",
+            "self_attn.k_proj",
+            "self_attn.v_proj",
+            "self_attn.o_proj",
+            "self_attn.q_norm",
+            "self_attn.k_norm",
+            "mlp.gate_proj",
+            "mlp.up_proj",
+            "mlp.down_proj",
+            "input_layernorm",
+            "post_attention_layernorm",
+            "pre_feedforward_layernorm",
+            "post_feedforward_layernorm",
+        ]:
+            for suffix in [".weight", ".bias"]:
+                mappings[f"language_model.model.layers.*.{layer_attr}{suffix}"] = f"model.layers.*.{layer_attr}{suffix}"
+                
+        # Temporarily expose the language model head counts to the top-level config
+        # so the default weight loader can resolve reshaping and padding layouts.
+        # Need to change after this code start to support video context. 
+        hf_config = self.vllm_config.model_config.hf_config
+        if hasattr(hf_config, "text_config"):
+            if not hasattr(hf_config, "num_attention_heads"):
+                hf_config.num_attention_heads = hf_config.text_config.num_attention_heads
+            if not hasattr(hf_config, "num_key_value_heads"):
+                hf_config.num_key_value_heads = hf_config.text_config.num_key_value_heads
+
+        loader = self.WeightLoader(self.vllm_config, self.mesh)
+            
+        loader.load_weights(
+            self,
+            mappings,
+            keep_hf_weight_suffix_when_match=['model'])
+            
+        # Restore PyTorch dtype in model_config so vLLM multimodal processor 
+        # doesn't crash during dummy input generation when calling x.to(dtype=...)
+        from tpu_inference.utils import to_torch_dtype
+        if hasattr(self.vllm_config.model_config.dtype, "type"):
+            self.vllm_config.model_config.dtype = to_torch_dtype(self.vllm_config.model_config.dtype)
+
+
+class GemmaRMSNorm(JaxRmsNorm):
+    """RMS normalization layer specific to Gemma models."""
+
+    def __call__(self,
+                 x: jax.Array,
+                 mask: Optional[jax.Array] = None) -> jax.Array:
+        # Gemma style RMSNorm: x * (1 + w)
+        # Save original weight
+        w = self.weight.value
+        # Temporarily set weight to ones to get pure norm and re-use JaxRmsNorm for efficient normalization. 
+        self.weight.value = jnp.ones_like(w)
+        normed_x = super().__call__(x, mask=mask)
+        # Restore weight
+        self.weight.value = w
+
+        return normed_x * (1.0 + w)
+
+
+class Gemma3MLP(JaxModule):
+    """Gated Feed-Forward Network (MLP) for Gemma 3."""
+
+    def __init__(self,
+                 config: Gemma3Config,
+                 dtype: jnp.dtype,
+                 rng: nnx.Rngs,
+                 quant_config: VllmQuantConfig,
+                 prefix: str = ""):
+        hidden_size = config.hidden_size
+        intermediate_size = config.intermediate_size
+
+        self.gate_proj = JaxLinear(
+            hidden_size,
+            intermediate_size,
+            use_bias=False,
+            dtype=dtype,
+            kernel_init=nnx.with_partitioning(init_fn, (None, "model")),
+            rngs=rng,
+            quant_config=quant_config,
+            prefix=prefix + ".gate_proj",
+        )
+        self.up_proj = JaxLinear(
+            hidden_size,
+            intermediate_size,
+            use_bias=False,
+            dtype=dtype,
+            kernel_init=nnx.with_partitioning(init_fn, (None, "model")),
+            rngs=rng,
+            quant_config=quant_config,
+            prefix=prefix + ".up_proj",
+        )
+        self.down_proj = JaxLinear(
+            intermediate_size,
+            hidden_size,
+            use_bias=False,
+            dtype=dtype,
+            kernel_init=nnx.with_partitioning(init_fn, ("model", None)),
+            rngs=rng,
+            quant_config=quant_config,
+            prefix=prefix + ".down_proj",
+        )
+
+    def __call__(self, x: jax.Array) -> jax.Array:
+        gate = self.gate_proj(x)
+        # Gemma 3 uses the approximate GELU activation function.
+        gate = jax.nn.gelu(gate, approximate=True)
+        up = self.up_proj(x)
+        fuse = gate * up
+        result = self.down_proj(fuse)
+        return result
+
+class Gemma3Attention(JaxModule):
+    """Multi-head attention mechanism for Gemma 3, supporting both global and sliding window attention."""
+
+    def __init__(self,
+                 config: Gemma3Config,
+                 dtype: jnp.dtype,
+                 rng: nnx.Rngs,
+                 mesh: Mesh,
+                 kv_cache_dtype: str,
+                 quant_config: VllmQuantConfig,
+                 prefix: str = ""):
+        self.hidden_size = config.hidden_size
+        self.num_heads = config.num_attention_heads
+        self.num_kv_heads = config.num_key_value_heads
+        self.attention_chunk_size = None
+
+        self.head_dim_original = getattr(
+            config, "head_dim", self.hidden_size // self.num_heads)
+        self.head_dim = utils.get_padded_head_dim(self.head_dim_original)
+
+        sharding_size = mesh.shape["model"]
+        self.num_heads = utils.get_padded_num_heads(self.num_heads,
+                                                    sharding_size)
+        self.num_kv_heads = utils.get_padded_num_heads(self.num_kv_heads,
+                                                       sharding_size)
+
+        self.mesh = mesh
+
+        # Determine if this specific layer uses sliding window attention 
+        # based on the model configuration's layer_types list.
+        try:
+            layer_idx = int(prefix.split('.')[-2])
+        except (ValueError, IndexError):
+            layer_idx = 0
+
+        layer_type = config.layer_types[
+            layer_idx] if hasattr(config, "layer_types") else "global"
+        self.is_sliding = layer_type == "sliding_attention"
+        self.rope_theta = getattr(config, "rope_theta", 10000.0)
+        
+        # Gemma3 using Local layer and Global layer with a ratial of 5:1, in the local layer, we apply a
+        # sliding window mask and use a relatively smaller rope_theta.
+        if self.is_sliding:
+            self.rope_theta = getattr(config, "rope_local_base_freq", 10000.0)
+            self.attention_chunk_size = getattr(config, "sliding_window", 1024)
+    
+        self.rope_scaling = getattr(config, "rope_scaling", None)
+        attention_bias = getattr(config, "attention_bias", False)
+
+        self.q_proj = JaxEinsum(
+            "TD,DNH->TNH",
+            (self.hidden_size, self.num_heads, self.head_dim),
+            bias_shape=(self.num_heads,
+                        self.head_dim) if attention_bias else None,
+            dtype=dtype,
+            kernel_init=nnx.with_partitioning(init_fn, (None, "model", None)),
+            bias_init=nnx.with_partitioning(init_fn, ("model", None))
+            if attention_bias else None,
+            rngs=rng,
+            quant_config=quant_config,
+            prefix=prefix + ".q_proj",
+        )
+        self.k_proj = JaxEinsum(
+            "TD,DKH->TKH",
+            (self.hidden_size, self.num_kv_heads, self.head_dim),
+            bias_shape=(self.num_kv_heads,
+                        self.head_dim) if attention_bias else None,
+            dtype=dtype,
+            kernel_init=nnx.with_partitioning(init_fn, (None, "model", None)),
+            bias_init=nnx.with_partitioning(init_fn, ("model", None))
+            if attention_bias else None,
+            rngs=rng,
+            quant_config=quant_config,
+            prefix=prefix + ".k_proj",
+        )
+        self.v_proj = JaxEinsum(
+            "TD,DKH->TKH",
+            (self.hidden_size, self.num_kv_heads, self.head_dim),
+            bias_shape=(self.num_kv_heads,
+                        self.head_dim) if attention_bias else None,
+            dtype=dtype,
+            kernel_init=nnx.with_partitioning(init_fn, (None, "model", None)),
+            bias_init=nnx.with_partitioning(init_fn, ("model", None))
+            if attention_bias else None,
+            rngs=rng,
+            quant_config=quant_config,
+            prefix=prefix + ".v_proj",
+        )
+        self.o_proj = JaxEinsum(
+            "TNH,NHD->TD",
+            (self.num_heads, self.head_dim, self.hidden_size),
+            bias_shape=(self.hidden_size, ) if attention_bias else None,
+            dtype=dtype,
+            kernel_init=nnx.with_partitioning(init_fn, ("model", None, None)),
+            bias_init=nnx.with_partitioning(
+                init_fn, (None, )) if attention_bias else None,
+            rngs=rng,
+            quant_config=quant_config,
+            prefix=prefix + ".o_proj",
+        )
+
+        self.q_norm = GemmaRMSNorm(self.head_dim,
+                                   epsilon=config.rms_norm_eps,
+                                   dtype=dtype,
+                                   rngs=rng,
+                                   quant_config=quant_config,
+                                   prefix=prefix + ".q_norm")
+        self.k_norm = GemmaRMSNorm(self.head_dim,
+                                   epsilon=config.rms_norm_eps,
+                                   dtype=dtype,
+                                   rngs=rng,
+                                   quant_config=quant_config,
+                                   prefix=prefix + ".k_norm")
+
+        # Gemma 3 queries scale pre-attention.
+        self._q_scale = getattr(config, "query_pre_attn_scalar", 1.0)**-0.5
+        self._k_scale = 1.0
+        self._v_scale = 1.0
+        self.kv_cache_quantized_dtype = None
+        if kv_cache_dtype != "auto":
+            self.kv_cache_quantized_dtype = utils.get_jax_dtype_from_str_dtype(
+                kv_cache_dtype)
+
+    def __call__(
+        self,
+        kv_cache: Optional[jax.Array],
+        x: jax.Array,
+        attention_metadata: AttentionMetadata,
+    ) -> Tuple[jax.Array, jax.Array]:
+        md = attention_metadata
+        
+        # q: (T, N, H)
+        q = self.q_proj(x)
+        q = self.q_norm(q)
+        q = apply_rope(q, md.input_positions, self.head_dim_original,
+                       self.rope_theta, self.rope_scaling)
+
+        # k: (T, K, H)
+        k = self.k_proj(x)
+        k = self.k_norm(k)
+        k = apply_rope(k, md.input_positions, self.head_dim_original,
+                       self.rope_theta, self.rope_scaling)
+
+        # v: (T, K, H)
+        v = self.v_proj(x)
+
+        # Apply KV cache quantization if enabled
+        q_scale = k_scale = v_scale = None
+        if self.kv_cache_quantized_dtype:
+            k_scale = self._k_scale
+            v_scale = self._v_scale
+            k, v = quantize_kv(self.kv_cache_quantized_dtype, k, v, k_scale,
+                               v_scale)
+
+        # Attention operation
+        new_kv_cache, outputs = attention(
+            kv_cache,
+            q,
+            k,
+            v,
+            attention_metadata,
+            self.mesh,
+            self.head_dim_original,
+            attention_chunk_size=self.attention_chunk_size,
+            q_scale=self._q_scale,
+            k_scale=k_scale,
+            v_scale=v_scale,
+        )
+
+        # o: (T, D)
+        o = self.o_proj(outputs)
+        return new_kv_cache, o
+
+
+class Gemma3DecoderLayer(JaxModule):
+    """A single Transformer block for Gemma 3."""
+
+    def __init__(self,
+                 config: Gemma3Config,
+                 dtype: jnp.dtype,
+                 rng: nnx.Rngs,
+                 mesh: Mesh,
+                 kv_cache_dtype: str,
+                 quant_config: VllmQuantConfig,
+                 prefix: str = ""):
+        rms_norm_eps = config.rms_norm_eps
+        hidden_size = config.hidden_size
+
+        self.input_layernorm = GemmaRMSNorm(
+            hidden_size,
+            epsilon=rms_norm_eps,
+            dtype=dtype,
+            rngs=rng,
+            quant_config=quant_config,
+            prefix=prefix + ".input_layernorm")
+        self.self_attn = Gemma3Attention(config=config,
+                                         dtype=dtype,
+                                         rng=rng,
+                                         mesh=mesh,
+                                         kv_cache_dtype=kv_cache_dtype,
+                                         quant_config=quant_config,
+                                         prefix=prefix + ".self_attn")
+        self.post_attention_layernorm = GemmaRMSNorm(
+            hidden_size,
+            epsilon=rms_norm_eps,
+            dtype=dtype,
+            rngs=rng,
+            quant_config=quant_config,
+            prefix=prefix + ".post_attention_layernorm")
+        self.pre_feedforward_layernorm = GemmaRMSNorm(
+            hidden_size,
+            epsilon=rms_norm_eps,
+            dtype=dtype,
+            rngs=rng,
+            quant_config=quant_config,
+            prefix=prefix + ".pre_feedforward_layernorm")
+        self.mlp = Gemma3MLP(config=config,
+                             dtype=dtype,
+                             rng=rng,
+                             quant_config=quant_config,
+                             prefix=prefix + ".mlp")
+        self.post_feedforward_layernorm = GemmaRMSNorm(
+            hidden_size,
+            epsilon=rms_norm_eps,
+            dtype=dtype,
+            rngs=rng,
+            quant_config=quant_config,
+            prefix=prefix + ".post_feedforward_layernorm")
+
+    def __call__(
+        self,
+        kv_cache: jax.Array,
+        hidden_states: jax.Array,
+        residual: Optional[jax.Array],
+        attention_metadata: AttentionMetadata,
+    ) -> Tuple[jax.Array, jax.Array, jax.Array]:
+
+        # Uses a specific residual stream structure where `residual` and 
+        # `hidden_states` are tracked separately across the transformer block.
+        # For the first layer where residual is not initialized. 
+        if residual is None:
+            residual = hidden_states
+            normed_hidden_states = self.input_layernorm(hidden_states)
+        else:
+        # For the other layers
+            hidden_states = hidden_states + residual
+            residual = hidden_states
+            normed_hidden_states = self.input_layernorm(hidden_states)
+
+        kv_cache, attn_output = self.self_attn(
+            kv_cache,
+            normed_hidden_states,
+            attention_metadata,
+        )
+        attn_output = self.post_attention_layernorm(attn_output)
+
+        hidden_states = attn_output + residual
+        residual = hidden_states
+        normed_hidden_states = self.pre_feedforward_layernorm(hidden_states)
+
+        mlp_output = self.mlp(normed_hidden_states)
+        hidden_states = self.post_feedforward_layernorm(mlp_output)
+
+        return kv_cache, hidden_states, residual
+
+class Gemma3Model(JaxModule):
+    """The core Gemma 3 model without the language modeling head."""
+
+    def __init__(self,
+                 vllm_config: VllmConfig,
+                 rng: nnx.Rngs,
+                 mesh: Mesh,
+                 prefix: str = "model") -> None:
+        model_config = vllm_config.model_config
+        hf_config = model_config.hf_config
+        
+        # Unwrap the text config if this is a multimodal model
+        if hasattr(hf_config, "text_config"):
+            hf_config = hf_config.text_config
+            
+        vocab_size = model_config.get_vocab_size()
+        dtype = model_config.dtype
+        rms_norm_eps = hf_config.rms_norm_eps
+        hidden_size = hf_config.hidden_size
+
+        self.is_first_rank = get_pp_group().is_first_rank
+        self.is_last_rank = get_pp_group().is_last_rank
+
+        if self.is_first_rank or (hf_config.tie_word_embeddings
+                                  and self.is_last_rank):
+            self.embed_tokens = JaxEmbed(
+                num_embeddings=vocab_size,
+                features=hidden_size,
+                dtype=dtype,
+                embedding_init=nnx.with_partitioning(init_fn, ("model", None)),
+                rngs=rng,
+                quant_config=vllm_config.quant_config,
+                prefix=prefix + ".embed_tokens",
+            )
+        else:
+            self.embed_tokens = PPMissingLayer()
+
+        # Normalize the embedding by sqrt(hidden_size)
+        # The normalizer's data type should be downcasted to the model's
+        # data type such as bfloat16, not float32.
+        # See https://github.com/huggingface/transformers/pull/29402 
+        self.normalizer = hidden_size**0.5
+
+        self.start_layer, self.end_layer, self.layers = make_layers(
+            hf_config.num_hidden_layers,
+   
+            lambda layer_index: Gemma3DecoderLayer(
+                config=hf_config,
+                dtype=dtype,
+                rng=rng,
+                mesh=mesh,
+                kv_cache_dtype=vllm_config.cache_config.cache_dtype,
+                quant_config=vllm_config.quant_config,
+                prefix=f"{prefix}.layers.{layer_index}",
+            ),
+        )
+        if self.is_last_rank:
+    
+            self.norm = GemmaRMSNorm(
+                hidden_size,
+                epsilon=rms_norm_eps,
+                dtype=dtype,
+                rngs=rng,
+                quant_config=vllm_config.quant_config,
+                prefix=prefix + ".norm",
+            )
+        else:
+            self.norm = PPMissingLayer()
+
+    def __call__(
+        self,
+        kv_caches: List[jax.Array],
+        input_ids: Optional[jax.Array],
+        attention_metadata: AttentionMetadata,
+        inputs_embeds: Optional[jax.Array] = None,
+        intermediate_tensors: Optional[JaxIntermediateTensors] = None,
+    ) -> Tuple[List[jax.Array], jax.Array, jax.Array]:
+
+        if self.is_first_rank:
+            if inputs_embeds is not None:
+                hidden_states = inputs_embeds
+            else:
+                hidden_states = self.embed_tokens(
+                    input_ids) * self.normalizer
+            residual = None
+        else:
+            # Handle pipeline parallelism intermediate states
+            hidden_states = intermediate_tensors["hidden_states"]
+            residual = intermediate_tensors.get("residual", None)
+
+        for i, layer in enumerate(
+                islice(self.layers, self.start_layer, self.end_layer)):
+            kv_cache = kv_caches[i]
+            kv_cache, hidden_states, residual = layer(
+                kv_cache,
+                hidden_states,
+                residual,
+                attention_metadata,
+            )
+            kv_caches[i] = kv_cache
+
+        if self.is_last_rank:
+            # normalize again at the very last layer. 
+            hidden_states = hidden_states + residual
+            hidden_states = self.norm(hidden_states)
+
+        return kv_caches, hidden_states, residual


### PR DESCRIPTION
# Description

This commit introduces the JAX/Flax backend implementation of the Gemma 3 architecture (`Gemma3ForCausalLM`) in `gemma3.py`, enabling it to run efficiently on TPUs via the vLLM integration.

Currently, this implementation focuses on the text-generation backbone, skipping the vision tower and multi-modal projectors for text-only execution.

Tests

1. manual tests
2. unitests
3. cross-validate on the first-4 layer of hiddenstates with huggingface implementation
