### PR TITLE
Fix Ray executor to support Async scheduling in Disagg

### DIFF
--- a/.buildkite/pipeline_jax.yml
+++ b/.buildkite/pipeline_jax.yml
@@ -444,7 +444,7 @@ steps:
           NUM_PROMPTS: 100
           RANDOM_SEED: 10
           MAX_CONCURRENCY: 10
-          TEST_MODE: 3
+          TEST_MODE: 1
         agents:
           queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
         commands:

--- a/.buildkite/pipeline_jax.yml
+++ b/.buildkite/pipeline_jax.yml
@@ -441,10 +441,10 @@ steps:
           MODEL: "Qwen/Qwen3-0.6B"
           INPUT_LEN: 1024
           OUTPUT_LEN: 1024
-          NUM_PROMPTS: 5
+          NUM_PROMPTS: 100
           RANDOM_SEED: 10
           MAX_CONCURRENCY: 10
-          TEST_MODE: 1
+          TEST_MODE: 3
         agents:
           queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
         commands:

--- a/examples/disagg/run_disagg_multi_host.sh
+++ b/examples/disagg/run_disagg_multi_host.sh
@@ -46,6 +46,13 @@ print_logs_on_exit() {
     else
       echo "File not found."
     fi
+
+    echo "--- Contents of $LOG_DIR/correctness.txt ---"
+    if [ -f "$LOG_DIR/correctness.txt" ]; then
+      cat "$LOG_DIR/correctness.txt"
+    else
+      echo "File not found."
+    fi
   else
     echo "Log directory '$LOG_DIR' not found."
   fi
@@ -140,6 +147,9 @@ fi
 LOG_DIR=$HOME/logs
 if [ ! -d $LOG_DIR ]; then
   mkdir -p $LOG_DIR
+else
+  # Delete old log files to avoid printing stale logs at the end
+  rm -f $LOG_DIR/prefill.txt $LOG_DIR/decode.txt $LOG_DIR/benchmark.txt $LOG_DIR/proxy.txt $LOG_DIR/correctness.txt
 fi
 
 # Define local mounts for non-Buildkite environments
@@ -233,10 +243,10 @@ docker exec -d ${CONTAINER_PREFIX}-0 /bin/bash -c \
     "vllm serve $MODEL \
     --port ${PREFILL_VLLM_PORT} \
     --gpu-memory-utilization 0.8 \
+    --no-enable-prefix-caching \
     --max-num-batched-tokens 1024 \
     --tensor-parallel-size 4 \
     --kv-transfer-config '{\"kv_connector\":\"TPUConnector\",\"kv_connector_module_path\":\"tpu_inference.distributed.tpu_connector\",\"kv_role\":\"kv_producer\"}' \
-    --no-async-scheduling \
     > /root/logs/prefill.txt 2>&1"
 set +x
 
@@ -306,10 +316,10 @@ docker exec -d ${CONTAINER_PREFIX}-2-0 /bin/bash -c \
     "vllm serve $MODEL \
     --port ${DECODE_VLLM_PORT} \
     --gpu-memory-utilization 0.8 \
+    --no-enable-prefix-caching \
     --max-num-batched-tokens 1024 \
     --tensor-parallel-size 4 \
     --kv-transfer-config '{\"kv_connector\":\"TPUConnector\",\"kv_connector_module_path\":\"tpu_inference.distributed.tpu_connector\",\"kv_role\":\"kv_consumer\"}' \
-    --no-async-scheduling \
     > /root/logs/decode.txt 2>&1"
 set +x
 
@@ -347,7 +357,7 @@ set +x
 if [ "$TEST_MODE" = "1" ] || [ "$TEST_MODE" = "3" ]; then
     echo "Running benchmark test in container."
     set -x
-    docker exec ${CONTAINER_PREFIX}-proxy-benchmark /bin/bash -c "python3 /workspace/tpu_inference/scripts/vllm/benchmarking/benchmark_serving.py \
+    docker exec ${CONTAINER_PREFIX}-proxy-benchmark /bin/bash -c "vllm bench serve \
         --backend vllm \
         --host localhost \
         --port 8000 \

--- a/examples/disagg/run_disagg_multi_host.sh
+++ b/examples/disagg/run_disagg_multi_host.sh
@@ -40,16 +40,16 @@ print_logs_on_exit() {
       echo "File not found."
     fi
 
-    echo "--- Contents of $LOG_DIR/benchmark.txt ---"
-    if [ -f "$LOG_DIR/benchmark.txt" ]; then
-      cat "$LOG_DIR/benchmark.txt"
+    echo "--- Contents of $LOG_DIR/correctness.txt ---"
+    if [ -f "$LOG_DIR/correctness.txt" ]; then
+      cat "$LOG_DIR/correctness.txt"
     else
       echo "File not found."
     fi
 
-    echo "--- Contents of $LOG_DIR/correctness.txt ---"
-    if [ -f "$LOG_DIR/correctness.txt" ]; then
-      cat "$LOG_DIR/correctness.txt"
+    echo "--- Contents of $LOG_DIR/benchmark.txt ---"
+    if [ -f "$LOG_DIR/benchmark.txt" ]; then
+      cat "$LOG_DIR/benchmark.txt"
     else
       echo "File not found."
     fi

--- a/tests/executors/test_ray_distributed_executor.py
+++ b/tests/executors/test_ray_distributed_executor.py
@@ -512,6 +512,7 @@ class TestRayDistributedExecutorExecuteDag(unittest.TestCase):
         self.executor.forward_dag = None
         self.executor.has_connector = False
         self.executor.workers = [MagicMock(), MagicMock()]
+        self.executor.kv_output_aggregator = None
 
     def tearDown(self):
         # Reset forward_dag to None so that __del__ -> shutdown() does not

--- a/tpu_inference/executors/ray_distributed_executor.py
+++ b/tpu_inference/executors/ray_distributed_executor.py
@@ -49,10 +49,11 @@ logger = init_logger(__name__)
 
 class AsyncResultFuture(Future):
 
-    def __init__(self, result_ids_ref, workers):
+    def __init__(self, result_ids_ref, workers, aggregator=None):
         super().__init__()
         self.result_ids_ref = result_ids_ref
         self.workers = workers
+        self.aggregator = aggregator
 
     def result(self, timeout=None):
         result_ids = ray.get(self.result_ids_ref, timeout=timeout)
@@ -61,7 +62,10 @@ class AsyncResultFuture(Future):
             ret_refs.append(
                 worker.execute_method.remote("get_execute_model_output",
                                              result_id))
-        return ray.get(ret_refs[0], timeout=timeout)
+        outputs = ray.get(ret_refs, timeout=timeout)
+        if self.aggregator is not None:
+            return self.aggregator.aggregate(outputs, output_rank=0)
+        return outputs[0]
 
 
 class RayDistributedExecutor(RayDistributedExecutorV1):
@@ -481,7 +485,7 @@ class RayDistributedExecutor(RayDistributedExecutorV1):
 
         refs = self.forward_dag.execute(
             (scheduler_output, grammar_output))  # type: ignore
-        return AsyncResultFuture(refs, self.workers)
+        return AsyncResultFuture(refs, self.workers, self.kv_output_aggregator)
 
 
 class RayWorkerWrapper(RayWorkerWrapperV1):

--- a/tpu_inference/executors/ray_distributed_executor.py
+++ b/tpu_inference/executors/ray_distributed_executor.py
@@ -62,10 +62,12 @@ class AsyncResultFuture(Future):
             ret_refs.append(
                 worker.execute_method.remote("get_execute_model_output",
                                              result_id))
-        outputs = ray.get(ret_refs, timeout=timeout)
         if self.aggregator is not None:
+            outputs = ray.get(ret_refs, timeout=timeout)
             return self.aggregator.aggregate(outputs, output_rank=0)
-        return outputs[0]
+        else:
+            return ray.get(ret_refs[0], timeout=timeout)
+        
 
 
 class RayDistributedExecutor(RayDistributedExecutorV1):

--- a/tpu_inference/executors/ray_distributed_executor.py
+++ b/tpu_inference/executors/ray_distributed_executor.py
@@ -67,7 +67,6 @@ class AsyncResultFuture(Future):
             return self.aggregator.aggregate(outputs, output_rank=0)
         else:
             return ray.get(ret_refs[0], timeout=timeout)
-        
 
 
 class RayDistributedExecutor(RayDistributedExecutorV1):


### PR DESCRIPTION
# Description


Fix Ray executor to support Async scheduling in multihost Disagg inference. The fix avoid race condition and use aggregator to avoid one worker finished KV pulling and notify scheduler to start model execution, while another worker have not finished the pulling.  Test results:

-------
Successful requests:                     300       
Failed requests:                         0         
Request rate configured (RPS):           4.00      
Benchmark duration (s):                  75.17     
Total input tokens:                      38400     
Total generated tokens:                  6000      
Request throughput (req/s):              3.99      
Output token throughput (tok/s):         79.82     
Peak output token throughput (tok/s):    219.00    
Peak concurrent requests:                12.00     
Total token throughput (tok/s):          590.68    
---------------Time to First Token----------------
Mean TTFT (ms):                          62.44     
Median TTFT (ms):                        45.72     
P99 TTFT (ms):                           383.87    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          7.17      
Median TPOT (ms):                        6.64      
P99 TPOT (ms):                           26.89     
---------------Inter-token Latency----------------
Mean ITL (ms):                           7.17      
Median ITL (ms):                         6.51      
P99 ITL (ms):                            9.81     

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
