### PR TITLE
feat: add video_grid_thw plumbing for multimodal video inputs

### DIFF
--- a/tests/test_video_input_plumbing.py
+++ b/tests/test_video_input_plumbing.py
@@ -1,0 +1,140 @@
+"""Smoke tests for the modality-agnostic helpers that handle video grids."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from tpu_inference.models.jax.utils.multi_modal_utils import (
+    merge_multimodal_embeddings,
+    normalize_mm_grid_thw,
+    split_mm_embeddings_by_grid,
+)
+
+
+HIDDEN = 8
+SPATIAL_MERGE = 2
+VIDEO_TOKEN_ID = 151656
+IMAGE_TOKEN_ID = 151655
+TEXT_TOKEN_ID = 1
+
+
+def _video_token_count(t: int, h: int, w: int, merge: int = SPATIAL_MERGE) -> int:
+    return t * (h // merge) * (w // merge)
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ([4, 8, 8], ((4, 8, 8),)),
+        ((4, 8, 8), ((4, 8, 8),)),
+        ([[4, 8, 8]], ((4, 8, 8),)),
+        ([[1, 8, 8], [4, 8, 8]], ((1, 8, 8), (4, 8, 8))),
+        (np.array([[4, 8, 8]]), ((4, 8, 8),)),
+        (np.array([[[4, 8, 8]]]), ((4, 8, 8),)),
+        (None, ()),
+        ([], ()),
+    ],
+)
+def test_normalize_grid_thw_accepts_video_shapes(raw, expected):
+    assert normalize_mm_grid_thw(raw) == expected
+
+
+def test_split_embeddings_round_trip_single_video():
+    grid = ((4, 8, 8),)
+    n_tokens = _video_token_count(*grid[0])
+    embeds = jnp.arange(n_tokens * HIDDEN, dtype=jnp.float32).reshape(n_tokens, HIDDEN)
+
+    splits, deepstack = split_mm_embeddings_by_grid(embeds, grid, SPATIAL_MERGE)
+
+    assert deepstack is None
+    assert len(splits) == 1
+    assert splits[0].shape == (n_tokens, HIDDEN)
+    assert jnp.array_equal(splits[0], embeds)
+
+
+def test_split_embeddings_mixed_image_and_video():
+    image_grid = (1, 8, 8)
+    video_grid = (4, 8, 8)
+    grid = (image_grid, video_grid)
+
+    n_image = _video_token_count(*image_grid)
+    n_video = _video_token_count(*video_grid)
+    total = n_image + n_video
+    assert (n_image, n_video) == (16, 64)
+
+    embeds = jnp.arange(total * HIDDEN, dtype=jnp.float32).reshape(total, HIDDEN)
+    splits, _ = split_mm_embeddings_by_grid(embeds, grid, SPATIAL_MERGE)
+
+    assert len(splits) == 2
+    assert splits[0].shape == (n_image, HIDDEN)
+    assert splits[1].shape == (n_video, HIDDEN)
+    assert jnp.array_equal(splits[0], embeds[:n_image])
+    assert jnp.array_equal(splits[1], embeds[n_image:])
+
+
+def test_merge_video_embeddings_into_input_ids():
+    t, h, w = 2, 4, 4
+    n_video_tokens = _video_token_count(t, h, w)
+    assert n_video_tokens == 8
+
+    text_prefix = [TEXT_TOKEN_ID] * 3
+    text_suffix = [TEXT_TOKEN_ID] * 2
+    input_ids = jnp.array(
+        text_prefix + [VIDEO_TOKEN_ID] * n_video_tokens + text_suffix,
+        dtype=jnp.int32,
+    )
+    seq_len = input_ids.shape[0]
+
+    inputs_embeds = jnp.zeros((seq_len, HIDDEN), dtype=jnp.float32)
+    video_embeds = jnp.tile(
+        jnp.arange(1, n_video_tokens + 1, dtype=jnp.float32)[:, None],
+        (1, HIDDEN),
+    )
+
+    merged = merge_multimodal_embeddings(
+        input_ids=input_ids,
+        inputs_embeds=inputs_embeds,
+        multimodal_embeddings=video_embeds,
+        placeholder_token_id=VIDEO_TOKEN_ID,
+    )
+
+    assert jnp.all(merged[:3] == 0)
+    assert jnp.all(merged[3 + n_video_tokens:] == 0)
+    np.testing.assert_array_equal(
+        np.asarray(merged[3:3 + n_video_tokens]), np.asarray(video_embeds)
+    )
+
+
+def test_merge_handles_image_and_video_token_ids_together():
+    n_image_tokens = 4
+    n_video_tokens = 8
+    total = n_image_tokens + n_video_tokens
+
+    # Layout: [text, IMG x4, text, VIDEO x8, text]
+    input_ids = jnp.array(
+        [TEXT_TOKEN_ID] + [IMAGE_TOKEN_ID] * n_image_tokens + [TEXT_TOKEN_ID]
+        + [VIDEO_TOKEN_ID] * n_video_tokens + [TEXT_TOKEN_ID],
+        dtype=jnp.int32,
+    )
+    seq_len = input_ids.shape[0]
+    inputs_embeds = jnp.zeros((seq_len, HIDDEN), dtype=jnp.float32)
+
+    image_embeds = jnp.full((n_image_tokens, HIDDEN), 1.0, dtype=jnp.float32)
+    video_embeds = jnp.full((n_video_tokens, HIDDEN), 2.0, dtype=jnp.float32)
+    mm_embeds = jnp.concatenate([image_embeds, video_embeds], axis=0)
+
+    merged = merge_multimodal_embeddings(
+        input_ids=input_ids,
+        inputs_embeds=inputs_embeds,
+        multimodal_embeddings=mm_embeds,
+        placeholder_token_id=[IMAGE_TOKEN_ID, VIDEO_TOKEN_ID],
+    )
+
+    assert merged[0, 0] == 0
+    assert jnp.all(merged[1:1 + n_image_tokens] == 1.0)
+    assert merged[1 + n_image_tokens, 0] == 0
+    video_start = 1 + n_image_tokens + 1
+    assert jnp.all(merged[video_start:video_start + n_video_tokens] == 2.0)
+    assert merged[-1, 0] == 0

--- a/tests/test_video_input_plumbing.py
+++ b/tests/test_video_input_plumbing.py
@@ -1,3 +1,16 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """Smoke tests for the modality-agnostic helpers that handle video grids."""
 
 from __future__ import annotations
@@ -7,11 +20,8 @@ import numpy as np
 import pytest
 
 from tpu_inference.models.jax.utils.multi_modal_utils import (
-    merge_multimodal_embeddings,
-    normalize_mm_grid_thw,
-    split_mm_embeddings_by_grid,
-)
-
+    merge_multimodal_embeddings, normalize_mm_grid_thw,
+    split_mm_embeddings_by_grid)
 
 HIDDEN = 8
 SPATIAL_MERGE = 2
@@ -20,19 +30,22 @@ IMAGE_TOKEN_ID = 151655
 TEXT_TOKEN_ID = 1
 
 
-def _video_token_count(t: int, h: int, w: int, merge: int = SPATIAL_MERGE) -> int:
+def _video_token_count(t: int,
+                       h: int,
+                       w: int,
+                       merge: int = SPATIAL_MERGE) -> int:
     return t * (h // merge) * (w // merge)
 
 
 @pytest.mark.parametrize(
     "raw,expected",
     [
-        ([4, 8, 8], ((4, 8, 8),)),
-        ((4, 8, 8), ((4, 8, 8),)),
-        ([[4, 8, 8]], ((4, 8, 8),)),
+        ([4, 8, 8], ((4, 8, 8), )),
+        ((4, 8, 8), ((4, 8, 8), )),
+        ([[4, 8, 8]], ((4, 8, 8), )),
         ([[1, 8, 8], [4, 8, 8]], ((1, 8, 8), (4, 8, 8))),
-        (np.array([[4, 8, 8]]), ((4, 8, 8),)),
-        (np.array([[[4, 8, 8]]]), ((4, 8, 8),)),
+        (np.array([[4, 8, 8]]), ((4, 8, 8), )),
+        (np.array([[[4, 8, 8]]]), ((4, 8, 8), )),
         (None, ()),
         ([], ()),
     ],
@@ -42,11 +55,13 @@ def test_normalize_grid_thw_accepts_video_shapes(raw, expected):
 
 
 def test_split_embeddings_round_trip_single_video():
-    grid = ((4, 8, 8),)
+    grid = ((4, 8, 8), )
     n_tokens = _video_token_count(*grid[0])
-    embeds = jnp.arange(n_tokens * HIDDEN, dtype=jnp.float32).reshape(n_tokens, HIDDEN)
+    embeds = jnp.arange(n_tokens * HIDDEN,
+                        dtype=jnp.float32).reshape(n_tokens, HIDDEN)
 
-    splits, deepstack = split_mm_embeddings_by_grid(embeds, grid, SPATIAL_MERGE)
+    splits, deepstack = split_mm_embeddings_by_grid(embeds, grid,
+                                                    SPATIAL_MERGE)
 
     assert deepstack is None
     assert len(splits) == 1
@@ -64,7 +79,8 @@ def test_split_embeddings_mixed_image_and_video():
     total = n_image + n_video
     assert (n_image, n_video) == (16, 64)
 
-    embeds = jnp.arange(total * HIDDEN, dtype=jnp.float32).reshape(total, HIDDEN)
+    embeds = jnp.arange(total * HIDDEN,
+                        dtype=jnp.float32).reshape(total, HIDDEN)
     splits, _ = split_mm_embeddings_by_grid(embeds, grid, SPATIAL_MERGE)
 
     assert len(splits) == 2
@@ -102,9 +118,8 @@ def test_merge_video_embeddings_into_input_ids():
 
     assert jnp.all(merged[:3] == 0)
     assert jnp.all(merged[3 + n_video_tokens:] == 0)
-    np.testing.assert_array_equal(
-        np.asarray(merged[3:3 + n_video_tokens]), np.asarray(video_embeds)
-    )
+    np.testing.assert_array_equal(np.asarray(merged[3:3 + n_video_tokens]),
+                                  np.asarray(video_embeds))
 
 
 def test_merge_handles_image_and_video_token_ids_together():
@@ -114,8 +129,8 @@ def test_merge_handles_image_and_video_token_ids_together():
 
     # Layout: [text, IMG x4, text, VIDEO x8, text]
     input_ids = jnp.array(
-        [TEXT_TOKEN_ID] + [IMAGE_TOKEN_ID] * n_image_tokens + [TEXT_TOKEN_ID]
-        + [VIDEO_TOKEN_ID] * n_video_tokens + [TEXT_TOKEN_ID],
+        [TEXT_TOKEN_ID] + [IMAGE_TOKEN_ID] * n_image_tokens + [TEXT_TOKEN_ID] +
+        [VIDEO_TOKEN_ID] * n_video_tokens + [TEXT_TOKEN_ID],
         dtype=jnp.int32,
     )
     seq_len = input_ids.shape[0]

--- a/tests/test_video_input_plumbing.py
+++ b/tests/test_video_input_plumbing.py
@@ -125,7 +125,6 @@ def test_merge_video_embeddings_into_input_ids():
 def test_merge_handles_image_and_video_token_ids_together():
     n_image_tokens = 4
     n_video_tokens = 8
-    total = n_image_tokens + n_video_tokens
 
     # Layout: [text, IMG x4, text, VIDEO x8, text]
     input_ids = jnp.array(

--- a/tpu_inference/models/common/model_loader.py
+++ b/tpu_inference/models/common/model_loader.py
@@ -402,7 +402,7 @@ def get_flax_model(
         return model.compute_logits(hidden_state)
 
     # Multi-modal support only
-    # This function calculates the image token's embeddings by VIT
+    # This function calculates the image/video token's embeddings by VIT
     def run_embed_multimodal(state_leaves, **kwargs):
         state = jax.tree_util.tree_unflatten(_state_treedef, state_leaves)
         model = nnx.merge(graphdef, state)

--- a/tpu_inference/models/jax/qwen2_5_vl.py
+++ b/tpu_inference/models/jax/qwen2_5_vl.py
@@ -989,13 +989,13 @@ class Qwen2_5_VLForConditionalGeneration(nnx.Module):
 
     def _parse_and_validate_multimodal_inputs(self, **kwargs: object) -> dict:
         # Convert torch tensors to numpy arrays that JAX can handle.
-        if "pixel_values" in kwargs and isinstance(kwargs["pixel_values"],
-                                                   list):
-            kwargs["pixel_values"] = torch.cat(kwargs["pixel_values"], dim=0)
+        for pv_key in ("pixel_values", "pixel_values_videos"):
+            if pv_key in kwargs and isinstance(kwargs[pv_key], list):
+                kwargs[pv_key] = torch.cat(kwargs[pv_key], dim=0)
         for key in list(kwargs.keys()):
             value = kwargs[key]
             if isinstance(value, torch.Tensor):
-                if key == 'image_grid_thw':
+                if key in ('image_grid_thw', 'video_grid_thw'):
                     # change it to tuple of tuples to make it hashable for JIT
                     # Shape: (B, N, 3) -> (B*N, 3) -> tuple of tuples
                     grid_thw_reshaped = value.reshape(-1, 3)

--- a/tpu_inference/models/jax/qwen2_5_vl.py
+++ b/tpu_inference/models/jax/qwen2_5_vl.py
@@ -989,13 +989,13 @@ class Qwen2_5_VLForConditionalGeneration(nnx.Module):
 
     def _parse_and_validate_multimodal_inputs(self, **kwargs: object) -> dict:
         # Convert torch tensors to numpy arrays that JAX can handle.
-        for pv_key in ("pixel_values", "pixel_values_videos"):
-            if pv_key in kwargs and isinstance(kwargs[pv_key], list):
-                kwargs[pv_key] = torch.cat(kwargs[pv_key], dim=0)
+        if "pixel_values" in kwargs and isinstance(kwargs["pixel_values"],
+                                                   list):
+            kwargs["pixel_values"] = torch.cat(kwargs["pixel_values"], dim=0)
         for key in list(kwargs.keys()):
             value = kwargs[key]
             if isinstance(value, torch.Tensor):
-                if key in ('image_grid_thw', 'video_grid_thw'):
+                if key == 'image_grid_thw':
                     # change it to tuple of tuples to make it hashable for JIT
                     # Shape: (B, N, 3) -> (B*N, 3) -> tuple of tuples
                     grid_thw_reshaped = value.reshape(-1, 3)

--- a/tpu_inference/models/jax/utils/multi_modal_utils.py
+++ b/tpu_inference/models/jax/utils/multi_modal_utils.py
@@ -12,10 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Union
+from typing import Optional, Union
 
 import jax
 import jax.numpy as jnp
+import numpy as np
 from typing_extensions import TypeAlias
 from vllm.logger import init_logger
 
@@ -87,6 +88,116 @@ def _embedding_count_expression(embeddings: NestedTensors) -> str:
 
     return " + ".join(
         _embedding_count_expression(inner) for inner in embeddings)
+
+
+def normalize_mm_grid_thw(
+    grid_thw: object,
+) -> tuple[tuple[int, int, int], ...]:
+    """Normalize grid_thw into a tuple-of-tuples.
+
+    Accepts (3,), (N, 3), or (B, N, 3) style list/tuple/numpy/torch/jax inputs.
+    """
+    if grid_thw is None:
+        return ()
+
+    if isinstance(grid_thw, (list, tuple)):
+        if len(grid_thw) == 0:
+            return ()
+        if len(grid_thw) == 3 and all(
+                isinstance(v, (int, np.integer)) for v in grid_thw):
+            return (tuple(int(v) for v in grid_thw), )
+        if all(isinstance(row, (list, tuple)) for row in grid_thw):
+            if grid_thw and grid_thw[0] and isinstance(grid_thw[0][0],
+                                                      (list, tuple)):
+                flat_rows = [row for batch in grid_thw for row in batch]
+                return tuple(tuple(int(v) for v in row) for row in flat_rows)
+            return tuple(tuple(int(v) for v in row) for row in grid_thw)
+
+    if hasattr(grid_thw, "detach"):
+        grid_thw = grid_thw.detach().cpu()
+    if hasattr(grid_thw, "numpy"):
+        try:
+            grid_thw = grid_thw.numpy()
+        except Exception:
+            pass
+
+    arr = np.asarray(grid_thw)
+    if arr.size == 0:
+        return ()
+    if arr.ndim == 1 and arr.shape[0] == 3:
+        return (tuple(int(v) for v in arr.tolist()), )
+    if arr.ndim == 2 and arr.shape[1] == 3:
+        return tuple(tuple(int(v) for v in row) for row in arr.tolist())
+    if arr.ndim == 3 and arr.shape[2] == 3:
+        flat = arr.reshape(-1, 3)
+        return tuple(tuple(int(v) for v in row) for row in flat.tolist())
+
+    raise ValueError(
+        "Incorrect type/shape of grid_thw. Expected (3,), (N, 3), or (B, N, 3)."
+    )
+
+
+def reshape_mm_tensor(mm_input: object, name: str) -> jax.Array:
+    """Normalize multimodal tensor input to a 2D JAX array."""
+    if isinstance(mm_input, list):
+        arrays_to_concat = [jnp.asarray(item) for item in mm_input]
+        return jnp.concatenate(arrays_to_concat, axis=0)
+
+    if hasattr(mm_input, "detach"):
+        mm_input = mm_input.detach().cpu()
+    if hasattr(mm_input, "numpy"):
+        try:
+            mm_input = mm_input.numpy()
+        except Exception:
+            pass
+
+    if hasattr(mm_input, 'ndim'):
+        array_input = jnp.asarray(mm_input)
+        if array_input.ndim == 2:
+            return array_input
+        if array_input.ndim == 3:
+            return array_input.reshape(-1, array_input.shape[-1])
+
+    raise ValueError(f"Incorrect type of {name}. "
+                     f"Got type: {type(mm_input)}")
+
+
+def split_mm_embeddings_by_grid(
+    embeddings: jax.Array,
+    grid_thw: tuple[tuple[int, int, int], ...],
+    spatial_merge_size: int,
+    deepstack_embeddings: Optional[list[jax.Array]] = None,
+) -> tuple[tuple[jax.Array, ...], Optional[list[list[jax.Array]]]]:
+    """Split concatenated multimodal embeddings back into per-item chunks."""
+    sizes = np.array([
+        t * (h // spatial_merge_size) * (w // spatial_merge_size)
+        for t, h, w in grid_thw
+    ],
+                     dtype=np.int64)
+
+    if sizes.size == 0:
+        return (), None
+    if sizes.size == 1:
+        item_splits = (embeddings, )
+        if not deepstack_embeddings:
+            return item_splits, None
+        return item_splits, [[layer_embeds for layer_embeds in deepstack_embeddings]]
+
+    split_indices = np.cumsum(sizes)[:-1]
+    item_splits = tuple(jnp.split(embeddings, split_indices))
+
+    if not deepstack_embeddings:
+        return item_splits, None
+
+    layer_splits = [
+        tuple(jnp.split(layer_embeds, split_indices))
+        for layer_embeds in deepstack_embeddings
+    ]
+    deepstack_by_item = []
+    for item_idx in range(len(item_splits)):
+        deepstack_by_item.append(
+            [layer_split[item_idx] for layer_split in layer_splits])
+    return item_splits, deepstack_by_item
 
 
 def _merge_multimodal_embeddings(

--- a/tpu_inference/models/jax/utils/multi_modal_utils.py
+++ b/tpu_inference/models/jax/utils/multi_modal_utils.py
@@ -91,8 +91,7 @@ def _embedding_count_expression(embeddings: NestedTensors) -> str:
 
 
 def normalize_mm_grid_thw(
-    grid_thw: object,
-) -> tuple[tuple[int, int, int], ...]:
+    grid_thw: object, ) -> tuple[tuple[int, int, int], ...]:
     """Normalize grid_thw into a tuple-of-tuples.
 
     Accepts (3,), (N, 3), or (B, N, 3) style list/tuple/numpy/torch/jax inputs.
@@ -108,7 +107,7 @@ def normalize_mm_grid_thw(
             return (tuple(int(v) for v in grid_thw), )
         if all(isinstance(row, (list, tuple)) for row in grid_thw):
             if grid_thw and grid_thw[0] and isinstance(grid_thw[0][0],
-                                                      (list, tuple)):
+                                                       (list, tuple)):
                 flat_rows = [row for batch in grid_thw for row in batch]
                 return tuple(tuple(int(v) for v in row) for row in flat_rows)
             return tuple(tuple(int(v) for v in row) for row in grid_thw)
@@ -181,7 +180,9 @@ def split_mm_embeddings_by_grid(
         item_splits = (embeddings, )
         if not deepstack_embeddings:
             return item_splits, None
-        return item_splits, [[layer_embeds for layer_embeds in deepstack_embeddings]]
+        return item_splits, [[
+            layer_embeds for layer_embeds in deepstack_embeddings
+        ]]
 
     split_indices = np.cumsum(sizes)[:-1]
     item_splits = tuple(jnp.split(embeddings, split_indices))


### PR DESCRIPTION
# Description

Add multimodal grid_thw plumbing for models that support video inputs

The rest of the description includes relevant details and context, examples:
- This is the atomic unit for adding support to future vision models.
- This PR would immediately lead to adding Qwen3VL Dense model, and Qwen3VL MoE model that was already tested

# Tests

Add new file test_video_input_plumbing.py. 
this code was tested with Qwen3 VL Flax NNX implementation. However, it was not tested with torchax based route of models as vision model loading failed.


# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
