### PR TITLE
Add warmup runs to OOT perf test to reduce flakiness

### DIFF
--- a/tests/e2e/test_model_loader.py
+++ b/tests/e2e/test_model_loader.py
@@ -256,7 +256,15 @@ def test_flax_nnx_vs_vllm_performance():
     # This should be 2-3% but 8% reduces flakiness.
     percentage_difference_threshold = 0.08
 
+    # Warmup each backend before measuring to populate JAX compilation cache.
+    # Without this, the first-run backend pays the compilation cost and
+    # appears slower, causing flaky failures.
+    print("Running warmup (vllm) to populate JAX compilation cache...")
+    _run_server_and_bench(model_name, "vllm", 8000)
     throughput_vllm = _run_server_and_bench(model_name, "vllm", 8001)
+
+    print("Running warmup (flax_nnx) to populate JAX compilation cache...")
+    _run_server_and_bench(model_name, "flax_nnx", 8000)
     throughput_flax = _run_server_and_bench(model_name, "flax_nnx", 8002)
 
     print(f"vLLM (PyTorch) throughput: {throughput_vllm:.2f} req/s.")


### PR DESCRIPTION
## Summary

`tests/e2e/test_model_loader.py::test_flax_nnx_vs_vllm_performance` has been flaky since Apr 14. Whichever backend runs first pays the JAX compilation cost and appears slower, while the second backend benefits from the warm cache. The test then fails when the throughput gap exceeds the threshold.

Fix: run a warmup for each backend before its measured run, so neither measured run pays the compilation cost.

Order: `warmup(vllm) -> measure(vllm) -> warmup(flax_nnx) -> measure(flax_nnx)`.

## Validation

Verified on [tpu-inference-dev build #80](https://buildkite.com/tpu-commons/tpu-inference-dev/builds/80): 10 parallel runs of the test on `tpu_v7x_2_queue`, all passed.

## Test plan

- [x] Run the test 10x in parallel on tpu7x — passed (https://buildkite.com/tpu-commons/tpu-inference-dev/builds/80 )
- [ ] Monitor CI nightly for a few days to confirm flakiness is gone