### PR TITLE
Revert "disable AG-FP8 temporarily for performation ablation for DS"

### DIFF
--- a/scripts/multihost/benchmarks/torchax/run_deepseek_v3_1k_8k.sh
+++ b/scripts/multihost/benchmarks/torchax/run_deepseek_v3_1k_8k.sh
@@ -32,4 +32,5 @@ bash "${NIGHTLY_SCRIPT}" \
   --moe-requantize-block-size "512" \
   --moe-requantize-weight-dtype "fp4" \
   --api-server-count 3 \
+  --moe-all-gather-activation-dtype "fp8" \
   --run-accuracy "mmlu"

--- a/scripts/multihost/benchmarks/torchax/run_deepseek_v3_1k_8k_random_routing.sh
+++ b/scripts/multihost/benchmarks/torchax/run_deepseek_v3_1k_8k_random_routing.sh
@@ -31,6 +31,7 @@ bash "${NIGHTLY_SCRIPT}" \
   --vllm-mla-disable "0" \
   --moe-requantize-block-size "512" \
   --moe-requantize-weight-dtype "fp4" \
+  --moe-all-gather-activation-dtype "fp8" \
   --api-server-count 3 \
   --force-moe-random-routing "1" \
   --run-accuracy "mmlu"

--- a/scripts/multihost/benchmarks/torchax/xprof/xprof_deepseek_v3_1k_8k.sh
+++ b/scripts/multihost/benchmarks/torchax/xprof/xprof_deepseek_v3_1k_8k.sh
@@ -32,5 +32,6 @@ bash "${NIGHTLY_SCRIPT}" \
   --vllm-mla-disable "0" \
   --moe-requantize-block-size "512" \
   --moe-requantize-weight-dtype "fp4" \
+  --moe-all-gather-activation-dtype "fp8" \
   --phased-profiling-dir "gs://tpu-commons-ci/xprof/deepseek-r1/torchax/1k-8k" \
   --skip-db-upload


### PR DESCRIPTION
Reverts vllm-project/tpu-inference#2375

The ablation is done, 
there is about 2.8% improvement from FP8-AG:
https://screenshot.googleplex.com/89tfKYt5SDGYVRq.
Also have collected Xprof during the last few days before Fp8-AG enabled (with 2.5k batch size)

re-able FP8 All-gather for DeepSeek.

