### PR TITLE
Add DeviceBuffer class so we can device_put a single contiguous array of metadata 

### DIFF
--- a/tests/layers/jax/sample/test_sampling_metadata.py
+++ b/tests/layers/jax/sample/test_sampling_metadata.py
@@ -22,7 +22,6 @@ from jax.sharding import Mesh, NamedSharding, PartitionSpec
 
 from tpu_inference.layers.jax.sample.sampling_metadata import (
     DEFAULT_SAMPLING_PARAMS, TPUSupportedSamplingMetadata)
-from tpu_inference.utils import DeviceBuffer
 
 ## Mocks and Fixtures
 
@@ -37,23 +36,6 @@ class MockInputBatch:
     top_k_cpu: np.ndarray = None
     top_p_cpu: np.ndarray = None
     max_num_logprobs: int = None
-
-
-def _create_metadata(
-    mesh: Mesh,
-    mock_batch: MockInputBatch,
-    padded_num_reqs: int,
-) -> TPUSupportedSamplingMetadata:
-    device_buffer = DeviceBuffer()
-    TPUSupportedSamplingMetadata.add_to_device_buffer(mock_batch,
-                                                      padded_num_reqs,
-                                                      device_buffer)
-    metadata_blob, metadata_layout = device_buffer.build()
-    sharding = NamedSharding(mesh, PartitionSpec(None))
-    dev_blob = jax.device_put(metadata_blob, sharding)
-    metadata_dict = DeviceBuffer.unpack_arrays(dev_blob, metadata_layout)
-    return TPUSupportedSamplingMetadata.from_unpacked_arrays(
-        mesh, metadata_dict, mock_batch)
 
 
 @pytest.fixture(scope="module")
@@ -76,7 +58,8 @@ def test_from_input_batch_all_greedy(mesh: Mesh):
     mock_batch = MockInputBatch(all_greedy=True)
     padded_num_reqs = 4
 
-    metadata = _create_metadata(mesh, mock_batch, padded_num_reqs)
+    metadata = TPUSupportedSamplingMetadata.from_input_batch(
+        mesh=mesh, input_batch=mock_batch, padded_num_reqs=padded_num_reqs)
 
     assert not metadata.do_sampling, "do_sampling should be False for greedy requests"
     assert metadata.temperature is None
@@ -105,7 +88,8 @@ def test_from_input_batch_with_sampling_and_padding(mesh: Mesh):
         top_p_cpu=top_p_tensor,
     )
 
-    metadata = _create_metadata(mesh, mock_batch, padded_num_reqs)
+    metadata = TPUSupportedSamplingMetadata.from_input_batch(
+        mesh=mesh, input_batch=mock_batch, padded_num_reqs=padded_num_reqs)
 
     # 1. Check metadata flags and types
     assert metadata.do_sampling, "do_sampling should be True"
@@ -171,7 +155,8 @@ def test_from_input_batch_no_padding_needed(mesh: Mesh):
         top_p_cpu=top_p_tensor,
     )
 
-    metadata = _create_metadata(mesh, mock_batch, padded_num_reqs)
+    metadata = TPUSupportedSamplingMetadata.from_input_batch(
+        mesh=mesh, input_batch=mock_batch, padded_num_reqs=padded_num_reqs)
 
     assert metadata.do_sampling
     # Check that values are identical to the input, since no padding was needed
@@ -217,18 +202,33 @@ def test_from_input_batch_with_logprobs(mesh: Mesh):
     Tests that the `logprobs` flag is correctly set based on `max_num_logprobs`.
     """
     # Case 1: Logprobs are requested
-    mock_batch = MockInputBatch(all_greedy=True, max_num_logprobs=5)
-    metadata_with = _create_metadata(mesh, mock_batch, 4)
+    mock_batch_with_logprobs = MockInputBatch(all_greedy=True,
+                                              max_num_logprobs=5)
+    metadata_with = TPUSupportedSamplingMetadata.from_input_batch(
+        mesh=mesh,
+        input_batch=mock_batch_with_logprobs,
+        padded_num_reqs=4,
+    )
     assert metadata_with.logprobs, "logprobs should be True when max_num_logprobs > 0"
 
     # Case 2: Logprobs are not requested (max_num_logprobs is 0)
-    mock_batch = MockInputBatch(all_greedy=True, max_num_logprobs=0)
-    metadata_without_zero = _create_metadata(mesh, mock_batch, 4)
+    mock_batch_no_logprobs_zero = MockInputBatch(all_greedy=True,
+                                                 max_num_logprobs=0)
+    metadata_without_zero = TPUSupportedSamplingMetadata.from_input_batch(
+        mesh=mesh,
+        input_batch=mock_batch_no_logprobs_zero,
+        padded_num_reqs=4,
+    )
     assert not metadata_without_zero.logprobs, "logprobs should be False when max_num_logprobs is 0"
 
     # Case 3: Logprobs are not requested (max_num_logprobs is None)
-    mock_batch = MockInputBatch(all_greedy=True, max_num_logprobs=None)
-    metadata_without_none = _create_metadata(mesh, mock_batch, 4)
+    mock_batch_no_logprobs_none = MockInputBatch(all_greedy=True,
+                                                 max_num_logprobs=None)
+    metadata_without_none = TPUSupportedSamplingMetadata.from_input_batch(
+        mesh=mesh,
+        input_batch=mock_batch_no_logprobs_none,
+        padded_num_reqs=4,
+    )
     assert not metadata_without_none.logprobs, "logprobs should be False when max_num_logprobs is None"
 
 
@@ -247,7 +247,8 @@ def test_from_input_batch_sampling_with_logprobs(mesh: Mesh):
         max_num_logprobs=10,
     )
 
-    metadata = _create_metadata(mesh, mock_batch, padded_num_reqs)
+    metadata = TPUSupportedSamplingMetadata.from_input_batch(
+        mesh=mesh, input_batch=mock_batch, padded_num_reqs=padded_num_reqs)
 
     assert metadata.do_sampling, "do_sampling should be True"
     assert metadata.logprobs, "logprobs should be True"

--- a/tests/layers/jax/sample/test_sampling_metadata.py
+++ b/tests/layers/jax/sample/test_sampling_metadata.py
@@ -22,6 +22,7 @@ from jax.sharding import Mesh, NamedSharding, PartitionSpec
 
 from tpu_inference.layers.jax.sample.sampling_metadata import (
     DEFAULT_SAMPLING_PARAMS, TPUSupportedSamplingMetadata)
+from tpu_inference.utils import DeviceBuffer
 
 ## Mocks and Fixtures
 
@@ -36,6 +37,23 @@ class MockInputBatch:
     top_k_cpu: np.ndarray = None
     top_p_cpu: np.ndarray = None
     max_num_logprobs: int = None
+
+
+def _create_metadata(
+    mesh: Mesh,
+    mock_batch: MockInputBatch,
+    padded_num_reqs: int,
+) -> TPUSupportedSamplingMetadata:
+    device_buffer = DeviceBuffer()
+    TPUSupportedSamplingMetadata.add_to_device_buffer(mock_batch,
+                                                      padded_num_reqs,
+                                                      device_buffer)
+    metadata_blob, metadata_layout = device_buffer.build()
+    sharding = NamedSharding(mesh, PartitionSpec(None))
+    dev_blob = jax.device_put(metadata_blob, sharding)
+    metadata_dict = DeviceBuffer.unpack_arrays(dev_blob, metadata_layout)
+    return TPUSupportedSamplingMetadata.from_unpacked_arrays(
+        mesh, metadata_dict, mock_batch)
 
 
 @pytest.fixture(scope="module")
@@ -58,8 +76,7 @@ def test_from_input_batch_all_greedy(mesh: Mesh):
     mock_batch = MockInputBatch(all_greedy=True)
     padded_num_reqs = 4
 
-    metadata = TPUSupportedSamplingMetadata.from_input_batch(
-        mesh=mesh, input_batch=mock_batch, padded_num_reqs=padded_num_reqs)
+    metadata = _create_metadata(mesh, mock_batch, padded_num_reqs)
 
     assert not metadata.do_sampling, "do_sampling should be False for greedy requests"
     assert metadata.temperature is None
@@ -88,8 +105,7 @@ def test_from_input_batch_with_sampling_and_padding(mesh: Mesh):
         top_p_cpu=top_p_tensor,
     )
 
-    metadata = TPUSupportedSamplingMetadata.from_input_batch(
-        mesh=mesh, input_batch=mock_batch, padded_num_reqs=padded_num_reqs)
+    metadata = _create_metadata(mesh, mock_batch, padded_num_reqs)
 
     # 1. Check metadata flags and types
     assert metadata.do_sampling, "do_sampling should be True"
@@ -155,8 +171,7 @@ def test_from_input_batch_no_padding_needed(mesh: Mesh):
         top_p_cpu=top_p_tensor,
     )
 
-    metadata = TPUSupportedSamplingMetadata.from_input_batch(
-        mesh=mesh, input_batch=mock_batch, padded_num_reqs=padded_num_reqs)
+    metadata = _create_metadata(mesh, mock_batch, padded_num_reqs)
 
     assert metadata.do_sampling
     # Check that values are identical to the input, since no padding was needed
@@ -202,33 +217,18 @@ def test_from_input_batch_with_logprobs(mesh: Mesh):
     Tests that the `logprobs` flag is correctly set based on `max_num_logprobs`.
     """
     # Case 1: Logprobs are requested
-    mock_batch_with_logprobs = MockInputBatch(all_greedy=True,
-                                              max_num_logprobs=5)
-    metadata_with = TPUSupportedSamplingMetadata.from_input_batch(
-        mesh=mesh,
-        input_batch=mock_batch_with_logprobs,
-        padded_num_reqs=4,
-    )
+    mock_batch = MockInputBatch(all_greedy=True, max_num_logprobs=5)
+    metadata_with = _create_metadata(mesh, mock_batch, 4)
     assert metadata_with.logprobs, "logprobs should be True when max_num_logprobs > 0"
 
     # Case 2: Logprobs are not requested (max_num_logprobs is 0)
-    mock_batch_no_logprobs_zero = MockInputBatch(all_greedy=True,
-                                                 max_num_logprobs=0)
-    metadata_without_zero = TPUSupportedSamplingMetadata.from_input_batch(
-        mesh=mesh,
-        input_batch=mock_batch_no_logprobs_zero,
-        padded_num_reqs=4,
-    )
+    mock_batch = MockInputBatch(all_greedy=True, max_num_logprobs=0)
+    metadata_without_zero = _create_metadata(mesh, mock_batch, 4)
     assert not metadata_without_zero.logprobs, "logprobs should be False when max_num_logprobs is 0"
 
     # Case 3: Logprobs are not requested (max_num_logprobs is None)
-    mock_batch_no_logprobs_none = MockInputBatch(all_greedy=True,
-                                                 max_num_logprobs=None)
-    metadata_without_none = TPUSupportedSamplingMetadata.from_input_batch(
-        mesh=mesh,
-        input_batch=mock_batch_no_logprobs_none,
-        padded_num_reqs=4,
-    )
+    mock_batch = MockInputBatch(all_greedy=True, max_num_logprobs=None)
+    metadata_without_none = _create_metadata(mesh, mock_batch, 4)
     assert not metadata_without_none.logprobs, "logprobs should be False when max_num_logprobs is None"
 
 
@@ -247,8 +247,7 @@ def test_from_input_batch_sampling_with_logprobs(mesh: Mesh):
         max_num_logprobs=10,
     )
 
-    metadata = TPUSupportedSamplingMetadata.from_input_batch(
-        mesh=mesh, input_batch=mock_batch, padded_num_reqs=padded_num_reqs)
+    metadata = _create_metadata(mesh, mock_batch, padded_num_reqs)
 
     assert metadata.do_sampling, "do_sampling should be True"
     assert metadata.logprobs, "logprobs should be True"

--- a/tests/runner/test_speculative_decoding_manager.py
+++ b/tests/runner/test_speculative_decoding_manager.py
@@ -196,7 +196,6 @@ class TestSpeculativeDecodingManager:
         # Mock runner attributes needed by the function
         self.runner.arange_cpu = np.arange(1024, dtype=np.int64)
         # Make input_ids_cpu a sequence of numbers for easy verification
-        self.runner.input_ids_cpu = np.arange(1024, dtype=np.int32) * 10
         self.runner.num_tokens_paddings = [16, 32, 64, 128, 256, 512, 1024]
 
         # Mock the device_array function to just return the numpy arrays

--- a/tests/runner/test_speculative_decoding_manager.py
+++ b/tests/runner/test_speculative_decoding_manager.py
@@ -250,6 +250,7 @@ class TestSpeculativeDecodingManager:
         num_draft_tokens_np = np.array(num_draft_tokens, dtype=np.int32)
         cu_num_scheduled_tokens_np = np.array(cu_num_scheduled_tokens,
                                               dtype=np.int32)
+        input_ids = np.arange(1024, dtype=np.int32) * 10
 
         # Act
         with patch(
@@ -258,7 +259,8 @@ class TestSpeculativeDecodingManager:
             metadata = self.runner.speculative_decoding_manager.get_spec_decode_metadata(
                 num_draft_tokens_np,
                 cu_num_scheduled_tokens_np,
-                padded_num_reqs=padded_num_reqs)
+                padded_num_reqs=padded_num_reqs,
+                input_ids=input_ids)
 
         # Assert basic properties
         assert isinstance(metadata, SpecDecodeMetadata)

--- a/tests/runner/test_tpu_runner.py
+++ b/tests/runner/test_tpu_runner.py
@@ -158,14 +158,11 @@ class TestTPUJaxRunner:
         # Mock block tables
         # there will be 2 block tables since there are 2 kv cache groups
         mock_block_table = MagicMock()
-        mock_block_table.get_cpu_tensor.return_value = np.zeros(
-            self.runner.block_tables_cpu[0].shape)
+        mock_block_table.max_num_blocks_per_req = 8
+        mock_block_table.get_cpu_tensor.return_value = np.zeros((1, 8),
+                                                                dtype=np.int32)
         self.runner.input_batch.block_table = [
             mock_block_table, mock_block_table
-        ]
-        self.runner.block_tables_cpu = [
-            np.zeros(self.runner.block_tables_cpu[0].shape, dtype=np.int32),
-            np.zeros(self.runner.block_tables_cpu[0].shape, dtype=np.int32)
         ]
 
         mock_sampling_instance = MagicMock()

--- a/tests/runner/test_tpu_runner_dp.py
+++ b/tests/runner/test_tpu_runner_dp.py
@@ -1337,8 +1337,13 @@ class TestSamplingMetadataPassthrough:
 
         TPUModelRunner._prepare_inputs_dp(runner, scheduler_output)
 
-        # Verify from_inp  utfrom_input_batch was called exactly once
+        # Verify from_input_batch was called exactly once with the ATTN_DATA sharding
         mock_sampling_metadata.from_input_batch.assert_called_once()
+        sharding_arg = mock_sampling_metadata.from_input_batch.call_args.kwargs.get(
+            'sharding')
+        assert sharding_arg is mock_named_sharding.return_value, (
+            "from_input_batch should receive the data_parallel_attn_sharding instance"
+        )
 
         # Verify NamedSharding was called with ATTN_DATA PartitionSpec.
         call_partition_specs = [

--- a/tests/runner/test_tpu_runner_dp.py
+++ b/tests/runner/test_tpu_runner_dp.py
@@ -59,6 +59,7 @@ class TestTPUJaxRunnerDPInputsLightweight:
         self.runner.input_batch.block_table = [mock_block_table]
 
         # Initialize CPU arrays that the method modifies
+        self.runner.positions_cpu = np.zeros(64, dtype=np.int32)
         self.runner.mrope_positions_cpu = np.zeros((3, 64), dtype=np.int64)
         self.runner.arange_cpu = np.arange(64, dtype=np.int64)
         self.runner.uses_mrope = False
@@ -1301,6 +1302,7 @@ class TestSamplingMetadataPassthrough:
         mock_block_table.max_num_blocks_per_req = 8
         mock_block_table.get_cpu_tensor.return_value = np.arange(32).reshape(
             4, 8)
+        runner.positions_cpu = np.zeros(64, dtype=np.int32)
         runner.input_batch.block_table = [mock_block_table]
         runner.arange_cpu = np.arange(64, dtype=np.int64)
 

--- a/tests/runner/test_tpu_runner_dp.py
+++ b/tests/runner/test_tpu_runner_dp.py
@@ -62,7 +62,6 @@ class TestTPUJaxRunnerDPInputsLightweight:
         self.runner.mrope_positions_cpu = np.zeros((3, 64), dtype=np.int64)
         self.runner.arange_cpu = np.arange(64, dtype=np.int64)
         self.runner.uses_mrope = False
-        self.runner.mrope_positions_cpu = np.zeros((3, 64), dtype=np.int64)
 
         from tpu_inference.utils import DeviceBuffer
         self.runner.device_buffer = DeviceBuffer(initial_capacity=1024 * 1024)
@@ -182,7 +181,7 @@ class TestTPUJaxRunnerDPInputsLightweight:
             num_scheduled_tokens, assigned_dp_ranks)
 
         mock_runner_utils.get_padded_token_len.return_value = 16
-        mock_sampling_metadata.from_unpacked_arrays.return_value = MagicMock()
+        mock_sampling_metadata.from_input_batch.return_value = MagicMock()
         self.runner.uses_mrope = True
 
         mock_mesh = MagicMock(spec=Mesh)
@@ -206,7 +205,7 @@ class TestTPUJaxRunnerDPInputsLightweight:
         """Test basic functionality of _prepare_inputs_dp."""
         # Mock utility functions
         mock_runner_utils.get_padded_token_len.return_value = 16
-        mock_sampling_metadata.from_unpacked_arrays.return_value = MagicMock()
+        mock_sampling_metadata.from_input_batch.return_value = MagicMock()
         mock_named_sharding.return_value = MagicMock()
 
         # Create test data - only use req1 and req2 to match num_reqs=2
@@ -256,7 +255,7 @@ class TestTPUJaxRunnerDPInputsLightweight:
         """Test basic functionality of _prepare_inputs_dp."""
         # Mock utility functions
         mock_runner_utils.get_padded_token_len.return_value = 16
-        mock_sampling_metadata.from_unpacked_arrays.return_value = MagicMock()
+        mock_sampling_metadata.from_input_batch.return_value = MagicMock()
         mock_named_sharding.return_value = MagicMock()
 
         # Create test data - only use req1 and req2 to match num_reqs=2
@@ -506,7 +505,7 @@ class TestTPUJaxRunnerDPInputsLightweight:
 
         mock_runner_utils.get_padded_token_len.side_effect = mock_get_padded_token_len
         mock_sampling_instance = MagicMock()
-        mock_sampling_metadata.from_unpacked_arrays.return_value = mock_sampling_instance
+        mock_sampling_metadata.from_input_batch.return_value = mock_sampling_instance
         mock_named_sharding.return_value = MagicMock()
 
         # Setup deterministic test data
@@ -619,7 +618,7 @@ class TestTPUJaxRunnerDPInputsLightweight:
 
         mock_runner_utils.get_padded_token_len.side_effect = mock_get_padded_token_len
         mock_sampling_instance = MagicMock()
-        mock_sampling_metadata.from_unpacked_arrays.return_value = mock_sampling_instance
+        mock_sampling_metadata.from_input_batch.return_value = mock_sampling_instance
         mock_named_sharding.return_value = MagicMock()
 
         # Setup test data with all requests on rank 0 (empty rank 1)
@@ -745,7 +744,7 @@ class TestTPUJaxRunnerDPInputsLightweight:
 
         mock_runner_utils.get_padded_token_len.side_effect = mock_get_padded_token_len
         mock_sampling_instance = MagicMock()
-        mock_sampling_metadata.from_unpacked_arrays.return_value = mock_sampling_instance
+        mock_sampling_metadata.from_input_batch.return_value = mock_sampling_instance
         mock_named_sharding.return_value = MagicMock()
 
         # Setup test data with decode requests (1 token) and prefill requests (>1 token)
@@ -807,7 +806,7 @@ class TestTPUJaxRunnerDPInputsLightweight:
 
         mock_runner_utils.get_padded_token_len.side_effect = mock_get_padded_token_len
         mock_sampling_instance = MagicMock()
-        mock_sampling_metadata.from_unpacked_arrays.return_value = mock_sampling_instance
+        mock_sampling_metadata.from_input_batch.return_value = mock_sampling_instance
         mock_named_sharding.return_value = MagicMock()
 
         # All requests are decode (1 token each)
@@ -1044,7 +1043,7 @@ class TestTPUJaxRunnerDPInputsLightweight:
 
         mock_runner_utils.get_padded_token_len.side_effect = mock_get_padded_token_len
         mock_sampling_instance = MagicMock()
-        mock_sampling_metadata.from_unpacked_arrays.return_value = mock_sampling_instance
+        mock_sampling_metadata.from_input_batch.return_value = mock_sampling_instance
         mock_named_sharding.return_value = MagicMock()
 
         # Setup test data
@@ -1117,7 +1116,7 @@ class TestTPUJaxRunnerDPInputsLightweight:
 
         mock_runner_utils.get_padded_token_len.side_effect = mock_get_padded_token_len
         mock_sampling_instance = MagicMock()
-        mock_sampling_metadata.from_unpacked_arrays.return_value = mock_sampling_instance
+        mock_sampling_metadata.from_input_batch.return_value = mock_sampling_instance
         mock_named_sharding.return_value = MagicMock()
 
         # Setup test data
@@ -1323,7 +1322,7 @@ class TestSamplingMetadataPassthrough:
             runner)
 
         mock_runner_utils.get_padded_token_len.side_effect = lambda paddings, val: 8
-        mock_sampling_metadata.from_unpacked_arrays.return_value = MagicMock()
+        mock_sampling_metadata.from_input_batch.return_value = MagicMock()
         mock_named_sharding.return_value = MagicMock()
 
         scheduler_output = MagicMock()
@@ -1336,10 +1335,8 @@ class TestSamplingMetadataPassthrough:
 
         TPUModelRunner._prepare_inputs_dp(runner, scheduler_output)
 
-        # Verify from_unpacked_arrays was called exactly once
-        mock_sampling_metadata.from_unpacked_arrays.assert_called_once()
-        # Verify add_to_device_buffer was called exactly once
-        mock_sampling_metadata.add_to_device_buffer.assert_called_once()
+        # Verify from_inp  utfrom_input_batch was called exactly once
+        mock_sampling_metadata.from_input_batch.assert_called_once()
 
         # Verify NamedSharding was called with ATTN_DATA PartitionSpec.
         call_partition_specs = [
@@ -1385,9 +1382,9 @@ class TestSamplingMetadataPassthrough:
                 padded_num_reqs=8,
             )
         except Exception:
-            pass  # only care that from_unpacked_arrays was never called
+            pass  # only care that from_input_batch was never called
 
-        mock_sampling_metadata.from_unpacked_arrays.assert_not_called()
+        mock_sampling_metadata.from_input_batch.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/tests/runner/test_tpu_runner_dp.py
+++ b/tests/runner/test_tpu_runner_dp.py
@@ -182,7 +182,7 @@ class TestTPUJaxRunnerDPInputsLightweight:
             num_scheduled_tokens, assigned_dp_ranks)
 
         mock_runner_utils.get_padded_token_len.return_value = 16
-        mock_sampling_metadata.from_input_batch.return_value = MagicMock()
+        mock_sampling_metadata.from_unpacked_arrays.return_value = MagicMock()
         self.runner.uses_mrope = True
 
         mock_mesh = MagicMock(spec=Mesh)
@@ -194,6 +194,7 @@ class TestTPUJaxRunnerDPInputsLightweight:
 
         assert len(result) == 8
 
+    @patch('jax.device_put', side_effect=lambda x, y: x)
     @patch('tpu_inference.runner.tpu_runner.NamedSharding')
     @patch('tpu_inference.runner.tpu_runner.runner_utils')
     @patch('tpu_inference.runner.tpu_runner.device_array',
@@ -205,7 +206,7 @@ class TestTPUJaxRunnerDPInputsLightweight:
         """Test basic functionality of _prepare_inputs_dp."""
         # Mock utility functions
         mock_runner_utils.get_padded_token_len.return_value = 16
-        mock_sampling_metadata.from_input_batch.return_value = MagicMock()
+        mock_sampling_metadata.from_unpacked_arrays.return_value = MagicMock()
         mock_named_sharding.return_value = MagicMock()
 
         # Create test data - only use req1 and req2 to match num_reqs=2
@@ -255,7 +256,7 @@ class TestTPUJaxRunnerDPInputsLightweight:
         """Test basic functionality of _prepare_inputs_dp."""
         # Mock utility functions
         mock_runner_utils.get_padded_token_len.return_value = 16
-        mock_sampling_metadata.from_input_batch.return_value = MagicMock()
+        mock_sampling_metadata.from_unpacked_arrays.return_value = MagicMock()
         mock_named_sharding.return_value = MagicMock()
 
         # Create test data - only use req1 and req2 to match num_reqs=2
@@ -505,7 +506,7 @@ class TestTPUJaxRunnerDPInputsLightweight:
 
         mock_runner_utils.get_padded_token_len.side_effect = mock_get_padded_token_len
         mock_sampling_instance = MagicMock()
-        mock_sampling_metadata.from_input_batch.return_value = mock_sampling_instance
+        mock_sampling_metadata.from_unpacked_arrays.return_value = mock_sampling_instance
         mock_named_sharding.return_value = MagicMock()
 
         # Setup deterministic test data
@@ -618,7 +619,7 @@ class TestTPUJaxRunnerDPInputsLightweight:
 
         mock_runner_utils.get_padded_token_len.side_effect = mock_get_padded_token_len
         mock_sampling_instance = MagicMock()
-        mock_sampling_metadata.from_input_batch.return_value = mock_sampling_instance
+        mock_sampling_metadata.from_unpacked_arrays.return_value = mock_sampling_instance
         mock_named_sharding.return_value = MagicMock()
 
         # Setup test data with all requests on rank 0 (empty rank 1)
@@ -744,7 +745,7 @@ class TestTPUJaxRunnerDPInputsLightweight:
 
         mock_runner_utils.get_padded_token_len.side_effect = mock_get_padded_token_len
         mock_sampling_instance = MagicMock()
-        mock_sampling_metadata.from_input_batch.return_value = mock_sampling_instance
+        mock_sampling_metadata.from_unpacked_arrays.return_value = mock_sampling_instance
         mock_named_sharding.return_value = MagicMock()
 
         # Setup test data with decode requests (1 token) and prefill requests (>1 token)
@@ -806,7 +807,7 @@ class TestTPUJaxRunnerDPInputsLightweight:
 
         mock_runner_utils.get_padded_token_len.side_effect = mock_get_padded_token_len
         mock_sampling_instance = MagicMock()
-        mock_sampling_metadata.from_input_batch.return_value = mock_sampling_instance
+        mock_sampling_metadata.from_unpacked_arrays.return_value = mock_sampling_instance
         mock_named_sharding.return_value = MagicMock()
 
         # All requests are decode (1 token each)
@@ -1043,7 +1044,7 @@ class TestTPUJaxRunnerDPInputsLightweight:
 
         mock_runner_utils.get_padded_token_len.side_effect = mock_get_padded_token_len
         mock_sampling_instance = MagicMock()
-        mock_sampling_metadata.from_input_batch.return_value = mock_sampling_instance
+        mock_sampling_metadata.from_unpacked_arrays.return_value = mock_sampling_instance
         mock_named_sharding.return_value = MagicMock()
 
         # Setup test data
@@ -1116,7 +1117,7 @@ class TestTPUJaxRunnerDPInputsLightweight:
 
         mock_runner_utils.get_padded_token_len.side_effect = mock_get_padded_token_len
         mock_sampling_instance = MagicMock()
-        mock_sampling_metadata.from_input_batch.return_value = mock_sampling_instance
+        mock_sampling_metadata.from_unpacked_arrays.return_value = mock_sampling_instance
         mock_named_sharding.return_value = MagicMock()
 
         # Setup test data
@@ -1322,7 +1323,7 @@ class TestSamplingMetadataPassthrough:
             runner)
 
         mock_runner_utils.get_padded_token_len.side_effect = lambda paddings, val: 8
-        mock_sampling_metadata.from_input_batch.return_value = MagicMock()
+        mock_sampling_metadata.from_unpacked_arrays.return_value = MagicMock()
         mock_named_sharding.return_value = MagicMock()
 
         scheduler_output = MagicMock()
@@ -1335,13 +1336,10 @@ class TestSamplingMetadataPassthrough:
 
         TPUModelRunner._prepare_inputs_dp(runner, scheduler_output)
 
-        # Verify from_input_batch was called exactly once with the ATTN_DATA sharding
-        mock_sampling_metadata.from_input_batch.assert_called_once()
-        sharding_arg = mock_sampling_metadata.from_input_batch.call_args.kwargs.get(
-            'sharding')
-        assert sharding_arg is mock_named_sharding.return_value, (
-            "from_input_batch should receive the data_parallel_attn_sharding instance"
-        )
+        # Verify from_unpacked_arrays was called exactly once
+        mock_sampling_metadata.from_unpacked_arrays.assert_called_once()
+        # Verify add_to_device_buffer was called exactly once
+        mock_sampling_metadata.add_to_device_buffer.assert_called_once()
 
         # Verify NamedSharding was called with ATTN_DATA PartitionSpec.
         call_partition_specs = [
@@ -1387,9 +1385,9 @@ class TestSamplingMetadataPassthrough:
                 padded_num_reqs=8,
             )
         except Exception:
-            pass  # only care that from_input_batch was never called
+            pass  # only care that from_unpacked_arrays was never called
 
-        mock_sampling_metadata.from_input_batch.assert_not_called()
+        mock_sampling_metadata.from_unpacked_arrays.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/tests/runner/test_tpu_runner_dp.py
+++ b/tests/runner/test_tpu_runner_dp.py
@@ -59,12 +59,7 @@ class TestTPUJaxRunnerDPInputsLightweight:
         self.runner.input_batch.block_table = [mock_block_table]
 
         # Initialize CPU arrays that the method modifies
-        self.runner.input_ids_cpu = np.zeros(64, dtype=np.int32)
-        self.runner.positions_cpu = np.zeros(64, dtype=np.int32)
         self.runner.mrope_positions_cpu = np.zeros((3, 64), dtype=np.int64)
-        self.runner.query_start_loc_cpu = np.zeros(10, dtype=np.int32)
-        self.runner.seq_lens_cpu = np.zeros(8, dtype=np.int32)
-        self.runner.logits_indices_cpu = np.zeros(8, dtype=np.int32)
         self.runner.arange_cpu = np.arange(64, dtype=np.int64)
         self.runner.uses_mrope = False
         self.runner.mrope_positions_cpu = np.zeros((3, 64), dtype=np.int64)
@@ -1307,11 +1302,6 @@ class TestSamplingMetadataPassthrough:
         mock_block_table.get_cpu_tensor.return_value = np.arange(32).reshape(
             4, 8)
         runner.input_batch.block_table = [mock_block_table]
-        runner.input_ids_cpu = np.zeros(64, dtype=np.int32)
-        runner.positions_cpu = np.zeros(64, dtype=np.int32)
-        runner.query_start_loc_cpu = np.zeros(10, dtype=np.int32)
-        runner.seq_lens_cpu = np.zeros(8, dtype=np.int32)
-        runner.logits_indices_cpu = np.zeros(8, dtype=np.int32)
         runner.arange_cpu = np.arange(64, dtype=np.int64)
 
         from tpu_inference.utils import DeviceBuffer

--- a/tests/runner/test_tpu_runner_dp.py
+++ b/tests/runner/test_tpu_runner_dp.py
@@ -53,6 +53,7 @@ class TestTPUJaxRunnerDPInputsLightweight:
 
         # Mock block table
         mock_block_table = MagicMock()
+        mock_block_table.max_num_blocks_per_req = 8
         mock_block_table.get_cpu_tensor.return_value = np.arange(32).reshape(
             4, 8)
         self.runner.input_batch.block_table = [mock_block_table]
@@ -64,8 +65,12 @@ class TestTPUJaxRunnerDPInputsLightweight:
         self.runner.query_start_loc_cpu = np.zeros(10, dtype=np.int32)
         self.runner.seq_lens_cpu = np.zeros(8, dtype=np.int32)
         self.runner.logits_indices_cpu = np.zeros(8, dtype=np.int32)
-        self.runner.block_tables_cpu = [np.zeros((8, 8), dtype=np.int32)]
         self.runner.arange_cpu = np.arange(64, dtype=np.int64)
+        self.runner.uses_mrope = False
+        self.runner.mrope_positions_cpu = np.zeros((3, 64), dtype=np.int64)
+
+        from tpu_inference.utils import DeviceBuffer
+        self.runner.device_buffer = DeviceBuffer(initial_capacity=1024 * 1024)
 
         # mock kv cache group
         mock_kv_cache_config = MagicMock()
@@ -199,11 +204,9 @@ class TestTPUJaxRunnerDPInputsLightweight:
     @patch('tpu_inference.runner.tpu_runner.device_array',
            side_effect=lambda mesh, tensors, **kwargs: tensors)
     @patch('tpu_inference.runner.tpu_runner.TPUSupportedSamplingMetadata')
-    def test_prepare_inputs_dp_basic_functionality(self,
-                                                   mock_sampling_metadata,
-                                                   mock_device_array,
-                                                   mock_runner_utils,
-                                                   mock_named_sharding):
+    def test_prepare_inputs_dp_basic_functionality(
+            self, mock_sampling_metadata, mock_device_array, mock_runner_utils,
+            mock_named_sharding, mock_device_put):
         """Test basic functionality of _prepare_inputs_dp."""
         # Mock utility functions
         mock_runner_utils.get_padded_token_len.return_value = 16
@@ -243,6 +246,7 @@ class TestTPUJaxRunnerDPInputsLightweight:
         with pytest.raises(AssertionError):
             self.runner._prepare_inputs_dp(scheduler_output)
 
+    @patch('jax.device_put', side_effect=lambda x, y: x)
     @patch('tpu_inference.runner.tpu_runner.NamedSharding')
     @patch('tpu_inference.runner.tpu_runner.runner_utils')
     @patch('tpu_inference.runner.tpu_runner.device_array',
@@ -251,7 +255,8 @@ class TestTPUJaxRunnerDPInputsLightweight:
     def test_prepare_inputs_dp_hybrid_kvcache(self, mock_sampling_metadata,
                                               mock_device_array,
                                               mock_runner_utils,
-                                              mock_named_sharding):
+                                              mock_named_sharding,
+                                              mock_device_put):
         """Test basic functionality of _prepare_inputs_dp."""
         # Mock utility functions
         mock_runner_utils.get_padded_token_len.return_value = 16
@@ -269,16 +274,11 @@ class TestTPUJaxRunnerDPInputsLightweight:
 
         # update input_batch's block_table
         mock_block_table = MagicMock()
+        mock_block_table.max_num_blocks_per_req = 8
         mock_block_table.get_cpu_tensor.return_value = np.arange(32).reshape(
             4, 8)
         self.runner.input_batch.block_table = [
             mock_block_table, mock_block_table
-        ]
-
-        # update model runner's block_tables_cpu:
-        self.runner.block_tables_cpu = [
-            np.zeros((8, 8), dtype=np.int32),
-            np.zeros((8, 8), dtype=np.int32)
         ]
 
         # Execute the method
@@ -486,16 +486,15 @@ class TestTPUJaxRunnerDPInputsLightweight:
             np.testing.assert_array_equal(logits_indices_selector,
                                           expected_positions)
 
+    @patch('jax.device_put', side_effect=lambda x, y: x)
     @patch('tpu_inference.runner.tpu_runner.NamedSharding')
     @patch('tpu_inference.runner.tpu_runner.runner_utils')
     @patch('tpu_inference.runner.tpu_runner.device_array',
            side_effect=lambda mesh, tensors, **kwargs: tensors)
     @patch('tpu_inference.runner.tpu_runner.TPUSupportedSamplingMetadata')
-    def test_prepare_inputs_dp_verify_content_balanced(self,
-                                                       mock_sampling_metadata,
-                                                       mock_device_array,
-                                                       mock_runner_utils,
-                                                       mock_named_sharding):
+    def test_prepare_inputs_dp_verify_content_balanced(
+            self, mock_sampling_metadata, mock_device_array, mock_runner_utils,
+            mock_named_sharding, mock_device_put):
         """Test _prepare_inputs_dp with content verification for balanced distribution."""
 
         # Setup mocking with specific behavior for tokens vs requests
@@ -602,6 +601,7 @@ class TestTPUJaxRunnerDPInputsLightweight:
         assert len(logits_indices_selector) == 2
         assert np.array_equal(logits_indices_selector, np.array([0, 4]))
 
+    @patch('jax.device_put', side_effect=lambda x, y: x)
     @patch('tpu_inference.runner.tpu_runner.NamedSharding')
     @patch('tpu_inference.runner.tpu_runner.runner_utils')
     @patch('tpu_inference.runner.tpu_runner.device_array',
@@ -609,7 +609,7 @@ class TestTPUJaxRunnerDPInputsLightweight:
     @patch('tpu_inference.runner.tpu_runner.TPUSupportedSamplingMetadata')
     def test_prepare_inputs_dp_verify_content_empty_rank(
             self, mock_sampling_metadata, mock_device_array, mock_runner_utils,
-            mock_named_sharding):
+            mock_named_sharding, mock_device_put):
         """Test _prepare_inputs_dp with detailed content verification for empty rank case."""
 
         # Setup mocking
@@ -727,16 +727,15 @@ class TestTPUJaxRunnerDPInputsLightweight:
         np.testing.assert_array_equal(logits_indices_selector,
                                       expected_selector)
 
+    @patch('jax.device_put', side_effect=lambda x, y: x)
     @patch('tpu_inference.runner.tpu_runner.NamedSharding')
     @patch('tpu_inference.runner.tpu_runner.runner_utils')
     @patch('tpu_inference.runner.tpu_runner.device_array',
            side_effect=lambda mesh, tensors, **kwargs: tensors)
     @patch('tpu_inference.runner.tpu_runner.TPUSupportedSamplingMetadata')
-    def test_prepare_inputs_dp_with_decode_requests(self,
-                                                    mock_sampling_metadata,
-                                                    mock_device_array,
-                                                    mock_runner_utils,
-                                                    mock_named_sharding):
+    def test_prepare_inputs_dp_with_decode_requests(
+            self, mock_sampling_metadata, mock_device_array, mock_runner_utils,
+            mock_named_sharding, mock_device_put):
         """Test _prepare_inputs_dp with decode requests (1 token each) to verify request_distribution."""
 
         # Setup mocking
@@ -790,16 +789,15 @@ class TestTPUJaxRunnerDPInputsLightweight:
         np.testing.assert_array_equal(attention_metadata.request_distribution,
                                       expected_distribution)
 
+    @patch('jax.device_put', side_effect=lambda x, y: x)
     @patch('tpu_inference.runner.tpu_runner.NamedSharding')
     @patch('tpu_inference.runner.tpu_runner.runner_utils')
     @patch('tpu_inference.runner.tpu_runner.device_array',
            side_effect=lambda mesh, tensors, **kwargs: tensors)
     @patch('tpu_inference.runner.tpu_runner.TPUSupportedSamplingMetadata')
-    def test_prepare_inputs_dp_all_decode_requests(self,
-                                                   mock_sampling_metadata,
-                                                   mock_device_array,
-                                                   mock_runner_utils,
-                                                   mock_named_sharding):
+    def test_prepare_inputs_dp_all_decode_requests(
+            self, mock_sampling_metadata, mock_device_array, mock_runner_utils,
+            mock_named_sharding, mock_device_put):
         """Test _prepare_inputs_dp with all decode requests."""
 
         # Setup mocking
@@ -852,6 +850,7 @@ class TestTPUJaxRunnerDPInputsLightweight:
         np.testing.assert_array_equal(attention_metadata.request_distribution,
                                       expected_distribution)
 
+    @patch('jax.device_put', side_effect=lambda x, y: x)
     @patch('tpu_inference.runner.tpu_runner.NamedSharding')
     @patch('tpu_inference.runner.tpu_runner.runner_utils')
     @patch('tpu_inference.runner.tpu_runner.device_array',
@@ -859,7 +858,7 @@ class TestTPUJaxRunnerDPInputsLightweight:
     @patch('tpu_inference.runner.tpu_runner.TPUSupportedSamplingMetadata')
     def test_prepare_async_token_substitution_indices_dp(
             self, mock_sampling_metadata, mock_device_array, mock_runner_utils,
-            mock_named_sharding):
+            mock_named_sharding, mock_device_put):
 
         # Setup test data
         req_ids_dp = {0: ["req1", "req2"], 1: ["req3"]}
@@ -892,6 +891,7 @@ class TestTPUJaxRunnerDPInputsLightweight:
         assert token_in_tpu_cur_input_indices_dp[1] == [11]
         assert token_in_tpu_pre_next_tokens_indices_dp[1] == [2]
 
+    @patch('jax.device_put', side_effect=lambda x, y: x)
     @patch('tpu_inference.runner.tpu_runner.NamedSharding')
     @patch('tpu_inference.runner.tpu_runner.runner_utils')
     @patch('tpu_inference.runner.tpu_runner.device_array',
@@ -899,7 +899,7 @@ class TestTPUJaxRunnerDPInputsLightweight:
     @patch('tpu_inference.runner.tpu_runner.TPUSupportedSamplingMetadata')
     def test_prepare_async_token_substitution_indices_dp_no_placeholders(
             self, mock_sampling_metadata, mock_device_array, mock_runner_utils,
-            mock_named_sharding):
+            mock_named_sharding, mock_device_put):
         """Test when no requests are placeholders."""
 
         req_ids_dp = {0: ["req1", "req2"], 1: ["req3"]}
@@ -1027,16 +1027,15 @@ class TestTPUJaxRunnerDPInputsLightweight:
         self.runner._prepare_inputs_non_dp.assert_called_once_with(
             scheduler_output)
 
+    @patch('jax.device_put', side_effect=lambda x, y: x)
     @patch('tpu_inference.runner.tpu_runner.NamedSharding')
     @patch('tpu_inference.runner.tpu_runner.runner_utils')
     @patch('tpu_inference.runner.tpu_runner.device_array',
            side_effect=lambda mesh, tensors, **kwargs: tensors)
     @patch('tpu_inference.runner.tpu_runner.TPUSupportedSamplingMetadata')
-    def test_prepare_inputs_dp_with_async_scheduling(self,
-                                                     mock_sampling_metadata,
-                                                     mock_device_array,
-                                                     mock_runner_utils,
-                                                     mock_named_sharding):
+    def test_prepare_inputs_dp_with_async_scheduling(
+            self, mock_sampling_metadata, mock_device_array, mock_runner_utils,
+            mock_named_sharding, mock_device_put):
 
         # Setup mocking
         def mock_get_padded_token_len(paddings_list, val):
@@ -1100,6 +1099,7 @@ class TestTPUJaxRunnerDPInputsLightweight:
         # Verify async token substitution was called
         mock_prepare_async.assert_called_once()
 
+    @patch('jax.device_put', side_effect=lambda x, y: x)
     @patch('tpu_inference.runner.tpu_runner.NamedSharding')
     @patch('tpu_inference.runner.tpu_runner.runner_utils')
     @patch('tpu_inference.runner.tpu_runner.device_array',
@@ -1107,7 +1107,7 @@ class TestTPUJaxRunnerDPInputsLightweight:
     @patch('tpu_inference.runner.tpu_runner.TPUSupportedSamplingMetadata')
     def test_prepare_inputs_dp_async_token_substitution_application(
             self, mock_sampling_metadata, mock_device_array, mock_runner_utils,
-            mock_named_sharding):
+            mock_named_sharding, mock_device_put):
         """Test async token substitution application in DP mode."""
 
         # Setup mocking
@@ -1279,6 +1279,7 @@ class TestSamplingMetadataPassthrough:
         assert runner._sample_from_logits.call_args.args[
             2] is mock_sampling_metadata
 
+    @patch('jax.device_put', side_effect=lambda x, y: x)
     @patch('tpu_inference.runner.tpu_runner.NamedSharding')
     @patch('tpu_inference.runner.tpu_runner.runner_utils')
     @patch('tpu_inference.runner.tpu_runner.device_array',
@@ -1286,7 +1287,7 @@ class TestSamplingMetadataPassthrough:
     @patch('tpu_inference.runner.tpu_runner.TPUSupportedSamplingMetadata')
     def test_prepare_inputs_dp_uses_attn_data_sharding_for_sampling_metadata(
             self, mock_sampling_metadata, mock_device_array, mock_runner_utils,
-            mock_named_sharding):
+            mock_named_sharding, mock_device_put):
         """_prepare_inputs_dp() should use ATTN_DATA sharding for TPUSupportedSamplingMetadata."""
         from jax.sharding import PartitionSpec
 
@@ -1302,6 +1303,7 @@ class TestSamplingMetadataPassthrough:
         runner.input_batch.num_computed_tokens_cpu = np.array([5, 6])
         runner.input_batch.token_ids_cpu = np.zeros((8, 64), dtype=np.int32)
         mock_block_table = MagicMock()
+        mock_block_table.max_num_blocks_per_req = 8
         mock_block_table.get_cpu_tensor.return_value = np.arange(32).reshape(
             4, 8)
         runner.input_batch.block_table = [mock_block_table]
@@ -1310,8 +1312,10 @@ class TestSamplingMetadataPassthrough:
         runner.query_start_loc_cpu = np.zeros(10, dtype=np.int32)
         runner.seq_lens_cpu = np.zeros(8, dtype=np.int32)
         runner.logits_indices_cpu = np.zeros(8, dtype=np.int32)
-        runner.block_tables_cpu = [np.zeros((8, 8), dtype=np.int32)]
         runner.arange_cpu = np.arange(64, dtype=np.int64)
+
+        from tpu_inference.utils import DeviceBuffer
+        runner.device_buffer = DeviceBuffer(initial_capacity=1024 * 1024)
         runner.num_tokens_paddings_per_dp = [8, 16, 32]
         runner.num_reqs_paddings_per_dp = [4, 8]
         runner.uses_mrope = False

--- a/tpu_inference/layers/jax/sample/sampling_metadata.py
+++ b/tpu_inference/layers/jax/sample/sampling_metadata.py
@@ -58,13 +58,16 @@ class TPUSupportedSamplingMetadata:
         input_batch: InputBatch,
         padded_num_reqs: int,
         device_buffer: "DeviceBuffer",
+        dp_size: int = 1,
     ):
         needs_logprobs = (input_batch.max_num_logprobs > 0
                           if input_batch.max_num_logprobs else False)
 
         # Use a dummy tensor with a unique shape for each logprobs config.
         # This avoids persistent cache collisions.
-        dummy_shape = (1 if needs_logprobs else 2, )
+        # We use a multiple of dp_size to ensure the total metadata buffer size
+        # is divisible by dp_size for sharding in DP mode.
+        dummy_shape = (dp_size if needs_logprobs else 2 * dp_size, )
         cache_collision_dummy_view = device_buffer.get_view(
             dummy_shape, key="cache_collision_dummy")
         cache_collision_dummy_view.fill(0)

--- a/tpu_inference/layers/jax/sample/sampling_metadata.py
+++ b/tpu_inference/layers/jax/sample/sampling_metadata.py
@@ -14,17 +14,16 @@
 
 import functools
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Dict, Optional
+from typing import Optional
 
 import jax
 import jax.numpy as jnp
 import numpy as np
+import torch
 from jax.sharding import Mesh
 
 from tpu_inference.runner.input_batch import InputBatch
-
-if TYPE_CHECKING:
-    from tpu_inference.utils import DeviceBuffer
+from tpu_inference.utils import device_array
 
 DEFAULT_SAMPLING_PARAMS = dict(
     temperature=-1.0,
@@ -53,73 +52,55 @@ class TPUSupportedSamplingMetadata:
     logprobs: bool = False
 
     @classmethod
-    def add_to_device_buffer(
+    def from_input_batch(
         cls,
+        mesh: Mesh,
         input_batch: InputBatch,
         padded_num_reqs: int,
-        device_buffer: "DeviceBuffer",
-        dp_size: int = 1,
-    ):
-        needs_logprobs = (input_batch.max_num_logprobs > 0
-                          if input_batch.max_num_logprobs else False)
+        sharding: Optional[jax.sharding.Sharding] = None,
+    ) -> "TPUSupportedSamplingMetadata":
+        needs_logprobs = input_batch.max_num_logprobs > 0 if input_batch.max_num_logprobs else False
 
         # Use a dummy tensor with a unique shape for each logprobs config.
         # This avoids persistent cache collisions.
-        # We use a multiple of dp_size to ensure the total metadata buffer size
-        # is divisible by dp_size for sharding in DP mode.
-        dummy_shape = (dp_size if needs_logprobs else 2 * dp_size, )
-        cache_collision_dummy_view = device_buffer.get_view(
-            dummy_shape, key="cache_collision_dummy")
-        cache_collision_dummy_view.fill(0)
-
-        if input_batch.all_greedy:
-            return
-
-        num_reqs = input_batch.num_reqs
-
-        temp_view = device_buffer.get_view((padded_num_reqs, ),
-                                           key="temperature")
-        top_k_view = device_buffer.get_view((padded_num_reqs, ), key="top_k")
-        top_p_view = device_buffer.get_view((padded_num_reqs, ), key="top_p")
-
-        # Pad values
-        temp_view[num_reqs:].fill(
-            np.array(DEFAULT_SAMPLING_PARAMS["temperature"],
-                     dtype=np.float32).view(np.int32))
-        top_k_view[num_reqs:].fill(DEFAULT_SAMPLING_PARAMS["top_k"])
-        top_p_view[num_reqs:].fill(
-            np.array(DEFAULT_SAMPLING_PARAMS["top_p"],
-                     dtype=np.float32).view(np.int32))
-
-        # Copy data
-        np.copyto(temp_view[:num_reqs],
-                  input_batch.temperature_cpu[:num_reqs].view(np.int32))
-        np.copyto(top_k_view[:num_reqs], input_batch.top_k_cpu[:num_reqs])
-        np.copyto(top_p_view[:num_reqs],
-                  input_batch.top_p_cpu[:num_reqs].view(np.int32))
-
-    @classmethod
-    def from_unpacked_arrays(
-        cls,
-        mesh: Mesh,
-        unpacked_metadata: Dict[str, jax.Array],
-        input_batch: InputBatch,
-    ) -> "TPUSupportedSamplingMetadata":
-        needs_logprobs = (input_batch.max_num_logprobs > 0
-                          if input_batch.max_num_logprobs else False)
-
-        cache_collision_dummy = unpacked_metadata["cache_collision_dummy"]
+        dummy_shape = (1 if needs_logprobs else 2, )
+        cache_collision_dummy = np.zeros(dummy_shape, dtype=np.int32)
+        # Use replicated sharding for dummy tensor.
+        cache_collision_dummy = device_array(mesh,
+                                             cache_collision_dummy,
+                                             sharding=None)
 
         if input_batch.all_greedy:
             return cls(do_sampling=False,
                        logprobs=needs_logprobs,
                        _cache_collision_dummy=cache_collision_dummy)
+        num_reqs = input_batch.num_reqs
 
+        def fill_slice(cpu_torch_tensor: torch.Tensor,
+                       fill_val: float) -> torch.Tensor:
+            # Pad value is the default one.
+            cpu_torch_tensor[num_reqs:padded_num_reqs] = fill_val
+            return cpu_torch_tensor
+
+        temp_tensor = fill_slice(input_batch.temperature_cpu,
+                                 DEFAULT_SAMPLING_PARAMS["temperature"])
+        top_k_tensor = fill_slice(input_batch.top_k_cpu,
+                                  DEFAULT_SAMPLING_PARAMS["top_k"])
+        top_p_tensor = fill_slice(input_batch.top_p_cpu,
+                                  DEFAULT_SAMPLING_PARAMS["top_p"])
+
+        # Slice persistent device tensors to a fixed pre-compiled padded shape.
         return cls(
-            temperature=unpacked_metadata["temperature"].view(jnp.float32),
-            top_k=unpacked_metadata["top_k"],
-            top_p=unpacked_metadata["top_p"].view(jnp.float32),
+            temperature=device_array(mesh,
+                                     temp_tensor[:padded_num_reqs],
+                                     sharding=sharding),
+            top_p=device_array(mesh,
+                               top_p_tensor[:padded_num_reqs],
+                               sharding=sharding),
+            top_k=device_array(mesh,
+                               top_k_tensor[:padded_num_reqs],
+                               sharding=sharding),
             _cache_collision_dummy=cache_collision_dummy,
-            do_sampling=True,
+            do_sampling=not input_batch.all_greedy,
             logprobs=needs_logprobs,
         )

--- a/tpu_inference/layers/jax/sample/sampling_metadata.py
+++ b/tpu_inference/layers/jax/sample/sampling_metadata.py
@@ -14,16 +14,17 @@
 
 import functools
 from dataclasses import dataclass
-from typing import Optional
+from typing import TYPE_CHECKING, Dict, Optional
 
 import jax
 import jax.numpy as jnp
 import numpy as np
-import torch
 from jax.sharding import Mesh
 
 from tpu_inference.runner.input_batch import InputBatch
-from tpu_inference.utils import device_array
+
+if TYPE_CHECKING:
+    from tpu_inference.utils import DeviceBuffer
 
 DEFAULT_SAMPLING_PARAMS = dict(
     temperature=-1.0,
@@ -52,55 +53,70 @@ class TPUSupportedSamplingMetadata:
     logprobs: bool = False
 
     @classmethod
-    def from_input_batch(
+    def add_to_device_buffer(
         cls,
-        mesh: Mesh,
         input_batch: InputBatch,
         padded_num_reqs: int,
-        sharding: Optional[jax.sharding.Sharding] = None,
-    ) -> "TPUSupportedSamplingMetadata":
-        needs_logprobs = input_batch.max_num_logprobs > 0 if input_batch.max_num_logprobs else False
+        device_buffer: "DeviceBuffer",
+    ):
+        needs_logprobs = (input_batch.max_num_logprobs > 0
+                          if input_batch.max_num_logprobs else False)
 
         # Use a dummy tensor with a unique shape for each logprobs config.
         # This avoids persistent cache collisions.
         dummy_shape = (1 if needs_logprobs else 2, )
-        cache_collision_dummy = np.zeros(dummy_shape, dtype=np.int32)
-        # Use replicated sharding for dummy tensor.
-        cache_collision_dummy = device_array(mesh,
-                                             cache_collision_dummy,
-                                             sharding=None)
+        cache_collision_dummy_view = device_buffer.get_view(
+            dummy_shape, key="cache_collision_dummy")
+        cache_collision_dummy_view.fill(0)
+
+        if input_batch.all_greedy:
+            return
+
+        num_reqs = input_batch.num_reqs
+
+        temp_view = device_buffer.get_view((padded_num_reqs, ),
+                                           key="temperature")
+        top_k_view = device_buffer.get_view((padded_num_reqs, ), key="top_k")
+        top_p_view = device_buffer.get_view((padded_num_reqs, ), key="top_p")
+
+        # Pad values
+        temp_view[num_reqs:].fill(
+            np.array(DEFAULT_SAMPLING_PARAMS["temperature"],
+                     dtype=np.float32).view(np.int32))
+        top_k_view[num_reqs:].fill(DEFAULT_SAMPLING_PARAMS["top_k"])
+        top_p_view[num_reqs:].fill(
+            np.array(DEFAULT_SAMPLING_PARAMS["top_p"],
+                     dtype=np.float32).view(np.int32))
+
+        # Copy data
+        np.copyto(temp_view[:num_reqs],
+                  input_batch.temperature_cpu[:num_reqs].view(np.int32))
+        np.copyto(top_k_view[:num_reqs], input_batch.top_k_cpu[:num_reqs])
+        np.copyto(top_p_view[:num_reqs],
+                  input_batch.top_p_cpu[:num_reqs].view(np.int32))
+
+    @classmethod
+    def from_unpacked_arrays(
+        cls,
+        mesh: Mesh,
+        unpacked_metadata: Dict[str, jax.Array],
+        input_batch: InputBatch,
+    ) -> "TPUSupportedSamplingMetadata":
+        needs_logprobs = (input_batch.max_num_logprobs > 0
+                          if input_batch.max_num_logprobs else False)
+
+        cache_collision_dummy = unpacked_metadata["cache_collision_dummy"]
 
         if input_batch.all_greedy:
             return cls(do_sampling=False,
                        logprobs=needs_logprobs,
                        _cache_collision_dummy=cache_collision_dummy)
-        num_reqs = input_batch.num_reqs
 
-        def fill_slice(cpu_torch_tensor: torch.Tensor,
-                       fill_val: float) -> torch.Tensor:
-            # Pad value is the default one.
-            cpu_torch_tensor[num_reqs:padded_num_reqs] = fill_val
-            return cpu_torch_tensor
-
-        temp_tensor = fill_slice(input_batch.temperature_cpu,
-                                 DEFAULT_SAMPLING_PARAMS["temperature"])
-        top_k_tensor = fill_slice(input_batch.top_k_cpu,
-                                  DEFAULT_SAMPLING_PARAMS["top_k"])
-        top_p_tensor = fill_slice(input_batch.top_p_cpu,
-                                  DEFAULT_SAMPLING_PARAMS["top_p"])
-
-        # Slice persistent device tensors to a fixed pre-compiled padded shape.
         return cls(
-            temperature=device_array(mesh,
-                                     temp_tensor[:padded_num_reqs],
-                                     sharding=sharding),
-            top_p=device_array(mesh,
-                               top_p_tensor[:padded_num_reqs],
-                               sharding=sharding),
-            top_k=device_array(mesh,
-                               top_k_tensor[:padded_num_reqs],
-                               sharding=sharding),
+            temperature=unpacked_metadata["temperature"].view(jnp.float32),
+            top_k=unpacked_metadata["top_k"],
+            top_p=unpacked_metadata["top_p"].view(jnp.float32),
             _cache_collision_dummy=cache_collision_dummy,
-            do_sampling=not input_batch.all_greedy,
+            do_sampling=True,
             logprobs=needs_logprobs,
         )

--- a/tpu_inference/runner/compilation_manager.py
+++ b/tpu_inference/runner/compilation_manager.py
@@ -568,12 +568,12 @@ class CompilationManager:
 
                     # Use a dummy tensor with a unique shape for each logprobs config.
                     # This avoids persistent cache collisions.
-                    dp_size = self.runner.dp_size
-                    dummy_shape = (dp_size if logprobs else 2 * dp_size, )
+                    dummy_shape = (1 if logprobs else 2, )
                     _cache_collision_dummy = jnp.zeros(dummy_shape,
                                                        dtype=jnp.int32)
                     _cache_collision_dummy = jax.device_put(
-                        _cache_collision_dummy, sampling_metadata_sharding)
+                        _cache_collision_dummy,
+                        NamedSharding(self.runner.mesh, PartitionSpec(None)))
 
                     sampling_metadata = TPUSupportedSamplingMetadata(
                         temperature=temperature,

--- a/tpu_inference/runner/compilation_manager.py
+++ b/tpu_inference/runner/compilation_manager.py
@@ -568,12 +568,12 @@ class CompilationManager:
 
                     # Use a dummy tensor with a unique shape for each logprobs config.
                     # This avoids persistent cache collisions.
-                    dummy_shape = (1 if logprobs else 2, )
+                    dp_size = self.runner.dp_size
+                    dummy_shape = (dp_size if logprobs else 2 * dp_size, )
                     _cache_collision_dummy = jnp.zeros(dummy_shape,
                                                        dtype=jnp.int32)
                     _cache_collision_dummy = jax.device_put(
-                        _cache_collision_dummy,
-                        NamedSharding(self.runner.mesh, PartitionSpec(None)))
+                        _cache_collision_dummy, sampling_metadata_sharding)
 
                     sampling_metadata = TPUSupportedSamplingMetadata(
                         temperature=temperature,

--- a/tpu_inference/runner/compilation_manager.py
+++ b/tpu_inference/runner/compilation_manager.py
@@ -191,8 +191,10 @@ class CompilationManager:
                                             sharding=dp_sharding)
 
         def build_block_table(kv_cache_gid: int) -> jax.Array:
-            block_tables = self.runner.block_tables_cpu[
-                kv_cache_gid][:self.runner.max_num_reqs]
+            block_table_obj = self.runner.input_batch.block_table[kv_cache_gid]
+            shape = (self.runner.max_num_reqs,
+                     block_table_obj.max_num_blocks_per_req)
+            block_tables = np.zeros(shape, dtype=np.int32)
             block_tables = block_tables.reshape(-1)
             block_tables = device_array(self.runner.mesh,
                                         block_tables,

--- a/tpu_inference/runner/kv_cache_manager.py
+++ b/tpu_inference/runner/kv_cache_manager.py
@@ -16,7 +16,6 @@ from typing import TYPE_CHECKING, List
 
 import jax
 import jax.numpy as jnp
-import numpy as np
 import vllm.envs as envs
 from jax.sharding import NamedSharding, PartitionSpec
 from torchax.ops.mappings import t2j_dtype
@@ -25,7 +24,6 @@ from vllm.model_executor.layers.attention import Attention
 from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
 from vllm.model_executor.layers.mamba.abstract import MambaBase
 from vllm.model_executor.layers.mla import MLAAttention
-from vllm.utils.math_utils import cdiv
 from vllm.v1.attention.backend import AttentionType
 from vllm.v1.kv_cache_interface import (FullAttentionSpec, KVCacheConfig,
                                         KVCacheSpec, MambaSpec,
@@ -329,11 +327,6 @@ class KVCacheManager:
             )
             self.runner.input_batch = new_input_batch
             self.runner.persistent_batch_manager.input_batch = new_input_batch
-            self.runner.block_tables_cpu = [
-                np.zeros((self.runner.max_num_reqs,
-                          cdiv(self.runner.max_model_len, block_size)),
-                         dtype=np.int32) for block_size in block_sizes
-            ]
 
     def initialize_kv_cache(self, kv_cache_config: KVCacheConfig) -> None:
         self.maybe_reinitialize_input_batch(kv_cache_config)

--- a/tpu_inference/runner/speculative_decoding_manager.py
+++ b/tpu_inference/runner/speculative_decoding_manager.py
@@ -164,6 +164,7 @@ class SpeculativeDecodingManager:
         num_draft_tokens: np.ndarray,
         cu_num_scheduled_tokens: np.ndarray,
         padded_num_reqs: int,
+        input_ids: np.ndarray,
     ) -> SpecDecodeMetadata:
         # Inputs:
         # cu_num_scheduled_tokens:  [  4, 104, 107, 207, 209]
@@ -204,7 +205,7 @@ class SpeculativeDecodingManager:
 
         # Compute the draft token ids.
         # draft_token_indices:      [  1,   2,   3, 105, 106, 208]
-        draft_token_ids = self.runner.input_ids_cpu[logits_indices]
+        draft_token_ids = input_ids[logits_indices]
         draft_token_ids = draft_token_ids[target_logits_indices + 1]
         padded_logits_length = runner_utils.get_padded_token_len(
             self.runner.num_logits_paddings, logits_indices.shape[0])

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -1558,11 +1558,9 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
 
         metadata_blob, metadata_layout = self.device_buffer.build()
 
-        request_distribution = jax.device_put(request_distribution,
-                                              data_parallel_attn_sharding)
-
-        dev_arrays_payload = jax.device_put(metadata_blob,
-                                            data_parallel_attn_sharding)
+        (request_distribution, dev_arrays_payload) = device_array(
+            self.mesh, (request_distribution, metadata_blob),
+            sharding=data_parallel_attn_sharding)
 
         metadata = common_utils.DeviceBuffer.unpack_arrays(
             dev_arrays_payload, metadata_layout)
@@ -1788,8 +1786,6 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         )
 
         request_distribution = np.array(self.input_batch.request_distribution)
-        request_distribution = jax.device_put(request_distribution,
-                                              data_parallel_attn_sharding)
 
         def build_block_table_host(kv_cache_gid: int) -> None:
             block_table_obj = self.input_batch.block_table[kv_cache_gid]
@@ -1813,10 +1809,9 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
 
         metadata_blob, metadata_layout = self.device_buffer.build()
 
-        dev_arrays_payload = jax.device_put(
-            metadata_blob,
-            data_parallel_attn_sharding,
-        )
+        (request_distribution, dev_arrays_payload) = device_array(
+            self.mesh, (request_distribution, metadata_blob),
+            sharding=data_parallel_attn_sharding)
 
         metadata = common_utils.DeviceBuffer.unpack_arrays(
             dev_arrays_payload, metadata_layout)

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -1760,6 +1760,9 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
 
         # Monolithic stack packing for small 1D metadata buffers
         self.device_buffer.reset()
+        self.device_buffer.append(input_ids, key="input_ids")
+        self.device_buffer.append(logits_indices, key="logits_indices")
+        self.device_buffer.append(positions, key="positions")
         self.device_buffer.append(query_start_loc, key="query_start_loc")
         self.device_buffer.append(seq_lens, key="seq_lens")
         self.device_buffer.append(request_distribution,
@@ -1789,36 +1792,23 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         metadata_blob, metadata_layout = self.device_buffer.build()
 
         host_arrays_payload = {
-            "input_ids": input_ids,
-            "positions": positions,
             "metadata_blob": metadata_blob,
-            "logits_indices": logits_indices,
         }
-        if self.uses_mrope:
-            host_arrays_payload["positions"] = mrope_positions
-
-        # Build sharding pytree payload.
-        # All arrays are sharded on ATTN_DATA (the DP axis), since all
-        # metadata and block tables are laid out in contiguous per-DP-rank
-        # chunks.
         sharding_payload = {
-            k: data_parallel_attn_sharding
-            for k in host_arrays_payload
+            "metadata_blob": data_parallel_attn_sharding,
         }
 
-        # Fire a SINGLE structural Compounded Monolithic transport flushes silencer silence voids!
         dev_arrays_payload = jax.device_put(
             host_arrays_payload,
             sharding_payload,
         )
 
-        input_ids = dev_arrays_payload["input_ids"]
-        positions = dev_arrays_payload["positions"]
         metadata_blob_dev = dev_arrays_payload["metadata_blob"]
-        logits_indices = dev_arrays_payload["logits_indices"]
-
         metadata = common_utils.DeviceBuffer.unpack_arrays(
             metadata_blob_dev, metadata_layout)
+        input_ids = metadata["input_ids"]
+        logits_indices = metadata["logits_indices"]
+        positions = metadata["positions"]
         query_start_loc = metadata["query_start_loc"]
         seq_lens = metadata["seq_lens"]
         request_distribution = metadata["request_distribution"]

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -537,9 +537,10 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         self.mrope_positions_cpu = np.zeros((3, self.max_num_tokens),
                                             dtype=np.int64)
 
-        # Monolithic stack packing for small 1D metadata buffers.
-        # This buffer grows dynamically to accommodate metadata and block tables.
-        # We start with a safe default and refine it in initialize_kv_cache.
+        # Contiguous buffer for metadata array. By using a single buffer, we are
+        # able to avoid the overhead of multiple device_put operations.
+        # Initialize to a constant size, and resize later after kv cache size is
+        # known.
         self.device_buffer = common_utils.DeviceBuffer(initial_capacity=1024)
 
     def load_model(self):
@@ -1368,7 +1369,12 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                 dp_rank]
             total_num_scheduled_tokens = num_scheduled_tokens_per_dp_rank[
                 dp_rank]
-
+            input_ids_cpu = input_ids_view[
+                token_offset:token_offset +
+                padded_num_scheduled_tokens_per_dp_rank]
+            positions_cpu = positions_view[
+                token_offset:token_offset +
+                padded_num_scheduled_tokens_per_dp_rank]
             # Get request indices.
             # E.g., [2, 5, 3] -> [0, 0, 1, 1, 1, 1, 1, 2, 2, 2]
             # For each scheduled token, what are the corresponding req index.
@@ -1381,19 +1387,18 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                 [self.arange_cpu[:n] for n in num_scheduled_tokens_per_req])
 
             # Get positions.
+            positions_np = positions_cpu[:total_num_scheduled_tokens]
             np.add(
                 self.input_batch.num_computed_tokens_cpu[req_indices],
                 arange,
-                out=positions_view[token_offset:token_offset +
-                                   total_num_scheduled_tokens],
+                out=positions_np,
             )
             # Get token indices.
             # E.g., [0, 1, 0, 1, 2, 3, 4, 0, 1, 2]
             # -> [0, 1, M, M + 1, M + 2, M + 3, M + 4, 2 * M, 2 * M + 1, 2 * M + 2]
             # where M is the max_model_len.
             token_indices = (
-                positions_view[token_offset:token_offset +
-                               total_num_scheduled_tokens] +
+                positions_np +
                 req_indices * self.input_batch.token_ids_cpu.shape[1])
             # NOTE(woosuk): We use torch.index_select instead of np.take here
             # because torch.index_select is much faster than np.take for large
@@ -1401,45 +1406,40 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             np.take(
                 self.input_batch.token_ids_cpu.ravel(),
                 token_indices,
-                out=input_ids_view[token_offset:token_offset +
-                                   total_num_scheduled_tokens],
+                out=input_ids_cpu[:total_num_scheduled_tokens],
             )
 
-            input_ids_view[token_offset +
-                           total_num_scheduled_tokens:token_offset +
-                           padded_num_scheduled_tokens_per_dp_rank] = 0
+            input_ids_cpu[total_num_scheduled_tokens:] = 0
 
         # Prepare the attention metadata (query_start_loc_cpu, seq_lens_cpu)
         for dp_rank in range(dp_size):
             req_offset = dp_rank * max_num_reqs_per_dp_rank
-            query_loc_offset = req_offset + dp_rank
+            query_start_loc_cpu = query_start_loc_view[
+                req_offset + dp_rank:req_offset + max_num_reqs_per_dp_rank +
+                dp_rank + 1]
+            seq_lens_cpu = seq_lens_view[req_offset:req_offset +
+                                         max_num_reqs_per_dp_rank]
             _num_reqs = num_req_per_dp_rank[dp_rank]
             req_indices = req_indices_dp[dp_rank]
             num_scheduled_tokens_per_req = scheduled_tokens_per_dp_rank[
                 dp_rank]
 
             if _num_reqs == 0:
-                query_start_loc_view[query_loc_offset:query_loc_offset +
-                                     max_num_reqs_per_dp_rank + 1] = 0
-                seq_lens_view[req_offset:req_offset +
-                              max_num_reqs_per_dp_rank] = 0
+                query_start_loc_cpu[:] = 0
+                seq_lens_cpu[:] = 0
                 continue
 
-            query_start_loc_view[query_loc_offset] = 0
+            query_start_loc_cpu[0] = 0
             np.cumsum(
                 num_scheduled_tokens_per_req,
-                out=query_start_loc_view[query_loc_offset +
-                                         1:query_loc_offset + _num_reqs + 1],
+                out=query_start_loc_cpu[1:_num_reqs + 1],
             )
-            query_start_loc_view[query_loc_offset + _num_reqs +
-                                 1:query_loc_offset +
-                                 max_num_reqs_per_dp_rank + 1] = 1
+            query_start_loc_cpu[_num_reqs + 1:] = 1
 
-            seq_lens_view[req_offset:req_offset + _num_reqs] = (
+            seq_lens_cpu[:_num_reqs] = (
                 self.input_batch.num_computed_tokens_cpu[req_indices] +
                 num_scheduled_tokens_per_req)
-            seq_lens_view[req_offset + _num_reqs:req_offset +
-                          max_num_reqs_per_dp_rank] = 0
+            seq_lens_cpu[_num_reqs:] = 0
 
         # populate logits_indices
         for dp_rank in range(dp_size):
@@ -1447,12 +1447,13 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             query_loc_req_offset = dp_rank * (max_num_reqs_per_dp_rank + 1)
             _num_reqs = num_req_per_dp_rank[dp_rank]
 
-            logits_indices_view[req_offset:req_offset + _num_reqs] = (
+            logits_indices_cpu = logits_indices_view[
+                req_offset:req_offset + padded_num_reqs_per_dp_rank]
+            logits_indices_cpu[:_num_reqs] = (
                 query_start_loc_view[query_loc_req_offset +
                                      1:query_loc_req_offset + _num_reqs + 1] -
                 1)
-            logits_indices_view[req_offset + _num_reqs:req_offset +
-                                padded_num_reqs_per_dp_rank] = -1
+            logits_indices_cpu[_num_reqs:] = -1
 
         # Please see runner_utils.PhasedBasedProfiler for details
         if self.phase_based_profiler:
@@ -1704,9 +1705,10 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             [self.arange_cpu[:n] for n in num_scheduled_tokens_per_req])
 
         # Get positions.
+        positions_np = positions_view[:total_num_scheduled_tokens]
         np.add(self.input_batch.num_computed_tokens_cpu[req_indices],
                arange,
-               out=positions_view[:total_num_scheduled_tokens])
+               out=positions_np)
         positions_view[total_num_scheduled_tokens:] = 0
 
         # Multi-modal support
@@ -1722,7 +1724,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         # E.g., [0, 1, 0, 1, 2, 3, 4, 0, 1, 2]
         # -> [0, 1, M, M + 1, M + 2, M + 3, M + 4, 2 * M, 2 * M + 1, 2 * M + 2]
         # where M is the max_model_len.
-        token_indices = (positions_view[:total_num_scheduled_tokens] +
+        token_indices = (positions_np +
                          req_indices * self.input_batch.token_ids_cpu.shape[1])
 
         # NOTE(woosuk): We use torch.index_select instead of np.take here

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -1492,7 +1492,8 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         # Monolithic stack packing for small 1D metadata buffers
         self.device_buffer.reset()
         TPUSupportedSamplingMetadata.add_to_device_buffer(
-            self.input_batch, padded_num_reqs, self.device_buffer)
+            self.input_batch, padded_num_reqs, self.device_buffer,
+            self.dp_size)
         self.device_buffer.append(input_ids, key="input_ids")
         self.device_buffer.append(positions, key="positions")
         self.device_buffer.append(query_start_loc, key="query_start_loc")
@@ -1752,7 +1753,8 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         # Monolithic stack packing for small 1D metadata buffers
         self.device_buffer.reset()
         TPUSupportedSamplingMetadata.add_to_device_buffer(
-            self.input_batch, padded_num_reqs, self.device_buffer)
+            self.input_batch, padded_num_reqs, self.device_buffer,
+            self.dp_size)
         self.device_buffer.append(input_ids, key="input_ids")
         self.device_buffer.append(logits_indices, key="logits_indices")
         self.device_buffer.append(positions, key="positions")

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -1351,8 +1351,11 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
 
         input_ids_view = self.device_buffer.get_view(
             (padded_total_num_scheduled_tokens, ), key="input_ids")
+        # Positions can be 3D for M-RoPE models (e.g. Qwen2-VL)
         positions_view = self.device_buffer.get_view(
-            (padded_total_num_scheduled_tokens, ), key="positions")
+            (dp_size, 3 if self.uses_mrope else 1,
+             padded_num_scheduled_tokens_per_dp_rank),
+            key="positions")
         query_start_loc_view = self.device_buffer.get_view(
             (self.max_num_reqs + dp_size, ), key="query_start_loc")
         seq_lens_view = self.device_buffer.get_view((self.max_num_reqs, ),
@@ -1361,6 +1364,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                                                           key="logits_indices")
 
         # Populates input_ids and positions
+        curr_global_token_ptr = 0
         for dp_rank in range(dp_size):
             if num_req_per_dp_rank[dp_rank] == 0:
                 continue
@@ -1372,27 +1376,42 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             input_ids_cpu = input_ids_view[
                 token_offset:token_offset +
                 padded_num_scheduled_tokens_per_dp_rank]
-            positions_cpu = positions_view[
-                token_offset:token_offset +
-                padded_num_scheduled_tokens_per_dp_rank]
+
             # Get request indices.
             # E.g., [2, 5, 3] -> [0, 0, 1, 1, 1, 1, 1, 2, 2, 2]
             # For each scheduled token, what are the corresponding req index.
             req_indices = np.repeat(req_indices_dp[dp_rank],
                                     num_scheduled_tokens_per_req)
-            # Get batched arange.
-            # E.g., [2, 5, 3] -> [0, 1, 0, 1, 2, 3, 4, 0, 1, 2]
-            # For each scheduled token, what is its position in corresponding req.
-            arange = np.concatenate(
-                [self.arange_cpu[:n] for n in num_scheduled_tokens_per_req])
 
             # Get positions.
-            positions_np = positions_cpu[:total_num_scheduled_tokens]
-            np.add(
-                self.input_batch.num_computed_tokens_cpu[req_indices],
-                arange,
-                out=positions_np,
-            )
+            if self.uses_mrope:
+                # For mrope, we want to reshard (3, DATA_ATTN) to (DATA_ATTN) sharding
+                positions_view[dp_rank, :, :total_num_scheduled_tokens] = \
+                    self.mrope_positions_cpu[:, curr_global_token_ptr:
+                                             curr_global_token_ptr +
+                                             total_num_scheduled_tokens]
+                positions_view[dp_rank, :, total_num_scheduled_tokens:] = 0
+                # Use first dimension for token indices calculation
+                positions_np = positions_view[dp_rank,
+                                              0, :total_num_scheduled_tokens]
+                curr_global_token_ptr += total_num_scheduled_tokens
+            else:
+                # Get batched arange.
+                # E.g., [2, 5, 3] -> [0, 1, 0, 1, 2, 3, 4, 0, 1, 2]
+                # For each scheduled token, what is its position in corresponding req.
+                arange = np.concatenate([
+                    self.arange_cpu[:n] for n in num_scheduled_tokens_per_req
+                ])
+                # Without mrope, we use the 0th slice of the positions view.
+                positions_np = positions_view[dp_rank,
+                                              0, :total_num_scheduled_tokens]
+                np.add(
+                    self.input_batch.num_computed_tokens_cpu[req_indices],
+                    arange,
+                    out=positions_np,
+                )
+                positions_view[dp_rank, 0, total_num_scheduled_tokens:] = 0
+
             # Get token indices.
             # E.g., [0, 1, 0, 1, 2, 3, 4, 0, 1, 2]
             # -> [0, 1, M, M + 1, M + 2, M + 3, M + 4, 2 * M, 2 * M + 1, 2 * M + 2]
@@ -1429,6 +1448,8 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                 seq_lens_cpu[:] = 0
                 continue
 
+            # After buffer.reset(), the buffer is still dirty, so we need to zero
+            # Out the starting index.
             query_start_loc_cpu[0] = 0
             np.cumsum(
                 num_scheduled_tokens_per_req,
@@ -1462,11 +1483,6 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                 padded_total_num_scheduled_tokens, scheduler_output)
 
             self.phase_based_profiler.step(batch_composition_stats)
-
-        if self.uses_mrope:
-            mrope_positions = self.mrope_positions_cpu[:, :
-                                                       padded_total_num_scheduled_tokens]
-            positions_view[:] = mrope_positions.ravel()
 
         _request_distribution = []
         for dp_rank in range(dp_size):
@@ -1553,6 +1569,8 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             self.mesh, metadata, self.input_batch)
         input_ids = metadata["input_ids"]
         positions = metadata["positions"]
+        if self.uses_mrope:
+            positions = positions.reshape(3, -1)
         query_start_loc = metadata["query_start_loc"]
         seq_lens = metadata["seq_lens"]
         logits_indices = metadata["logits_indices"]
@@ -1664,7 +1682,8 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         logits_indices_view = self.device_buffer.get_view((padded_num_reqs, ),
                                                           key="logits_indices")
         positions_view = self.device_buffer.get_view(
-            (padded_total_num_scheduled_tokens, ), key="positions")
+            (3 if self.uses_mrope else 1, padded_total_num_scheduled_tokens),
+            key="positions")
         query_start_loc_view = self.device_buffer.get_view(
             (self.max_num_reqs + 1, ), key="query_start_loc")
         seq_lens_view = self.device_buffer.get_view((self.max_num_reqs, ),
@@ -1705,20 +1724,20 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             [self.arange_cpu[:n] for n in num_scheduled_tokens_per_req])
 
         # Get positions.
-        positions_np = positions_view[:total_num_scheduled_tokens]
-        np.add(self.input_batch.num_computed_tokens_cpu[req_indices],
-               arange,
-               out=positions_np)
-        positions_view[total_num_scheduled_tokens:] = 0
-
-        # Multi-modal support
-        # Calculate M-RoPE positions.
-        # Only relevant for models using M-RoPE (e.g, Qwen2-VL)
         if self.uses_mrope:
             self.mm_manager.calc_mrope_positions(scheduler_output)
             mrope_positions = self.mrope_positions_cpu[:, :
                                                        padded_total_num_scheduled_tokens]
-            positions_view[:] = mrope_positions.ravel()
+            positions_view[:, :total_num_scheduled_tokens] = mrope_positions
+            positions_view[:, total_num_scheduled_tokens:] = 0
+            # Use first dimension for token indices calculation
+            positions_np = positions_view[0, :total_num_scheduled_tokens]
+        else:
+            positions_np = positions_view[0, :total_num_scheduled_tokens]
+            np.add(self.input_batch.num_computed_tokens_cpu[req_indices],
+                   arange,
+                   out=positions_np)
+            positions_view[0, total_num_scheduled_tokens:] = 0
 
         # Get token indices.
         # E.g., [0, 1, 0, 1, 2, 3, 4, 0, 1, 2]
@@ -1803,6 +1822,8 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             self.mesh, metadata, self.input_batch)
         input_ids = metadata["input_ids"]
         positions = metadata["positions"]
+        if self.uses_mrope:
+            positions = positions.reshape(3, -1)
         query_start_loc = metadata["query_start_loc"]
         seq_lens = metadata["seq_lens"]
         logits_indices = metadata["logits_indices"]

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -627,16 +627,13 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         query_start_loc_size = self.max_num_reqs + self.dp_size
         seq_lens_size = self.max_num_reqs
         logits_indices_size = self.max_num_reqs
-        request_distribution_size = 3 * self.dp_size
         # Block tables for each KV cache group.
         block_tables_size = num_kv_groups * self.max_num_reqs * self.max_num_blocks_per_req
-        cache_collision_dummy_size = 2 * self.dp_size
 
         initial_capacity = (sampling_params_size + input_ids_size +
                             positions_size + query_start_loc_size +
                             seq_lens_size + logits_indices_size +
-                            request_distribution_size + block_tables_size +
-                            cache_collision_dummy_size + 1024)
+                            block_tables_size + 1024)
         self.device_buffer = common_utils.DeviceBuffer(
             initial_capacity=initial_capacity)
 
@@ -1345,9 +1342,6 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
 
         # Monolithic stack packing for small 1D metadata buffers
         self.device_buffer.reset()
-        TPUSupportedSamplingMetadata.add_to_device_buffer(
-            self.input_batch, padded_num_reqs, self.device_buffer,
-            self.dp_size)
 
         input_ids_view = self.device_buffer.get_view(
             (padded_total_num_scheduled_tokens, ), key="input_ids")
@@ -1495,10 +1489,8 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                     num_decode_in_dp_rank += 1
             _request_distribution.append(
                 [num_decode_in_dp_rank, num_decode_in_dp_rank, _num_reqs])
-        request_distribution_view = self.device_buffer.get_view(
-            (dp_size * 3, ), key="request_distribution")
-        request_distribution_view[:] = np.array(_request_distribution,
-                                                dtype=np.int32).ravel()
+        request_distribution = np.array(_request_distribution,
+                                        dtype=np.int32).ravel()
 
         use_spec_decode = len(
             scheduler_output.scheduled_spec_decode_tokens) > 0
@@ -1521,6 +1513,14 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                 ))
             logits_indices_view[:] = spec_decode_metadata.final_logits_indices.ravel(
             )
+
+        # Put to device
+        sampling_metadata = TPUSupportedSamplingMetadata.from_input_batch(
+            self.mesh,
+            self.input_batch,
+            padded_num_reqs,
+            sharding=data_parallel_attn_sharding,
+        )
 
         # Collect block tables host arrays loops zone presence zones legality
         def build_block_table_host(kv_cache_gid: int) -> None:
@@ -1558,15 +1558,14 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
 
         metadata_blob, metadata_layout = self.device_buffer.build()
 
-        dev_arrays_payload = jax.device_put(
-            metadata_blob,
-            data_parallel_attn_sharding,
-        )
+        request_distribution = jax.device_put(request_distribution,
+                                              data_parallel_attn_sharding)
+
+        dev_arrays_payload = jax.device_put(metadata_blob,
+                                            data_parallel_attn_sharding)
 
         metadata = common_utils.DeviceBuffer.unpack_arrays(
             dev_arrays_payload, metadata_layout)
-        sampling_metadata = TPUSupportedSamplingMetadata.from_unpacked_arrays(
-            self.mesh, metadata, self.input_batch)
         input_ids = metadata["input_ids"]
         positions = metadata["positions"]
         if self.uses_mrope:
@@ -1574,7 +1573,6 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         query_start_loc = metadata["query_start_loc"]
         seq_lens = metadata["seq_lens"]
         logits_indices = metadata["logits_indices"]
-        request_distribution = metadata["request_distribution"]
 
         def build_attn(block_tables: jax.Array | None) -> AttentionMetadata:
             attention_metadata_gid = AttentionMetadata(
@@ -1673,9 +1671,6 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
 
         # Monolithic stack packing for small 1D metadata buffers
         self.device_buffer.reset()
-        TPUSupportedSamplingMetadata.add_to_device_buffer(
-            self.input_batch, padded_num_reqs, self.device_buffer,
-            self.dp_size)
 
         input_ids_view = self.device_buffer.get_view(
             (padded_total_num_scheduled_tokens, ), key="input_ids")
@@ -1784,10 +1779,17 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             logits_indices_view[:] = spec_decode_metadata.final_logits_indices.ravel(
             )
 
-        request_distribution_view = self.device_buffer.get_view(
-            (3, ), key="request_distribution")
-        request_distribution_view[:] = np.array(
-            self.input_batch.request_distribution, dtype=np.int32).ravel()
+    # Put to device
+        sampling_metadata = TPUSupportedSamplingMetadata.from_input_batch(
+            self.mesh,
+            self.input_batch,
+            padded_num_reqs,
+            sharding=data_parallel_attn_sharding,
+        )
+
+        request_distribution = np.array(self.input_batch.request_distribution)
+        request_distribution = jax.device_put(request_distribution,
+                                              data_parallel_attn_sharding)
 
         def build_block_table_host(kv_cache_gid: int) -> None:
             block_table_obj = self.input_batch.block_table[kv_cache_gid]
@@ -1818,8 +1820,6 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
 
         metadata = common_utils.DeviceBuffer.unpack_arrays(
             dev_arrays_payload, metadata_layout)
-        sampling_metadata = TPUSupportedSamplingMetadata.from_unpacked_arrays(
-            self.mesh, metadata, self.input_batch)
         input_ids = metadata["input_ids"]
         positions = metadata["positions"]
         if self.uses_mrope:
@@ -1827,7 +1827,6 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         query_start_loc = metadata["query_start_loc"]
         seq_lens = metadata["seq_lens"]
         logits_indices = metadata["logits_indices"]
-        request_distribution = metadata["request_distribution"]
 
         def build_attn(block_tables: jax.Array | None) -> AttentionMetadata:
             attention_metadata_gid = AttentionMetadata(

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -616,7 +616,6 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         self.use_hybrid_kvcache = len(kv_cache_config.kv_cache_groups) > 1
         self.kv_cache_manager.initialize_kv_cache(kv_cache_config)
 
-        # Monolithic stack packing for small 1D metadata buffers.
         # This buffer grows dynamically to accommodate metadata and block tables.
         # We re-initialize with a precise capacity now that kv_cache_config is known.
         num_kv_groups = len(kv_cache_config.kv_cache_groups)
@@ -633,7 +632,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         initial_capacity = (sampling_params_size + input_ids_size +
                             positions_size + query_start_loc_size +
                             seq_lens_size + logits_indices_size +
-                            block_tables_size + 1024)
+                            block_tables_size)
         self.device_buffer = common_utils.DeviceBuffer(
             initial_capacity=initial_capacity)
 
@@ -1340,7 +1339,6 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                  req_ids_dp, scheduled_tokens_per_dp_rank,
                  padded_num_scheduled_tokens_per_dp_rank, dp_size)
 
-        # Monolithic stack packing for small 1D metadata buffers
         self.device_buffer.reset()
 
         input_ids_view = self.device_buffer.get_view(
@@ -1667,7 +1665,6 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
 
             self.phase_based_profiler.step(batch_composition_stats)
 
-        # Monolithic stack packing for small 1D metadata buffers
         self.device_buffer.reset()
 
         input_ids_view = self.device_buffer.get_view(

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -1352,7 +1352,28 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             (self.max_num_reqs + dp_size, ), key="query_start_loc")
         seq_lens_view = self.device_buffer.get_view((self.max_num_reqs, ),
                                                     key="seq_lens")
-        logits_indices_view = self.device_buffer.get_view((padded_num_reqs, ),
+
+        use_spec_decode = len(
+            scheduler_output.scheduled_spec_decode_tokens) > 0
+
+        if use_spec_decode:
+            num_draft_tokens = np.zeros(num_reqs, dtype=np.int32)
+            for (
+                    req_id,
+                    draft_token_ids,
+            ) in scheduler_output.scheduled_spec_decode_tokens.items():
+                req_idx = self.input_batch.req_id_to_index[req_id]
+                num_draft_tokens[req_idx] = len(draft_token_ids)
+
+            num_sampled_tokens = num_draft_tokens + 1
+            total_sampled_tokens = np.sum(num_sampled_tokens)
+            padded_logits_length = runner_utils.get_padded_token_len(
+                self.num_logits_paddings, total_sampled_tokens)
+            logits_indices_shape = (padded_logits_length, )
+        else:
+            logits_indices_shape = (padded_num_reqs, )
+
+        logits_indices_view = self.device_buffer.get_view(logits_indices_shape,
                                                           key="logits_indices")
 
         # Populates input_ids and positions
@@ -1494,14 +1515,6 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             scheduler_output.scheduled_spec_decode_tokens) > 0
         spec_decode_metadata = None
         if use_spec_decode:
-            num_draft_tokens = np.zeros(num_reqs, dtype=np.int32)
-            for (
-                    req_id,
-                    draft_token_ids,
-            ) in scheduler_output.scheduled_spec_decode_tokens.items():
-                req_idx = self.input_batch.req_id_to_index[req_id]
-                num_draft_tokens[req_idx] = len(draft_token_ids)
-
             spec_decode_metadata = (
                 self.speculative_decoding_manager.get_spec_decode_metadata(
                     num_draft_tokens,
@@ -1669,7 +1682,26 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
 
         input_ids_view = self.device_buffer.get_view(
             (padded_total_num_scheduled_tokens, ), key="input_ids")
-        logits_indices_view = self.device_buffer.get_view((padded_num_reqs, ),
+
+        use_spec_decode = len(
+            scheduler_output.scheduled_spec_decode_tokens) > 0
+
+        if use_spec_decode:
+            num_draft_tokens = np.zeros(num_reqs, dtype=np.int32)
+            for req_id, draft_token_ids in (
+                    scheduler_output.scheduled_spec_decode_tokens.items()):
+                req_idx = self.input_batch.req_id_to_index[req_id]
+                num_draft_tokens[req_idx] = len(draft_token_ids)
+
+            num_sampled_tokens = num_draft_tokens + 1
+            total_sampled_tokens = np.sum(num_sampled_tokens)
+            padded_logits_length = runner_utils.get_padded_token_len(
+                self.num_logits_paddings, total_sampled_tokens)
+            logits_indices_shape = (padded_logits_length, )
+        else:
+            logits_indices_shape = (padded_num_reqs, )
+
+        logits_indices_view = self.device_buffer.get_view(logits_indices_shape,
                                                           key="logits_indices")
         positions_view = self.device_buffer.get_view(
             (3 if self.uses_mrope else 1, padded_total_num_scheduled_tokens),
@@ -1762,12 +1794,6 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             logits_indices_view[:padded_num_reqs] = (
                 query_start_loc_view[1:padded_num_reqs + 1] - 1)
         else:
-            num_draft_tokens = np.zeros(num_reqs, dtype=np.int32)
-            for req_id, draft_token_ids in (
-                    scheduler_output.scheduled_spec_decode_tokens.items()):
-                req_idx = self.input_batch.req_id_to_index[req_id]
-                num_draft_tokens[req_idx] = len(draft_token_ids)
-
             spec_decode_metadata = self.speculative_decoding_manager.get_spec_decode_metadata(
                 num_draft_tokens, query_start_loc_view[1:num_reqs + 1],
                 padded_num_reqs, input_ids_view)

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -491,10 +491,10 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             is_spec_decode=bool(self.vllm_config.speculative_config),
         )
 
+        self.positions_cpu = np.zeros(self.max_num_tokens, dtype=np.int32)
         # Range tensor with values [0 .. self.max_num_tokens - 1].
         # Used to initialize positions / context_lens / seq_lens
         # Keep in int64 to avoid overflow with long context
-        self.positions_cpu = np.zeros(self.max_num_tokens, dtype=np.int32)
         self.arange_cpu = np.arange(self.max_num_tokens, dtype=np.int64)
         min_num_reqs = max(MIN_NUM_SEQS, next_power_of_2(self.dp_size))
         self.num_reqs_paddings = runner_utils.get_req_paddings(

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -1501,15 +1501,15 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
 
         # Collect block tables host arrays loops zone presence zones legality
         def build_block_table_host(kv_cache_gid: int) -> None:
+            block_table_obj = self.input_batch.block_table[kv_cache_gid]
             block_tables_view = self.device_buffer.get_view(
-                (self.max_num_reqs, self.max_num_blocks_per_req),
+                (self.max_num_reqs, block_table_obj.max_num_blocks_per_req),
                 key=f"block_tables_gid_{kv_cache_gid}")
 
             # Zero out the view once for correct padding
             block_tables_view.fill(0)
 
-            cpu_tensor = self.input_batch.block_table[
-                kv_cache_gid].get_cpu_tensor()
+            cpu_tensor = block_table_obj.get_cpu_tensor()
             for dp_rank in range(dp_size):
                 _num_reqs = num_req_per_dp_rank[dp_rank]
                 if _num_reqs == 0:
@@ -1552,6 +1552,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         positions = metadata["positions"]
         query_start_loc = metadata["query_start_loc"]
         seq_lens = metadata["seq_lens"]
+        logits_indices = metadata["logits_indices"]
         request_distribution = metadata["request_distribution"]
 
         def build_attn(block_tables: jax.Array | None) -> AttentionMetadata:
@@ -1768,7 +1769,6 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         self.device_buffer.append(request_distribution,
                                   key="request_distribution")
 
-        # Collect block tables host arrays loops zone presence zones legality
         def build_block_table_host(kv_cache_gid: int) -> None:
             block_table_obj = self.input_batch.block_table[kv_cache_gid]
             block_tables_view = self.device_buffer.get_view(
@@ -1807,10 +1807,10 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         metadata = common_utils.DeviceBuffer.unpack_arrays(
             metadata_blob_dev, metadata_layout)
         input_ids = metadata["input_ids"]
-        logits_indices = metadata["logits_indices"]
         positions = metadata["positions"]
         query_start_loc = metadata["query_start_loc"]
         seq_lens = metadata["seq_lens"]
+        logits_indices = metadata["logits_indices"]
         request_distribution = metadata["request_distribution"]
 
         def build_attn(block_tables: jax.Array | None) -> AttentionMetadata:

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -1491,6 +1491,8 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
 
         # Monolithic stack packing for small 1D metadata buffers
         self.device_buffer.reset()
+        TPUSupportedSamplingMetadata.add_to_device_buffer(
+            self.input_batch, padded_num_reqs, self.device_buffer)
         self.device_buffer.append(input_ids, key="input_ids")
         self.device_buffer.append(positions, key="positions")
         self.device_buffer.append(query_start_loc, key="query_start_loc")
@@ -1534,20 +1536,15 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
 
         metadata_blob, metadata_layout = self.device_buffer.build()
 
-        host_arrays_payload = {
-            "metadata_blob": metadata_blob,
-        }
-        sharding_payload = {
-            "metadata_blob": data_parallel_attn_sharding,
-        }
         dev_arrays_payload = jax.device_put(
-            host_arrays_payload,
-            sharding_payload,
+            metadata_blob,
+            data_parallel_attn_sharding,
         )
 
-        metadata_blob_dev = dev_arrays_payload["metadata_blob"]
         metadata = common_utils.DeviceBuffer.unpack_arrays(
-            metadata_blob_dev, metadata_layout)
+            dev_arrays_payload, metadata_layout)
+        sampling_metadata = TPUSupportedSamplingMetadata.from_unpacked_arrays(
+            self.mesh, metadata, self.input_batch)
         input_ids = metadata["input_ids"]
         positions = metadata["positions"]
         query_start_loc = metadata["query_start_loc"]
@@ -1747,13 +1744,6 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                 padded_num_reqs)
             logits_indices = spec_decode_metadata.final_logits_indices
 
-        # Put to device
-        sampling_metadata = TPUSupportedSamplingMetadata.from_input_batch(
-            self.mesh,
-            self.input_batch,
-            padded_num_reqs,
-            sharding=data_parallel_attn_sharding,
-        )
         if self.uses_mrope:
             positions = mrope_positions
         query_start_loc_cpu = query_start_loc
@@ -1761,6 +1751,8 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
 
         # Monolithic stack packing for small 1D metadata buffers
         self.device_buffer.reset()
+        TPUSupportedSamplingMetadata.add_to_device_buffer(
+            self.input_batch, padded_num_reqs, self.device_buffer)
         self.device_buffer.append(input_ids, key="input_ids")
         self.device_buffer.append(logits_indices, key="logits_indices")
         self.device_buffer.append(positions, key="positions")
@@ -1791,21 +1783,15 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
 
         metadata_blob, metadata_layout = self.device_buffer.build()
 
-        host_arrays_payload = {
-            "metadata_blob": metadata_blob,
-        }
-        sharding_payload = {
-            "metadata_blob": data_parallel_attn_sharding,
-        }
-
         dev_arrays_payload = jax.device_put(
-            host_arrays_payload,
-            sharding_payload,
+            metadata_blob,
+            data_parallel_attn_sharding,
         )
 
-        metadata_blob_dev = dev_arrays_payload["metadata_blob"]
         metadata = common_utils.DeviceBuffer.unpack_arrays(
-            metadata_blob_dev, metadata_layout)
+            dev_arrays_payload, metadata_layout)
+        sampling_metadata = TPUSupportedSamplingMetadata.from_unpacked_arrays(
+            self.mesh, metadata, self.input_batch)
         input_ids = metadata["input_ids"]
         positions = metadata["positions"]
         query_start_loc = metadata["query_start_loc"]

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -494,6 +494,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         # Range tensor with values [0 .. self.max_num_tokens - 1].
         # Used to initialize positions / context_lens / seq_lens
         # Keep in int64 to avoid overflow with long context
+        self.positions_cpu = np.zeros(self.max_num_tokens, dtype=np.int32)
         self.arange_cpu = np.arange(self.max_num_tokens, dtype=np.int64)
         min_num_reqs = max(MIN_NUM_SEQS, next_power_of_2(self.dp_size))
         self.num_reqs_paddings = runner_utils.get_req_paddings(
@@ -622,7 +623,6 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         sampling_params_size = 3 * self.max_num_reqs
         input_ids_size = self.max_num_tokens
         # Positions can be 3D for M-RoPE models (e.g. Qwen2-VL)
-        positions_size = (3 if self.uses_mrope else 1) * self.max_num_tokens
         query_start_loc_size = self.max_num_reqs + self.dp_size
         seq_lens_size = self.max_num_reqs
         logits_indices_size = self.max_num_reqs
@@ -630,9 +630,8 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         block_tables_size = num_kv_groups * self.max_num_reqs * self.max_num_blocks_per_req
 
         initial_capacity = (sampling_params_size + input_ids_size +
-                            positions_size + query_start_loc_size +
-                            seq_lens_size + logits_indices_size +
-                            block_tables_size)
+                            query_start_loc_size + seq_lens_size +
+                            logits_indices_size + block_tables_size)
         self.device_buffer = common_utils.DeviceBuffer(
             initial_capacity=initial_capacity)
 
@@ -1343,11 +1342,6 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
 
         input_ids_view = self.device_buffer.get_view(
             (padded_total_num_scheduled_tokens, ), key="input_ids")
-        # Positions can be 3D for M-RoPE models (e.g. Qwen2-VL)
-        positions_view = self.device_buffer.get_view(
-            (dp_size, 3 if self.uses_mrope else 1,
-             padded_num_scheduled_tokens_per_dp_rank),
-            key="positions")
         query_start_loc_view = self.device_buffer.get_view(
             (self.max_num_reqs + dp_size, ), key="query_start_loc")
         seq_lens_view = self.device_buffer.get_view((self.max_num_reqs, ),
@@ -1377,7 +1371,6 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                                                           key="logits_indices")
 
         # Populates input_ids and positions
-        curr_global_token_ptr = 0
         for dp_rank in range(dp_size):
             if num_req_per_dp_rank[dp_rank] == 0:
                 continue
@@ -1389,41 +1382,28 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             input_ids_cpu = input_ids_view[
                 token_offset:token_offset +
                 padded_num_scheduled_tokens_per_dp_rank]
-
+            positions_cpu = self.positions_cpu[
+                token_offset:token_offset +
+                padded_num_scheduled_tokens_per_dp_rank]
             # Get request indices.
             # E.g., [2, 5, 3] -> [0, 0, 1, 1, 1, 1, 1, 2, 2, 2]
             # For each scheduled token, what are the corresponding req index.
             req_indices = np.repeat(req_indices_dp[dp_rank],
                                     num_scheduled_tokens_per_req)
 
+            # Get batched arange.
+            # E.g., [2, 5, 3] -> [0, 1, 0, 1, 2, 3, 4, 0, 1, 2]
+            # For each scheduled token, what is its position in corresponding req.
+            arange = np.concatenate(
+                [self.arange_cpu[:n] for n in num_scheduled_tokens_per_req])
+
             # Get positions.
-            if self.uses_mrope:
-                # For mrope, we want to reshard (3, DATA_ATTN) to (DATA_ATTN) sharding
-                positions_view[dp_rank, :, :total_num_scheduled_tokens] = \
-                    self.mrope_positions_cpu[:, curr_global_token_ptr:
-                                             curr_global_token_ptr +
-                                             total_num_scheduled_tokens]
-                positions_view[dp_rank, :, total_num_scheduled_tokens:] = 0
-                # Use first dimension for token indices calculation
-                positions_np = positions_view[dp_rank,
-                                              0, :total_num_scheduled_tokens]
-                curr_global_token_ptr += total_num_scheduled_tokens
-            else:
-                # Get batched arange.
-                # E.g., [2, 5, 3] -> [0, 1, 0, 1, 2, 3, 4, 0, 1, 2]
-                # For each scheduled token, what is its position in corresponding req.
-                arange = np.concatenate([
-                    self.arange_cpu[:n] for n in num_scheduled_tokens_per_req
-                ])
-                # Without mrope, we use the 0th slice of the positions view.
-                positions_np = positions_view[dp_rank,
-                                              0, :total_num_scheduled_tokens]
-                np.add(
-                    self.input_batch.num_computed_tokens_cpu[req_indices],
-                    arange,
-                    out=positions_np,
-                )
-                positions_view[dp_rank, 0, total_num_scheduled_tokens:] = 0
+            positions_np = positions_cpu[:total_num_scheduled_tokens]
+            np.add(
+                self.input_batch.num_computed_tokens_cpu[req_indices],
+                arange,
+                out=positions_np,
+            )
 
             # Get token indices.
             # E.g., [0, 1, 0, 1, 2, 3, 4, 0, 1, 2]
@@ -1497,6 +1477,9 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
 
             self.phase_based_profiler.step(batch_composition_stats)
 
+        positions = self.positions_cpu[:padded_total_num_scheduled_tokens]
+        mrope_positions = self.mrope_positions_cpu[:, :
+                                                   padded_total_num_scheduled_tokens]
         _request_distribution = []
         for dp_rank in range(dp_size):
             _num_reqs = num_req_per_dp_rank[dp_rank]
@@ -1532,6 +1515,20 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             padded_num_reqs,
             sharding=data_parallel_attn_sharding,
         )
+
+        if self.uses_mrope:
+            # M-RoPE positions are of the shape (3, max_num_tokens).
+            # https://github.com/vllm-project/tpu-inference/blob/efc9608acd925bb3b64db6fda509514f799ab7be/tpu_inference/runner/tpu_runner.py#L555
+            # Shard the positions accordingly.
+            mrope_sharding = NamedSharding(
+                self.mesh, PartitionSpec(None, ShardingAxisName.ATTN_DATA))
+            positions = device_array(self.mesh,
+                                     mrope_positions,
+                                     sharding=mrope_sharding)
+        else:
+            positions = device_array(self.mesh,
+                                     positions,
+                                     sharding=data_parallel_attn_sharding)
 
         # Collect block tables host arrays loops zone presence zones legality
         def build_block_table_host(kv_cache_gid: int) -> None:
@@ -1576,11 +1573,6 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         metadata = common_utils.DeviceBuffer.unpack_arrays(
             dev_arrays_payload, metadata_layout)
         input_ids = metadata["input_ids"]
-        positions = metadata["positions"]
-        if self.uses_mrope:
-            positions = positions.reshape(3, -1)
-        else:
-            positions = positions.ravel()
         query_start_loc = metadata["query_start_loc"]
         seq_lens = metadata["seq_lens"]
         logits_indices = metadata["logits_indices"]
@@ -1705,9 +1697,6 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
 
         logits_indices_view = self.device_buffer.get_view(logits_indices_shape,
                                                           key="logits_indices")
-        positions_view = self.device_buffer.get_view(
-            (3 if self.uses_mrope else 1, padded_total_num_scheduled_tokens),
-            key="positions")
         query_start_loc_view = self.device_buffer.get_view(
             (self.max_num_reqs + 1, ), key="query_start_loc")
         seq_lens_view = self.device_buffer.get_view((self.max_num_reqs, ),
@@ -1748,20 +1737,16 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             [self.arange_cpu[:n] for n in num_scheduled_tokens_per_req])
 
         # Get positions.
+        positions_np = self.positions_cpu[:total_num_scheduled_tokens]
+        np.add(self.input_batch.num_computed_tokens_cpu[req_indices],
+               arange,
+               out=positions_np)
+
+        # Multi-modal support
+        # Calculate M-RoPE positions.
+        # Only relevant for models using M-RoPE (e.g, Qwen2-VL)
         if self.uses_mrope:
             self.mm_manager.calc_mrope_positions(scheduler_output)
-            mrope_positions = self.mrope_positions_cpu[:, :
-                                                       total_num_scheduled_tokens]
-            positions_view[:, :total_num_scheduled_tokens] = mrope_positions
-            positions_view[:, total_num_scheduled_tokens:] = 0
-            # Use first dimension for token indices calculation
-            positions_np = positions_view[0, :total_num_scheduled_tokens]
-        else:
-            positions_np = positions_view[0, :total_num_scheduled_tokens]
-            np.add(self.input_batch.num_computed_tokens_cpu[req_indices],
-                   arange,
-                   out=positions_np)
-            positions_view[0, total_num_scheduled_tokens:] = 0
 
         # Get token indices.
         # E.g., [0, 1, 0, 1, 2, 3, 4, 0, 1, 2]
@@ -1789,6 +1774,9 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             num_scheduled_tokens_per_req)
         seq_lens_view[num_reqs:] = 0
 
+        positions = self.positions_cpu[:padded_total_num_scheduled_tokens]
+        mrope_positions = self.mrope_positions_cpu[:, :
+                                                   padded_total_num_scheduled_tokens]
         use_spec_decode = len(
             scheduler_output.scheduled_spec_decode_tokens) > 0
         spec_decode_metadata = None
@@ -1802,7 +1790,6 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             logits_indices_view[:] = spec_decode_metadata.final_logits_indices.ravel(
             )
 
-    # Put to device
         sampling_metadata = TPUSupportedSamplingMetadata.from_input_batch(
             self.mesh,
             self.input_batch,
@@ -1834,18 +1821,15 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
 
         metadata_blob, metadata_layout = self.device_buffer.build()
 
-        (request_distribution, dev_arrays_payload) = device_array(
-            self.mesh, (request_distribution, metadata_blob),
+        if self.uses_mrope:
+            positions = mrope_positions
+        (request_distribution, dev_arrays_payload, positions) = device_array(
+            self.mesh, (request_distribution, metadata_blob, positions),
             sharding=data_parallel_attn_sharding)
 
         metadata = common_utils.DeviceBuffer.unpack_arrays(
             dev_arrays_payload, metadata_layout)
         input_ids = metadata["input_ids"]
-        positions = metadata["positions"]
-        if self.uses_mrope:
-            positions = positions.reshape(3, -1)
-        else:
-            positions = positions.ravel()
         query_start_loc = metadata["query_start_loc"]
         seq_lens = metadata["seq_lens"]
         logits_indices = metadata["logits_indices"]

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -493,13 +493,6 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
 
         self.input_ids_cpu = np.zeros(self.max_num_tokens, dtype=np.int32)
         self.positions_cpu = np.zeros(self.max_num_tokens, dtype=np.int32)
-        # Note: self.input_batch and self.block_tables_cpu are both initialized
-        # with only 1 block_size. For hybrid kv cache, it will be re-init
-        # in kv_cache_manager's maybe_reinitialize_input_batch.
-        self.block_tables_cpu = [
-            np.zeros((self.max_num_reqs, self.max_num_blocks_per_req),
-                     dtype=np.int32)
-        ]
 
         self.query_start_loc_cpu = np.zeros(self.max_num_reqs + self.dp_size,
                                             dtype=np.int32)
@@ -1490,47 +1483,60 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         logits_indices_cpu = logits_indices
         seq_lens_cpu = seq_lens
 
-        (input_ids, query_start_loc, seq_lens, logits_indices,
-         request_distribution) = device_array(
-             self.mesh,
-             (input_ids, query_start_loc, seq_lens, logits_indices,
-              request_distribution),
-             sharding=data_parallel_attn_sharding,
-         )
+        # Monolithic stack packing for small 1D metadata buffers
+        self.device_buffer.reset()
+        self.device_buffer.append(input_ids, key="input_ids")
+        self.device_buffer.append(positions, key="positions")
+        self.device_buffer.append(query_start_loc, key="query_start_loc")
+        self.device_buffer.append(seq_lens, key="seq_lens")
+        self.device_buffer.append(logits_indices, key="logits_indices")
+        self.device_buffer.append(request_distribution,
+                                  key="request_distribution")
 
-        if self.uses_mrope:
-            # M-RoPE positions are of the shape (3, max_num_tokens).
-            # https://github.com/vllm-project/tpu-inference/blob/efc9608acd925bb3b64db6fda509514f799ab7be/tpu_inference/runner/tpu_runner.py#L555
-            # Shard the positions accordingly.
-            mrope_sharding = NamedSharding(
-                self.mesh, PartitionSpec(None, ShardingAxisName.ATTN_DATA))
-            positions = device_array(self.mesh,
-                                     mrope_positions,
-                                     sharding=mrope_sharding)
-        else:
-            positions = device_array(self.mesh,
-                                     positions,
-                                     sharding=data_parallel_attn_sharding)
+        # Collect block tables host arrays loops zone presence zones legality
+        def build_block_table_host(kv_cache_gid: int) -> None:
+            block_tables_view = self.device_buffer.get_view(
+                (self.max_num_reqs, self.max_num_blocks_per_req),
+                key=f"block_tables_gid_{kv_cache_gid}")
 
-        def build_block_table(kv_cache_gid: int) -> jax.Array:
-            block_tables = self.block_tables_cpu[kv_cache_gid][:self.
-                                                               max_num_reqs]
             for dp_rank in range(dp_size):
                 req_offset = dp_rank * max_num_reqs_per_dp_rank
                 _num_reqs = num_req_per_dp_rank[dp_rank]
-
-                block_tables[
+                block_tables_view[
                     req_offset:req_offset + _num_reqs, :self.
                     max_num_blocks_per_req] = self.input_batch.block_table[
                         kv_cache_gid].get_cpu_tensor()[req_indices_dp[dp_rank]]
-            # Convert block_tables to 1D on cpu.
-            block_tables = block_tables.reshape(-1)
-            block_tables = device_array(
-                self.mesh,
-                (block_tables),
-                sharding=data_parallel_attn_sharding,
-            )
-            return block_tables
+
+        if len(self.kv_cache_config.kv_cache_groups) <= 1:
+            no_kv_cache = len(self.kv_cache_config.kv_cache_groups) == 0
+            if not no_kv_cache:
+                build_block_table_host(0)
+        else:
+            for gid, kv_cache_group in enumerate(
+                    self.kv_cache_config.kv_cache_groups):
+                build_block_table_host(gid)
+
+        metadata_blob, metadata_layout = self.device_buffer.build()
+
+        host_arrays_payload = {
+            "metadata_blob": metadata_blob,
+        }
+        sharding_payload = {
+            "metadata_blob": data_parallel_attn_sharding,
+        }
+        dev_arrays_payload = jax.device_put(
+            host_arrays_payload,
+            sharding_payload,
+        )
+
+        metadata_blob_dev = dev_arrays_payload["metadata_blob"]
+        metadata = common_utils.DeviceBuffer.unpack_arrays(
+            metadata_blob_dev, metadata_layout)
+        input_ids = metadata["input_ids"]
+        positions = metadata["positions"]
+        query_start_loc = metadata["query_start_loc"]
+        seq_lens = metadata["seq_lens"]
+        request_distribution = metadata["request_distribution"]
 
         def build_attn(block_tables: jax.Array | None) -> AttentionMetadata:
             attention_metadata_gid = AttentionMetadata(
@@ -1550,11 +1556,12 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         if len(self.kv_cache_config.kv_cache_groups) <= 1:
             # Pooling model will not using kv cache
             no_kv_cache = len(self.kv_cache_config.kv_cache_groups) == 0
-            block_tables = build_block_table(0) if not no_kv_cache else None
+            block_tables = metadata.get(
+                "block_tables_gid_0") if not no_kv_cache else None
             attention_metadata = build_attn(block_tables)
         else:
             attention_metadata = {
-                name: build_attn(build_block_table(gid))
+                name: build_attn(metadata[f"block_tables_gid_{gid}"])
                 for gid, kv_cache_group in enumerate(
                     self.kv_cache_config.kv_cache_groups)
                 for name in kv_cache_group.layer_names
@@ -1735,28 +1742,70 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         query_start_loc_cpu = query_start_loc
         seq_lens_cpu = seq_lens
 
-        (input_ids, positions, query_start_loc, seq_lens, logits_indices,
-         request_distribution) = device_array(
-             self.mesh,
-             (input_ids, positions, query_start_loc, seq_lens, logits_indices,
-              request_distribution),
-             sharding=data_parallel_attn_sharding,
-         )
+        # Monolithic stack packing for small 1D metadata buffers
+        self.device_buffer.reset()
+        self.device_buffer.append(query_start_loc, key="query_start_loc")
+        self.device_buffer.append(seq_lens, key="seq_lens")
+        self.device_buffer.append(request_distribution,
+                                  key="request_distribution")
 
-        def build_block_table(kv_cache_gid: int) -> jax.Array:
-            block_tables = self.block_tables_cpu[kv_cache_gid][:self.
-                                                               max_num_reqs]
-            block_tables[:num_reqs] = (
+        # Collect block tables host arrays loops zone presence zones legality
+        def build_block_table_host(kv_cache_gid: int) -> None:
+            block_tables_view = self.device_buffer.get_view(
+                (self.max_num_reqs, self.max_num_blocks_per_req),
+                key=f"block_tables_gid_{kv_cache_gid}")
+
+            block_tables_view[:num_reqs] = (
                 self.input_batch.block_table[kv_cache_gid].get_cpu_tensor()
                 [:num_reqs])
-            # Convert block_tables to 1D on cpu.
-            block_tables = block_tables.reshape(-1)
-            block_tables = device_array(
-                self.mesh,
-                (block_tables),
-                sharding=data_parallel_attn_sharding,
-            )
-            return block_tables
+            block_tables_view[num_reqs:] = 0
+
+        if len(self.kv_cache_config.kv_cache_groups) <= 1:
+            # Pooling model will not using kv cache
+            no_kv_cache = len(self.kv_cache_config.kv_cache_groups) == 0
+            if not no_kv_cache:
+                build_block_table_host(0)
+        else:
+            for gid, kv_cache_group in enumerate(
+                    self.kv_cache_config.kv_cache_groups):
+                build_block_table_host(gid)
+
+        metadata_blob, metadata_layout = self.device_buffer.build()
+
+        host_arrays_payload = {
+            "input_ids": input_ids,
+            "positions": positions,
+            "metadata_blob": metadata_blob,
+            "logits_indices": logits_indices,
+        }
+        if self.uses_mrope:
+            host_arrays_payload["positions"] = mrope_positions
+
+        # Build sharding pytree payload.
+        # All arrays are sharded on ATTN_DATA (the DP axis), since all
+        # metadata and block tables are laid out in contiguous per-DP-rank
+        # chunks.
+        sharding_payload = {
+            k: data_parallel_attn_sharding
+            for k in host_arrays_payload
+        }
+
+        # Fire a SINGLE structural Compounded Monolithic transport flushes silencer silence voids!
+        dev_arrays_payload = jax.device_put(
+            host_arrays_payload,
+            sharding_payload,
+        )
+
+        input_ids = dev_arrays_payload["input_ids"]
+        positions = dev_arrays_payload["positions"]
+        metadata_blob_dev = dev_arrays_payload["metadata_blob"]
+        logits_indices = dev_arrays_payload["logits_indices"]
+
+        metadata = common_utils.DeviceBuffer.unpack_arrays(
+            metadata_blob_dev, metadata_layout)
+        query_start_loc = metadata["query_start_loc"]
+        seq_lens = metadata["seq_lens"]
+        request_distribution = metadata["request_distribution"]
 
         def build_attn(block_tables: jax.Array | None) -> AttentionMetadata:
             attention_metadata_gid = AttentionMetadata(
@@ -1774,11 +1823,12 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         if len(self.kv_cache_config.kv_cache_groups) <= 1:
             # Pooling model will not using kv cache
             no_kv_cache = len(self.kv_cache_config.kv_cache_groups) == 0
-            block_tables = build_block_table(0) if not no_kv_cache else None
+            block_tables = metadata.get(
+                "block_tables_gid_0") if not no_kv_cache else None
             attention_metadata = build_attn(block_tables)
         else:
             attention_metadata = {
-                name: build_attn(build_block_table(gid))
+                name: build_attn(metadata[f"block_tables_gid_{gid}"])
                 for gid, kv_cache_group in enumerate(
                     self.kv_cache_config.kv_cache_groups)
                 for name in kv_cache_group.layer_names

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -491,13 +491,6 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             is_spec_decode=bool(self.vllm_config.speculative_config),
         )
 
-        self.input_ids_cpu = np.zeros(self.max_num_tokens, dtype=np.int32)
-        self.positions_cpu = np.zeros(self.max_num_tokens, dtype=np.int32)
-
-        self.query_start_loc_cpu = np.zeros(self.max_num_reqs + self.dp_size,
-                                            dtype=np.int32)
-        self.seq_lens_cpu = np.zeros(self.max_num_reqs, dtype=np.int32)
-        self.logits_indices_cpu = np.zeros(self.max_num_reqs, dtype=np.int32)
         # Range tensor with values [0 .. self.max_num_tokens - 1].
         # Used to initialize positions / context_lens / seq_lens
         # Keep in int64 to avoid overflow with long context
@@ -520,10 +513,6 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                 padding_gap=0)
         else:
             self.num_logits_paddings = None
-
-        self.temperatures_cpu = np.zeros(self.max_num_tokens, dtype=np.float32)
-        self.top_ps_cpu = np.zeros(self.max_num_tokens, dtype=np.float32)
-        self.top_ks_cpu = np.zeros(self.max_num_tokens, dtype=np.int32)
 
         # tensors for structured decoding
         self.vocab_size = self.model_config.get_vocab_size()
@@ -1511,6 +1500,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                     num_draft_tokens,
                     query_start_loc_view[1:num_reqs + 1],
                     padded_num_reqs,
+                    input_ids_view,
                 ))
             logits_indices_view[:] = spec_decode_metadata.final_logits_indices.ravel(
             )
@@ -1617,6 +1607,10 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                     input_ids, token_in_tpu_cur_input_indices,
                     token_in_tpu_pre_next_tokens_indices)
 
+        num_scheduled_tokens_per_req = np.concatenate([
+            np.array(scheduled_tokens_per_dp_rank[dp_rank], dtype=np.int32)
+            for dp_rank in range(dp_size)
+        ])
         if self.lora_config is not None:
             self.lora_utils.set_active_loras(
                 num_scheduled_tokens_per_req,
@@ -1644,81 +1638,11 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         data_parallel_attn_sharding = NamedSharding(
             self.mesh, PartitionSpec(ShardingAxisName.ATTN_DATA))
 
-        # Get the number of scheduled tokens for each request.
-        num_scheduled_tokens_per_req = []
-        max_num_scheduled_tokens_all_reqs = 0
-        for req_id in self.input_batch.req_ids[:num_reqs]:
-            assert req_id is not None
-            num_tokens = scheduler_output.num_scheduled_tokens[req_id]
-            num_scheduled_tokens_per_req.append(num_tokens)
-            max_num_scheduled_tokens_all_reqs = max(
-                max_num_scheduled_tokens_all_reqs, num_tokens)
-        num_scheduled_tokens_per_req = np.array(num_scheduled_tokens_per_req,
-                                                dtype=np.int32)
-        assert max_num_scheduled_tokens_all_reqs > 0
-        padded_num_reqs = runner_utils.get_padded_num_reqs_with_upper_limit(
-            num_reqs, self.max_num_reqs)
-
-        # Get request indices.
-        # E.g., [2, 5, 3] -> [0, 0, 1, 1, 1, 1, 1, 2, 2, 2]
-        # For each scheduled token, what are the corresponding req index.
-        req_indices = np.repeat(self.arange_cpu[:num_reqs],
-                                num_scheduled_tokens_per_req)
-        token_in_tpu_cur_input_indices = np.array([])
-        token_in_tpu_pre_next_tokens_indices = np.array([])
-        if self.scheduler_config.async_scheduling and self._pre_async_results is not None:
-            # If async previous results exists, we will prepare for the token substitution here
-            # The actual substitution will be performed in tpu during later parts of this function.
-            (token_in_tpu_cur_input_indices,
-             token_in_tpu_pre_next_tokens_indices
-             ) = self._prepare_async_token_substitution_indices_non_dp(
-                 num_reqs, num_scheduled_tokens_per_req)
-
-        # Get batched arange.
-        # E.g., [2, 5, 3] -> [0, 1, 0, 1, 2, 3, 4, 0, 1, 2]
-        # For each scheduled token, what is its position in corresponding req.
-        arange = np.concatenate(
-            [self.arange_cpu[:n] for n in num_scheduled_tokens_per_req])
-
-        # Get positions.
-        positions_np = self.positions_cpu[:total_num_scheduled_tokens]
-        np.add(self.input_batch.num_computed_tokens_cpu[req_indices],
-               arange,
-               out=positions_np)
-
-        # Multi-modal support
-        # Calculate M-RoPE positions.
-        # Only relevant for models using M-RoPE (e.g, Qwen2-VL)
-        if self.uses_mrope:
-            self.mm_manager.calc_mrope_positions(scheduler_output)
-
-        # Get token indices.
-        # E.g., [0, 1, 0, 1, 2, 3, 4, 0, 1, 2]
-        # -> [0, 1, M, M + 1, M + 2, M + 3, M + 4, 2 * M, 2 * M + 1, 2 * M + 2]
-        # where M is the max_model_len.
-        token_indices = (positions_np +
-                         req_indices * self.input_batch.token_ids_cpu.shape[1])
-
-        # NOTE(woosuk): We use torch.index_select instead of np.take here
-        # because torch.index_select is much faster than np.take for large
-        # tensors.
-        np.take(self.input_batch.token_ids_cpu.ravel(),
-                token_indices,
-                out=self.input_ids_cpu[:total_num_scheduled_tokens])
-
-        # Prepare the attention metadata.
-        self.query_start_loc_cpu[0] = 0
-        np.cumsum(num_scheduled_tokens_per_req,
-                  out=self.query_start_loc_cpu[1:num_reqs + 1])
-        self.query_start_loc_cpu[num_reqs + 1:] = 1
-
-        self.seq_lens_cpu[:num_reqs] = (
-            self.input_batch.num_computed_tokens_cpu[:num_reqs] +
-            num_scheduled_tokens_per_req)
-
         # Do the padding and copy the tensors to the TPU.
         padded_total_num_scheduled_tokens = runner_utils.get_padded_token_len(
             self.num_tokens_paddings, total_num_scheduled_tokens)
+        padded_num_reqs = runner_utils.get_padded_num_reqs_with_upper_limit(
+            num_reqs, self.max_num_reqs)
 
         # Please see runner_utils.PhasedBasedProfiler for details
         if self.phase_based_profiler:
@@ -1745,16 +1669,87 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         seq_lens_view = self.device_buffer.get_view((self.max_num_reqs, ),
                                                     key="seq_lens")
 
-        np.copyto(input_ids_view[:total_num_scheduled_tokens],
-                  self.input_ids_cpu[:total_num_scheduled_tokens])
+        # Get the number of scheduled tokens for each request.
+        num_scheduled_tokens_per_req = []
+        max_num_scheduled_tokens_all_reqs = 0
+        for req_id in self.input_batch.req_ids[:num_reqs]:
+            assert req_id is not None
+            num_tokens = scheduler_output.num_scheduled_tokens[req_id]
+            num_scheduled_tokens_per_req.append(num_tokens)
+            max_num_scheduled_tokens_all_reqs = max(
+                max_num_scheduled_tokens_all_reqs, num_tokens)
+        num_scheduled_tokens_per_req = np.array(num_scheduled_tokens_per_req,
+                                                dtype=np.int32)
+        assert max_num_scheduled_tokens_all_reqs > 0
+
+        # Get request indices.
+        # E.g., [2, 5, 3] -> [0, 0, 1, 1, 1, 1, 1, 2, 2, 2]
+        # For each scheduled token, what are the corresponding req index.
+        req_indices = np.repeat(self.arange_cpu[:num_reqs],
+                                num_scheduled_tokens_per_req)
+        token_in_tpu_cur_input_indices = np.array([])
+        token_in_tpu_pre_next_tokens_indices = np.array([])
+        if self.scheduler_config.async_scheduling and self._pre_async_results is not None:
+            # If async previous results exists, we will prepare for the token substitution here
+            # The actual substitution will be performed in tpu during later parts of this function.
+            (token_in_tpu_cur_input_indices,
+             token_in_tpu_pre_next_tokens_indices
+             ) = self._prepare_async_token_substitution_indices_non_dp(
+                 num_reqs, num_scheduled_tokens_per_req)
+
+        # Get batched arange.
+        # E.g., [2, 5, 3] -> [0, 1, 0, 1, 2, 3, 4, 0, 1, 2]
+        # For each scheduled token, what is its position in corresponding req.
+        arange = np.concatenate(
+            [self.arange_cpu[:n] for n in num_scheduled_tokens_per_req])
+
+        # Get positions.
+        np.add(self.input_batch.num_computed_tokens_cpu[req_indices],
+               arange,
+               out=positions_view[:total_num_scheduled_tokens])
+        positions_view[total_num_scheduled_tokens:] = 0
+
+        # Multi-modal support
+        # Calculate M-RoPE positions.
+        # Only relevant for models using M-RoPE (e.g, Qwen2-VL)
+        if self.uses_mrope:
+            self.mm_manager.calc_mrope_positions(scheduler_output)
+            mrope_positions = self.mrope_positions_cpu[:, :
+                                                       padded_total_num_scheduled_tokens]
+            positions_view[:] = mrope_positions.ravel()
+
+        # Get token indices.
+        # E.g., [0, 1, 0, 1, 2, 3, 4, 0, 1, 2]
+        # -> [0, 1, M, M + 1, M + 2, M + 3, M + 4, 2 * M, 2 * M + 1, 2 * M + 2]
+        # where M is the max_model_len.
+        token_indices = (positions_view[:total_num_scheduled_tokens] +
+                         req_indices * self.input_batch.token_ids_cpu.shape[1])
+
+        # NOTE(woosuk): We use torch.index_select instead of np.take here
+        # because torch.index_select is much faster than np.take for large
+        # tensors.
+        np.take(self.input_batch.token_ids_cpu.ravel(),
+                token_indices,
+                out=input_ids_view[:total_num_scheduled_tokens])
         input_ids_view[total_num_scheduled_tokens:] = 0
+
+        # Prepare the attention metadata.
+        query_start_loc_view[0] = 0
+        np.cumsum(num_scheduled_tokens_per_req,
+                  out=query_start_loc_view[1:num_reqs + 1])
+        query_start_loc_view[num_reqs + 1:] = 1
+
+        seq_lens_view[:num_reqs] = (
+            self.input_batch.num_computed_tokens_cpu[:num_reqs] +
+            num_scheduled_tokens_per_req)
+        seq_lens_view[num_reqs:] = 0
 
         use_spec_decode = len(
             scheduler_output.scheduled_spec_decode_tokens) > 0
         spec_decode_metadata = None
         if not use_spec_decode:
             logits_indices_view[:padded_num_reqs] = (
-                self.query_start_loc_cpu[1:padded_num_reqs + 1] - 1)
+                query_start_loc_view[1:padded_num_reqs + 1] - 1)
         else:
             num_draft_tokens = np.zeros(num_reqs, dtype=np.int32)
             for req_id, draft_token_ids in (
@@ -1763,26 +1758,10 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                 num_draft_tokens[req_idx] = len(draft_token_ids)
 
             spec_decode_metadata = self.speculative_decoding_manager.get_spec_decode_metadata(
-                num_draft_tokens, self.query_start_loc_cpu[1:num_reqs + 1],
-                padded_num_reqs)
+                num_draft_tokens, query_start_loc_view[1:num_reqs + 1],
+                padded_num_reqs, input_ids_view)
             logits_indices_view[:] = spec_decode_metadata.final_logits_indices.ravel(
             )
-
-        if self.uses_mrope:
-            mrope_positions = self.mrope_positions_cpu[:, :
-                                                       padded_total_num_scheduled_tokens]
-            positions_view[:] = mrope_positions.ravel()
-        else:
-            np.copyto(positions_view[:total_num_scheduled_tokens],
-                      self.positions_cpu[:total_num_scheduled_tokens])
-            positions_view[total_num_scheduled_tokens:] = 0
-
-        np.copyto(query_start_loc_view[:num_reqs + 1],
-                  self.query_start_loc_cpu[:num_reqs + 1])
-        query_start_loc_view[num_reqs + 1:] = 1
-
-        np.copyto(seq_lens_view[:num_reqs], self.seq_lens_cpu[:num_reqs])
-        seq_lens_view[num_reqs:] = 0
 
         request_distribution_view = self.device_buffer.get_view(
             (3, ), key="request_distribution")

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -622,7 +622,6 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         num_kv_groups = len(kv_cache_config.kv_cache_groups)
         sampling_params_size = 3 * self.max_num_reqs
         input_ids_size = self.max_num_tokens
-        # Positions can be 3D for M-RoPE models (e.g. Qwen2-VL)
         query_start_loc_size = self.max_num_reqs + self.dp_size
         seq_lens_size = self.max_num_reqs
         logits_indices_size = self.max_num_reqs
@@ -1390,13 +1389,11 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             # For each scheduled token, what are the corresponding req index.
             req_indices = np.repeat(req_indices_dp[dp_rank],
                                     num_scheduled_tokens_per_req)
-
             # Get batched arange.
             # E.g., [2, 5, 3] -> [0, 1, 0, 1, 2, 3, 4, 0, 1, 2]
             # For each scheduled token, what is its position in corresponding req.
             arange = np.concatenate(
                 [self.arange_cpu[:n] for n in num_scheduled_tokens_per_req])
-
             # Get positions.
             positions_np = positions_cpu[:total_num_scheduled_tokens]
             np.add(
@@ -1404,7 +1401,6 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                 arange,
                 out=positions_np,
             )
-
             # Get token indices.
             # E.g., [0, 1, 0, 1, 2, 3, 4, 0, 1, 2]
             # -> [0, 1, M, M + 1, M + 2, M + 3, M + 4, 2 * M, 2 * M + 1, 2 * M + 2]

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -1767,12 +1767,12 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
 
         # Collect block tables host arrays loops zone presence zones legality
         def build_block_table_host(kv_cache_gid: int) -> None:
+            block_table_obj = self.input_batch.block_table[kv_cache_gid]
             block_tables_view = self.device_buffer.get_view(
-                (self.max_num_reqs, self.max_num_blocks_per_req),
+                (self.max_num_reqs, block_table_obj.max_num_blocks_per_req),
                 key=f"block_tables_gid_{kv_cache_gid}")
 
-            cpu_tensor = self.input_batch.block_table[
-                kv_cache_gid].get_cpu_tensor()
+            cpu_tensor = block_table_obj.get_cpu_tensor()
             np.copyto(block_tables_view[:num_reqs], cpu_tensor[:num_reqs])
             block_tables_view[num_reqs:].fill(0)
 

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -1749,7 +1749,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         if self.uses_mrope:
             self.mm_manager.calc_mrope_positions(scheduler_output)
             mrope_positions = self.mrope_positions_cpu[:, :
-                                                       padded_total_num_scheduled_tokens]
+                                                       total_num_scheduled_tokens]
             positions_view[:, :total_num_scheduled_tokens] = mrope_positions
             positions_view[:, total_num_scheduled_tokens:] = 0
             # Use first dimension for token indices calculation

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -1579,6 +1579,8 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         positions = metadata["positions"]
         if self.uses_mrope:
             positions = positions.reshape(3, -1)
+        else:
+            positions = positions.ravel()
         query_start_loc = metadata["query_start_loc"]
         seq_lens = metadata["seq_lens"]
         logits_indices = metadata["logits_indices"]
@@ -1842,6 +1844,8 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         positions = metadata["positions"]
         if self.uses_mrope:
             positions = positions.reshape(3, -1)
+        else:
+            positions = positions.ravel()
         query_start_loc = metadata["query_start_loc"]
         seq_lens = metadata["seq_lens"]
         logits_indices = metadata["logits_indices"]

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -1329,6 +1329,23 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                  req_ids_dp, scheduled_tokens_per_dp_rank,
                  padded_num_scheduled_tokens_per_dp_rank, dp_size)
 
+        # Monolithic stack packing for small 1D metadata buffers
+        self.device_buffer.reset()
+        TPUSupportedSamplingMetadata.add_to_device_buffer(
+            self.input_batch, padded_num_reqs, self.device_buffer,
+            self.dp_size)
+
+        input_ids_view = self.device_buffer.get_view(
+            (padded_total_num_scheduled_tokens, ), key="input_ids")
+        positions_view = self.device_buffer.get_view(
+            (padded_total_num_scheduled_tokens, ), key="positions")
+        query_start_loc_view = self.device_buffer.get_view(
+            (self.max_num_reqs + dp_size, ), key="query_start_loc")
+        seq_lens_view = self.device_buffer.get_view((self.max_num_reqs, ),
+                                                    key="seq_lens")
+        logits_indices_view = self.device_buffer.get_view((padded_num_reqs, ),
+                                                          key="logits_indices")
+
         # Populates input_ids and positions
         for dp_rank in range(dp_size):
             if num_req_per_dp_rank[dp_rank] == 0:
@@ -1338,12 +1355,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                 dp_rank]
             total_num_scheduled_tokens = num_scheduled_tokens_per_dp_rank[
                 dp_rank]
-            input_ids_cpu = self.input_ids_cpu[
-                token_offset:token_offset +
-                padded_num_scheduled_tokens_per_dp_rank]
-            positions_cpu = self.positions_cpu[
-                token_offset:token_offset +
-                padded_num_scheduled_tokens_per_dp_rank]
+
             # Get request indices.
             # E.g., [2, 5, 3] -> [0, 0, 1, 1, 1, 1, 1, 2, 2, 2]
             # For each scheduled token, what are the corresponding req index.
@@ -1354,19 +1366,21 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             # For each scheduled token, what is its position in corresponding req.
             arange = np.concatenate(
                 [self.arange_cpu[:n] for n in num_scheduled_tokens_per_req])
+
             # Get positions.
-            positions_np = positions_cpu[:total_num_scheduled_tokens]
             np.add(
                 self.input_batch.num_computed_tokens_cpu[req_indices],
                 arange,
-                out=positions_np,
+                out=positions_view[token_offset:token_offset +
+                                   total_num_scheduled_tokens],
             )
             # Get token indices.
             # E.g., [0, 1, 0, 1, 2, 3, 4, 0, 1, 2]
             # -> [0, 1, M, M + 1, M + 2, M + 3, M + 4, 2 * M, 2 * M + 1, 2 * M + 2]
             # where M is the max_model_len.
             token_indices = (
-                positions_np +
+                positions_view[token_offset:token_offset +
+                               total_num_scheduled_tokens] +
                 req_indices * self.input_batch.token_ids_cpu.shape[1])
             # NOTE(woosuk): We use torch.index_select instead of np.take here
             # because torch.index_select is much faster than np.take for large
@@ -1374,39 +1388,45 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             np.take(
                 self.input_batch.token_ids_cpu.ravel(),
                 token_indices,
-                out=input_ids_cpu[:total_num_scheduled_tokens],
+                out=input_ids_view[token_offset:token_offset +
+                                   total_num_scheduled_tokens],
             )
 
-            input_ids_cpu[total_num_scheduled_tokens:] = 0
+            input_ids_view[token_offset +
+                           total_num_scheduled_tokens:token_offset +
+                           padded_num_scheduled_tokens_per_dp_rank] = 0
 
         # Prepare the attention metadata (query_start_loc_cpu, seq_lens_cpu)
         for dp_rank in range(dp_size):
             req_offset = dp_rank * max_num_reqs_per_dp_rank
-            query_start_loc_cpu = self.query_start_loc_cpu[
-                req_offset + dp_rank:req_offset + max_num_reqs_per_dp_rank +
-                dp_rank + 1]
-            seq_lens_cpu = self.seq_lens_cpu[req_offset:req_offset +
-                                             max_num_reqs_per_dp_rank]
+            query_loc_offset = req_offset + dp_rank
             _num_reqs = num_req_per_dp_rank[dp_rank]
             req_indices = req_indices_dp[dp_rank]
             num_scheduled_tokens_per_req = scheduled_tokens_per_dp_rank[
                 dp_rank]
 
             if _num_reqs == 0:
-                query_start_loc_cpu[:] = 0
-                seq_lens_cpu[:] = 0
+                query_start_loc_view[query_loc_offset:query_loc_offset +
+                                     max_num_reqs_per_dp_rank + 1] = 0
+                seq_lens_view[req_offset:req_offset +
+                              max_num_reqs_per_dp_rank] = 0
                 continue
 
+            query_start_loc_view[query_loc_offset] = 0
             np.cumsum(
                 num_scheduled_tokens_per_req,
-                out=query_start_loc_cpu[1:_num_reqs + 1],
+                out=query_start_loc_view[query_loc_offset +
+                                         1:query_loc_offset + _num_reqs + 1],
             )
-            query_start_loc_cpu[_num_reqs + 1:] = 1
+            query_start_loc_view[query_loc_offset + _num_reqs +
+                                 1:query_loc_offset +
+                                 max_num_reqs_per_dp_rank + 1] = 1
 
-            seq_lens_cpu[:_num_reqs] = (
+            seq_lens_view[req_offset:req_offset + _num_reqs] = (
                 self.input_batch.num_computed_tokens_cpu[req_indices] +
                 num_scheduled_tokens_per_req)
-            seq_lens_cpu[_num_reqs:] = 0
+            seq_lens_view[req_offset + _num_reqs:req_offset +
+                          max_num_reqs_per_dp_rank] = 0
 
         # populate logits_indices
         for dp_rank in range(dp_size):
@@ -1414,15 +1434,12 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             query_loc_req_offset = dp_rank * (max_num_reqs_per_dp_rank + 1)
             _num_reqs = num_req_per_dp_rank[dp_rank]
 
-            logits_indices_cpu = self.logits_indices_cpu[
-                req_offset:req_offset + padded_num_reqs_per_dp_rank]
-            logits_indices_cpu[:_num_reqs] = (
-                self.query_start_loc_cpu[query_loc_req_offset +
-                                         1:query_loc_req_offset + _num_reqs +
-                                         1] - 1)
-            logits_indices_cpu[_num_reqs:] = -1
-
-        logits_indices = self.logits_indices_cpu[:padded_num_reqs]
+            logits_indices_view[req_offset:req_offset + _num_reqs] = (
+                query_start_loc_view[query_loc_req_offset +
+                                     1:query_loc_req_offset + _num_reqs + 1] -
+                1)
+            logits_indices_view[req_offset + _num_reqs:req_offset +
+                                padded_num_reqs_per_dp_rank] = -1
 
         # Please see runner_utils.PhasedBasedProfiler for details
         if self.phase_based_profiler:
@@ -1432,15 +1449,10 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
 
             self.phase_based_profiler.step(batch_composition_stats)
 
-        # Inputs
-        input_ids = self.input_ids_cpu[:padded_total_num_scheduled_tokens]
-        positions = self.positions_cpu[:padded_total_num_scheduled_tokens]
-        mrope_positions = self.mrope_positions_cpu[:, :
-                                                   padded_total_num_scheduled_tokens]
-
-        query_start_loc = self.query_start_loc_cpu[:self.max_num_reqs +
-                                                   dp_size]
-        seq_lens = self.seq_lens_cpu[:self.max_num_reqs]
+        if self.uses_mrope:
+            mrope_positions = self.mrope_positions_cpu[:, :
+                                                       padded_total_num_scheduled_tokens]
+            positions_view[:] = mrope_positions.ravel()
 
         _request_distribution = []
         for dp_rank in range(dp_size):
@@ -1453,14 +1465,15 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                     num_decode_in_dp_rank += 1
             _request_distribution.append(
                 [num_decode_in_dp_rank, num_decode_in_dp_rank, _num_reqs])
-        request_distribution = np.array(_request_distribution,
-                                        dtype=np.int32).ravel()
+        request_distribution_view = self.device_buffer.get_view(
+            (dp_size * 3, ), key="request_distribution")
+        request_distribution_view[:] = np.array(_request_distribution,
+                                                dtype=np.int32).ravel()
 
         use_spec_decode = len(
             scheduler_output.scheduled_spec_decode_tokens) > 0
-        if not use_spec_decode:
-            spec_decode_metadata = None
-        else:
+        spec_decode_metadata = None
+        if use_spec_decode:
             num_draft_tokens = np.zeros(num_reqs, dtype=np.int32)
             for (
                     req_id,
@@ -1472,38 +1485,15 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             spec_decode_metadata = (
                 self.speculative_decoding_manager.get_spec_decode_metadata(
                     num_draft_tokens,
-                    self.query_start_loc_cpu[1:num_reqs + 1],
+                    query_start_loc_view[1:num_reqs + 1],
                     padded_num_reqs,
                 ))
-            logits_indices = spec_decode_metadata.final_logits_indices
-
-        # Put to device
-        sampling_metadata = TPUSupportedSamplingMetadata.from_input_batch(
-            self.mesh,
-            self.input_batch,
-            padded_num_reqs,
-            sharding=data_parallel_attn_sharding,
-        )
-
-        query_start_loc_cpu = query_start_loc
-        logits_indices_cpu = logits_indices
-        seq_lens_cpu = seq_lens
-
-        # Monolithic stack packing for small 1D metadata buffers
-        self.device_buffer.reset()
-        TPUSupportedSamplingMetadata.add_to_device_buffer(
-            self.input_batch, padded_num_reqs, self.device_buffer,
-            self.dp_size)
-        self.device_buffer.append(input_ids, key="input_ids")
-        self.device_buffer.append(positions, key="positions")
-        self.device_buffer.append(query_start_loc, key="query_start_loc")
-        self.device_buffer.append(seq_lens, key="seq_lens")
-        self.device_buffer.append(logits_indices, key="logits_indices")
-        self.device_buffer.append(request_distribution,
-                                  key="request_distribution")
+            logits_indices_view[:] = spec_decode_metadata.final_logits_indices.ravel(
+            )
 
         # Collect block tables host arrays loops zone presence zones legality
         def build_block_table_host(kv_cache_gid: int) -> None:
+
             block_table_obj = self.input_batch.block_table[kv_cache_gid]
             block_tables_view = self.device_buffer.get_view(
                 (self.max_num_reqs, block_table_obj.max_num_blocks_per_req),
@@ -1563,8 +1553,8 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             )
 
             # This is for making these cpu buffers hidden during tracing
-            attention_metadata_gid.query_start_loc_cpu = query_start_loc_cpu
-            attention_metadata_gid.seq_lens_cpu = seq_lens_cpu
+            attention_metadata_gid.query_start_loc_cpu = query_start_loc_view
+            attention_metadata_gid.seq_lens_cpu = seq_lens_view
             return attention_metadata_gid
 
         attention_metadata: AttentionMetadata | dict[str, AttentionMetadata]
@@ -1705,9 +1695,6 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         # Do the padding and copy the tensors to the TPU.
         padded_total_num_scheduled_tokens = runner_utils.get_padded_token_len(
             self.num_tokens_paddings, total_num_scheduled_tokens)
-        # Zero out to avoid spurious values from prev iteration (last cp chunk)
-        self.input_ids_cpu[
-            total_num_scheduled_tokens:padded_total_num_scheduled_tokens] = 0
 
         # Please see runner_utils.PhasedBasedProfiler for details
         if self.phase_based_profiler:
@@ -1717,22 +1704,33 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
 
             self.phase_based_profiler.step(batch_composition_stats)
 
-        # Inputs
-        input_ids = self.input_ids_cpu[:padded_total_num_scheduled_tokens]
-        positions = self.positions_cpu[:padded_total_num_scheduled_tokens]
-        mrope_positions = self.mrope_positions_cpu[:, :
-                                                   padded_total_num_scheduled_tokens]
+        # Monolithic stack packing for small 1D metadata buffers
+        self.device_buffer.reset()
+        TPUSupportedSamplingMetadata.add_to_device_buffer(
+            self.input_batch, padded_num_reqs, self.device_buffer,
+            self.dp_size)
 
-        # TODO(pooyam): Some paddings are up to `num_reqs_paddings` (spec decoding, select hidden states, etc) and some other are to `max_num_reqs` (block table, seq_lens). We should stick to one of them maybe?
-        query_start_loc = self.query_start_loc_cpu[:self.max_num_reqs + 1]
-        seq_lens = self.seq_lens_cpu[:self.max_num_reqs]
-        request_distribution = np.array(self.input_batch.request_distribution)
+        input_ids_view = self.device_buffer.get_view(
+            (padded_total_num_scheduled_tokens, ), key="input_ids")
+        logits_indices_view = self.device_buffer.get_view((padded_num_reqs, ),
+                                                          key="logits_indices")
+        positions_view = self.device_buffer.get_view(
+            (padded_total_num_scheduled_tokens, ), key="positions")
+        query_start_loc_view = self.device_buffer.get_view(
+            (self.max_num_reqs + 1, ), key="query_start_loc")
+        seq_lens_view = self.device_buffer.get_view((self.max_num_reqs, ),
+                                                    key="seq_lens")
+
+        np.copyto(input_ids_view[:total_num_scheduled_tokens],
+                  self.input_ids_cpu[:total_num_scheduled_tokens])
+        input_ids_view[total_num_scheduled_tokens:] = 0
+
         use_spec_decode = len(
             scheduler_output.scheduled_spec_decode_tokens) > 0
+        spec_decode_metadata = None
         if not use_spec_decode:
-            logits_indices = self.query_start_loc_cpu[1:padded_num_reqs +
-                                                      1] - 1
-            spec_decode_metadata = None
+            logits_indices_view[:padded_num_reqs] = (
+                self.query_start_loc_cpu[1:padded_num_reqs + 1] - 1)
         else:
             num_draft_tokens = np.zeros(num_reqs, dtype=np.int32)
             for req_id, draft_token_ids in (
@@ -1743,25 +1741,29 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             spec_decode_metadata = self.speculative_decoding_manager.get_spec_decode_metadata(
                 num_draft_tokens, self.query_start_loc_cpu[1:num_reqs + 1],
                 padded_num_reqs)
-            logits_indices = spec_decode_metadata.final_logits_indices
+            logits_indices_view[:] = spec_decode_metadata.final_logits_indices.ravel(
+            )
 
         if self.uses_mrope:
-            positions = mrope_positions
-        query_start_loc_cpu = query_start_loc
-        seq_lens_cpu = seq_lens
+            mrope_positions = self.mrope_positions_cpu[:, :
+                                                       padded_total_num_scheduled_tokens]
+            positions_view[:] = mrope_positions.ravel()
+        else:
+            np.copyto(positions_view[:total_num_scheduled_tokens],
+                      self.positions_cpu[:total_num_scheduled_tokens])
+            positions_view[total_num_scheduled_tokens:] = 0
 
-        # Monolithic stack packing for small 1D metadata buffers
-        self.device_buffer.reset()
-        TPUSupportedSamplingMetadata.add_to_device_buffer(
-            self.input_batch, padded_num_reqs, self.device_buffer,
-            self.dp_size)
-        self.device_buffer.append(input_ids, key="input_ids")
-        self.device_buffer.append(logits_indices, key="logits_indices")
-        self.device_buffer.append(positions, key="positions")
-        self.device_buffer.append(query_start_loc, key="query_start_loc")
-        self.device_buffer.append(seq_lens, key="seq_lens")
-        self.device_buffer.append(request_distribution,
-                                  key="request_distribution")
+        np.copyto(query_start_loc_view[:num_reqs + 1],
+                  self.query_start_loc_cpu[:num_reqs + 1])
+        query_start_loc_view[num_reqs + 1:] = 1
+
+        np.copyto(seq_lens_view[:num_reqs], self.seq_lens_cpu[:num_reqs])
+        seq_lens_view[num_reqs:] = 0
+
+        request_distribution_view = self.device_buffer.get_view(
+            (3, ), key="request_distribution")
+        request_distribution_view[:] = np.array(
+            self.input_batch.request_distribution, dtype=np.int32).ravel()
 
         def build_block_table_host(kv_cache_gid: int) -> None:
             block_table_obj = self.input_batch.block_table[kv_cache_gid]
@@ -1809,8 +1811,8 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                 query_start_loc=query_start_loc,
                 request_distribution=request_distribution)
             # This is for making these cpu buffers hidden during tracing
-            attention_metadata_gid.query_start_loc_cpu = query_start_loc_cpu
-            attention_metadata_gid.seq_lens_cpu = seq_lens_cpu
+            attention_metadata_gid.query_start_loc_cpu = query_start_loc_view
+            attention_metadata_gid.seq_lens_cpu = seq_lens_view
             return attention_metadata_gid
 
         attention_metadata: AttentionMetadata | dict[str, AttentionMetadata]

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -548,6 +548,12 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         self.mrope_positions_cpu = np.zeros((3, self.max_num_tokens),
                                             dtype=np.int64)
 
+        # Monolithic stack packing for small 1D metadata buffers.
+        # This buffer grows dynamically to accommodate metadata and block tables.
+        # We start with a larger capacity to avoid resizing jitter in early steps.
+        self.device_buffer = common_utils.DeviceBuffer(initial_capacity=1024 *
+                                                       1024)
+
     def load_model(self):
         with set_current_vllm_config(self.vllm_config):
             self.model_fn, self.compute_logits_fn, self.pooler_fn, self.combine_hidden_states_fn, multimodal_fns, self.state, self.lora_manager, self.model = get_model(
@@ -1499,13 +1505,23 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                 (self.max_num_reqs, self.max_num_blocks_per_req),
                 key=f"block_tables_gid_{kv_cache_gid}")
 
+            # Zero out the view once for correct padding
+            block_tables_view.fill(0)
+
+            cpu_tensor = self.input_batch.block_table[
+                kv_cache_gid].get_cpu_tensor()
             for dp_rank in range(dp_size):
-                req_offset = dp_rank * max_num_reqs_per_dp_rank
                 _num_reqs = num_req_per_dp_rank[dp_rank]
-                block_tables_view[
-                    req_offset:req_offset + _num_reqs, :self.
-                    max_num_blocks_per_req] = self.input_batch.block_table[
-                        kv_cache_gid].get_cpu_tensor()[req_indices_dp[dp_rank]]
+                if _num_reqs == 0:
+                    continue
+
+                req_offset = dp_rank * max_num_reqs_per_dp_rank
+                # Use np.take with out= to avoid intermediate copies from advanced indexing
+                np.take(cpu_tensor,
+                        req_indices_dp[dp_rank],
+                        axis=0,
+                        out=block_tables_view[req_offset:req_offset +
+                                              _num_reqs])
 
         if len(self.kv_cache_config.kv_cache_groups) <= 1:
             no_kv_cache = len(self.kv_cache_config.kv_cache_groups) == 0
@@ -1755,10 +1771,10 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                 (self.max_num_reqs, self.max_num_blocks_per_req),
                 key=f"block_tables_gid_{kv_cache_gid}")
 
-            block_tables_view[:num_reqs] = (
-                self.input_batch.block_table[kv_cache_gid].get_cpu_tensor()
-                [:num_reqs])
-            block_tables_view[num_reqs:] = 0
+            cpu_tensor = self.input_batch.block_table[
+                kv_cache_gid].get_cpu_tensor()
+            np.copyto(block_tables_view[:num_reqs], cpu_tensor[:num_reqs])
+            block_tables_view[num_reqs:].fill(0)
 
         if len(self.kv_cache_config.kv_cache_groups) <= 1:
             # Pooling model will not using kv cache

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -550,9 +550,8 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
 
         # Monolithic stack packing for small 1D metadata buffers.
         # This buffer grows dynamically to accommodate metadata and block tables.
-        # We start with a larger capacity to avoid resizing jitter in early steps.
-        self.device_buffer = common_utils.DeviceBuffer(initial_capacity=1024 *
-                                                       1024)
+        # We start with a safe default and refine it in initialize_kv_cache.
+        self.device_buffer = common_utils.DeviceBuffer(initial_capacity=1024)
 
     def load_model(self):
         with set_current_vllm_config(self.vllm_config):
@@ -626,6 +625,31 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         self.kv_cache_config = kv_cache_config
         self.use_hybrid_kvcache = len(kv_cache_config.kv_cache_groups) > 1
         self.kv_cache_manager.initialize_kv_cache(kv_cache_config)
+
+        # Monolithic stack packing for small 1D metadata buffers.
+        # This buffer grows dynamically to accommodate metadata and block tables.
+        # We re-initialize with a precise capacity now that kv_cache_config is known.
+        num_kv_groups = len(kv_cache_config.kv_cache_groups)
+        sampling_params_size = 3 * self.max_num_reqs
+        input_ids_size = self.max_num_tokens
+        # Positions can be 3D for M-RoPE models (e.g. Qwen2-VL)
+        positions_size = (3 if self.uses_mrope else 1) * self.max_num_tokens
+        query_start_loc_size = self.max_num_reqs + self.dp_size
+        seq_lens_size = self.max_num_reqs
+        logits_indices_size = self.max_num_reqs
+        request_distribution_size = 3 * self.dp_size
+        # Block tables for each KV cache group.
+        block_tables_size = num_kv_groups * self.max_num_reqs * self.max_num_blocks_per_req
+        cache_collision_dummy_size = 2 * self.dp_size
+
+        initial_capacity = (sampling_params_size + input_ids_size +
+                            positions_size + query_start_loc_size +
+                            seq_lens_size + logits_indices_size +
+                            request_distribution_size + block_tables_size +
+                            cache_collision_dummy_size + 1024)
+        self.device_buffer = common_utils.DeviceBuffer(
+            initial_capacity=initial_capacity)
+
         if has_kv_transfer_group():
             get_kv_transfer_group().register_runner(self)
 

--- a/tpu_inference/utils.py
+++ b/tpu_inference/utils.py
@@ -1,9 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
+import functools
 import time
 from collections import defaultdict
 from collections.abc import Sequence
 from functools import wraps
-from typing import Any, Callable, List, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import jax
 import jax.numpy as jnp
@@ -409,3 +410,82 @@ def time_function(func):
         return result
 
     return wrapper
+
+
+class DeviceBuffer:
+    """
+    A utility to pack 1D numpy arrays into a monolithic buffer.
+    Supports appending data or getting views, then tagging the accumulated
+    data with a key. The internal buffer grows dynamically as needed.
+    """
+
+    def __init__(self, initial_capacity: int = 1024):
+        self.buffer = np.zeros(initial_capacity, dtype=np.int32)
+        self._offset = 0
+        self._last_offset = 0
+        self._metadata = []
+
+    def _ensure_capacity(self, size: int):
+        """Ensure the internal buffer has enough space for 'size' more elements."""
+        if self._offset + size > self.buffer.size:
+            new_capacity = max(self.buffer.size * 2,
+                               self._offset + size + 1024)
+            new_buffer = np.zeros(new_capacity, dtype=np.int32)
+            new_buffer[:self._offset] = self.buffer[:self._offset]
+            self.buffer = new_buffer
+
+    def append(self, array: np.ndarray, key: Optional[str] = None):
+        """Append data to the buffer and advance offset."""
+        size = array.size
+        self._ensure_capacity(size)
+        self.buffer[self._offset:self._offset + size] = array.ravel()
+        self._offset += size
+        if key:
+            self.set_key(key)
+
+    def get_view(self,
+                 shape: Union[int, Tuple[int, ...]],
+                 key: Optional[str] = None) -> np.ndarray:
+        """Reserve space in the buffer and return a reshaped view for direct writing."""
+        if isinstance(shape, (int, np.integer)):
+            size = int(shape)
+            shape = (size, )
+        else:
+            size = int(np.prod(shape))
+
+        self._ensure_capacity(size)
+        view = self.buffer[self._offset:self._offset + size].reshape(shape)
+        self._offset += size
+        if key:
+            self.set_key(key)
+        return view
+
+    def set_key(self, key: str):
+        """Tag all data accumulated since the last set_key() call."""
+        size = self._offset - self._last_offset
+        self._metadata.append((key, size))
+        self._last_offset = self._offset
+
+    def build(self) -> Tuple[np.ndarray, Tuple[Tuple[str, int], ...]]:
+        """Return the active portion of the buffer and its layout metadata."""
+        return self.buffer[:self._offset], tuple(self._metadata)
+
+    def reset(self):
+        """Reset offsets and metadata for reuse. Keeps the allocated buffer."""
+        self._offset = 0
+        self._last_offset = 0
+        self._metadata = []
+
+    @staticmethod
+    @functools.partial(jax.jit, static_argnums=(1, ))
+    def unpack_arrays(
+            blob: jax.Array, metadata: Tuple[Tuple[str, int],
+                                             ...]) -> Dict[str, jax.Array]:
+        """
+        Unpack a 1D blob into a dictionary of arrays based on provided metadata.
+        Uses JIT and jnp.split to minimize dispatch overhead.
+        """
+        sizes = [size for _, size in metadata]
+        indices = tuple(np.cumsum(sizes)[:-1])
+        parts = jnp.split(blob, indices)
+        return {metadata[i][0]: parts[i] for i in range(len(metadata))}

--- a/tpu_inference/utils.py
+++ b/tpu_inference/utils.py
@@ -428,9 +428,6 @@ class DeviceBuffer:
     def _ensure_capacity(self, size: int):
         """Ensure the internal buffer has enough space for 'size' more elements."""
         if self._offset + size > self.buffer.size:
-            logger.error(
-                "DeviceBuffer: Buffer overflow. Current size: %d, "
-                "Requested size: %d", self.buffer.size, self._offset + size)
             new_capacity = max(self.buffer.size * 2,
                                self._offset + size + 1024)
             new_buffer = np.zeros(new_capacity, dtype=np.int32)

--- a/tpu_inference/utils.py
+++ b/tpu_inference/utils.py
@@ -3,6 +3,7 @@ import functools
 import time
 from collections import defaultdict
 from collections.abc import Sequence
+from dataclasses import dataclass
 from functools import wraps
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
@@ -412,6 +413,13 @@ def time_function(func):
     return wrapper
 
 
+@dataclass(frozen=True)
+class DeviceBufferMetadata:
+    """Metadata for the layout of a DeviceBuffer."""
+    keys: Tuple[str, ...]
+    sizes: Tuple[int, ...]
+
+
 class DeviceBuffer:
     """
     A utility to pack 1D numpy arrays into a monolithic buffer.
@@ -423,7 +431,8 @@ class DeviceBuffer:
         self.buffer = np.zeros(initial_capacity, dtype=np.int32)
         self._offset = 0
         self._last_offset = 0
-        self._metadata = []
+        self._keys: List[str] = []
+        self._sizes: List[int] = []
 
     def _ensure_capacity(self, size: int):
         """Ensure the internal buffer has enough space for 'size' more elements."""
@@ -463,29 +472,30 @@ class DeviceBuffer:
     def set_key(self, key: str):
         """Tag all data accumulated since the last set_key() call."""
         size = self._offset - self._last_offset
-        self._metadata.append((key, size))
+        self._keys.append(key)
+        self._sizes.append(size)
         self._last_offset = self._offset
 
-    def build(self) -> Tuple[np.ndarray, Tuple[Tuple[str, int], ...]]:
+    def build(self) -> Tuple[np.ndarray, DeviceBufferMetadata]:
         """Return the active portion of the buffer and its layout metadata."""
-        return self.buffer[:self._offset], tuple(self._metadata)
+        return self.buffer[:self._offset], DeviceBufferMetadata(
+            keys=tuple(self._keys), sizes=tuple(self._sizes))
 
     def reset(self):
         """Reset offsets and metadata for reuse. Keeps the allocated buffer."""
         self._offset = 0
         self._last_offset = 0
-        self._metadata = []
+        self._keys = []
+        self._sizes = []
 
     @staticmethod
     @functools.partial(jax.jit, static_argnums=(1, ))
-    def unpack_arrays(
-            blob: jax.Array, metadata: Tuple[Tuple[str, int],
-                                             ...]) -> Dict[str, jax.Array]:
+    def unpack_arrays(blob: jax.Array,
+                      metadata: DeviceBufferMetadata) -> Dict[str, jax.Array]:
         """
         Unpack a 1D blob into a dictionary of arrays based on provided metadata.
         Uses JIT and jnp.split to minimize dispatch overhead.
         """
-        sizes = [size for _, size in metadata]
-        indices = tuple(np.cumsum(sizes)[:-1])
+        indices = tuple(np.cumsum(metadata.sizes)[:-1])
         parts = jnp.split(blob, indices)
-        return {metadata[i][0]: parts[i] for i in range(len(metadata))}
+        return {key: parts[i] for i, key in enumerate(metadata.keys)}

--- a/tpu_inference/utils.py
+++ b/tpu_inference/utils.py
@@ -428,6 +428,9 @@ class DeviceBuffer:
     def _ensure_capacity(self, size: int):
         """Ensure the internal buffer has enough space for 'size' more elements."""
         if self._offset + size > self.buffer.size:
+            logger.error(
+                "DeviceBuffer: Buffer overflow. Current size: %d, "
+                "Requested size: %d", self.buffer.size, self._offset + size)
             new_capacity = max(self.buffer.size * 2,
                                self._offset + size + 1024)
             new_buffer = np.zeros(new_capacity, dtype=np.int32)


### PR DESCRIPTION
# Description

We had multiple arrays of different metadata being used in `tpu_runner.py` and we called `device_array` on them, which under the hood it creates many `device_put` requests. This wastes CPU time with `device_put` overhead, so we can optimize this if we can do it all a single array and `device_put` call. This was particularly impactful when DP is enabled.

Added a `DeviceBuffer` class to keep track of the single buffer and pointers to the different metadata slices.

Updated `build_block_table` to directly write to buffer, along with many other metadata. This array is very large (1M+ elements) so we have to avoid intermediate arrays when handling this array.

There are a few more changes that need to be made:
- update get_spec_decode_metadata to use device buffer directly

# Tests

## Profiling

```
SKIP_JAX_PRECOMPILE=1 MODEL_IMPL_TYPE=vllm python3 examples/tpu_profiling.py --model=Qwen/Qwen2.5-1.5B --input-len=16 --output-len=5 --batch-size=8192 --profile-result-dir=gs://piv-test/tpu-profile/apr13/1/ --tensor_parallel_size=1 --data_parallel_size=1 --load-format dummy --max-num-seqs 512
```

### Before

DP=1: https://xprof.corp.google.com/trace_viewer/piv-13989742128299219625?view_start=25872.550&view_end=25876.404 

DP=8: https://xprof.corp.google.com/trace_viewer/piv-318240194002393446?view_start=25035.871&view_end=26739.412 

### After:

DP=1 https://xprof.corp.google.com/trace_viewer/piv-6312356893012922929?view_start=7967.095&view_end=8018.642

DP=8 https://xprof.corp.google.com/trace_viewer/piv-5549812232919626214?view_start=24556.367&view_end=24585.245

### Conclusion

`_prepare_inputs_dp` went from ~22ms to ~12ms
`_prepare_inputs_non_dp` small difference since it is already short with high variance ~1-3ms

## Testing

```
VLLM_XLA_CHECK_RECOMPILATION=1 pytest tests/e2e/test_data_parallel.py
VLLM_XLA_CHECK_RECOMPILATION=1 pytest tests/e2e/test_pipeline_parallel.py
VLLM_XLA_CHECK_RECOMPILATION=1 pytest tests/e2e/test_hybrid_kvcache.py
```

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
