### PR TITLE
[Kernel][Batched RPA] Code cleanup

### DIFF
--- a/tpu_inference/kernels/experimental/batched_rpa/bref_override.py
+++ b/tpu_inference/kernels/experimental/batched_rpa/bref_override.py
@@ -13,118 +13,73 @@
 # limitations under the License.
 
 import dataclasses
-from typing import Any
 
 import jax
 import jax.numpy as jnp
-from jax import tree_util
-from jax._src.pallas.mosaic import pipeline
-from jax._src.pallas.mosaic import primitives as tpu_primitives
 from jax.experimental import pallas as pl
+from jax.experimental.pallas import tpu as pltpu
 
-from tpu_inference.kernels.experimental.batched_rpa import \
-    schedule as rpa_schedule
+from tpu_inference.kernels.experimental.batched_rpa import configs, schedule
 
 
-@tree_util.register_dataclass
+@jax.tree_util.register_dataclass
 @dataclasses.dataclass(frozen=True)
-class _BypassRef(pipeline.BufferedRef):
+class _BypassRef(pltpu.BufferedRef):
     """Helper class to safely bypass buffer_count checks during creation."""
-
-    def __post_init__(self):
-        pass
-
-
-@tree_util.register_dataclass
-@dataclasses.dataclass(frozen=True)
-class KVBufferedRef(pipeline.BufferedRef):
-    """Handles fetching and updating KV cache using precomputed metadata."""
-
-    bkv_p_cache: int = dataclasses.field(metadata={"static": True})
-    bkv_p_new: int = dataclasses.field(metadata={"static": True})
-    page_size: int = dataclasses.field(metadata={"static": True})
-    batch_size: int = dataclasses.field(metadata={"static": True})
-    hbm_stride: int = dataclasses.field(metadata={"static": True})
-    page_size_log2: int = dataclasses.field(metadata={"static": True})
-    page_size_mask: int = dataclasses.field(metadata={"static": True})
 
     def __post_init__(self):
         # pallas doesn't allow you to set n_buffer > 2 for output refs, so
         # we override to bypass this check.
         pass
 
-    @classmethod
-    def from_ref(
-        cls,
-        ref: pipeline.BufferedRef,
-        bkv_p_cache: int,
-        bkv_p_new: int,
-        page_size: int,
-        batch_size: int,
-        hbm_stride: int,
-        page_size_log2: int,
-        page_size_mask: int,
-    ):
-        return cls(
-            bkv_p_cache=bkv_p_cache,
-            bkv_p_new=bkv_p_new,
-            page_size=page_size,
-            batch_size=batch_size,
-            hbm_stride=hbm_stride,
-            page_size_log2=page_size_log2,
-            page_size_mask=page_size_mask,
-            **{
-                f.name: getattr(ref, f.name)
-                for f in dataclasses.fields(pipeline.BufferedRef)
-            },
-        )
+
+@jax.tree_util.register_dataclass
+@dataclasses.dataclass(frozen=True)
+class KVBufferedRef(_BypassRef):
+    """Handles fetching and updating KV cache using precomputed metadata."""
+
+    cfgs: configs.RPAConfig = dataclasses.field(default=None,
+                                                metadata=dict(static=True))
 
     @classmethod
     def create(
         cls,
         spec: pl.BlockSpec,
-        source_memory_space: jax.Array,
-        bkv_p_cache: int,
-        bkv_p_new: int,
-        page_size: int,
-        batch_size: int,
-        hbm_stride: int,
-        page_size_log2: int,
-        page_size_mask: int,
-        buffer_count: int = 2,
-        use_lookahead: bool = True,
+        dtype_or_type: jax.Array,
+        buffer_type,  # pltpu.BufferType,
+        buffer_count: int,
+        use_lookahead: bool,
+        cfgs: configs.RPAConfig,
     ):
+        # TODO(kyuyeunk): Uncomment this out after jax version update.
+        # assert buffer_type == pltpu.BufferType.INPUT_OUTPUT
+
         standard_ref = _BypassRef.create(
             spec=spec,
-            dtype_or_type=pipeline._ref_to_value_aval(source_memory_space),
-            buffer_type=pipeline.BufferType.INPUT_OUTPUT,
+            dtype_or_type=dtype_or_type,
+            buffer_type=buffer_type,
             buffer_count=buffer_count,
             grid_rank=1,
             use_lookahead=use_lookahead,
-            source_memory_space=source_memory_space,
         )
-        return cls.from_ref(
-            standard_ref,
-            bkv_p_cache=bkv_p_cache,
-            bkv_p_new=bkv_p_new,
-            page_size=page_size,
-            batch_size=batch_size,
-            hbm_stride=hbm_stride,
-            page_size_log2=page_size_log2,
-            page_size_mask=page_size_mask,
+        return cls(
+            cfgs=cfgs,
+            **{
+                f.name: getattr(standard_ref, f.name)
+                for f in dataclasses.fields(pltpu.BufferedRef)
+            },
         )
 
     def copy_in(
         self,
-        src_ref: tuple[jax.Array, jax.Array, rpa_schedule.RPASchedule,
-                       jax.Array],
-        grid_indices: tuple[int, ...],
+        src_ref: tuple[jax.Ref, jax.Ref, schedule.RPASchedule, jax.Ref],
+        grid_indices: tuple[int | jax.Array, ...],
     ):
-        # src_ref: (kv_cache_hbm, new_kv_hbm, schedule, page_indices_ref)
-        kv_cache_hbm, new_kv_hbm, schedule, page_indices_ref = src_ref
+        # src_ref: (kv_cache_hbm, new_kv_hbm, schedule_ref, page_indices_ref)
+        kv_cache_hbm, new_kv_hbm, schedule_ref, page_indices_ref = src_ref
         slot = self.current_copy_in_slot
         sem = self.sem_recvs.at[slot]
-        vmem_dst = self.window_ref.at[slot]
+        vmem_dst = self.window_ref.at[slot, :, :, :self.cfgs.kv_hbm_stride]
         block_idx = jnp.maximum(grid_indices[0], 0)
 
         kv_cache_hbm_flat = kv_cache_hbm.reshape(-1, *kv_cache_hbm.shape[2:])
@@ -132,171 +87,167 @@ class KVBufferedRef(pipeline.BufferedRef):
         dma_list_cache = []
         dma_list_new = []
 
-        for b in range(self.batch_size):
-            for i in range(self.bkv_p_cache):
-                p_idx, dst_off, sz = schedule.get_dma_kv_cache(block_idx, b, i)
-                src_off = page_indices_ref[p_idx] * self.page_size
+        for b in range(self.cfgs.batch_size):
+            for i in range(self.cfgs.bkv_p_cache):
+                p_idx, dst_off, sz = schedule_ref.get_dma_kv_cache(
+                    block_idx, b, i)
+                src_off = page_indices_ref[p_idx] * self.cfgs.serve.page_size
                 dma_list_cache.append((src_off, dst_off, sz, b))
 
             # Contiguous fetch for new KV
-            _, src_new_off, dst_vmem_off, _ = schedule.get_dma_kv_new(
+            _, src_new_off, dst_vmem_off, _ = schedule_ref.get_dma_kv_new(
                 block_idx, b, 0)
             total_new_sz = 0
-            for i in range(self.bkv_p_new):
-                _, _, _, sz = schedule.get_dma_kv_new(block_idx, b, i)
+            for i in range(self.cfgs.bkv_p_new):
+                _, _, _, sz = schedule_ref.get_dma_kv_new(block_idx, b, i)
                 total_new_sz += sz
             dma_list_new.append((src_new_off, dst_vmem_off, total_new_sz, b))
 
         for i in range(len(dma_list_cache)):
             src_off, dst_off, sz, b = dma_list_cache[i]
-            tpu_primitives.make_async_copy(
+            pltpu.make_async_copy(
                 kv_cache_hbm_flat.at[pl.ds(src_off, sz)],
-                vmem_dst.at[b, pl.ds(dst_off, sz), :self.hbm_stride],
+                vmem_dst.at[b, pl.ds(dst_off, sz)],
                 sem,
             ).start()
 
         for i in range(len(dma_list_new)):
             src_off, dst_off, sz, b = dma_list_new[i]
-            tpu_primitives.make_async_copy(
+            pltpu.make_async_copy(
                 new_kv_hbm.at[pl.ds(src_off, sz)],
-                vmem_dst.at[b, pl.ds(dst_off, sz), :self.hbm_stride],
+                vmem_dst.at[b, pl.ds(dst_off, sz)],
                 sem,
             ).start()
 
     def copy_out(
         self,
-        dst_ref: tuple[jax.Array, Any, rpa_schedule.RPASchedule, jax.Array],
-        grid_indices: tuple[int, ...],
+        dst_ref: tuple[jax.Ref, jax.Ref, schedule.RPASchedule, jax.Ref],
+        grid_indices: tuple[int | jax.Array, ...],
     ):
-        kv_out_ref, _, schedule, page_indices_ref = dst_ref
+        kv_out_ref, _, schedule_ref, page_indices_ref = dst_ref
         kv_out_ref_flat = kv_out_ref.reshape(-1, *kv_out_ref.shape[2:])
         slot = self.current_copy_out_slot
         sem = self.sem_sends.at[slot]
-        vmem_src = self.window_ref.at[slot]
+        vmem_src = self.window_ref.at[slot, :, :, :self.cfgs.kv_hbm_stride]
         block_idx = grid_indices[0]
 
-        @pl.loop(0, self.batch_size, unroll=True)
-        def _for_each_seq(b):
-            idx = block_idx * self.batch_size + b
-            do_writeback = schedule.do_writeback[idx]
-            for i in range(self.bkv_p_new):
-                encoded_dst_hbm_off, _, src_vmem_off, new_sz = schedule.get_dma_kv_new(
-                    block_idx, b, i)
-                global_p_idx = encoded_dst_hbm_off >> self.page_size_log2
-                p_off = encoded_dst_hbm_off & self.page_size_mask
+        for b in range(self.cfgs.batch_size):
+            do_writeback = schedule_ref.do_writeback[block_idx, b] == 1
+            for i in range(self.cfgs.bkv_p_new):
+                encoded_dst_hbm_off, _, src_vmem_off, new_sz = (
+                    schedule_ref.get_dma_kv_new(block_idx, b, i))
+                global_p_idx = encoded_dst_hbm_off >> self.cfgs.serve.page_size_log2
+                p_off = encoded_dst_hbm_off & self.cfgs.serve.page_size_mask
                 dst_hbm_off = (page_indices_ref[global_p_idx] <<
-                               self.page_size_log2) | p_off
-                sz = jax.lax.select(do_writeback == 1, new_sz, 0)
-                tpu_primitives.make_async_copy(
-                    vmem_src.at[b,
-                                pl.ds(src_vmem_off, sz), :self.hbm_stride],
+                               self.cfgs.serve.page_size_log2) | p_off
+                sz = jnp.where(do_writeback, new_sz, 0)
+                pltpu.make_async_copy(
+                    vmem_src.at[b, pl.ds(src_vmem_off, sz)],
                     kv_out_ref_flat.at[pl.ds(dst_hbm_off, sz)],
                     sem,
                 ).start()
 
     def wait_in(
         self,
-        src_ref: tuple[jax.Array, jax.Array, rpa_schedule.RPASchedule,
-                       jax.Array],
-        grid_indices: tuple[int, ...],
+        src_ref: tuple[jax.Ref, jax.Ref, schedule.RPASchedule, jax.Ref],
+        grid_indices: tuple[int | jax.Array, ...],
     ):
-        _, _, schedule, _ = src_ref
+        _, _, schedule_ref, _ = src_ref
         slot = self.current_wait_in_slot
         sem = self.sem_recvs.at[slot]
         vmem_dst = self.window_ref.at[slot]
         block_idx = grid_indices[0]
 
         total_sz = 0
-        for b in range(self.batch_size):
-            for i in range(self.bkv_p_cache):
-                _, _, sz = schedule.get_dma_kv_cache(block_idx, b, i)
+        for b in range(self.cfgs.batch_size):
+            for i in range(self.cfgs.bkv_p_cache):
+                _, _, sz = schedule_ref.get_dma_kv_cache(block_idx, b, i)
                 total_sz += sz
 
             # Contiguous wait for new KV
-            for i in range(self.bkv_p_new):
-                _, _, _, sz = schedule.get_dma_kv_new(block_idx, b, i)
+            for i in range(self.cfgs.bkv_p_new):
+                _, _, _, sz = schedule_ref.get_dma_kv_new(block_idx, b, i)
                 total_sz += sz
 
-        # Flatten the first two dimensions (Batch, Seq) to create a 1D view for waiting.
+        # Flatten the first two dimensions (Batch, Seq) to create a 1D view.
         flat_vmem = vmem_dst.reshape((-1, *vmem_dst.shape[2:]))
-        tpu_primitives.make_async_copy(
-            flat_vmem.at[pl.ds(0, total_sz), :self.hbm_stride],
-            flat_vmem.at[pl.ds(0, total_sz), :self.hbm_stride],
+        pltpu.make_async_copy(
+            flat_vmem.at[pl.ds(0, total_sz), :self.cfgs.kv_hbm_stride],
+            flat_vmem.at[pl.ds(0, total_sz), :self.cfgs.kv_hbm_stride],
             sem,
         ).wait()
 
     def wait_out(
         self,
-        dst_ref: tuple[jax.Array, Any, rpa_schedule.RPASchedule, jax.Array],
-        grid_indices: tuple[int, ...],
+        dst_ref: tuple[jax.Ref, jax.Ref, schedule.RPASchedule, jax.Ref],
+        grid_indices: tuple[int | jax.Array, ...],
     ):
-        kv_out_ref, _, schedule, _ = dst_ref
+        kv_out_ref, _, schedule_ref, _ = dst_ref
         slot = self.current_wait_out_slot
         sem = self.sem_sends.at[slot]
         block_idx = grid_indices[0]
 
         total_sz = 0
-        for b in range(self.batch_size):
-            idx = block_idx * self.batch_size + b
-            do_writeback = schedule.do_writeback[idx]
-            for i in range(self.bkv_p_new):
-                _, _, _, new_sz = schedule.get_dma_kv_new(block_idx, b, i)
-                sz = jax.lax.select(do_writeback == 1, new_sz, 0)
+        for b in range(self.cfgs.batch_size):
+            do_writeback = schedule_ref.do_writeback[block_idx, b] == 1
+            for i in range(self.cfgs.bkv_p_new):
+                _, _, _, new_sz = schedule_ref.get_dma_kv_new(block_idx, b, i)
+                sz = jnp.where(do_writeback, new_sz, 0)
                 total_sz += sz
 
         # Flatten to 2D: (Total_Rows, Head_Dim)
         flat_ref = kv_out_ref.reshape((-1, *kv_out_ref.shape[2:]))
-        tpu_primitives.make_async_copy(
+        pltpu.make_async_copy(
             flat_ref.at[pl.ds(0, total_sz)],
             flat_ref.at[pl.ds(0, total_sz)],
             sem,
         ).wait()
 
 
-@tree_util.register_dataclass
+@jax.tree_util.register_dataclass
 @dataclasses.dataclass(frozen=True)
-class BatchingORef(pipeline.BufferedRef):
+class BatchingORef(pltpu.BufferedRef):
     """Handles normalizing and storing the final attention output."""
 
-    batch_size: int = dataclasses.field(metadata={"static": True})
-
-    @classmethod
-    def from_ref(cls, ref: pipeline.BufferedRef, batch_size: int):
-        return cls(
-            batch_size=batch_size,
-            **{
-                f.name: getattr(ref, f.name)
-                for f in dataclasses.fields(pipeline.BufferedRef)
-            },
-        )
+    cfgs: configs.RPAConfig = dataclasses.field(default=None,
+                                                metadata=dict(static=True))
 
     @classmethod
     def create(
         cls,
         spec: pl.BlockSpec,
-        source_memory_space: jax.Array,
-        batch_size: int,
-        buffer_count: int = 2,
-        use_lookahead: bool = False,
+        dtype_or_type: jax.Array,
+        buffer_type,  # pltpu.BufferType,
+        buffer_count: int,
+        use_lookahead: bool,
+        cfgs: configs.RPAConfig,
     ):
-        standard_ref = pipeline.BufferedRef.create(
+        # TODO(kyuyeunk): Uncomment this out after jax version update.
+        # assert buffer_type == pltpu.BufferType.OUTPUT
+
+        standard_ref = pltpu.BufferedRef.create(
             spec=spec,
-            dtype_or_type=pipeline._ref_to_value_aval(source_memory_space),
-            buffer_type=pipeline.BufferType.OUTPUT,
+            dtype_or_type=dtype_or_type,
+            buffer_type=buffer_type,
             buffer_count=buffer_count,
             grid_rank=1,
             use_lookahead=use_lookahead,
-            source_memory_space=source_memory_space,
         )
-        return cls.from_ref(standard_ref, batch_size=batch_size)
+        return cls(
+            cfgs=cfgs,
+            **{
+                f.name: getattr(standard_ref, f.name)
+                for f in dataclasses.fields(pltpu.BufferedRef)
+            },
+        )
 
     def copy_out(
         self,
-        dst_ref: tuple[jax.Array, rpa_schedule.RPASchedule],
-        grid_indices: tuple[int, ...],
+        dst_ref: tuple[jax.Ref, schedule.RPASchedule],
+        grid_indices: tuple[int | jax.Array, ...],
     ):
-        # dst_ref: (o_hbm, schedule)
-        o_hbm, schedule = dst_ref
+        # dst_ref: (o_hbm, schedule_ref)
+        o_hbm, schedule_ref = dst_ref
         slot = self.current_copy_out_slot
         sem = self.sem_sends.at[slot]
         vmem_src = self.window_ref.at[slot]
@@ -304,16 +255,15 @@ class BatchingORef(pipeline.BufferedRef):
 
         # is_last_k stride: batch size
         dma_list = []
-        for b in range(self.batch_size):
-            idx = block_idx * self.batch_size + b
-            is_last_k = schedule.is_last_k[idx]
-            q_src, q_sz = schedule.get_dma_q(block_idx, b)
-            q_sz = jax.lax.select(is_last_k == 1, q_sz, 0)
+        for b in range(self.cfgs.batch_size):
+            is_last_k = schedule_ref.is_last_k[block_idx, b] == 1
+            q_src, q_sz = schedule_ref.get_dma_q(block_idx, b)
+            q_sz = jnp.where(is_last_k, q_sz, 0)
             dma_list.append((q_src, q_sz, b))
 
         for i in range(len(dma_list)):
             q_src, q_sz, b = dma_list[i]
-            tpu_primitives.make_async_copy(
+            pltpu.make_async_copy(
                 vmem_src.at[b, :, pl.ds(0, q_sz)],
                 o_hbm.at[:, pl.ds(q_src, q_sz)],
                 sem,
@@ -321,96 +271,87 @@ class BatchingORef(pipeline.BufferedRef):
 
     def wait_out(
         self,
-        dst_ref: tuple[jax.Array, rpa_schedule.RPASchedule],
-        grid_indices: tuple[int, ...],
+        dst_ref: tuple[jax.Ref, schedule.RPASchedule],
+        grid_indices: tuple[int | jax.Array, ...],
     ):
-        # dst_ref: (o_hbm, schedule)
-        o_hbm, schedule = dst_ref
+        # dst_ref: (o_hbm, schedule_ref)
+        o_hbm, schedule_ref = dst_ref
         slot = self.current_wait_out_slot
         sem = self.sem_sends.at[slot]
         block_idx = grid_indices[0]
 
         total_sz = 0
-        for b in range(self.batch_size):
-            idx = block_idx * self.batch_size + b
-            is_last_k = schedule.is_last_k[idx]
-            _, q_sz = schedule.get_dma_q(block_idx, b)
-            q_sz = jax.lax.select(is_last_k == 1, q_sz, 0)
+        for b in range(self.cfgs.batch_size):
+            is_last_k = schedule_ref.is_last_k[block_idx, b] == 1
+            _, q_sz = schedule_ref.get_dma_q(block_idx, b)
+            q_sz = jnp.where(is_last_k, q_sz, 0)
             total_sz += q_sz
 
         flat_ref = o_hbm.reshape((-1, *o_hbm.shape[2:]))
-        tpu_primitives.make_async_copy(
+        pltpu.make_async_copy(
             flat_ref.at[pl.ds(0, total_sz * o_hbm.shape[0])],
             flat_ref.at[pl.ds(0, total_sz * o_hbm.shape[0])],
             sem,
         ).wait()
 
 
-@tree_util.register_dataclass
+@jax.tree_util.register_dataclass
 @dataclasses.dataclass(frozen=True)
-class BatchingQRef(pipeline.BufferedRef):
+class BatchingQRef(pltpu.BufferedRef):
     """Handles fetching Q blocks using precomputed metadata."""
 
-    bq_sz: int = dataclasses.field(metadata={"static": True})
-    batch_size: int = dataclasses.field(metadata={"static": True})
-
-    @classmethod
-    def from_ref(
-        cls,
-        ref: pipeline.BufferedRef,
-        bq_sz: int,
-        batch_size: int,
-    ):
-        return cls(
-            bq_sz=bq_sz,
-            batch_size=batch_size,
-            **{
-                f.name: getattr(ref, f.name)
-                for f in dataclasses.fields(pipeline.BufferedRef)
-            },
-        )
+    cfgs: configs.RPAConfig = dataclasses.field(default=None,
+                                                metadata=dict(static=True))
 
     @classmethod
     def create(
         cls,
         spec: pl.BlockSpec,
-        source_memory_space: jax.Array,
-        bq_sz: int,
-        batch_size: int,
-        buffer_count: int = 2,
-        use_lookahead: bool = True,
+        dtype_or_type: jax.Array,
+        buffer_type,  # pltpu.BufferType,
+        buffer_count: int,
+        use_lookahead: bool,
+        cfgs: configs.RPAConfig,
     ):
-        standard_ref = pipeline.BufferedRef.create(
+        # TODO(kyuyeunk): Uncomment this out after jax version update.
+        # assert buffer_type == pltpu.BufferType.INPUT
+
+        standard_ref = pltpu.BufferedRef.create(
             spec=spec,
-            dtype_or_type=pipeline._ref_to_value_aval(source_memory_space),
-            buffer_type=pipeline.BufferType.INPUT,
+            dtype_or_type=dtype_or_type,
+            buffer_type=buffer_type,
             buffer_count=buffer_count,
             grid_rank=1,
             use_lookahead=use_lookahead,
-            source_memory_space=source_memory_space,
         )
-        return cls.from_ref(standard_ref, bq_sz=bq_sz, batch_size=batch_size)
+        return cls(
+            cfgs=cfgs,
+            **{
+                f.name: getattr(standard_ref, f.name)
+                for f in dataclasses.fields(pltpu.BufferedRef)
+            },
+        )
 
     def copy_in(
         self,
-        src_ref: tuple[jax.Array, rpa_schedule.RPASchedule],
-        grid_indices: tuple[int, ...],
+        src_ref: tuple[jax.Ref, schedule.RPASchedule],
+        grid_indices: tuple[int | jax.Array, ...],
     ):
-        # src_ref: (q_hbm, schedule)
-        q_hbm, schedule = src_ref
+        # src_ref: (q_hbm, schedule_ref)
+        q_hbm, schedule_ref = src_ref
         slot = self.current_copy_in_slot
         sem = self.sem_recvs.at[slot]
         vmem_dst = self.window_ref.at[slot]
         block_idx = grid_indices[0]
 
         dma_list = []
-        for b in range(self.batch_size):
-            q_src, q_sz = schedule.get_dma_q(block_idx, b)
+        for b in range(self.cfgs.batch_size):
+            q_src, q_sz = schedule_ref.get_dma_q(block_idx, b)
             dma_list.append((q_src, q_sz, b))
 
         for i in range(len(dma_list)):
             q_src, q_sz, b = dma_list[i]
-            tpu_primitives.make_async_copy(
+            pltpu.make_async_copy(
                 q_hbm.at[:, pl.ds(q_src, q_sz)],
                 vmem_dst.at[b, :, pl.ds(0, q_sz)],
                 sem,
@@ -418,24 +359,24 @@ class BatchingQRef(pipeline.BufferedRef):
 
     def wait_in(
         self,
-        src_ref: tuple[jax.Array, rpa_schedule.RPASchedule],
-        grid_indices: tuple[int, ...],
+        src_ref: tuple[jax.Ref, schedule.RPASchedule],
+        grid_indices: tuple[int | jax.Array, ...],
     ):
-        _, schedule = src_ref
+        _, schedule_ref = src_ref
         slot = self.current_wait_in_slot
         sem = self.sem_recvs.at[slot]
         vmem_dst = self.window_ref.at[slot]
         block_idx = grid_indices[0]
 
         total_sz = 0
-        for b in range(self.batch_size):
-            _, q_sz = schedule.get_dma_q(block_idx, b)
+        for b in range(self.cfgs.batch_size):
+            _, q_sz = schedule_ref.get_dma_q(block_idx, b)
             total_sz += q_sz
 
         # Flatten to 2D: (Total_Rows, Head_Dim)
         # vmem_dst is (Batch, Heads, Q, Head_Dim). We copy Heads * q_sz rows.
         flat_vmem = vmem_dst.reshape((-1, *vmem_dst.shape[3:]))
-        tpu_primitives.make_async_copy(
+        pltpu.make_async_copy(
             flat_vmem.at[pl.ds(0, total_sz * vmem_dst.shape[1])],
             flat_vmem.at[pl.ds(0, total_sz * vmem_dst.shape[1])],
             sem,

--- a/tpu_inference/kernels/experimental/batched_rpa/configs.py
+++ b/tpu_inference/kernels/experimental/batched_rpa/configs.py
@@ -1,0 +1,285 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import dataclasses
+import enum
+
+import jax
+import jax.numpy as jnp
+from jax.experimental.pallas import tpu as pltpu
+
+from tpu_inference.kernels.experimental.batched_rpa import utils
+
+
+@dataclasses.dataclass(frozen=True)
+class BlockSizes:
+    """Tuning parameters for the RPA kernel."""
+
+    bq_sz: int
+    bkv_sz: int
+    batch_size: int
+    n_buffer: int
+
+
+@dataclasses.dataclass(frozen=True)
+class ModelConfigs:
+    """Model config that will always stay constant."""
+
+    num_q_heads: int
+    num_kv_heads: int
+    head_dim: int
+    mask_value: float
+    sm_scale: float = 1.0
+    soft_cap: float | None = None
+    sliding_window: int | None = None
+
+    @property
+    def num_q_heads_per_kv_head(self) -> int:
+        return self.num_q_heads // self.num_kv_heads
+
+
+@dataclasses.dataclass(frozen=True)
+class ServingConfigs:
+    """Serving config that can change depending on use cases."""
+
+    num_seqs: int
+    page_size: int
+    total_q_tokens: int
+    num_page_indices: int
+    dtype_q: jnp.dtype
+    dtype_kv: jnp.dtype
+    dtype_out: jnp.dtype
+    scale_q: int | None = None
+    scale_k: int | None = None
+    scale_v: int | None = None
+
+    @property
+    def pages_per_seq(self) -> int:
+        return self.num_page_indices // self.num_seqs
+
+    @property
+    def page_size_log2(self) -> int:
+        return (self.page_size - 1).bit_length()
+
+    @property
+    def page_size_mask(self) -> int:
+        return self.page_size - 1
+
+    @property
+    def int_ty(self) -> jnp.dtype:
+        if utils.get_dtype_packing(self.dtype_q) == 1:
+            return jnp.int32
+
+        match pltpu.get_tpu_info().generation:
+            case 6 | 7:
+                return jnp.int16
+            case _:
+                return jnp.int32
+
+    @property
+    def packing_q(self) -> int:
+        return utils.get_dtype_packing(self.dtype_q)
+
+    @property
+    def packing_kv(self) -> int:
+        return utils.get_dtype_packing(self.dtype_kv)
+
+
+class RpaCase(enum.StrEnum):
+    """Represents the different cases for Ragged Paged Attention.
+
+    - DECODE: Sequences are in decode-only mode (q_len = 1).
+    - PREFILL: Sequences are in prefill-only mode (q_len > 1, static).
+    - MIXED: Sequences can be a mix of prefill and decode (q_len > 1, dynamic).
+    """
+
+    DECODE = enum.auto()
+    PREFILL = enum.auto()
+    MIXED = enum.auto()
+
+    @property
+    def symbol(self):
+        return {
+            RpaCase.DECODE: "d",
+            RpaCase.PREFILL: "p",
+            RpaCase.MIXED: "m",
+        }[self]
+
+    def get_range(
+        self, distribution: jax.Array
+    ) -> tuple[jax.typing.ArrayLike, jax.typing.ArrayLike]:
+        assert distribution.shape == (3, )
+        match self:
+            case RpaCase.DECODE:
+                return 0, distribution[0]
+            case RpaCase.PREFILL:
+                return distribution[0], distribution[1]
+            case RpaCase.MIXED:
+                return distribution[1], distribution[2]
+
+
+@dataclasses.dataclass(frozen=True, eq=True)
+class RPAConfig:
+    block: BlockSizes
+    model: ModelConfigs
+    serve: ServingConfigs
+    mode: RpaCase
+    vmem_limit_bytes: int
+
+    # Expose block sizes for ease of use.
+
+    @property
+    def bq_sz(self) -> int:
+        return self.block.bq_sz
+
+    @property
+    def bkv_sz(self) -> int:
+        return self.block.bkv_sz
+
+    @property
+    def batch_size(self) -> int:
+        return self.block.batch_size
+
+    @property
+    def n_buffer(self) -> int:
+        return self.block.n_buffer
+
+    # Define derived values.
+
+    @property
+    def max_steps_ub(self) -> int:
+        """Get maximum upper bound of kernel steps based on SMEM limit."""
+
+        fixed_bytes = 0
+        fixed_bytes += self.serve.num_seqs  # kv_lens
+        fixed_bytes += self.serve.num_seqs + 1  # cu_q_lens
+        fixed_bytes += self.serve.num_seqs * self.serve.pages_per_seq  # page_indices
+        fixed_bytes += 3  # distribution
+        fixed_bytes += self.block.batch_size  # lane_lengths
+        fixed_bytes += 1  # actual_steps
+
+        word_size_bytes = 4
+        fixed_bytes *= word_size_bytes
+
+        smem_limit_bytes = pltpu.get_tpu_info().smem_capacity_bytes - 32 * 1024
+        available_bytes = smem_limit_bytes - fixed_bytes
+
+        # Per step per batch item:
+        # s_idx, q_idx, k_idx, is_last_k, do_writeback: 5 * 4 = 20
+        # dma_q: 2 * 4 = 8
+        # dma_kv_cache: bkv_p_cache * 3 * 4 = 12 * bkv_p_cache
+        # dma_kv_new: bkv_p_new * 4 * 4 = 16 * bkv_p_new
+        bytes_per_step = 28 + 12 * self.bkv_p_cache + 16 * self.bkv_p_new
+        bytes_per_step *= self.block.batch_size
+
+        max_steps_ub = available_bytes // bytes_per_step
+
+        num_lanes = pltpu.get_tpu_info().num_lanes
+        max_steps_ub = max(1, max_steps_ub // num_lanes) * num_lanes
+        return max_steps_ub
+
+    @property
+    def bkv_p(self) -> int:
+        return self.block.bkv_sz // self.serve.page_size
+
+    @property
+    def bkv_p_cache(self) -> int:
+        if self.mode == RpaCase.PREFILL:
+            return 0
+        return self.bkv_p
+
+    @property
+    def bkv_p_new(self) -> int:
+        if self.mode == RpaCase.DECODE:
+            return 1
+        return self.bkv_p
+
+    @property
+    def bkv_stride(self) -> int:
+        bkv_stride = (self.model.num_kv_heads * 2) // self.serve.packing_kv
+
+        if utils.has_bank_conflicts(bkv_stride):
+            bkv_stride += 1
+        return bkv_stride
+
+    @property
+    def aligned_head_dim(self) -> int:
+        num_lanes = pltpu.get_tpu_info().num_lanes
+        return utils.align_to(self.model.head_dim, num_lanes)
+
+    @property
+    def aligned_num_kv_heads(self) -> int:
+        packing_kv = self.serve.packing_kv
+        return utils.align_to(self.model.num_kv_heads, packing_kv)
+
+    @property
+    def aligned_num_q_heads_per_kv_head(self) -> int:
+        packing_q = self.serve.packing_q
+        return utils.align_to(self.model.num_q_heads_per_kv_head, packing_q)
+
+    @property
+    def kv_hbm_stride(self) -> int:
+        kv_packing = utils.get_dtype_packing(self.serve.dtype_kv)
+        return utils.align_to(self.model.num_kv_heads * 2,
+                              kv_packing) // kv_packing
+
+    @property
+    def fuse_accum(self) -> bool:
+        return self.mode == RpaCase.DECODE
+
+    @property
+    def mask_v(self) -> bool:
+        return self.mode != RpaCase.DECODE
+
+    @property
+    def q_vmem_shape(self):
+        q_per_kv_packing = (self.model.num_q_heads_per_kv_head //
+                            self.serve.packing_q)
+        return (
+            self.block.batch_size,
+            self.model.num_kv_heads,
+            self.block.bq_sz,
+            q_per_kv_packing,
+            self.serve.packing_q,
+            self.model.head_dim,
+        )
+
+    @property
+    def kv_vmem_shape(self):
+        return (
+            self.block.batch_size,
+            self.block.bkv_sz,
+            self.bkv_stride,
+            self.serve.packing_kv,
+            self.model.head_dim,
+        )
+
+    @property
+    def lm_scratch_shape(self):
+        num_lanes = pltpu.get_tpu_info().num_lanes
+        return (
+            self.block.batch_size,
+            self.model.num_kv_heads,
+            self.block.bq_sz * self.model.num_q_heads_per_kv_head,
+            num_lanes,
+        )
+
+    @property
+    def acc_scratch_shape(self):
+        return (
+            self.block.batch_size,
+            self.model.num_kv_heads,
+            self.block.bq_sz * self.model.num_q_heads_per_kv_head,
+            self.model.head_dim,
+        )

--- a/tpu_inference/kernels/experimental/batched_rpa/flash_attention.py
+++ b/tpu_inference/kernels/experimental/batched_rpa/flash_attention.py
@@ -12,33 +12,33 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import jax
 import jax.numpy as jnp
 from jax import lax
+from jax.experimental.pallas import tpu as pltpu
 
-from tpu_inference.kernels.experimental.batched_rpa import \
-    schedule as rpa_schedule
-from tpu_inference.kernels.experimental.batched_rpa import utils
+from tpu_inference.kernels.experimental.batched_rpa import configs, utils
 
 
 def flash_attention(
-    q,  # [B, KV, TQ, H]
-    k,  # [B, KV, S, H]
-    v,  # [B, KV, S, H]
-    o_prev,  # [B, KV, TQ, H]
-    m_prev,  # [B, KV, TQ, 128]
-    l_prev,  # [B, KV, TQ, 128]
+    q: jax.Array,  # [B, KV, TQ, H]
+    k: jax.Array,  # [B, KV, S, H]
+    v: jax.Array,  # [B, KV, S, H]
+    o_prev: jax.Array,  # [B, KV, TQ, H]
+    m_prev: jax.Array,  # [B, KV, TQ, 128]
+    l_prev: jax.Array,  # [B, KV, TQ, 128]
     *,
-    processed_q_len,  # [B]
-    processed_kv_len,  # [B]
-    effective_kv_len,  # [B]
-    config: rpa_schedule.RPAConfig,
+    processed_q_len: list[jax.Array],  # [B]
+    processed_kv_len: list[jax.Array],  # [B]
+    effective_kv_len: list[jax.Array],  # [B]
+    cfgs: configs.RPAConfig,
 ):
     """Flash attention kernel."""
     b, k_heads, tq, h = q.shape
     s = k.shape[2]
 
-    if config.q_scale is not None:
-        q = q / config.q_scale
+    if cfgs.serve.scale_q is not None:
+        q = q / cfgs.serve.scale_q
         if jnp.issubdtype(k.dtype, jnp.floating):
             dtype_info = jnp.finfo(k.dtype)
             minval = float(dtype_info.min)
@@ -47,48 +47,48 @@ def flash_attention(
         q = q.astype(k.dtype)
 
     qk = lax.dot_general(
-        q.reshape((b * k_heads, tq, h)),
-        k.reshape((b * k_heads, s, h)),
+        pltpu.einshape("bkth->(bk)th", q, True),
+        pltpu.einshape("bksh->(bk)sh", k, True),
         dimension_numbers=(([2], [2]), ([0], [0])),
         preferred_element_type=jnp.float32,
-    )
-    qk = qk.reshape((b, k_heads, tq, s)).astype(config.out_dtype)
+    ).astype(cfgs.serve.dtype_out)
+    qk = pltpu.einshape("(bk)ts->bkts", qk, True, b=b)
 
-    qk *= config.sm_scale
-    if config.k_scale is not None:
-        qk *= config.k_scale
-    if config.q_scale is not None:
-        qk *= config.q_scale
+    qk *= cfgs.model.sm_scale
+    if cfgs.serve.scale_k is not None:
+        qk *= cfgs.serve.scale_k
+    if cfgs.serve.scale_q is not None:
+        qk *= cfgs.serve.scale_q
 
-    if config.soft_cap is not None:
-        qk = config.soft_cap * jnp.tanh(qk / config.soft_cap)
+    if cfgs.model.soft_cap is not None:
+        qk = cfgs.model.soft_cap * jnp.tanh(qk / cfgs.model.soft_cap)
 
     qk_masked = []
     v_masked = []
 
-    int_ty = config.int_ty
+    int_ty = cfgs.serve.int_ty
 
-    for b_idx in range(config.batch_size):
+    for b_idx in range(cfgs.block.batch_size):
         kv_idx_b = (lax.broadcasted_iota(int_ty, (k_heads, tq, s), 2) +
                     processed_kv_len[b_idx])
         q_idx_b = (lax.broadcasted_iota(jnp.int32, (k_heads, tq, s), 1) //
-                   config.num_q_heads_per_kv_head
+                   cfgs.model.num_q_heads_per_kv_head
                    ).astype(int_ty) + processed_q_len[b_idx]
 
         eff_kv_len_b = effective_kv_len[b_idx]
         mask_b = q_idx_b < eff_kv_len_b
         mask_b = jnp.logical_and(mask_b, q_idx_b >= kv_idx_b)
 
-        if config.sliding_window is not None:
-            mask_b = jnp.logical_and(
-                mask_b, q_idx_b < kv_idx_b + config.sliding_window)
+        if (sliding_window := cfgs.model.sliding_window) is not None:
+            mask_b = jnp.logical_and(mask_b, q_idx_b
+                                     < kv_idx_b + sliding_window)
 
-        if not config.mask_v:
+        if not cfgs.mask_v:
             mask_b = jnp.logical_and(mask_b, kv_idx_b < eff_kv_len_b)
 
-        qk_masked.append(jnp.where(mask_b, qk[b_idx], config.mask_value))
+        qk_masked.append(jnp.where(mask_b, qk[b_idx], cfgs.model.mask_value))
 
-        if config.mask_v:
+        if cfgs.mask_v:
             kv_idx_v = (lax.broadcasted_iota(int_ty, (k_heads, s, h), 1) +
                         processed_kv_len[b_idx])
             v_mask_b = kv_idx_v < eff_kv_len_b
@@ -104,17 +104,17 @@ def flash_attention(
     p = jnp.exp(qk - utils.broadcast_minor(m_next, qk.shape))
 
     pv = lax.dot_general(
-        p.reshape((b * k_heads, tq, s)),
-        v.reshape((b * k_heads, s, h)),
+        pltpu.einshape("bkts->(bk)ts", p, True),
+        pltpu.einshape("bksh->(bk)sh", v, True),
         dimension_numbers=(([2], [1]), ([0], [0])),
         preferred_element_type=jnp.float32,
-    )
-    pv = pv.reshape((b, k_heads, tq, h)).astype(config.out_dtype)
+    ).astype(cfgs.serve.dtype_out)
+    pv = pltpu.einshape("(bk)th->bkth", pv, True, b=b)
 
-    if config.v_scale is not None:
-        pv *= config.v_scale
+    if cfgs.serve.scale_v is not None:
+        pv *= cfgs.serve.scale_v
 
-    p_rowsum = jnp.sum(p, axis=-1, keepdims=True, dtype=config.out_dtype)
+    p_rowsum = jnp.sum(p, axis=-1, keepdims=True, dtype=cfgs.serve.dtype_out)
     alpha = jnp.exp(m_prev - m_next)
     l_next = alpha * l_prev + p_rowsum
 

--- a/tpu_inference/kernels/experimental/batched_rpa/kernel.py
+++ b/tpu_inference/kernels/experimental/batched_rpa/kernel.py
@@ -12,481 +12,486 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import dataclasses
+import functools
+
 import jax
 import jax.experimental.pallas as pl
 import jax.experimental.pallas.tpu as pltpu
-import jax.lax as lax
 import jax.numpy as jnp
-from jax._src.pallas.mosaic import pipeline
+from jax import lax
 
 from tpu_inference.kernels.experimental.batched_rpa import (bref_override,
-                                                            flash_attention)
-from tpu_inference.kernels.experimental.batched_rpa import \
-    schedule as schedule_lib
-from tpu_inference.kernels.experimental.batched_rpa import utils
+                                                            configs,
+                                                            flash_attention,
+                                                            schedule, utils)
+
+# Define inner kernel.
 
 
-def make_rpa_kernel(config: schedule_lib.RPAConfig):
-    q_packing = schedule_lib.get_dtype_packing(config.q_dtype)
-    kv_packing = schedule_lib.get_dtype_packing(config.kv_dtype)
+def strided_load_bkv(
+    kv_in_vref: jax.Ref,
+    b_idx: int,
+    start: int,
+    *,
+    cfgs: configs.RPAConfig,
+) -> list[tuple[jax.Array, jax.Array]]:
+    assert start % cfgs.serve.packing_kv == 0
+    start //= cfgs.serve.packing_kv
+    kv_u32_ref = kv_in_vref.at[b_idx].bitcast(jnp.uint32)
+    kv_ref = kv_u32_ref.reshape(-1, cfgs.model.head_dim)
+
+    if cfgs.serve.packing_kv == 1:
+        k = utils.strided_load(
+            kv_ref,
+            start,
+            cfgs.bkv_sz * cfgs.bkv_stride,
+            cfgs.bkv_stride,
+            dtype=cfgs.serve.dtype_kv,
+        )
+        v = utils.strided_load(
+            kv_ref,
+            start + 1,
+            cfgs.bkv_sz * cfgs.bkv_stride,
+            cfgs.bkv_stride,
+            dtype=cfgs.serve.dtype_kv,
+        )
+        return [(k, v)]
+
+    kv = utils.strided_load(kv_ref, start, cfgs.bkv_sz * cfgs.bkv_stride,
+                            cfgs.bkv_stride)
+    bitwidth = jax.dtypes.itemsize_bits(cfgs.serve.dtype_kv)
+
+    return utils.convert_to_target_bitwidth(kv,
+                                            target_bitwidth=bitwidth,
+                                            kv_dtype=cfgs.serve.dtype_kv)
+
+
+def calculate_and_store_out(
+    step_idx: jax.Array,
+    schedule_ref: schedule.RPASchedule,
+    acc_scratch_ref: jax.Ref,
+    l_scratch_ref: jax.Ref,
+    o_vref: jax.Ref,
+    *,
+    cfgs: configs.RPAConfig,
+):
+
+    def _accum(b_idx: int):
+        batch_acc = acc_scratch_ref[b_idx]
+        batch_l = l_scratch_ref[b_idx]
+        batch_l = utils.broadcast_minor(batch_l, batch_acc.shape)
+
+        if (cfgs.serve.dtype_out == jnp.float32
+                or cfgs.serve.dtype_out == batch_l.dtype == jnp.bfloat16):
+            result = lax.div(batch_acc, batch_l)
+        else:
+            result = batch_acc * pl.reciprocal(batch_l, approx=True)
+        out = result.astype(cfgs.serve.dtype_out)
+
+        o_u32_vref = o_vref.at[b_idx].bitcast(jnp.uint32)
+        out_ref = o_u32_vref.reshape(-1, cfgs.model.head_dim)
+        out = pltpu.bitcast(out, out_ref.dtype).reshape(out_ref.shape)
+        utils.strided_store(out_ref, 0, out_ref.shape[0], 1, out)
+
+    for b in range(cfgs.batch_size):
+        # Adding a conditional causes a scheduling barrier. In prefill, we often
+        # use small block sizes, so it's not worth executing the accumulation
+        # on every block. In decode, because of the large block sizes / and or
+        # batch sizes, we almost always use accumulation on every block. Please
+        # tune `fuse_accum` for your use case.
+        if not cfgs.fuse_accum:
+            is_last_k = schedule_ref.is_last_k[step_idx, b] == 1
+            jax.lax.cond(is_last_k, jax.named_call(_accum, name="accum"),
+                         lambda _: None, b)
+        else:
+            _accum(b)
+
+
+def rpa_body(
+    # Inputs.
+    q_vref: jax.Ref,
+    kv_in_vref: jax.Ref,
+    # Outputs
+    o_vref: jax.Ref,
+    # Scratches.
+    schedule_ref: schedule.RPASchedule,
+    m_scratch_ref: jax.Ref,
+    l_scratch_ref: jax.Ref,
+    acc_scratch_ref: jax.Ref,
+    *,
+    # Passed refs
+    cu_q_lens_ref: jax.Ref,
+    kv_lens_ref: jax.Ref,
+    # Configs.
+    cfgs: configs.RPAConfig,
+):
+    step = pl.program_id(0)
+
+    # Step 1: Fetch metadata.
+    processed_q_len = []
+    processed_kv_len = []
+    effective_kv_len = []
+    int_ty = cfgs.serve.int_ty
+    for b_idx in range(cfgs.batch_size):
+        s_idx = schedule_ref.s_idx[step, b_idx]
+        is_valid = s_idx != -1
+        q_idx = schedule_ref.q_idx[step, b_idx]
+        k_idx = schedule_ref.k_idx[step, b_idx]
+        k_id = jnp.where(is_valid, k_idx * cfgs.bkv_sz, 0)
+        kv_len = jnp.where(is_valid, kv_lens_ref[s_idx], 0)
+        q_start = jnp.where(is_valid, cu_q_lens_ref[s_idx], 0)
+        q_end = jnp.where(is_valid, cu_q_lens_ref[s_idx + 1], 0)
+        q_len = q_end - q_start
+        offset = kv_len - q_len
+
+        processed_q_len.append((q_idx * cfgs.bq_sz + offset).astype(int_ty))
+        processed_kv_len.append(k_id.astype(int_ty))
+        effective_kv_len.append(kv_len.astype(int_ty))
+
+        start_k_idx = 0
+        if (sliding_window := cfgs.model.sliding_window) is not None:
+            sw_start_idx = kv_len - q_len + q_idx * cfgs.bq_sz - sliding_window + 1
+            start_k_idx = jnp.maximum(0, sw_start_idx) // cfgs.bkv_sz
+
+        is_first_k_block = k_idx == start_k_idx
+        reset_cond = jnp.logical_and(is_valid, is_first_k_block)
+        m_scratch_ref[b_idx] = jnp.where(reset_cond, -jnp.inf,
+                                         m_scratch_ref[b_idx])
+        l_scratch_ref[b_idx] = jnp.where(reset_cond, 0.0, l_scratch_ref[b_idx])
+        acc_scratch_ref[b_idx] = jnp.where(reset_cond, 0.0,
+                                           acc_scratch_ref[b_idx])
+
+    # Step 2: Fetch inputs.
+    q_p = cfgs.aligned_num_q_heads_per_kv_head // cfgs.serve.packing_q
+    q_ref = q_vref.bitcast(jnp.uint32).reshape(-1, cfgs.model.head_dim)
+    q_loaded = utils.strided_load(
+        q_ref,
+        0,
+        cfgs.batch_size * cfgs.model.num_kv_heads * cfgs.bq_sz * q_p,
+        1,
+        dtype=cfgs.serve.dtype_q,
+    )
+    q = q_loaded.reshape(
+        cfgs.batch_size,
+        cfgs.model.num_kv_heads,
+        cfgs.bq_sz * cfgs.aligned_num_q_heads_per_kv_head,
+        cfgs.model.head_dim,
+    )
+
+    # We want to load k, v from (batch, bkv_sz, bkv_stride, kv_packing, d)
+    # where bkv_stride ~= num_kv_heads * 2 // kv_packing
+    # to 2x (batch, num_kv_heads, bkv_sz, d)
+    # We use strided_load to avoid the expensive transpose.
+    k_b = []
+    v_b = []
+    for b_idx in range(cfgs.batch_size):
+        heads_per_load = pl.cdiv(cfgs.serve.packing_kv, 2)
+        ks = []
+        vs = []
+        for kv_head_start in range(0, cfgs.model.num_kv_heads, heads_per_load):
+            bkv_lst = strided_load_bkv(
+                kv_in_vref,
+                b_idx,
+                kv_head_start * 2,
+                cfgs=cfgs,
+            )
+            ks.append(jnp.stack([k for k, _ in bkv_lst], axis=0))
+            vs.append(jnp.stack([v for _, v in bkv_lst], axis=0))
+        k, v = jnp.concat(ks, axis=0), jnp.concat(vs, axis=0)
+        k = k.reshape(-1, cfgs.bkv_sz, cfgs.model.head_dim)
+        v = v.reshape(-1, cfgs.bkv_sz, cfgs.model.head_dim)
+
+        k = k[:cfgs.model.num_kv_heads]
+        v = v[:cfgs.model.num_kv_heads]
+        k_b.append(k)
+        v_b.append(v)
+    # Stack to (batch, num_heads, bkv_sz, num_lanes)
+    k = jnp.stack(k_b, axis=0)
+    v = jnp.stack(v_b, axis=0)
+
+    # Step 3: Perform compute.
+    m_val = m_scratch_ref[...]
+    l_val = l_scratch_ref[...]
+    acc_val = acc_scratch_ref[...]
+
+    m_next, l_next, o_next = flash_attention.flash_attention(
+        q,
+        k,
+        v,
+        acc_val,
+        m_val,
+        l_val,
+        processed_q_len=processed_q_len,
+        processed_kv_len=processed_kv_len,
+        effective_kv_len=effective_kv_len,
+        cfgs=cfgs,
+    )
+    m_scratch_ref[...] = m_next
+    l_scratch_ref[...] = l_next
+    acc_scratch_ref[...] = o_next
+
+    # Step 4: Write back outputs.
+    calculate_and_store_out(
+        step,
+        schedule_ref,
+        acc_scratch_ref,
+        l_scratch_ref,
+        o_vref,
+        cfgs=cfgs,
+    )
+
+
+# Define main kernel.
+
+
+def create_allocs(
+    kv_cache_hbm_ref: jax.Ref, o_hbm_ref: jax.Ref, cfgs: configs.RPAConfig
+) -> tuple[
+        bref_override.BatchingQRef,
+        bref_override.KVBufferedRef,
+        bref_override.BatchingORef,
+]:
+    kv_cache_spec = pl.BlockSpec(
+        block_shape=cfgs.kv_vmem_shape,
+        memory_space=pltpu.VMEM,
+        index_map=lambda i: (i, ),
+        pipeline_mode=pl.Buffered(buffer_count=cfgs.n_buffer,
+                                  use_lookahead=True),
+    )
+    q_spec = pl.BlockSpec(
+        block_shape=cfgs.q_vmem_shape,
+        memory_space=pltpu.VMEM,
+        index_map=lambda i: (i, ),
+        pipeline_mode=pl.Buffered(buffer_count=cfgs.n_buffer,
+                                  use_lookahead=True),
+    )
+    o_spec = pl.BlockSpec(
+        block_shape=cfgs.q_vmem_shape,
+        memory_space=pltpu.VMEM,
+        index_map=lambda i: (i, ),
+        pipeline_mode=pl.Buffered(buffer_count=2, use_lookahead=False),
+    )
+
+    kv_cache_alloc = bref_override.KVBufferedRef.input_output(
+        spec=kv_cache_spec,
+        dtype_or_type=kv_cache_hbm_ref,
+        buffer_count=cfgs.n_buffer,
+        use_lookahead=True,
+        cfgs=cfgs,
+    )
+    q_alloc = bref_override.BatchingQRef.input(
+        spec=q_spec,
+        dtype_or_type=o_hbm_ref,
+        buffer_count=cfgs.n_buffer,
+        use_lookahead=True,
+        cfgs=cfgs,
+    )
+    o_alloc = bref_override.BatchingORef.output(
+        spec=o_spec,
+        dtype_or_type=o_hbm_ref,
+        buffer_count=2,
+        use_lookahead=False,
+        cfgs=cfgs,
+    )
+
+    return q_alloc, kv_cache_alloc, o_alloc
+
+
+def get_kernel_name(cfgs: configs.RPAConfig) -> str:
+    name = f"RPA{cfgs.mode.symbol}-p{cfgs.serve.page_size}"
+    name += f"-b{cfgs.batch_size}-q{cfgs.bq_sz}-k{cfgs.bkv_sz}"
+    if cfgs.model.sliding_window:
+        name += f"-sw{cfgs.model.sliding_window}"
+    return name
+
+
+def get_kernel_metadata(
+    cfgs: configs.RPAConfig, ) -> dict[str, str | int | float]:
+    cfgs_dict = dataclasses.asdict(cfgs)
+    ret = {}
+    for path, val in jax.tree_util.tree_leaves_with_path(cfgs_dict):
+        key = jax.tree_util.keystr(path, simple=True, separator=".")
+        if not isinstance(val, str | int | float):
+            val = str(val)
+        ret[key] = val
+    return ret
+
+
+def rpa_kernel(
+    cu_q_lens: jax.Array,
+    kv_lens: jax.Array,
+    page_indices: jax.Array,
+    schedule_hbm: schedule.RPASchedule,
+    q_hbm: jax.Array,
+    new_kv_hbm: jax.Array,
+    kv_cache_hbm: jax.Array,
+    *,
+    cfgs: configs.RPAConfig,
+) -> tuple[jax.Array, jax.Array]:
+    """Perform batched ragged paged attention with scheduler data.
+
+    Args:
+        cu_q_lens: [max_num_seqs + 1]. Cumulative sum of each sequence's query
+            length. queries[a:b], keys[a:b], and values[a:b] where a=cu_q_lens[i] and
+            b=cu_q_lens[i+1] represents q/k/v of sequence i.
+        kv_lens: [max_num_seqs]. Existing kv cache length of each sequence.
+        page_indices: [max_num_seqs * pages_per_seqs]. kv cache page table of each
+            sequence.
+        schedule: Output of scheduler kernel. It informs which: 1. seqs 2. q block
+            3. kv block that should be processed at a given step.
+        q_hbm: [max_num_tokens, num_q_heads_per_kv_heads, cdiv(num_kv_heads,
+            q_packing), q_packing, head_dim]. Output of q projection that has been
+            pre-processed to align with existing kv cache data layout.
+        new_kv_hbm: [max_num_tokens, cdiv(num_kv_heads * 2, kv_packing), kv_packing,
+            head_dim]. Output of k & v projection that has been pre-processed to align
+            with existing kv cache data layout.
+        kv_cache_hbm: [num_pages, page_size, cdiv(num_kv_heads * 2, kv_packing),
+            kv_packing, head_dim]. Stores existing kv cache data where k & vs are
+            concatenated along num kv heads dim.
+        cfgs: Configuration of the kernel.
+
+    Returns:
+        out: [max_num_tokens, num_q_heads, head_dim]. Output of self attention.
+        new_kv_cache: [num_pages, page_size, num_kv_heads // kv_packing, kv_packing,
+            head_dim]. Result of new kv cache.
+    """
 
     def ragged_paged_attention_pipeline(
-        # metadata inputs
-        cu_q_lens_ref,
-        kv_lens_ref,
-        page_indices_ref,
-        # schedule flattened (9 arrays)
-        schedule_hbm,
-        # hbm inputs
-        o_hbm_alias_q_hbm_ref,
-        new_kv_hbm_ref,
-        kv_cache_hbm_ref,
-        # output
-        o_hbm_ref,
-        kv_cache_out_ref,
-        # scratch allocations
-        schedule,
-        m_scratch,
-        l_scratch,
-        acc_scratch,
-        dma_sem,
+        # Scalar prefetch.
+        cu_q_lens_ref: jax.Ref,
+        kv_lens_ref: jax.Ref,
+        page_indices_ref: jax.Ref,
+        # Inputs.
+        schedule_hbm_ref: schedule.RPASchedule,
+        q_hbm_ref: jax.Ref,
+        new_kv_hbm_ref: jax.Ref,
+        kv_cache_hbm_ref: jax.Ref,
+        # Outputs.
+        o_hbm_ref: jax.Ref,
+        o_kv_cache_hbm_ref: jax.Ref,
     ):
 
-        # q_hbm_ref shape: [q_times_kv, max_tokens, d] or similar
-        # We use config values for dimensions where possible, or infer from refs
-        kv_heads = config.num_kv_heads
-        q_per_kv = config.num_q_heads_per_kv_head
-        d_dim = config.head_dim
-        _, _, num_kv_x2_packed, _, _ = kv_cache_hbm_ref.shape
+        del o_kv_cache_hbm_ref
 
-        q_vmem_shape = (
-            config.batch_size,
-            kv_heads,
-            config.bq_sz,
-            q_per_kv // q_packing,
-            q_packing,
-            d_dim,
-        )
-        bkv_stride: int = (kv_heads * 2) // kv_packing
+        q_alloc, kv_cache_alloc, o_alloc = create_allocs(
+            kv_cache_hbm_ref, q_hbm_ref, cfgs)
 
-        if schedule_lib.has_bank_conflicts(bkv_stride):
-            bkv_stride += 1
-
-        kv_vmem_shape = (
-            config.batch_size,
-            config.bkv_sz,
-            bkv_stride,
-            kv_packing,
-            d_dim,
+        actual_steps = schedule_hbm_ref.actual_steps[0]
+        safe_steps = jnp.minimum(actual_steps, cfgs.max_steps_ub)
+        pipeline_func = pltpu.emit_pipeline(
+            body=functools.partial(
+                rpa_body,
+                cfgs=cfgs,
+                cu_q_lens_ref=cu_q_lens_ref,
+                kv_lens_ref=kv_lens_ref,
+            ),
+            grid=(safe_steps, ),
+            in_specs=(q_alloc.spec, kv_cache_alloc.spec),
+            out_specs=(o_alloc.spec, ),
         )
 
-        def rpa_body(
-            # input
-            q_vref,
-            kv_in_vref,
-            # output
-            o_vref,
-        ):
-
-            def _strided_load_bkv(b_idx, start):
-                assert start % kv_packing == 0
-                start //= kv_packing
-                kv_ref = (kv_in_vref.bitcast(jnp.uint32).at[b_idx].reshape(
-                    config.bkv_sz * bkv_stride, config.head_dim))
-
-                if kv_packing == 1:
-                    k = utils.strided_load(
-                        kv_ref,
-                        start,
-                        config.bkv_sz * bkv_stride,
-                        bkv_stride,
-                        dtype=config.kv_dtype,
-                    )
-                    v = utils.strided_load(
-                        kv_ref,
-                        start + 1,
-                        config.bkv_sz * bkv_stride,
-                        bkv_stride,
-                        dtype=config.kv_dtype,
-                    )
-                    return [(k, v)]
-
-                kv = utils.strided_load(kv_ref, start,
-                                        config.bkv_sz * bkv_stride, bkv_stride)
-                bitwidth = 32 // kv_packing
-
-                return utils.convert_to_target_bitwidth(
-                    kv, target_bitwidth=bitwidth, kv_dtype=config.kv_dtype)
-
-            step = pl.program_id(0)
-
-            processed_q_len = []
-            processed_kv_len = []
-            effective_kv_len = []
-            int_ty = config.int_ty
-            for b in range(config.batch_size):
-                idx = step * config.batch_size + b
-                s_idx = schedule.s_idx[idx]
-                is_valid = s_idx != -1
-                q_idx = schedule.q_idx[idx]
-                k_idx = schedule.k_idx[idx]
-                k_id = lax.select(is_valid, k_idx * config.bkv_sz, 0)
-                kv_len = lax.select(is_valid, kv_lens_ref[s_idx], 0)
-                q_start = lax.select(is_valid, cu_q_lens_ref[s_idx], 0)
-                q_end = lax.select(is_valid, cu_q_lens_ref[s_idx + 1], 0)
-                q_len = q_end - q_start
-                offset = kv_len - q_len
-
-                processed_q_len.append(
-                    (q_idx * config.bq_sz + offset).astype(int_ty))
-                processed_kv_len.append(k_id.astype(int_ty))
-                effective_kv_len.append(kv_len.astype(int_ty))
-
-                start_k_idx = 0
-                if config.sliding_window is not None:
-                    sw_start_idx = (kv_len - q_len + q_idx * config.bq_sz -
-                                    config.sliding_window + 1)
-                    start_k_idx = jnp.maximum(0, sw_start_idx) // config.bkv_sz
-
-                is_first_k_block = k_idx == start_k_idx
-                reset_cond = is_valid & is_first_k_block
-                m_scratch[b] = jnp.where(reset_cond, -jnp.inf, m_scratch[b])
-                l_scratch[b] = jnp.where(reset_cond, 0.0, l_scratch[b])
-                acc_scratch[b] = jnp.where(reset_cond, 0.0, acc_scratch[b])
-
-            q_p = config.num_q_heads_per_kv_head // q_packing
-            q_ref = q_vref.bitcast(jnp.uint32).reshape(-1, config.head_dim)
-            q_loaded = utils.strided_load(
-                q_ref,
-                0,
-                config.batch_size * config.num_kv_heads * config.bq_sz * q_p,
-                1,
-                dtype=config.q_dtype,
-            )
-            q = q_loaded.reshape(
-                config.batch_size,
-                config.num_kv_heads,
-                config.bq_sz * config.num_q_heads_per_kv_head,
-                config.head_dim,
-            )
-
-            # We want to load k, v from (batch, bkv_sz, bkv_stride, kv_packing, d)
-            # where bkv_stride ~= num_kv_heads * 2 // kv_packing
-            # to 2x (batch, num_kv_heads, bkv_sz, d)
-            # We use strided_load to avoid the expensive transpose.
-            k_b = []
-            v_b = []
-            for b in range(config.batch_size):
-                heads_per_load = max(1, kv_packing // 2)
-                ks = []
-                vs = []
-                for kv_head_start in range(0, config.num_kv_heads,
-                                           heads_per_load):
-                    bkv_lst = _strided_load_bkv(
-                        b,
-                        kv_head_start * 2,
-                    )
-                    ks.append(jnp.stack([k for k, _ in bkv_lst], axis=0))
-                    vs.append(jnp.stack([v for _, v in bkv_lst], axis=0))
-                k, v = jnp.concatenate(ks, axis=0), jnp.concatenate(vs, axis=0)
-                k = k.reshape(-1, config.bkv_sz, config.head_dim)
-                v = v.reshape(-1, config.bkv_sz, config.head_dim)
-
-                k = k[:config.num_kv_heads]
-                v = v[:config.num_kv_heads]
-                k_b.append(k)
-                v_b.append(v)
-            # Stack to (batch, num_heads, bkv_sz, 128)
-            k = jnp.stack(k_b, axis=0)
-            v = jnp.stack(v_b, axis=0)
-
-            m_val = m_scratch[...]
-            l_val = l_scratch[...]
-            acc_val = acc_scratch[...]
-
-            m_next, l_next, o_next = flash_attention.flash_attention(
-                q,
-                k,
-                v,
-                acc_val,
-                m_val,
-                l_val,
-                processed_q_len=processed_q_len,
-                processed_kv_len=processed_kv_len,
-                effective_kv_len=effective_kv_len,
-                config=config,
-            )
-            m_scratch[...] = m_next
-            l_scratch[...] = l_next
-            acc_scratch[...] = o_next
-
-            @pl.loop(0, config.batch_size, unroll=True)
-            def _for_each_row(b):
-
-                def _accum():
-                    o = acc_scratch[b]
-                    l_ = l_scratch[b]
-                    l_ = jnp.tile(l_, (o.shape[-1] // l_.shape[-1], ))
-                    if config.out_dtype == jnp.float32:
-                        result = lax.div(o, l_)
-                    else:
-                        result = (o * pl.reciprocal(l_, approx=True) if
-                                  (l_.dtype == jnp.float32
-                                   and config.out_dtype != jnp.float32) else
-                                  lax.div(o, l_)).astype(config.out_dtype)
-
-                    out = result.astype(o_vref.dtype)
-                    out_ref = (o_vref.at[b].bitcast(jnp.int32).reshape(
-                        config.num_kv_heads * config.bq_sz *
-                        (config.num_q_heads_per_kv_head // q_packing),
-                        config.head_dim,
-                    ))
-                    out = pltpu.bitcast(out,
-                                        out_ref.dtype).reshape(out_ref.shape)
-                    utils.strided_store(out_ref, 0, out_ref.shape[0], 1, out)
-
-                # Adding a conditional causes a scheduling barrier. In prefill, we often
-                # use small block sizes, so it's not worth executing the accumulation
-                # on every block. In decode, because of the large block sizes / and or
-                # batch sizes, we almost always use accumulation on every block. Please
-                # tune `fuse_accum` for your use case.
-                if not config.fuse_accum:
-                    idx = step * config.batch_size + b
-                    is_last_k = schedule.is_last_k[idx] == 1
-                    jax.lax.cond(is_last_k, _accum, lambda: None)
-                else:
-                    _accum()
-
-        kv_cache_spec = pl.BlockSpec(
-            block_shape=kv_vmem_shape,
-            memory_space=pltpu.VMEM,
-            index_map=lambda i: (i, ),
-            pipeline_mode=pl.Buffered(buffer_count=config.n_buffer,
-                                      use_lookahead=True),
+        @pl.with_scoped(
+            final_allocs=(q_alloc, kv_cache_alloc, o_alloc),
+            schedule_ref=schedule_hbm_ref.scratch_shapes(),
+            dma_sem=pltpu.SemaphoreType.DMA((1, )),
+            scratches=(
+                pltpu.VMEM(
+                    cfgs.lm_scratch_shape,
+                    dtype=cfgs.serve.dtype_out,
+                ),  # m
+                pltpu.VMEM(
+                    cfgs.lm_scratch_shape,
+                    dtype=cfgs.serve.dtype_out,
+                ),  # l
+                pltpu.VMEM(
+                    cfgs.acc_scratch_shape,
+                    dtype=cfgs.serve.dtype_out,
+                ),  # acc
+            ),
         )
-        q_spec = pl.BlockSpec(
-            block_shape=q_vmem_shape,
-            memory_space=pltpu.VMEM,
-            index_map=lambda i: (i, ),
-            pipeline_mode=pl.Buffered(buffer_count=config.n_buffer,
-                                      use_lookahead=True),
-        )
-        o_spec = pl.BlockSpec(
-            block_shape=q_vmem_shape,
-            memory_space=pltpu.VMEM,
-            index_map=lambda i: (i, ),
-            pipeline_mode=pl.Buffered(buffer_count=2, use_lookahead=False),
-        )
-
-        # hbm_kv_packed_stride = (config.num_kv_heads * 2 + kv_packing - 1) // kv_packing
-        kv_cache_alloc = bref_override.KVBufferedRef.create(
-            spec=kv_cache_spec,
-            source_memory_space=kv_cache_hbm_ref,
-            bkv_p_cache=config.bkv_p_cache,
-            bkv_p_new=config.bkv_p_new,
-            page_size=config.page_size,
-            batch_size=config.batch_size,
-            hbm_stride=num_kv_x2_packed,
-            page_size_log2=config.page_size_log2,
-            page_size_mask=config.page_size_mask,
-            buffer_count=config.n_buffer,
-            use_lookahead=True,
-        )
-        q_alloc = bref_override.BatchingQRef.create(
-            spec=q_spec,
-            source_memory_space=o_hbm_alias_q_hbm_ref,
-            bq_sz=config.bq_sz,
-            batch_size=config.batch_size,
-            buffer_count=config.n_buffer,
-            use_lookahead=True,
-        )
-        o_alloc = bref_override.BatchingORef.create(
-            spec=o_spec,
-            source_memory_space=o_hbm_ref,
-            batch_size=config.batch_size,
-            buffer_count=2,
-            use_lookahead=False,
-        )
-
-        def _run(final_allocs):
-            actual_steps = schedule_hbm.actual_steps[0]
-            safe_steps = jnp.minimum(actual_steps, config.max_steps_ub)
-            grid = (safe_steps, )
+        def _run(final_allocs, schedule_ref, dma_sem, scratches):
 
             # Transfer schedule from HBM to SMEM --- we only copy what we need. Since
-            # we almost always over-allocate schedule size, we only want to copy a small
-            # portion of it from HBM to SMEM.
-            sem = dma_sem.at[0]
-            flat_hbm = jax.tree_util.tree_leaves(schedule_hbm)
-            flat_smem = jax.tree_util.tree_leaves(schedule)
+            # we almost always over-allocate schedule size, we only want to copy a
+            # small portion of it from HBM to SMEM.
+            flat_hbm = jax.tree_util.tree_leaves(schedule_hbm_ref)
+            flat_smem = jax.tree_util.tree_leaves(schedule_ref)
             dma_list = []
             for h, s in zip(flat_hbm, flat_smem):
-                if h.shape[0] != 1:
-                    fetch_size = (h.shape[0] //
-                                  config.max_steps_ub) * safe_steps
-                    fetch_size = pl.cdiv(fetch_size, 1024) * 1024
+                if h.memory_space == pltpu.HBM:
+                    read_size = (h.shape[0] // cfgs.max_steps_ub) * safe_steps
+                    read_size = utils.align_to(read_size, 1024)
 
                     copy = pltpu.make_async_copy(
-                        h.at[pl.ds(0, fetch_size)],
-                        s.at[pl.ds(0, fetch_size)],
-                        sem,
+                        h.at[pl.ds(0, read_size)],
+                        s.at[pl.ds(0, read_size)],
+                        dma_sem.at[0],
                     )
                     copy.start()
                     dma_list.append(copy)
 
-            # Initialize KV cache to zeros
-            kv_alloc = final_allocs[1]
+            # Initialize KV cache to zeros.
+            # When perfomring p * v, we perform causal masking on lhs (p) by zeroing
+            # out columns that should not be processed for a given row. Even if we
+            # don't perform masking on rows of rhs (v), the output is still correct
+            # since reuslt of multiplication will be zero thanks zero on lhs. However,
+            # this assumption does not hold if a row of rhs has NaNs. To avoid this,
+            # we initiallize scratch memory with non-zero values. Even if the scratch
+            # memory is storing kv cache from previous step, as long as the data is
+            # not NaNs, there will be no numeric concerns.
             num_lanes = pltpu.get_tpu_info().num_lanes
+            kv_alloc = final_allocs[1]
             kv_ref_flat = kv_alloc.window_ref.bitcast(jnp.uint32).reshape(
                 -1, num_lanes)
             kv_ref_flat[...] = jnp.zeros_like(kv_ref_flat)
 
-            for copy in dma_list:
-                copy.wait()
-
-            pipeline_func = pipeline.emit_pipeline(
-                body=rpa_body,
-                grid=grid,
-                in_specs=[
-                    q_spec,
-                    kv_cache_spec,
-                ],
-                out_specs=[
-                    o_spec,
-                ],
-            )
+            jax.tree.map(lambda x: x.wait(), dma_list)
 
             pipeline_func(
-                (o_hbm_alias_q_hbm_ref, schedule),
-                (kv_cache_hbm_ref, new_kv_hbm_ref, schedule, page_indices_ref),
-                (o_hbm_ref, schedule),
+                (q_hbm_ref, schedule_ref),
+                (kv_cache_hbm_ref, new_kv_hbm_ref, schedule_ref,
+                 page_indices_ref),
+                (o_hbm_ref, schedule_ref),
+                scratches=(schedule_ref, ) + scratches,
                 allocations=final_allocs,
             )
 
-        return pl.run_scoped(_run, (q_alloc, kv_cache_alloc, o_alloc))
+        _run()
 
-    num_pages = config.num_seq * config.pages_per_seq
-    if config.total_num_pages is not None:
-        num_pages = config.total_num_pages
-    num_kv_heads_x2_packed = (config.num_kv_heads * 2 + kv_packing -
-                              1) // kv_packing
-
-    out_shape = [
-        jax.ShapeDtypeStruct(
-            (
-                config.num_kv_heads,
-                config.total_q_tokens,
-                config.num_q_heads_per_kv_head // q_packing,
-                q_packing,
-                config.head_dim,
-            ),
-            config.q_dtype,
-        ),
-        jax.ShapeDtypeStruct(
-            (
-                num_pages,
-                config.page_size,
-                num_kv_heads_x2_packed,
-                kv_packing,
-                config.head_dim,
-            ),
-            config.kv_dtype,
-        ),
-    ]
-
-    schedule_shapes = schedule_lib.RPASchedule.smem_specs(config)
-    scratch_shapes = [
-        schedule_shapes,
-        pltpu.VMEM(
-            (
-                config.batch_size,
-                config.num_kv_heads,
-                config.bq_sz * config.num_q_heads_per_kv_head,
-                128,
-            ),
-            dtype=config.out_dtype,
-        ),  # m
-        pltpu.VMEM(
-            (
-                config.batch_size,
-                config.num_kv_heads,
-                config.bq_sz * config.num_q_heads_per_kv_head,
-                128,
-            ),
-            dtype=config.out_dtype,
-        ),  # l
-        pltpu.VMEM(
-            (
-                config.batch_size,
-                config.num_kv_heads,
-                config.bq_sz * config.num_q_heads_per_kv_head,
-                config.head_dim,
-            ),
-            dtype=config.out_dtype,
-        ),  # acc
-        pltpu.SemaphoreType.DMA((1, )),  # dma_sem
-    ]
-    in_specs = [
-        schedule_lib.RPASchedule.kernel_in_specs(config),  # 9 refs
-        pl.BlockSpec(memory_space=pltpu.HBM),  # o_hbm_alias_q_hbm_ref
-        pl.BlockSpec(memory_space=pltpu.HBM),  # new_kv_hbm_ref
-        pl.BlockSpec(memory_space=pltpu.HBM),  # kv_cache_hbm_ref
-    ]
-    input_output_aliases = {12: 0, 14: 1}
-
-    scope_name = f"RPA{config.case.symbol}-p{config.page_size}-b{config.batch_size}-q{config.bq_sz}-k{config.bkv_sz}"
-    if config.sliding_window:
-        scope_name += f"-sw{config.sliding_window}"
-    _kernel = pl.pallas_call(
+    return pl.pallas_call(
         ragged_paged_attention_pipeline,
-        out_shape=out_shape,
+        out_shape=[q_hbm, kv_cache_hbm],
         grid_spec=pltpu.PrefetchScalarGridSpec(
-            grid=(1, ),
             num_scalar_prefetch=3,
-            in_specs=in_specs,
-            out_specs=[
-                pl.BlockSpec(memory_space=pltpu.HBM),  # o_hbm_ref
-                pl.BlockSpec(memory_space=pltpu.HBM),  # kv_cache_out_ref
+            in_specs=[
+                schedule_hbm.in_specs(),
+                pl.BlockSpec(memory_space=pltpu.HBM),  # q_hbm_ref
+                pl.BlockSpec(memory_space=pltpu.HBM),  # new_kv_hbm_ref
+                pl.BlockSpec(memory_space=pltpu.HBM),  # kv_cache_hbm_ref
             ],
-            scratch_shapes=scratch_shapes,
+            out_specs=[
+                pl.BlockSpec(memory_space=pltpu.HBM),  # aliased_o_hbm_ref
+                pl.BlockSpec(
+                    memory_space=pltpu.HBM),  # aliased_kv_cache_hbm_ref
+            ],
         ),
         compiler_params=pltpu.CompilerParams(
-            dimension_semantics=("arbitrary", ),
-            vmem_limit_bytes=config.vmem_limit_bytes,
+            vmem_limit_bytes=cfgs.vmem_limit_bytes,
             disable_bounds_checks=True,
         ),
-        input_output_aliases=input_output_aliases,
-        name=scope_name,
+        input_output_aliases={
+            12: 0,
+            14: 1
+        },
+        name=get_kernel_name(cfgs),
+        metadata=get_kernel_metadata(cfgs),
+    )(
+        cu_q_lens,
+        kv_lens,
+        page_indices,
+        schedule_hbm,
+        q_hbm,
+        new_kv_hbm,
+        kv_cache_hbm,
     )
-
-    def _wrap_kernel_in_hbm_constraints(
-        cu_q_lens_ref,
-        kv_lens_ref,
-        page_indices_ref,
-        schedule_hbm_ref,
-        o_hbm_alias_q_hbm_ref,
-        new_kv_hbm_ref,
-        kv_cache_hbm_ref,
-    ):
-
-        def _constrain_hbm(path, x):
-            for p in path:
-                key = getattr(p, "name", getattr(p, "key", None))
-                if key == "actual_steps":
-                    return x
-            return pltpu.with_memory_space_constraint(x, pltpu.HBM)
-
-        constrained_schedule_hbm_ref = jax.tree_util.tree_map_with_path(
-            _constrain_hbm, schedule_hbm_ref)
-        return _kernel(
-            cu_q_lens_ref,
-            kv_lens_ref,
-            page_indices_ref,
-            constrained_schedule_hbm_ref,
-            pltpu.with_memory_space_constraint(o_hbm_alias_q_hbm_ref,
-                                               pltpu.HBM),
-            pltpu.with_memory_space_constraint(new_kv_hbm_ref, pltpu.HBM),
-            pltpu.with_memory_space_constraint(kv_cache_hbm_ref, pltpu.HBM),
-        )
-
-    return _wrap_kernel_in_hbm_constraints

--- a/tpu_inference/kernels/experimental/batched_rpa/schedule.py
+++ b/tpu_inference/kernels/experimental/batched_rpa/schedule.py
@@ -14,549 +14,454 @@
 
 import dataclasses
 import functools
-from enum import Enum
 from typing import Any
 
 import jax
 import jax.numpy as jnp
-from jax._src import dtypes
+import numpy as np
 from jax.experimental import pallas as pl
 from jax.experimental.pallas import tpu as pltpu
 
-
-class RpaCase(Enum):
-    """Represents the different cases for Ragged Paged Attention.
-
-  - DECODE: Sequences are in decode-only mode (q_len = 1).
-  - PREFILL: Sequences are in prefill-only mode (q_len > 1, static).
-  - MIXED: Sequences can be a mix of prefill and decode (q_len > 1, dynamic).
-  """
-
-    DECODE = 0
-    PREFILL = 1
-    MIXED = 2
-
-    @property
-    def symbol(self):
-        return {
-            RpaCase.DECODE: "d",
-            RpaCase.PREFILL: "p",
-            RpaCase.MIXED: "m",
-        }[self]
-
-    def get_range(self, distribution):
-        assert distribution.shape == (3, )
-        if self == RpaCase.DECODE:
-            return 0, distribution[0]
-        elif self == RpaCase.PREFILL:
-            return distribution[0], distribution[1]
-        elif self == RpaCase.MIXED:
-            return distribution[1], distribution[2]
-        else:
-            raise ValueError(f"Unsupported RPA case: {self}")
+from tpu_inference.kernels.experimental.batched_rpa import configs, utils
 
 
 @jax.tree_util.register_dataclass
-@dataclasses.dataclass(frozen=True, eq=True)
-class RPAConfig:
-    num_seq: int
-    bq_sz: int
-    bkv_sz: int
-    batch_size: int
-    page_size: int
-    bkv_p: int
-    pages_per_seq: int
-    max_steps_ub: int
-    total_q_tokens: int
-    total_num_pages: int | None = None
-    head_dim: int = 128
-    num_kv_heads: int = 8
-    sm_scale: float = 1.0
-    soft_cap: Any = None
-    num_q_heads_per_kv_head: int = 1
-    sliding_window: Any = None
-    mask_value: float = -1e30
-    q_dtype: Any = jnp.bfloat16
-    kv_dtype: Any = jnp.bfloat16
-    q_scale: Any = None
-    k_scale: Any = None
-    v_scale: Any = None
-    vmem_limit_bytes: int | None = None
-    case: RpaCase = RpaCase.MIXED
-    n_buffer: int = 2
-    out_dtype: Any = jnp.bfloat16
-    fuse_accum: bool = False
-    mask_v: bool = True
+@dataclasses.dataclass(frozen=True)
+class SmemWrapper:
+    """Maps physical 1-D data into logical N-D representation."""
 
-    @property
-    def bkv_p_cache(self) -> int:
-        if self.case == RpaCase.PREFILL:
-            return 0
-        return self.bkv_p
+    data: Any
+    shape: tuple[int, ...] = dataclasses.field(metadata=dict(static=True))
 
-    @property
-    def bkv_p_new(self) -> int:
-        if self.case == RpaCase.DECODE:
-            return 1
-        return self.bkv_p
+    @classmethod
+    def create_shape_dtype(cls, shape):
+        return cls(data=jax.ShapeDtypeStruct((np.prod(shape), ), jnp.int32),
+                   shape=shape)
 
-    @property
-    def num_page_indices(self) -> int:
-        return self.num_seq * self.pages_per_seq
+    def _get_pos(self, indices):
+        strides = pl.strides_from_shape(self.shape)
+        assert len(strides) == len(indices)
 
-    @property
-    def page_size_log2(self) -> int:
-        return (self.page_size - 1).bit_length()
+        pos = 0
+        for stride, idx in zip(strides, indices):
+            pos += stride * idx
+        return pos
 
-    @property
-    def page_size_mask(self) -> int:
-        return self.page_size - 1
+    def __getitem__(self, indices):
+        return self.data[self._get_pos(indices)]
 
-    @property
-    def int_ty(self) -> Any:
-        if (get_dtype_packing(self.q_dtype) != 1
-                and pltpu.get_tpu_info().generation >= 6):
-            return jnp.int16
-        return jnp.int32
+    def __setitem__(self, indices, value):
+        self.data[self._get_pos(indices)] = value
 
 
-def get_dtype_bitwidth(dtype):
-    return dtypes.itemsize_bits(dtype)
-
-
-def get_dtype_packing(dtype):
-    bits = get_dtype_bitwidth(dtype)
-    return 32 // bits
-
-
-def has_bank_conflicts(stride: int, distance=24, num_banks=32) -> bool:
-    banks = set()
-    for i in range(distance):
-        bank = (i * stride) % num_banks
-        if bank in banks:
-            return True
-        banks.add(bank)
-    return False
-
-
-@jax.tree_util.register_pytree_node_class
+@jax.tree_util.register_dataclass
 @dataclasses.dataclass(frozen=True)
 class RPASchedule:
     """Container for metadata arrays with integrated shape/spec logic."""
 
-    s_idx: Any
-    q_idx: Any
-    k_idx: Any
-    is_last_k: Any  # [steps * batch]
-    do_writeback: Any  # [steps * batch]
-    dma_q: Any  # [steps * batch * 2]
-    dma_kv_cache: Any  # [steps * batch * bkv_p_cache * 3]
-    dma_kv_new: Any  # [steps * batch * bkv_p_new * 4]
-    actual_steps: Any
-    batch_size: int = dataclasses.field(default=0, metadata={"static": True})
-    bkv_p_cache: int = dataclasses.field(default=0, metadata={"static": True})
-    bkv_p_new: int = dataclasses.field(default=0, metadata={"static": True})
+    s_idx: SmemWrapper  # [steps, batch]
+    q_idx: SmemWrapper  # [steps, batch]
+    k_idx: SmemWrapper  # [steps, batch]
+    is_last_k: SmemWrapper  # [steps, batch]
+    do_writeback: SmemWrapper  # [steps, batch]
+    dma_q: SmemWrapper  # [steps, batch, 2]
+    dma_kv_cache: SmemWrapper  # [steps, batch, bkv_p_cache, 3]
+    dma_kv_new: SmemWrapper  # [steps, batch, bkv_p_new, 4]
+    actual_steps: Any  # [1]
 
-    def tree_flatten(self):
-        return (
-            self.s_idx,
-            self.q_idx,
-            self.k_idx,
-            self.is_last_k,
-            self.do_writeback,
-            self.dma_q,
-            self.dma_kv_cache,
-            self.dma_kv_new,
-            self.actual_steps,
-        ), (self.batch_size, self.bkv_p_cache, self.bkv_p_new)
+    cfgs: configs.RPAConfig = dataclasses.field(metadata=dict(static=True))
 
     @classmethod
-    def tree_unflatten(cls, aux, children):
+    def create_shape_dtype(cls, cfgs: configs.RPAConfig):
+
+        idx_wrapper = SmemWrapper.create_shape_dtype(
+            (cfgs.max_steps_ub, cfgs.batch_size))
+
         return cls(
-            *children,
-            batch_size=aux[0],
-            bkv_p_cache=aux[1],
-            bkv_p_new=aux[2],
+            s_idx=idx_wrapper,
+            q_idx=idx_wrapper,
+            k_idx=idx_wrapper,
+            is_last_k=idx_wrapper,
+            do_writeback=idx_wrapper,
+            dma_q=SmemWrapper.create_shape_dtype(
+                (cfgs.max_steps_ub, cfgs.batch_size, 2)),
+            dma_kv_cache=SmemWrapper.create_shape_dtype(
+                (cfgs.max_steps_ub, cfgs.batch_size, cfgs.bkv_p_cache, 3)),
+            dma_kv_new=SmemWrapper.create_shape_dtype(
+                (cfgs.max_steps_ub, cfgs.batch_size, cfgs.bkv_p_new, 4), ),
+            actual_steps=jax.ShapeDtypeStruct((1, ), jnp.int32),
+            cfgs=cfgs,
         )
 
-    num_metadata_arrays = 9
-
-    def get_dma_kv_cache(self, step: int, batch_idx: int,
-                         page_idx: int) -> tuple[int, int, int]:
-        # Stride is 3: src_hbm, dst_vmem, size
-        cache_step_stride = self.batch_size * self.bkv_p_cache * 3
-        cache_batch_stride = self.bkv_p_cache * 3
-        idx = (step * cache_step_stride + batch_idx * cache_batch_stride +
-               page_idx * 3)
+    def get_dma_kv_cache(
+        self,
+        step: jax.typing.ArrayLike,
+        batch_idx: jax.typing.ArrayLike,
+        page_idx: jax.typing.ArrayLike,
+    ) -> tuple[jax.Array, jax.Array, jax.Array]:
         # 0: src_hbm, 1: dst_vmem, 2: size
-        src_off = self.dma_kv_cache[idx + 0]
-        dst_off = self.dma_kv_cache[idx + 1]
-        sz = self.dma_kv_cache[idx + 2]
+        src_off = self.dma_kv_cache[step, batch_idx, page_idx, 0]
+        dst_off = self.dma_kv_cache[step, batch_idx, page_idx, 1]
+        sz = self.dma_kv_cache[step, batch_idx, page_idx, 2]
         return src_off, dst_off, sz
 
-    def get_dma_kv_new(self, step: int, batch_idx: int,
-                       page_idx: int) -> tuple[int, int, int, int]:
-        # Stride is 4: dst_hbm, src_hbm, dst_vmem, size
-        new_step_stride = self.batch_size * self.bkv_p_new * 4
-        base_idx = (step * new_step_stride + batch_idx * self.bkv_p_new * 4 +
-                    page_idx * 4)
+    def get_dma_kv_new(
+        self,
+        step: jax.typing.ArrayLike,
+        batch_idx: jax.typing.ArrayLike,
+        page_idx: jax.typing.ArrayLike,
+    ) -> tuple[jax.Array, jax.Array, jax.Array, jax.Array]:
         # 0: dst_hbm, 1: src_hbm, 2: dst_vmem, 3: size
-        dst_hbm = self.dma_kv_new[base_idx + 0]
-        src_hbm = self.dma_kv_new[base_idx + 1]
-        dst_vmem = self.dma_kv_new[base_idx + 2]
-        sz = self.dma_kv_new[base_idx + 3]
+        dst_hbm = self.dma_kv_new[step, batch_idx, page_idx, 0]
+        src_hbm = self.dma_kv_new[step, batch_idx, page_idx, 1]
+        dst_vmem = self.dma_kv_new[step, batch_idx, page_idx, 2]
+        sz = self.dma_kv_new[step, batch_idx, page_idx, 3]
         return dst_hbm, src_hbm, dst_vmem, sz
 
-    def get_dma_q(self, step: int, batch_idx: int) -> tuple[int, int]:
-        # Stride is 2: src_hbm, size
-        q_step_stride = self.batch_size * 2
-        base_idx = step * q_step_stride + batch_idx * 2
+    def get_dma_q(
+            self, step: jax.typing.ArrayLike,
+            batch_idx: jax.typing.ArrayLike) -> tuple[jax.Array, jax.Array]:
         # 0: src_hbm, 1: size
-        src_hbm = self.dma_q[base_idx + 0]
-        sz = self.dma_q[base_idx + 1]
+        src_hbm = self.dma_q[step, batch_idx, 0]
+        sz = self.dma_q[step, batch_idx, 1]
         return src_hbm, sz
 
-    @classmethod
-    def _map_shapes(cls, config: RPAConfig, wrapper):
-        bs = config.batch_size
-        steps = config.max_steps_ub
-        return cls(
-            s_idx=wrapper((steps * bs, ), is_smem=False),
-            q_idx=wrapper((steps * bs, ), is_smem=False),
-            k_idx=wrapper((steps * bs, ), is_smem=False),
-            is_last_k=wrapper((steps * bs, ), is_smem=False),
-            do_writeback=wrapper((steps * bs, ), is_smem=False),
-            dma_q=wrapper((steps * bs * 2, ), is_smem=False),
-            # we do this hacky workaround because xla throws an error if we have
-            # zero-sized tensors.
-            dma_kv_cache=wrapper(
-                (max(1, steps * bs * config.bkv_p_cache * 3), ),
-                is_smem=False),
-            dma_kv_new=wrapper((max(1, steps * bs * config.bkv_p_new * 4), ),
-                               is_smem=False),
-            # this needs to be in SMEM when we prefetch it so we can read from it immediately
-            actual_steps=wrapper((1, ), is_smem=True),
-            batch_size=bs,
-            bkv_p_cache=config.bkv_p_cache,
-            bkv_p_new=config.bkv_p_new,
+    def scratch_shapes(self):
+        """Returns a Pytree of SMEM scratch memory."""
+
+        return jax.tree.map(
+            lambda x: pltpu.SMEM(x.shape, x.dtype),
+            self,
         )
 
-    @classmethod
-    def out_shape(cls, config: RPAConfig):
-        """Returns a Pytree of ShapeDtypeStruct for pallas_call."""
-        return cls._map_shapes(
-            config,
-            lambda shape, is_smem=False: jax.ShapeDtypeStruct(
-                shape, jnp.int32),
+    def in_specs(self):
+        """Returns a Pytree of input BlockSpecs."""
+
+        def wrapper(x):
+            if x.size == 1:
+                return pl.BlockSpec(memory_space=pltpu.SMEM)
+            else:
+                # Since we use maximum upper bound when allocating scheduler data,
+                # it is not feasible to use scalar prefetch and fetch entire scheduler
+                # data into the kernel. Instead, we stored it to HBM first and perform
+                # dynamic sized DMA inside the kernel using actual number of steps.
+                return pl.BlockSpec(memory_space=pltpu.HBM)
+
+        return jax.tree.map(wrapper, self)
+
+    def out_specs(self):
+        """Returns a Pytree of output BlockSpecs."""
+
+        return jax.tree.map(
+            lambda x: pl.BlockSpec(memory_space=pltpu.HBM),
+            self,
         )
 
-    @classmethod
-    def hbm_specs(cls, config: RPAConfig):
-        """Returns a Pytree of BlockSpecs in HBM matching the output structure."""
 
-        def wrapper(shape, is_smem=False):
-            return pl.BlockSpec(memory_space=pltpu.HBM, block_shape=shape)
-
-        return cls._map_shapes(config, wrapper)
-
-    @classmethod
-    def kernel_in_specs(cls, config: RPAConfig):
-        """Returns a Pytree of BlockSpecs for passing schedule to kernel."""
-
-        def wrapper(shape, is_smem=False):
-            memory_space = pltpu.SMEM if is_smem else pltpu.HBM
-            return pl.BlockSpec(memory_space=memory_space, block_shape=shape)
-
-        return cls._map_shapes(config, wrapper)
-
-    @classmethod
-    def out_specs(cls, config: RPAConfig):
-        """Returns a Pytree of BlockSpecs matching the output structure."""
-
-        def wrapper(shape, is_smem=False):
-            return pl.BlockSpec(memory_space=pltpu.SMEM, block_shape=shape)
-
-        return cls._map_shapes(config, wrapper)
-
-    @classmethod
-    def smem_specs(cls, config: RPAConfig):
-        """Returns a Pytree of pltpu.SMEM matching the output structure."""
-        return cls._map_shapes(
-            config, lambda shape, is_smem=False: pltpu.SMEM(shape, jnp.int32))
-
-
-def rpa_metadata_schedule_kernel(
-    ## HBM inputs
-    cu_q_lens_ref,
-    kv_lens_ref,
-    distribution_ref,
-    # output
-    schedule_hbm: RPASchedule,
-    # scratch
+def compute_metadata(
+    cu_q_lens_ref: jax.Ref,
+    kv_lens_ref: jax.Ref,
+    distribution_ref: jax.Ref,
     schedule: RPASchedule,
-    lane_lengths_ref,
-    dma_sem,
+    lane_lengths_ref: jax.Ref,
     *,
-    config: RPAConfig,
+    cfgs: configs.RPAConfig,
 ):
-    """Generates the HBM-to-VMEM DMA schedule
+    """Fill metadata using triple nested loop of seq->q->k loop."""
 
-  This kernel:
-  1. Iterates through each (potentially ragged) sequence
-  2. Breaks Queries (Q) and Key-Values (KV) into blocks (bq_sz, bkv_sz).
-  3. Assigns tasks to 'lanes' (TPU batch items) based on current lane occupancy
-     to ensure balanced execution across the batch dimension.
-  4. Encodes DMA offsets:
-     - dma_q: HBM start index and size for Query blocks.
-     - dma_kv_cache: Paged indices for existing KV tokens.
-     - dma_kv_new: offsets for new tokens being added to the cache.
-     - do_writeback: boolean flag indicating if a block should be flushed to
-     HBM (ie does this block contain new tokens to add to KV cache).
+    @jax.named_scope("k_loop")
+    def k_loop(
+        k_idx,
+        step,
+        *,
+        target_lane,
+        s_idx,
+        q_idx,
+        q_end,
+        q_src,
+        q_sz_task,
+        k_len,
+        q_len,
+        end_k_idx,
+    ):
 
-  Check bref_override.py to check usage of the schedule.
-  """
-    for b in range(config.batch_size):
-        lane_lengths_ref[b] = 0
+        schedule.s_idx[step, target_lane] = s_idx
+        schedule.q_idx[step, target_lane] = q_idx
+        schedule.k_idx[step, target_lane] = k_idx
 
+        is_last_k = jnp.where(k_idx == end_k_idx - 1, 1, 0)
+        schedule.is_last_k[step, target_lane] = is_last_k
+
+        schedule.dma_q[step, target_lane, 0] = q_src
+        schedule.dma_q[step, target_lane, 1] = q_sz_task
+
+        kv_len_start = k_idx * cfgs.bkv_sz
+        kv_p_start = k_idx * cfgs.bkv_p
+        kv_left = k_len - kv_len_start
+        kv_left_frm_cache = jnp.maximum(kv_left - q_len, 0)
+        p_offset = s_idx * cfgs.serve.pages_per_seq + kv_p_start
+
+        for i in range(cfgs.bkv_p_cache):
+            dst_vmem = i << cfgs.serve.page_size_log2
+            dma_sz = kv_left_frm_cache - dst_vmem
+            dma_sz = jnp.clip(dma_sz, 0, cfgs.serve.page_size)
+
+            src_hbm = jnp.minimum(p_offset + i,
+                                  cfgs.serve.num_page_indices - 1)
+
+            schedule.dma_kv_cache[step, target_lane, i, 0] = src_hbm
+            schedule.dma_kv_cache[step, target_lane, i, 1] = dst_vmem
+            schedule.dma_kv_cache[step, target_lane, i, 2] = dma_sz
+
+        kv_left_frm_new = kv_left - kv_left_frm_cache
+        bkv_sz_cache = jnp.minimum(kv_left_frm_cache, cfgs.bkv_sz)
+        new_sz = jnp.minimum(cfgs.bkv_sz - bkv_sz_cache, kv_left_frm_new)
+
+        # Writeback logic: each new k block is written back by the first q block
+        # that attends to it.
+        q_wb = jnp.maximum(0, (kv_len_start - (k_len - q_len))) // cfgs.bq_sz
+
+        do_writeback = jnp.where((new_sz > 0) & (q_idx == q_wb), 1, 0)
+        schedule.do_writeback[step, target_lane] = do_writeback
+        src_hbm = q_end - kv_left_frm_new
+
+        if cfgs.bkv_p_new < cfgs.bkv_p:
+            # Special case where we only need to write back one page.
+            assert cfgs.bkv_p_new == 1
+            dst_vmem = bkv_sz_cache
+            dma_sz = new_sz
+
+            p_idx = (kv_len_start + dst_vmem) >> cfgs.serve.page_size_log2
+            p_idx = jnp.minimum(p_idx, cfgs.serve.pages_per_seq - 1)
+            p_off = (kv_len_start + dst_vmem) & cfgs.serve.page_size_mask
+            global_p_idx = s_idx * cfgs.serve.pages_per_seq + p_idx
+
+            dst_hbm = (global_p_idx << cfgs.serve.page_size_log2) | p_off
+            schedule.dma_kv_new[step, target_lane, 0, 0] = dst_hbm
+            schedule.dma_kv_new[step, target_lane, 0, 1] = src_hbm
+            schedule.dma_kv_new[step, target_lane, 0, 2] = dst_vmem
+            schedule.dma_kv_new[step, target_lane, 0, 3] = dma_sz
+        else:
+            for i in range(cfgs.bkv_p):
+                slot_start = i << cfgs.serve.page_size_log2
+                slot_end = (i + 1) << cfgs.serve.page_size_log2
+
+                dst_vmem = jnp.maximum(slot_start, bkv_sz_cache)
+                end_in_slot = jnp.minimum(slot_end, bkv_sz_cache + new_sz)
+                dma_sz = jnp.maximum(0, end_in_slot - dst_vmem)
+
+                p_idx = (kv_len_start + dst_vmem) >> cfgs.serve.page_size_log2
+                p_idx = jnp.minimum(p_idx, cfgs.serve.pages_per_seq - 1)
+                p_off = (kv_len_start + dst_vmem) & cfgs.serve.page_size_mask
+                global_p_idx = s_idx * cfgs.serve.pages_per_seq + p_idx
+
+                dst_hbm = (global_p_idx << cfgs.serve.page_size_log2) | p_off
+                schedule.dma_kv_new[step, target_lane, i, 0] = dst_hbm
+                schedule.dma_kv_new[step, target_lane, i, 1] = src_hbm
+                schedule.dma_kv_new[step, target_lane, i, 2] = dst_vmem
+                schedule.dma_kv_new[step, target_lane, i, 3] = dma_sz
+
+        return step + 1
+
+    @jax.named_scope("q_loop")
+    def q_loop(q_idx, _, *, s_idx, q_start, q_end, k_len, q_len, num_k):
+        target_lane = 0
+        min_len = lane_lengths_ref[0]
+        for b in range(1, cfgs.batch_size):
+            is_better = lane_lengths_ref[b] < min_len
+            target_lane = jnp.where(is_better, b, target_lane)
+            min_len = jnp.where(is_better, lane_lengths_ref[b], min_len)
+
+        curr_ptr = lane_lengths_ref[target_lane]
+        q_src = q_start + q_idx * cfgs.bq_sz
+        q_sz_task = jnp.clip(q_end - q_src, 0, cfgs.bq_sz)
+
+        start_k_idx = 0
+        if (sliding_window := cfgs.model.sliding_window) is not None:
+            sw_start_idx = k_len - q_len + q_idx * cfgs.bq_sz - sliding_window + 1
+            start_k_idx = jnp.maximum(0, sw_start_idx) // cfgs.bkv_sz
+
+        end_k_idx_causal = (k_len - q_len + q_idx * cfgs.bq_sz + q_sz_task -
+                            1) // cfgs.bkv_sz + 1
+        end_k_idx = jnp.minimum(num_k, end_k_idx_causal)
+
+        k_loop_fn = functools.partial(
+            k_loop,
+            target_lane=target_lane,
+            s_idx=s_idx,
+            q_idx=q_idx,
+            q_end=q_end,
+            q_src=q_src,
+            q_sz_task=q_sz_task,
+            k_len=k_len,
+            q_len=q_len,
+            end_k_idx=end_k_idx,
+        )
+        lane_lengths_ref[target_lane] = jax.lax.fori_loop(
+            start_k_idx, end_k_idx, k_loop_fn, curr_ptr)
+
+    @jax.named_scope("seq_loop")
     def seq_loop(s_idx, _):
         q_start = cu_q_lens_ref[s_idx]
         q_end = cu_q_lens_ref[s_idx + 1]
         k_len = kv_lens_ref[s_idx]
         q_len = q_end - q_start
 
-        n_q = (q_len + config.bq_sz - 1) // config.bq_sz
-        n_k = (k_len + config.bkv_sz - 1) // config.bkv_sz
+        num_q = pl.cdiv(q_len, cfgs.bq_sz)
+        num_k = pl.cdiv(k_len, cfgs.bkv_sz)
 
-        def q_loop(q_idx, _):
-            target_lane = 0
-            min_len = lane_lengths_ref[0]
-            for b in range(1, config.batch_size):
-                is_better = lane_lengths_ref[b] < min_len
-                target_lane = jnp.where(is_better, b, target_lane)
-                min_len = jnp.where(is_better, lane_lengths_ref[b], min_len)
+        q_loop_fn = functools.partial(
+            q_loop,
+            s_idx=s_idx,
+            q_start=q_start,
+            q_end=q_end,
+            k_len=k_len,
+            q_len=q_len,
+            num_k=num_k,
+        )
 
-            curr_ptr = lane_lengths_ref[target_lane]
-            q_src = q_start + q_idx * config.bq_sz
-            q_sz_task = jnp.clip(q_end - q_src, 0, config.bq_sz)
+        jax.lax.fori_loop(0, num_q, q_loop_fn, None)
 
-            start_k_idx = 0
-            if config.sliding_window is not None:
-                sw_start_idx = (k_len - q_len + q_idx * config.bq_sz -
-                                config.sliding_window + 1)
-                start_k_idx = jnp.maximum(0, sw_start_idx) // config.bkv_sz
-
-            end_k_idx_causal = (k_len - q_len + q_idx * config.bq_sz +
-                                q_sz_task - 1) // config.bkv_sz + 1
-            end_k_idx = jnp.minimum(n_k, end_k_idx_causal)
-
-            def k_loop(k_idx, curr_ptr):
-
-                idx = curr_ptr * config.batch_size + target_lane
-                schedule.s_idx[idx] = s_idx
-                schedule.q_idx[idx] = q_idx
-                schedule.k_idx[idx] = k_idx
-                schedule.is_last_k[idx] = jnp.asarray(k_idx == end_k_idx - 1,
-                                                      dtype=jnp.int32)
-
-                q_idx_base = curr_ptr * (config.batch_size *
-                                         2) + target_lane * 2
-                schedule.dma_q[q_idx_base + 0] = q_src
-                schedule.dma_q[q_idx_base + 1] = q_sz_task
-
-                kv_len_start = k_idx * config.bkv_sz
-                kv_p_start = k_idx * config.bkv_p
-                kv_left = k_len - kv_len_start
-                kv_left_frm_cache = jnp.maximum(kv_left - q_len, 0)
-                p_offset = s_idx * config.pages_per_seq + kv_p_start
-
-                kv_cache_base = curr_ptr * (
-                    config.batch_size * config.bkv_p_cache *
-                    3) + target_lane * (config.bkv_p_cache * 3)
-                for i in range(config.bkv_p_cache):
-                    sz = jnp.clip(
-                        kv_left_frm_cache - (i << config.page_size_log2),
-                        0,
-                        config.page_size,
-                    )
-                    p_idx = jnp.minimum(p_offset + i,
-                                        config.num_page_indices - 1)
-
-                    base_i = kv_cache_base + i * 3
-                    schedule.dma_kv_cache[base_i + 0] = p_idx
-                    schedule.dma_kv_cache[base_i +
-                                          1] = i << config.page_size_log2
-                    schedule.dma_kv_cache[base_i + 2] = sz
-
-                kv_left_frm_new = kv_left - kv_left_frm_cache
-                bkv_sz_cache = jnp.minimum(kv_left_frm_cache, config.bkv_sz)
-                new_sz = jnp.minimum(config.bkv_sz - bkv_sz_cache,
-                                     kv_left_frm_new)
-
-                # Writeback logic: each new k block is written back by the first q block that attends to it.
-                q_wb = jnp.maximum(0, (k_idx * config.bkv_sz -
-                                       (k_len - q_len)) // config.bq_sz)
-                schedule.do_writeback[idx] = jnp.asarray(
-                    (new_sz > 0) & (q_idx == q_wb), dtype=jnp.int32)
-
-                kv_new_base = curr_ptr * (
-                    config.batch_size * config.bkv_p_new *
-                    4) + target_lane * (config.bkv_p_new * 4)
-
-                if config.case == RpaCase.DECODE:
-                    # During DECODE, we only have 1 new token, so we only need 1 page slot.
-                    start_in_slot = bkv_sz_cache
-                    sz = new_sz
-
-                    p_idx = (kv_len_start +
-                             start_in_slot) >> config.page_size_log2
-                    p_idx = jnp.minimum(p_idx, config.pages_per_seq - 1)
-                    p_off = (kv_len_start +
-                             start_in_slot) & config.page_size_mask
-                    global_p_idx = s_idx * config.pages_per_seq + p_idx
-
-                    schedule.dma_kv_new[kv_new_base + 0] = (
-                        global_p_idx << config.page_size_log2) | p_off
-                    schedule.dma_kv_new[kv_new_base +
-                                        1] = q_end - kv_left_frm_new
-                    schedule.dma_kv_new[kv_new_base + 2] = start_in_slot
-                    schedule.dma_kv_new[kv_new_base + 3] = sz
-                else:
-                    for i in range(config.bkv_p_new):
-                        slot_start = i << config.page_size_log2
-                        slot_end = (i + 1) << config.page_size_log2
-
-                        start_in_slot = jnp.maximum(slot_start, bkv_sz_cache)
-                        end_in_slot = jnp.minimum(slot_end,
-                                                  bkv_sz_cache + new_sz)
-                        sz = jnp.maximum(0, end_in_slot - start_in_slot)
-
-                        p_idx = (kv_len_start +
-                                 start_in_slot) >> config.page_size_log2
-                        p_idx = jnp.minimum(p_idx, config.pages_per_seq - 1)
-                        p_off = (kv_len_start +
-                                 start_in_slot) & config.page_size_mask
-                        global_p_idx = s_idx * config.pages_per_seq + p_idx
-
-                        base_i = kv_new_base + i * 4
-                        schedule.dma_kv_new[base_i + 0] = (
-                            global_p_idx << config.page_size_log2) | p_off
-                        schedule.dma_kv_new[base_i +
-                                            1] = q_end - kv_left_frm_new
-                        schedule.dma_kv_new[base_i + 2] = start_in_slot
-                        schedule.dma_kv_new[base_i + 3] = sz
-                return curr_ptr + 1
-
-            lane_lengths_ref[target_lane] = jax.lax.fori_loop(
-                start_k_idx, end_k_idx, k_loop, curr_ptr)
-            return None
-
-        jax.lax.fori_loop(0, n_q, q_loop, None)
-
-    start_seq_idx, end_seq_idx = config.case.get_range(distribution_ref)
+    start_seq_idx, end_seq_idx = cfgs.mode.get_range(distribution_ref)
     jax.lax.fori_loop(start_seq_idx, end_seq_idx, seq_loop, None)
 
-    max_steps = lane_lengths_ref[0]
-    for b in range(1, config.batch_size):
-        max_steps = jnp.where(lane_lengths_ref[b] > max_steps,
-                              lane_lengths_ref[b], max_steps)
-    schedule.actual_steps[0] = max_steps
 
-    safe_max_steps = jnp.minimum(max_steps + config.n_buffer + 1,
-                                 config.max_steps_ub)
+def rpa_metadata_schedule_kernel(
+    ## Scalar prefetch.
+    cu_q_lens_ref: jax.Ref,
+    kv_lens_ref: jax.Ref,
+    distribution_ref: jax.Ref,
+    # Outputs.
+    schedule_hbm_ref: RPASchedule,
+    # Scratch.
+    schedule_ref: RPASchedule,
+    lane_lengths_ref: jax.Ref,
+    dma_sem: jax.Ref,
+    *,
+    cfgs: configs.RPAConfig,
+):
+    """Generates the HBM-to-VMEM DMA schedule.
 
-    def mask_lane(b, _):
-        start_step = lane_lengths_ref[b]
+    This kernel:
+    1. Iterates through each (potentially ragged) sequence
+    2. Breaks Queries (Q) and Key-Values (KV) into blocks (bq_sz, bkv_sz).
+    3. Assigns tasks to 'lanes' (TPU batch items) based on current lane occupancy
+        to ensure balanced execution across the batch dimension.
+    4. Encodes DMA offsets:
+        - dma_q: HBM start index and size for Query blocks.
+        - dma_kv_cache: Paged indices for existing KV tokens.
+        - dma_kv_new: offsets for new tokens being added to the cache.
+        - do_writeback: boolean flag indicating if a block should be flushed to
+        HBM (ie does this block contain new tokens to add to KV cache).
 
-        def mask_step(step, _):
-            idx = step * config.batch_size + b
+    Args:
+        cu_q_lens_ref: [max_num_seqs + 1]. Cumulative sum of each sequence's query
+            length. queries[a:b], keys[a:b], and values[a:b] where a=cu_q_lens[i] and
+            b=cu_q_lens[i+1] represents q/k/v of sequence i.
+        kv_lens_ref: [max_num_seqs]. Existing kv cache length of each sequence.
+            distribution_ref: [3]. Cumulative sum of number of decode, prefill, and
+            mixed
+        schedule_hbm_ref: HBM memory that will store output of the kernel.
+        schedule_ref: Scratch memory where schedule results gets written.
+        lane_lengths_ref: Scratch memory that keeps track of number of steps for
+            each batch lane.
+        dma_sem: Semaphore used for writing scheduler output to HBM.
+        cfgs: Configuration of the kernel.
+    """
 
-            # Mark as invalid and zero out control flags
-            schedule.s_idx[idx] = -1
-            schedule.q_idx[idx] = 0
-            schedule.k_idx[idx] = 0
-            schedule.is_last_k[idx] = 0
-            schedule.do_writeback[idx] = 0
+    for b_idx in range(cfgs.batch_size):
+        lane_lengths_ref[b_idx] = 0
 
-            # TODO: theoretically we just need to zero out the size, check later
-            q_base = step * config.batch_size * 2 + b * 2
-            schedule.dma_q[q_base + 0] = 0
-            schedule.dma_q[q_base + 1] = 0
+    # Step 1: Compute and fill scheduler metadata.
+    compute_metadata(
+        cu_q_lens_ref,
+        kv_lens_ref,
+        distribution_ref,
+        schedule_ref,
+        lane_lengths_ref,
+        cfgs=cfgs,
+    )
 
-            cache_base = (step * config.batch_size * config.bkv_p_cache * 3 +
-                          b * config.bkv_p_cache * 3)
-            for i in range(config.bkv_p_cache):
-                base_i = cache_base + i * 3
-                schedule.dma_kv_cache[base_i + 0] = 0
-                schedule.dma_kv_cache[base_i + 1] = 0
-                schedule.dma_kv_cache[base_i + 2] = 0
+    # Step 2: Compute actual number of steps.
+    max_steps = 0
+    for b_idx in range(cfgs.batch_size):
+        max_steps = jnp.maximum(max_steps, lane_lengths_ref[b_idx])
+    schedule_ref.actual_steps[0] = max_steps
 
-            new_base = (step * config.batch_size * config.bkv_p_new * 4 +
-                        b * config.bkv_p_new * 4)
-            for i in range(config.bkv_p_new):
-                base_i = new_base + i * 4
-                schedule.dma_kv_new[base_i + 0] = 0
-                schedule.dma_kv_new[base_i + 1] = 0
-                schedule.dma_kv_new[base_i + 2] = 0
-                schedule.dma_kv_new[base_i + 3] = 0
+    safe_max_steps = jnp.minimum(max_steps + cfgs.n_buffer + 1,
+                                 cfgs.max_steps_ub)
 
-        jax.lax.fori_loop(start_step, safe_max_steps, mask_step, None)
+    # Step 3: Mask out unvisited steps.
+    @jax.named_scope("mask_out_steps")
+    def mask_out_steps(step, _, *, b_idx):
+        schedule_ref.s_idx[step, b_idx] = -1
+        schedule_ref.q_idx[step, b_idx] = 0
+        schedule_ref.k_idx[step, b_idx] = 0
+        schedule_ref.is_last_k[step, b_idx] = 0
+        schedule_ref.do_writeback[step, b_idx] = 0
 
-    jax.lax.fori_loop(0, config.batch_size, mask_lane, None)
+        schedule_ref.dma_q[step, b_idx, 0] = 0
+        schedule_ref.dma_q[step, b_idx, 1] = 0
 
-    flat_hbm = jax.tree_util.tree_leaves(schedule_hbm)
-    flat_smem = jax.tree_util.tree_leaves(schedule)
+        for i in range(cfgs.bkv_p_cache):
+            schedule_ref.dma_kv_cache[step, b_idx, i, 0] = 0
+            schedule_ref.dma_kv_cache[step, b_idx, i, 1] = 0
+            schedule_ref.dma_kv_cache[step, b_idx, i, 2] = 0
+
+        for i in range(cfgs.bkv_p_new):
+            schedule_ref.dma_kv_new[step, b_idx, i, 0] = 0
+            schedule_ref.dma_kv_new[step, b_idx, i, 1] = 0
+            schedule_ref.dma_kv_new[step, b_idx, i, 2] = 0
+            schedule_ref.dma_kv_new[step, b_idx, i, 3] = 0
+
+    for b_idx in range(cfgs.batch_size):
+        start_step = lane_lengths_ref[b_idx]
+        mask_step_fn = functools.partial(mask_out_steps, b_idx=b_idx)
+        jax.lax.fori_loop(start_step, safe_max_steps, mask_step_fn, None)
+
+    # Ste 4: Write back results to HBM.
+    flat_hbm = jax.tree_util.tree_leaves(schedule_hbm_ref)
+    flat_smem = jax.tree_util.tree_leaves(schedule_ref)
     dma_list = []
-    sem = dma_sem.at[0]
-
     for h, s in zip(flat_hbm, flat_smem):
-        if h.shape[0] != 1:
-            multiplier = h.shape[0] // config.max_steps_ub
-            fetch_size = multiplier * safe_max_steps
-            # Ensure fetch_size is at most h.shape[0] to prevent out-of-bounds DMA
-            fetch_size = pl.cdiv(fetch_size, 1024) * 1024
+        write_size = h.shape[0]
+        if write_size > 1:
+            write_size = (write_size // cfgs.max_steps_ub) * safe_max_steps
+            write_size = utils.align_to(write_size, 1024)
 
-            copy = pltpu.make_async_copy(
-                s.at[pl.ds(0, fetch_size)],
-                h.at[pl.ds(0, fetch_size)],
-                sem,
-            )
-            copy.start()
-            dma_list.append(copy)
-        else:
-            copy = pltpu.make_async_copy(
-                s,
-                h,
-                sem,
-            )
-            copy.start()
-            dma_list.append(copy)
+        copy = pltpu.make_async_copy(
+            s.at[pl.ds(0, write_size)],
+            h.at[pl.ds(0, write_size)],
+            dma_sem.at[0],
+        )
+        dma_list.append(copy)
 
-    for copy in dma_list:
-        copy.wait()
+    jax.tree.map(lambda x: x.start(), dma_list)
+    jax.tree.map(lambda x: x.wait(), dma_list)
 
 
 def generate_rpa_metadata(
-    cu_q_lens,
-    kv_lens,
-    distribution,
-    config: RPAConfig,
+    cu_q_lens: jax.Array,
+    kv_lens: jax.Array,
+    distribution: jax.Array,
+    cfgs: configs.RPAConfig,
     *,
     interpret=False,
-):
-    scratch_shapes = [
-        RPASchedule.smem_specs(config),
-        pltpu.SMEM((config.batch_size, ), jnp.int32),
-        pltpu.SemaphoreType.DMA((1, )),
-    ]
+) -> RPASchedule:
+    schedule_shaped_dtype = RPASchedule.create_shape_dtype(cfgs)
 
     return pl.pallas_call(
-        functools.partial(rpa_metadata_schedule_kernel, config=config),
-        out_shape=RPASchedule.out_shape(config),
+        functools.partial(rpa_metadata_schedule_kernel, cfgs=cfgs),
+        out_shape=schedule_shaped_dtype,
         grid_spec=pltpu.PrefetchScalarGridSpec(
             num_scalar_prefetch=3,
             in_specs=[],
-            out_specs=RPASchedule.hbm_specs(config),
-            scratch_shapes=scratch_shapes,
+            out_specs=schedule_shaped_dtype.out_specs(),
+            scratch_shapes=[
+                schedule_shaped_dtype.scratch_shapes(),
+                pltpu.SMEM((cfgs.batch_size, ), jnp.int32),
+                pltpu.SemaphoreType.DMA((1, )),
+            ],
         ),
         interpret=interpret,
         name="rpa_metadata_schedule",

--- a/tpu_inference/kernels/experimental/batched_rpa/utils.py
+++ b/tpu_inference/kernels/experimental/batched_rpa/utils.py
@@ -11,14 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+"""Utility functions for Ragged Paged Attention."""
 
 import jax
 import jax.experimental.pallas as pl
 import jax.experimental.pallas.tpu as pltpu
 import jax.numpy as jnp
-
-from tpu_inference.kernels.experimental.batched_rpa import \
-    schedule as schedule_lib
 
 
 def align_to(a, b):
@@ -30,24 +28,25 @@ def broadcast_minor(src, shape):
     """Broadcasts 'src' to 'shape' in the minor dimension."""
     if src.shape == shape:
         return src
+    num_lanes = pltpu.get_tpu_info().num_lanes
     assert src.shape[:-1] == shape[:-1]
-    assert src.shape[-1] % 128 == 0
+    assert src.shape[-1] % num_lanes == 0
     target_minor = align_to(shape[-1], src.shape[-1])
     # no-op concatenation.
-    return jnp.concatenate([src for _ in range(target_minor // src.shape[-1])],
-                           axis=-1)[..., :shape[-1]]
+    broadcasted = jnp.concat([src] * (target_minor // src.shape[-1]), axis=-1)
+    return broadcasted[..., :shape[-1]]
 
 
-def get_dtype_bitwidth(dtype):
-    """Returns the bitwidth of a JAX dtype."""
-    return jax._src.dtypes.itemsize_bits(dtype)
+def get_dtype_packing(dtype):
+    return 32 // jax.dtypes.itemsize_bits(dtype)
 
 
 def strided_load(ref, start_row, num_rows, step, *, dtype=None):
     """Loads data from HBM with strided access, handling 128-lane alignment."""
     _, row_width = ref.shape
-    num_sub_lanes = row_width // 128
-    ref_flat = ref.reshape(-1, 128)
+    num_lanes = pltpu.get_tpu_info().num_lanes
+    num_sub_lanes = row_width // num_lanes
+    ref_flat = ref.reshape(-1, num_lanes)
 
     # scale indices to match flattened arraw.
     v_start = start_row * num_sub_lanes
@@ -66,33 +65,36 @@ def strided_load(ref, start_row, num_rows, step, *, dtype=None):
 
 def strided_store(ref, start, sz, step, val):
     """Stores data to HBM with strided access, handling 128-lane alignment."""
-    assert schedule_lib.get_dtype_packing(ref.dtype) == 1
+    assert get_dtype_packing(ref.dtype) == 1
     assert ref.dtype == val.dtype
     assert ref.shape == val.shape
-    assert len(ref.shape) == 2
-    r, l = ref.shape  # noqa
-    assert l % 128 == 0
-    folds = l // 128
-    ref = ref.reshape(r * folds, 128)
+    assert ref.ndim == 2
+    rows, cols = ref.shape
+    num_lanes = pltpu.get_tpu_info().num_lanes
+    assert cols % num_lanes == 0
+    folds = cols // num_lanes
+    ref = ref.reshape(rows * folds, num_lanes)
     start *= folds
     sz *= folds
     step *= folds
     assert sz % step == 0
     for i in range(folds):
-        ref[pl.ds(start + i, sz // step, step)] = val[:, i * 128:(i + 1) * 128]
+        val_slice = val[:, i * num_lanes:(i + 1) * num_lanes]
+        ref[pl.ds(start + i, sz // step, step)] = val_slice
 
 
-# If we want to convert 32-bits into 32//N number of N-bits value, naive
-# approach would be to perform 32//N number of 32-bits to N-bits conversion.
-# However, we can reduce number of instructions by utilizing binary tree.
-# 0: [32]
-# 1: [16, 16]
-# ...
-# log2(32//N): [N, N, ... N]
 def convert_to_target_bitwidth(val, target_bitwidth: int, kv_dtype: jnp.dtype):
     """Converts a value to a target bitwidth."""
+    # If we want to convert 32-bits into 32//N number of N-bits value, naive
+    # approach would be to perform 32//N number of 32-bits to N-bits conversion.
+    # However, we can reduce number of instructions by utilizing binary tree.
+    # 0: [32]
+    # 1: [16, 16]
+    # ...
+    # log2(32//N): [N, N, ... N]
+
     curr_dtype = val.dtype
-    curr_bitwidth = get_dtype_bitwidth(curr_dtype)
+    curr_bitwidth = jax.dtypes.itemsize_bits(curr_dtype)
     assert target_bitwidth != curr_bitwidth, "No conversion is needed."
 
     # We split val into two vals (left and right) where each have half of the
@@ -121,3 +123,13 @@ def convert_to_target_bitwidth(val, target_bitwidth: int, kv_dtype: jnp.dtype):
                                                target_bitwidth=target_bitwidth,
                                                kv_dtype=kv_dtype)
         return left_out + right_out
+
+
+def has_bank_conflicts(stride: int, distance=24, num_banks=32) -> bool:
+    banks = set()
+    for i in range(distance):
+        bank = (i * stride) % num_banks
+        if bank in banks:
+            return True
+        banks.add(bank)
+    return False

--- a/tpu_inference/kernels/experimental/batched_rpa/wrapper.py
+++ b/tpu_inference/kernels/experimental/batched_rpa/wrapper.py
@@ -29,265 +29,45 @@ scheduler.py kernel. Kernel is calculated once and ammortized across different l
 Note: batched_rpa is build on top / derived from RPA3. 
 """
 
-import dataclasses
-import functools
-from typing import Any
-
 import jax
 import jax.numpy as jnp
-import numpy as np
 from jax.experimental.pallas import tpu as pltpu
 
-from tpu_inference.kernels.experimental.batched_rpa import (kernel, schedule,
-                                                            utils)
-
-DEFAULT_MASK_VALUE = -float(jnp.finfo(jnp.dtype("float32")).max)
-
-
-@dataclasses.dataclass(frozen=True)
-class BlockSizes:
-    """Tuning parameters for the RPA kernel."""
-
-    bq_sz: int
-    bkv_sz: int
-    batch_size: int
-    n_buffer: int
-
-
-def prepare_inputs(
-    q: jax.Array,  # [max_tokens, num_q_heads, head_dim]
-    k: jax.Array,  # [max_tokens, num_kv_heads, head_dim]
-    v: jax.Array,  # [max_tokens, num_kv_heads, head_dim]
-    q_dtype: Any,
-    kv_dtype: Any,
-):
-    total_q_tokens, actual_num_q_heads, actual_head_dim = q.shape
-    _, actual_num_kv_heads, _ = k.shape
-    num_q_heads_per_kv_head = actual_num_q_heads // actual_num_kv_heads
-
-    q_packing = schedule.get_dtype_packing(q_dtype)
-    kv_packing = schedule.get_dtype_packing(kv_dtype)
-
-    aligned_num_q_heads_per_kv_head = utils.align_to(num_q_heads_per_kv_head,
-                                                     q_packing)
-    aligned_head_dim = utils.align_to(actual_head_dim, 128)
-
-    # queries: (T, H, D) -> (T, H_kv, G, D)
-    o_hbm_alias_q_hbm = (jnp.pad(
-        q.reshape(
-            total_q_tokens,
-            actual_num_kv_heads,
-            num_q_heads_per_kv_head,
-            actual_head_dim,
-        ),
-        (
-            (0, 0),
-            (0, 0),
-            (0, aligned_num_q_heads_per_kv_head - num_q_heads_per_kv_head),
-            (0, aligned_head_dim - actual_head_dim),
-        ),
-        constant_values=0,
-    ).reshape(
-        total_q_tokens,
-        actual_num_kv_heads,
-        aligned_num_q_heads_per_kv_head // q_packing,
-        q_packing,
-        aligned_head_dim,
-    ).swapaxes(0, 1))
-
-    # Pad keys and values head_dim
-    actual_num_kv_heads_x2 = actual_num_kv_heads * 2
-    num_kv_heads_x2_aligned = utils.align_to(actual_num_kv_heads_x2,
-                                             kv_packing)
-    new_kv_hbm = jnp.pad(
-        jnp.concatenate([k, v], axis=-1).reshape(total_q_tokens,
-                                                 actual_num_kv_heads_x2,
-                                                 actual_head_dim),
-        (
-            (0, 0),
-            (0, num_kv_heads_x2_aligned - actual_num_kv_heads_x2),
-            (0, aligned_head_dim - actual_head_dim),
-        ),
-        constant_values=0,
-    ).reshape(
-        total_q_tokens,
-        num_kv_heads_x2_aligned // kv_packing,
-        kv_packing,
-        aligned_head_dim,
-    )
-    return o_hbm_alias_q_hbm, new_kv_hbm
-
-
-def prepare_outputs(
-        out: jax.
-    Array,  # [kv_heads, max_tokens, q_per_kv // q_packing, q_packing, d]
-):
-    kv_heads, max_tokens, q_per_kv_packed, q_packing, d = out.shape
-    return out.reshape(kv_heads, max_tokens, q_per_kv_packed * q_packing, d)
-
-
-def _get_max_steps_ub(
-    max_num_seqs: int,
-    pages_per_seq: int,
-    bkv_sz: int,
-    page_size: int,
-    batch_size: int,
-    case: schedule.RpaCase,
-) -> int:
-    """Get max_steps_ub based on SMEM limit."""
-    # We use a static allocation based on SMEM limit (1 MiB) to avoid
-    # data-dependent shapes which can cause host-device syncs.
-    # The schedule is stored in SMEM along with kv_lens, cu_q_lens, page_indices,
-    # distribution, lane_lengths, and actual_steps.
-    smem_limit_bytes = pltpu.get_tpu_info().smem_capacity_bytes - 32 * 1024
-    word_size_bytes = 4
-    fixed_bytes = (
-        max_num_seqs * word_size_bytes  # kv_lens
-        + (max_num_seqs + 1) * word_size_bytes  # cu_q_lens
-        + max_num_seqs * pages_per_seq * word_size_bytes  # page_indices
-        + 3 * word_size_bytes  # distribution
-        + batch_size * word_size_bytes  # lane_lengths
-        + 1 * word_size_bytes  # actual_steps
-    )
-    available_bytes = smem_limit_bytes - fixed_bytes
-
-    bkv_p = bkv_sz // page_size
-    bkv_p_cache = 0 if case == schedule.RpaCase.PREFILL else bkv_p
-    bkv_p_new = 1 if case == schedule.RpaCase.DECODE else bkv_p
-
-    # Per step per batch item:
-    # s_idx, q_idx, k_idx, is_last_k, do_writeback: 5 * 4 = 20
-    # dma_q: 2 * 4 = 8
-    # dma_kv_cache: bkv_p_cache * 3 * 4 = 12 * bkv_p_cache
-    # dma_kv_new: bkv_p_new * 4 * 4 = 16 * bkv_p_new
-    bytes_per_step = batch_size * (28 + 12 * bkv_p_cache + 16 * bkv_p_new)
-    max_steps_ub = available_bytes // bytes_per_step
-    max_steps_ub = (max_steps_ub // 128) * 128
-    if max_steps_ub <= 0:
-        max_steps_ub = 128
-    return max_steps_ub
-
-
-def get_kv_cache_shape(
-    total_num_pages,
-    page_size,
-    actual_num_kv_heads,
-    actual_head_dim,
-    kv_dtype,
-):
-    kv_packing = schedule.get_dtype_packing(kv_dtype)
-    return (
-        total_num_pages,
-        page_size,
-        utils.align_to(actual_num_kv_heads * 2, kv_packing) // kv_packing,
-        kv_packing,
-        utils.align_to(actual_head_dim, 128),
-    )
-
-
-def get_vmem_estimate_bytes(
-    bq_sz,
-    bkv_sz,
-    batch_size,
-    num_q_heads,
-    num_kv_heads,
-    head_dim,
-    q_dtype,
-    kv_dtype,
-    n_buffer=2,
-):
-    """Get VMEM estimate bytes."""
-    q_packing = schedule.get_dtype_packing(q_dtype)
-    kv_packing = schedule.get_dtype_packing(kv_dtype)
-    num_q_heads_per_kv_head = num_q_heads // num_kv_heads
-    aligned_num_q_heads_per_kv_head = utils.align_to(num_q_heads_per_kv_head,
-                                                     q_packing)
-    aligned_head_dim = utils.align_to(head_dim, 128)
-
-    m_shape = (
-        batch_size,
-        num_kv_heads,
-        bq_sz * aligned_num_q_heads_per_kv_head,
-        128,
-    )
-    l_shape = (
-        batch_size,
-        num_kv_heads,
-        bq_sz * aligned_num_q_heads_per_kv_head,
-        128,
-    )
-    acc_shape = (
-        batch_size,
-        num_kv_heads,
-        bq_sz * aligned_num_q_heads_per_kv_head,
-        aligned_head_dim,
-    )
-    out_dtype = jnp.float32 if q_dtype == jnp.float32 else jnp.bfloat16
-    out_dtype_itemsize = jnp.dtype(out_dtype).itemsize
-    m_bytes = np.prod(m_shape) * out_dtype_itemsize
-    l_bytes = np.prod(l_shape) * out_dtype_itemsize
-    acc_bytes = np.prod(acc_shape) * out_dtype_itemsize
-
-    q_vmem_shape = (
-        batch_size,
-        num_kv_heads,
-        bq_sz,
-        aligned_num_q_heads_per_kv_head // q_packing,
-        q_packing,
-        aligned_head_dim,
-    )
-    q_bytes = np.prod(q_vmem_shape) * jnp.dtype(q_dtype).itemsize
-
-    bkv_stride = utils.align_to(num_kv_heads * 2, kv_packing) // kv_packing
-    if schedule.has_bank_conflicts(bkv_stride):
-        bkv_stride += 1
-    kv_vmem_shape = (
-        batch_size,
-        bkv_sz,
-        bkv_stride,
-        kv_packing,
-        aligned_head_dim,
-    )
-    kv_bytes = np.prod(kv_vmem_shape) * jnp.dtype(kv_dtype).itemsize
-
-    return (m_bytes + l_bytes + acc_bytes + (n_buffer + 2) * q_bytes +
-            n_buffer * kv_bytes)
+from tpu_inference.kernels.experimental.batched_rpa import (configs, kernel,
+                                                            schedule, utils)
 
 
 # Expect to run this validation during compile time.
 def static_validate_inputs(
-    queries: jax.
-    Array,  # [max_num_tokens, actual_num_q_heads, actual_head_dim]
-    keys: jax.Array,  # [max_num_tokens, actual_num_kv_heads, actual_head_dim]
-    values: jax.
-    Array,  # [max_num_tokens, actual_num_kv_heads, actual_head_dim]
-    kv_cache: jax.
-    Array,  # [total_num_pages, page_size, num_kv_heads_x2 // kv_packing, kv_packing, head_dim]
-    kv_lens: jax.Array,  # i32[max_num_seqs]
-    page_indices: jax.Array,  # i32[max_num_seqs * pages_per_seq]
-    cu_q_lens: jax.Array,  # i32[max_num_seqs + 1]
-    distribution: jax.Array,  # i32[3]
+    q: jax.Array,
+    k: jax.Array,
+    v: jax.Array,
+    kv_cache: jax.Array,
+    kv_lens: jax.Array,
+    page_indices: jax.Array,
+    cu_q_lens: jax.Array,
+    distribution: jax.Array,
     *,
     sm_scale: float = 1.0,
     sliding_window: int | None = None,
     soft_cap: float | None = None,
-    mask_value: float | None = DEFAULT_MASK_VALUE,
+    mask_value: float | None = None,
     q_scale: float | None = None,
     k_scale: float | None = None,
     v_scale: float | None = None,
     # Kernel optimization params.
     chunk_prefill_size: int | None = None,
     # Kernel tuning params.
-    decode_block_sizes: BlockSizes | None = None,
-    prefill_block_sizes: BlockSizes | None = None,
+    decode_block_sizes: configs.BlockSizes | None = None,
+    prefill_block_sizes: configs.BlockSizes | None = None,
     vmem_limit_bytes: int | None = None,
     # Debug params.
     debug_mode: bool = False,
     use_causal_mask: bool = True,
 ):
     """Validate inputs to the RPA kernel statically."""
-    q, k, v = queries, keys, values
-    if not (len(q.shape) == len(k.shape) == len(v.shape) == 3):
+    num_lanes = pltpu.get_tpu_info().num_lanes
+    if not q.ndim == k.ndim == k.ndim == 3:
         raise ValueError(
             f"Expected 3D array for {q.shape=}, {k.shape=}, {v.shape=}")
     if k.shape != v.shape:
@@ -330,10 +110,10 @@ def static_validate_inputs(
         head_dim,
     ) = kv_cache.shape
 
-    if head_dim != utils.align_to(actual_head_dim, 128):
+    if head_dim != (aligned_head_dim := utils.align_to(actual_head_dim,
+                                                       num_lanes)):
         raise ValueError(
-            f"Expected {head_dim=} is equal to {utils.align_to(actual_head_dim, 128)=}"
-        )
+            f"Expected {head_dim=} is equal to {aligned_head_dim=}")
     # Note: we expect the kv quantization happens outside of the RPA kernel.
     if not (kv_cache.dtype == k.dtype == v.dtype):
         raise ValueError(
@@ -342,7 +122,7 @@ def static_validate_inputs(
     # Integer kv quantization is currently not supported.
     if not jnp.issubdtype(kv_cache.dtype, jnp.floating):
         raise ValueError(f"Expected {kv_cache.dtype=} to be a floating point.")
-    if kv_packing != schedule.get_dtype_packing(kv_cache.dtype):
+    if kv_packing != utils.get_dtype_packing(kv_cache.dtype):
         raise ValueError(
             f"{kv_packing=} does not match with {kv_cache.dtype=}")
 
@@ -407,29 +187,110 @@ def static_validate_inputs(
         raise ValueError(f"{vmem_limit_bytes=} must be positive.")
 
     # No constraints for the following inputs.
-    del sm_scale
-    del mask_value
-    del q_scale
-    del k_scale
-    del v_scale
-    del debug_mode
+    del sm_scale, mask_value, q_scale, k_scale, v_scale, debug_mode
+
+
+def prepare_inputs(
+    q: jax.Array,
+    k: jax.Array,
+    v: jax.Array,
+    q_dtype: jnp.dtype,
+    kv_dtype: jnp.dtype,
+) -> tuple[jax.Array, jax.Array]:
+
+    total_q_tokens, actual_num_q_heads, actual_head_dim = q.shape
+    _, actual_num_kv_heads, _ = k.shape
+    num_q_heads_per_kv_head = actual_num_q_heads // actual_num_kv_heads
+
+    q_packing = utils.get_dtype_packing(q_dtype)
+    kv_packing = utils.get_dtype_packing(kv_dtype)
+
+    aligned_num_q_heads_per_kv_head = utils.align_to(num_q_heads_per_kv_head,
+                                                     q_packing)
+    num_lanes = pltpu.get_tpu_info().num_lanes
+    aligned_head_dim = utils.align_to(actual_head_dim, num_lanes)
+
+    # queries: (T, H, D) -> (T, H_kv, G, D)
+    o_hbm_alias_q_hbm = (jnp.pad(
+        q.reshape(
+            total_q_tokens,
+            actual_num_kv_heads,
+            num_q_heads_per_kv_head,
+            actual_head_dim,
+        ),
+        (
+            (0, 0),
+            (0, 0),
+            (0, aligned_num_q_heads_per_kv_head - num_q_heads_per_kv_head),
+            (0, aligned_head_dim - actual_head_dim),
+        ),
+        constant_values=0,
+    ).reshape(
+        total_q_tokens,
+        actual_num_kv_heads,
+        aligned_num_q_heads_per_kv_head // q_packing,
+        q_packing,
+        aligned_head_dim,
+    ).swapaxes(0, 1))
+
+    # Pad keys and values head_dim
+    actual_num_kv_heads_x2 = actual_num_kv_heads * 2
+    num_kv_heads_x2_aligned = utils.align_to(actual_num_kv_heads_x2,
+                                             kv_packing)
+    new_kv_hbm = jnp.pad(
+        jnp.concatenate([k, v], axis=-1).reshape(total_q_tokens,
+                                                 actual_num_kv_heads_x2,
+                                                 actual_head_dim),
+        (
+            (0, 0),
+            (0, num_kv_heads_x2_aligned - actual_num_kv_heads_x2),
+            (0, aligned_head_dim - actual_head_dim),
+        ),
+        constant_values=0,
+    ).reshape(
+        total_q_tokens,
+        num_kv_heads_x2_aligned // kv_packing,
+        kv_packing,
+        aligned_head_dim,
+    )
+    return o_hbm_alias_q_hbm, new_kv_hbm
+
+
+def prepare_outputs(out: jax.Array) -> jax.Array:
+    kv_heads, max_tokens, q_per_kv_packed, q_packing, d = out.shape
+    return out.reshape(kv_heads, max_tokens, q_per_kv_packed * q_packing, d)
+
+
+def get_kv_cache_shape(
+    total_num_pages,
+    page_size,
+    actual_num_kv_heads,
+    actual_head_dim,
+    kv_dtype,
+):
+    num_lanes = pltpu.get_tpu_info().num_lanes
+    kv_packing = utils.get_dtype_packing(kv_dtype)
+    return (
+        total_num_pages,
+        page_size,
+        utils.align_to(actual_num_kv_heads * 2, kv_packing) // kv_packing,
+        kv_packing,
+        utils.align_to(actual_head_dim, num_lanes),
+    )
 
 
 def get_default_block_sizes(
-    q_dtype,
-    kv_dtype,
-    actual_num_q_heads,
-    actual_num_kv_heads,
-    head_dim,
-    page_size,
-    max_num_tokens,
-    max_num_seqs,
-    pages_per_seq,
-) -> tuple[BlockSizes, BlockSizes]:
-    """Get (bq_sz, bkv_sz, batch_size) by some heuristic formulas.
-
-  Note the default block sizes are not necessarily optimal.
-  """
+    q_dtype: jnp.dtype,
+    kv_dtype: jnp.dtype,
+    actual_num_q_heads: int,
+    actual_num_kv_heads: int,
+    head_dim: int,
+    page_size: int,
+    max_num_tokens: int,
+    max_num_seqs: int,
+    pages_per_seq: int,
+) -> tuple[configs.BlockSizes, configs.BlockSizes]:
+    """Get (bq_sz, bkv_sz, batch_size) by some heuristic formulas."""
     del (
         q_dtype,
         head_dim,
@@ -437,15 +298,15 @@ def get_default_block_sizes(
         max_num_seqs,
         pages_per_seq,
     )
-    is_8bit = schedule.get_dtype_packing(kv_dtype) == 4
+    is_8bit = utils.get_dtype_packing(kv_dtype) == 4
     # Qwen32b
     if actual_num_q_heads == 32 and actual_num_kv_heads == 4 and is_8bit:
-        return BlockSizes(
+        return configs.BlockSizes(
             bq_sz=1,
             bkv_sz=512,
             batch_size=10,
             n_buffer=2,
-        ), BlockSizes(
+        ), configs.BlockSizes(
             bq_sz=256,
             bkv_sz=512,
             batch_size=2,
@@ -453,28 +314,29 @@ def get_default_block_sizes(
         )
     # Qwen-coder
     if actual_num_q_heads == 12 and actual_num_kv_heads == 1 and is_8bit:
-        return BlockSizes(
+        return configs.BlockSizes(
             bq_sz=1,
             bkv_sz=2304,
             batch_size=8,
             n_buffer=3,
-        ), BlockSizes(
+        ), configs.BlockSizes(
             bq_sz=512,
             bkv_sz=512,
             batch_size=3,
             n_buffer=3,
         )
-    return BlockSizes(bq_sz=1, bkv_sz=page_size, batch_size=1,
-                      n_buffer=2), BlockSizes(
-                          bq_sz=1,
-                          bkv_sz=page_size,
-                          batch_size=1,
-                          n_buffer=2,
-                      )
+
+    default_block_sizes = configs.BlockSizes(
+        bq_sz=1,
+        bkv_sz=page_size,
+        batch_size=1,
+        n_buffer=2,
+    )
+
+    return default_block_sizes, default_block_sizes
 
 
-@functools.partial(
-    jax.jit,
+@jax.jit(
     static_argnames=(
         "sm_scale",
         "sliding_window",
@@ -506,19 +368,61 @@ def ragged_paged_attention(
     sm_scale: float = 1.0,
     sliding_window: int | None = None,
     soft_cap: float | None = None,
-    mask_value: float | None = DEFAULT_MASK_VALUE,
+    mask_value: float | None = None,
     q_scale: float | None = None,
     k_scale: float | None = None,
     v_scale: float | None = None,
     chunk_prefill_size: int | None = None,
-    decode_block_sizes: BlockSizes | None = None,
-    prefill_block_sizes: BlockSizes | None = None,
-    # obsolete, for benchmarking backwards compatibility.
+    decode_block_sizes: configs.BlockSizes | None = None,
+    prefill_block_sizes: configs.BlockSizes | None = None,
     vmem_limit_bytes: int | None = None,
     debug_mode: bool = False,
-    out_dtype: Any | None = None,
+    out_dtype: jnp.dtype | None = None,
     use_causal_mask: bool = True,
-):
+) -> tuple[jax.Array, jax.Array]:
+    """Perform batched ragged paged attention.
+
+    Args:
+        queries: [max_num_tokens, num_q_heads, head_dim]. Output of q projection.
+        keys: [max_num_tokens, num_kv_heads, head_dim]. Output of k projection.
+        values: [max_num_tokens, num_kv_heads, head_dim]. Output of v projection.
+        kv_cache: [num_pages, page_size, cdiv(num_kv_heads * 2, kv_packing),
+            kv_packing, head_dim]. Stores existing kv cache data where k & vs are
+            concatenated along num kv heads dim.
+        kv_lens: [max_num_seqs]. Existing kv cache length of each sequence.
+            page_indices: [max_num_seqs * pages_per_seqs]. kv cache page table of each
+            sequence.
+        cu_q_lens: [max_num_seqs + 1]. Cumulative sum of each sequence's query
+            length. queries[a:b], keys[a:b], and values[a:b] where a=cu_q_lens[i] and
+            b=cu_q_lens[i+1] represents q/k/v of sequence i.
+        distribution: [3]. Cumulative sum of number of decode, prefill, and mixed
+            sequences. distribution[2] represents total number of sequences.
+        sm_scale: Softmax scale value.
+        sliding_window: Size of sliding window (also known as local attention). kvs
+            outside of the window is not fetched from hbm and masked out during
+            computation.
+        soft_cap: Cap values of softmax inputs.
+        mask_value: Value to use for causal masking. Defaults to smallest
+            representable value of the activation dtype.
+        q_scale: Quantization scale value of queries.
+        k_scale: Quantization scale value of keys.
+        v_scale: Quantization scale value of values.
+        chunk_prefill_size: Not used.
+        decode_block_sizes: Kernel block size to use during decode.
+        prefill_block_sizes: Kernel block size to use during prefill.
+        vmem_limit_bytes: VMEM size limit of the kernel. Defaults to maximum VMEM
+            size of the hardware.
+        debug_mode: Not used.
+        out_dtype: Dtype of output. Defaults to dtype of queries.
+        use_causal_mask: Not used.
+
+    Returns:
+        out: [max_num_tokens, num_q_heads, head_dim]. Output of self attention.
+        new_kv_cache: [num_pages, page_size, cdiv(num_kv_heads * 2, kv_packing),
+            kv_packing, head_dim]. Result of new kv cache where k & vs are
+            concatenated along num kv heads dim.
+    """
+
     static_validate_inputs(
         queries,
         keys,
@@ -542,118 +446,102 @@ def ragged_paged_attention(
         debug_mode=debug_mode,
         use_causal_mask=use_causal_mask,
     )
-    if mask_value is None:
-        mask_value = DEFAULT_MASK_VALUE
     if out_dtype is None:
-        out_dtype = jnp.float32 if queries.dtype == jnp.float32 else jnp.bfloat16
+        out_dtype = queries.dtype
+    if mask_value is None:
+        mask_value = jnp.finfo(out_dtype).min
+    if vmem_limit_bytes is None:
+        vmem_limit_bytes = pltpu.get_tpu_info().vmem_capacity_bytes
 
     max_num_seqs = kv_lens.shape[0]
-    total_num_pages = kv_cache.shape[0]
     page_size = kv_cache.shape[1]
 
-    actual_num_q_heads = queries.shape[1]
-    actual_head_dim = queries.shape[2]
-    actual_num_kv_heads = keys.shape[1]
-    pages_per_seq = page_indices.shape[0] // max_num_seqs
+    num_q_heads = queries.shape[1]
+    head_dim = queries.shape[2]
+    num_kv_heads = keys.shape[1]
+    num_page_indices = page_indices.shape[0]
+    pages_per_seq = num_page_indices // max_num_seqs
     total_q_tokens = queries.shape[0]
 
-    num_q_heads_per_kv_head = actual_num_q_heads // actual_num_kv_heads
-    o_hbm_alias_q_hbm, new_kv_hbm = prepare_inputs(queries, keys, values,
-                                                   queries.dtype,
-                                                   kv_cache.dtype)
-    _, _, q_per_kv_packed, q_packing, aligned_head_dim = o_hbm_alias_q_hbm.shape
-    aligned_num_q_heads_per_kv_head = q_per_kv_packed * q_packing
+    q_hbm, new_kv_hbm = prepare_inputs(queries, keys, values, queries.dtype,
+                                       kv_cache.dtype)
 
     def run_rpa_kernel(
-        case: schedule.RpaCase,
-        o_hbm_alias_q_hbm,
-        kv_cache,
+        mode: configs.RpaCase,
+        o_hbm_alias_q_hbm: jax.Array,
+        kv_cache: jax.Array,
     ):
         default_decode, default_prefill = get_default_block_sizes(
             queries.dtype,
             kv_cache.dtype,
-            actual_num_q_heads,
-            actual_num_kv_heads,
-            actual_head_dim,
+            num_q_heads,
+            num_kv_heads,
+            head_dim,
             page_size,
             total_q_tokens,
             max_num_seqs,
             pages_per_seq,
         )
-        if case == schedule.RpaCase.DECODE:
+        if mode == configs.RpaCase.DECODE:
             effective_blocks = decode_block_sizes or default_decode
         else:
             effective_blocks = prefill_block_sizes or default_prefill
 
-        max_steps_ub = _get_max_steps_ub(
-            max_num_seqs,
-            pages_per_seq,
-            effective_blocks.bkv_sz,
-            page_size,
-            effective_blocks.batch_size,
-            case,
+        cfgs = configs.RPAConfig(
+            block=effective_blocks,
+            model=configs.ModelConfigs(
+                num_q_heads=num_q_heads,
+                num_kv_heads=num_kv_heads,
+                head_dim=head_dim,
+                sliding_window=sliding_window,
+                sm_scale=sm_scale,
+                soft_cap=soft_cap,
+                mask_value=mask_value,
+            ),
+            serve=configs.ServingConfigs(
+                num_seqs=max_num_seqs,
+                num_page_indices=num_page_indices,
+                total_q_tokens=total_q_tokens,
+                dtype_q=queries.dtype,
+                dtype_kv=kv_cache.dtype,
+                dtype_out=out_dtype,
+                page_size=page_size,
+                scale_q=q_scale,
+                scale_k=k_scale,
+                scale_v=v_scale,
+            ),
+            vmem_limit_bytes=vmem_limit_bytes,
+            mode=mode,
         )
-
-        config = schedule.RPAConfig(
-            num_seq=max_num_seqs,
-            bq_sz=effective_blocks.bq_sz,
-            bkv_sz=effective_blocks.bkv_sz,
-            batch_size=effective_blocks.batch_size,
-            page_size=page_size,
-            bkv_p=effective_blocks.bkv_sz // page_size,
-            pages_per_seq=pages_per_seq,
-            max_steps_ub=max_steps_ub,
-            total_q_tokens=total_q_tokens,
-            head_dim=aligned_head_dim,
-            num_kv_heads=actual_num_kv_heads,
-            num_q_heads_per_kv_head=aligned_num_q_heads_per_kv_head,
-            sm_scale=sm_scale,
-            soft_cap=soft_cap,
-            sliding_window=sliding_window,
-            mask_value=mask_value,
-            q_dtype=queries.dtype,
-            kv_dtype=kv_cache.dtype,
-            q_scale=q_scale,
-            k_scale=k_scale,
-            v_scale=v_scale,
-            vmem_limit_bytes=vmem_limit_bytes if vmem_limit_bytes is not None
-            else pltpu.get_tpu_info().vmem_capacity_bytes,
-            total_num_pages=total_num_pages,
-            case=case,
-            n_buffer=effective_blocks.n_buffer,
-            out_dtype=out_dtype,
-            fuse_accum=True if case == schedule.RpaCase.DECODE else False,
-            mask_v=False if case == schedule.RpaCase.DECODE else True,
+        schedule_hbm = schedule.generate_rpa_metadata(
+            cu_q_lens,
+            kv_lens,
+            distribution,
+            cfgs=cfgs,
         )
-        rpa_schedule = schedule.generate_rpa_metadata(cu_q_lens,
-                                                      kv_lens,
-                                                      distribution,
-                                                      config=config)
-        rpa_kernel_instance = kernel.make_rpa_kernel(config)
-        o_hbm_alias_q_hbm, kv_cache = rpa_kernel_instance(
+        return kernel.rpa_kernel(
             cu_q_lens,
             kv_lens,
             page_indices,
-            rpa_schedule,
+            schedule_hbm,
             o_hbm_alias_q_hbm,
             new_kv_hbm,
             kv_cache,
+            cfgs=cfgs,
         )
-        return o_hbm_alias_q_hbm, kv_cache
 
-    o_hbm_alias_q_hbm, kv_cache = run_rpa_kernel(schedule.RpaCase.DECODE,
-                                                 o_hbm_alias_q_hbm, kv_cache)
-    o_hbm_alias_q_hbm, kv_cache = run_rpa_kernel(schedule.RpaCase.MIXED,
+    o_hbm_alias_q_hbm, kv_cache = run_rpa_kernel(configs.RpaCase.DECODE, q_hbm,
+                                                 kv_cache)
+    o_hbm_alias_q_hbm, kv_cache = run_rpa_kernel(configs.RpaCase.MIXED,
                                                  o_hbm_alias_q_hbm, kv_cache)
 
     # before: [kv_heads, max_tokens, q_per_kv // q_packing, q_packing, d]
-    o_hbm_alias_q_hbm = prepare_outputs(o_hbm_alias_q_hbm)
+    o_hbm = prepare_outputs(o_hbm_alias_q_hbm)
     # after: [kv_heads, max_tokens, q_per_kv, d]
 
     # slice back to original shape if padded
-    o_hbm_alias_q_hbm = (
-        o_hbm_alias_q_hbm[:, :, :num_q_heads_per_kv_head, :actual_head_dim].
-        transpose(1, 0, 2, 3).reshape(total_q_tokens, actual_num_q_heads,
-                                      actual_head_dim))
+    num_q_heads_per_kv_head = num_q_heads // num_kv_heads
+    o_hbm = o_hbm[:, :, :num_q_heads_per_kv_head, :head_dim]
+    o_hbm = o_hbm.swapaxes(1, 0).reshape(queries.shape)
 
-    return o_hbm_alias_q_hbm, kv_cache
+    return o_hbm, kv_cache


### PR DESCRIPTION
# Description

Code cleanup. No functionality changes.

- Remove all use of JAX's private APIs.
- Move all configs related logics into a newly created `configs.py` file.
- Consolidate all access to a config values to a single `RpaConfigs` object.
- Minimize the use of nested functions and keep functions stateless.
- Add more comments and rename variables to be more intuitive.
- Create `SmemWrapper` that maps physical 1-d smem data into logical n-d layout for better readability.
- Refactor `RPASchedule` to leverage `ShapeDtypeStruct` for creating in/out specs & scratch shapes.

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
