### PR TITLE
Optimizing ragged_gated_delta_rule by simplifying scattering

### DIFF
--- a/tpu_inference/layers/common/gdn_attention.py
+++ b/tpu_inference/layers/common/gdn_attention.py
@@ -76,9 +76,11 @@ def run_jax_gdn_attention_local(
         mixed_qkv: Combined QKV tensor of shape `(num_tokens, dim)`.
         b: B tensor of shape `(num_tokens, n_v)`.
         a: A tensor of shape `(num_tokens, n_v)`.
-        conv_state: Combined convolutional state of shape `(max_reqs, kernel_size
-          - 1, dim)`.
-        recurrent_state: Recurrent state of shape `(max_reqs, n_v, d_k, d_v)`.
+        conv_state: Combined convolutional state of shape `(num_blocks,
+          kernel_size - 1, dim)`. `num_blocks` is always equal or larger than
+          `max_seqs + 1`. The first block is a null_block and only used for
+          padded / invalid tokens.
+        recurrent_state: Recurrent state of shape `(num_blocks, n_v, d_k, d_v)`.
         conv_weight: Combined convolutional weight of shape `(dim, 1,
           kernel_size)`.
         conv_bias: Optional combined convolutional bias of shape `(dim,)`.
@@ -88,7 +90,8 @@ def run_jax_gdn_attention_local(
           each sequence.
         state_indices: Tensor of shape `(max_reqs,)` mapping request index to
           state index.
-        distribution: Tensor of shape `(3,)` int32 — `(decode_end, prefill_end, mixed_end)`.
+        distribution: Tensor of shape `(3,)` int32 — `(decode_end, prefill_end,
+          mixed_end)`.
         n_kq: Number of key/query heads.
         n_v: Number of value heads.
         d_k: Dimension of key.
@@ -178,9 +181,11 @@ def run_jax_gdn_attention(
         j_mixed_qkv: Input tensor of shape `(num_tokens, dim)`.
         j_b: Input tensor of shape `(num_tokens, n_v)`.
         j_a: Input tensor of shape `(num_tokens, n_v)`.
-        conv_state: Convolutional state tensor of shape `(max_reqs, kernel_size -
-          1, dim)`.
-        recurrent_state: Recurrent state tensor of shape `(max_reqs, n_v, d_k,
+        conv_state: Convolutional state tensor of shape `(num_blocks, kernel_size
+          - 1, dim)`. `num_blocks` is always equal or larger than `max_seqs +
+          1`. The first block is a null_block and only used for padded / invalid
+          tokens.
+        recurrent_state: Recurrent state tensor of shape `(num_blocks, n_v, d_k,
           d_v)`.
         j_conv_weight: Convolutional weight tensor of shape `(dim, 1,
           kernel_size)`.
@@ -191,7 +196,8 @@ def run_jax_gdn_attention(
           state index.
         query_start_loc: Tensor of shape `(num_seqs + 1,)` with start locations of
           each sequence.
-        distribution: Tensor of shape `(3,)` int32 — `(decode_end, prefill_end, mixed_end)`.
+        distribution: Tensor of shape `(3,)` int32 — `(decode_end, prefill_end,
+          mixed_end)`.
         n_kq: Number of key/query heads.
         n_v: Number of value heads.
         d_k: Dimension of key.
@@ -203,11 +209,10 @@ def run_jax_gdn_attention(
     Returns:
         A tuple containing:
         - A tuple of (new_conv_state, new_recurrent_state).
-          - new_conv_state: `(max_reqs, kernel_size - 1, dim)`
-          - new_recurrent_state: `(max_reqs, n_v, d_k, d_v)`
+          - new_conv_state: `(num_blocks, kernel_size - 1, dim)`
+          - new_recurrent_state: `(num_blocks, n_v, d_k, d_v)`
         - The output tensor of shape `(num_tokens, n_v * d_v)`.
     """
-
     in_specs = (
         P(None, ShardingAxisName.ATTN_HEAD),  # j_mixed_qkv
         P(None, ShardingAxisName.ATTN_HEAD),  # j_b

--- a/tpu_inference/layers/common/ragged_conv1d_jax.py
+++ b/tpu_inference/layers/common/ragged_conv1d_jax.py
@@ -30,8 +30,9 @@ def ragged_conv1d(
 
     Args:
       x: Input tensor of shape `(num_tokens, dim)`.
-      conv_state: Combined convolutional state of shape `(max_reqs, kernel_size -
-        1, dim)`.
+      conv_state: Combined convolutional state of shape `(num_blocks, kernel_size
+        - 1, dim)`. `num_blocks` is always equal or larger than `max_seqs + 1`.
+        The first block is a null_block and only used for padded / invalid tokens.
       conv_weight: Convolutional weight of shape `(dim, 1, kernel_size)`.
       conv_bias: Optional convolutional bias of shape `(dim,)`.
       query_start_loc: Tensor of shape `(num_seqs + 1,)` containing the start
@@ -40,11 +41,13 @@ def ragged_conv1d(
       state_indices: Tensor of shape `(max_reqs,)` mapping request index to state
         index.
       kernel_size: The size of the convolution kernel.
+      distribution: Distribution tensor containing number of valid sequences at
+        index 2.
 
     Returns:
       A tuple containing:
       - output: The output tensor of shape `(num_tokens, dim)`.
-      - updated_conv_state: The updated convolutional state of shape `(max_reqs,
+      - updated_conv_state: The updated convolutional state of shape `(num_blocks,
         kernel_size - 1, dim)`.
     """
     num_tokens = x.shape[0]
@@ -63,7 +66,7 @@ def ragged_conv1d(
     req_indices = jnp.clip(req_indices, 0, max_reqs - 1)
     local_indices = token_idx - effective_query_start_loc[req_indices]
 
-    lengths = (effective_query_start_loc[1:] - effective_query_start_loc[:-1])
+    lengths = effective_query_start_loc[1:] - effective_query_start_loc[:-1]
 
     # 1. Compute Convolution
     out = jnp.zeros_like(x)

--- a/tpu_inference/layers/common/ragged_gated_delta_rule_chunked.py
+++ b/tpu_inference/layers/common/ragged_gated_delta_rule_chunked.py
@@ -91,7 +91,8 @@ def pack_inputs_single_stream(
       g: Gate tensor.
       beta: Beta tensor.
       query_start_loc: Start locations of each sequence in original stream.
-      distribution: Tensor of shape `(3,)` int32 — `(decode_end, prefill_end, mixed_end)`.
+      distribution: Distribution tensor containing number of valid sequences at
+        index 2.
       chunk_size: Chunk size for padding.
       compute_dtype: Dtype for computation (Q, K, V, beta).
 
@@ -220,9 +221,12 @@ def ragged_gated_delta_rule_mixed_prefill(
       A_log: A_log tensor.
       dt_bias: dt_bias tensor.
       query_start_loc: Start locations of sequences in original stream.
-      recurrent_state: Recurrent state tensor.
+      recurrent_state: Recurrent state tensor of shape `(num_blocks, n_v, d_k,
+        d_v)`. `num_blocks` is always equal or larger than `max_seqs + 1`. The
+        first block is a null_block and only used for padded / invalid tokens.
       state_indices: Indices mapping sequences to recurrent state slots.
-      distribution: Tensor of shape `(3,)` int32 — `(decode_end, prefill_end, mixed_end)`.
+      distribution: Distribution tensor containing number of valid sequences at
+        index 2.
       chunk_size: Chunk size for padding and processing.
       use_qk_norm_in_gdn: Whether to use QK normalization.
       compute_dtype: Dtype for computation.
@@ -231,7 +235,8 @@ def ragged_gated_delta_rule_mixed_prefill(
 
     Returns:
       A tuple containing:
-        - updated_recurrent_state: Updated recurrent state tensor.
+        - updated_recurrent_state: Updated recurrent state tensor of shape
+          `(num_blocks, n_v, d_k, d_v)`.
         - output: Output tensor.
     """
     initial_dtype = query.dtype
@@ -433,8 +438,17 @@ def ragged_gated_delta_rule_mixed_prefill(
     # Update recurrent state
     last_chunk_indices = (new_query_start_loc[1:] // chunk_size) - 1
     final_states = h_chunks[last_chunk_indices]
+
+    num_seqs = last_chunk_indices.shape[0]
+    valid_seq_mask = jnp.arange(num_seqs) < distribution[2]
+    current_states = recurrent_state[state_indices]
+    states_to_set = jnp.where(
+        valid_seq_mask[:, None, None, None],
+        final_states.astype(recurrent_state.dtype),
+        current_states,
+    )
     updated_recurrent_state = recurrent_state.at[state_indices].set(
-        final_states.astype(recurrent_state.dtype))
+        states_to_set)
 
     return updated_recurrent_state, output
 
@@ -498,25 +512,28 @@ def ragged_gated_delta_rule_decode_only(
       value: Value tensor.
       b_reshaped: Reshaped b tensor (for beta).
       a_reshaped: Reshaped a tensor (for g).
-      recurrent_state: Recurrent state tensor.
+      recurrent_state: Recurrent state tensor of shape `(num_blocks, n_v, d_k,
+        d_v)`. `num_blocks` is always equal or larger than `max_seqs + 1`. The
+        first block is a null_block and only used for padded / invalid tokens.
       A_log: A_log tensor.
       dt_bias: dt_bias tensor.
       query_start_loc: Start locations of sequences.
       state_indices: Indices mapping sequences to recurrent state slots.
-      distribution: Distribution tensor containing number of valid sequences at index 2.
+      distribution: Distribution tensor containing number of valid sequences at
+        index 2.
       use_qk_norm_in_gdn: Whether to use QK normalization.
 
     Returns:
       A tuple containing:
-        - updated_recurrent_state: Updated recurrent state tensor.
+        - updated_recurrent_state: Updated recurrent state tensor of shape
+          `(num_blocks, n_v, d_k, d_v)`.
         - output: Output tensor.
     """
     num_tokens = query.shape[0]
     max_reqs = recurrent_state.shape[0]
 
     token_idx = jnp.arange(num_tokens)
-    req_indices = token_idx
-    req_indices = jnp.clip(req_indices, 0, max_reqs - 1)
+    req_indices = jnp.clip(token_idx, 0, max_reqs - 1)
     valid_mask = token_idx < distribution[2]
 
     beta = jax.nn.sigmoid(b_reshaped)
@@ -527,35 +544,32 @@ def ragged_gated_delta_rule_decode_only(
         query = l2norm(query)
         key = l2norm(key)
 
+    # Gather the current states for the requests in this batch
     req_state_indices = state_indices[req_indices]
-    curr_states = recurrent_state[req_state_indices]
+    current_states = recurrent_state[req_state_indices]
 
+    # Call step function directly with the inputs (no scattering needed)
     outputs, new_states = recurrent_gated_delta_rule_step(
         query,
         key,
         value,
         g,
         beta,
-        state=curr_states,
+        state=current_states,
     )
 
+    # Mask outputs for invalid tokens
+    outputs = jnp.where(valid_mask[:, None, None], outputs, 0.0)
     outputs = outputs.reshape(num_tokens, -1)
 
-    dummy_idx = max_reqs
-    recurrent_state_padded = jnp.pad(
-        recurrent_state,
-        ((0, 1), (0, 0), (0, 0), (0, 0)),
-        mode="constant",
-        constant_values=0,
-    )
+    # Mask state for invalid tokens
+    states_to_set = jnp.where(valid_mask[:, None, None, None], new_states,
+                              current_states)
 
-    safe_indices = jnp.where(valid_mask, req_state_indices, dummy_idx)
-    updated_recurrent_state_padded = recurrent_state_padded.at[
-        safe_indices].set(new_states.astype(recurrent_state.dtype))
+    updated_recurrent_state = recurrent_state.at[req_state_indices].set(
+        states_to_set)
 
-    new_recurrent_state = updated_recurrent_state_padded[:max_reqs]
-
-    return new_recurrent_state, outputs
+    return updated_recurrent_state.astype(recurrent_state.dtype), outputs
 
 
 def ragged_gated_delta_rule(
@@ -586,12 +600,15 @@ def ragged_gated_delta_rule(
       mixed_qkv: Mixed query, key, value tensor.
       b: b tensor (for beta).
       a: a tensor (for g).
-      recurrent_state: Recurrent state tensor.
+      recurrent_state: Recurrent state tensor of shape `(num_blocks, n_v, d_k,
+        d_v)`. `num_blocks` is always equal or larger than `max_seqs + 1`. The
+        first block is a null_block and only used for padded / invalid tokens.
       A_log: A_log tensor.
       dt_bias: dt_bias tensor.
       query_start_loc: Start locations of sequences.
       state_indices: Indices mapping sequences to recurrent state slots.
-      distribution: Tensor of shape `(3,)` int32 — `(decode_end, prefill_end, mixed_end)`.
+      distribution: Tensor of shape `(3,)` int32 — `(decode_end, prefill_end,
+        mixed_end)`.
       n_kq: Number of key/query heads.
       n_v: Number of value heads.
       d_k: Key/query dimension.
@@ -601,7 +618,8 @@ def ragged_gated_delta_rule(
 
     Returns:
       A tuple containing:
-        - updated_recurrent_state: Updated recurrent state tensor.
+        - updated_recurrent_state: Updated recurrent state tensor of shape
+          `(num_blocks, n_v, d_k, d_v)`.
         - output: Output tensor.
     """
     num_tokens = mixed_qkv.shape[0]

--- a/tpu_inference/layers/common/ragged_gated_delta_rule_ref.py
+++ b/tpu_inference/layers/common/ragged_gated_delta_rule_ref.py
@@ -116,7 +116,9 @@ def ragged_gated_delta_rule(
         d_v)`.
       b: B tensor of shape `(num_tokens, n_v)`.
       a: A tensor of shape `(num_tokens, n_v)`.
-      recurrent_state: Recurrent state of shape `(max_reqs, n_v, d_k, d_v)`.
+      recurrent_state: Recurrent state of shape `(num_blocks, n_v, d_k, d_v)`.
+        `num_blocks` is always equal or larger than `max_seqs + 1`. The first
+        block is a null_block and only used for padded / invalid tokens.
       A_log: Log of A parameter of shape `(n_v,)`.
       dt_bias: Delta T bias of shape `(n_v,)`.
       query_start_loc: Tensor of shape `(num_seqs + 1,)` containing the start
@@ -133,7 +135,8 @@ def ragged_gated_delta_rule(
 
     Returns:
       A tuple containing:
-      - updated_recurrent_state: The updated recurrent state of shape `(max_reqs,
+      - updated_recurrent_state: The updated recurrent state of shape
+      `(num_blocks,
         n_v, d_k, d_v)`.
       - output: The output tensor of shape `(num_tokens, n_v * d_v)`.
     """
@@ -145,10 +148,16 @@ def ragged_gated_delta_rule(
     max_reqs = state_indices.shape[0]
     token_idx = jnp.arange(num_tokens)
 
-    req_indices = jnp.sum(token_idx[:, None] >= query_start_loc[None, :],
-                          axis=1) - 1
+    num_valid_seqs = distribution[2]
+    valid_loc_mask = jnp.arange(query_start_loc.shape[0]) <= num_valid_seqs
+    last_valid_loc = query_start_loc[num_valid_seqs]
+    effective_query_start_loc = jnp.where(valid_loc_mask, query_start_loc,
+                                          last_valid_loc)
+
+    req_indices = (jnp.sum(
+        token_idx[:, None] >= effective_query_start_loc[None, :], axis=1) - 1)
     req_indices = jnp.clip(req_indices, 0, max_reqs - 1)
-    valid_mask = token_idx < query_start_loc[-1]
+    valid_mask = token_idx < last_valid_loc
 
     def scan_fn(carry, xs):
         recurrent_state_all = carry


### PR DESCRIPTION
# Description

Optimizing ragged_gated_delta_rule by simplifying scattering.

Qwen 3.5, 64 token decode
Original 752 us
New: 469 us

Some python docs are updated, the recurren_state shape was wrongly documentd as (max_seqs, ...), It should be (block_size, ...)


# Tests

Tested prompts in offline_inference.py script and shows the same output as before
E2E tested performance

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
