### PR TITLE
[CI] Fix Correctness tests for Multimodal Inputs

### DIFF
--- a/tests/e2e/test_multi_modal_inference.py
+++ b/tests/e2e/test_multi_modal_inference.py
@@ -78,6 +78,11 @@ def test_multi_modal_inference(monkeypatch, enable_dynamic_image_sizes):
     engine_args["additional_config"][
         "enable_dynamic_image_sizes"] = enable_dynamic_image_sizes
     engine_args["compilation_config"]["cudagraph_capture_sizes"] = []
+    if engine_args["compilation_config"].get("pass_config") is None:
+        engine_args["compilation_config"]["pass_config"] = {}
+
+    engine_args["compilation_config"]["pass_config"][
+        "fuse_minimax_qk_norm"] = False
 
     llm = LLM(**engine_args)
 


### PR DESCRIPTION
# Description

Fix the error `pass_config.fuse_minimax_qk_norm pydantic ValidationError (None not valid bool)` occurred in v6 and v7 Multimodal Inputs tests.

# Tests

Tested locally on v7 with `python3 -m pytest -s -v tests/e2e/test_multi_modal_inference.py`.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
