### PR TITLE
[Kernel][Batched RPA] Add prefill optimization and block size heursitic

### DIFF
--- a/tpu_inference/kernels/experimental/batched_rpa/bref_override.py
+++ b/tpu_inference/kernels/experimental/batched_rpa/bref_override.py
@@ -38,8 +38,8 @@ class _BypassRef(pltpu.BufferedRef):
 class KVBufferedRef(_BypassRef):
     """Handles fetching and updating KV cache using precomputed metadata."""
 
-    cfgs: configs.RPAConfig = dataclasses.field(default=None,
-                                                metadata=dict(static=True))
+    cfgs: configs.RpaConfigs = dataclasses.field(default=None,
+                                                 metadata=dict(static=True))
 
     @classmethod
     def create(
@@ -49,7 +49,7 @@ class KVBufferedRef(_BypassRef):
         buffer_type,  # pltpu.BufferType,
         buffer_count: int,
         use_lookahead: bool,
-        cfgs: configs.RPAConfig,
+        cfgs: configs.RpaConfigs,
     ):
         # TODO(kyuyeunk): Uncomment this out after jax version update.
         # assert buffer_type == pltpu.BufferType.INPUT_OUTPUT
@@ -72,7 +72,7 @@ class KVBufferedRef(_BypassRef):
 
     def copy_in(
         self,
-        src_ref: tuple[jax.Ref, jax.Ref, schedule.RPASchedule, jax.Ref],
+        src_ref: tuple[jax.Ref, jax.Ref, schedule.RpaSchedule, jax.Ref],
         grid_indices: tuple[int | jax.Array, ...],
     ):
         # src_ref: (kv_cache_hbm, new_kv_hbm, schedule_ref, page_indices_ref)
@@ -121,7 +121,7 @@ class KVBufferedRef(_BypassRef):
 
     def copy_out(
         self,
-        dst_ref: tuple[jax.Ref, jax.Ref, schedule.RPASchedule, jax.Ref],
+        dst_ref: tuple[jax.Ref, jax.Ref, schedule.RpaSchedule, jax.Ref],
         grid_indices: tuple[int | jax.Array, ...],
     ):
         kv_out_ref, _, schedule_ref, page_indices_ref = dst_ref
@@ -149,7 +149,7 @@ class KVBufferedRef(_BypassRef):
 
     def wait_in(
         self,
-        src_ref: tuple[jax.Ref, jax.Ref, schedule.RPASchedule, jax.Ref],
+        src_ref: tuple[jax.Ref, jax.Ref, schedule.RpaSchedule, jax.Ref],
         grid_indices: tuple[int | jax.Array, ...],
     ):
         _, _, schedule_ref, _ = src_ref
@@ -179,7 +179,7 @@ class KVBufferedRef(_BypassRef):
 
     def wait_out(
         self,
-        dst_ref: tuple[jax.Ref, jax.Ref, schedule.RPASchedule, jax.Ref],
+        dst_ref: tuple[jax.Ref, jax.Ref, schedule.RpaSchedule, jax.Ref],
         grid_indices: tuple[int | jax.Array, ...],
     ):
         kv_out_ref, _, schedule_ref, _ = dst_ref
@@ -209,8 +209,8 @@ class KVBufferedRef(_BypassRef):
 class BatchingORef(pltpu.BufferedRef):
     """Handles normalizing and storing the final attention output."""
 
-    cfgs: configs.RPAConfig = dataclasses.field(default=None,
-                                                metadata=dict(static=True))
+    cfgs: configs.RpaConfigs = dataclasses.field(default=None,
+                                                 metadata=dict(static=True))
 
     @classmethod
     def create(
@@ -220,7 +220,7 @@ class BatchingORef(pltpu.BufferedRef):
         buffer_type,  # pltpu.BufferType,
         buffer_count: int,
         use_lookahead: bool,
-        cfgs: configs.RPAConfig,
+        cfgs: configs.RpaConfigs,
     ):
         # TODO(kyuyeunk): Uncomment this out after jax version update.
         # assert buffer_type == pltpu.BufferType.OUTPUT
@@ -243,7 +243,7 @@ class BatchingORef(pltpu.BufferedRef):
 
     def copy_out(
         self,
-        dst_ref: tuple[jax.Ref, schedule.RPASchedule],
+        dst_ref: tuple[jax.Ref, schedule.RpaSchedule],
         grid_indices: tuple[int | jax.Array, ...],
     ):
         # dst_ref: (o_hbm, schedule_ref)
@@ -271,7 +271,7 @@ class BatchingORef(pltpu.BufferedRef):
 
     def wait_out(
         self,
-        dst_ref: tuple[jax.Ref, schedule.RPASchedule],
+        dst_ref: tuple[jax.Ref, schedule.RpaSchedule],
         grid_indices: tuple[int | jax.Array, ...],
     ):
         # dst_ref: (o_hbm, schedule_ref)
@@ -300,8 +300,8 @@ class BatchingORef(pltpu.BufferedRef):
 class BatchingQRef(pltpu.BufferedRef):
     """Handles fetching Q blocks using precomputed metadata."""
 
-    cfgs: configs.RPAConfig = dataclasses.field(default=None,
-                                                metadata=dict(static=True))
+    cfgs: configs.RpaConfigs = dataclasses.field(default=None,
+                                                 metadata=dict(static=True))
 
     @classmethod
     def create(
@@ -311,7 +311,7 @@ class BatchingQRef(pltpu.BufferedRef):
         buffer_type,  # pltpu.BufferType,
         buffer_count: int,
         use_lookahead: bool,
-        cfgs: configs.RPAConfig,
+        cfgs: configs.RpaConfigs,
     ):
         # TODO(kyuyeunk): Uncomment this out after jax version update.
         # assert buffer_type == pltpu.BufferType.INPUT
@@ -334,7 +334,7 @@ class BatchingQRef(pltpu.BufferedRef):
 
     def copy_in(
         self,
-        src_ref: tuple[jax.Ref, schedule.RPASchedule],
+        src_ref: tuple[jax.Ref, schedule.RpaSchedule],
         grid_indices: tuple[int | jax.Array, ...],
     ):
         # src_ref: (q_hbm, schedule_ref)
@@ -359,7 +359,7 @@ class BatchingQRef(pltpu.BufferedRef):
 
     def wait_in(
         self,
-        src_ref: tuple[jax.Ref, schedule.RPASchedule],
+        src_ref: tuple[jax.Ref, schedule.RpaSchedule],
         grid_indices: tuple[int | jax.Array, ...],
     ):
         _, schedule_ref = src_ref

--- a/tpu_inference/kernels/experimental/batched_rpa/configs.py
+++ b/tpu_inference/kernels/experimental/batched_rpa/configs.py
@@ -27,6 +27,7 @@ class BlockSizes:
     """Tuning parameters for the RPA kernel."""
 
     bq_sz: int
+    bq_c_sz: int
     bkv_sz: int
     batch_size: int
     n_buffer: int
@@ -142,6 +143,10 @@ class RPAConfig:
     @property
     def bq_sz(self) -> int:
         return self.block.bq_sz
+
+    @property
+    def bq_c_sz(self) -> int:
+        return self.block.bq_c_sz
 
     @property
     def bkv_sz(self) -> int:

--- a/tpu_inference/kernels/experimental/batched_rpa/configs.py
+++ b/tpu_inference/kernels/experimental/batched_rpa/configs.py
@@ -17,6 +17,7 @@ import enum
 
 import jax
 import jax.numpy as jnp
+from jax.experimental import pallas as pl
 from jax.experimental.pallas import tpu as pltpu
 
 from tpu_inference.kernels.experimental.batched_rpa import utils
@@ -131,7 +132,7 @@ class RpaCase(enum.StrEnum):
 
 
 @dataclasses.dataclass(frozen=True, eq=True)
-class RPAConfig:
+class RpaConfigs:
     block: BlockSizes
     model: ModelConfigs
     serve: ServingConfigs
@@ -212,7 +213,8 @@ class RPAConfig:
 
     @property
     def bkv_stride(self) -> int:
-        bkv_stride = (self.model.num_kv_heads * 2) // self.serve.packing_kv
+        bkv_stride = pl.cdiv(self.model.num_kv_heads * 2,
+                             self.serve.packing_kv)
 
         if utils.has_bank_conflicts(bkv_stride):
             bkv_stride += 1
@@ -224,9 +226,9 @@ class RPAConfig:
         return utils.align_to(self.model.head_dim, num_lanes)
 
     @property
-    def aligned_num_kv_heads(self) -> int:
+    def aligned_num_kv_heads_x2(self) -> int:
         packing_kv = self.serve.packing_kv
-        return utils.align_to(self.model.num_kv_heads, packing_kv)
+        return utils.align_to(self.model.num_kv_heads * 2, packing_kv)
 
     @property
     def aligned_num_q_heads_per_kv_head(self) -> int:
@@ -242,10 +244,6 @@ class RPAConfig:
     @property
     def fuse_accum(self) -> bool:
         return self.mode == RpaCase.DECODE
-
-    @property
-    def mask_v(self) -> bool:
-        return self.mode != RpaCase.DECODE
 
     @property
     def q_vmem_shape(self):
@@ -288,3 +286,74 @@ class RPAConfig:
             self.block.bq_sz * self.model.num_q_heads_per_kv_head,
             self.model.head_dim,
         )
+
+    def validate_inputs(
+        self,
+        q: jax.Array,
+        k: jax.Array,
+        v: jax.Array,
+        kv_cache: jax.Array,
+        kv_lens: jax.Array,
+        page_indices: jax.Array,
+        cu_q_lens: jax.Array,
+        distribution: jax.Array,
+    ):
+        """Validate inputs to the RPA kernel statically."""
+
+        if not q.ndim == k.ndim == v.ndim == 3:
+            raise ValueError(
+                f"Expected 3D array for {q.shape=}, {k.shape=}, {v.shape=}")
+        if k.shape != v.shape:
+            raise ValueError(f"Expected {k.shape=} to be equal to {v.shape=}")
+        if not (q.shape[0] == k.shape[0] == v.shape[0]):
+            raise ValueError(
+                "Expected number of sequences in Q, K, and V to be the same, but got"
+                f" {q.shape[0]=}, {k.shape[0]=}, and {v.shape[0]=}")
+        if not (q.shape[2] == k.shape[2] == v.shape[2]):
+            raise ValueError(
+                "Expected number of head dimensions in Q, K, and V to be the same,"
+                f" but got {q.shape[2]=}, {k.shape[2]=}, and {v.shape[2]=}")
+
+        expected_kv_cache_shape = (
+            kv_cache.shape[0],
+            self.serve.page_size,
+            self.aligned_num_kv_heads_x2 // self.serve.packing_kv,
+            self.serve.packing_kv,
+            self.aligned_head_dim,
+        )
+
+        if kv_cache.shape != expected_kv_cache_shape:
+            raise ValueError(f"Expected {kv_cache.shape=} to be equal to"
+                             f" {expected_kv_cache_shape=}")
+
+        # Integer kv quantization is currently not supported.
+        if not jnp.issubdtype(kv_cache.dtype, jnp.floating):
+            raise ValueError(
+                f"Expected {kv_cache.dtype=} to be a floating point.")
+        if not (kv_cache.dtype == k.dtype == v.dtype):
+            raise ValueError(
+                "Expected KV cache dtype and K/V dtype to be the same, but got"
+                f" {kv_cache.dtype=}, {k.dtype=}, and {v.dtype=}")
+
+        if not (jnp.int32 == kv_lens.dtype == page_indices.dtype ==
+                cu_q_lens.dtype == distribution.dtype):
+            raise ValueError(
+                f"Expected int32 dtype for {kv_lens.dtype=}, {page_indices.dtype=},"
+                f" {cu_q_lens.dtype=}, {distribution.dtype=}")
+
+        if not (kv_lens.ndim == page_indices.ndim == cu_q_lens.ndim == 1):
+            raise ValueError(
+                f"Expected 1D array for {kv_lens.shape=}, {page_indices.shape=},"
+                f" {cu_q_lens.shape=}")
+
+        max_num_seqs = kv_lens.shape[0]
+        num_page_indices = page_indices.shape[0]
+        if num_page_indices % max_num_seqs != 0:
+            raise ValueError(
+                f"Expected {num_page_indices=} to be divisible by {max_num_seqs=}."
+            )
+        if cu_q_lens.shape != (max_num_seqs + 1, ):
+            raise ValueError(
+                f"Expected {cu_q_lens.shape=} to be ({max_num_seqs + 1},).")
+        if distribution.shape != (3, ):
+            raise ValueError(f"Expected {distribution.shape=} to be (3,).")

--- a/tpu_inference/kernels/experimental/batched_rpa/flash_attention.py
+++ b/tpu_inference/kernels/experimental/batched_rpa/flash_attention.py
@@ -32,6 +32,7 @@ def flash_attention(
     processed_kv_len: list[jax.Array],  # [B]
     effective_kv_len: list[jax.Array],  # [B]
     cfgs: configs.RPAConfig,
+    bq_start: int,
 ):
     """Flash attention kernel."""
     b, k_heads, tq, h = q.shape
@@ -64,7 +65,6 @@ def flash_attention(
         qk = cfgs.model.soft_cap * jnp.tanh(qk / cfgs.model.soft_cap)
 
     qk_masked = []
-    v_masked = []
 
     int_ty = cfgs.serve.int_ty
 
@@ -72,8 +72,8 @@ def flash_attention(
         kv_idx_b = (lax.broadcasted_iota(int_ty, (k_heads, tq, s), 2) +
                     processed_kv_len[b_idx])
         q_idx_b = (lax.broadcasted_iota(jnp.int32, (k_heads, tq, s), 1) //
-                   cfgs.model.num_q_heads_per_kv_head
-                   ).astype(int_ty) + processed_q_len[b_idx]
+                   cfgs.model.num_q_heads_per_kv_head +
+                   bq_start).astype(int_ty) + processed_q_len[b_idx]
 
         eff_kv_len_b = effective_kv_len[b_idx]
         mask_b = q_idx_b < eff_kv_len_b
@@ -83,21 +83,8 @@ def flash_attention(
             mask_b = jnp.logical_and(mask_b, q_idx_b
                                      < kv_idx_b + sliding_window)
 
-        if not cfgs.mask_v:
-            mask_b = jnp.logical_and(mask_b, kv_idx_b < eff_kv_len_b)
-
         qk_masked.append(jnp.where(mask_b, qk[b_idx], cfgs.model.mask_value))
-
-        if cfgs.mask_v:
-            kv_idx_v = (lax.broadcasted_iota(int_ty, (k_heads, s, h), 1) +
-                        processed_kv_len[b_idx])
-            v_mask_b = kv_idx_v < eff_kv_len_b
-            v_masked.append(jnp.where(v_mask_b, v[b_idx], 0))
-        else:
-            v_masked.append(v[b_idx])
-
     qk = jnp.stack(qk_masked, axis=0)
-    v = jnp.stack(v_masked, axis=0)
 
     m_curr = jnp.max(qk, axis=-1, keepdims=True)
     m_next = jnp.maximum(m_prev, m_curr)

--- a/tpu_inference/kernels/experimental/batched_rpa/flash_attention.py
+++ b/tpu_inference/kernels/experimental/batched_rpa/flash_attention.py
@@ -20,22 +20,20 @@ from jax.experimental.pallas import tpu as pltpu
 from tpu_inference.kernels.experimental.batched_rpa import configs, utils
 
 
-def flash_attention(
+def flash_attention_qk_softmax(
     q: jax.Array,  # [B, KV, TQ, H]
     k: jax.Array,  # [B, KV, S, H]
-    v: jax.Array,  # [B, KV, S, H]
-    o_prev: jax.Array,  # [B, KV, TQ, H]
     m_prev: jax.Array,  # [B, KV, TQ, 128]
     l_prev: jax.Array,  # [B, KV, TQ, 128]
     *,
     processed_q_len: list[jax.Array],  # [B]
     processed_kv_len: list[jax.Array],  # [B]
     effective_kv_len: list[jax.Array],  # [B]
-    cfgs: configs.RPAConfig,
+    cfgs: configs.RpaConfigs,
     bq_start: int,
 ):
     """Flash attention kernel."""
-    b, k_heads, tq, h = q.shape
+    b, k_heads, tq, _ = q.shape
     s = k.shape[2]
 
     if cfgs.serve.scale_q is not None:
@@ -89,7 +87,23 @@ def flash_attention(
     m_curr = jnp.max(qk, axis=-1, keepdims=True)
     m_next = jnp.maximum(m_prev, m_curr)
     p = jnp.exp(qk - utils.broadcast_minor(m_next, qk.shape))
+    p_rowsum = jnp.sum(p, axis=-1, keepdims=True, dtype=cfgs.serve.dtype_out)
 
+    alpha = jnp.exp(m_prev - m_next)
+    l_next = alpha * l_prev + p_rowsum
+
+    return p, alpha, m_next, l_next
+
+
+def flash_attention_pv(
+    p: jax.Array,  # [B, KV, TQ, S]
+    v: jax.Array,  # [B, KV, S, H]
+    alpha: jax.Array,  # [B, KV, TQ, 128]
+    o_prev: jax.Array,  # [B, KV, TQ, H]
+    cfgs: configs.RpaConfigs,
+):
+    """Flash attention kernel."""
+    b = p.shape[0]
     pv = lax.dot_general(
         pltpu.einshape("bkts->(bk)ts", p, True),
         pltpu.einshape("bksh->(bk)sh", v, True),
@@ -101,10 +115,6 @@ def flash_attention(
     if cfgs.serve.scale_v is not None:
         pv *= cfgs.serve.scale_v
 
-    p_rowsum = jnp.sum(p, axis=-1, keepdims=True, dtype=cfgs.serve.dtype_out)
-    alpha = jnp.exp(m_prev - m_next)
-    l_next = alpha * l_prev + p_rowsum
-
     o_next = utils.broadcast_minor(alpha, o_prev.shape) * o_prev + pv
 
-    return m_next, l_next, o_next
+    return o_next

--- a/tpu_inference/kernels/experimental/batched_rpa/kernel.py
+++ b/tpu_inference/kernels/experimental/batched_rpa/kernel.py
@@ -215,21 +215,28 @@ def rpa_body(
     l_val = l_scratch_ref[...]
     acc_val = acc_scratch_ref[...]
 
-    m_next, l_next, o_next = flash_attention.flash_attention(
-        q,
-        k,
-        v,
-        acc_val,
-        m_val,
-        l_val,
-        processed_q_len=processed_q_len,
-        processed_kv_len=processed_kv_len,
-        effective_kv_len=effective_kv_len,
-        cfgs=cfgs,
-    )
-    m_scratch_ref[...] = m_next
-    l_scratch_ref[...] = l_next
-    acc_scratch_ref[...] = o_next
+    for bq_start in range(0, cfgs.bq_sz, cfgs.bq_c_sz):
+        bq_end = min(bq_start + cfgs.bq_c_sz, cfgs.bq_sz)
+        q_start = bq_start * cfgs.model.num_q_heads_per_kv_head
+        q_end = bq_end * cfgs.model.num_q_heads_per_kv_head
+        q_slice = slice(q_start, q_end)
+
+        m_next, l_next, o_next = flash_attention.flash_attention(
+            q[:, :, q_slice],
+            k,
+            v,
+            acc_val[:, :, q_slice],
+            m_val[:, :, q_slice],
+            l_val[:, :, q_slice],
+            processed_q_len=processed_q_len,
+            processed_kv_len=processed_kv_len,
+            effective_kv_len=effective_kv_len,
+            cfgs=cfgs,
+            bq_start=bq_start,
+        )
+        m_scratch_ref[:, :, q_slice] = m_next
+        l_scratch_ref[:, :, q_slice] = l_next
+        acc_scratch_ref[:, :, q_slice] = o_next
 
     # Step 4: Write back outputs.
     calculate_and_store_out(

--- a/tpu_inference/kernels/experimental/batched_rpa/kernel.py
+++ b/tpu_inference/kernels/experimental/batched_rpa/kernel.py
@@ -34,7 +34,7 @@ def strided_load_bkv(
     b_idx: int,
     start: int,
     *,
-    cfgs: configs.RPAConfig,
+    cfgs: configs.RpaConfigs,
 ) -> list[tuple[jax.Array, jax.Array]]:
     assert start % cfgs.serve.packing_kv == 0
     start //= cfgs.serve.packing_kv
@@ -69,12 +69,12 @@ def strided_load_bkv(
 
 def calculate_and_store_out(
     step_idx: jax.Array,
-    schedule_ref: schedule.RPASchedule,
+    schedule_ref: schedule.RpaSchedule,
     acc_scratch_ref: jax.Ref,
     l_scratch_ref: jax.Ref,
     o_vref: jax.Ref,
     *,
-    cfgs: configs.RPAConfig,
+    cfgs: configs.RpaConfigs,
 ):
 
     def _accum(b_idx: int):
@@ -115,7 +115,7 @@ def rpa_body(
     # Outputs
     o_vref: jax.Ref,
     # Scratches.
-    schedule_ref: schedule.RPASchedule,
+    schedule_ref: schedule.RpaSchedule,
     m_scratch_ref: jax.Ref,
     l_scratch_ref: jax.Ref,
     acc_scratch_ref: jax.Ref,
@@ -124,7 +124,7 @@ def rpa_body(
     cu_q_lens_ref: jax.Ref,
     kv_lens_ref: jax.Ref,
     # Configs.
-    cfgs: configs.RPAConfig,
+    cfgs: configs.RpaConfigs,
 ):
     step = pl.program_id(0)
 
@@ -215,17 +215,16 @@ def rpa_body(
     l_val = l_scratch_ref[...]
     acc_val = acc_scratch_ref[...]
 
+    prev_p = prev_alpha = prev_q_slice = None
     for bq_start in range(0, cfgs.bq_sz, cfgs.bq_c_sz):
         bq_end = min(bq_start + cfgs.bq_c_sz, cfgs.bq_sz)
         q_start = bq_start * cfgs.model.num_q_heads_per_kv_head
         q_end = bq_end * cfgs.model.num_q_heads_per_kv_head
         q_slice = slice(q_start, q_end)
 
-        m_next, l_next, o_next = flash_attention.flash_attention(
+        p, alpha, m_next, l_next = flash_attention.flash_attention_qk_softmax(
             q[:, :, q_slice],
             k,
-            v,
-            acc_val[:, :, q_slice],
             m_val[:, :, q_slice],
             l_val[:, :, q_slice],
             processed_q_len=processed_q_len,
@@ -236,7 +235,30 @@ def rpa_body(
         )
         m_scratch_ref[:, :, q_slice] = m_next
         l_scratch_ref[:, :, q_slice] = l_next
-        acc_scratch_ref[:, :, q_slice] = o_next
+
+        if prev_p is not None:
+            o_next = flash_attention.flash_attention_pv(
+                prev_p,
+                v,
+                prev_alpha,
+                acc_val[:, :, prev_q_slice],
+                cfgs=cfgs,
+            )
+            acc_scratch_ref[:, :, prev_q_slice] = o_next
+
+        prev_p = p
+        prev_alpha = alpha
+        prev_q_slice = q_slice
+
+    assert prev_p is not None
+    o_next = flash_attention.flash_attention_pv(
+        prev_p,
+        v,
+        prev_alpha,
+        acc_val[:, :, prev_q_slice],
+        cfgs=cfgs,
+    )
+    acc_scratch_ref[:, :, prev_q_slice] = o_next
 
     # Step 4: Write back outputs.
     calculate_and_store_out(
@@ -253,7 +275,7 @@ def rpa_body(
 
 
 def create_allocs(
-    kv_cache_hbm_ref: jax.Ref, o_hbm_ref: jax.Ref, cfgs: configs.RPAConfig
+    kv_cache_hbm_ref: jax.Ref, o_hbm_ref: jax.Ref, cfgs: configs.RpaConfigs
 ) -> tuple[
         bref_override.BatchingQRef,
         bref_override.KVBufferedRef,
@@ -305,7 +327,7 @@ def create_allocs(
     return q_alloc, kv_cache_alloc, o_alloc
 
 
-def get_kernel_name(cfgs: configs.RPAConfig) -> str:
+def get_kernel_name(cfgs: configs.RpaConfigs) -> str:
     name = f"RPA{cfgs.mode.symbol}-p{cfgs.serve.page_size}"
     name += f"-b{cfgs.batch_size}-q{cfgs.bq_sz}-k{cfgs.bkv_sz}"
     if cfgs.model.sliding_window:
@@ -314,7 +336,7 @@ def get_kernel_name(cfgs: configs.RPAConfig) -> str:
 
 
 def get_kernel_metadata(
-    cfgs: configs.RPAConfig, ) -> dict[str, str | int | float]:
+    cfgs: configs.RpaConfigs, ) -> dict[str, str | int | float]:
     cfgs_dict = dataclasses.asdict(cfgs)
     ret = {}
     for path, val in jax.tree_util.tree_leaves_with_path(cfgs_dict):
@@ -329,12 +351,12 @@ def rpa_kernel(
     cu_q_lens: jax.Array,
     kv_lens: jax.Array,
     page_indices: jax.Array,
-    schedule_hbm: schedule.RPASchedule,
+    schedule_hbm: schedule.RpaSchedule,
     q_hbm: jax.Array,
     new_kv_hbm: jax.Array,
     kv_cache_hbm: jax.Array,
     *,
-    cfgs: configs.RPAConfig,
+    cfgs: configs.RpaConfigs,
 ) -> tuple[jax.Array, jax.Array]:
     """Perform batched ragged paged attention with scheduler data.
 
@@ -370,7 +392,7 @@ def rpa_kernel(
         kv_lens_ref: jax.Ref,
         page_indices_ref: jax.Ref,
         # Inputs.
-        schedule_hbm_ref: schedule.RPASchedule,
+        schedule_hbm_ref: schedule.RpaSchedule,
         q_hbm_ref: jax.Ref,
         new_kv_hbm_ref: jax.Ref,
         kv_cache_hbm_ref: jax.Ref,

--- a/tpu_inference/kernels/experimental/batched_rpa/schedule.py
+++ b/tpu_inference/kernels/experimental/batched_rpa/schedule.py
@@ -56,7 +56,7 @@ class SmemWrapper:
 
 @jax.tree_util.register_dataclass
 @dataclasses.dataclass(frozen=True)
-class RPASchedule:
+class RpaSchedule:
     """Container for metadata arrays with integrated shape/spec logic."""
 
     s_idx: SmemWrapper  # [steps, batch]
@@ -69,10 +69,10 @@ class RPASchedule:
     dma_kv_new: SmemWrapper  # [steps, batch, bkv_p_new, 4]
     actual_steps: Any  # [1]
 
-    cfgs: configs.RPAConfig = dataclasses.field(metadata=dict(static=True))
+    cfgs: configs.RpaConfigs = dataclasses.field(metadata=dict(static=True))
 
     @classmethod
-    def create_shape_dtype(cls, cfgs: configs.RPAConfig):
+    def create_shape_dtype(cls, cfgs: configs.RpaConfigs):
 
         idx_wrapper = SmemWrapper.create_shape_dtype(
             (cfgs.max_steps_ub, cfgs.batch_size))
@@ -162,10 +162,10 @@ def compute_metadata(
     cu_q_lens_ref: jax.Ref,
     kv_lens_ref: jax.Ref,
     distribution_ref: jax.Ref,
-    schedule: RPASchedule,
+    schedule: RpaSchedule,
     lane_lengths_ref: jax.Ref,
     *,
-    cfgs: configs.RPAConfig,
+    cfgs: configs.RpaConfigs,
 ):
     """Fill metadata using triple nested loop of seq->q->k loop."""
 
@@ -332,13 +332,13 @@ def rpa_metadata_schedule_kernel(
     kv_lens_ref: jax.Ref,
     distribution_ref: jax.Ref,
     # Outputs.
-    schedule_hbm_ref: RPASchedule,
+    schedule_hbm_ref: RpaSchedule,
     # Scratch.
-    schedule_ref: RPASchedule,
+    schedule_ref: RpaSchedule,
     lane_lengths_ref: jax.Ref,
     dma_sem: jax.Ref,
     *,
-    cfgs: configs.RPAConfig,
+    cfgs: configs.RpaConfigs,
 ):
     """Generates the HBM-to-VMEM DMA schedule.
 
@@ -444,11 +444,11 @@ def generate_rpa_metadata(
     cu_q_lens: jax.Array,
     kv_lens: jax.Array,
     distribution: jax.Array,
-    cfgs: configs.RPAConfig,
+    cfgs: configs.RpaConfigs,
     *,
     interpret=False,
-) -> RPASchedule:
-    schedule_shaped_dtype = RPASchedule.create_shape_dtype(cfgs)
+) -> RpaSchedule:
+    schedule_shaped_dtype = RpaSchedule.create_shape_dtype(cfgs)
 
     return pl.pallas_call(
         functools.partial(rpa_metadata_schedule_kernel, cfgs=cfgs),

--- a/tpu_inference/kernels/experimental/batched_rpa/wrapper.py
+++ b/tpu_inference/kernels/experimental/batched_rpa/wrapper.py
@@ -31,163 +31,11 @@ Note: batched_rpa is build on top / derived from RPA3.
 
 import jax
 import jax.numpy as jnp
+from jax.experimental import pallas as pl
 from jax.experimental.pallas import tpu as pltpu
 
 from tpu_inference.kernels.experimental.batched_rpa import (configs, kernel,
                                                             schedule, utils)
-
-
-# Expect to run this validation during compile time.
-def static_validate_inputs(
-    q: jax.Array,
-    k: jax.Array,
-    v: jax.Array,
-    kv_cache: jax.Array,
-    kv_lens: jax.Array,
-    page_indices: jax.Array,
-    cu_q_lens: jax.Array,
-    distribution: jax.Array,
-    *,
-    sm_scale: float = 1.0,
-    sliding_window: int | None = None,
-    soft_cap: float | None = None,
-    mask_value: float | None = None,
-    q_scale: float | None = None,
-    k_scale: float | None = None,
-    v_scale: float | None = None,
-    # Kernel optimization params.
-    chunk_prefill_size: int | None = None,
-    # Kernel tuning params.
-    decode_block_sizes: configs.BlockSizes | None = None,
-    prefill_block_sizes: configs.BlockSizes | None = None,
-    vmem_limit_bytes: int | None = None,
-    # Debug params.
-    debug_mode: bool = False,
-    use_causal_mask: bool = True,
-):
-    """Validate inputs to the RPA kernel statically."""
-    num_lanes = pltpu.get_tpu_info().num_lanes
-    if not q.ndim == k.ndim == k.ndim == 3:
-        raise ValueError(
-            f"Expected 3D array for {q.shape=}, {k.shape=}, {v.shape=}")
-    if k.shape != v.shape:
-        raise ValueError(f"Expected {k.shape=} to be equal to {v.shape=}")
-    if not (q.shape[0] == k.shape[0] == v.shape[0]):
-        raise ValueError(
-            f"Expected {q.shape[0]=} to be equal to {k.shape[0]=} and {v.shape[0]=}"
-        )
-    if not (q.shape[2] == k.shape[2] == v.shape[2]):
-        raise ValueError(
-            f"Expected {q.shape[2]=} to be equal to {k.shape[2]=} and {v.shape[2]=}"
-        )
-
-    actual_head_dim = q.shape[2]
-    actual_num_q_heads = q.shape[1]
-    actual_num_kv_heads = k.shape[1]
-
-    if actual_num_q_heads % actual_num_kv_heads != 0:
-        raise ValueError(f"Expected {actual_num_q_heads=} to be divisible by"
-                         f" {actual_num_kv_heads=}.")
-
-    expected_kv_cache_shape = get_kv_cache_shape(
-        kv_cache.shape[0],
-        kv_cache.shape[1],
-        actual_num_kv_heads,
-        actual_head_dim,
-        kv_cache.dtype,
-    )
-
-    if kv_cache.shape != expected_kv_cache_shape:
-        raise ValueError(
-            f"Expected {kv_cache.shape=} to be equal to {expected_kv_cache_shape=}"
-        )
-
-    (
-        _,
-        page_size,
-        num_kv_heads_x2_per_kv_packing,
-        kv_packing,
-        head_dim,
-    ) = kv_cache.shape
-
-    if head_dim != (aligned_head_dim := utils.align_to(actual_head_dim,
-                                                       num_lanes)):
-        raise ValueError(
-            f"Expected {head_dim=} is equal to {aligned_head_dim=}")
-    # Note: we expect the kv quantization happens outside of the RPA kernel.
-    if not (kv_cache.dtype == k.dtype == v.dtype):
-        raise ValueError(
-            f"Expected {kv_cache.dtype=} to be equal to {k.dtype=} and {v.dtype=}."
-        )
-    # Integer kv quantization is currently not supported.
-    if not jnp.issubdtype(kv_cache.dtype, jnp.floating):
-        raise ValueError(f"Expected {kv_cache.dtype=} to be a floating point.")
-    if kv_packing != utils.get_dtype_packing(kv_cache.dtype):
-        raise ValueError(
-            f"{kv_packing=} does not match with {kv_cache.dtype=}")
-
-    num_kv_heads_x2 = num_kv_heads_x2_per_kv_packing * kv_packing
-    if num_kv_heads_x2 % 2 != 0:
-        raise ValueError(
-            f"Combined KV heads must be divisible by 2, but got {num_kv_heads_x2}"
-        )
-    if (num_kv_heads_x2 % kv_packing != 0
-            or num_kv_heads_x2 // 2 < actual_num_kv_heads):
-        raise ValueError(
-            f"Invalid {num_kv_heads_x2=}, {actual_num_kv_heads=}, {kv_packing=}"
-        )
-
-    if not (jnp.int32 == kv_lens.dtype == page_indices.dtype == cu_q_lens.dtype
-            == distribution.dtype):
-        raise ValueError(
-            f"Expected int32 dtype for {kv_lens.dtype=}, {page_indices.dtype=},"
-            f" {cu_q_lens.dtype=}, {distribution.dtype=}")
-
-    if not (len(kv_lens.shape) == len(page_indices.shape) == len(
-            cu_q_lens.shape) == 1):
-        raise ValueError(
-            f"Expected 1D array for {kv_lens.shape=}, {page_indices.shape=},"
-            f" {cu_q_lens.shape=}")
-
-    max_num_seqs = kv_lens.shape[0]
-    num_page_indices = page_indices.shape[0]
-    if num_page_indices % max_num_seqs != 0:
-        raise ValueError(
-            f"Expected {num_page_indices=} to be divisible by {max_num_seqs=}."
-        )
-    if cu_q_lens.shape != (max_num_seqs + 1, ):
-        raise ValueError(
-            f"Expected {cu_q_lens.shape=} to be ({max_num_seqs + 1},).")
-    if distribution.shape != (3, ):
-        raise ValueError(f"Expected {distribution.shape=} to be (3,).")
-
-    if page_size % kv_packing != 0:
-        raise ValueError(f"{page_size=} must be divisible by {kv_packing=}.")
-    if sliding_window is not None and sliding_window <= 0:
-        raise ValueError(f"{sliding_window=} must be positive.")
-    if soft_cap is not None and soft_cap == 0.0:
-        raise ValueError(f"{soft_cap=} must not be 0.0.")
-    if chunk_prefill_size is not None and chunk_prefill_size <= 0:
-        raise ValueError(f"{chunk_prefill_size=} must be positive.")
-
-    for block_sizes in (decode_block_sizes, prefill_block_sizes):
-        if block_sizes is not None:
-            if block_sizes.bkv_sz <= 0:
-                raise ValueError(f"{block_sizes.bkv_sz=} must be positive.")
-            if block_sizes.bkv_sz % page_size != 0:
-                raise ValueError(
-                    f"{block_sizes.bkv_sz=} must be divisible by {page_size=}."
-                )
-            if block_sizes.bq_sz <= 0:
-                raise ValueError(f"{block_sizes.bq_sz=} must be positive.")
-            if block_sizes.n_buffer <= 0:
-                raise ValueError(f"{block_sizes.n_buffer=} must be positive.")
-
-    if vmem_limit_bytes is not None and vmem_limit_bytes <= 0:
-        raise ValueError(f"{vmem_limit_bytes=} must be positive.")
-
-    # No constraints for the following inputs.
-    del sm_scale, mask_value, q_scale, k_scale, v_scale, debug_mode
 
 
 def prepare_inputs(
@@ -279,66 +127,190 @@ def get_kv_cache_shape(
     )
 
 
-def get_default_block_sizes(
-    q_dtype: jnp.dtype,
-    kv_dtype: jnp.dtype,
-    actual_num_q_heads: int,
-    actual_num_kv_heads: int,
-    head_dim: int,
-    page_size: int,
-    max_num_tokens: int,
-    max_num_seqs: int,
-    pages_per_seq: int,
+def calculate_block_sizes(
+    model_cfgs: configs.ModelConfigs,
+    serve_cfgs: configs.ServingConfigs,
+    vmem_limit_bytes: int,
 ) -> tuple[configs.BlockSizes, configs.BlockSizes]:
-    """Get (bq_sz, bkv_sz, batch_size) by some heuristic formulas."""
-    del (
-        q_dtype,
-        head_dim,
-        max_num_tokens,
-        max_num_seqs,
-        pages_per_seq,
-    )
-    is_8bit = utils.get_dtype_packing(kv_dtype) == 4
-    # Qwen32b
-    if actual_num_q_heads == 32 and actual_num_kv_heads == 4 and is_8bit:
+    """Calculate optimal block size for decode and prefill."""
+
+    tpu_info = pltpu.get_tpu_info()
+    num_lanes = tpu_info.num_lanes
+    mxu_column_size = tpu_info.mxu_column_size
+
+    # Calculate aligned model dimensions.
+    aligned_head_dim = utils.align_to(model_cfgs.head_dim, num_lanes)
+    aligned_num_q_heads_per_kv_head = utils.align_to(
+        model_cfgs.num_q_heads_per_kv_head, serve_cfgs.packing_q)
+    aligned_num_q_heads = (aligned_num_q_heads_per_kv_head *
+                           model_cfgs.num_kv_heads)
+
+    bkv_stride = pl.cdiv(model_cfgs.num_kv_heads * 2, serve_cfgs.packing_kv)
+    if utils.has_bank_conflicts(bkv_stride):
+        bkv_stride += 1
+    aligned_num_kv_heads_x2 = bkv_stride * serve_cfgs.packing_kv
+
+    q_bytes = jnp.dtype(serve_cfgs.dtype_q).itemsize
+    kv_bytes = jnp.dtype(serve_cfgs.dtype_kv).itemsize
+    out_bytes = jnp.dtype(serve_cfgs.dtype_out).itemsize
+
+    def calculate_vmem_usage(batch_size: int, n_buffer: int, bq_sz: int,
+                             bkv_sz: int) -> int:
+        """Given tile size, calculate VMEM usage of the kernel."""
+
+        # Step 1: Calculate buffer sizes.
+
+        # Calculate size bq & bkv arrays for a single buffer.
+        bq_array_size = bq_sz * aligned_num_q_heads * aligned_head_dim
+        bkv_array_size = bkv_sz * aligned_num_kv_heads_x2 * aligned_head_dim
+
+        # Get output buffer size as well - which has same size as query size.
+        bo_array_size = bq_array_size
+
+        # Convert to bytes.
+        bq_bytes = bq_array_size * q_bytes
+        bkv_bytes = bkv_array_size * kv_bytes
+        bo_bytes = bo_array_size * out_bytes
+
+        # Account for multiple buffers. For output, we always use double buffer.
+        bq_bytes *= n_buffer
+        bkv_bytes *= n_buffer
+        bo_bytes *= 2
+
+        # Sum up all buffer memory usage.
+        buffer_bytes = bq_bytes + bkv_bytes + bo_bytes
+
+        # Step 2: Calculate worst case memory usage during computation.
+
+        # Calculate the size of loaded bq and bkv size.
+        loaded_bq_size = bq_sz * model_cfgs.num_q_heads * aligned_head_dim
+        loaded_bkv_size = bkv_sz * model_cfgs.num_kv_heads * aligned_head_dim
+
+        # Calculate peak memory requirement of output - which is attention weight.
+        qk_size = bq_sz * bkv_sz * model_cfgs.num_q_heads
+
+        # Convert to bytes.
+        loaded_bq_bytes = loaded_bq_size * q_bytes
+        loaded_bkv_bytes = loaded_bkv_size * kv_bytes
+        qk_bytes = qk_size * out_bytes
+
+        # Sum up all compute memory usage.
+        compute_bytes = loaded_bq_bytes + loaded_bkv_bytes + qk_bytes
+
+        # Step 3: Sum up all memory usage.
+        total_bytes = buffer_bytes + compute_bytes
+
+        # Account for batch size.
+        total_bytes *= batch_size
+
+        return total_bytes
+
+    def calculate_compute_buffer_time(batch_size: int, bq_c_sz: int,
+                                      bkv_sz: int) -> int:
+        """Calculate computational complexity of a single compute block."""
+
+        num_k_rows = pl.cdiv(bkv_sz, mxu_column_size)
+        num_k_cols = pl.cdiv(model_cfgs.head_dim, mxu_column_size)
+        num_k = num_k_rows * num_k_cols
+        num_muls = bq_c_sz * num_k * model_cfgs.num_q_heads
+
+        return batch_size * num_muls
+
+    def find_best_block_sizes(
+            max_batch_size: int,
+            max_n_buffer: int,
+            fixed_bq_sz: int | None = None) -> configs.BlockSizes:
+        """Loop through different block sizes to find the most optimal one."""
+
+        # Even if we loose some potential performance, we want to avoid OOM at all
+        # costs. Therefore, we conservatively only use 80% of the VMEM budget.
+        capped_vmem_limit_bytes = vmem_limit_bytes * 0.8
+
+        bkv_sz = bkv_stride = mxu_column_size
+        if fixed_bq_sz is None:
+            bq_sz = bq_stride = bkv_sz
+        else:
+            bq_sz = fixed_bq_sz
+            bq_stride = 0
+        batch_size = max_batch_size
+        n_buffer = max_n_buffer
+
+        # Step 1: Lower batch_size and/or n_buffer if even the smallest bq and bkv
+        # size can trigger OOM.
+
+        # If current batch size triggers OOM, decrease batch size until the kernel
+        # fits within VMEM limit.
+        while (calculate_vmem_usage(batch_size, n_buffer, bq_sz, bkv_sz)
+               > capped_vmem_limit_bytes):
+            batch_size -= 1
+
+        # As a last resort, attempt to decrease number of buffers to avoid OOM.
+        while (calculate_vmem_usage(batch_size, n_buffer, bq_sz, bkv_sz)
+               > capped_vmem_limit_bytes):
+            n_buffer -= 1
+
+        # Indicates OOM was triggered even when batch_size=1 or n_buffer=1.
+        # NOTE: If the function does not exit at this point even when either values
+        # are zero, it will trigger infinite loop at the next while loop.
+        if batch_size == 0 or n_buffer == 0:
+            raise ValueError(
+                "Cannot find batch size that fits within VMEM limit.")
+
+        # Step 2: Increase block sizes until the kernel is unable to fit into VMEM.
+        while (calculate_vmem_usage(batch_size, n_buffer, bq_sz, bkv_sz)
+               < capped_vmem_limit_bytes):
+            # Unless bq is a fixed value, we want to ensure bq size is the same as bkv
+            # size. When using causal masking, if bq size is larger than bkv size,
+            # entire kv tile can be masked out for some query tokens. Similarly, if
+            # bkv size is larger than bq size, entire query tile can be masked out for
+            # some kv tokens.
+            bkv_sz += bkv_stride
+            bq_sz += bq_stride
+
+        # Rollback one step since the last attempted value triggered OOM.
+        bkv_sz -= bkv_stride
+        bq_sz -= bq_stride
+
+        # Indicates OOM was triggered from the starting bkv size.
+        if bkv_sz == 0:
+            raise ValueError(
+                "Cannot find block sizes that fit within VMEM limit.")
+
+        # Step 3: Given current tile size, calculate compute tile size.
+
+        # Fixed threshold value based on hardware spec.
+        # TODO(kyuyeunk): Use different threshold based on hardware and precision.
+        threshold = 1500
+
+        num_bq_c = 1
+        last_valid_bq_c_sz = bq_c_sz = bq_sz
+        bq_c_rem = 0
+
+        while (calculate_compute_buffer_time(batch_size, bq_c_sz, bkv_sz)
+               > threshold or bq_c_rem != 0) and num_bq_c < bq_sz:
+            if bq_c_rem == 0:
+                last_valid_bq_c_sz = bq_c_sz
+            num_bq_c += 1
+            bq_c_sz, bq_c_rem = divmod(bq_sz, num_bq_c)
+
         return configs.BlockSizes(
-            bq_sz=1,
-            bq_c_sz=1,
-            bkv_sz=512,
-            batch_size=10,
-            n_buffer=2,
-        ), configs.BlockSizes(
-            bq_sz=256,
-            bq_c_sz=32,
-            bkv_sz=512,
-            batch_size=2,
-            n_buffer=2,
-        )
-    # Qwen-coder
-    if actual_num_q_heads == 12 and actual_num_kv_heads == 1 and is_8bit:
-        return configs.BlockSizes(
-            bq_sz=1,
-            bq_c_sz=1,
-            bkv_sz=4096,
-            batch_size=8,
-            n_buffer=3,
-        ), configs.BlockSizes(
-            bq_sz=512,
-            bq_c_sz=32,
-            bkv_sz=512,
-            batch_size=3,
-            n_buffer=3,
+            bq_sz=bq_sz,
+            bq_c_sz=last_valid_bq_c_sz,
+            bkv_sz=bkv_sz,
+            batch_size=batch_size,
+            n_buffer=n_buffer,
         )
 
-    default_block_sizes = configs.BlockSizes(
-        bq_sz=1,
-        bq_c_sz=1,
-        bkv_sz=page_size,
-        batch_size=1,
-        n_buffer=2,
-    )
+    # Default to triple buffer as its almost always beneficial.
+    n_buffer = 3
+    # Fixed value based on experimental results.
+    decode_batch_size = 8
+    prefill_batch_size = 2
 
-    return default_block_sizes, default_block_sizes
+    decode_block_sizes = find_best_block_sizes(decode_batch_size, n_buffer, 1)
+    prefill_block_sizes = find_best_block_sizes(prefill_batch_size, n_buffer)
+
+    return decode_block_sizes, prefill_block_sizes
 
 
 @jax.jit(
@@ -428,29 +400,13 @@ def ragged_paged_attention(
             concatenated along num kv heads dim.
     """
 
-    static_validate_inputs(
-        queries,
-        keys,
-        values,
-        kv_cache,
-        kv_lens,
-        page_indices,
-        cu_q_lens,
-        distribution,
-        sm_scale=sm_scale,
-        sliding_window=sliding_window,
-        soft_cap=soft_cap,
-        mask_value=mask_value,
-        q_scale=q_scale,
-        k_scale=k_scale,
-        v_scale=v_scale,
-        chunk_prefill_size=chunk_prefill_size,
-        decode_block_sizes=decode_block_sizes,
-        prefill_block_sizes=prefill_block_sizes,
-        vmem_limit_bytes=vmem_limit_bytes,
-        debug_mode=debug_mode,
-        use_causal_mask=use_causal_mask,
-    )
+    if not use_causal_mask:
+        raise ValueError("Only causal attention is supported.")
+    if chunk_prefill_size is not None:
+        raise ValueError("Specifying chunk prefill size is not supported.")
+    if debug_mode:
+        raise ValueError("Debug mode is not supported.")
+
     if out_dtype is None:
         out_dtype = queries.dtype
     if mask_value is None:
@@ -465,59 +421,63 @@ def ragged_paged_attention(
     head_dim = queries.shape[2]
     num_kv_heads = keys.shape[1]
     num_page_indices = page_indices.shape[0]
-    pages_per_seq = num_page_indices // max_num_seqs
-    total_q_tokens = queries.shape[0]
+
+    model_cfgs = configs.ModelConfigs(
+        num_q_heads=num_q_heads,
+        num_kv_heads=num_kv_heads,
+        head_dim=head_dim,
+        sliding_window=sliding_window,
+        sm_scale=sm_scale,
+        soft_cap=soft_cap,
+        mask_value=mask_value,
+    )
+    serve_cfgs = configs.ServingConfigs(
+        num_seqs=max_num_seqs,
+        num_page_indices=num_page_indices,
+        total_q_tokens=queries.shape[0],
+        dtype_q=queries.dtype,
+        dtype_kv=kv_cache.dtype,
+        dtype_out=out_dtype,
+        page_size=page_size,
+        scale_q=q_scale,
+        scale_k=k_scale,
+        scale_v=v_scale,
+    )
 
     q_hbm, new_kv_hbm = prepare_inputs(queries, keys, values, queries.dtype,
                                        kv_cache.dtype)
+
+    default_decode, default_prefill = calculate_block_sizes(
+        model_cfgs, serve_cfgs, vmem_limit_bytes)
 
     def run_rpa_kernel(
         mode: configs.RpaCase,
         o_hbm_alias_q_hbm: jax.Array,
         kv_cache: jax.Array,
     ):
-        default_decode, default_prefill = get_default_block_sizes(
-            queries.dtype,
-            kv_cache.dtype,
-            num_q_heads,
-            num_kv_heads,
-            head_dim,
-            page_size,
-            total_q_tokens,
-            max_num_seqs,
-            pages_per_seq,
-        )
         if mode == configs.RpaCase.DECODE:
             effective_blocks = decode_block_sizes or default_decode
         else:
             effective_blocks = prefill_block_sizes or default_prefill
 
-        cfgs = configs.RPAConfig(
+        cfgs = configs.RpaConfigs(
             block=effective_blocks,
-            model=configs.ModelConfigs(
-                num_q_heads=num_q_heads,
-                num_kv_heads=num_kv_heads,
-                head_dim=head_dim,
-                sliding_window=sliding_window,
-                sm_scale=sm_scale,
-                soft_cap=soft_cap,
-                mask_value=mask_value,
-            ),
-            serve=configs.ServingConfigs(
-                num_seqs=max_num_seqs,
-                num_page_indices=num_page_indices,
-                total_q_tokens=total_q_tokens,
-                dtype_q=queries.dtype,
-                dtype_kv=kv_cache.dtype,
-                dtype_out=out_dtype,
-                page_size=page_size,
-                scale_q=q_scale,
-                scale_k=k_scale,
-                scale_v=v_scale,
-            ),
+            model=model_cfgs,
+            serve=serve_cfgs,
             vmem_limit_bytes=vmem_limit_bytes,
             mode=mode,
         )
+        cfgs.validate_inputs(
+            q=queries,
+            k=keys,
+            v=values,
+            kv_cache=kv_cache,
+            kv_lens=kv_lens,
+            page_indices=page_indices,
+            cu_q_lens=cu_q_lens,
+            distribution=distribution,
+        )
+
         schedule_hbm = schedule.generate_rpa_metadata(
             cu_q_lens,
             kv_lens,

--- a/tpu_inference/kernels/experimental/batched_rpa/wrapper.py
+++ b/tpu_inference/kernels/experimental/batched_rpa/wrapper.py
@@ -303,11 +303,13 @@ def get_default_block_sizes(
     if actual_num_q_heads == 32 and actual_num_kv_heads == 4 and is_8bit:
         return configs.BlockSizes(
             bq_sz=1,
+            bq_c_sz=1,
             bkv_sz=512,
             batch_size=10,
             n_buffer=2,
         ), configs.BlockSizes(
             bq_sz=256,
+            bq_c_sz=32,
             bkv_sz=512,
             batch_size=2,
             n_buffer=2,
@@ -316,11 +318,13 @@ def get_default_block_sizes(
     if actual_num_q_heads == 12 and actual_num_kv_heads == 1 and is_8bit:
         return configs.BlockSizes(
             bq_sz=1,
-            bkv_sz=2304,
+            bq_c_sz=1,
+            bkv_sz=4096,
             batch_size=8,
             n_buffer=3,
         ), configs.BlockSizes(
             bq_sz=512,
+            bq_c_sz=32,
             bkv_sz=512,
             batch_size=3,
             n_buffer=3,
@@ -328,6 +332,7 @@ def get_default_block_sizes(
 
     default_block_sizes = configs.BlockSizes(
         bq_sz=1,
+        bq_c_sz=1,
         bkv_sz=page_size,
         batch_size=1,
         n_buffer=2,


### PR DESCRIPTION
# Description

- Apply prefill optimization that reorders MXU operation for better utilization
- Add experimental heuristic logic for calculating optimal block size. Note the kernel lacks knowledge of workload characteristics during compilation / server launch time and therefore might perform sub-optimally than a block size tuned specifically for a given workload.

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
