### PR TITLE
Fix compute_logits jit cache miss causing ForbidCompile error for VLM models

### DIFF
--- a/tpu_inference/runner/compilation_manager.py
+++ b/tpu_inference/runner/compilation_manager.py
@@ -497,11 +497,17 @@ class CompilationManager:
         logger.info("Compiling compute_logits with different input shapes.")
         hsize = self.runner.model_config.get_hidden_size()
         leading_shape = self.runner.num_reqs_paddings if not self.runner.speculative_config else self.runner.num_logits_paddings
-        dp_sharding = NamedSharding(self.runner.mesh,
-                                    PartitionSpec(ShardingAxisName.ATTN_DATA))
+        # Use PartitionSpec(ATTN_DATA, None) (2D explicit) to match the sharding
+        # that _select_from_array_fn produces at inference time. shard_map with
+        # out_specs=P('data') returns arrays with spec P('data', None); since
+        # compute_logits_fn has no in_shardings, JAX uses the actual input
+        # sharding as the jit cache key. P('data',) != P('data', None) as cache
+        # keys, causing a cache miss inside ForbidCompile → RuntimeError for VLMs.
+        hidden_states_sharding = NamedSharding(
+            self.runner.mesh, PartitionSpec(ShardingAxisName.ATTN_DATA, None))
         for num_reqs in leading_shape:
             hidden_states = self._create_dummy_tensor(
-                (num_reqs, hsize), jnp.bfloat16, dp_sharding)
+                (num_reqs, hsize), jnp.bfloat16, hidden_states_sharding)
             with self.runner.maybe_select_dummy_loras(
                     self.runner.lora_config,
                     np.array([num_reqs], dtype=np.int32)):


### PR DESCRIPTION
## Problem

(Migrate from releases/v0.18.0's PR: https://github.com/vllm-project/tpu-inference/pull/2223 to main.) 

For VLM models (e.g. Qwen2.5-VL), inference crashes with:

```
RuntimeError: JAX compilation occurred but was forbidden in this context.
```

`_precompile_compute_logits` warms the jit cache for `compute_logits_fn` using a dummy `hidden_states` with `PartitionSpec(ATTN_DATA)` (1D). At inference time, `hidden_states` is the output of `_select_from_array_fn`, which uses `jax.shard_map` with `out_specs=P('data')`. `shard_map` outputs carry an explicit trailing `None` on unreplicated axes, so the actual runtime sharding is `PartitionSpec(ATTN_DATA, None)` (2D).

Because `compute_logits_fn` has no `in_shardings`, JAX uses the actual input sharding as the jit cache key. `P('data',) != P('data', None)` as Python objects, so JAX sees a cache miss, triggers recompilation inside the `ForbidCompile` context, and raises.

This only manifests for VLMs because the vision encoder path produces `hidden_states` whose sharding propagates through `_select_from_array_fn` as `P('data', None)`. Non-VLM paths were not hit in practice.

## Fix

- Use `PartitionSpec(ATTN_DATA, None)` in `_precompile_compute_logits` to match the runtime sharding.
- Bake `HF_HUB_DISABLE_XET=1` into the Dockerfile to prevent HuggingFace download stalls from the XET protocol.

## Testing

Validated on the release branch equivalent (`fix-compute-logits-sharding-mismatch`, build #14405):
- `tpu7x Accuracy for Qwen/Qwen2.5-VL-7B-Instruct` — passed (previously failing)
- `tpu6e Accuracy for Qwen/Qwen2.5-VL-7B-Instruct` — passed
- All other accuracy tests (tpu7x + tpu6e) — passed