### PR TITLE
Skip expensive batch reordering when the entire batch consists of decode tokens

### DIFF
--- a/tests/runner/test_persistent_batch_manager.py
+++ b/tests/runner/test_persistent_batch_manager.py
@@ -13,12 +13,117 @@
 # limitations under the License.
 
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import numpy as np
 
 from tpu_inference.runner.persistent_batch_manager import \
     PersistentBatchManager
+
+
+class MockInputBatch:
+    """Lightweight mock InputBatch that tracks the state needed by
+    _reorder_batch: req_ids, request_distribution, and swap_states."""
+
+    def __init__(self, req_ids: list[str]):
+        self._req_ids = list(req_ids)
+        self.req_id_to_index = {rid: i for i, rid in enumerate(req_ids)}
+        self.request_distribution = [0, 0, 0]
+
+    @property
+    def num_reqs(self):
+        return len(self._req_ids)
+
+    @property
+    def req_ids(self):
+        return self._req_ids
+
+    def swap_states(self, i: int, j: int):
+        self._req_ids[i], self._req_ids[j] = (self._req_ids[j],
+                                              self._req_ids[i])
+        id_i, id_j = self._req_ids[i], self._req_ids[j]
+        self.req_id_to_index[id_i] = i
+        self.req_id_to_index[id_j] = j
+
+
+def _create_manager(req_ids, num_scheduled_tokens_map):
+    """Helper to create a PersistentBatchManager with a MockInputBatch
+    and a mock scheduler_output.
+
+    Args:
+        req_ids: list of request id strings, in the order they appear
+            in the batch.
+        num_scheduled_tokens_map: dict mapping req_id -> num_scheduled_tokens.
+
+    Returns:
+        (manager, scheduler_output) tuple.
+    """
+    input_batch = MockInputBatch(req_ids)
+
+    manager = PersistentBatchManager(
+        requests={},
+        input_batch=input_batch,
+        encoder_cache={},
+        uses_mrope=False,
+        model_config=MagicMock(),
+        is_last_rank=True,
+    )
+
+    scheduler_output = MagicMock()
+    scheduler_output.num_scheduled_tokens = num_scheduled_tokens_map
+    scheduler_output.total_num_scheduled_tokens = sum(
+        num_scheduled_tokens_map.values())
+
+    return manager, scheduler_output
+
+
+class TestReorderBatch(unittest.TestCase):
+    """Tests for the _reorder_batch method."""
+
+    def test_empty_batch(self):
+        """An empty batch should return 0 swaps and not modify anything."""
+        manager, sched_out = _create_manager([], {})
+
+        swap_cnt = manager._reorder_batch(sched_out)
+
+        self.assertEqual(swap_cnt, 0)
+
+    def test_all_decode_fast_path(self):
+        """When all requests are decode (1 token each), the fast path should
+        skip the two-pointer loop, return 0 swaps, and set distribution to
+        all-decode."""
+        req_ids = ["r0", "r1", "r2", "r3"]
+        num_scheduled = {r: 1 for r in req_ids}
+        manager, sched_out = _create_manager(req_ids, num_scheduled)
+
+        with patch.object(manager.input_batch,
+                          'swap_states',
+                          wraps=manager.input_batch.swap_states) as mock_swap:
+            swap_cnt = manager._reorder_batch(sched_out)
+
+            self.assertEqual(swap_cnt, 0)
+            self.assertEqual(manager.input_batch.request_distribution,
+                             [4, 4, 4])
+            mock_swap.assert_not_called()
+
+    def test_mixed_batch_needs_swap(self):
+        """Batch is [prefill, decode, decode, prefill] — needs reordering
+        to move decodes to front."""
+        req_ids = ["r0", "r1", "r2", "r3"]
+        num_scheduled = {"r0": 10, "r1": 1, "r2": 1, "r3": 20}
+        manager, sched_out = _create_manager(req_ids, num_scheduled)
+
+        swap_cnt = manager._reorder_batch(sched_out)
+
+        self.assertEqual(swap_cnt, 1)
+        self.assertEqual(manager.input_batch.request_distribution, [2, 2, 4])
+        result_ids = manager.input_batch.req_ids
+        # First 2 should be decode requests
+        for rid in result_ids[:2]:
+            self.assertEqual(num_scheduled[rid], 1)
+        # Last 2 should be prefill requests
+        for rid in result_ids[2:]:
+            self.assertGreater(num_scheduled[rid], 1)
 
 
 class TestPersistentBatchManager(unittest.TestCase):
@@ -48,6 +153,8 @@ class TestPersistentBatchManager(unittest.TestCase):
         input_batch.num_tokens = np.array([2], dtype=np.int32)
         input_batch.num_tokens_no_spec = np.array([2], dtype=np.int32)
         input_batch.num_reqs = 1
+        input_batch.req_ids = [req_id]
+        input_batch.request_distribution = [0, 0, 0]
 
         encoder_cache = MagicMock()
         model_config = MagicMock()
@@ -69,6 +176,8 @@ class TestPersistentBatchManager(unittest.TestCase):
         req_data.num_output_tokens = [len(initial_output_tokens) + 1]
         scheduler_output.scheduled_cached_reqs = req_data
         scheduler_output.scheduled_spec_decode_tokens = {}
+        scheduler_output.num_scheduled_tokens = {req_id: 1}
+        scheduler_output.total_num_scheduled_tokens = 1
 
         manager.update_states(scheduler_output, None)
 

--- a/tpu_inference/runner/persistent_batch_manager.py
+++ b/tpu_inference/runner/persistent_batch_manager.py
@@ -49,6 +49,28 @@ class PersistentBatchManager:
         swap_cnt = 0
         if num_reqs <= 0:
             return swap_cnt
+
+        prev_distribution = list(self.input_batch.request_distribution)
+
+        # If total_num_scheduled_tokens == num_reqs, every request
+        # is scheduled for exactly 1 token (all decode). No reordering needed.
+        if scheduler_output.total_num_scheduled_tokens == num_reqs:
+            num_decode = num_reqs
+            self.input_batch.request_distribution = [
+                num_decode, num_decode, num_reqs
+            ]
+            return swap_cnt
+
+        # Log the pre-reorder request layout.
+        pre_order = [(self.input_batch.req_ids[idx],
+                      scheduler_output.num_scheduled_tokens[
+                          self.input_batch.req_ids[idx]])
+                     for idx in range(num_reqs)]
+        logger.info(
+            "Batch reorder: num_reqs=%d, prev_distribution=%s, "
+            "pre_reorder layout (req_id, num_scheduled_tokens): %s", num_reqs,
+            prev_distribution, pre_order)
+
         # Use two-pointer approach to reorder the decode requests to front.
         i, j = 0, num_reqs - 1
         while i < j:
@@ -74,6 +96,13 @@ class PersistentBatchManager:
         self.input_batch.request_distribution = [
             num_decode, num_decode, num_reqs
         ]
+
+        if swap_cnt > 0 or prev_distribution != self.input_batch.request_distribution:
+            logger.info(
+                "Batch reordered: swaps=%d, distribution %s -> %s "
+                "(num_decode=%d, num_prefill=%d)", swap_cnt, prev_distribution,
+                self.input_batch.request_distribution, num_decode,
+                num_reqs - num_decode)
 
         return swap_cnt
 

--- a/tpu_inference/runner/persistent_batch_manager.py
+++ b/tpu_inference/runner/persistent_batch_manager.py
@@ -49,9 +49,6 @@ class PersistentBatchManager:
         swap_cnt = 0
         if num_reqs <= 0:
             return swap_cnt
-
-        prev_distribution = list(self.input_batch.request_distribution)
-
         # If total_num_scheduled_tokens == num_reqs, every request
         # is scheduled for exactly 1 token (all decode). No reordering needed.
         if scheduler_output.total_num_scheduled_tokens == num_reqs:
@@ -60,17 +57,6 @@ class PersistentBatchManager:
                 num_decode, num_decode, num_reqs
             ]
             return swap_cnt
-
-        # Log the pre-reorder request layout.
-        pre_order = [(self.input_batch.req_ids[idx],
-                      scheduler_output.num_scheduled_tokens[
-                          self.input_batch.req_ids[idx]])
-                     for idx in range(num_reqs)]
-        logger.info(
-            "Batch reorder: num_reqs=%d, prev_distribution=%s, "
-            "pre_reorder layout (req_id, num_scheduled_tokens): %s", num_reqs,
-            prev_distribution, pre_order)
-
         # Use two-pointer approach to reorder the decode requests to front.
         i, j = 0, num_reqs - 1
         while i < j:
@@ -96,13 +82,6 @@ class PersistentBatchManager:
         self.input_batch.request_distribution = [
             num_decode, num_decode, num_reqs
         ]
-
-        if swap_cnt > 0 or prev_distribution != self.input_batch.request_distribution:
-            logger.info(
-                "Batch reordered: swaps=%d, distribution %s -> %s "
-                "(num_decode=%d, num_prefill=%d)", swap_cnt, prev_distribution,
-                self.input_batch.request_distribution, num_decode,
-                num_reqs - num_decode)
 
         return swap_cnt
 


### PR DESCRIPTION
# Description

This pull request optimizes `_reorder_batch` in `PersistentBatchManager` by skipping unnecessary reordering logic when the entire batch consists of decode tokens, which happens the majority of the time in decode-heavy offline inference. 

This `_reorder_batch` function is very expensive, taking 5m for 8k requests. 
 
Before: 

<img width="1249" height="493" alt="Screenshot 2026-04-14 at 1 01 33 PM" src="https://github.com/user-attachments/assets/8825f0c0-060f-4f10-92ee-34de1786c006" />

After: 

<img width="979" height="438" alt="Screenshot 2026-04-14 at 1 01 38 PM" src="https://github.com/user-attachments/assets/8fc959ea-6de7-4cb6-94c4-0dae097ef7ab" />


# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
