### PR TITLE
[Bug][DeepSeek] Fix breakage from vllm#33892

### DIFF
--- a/tpu_inference/layers/vllm/quantization/fp8.py
+++ b/tpu_inference/layers/vllm/quantization/fp8.py
@@ -122,6 +122,26 @@ class VllmFp8LinearMethod(vllm_fp8.Fp8LinearMethod,
                 "Blockwise quantization is supported by quantized matmul kernel. Please enable quantized_matmul_kernel or unset the quantize block size to trigger XLA per-channel quantization."
             )
 
+    def create_weights(
+        self,
+        layer: torch.nn.Module,
+        input_size_per_partition: int,
+        output_partition_sizes: list[int],
+        input_size: int,
+        output_size: int,
+        params_dtype: torch.dtype,
+        **extra_weight_attrs,
+    ):
+        # Per https://github.com/vllm-project/vllm/pull/33892, use_marlin is set again
+        # in vllm/model_executor/layers/quantization/fp8.py `create_weights`.
+        # The flag is set on whether a specific type of GPU kernel is being used which
+        # means it is set to False for TPU.
+        # We need to return it back to True here.
+        super().create_weights(layer, input_size_per_partition,
+                               output_partition_sizes, input_size, output_size,
+                               params_dtype, **extra_weight_attrs)
+        self.use_marlin = True
+
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
         assert isinstance(layer, vllm_linear.LinearBase)
 


### PR DESCRIPTION
# Description
Per  [vLLM #33892](https://github.com/vllm-project/vllm/pull/33892), use_marlin is assigned
in vllm/model_executor/layers/quantization/fp8.py `create_weights`.
The boolean flag is assigned based on whether a specific type of GPU kernel is being used which
means it is set to False for TPU. This undoes the patch previously performed in https://github.com/vllm-project/tpu-inference/pull/2029 and is fixed again in this code push.

# Tests

Confirmed accuracy on MMLU and validated that perf remains the same with this fix.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
