### PR TITLE
Optimize GDN conv1d

### DIFF
--- a/tests/layers/common/test_ragged_conv1d.py
+++ b/tests/layers/common/test_ragged_conv1d.py
@@ -1,0 +1,300 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import jax.numpy as jnp
+import numpy as np
+from absl.testing import parameterized
+
+import tpu_inference.layers.common.ragged_conv1d_jax as ragged_conv1d_jax
+
+
+class RaggedConv1dJaxTest(parameterized.TestCase):
+
+    def test_single_sequence(self):
+        dim = 2
+        kernel_size = 3
+        num_tokens = 5
+        num_reqs = 1
+
+        x = jnp.arange(num_tokens * dim, dtype=jnp.float32).reshape(
+            (num_tokens, dim))
+        conv_state = jnp.array([[[-0.5, 0.5], [1.0, -1.0]]], dtype=jnp.float32)
+        conv_weight = jnp.array([[[0.3, -0.6, 1.2]], [[-0.8, 0.4, 0.9]]],
+                                dtype=jnp.float32)
+        conv_bias = None
+
+        query_start_loc = jnp.array([0, 5], dtype=jnp.int32)
+        state_indices = jnp.array([0], dtype=jnp.int32)
+        distribution = jnp.array([0, 0, num_reqs], dtype=jnp.int32)
+
+        has_initial_state = jnp.array([True], dtype=bool)
+        output, updated_state = ragged_conv1d_jax.ragged_conv1d(
+            x,
+            conv_state,
+            conv_weight,
+            conv_bias,
+            query_start_loc,
+            state_indices,
+            distribution,
+            has_initial_state,
+            kernel_size=kernel_size,
+        )
+
+        self.assertEqual(output.shape, (num_tokens, dim))
+        self.assertEqual(updated_state.shape, (1, kernel_size - 1, dim))
+
+        expected_output = np.array(
+            [
+                [-0.75, 0.09999996423721313],
+                [2.700000047683716, 3.8999998569488525],
+                [3.6000001430511475, 4.9],
+                [5.400000095367432, 5.899999141693115],
+                [7.199999809265137, 6.899999618530273],
+            ],
+            dtype=np.float32,
+        )
+
+        np.testing.assert_allclose(output, expected_output, atol=1e-6)
+
+        expected_state = np.array([[[6.0, 7.0], [8.0, 9.0]]], dtype=np.float32)
+        np.testing.assert_allclose(updated_state[0],
+                                   expected_state[0],
+                                   atol=1e-6)
+
+    def test_multiple_sequences(self):
+        dtype = jnp.float32
+        dim = 2
+        kernel_size = 4
+        num_tokens = 12
+        max_reqs = 6
+        num_valid_reqs = 4
+
+        x = jnp.arange(num_tokens * dim, dtype=dtype).reshape(
+            (num_tokens, dim))
+        # 2 requests, kernel size 4 -> 3 state tokens
+        # shape: (2, 3, 2)
+        conv_state = jnp.array(
+            [
+                [[-0.1, 0.4], [0.8, -0.3], [0.2, -0.9]],
+                [[0.5, -0.2], [-0.6, 0.7], [0.1, -0.5]],
+                [[-0.3, 0.6], [0.4, -0.8], [0.9, -0.1]],
+                [[0.2, -0.4], [-0.7, 0.3], [0.6, -0.2]],
+                [[-0.9, 0.1], [0.5, -0.6], [0.3, -0.7]],
+                [[0.7, -0.5], [-0.2, 0.9], [0.4, -0.3]],
+            ],
+            dtype=dtype,
+        )
+        # shape: (dim, 1, kernel_size)
+        conv_weight = jnp.array(
+            [[[0.3, -0.6, 1.2, -0.5]], [[-0.8, 0.4, 0.9, 0.1]]], dtype=dtype)
+        conv_bias = jnp.array([1.0, 2.0], dtype=dtype)
+
+        # Lengths: 2, 1, 4, 3
+        query_start_loc = jnp.array([0, 2, 3, 7, 10, 1, 1], dtype=jnp.int32)
+
+        # max_reqs = 4
+        state_indices = jnp.arange(max_reqs, dtype=jnp.int32)
+        distribution = jnp.array([1, 1, num_valid_reqs], dtype=jnp.int32)
+        has_initial_state = jnp.array([True] * max_reqs, dtype=bool)
+        output, updated_state = ragged_conv1d_jax.ragged_conv1d(
+            x,
+            conv_state,
+            conv_weight,
+            conv_bias,
+            query_start_loc,
+            state_indices,
+            distribution,
+            has_initial_state,
+            kernel_size=kernel_size,
+        )
+        self.assertEqual(output.shape, (num_tokens, dim))
+        expected_output = np.array(
+            [
+                [0.7300000190734863, 0.8500000238418579],
+                [0.12000000476837158, 3.0799999237060547],
+                [-0.3700000047683716, 2.490000009536743],
+                [-1.249999761581421, 1.809999942779541],
+                [3.7800002098083496, 9.799999237060547],
+                [2.2700002193450928, 14.079999923706055],
+                [4.0, 11.200000762939453],
+                [-4.799999713897705, 3.760000228881836],
+                [9.230001449584961, 16.880001068115234],
+                [2.9800002574920654, 25.35999870300293],
+                [0.0, 0.0],
+                [0.0, 0.0],
+            ],
+            dtype=dtype,
+        )
+        np.testing.assert_allclose(output, expected_output, atol=1e-6)
+        expected_state = np.array(
+            [
+                [[0.2, -0.9], [0.0, 1.0], [2.0, 3.0]],
+                [[-0.6, 0.7], [0.1, -0.5], [4.0, 5.0]],
+                [[8.0, 9.0], [10.0, 11.0], [12.0, 13.0]],
+                [[14.0, 15.0], [16.0, 17.0], [18.0, 19.0]],
+                [[-0.9, 0.1], [0.5, -0.6], [0.3, -0.7]],
+                [[0.7, -0.5], [-0.2, 0.9], [0.4, -0.3]],
+            ],
+            dtype=dtype,
+        )
+        np.testing.assert_allclose(updated_state, expected_state, atol=1e-6)
+
+    def test_multiple_sequences_with_no_initial_state(self):
+        dtype = jnp.float32
+        dim = 2
+        kernel_size = 4
+        num_tokens = 12
+        max_reqs = 6
+        num_valid_reqs = 4
+
+        x = jnp.arange(num_tokens * dim, dtype=dtype).reshape(
+            (num_tokens, dim))
+        # 2 requests, kernel size 4 -> 3 state tokens
+        # shape: (2, 3, 2)
+        conv_state = jnp.array(
+            [
+                [[-0.1, 0.4], [0.8, -0.3], [0.2, -0.9]],
+                [[0.5, -0.2], [-0.6, 0.7], [0.1, -0.5]],
+                [[-0.3, 0.6], [0.4, -0.8], [0.9, -0.1]],
+                [[0.2, -0.4], [-0.7, 0.3], [0.6, -0.2]],
+                [[-0.9, 0.1], [0.5, -0.6], [0.3, -0.7]],
+                [[0.7, -0.5], [-0.2, 0.9], [0.4, -0.3]],
+            ],
+            dtype=dtype,
+        )
+        # shape: (dim, 1, kernel_size)
+        conv_weight = jnp.array(
+            [[[0.3, -0.6, 1.2, -0.5]], [[-0.8, 0.4, 0.9, 0.1]]], dtype=dtype)
+        conv_bias = jnp.array([1.0, 2.0], dtype=dtype)
+
+        # Lengths: 2, 1, 4, 3
+        query_start_loc = jnp.array([0, 2, 3, 7, 10, 1, 1], dtype=jnp.int32)
+
+        # max_reqs = 4
+        state_indices = jnp.arange(max_reqs, dtype=jnp.int32)
+        distribution = jnp.array([1, 1, num_valid_reqs], dtype=jnp.int32)
+        has_initial_state = jnp.array([False] * max_reqs, dtype=bool)
+        output, updated_state = ragged_conv1d_jax.ragged_conv1d(
+            x,
+            conv_state,
+            conv_weight,
+            conv_bias,
+            query_start_loc,
+            state_indices,
+            distribution,
+            has_initial_state,
+            kernel_size=kernel_size,
+        )
+        self.assertEqual(output.shape, (num_tokens, dim))
+        expected_output = np.array(
+            [
+                [1.0, 2.1],
+                [0.0, 3.2],
+                [-1.0, 2.5],
+                [-2.0, 2.7],
+                [4.2000003, 9.2],
+                [2.0, 14.0],
+                [4.0, 11.2],
+                [-6.0, 3.5],
+                [9.800001, 17.2],
+                [2.8000002, 25.199999],
+                [0.0, 0.0],
+                [0.0, 0.0],
+            ],
+            dtype=dtype,
+        )
+        np.testing.assert_allclose(output, expected_output, atol=1e-6)
+        expected_state = np.array(
+            [
+                [[0.0, 0.0], [0.0, 1.0], [2.0, 3.0]],
+                [[0.0, 0.0], [0.0, 0.0], [4.0, 5.0]],
+                [[8.0, 9.0], [10.0, 11.0], [12.0, 13.0]],
+                [[14.0, 15.0], [16.0, 17.0], [18.0, 19.0]],
+                [[-0.9, 0.1], [0.5, -0.6], [0.3, -0.7]],
+                [[0.7, -0.5], [-0.2, 0.9], [0.4, -0.3]],
+            ],
+            dtype=dtype,
+        )
+        np.testing.assert_allclose(updated_state, expected_state, atol=1e-6)
+
+    def test_multiple_sequences_all_length_1(self):
+        dtype = jnp.float32
+        dim = 2
+        kernel_size = 4
+        num_tokens = 6
+        max_reqs = 6
+        num_valid_reqs = 4
+
+        x = jnp.arange(num_tokens * dim, dtype=dtype).reshape(
+            (num_tokens, dim))
+        conv_state = jnp.array(
+            [
+                [[-0.1, 0.4], [0.8, -0.3], [0.2, -0.9]],
+                [[0.5, -0.2], [-0.6, 0.7], [0.1, -0.5]],
+                [[-0.3, 0.6], [0.4, -0.8], [0.9, -0.1]],
+                [[0.2, -0.4], [-0.7, 0.3], [0.6, -0.2]],
+                [[-0.9, 0.1], [0.5, -0.6], [0.3, -0.7]],
+                [[0.7, -0.5], [-0.2, 0.9], [0.4, -0.3]],
+            ],
+            dtype=dtype,
+        )
+        conv_weight = jnp.array(
+            [[[0.3, -0.6, 1.2, -0.5]], [[-0.8, 0.4, 0.9, 0.1]]], dtype=dtype)
+        conv_bias = jnp.array([1.0, 2.0], dtype=dtype)
+
+        # Lengths: 1, 1, 1, 1, 0, 0
+        query_start_loc = jnp.array([0, 1, 2, 3, 4, 1, 1], dtype=jnp.int32)
+
+        state_indices = jnp.arange(max_reqs, dtype=jnp.int32)
+        distribution = jnp.array(
+            [num_valid_reqs, num_valid_reqs, num_valid_reqs], dtype=jnp.int32)
+
+        has_initial_state = jnp.array([True] * max_reqs, dtype=bool)
+        output, updated_state = ragged_conv1d_jax.ragged_conv1d(
+            x,
+            conv_state,
+            conv_weight,
+            conv_bias,
+            query_start_loc,
+            state_indices,
+            distribution,
+            has_initial_state,
+            kernel_size=kernel_size,
+        )
+        self.assertEqual(output.shape, (num_tokens, dim))
+        expected_output = np.array(
+            [
+                [0.73, 0.85],
+                [0.63, 2.29],
+                [-0.25, 1.61],
+                [-0.80, 2.96],
+                [0.0, 0.0],
+                [0.0, 0.0],
+            ],
+            dtype=dtype,
+        )
+        np.testing.assert_allclose(output, expected_output, atol=1e-5)
+
+        expected_state = np.array(
+            [
+                [[0.8, -0.3], [0.2, -0.9], [0.0, 1.0]],
+                [[-0.6, 0.7], [0.1, -0.5], [2.0, 3.0]],
+                [[0.4, -0.8], [0.9, -0.1], [4.0, 5.0]],
+                [[-0.7, 0.3], [0.6, -0.2], [6.0, 7.0]],
+                [[-0.9, 0.1], [0.5, -0.6], [0.3, -0.7]],
+                [[0.7, -0.5], [-0.2, 0.9], [0.4, -0.3]],
+            ],
+            dtype=dtype,
+        )
+        np.testing.assert_allclose(updated_state, expected_state, atol=1e-6)

--- a/tpu_inference/layers/common/ragged_conv1d_jax.py
+++ b/tpu_inference/layers/common/ragged_conv1d_jax.py
@@ -11,16 +11,99 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Ragged convolution Jax implementation."""
+"""Ragged convolution Jax implementation.
+
+This file provides highly optimized 1D convolutions over ragged sequences on
+TPUs in JAX.
+
+Key design ideas:
+1. Convolution via standard operators: Instead of mapping large index loops,
+   it applies standard `lax.conv_general_dilated` on flat tokens to perform a
+   depthwise 1-D convolution.
+2. Ragged boundary fixup: To prevent cross-sequence pollution at padded
+   boundaries in consecutive batch groups, we compute slice segments right where
+   sequences transition and resolve border overlaps accurately.
+3. State update: We update the convolutional state by selecting either the
+   previous state or the current input based on whether the current position is
+   within the state's range or not.
+"""
 
 import jax
 import jax.numpy as jnp
+from jax import lax
 
 
-# Donate conv_state to avoid "copy" op by XLA
-@jax.jit(donate_argnames=("conv_state", ), static_argnames=("kernel_size", ))
-@jax.named_scope("ragged_conv1d_jax")
-def ragged_conv1d(
+def _fix_query_start_loc(query_start_loc, num_valid_seqs):
+    """Fixes query_start_loc to be non-decreasing for invalid sequences."""
+    last_valid_loc = query_start_loc[num_valid_seqs]
+    valid_loc_mask = jnp.arange(query_start_loc.shape[0]) <= num_valid_seqs
+    return jnp.where(valid_loc_mask, query_start_loc, last_valid_loc)
+
+
+def _get_boundary_indices(starts, lengths, kernel_size, num_valid_seqs):
+    """Computes indices for boundary fixup."""
+    valid_mask = jnp.arange(starts.shape[0]) < num_valid_seqs
+    starts = jnp.where(valid_mask, starts, 1)[:, None]
+    lengths = lengths[:, None]
+    k_range = jnp.arange(kernel_size - 1)[None, :]
+    gather_indices = starts + jnp.minimum(k_range, lengths - 1)
+    scatter_indices = jnp.where(
+        (k_range < lengths) & valid_mask[:, None],
+        starts + k_range,
+        -1,
+    )
+    return gather_indices, scatter_indices
+
+
+def _get_state_update_indices(query_start_loc, kernel_size, num_tokens):
+    """Computes indices for updating the convolutional state."""
+    lengths = query_start_loc[1:] - query_start_loc[:-1]
+
+    k_range = jnp.arange(kernel_size - 1)
+
+    safe_idx_x = (query_start_loc[1:, None] -
+                  jnp.arange(kernel_size - 1, 0, -1)[None, :])
+    safe_idx_x = jnp.clip(safe_idx_x, 0, num_tokens - 1)
+
+    is_from_old_state = k_range[None, :] < (kernel_size - 1 - lengths)[:, None]
+
+    idx_g = k_range[None, :] + lengths[:, None]
+    idx_g = jnp.clip(idx_g, 0, kernel_size - 2)
+
+    return safe_idx_x, is_from_old_state, idx_g
+
+
+def _depthwise_conv1d_loop_and_bias(x, conv_weight, conv_bias):
+    """Depthwise 1D convolution using loops over kernel size.
+
+  Note that an alternative is to use `lax.conv_general_dilated`. However we use
+  loops to enable fusing bias addition.
+  """
+    num_tokens = x.shape[0]
+    kernel_size = conv_weight.shape[-1]
+    out = None
+
+    # Pad x on the left with kernel_size - 1 zeros
+    padded_x = jnp.pad(x, ((kernel_size - 1, 0), (0, 0)))
+
+    # Accumulate over kernel size
+    for k in range(kernel_size):
+        # Accumulation needs to be done in float32 to avoid accuracy loss
+        x_slice = padded_x[k:k + num_tokens, :].astype(jnp.float32)
+        weight_slice = conv_weight[:, 0, k].astype(jnp.float32)
+        if out is None:
+            if conv_bias is None:
+                out = x_slice * weight_slice
+            else:
+                out = x_slice * weight_slice + conv_bias[jnp.newaxis, :]
+        else:
+            out += x_slice * weight_slice
+
+    assert out is not None
+    return out.astype(x.dtype)
+
+
+def ragged_conv1d_mixed_prefill(
     x,
     conv_state,
     conv_weight,
@@ -32,117 +115,71 @@ def ragged_conv1d(
     *,
     kernel_size,
 ):
-    """Applies 1D convolution over ragged sequences and updates state.
-
-    Args:
-      x: Input tensor of shape `(num_tokens, dim)`.
-      conv_state: Combined convolutional state of shape `(num_blocks, kernel_size
-        - 1, dim)`. `num_blocks` is always equal or larger than `max_seqs + 1`.
-        The first block is a null_block and only used for padded / invalid tokens.
-      conv_weight: Convolutional weight of shape `(dim, 1, kernel_size)`.
-      conv_bias: Optional convolutional bias of shape `(dim,)`.
-      query_start_loc: Tensor of shape `(num_seqs + 1,)` containing the start
-        indices of each sequence, with the last element being the total number of
-        valid tokens.
-      state_indices: Tensor of shape `(max_reqs,)` mapping request index to state
-        index.
-      kernel_size: The size of the convolution kernel.
-      distribution: Distribution tensor containing number of valid sequences at
-        index 2.
-      has_initial_state: Boolean tensor of shape `(max_reqs,)`. ``True`` when
-        the request has prior conv state to use (chunked-prefill continuation
-        or prefix-cache hit). ``False`` for brand-new prefills, in which case
-        the gathered conv state is treated as zeros — matching GPU's
-        ``causal_conv1d_fn(has_initial_state=...)`` semantics. Without this
-        masking the conv would consume whatever a reused mamba slot still
-        held from a prior request, silently corrupting the first
-        ``kernel_size - 1`` outputs of every new request.
-
-    Returns:
-      A tuple containing:
-      - output: The output tensor of shape `(num_tokens, dim)`.
-      - updated_conv_state: The updated convolutional state of shape `(num_blocks,
-        kernel_size - 1, dim)`.
-    """
+    """Applies 1D convolution, optimized for prefill."""
     num_tokens = x.shape[0]
-    max_reqs = state_indices.shape[0]
-    token_idx = jnp.arange(num_tokens)
-
+    max_blocks = state_indices.shape[0]
     num_valid_seqs = distribution[2]
-    valid_loc_mask = jnp.arange(query_start_loc.shape[0]) <= num_valid_seqs
-    # Handle case where query_start_loc has trailing zeros by filling them with the last valid location.
-    last_valid_loc = query_start_loc[num_valid_seqs]
-    effective_query_start_loc = jnp.where(valid_loc_mask, query_start_loc,
-                                          last_valid_loc)
 
-    req_indices = (jnp.sum(
-        token_idx[:, None] >= effective_query_start_loc[None, :], axis=1) - 1)
-    req_indices = jnp.clip(req_indices, 0, max_reqs - 1)
-    local_indices = token_idx - effective_query_start_loc[req_indices]
+    # 1. Compute Convolution
+    out = _depthwise_conv1d_loop_and_bias(x, conv_weight, conv_bias)
 
-    lengths = effective_query_start_loc[1:] - effective_query_start_loc[:-1]
+    # 2. Fixup Boundary Tokens
+    query_start_loc = _fix_query_start_loc(query_start_loc, num_valid_seqs)
+    starts = query_start_loc[:-1]
+    lengths = query_start_loc[1:] - query_start_loc[:-1]
+    gather_indices, scatter_indices = _get_boundary_indices(
+        starts, lengths, kernel_size, num_valid_seqs)
+    x_first = x[gather_indices]  # (max_blocks, K-1, dim)
 
-    # 1. Compute Convolution.
-    # Accumulate in fp32 to match GPU's `causal_conv1d_fn`
-    # (`vllm/model_executor/layers/mamba/ops/causal_conv1d.py`), which
-    # loads x and weights as fp32 before the kernel-size-element sum.
-    orig_dtype = x.dtype
-    x_f32 = x.astype(jnp.float32)
-    w = conv_weight[:, 0, :].T.astype(jnp.float32)  # (K, C)
+    # Concatenate state and x_first along the spatial dimension
+    gathered_state = conv_state[state_indices]  # (max_blocks, K-1, dim)
 
-    gathered_state = conv_state[state_indices]  # (max_reqs, K-1, C)
     # Mask the gathered conv state to zero for sequences without initial
     # state, so brand-new prefills see zeros instead of whatever a reused
-    # slot still held. Mirrors GPU's `has_initial_state` plumbing.
+    # slot still held.
     gathered_state = jnp.where(
         has_initial_state[:, None, None],
         gathered_state,
         jnp.zeros_like(gathered_state),
     )
-    gathered_state_f32 = gathered_state.astype(jnp.float32)
 
-    out = jnp.zeros((num_tokens, x.shape[-1]), dtype=jnp.float32)
-    for k in range(kernel_size):
-        mask = local_indices >= k
+    combined_tokens = jnp.concatenate([gathered_state, x_first],
+                                      axis=1)  # (max_blocks, 2K - 2, dim)
 
-        idx_x = jnp.clip(token_idx - k, 0, num_tokens - 1)
-        idx_state_t = (kernel_size - 1) + (local_indices - k)
-
-        x_tokens = x_f32[idx_x]
-        state_tokens = gathered_state_f32[req_indices, idx_state_t]
-
-        token_k = jnp.where(mask[:, None], x_tokens, state_tokens)
-        out = out + token_k * w[kernel_size - 1 - k]
-
+    # Depthwise Convolution for Fixup
+    b_out = lax.conv_general_dilated(
+        combined_tokens,
+        conv_weight,
+        window_strides=(1, ),
+        padding="VALID",
+        dimension_numbers=("NWC", "OIW", "NWC"),
+        feature_group_count=x.shape[-1],
+        precision=lax.Precision.HIGHEST,
+    ).reshape(-1, x.shape[-1])
     if conv_bias is not None:
-        out = out + conv_bias.astype(jnp.float32)[jnp.newaxis, :]
-    out = out.astype(orig_dtype)
+        b_out += conv_bias[jnp.newaxis, :]
 
-    # 2. Update State
-    padded_lengths = jnp.zeros(max_reqs, dtype=jnp.int32)
-    padded_lengths = padded_lengths.at[:lengths.shape[0]].set(lengths)
+    # Scatter the updates. Note that scatter indices may contain -1, which will be
+    # ignored by the scatter operation with mode="drop".
+    out = out.at[scatter_indices.flatten()].set(b_out.astype(out.dtype),
+                                                mode="drop",
+                                                wrap_negative_indices=False)
+    # Mask invalid tokens to 0
+    total_valid_tokens = query_start_loc[num_valid_seqs]
+    valid_token_mask = jnp.arange(num_tokens) < total_valid_tokens
+    out = jnp.where(valid_token_mask[:, jnp.newaxis], out, 0.0)
+    # 3. Update State
+    true_valid_seq_mask = jnp.arange(max_blocks) < num_valid_seqs
+    safe_idx_x, is_from_old_state, idx_g = _get_state_update_indices(
+        query_start_loc, kernel_size, num_tokens)
 
-    padded_q_loc = jnp.zeros(max_reqs + 1, dtype=jnp.int32)
-    padded_q_loc = padded_q_loc.at[:effective_query_start_loc.shape[0]].set(
-        effective_query_start_loc)
-    padded_q_loc = padded_q_loc.at[effective_query_start_loc.shape[0]:].set(
-        effective_query_start_loc[-1])
+    x_tokens = x[safe_idx_x]
+    r_grid = jnp.arange(max_blocks)[:, None]
+    state_tokens = gathered_state[r_grid, idx_g]
 
-    r_grid = jnp.arange(max_reqs)[:, None]
-    j_grid = jnp.arange(kernel_size - 1)[None, :]
+    new_state_extracted = jnp.where(is_from_old_state[..., None], state_tokens,
+                                    x_tokens)
 
-    v_i = padded_lengths[:, None] + j_grid
-    is_from_old_state = v_i < kernel_size - 1
-
-    idx_state = jnp.where(is_from_old_state, v_i, 0)
-    idx_x = padded_q_loc[r_grid + 1] + j_grid - (kernel_size - 1)
-    idx_x = jnp.clip(idx_x, 0, num_tokens - 1)
-
-    new_state_extracted = jnp.where(is_from_old_state[..., None],
-                                    gathered_state[r_grid,
-                                                   idx_state], x[idx_x])
-
-    true_valid_seq_mask = jnp.arange(max_reqs) < num_valid_seqs
     updated_conv_state = conv_state.at[state_indices].set(
         jnp.where(
             true_valid_seq_mask[:, None, None],
@@ -150,4 +187,138 @@ def ragged_conv1d(
             conv_state[state_indices],
         ))
 
-    return out, updated_conv_state
+    return out.astype(x.dtype), updated_conv_state
+
+
+def ragged_conv1d_decode_only(
+    x,
+    conv_state,
+    conv_weight,
+    conv_bias,
+    query_start_loc,
+    state_indices,
+    distribution,
+    has_initial_state,
+    *,
+    kernel_size,
+):
+    """Apply conv1d for decode-only case (All valid reqs have seq_len=1)."""
+    num_tokens = x.shape[0]
+
+    token_idx = jnp.arange(num_tokens)
+    req_state_indices = state_indices[token_idx]
+    gathered_state = conv_state[
+        req_state_indices]  # (num_tokens, kernel_size - 1, dim)
+
+    # Concat old state and new token to form (num_tokens, kernel_size, dim)
+    lhs = jnp.concatenate([gathered_state, x[:, jnp.newaxis, :]], axis=1)
+
+    out = jnp.einsum(
+        "nkd,dk->nd",
+        lhs,
+        conv_weight[:, 0, :],
+        precision=lax.Precision.HIGHEST,
+    )
+
+    if conv_bias is not None:
+        out = out + conv_bias
+
+    num_valid_seqs = distribution[2]
+
+    # Drop oldest state and append new state
+    new_state_extracted = jnp.concatenate(
+        [gathered_state[:, 1:, :], x[:, jnp.newaxis, :]], axis=1)
+
+    token_idx = jnp.arange(num_tokens)
+    valid_mask = token_idx < num_valid_seqs
+    states_to_set = jnp.where(
+        valid_mask[:, jnp.newaxis, jnp.newaxis],
+        new_state_extracted,
+        gathered_state,
+    )
+
+    updated_conv_state = conv_state.at[req_state_indices].set(states_to_set)
+
+    out = jnp.where(valid_mask[:, jnp.newaxis], out, 0.0)
+
+    return out.astype(x.dtype), updated_conv_state
+
+
+# Donate conv_state to avoid "copy" op by XLA
+@jax.jit(donate_argnames=("conv_state", ), static_argnames=("kernel_size", ))
+@jax.named_scope("ragged_conv1d_jax")
+def ragged_conv1d(
+    x: jax.Array,
+    conv_state: jax.Array,
+    conv_weight: jax.Array,
+    conv_bias: jax.Array | None,
+    query_start_loc: jax.Array,
+    state_indices: jax.Array,
+    distribution: jax.Array,
+    has_initial_state: jax.Array,
+    *,
+    kernel_size: int,
+) -> tuple[jax.Array, jax.Array]:
+    """Applies 1D convolution over ragged sequences and updates state.
+
+    Args:
+      x: Input tensor of shape `(num_tokens, dim)`.
+      conv_state: Combined convolutional state of shape `(max_blocks, kernel_size
+        - 1, dim)`.
+      conv_weight: Convolutional weight of shape `(dim, 1, kernel_size)`.
+      conv_bias: Optional convolutional bias of shape `(dim,)`.
+      query_start_loc: Tensor of shape `(num_seqs + 1,)` containing the start
+        indices of each sequence, with the last element being the total number of
+        valid tokens.
+      state_indices: Tensor of shape `(max_blocks,)` mapping request index to
+        state index.
+      distribution: Distribution tensor containing number of valid sequences at
+        index 2.
+      has_initial_state: Boolean tensor of shape `(max_reqs,)`. ``True`` when the
+        request has prior conv state to use (chunked-prefill continuation or
+        prefix-cache hit). ``False`` for brand-new prefills, in which case the
+        gathered conv state is treated as zeros — matching GPU's
+        ``causal_conv1d_fn(has_initial_state=...)`` semantics. Without this
+        masking the conv would consume whatever a reused mamba slot still held
+        from a prior request, silently corrupting the first ``kernel_size - 1``
+        outputs of every new request.
+      kernel_size: The size of the convolution kernel.
+
+    Returns:
+      A tuple containing:
+      - output: The output tensor of shape `(num_tokens, dim)`.
+      - updated_conv_state: The updated convolutional state of shape `(max_blocks,
+        kernel_size - 1, dim)`.
+    """
+    is_decode_only = distribution[0] == distribution[2]
+
+    def decode_only_branch(_):
+        return ragged_conv1d_decode_only(
+            x,
+            conv_state,
+            conv_weight,
+            conv_bias,
+            query_start_loc,
+            state_indices,
+            distribution,
+            has_initial_state,
+            kernel_size=kernel_size,
+        )
+
+    def mixed_prefill_branch(_):
+        return ragged_conv1d_mixed_prefill(
+            x,
+            conv_state,
+            conv_weight,
+            conv_bias,
+            query_start_loc,
+            state_indices,
+            distribution,
+            has_initial_state,
+            kernel_size=kernel_size,
+        )
+
+    return jax.lax.cond(is_decode_only,
+                        decode_only_branch,
+                        mixed_prefill_branch,
+                        operand=None)


### PR DESCRIPTION
# Description

* Separating decode and prefill
* Prefill  uses a more optimal algorithm to reduce scatter
* Decode uses a very simple algorithm to do batch conv1d 

If the change fixes a Github issue, please include a link, e.g.,:
FIXES: #123456

# Tests
Tested prompt quality offline script.
Benchmark tested.
Micro benchmkark
8K/1K, qwen 3.5
Prefill 797us -> 291us
Decode: 54us -> 40us

Quality test

```
=================================================================================================================================================
 EVALUATION RESULTS SUMMARY                                                              
=================================================================================================================================================
| Task                        | Model Name                   | Flags              | Limit  | Filter           | Value  | Stderr | Time (s) |
|-----------------------------|------------------------------|--------------------|--------|------------------|--------|--------|----------|
| gpqa_diamond_cot_zeroshot   | Qwen/Qwen3.5-397B-A17B-FP8   | fused_gdn_kernel   | None   | flexible-extract | 0.8332 | 0.0272 | 1460.10  |
| mmlu_pro                    | Qwen/Qwen3.5-397B-A17B-FP8   | fused_gdn_kernel   | 50     | custom-extract   | 0.8329 | 0.0138 | 926.66   |
=================================================================================================================================================

```

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
