### PR TITLE
[Disagg/qwen3.5] disagg support for qwen3.5 (2/n send load metadata)

### DIFF
--- a/tpu_inference/distributed/tpu_connector.py
+++ b/tpu_inference/distributed/tpu_connector.py
@@ -106,15 +106,19 @@ logger = init_logger(__name__)
 @dataclass
 class SendMeta:
     uuid: int
-    local_block_ids: list[int]
+    # `list[int]`       used for non-HMA connector
+    # `list[list[int]]` used for HMA connector (per-kv-cache-group)
+    local_block_ids: list[int] | list[list[int]]
     expiration_time: float
 
 
 @dataclass
 class LoadMeta:
     uuid: int
-    local_block_ids: list[int]
-    remote_block_ids: list[int]
+    # `list[int]`       used for non-HMA connector.
+    # `list[list[int]]` used for HMA connector (per-kv-cache-group).
+    local_block_ids: list[int] | list[list[int]] | None
+    remote_block_ids: list[int] | list[list[int]] | None
     remote_host: str | list[str]
     remote_port: int | list[int]
 


### PR DESCRIPTION
Extend current SendMeta and LoadMeta to allow list of list for block ids.

Why:
Qwen3.5 is a hybrid attention + Mamba model, where the kv cache manager partitions layers into multiple kv cache groups. So block ids will be a list per kv cache group, e.g.
local_block_ids = [
[1], # Mamba
[2], # Mamba
[3], # Mamba
[4, 5, 6], # Attn
]
