### PR TITLE
keep a lower gdown to avoid breaking changes in 6.0.0.

### DIFF
--- a/requirements_benchmarking.txt
+++ b/requirements_benchmarking.txt
@@ -6,4 +6,4 @@ datasets
 rouge-score
 scikit-learn
 pandas
-gdown
+gdown<6.0.0


### PR DESCRIPTION
Cherry-pick of #2221 from `releases/v0.18.0` to `main`.

Pin `gdown<6.0.0` to avoid breaking API changes introduced in 6.0.0.