### PR TITLE
Change to n-d device buffer

### DIFF
--- a/tests/layers/jax/sample/test_sampling_metadata.py
+++ b/tests/layers/jax/sample/test_sampling_metadata.py
@@ -23,6 +23,31 @@ from jax.sharding import Mesh, NamedSharding, PartitionSpec
 from tpu_inference.layers.jax.sample.sampling_metadata import (
     DEFAULT_SAMPLING_PARAMS, TPUSupportedSamplingMetadata)
 
+
+def _create_sampling_metadata(mesh, mock_batch, padded_num_reqs, dp_size=1):
+    from tpu_inference.utils import DeviceBuffer
+    padded_num_reqs_per_dp_rank = padded_num_reqs // dp_size
+    buffer = DeviceBuffer(leading_shape=(dp_size, ), initial_capacity=1024)
+
+    TPUSupportedSamplingMetadata.add_to_device_buffer(
+        buffer=buffer,
+        input_batch=mock_batch,
+        padded_num_reqs_per_dp_rank=padded_num_reqs_per_dp_rank,
+        dp_size=dp_size)
+
+    blob, metadata_layout = buffer.build()
+    from tpu_inference.utils import device_array
+    sharding = NamedSharding(mesh, PartitionSpec(None, None))
+    blob_jax = device_array(mesh, blob, sharding=sharding)
+    unpacked_metadata = DeviceBuffer.unpack_arrays(blob_jax, metadata_layout)
+
+    return TPUSupportedSamplingMetadata.from_unpacked_blob(
+        mesh=mesh,
+        metadata=unpacked_metadata,
+        input_batch=mock_batch,
+        padded_num_reqs=padded_num_reqs)
+
+
 ## Mocks and Fixtures
 
 
@@ -58,8 +83,9 @@ def test_from_input_batch_all_greedy(mesh: Mesh):
     mock_batch = MockInputBatch(all_greedy=True)
     padded_num_reqs = 4
 
-    metadata = TPUSupportedSamplingMetadata.from_input_batch(
-        mesh=mesh, input_batch=mock_batch, padded_num_reqs=padded_num_reqs)
+    metadata = _create_sampling_metadata(mesh=mesh,
+                                         mock_batch=mock_batch,
+                                         padded_num_reqs=padded_num_reqs)
 
     assert not metadata.do_sampling, "do_sampling should be False for greedy requests"
     assert metadata.temperature is None
@@ -88,8 +114,9 @@ def test_from_input_batch_with_sampling_and_padding(mesh: Mesh):
         top_p_cpu=top_p_tensor,
     )
 
-    metadata = TPUSupportedSamplingMetadata.from_input_batch(
-        mesh=mesh, input_batch=mock_batch, padded_num_reqs=padded_num_reqs)
+    metadata = _create_sampling_metadata(mesh=mesh,
+                                         mock_batch=mock_batch,
+                                         padded_num_reqs=padded_num_reqs)
 
     # 1. Check metadata flags and types
     assert metadata.do_sampling, "do_sampling should be True"
@@ -103,7 +130,7 @@ def test_from_input_batch_with_sampling_and_padding(mesh: Mesh):
     assert metadata.top_p.shape == (padded_num_reqs, )
 
     # 3. Check sharding (should be fully replicated)
-    expected_sharding = NamedSharding(mesh, PartitionSpec(None))
+    expected_sharding = NamedSharding(mesh, PartitionSpec())
     assert metadata.temperature.sharding == expected_sharding
     assert metadata.top_k.sharding == expected_sharding
     assert metadata.top_p.sharding == expected_sharding
@@ -155,8 +182,9 @@ def test_from_input_batch_no_padding_needed(mesh: Mesh):
         top_p_cpu=top_p_tensor,
     )
 
-    metadata = TPUSupportedSamplingMetadata.from_input_batch(
-        mesh=mesh, input_batch=mock_batch, padded_num_reqs=padded_num_reqs)
+    metadata = _create_sampling_metadata(mesh=mesh,
+                                         mock_batch=mock_batch,
+                                         padded_num_reqs=padded_num_reqs)
 
     assert metadata.do_sampling
     # Check that values are identical to the input, since no padding was needed
@@ -204,9 +232,9 @@ def test_from_input_batch_with_logprobs(mesh: Mesh):
     # Case 1: Logprobs are requested
     mock_batch_with_logprobs = MockInputBatch(all_greedy=True,
                                               max_num_logprobs=5)
-    metadata_with = TPUSupportedSamplingMetadata.from_input_batch(
+    metadata_with = _create_sampling_metadata(
         mesh=mesh,
-        input_batch=mock_batch_with_logprobs,
+        mock_batch=mock_batch_with_logprobs,
         padded_num_reqs=4,
     )
     assert metadata_with.logprobs, "logprobs should be True when max_num_logprobs > 0"
@@ -214,9 +242,9 @@ def test_from_input_batch_with_logprobs(mesh: Mesh):
     # Case 2: Logprobs are not requested (max_num_logprobs is 0)
     mock_batch_no_logprobs_zero = MockInputBatch(all_greedy=True,
                                                  max_num_logprobs=0)
-    metadata_without_zero = TPUSupportedSamplingMetadata.from_input_batch(
+    metadata_without_zero = _create_sampling_metadata(
         mesh=mesh,
-        input_batch=mock_batch_no_logprobs_zero,
+        mock_batch=mock_batch_no_logprobs_zero,
         padded_num_reqs=4,
     )
     assert not metadata_without_zero.logprobs, "logprobs should be False when max_num_logprobs is 0"
@@ -224,9 +252,9 @@ def test_from_input_batch_with_logprobs(mesh: Mesh):
     # Case 3: Logprobs are not requested (max_num_logprobs is None)
     mock_batch_no_logprobs_none = MockInputBatch(all_greedy=True,
                                                  max_num_logprobs=None)
-    metadata_without_none = TPUSupportedSamplingMetadata.from_input_batch(
+    metadata_without_none = _create_sampling_metadata(
         mesh=mesh,
-        input_batch=mock_batch_no_logprobs_none,
+        mock_batch=mock_batch_no_logprobs_none,
         padded_num_reqs=4,
     )
     assert not metadata_without_none.logprobs, "logprobs should be False when max_num_logprobs is None"
@@ -247,8 +275,9 @@ def test_from_input_batch_sampling_with_logprobs(mesh: Mesh):
         max_num_logprobs=10,
     )
 
-    metadata = TPUSupportedSamplingMetadata.from_input_batch(
-        mesh=mesh, input_batch=mock_batch, padded_num_reqs=padded_num_reqs)
+    metadata = _create_sampling_metadata(mesh=mesh,
+                                         mock_batch=mock_batch,
+                                         padded_num_reqs=padded_num_reqs)
 
     assert metadata.do_sampling, "do_sampling should be True"
     assert metadata.logprobs, "logprobs should be True"

--- a/tests/runner/test_tpu_runner.py
+++ b/tests/runner/test_tpu_runner.py
@@ -153,6 +153,7 @@ class TestTPUJaxRunner:
         self.runner.input_batch.num_reqs = 1
         self.runner.input_batch.req_ids = ['req1']
         self.runner.input_batch.req_id_to_index = {'req1': 0}
+        self.runner.input_batch.request_distribution = [0, 0, 1]
         self.runner.input_batch.num_computed_tokens_cpu = np.array([10])
         self.runner.input_batch.token_ids_cpu = np.random.randint(
             0, 1000, (8, 64), dtype=np.int32)

--- a/tests/runner/test_tpu_runner_dp.py
+++ b/tests/runner/test_tpu_runner_dp.py
@@ -1317,7 +1317,6 @@ class TestSamplingMetadataPassthrough:
         mock_kv_cache_config = MagicMock()
         mock_kv_cache_config.kv_cache_groups = [MagicMock()]
         runner.kv_cache_config = mock_kv_cache_config
-        runner.data_parallel_attn_sharding = mock_named_sharding.return_value
         runner._prepare_dp_input_metadata = TPUModelRunner._prepare_dp_input_metadata.__get__(
             runner)
         runner._prepare_async_token_substitution_indices_dp = TPUModelRunner._prepare_async_token_substitution_indices_dp.__get__(

--- a/tests/runner/test_tpu_runner_dp.py
+++ b/tests/runner/test_tpu_runner_dp.py
@@ -184,7 +184,7 @@ class TestTPUJaxRunnerDPInputsLightweight:
             num_scheduled_tokens, assigned_dp_ranks)
 
         mock_runner_utils.get_padded_token_len.return_value = 16
-        mock_sampling_metadata.from_input_batch.return_value = MagicMock()
+        mock_sampling_metadata.from_unpacked_blob.return_value = MagicMock()
         self.runner.uses_mrope = True
 
         mock_mesh = MagicMock(spec=Mesh)
@@ -208,7 +208,7 @@ class TestTPUJaxRunnerDPInputsLightweight:
         """Test basic functionality of _prepare_inputs_dp."""
         # Mock utility functions
         mock_runner_utils.get_padded_token_len.return_value = 16
-        mock_sampling_metadata.from_input_batch.return_value = MagicMock()
+        mock_sampling_metadata.from_unpacked_blob.return_value = MagicMock()
         mock_named_sharding.return_value = MagicMock()
 
         # Create test data - only use req1 and req2 to match num_reqs=2
@@ -258,7 +258,7 @@ class TestTPUJaxRunnerDPInputsLightweight:
         """Test basic functionality of _prepare_inputs_dp."""
         # Mock utility functions
         mock_runner_utils.get_padded_token_len.return_value = 16
-        mock_sampling_metadata.from_input_batch.return_value = MagicMock()
+        mock_sampling_metadata.from_unpacked_blob.return_value = MagicMock()
         mock_named_sharding.return_value = MagicMock()
 
         # Create test data - only use req1 and req2 to match num_reqs=2
@@ -508,7 +508,7 @@ class TestTPUJaxRunnerDPInputsLightweight:
 
         mock_runner_utils.get_padded_token_len.side_effect = mock_get_padded_token_len
         mock_sampling_instance = MagicMock()
-        mock_sampling_metadata.from_input_batch.return_value = mock_sampling_instance
+        mock_sampling_metadata.from_unpacked_blob.return_value = mock_sampling_instance
         mock_named_sharding.return_value = MagicMock()
 
         # Setup deterministic test data
@@ -621,7 +621,7 @@ class TestTPUJaxRunnerDPInputsLightweight:
 
         mock_runner_utils.get_padded_token_len.side_effect = mock_get_padded_token_len
         mock_sampling_instance = MagicMock()
-        mock_sampling_metadata.from_input_batch.return_value = mock_sampling_instance
+        mock_sampling_metadata.from_unpacked_blob.return_value = mock_sampling_instance
         mock_named_sharding.return_value = MagicMock()
 
         # Setup test data with all requests on rank 0 (empty rank 1)
@@ -747,7 +747,7 @@ class TestTPUJaxRunnerDPInputsLightweight:
 
         mock_runner_utils.get_padded_token_len.side_effect = mock_get_padded_token_len
         mock_sampling_instance = MagicMock()
-        mock_sampling_metadata.from_input_batch.return_value = mock_sampling_instance
+        mock_sampling_metadata.from_unpacked_blob.return_value = mock_sampling_instance
         mock_named_sharding.return_value = MagicMock()
 
         # Setup test data with decode requests (1 token) and prefill requests (>1 token)
@@ -809,7 +809,7 @@ class TestTPUJaxRunnerDPInputsLightweight:
 
         mock_runner_utils.get_padded_token_len.side_effect = mock_get_padded_token_len
         mock_sampling_instance = MagicMock()
-        mock_sampling_metadata.from_input_batch.return_value = mock_sampling_instance
+        mock_sampling_metadata.from_unpacked_blob.return_value = mock_sampling_instance
         mock_named_sharding.return_value = MagicMock()
 
         # All requests are decode (1 token each)
@@ -1046,7 +1046,7 @@ class TestTPUJaxRunnerDPInputsLightweight:
 
         mock_runner_utils.get_padded_token_len.side_effect = mock_get_padded_token_len
         mock_sampling_instance = MagicMock()
-        mock_sampling_metadata.from_input_batch.return_value = mock_sampling_instance
+        mock_sampling_metadata.from_unpacked_blob.return_value = mock_sampling_instance
         mock_named_sharding.return_value = MagicMock()
 
         # Setup test data
@@ -1119,7 +1119,7 @@ class TestTPUJaxRunnerDPInputsLightweight:
 
         mock_runner_utils.get_padded_token_len.side_effect = mock_get_padded_token_len
         mock_sampling_instance = MagicMock()
-        mock_sampling_metadata.from_input_batch.return_value = mock_sampling_instance
+        mock_sampling_metadata.from_unpacked_blob.return_value = mock_sampling_instance
         mock_named_sharding.return_value = MagicMock()
 
         # Setup test data
@@ -1321,13 +1321,14 @@ class TestSamplingMetadataPassthrough:
         mock_kv_cache_config = MagicMock()
         mock_kv_cache_config.kv_cache_groups = [MagicMock()]
         runner.kv_cache_config = mock_kv_cache_config
+        runner.data_parallel_attn_sharding = MagicMock()
         runner._prepare_dp_input_metadata = TPUModelRunner._prepare_dp_input_metadata.__get__(
             runner)
         runner._prepare_async_token_substitution_indices_dp = TPUModelRunner._prepare_async_token_substitution_indices_dp.__get__(
             runner)
 
         mock_runner_utils.get_padded_token_len.side_effect = lambda paddings, val: 8
-        mock_sampling_metadata.from_input_batch.return_value = MagicMock()
+        mock_sampling_metadata.from_unpacked_blob.return_value = MagicMock()
         mock_named_sharding.return_value = MagicMock()
 
         scheduler_output = MagicMock()
@@ -1340,13 +1341,23 @@ class TestSamplingMetadataPassthrough:
 
         TPUModelRunner._prepare_inputs_dp(runner, scheduler_output)
 
-        # Verify from_input_batch was called exactly once with the ATTN_DATA sharding
-        mock_sampling_metadata.from_input_batch.assert_called_once()
-        sharding_arg = mock_sampling_metadata.from_input_batch.call_args.kwargs.get(
-            'sharding')
-        assert sharding_arg is mock_named_sharding.return_value, (
-            "from_input_batch should receive the data_parallel_attn_sharding instance"
-        )
+        # Verify device_array was called with data_parallel_attn_sharding
+        mock_device_array.assert_called()
+        # Find the call that passes metadata_blob
+        call_args_list = mock_device_array.call_args_list
+        found_call = False
+        for call in call_args_list:
+            args, kwargs = call
+            if len(args) > 1 and isinstance(args[1], tuple) and len(
+                    args[1]) == 2:
+                # Check if it is (request_distribution, metadata_blob)
+                found_call = True
+                sharding_arg = kwargs.get('sharding')
+                assert sharding_arg is mock_named_sharding.return_value, (
+                    "device_array should receive the data_parallel_attn_sharding instance"
+                )
+                break
+        assert found_call, "Should find a call to device_array with metadata_blob"
 
         # Verify NamedSharding was called with ATTN_DATA PartitionSpec.
         call_partition_specs = [
@@ -1394,7 +1405,7 @@ class TestSamplingMetadataPassthrough:
         except Exception:
             pass  # only care that from_input_batch was never called
 
-        mock_sampling_metadata.from_input_batch.assert_not_called()
+        mock_sampling_metadata.from_unpacked_blob.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/tests/runner/test_tpu_runner_dp.py
+++ b/tests/runner/test_tpu_runner_dp.py
@@ -944,10 +944,10 @@ class TestTPUJaxRunnerDPInputsLightweight:
         # Should return input_ids unchanged
         np.testing.assert_array_equal(result, input_ids)
 
-    @patch('tpu_inference.runner.tpu_runner.device_array',
-           side_effect=lambda mesh, tensors, **kwargs: tensors)
+    @patch('tpu_inference.runner.tpu_runner.NamedSharding')
+    @patch('jax.device_put', side_effect=lambda x, *args, **kwargs: x)
     def test_apply_async_token_substitution_with_padding(
-            self, mock_device_array):
+            self, mock_device_put, mock_named_sharding):
         """Test _apply_async_token_substitution with padding."""
 
         # Bind the actual method
@@ -981,12 +981,11 @@ class TestTPUJaxRunnerDPInputsLightweight:
         # Verify input_ids
         np.testing.assert_array_equal(call_args[0], input_ids)
 
-        # Verify padded indices length matches input_ids length
-        assert len(call_args[1]) == len(input_ids)
-        assert len(call_args[2]) == len(input_ids)
+        # Verify combined_indices length matches 2 * input_ids length
+        assert len(call_args[1]) == 2 * len(input_ids)
 
-        # Verify placeholder_num
-        assert call_args[4] == 2  # Number of actual substitutions
+        # Verify placeholder_num (now at index 3)
+        assert call_args[3] == 2  # Number of actual substitutions
 
     def test_prepare_inputs_routing_to_dp(self):
         """Test _prepare_inputs routes to _prepare_inputs_dp when dp_size > 1."""
@@ -1349,8 +1348,7 @@ class TestSamplingMetadataPassthrough:
         for call in call_args_list:
             args, kwargs = call
             sharding_arg = kwargs.get('sharding')
-            if sharding_arg is None and len(args) > 1:
-                sharding_arg = args[1]
+            sharding_arg = args[1]
             if sharding_arg is mock_named_sharding.return_value:
                 found_call = True
                 break

--- a/tests/runner/test_tpu_runner_dp.py
+++ b/tests/runner/test_tpu_runner_dp.py
@@ -1341,23 +1341,20 @@ class TestSamplingMetadataPassthrough:
 
         TPUModelRunner._prepare_inputs_dp(runner, scheduler_output)
 
-        # Verify device_array was called with data_parallel_attn_sharding
-        mock_device_array.assert_called()
-        # Find the call that passes metadata_blob
-        call_args_list = mock_device_array.call_args_list
+        # Verify jax.device_put was called with data_parallel_attn_sharding
+        mock_device_put.assert_called()
+        # Find the call that passes data_parallel_attn_sharding
+        call_args_list = mock_device_put.call_args_list
         found_call = False
         for call in call_args_list:
             args, kwargs = call
-            if len(args) > 1 and isinstance(args[1], tuple) and len(
-                    args[1]) == 2:
-                # Check if it is (request_distribution, metadata_blob)
+            sharding_arg = kwargs.get('sharding')
+            if sharding_arg is None and len(args) > 1:
+                sharding_arg = args[1]
+            if sharding_arg is mock_named_sharding.return_value:
                 found_call = True
-                sharding_arg = kwargs.get('sharding')
-                assert sharding_arg is mock_named_sharding.return_value, (
-                    "device_array should receive the data_parallel_attn_sharding instance"
-                )
                 break
-        assert found_call, "Should find a call to device_array with metadata_blob"
+        assert found_call, "Should find a call to jax.device_put with data_parallel_attn_sharding"
 
         # Verify NamedSharding was called with ATTN_DATA PartitionSpec.
         call_partition_specs = [

--- a/tests/runner/test_tpu_runner_dp.py
+++ b/tests/runner/test_tpu_runner_dp.py
@@ -1286,9 +1286,6 @@ class TestSamplingMetadataPassthrough:
             self, mock_sampling_metadata, mock_device_array, mock_runner_utils,
             mock_named_sharding, mock_device_put):
         """_prepare_inputs_dp() should use ATTN_DATA sharding for TPUSupportedSamplingMetadata."""
-        from jax.sharding import PartitionSpec
-
-        from tpu_inference.layers.common.sharding import ShardingAxisName
 
         runner = MagicMock()
         runner.dp_size = 2
@@ -1320,7 +1317,7 @@ class TestSamplingMetadataPassthrough:
         mock_kv_cache_config = MagicMock()
         mock_kv_cache_config.kv_cache_groups = [MagicMock()]
         runner.kv_cache_config = mock_kv_cache_config
-        runner.data_parallel_attn_sharding = MagicMock()
+        runner.data_parallel_attn_sharding = mock_named_sharding.return_value
         runner._prepare_dp_input_metadata = TPUModelRunner._prepare_dp_input_metadata.__get__(
             runner)
         runner._prepare_async_token_substitution_indices_dp = TPUModelRunner._prepare_async_token_substitution_indices_dp.__get__(
@@ -1328,7 +1325,6 @@ class TestSamplingMetadataPassthrough:
 
         mock_runner_utils.get_padded_token_len.side_effect = lambda paddings, val: 8
         mock_sampling_metadata.from_unpacked_blob.return_value = MagicMock()
-        mock_named_sharding.return_value = MagicMock()
 
         scheduler_output = MagicMock()
         scheduler_output.num_scheduled_tokens = {"req1": 3, "req2": 2}
@@ -1348,20 +1344,12 @@ class TestSamplingMetadataPassthrough:
         for call in call_args_list:
             args, kwargs = call
             sharding_arg = kwargs.get('sharding')
-            sharding_arg = args[1]
+            if sharding_arg is None and len(args) > 1:
+                sharding_arg = args[1]
             if sharding_arg is mock_named_sharding.return_value:
                 found_call = True
                 break
         assert found_call, "Should find a call to jax.device_put with data_parallel_attn_sharding"
-
-        # Verify NamedSharding was called with ATTN_DATA PartitionSpec.
-        call_partition_specs = [
-            call.args[1] for call in mock_named_sharding.call_args_list
-            if len(call.args) > 1
-        ]
-        assert PartitionSpec(
-            ShardingAxisName.ATTN_DATA) in call_partition_specs, (
-                "NamedSharding must be called with ATTN_DATA PartitionSpec")
 
     @patch('tpu_inference.runner.tpu_runner.TPUSupportedSamplingMetadata')
     @patch('tpu_inference.runner.tpu_runner.sample')

--- a/tests/runner/test_tpu_runner_dp.py
+++ b/tests/runner/test_tpu_runner_dp.py
@@ -65,7 +65,9 @@ class TestTPUJaxRunnerDPInputsLightweight:
         self.runner.uses_mrope = False
 
         from tpu_inference.utils import DeviceBuffer
-        self.runner.device_buffer = DeviceBuffer(initial_capacity=1024 * 1024)
+        self.runner.device_buffer = DeviceBuffer(
+            leading_shape=(self.runner.dp_size, ),
+            initial_capacity=1024 * 1024)
 
         # mock kv cache group
         mock_kv_cache_config = MagicMock()
@@ -1307,7 +1309,8 @@ class TestSamplingMetadataPassthrough:
         runner.arange_cpu = np.arange(64, dtype=np.int64)
 
         from tpu_inference.utils import DeviceBuffer
-        runner.device_buffer = DeviceBuffer(initial_capacity=1024 * 1024)
+        runner.device_buffer = DeviceBuffer(leading_shape=(runner.dp_size, ),
+                                            initial_capacity=1024 * 1024)
         runner.num_tokens_paddings_per_dp = [8, 16, 32]
         runner.num_reqs_paddings_per_dp = [4, 8]
         runner.uses_mrope = False

--- a/tpu_inference/layers/jax/sample/sampling_metadata.py
+++ b/tpu_inference/layers/jax/sample/sampling_metadata.py
@@ -14,16 +14,17 @@
 
 import functools
 from dataclasses import dataclass
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:
+    from tpu_inference.utils import DeviceBuffer
 
 import jax
 import jax.numpy as jnp
 import numpy as np
-import torch
 from jax.sharding import Mesh
 
 from tpu_inference.runner.input_batch import InputBatch
-from tpu_inference.utils import device_array
 
 DEFAULT_SAMPLING_PARAMS = dict(
     temperature=-1.0,
@@ -52,54 +53,78 @@ class TPUSupportedSamplingMetadata:
     logprobs: bool = False
 
     @classmethod
-    def from_input_batch(
+    def add_to_device_buffer(
+        cls,
+        buffer: "DeviceBuffer",
+        input_batch: InputBatch,
+        padded_num_reqs_per_dp_rank: int,
+        dp_size: int,
+    ):
+        """Add sampling parameters to the device buffer."""
+        num_reqs = input_batch.num_reqs
+
+        temp_view = buffer.get_view((padded_num_reqs_per_dp_rank, ),
+                                    key="temperature")
+        top_k_view = buffer.get_view((padded_num_reqs_per_dp_rank, ),
+                                     key="top_k")
+        top_p_view = buffer.get_view((padded_num_reqs_per_dp_rank, ),
+                                     key="top_p")
+
+        needs_logprobs = input_batch.max_num_logprobs > 0 if input_batch.max_num_logprobs else False
+        dummy_len = 1 if needs_logprobs else 2
+        dummy_view = buffer.get_view((dummy_len, ),
+                                     key="cache_collision_dummy")
+        dummy_view.fill(0)
+
+        # Fill with defaults first (bitcasted to int32 for floats)
+        default_temp_int = np.array([DEFAULT_SAMPLING_PARAMS["temperature"]],
+                                    dtype=np.float32).view(np.int32)[0]
+        default_top_p_int = np.array([DEFAULT_SAMPLING_PARAMS["top_p"]],
+                                     dtype=np.float32).view(np.int32)[0]
+
+        temp_view.fill(default_temp_int)
+        top_k_view.fill(DEFAULT_SAMPLING_PARAMS["top_k"])
+        top_p_view.fill(default_top_p_int)
+
+        # If not all greedy, copy over actual values directly to the view
+        if input_batch.all_greedy:
+            return
+
+        temp_view.ravel(
+        )[:num_reqs] = input_batch.temperature_cpu[:num_reqs].view(np.int32)
+        top_k_view.ravel()[:num_reqs] = input_batch.top_k_cpu[:num_reqs]
+        top_p_view.ravel()[:num_reqs] = input_batch.top_p_cpu[:num_reqs].view(
+            np.int32)
+
+    @classmethod
+    def from_unpacked_blob(
         cls,
         mesh: Mesh,
+        metadata: dict[str, jax.Array],
         input_batch: InputBatch,
         padded_num_reqs: int,
-        sharding: Optional[jax.sharding.Sharding] = None,
     ) -> "TPUSupportedSamplingMetadata":
+        """Unpack sampling parameters from the metadata blob."""
         needs_logprobs = input_batch.max_num_logprobs > 0 if input_batch.max_num_logprobs else False
-
-        # Use a dummy tensor with a unique shape for each logprobs config.
-        # This avoids persistent cache collisions.
-        dummy_shape = (1 if needs_logprobs else 2, )
-        cache_collision_dummy = np.zeros(dummy_shape, dtype=np.int32)
-        # Use replicated sharding for dummy tensor.
-        cache_collision_dummy = device_array(mesh,
-                                             cache_collision_dummy,
-                                             sharding=None)
+        cache_collision_dummy = metadata["cache_collision_dummy"].ravel()
 
         if input_batch.all_greedy:
             return cls(do_sampling=False,
                        logprobs=needs_logprobs,
                        _cache_collision_dummy=cache_collision_dummy)
-        num_reqs = input_batch.num_reqs
 
-        def fill_slice(cpu_torch_tensor: torch.Tensor,
-                       fill_val: float) -> torch.Tensor:
-            # Pad value is the default one.
-            cpu_torch_tensor[num_reqs:padded_num_reqs] = fill_val
-            return cpu_torch_tensor
+        temp = metadata["temperature"].ravel()
+        top_k = metadata["top_k"].ravel()
+        top_p = metadata["top_p"].ravel()
 
-        temp_tensor = fill_slice(input_batch.temperature_cpu,
-                                 DEFAULT_SAMPLING_PARAMS["temperature"])
-        top_k_tensor = fill_slice(input_batch.top_k_cpu,
-                                  DEFAULT_SAMPLING_PARAMS["top_k"])
-        top_p_tensor = fill_slice(input_batch.top_p_cpu,
-                                  DEFAULT_SAMPLING_PARAMS["top_p"])
+        # Bitcast back to float32 if needed
+        temp = jax.lax.bitcast_convert_type(temp, jnp.float32)
+        top_p = jax.lax.bitcast_convert_type(top_p, jnp.float32)
 
-        # Slice persistent device tensors to a fixed pre-compiled padded shape.
         return cls(
-            temperature=device_array(mesh,
-                                     temp_tensor[:padded_num_reqs],
-                                     sharding=sharding),
-            top_p=device_array(mesh,
-                               top_p_tensor[:padded_num_reqs],
-                               sharding=sharding),
-            top_k=device_array(mesh,
-                               top_k_tensor[:padded_num_reqs],
-                               sharding=sharding),
+            temperature=temp[:padded_num_reqs],
+            top_p=top_p[:padded_num_reqs],
+            top_k=top_k[:padded_num_reqs],
             _cache_collision_dummy=cache_collision_dummy,
             do_sampling=not input_batch.all_greedy,
             logprobs=needs_logprobs,

--- a/tpu_inference/runner/compilation_manager.py
+++ b/tpu_inference/runner/compilation_manager.py
@@ -291,14 +291,16 @@ class CompilationManager:
                 padded_token_in_tpu_cur_input_indices = np.zeros(
                     (num_tokens, ), dtype=np.int32)
                 padded_token_in_tpu_pre_next_tokens_indices = np.zeros(
-                    (num_tokens, ), dtype=jnp.int32)
-                (padded_token_in_tpu_cur_input_indices,
-                 padded_token_in_tpu_pre_next_tokens_indices) = device_array(
-                     self.runner.mesh,
-                     (padded_token_in_tpu_cur_input_indices,
-                      padded_token_in_tpu_pre_next_tokens_indices),
-                     sharding=NamedSharding(self.runner.mesh,
-                                            PartitionSpec(None)))
+                    (num_tokens, ), dtype=np.int32)
+
+                combined_indices = np.concatenate([
+                    padded_token_in_tpu_cur_input_indices,
+                    padded_token_in_tpu_pre_next_tokens_indices
+                ])
+
+                combined_indices = jax.device_put(
+                    combined_indices,
+                    NamedSharding(self.runner.mesh, PartitionSpec()))
 
                 input_ids = self._create_dummy_tensor((num_tokens, ),
                                                       jnp.int32, dp_sharding)
@@ -312,8 +314,7 @@ class CompilationManager:
                     "_substitute_placeholder_token_fn",
                     self.runner._substitute_placeholder_token_fn,
                     input_ids,
-                    padded_token_in_tpu_cur_input_indices,
-                    padded_token_in_tpu_pre_next_tokens_indices,
+                    combined_indices,
                     next_tokens,
                     placeholder_num,
                     num_tokens=num_tokens,

--- a/tpu_inference/runner/compilation_manager.py
+++ b/tpu_inference/runner/compilation_manager.py
@@ -582,12 +582,15 @@ class CompilationManager:
 
                     # Use a dummy tensor with a unique shape for each logprobs config.
                     # This avoids persistent cache collisions.
-                    dummy_shape = (1 if logprobs else 2, )
+                    dummy_len = 1 if logprobs else 2
+                    dummy_shape = (self.runner.dp_size * dummy_len, )
                     _cache_collision_dummy = jnp.zeros(dummy_shape,
                                                        dtype=jnp.int32)
                     _cache_collision_dummy = jax.device_put(
                         _cache_collision_dummy,
-                        NamedSharding(self.runner.mesh, PartitionSpec(None)))
+                        NamedSharding(
+                            self.runner.mesh,
+                            PartitionSpec(ShardingAxisName.ATTN_DATA)))
 
                     sampling_metadata = TPUSupportedSamplingMetadata(
                         temperature=temperature,
@@ -690,12 +693,15 @@ class CompilationManager:
                     # Use a dummy tensor with a unique shape for each logprobs config.
                     # Currently logprobs=False for rejection_sampler.
                     logprobs_dummy = False
-                    dummy_shape = (1 if logprobs_dummy else 2, )
+                    dummy_len = 1 if logprobs_dummy else 2
+                    dummy_shape = (self.runner.dp_size * dummy_len, )
                     _cache_collision_dummy = jnp.zeros(dummy_shape,
                                                        dtype=jnp.int32)
                     _cache_collision_dummy = jax.device_put(
                         _cache_collision_dummy,
-                        NamedSharding(self.runner.mesh, PartitionSpec(None)))
+                        NamedSharding(
+                            self.runner.mesh,
+                            PartitionSpec(ShardingAxisName.ATTN_DATA)))
 
                     if do_sampling:
                         compilation_name = "random_rejection_sampler"

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -495,6 +495,8 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             is_spec_decode=bool(self.vllm_config.speculative_config),
         )
 
+        self.positions_cpu = np.zeros(self.max_num_tokens, dtype=np.int32)
+
         # Range tensor with values [0 .. self.max_num_tokens - 1].
         # Used to initialize positions / context_lens / seq_lens
         # Keep in int64 to avoid overflow with long context
@@ -1358,12 +1360,6 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         seq_lens_view = self.device_buffer.get_view(
             (max_num_reqs_per_dp_rank, ), key="seq_lens")
 
-        if self.uses_mrope:
-            positions_view = self.device_buffer.get_view(
-                (3, padded_num_scheduled_tokens_per_dp_rank), key="positions")
-        else:
-            positions_view = self.device_buffer.get_view(
-                (padded_num_scheduled_tokens_per_dp_rank, ), key="positions")
         use_spec_decode = len(
             scheduler_output.scheduled_spec_decode_tokens) > 0
 
@@ -1407,12 +1403,9 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                 [self.arange_cpu[:n] for n in num_scheduled_tokens_per_req])
 
             # Get positions (1D).
-            if self.uses_mrope:
-                positions_np = positions_view[dp_rank,
-                                              0, :total_num_scheduled_tokens]
-            else:
-                positions_np = positions_view[
-                    dp_rank, :total_num_scheduled_tokens]
+            token_offset = dp_rank * padded_num_scheduled_tokens_per_dp_rank
+            positions_np = self.positions_cpu[token_offset:token_offset +
+                                              total_num_scheduled_tokens]
 
             np.add(
                 self.input_batch.num_computed_tokens_cpu[req_indices],
@@ -1420,8 +1413,9 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                 out=positions_np,
             )
 
-            if not self.uses_mrope:
-                positions_view[dp_rank, total_num_scheduled_tokens:] = 0
+            self.positions_cpu[token_offset +
+                               total_num_scheduled_tokens:token_offset +
+                               padded_num_scheduled_tokens_per_dp_rank] = 0
             # Get token indices.
             # E.g., [0, 1, 0, 1, 2, 3, 4, 0, 1, 2]
             # -> [0, 1, M, M + 1, M + 2, M + 3, M + 4, 2 * M, 2 * M + 1, 2 * M + 2]
@@ -1521,13 +1515,6 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             dp_size,
         )
 
-        # Add positions to buffer
-        if self.uses_mrope:
-            # Reshape and transpose to match (dp_size, 3, tokens_per_dp)
-            positions_view[:] = mrope_positions.reshape(
-                3, dp_size,
-                padded_num_scheduled_tokens_per_dp_rank).transpose(1, 0, 2)
-
         # Collect block tables host arrays loops zone presence zones legality
         def build_block_table_host(kv_cache_gid: int) -> None:
 
@@ -1574,15 +1561,19 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         logits_indices = metadata["logits_indices"].ravel()
         request_distribution = metadata["request_distribution"].ravel()
 
-        # Unpack positions
-        positions = metadata["positions"]
+        # Place positions on device
         if self.uses_mrope:
-            # Transpose back to (3, dp_size, tokens_per_dp) and reshape to (3, total_tokens)
-            positions = positions.reshape(self.dp_size, 3,
-                                          -1).transpose(1, 0,
-                                                        2).reshape(3, -1)
+            mrope_sharding = NamedSharding(
+                self.mesh, PartitionSpec(None, ShardingAxisName.ATTN_DATA))
+            positions = device_array(self.mesh,
+                                     mrope_positions,
+                                     sharding=mrope_sharding)
         else:
-            positions = positions.ravel()
+            positions = device_array(
+                self.mesh,
+                self.positions_cpu[:padded_num_scheduled_tokens_per_dp_rank *
+                                   dp_size],
+                sharding=data_parallel_attn_sharding)
 
         # Unpack sampling metadata
         sampling_metadata = TPUSupportedSamplingMetadata.from_unpacked_blob(
@@ -1720,13 +1711,6 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         seq_lens_view = self.device_buffer.get_view((self.max_num_reqs, ),
                                                     key="seq_lens")
 
-        if self.uses_mrope:
-            positions_view = self.device_buffer.get_view(
-                (3, padded_total_num_scheduled_tokens), key="positions")
-        else:
-            positions_view = self.device_buffer.get_view(
-                (padded_total_num_scheduled_tokens, ), key="positions")
-
         # Get the number of scheduled tokens for each request.
         num_scheduled_tokens_per_req = []
         max_num_scheduled_tokens_all_reqs = 0
@@ -1762,17 +1746,14 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             [self.arange_cpu[:n] for n in num_scheduled_tokens_per_req])
 
         # Get positions (1D).
-        if self.uses_mrope:
-            positions_np = positions_view[0, :total_num_scheduled_tokens]
-        else:
-            positions_np = positions_view[:total_num_scheduled_tokens]
+        positions_np = self.positions_cpu[:total_num_scheduled_tokens]
 
         np.add(self.input_batch.num_computed_tokens_cpu[req_indices],
                arange,
                out=positions_np)
 
-        if not self.uses_mrope:
-            positions_view[total_num_scheduled_tokens:] = 0
+        self.positions_cpu[
+            total_num_scheduled_tokens:padded_total_num_scheduled_tokens] = 0
 
         # Multi-modal support
         # Calculate M-RoPE positions.
@@ -1828,9 +1809,6 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         )
 
         # Add positions to buffer
-        if self.uses_mrope:
-            positions_view[:] = mrope_positions.reshape(
-                3, padded_total_num_scheduled_tokens)
 
         req_dist_view = self.device_buffer.get_view((3, ),
                                                     key="request_distribution")
@@ -1869,12 +1847,18 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         request_distribution = metadata["request_distribution"]
         logits_indices = metadata["logits_indices"]
 
-        # Unpack positions
-        positions = metadata["positions"]
+        # Place positions on device
         if self.uses_mrope:
-            positions = positions.reshape(3, -1)
+            mrope_sharding = NamedSharding(
+                self.mesh, PartitionSpec(None, ShardingAxisName.ATTN_DATA))
+            positions = device_array(self.mesh,
+                                     mrope_positions,
+                                     sharding=mrope_sharding)
         else:
-            positions = positions.ravel()
+            positions = device_array(
+                self.mesh,
+                self.positions_cpu[:padded_total_num_scheduled_tokens],
+                sharding=data_parallel_attn_sharding)
 
         # Unpack sampling metadata
         sampling_metadata = TPUSupportedSamplingMetadata.from_unpacked_blob(

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -166,11 +166,11 @@ class ExecuteModelState:
     padded_num_reqs: Optional[int] = None
 
 
-@jax.jit(donate_argnums=(0, 1, 2))
-def _substitute_placeholder_token(
-        input_ids: jax.Array, token_in_tpu_cur_input_indices: jax.Array,
-        token_in_tpu_pre_next_tokens_indices: jax.Array,
-        next_tokens: jax.Array, placeholder_num: int):
+@jax.jit(donate_argnums=(0, 1))
+def _substitute_placeholder_token(input_ids: jax.Array,
+                                  combined_indices: jax.Array,
+                                  next_tokens: jax.Array,
+                                  placeholder_num: int):
     """Substitute placeholder tokens from TPU for async scheduler
 
     Padding for parallelisation of the substitute_placeholder_token_fn
@@ -182,13 +182,16 @@ def _substitute_placeholder_token(
 
     Args:
         input_ids: possible input_ids size
-        token_in_tpu_cur_input_indices: replace holder idx in input_ids. Length the same to input_ids.
-        token_in_tpu_pre_next_tokens_indices: value idx in next_tokens. Length the same to input_ids.
+        combined_indices: concatenated [cur_input_indices, pre_next_tokens_indices]
         next_tokens: next tokens on the TPU from previous step.
-        placeholder_num: number of placeholders. placeholder_num <= len(token_in_tpu_cur_input_indices)
+        placeholder_num: number of placeholders. placeholder_num <= len(input_ids)
     Return:
         input_ids after replace placeholder tokens
     """
+    num_tokens = input_ids.shape[0]
+    token_in_tpu_cur_input_indices = combined_indices[:num_tokens]
+    token_in_tpu_pre_next_tokens_indices = combined_indices[num_tokens:]
+
     assert input_ids.shape == token_in_tpu_cur_input_indices.shape == token_in_tpu_pre_next_tokens_indices.shape, \
         f"Shape mismatch: input_ids and index arrays must have identical shapes due to precompilation assumptions. " \
         f"Got: {input_ids.shape=}, {token_in_tpu_cur_input_indices.shape=}, {token_in_tpu_pre_next_tokens_indices.shape=}"
@@ -1285,15 +1288,17 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             mode='constant',
             constant_values=-1).astype(np.int32)
 
-        (padded_token_in_tpu_cur_input_indices,
-         padded_token_in_tpu_pre_next_tokens_indices) = device_array(
-             self.mesh, (padded_token_in_tpu_cur_input_indices,
-                         padded_token_in_tpu_pre_next_tokens_indices))
+        combined_indices = np.concatenate([
+            padded_token_in_tpu_cur_input_indices,
+            padded_token_in_tpu_pre_next_tokens_indices
+        ])
+
+        combined_indices = jax.device_put(
+            combined_indices, NamedSharding(self.mesh, PartitionSpec()))
 
         with self.maybe_forbid_compile:
             input_ids = self._substitute_placeholder_token_fn(
-                input_ids, padded_token_in_tpu_cur_input_indices,
-                padded_token_in_tpu_pre_next_tokens_indices,
+                input_ids, combined_indices,
                 self._pre_async_results.next_tokens,
                 jnp.asarray(len(token_in_tpu_cur_input_indices),
                             dtype=jnp.int32))

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -273,8 +273,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
 
         self._init_random()
         self._init_mesh()
-        self.data_parallel_attn_sharding = NamedSharding(
-            self.mesh, PartitionSpec(ShardingAxisName.ATTN_DATA))
+
         self._init_phased_profiling()
         self._init_mm()
         self._init_inputs()
@@ -1323,6 +1322,8 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         assert num_reqs > 0
 
         dp_size = self.dp_size
+        data_parallel_attn_sharding = NamedSharding(
+            self.mesh, PartitionSpec(ShardingAxisName.ATTN_DATA))
 
         (req_ids_dp, req_indices_dp, num_scheduled_tokens_per_dp_rank,
          scheduled_tokens_per_dp_rank, num_req_per_dp_rank,
@@ -1563,7 +1564,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         metadata_blob, metadata_layout = self.device_buffer.build()
 
         dev_arrays_payload = jax.device_put(metadata_blob,
-                                            self.data_parallel_attn_sharding)
+                                            data_parallel_attn_sharding)
 
         metadata = common_utils.DeviceBuffer.unpack_arrays(
             dev_arrays_payload, metadata_layout)
@@ -1671,6 +1672,9 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         assert total_num_scheduled_tokens > 0
         num_reqs = self.input_batch.num_reqs
         assert num_reqs > 0
+
+        data_parallel_attn_sharding = NamedSharding(
+            self.mesh, PartitionSpec(ShardingAxisName.ATTN_DATA))
 
         # Do the padding and copy the tensors to the TPU.
         padded_total_num_scheduled_tokens = runner_utils.get_padded_token_len(
@@ -1855,7 +1859,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         metadata_blob, metadata_layout = self.device_buffer.build()
 
         dev_arrays_payload = jax.device_put(metadata_blob,
-                                            self.data_parallel_attn_sharding)
+                                            data_parallel_attn_sharding)
 
         metadata = common_utils.DeviceBuffer.unpack_arrays(
             dev_arrays_payload, metadata_layout)

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -1476,7 +1476,8 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
 
         mrope_positions = self.mrope_positions_cpu[:, :
                                                    padded_total_num_scheduled_tokens]
-        _request_distribution = []
+        req_dist_view = self.device_buffer.get_view((3, ),
+                                                    key="request_distribution")
         for dp_rank in range(dp_size):
             _num_reqs = num_req_per_dp_rank[dp_rank]
             # The batch has been reordered by _reorder_batch so decode requests come first
@@ -1485,10 +1486,9 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             for req_id in req_ids_dp[dp_rank]:
                 if scheduler_output.num_scheduled_tokens[req_id] == 1:
                     num_decode_in_dp_rank += 1
-            _request_distribution.append(
-                [num_decode_in_dp_rank, num_decode_in_dp_rank, _num_reqs])
-        request_distribution = np.array(_request_distribution,
-                                        dtype=np.int32).ravel()
+            req_dist_view[dp_rank] = [
+                num_decode_in_dp_rank, num_decode_in_dp_rank, _num_reqs
+            ]
 
         use_spec_decode = len(
             scheduler_output.scheduled_spec_decode_tokens) > 0
@@ -1554,9 +1554,8 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
 
         metadata_blob, metadata_layout = self.device_buffer.build()
 
-        (request_distribution, dev_arrays_payload) = device_array(
-            self.mesh, (request_distribution, metadata_blob),
-            sharding=data_parallel_attn_sharding)
+        dev_arrays_payload = jax.device_put(metadata_blob,
+                                            data_parallel_attn_sharding)
 
         metadata = common_utils.DeviceBuffer.unpack_arrays(
             dev_arrays_payload, metadata_layout)
@@ -1564,6 +1563,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         query_start_loc = metadata["query_start_loc"].ravel()
         seq_lens = metadata["seq_lens"].ravel()
         logits_indices = metadata["logits_indices"].ravel()
+        request_distribution = metadata["request_distribution"].ravel()
 
         # Unpack positions
         positions = metadata["positions"]
@@ -1823,7 +1823,9 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             positions_view[:] = mrope_positions.reshape(
                 1, 3, padded_total_num_scheduled_tokens)
 
-        request_distribution = np.array(self.input_batch.request_distribution)
+        req_dist_view = self.device_buffer.get_view((3, ),
+                                                    key="request_distribution")
+        req_dist_view[0] = self.input_batch.request_distribution
 
         def build_block_table_host(kv_cache_gid: int) -> None:
             block_table_obj = self.input_batch.block_table[kv_cache_gid]
@@ -1847,15 +1849,15 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
 
         metadata_blob, metadata_layout = self.device_buffer.build()
 
-        (request_distribution, dev_arrays_payload) = device_array(
-            self.mesh, (request_distribution, metadata_blob),
-            sharding=data_parallel_attn_sharding)
+        dev_arrays_payload = jax.device_put(metadata_blob,
+                                            data_parallel_attn_sharding)
 
         metadata = common_utils.DeviceBuffer.unpack_arrays(
             dev_arrays_payload, metadata_layout)
         input_ids = metadata["input_ids"].ravel()
         query_start_loc = metadata["query_start_loc"].ravel()
         seq_lens = metadata["seq_lens"].ravel()
+        request_distribution = metadata["request_distribution"].ravel()
         logits_indices = metadata["logits_indices"].ravel()
 
         # Unpack positions

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -546,8 +546,10 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         # able to avoid the overhead of multiple device_put operations.
         # Initialize to a constant size, and resize later after kv cache size is
         # known.
-        self.device_buffer = common_utils.DeviceBuffer((self.dp_size, ),
-                                                       initial_capacity=1024)
+        self.device_buffer_leading_shape = (
+            self.dp_size, ) if self.dp_size > 1 else ()
+        self.device_buffer = common_utils.DeviceBuffer(
+            self.device_buffer_leading_shape, initial_capacity=1024)
 
     def load_model(self):
         with set_current_vllm_config(self.vllm_config):
@@ -640,7 +642,8 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                             query_start_loc_size + seq_lens_size +
                             logits_indices_size + block_tables_size)
         self.device_buffer = common_utils.DeviceBuffer(
-            (self.dp_size, ), initial_capacity=initial_capacity)
+            self.device_buffer_leading_shape,
+            initial_capacity=initial_capacity)
 
         if has_kv_transfer_group():
             get_kv_transfer_group().register_runner(self)
@@ -1756,16 +1759,16 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
 
         # Get positions (1D).
         if self.uses_mrope:
-            positions_np = positions_view[0, 0, :total_num_scheduled_tokens]
-        else:
             positions_np = positions_view[0, :total_num_scheduled_tokens]
+        else:
+            positions_np = positions_view[:total_num_scheduled_tokens]
 
         np.add(self.input_batch.num_computed_tokens_cpu[req_indices],
                arange,
                out=positions_np)
 
         if not self.uses_mrope:
-            positions_view[0, total_num_scheduled_tokens:] = 0
+            positions_view[total_num_scheduled_tokens:] = 0
 
         # Multi-modal support
         # Calculate M-RoPE positions.
@@ -1782,19 +1785,19 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
 
         np.take(self.input_batch.token_ids_cpu.ravel(),
                 token_indices,
-                out=input_ids_view[0, :total_num_scheduled_tokens])
-        input_ids_view[0, total_num_scheduled_tokens:] = 0
+                out=input_ids_view[:total_num_scheduled_tokens])
+        input_ids_view[total_num_scheduled_tokens:] = 0
 
         # Prepare the attention metadata.
-        query_start_loc_view[0, 0] = 0
+        query_start_loc_view[0] = 0
         np.cumsum(num_scheduled_tokens_per_req,
-                  out=query_start_loc_view[0, 1:num_reqs + 1])
-        query_start_loc_view[0, num_reqs + 1:] = 1
+                  out=query_start_loc_view[1:num_reqs + 1])
+        query_start_loc_view[num_reqs + 1:] = 1
 
-        seq_lens_view[0, :num_reqs] = (
+        seq_lens_view[:num_reqs] = (
             self.input_batch.num_computed_tokens_cpu[:num_reqs] +
             num_scheduled_tokens_per_req)
-        seq_lens_view[0, num_reqs:] = 0
+        seq_lens_view[num_reqs:] = 0
 
         mrope_positions = self.mrope_positions_cpu[:, :
                                                    padded_total_num_scheduled_tokens]
@@ -1823,11 +1826,11 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         # Add positions to buffer
         if self.uses_mrope:
             positions_view[:] = mrope_positions.reshape(
-                1, 3, padded_total_num_scheduled_tokens)
+                3, padded_total_num_scheduled_tokens)
 
         req_dist_view = self.device_buffer.get_view((3, ),
                                                     key="request_distribution")
-        req_dist_view[0] = self.input_batch.request_distribution
+        req_dist_view[:] = self.input_batch.request_distribution
 
         def build_block_table_host(kv_cache_gid: int) -> None:
             block_table_obj = self.input_batch.block_table[kv_cache_gid]
@@ -1836,8 +1839,8 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                 key=f"block_tables_gid_{kv_cache_gid}")
 
             cpu_tensor = block_table_obj.get_cpu_tensor()
-            np.copyto(block_tables_view[0, :num_reqs], cpu_tensor[:num_reqs])
-            block_tables_view[0, num_reqs:].fill(0)
+            np.copyto(block_tables_view[:num_reqs], cpu_tensor[:num_reqs])
+            block_tables_view[num_reqs:].fill(0)
 
         if len(self.kv_cache_config.kv_cache_groups) <= 1:
             # Pooling model will not using kv cache
@@ -1856,18 +1859,16 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
 
         metadata = common_utils.DeviceBuffer.unpack_arrays(
             dev_arrays_payload, metadata_layout)
-        input_ids = metadata["input_ids"].ravel()
-        query_start_loc = metadata["query_start_loc"].ravel()
-        seq_lens = metadata["seq_lens"].ravel()
-        request_distribution = metadata["request_distribution"].ravel()
-        logits_indices = metadata["logits_indices"].ravel()
+        input_ids = metadata["input_ids"]
+        query_start_loc = metadata["query_start_loc"]
+        seq_lens = metadata["seq_lens"]
+        request_distribution = metadata["request_distribution"]
+        logits_indices = metadata["logits_indices"]
 
         # Unpack positions
         positions = metadata["positions"]
         if self.uses_mrope:
-            positions = positions.reshape(1, 3,
-                                          -1).transpose(1, 0,
-                                                        2).reshape(3, -1)
+            positions = positions.reshape(3, -1)
         else:
             positions = positions.ravel()
 
@@ -1887,9 +1888,8 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                 query_start_loc=query_start_loc,
                 request_distribution=request_distribution)
             # This is for making these cpu buffers hidden during tracing
-            attention_metadata_gid.query_start_loc_cpu = query_start_loc_view.ravel(
-            )
-            attention_metadata_gid.seq_lens_cpu = seq_lens_view.ravel()
+            attention_metadata_gid.query_start_loc_cpu = query_start_loc_view
+            attention_metadata_gid.seq_lens_cpu = seq_lens_view
             return attention_metadata_gid
 
         attention_metadata: AttentionMetadata | dict[str, AttentionMetadata]

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -491,7 +491,6 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             is_spec_decode=bool(self.vllm_config.speculative_config),
         )
 
-        self.positions_cpu = np.zeros(self.max_num_tokens, dtype=np.int32)
         # Range tensor with values [0 .. self.max_num_tokens - 1].
         # Used to initialize positions / context_lens / seq_lens
         # Keep in int64 to avoid overflow with long context
@@ -1349,6 +1348,13 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             (max_num_reqs_per_dp_rank + 1, ), key="query_start_loc")
         seq_lens_view = self.device_buffer.get_view(
             (max_num_reqs_per_dp_rank, ), key="seq_lens")
+
+        if self.uses_mrope:
+            positions_view = self.device_buffer.get_view(
+                (3, padded_num_scheduled_tokens_per_dp_rank), key="positions")
+        else:
+            positions_view = self.device_buffer.get_view(
+                (padded_num_scheduled_tokens_per_dp_rank, ), key="positions")
         use_spec_decode = len(
             scheduler_output.scheduled_spec_decode_tokens) > 0
 
@@ -1380,10 +1386,6 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             total_num_scheduled_tokens = num_scheduled_tokens_per_dp_rank[
                 dp_rank]
             input_ids_cpu = input_ids_view[dp_rank]
-            token_offset = padded_num_scheduled_tokens_per_dp_rank * dp_rank
-            positions_cpu = self.positions_cpu[
-                token_offset:token_offset +
-                padded_num_scheduled_tokens_per_dp_rank]
             # Get request indices.
             # E.g., [2, 5, 3] -> [0, 0, 1, 1, 1, 1, 1, 2, 2, 2]
             # For each scheduled token, what are the corresponding req index.
@@ -1394,13 +1396,23 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             # For each scheduled token, what is its position in corresponding req.
             arange = np.concatenate(
                 [self.arange_cpu[:n] for n in num_scheduled_tokens_per_req])
-            # Get positions.
-            positions_np = positions_cpu[:total_num_scheduled_tokens]
+
+            # Get positions (1D).
+            if self.uses_mrope:
+                positions_np = positions_view[dp_rank,
+                                              0, :total_num_scheduled_tokens]
+            else:
+                positions_np = positions_view[
+                    dp_rank, :total_num_scheduled_tokens]
+
             np.add(
                 self.input_batch.num_computed_tokens_cpu[req_indices],
                 arange,
                 out=positions_np,
             )
+
+            if not self.uses_mrope:
+                positions_view[dp_rank, total_num_scheduled_tokens:] = 0
             # Get token indices.
             # E.g., [0, 1, 0, 1, 2, 3, 4, 0, 1, 2]
             # -> [0, 1, M, M + 1, M + 2, M + 3, M + 4, 2 * M, 2 * M + 1, 2 * M + 2]
@@ -1462,7 +1474,6 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
 
             self.phase_based_profiler.step(batch_composition_stats)
 
-        positions = self.positions_cpu[:padded_total_num_scheduled_tokens]
         mrope_positions = self.mrope_positions_cpu[:, :
                                                    padded_total_num_scheduled_tokens]
         _request_distribution = []
@@ -1493,27 +1504,20 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             logits_indices_view.ravel(
             )[:] = spec_decode_metadata.final_logits_indices.ravel()
 
-        # Put to device
-        sampling_metadata = TPUSupportedSamplingMetadata.from_input_batch(
-            self.mesh,
+        # Add sampling metadata to buffer
+        TPUSupportedSamplingMetadata.add_to_device_buffer(
+            self.device_buffer,
             self.input_batch,
-            padded_num_reqs,
-            sharding=data_parallel_attn_sharding,
+            padded_num_reqs_per_dp_rank,
+            dp_size,
         )
 
+        # Add positions to buffer
         if self.uses_mrope:
-            # M-RoPE positions are of the shape (3, max_num_tokens).
-            # https://github.com/vllm-project/tpu-inference/blob/efc9608acd925bb3b64db6fda509514f799ab7be/tpu_inference/runner/tpu_runner.py#L555
-            # Shard the positions accordingly.
-            mrope_sharding = NamedSharding(
-                self.mesh, PartitionSpec(None, ShardingAxisName.ATTN_DATA))
-            positions = device_array(self.mesh,
-                                     mrope_positions,
-                                     sharding=mrope_sharding)
-        else:
-            positions = device_array(self.mesh,
-                                     positions,
-                                     sharding=data_parallel_attn_sharding)
+            # Reshape and transpose to match (dp_size, 3, tokens_per_dp)
+            positions_view[:] = mrope_positions.reshape(
+                3, dp_size,
+                padded_num_scheduled_tokens_per_dp_rank).transpose(1, 0, 2)
 
         # Collect block tables host arrays loops zone presence zones legality
         def build_block_table_host(kv_cache_gid: int) -> None:
@@ -1560,6 +1564,24 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         query_start_loc = metadata["query_start_loc"].ravel()
         seq_lens = metadata["seq_lens"].ravel()
         logits_indices = metadata["logits_indices"].ravel()
+
+        # Unpack positions
+        positions = metadata["positions"]
+        if self.uses_mrope:
+            # Transpose back to (3, dp_size, tokens_per_dp) and reshape to (3, total_tokens)
+            positions = positions.reshape(self.dp_size, 3,
+                                          -1).transpose(1, 0,
+                                                        2).reshape(3, -1)
+        else:
+            positions = positions.ravel()
+
+        # Unpack sampling metadata
+        sampling_metadata = TPUSupportedSamplingMetadata.from_unpacked_blob(
+            self.mesh,
+            metadata,
+            self.input_batch,
+            padded_num_reqs,
+        )
 
         def build_attn(block_tables: jax.Array | None) -> AttentionMetadata:
             attention_metadata_gid = AttentionMetadata(
@@ -1689,6 +1711,13 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         seq_lens_view = self.device_buffer.get_view((self.max_num_reqs, ),
                                                     key="seq_lens")
 
+        if self.uses_mrope:
+            positions_view = self.device_buffer.get_view(
+                (3, padded_total_num_scheduled_tokens), key="positions")
+        else:
+            positions_view = self.device_buffer.get_view(
+                (padded_total_num_scheduled_tokens, ), key="positions")
+
         # Get the number of scheduled tokens for each request.
         num_scheduled_tokens_per_req = []
         max_num_scheduled_tokens_all_reqs = 0
@@ -1723,11 +1752,18 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         arange = np.concatenate(
             [self.arange_cpu[:n] for n in num_scheduled_tokens_per_req])
 
-        # Get positions.
-        positions_np = self.positions_cpu[:total_num_scheduled_tokens]
+        # Get positions (1D).
+        if self.uses_mrope:
+            positions_np = positions_view[0, 0, :total_num_scheduled_tokens]
+        else:
+            positions_np = positions_view[0, :total_num_scheduled_tokens]
+
         np.add(self.input_batch.num_computed_tokens_cpu[req_indices],
                arange,
                out=positions_np)
+
+        if not self.uses_mrope:
+            positions_view[0, total_num_scheduled_tokens:] = 0
 
         # Multi-modal support
         # Calculate M-RoPE positions.
@@ -1758,7 +1794,6 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             num_scheduled_tokens_per_req)
         seq_lens_view[0, num_reqs:] = 0
 
-        positions = self.positions_cpu[:padded_total_num_scheduled_tokens]
         mrope_positions = self.mrope_positions_cpu[:, :
                                                    padded_total_num_scheduled_tokens]
         use_spec_decode = len(
@@ -1775,27 +1810,18 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             logits_indices_view.ravel(
             )[:] = spec_decode_metadata.final_logits_indices.ravel()
 
-        # Put to device
-        sampling_metadata = TPUSupportedSamplingMetadata.from_input_batch(
-            self.mesh,
+        # Add sampling metadata to buffer
+        TPUSupportedSamplingMetadata.add_to_device_buffer(
+            self.device_buffer,
             self.input_batch,
             padded_num_reqs,
-            sharding=data_parallel_attn_sharding,
+            dp_size=1,
         )
 
+        # Add positions to buffer
         if self.uses_mrope:
-            # M-RoPE positions are of the shape (3, max_num_tokens).
-            # https://github.com/vllm-project/tpu-inference/blob/efc9608acd925bb3b64db6fda509514f799ab7be/tpu_inference/runner/tpu_runner.py#L555
-            # Shard the positions accordingly.
-            mrope_sharding = NamedSharding(
-                self.mesh, PartitionSpec(None, ShardingAxisName.ATTN_DATA))
-            positions = device_array(self.mesh,
-                                     mrope_positions,
-                                     sharding=mrope_sharding)
-        else:
-            positions = device_array(self.mesh,
-                                     positions,
-                                     sharding=data_parallel_attn_sharding)
+            positions_view[:] = mrope_positions.reshape(
+                1, 3, padded_total_num_scheduled_tokens)
 
         request_distribution = np.array(self.input_batch.request_distribution)
 
@@ -1831,6 +1857,23 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         query_start_loc = metadata["query_start_loc"].ravel()
         seq_lens = metadata["seq_lens"].ravel()
         logits_indices = metadata["logits_indices"].ravel()
+
+        # Unpack positions
+        positions = metadata["positions"]
+        if self.uses_mrope:
+            positions = positions.reshape(1, 3,
+                                          -1).transpose(1, 0,
+                                                        2).reshape(3, -1)
+        else:
+            positions = positions.ravel()
+
+        # Unpack sampling metadata
+        sampling_metadata = TPUSupportedSamplingMetadata.from_unpacked_blob(
+            self.mesh,
+            metadata,
+            self.input_batch,
+            padded_num_reqs,
+        )
 
         def build_attn(block_tables: jax.Array | None) -> AttentionMetadata:
             attention_metadata_gid = AttentionMetadata(

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -542,7 +542,8 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         # able to avoid the overhead of multiple device_put operations.
         # Initialize to a constant size, and resize later after kv cache size is
         # known.
-        self.device_buffer = common_utils.DeviceBuffer(initial_capacity=1024)
+        self.device_buffer = common_utils.DeviceBuffer((self.dp_size, ),
+                                                       initial_capacity=1024)
 
     def load_model(self):
         with set_current_vllm_config(self.vllm_config):
@@ -635,7 +636,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                             query_start_loc_size + seq_lens_size +
                             logits_indices_size + block_tables_size)
         self.device_buffer = common_utils.DeviceBuffer(
-            initial_capacity=initial_capacity)
+            (self.dp_size, ), initial_capacity=initial_capacity)
 
         if has_kv_transfer_group():
             get_kv_transfer_group().register_runner(self)
@@ -1343,12 +1344,11 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         self.device_buffer.reset()
 
         input_ids_view = self.device_buffer.get_view(
-            (padded_total_num_scheduled_tokens, ), key="input_ids")
+            (padded_num_scheduled_tokens_per_dp_rank, ), key="input_ids")
         query_start_loc_view = self.device_buffer.get_view(
-            (self.max_num_reqs + dp_size, ), key="query_start_loc")
-        seq_lens_view = self.device_buffer.get_view((self.max_num_reqs, ),
-                                                    key="seq_lens")
-
+            (max_num_reqs_per_dp_rank + 1, ), key="query_start_loc")
+        seq_lens_view = self.device_buffer.get_view(
+            (max_num_reqs_per_dp_rank, ), key="seq_lens")
         use_spec_decode = len(
             scheduler_output.scheduled_spec_decode_tokens) > 0
 
@@ -1367,8 +1367,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                 self.num_logits_paddings, total_sampled_tokens)
             logits_indices_shape = (padded_logits_length, )
         else:
-            logits_indices_shape = (padded_num_reqs, )
-
+            logits_indices_shape = (padded_num_reqs_per_dp_rank, )
         logits_indices_view = self.device_buffer.get_view(logits_indices_shape,
                                                           key="logits_indices")
 
@@ -1376,14 +1375,12 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         for dp_rank in range(dp_size):
             if num_req_per_dp_rank[dp_rank] == 0:
                 continue
-            token_offset = padded_num_scheduled_tokens_per_dp_rank * dp_rank
             num_scheduled_tokens_per_req = scheduled_tokens_per_dp_rank[
                 dp_rank]
             total_num_scheduled_tokens = num_scheduled_tokens_per_dp_rank[
                 dp_rank]
-            input_ids_cpu = input_ids_view[
-                token_offset:token_offset +
-                padded_num_scheduled_tokens_per_dp_rank]
+            input_ids_cpu = input_ids_view[dp_rank]
+            token_offset = padded_num_scheduled_tokens_per_dp_rank * dp_rank
             positions_cpu = self.positions_cpu[
                 token_offset:token_offset +
                 padded_num_scheduled_tokens_per_dp_rank]
@@ -1419,17 +1416,12 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                 token_indices,
                 out=input_ids_cpu[:total_num_scheduled_tokens],
             )
-
             input_ids_cpu[total_num_scheduled_tokens:] = 0
 
         # Prepare the attention metadata (query_start_loc_cpu, seq_lens_cpu)
         for dp_rank in range(dp_size):
-            req_offset = dp_rank * max_num_reqs_per_dp_rank
-            query_start_loc_cpu = query_start_loc_view[
-                req_offset + dp_rank:req_offset + max_num_reqs_per_dp_rank +
-                dp_rank + 1]
-            seq_lens_cpu = seq_lens_view[req_offset:req_offset +
-                                         max_num_reqs_per_dp_rank]
+            query_start_loc_cpu = query_start_loc_view[dp_rank]
+            seq_lens_cpu = seq_lens_view[dp_rank]
             _num_reqs = num_req_per_dp_rank[dp_rank]
             req_indices = req_indices_dp[dp_rank]
             num_scheduled_tokens_per_req = scheduled_tokens_per_dp_rank[
@@ -1456,16 +1448,10 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
 
         # populate logits_indices
         for dp_rank in range(dp_size):
-            req_offset = dp_rank * padded_num_reqs_per_dp_rank
-            query_loc_req_offset = dp_rank * (max_num_reqs_per_dp_rank + 1)
             _num_reqs = num_req_per_dp_rank[dp_rank]
-
-            logits_indices_cpu = logits_indices_view[
-                req_offset:req_offset + padded_num_reqs_per_dp_rank]
+            logits_indices_cpu = logits_indices_view[dp_rank]
             logits_indices_cpu[:_num_reqs] = (
-                query_start_loc_view[query_loc_req_offset +
-                                     1:query_loc_req_offset + _num_reqs + 1] -
-                1)
+                query_start_loc_view[dp_rank, 1:_num_reqs + 1] - 1)
             logits_indices_cpu[_num_reqs:] = -1
 
         # Please see runner_utils.PhasedBasedProfiler for details
@@ -1500,12 +1486,12 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             spec_decode_metadata = (
                 self.speculative_decoding_manager.get_spec_decode_metadata(
                     num_draft_tokens,
-                    query_start_loc_view[1:num_reqs + 1],
+                    query_start_loc_view.ravel()[1:num_reqs + 1],
                     padded_num_reqs,
-                    input_ids_view,
+                    input_ids_view.ravel(),
                 ))
-            logits_indices_view[:] = spec_decode_metadata.final_logits_indices.ravel(
-            )
+            logits_indices_view.ravel(
+            )[:] = spec_decode_metadata.final_logits_indices.ravel()
 
         # Put to device
         sampling_metadata = TPUSupportedSamplingMetadata.from_input_batch(
@@ -1534,7 +1520,8 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
 
             block_table_obj = self.input_batch.block_table[kv_cache_gid]
             block_tables_view = self.device_buffer.get_view(
-                (self.max_num_reqs, block_table_obj.max_num_blocks_per_req),
+                (max_num_reqs_per_dp_rank,
+                 block_table_obj.max_num_blocks_per_req),
                 key=f"block_tables_gid_{kv_cache_gid}")
 
             # Zero out the view once for correct padding
@@ -1546,13 +1533,11 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                 if _num_reqs == 0:
                     continue
 
-                req_offset = dp_rank * max_num_reqs_per_dp_rank
                 # Use np.take with out= to avoid intermediate copies from advanced indexing
                 np.take(cpu_tensor,
                         req_indices_dp[dp_rank],
                         axis=0,
-                        out=block_tables_view[req_offset:req_offset +
-                                              _num_reqs])
+                        out=block_tables_view[dp_rank, :_num_reqs])
 
         if len(self.kv_cache_config.kv_cache_groups) <= 1:
             no_kv_cache = len(self.kv_cache_config.kv_cache_groups) == 0
@@ -1571,10 +1556,10 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
 
         metadata = common_utils.DeviceBuffer.unpack_arrays(
             dev_arrays_payload, metadata_layout)
-        input_ids = metadata["input_ids"]
-        query_start_loc = metadata["query_start_loc"]
-        seq_lens = metadata["seq_lens"]
-        logits_indices = metadata["logits_indices"]
+        input_ids = metadata["input_ids"].ravel()
+        query_start_loc = metadata["query_start_loc"].ravel()
+        seq_lens = metadata["seq_lens"].ravel()
+        logits_indices = metadata["logits_indices"].ravel()
 
         def build_attn(block_tables: jax.Array | None) -> AttentionMetadata:
             attention_metadata_gid = AttentionMetadata(
@@ -1586,8 +1571,9 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             )
 
             # This is for making these cpu buffers hidden during tracing
-            attention_metadata_gid.query_start_loc_cpu = query_start_loc_view
-            attention_metadata_gid.seq_lens_cpu = seq_lens_view
+            attention_metadata_gid.query_start_loc_cpu = query_start_loc_view.ravel(
+            )
+            attention_metadata_gid.seq_lens_cpu = seq_lens_view.ravel()
             return attention_metadata_gid
 
         attention_metadata: AttentionMetadata | dict[str, AttentionMetadata]
@@ -1596,10 +1582,12 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             no_kv_cache = len(self.kv_cache_config.kv_cache_groups) == 0
             block_tables = metadata.get(
                 "block_tables_gid_0") if not no_kv_cache else None
+            if block_tables is not None:
+                block_tables = block_tables.ravel()
             attention_metadata = build_attn(block_tables)
         else:
             attention_metadata = {
-                name: build_attn(metadata[f"block_tables_gid_{gid}"])
+                name: build_attn(metadata[f"block_tables_gid_{gid}"].ravel())
                 for gid, kv_cache_group in enumerate(
                     self.kv_cache_config.kv_cache_groups)
                 for name in kv_cache_group.layer_names
@@ -1754,24 +1742,21 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         token_indices = (positions_np +
                          req_indices * self.input_batch.token_ids_cpu.shape[1])
 
-        # NOTE(woosuk): We use torch.index_select instead of np.take here
-        # because torch.index_select is much faster than np.take for large
-        # tensors.
         np.take(self.input_batch.token_ids_cpu.ravel(),
                 token_indices,
-                out=input_ids_view[:total_num_scheduled_tokens])
-        input_ids_view[total_num_scheduled_tokens:] = 0
+                out=input_ids_view[0, :total_num_scheduled_tokens])
+        input_ids_view[0, total_num_scheduled_tokens:] = 0
 
         # Prepare the attention metadata.
-        query_start_loc_view[0] = 0
+        query_start_loc_view[0, 0] = 0
         np.cumsum(num_scheduled_tokens_per_req,
-                  out=query_start_loc_view[1:num_reqs + 1])
-        query_start_loc_view[num_reqs + 1:] = 1
+                  out=query_start_loc_view[0, 1:num_reqs + 1])
+        query_start_loc_view[0, num_reqs + 1:] = 1
 
-        seq_lens_view[:num_reqs] = (
+        seq_lens_view[0, :num_reqs] = (
             self.input_batch.num_computed_tokens_cpu[:num_reqs] +
             num_scheduled_tokens_per_req)
-        seq_lens_view[num_reqs:] = 0
+        seq_lens_view[0, num_reqs:] = 0
 
         positions = self.positions_cpu[:padded_total_num_scheduled_tokens]
         mrope_positions = self.mrope_positions_cpu[:, :
@@ -1780,15 +1765,17 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             scheduler_output.scheduled_spec_decode_tokens) > 0
         spec_decode_metadata = None
         if not use_spec_decode:
-            logits_indices_view[:padded_num_reqs] = (
-                query_start_loc_view[1:padded_num_reqs + 1] - 1)
+            logits_indices_view.ravel()[:padded_num_reqs] = (
+                query_start_loc_view.ravel()[1:padded_num_reqs + 1] - 1)
         else:
             spec_decode_metadata = self.speculative_decoding_manager.get_spec_decode_metadata(
-                num_draft_tokens, query_start_loc_view[1:num_reqs + 1],
-                padded_num_reqs, input_ids_view)
-            logits_indices_view[:] = spec_decode_metadata.final_logits_indices.ravel(
-            )
+                num_draft_tokens,
+                query_start_loc_view.ravel()[1:num_reqs + 1], padded_num_reqs,
+                input_ids_view.ravel())
+            logits_indices_view.ravel(
+            )[:] = spec_decode_metadata.final_logits_indices.ravel()
 
+        # Put to device
         sampling_metadata = TPUSupportedSamplingMetadata.from_input_batch(
             self.mesh,
             self.input_batch,
@@ -1819,8 +1806,8 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                 key=f"block_tables_gid_{kv_cache_gid}")
 
             cpu_tensor = block_table_obj.get_cpu_tensor()
-            np.copyto(block_tables_view[:num_reqs], cpu_tensor[:num_reqs])
-            block_tables_view[num_reqs:].fill(0)
+            np.copyto(block_tables_view[0, :num_reqs], cpu_tensor[:num_reqs])
+            block_tables_view[0, num_reqs:].fill(0)
 
         if len(self.kv_cache_config.kv_cache_groups) <= 1:
             # Pooling model will not using kv cache
@@ -1840,10 +1827,10 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
 
         metadata = common_utils.DeviceBuffer.unpack_arrays(
             dev_arrays_payload, metadata_layout)
-        input_ids = metadata["input_ids"]
-        query_start_loc = metadata["query_start_loc"]
-        seq_lens = metadata["seq_lens"]
-        logits_indices = metadata["logits_indices"]
+        input_ids = metadata["input_ids"].ravel()
+        query_start_loc = metadata["query_start_loc"].ravel()
+        seq_lens = metadata["seq_lens"].ravel()
+        logits_indices = metadata["logits_indices"].ravel()
 
         def build_attn(block_tables: jax.Array | None) -> AttentionMetadata:
             attention_metadata_gid = AttentionMetadata(
@@ -1853,8 +1840,9 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                 query_start_loc=query_start_loc,
                 request_distribution=request_distribution)
             # This is for making these cpu buffers hidden during tracing
-            attention_metadata_gid.query_start_loc_cpu = query_start_loc_view
-            attention_metadata_gid.seq_lens_cpu = seq_lens_view
+            attention_metadata_gid.query_start_loc_cpu = query_start_loc_view.ravel(
+            )
+            attention_metadata_gid.seq_lens_cpu = seq_lens_view.ravel()
             return attention_metadata_gid
 
         attention_metadata: AttentionMetadata | dict[str, AttentionMetadata]
@@ -1863,10 +1851,12 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             no_kv_cache = len(self.kv_cache_config.kv_cache_groups) == 0
             block_tables = metadata.get(
                 "block_tables_gid_0") if not no_kv_cache else None
+            if block_tables is not None:
+                block_tables = block_tables.ravel()
             attention_metadata = build_attn(block_tables)
         else:
             attention_metadata = {
-                name: build_attn(metadata[f"block_tables_gid_{gid}"])
+                name: build_attn(metadata[f"block_tables_gid_{gid}"].ravel())
                 for gid, kv_cache_group in enumerate(
                     self.kv_cache_config.kv_cache_groups)
                 for name in kv_cache_group.layer_names

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -273,6 +273,8 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
 
         self._init_random()
         self._init_mesh()
+        self.data_parallel_attn_sharding = NamedSharding(
+            self.mesh, PartitionSpec(ShardingAxisName.ATTN_DATA))
         self._init_phased_profiling()
         self._init_mm()
         self._init_inputs()
@@ -1318,8 +1320,6 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         assert num_reqs > 0
 
         dp_size = self.dp_size
-        data_parallel_attn_sharding = NamedSharding(
-            self.mesh, PartitionSpec(ShardingAxisName.ATTN_DATA))
 
         (req_ids_dp, req_indices_dp, num_scheduled_tokens_per_dp_rank,
          scheduled_tokens_per_dp_rank, num_req_per_dp_rank,
@@ -1560,7 +1560,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         metadata_blob, metadata_layout = self.device_buffer.build()
 
         dev_arrays_payload = jax.device_put(metadata_blob,
-                                            data_parallel_attn_sharding)
+                                            self.data_parallel_attn_sharding)
 
         metadata = common_utils.DeviceBuffer.unpack_arrays(
             dev_arrays_payload, metadata_layout)
@@ -1668,9 +1668,6 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         assert total_num_scheduled_tokens > 0
         num_reqs = self.input_batch.num_reqs
         assert num_reqs > 0
-
-        data_parallel_attn_sharding = NamedSharding(
-            self.mesh, PartitionSpec(ShardingAxisName.ATTN_DATA))
 
         # Do the padding and copy the tensors to the TPU.
         padded_total_num_scheduled_tokens = runner_utils.get_padded_token_len(
@@ -1855,7 +1852,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         metadata_blob, metadata_layout = self.device_buffer.build()
 
         dev_arrays_payload = jax.device_put(metadata_blob,
-                                            data_parallel_attn_sharding)
+                                            self.data_parallel_attn_sharding)
 
         metadata = common_utils.DeviceBuffer.unpack_arrays(
             dev_arrays_payload, metadata_layout)

--- a/tpu_inference/utils.py
+++ b/tpu_inference/utils.py
@@ -422,32 +422,39 @@ class DeviceBufferMetadata:
 
 class DeviceBuffer:
     """
-    A utility to pack 1D numpy arrays into a monolithic buffer.
+    A utility to pack numpy arrays into a monolithic buffer.
     Supports appending data or getting views, then tagging the accumulated
-    data with a key. The internal buffer grows dynamically as needed.
+    data with a key. The internal buffer has shape `leading_shape + (capacity,)`
+    and grows dynamically along the last axis.
     """
 
-    def __init__(self, initial_capacity: int = 1024):
-        self.buffer = np.zeros(initial_capacity, dtype=np.int32)
+    def __init__(self,
+                 leading_shape: Tuple[int, ...] = (),
+                 initial_capacity: int = 1024):
+        self.leading_shape = leading_shape
+        self.buffer = np.zeros(leading_shape + (initial_capacity, ),
+                               dtype=np.int32)
         self._offset = 0
         self._last_offset = 0
         self._keys: List[str] = []
         self._sizes: List[int] = []
 
     def _ensure_capacity(self, size: int):
-        """Ensure the internal buffer has enough space for 'size' more elements."""
-        if self._offset + size > self.buffer.size:
-            new_capacity = max(self.buffer.size * 2,
+        """Ensure the internal buffer has enough space for 'size' more elements along the last axis."""
+        if self._offset + size > self.buffer.shape[-1]:
+            new_capacity = max(self.buffer.shape[-1] * 2,
                                self._offset + size + 1024)
-            new_buffer = np.zeros(new_capacity, dtype=np.int32)
-            new_buffer[:self._offset] = self.buffer[:self._offset]
+            new_buffer = np.zeros(self.leading_shape + (new_capacity, ),
+                                  dtype=np.int32)
+            new_buffer[..., :self._offset] = self.buffer[..., :self._offset]
             self.buffer = new_buffer
 
     def append(self, array: np.ndarray, key: Optional[str] = None):
-        """Append data to the buffer and advance offset."""
-        size = array.size
+        """Append data to the buffer along the last axis."""
+        assert array.shape[:-1] == self.leading_shape
+        size = array.shape[-1]
         self._ensure_capacity(size)
-        self.buffer[self._offset:self._offset + size] = array.ravel()
+        self.buffer[..., self._offset:self._offset + size] = array
         self._offset += size
         if key:
             self.set_key(key)
@@ -455,7 +462,9 @@ class DeviceBuffer:
     def get_view(self,
                  shape: Union[int, Tuple[int, ...]],
                  key: Optional[str] = None) -> np.ndarray:
-        """Reserve space in the buffer and return a reshaped view for direct writing."""
+        """Reserve space in the buffer and return a view for direct writing.
+        'shape' is the shape of the reserved space per leading dimension instance.
+        """
         if isinstance(shape, (int, np.integer)):
             size = int(shape)
             shape = (size, )
@@ -463,7 +472,8 @@ class DeviceBuffer:
             size = int(np.prod(shape))
 
         self._ensure_capacity(size)
-        view = self.buffer[self._offset:self._offset + size].reshape(shape)
+        view = self.buffer[..., self._offset:self._offset +
+                           size].reshape(self.leading_shape + shape)
         self._offset += size
         if key:
             self.set_key(key)
@@ -478,7 +488,7 @@ class DeviceBuffer:
 
     def build(self) -> Tuple[np.ndarray, DeviceBufferMetadata]:
         """Return the active portion of the buffer and its layout metadata."""
-        return self.buffer[:self._offset], DeviceBufferMetadata(
+        return self.buffer[..., :self._offset], DeviceBufferMetadata(
             keys=tuple(self._keys), sizes=tuple(self._sizes))
 
     def reset(self):
@@ -493,9 +503,9 @@ class DeviceBuffer:
     def unpack_arrays(blob: jax.Array,
                       metadata: DeviceBufferMetadata) -> Dict[str, jax.Array]:
         """
-        Unpack a 1D blob into a dictionary of arrays based on provided metadata.
-        Uses JIT and jnp.split to minimize dispatch overhead.
+        Unpack a blob into a dictionary of arrays based on provided metadata.
+        Uses JIT and jnp.split along the last axis.
         """
         indices = tuple(np.cumsum(metadata.sizes)[:-1])
-        parts = jnp.split(blob, indices)
+        parts = jnp.split(blob, indices, axis=-1)
         return {key: parts[i] for i, key in enumerate(metadata.keys)}


### PR DESCRIPTION
# Description

Trying to simplify some of the index offset management in tpu runner by changing the buffer's shape to match the sharding that we are aiming for. This allows us to easily append padding mismatched arrays together such as positions and sampling metadata.

# Tests

```
pytest tests/layers/jax/sample/test_sampling_metadata.py tests/runner/test_speculative_decoding_manager.py tests/runner/test_tpu_runner.py tests/runner/test_tpu_runner_dp.py

MODEL_IMPL_TYPE=flax_nnx VLLM_XLA_CHECK_RECOMPILATION=1 SKIP_JAX_PRECOMPILE=0 python examples/offline_inference.py --model Qwen/Qwen2.5-VL-7B-Instruct --max_num_batched_tokens=16384 --max_num_seqs=64 --disable_log_stats --max_model_len=2048 --seed=1234

VLLM_XLA_CHECK_RECOMPILATION=1 pytest tests/e2e/test_data_parallel.py tests/e2e/test_pipeline_parallel.py tests/e2e/test_hybrid_kvcache.py
```

https://xprof.corp.google.com/trace_viewer/piv-8888949095252426210?view_start=22363.251&view_end=22368.342

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
