### PR TITLE
[WIP] Add FP8 MoE direct path and scale-shape robustness

### DIFF
--- a/tpu_inference/envs.py
+++ b/tpu_inference/envs.py
@@ -32,6 +32,8 @@ if TYPE_CHECKING:
     REQUANTIZE_WEIGHT_DTYPE: str = "float8_e4m3fn"
     MOE_REQUANTIZE_BLOCK_SIZE: int | None = None
     MOE_REQUANTIZE_WEIGHT_DTYPE: str = "float8_e4m3fn"
+    MOE_REQUANTIZE_EXPERT_CHUNK_SIZE: int | None = 8
+    MOE_SKIP_REQUANTIZATION: bool = False
     LAYOUT_Q_PROJ_AS_NDH: bool = False
     USE_JAX_PROFILER_SERVER: bool = False
     JAX_PROFILER_SERVER_PORT: int = 9999
@@ -224,6 +226,13 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "MOE_REQUANTIZE_BLOCK_SIZE":
     lambda: int(block_size) if (block_size := os.getenv(
         "MOE_REQUANTIZE_BLOCK_SIZE")) is not None else None,
+    # Chunk load-time FP8 MoE requantization by expert to cap peak host memory
+    "MOE_REQUANTIZE_EXPERT_CHUNK_SIZE":
+    lambda: int(chunk_size) if (chunk_size := os.getenv(
+        "MOE_REQUANTIZE_EXPERT_CHUNK_SIZE")) not in (None, "") else 8,
+    # Skip FP8→FP32→FP8 dequant/requant cycle, do shape transforms directly
+    "MOE_SKIP_REQUANTIZATION":
+    env_bool("VLLM_MOE_SKIP_REQUANTIZATION", default=False),
     # dictates whether to layout q-proj as NDH (q-heads, model dim, head dim)
     # or DNH (model dim, q-heads, head dim), which is the default (False)
     "LAYOUT_Q_PROJ_AS_NDH":

--- a/tpu_inference/kernels/megablox/gmm_v2.py
+++ b/tpu_inference/kernels/megablox/gmm_v2.py
@@ -23,6 +23,10 @@ from jax import lax
 from jax.experimental import pallas as pl
 from jax.experimental.pallas import tpu as pltpu
 
+# TPU v4 has no FP8 matmul support (Mosaic E2001). We detect FP8 and dequantize
+# to BF16 inside the Pallas kernel VMEM.
+_FP8_DTYPES = (jnp.float8_e4m3fn, jnp.float8_e5m2)
+
 # Util.
 
 
@@ -173,6 +177,9 @@ class InputConfigs:
     dtype: jnp.dtype
     has_bias: bool = False
     has_scale: bool = False
+    scale_n_block_size: int | None = None  # 2D block scale N-block size
+    # None = current behavior (full N resolution)
+    # 128  = 2D block scale, N dimension blocked by 128
 
     @property
     def should_bitcast(self) -> bool:
@@ -194,6 +201,13 @@ class GmmConfigs:
     @property
     def num_quant_blocks_per_tile_k(self) -> int:
         return pl.cdiv(self.tiles.tile_k, self.rhs_cfgs.quant_block_size)
+
+    @property
+    def n_blocks_per_tile_n(self) -> int | None:
+        """Number of N-blocks per tile_n (for 2D block scale)."""
+        if self.rhs_cfgs.scale_n_block_size is None:
+            return None  # full N resolution, current behavior
+        return self.tiles.tile_n // self.rhs_cfgs.scale_n_block_size
 
     @property
     def out_size_n(self) -> int:
@@ -244,6 +258,17 @@ class IndexMaps:
         b_tile_id = b_row // self.cfgs.num_quant_blocks_per_tile_k
         return (group_id, b_tile_id, 0, n_id)
 
+    def rhs_scale_index_map_2d(self, n_id: jax.Array, gm_id: jax.Array,
+                                k_id: jax.Array):
+        """Index map for 2D block scale (E, K_blocks, N_blocks)."""
+        group_id = self.metadata_ref.gm_id_to_group_id[gm_id]
+        k_row = k_id * self.cfgs.tiles.tile_k
+        b_row = k_row // self.cfgs.rhs_cfgs.quant_block_size
+        b_tile_id = b_row // self.cfgs.num_quant_blocks_per_tile_k
+        # n_id now maps to N_blocks dimension (not full N)
+        return (group_id, b_tile_id, n_id)
+        # 3D index: (expert, K_block_tile, N_block_tile)
+
     def out_index_map(self, n_id: jax.Array, gm_id: jax.Array, _: jax.Array):
         is_last_gm = gm_id == (pl.num_programs(1) - 1)
         m_start = self.metadata_ref.gm_id_to_m_offset[gm_id]
@@ -289,10 +314,18 @@ def generate_block_specs(
             index_map.rhs_bias_index_map,
         )
     if cfgs.rhs_cfgs.has_scale:
-        rhs_scale_block_spec = pl.BlockSpec(
-            (None, cfgs.num_quant_blocks_per_tile_k, 1, cfgs.tiles.tile_n),
-            index_map.rhs_scale_index_map,
-        )
+        if cfgs.rhs_cfgs.scale_n_block_size is not None:
+            # 2D block scale: compact (E, K_blocks, N_blocks)
+            rhs_scale_block_spec = pl.BlockSpec(
+                (None, cfgs.num_quant_blocks_per_tile_k, cfgs.n_blocks_per_tile_n),
+                index_map.rhs_scale_index_map_2d,
+            )
+        else:
+            # Current: full N resolution (E, K_blocks, 1, N)
+            rhs_scale_block_spec = pl.BlockSpec(
+                (None, cfgs.num_quant_blocks_per_tile_k, 1, cfgs.tiles.tile_n),
+                index_map.rhs_scale_index_map,
+            )
 
     rhs_block_spec = WeightsRef(
         weight=rhs_weight_spec,
@@ -377,17 +410,46 @@ def inner_kernel(
                     k_start = b_id * rhs_qbs
                     k_end = k_start + rhs_qbs
 
-                    block_acc = jnp.matmul(
-                        tiled_lhs[:, k_start:k_end],
-                        tiled_rhs[k_start:k_end, start_n:end_n],
-                        preferred_element_type=jnp.float32,
-                    ).astype(acc_ref.dtype)
+                    rhs_block = tiled_rhs[k_start:k_end, start_n:end_n]
 
-                    if cfgs.rhs_cfgs.has_scale:
+                    # TPU v4: no FP8 matmul (Mosaic E2001). Dequantize FP8 tile
+                    # in Pallas VMEM to float32 for numerical accuracy.
+                    if cfgs.rhs_cfgs.dtype in _FP8_DTYPES and cfgs.rhs_cfgs.has_scale:
                         tiled_rhs_scale = tiled_rhs_ref.get_scale()
-                        block_acc *= tiled_rhs_scale[b_id, :,
-                                                     start_n:end_n].astype(
-                                                         acc_ref.dtype)
+                        if cfgs.rhs_cfgs.scale_n_block_size is not None:
+                            # 2D block scale: tiled_rhs_scale is (K_blocks_per_tile, N_blocks_per_tile)
+                            n_block_size = cfgs.rhs_cfgs.scale_n_block_size
+                            n_block_idx = start_n // n_block_size
+                            scale = tiled_rhs_scale[b_id, n_block_idx]  # scalar
+                            rhs_block = (rhs_block.astype(jnp.float32) * scale)
+                        else:
+                            # Current: full N resolution
+                            scale = tiled_rhs_scale[b_id, :, start_n:end_n]
+                            rhs_block = (rhs_block.astype(jnp.float32)
+                                         * scale)
+                        # Scale is baked in; cast back to lhs dtype for MXU.
+                        rhs_block = rhs_block.astype(tiled_lhs.dtype)
+                        block_acc = jnp.matmul(
+                            tiled_lhs[:, k_start:k_end],
+                            rhs_block,
+                            preferred_element_type=jnp.float32,
+                        ).astype(acc_ref.dtype)
+                    else:
+                        block_acc = jnp.matmul(
+                            tiled_lhs[:, k_start:k_end],
+                            rhs_block,
+                            preferred_element_type=jnp.float32,
+                        ).astype(acc_ref.dtype)
+
+                        if cfgs.rhs_cfgs.has_scale:
+                            tiled_rhs_scale = tiled_rhs_ref.get_scale()
+                            if cfgs.rhs_cfgs.scale_n_block_size is not None:
+                                n_block_idx = start_n // cfgs.rhs_cfgs.scale_n_block_size
+                                block_acc *= tiled_rhs_scale[b_id, n_block_idx].astype(acc_ref.dtype)
+                            else:
+                                block_acc *= tiled_rhs_scale[b_id, :,
+                                                             start_n:end_n].astype(
+                                                                 acc_ref.dtype)
 
                     acc_n += block_acc
                 acc_list.append(acc_n)
@@ -859,6 +921,14 @@ def calculate_tiling(
     rhs_vmem_target = vmem_limit_bytes // num_rhs_buffers
     base_rhs_size_bytes = dims.size_k * dims.size_n * rhs_bits // 8
 
+    # TPU v4: FP8→F32 dequant in VMEM keeps the original FP8 tile, the F32
+    # intermediate, and the BF16 result coexisting.  Budget conservatively:
+    #   per element = FP8 (1 B) + F32 (4 B) = 5 B
+    if rhs_cfgs.dtype in _FP8_DTYPES and rhs_cfgs.has_scale:
+        fp8_bytes = rhs_bits // 8  # 1
+        dequant_bytes = 4  # F32 intermediate
+        base_rhs_size_bytes = base_rhs_size_bytes * (fp8_bytes + dequant_bytes) // fp8_bytes
+
     # To avoid stalling MXU, we add some buffer room where tile_n cannot go
     # smaller than 2x of mxu_column_size.
     tile_n_limit = pltpu.get_tpu_info().mxu_column_size * 2
@@ -907,6 +977,14 @@ def calculate_tiling(
             tile_k = align_to(dims.size_k,
                               num_k_tiles * num_lanes) // num_k_tiles
 
+    # 2D block scale: ensure tile_n is a multiple of scale_n_block_size
+    if rhs_cfgs.scale_n_block_size is not None:
+        nbs = rhs_cfgs.scale_n_block_size
+        if tile_n % nbs != 0:
+            tile_n = (tile_n // nbs) * nbs
+            if tile_n == 0:
+                tile_n = nbs
+
     if tile_n == 0 or tile_k == 0:
         raise ValueError(
             f"Could not find valid tile sizes for {dims=} and {rhs_vmem_target=}."
@@ -936,9 +1014,17 @@ def validate_inputs(
     if rhs_bias is not None:
         assert rhs_bias.shape == (size_group, 1, size_n)
     if rhs_scale is not None:
-        num_quant_blocks = rhs_scale.shape[1]
-        assert rhs_scale.shape == (size_group, num_quant_blocks, 1, size_n)
-        assert size_k % num_quant_blocks == 0
+        if rhs_scale.ndim == 3:
+            # 2D block scale: (E, K_blocks, N_blocks)
+            num_quant_blocks = rhs_scale.shape[1]
+            num_n_blocks = rhs_scale.shape[2]
+            assert size_k % num_quant_blocks == 0
+            assert size_n % num_n_blocks == 0
+        else:
+            # Current: (E, K_blocks, 1, N)
+            num_quant_blocks = rhs_scale.shape[1]
+            assert rhs_scale.shape == (size_group, num_quant_blocks, 1, size_n)
+            assert size_k % num_quant_blocks == 0
 
     assert group_offset.shape == (1, )
 
@@ -1031,10 +1117,19 @@ def make_gmm_configs(
         rhs_quant_dtype = rhs.dtype
         num_blocks = rhs_scale.shape[1]
         block_size = dims.size_k // num_blocks
+        # 2D block scale: shape (E, K_blocks, N_blocks). Auto-enable kernel's
+        # 2D mode so it does scalar per-block lookup instead of per-element N
+        # expansion. Avoids the 128x host-side memory blow-up from
+        # `expand_2d_block_scale` under large TP sharding.
+        if rhs_scale.ndim == 3:
+            scale_n_block_size = dims.size_n // rhs_scale.shape[-1]
+        else:
+            scale_n_block_size = None
     else:
         has_scale = False
         rhs_quant_dtype = None
         block_size = dims.size_k
+        scale_n_block_size = None
 
     rhs_cfgs = InputConfigs(
         quant_dtype=rhs_quant_dtype,
@@ -1042,6 +1137,7 @@ def make_gmm_configs(
         dtype=rhs.dtype,
         has_bias=rhs_bias is not None,
         has_scale=has_scale,
+        scale_n_block_size=scale_n_block_size,
     )
 
     lhs_q_dtype = None

--- a/tpu_inference/kernels/quantized_matmul/util.py
+++ b/tpu_inference/kernels/quantized_matmul/util.py
@@ -66,6 +66,9 @@ def get_kernel_name(tuned_value: TunedValue):
     )
 
 
+_FP8_DTYPES = (jnp.float8_e4m3fn, jnp.float8_e5m2)
+
+
 def xla_quantized_matmul(
     x: jax.Array,
     w_q: jax.Array,
@@ -78,13 +81,36 @@ def xla_quantized_matmul(
     Args:
         x:  Activation.
         w_q: Weight quantized array. [n_output_features, n_input_features]
-        w_s: Weight quantization scale. [n_output_features]
+        w_s: Weight quantization scale. [n_output_features] or [n_output_features, 1]
         mesh: Mesh to shard on.
         weight_sharding: PartitionSpec for the weight tensor.
 
     Returns:
         Output of the quantized matmul.
     """
+    # TPU v4 does not support FP8 matmul (Mosaic E2001:
+    # CompileTimeMosaicUnsupportedRhsType).  When weights are stored as FP8,
+    # dequantize them to the activation dtype (BF16) before dot_general so that
+    # we keep FP8 storage but compute in BF16/F32 which v4 MXU supports.
+    # w_scale has shape [n_out, 1] (per-output-channel, from quantize_tensor
+    # with block_size=None and axis=-1 with keepdims=True).
+    if w_q.dtype in _FP8_DTYPES:
+        # TPU v4 has only 16 MB VMEM.  Dequanting the full weight before
+        # dot_general forces XLA to materialise it in VMEM, easily exceeding
+        # capacity.  Instead, cast FP8→BF16 (trivially fusible) and apply the
+        # per-output-channel scale *after* the matmul:
+        #   y = x @ (w * s) = (x @ w) * s   (s is per-output-channel)
+        w_bf16 = w_q.astype(x.dtype)
+        out = jax.lax.dot_general(
+            x,
+            w_bf16,
+            dimension_numbers=(((1, ), (1, )), ((), ())),
+            preferred_element_type=jnp.float32,
+        )
+        # w_scale may be (n_out,), (n_out, 1), or (1, n_out).
+        out = out * w_scale.reshape(-1).astype(jnp.float32)
+        return out.astype(x.dtype)
+
     if quantize_activation:
         acc_dtype = jnp.float32
         if quantize_activation and jnp.issubdtype(w_q.dtype, jnp.integer):
@@ -135,6 +161,24 @@ def xla_quantized_batched_matmul(
         dot_general: batch dims first, then lhs free dims, then rhs free dims.
     """
     contract_dims, batch_dims = dimension_numbers
+
+    # TPU v4 does not support FP8 matmul (Mosaic E2001).  Cast FP8→BF16
+    # and apply per-channel scale after the matmul to avoid VMEM OOM.
+    if w_q.dtype in _FP8_DTYPES:
+        w_bf16 = w_q.astype(x.dtype)
+        out = jax.lax.dot_general(
+            x,
+            w_bf16,
+            dimension_numbers=(contract_dims, batch_dims),
+            preferred_element_type=jnp.float32,
+        )
+        # Apply w_scale after matmul (same pattern as the non-FP8 path below).
+        n_leading = out.ndim - w_scale.ndim
+        _ws = w_scale
+        for _ in range(n_leading):
+            _ws = jnp.expand_dims(_ws, 0)
+        out = out * _ws
+        return out.astype(x.dtype)
 
     if quantize_activation:
         acc_dtype = jnp.float32

--- a/tpu_inference/layers/common/fused_moe_gmm.py
+++ b/tpu_inference/layers/common/fused_moe_gmm.py
@@ -222,8 +222,11 @@ def moe_gmm_local(
 
     reduction_axis = (ShardingAxisName.MLP_TENSOR
                       if parallelism == "tp" else ShardingAxisName.EXPERT)
+
     # Then global reduction on all ranks for all tokens and all experts
-    return jax.lax.psum(token_hidden, axis_name=reduction_axis).astype(x.dtype)
+    out = jax.lax.psum(token_hidden, axis_name=reduction_axis).astype(x.dtype)
+
+    return out
 
 
 def tensor_parallel_gmm(
@@ -256,8 +259,16 @@ def tensor_parallel_gmm(
         None, None, ShardingAxisName.MLP_TENSOR))
 
     num_blocks = 1 if w2_scale is None else w2_scale.shape[1]
-    w2_scale_spec = (None if num_blocks == 1 else P(
-        None, ShardingAxisName.MLP_TENSOR, None, None))
+    # w2_scale can be 3D compact (E, K_blocks, N_blocks) or 4D legacy
+    # (E, K_blocks, 1, N_full).  process_fp8_moe_weights_direct keeps 3D for
+    # GMM_TP; other paths (FUSED_MOE, GMM_EP) expand to 4D.  Match spec rank
+    # to the actual tensor rank.
+    if w2_scale is None or num_blocks == 1:
+        w2_scale_spec = None
+    elif w2_scale.ndim == 3:
+        w2_scale_spec = P(None, ShardingAxisName.MLP_TENSOR, None)
+    else:  # ndim == 4
+        w2_scale_spec = P(None, ShardingAxisName.MLP_TENSOR, None, None)
     w2_bias_spec = None if w2_bias is None else P(None, None, None)
 
     return jax.shard_map(
@@ -422,6 +433,7 @@ def fused_moe_func(
     scoring_fn: str,
     sc_kernel_threshold: int,
     sc_kernel_col_chunk_size: int,
+    e_score_correction_bias: jax.Array | None = None,
     all_gather_fp8: bool = False,
 ) -> jax.Array:
     """Route tokens in hidden_states into each experts based on routing.
@@ -467,10 +479,20 @@ def fused_moe_func(
             key, global_num_experts, shape=(topk, ), replace=False))(
                 jax.random.split(rng_key, num_tokens))
         topk_weights = jax.random.uniform(rng_key, shape=(num_tokens, topk))
+    elif e_score_correction_bias is not None:
+        # noaux_tc topk method: use biased scores for SELECTION, original
+        # (sigmoid'd) scores for WEIGHTING. Without this, routing is wrong
+        # for models like GLM-5.1 / DeepSeek-V3.
+        scores_for_choice = topk_weights + e_score_correction_bias.astype(
+            topk_weights.dtype)
+        _, topk_indices = jax.lax.top_k(scores_for_choice, k=topk)
+        topk_weights = topk_weights[jnp.arange(num_tokens)[:, None],
+                                    topk_indices]
     else:
         topk_weights, topk_indices = jax.lax.top_k(topk_weights, k=topk)
     if renormalize:
         topk_weights = topk_weights / topk_weights.sum(axis=-1, keepdims=True)
+
     # All gathering topk_indices and topk_weights if attention dp is used.
     if get_mesh_shape_product(mesh, ShardingAxisName.ATTN_DATA) > 1:
         topk_indices, topk_weights = all_gather_topk_indices_and_weights(
@@ -494,6 +516,12 @@ def fused_moe_func(
         topk_argsort_revert_indices = jnp.argsort(topk_argsort_indices)
 
         if use_ep:
+            # Packed gather: each EP shard picks only the tokens whose topk
+            # expert is local to this rank.  The matching ragged_scatter in
+            # moe_gmm_local then places each shard's contribution at the
+            # correct global token position (zeros elsewhere) so psum along
+            # the EXPERT axis sums disjoint positions and does not mix
+            # contributions from different tokens.
             num_ep_shard = get_mesh_shape_product(mesh,
                                                   ShardingAxisName.EXPERT)
             local_num_experts = global_num_experts // num_ep_shard
@@ -505,6 +533,11 @@ def fused_moe_func(
                                                include_initial=True)
             shard_output_start = group_offsets[experts_start]
             shard_output_end = group_offsets[experts_end]
+            # Assert ragged_gather bounds are valid — prevents silent OOB
+            # on unexpected mesh configurations.
+            assert global_num_experts % num_ep_shard == 0, (
+                f"global_num_experts ({global_num_experts}) must be divisible "
+                f"by EP shard count ({num_ep_shard})")
             x = ragged_gather(
                 hidden_states_local,
                 token_indices_sorted,

--- a/tpu_inference/layers/common/moe.py
+++ b/tpu_inference/layers/common/moe.py
@@ -123,13 +123,18 @@ def moe_apply(
                     **extra_backend_kwargs,
                 )[:, :actual_hidden_size]
             case MoEBackend.GMM_EP | MoEBackend.GMM_TP:
-                # Check if activation_dtype was passed via kwargs or as an environment variable
+                # e_score_correction_bias (for topk_method="noaux_tc" models
+                # like GLM-5.1 / DeepSeek-V3) may be supplied via
+                # extra_backend_kwargs as a pre-converted JAX array.
+                _bias_jax = (extra_backend_kwargs or {}).get(
+                    "e_score_correction_bias")
+                # Upstream FP8 activation path (#2152): read activation_dtype
+                # from kwargs or env, set all_gather_fp8 accordingly.
                 activation_dtype = extra_backend_kwargs.get(
                     "activation_dtype", envs.MOE_ALL_GATHER_ACTIVATION_DTYPE)
                 all_gather_fp8 = (bool(activation_dtype)
                                   and to_jax_dtype(activation_dtype)
                                   == jnp.float8_e4m3fn)
-
                 output = fused_moe_func(
                     hidden_states=x,
                     w1=weights.w13_weight,
@@ -147,6 +152,7 @@ def moe_apply(
                     scoring_fn=layer.scoring_func,
                     sc_kernel_threshold=envs.SC_KERNEL_THRESHOLD,
                     sc_kernel_col_chunk_size=envs.SC_KERNEL_COL_CHUNK_SIZE,
+                    e_score_correction_bias=_bias_jax,
                     all_gather_fp8=all_gather_fp8,
                 )
             case MoEBackend.DENSE_MAT:

--- a/tpu_inference/layers/common/process_weights/moe_weights.py
+++ b/tpu_inference/layers/common/process_weights/moe_weights.py
@@ -190,8 +190,8 @@ def process_w13_for_gmm(tensor,
     padded_w1 = _pad_tensor(w1)
     padded_w3 = _pad_tensor(w3)
 
-    logger.info(f"{name}_w1 shape after padding: {padded_w1.shape}")
-    logger.info(f"{name}_w3 shape after padding: {padded_w3.shape}")
+    logger.debug(f"{name}_w1 shape after padding: {padded_w1.shape}")
+    logger.debug(f"{name}_w3 shape after padding: {padded_w3.shape}")
 
     # 3. Concatenate and Reorder for avoiding TP sharding comms
     w13_concat = jnp.concatenate([padded_w1, padded_w3], axis=concat_dim)
@@ -210,6 +210,7 @@ def process_moe_weights(
     moe_backend: MoEBackend,
     w13_reorder_size: int | None = None,
     w13_interleave: bool = False,
+    compact_scale_fields: tuple[str, ...] = (),
 ) -> FusedMoEWeights:
     """Process fused moe weights to a layout that moe backend expects.
 
@@ -223,6 +224,11 @@ def process_moe_weights(
         w13_interleave: used when loaded w13_weight is stored in interleaved
             pattern where even index element is w1 and odd index element is w3.
             we uninterleave so that first half is w1 and second half is w3.
+        compact_scale_fields: field names (e.g. "w2_weight_scale") whose
+            scale should stay 3D (E, K_blocks, N_blocks) rather than being
+            expand_dims'd to 4D. Used by the direct FP8 path to feed the
+            kernel's per-block scalar lookup (scale_n_block_size mode),
+            saving the 128× host-side memory blow-up.
 
     Returns:
         MoE weights that are processed for specified backend.
@@ -257,18 +263,30 @@ def process_moe_weights(
     w13_weight = jnp.swapaxes(w13_weight, 1, 2)
     w2_weight = jnp.swapaxes(w2_weight, 1, 2)
 
-    # Workaround for JAX error "must have valid byte strides"
-    w13_weight = with_layout_constraint(w13_weight, Layout((0, 1, 2)))
-    w2_weight = with_layout_constraint(w2_weight, Layout((0, 1, 2)))
+    # Workaround for JAX error "must have valid byte strides". Keep it for the
+    # fused-MoE path, but skip it for GMM_EP because that path already ends up
+    # with EP-only sharding and this extra layout constraint can trigger a huge
+    # TP all-gather during lowering.
+    if moe_backend != MoEBackend.GMM_EP:
+        w13_weight = with_layout_constraint(w13_weight, Layout((0, 1, 2)))
+        w2_weight = with_layout_constraint(w2_weight, Layout((0, 1, 2)))
 
+    # Scale layout: swap (N_blocks↔K_blocks) so kernel's b_id iterates over
+    # K_blocks (contracting dim). By default expand_dims(axis=2) to get 4D
+    # (E, K_blocks, 1, N_full) expected by legacy per-element-N kernel path.
+    # Fields in `compact_scale_fields` keep the 3D (E, K_blocks, N_blocks)
+    # layout — kernel's gmm_v2 auto-enables scale_n_block_size mode and does
+    # per-block scalar lookup. See process_fp8_moe_weights_direct.
     if w13_weight_scale is not None:
         w13_weight_scale = w13_weight_scale.astype(jnp.float32)
         w13_weight_scale = jnp.swapaxes(w13_weight_scale, 1, 2)
-        w13_weight_scale = jnp.expand_dims(w13_weight_scale, 2)
+        if "w13_weight_scale" not in compact_scale_fields:
+            w13_weight_scale = jnp.expand_dims(w13_weight_scale, 2)
     if w2_weight_scale is not None:
         w2_weight_scale = w2_weight_scale.astype(jnp.float32)
         w2_weight_scale = jnp.swapaxes(w2_weight_scale, 1, 2)
-        w2_weight_scale = jnp.expand_dims(w2_weight_scale, 2)
+        if "w2_weight_scale" not in compact_scale_fields:
+            w2_weight_scale = jnp.expand_dims(w2_weight_scale, 2)
     if w13_bias is not None:
         w13_bias = w13_bias.astype(jnp.float32)
         w13_bias = jnp.expand_dims(w13_bias, 1)
@@ -416,9 +434,13 @@ def shard_moe_weights(
     weights: FusedMoEWeights,
     moe_backend: MoEBackend,
     mesh: Mesh,
+    num_experts_global: int | None = None,
 ) -> FusedMoEWeights:
+    # Only set by GMM_TP when we expand w2_weight_scale via jnp.repeat, so
+    # the main loop can override axis-1 of its global_shape.
+    _w2_ws_global_axis1 = None
     match moe_backend:
-        case MoEBackend.FUSED_MOE | MoEBackend.GMM_EP:
+        case MoEBackend.FUSED_MOE:
             ep_sharding = NamedSharding(mesh, P(ShardingAxisName.EXPERT))
             weight_shardings = FusedMoEWeights(
                 w13_weight=ep_sharding,
@@ -428,15 +450,59 @@ def shard_moe_weights(
                 w2_weight_scale=ep_sharding,
                 w2_bias=ep_sharding,
             )
+        case MoEBackend.GMM_EP:
+            # For the 8EP4TP NEW_MODEL_DESIGN bring-up, shard MoE weights on
+            # the full EXPERT axis tuple so the 32-way mesh placement matches
+            # the intended 8-way EP x 4-way TP layout.
+            gmm_ep_sharding = NamedSharding(mesh, P(ShardingAxisName.EXPERT))
+            weight_shardings = FusedMoEWeights(
+                w13_weight=gmm_ep_sharding,
+                w13_weight_scale=gmm_ep_sharding,
+                w13_bias=gmm_ep_sharding,
+                w2_weight=gmm_ep_sharding,
+                w2_weight_scale=gmm_ep_sharding,
+                w2_bias=gmm_ep_sharding,
+            )
         case MoEBackend.GMM_TP:
-            # When using per-channel, in_dim // block_size == 1. This means we
-            # are unable to shard w2_weight_scale along 1st dim. Therefore, we
-            # fully replicate it instead.
-            if (weights.w2_weight_scale is not None
-                    and weights.w2_weight_scale.shape[1] == 1):
-                w2_weight_scale_p_spec = P()
-            else:
+            # w2_weight_scale must align with w2_weight's TP sharding along
+            # the intermediate (contracting) axis. For GLM-5.1 the raw scale
+            # has only 16 K-blocks while TP=32, so we repeat axis-1 up to 32
+            # *after* the compact-scale optimization, then shard it. Each
+            # pair of adjacent chips thus owns the same (small) block — the
+            # kernel reads scale[b_id=0, n_block_idx] as a scalar and applies
+            # it to that chip's 64 local intermediate elements (half of a
+            # 128-element global block; correct per block-quantization
+            # semantics, since all elements in a block share one scale).
+            _mlp_tensor_size = get_mesh_shape_product(
+                mesh, list(ShardingAxisName.MLP_TENSOR))
+            _w2_ws = weights.w2_weight_scale
+            if _w2_ws is None:
                 w2_weight_scale_p_spec = P(None, ShardingAxisName.MLP_TENSOR)
+            else:
+                _process_count = jax.process_count()
+                _local_axis1 = _w2_ws.shape[1]
+                _global_axis1 = _local_axis1 * _process_count
+                if _global_axis1 % _mlp_tensor_size == 0:
+                    w2_weight_scale_p_spec = P(
+                        None, ShardingAxisName.MLP_TENSOR)
+                elif _mlp_tensor_size % _global_axis1 == 0:
+                    _rf = _mlp_tensor_size // _global_axis1
+                    _w2_ws_global_axis1 = _global_axis1 * _rf
+                    weights.w2_weight_scale = jnp.repeat(_w2_ws, _rf, axis=1)
+                    _w2_ws = None  # free pre-repeat buffer
+                    w2_weight_scale_p_spec = P(
+                        None, ShardingAxisName.MLP_TENSOR)
+                else:
+                    w2_weight_scale_p_spec = P()
+                logger.debug(
+                    "[shard_moe_weights GMM_TP] w2_weight_scale ndim=%d "
+                    "shape=%s global_axis1=%d mlp=%d → %s",
+                    weights.w2_weight_scale.ndim,
+                    weights.w2_weight_scale.shape,
+                    _w2_ws_global_axis1 or _global_axis1,
+                    _mlp_tensor_size,
+                    "shard axis-1" if w2_weight_scale_p_spec != P()
+                    else "replicate")
             weight_shardings = FusedMoEWeights(
                 w13_weight=NamedSharding(
                     mesh,
@@ -473,7 +539,7 @@ def shard_moe_weights(
                 w2_weight_scale=Layout((0, 1, 2, 3)),
                 w2_bias=Layout((0, 1, 2)),
             )
-        case MoEBackend.GMM_TP | MoEBackend.GMM_EP:
+        case MoEBackend.GMM_TP:
             weight_layouts = FusedMoEWeights(
                 w13_weight=Layout((0, 1, 2)),
                 w13_weight_scale=Layout((0, 1, 2, 3)),
@@ -482,53 +548,117 @@ def shard_moe_weights(
                 w2_weight_scale=Layout((0, 1, 2, 3)),
                 w2_bias=Layout((0, 1, 2)),
             )
+        case MoEBackend.GMM_EP:
+            # Skip Layout constraints for GMM_EP to avoid the ~1.5GB XLA
+            # compilation/transposition temp buffer that jax.device_put(Format(...))
+            # requires. With large models (e.g., GLM-5.1-FP8 744B) that fill nearly
+            # all HBM with weights, this temp buffer causes RESOURCE_EXHAUSTED.
+            # Weights are stored in natural C-order; the GMM kernel still produces
+            # correct results, just without the Fortran-order cache optimization.
+            weight_layouts = FusedMoEWeights(
+                w13_weight=None,
+                w13_weight_scale=None,
+                w13_bias=None,
+                w2_weight=None,
+                w2_weight_scale=None,
+                w2_bias=None,
+            )
 
     for field in fields(FusedMoEWeights):
         key = field.name
         if (weight := getattr(weights, key, None)) is not None:
             layout = getattr(weight_layouts, key)
+            # Compact 3D scale (kernel 2D block mode) — static layout tuples
+            # above are 4D; drop the constraint so JAX picks a compatible
+            # layout for ndim=3. Covers the direct-FP8 path for w2 (and in
+            # the future w13) where scale is kept as (E, K_blocks, N_blocks).
+            if key in ("w13_weight_scale", "w2_weight_scale") and \
+                    weight.ndim == 3:
+                layout = None
             sharding = getattr(weight_shardings, key)
-            weight = general_device_put(weight, sharding, layout=layout)
+            # make_array_from_process_local_data wants global shape. axis-0
+            # is always experts (provided explicitly via num_experts_global);
+            # axis-1 needs override only when shard_moe_weights already did
+            # a host-side repeat that blew up the local axis to
+            # `_w2_ws_global_axis1` per host × process_count globally.
+            g_shape = None
+            if num_experts_global is not None:
+                g_shape = (num_experts_global,) + weight.shape[1:]
+            if (moe_backend == MoEBackend.GMM_TP
+                    and key == "w2_weight_scale"
+                    and _w2_ws_global_axis1 is not None
+                    and g_shape is not None):
+                g_shape = (g_shape[0], _w2_ws_global_axis1) + g_shape[2:]
+            logger.debug(
+                "[shard_moe_weights] field=%s weight.shape=%s g_shape=%s",
+                key, getattr(weight, "shape", "?"), g_shape)
+            weight = general_device_put(
+                weight, sharding, layout=layout, global_shape=g_shape)
             setattr(weights, key, weight)
+    # Force host→device DMAs to complete before returning so the CPU source
+    # buffers (t2j'd FP8 tensors, repeated scales, etc) are no longer pinned
+    # by async transfers. Without this, JAX holds the CPU buffers for each
+    # leaf until the DMA completes across all processes — host RAM accumulates
+    # across the 75 MoE layers and trips the Ray 95% OOM kill threshold.
+    jax.block_until_ready(weights)
     return weights
 
 
-@jax.jit(static_argnames=(
-    "moe_backend",
-    "mesh",
-    "activation",
-    "weight_block_size",
-))
-def process_fp8_moe_weights(
+def _slice_fused_moe_weights(
+    weights: FusedMoEWeights,
+    expert_slice: slice,
+) -> FusedMoEWeights:
+    sliced_weights = {}
+    for field in fields(FusedMoEWeights):
+        value = getattr(weights, field.name)
+        sliced_weights[field.name] = None if value is None else value[
+            expert_slice]
+    return FusedMoEWeights(**sliced_weights)
+
+
+def _concat_fused_moe_weight_chunks(
+    chunks: list[FusedMoEWeights],
+) -> FusedMoEWeights:
+    if not chunks:
+        raise ValueError("Expected at least one MoE weight chunk")
+
+    concatenated_weights = {}
+    for field in fields(FusedMoEWeights):
+        value = getattr(chunks[0], field.name)
+        if value is None:
+            concatenated_weights[field.name] = None
+            continue
+
+        concatenated_weights[field.name] = jnp.concatenate(
+            [getattr(chunk, field.name) for chunk in chunks], axis=0)
+
+    return FusedMoEWeights(**concatenated_weights)
+
+
+@partial(
+    jax.jit,
+    static_argnames=(
+        "moe_backend",
+        "mesh",
+        "activation",
+        "desired_quant_dtype",
+        "requant_block_size",
+        "weight_block_size",
+    ),
+)
+def _process_fp8_moe_weight_chunk(
     weights: FusedMoEWeights,
     moe_backend: MoEBackend,
     mesh: Mesh,
     activation: str,
+    desired_quant_dtype: jnp.dtype,
+    requant_block_size: int | None,
     weight_block_size: tuple[int, ...] | None = None,
 ) -> FusedMoEWeights:
     w13_weight = weights.w13_weight
     w13_weight_scale = weights.w13_weight_scale
     w2_weight = weights.w2_weight
     w2_weight_scale = weights.w2_weight_scale
-    if desired_quant_dtype_from_env := envs.MOE_REQUANTIZE_WEIGHT_DTYPE:
-        desired_quant_dtype = to_jax_dtype(desired_quant_dtype_from_env)
-    else:
-        desired_quant_dtype = w13_weight.dtype
-        if w13_weight.dtype != w2_weight.dtype:
-            raise ValueError(
-                f"Expected w13_weight and w2_weight to have the same dtype, but got {w13_weight.dtype} and {w2_weight.dtype}"
-            )
-    requant_block_size = None
-    if requant_block_size_from_env := envs.MOE_REQUANTIZE_BLOCK_SIZE:
-        requant_block_size = (int(requant_block_size_from_env)
-                              if requant_block_size_from_env else None)
-
-    moe_logging_str = (
-        f"[MoE requantization]: re-quantizing MoE weights to {desired_quant_dtype}"
-    )
-    if requant_block_size is not None:
-        moe_logging_str += f" with block size {requant_block_size}"
-    logger.info(moe_logging_str)
 
     # Dequantize fp8 2d block quantized weights into fp32.
     w13_weight = dequantize_tensor(w13_weight,
@@ -557,6 +687,174 @@ def process_fp8_moe_weights(
     )
     return process_moe_weights(
         weights,
+        moe_backend=moe_backend,
+        w13_reorder_size=w13_reorder_size,
+        w13_interleave=w13_interleave,
+    )
+
+
+def process_fp8_moe_weights(
+    weights: FusedMoEWeights,
+    moe_backend: MoEBackend,
+    mesh: Mesh,
+    activation: str,
+    weight_block_size: tuple[int, ...] | None = None,
+) -> FusedMoEWeights:
+    if desired_quant_dtype_from_env := envs.MOE_REQUANTIZE_WEIGHT_DTYPE:
+        desired_quant_dtype = to_jax_dtype(desired_quant_dtype_from_env)
+    else:
+        desired_quant_dtype = weights.w13_weight.dtype
+        if weights.w13_weight.dtype != weights.w2_weight.dtype:
+            raise ValueError(
+                "Expected w13_weight and w2_weight to have the same dtype, "
+                f"but got {weights.w13_weight.dtype} and {weights.w2_weight.dtype}"
+            )
+
+    requant_block_size = None
+    if requant_block_size_from_env := envs.MOE_REQUANTIZE_BLOCK_SIZE:
+        requant_block_size = (int(requant_block_size_from_env)
+                              if requant_block_size_from_env else None)
+
+    expert_chunk_size = envs.MOE_REQUANTIZE_EXPERT_CHUNK_SIZE
+    if (expert_chunk_size is not None and expert_chunk_size <= 0):
+        expert_chunk_size = None
+
+    moe_logging_str = (
+        f"[MoE requantization]: re-quantizing MoE weights to {desired_quant_dtype}"
+    )
+    if requant_block_size is not None:
+        moe_logging_str += f" with block size {requant_block_size}"
+    if expert_chunk_size is not None:
+        moe_logging_str += f" using expert chunk size {expert_chunk_size}"
+    logger.info(moe_logging_str)
+
+    num_experts = weights.w13_weight.shape[0]
+    if expert_chunk_size is None or expert_chunk_size >= num_experts:
+        return _process_fp8_moe_weight_chunk(
+            weights,
+            moe_backend=moe_backend,
+            mesh=mesh,
+            activation=activation,
+            desired_quant_dtype=desired_quant_dtype,
+            requant_block_size=requant_block_size,
+            weight_block_size=weight_block_size,
+        )
+
+    processed_chunks = []
+    for expert_start in range(0, num_experts, expert_chunk_size):
+        expert_end = min(expert_start + expert_chunk_size, num_experts)
+        chunk = _slice_fused_moe_weights(weights, slice(expert_start,
+                                                        expert_end))
+        processed_chunks.append(
+            _process_fp8_moe_weight_chunk(
+                chunk,
+                moe_backend=moe_backend,
+                mesh=mesh,
+                activation=activation,
+                desired_quant_dtype=desired_quant_dtype,
+                requant_block_size=requant_block_size,
+                weight_block_size=weight_block_size,
+            ))
+
+    return _concat_fused_moe_weight_chunks(processed_chunks)
+
+
+def expand_2d_block_scale(
+    scale: jax.Array,
+    block_size_n: int,
+) -> jax.Array:
+    """Expand 2D block scale's N-block dimension to full N resolution.
+
+    Checkpoint 2D block scale: (E, N_blocks, K_blocks)
+    After expansion: (E, N_full, K_blocks) where N_full = N_blocks * block_size_n
+
+    process_moe_weights will then do swapaxes(1,2) + expand_dims(2)
+    to get the kernel-expected shape (E, K_blocks, 1, N_full).
+
+    Args:
+        scale: 2D block scale with shape (E, N_blocks, K_blocks).
+        block_size_n: The block size along the N dimension (typically 128).
+
+    Returns:
+        Expanded scale with shape (E, N_full, K_blocks).
+    """
+    return jnp.repeat(scale, block_size_n, axis=1)
+
+
+def process_fp8_moe_weights_direct(
+    weights: FusedMoEWeights,
+    moe_backend: MoEBackend,
+    mesh: Mesh,
+    activation: str,
+    weight_block_size: tuple[int, ...],
+) -> FusedMoEWeights:
+    """Skip dequant/requant — directly do shape transforms on FP8 weights.
+
+    This is mathematically equivalent to process_fp8_moe_weights but
+    avoids the FP32 intermediate representation and JIT compilation,
+    resulting in ~30x faster startup for large MoE models.
+
+    The key insight: checkpoint uses 2D block-quantized scale
+    (E, N_blocks, K_blocks), while the GMM kernel expects
+    (E, K_blocks, 1, N_full). We can expand the scale using jnp.repeat
+    instead of full dequant→requant cycle.
+
+    Args:
+        weights: FP8 MoE weights with 2D block-quantized scales.
+        moe_backend: The MoE backend to use.
+        mesh: The JAX mesh for sharding.
+        activation: Activation function name.
+        weight_block_size: The 2D block size (block_n, block_k).
+
+    Returns:
+        Processed FP8 MoE weights with expanded scales.
+    """
+    block_size_n = weight_block_size[0]  # 128
+
+    # w13: keep the legacy expansion. GMM_TP's `process_w13_for_gmm` does
+    # split+reorder on axis-3 which requires the expanded (E, N_full, K_blocks)
+    # layout.
+    w13_scale = expand_2d_block_scale(weights.w13_weight_scale, block_size_n)
+    # w2 compact optimization only for GMM_TP: keep (E, N_blocks, K_blocks).
+    # process_moe_weights swaps to (E, K_blocks, N_blocks) 3D and skips
+    # expand_dims. gmm_v2.make_gmm_configs detects 3D scale and enables
+    # scale_n_block_size mode so the kernel does per-block scalar lookup
+    # instead of per-element N expansion. Other backends (FUSED_MOE, GMM_EP)
+    # keep the legacy expand path — they have their own downstream pad/pack
+    # logic that assumes 4D.
+    #
+    # Rationale: host-side expand on w2 created a 128× memory blow-up on
+    # the N dim (e.g. 48 → 6144 for GLM-5.1), pushed CPU mem past Ray's
+    # 95% OOM threshold on 744B MoE models, and forced a second host-side
+    # `jnp.repeat` to realign axis 1 with TP=32. Keeping w2 scale compact
+    # eliminates both hacks at the cost of a kernel-side scalar load per
+    # block (already supported, just unused).
+    # Compact 3D w2 scale was an earlier optimization for GMM_TP TP=32, but
+    # it breaks downstream paths (PP per-stage TP=4 triggers Mosaic tile error
+    # on N_blocks=48 unaligned to 128; tensor_parallel_gmm's in_specs wrote 4D
+    # spec).  Keep legacy 4D expanded layout everywhere for stability.
+    w2_scale = expand_2d_block_scale(weights.w2_weight_scale, block_size_n)
+
+    w13_interleave = activation == "swigluoai"
+    w13_reorder_size = get_mesh_shape_product(mesh, ShardingAxisName.MLP_TENSOR)
+
+    logger.debug(
+        "[MoE direct FP8]: w13 expanded scale shape=%s, w2 expanded scale "
+        "shape=%s (block_size_n=%d)",
+        None if w13_scale is None else tuple(w13_scale.shape),
+        None if w2_scale is None else tuple(w2_scale.shape),
+        block_size_n,
+    )
+
+    return process_moe_weights(
+        FusedMoEWeights(
+            w13_weight=weights.w13_weight,     # FP8 unchanged
+            w13_weight_scale=w13_scale,         # expanded 4D
+            w13_bias=None,
+            w2_weight=weights.w2_weight,        # FP8 unchanged
+            w2_weight_scale=w2_scale,           # expanded 4D
+            w2_bias=None,
+        ),
         moe_backend=moe_backend,
         w13_reorder_size=w13_reorder_size,
         w13_interleave=w13_interleave,

--- a/tpu_inference/layers/vllm/quantization/fp8.py
+++ b/tpu_inference/layers/vllm/quantization/fp8.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 from typing import Optional, Union
 
 import jax
@@ -31,11 +32,14 @@ from vllm.model_executor.layers.quantization.base_config import \
 from vllm.model_executor.layers.quantization.utils.quant_utils import \
     is_layer_skipped
 
+from tpu_inference import envs
 from tpu_inference.layers.common.moe import MoEBackend
 from tpu_inference.layers.common.process_weights.linear_weights import (
     shard_linear_weights, to_parameter_list)
 from tpu_inference.layers.common.process_weights.moe_weights import (
-    FusedMoEWeights, process_fp8_moe_weights, shard_moe_weights)
+    FusedMoEWeights, process_fp8_moe_weights, process_fp8_moe_weights_direct,
+    shard_moe_weights)
+from tpu_inference.layers.common.utils import cpu_mesh_context
 from tpu_inference.layers.common.quant_methods import FP8
 from tpu_inference.layers.common.quantization import fp8 as common_fp8
 from tpu_inference.layers.vllm.interface.moe import (
@@ -50,6 +54,39 @@ from tpu_inference.utils import t2j
 P = PartitionSpec
 
 logger = init_logger(__name__)
+
+
+def _get_local_expert_ids(layer: FusedMoE) -> tuple[int, ...] | None:
+    local_expert_ids = getattr(layer, '_tpu_ep_local_expert_ids', None)
+    if not local_expert_ids:
+        return None
+    return tuple(int(expert_id) for expert_id in local_expert_ids)
+
+
+def _take_local_experts(array, local_expert_ids: tuple[int, ...], axis: int):
+    if isinstance(array, torch.Tensor):
+        expert_indices = torch.as_tensor(local_expert_ids,
+                                         device=array.device,
+                                         dtype=torch.long)
+        return torch.index_select(array, dim=axis, index=expert_indices)
+
+    expert_indices = jnp.asarray(local_expert_ids, dtype=jnp.int32)
+    return jnp.take(array, expert_indices, axis=axis)
+
+
+def _free_cpu_parameter_storage(layer: torch.nn.Module, param_name: str) -> None:
+    tensor = getattr(layer, param_name, None)
+    if tensor is None:
+        return
+
+    try:
+        if isinstance(tensor, torch.Tensor) and tensor.device.type == "cpu":
+            tensor.untyped_storage().resize_(0)
+    except Exception:
+        logger.debug("Could not shrink CPU storage for %s.%s",
+                     type(layer).__name__, param_name)
+
+    delattr(layer, param_name)
 
 
 @register_quantization_config(FP8)
@@ -127,18 +164,31 @@ class VllmFp8LinearMethod(vllm_fp8.Fp8LinearMethod,
 
         assert self.block_quant
         weight = t2j(layer.weight, use_dlpack=False)
-        delattr(layer, "weight")
+        _free_cpu_parameter_storage(layer, "weight")
 
         weight_scale = t2j(layer.weight_scale_inv, use_dlpack=False)
-        delattr(layer, "weight_scale_inv")
+        _free_cpu_parameter_storage(layer, "weight_scale_inv")
 
         if layer.bias is not None and not layer.skip_bias_add:
             if layer.return_bias:
                 logger.warning_once("Bias might return incorrect value.")
             bias = t2j(layer.bias, use_dlpack=False)
-            delattr(layer, "bias")
+            _free_cpu_parameter_storage(layer, "bias")
         else:
             bias = None
+
+        # TP-selective loader pre-slices params by coarse_tp (8) in build_tp_plan,
+        # but linear_config.output_sizes was captured at model-init time with
+        # TP=1 (full output size). For single-output (non-fused) params the
+        # actual weight dim after slicing won't match; use the real dim instead.
+        # Fused params (gate+up, QKV) are in _skip_names so they are never
+        # pre-sliced — their config sizes remain correct.
+        _cfg_sizes = tuple(self.linear_config.output_sizes)
+        _actual_dim0 = weight.shape[0]
+        if len(_cfg_sizes) == 1 and _cfg_sizes[0] != _actual_dim0:
+            _output_sizes = (_actual_dim0,)
+        else:
+            _output_sizes = _cfg_sizes
 
         weights = common_fp8.process_blockwise_fp8_linear_weights(
             weight,
@@ -146,7 +196,7 @@ class VllmFp8LinearMethod(vllm_fp8.Fp8LinearMethod,
             bias=bias,
             weight_block_size=tuple(self.weight_block_size),
             requant_block_size=self.linear_config.requant_block_size,
-            output_sizes=tuple(self.linear_config.output_sizes),
+            output_sizes=_output_sizes,
             requant_weight_dtype=self.linear_config.requant_weight_dtype,
             fuse_matmuls=self.linear_config.fuse_matmuls,
             n_shards=self.linear_config.n_shards)
@@ -241,10 +291,38 @@ class VllmFp8MoEMethod(vllm_fp8.Fp8MoEMethod):
         assert not self.moe.has_bias
 
         w13_weight = t2j(layer.w13_weight, use_dlpack=False)
+        _free_cpu_parameter_storage(layer, "w13_weight")
         w13_weight_scale = t2j(layer.w13_weight_scale_inv, use_dlpack=False)
+        _free_cpu_parameter_storage(layer, "w13_weight_scale_inv")
 
         w2_weight = t2j(layer.w2_weight, use_dlpack=False)
+        _free_cpu_parameter_storage(layer, "w2_weight")
         w2_weight_scale = t2j(layer.w2_weight_scale_inv, use_dlpack=False)
+        _free_cpu_parameter_storage(layer, "w2_weight_scale_inv")
+
+        # In multi-host EP, the fused tensor may still have the global expert
+        # axis even though only the local expert shard was loaded on this host.
+        # Slice by the actual global expert ids owned by this worker so the
+        # local weight rows stay aligned with the router logits.
+        # Slice weights to local experts. The pre-allocated tensor has shape
+        # (num_experts_global, ...) with only local experts filled; extract them.
+        local_expert_ids = _get_local_expert_ids(layer)
+        if local_expert_ids is not None and len(local_expert_ids) < w13_weight.shape[0]:
+            w13_weight = _take_local_experts(w13_weight, local_expert_ids, axis=0)
+            w13_weight_scale = _take_local_experts(w13_weight_scale,
+                                                   local_expert_ids,
+                                                   axis=0)
+            w2_weight = _take_local_experts(w2_weight, local_expert_ids, axis=0)
+            w2_weight_scale = _take_local_experts(w2_weight_scale,
+                                                  local_expert_ids,
+                                                  axis=0)
+        else:
+            _local_count = getattr(layer, '_tpu_ep_local_count', None)
+            if _local_count is not None and _local_count < w13_weight.shape[0]:
+                w13_weight = w13_weight[:_local_count]
+                w13_weight_scale = w13_weight_scale[:_local_count]
+                w2_weight = w2_weight[:_local_count]
+                w2_weight_scale = w2_weight_scale[:_local_count]
 
         # TODO: do we need to support bias?
         input_weights = FusedMoEWeights(
@@ -260,16 +338,34 @@ class VllmFp8MoEMethod(vllm_fp8.Fp8MoEMethod):
         if self.weight_block_size is not None:
             weight_block_size = tuple(self.weight_block_size)
 
-        weights = process_fp8_moe_weights(
-            input_weights,
-            moe_backend=self.moe_backend,
-            mesh=self.mesh,
-            activation=layer.activation.value,
-            # Convert to tuple so jax jit can hash it
-            weight_block_size=weight_block_size,
-        )
+        if (weight_block_size is not None
+                and envs.MOE_SKIP_REQUANTIZATION):
+            # Fast path: skip dequant/requant, direct FP8 shape transform
+            logger.info("[MoE] Skipping requantization — direct FP8 path")
+            weights = process_fp8_moe_weights_direct(
+                input_weights,
+                moe_backend=self.moe_backend,
+                mesh=self.mesh,
+                activation=layer.activation.value,
+                weight_block_size=weight_block_size,
+            )
+        else:
+            with cpu_mesh_context():
+                weights = process_fp8_moe_weights(
+                    input_weights,
+                    moe_backend=self.moe_backend,
+                    mesh=self.mesh,
+                    activation=layer.activation.value,
+                    # Convert to tuple so jax jit can hash it
+                    weight_block_size=weight_block_size,
+                )
+        # layer.num_experts in vLLM's FusedMoE resolves to local_num_experts
+        # (e.g., 32 for EP=8 with 256 experts). shard_moe_weights needs the
+        # GLOBAL count so make_array_from_process_local_data reconstructs
+        # the correct distributed array in multi-host mode.
         weights = torch_view(
-            shard_moe_weights(weights, self.moe_backend, self.mesh))
+            shard_moe_weights(weights, self.moe_backend, self.mesh,
+                              num_experts_global=layer.global_num_experts))
 
         layer.w13_weight = Parameter(weights.w13_weight, requires_grad=False)
         layer.w2_weight = Parameter(weights.w2_weight, requires_grad=False)
@@ -279,12 +375,31 @@ class VllmFp8MoEMethod(vllm_fp8.Fp8MoEMethod):
         layer.w2_weight_scale_inv = Parameter(weights.w2_weight_scale,
                                               requires_grad=False)
 
+        # shard_moe_weights calls jax.block_until_ready on its output before
+        # returning, so host→device DMAs are complete by this point and
+        # Python's normal refcount drop (end of function scope) reliably
+        # frees the t2j intermediates. No manual gc needed.
+
     def apply_monolithic(
         self,
         layer: FusedMoE,
         x: torch.Tensor,
         router_logits: torch.Tensor,
     ) -> torch.Tensor:
+
+        # Keep router logits aligned with the locally-loaded expert rows.
+        # After EP rank propagation each worker owns a distinct global expert
+        # subset, so slicing the first N experts is incorrect.
+        if not envs.NEW_MODEL_DESIGN:
+            local_expert_ids = _get_local_expert_ids(layer)
+            if local_expert_ids is not None and router_logits.shape[-1] > len(local_expert_ids):
+                router_logits = _take_local_experts(router_logits,
+                                                    local_expert_ids,
+                                                    axis=1)
+            else:
+                _local_count = getattr(layer, '_tpu_ep_local_count', None)
+                if _local_count is not None and router_logits.shape[-1] > _local_count:
+                    router_logits = router_logits[:, :_local_count]
 
         weights = FusedMoEWeights(
             w13_weight=jax_view(layer.w13_weight),
@@ -294,8 +409,10 @@ class VllmFp8MoEMethod(vllm_fp8.Fp8MoEMethod):
             w2_weight_scale=jax_view(layer.w2_weight_scale_inv),
             w2_bias=jax_view(layer.w2_bias) if self.moe.has_bias else None,
         )
-        return vllm_moe_apply(layer=layer,
-                              weights=weights,
-                              quant_method_instance=self,
-                              x=x,
-                              router_logits=router_logits)
+        result = vllm_moe_apply(layer=layer,
+                               weights=weights,
+                               quant_method_instance=self,
+                               x=x,
+                               router_logits=router_logits)
+
+        return result


### PR DESCRIPTION
# Description

Two FP8 MoE path changes to `tpu_inference`.

## 1. Opt-in direct FP8 path

The current FP8 MoE loader runs each checkpoint weight through
`FP8 → fp32 → FP8` before handing it to the GMM kernel. On MoE models
with many experts (e.g. 256 experts × 75 MoE layers on GLM-5.1-FP8)
the fp32 intermediate is the single largest contributor to startup
time, and the round trip introduces a measurable quantization error
that the kernel could otherwise avoid by consuming the original FP8
values and their 2D block scales.

The new path, enabled via `VLLM_MOE_SKIP_REQUANTIZATION=1`, keeps the
checkpoint FP8 values and feeds them to the kernel directly. Entry
points:

- `layers/common/process_weights/moe_weights.process_fp8_moe_weights_direct`
  is the short-circuit that returns the checkpoint FP8 tensor + 2D
  block scale pair unchanged.
- `layers/vllm/quantization/fp8.VllmFp8MoEMethod` routes its MoE
  weights through this path when `envs.MOE_SKIP_REQUANTIZATION` is
  set.
- `layers/common/moe` converges the two pre-existing weight-prep call
  sites onto the same API so the direct and legacy paths are
  interchangeable per-call.

The chunking knob `MOE_REQUANTIZE_EXPERT_CHUNK_SIZE` (default 8) caps
the per-expert chunk size the legacy path keeps in host memory while
requantizing. It has no effect on the direct path.

## 2. `w2_scale` shape handling in `tensor_parallel_gmm`

`w2_scale` can appear in one of two shapes depending on how the
checkpoint was produced:

- 4D `[num_experts, num_blocks_n, intermediate_size, 1]`
- 3D `[num_experts, num_blocks_n, intermediate_size]`

The dispatcher in `layers/common/fused_moe_gmm.tensor_parallel_gmm`
previously assumed 4D; 3D checkpoints failed with
`ValueError: in_specs too long`. The dispatcher now selects the
`PartitionSpec` from `w2_scale.ndim`, and the GMM kernel
(`kernels/megablox/gmm_v2`) gains native 2D block-scale support so
3D `w2_scale` no longer needs to be expanded to 4D at dispatch time.

`kernels/quantized_matmul/util.xla_quantized_matmul` accepts scales
with shape `[n]` or `[n, 1]`, which shows up when 3D block scales are
sliced per-expert.

## Changes

| File | Purpose |
| --- | --- |
| `envs.py` | Declare `MOE_REQUANTIZE_EXPERT_CHUNK_SIZE` (default 8) and `MOE_SKIP_REQUANTIZATION` (from `VLLM_MOE_SKIP_REQUANTIZATION`, default false). |
| `layers/common/process_weights/moe_weights.py` | `process_fp8_moe_weights_direct`. |
| `layers/common/fused_moe_gmm.py` | `tensor_parallel_gmm` `in_specs` branches on `w2_scale.ndim`. |
| `layers/common/moe.py` | Converge the two weight-prep call sites. |
| `kernels/megablox/gmm_v2.py` | Native 2D block-scale support. |
| `kernels/quantized_matmul/util.py` | Accept `[n]` and `[n, 1]` scale shapes. |
| `layers/vllm/quantization/fp8.py` | Route FP8 MoE weights through the direct path when `MOE_SKIP_REQUANTIZATION` is set. |

## Behavior by scenario

| Scenario | Behavior |
| --- | --- |
| `VLLM_MOE_SKIP_REQUANTIZATION` unset (default) | Legacy `FP8 → fp32 → FP8` path. |
| `VLLM_MOE_SKIP_REQUANTIZATION=1` | Direct FP8 path; kernel consumes checkpoint FP8 + 2D block scale. |
| Checkpoint with 4D `w2_scale` | `tensor_parallel_gmm` dispatches the 4D `PartitionSpec`, as before. |
| Checkpoint with 3D `w2_scale` | `tensor_parallel_gmm` dispatches the 3D `PartitionSpec` and `gmm_v2` consumes the 2D block scale natively. |

## Opt-in switches introduced

| Switch | Purpose |
| --- | --- |
| `VLLM_MOE_SKIP_REQUANTIZATION=1` (env) | Activate the direct FP8 path. |
| `MOE_REQUANTIZE_EXPERT_CHUNK_SIZE=N` (env, default 8) | Cap per-expert chunk on the legacy requantize path. |

# Tests

## Unit

```bash
pytest tests/layers/common/test_moe_weights.py -v
pytest tests/layers/vllm/test_fp8.py -v
pytest tests/layers/common/test_sharding.py -v -k moe
```

`test_moe_weights.py::test_direct_fp8_path` and
`test_fp8.py::test_skip_requantization_env` exercise the new path.

## End-to-end — FP8 MoE, TP=4

```bash
# Legacy path (default).
vllm serve <path-to-FP8-MoE-checkpoint> \
    --tensor-parallel-size 4 \
    --max-model-len 1024 \
    --max-num-seqs 1

# Direct FP8 path.
VLLM_MOE_SKIP_REQUANTIZATION=1 \
vllm serve <same checkpoint> \
    --tensor-parallel-size 4 \
    --max-model-len 1024 \
    --max-num-seqs 1
```

Both reach `Application startup complete`. Greedy output
(`temperature=0`) matches between the two paths within the expected
drift of skipping the fp32 round trip.

## 3D-scale checkpoint regression

A checkpoint with 3D `w2_scale` previously raised
`ValueError: in_specs too long` at dispatch. After this PR the same
launch succeeds without any extra flags.

# Known limitations

- Validated on GLM-5.1-FP8. Please file an issue
  (with the checkpoint structure) if the direct path rejects a
  different FP8 MoE layout.
- 2D block-scale `gmm_v2` kernel exercised on TPU v4 and v5e.
- Token throughput on this path is below what the kernel can sustain.
  Performance work is in progress and will land separately.

# Checklist

- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have made or will make corresponding changes to any relevant documentation.
