### PR TITLE
Optimize GDN sequence handling for better performance

### DIFF
--- a/tpu_inference/layers/common/gdn_attention.py
+++ b/tpu_inference/layers/common/gdn_attention.py
@@ -102,10 +102,6 @@ def run_jax_gdn_attention_local(
         - The output tensor of shape `(num_tokens, n_v * d_v)`.
     """
 
-    # Ensure query_start_loc is monotonically increasing. This is required to
-    # handle cases where query_start_loc might be padded with trailing zeros.
-    query_start_loc = jnp.maximum.accumulate(query_start_loc)
-
     # TODO: Switch conv implementaion based on config once we have more than 1 impl
     conv_impl = ragged_conv1d_jax
 
@@ -117,9 +113,14 @@ def run_jax_gdn_attention_local(
         query_start_loc,
         state_indices,
         kernel_size,
+        distribution,
     )
 
     out_mixed_qkv = jax.nn.silu(out_mixed_qkv)
+
+    # Ensure query_start_loc is monotonically increasing. This is required to
+    # handle cases where query_start_loc might be padded with trailing zeros.
+    #query_start_loc = jnp.maximum.accumulate(query_start_loc)
 
     if config.ragged_gated_delta_rule_impl == RaggedGatedDeltaRuleImpl.REF:
         ragged_gdn_impl = functools.partial(
@@ -210,6 +211,7 @@ def run_jax_gdn_attention(
           - new_recurrent_state: `(max_reqs, n_v, d_k, d_v)`
         - The output tensor of shape `(num_tokens, n_v * d_v)`.
     """
+
     in_specs = (
         P(None, ShardingAxisName.ATTN_HEAD),  # j_mixed_qkv
         P(None, ShardingAxisName.ATTN_HEAD),  # j_b

--- a/tpu_inference/layers/common/gdn_attention.py
+++ b/tpu_inference/layers/common/gdn_attention.py
@@ -118,10 +118,6 @@ def run_jax_gdn_attention_local(
 
     out_mixed_qkv = jax.nn.silu(out_mixed_qkv)
 
-    # Ensure query_start_loc is monotonically increasing. This is required to
-    # handle cases where query_start_loc might be padded with trailing zeros.
-    #query_start_loc = jnp.maximum.accumulate(query_start_loc)
-
     if config.ragged_gated_delta_rule_impl == RaggedGatedDeltaRuleImpl.REF:
         ragged_gdn_impl = functools.partial(
             ragged_gated_delta_rule_ref,

--- a/tpu_inference/layers/common/ragged_conv1d_jax.py
+++ b/tpu_inference/layers/common/ragged_conv1d_jax.py
@@ -24,6 +24,7 @@ def ragged_conv1d(
     query_start_loc,
     state_indices,
     kernel_size,
+    distribution,
 ):
     """Applies 1D convolution over ragged sequences and updates state.
 
@@ -39,7 +40,7 @@ def ragged_conv1d(
       state_indices: Tensor of shape `(max_reqs,)` mapping request index to state
         index.
       kernel_size: The size of the convolution kernel.
-  
+
     Returns:
       A tuple containing:
       - output: The output tensor of shape `(num_tokens, dim)`.
@@ -50,12 +51,19 @@ def ragged_conv1d(
     max_reqs = state_indices.shape[0]
     token_idx = jnp.arange(num_tokens)
 
-    req_indices = (
-        jnp.sum(token_idx[:, None] >= query_start_loc[None, :], axis=1) - 1)
-    req_indices = jnp.clip(req_indices, 0, max_reqs - 1)
-    local_indices = token_idx - query_start_loc[req_indices]
+    num_valid_seqs = distribution[2]
+    valid_loc_mask = jnp.arange(query_start_loc.shape[0]) <= num_valid_seqs
+    # Handle case where query_start_loc has trailing zeros by filling them with the last valid location.
+    last_valid_loc = query_start_loc[num_valid_seqs]
+    effective_query_start_loc = jnp.where(valid_loc_mask, query_start_loc,
+                                          last_valid_loc)
 
-    lengths = query_start_loc[1:] - query_start_loc[:-1]
+    req_indices = (jnp.sum(
+        token_idx[:, None] >= effective_query_start_loc[None, :], axis=1) - 1)
+    req_indices = jnp.clip(req_indices, 0, max_reqs - 1)
+    local_indices = token_idx - effective_query_start_loc[req_indices]
+
+    lengths = (effective_query_start_loc[1:] - effective_query_start_loc[:-1])
 
     # 1. Compute Convolution
     out = jnp.zeros_like(x)
@@ -83,10 +91,10 @@ def ragged_conv1d(
     padded_lengths = padded_lengths.at[:lengths.shape[0]].set(lengths)
 
     padded_q_loc = jnp.zeros(max_reqs + 1, dtype=jnp.int32)
-    padded_q_loc = padded_q_loc.at[:query_start_loc.shape[0]].set(
-        query_start_loc)
-    padded_q_loc = padded_q_loc.at[query_start_loc.shape[0]:].set(
-        query_start_loc[-1])
+    padded_q_loc = padded_q_loc.at[:effective_query_start_loc.shape[0]].set(
+        effective_query_start_loc)
+    padded_q_loc = padded_q_loc.at[effective_query_start_loc.shape[0]:].set(
+        effective_query_start_loc[-1])
 
     r_grid = jnp.arange(max_reqs)[:, None]
     j_grid = jnp.arange(kernel_size - 1)[None, :]
@@ -102,10 +110,10 @@ def ragged_conv1d(
                                     gathered_state[r_grid,
                                                    idx_state], x[idx_x])
 
-    valid_seq_mask = jnp.arange(max_reqs) < lengths.shape[0]
+    true_valid_seq_mask = jnp.arange(max_reqs) < num_valid_seqs
     updated_conv_state = conv_state.at[state_indices].set(
         jnp.where(
-            valid_seq_mask[:, None, None],
+            true_valid_seq_mask[:, None, None],
             new_state_extracted,
             conv_state[state_indices],
         ))

--- a/tpu_inference/layers/common/ragged_gated_delta_rule_chunked.py
+++ b/tpu_inference/layers/common/ragged_gated_delta_rule_chunked.py
@@ -91,7 +91,7 @@ def pack_inputs_single_stream(
       g: Gate tensor.
       beta: Beta tensor.
       query_start_loc: Start locations of each sequence in original stream.
-      distribution: Distribution tensor containing number of valid sequences at index 2.
+      distribution: Tensor of shape `(3,)` int32 — `(decode_end, prefill_end, mixed_end)`.
       chunk_size: Chunk size for padding.
       compute_dtype: Dtype for computation (Q, K, V, beta).
 
@@ -222,7 +222,7 @@ def ragged_gated_delta_rule_mixed_prefill(
       query_start_loc: Start locations of sequences in original stream.
       recurrent_state: Recurrent state tensor.
       state_indices: Indices mapping sequences to recurrent state slots.
-      distribution: Distribution tensor containing number of valid sequences at index 2.
+      distribution: Tensor of shape `(3,)` int32 — `(decode_end, prefill_end, mixed_end)`.
       chunk_size: Chunk size for padding and processing.
       use_qk_norm_in_gdn: Whether to use QK normalization.
       compute_dtype: Dtype for computation.

--- a/tpu_inference/layers/common/ragged_gated_delta_rule_chunked.py
+++ b/tpu_inference/layers/common/ragged_gated_delta_rule_chunked.py
@@ -43,6 +43,7 @@ def pack_inputs_single_stream(
     g: jnp.ndarray,
     beta: jnp.ndarray,
     query_start_loc: jnp.ndarray,
+    distribution: jnp.ndarray,
     chunk_size: int,
     compute_dtype: jnp.dtype = jnp.bfloat16,
 ) -> tuple[
@@ -90,6 +91,7 @@ def pack_inputs_single_stream(
       g: Gate tensor.
       beta: Beta tensor.
       query_start_loc: Start locations of each sequence in original stream.
+      distribution: Distribution tensor containing number of valid sequences at index 2.
       chunk_size: Chunk size for padding.
       compute_dtype: Dtype for computation (Q, K, V, beta).
 
@@ -107,8 +109,14 @@ def pack_inputs_single_stream(
     num_tokens = query.shape[0]
     num_seqs = len(query_start_loc) - 1
 
+    num_valid_seqs = distribution[2]
+    valid_loc_mask = jnp.arange(query_start_loc.shape[0]) <= num_valid_seqs
+    last_valid_loc = query_start_loc[num_valid_seqs]
+    effective_query_start_loc = jnp.where(valid_loc_mask, query_start_loc,
+                                          last_valid_loc)
+
     # Calculate sequence lengths and pad them to multiples of chunk_size.
-    seq_lengths = query_start_loc[1:] - query_start_loc[:-1]
+    seq_lengths = effective_query_start_loc[1:] - effective_query_start_loc[:-1]
     num_chunks = (seq_lengths + chunk_size - 1) // chunk_size
     padded_lengths = num_chunks * chunk_size
 
@@ -117,19 +125,19 @@ def pack_inputs_single_stream(
         jnp.concatenate([jnp.array([0]), padded_lengths]))
 
     # Map each original token index to its sequence ID in a JIT-friendly way.
-    # For each token index, searchsorted finds the insertion point in query_start_loc
+    # For each token index, searchsorted finds the insertion point in effective_query_start_loc
     # where the token would go to maintain order (using side="right").
     # Subtracting 1 gives the index of the sequence the token actually belongs to.
-    seq_id = jnp.searchsorted(
-        query_start_loc, jnp.arange(num_tokens), side="right") - 1
-    original_start = query_start_loc[seq_id]
+    seq_id = (jnp.searchsorted(
+        effective_query_start_loc, jnp.arange(num_tokens), side="right") - 1)
+    original_start = effective_query_start_loc[seq_id]
     new_start = new_query_start_loc[seq_id]
     padded_indices_valid = new_start + (jnp.arange(num_tokens) -
                                         original_start)
 
     max_packed_tokens = num_tokens + num_seqs * chunk_size
-    max_packed_tokens = (max_packed_tokens + chunk_size -
-                         1) // chunk_size * chunk_size
+    max_packed_tokens = ((max_packed_tokens + chunk_size - 1) // chunk_size *
+                         chunk_size)
 
     # Concatenate by dtype to reduce scatter operations
     beta_expanded = beta[..., None]
@@ -189,6 +197,7 @@ def ragged_gated_delta_rule_mixed_prefill(
     query_start_loc: jnp.ndarray,
     recurrent_state: jnp.ndarray,
     state_indices: jnp.ndarray,
+    distribution: jnp.ndarray,
     chunk_size: int = 64,
     use_qk_norm_in_gdn: bool = False,
     compute_dtype: jnp.dtype = jnp.bfloat16,
@@ -213,6 +222,7 @@ def ragged_gated_delta_rule_mixed_prefill(
       query_start_loc: Start locations of sequences in original stream.
       recurrent_state: Recurrent state tensor.
       state_indices: Indices mapping sequences to recurrent state slots.
+      distribution: Distribution tensor containing number of valid sequences at index 2.
       chunk_size: Chunk size for padding and processing.
       use_qk_norm_in_gdn: Whether to use QK normalization.
       compute_dtype: Dtype for computation.
@@ -247,6 +257,7 @@ def ragged_gated_delta_rule_mixed_prefill(
         g,
         beta,
         query_start_loc,
+        distribution,
         chunk_size,
         compute_dtype=compute_dtype,
     )
@@ -476,6 +487,7 @@ def ragged_gated_delta_rule_decode_only(
     dt_bias: jnp.ndarray,
     query_start_loc: jnp.ndarray,
     state_indices: jnp.ndarray,
+    distribution: jnp.ndarray,
     use_qk_norm_in_gdn: bool,
 ) -> tuple[jnp.ndarray, jnp.ndarray]:
     """Applies gated delta rule for decode-only case (sequence lengths = 1).
@@ -491,6 +503,7 @@ def ragged_gated_delta_rule_decode_only(
       dt_bias: dt_bias tensor.
       query_start_loc: Start locations of sequences.
       state_indices: Indices mapping sequences to recurrent state slots.
+      distribution: Distribution tensor containing number of valid sequences at index 2.
       use_qk_norm_in_gdn: Whether to use QK normalization.
 
     Returns:
@@ -504,7 +517,7 @@ def ragged_gated_delta_rule_decode_only(
     token_idx = jnp.arange(num_tokens)
     req_indices = token_idx
     req_indices = jnp.clip(req_indices, 0, max_reqs - 1)
-    valid_mask = token_idx < query_start_loc[-1]
+    valid_mask = token_idx < distribution[2]
 
     beta = jax.nn.sigmoid(b_reshaped)
     g = -jnp.exp(A_log.astype(jnp.float32)) * jax.nn.softplus(
@@ -620,6 +633,7 @@ def ragged_gated_delta_rule(
             dt_bias=dt_bias,
             query_start_loc=query_start_loc,
             state_indices=state_indices,
+            distribution=distribution,
             use_qk_norm_in_gdn=use_qk_norm_in_gdn,
         )
         return new_state, output.astype(mixed_qkv.dtype)
@@ -636,6 +650,7 @@ def ragged_gated_delta_rule(
             query_start_loc=query_start_loc,
             recurrent_state=recurrent_state,
             state_indices=state_indices,
+            distribution=distribution,
             chunk_size=chunk_size,
             use_qk_norm_in_gdn=use_qk_norm_in_gdn,
         )


### PR DESCRIPTION
# Description

The line `query_start_loc = jnp.maximum.accumulate(query_start_loc)` for processing
padded query_start_loc is one of the performance bottleneck even though query_start_loc
is relatively small (max_seq_len, ). 

This PR removes query_start_loc processing and use distribution[2] to determine the sequence
length and mask the values not in the sequence. This has lead to 2x+ throughput increase.


# Tests
Tested offline script giving the same output as reference.
Benchmark the performance

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
