### PR TITLE
fix: correct output sharding spec order in MLA attention

### DIFF
--- a/tpu_inference/layers/common/attention_interface.py
+++ b/tpu_inference/layers/common/attention_interface.py
@@ -513,9 +513,9 @@ def mla_attention(
         P(ShardingAxisName.ATTN_DATA),  # md.distribution
     )
     out_specs = (
+        P(ShardingAxisName.MLP_TENSOR),  # kv cache
         attn_o_tnh_sharding
-        or P(ShardingAxisName.MLP_TENSOR, None, None),  # attn output
-        P(ShardingAxisName.MLP_TENSOR)  # kv cache
+        or P(ShardingAxisName.MLP_TENSOR, None, None)  # attn output
     )
 
     def _mla_ragged_paged_attention(q, q_rope, k, k_rope, cache, *args):


### PR DESCRIPTION
# Description
In `tpu_inference/layers/common/attention_interface.py`, corrected the output sharding spec order in `_mla_ragged_paged_attention` to match the return order.

This resolves the `IndivisibleError` caused by `jax.shard_map` applying the attention output sharding spec to the KV cache.

# Tests
I have run the model locally/on TPU instances to ensure the `IndivisibleError` is no longer raised during MLA attention execution. The automated CI pipeline will also verify the e2e correctness.

# Checklist
Before submitting this PR, please make sure:
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have made or will make corresponding changes to any relevant documentation.