### PR TITLE
Suppress XLA CPU AOT loader warnings in Docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -38,6 +38,9 @@ RUN apt-get update && apt-get install -y \
     unzip \
     && rm -rf /var/lib/apt/lists/*
 
+# Suppress noisy XLA CPU AOT loader warnings
+ENV TF_CPP_MIN_LOG_LEVEL=3
+
 # Build vLLM
 WORKDIR /workspace/vllm
 ARG VLLM_REPO=https://github.com/vllm-project/vllm.git


### PR DESCRIPTION
## Summary
- Set `TF_CPP_MIN_LOG_LEVEL=3` in the Dockerfile to suppress verbose `cpu_aot_loader.cc` warnings about compile vs host machine feature mismatches
- These warnings bloat CI logs significantly (e.g. gemma4-26B accuracy test log was ~35MB) but are harmless — the kernels still run correctly

## Test plan
- Before: [build #15073 gemma4-26B accuracy](https://buildkite.com/tpu-commons/tpu-inference-ci/builds/15073#019da902-78b5-4410-b498-6cadbf381188) — log full of XLA CPU AOT warnings
- After: [dev build #48 gemma4-26B accuracy](https://buildkite.com/tpu-commons/tpu-inference-dev/builds/48#019dabca-c08f-4540-a591-b586c84335e4) — warnings suppressed