### PR TITLE
[Jax][MoE] Sharding fix in UnquantizedFusedMoEMethod for Jax native

### DIFF
--- a/tests/models/jax/test_qwen3_moe.py
+++ b/tests/models/jax/test_qwen3_moe.py
@@ -31,14 +31,16 @@ from tpu_inference.models.jax.qwen3_moe import Qwen3MoeForCausalLM
 
 class TestQwen3MoeForCausalLM:
 
-    @pytest.mark.parametrize("model_name", [
-        "Qwen/Qwen3-30B-A3B-Instruct-2507",
-        "Qwen/Qwen3-30B-A3B-Instruct-2507-FP8",
+    @pytest.mark.parametrize("model_name,pp_rank,pp_world_size,load_format", [
+        (model, rank, world, fmt)
+        for model in [
+            "Qwen/Qwen3-30B-A3B-Instruct-2507",
+            "Qwen/Qwen3-30B-A3B-Instruct-2507-FP8",
+        ]
+        for rank, world in [(0, 1), (0, 4), (1, 4), (3, 4)]
+        for fmt in ["skip_layers_model_loader_for_test", "jax_dummy"]
+        if not (world == 1 and fmt == "jax_dummy")
     ])
-    @pytest.mark.parametrize("pp_rank,pp_world_size", [(0, 1), (0, 4), (1, 4),
-                                                       (3, 4)])
-    @pytest.mark.parametrize(
-        "load_format", ["skip_layers_model_loader_for_test", "jax_dummy"])
     def test_model_loading(
             self,
             model_name,

--- a/tests/models/jax/test_qwen3_moe.py
+++ b/tests/models/jax/test_qwen3_moe.py
@@ -31,16 +31,14 @@ from tpu_inference.models.jax.qwen3_moe import Qwen3MoeForCausalLM
 
 class TestQwen3MoeForCausalLM:
 
-    @pytest.mark.parametrize("model_name,pp_rank,pp_world_size,load_format", [
-        (model, rank, world, fmt)
-        for model in [
+    @pytest.mark.parametrize(
+        "model_name,pp_rank,pp_world_size,load_format",
+        [(model, rank, world, fmt) for model in [
             "Qwen/Qwen3-30B-A3B-Instruct-2507",
             "Qwen/Qwen3-30B-A3B-Instruct-2507-FP8",
-        ]
-        for rank, world in [(0, 1), (0, 4), (1, 4), (3, 4)]
-        for fmt in ["skip_layers_model_loader_for_test", "jax_dummy"]
-        if not (world == 1 and fmt == "jax_dummy")
-    ])
+        ] for rank, world in [(0, 1), (0, 4), (1, 4), (3, 4)]
+         for fmt in ["skip_layers_model_loader_for_test", "jax_dummy"]
+         if not (world == 1 and fmt == "jax_dummy")])
     def test_model_loading(
             self,
             model_name,

--- a/tpu_inference/layers/jax/quantization/unquantized.py
+++ b/tpu_inference/layers/jax/quantization/unquantized.py
@@ -129,15 +129,6 @@ class UnquantizedFusedMoEMethod(QuantizeMethodBase):
             w13_val = jnp.concatenate([w_gate, w_up], axis=1)
             del w_gate, w_up
 
-            # --- NEW DEBUG PRINTS: BEFORE JIT ---
-            print("\n[DEBUG] Before jax_common.process_unquantized_moe_weights:")
-            for name, w in [("w13_val", w13_val), ("w2_val", w2_val)]:
-                sharding_info = getattr(w, 'sharding', 'NO_SHARDING_INFO')
-                byte_size_mb = (w.nbytes / (1024 * 1024)) if hasattr(w, 'nbytes') else 'UNKNOWN'
-                print(f"  -> {name} | Shape: {w.shape} | Dtype: {w.dtype} | Size: {byte_size_mb} MB | Sharding: {sharding_info}")
-            print("-" * 50)
-            # ------------------------------------
-
             weights = jax_common.process_unquantized_moe_weights(
                 mesh=jax.sharding.get_mesh(),
                 moe_backend=layer.moe_backend,
@@ -148,23 +139,11 @@ class UnquantizedFusedMoEMethod(QuantizeMethodBase):
                 w2_bias=None,
             )
 
-            # --- NEW DEBUG PRINTS: AFTER JIT ---
-            print("\n[DEBUG] After jax_common.process_unquantized_moe_weights:")
-            # Use dataclass/NamedTuple attribute access depending on FusedMoEWeights implementation
-            for name, w in [("w13_weight", getattr(weights, 'w13_weight', None)), 
-                            ("w2_weight", getattr(weights, 'w2_weight', None))]:
-                if w is not None:
-                    sharding_info = getattr(w, 'sharding', 'NO_SHARDING_INFO')
-                    byte_size_mb = (w.nbytes / (1024 * 1024)) if hasattr(w, 'nbytes') else 'UNKNOWN'
-                    print(f"  -> {name} | Shape: {w.shape} | Dtype: {w.dtype} | Size: {byte_size_mb} MB | Sharding: {sharding_info}")
-            print("-" * 50 + "\n")
-            # -----------------------------------
-
             # TODO (jacobplatin): we probably want to make the sharding configurable
             # layer.kernel_gating_upproj_EDF = nnx.Param(weights.w13_weight)
             # layer.kernel_down_proj_EFD = nnx.Param(weights.w2_weight)
 
-            # --- MANUALLY CONSTRUCT PARTITION SPECS ---
+
             if layer.moe_backend == MoEBackend.GMM_EP:
                 # Expert Parallelism: Shard the Experts (0th dimension)
                 edf_spec = P('model', None, None)
@@ -176,14 +155,8 @@ class UnquantizedFusedMoEMethod(QuantizeMethodBase):
                 edf_spec = P(None, None, 'model')
                 efd_spec = P(None, 'model', None)
 
-            print(f"\n[DEBUG] Forcing Sharding Specs | w13: {edf_spec} | w2: {efd_spec}")
-
-            # Apply the explicit sharding
             sharded_w13 = shard_put(weights.w13_weight, shardings=edf_spec)
             sharded_w2 = shard_put(weights.w2_weight, shardings=efd_spec)
-            
-            print(f"[DEBUG] After shard_put | w13: {getattr(sharded_w13, 'sharding', 'UNKNOWN')}")
-            print("-" * 50 + "\n")
 
             layer.kernel_gating_upproj_EDF = nnx.Param(sharded_w13)
             layer.kernel_down_proj_EFD = nnx.Param(sharded_w2)

--- a/tpu_inference/layers/jax/quantization/unquantized.py
+++ b/tpu_inference/layers/jax/quantization/unquantized.py
@@ -129,6 +129,15 @@ class UnquantizedFusedMoEMethod(QuantizeMethodBase):
             w13_val = jnp.concatenate([w_gate, w_up], axis=1)
             del w_gate, w_up
 
+            # --- NEW DEBUG PRINTS: BEFORE JIT ---
+            print("\n[DEBUG] Before jax_common.process_unquantized_moe_weights:")
+            for name, w in [("w13_val", w13_val), ("w2_val", w2_val)]:
+                sharding_info = getattr(w, 'sharding', 'NO_SHARDING_INFO')
+                byte_size_mb = (w.nbytes / (1024 * 1024)) if hasattr(w, 'nbytes') else 'UNKNOWN'
+                print(f"  -> {name} | Shape: {w.shape} | Dtype: {w.dtype} | Size: {byte_size_mb} MB | Sharding: {sharding_info}")
+            print("-" * 50)
+            # ------------------------------------
+
             weights = jax_common.process_unquantized_moe_weights(
                 mesh=jax.sharding.get_mesh(),
                 moe_backend=layer.moe_backend,
@@ -139,10 +148,48 @@ class UnquantizedFusedMoEMethod(QuantizeMethodBase):
                 w2_bias=None,
             )
 
-            # TODO (jacobplatin): we probably want to make the sharding configurable
-            layer.kernel_gating_upproj_EDF = nnx.Param(weights.w13_weight)
-            layer.kernel_down_proj_EFD = nnx.Param(weights.w2_weight)
+            # --- NEW DEBUG PRINTS: AFTER JIT ---
+            print("\n[DEBUG] After jax_common.process_unquantized_moe_weights:")
+            # Use dataclass/NamedTuple attribute access depending on FusedMoEWeights implementation
+            for name, w in [("w13_weight", getattr(weights, 'w13_weight', None)), 
+                            ("w2_weight", getattr(weights, 'w2_weight', None))]:
+                if w is not None:
+                    sharding_info = getattr(w, 'sharding', 'NO_SHARDING_INFO')
+                    byte_size_mb = (w.nbytes / (1024 * 1024)) if hasattr(w, 'nbytes') else 'UNKNOWN'
+                    print(f"  -> {name} | Shape: {w.shape} | Dtype: {w.dtype} | Size: {byte_size_mb} MB | Sharding: {sharding_info}")
+            print("-" * 50 + "\n")
+            # -----------------------------------
 
+            # TODO (jacobplatin): we probably want to make the sharding configurable
+            # layer.kernel_gating_upproj_EDF = nnx.Param(weights.w13_weight)
+            # layer.kernel_down_proj_EFD = nnx.Param(weights.w2_weight)
+
+            # --- MANUALLY CONSTRUCT PARTITION SPECS ---
+            if layer.moe_backend == MoEBackend.GMM_EP:
+                # Expert Parallelism: Shard the Experts (0th dimension)
+                edf_spec = P('model', None, None)
+                efd_spec = P('model', None, None)
+            else:
+                # Tensor Parallelism (GMM_TP): Shard the intermediate dimension
+                # w13 shape is (E, D, F) -> shard F (axis 2)
+                # w2 shape is (E, F, D) -> shard F (axis 1)
+                edf_spec = P(None, None, 'model')
+                efd_spec = P(None, 'model', None)
+
+            print(f"\n[DEBUG] Forcing Sharding Specs | w13: {edf_spec} | w2: {efd_spec}")
+
+            # Apply the explicit sharding
+            sharded_w13 = shard_put(weights.w13_weight, shardings=edf_spec)
+            sharded_w2 = shard_put(weights.w2_weight, shardings=efd_spec)
+            
+            print(f"[DEBUG] After shard_put | w13: {getattr(sharded_w13, 'sharding', 'UNKNOWN')}")
+            print("-" * 50 + "\n")
+
+            layer.kernel_gating_upproj_EDF = nnx.Param(sharded_w13)
+            layer.kernel_down_proj_EFD = nnx.Param(sharded_w2)
+            
+            del sharded_w13
+            del sharded_w2
             del weights
             del w13_val
             del w2_val

--- a/tpu_inference/layers/jax/quantization/unquantized.py
+++ b/tpu_inference/layers/jax/quantization/unquantized.py
@@ -23,7 +23,7 @@ from jax.sharding import PartitionSpec as P
 
 from tpu_inference.layers.common.moe import MoEBackend, moe_apply
 from tpu_inference.layers.common.process_weights.moe_weights import (
-    FusedMoEWeights, UnfusedMoEWeights)
+    FusedMoEWeights, UnfusedMoEWeights, shard_moe_weights)
 from tpu_inference.layers.common.quantization import unquantized as jax_common
 from tpu_inference.layers.common.quantization.configs import QuantLinearConfig
 from tpu_inference.layers.jax import JaxModule
@@ -139,30 +139,15 @@ class UnquantizedFusedMoEMethod(QuantizeMethodBase):
                 w2_bias=None,
             )
 
-            # TODO (jacobplatin): we probably want to make the sharding configurable
-            # layer.kernel_gating_upproj_EDF = nnx.Param(weights.w13_weight)
-            # layer.kernel_down_proj_EFD = nnx.Param(weights.w2_weight)
+            sharded_weights = shard_moe_weights(
+                weights, 
+                moe_backend=layer.moe_backend, 
+                mesh=jax.sharding.get_mesh()
+            )
 
+            layer.kernel_gating_upproj_EDF = nnx.Param(sharded_weights.w13_weight)
+            layer.kernel_down_proj_EFD = nnx.Param(sharded_weights.w2_weight)
 
-            if layer.moe_backend == MoEBackend.GMM_EP:
-                # Expert Parallelism: Shard the Experts (0th dimension)
-                edf_spec = P('model', None, None)
-                efd_spec = P('model', None, None)
-            else:
-                # Tensor Parallelism (GMM_TP): Shard the intermediate dimension
-                # w13 shape is (E, D, F) -> shard F (axis 2)
-                # w2 shape is (E, F, D) -> shard F (axis 1)
-                edf_spec = P(None, None, 'model')
-                efd_spec = P(None, 'model', None)
-
-            sharded_w13 = shard_put(weights.w13_weight, shardings=edf_spec)
-            sharded_w2 = shard_put(weights.w2_weight, shardings=efd_spec)
-
-            layer.kernel_gating_upproj_EDF = nnx.Param(sharded_w13)
-            layer.kernel_down_proj_EFD = nnx.Param(sharded_w2)
-            
-            del sharded_w13
-            del sharded_w2
             del weights
             del w13_val
             del w2_val

--- a/tpu_inference/layers/jax/quantization/unquantized.py
+++ b/tpu_inference/layers/jax/quantization/unquantized.py
@@ -139,13 +139,12 @@ class UnquantizedFusedMoEMethod(QuantizeMethodBase):
                 w2_bias=None,
             )
 
-            sharded_weights = shard_moe_weights(
-                weights, 
-                moe_backend=layer.moe_backend, 
-                mesh=jax.sharding.get_mesh()
-            )
+            sharded_weights = shard_moe_weights(weights,
+                                                moe_backend=layer.moe_backend,
+                                                mesh=jax.sharding.get_mesh())
 
-            layer.kernel_gating_upproj_EDF = nnx.Param(sharded_weights.w13_weight)
+            layer.kernel_gating_upproj_EDF = nnx.Param(
+                sharded_weights.w13_weight)
             layer.kernel_down_proj_EFD = nnx.Param(sharded_weights.w2_weight)
 
             del weights


### PR DESCRIPTION
# Description

Fixes TPU OOM during MoE weight loading in the JAX native path.
Previously, `process_weights_after_loading` assigned the processed fused weights (w13_weight, w2_weight) directly to nnx.Param without explicit sharding. This caused JAX to replicate  unsharded MoE tensors across every TPU leading to OOM.

### Solution:
We call `shard_moe_weights` after process_unquantized_moe_weights. This distributes the weights across the mesh (using the existing TP partition spec) before creating the Flax parameters. 

# Tests

- Verified the model Qwen3-30B-A3B loads successfully without TPU OOM.
```bash
SKIP_JAX_PRECOMPILE=1 MODEL_IMPL_TYPE=flax_nnx vllm serve "Qwen/Qwen3-30B-A3B"   --tensor-parallel-size 4   --max-model-len 8192 --max-num-batched-tokens 8192   --trust-remote-code   --gpu-memory-utilization 0.85   --port 8000
```

-  Verified the model works correctly by sending requests


# Checklist

- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
