### PR TITLE
Enable Gather All Reduce Pipelining.

### DIFF
--- a/tpu_inference/env_override.py
+++ b/tpu_inference/env_override.py
@@ -7,12 +7,7 @@ import os
 # This prevents errors when trying to create CUDA streams on TPU hardware
 # The issue was introduced by vllm-project/vllm#26440
 os.environ["VLLM_DISABLE_SHARED_EXPERTS_STREAM"] = "1"
-# yapf: disable
-# NOTE: if the user specifies a custom --xla_tpu_use_tc_device_shape_on_sc value, the second value
-# will be used by default, effectively overriding this value
-# TODO (jrplatin/clee1994): remove this after https://github.com/vllm-project/tpu-inference/blob/main/tpu_inference/kernels/gather/gather_reduce.py
-# is moved to Pallas
-os.environ["LIBTPU_INIT_ARGS"] = "--xla_tpu_use_tc_device_shape_on_sc=true " + os.environ.get("LIBTPU_INIT_ARGS", "")
+
 # AOT compile is currently a Torch-only feature and thus we should not enable it
 # for TPU
 os.environ["VLLM_USE_AOT_COMPILE"] = "0"

--- a/tpu_inference/layers/common/fused_moe_gmm.py
+++ b/tpu_inference/layers/common/fused_moe_gmm.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import functools
-import math
 from typing import Literal
 
 import jax
@@ -23,7 +22,6 @@ from jax.sharding import PartitionSpec as P
 
 import tpu_inference.envs as envs
 from tpu_inference.kernels.megablox.gmm_v2 import gmm_v2
-from tpu_inference.kernels.sparse_core import gather_reduce as gather_reduce_sc
 from tpu_inference.kernels.sparse_core.ragged_gather import ragged_gather
 from tpu_inference.kernels.sparse_core.ragged_scatter import ragged_scatter
 from tpu_inference.layers.common.quantization import quantize_tensor
@@ -32,10 +30,6 @@ from tpu_inference.logger import init_logger
 from tpu_inference.utils import get_mesh_shape_product
 
 logger = init_logger(__name__)
-
-# Target chunk size of 2048 slots was found empirically to be optimal
-# for MoE workloads (e.g., Qwen) to hide ICI/DMA latency during AllReduce.
-TARGET_SLOT_CHUNK_SIZE = 2048
 
 
 def _override_token_indices_for_random_routing(
@@ -101,8 +95,7 @@ def gmm_wrapper(lhs,
                 rhs_bias,
                 group_sizes,
                 group_offset,
-                fuse_act=None,
-                preferred_element_type=None):
+                fuse_act=None):
     gmm_res = gmm_v2(
         lhs=lhs,
         rhs=rhs,
@@ -112,7 +105,6 @@ def gmm_wrapper(lhs,
         group_offset=group_offset[0],
         zero_initialize=False,
         fuse_act=fuse_act,
-        preferred_element_type=preferred_element_type,
     )
     return gmm_res
 
@@ -145,7 +137,7 @@ def moe_gmm_local(x: jax.Array, w1: jax.Array, w1_scale: jax.Array | None,
 
     assert parallelism in ["tp", "ep"]
 
-    # GMM1 computes x @ (W_up | W_gate) together and activation, output is [tokens,padded_intermediate_size]
+    # GMM1 computes x @ (W_up | W_gate) together and activation.
     gmm1_res = gmm_wrapper(
         x,
         w1,
@@ -157,9 +149,10 @@ def moe_gmm_local(x: jax.Array, w1: jax.Array, w1_scale: jax.Array | None,
         preferred_element_type=x.dtype,
     )
 
-    # When the parallelism is TP since w2_bias is not sharded, we should only apply bias
-    # once, not applying to every shard. So we set w2_bias to 0 to all shards other than
-    # shard 0. For EP, it is not needed since bias is sharded on leading expert axis.
+    # When the parallelism is TP since w2_bias is not sharded, we should only
+    # apply bias once, not applying to every shard. So we set w2_bias to 0 to
+    # all shards other than shard 0. For EP, it is not needed since bias is
+    # sharded on leading expert axis.
     if parallelism == "tp" and w2_bias is not None:
         shard_id = jax.lax.axis_index(ShardingAxisName.MLP_TENSOR).sum()
         w2_bias = jnp.where(shard_id == 0, w2_bias, 0)
@@ -169,10 +162,9 @@ def moe_gmm_local(x: jax.Array, w1: jax.Array, w1_scale: jax.Array | None,
 
     batch_size = gmm2_res.shape[0]
     local_group_size = w1.shape[0]
-
     if local_group_size < group_sizes.size:
         mask = valid_rows_mask(
-            gmm1_res.shape[0],
+            gmm2_res.shape[0],
             group_sizes,
             group_offset,
             group_offset + local_group_size,
@@ -180,100 +172,43 @@ def moe_gmm_local(x: jax.Array, w1: jax.Array, w1_scale: jax.Array | None,
     else:
         mask = jnp.full((batch_size, ), True).reshape(-1, topk, 1)
 
-    reduction_axis = (ShardingAxisName.MLP_TENSOR
-                      if parallelism == "tp" else ShardingAxisName.EXPERT)
-
-    lcm = (128 * topk) // math.gcd(128, topk)
-    chunk_size = max(lcm, (TARGET_SLOT_CHUNK_SIZE + lcm // 2) // lcm * lcm)
-
-    use_sc = gather_reduce_sc.is_supported_by_sc_gather_reduce(
-        gmm1_res.shape[0], chunk_size) and topk == 8
-
-    if batch_size <= chunk_size:
-        # Path 3: No pipeline at all no kernel
-        if local_group_size < group_sizes.size:
-            group_offsets = jnp.cumulative_sum(group_sizes,
-                                               include_initial=True)
-            experts_start = group_offset[0]
-            experts_end = group_offset[0] + local_group_size
-            shard_output_start = group_offsets[experts_start]
-            shard_output_end = group_offsets[experts_end]
-            token_hidden_full = ragged_scatter(gmm2_res,
-                                               topk_argsort_revert_indices,
-                                               shard_output_start,
-                                               shard_output_end)
-        else:
-            token_hidden_full = gmm2_res[topk_argsort_revert_indices]
-
-        cur_sorted = token_hidden_full.reshape((-1, topk, gmm2_res.shape[-1]))
-        cur_topk_weights = jnp.expand_dims(topk_weights, axis=-1)
-        cur_weighted = cur_sorted * cur_topk_weights
-        cur_masked = jnp.where(mask, cur_weighted, 0.0)
-        cur_reduced = cur_masked.sum(axis=-2)
-        out = jax.lax.psum(cur_reduced, axis_name=reduction_axis)
-        return out
-
-    # Pipelined paths
-    if use_sc:
-        # Path 1: Kernel pipeline
-        hidden_size = gmm2_res.shape[1]
-        sc_kernel_col_chunk_size = gather_reduce_sc.get_valid_col_chunk_size(
-            hidden_size)
-
-        if local_group_size < group_sizes.size:
-            mask_flat = mask.reshape(-1, topk)
-            topk_weights_sc = jnp.where(mask_flat, topk_weights, 0)
-            topk_wgt_zero_nan = True
-        else:
-            topk_weights_sc = topk_weights
-            topk_wgt_zero_nan = False
-        topk_weights_flat = topk_weights_sc.flatten()
-    else:
-        # Path 2: No kernel pipeline
-        if local_group_size < group_sizes.size:
-            group_offsets = jnp.cumulative_sum(group_sizes,
-                                               include_initial=True)
-            experts_start = group_offset[0]
-            experts_end = group_offset[0] + local_group_size
-            shard_output_start = group_offsets[experts_start]
-            shard_output_end = group_offsets[experts_end]
-            token_hidden_full = ragged_scatter(gmm2_res,
-                                               topk_argsort_revert_indices,
-                                               shard_output_start,
-                                               shard_output_end)
-        else:
-            token_hidden_full = gmm2_res[topk_argsort_revert_indices]
-
     out_list = []
-    for start in range(0, batch_size, chunk_size):
-        end = min(batch_size, start + chunk_size)
-        start_tok = start // topk
-        end_tok = end // topk
+    # NOTE: Optimal chunk size based on TPU spec.
+    chunk_size = 2048
+    for start_topk in range(0, batch_size // topk, chunk_size):
+        end_topk = min(batch_size // topk, start_topk + chunk_size)
+        start = start_topk * topk
+        end = end_topk * topk
+
         cur_indices = topk_argsort_revert_indices[start:end]
+        cur_topk_weights = topk_weights[start_topk:end_topk]
+        cur_mask = mask[start_topk:end_topk]
 
-        if use_sc:
-            cur_weights = topk_weights_flat[start:end].reshape(-1, 128)
-            cur_reduced = gather_reduce_sc.sc_gather_reduce(
-                op=gmm2_res,
-                idx=cur_indices,
-                reduce_group_size=topk,
-                topk_weights=cur_weights,
-                col_chunk_size=sc_kernel_col_chunk_size,
-                topk_wgt_zero_nan=topk_wgt_zero_nan,
-            )
+        if local_group_size < group_sizes.size:
+            group_offsets = jnp.cumulative_sum(group_sizes,
+                                               include_initial=True)
+            experts_start = group_offset[0]
+            experts_end = group_offset[0] + local_group_size
+
+            shard_output_start = group_offsets[experts_start]
+            shard_output_end = group_offsets[experts_end]
+
+            cur_sorted = ragged_scatter(gmm2_res, cur_indices,
+                                        shard_output_start, shard_output_end)
         else:
-            cur_topk_weights = topk_weights[start_tok:end_tok]
-            cur_mask = mask[start_tok:end_tok]
-            cur_sorted = token_hidden_full[start:end].reshape(
-                (-1, topk, gmm2_res.shape[-1]))
-            cur_topk_weights = jnp.expand_dims(cur_topk_weights, axis=-1)
-            cur_weighted = cur_sorted * cur_topk_weights
-            cur_masked = jnp.where(cur_mask, cur_weighted, 0.0)
-            cur_reduced = cur_masked.sum(axis=-2)
+            cur_sorted = gmm2_res[cur_indices]
 
+        cur_sorted = cur_sorted.reshape(-1, topk, gmm2_res.shape[-1])
+
+        cur_topk_weights = jnp.expand_dims(cur_topk_weights, axis=-1)
+        cur_weighted = cur_sorted * cur_topk_weights
+        cur_masked = jnp.where(cur_mask, cur_weighted, 0.0)
+        cur_reduced = cur_masked.sum(axis=-2)
+
+        reduction_axis = (ShardingAxisName.MLP_TENSOR
+                          if parallelism == "tp" else ShardingAxisName.EXPERT)
         out = jax.lax.psum(cur_reduced, axis_name=reduction_axis)
         out_list.append(out)
-
     return jnp.concat(out_list, axis=0)
 
 

--- a/tpu_inference/models/vllm/vllm_model_wrapper.py
+++ b/tpu_inference/models/vllm/vllm_model_wrapper.py
@@ -286,7 +286,17 @@ class VllmModelWrapper:
                 "xla_tpu_all_gather_collective_matmul_mode":
                 "post_spmd_conservative",
                 "xla_tpu_reduce_scatter_collective_matmul_mode":
-                "post_spmd_conservative"
+                "post_spmd_conservative",
+                # Add below 3 XLA flags to pipeline gather / all-reduce.
+                # 1: Prevent XLA from undoing all-reduce tiling.
+                "xla_jf_crs_combiner_threshold_in_bytes": 0,
+                # 2: Enforce all-reduce to be done in tensor core.
+                "xla_tpu_enable_sparse_core_collective_offload_all_reduce":
+                False,
+                # 3. Increase memory limit to allow extra memory usage from
+                # pipeline.
+                # TODO(kyuyeunk): Investigate XLA scheduler memory limit.
+                "xla_tpu_scheduler_percent_shared_memory_limit": 1000,
             },
             static_argnames=(
                 "layer_name_to_kvcache_index",


### PR DESCRIPTION
# Description

Add below 3 XLA flags to pipeline gather / all-reduce.
1. Prevent XLA from undoing all-reduce tiling.
2. Enforce all-reduce to be done in tensor core.
3. Increase memory limit to allow extra memory usage from pipeline.

Additionally, reverting many of changes from previous PR as it has been the source of performance degradataion: https://github.com/vllm-project/tpu-inference/pull/2083 

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
