### PR TITLE
Append MoE expert IDs when enable_return_routed_experts is enabled

### DIFF
--- a/examples/rl_inference.py
+++ b/examples/rl_inference.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-import json
 import os
 
 from vllm import LLM, EngineArgs
@@ -27,15 +26,6 @@ def create_parser():
     sampling_group.add_argument("--top-p", type=float)
     sampling_group.add_argument("--top-k", type=int)
 
-    # chat params
-    chat_group = parser.add_argument_group("Chat parameters")
-    chat_group.add_argument("--use-chat-template", action="store_true")
-    # NOTE: a few models (like Qwen3.5) can use this to disable thinking,
-    # e.g. --chat-template-kwargs='{"enable_thinking": false}'
-    chat_group.add_argument('--chat-template-kwargs',
-                            type=json.loads,
-                            default={})
-
     return parser
 
 
@@ -45,11 +35,6 @@ def main(args: dict):
     temperature = args.pop("temperature")
     top_p = args.pop("top_p")
     top_k = args.pop("top_k")
-    use_chat_template = args.pop("use_chat_template")
-    chat_template_kwargs = args.pop('chat_template_kwargs')
-    # Safeguard in case the user doesn't provide use_chat_template
-    if chat_template_kwargs != {}:
-        use_chat_template = True
 
     # Create an LLM
     if "additional_config" not in args or args["additional_config"] is None:
@@ -112,20 +97,7 @@ def main(args: dict):
     if profiler_config.profiler == "torch":
         llm.start_profile()
 
-    if use_chat_template:
-        logger.info(
-            f"Using LLM chat API for inference with extra chat kwargs: {chat_template_kwargs}"
-        )
-        conversations = [[{
-            "role": "user",
-            "content": prompt
-        }] for prompt in prompts]
-        outputs = llm.chat(messages=conversations,
-                           sampling_params=sampling_params,
-                           chat_template_kwargs=chat_template_kwargs)
-    else:
-        logger.info("Using LLM generate API for inference")
-        outputs = llm.generate(prompts, sampling_params)
+    outputs = llm.generate(prompts, sampling_params)
 
     if profiler_config.profiler == "torch":
         llm.stop_profile()

--- a/examples/rl_inference.py
+++ b/examples/rl_inference.py
@@ -39,9 +39,7 @@ def main(args: dict):
     log_probs = args.pop("log_probs")
 
     # Create an LLM
-    if "additional_config" not in args or args["additional_config"] is None:
-        args["additional_config"] = {}
-    args["additional_config"]["enable_return_routed_experts"] = True
+    args["enable_return_routed_experts"] = True
     llm = LLM(**args)
 
     # Create a sampling params object

--- a/examples/rl_inference.py
+++ b/examples/rl_inference.py
@@ -52,11 +52,7 @@ def main(args: dict):
         use_chat_template = True
 
     # Create an LLM
-    llm = LLM(**args)
-
-    # Enable expert IDs returning for testing
-    llm.llm_engine.vllm_config.additional_config[
-        "enable_return_routed_experts"] = True
+    llm = LLM(**args, enable_return_routed_experts=True)
 
     # Create a sampling params object
     sampling_params = llm.get_default_sampling_params()

--- a/examples/rl_inference.py
+++ b/examples/rl_inference.py
@@ -25,6 +25,7 @@ def create_parser():
     sampling_group.add_argument("--temperature", type=float)
     sampling_group.add_argument("--top-p", type=float)
     sampling_group.add_argument("--top-k", type=int)
+    sampling_group.add_argument("--log-probs", type=int)
 
     return parser
 
@@ -35,6 +36,7 @@ def main(args: dict):
     temperature = args.pop("temperature")
     top_p = args.pop("top_p")
     top_k = args.pop("top_k")
+    log_probs = args.pop("log_probs")
 
     # Create an LLM
     if "additional_config" not in args or args["additional_config"] is None:
@@ -52,6 +54,8 @@ def main(args: dict):
         sampling_params.top_p = top_p
     if top_k is not None:
         sampling_params.top_k = top_k
+    if log_probs is not None:
+        sampling_params.logprobs = log_probs
 
     # Generate texts from the prompts. The output is a list of RequestOutput
     # objects that contain the prompt, generated text, and other information.
@@ -108,9 +112,7 @@ def main(args: dict):
         prompt = output.prompt
         generated_text = output.outputs[0].text
         print(f"Prompt: {prompt!r}\nGenerated text: {generated_text!r}")
-        print("-" * 50)
 
-    for output in outputs:
         for completion in output.outputs:
             if completion.routed_experts is not None:
                 # Shape will be [len(completion.token_ids), num_layers, top_k]
@@ -119,6 +121,11 @@ def main(args: dict):
                 print(
                     f"First token expert selection: {completion.routed_experts[0]}"
                 )
+
+            if completion.logprobs is not None:
+                print(f"Logprobs for first token: {completion.logprobs[0]}")
+
+        print("-" * 50)
 
 
 if __name__ == "__main__":

--- a/examples/rl_inference.py
+++ b/examples/rl_inference.py
@@ -52,7 +52,10 @@ def main(args: dict):
         use_chat_template = True
 
     # Create an LLM
-    llm = LLM(**args, enable_return_routed_experts=True)
+    if "additional_config" not in args or args["additional_config"] is None:
+        args["additional_config"] = {}
+    args["additional_config"]["enable_return_routed_experts"] = True
+    llm = LLM(**args)
 
     # Create a sampling params object
     sampling_params = llm.get_default_sampling_params()

--- a/examples/rl_inference.py
+++ b/examples/rl_inference.py
@@ -1,0 +1,170 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import json
+import os
+
+from vllm import LLM, EngineArgs
+from vllm.utils.argparse_utils import FlexibleArgumentParser
+
+from tpu_inference.core import disagg_utils
+from tpu_inference.logger import init_logger
+
+logger = init_logger(__name__)
+
+
+def create_parser():
+    parser = FlexibleArgumentParser()
+    # Add engine args
+    EngineArgs.add_cli_args(parser)
+    parser.set_defaults(model="meta-llama/Llama-3.2-1B-Instruct")
+    parser.set_defaults(max_model_len=1024)
+
+    # Add sampling params
+    sampling_group = parser.add_argument_group("Sampling parameters")
+    sampling_group.add_argument("--max-tokens", type=int)
+    sampling_group.add_argument("--temperature", type=float)
+    sampling_group.add_argument("--top-p", type=float)
+    sampling_group.add_argument("--top-k", type=int)
+
+    # chat params
+    chat_group = parser.add_argument_group("Chat parameters")
+    chat_group.add_argument("--use-chat-template", action="store_true")
+    # NOTE: a few models (like Qwen3.5) can use this to disable thinking,
+    # e.g. --chat-template-kwargs='{"enable_thinking": false}'
+    chat_group.add_argument('--chat-template-kwargs',
+                            type=json.loads,
+                            default={})
+
+    return parser
+
+
+def main(args: dict):
+    # Pop arguments not used by LLM
+    max_tokens = args.pop("max_tokens")
+    temperature = args.pop("temperature")
+    top_p = args.pop("top_p")
+    top_k = args.pop("top_k")
+    use_chat_template = args.pop("use_chat_template")
+    chat_template_kwargs = args.pop('chat_template_kwargs')
+    # Safeguard in case the user doesn't provide use_chat_template
+    if chat_template_kwargs != {}:
+        use_chat_template = True
+
+    # Create an LLM
+    llm = LLM(**args)
+
+    # Enable expert IDs returning for testing
+    llm.llm_engine.vllm_config.additional_config[
+        "enable_return_routed_experts"] = True
+
+    # Create a sampling params object
+    sampling_params = llm.get_default_sampling_params()
+    if max_tokens is not None:
+        sampling_params.max_tokens = max_tokens
+    if temperature is not None:
+        sampling_params.temperature = temperature
+    if top_p is not None:
+        sampling_params.top_p = top_p
+    if top_k is not None:
+        sampling_params.top_k = top_k
+
+    # Generate texts from the prompts. The output is a list of RequestOutput
+    # objects that contain the prompt, generated text, and other information.
+    prompts = [
+        "Hello, my name is",
+        "The capital of France is",
+        "The colors of the rainbow are",
+        "The future of AI is",
+        "The president of the United States is",
+        "How many players are on a standard soccer team on the field at one time?",
+        "In Greek mythology, who is the god of the sea?",
+        "In what year did the Titanic sink?",
+        "In which museum is the Mona Lisa displayed?",
+        "Mount Everest is located in which mountain range?",
+        "What ancient empire was ruled by Julius Caesar?",
+        "What are the four fundamental forces of nature?",
+        'What does "CPU" stand for?',
+        'What does "HTML" stand for?',
+        "What is the capital of Australia?",
+        "What is the chemical symbol for gold?",
+        "What is the currency of Switzerland?",
+        "What is the distance from the Earth to the Sun called?",
+        "What is the freezing point of water in Celsius?",
+        "What is the hardest known natural substance on Earth?",
+        "What is the largest planet in our solar system?",
+        "What is the longest river in the world?",
+        "What is the main function of the kidneys in the human body?",
+        "What is the main ingredient in guacamole?",
+        "What is the most spoken language in the world by number of native speakers?",
+        "What is the process by which plants use sunlight to create food?",
+        "Which country is known as the Land of the Rising Sun?",
+        "Who developed the theory of general relativity?",
+        'Who directed the original "Star Wars" trilogy?',
+        "Who is credited with inventing the telephone?",
+        "Who painted the ceiling of the Sistine Chapel?",
+        "Who was the first female Prime Minister of the United Kingdom?",
+        "Who was the first person to walk on the moon?",
+        "Who wrote the American Declaration of Independence?",
+        'Who wrote the novel "Pride and Prejudice"?',
+    ]
+
+    profiler_config = llm.llm_engine.vllm_config.profiler_config
+    if profiler_config.profiler == "torch":
+        llm.start_profile()
+
+    if use_chat_template:
+        logger.info(
+            f"Using LLM chat API for inference with extra chat kwargs: {chat_template_kwargs}"
+        )
+        conversations = [[{
+            "role": "user",
+            "content": prompt
+        }] for prompt in prompts]
+        outputs = llm.chat(messages=conversations,
+                           sampling_params=sampling_params,
+                           chat_template_kwargs=chat_template_kwargs)
+    else:
+        logger.info("Using LLM generate API for inference")
+        outputs = llm.generate(prompts, sampling_params)
+
+    if profiler_config.profiler == "torch":
+        llm.stop_profile()
+
+    # Print the outputs.
+    print("-" * 50)
+    for output in outputs:
+        prompt = output.prompt
+        generated_text = output.outputs[0].text
+        print(f"Prompt: {prompt!r}\nGenerated text: {generated_text!r}")
+        print("-" * 50)
+
+    for output in outputs:
+        for completion in output.outputs:
+            if completion.routed_experts is not None:
+                # Shape will be [len(completion.token_ids), num_layers, top_k]
+                print(
+                    f"Routed experts shape: {completion.routed_experts.shape}")
+                print(
+                    f"First token expert selection: {completion.routed_experts[0]}"
+                )
+
+
+if __name__ == "__main__":
+    # Skip long warmup for local simple test.
+    os.environ.setdefault('SKIP_JAX_PRECOMPILE', '1')
+
+    parser = create_parser()
+    args: dict = vars(parser.parse_args())
+
+    if not disagg_utils.is_disagg_enabled():
+        main(args)
+    else:
+        from unittest.mock import patch
+
+        from tpu_inference.core.core_tpu import (DisaggEngineCore,
+                                                 DisaggEngineCoreProc)
+
+        with patch("vllm.v1.engine.core.EngineCore", DisaggEngineCore), patch(
+                "vllm.v1.engine.core.EngineCoreProc", DisaggEngineCoreProc):
+            main(args)

--- a/tests/e2e/test_rl_integration.py
+++ b/tests/e2e/test_rl_integration.py
@@ -290,9 +290,7 @@ class TestMoEExpertIds:
         """routed_experts must be properly shaped if it is an MoE, or None if not."""
         prompt = "The capital of France is"
         # Test standard execution with the flag enabled.
-        # To bypass vllm native validation we can inject it into additional_config safely
-        llm.llm_engine.vllm_config.additional_config[
-            "enable_return_routed_experts"] = True
+        llm.llm_engine.vllm_config.model_config.enable_return_routed_experts = True
 
         sampling_params = SamplingParams(temperature=0, max_tokens=10)
         outputs = llm.generate([prompt], sampling_params)

--- a/tests/e2e/test_rl_integration.py
+++ b/tests/e2e/test_rl_integration.py
@@ -282,6 +282,33 @@ class TestLogprobsNoRecompilation:
                     f"Log probability must be <= 0, got {logprob_obj.logprob}")
 
 
+class TestMoEExpertIds:
+    """Verify that MoE routed experts are successfully returned when enabled.
+    """
+
+    def test_moe_expert_ids_returned(self, llm: LLM):
+        """routed_experts must be properly shaped if it is an MoE, or None if not."""
+        prompt = "The capital of France is"
+        # Test standard execution with the flag enabled.
+        # To bypass vllm native validation we can inject it into additional_config safely
+        llm.llm_engine.vllm_config.additional_config[
+            "enable_return_routed_experts"] = True
+
+        sampling_params = SamplingParams(temperature=0, max_tokens=10)
+        outputs = llm.generate([prompt], sampling_params)
+        output = outputs[0].outputs[0]
+
+        is_moe = llm.llm_engine.model_config.is_moe
+        if is_moe:
+            assert output.routed_experts is not None, (
+                "MoE models must populate routed_experts when enabled")
+            assert len(output.routed_experts.shape) == 3, (
+                f"Expected 3D expert shape, got {output.routed_experts.shape}")
+        else:
+            assert output.routed_experts is None, (
+                "Non-MoE models must not populate routed_experts")
+
+
 # ========================================================================
 # Performance tests
 # ========================================================================

--- a/tests/layers/jax/moe/test_moe.py
+++ b/tests/layers/jax/moe/test_moe.py
@@ -174,7 +174,7 @@ class TestMoE(unittest.TestCase):
                                    apply_expert_weight_before_computation)
 
         with jax.set_mesh(self.mesh):
-            actual_output = moe(self.x)
+            actual_output, _ = moe(self.x)
 
             expected_output = self._compute_ground_truth(moe, self.x)
 
@@ -197,7 +197,7 @@ class TestMoE(unittest.TestCase):
 
         # Run Forward Pass (Distributed)
         with jax.set_mesh(self.mesh):
-            actual_output = moe(self.x)
+            actual_output, _ = moe(self.x)
 
         # Compute Ground Truth using the exact same weights
         expected_output = self._compute_ground_truth(moe, self.x)
@@ -220,13 +220,13 @@ class TestMoE(unittest.TestCase):
         # 1. Run Dense
         moe_dense = self._create_moe(MoEBackend.DENSE_MAT)
         with jax.set_mesh(self.mesh):
-            out_dense = moe_dense(self.x)
+            out_dense, _ = moe_dense(self.x)
 
         # 2. Run Sparse
         # We must re-init with same key to get same weights
         moe_sparse = self._create_moe(MoEBackend.MEGABLX_GMM)
         with jax.set_mesh(self.mesh):
-            out_sparse = moe_sparse(self.x)
+            out_sparse, _ = moe_sparse(self.x)
 
         self.assertTrue(
             jnp.allclose(out_dense, out_sparse, atol=5e-2, rtol=5e-2),

--- a/tests/layers/jax/moe/test_moe.py
+++ b/tests/layers/jax/moe/test_moe.py
@@ -166,6 +166,46 @@ class TestMoE(unittest.TestCase):
 
         return jnp.array(expected_output, dtype=self.dtype)
 
+    def _compute_ground_truth_with_fixed_ids(self, moe_instance, x_input,
+                                             expert_ids):
+        """Computes ground truth using fixed expert IDs instead of router decisions."""
+        weights, _ = moe_instance.router(x_input)
+        gating_kernel_full = jax.device_get(
+            moe_instance.kernel_gating_EDF.value)
+        up_proj_kernel_full = jax.device_get(
+            moe_instance.kernel_up_proj_EDF.value)
+        down_proj_kernel_full = jax.device_get(
+            moe_instance.kernel_down_proj_EFD.value)
+
+        flat_x = x_input.reshape(-1, self.D)
+        flat_weights = weights.reshape(-1, self.K)
+        flat_indices = expert_ids.reshape(-1, self.K)
+
+        expected_output = np.zeros_like(flat_x)
+
+        for t in range(flat_x.shape[0]):
+            token_val = flat_x[t]
+            token_accum = np.zeros_like(token_val)
+
+            for k in range(self.K):
+                expert_idx = flat_indices[t, k]
+                router_weight = flat_weights[t, k]
+
+                w_gating = gating_kernel_full[expert_idx]
+                w_up = up_proj_kernel_full[expert_idx]
+                w_down = down_proj_kernel_full[expert_idx]
+
+                gate_out = np.dot(token_val, w_gating)
+                up_out = np.dot(token_val, w_up)
+                silu_out = gate_out * (1 / (1 + np.exp(-gate_out)))
+                expert_out = silu_out * up_out
+                down_out = np.dot(expert_out, w_down)
+                token_accum += down_out * router_weight
+
+            expected_output[t] = token_accum
+
+        return jnp.array(expected_output, dtype=self.dtype)
+
     def test_dense_backend_correctness(self):
         """Verifies the DENSE_MAT backend against the sequential ground truth."""
         for apply_expert_weight_before_computation in [False, True]:
@@ -232,3 +272,24 @@ class TestMoE(unittest.TestCase):
             jnp.allclose(out_dense, out_sparse, atol=5e-2, rtol=5e-2),
             "Dense and Sparse backends produced different results for identical initialization."
         )
+
+    def test_moe_replay_correctness(self):
+        """Tests that the MoE output can be reconstructed using saved expert IDs."""
+        moe = self._create_moe(MoEBackend.DENSE_MAT)
+
+        # Enable returning expert IDs
+        moe.enable_return_routed_experts = True
+
+        with jax.set_mesh(self.mesh):
+            output_run1, expert_ids = moe(self.x)
+
+        self.assertIsNotNone(expert_ids,
+                             "expert_ids should not be None when enabled")
+
+        # Compute ground truth with the saved expert_ids
+        reconstructed = self._compute_ground_truth_with_fixed_ids(
+            moe, self.x, expert_ids)
+
+        self.assertTrue(
+            jnp.allclose(output_run1, reconstructed, atol=1e-2, rtol=1e-2),
+            "Reconstructed output does not match run1 output.")

--- a/tests/layers/jax/quantization/test_fp8.py
+++ b/tests/layers/jax/quantization/test_fp8.py
@@ -633,7 +633,7 @@ class TestFp8FusedMoE:
         with patch.object(layer, 'router', return_value=score):
             # Run the actual forward pass and up-cast
             # to avoid promote error
-            actual = layer(a).astype(expected.dtype)
+            actual = layer(a)[0].astype(expected.dtype)
 
         assert jnp.allclose(expected, actual, atol=5e-2, rtol=1e-1)
 

--- a/tests/layers/jax/test_transformer_block.py
+++ b/tests/layers/jax/test_transformer_block.py
@@ -63,7 +63,7 @@ class TestTransformerBlock(unittest.TestCase):
         mock_pre_attn_norm.side_effect = lambda val: val
         mock_pre_mlp_norm.side_effect = lambda val: val
 
-        new_kv_cache, final_output = transformer_block(
+        new_kv_cache, final_output, _ = transformer_block(
             x,
             is_prefill=True,
             kv_cache=initial_kv_cache,
@@ -134,7 +134,7 @@ class TestTransformerBlock(unittest.TestCase):
         mock_pre_attn_norm.side_effect = lambda val: val
         mock_pre_mlp_norm.side_effect = lambda val: val
 
-        new_kv_cache, final_output = transformer_block(
+        new_kv_cache, final_output, _ = transformer_block(
             x,
             is_prefill=True,
             kv_cache=initial_kv_cache,

--- a/tests/models/jax/test_llama3.py
+++ b/tests/models/jax/test_llama3.py
@@ -172,7 +172,7 @@ class TestLlamaForCausalLM:
             jnp.bfloat16)
         # 1 seq with 16 tokens
         input_ids, attention_metadata, indices_do_sample = mock_model_inputs
-        kv_caches, hidden_states, aux_hidden_states = model(
+        kv_caches, hidden_states, aux_hidden_states, _ = model(
             kv_caches, input_ids, attention_metadata, None, None, None, None,
             None, True, True)
         assert hidden_states.shape == (8, hidden_size)

--- a/tests/models/jax/test_llama_eagle3.py
+++ b/tests/models/jax/test_llama_eagle3.py
@@ -159,7 +159,7 @@ class TestEagleLlama3ForCausalLM:
             if mock_vllm_config.cache_config.cache_dtype == "fp8" else
             jnp.bfloat16)
 
-        _, output_hidden_states, aux_hidden_states = model(
+        _, output_hidden_states, aux_hidden_states, _ = model(
             kv_caches, input_ids, hidden_states, attention_metadata)
 
         logits = model.compute_logits(output_hidden_states)

--- a/tests/models/jax/test_qwen2.py
+++ b/tests/models/jax/test_qwen2.py
@@ -182,7 +182,7 @@ class TestQwen2ForCausalLM:
             jnp.bfloat16)
         # 1 seq with 16 tokens
         input_ids, attention_metadata, indices_do_sample = mock_model_inputs
-        kv_caches, hidden_states, aux_hidden_states = model(
+        kv_caches, hidden_states, aux_hidden_states, _ = model(
             kv_caches, input_ids, attention_metadata)
         assert hidden_states.shape == (8, hidden_size)
         assert len(aux_hidden_states) == 0

--- a/tests/models/jax/test_qwen2_5_vl.py
+++ b/tests/models/jax/test_qwen2_5_vl.py
@@ -597,7 +597,8 @@ class TestQwen2_5_VLForConditionalGeneration:
                               (1, 10, model.config.text_config.hidden_size)))
         model.model.return_value = mock_lm_output
 
-        new_kvs, x, aux_hidden_states = model(kv_caches, input_ids, attn_meta)
+        new_kvs, x, aux_hidden_states, _ = model(kv_caches, input_ids,
+                                                 attn_meta)
         model.model.assert_called_once_with(kv_caches=kv_caches,
                                             input_ids=input_ids,
                                             attention_metadata=attn_meta,
@@ -698,11 +699,11 @@ class TestQwen2_5_VLPipelineParallel:
             attn_meta = MagicMock(spec=AttentionMetadata)
 
             model.model.return_value = (kv_caches, jnp.ones((3, 16)))
-            new_kvs, x, aux = model(kv_caches,
-                                    input_ids,
-                                    attn_meta,
-                                    is_first_rank=True,
-                                    is_last_rank=False)
+            new_kvs, x, aux, _ = model(kv_caches,
+                                       input_ids,
+                                       attn_meta,
+                                       is_first_rank=True,
+                                       is_last_rank=False)
             assert isinstance(x, JaxIntermediateTensors)
             assert "hidden_states" in x.tensors
             model.model.assert_called_once()
@@ -724,12 +725,12 @@ class TestQwen2_5_VLPipelineParallel:
                 tensors={"hidden_states": jnp.ones((3, 16))})
 
             model.model.return_value = (kv_caches, jnp.ones((3, 16)))
-            new_kvs, x, aux = model(kv_caches,
-                                    None,
-                                    attn_meta,
-                                    intermediate_tensors=intermediate,
-                                    is_first_rank=False,
-                                    is_last_rank=True)
+            new_kvs, x, aux, _ = model(kv_caches,
+                                       None,
+                                       attn_meta,
+                                       intermediate_tensors=intermediate,
+                                       is_first_rank=False,
+                                       is_last_rank=True)
             assert isinstance(x, jax.Array)
             model.model.assert_called_once()
             _, kwargs = model.model.call_args

--- a/tests/models/jax/test_qwen3.py
+++ b/tests/models/jax/test_qwen3.py
@@ -206,7 +206,7 @@ class TestQwen3ForCausalLM:
             jnp.bfloat16)
         # 1 seq with 16 tokens
         input_ids, attention_metadata, indices_do_sample = mock_model_inputs
-        kv_caches, hidden_states, aux_hidden_states = model(
+        kv_caches, hidden_states, aux_hidden_states, _ = model(
             kv_caches, input_ids, attention_metadata)
         assert hidden_states.shape == (8, hidden_size)
         assert len(aux_hidden_states) == 0

--- a/tests/models/jax/test_qwen3_moe.py
+++ b/tests/models/jax/test_qwen3_moe.py
@@ -105,7 +105,7 @@ class TestQwen3MoeForCausalLM:
                                          kv_dtype)
 
         with jax.set_mesh(mesh):
-            jax_output, _ = jax_layer_0(
+            kv_cache, jax_output, _ = jax_layer_0(
                 kv_cache=jnp.zeros(cache_shape, dtype=kv_dtype),
                 x=input_tensor_jax,
                 attention_metadata=AttentionMetadata(

--- a/tests/spec_decode/test_eagle3.py
+++ b/tests/spec_decode/test_eagle3.py
@@ -231,8 +231,9 @@ def test_propose(method, num_speculative_tokens):
             residual_hidden_states = residual_hidden_states.at[:, 0].set(
                 next_token_ids_encoded)
 
-        # Return (kv_caches, hidden_states, residual_tuple)
-        return kv_caches, hidden_states_for_logits, (residual_hidden_states, )
+        # Return (kv_caches, hidden_states, residual_tuple, None)
+        return kv_caches, hidden_states_for_logits, (
+            residual_hidden_states, ), None
 
     def mock_compute_logits_fn(state, hidden_states, lora_metadata):
         # Create deterministic logits from hidden_states.

--- a/tpu_inference/core/sched/dp_scheduler.py
+++ b/tpu_inference/core/sched/dp_scheduler.py
@@ -950,29 +950,29 @@ class DPScheduler(SchedulerInterface):
             global_indices = [g.req_id_to_index[rid] for rid in req_ids]
             rank_req_id_to_index = {rid: i for i, rid in enumerate(req_ids)}
 
-            outputs.append(
-                ModelRunnerOutput(
-                    req_ids=req_ids,
-                    req_id_to_index=rank_req_id_to_index,
-                    sampled_token_ids=([
-                        g.sampled_token_ids[i] for i in global_indices
-                    ] if g.sampled_token_ids else []),
-                    logprobs=(self._slice_logprobs(g.logprobs, global_indices)
-                              if g.logprobs is not None and global_indices else
-                              None),
-                    prompt_logprobs_dict={
-                        rid: g.prompt_logprobs_dict[rid]
-                        for rid in req_ids if rid in g.prompt_logprobs_dict
-                    },
-                    pooler_output=([
-                        g.pooler_output[i] for i in global_indices
-                    ] if g.pooler_output else None),
-                    num_nans_in_logits=({
-                        rid: g.num_nans_in_logits[rid]
-                        for rid in req_ids if rid in g.num_nans_in_logits
-                    } if g.num_nans_in_logits else None),
-                    kv_connector_output=g.kv_connector_output,
-                ))
+            rank_model_runner_output = ModelRunnerOutput(
+                req_ids=req_ids,
+                req_id_to_index=rank_req_id_to_index,
+                sampled_token_ids=(
+                    [g.sampled_token_ids[i]
+                     for i in global_indices] if g.sampled_token_ids else []),
+                logprobs=(self._slice_logprobs(g.logprobs, global_indices) if
+                          g.logprobs is not None and global_indices else None),
+                prompt_logprobs_dict={
+                    rid: g.prompt_logprobs_dict[rid]
+                    for rid in req_ids if rid in g.prompt_logprobs_dict
+                },
+                pooler_output=([g.pooler_output[i] for i in global_indices]
+                               if g.pooler_output else None),
+                num_nans_in_logits=({
+                    rid: g.num_nans_in_logits[rid]
+                    for rid in req_ids if rid in g.num_nans_in_logits
+                } if g.num_nans_in_logits else None),
+                kv_connector_output=g.kv_connector_output,
+            )
+            rank_model_runner_output.expert_indices = getattr(
+                g, 'expert_indices', None)
+            outputs.append(rank_model_runner_output)
 
         return outputs
 

--- a/tpu_inference/core/sched/dp_scheduler.py
+++ b/tpu_inference/core/sched/dp_scheduler.py
@@ -943,6 +943,18 @@ class DPScheduler(SchedulerInterface):
         g = global_model_output  # short alias
 
         outputs = []
+
+        expert_indices = getattr(g, "expert_indices", None)
+        req_id_to_token_range = {}
+        if expert_indices is not None:
+            current_token_offset = 0
+            for req_id, num_tokens_scheduled in scheduler_output.num_scheduled_tokens.items(
+            ):
+                start_idx = current_token_offset
+                end_idx = start_idx + num_tokens_scheduled
+                current_token_offset = end_idx
+                req_id_to_token_range[req_id] = (start_idx, end_idx)
+
         for rank in range(self.dp_size):
             req_ids = scheduler_output.req_ids_per_rank.get(rank, [])
 
@@ -970,8 +982,22 @@ class DPScheduler(SchedulerInterface):
                 } if g.num_nans_in_logits else None),
                 kv_connector_output=g.kv_connector_output,
             )
-            rank_model_runner_output.expert_indices = getattr(
-                g, 'expert_indices', None)
+
+            if expert_indices is not None:
+                rank_expert_indices = []
+                for rid in req_ids:
+                    if rid in req_id_to_token_range:
+                        start_idx, end_idx = req_id_to_token_range[rid]
+                        rank_expert_indices.append(
+                            expert_indices[:, start_idx:end_idx, :])
+                if rank_expert_indices:
+                    rank_model_runner_output.expert_indices = np.concatenate(
+                        rank_expert_indices, axis=1)
+                else:
+                    rank_model_runner_output.expert_indices = None
+            else:
+                rank_model_runner_output.expert_indices = None
+
             outputs.append(rank_model_runner_output)
 
         return outputs

--- a/tpu_inference/core/sched/utils.py
+++ b/tpu_inference/core/sched/utils.py
@@ -15,7 +15,23 @@
 
 def update_vllm_scheduler_for_exporting_expert_ids():
     # Monkeypatch vLLM Scheduler to attach expert indices to outputs
+    from vllm.model_executor.layers.fused_moe.routed_experts_capturer import \
+        RoutedExpertsReader
     from vllm.v1.core.sched.scheduler import Scheduler
+
+    class DummyRoutedExpertsReader:
+
+        @staticmethod
+        def create():
+            return DummyRoutedExpertsReader()
+
+        def attach_buffer(self, *args, **kwargs):
+            pass
+
+        def get_routed_experts(self, *args, **kwargs):
+            return None
+
+    RoutedExpertsReader.create = DummyRoutedExpertsReader.create
 
     original_update_from_output = Scheduler.update_from_output
 

--- a/tpu_inference/core/sched/utils.py
+++ b/tpu_inference/core/sched/utils.py
@@ -1,0 +1,56 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+def update_vllm_scheduler_for_exporting_expert_ids():
+    # Monkeypatch vLLM Scheduler to attach expert indices to outputs
+    from vllm.v1.core.sched.scheduler import Scheduler
+
+    original_update_from_output = Scheduler.update_from_output
+
+    def custom_update_from_output(self, scheduler_output, model_runner_output):
+        expert_indices = getattr(model_runner_output, "expert_indices", None)
+
+        if expert_indices is not None:
+            num_scheduled_tokens = scheduler_output.num_scheduled_tokens
+            current_token_offset = 0
+            for req_id, num_tokens_scheduled in num_scheduled_tokens.items():
+                start_idx = current_token_offset
+                end_idx = start_idx + num_tokens_scheduled
+                current_token_offset = end_idx
+
+                request = self.requests.get(req_id)
+                if request is not None:
+                    step_experts = expert_indices[:, start_idx:
+                                                  end_idx, :].transpose(
+                                                      1, 0, 2)
+                    if not hasattr(request, "_accumulated_routed_experts"):
+                        request._accumulated_routed_experts = []
+                    request._accumulated_routed_experts.append(step_experts)
+
+        return original_update_from_output(self, scheduler_output,
+                                           model_runner_output)
+
+    Scheduler.update_from_output = custom_update_from_output
+
+    original_get_routed_experts = Scheduler._get_routed_experts
+
+    def custom_get_routed_experts(self, request):
+        if hasattr(request, "_accumulated_routed_experts"
+                   ) and request._accumulated_routed_experts:
+            import numpy as np
+            return np.concatenate(request._accumulated_routed_experts, axis=0)
+        return original_get_routed_experts(self, request)
+
+    Scheduler._get_routed_experts = custom_get_routed_experts

--- a/tpu_inference/core/sched/utils.py
+++ b/tpu_inference/core/sched/utils.py
@@ -31,6 +31,9 @@ def update_vllm_scheduler_for_exporting_expert_ids():
         def get_routed_experts(self, *args, **kwargs):
             return None
 
+    # Since we are reusing the upstream enable_return_routed_experts flag,
+    # we need to stub out the actual RoutedExpertsReader class which the
+    # upstream scheduler tries to create.
     RoutedExpertsReader.create = DummyRoutedExpertsReader.create
 
     original_update_from_output = Scheduler.update_from_output

--- a/tpu_inference/layers/jax/moe/gpt_oss_moe.py
+++ b/tpu_inference/layers/jax/moe/gpt_oss_moe.py
@@ -49,7 +49,7 @@ class GptOssRouter(Router):
                                    sharding=self.e_sharding,
                                    random_init=self.random_init)
 
-    def __call__(self, x_TD: Float):
+    def __call__(self, x_TD: Float) -> tuple[Float, jax.Array]:
         """
         Overrides the parent's forward pass to include the bias.
         """
@@ -132,8 +132,9 @@ class GptOssMoE(nnx.Module):
     ed_sharding: Sharding
 
     random_init: bool = False
+    enable_return_routed_experts: bool = False
 
-    def __call__(self, x_TD: Float) -> Float:
+    def __call__(self, x_TD: Float):
         """Performs the forward pass for the GPT-OSS MoE layer."""
         x_TD = jnp.asarray(x_TD, self.dtype)
         x_TD = lax.with_sharding_constraint(x_TD, self.activation_ffw_td)
@@ -169,7 +170,10 @@ class GptOssMoE(nnx.Module):
         # Weighted sum of expert outputs
         output_TD = self.combine_experts(down_proj_TED, weights_TX, indices_TX)
 
-        return output_TD
+        if self.enable_return_routed_experts:
+            return output_TD, indices_TX
+        else:
+            return output_TD, None
 
     def __post_init__(self, rngs: nnx.Rngs):
         """Initializes all weights and biases for the MoE block."""

--- a/tpu_inference/layers/jax/moe/moe.py
+++ b/tpu_inference/layers/jax/moe/moe.py
@@ -169,6 +169,7 @@ class JaxMoE(JaxModule):
     # ---- Quantization Specific Attributes ----
     quant_config: Optional[QuantizationConfig] = None
     prefix: str = ""
+    enable_return_routed_experts: bool = False
 
     def __call__(self, x_TD: jax.Array) -> jax.Array:
         """Performs the forward pass of the MoE layer.
@@ -181,9 +182,18 @@ class JaxMoE(JaxModule):
         """
         if self.quant_method is not None:
             router_logits = self.router(x_TD)
-            return self.quant_method.apply_jax(self,
+            x_TD = self.quant_method.apply_jax(self,
                                                x_TD,
                                                router_logits=router_logits)
+            if self.enable_return_routed_experts:
+                if self.moe_backend in MoEBackend.fused_moe_backends():
+                    _, selected_experts_TX = jax.lax.top_k(
+                        router_logits, self.num_experts_per_tok)
+                else:
+                    _, selected_experts_TX = router_logits
+                return x_TD, selected_experts_TX
+            else:
+                return x_TD, None
         raise ValueError("Expected quant_method to be set!")
 
     def __post_init__(self, rngs: nnx.Rngs):

--- a/tpu_inference/layers/jax/transformer_block.py
+++ b/tpu_inference/layers/jax/transformer_block.py
@@ -38,11 +38,12 @@ class TransformerBlock(nnx.Module):
     attn: nnx.Module
     use_attention_rope: bool = True
     quant: Any | None = None
+    enable_return_routed_experts: bool = False
 
     def __call__(
-            self, x_TD: jax.Array, is_prefill: bool, kv_cache: KVCache,
-            attention_metadata: AttentionMetadata
-    ) -> Tuple[KVCache, jax.Array]:
+        self, x_TD: jax.Array, is_prefill: bool, kv_cache: KVCache,
+        attention_metadata: AttentionMetadata
+    ) -> Tuple[KVCache, jax.Array, Optional[jax.Array]]:
         # Attn Block
         attn_residual_TD = x_TD
         x_TD = self.pre_attention_norm(x_TD)
@@ -54,9 +55,16 @@ class TransformerBlock(nnx.Module):
         # FFW Block
         ffw_residual_TD = attn_output_TD
         normed_ffw_input_TD = self.pre_mlp_norm(attn_output_TD)
-        logits_TD = self.custom_module(normed_ffw_input_TD)
+
+        expert_ids = None
+        if isinstance(self.custom_module, JaxMoE):
+            logits_TD, expert_ids = self.custom_module(normed_ffw_input_TD)
+        else:
+            logits_TD = self.custom_module(normed_ffw_input_TD)
+
         logits_TD += ffw_residual_TD
-        return new_cache, logits_TD
+
+        return new_cache, logits_TD, expert_ids
 
 
 @dataclass(kw_only=True)
@@ -81,6 +89,7 @@ class SharedExpertsTransformerBlock(TransformerBlock):
     moe_ffw: Optional[JaxMoE] = None
     dense_ffw: Optional[DenseFFW] = None
     shared_experts: Optional[DenseFFW] = None
+    enable_return_routed_experts: bool = False
 
     def __call__(self, x_TD, is_prefill, kv_cache, attention_metadata):
         # Attn Block
@@ -105,8 +114,9 @@ class SharedExpertsTransformerBlock(TransformerBlock):
         else:
             dense_layer = self.dense_ffw
 
+        expert_ids = None
         if moe_layer is not None:
-            logits_TD = moe_layer(normed_ffw_input_TD)
+            logits_TD, expert_ids = moe_layer(normed_ffw_input_TD)
             # Add the shared expert outputs to the MoE outputs.
             shared_expert_output_TD = self.shared_experts(normed_ffw_input_TD)
             logits_TD += shared_expert_output_TD
@@ -118,4 +128,5 @@ class SharedExpertsTransformerBlock(TransformerBlock):
             )
 
         logits_TD += ffw_residual_TD
-        return new_cache, logits_TD
+
+        return new_cache, logits_TD, expert_ids

--- a/tpu_inference/layers/jax/transformer_block.py
+++ b/tpu_inference/layers/jax/transformer_block.py
@@ -57,10 +57,11 @@ class TransformerBlock(nnx.Module):
         normed_ffw_input_TD = self.pre_mlp_norm(attn_output_TD)
 
         expert_ids = None
-        if isinstance(self.custom_module, JaxMoE):
-            logits_TD, expert_ids = self.custom_module(normed_ffw_input_TD)
+        mlp_output = self.custom_module(normed_ffw_input_TD)
+        if isinstance(mlp_output, tuple):
+            logits_TD, expert_ids = mlp_output
         else:
-            logits_TD = self.custom_module(normed_ffw_input_TD)
+            logits_TD = mlp_output
 
         logits_TD += ffw_residual_TD
 
@@ -116,7 +117,11 @@ class SharedExpertsTransformerBlock(TransformerBlock):
 
         expert_ids = None
         if moe_layer is not None:
-            logits_TD, expert_ids = moe_layer(normed_ffw_input_TD)
+            mlp_output = moe_layer(normed_ffw_input_TD)
+            if isinstance(mlp_output, tuple):
+                logits_TD, expert_ids = mlp_output
+            else:
+                logits_TD = mlp_output
             # Add the shared expert outputs to the MoE outputs.
             shared_expert_output_TD = self.shared_experts(normed_ffw_input_TD)
             logits_TD += shared_expert_output_TD

--- a/tpu_inference/layers/vllm/interface/moe.py
+++ b/tpu_inference/layers/vllm/interface/moe.py
@@ -85,10 +85,7 @@ def vllm_moe_apply(layer: FusedMoE, weights: FusedMoEWeights,
     except AssertionError:
         vllm_config = None
 
-    enable_return_routed_experts = vllm_config.additional_config.get(
-        "enable_return_routed_experts", False) if vllm_config and hasattr(
-            vllm_config, 'additional_config') and isinstance(
-                vllm_config.additional_config, dict) else False
+    enable_return_routed_experts = vllm_config.model_config.enable_return_routed_experts if vllm_config else False
 
     if enable_return_routed_experts:
         if isinstance(router_logits, torch.Tensor):

--- a/tpu_inference/layers/vllm/interface/moe.py
+++ b/tpu_inference/layers/vllm/interface/moe.py
@@ -77,11 +77,18 @@ def vllm_moe_apply(layer: FusedMoE, weights: FusedMoEWeights,
     assert isinstance(quant_method_instance, FusedMoEMethodBase)
     assert isinstance(weights, FusedMoEWeights)
 
-    from vllm.config import get_current_vllm_config_or_none
-    vllm_config = get_current_vllm_config_or_none()
-    enable_return_routed_experts = getattr(vllm_config.additional_config,
-                                           "enable_return_routed_experts",
-                                           False) if vllm_config else False
+    from tpu_inference.models.vllm.vllm_model_wrapper_context import \
+        get_vllm_model_wrapper_context
+    try:
+        context = get_vllm_model_wrapper_context()
+        vllm_config = context.vllm_config
+    except AssertionError:
+        vllm_config = None
+
+    enable_return_routed_experts = vllm_config.additional_config.get(
+        "enable_return_routed_experts", False) if vllm_config and hasattr(
+            vllm_config, 'additional_config') and isinstance(
+                vllm_config.additional_config, dict) else False
 
     if enable_return_routed_experts:
         if isinstance(router_logits, torch.Tensor):

--- a/tpu_inference/layers/vllm/interface/moe.py
+++ b/tpu_inference/layers/vllm/interface/moe.py
@@ -77,6 +77,23 @@ def vllm_moe_apply(layer: FusedMoE, weights: FusedMoEWeights,
     assert isinstance(quant_method_instance, FusedMoEMethodBase)
     assert isinstance(weights, FusedMoEWeights)
 
+    from vllm.config import get_current_vllm_config_or_none
+    vllm_config = get_current_vllm_config_or_none()
+    enable_return_routed_experts = getattr(vllm_config.additional_config,
+                                           "enable_return_routed_experts",
+                                           False) if vllm_config else False
+
+    if enable_return_routed_experts:
+        if isinstance(router_logits, torch.Tensor):
+            _, expert_indices = torch.topk(router_logits, layer.top_k, dim=-1)
+            from tpu_inference.models.vllm.vllm_model_wrapper_context import \
+                get_vllm_model_wrapper_context
+            try:
+                context = get_vllm_model_wrapper_context()
+                context.expert_indices_list.append(jax_view(expert_indices))
+            except AssertionError:
+                pass
+
     return torch_view(
         moe_apply(
             layer=layer,

--- a/tpu_inference/models/common/model_loader.py
+++ b/tpu_inference/models/common/model_loader.py
@@ -321,6 +321,7 @@ def get_flax_model(
             kv_cache_sharding,
             hidden_states_sharding,
             hidden_states_sharding,  # aux hidden states
+            None,  # expert ids
         ),
         donate_argnums=2,  # 0 is graphdef, 1 is state, 2 is kv_cache
         static_argnums=(

--- a/tpu_inference/models/common/model_loader.py
+++ b/tpu_inference/models/common/model_loader.py
@@ -337,6 +337,7 @@ def get_flax_model(
             kv_cache_sharding,
             hidden_states_sharding,
             hidden_states_sharding,  # residual
+            None,  # expert ids
         ),
         donate_argnums=2,  # 0 is graphdef, 1 is state, 2 is kv_cache
         static_argnums=(6, ),  # 6 is layer_name_to_kvcache_index

--- a/tpu_inference/models/jax/deepseek_v3.py
+++ b/tpu_inference/models/jax/deepseek_v3.py
@@ -1122,8 +1122,7 @@ class DeepSeekV3(JaxModule):
                  quant_config,
                  prefix: str = ""):
         self.vllm_config = vllm_config
-        self.enable_return_routed_experts = self.vllm_config.additional_config.get(
-            "enable_return_routed_experts", False)
+        self.enable_return_routed_experts = self.vllm_config.model_config.enable_return_routed_experts
 
         self.use_mla_kernel: bool = self.vllm_config.model_config.use_mla
 

--- a/tpu_inference/models/jax/deepseek_v3.py
+++ b/tpu_inference/models/jax/deepseek_v3.py
@@ -970,10 +970,7 @@ class DeepseekV3DecoderLayer(JaxModule):
         # Residual
         hidden_states = residual + mlp_output
 
-        if expert_indices is not None:
-            return new_cache, hidden_states, expert_indices
-        else:
-            return new_cache, hidden_states
+        return new_cache, hidden_states, expert_indices
 
 
 class DeepSeekV3Router(JaxEinsum):

--- a/tpu_inference/models/jax/deepseek_v3.py
+++ b/tpu_inference/models/jax/deepseek_v3.py
@@ -816,9 +816,10 @@ class SharedFusedMoe(JaxMoE):
 
     routed_scaling_factor: float = 1.0
 
-    def __call__(self, x_TD: jax.Array) -> jax.Array:
+    def __call__(self, x_TD: jax.Array):
         # Compute Routed Experts
-        final_hidden_states = super().__call__(x_TD)
+        final_hidden_states, expert_indices = super().__call__(x_TD)
+
         final_hidden_states *= self.routed_scaling_factor
 
         # (Maybe) Compute Shared Experts
@@ -826,7 +827,7 @@ class SharedFusedMoe(JaxMoE):
             shared_output = self.shared_experts(x_TD)
             final_hidden_states += shared_output
 
-        return final_hidden_states
+        return final_hidden_states, expert_indices
 
 
 class DeepseekV2Moe(JaxModule):
@@ -844,7 +845,8 @@ class DeepseekV2Moe(JaxModule):
                  quant_config,
                  scoring_func,
                  rng,
-                 prefix: str = ""):
+                 prefix: str = "",
+                 enable_return_routed_experts: bool = False):
 
         self.gate = DeepSeekV3Router(
             hidden_size=hidden_size,
@@ -918,6 +920,7 @@ class DeepseekV2Moe(JaxModule):
             router=self.gate,
             shared_experts=self.shared_experts,
             scoring_func=scoring_func,
+            enable_return_routed_experts=enable_return_routed_experts,
             routed_scaling_factor=routed_scaling_factor)
 
     def __call__(self, x_TD: jax.Array):
@@ -946,7 +949,7 @@ class DeepseekV3DecoderLayer(JaxModule):
     def __call__(
         self, x_TD: jax.Array, *, kv_cache: List[jax.Array],
         attention_metadata: AttentionMetadata
-    ) -> Tuple[List[jax.Array], jax.Array]:
+    ) -> Tuple[List[jax.Array], jax.Array, Optional[jax.Array]]:
 
         # Run Self-Attention
         residual = x_TD
@@ -960,10 +963,17 @@ class DeepseekV3DecoderLayer(JaxModule):
         hidden_states = self.post_attention_layernorm(hidden_states)
         mlp_output = self.mlp(hidden_states)
 
+        expert_indices = None
+        if isinstance(mlp_output, tuple):
+            mlp_output, expert_indices = mlp_output
+
         # Residual
         hidden_states = residual + mlp_output
 
-        return new_cache, hidden_states
+        if expert_indices is not None:
+            return new_cache, hidden_states, expert_indices
+        else:
+            return new_cache, hidden_states
 
 
 class DeepSeekV3Router(JaxEinsum):
@@ -1115,6 +1125,8 @@ class DeepSeekV3(JaxModule):
                  quant_config,
                  prefix: str = ""):
         self.vllm_config = vllm_config
+        self.enable_return_routed_experts = self.vllm_config.additional_config.get(
+            "enable_return_routed_experts", False)
 
         self.use_mla_kernel: bool = self.vllm_config.model_config.use_mla
 
@@ -1283,7 +1295,9 @@ class DeepSeekV3(JaxModule):
                     quant_config=quant_config,
                     scoring_func=scoring_func,
                     rng=rng,
-                    prefix=f"{prefix}.layers.{layer_index}.mlp")
+                    prefix=f"{prefix}.layers.{layer_index}.mlp",
+                    enable_return_routed_experts=self.
+                    enable_return_routed_experts)
 
             return DeepseekV3DecoderLayer(
                 input_layernorm=input_layernorm,
@@ -1325,23 +1339,29 @@ class DeepSeekV3(JaxModule):
         input_ids: Optional[jax.Array],
         attention_metadata: AttentionMetadata,
         inputs_embeds: Optional[jax.Array] = None,
-    ) -> Tuple[List[jax.Array], jax.Array]:
+    ) -> Tuple[List[jax.Array], jax.Array, Optional[jax.Array]]:
         if inputs_embeds is not None:
             x = inputs_embeds
         else:
             x = self.embed_tokens(input_ids)
 
+        all_expert_ids = []
         for i, layer in enumerate(
                 islice(self.layers, self.start_layer, self.end_layer)):
             kv_cache = kv_caches[i]
-            kv_cache, x = layer(
+            kv_cache, x, expert_ids = layer(
                 x,
                 kv_cache=kv_cache,
                 attention_metadata=attention_metadata,
             )
+            if expert_ids is not None:
+                all_expert_ids.append(expert_ids)
             kv_caches[i] = kv_cache
         x = self.norm(x)
-        return kv_caches, x
+
+        stacked_expert_ids = jnp.stack(all_expert_ids,
+                                       axis=0) if all_expert_ids else None
+        return kv_caches, x, stacked_expert_ids
 
 
 class DeepseekV3ForCausalLM(JaxModule, LoadableWithIterator):
@@ -1394,12 +1414,12 @@ class DeepseekV3ForCausalLM(JaxModule, LoadableWithIterator):
         is_last_rank: bool = True,
         *args,
     ) -> Tuple[List[jax.Array], jax.Array | JaxIntermediateTensors,
-               List[jax.Array]]:
+               List[jax.Array], Optional[jax.Array]]:
         if not is_first_rank:
             assert intermediate_tensors is not None
             inputs_embeds = intermediate_tensors["hidden_states"]
 
-        kv_caches, x = self.model(
+        kv_caches, x, expert_indices = self.model(
             kv_caches,
             input_ids,
             attention_metadata,
@@ -1409,7 +1429,7 @@ class DeepseekV3ForCausalLM(JaxModule, LoadableWithIterator):
         if not is_last_rank:
             x = JaxIntermediateTensors(tensors={"hidden_states": x}, )
 
-        return kv_caches, x, []
+        return kv_caches, x, [], expert_indices
 
     def compute_logits(self, hidden_states: jax.Array) -> jax.Array:
         return self.lm_head(hidden_states)

--- a/tpu_inference/models/jax/gpt_oss.py
+++ b/tpu_inference/models/jax/gpt_oss.py
@@ -90,6 +90,8 @@ class GptOss(nnx.Module):
 
         self.random_init = force_random_weights or self.vllm_config.additional_config.get(
             "random_weights", False)
+        self.enable_return_routed_experts = self.vllm_config.additional_config.get(
+            "enable_return_routed_experts", False)
         self.mesh = mesh
 
         self.embedder = Embedder(
@@ -154,6 +156,7 @@ class GptOss(nnx.Module):
                 edf_sharding=P('model', None, None),
                 efd_sharding=P('model', None, None),
                 ed_sharding=P('model', None),
+                enable_return_routed_experts=self.enable_return_routed_experts,
             )
 
             block = TransformerBlock(
@@ -175,6 +178,7 @@ class GptOss(nnx.Module):
                 ),
                 attn=attn,
                 custom_module=moe_mlp,
+                enable_return_routed_experts=self.enable_return_routed_experts,
             )
             self.layers.append(block)
         # Note: ALL RMSNorm does not upcast input to float32, while the pytorch does
@@ -523,21 +527,28 @@ class GptOss(nnx.Module):
         input_ids: jax.Array,
         attention_metadata: AttentionMetadata,
         *args,
-    ) -> Tuple[List[KVCacheType], jax.Array, List[jax.Array]]:
+    ) -> Tuple[List[KVCacheType], jax.Array, List[jax.Array],
+               Optional[jax.Array]]:
         is_prefill = False
         x = self.embedder.encode(input_ids)
 
+        all_expert_ids = []
         for i, block in enumerate(self.layers):
             kv_cache = kv_caches[i]
             current_sliding_window = self.sliding_window if i % 2 == 0 else None
             attention_metadata.sliding_window = current_sliding_window
 
-            new_kv_cache, x = block(x, is_prefill, kv_cache,
-                                    attention_metadata)
+            new_kv_cache, x, expert_ids = block(x, is_prefill, kv_cache,
+                                                attention_metadata)
+            if expert_ids is not None:
+                all_expert_ids.append(expert_ids)
             kv_caches[i] = new_kv_cache
 
         final_activation = self.final_norm(x)
-        return kv_caches, final_activation, []
+
+        stacked_expert_ids = jnp.stack(all_expert_ids,
+                                       axis=0) if all_expert_ids else None
+        return kv_caches, final_activation, [], stacked_expert_ids
 
     def compute_logits(self, hidden_states: jax.Array) -> jax.Array:
         return self.lm_head.decode(hidden_states)

--- a/tpu_inference/models/jax/gpt_oss.py
+++ b/tpu_inference/models/jax/gpt_oss.py
@@ -90,8 +90,7 @@ class GptOss(nnx.Module):
 
         self.random_init = force_random_weights or self.vllm_config.additional_config.get(
             "random_weights", False)
-        self.enable_return_routed_experts = self.vllm_config.additional_config.get(
-            "enable_return_routed_experts", False)
+        self.enable_return_routed_experts = self.vllm_config.model_config.enable_return_routed_experts
         self.mesh = mesh
 
         self.embedder = Embedder(

--- a/tpu_inference/models/jax/llama3.py
+++ b/tpu_inference/models/jax/llama3.py
@@ -322,8 +322,8 @@ class LlamaModel(nnx.Module):
         input_ids: jax.Array,
         attention_metadata: AttentionMetadata,
         intermediate_tensors: JaxIntermediateTensors | None,
-    ) -> Tuple[List[jax.Array], jax.Array, List[jax.Array]] | Tuple[
-            List[jax.Array], JaxIntermediateTensors]:
+    ) -> Tuple[List[jax.Array], jax.Array | JaxIntermediateTensors,
+               List[jax.Array]]:
         if self.is_first_rank:
             x = self.embed(input_ids)
         else:
@@ -384,14 +384,15 @@ class LlamaForCausalLM(nnx.Module):
         _is_first_rank: bool | None = None,
         _is_last_rank: bool | None = None,
         *args,
-    ) -> Tuple[List[jax.Array], jax.Array, List[jax.Array]] | Tuple[
-            List[jax.Array], JaxIntermediateTensors]:
-        return self.model(
+    ) -> Tuple[List[jax.Array], jax.Array | JaxIntermediateTensors,
+               List[jax.Array], Optional[jax.Array]]:
+        outputs = self.model(
             kv_caches,
             input_ids,
             attention_metadata,
             intermediate_tensors,
         )
+        return outputs[0], outputs[1], outputs[2], None
 
     def compute_logits(self, hidden_states: jax.Array) -> jax.Array:
         if self.vllm_config.model_config.hf_config.tie_word_embeddings:

--- a/tpu_inference/models/jax/llama4.py
+++ b/tpu_inference/models/jax/llama4.py
@@ -431,6 +431,9 @@ class Llama4ForCausalLM(nnx.Module):
         self.mesh = mesh
         self.is_verbose = getattr(self.vllm_config.additional_config,
                                   "is_verbose", False)
+        self.enable_return_routed_experts = getattr(
+            self.vllm_config.additional_config, "enable_return_routed_experts",
+            False)
 
         # Currently the runner will always set a mesh, so the custom default sharding (when
         #  no sharding is set in vllm config) doesn't take effect.
@@ -538,7 +541,9 @@ class Llama4ForCausalLM(nnx.Module):
                 edf_sharding=('model', None, None),
                 efd_sharding=('model', None, None),
                 quant_config=vllm_config.quant_config,
-                random_init=force_random_weights) if is_moe_layer else None
+                random_init=force_random_weights,
+                enable_return_routed_experts=self.enable_return_routed_experts
+            ) if is_moe_layer else None
 
             dense_ffw = DenseFFW(dtype=dtype,
                                  hidden_act=self.hidden_act,
@@ -623,7 +628,8 @@ class Llama4ForCausalLM(nnx.Module):
                 attn=attn,
                 pre_attention_norm=pre_attention_norm,
                 pre_mlp_norm=pre_mlp_norm,
-                use_attention_rope=use_attention_rope)
+                use_attention_rope=use_attention_rope,
+                enable_return_routed_experts=self.enable_return_routed_experts)
             layers.append(block)
 
         for i in range(self.end_layer, self.num_layers):
@@ -696,7 +702,8 @@ class Llama4ForCausalLM(nnx.Module):
         _lora_metadata: Any = None,
         intermediate_tensors: Optional[JaxIntermediateTensors] = None,
         *args,
-    ) -> Tuple[List[KVCacheType], jax.Array, List[jax.Array]]:
+    ) -> Tuple[List[KVCacheType], jax.Array, List[jax.Array],
+               Optional[jax.Array]]:
         is_prefill = False
         if self.is_first_rank:
             x_TD = self.embedder.encode(input_ids)
@@ -704,20 +711,26 @@ class Llama4ForCausalLM(nnx.Module):
             assert intermediate_tensors is not None
             x_TD = intermediate_tensors["hidden_states"]
 
+        expert_indices_list = []
         for (i, block) in enumerate(
                 islice(self.layers, self.start_layer, self.end_layer)):
             kv_cache = kv_caches[i]
-            new_kv_cache, x_TD = block(x_TD, is_prefill, kv_cache,
-                                       attention_metadata)
+            new_kv_cache, x_TD, expert_ids = block(x_TD, is_prefill, kv_cache,
+                                                   attention_metadata)
+            if expert_ids is not None:
+                expert_indices_list.append(expert_ids)
             jax.block_until_ready(x_TD)
             kv_caches[i] = new_kv_cache
 
+        expert_indices = jnp.stack(expert_indices_list,
+                                   axis=0) if expert_indices_list else None
+
         if not self.is_last_rank:
-            return kv_caches, JaxIntermediateTensors({"hidden_states":
-                                                      x_TD}), []
+            return kv_caches, JaxIntermediateTensors({"hidden_states": x_TD
+                                                      }), [], expert_indices
 
         final_activation_TD = self.final_norm(x_TD)
-        return kv_caches, final_activation_TD, []
+        return kv_caches, final_activation_TD, [], expert_indices
 
     def compute_logits(self, hidden_states: jax.Array) -> jax.Array:
         logits_TV = jnp.dot(hidden_states,

--- a/tpu_inference/models/jax/llama4.py
+++ b/tpu_inference/models/jax/llama4.py
@@ -431,9 +431,7 @@ class Llama4ForCausalLM(nnx.Module):
         self.mesh = mesh
         self.is_verbose = getattr(self.vllm_config.additional_config,
                                   "is_verbose", False)
-        self.enable_return_routed_experts = getattr(
-            self.vllm_config.additional_config, "enable_return_routed_experts",
-            False)
+        self.enable_return_routed_experts = self.vllm_config.model_config.enable_return_routed_experts
 
         # Currently the runner will always set a mesh, so the custom default sharding (when
         #  no sharding is set in vllm config) doesn't take effect.

--- a/tpu_inference/models/jax/llama_eagle3.py
+++ b/tpu_inference/models/jax/llama_eagle3.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List, Tuple
+from typing import List, Optional, Tuple
 
 import jax
 import jax.numpy as jnp
@@ -185,7 +185,8 @@ class Eagle3LlamaModel(nnx.Module):
         input_ids: jax.Array,
         hidden_states: jax.Array,
         attention_metadata: AttentionMetadata,
-    ) -> Tuple[List[jax.Array], jax.Array, List[jax.Array]]:
+    ) -> Tuple[List[jax.Array], jax.Array, List[jax.Array],
+               Optional[jax.Array]]:
         embeds = self.embed_tokens(input_ids)
         assert hidden_states.shape[-1] == embeds.shape[-1]
 
@@ -203,7 +204,7 @@ class Eagle3LlamaModel(nnx.Module):
         hidden_states = hidden_states + residual
         residual = hidden_states
         hidden_states = self.norm(hidden_states)
-        return kv_caches, hidden_states, [residual]
+        return kv_caches, hidden_states, [residual], None
 
 
 def update_reshape_map_for_eagle3(vllm_config: VllmConfig,
@@ -302,7 +303,8 @@ class EagleLlama3ForCausalLM(nnx.Module):
         hidden_states: jax.Array,
         attention_metadata: AttentionMetadata,
         _layer_name_to_kv_cache=None,
-    ) -> Tuple[List[jax.Array], jax.Array, List[jax.Array]]:
+    ) -> Tuple[List[jax.Array], jax.Array, List[jax.Array],
+               Optional[jax.Array]]:
         return self.model(
             kv_caches,
             input_ids,

--- a/tpu_inference/models/jax/qwen2.py
+++ b/tpu_inference/models/jax/qwen2.py
@@ -420,7 +420,7 @@ class Qwen2ForCausalLM(JaxModule, LoadableWithIterator):
         is_last_rank: bool = True,
         *args,
     ) -> Tuple[List[jax.Array], jax.Array | JaxIntermediateTensors,
-               List[jax.Array]]:
+               List[jax.Array], Optional[jax.Array]]:
         if not is_first_rank:
             assert intermediate_tensors is not None
             inputs_embeds = intermediate_tensors["hidden_states"]
@@ -432,7 +432,7 @@ class Qwen2ForCausalLM(JaxModule, LoadableWithIterator):
         )
         if not is_last_rank:
             x = JaxIntermediateTensors(tensors={"hidden_states": x}, )
-        return kv_caches, x, []
+        return kv_caches, x, [], None
 
     def compute_logits(self, hidden_states: jax.Array) -> jax.Array:
         if hasattr(self, 'lm_head'):

--- a/tpu_inference/models/jax/qwen2_5_vl.py
+++ b/tpu_inference/models/jax/qwen2_5_vl.py
@@ -1126,7 +1126,7 @@ class Qwen2_5_VLForConditionalGeneration(nnx.Module):
         is_last_rank: bool = True,
         *args,
     ) -> tuple[list[jax.Array], jax.Array | JaxIntermediateTensors,
-               List[jax.Array]]:
+               List[jax.Array], Optional[jax.Array]]:
         # The logic of choosing between input_ids and inputs_embeds is
         # handled inside self.model.__call__
         if not is_first_rank:
@@ -1143,7 +1143,7 @@ class Qwen2_5_VLForConditionalGeneration(nnx.Module):
         if not is_last_rank:
             x = JaxIntermediateTensors(tensors={"hidden_states": x})
 
-        return kv_caches, x, []
+        return kv_caches, x, [], None
 
     def compute_logits(self, hidden_states: jax.Array) -> jax.Array:
         if hasattr(self, 'lm_head'):

--- a/tpu_inference/models/jax/qwen3.py
+++ b/tpu_inference/models/jax/qwen3.py
@@ -360,7 +360,7 @@ class Qwen3ForCausalLM(JaxModule, LoadableWithIterator):
         is_last_rank: bool = True,
         *args,
     ) -> Tuple[List[jax.Array], jax.Array | JaxIntermediateTensors,
-               List[jax.Array]]:
+               List[jax.Array], Optional[jax.Array]]:
         if not is_first_rank:
             assert intermediate_tensors is not None
             inputs_embeds = intermediate_tensors["hidden_states"]
@@ -372,7 +372,7 @@ class Qwen3ForCausalLM(JaxModule, LoadableWithIterator):
         )
         if not is_last_rank:
             x = JaxIntermediateTensors(tensors={"hidden_states": x}, )
-        return kv_caches, x, []
+        return kv_caches, x, [], None
 
     def compute_logits(self, hidden_states: jax.Array) -> jax.Array:
         if hasattr(self, 'lm_head'):

--- a/tpu_inference/models/jax/qwen3_moe.py
+++ b/tpu_inference/models/jax/qwen3_moe.py
@@ -100,6 +100,7 @@ class Qwen3MoeSparseMoeBlock(JaxModule):
             self.shared_expert = None
 
         # Experts (Routed)
+        self.enable_return_routed_experts = True
         self.experts = JaxMoE(
             dtype=dtype,
             num_local_experts=config.num_experts,
@@ -118,13 +119,17 @@ class Qwen3MoeSparseMoeBlock(JaxModule):
             num_expert_parallelism=num_expert_parallelism,
             moe_backend=moe_backend,
             quant_config=quant_config,
+            enable_return_routed_experts=self.enable_return_routed_experts,
             prefix=prefix + ".experts")
 
-    def __call__(self, x: jax.Array) -> jax.Array:
-        out = self.experts(x)
+    def __call__(self, x: jax.Array) -> Tuple[jax.Array, Optional[jax.Array]]:
+
+        out, expert_ids = self.experts(x)
+
         if self.shared_expert is not None:
             out += self.shared_expert(x)
-        return out
+
+        return out, expert_ids
 
 
 class Qwen3MoeDecoderLayer(JaxModule):
@@ -190,7 +195,7 @@ class Qwen3MoeDecoderLayer(JaxModule):
         kv_cache: jax.Array,
         x: jax.Array,
         attention_metadata: AttentionMetadata,
-    ) -> Tuple[jax.Array, jax.Array]:
+    ) -> Tuple[jax.Array, jax.Array, Optional[jax.Array]]:
         hidden_states = self.input_layernorm(x)
         kv_cache, attn_output = self.self_attn(
             kv_cache,
@@ -201,9 +206,15 @@ class Qwen3MoeDecoderLayer(JaxModule):
 
         residual = attn_output
         attn_output = self.post_attention_layernorm(attn_output)
-        outputs = self.mlp(attn_output)
-        outputs = residual + outputs
-        return kv_cache, outputs
+
+        expert_ids = None
+        mlp_output = self.mlp(attn_output)
+        if isinstance(mlp_output, tuple):
+            mlp_output, expert_ids = mlp_output
+
+        outputs = residual + mlp_output
+
+        return kv_cache, outputs, expert_ids
 
 
 class Qwen3MoeModel(JaxModule):
@@ -272,7 +283,8 @@ class Qwen3MoeModel(JaxModule):
         input_ids: jax.Array,
         attention_metadata: AttentionMetadata,
         inputs_embeds: Optional[jax.Array] = None,
-    ) -> Tuple[List[jax.Array], jax.Array]:
+    ) -> Tuple[List[jax.Array], jax.Array] | Tuple[List[jax.Array], jax.Array,
+                                                   jax.Array]:
         if self.is_first_rank:
             assert inputs_embeds is None
             inputs_embeds = self.embed_tokens(input_ids)
@@ -281,18 +293,23 @@ class Qwen3MoeModel(JaxModule):
 
         x = inputs_embeds
         new_kv_caches = []
+        all_expert_ids = []
         for i, layer in enumerate(self.layers):
             if isinstance(layer, PPMissingLayer):
                 new_kv_caches.append(kv_caches[i])
                 continue
             kv_cache = kv_caches[i]
-            kv_cache, x = layer(kv_cache, x, attention_metadata)
+            kv_cache, x, expert_ids = layer(kv_cache, x, attention_metadata)
+            if expert_ids is not None:
+                all_expert_ids.append(expert_ids)
             new_kv_caches.append(kv_cache)
 
         if self.is_last_rank:
             x = self.norm(x)
 
-        return new_kv_caches, x
+        stacked_expert_ids = jnp.stack(all_expert_ids,
+                                       axis=0) if all_expert_ids else None
+        return new_kv_caches, x, stacked_expert_ids
 
 
 class Qwen3MoeForCausalLM(JaxModule, LoadableWithIterator):
@@ -340,19 +357,21 @@ class Qwen3MoeForCausalLM(JaxModule, LoadableWithIterator):
         is_last_rank: bool = True,
         *args,
     ) -> Tuple[List[jax.Array], jax.Array | JaxIntermediateTensors,
-               List[jax.Array]]:
+               List[jax.Array], Optional[jax.Array]]:
         if not is_first_rank:
             assert intermediate_tensors is not None
             inputs_embeds = intermediate_tensors["hidden_states"]
-        kv_caches, x = self.model(
+        kv_caches, x, expert_indices = self.model(
             kv_caches,
             input_ids,
             attention_metadata,
             inputs_embeds,
         )
+
         if not is_last_rank:
             x = JaxIntermediateTensors(tensors={"hidden_states": x}, )
-        return kv_caches, x, []
+
+        return kv_caches, x, [], expert_indices
 
     def compute_logits(self, hidden_states: jax.Array) -> jax.Array:
         if hasattr(self, 'lm_head'):

--- a/tpu_inference/models/jax/qwen3_moe.py
+++ b/tpu_inference/models/jax/qwen3_moe.py
@@ -109,6 +109,7 @@ class Qwen3MoeSparseMoeBlock(JaxModule):
             hidden_act=config.hidden_act,
             rngs=rng,
             router=self.gate,
+            num_experts_per_tok=config.num_experts_per_tok,
             mesh=mesh,
             activation_ffw_td=P(ShardingAxisName.MLP_DATA, None),
             activation_ffw_ted=P(ShardingAxisName.MLP_DATA, None, None),

--- a/tpu_inference/models/vllm/vllm_model_wrapper.py
+++ b/tpu_inference/models/vllm/vllm_model_wrapper.py
@@ -270,17 +270,16 @@ class VllmModelWrapper:
         return jax_view(params_and_buffers), lora_manager
 
     def jit_step_func(self):
-        out_shardings = [
-            None,  # kv_caches - keep original sharding
-            NamedSharding(self.mesh,
-                          PartitionSpec(ShardingAxisName.ATTN_DATA, None)),
-            None,  # empty list
-            None,  # expert ids
-        ]
 
         @jax.jit(
             donate_argnames=("kv_caches", ),
-            out_shardings=tuple(out_shardings),
+            out_shardings=(
+                None,  # kv_caches - keep original sharding
+                NamedSharding(self.mesh,
+                              PartitionSpec(ShardingAxisName.ATTN_DATA, None)),
+                None,  # empty list
+                None,  # expert ids
+            ),
             compiler_options={
                 "xla_tpu_all_gather_collective_matmul_mode":
                 "post_spmd_conservative",

--- a/tpu_inference/models/vllm/vllm_model_wrapper.py
+++ b/tpu_inference/models/vllm/vllm_model_wrapper.py
@@ -312,9 +312,10 @@ class VllmModelWrapper:
             with torchax.default_env(), set_vllm_model_wrapper_context(
                     kv_caches=kv_caches,
                     mesh=self.mesh,
-                    layer_name_to_kvcache_index=layer_name_to_kvcache_index
-            ), set_forward_context(attn_metadata=attn_metadata,
-                                   vllm_config=self.vllm_config):
+                    layer_name_to_kvcache_index=layer_name_to_kvcache_index,
+                    vllm_config=self.vllm_config), set_forward_context(
+                        attn_metadata=attn_metadata,
+                        vllm_config=self.vllm_config):
                 # We need to wrap args from jax land into TorchValue with
                 # torch_view in order to call the Torch function.
                 original_lora_metadata = replace_lora_metadata(

--- a/tpu_inference/models/vllm/vllm_model_wrapper.py
+++ b/tpu_inference/models/vllm/vllm_model_wrapper.py
@@ -366,6 +366,7 @@ class VllmModelWrapper:
                 NamedSharding(self.mesh,
                               PartitionSpec(ShardingAxisName.ATTN_DATA, None)),
                 None,  # list of aux hidden states
+                None,  # expert ids
             ),
             compiler_options={
                 "xla_tpu_all_gather_collective_matmul_mode":
@@ -382,7 +383,8 @@ class VllmModelWrapper:
             hidden_states: jax.Array,
             attn_metadata: AttentionMetadata,
             layer_name_to_kvcache_index: Sequence[Tuple[str, int]],
-        ) -> Tuple[List[jax.Array], jax.Array, List[jax.Array]]:
+        ) -> Tuple[List[jax.Array], jax.Array, List[jax.Array],
+                   Optional[jax.Array]]:
             layer_name_to_kvcache_index = dict(layer_name_to_kvcache_index)
             with torchax.default_env(), set_vllm_model_wrapper_context(
                     kv_caches=kv_caches,
@@ -407,7 +409,7 @@ class VllmModelWrapper:
             hidden_states, hidden_prenorm = output_from_torch
             hidden_states = jax_view(hidden_states)
             hidden_prenorm = jax_view(hidden_prenorm)
-            return new_kv_caches, hidden_states, [hidden_prenorm]
+            return new_kv_caches, hidden_states, [hidden_prenorm], None
 
         return draft_step_fun if self.is_draft_model else step_fun
 

--- a/tpu_inference/models/vllm/vllm_model_wrapper.py
+++ b/tpu_inference/models/vllm/vllm_model_wrapper.py
@@ -270,15 +270,17 @@ class VllmModelWrapper:
         return jax_view(params_and_buffers), lora_manager
 
     def jit_step_func(self):
+        out_shardings = [
+            None,  # kv_caches - keep original sharding
+            NamedSharding(self.mesh,
+                          PartitionSpec(ShardingAxisName.ATTN_DATA, None)),
+            None,  # empty list
+            None,  # expert ids
+        ]
 
         @jax.jit(
             donate_argnames=("kv_caches", ),
-            out_shardings=(
-                None,  # kv_caches - keep original sharding
-                NamedSharding(self.mesh,
-                              PartitionSpec(ShardingAxisName.ATTN_DATA, None)),
-                None,  # empty list
-            ),
+            out_shardings=tuple(out_shardings),
             compiler_options={
                 "xla_tpu_all_gather_collective_matmul_mode":
                 "post_spmd_conservative",
@@ -304,7 +306,8 @@ class VllmModelWrapper:
             is_first_rank: bool = True,
             is_last_rank: bool = True,
             *args,
-        ) -> Tuple[List[jax.Array], jax.Array, List[jax.Array]]:
+        ) -> Tuple[List[jax.Array], jax.Array, List[jax.Array]] | Tuple[
+                List[jax.Array], jax.Array, List[jax.Array], jax.Array]:
             layer_name_to_kvcache_index = dict(layer_name_to_kvcache_index)
             lora_metadata = torch_view(lora_metadata)
             with torchax.default_env(), set_vllm_model_wrapper_context(
@@ -334,6 +337,10 @@ class VllmModelWrapper:
                                       self.vllm_config.lora_config)
                 vllm_model_wrapper_context = get_vllm_model_wrapper_context()
                 new_kv_caches = vllm_model_wrapper_context.kv_caches
+
+                expert_indices_list = getattr(vllm_model_wrapper_context,
+                                              "expert_indices_list", [])
+
             # Wrap the output(hidden states or intermediate tensor)
             # from torch land into a JaxValue for the jax code to consume.
             aux_hidden_states = []
@@ -344,7 +351,13 @@ class VllmModelWrapper:
                     output, aux_hidden_states = jax_view(output_from_torch)
                 else:
                     output = jax_view(output_from_torch)
-            return new_kv_caches, output, aux_hidden_states
+
+            if expert_indices_list:
+                import jax.numpy as jnp
+                expert_indices = jnp.stack(expert_indices_list, axis=0)
+            else:
+                expert_indices = None
+            return new_kv_caches, output, aux_hidden_states, expert_indices
 
         @jax.jit(
             donate_argnames=("kv_caches", ),

--- a/tpu_inference/models/vllm/vllm_model_wrapper_context.py
+++ b/tpu_inference/models/vllm/vllm_model_wrapper_context.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from contextlib import contextmanager
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Dict, List, Optional
 
 import jax
@@ -25,6 +25,7 @@ class VllmModelWrapperContext:
     kv_caches: List[jax.Array]
     mesh: Mesh
     layer_name_to_kvcache_index: Dict[str, int]
+    expert_indices_list: List[jax.Array] = field(default_factory=list)
 
 
 _vllm_model_wrapper_context: Optional[VllmModelWrapperContext] = None

--- a/tpu_inference/models/vllm/vllm_model_wrapper_context.py
+++ b/tpu_inference/models/vllm/vllm_model_wrapper_context.py
@@ -18,6 +18,7 @@ from typing import Dict, List, Optional
 
 import jax
 from jax.sharding import Mesh
+from vllm.config import VllmConfig
 
 
 @dataclass
@@ -25,6 +26,7 @@ class VllmModelWrapperContext:
     kv_caches: List[jax.Array]
     mesh: Mesh
     layer_name_to_kvcache_index: Dict[str, int]
+    vllm_config: Optional[VllmConfig] = None
     expert_indices_list: List[jax.Array] = field(default_factory=list)
 
 
@@ -45,6 +47,7 @@ def set_vllm_model_wrapper_context(
     kv_caches: List[jax.Array],
     mesh: Mesh,
     layer_name_to_kvcache_index: Dict[str, int] = None,
+    vllm_config: Optional[VllmConfig] = None,
 ):
     global _vllm_model_wrapper_context
     prev_context = _vllm_model_wrapper_context
@@ -52,6 +55,7 @@ def set_vllm_model_wrapper_context(
         kv_caches=kv_caches,
         mesh=mesh,
         layer_name_to_kvcache_index=layer_name_to_kvcache_index,
+        vllm_config=vllm_config,
     )
 
     try:

--- a/tpu_inference/platforms/tpu_platform.py
+++ b/tpu_inference/platforms/tpu_platform.py
@@ -289,51 +289,9 @@ class TpuPlatform(Platform):
             update_vllm_config_for_dp_scheduler
         update_vllm_config_for_dp_scheduler(vllm_config)
 
-        # Monkeypatch vLLM Scheduler to attach expert indices to outputs
-        from vllm.v1.core.sched.scheduler import Scheduler
-
-        original_update_from_output = Scheduler.update_from_output
-
-        def custom_update_from_output(self, scheduler_output,
-                                      model_runner_output):
-            expert_indices = getattr(model_runner_output, "expert_indices",
-                                     None)
-
-            if expert_indices is not None:
-                num_scheduled_tokens = scheduler_output.num_scheduled_tokens
-                current_token_offset = 0
-                for req_id, num_tokens_scheduled in num_scheduled_tokens.items(
-                ):
-                    start_idx = current_token_offset
-                    end_idx = start_idx + num_tokens_scheduled
-                    current_token_offset = end_idx
-
-                    request = self.requests.get(req_id)
-                    if request is not None:
-                        step_experts = expert_indices[:, start_idx:
-                                                      end_idx, :].transpose(
-                                                          1, 0, 2)
-                        if not hasattr(request, "_accumulated_routed_experts"):
-                            request._accumulated_routed_experts = []
-                        request._accumulated_routed_experts.append(
-                            step_experts)
-
-            return original_update_from_output(self, scheduler_output,
-                                               model_runner_output)
-
-        Scheduler.update_from_output = custom_update_from_output
-
-        original_get_routed_experts = Scheduler._get_routed_experts
-
-        def custom_get_routed_experts(self, request):
-            if hasattr(request, "_accumulated_routed_experts"
-                       ) and request._accumulated_routed_experts:
-                import numpy as np
-                return np.concatenate(request._accumulated_routed_experts,
-                                      axis=0)
-            return original_get_routed_experts(self, request)
-
-        Scheduler._get_routed_experts = custom_get_routed_experts
+        from tpu_inference.core.sched.utils import \
+            update_vllm_scheduler_for_exporting_expert_ids
+        update_vllm_scheduler_for_exporting_expert_ids()
 
     @classmethod
     def update_block_size_for_backend(cls, vllm_config: VllmConfig) -> None:

--- a/tpu_inference/platforms/tpu_platform.py
+++ b/tpu_inference/platforms/tpu_platform.py
@@ -289,6 +289,52 @@ class TpuPlatform(Platform):
             update_vllm_config_for_dp_scheduler
         update_vllm_config_for_dp_scheduler(vllm_config)
 
+        # Monkeypatch vLLM Scheduler to attach expert indices to outputs
+        from vllm.v1.core.sched.scheduler import Scheduler
+
+        original_update_from_output = Scheduler.update_from_output
+
+        def custom_update_from_output(self, scheduler_output,
+                                      model_runner_output):
+            expert_indices = getattr(model_runner_output, "expert_indices",
+                                     None)
+
+            if expert_indices is not None:
+                num_scheduled_tokens = scheduler_output.num_scheduled_tokens
+                current_token_offset = 0
+                for req_id, num_tokens_scheduled in num_scheduled_tokens.items(
+                ):
+                    start_idx = current_token_offset
+                    end_idx = start_idx + num_tokens_scheduled
+                    current_token_offset = end_idx
+
+                    request = self.requests.get(req_id)
+                    if request is not None:
+                        step_experts = expert_indices[:, start_idx:
+                                                      end_idx, :].transpose(
+                                                          1, 0, 2)
+                        if not hasattr(request, "_accumulated_routed_experts"):
+                            request._accumulated_routed_experts = []
+                        request._accumulated_routed_experts.append(
+                            step_experts)
+
+            return original_update_from_output(self, scheduler_output,
+                                               model_runner_output)
+
+        Scheduler.update_from_output = custom_update_from_output
+
+        original_get_routed_experts = Scheduler._get_routed_experts
+
+        def custom_get_routed_experts(self, request):
+            if hasattr(request, "_accumulated_routed_experts"
+                       ) and request._accumulated_routed_experts:
+                import numpy as np
+                return np.concatenate(request._accumulated_routed_experts,
+                                      axis=0)
+            return original_get_routed_experts(self, request)
+
+        Scheduler._get_routed_experts = custom_get_routed_experts
+
     @classmethod
     def update_block_size_for_backend(cls, vllm_config: VllmConfig) -> None:
         # TODO: TPU still sets block_size in check_and_update_config.

--- a/tpu_inference/runner/compilation_manager.py
+++ b/tpu_inference/runner/compilation_manager.py
@@ -246,14 +246,12 @@ class CompilationManager:
             is_first_rank,
             is_last_rank,
         ):
-            outputs = self.runner.model_fn(state, kv_caches, input_ids,
-                                           attention_metadata, inputs_embeds,
-                                           positions,
-                                           layer_name_to_kvcache_index,
-                                           lora_metadata, intermediate_tensors,
-                                           is_first_rank, is_last_rank)
-            self.runner.kv_caches = outputs[0]
-            return outputs[1]
+            kv_caches, hidden_states, *_ = self.runner.model_fn(
+                state, kv_caches, input_ids, attention_metadata, inputs_embeds,
+                positions, layer_name_to_kvcache_index, lora_metadata,
+                intermediate_tensors, is_first_rank, is_last_rank)
+            self.runner.kv_caches = kv_caches
+            return hidden_states
 
         with self.runner.maybe_select_dummy_loras(
                 self.runner.lora_config, np.array([num_tokens],

--- a/tpu_inference/runner/compilation_manager.py
+++ b/tpu_inference/runner/compilation_manager.py
@@ -246,12 +246,14 @@ class CompilationManager:
             is_first_rank,
             is_last_rank,
         ):
-            kv_caches, hidden_states, _ = self.runner.model_fn(
-                state, kv_caches, input_ids, attention_metadata, inputs_embeds,
-                positions, layer_name_to_kvcache_index, lora_metadata,
-                intermediate_tensors, is_first_rank, is_last_rank)
-            self.runner.kv_caches = kv_caches
-            return hidden_states
+            outputs = self.runner.model_fn(state, kv_caches, input_ids,
+                                           attention_metadata, inputs_embeds,
+                                           positions,
+                                           layer_name_to_kvcache_index,
+                                           lora_metadata, intermediate_tensors,
+                                           is_first_rank, is_last_rank)
+            self.runner.kv_caches = outputs[0]
+            return outputs[1]
 
         with self.runner.maybe_select_dummy_loras(
                 self.runner.lora_config, np.array([num_tokens],

--- a/tpu_inference/runner/compilation_manager.py
+++ b/tpu_inference/runner/compilation_manager.py
@@ -885,7 +885,7 @@ class CompilationManager:
                 attention_metadata,
                 layer_name_to_kvcache_index,
             ):
-                kv_caches, hidden_states, _ = self.runner.drafter.model_fn(
+                kv_caches, hidden_states, _, _ = self.runner.drafter.model_fn(
                     state, kv_caches, input_ids, draft_hidden_states,
                     attention_metadata, layer_name_to_kvcache_index)
                 self.runner.kv_caches = kv_caches

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -111,6 +111,8 @@ class AsyncTPUModelRunnerOutput(AsyncModelRunnerOutput):
         discard_sampled_tokens_req_indices: list[int],
         logits_indices_selector: Optional[List[int]] = None,
         logprobs_tensors: Optional[LogprobsTensors] = None,
+        expert_indices: Optional[jax.Array] = None,
+        total_num_scheduled_tokens: int = 0,
     ):
         self._model_runner_output = model_runner_output
         self._next_tokens = next_tokens
@@ -118,6 +120,8 @@ class AsyncTPUModelRunnerOutput(AsyncModelRunnerOutput):
         self._discard_sampled_tokens_req_indices = discard_sampled_tokens_req_indices
         self.logits_indices_selector: list[int] = logits_indices_selector
         self._logprobs_tensors = logprobs_tensors
+        self._expert_indices = expert_indices
+        self._total_num_scheduled_tokens = total_num_scheduled_tokens
 
     def get_output(self) -> ModelRunnerOutput:
         next_tokens_cpu = np.asarray(jax.device_get(self._next_tokens))
@@ -134,6 +138,13 @@ class AsyncTPUModelRunnerOutput(AsyncModelRunnerOutput):
             # Use materialize to ensure logprobs are ready on host when we return async results
             self._model_runner_output.logprobs = _jax_logprobs_materialize(
                 self._logprobs_tensors, self.logits_indices_selector)
+
+        if self._expert_indices is not None:
+            expert_indices_cpu = np.asarray(
+                jax.device_get(self._expert_indices))
+            expert_indices_cpu = expert_indices_cpu[:, :self.
+                                                    _total_num_scheduled_tokens, :]
+            self._model_runner_output.expert_indices = expert_indices_cpu
 
         return self._model_runner_output
 
@@ -164,6 +175,7 @@ class ExecuteModelState:
     kv_connector_output: Optional[KVConnectorOutput]
     logits_indices_selector: Optional[List[int]] = None
     padded_num_reqs: Optional[int] = None
+    expert_indices: Optional[jax.Array] = None
 
 
 @jax.jit(donate_argnums=(0, 1, 2))
@@ -676,18 +688,19 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
 
         (scheduler_output, attn_metadata, sampling_metadata, input_ids,
          hidden_states, logits, aux_hidden_states, spec_decode_metadata,
-         kv_connector_output, logits_indices_selector,
-         padded_num_reqs) = (self.execute_model_state.scheduler_output,
-                             self.execute_model_state.attn_metadata,
-                             self.execute_model_state.sampling_metadata,
-                             self.execute_model_state.input_ids,
-                             self.execute_model_state.hidden_states,
-                             self.execute_model_state.logits,
-                             self.execute_model_state.aux_hidden_states,
-                             self.execute_model_state.spec_decode_metadata,
-                             self.execute_model_state.kv_connector_output,
-                             self.execute_model_state.logits_indices_selector,
-                             self.execute_model_state.padded_num_reqs)
+         kv_connector_output, logits_indices_selector, padded_num_reqs,
+         expert_indices) = (self.execute_model_state.scheduler_output,
+                            self.execute_model_state.attn_metadata,
+                            self.execute_model_state.sampling_metadata,
+                            self.execute_model_state.input_ids,
+                            self.execute_model_state.hidden_states,
+                            self.execute_model_state.logits,
+                            self.execute_model_state.aux_hidden_states,
+                            self.execute_model_state.spec_decode_metadata,
+                            self.execute_model_state.kv_connector_output,
+                            self.execute_model_state.logits_indices_selector,
+                            self.execute_model_state.padded_num_reqs,
+                            self.execute_model_state.expert_indices)
         self.execute_model_state = None
 
         if grammar_output is not None:
@@ -704,7 +717,8 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         return self._sample_from_logits(
             scheduler_output, attn_metadata, sampling_metadata, input_ids,
             hidden_states, logits, aux_hidden_states, spec_decode_metadata,
-            kv_connector_output, logits_indices_selector, padded_num_reqs)
+            kv_connector_output, logits_indices_selector, padded_num_reqs,
+            expert_indices)
 
     def _modify_prev_results(self):
         # If copy to host has not been done, we just wait.
@@ -854,8 +868,8 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                     scheduler_output) as kv_connector_output:
                 # NOTE(Wenlong): It takes both `input_ids` and `inputs_embeds`,
                 # but one of them would be `None`
-                (self.kv_caches, hidden_states,
-                 aux_hidden_states) = self.model_fn(
+                (self.kv_caches, hidden_states, aux_hidden_states,
+                 expert_indices) = self.model_fn(
                      self.state,
                      self.kv_caches,
                      input_ids,
@@ -871,6 +885,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             if not self.is_last_rank:
                 assert isinstance(hidden_states, JaxIntermediateTensors)
                 hidden_states.kv_connector_output = kv_connector_output
+                hidden_states.expert_indices = expert_indices
                 return hidden_states
 
             if self.is_pooling_model:
@@ -912,7 +927,8 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             spec_decode_metadata=spec_decode_metadata,
             kv_connector_output=kv_connector_output,
             logits_indices_selector=logits_indices_selector,
-            padded_num_reqs=padded_num_reqs)
+            padded_num_reqs=padded_num_reqs,
+            expert_indices=expert_indices)
         return None
 
     def _sample_from_logits(
@@ -928,6 +944,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         kv_connector_output: Optional[KVConnectorOutput],
         logits_indices_selector: Optional[List[int]] = None,
         padded_num_reqs: Optional[int] = None,
+        expert_indices: Optional[jax.Array] = None,
     ) -> ModelRunnerOutput | AsyncTPUModelRunnerOutput:
         if padded_num_reqs is None:
             padded_num_reqs = runner_utils.get_padded_num_reqs_with_upper_limit(
@@ -1064,7 +1081,10 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                 num_reqs,
                 discard_sampled_tokens_req_indices,
                 logits_indices_selector,
-                logprobs_tensors=logprobs)
+                logprobs_tensors=logprobs,
+                expert_indices=expert_indices,
+                total_num_scheduled_tokens=scheduler_output.
+                total_num_scheduled_tokens)
             return async_model_runner_output
 
         if spec_decode_metadata is None:
@@ -1129,6 +1149,14 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             pooler_output=[],
             kv_connector_output=kv_connector_output,
         )
+
+        if expert_indices is not None:
+            expert_indices_cpu = np.asarray(jax.device_get(expert_indices))
+            # Slice to actual scheduled tokens
+            actual_t = scheduler_output.total_num_scheduled_tokens
+            expert_indices_cpu = expert_indices_cpu[:, :actual_t, :]
+            model_runner_output.expert_indices = expert_indices_cpu
+
         return model_runner_output
 
     @jax.jit(static_argnums=(0, ))

--- a/tpu_inference/spec_decode/jax/eagle3.py
+++ b/tpu_inference/spec_decode/jax/eagle3.py
@@ -430,7 +430,7 @@ class Eagle3Proposer:
         """
 
         # input_ids and target_hidden_states for the first speculation have been prepared in prepare_inputs() to improve performance.
-        kv_caches, hidden_states, residual = self.model_fn(
+        kv_caches, hidden_states, residual, _ = self.model_fn(
             self.state,
             kv_caches,
             input_ids,
@@ -462,7 +462,7 @@ class Eagle3Proposer:
                 query_start_loc=query_start_loc,
                 block_tables=new_block_tables,
             )
-            kv_caches, new_hidden_states, residual = self.model_fn(
+            kv_caches, new_hidden_states, residual, _ = self.model_fn(
                 self.state,
                 kv_caches,
                 input_ids_loop,


### PR DESCRIPTION
# Description

Introduced enable_return_routed_experts flag in vllm_config.additional_config to gate the feature.

Monkeypatched vLLM Scheduler in TpuPlatform to accumulate routed experts per request and expose them via _get_routed_experts.

Added examples/rl_inference.py to demonstrate how to enable and access routed experts.

## Jax Integration

Updated JaxMoE, SharedFusedMoe, and GptOssMoE to return selected expert indices when the flag is enabled.

Updated DeepSeek V3, Qwen, Llama, and GPT-OSS models to propagate expert indices from the layers to the model output.

## vLLM Integration

Updated VllmModelWrapper to capture expert indices from the JAX model execution.

Updated TPUModelRunner to pass expert indices to ModelRunnerOutput and AsyncTPUModelRunnerOutput.


# Tests

```
VLLM_LOGGING_LEVEL=DEBUG MODEL_IMPL_TYPE=vllm SKIP_JAX_PRECOMPILE=1 python examples/rl_inference.py --model Qwen/Qwen3-30B-A3B-Instruct-2507

VLLM_LOGGING_LEVEL=DEBUG MODEL_IMPL_TYPE=flax_nnx SKIP_JAX_PRECOMPILE=1 python examples/rl_inference.py --model Qwen/Qwen3-30B-A3B-Instruct-2507


Routed experts shape: (54, 48, 8)
First token expert selection: [[  2  80  21  50  75  63   6  13]
 [ 68 114  55   9  90   0   2  77]
 [ 92  77  10  24  41  81 115   6]
 [ 82 107  85 108 118   3  12  43]
...
```

## Profiling

```
SKIP_JAX_PRECOMPILE=1 MODEL_IMPL_TYPE=vllm python3 examples/tpu_profiling.py --model=Qwen/Qwen3-30B-A3B-Instruct-2507 --profile-result-dir=gs://piv-test/tpu-profile/apr21/1/ --data_parallel_size=8
```

### VLLM model

Before:

DP=1 https://xprof.corp.google.com/trace_viewer/piv-5545336954580425898

DP=8 https://xprof.corp.google.com/trace_viewer/piv-4468558515990429569

After:

DP=1 http://xprof.corp.google.com/trace_viewer/piv-9445721038490436399

DP=8 https://xprof.corp.google.com/trace_viewer/piv-835213929589036340

### Jax model, no async scheduling

Before:

DP=1 https://xprof.corp.google.com/trace_viewer/piv-8963587991025540411

DP=8 https://xprof.corp.google.com/trace_viewer/piv-8218184325748750091

After:

DP=1 http://xprof.corp.google.com/trace_viewer/piv-6800893088604483396

DP=8 http://xprof.corp.google.com/trace_viewer/piv-580454236464879461

For DP=1 it is a 200 microseconds increase per cpu cycle from the extra `device_get`, for DP=8 it was around 400 microseconds.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
