### PR TITLE
[Bug][Qwen3.5] Fix KV cache OOB block IDs in hybrid attn+mamba models

### DIFF
--- a/tests/runner/test_kv_cache_manager.py
+++ b/tests/runner/test_kv_cache_manager.py
@@ -862,6 +862,7 @@ class TestKVCacheManager:
         per-layer TPU allocation.
         """
         self.runner.cache_config.block_size = 1056
+        self.runner.cache_config.mamba_block_size = 1056
         self.runner.kv_cache_dtype = torch.float8_e4m3fn
         self.runner.cache_config.mamba_page_size_padded = None
 

--- a/tests/runner/test_kv_cache_manager.py
+++ b/tests/runner/test_kv_cache_manager.py
@@ -824,18 +824,94 @@ class TestKVCacheManager:
         }
         self.runner.vllm_config.compilation_config.static_forward_context = layers
 
+        # Unpadded mamba page size for DummyMamba: (3*12288)*2 + (64*128*128)*4
+        expected_mamba_unpadded = 3 * 12288 * 2 + 64 * 128 * 128 * 4
+        expected_attn_page_size = 1081344  # what update_mamba_page_size_padded
+        # previously set. For this 1:1 hybrid the new uniform page size is
+        # attn_page + mamba_unpadded.
+        expected_uniform = expected_attn_page_size + expected_mamba_unpadded
+
         with patch(
                 'tpu_inference.runner.kv_cache_manager.get_layers_from_vllm_config',
                 return_value=layers):
             kv_cache_spec = self.runner.get_kv_cache_spec()
 
-            # Verify the mamba page size was unified with full attention.
-            assert self.runner.cache_config.mamba_page_size_padded == 1081344
+            # Every layer spec (both mamba and attn) is padded to the
+            # per-shared_by sum so vLLM sees a uniform page size and sizes
+            # its block pool to match per-layer TPU allocation.
+            assert self.runner.cache_config.mamba_page_size_padded == \
+                expected_uniform
 
-            # The layer spec should reflect the cache config update.
             mamba_spec = kv_cache_spec['linear_attn']
             assert isinstance(mamba_spec, MambaSpec)
-            assert mamba_spec.page_size_padded == 1081344
+            assert mamba_spec.page_size_padded == expected_uniform
+
+            attn_spec = kv_cache_spec['full_attn']
+            assert isinstance(attn_spec, FullAttentionSpec)
+            assert attn_spec.page_size_padded == expected_uniform
+            # Uniform check: vLLM would fail otherwise.
+            assert attn_spec.page_size_bytes == mamba_spec.page_size_bytes
+
+    def test_get_kv_cache_spec_hybrid_uniform_page_size_qwen35_ratio(self):
+        """Verify update_mamba_page_size_padded for a 10:30 attn:mamba model.
+
+        For Qwen3.5 (10 full-attn layers + 30 linear-attn layers), vLLM's
+        hybrid grouping produces `group_size=10` and 4 kv-cache groups
+        (1 attn + 3 mamba). The fix pads each layer spec to
+        `attn_page + 3 * mamba_unpadded` so vLLM's num_blocks matches
+        per-layer TPU allocation.
+        """
+        self.runner.cache_config.block_size = 1056
+        self.runner.kv_cache_dtype = torch.float8_e4m3fn
+        self.runner.cache_config.mamba_page_size_padded = None
+
+        class DummyMamba(MambaBase):
+
+            def __init__(self):
+                super().__init__()
+
+            def get_state_shape(self):
+                return ((3, 12288), (64, 128, 128))
+
+            def get_state_dtype(self):
+                return (torch.bfloat16, torch.float32)
+
+            @property
+            def mamba_type(self):
+                return "dummy"
+
+        layers: dict = {}
+        for i in range(30):
+            layers[f'linear_attn.{i}'] = DummyMamba()
+        for i in range(10):
+            mock_attn = MagicMock(spec=Attention)
+            mock_attn.attn_type = AttentionType.DECODER
+            mock_attn.num_kv_heads = 2
+            mock_attn.head_size = 256
+            mock_attn.sliding_window = None
+            mock_attn.kv_sharing_target_layer_name = None
+            layers[f'full_attn.{i}'] = mock_attn
+
+        mamba_unpadded = 3 * 12288 * 2 + 64 * 128 * 128 * 4
+        attn_page = 1081344
+        expected_uniform = attn_page + 3 * mamba_unpadded
+
+        self.runner.vllm_config.compilation_config.static_forward_context = \
+            layers
+
+        with patch(
+                'tpu_inference.runner.kv_cache_manager.get_layers_from_vllm_config',
+                return_value=layers):
+            kv_cache_spec = self.runner.get_kv_cache_spec()
+
+        assert self.runner.cache_config.mamba_page_size_padded == \
+            expected_uniform, (
+                f"expected {expected_uniform}, "
+                f"got {self.runner.cache_config.mamba_page_size_padded}")
+        for name, spec in kv_cache_spec.items():
+            assert spec.page_size_bytes == expected_uniform, (
+                f"layer {name} has page_size_bytes={spec.page_size_bytes} "
+                f"but expected uniform={expected_uniform}")
 
     def test_get_kv_cache_spec_pure_attention_no_cache_config_updates(self):
         mock_attn = MagicMock(spec=MambaBase)
@@ -848,7 +924,20 @@ class TestKVCacheManager:
 
     def test_hybrid_mamba_num_blocks(self):
         num_blocks = 100
-        attn_page_size = 67584
+        # The duplicate-path num_blocks calc now uses the TPU-actual
+        # attention per-block size (`get_attention_page_size_bytes`) on
+        # both sides of the comparison — so the mock spec's `num_kv_heads`,
+        # `head_size`, `block_size`, and `dtype` have to produce the
+        # expected `attn_page_size` when fed through that function.
+        attn_spec_block_size = self.runner.vllm_config.cache_config.block_size
+        attn_spec_num_kv_heads = 8
+        attn_spec_head_size = 128
+        attn_spec_dtype = torch.bfloat16
+        attn_page_size = get_attention_page_size_bytes(self.runner.mesh,
+                                                       attn_spec_block_size,
+                                                       attn_spec_num_kv_heads,
+                                                       attn_spec_head_size,
+                                                       attn_spec_dtype, False)
 
         mamba_shapes = ((4, 128), (8, 32, 32))
         mamba_dtypes = (torch.bfloat16, torch.float32)
@@ -861,17 +950,17 @@ class TestKVCacheManager:
             block_size=self.runner.vllm_config.cache_config.block_size,
             shapes=mamba_shapes,
             dtypes=mamba_dtypes,
-            page_size_padded=67584)
+            page_size_padded=attn_page_size)
 
         # Total tensor size derived from sum of the unpadded Mamba page size and the Attention page size
         tensor_size = num_blocks * (mamba_unpadded_page_size + attn_page_size)
 
         attn_spec = MagicMock(spec=FullAttentionSpec)
-        attn_spec.block_size = self.runner.vllm_config.cache_config.block_size
+        attn_spec.block_size = attn_spec_block_size
         attn_spec.page_size_bytes = attn_page_size
-        attn_spec.num_kv_heads = 8
-        attn_spec.head_size = 128
-        attn_spec.dtype = torch.bfloat16
+        attn_spec.num_kv_heads = attn_spec_num_kv_heads
+        attn_spec.head_size = attn_spec_head_size
+        attn_spec.dtype = attn_spec_dtype
 
         layer_names = ['layer.0', 'layer.1']
         kv_cache_groups = [
@@ -904,3 +993,117 @@ class TestKVCacheManager:
 
         attn_cache = self.runner.kv_caches[1]
         assert attn_cache.shape[0] == num_blocks
+
+    def test_hybrid_num_blocks_matches_vllm_pool_for_qwen35_topology(self):
+        """Regression test for the OOB block-id bug observed on Qwen3.5.
+
+        vLLM's hybrid allocator groups Qwen3.5's 40 layers into 4 kv-cache
+        groups (1 full-attn + 3 linear-attn/mamba), then builds
+        `group_size=10` `KVCacheTensor`s, each `shared_by` one layer per
+        group (so shared_by has 4 layer names). Block ids are drawn from a
+        single shared pool of size `kv_cache_config.num_blocks`. Before the
+        fix, per-layer num_blocks on TPU was `tensor.size /
+        total_group_page_size` (~vllm_num_blocks / 3.5 for Qwen3.5), so the
+        scheduler could hand out a block id beyond a layer's cache range.
+
+        After the fix, every layer spec is padded so
+        `tensor.size / uniform_page_size == kv_cache_config.num_blocks`, and
+        each duplicated per-layer cache has exactly that many slots.
+        """
+        num_blocks = 7  # matches gpu-memory-utilization=0.36 in the repro
+
+        # Attention per-block size comes from `get_attention_page_size_bytes`
+        # (same as what `update_mamba_page_size_padded` uses) — on fp8
+        # models this differs from `spec.real_page_size_bytes` because of
+        # TPU packing, so stay consistent.
+        attn_spec_block_size = self.runner.vllm_config.cache_config.block_size
+        attn_spec_num_kv_heads = 8
+        attn_spec_head_size = 128
+        attn_spec_dtype = torch.bfloat16
+        attn_page_size = get_attention_page_size_bytes(self.runner.mesh,
+                                                       attn_spec_block_size,
+                                                       attn_spec_num_kv_heads,
+                                                       attn_spec_head_size,
+                                                       attn_spec_dtype, False)
+
+        mamba_shapes = ((3, 12288), (64, 128, 128))
+        mamba_dtypes = (torch.bfloat16, torch.float32)
+        mamba_unpadded = sum(
+            int(np.prod(shape)) * torch.tensor([], dtype=dtype).element_size()
+            for shape, dtype in zip(mamba_shapes, mamba_dtypes))
+
+        # 1 full-attn + 3 linear-attn per shared_by, so the spec padding
+        # applied by the fix is (1*attn + 3*mamba_unpadded).
+        uniform_page_size = attn_page_size + 3 * mamba_unpadded
+
+        # vLLM computes this for hybrid: tensor.size = uniform * num_blocks.
+        tensor_size = uniform_page_size * num_blocks
+
+        # Every layer spec reports `page_size_bytes == uniform_page_size`
+        # after the fix (MambaSpec via page_size_padded, AttentionSpec via
+        # page_size_padded as well).
+        mamba_spec = MambaSpec(
+            block_size=self.runner.vllm_config.cache_config.block_size,
+            shapes=mamba_shapes,
+            dtypes=mamba_dtypes,
+            page_size_padded=uniform_page_size,
+        )
+
+        attn_spec = MagicMock(spec=FullAttentionSpec)
+        attn_spec.block_size = attn_spec_block_size
+        attn_spec.page_size_bytes = uniform_page_size
+        attn_spec.num_kv_heads = attn_spec_num_kv_heads
+        attn_spec.head_size = attn_spec_head_size
+        attn_spec.dtype = attn_spec_dtype
+
+        # 10 shared_by tensors, each holding 1 attn + 3 mamba layers
+        # (Qwen3.5: 10 full-attn, 30 linear-attn).
+        layer_names_per_tensor = [(f'attn.{i}', f'mamba_a.{i}', f'mamba_b.{i}',
+                                   f'mamba_c.{i}') for i in range(10)]
+        attn_layer_names = [t[0] for t in layer_names_per_tensor]
+        mamba_a_names = [t[1] for t in layer_names_per_tensor]
+        mamba_b_names = [t[2] for t in layer_names_per_tensor]
+        mamba_c_names = [t[3] for t in layer_names_per_tensor]
+
+        kv_cache_groups = [
+            KVCacheGroupSpec(layer_names=attn_layer_names,
+                             kv_cache_spec=attn_spec),
+            KVCacheGroupSpec(layer_names=mamba_a_names,
+                             kv_cache_spec=mamba_spec),
+            KVCacheGroupSpec(layer_names=mamba_b_names,
+                             kv_cache_spec=mamba_spec),
+            KVCacheGroupSpec(layer_names=mamba_c_names,
+                             kv_cache_spec=mamba_spec),
+        ]
+        kv_cache_tensors = [
+            KVCacheTensor(size=tensor_size, shared_by=list(names))
+            for names in layer_names_per_tensor
+        ]
+        kv_cache_config = KVCacheConfig(
+            num_blocks=num_blocks,
+            kv_cache_tensors=kv_cache_tensors,
+            kv_cache_groups=kv_cache_groups,
+        )
+
+        self.runner.initialize_kv_cache(kv_cache_config)
+
+        # 10 tensors × 4 duplicated layers = 40 caches, one per layer.
+        assert len(self.runner.kv_caches) == 40
+
+        # The whole point of the fix: every layer's physical cache holds
+        # exactly `kv_cache_config.num_blocks` slots so block ids from
+        # vLLM's shared pool can never index out of range.
+        for name in (attn_layer_names + mamba_a_names + mamba_b_names +
+                     mamba_c_names):
+            idx = self.runner.layer_name_to_kvcache_index[name]
+            cache = self.runner.kv_caches[idx]
+            if isinstance(cache, tuple):  # mamba: (conv_state, ssm_state)
+                for state in cache:
+                    assert state.shape[0] == num_blocks, (
+                        f"layer {name} mamba state has "
+                        f"{state.shape[0]} blocks but vLLM pool has "
+                        f"{num_blocks}")
+            else:
+                assert cache.shape[0] == num_blocks, (
+                    f"layer {name} attn cache has {cache.shape[0]} blocks "
+                    f"but vLLM pool has {num_blocks}")

--- a/tpu_inference/runner/kv_cache_manager.py
+++ b/tpu_inference/runner/kv_cache_manager.py
@@ -56,6 +56,13 @@ class KVCacheManager:
         # from the KV cache of `shared_kv_cache_layers[layer_name]`.
         self.shared_kv_cache_layers: dict[str, str] = {}
         self.use_mla = self.runner.model_config.use_mla
+        # Set by `update_mamba_page_size_padded` for hybrid attention+mamba
+        # models. When set, every attention layer spec reports this as its
+        # `page_size_padded` so vLLM sees a uniform page size across groups
+        # and computes `num_blocks` that matches what each layer actually gets
+        # on the TPU side (where we duplicate the shared tensor per layer
+        # because mamba and attention caches have different shapes).
+        self._hybrid_uniform_page_size_bytes: int | None = None
 
     def _create_attention_spec(
             self,
@@ -67,38 +74,72 @@ class KVCacheManager:
             page_size_bytes = get_attention_page_size_bytes(
                 self.runner.mesh, block_size, num_kv_heads, head_size,
                 self.runner.kv_cache_dtype, True)
+            page_size_padded = (self._hybrid_uniform_page_size_bytes
+                                if self._hybrid_uniform_page_size_bytes
+                                is not None else int(page_size_bytes))
             return MLAAttentionSpec(block_size=block_size,
                                     num_kv_heads=1,
                                     head_size=head_size,
                                     dtype=self.runner.kv_cache_dtype,
                                     cache_dtype_str=self.runner.vllm_config.
                                     cache_config.cache_dtype,
-                                    page_size_padded=int(page_size_bytes))
+                                    page_size_padded=page_size_padded)
         else:
             page_size_bytes = get_attention_page_size_bytes(
                 self.runner.mesh, block_size, num_kv_heads, head_size,
                 self.runner.kv_cache_dtype, False)
+            page_size_padded = (self._hybrid_uniform_page_size_bytes
+                                if self._hybrid_uniform_page_size_bytes
+                                is not None else int(page_size_bytes))
             if sliding_window is not None:
                 return SlidingWindowSpec(block_size=block_size,
                                          num_kv_heads=num_kv_heads,
                                          head_size=head_size,
                                          dtype=self.runner.kv_cache_dtype,
                                          sliding_window=sliding_window,
-                                         page_size_padded=int(page_size_bytes))
+                                         page_size_padded=page_size_padded)
             else:
                 return FullAttentionSpec(block_size=block_size,
                                          num_kv_heads=num_kv_heads,
                                          head_size=head_size,
                                          dtype=self.runner.kv_cache_dtype,
-                                         page_size_padded=int(page_size_bytes))
+                                         page_size_padded=page_size_padded)
 
     def update_mamba_page_size_padded(
             self, layers: dict[str, AttentionLayerBase]) -> None:
-        """Set mamba padded page size to match the full attention page size.
+        """Pad attention and mamba page sizes so vLLM's num_blocks matches
+        what the TPU allocates per layer.
 
-        vLLM expects hybrid models to share KV cache across different attention
-        modules. This updates `mamba_page_size_padded` to the larger footprint
-        of full attention layers to unify the page sizes.
+        For hybrid attention+mamba models, vLLM groups a tensor's memory so
+        that one `KVCacheTensor` is `shared_by` one layer from each kv-cache
+        group (e.g., Qwen3.5: 1 full-attn + 3 linear-attn per shared_by).
+        vLLM's scheduler assumes these layers share a single physical
+        tensor at the byte level — each layer's block_table indexes into
+        disjoint slots of the same backing allocation, and device kernels
+        reinterpret the bytes as attention KV or mamba state depending on
+        which layer is accessing the slot.
+
+        TPU `jax.Array`s are strongly typed, so we cannot overlay an
+        attention tensor and a mamba tensor on the same bytes.
+        `initialize_kv_cache` therefore allocates one physical array per
+        layer in the `shared_by` group, carving the group's byte budget
+        into separate per-layer tensors. Without the compensation done
+        here, vLLM's block pool would hold `num_shared_layers`× more
+        block IDs than each per-layer array has slots — the scheduler
+        would hand out block IDs beyond a layer's leading dimension,
+        JAX's indexed writes would silently clip them, and multiple
+        requests' mamba recurrent states would collapse onto the same
+        slot (corrupted state → gibberish generation).
+
+        The fix: set every layer's reported `page_size_padded` equal to the
+        full per-`shared_by` footprint — `num_attn_groups × attn_page +
+        num_mamba_groups × mamba_unpadded`, where `attn_page` is the
+        TPU-actual per-block bytes (from `get_attention_page_size_bytes`,
+        which accounts for dtype packing like fp8) and `mamba_unpadded` is
+        the natural `prod(shape) × dtype_size`. vLLM then computes a
+        smaller `num_blocks` that exactly matches what we allocate per layer
+        on the TPU side. HBM usage is unchanged; only the block-ID
+        accounting lines up.
 
         Args:
             layers: A dictionary mapping layer names to their corresponding
@@ -122,12 +163,178 @@ class KVCacheManager:
                                                 ShardingAxisName.ATTN_HEAD))
         head_size = common_utils.get_padded_head_dim(
             first_attn_module.head_size)
-        page_size_bytes = get_attention_page_size_bytes(
+        attn_page_size_bytes = get_attention_page_size_bytes(
             self.runner.mesh, self.runner.cache_config.block_size,
             num_kv_heads, head_size, self.runner.kv_cache_dtype, False)
-        logger.debug("Setting padded mamba page size in cache config to %d",
-                     page_size_bytes)
-        self.runner.cache_config.mamba_page_size_padded = page_size_bytes
+
+        mamba_modules = [
+            module for module in layers.values()
+            if isinstance(module, MambaBase)
+        ]
+        if not mamba_modules:
+            # Not hybrid; set `mamba_page_size_padded` to the attention
+            # page size as a no-op default (vLLM's platform interface sets
+            # this too when it detects hybrid). No layer duplication will
+            # happen without mamba layers, so no block-ID mismatch to fix.
+            logger.debug(
+                "Setting padded mamba page size in cache config to %d",
+                attn_page_size_bytes)
+            self.runner.cache_config.mamba_page_size_padded = (
+                attn_page_size_bytes)
+            return
+
+        # Compute the unpadded mamba page size from an actual mamba module's
+        # spec (shapes × dtype-size), ignoring any existing padding.
+        first_mamba_spec = mamba_modules[0].get_kv_cache_spec(
+            self.runner.vllm_config)
+        assert isinstance(first_mamba_spec, MambaSpec)
+        unpadded_mamba_page_size = dataclasses.replace(
+            first_mamba_spec, page_size_padded=None).page_size_bytes
+
+        # Derive vLLM's kv-cache group layout. vLLM splits each type into
+        # equal-sized groups of `group_size` layers, then allocates
+        # `group_size` `KVCacheTensor`s, each `shared_by` one layer from
+        # every group — so each tensor covers `num_attn_groups +
+        # num_mamba_groups` layers.
+        #
+        # Choosing `group_size` trades off padding vs. number of groups:
+        #   * group_size = max_count → fewer groups (often 1 per type),
+        #     but the smaller side pads its group up to max_count layers
+        #     (wastes space if max ≫ min).
+        #   * group_size = min_count → no padding, but the larger side
+        #     splits into `ceil(max/min)` groups.
+        # vLLM's rule: pick max_count only when counts are close enough
+        # that the padding is minor (max < 1.5 × min), else min_count.
+        #   e.g. 12 sliding-window + 13 full-attn → max (1 group each)
+        #   e.g. 10 full-attn      + 30 mamba     → min (1 attn + 3 mamba)
+        #
+        # This duplicates the heuristic from
+        # `vllm/v1/core/kv_cache_utils.py::_get_kv_cache_groups_uniform_page_size`.
+        # We can't call it directly because vLLM's grouping needs a fully
+        # populated spec dict, while we need the group layout *before* we
+        # can finish creating the specs (padding depends on grouping,
+        # spec creation depends on padding). Keep in sync if that
+        # heuristic ever changes — it has been stable since the hybrid
+        # allocator landed.
+        num_attn = len(attn_modules)
+        num_mamba = len(mamba_modules)
+        min_count = min(num_attn, num_mamba)
+        max_count = max(num_attn, num_mamba)
+        # Match vLLM exactly: float comparison, no int() truncation (matters
+        # at e.g. min=3, max=4, where 4 < 4.5 but 4 < int(4.5)==4 differs).
+        if max_count < min_count * 1.5:
+            group_size = max_count
+        else:
+            group_size = min_count
+        num_attn_groups = (num_attn + group_size - 1) // group_size
+        num_mamba_groups = (num_mamba + group_size - 1) // group_size
+
+        uniform_page_size_bytes = (num_attn_groups * attn_page_size_bytes +
+                                   num_mamba_groups * unpadded_mamba_page_size)
+
+        logger.info(
+            "Hybrid KV cache: padding every layer spec to %d bytes "
+            "(num_attn_groups=%d × attn_page=%d + "
+            "num_mamba_groups=%d × mamba_unpadded=%d). This makes vLLM's "
+            "num_blocks match per-layer TPU allocation when mamba layers "
+            "cannot be truly shared.", uniform_page_size_bytes,
+            num_attn_groups, attn_page_size_bytes, num_mamba_groups,
+            unpadded_mamba_page_size)
+
+        self._hybrid_uniform_page_size_bytes = int(uniform_page_size_bytes)
+        self.runner.cache_config.mamba_page_size_padded = int(
+            uniform_page_size_bytes)
+
+        # Pin vLLM's num_blocks via a two-step flooring that keeps peak
+        # HBM within `gpu_memory_utilization × total_hbm` at high
+        # utilization. See `_maybe_set_num_blocks_override` for the
+        # formula and rationale; the short version is that vLLM's
+        # single-step `floor(avail / (uniform × group_size))` can land
+        # one block higher than the two-step value, and that extra
+        # block × group_size × uniform bytes is enough to push past the
+        # budget against imprecision in vLLM's `avail` estimate.
+        self._maybe_set_num_blocks_override(attn_page_size_bytes,
+                                            int(uniform_page_size_bytes),
+                                            group_size)
+
+    def _maybe_set_num_blocks_override(self, attn_page_size_bytes: int,
+                                       uniform_page_size_bytes: int,
+                                       group_size: int) -> None:
+        """Pin `cache_config.num_gpu_blocks_override` to the two-step
+        flooring value that keeps peak HBM within the user-set
+        `gpu_memory_utilization` budget at high utilization.
+
+        Formula:
+          `num_blocks_attn = floor(avail / (attn_page × group_size))`
+          `num_blocks_tpu  = floor(attn_page × num_blocks_attn / uniform)`
+
+        The two-step flooring can land 1 block lower than vLLM's
+        single-step `floor(avail / (uniform × group_size))`. Since
+        `uniform > attn_page`, that 1-block gap costs `group_size × uniform`
+        bytes of HBM, which — against the imprecision in vLLM's `avail`
+        estimate — is enough to tip high-utilization configurations into
+        OOM. Pinning to `num_blocks_tpu` preserves the headroom the
+        single-step formula silently removes.
+
+        No internal safety margin is applied — `gpu_memory_utilization` is
+        the knob users already have for reserving headroom. Adding a
+        silent reduction here would conflict with their explicit budget.
+
+        Skipped if the user has explicitly set `num_gpu_blocks_override` or
+        if HBM usage isn't readable (e.g. in tests without real devices).
+        Spec padding alone still fixes the OOB bug in that case; only the
+        ~1-block-per-tensor flooring-boundary precision is lost.
+
+        Args:
+            attn_page_size_bytes: TPU-actual bytes per block for one
+                attention layer, from `get_attention_page_size_bytes`
+                (accounts for dtype packing like fp8).
+            uniform_page_size_bytes: bytes per block for one `KVCacheTensor`
+                shared across `num_attn_groups + num_mamba_groups` layers
+                (the `_hybrid_uniform_page_size_bytes` value set above).
+            group_size: number of layers per vLLM kv-cache group, used by
+                vLLM to compute `num_blocks` from the attention tensor size.
+
+        Returns:
+            None. Side effect: sets `cache_config.num_gpu_blocks_override`
+            if all preconditions hold; otherwise leaves it unset.
+        """
+        cache_config = self.runner.cache_config
+        if cache_config.num_gpu_blocks_override is not None:
+            return
+
+        devices = self.runner.mesh.devices.flatten()
+        try:
+            hbm_usage = utils.hbm_usage_bytes(devices)
+        except Exception as exc:  # noqa: BLE001
+            logger.debug(
+                "Skipping num_gpu_blocks_override: hbm_usage_bytes failed "
+                "(%s). Spec padding alone still fixes the OOB bug; the "
+                "scheduler's pool may exceed per-layer TPU capacity by one "
+                "block at flooring boundaries.", exc)
+            return
+
+        total_limit = sum(limit for _, limit in hbm_usage)
+        total_used = sum(used for used, _ in hbm_usage)
+        gpu_mem_util = cache_config.gpu_memory_utilization
+        avail = int(total_limit * gpu_mem_util - total_used)
+        if avail <= 0:
+            return
+
+        naive_vllm_num_blocks = avail // (attn_page_size_bytes * group_size)
+        if naive_vllm_num_blocks <= 0:
+            return
+        naive_tensor_size = attn_page_size_bytes * naive_vllm_num_blocks
+        num_blocks_tpu = naive_tensor_size // uniform_page_size_bytes
+        if num_blocks_tpu <= 0:
+            return
+
+        cache_config.num_gpu_blocks_override = int(num_blocks_tpu)
+        logger.info(
+            "Hybrid KV cache: setting num_gpu_blocks_override=%d to align "
+            "the scheduler's block pool with per-layer TPU allocation "
+            "(avail=%d, naive_vllm_num_blocks=%d).", num_blocks_tpu, avail,
+            naive_vllm_num_blocks)
 
     def get_kv_cache_spec(self):
         # TODO(xiang): this hack tricks engine core to init successfully
@@ -385,15 +592,23 @@ class KVCacheManager:
                 total_group_page_size = 0
                 for name in kv_cache_tensor.shared_by:
                     spec = layer_name_to_spec[name]
-                    # MambaSpec has a padded page size to unify it with full
-                    # attention layers. If duplicating, use unpadded size for
-                    # num_blocks calculation to make it consistent with actual
-                    # allocation and avoid underutilization of HBM.
+                    # Use the per-layer *TPU-actual* per-block bytes so the
+                    # sum equals the `page_size_padded` that
+                    # `update_mamba_page_size_padded` installed on every
+                    # spec (== attn_page + N × mamba_unpadded). For
+                    # attention, the TPU-actual size includes dtype-
+                    # specific packing (e.g., fp8 KV packs 4 elements per
+                    # 32-bit word) which `spec.real_page_size_bytes`
+                    # doesn't account for — on fp8 models they differ by
+                    # 2×, which would break the num_blocks match here.
                     if isinstance(spec, MambaSpec):
                         total_group_page_size += dataclasses.replace(
                             spec, page_size_padded=None).page_size_bytes
                     else:
-                        total_group_page_size += spec.page_size_bytes
+                        total_group_page_size += get_attention_page_size_bytes(
+                            self.runner.mesh, spec.block_size,
+                            spec.num_kv_heads, spec.head_size, spec.dtype,
+                            self.use_mla)
                 num_blocks = kv_cache_tensor.size // total_group_page_size
             else:
                 # If sharing KV cache, compute `num_blocks` using the page size
@@ -506,6 +721,13 @@ class KVCacheManager:
                 self.runner.layer_name_to_kvcache_index[
                     layer_name] = self.runner.layer_name_to_kvcache_index[
                         target_layer_name]
+
+        logger.info(
+            "Hybrid KV cache layout: num_kv_cache_groups=%d, "
+            "num_kv_cache_tensors=%d, kv_cache_config.num_blocks=%d, "
+            "duplicate_shared_layers=%s", len(kv_cache_config.kv_cache_groups),
+            len(kv_cache_config.kv_cache_tensors), kv_cache_config.num_blocks,
+            duplicate_shared_layers)
 
         log_parts = [
             "Init kv-cache", f"num_total_layers={len(kv_caches)}",


### PR DESCRIPTION
  ## Summary
  Fixes a silent KV-cache corruption on TPU for hybrid attention + mamba
  models (e.g. Qwen3.5-A3B / A17B) that manifests as gibberish output when
  2+ requests run concurrently at modest `gpu_memory_utilization`.

  ## Root cause

  vLLM's hybrid allocator sizes one `KVCacheTensor` per `shared_by` group
  (Qwen3.5: 1 full-attn + 3 linear-attn = 4 layers sharing a tensor),
  relying on **GPU-style byte-level reinterpretation** — the four layers
  point at disjoint slots within the same physical tensor, and CUDA
  kernels reinterpret the bytes as attention KV or mamba state.

  TPU can't do that: `jax.Array`s are strongly typed, so tpu-inference
  **duplicates** each of the 4 layers into its own physical tensor. That
  divides the `shared_by` budget four ways, leaving each per-layer cache
  with roughly `1 / (num_attn_per_shared + num_mamba_per_shared)` the
  block count that vLLM's scheduler thinks exists (~3.5× smaller for
  Qwen3.5).

  When the scheduler hands out a block ID past the per-layer slot count,
  JAX's `dynamic_update_slice_in_dim` silently clips it to the last valid
  slot. Multiple requests' mamba recurrent states collapse onto the same
  slot → corrupted state → gibberish. Attention layers have the same
  mismatch but usually only manifest when IDs climb high (concurrency
  high, memory low).

  ## Fix

  Two coordinated changes in `tpu_inference/runner/kv_cache_manager.py`:

  1. **Pad every layer spec's `page_size_padded`** to the full per-
     `shared_by` footprint (`num_attn_groups × attn_page + num_mamba_groups
     × mamba_unpadded`). vLLM's uniform-page-size check passes, and its
     `num_blocks` calculation now reflects the duplicated-tensor reality.

  2. **Set `num_gpu_blocks_override`** to exactly match the block count
     that main's buggy-but-memory-accurate formula would land on. This
     eliminates a 1-block flooring-boundary drift between vLLM's naive
     padded calc and main's effective TPU allocation, so peak HBM usage is
     identical to main bit-for-bit.

  `attn_page` consistently uses `get_attention_page_size_bytes` (which
  accounts for dtype-specific packing like fp8) on both sides of the
  `tensor.size / total_group_page` computation, so fp8 KV cache models
  (397B-A17B) work too.


Eval results
```
|       Tasks       |Version|    Filter    |n-shot|  Metric   |   |Value |   |Stderr|
|-------------------|------:|--------------|-----:|-----------|---|-----:|---|-----:|
|mmlu_pro           |      2|custom-extract|      |exact_match|↑  |0.8179|±  |0.0230|
| - biology         |      3|custom-extract|     5|exact_match|↑  |0.8500|±  |0.0819|
| - business        |      3|custom-extract|     5|exact_match|↑  |0.7500|±  |0.0993|
| - chemistry       |      3|custom-extract|     5|exact_match|↑  |0.8000|±  |0.0918|
| - computer_science|      3|custom-extract|     5|exact_match|↑  |0.8000|±  |0.0918|
| - economics       |      3|custom-extract|     5|exact_match|↑  |0.9500|±  |0.0500|
| - engineering     |      3|custom-extract|     5|exact_match|↑  |0.7000|±  |0.1051|
| - health          |      3|custom-extract|     5|exact_match|↑  |0.7500|±  |0.0993|
| - history         |      3|custom-extract|     5|exact_match|↑  |0.8000|±  |0.0918|
| - law             |      3|custom-extract|     5|exact_match|↑  |0.7000|±  |0.1051|
| - math            |      3|custom-extract|     5|exact_match|↑  |0.9500|±  |0.0500|
| - other           |      3|custom-extract|     5|exact_match|↑  |0.7500|±  |0.0993|
| - philosophy      |      3|custom-extract|     5|exact_match|↑  |0.7500|±  |0.0993|
| - physics         |      3|custom-extract|     5|exact_match|↑  |1.0000|±  |0.0000|
| - psychology      |      3|custom-extract|     5|exact_match|↑  |0.9000|±  |0.0688|

| Groups |Version|    Filter    |n-shot|  Metric   |   |Value |   |Stderr|
|--------|------:|--------------|------|-----------|---|-----:|---|-----:|
|mmlu_pro|      2|custom-extract|      |exact_match|↑  |0.8179|±  | 0.023|