### PR TITLE
Add stats utility

### DIFF
--- a/scripts/stats/plot_batch_stats.py
+++ b/scripts/stats/plot_batch_stats.py
@@ -1,0 +1,450 @@
+#!/usr/bin/env python3
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Utility script to parse and visualize TPU inference batch statistics from JSONL logs.
+"""
+import argparse
+import os
+
+import matplotlib.pyplot as plt
+import matplotlib.ticker as mticker
+import pandas as pd
+
+from tpu_inference.runner.utils import (
+    InferencePhase, determine_phase_from_batch_composition_stats)
+
+
+def plot_tokens_vs_requests(df: pd.DataFrame, output_dir: str):
+    """
+    Plots prefill/decode token counts and active requests over time (by batch number).
+    
+    Args:
+        df: DataFrame containing parsed batch statistics.
+        output_dir: Local directory path to save the generated plot.
+        
+    Returns:
+        Path to the generated image file, or None if skipped due to missing data.
+    """
+    required_cols = ['batch_no', 'num_prefill_tokens', 'num_decode_tokens']
+    missing_cols = [col for col in required_cols if col not in df.columns]
+    if missing_cols:
+        print(
+            f"Warning: Skipping 'Tokens vs Requests' plot. Missing columns: {missing_cols}"
+        )
+        return None
+
+    plot_df = df.dropna(subset=required_cols).copy()
+    if plot_df.empty:
+        print(
+            "Warning: Insufficient valid data for 'Tokens vs Requests' plot.")
+        return None
+
+    plain_formatter = mticker.ScalarFormatter()
+    plain_formatter.set_scientific(False)
+
+    fig, ax1 = plt.subplots(figsize=(14, 5))
+    ax1.fill_between(plot_df['batch_no'],
+                     plot_df['num_prefill_tokens'],
+                     color='orange',
+                     alpha=0.3)
+    ax1.plot(plot_df['batch_no'],
+             plot_df['num_prefill_tokens'],
+             label='Prefill Tokens',
+             color='darkorange',
+             linewidth=2)
+
+    ax1.fill_between(plot_df['batch_no'],
+                     plot_df['num_decode_tokens'],
+                     color='green',
+                     alpha=0.3)
+    ax1.plot(plot_df['batch_no'],
+             plot_df['num_decode_tokens'],
+             label='Decode Tokens',
+             color='darkgreen',
+             linewidth=2)
+
+    ax1.set_yscale('symlog', linthresh=1)
+    ax1.set_ylim(bottom=0)
+    ax1.set_ylabel('Token Count')
+    ax1.set_xlabel('Batch Number')
+    ax1.set_title('Tokens vs Requests')
+    ax1.grid(True, linestyle='--', alpha=0.7)
+    ax1.legend(loc='upper left')
+    ax1.yaxis.set_major_formatter(plain_formatter)
+
+    if 'num_reqs' in plot_df.columns:
+        ax1_req = ax1.twinx()
+        ax1_req.plot(plot_df['batch_no'],
+                     plot_df['num_reqs'],
+                     label='Active Requests',
+                     color='blue',
+                     linestyle=':',
+                     linewidth=2)
+        ax1_req.set_ylabel('Active Requests', color='blue')
+        ax1_req.tick_params(axis='y', labelcolor='blue')
+        ax1_req.set_ylim(bottom=0)
+        ax1_req.legend(loc='upper right')
+        ax1_req.yaxis.set_major_formatter(plain_formatter)
+
+    plt.tight_layout()
+    out_path = os.path.join(output_dir, "tokens_vs_requests.png")
+    fig.savefig(out_path, dpi=300)
+    plt.close(fig)
+    return out_path
+
+
+def plot_bucket_utilization(df: pd.DataFrame, output_dir: str):
+    """
+    Plots the hardware bucket utilization (actual tokens vs wasted padding) per batch.
+    
+    Args:
+        df: DataFrame containing parsed batch statistics.
+        output_dir: Local directory path to save the generated plot.
+        
+    Returns:
+        Path to the generated image file, or None if skipped due to missing data.
+    """
+    required_cols = [
+        'batch_no', 'padded_total_num_scheduled_tokens',
+        'total_num_scheduled_tokens'
+    ]
+    missing_cols = [col for col in required_cols if col not in df.columns]
+    if missing_cols:
+        print(
+            f"Warning: Skipping 'Bucket Utilization' plot. Missing columns: {missing_cols}"
+        )
+        return None
+
+    plot_df = df.dropna(subset=required_cols).copy()
+    if plot_df.empty:
+        print(
+            "Warning: Insufficient valid data for 'Bucket Utilization' plot.")
+        return None
+
+    fig, ax2 = plt.subplots(figsize=(14, 5))
+    padded_safe = plot_df['padded_total_num_scheduled_tokens'].replace(
+        0, 1)  # Prevent division by zero
+    actual_pct = (plot_df['total_num_scheduled_tokens'] / padded_safe) * 100
+    waste_pct = ((padded_safe - plot_df['total_num_scheduled_tokens']) /
+                 padded_safe) * 100
+
+    ax2.stackplot(plot_df['batch_no'],
+                  actual_pct,
+                  waste_pct,
+                  labels=['Actual Tokens Processed (%)', 'Wasted Padding (%)'],
+                  colors=['blue', 'red'],
+                  alpha=0.5)
+    ax2.set_title('Bucket Utilization')
+    ax2.set_xlabel('Batch Number')
+    ax2.set_ylabel('Percentage of Bucket (%)')
+    ax2.set_ylim(0, 100)
+    ax2.legend(loc='lower right')
+    ax2.grid(True, linestyle='--', alpha=0.7)
+
+    plt.tight_layout()
+    out_path = os.path.join(output_dir, "bucket_utilization.png")
+    fig.savefig(out_path, dpi=300)
+    plt.close(fig)
+    return out_path
+
+
+def plot_token_volume_by_phase(df: pd.DataFrame, output_dir: str):
+    """
+    Plots the total token volume distributed across different inference phases.
+    
+    Args:
+        df: DataFrame containing parsed batch statistics.
+        output_dir: Local directory path to save the generated plot.
+        
+    Returns:
+        Path to the generated image file, or None if skipped due to missing data.
+    """
+    required_cols = [
+        'num_prefill_tokens', 'num_decode_tokens', 'total_num_scheduled_tokens'
+    ]
+    missing_cols = [col for col in required_cols if col not in df.columns]
+    if missing_cols:
+        print(
+            f"Warning: Skipping 'Token Volume by Phase' plot. Missing columns: {missing_cols}"
+        )
+        return None
+
+    plot_df = df.dropna(subset=required_cols).copy()
+    # Calculate the phase for each row using the utility function and avoid division by zero
+    plot_df = plot_df[plot_df['total_num_scheduled_tokens'] > 0].copy()
+    if plot_df.empty:
+        print(
+            "Warning: Insufficient valid data for 'Token Volume by Phase' plot."
+        )
+        return None
+
+    try:
+        plot_df['phase'] = plot_df.apply(
+            lambda row: determine_phase_from_batch_composition_stats(
+                row.to_dict()).name,
+            axis=1)
+    except Exception as e:
+        print(
+            f"Warning: Failed to determine phases for 'Token Volume by Phase' plot: {e}"
+        )
+        return None
+
+    plain_formatter = mticker.ScalarFormatter()
+    plain_formatter.set_scientific(False)
+
+    fig, ax3 = plt.subplots(figsize=(14, 5))
+    phase_stats = plot_df.groupby('phase')[[
+        'num_prefill_tokens', 'num_decode_tokens'
+    ]].sum()
+
+    # Enforce a logical progression of phases on the x-axis
+    expected_phases = [
+        InferencePhase.PREFILL_ONLY.name, InferencePhase.PREFILL_HEAVY.name,
+        InferencePhase.BALANCED.name, InferencePhase.DECODE_HEAVY.name,
+        InferencePhase.DECODE_ONLY.name, InferencePhase.AMBIGUOUS.name
+    ]
+    all_phases = expected_phases + [
+        p for p in phase_stats.index if p not in expected_phases
+    ]
+    phase_stats = phase_stats.reindex(all_phases).fillna(0)
+
+    total_phase_tokens = phase_stats['num_prefill_tokens'] + phase_stats[
+        'num_decode_tokens']
+
+    phase_stats.plot(kind='bar',
+                     stacked=True,
+                     ax=ax3,
+                     color=['darkorange', 'darkgreen'],
+                     alpha=0.8)
+    ax3.set_title('Total Token Volume by Phase')
+    ax3.set_xlabel('Phase')
+    ax3.set_ylabel('Total Tokens')
+    ax3.legend(['Prefill Tokens', 'Decode Tokens'])
+    ax3.grid(axis='y', linestyle='--', alpha=0.7)
+    ax3.yaxis.set_major_formatter(plain_formatter)
+    ax3.tick_params(axis='x', rotation=0)
+    ax3.margins(y=0.15)
+
+    # Annotate Graph 3 with the actual token counts
+    for i, phase in enumerate(phase_stats.index):
+        total_tokens = total_phase_tokens[phase]
+        prefill_tokens = phase_stats.loc[phase, 'num_prefill_tokens']
+        decode_tokens = phase_stats.loc[phase, 'num_decode_tokens']
+
+        if total_tokens > 0:
+            prefill_pct = (prefill_tokens / total_tokens) * 100
+            decode_pct = (decode_tokens / total_tokens) * 100
+        else:
+            prefill_pct = decode_pct = 0.0
+
+        annotation_text = f"Phase Total: {int(total_tokens):,}\nPrefill: {int(prefill_tokens):,} ({prefill_pct:.1f}%)\nDecode: {int(decode_tokens):,} ({decode_pct:.1f}%)"
+
+        ax3.text(i,
+                 total_tokens,
+                 annotation_text,
+                 ha='center',
+                 va='bottom',
+                 fontsize=10,
+                 bbox=dict(facecolor='white',
+                           alpha=0.8,
+                           edgecolor='gray',
+                           boxstyle='round,pad=0.3'))
+
+    plt.tight_layout()
+    out_path = os.path.join(output_dir, "token_volume_by_phase.png")
+    fig.savefig(out_path, dpi=300)
+    plt.close(fig)
+    return out_path
+
+
+def plot_batch_volume_by_phase(df: pd.DataFrame, output_dir: str):
+    """
+    Plots the number of batches that fall into each inference phase.
+    
+    Args:
+        df: DataFrame containing parsed batch statistics.
+        output_dir: Local directory path to save the generated plot.
+        
+    Returns:
+        Path to the generated image file, or None if skipped due to missing data.
+    """
+    required_cols = [
+        'num_prefill_tokens', 'num_decode_tokens', 'total_num_scheduled_tokens'
+    ]
+    missing_cols = [col for col in required_cols if col not in df.columns]
+    if missing_cols:
+        print(
+            f"Warning: Skipping 'Batch Volume by Phase' plot. Missing columns: {missing_cols}"
+        )
+        return None
+
+    plot_df = df.dropna(subset=required_cols).copy()
+    # Calculate the phase for each row using the utility function and avoid division by zero
+    plot_df = plot_df[plot_df['total_num_scheduled_tokens'] > 0].copy()
+    if plot_df.empty:
+        print(
+            "Warning: Insufficient valid data for 'Batch Volume by Phase' plot."
+        )
+        return None
+
+    try:
+        plot_df['phase'] = plot_df.apply(
+            lambda row: determine_phase_from_batch_composition_stats(
+                row.to_dict()).name,
+            axis=1)
+    except Exception as e:
+        print(
+            f"Warning: Failed to determine phases for 'Batch Volume by Phase' plot: {e}"
+        )
+        return None
+
+    plain_formatter = mticker.ScalarFormatter()
+    plain_formatter.set_scientific(False)
+
+    fig, ax4 = plt.subplots(figsize=(14, 5))
+    phase_counts = plot_df['phase'].value_counts()
+
+    # Enforce a logical progression of phases on the x-axis
+    expected_phases = [
+        InferencePhase.PREFILL_ONLY.name, InferencePhase.PREFILL_HEAVY.name,
+        InferencePhase.BALANCED.name, InferencePhase.DECODE_HEAVY.name,
+        InferencePhase.DECODE_ONLY.name, InferencePhase.AMBIGUOUS.name
+    ]
+    all_phases = expected_phases + [
+        p for p in phase_counts.index if p not in expected_phases
+    ]
+    phase_counts = phase_counts.reindex(all_phases).fillna(0)
+
+    total_batches = phase_counts.sum()
+
+    phase_counts.plot(kind='bar', ax=ax4, color='purple', alpha=0.8)
+    ax4.set_title('Total Batch Volume by Phase')
+    ax4.set_xlabel('Phase')
+    ax4.set_ylabel('Number of Batches')
+    ax4.grid(axis='y', linestyle='--', alpha=0.7)
+    ax4.yaxis.set_major_formatter(plain_formatter)
+    ax4.tick_params(axis='x', rotation=0)
+    ax4.margins(y=0.15)
+
+    # Annotate Graph 4 with the actual batch counts
+    for i, phase in enumerate(phase_counts.index):
+        count = phase_counts[phase]
+
+        if total_batches > 0:
+            pct = (count / total_batches) * 100
+        else:
+            pct = 0.0
+
+        annotation_text = f"Batches: {int(count):,}\n({pct:.1f}%)"
+
+        ax4.text(i,
+                 count,
+                 annotation_text,
+                 ha='center',
+                 va='bottom',
+                 fontsize=10,
+                 bbox=dict(facecolor='white',
+                           alpha=0.8,
+                           edgecolor='gray',
+                           boxstyle='round,pad=0.3'))
+
+    plt.tight_layout()
+    out_path = os.path.join(output_dir, "batch_volume_by_phase.png")
+    fig.savefig(out_path, dpi=300)
+    plt.close(fig)
+    return out_path
+
+
+def plot_stats(input_file: str, output_dir: str, graphs: list) -> list:
+    """
+    Reads the input JSONL file and triggers the requested plotting functions.
+    
+    Args:
+        input_file: Path to the raw JSONL batch stats log file.
+        output_dir: Local directory path to save the output graphs.
+        graphs: List of specific graph types to generate (or ["all"]).
+        
+    Returns:
+        List of file paths to the successfully generated image files.
+    """
+    if not os.path.exists(input_file):
+        print(f"Error: Input file {input_file} does not exist.")
+        return []
+
+    try:
+        df = pd.read_json(input_file, lines=True)
+    except ValueError as e:
+        print(f"Error reading JSONL file {input_file}: {e}")
+        return []
+
+    if df.empty:
+        print(f"Warning: Input file {input_file} contains no data.")
+        return []
+
+    os.makedirs(output_dir, exist_ok=True)
+    generated_files = []
+
+    if 'all' in graphs or 'tokens_vs_requests' in graphs:
+        if file1 := plot_tokens_vs_requests(df, output_dir):
+            generated_files.append(file1)
+
+    if 'all' in graphs or 'bucket_utilization' in graphs:
+        if file2 := plot_bucket_utilization(df, output_dir):
+            generated_files.append(file2)
+
+    if 'all' in graphs or 'token_volume_by_phase' in graphs:
+        if file3 := plot_token_volume_by_phase(df, output_dir):
+            generated_files.append(file3)
+
+    if 'all' in graphs or 'batch_volume_by_phase' in graphs:
+        if file4 := plot_batch_volume_by_phase(df, output_dir):
+            generated_files.append(file4)
+
+    return generated_files
+
+
+def main():
+
+    parser = argparse.ArgumentParser(description="Plot TPU batch statistics.")
+    parser.add_argument("--input",
+                        "-i",
+                        type=str,
+                        required=True,
+                        help="Path to the input JSONL stats file")
+    parser.add_argument(
+        "--output-dir",
+        "-o",
+        type=str,
+        default="/tmp/batch_stats",
+        help="Local directory to save the generated graph images")
+    parser.add_argument("--graphs",
+                        nargs="+",
+                        default=["all"],
+                        choices=[
+                            "tokens_vs_requests", "bucket_utilization",
+                            "token_volume_by_phase", "batch_volume_by_phase",
+                            "all"
+                        ],
+                        help="Specify which graphs to generate (default: all)")
+
+    args = parser.parse_args()
+
+    generated_files = plot_stats(args.input, args.output_dir, args.graphs)
+    if generated_files:
+        print(f"Graphs saved to {args.output_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/runner/test_utils.py
+++ b/tests/runner/test_utils.py
@@ -317,10 +317,10 @@ def test_get_batch_composition_stats(scenario, num_reqs, req_ids, computed,
     (40, 100, InferencePhase.BALANCED),
     (50, 100, InferencePhase.BALANCED),
     (60, 100, InferencePhase.BALANCED),
-    (100, 100, InferencePhase.PREFILL_HEAVY),
+    (100, 100, InferencePhase.PREFILL_ONLY),
     (20, 100, InferencePhase.DECODE_HEAVY),
     (21, 100, InferencePhase.AMBIGUOUS),
-    (0, 100, InferencePhase.DECODE_HEAVY),
+    (0, 100, InferencePhase.DECODE_ONLY),
 ])
 def test_determine_phase_from_batch_composition_stats(prefill_tokens,
                                                       total_tokens,
@@ -426,7 +426,8 @@ def test_phased_profiler_handles_all_phases(profiler_fixture):
 
     stats = {"num_reqs": 2, "total_num_scheduled_tokens": 100}
     phases_to_profile = [
-        InferencePhase.PREFILL_HEAVY, InferencePhase.DECODE_HEAVY,
+        InferencePhase.PREFILL_ONLY, InferencePhase.PREFILL_HEAVY,
+        InferencePhase.DECODE_ONLY, InferencePhase.DECODE_HEAVY,
         InferencePhase.BALANCED
     ]
 

--- a/tests/runner/test_utils.py
+++ b/tests/runner/test_utils.py
@@ -1,7 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 import io
+import json
 import logging
 import time
+from pathlib import Path
 from unittest.mock import MagicMock, mock_open, patch
 
 import jax
@@ -12,8 +14,8 @@ from jax._src.interpreters import pxla
 from jax._src.pallas.utils import next_power_of_2
 
 from tpu_inference.runner.utils import (
-    PHASED_PROFILER_NUM_STEPS_TO_PROFILE_FOR, ForbidCompile, InferencePhase,
-    LatencyTracker, PhasedBasedProfiler,
+    PHASED_PROFILER_NUM_STEPS_TO_PROFILE_FOR, ContinuousBatchStatsLogger,
+    ForbidCompile, InferencePhase, LatencyTracker, PhasedBasedProfiler,
     determine_phase_from_batch_composition_stats, get_batch_composition_stats,
     get_padded_num_reqs_with_upper_limit, get_padded_token_len,
     get_req_paddings, get_token_paddings)
@@ -339,6 +341,111 @@ def test_determine_phase_from_batch_composition_stats(prefill_tokens,
 
 
 @pytest.fixture
+def continuous_logger_fixture(tmp_path):
+    """Fixture to mock dependencies for ContinuousBatchStatsLogger."""
+    target_module = "tpu_inference.runner.utils"
+    with patch(f"{target_module}.datetime") as mock_datetime, \
+         patch(f"{target_module}.atexit") as mock_atexit, \
+         patch(f"{target_module}.subprocess.run") as mock_subprocess_run, \
+         patch(f"{target_module}.tempfile.gettempdir", return_value=str(tmp_path)):
+
+        mock_now = MagicMock()
+        mock_now.strftime.return_value = "2025_01_01_12_00_00"
+        mock_datetime.datetime.now.return_value = mock_now
+
+        yield {
+            "mock_datetime": mock_datetime,
+            "mock_atexit": mock_atexit,
+            "mock_subprocess_run": mock_subprocess_run,
+            "tmp_path": tmp_path,
+        }
+
+
+def test_continuous_logger_initialization_local_path(continuous_logger_fixture):
+    """Test logger initialization with a local directory."""
+    tmp_path = continuous_logger_fixture["tmp_path"]
+    profile_dir = tmp_path / "profiles"
+    logger = ContinuousBatchStatsLogger(profile_dir=str(profile_dir))
+
+    expected_filename = "all_batches_stats_2025_01_01_12_00_00.jsonl"
+    expected_path = profile_dir / expected_filename
+
+    assert logger.profile_dir == str(profile_dir)
+    assert logger.local_temp_file == str(expected_path)
+    assert logger.target_file == str(expected_path)
+    assert profile_dir.exists()
+    assert expected_path.exists()
+    assert expected_path.read_text() == ""
+
+    continuous_logger_fixture["mock_atexit"].register.assert_called_once_with(
+        logger.close)
+
+
+def test_continuous_logger_initialization_gcs_path(continuous_logger_fixture):
+    """Test logger initialization with a GCS directory."""
+    tmp_path = continuous_logger_fixture["tmp_path"]
+    profile_dir = "gs://my-bucket/profiles"
+    logger = ContinuousBatchStatsLogger(profile_dir=profile_dir)
+
+    expected_filename = "all_batches_stats_2025_01_01_12_00_00.jsonl"
+    expected_local_path = tmp_path / expected_filename
+    expected_target_path = f"gs://my-bucket/profiles/{expected_filename}"
+
+    assert logger.profile_dir == profile_dir
+    assert logger.local_temp_file == str(expected_local_path)
+    assert logger.target_file == expected_target_path
+    assert expected_local_path.exists()
+    assert expected_local_path.read_text() == ""
+
+    continuous_logger_fixture["mock_atexit"].register.assert_called_once_with(
+        logger.close)
+
+
+def test_continuous_logger_log_single_entry(continuous_logger_fixture):
+    """Test logging a single statistics dictionary."""
+    tmp_path = continuous_logger_fixture["tmp_path"]
+    profile_dir = tmp_path / "logs"
+    logger = ContinuousBatchStatsLogger(profile_dir=str(profile_dir))
+
+    stats = {"batch_no": 1, "tokens": 100}
+    logger.log(stats)
+
+    expected_json = '{"batch_no": 1, "tokens": 100}\n'
+    local_file_path = Path(logger.local_temp_file)
+    assert local_file_path.read_text() == expected_json
+
+
+def test_continuous_logger_auto_flush(continuous_logger_fixture):
+    """Test that flush is called automatically after flush_interval."""
+    profile_dir = "gs://my-bucket/logs"
+    flush_interval = 3
+    logger = ContinuousBatchStatsLogger(profile_dir=profile_dir,
+                                        flush_interval=flush_interval)
+    mock_subprocess_run = continuous_logger_fixture["mock_subprocess_run"]
+
+    for i in range(flush_interval - 1):
+        logger.log({"step": i})
+    mock_subprocess_run.assert_not_called()
+
+    logger.log({"step": flush_interval - 1})
+    mock_subprocess_run.assert_called_once()
+
+
+def test_continuous_logger_close_flushes_and_cleans_up_gcs(continuous_logger_fixture):
+    """Test that close() flushes and removes the local temp file for GCS."""
+    profile_dir = "gs://my-bucket/logs"
+    logger = ContinuousBatchStatsLogger(profile_dir=profile_dir)
+    mock_subprocess_run = continuous_logger_fixture["mock_subprocess_run"]
+    logger.log({"step": 1})
+    local_file_path = Path(logger.local_temp_file)
+
+    with patch("os.remove") as mock_os_remove:
+        logger.close()
+        mock_subprocess_run.assert_called_once()
+        mock_os_remove.assert_called_once_with(str(local_file_path))
+
+
+@pytest.fixture
 def profiler_fixture(tmp_path):
     """Fixture to set up a PhasedBasedProfiler with mocked dependencies."""
     target_module = "tpu_inference.runner.utils"
@@ -363,6 +470,37 @@ def profiler_fixture(tmp_path):
             "mock_file": mock_file,
             "mock_determine_phase": mock_determine_phase,
         }
+
+
+def test_phased_profiler_initializes_continuous_logger(tmp_path):
+    """Tests that PhasedBasedProfiler initializes ContinuousBatchStatsLogger."""
+    with patch("tpu_inference.runner.utils.envs.ENABLE_CONTINUOUS_BATCH_LOGGER", True), \
+         patch("tpu_inference.runner.utils.ContinuousBatchStatsLogger") as mock_logger_cls:
+        # Test with worker_rank = 0
+        PhasedBasedProfiler(profile_dir=str(tmp_path),
+                            worker_rank=0,
+                            flush_interval=50)
+        mock_logger_cls.assert_called_once_with(str(tmp_path), 50)
+
+        # Test with worker_rank != 0
+        mock_logger_cls.reset_mock()
+        PhasedBasedProfiler(profile_dir=str(tmp_path), worker_rank=1)
+        mock_logger_cls.assert_not_called()
+
+    with patch("tpu_inference.runner.utils.envs.ENABLE_CONTINUOUS_BATCH_LOGGER", False), \
+         patch("tpu_inference.runner.utils.ContinuousBatchStatsLogger") as mock_logger_cls:
+        # Test with continuous logging disabled
+        PhasedBasedProfiler(profile_dir=str(tmp_path), worker_rank=0)
+        mock_logger_cls.assert_not_called()
+
+
+def test_phased_profiler_step_calls_continuous_logger(profiler_fixture):
+    """Tests that profiler.step() calls continuous_logger.log()."""
+    profiler = profiler_fixture["profiler"]
+    profiler.continuous_logger = MagicMock()
+    stats = {"batch_no": 1, "tokens": 100}
+    profiler.step(stats)
+    profiler.continuous_logger.log.assert_called_once_with(stats)
 
 
 def test_phased_profiler_full_cycle(profiler_fixture):

--- a/tests/runner/test_utils.py
+++ b/tests/runner/test_utils.py
@@ -264,47 +264,51 @@ class MockSchedulerOutput:
 
 
 @pytest.mark.parametrize(
-    "scenario, num_reqs, req_ids, computed, scheduled, expected_prefill, expected_decode",
+    "scenario, num_reqs, req_ids, computed, scheduled, expected_prefill, expected_decode, expected_phase",
     [
         ("prefill_only", 2, [101, 102], [0, 0], {
             101: 50,
             102: 100
-        }, 150, 0),
+        }, 150, 0, "PREFILL_ONLY"),
         ("decode_only", 3, [201, 202, 203], [10, 20, 5], {
             201: 1,
             202: 1,
             203: 1
-        }, 0, 3),
+        }, 0, 3, "DECODE_ONLY"),
         ("mixed_batch", 4, [301, 302, 303, 304], [0, 10, 0, 20], {
             301: 100,
             302: 1,
             303: 50,
             304: 1
-        }, 150, 2),
+        }, 150, 2, "PREFILL_HEAVY"),
         ("chunked_prefill", 2, [401, 402], [50, 10], {
             401: 50,
             402: 1
-        }, 50, 1),
+        }, 50, 1, "PREFILL_HEAVY"),
     ])
 def test_get_batch_composition_stats(scenario, num_reqs, req_ids, computed,
                                      scheduled, expected_prefill,
-                                     expected_decode):
+                                     expected_decode, expected_phase):
     """Tests get_batch_composition_stats for various scenarios."""
     input_batch = MockInputBatch(req_ids, computed)
     scheduler_output = MockSchedulerOutput(scheduled)
     total_tokens = sum(scheduled.values())
+    batch_no = 42
 
     stats = get_batch_composition_stats(
+        batch_no=batch_no,
         input_batch=input_batch,
         total_num_scheduled_tokens=total_tokens,
         num_reqs=num_reqs,
         padded_total_num_scheduled_tokens=total_tokens + 8,
         scheduler_output=scheduler_output)
 
+    assert stats["batch_no"] == batch_no
     assert stats["num_prefill_tokens"] == expected_prefill
     assert stats["num_decode_tokens"] == expected_decode
     assert stats["num_reqs"] == num_reqs
     assert stats["total_num_scheduled_tokens"] == total_tokens
+    assert stats["phase"] == expected_phase
 
 
 @pytest.mark.parametrize("prefill_tokens, total_tokens, expected_phase", [

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -64,6 +64,7 @@ def test_boolean_env_vars(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv("USE_MOE_EP_KERNEL", "0")
     monkeypatch.setenv("LAYOUT_Q_PROJ_AS_NDH", "0")
     monkeypatch.setenv("USE_BATCHED_RPA_KERNEL", "0")
+    monkeypatch.setenv("ENABLE_CONTINUOUS_BATCH_LOGGER", "0")
 
     # Test SKIP_JAX_PRECOMPILE (default False)
     assert envs.SKIP_JAX_PRECOMPILE is False
@@ -103,6 +104,12 @@ def test_boolean_env_vars(monkeypatch: pytest.MonkeyPatch):
     assert envs.USE_BATCHED_RPA_KERNEL is False
     monkeypatch.setenv("USE_BATCHED_RPA_KERNEL", "1")
     assert envs.USE_BATCHED_RPA_KERNEL is True
+
+    # Test ENABLE_CONTINUOUS_BATCH_LOGGER
+    assert envs.ENABLE_CONTINUOUS_BATCH_LOGGER is False
+    monkeypatch.setenv("PHASED_PROFILING_DIR", "/tmp")
+    monkeypatch.setenv("ENABLE_CONTINUOUS_BATCH_LOGGER", "1")
+    assert envs.ENABLE_CONTINUOUS_BATCH_LOGGER is True
 
 
 def test_boolean_env_vars_string_values(monkeypatch: pytest.MonkeyPatch):
@@ -312,3 +319,10 @@ def test_cache_preserves_values_across_env_changes(
 
     # Now it should reflect the new value
     assert envs.JAX_PLATFORMS == "cpu"
+
+def test_continuous_batch_logger_validation(monkeypatch: pytest.MonkeyPatch):
+    """Test that ENABLE_CONTINUOUS_BATCH_LOGGER requires PHASED_PROFILING_DIR"""
+    monkeypatch.setenv("ENABLE_CONTINUOUS_BATCH_LOGGER", "1")
+    monkeypatch.delenv("PHASED_PROFILING_DIR", raising=False)
+    with pytest.raises(ValueError, match="ENABLE_CONTINUOUS_BATCH_LOGGER can only be set if PHASED_PROFILING_DIR is set."):
+        _ = envs.ENABLE_CONTINUOUS_BATCH_LOGGER

--- a/tpu_inference/envs.py
+++ b/tpu_inference/envs.py
@@ -91,7 +91,7 @@ def env_with_choices(
     return _get_validated_env
 
 
-def env_bool(env_name: str, default: bool = False) -> Callable[[], bool]:
+def env_bool(env_name: str, default: bool = False, requires: list[str] | None = None) -> Callable[[], bool]:
     """
     Accepts both numeric strings ("0", "1") and boolean strings
     ("true", "false", "True", "False").
@@ -99,22 +99,30 @@ def env_bool(env_name: str, default: bool = False) -> Callable[[], bool]:
     Args:
         env_name: Name of the environment variable
         default: Default boolean value if not set
+        requires: List of environment variables that must be set if this is True.
     """
 
     def _get_bool_env() -> bool:
         value = os.getenv(env_name)
         if value is None or value == "":
-            return default
-
-        value_lower = value.lower()
-        if value_lower in ("true", "1"):
-            return True
-        elif value_lower in ("false", "0"):
-            return False
+            parsed_value = default
         else:
-            raise ValueError(
-                f"Invalid boolean value '{value}' for {env_name}. "
-                f"Valid options: '0', '1', 'true', 'false', 'True', 'False'.")
+            value_lower = value.lower()
+            if value_lower in ("true", "1"):
+                parsed_value = True
+            elif value_lower in ("false", "0"):
+                parsed_value = False
+            else:
+                raise ValueError(
+                    f"Invalid boolean value '{value}' for {env_name}. "
+                    f"Valid options: '0', '1', 'true', 'false', 'True', 'False'.")
+
+        if parsed_value and requires:
+            for req in requires:
+                if not os.getenv(req):
+                    raise ValueError(f"{env_name} can only be set if {req} is set.")
+
+        return parsed_value
 
     return _get_bool_env
 
@@ -248,6 +256,8 @@ environment_variables: dict[str, Callable[[], Any]] = {
     env_with_choices(
         "RAGGED_GATED_DELTA_RULE_IMPL", "ragged_gated_delta_rule_chunked",
         ["ragged_gated_delta_rule_ref", "ragged_gated_delta_rule_chunked"]),
+    "ENABLE_CONTINUOUS_BATCH_LOGGER":
+    env_bool("ENABLE_CONTINUOUS_BATCH_LOGGER", default=False, requires=["PHASED_PROFILING_DIR"]),
 }
 
 

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -296,6 +296,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         self._pre_async_results: AsyncPreResults | None = None
         self._substitute_placeholder_token_fn = _substitute_placeholder_token
         self.execute_model_state: ExecuteModelState | None = None
+        self.batch_counter = 0
 
         self.kv_caches: list[jax.Array] = []
         self.layer_name_to_kvcache_index: dict[str, int] = {}
@@ -1467,8 +1468,10 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
 
         # Please see runner_utils.PhasedBasedProfiler for details
         if self.phase_based_profiler:
+            self.batch_counter += 1
             batch_composition_stats = runner_utils.get_batch_composition_stats(
-                self.input_batch, total_num_scheduled_tokens, num_reqs,
+                self.batch_counter, self.input_batch,
+                total_num_scheduled_tokens, num_reqs,
                 padded_total_num_scheduled_tokens, scheduler_output)
 
             self.phase_based_profiler.step(batch_composition_stats)
@@ -1662,8 +1665,10 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
 
         # Please see runner_utils.PhasedBasedProfiler for details
         if self.phase_based_profiler:
+            self.batch_counter += 1
             batch_composition_stats = runner_utils.get_batch_composition_stats(
-                self.input_batch, total_num_scheduled_tokens, num_reqs,
+                self.batch_counter, self.input_batch,
+                total_num_scheduled_tokens, num_reqs,
                 padded_total_num_scheduled_tokens, scheduler_output)
 
             self.phase_based_profiler.step(batch_composition_stats)

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -421,7 +421,8 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         self.phase_based_profiler = None
         if self.phased_profiling_dir:
             self.phase_based_profiler = runner_utils.PhasedBasedProfiler(
-                self.phased_profiling_dir)
+                self.phased_profiling_dir,
+                worker_rank=self.rank)
 
     def _init_mm(self) -> None:
         self.is_multimodal_model = None
@@ -1672,6 +1673,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                 padded_total_num_scheduled_tokens, scheduler_output)
 
             self.phase_based_profiler.step(batch_composition_stats)
+
 
         self.device_buffer.reset()
 

--- a/tpu_inference/runner/utils.py
+++ b/tpu_inference/runner/utils.py
@@ -43,6 +43,8 @@ class InferencePhase(Enum):
     DECODE_HEAVY = 1
     BALANCED = 2
     AMBIGUOUS = 3
+    PREFILL_ONLY = 4
+    DECODE_ONLY = 5
 
 
 def get_padded_num_reqs_with_upper_limit(x: int, upper_limit: int) -> int:
@@ -260,15 +262,19 @@ def determine_phase_from_batch_composition_stats(
     total_num_scheduled_tokens = batch_composition_stats[
         "total_num_scheduled_tokens"]
     prefill_ratio_for_batch = num_prefill_tokens / total_num_scheduled_tokens
+    if prefill_ratio_for_batch == 1.0:
+        return InferencePhase.PREFILL_ONLY
+    if prefill_ratio_for_batch == 0.0:
+        return InferencePhase.DECODE_ONLY
     if prefill_ratio_for_batch >= PREFILL_HEAVY_RATIO_THRESHOLD:
         return InferencePhase.PREFILL_HEAVY
-    elif prefill_ratio_for_batch <= DECODE_HEAVY_RATIO_THRESHOLD:
+    if prefill_ratio_for_batch <= DECODE_HEAVY_RATIO_THRESHOLD:
         return InferencePhase.DECODE_HEAVY
-    elif prefill_ratio_for_batch >= BALANCED_RATIO_THRESHOLD[
+    if prefill_ratio_for_batch >= BALANCED_RATIO_THRESHOLD[
             0] and prefill_ratio_for_batch <= BALANCED_RATIO_THRESHOLD[1]:
         return InferencePhase.BALANCED
-    else:
-        return InferencePhase.AMBIGUOUS
+
+    return InferencePhase.AMBIGUOUS
 
 
 class PhasedBasedProfiler:
@@ -307,7 +313,9 @@ class PhasedBasedProfiler:
         self.profile_dir: str = profile_dir
         # NOTE: we purposely don't have AMBIGUOUS here
         self.inference_phase_seen: dict = {
+            InferencePhase.PREFILL_ONLY: False,
             InferencePhase.PREFILL_HEAVY: False,
+            InferencePhase.DECODE_ONLY: False,
             InferencePhase.DECODE_HEAVY: False,
             InferencePhase.BALANCED: False
         }

--- a/tpu_inference/runner/utils.py
+++ b/tpu_inference/runner/utils.py
@@ -186,6 +186,7 @@ class ForbidCompile:
 
 
 def get_batch_composition_stats(
+        batch_no: int,
         input_batch: InputBatch, total_num_scheduled_tokens: int,
         num_reqs: int, padded_total_num_scheduled_tokens: int,
         scheduler_output: "VllmSchedulerOutput") -> dict:
@@ -233,13 +234,17 @@ def get_batch_composition_stats(
             else:
                 # It's a single token for an ongoing request, so it's decode
                 num_decode_tokens += 1
-    return {
+
+    stats = {
+        "batch_no": batch_no,
         "total_num_scheduled_tokens": total_num_scheduled_tokens,
         "num_prefill_tokens": num_prefill_tokens,
         "num_decode_tokens": num_decode_tokens,
         "padded_total_num_scheduled_tokens": padded_total_num_scheduled_tokens,
         "num_reqs": num_reqs
     }
+    stats["phase"] = determine_phase_from_batch_composition_stats(stats).name
+    return stats
 
 
 def determine_phase_from_batch_composition_stats(

--- a/tpu_inference/runner/utils.py
+++ b/tpu_inference/runner/utils.py
@@ -7,8 +7,11 @@ import datetime
 import functools
 import json
 import os
+import subprocess
+import tempfile
 import time
 from enum import Enum
+import atexit
 from typing import Any
 
 import jax
@@ -282,6 +285,70 @@ def determine_phase_from_batch_composition_stats(
     return InferencePhase.AMBIGUOUS
 
 
+class ContinuousBatchStatsLogger:
+    """
+    Logs batch composition stats continuously for all steps to a file and
+    periodically flushes them to GCS if required.
+    """
+
+    def __init__(self, profile_dir: str, flush_interval: int = 100):
+        self.profile_dir = profile_dir
+        self.flush_interval = flush_interval
+        self.step_count = 0
+
+        now = datetime.datetime.now()
+        date_string = now.strftime("%Y_%m_%d_%H_%M_%S")
+        filename = f"all_batches_stats_{date_string}.jsonl"
+        self.local_temp_file, self.target_file = \
+            self._get_local_and_target_paths(self.profile_dir, filename)
+
+        self._f_local = open(self.local_temp_file, "w")
+        self._f_tmp = open("/tmp/all_batches_stats.jsonl", "w")
+
+        logger.info(f"Initialized ContinuousBatchLogger with output path: {self.target_file}")
+        atexit.register(self.close)
+
+    def _get_local_and_target_paths(self, base_dir: str, filename: str) -> tuple[str, str]:
+        """Helper to resolve local temp path vs final target path (e.g. for GCS)."""
+        target = os.path.join(base_dir, filename)
+        if base_dir.startswith("gs://"):
+            return os.path.join(tempfile.gettempdir(), filename), target
+        os.makedirs(base_dir, exist_ok=True)
+        return target, target
+
+    def _sync_to_gcs(self, local_file: str, target_file: str) -> None:
+        """Helper to sync local file to GCS."""
+        if target_file.startswith("gs://") and os.path.exists(local_file):
+            subprocess.Popen(["gcloud", "storage", "cp", local_file, target_file],
+                             stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+    def log(self, batch_composition_stats: dict) -> None:
+        stats_json = json.dumps(batch_composition_stats) + "\n"
+        self._f_local.write(stats_json)
+        self._f_tmp.write(stats_json)
+
+        self.step_count += 1
+        if self.step_count % self.flush_interval == 0:
+            self.flush()
+
+    def flush(self) -> None:
+        self._f_local.flush()
+        self._f_tmp.flush()
+        if self.target_file.startswith("gs://") and os.path.exists(self.local_temp_file):
+            logger.info(f"Syncing continuous batch stats to {self.target_file} (Step {self.step_count})...")
+            self._sync_to_gcs(self.local_temp_file, self.target_file)
+
+    def close(self) -> None:
+        self.flush()
+        self._f_local.close()
+        self._f_tmp.close()
+        if self.profile_dir.startswith("gs://") and os.path.exists(self.local_temp_file):
+            try:
+                os.remove(self.local_temp_file)
+            except OSError:
+                pass
+
+
 class PhasedBasedProfiler:
     """
     Implements a phased-based profiler, which will profile three phases:
@@ -294,6 +361,7 @@ class PhasedBasedProfiler:
 
     Args:
         profile_dir: The directory to save the profiles to.
+        worker_rank: The rank of the current worker process.
 
     Attributes:
         profiling_n_steps_left: The number of steps left to profile for the current phase.
@@ -305,7 +373,7 @@ class PhasedBasedProfiler:
         current_phase: The current phase.
     """
 
-    def __init__(self, profile_dir: str):
+    def __init__(self, profile_dir: str, worker_rank: int = 0, flush_interval: int = 100):
         self.profiling_n_steps_left: int = 0
         self.profile_dir_with_phase_suffix: str = None
         self.num_steps_to_profile_for: int = int(
@@ -328,6 +396,12 @@ class PhasedBasedProfiler:
         self.default_profiling_options.python_tracer_level = envs.PYTHON_TRACER_LEVEL
 
         self.current_phase: str = ""
+
+        self.worker_rank = worker_rank
+        self.continuous_logger = None
+
+        if self.worker_rank == 0 and envs.ENABLE_CONTINUOUS_BATCH_LOGGER:
+            self.continuous_logger = ContinuousBatchStatsLogger(self.profile_dir, flush_interval)
 
         logger.info(
             "Phased-based profiler enabled. Traces will be saved to: %s",
@@ -442,6 +516,9 @@ class PhasedBasedProfiler:
                     padded_total_num_scheduled_tokens: The padded total number of tokens scheduled for the batch.
                     num_reqs: The number of requests in the batch.
         """
+        if self.continuous_logger is not None:
+            self.continuous_logger.log(batch_composition_stats)
+
         have_seen_all_phases = all(self.inference_phase_seen.values())
         # We want to start profiling only after the first trial request
         is_past_initial_request = batch_composition_stats[


### PR DESCRIPTION
# Description

This PR introduces `scripts/stats/plot_batch_stats.py`, a new standalone utility script to visualize TPU inference telemetry and batch statistics.

**Details and Context:**
- **Why is this change being made?** We need an automated way to parse, analyze, and visualize this data.
- **The problem being solved:** Raw JSONL logs are difficult to interpret manually. This script transforms the raw numbers into clear time-series graphs and bar charts so developers can easily diagnose scheduling inefficiencies, padding waste, and workload characteristics.
- **Specific implementation:**
  - Uses `pandas` for efficient JSONL parsing and data manipulation, and `matplotlib` for graphing.
  - Generates three distinct visualizations:
    1. **Tokens vs Requests:** A time-series showing the magnitude of prefill/decode tokens alongside the number of active requests per batch.
    2. **Bucket Utilization:** A stacked area chart displaying the percentage of the TPU hardware shape bucket that is actively utilized versus wasted on padding.
    3. **Token Volume by Phase:** A bar chart breaking down the total token volume distributed across different inference phases (e.g., `PREFILL_ONLY`, `BALANCED`, `DECODE_ONLY`).
  - **CLI Flexibility:** Uses `argparse` to allow users to generate all graphs or specify a subset using the `--graphs` argument.
  - **Robustness:** Includes error handling to gracefully skip graphs if the input JSONL is missing required telemetry columns or contains corrupted data.

# Tests

I tested this script locally by running an inference benchmark to generate a sample `/tmp/all_batches_stats.jsonl` file, and then executing the script:
```bash
# Generate all graphs
python scripts/stats/plot_batch_stats.py -i /tmp/all_batches_stats.jsonl -o /tmp/batch_stats/

# Generate only specific graphs
python scripts/stats/plot_batch_stats.py -i /tmp/all_batches_stats.jsonl -o /tmp/batch_stats/ --graphs bucket_utilization token_volume_by_phase
```

Here are examples of the generated graphs:

<img width="6168" height="2590" alt="image" src="https://github.com/user-attachments/assets/9e951dd1-92d0-4d9f-89a9-5b9b723309fd" />
<img width="6168" height="2590" alt="image" src="https://github.com/user-attachments/assets/b4410d2c-b5cd-430f-b25a-cd04acf45c54" />
<img width="6168" height="2590" alt="image" src="https://github.com/user-attachments/assets/4437c620-10c7-40f9-b1f8-291145df76df" />
<img width="3200" height="1326" alt="image" src="https://github.com/user-attachments/assets/097888e9-47bd-4d0a-94dd-571d2a05c8fd" />

