### PR TITLE
Fix the high request rate hang issue in Disagg

### DIFF
--- a/tests/distributed/test_tpu_connector.py
+++ b/tests/distributed/test_tpu_connector.py
@@ -424,7 +424,7 @@ class TestTPUConnectorWorker(unittest.TestCase):
         worker._maybe_build_kv_connection.assert_called_once_with(load_meta)
         self.all_mocks[
             "ThreadPoolExecutor"].return_value.submit.assert_called_once_with(
-                worker._pull_kv, "req1", "conn", load_meta, mock_indices)
+                worker._pull_kv, "req1", "conn", load_meta)
 
     def test_process_send_load_for_consumer_notifying(self):
         """Tests process_send_load for a consumer that needs to notify."""
@@ -446,7 +446,7 @@ class TestTPUConnectorWorker(unittest.TestCase):
         worker.sharding = MagicMock()
         worker.sharding.spec = "mock_spec"
         worker.mesh = "mock_mesh"
-        worker.reqs_ready_to_insert = {"req1": ("kv_data", "indices", [1])}
+        worker.reqs_pulling = {"req1": [None, "kv_data", [1]]}
         self.all_mocks['insert_kv_chunks'].return_value = "new_kv_caches"
 
         worker.process_send_load(meta)
@@ -454,7 +454,7 @@ class TestTPUConnectorWorker(unittest.TestCase):
         self.all_mocks['insert_kv_chunks'].assert_called_once_with(
             original_kv_caches, "kv_data", [1], "mock_mesh", "mock_spec")
         self.assertEqual(worker.runner.kv_caches, "new_kv_caches")
-        self.assertNotIn("req1", worker.reqs_ready_to_insert)
+        self.assertNotIn("req1", worker.reqs_pulling)
         worker._maybe_build_notif_socket.assert_called_once_with(load_meta)
         worker._notify_pull_done.assert_called_once_with(
             "socket", "req1", uuid)
@@ -468,15 +468,14 @@ class TestTPUConnectorWorker(unittest.TestCase):
         mock_future = MagicMock()
         mock_future.done.return_value = True
         mock_future.result.return_value = ('kv_data', 'indices', [1])
-        worker.reqs_pulling = {'req1': mock_future}
+        worker.reqs_pulling = {'req1': [mock_future, None, [1]]}
 
         done_sending, done_recving = worker.get_finished()
 
         self.assertEqual(done_sending, set())
         self.assertEqual(done_recving, {'req1'})
-        self.assertNotIn('req1', worker.reqs_pulling)
-        self.assertIn('req1', worker.reqs_ready_to_insert)
-        self.assertEqual(worker.reqs_ready_to_insert['req1'],
+        self.assertIn('req1', worker.reqs_pulling)
+        self.assertEqual(worker.reqs_pulling['req1'][1],
                          ('kv_data', 'indices', [1]))
         self.all_mocks['insert_kv_chunks'].assert_not_called()
 

--- a/tests/distributed/test_tpu_connector.py
+++ b/tests/distributed/test_tpu_connector.py
@@ -204,6 +204,7 @@ class TestTPUConnectorScheduler(unittest.TestCase):
             "remote_port": 54321
         }
         mock_blocks = MagicMock()
+        mock_blocks.get_block_ids.return_value = [[1, 2]]
         num_external_tokens = 0
 
         self.scheduler.update_state_after_alloc(mock_request, mock_blocks,
@@ -212,7 +213,7 @@ class TestTPUConnectorScheduler(unittest.TestCase):
         self.assertIn("req1", self.scheduler.reqs_to_load)
         load_meta = self.scheduler.reqs_to_load["req1"]
         self.assertEqual(load_meta.uuid, 123)
-        self.assertIsNone(load_meta.local_block_ids)
+        self.assertEqual(load_meta.local_block_ids, [1, 2])
         self.assertIsNone(load_meta.remote_block_ids)
 
     def test_build_connector_meta(self):
@@ -428,6 +429,7 @@ class TestTPUConnectorWorker(unittest.TestCase):
 
     def test_process_send_load_for_consumer_notifying(self):
         """Tests process_send_load for a consumer that needs to notify."""
+        self.all_mocks["time"].perf_counter.side_effect = [0.0, 1.0]
         self.vllm_config.kv_transfer_config.is_kv_producer = False
         worker = tpu_connector.TPUConnectorWorker(self.vllm_config)
         worker._maybe_build_notif_socket = MagicMock(return_value="socket")

--- a/tpu_inference/distributed/host_kv_pool.py
+++ b/tpu_inference/distributed/host_kv_pool.py
@@ -98,7 +98,7 @@ class HostKVPool:
         """
         Returns the buffer to the pool so other requests can use it.
         """
-        # logger.info(f"Returning buffer to HostKVPool (idx={idx})")
+        logger.info(f"Returning buffer to HostKVPool (idx={idx})")
 
         if updated_buffer is not None:
             # Overwrite the donated Python references with the new valid ones

--- a/tpu_inference/distributed/host_kv_pool.py
+++ b/tpu_inference/distributed/host_kv_pool.py
@@ -47,15 +47,17 @@ class HostKVPool:
         # e.g., (1024, 16, 128) -> (max_blocks, num_heads, head_size)
         layer_buffer_shape = (max_blocks_per_req, ) + cache_inner_shape
 
+        def _allocate():
+            return jnp.zeros(shape=layer_buffer_shape, dtype=dtype)
+
+        self.sharded_allocate = jax.jit(_allocate, out_shardings=host_sharding)
+
         logger.info(f"Allocating {pool_size} Host DRAM buffers for KV pool.")
         start_time = time.perf_counter()
         for i in range(pool_size):
             # Each item in the pool is a list of JAX arrays (one for each transformer layer)
             layer_buffers = [
-                self._create_single_layer_kv_cache_zeros(
-                    cache_shape=layer_buffer_shape,
-                    cache_dtype=dtype,
-                    cache_sharding=host_sharding) for _ in range(num_layers)
+                self.sharded_allocate() for _ in range(num_layers)
             ]
             self.buffers.append(layer_buffers)
 
@@ -65,15 +67,6 @@ class HostKVPool:
         logger.info(
             f"Host DRAM KV pool allocation complete. Time taken: {end_time - start_time:.2f} seconds."
         )
-
-    def _create_single_layer_kv_cache_zeros(self, cache_shape, cache_dtype,
-                                            cache_sharding):
-
-        def _allocate():
-            return jnp.zeros(shape=cache_shape, dtype=cache_dtype)
-
-        sharded_allocate = jax.jit(_allocate, out_shardings=cache_sharding)
-        return sharded_allocate()
 
     def get_buffer(self,
                    block: bool = True,

--- a/tpu_inference/distributed/tpu_connector.py
+++ b/tpu_inference/distributed/tpu_connector.py
@@ -662,7 +662,8 @@ class TPUConnectorWorker:
             f"Worker {self.node_id} --> Doing D2H kv transfer for req_id={req_id}"
         )
         buffer_idx, dest_buffer = self.host_kv_pool.get_buffer()
-        logger.debug(f"Worker {self.node_id} -->get the buffer id {buffer_idx}")
+        logger.debug(
+            f"Worker {self.node_id} -->get the buffer id {buffer_idx}")
         updated_dest_buffer = []
 
         start_time = time.perf_counter()
@@ -748,7 +749,8 @@ class TPUConnectorWorker:
                 logger.info(
                     f"Worker {self.node_id} --> kv transfer | done pull req_id={req_id} | "
                     f"uuid={req_meta.uuid} | prepare time={prepare_time_ms:.2f}ms | "
-                    f"pull time={pull_time_ms:.2f}ms | size={kv_size_mb:.2f}MB")
+                    f"pull time={pull_time_ms:.2f}ms | size={kv_size_mb:.2f}MB"
+                )
             else:
                 logger.warning(
                     f"Worker {self.node_id} --> kv transfer | failed to pull req_id={req_id} with in {pull_time_ms:.2f}ms | "
@@ -819,7 +821,9 @@ class TPUConnectorWorker:
             buffer, expires, buffer_index = self.reqs_wait_pull[req_id]
             if now > expires:
                 if expires > 0:
-                    logger.warning(f"Worker {self.node_id} --> req_id={req_id} KV transfer timeout. Force recycle the memory buffer.")
+                    logger.warning(
+                        f"Worker {self.node_id} --> req_id={req_id} KV transfer timeout. Force recycle the memory buffer."
+                    )
                 if buffer_index != -1 and self.host_kv_pool is not None:
                     self.host_kv_pool.return_buffer(buffer_index, buffer)
                 del self.reqs_wait_pull[req_id]

--- a/tpu_inference/distributed/tpu_connector.py
+++ b/tpu_inference/distributed/tpu_connector.py
@@ -283,6 +283,11 @@ class TPUConnectorScheduler():
         if self.is_producer or not request.kv_transfer_params:
             return 0, False
 
+        # Only trigger 1 KV transfer per request.
+        if request.kv_transfer_params.get("do_remote_prefill", True) is False:
+            # logger.debug(f"TPUConnector Scheduler skip kv transfer for request {request.request_id} as it already pulled before.")
+            return 0, False
+
         assert num_computed_tokens % self.block_size == 0
         # This rounding logic must be consistent with calculating
         # remote_block_ids in P's request_finished()
@@ -345,6 +350,10 @@ class TPUConnectorScheduler():
                 remote_host=params["remote_host"],
                 remote_port=params["remote_port"],
             )
+
+        # Only trigger 1 KV transfer per request.
+        params["do_remote_prefill"] = False
+
         logger.info(
             f"TPUConnector Scheduler update_state_after_alloc -->  reqs_to_load={self.reqs_to_load}"
         )
@@ -447,8 +456,9 @@ class TPUConnectorWorker:
         # req_id: (kv, expiration_time, buffer_index)
         self.reqs_wait_pull: dict[ReqId, list[list[jax.Array], float,
                                               int]] = {}
-        # req_id: thread_future
-        self.reqs_pulling: dict[ReqId, Future] = {}
+        # req_id: (pull_thread_future, kv, block_ids)
+        self.reqs_pulling: dict[ReqId, list[Future, list[jax.Array], list[int]]] = {}
+
         # req_id: (kv, indices)
         self.reqs_ready_to_insert: dict[ReqId, tuple[list[jax.Array],
                                                      jax.Array]] = {}
@@ -612,25 +622,25 @@ class TPUConnectorWorker:
                 # We execute device_array here so JAX sees the exact same sequence
                 # of local_block_ids across all TPU nodes simultaneously.
                 # TODO(xiang): pad block_ids to avoid recompilation
-                indices = device_array(self.mesh,
-                                       np.array(req_meta.local_block_ids))
                 conn = self._maybe_build_kv_connection(req_meta)
-
-                self.reqs_pulling[req_id] = self.pull_executor.submit(
-                    self._pull_kv, req_id, conn, req_meta, indices)
+                if req_id not in self.reqs_pulling:
+                    self.reqs_pulling[req_id] = [self.pull_executor.submit(
+                        self._pull_kv, req_id, conn, req_meta), None, req_meta.local_block_ids]
+                else:
+                    # Update the local block ids as the pre-allocated blocks may get preempted
+                    self.reqs_pulling[req_id][2] = req_meta.local_block_ids
             else:
-                if req_id in self.reqs_ready_to_insert:
-                    kv, indices, block_numbers = self.reqs_ready_to_insert.pop(
-                        req_id)
+                if req_id in self.reqs_pulling:
+                    assert self.reqs_pulling[req_id][1] is not None
+                    _, kv, block_numbers = self.reqs_pulling.pop(req_id)
                     if len(block_numbers) > 0:
                         self.runner.kv_caches = insert_kv_chunks(
                             self.runner.kv_caches, kv, block_numbers,
                             self.mesh, self.sharding.spec)
-
-                # The request has finished pulling the KV from remote, or it has full local
-                # prefix cache, need to notify P to let it free blocks.
-                socket = self._maybe_build_notif_socket(req_meta)
-                self._notify_pull_done(socket, req_id, req_meta.uuid)
+                    # The request has finished pulling the KV from remote, or it has full local
+                    # prefix cache, need to notify P to let it free blocks.
+                    socket = self._maybe_build_notif_socket(req_meta)
+                    self._notify_pull_done(socket, req_id, req_meta.uuid)
 
     def _prepare_kv_and_wait(self, req_id: str, req_meta: SendMeta):
         local_block_ids = req_meta.local_block_ids
@@ -716,8 +726,7 @@ class TPUConnectorWorker:
             )
         return conn
 
-    def _pull_kv(self, req_id: str, conn: Any, req_meta: LoadMeta,
-                 indices: jax.Array):
+    def _pull_kv(self, req_id: str, conn: Any, req_meta: LoadMeta):
         # The local allocated blocks which don't hit prefix caching.
         local_block_ids = req_meta.local_block_ids
         # The remote computed blocks which need to pull from P.
@@ -761,7 +770,7 @@ class TPUConnectorWorker:
                 f"Worker {self.node_id} --> kv transfer | done pull req_id={req_id} | "
                 f"uuid={req_meta.uuid} | prepare time={prepare_time_ms:.2f}ms | "
                 f"size={kv_size_mb:.2f}MB")
-        return kv, indices, req_meta.local_block_ids
+        return kv
 
     def _get_kv_spec(self, num_blocks: int) -> list[jax.ShapeDtypeStruct]:
         assert num_blocks <= self.shape[0]
@@ -806,13 +815,12 @@ class TPUConnectorWorker:
         # Mark a req as done recieving after its pulling thread returns.
         # This req can then be scheduled for decoding in the next scheduler step.
         for req_id in list(self.reqs_pulling.keys()):
-            future = self.reqs_pulling[req_id]
-            if future.done():
-                kv, indices, block_numbers = future.result()
-                self.reqs_ready_to_insert[req_id] = (kv, indices,
-                                                     block_numbers)
-                del self.reqs_pulling[req_id]
-                done_recving.add(req_id)
+            if self.reqs_pulling[req_id][1] is None:
+                future = self.reqs_pulling[req_id][0]
+                if future.done():
+                    kv = future.result()
+                    self.reqs_pulling[req_id][1] = kv
+                    done_recving.add(req_id)
 
         # Mark a req as done seding when it's expired.
         # This req can then be released blocks in the current scheduler step.

--- a/tpu_inference/distributed/tpu_connector.py
+++ b/tpu_inference/distributed/tpu_connector.py
@@ -444,7 +444,7 @@ class TPUConnectorWorker:
         # based on topology_order_id
         self.node_id = 0
 
-        # req_id: (kv, expiration_time)
+        # req_id: (kv, expiration_time, buffer_index)
         self.reqs_wait_pull: dict[ReqId, list[list[jax.Array], float,
                                               int]] = {}
         # req_id: thread_future
@@ -568,7 +568,11 @@ class TPUConnectorWorker:
                 )
                 if req_id in self.reqs_wait_pull:
                     # Set the expiration time of this request to -1, mark to be done
+                    buffer, _, buffer_index = self.reqs_wait_pull[req_id]
+                    if buffer_index != -1 and self.host_kv_pool is not None:
+                        self.host_kv_pool.return_buffer(buffer_index, buffer)
                     self.reqs_wait_pull[req_id][1] = -1
+                    self.reqs_wait_pull[req_id][2] = -1
                     self.kv_pull_uuid_to_req_id_map.pop(uuid)
                 else:
                     logger.warning(
@@ -658,6 +662,7 @@ class TPUConnectorWorker:
             f"Worker {self.node_id} --> Doing D2H kv transfer for req_id={req_id}"
         )
         buffer_idx, dest_buffer = self.host_kv_pool.get_buffer()
+        logger.debug(f"Worker {self.node_id} -->get the buffer id {buffer_idx}")
         updated_dest_buffer = []
 
         start_time = time.perf_counter()
@@ -728,6 +733,7 @@ class TPUConnectorWorker:
         kv = conn.pull(req_meta.uuid, kv_spec)
         kv_size_mb = sum(k.nbytes for k in kv) / (1024 * 1024)
         end_time_0, end_time_1 = time.perf_counter(), None
+        prepare_time_ms = (end_time_0 - start_time) * 1000
         if dist_utils.get_enable_block_kv_transfer():
             while True:
                 end_time_1 = time.perf_counter()
@@ -737,14 +743,22 @@ class TPUConnectorWorker:
                 ):
                     break
                 time.sleep(0.001)
-
-        prepare_time_ms = (end_time_0 - start_time) * 1000
-        pull_time_ms = (end_time_1 -
-                        end_time_0) * 1000 if end_time_1 is not None else 0.0
-        logger.info(
-            f"Worker {self.node_id} --> kv transfer | done pull req_id={req_id} | "
-            f"uuid={req_meta.uuid} | prepare time={prepare_time_ms:.2f}ms | "
-            f"pull time={pull_time_ms:.2f}ms | size={kv_size_mb:.2f}MB")
+            pull_time_ms = (end_time_1 - end_time_0) * 1000
+            if all(chunk.is_ready() for chunk in kv):
+                logger.info(
+                    f"Worker {self.node_id} --> kv transfer | done pull req_id={req_id} | "
+                    f"uuid={req_meta.uuid} | prepare time={prepare_time_ms:.2f}ms | "
+                    f"pull time={pull_time_ms:.2f}ms | size={kv_size_mb:.2f}MB")
+            else:
+                logger.warning(
+                    f"Worker {self.node_id} --> kv transfer | failed to pull req_id={req_id} with in {pull_time_ms:.2f}ms | "
+                    f"uuid={req_meta.uuid} | prepare time={prepare_time_ms:.2f}ms | "
+                    f"size={kv_size_mb:.2f}MB")
+        else:
+            logger.info(
+                f"Worker {self.node_id} --> kv transfer | done pull req_id={req_id} | "
+                f"uuid={req_meta.uuid} | prepare time={prepare_time_ms:.2f}ms | "
+                f"size={kv_size_mb:.2f}MB")
         return kv, indices, req_meta.local_block_ids
 
     def _get_kv_spec(self, num_blocks: int) -> list[jax.ShapeDtypeStruct]:
@@ -804,6 +818,8 @@ class TPUConnectorWorker:
         for req_id in list(self.reqs_wait_pull):
             buffer, expires, buffer_index = self.reqs_wait_pull[req_id]
             if now > expires:
+                if expires > 0:
+                    logger.warning(f"Worker {self.node_id} --> req_id={req_id} KV transfer timeout. Force recycle the memory buffer.")
                 if buffer_index != -1 and self.host_kv_pool is not None:
                     self.host_kv_pool.return_buffer(buffer_index, buffer)
                 del self.reqs_wait_pull[req_id]

--- a/tpu_inference/distributed/tpu_connector.py
+++ b/tpu_inference/distributed/tpu_connector.py
@@ -457,7 +457,8 @@ class TPUConnectorWorker:
         self.reqs_wait_pull: dict[ReqId, list[list[jax.Array], float,
                                               int]] = {}
         # req_id: (pull_thread_future, kv, block_ids)
-        self.reqs_pulling: dict[ReqId, list[Future, list[jax.Array], list[int]]] = {}
+        self.reqs_pulling: dict[ReqId, list[Future, list[jax.Array],
+                                            list[int]]] = {}
 
         # req_id: (kv, indices)
         self.reqs_ready_to_insert: dict[ReqId, tuple[list[jax.Array],
@@ -624,8 +625,11 @@ class TPUConnectorWorker:
                 # TODO(xiang): pad block_ids to avoid recompilation
                 conn = self._maybe_build_kv_connection(req_meta)
                 if req_id not in self.reqs_pulling:
-                    self.reqs_pulling[req_id] = [self.pull_executor.submit(
-                        self._pull_kv, req_id, conn, req_meta), None, req_meta.local_block_ids]
+                    self.reqs_pulling[req_id] = [
+                        self.pull_executor.submit(self._pull_kv, req_id, conn,
+                                                  req_meta), None,
+                        req_meta.local_block_ids
+                    ]
                 else:
                     # Update the local block ids as the pre-allocated blocks may get preempted
                     self.reqs_pulling[req_id][2] = req_meta.local_block_ids

--- a/tpu_inference/distributed/tpu_connector.py
+++ b/tpu_inference/distributed/tpu_connector.py
@@ -345,7 +345,7 @@ class TPUConnectorScheduler():
             # In both cases we need to send notification to let P free memory.
             self.reqs_to_load[request.request_id] = LoadMeta(
                 uuid=params["uuid"],
-                local_block_ids=None,
+                local_block_ids=blocks.get_block_ids()[0],
                 remote_block_ids=None,
                 remote_host=params["remote_host"],
                 remote_port=params["remote_port"],
@@ -638,13 +638,22 @@ class TPUConnectorWorker:
                     assert self.reqs_pulling[req_id][1] is not None
                     _, kv, block_numbers = self.reqs_pulling.pop(req_id)
                     if len(block_numbers) > 0:
+                        start_time = time.perf_counter()
                         self.runner.kv_caches = insert_kv_chunks(
                             self.runner.kv_caches, kv, block_numbers,
                             self.mesh, self.sharding.spec)
+                        end_time = time.perf_counter()
+                        logger.info(
+                            f"TPUConnector Worker {self.node_id} --> req_id={req_id}, takes {(end_time - start_time)*1000:.2f}ms for insert_kv_chunks"
+                        )
                     # The request has finished pulling the KV from remote, or it has full local
                     # prefix cache, need to notify P to let it free blocks.
                     socket = self._maybe_build_notif_socket(req_meta)
                     self._notify_pull_done(socket, req_id, req_meta.uuid)
+                else:
+                    logger.info(
+                        f"TPUConnector Worker {self.node_id} --> req_id={req_id}, skip insert_kv_chunks."
+                    )
 
     def _prepare_kv_and_wait(self, req_id: str, req_meta: SendMeta):
         local_block_ids = req_meta.local_block_ids
@@ -797,6 +806,7 @@ class TPUConnectorWorker:
                                    path=sock_path,
                                    socket_type=zmq.DEALER,
                                    bind=False)
+            self.notif_sockets[sock_path] = sock
             logger.info(
                 f"Worker {self.node_id} --> notify make_zmq_socket | sock_path={sock_path}"
             )

--- a/tpu_inference/distributed/utils.py
+++ b/tpu_inference/distributed/utils.py
@@ -87,7 +87,7 @@ def get_enable_block_kv_transfer() -> bool:
 
 def get_p2p_wait_pull_timeout() -> int:
     """KV-cache transfer timeout in seconds."""
-    timeout_str = os.getenv("TPU_P2P_WAIT_PULL_TIMEOUT", "30")
+    timeout_str = os.getenv("TPU_P2P_WAIT_PULL_TIMEOUT", "180")
     return int(timeout_str)
 
 


### PR DESCRIPTION
# Description

Fix the high request rate hang issue in Disagg

get_finished method will not get called if there is no more request in queue, It will lead a situation that even decode notify KV cache is pulled but the host pool can not be recycle. If will make decode keep waiting the prefill when the host pool exhausted.

when request get preempt, we should not pull the kv again as prefill already removed the KV. 

Optimize the host intitial function to avoid XLA keep compile.

Successful requests:                     200       
Failed requests:                         0         
Request rate configured (RPS):           4.00      
Benchmark duration (s):                  81.98     
Total input tokens:                      204800    
Total generated tokens:                  404800    
Request throughput (req/s):              2.44      
Output token throughput (tok/s):         4937.97   
Peak output token throughput (tok/s):    6194.00   
Peak concurrent requests:                151.00    
Total token throughput (tok/s):          7436.24   
---------------Time to First Token----------------
Mean TTFT (ms):                          4613.70   
Median TTFT (ms):                        2530.10   
P99 TTFT (ms):                           13167.83  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          15.48     
Median TPOT (ms):                        15.99     
P99 TPOT (ms):                           17.45     
---------------Inter-token Latency----------------
Mean ITL (ms):                           15.48     
Median ITL (ms):                         15.54     
P99 ITL (ms):                            19.37  

tested the long output length with high request rate:

Successful requests:                     200       
Failed requests:                         0         
Request rate configured (RPS):           4.00      
Benchmark duration (s):                  633.09    
Total input tokens:                      204800    
Total generated tokens:                  1782400   
Request throughput (req/s):              0.32      
Output token throughput (tok/s):         2815.39   
Peak output token throughput (tok/s):    6167.00   
Peak concurrent requests:                200.00    
Total token throughput (tok/s):          3138.88   
---------------Time to First Token----------------
Mean TTFT (ms):                          137399.56 
Median TTFT (ms):                        109119.39 
P99 TTFT (ms):                           422623.76 
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          24.80     
Median TPOT (ms):                        24.09     
P99 TPOT (ms):                           38.57     
---------------Inter-token Latency----------------
Mean ITL (ms):                           24.80     
Median ITL (ms):                         15.16     
P99 ITL (ms):                            19.98    


with max_concurrency=20

Successful requests:                     200       
Failed requests:                         0         
Maximum request concurrency:             20        
Request rate configured (RPS):           4.00      
Benchmark duration (s):                  756.20    
Total input tokens:                      204800    
Total generated tokens:                  1782400   
Request throughput (req/s):              0.26      
Output token throughput (tok/s):         2357.05   
Peak output token throughput (tok/s):    3580.00   
Peak concurrent requests:                25.00     
Total token throughput (tok/s):          2627.88   
---------------Time to First Token----------------
Mean TTFT (ms):                          89.12     
Median TTFT (ms):                        86.56     
P99 TTFT (ms):                           214.06    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          8.41      
Median TPOT (ms):                        8.43      
P99 TPOT (ms):                           8.49      
---------------Inter-token Latency----------------
Mean ITL (ms):                           8.41      
Median ITL (ms):                         8.74      
P99 ITL (ms):                            12.53  
# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
