### PR TITLE
feat: Update GKE offload examples for Qwen3-235B on tpu7x

### DIFF
--- a/examples/offload/gke/benchmarks/README.md
+++ b/examples/offload/gke/benchmarks/README.md
@@ -6,8 +6,7 @@ This guide outlines the steps to deploy a vLLM serving instance on Google Kubern
 
 * `kubectl` configured to connect to your GKE cluster.
 * `gcloud` CLI installed and authenticated.
-* A GKE cluster with TPU nodes (the below steps have been verified with `ct6e-standard-8t` GKE node)
-* Access to Llama-3.3-70B model on Hugging Face
+* A GKE cluster with TPU nodes (the below steps have been verified with `tpu7x-standard-4t` GKE node)
 
 ## 1. Create Hugging Face Token Secret
 

--- a/examples/offload/gke/benchmarks/benchmark-pod.yaml
+++ b/examples/offload/gke/benchmarks/benchmark-pod.yaml
@@ -50,20 +50,20 @@ spec:
     - name: PORT
       value: "80"
     - name: MODEL
-      value: "meta-llama/Llama-3.3-70B-Instruct"
+      value: "Qwen/Qwen3-235B-A22B-Instruct-2507-FP8"
     - name: HF_TOKEN
       valueFrom:
         secretKeyRef:
           name: hf-token-secret
           key: token
     - name: GSP_NUM_GROUPS
-      value: "2"
+      value: "100"
     - name: GSP_PROMPTS_PER_GROUP
-      value: "16"
+      value: "30"
     - name: GSP_SYSTEM_PROMPT_LEN
-      value: "2048"
+      value: "16384"
     - name: GSP_QUESTION_LEN
-      value: "256"
+      value: "128"
     - name: GSP_OUTPUT_LEN
-      value: "512"
+      value: "256"
   restartPolicy: Never

--- a/examples/offload/gke/benchmarks/deploy-baseline.yaml
+++ b/examples/offload/gke/benchmarks/deploy-baseline.yaml
@@ -27,15 +27,15 @@ spec:
         app: tpu-offline-inference
     spec:
       nodeSelector:
-        cloud.google.com/gke-tpu-accelerator: tpu-v6e-slice
-        cloud.google.com/gke-tpu-topology: 2x4 # Specify the physical topology for the TPU slice.
+        cloud.google.com/gke-tpu-accelerator: tpu7x
+        cloud.google.com/gke-tpu-topology: 2x2x1 # Specify the physical topology for the TPU slice.
       containers:
       - name: tpu-job
         image: <your-tpu-inference-container-image>
         imagePullPolicy: Always
         command: ["/bin/sh", "-c"]
         args:
-        - "vllm serve meta-llama/Llama-3.3-70B-Instruct --port 8000 --enable-chunked-prefill --tensor-parallel-size 8 --seed 42 --enable_prefix_caching --gpu-memory-utilization 0.9"
+        - "vllm serve Qwen/Qwen3-235B-A22B-Instruct-2507-FP8 --port 8000 --enable-chunked-prefill --tensor-parallel-size 8 --seed 42 --enable_prefix_caching --gpu-memory-utilization 0.9"
         env:
         - name: HUGGING_FACE_HUB_TOKEN
           valueFrom:
@@ -48,6 +48,6 @@ spec:
         - containerPort: 8000
         resources:
           requests:
-            google.com/tpu: 8
+            google.com/tpu: 4
           limits:
-            google.com/tpu: 8
+            google.com/tpu: 4

--- a/examples/offload/gke/benchmarks/deploy-cpu-offload.yaml
+++ b/examples/offload/gke/benchmarks/deploy-cpu-offload.yaml
@@ -33,8 +33,8 @@ spec:
       #   gke-gcsfuse/ephemeral-storage-limit: "200Gi"
     spec:
       nodeSelector:
-        cloud.google.com/gke-tpu-accelerator: tpu-v6e-slice
-        cloud.google.com/gke-tpu-topology: 2x4 # Specify the physical topology for the TPU slice.
+        cloud.google.com/gke-tpu-accelerator: tpu7x
+        cloud.google.com/gke-tpu-topology: 2x2x1 # Specify the physical topology for the TPU slice.
       initContainers:
         - name: tpu-node-setup
           image: busybox
@@ -73,10 +73,9 @@ spec:
           # mkdir -p "${profiler_dir}"
           # PROFILER_CONFIG_JSON='{"profiler": "torch", "torch_profiler_dir": "'"${profiler_dir}"'"}'
           
-          # Run vLLM
-          vllm serve Qwen/Qwen3-32B \
+          # Run vLLM. Add --profiler-config "${PROFILER_CONFIG_JSON}" to the command to use profiler
+          vllm serve Qwen/Qwen3-235B-A22B-Instruct-2507-FP8 \
             --kv-transfer-config '{"kv_connector":"TPUOffloadConnector","kv_connector_module_path":"tpu_inference.offload.tpu_offload_connector","kv_role":"kv_both"}' \
-            # --profiler-config "${PROFILER_CONFIG_JSON}" \
             --port 8000 \
             --enable-chunked-prefill \
             --tensor-parallel-size 8 \
@@ -97,16 +96,16 @@ spec:
         - name: SKIP_JAX_PRECOMPILE
           value: "0"
         - name: TPU_OFFLOAD_NUM_CPU_CHUNKS
-          value: "4096"
+          value: "3000"
         - name: TPU_OFFLOAD_NUM_STAGING_BLOCKS
-          value: "256"
+          value: "100"
         ports:
         - containerPort: 8000
         resources:
           requests:
-            google.com/tpu: 8
+            google.com/tpu: 4
           limits:
-            google.com/tpu: 8
+            google.com/tpu: 4
       #   volumeMounts:
       #   - name: gcs-bucket
       #     mountPath: /mnt/gcs

--- a/examples/offload/gke/pod_tpu_commons_cpu_offload.yaml
+++ b/examples/offload/gke/pod_tpu_commons_cpu_offload.yaml
@@ -19,8 +19,8 @@ metadata:
 spec:
   restartPolicy: Never
   nodeSelector:
-    cloud.google.com/gke-tpu-accelerator: tpu-v6e-slice
-    cloud.google.com/gke-tpu-topology: 2x4 # Specify the physical topology for the TPU slice.
+    cloud.google.com/gke-tpu-accelerator: tpu7x
+    cloud.google.com/gke-tpu-topology: 2x2x1 # Specify the physical topology for the TPU slice.
   containers:
   - name: tpu-job
     image: <your-tpu-inference-container-image>
@@ -41,6 +41,6 @@ spec:
           key: token
     resources:
       requests:
-        google.com/tpu: 8
+        google.com/tpu: 4
       limits:
-        google.com/tpu: 8
+        google.com/tpu: 4

--- a/examples/offload/gke/pod_tpu_commons_cpu_offload_verification.yaml
+++ b/examples/offload/gke/pod_tpu_commons_cpu_offload_verification.yaml
@@ -25,8 +25,8 @@ metadata:
 spec:
   restartPolicy: Never
   nodeSelector:
-    cloud.google.com/gke-tpu-accelerator: tpu-v6e-slice
-    cloud.google.com/gke-tpu-topology: 2x4 # Specify the physical topology for the TPU slice.
+    cloud.google.com/gke-tpu-accelerator: tpu7x
+    cloud.google.com/gke-tpu-topology: 2x2x1 # Specify the physical topology for the TPU slice.
   containers:
   - name: tpu-job
     image: <your-tpu-inference-image>
@@ -48,6 +48,6 @@ spec:
           key: token
     resources:
       requests:
-        google.com/tpu: 8
+        google.com/tpu: 4
       limits:
-        google.com/tpu: 8
+        google.com/tpu: 4

--- a/examples/offload/gke/pod_tpu_host_offload_unit_tests.yaml
+++ b/examples/offload/gke/pod_tpu_host_offload_unit_tests.yaml
@@ -22,8 +22,8 @@ metadata:
 spec:
   restartPolicy: Never
   nodeSelector:
-    cloud.google.com/gke-tpu-accelerator: tpu-v6e-slice
-    cloud.google.com/gke-tpu-topology: 2x4 # Specify the physical topology for the TPU slice.
+    cloud.google.com/gke-tpu-accelerator: tpu7x
+    cloud.google.com/gke-tpu-topology: 2x2x1 # Specify the physical topology for the TPU slice.
   containers:
   - name: tpu-job
     image: <your-tpu-inference-container-image>
@@ -40,6 +40,6 @@ spec:
           key: token
     resources:
       requests:
-        google.com/tpu: 8
+        google.com/tpu: 4
       limits:
-        google.com/tpu: 8
+        google.com/tpu: 4


### PR DESCRIPTION
# Description

This PR updates the GKE TPU offloading examples and benchmarks to:

*   Utilize `tpu7x` accelerator type with a `2x2x1` topology.
*   Target the `Qwen/Qwen3-235B-A22B-Instruct-2507-FP8` model.
*   Adjust benchmark parameters for the new model and hardware.
*   Update a README to reflect the new TPU type.

These changes are made across various deployment and testing YAML files to ensure consistency.

If the change fixes a Github issue, please include a link, e.g.,:
FIXES: #123456

# Tests

examples/offload/gke/pod_tpu_host_offload_unit_tests.yaml
examples/offload/gke/pod_tpu_commons_cpu_offload_verification.yaml
examples/offload/gke/pod_tpu_commons_cpu_offload.yaml
e2e benchmark

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
