### PR TITLE
Increase PP e2e timeout

### DIFF
--- a/tests/e2e/test_data_parallel.py
+++ b/tests/e2e/test_data_parallel.py
@@ -99,7 +99,7 @@ def _run_inference(
     elapsed_time = time.time() - start_time
 
     del llm
-    time.sleep(10)
+    time.sleep(15)
     return outputs, elapsed_time
 
 

--- a/tests/e2e/test_pipeline_parallel.py
+++ b/tests/e2e/test_pipeline_parallel.py
@@ -74,7 +74,7 @@ def _run_inference_with_config(model_name: str,
     finally:
         del llm
         # Wait for TPUs to be released
-        time.sleep(5)
+        time.sleep(15)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# Description

Fixing flaky errors

```
(Worker pid=6625) ERROR 04-15 07:27:42 [multiproc_executor.py:871] RuntimeError: Unable to initialize backend 'tpu': FAILED_PRECONDITION: TPU initialization failed: open(/dev/vfio/0): Device or resource busy: Device or resource busy; Couldn't open iommu group /dev/vfio/0 (set JAX_PLATFORMS='' to automatically choose an available backend)
```

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
