### PR TITLE
Fix release bug by setting tp=2 for tpu7x.

### DIFF
--- a/.buildkite/features/Out_Of_Tree_Model_Support.yml
+++ b/.buildkite/features/Out_Of_Tree_Model_Support.yml
@@ -43,6 +43,8 @@ steps:
   - label: "${TPU_VERSION:-tpu6e} Performance tests for Out-of-tree model support"
     key: "${TPU_VERSION:-tpu6e}_out_of_tree_model_support_PerformanceTest"
     depends_on: "${TPU_VERSION:-tpu6e}_record_out_of_tree_model_support_CorrectnessTest"
+    env:
+      TPU_VERSION: "${TPU_VERSION:-tpu6e}"
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"

--- a/.buildkite/models/Qwen_Qwen3-4B.yml
+++ b/.buildkite/models/Qwen_Qwen3-4B.yml
@@ -46,7 +46,7 @@ steps:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     env:
       TEST_MODEL: Qwen/Qwen3-4B
-      TENSOR_PARALLEL_SIZE: 1
+      TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       MINIMUM_ACCURACY_THRESHOLD: 0.85
     commands:
       - |
@@ -73,7 +73,7 @@ steps:
     soft_fail: true
     env:
       TEST_MODEL: Qwen/Qwen3-4B
-      TENSOR_PARALLEL_SIZE: 1
+      TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       MINIMUM_THROUGHPUT_THRESHOLD: 11.00
       INPUT_LEN: 1800
       OUTPUT_LEN: 128

--- a/tests/e2e/test_model_loader.py
+++ b/tests/e2e/test_model_loader.py
@@ -32,6 +32,10 @@ from tpu_inference.models.common.model_loader import (_MODEL_REGISTRY,
                                                       register_model)
 
 
+def _get_tensor_parallel_size():
+    return 2 if os.environ.get("TPU_VERSION", "tpu6e") == "tpu7x" else 1
+
+
 @pytest.fixture
 def cleanup_registries():
     """Cleans up the model registries before and after each test."""
@@ -145,7 +149,7 @@ def _run_server_and_bench(model_name: str, model_impl_type: str,
         "--max-model-len",
         "2048",
         "--tensor-parallel-size",
-        "1",
+        str(_get_tensor_parallel_size()),
         "--no-enable-prefix-caching",
         "--gpu-memory-utilization",
         "0.90",


### PR DESCRIPTION
# Description
Set tp=2 for tpu7x tests that have OOM issues.

# Test
https://buildkite.com/tpu-commons/tpu-inference-ci/builds/14378
