### PR TITLE
Add a heuristic for the ragged-scatter to fallback to xla op for small input/output

### DIFF
--- a/tests/kernels/ragged_scatter_test.py
+++ b/tests/kernels/ragged_scatter_test.py
@@ -41,6 +41,12 @@ class ScatterTest(jtu.JaxTestCase):
                 [7168],
                 [jnp.bfloat16],
             ),
+            itertools.product(
+                [4096],
+                [(13, 500)],
+                [2048],
+                [jnp.bfloat16],
+            ),
         )
     ]
 

--- a/tpu_inference/kernels/sparse_core/ragged_scatter.py
+++ b/tpu_inference/kernels/sparse_core/ragged_scatter.py
@@ -391,6 +391,14 @@ def ragged_scatter(x: jax.Array, indices: jax.Array, start: jax.Array,
     dtype_bits = jax.dtypes.itemsize_bits(dtype)
     packing = 32 // dtype_bits
 
+    # Heuristic threshold on whether to fallback to xla gather.
+    if jnp.size(
+            x) * packing * 2 < pltpu.get_tpu_info().vmem_capacity_bytes * 0.6:
+        # For small {input + output}, it's likely that both can be put in TC VMEM,
+        # so it's likely faster to run TC-based gather on it than going through SC,
+        # without data movement to/from HBM.
+        return x[indices]
+
     hidden_size = x.shape[-1]
     out_size = indices.size
 


### PR DESCRIPTION
Add a heuristic for the ragged-scatter to fallback to xla op for small input/output.
The heuristic is: if the input size + output size is less than 60% of TPU VMEM size, fallback to XLA op instead.

# Tests
Add a new test case to demonstrate fallback is beneficial, the input is about 1/4 of VMEM size:
with XLA op: https://screenshot.googleplex.com/4ZRyU8RwKdJYeYk
with SC kernel: https://screenshot.googleplex.com/AB8adKVS8rpQoVx
