### PR TITLE
fix: increase jax vs pytorch perf threshold to reduce flakiness

### DIFF
--- a/tests/e2e/test_model_loader.py
+++ b/tests/e2e/test_model_loader.py
@@ -253,8 +253,8 @@ def test_flax_nnx_vs_vllm_performance():
     difference is within a reasonable threshold.
     """
     model_name = "Qwen/Qwen3-4B"
-    # This should be 2-3% but 6% reduces flakiness.
-    percentage_difference_threshold = 0.06
+    # This should be 2-3% but 8% reduces flakiness.
+    percentage_difference_threshold = 0.08
 
     throughput_vllm = _run_server_and_bench(model_name, "vllm", 8001)
     throughput_flax = _run_server_and_bench(model_name, "flax_nnx", 8002)


### PR DESCRIPTION
# Description

Increase jax vs pytorch perf threshold to reduce flakiness. In my local runs, this is still a ~2% difference (expected), but sometimes in nightly tests can be high.

# Tests

```bash
$ pytest tests/e2e/test_model_loader.py
========================================== test session starts ===========================================
platform linux -- Python 3.12.3, pytest-9.0.2, pluggy-1.6.0
rootdir: /home/karangoel_google_com/tpu-inference
configfile: pyproject.toml
plugins: jaxtyping-0.3.9, mock-3.15.1, anyio-4.13.0, hypothesis-6.151.9
collected 3 items

tests/e2e/test_model_loader.py ...                                                                                                                                                                             [100%]

================================================================================================== warnings summary ==================================================================================================
<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyPacked has no __module__ attribute

<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyObject has no __module__ attribute

../ullm/venv/lib/python3.12/site-packages/tpu_info/device.py:33
  /home/karangoel_google_com/ullm/venv/lib/python3.12/site-packages/tpu_info/device.py:33: DeprecationWarning: In 3.13 classes created inside an enum will not become a member.  Use the `member` decorator to keep the current behavior.
    class Info(typing.NamedTuple):

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
===================================================================================== 3 passed, 3 warnings in 216.72s (0:03:36) ======================================================================================
sys:1: DeprecationWarning: builtin type swigvarlink has no __module__ attribute
```

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
