### PR TITLE
PhaseBasedProfiler supports PREFILL_ONLY and DECODE_ONLY phases

### DIFF
--- a/tests/runner/test_utils.py
+++ b/tests/runner/test_utils.py
@@ -317,10 +317,10 @@ def test_get_batch_composition_stats(scenario, num_reqs, req_ids, computed,
     (40, 100, InferencePhase.BALANCED),
     (50, 100, InferencePhase.BALANCED),
     (60, 100, InferencePhase.BALANCED),
-    (100, 100, InferencePhase.PREFILL_HEAVY),
+    (100, 100, InferencePhase.PREFILL_ONLY),
     (20, 100, InferencePhase.DECODE_HEAVY),
     (21, 100, InferencePhase.AMBIGUOUS),
-    (0, 100, InferencePhase.DECODE_HEAVY),
+    (0, 100, InferencePhase.DECODE_ONLY),
 ])
 def test_determine_phase_from_batch_composition_stats(prefill_tokens,
                                                       total_tokens,
@@ -426,7 +426,8 @@ def test_phased_profiler_handles_all_phases(profiler_fixture):
 
     stats = {"num_reqs": 2, "total_num_scheduled_tokens": 100}
     phases_to_profile = [
-        InferencePhase.PREFILL_HEAVY, InferencePhase.DECODE_HEAVY,
+        InferencePhase.PREFILL_ONLY, InferencePhase.PREFILL_HEAVY,
+        InferencePhase.DECODE_ONLY, InferencePhase.DECODE_HEAVY,
         InferencePhase.BALANCED
     ]
 

--- a/tpu_inference/runner/utils.py
+++ b/tpu_inference/runner/utils.py
@@ -43,6 +43,8 @@ class InferencePhase(Enum):
     DECODE_HEAVY = 1
     BALANCED = 2
     AMBIGUOUS = 3
+    PREFILL_ONLY = 4
+    DECODE_ONLY = 5
 
 
 def get_padded_num_reqs_with_upper_limit(x: int, upper_limit: int) -> int:
@@ -260,15 +262,19 @@ def determine_phase_from_batch_composition_stats(
     total_num_scheduled_tokens = batch_composition_stats[
         "total_num_scheduled_tokens"]
     prefill_ratio_for_batch = num_prefill_tokens / total_num_scheduled_tokens
+    if prefill_ratio_for_batch == 1.0:
+        return InferencePhase.PREFILL_ONLY
+    if prefill_ratio_for_batch == 0.0:
+        return InferencePhase.DECODE_ONLY
     if prefill_ratio_for_batch >= PREFILL_HEAVY_RATIO_THRESHOLD:
         return InferencePhase.PREFILL_HEAVY
-    elif prefill_ratio_for_batch <= DECODE_HEAVY_RATIO_THRESHOLD:
+    if prefill_ratio_for_batch <= DECODE_HEAVY_RATIO_THRESHOLD:
         return InferencePhase.DECODE_HEAVY
-    elif prefill_ratio_for_batch >= BALANCED_RATIO_THRESHOLD[
+    if prefill_ratio_for_batch >= BALANCED_RATIO_THRESHOLD[
             0] and prefill_ratio_for_batch <= BALANCED_RATIO_THRESHOLD[1]:
         return InferencePhase.BALANCED
-    else:
-        return InferencePhase.AMBIGUOUS
+
+    return InferencePhase.AMBIGUOUS
 
 
 class PhasedBasedProfiler:
@@ -307,7 +313,9 @@ class PhasedBasedProfiler:
         self.profile_dir: str = profile_dir
         # NOTE: we purposely don't have AMBIGUOUS here
         self.inference_phase_seen: dict = {
+            InferencePhase.PREFILL_ONLY: False,
             InferencePhase.PREFILL_HEAVY: False,
+            InferencePhase.DECODE_ONLY: False,
             InferencePhase.DECODE_HEAVY: False,
             InferencePhase.BALANCED: False
         }


### PR DESCRIPTION
# Description

This PR introduces two new inference phases, `PREFILL_ONLY` and `DECODE_ONLY`, to provide finer-grained categorization of batch compositions. 

**Details and Context:**
- **Why is this change being made?** Previously, pure prefill batches (100% prefill tokens) and pure decode batches (100% decode tokens) were lumped into the broader `PREFILL_HEAVY` and `DECODE_HEAVY` buckets. Separating them out allows for more precise and granular profiling.
- **The problem being solved:** When analyzing performance profiles or hardware utilization, pure phases often exhibit different execution characteristics compared to mixed "heavy" phases (e.g., a batch that is 95% prefill and 5% decode). This change allows the `PhasedBasedProfiler` and external telemetry scripts to isolate and analyze these pure phases independently.
- **Specific implementation:**
  - Added `PREFILL_ONLY` and `DECODE_ONLY` to the `InferencePhase` enum in `tpu_inference/runner/utils.py`.
  - Updated `determine_phase_from_batch_composition_stats` to return these new phases when the prefill ratio is exactly `1.0` or `0.0` respectively. 
  - Refactored the `elif` chain in `determine_phase_from_batch_composition_stats` to use early returns for cleaner control flow.
  - Registered the new phases in `PhasedBasedProfiler`'s `inference_phase_seen` dictionary so they are actively traced during profiling.

# Tests

I updated the existing unit tests in `tests/runner/test_utils.py` to verify the new phase logic.

Commands to reproduce locally:
```bash
pytest tests/runner/test_utils.py::test_determine_phase_from_batch_composition_stats
pytest tests/runner/test_utils.py::test_phased_profiler_handles_all_phases
