### PR TITLE
[Torchax][Multimodal] Fix multimodal in torchax path

### DIFF
--- a/tpu_inference/models/vllm/vllm_model_wrapper.py
+++ b/tpu_inference/models/vllm/vllm_model_wrapper.py
@@ -31,6 +31,7 @@ from torchax.interop import jax_view, torch_view
 from torchax.ops.mappings import TORCH_DTYPE_TO_JAX
 from vllm.config import VllmConfig, set_current_vllm_config
 from vllm.forward_context import set_forward_context
+from vllm.ir import enable_torch_wrap
 from vllm.lora.layers import BaseLayerWithLoRA
 from vllm.lora.worker_manager import LRUCacheWorkerLoRAManager
 from vllm.model_executor.layers.pooler import Pooler
@@ -405,13 +406,14 @@ class VllmModelWrapper:
             **kwargs,
         ) -> Any:
 
-            def move(v: torch.Tensor) -> torch.Tensor:
-                if not isinstance(v, torch.Tensor):
-                    logger.warning(f"Expect torch.Tensor, got {type(v)}")
-                    return v
-                return v.to(device="jax")
+            with torchax.default_env(), enable_torch_wrap(False):
 
-            with torchax.default_env():
+                def move(v: torch.Tensor) -> torch.Tensor:
+                    if not isinstance(v, torch.Tensor):
+                        logger.warning(f"Expect torch.Tensor, got {type(v)}")
+                        return v
+                    return v.to(device="jax")
+
                 # Ensure all tensors are moved into accelerator so the
                 # computation with weights can work properly.
                 call_kwargs = {

--- a/tpu_inference/models/vllm/vllm_model_wrapper.py
+++ b/tpu_inference/models/vllm/vllm_model_wrapper.py
@@ -444,6 +444,7 @@ class VllmModelWrapper:
             params_and_buffers: Any,
             input_ids: jax.Array,
             mm_embeds: list[jax.Array] | jax.Array | None = None,
+            *,
             is_multimodal: jax.Array | None = None,
         ) -> jax.Array:
             with torchax.default_env():

--- a/tpu_inference/models/vllm/vllm_model_wrapper.py
+++ b/tpu_inference/models/vllm/vllm_model_wrapper.py
@@ -444,7 +444,6 @@ class VllmModelWrapper:
             params_and_buffers: Any,
             input_ids: jax.Array,
             mm_embeds: list[jax.Array] | jax.Array | None = None,
-            *,
             is_multimodal: jax.Array | None = None,
         ) -> jax.Array:
             with torchax.default_env():
@@ -453,8 +452,8 @@ class VllmModelWrapper:
                         torch_mm_embeds = [torch_view(x) for x in mm_embeds]
                     else:
                         torch_mm_embeds = torch_view(mm_embeds)
-                    if is_multimodal is not None:
-                        torch_mm_embeds = torch_mm_embeds[is_multimodal]
+                    assert is_multimodal is not None
+                    torch_mm_embeds = torch_mm_embeds[is_multimodal]
                     call_args = (torch_view(input_ids), torch_mm_embeds)
                 else:
                     call_args = (torch_view(input_ids), )

--- a/tpu_inference/models/vllm/vllm_model_wrapper.py
+++ b/tpu_inference/models/vllm/vllm_model_wrapper.py
@@ -453,6 +453,8 @@ class VllmModelWrapper:
                         torch_mm_embeds = [torch_view(x) for x in mm_embeds]
                     else:
                         torch_mm_embeds = torch_view(mm_embeds)
+                    if is_multimodal is not None:
+                        torch_mm_embeds = torch_mm_embeds[is_multimodal]
                     call_args = (torch_view(input_ids), torch_mm_embeds)
                 else:
                     call_args = (torch_view(input_ids), )

--- a/tpu_inference/runner/compilation_manager.py
+++ b/tpu_inference/runner/compilation_manager.py
@@ -139,6 +139,8 @@ class CompilationManager:
                 sharding=sharding)
             dummy_input_ids = self._create_dummy_tensor(
                 (num_tokens, ), jnp.int32, sharding=input_sharding)
+            dummy_is_multimodal = self._create_dummy_tensor(
+                (num_tokens, ), jnp.int32, sharding=input_sharding)
 
             self._run_compilation(
                 "input_embeddings_merger",
@@ -146,6 +148,7 @@ class CompilationManager:
                 self.runner.state,
                 dummy_input_ids,
                 dummy_multimodal_embeddings,
+                dummy_is_multimodal,
                 num_tokens=num_tokens,
             )
 
@@ -154,6 +157,7 @@ class CompilationManager:
                 self.runner.embed_input_ids_fn,
                 self.runner.state,
                 dummy_input_ids,
+                None,
                 None,
                 num_tokens=num_tokens,
             )

--- a/tpu_inference/runner/compilation_manager.py
+++ b/tpu_inference/runner/compilation_manager.py
@@ -76,11 +76,15 @@ class CompilationManager:
             return inner_val != outer_val
         return inner_val > outer_val
 
-    def _run_compilation(self, name: str, fn: Callable, *args,
+    def _run_compilation(self,
+                         name: str,
+                         fn: Callable,
+                         *args,
+                         call_kwargs=dict(),
                          **kwargs) -> None:
         logger.info(f"Precompile {name} --> {kwargs}")
         start = time.perf_counter()
-        result = fn(*args)
+        result = fn(*args, **call_kwargs)
         jax.tree.map(lambda r: r.block_until_ready(), result)
         end = time.perf_counter()
         logger.info("Compilation finished in %.2f [secs].", end - start)
@@ -148,7 +152,7 @@ class CompilationManager:
                 self.runner.state,
                 dummy_input_ids,
                 dummy_multimodal_embeddings,
-                dummy_is_multimodal,
+                call_kwargs={"is_multimodal": dummy_is_multimodal},
                 num_tokens=num_tokens,
             )
 
@@ -158,7 +162,7 @@ class CompilationManager:
                 self.runner.state,
                 dummy_input_ids,
                 None,
-                None,
+                call_kwargs={"is_multimodal": None},
                 num_tokens=num_tokens,
             )
 


### PR DESCRIPTION
# Description

- move function `move` to the inside of `with torchax.default_env()`
- use `enable_torch_wrap(False)` to disable vllm irs.
-  use `torch_mm_embeds[is_multimodal]` to remove padding.

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
