### PR TITLE
Fix forward n-d buffer with jitted unpack

### DIFF
--- a/tests/layers/jax/sample/test_sampling_metadata.py
+++ b/tests/layers/jax/sample/test_sampling_metadata.py
@@ -23,6 +23,31 @@ from jax.sharding import Mesh, NamedSharding, PartitionSpec
 from tpu_inference.layers.jax.sample.sampling_metadata import (
     DEFAULT_SAMPLING_PARAMS, TPUSupportedSamplingMetadata)
 
+
+def _create_sampling_metadata(mesh, mock_batch, padded_num_reqs, dp_size=1):
+    from tpu_inference.utils import DeviceBuffer
+    padded_num_reqs_per_dp_rank = padded_num_reqs // dp_size
+    buffer = DeviceBuffer(leading_shape=(dp_size, ), initial_capacity=1024)
+
+    TPUSupportedSamplingMetadata.add_to_device_buffer(
+        buffer=buffer,
+        input_batch=mock_batch,
+        padded_num_reqs_per_dp_rank=padded_num_reqs_per_dp_rank,
+        dp_size=dp_size)
+
+    blob, metadata_layout = buffer.build()
+    from tpu_inference.utils import device_array
+    sharding = NamedSharding(mesh, PartitionSpec(None, None))
+    blob_jax = device_array(mesh, blob, sharding=sharding)
+    unpacked_metadata = DeviceBuffer.unpack_arrays(blob_jax, metadata_layout)
+
+    return TPUSupportedSamplingMetadata.from_unpacked_blob(
+        mesh=mesh,
+        metadata=unpacked_metadata,
+        input_batch=mock_batch,
+        padded_num_reqs=padded_num_reqs)
+
+
 ## Mocks and Fixtures
 
 
@@ -58,8 +83,9 @@ def test_from_input_batch_all_greedy(mesh: Mesh):
     mock_batch = MockInputBatch(all_greedy=True)
     padded_num_reqs = 4
 
-    metadata = TPUSupportedSamplingMetadata.from_input_batch(
-        mesh=mesh, input_batch=mock_batch, padded_num_reqs=padded_num_reqs)
+    metadata = _create_sampling_metadata(mesh=mesh,
+                                         mock_batch=mock_batch,
+                                         padded_num_reqs=padded_num_reqs)
 
     assert not metadata.do_sampling, "do_sampling should be False for greedy requests"
     assert metadata.temperature is None
@@ -88,8 +114,9 @@ def test_from_input_batch_with_sampling_and_padding(mesh: Mesh):
         top_p_cpu=top_p_tensor,
     )
 
-    metadata = TPUSupportedSamplingMetadata.from_input_batch(
-        mesh=mesh, input_batch=mock_batch, padded_num_reqs=padded_num_reqs)
+    metadata = _create_sampling_metadata(mesh=mesh,
+                                         mock_batch=mock_batch,
+                                         padded_num_reqs=padded_num_reqs)
 
     # 1. Check metadata flags and types
     assert metadata.do_sampling, "do_sampling should be True"
@@ -103,7 +130,7 @@ def test_from_input_batch_with_sampling_and_padding(mesh: Mesh):
     assert metadata.top_p.shape == (padded_num_reqs, )
 
     # 3. Check sharding (should be fully replicated)
-    expected_sharding = NamedSharding(mesh, PartitionSpec(None))
+    expected_sharding = NamedSharding(mesh, PartitionSpec())
     assert metadata.temperature.sharding == expected_sharding
     assert metadata.top_k.sharding == expected_sharding
     assert metadata.top_p.sharding == expected_sharding
@@ -155,8 +182,9 @@ def test_from_input_batch_id_padding_needed(mesh: Mesh):
         top_p_cpu=top_p_tensor,
     )
 
-    metadata = TPUSupportedSamplingMetadata.from_input_batch(
-        mesh=mesh, input_batch=mock_batch, padded_num_reqs=padded_num_reqs)
+    metadata = _create_sampling_metadata(mesh=mesh,
+                                         mock_batch=mock_batch,
+                                         padded_num_reqs=padded_num_reqs)
 
     assert metadata.do_sampling
     # Check that values are identical to the input, since no padding was needed
@@ -204,9 +232,9 @@ def test_from_input_batch_with_logprobs(mesh: Mesh):
     # Case 1: Logprobs are requested
     mock_batch_with_logprobs = MockInputBatch(all_greedy=True,
                                               max_num_logprobs=5)
-    metadata_with = TPUSupportedSamplingMetadata.from_input_batch(
+    metadata_with = _create_sampling_metadata(
         mesh=mesh,
-        input_batch=mock_batch_with_logprobs,
+        mock_batch=mock_batch_with_logprobs,
         padded_num_reqs=4,
     )
     assert metadata_with.logprobs, "logprobs should be True when max_num_logprobs > 0"
@@ -214,9 +242,9 @@ def test_from_input_batch_with_logprobs(mesh: Mesh):
     # Case 2: Logprobs are not requested (max_num_logprobs is 0)
     mock_batch_id_logprobs_zero = MockInputBatch(all_greedy=True,
                                                  max_num_logprobs=0)
-    metadata_without_zero = TPUSupportedSamplingMetadata.from_input_batch(
+    metadata_without_zero = _create_sampling_metadata(
         mesh=mesh,
-        input_batch=mock_batch_id_logprobs_zero,
+        mock_batch=mock_batch_id_logprobs_zero,
         padded_num_reqs=4,
     )
     assert not metadata_without_zero.logprobs, "logprobs should be False when max_num_logprobs is 0"
@@ -224,9 +252,9 @@ def test_from_input_batch_with_logprobs(mesh: Mesh):
     # Case 3: Logprobs are not requested (max_num_logprobs is None)
     mock_batch_id_logprobs_none = MockInputBatch(all_greedy=True,
                                                  max_num_logprobs=None)
-    metadata_without_none = TPUSupportedSamplingMetadata.from_input_batch(
+    metadata_without_none = _create_sampling_metadata(
         mesh=mesh,
-        input_batch=mock_batch_id_logprobs_none,
+        mock_batch=mock_batch_id_logprobs_none,
         padded_num_reqs=4,
     )
     assert not metadata_without_none.logprobs, "logprobs should be False when max_num_logprobs is None"
@@ -247,8 +275,9 @@ def test_from_input_batch_sampling_with_logprobs(mesh: Mesh):
         max_num_logprobs=10,
     )
 
-    metadata = TPUSupportedSamplingMetadata.from_input_batch(
-        mesh=mesh, input_batch=mock_batch, padded_num_reqs=padded_num_reqs)
+    metadata = _create_sampling_metadata(mesh=mesh,
+                                         mock_batch=mock_batch,
+                                         padded_num_reqs=padded_num_reqs)
 
     assert metadata.do_sampling, "do_sampling should be True"
     assert metadata.logprobs, "logprobs should be True"

--- a/tests/runner/test_tpu_runner.py
+++ b/tests/runner/test_tpu_runner.py
@@ -153,6 +153,7 @@ class TestTPUJaxRunner:
         self.runner.input_batch.num_reqs = 1
         self.runner.input_batch.req_ids = ['req1']
         self.runner.input_batch.req_id_to_index = {'req1': 0}
+        self.runner.input_batch.request_distribution = [0, 0, 1]
         self.runner.input_batch.num_computed_tokens_cpu = np.array([10])
         self.runner.input_batch.token_ids_cpu = np.random.randint(
             0, 1000, (8, 64), dtype=np.int32)

--- a/tests/runner/test_tpu_runner_dp.py
+++ b/tests/runner/test_tpu_runner_dp.py
@@ -65,7 +65,9 @@ class TestTPUJaxRunnerDPInputsLightweight:
         self.runner.uses_mrope = False
 
         from tpu_inference.utils import DeviceBuffer
-        self.runner.device_buffer = DeviceBuffer(initial_capacity=1024 * 1024)
+        self.runner.device_buffer = DeviceBuffer(
+            leading_shape=(self.runner.dp_size, ),
+            initial_capacity=1024 * 1024)
 
         # mock kv cache group
         mock_kv_cache_config = MagicMock()
@@ -169,7 +171,7 @@ class TestTPUJaxRunnerDPInputsLightweight:
             num_scheduled_tokens, assigned_dp_ranks)
 
         mock_runner_utils.get_padded_token_len.return_value = 16
-        mock_sampling_metadata.from_input_batch.return_value = MagicMock()
+        mock_sampling_metadata.from_unpacked_blob.return_value = MagicMock()
         self.runner.uses_mrope = True
 
         mock_mesh = MagicMock(spec=Mesh)
@@ -193,7 +195,7 @@ class TestTPUJaxRunnerDPInputsLightweight:
         """Test basic functionality of _prepare_inputs_dp."""
         # Mock utility functions
         mock_runner_utils.get_padded_token_len.return_value = 16
-        mock_sampling_metadata.from_input_batch.return_value = MagicMock()
+        mock_sampling_metadata.from_unpacked_blob.return_value = MagicMock()
         mock_named_sharding.return_value = MagicMock()
 
         # Create test data - only use req1 and req2 to match num_reqs=2
@@ -243,7 +245,7 @@ class TestTPUJaxRunnerDPInputsLightweight:
         """Test basic functionality of _prepare_inputs_dp."""
         # Mock utility functions
         mock_runner_utils.get_padded_token_len.return_value = 16
-        mock_sampling_metadata.from_input_batch.return_value = MagicMock()
+        mock_sampling_metadata.from_unpacked_blob.return_value = MagicMock()
         mock_named_sharding.return_value = MagicMock()
 
         # Create test data - only use req1 and req2 to match num_reqs=2
@@ -493,7 +495,7 @@ class TestTPUJaxRunnerDPInputsLightweight:
 
         mock_runner_utils.get_padded_token_len.side_effect = mock_get_padded_token_len
         mock_sampling_instance = MagicMock()
-        mock_sampling_metadata.from_input_batch.return_value = mock_sampling_instance
+        mock_sampling_metadata.from_unpacked_blob.return_value = mock_sampling_instance
         mock_named_sharding.return_value = MagicMock()
 
         # Setup deterministic test data
@@ -606,7 +608,7 @@ class TestTPUJaxRunnerDPInputsLightweight:
 
         mock_runner_utils.get_padded_token_len.side_effect = mock_get_padded_token_len
         mock_sampling_instance = MagicMock()
-        mock_sampling_metadata.from_input_batch.return_value = mock_sampling_instance
+        mock_sampling_metadata.from_unpacked_blob.return_value = mock_sampling_instance
         mock_named_sharding.return_value = MagicMock()
 
         # Setup test data with all requests on rank 0 (empty rank 1)
@@ -732,7 +734,7 @@ class TestTPUJaxRunnerDPInputsLightweight:
 
         mock_runner_utils.get_padded_token_len.side_effect = mock_get_padded_token_len
         mock_sampling_instance = MagicMock()
-        mock_sampling_metadata.from_input_batch.return_value = mock_sampling_instance
+        mock_sampling_metadata.from_unpacked_blob.return_value = mock_sampling_instance
         mock_named_sharding.return_value = MagicMock()
 
         # Setup test data with decode requests (1 token) and prefill requests (>1 token)
@@ -794,7 +796,7 @@ class TestTPUJaxRunnerDPInputsLightweight:
 
         mock_runner_utils.get_padded_token_len.side_effect = mock_get_padded_token_len
         mock_sampling_instance = MagicMock()
-        mock_sampling_metadata.from_input_batch.return_value = mock_sampling_instance
+        mock_sampling_metadata.from_unpacked_blob.return_value = mock_sampling_instance
         mock_named_sharding.return_value = MagicMock()
 
         # All requests are decode (1 token each)
@@ -929,10 +931,10 @@ class TestTPUJaxRunnerDPInputsLightweight:
         # Should return input_ids unchanged
         np.testing.assert_array_equal(result, input_ids)
 
-    @patch('tpu_inference.runner.tpu_runner.device_array',
-           side_effect=lambda mesh, tensors, **kwargs: tensors)
+    @patch('tpu_inference.runner.tpu_runner.NamedSharding')
+    @patch('jax.device_put', side_effect=lambda x, *args, **kwargs: x)
     def test_apply_async_token_substitution_with_padding(
-            self, mock_device_array):
+            self, mock_device_put, mock_named_sharding):
         """Test _apply_async_token_substitution with padding."""
 
         # Bind the actual method
@@ -966,12 +968,11 @@ class TestTPUJaxRunnerDPInputsLightweight:
         # Verify input_ids
         np.testing.assert_array_equal(call_args[0], input_ids)
 
-        # Verify padded indices length matches input_ids length
-        assert len(call_args[1]) == len(input_ids)
-        assert len(call_args[2]) == len(input_ids)
+        # Verify combined_indices length matches 2 * input_ids length
+        assert len(call_args[1]) == 2 * len(input_ids)
 
-        # Verify placeholder_num
-        assert call_args[4] == 2  # Number of actual substitutions
+        # Verify placeholder_num (now at index 3)
+        assert call_args[3] == 2  # Number of actual substitutions
 
     def test_prepare_inputs_routing_to_dp(self):
         """Test _prepare_inputs routes to _prepare_inputs_dp when dp_size > 1."""
@@ -1031,7 +1032,7 @@ class TestTPUJaxRunnerDPInputsLightweight:
 
         mock_runner_utils.get_padded_token_len.side_effect = mock_get_padded_token_len
         mock_sampling_instance = MagicMock()
-        mock_sampling_metadata.from_input_batch.return_value = mock_sampling_instance
+        mock_sampling_metadata.from_unpacked_blob.return_value = mock_sampling_instance
         mock_named_sharding.return_value = MagicMock()
 
         # Setup test data
@@ -1104,7 +1105,7 @@ class TestTPUJaxRunnerDPInputsLightweight:
 
         mock_runner_utils.get_padded_token_len.side_effect = mock_get_padded_token_len
         mock_sampling_instance = MagicMock()
-        mock_sampling_metadata.from_input_batch.return_value = mock_sampling_instance
+        mock_sampling_metadata.from_unpacked_blob.return_value = mock_sampling_instance
         mock_named_sharding.return_value = MagicMock()
 
         # Setup test data
@@ -1272,9 +1273,6 @@ class TestSamplingMetadataPassthrough:
             self, mock_sampling_metadata, mock_device_array, mock_runner_utils,
             mock_named_sharding, mock_device_put):
         """_prepare_inputs_dp() should use ATTN_DATA sharding for TPUSupportedSamplingMetadata."""
-        from jax.sharding import PartitionSpec
-
-        from tpu_inference.layers.common.sharding import ShardingAxisName
 
         runner = MagicMock()
         runner.dp_size = 2
@@ -1294,7 +1292,8 @@ class TestSamplingMetadataPassthrough:
         runner.arange_cpu = np.arange(64, dtype=np.int64)
 
         from tpu_inference.utils import DeviceBuffer
-        runner.device_buffer = DeviceBuffer(initial_capacity=1024 * 1024)
+        runner.device_buffer = DeviceBuffer(leading_shape=(runner.dp_size, ),
+                                            initial_capacity=1024 * 1024)
         runner.num_tokens_paddings_per_dp = [8, 16, 32]
         runner.num_reqs_paddings_per_dp = [4, 8]
         runner.uses_mrope = False
@@ -1311,8 +1310,7 @@ class TestSamplingMetadataPassthrough:
             runner)
 
         mock_runner_utils.get_padded_token_len.side_effect = lambda paddings, val: 8
-        mock_sampling_metadata.from_input_batch.return_value = MagicMock()
-        mock_named_sharding.return_value = MagicMock()
+        mock_sampling_metadata.from_unpacked_blob.return_value = MagicMock()
 
         scheduler_output = MagicMock()
         scheduler_output.num_scheduled_tokens = {"req1": 3, "req2": 2}
@@ -1322,22 +1320,20 @@ class TestSamplingMetadataPassthrough:
 
         TPUModelRunner._prepare_inputs_dp(runner, scheduler_output)
 
-        # Verify from_input_batch was called exactly once with the ATTN_DATA sharding
-        mock_sampling_metadata.from_input_batch.assert_called_once()
-        sharding_arg = mock_sampling_metadata.from_input_batch.call_args.kwargs.get(
-            'sharding')
-        assert sharding_arg is mock_named_sharding.return_value, (
-            "from_input_batch should receive the data_parallel_attn_sharding instance"
-        )
-
-        # Verify NamedSharding was called with ATTN_DATA PartitionSpec.
-        call_partition_specs = [
-            call.args[1] for call in mock_named_sharding.call_args_list
-            if len(call.args) > 1
-        ]
-        assert PartitionSpec(
-            ShardingAxisName.ATTN_DATA) in call_partition_specs, (
-                "NamedSharding must be called with ATTN_DATA PartitionSpec")
+        # Verify jax.device_put was called with data_parallel_attn_sharding
+        mock_device_put.assert_called()
+        # Find the call that passes data_parallel_attn_sharding
+        call_args_list = mock_device_put.call_args_list
+        found_call = False
+        for call in call_args_list:
+            args, kwargs = call
+            sharding_arg = kwargs.get('sharding')
+            if sharding_arg is None and len(args) > 1:
+                sharding_arg = args[1]
+            if sharding_arg is mock_named_sharding.return_value:
+                found_call = True
+                break
+        assert found_call, "Should find a call to jax.device_put with data_parallel_attn_sharding"
 
     @patch('tpu_inference.runner.tpu_runner.TPUSupportedSamplingMetadata')
     @patch('tpu_inference.runner.tpu_runner.sample')
@@ -1376,7 +1372,7 @@ class TestSamplingMetadataPassthrough:
         except Exception:
             pass  # only care that from_input_batch was never called
 
-        mock_sampling_metadata.from_input_batch.assert_not_called()
+        mock_sampling_metadata.from_unpacked_blob.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/tests/runner/test_tpu_runner_dp.py
+++ b/tests/runner/test_tpu_runner_dp.py
@@ -88,6 +88,8 @@ class TestTPUJaxRunnerDPInputsLightweight:
             self.runner)
         self.runner._prepare_async_token_substitution_indices_dp = TPUModelRunner._prepare_async_token_substitution_indices_dp.__get__(
             self.runner)
+        self.runner._define_device_buffer_layout_dp = TPUModelRunner._define_device_buffer_layout_dp.__get__(
+            self.runner)
 
     def _create_mock_scheduler_output(self,
                                       num_scheduled_tokens_dict,
@@ -1307,6 +1309,8 @@ class TestSamplingMetadataPassthrough:
         runner._prepare_dp_input_metadata = TPUModelRunner._prepare_dp_input_metadata.__get__(
             runner)
         runner._prepare_async_token_substitution_indices_dp = TPUModelRunner._prepare_async_token_substitution_indices_dp.__get__(
+            runner)
+        runner._define_device_buffer_layout_dp = TPUModelRunner._define_device_buffer_layout_dp.__get__(
             runner)
 
         mock_runner_utils.get_padded_token_len.side_effect = lambda paddings, val: 8

--- a/tpu_inference/layers/jax/sample/sampling_metadata.py
+++ b/tpu_inference/layers/jax/sample/sampling_metadata.py
@@ -14,16 +14,17 @@
 
 import functools
 from dataclasses import dataclass
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:
+    from tpu_inference.utils import DeviceBuffer
 
 import jax
 import jax.numpy as jnp
 import numpy as np
-import torch
 from jax.sharding import Mesh
 
 from tpu_inference.runner.input_batch import InputBatch
-from tpu_inference.utils import device_array
 
 DEFAULT_SAMPLING_PARAMS = dict(
     temperature=-1.0,
@@ -52,54 +53,78 @@ class TPUSupportedSamplingMetadata:
     logprobs: bool = False
 
     @classmethod
-    def from_input_batch(
+    def add_to_device_buffer(
+        cls,
+        buffer: "DeviceBuffer",
+        input_batch: InputBatch,
+        padded_num_reqs_per_dp_rank: int,
+        dp_size: int,
+    ):
+        """Add sampling parameters to the device buffer."""
+        num_reqs = input_batch.num_reqs
+
+        temp_view = buffer.get_view((padded_num_reqs_per_dp_rank, ),
+                                    key="temperature")
+        top_k_view = buffer.get_view((padded_num_reqs_per_dp_rank, ),
+                                     key="top_k")
+        top_p_view = buffer.get_view((padded_num_reqs_per_dp_rank, ),
+                                     key="top_p")
+
+        needs_logprobs = input_batch.max_num_logprobs > 0 if input_batch.max_num_logprobs else False
+        dummy_len = 1 if needs_logprobs else 2
+        dummy_view = buffer.get_view((dummy_len, ),
+                                     key="cache_collision_dummy")
+        dummy_view.fill(0)
+
+        # Fill with defaults first (bitcasted to int32 for floats)
+        default_temp_int = np.array([DEFAULT_SAMPLING_PARAMS["temperature"]],
+                                    dtype=np.float32).view(np.int32)[0]
+        default_top_p_int = np.array([DEFAULT_SAMPLING_PARAMS["top_p"]],
+                                     dtype=np.float32).view(np.int32)[0]
+
+        temp_view.fill(default_temp_int)
+        top_k_view.fill(DEFAULT_SAMPLING_PARAMS["top_k"])
+        top_p_view.fill(default_top_p_int)
+
+        # If not all greedy, copy over actual values directly to the view
+        if input_batch.all_greedy:
+            return
+
+        temp_view.ravel(
+        )[:num_reqs] = input_batch.temperature_cpu[:num_reqs].view(np.int32)
+        top_k_view.ravel()[:num_reqs] = input_batch.top_k_cpu[:num_reqs]
+        top_p_view.ravel()[:num_reqs] = input_batch.top_p_cpu[:num_reqs].view(
+            np.int32)
+
+    @classmethod
+    def from_unpacked_blob(
         cls,
         mesh: Mesh,
+        metadata: dict[str, jax.Array],
         input_batch: InputBatch,
         padded_num_reqs: int,
-        sharding: Optional[jax.sharding.Sharding] = None,
     ) -> "TPUSupportedSamplingMetadata":
+        """Unpack sampling parameters from the metadata blob."""
         needs_logprobs = input_batch.max_num_logprobs > 0 if input_batch.max_num_logprobs else False
-
-        # Use a dummy tensor with a unique shape for each logprobs config.
-        # This avoids persistent cache collisions.
-        dummy_shape = (1 if needs_logprobs else 2, )
-        cache_collision_dummy = np.zeros(dummy_shape, dtype=np.int32)
-        # Use replicated sharding for dummy tensor.
-        cache_collision_dummy = device_array(mesh,
-                                             cache_collision_dummy,
-                                             sharding=None)
+        cache_collision_dummy = metadata["cache_collision_dummy"].ravel()
 
         if input_batch.all_greedy:
             return cls(do_sampling=False,
                        logprobs=needs_logprobs,
                        _cache_collision_dummy=cache_collision_dummy)
-        num_reqs = input_batch.num_reqs
 
-        def fill_slice(cpu_torch_tensor: torch.Tensor,
-                       fill_val: float) -> torch.Tensor:
-            # Pad value is the default one.
-            cpu_torch_tensor[num_reqs:padded_num_reqs] = fill_val
-            return cpu_torch_tensor
+        temp = metadata["temperature"].ravel()
+        top_k = metadata["top_k"].ravel()
+        top_p = metadata["top_p"].ravel()
 
-        temp_tensor = fill_slice(input_batch.temperature_cpu,
-                                 DEFAULT_SAMPLING_PARAMS["temperature"])
-        top_k_tensor = fill_slice(input_batch.top_k_cpu,
-                                  DEFAULT_SAMPLING_PARAMS["top_k"])
-        top_p_tensor = fill_slice(input_batch.top_p_cpu,
-                                  DEFAULT_SAMPLING_PARAMS["top_p"])
+        # Bitcast back to float32 if needed
+        temp = jax.lax.bitcast_convert_type(temp, jnp.float32)
+        top_p = jax.lax.bitcast_convert_type(top_p, jnp.float32)
 
-        # Slice persistent device tensors to a fixed pre-compiled padded shape.
         return cls(
-            temperature=device_array(mesh,
-                                     temp_tensor[:padded_num_reqs],
-                                     sharding=sharding),
-            top_p=device_array(mesh,
-                               top_p_tensor[:padded_num_reqs],
-                               sharding=sharding),
-            top_k=device_array(mesh,
-                               top_k_tensor[:padded_num_reqs],
-                               sharding=sharding),
+            temperature=temp[:padded_num_reqs],
+            top_p=top_p[:padded_num_reqs],
+            top_k=top_k[:padded_num_reqs],
             _cache_collision_dummy=cache_collision_dummy,
             do_sampling=not input_batch.all_greedy,
             logprobs=needs_logprobs,

--- a/tpu_inference/runner/compilation_manager.py
+++ b/tpu_inference/runner/compilation_manager.py
@@ -291,14 +291,16 @@ class CompilationManager:
                 padded_token_in_tpu_cur_input_indices = np.zeros(
                     (num_tokens, ), dtype=np.int32)
                 padded_token_in_tpu_pre_next_tokens_indices = np.zeros(
-                    (num_tokens, ), dtype=jnp.int32)
-                (padded_token_in_tpu_cur_input_indices,
-                 padded_token_in_tpu_pre_next_tokens_indices) = device_array(
-                     self.runner.mesh,
-                     (padded_token_in_tpu_cur_input_indices,
-                      padded_token_in_tpu_pre_next_tokens_indices),
-                     sharding=NamedSharding(self.runner.mesh,
-                                            PartitionSpec(None)))
+                    (num_tokens, ), dtype=np.int32)
+
+                combined_indices = np.concatenate([
+                    padded_token_in_tpu_cur_input_indices,
+                    padded_token_in_tpu_pre_next_tokens_indices
+                ])
+
+                combined_indices = jax.device_put(
+                    combined_indices,
+                    NamedSharding(self.runner.mesh, PartitionSpec()))
 
                 input_ids = self._create_dummy_tensor((num_tokens, ),
                                                       jnp.int32, dp_sharding)
@@ -312,8 +314,7 @@ class CompilationManager:
                     "_substitute_placeholder_token_fn",
                     self.runner._substitute_placeholder_token_fn,
                     input_ids,
-                    padded_token_in_tpu_cur_input_indices,
-                    padded_token_in_tpu_pre_next_tokens_indices,
+                    combined_indices,
                     next_tokens,
                     placeholder_num,
                     num_tokens=num_tokens,
@@ -582,11 +583,15 @@ class CompilationManager:
 
                     # Use a dummy tensor with a unique shape for each logprobs config.
                     # This avoids persistent cache collisions.
-                    dummy_shape = (1 if logprobs else 2, )
+                    dummy_len = 1 if logprobs else 2
+                    dummy_shape = (self.runner.dp_size * dummy_len, )
                     _cache_collision_dummy = jnp.zeros(dummy_shape,
                                                        dtype=jnp.int32)
-                    _cache_collision_dummy = device_array(
-                        self.runner.mesh, _cache_collision_dummy)
+                    _cache_collision_dummy = jax.device_put(
+                        _cache_collision_dummy,
+                        NamedSharding(
+                            self.runner.mesh,
+                            PartitionSpec(ShardingAxisName.ATTN_DATA)))
 
                     sampling_metadata = TPUSupportedSamplingMetadata(
                         temperature=temperature,
@@ -689,11 +694,15 @@ class CompilationManager:
                     # Use a dummy tensor with a unique shape for each logprobs config.
                     # Currently logprobs=False for rejection_sampler.
                     logprobs_dummy = False
-                    dummy_shape = (1 if logprobs_dummy else 2, )
+                    dummy_len = 1 if logprobs_dummy else 2
+                    dummy_shape = (self.runner.dp_size * dummy_len, )
                     _cache_collision_dummy = jnp.zeros(dummy_shape,
                                                        dtype=jnp.int32)
-                    _cache_collision_dummy = device_array(
-                        self.runner.mesh, _cache_collision_dummy)
+                    _cache_collision_dummy = jax.device_put(
+                        _cache_collision_dummy,
+                        NamedSharding(
+                            self.runner.mesh,
+                            PartitionSpec(ShardingAxisName.ATTN_DATA)))
 
                     if do_sampling:
                         compilation_name = "random_rejection_sampler"

--- a/tpu_inference/runner/compilation_manager.py
+++ b/tpu_inference/runner/compilation_manager.py
@@ -130,7 +130,6 @@ class CompilationManager:
 
     def _precompile_unpack_arrays(self) -> None:
         logger.info("Compiling unpack_arrays with different input shapes.")
-        from tpu_inference.utils import DeviceBuffer
 
         dp_size = self.runner.dp_size
         original_buffer = self.runner.device_buffer
@@ -138,11 +137,6 @@ class CompilationManager:
         needs_logprobs_options = [False]
         if self.runner.vllm_config.model_config.max_logprobs and self.runner.vllm_config.model_config.max_logprobs > 0:
             needs_logprobs_options.append(True)
-
-        leading_shape = (dp_size, ) if dp_size > 1 else ()
-        temp_buffer = DeviceBuffer(leading_shape=leading_shape,
-                                   initial_capacity=1024)
-        self.runner.device_buffer = temp_buffer
 
         try:
             if dp_size > 1:
@@ -153,13 +147,12 @@ class CompilationManager:
                                 for padded_logits_length in self.runner.num_logits_paddings:
                                     self.runner._define_device_buffer_layout_dp(
                                         num_tokens, num_reqs,
-                                        (padded_logits_length, ),
-                                        needs_logprobs)
+                                        (padded_logits_length, ), num_reqs)
                                     self._compile_unpack_arrays_helper(dp_size)
                             else:
                                 self.runner._define_device_buffer_layout_dp(
                                     num_tokens, num_reqs, (num_reqs, ),
-                                    needs_logprobs)
+                                    num_reqs)
                                 self._compile_unpack_arrays_helper(dp_size)
             else:
                 for num_tokens in self.runner.num_tokens_paddings:
@@ -167,16 +160,16 @@ class CompilationManager:
                         for needs_logprobs in needs_logprobs_options:
                             if self.runner.speculative_config:
                                 for padded_logits_length in self.runner.num_logits_paddings:
-                                    self.runner._define_device_buffer_layout_non_dp(
-                                        num_tokens, num_reqs,
-                                        (padded_logits_length, ),
-                                        needs_logprobs)
+                                    self.runner._define_device_buffer_layout_dp(
+                                        num_tokens, self.runner.max_num_reqs,
+                                        (padded_logits_length, ), num_reqs)
                                     self._compile_unpack_arrays_helper(1)
                             else:
-                                self.runner._define_device_buffer_layout_non_dp(
-                                    num_tokens, num_reqs, (num_reqs, ),
-                                    needs_logprobs)
+                                self.runner._define_device_buffer_layout_dp(
+                                    num_tokens, self.runner.max_num_reqs,
+                                    (num_reqs, ), num_reqs)
                                 self._compile_unpack_arrays_helper(1)
+
         finally:
             self.runner.device_buffer = original_buffer
 

--- a/tpu_inference/runner/compilation_manager.py
+++ b/tpu_inference/runner/compilation_manager.py
@@ -139,36 +139,19 @@ class CompilationManager:
             needs_logprobs_options.append(True)
 
         try:
-            if dp_size > 1:
-                for num_tokens in self.runner.num_tokens_paddings_per_dp:
-                    for num_reqs in self.runner.num_reqs_paddings_per_dp:
-                        for needs_logprobs in needs_logprobs_options:
-                            if self.runner.speculative_config:
-                                for padded_logits_length in self.runner.num_logits_paddings:
-                                    self.runner._define_device_buffer_layout_dp(
-                                        num_tokens, num_reqs,
-                                        (padded_logits_length, ), num_reqs)
-                                    self._compile_unpack_arrays_helper(dp_size)
-                            else:
+            for num_tokens in self.runner.num_tokens_paddings_per_dp:
+                for num_reqs in self.runner.num_reqs_paddings_per_dp:
+                    for needs_logprobs in needs_logprobs_options:
+                        if self.runner.speculative_config:
+                            for padded_logits_length in self.runner.num_logits_paddings:
                                 self.runner._define_device_buffer_layout_dp(
-                                    num_tokens, num_reqs, (num_reqs, ),
-                                    num_reqs)
+                                    num_tokens, num_reqs,
+                                    (padded_logits_length, ), num_reqs)
                                 self._compile_unpack_arrays_helper(dp_size)
-            else:
-                for num_tokens in self.runner.num_tokens_paddings:
-                    for num_reqs in self.runner.num_reqs_paddings:
-                        for needs_logprobs in needs_logprobs_options:
-                            if self.runner.speculative_config:
-                                for padded_logits_length in self.runner.num_logits_paddings:
-                                    self.runner._define_device_buffer_layout_dp(
-                                        num_tokens, self.runner.max_num_reqs,
-                                        (padded_logits_length, ), num_reqs)
-                                    self._compile_unpack_arrays_helper(1)
-                            else:
-                                self.runner._define_device_buffer_layout_dp(
-                                    num_tokens, self.runner.max_num_reqs,
-                                    (num_reqs, ), num_reqs)
-                                self._compile_unpack_arrays_helper(1)
+                        else:
+                            self.runner._define_device_buffer_layout_dp(
+                                num_tokens, num_reqs, (num_reqs, ), num_reqs)
+                            self._compile_unpack_arrays_helper(dp_size)
 
         finally:
             self.runner.device_buffer = original_buffer

--- a/tpu_inference/runner/compilation_manager.py
+++ b/tpu_inference/runner/compilation_manager.py
@@ -123,9 +123,72 @@ class CompilationManager:
             self._precompile_structured_decoding()
             if self.runner.speculative_config:
                 self._precompile_speculative_decoding()
+            self._precompile_unpack_arrays()
 
         elapsed = time.perf_counter() - compilation_start_time
         self.runner.vllm_config.compilation_config.compilation_time += elapsed
+
+    def _precompile_unpack_arrays(self) -> None:
+        logger.info("Compiling unpack_arrays with different input shapes.")
+        from tpu_inference.utils import DeviceBuffer
+
+        dp_size = self.runner.dp_size
+        original_buffer = self.runner.device_buffer
+
+        needs_logprobs_options = [False]
+        if self.runner.vllm_config.model_config.max_logprobs and self.runner.vllm_config.model_config.max_logprobs > 0:
+            needs_logprobs_options.append(True)
+
+        leading_shape = (dp_size, ) if dp_size > 1 else ()
+        temp_buffer = DeviceBuffer(leading_shape=leading_shape,
+                                   initial_capacity=1024)
+        self.runner.device_buffer = temp_buffer
+
+        try:
+            if dp_size > 1:
+                for num_tokens in self.runner.num_tokens_paddings_per_dp:
+                    for num_reqs in self.runner.num_reqs_paddings_per_dp:
+                        for needs_logprobs in needs_logprobs_options:
+                            if self.runner.speculative_config:
+                                for padded_logits_length in self.runner.num_logits_paddings:
+                                    self.runner._define_device_buffer_layout_dp(
+                                        num_tokens, num_reqs,
+                                        (padded_logits_length, ),
+                                        needs_logprobs)
+                                    self._compile_unpack_arrays_helper(dp_size)
+                            else:
+                                self.runner._define_device_buffer_layout_dp(
+                                    num_tokens, num_reqs, (num_reqs, ),
+                                    needs_logprobs)
+                                self._compile_unpack_arrays_helper(dp_size)
+            else:
+                for num_tokens in self.runner.num_tokens_paddings:
+                    for num_reqs in self.runner.num_reqs_paddings:
+                        for needs_logprobs in needs_logprobs_options:
+                            if self.runner.speculative_config:
+                                for padded_logits_length in self.runner.num_logits_paddings:
+                                    self.runner._define_device_buffer_layout_non_dp(
+                                        num_tokens, num_reqs,
+                                        (padded_logits_length, ),
+                                        needs_logprobs)
+                                    self._compile_unpack_arrays_helper(1)
+                            else:
+                                self.runner._define_device_buffer_layout_non_dp(
+                                    num_tokens, num_reqs, (num_reqs, ),
+                                    needs_logprobs)
+                                self._compile_unpack_arrays_helper(1)
+        finally:
+            self.runner.device_buffer = original_buffer
+
+    def _compile_unpack_arrays_helper(self, dp_size: int) -> None:
+        from tpu_inference.utils import DeviceBuffer
+        _, metadata_layout = self.runner.device_buffer.build()
+
+        total_size = sum(metadata_layout.sizes)
+        leading_shape = (dp_size, ) if dp_size > 1 else ()
+        dummy_blob = jnp.zeros(leading_shape + (total_size, ), dtype=jnp.int32)
+
+        DeviceBuffer.unpack_arrays(dummy_blob, metadata_layout, shape=(-1, ))
 
     def _precompile_input_embeddings_merger(self) -> None:
         for num_tokens in self.runner.num_tokens_paddings:

--- a/tpu_inference/runner/compilation_manager.py
+++ b/tpu_inference/runner/compilation_manager.py
@@ -131,30 +131,24 @@ class CompilationManager:
     def _precompile_unpack_arrays(self) -> None:
         logger.info("Compiling unpack_arrays with different input shapes.")
 
-        dp_size = self.runner.dp_size
-        original_buffer = self.runner.device_buffer
-
         needs_logprobs_options = [False]
         if self.runner.vllm_config.model_config.max_logprobs and self.runner.vllm_config.model_config.max_logprobs > 0:
             needs_logprobs_options.append(True)
 
-        try:
-            for num_tokens in self.runner.num_tokens_paddings_per_dp:
-                for num_reqs in self.runner.num_reqs_paddings_per_dp:
-                    for needs_logprobs in needs_logprobs_options:
-                        if self.runner.speculative_config:
-                            for padded_logits_length in self.runner.num_logits_paddings:
-                                self.runner._define_device_buffer_layout_dp(
-                                    num_tokens, num_reqs,
-                                    (padded_logits_length, ), num_reqs)
-                                self._compile_unpack_arrays_helper(dp_size)
-                        else:
+        for num_tokens in self.runner.num_tokens_paddings_per_dp:
+            for num_reqs in self.runner.num_reqs_paddings_per_dp:
+                for needs_logprobs in needs_logprobs_options:
+                    if self.runner.speculative_config:
+                        for padded_logits_length in self.runner.num_logits_paddings:
                             self.runner._define_device_buffer_layout_dp(
-                                num_tokens, num_reqs, (num_reqs, ), num_reqs)
-                            self._compile_unpack_arrays_helper(dp_size)
-
-        finally:
-            self.runner.device_buffer = original_buffer
+                                num_tokens, num_reqs, (padded_logits_length, ),
+                                num_reqs)
+                            self._compile_unpack_arrays_helper(
+                                self.runner.dp_size)
+                    else:
+                        self.runner._define_device_buffer_layout_dp(
+                            num_tokens, num_reqs, (num_reqs, ), num_reqs)
+                        self._compile_unpack_arrays_helper(self.runner.dp_size)
 
     def _compile_unpack_arrays_helper(self, dp_size: int) -> None:
         from tpu_inference.utils import DeviceBuffer

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -1564,13 +1564,14 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         dev_arrays_payload = jax.device_put(metadata_blob,
                                             data_parallel_attn_sharding)
 
-        metadata = common_utils.DeviceBuffer.unpack_arrays(
-            dev_arrays_payload, metadata_layout)
-        input_ids = metadata["input_ids"].ravel()
-        query_start_loc = metadata["query_start_loc"].ravel()
-        seq_lens = metadata["seq_lens"].ravel()
-        logits_indices = metadata["logits_indices"].ravel()
-        request_distribution = metadata["request_distribution"].ravel()
+        metadata = common_utils.DeviceBuffer.unpack_arrays(dev_arrays_payload,
+                                                           metadata_layout,
+                                                           shape=(-1, ))
+        input_ids = metadata["input_ids"]
+        query_start_loc = metadata["query_start_loc"]
+        seq_lens = metadata["seq_lens"]
+        logits_indices = metadata["logits_indices"]
+        request_distribution = metadata["request_distribution"]
 
         # Place positions on device
         if self.uses_mrope:
@@ -1615,12 +1616,10 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             no_kv_cache = len(self.kv_cache_config.kv_cache_groups) == 0
             block_tables = metadata.get(
                 "block_tables_gid_0") if not no_kv_cache else None
-            if block_tables is not None:
-                block_tables = block_tables.ravel()
             attention_metadata = build_attn(block_tables)
         else:
             attention_metadata = {
-                name: build_attn(metadata[f"block_tables_gid_{gid}"].ravel())
+                name: build_attn(metadata[f"block_tables_gid_{gid}"])
                 for gid, kv_cache_group in enumerate(
                     self.kv_cache_config.kv_cache_groups)
                 for name in kv_cache_group.layer_names
@@ -1852,8 +1851,9 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         dev_arrays_payload = jax.device_put(metadata_blob,
                                             data_parallel_attn_sharding)
 
-        metadata = common_utils.DeviceBuffer.unpack_arrays(
-            dev_arrays_payload, metadata_layout)
+        metadata = common_utils.DeviceBuffer.unpack_arrays(dev_arrays_payload,
+                                                           metadata_layout,
+                                                           shape=(-1, ))
         input_ids = metadata["input_ids"]
         query_start_loc = metadata["query_start_loc"]
         seq_lens = metadata["seq_lens"]
@@ -1899,12 +1899,10 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             no_kv_cache = len(self.kv_cache_config.kv_cache_groups) == 0
             block_tables = metadata.get(
                 "block_tables_gid_0") if not no_kv_cache else None
-            if block_tables is not None:
-                block_tables = block_tables.ravel()
             attention_metadata = build_attn(block_tables)
         else:
             attention_metadata = {
-                name: build_attn(metadata[f"block_tables_gid_{gid}"].ravel())
+                name: build_attn(metadata[f"block_tables_gid_{gid}"])
                 for gid, kv_cache_group in enumerate(
                     self.kv_cache_config.kv_cache_groups)
                 for name in kv_cache_group.layer_names

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -166,11 +166,11 @@ class ExecuteModelState:
     padded_num_reqs: Optional[int] = None
 
 
-@jax.jit(donate_argnums=(0, 1, 2))
-def _substitute_placeholder_token(
-        input_ids: jax.Array, token_in_tpu_cur_input_indices: jax.Array,
-        token_in_tpu_pre_next_tokens_indices: jax.Array,
-        next_tokens: jax.Array, placeholder_num: int):
+@jax.jit(donate_argnums=(0, 1))
+def _substitute_placeholder_token(input_ids: jax.Array,
+                                  combined_indices: jax.Array,
+                                  next_tokens: jax.Array,
+                                  placeholder_num: int):
     """Substitute placeholder tokens from TPU for async scheduler
 
     Padding for parallelisation of the substitute_placeholder_token_fn
@@ -182,13 +182,16 @@ def _substitute_placeholder_token(
 
     Args:
         input_ids: possible input_ids size
-        token_in_tpu_cur_input_indices: replace holder idx in input_ids. Length the same to input_ids.
-        token_in_tpu_pre_next_tokens_indices: value idx in next_tokens. Length the same to input_ids.
+        combined_indices: concatenated [cur_input_indices, pre_next_tokens_indices]
         next_tokens: next tokens on the TPU from previous step.
-        placeholder_num: number of placeholders. placeholder_num <= len(token_in_tpu_cur_input_indices)
+        placeholder_num: number of placeholders. placeholder_num <= len(input_ids)
     Return:
         input_ids after replace placeholder tokens
     """
+    num_tokens = input_ids.shape[0]
+    token_in_tpu_cur_input_indices = combined_indices[:num_tokens]
+    token_in_tpu_pre_next_tokens_indices = combined_indices[num_tokens:]
+
     assert input_ids.shape == token_in_tpu_cur_input_indices.shape == token_in_tpu_pre_next_tokens_indices.shape, \
         f"Shape mismatch: input_ids and index arrays must have identical shapes due to precompilation assumptions. " \
         f"Got: {input_ids.shape=}, {token_in_tpu_cur_input_indices.shape=}, {token_in_tpu_pre_next_tokens_indices.shape=}"
@@ -270,6 +273,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
 
         self._init_random()
         self._init_mesh()
+
         self._init_phased_profiling()
         self._init_mm()
         self._init_inputs()
@@ -493,6 +497,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         )
 
         self.positions_cpu = np.zeros(self.max_num_tokens, dtype=np.int32)
+
         # Range tensor with values [0 .. self.max_num_tokens - 1].
         # Used to initialize positions / context_lens / seq_lens
         # Keep in int64 to avoid overflow with long context
@@ -543,7 +548,10 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         # able to avoid the overhead of multiple device_put operations.
         # Initialize to a constant size, and resize later after kv cache size is
         # known.
-        self.device_buffer = common_utils.DeviceBuffer(initial_capacity=1024)
+        self.device_buffer_leading_shape = (
+            self.dp_size, ) if self.dp_size > 1 else ()
+        self.device_buffer = common_utils.DeviceBuffer(
+            self.device_buffer_leading_shape, initial_capacity=1024)
 
     def load_model(self):
         with set_current_vllm_config(self.vllm_config):
@@ -639,6 +647,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                             query_start_loc_size + seq_lens_size +
                             logits_indices_size + block_tables_size)
         self.device_buffer = common_utils.DeviceBuffer(
+            self.device_buffer_leading_shape,
             initial_capacity=initial_capacity)
 
         if has_kv_transfer_group():
@@ -1294,15 +1303,17 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             mode='constant',
             constant_values=-1).astype(np.int32)
 
-        (padded_token_in_tpu_cur_input_indices,
-         padded_token_in_tpu_pre_next_tokens_indices) = device_array(
-             self.mesh, (padded_token_in_tpu_cur_input_indices,
-                         padded_token_in_tpu_pre_next_tokens_indices))
+        combined_indices = np.concatenate([
+            padded_token_in_tpu_cur_input_indices,
+            padded_token_in_tpu_pre_next_tokens_indices
+        ])
+
+        combined_indices = jax.device_put(
+            combined_indices, NamedSharding(self.mesh, PartitionSpec()))
 
         with self.maybe_forbid_compile:
             input_ids = self._substitute_placeholder_token_fn(
-                input_ids, padded_token_in_tpu_cur_input_indices,
-                padded_token_in_tpu_pre_next_tokens_indices,
+                input_ids, combined_indices,
                 self._pre_async_results.next_tokens,
                 jnp.asarray(len(token_in_tpu_cur_input_indices),
                             dtype=jnp.int32))
@@ -1352,11 +1363,11 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         self.device_buffer.reset()
 
         input_ids_view = self.device_buffer.get_view(
-            (padded_total_num_scheduled_tokens, ), key="input_ids")
+            (padded_num_scheduled_tokens_per_dp_rank, ), key="input_ids")
         query_start_loc_view = self.device_buffer.get_view(
-            (self.max_num_reqs + dp_size, ), key="query_start_loc")
-        seq_lens_view = self.device_buffer.get_view((self.max_num_reqs, ),
-                                                    key="seq_lens")
+            (max_num_reqs_per_dp_rank + 1, ), key="query_start_loc")
+        seq_lens_view = self.device_buffer.get_view(
+            (max_num_reqs_per_dp_rank, ), key="seq_lens")
 
         use_spec_decode = len(
             scheduler_output.scheduled_spec_decode_tokens) > 0
@@ -1376,8 +1387,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                 self.num_logits_paddings, total_sampled_tokens)
             logits_indices_shape = (padded_logits_length, )
         else:
-            logits_indices_shape = (padded_num_reqs, )
-
+            logits_indices_shape = (padded_num_reqs_per_dp_rank, )
         logits_indices_view = self.device_buffer.get_view(logits_indices_shape,
                                                           key="logits_indices")
 
@@ -1385,17 +1395,11 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         for dp_rank in range(dp_size):
             if num_req_per_dp_rank[dp_rank] == 0:
                 continue
-            token_offset = padded_num_scheduled_tokens_per_dp_rank * dp_rank
             num_scheduled_tokens_per_req = scheduled_tokens_per_dp_rank[
                 dp_rank]
             total_num_scheduled_tokens = num_scheduled_tokens_per_dp_rank[
                 dp_rank]
-            input_ids_cpu = input_ids_view[
-                token_offset:token_offset +
-                padded_num_scheduled_tokens_per_dp_rank]
-            positions_cpu = self.positions_cpu[
-                token_offset:token_offset +
-                padded_num_scheduled_tokens_per_dp_rank]
+            input_ids_cpu = input_ids_view[dp_rank]
             # Get request indices.
             # E.g., [2, 5, 3] -> [0, 0, 1, 1, 1, 1, 1, 2, 2, 2]
             # For each scheduled token, what are the corresponding req index.
@@ -1406,13 +1410,21 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             # For each scheduled token, what is its position in corresponding req.
             arange = np.concatenate(
                 [self.arange_cpu[:n] for n in num_scheduled_tokens_per_req])
-            # Get positions.
-            positions_np = positions_cpu[:total_num_scheduled_tokens]
+
+            # Get positions (1D).
+            token_offset = dp_rank * padded_num_scheduled_tokens_per_dp_rank
+            positions_np = self.positions_cpu[token_offset:token_offset +
+                                              total_num_scheduled_tokens]
+
             np.add(
                 self.input_batch.num_computed_tokens_cpu[req_indices],
                 arange,
                 out=positions_np,
             )
+
+            self.positions_cpu[token_offset +
+                               total_num_scheduled_tokens:token_offset +
+                               padded_num_scheduled_tokens_per_dp_rank] = 0
             # Get token indices.
             # E.g., [0, 1, 0, 1, 2, 3, 4, 0, 1, 2]
             # -> [0, 1, M, M + 1, M + 2, M + 3, M + 4, 2 * M, 2 * M + 1, 2 * M + 2]
@@ -1428,17 +1440,12 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                 token_indices,
                 out=input_ids_cpu[:total_num_scheduled_tokens],
             )
-
             input_ids_cpu[total_num_scheduled_tokens:] = 0
 
         # Prepare the attention metadata (query_start_loc_cpu, seq_lens_cpu)
         for dp_rank in range(dp_size):
-            req_offset = dp_rank * max_num_reqs_per_dp_rank
-            query_start_loc_cpu = query_start_loc_view[
-                req_offset + dp_rank:req_offset + max_num_reqs_per_dp_rank +
-                dp_rank + 1]
-            seq_lens_cpu = seq_lens_view[req_offset:req_offset +
-                                         max_num_reqs_per_dp_rank]
+            query_start_loc_cpu = query_start_loc_view[dp_rank]
+            seq_lens_cpu = seq_lens_view[dp_rank]
             _num_reqs = num_req_per_dp_rank[dp_rank]
             req_indices = req_indices_dp[dp_rank]
             num_scheduled_tokens_per_req = scheduled_tokens_per_dp_rank[
@@ -1465,16 +1472,10 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
 
         # populate logits_indices
         for dp_rank in range(dp_size):
-            req_offset = dp_rank * padded_num_reqs_per_dp_rank
-            query_loc_req_offset = dp_rank * (max_num_reqs_per_dp_rank + 1)
             _num_reqs = num_req_per_dp_rank[dp_rank]
-
-            logits_indices_cpu = logits_indices_view[
-                req_offset:req_offset + padded_num_reqs_per_dp_rank]
+            logits_indices_cpu = logits_indices_view[dp_rank]
             logits_indices_cpu[:_num_reqs] = (
-                query_start_loc_view[query_loc_req_offset +
-                                     1:query_loc_req_offset + _num_reqs + 1] -
-                1)
+                query_start_loc_view[dp_rank, 1:_num_reqs + 1] - 1)
             logits_indices_cpu[_num_reqs:] = -1
 
         # Please see runner_utils.PhasedBasedProfiler for details
@@ -1487,10 +1488,10 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
 
             self.phase_based_profiler.step(batch_composition_stats)
 
-        positions = self.positions_cpu[:padded_total_num_scheduled_tokens]
         mrope_positions = self.mrope_positions_cpu[:, :
                                                    padded_total_num_scheduled_tokens]
-        _request_distribution = []
+        req_dist_view = self.device_buffer.get_view((3, ),
+                                                    key="request_distribution")
         for dp_rank in range(dp_size):
             _num_reqs = num_req_per_dp_rank[dp_rank]
             # The batch has been reordered by _reorder_batch so decode requests come first
@@ -1499,10 +1500,9 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             for req_id in req_ids_dp[dp_rank]:
                 if scheduler_output.num_scheduled_tokens[req_id] == 1:
                     num_decode_in_dp_rank += 1
-            _request_distribution.append(
-                [num_decode_in_dp_rank, num_decode_in_dp_rank, _num_reqs])
-        request_distribution = np.array(_request_distribution,
-                                        dtype=np.int32).ravel()
+            req_dist_view[dp_rank] = [
+                num_decode_in_dp_rank, num_decode_in_dp_rank, _num_reqs
+            ]
 
         use_spec_decode = len(
             scheduler_output.scheduled_spec_decode_tokens) > 0
@@ -1511,41 +1511,28 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             spec_decode_metadata = (
                 self.speculative_decoding_manager.get_spec_decode_metadata(
                     num_draft_tokens,
-                    query_start_loc_view[1:num_reqs + 1],
+                    query_start_loc_view.ravel()[1:num_reqs + 1],
                     padded_num_reqs,
-                    input_ids_view,
+                    input_ids_view.ravel(),
                 ))
-            logits_indices_view[:] = spec_decode_metadata.final_logits_indices.ravel(
-            )
+            logits_indices_view.ravel(
+            )[:] = spec_decode_metadata.final_logits_indices.ravel()
 
-        # Put to device
-        sampling_metadata = TPUSupportedSamplingMetadata.from_input_batch(
-            self.mesh,
+        # Add sampling metadata to buffer
+        TPUSupportedSamplingMetadata.add_to_device_buffer(
+            self.device_buffer,
             self.input_batch,
-            padded_num_reqs,
-            sharding=data_parallel_attn_sharding,
+            padded_num_reqs_per_dp_rank,
+            dp_size,
         )
-
-        if self.uses_mrope:
-            # M-RoPE positions are of the shape (3, max_num_tokens).
-            # https://github.com/vllm-project/tpu-inference/blob/efc9608acd925bb3b64db6fda509514f799ab7be/tpu_inference/runner/tpu_runner.py#L555
-            # Shard the positions accordingly.
-            mrope_sharding = NamedSharding(
-                self.mesh, PartitionSpec(None, ShardingAxisName.ATTN_DATA))
-            positions = device_array(self.mesh,
-                                     mrope_positions,
-                                     sharding=mrope_sharding)
-        else:
-            positions = device_array(self.mesh,
-                                     positions,
-                                     sharding=data_parallel_attn_sharding)
 
         # Collect block tables host arrays loops zone presence zones legality
         def build_block_table_host(kv_cache_gid: int) -> None:
 
             block_table_obj = self.input_batch.block_table[kv_cache_gid]
             block_tables_view = self.device_buffer.get_view(
-                (self.max_num_reqs, block_table_obj.max_num_blocks_per_req),
+                (max_num_reqs_per_dp_rank,
+                 block_table_obj.max_num_blocks_per_req),
                 key=f"block_tables_gid_{kv_cache_gid}")
 
             # Zero out the view once for correct padding
@@ -1557,13 +1544,11 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                 if _num_reqs == 0:
                     continue
 
-                req_offset = dp_rank * max_num_reqs_per_dp_rank
                 # Use np.take with out= to avoid intermediate copies from advanced indexing
                 np.take(cpu_tensor,
                         req_indices_dp[dp_rank],
                         axis=0,
-                        out=block_tables_view[req_offset:req_offset +
-                                              _num_reqs])
+                        out=block_tables_view[dp_rank, :_num_reqs])
 
         if len(self.kv_cache_config.kv_cache_groups) <= 1:
             no_kv_cache = len(self.kv_cache_config.kv_cache_groups) == 0
@@ -1576,16 +1561,38 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
 
         metadata_blob, metadata_layout = self.device_buffer.build()
 
-        (request_distribution, dev_arrays_payload) = device_array(
-            self.mesh, (request_distribution, metadata_blob),
-            sharding=data_parallel_attn_sharding)
+        dev_arrays_payload = jax.device_put(metadata_blob,
+                                            data_parallel_attn_sharding)
 
         metadata = common_utils.DeviceBuffer.unpack_arrays(
             dev_arrays_payload, metadata_layout)
-        input_ids = metadata["input_ids"]
-        query_start_loc = metadata["query_start_loc"]
-        seq_lens = metadata["seq_lens"]
-        logits_indices = metadata["logits_indices"]
+        input_ids = metadata["input_ids"].ravel()
+        query_start_loc = metadata["query_start_loc"].ravel()
+        seq_lens = metadata["seq_lens"].ravel()
+        logits_indices = metadata["logits_indices"].ravel()
+        request_distribution = metadata["request_distribution"].ravel()
+
+        # Place positions on device
+        if self.uses_mrope:
+            mrope_sharding = NamedSharding(
+                self.mesh, PartitionSpec(None, ShardingAxisName.ATTN_DATA))
+            positions = device_array(self.mesh,
+                                     mrope_positions,
+                                     sharding=mrope_sharding)
+        else:
+            positions = device_array(
+                self.mesh,
+                self.positions_cpu[:padded_num_scheduled_tokens_per_dp_rank *
+                                   dp_size],
+                sharding=data_parallel_attn_sharding)
+
+        # Unpack sampling metadata
+        sampling_metadata = TPUSupportedSamplingMetadata.from_unpacked_blob(
+            self.mesh,
+            metadata,
+            self.input_batch,
+            padded_num_reqs,
+        )
 
         def build_attn(block_tables: jax.Array | None) -> AttentionMetadata:
             attention_metadata_gid = AttentionMetadata(
@@ -1597,8 +1604,9 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             )
 
             # This is for making these cpu buffers hidden during tracing
-            attention_metadata_gid.query_start_loc_cpu = query_start_loc_view
-            attention_metadata_gid.seq_lens_cpu = seq_lens_view
+            attention_metadata_gid.query_start_loc_cpu = query_start_loc_view.ravel(
+            )
+            attention_metadata_gid.seq_lens_cpu = seq_lens_view.ravel()
             return attention_metadata_gid
 
         attention_metadata: AttentionMetadata | dict[str, AttentionMetadata]
@@ -1607,10 +1615,12 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             no_kv_cache = len(self.kv_cache_config.kv_cache_groups) == 0
             block_tables = metadata.get(
                 "block_tables_gid_0") if not no_kv_cache else None
+            if block_tables is not None:
+                block_tables = block_tables.ravel()
             attention_metadata = build_attn(block_tables)
         else:
             attention_metadata = {
-                name: build_attn(metadata[f"block_tables_gid_{gid}"])
+                name: build_attn(metadata[f"block_tables_gid_{gid}"].ravel())
                 for gid, kv_cache_group in enumerate(
                     self.kv_cache_config.kv_cache_groups)
                 for name in kv_cache_group.layer_names
@@ -1748,11 +1758,15 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         arange = np.concatenate(
             [self.arange_cpu[:n] for n in num_scheduled_tokens_per_req])
 
-        # Get positions.
+        # Get positions (1D).
         positions_np = self.positions_cpu[:total_num_scheduled_tokens]
+
         np.add(self.input_batch.num_computed_tokens_cpu[req_indices],
                arange,
                out=positions_np)
+
+        self.positions_cpu[
+            total_num_scheduled_tokens:padded_total_num_scheduled_tokens] = 0
 
         # Multi-modal support
         # Calculate M-RoPE positions.
@@ -1767,9 +1781,6 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         token_indices = (positions_np +
                          req_indices * self.input_batch.token_ids_cpu.shape[1])
 
-        # NOTE(woosuk): We use torch.index_select instead of np.take here
-        # because torch.index_select is much faster than np.take for large
-        # tensors.
         np.take(self.input_batch.token_ids_cpu.ravel(),
                 token_indices,
                 out=input_ids_view[:total_num_scheduled_tokens])
@@ -1786,44 +1797,35 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             num_scheduled_tokens_per_req)
         seq_lens_view[num_reqs:] = 0
 
-        positions = self.positions_cpu[:padded_total_num_scheduled_tokens]
         mrope_positions = self.mrope_positions_cpu[:, :
                                                    padded_total_num_scheduled_tokens]
         use_spec_decode = len(
             scheduler_output.scheduled_spec_decode_tokens) > 0
         spec_decode_metadata = None
         if not use_spec_decode:
-            logits_indices_view[:padded_num_reqs] = (
-                query_start_loc_view[1:padded_num_reqs + 1] - 1)
+            logits_indices_view.ravel()[:padded_num_reqs] = (
+                query_start_loc_view.ravel()[1:padded_num_reqs + 1] - 1)
         else:
             spec_decode_metadata = self.speculative_decoding_manager.get_spec_decode_metadata(
-                num_draft_tokens, query_start_loc_view[1:num_reqs + 1],
-                padded_num_reqs, input_ids_view)
-            logits_indices_view[:] = spec_decode_metadata.final_logits_indices.ravel(
-            )
+                num_draft_tokens,
+                query_start_loc_view.ravel()[1:num_reqs + 1], padded_num_reqs,
+                input_ids_view.ravel())
+            logits_indices_view.ravel(
+            )[:] = spec_decode_metadata.final_logits_indices.ravel()
 
-        sampling_metadata = TPUSupportedSamplingMetadata.from_input_batch(
-            self.mesh,
+        # Add sampling metadata to buffer
+        TPUSupportedSamplingMetadata.add_to_device_buffer(
+            self.device_buffer,
             self.input_batch,
             padded_num_reqs,
-            sharding=data_parallel_attn_sharding,
+            dp_size=1,
         )
 
-        if self.uses_mrope:
-            # M-RoPE positions are of the shape (3, max_num_tokens).
-            # https://github.com/vllm-project/tpu-inference/blob/efc9608acd925bb3b64db6fda509514f799ab7be/tpu_inference/runner/tpu_runner.py#L555
-            # Shard the positions accordingly.
-            mrope_sharding = NamedSharding(
-                self.mesh, PartitionSpec(None, ShardingAxisName.ATTN_DATA))
-            positions = device_array(self.mesh,
-                                     mrope_positions,
-                                     sharding=mrope_sharding)
-        else:
-            positions = device_array(self.mesh,
-                                     positions,
-                                     sharding=data_parallel_attn_sharding)
+        # Add positions to buffer
 
-        request_distribution = np.array(self.input_batch.request_distribution)
+        req_dist_view = self.device_buffer.get_view((3, ),
+                                                    key="request_distribution")
+        req_dist_view[:] = self.input_batch.request_distribution
 
         def build_block_table_host(kv_cache_gid: int) -> None:
             block_table_obj = self.input_batch.block_table[kv_cache_gid]
@@ -1847,16 +1849,37 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
 
         metadata_blob, metadata_layout = self.device_buffer.build()
 
-        (request_distribution, dev_arrays_payload) = device_array(
-            self.mesh, (request_distribution, metadata_blob),
-            sharding=data_parallel_attn_sharding)
+        dev_arrays_payload = jax.device_put(metadata_blob,
+                                            data_parallel_attn_sharding)
 
         metadata = common_utils.DeviceBuffer.unpack_arrays(
             dev_arrays_payload, metadata_layout)
         input_ids = metadata["input_ids"]
         query_start_loc = metadata["query_start_loc"]
         seq_lens = metadata["seq_lens"]
+        request_distribution = metadata["request_distribution"]
         logits_indices = metadata["logits_indices"]
+
+        # Place positions on device
+        if self.uses_mrope:
+            mrope_sharding = NamedSharding(
+                self.mesh, PartitionSpec(None, ShardingAxisName.ATTN_DATA))
+            positions = device_array(self.mesh,
+                                     mrope_positions,
+                                     sharding=mrope_sharding)
+        else:
+            positions = device_array(
+                self.mesh,
+                self.positions_cpu[:padded_total_num_scheduled_tokens],
+                sharding=data_parallel_attn_sharding)
+
+        # Unpack sampling metadata
+        sampling_metadata = TPUSupportedSamplingMetadata.from_unpacked_blob(
+            self.mesh,
+            metadata,
+            self.input_batch,
+            padded_num_reqs,
+        )
 
         def build_attn(block_tables: jax.Array | None) -> AttentionMetadata:
             attention_metadata_gid = AttentionMetadata(
@@ -1876,10 +1899,12 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             no_kv_cache = len(self.kv_cache_config.kv_cache_groups) == 0
             block_tables = metadata.get(
                 "block_tables_gid_0") if not no_kv_cache else None
+            if block_tables is not None:
+                block_tables = block_tables.ravel()
             attention_metadata = build_attn(block_tables)
         else:
             attention_metadata = {
-                name: build_attn(metadata[f"block_tables_gid_{gid}"])
+                name: build_attn(metadata[f"block_tables_gid_{gid}"].ravel())
                 for gid, kv_cache_group in enumerate(
                     self.kv_cache_config.kv_cache_groups)
                 for name in kv_cache_group.layer_names

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -1326,6 +1326,37 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         else:
             return self._prepare_inputs_non_dp(scheduler_output)
 
+    def _define_device_buffer_layout_dp(
+        self,
+        padded_num_scheduled_tokens_per_dp_rank: int,
+        max_num_reqs_per_dp_rank: int,
+        logits_indices_shape: Tuple[int, ...],
+        padded_num_reqs_per_dp_rank: int,
+    ) -> None:
+        self.device_buffer.reset()
+        self.device_buffer.get_view(
+            (padded_num_scheduled_tokens_per_dp_rank, ), key="input_ids")
+        self.device_buffer.get_view((max_num_reqs_per_dp_rank + 1, ),
+                                    key="query_start_loc")
+        self.device_buffer.get_view((max_num_reqs_per_dp_rank, ),
+                                    key="seq_lens")
+        self.device_buffer.get_view(logits_indices_shape, key="logits_indices")
+        self.device_buffer.get_view((3, ), key="request_distribution")
+
+        TPUSupportedSamplingMetadata.add_to_device_buffer(
+            self.device_buffer,
+            self.input_batch,
+            padded_num_reqs_per_dp_rank,
+            self.dp_size,
+        )
+
+        for gid in range(len(self.kv_cache_config.kv_cache_groups)):
+            block_table_obj = self.input_batch.block_table[gid]
+            self.device_buffer.get_view(
+                (max_num_reqs_per_dp_rank,
+                 block_table_obj.max_num_blocks_per_req),
+                key=f"block_tables_gid_{gid}")
+
     def _prepare_inputs_dp(self, scheduler_output: "VllmSchedulerOutput"):
         total_num_scheduled_tokens = scheduler_output.total_num_scheduled_tokens
         assert total_num_scheduled_tokens > 0
@@ -1360,15 +1391,6 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                  req_ids_dp, scheduled_tokens_per_dp_rank,
                  padded_num_scheduled_tokens_per_dp_rank, dp_size)
 
-        self.device_buffer.reset()
-
-        input_ids_view = self.device_buffer.get_view(
-            (padded_num_scheduled_tokens_per_dp_rank, ), key="input_ids")
-        query_start_loc_view = self.device_buffer.get_view(
-            (max_num_reqs_per_dp_rank + 1, ), key="query_start_loc")
-        seq_lens_view = self.device_buffer.get_view(
-            (max_num_reqs_per_dp_rank, ), key="seq_lens")
-
         use_spec_decode = len(
             scheduler_output.scheduled_spec_decode_tokens) > 0
 
@@ -1388,8 +1410,19 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             logits_indices_shape = (padded_logits_length, )
         else:
             logits_indices_shape = (padded_num_reqs_per_dp_rank, )
-        logits_indices_view = self.device_buffer.get_view(logits_indices_shape,
-                                                          key="logits_indices")
+        self._define_device_buffer_layout_dp(
+            padded_num_scheduled_tokens_per_dp_rank,
+            max_num_reqs_per_dp_rank,
+            logits_indices_shape,
+            padded_num_reqs_per_dp_rank,
+        )
+
+        input_ids_view = self.device_buffer.get_allocated_view("input_ids")
+        query_start_loc_view = self.device_buffer.get_allocated_view(
+            "query_start_loc")
+        seq_lens_view = self.device_buffer.get_allocated_view("seq_lens")
+        logits_indices_view = self.device_buffer.get_allocated_view(
+            "logits_indices")
 
         # Populates input_ids and positions
         for dp_rank in range(dp_size):
@@ -1490,8 +1523,9 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
 
         mrope_positions = self.mrope_positions_cpu[:, :
                                                    padded_total_num_scheduled_tokens]
-        req_dist_view = self.device_buffer.get_view((3, ),
-                                                    key="request_distribution")
+        req_dist_view = self.device_buffer.get_allocated_view(
+            "request_distribution")
+
         for dp_rank in range(dp_size):
             _num_reqs = num_req_per_dp_rank[dp_rank]
             # The batch has been reordered by _reorder_batch so decode requests come first
@@ -1519,21 +1553,13 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             )[:] = spec_decode_metadata.final_logits_indices.ravel()
 
         # Add sampling metadata to buffer
-        TPUSupportedSamplingMetadata.add_to_device_buffer(
-            self.device_buffer,
-            self.input_batch,
-            padded_num_reqs_per_dp_rank,
-            dp_size,
-        )
 
         # Collect block tables host arrays loops zone presence zones legality
         def build_block_table_host(kv_cache_gid: int) -> None:
 
             block_table_obj = self.input_batch.block_table[kv_cache_gid]
-            block_tables_view = self.device_buffer.get_view(
-                (max_num_reqs_per_dp_rank,
-                 block_table_obj.max_num_blocks_per_req),
-                key=f"block_tables_gid_{kv_cache_gid}")
+            block_tables_view = self.device_buffer.get_allocated_view(
+                f"block_tables_gid_{kv_cache_gid}")
 
             # Zero out the view once for correct padding
             block_tables_view.fill(0)
@@ -1696,11 +1722,6 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
 
             self.phase_based_profiler.step(batch_composition_stats)
 
-        self.device_buffer.reset()
-
-        input_ids_view = self.device_buffer.get_view(
-            (padded_total_num_scheduled_tokens, ), key="input_ids")
-
         use_spec_decode = len(
             scheduler_output.scheduled_spec_decode_tokens) > 0
 
@@ -1719,12 +1740,19 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         else:
             logits_indices_shape = (padded_num_reqs, )
 
-        logits_indices_view = self.device_buffer.get_view(logits_indices_shape,
-                                                          key="logits_indices")
-        query_start_loc_view = self.device_buffer.get_view(
-            (self.max_num_reqs + 1, ), key="query_start_loc")
-        seq_lens_view = self.device_buffer.get_view((self.max_num_reqs, ),
-                                                    key="seq_lens")
+        self._define_device_buffer_layout_dp(
+            padded_total_num_scheduled_tokens,
+            self.max_num_reqs,
+            logits_indices_shape,
+            padded_num_reqs,
+        )
+
+        input_ids_view = self.device_buffer.get_allocated_view("input_ids")
+        logits_indices_view = self.device_buffer.get_allocated_view(
+            "logits_indices")
+        query_start_loc_view = self.device_buffer.get_allocated_view(
+            "query_start_loc")
+        seq_lens_view = self.device_buffer.get_allocated_view("seq_lens")
 
         # Get the number of scheduled tokens for each request.
         num_scheduled_tokens_per_req = []
@@ -1816,24 +1844,18 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             )[:] = spec_decode_metadata.final_logits_indices.ravel()
 
         # Add sampling metadata to buffer
-        TPUSupportedSamplingMetadata.add_to_device_buffer(
-            self.device_buffer,
-            self.input_batch,
-            padded_num_reqs,
-            dp_size=1,
-        )
 
         # Add positions to buffer
 
-        req_dist_view = self.device_buffer.get_view((3, ),
-                                                    key="request_distribution")
+        req_dist_view = self.device_buffer.get_allocated_view(
+            "request_distribution")
+
         req_dist_view[:] = self.input_batch.request_distribution
 
         def build_block_table_host(kv_cache_gid: int) -> None:
             block_table_obj = self.input_batch.block_table[kv_cache_gid]
-            block_tables_view = self.device_buffer.get_view(
-                (self.max_num_reqs, block_table_obj.max_num_blocks_per_req),
-                key=f"block_tables_gid_{kv_cache_gid}")
+            block_tables_view = self.device_buffer.get_allocated_view(
+                f"block_tables_gid_{kv_cache_gid}")
 
             cpu_tensor = block_table_obj.get_cpu_tensor()
             np.copyto(block_tables_view[:num_reqs], cpu_tensor[:num_reqs])

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -1564,9 +1564,12 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         dev_arrays_payload = jax.device_put(metadata_blob,
                                             data_parallel_attn_sharding)
 
-        metadata = common_utils.DeviceBuffer.unpack_arrays(dev_arrays_payload,
-                                                           metadata_layout,
-                                                           shape=(-1, ))
+        metadata = common_utils.DeviceBuffer.unpack_arrays(
+            dev_arrays_payload,
+            metadata_layout,
+            shape=(-1, ),
+        )
+
         input_ids = metadata["input_ids"]
         query_start_loc = metadata["query_start_loc"]
         seq_lens = metadata["seq_lens"]
@@ -1851,9 +1854,12 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         dev_arrays_payload = jax.device_put(metadata_blob,
                                             data_parallel_attn_sharding)
 
-        metadata = common_utils.DeviceBuffer.unpack_arrays(dev_arrays_payload,
-                                                           metadata_layout,
-                                                           shape=(-1, ))
+        metadata = common_utils.DeviceBuffer.unpack_arrays(
+            dev_arrays_payload,
+            metadata_layout,
+            shape=(-1, ),
+        )
+
         input_ids = metadata["input_ids"]
         query_start_loc = metadata["query_start_loc"]
         seq_lens = metadata["seq_lens"]

--- a/tpu_inference/utils.py
+++ b/tpu_inference/utils.py
@@ -499,13 +499,25 @@ class DeviceBuffer:
         self._sizes = []
 
     @staticmethod
-    @functools.partial(jax.jit, static_argnums=(1, ))
-    def unpack_arrays(blob: jax.Array,
-                      metadata: DeviceBufferMetadata) -> Dict[str, jax.Array]:
+    @functools.partial(jax.jit, static_argnums=(1, 2))
+    def _unpack_arrays_jit(
+            blob: jax.Array,
+            metadata: DeviceBufferMetadata,
+            shape: Optional[Tuple[int, ...]] = None) -> List[jax.Array]:
+        indices = tuple(np.cumsum(metadata.sizes)[:-1])
+        parts = jnp.split(blob, indices, axis=-1)
+        if shape:
+            return [x.reshape(shape) for x in parts]
+        return parts
+
+    @staticmethod
+    def unpack_arrays(
+            blob: jax.Array,
+            metadata: DeviceBufferMetadata,
+            shape: Optional[Tuple[int, ...]] = None) -> Dict[str, jax.Array]:
         """
         Unpack a blob into a dictionary of arrays based on provided metadata.
         Uses JIT and jnp.split along the last axis.
         """
-        indices = tuple(np.cumsum(metadata.sizes)[:-1])
-        parts = jnp.split(blob, indices, axis=-1)
+        parts = DeviceBuffer._unpack_arrays_jit(blob, metadata, shape)
         return {key: parts[i] for i, key in enumerate(metadata.keys)}

--- a/tpu_inference/utils.py
+++ b/tpu_inference/utils.py
@@ -438,6 +438,7 @@ class DeviceBuffer:
         self._last_offset = 0
         self._keys: List[str] = []
         self._sizes: List[int] = []
+        self._views: Dict[str, np.ndarray] = {}
 
     def _ensure_capacity(self, size: int):
         """Ensure the internal buffer has enough space for 'size' more elements along the last axis."""
@@ -477,6 +478,7 @@ class DeviceBuffer:
         self._offset += size
         if key:
             self.set_key(key)
+            self._views[key] = view
         return view
 
     def set_key(self, key: str):
@@ -497,6 +499,11 @@ class DeviceBuffer:
         self._last_offset = 0
         self._keys = []
         self._sizes = []
+        self._views = {}
+
+    def get_allocated_view(self, key: str) -> np.ndarray:
+        """Get an allocated view by key."""
+        return self._views[key]
 
     @staticmethod
     @functools.partial(jax.jit, static_argnums=(1, 2))

--- a/tpu_inference/utils.py
+++ b/tpu_inference/utils.py
@@ -499,25 +499,19 @@ class DeviceBuffer:
         self._sizes = []
 
     @staticmethod
-    @functools.partial(jax.jit, static_argnums=(1, 2))
-    def _unpack_arrays_jit(
-            blob: jax.Array,
-            metadata: DeviceBufferMetadata,
-            shape: Optional[Tuple[int, ...]] = None) -> List[jax.Array]:
-        indices = tuple(np.cumsum(metadata.sizes)[:-1])
-        parts = jnp.split(blob, indices, axis=-1)
-        if shape:
-            return [x.reshape(shape) for x in parts]
-        return parts
-
-    @staticmethod
+    @functools.partial(jax.jit, static_argnums=(1, 2, 3))
     def unpack_arrays(
-            blob: jax.Array,
-            metadata: DeviceBufferMetadata,
-            shape: Optional[Tuple[int, ...]] = None) -> Dict[str, jax.Array]:
+        blob: jax.Array,
+        metadata: DeviceBufferMetadata,
+        shape: Optional[Tuple[int, ...]] = None,
+    ) -> Dict[str, jax.Array]:
         """
         Unpack a blob into a dictionary of arrays based on provided metadata.
         Uses JIT and jnp.split along the last axis.
         """
-        parts = DeviceBuffer._unpack_arrays_jit(blob, metadata, shape)
+        indices = tuple(np.cumsum(metadata.sizes)[:-1])
+        parts = jnp.split(blob, indices, axis=-1)
+        if shape:
+            parts = [x.reshape(shape) for x in parts]
+
         return {key: parts[i] for i, key in enumerate(metadata.keys)}

--- a/tpu_inference/utils.py
+++ b/tpu_inference/utils.py
@@ -438,7 +438,7 @@ class DeviceBuffer:
         self._last_offset = 0
         self._keys: List[str] = []
         self._sizes: List[int] = []
-        self._views: Dict[str, np.ndarray] = {}
+        self._views: Dict[str, Any] = {}
 
     def _ensure_capacity(self, size: int):
         """Ensure the internal buffer has enough space for 'size' more elements along the last axis."""
@@ -449,6 +449,13 @@ class DeviceBuffer:
                                   dtype=np.int32)
             new_buffer[..., :self._offset] = self.buffer[..., :self._offset]
             self.buffer = new_buffer
+
+            # Repoint the Python descriptors to the new memory address
+            for key, info in self._views.items():
+                off, sz, shp = info["offset"], info["size"], info["shape"]
+                info["view"] = self.buffer[..., off:off +
+                                           sz].reshape(self.leading_shape +
+                                                       shp)
 
     def append(self, array: np.ndarray, key: Optional[str] = None):
         """Append data to the buffer along the last axis."""
@@ -473,12 +480,18 @@ class DeviceBuffer:
             size = int(np.prod(shape))
 
         self._ensure_capacity(size)
-        view = self.buffer[..., self._offset:self._offset +
+        current_offset = self._offset
+        view = self.buffer[..., current_offset:current_offset +
                            size].reshape(self.leading_shape + shape)
         self._offset += size
         if key:
             self.set_key(key)
-            self._views[key] = view
+            self._views[key] = {
+                "offset": current_offset,
+                "size": size,
+                "shape": shape,
+                "view": view
+            }
         return view
 
     def set_key(self, key: str):
@@ -503,22 +516,28 @@ class DeviceBuffer:
 
     def get_allocated_view(self, key: str) -> np.ndarray:
         """Get an allocated view by key."""
-        return self._views[key]
+        return self._views[key]["view"]
 
     @staticmethod
     @functools.partial(jax.jit, static_argnums=(1, 2))
+    def _unpack_arrays_jit(
+            blob: jax.Array,
+            metadata: DeviceBufferMetadata,
+            shape: Optional[Tuple[int, ...]] = None) -> List[jax.Array]:
+        indices = tuple(np.cumsum(metadata.sizes)[:-1])
+        parts = jnp.split(blob, indices, axis=-1)
+        if shape:
+            return [x.reshape(shape) for x in parts]
+        return parts
+
+    @staticmethod
     def unpack_arrays(
-        blob: jax.Array,
-        metadata: DeviceBufferMetadata,
-        shape: Optional[Tuple[int, ...]] = None,
-    ) -> Dict[str, jax.Array]:
+            blob: jax.Array,
+            metadata: DeviceBufferMetadata,
+            shape: Optional[Tuple[int, ...]] = None) -> Dict[str, jax.Array]:
         """
         Unpack a blob into a dictionary of arrays based on provided metadata.
         Uses JIT and jnp.split along the last axis.
         """
-        indices = tuple(np.cumsum(metadata.sizes)[:-1])
-        parts = jnp.split(blob, indices, axis=-1)
-        if shape:
-            parts = [x.reshape(shape) for x in parts]
-
+        parts = DeviceBuffer._unpack_arrays_jit(blob, metadata, shape)
         return {key: parts[i] for i, key in enumerate(metadata.keys)}

--- a/tpu_inference/utils.py
+++ b/tpu_inference/utils.py
@@ -499,7 +499,7 @@ class DeviceBuffer:
         self._sizes = []
 
     @staticmethod
-    @functools.partial(jax.jit, static_argnums=(1, 2, 3))
+    @functools.partial(jax.jit, static_argnums=(1, 2))
     def unpack_arrays(
         blob: jax.Array,
         metadata: DeviceBufferMetadata,

--- a/tpu_inference/utils.py
+++ b/tpu_inference/utils.py
@@ -422,32 +422,39 @@ class DeviceBufferMetadata:
 
 class DeviceBuffer:
     """
-    A utility to pack 1D numpy arrays into a monolithic buffer.
+    A utility to pack numpy arrays into a monolithic buffer.
     Supports appending data or getting views, then tagging the accumulated
-    data with a key. The internal buffer grows dynamically as needed.
+    data with a key. The internal buffer has shape `leading_shape + (capacity,)`
+    and grows dynamically along the last axis.
     """
 
-    def __init__(self, initial_capacity: int = 1024):
-        self.buffer = np.zeros(initial_capacity, dtype=np.int32)
+    def __init__(self,
+                 leading_shape: Tuple[int, ...] = (),
+                 initial_capacity: int = 1024):
+        self.leading_shape = leading_shape
+        self.buffer = np.zeros(leading_shape + (initial_capacity, ),
+                               dtype=np.int32)
         self._offset = 0
         self._last_offset = 0
         self._keys: List[str] = []
         self._sizes: List[int] = []
 
     def _ensure_capacity(self, size: int):
-        """Ensure the internal buffer has enough space for 'size' more elements."""
-        if self._offset + size > self.buffer.size:
-            new_capacity = max(self.buffer.size * 2,
+        """Ensure the internal buffer has enough space for 'size' more elements along the last axis."""
+        if self._offset + size > self.buffer.shape[-1]:
+            new_capacity = max(self.buffer.shape[-1] * 2,
                                self._offset + size + 1024)
-            new_buffer = np.zeros(new_capacity, dtype=np.int32)
-            new_buffer[:self._offset] = self.buffer[:self._offset]
+            new_buffer = np.zeros(self.leading_shape + (new_capacity, ),
+                                  dtype=np.int32)
+            new_buffer[..., :self._offset] = self.buffer[..., :self._offset]
             self.buffer = new_buffer
 
     def append(self, array: np.ndarray, key: Optional[str] = None):
-        """Append data to the buffer and advance offset."""
-        size = array.size
+        """Append data to the buffer along the last axis."""
+        assert array.shape[:-1] == self.leading_shape
+        size = array.shape[-1]
         self._ensure_capacity(size)
-        self.buffer[self._offset:self._offset + size] = array.ravel()
+        self.buffer[..., self._offset:self._offset + size] = array
         self._offset += size
         if key:
             self.set_key(key)
@@ -455,7 +462,9 @@ class DeviceBuffer:
     def get_view(self,
                  shape: Union[int, Tuple[int, ...]],
                  key: Optional[str] = None) -> np.ndarray:
-        """Reserve space in the buffer and return a reshaped view for direct writing."""
+        """Reserve space in the buffer and return a view for direct writing.
+        'shape' is the shape of the reserved space per leading dimension instance.
+        """
         if isinstance(shape, (int, np.integer)):
             size = int(shape)
             shape = (size, )
@@ -463,7 +472,8 @@ class DeviceBuffer:
             size = int(np.prod(shape))
 
         self._ensure_capacity(size)
-        view = self.buffer[self._offset:self._offset + size].reshape(shape)
+        view = self.buffer[..., self._offset:self._offset +
+                           size].reshape(self.leading_shape + shape)
         self._offset += size
         if key:
             self.set_key(key)
@@ -478,7 +488,7 @@ class DeviceBuffer:
 
     def build(self) -> Tuple[np.ndarray, DeviceBufferMetadata]:
         """Return the active portion of the buffer and its layout metadata."""
-        return self.buffer[:self._offset], DeviceBufferMetadata(
+        return self.buffer[..., :self._offset], DeviceBufferMetadata(
             keys=tuple(self._keys), sizes=tuple(self._sizes))
 
     def reset(self):
@@ -493,9 +503,9 @@ class DeviceBuffer:
     def unpack_arrays(blob: jax.Array,
                       metadata: DeviceBufferMetadata) -> Dict[str, jax.Array]:
         """
-        Unpack a 1D blob into a dictionary of arrays based on provided metadata.
-        Uses JIT and jnp.split to minimize dispatch overhead.
+        Unpack a blob into a dictionary of arrays based on provided metadata.
+        Uses JIT and jnp.split along the last axis.
         """
         indices = tuple(np.cumsum(metadata.sizes)[:-1])
-        parts = jnp.split(blob, indices)
+        parts = jnp.split(blob, indices, axis=-1)
         return {key: parts[i] for i, key in enumerate(metadata.keys)}


### PR DESCRIPTION
# Description

Optimize TPU runner by reshaping arrays during unpack

Currently, `tpu_runner.py` unpacks the metadata blob and then flattens the arrays individually in Python via `.ravel()`. This introduces unnecessary Python overhead.

This change introduces an optional `shape` argument to `DeviceBuffer.unpack_arrays` and fuses the `reshape` operation directly into the underlying JIT-compiled `_unpack_arrays_jit` helper. 

We now pass `shape=(-1,)` early on, allowing us to remove multiple redundant `.ravel()` calls in the runner.

# Tests

## Profile diff before PR on main vs after PR 

```
SKIP_JAX_PRECOMPILE=1 MODEL_IMPL_TYPE=vllm python3 examples/tpu_profiling.py --model=Qwen/Qwen2.5-1.5B --input-len=16 --output-len=5 --batch-size=8192 --profile-result-dir=gs://piv-test/tpu-profile/apr22/1/ --tensor_parallel_size=1 --data_parallel_size=8 --load-format dummy --max-num-seqs 512
```

Before https://xprof.corp.google.com/trace_viewer/piv-16042588652955926282

After http://xprof.corp.google.com/trace_viewer/piv-862724074156765665

```
SKIP_JAX_PRECOMPILE=1 MODEL_IMPL_TYPE=vllm python3 examples/tpu_profiling.py --model=Qwen/Qwen3.5-397B-A17B-FP8 --profile-result-dir=gs://piv-test/tpu-profile/apr22/5/ --max-model-len=9216 --max-num-batched-tokens=8192 --max-num-seqs=512 --no-enable-prefix-caching --gpu-memory-utilization=0.9 --tensor-parallel-size=8 --async-scheduling --language-model-only --reasoning-parser=qwen3 --kv-cache-dtype=fp8 --enable-expert-parallel
```

Before http://xprof.corp.google.com/trace_viewer/piv-11595214206448007464

After https://xprof.corp.google.com/trace_viewer/piv-16596486843427976847

`_prepare_inputs_non_dp` went from 4.6ms to 3.9ms

## Benchmarking

```
USE_MOE_EP_KERNEL="0" MODEL_IMPL_TYPE="vllm" PHASED_PROFILING_DIR="/mnt/disks/persist/vllm-xprof" vllm serve Qwen/Qwen3.5-397B-A17B-FP8 --max-model-len=9216 --max-num-batched-tokens=8192 --max-num-seqs=512 --no-enable-prefix-caching --gpu-memory-utilization=0.9 --tensor-parallel-size=8 --async-scheduling --port=8000 --language-model-only --enable-auto-tool-choice --tool-call-parser=qwen3_coder --reasoning-parser=qwen3  --kv-cache-dtype=fp8 --enable-expert-parallel
```

```
python ~/tpu/bench_serving/benchmark_serving.py --model Qwen/Qwen3.5-397B-A17B-FP8 --dataset-name random --backend vllm --random-input-len=1024 --random-output-len=8192 --num-prompts=64 --random-range-ratio=0.8 --ignore-eos --save-result --result-dir /tmp/a --max-concurrency=64
```

Before

```
============ Serving Benchmark Result ============
Successful requests:                     64
Benchmark duration (s):                  471.55
Total input tokens:                      59283
Total generated tokens:                  470799
Request throughput (req/s):              0.14
Output token throughput (tok/s):         998.41
Total Token throughput (tok/s):          1124.13
---------------Time to First Token----------------
Mean TTFT (ms):                          4214.70
Median TTFT (ms):                        4044.43
P99 TTFT (ms):                           7379.72
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          60.29
Median TPOT (ms):                        60.42
P99 TPOT (ms):                           63.11
---------------Inter-token Latency----------------
Mean ITL (ms):                           60.18
Median ITL (ms):                         40.45
P99 ITL (ms):                            41.78
==================================================
```

After

```
============ Serving Benchmark Result ============
Successful requests:                     64
Benchmark duration (s):                  471.82
Total input tokens:                      59283
Total generated tokens:                  470799
Request throughput (req/s):              0.14
Output token throughput (tok/s):         997.84
Total Token throughput (tok/s):          1123.49
---------------Time to First Token----------------
Mean TTFT (ms):                          4514.57
Median TTFT (ms):                        4214.77
P99 TTFT (ms):                           7547.71
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          60.30
Median TPOT (ms):                        60.37
P99 TPOT (ms):                           63.15
---------------Inter-token Latency----------------
Mean ITL (ms):                           60.19
Median ITL (ms):                         40.63
P99 ITL (ms):                            41.84
==================================================
```

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
