### PR TITLE
[BugFix] use deepcopy's model_config when calling vllm_get_model to prevent config mutation

### DIFF
--- a/tpu_inference/models/vllm/vllm_model_wrapper.py
+++ b/tpu_inference/models/vllm/vllm_model_wrapper.py
@@ -125,7 +125,6 @@ class VllmModelWrapper:
 
         self.vllm_config.quant_config = get_tpu_quantization_config(
             self.vllm_config, self.mesh)
-        self.model_config = vllm_config.speculative_config.draft_model_config if is_draft_model else vllm_config.model_config
         self._apply_pp_patch()
 
     def _apply_pp_patch(self):
@@ -214,9 +213,9 @@ class VllmModelWrapper:
 
         with load_context, jax_context, set_current_vllm_config(
                 self.vllm_config):
+            model_config_for_load = vllm_config_for_load.speculative_config.draft_model_config if self.is_draft_model else vllm_config_for_load.model_config
             vllm_model = vllm_get_model(vllm_config=vllm_config_for_load,
-                                        model_config=self.model_config)
-
+                                        model_config=model_config_for_load)
         lora_manager = None
         if vllm_config_for_load.lora_config is not None:
             # Replace layers in the model with LoRA layers.


### PR DESCRIPTION
# Description

VllmModelWrapper.load_weights() creates a deepcopy of vllm_config to isolate the model loading process from the live config used during inference. However, vllm_get_model was called with model_config=self.model_config, which points to the original (non-deepcopy) config.

# Tests


# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
