### PR TITLE
Append MoE expert IDs when enable_return_routed_experts is enabled

### DIFF
--- a/examples/offline_inference.py
+++ b/examples/offline_inference.py
@@ -52,6 +52,7 @@ def main(args: dict):
         use_chat_template = True
 
     # Create an LLM
+    args["enable_return_routed_experts"] = True
     llm = LLM(**args)
 
     # Create a sampling params object
@@ -133,6 +134,12 @@ def main(args: dict):
         prompt = output.prompt
         generated_text = output.outputs[0].text
         print(f"Prompt: {prompt!r}\nGenerated text: {generated_text!r}")
+
+        # Print experts if available
+        if hasattr(output.outputs[0], "routed_experts"
+                   ) and output.outputs[0].routed_experts is not None:
+            print(f"Routed experts: {output.outputs[0].routed_experts}")
+
         print("-" * 50)
 
 

--- a/examples/rl_inference.py
+++ b/examples/rl_inference.py
@@ -52,6 +52,7 @@ def main(args: dict):
         use_chat_template = True
 
     # Create an LLM
+    args["enable_return_routed_experts"] = True
     llm = LLM(**args)
 
     # Create a sampling params object
@@ -133,6 +134,12 @@ def main(args: dict):
         prompt = output.prompt
         generated_text = output.outputs[0].text
         print(f"Prompt: {prompt!r}\nGenerated text: {generated_text!r}")
+
+        # Print experts if available
+        if hasattr(output.outputs[0], "routed_experts"
+                   ) and output.outputs[0].routed_experts is not None:
+            print(f"Routed experts: {output.outputs[0].routed_experts}")
+
         print("-" * 50)
 
 

--- a/tests/layers/jax/moe/test_moe.py
+++ b/tests/layers/jax/moe/test_moe.py
@@ -174,7 +174,7 @@ class TestMoE(unittest.TestCase):
                                    apply_expert_weight_before_computation)
 
         with jax.set_mesh(self.mesh):
-            actual_output = moe(self.x)
+            actual_output, _ = moe(self.x)
 
             expected_output = self._compute_ground_truth(moe, self.x)
 
@@ -197,7 +197,7 @@ class TestMoE(unittest.TestCase):
 
         # Run Forward Pass (Distributed)
         with jax.set_mesh(self.mesh):
-            actual_output = moe(self.x)
+            actual_output, _ = moe(self.x)
 
         # Compute Ground Truth using the exact same weights
         expected_output = self._compute_ground_truth(moe, self.x)
@@ -220,13 +220,13 @@ class TestMoE(unittest.TestCase):
         # 1. Run Dense
         moe_dense = self._create_moe(MoEBackend.DENSE_MAT)
         with jax.set_mesh(self.mesh):
-            out_dense = moe_dense(self.x)
+            out_dense, _ = moe_dense(self.x)
 
         # 2. Run Sparse
         # We must re-init with same key to get same weights
         moe_sparse = self._create_moe(MoEBackend.MEGABLX_GMM)
         with jax.set_mesh(self.mesh):
-            out_sparse = moe_sparse(self.x)
+            out_sparse, _ = moe_sparse(self.x)
 
         self.assertTrue(
             jnp.allclose(out_dense, out_sparse, atol=5e-2, rtol=5e-2),

--- a/tests/runner/test_tpu_runner.py
+++ b/tests/runner/test_tpu_runner.py
@@ -189,6 +189,96 @@ class TestTPUJaxRunner:
         self.runner.kv_cache_config = mock_kv_cache_config
         self.runner.use_hybrid_kvcache = True
 
+    @patch(
+        'vllm.model_executor.layers.fused_moe.routed_experts_capturer.RoutedExpertsCapturer'
+    )
+    def test_execute_model_moe_experts(self, mock_capturer_class):
+        """Test that _execute_model correctly stores experts in the shared buffer."""
+        # 1. ===== Setup =====
+        mock_capturer = MagicMock()
+        mock_capturer_class.get_instance.return_value = mock_capturer
+        self.runner.experts_capturer = mock_capturer
+
+        max_tokens = 10
+        num_layers = 2
+        top_k = 1
+        dummy_buffer = np.zeros((max_tokens, num_layers, top_k),
+                                dtype=np.int32)
+        mock_capturer._host_buffer_view = dummy_buffer
+        mock_capturer._lock_file = "dummy.lock"
+
+        dummy_experts_layer0 = jnp.array([[72], [73]], dtype=jnp.int32)
+        dummy_experts_layer1 = jnp.array([[82], [83]], dtype=jnp.int32)
+
+        self.runner.model_fn = MagicMock()
+        self.runner.model_fn.return_value = (
+            MagicMock(),  # kv_caches
+            MagicMock(),  # hidden_states
+            MagicMock(),  # aux_hidden_states
+            [dummy_experts_layer0, dummy_experts_layer1]  # all_experts
+        )
+
+        self.runner.input_batch = MagicMock()
+        self.runner.input_batch.num_reqs = 1
+        self.runner.input_batch.req_ids = ['req1']
+        self.runner.input_batch.num_computed_tokens_cpu = np.array([0])
+        self.runner.input_batch.token_ids_cpu = np.zeros((8, 64),
+                                                         dtype=np.int32)
+        self.runner.input_batch.max_num_logprobs = 0
+        self.runner.input_batch.request_distribution = []
+        self.runner.get_mrope_input_positions_fn = None
+        self.runner.state = MagicMock()
+
+        mock_kv_cache_config = MagicMock()
+        mock_kv_cache_config.kv_cache_groups = [MagicMock()]
+        self.runner.kv_cache_config = mock_kv_cache_config
+
+        self.runner._prepare_inputs_non_dp = MagicMock(return_value=(
+            jnp.zeros((2, ), dtype=jnp.int32),  # input_ids
+            jnp.zeros((2, ), dtype=jnp.int32),  # positions
+            {},  # attention_metadata
+            MagicMock(),  # sampling_metadata
+            jnp.zeros((2, ), dtype=jnp.int32),  # logits_indices
+            None,  # spec_decode_metadata
+            None,  # logits_indices_selector
+            1,  # padded_num_reqs
+        ))
+
+        self.runner._select_from_array_fn = MagicMock(
+            side_effect=lambda x, *args, **kwargs: x)
+        self.runner.compute_logits_fn = MagicMock(
+            return_value=jnp.zeros((2, 1000), dtype=jnp.float32))
+        self.runner.pooler_fn = MagicMock()
+        self.runner.combine_hidden_states_fn = MagicMock()
+        self.runner.lora_manager = None
+        self.runner.model = None
+
+        scheduler_output = MagicMock()
+        scheduler_output.total_num_scheduled_tokens = 2
+        scheduler_output.num_scheduled_tokens = {'req1': 2}
+
+        dummy_slots = np.array([2, 5], dtype=np.int32)
+        self.runner._get_slot_mapping = MagicMock(return_value=dummy_slots)
+
+        # 2. ===== Act =====
+        with patch(
+                'vllm.model_executor.layers.fused_moe.routed_experts_capturer._file_lock',
+                return_value=MagicMock()):
+            self.runner._execute_model(scheduler_output)
+
+        # 3. ===== Assert =====
+        # The buffer dimensions are (Token_Slot, Layer, Expert_Rank)
+        # We mocked _get_slot_mapping to return [2, 5] for the 2 tokens in the batch.
+
+        # Token at slot 2, Layer 0, Top-1 expert is 72
+        assert dummy_buffer[2, 0, 0] == 72
+        # Token at slot 5, Layer 0, Top-1 expert is 73
+        assert dummy_buffer[5, 0, 0] == 73
+        # Token at slot 2, Layer 1, Top-1 expert is 82
+        assert dummy_buffer[2, 1, 0] == 82
+        # Token at slot 5, Layer 1, Top-1 expert is 83
+        assert dummy_buffer[5, 1, 0] == 83
+
 
 class TestTPUJaxRunnerMultimodalModelLoadedForTextOnly:
 

--- a/tpu_inference/layers/jax/moe/gpt_oss_moe.py
+++ b/tpu_inference/layers/jax/moe/gpt_oss_moe.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from dataclasses import InitVar, dataclass
+from typing import Optional
 
 import jax
 import jax.numpy as jnp
@@ -132,8 +133,9 @@ class GptOssMoE(nnx.Module):
     ed_sharding: Sharding
 
     random_init: bool = False
+    enable_return_routed_experts: bool = False
 
-    def __call__(self, x_TD: Float) -> Float:
+    def __call__(self, x_TD: Float) -> tuple[Float, Optional[jax.Array]]:
         """Performs the forward pass for the GPT-OSS MoE layer."""
         x_TD = jnp.asarray(x_TD, self.dtype)
         x_TD = lax.with_sharding_constraint(x_TD, self.activation_ffw_td)
@@ -169,7 +171,8 @@ class GptOssMoE(nnx.Module):
         # Weighted sum of expert outputs
         output_TD = self.combine_experts(down_proj_TED, weights_TX, indices_TX)
 
-        return output_TD
+        experts = indices_TX if self.enable_return_routed_experts else None
+        return output_TD, experts
 
     def __post_init__(self, rngs: nnx.Rngs):
         """Initializes all weights and biases for the MoE block."""

--- a/tpu_inference/layers/jax/moe/moe.py
+++ b/tpu_inference/layers/jax/moe/moe.py
@@ -170,20 +170,30 @@ class JaxMoE(JaxModule):
     quant_config: Optional[QuantizationConfig] = None
     prefix: str = ""
 
-    def __call__(self, x_TD: jax.Array) -> jax.Array:
+    def __call__(self,
+                 x_TD: jax.Array) -> tuple[jax.Array, Optional[jax.Array]]:
         """Performs the forward pass of the MoE layer.
 
         Args:
             x_TD: Input array of shape (sequence_length, d_model).
 
         Returns:
-            Output array of shape (sequence_length, d_model) after passing through MoE.
+            A tuple containing:
+                - Output array of shape (sequence_length, d_model) after passing through MoE.
+                - Indices of selected experts, shape (sequence_length, num_experts_per_tok) or None.
         """
         if self.quant_method is not None:
             router_logits = self.router(x_TD)
-            return self.quant_method.apply_jax(self,
+            x_TD = self.quant_method.apply_jax(self,
                                                x_TD,
                                                router_logits=router_logits)
+            if self.moe_backend in MoEBackend.fused_moe_backends():
+                _, selected_experts_TX = jax.lax.top_k(
+                    router_logits, self.num_experts_per_tok)
+            else:
+                _, selected_experts_TX = router_logits
+            return x_TD, selected_experts_TX
+
         raise ValueError("Expected quant_method to be set!")
 
     def __post_init__(self, rngs: nnx.Rngs):

--- a/tpu_inference/layers/jax/moe/moe.py
+++ b/tpu_inference/layers/jax/moe/moe.py
@@ -156,6 +156,7 @@ class JaxMoE(JaxModule):
     random_init: bool = False
     moe_backend: MoEBackend = MoEBackend.DENSE_MAT
     scoring_func: str = "softmax"
+    enable_return_routed_experts: bool = False
 
     # --- Sparse MoE Specific Attributes ---
     num_experts_per_tok: int = 1  # Required for Sparse, optional/derived for Dense
@@ -187,11 +188,15 @@ class JaxMoE(JaxModule):
             x_TD = self.quant_method.apply_jax(self,
                                                x_TD,
                                                router_logits=router_logits)
-            if self.moe_backend in MoEBackend.fused_moe_backends():
-                _, selected_experts_TX = jax.lax.top_k(
-                    router_logits, self.num_experts_per_tok)
+            if self.enable_return_routed_experts:
+                if self.moe_backend in MoEBackend.fused_moe_backends():
+                    _, selected_experts_TX = jax.lax.top_k(
+                        router_logits, self.num_experts_per_tok)
+                else:
+                    _, selected_experts_TX = router_logits
             else:
-                _, selected_experts_TX = router_logits
+                selected_experts_TX = None
+
             return x_TD, selected_experts_TX
 
         raise ValueError("Expected quant_method to be set!")

--- a/tpu_inference/layers/jax/transformer_block.py
+++ b/tpu_inference/layers/jax/transformer_block.py
@@ -40,9 +40,9 @@ class TransformerBlock(nnx.Module):
     quant: Any | None = None
 
     def __call__(
-            self, x_TD: jax.Array, is_prefill: bool, kv_cache: KVCache,
-            attention_metadata: AttentionMetadata
-    ) -> Tuple[KVCache, jax.Array]:
+        self, x_TD: jax.Array, is_prefill: bool, kv_cache: KVCache,
+        attention_metadata: AttentionMetadata
+    ) -> Tuple[KVCache, jax.Array, Optional[jax.Array]]:
         # Attn Block
         attn_residual_TD = x_TD
         x_TD = self.pre_attention_norm(x_TD)
@@ -54,9 +54,16 @@ class TransformerBlock(nnx.Module):
         # FFW Block
         ffw_residual_TD = attn_output_TD
         normed_ffw_input_TD = self.pre_mlp_norm(attn_output_TD)
-        logits_TD = self.custom_module(normed_ffw_input_TD)
+
+        custom_output = self.custom_module(normed_ffw_input_TD)
+        if isinstance(custom_output, tuple):
+            logits_TD, experts = custom_output
+        else:
+            logits_TD = custom_output
+            experts = None
+
         logits_TD += ffw_residual_TD
-        return new_cache, logits_TD
+        return new_cache, logits_TD, experts
 
 
 @dataclass(kw_only=True)
@@ -82,7 +89,9 @@ class SharedExpertsTransformerBlock(TransformerBlock):
     dense_ffw: Optional[DenseFFW] = None
     shared_experts: Optional[DenseFFW] = None
 
-    def __call__(self, x_TD, is_prefill, kv_cache, attention_metadata):
+    def __call__(
+            self, x_TD, is_prefill, kv_cache, attention_metadata
+    ) -> Tuple[KVCache, jax.Array, Optional[jax.Array]]:
         # Attn Block
         attn_residual_TD = x_TD
         x_TD = self.pre_attention_norm(x_TD)
@@ -105,8 +114,10 @@ class SharedExpertsTransformerBlock(TransformerBlock):
         else:
             dense_layer = self.dense_ffw
 
+        experts = None
         if moe_layer is not None:
-            logits_TD = moe_layer(normed_ffw_input_TD)
+            logits_TD, experts = moe_layer(normed_ffw_input_TD)
+
             # Add the shared expert outputs to the MoE outputs.
             shared_expert_output_TD = self.shared_experts(normed_ffw_input_TD)
             logits_TD += shared_expert_output_TD
@@ -118,4 +129,4 @@ class SharedExpertsTransformerBlock(TransformerBlock):
             )
 
         logits_TD += ffw_residual_TD
-        return new_cache, logits_TD
+        return new_cache, logits_TD, experts

--- a/tpu_inference/models/common/model_loader.py
+++ b/tpu_inference/models/common/model_loader.py
@@ -318,7 +318,8 @@ def get_flax_model(
         out_shardings=(
             kv_cache_sharding,
             hidden_states_sharding,
-            None,  # all_experts
+            hidden_states_sharding,  # aux hidden states
+            None,  # expert_indices
         ),
         donate_argnums=2,  # 0 is graphdef, 1 is state, 2 is kv_cache
         static_argnums=(

--- a/tpu_inference/models/common/model_loader.py
+++ b/tpu_inference/models/common/model_loader.py
@@ -318,7 +318,7 @@ def get_flax_model(
         out_shardings=(
             kv_cache_sharding,
             hidden_states_sharding,
-            hidden_states_sharding,  # aux hidden states
+            None,  # all_experts
         ),
         donate_argnums=2,  # 0 is graphdef, 1 is state, 2 is kv_cache
         static_argnums=(

--- a/tpu_inference/models/jax/deepseek_v3.py
+++ b/tpu_inference/models/jax/deepseek_v3.py
@@ -816,9 +816,16 @@ class SharedFusedMoe(JaxMoE):
 
     routed_scaling_factor: float = 1.0
 
-    def __call__(self, x_TD: jax.Array) -> jax.Array:
+    def __call__(self,
+                 x_TD: jax.Array) -> tuple[jax.Array, Optional[jax.Array]]:
         # Compute Routed Experts
-        final_hidden_states = super().__call__(x_TD)
+        custom_output = super().__call__(x_TD)
+        if isinstance(custom_output, tuple):
+            final_hidden_states, experts = custom_output
+        else:
+            final_hidden_states = custom_output
+            experts = None
+
         final_hidden_states *= self.routed_scaling_factor
 
         # (Maybe) Compute Shared Experts
@@ -826,7 +833,7 @@ class SharedFusedMoe(JaxMoE):
             shared_output = self.shared_experts(x_TD)
             final_hidden_states += shared_output
 
-        return final_hidden_states
+        return final_hidden_states, experts
 
 
 class DeepseekV2Moe(JaxModule):
@@ -844,7 +851,8 @@ class DeepseekV2Moe(JaxModule):
                  quant_config,
                  scoring_func,
                  rng,
-                 prefix: str = ""):
+                 prefix: str = "",
+                 enable_return_routed_experts: bool = False):
 
         self.gate = DeepSeekV3Router(
             hidden_size=hidden_size,
@@ -918,6 +926,7 @@ class DeepseekV2Moe(JaxModule):
             router=self.gate,
             shared_experts=self.shared_experts,
             scoring_func=scoring_func,
+            enable_return_routed_experts=enable_return_routed_experts,
             routed_scaling_factor=routed_scaling_factor)
 
     def __call__(self, x_TD: jax.Array):
@@ -946,7 +955,7 @@ class DeepseekV3DecoderLayer(JaxModule):
     def __call__(
         self, x_TD: jax.Array, *, kv_cache: List[jax.Array],
         attention_metadata: AttentionMetadata
-    ) -> Tuple[List[jax.Array], jax.Array]:
+    ) -> Tuple[List[jax.Array], jax.Array, Optional[jax.Array]]:
 
         # Run Self-Attention
         residual = x_TD
@@ -958,12 +967,18 @@ class DeepseekV3DecoderLayer(JaxModule):
         # Run MLP/MoE
         residual = hidden_states
         hidden_states = self.post_attention_layernorm(hidden_states)
-        mlp_output = self.mlp(hidden_states)
+
+        custom_output = self.mlp(hidden_states)
+        if isinstance(custom_output, tuple):
+            mlp_output, experts = custom_output
+        else:
+            mlp_output = custom_output
+            experts = None
 
         # Residual
         hidden_states = residual + mlp_output
 
-        return new_cache, hidden_states
+        return new_cache, hidden_states, experts
 
 
 class DeepSeekV3Router(JaxEinsum):
@@ -1283,6 +1298,8 @@ class DeepSeekV3(JaxModule):
                     quant_config=quant_config,
                     scoring_func=scoring_func,
                     rng=rng,
+                    enable_return_routed_experts=self.vllm_config.model_config.
+                    enable_return_routed_experts,
                     prefix=f"{prefix}.layers.{layer_index}.mlp")
 
             return DeepseekV3DecoderLayer(
@@ -1325,23 +1342,27 @@ class DeepSeekV3(JaxModule):
         input_ids: Optional[jax.Array],
         attention_metadata: AttentionMetadata,
         inputs_embeds: Optional[jax.Array] = None,
-    ) -> Tuple[List[jax.Array], jax.Array]:
+    ) -> Tuple[List[jax.Array], jax.Array, list]:
         if inputs_embeds is not None:
             x = inputs_embeds
         else:
             x = self.embed_tokens(input_ids)
 
+        all_experts = []
         for i, layer in enumerate(
                 islice(self.layers, self.start_layer, self.end_layer)):
             kv_cache = kv_caches[i]
-            kv_cache, x = layer(
+            kv_cache, x, experts = layer(
                 x,
                 kv_cache=kv_cache,
                 attention_metadata=attention_metadata,
             )
             kv_caches[i] = kv_cache
+            if experts is not None:
+                all_experts.append(experts)
+
         x = self.norm(x)
-        return kv_caches, x
+        return kv_caches, x, all_experts
 
 
 class DeepseekV3ForCausalLM(JaxModule, LoadableWithIterator):
@@ -1405,22 +1426,25 @@ class DeepseekV3ForCausalLM(JaxModule, LoadableWithIterator):
         is_last_rank: bool = True,
         *args,
     ) -> Tuple[List[jax.Array], jax.Array | JaxIntermediateTensors,
-               List[jax.Array]]:
+               List[jax.Array], list]:
         if not is_first_rank:
             assert intermediate_tensors is not None
             inputs_embeds = intermediate_tensors["hidden_states"]
 
-        kv_caches, x = self.model(
+        kv_caches, x, all_experts = self.model(
             kv_caches,
             input_ids,
             attention_metadata,
             inputs_embeds,
         )
 
+        if not self.vllm_config.model_config.enable_return_routed_experts:
+            all_experts = []
+
         if not is_last_rank:
             x = JaxIntermediateTensors(tensors={"hidden_states": x}, )
 
-        return kv_caches, x, []
+        return kv_caches, x, [], all_experts
 
     def compute_logits(self, hidden_states: jax.Array) -> jax.Array:
         return self.lm_head(hidden_states)

--- a/tpu_inference/models/jax/deepseek_v3.py
+++ b/tpu_inference/models/jax/deepseek_v3.py
@@ -1426,7 +1426,7 @@ class DeepseekV3ForCausalLM(JaxModule, LoadableWithIterator):
         is_last_rank: bool = True,
         *args,
     ) -> Tuple[List[jax.Array], jax.Array | JaxIntermediateTensors,
-               List[jax.Array], list]:
+               List[jax.Array], dict]:
         if not is_first_rank:
             assert intermediate_tensors is not None
             inputs_embeds = intermediate_tensors["hidden_states"]
@@ -1444,7 +1444,7 @@ class DeepseekV3ForCausalLM(JaxModule, LoadableWithIterator):
         if not is_last_rank:
             x = JaxIntermediateTensors(tensors={"hidden_states": x}, )
 
-        return kv_caches, x, [], all_experts
+        return kv_caches, x, [], {"expert_ids": all_experts}
 
     def compute_logits(self, hidden_states: jax.Array) -> jax.Array:
         return self.lm_head(hidden_states)

--- a/tpu_inference/models/jax/gemma4.py
+++ b/tpu_inference/models/jax/gemma4.py
@@ -858,7 +858,7 @@ class Gemma4ForCausalLM(JaxModule, LoadableWithIterator):
         is_last_rank: bool = True,
         *args,
     ) -> Tuple[List[jax.Array], jax.Array | JaxIntermediateTensors,
-               List[jax.Array], list]:
+               List[jax.Array], dict]:
 
         if not is_first_rank:
             assert intermediate_tensors is not None
@@ -877,7 +877,7 @@ class Gemma4ForCausalLM(JaxModule, LoadableWithIterator):
         if not is_last_rank:
             x = JaxIntermediateTensors(tensors={"hidden_states": x}, )
 
-        return kv_caches, x, [], all_experts
+        return kv_caches, x, [], {"expert_ids": all_experts}
 
     def compute_logits(self, hidden_states: jax.Array) -> jax.Array:
         if hasattr(self, 'lm_head'):

--- a/tpu_inference/models/jax/gemma4.py
+++ b/tpu_inference/models/jax/gemma4.py
@@ -232,9 +232,15 @@ class Gemma4MoE(JaxMoE):
             Output array of shape (sequence_length, d_model) after passing through MoE.
         """
         if self.quant_method is not None:
-            return self.quant_method.apply_jax(self,
-                                               x_TD,
-                                               router_logits=router_logits)
+            output_TD = self.quant_method.apply_jax(
+                self, x_TD, router_logits=router_logits)
+            if self.enable_return_routed_experts:
+                _, selected_experts_TX = jax.lax.top_k(
+                    router_logits, self.num_experts_per_tok)
+            else:
+                selected_experts_TX = None
+
+            return output_TD, selected_experts_TX
         raise ValueError("Expected quant_method to be set!")
 
     def load_weights(self, weights: Iterable):
@@ -597,6 +603,8 @@ class Gemma4DecoderLayer(JaxModule):
                                      mesh=mesh,
                                      rngs=rng,
                                      quant_config=quant_config,
+                                     enable_return_routed_experts=config.
+                                     enable_return_routed_experts,
                                      prefix=prefix + ".experts")
             self.post_feedforward_layernorm_1 = JaxRmsNorm(
                 text_config.hidden_size,
@@ -634,7 +642,7 @@ class Gemma4DecoderLayer(JaxModule):
         kv_cache: jax.Array,
         x: jax.Array,
         attention_metadata: AttentionMetadata,
-    ) -> Tuple[jax.Array, jax.Array]:
+    ) -> Tuple[jax.Array, jax.Array, Optional[jax.Array]]:
         residual = x
         hidden_states = self.input_layernorm(x)
         kv_cache, attn_output = self.self_attn(
@@ -646,6 +654,7 @@ class Gemma4DecoderLayer(JaxModule):
         hidden_states = residual + attn_output
         residual = hidden_states
 
+        experts = None
         if self.enable_moe_block:
             # Dense MLP branch
             hidden_states_1 = self.pre_feedforward_layernorm(hidden_states)
@@ -657,7 +666,10 @@ class Gemma4DecoderLayer(JaxModule):
             # norm + scale internally); experts see separately normed input
             router_logits = self.router(hidden_states)
             hidden_states_2 = self.pre_feedforward_layernorm_2(hidden_states)
-            hidden_states_2 = self.experts(hidden_states_2, router_logits)
+
+            hidden_states_2, experts = self.experts(hidden_states_2,
+                                                    router_logits)
+
             hidden_states_2 = self.post_feedforward_layernorm_2(
                 hidden_states_2)
 
@@ -673,7 +685,7 @@ class Gemma4DecoderLayer(JaxModule):
 
         outputs = outputs * self.layer_scalar.value
 
-        return kv_cache, outputs
+        return kv_cache, outputs, experts
 
 
 class Gemma4Model(JaxModule):
@@ -744,7 +756,7 @@ class Gemma4Model(JaxModule):
         attention_metadata: AttentionMetadata,
         inputs_embeds: Optional[jax.Array] = None,
         layer_name_to_kv_cache: Optional[dict] = None,
-    ) -> Tuple[List[jax.Array], jax.Array]:
+    ) -> Tuple[List[jax.Array], jax.Array, list]:
 
         if inputs_embeds is not None:
             x = inputs_embeds
@@ -753,6 +765,7 @@ class Gemma4Model(JaxModule):
             # Gemma4: Apply embedding scaling
             x = x * self.embedding_scale
 
+        all_experts = []
         for i, layer in enumerate(
                 islice(self.layers, self.start_layer, self.end_layer)):
             layer_name = f"layer.{i + self.start_layer}"
@@ -767,14 +780,17 @@ class Gemma4Model(JaxModule):
                 cache_idx = i + self.start_layer
 
             kv_cache = kv_caches[cache_idx]
-            kv_cache, x = layer(
+            kv_cache, x, experts = layer(
                 kv_cache,
                 x,
                 layer_attn_metadata,
             )
             kv_caches[cache_idx] = kv_cache
+            if experts is not None:
+                all_experts.append(experts)
+
         x = self.norm(x)
-        return kv_caches, x
+        return kv_caches, x, all_experts
 
 
 class Gemma4ForCausalLM(JaxModule, LoadableWithIterator):
@@ -842,7 +858,7 @@ class Gemma4ForCausalLM(JaxModule, LoadableWithIterator):
         is_last_rank: bool = True,
         *args,
     ) -> Tuple[List[jax.Array], jax.Array | JaxIntermediateTensors,
-               List[jax.Array]]:
+               List[jax.Array], list]:
 
         if not is_first_rank:
             assert intermediate_tensors is not None
@@ -850,7 +866,7 @@ class Gemma4ForCausalLM(JaxModule, LoadableWithIterator):
 
         layer_name_to_kv_cache = dict(
             _layer_name_to_kv_cache) if _layer_name_to_kv_cache else None
-        kv_caches, x = self.model(
+        kv_caches, x, all_experts = self.model(
             kv_caches,
             input_ids,
             attention_metadata,
@@ -861,7 +877,7 @@ class Gemma4ForCausalLM(JaxModule, LoadableWithIterator):
         if not is_last_rank:
             x = JaxIntermediateTensors(tensors={"hidden_states": x}, )
 
-        return kv_caches, x, []
+        return kv_caches, x, [], all_experts
 
     def compute_logits(self, hidden_states: jax.Array) -> jax.Array:
         if hasattr(self, 'lm_head'):

--- a/tpu_inference/models/jax/gpt_oss.py
+++ b/tpu_inference/models/jax/gpt_oss.py
@@ -154,6 +154,8 @@ class GptOss(nnx.Module):
                 edf_sharding=P('model', None, None),
                 efd_sharding=P('model', None, None),
                 ed_sharding=P('model', None),
+                enable_return_routed_experts=self.vllm_config.model_config.
+                enable_return_routed_experts,
             )
 
             block = TransformerBlock(
@@ -523,21 +525,25 @@ class GptOss(nnx.Module):
         input_ids: jax.Array,
         attention_metadata: AttentionMetadata,
         *args,
-    ) -> Tuple[List[KVCacheType], jax.Array, List[jax.Array]]:
+    ) -> Tuple[List[KVCacheType], jax.Array, List[jax.Array], list]:
         is_prefill = False
         x = self.embedder.encode(input_ids)
 
+        all_experts = []
         for i, block in enumerate(self.layers):
             kv_cache = kv_caches[i]
             current_sliding_window = self.sliding_window if i % 2 == 0 else None
             attention_metadata.sliding_window = current_sliding_window
 
-            new_kv_cache, x = block(x, is_prefill, kv_cache,
-                                    attention_metadata)
+            new_kv_cache, x, experts = block(x, is_prefill, kv_cache,
+                                             attention_metadata)
             kv_caches[i] = new_kv_cache
+            if experts is not None:
+                all_experts.append(experts)
 
         final_activation = self.final_norm(x)
-        return kv_caches, final_activation, []
+
+        return kv_caches, final_activation, [], all_experts
 
     def compute_logits(self, hidden_states: jax.Array) -> jax.Array:
         return self.lm_head.decode(hidden_states)

--- a/tpu_inference/models/jax/gpt_oss.py
+++ b/tpu_inference/models/jax/gpt_oss.py
@@ -525,7 +525,7 @@ class GptOss(nnx.Module):
         input_ids: jax.Array,
         attention_metadata: AttentionMetadata,
         *args,
-    ) -> Tuple[List[KVCacheType], jax.Array, List[jax.Array], list]:
+    ) -> Tuple[List[KVCacheType], jax.Array, List[jax.Array], dict]:
         is_prefill = False
         x = self.embedder.encode(input_ids)
 
@@ -543,7 +543,7 @@ class GptOss(nnx.Module):
 
         final_activation = self.final_norm(x)
 
-        return kv_caches, final_activation, [], all_experts
+        return kv_caches, final_activation, [], {"expert_ids": all_experts}
 
     def compute_logits(self, hidden_states: jax.Array) -> jax.Array:
         return self.lm_head.decode(hidden_states)

--- a/tpu_inference/models/jax/llama3.py
+++ b/tpu_inference/models/jax/llama3.py
@@ -382,15 +382,15 @@ class LlamaForCausalLM(nnx.Module):
         _is_first_rank: bool | None = None,
         _is_last_rank: bool | None = None,
         *args,
-    ) -> Tuple[List[jax.Array], jax.Array, List[jax.Array], list] | Tuple[
-            List[jax.Array], JaxIntermediateTensors, List[jax.Array], list]:
+    ) -> Tuple[List[jax.Array], jax.Array, List[jax.Array], dict] | Tuple[
+            List[jax.Array], JaxIntermediateTensors, List[jax.Array], dict]:
         outputs = self.model(
             kv_caches,
             input_ids,
             attention_metadata,
             intermediate_tensors,
         )
-        return outputs[0], outputs[1], outputs[2], []
+        return outputs[0], outputs[1], outputs[2], {}
 
     def compute_logits(self, hidden_states: jax.Array) -> jax.Array:
         if self.vllm_config.model_config.hf_config.tie_word_embeddings:

--- a/tpu_inference/models/jax/llama3.py
+++ b/tpu_inference/models/jax/llama3.py
@@ -382,14 +382,15 @@ class LlamaForCausalLM(nnx.Module):
         _is_first_rank: bool | None = None,
         _is_last_rank: bool | None = None,
         *args,
-    ) -> Tuple[List[jax.Array], jax.Array, List[jax.Array]] | Tuple[
-            List[jax.Array], JaxIntermediateTensors]:
-        return self.model(
+    ) -> Tuple[List[jax.Array], jax.Array, List[jax.Array], list] | Tuple[
+            List[jax.Array], JaxIntermediateTensors, List[jax.Array], list]:
+        outputs = self.model(
             kv_caches,
             input_ids,
             attention_metadata,
             intermediate_tensors,
         )
+        return outputs[0], outputs[1], outputs[2], []
 
     def compute_logits(self, hidden_states: jax.Array) -> jax.Array:
         if self.vllm_config.model_config.hf_config.tie_word_embeddings:

--- a/tpu_inference/models/jax/llama4.py
+++ b/tpu_inference/models/jax/llama4.py
@@ -538,6 +538,8 @@ class Llama4ForCausalLM(nnx.Module):
                 edf_sharding=('model', None, None),
                 efd_sharding=('model', None, None),
                 quant_config=vllm_config.quant_config,
+                enable_return_routed_experts=vllm_config.model_config.
+                enable_return_routed_experts,
                 random_init=force_random_weights) if is_moe_layer else None
 
             dense_ffw = DenseFFW(dtype=dtype,
@@ -696,7 +698,8 @@ class Llama4ForCausalLM(nnx.Module):
         _lora_metadata: Any = None,
         intermediate_tensors: Optional[JaxIntermediateTensors] = None,
         *args,
-    ) -> Tuple[List[KVCacheType], jax.Array, List[jax.Array]]:
+    ) -> Tuple[List[KVCacheType], jax.Array | JaxIntermediateTensors,
+               List[jax.Array], list]:
         is_prefill = False
         if self.is_first_rank:
             x_TD = self.embedder.encode(input_ids)
@@ -704,20 +707,23 @@ class Llama4ForCausalLM(nnx.Module):
             assert intermediate_tensors is not None
             x_TD = intermediate_tensors["hidden_states"]
 
+        all_experts = []
         for (i, block) in enumerate(
                 islice(self.layers, self.start_layer, self.end_layer)):
             kv_cache = kv_caches[i]
-            new_kv_cache, x_TD = block(x_TD, is_prefill, kv_cache,
-                                       attention_metadata)
+            new_kv_cache, x_TD, experts = block(x_TD, is_prefill, kv_cache,
+                                                attention_metadata)
             jax.block_until_ready(x_TD)
             kv_caches[i] = new_kv_cache
+            if experts is not None:
+                all_experts.append(experts)
 
         if not self.is_last_rank:
             return kv_caches, JaxIntermediateTensors({"hidden_states":
-                                                      x_TD}), []
+                                                      x_TD}), [], all_experts
 
         final_activation_TD = self.final_norm(x_TD)
-        return kv_caches, final_activation_TD, []
+        return kv_caches, final_activation_TD, [], all_experts
 
     def compute_logits(self, hidden_states: jax.Array) -> jax.Array:
         logits_TV = jnp.dot(hidden_states,

--- a/tpu_inference/models/jax/llama4.py
+++ b/tpu_inference/models/jax/llama4.py
@@ -699,7 +699,7 @@ class Llama4ForCausalLM(nnx.Module):
         intermediate_tensors: Optional[JaxIntermediateTensors] = None,
         *args,
     ) -> Tuple[List[KVCacheType], jax.Array | JaxIntermediateTensors,
-               List[jax.Array], list]:
+               List[jax.Array], dict]:
         is_prefill = False
         if self.is_first_rank:
             x_TD = self.embedder.encode(input_ids)
@@ -720,10 +720,13 @@ class Llama4ForCausalLM(nnx.Module):
 
         if not self.is_last_rank:
             return kv_caches, JaxIntermediateTensors({"hidden_states":
-                                                      x_TD}), [], all_experts
+                                                      x_TD}), [], {
+                                                          "expert_ids":
+                                                          all_experts
+                                                      }
 
         final_activation_TD = self.final_norm(x_TD)
-        return kv_caches, final_activation_TD, [], all_experts
+        return kv_caches, final_activation_TD, [], {"expert_ids": all_experts}
 
     def compute_logits(self, hidden_states: jax.Array) -> jax.Array:
         logits_TV = jnp.dot(hidden_states,

--- a/tpu_inference/models/jax/llama_eagle3.py
+++ b/tpu_inference/models/jax/llama_eagle3.py
@@ -185,7 +185,7 @@ class Eagle3LlamaModel(nnx.Module):
         input_ids: jax.Array,
         hidden_states: jax.Array,
         attention_metadata: AttentionMetadata,
-    ) -> Tuple[List[jax.Array], jax.Array, List[jax.Array]]:
+    ) -> Tuple[List[jax.Array], jax.Array, List[jax.Array], dict]:
         embeds = self.embed_tokens(input_ids)
         assert hidden_states.shape[-1] == embeds.shape[-1]
 
@@ -203,7 +203,7 @@ class Eagle3LlamaModel(nnx.Module):
         hidden_states = hidden_states + residual
         residual = hidden_states
         hidden_states = self.norm(hidden_states)
-        return kv_caches, hidden_states, [residual]
+        return kv_caches, hidden_states, [residual], {}
 
 
 def update_reshape_map_for_eagle3(vllm_config: VllmConfig,
@@ -302,13 +302,14 @@ class EagleLlama3ForCausalLM(nnx.Module):
         hidden_states: jax.Array,
         attention_metadata: AttentionMetadata,
         _layer_name_to_kv_cache=None,
-    ) -> Tuple[List[jax.Array], jax.Array, List[jax.Array]]:
-        return self.model(
+    ) -> Tuple[List[jax.Array], jax.Array, List[jax.Array], dict]:
+        kv_caches, hidden_states, aux_hidden_states, metadata = self.model(
             kv_caches,
             input_ids,
             hidden_states,
             attention_metadata,
         )
+        return kv_caches, hidden_states, aux_hidden_states, metadata
 
     def compute_logits(self, hidden_states: jax.Array) -> jax.Array:
         logits = self.lm_head(hidden_states)

--- a/tpu_inference/models/jax/llama_eagle3.py
+++ b/tpu_inference/models/jax/llama_eagle3.py
@@ -185,7 +185,7 @@ class Eagle3LlamaModel(nnx.Module):
         input_ids: jax.Array,
         hidden_states: jax.Array,
         attention_metadata: AttentionMetadata,
-    ) -> Tuple[List[jax.Array], jax.Array, List[jax.Array]]:
+    ) -> Tuple[List[jax.Array], jax.Array, List[jax.Array], list]:
         embeds = self.embed_tokens(input_ids)
         assert hidden_states.shape[-1] == embeds.shape[-1]
 
@@ -203,7 +203,7 @@ class Eagle3LlamaModel(nnx.Module):
         hidden_states = hidden_states + residual
         residual = hidden_states
         hidden_states = self.norm(hidden_states)
-        return kv_caches, hidden_states, [residual]
+        return kv_caches, hidden_states, [residual], []
 
 
 def update_reshape_map_for_eagle3(vllm_config: VllmConfig,
@@ -302,7 +302,7 @@ class EagleLlama3ForCausalLM(nnx.Module):
         hidden_states: jax.Array,
         attention_metadata: AttentionMetadata,
         _layer_name_to_kv_cache=None,
-    ) -> Tuple[List[jax.Array], jax.Array, List[jax.Array]]:
+    ) -> Tuple[List[jax.Array], jax.Array, List[jax.Array], list]:
         return self.model(
             kv_caches,
             input_ids,

--- a/tpu_inference/models/jax/llama_eagle3.py
+++ b/tpu_inference/models/jax/llama_eagle3.py
@@ -185,7 +185,7 @@ class Eagle3LlamaModel(nnx.Module):
         input_ids: jax.Array,
         hidden_states: jax.Array,
         attention_metadata: AttentionMetadata,
-    ) -> Tuple[List[jax.Array], jax.Array, List[jax.Array], list]:
+    ) -> Tuple[List[jax.Array], jax.Array, List[jax.Array]]:
         embeds = self.embed_tokens(input_ids)
         assert hidden_states.shape[-1] == embeds.shape[-1]
 
@@ -203,7 +203,7 @@ class Eagle3LlamaModel(nnx.Module):
         hidden_states = hidden_states + residual
         residual = hidden_states
         hidden_states = self.norm(hidden_states)
-        return kv_caches, hidden_states, [residual], []
+        return kv_caches, hidden_states, [residual]
 
 
 def update_reshape_map_for_eagle3(vllm_config: VllmConfig,
@@ -302,7 +302,7 @@ class EagleLlama3ForCausalLM(nnx.Module):
         hidden_states: jax.Array,
         attention_metadata: AttentionMetadata,
         _layer_name_to_kv_cache=None,
-    ) -> Tuple[List[jax.Array], jax.Array, List[jax.Array], list]:
+    ) -> Tuple[List[jax.Array], jax.Array, List[jax.Array]]:
         return self.model(
             kv_caches,
             input_ids,

--- a/tpu_inference/models/jax/llama_guard_4.py
+++ b/tpu_inference/models/jax/llama_guard_4.py
@@ -594,7 +594,8 @@ class LlamaGuard4ForCausalLM(nnx.Module):
         attention_metadata: AttentionMetadata,
         inputs_embeds: Optional[jax.Array] = None,
         *args,
-    ) -> Tuple[List[KVCacheType], jax.Array]:
+    ) -> Tuple[List[KVCacheType], jax.Array | JaxIntermediateTensors,
+               List[jax.Array], list]:
         is_prefill = False
 
         if self.is_first_rank:
@@ -620,10 +621,10 @@ class LlamaGuard4ForCausalLM(nnx.Module):
             kv_caches[i] = new_kv_cache
 
         if not self.is_last_rank:
-            return kv_caches, JaxIntermediateTensors({"hidden_states": x_TD}), []
+            return kv_caches, JaxIntermediateTensors({"hidden_states": x_TD}), [], []
 
         final_activation_TD = self.final_norm(x_TD)
-        return kv_caches, final_activation_TD, []
+        return kv_caches, final_activation_TD, [], []
 
     def compute_logits(self, hidden_states: jax.Array) -> jax.Array:
         logits_TV = jnp.dot(hidden_states,

--- a/tpu_inference/models/jax/llama_guard_4.py
+++ b/tpu_inference/models/jax/llama_guard_4.py
@@ -595,7 +595,7 @@ class LlamaGuard4ForCausalLM(nnx.Module):
         inputs_embeds: Optional[jax.Array] = None,
         *args,
     ) -> Tuple[List[KVCacheType], jax.Array | JaxIntermediateTensors,
-               List[jax.Array], list]:
+               List[jax.Array], dict]:
         is_prefill = False
 
         if self.is_first_rank:
@@ -621,10 +621,10 @@ class LlamaGuard4ForCausalLM(nnx.Module):
             kv_caches[i] = new_kv_cache
 
         if not self.is_last_rank:
-            return kv_caches, JaxIntermediateTensors({"hidden_states": x_TD}), [], []
+            return kv_caches, JaxIntermediateTensors({"hidden_states": x_TD}), [], {}
 
         final_activation_TD = self.final_norm(x_TD)
-        return kv_caches, final_activation_TD, [], []
+        return kv_caches, final_activation_TD, [], {}
 
     def compute_logits(self, hidden_states: jax.Array) -> jax.Array:
         logits_TV = jnp.dot(hidden_states,

--- a/tpu_inference/models/jax/qwen2.py
+++ b/tpu_inference/models/jax/qwen2.py
@@ -414,7 +414,7 @@ class Qwen2ForCausalLM(JaxModule, LoadableWithIterator):
         is_last_rank: bool = True,
         *args,
     ) -> Tuple[List[jax.Array], jax.Array | JaxIntermediateTensors,
-               List[jax.Array]]:
+               List[jax.Array], list]:
         if not is_first_rank:
             assert intermediate_tensors is not None
             inputs_embeds = intermediate_tensors["hidden_states"]
@@ -426,7 +426,7 @@ class Qwen2ForCausalLM(JaxModule, LoadableWithIterator):
         )
         if not is_last_rank:
             x = JaxIntermediateTensors(tensors={"hidden_states": x}, )
-        return kv_caches, x, []
+        return kv_caches, x, [], []
 
     def compute_logits(self, hidden_states: jax.Array) -> jax.Array:
         if hasattr(self, 'lm_head'):

--- a/tpu_inference/models/jax/qwen2.py
+++ b/tpu_inference/models/jax/qwen2.py
@@ -414,7 +414,7 @@ class Qwen2ForCausalLM(JaxModule, LoadableWithIterator):
         is_last_rank: bool = True,
         *args,
     ) -> Tuple[List[jax.Array], jax.Array | JaxIntermediateTensors,
-               List[jax.Array], list]:
+               List[jax.Array], dict]:
         if not is_first_rank:
             assert intermediate_tensors is not None
             inputs_embeds = intermediate_tensors["hidden_states"]
@@ -426,7 +426,7 @@ class Qwen2ForCausalLM(JaxModule, LoadableWithIterator):
         )
         if not is_last_rank:
             x = JaxIntermediateTensors(tensors={"hidden_states": x}, )
-        return kv_caches, x, [], []
+        return kv_caches, x, [], {}
 
     def compute_logits(self, hidden_states: jax.Array) -> jax.Array:
         if hasattr(self, 'lm_head'):

--- a/tpu_inference/models/jax/qwen2_5_vl.py
+++ b/tpu_inference/models/jax/qwen2_5_vl.py
@@ -1120,7 +1120,7 @@ class Qwen2_5_VLForConditionalGeneration(nnx.Module):
         is_last_rank: bool = True,
         *args,
     ) -> tuple[list[jax.Array], jax.Array | JaxIntermediateTensors,
-               List[jax.Array]]:
+               List[jax.Array], list]:
         # The logic of choosing between input_ids and inputs_embeds is
         # handled inside self.model.__call__
         if not is_first_rank:
@@ -1137,7 +1137,7 @@ class Qwen2_5_VLForConditionalGeneration(nnx.Module):
         if not is_last_rank:
             x = JaxIntermediateTensors(tensors={"hidden_states": x})
 
-        return kv_caches, x, []
+        return kv_caches, x, [], []
 
     def compute_logits(self, hidden_states: jax.Array) -> jax.Array:
         if hasattr(self, 'lm_head'):

--- a/tpu_inference/models/jax/qwen2_5_vl.py
+++ b/tpu_inference/models/jax/qwen2_5_vl.py
@@ -1120,7 +1120,7 @@ class Qwen2_5_VLForConditionalGeneration(nnx.Module):
         is_last_rank: bool = True,
         *args,
     ) -> tuple[list[jax.Array], jax.Array | JaxIntermediateTensors,
-               List[jax.Array], list]:
+               List[jax.Array], dict]:
         # The logic of choosing between input_ids and inputs_embeds is
         # handled inside self.model.__call__
         if not is_first_rank:
@@ -1137,7 +1137,7 @@ class Qwen2_5_VLForConditionalGeneration(nnx.Module):
         if not is_last_rank:
             x = JaxIntermediateTensors(tensors={"hidden_states": x})
 
-        return kv_caches, x, [], []
+        return kv_caches, x, [], {}
 
     def compute_logits(self, hidden_states: jax.Array) -> jax.Array:
         if hasattr(self, 'lm_head'):

--- a/tpu_inference/models/jax/qwen3.py
+++ b/tpu_inference/models/jax/qwen3.py
@@ -369,7 +369,7 @@ class Qwen3ForCausalLM(JaxModule, LoadableWithIterator):
         is_last_rank: bool = True,
         *args,
     ) -> Tuple[List[jax.Array], jax.Array | JaxIntermediateTensors,
-               List[jax.Array], list]:
+               List[jax.Array], dict]:
         if not is_first_rank:
             assert intermediate_tensors is not None
             inputs_embeds = intermediate_tensors["hidden_states"]
@@ -381,7 +381,7 @@ class Qwen3ForCausalLM(JaxModule, LoadableWithIterator):
         )
         if not is_last_rank:
             x = JaxIntermediateTensors(tensors={"hidden_states": x}, )
-        return kv_caches, x, [], []
+        return kv_caches, x, [], {}
 
     def compute_logits(self, hidden_states: jax.Array) -> jax.Array:
         if hasattr(self, 'lm_head'):

--- a/tpu_inference/models/jax/qwen3.py
+++ b/tpu_inference/models/jax/qwen3.py
@@ -369,7 +369,7 @@ class Qwen3ForCausalLM(JaxModule, LoadableWithIterator):
         is_last_rank: bool = True,
         *args,
     ) -> Tuple[List[jax.Array], jax.Array | JaxIntermediateTensors,
-               List[jax.Array]]:
+               List[jax.Array], list]:
         if not is_first_rank:
             assert intermediate_tensors is not None
             inputs_embeds = intermediate_tensors["hidden_states"]
@@ -381,7 +381,7 @@ class Qwen3ForCausalLM(JaxModule, LoadableWithIterator):
         )
         if not is_last_rank:
             x = JaxIntermediateTensors(tensors={"hidden_states": x}, )
-        return kv_caches, x, []
+        return kv_caches, x, [], []
 
     def compute_logits(self, hidden_states: jax.Array) -> jax.Array:
         if hasattr(self, 'lm_head'):

--- a/tpu_inference/models/jax/qwen3_moe.py
+++ b/tpu_inference/models/jax/qwen3_moe.py
@@ -355,7 +355,7 @@ class Qwen3MoeForCausalLM(JaxModule, LoadableWithIterator):
         is_last_rank: bool = True,
         *args,
     ) -> Tuple[List[jax.Array], jax.Array | JaxIntermediateTensors,
-               List[jax.Array], List[Optional[jax.Array]]]:
+               List[jax.Array], dict]:
         if not is_first_rank:
             assert intermediate_tensors is not None
             inputs_embeds = intermediate_tensors["hidden_states"]
@@ -368,7 +368,7 @@ class Qwen3MoeForCausalLM(JaxModule, LoadableWithIterator):
 
         if not is_last_rank:
             x = JaxIntermediateTensors(tensors={"hidden_states": x}, )
-        return kv_caches, x, [], all_experts
+        return kv_caches, x, [], {"expert_ids": all_experts}
 
     def compute_logits(self, hidden_states: jax.Array) -> jax.Array:
         if hasattr(self, 'lm_head'):

--- a/tpu_inference/models/jax/qwen3_moe.py
+++ b/tpu_inference/models/jax/qwen3_moe.py
@@ -118,6 +118,8 @@ class Qwen3MoeSparseMoeBlock(JaxModule):
             num_expert_parallelism=num_expert_parallelism,
             moe_backend=moe_backend,
             quant_config=quant_config,
+            enable_return_routed_experts=vllm_config.model_config.
+            enable_return_routed_experts,
             prefix=prefix + ".experts")
 
     def __call__(self, x: jax.Array) -> tuple[jax.Array, Optional[jax.Array]]:
@@ -353,7 +355,7 @@ class Qwen3MoeForCausalLM(JaxModule, LoadableWithIterator):
         is_last_rank: bool = True,
         *args,
     ) -> Tuple[List[jax.Array], jax.Array | JaxIntermediateTensors,
-               List[Optional[jax.Array]]]:
+               List[jax.Array], List[Optional[jax.Array]]]:
         if not is_first_rank:
             assert intermediate_tensors is not None
             inputs_embeds = intermediate_tensors["hidden_states"]
@@ -363,9 +365,10 @@ class Qwen3MoeForCausalLM(JaxModule, LoadableWithIterator):
             attention_metadata,
             inputs_embeds,
         )
+
         if not is_last_rank:
             x = JaxIntermediateTensors(tensors={"hidden_states": x}, )
-        return kv_caches, x, all_experts
+        return kv_caches, x, [], all_experts
 
     def compute_logits(self, hidden_states: jax.Array) -> jax.Array:
         if hasattr(self, 'lm_head'):

--- a/tpu_inference/models/jax/qwen3_moe.py
+++ b/tpu_inference/models/jax/qwen3_moe.py
@@ -120,11 +120,11 @@ class Qwen3MoeSparseMoeBlock(JaxModule):
             quant_config=quant_config,
             prefix=prefix + ".experts")
 
-    def __call__(self, x: jax.Array) -> jax.Array:
-        out = self.experts(x)
+    def __call__(self, x: jax.Array) -> tuple[jax.Array, Optional[jax.Array]]:
+        out, experts = self.experts(x)
         if self.shared_expert is not None:
             out += self.shared_expert(x)
-        return out
+        return out, experts
 
 
 class Qwen3MoeDecoderLayer(JaxModule):
@@ -190,7 +190,7 @@ class Qwen3MoeDecoderLayer(JaxModule):
         kv_cache: jax.Array,
         x: jax.Array,
         attention_metadata: AttentionMetadata,
-    ) -> Tuple[jax.Array, jax.Array]:
+    ) -> Tuple[jax.Array, jax.Array, Optional[jax.Array]]:
         hidden_states = self.input_layernorm(x)
         kv_cache, attn_output = self.self_attn(
             kv_cache,
@@ -201,9 +201,9 @@ class Qwen3MoeDecoderLayer(JaxModule):
 
         residual = attn_output
         attn_output = self.post_attention_layernorm(attn_output)
-        outputs = self.mlp(attn_output)
+        outputs, experts = self.mlp(attn_output)
         outputs = residual + outputs
-        return kv_cache, outputs
+        return kv_cache, outputs, experts
 
 
 class Qwen3MoeModel(JaxModule):
@@ -272,7 +272,7 @@ class Qwen3MoeModel(JaxModule):
         input_ids: jax.Array,
         attention_metadata: AttentionMetadata,
         inputs_embeds: Optional[jax.Array] = None,
-    ) -> Tuple[List[jax.Array], jax.Array]:
+    ) -> Tuple[List[jax.Array], jax.Array, List[Optional[jax.Array]]]:
         if self.is_first_rank:
             assert inputs_embeds is None
             inputs_embeds = self.embed_tokens(input_ids)
@@ -281,18 +281,20 @@ class Qwen3MoeModel(JaxModule):
 
         x = inputs_embeds
         new_kv_caches = []
+        all_experts = []
         for i, layer in enumerate(self.layers):
             if isinstance(layer, PPMissingLayer):
                 new_kv_caches.append(kv_caches[i])
                 continue
             kv_cache = kv_caches[i]
-            kv_cache, x = layer(kv_cache, x, attention_metadata)
+            kv_cache, x, experts = layer(kv_cache, x, attention_metadata)
             new_kv_caches.append(kv_cache)
+            all_experts.append(experts)
 
         if self.is_last_rank:
             x = self.norm(x)
 
-        return new_kv_caches, x
+        return new_kv_caches, x, all_experts
 
 
 class Qwen3MoeForCausalLM(JaxModule, LoadableWithIterator):
@@ -351,11 +353,11 @@ class Qwen3MoeForCausalLM(JaxModule, LoadableWithIterator):
         is_last_rank: bool = True,
         *args,
     ) -> Tuple[List[jax.Array], jax.Array | JaxIntermediateTensors,
-               List[jax.Array]]:
+               List[Optional[jax.Array]]]:
         if not is_first_rank:
             assert intermediate_tensors is not None
             inputs_embeds = intermediate_tensors["hidden_states"]
-        kv_caches, x = self.model(
+        kv_caches, x, all_experts = self.model(
             kv_caches,
             input_ids,
             attention_metadata,
@@ -363,7 +365,7 @@ class Qwen3MoeForCausalLM(JaxModule, LoadableWithIterator):
         )
         if not is_last_rank:
             x = JaxIntermediateTensors(tensors={"hidden_states": x}, )
-        return kv_caches, x, []
+        return kv_caches, x, all_experts
 
     def compute_logits(self, hidden_states: jax.Array) -> jax.Array:
         if hasattr(self, 'lm_head'):

--- a/tpu_inference/runner/compilation_manager.py
+++ b/tpu_inference/runner/compilation_manager.py
@@ -245,13 +245,11 @@ class CompilationManager:
                                            lora_metadata, intermediate_tensors,
                                            is_first_rank, is_last_rank)
 
-            if len(outputs) == 3:
-                kv_caches, hidden_states, _ = outputs
-            elif len(outputs) == 4:
-                kv_caches, hidden_states, _, _ = outputs
-            else:
+            if len(outputs) != 4:
                 raise ValueError(
-                    f"Unexpected model_fn return length: {len(outputs)}")
+                    f"Expected exactly 4 return values from model_fn, got {len(outputs)}"
+                )
+            kv_caches, hidden_states, _, _ = outputs
             self.runner.kv_caches = kv_caches
             return hidden_states
 
@@ -887,7 +885,7 @@ class CompilationManager:
                 attention_metadata,
                 layer_name_to_kvcache_index,
             ):
-                kv_caches, hidden_states, _ = self.runner.drafter.model_fn(
+                kv_caches, hidden_states, _, _ = self.runner.drafter.model_fn(
                     state, kv_caches, input_ids, draft_hidden_states,
                     attention_metadata, layer_name_to_kvcache_index)
                 self.runner.kv_caches = kv_caches

--- a/tpu_inference/runner/compilation_manager.py
+++ b/tpu_inference/runner/compilation_manager.py
@@ -238,10 +238,20 @@ class CompilationManager:
             is_first_rank,
             is_last_rank,
         ):
-            kv_caches, hidden_states, _, _ = self.runner.model_fn(
-                state, kv_caches, input_ids, attention_metadata, inputs_embeds,
-                positions, layer_name_to_kvcache_index, lora_metadata,
-                intermediate_tensors, is_first_rank, is_last_rank)
+            outputs = self.runner.model_fn(state, kv_caches, input_ids,
+                                           attention_metadata, inputs_embeds,
+                                           positions,
+                                           layer_name_to_kvcache_index,
+                                           lora_metadata, intermediate_tensors,
+                                           is_first_rank, is_last_rank)
+
+            if len(outputs) == 3:
+                kv_caches, hidden_states, _ = outputs
+            elif len(outputs) == 4:
+                kv_caches, hidden_states, _, _ = outputs
+            else:
+                raise ValueError(
+                    f"Unexpected model_fn return length: {len(outputs)}")
             self.runner.kv_caches = kv_caches
             return hidden_states
 

--- a/tpu_inference/runner/compilation_manager.py
+++ b/tpu_inference/runner/compilation_manager.py
@@ -238,7 +238,7 @@ class CompilationManager:
             is_first_rank,
             is_last_rank,
         ):
-            (kv_caches, hidden_states, _), _ = self.runner.model_fn(
+            kv_caches, hidden_states, _, _ = self.runner.model_fn(
                 state, kv_caches, input_ids, attention_metadata, inputs_embeds,
                 positions, layer_name_to_kvcache_index, lora_metadata,
                 intermediate_tensors, is_first_rank, is_last_rank)

--- a/tpu_inference/runner/compilation_manager.py
+++ b/tpu_inference/runner/compilation_manager.py
@@ -238,7 +238,7 @@ class CompilationManager:
             is_first_rank,
             is_last_rank,
         ):
-            kv_caches, hidden_states, _ = self.runner.model_fn(
+            (kv_caches, hidden_states, _), _ = self.runner.model_fn(
                 state, kv_caches, input_ids, attention_metadata, inputs_embeds,
                 positions, layer_name_to_kvcache_index, lora_metadata,
                 intermediate_tensors, is_first_rank, is_last_rank)

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -957,17 +957,15 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                         num_reqs = self.input_batch.num_reqs
 
                         # 1. Compute global slot mapping for the entire batch of tokens
-                        all_slot_mappings = []
-                        for i, req_id in enumerate(
-                                self.input_batch.req_ids[:num_reqs]):
-                            num_tokens = scheduler_output.num_scheduled_tokens[
-                                req_id]
-                            slot_mapping = self._get_slot_mapping(
-                                req_id, num_tokens)
-                            all_slot_mappings.append(slot_mapping)
-                        global_slot_mapping = np.concatenate(all_slot_mappings)
+                        num_scheduled_tokens_per_req = [
+                            scheduler_output.num_scheduled_tokens[req_id]
+                            for req_id in self.input_batch.req_ids[:num_reqs]
+                        ]
+                        num_scheduled_tokens_per_req = np.array(
+                            num_scheduled_tokens_per_req, dtype=np.int32)
+                        offsets = np.cumsum(
+                            np.insert(num_scheduled_tokens_per_req, 0, 0))
 
-                        # 2. Write to shared memory in one shot per layer
                         from vllm.model_executor.layers.fused_moe.routed_experts_capturer import \
                             _file_lock
 
@@ -976,11 +974,24 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                                 experts_cpu = np.asarray(
                                     jax.device_get(experts))
 
-                                with _file_lock(
-                                        self.experts_capturer._lock_file):
-                                    self.experts_capturer._host_buffer_view[
-                                        global_slot_mapping,
-                                        layer_idx, :] = experts_cpu
+                                for i, req_id in enumerate(
+                                        self.input_batch.req_ids[:num_reqs]):
+                                    num_tokens = num_scheduled_tokens_per_req[
+                                        i]
+                                    start_token_idx = offsets[i]
+                                    end_token_idx = offsets[i + 1]
+
+                                    req_experts = experts_cpu[
+                                        start_token_idx:end_token_idx]
+
+                                    slot_mapping = self._get_slot_mapping(
+                                        req_id, num_tokens)
+
+                                    with _file_lock(
+                                            self.experts_capturer._lock_file):
+                                        self.experts_capturer._host_buffer_view[
+                                            slot_mapping,
+                                            layer_idx, :] = req_experts
                 except Exception as e:
                     logger.warning(f"Failed to extract captured experts: {e}")
 

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -949,14 +949,13 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                     self.is_first_rank,
                     self.is_last_rank,
                 )
-                if len(outputs) == 3:
-                    self.kv_caches, hidden_states, aux_hidden_states = outputs
-                    all_experts = []
-                elif len(outputs) == 4:
-                    self.kv_caches, hidden_states, aux_hidden_states, all_experts = outputs
-                else:
+                if len(outputs) != 4:
                     raise ValueError(
-                        f"Unexpected model_fn return length: {len(outputs)}")
+                        f"Expected exactly 4 return values from model_fn, got {len(outputs)}"
+                    )
+                self.kv_caches, hidden_states, aux_hidden_states, metadata = outputs
+                all_experts = metadata.get("expert_ids", []) if isinstance(
+                    metadata, dict) else metadata
 
                 # Extract captured experts from all layers
                 try:

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -936,20 +936,27 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                     scheduler_output) as kv_connector_output:
                 # NOTE(Wenlong): It takes both `input_ids` and `inputs_embeds`,
                 # but one of them would be `None`
-                (self.kv_caches, hidden_states, aux_hidden_states,
-                 all_experts) = self.model_fn(
-                     self.state,
-                     self.kv_caches,
-                     input_ids,
-                     attn_metadata,
-                     inputs_embeds,
-                     input_positions,
-                     tuple(self.layer_name_to_kvcache_index.items()),
-                     lora_metadata,
-                     intermediate_tensors,
-                     self.is_first_rank,
-                     self.is_last_rank,
-                 )
+                outputs = self.model_fn(
+                    self.state,
+                    self.kv_caches,
+                    input_ids,
+                    attn_metadata,
+                    inputs_embeds,
+                    input_positions,
+                    tuple(self.layer_name_to_kvcache_index.items()),
+                    lora_metadata,
+                    intermediate_tensors,
+                    self.is_first_rank,
+                    self.is_last_rank,
+                )
+                if len(outputs) == 3:
+                    self.kv_caches, hidden_states, aux_hidden_states = outputs
+                    all_experts = []
+                elif len(outputs) == 4:
+                    self.kv_caches, hidden_states, aux_hidden_states, all_experts = outputs
+                else:
+                    raise ValueError(
+                        f"Unexpected model_fn return length: {len(outputs)}")
 
                 # Extract captured experts from all layers
                 try:

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -237,6 +237,18 @@ def _jax_logprobs_materialize(
     )
 
 
+class RoutedExpertsReader:
+    """Reader for routed experts from a buffer."""
+
+    def __init__(self, buffer: np.ndarray):
+        self.buffer = buffer
+
+    def get_routed_experts(self, indices: np.ndarray) -> np.ndarray:
+        if self.buffer is None:
+            raise RuntimeError("Buffer not initialized.")
+        return self.buffer[indices]
+
+
 class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
 
     def __init__(
@@ -302,6 +314,8 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
 
         self.is_pooling_model: bool = self.model_config.runner_type == "pooling"
         """Generative model or pooling model select different computations."""
+
+        self.routed_experts_reader: Optional[RoutedExpertsReader] = None
 
     def _init_random(self):
         if self.model_config.seed is None:
@@ -637,6 +651,39 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         if has_kv_transfer_group():
             get_kv_transfer_group().register_runner(self)
 
+        # Initialize routed experts capturer to create shared memory buffer
+        from vllm.model_executor.layers.fused_moe.routed_experts_capturer import \
+            RoutedExpertsCapturer
+        from vllm.platforms import current_platform
+
+        try:
+            self.experts_capturer = RoutedExpertsCapturer.create()
+        except RuntimeError:
+            self.experts_capturer = RoutedExpertsCapturer.get_instance()
+
+        num_groups = len(kv_cache_config.kv_cache_groups)
+        min_block_size = min([
+            group.kv_cache_spec.block_size
+            for group in kv_cache_config.kv_cache_groups
+        ])
+        max_num_kv_tokens = (kv_cache_config.num_blocks //
+                             num_groups) * min_block_size
+
+        # Monkey-patch current_platform.device_type to 'cpu' to avoid PyTorch error with 'tpu'
+        original_device_type = current_platform.device_type
+        current_platform.device_type = "cpu"
+
+        try:
+            self.experts_capturer.init_buffer(
+                max_num_batched_tokens=self.max_num_tokens,
+                max_num_kv_tokens=max_num_kv_tokens,
+                vllm_config=self.vllm_config)
+        finally:
+            current_platform.device_type = original_device_type
+
+        logger.info(
+            "Initialized RoutedExpertsCapturer and shared memory buffer.")
+
     def delete_kv_cache(self) -> None:
         self.kv_cache_manager.delete_kv_cache()
 
@@ -784,6 +831,47 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                     req_state.req_id] = logits_indices_selector[req_idx]
         return placeholder_req_id_to_index
 
+    def _get_slot_mapping(self,
+                          request_id: str,
+                          num_tokens: int,
+                          attn_gid: int = 0) -> np.ndarray:
+        """Compute slot mapping for a request's current scheduled tokens."""
+        req_index = self.input_batch.req_id_to_index.get(request_id)
+        if req_index is None:
+            raise ValueError(f"Request {request_id} not found in batch")
+
+        block_table = self.input_batch.block_table[attn_gid]
+        num_blocks = block_table.num_blocks_per_row[req_index]
+        block_ids = block_table.block_table_cpu[req_index, :num_blocks]
+
+        block_ids_array = np.array(block_ids, dtype=np.int32)
+        attn_group = self.kv_cache_config.kv_cache_groups[attn_gid]
+        block_size = attn_group.kv_cache_spec.block_size
+
+        block_offsets = np.arange(0, block_size)
+
+        all_slots = (block_offsets.reshape(
+            (1, block_size)) + block_ids_array.reshape(
+                (num_blocks, 1)) * block_size).flatten()
+
+        num_computed_tokens = self.input_batch.num_computed_tokens_cpu[
+            req_index]
+        return all_slots[num_computed_tokens:num_computed_tokens + num_tokens]
+
+    def _get_routed_experts(self,
+                            request_id: str,
+                            num_tokens: int,
+                            attn_gid: int = 0) -> Optional[np.ndarray]:
+        """Get routed experts for a request."""
+        if not hasattr(
+                self,
+                "routed_experts_reader") or self.routed_experts_reader is None:
+            return None
+
+        slot_mapping = self._get_slot_mapping(request_id, num_tokens, attn_gid)
+        return self.routed_experts_reader.get_routed_experts(
+            indices=slot_mapping)
+
     def _execute_model(
         self,
         scheduler_output: "VllmSchedulerOutput",
@@ -865,6 +953,77 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                      self.is_first_rank,
                      self.is_last_rank,
                  )
+
+                # For MoE models, aux_hidden_states contains the experts
+                all_experts = aux_hidden_states if getattr(
+                    self.model_config.hf_config, "num_experts",
+                    0) > 0 else None
+
+                # Extract captured experts from all layers
+                try:
+                    logger.error(
+                        f"MOEMOE TPUModelRunner | all_experts: {all_experts}")
+                    if all_experts:
+                        num_reqs = self.input_batch.num_reqs
+                        num_scheduled_tokens_per_req = [
+                            scheduler_output.num_scheduled_tokens[req_id]
+                            for req_id in self.input_batch.req_ids[:num_reqs]
+                        ]
+                        num_scheduled_tokens_per_req = np.array(
+                            num_scheduled_tokens_per_req, dtype=np.int32)
+                        offsets = np.cumsum(
+                            np.insert(num_scheduled_tokens_per_req, 0, 0))
+
+                        for layer_idx, experts in enumerate(all_experts):
+                            if experts is not None:
+                                experts_cpu = np.asarray(
+                                    jax.device_get(experts))
+
+                                for i, req_id in enumerate(
+                                        self.input_batch.req_ids[:num_reqs]):
+                                    num_tokens = num_scheduled_tokens_per_req[
+                                        i]
+                                    start_token_idx = offsets[i]
+                                    end_token_idx = offsets[i + 1]
+
+                                    req_experts = experts_cpu[
+                                        start_token_idx:end_token_idx]
+
+                                    slot_mapping = self._get_slot_mapping(
+                                        req_id, num_tokens)
+
+                                    if hasattr(
+                                            self, "experts_capturer"
+                                    ) and self.experts_capturer is not None and self.experts_capturer._host_buffer_view is not None:
+                                        from vllm.model_executor.layers.fused_moe.routed_experts_capturer import \
+                                            _file_lock
+                                        with _file_lock(self.experts_capturer.
+                                                        _lock_file):
+                                            self.experts_capturer._host_buffer_view[
+                                                slot_mapping,
+                                                layer_idx, :] = req_experts
+
+                        logger.error(
+                            f"MOEMOE TPUModelRunner | Successfully extracted and stored experts for {num_reqs} requests."
+                        )
+                        if num_reqs > 0:
+                            req_id = self.input_batch.req_ids[0]
+                            num_tokens = num_scheduled_tokens_per_req[0]
+                            # We need to offset by num_computed_tokens to get the current step's slots.
+                            # _get_slot_mapping already does that!
+                            slot_mapping = self._get_slot_mapping(
+                                req_id, num_tokens)
+                            if len(slot_mapping) > 0:
+                                sample_experts = self.experts_capturer._host_buffer_view[
+                                    slot_mapping[0], 0, :]
+                                logger.error(
+                                    f"MOEMOE TPUModelRunner | Sample experts (req 0, token 0, layer 0): {sample_experts}"
+                                )
+                except Exception as e:
+                    logger.warning(f"Failed to extract captured experts: {e}")
+
+                # Experts are now stored in shared memory for the vLLM scheduler to pick up.
+
             if not self.is_last_rank:
                 assert isinstance(hidden_states, JaxIntermediateTensors)
                 hidden_states.kv_connector_output = kv_connector_output

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -652,37 +652,34 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             get_kv_transfer_group().register_runner(self)
 
         # Initialize routed experts capturer to create shared memory buffer
-        from vllm.model_executor.layers.fused_moe.routed_experts_capturer import \
-            RoutedExpertsCapturer
-        from vllm.platforms import current_platform
+        if self.vllm_config.model_config.enable_return_routed_experts:
+            from vllm.model_executor.layers.fused_moe.routed_experts_capturer import \
+                RoutedExpertsCapturer
+            from vllm.platforms import current_platform
+            try:
+                self.experts_capturer = RoutedExpertsCapturer.create()
+            except RuntimeError:
+                self.experts_capturer = RoutedExpertsCapturer.get_instance()
 
-        try:
-            self.experts_capturer = RoutedExpertsCapturer.create()
-        except RuntimeError:
-            self.experts_capturer = RoutedExpertsCapturer.get_instance()
+            num_groups = len(kv_cache_config.kv_cache_groups)
+            min_block_size = min([
+                group.kv_cache_spec.block_size
+                for group in kv_cache_config.kv_cache_groups
+            ])
+            max_num_kv_tokens = (kv_cache_config.num_blocks //
+                                 num_groups) * min_block_size
 
-        num_groups = len(kv_cache_config.kv_cache_groups)
-        min_block_size = min([
-            group.kv_cache_spec.block_size
-            for group in kv_cache_config.kv_cache_groups
-        ])
-        max_num_kv_tokens = (kv_cache_config.num_blocks //
-                             num_groups) * min_block_size
+            # # Monkey-patch current_platform.device_type to 'cpu' to avoid PyTorch error with 'tpu'
+            original_device_type = current_platform.device_type
+            current_platform.device_type = "cpu"
 
-        # Monkey-patch current_platform.device_type to 'cpu' to avoid PyTorch error with 'tpu'
-        original_device_type = current_platform.device_type
-        current_platform.device_type = "cpu"
-
-        try:
-            self.experts_capturer.init_buffer(
-                max_num_batched_tokens=self.max_num_tokens,
-                max_num_kv_tokens=max_num_kv_tokens,
-                vllm_config=self.vllm_config)
-        finally:
-            current_platform.device_type = original_device_type
-
-        logger.info(
-            "Initialized RoutedExpertsCapturer and shared memory buffer.")
+            try:
+                self.experts_capturer.init_buffer(
+                    max_num_batched_tokens=self.max_num_tokens,
+                    max_num_kv_tokens=max_num_kv_tokens,
+                    vllm_config=self.vllm_config)
+            finally:
+                current_platform.device_type = original_device_type
 
     def delete_kv_cache(self) -> None:
         self.kv_cache_manager.delete_kv_cache()
@@ -939,8 +936,8 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                     scheduler_output) as kv_connector_output:
                 # NOTE(Wenlong): It takes both `input_ids` and `inputs_embeds`,
                 # but one of them would be `None`
-                (self.kv_caches, hidden_states,
-                 aux_hidden_states) = self.model_fn(
+                (self.kv_caches, hidden_states, aux_hidden_states,
+                 all_experts) = self.model_fn(
                      self.state,
                      self.kv_caches,
                      input_ids,
@@ -954,71 +951,36 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                      self.is_last_rank,
                  )
 
-                # For MoE models, aux_hidden_states contains the experts
-                all_experts = aux_hidden_states if getattr(
-                    self.model_config.hf_config, "num_experts",
-                    0) > 0 else None
-
                 # Extract captured experts from all layers
                 try:
-                    logger.error(
-                        f"MOEMOE TPUModelRunner | all_experts: {all_experts}")
                     if all_experts:
                         num_reqs = self.input_batch.num_reqs
-                        num_scheduled_tokens_per_req = [
-                            scheduler_output.num_scheduled_tokens[req_id]
-                            for req_id in self.input_batch.req_ids[:num_reqs]
-                        ]
-                        num_scheduled_tokens_per_req = np.array(
-                            num_scheduled_tokens_per_req, dtype=np.int32)
-                        offsets = np.cumsum(
-                            np.insert(num_scheduled_tokens_per_req, 0, 0))
+
+                        # 1. Compute global slot mapping for the entire batch of tokens
+                        all_slot_mappings = []
+                        for i, req_id in enumerate(
+                                self.input_batch.req_ids[:num_reqs]):
+                            num_tokens = scheduler_output.num_scheduled_tokens[
+                                req_id]
+                            slot_mapping = self._get_slot_mapping(
+                                req_id, num_tokens)
+                            all_slot_mappings.append(slot_mapping)
+                        global_slot_mapping = np.concatenate(all_slot_mappings)
+
+                        # 2. Write to shared memory in one shot per layer
+                        from vllm.model_executor.layers.fused_moe.routed_experts_capturer import \
+                            _file_lock
 
                         for layer_idx, experts in enumerate(all_experts):
                             if experts is not None:
                                 experts_cpu = np.asarray(
                                     jax.device_get(experts))
 
-                                for i, req_id in enumerate(
-                                        self.input_batch.req_ids[:num_reqs]):
-                                    num_tokens = num_scheduled_tokens_per_req[
-                                        i]
-                                    start_token_idx = offsets[i]
-                                    end_token_idx = offsets[i + 1]
-
-                                    req_experts = experts_cpu[
-                                        start_token_idx:end_token_idx]
-
-                                    slot_mapping = self._get_slot_mapping(
-                                        req_id, num_tokens)
-
-                                    if hasattr(
-                                            self, "experts_capturer"
-                                    ) and self.experts_capturer is not None and self.experts_capturer._host_buffer_view is not None:
-                                        from vllm.model_executor.layers.fused_moe.routed_experts_capturer import \
-                                            _file_lock
-                                        with _file_lock(self.experts_capturer.
-                                                        _lock_file):
-                                            self.experts_capturer._host_buffer_view[
-                                                slot_mapping,
-                                                layer_idx, :] = req_experts
-
-                        logger.error(
-                            f"MOEMOE TPUModelRunner | Successfully extracted and stored experts for {num_reqs} requests."
-                        )
-                        if num_reqs > 0:
-                            req_id = self.input_batch.req_ids[0]
-                            num_tokens = num_scheduled_tokens_per_req[0]
-                            # We need to offset by num_computed_tokens to get the current step's slots.
-                            # _get_slot_mapping already does that!
-                            slot_mapping = self._get_slot_mapping(
-                                req_id, num_tokens)
-                            if len(slot_mapping) > 0:
-                                sample_experts = self.experts_capturer._host_buffer_view[
-                                    slot_mapping[0], 0, :]
-                                logger.error(
-                                    f"MOEMOE TPUModelRunner | Sample experts (req 0, token 0, layer 0): {sample_experts}"
-                                )
+                                with _file_lock(
+                                        self.experts_capturer._lock_file):
+                                    self.experts_capturer._host_buffer_view[
+                                        global_slot_mapping,
+                                        layer_idx, :] = experts_cpu
                 except Exception as e:
                     logger.warning(f"Failed to extract captured experts: {e}")
 

--- a/tpu_inference/spec_decode/jax/eagle3.py
+++ b/tpu_inference/spec_decode/jax/eagle3.py
@@ -418,7 +418,7 @@ class Eagle3Proposer:
         """
 
         # input_ids and target_hidden_states for the first speculation have been prepared in prepare_inputs() to improve performance.
-        kv_caches, hidden_states, residual = self.model_fn(
+        kv_caches, hidden_states, residual, _ = self.model_fn(
             self.state,
             kv_caches,
             input_ids,
@@ -450,7 +450,7 @@ class Eagle3Proposer:
                 query_start_loc=query_start_loc,
                 block_tables=new_block_tables,
             )
-            kv_caches, new_hidden_states, residual = self.model_fn(
+            kv_caches, new_hidden_states, residual, _ = self.model_fn(
                 self.state,
                 kv_caches,
                 input_ids_loop,


### PR DESCRIPTION
# Description

vLLM [captures expert IDs](https://github.com/vllm-project/vllm/blob/5f7fab881a13df2926f50cb8d9f67b0bbc2ee41f/vllm/v1/core/sched/scheduler.py#L1606) and exposes them through [CompletionOutput.routed_experts](https://github.com/vllm-project/vllm/blob/6ef1efd51f11106fc44deb9e7b2f5cd1247fc37e/vllm/outputs.py#L45)

This relies on reading/writing from memory buffer on a single machine, so multihost scenarios won't work.

## 1. What RoutedExpertsCapturer does

Shared Memory Creation: The RoutedExpertsCapturer creates a POSIX shared memory buffer. This is a chunk of RAM that can be seen and modified by both the TPUModelRunner process and the Scheduler process at the same time.

Sizing: It creates a 3D array of shape (max_num_kv_tokens, num_layers, num_experts_per_tok). This size ensures we have a slot for every possible token in the global KV cache.

File Lock: It manages a file lock (.lock file) to ensure that when one process is writing to the shared memory, the other isn't reading it, preventing data corruption.

## 2. How _execute_model stores it on the buffer

JAX Capture: During the forward pass, our modifications in moe.py capture the selected expert IDs and return them as all_experts (a list of tensors, one per layer) up to _execute_model.

Slot Mapping: For each request in the current batch, _execute_model calls _get_slot_mapping to find out exactly which indices in the global KV cache belong to the tokens processed in this step.

Writing: It transfers the experts from TPU to CPU (jax.device_get), acquires the file lock, and writes the expert IDs into the shared memory buffer at the specific indices returned by slot_mapping.

By doing this at every step, the shared memory buffer becomes a complete history of expert selections, indexed by the exact same slots as their keys and values in the KV cache.

## 3. How the vLLM Scheduler picks up the values

Attaching to Buffer: The vLLM scheduler creates a RoutedExpertsReader which attaches to the same shared memory buffer by its unique name (derived from instance_id and dp_rank).

Reading: When a request finishes or when the scheduler needs to construct the output, it computes the slot_mapping for ALL tokens in that request (from token 0 to the current length).

It acquires the lock and uses this slot_mapping to read the expert IDs from the shared memory buffer.

Because the TPUModelRunner wrote them to the correct slots at each step, the scheduler can now retrieve the full sequence of expert selections for that request and put them into CompletionOutput.routed_experts.

# Tests

```
VLLM_LOGGING_LEVEL=DEBUG MODEL_IMPL_TYPE=flax_nnx SKIP_JAX_PRECOMPILE=1 python examples/offline_inference.py --model Qwen/Qwen3-30B-A3B-Instruct-2507
```

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
