### PR TITLE
[torchax] Add ViT sdpa op

### DIFF
--- a/tpu_inference/layers/vllm/ops/scaled_dot_product_attention.py
+++ b/tpu_inference/layers/vllm/ops/scaled_dot_product_attention.py
@@ -40,7 +40,6 @@ def scaled_dot_product_attention(
 
     # Q, K, V shapes: (batch, num_heads, seq_len, head_dim)
     batch = query.shape[0]
-    num_heads = query.shape[1]
     q_seq_len = query.shape[2]
     kv_seq_len = key.shape[2]
 

--- a/tpu_inference/layers/vllm/ops/scaled_dot_product_attention.py
+++ b/tpu_inference/layers/vllm/ops/scaled_dot_product_attention.py
@@ -84,6 +84,7 @@ def scaled_dot_product_attention(
 
     return out
 
+
 def vllm_vit_sdpa(
     query,
     key,
@@ -96,7 +97,7 @@ def vllm_vit_sdpa(
 ):
     """Custom JAX implementation of ViT SDPA as an alternative of [upstream vLLM SDPA](https://github.com/vllm-project/vllm/blob/bcc2306cefa4179c548d3e638e7a22a88d281733/vllm/v1/attention/ops/vit_attn_wrappers.py#L211-L239) implementation."""
 
-    # The custom vLLM operator `torch.ops.vllm.torch_sdpa_wrapper` used in ViT, passes tensors in 
+    # The custom vLLM operator `torch.ops.vllm.torch_sdpa_wrapper` used in ViT, passes tensors in
     # shape (batch, seq_len, num_heads, head_dim)
     # while `sharded_flash_attention` expects shape (batch, num_heads, seq_len, head_dim)
     query = jnp.swapaxes(query, 1, 2)
@@ -110,7 +111,7 @@ def vllm_vit_sdpa(
     # The `sharded_flash_attention` kernel requires sequence lengths to be multiples of 128. So, padding accordingly.
     q_pad = (128 - (q_seq_len % 128)) % 128
     kv_pad = (128 - (kv_seq_len % 128)) % 128
-    
+
     # Pad the sequence dimension (axis 2) with zeros at the end.
     if q_pad > 0:
         query = jnp.pad(query, ((0, 0), (0, 0), (0, q_pad), (0, 0)))
@@ -125,18 +126,20 @@ def vllm_vit_sdpa(
         num_segs = lens.shape[0]
 
         # Create segment IDs for each token by repeating the sequence index by its length.
-        q_real_seg = jnp.repeat(jnp.arange(num_segs), lens, total_repeat_length=q_seq_len)
+        q_real_seg = jnp.repeat(jnp.arange(num_segs),
+                                lens,
+                                total_repeat_length=q_seq_len)
         kv_real_seg = q_real_seg
 
         # Pad segment IDs if sequence lengths are not multiples of 128.
         if q_pad > 0:
-            q_pad_seg = jnp.full((q_pad,), num_segs)
+            q_pad_seg = jnp.full((q_pad, ), num_segs)
             q_seg = jnp.concatenate([q_real_seg, q_pad_seg])
         else:
             q_seg = q_real_seg
 
         if kv_pad > 0:
-            kv_pad_seg = jnp.full((kv_pad,), num_segs)
+            kv_pad_seg = jnp.full((kv_pad, ), num_segs)
             kv_seg = jnp.concatenate([kv_real_seg, kv_pad_seg])
         else:
             kv_seg = kv_real_seg
@@ -150,15 +153,13 @@ def vllm_vit_sdpa(
     else:
         seg_ids = None
 
-    # Note: 
+    # Note:
     # 1. causal=False as ViT attention is bidirectional (non-causal)
     # 2. use_attention_bias=False as sequence boundaries are handled by seg_ids instead of an explicit attention bias matrix.
-    attn_fn = sharded_flash_attention(
-        mesh,
-        causal=False,
-        sm_scale=scale,
-        use_attention_bias=False
-    )
+    attn_fn = sharded_flash_attention(mesh,
+                                      causal=False,
+                                      sm_scale=scale,
+                                      use_attention_bias=False)
 
     out = attn_fn(query, key, value, seg_ids)
 

--- a/tpu_inference/layers/vllm/ops/scaled_dot_product_attention.py
+++ b/tpu_inference/layers/vllm/ops/scaled_dot_product_attention.py
@@ -40,6 +40,7 @@ def scaled_dot_product_attention(
 
     # Q, K, V shapes: (batch, num_heads, seq_len, head_dim)
     batch = query.shape[0]
+    num_heads = query.shape[1]
     q_seq_len = query.shape[2]
     kv_seq_len = key.shape[2]
 
@@ -93,7 +94,7 @@ def vllm_vit_sdpa(
     *,
     mesh,
 ):
-    """Custom JAX implementation of ViT SDPA as an alternative of upstream vLLM SDPA implementation."""
+    """Custom JAX implementation of ViT SDPA as an alternative of [upstream vLLM SDPA](https://github.com/vllm-project/vllm/blob/bcc2306cefa4179c548d3e638e7a22a88d281733/vllm/v1/attention/ops/vit_attn_wrappers.py#L211-L239) implementation."""
 
     # The custom vLLM operator `torch.ops.vllm.torch_sdpa_wrapper` used in ViT, passes tensors in 
     # shape (batch, seq_len, num_heads, head_dim)
@@ -103,7 +104,6 @@ def vllm_vit_sdpa(
     value = jnp.swapaxes(value, 1, 2)
 
     batch = query.shape[0]
-    num_heads = query.shape[1]
     q_seq_len = query.shape[2]
     kv_seq_len = key.shape[2]
 

--- a/tpu_inference/layers/vllm/ops/scaled_dot_product_attention.py
+++ b/tpu_inference/layers/vllm/ops/scaled_dot_product_attention.py
@@ -94,4 +94,79 @@ def vllm_vit_sdpa(
     *,
     mesh,
 ):
-    pass
+    """Custom JAX implementation of ViT SDPA as an alternative of upstream vLLM SDPA implementation."""
+
+    # The custom vLLM operator `torch.ops.vllm.torch_sdpa_wrapper` used in ViT, passes tensors in 
+    # shape (batch, seq_len, num_heads, head_dim)
+    # while `sharded_flash_attention` expects shape (batch, num_heads, seq_len, head_dim)
+    query = jnp.swapaxes(query, 1, 2)
+    key = jnp.swapaxes(key, 1, 2)
+    value = jnp.swapaxes(value, 1, 2)
+
+    batch = query.shape[0]
+    num_heads = query.shape[1]
+    q_seq_len = query.shape[2]
+    kv_seq_len = key.shape[2]
+
+    # The `sharded_flash_attention` kernel requires sequence lengths to be multiples of 128. So, padding accordingly.
+    q_pad = (128 - (q_seq_len % 128)) % 128
+    kv_pad = (128 - (kv_seq_len % 128)) % 128
+    
+    # Pad the sequence dimension (axis 2) with zeros at the end.
+    if q_pad > 0:
+        query = jnp.pad(query, ((0, 0), (0, 0), (0, q_pad), (0, 0)))
+    if kv_pad > 0:
+        key = jnp.pad(key, ((0, 0), (0, 0), (0, kv_pad), (0, 0)))
+        value = jnp.pad(value, ((0, 0), (0, 0), (0, kv_pad), (0, 0)))
+
+    if cu_seqlens is not None:
+        # Compute individual sequence lengths from cumulative sequence lengths.
+        cu_seqlens_arr = jnp.array(cu_seqlens)
+        lens = cu_seqlens_arr[1:] - cu_seqlens_arr[:-1]
+        num_segs = lens.shape[0]
+
+        # Create segment IDs for each token by repeating the sequence index by its length.
+        q_real_seg = jnp.repeat(jnp.arange(num_segs), lens, total_repeat_length=q_seq_len)
+        kv_real_seg = q_real_seg
+
+        # Pad segment IDs if sequence lengths are not multiples of 128.
+        if q_pad > 0:
+            q_pad_seg = jnp.full((q_pad,), num_segs)
+            q_seg = jnp.concatenate([q_real_seg, q_pad_seg])
+        else:
+            q_seg = q_real_seg
+
+        if kv_pad > 0:
+            kv_pad_seg = jnp.full((kv_pad,), num_segs)
+            kv_seg = jnp.concatenate([kv_real_seg, kv_pad_seg])
+        else:
+            kv_seg = kv_real_seg
+
+        # Broadcast from 1D (seq_len,) to 2D (batch, seq_len) to match kernel expectations.
+        q_seg = jnp.broadcast_to(q_seg, (batch, q_seg.shape[0]))
+        kv_seg = jnp.broadcast_to(kv_seg, (batch, kv_seg.shape[0]))
+
+        from tpu_inference.kernels.flash_attention.kernel import SegmentIds
+        seg_ids = SegmentIds(q=q_seg, kv=kv_seg)
+    else:
+        seg_ids = None
+
+    # Note: 
+    # 1. causal=False as ViT attention is bidirectional (non-causal)
+    # 2. use_attention_bias=False as sequence boundaries are handled by seg_ids instead of an explicit attention bias matrix.
+    attn_fn = sharded_flash_attention(
+        mesh,
+        causal=False,
+        sm_scale=scale,
+        use_attention_bias=False
+    )
+
+    out = attn_fn(query, key, value, seg_ids)
+
+    if q_pad > 0:
+        out = out[:, :, :q_seq_len, :]
+
+    # Reshape back to (batch, seq_len, num_heads, head_dim) to match the original input shape.
+    out = jnp.swapaxes(out, 1, 2)
+
+    return out

--- a/tpu_inference/layers/vllm/ops/scaled_dot_product_attention.py
+++ b/tpu_inference/layers/vllm/ops/scaled_dot_product_attention.py
@@ -83,3 +83,15 @@ def scaled_dot_product_attention(
         out = out[:, :, :q_seq_len, :]
 
     return out
+
+def vllm_vit_sdpa(
+    query,
+    key,
+    value,
+    scale=None,
+    cu_seqlens=None,
+    enable_gqa=False,
+    *,
+    mesh,
+):
+    pass

--- a/tpu_inference/models/vllm/vllm_model_wrapper.py
+++ b/tpu_inference/models/vllm/vllm_model_wrapper.py
@@ -30,7 +30,10 @@ from flax.typing import PRNGKey
 from jax.sharding import Mesh, NamedSharding, PartitionSpec
 from torchax.interop import jax_view, torch_view
 from torchax.ops.mappings import TORCH_DTYPE_TO_JAX
-from torchax.ops.ops_registry import register_torch_function_op
+from torchax.ops.ops_registry import (
+    register_torch_function_op,
+    register_torch_dispatch_op,
+)
 from vllm.config import VllmConfig, set_current_vllm_config
 from vllm.forward_context import set_forward_context
 from vllm.lora.layers import BaseLayerWithLoRA
@@ -146,6 +149,13 @@ class VllmModelWrapper:
                               mesh=self.mesh),
             is_jax_function=True,
             needs_env=False,
+        )
+
+        register_torch_dispatch_op(
+            torch.ops.vllm.torch_sdpa_wrapper,
+            functools.partial(
+                patch_ops.scaled_dot_product_attention.vllm_vit_sdpa, mesh=self.mesh
+            )
         )
 
     def _apply_pp_patch(self):

--- a/tpu_inference/models/vllm/vllm_model_wrapper.py
+++ b/tpu_inference/models/vllm/vllm_model_wrapper.py
@@ -30,10 +30,8 @@ from flax.typing import PRNGKey
 from jax.sharding import Mesh, NamedSharding, PartitionSpec
 from torchax.interop import jax_view, torch_view
 from torchax.ops.mappings import TORCH_DTYPE_TO_JAX
-from torchax.ops.ops_registry import (
-    register_torch_function_op,
-    register_torch_dispatch_op,
-)
+from torchax.ops.ops_registry import (register_torch_dispatch_op,
+                                      register_torch_function_op)
 from vllm.config import VllmConfig, set_current_vllm_config
 from vllm.forward_context import set_forward_context
 from vllm.lora.layers import BaseLayerWithLoRA
@@ -154,9 +152,8 @@ class VllmModelWrapper:
         register_torch_dispatch_op(
             torch.ops.vllm.torch_sdpa_wrapper,
             functools.partial(
-                patch_ops.scaled_dot_product_attention.vllm_vit_sdpa, mesh=self.mesh
-            )
-        )
+                patch_ops.scaled_dot_product_attention.vllm_vit_sdpa,
+                mesh=self.mesh))
 
     def _apply_pp_patch(self):
         # patch `get_pp_group` in vLLM to jax's get_pp_group.


### PR DESCRIPTION
# Description

This PR implements the vllm_vit_sdpa function in scaled_dot_product_attention.py. This provides a custom JAX implementation of vLLM Scaled Dot Product Attention (SDPA) specifically for ViTs. `register_torchax_dispatch_op` intercepts the vLLM ViT SDPA wrapper and replaces it with custom JAX implementation

FIXES: #1850

# Tests

Manually tested accuracy and run by serving Qwen3-VL model on Torchax

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
