### PR TITLE
Add DCP sharding axis and KV cache support

### DIFF
--- a/tests/layers/common/test_sharding.py
+++ b/tests/layers/common/test_sharding.py
@@ -28,6 +28,7 @@ class TestShardingConfigManager(unittest.TestCase):
         vllm_config = MagicMock()
         vllm_config.parallel_config.tensor_parallel_size = 8
         vllm_config.parallel_config.data_parallel_size = 2
+        vllm_config.parallel_config.decode_context_parallel_size = 1
         vllm_config.model_config.use_mla = True
         vllm_config.model_config.get_total_num_kv_heads.return_value = 1
         vllm_config.speculative_config = None
@@ -48,6 +49,7 @@ class TestShardingConfigManager(unittest.TestCase):
         vllm_config = MagicMock()
         vllm_config.parallel_config.tensor_parallel_size = 8
         vllm_config.parallel_config.data_parallel_size = 1
+        vllm_config.parallel_config.decode_context_parallel_size = 1
         vllm_config.model_config.use_mla = True
         vllm_config.model_config.get_total_num_kv_heads.return_value = 1
         vllm_config.speculative_config = None
@@ -83,6 +85,7 @@ class TestShardingConfigManager(unittest.TestCase):
         vllm_config = MagicMock()
         vllm_config.parallel_config.tensor_parallel_size = 1
         vllm_config.parallel_config.data_parallel_size = 1
+        vllm_config.parallel_config.decode_context_parallel_size = 1
         vllm_config.model_config.use_mla = False
         vllm_config.model_config.get_total_num_kv_heads.return_value = 4
         vllm_config.speculative_config = None
@@ -118,6 +121,7 @@ class TestShardingConfigManager(unittest.TestCase):
         vllm_config = MagicMock()
         vllm_config.parallel_config.tensor_parallel_size = 8
         vllm_config.parallel_config.data_parallel_size = 1
+        vllm_config.parallel_config.decode_context_parallel_size = 1
         vllm_config.model_config.use_mla = False
         vllm_config.model_config.get_total_num_kv_heads.return_value = 4
         vllm_config.speculative_config = None
@@ -154,6 +158,7 @@ class TestShardingConfigManager(unittest.TestCase):
         vllm_config = MagicMock()
         vllm_config.parallel_config.tensor_parallel_size = 2
         vllm_config.parallel_config.data_parallel_size = 1
+        vllm_config.parallel_config.decode_context_parallel_size = 1
         vllm_config.model_config.use_mla = False
         vllm_config.model_config.get_total_num_kv_heads.return_value = 4
         vllm_config.speculative_config = None
@@ -190,6 +195,7 @@ class TestShardingConfigManager(unittest.TestCase):
         vllm_config = MagicMock()
         vllm_config.parallel_config.tensor_parallel_size = 4
         vllm_config.parallel_config.data_parallel_size = 1
+        vllm_config.parallel_config.decode_context_parallel_size = 1
         vllm_config.model_config.use_mla = False
         vllm_config.model_config.get_total_num_kv_heads.return_value = 4
         vllm_config.speculative_config = None
@@ -224,6 +230,7 @@ class TestShardingConfigManager(unittest.TestCase):
         vllm_config = MagicMock()
         vllm_config.parallel_config.tensor_parallel_size = 1
         vllm_config.parallel_config.data_parallel_size = 1
+        vllm_config.parallel_config.decode_context_parallel_size = 1
         vllm_config.model_config.use_mla = True
         vllm_config.speculative_config = None
 
@@ -242,6 +249,7 @@ class TestShardingConfigManager(unittest.TestCase):
         vllm_config = MagicMock()
         vllm_config.parallel_config.tensor_parallel_size = 8
         vllm_config.parallel_config.data_parallel_size = 1
+        vllm_config.parallel_config.decode_context_parallel_size = 1
         vllm_config.model_config.use_mla = True
         vllm_config.speculative_config = None
 
@@ -262,6 +270,7 @@ class TestShardingConfigManager(unittest.TestCase):
         vllm_config = MagicMock()
         vllm_config.parallel_config.tensor_parallel_size = 8
         vllm_config.parallel_config.data_parallel_size = 1
+        vllm_config.parallel_config.decode_context_parallel_size = 1
         vllm_config.model_config.use_mla = True
         vllm_config.speculative_config = None
 
@@ -282,6 +291,7 @@ class TestShardingConfigManager(unittest.TestCase):
         vllm_config = MagicMock()
         vllm_config.parallel_config.tensor_parallel_size = 8
         vllm_config.parallel_config.data_parallel_size = 1
+        vllm_config.parallel_config.decode_context_parallel_size = 1
         vllm_config.model_config.use_mla = True
         vllm_config.speculative_config = None
 

--- a/tests/layers/common/utils.py
+++ b/tests/layers/common/utils.py
@@ -34,7 +34,7 @@ def get_spmd_mesh(num_devices: int = 1, enable_attn_dp: bool = False):
         axis_names = MESH_AXIS_NAMES
         attn_dp_size = 2
         model_size = num_devices // attn_dp_size
-        mesh_shape = (1, attn_dp_size, 1, 1, model_size)
+        mesh_shape = (1, attn_dp_size, 1, 1, model_size, 1)
     else:
         axis_names = MESH_AXIS_NAMES_2D
         mesh_shape = (1, len(devices))

--- a/tests/runner/test_kv_cache.py
+++ b/tests/runner/test_kv_cache.py
@@ -32,7 +32,9 @@ from tpu_inference.utils import get_dtype_packing
 def mesh():
     devices = np.array(jax.local_devices()[:1])
     devices = devices.reshape((1, 1, 1, 1, 1, -1))
-    return Mesh(devices, axis_names=("data", "attn_dp", "attn_dp_expert", "expert", "model", "dcp"))
+    return Mesh(devices,
+                axis_names=("data", "attn_dp", "attn_dp_expert", "expert",
+                            "model", "dcp"))
 
 
 def test_create_kv_caches(mesh: Mesh):
@@ -51,15 +53,16 @@ def test_create_kv_caches(mesh: Mesh):
     with patch("tpu_inference.logger.init_logger",
                return_value=MagicMock()), patch(
                    "tpu_inference.utils.hbm_usage_gb",
-                   return_value=[(0.0, 0.0), (0.0, 0.0)]), patch(
-                       "tpu_inference.envs.NEW_MODEL_DESIGN", True):
+                   return_value=[
+                       (0.0, 0.0), (0.0, 0.0)
+                   ]), patch("tpu_inference.envs.NEW_MODEL_DESIGN", True):
         expected_sharding = NamedSharding(
             mesh,
-            PartitionSpec(ShardingAxisName.BATCH,
-                          ShardingAxisName.CONTEXT,
+            PartitionSpec(ShardingAxisName.BATCH, ShardingAxisName.CONTEXT,
                           ShardingAxisName.KV_CACHE_HEAD))
-        expected_shape = get_kv_cache_shape_with_mesh(mesh, num_blocks, block_size,
-                                                      num_kv_heads, head_size,
+        expected_shape = get_kv_cache_shape_with_mesh(mesh, num_blocks,
+                                                      block_size, num_kv_heads,
+                                                      head_size,
                                                       expected_dtype)
         kv_caches = create_kv_caches(
             num_blocks=num_blocks,
@@ -111,8 +114,9 @@ def test_create_kv_caches_mla(mesh: Mesh):
     with patch("tpu_inference.logger.init_logger",
                return_value=MagicMock()), patch(
                    "tpu_inference.utils.hbm_usage_gb",
-                   return_value=[(0.0, 0.0), (0.0, 0.0)]), patch(
-                       "tpu_inference.envs.NEW_MODEL_DESIGN", True):
+                   return_value=[
+                       (0.0, 0.0), (0.0, 0.0)
+                   ]), patch("tpu_inference.envs.NEW_MODEL_DESIGN", True):
         kv_caches = create_kv_caches(
             num_blocks=num_blocks,
             block_size=block_size,

--- a/tests/runner/test_kv_cache.py
+++ b/tests/runner/test_kv_cache.py
@@ -46,21 +46,21 @@ def test_create_kv_caches(mesh: Mesh):
     head_size = 128
     layer_names = ["decoder.0", "decoder.1", "decoder.2"]  # Test with 3 layers
 
-    expected_sharding = NamedSharding(
-        mesh,
-        PartitionSpec(ShardingAxisName.BATCH, 
-                      ShardingAxisName.CONTEXT,
-                      ShardingAxisName.ATTN_HEAD)
     expected_dtype = jnp.bfloat16
-    expected_shape = get_kv_cache_shape_with_mesh(mesh, num_blocks, block_size,
-                                                  num_kv_heads, head_size,
-                                                  expected_dtype)
 
     with patch("tpu_inference.logger.init_logger",
                return_value=MagicMock()), patch(
                    "tpu_inference.utils.hbm_usage_gb",
                    return_value=[(0.0, 0.0), (0.0, 0.0)]), patch(
                        "tpu_inference.envs.NEW_MODEL_DESIGN", True):
+        expected_sharding = NamedSharding(
+            mesh,
+            PartitionSpec(ShardingAxisName.BATCH,
+                          ShardingAxisName.CONTEXT,
+                          ShardingAxisName.KV_CACHE_HEAD))
+        expected_shape = get_kv_cache_shape_with_mesh(mesh, num_blocks, block_size,
+                                                      num_kv_heads, head_size,
+                                                      expected_dtype)
         kv_caches = create_kv_caches(
             num_blocks=num_blocks,
             block_size=block_size,

--- a/tests/runner/test_kv_cache.py
+++ b/tests/runner/test_kv_cache.py
@@ -96,7 +96,7 @@ def test_create_kv_caches_mla(mesh: Mesh):
 
     # For MLA, sharding is by the 'model' axis on the token dimension.
     expected_sharding = NamedSharding(
-        mesh, PartitionSpec(ShardingAxisName.MLP_TENSOR))
+        mesh, PartitionSpec(ShardingAxisName.BATCH, ShardingAxisName.CONTEXT))
     expected_dtype = jnp.bfloat16
     expected_shape = get_kv_cache_shape_with_mesh(
         mesh,

--- a/tests/runner/test_kv_cache.py
+++ b/tests/runner/test_kv_cache.py
@@ -31,8 +31,8 @@ from tpu_inference.utils import get_dtype_packing
 @pytest.fixture
 def mesh():
     devices = np.array(jax.local_devices()[:1])
-    devices = devices.reshape((1, 1, -1))
-    return Mesh(devices, axis_names=("data", "attn_dp", "model"))
+    devices = devices.reshape((1, 1, 1, 1, 1, -1))
+    return Mesh(devices, axis_names=("data", "attn_dp", "attn_dp_expert", "expert", "model", "dcp"))
 
 
 def test_create_kv_caches(mesh: Mesh):
@@ -47,7 +47,10 @@ def test_create_kv_caches(mesh: Mesh):
     layer_names = ["decoder.0", "decoder.1", "decoder.2"]  # Test with 3 layers
 
     expected_sharding = NamedSharding(
-        mesh, PartitionSpec(ShardingAxisName.ATTN_DATA, None, "model"))
+        mesh,
+        PartitionSpec(ShardingAxisName.BATCH, 
+                      ShardingAxisName.CONTEXT,
+                      ShardingAxisName.ATTN_HEAD)
     expected_dtype = jnp.bfloat16
     expected_shape = get_kv_cache_shape_with_mesh(mesh, num_blocks, block_size,
                                                   num_kv_heads, head_size,
@@ -56,7 +59,8 @@ def test_create_kv_caches(mesh: Mesh):
     with patch("tpu_inference.logger.init_logger",
                return_value=MagicMock()), patch(
                    "tpu_inference.utils.hbm_usage_gb",
-                   return_value=[(0.0, 0.0), (0.0, 0.0)]):
+                   return_value=[(0.0, 0.0), (0.0, 0.0)]), patch(
+                       "tpu_inference.envs.NEW_MODEL_DESIGN", True):
         kv_caches = create_kv_caches(
             num_blocks=num_blocks,
             block_size=block_size,
@@ -107,7 +111,8 @@ def test_create_kv_caches_mla(mesh: Mesh):
     with patch("tpu_inference.logger.init_logger",
                return_value=MagicMock()), patch(
                    "tpu_inference.utils.hbm_usage_gb",
-                   return_value=[(0.0, 0.0), (0.0, 0.0)]):
+                   return_value=[(0.0, 0.0), (0.0, 0.0)]), patch(
+                       "tpu_inference.envs.NEW_MODEL_DESIGN", True):
         kv_caches = create_kv_caches(
             num_blocks=num_blocks,
             block_size=block_size,

--- a/tests/runner/test_tpu_runner_mesh.py
+++ b/tests/runner/test_tpu_runner_mesh.py
@@ -35,6 +35,7 @@ class TestTPUModelRunnerMeshInit:
         config.sharding_config.tp_size = 8
         config.sharding_config.device_indexes = None
         config.sharding_config.total_dp_size = 4
+        config.sharding_config.decode_cp_size = 1
         return config
 
     @pytest.fixture
@@ -133,15 +134,15 @@ class TestTPUModelRunnerMeshInit:
             mock_mesh_utils.create_device_mesh.assert_called_once()
             call_args = mock_mesh_utils.create_device_mesh.call_args
 
-            # Verify mesh_shape: (model_dp_size, attn_dp_size, attn_dp_expert_size, expert_size, tp_size)
-            assert call_args[0][0] == (4, 2, 1, 1, 8)
+            # Verify mesh_shape: (model_dp_size, attn_dp_size, attn_dp_expert_size, expert_size, tp_size, dcp_size)
+            assert call_args[0][0] == (4, 2, 1, 1, 8, 1)
             assert call_args[0][1] == runner_instance.devices
             assert call_args[1]['allow_split_physical_axes'] is True
 
             # Verify Mesh was created with correct axis names
             mock_jax_mesh.assert_called_once_with(
-                mock_devices_array,
-                ("data", "attn_dp", "attn_dp_expert", "expert", "model"))
+                mock_devices_array, ("data", "attn_dp", "attn_dp_expert",
+                                     "expert", "model", "dcp"))
 
             assert runner_instance.mesh == mock_mesh
 
@@ -165,18 +166,18 @@ class TestTPUModelRunnerMeshInit:
             mock_mesh_utils.create_hybrid_device_mesh.assert_called_once()
             call_args = mock_mesh_utils.create_hybrid_device_mesh.call_args
 
-            # Verify intra_node_shape: (dp_inner, attn_dp_size, attn_dp_expert_size, expert_size, tp_size)
+            # Verify intra_node_shape: (dp_inner, attn_dp_size, attn_dp_expert_size, expert_size, tp_size, dcp_size)
             # dp_inner = model_dp_size // num_slices = 4 // 2 = 2
-            assert call_args[1]['mesh_shape'] == (2, 2, 1, 1, 8)
+            assert call_args[1]['mesh_shape'] == (2, 2, 1, 1, 8, 1)
             # Verify outer_node_shape: (num_slices, 1, 1, 1, 1)
-            assert call_args[1]['dcn_mesh_shape'] == (2, 1, 1, 1, 1)
+            assert call_args[1]['dcn_mesh_shape'] == (2, 1, 1, 1, 1, 1)
             assert call_args[1]['devices'] == runner_instance.devices
             assert call_args[1]['allow_split_physical_axes'] is True
 
             # Verify Mesh was created with correct axis names
             mock_jax_mesh.assert_called_once_with(
-                mock_devices_array,
-                ("data", "attn_dp", "attn_dp_expert", "expert", "model"))
+                mock_devices_array, ("data", "attn_dp", "attn_dp_expert",
+                                     "expert", "model", "dcp"))
 
             assert runner_instance.mesh == mock_mesh
 

--- a/tpu_inference/layers/common/attention_interface.py
+++ b/tpu_inference/layers/common/attention_interface.py
@@ -506,14 +506,14 @@ def mla_attention(
         keyvalue_skh_sharding or P(ShardingAxisName.MLP_TENSOR, None),  # k
         keyvalue_skh_sharding
         or P(ShardingAxisName.MLP_TENSOR, None),  # k_rope
-        P(ShardingAxisName.MLP_TENSOR),  # kv_cache
+        P(ShardingAxisName.BATCH),  # kv_cache
         P(ShardingAxisName.ATTN_DATA),  # md.seq_lens
         P(ShardingAxisName.ATTN_DATA),  # md.page_indices_flat
         P(ShardingAxisName.ATTN_DATA),  # md.query_start_loc
         P(ShardingAxisName.ATTN_DATA),  # md.distribution
     )
     out_specs = (
-        P(ShardingAxisName.MLP_TENSOR),  # kv cache
+        P(ShardingAxisName.BATCH),  # kv cache
         attn_o_tnh_sharding
         or P(ShardingAxisName.MLP_TENSOR, None, None)  # attn output
     )

--- a/tpu_inference/layers/common/sharding.py
+++ b/tpu_inference/layers/common/sharding.py
@@ -26,7 +26,7 @@ from tpu_inference import envs, utils
 if TYPE_CHECKING:
     from vllm.config import VllmConfig
 
-MESH_AXIS_NAMES = ("data", "attn_dp", "attn_dp_expert", "expert", "model")
+MESH_AXIS_NAMES = ("data", "attn_dp", "attn_dp_expert", "expert", "model", "dcp")
 MESH_AXIS_NAMES_2D = ('data', 'model')
 
 
@@ -40,16 +40,20 @@ class ShardingAxisNameBase:
     ATTN_DATA = ('data', 'attn_dp', 'attn_dp_expert')
     ATTN_DATA_EXPERT = ('attn_dp_expert', 'expert')
     MLP_DATA = 'data'
-    ATTN_HEAD = ('model', 'expert')
+    ATTN_HEAD = ('model', 'expert', 'dcp')
     ATTN_TENSOR = None
-    MLP_TENSOR = ('attn_dp', 'attn_dp_expert', 'model', 'expert')
-    MOE_TENSOR = ('attn_dp', 'model')
-    EXPERT = ('attn_dp', 'attn_dp_expert', 'expert', 'model')
+    MLP_TENSOR = ('attn_dp', 'attn_dp_expert', 'model', 'dcp', 'expert')
+    MOE_TENSOR = ('attn_dp', 'model', 'dcp')
+    EXPERT = ('attn_dp', 'attn_dp_expert', 'expert', 'model', 'dcp')
     EXPERT_DATA = ('data', 'attn_dp', 'attn_dp_expert', 'expert', 'model')
-    VOCAB = ('model', 'attn_dp', 'attn_dp_expert', 'expert')
+    VOCAB = ('data', 'expert', 'attn_dp', 'model', 'dcp')
     MODEL_1 = 'model'
     MODEL_2 = 'expert'
 
+    # These axes are used in KV caches management.
+    BATCH = ('data', 'attn_dp')
+    CONTEXT = 'dcp'
+    KV_CACHE_HEAD = ('model', 'expert')
 
 class ShardingAxisName2D:
     """Sharding axis names for 2D data parallelism scenarios.
@@ -67,6 +71,10 @@ class ShardingAxisName2D:
     EXPERT = 'model'
     EXPERT_DATA = ('data', 'model')
     VOCAB = ('data', 'model')
+
+    KV_CACHE_BLOCK = 'data'
+    KV_CACHE_PAGE = None
+    KV_CACHE_HEAD = 'model'
 
 
 # Lazily initialize the ShardingAxisName so that we can decide which one to use based on the
@@ -119,6 +127,7 @@ class ShardingStrategy:
     data_parallelism: int = 1
     attention_data_parallelism: int = 1
     attention_data_expert_parallelism: int = 1
+    decode_context_parallelism: int = 1
 
 
 class ShardingConfigManager:
@@ -160,6 +169,10 @@ class ShardingConfigManager:
         sequence_parallelism = sharding_strategy.get("sequence_parallelism", 1)
         device_indexes = sharding_strategy.get("device_indexes", None)
 
+        # Decode Context Parallel is introduced in vllm.
+        # https://github.com/vllm-project/vllm/blob/bb51d5b40db6076fc477df27a57e70b7421d87c1/vllm/config/parallel.py
+        decode_context_parallelism = parallel_config.decode_context_parallel_size
+
         enable_dp_attention = sharding_strategy.get("enable_dp_attention",
                                                     False)
         if pc_tensor_parallelism != ss_tensor_parallelsim and ss_tensor_parallelsim:
@@ -167,6 +180,13 @@ class ShardingConfigManager:
             tensor_parallelism = ss_tensor_parallelsim
         else:
             tensor_parallelism = pc_tensor_parallelism
+
+        if tensor_parallelism % decode_context_parallelism != 0:
+            raise ValueError(
+                f"tensor_parallelism ({tensor_parallelism}) must be divisible by "
+                f"decode_context_parallelism ({decode_context_parallelism})")
+        # DCP reused TP axis
+        tensor_parallelism = tensor_parallelism // decode_context_parallelism
 
         if enable_dp_attention:
             # Replicate attention layer when num_kv_heads < TP
@@ -221,7 +241,8 @@ class ShardingConfigManager:
             expert_parallelism=expert_parallelism,
             sequence_parallelism=sequence_parallelism,
             attention_data_parallelism=attn_dp,
-            attention_data_expert_parallelism=attn_dp_expert)
+            attention_data_expert_parallelism=attn_dp_expert,
+            decode_context_parallelism=decode_context_parallelism)
 
         # Must override here to avoid vLLM spinning up multiple DP engines.
         if vllm_config.parallel_config.data_parallel_size > 1:
@@ -251,6 +272,12 @@ class ShardingConfigManager:
                 raise ValueError(
                     "Must run Attention DP with NEW_MODEL_DESIGN enabled. Please set "
                     "NEW_MODEL_DESIGN=True")
+        if sharding_strategy.decode_context_parallelism > 1 :
+            if not envs.NEW_MODEL_DESIGN:
+                raise ValueError(
+                    "Must run Context Parallelism with NEW_MODEL_DESIGN enabled. Please set "
+                    "NEW_MODEL_DESIGN=True"
+                )
 
     @property
     def total_dp_size(self) -> int:
@@ -279,6 +306,10 @@ class ShardingConfigManager:
     @property
     def sequence_size(self) -> int:
         return self.sharding_strategy.sequence_parallelism
+
+    @property
+    def decode_cp_size(self) -> int:
+        return self.sharding_strategy.decode_context_parallelism
 
     @property
     def total_devices(self) -> int:
@@ -434,6 +465,7 @@ def build_mesh(devices, strategy: dict[str, int]) -> Mesh:
         "expert": strategy.get("expert_parallelism", 1),
         "seq": strategy.get("sequence_parallelism", 1),
         "model": strategy.get("tensor_parallelism", 1),
+        "dcp": strategy.get("decode_context_parallelism", 1),
     }
     # TODO: add logic to infer axis when the degree is -1
     mesh_axis_names = []

--- a/tpu_inference/layers/common/sharding.py
+++ b/tpu_inference/layers/common/sharding.py
@@ -26,7 +26,8 @@ from tpu_inference import envs, utils
 if TYPE_CHECKING:
     from vllm.config import VllmConfig
 
-MESH_AXIS_NAMES = ("data", "attn_dp", "attn_dp_expert", "expert", "model", "dcp")
+MESH_AXIS_NAMES = ("data", "attn_dp", "attn_dp_expert", "expert", "model",
+                   "dcp")
 MESH_AXIS_NAMES_2D = ('data', 'model')
 
 
@@ -45,7 +46,8 @@ class ShardingAxisNameBase:
     MLP_TENSOR = ('attn_dp', 'attn_dp_expert', 'expert', 'model', 'dcp')
     MOE_TENSOR = ('attn_dp', 'model', 'dcp')
     EXPERT = ('attn_dp', 'attn_dp_expert', 'expert', 'model', 'dcp')
-    EXPERT_DATA = ('data', 'attn_dp', 'attn_dp_expert', 'expert', 'model', 'dcp')
+    EXPERT_DATA = ('data', 'attn_dp', 'attn_dp_expert', 'expert', 'model',
+                   'dcp')
     VOCAB = ('attn_dp', 'attn_dp_expert', 'expert', 'model', 'dcp')
     MODEL_1 = 'model'
     MODEL_2 = 'expert'
@@ -54,6 +56,7 @@ class ShardingAxisNameBase:
     BATCH = ('data', 'attn_dp')
     CONTEXT = 'dcp'
     KV_CACHE_HEAD = ('model', 'expert')
+
 
 class ShardingAxisName2D:
     """Sharding axis names for 2D data parallelism scenarios.
@@ -74,6 +77,7 @@ class ShardingAxisName2D:
     BATCH = 'data'
     CONTEXT = None
     KV_CACHE_HEAD = 'model'
+
 
 # Lazily initialize the ShardingAxisName so that we can decide which one to use based on the
 # propagated / updated environment variables in the multi-host setup.
@@ -268,12 +272,11 @@ class ShardingConfigManager:
                 raise ValueError(
                     "Must run Attention DP with NEW_MODEL_DESIGN enabled. Please set "
                     "NEW_MODEL_DESIGN=True")
-        if sharding_strategy.decode_context_parallelism > 1 :
+        if sharding_strategy.decode_context_parallelism > 1:
             if not envs.NEW_MODEL_DESIGN:
                 raise ValueError(
                     "Must run Context Parallelism with NEW_MODEL_DESIGN enabled. Please set "
-                    "NEW_MODEL_DESIGN=True"
-                )
+                    "NEW_MODEL_DESIGN=True")
 
     @property
     def total_dp_size(self) -> int:

--- a/tpu_inference/layers/common/sharding.py
+++ b/tpu_inference/layers/common/sharding.py
@@ -45,7 +45,7 @@ class ShardingAxisNameBase:
     MLP_TENSOR = ('attn_dp', 'attn_dp_expert', 'expert', 'model', 'dcp')
     MOE_TENSOR = ('attn_dp', 'model', 'dcp')
     EXPERT = ('attn_dp', 'attn_dp_expert', 'expert', 'model', 'dcp')
-    EXPERT_DATA = ('data', 'attn_dp', 'attn_dp_expert', 'expert', 'model')
+    EXPERT_DATA = ('data', 'attn_dp', 'attn_dp_expert', 'expert', 'model', 'dcp')
     VOCAB = ('attn_dp', 'attn_dp_expert', 'expert', 'model', 'dcp')
     MODEL_1 = 'model'
     MODEL_2 = 'expert'

--- a/tpu_inference/layers/common/sharding.py
+++ b/tpu_inference/layers/common/sharding.py
@@ -42,11 +42,11 @@ class ShardingAxisNameBase:
     MLP_DATA = 'data'
     ATTN_HEAD = ('model', 'expert', 'dcp')
     ATTN_TENSOR = None
-    MLP_TENSOR = ('attn_dp', 'attn_dp_expert', 'model', 'dcp', 'expert')
+    MLP_TENSOR = ('attn_dp', 'attn_dp_expert', 'expert', 'model', 'dcp')
     MOE_TENSOR = ('attn_dp', 'model', 'dcp')
     EXPERT = ('attn_dp', 'attn_dp_expert', 'expert', 'model', 'dcp')
     EXPERT_DATA = ('data', 'attn_dp', 'attn_dp_expert', 'expert', 'model')
-    VOCAB = ('data', 'expert', 'attn_dp', 'model', 'dcp')
+    VOCAB = ('data',  'attn_dp', 'attn_dp_expert', 'expert', 'model', 'dcp')
     MODEL_1 = 'model'
     MODEL_2 = 'expert'
 
@@ -167,8 +167,6 @@ class ShardingConfigManager:
         sequence_parallelism = sharding_strategy.get("sequence_parallelism", 1)
         device_indexes = sharding_strategy.get("device_indexes", None)
 
-        # Decode Context Parallel is introduced in vllm.
-        # https://github.com/vllm-project/vllm/blob/bb51d5b40db6076fc477df27a57e70b7421d87c1/vllm/config/parallel.py
         decode_context_parallelism = parallel_config.decode_context_parallel_size
 
         enable_dp_attention = sharding_strategy.get("enable_dp_attention",

--- a/tpu_inference/layers/common/sharding.py
+++ b/tpu_inference/layers/common/sharding.py
@@ -53,7 +53,7 @@ class ShardingAxisNameBase:
     MODEL_2 = 'expert'
 
     # These axes are used in KV caches management.
-    BATCH = ('data', 'attn_dp')
+    BATCH = ('data', 'attn_dp', 'attn_dp_expert')
     CONTEXT = 'dcp'
     KV_CACHE_HEAD = ('model', 'expert')
 

--- a/tpu_inference/layers/common/sharding.py
+++ b/tpu_inference/layers/common/sharding.py
@@ -71,11 +71,9 @@ class ShardingAxisName2D:
     EXPERT = 'model'
     EXPERT_DATA = ('data', 'model')
     VOCAB = ('data', 'model')
-
-    KV_CACHE_BLOCK = 'data'
-    KV_CACHE_PAGE = None
+    BATCH = 'data'
+    CONTEXT = None
     KV_CACHE_HEAD = 'model'
-
 
 # Lazily initialize the ShardingAxisName so that we can decide which one to use based on the
 # propagated / updated environment variables in the multi-host setup.

--- a/tpu_inference/layers/common/sharding.py
+++ b/tpu_inference/layers/common/sharding.py
@@ -46,7 +46,7 @@ class ShardingAxisNameBase:
     MOE_TENSOR = ('attn_dp', 'model', 'dcp')
     EXPERT = ('attn_dp', 'attn_dp_expert', 'expert', 'model', 'dcp')
     EXPERT_DATA = ('data', 'attn_dp', 'attn_dp_expert', 'expert', 'model')
-    VOCAB = ('data',  'attn_dp', 'attn_dp_expert', 'expert', 'model', 'dcp')
+    VOCAB = ('attn_dp', 'attn_dp_expert', 'expert', 'model', 'dcp')
     MODEL_1 = 'model'
     MODEL_2 = 'expert'
 

--- a/tpu_inference/models/jax/deepseek_v3.py
+++ b/tpu_inference/models/jax/deepseek_v3.py
@@ -452,7 +452,8 @@ class DeepseekV3Attention(DeepseekV3BaseAttention):
             self.query_tnh,  # q
             self.keyvalue_skh,  # k
             self.keyvalue_skh,  # v
-            P(ShardingAxisName.BATCH, None, ShardingAxisName.ATTN_HEAD),  # kv_cache
+            P(ShardingAxisName.BATCH, None,
+              ShardingAxisName.ATTN_HEAD),  # kv_cache
             P(),  # md.seq_lens: Replicated
             P(),  # page_indices_flat: Replicated
             P(),  # query_start_loc: Replicated

--- a/tpu_inference/models/jax/deepseek_v3.py
+++ b/tpu_inference/models/jax/deepseek_v3.py
@@ -452,7 +452,7 @@ class DeepseekV3Attention(DeepseekV3BaseAttention):
             self.query_tnh,  # q
             self.keyvalue_skh,  # k
             self.keyvalue_skh,  # v
-            P(None, None, ShardingAxisName.ATTN_HEAD),  # kv_cache
+            P(ShardingAxisName.BATCH, None, ShardingAxisName.ATTN_HEAD),  # kv_cache
             P(),  # md.seq_lens: Replicated
             P(),  # page_indices_flat: Replicated
             P(),  # query_start_loc: Replicated

--- a/tpu_inference/runner/kv_cache.py
+++ b/tpu_inference/runner/kv_cache.py
@@ -55,8 +55,7 @@ def get_kv_cache_shape_with_mesh(mesh: Mesh,
                                  use_mla: bool = False):
     """Gets the KV cache shape based on the mesh configuration."""
 
-    axis_name = ShardingAxisName.ATTN_HEAD
-    model_cnt = utils.get_mesh_shape_product(mesh, axis_name)
+    model_cnt = utils.get_mesh_shape_product(mesh, ShardingAxisName.KV_CACHE_HEAD)
 
     # NOTE(chengjiyao): Currently, the attention kernel is tailored to the
     # specific model, rather than being determined by the head_dim. If new
@@ -80,6 +79,7 @@ def get_kv_cache_shape_with_mesh(mesh: Mesh,
                                   actual_num_kv_heads // model_cnt,
                                   actual_head_dim, kv_dtype))
         shape[2] *= model_cnt
+    print('shape', shape)
     return tuple(shape)
 
 
@@ -120,14 +120,20 @@ def create_kv_caches(
                                                num_kv_heads, head_size,
                                                cache_dtype, use_mla)
 
+    # num_blocks --> shard by data batch
+    # block_size --> shard by context
+    # head       --> shard by heads
     if use_mla:
-        sharding = NamedSharding(mesh,
-                                 PartitionSpec(ShardingAxisName.MLP_TENSOR))
+        sharding = NamedSharding(
+            mesh,
+            PartitionSpec(ShardingAxisName.BATCH,
+                          ShardingAxisName.CONTEXT))
     else:
         sharding = NamedSharding(
             mesh,
-            PartitionSpec(ShardingAxisName.ATTN_DATA, None,
-                          ShardingAxisName.ATTN_HEAD))
+            PartitionSpec(ShardingAxisName.BATCH,
+                          ShardingAxisName.CONTEXT,
+                          ShardingAxisName.KV_CACHE_HEAD))
 
     def _allocate() -> jax.Array:
         return jnp.empty(

--- a/tpu_inference/runner/kv_cache.py
+++ b/tpu_inference/runner/kv_cache.py
@@ -79,7 +79,6 @@ def get_kv_cache_shape_with_mesh(mesh: Mesh,
                                   actual_num_kv_heads // model_cnt,
                                   actual_head_dim, kv_dtype))
         shape[2] *= model_cnt
-    print('shape', shape)
     return tuple(shape)
 
 
@@ -126,7 +125,8 @@ def create_kv_caches(
     if use_mla:
         sharding = NamedSharding(
             mesh,
-            PartitionSpec(ShardingAxisName.MLP_TENSOR))
+            PartitionSpec(ShardingAxisName.BATCH,
+                          ShardingAxisName.CONTEXT))
     else:
         sharding = NamedSharding(
             mesh,

--- a/tpu_inference/runner/kv_cache.py
+++ b/tpu_inference/runner/kv_cache.py
@@ -55,7 +55,8 @@ def get_kv_cache_shape_with_mesh(mesh: Mesh,
                                  use_mla: bool = False):
     """Gets the KV cache shape based on the mesh configuration."""
 
-    model_cnt = utils.get_mesh_shape_product(mesh, ShardingAxisName.KV_CACHE_HEAD)
+    model_cnt = utils.get_mesh_shape_product(mesh,
+                                             ShardingAxisName.KV_CACHE_HEAD)
 
     # NOTE(chengjiyao): Currently, the attention kernel is tailored to the
     # specific model, rather than being determined by the head_dim. If new
@@ -125,13 +126,11 @@ def create_kv_caches(
     if use_mla:
         sharding = NamedSharding(
             mesh,
-            PartitionSpec(ShardingAxisName.BATCH,
-                          ShardingAxisName.CONTEXT))
+            PartitionSpec(ShardingAxisName.BATCH, ShardingAxisName.CONTEXT))
     else:
         sharding = NamedSharding(
             mesh,
-            PartitionSpec(ShardingAxisName.BATCH,
-                          ShardingAxisName.CONTEXT,
+            PartitionSpec(ShardingAxisName.BATCH, ShardingAxisName.CONTEXT,
                           ShardingAxisName.KV_CACHE_HEAD))
 
     def _allocate() -> jax.Array:

--- a/tpu_inference/runner/kv_cache.py
+++ b/tpu_inference/runner/kv_cache.py
@@ -126,8 +126,7 @@ def create_kv_caches(
     if use_mla:
         sharding = NamedSharding(
             mesh,
-            PartitionSpec(ShardingAxisName.BATCH,
-                          ShardingAxisName.CONTEXT))
+            PartitionSpec(ShardingAxisName.MLP_TENSOR))
     else:
         sharding = NamedSharding(
             mesh,

--- a/tpu_inference/runner/kv_cache_manager.py
+++ b/tpu_inference/runner/kv_cache_manager.py
@@ -847,7 +847,6 @@ class KVCacheManager:
                 self.runner.layer_name_to_kvcache_index[
                     layer_name] = self.runner.layer_name_to_kvcache_index[
                         target_layer_name]
-                print(f"kv cache sharing: {layer_name}-->{target_layer_name}")
 
         logger.info(
             "Hybrid KV cache layout: num_kv_cache_groups=%d, "
@@ -1097,9 +1096,7 @@ class KVCacheManager:
             f"Transferring kv cache shape {len(kv_cache_slices)} * {kv_cache_slices[0].shape} sharding {kv_cache_slices[0].sharding} size {kv_cache_slices[0].nbytes * len(kv_cache_slices)/1024/1024} Mbytes"
         )
         sharding = NamedSharding(
-            self.runner.mesh,
-            PartitionSpec(ShardingAxisName.KV_CACHE_PAGE,
-                          ShardingAxisName.ATTN_HEAD, None))
+            self.runner.mesh, PartitionSpec(None, ShardingAxisName.ATTN_HEAD))
         if envs.VLLM_TPU_USING_PATHWAYS:
             from pathwaysutils.experimental import \
                 reshard as experimental_reshard

--- a/tpu_inference/runner/kv_cache_manager.py
+++ b/tpu_inference/runner/kv_cache_manager.py
@@ -84,13 +84,12 @@ class KVCacheManager:
     def _create_attention_spec(
             self,
             block_size: int,
-            logical_block_size: int,
             num_kv_heads: int,
             head_size: int,
             sliding_window: bool | None = None) -> KVCacheSpec:
         if self.use_mla:
             page_size_bytes = get_attention_page_size_bytes(
-                self.runner.mesh, logical_block_size, num_kv_heads, head_size,
+                self.runner.mesh, block_size, num_kv_heads, head_size,
                 self.runner.kv_cache_dtype, True)
             page_size_padded = (self._hybrid_uniform_page_size_bytes
                                 if self._hybrid_uniform_page_size_bytes
@@ -104,7 +103,7 @@ class KVCacheManager:
                                     page_size_padded=page_size_padded)
         else:
             page_size_bytes = get_attention_page_size_bytes(
-                self.runner.mesh, logical_block_size, num_kv_heads, head_size,
+                self.runner.mesh, block_size, num_kv_heads, head_size,
                 self.runner.kv_cache_dtype, False)
             page_size_padded = (self._hybrid_uniform_page_size_bytes
                                 if self._hybrid_uniform_page_size_bytes
@@ -424,8 +423,7 @@ class KVCacheManager:
     def get_kv_cache_spec(self):
         # TODO(xiang): this hack tricks engine core to init successfully
         block_size = self.runner.cache_config.block_size
-        logical_block_size = (
-            block_size *
+        block_size *= (
             self.runner.vllm_config.parallel_config.decode_context_parallel_size *
             self.runner.vllm_config.parallel_config.prefill_context_parallel_size
         )
@@ -459,7 +457,7 @@ class KVCacheManager:
             for i in range(model_config.get_num_layers(parallel_config)):
                 if self.use_mla:
                     kv_cache_spec[f"layer.{i}"] = self._create_attention_spec(
-                        block_size, logical_block_size, 1, mla_head_size)
+                        block_size, 1, mla_head_size)
                 else:
                     # TODO(kwang3939): unify the hybrid kv cache of jax path and tochax path.
                     layer_type = "full_attention"
@@ -504,13 +502,11 @@ class KVCacheManager:
                     if self.use_mla:
                         kv_cache_spec[
                             f"draft_layer.{i}"] = self._create_attention_spec(
-                                block_size,
-                                logical_block_size, 1, mla_head_size)
+                                block_size, 1, mla_head_size)
                     else:
                         kv_cache_spec[
                             f"draft_layer.{i}"] = self._create_attention_spec(
-                                block_size,
-                                logical_block_size, num_kv_heads, head_size)
+                                block_size, num_kv_heads, head_size)
         else:
             # Else propagate attention modules from compilation config.
             layers = get_layers_from_vllm_config(
@@ -581,20 +577,17 @@ class KVCacheManager:
                         kv_cache_spec[
                             layer_name] = self._create_attention_spec(
                                 block_size,
-                                logical_block_size,
                                 num_kv_heads,
                                 head_size,
                                 sliding_window=attn_module.sliding_window)
                     elif self.use_mla:
                         kv_cache_spec[
                             layer_name] = self._create_attention_spec(
-                                block_size,
-                                logical_block_size, 1, mla_head_size)
+                                block_size, 1, mla_head_size)
                     else:
                         kv_cache_spec[
                             layer_name] = self._create_attention_spec(
-                                block_size,
-                                logical_block_size, num_kv_heads, head_size)
+                                block_size, num_kv_heads, head_size)
                 elif attn_module.attn_type in (AttentionType.ENCODER,
                                                AttentionType.ENCODER_ONLY):
                     # encoder-only attention does not need KV cache.

--- a/tpu_inference/runner/kv_cache_manager.py
+++ b/tpu_inference/runner/kv_cache_manager.py
@@ -84,12 +84,13 @@ class KVCacheManager:
     def _create_attention_spec(
             self,
             block_size: int,
+            logical_block_size: int,
             num_kv_heads: int,
             head_size: int,
             sliding_window: bool | None = None) -> KVCacheSpec:
         if self.use_mla:
             page_size_bytes = get_attention_page_size_bytes(
-                self.runner.mesh, block_size, num_kv_heads, head_size,
+                self.runner.mesh, logical_block_size, num_kv_heads, head_size,
                 self.runner.kv_cache_dtype, True)
             page_size_padded = (self._hybrid_uniform_page_size_bytes
                                 if self._hybrid_uniform_page_size_bytes
@@ -103,7 +104,7 @@ class KVCacheManager:
                                     page_size_padded=page_size_padded)
         else:
             page_size_bytes = get_attention_page_size_bytes(
-                self.runner.mesh, block_size, num_kv_heads, head_size,
+                self.runner.mesh, logical_block_size, num_kv_heads, head_size,
                 self.runner.kv_cache_dtype, False)
             page_size_padded = (self._hybrid_uniform_page_size_bytes
                                 if self._hybrid_uniform_page_size_bytes
@@ -423,6 +424,11 @@ class KVCacheManager:
     def get_kv_cache_spec(self):
         # TODO(xiang): this hack tricks engine core to init successfully
         block_size = self.runner.cache_config.block_size
+        logical_block_size = (
+            block_size *
+            self.runner.vllm_config.parallel_config.decode_context_parallel_size *
+            self.runner.vllm_config.parallel_config.prefill_context_parallel_size
+        )
         kv_cache_spec: dict[str, KVCacheSpec] = {}
 
         tp_axis_name = ShardingAxisName.ATTN_HEAD
@@ -453,7 +459,7 @@ class KVCacheManager:
             for i in range(model_config.get_num_layers(parallel_config)):
                 if self.use_mla:
                     kv_cache_spec[f"layer.{i}"] = self._create_attention_spec(
-                        block_size, 1, mla_head_size)
+                        block_size, logical_block_size, 1, mla_head_size)
                 else:
                     # TODO(kwang3939): unify the hybrid kv cache of jax path and tochax path.
                     layer_type = "full_attention"
@@ -498,11 +504,13 @@ class KVCacheManager:
                     if self.use_mla:
                         kv_cache_spec[
                             f"draft_layer.{i}"] = self._create_attention_spec(
-                                block_size, 1, mla_head_size)
+                                block_size,
+                                logical_block_size, 1, mla_head_size)
                     else:
                         kv_cache_spec[
                             f"draft_layer.{i}"] = self._create_attention_spec(
-                                block_size, num_kv_heads, head_size)
+                                block_size,
+                                logical_block_size, num_kv_heads, head_size)
         else:
             # Else propagate attention modules from compilation config.
             layers = get_layers_from_vllm_config(
@@ -573,17 +581,20 @@ class KVCacheManager:
                         kv_cache_spec[
                             layer_name] = self._create_attention_spec(
                                 block_size,
+                                logical_block_size,
                                 num_kv_heads,
                                 head_size,
                                 sliding_window=attn_module.sliding_window)
                     elif self.use_mla:
                         kv_cache_spec[
                             layer_name] = self._create_attention_spec(
-                                block_size, 1, mla_head_size)
+                                block_size,
+                                logical_block_size, 1, mla_head_size)
                     else:
                         kv_cache_spec[
                             layer_name] = self._create_attention_spec(
-                                block_size, num_kv_heads, head_size)
+                                block_size,
+                                logical_block_size, num_kv_heads, head_size)
                 elif attn_module.attn_type in (AttentionType.ENCODER,
                                                AttentionType.ENCODER_ONLY):
                     # encoder-only attention does not need KV cache.
@@ -836,6 +847,7 @@ class KVCacheManager:
                 self.runner.layer_name_to_kvcache_index[
                     layer_name] = self.runner.layer_name_to_kvcache_index[
                         target_layer_name]
+                print(f"kv cache sharing: {layer_name}-->{target_layer_name}")
 
         logger.info(
             "Hybrid KV cache layout: num_kv_cache_groups=%d, "
@@ -1085,7 +1097,9 @@ class KVCacheManager:
             f"Transferring kv cache shape {len(kv_cache_slices)} * {kv_cache_slices[0].shape} sharding {kv_cache_slices[0].sharding} size {kv_cache_slices[0].nbytes * len(kv_cache_slices)/1024/1024} Mbytes"
         )
         sharding = NamedSharding(
-            self.runner.mesh, PartitionSpec(None, ShardingAxisName.ATTN_HEAD))
+            self.runner.mesh,
+            PartitionSpec(ShardingAxisName.KV_CACHE_PAGE,
+                          ShardingAxisName.ATTN_HEAD, None))
         if envs.VLLM_TPU_USING_PATHWAYS:
             from pathwaysutils.experimental import \
                 reshard as experimental_reshard

--- a/tpu_inference/runner/kv_cache_manager.py
+++ b/tpu_inference/runner/kv_cache_manager.py
@@ -718,16 +718,9 @@ class KVCacheManager:
                 assert kv_cache_tensor.size % page_size_bytes == 0
                 num_blocks = kv_cache_tensor.size // page_size_bytes
 
-            if self.use_mla and not self.runner.vllm_config.additional_config.get(
-                    "sharding", {}).get("sharding_strategy", {}).get(
-                        "enable_dp_attention", False):
-                # MLA KV cache is sharded over MLP_TENSOR
-                divisor = common_utils.get_mesh_shape_product(
-                    self.runner.mesh, ShardingAxisName.MLP_TENSOR)
-            else:
-                # Default KV cache is sharded over ATTN_DATA
-                divisor = common_utils.get_mesh_shape_product(
-                    self.runner.mesh, ShardingAxisName.ATTN_DATA)
+            # Default KV cache is sharded over (BATCH=(dp, attn_dp))
+            divisor = common_utils.get_mesh_shape_product(
+                self.runner.mesh, ShardingAxisName.BATCH)
 
             # num_blocks must be a multiple of the sharding divisor
             num_blocks = (num_blocks // divisor) * divisor

--- a/tpu_inference/runner/kv_cache_manager.py
+++ b/tpu_inference/runner/kv_cache_manager.py
@@ -423,10 +423,7 @@ class KVCacheManager:
     def get_kv_cache_spec(self):
         # TODO(xiang): this hack tricks engine core to init successfully
         block_size = self.runner.cache_config.block_size
-        block_size *= (
-            self.runner.vllm_config.parallel_config.decode_context_parallel_size *
-            self.runner.vllm_config.parallel_config.prefill_context_parallel_size
-        )
+        block_size *= self.runner.vllm_config.parallel_config.decode_context_parallel_size
         kv_cache_spec: dict[str, KVCacheSpec] = {}
 
         tp_axis_name = ShardingAxisName.ATTN_HEAD

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -336,13 +336,14 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         return jax.sharding.Mesh(devices_array, MESH_AXIS_NAMES)
 
     def _create_single_slice_mesh(self) -> jax.Array:
-        sharding_strategy: ShardingConfigManager = self.vllm_config.sharding_config
+        sharding_config: ShardingConfigManager = self.vllm_config.sharding_config
         mesh_shape = (
-            sharding_strategy.model_dp_size,
-            sharding_strategy.attn_dp_size,
-            sharding_strategy.attn_dp_expert_size,
-            sharding_strategy.expert_size,
-            sharding_strategy.tp_size,
+            sharding_config.model_dp_size,
+            sharding_config.attn_dp_size,
+            sharding_config.attn_dp_expert_size,
+            sharding_config.expert_size,
+            sharding_config.tp_size,
+            sharding_config.decode_cp_size,
         )
 
         # Attempt to create a physically optimized mesh. Fall back to a simple
@@ -362,18 +363,19 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             return np.array(self.devices).reshape(mesh_shape)
 
     def _create_multi_slice_mesh(self, num_slices: int) -> jax.Array:
-        sharding_strategy: ShardingConfigManager = self.vllm_config.sharding_config
-        dp_inner = sharding_strategy.model_dp_size // num_slices
+        sharding_config: ShardingConfigManager = self.vllm_config.sharding_config
+        dp_inner = sharding_config.model_dp_size // num_slices
 
         # Splits data parallelism across multiple slices.
         ici_mesh_shape = (
             dp_inner,
-            sharding_strategy.attn_dp_size,
-            sharding_strategy.attn_dp_expert_size,
-            sharding_strategy.expert_size,
-            sharding_strategy.tp_size,
+            sharding_config.attn_dp_size,
+            sharding_config.attn_dp_expert_size,
+            sharding_config.expert_size,
+            sharding_config.tp_size,
+            sharding_config.decode_cp_size,
         )
-        dcn_mesh_shape = (num_slices, 1, 1, 1, 1)
+        dcn_mesh_shape = (num_slices, 1, 1, 1, 1, 1)
 
         # Attempt to create a physically optimized hybrid mesh (ICI + DCN).
         # Fall back to a logical reshape for non-power-of-two device counts


### PR DESCRIPTION
# Description

This PR introduces the Decode Context Parallelism (DCP) sharding axis. It updates the sharding strategy to allow KV caches to be sharded on context dimension.

Key Changes:
- Mesh Axis Updates: Added `dcp` to `MESH_AXIS_NAMES` and updated sharding groups.
- New Sharding Axis Names: Updated `create_kv_caches` `get_kv_cache_shape_with_mesh` to use `ShardingAxisName.BATCH, CONTEXT, and KV_CACHE_HEAD`.
  - Note: These new sharding names are necessary because `ATTN_HEAD` is shared with Tensor sharding and `ATTN_DATA` is used for attention Input sharding, whereas DCP requires a unique sharding approach for KV caches.

- KV block_size: Updated the KV cache manager to handle logical_block_size calculations based on the DCP size. Following vllm upstream logic, the page_size is multiplied when DCP is enabled.

- Validation: Added checks to ensure tensor_parallelism is divisible by decode_context_parallelism and that NEW_MODEL_DESIGN is enabled.
- Additional: Decode Context Parallel is introduced in vllm (https://github.com/vllm-project/vllm/blob/bb51d5b40db6076fc477df27a57e70b7421d87c1/vllm/config/parallel.py)
        


# Tests
- [x] Run pytest tests/runner/test_kv_cache.py. (Passed)
- [x] Benchmark MLA model  

Server command: 
```
MOE_REQUANTIZE_WEIGHT_DTYPE=fp4 MOE_REQUANTIZE_BLOCK_SIZE=512 NEW_MODEL_DESIGN=1 MODEL_IMPL_TYPE=vllm vllm serve deepseek-ai/DeepSeek-R1 --max-model-len=9216 --max-num-batched-tokens=256 --max-num-seqs=128 --kv-cache-dtype=fp8 --no-enable-prefix-caching --gpu-memory-utilization=0.95 --tensor-parallel-size=8 --download_dir=/mnt/pd --async-scheduling --enable-expert-parallel --additional_config='{"compilation_sizes": [1024], "sharding": {"sharding_strategy": {"enable_dp_attention": true}}}'
```
Benchmark command: 
```
python tpu-inference/scripts/vllm/benchmarking/benchmark_serving.py --backend=vllm --model=deepseek-ai/DeepSeek-R1 --dataset-name=mmlu --dataset-path=mmlu/data/test/ --num-prompts=1000 --run_eval --mmlu-input-len=1536 --mmlu-output-len=2048 --mmlu-use-chat-template
```
| Metric | Base | Current PR |
| :--- | :--- | :--- |
| **MMLU Accuracy** | 0.673 | 0.673 |
| **Mean TTFT (ms)** | 8409.79 | 8375.89 |
| **Mean TPOT (ms)** | 68.53 | 68.58 |



# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
