### PR TITLE
[CI] Automate validation for add_model_to_ci.py

### DIFF
--- a/.buildkite/pipeline_generation/test_generation.sh
+++ b/.buildkite/pipeline_generation/test_generation.sh
@@ -13,40 +13,80 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -e
+set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 ADD_MODEL_SCRIPT="${SCRIPT_DIR}/add_model_to_ci.py"
 OUTPUT_DIR="${PROJECT_ROOT}/models"
 
+# Define the pattern for generated test files to ensure consistency
+TEST_FILE_PATTERN="test_org_test-model-*.yml"
+
+# Use trap to ensure cleanup happens on exit, regardless of success or failure
+cleanup() {
+    echo "--- :wastebasket: Cleaning up generated test files"
+    rm -f "${OUTPUT_DIR}"/${TEST_FILE_PATTERN}
+    echo "✨ Cleanup complete!"
+}
+trap cleanup EXIT
+
 TYPES=("tpu-optimized" "vllm-native")
 CATEGORIES=("text-only" "multimodal")
 SCALES=("single" "multi")
 
-echo "Starting generation test for add_model_to_ci.py..."
+FAILED_CASES=()
+
+echo "--- :python: Starting generation test for add_model_to_ci.py"
 
 for t in "${TYPES[@]}"; do
     for c in "${CATEGORIES[@]}"; do
         for s in "${SCALES[@]}"; do
+            # Note: add_model_to_ci.py replaces '/' with '_' in filenames
             MODEL_NAME="test_org/test-model-${t}-${c}-${s}"
-            echo "--------------------------------------------------"
             echo "Generating for: Type=$t, Category=$c, HostScale=$s"
-            python3 "$ADD_MODEL_SCRIPT" \
+            
+            # Run python script and capture error without exiting immediately
+            if ! python3 "$ADD_MODEL_SCRIPT" \
                 --model-name "$MODEL_NAME" \
                 --type "$t" \
                 --category "$c" \
-                --host-scale "$s"
+                --host-scale "$s"; then
+                echo "❌ Failed to generate: $MODEL_NAME"
+                FAILED_CASES+=("$MODEL_NAME (Generation Failed)")
+            fi
         done
     done
 done
 
-echo "--------------------------------------------------"
-echo "✅ Successfully generated all 8 combinations!"
-echo "Checking generated files in ${OUTPUT_DIR}:"
-ls -lh "${OUTPUT_DIR}"/test_org_test-model-*
+# If generation failed, report now
+if [ ${#FAILED_CASES[@]} -ne 0 ]; then
+    echo "❌ Some generation cases failed!"
+    for f in "${FAILED_CASES[@]}"; do
+        echo "  - $f"
+    done
+    exit 1
+fi
 
-# echo "--------------------------------------------------"
-# echo "Cleaning up generated test files..."
-# rm "${OUTPUT_DIR}"/test_org_test-model-*.yml
-# echo "✨ Cleanup complete!"
+echo "--- :white_check_mark: Successfully generated all combinations"
+ls -lh "${OUTPUT_DIR}"/${TEST_FILE_PATTERN}
+
+echo "--- :mag: Validating generated YAML files syntax"
+GENERATED_FILES=$(ls .buildkite/models/${TEST_FILE_PATTERN} 2>/dev/null || true)
+
+if [ -z "$GENERATED_FILES" ]; then
+    echo "❌ No files were generated to validate!"
+    exit 1
+fi
+
+# Run validation and capture status
+VALIDATE_STATUS=0
+.buildkite/scripts/validate_all_pipelines.sh "$GENERATED_FILES" || VALIDATE_STATUS=$?
+
+if [ $VALIDATE_STATUS -eq 0 ]; then
+    echo "✅ All generated pipelines are syntactically valid!"
+    exit $VALIDATE_STATUS
+else
+    echo "❌ YAML validation failed for generated pipelines!"
+    exit $VALIDATE_STATUS
+fi

--- a/.buildkite/pipeline_generation/test_generation.sh
+++ b/.buildkite/pipeline_generation/test_generation.sh
@@ -24,8 +24,11 @@ OUTPUT_DIR="${PROJECT_ROOT}/models"
 TEST_FILE_PATTERN="test_org_test-model-*.yml"
 
 # Use trap to ensure cleanup happens on exit, regardless of success or failure
+# shellcheck disable=SC2317
 cleanup() {
     echo "--- :wastebasket: Cleaning up generated test files"
+    # Ensure wildcard expansion by keeping it outside of double quotes
+    # shellcheck disable=SC2086
     rm -f "${OUTPUT_DIR}"/${TEST_FILE_PATTERN}
     echo "✨ Cleanup complete!"
 }
@@ -69,9 +72,14 @@ if [ ${#FAILED_CASES[@]} -ne 0 ]; then
 fi
 
 echo "--- :white_check_mark: Successfully generated all combinations"
+# shellcheck disable=SC2086
 ls -lh "${OUTPUT_DIR}"/${TEST_FILE_PATTERN}
 
 echo "--- :mag: Validating generated YAML files syntax"
+
+# Use OUTPUT_DIR and strip the repo root prefix to get relative paths starting with .buildkite/
+# (required by validate_all_pipelines.sh grep rules)
+# shellcheck disable=SC2012,SC2086
 GENERATED_FILES=$(ls .buildkite/models/${TEST_FILE_PATTERN} 2>/dev/null || true)
 
 if [ -z "$GENERATED_FILES" ]; then

--- a/.buildkite/scripts/bootstrap.sh
+++ b/.buildkite/scripts/bootstrap.sh
@@ -68,6 +68,11 @@ if [ "$BUILDKITE_PULL_REQUEST" != "false" ]; then
       echo "Some pipelines syntax are invalid. Failing build."
       exit 1
     fi
+
+    # Run generation test if add_model_to_ci.py or its templates were modified
+    if echo "$FILES_CHANGED" | grep -qE "add_model_to_ci.py|tpu_optimized_model_template.yml|vllm_native_model_template.yml"; then
+      .buildkite/pipeline_generation/test_generation.sh
+    fi
 else
     echo "Non-PR build. Bypassing file change check."
     FILES_CHANGED=$(git diff-tree --no-commit-id --name-only -r -m "$BUILDKITE_COMMIT")

--- a/.buildkite/scripts/validate_all_pipelines.sh
+++ b/.buildkite/scripts/validate_all_pipelines.sh
@@ -52,6 +52,8 @@ done < <(echo "$YAML_FILES_TO_CHECK")
 
 echo "--- 🔍 Validating changed YAML files"
 if [ ${#VALIDATE_ARGS[@]} -gt 0 ]; then
+    # TODO: Currently using standard 'bk pipeline validate' for syntax checking.
+    # In the future, this could be extended to include more complex validation logic.
     if ! bk pipeline validate "${VALIDATE_ARGS[@]}"; then
         echo "+++ ❌ Validation Failed"
         echo "Result: FAIL (Please fix the YAML syntax errors above)"


### PR DESCRIPTION
# Description

[CI] Automate validation for add_model_to_ci.py

 - Trigger validation when the `add_model_to_ci.py` and YAML template are modified.
 - Enhance `test_generation.sh` to include YAML validation and Buildkite-friendly logging.
 - Add execution permissions for CI scripts (`test_generation.sh` and `validate_all_pipelines.sh`).

# Tests

[Buildkite](https://buildkite.com/tpu-commons/tpu-inference-ci/builds/15109#019daa26-d121-4099-ab1a-1c5482630c8a) (Simulating a broken `add_model_to_ci.py`)
[Buildkite](https://buildkite.com/tpu-commons/tpu-inference-ci/builds/15111#019daa29-a0e4-4752-a1a9-ac95faa7deff) (Simulating an extra `{` in the YAML template)
[Buildkite](https://buildkite.com/tpu-commons/tpu-inference-ci/builds/15112#019daa2b-de5b-4a5b-a0ec-d500b47c829f) (Simulating incorrect indentation in the YAML template)
[Buildkite](https://buildkite.com/tpu-commons/tpu-inference-ci/builds/15123#019daa45-11b9-47f4-8ea6-99628739f907) (Simulating correct changed in the YAML template)

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
