### PR TITLE
[Bug][Qwen3.5] Match GPU FLA precision in GDN to close CoT accuracy gap

### DIFF
--- a/tests/layers/common/test_gdn_attention.py
+++ b/tests/layers/common/test_gdn_attention.py
@@ -19,6 +19,10 @@ from absl.testing import parameterized
 
 from tpu_inference.layers.common.gdn_attention import (
     GdnAttentionConfig, RaggedGatedDeltaRuleImpl, run_jax_gdn_attention_local)
+from tpu_inference.layers.common.ragged_gated_delta_rule_chunked import \
+    l2norm as l2norm_chunked
+from tpu_inference.layers.common.ragged_gated_delta_rule_ref import \
+    _l2_normalize as l2_normalize_ref
 
 
 class GDNAttentionTest(parameterized.TestCase):
@@ -155,6 +159,12 @@ class GDNAttentionTest(parameterized.TestCase):
             ],
         )
 
+        # All sequences in this test start from a fresh slot; the existing
+        # parametrizations don't exercise prefix-cache-hit / chunked-prefill
+        # continuation. `has_initial_state=False` reproduces the prior
+        # behavior (zero initial state regardless of slot contents).
+        has_initial_state = jnp.zeros((max_reqs, ), dtype=jnp.bool_)
+
         common_kwargs = dict(
             mixed_qkv=mixed_qkv,
             b=b,
@@ -168,6 +178,7 @@ class GDNAttentionTest(parameterized.TestCase):
             query_start_loc=q_loc,
             state_indices=state_indices,
             distribution=distribution,
+            has_initial_state=has_initial_state,
             n_kq=n_kq,
             n_v=n_v,
             d_k=kq_head_dim,
@@ -196,3 +207,334 @@ class GDNAttentionTest(parameterized.TestCase):
                                    new_states_chunked[1],
                                    rtol=2e-2,
                                    atol=2e-2)
+
+    @parameterized.named_parameters(
+        dict(
+            testcase_name="chunked",
+            test_config=GdnAttentionConfig(
+                ragged_gated_delta_rule_impl=RaggedGatedDeltaRuleImpl.CHUNKED),
+        ),
+        dict(
+            testcase_name="ref",
+            test_config=GdnAttentionConfig(
+                ragged_gated_delta_rule_impl=RaggedGatedDeltaRuleImpl.REF),
+        ),
+    )
+    def test_has_initial_state_zeros_stale_slot(self, test_config):
+        """A new prefill landing on a slot whose previous tenant left
+        non-zero state must produce the same output and final state as it
+        would on a fresh-zero slot. This exercises the production bug fixed
+        by the `has_initial_state` plumbing: vLLM's mamba pool reuses
+        freed slots without clearing them, and previously the TPU GDN
+        kernel consumed the stale state, silently corrupting the new
+        request's recurrent trajectory.
+        """
+        kq_head_dim = 128
+        v_head_dim = 128
+        n_kq = 2
+        n_v = 8
+        kernel_size = 4
+
+        # Two requests, one prefill of 64 tokens each.
+        max_reqs = 2
+        lengths = [64, 64]
+        q_loc = jnp.array([0, 64, 128])
+        distribution = jnp.array([0, 2, 2], dtype=jnp.int32)
+        num_tokens = sum(lengths)
+
+        state_indices = jnp.arange(1, max_reqs + 1)
+        num_blocks = max_reqs + 1
+
+        rngs = iter(jax.random.split(jax.random.key(7), 12))
+        query = jax.random.normal(next(rngs), (num_tokens, n_kq * kq_head_dim))
+        key = jax.random.normal(next(rngs), (num_tokens, n_kq * kq_head_dim))
+        value = jax.random.normal(next(rngs), (num_tokens, n_v * v_head_dim))
+        b = jax.random.normal(next(rngs), (num_tokens, n_v))
+        a = jax.random.normal(next(rngs), (num_tokens, n_v))
+
+        conv_dim = (n_kq * kq_head_dim) * 2 + n_v * v_head_dim
+        conv_state_fresh = jnp.zeros((num_blocks, kernel_size - 1, conv_dim))
+        recurrent_state_fresh = jnp.zeros(
+            (num_blocks, n_v, kq_head_dim, v_head_dim))
+
+        # Build a "stale" pair where the slots that the two new requests
+        # land on are filled with arbitrary nonzero values (simulating a
+        # prior request that finished without the pool clearing the slot).
+        stale_conv = jax.random.normal(next(rngs),
+                                       (num_blocks, kernel_size - 1, conv_dim))
+        stale_recurrent = jax.random.normal(
+            next(rngs), (num_blocks, n_v, kq_head_dim, v_head_dim))
+        # Slot 0 is the null block; leave it zero.
+        conv_state_stale = conv_state_fresh.at[1:].set(stale_conv[1:])
+        recurrent_state_stale = recurrent_state_fresh.at[1:].set(
+            stale_recurrent[1:])
+
+        conv_weight = jax.random.normal(next(rngs), (conv_dim, 1, kernel_size))
+        conv_bias = jax.random.normal(next(rngs), (conv_dim, ))
+        A_log = jax.random.normal(next(rngs), (n_v, ))
+        dt_bias = jax.random.normal(next(rngs), (n_v, ))
+
+        mixed_qkv = jnp.concatenate([query, key, value], axis=-1)
+
+        run_jitted = jax.jit(
+            run_jax_gdn_attention_local,
+            static_argnames=[
+                "n_kq", "n_v", "d_k", "d_v", "kernel_size", "config"
+            ],
+        )
+
+        # Both requests are brand new — no prior context.
+        has_initial_state_new = jnp.zeros((max_reqs, ), dtype=jnp.bool_)
+
+        common_kwargs = dict(
+            mixed_qkv=mixed_qkv,
+            b=b,
+            a=a,
+            conv_weight=conv_weight,
+            conv_bias=conv_bias,
+            A_log=A_log,
+            dt_bias=dt_bias,
+            query_start_loc=q_loc,
+            state_indices=state_indices,
+            distribution=distribution,
+            has_initial_state=has_initial_state_new,
+            n_kq=n_kq,
+            n_v=n_v,
+            d_k=kq_head_dim,
+            d_v=v_head_dim,
+            kernel_size=kernel_size,
+            config=test_config,
+        )
+
+        # Reference run: fresh-zero slots.
+        (new_conv_fresh, new_rec_fresh), output_fresh = run_jitted(
+            conv_state=conv_state_fresh,
+            recurrent_state=recurrent_state_fresh,
+            **common_kwargs,
+        )
+        # Stale-slot run: same inputs, but the slots already contain a
+        # prior request's state. With the fix, has_initial_state=False
+        # masks that out — outputs and the writeback at the active slots
+        # must match the fresh-zero run.
+        (new_conv_stale, new_rec_stale), output_stale = run_jitted(
+            conv_state=conv_state_stale,
+            recurrent_state=recurrent_state_stale,
+            **common_kwargs,
+        )
+
+        np.testing.assert_allclose(output_fresh,
+                                   output_stale,
+                                   rtol=1e-5,
+                                   atol=1e-5)
+        # Compare the active slots (1..max_reqs+1); slot 0 (null) is
+        # untouched in both runs and inactive slots are unused.
+        np.testing.assert_allclose(new_conv_fresh[1:max_reqs + 1],
+                                   new_conv_stale[1:max_reqs + 1],
+                                   rtol=1e-5,
+                                   atol=1e-5)
+        np.testing.assert_allclose(new_rec_fresh[1:max_reqs + 1],
+                                   new_rec_stale[1:max_reqs + 1],
+                                   rtol=1e-5,
+                                   atol=1e-5)
+
+    @parameterized.named_parameters(
+        dict(
+            testcase_name="chunked",
+            test_config=GdnAttentionConfig(
+                ragged_gated_delta_rule_impl=RaggedGatedDeltaRuleImpl.CHUNKED),
+        ),
+        dict(
+            testcase_name="ref",
+            test_config=GdnAttentionConfig(
+                ragged_gated_delta_rule_impl=RaggedGatedDeltaRuleImpl.REF),
+        ),
+    )
+    def test_has_initial_state_preserves_continuation(self, test_config):
+        """When ``has_initial_state[i]`` is True, the kernel must use the
+        slot's existing state as the prefill's initial state. This is the
+        chunked-prefill / prefix-cache continuation path: a prior step
+        wrote a recurrent/conv state to the slot, and the next prefill
+        chunk for the same request must continue from that state — not
+        from zero. Compares against running the equivalent single-shot
+        prefill on the concatenated token stream from a zero state.
+        """
+        kq_head_dim = 128
+        v_head_dim = 128
+        n_kq = 2
+        n_v = 8
+        kernel_size = 4
+
+        # One request, prefill split into two halves of 32 tokens each.
+        # Step A: tokens [0, 32) starting from zero state.
+        # Step B: tokens [32, 64) starting from Step A's final state.
+        # Reference: tokens [0, 64) in a single shot from zero state.
+        max_reqs = 1
+        half = 32
+        full = 64
+        state_indices = jnp.array([1])
+        num_blocks = 2
+
+        rngs = iter(jax.random.split(jax.random.key(11), 12))
+        query = jax.random.normal(next(rngs), (full, n_kq * kq_head_dim))
+        key = jax.random.normal(next(rngs), (full, n_kq * kq_head_dim))
+        value = jax.random.normal(next(rngs), (full, n_v * v_head_dim))
+        b = jax.random.normal(next(rngs), (full, n_v))
+        a = jax.random.normal(next(rngs), (full, n_v))
+
+        conv_dim = (n_kq * kq_head_dim) * 2 + n_v * v_head_dim
+        conv_weight = jax.random.normal(next(rngs), (conv_dim, 1, kernel_size))
+        conv_bias = jax.random.normal(next(rngs), (conv_dim, ))
+        A_log = jax.random.normal(next(rngs), (n_v, ))
+        dt_bias = jax.random.normal(next(rngs), (n_v, ))
+
+        mixed_qkv_full = jnp.concatenate([query, key, value], axis=-1)
+        mixed_qkv_a = mixed_qkv_full[:half]
+        mixed_qkv_b = mixed_qkv_full[half:]
+
+        conv_state_zero = jnp.zeros((num_blocks, kernel_size - 1, conv_dim))
+        recurrent_state_zero = jnp.zeros(
+            (num_blocks, n_v, kq_head_dim, v_head_dim))
+
+        run_jitted = jax.jit(
+            run_jax_gdn_attention_local,
+            static_argnames=[
+                "n_kq", "n_v", "d_k", "d_v", "kernel_size", "config"
+            ],
+        )
+        common_static = dict(
+            conv_weight=conv_weight,
+            conv_bias=conv_bias,
+            A_log=A_log,
+            dt_bias=dt_bias,
+            state_indices=state_indices,
+            n_kq=n_kq,
+            n_v=n_v,
+            d_k=kq_head_dim,
+            d_v=v_head_dim,
+            kernel_size=kernel_size,
+            config=test_config,
+        )
+
+        # Single-shot reference (all 64 tokens, zero state, has_initial=False).
+        (_, _), output_ref = run_jitted(
+            mixed_qkv=mixed_qkv_full,
+            b=b,
+            a=a,
+            conv_state=conv_state_zero,
+            recurrent_state=recurrent_state_zero,
+            query_start_loc=jnp.array([0, full]),
+            distribution=jnp.array([0, 1, 1], dtype=jnp.int32),
+            has_initial_state=jnp.zeros((max_reqs, ), dtype=jnp.bool_),
+            **common_static,
+        )
+
+        # Step A: first 32 tokens, zero state, has_initial=False.
+        (conv_after_a, rec_after_a), output_a = run_jitted(
+            mixed_qkv=mixed_qkv_a,
+            b=b[:half],
+            a=a[:half],
+            conv_state=conv_state_zero,
+            recurrent_state=recurrent_state_zero,
+            query_start_loc=jnp.array([0, half]),
+            distribution=jnp.array([0, 1, 1], dtype=jnp.int32),
+            has_initial_state=jnp.zeros((max_reqs, ), dtype=jnp.bool_),
+            **common_static,
+        )
+
+        # Step B: next 32 tokens, slot now holds Step A's state,
+        # has_initial=True so the kernel continues from that state.
+        (_, _), output_b = run_jitted(
+            mixed_qkv=mixed_qkv_b,
+            b=b[half:],
+            a=a[half:],
+            conv_state=conv_after_a,
+            recurrent_state=rec_after_a,
+            query_start_loc=jnp.array([0, half]),
+            distribution=jnp.array([0, 1, 1], dtype=jnp.int32),
+            has_initial_state=jnp.ones((max_reqs, ), dtype=jnp.bool_),
+            **common_static,
+        )
+
+        # Step A's output must match the first half of the single-shot
+        # reference; Step B (continuation) must match the second half.
+        np.testing.assert_allclose(output_a,
+                                   output_ref[:half],
+                                   rtol=2e-2,
+                                   atol=2e-2)
+        np.testing.assert_allclose(output_b,
+                                   output_ref[half:],
+                                   rtol=2e-2,
+                                   atol=2e-2)
+
+    @parameterized.named_parameters(
+        dict(testcase_name="chunked", l2norm_fn=l2norm_chunked),
+        dict(testcase_name="ref", l2norm_fn=l2_normalize_ref),
+    )
+    def test_l2norm_fp32_internal_more_precise_than_bf16(self, l2norm_fn):
+        """The l2norm helper must do its sum-of-squares in fp32 even when
+        the input is bf16. This is what GPU FLA's ``l2norm_fwd`` does.
+
+        Regression test for the full-GPQA-Diamond drop we observed when
+        the reduction was left in bf16: pick a bf16 input that is
+        nontrivial (non-unit-norm, large magnitude so sum-of-squares is
+        well above 1.0) and compare both the current implementation and
+        a deliberately-bf16-only reduction against an fp64 reference.
+        The fp32-internal implementation must be at least as close to
+        the fp64 ground truth — the bf16 reduction loses precision in
+        the sum-of-squares accumulation.
+        """
+        rng = jax.random.key(13)
+        # Vectors with components on the order of 5 — sum-of-squares is
+        # ~d*25, well above the bf16 ULP near that magnitude.
+        x_f32 = jax.random.normal(rng, (32, 256)) * 5.0
+        x_bf16 = x_f32.astype(jnp.bfloat16)
+
+        # fp64 ground truth on the bf16 quantized input. Whatever
+        # precision-loss the bf16 cast itself caused is shared with both
+        # implementations under test, so this isolates the reduction
+        # precision.
+        x_fp64 = x_bf16.astype(jnp.float64)
+        sq_sum_fp64 = (x_fp64 * x_fp64).sum(axis=-1, keepdims=True)
+        ref = (x_fp64 / jnp.sqrt(sq_sum_fp64 + 1e-6)).astype(jnp.float32)
+
+        # The implementation under test (current code, fp32 internal).
+        if l2norm_fn is l2norm_chunked:
+            test_out = l2norm_fn(x_bf16, dim=-1, eps=1e-6)
+        else:
+            test_out = l2norm_fn(x_bf16, eps=1e-6)
+        # A deliberately-bf16-only baseline that mimics the pre-fix
+        # behavior: rsqrt + reduction stay in bf16.
+        bf16_only = (
+            x_bf16 *
+            jax.lax.rsqrt((x_bf16 * x_bf16).sum(axis=-1, keepdims=True) +
+                          jnp.array(1e-6, dtype=jnp.bfloat16)))
+
+        test_err = float(jnp.max(jnp.abs(test_out.astype(jnp.float32) - ref)))
+        bf16_err = float(jnp.max(jnp.abs(bf16_only.astype(jnp.float32) - ref)))
+
+        # The current (fp32-internal) implementation is meaningfully
+        # closer to the fp64 reference than the bf16-only baseline. We
+        # assert a strict factor-of-2 improvement to catch silent
+        # regressions to bf16.
+        self.assertLess(
+            test_err, bf16_err / 2.0,
+            f"fp32 l2norm err {test_err:.4g} is not at "
+            f"least 2× tighter than bf16 err {bf16_err:.4g}")
+
+    @parameterized.named_parameters(
+        dict(testcase_name="chunked", l2norm_fn=l2norm_chunked),
+        dict(testcase_name="ref", l2norm_fn=l2_normalize_ref),
+    )
+    def test_l2norm_returns_input_dtype(self, l2norm_fn):
+        """The l2norm helpers compute in fp32 internally but must return
+        the input dtype unchanged so callers' downstream layout
+        assumptions (e.g. ``compute_dtype`` casts in
+        `pack_inputs_single_stream`) keep working.
+        """
+        x = jax.random.normal(jax.random.key(17),
+                              (4, 128)).astype(jnp.bfloat16)
+        if l2norm_fn is l2norm_chunked:
+            out = l2norm_fn(x, dim=-1)
+        else:
+            out = l2norm_fn(x)
+        self.assertEqual(out.dtype, jnp.bfloat16)

--- a/tests/layers/common/test_gdn_attention.py
+++ b/tests/layers/common/test_gdn_attention.py
@@ -161,9 +161,11 @@ class GDNAttentionTest(parameterized.TestCase):
 
         # All sequences in this test start from a fresh slot; the existing
         # parametrizations don't exercise prefix-cache-hit / chunked-prefill
-        # continuation. `has_initial_state=False` reproduces the prior
-        # behavior (zero initial state regardless of slot contents).
-        has_initial_state = jnp.zeros((max_reqs, ), dtype=jnp.bool_)
+        # continuation. ``seq_lens == query_lens`` (context_len = 0)
+        # reproduces the prior behavior (zero initial state regardless of
+        # slot contents).
+        seq_lens = jnp.asarray(q_loc[1:max_reqs + 1] - q_loc[:max_reqs],
+                               dtype=jnp.int32)
 
         common_kwargs = dict(
             mixed_qkv=mixed_qkv,
@@ -178,7 +180,7 @@ class GDNAttentionTest(parameterized.TestCase):
             query_start_loc=q_loc,
             state_indices=state_indices,
             distribution=distribution,
-            has_initial_state=has_initial_state,
+            seq_lens=seq_lens,
             n_kq=n_kq,
             n_v=n_v,
             d_k=kq_head_dim,
@@ -283,8 +285,9 @@ class GDNAttentionTest(parameterized.TestCase):
             ],
         )
 
-        # Both requests are brand new — no prior context.
-        has_initial_state_new = jnp.zeros((max_reqs, ), dtype=jnp.bool_)
+        # Both requests are brand new — no prior context. seq_lens equals
+        # query_lens so context_len = 0 → has_initial_state = False.
+        seq_lens_new = jnp.asarray(lengths, dtype=jnp.int32)
 
         common_kwargs = dict(
             mixed_qkv=mixed_qkv,
@@ -297,7 +300,7 @@ class GDNAttentionTest(parameterized.TestCase):
             query_start_loc=q_loc,
             state_indices=state_indices,
             distribution=distribution,
-            has_initial_state=has_initial_state_new,
+            seq_lens=seq_lens_new,
             n_kq=n_kq,
             n_v=n_v,
             d_k=kq_head_dim,
@@ -368,7 +371,6 @@ class GDNAttentionTest(parameterized.TestCase):
         # Step A: tokens [0, 32) starting from zero state.
         # Step B: tokens [32, 64) starting from Step A's final state.
         # Reference: tokens [0, 64) in a single shot from zero state.
-        max_reqs = 1
         half = 32
         full = 64
         state_indices = jnp.array([1])
@@ -415,7 +417,8 @@ class GDNAttentionTest(parameterized.TestCase):
             config=test_config,
         )
 
-        # Single-shot reference (all 64 tokens, zero state, has_initial=False).
+        # Single-shot reference (all 64 tokens, zero state, has_initial=False
+        # encoded as seq_lens == query_lens == [full]).
         (_, _), output_ref = run_jitted(
             mixed_qkv=mixed_qkv_full,
             b=b,
@@ -424,7 +427,7 @@ class GDNAttentionTest(parameterized.TestCase):
             recurrent_state=recurrent_state_zero,
             query_start_loc=jnp.array([0, full]),
             distribution=jnp.array([0, 1, 1], dtype=jnp.int32),
-            has_initial_state=jnp.zeros((max_reqs, ), dtype=jnp.bool_),
+            seq_lens=jnp.array([full], dtype=jnp.int32),
             **common_static,
         )
 
@@ -437,12 +440,13 @@ class GDNAttentionTest(parameterized.TestCase):
             recurrent_state=recurrent_state_zero,
             query_start_loc=jnp.array([0, half]),
             distribution=jnp.array([0, 1, 1], dtype=jnp.int32),
-            has_initial_state=jnp.zeros((max_reqs, ), dtype=jnp.bool_),
+            seq_lens=jnp.array([half], dtype=jnp.int32),
             **common_static,
         )
 
-        # Step B: next 32 tokens, slot now holds Step A's state,
-        # has_initial=True so the kernel continues from that state.
+        # Step B: next 32 tokens, slot now holds Step A's state.
+        # seq_lens=[full] with query_lens=[half] gives context_len=half>0,
+        # i.e., has_initial=True so the kernel continues from that state.
         (_, _), output_b = run_jitted(
             mixed_qkv=mixed_qkv_b,
             b=b[half:],
@@ -451,7 +455,7 @@ class GDNAttentionTest(parameterized.TestCase):
             recurrent_state=rec_after_a,
             query_start_loc=jnp.array([0, half]),
             distribution=jnp.array([0, 1, 1], dtype=jnp.int32),
-            has_initial_state=jnp.ones((max_reqs, ), dtype=jnp.bool_),
+            seq_lens=jnp.array([full], dtype=jnp.int32),
             **common_static,
         )
 

--- a/tpu_inference/layers/common/gdn_attention.py
+++ b/tpu_inference/layers/common/gdn_attention.py
@@ -67,6 +67,7 @@ def run_jax_gdn_attention_local(
     query_start_loc: jnp.ndarray,
     state_indices: jnp.ndarray,
     distribution: jnp.ndarray,
+    has_initial_state: jnp.ndarray,
     n_kq: int,
     n_v: int,
     d_k: int,
@@ -96,6 +97,14 @@ def run_jax_gdn_attention_local(
           state index.
         distribution: Tensor of shape `(3,)` int32 — `(decode_end, prefill_end,
           mixed_end)`.
+        has_initial_state: Boolean tensor of shape `(max_reqs,)`. ``True`` for
+          requests whose slot already holds a valid recurrent/conv state
+          (chunked-prefill continuation, prefix-cache hit, or running decode);
+          ``False`` for brand-new prefills, in which case the gathered
+          conv_state and recurrent_state are treated as zeros. Without this,
+          a reused mamba slot's stale state would silently corrupt the
+          first conv outputs and the entire recurrent trajectory of every
+          new request.
         n_kq: Number of key/query heads.
         n_v: Number of value heads.
         d_k: Dimension of key.
@@ -120,6 +129,7 @@ def run_jax_gdn_attention_local(
         query_start_loc,
         state_indices,
         distribution,
+        has_initial_state,
         kernel_size=kernel_size,
     )
 
@@ -151,17 +161,34 @@ def run_jax_gdn_attention_local(
             use_qk_norm_in_gdn=True,
         )
 
-    new_recurrent_state, output = ragged_gdn_impl(
-        out_mixed_qkv,
-        b,
-        a,
-        recurrent_state,
-        A_log,
-        dt_bias,
-        query_start_loc,
-        state_indices,
-        distribution,
-    )
+    if config.ragged_gated_delta_rule_impl == RaggedGatedDeltaRuleImpl.FUSED:
+        # The fused kernel does not yet honor `has_initial_state`. Fall
+        # through with the existing call signature; the chunked/ref paths
+        # used in production already mask via the new argument below.
+        new_recurrent_state, output = ragged_gdn_impl(
+            out_mixed_qkv,
+            b,
+            a,
+            recurrent_state,
+            A_log,
+            dt_bias,
+            query_start_loc,
+            state_indices,
+            distribution,
+        )
+    else:
+        new_recurrent_state, output = ragged_gdn_impl(
+            out_mixed_qkv,
+            b,
+            a,
+            recurrent_state,
+            A_log,
+            dt_bias,
+            query_start_loc,
+            state_indices,
+            distribution,
+            has_initial_state,
+        )
 
     return (new_conv_state, new_recurrent_state), output
 
@@ -179,6 +206,7 @@ def run_jax_gdn_attention(
     state_indices: jnp.ndarray,
     query_start_loc: jnp.ndarray,
     distribution: jnp.ndarray,
+    has_initial_state: jnp.ndarray,
     n_kq: int,
     n_v: int,
     d_k: int,
@@ -210,6 +238,10 @@ def run_jax_gdn_attention(
           each sequence.
         distribution: Tensor of shape `(3,)` int32 — `(decode_end, prefill_end,
           mixed_end)`.
+        has_initial_state: Boolean tensor of shape `(max_reqs,)` indicating
+          which requests already have a valid prior state in their slot.
+          ``False`` entries get zero initial state for both the conv and
+          recurrent paths, matching GPU behavior.
         n_kq: Number of key/query heads.
         n_v: Number of value heads.
         d_k: Dimension of key.
@@ -242,6 +274,7 @@ def run_jax_gdn_attention(
         P(ShardingAxisName.ATTN_DATA),  # query_start_loc
         P(ShardingAxisName.ATTN_DATA),  # state_indices
         P(ShardingAxisName.ATTN_DATA),  # distribution
+        P(ShardingAxisName.ATTN_DATA),  # has_initial_state
     )
 
     out_specs = (
@@ -287,6 +320,7 @@ def run_jax_gdn_attention(
         query_start_loc,
         state_indices,
         distribution,
+        has_initial_state,
     )
 
     return (new_conv_state, new_recurrent_state), output

--- a/tpu_inference/layers/common/gdn_attention.py
+++ b/tpu_inference/layers/common/gdn_attention.py
@@ -67,7 +67,7 @@ def run_jax_gdn_attention_local(
     query_start_loc: jnp.ndarray,
     state_indices: jnp.ndarray,
     distribution: jnp.ndarray,
-    has_initial_state: jnp.ndarray,
+    seq_lens: jnp.ndarray,
     n_kq: int,
     n_v: int,
     d_k: int,
@@ -97,14 +97,12 @@ def run_jax_gdn_attention_local(
           state index.
         distribution: Tensor of shape `(3,)` int32 — `(decode_end, prefill_end,
           mixed_end)`.
-        has_initial_state: Boolean tensor of shape `(max_reqs,)`. ``True`` for
-          requests whose slot already holds a valid recurrent/conv state
-          (chunked-prefill continuation, prefix-cache hit, or running decode);
-          ``False`` for brand-new prefills, in which case the gathered
-          conv_state and recurrent_state are treated as zeros. Without this,
-          a reused mamba slot's stale state would silently corrupt the
-          first conv outputs and the entire recurrent trajectory of every
-          new request.
+        seq_lens: Tensor of shape `(max_reqs,)` with the total sequence length
+          per request (computed + scheduled). Used to derive
+          ``has_initial_state`` so brand-new prefills don't read stale state
+          from a reused mamba slot, mirroring GPU's
+          ``initial_state[~has_initial_state, ...] = 0`` in
+          ``gdn_linear_attn._forward_core``.
         n_kq: Number of key/query heads.
         n_v: Number of value heads.
         d_k: Dimension of key.
@@ -117,6 +115,14 @@ def run_jax_gdn_attention_local(
         - A tuple of (new_conv_state, new_recurrent_state).
         - The output tensor of shape `(num_tokens, n_v * d_v)`.
     """
+    # has_initial_state[i] = True iff request i already has computed
+    # tokens in its mamba slot (chunked-prefill continuation, prefix-cache
+    # hit, or running decode). False for brand-new prefills, whose
+    # gathered conv/recurrent state is then masked to zero by the
+    # ragged kernels. context_len = seq_len - query_len.
+    max_reqs = seq_lens.shape[0]
+    query_lens = query_start_loc[1:max_reqs + 1] - query_start_loc[:max_reqs]
+    has_initial_state = (seq_lens - query_lens) > 0
 
     # TODO: Switch conv implementaion based on config once we have more than 1 impl
     conv_impl = ragged_conv1d_jax
@@ -206,7 +212,7 @@ def run_jax_gdn_attention(
     state_indices: jnp.ndarray,
     query_start_loc: jnp.ndarray,
     distribution: jnp.ndarray,
-    has_initial_state: jnp.ndarray,
+    seq_lens: jnp.ndarray,
     n_kq: int,
     n_v: int,
     d_k: int,
@@ -238,10 +244,9 @@ def run_jax_gdn_attention(
           each sequence.
         distribution: Tensor of shape `(3,)` int32 — `(decode_end, prefill_end,
           mixed_end)`.
-        has_initial_state: Boolean tensor of shape `(max_reqs,)` indicating
-          which requests already have a valid prior state in their slot.
-          ``False`` entries get zero initial state for both the conv and
-          recurrent paths, matching GPU behavior.
+        seq_lens: Tensor of shape `(max_reqs,)` with the total sequence length
+          per request (computed + scheduled). Used inside the local function
+          to derive ``has_initial_state``.
         n_kq: Number of key/query heads.
         n_v: Number of value heads.
         d_k: Dimension of key.
@@ -274,7 +279,7 @@ def run_jax_gdn_attention(
         P(ShardingAxisName.ATTN_DATA),  # query_start_loc
         P(ShardingAxisName.ATTN_DATA),  # state_indices
         P(ShardingAxisName.ATTN_DATA),  # distribution
-        P(ShardingAxisName.ATTN_DATA),  # has_initial_state
+        P(ShardingAxisName.ATTN_DATA),  # seq_lens
     )
 
     out_specs = (
@@ -320,7 +325,7 @@ def run_jax_gdn_attention(
         query_start_loc,
         state_indices,
         distribution,
-        has_initial_state,
+        seq_lens,
     )
 
     return (new_conv_state, new_recurrent_state), output

--- a/tpu_inference/layers/common/ragged_conv1d_jax.py
+++ b/tpu_inference/layers/common/ragged_conv1d_jax.py
@@ -28,6 +28,7 @@ def ragged_conv1d(
     query_start_loc,
     state_indices,
     distribution,
+    has_initial_state,
     *,
     kernel_size,
 ):
@@ -48,6 +49,14 @@ def ragged_conv1d(
       kernel_size: The size of the convolution kernel.
       distribution: Distribution tensor containing number of valid sequences at
         index 2.
+      has_initial_state: Boolean tensor of shape `(max_reqs,)`. ``True`` when
+        the request has prior conv state to use (chunked-prefill continuation
+        or prefix-cache hit). ``False`` for brand-new prefills, in which case
+        the gathered conv state is treated as zeros — matching GPU's
+        ``causal_conv1d_fn(has_initial_state=...)`` semantics. Without this
+        masking the conv would consume whatever a reused mamba slot still
+        held from a prior request, silently corrupting the first
+        ``kernel_size - 1`` outputs of every new request.
 
     Returns:
       A tuple containing:
@@ -73,26 +82,47 @@ def ragged_conv1d(
 
     lengths = effective_query_start_loc[1:] - effective_query_start_loc[:-1]
 
-    # 1. Compute Convolution
-    out = jnp.zeros_like(x)
-    w = conv_weight[:, 0, :].T  # (K, C)
+    # 1. Compute Convolution.
+    #
+    # Accumulate in fp32 to match GPU's `causal_conv1d_fn` (FLA), which
+    # loads x and weights as fp32 before the kernel-size-element sum.
+    # bf16 accumulation gives ~1-2% per-channel relative error on every
+    # GDN layer's conv output. We did not isolate this fix's individual
+    # contribution; it's part of the bundle that closes the
+    # GPQA-Diamond gap — see
+    # `ragged_gated_delta_rule_chunked.py` module docstring for the
+    # full ablation.
+    orig_dtype = x.dtype
+    x_f32 = x.astype(jnp.float32)
+    w = conv_weight[:, 0, :].T.astype(jnp.float32)  # (K, C)
 
     gathered_state = conv_state[state_indices]  # (max_reqs, K-1, C)
+    # Mask the gathered conv state to zero for sequences without initial
+    # state, so brand-new prefills see zeros instead of whatever a reused
+    # slot still held. Mirrors GPU's `has_initial_state` plumbing.
+    gathered_state = jnp.where(
+        has_initial_state[:, None, None],
+        gathered_state,
+        jnp.zeros_like(gathered_state),
+    )
+    gathered_state_f32 = gathered_state.astype(jnp.float32)
 
+    out = jnp.zeros((num_tokens, x.shape[-1]), dtype=jnp.float32)
     for k in range(kernel_size):
         mask = local_indices >= k
 
         idx_x = jnp.clip(token_idx - k, 0, num_tokens - 1)
         idx_state_t = (kernel_size - 1) + (local_indices - k)
 
-        x_tokens = x[idx_x]
-        state_tokens = gathered_state[req_indices, idx_state_t]
+        x_tokens = x_f32[idx_x]
+        state_tokens = gathered_state_f32[req_indices, idx_state_t]
 
         token_k = jnp.where(mask[:, None], x_tokens, state_tokens)
         out = out + token_k * w[kernel_size - 1 - k]
 
     if conv_bias is not None:
-        out = out + conv_bias[jnp.newaxis, :]
+        out = out + conv_bias.astype(jnp.float32)[jnp.newaxis, :]
+    out = out.astype(orig_dtype)
 
     # 2. Update State
     padded_lengths = jnp.zeros(max_reqs, dtype=jnp.int32)

--- a/tpu_inference/layers/common/ragged_conv1d_jax.py
+++ b/tpu_inference/layers/common/ragged_conv1d_jax.py
@@ -83,15 +83,9 @@ def ragged_conv1d(
     lengths = effective_query_start_loc[1:] - effective_query_start_loc[:-1]
 
     # 1. Compute Convolution.
-    #
-    # Accumulate in fp32 to match GPU's `causal_conv1d_fn` (FLA), which
+    # Accumulate in fp32 to match GPU's `causal_conv1d_fn`
+    # (`vllm/model_executor/layers/mamba/ops/causal_conv1d.py`), which
     # loads x and weights as fp32 before the kernel-size-element sum.
-    # bf16 accumulation gives ~1-2% per-channel relative error on every
-    # GDN layer's conv output. We did not isolate this fix's individual
-    # contribution; it's part of the bundle that closes the
-    # GPQA-Diamond gap — see
-    # `ragged_gated_delta_rule_chunked.py` module docstring for the
-    # full ablation.
     orig_dtype = x.dtype
     x_f32 = x.astype(jnp.float32)
     w = conv_weight[:, 0, :].T.astype(jnp.float32)  # (K, C)

--- a/tpu_inference/layers/common/ragged_gated_delta_rule_chunked.py
+++ b/tpu_inference/layers/common/ragged_gated_delta_rule_chunked.py
@@ -11,7 +11,46 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Ragged gated delta rule packed JAX implementation."""
+"""Ragged gated delta rule packed JAX implementation.
+
+Precision discipline (Qwen3.5 397B GPQA fix, 2026-04-26)
+--------------------------------------------------------
+The original implementation ran the entire decode-side recurrent step
+at TPU's default precision (bf16 multiply, fp32 accumulate). On long
+CoT generations (``max_gen_toks=32768``) the per-token bf16 multiply
+error compounds through the recurrent state, contributing to a
+GPQA-Diamond gap vs. GPU (TPU 0.7929 vs. GPU 0.8343, full N=198). The
+fix mirrors GPU FLA's fp32 precision discipline across five kernel
+sites (see commit body for the full ablation table):
+
+  ALL load-bearing — do not revert without re-running the full eval:
+    - ``recurrent_gated_delta_rule_step``: fp32 inputs + HIGHEST matmul.
+    - ``ragged_conv1d_jax``: fp32 conv accumulation.
+    - ``l2norm`` (chunked + ref): fp32 sum-of-squares reduction.
+    - ``sigmoid(b)`` for the beta gate (chunked + ref): fp32 input.
+    - ``has_initial_state`` plumbing in mixed-prefill init carry.
+
+What we ablated (full GPQA-Diamond, N=198, flexible-extract):
+    no fixes:                0.7929
+    fixes (1)+(2)+(3):       0.8232    (+0.030 over baseline)
+    all 5 fixes:             0.8485    (+0.056 over baseline,
+                                        +0.025 over (1)+(2)+(3))
+    GPU reference:           0.8343
+
+We did NOT ablate (1) vs (2) vs (3) individually, so the ranking
+inside that group is unproven. We can say that (1)+(2)+(3) is
+necessary but not sufficient on its own, and (4)+(5) close the
+remaining gap.
+
+The TPU perf cost of the full fp32 set is ~0% throughput on a
+30-prompt × 512-token decode bench (957.55 → 956.47 tokens/sec). The
+decode path is HBM-bandwidth-bound and these are tiny per-token ops.
+
+If you change the recurrent matmul precision OR remove any of the
+fp32 promotions above, re-run
+``gpqa_diamond_cot_zeroshot`` (full N=198, no ``--limit``) against
+``Qwen/Qwen3.5-397B-A17B-FP8`` before merging.
+"""
 
 import jax
 import jax.numpy as jnp
@@ -23,17 +62,26 @@ import tpu_inference.kernels.gdn.triangle_solver as triangle_solver
 def l2norm(x: jnp.ndarray, dim: int = -1, eps: float = 1e-6) -> jnp.ndarray:
     """Normalizes x along the specified dimension using L2 norm.
 
+  Computes the sum-of-squares and rsqrt in float32 even when the input
+  is bf16, matching GPU FLA's ``l2norm_fwd``
+  (`vllm/model_executor/layers/fla/ops/l2norm.py`). This fix is part
+  of the bundle that closes the GPQA-Diamond gap; we did not ablate
+  l2norm individually but joint removal of l2norm + sigmoid below
+  drops full-Diamond score from 0.8485 to 0.8232. See the module
+  docstring for the full ablation.
+
   Args:
     x: Input array.
     dim: Dimension along which to normalize.
     eps: Epsilon value to avoid division by zero.
 
   Returns:
-    Normalized array.
+    Normalized array, in the same dtype as ``x``.
   """
-    inv_norm = jax.lax.rsqrt((x * x).sum(axis=dim, keepdims=True) +
-                             jnp.array(eps, dtype=x.dtype))
-    return x * inv_norm
+    x_f32 = x.astype(jnp.float32)
+    inv_norm = jax.lax.rsqrt((x_f32 * x_f32).sum(axis=dim, keepdims=True) +
+                             eps)
+    return (x_f32 * inv_norm).astype(x.dtype)
 
 
 def pack_inputs_single_stream(
@@ -199,6 +247,7 @@ def ragged_gated_delta_rule_mixed_prefill(
     recurrent_state: jnp.ndarray,
     state_indices: jnp.ndarray,
     distribution: jnp.ndarray,
+    has_initial_state: jnp.ndarray,
     chunk_size: int = 64,
     use_qk_norm_in_gdn: bool = False,
     compute_dtype: jnp.dtype = jnp.bfloat16,
@@ -229,6 +278,12 @@ def ragged_gated_delta_rule_mixed_prefill(
       state_indices: Indices mapping sequences to recurrent state slots.
       distribution: Distribution tensor containing number of valid sequences at
         index 2.
+      has_initial_state: Boolean tensor of shape `(max_reqs,)`. ``True`` when
+        the request has prior recurrent state to use (chunked-prefill
+        continuation or prefix-cache hit). ``False`` for brand-new prefills,
+        in which case the gathered recurrent state is treated as zeros —
+        matching GPU's `initial_state[~has_initial_state, ...] = 0` in
+        `gdn_linear_attn._forward_core`.
       chunk_size: Chunk size for padding and processing.
       use_qk_norm_in_gdn: Whether to use QK normalization.
       compute_dtype: Dtype for computation.
@@ -244,7 +299,10 @@ def ragged_gated_delta_rule_mixed_prefill(
     """
     initial_dtype = query.dtype
 
-    beta = jax.nn.sigmoid(b_reshaped)
+    # Cast b to fp32 before sigmoid to match GPU's
+    # `fused_gdn_gating_kernel`. Bundled with the l2norm fp32 fix
+    # above; see the module docstring for the joint ablation.
+    beta = jax.nn.sigmoid(b_reshaped.astype(jnp.float32))
     g = -jnp.exp(A_log.astype(jnp.float32)) * jax.nn.softplus(
         a_reshaped.astype(jnp.float32) + dt_bias.astype(jnp.float32))
 
@@ -370,6 +428,14 @@ def ragged_gated_delta_rule_mixed_prefill(
                                  dtype=recurrent_state.dtype)
     start_chunk_indices = new_query_start_loc[:-1] // chunk_size
     init_states_for_seqs = recurrent_state[state_indices]
+    # For brand-new prefills (no prior context), use zero initial state
+    # rather than whatever a reused mamba slot still held. Matches GPU's
+    # `initial_state[~has_initial_state, ...] = 0`.
+    init_states_for_seqs = jnp.where(
+        has_initial_state[:, None, None, None],
+        init_states_for_seqs,
+        jnp.zeros_like(init_states_for_seqs),
+    )
     init_h_per_chunk = init_h_per_chunk.at[start_chunk_indices].set(
         init_states_for_seqs)
 
@@ -463,24 +529,52 @@ def recurrent_gated_delta_rule_step(
     beta: jnp.ndarray,
     state: jnp.ndarray | None = None,
 ) -> tuple[jnp.ndarray, jnp.ndarray]:
-    """Single-step recurrent update for decode."""
+    """Single-step recurrent update for decode.
+
+    Computes the gated-delta-rule step in float32 to match GPU FLA's
+    ``fused_sigmoid_gating_delta_rule_update`` kernel
+    (`vllm/model_executor/layers/fla/ops/fused_sigmoid_gating.py`),
+    which loads q/k/v/state as fp32 and keeps the entire recurrent
+    update in registers as fp32. Without this, the einsums below
+    default to TPU's ``Precision.DEFAULT`` (bf16 multiply with fp32
+    accumulate); the bf16 multiply error of order
+    ``sqrt(d_k) * bf16_ULP`` propagates through the recurrent state on
+    every decode step, and over the long generation budgets used here
+    (``max_gen_toks=32768``) it contributes to the GPQA-Diamond gap
+    vs. GPU. See the module docstring for the full ablation; we did
+    not isolate this fix's individual contribution.
+    """
     B, H, d_k = query.shape
     d_v = value.shape[-1]
 
+    orig_dtype = query.dtype
+    query = query.astype(jnp.float32)
+    key = key.astype(jnp.float32)
+    value = value.astype(jnp.float32)
+    beta = beta.astype(jnp.float32)
+    g = g.astype(jnp.float32)
     if state is None:
-        state = jnp.zeros((B, H, d_k, d_v), dtype=query.dtype)
+        state = jnp.zeros((B, H, d_k, d_v), dtype=jnp.float32)
+    else:
+        state = state.astype(jnp.float32)
 
     scale = d_k**-0.5
     query = query * scale
 
     exp_g = jnp.exp(g)
 
-    k_state = jnp.einsum("bhd, bhdm -> bhm", key, state)
+    k_state = jnp.einsum("bhd, bhdm -> bhm",
+                         key,
+                         state,
+                         precision=jax.lax.Precision.HIGHEST)
     v_diff = value - exp_g[..., None] * k_state
 
     v_new = beta[..., None] * v_diff
 
-    q_state = jnp.einsum("bhd, bhdm -> bhm", query, state)
+    q_state = jnp.einsum("bhd, bhdm -> bhm",
+                         query,
+                         state,
+                         precision=jax.lax.Precision.HIGHEST)
     q_k = jnp.sum(query * key, axis=-1, keepdims=True)
 
     out = exp_g[..., None] * q_state + q_k * v_new
@@ -489,7 +583,7 @@ def recurrent_gated_delta_rule_step(
     k_v_new = key[..., :, None] * v_new[..., None, :]
     new_state = state * exp_g[..., None, None] + k_v_new
 
-    return out, new_state
+    return out.astype(orig_dtype), new_state
 
 
 def ragged_gated_delta_rule_decode_only(
@@ -538,7 +632,10 @@ def ragged_gated_delta_rule_decode_only(
     req_indices = jnp.clip(token_idx, 0, max_reqs - 1)
     valid_mask = token_idx < distribution[2]
 
-    beta = jax.nn.sigmoid(b_reshaped)
+    # See comment on the same expression in
+    # `ragged_gated_delta_rule_mixed_prefill` for why sigmoid runs in
+    # fp32.
+    beta = jax.nn.sigmoid(b_reshaped.astype(jnp.float32))
     g = -jnp.exp(A_log.astype(jnp.float32)) * jax.nn.softplus(
         a_reshaped.astype(jnp.float32) + dt_bias.astype(jnp.float32))
 
@@ -597,6 +694,7 @@ def ragged_gated_delta_rule(
     query_start_loc: jnp.ndarray,
     state_indices: jnp.ndarray,
     distribution: jnp.ndarray,
+    has_initial_state: jnp.ndarray,
     *,
     n_kq: int,
     n_v: int,
@@ -624,6 +722,10 @@ def ragged_gated_delta_rule(
       state_indices: Indices mapping sequences to recurrent state slots.
       distribution: Tensor of shape `(3,)` int32 — `(decode_end, prefill_end,
         mixed_end)`.
+      has_initial_state: Boolean tensor of shape `(max_reqs,)` indicating
+        which sequences have a valid prior recurrent state in their slot.
+        Forwarded to the prefill branch; the decode branch ignores it
+        because decodes always continue from the running state.
       n_kq: Number of key/query heads.
       n_v: Number of value heads.
       d_k: Key/query dimension.
@@ -684,6 +786,7 @@ def ragged_gated_delta_rule(
             recurrent_state=recurrent_state,
             state_indices=state_indices,
             distribution=distribution,
+            has_initial_state=has_initial_state,
             chunk_size=chunk_size,
             use_qk_norm_in_gdn=use_qk_norm_in_gdn,
         )

--- a/tpu_inference/layers/common/ragged_gated_delta_rule_chunked.py
+++ b/tpu_inference/layers/common/ragged_gated_delta_rule_chunked.py
@@ -13,43 +13,10 @@
 # limitations under the License.
 """Ragged gated delta rule packed JAX implementation.
 
-Precision discipline (Qwen3.5 397B GPQA fix, 2026-04-26)
---------------------------------------------------------
-The original implementation ran the entire decode-side recurrent step
-at TPU's default precision (bf16 multiply, fp32 accumulate). On long
-CoT generations (``max_gen_toks=32768``) the per-token bf16 multiply
-error compounds through the recurrent state, contributing to a
-GPQA-Diamond gap vs. GPU (TPU 0.7929 vs. GPU 0.8343, full N=198). The
-fix mirrors GPU FLA's fp32 precision discipline across five kernel
-sites (see commit body for the full ablation table):
-
-  ALL load-bearing — do not revert without re-running the full eval:
-    - ``recurrent_gated_delta_rule_step``: fp32 inputs + HIGHEST matmul.
-    - ``ragged_conv1d_jax``: fp32 conv accumulation.
-    - ``l2norm`` (chunked + ref): fp32 sum-of-squares reduction.
-    - ``sigmoid(b)`` for the beta gate (chunked + ref): fp32 input.
-    - ``has_initial_state`` plumbing in mixed-prefill init carry.
-
-What we ablated (full GPQA-Diamond, N=198, flexible-extract):
-    no fixes:                0.7929
-    fixes (1)+(2)+(3):       0.8232    (+0.030 over baseline)
-    all 5 fixes:             0.8485    (+0.056 over baseline,
-                                        +0.025 over (1)+(2)+(3))
-    GPU reference:           0.8343
-
-We did NOT ablate (1) vs (2) vs (3) individually, so the ranking
-inside that group is unproven. We can say that (1)+(2)+(3) is
-necessary but not sufficient on its own, and (4)+(5) close the
-remaining gap.
-
-The TPU perf cost of the full fp32 set is ~0% throughput on a
-30-prompt × 512-token decode bench (957.55 → 956.47 tokens/sec). The
-decode path is HBM-bandwidth-bound and these are tiny per-token ops.
-
-If you change the recurrent matmul precision OR remove any of the
-fp32 promotions above, re-run
-``gpqa_diamond_cot_zeroshot`` (full N=198, no ``--limit``) against
-``Qwen/Qwen3.5-397B-A17B-FP8`` before merging.
+Several call sites here run in fp32 to match GPU FLA's precision
+(``vllm/model_executor/layers/fla/ops/{fused_sigmoid_gating,l2norm}.py``
+and ``vllm/model_executor/layers/mamba/gdn_linear_attn.py``). See PR
+#2408 for the ablation that ties this to Qwen3.5-397B GPQA-Diamond.
 """
 
 import jax
@@ -62,13 +29,9 @@ import tpu_inference.kernels.gdn.triangle_solver as triangle_solver
 def l2norm(x: jnp.ndarray, dim: int = -1, eps: float = 1e-6) -> jnp.ndarray:
     """Normalizes x along the specified dimension using L2 norm.
 
-  Computes the sum-of-squares and rsqrt in float32 even when the input
-  is bf16, matching GPU FLA's ``l2norm_fwd``
-  (`vllm/model_executor/layers/fla/ops/l2norm.py`). This fix is part
-  of the bundle that closes the GPQA-Diamond gap; we did not ablate
-  l2norm individually but joint removal of l2norm + sigmoid below
-  drops full-Diamond score from 0.8485 to 0.8232. See the module
-  docstring for the full ablation.
+  Sum-of-squares and rsqrt run in fp32 even when ``x`` is bf16, to
+  match GPU FLA's ``l2norm_fwd``
+  (`vllm/model_executor/layers/fla/ops/l2norm.py`).
 
   Args:
     x: Input array.
@@ -300,8 +263,8 @@ def ragged_gated_delta_rule_mixed_prefill(
     initial_dtype = query.dtype
 
     # Cast b to fp32 before sigmoid to match GPU's
-    # `fused_gdn_gating_kernel`. Bundled with the l2norm fp32 fix
-    # above; see the module docstring for the joint ablation.
+    # `fused_gdn_gating_kernel`
+    # (`vllm/model_executor/layers/mamba/gdn_linear_attn.py`).
     beta = jax.nn.sigmoid(b_reshaped.astype(jnp.float32))
     g = -jnp.exp(A_log.astype(jnp.float32)) * jax.nn.softplus(
         a_reshaped.astype(jnp.float32) + dt_bias.astype(jnp.float32))
@@ -531,18 +494,10 @@ def recurrent_gated_delta_rule_step(
 ) -> tuple[jnp.ndarray, jnp.ndarray]:
     """Single-step recurrent update for decode.
 
-    Computes the gated-delta-rule step in float32 to match GPU FLA's
-    ``fused_sigmoid_gating_delta_rule_update`` kernel
-    (`vllm/model_executor/layers/fla/ops/fused_sigmoid_gating.py`),
-    which loads q/k/v/state as fp32 and keeps the entire recurrent
-    update in registers as fp32. Without this, the einsums below
-    default to TPU's ``Precision.DEFAULT`` (bf16 multiply with fp32
-    accumulate); the bf16 multiply error of order
-    ``sqrt(d_k) * bf16_ULP`` propagates through the recurrent state on
-    every decode step, and over the long generation budgets used here
-    (``max_gen_toks=32768``) it contributes to the GPQA-Diamond gap
-    vs. GPU. See the module docstring for the full ablation; we did
-    not isolate this fix's individual contribution.
+    Runs in fp32 to match GPU FLA's
+    ``fused_sigmoid_gating_delta_rule_update`` kernel, which loads
+    q/k/v/state as fp32 and keeps the recurrent update in fp32
+    registers.
     """
     B, H, d_k = query.shape
     d_v = value.shape[-1]
@@ -563,6 +518,8 @@ def recurrent_gated_delta_rule_step(
 
     exp_g = jnp.exp(g)
 
+    # `Precision.HIGHEST` is required even with fp32 inputs: TPU MXU's
+    # default mode downconverts fp32 operands to bf16 before multiply.
     k_state = jnp.einsum("bhd, bhdm -> bhm",
                          key,
                          state,

--- a/tpu_inference/layers/common/ragged_gated_delta_rule_chunked.py
+++ b/tpu_inference/layers/common/ragged_gated_delta_rule_chunked.py
@@ -492,16 +492,14 @@ def recurrent_gated_delta_rule_step(
     beta: jnp.ndarray,
     state: jnp.ndarray | None = None,
 ) -> tuple[jnp.ndarray, jnp.ndarray]:
-    """Single-step recurrent update for decode.
-
-    Runs in fp32 to match GPU FLA's
-    ``fused_sigmoid_gating_delta_rule_update`` kernel, which loads
-    q/k/v/state as fp32 and keeps the recurrent update in fp32
-    registers.
-    """
+    """Single-step recurrent update for decode."""
     B, H, d_k = query.shape
     d_v = value.shape[-1]
 
+    # Run in fp32 to match GPU FLA's
+    # `fused_sigmoid_gating_delta_rule_update` kernel, which loads
+    # q/k/v/state as fp32 and keeps the recurrent update in fp32
+    # registers.
     orig_dtype = query.dtype
     query = query.astype(jnp.float32)
     key = key.astype(jnp.float32)

--- a/tpu_inference/layers/common/ragged_gated_delta_rule_ref.py
+++ b/tpu_inference/layers/common/ragged_gated_delta_rule_ref.py
@@ -22,15 +22,20 @@ import jax.numpy as jnp
 def _l2_normalize(x: jnp.ndarray, eps: float = 1e-6) -> jnp.ndarray:
     """L2 normalize along last dimension.
 
+    See module docstring of `ragged_gated_delta_rule_chunked.py` for the
+    full precision-discipline rationale; the fp32 reduction matches GPU
+    FLA's `l2norm_fwd`.
+
     Args:
         x: input to normalize
         eps: epsilon for numerical stability
 
     Returns:
-        normalized x
+        normalized x, in the same dtype as `x`.
     """
-    norm = jnp.sqrt(jnp.sum(x * x, axis=-1, keepdims=True) + eps)
-    return x / norm
+    x_f32 = x.astype(jnp.float32)
+    norm = jnp.sqrt(jnp.sum(x_f32 * x_f32, axis=-1, keepdims=True) + eps)
+    return (x_f32 / norm).astype(x.dtype)
 
 
 def _recurrent_gated_delta_rule_step(
@@ -103,6 +108,7 @@ def ragged_gated_delta_rule(
     query_start_loc,
     state_indices,
     distribution,
+    has_initial_state,
     *,
     n_kq,
     n_v,
@@ -128,6 +134,13 @@ def ragged_gated_delta_rule(
         index.
       distribution: Tensor of shape `(3,)` int32 — `(decode_end, prefill_end,
         mixed_end)`.
+      has_initial_state: Boolean tensor of shape `(max_reqs,)`. ``True`` when
+        the request's slot already holds a valid recurrent state (chunked-
+        prefill continuation, prefix-cache hit, or running decode);
+        ``False`` for brand-new prefills, which must start from zero
+        regardless of the slot's contents. Mirrors GPU's
+        `initial_state[~has_initial_state, ...] = 0` in
+        `gdn_linear_attn._forward_core`.
       n_kq: Number of key/query heads.
       n_v: Number of value heads.
       d_k: Dimension of key.
@@ -159,6 +172,21 @@ def ragged_gated_delta_rule(
     req_indices = jnp.clip(req_indices, 0, max_reqs - 1)
     valid_mask = token_idx < last_valid_loc
 
+    # Zero the carry's recurrent state for slots whose request has no prior
+    # context. We do this once up front so the scan can keep its simple
+    # token-by-token shape: each step reads `recurrent_state_all[state_index]`,
+    # which now holds zeros for new prefills regardless of what stale data
+    # the slot may have held from a previous request. Mirrors GPU's
+    # `initial_state[~has_initial_state, ...] = 0`.
+    gathered_states = recurrent_state[state_indices]
+    masked_initial_states = jnp.where(
+        has_initial_state[:, None, None, None],
+        gathered_states,
+        jnp.zeros_like(gathered_states),
+    )
+    recurrent_state = recurrent_state.at[state_indices].set(
+        masked_initial_states)
+
     def scan_fn(carry, xs):
         recurrent_state_all = carry
         (
@@ -185,7 +213,10 @@ def ragged_gated_delta_rule(
         key_reshaped = curr_k.reshape(B, T, n_kq, d_k)
         value_reshaped = curr_v.reshape(B, T, n_v, d_v)
 
-        beta = jax.nn.sigmoid(curr_b)
+        # Cast b to fp32 before sigmoid to match GPU's
+        # `fused_gdn_gating_kernel`. See module docstring of
+        # `ragged_gated_delta_rule_chunked.py` for context.
+        beta = jax.nn.sigmoid(curr_b.astype(jnp.float32))
         g = -jnp.exp(A_log.astype(jnp.float32)) * jax.nn.softplus(
             curr_a.astype(jnp.float32) + dt_bias.astype(jnp.float32))
 

--- a/tpu_inference/layers/common/ragged_gated_delta_rule_ref.py
+++ b/tpu_inference/layers/common/ragged_gated_delta_rule_ref.py
@@ -22,9 +22,8 @@ import jax.numpy as jnp
 def _l2_normalize(x: jnp.ndarray, eps: float = 1e-6) -> jnp.ndarray:
     """L2 normalize along last dimension.
 
-    See module docstring of `ragged_gated_delta_rule_chunked.py` for the
-    full precision-discipline rationale; the fp32 reduction matches GPU
-    FLA's `l2norm_fwd`.
+    Sum-of-squares and rsqrt run in fp32 even when ``x`` is bf16, to
+    match GPU FLA's ``l2norm_fwd``.
 
     Args:
         x: input to normalize
@@ -214,8 +213,8 @@ def ragged_gated_delta_rule(
         value_reshaped = curr_v.reshape(B, T, n_v, d_v)
 
         # Cast b to fp32 before sigmoid to match GPU's
-        # `fused_gdn_gating_kernel`. See module docstring of
-        # `ragged_gated_delta_rule_chunked.py` for context.
+        # `fused_gdn_gating_kernel`
+        # (`vllm/model_executor/layers/mamba/gdn_linear_attn.py`).
         beta = jax.nn.sigmoid(curr_b.astype(jnp.float32))
         g = -jnp.exp(A_log.astype(jnp.float32)) * jax.nn.softplus(
             curr_a.astype(jnp.float32) + dt_bias.astype(jnp.float32))

--- a/tpu_inference/layers/vllm/custom_ops/gdn_attention_op.py
+++ b/tpu_inference/layers/vllm/custom_ops/gdn_attention_op.py
@@ -104,6 +104,23 @@ def gdn_attention_core_tpu(
     # Map tokens to their respective requests
     q_loc = jax_view(attn_metadata.query_start_loc)
     distribution = jax_view(attn_metadata.request_distribution)
+
+    # Derive has_initial_state per request: True if the request already has
+    # computed tokens in its slot (chunked-prefill continuation, prefix-cache
+    # hit, or running decode), False for brand-new prefills. We cannot rely
+    # on the slot's contents being zero — vLLM's kv-cache pool reuses freed
+    # slots without clearing them, so a new request that lands on a slot
+    # previously held by another request would silently consume that
+    # request's recurrent state. GPU's GDN backend handles this via
+    # `initial_state[~has_initial_state, ...] = 0` in
+    # `gdn_linear_attn._forward_core`; without the equivalent on TPU, every
+    # slot reuse corrupts the new request's GDN trajectory.
+    #
+    # context_len = seq_len - query_len. If > 0, prior tokens exist.
+    j_seq_lens = jax_view(attn_metadata.seq_lens)
+    query_lens = q_loc[1:] - q_loc[:-1]
+    has_initial_state = (j_seq_lens - query_lens) > 0
+
     config = GdnAttentionConfig(
         ragged_gated_delta_rule_impl=RaggedGatedDeltaRuleImpl(
             envs.RAGGED_GATED_DELTA_RULE_IMPL))
@@ -121,6 +138,7 @@ def gdn_attention_core_tpu(
                                                             state_indices,
                                                             q_loc,
                                                             distribution,
+                                                            has_initial_state,
                                                             n_kq,
                                                             n_v,
                                                             d_k,

--- a/tpu_inference/layers/vllm/custom_ops/gdn_attention_op.py
+++ b/tpu_inference/layers/vllm/custom_ops/gdn_attention_op.py
@@ -104,22 +104,7 @@ def gdn_attention_core_tpu(
     # Map tokens to their respective requests
     q_loc = jax_view(attn_metadata.query_start_loc)
     distribution = jax_view(attn_metadata.request_distribution)
-
-    # Derive has_initial_state per request: True if the request already has
-    # computed tokens in its slot (chunked-prefill continuation, prefix-cache
-    # hit, or running decode), False for brand-new prefills. We cannot rely
-    # on the slot's contents being zero — vLLM's kv-cache pool reuses freed
-    # slots without clearing them, so a new request that lands on a slot
-    # previously held by another request would silently consume that
-    # request's recurrent state. GPU's GDN backend handles this via
-    # `initial_state[~has_initial_state, ...] = 0` in
-    # `gdn_linear_attn._forward_core`; without the equivalent on TPU, every
-    # slot reuse corrupts the new request's GDN trajectory.
-    #
-    # context_len = seq_len - query_len. If > 0, prior tokens exist.
     j_seq_lens = jax_view(attn_metadata.seq_lens)
-    query_lens = q_loc[1:] - q_loc[:-1]
-    has_initial_state = (j_seq_lens - query_lens) > 0
 
     config = GdnAttentionConfig(
         ragged_gated_delta_rule_impl=RaggedGatedDeltaRuleImpl(
@@ -138,7 +123,7 @@ def gdn_attention_core_tpu(
                                                             state_indices,
                                                             q_loc,
                                                             distribution,
-                                                            has_initial_state,
+                                                            j_seq_lens,
                                                             n_kq,
                                                             n_v,
                                                             d_k,


### PR DESCRIPTION
Closes the TPU↔GPU quality gap on Qwen3.5-397B GPQA-Diamond CoT (zero-shot, flexible-extract): TPU goes from 0.7929 to 0.8485 (full N=198), slightly above the 0.8343 GPU reference. Mirroring GPU FLA's fp32 precision discipline across the GDN kernel restores parity with negligible perf impact (~0% throughput on a 30-prompt × 512-token decode bench, 957.55 → 956.47 output tokens/sec).

Five fixes, all in the GDN path used by Qwen3-Next / Qwen3.5:

1. has_initial_state plumbing (correctness) GPU's gdn_linear_attn._forward_core does initial_state[~has_initial_state, ...] = 0 for prefills with no prior context, and the equivalent for the conv state via causal_conv1d_fn(has_initial_state=...). vLLM's mamba block manager does NOT zero freed slots — it relies on the kernel to honor the flag. The TPU GDN kernel was reading recurrent_state[slot] / conv_state[slot] unconditionally, so once a freed slot got reused, the new request would silently consume the previous tenant's state and corrupt its entire GDN trajectory.

   Derive `has_initial_state = (seq_lens - query_lens) > 0` from the existing attn metadata in gdn_attention_op.py and plumb it through run_jax_gdn_attention → ragged_conv1d_jax and the chunked + ref ragged_gated_delta_rule. Each masks the gathered slot state to zero where ~has_initial_state. Decode-only branch ignores it because decodes always have prior context.

2. recurrent_gated_delta_rule_step in fp32 with Precision.HIGHEST The decode-side recurrent step had been running at TPU's default precision (bf16 multiply, fp32 accumulate), accumulating ~sqrt(d_k) × bf16_ULP ≈ 1% per-element error in the recurrent state on every decode token. Over the long generations used for CoT eval (max_gen_toks=32768) this drift compounds enough to plausibly flip CoT answers vs. the GPU run, though we did not ablate per-fix to prove it is the dominant contributor.

   GPU FLA's fused_sigmoid_gating_delta_rule_update kernel loads q/k/v/state as fp32 and keeps the entire recurrent update in fp32 registers. Mirror that on TPU with explicit fp32 input casts and Precision.HIGHEST in the two einsums (k_state, q_state). The matmul is 8×128×128 — even at 6× cost (bf16x6) it's a rounding error against the 397B-parameter MoE forward pass, which is HBM-bound.

3. ragged_conv1d_jax fp32 accumulation GPU's causal_conv1d_fn loads x and weights as fp32 before the kernel-size-element sum. The TPU loop was accumulating in bf16, contributing ~1-2% per-channel relative error on every GDN layer's conv output. Promote x, weights, and the gathered conv state to fp32 inside the loop; cast the final out back to the input dtype. The state writeback path stays bf16 (it's a pure shuffle of the last kernel_size-1 tokens, no arithmetic).

4. l2norm fp32 sum-of-squares reduction (chunked + ref) GPU FLA's l2norm_fwd reduces in fp32. We initially left this in bf16 because on a small --limit=30 GPQA sample it appeared the bf16 path was fine. On the full 198-question Diamond the bf16-l2norm + bf16-sigmoid variant landed at 0.8232 (below GPU's 0.8343) and produced ~37% slower wall-clock generation, so the fp32 path is restored.

5. sigmoid(b) for the beta gate in fp32 (chunked + ref) GPU's fused_gdn_gating_kernel casts b to fp32 before sigmoid. Restored alongside (4) for the same reason.

Empirical evidence we have for which fixes matter:

   no fixes (baseline):      0.7929 ± 0.0289   full Diamond
   fixes (1)+(2)+(3):         0.8232 ± 0.0272   full Diamond  (+0.030)
   all 5 fixes:                     0.8485 ± 0.0255   full Diamond  (+0.056,
                                               +0.025 over the
                                               (1)+(2)+(3) subset)

Tests (tests/layers/common/test_gdn_attention.py)
   + test_has_initial_state_zeros_stale_slot_{chunked,ref}: a new prefill landing on a slot pre-populated with random nonzero state must produce the same output and final state as on a fresh-zero slot when has_initial_state=False.
   + test_has_initial_state_preserves_continuation_{chunked,ref}: a chunked prefill in two halves (step A from zero, step B from step A's slot with has_initial_state=True) must match a single-shot prefill of the concatenated stream.
   + test_l2norm_fp32_internal_more_precise_than_bf16_{chunked,ref}: on a bf16 input where sum-of-squares is well above 1.0, the fp32 reduction is at least 2× closer to a fp64 reference than a bf16-only reduction. Catches silent regressions to bf16.
   + test_l2norm_returns_input_dtype_{chunked,ref}: the helpers compute in fp32 internally but must return the input dtype so downstream `compute_dtype` casts in pack_inputs_single_stream keep their layout assumptions. 14/14 GDN tests pass on TPU v7x-8.

Eval (TPU v7x-8, Qwen/Qwen3.5-397B-A17B-FP8,
gpqa_diamond_cot_zeroshot --apply_chat_template seed=42, full N=198)

   Prior TPU baseline:           0.7929 ± 0.0289
   GPU reference:                 0.8343
   This commit (full Diamond):   0.8485 ± 0.0255   ← +0.014 vs GPU

Perf (Qwen3.5-397B-A17B-FP8, TPU v7x-8, 30 prompts × 512 forced output tokens, ignore_eos=True)

   baseline:  957.55 output tokens/sec
   this fix:  956.47 output tokens/sec   (−0.11%)

