### PR TITLE
[TPU KV Offload] Update test yaml and metrics unit

### DIFF
--- a/examples/offload/gke/benchmarks/deploy-cpu-offload.yaml
+++ b/examples/offload/gke/benchmarks/deploy-cpu-offload.yaml
@@ -96,9 +96,9 @@ spec:
         - name: SKIP_JAX_PRECOMPILE
           value: "0"
         - name: TPU_OFFLOAD_NUM_CPU_CHUNKS
-          value: "3000"
+          value: "3268"
         - name: TPU_OFFLOAD_NUM_STAGING_BLOCKS
-          value: "100"
+          value: "640"
         ports:
         - containerPort: 8000
         resources:

--- a/examples/offload/gke/pod_tpu_host_offload_unit_tests.yaml
+++ b/examples/offload/gke/pod_tpu_host_offload_unit_tests.yaml
@@ -30,8 +30,15 @@ spec:
     imagePullPolicy: Always
     command:
     - /bin/bash
-    - -c
-    - "pytest -sv tests/offload/ --ignore=tests/offload/tpu_offload_multi_request_accuracy_test.py"
+    - -c  
+    - |
+      # 1. Run general tests while ignoring accuracy and performance scripts
+      pytest -sv tests/offload/ \
+        --ignore=tests/offload/tpu_offload_multi_request_accuracy_test.py \
+        --ignore=tests/offload/tpu_offload_performance_test.py && \
+      
+      # 2. Execute the performance test in isolation; running it concurrently with the main suite causes initialization hangs.
+      pytest -sv tests/offload/tpu_offload_performance_test.py
     env:
     - name: HUGGING_FACE_HUB_TOKEN
       valueFrom:

--- a/tpu_inference/offload/metrics.py
+++ b/tpu_inference/offload/metrics.py
@@ -27,7 +27,7 @@ logger = init_logger(__name__)
 LATENCY_BUCKETS = (0.001, 0.002, 0.005, 0.01, 0.02, 0.05, 0.1, 0.2, 0.5, 1.0,
                    2.0, 5.0, 10.0, 20, 30, float("inf"))
 
-# Custom buckets defined in Gbps
+# Custom buckets defined in GBps
 # Adjust these based on your hardware (e.g., PCIe 4.0/5.0 limits)
 GBPS_BUCKETS = (1.0, 10.0, 25.0, 50.0, 100.0, 200.0, 400.0, 500.0,
                 float("inf"))
@@ -251,9 +251,9 @@ class PrometheusLogger:
         ).labels(**labels)
         self.d2h_transfer_bw = self._histogram_cls(
             "tpu_inference:prefix_cache_d2h_transfer_bw",
-            "Bandwidth of transfer KV cache from device to host memory in gbps",
+            "Bandwidth of transfer KV cache from device to host memory in GBps",
             labelnames=labelnames,
-            unit="gbps",
+            unit="GBps",
             buckets=GBPS_BUCKETS,
         ).labels(**labels)
         self.d2h_bytes = self._histogram_cls(
@@ -274,9 +274,9 @@ class PrometheusLogger:
         ).labels(**labels)
         self.h2d_transfer_bw = self._histogram_cls(
             "tpu_inference:prefix_cache_h2d_transfer_bw",
-            "Bandwidth of transfer KV cache from host memory to device in gbps",
+            "Bandwidth of transfer KV cache from host memory to device in GBps",
             labelnames=labelnames,
-            unit="gbps",
+            unit="GBps",
             buckets=GBPS_BUCKETS,
         ).labels(**labels)
         self.h2d_bytes = self._histogram_cls(


### PR DESCRIPTION
# Description

- Update TPU_OFFLOAD_NUM_CPU_CHUNKS  and TPU_OFFLOAD_NUM_STAGING_BLOCKS  in examples/offload/gke/benchmarks/deploy-cpu-offload.yaml 
- Fix test command in examples/offload/gke/pod_tpu_host_offload_unit_tests.yaml
- Fix unit for prefix_cache_d2h_transfer_bw and prefix_cache_h2d_transfer_bw metrics

If the change fixes a Github issue, please include a link, e.g.,:
FIXES: #123456

# Tests

examples/offload/gke/pod_tpu_host_offload_unit_tests.yaml

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
