### PR TITLE
Propagate JIT configuration env vars to Ray workers

### DIFF
--- a/tpu_inference/platforms/tpu_platform.py
+++ b/tpu_inference/platforms/tpu_platform.py
@@ -56,6 +56,8 @@ class TpuPlatform(Platform):
         "NEW_MODEL_DESIGN",
         "MODEL_IMPL_TYPE",
         "VLLM_DISABLE_SHARED_EXPERTS_STREAM",
+        "JITTED_MM_MODULE_KEYS",
+        "REGISTER_MM_MODULE_CUSTOM_PYTREE_CLASSES",
     ]
 
     @classmethod


### PR DESCRIPTION
# Description

When attempting to enable JIT compilation for the Qwen3-VL vision encoder using the ```JITTED_MM_MODULE_KEYS``` environment variable, the configuration was failing to take effect when running via vllm serve.

Investigation revealed that vllm serve uses `RayDistributedExecutor` (even for tensor-parallel-size=1 on TPU) to isolate the model execution process. vLLM's Ray integration explicitly filters environment variables passed from the driver to workers using an allowlist. Because JITTED_MM_MODULE_KEYS and REGISTER_MM_MODULE_CUSTOM_PYTREE_CLASSES were not in this allowlist, they were silently dropped, preventing the patch_mm_model logic from triggering in the worker process.

Fix
Added JITTED_MM_MODULE_KEYS and REGISTER_MM_MODULE_CUSTOM_PYTREE_CLASSES to additional_env_vars in TpuPlatform. This ensures they are included in the environment variables copied to Ray workers during initialization, allowing the JIT patching logic to execute correctly.


# Tests

Manual Verification
Verified that setting JITTED_MM_MODULE_KEYS="model.visual" now correctly triggers the patch_mm_model logic and logs are visible in the worker context.
Confirmed that the server starts up successfully without regressions from the cleanup.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
