### PR TITLE
[Gemma4] increase performance benchmark timeout in nightly test

### DIFF
--- a/.buildkite/models/google_gemma-4-31B-it.yml
+++ b/.buildkite/models/google_gemma-4-31B-it.yml
@@ -83,6 +83,7 @@ steps:
       TEST_MODEL: google/gemma-4-31B-it
       TENSOR_PARALLEL_SIZE: 8
       MINIMUM_THROUGHPUT_THRESHOLD: 2
+      TIMEOUT_SECONDS: 720
     # TODO(#2333): enable performance benchmark on v6e
     commands:
       - |

--- a/tests/e2e/benchmarking/mm_bench_recipe.sh
+++ b/tests/e2e/benchmarking/mm_bench_recipe.sh
@@ -22,7 +22,7 @@ dataset_name="random-mm"
 backend="openai-chat"
 num_prompts=128
 
-TIMEOUT_SECONDS=600
+TIMEOUT_SECONDS="${TIMEOUT_SECONDS:-600}"
 READY_MESSAGE="Application startup complete."
 LOG_FILE="server.log"
 BENCHMARK_LOG_FILE="benchmark.log"


### PR DESCRIPTION
# Description

In [nightly test](https://buildkite.com/tpu-commons/tpu-inference-ci/builds/15416#019db61c-5c48-4a11-b34d-8a068cbf2933/L1785) it times out, although I cannot reproduce locally.

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
