### PR TITLE
[CI] Correct the TENSOR_PARALLEL_SIZE in current yml files for v6 and v7

### DIFF
--- a/.buildkite/excluded/meta-llama_Llama-Guard-4-12B_Multimodal.yml
+++ b/.buildkite/excluded/meta-llama_Llama-Guard-4-12B_Multimodal.yml
@@ -57,7 +57,7 @@ steps:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     env:
       TEST_MODEL: meta-llama/Llama-Guard-4-12B
-      TENSOR_PARALLEL_SIZE: 1
+      TENSOR_PARALLEL_SIZE: "${TENSOR_PARALLEL_SIZE_SINGLE:-1}"
       MINIMUM_ACCURACY_THRESHOLD: 0.02 #TODO: increase threshold when this model becomes higher priority 
     commands:
       - |
@@ -84,7 +84,7 @@ steps:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     env:
       TEST_MODEL: meta-llama/Llama-Guard-4-12B
-      TENSOR_PARALLEL_SIZE: 1
+      TENSOR_PARALLEL_SIZE: "${TENSOR_PARALLEL_SIZE_SINGLE:-1}"
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/safety_model_benchmark.sh --mode performance --benchmark multimodal

--- a/.buildkite/excluded/meta-llama_Llama-Guard-4-12B_Text-Only.yml
+++ b/.buildkite/excluded/meta-llama_Llama-Guard-4-12B_Text-Only.yml
@@ -46,7 +46,7 @@ steps:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     env:
       TEST_MODEL: meta-llama/Llama-Guard-4-12B
-      TENSOR_PARALLEL_SIZE: 1
+      TENSOR_PARALLEL_SIZE: "${TENSOR_PARALLEL_SIZE_SINGLE:-1}"
       MINIMUM_ACCURACY_THRESHOLD: 0.31 #TODO: This will be updated later with a true threshold
     commands:
       - |
@@ -73,7 +73,7 @@ steps:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     env:
       TEST_MODEL: meta-llama/Llama-Guard-4-12B
-      TENSOR_PARALLEL_SIZE: 1
+      TENSOR_PARALLEL_SIZE: "${TENSOR_PARALLEL_SIZE_SINGLE:-1}"
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/safety_model_benchmark.sh --mode performance --benchmark text-only

--- a/.buildkite/models/MiniMaxAI_MiniMax-M2_5.yml
+++ b/.buildkite/models/MiniMaxAI_MiniMax-M2_5.yml
@@ -45,7 +45,7 @@ steps:
       queue: cpu  # TODO: replace with execution environment
     env:
       TEST_MODEL: MiniMaxAI/MiniMax-M2.5
-      TENSOR_PARALLEL_SIZE: 1
+      TENSOR_PARALLEL_SIZE: "${TENSOR_PARALLEL_SIZE_SINGLE:-1}"
       MINIMUM_ACCURACY_THRESHOLD: 0  # TODO : replace 0 with your accuracy threshold
     commands:
       - |
@@ -72,7 +72,7 @@ steps:
       queue: cpu  # TODO: replace with execution environment
     env:
       TEST_MODEL: MiniMaxAI/MiniMax-M2.5
-      TENSOR_PARALLEL_SIZE: 1
+      TENSOR_PARALLEL_SIZE: "${TENSOR_PARALLEL_SIZE_SINGLE:-1}"
       MINIMUM_THROUGHPUT_THRESHOLD: 0  # TODO : replace 0 with your performance threshold
     commands:
       - |

--- a/.buildkite/models/Qwen_Qwen2_5-VL-7B-Instruct.yml
+++ b/.buildkite/models/Qwen_Qwen2_5-VL-7B-Instruct.yml
@@ -42,11 +42,11 @@ steps:
     key: "${TPU_VERSION:-tpu6e}_Qwen_Qwen2_5-VL-7B-Instruct_Accuracy"
     depends_on: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen2_5-VL-7B-Instruct_UnitTest"
     agents:
-      queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     soft_fail: true
     env:
       TEST_MODEL: Qwen/Qwen2.5-VL-7B-Instruct
-      TENSOR_PARALLEL_SIZE: 1
+      TENSOR_PARALLEL_SIZE: "${TENSOR_PARALLEL_SIZE_SINGLE:-1}"
       MINIMUM_ACCURACY_THRESHOLD: 0.72
     commands:
       - |

--- a/.buildkite/models/Qwen_Qwen3-30B-A3B.yml
+++ b/.buildkite/models/Qwen_Qwen3-30B-A3B.yml
@@ -46,7 +46,7 @@ steps:
     soft_fail: true
     env:
       TEST_MODEL: Qwen/Qwen3-30B-A3B
-      TENSOR_PARALLEL_SIZE: 4
+      TENSOR_PARALLEL_SIZE: "${TENSOR_PARALLEL_SIZE_MULTI:-8}"
       MINIMUM_ACCURACY_THRESHOLD: 0.89
       MODEL_IMPL_TYPE: vllm
     commands:
@@ -74,7 +74,7 @@ steps:
       queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
     env:
       TEST_MODEL: Qwen/Qwen3-30B-A3B
-      TENSOR_PARALLEL_SIZE: 4
+      TENSOR_PARALLEL_SIZE: "${TENSOR_PARALLEL_SIZE_MULTI:-8}"
       MINIMUM_THROUGHPUT_THRESHOLD: 7.20
       INPUT_LEN: 1800
       OUTPUT_LEN: 128

--- a/.buildkite/models/Qwen_Qwen3-32B.yml
+++ b/.buildkite/models/Qwen_Qwen3-32B.yml
@@ -46,7 +46,7 @@ steps:
     soft_fail: true
     env:
       TEST_MODEL: Qwen/Qwen3-32B
-      TENSOR_PARALLEL_SIZE: 8
+      TENSOR_PARALLEL_SIZE: "${TENSOR_PARALLEL_SIZE_MULTI:-8}"
       MINIMUM_ACCURACY_THRESHOLD: 0.74
     commands:
       - |
@@ -73,7 +73,7 @@ steps:
     soft_fail: true
     env:
       TEST_MODEL: Qwen/Qwen3-32B
-      TENSOR_PARALLEL_SIZE: 8
+      TENSOR_PARALLEL_SIZE: "${TENSOR_PARALLEL_SIZE_MULTI:-8}"
       MINIMUM_THROUGHPUT_THRESHOLD: 12.46
       INPUT_LEN: 1800
       OUTPUT_LEN: 128

--- a/.buildkite/models/Qwen_Qwen3-4B.yml
+++ b/.buildkite/models/Qwen_Qwen3-4B.yml
@@ -46,7 +46,7 @@ steps:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     env:
       TEST_MODEL: Qwen/Qwen3-4B
-      TPU_VERSION: "${TPU_VERSION:-tpu6e}"
+      TENSOR_PARALLEL_SIZE: "${TENSOR_PARALLEL_SIZE_SINGLE:-1}"
       MINIMUM_ACCURACY_THRESHOLD: 0.85
     commands:
       - |
@@ -73,7 +73,7 @@ steps:
     soft_fail: true
     env:
       TEST_MODEL: Qwen/Qwen3-4B
-      TPU_VERSION: "${TPU_VERSION:-tpu6e}"
+      TENSOR_PARALLEL_SIZE: "${TENSOR_PARALLEL_SIZE_SINGLE:-1}"
       MINIMUM_THROUGHPUT_THRESHOLD: 11.00
       INPUT_LEN: 1800
       OUTPUT_LEN: 128

--- a/.buildkite/models/Qwen_Qwen3-VL-8B-Instruct.yml
+++ b/.buildkite/models/Qwen_Qwen3-VL-8B-Instruct.yml
@@ -45,7 +45,7 @@ steps:
       queue: cpu  # TODO: replace with execution environment
     env:
       TEST_MODEL: Qwen/Qwen3-VL-8B-Instruct
-      TENSOR_PARALLEL_SIZE: 1
+      TENSOR_PARALLEL_SIZE: "${TENSOR_PARALLEL_SIZE_SINGLE:-1}"
       MINIMUM_ACCURACY_THRESHOLD: 0  # TODO : replace 0 with your accuracy threshold
     commands:
       - |
@@ -72,7 +72,7 @@ steps:
       queue: cpu  # TODO: replace with execution environment
     env:
       TEST_MODEL: Qwen/Qwen3-VL-8B-Instruct
-      TENSOR_PARALLEL_SIZE: 1
+      TENSOR_PARALLEL_SIZE: "${TENSOR_PARALLEL_SIZE_SINGLE:-1}"
       MINIMUM_THROUGHPUT_THRESHOLD: 0  # TODO : replace 0 with your performance threshold
     commands:
       - |

--- a/.buildkite/models/Qwen_Qwen3_5-9B.yml
+++ b/.buildkite/models/Qwen_Qwen3_5-9B.yml
@@ -45,7 +45,7 @@ steps:
       queue: cpu  # TODO: replace with execution environment
     env:
       TEST_MODEL: Qwen/Qwen3.5-9B
-      TENSOR_PARALLEL_SIZE: 1
+      TENSOR_PARALLEL_SIZE: "${TENSOR_PARALLEL_SIZE_SINGLE:-1}"
       MINIMUM_ACCURACY_THRESHOLD: 0  # TODO : replace 0 with your accuracy threshold
     commands:
       - |
@@ -72,7 +72,7 @@ steps:
       queue: cpu  # TODO: replace with execution environment
     env:
       TEST_MODEL: Qwen/Qwen3.5-9B
-      TENSOR_PARALLEL_SIZE: 1
+      TENSOR_PARALLEL_SIZE: "${TENSOR_PARALLEL_SIZE_SINGLE:-1}"
       MINIMUM_THROUGHPUT_THRESHOLD: 0  # TODO : replace 0 with your performance threshold
     commands:
       - |

--- a/.buildkite/models/deepseek-ai_DeepSeek-Math-V2.yml
+++ b/.buildkite/models/deepseek-ai_DeepSeek-Math-V2.yml
@@ -45,7 +45,7 @@ steps:
       queue: cpu  # TODO: replace with execution environment
     env:
       TEST_MODEL: deepseek-ai/DeepSeek-Math-V2
-      TENSOR_PARALLEL_SIZE: 1
+      TENSOR_PARALLEL_SIZE: "${TENSOR_PARALLEL_SIZE_SINGLE:-1}"
       MINIMUM_ACCURACY_THRESHOLD: 0  # TODO : replace 0 with your accuracy threshold
     commands:
       - |
@@ -72,7 +72,7 @@ steps:
       queue: cpu  # TODO: replace with execution environment
     env:
       TEST_MODEL: deepseek-ai/DeepSeek-Math-V2
-      TENSOR_PARALLEL_SIZE: 1
+      TENSOR_PARALLEL_SIZE: "${TENSOR_PARALLEL_SIZE_SINGLE:-1}"
       MINIMUM_THROUGHPUT_THRESHOLD: 0  # TODO : replace 0 with your performance threshold
     commands:
       - |

--- a/.buildkite/models/deepseek-ai_DeepSeek-OCR.yml
+++ b/.buildkite/models/deepseek-ai_DeepSeek-OCR.yml
@@ -45,7 +45,7 @@ steps:
       queue: cpu  # TODO: replace with execution environment
     env:
       TEST_MODEL: deepseek-ai/DeepSeek-OCR
-      TENSOR_PARALLEL_SIZE: 1
+      TENSOR_PARALLEL_SIZE: "${TENSOR_PARALLEL_SIZE_SINGLE:-1}"
       MINIMUM_ACCURACY_THRESHOLD: 0  # TODO : replace 0 with your accuracy threshold
     commands:
       - |
@@ -72,7 +72,7 @@ steps:
       queue: cpu  # TODO: replace with execution environment
     env:
       TEST_MODEL: deepseek-ai/DeepSeek-OCR
-      TENSOR_PARALLEL_SIZE: 1
+      TENSOR_PARALLEL_SIZE: "${TENSOR_PARALLEL_SIZE_SINGLE:-1}"
       MINIMUM_THROUGHPUT_THRESHOLD: 0  # TODO : replace 0 with your performance threshold
     commands:
       - |

--- a/.buildkite/models/deepseek-ai_DeepSeek-R1.yml
+++ b/.buildkite/models/deepseek-ai_DeepSeek-R1.yml
@@ -58,7 +58,7 @@ steps:
       queue: cpu  # TODO: replace with execution environment
     env:
       TEST_MODEL: deepseek-ai/DeepSeek-R1
-      TENSOR_PARALLEL_SIZE: 1
+      TENSOR_PARALLEL_SIZE: "${TENSOR_PARALLEL_SIZE_SINGLE:-1}"
       MINIMUM_ACCURACY_THRESHOLD: 0  # TODO : replace 0 with your accuracy threshold
     commands:
       - |
@@ -85,7 +85,7 @@ steps:
       queue: cpu  # TODO: replace with execution environment
     env:
       TEST_MODEL: deepseek-ai/DeepSeek-R1
-      TENSOR_PARALLEL_SIZE: 1
+      TENSOR_PARALLEL_SIZE: "${TENSOR_PARALLEL_SIZE_SINGLE:-1}"
       MINIMUM_THROUGHPUT_THRESHOLD: 0  # TODO : replace 0 with your performance threshold
     commands:
       - |

--- a/.buildkite/models/deepseek-ai_DeepSeek-V3_2-Speciale.yml
+++ b/.buildkite/models/deepseek-ai_DeepSeek-V3_2-Speciale.yml
@@ -45,7 +45,7 @@ steps:
       queue: cpu  # TODO: replace with execution environment
     env:
       TEST_MODEL: deepseek-ai/DeepSeek-V3.2-Speciale
-      TENSOR_PARALLEL_SIZE: 1
+      TENSOR_PARALLEL_SIZE: "${TENSOR_PARALLEL_SIZE_SINGLE:-1}"
       MINIMUM_ACCURACY_THRESHOLD: 0  # TODO : replace 0 with your accuracy threshold
     commands:
       - |
@@ -72,7 +72,7 @@ steps:
       queue: cpu  # TODO: replace with execution environment
     env:
       TEST_MODEL: deepseek-ai/DeepSeek-V3.2-Speciale
-      TENSOR_PARALLEL_SIZE: 1
+      TENSOR_PARALLEL_SIZE: "${TENSOR_PARALLEL_SIZE_SINGLE:-1}"
       MINIMUM_THROUGHPUT_THRESHOLD: 0  # TODO : replace 0 with your performance threshold
     commands:
       - |

--- a/.buildkite/models/deepseek-ai_DeepSeek-V3_2.yml
+++ b/.buildkite/models/deepseek-ai_DeepSeek-V3_2.yml
@@ -45,7 +45,7 @@ steps:
       queue: cpu  # TODO: replace with execution environment
     env:
       TEST_MODEL: deepseek-ai/DeepSeek-V3.2
-      TENSOR_PARALLEL_SIZE: 1
+      TENSOR_PARALLEL_SIZE: "${TENSOR_PARALLEL_SIZE_SINGLE:-1}"
       MINIMUM_ACCURACY_THRESHOLD: 0  # TODO : replace 0 with your accuracy threshold
     commands:
       - |
@@ -72,7 +72,7 @@ steps:
       queue: cpu  # TODO: replace with execution environment
     env:
       TEST_MODEL: deepseek-ai/DeepSeek-V3.2
-      TENSOR_PARALLEL_SIZE: 1
+      TENSOR_PARALLEL_SIZE: "${TENSOR_PARALLEL_SIZE_SINGLE:-1}"
       MINIMUM_THROUGHPUT_THRESHOLD: 0  # TODO : replace 0 with your performance threshold
     commands:
       - |

--- a/.buildkite/models/google_gemma-3-27b-it.yml
+++ b/.buildkite/models/google_gemma-3-27b-it.yml
@@ -46,7 +46,7 @@ steps:
     soft_fail: true
     env:
       TEST_MODEL: google/gemma-3-27b-it
-      TENSOR_PARALLEL_SIZE: 8
+      TENSOR_PARALLEL_SIZE: "${TENSOR_PARALLEL_SIZE_MULTI:-8}"
       MINIMUM_ACCURACY_THRESHOLD: 0.56
     commands:
       - |
@@ -73,7 +73,7 @@ steps:
     soft_fail: true
     env:
       TEST_MODEL: google/gemma-3-27b-it
-      TENSOR_PARALLEL_SIZE: 8
+      TENSOR_PARALLEL_SIZE: "${TENSOR_PARALLEL_SIZE_MULTI:-8}"
       MINIMUM_THROUGHPUT_THRESHOLD: 21
       INPUT_LEN: 1000
       OUTPUT_LEN: 100

--- a/.buildkite/models/meta-llama_Llama-3_1-8B-Instruct.yml
+++ b/.buildkite/models/meta-llama_Llama-3_1-8B-Instruct.yml
@@ -46,7 +46,7 @@ steps:
     soft_fail: true
     env:
       TEST_MODEL: meta-llama/Llama-3.1-8B-Instruct
-      TPU_VERSION: "${TPU_VERSION:-tpu6e}"
+      TENSOR_PARALLEL_SIZE: "${TENSOR_PARALLEL_SIZE_SINGLE:-1}"
       MINIMUM_ACCURACY_THRESHOLD: 0.75
     commands:
       - |
@@ -73,7 +73,7 @@ steps:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     env:
       TEST_MODEL: meta-llama/Llama-3.1-8B-Instruct
-      TPU_VERSION: "${TPU_VERSION:-tpu6e}"
+      TENSOR_PARALLEL_SIZE: "${TENSOR_PARALLEL_SIZE_SINGLE:-1}"
       MINIMUM_THROUGHPUT_THRESHOLD: 10.77
       INPUT_LEN: 1800
       OUTPUT_LEN: 128

--- a/.buildkite/models/meta-llama_Llama-3_3-70B-Instruct.yml
+++ b/.buildkite/models/meta-llama_Llama-3_3-70B-Instruct.yml
@@ -46,7 +46,7 @@ steps:
       queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
     env:
       TEST_MODEL: meta-llama/Llama-3.3-70B-Instruct
-      TENSOR_PARALLEL_SIZE: 8
+      TENSOR_PARALLEL_SIZE: "${TENSOR_PARALLEL_SIZE_MULTI:-8}"
       MINIMUM_ACCURACY_THRESHOLD: 0.90
     commands:
       - |
@@ -73,7 +73,7 @@ steps:
       queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
     env:
       TEST_MODEL: meta-llama/Llama-3.3-70B-Instruct
-      TENSOR_PARALLEL_SIZE: 8
+      TENSOR_PARALLEL_SIZE: "${TENSOR_PARALLEL_SIZE_MULTI:-8}"
       MINIMUM_THROUGHPUT_THRESHOLD: 7.0
       INPUT_LEN: 1800
       OUTPUT_LEN: 128

--- a/.buildkite/models/moonshotai_Kimi-K2_5.yml
+++ b/.buildkite/models/moonshotai_Kimi-K2_5.yml
@@ -45,7 +45,7 @@ steps:
       queue: cpu  # TODO: replace with execution environment
     env:
       TEST_MODEL: moonshotai/Kimi-K2.5
-      TENSOR_PARALLEL_SIZE: 1
+      TENSOR_PARALLEL_SIZE: "${TENSOR_PARALLEL_SIZE_SINGLE:-1}"
       MINIMUM_ACCURACY_THRESHOLD: 0  # TODO : replace 0 with your accuracy threshold
     commands:
       - |
@@ -72,7 +72,7 @@ steps:
       queue: cpu  # TODO: replace with execution environment
     env:
       TEST_MODEL: moonshotai/Kimi-K2.5
-      TENSOR_PARALLEL_SIZE: 1
+      TENSOR_PARALLEL_SIZE: "${TENSOR_PARALLEL_SIZE_SINGLE:-1}"
       MINIMUM_THROUGHPUT_THRESHOLD: 0  # TODO : replace 0 with your performance threshold
     commands:
       - |

--- a/.buildkite/models/openai_gpt-oss-20b.yml
+++ b/.buildkite/models/openai_gpt-oss-20b.yml
@@ -45,7 +45,7 @@ steps:
       queue: cpu  # TODO: replace with execution environment
     env:
       TEST_MODEL: openai/gpt-oss-20b
-      TENSOR_PARALLEL_SIZE: 1
+      TENSOR_PARALLEL_SIZE: "${TENSOR_PARALLEL_SIZE_SINGLE:-1}"
       MINIMUM_ACCURACY_THRESHOLD: 0  # TODO : replace 0 with your accuracy threshold
     commands:
       - |
@@ -72,7 +72,7 @@ steps:
       queue: cpu  # TODO: replace with execution environment
     env:
       TEST_MODEL: openai/gpt-oss-20b
-      TENSOR_PARALLEL_SIZE: 1
+      TENSOR_PARALLEL_SIZE: "${TENSOR_PARALLEL_SIZE_SINGLE:-1}"
       MINIMUM_THROUGHPUT_THRESHOLD: 0  # TODO : replace 0 with your performance threshold
     commands:
       - |

--- a/.buildkite/models/zai-org_GLM-5.yml
+++ b/.buildkite/models/zai-org_GLM-5.yml
@@ -45,7 +45,7 @@ steps:
       queue: cpu  # TODO: replace with execution environment
     env:
       TEST_MODEL: zai-org/GLM-5
-      TENSOR_PARALLEL_SIZE: 1
+      TENSOR_PARALLEL_SIZE: "${TENSOR_PARALLEL_SIZE_SINGLE:-1}"
       MINIMUM_ACCURACY_THRESHOLD: 0  # TODO : replace 0 with your accuracy threshold
     commands:
       - |
@@ -72,7 +72,7 @@ steps:
       queue: cpu  # TODO: replace with execution environment
     env:
       TEST_MODEL: zai-org/GLM-5
-      TENSOR_PARALLEL_SIZE: 1
+      TENSOR_PARALLEL_SIZE: "${TENSOR_PARALLEL_SIZE_SINGLE:-1}"
       MINIMUM_THROUGHPUT_THRESHOLD: 0  # TODO : replace 0 with your performance threshold
     commands:
       - |

--- a/.buildkite/pipeline_jax.yml
+++ b/.buildkite/pipeline_jax.yml
@@ -583,7 +583,7 @@ steps:
         soft_fail: true
         env:
           TEST_MODEL: Qwen/Qwen2.5-VL-7B-Instruct
-          TENSOR_PARALLEL_SIZE: 1
+          TENSOR_PARALLEL_SIZE: "${TENSOR_PARALLEL_SIZE_SINGLE:-1}"
           MINIMUM_ACCURACY_THRESHOLD: 0.72
         commands:
           - |

--- a/.buildkite/scripts/bootstrap.sh
+++ b/.buildkite/scripts/bootstrap.sh
@@ -115,16 +115,20 @@ set_jax_envs() {
             export TPU_VERSION="tpu6e"
             export TPU_QUEUE_SINGLE="tpu_v6e_queue"
             export TPU_QUEUE_MULTI="tpu_v6e_8_queue"
+            export TENSOR_PARALLEL_SIZE_SINGLE=1
+            export TENSOR_PARALLEL_SIZE_MULTI=8
             ;;
         v7)
             export TESTS_GROUP_LABEL="[jax] TPU7x Tests Group"
             export TPU_VERSION="tpu7x"
             export TPU_QUEUE_SINGLE="tpu_v7x_2_queue"
             export TPU_QUEUE_MULTI="tpu_v7x_8_queue"
+            export TENSOR_PARALLEL_SIZE_SINGLE=2
+            export TENSOR_PARALLEL_SIZE_MULTI=8
             export COV_FAIL_UNDER="67"
             ;;
         unset)
-            unset TESTS_GROUP_LABEL TPU_VERSION TPU_QUEUE_SINGLE TPU_QUEUE_MULTI COV_FAIL_UNDER
+            unset TESTS_GROUP_LABEL TPU_VERSION TPU_QUEUE_SINGLE TPU_QUEUE_MULTI TENSOR_PARALLEL_SIZE_SINGLE TENSOR_PARALLEL_SIZE_MULTI COV_FAIL_UNDER
             ;;
     esac
 }

--- a/.buildkite/scripts/upload_models_and_features.sh
+++ b/.buildkite/scripts/upload_models_and_features.sh
@@ -127,6 +127,8 @@ if [[ "${#pipeline_v6e_fragments[@]}" -gt 0 ]]; then
   export TPU_QUEUE_SINGLE="tpu_v6e_queue"
   export TPU_QUEUE_MULTI="tpu_v6e_8_queue"
   export TPU_VERSION="tpu6e"
+  export TENSOR_PARALLEL_SIZE_SINGLE=1
+  export TENSOR_PARALLEL_SIZE_MULTI=8
   buildkite-agent meta-data set "run_v6_matrix" "true"
   {
     echo "priority: ${JOB_PRIORITY:-1}"

--- a/.buildkite/scripts/upload_models_and_features.sh
+++ b/.buildkite/scripts/upload_models_and_features.sh
@@ -147,6 +147,8 @@ if [[ "${#pipeline_v7x_fragments[@]}" -gt 0 ]]; then
   export TPU_QUEUE_SINGLE="tpu_v7x_2_queue"
   export TPU_QUEUE_MULTI="tpu_v7x_8_queue"
   export TPU_VERSION="tpu7x"
+  export TENSOR_PARALLEL_SIZE_SINGLE=2
+  export TENSOR_PARALLEL_SIZE_MULTI=8
   buildkite-agent meta-data set "run_v7_matrix" "true"
   {
     echo "priority: ${JOB_PRIORITY:-1}"


### PR DESCRIPTION
# Description

Correct the TENSOR_PARALLEL_SIZE info for v6 and v7

```
TENSOR_PARALLEL_SIZE_SINGLE, v6 should be `1`
TENSOR_PARALLEL_SIZE_MUTI, v6 should be `8`

TENSOR_PARALLEL_SIZE_SINGLE, v7 should be `2`
TENSOR_PARALLEL_SIZE_MUTI, v7 should be `8`
```

We use `${TENSOR_PARALLEL_SIZE_SINGLE:-1}` and `${TENSOR_PARALLEL_SIZE_MULTI:-8}` instead of hardcoding the values. These defaults are for v6; otherwise, the environment variables should be set to the values for v7.

Addition:

- For `.buildkite/models/Qwen_Qwen3-30B-A3B.yml`:
Update `TENSOR_PARALLEL_SIZE` from `4` to `${TENSOR_PARALLEL_SIZE_MULTI:-8}`.

- For `.buildkite/models/Qwen_Qwen2_5-VL-7B-Instruct.yml`:
Switch to `TPU_QUEUE_SINGLE` instead of `TPU_QUEUE_MULTI`.

# Tests

Nightly tests [BuildKite](https://buildkite.com/tpu-commons/tpu-inference-ci/builds/14686)

For `.buildkite/excluded/meta-llama_Llama-Guard-4-12B_Multimodal.yml` and `.buildkite/excluded/meta-llama_Llama-Guard-4-12B_Text-Only.yml` (not include in current CI)
[Buildkite](https://buildkite.com/tpu-commons/tpu-inference-ci/builds/14901)

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.