### PR TITLE
[Fix] fix the "disable_mm_from_limits" related logic in tpu_runner.py

### DIFF
--- a/tests/runner/test_tpu_runner.py
+++ b/tests/runner/test_tpu_runner.py
@@ -17,8 +17,10 @@ from unittest.mock import MagicMock, patch
 import jax
 import jax.numpy as jnp
 import numpy as np
+import pytest
 from vllm.config import (CacheConfig, ModelConfig, ParallelConfig,
                          SchedulerConfig, SpeculativeConfig, VllmConfig)
+from vllm.config.multimodal import BaseDummyOptions
 
 from tpu_inference.runner.tpu_runner import TPUModelRunner
 
@@ -275,3 +277,101 @@ class TestTPUJaxRunnerMultimodalModelLoadedForTextOnly:
         _ = self.runner._get_input_ids_embeds(dummy_input_ids, dummy_mm_embeds,
                                               dummy_is_mm_embed)
         self.runner.embed_input_ids_fn.assert_not_called()
+
+
+class TestTPUJaxRunnerDisableMM:
+
+    def setup_method(self):
+        # Mock JAX dependencies
+        self.mock_devices = [MagicMock(coords=i) for i in range(4)]
+        self.mock_rng_key = MagicMock()
+        device_array = np.array(jax.devices()[:1]).reshape(1, 1, 1, -1)
+        self.mock_mesh = jax.make_mesh(device_array.shape,
+                                       ('data', 'attn_dp', 'expert', 'model'))
+
+    def _model_get_model(self):
+        mock_multimodal_fns = {
+            "precompile_vision_encoder_fn": None,
+            "embed_multimodal_fn": MagicMock(),
+            "embed_input_ids_fn": MagicMock(),
+            "get_mrope_input_positions_fn": None
+        }
+        return (
+            MagicMock(),  # TPUModelRunner.model_fn
+            MagicMock(),  # TPUModelRunner.compute_logits_fn
+            MagicMock(),  # TPUModelRunner.pooler_fn
+            MagicMock(),  # TPUModelRunner.combine_hidden_states_fn
+            mock_multimodal_fns,  # TPUModelRunner.multimodal_fns
+            MagicMock(),  # TPUModelRunner.state (model params)
+            None,  # TPUModelRunner.lora_manager
+            None,  # TPUModelRunner.model
+        )
+
+    @pytest.mark.parametrize(
+        "limit_per_prompt, still_mm_after_loading_model",
+        [
+            ({
+                "image": BaseDummyOptions(count=0),
+                "video": BaseDummyOptions(count=0)
+            }, False),
+            ({
+                "video": BaseDummyOptions(count=0)
+            }, False),
+            ({
+                "image": BaseDummyOptions(count=0),
+                "video": BaseDummyOptions(count=1)
+            }, True),
+            (
+                {
+                    # Empty limit means no limit, which should not disable MM.
+                },
+                True)
+        ])
+    def test_multimodal_model_loading_with_limits(
+            self, limit_per_prompt, still_mm_after_loading_model):
+        """Test that "--limit-mm-per-prompt" config can disable multi-modality for a multi-modal model.
+
+        If an user *explicitly* sets the limit for all modalities to 0, then we can safely disable multi-modality even if the model itself claims to be multimodal.
+        """
+        with patch('jax.devices', return_value=self.mock_devices), \
+             patch('jax.make_mesh', return_value=self.mock_mesh), \
+             patch('jax.random.key', return_value=self.mock_rng_key), \
+             patch('tpu_inference.runner.tpu_runner.nnx.Rngs', return_value=self.mock_rng_key), \
+             patch('tpu_inference.runner.tpu_runner.get_model', return_value=self._model_get_model()), \
+             patch('tpu_inference.runner.tpu_runner.make_optimized_mesh', return_value=self.mock_mesh):
+
+            model_config = ModelConfig(tokenizer_mode="auto",
+                                       trust_remote_code=False,
+                                       seed=0,
+                                       dtype='bfloat16')
+            model_config.multimodal_config = MagicMock()
+            model_config.multimodal_config.limit_per_prompt = limit_per_prompt
+
+            cache_config = CacheConfig(
+                block_size=16,
+                gpu_memory_utilization=0.9,
+                cache_dtype="auto",
+            )
+            scheduler_config = SchedulerConfig(max_num_seqs=16,
+                                               max_model_len=1024,
+                                               is_encoder_decoder=False)
+            parallel_config = ParallelConfig(
+                pipeline_parallel_size=1,
+                tensor_parallel_size=1,
+            )
+            vllm_config = VllmConfig(
+                model_config=model_config,
+                cache_config=cache_config,
+                scheduler_config=scheduler_config,
+                parallel_config=parallel_config,
+                speculative_config=None,
+                observability_config={},
+                additional_config={},
+            )
+
+            runner = TPUModelRunner(vllm_config, devices=self.mock_devices)
+            # Precondition: make sure the model_config claims the model supports MM.
+            assert runner.model_config.is_multimodal_model
+            runner.load_model()
+
+            assert runner.is_multimodal_model == still_mm_after_loading_model

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -586,15 +586,15 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         disable_mm_from_limits = False
         if self.model_config.is_multimodal_model:
             mm_limits = self.model_config.multimodal_config.limit_per_prompt
-            image_limit = mm_limits.get("image")
-            video_limit = mm_limits.get("video")
-            image_count = image_limit.count if image_limit else 0
-            video_count = video_limit.count if video_limit else 0
-            disable_mm_from_limits = image_count == 0 and video_count == 0
+            # According to https://github.com/vllm-project/vllm/blob/21d2b53f88d99f9ab369444f6d53ed2b9c260e4f/vllm/config/multimodal.py#L79-L95
+            # if a modality limit is missing, we should treat count as 999. So here we disable multi-modality only when all limits are set to 0.
+            if mm_limits and all(limit.count == 0
+                                 for limit in mm_limits.values()):
+                disable_mm_from_limits = True
 
             if disable_mm_from_limits:
-                logger.info(
-                    "Disabling multi-modality for model because limits are set to 0."
+                logger.warning(
+                    f"Disabling multi-modality for model because limits are set to 0. {mm_limits=}"
                 )
 
         self.is_multimodal_model = (self.model_config.is_multimodal_model


### PR DESCRIPTION
# Description

If user doesn't explicitly specify `--limit-mm-per-prompt`, we should treat [per-modality limit as 999](https://github.com/vllm-project/vllm/blob/21d2b53f88d99f9ab369444f6d53ed2b9c260e4f/vllm/config/multimodal.py#L79-L95) but the current logic is treating as 0, which disables MM.

This PR fixes the logic to only consider **explicit** limit.

# Tests

CI, and check the logs when running
```
vllm serve google/gemma-4-31B-it \
    --max-num-batched-tokens=4096 --tensor-parallel-size=8 \
    --no-enable-prefix-caching  \
    --max-model-len=4096
```

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
