### PR TITLE
Updating DS-R1 bsz to 2560 in dashboards.

### DIFF
--- a/scripts/multihost/benchmarks/jax/run_deepseek_v3_1k_8k.sh
+++ b/scripts/multihost/benchmarks/jax/run_deepseek_v3_1k_8k.sh
@@ -14,7 +14,7 @@ bash "${NIGHTLY_SCRIPT}" \
   --input-len 1024 \
   --output-len 8192 \
   --tp-size 16 \
-  --max-seqs 128 \
+  --max-seqs 160 \
   --max-model-len 9216 \
   --max-batched-tokens 512 \
   --num-prompts 2048 \
@@ -23,7 +23,7 @@ bash "${NIGHTLY_SCRIPT}" \
   --device "tpu7x-16" \
   --created-by "bm-scheduler" \
   --new-model-design "1" \
-  --gpu-memory-utilization "0.92" \
+  --gpu-memory-utilization "0.95" \
   --enable-expert-parallel \
   --additional-config '{"sharding": {"sharding_strategy": {"enable_dp_attention": true, "expert_parallelism": 16, "tensor_parallelism": 1}}, "replicate_attn_weights": "True", "sparse_matmul": "True"}' \
   --disable-shared-experts-stream "0" \

--- a/scripts/multihost/benchmarks/jax/xprof/xprof_deepseek_v3_1k_8k.sh
+++ b/scripts/multihost/benchmarks/jax/xprof/xprof_deepseek_v3_1k_8k.sh
@@ -15,7 +15,7 @@ bash "${NIGHTLY_SCRIPT}" \
   --input-len 1024 \
   --output-len 8192 \
   --tp-size 16 \
-  --max-seqs 128 \
+  --max-seqs 160 \
   --max-model-len 9216 \
   --max-batched-tokens 512 \
   --num-prompts 2048 \
@@ -24,7 +24,7 @@ bash "${NIGHTLY_SCRIPT}" \
   --device "tpu7x-16" \
   --created-by "bm-scheduler" \
   --new-model-design "1" \
-  --gpu-memory-utilization "0.85" \
+  --gpu-memory-utilization "0.95" \
   --enable-expert-parallel \
   --additional-config '{"sharding": {"sharding_strategy": {"enable_dp_attention": true, "expert_parallelism": 16, "tensor_parallelism": 1}}, "replicate_attn_weights": "True", "sparse_matmul": "True"}' \
   --disable-shared-experts-stream "0" \

--- a/scripts/multihost/benchmarks/torchax/run_deepseek_v3_1k_8k.sh
+++ b/scripts/multihost/benchmarks/torchax/run_deepseek_v3_1k_8k.sh
@@ -14,7 +14,7 @@ bash "${NIGHTLY_SCRIPT}" \
   --input-len 1024 \
   --output-len 8192 \
   --tp-size 16 \
-  --max-seqs 128 \
+  --max-seqs 160 \
   --max-model-len 9216 \
   --max-batched-tokens 512 \
   --num-prompts 2048 \
@@ -23,7 +23,7 @@ bash "${NIGHTLY_SCRIPT}" \
   --device "tpu7x-16" \
   --created-by "bm-scheduler" \
   --new-model-design "1" \
-  --gpu-memory-utilization "0.92" \
+  --gpu-memory-utilization "0.95" \
   --enable-expert-parallel \
   --additional-config '{"sharding": {"sharding_strategy": {"enable_dp_attention": true}}}' \
   --disable-shared-experts-stream "0" \

--- a/scripts/multihost/benchmarks/torchax/run_deepseek_v3_1k_8k_random_routing.sh
+++ b/scripts/multihost/benchmarks/torchax/run_deepseek_v3_1k_8k_random_routing.sh
@@ -14,7 +14,7 @@ bash "${NIGHTLY_SCRIPT}" \
   --input-len 1024 \
   --output-len 8192 \
   --tp-size 16 \
-  --max-seqs 128 \
+  --max-seqs 160 \
   --max-model-len 9216 \
   --max-batched-tokens 512 \
   --num-prompts 2048 \
@@ -23,7 +23,7 @@ bash "${NIGHTLY_SCRIPT}" \
   --device "tpu7x-16" \
   --created-by "bm-scheduler" \
   --new-model-design "1" \
-  --gpu-memory-utilization "0.92" \
+  --gpu-memory-utilization "0.95" \
   --enable-expert-parallel \
   --additional-config '{"sharding": {"sharding_strategy": {"enable_dp_attention": true}}}' \
   --disable-shared-experts-stream "0" \

--- a/scripts/multihost/benchmarks/torchax/xprof/xprof_deepseek_v3_1k_8k.sh
+++ b/scripts/multihost/benchmarks/torchax/xprof/xprof_deepseek_v3_1k_8k.sh
@@ -15,7 +15,7 @@ bash "${NIGHTLY_SCRIPT}" \
   --input-len 1024 \
   --output-len 8192 \
   --tp-size 16 \
-  --max-seqs 128 \
+  --max-seqs 160 \
   --max-model-len 9216 \
   --max-batched-tokens 512 \
   --num-prompts 2048 \
@@ -24,7 +24,7 @@ bash "${NIGHTLY_SCRIPT}" \
   --device "tpu7x-16" \
   --created-by "bm-scheduler" \
   --new-model-design "1" \
-  --gpu-memory-utilization "0.92" \
+  --gpu-memory-utilization "0.95" \
   --enable-expert-parallel \
   --additional-config '{"sharding": {"sharding_strategy": {"enable_dp_attention": true}}}' \
   --disable-shared-experts-stream "0" \


### PR DESCRIPTION
# Description

Updating the batch size to 2560 and gpu-memory-utilization for Jax and Torchax multi host models in the performance dashboards.
e2e improvement is about 5%.

# Tests

Confirmed updating the batch size and utilization worked on a multi host machine.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
