### PR TITLE
Replicate the sampling RNG key to avoid extra device_put 

### DIFF
--- a/tests/runner/test_tpu_runner.py
+++ b/tests/runner/test_tpu_runner.py
@@ -208,7 +208,8 @@ class TestTPUJaxRunnerMultimodalModelLoadedForTextOnly:
              patch('jax.random.key', return_value=self.mock_rng_key), \
              patch('tpu_inference.runner.tpu_runner.nnx.Rngs', return_value=self.mock_rng_key), \
              patch('tpu_inference.runner.tpu_runner.get_model', return_value=self._model_get_model()), \
-             patch('tpu_inference.runner.tpu_runner.make_optimized_mesh', return_value=self.mock_mesh):
+             patch('tpu_inference.runner.tpu_runner.make_optimized_mesh', return_value=self.mock_mesh), \
+             patch('jax.device_put', side_effect=lambda x, *args, **kwargs: x):
 
             model_config = ModelConfig(tokenizer_mode="auto",
                                        trust_remote_code=False,
@@ -338,7 +339,8 @@ class TestTPUJaxRunnerDisableMM:
              patch('jax.random.key', return_value=self.mock_rng_key), \
              patch('tpu_inference.runner.tpu_runner.nnx.Rngs', return_value=self.mock_rng_key), \
              patch('tpu_inference.runner.tpu_runner.get_model', return_value=self._model_get_model()), \
-             patch('tpu_inference.runner.tpu_runner.make_optimized_mesh', return_value=self.mock_mesh):
+             patch('tpu_inference.runner.tpu_runner.make_optimized_mesh', return_value=self.mock_mesh), \
+             patch('jax.device_put', side_effect=lambda x, *args, **kwargs: x):
 
             model_config = ModelConfig(tokenizer_mode="auto",
                                        trust_remote_code=False,

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -578,8 +578,11 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             self.drafter.load_model(self.state)
 
         rng_key = nnx.Rngs(jax.random.key(self.model_config.seed)).params()
-        self.rng_params_for_sampling = jax.device_put(
-            rng_key, NamedSharding(self.mesh, PartitionSpec()))
+        self.rng_params_for_sampling = device_array(self.mesh,
+                                                    rng_key,
+                                                    sharding=NamedSharding(
+                                                        self.mesh,
+                                                        PartitionSpec()))
         # This allows a multi-modal model to be used as text-only, assuming the user
         # passes the following to vLLM (on the CLI):
         # --limit-mm-per-prompt '{"image": 0, "video": 0}'

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -577,9 +577,9 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             logger.info("Loading drafter model...")
             self.drafter.load_model(self.state)
 
-        self.rng_params_for_sampling = nnx.Rngs(
-            jax.random.key(self.model_config.seed)).params()
-
+        rng_key = nnx.Rngs(jax.random.key(self.model_config.seed)).params()
+        self.rng_params_for_sampling = jax.device_put(
+            rng_key, NamedSharding(self.mesh, PartitionSpec()))
         # This allows a multi-modal model to be used as text-only, assuming the user
         # passes the following to vLLM (on the CLI):
         # --limit-mm-per-prompt '{"image": 0, "video": 0}'


### PR DESCRIPTION
# Description

Replicate the RNG key across all devices in the mesh so that `jax.random.split` produces replicated keys and the jitted sample() function does not trigger a `DevicePutWithSharding` to broadcast from a single device at every step.

Before: 

<img width="1138" height="504" alt="Screenshot 2026-04-13 at 12 17 42 PM" src="https://github.com/user-attachments/assets/d03c5a89-dac2-433b-b455-ac2bdfa6e6b2" />

After: 

<img width="1260" height="491" alt="Screenshot 2026-04-13 at 12 19 04 PM" src="https://github.com/user-attachments/assets/6b48823e-0a83-4217-8e00-907c1ddab328" />


# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
