### PR TITLE
[CI] Correct default TPU queue to use v6e instead of v7x for EP and SP tests

### DIFF
--- a/.buildkite/parallelism/EP.yml
+++ b/.buildkite/parallelism/EP.yml
@@ -19,7 +19,7 @@ steps:
     key: "${TPU_VERSION:-tpu6e}_EP_CorrectnessTest_Single_Host"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_MULTI:-tpu_v7x_8_queue}"
+      queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh \
@@ -46,7 +46,7 @@ steps:
     depends_on: "${TPU_VERSION:-tpu6e}_record_EP_CorrectnessTest_Single_Host"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_MULTI:-tpu_v7x_8_queue}"
+      queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh \
@@ -69,7 +69,7 @@ steps:
     key: "${TPU_VERSION:-tpu6e}_EP_CorrectnessTest_Multi_Host"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_MULTI:-tpu_v7x_8_queue}"
+      queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_EP_CorrectnessTest_Multi_Host" "unverified"
@@ -91,7 +91,7 @@ steps:
     depends_on: "${TPU_VERSION:-tpu6e}_record_EP_CorrectnessTest_Multi_Host"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_MULTI:-tpu_v7x_8_queue}"
+      queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_EP_PerformanceTest_Multi_Host" "unverified"

--- a/.buildkite/parallelism/SP.yml
+++ b/.buildkite/parallelism/SP.yml
@@ -19,7 +19,7 @@ steps:
     key: "${TPU_VERSION:-tpu6e}_SP_CorrectnessTest_Single_Host"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_MULTI:-tpu_v7x_8_queue}"
+      queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh \
@@ -65,7 +65,7 @@ steps:
     key: "${TPU_VERSION:-tpu6e}_SP_CorrectnessTest_Multi_Host"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_MULTI:-tpu_v7x_8_queue}"
+      queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_SP_CorrectnessTest_Multi_Host" "unverified"


### PR DESCRIPTION
# Description

[CI] Correct default TPU queue to use v6e instead of v7x for EP and SP tests

# Tests

[Buildkite](https://buildkite.com/tpu-commons/tpu-inference-ci/builds/14696/canvas)

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
