### PR TITLE
[CI] Enhance YAML pipeline validation with custom metadata audits

### DIFF
--- a/.buildkite/scripts/bootstrap.sh
+++ b/.buildkite/scripts/bootstrap.sh
@@ -92,6 +92,14 @@ if [ "$BUILDKITE_PULL_REQUEST" != "false" ]; then
       echo "Code files changed. Proceeding with pipeline upload."
     fi
     
+    # Validate custom pipeline metadata (Uniqueness & Completeness)
+    if .buildkite/scripts/validate_pipeline_metadata.sh "$NON_SKIPPABLE_FILES"; then
+      echo "Pipeline metadata validation passed."
+    else
+      echo "+++ ❌ Pipeline metadata validation failed. Failing build."
+      exit 1
+    fi
+
     # Validate modified YAML pipelines using bk pipeline validate
     if .buildkite/scripts/validate_buildkite_ymls.sh "$NON_SKIPPABLE_FILES"; then
       echo "All pipelines syntax are valid. Proceeding with pipeline upload."

--- a/.buildkite/scripts/validate_buildkite_ymls.sh
+++ b/.buildkite/scripts/validate_buildkite_ymls.sh
@@ -19,24 +19,30 @@ set -euo pipefail
 # Assign the first argument to a local variable
 RAW_FILES_TO_CHECK="${1:-}"
 
-# Define directory path for non-pipeline YAML files to skip during Buildkite validation
-# Exclude the benchmark/lm_eval directory as it contains YAML files that are not Buildkite pipelines
-EXCLUDE_PATTERN="\.buildkite/benchmark/lm_eval/.*\.ya?ml$"
+# Define directories relative to the repo root for exact matching
+EXCLUDED_FOLDERS=(
+    "\.buildkite/kubernetes/"
+    "\.buildkite/benchmark/lm_eval/"
+)
 
-# Pre-filter: Only include .yml or .yaml files located within the .buildkite/ directory
-# Using '|| true' to prevent the script from exiting if no matches are found
-# This automatically ignores .github/, root level yamls, etc.
-YAML_FILES_TO_CHECK=$(echo "$RAW_FILES_TO_CHECK" | grep -E "^\.buildkite/.*\.ya?ml$" | grep -vE "$EXCLUDE_PATTERN" || true)
+# Convert the array into a pipe-separated string for regex
+EXCLUDE_PATTERN=$(printf "|%s" "${EXCLUDED_FOLDERS[@]}")
+EXCLUDE_PATTERN=${EXCLUDE_PATTERN:1}
+
+# Filter: Include YAML files in .buildkite/ while skipping excluded patterns
+YAML_FILES_TO_CHECK=$(echo "$RAW_FILES_TO_CHECK" | \
+    grep -E "^\.buildkite/.*\.ya?ml$" | \
+    grep -Ev "^($EXCLUDE_PATTERN)" || true)
 
 # Early exit: If no YAML files were modified, skip validation
 if [ -z "$YAML_FILES_TO_CHECK" ]; then
-    echo "--- :crossed_fingers: No YAML changes detected. Skipping validation."
+    echo "--- :fast_forward: No applicable YAML changes found (none detected or all excluded). Skipping validation."
     exit 0
 fi
 
 VALIDATE_ARGS=()
 
-echo "--- 📂 Preparing files for validation"
+echo "--- 📂 Preparing all files for validation"
 
 # Iterate through the list to build the arguments array and check file existence
 while IFS= read -r file; do
@@ -54,7 +60,7 @@ while IFS= read -r file; do
 
 done < <(echo "$YAML_FILES_TO_CHECK")
 
-echo "--- 🔍 Validating changed YAML files"
+echo "--- 🔍 Executing Buildkite syntax validation..."
 if [ ${#VALIDATE_ARGS[@]} -gt 0 ]; then
     # TODO: Currently using standard 'bk pipeline validate' for syntax checking.
     # In the future, this could be extended to include more complex validation logic.
@@ -63,7 +69,7 @@ if [ ${#VALIDATE_ARGS[@]} -gt 0 ]; then
         echo "Result: FAIL (Please fix the YAML syntax errors above)"
         exit 1
     else
-        echo "+++ ✅ Validation Successful"
+        echo "+++ ✅ YAML syntax validation passed."
         echo "Result: SUCCESS"
         exit 0
     fi

--- a/.buildkite/scripts/validate_pipeline_metadata.sh
+++ b/.buildkite/scripts/validate_pipeline_metadata.sh
@@ -1,0 +1,167 @@
+#!/bin/bash
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Exit on error, exit on unset variable, fail on pipe errors.
+set -euo pipefail
+
+RAW_FILES_TO_CHECK="${1:-}"
+BUILDKITE_DIR=".buildkite"
+
+# Define directories relative to the repo root for exact matching
+EXCLUDED_FOLDERS=(
+    "\.buildkite/kubernetes/"
+    "\.buildkite/benchmark/lm_eval/"
+)
+
+# Convert the array into a pipe-separated string for regex
+EXCLUDE_PATTERN=$(printf "|%s" "${EXCLUDED_FOLDERS[@]}")
+EXCLUDE_PATTERN=${EXCLUDE_PATTERN:1}
+
+# Filter: Include YAML files in .buildkite/ while skipping excluded patterns
+YAML_FILES_TO_CHECK=$(echo "$RAW_FILES_TO_CHECK" | \
+    grep -E "^\.buildkite/.*\.ya?ml$" | \
+    grep -Ev "^($EXCLUDE_PATTERN)" || true)
+
+# Early exit: If no YAML files were modified, skip validation
+if [ -z "$YAML_FILES_TO_CHECK" ]; then
+    echo "--- :fast_forward: No applicable YAML changes found (none detected or all excluded). Skipping validation."
+    exit 0
+fi
+
+# Helper function to enforce that ALL occurrences of a field in a file are not empty.
+validate_all_entries() {
+    local label="$1"
+    local pattern="$2"
+    local file="$3"
+    local description="$4"
+
+    # Fetch all lines matching the pattern.
+    local lines
+    lines=$(grep -E "$pattern" "$file" || true)
+
+    # Ensure the field appears at least once in the file.
+    if [[ -z "$lines" ]]; then
+        echo "+++ ❌ Error: Missing mandatory field '$label' in $file"
+        echo "💡 Tip: $description"
+        exit 1
+    fi
+
+    # Iterate through every match to check for empty values.
+    while IFS= read -r line; do
+        local val
+        # Extract value after colon, remove quotes, and trim whitespace.
+        val=$(echo "$line" | sed 's/^[^:]*:[[:space:]]*//' | tr -d '"'\' | xargs)
+        if [[ -z "$val" ]]; then
+            echo "+++ ❌ Error: Detected empty value for '$label' in $file"
+            echo "   Problematic line: $line"
+            echo "💡 Tip: $description"
+            exit 1
+        fi
+    done <<< "$lines"
+}
+
+# --- GLOBAL UNIQUENESS VALIDATION ---
+# Ensure that pipeline-name and CI_TARGET are unique across all spec directories
+declare -a SPEC_DIRS=("quantization" "parallelism" "models" "features" "rl")
+KERNEL_PARENT_DIR="$BUILDKITE_DIR/kernel_microbenchmarks"
+
+echo "--- 🌍 Scanning all spec folders for global metadata uniqueness..."
+
+if [[ -d "$KERNEL_PARENT_DIR" ]]; then
+    while IFS= read -r dir; do
+        SPEC_DIRS+=("${dir#"$BUILDKITE_DIR"/}")
+    done < <(find "$KERNEL_PARENT_DIR" -maxdepth 1 -mindepth 1 -type d)
+fi
+
+declare -A PIPELINE_NAMES
+declare -A CI_TARGETS
+
+for folder in "${SPEC_DIRS[@]}"; do
+    full_path="$BUILDKITE_DIR/$folder"
+    [[ ! -d "$full_path" ]] && continue
+
+    while IFS= read -r -d '' file; do
+        # Extract the primary pipeline-name for the file
+        P_NAME=$(awk '/^[[:space:]]*#[[:space:]]*pipeline-name:/ {print $0; exit}' "$file" | sed 's/^[^:]*:[[:space:]]*//' | xargs)
+        
+        # Global uniqueness check for pipeline-name
+        if [[ -n "$P_NAME" ]]; then
+            if [[ -n "${PIPELINE_NAMES[$P_NAME]:-}" && "${PIPELINE_NAMES[$P_NAME]}" != "$file" ]]; then
+                echo "+++ ❌ Error: Global duplicate '# pipeline-name: $P_NAME' detected!"
+                echo "Conflict: $file and ${PIPELINE_NAMES[$P_NAME]}"
+                echo "💡 Tip: The '# pipeline-name' comment must be unique across all configuration files. It serves as the display title in the support matrices. For models, ensure you use the full model name on Hugging Face (e.g., meta-llama/Llama-3.1-8B) to prevent name collisions."
+                exit 1
+            fi
+            PIPELINE_NAMES["$P_NAME"]="$file"
+        fi
+
+        # Global uniqueness check for CI_TARGET
+        while IFS= read -r line; do
+            t_val=$(echo "$line" | sed 's/^[^:]*:[[:space:]]*//' | tr -d '"'\' | xargs)
+            if [[ -n "$t_val" ]]; then
+                if [[ -n "${CI_TARGETS[$t_val]:-}" && "${CI_TARGETS[$t_val]}" != "$file" ]]; then
+                    echo "+++ ❌ Error: Global duplicate 'CI_TARGET: $t_val' detected!"
+                    echo "Conflict: $file and ${CI_TARGETS[$t_val]}"
+                    echo "💡 Tip: 'CI_TARGET' is the unique identifier used by the backend for result tracking. It must be distinct for every test configuration and must be identical to the '# pipeline-name' defined at the top of the file."
+                    exit 1
+                fi
+                CI_TARGETS["$t_val"]="$file"
+            fi
+        done < <(grep -E "^[[:space:]]*CI_TARGET:" "$file" || true)
+    done < <(find "$full_path" -maxdepth 1 -type f \( -name "*.yml" -o -name "*.yaml" \) -print0)
+done
+
+
+# --- METADATA COMPLETENESS & CONSISTENCY (Modified files only) ---
+echo "--- 📂 Checking metadata completeness and consistency for changed files"
+
+while IFS= read -r file; do
+    [ -z "$file" ] || [ ! -f "$file" ] && continue
+
+    # Check presence ONLY for changed files inside spec folders.
+    if [[ "$file" =~ ^\.buildkite/(quantization|parallelism|models|features|rl|kernel_microbenchmarks)/ ]]; then
+        echo "🔍 Verifying metadata for spec file: $file"
+
+        # Audit ALL entries to ensure no empty fields exist in any step.
+        validate_all_entries "pipeline-name"   "^[[:space:]]*#[[:space:]]*pipeline-name:" "$file" "This maps to the name displayed in support matrices. For models, use the full model name on Hugging Face (e.g., meta-llama/Llama-3.1-8B-Instruct). Acts as the canonical reference; every 'CI_TARGET' entry must match this value."
+        validate_all_entries "CI_TARGET"       "^[[:space:]]*CI_TARGET:"      "$file" "Identifier for result tracking. Every 'CI_TARGET' entry must be identical to the '# pipeline-name' defined at the top of the file."
+        validate_all_entries "CI_TPU_VERSION"  "^[[:space:]]*CI_TPU_VERSION:" "$file" "Specifies the TPU hardware generation (e.g., tpu6e, tpu7x) required for this test."
+        validate_all_entries "CI_STAGE"        "^[[:space:]]*CI_STAGE:"       "$file" "Defines the testing phase (e.g., UnitTest, Accuracy/Correctness, Benchmark, CorrectnessTest, PerformanceTest)."
+        validate_all_entries "CI_CATEGORY"     "^[[:space:]]*CI_CATEGORY:"    "$file" "Determines which support matrix (e.g., multimodal, text-only, feature support matrix) the results belong to."
+
+        # Consistency: Ensure all 'CI_TARGET' entries match the '# pipeline-name'.
+        # This also ensures all CI_TARGET entries in the same file are identical.
+        FILE_P_NAME=$(awk '/^[[:space:]]*#[[:space:]]*pipeline-name:/ {print $0; exit}' "$file" | sed 's/^[^:]*:[[:space:]]*//' | xargs)
+        while IFS= read -r line; do
+            [ -z "$line" ] && continue
+            FILE_T_VAL=$(echo "$line" | sed 's/^[^:]*:[[:space:]]*//' | tr -d '"'\' | xargs)
+            
+            if [[ "$FILE_T_VAL" != "$FILE_P_NAME" ]]; then
+                echo "+++ ❌ Error: Metadata mismatch detected in $file"
+                echo "   The '# pipeline-name' is: '$FILE_P_NAME'"
+                echo "   But a 'CI_TARGET' is set to: '$FILE_T_VAL'"
+                echo "💡 Tip: All 'CI_TARGET' entries in a file must be identical and match the '# pipeline-name' comment."
+                exit 1
+            fi
+        done < <(grep -E "^[[:space:]]*CI_TARGET:" "$file" || true)
+
+    else
+        echo "⏭️  Skipping metadata check for non-spec file: $file"
+    fi
+
+done < <(echo "$YAML_FILES_TO_CHECK")
+
+echo "+++ ✅ Metadata verification passed."
+exit 0


### PR DESCRIPTION
# Description

Enhance YAML pipeline validation with custom metadata audits:
1. Exclude all YAML files within the kubernetes/ directory from validation.
2. Ensure that pipeline-name and CI_TARGET are globally unique across all spec directories.
3. Verify that mandatory metadata fields (pipeline-name, CI_TARGET, CI_TPU_VERSION, CI_STAGE, and CI_CATEGORY) are present and non-empty in all modified pipelines.

# Tests

[Test: all yml](https://buildkite.com/tpu-commons/tpu-inference-ci/builds/15502/steps/canvas?sid=019db80d-e3e9-4a55-9538-4cd95059d617&tab=output)
[Test: kubernetes folder is excluded](https://buildkite.com/tpu-commons/tpu-inference-ci/builds/15502/steps/canvas?sid=019db80d-e3e9-4a55-9538-4cd95059d617&tab=output)

[Test: pipeline-name is empty](https://buildkite.com/tpu-commons/tpu-inference-ci/builds/15504/steps/canvas?sid=019db822-e82b-4ad5-86da-bf106064287c&tab=output)
[Test: CI_TPU_VERSION is empty](https://buildkite.com/tpu-commons/tpu-inference-ci/builds/15506/steps/canvas?sid=019db82c-6d4e-40ee-9331-493c159c6fd4&tab=output)


[Test: pipeline-name is duplicate](https://buildkite.com/tpu-commons/tpu-inference-ci/builds/15508/steps/canvas?sid=019db82d-befc-4419-bab4-cb868674c35b&tab=output)
[Test: CI_TARGET is duplicate](https://buildkite.com/tpu-commons/tpu-inference-ci/builds/15509/steps/canvas?sid=019db830-5637-427a-92bc-71cf9913efce&tab=output)

[Test: Pipeline name mismatch with CI_TARGET](https://buildkite.com/tpu-commons/tpu-inference-ci/builds/15510/steps/canvas?sid=019db832-5417-4c3c-bfef-0cf4c7eb7228&tab=output)
[Test: Differing CI_TARGET entries in one file](https://buildkite.com/tpu-commons/tpu-inference-ci/builds/15510/steps/canvas?sid=019db832-5417-4c3c-bfef-0cf4c7eb7228&tab=output)


# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
