### PR TITLE
Extend attn_dp_expert to emulate attn_dp.

### DIFF
--- a/tests/layers/common/test_sharding.py
+++ b/tests/layers/common/test_sharding.py
@@ -78,6 +78,148 @@ class TestShardingConfigManager(unittest.TestCase):
         self.assertEqual(manager.expert_size, 1)
         self.assertEqual(manager.total_dp_size, 32)  # 1 * 8 * 4
 
+    @patch("tpu_inference.layers.common.sharding.envs.NEW_MODEL_DESIGN", True)
+    def test_sharding_config_manager_with_dp_attention_expert(self):
+        vllm_config = MagicMock()
+        vllm_config.parallel_config.tensor_parallel_size = 1
+        vllm_config.parallel_config.data_parallel_size = 1
+        vllm_config.model_config.use_mla = False
+        vllm_config.model_config.get_total_num_kv_heads.return_value = 4
+        vllm_config.speculative_config = None
+        vllm_config.lora_config = None
+        vllm_config.cache_config.cache_dtype = "bfloat16"
+
+        # Test with enable_dp_attention=True and expert_parallelism
+        vllm_config.additional_config = {
+            "sharding": {
+                "sharding_strategy": {
+                    "enable_dp_attention": True,
+                    "expert_parallelism": 8
+                }
+            }
+        }
+
+        manager = ShardingConfigManager.from_vllm_config(vllm_config)
+        # num_kv_heads = 4 (non-MLA), packing = 2 (BF16)
+        # num_kv_heads_per_device_in_kv_cache = max(1, (4 * 2) / 2) = 4
+        # attn_dp = max(int(1 // 4), 1) = 1
+        # tensor_parallelism = 1 // 1 = 1
+        # attn_dp_expert = max(int(8 // 4), 1) = 2
+        # expert_parallelism = 4
+
+        self.assertEqual(manager.tp_size, 1)
+        self.assertEqual(manager.attn_dp_size, 1)
+        self.assertEqual(manager.attn_dp_expert_size, 2)
+        self.assertEqual(manager.expert_size, 4)
+        self.assertEqual(manager.total_dp_size, 2)  # 1 * 1 * 2
+
+    @patch("tpu_inference.layers.common.sharding.envs.NEW_MODEL_DESIGN", True)
+    def test_sharding_config_manager_with_dp_attention_expert_model(self):
+        vllm_config = MagicMock()
+        vllm_config.parallel_config.tensor_parallel_size = 8
+        vllm_config.parallel_config.data_parallel_size = 1
+        vllm_config.model_config.use_mla = False
+        vllm_config.model_config.get_total_num_kv_heads.return_value = 4
+        vllm_config.speculative_config = None
+        vllm_config.lora_config = None
+        vllm_config.cache_config.cache_dtype = "bfloat16"
+
+        # Test with enable_dp_attention=True and expert_parallelism
+        vllm_config.additional_config = {
+            "sharding": {
+                "sharding_strategy": {
+                    "enable_dp_attention": True,
+                    "expert_parallelism": 4
+                }
+            }
+        }
+
+        manager = ShardingConfigManager.from_vllm_config(vllm_config)
+        # num_kv_heads = 4 (non-MLA), packing = 2 (BF16)
+        # num_kv_heads_per_device_in_kv_cache = max(1, (4 * 2) / 2) = 4
+        # attn_dp = max(int(8 // 4), 1) = 2
+        # tensor_parallelism = 8 // 2 = 4
+        # attn_dp_expert = expert_parallelism =  4
+        # expert_parallelism = 1
+
+        self.assertEqual(manager.tp_size, 4)
+        self.assertEqual(manager.attn_dp_size, 2)
+        self.assertEqual(manager.attn_dp_expert_size, 4)
+        self.assertEqual(manager.expert_size, 1)
+        self.assertEqual(manager.total_dp_size, 8)  # 4 * 2 * 1
+
+    @patch("tpu_inference.layers.common.sharding.envs.NEW_MODEL_DESIGN", True)
+    def test_sharding_config_manager_with_dp_attention_expert_model_partial(
+            self):
+        vllm_config = MagicMock()
+        vllm_config.parallel_config.tensor_parallel_size = 2
+        vllm_config.parallel_config.data_parallel_size = 1
+        vllm_config.model_config.use_mla = False
+        vllm_config.model_config.get_total_num_kv_heads.return_value = 4
+        vllm_config.speculative_config = None
+        vllm_config.lora_config = None
+        vllm_config.cache_config.cache_dtype = "bfloat16"
+
+        # Test with enable_dp_attention=True and expert_parallelism
+        vllm_config.additional_config = {
+            "sharding": {
+                "sharding_strategy": {
+                    "enable_dp_attention": True,
+                    "expert_parallelism": 16
+                }
+            }
+        }
+
+        manager = ShardingConfigManager.from_vllm_config(vllm_config)
+        # num_kv_heads = 4 (non-MLA), packing = 2 (BF16)
+        # num_kv_heads_per_device_in_kv_cache = max(1, (4 * 2) / 2) = 4
+        # attn_dp = max(int(2 // 4), 1) = 1
+        # tensor_parallelism = 2 // 1 = 2
+        # attn_dp_expert = expert_parallelism // tensor_parallelism = 16 // 2 = 8
+        # expert_parallelism = expert_parallelism // attn_dp_expert = 16 // 8 = 2
+
+        self.assertEqual(manager.tp_size, 2)
+        self.assertEqual(manager.attn_dp_size, 1)
+        self.assertEqual(manager.attn_dp_expert_size, 8)
+        self.assertEqual(manager.expert_size, 2)
+        self.assertEqual(manager.total_dp_size, 8)  # 8 * 1 * 1
+
+    @patch("tpu_inference.layers.common.sharding.envs.NEW_MODEL_DESIGN", True)
+    def test_sharding_config_manager_with_dp_attention_expert_model_exact(
+            self):
+        vllm_config = MagicMock()
+        vllm_config.parallel_config.tensor_parallel_size = 4
+        vllm_config.parallel_config.data_parallel_size = 1
+        vllm_config.model_config.use_mla = False
+        vllm_config.model_config.get_total_num_kv_heads.return_value = 4
+        vllm_config.speculative_config = None
+        vllm_config.lora_config = None
+        vllm_config.cache_config.cache_dtype = "bfloat16"
+
+        # Test with enable_dp_attention=True and expert_parallelism
+        vllm_config.additional_config = {
+            "sharding": {
+                "sharding_strategy": {
+                    "enable_dp_attention": True,
+                    "expert_parallelism": 8
+                }
+            }
+        }
+
+        manager = ShardingConfigManager.from_vllm_config(vllm_config)
+        # num_kv_heads = 4 (non-MLA), packing = 2 (BF16)
+        # num_kv_heads_per_device_in_kv_cache = max(1, (4 * 2) / 2) = 4
+        # attn_dp = max(int(4 // 4), 1) = 1
+        # tensor_parallelism = 4 // 1 = 4
+        # attn_dp_expert = expert_parallelism = 8
+        # expert_parallelism = 1
+
+        self.assertEqual(manager.tp_size, 4)
+        self.assertEqual(manager.attn_dp_size, 1)
+        self.assertEqual(manager.attn_dp_expert_size, 8)
+        self.assertEqual(manager.expert_size, 1)
+        self.assertEqual(manager.total_dp_size, 8)  # 8 * 1 * 1
+
     def test_sharding_config_manager_explicit_tp(self):
         vllm_config = MagicMock()
         vllm_config.parallel_config.tensor_parallel_size = 1

--- a/tpu_inference/layers/common/sharding.py
+++ b/tpu_inference/layers/common/sharding.py
@@ -194,8 +194,23 @@ class ShardingConfigManager:
                 int(tensor_parallelism // num_kv_heads_per_device_in_kv_cache),
                 1)
             tensor_parallelism = tensor_parallelism // attn_dp
-            attn_dp_expert = expert_parallelism
-            expert_parallelism = 1
+
+            # If Attention DP is active or TP perfectly saturates the KV heads limit,
+            # prioritize TP for KV heads and shift all expert parallelism to attn_dp_expert.
+            is_kv_fully_sharded_by_tp = (attn_dp > 1) or (
+                tensor_parallelism == num_kv_heads_per_device_in_kv_cache)
+
+            if is_kv_fully_sharded_by_tp:
+                attn_dp_expert = expert_parallelism
+                expert_parallelism = 1
+            else:
+                # Otherwise, shard KV heads over the expert axis.
+                # Use the remaining KV heads per device as the divisor.
+                shard_divisor = num_kv_heads_per_device_in_kv_cache // tensor_parallelism
+                attn_dp_expert = max(1,
+                                     int(expert_parallelism // shard_divisor))
+                expert_parallelism //= attn_dp_expert
+
         else:
             attn_dp = 1
             attn_dp_expert = 1


### PR DESCRIPTION
# Description

This PR modified `attn_dp_expert` to emulate the behavior of `attn_dp`. Concretely, this PR allows the "expert" mesh physical axis to extend beyond the number of KV heads in a model by assigning the quotient to "attn_dp_expert". 

This is helpful for models that shard the expert dimension of MoE layers over the "expert" physical axis.  

# Tests

Added a new unit test in `tests/layers/common/test_sharding.py` to validate this behavior. Additionally, this has been tested as part of the e2e RL efforts on Qwen3-235B-A22B with the plugin MaxText model (which shards experts using the "expert" axis).

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
