### PR TITLE
[Nightly Test Fix] Fix broken Qwen3.5-397B test

### DIFF
--- a/.buildkite/models/Qwen_Qwen3_5-397B-A17B.yml
+++ b/.buildkite/models/Qwen_Qwen3_5-397B-A17B.yml
@@ -77,12 +77,14 @@ steps:
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
     soft_fail: true
+    # NOTE (jacobplatin): expert parallelism and model loading (as of April 2026) are taking longer than expected, so
+    # I increased the timeout to 52 minutes -- this should be fine since this test is only run nightly though
     commands:
       - |
         if [ "${TPU_VERSION:-tpu6e}" = "tpu6e" ]; then
           buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_Qwen_Qwen3_5-397B-A17B_Benchmark" "not enough HBM"
         else
-          .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/bm_qwen3_coder.sh --model Qwen/Qwen3.5-397B-A17B-FP8 --tp 8 --req_tput_limit 0.04  --output_token_tput_limit 300 --total_token_tput_limit 345 --input_len 1024 --output_len 8192 --use_moe_ep_kernel 0 --limit_mm_per_prompt '{"image": 0, "video": 0}' --block_size 256 --num_prompts 64
+              .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/bm_qwen3_coder.sh --model Qwen/Qwen3.5-397B-A17B-FP8 --tp 8 --req_tput_limit 0.04  --output_token_tput_limit 300 --total_token_tput_limit 345 --input_len 1024 --output_len 8192 --use_moe_ep_kernel 0 --limit_mm_per_prompt '{"image": 0, "video": 0}' --block_size 256 --num_prompts 64 --timeout 52 --gpu-memory-utilization 0.9
         fi
 
   - label: "${TPU_VERSION:-tpu6e} Record performance benchmark result for Qwen/Qwen3.5-397B-A17B-FP8"

--- a/tests/e2e/benchmarking/bm_qwen3_coder.sh
+++ b/tests/e2e/benchmarking/bm_qwen3_coder.sh
@@ -31,10 +31,11 @@ set -ex
 
 
 OPTIONS=""
-LONGOPTS=model:,tp:,req_tput_limit:,output_token_tput_limit:,total_token_tput_limit:,input_len:,output_len:,use_moe_ep_kernel:,limit_mm_per_prompt:,hf_overrides:,block_size:,num_prompts:,num-prompts:,gpu_memory_utilization:,gpu-memory-utilization:
+LONGOPTS=model:,tp:,req_tput_limit:,output_token_tput_limit:,total_token_tput_limit:,input_len:,output_len:,use_moe_ep_kernel:,limit_mm_per_prompt:,hf_overrides:,block_size:,num_prompts:,num-prompts:,gpu_memory_utilization:,gpu-memory-utilization:,timeout:
 
 num_prompts=320
 gpu_memory_utilization=0.95
+timeout_mins=40
 
 # Parse arguments
 if ! PARSED=$(getopt --options="$OPTIONS" --longoptions=$LONGOPTS --name "$0" -- "$@"); then
@@ -94,6 +95,10 @@ while true; do
       ;;
     --gpu_memory_utilization|--gpu-memory-utilization)
       gpu_memory_utilization=$2
+      shift 2
+      ;;
+    --timeout)
+      timeout_mins=$2
       shift 2
       ;;
     --)
@@ -156,13 +161,13 @@ trap cleanup EXIT
 
 # Need to put the nc command in a condition.
 # If we assign it to a variable, the nc command is supposed to fail at first because it takes some time for the server to be ready. But the "set -e" will cause the script to exit immediately so the while loop will not run.
-TIMEOUT_SECONDS=$((40 * 60))  # 40 minutes
+TIMEOUT_SECONDS=$((timeout_mins * 60))
 wait_start_time=$(date +%s)
 while ! nc -zv $DEFAULT_HOST $DEFAULT_PORT; do
   current_time=$(date +%s)
   elapsed=$((current_time - wait_start_time))
   if [ "$elapsed" -ge "$TIMEOUT_SECONDS" ]; then
-    echo "Timeout: Server did not start within 40 minutes."
+    echo "Timeout: Server did not start within ${timeout_mins} minutes."
     exit 1
   fi
   echo "Waiting for the server to start... (${elapsed}s elapsed)"


### PR DESCRIPTION
# Description

In this PR, I add a longer timeout for 397B for the nightly test since recent changes to expert parallelism / model loading (potentially upstream) are causing a bit of a slowdown.

# Tests

Passing build: https://buildkite.com/tpu-commons/tpu-inference-ci/builds/14767#_

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
