### PR TITLE
fix: handle non-addressable devices in hbm_usage_bytes for multi-host TPU

### DIFF
--- a/tpu_inference/utils.py
+++ b/tpu_inference/utils.py
@@ -145,10 +145,18 @@ def hbm_usage_bytes(devices: Any) -> List[Tuple[int, int]]:
                     "Failed to get memory stats for device %s: %s. ", device,
                     e)
     else:
+        # On multi-host TPU pods, only addressable (local) devices support
+        # memory_stats(). Query local devices and assume remote devices
+        # have similar memory usage, matching the Ray backend behavior.
+        current_process = jax.process_index()
         for device in devices:
+            if device.process_index != current_process:
+                continue
             hbm_used = device.memory_stats()["bytes_in_use"]
             hbm_limit = device.memory_stats()["bytes_limit"]
             usage.append((hbm_used, hbm_limit))
+        if usage and len(usage) < len(list(devices)):
+            usage = [usage[0]] * len(list(devices))
 
     return usage
 


### PR DESCRIPTION
## Summary

Fix `hbm_usage_bytes()` crash on multi-host TPU pods (e.g., v6e-16) where `device.memory_stats()` fails on non-addressable remote devices.

## Problem

On multi-host TPU pods, the JAX mesh includes devices across all hosts, but only local (addressable) devices support `memory_stats()`. The current `else` branch in `hbm_usage_bytes()` iterates over ALL devices, causing:

```
jax.errors.JaxRuntimeError: INVALID_ARGUMENT: MemoryStats is only supported for addressable PjRt devices.
```

This prevents vLLM from running on any multi-host TPU configuration (v6e-16, v6e-32, etc.) without the Ray backend.

## Fix

Filter for local devices using `device.process_index == jax.process_index()` and assume remote devices have similar memory usage — matching the existing `ray` backend behavior.

## Test Environment

- TPU: v6e-16 (4x4 topology, 4 hosts × 4 chips = 16 chips)
- Model: google/gemma-4-31B-it
- Config: tensor-parallel-size=16, max-model-len=131072 (128K)
- Docker: vllm/vllm-tpu:gemma4 (vLLM 0.17.2)

Before fix: crash at worker init
After fix: successful init, model serving with 128K context across all 16 chips

## Changes

- `tpu_inference/utils.py`: Modified `hbm_usage_bytes()` else branch to skip non-addressable devices

🤖 Generated with [Claude Code](https://claude.com/claude-code)