### PR TITLE
bug fix: correct sharding annotation for MOE with EP and correct size calculation of ragged scatter

### DIFF
--- a/tpu_inference/kernels/sparse_core/ragged_scatter.py
+++ b/tpu_inference/kernels/sparse_core/ragged_scatter.py
@@ -390,10 +390,11 @@ def ragged_scatter(x: jax.Array, indices: jax.Array, start: jax.Array,
     dtype = x.dtype
     dtype_bits = jax.dtypes.itemsize_bits(dtype)
     packing = 32 // dtype_bits
+    dtype_bytes = dtype_bits // 8
 
     # Heuristic threshold on whether to fallback to xla gather.
-    if jnp.size(
-            x) * packing * 2 < pltpu.get_tpu_info().vmem_capacity_bytes * 0.6:
+    if jnp.size(x) * dtype_bytes * 2 < pltpu.get_tpu_info(
+    ).vmem_capacity_bytes * 0.6:
         # For small {input + output}, it's likely that both can be put in TC VMEM,
         # so it's likely faster to run TC-based gather on it than going through SC,
         # without data movement to/from HBM.

--- a/tpu_inference/layers/common/fused_moe_gmm.py
+++ b/tpu_inference/layers/common/fused_moe_gmm.py
@@ -325,7 +325,6 @@ def expert_parallel_gmm(
     num_experts_per_shard = num_experts // ep_size
     group_offset = jnp.arange(0, num_experts, num_experts_per_shard)
 
-    x_p_spec = P(ShardingAxisName.EXPERT_DATA)
     w1_scale_spec = None if w1_scale is None else ep_p_spec
     w1_bias_spec = None if w1_bias is None else ep_p_spec
     w2_scale_spec = None if w2_scale is None else ep_p_spec
@@ -342,7 +341,7 @@ def expert_parallel_gmm(
         ),
         mesh=mesh,
         in_specs=(
-            x_p_spec,
+            data_p_spec,
             ep_p_spec,
             w1_scale_spec,
             w1_bias_spec,
@@ -516,8 +515,6 @@ def fused_moe_func(
 
         return x, group_sizes_local, topk_argsort_revert_indices
 
-    x_out_spec = (P(ShardingAxisName.EXPERT_DATA)
-                  if use_ep else P(ShardingAxisName.MLP_DATA))
     if all_gather_fp8:
         hidden_states = _apply_all_gather_fp8(hidden_states, mesh, dtype)
 
@@ -529,7 +526,7 @@ def fused_moe_func(
             P(ShardingAxisName.MLP_DATA, None),
         ),
         out_specs=(
-            x_out_spec,
+            P(ShardingAxisName.MLP_DATA),
             P(ShardingAxisName.MLP_DATA),
             P(ShardingAxisName.MLP_DATA),
         ),


### PR DESCRIPTION
# Description
2 bug fix:

1. correct size calculation of ragged scatter, use `dtype_bytes` instead of `packing`.
2. correct sharding annotation in tpu_inference/layers/common/fused_moe_gmm.py when EP is used. When EP is used, the activation (e.g. x) is replicated.

# Tests
verified with DS MMLU test
https://paste.googleplex.com/6230234585235456
