### PR TITLE
Flip pinned tensors to unpinned tensors on host

### DIFF
--- a/tpu_inference/offload/tpu_offload_connector.py
+++ b/tpu_inference/offload/tpu_offload_connector.py
@@ -1729,7 +1729,7 @@ class TPUOffloadConnectorWorker:
             self.host_sharding = jax.sharding.NamedSharding(
                 mesh=self.device_sharding.mesh,
                 spec=jax.sharding.PartitionSpec(None, None, "model"),
-                memory_kind="pinned_host")
+                memory_kind="unpinned_host")
             # [num_blocks * block_size, num_head, 2, head_dim]
             self.flatten_device_sharding = jax.sharding.NamedSharding(
                 mesh=self.device_sharding.mesh,
@@ -1738,12 +1738,12 @@ class TPUOffloadConnectorWorker:
             self.flatten_host_sharding = jax.sharding.NamedSharding(
                 mesh=self.device_sharding.mesh,
                 spec=jax.sharding.PartitionSpec(None, "model"),
-                memory_kind="pinned_host")
+                memory_kind="unpinned_host")
             # [1, num_layers, block_size, num_head, 2, head_dim]
             self.expanded_host_sharding = jax.sharding.NamedSharding(
                 mesh=self.device_sharding.mesh,
                 spec=jax.sharding.PartitionSpec(None, None, None, "model"),
-                memory_kind="pinned_host")
+                memory_kind="unpinned_host")
             self.expanded_device_sharding = jax.sharding.NamedSharding(
                 mesh=self.device_sharding.mesh,
                 spec=jax.sharding.PartitionSpec(None, None, None, "model"),


### PR DESCRIPTION
Ensure that the tensors used for kv-cache-offloading are unpinned on host.