### PR TITLE
Avoid recurrent_state and conv_state copy to optimize GDN perf

### DIFF
--- a/tpu_inference/layers/common/gdn_attention.py
+++ b/tpu_inference/layers/common/gdn_attention.py
@@ -116,8 +116,8 @@ def run_jax_gdn_attention_local(
         conv_bias,
         query_start_loc,
         state_indices,
-        kernel_size,
         distribution,
+        kernel_size=kernel_size,
     )
 
     out_mixed_qkv = jax.nn.silu(out_mixed_qkv)

--- a/tpu_inference/layers/common/ragged_conv1d_jax.py
+++ b/tpu_inference/layers/common/ragged_conv1d_jax.py
@@ -17,7 +17,8 @@ import jax
 import jax.numpy as jnp
 
 
-@jax.jit(static_argnames=("kernel_size", ), donate_argnames=("conv_state", ))
+# Donate conv_state to avoid "copy" op by XLA
+@jax.jit(donate_argnames=("conv_state", ), static_argnames=("kernel_size", ))
 @jax.named_scope("ragged_conv1d_jax")
 def ragged_conv1d(
     x,

--- a/tpu_inference/layers/common/ragged_conv1d_jax.py
+++ b/tpu_inference/layers/common/ragged_conv1d_jax.py
@@ -13,9 +13,12 @@
 # limitations under the License.
 """Ragged convolution Jax implementation."""
 
+import jax
 import jax.numpy as jnp
 
 
+@jax.jit(static_argnames=("kernel_size", ), donate_argnames=("conv_state", ))
+@jax.named_scope("ragged_conv1d_jax")
 def ragged_conv1d(
     x,
     conv_state,
@@ -23,8 +26,9 @@ def ragged_conv1d(
     conv_bias,
     query_start_loc,
     state_indices,
-    kernel_size,
     distribution,
+    *,
+    kernel_size,
 ):
     """Applies 1D convolution over ragged sequences and updates state.
 

--- a/tpu_inference/layers/common/ragged_gated_delta_rule_chunked.py
+++ b/tpu_inference/layers/common/ragged_gated_delta_rule_chunked.py
@@ -572,6 +572,7 @@ def ragged_gated_delta_rule_decode_only(
     return updated_recurrent_state.astype(recurrent_state.dtype), outputs
 
 
+# Donate conv_state to avoid "copy" op by XLA
 @jax.jit(
     donate_argnames=('recurrent_state', ),
     static_argnames=(

--- a/tpu_inference/layers/common/ragged_gated_delta_rule_chunked.py
+++ b/tpu_inference/layers/common/ragged_gated_delta_rule_chunked.py
@@ -23,14 +23,14 @@ import tpu_inference.kernels.gdn.triangle_solver as triangle_solver
 def l2norm(x: jnp.ndarray, dim: int = -1, eps: float = 1e-6) -> jnp.ndarray:
     """Normalizes x along the specified dimension using L2 norm.
 
-    Args:
-      x: Input array.
-      dim: Dimension along which to normalize.
-      eps: Epsilon value to avoid division by zero.
+  Args:
+    x: Input array.
+    dim: Dimension along which to normalize.
+    eps: Epsilon value to avoid division by zero.
 
-    Returns:
-      Normalized array.
-    """
+  Returns:
+    Normalized array.
+  """
     inv_norm = jax.lax.rsqrt((x * x).sum(axis=dim, keepdims=True) +
                              jnp.array(eps, dtype=x.dtype))
     return x * inv_norm
@@ -572,6 +572,18 @@ def ragged_gated_delta_rule_decode_only(
     return updated_recurrent_state.astype(recurrent_state.dtype), outputs
 
 
+@jax.jit(
+    donate_argnames=('recurrent_state', ),
+    static_argnames=(
+        'n_kq',
+        'n_v',
+        'd_k',
+        'd_v',
+        'chunk_size',
+        'use_qk_norm_in_gdn',
+    ),
+)
+@jax.named_scope("ragged_gated_delta_rule_chunked")
 def ragged_gated_delta_rule(
     mixed_qkv: jnp.ndarray,
     b: jnp.ndarray,


### PR DESCRIPTION
# Description

Avoid recurrent_state and conv_state copy to optimize GDN perf. 

This significant improved E2E decoding performance by about 60% for 1K/8K qwen3.5 case.


# Tests
Tested offline prompts and gives exactly the same output as before.
Benchmarked the performance and no regression on all cases.


# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
