### PR TITLE
Fix multimodal test expected text for transformers v5

### DIFF
--- a/.buildkite/pipeline_dev.yml
+++ b/.buildkite/pipeline_dev.yml
@@ -49,13 +49,8 @@ steps:
     commands:
       - bash -c 'source .buildkite/scripts/setup_docker_env.sh && setup_environment "vllm-tpu" "false" "true"'
 
-  # -----------------------------------------------------------------
-  # Demo 1: offline_inference.py
-  # Shows the simplest pattern: run a Python script inside Docker.
-  # Use this as a starting point for any offline batch inference test.
-  # -----------------------------------------------------------------
-  - label: "tpu7x [demo] offline_inference.py"
-    key: tpu7x_demo_offline_inference
+  - label: "tpu7x Correctness tests for Multimodal Inputs"
+    key: tpu7x_multimodal_test
     depends_on: tpu7x_build_docker
     env:
       USE_PREBUILT_IMAGE: "1"
@@ -63,86 +58,4 @@ steps:
     agents:
       queue: tpu_v7x_2_queue
     commands:
-      - |
-        # Run offline inference with a small model.
-        # --tensor-parallel-size 2: tp=1 is currently unsupported on tpu7x.
-        # Customize --model, --max-model-len, --max-tokens as needed.
-        .buildkite/scripts/run_in_docker.sh bash -c '
-          python3 examples/offline_inference.py \
-            --model Qwen/Qwen3-0.6B \
-            --tensor-parallel-size 2 \
-            --max-model-len 1024 \
-            --max-tokens 128'
-
-  # -----------------------------------------------------------------
-  # Demo 2: vllm serve + vllm bench serve
-  # Shows how to start a server and run a benchmark against it.
-  # Uses --dataset-name random so no dataset file is needed.
-  # -----------------------------------------------------------------
-  - label: "tpu7x [demo] vllm serve + vllm bench serve"
-    key: tpu7x_demo_serve_bench
-    depends_on: tpu7x_build_docker
-    env:
-      USE_PREBUILT_IMAGE: "1"
-      TPU_VERSION: "tpu7x"
-    agents:
-      queue: tpu_v7x_2_queue
-    commands:
-      - |
-        # Customize behaviour via env vars: MODEL, PORT, TENSOR_PARALLEL_SIZE,
-        # MAX_MODEL_LEN, RANDOM_INPUT_LEN, RANDOM_OUTPUT_LEN, NUM_PROMPTS, NUM_WARMUPS.
-        .buildkite/scripts/run_in_docker.sh bash .buildkite/scripts/run_benchmark_demo.sh
-
-  # -----------------------------------------------------------------
-  # Demo 3: DCN-based P/D disaggregation
-  # Mirrors test_25 in pipeline_jax.yml.
-  # Uses run_disagg.sh which delegates to examples/disagg/.
-  # Requires a multi-chip queue (tpu_v7x_8_queue).
-  # -----------------------------------------------------------------
-  - label: "tpu7x [demo] E2E disaggregation (DCN P/D)"
-    key: tpu7x_demo_disagg
-    depends_on: tpu7x_build_docker
-    env:
-      USE_PREBUILT_IMAGE: "1"
-      TPU_VERSION: "tpu7x"
-      # Customize these to change the disagg benchmark behaviour.
-      MODEL: "Qwen/Qwen3-0.6B"
-      INPUT_LEN: 1024
-      OUTPUT_LEN: 128
-      NUM_PROMPTS: 5
-      RANDOM_SEED: 10
-      MAX_CONCURRENCY: 4
-      TEST_MODE: 1
-    agents:
-      queue: tpu_v7x_8_queue
-    commands:
-      - .buildkite/scripts/run_disagg.sh
-
-  # -----------------------------------------------------------------
-  # Demo 4: Ray-based multi-host inference
-  # Mirrors test_26 in pipeline_jax.yml.
-  # Uses run_multihost.sh to serve a large model across 16 chips (2 hosts).
-  # Requires a 16-chip queue (tpu_v7x_16_queue).
-  # -----------------------------------------------------------------
-  - label: "tpu7x [demo] Ray-based multi-host"
-    key: tpu7x_demo_multihost
-    env:
-      TPU_VERSION: "tpu7x"
-    agents:
-      queue: tpu_v7x_16_queue
-    commands:
-      - |
-        MODEL="gs://tpu-commons-ci/qwen/models--Qwen--Qwen3-30B-A3B/snapshots/ad44e777bcd18fa416d9da3bd8f70d33ebb85d39"
-        .buildkite/scripts/run_multihost.sh \
-          "vllm serve \${MODEL} \
-            --port 8000 \
-            --tensor-parallel-size 16 \
-            --trust-remote-code \
-            --max-model-len 1024 \
-            --no-async-scheduling \
-            --load-format=runai_streamer \
-            --no-enable-prefix-caching" \
-          "curl http://localhost:8000/v1/completions \
-            -X POST \
-            -H 'Content-Type: application/json' \
-            -d '{\"model\": \"${MODEL}\", \"prompt\": \"San Francisco is a\", \"max_tokens\": 50}'"
+      - .buildkite/scripts/run_in_docker.sh python3 -m pytest -s -v /workspace/tpu_inference/tests/e2e/test_multi_modal_inference.py

--- a/.buildkite/pipeline_dev.yml
+++ b/.buildkite/pipeline_dev.yml
@@ -49,8 +49,13 @@ steps:
     commands:
       - bash -c 'source .buildkite/scripts/setup_docker_env.sh && setup_environment "vllm-tpu" "false" "true"'
 
-  - label: "tpu7x Correctness tests for Multimodal Inputs"
-    key: tpu7x_multimodal_test
+  # -----------------------------------------------------------------
+  # Demo 1: offline_inference.py
+  # Shows the simplest pattern: run a Python script inside Docker.
+  # Use this as a starting point for any offline batch inference test.
+  # -----------------------------------------------------------------
+  - label: "tpu7x [demo] offline_inference.py"
+    key: tpu7x_demo_offline_inference
     depends_on: tpu7x_build_docker
     env:
       USE_PREBUILT_IMAGE: "1"
@@ -58,4 +63,86 @@ steps:
     agents:
       queue: tpu_v7x_2_queue
     commands:
-      - .buildkite/scripts/run_in_docker.sh python3 -m pytest -s -v /workspace/tpu_inference/tests/e2e/test_multi_modal_inference.py
+      - |
+        # Run offline inference with a small model.
+        # --tensor-parallel-size 2: tp=1 is currently unsupported on tpu7x.
+        # Customize --model, --max-model-len, --max-tokens as needed.
+        .buildkite/scripts/run_in_docker.sh bash -c '
+          python3 examples/offline_inference.py \
+            --model Qwen/Qwen3-0.6B \
+            --tensor-parallel-size 2 \
+            --max-model-len 1024 \
+            --max-tokens 128'
+
+  # -----------------------------------------------------------------
+  # Demo 2: vllm serve + vllm bench serve
+  # Shows how to start a server and run a benchmark against it.
+  # Uses --dataset-name random so no dataset file is needed.
+  # -----------------------------------------------------------------
+  - label: "tpu7x [demo] vllm serve + vllm bench serve"
+    key: tpu7x_demo_serve_bench
+    depends_on: tpu7x_build_docker
+    env:
+      USE_PREBUILT_IMAGE: "1"
+      TPU_VERSION: "tpu7x"
+    agents:
+      queue: tpu_v7x_2_queue
+    commands:
+      - |
+        # Customize behaviour via env vars: MODEL, PORT, TENSOR_PARALLEL_SIZE,
+        # MAX_MODEL_LEN, RANDOM_INPUT_LEN, RANDOM_OUTPUT_LEN, NUM_PROMPTS, NUM_WARMUPS.
+        .buildkite/scripts/run_in_docker.sh bash .buildkite/scripts/run_benchmark_demo.sh
+
+  # -----------------------------------------------------------------
+  # Demo 3: DCN-based P/D disaggregation
+  # Mirrors test_25 in pipeline_jax.yml.
+  # Uses run_disagg.sh which delegates to examples/disagg/.
+  # Requires a multi-chip queue (tpu_v7x_8_queue).
+  # -----------------------------------------------------------------
+  - label: "tpu7x [demo] E2E disaggregation (DCN P/D)"
+    key: tpu7x_demo_disagg
+    depends_on: tpu7x_build_docker
+    env:
+      USE_PREBUILT_IMAGE: "1"
+      TPU_VERSION: "tpu7x"
+      # Customize these to change the disagg benchmark behaviour.
+      MODEL: "Qwen/Qwen3-0.6B"
+      INPUT_LEN: 1024
+      OUTPUT_LEN: 128
+      NUM_PROMPTS: 5
+      RANDOM_SEED: 10
+      MAX_CONCURRENCY: 4
+      TEST_MODE: 1
+    agents:
+      queue: tpu_v7x_8_queue
+    commands:
+      - .buildkite/scripts/run_disagg.sh
+
+  # -----------------------------------------------------------------
+  # Demo 4: Ray-based multi-host inference
+  # Mirrors test_26 in pipeline_jax.yml.
+  # Uses run_multihost.sh to serve a large model across 16 chips (2 hosts).
+  # Requires a 16-chip queue (tpu_v7x_16_queue).
+  # -----------------------------------------------------------------
+  - label: "tpu7x [demo] Ray-based multi-host"
+    key: tpu7x_demo_multihost
+    env:
+      TPU_VERSION: "tpu7x"
+    agents:
+      queue: tpu_v7x_16_queue
+    commands:
+      - |
+        MODEL="gs://tpu-commons-ci/qwen/models--Qwen--Qwen3-30B-A3B/snapshots/ad44e777bcd18fa416d9da3bd8f70d33ebb85d39"
+        .buildkite/scripts/run_multihost.sh \
+          "vllm serve \${MODEL} \
+            --port 8000 \
+            --tensor-parallel-size 16 \
+            --trust-remote-code \
+            --max-model-len 1024 \
+            --no-async-scheduling \
+            --load-format=runai_streamer \
+            --no-enable-prefix-caching" \
+          "curl http://localhost:8000/v1/completions \
+            -X POST \
+            -H 'Content-Type: application/json' \
+            -d '{\"model\": \"${MODEL}\", \"prompt\": \"San Francisco is a\", \"max_tokens\": 50}'"

--- a/tests/e2e/test_multi_modal_inference.py
+++ b/tests/e2e/test_multi_modal_inference.py
@@ -13,11 +13,25 @@ from vllm import LLM, EngineArgs, SamplingParams
 from vllm.assets.image import ImageAsset
 from vllm.multimodal.image import convert_image_mode
 
-# Expected partial text output from the model. This is based on a query to
-# vllm 0.17.0 on A100. The test is considered passed if the
-# generated output match with this text.
-EXPECTED_TEXT = (
-    "The image depicts a stunning view of the Tokyo Skytree, a tall tower located in Tokyo, Japan. The sky is clear and blue, providing a beautiful backdrop for the tower. In the foreground, there are cherry blossom trees in full bloom, with pink flowers covering the branches. The cherry blossoms are in full bloom"
+# Expected partial text output from the model.
+# Separate expected texts for static vs dynamic image sizes because the image
+# processing pipeline produces different vision tokens for each mode.
+# Updated for transformers v5 which fixed temporal RoPE scaling for still
+# images (time_interval=1 instead of tokens_per_second * second_per_grid_ts).
+EXPECTED_TEXT_STATIC = (
+    "The image depicts a stunning view of the Tokyo Skytree, a tall"
+    " broadcasting tower located in the Odaiba district of Tokyo, Japan."
+    " The skytree is surrounded by cherry blossom trees in full bloom,"
+    " creating a picturesque and vibrant scene. The cherry blossoms are"
+    " in various stages of bloom, with some branches densely covered"
+)
+
+EXPECTED_TEXT_DYNAMIC = (
+    "The image depicts a tall, cylindrical tower with a lattice-like"
+    " structure, surrounded by cherry blossom trees in full bloom."
+    " The cherry blossoms are in various stages of opening, with pink"
+    " petals covering the branches. The sky is clear and blue, providing"
+    " a vibrant backdrop to t"
 )
 
 
@@ -111,10 +125,12 @@ def test_multi_modal_inference(monkeypatch, enable_dynamic_image_sizes):
     print("-" * 50)
 
     # Check output
+    expected_text = (EXPECTED_TEXT_DYNAMIC
+                     if enable_dynamic_image_sizes else EXPECTED_TEXT_STATIC)
     similarity_score = difflib.SequenceMatcher(None, generated_text,
-                                               EXPECTED_TEXT).ratio()
+                                               expected_text).ratio()
     print(f"Similarity Score: {similarity_score:.4f}")
     assert similarity_score >= 0.85, (
         f"Text similarity too low ({similarity_score:.2f}).\n"
-        f"Expected: {EXPECTED_TEXT}\n"
+        f"Expected: {expected_text}\n"
         f"Actual:   {generated_text}")


### PR DESCRIPTION
## Summary
- Update `EXPECTED_TEXT` in `test_multi_modal_inference.py` for transformers v5 (introduced by vLLM LKG bump in #2308)
- Split into `EXPECTED_TEXT_STATIC` and `EXPECTED_TEXT_DYNAMIC` since the two image processing modes produce different outputs
- Transformers v5 fixed temporal RoPE scaling for still images (`time_interval=1` instead of `tokens_per_second * second_per_grid_ts`), changing Qwen2.5-VL-3B-Instruct output

## Root cause
PR #2308 bumped the vLLM LKG, which lifted the `transformers < 5` pin. The multimodal test has been failing since Apr 18 (similarity score 0.28 vs threshold 0.85).

## Test plan
- [x] Dev build [#148](https://buildkite.com/tpu-commons/tpu-inference-dev/builds/148) passed with the updated expected text
- [x] Verified pinning transformers v4 on the failing build restores the old output (dev build #146)