### PR TITLE
[CI] Re-enable BK validation after upstream fix

### DIFF
--- a/.buildkite/scripts/bootstrap.sh
+++ b/.buildkite/scripts/bootstrap.sh
@@ -60,9 +60,14 @@ if [ "$BUILDKITE_PULL_REQUEST" != "false" ]; then
     else
       echo "Code files changed. Proceeding with pipeline upload."
     fi
-    # TODO(#2066): Temporarily disabled static pipeline validation due to upstream schema breakage.
-    # Re-evaluate restoring the validation once Buildkite supports dynamic interpolation in strict mode.
-    echo "Skipping static yaml validation to allow dynamic variables."
+    
+    # Validate modified YAML pipelines using bk pipeline validate
+    if .buildkite/scripts/validate_all_pipelines.sh "$NON_SKIPPABLE_FILES"; then
+      echo "All pipelines syntax are valid. Proceeding with pipeline upload."
+    else
+      echo "Some pipelines syntax are invalid. Failing build."
+      exit 1
+    fi
 else
     echo "Non-PR build. Bypassing file change check."
     FILES_CHANGED=$(git diff-tree --no-commit-id --name-only -r -m "$BUILDKITE_COMMIT")


### PR DESCRIPTION
# Description

Re-incorporates bk pipeline validate now that the upstream schema issue is resolved (see: [buildkite/pipeline-schema#157](https://github.com/buildkite/pipeline-schema/pull/157)).

Fixes #2066 

# Tests

[BuildKite](https://buildkite.com/tpu-commons/tpu-inference-ci/builds/14672#019d93d8-ce07-40e9-9eff-004eb39ba1ab)

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
