### PR TITLE
[MoE] Fix EP token sharding mismatch with psum reduction

### DIFF
--- a/tpu_inference/layers/common/fused_moe_gmm.py
+++ b/tpu_inference/layers/common/fused_moe_gmm.py
@@ -449,23 +449,12 @@ def fused_moe_func(
                                            dtype=jnp.int32).sum(axis=0)
         topk_argsort_revert_indices = jnp.argsort(topk_argsort_indices)
 
-        # The EP path previously sharded ``x`` by EXPERT_DATA via ragged_gather
-        # (#2137) so that every EP rank only materialised the tokens routed
-        # to its local experts.  ``expert_parallel_gmm`` still does a
-        # ``psum(EXPERT)`` at the end, which adds tensors across every axis
-        # of ``EXPERT = ('attn_dp', 'attn_dp_expert', 'expert', 'model')``
-        # (all 32 devices on v4-64 TP=4 EP=8).  Because each rank now holds
-        # *different* tokens at the same local offsets, the psum combines
-        # unrelated tokens' partial outputs.  The per-layer error compounds
-        # (~1.05x per layer) and, on deep MoE models such as GLM-5.1-FP8
-        # (78 layers) or DeepSeek-V3 (61 layers), inflates the MoE output
-        # by ~10x at the final layer, overflows bf16 to NaN on the next
-        # forward, and decode collapses to ``"!!!"``.
-        #
-        # Revert to the pre-#2137 behaviour for EP: keep ``x`` replicated
-        # along non-data axes so every rank sees every token, compute the
-        # local experts' contribution, and let ``psum(EXPERT)`` aggregate
-        # non-overlapping expert-range contributions correctly.
+        # In the EP path, ``x`` must stay replicated across the same axes
+        # that ``expert_parallel_gmm`` reduces over at the end. If ranks hold
+        # different token layouts at the same local offsets, the final
+        # reduction/indexing will mix unrelated token contributions.
+        # Keeping every rank's token ordering aligned lets the reduction
+        # correctly combine only the local experts' non-overlapping outputs.
         x = hidden_states_local[token_indices_sorted]
 
         return x, group_sizes_local, topk_argsort_revert_indices

--- a/tpu_inference/layers/common/fused_moe_gmm.py
+++ b/tpu_inference/layers/common/fused_moe_gmm.py
@@ -22,7 +22,6 @@ from jax.sharding import PartitionSpec as P
 
 import tpu_inference.envs as envs
 from tpu_inference.kernels.gather import gather_reduce as gather_reduce_sc
-from tpu_inference.kernels.gather.ragged_gather import ragged_gather
 from tpu_inference.kernels.megablox.gmm_v2 import gmm_v2
 from tpu_inference.layers.common.sharding import ShardingAxisName
 from tpu_inference.utils import get_mesh_shape_product
@@ -307,7 +306,7 @@ def expert_parallel_gmm(
     num_experts_per_shard = num_experts // ep_size
     group_offset = jnp.arange(0, num_experts, num_experts_per_shard)
 
-    x_p_spec = P(ShardingAxisName.EXPERT_DATA)
+    x_p_spec = P(ShardingAxisName.MLP_DATA)
     w1_scale_spec = None if w1_scale is None else ep_p_spec
     w1_bias_spec = None if w1_bias is None else ep_p_spec
     w2_scale_spec = None if w2_scale is None else ep_p_spec
@@ -450,31 +449,28 @@ def fused_moe_func(
                                            dtype=jnp.int32).sum(axis=0)
         topk_argsort_revert_indices = jnp.argsort(topk_argsort_indices)
 
-        if use_ep:
-            num_ep_shard = get_mesh_shape_product(mesh,
-                                                  ShardingAxisName.EXPERT)
-            local_num_experts = global_num_experts // num_ep_shard
-            shard_idx = jax.lax.axis_index(ShardingAxisName.EXPERT)
-
-            experts_start = shard_idx * local_num_experts
-            experts_end = experts_start + local_num_experts
-            group_offsets = jnp.cumulative_sum(group_sizes_local,
-                                               include_initial=True)
-            shard_output_start = group_offsets[experts_start]
-            shard_output_end = group_offsets[experts_end]
-            x = ragged_gather(
-                hidden_states_local,
-                token_indices_sorted,
-                shard_output_start,
-                shard_output_end,
-            )
-        else:
-            x = hidden_states_local[token_indices_sorted]
+        # The EP path previously sharded ``x`` by EXPERT_DATA via ragged_gather
+        # (#2137) so that every EP rank only materialised the tokens routed
+        # to its local experts.  ``expert_parallel_gmm`` still does a
+        # ``psum(EXPERT)`` at the end, which adds tensors across every axis
+        # of ``EXPERT = ('attn_dp', 'attn_dp_expert', 'expert', 'model')``
+        # (all 32 devices on v4-64 TP=4 EP=8).  Because each rank now holds
+        # *different* tokens at the same local offsets, the psum combines
+        # unrelated tokens' partial outputs.  The per-layer error compounds
+        # (~1.05x per layer) and, on deep MoE models such as GLM-5.1-FP8
+        # (78 layers) or DeepSeek-V3 (61 layers), inflates the MoE output
+        # by ~10x at the final layer, overflows bf16 to NaN on the next
+        # forward, and decode collapses to ``"!!!"``.
+        #
+        # Revert to the pre-#2137 behaviour for EP: keep ``x`` replicated
+        # along non-data axes so every rank sees every token, compute the
+        # local experts' contribution, and let ``psum(EXPERT)`` aggregate
+        # non-overlapping expert-range contributions correctly.
+        x = hidden_states_local[token_indices_sorted]
 
         return x, group_sizes_local, topk_argsort_revert_indices
 
-    x_out_spec = (P(ShardingAxisName.EXPERT_DATA)
-                  if use_ep else P(ShardingAxisName.MLP_DATA))
+    x_out_spec = P(ShardingAxisName.MLP_DATA)
     x, group_sizes, topk_argsort_revert_indices = jax.shard_map(
         _process_tokens_locally,
         mesh=mesh,


### PR DESCRIPTION
# Description

We've been bringing up GLM-5.1-FP8 on TPU v4-64 (TP=4, EP=8) and ran into a decode-time NaN that we'd like to propose a fix for. First of all, thank you for the sparse-core ragged-gather work in `#2137` — it's a nice direction for the EP path. We think there may be a small correctness issue worth a second look, and would appreciate your review.

## What we believe happens

`#2137` changed the EP branch of `fused_moe_func`'s `_process_tokens_locally` so that each rank only materialises the tokens routed to its local experts:

```python
x = ragged_gather(hidden_states_local,
                  token_indices_sorted,
                  shard_output_start, shard_output_end)
```

and the returned `x` carries `P(ShardingAxisName.EXPERT_DATA)`. The downstream `expert_parallel_gmm` still ends with

```python
jax.lax.psum(token_hidden, axis_name=ShardingAxisName.EXPERT)
```

where `EXPERT == ('attn_dp', 'attn_dp_expert', 'expert', 'model')`.

Before `#2137`, `x` was replicated along non-data axes, so the same rows in every rank referred to the same tokens; the `psum` then correctly aggregated non-overlapping expert-range contributions for each token.

After `#2137`, each rank's `x` holds a *different* subset of tokens at the same local offsets, but the reduction is unchanged. As far as we can see, `token_hidden[i]` in rank A and `token_hidden[i]` in rank B refer to different tokens, so the psum adds partial outputs from unrelated tokens rather than aggregating for one token.

If our reading is correct, the per-layer error is small (a modest amplification of the MoE output), but on deep MoE stacks it compounds layer after layer until activations overflow bf16.

## Symptoms we observed

On TPU v4-64 with GLM-5.1-FP8 (78 layers, TP=4, EP=8, `--enable-expert-parallel`):

* Prefill looks mostly fine — the first decoded token is often a plausible top-1 guess.
* A few tokens into the continuation, activations explode and NaN propagates.
* Decode collapses to a repeating `!` sequence.

We haven't had a chance to reproduce on DeepSeek-V3 or on v5/v6/v7, so it's possible this only surfaces under specific topologies or depths. If the maintainers can point us at a known-good configuration for the current EP path, we'd be grateful — we may be missing context.

## Proposed fix

Revert just the EP branch to the pre-`#2137` sharding, without touching the TP path or any other behaviour:

* `_process_tokens_locally` returns `x` sharded by `P(MLP_DATA)` for both TP and EP (tokens replicated along non-data axes).
* `expert_parallel_gmm` uses `P(MLP_DATA)` for its `x` input spec.
* The EP-specific `ragged_gather(...)` branch and the now-unused import are removed.

The masking already present inside `moe_gmm_local` continues to ensure each rank only contributes for its own expert range, so the final `psum(EXPERT)` reduces non-overlapping contributions correctly.

We're keeping the change minimal because the sparse-core path is a real optimisation. If this analysis is correct, it could be reintroduced once the reduction scatters each rank's local expert outputs into a globally-aligned buffer before the `psum`. We didn't attempt that here to avoid enlarging the diff.

# Tests

On TPU v4-64 with GLM-5.1-FP8 (78 layers, TP=4, EP=8) we used a TP=4, PP=8 (no EP) run on the same 32-chip topology as a ground-truth reference. With this patch the EP configuration produces equivalent outputs:

| Prompt | EP before fix | EP after fix / TP+PP reference |
|---|---|---|
| `The capital of France is` | ` Paris. Distance from London` → `!!!` collapse | ` Paris. Distance from London to Paris is 343 km, while direct flight time is 1` |
| `def fibonacci(n):` | NaN / garbage | Correct recursive Python implementation |
| `Once upon a time there was a` | garbage | Little Red Riding Hood continuation |
| `2+3=` | `5!!!` | `5` |

To give some quantitative backing, we added temporary `jax.debug.print` probes after each MoE (inside `fused_moe_func`) and after MLP-add in the decoder layer, and captured the norm of `||MoE_out|| / ||MoE_in||` and `||hidden_after_mlp||` across all 78 layers on a single deterministic `2+3=` request. The table below summarises the distribution across all layers and requests; the same probes read 0 NaN events on both the TP+PP reference and our post-fix EP run:

| Metric | EP before fix | TP+PP reference (32 chips) |
|---|---|---|
| MoE output/input ratio, p50 | (healthy early, then drifts) | 0.10 |
| MoE output/input ratio, p99 | — | 1.41 |
| MoE output/input ratio, max | 10.12 (at final layer, single decode step) | 3.33 |
| Per-layer `after_mlp_norm`, max | 21 248 | 6 944 |
| Runtime NaN events (norm probes) | 17 255 | 0 |

(The probes are purely local instrumentation and not part of this PR — happy to share the patch if it would help with repro or with adding an upstream sanity check.)

Reproduction (model-specific, but any sufficiently deep MoE on EP should show something similar):
1. Serve GLM-5.1-FP8 on v4-64 with `--tensor-parallel-size 4 --enable-expert-parallel` and the EP size set in `additional_config`.
2. Send a decode request with `max_tokens >= 5, temperature=0`; before this patch the completion tends to collapse to `!` after the first few tokens.

We did not run the full CI matrix locally. If the maintainers notice anything we've missed — a scenario where the current behaviour is actually correct, or a cleaner fix — we'd welcome the feedback and are happy to iterate on this PR.

# Checklist

- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have made or will make corresponding changes to any relevant documentation. *(no doc changes in this PR; if the sparse-core path is reintroduced later, documenting the scatter-before-psum requirement would be helpful.)*
