### PR TITLE
Only swap active tokens in InputBatch.swap_states() method

### DIFF
--- a/tests/runner/test_input_batch.py
+++ b/tests/runner/test_input_batch.py
@@ -210,6 +210,42 @@ def test_swap_states(input_batch: InputBatch):
                                   req1_tokens_before)
 
 
+def test_swap_states_only_swaps_active_tokens(input_batch: InputBatch):
+    """Tests that swap_states only swaps up to max_active_token_count columns,
+    leaving data beyond that range untouched (optimization correctness)."""
+    # Create requests with very different lengths.
+    req_short = create_dummy_request("req-short", prompt_len=5, output_len=1)
+    req_long = create_dummy_request("req-long", prompt_len=50, output_len=10)
+
+    input_batch.add_request(req_short)
+    input_batch.add_request(req_long)
+
+    # max_active_token_count = max(6, 60) = 60
+    max_active = max(
+        int(input_batch.num_tokens[0]),
+        int(input_batch.num_tokens[1]),
+    )
+    assert max_active == 60
+
+    # Capture only the active region before swap.
+    short_active_before = input_batch.token_ids_cpu[0, :max_active].copy()
+    long_active_before = input_batch.token_ids_cpu[1, :max_active].copy()
+
+    input_batch.swap_states(0, 1)
+
+    # Active region should be swapped.
+    np.testing.assert_array_equal(input_batch.token_ids_cpu[0, :max_active],
+                                  long_active_before)
+    np.testing.assert_array_equal(input_batch.token_ids_cpu[1, :max_active],
+                                  short_active_before)
+
+    # num_tokens should also be swapped correctly.
+    assert input_batch.num_tokens[0] == 60
+    assert input_batch.num_tokens[1] == 6
+    assert input_batch.num_tokens_no_spec[0] == 60
+    assert input_batch.num_tokens_no_spec[1] == 6
+
+
 def test_all_greedy_property(input_batch: InputBatch):
     """Tests the `all_greedy` property."""
     # Initially true

--- a/tpu_inference/runner/input_batch.py
+++ b/tpu_inference/runner/input_batch.py
@@ -315,6 +315,8 @@ class InputBatch:
     def swap_states(self, i1: int, i2: int) -> None:
         old_id_i1 = self._req_ids[i1]
         old_id_i2 = self._req_ids[i2]
+        max_active_token_count = max(int(self.num_tokens[i1]),
+                                     int(self.num_tokens[i2]))
         self._req_ids[i1], self._req_ids[i2] =\
             self._req_ids[i2], self._req_ids[i1] # noqa
         self.req_output_token_ids[i1], self.req_output_token_ids[i2] =\
@@ -337,14 +339,8 @@ class InputBatch:
         self.top_k_cpu[i1], self.top_k_cpu[i2] =\
             self.top_k_cpu[i2], self.top_k_cpu[i1]
 
-        # NOTE: the following is unsafe
-        # self.token_ids_cpu[i1, ...], self.token_ids_cpu[i2, ...], =\
-        #     self.token_ids_cpu[i2, ...], self.token_ids_cpu[i1, ...]
-        # instead, we need to temporiarily copy the data for one of the indices
-        # TODO(lucas): optimize this by only copying valid indices
-        tmp = self.token_ids_cpu[i1, ...].copy()
-        self.token_ids_cpu[i1, ...] = self.token_ids_cpu[i2, ...]
-        self.token_ids_cpu[i2, ...] = tmp
+        self.token_ids_cpu[[i1, i2], :max_active_token_count] = \
+            self.token_ids_cpu[[i2, i1], :max_active_token_count]
 
         swap_dict_values(self.generators, i1, i2)
         swap_dict_values(self.min_tokens, i1, i2)


### PR DESCRIPTION
# Description

This PR improves the efficiency of the `swap_states` method in the `InputBatch` class by swapping only the active tokens instead of the entire token array. This mirrors the vLLM upstream implementation. 


# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
