### PR TITLE
[DeepSeek] reduce array copy in attn layer

### DIFF
--- a/tests/layers/vllm/backends/test_flash_attn_mla.py
+++ b/tests/layers/vllm/backends/test_flash_attn_mla.py
@@ -69,16 +69,18 @@ def create_mla_inputs(
     max_blocks_per_seq: int = MAX_BLOCKS_PER_SEQ,
 ):
     key = jax.random.key(0)
-    qk_head_dim = qk_nope_head_dim + qk_rope_head_dim
 
-    q = jax.random.uniform(key, (total_tokens, num_heads, qk_head_dim),
-                           dtype=q_dtype)
+    q_nope = jax.random.uniform(key,
+                                (total_tokens, num_heads, qk_nope_head_dim),
+                                dtype=q_dtype)
+    q_pe = jax.random.uniform(key, (total_tokens, num_heads, qk_rope_head_dim),
+                              dtype=q_dtype)
     kv_c_normed = jax.random.uniform(key, (total_tokens, kv_lora_rank),
                                      dtype=q_dtype)
     k_pe = jax.random.uniform(key, (total_tokens, 1, qk_rope_head_dim),
                               dtype=q_dtype)
 
-    q = torch_view(q)
+    q = (torch_view(q_nope), torch_view(q_pe))
     kv_c_normed = torch_view(kv_c_normed)
     k_pe = torch_view(k_pe)
 

--- a/tests/layers/vllm/test_mla_attention.py
+++ b/tests/layers/vllm/test_mla_attention.py
@@ -177,7 +177,7 @@ class TestVllmTPUMLAAttention:
         mock_get_attention_context.return_value = (mock_attn_metadata, None,
                                                    None, None)
 
-        q = torch.rand(1, 10)
+        q = (torch.rand(1, 5), torch.rand(1, 5))
         kv_c_normed = torch.rand(1, 10)
         k_pe = torch.rand(1, 10)
 
@@ -238,7 +238,7 @@ class TestVllmTPUMLAAttention:
         mock_get_attention_context.return_value = (MagicMock(), None, None,
                                                    None)
 
-        q = torch.rand(1, 10)
+        q = (torch.rand(1, 5), torch.rand(1, 5))
         kv_c_normed = torch.rand(1, 10)
         k_pe = torch.rand(1, 10)
 

--- a/tpu_inference/layers/vllm/backends/flash_attn_mla.py
+++ b/tpu_inference/layers/vllm/backends/flash_attn_mla.py
@@ -109,7 +109,7 @@ class PallasMLAttentionBackendImpl(MLAAttentionImpl):
         pass
 
     def forward(self,
-                q: torch.Tensor,
+                q: tuple[torch.Tensor, torch.Tensor],
                 kv_c_normed: torch.Tensor,
                 k_pe: torch.Tensor,
                 kv_cache: jnp.ndarray,
@@ -126,7 +126,7 @@ class PallasMLAttentionBackendImpl(MLAAttentionImpl):
         below anyways.
 
         Args:
-            q: torch.Tensor
+            q: q_nope, q_pe tuple of torch.Tensor
             kv_c_normed: torch.Tensor
             k_pe: torch.Tensor
             kv_cache: jnp.ndarray
@@ -139,13 +139,12 @@ class PallasMLAttentionBackendImpl(MLAAttentionImpl):
             Tuple[jnp.ndarray, jnp.ndarray]: (new_kv_cache, outputs)
         """
 
-        q = jax_view(q)
+        q_nope, q_pe = q
+        q_nope = jax_view(q_nope)
+        q_pe = jax_view(q_pe)
         kv_c_normed = jax_view(kv_c_normed)
         k_pe = jax_view(k_pe)
-        input_dtype = q.dtype
-
-        # Prepare inputs
-        q_nope, q_pe = jnp.split(q, [self.qk_nope_head_dim], axis=2)
+        input_dtype = q_nope.dtype
 
         # (B, N, P) x (N, P, L) -> (B, N, L)
         # torch nn param

--- a/tpu_inference/layers/vllm/custom_ops/mla_attention.py
+++ b/tpu_inference/layers/vllm/custom_ops/mla_attention.py
@@ -109,7 +109,7 @@ class VllmMLAAttention(MLAAttention):
                 delattr(self.kv_b_proj, key)
 
     def forward(self,
-                q: torch.Tensor,
+                q: tuple[torch.Tensor, torch.Tensor],
                 kv_c_normed: torch.Tensor,
                 k_pe: torch.Tensor,
                 output: torch.Tensor | None = None,
@@ -213,3 +213,67 @@ class VllmMultiHeadLatentAttentionWrapper(MultiHeadLatentAttentionWrapper):
         )
 
         self.prefix = prefix
+
+    def forward(
+        self,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+        llama_4_scaling: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        q_c = None
+        kv_lora = None
+
+        if self.q_lora_rank is not None:
+            assert self.fused_qkv_a_proj is not None, (
+                "fused_qkv_a_proj is required when q_lora_rank is not None")
+            assert self.q_a_layernorm is not None, (
+                "q_a_layernorm is required when q_lora_rank is not None")
+            assert self.q_b_proj is not None, (
+                "q_b_proj is required when q_lora_rank is not None")
+
+            qkv_lora = self.fused_qkv_a_proj(hidden_states)[0]
+            q_c, kv_lora = qkv_lora.split(
+                [self.q_lora_rank, self.kv_lora_rank + self.qk_rope_head_dim],
+                dim=-1,
+            )
+            q_c = self.q_a_layernorm(q_c)
+            q = self.q_b_proj(q_c)[0]
+        else:
+            assert self.kv_a_proj_with_mqa is not None, (
+                "kv_a_proj_with_mqa is required when q_lora_rank is None")
+            assert self.q_proj is not None, (
+                "q_proj is required when q_lora_rank is None")
+            kv_lora = self.kv_a_proj_with_mqa(hidden_states)[0]
+            q = self.q_proj(hidden_states)[0]
+
+        kv_c, k_pe = kv_lora.split([self.kv_lora_rank, self.qk_rope_head_dim],
+                                   dim=-1)
+        kv_c_normed = self.kv_a_layernorm(kv_c)
+
+        q = q.view(-1, self.num_heads, self.qk_head_dim)
+        q_nope, q_pe = q.split([self.qk_nope_head_dim, self.qk_rope_head_dim],
+                               dim=-1)
+
+        # Add head dim of 1 to k_pe
+        k_pe = k_pe.unsqueeze(1)
+
+        if self.rotary_emb is not None:
+            q_pe, k_pe = self.rotary_emb(positions, q_pe, k_pe)
+
+        if self.indexer and self.is_sparse:
+            _topk_indices = self.indexer(hidden_states, q_c, positions,
+                                         self.indexer_rope_emb)
+
+        if llama_4_scaling is not None:
+            q_nope *= llama_4_scaling
+            q_pe *= llama_4_scaling
+
+        attn_out = self.mla_attn(
+            (q_nope, q_pe),
+            kv_c_normed,
+            k_pe,
+            output_shape=(hidden_states.shape[0],
+                          self.num_heads * self.v_head_dim),
+        )
+
+        return self.o_proj(attn_out)[0]


### PR DESCRIPTION
Reduce array copy in attn layer.

override MultiHeadLatentAttentionWrapper::foward() (https://github.com/vllm-project/vllm/blob/65b9808960d7f25a018c525d2aca3dba7c411cfb/vllm/model_executor/layers/mla.py#L113-L175) with VllmMultiHeadLatentAttentionWrapper::forward().

The main difference:
tpu-inference: split q-nope, q-pe early on, and apply ROPE on the q-pe: https://screenshot.googleplex.com/C6rYNgA69Nsm8QL
instead of vllm:
https://screenshot.googleplex.com/BFcYzHDiBUdLscF apply ROPE on a  a slice of Q.

This save about 30us per layer (2~3% E2E) due to less array copies.
With this PR:
https://screenshot.googleplex.com/3dbRxggUeELATnt about 100us before MLA Pallas kernel.
HEAD:
https://screenshot.googleplex.com/4hDYKWsNepGQLwR about 128us before MLA Pallas kernel.

# Tests
quality verfied:
https://paste.googleplex.com/4554609801691136 