### PR TITLE
Compact mamba KV cache + GDN op req-slot indexing

### DIFF
--- a/tests/runner/test_input_batch.py
+++ b/tests/runner/test_input_batch.py
@@ -247,16 +247,18 @@ def test_swap_states_only_swaps_active_tokens(input_batch: InputBatch):
 
 
 def test_mamba_state_indices_unique_per_request(input_batch: InputBatch):
-    """Each request must get its own mamba state slot id."""
-    reqs = [create_dummy_request(f"req-{i}") for i in range(4)]
-    for req in reqs:
-        input_batch.add_request(req)
+    """Two concurrent requests must never receive the same mamba slot id —
+    if they did, the GDN op would write both requests' recurrent state
+    into the same physical cache slot and corrupt one of them. Also
+    verifies slot 0 is reserved (vLLM's null block convention)."""
+    for i in range(4):
+        input_batch.add_request(create_dummy_request(f"req-{i}"))
 
     slots = input_batch.mamba_state_indices_cpu[:input_batch.num_reqs].tolist()
     assert len(set(slots)) == len(slots), \
-        f"Mamba slots should be unique per request, got: {slots}"
-    # Slot 0 is reserved as the null block.
-    assert all(s >= 1 for s in slots), f"Slot 0 must be reserved: {slots}"
+        f"Slots not unique across concurrent requests: {slots}"
+    assert all(s >= 1 for s in slots), \
+        f"Slot 0 is the null block and must not be assigned: {slots}"
 
 
 def test_mamba_state_indices_freed_on_remove(input_batch: InputBatch):

--- a/tests/runner/test_input_batch.py
+++ b/tests/runner/test_input_batch.py
@@ -246,6 +246,81 @@ def test_swap_states_only_swaps_active_tokens(input_batch: InputBatch):
     assert input_batch.num_tokens_no_spec[1] == 6
 
 
+def test_mamba_state_indices_unique_per_request(input_batch: InputBatch):
+    """Each request must get its own mamba state slot id."""
+    reqs = [create_dummy_request(f"req-{i}") for i in range(4)]
+    for req in reqs:
+        input_batch.add_request(req)
+
+    slots = input_batch.mamba_state_indices_cpu[:input_batch.num_reqs].tolist()
+    assert len(set(slots)) == len(slots), \
+        f"Mamba slots should be unique per request, got: {slots}"
+    # Slot 0 is reserved as the null block.
+    assert all(s >= 1 for s in slots), f"Slot 0 must be reserved: {slots}"
+
+
+def test_mamba_state_indices_freed_on_remove(input_batch: InputBatch):
+    """Removing a request must return its slot id to the free pool so the
+    next add reuses it (rather than running the pool dry)."""
+    req = create_dummy_request("req-0")
+    input_batch.add_request(req)
+    slot_first = int(input_batch.mamba_state_indices_cpu[0])
+
+    input_batch.remove_request("req-0")
+    # condense() with empty_indices=[0] would early-return because num_reqs==0,
+    # so we just verify the slot is back in the pool.
+    assert slot_first in input_batch._free_mamba_slots
+
+    new_req = create_dummy_request("req-new")
+    input_batch.add_request(new_req)
+    # The most-recently-freed slot is at the end of the free list — pop()
+    # returns it, so the new request gets the same id back.
+    assert int(input_batch.mamba_state_indices_cpu[0]) == slot_first
+
+
+def test_mamba_state_indices_follow_condense(input_batch: InputBatch):
+    """When condense moves a request to a different persistent-batch slot,
+    its mamba state id must follow it — otherwise the GDN op reads stale
+    state from the recurrent_state cache. This is the bug that broke gsm8k
+    accuracy on Qwen3.5-397B (only triggered when requests finish out of
+    order, which `--ignore-eos` benchmarks suppress)."""
+    reqs = [create_dummy_request(f"req-{i}") for i in range(4)]
+    for req in reqs:
+        input_batch.add_request(req)
+
+    # Snapshot the slot id assigned to each request before any churn.
+    slot_for_req = {
+        rid: int(input_batch.mamba_state_indices_cpu[idx])
+        for rid, idx in input_batch.req_id_to_index.items()
+    }
+
+    # Remove the lower-indexed requests so condense has to move the higher
+    # ones down: [req-0, req-1, req-2, req-3] → [req-3, req-2, _, _].
+    input_batch.remove_request("req-0")
+    input_batch.remove_request("req-1")
+    input_batch.condense(sorted([0, 1], reverse=True))
+
+    # After condense, indexing-by-persistent-slot must yield the same slot
+    # id each request had before the move.
+    assert input_batch.req_id_to_index["req-3"] == 0
+    assert input_batch.req_id_to_index["req-2"] == 1
+    assert int(input_batch.mamba_state_indices_cpu[0]) == slot_for_req["req-3"]
+    assert int(input_batch.mamba_state_indices_cpu[1]) == slot_for_req["req-2"]
+
+
+def test_mamba_state_indices_swap(input_batch: InputBatch):
+    """swap_states swaps the request mappings, so the slot ids must swap too."""
+    input_batch.add_request(create_dummy_request("req-0"))
+    input_batch.add_request(create_dummy_request("req-1"))
+    slot0 = int(input_batch.mamba_state_indices_cpu[0])
+    slot1 = int(input_batch.mamba_state_indices_cpu[1])
+
+    input_batch.swap_states(0, 1)
+
+    assert int(input_batch.mamba_state_indices_cpu[0]) == slot1
+    assert int(input_batch.mamba_state_indices_cpu[1]) == slot0
+
+
 def test_all_greedy_property(input_batch: InputBatch):
     """Tests the `all_greedy` property."""
     # Initially true

--- a/tests/runner/test_kv_cache_manager.py
+++ b/tests/runner/test_kv_cache_manager.py
@@ -917,6 +917,115 @@ class TestKVCacheManager:
                 f"layer {name} has page_size_bytes={spec.page_size_bytes} "
                 f"but expected uniform={expected_uniform}")
 
+    def test_compact_mamba_override_caps_mamba_and_grows_attn(self):
+        """Compact-mamba: with HBM available, mamba should be capped at
+        max_num_reqs+1 (rounded to divisor) and num_gpu_blocks_override
+        should grow beyond what the legacy single-num_blocks path gives."""
+        from tpu_inference.runner.kv_cache_manager import KVCacheManager
+
+        manager = KVCacheManager(self.runner)
+        # Force the use_mla branch off so divisor uses ATTN_DATA.
+        manager.use_mla = False
+        # 304 GiB of available HBM, 4-device mesh — match the Qwen3.5 TP=8
+        # situation as closely as a CPU mesh allows. Returns (used, limit)
+        # per device summing to total_used=0, total_limit=304 GiB.
+        avail_per_device = 304 * (1 << 30) // 4
+
+        with patch(
+                "tpu_inference.runner.kv_cache_manager.utils.hbm_usage_bytes",
+                return_value=[(0, avail_per_device)] * 4):
+            self.runner.cache_config.gpu_memory_utilization = 1.0
+            self.runner.cache_config.num_gpu_blocks_override = None
+            # Pretend the model wants 256 max in-flight requests; mamba
+            # should be capped at 257 (rounded up to divisor=1).
+            self.runner.scheduler_config = MagicMock(max_num_seqs=256)
+            self.runner.max_num_reqs = 256
+            # Big mamba (4 MiB / state) and modest attn page (1 MiB / block)
+            # so the compact reshuffle is a clear win.
+            attn_page = 1 << 20  # 1 MiB
+            unpadded_mamba = 4 << 20  # 4 MiB
+            # Set the state that update_mamba_page_size_padded would set if
+            # we were calling it from a real run; the compact override
+            # function reads `_hybrid_uniform_page_size_bytes` for its
+            # legacy-comparison sanity check.
+            uniform = attn_page + 3 * unpadded_mamba
+            manager._hybrid_uniform_page_size_bytes = uniform
+            manager._maybe_set_compact_mamba_num_blocks_override(
+                attn_page_size_bytes=attn_page,
+                unpadded_mamba_page_size_bytes=unpadded_mamba,
+                num_attn_groups=1,
+                num_mamba_groups=3,
+                num_attn_layers=15,
+                num_mamba_layers=45,
+                group_size=15,
+            )
+
+        assert manager._mamba_num_blocks == 257
+        assert self.runner.cache_config.num_gpu_blocks_override is not None
+        # Attention pool must beat the legacy single-num_blocks calc — the
+        # whole point of the optimization. Quick sanity:
+        # legacy = avail / (uniform × group_size).
+        legacy = (304 * (1 << 30)) // (uniform * 15)
+        assert self.runner.cache_config.num_gpu_blocks_override > legacy
+
+    def test_compact_mamba_override_falls_back_when_hbm_unreadable(self):
+        """If hbm_usage_bytes raises (e.g., on CPU), compact override is a
+        no-op and the legacy path takes over."""
+        from tpu_inference.runner.kv_cache_manager import KVCacheManager
+
+        manager = KVCacheManager(self.runner)
+        manager.use_mla = False
+        manager._hybrid_uniform_page_size_bytes = 1 << 20
+
+        with patch(
+                "tpu_inference.runner.kv_cache_manager.utils.hbm_usage_bytes",
+                side_effect=RuntimeError("no devices")):
+            self.runner.cache_config.num_gpu_blocks_override = None
+            self.runner.scheduler_config = MagicMock(max_num_seqs=256)
+            self.runner.max_num_reqs = 256
+            manager._maybe_set_compact_mamba_num_blocks_override(
+                attn_page_size_bytes=1 << 20,
+                unpadded_mamba_page_size_bytes=4 << 20,
+                num_attn_groups=1,
+                num_mamba_groups=3,
+                num_attn_layers=15,
+                num_mamba_layers=45,
+                group_size=15,
+            )
+
+        assert manager._mamba_num_blocks is None
+        assert self.runner.cache_config.num_gpu_blocks_override is None
+
+    def test_compact_mamba_override_respects_user_override(self):
+        """If the user already set num_gpu_blocks_override, compact path
+        must not clobber it."""
+        from tpu_inference.runner.kv_cache_manager import KVCacheManager
+
+        manager = KVCacheManager(self.runner)
+        manager.use_mla = False
+        manager._hybrid_uniform_page_size_bytes = 1 << 20
+
+        with patch(
+                "tpu_inference.runner.kv_cache_manager.utils.hbm_usage_bytes",
+                return_value=[(0, 304 * (1 << 30) // 4)] * 4):
+            self.runner.cache_config.num_gpu_blocks_override = 999
+            self.runner.scheduler_config = MagicMock(max_num_seqs=256)
+            self.runner.max_num_reqs = 256
+            manager._maybe_set_compact_mamba_num_blocks_override(
+                attn_page_size_bytes=1 << 20,
+                unpadded_mamba_page_size_bytes=4 << 20,
+                num_attn_groups=1,
+                num_mamba_groups=3,
+                num_attn_layers=15,
+                num_mamba_layers=45,
+                group_size=15,
+            )
+
+        # User's override must survive untouched and we must skip the
+        # compact path so initialize_kv_cache uses legacy sizing.
+        assert manager._mamba_num_blocks is None
+        assert self.runner.cache_config.num_gpu_blocks_override == 999
+
     def test_get_kv_cache_spec_pure_attention_no_cache_config_updates(self):
         mock_attn = MagicMock(spec=MambaBase)
         layers = {'layer.0': mock_attn}

--- a/tests/runner/test_kv_cache_manager.py
+++ b/tests/runner/test_kv_cache_manager.py
@@ -917,112 +917,115 @@ class TestKVCacheManager:
                 f"layer {name} has page_size_bytes={spec.page_size_bytes} "
                 f"but expected uniform={expected_uniform}")
 
-    def test_compact_mamba_override_caps_mamba_and_grows_attn(self):
-        """Compact-mamba: with HBM available, mamba should be capped at
-        max_num_reqs+1 (rounded to divisor) and num_gpu_blocks_override
-        should grow beyond what the legacy single-num_blocks path gives."""
-        from tpu_inference.runner.kv_cache_manager import KVCacheManager
+    def _run_compact_mamba_override(self,
+                                    manager,
+                                    *,
+                                    attn_page,
+                                    unpadded_mamba,
+                                    num_attn_groups=1,
+                                    num_mamba_groups=3,
+                                    num_attn_layers=15,
+                                    num_mamba_layers=45,
+                                    group_size=15):
+        """Helper: invoke `_maybe_set_compact_mamba_num_blocks_override` with
+        the Qwen3.5-shaped layer counts (15 attn + 45 mamba layers, grouped
+        into 1 attn group + 3 mamba groups, 15 layers per kv-cache group)."""
+        manager._maybe_set_compact_mamba_num_blocks_override(
+            attn_page_size_bytes=attn_page,
+            unpadded_mamba_page_size_bytes=unpadded_mamba,
+            num_attn_groups=num_attn_groups,
+            num_mamba_groups=num_mamba_groups,
+            num_attn_layers=num_attn_layers,
+            num_mamba_layers=num_mamba_layers,
+            group_size=group_size,
+        )
 
+    def test_compact_mamba_override_caps_mamba_at_max_num_reqs(self):
+        """With HBM available, compact-mamba caps each mamba layer at
+        `max_num_reqs + 1` slots (rounded up to the sharding divisor) and
+        sets `num_gpu_blocks_override` for the attention pool that fits
+        the remaining HBM."""
+        from tpu_inference.runner.kv_cache_manager import KVCacheManager
         manager = KVCacheManager(self.runner)
-        # Force the use_mla branch off so divisor uses ATTN_DATA.
-        manager.use_mla = False
-        # 304 GiB of available HBM, 4-device mesh — match the Qwen3.5 TP=8
-        # situation as closely as a CPU mesh allows. Returns (used, limit)
-        # per device summing to total_used=0, total_limit=304 GiB.
-        avail_per_device = 304 * (1 << 30) // 4
+        manager.use_mla = False  # divisor is computed from ATTN_DATA.
+
+        # 304 GiB across 4 mock devices (sum is total_limit).
+        avail_per_device = 304 * (2**30) // 4
+        attn_page = 2**20  # 1 MiB / block / attn layer
+        unpadded_mamba = 4 * (2**20)  # 4 MiB / slot / mamba layer
+        max_num_reqs = 256
+
+        self.runner.cache_config.gpu_memory_utilization = 1.0
+        self.runner.cache_config.num_gpu_blocks_override = None
+        self.runner.scheduler_config = MagicMock(max_num_seqs=max_num_reqs)
+        self.runner.max_num_reqs = max_num_reqs
 
         with patch(
                 "tpu_inference.runner.kv_cache_manager.utils.hbm_usage_bytes",
                 return_value=[(0, avail_per_device)] * 4):
-            self.runner.cache_config.gpu_memory_utilization = 1.0
-            self.runner.cache_config.num_gpu_blocks_override = None
-            # Pretend the model wants 256 max in-flight requests; mamba
-            # should be capped at 257 (rounded up to divisor=1).
-            self.runner.scheduler_config = MagicMock(max_num_seqs=256)
-            self.runner.max_num_reqs = 256
-            # Big mamba (4 MiB / state) and modest attn page (1 MiB / block)
-            # so the compact reshuffle is a clear win.
-            attn_page = 1 << 20  # 1 MiB
-            unpadded_mamba = 4 << 20  # 4 MiB
-            # Set the state that update_mamba_page_size_padded would set if
-            # we were calling it from a real run; the compact override
-            # function reads `_hybrid_uniform_page_size_bytes` for its
-            # legacy-comparison sanity check.
-            uniform = attn_page + 3 * unpadded_mamba
-            manager._hybrid_uniform_page_size_bytes = uniform
-            manager._maybe_set_compact_mamba_num_blocks_override(
-                attn_page_size_bytes=attn_page,
-                unpadded_mamba_page_size_bytes=unpadded_mamba,
-                num_attn_groups=1,
-                num_mamba_groups=3,
-                num_attn_layers=15,
-                num_mamba_layers=45,
-                group_size=15,
-            )
+            self._run_compact_mamba_override(manager,
+                                             attn_page=attn_page,
+                                             unpadded_mamba=unpadded_mamba)
 
-        assert manager._mamba_num_blocks == 257
-        assert self.runner.cache_config.num_gpu_blocks_override is not None
-        # Attention pool must beat the legacy single-num_blocks calc — the
-        # whole point of the optimization. Quick sanity:
-        # legacy = avail / (uniform × group_size).
-        legacy = (304 * (1 << 30)) // (uniform * 15)
-        assert self.runner.cache_config.num_gpu_blocks_override > legacy
+        # Mamba is capped at max_num_reqs + 1 (the +1 is the null block).
+        assert manager._mamba_num_blocks == max_num_reqs + 1
+        # Attention pool is sized to fill the remaining per-tensor budget.
+        # group_size=15 ⇒ avail_per_tensor = 304 GiB / 15.
+        # mamba_per_tensor = 3 × 257 × 4 MiB.
+        # attn_per_tensor = avail_per_tensor − mamba_per_tensor.
+        # N_attn = attn_per_tensor / (1 × 1 MiB), divisor=1.
+        avail_per_tensor = (304 * 2**30) // 15
+        expected_attn = (avail_per_tensor - 3 *
+                         (max_num_reqs + 1) * unpadded_mamba) // attn_page
+        assert (
+            self.runner.cache_config.num_gpu_blocks_override == expected_attn)
 
-    def test_compact_mamba_override_falls_back_when_hbm_unreadable(self):
-        """If hbm_usage_bytes raises (e.g., on CPU), compact override is a
-        no-op and the legacy path takes over."""
+    def test_compact_mamba_override_skipped_when_hbm_probe_fails(self):
+        """`hbm_usage_bytes` raises on CPU-only test machines (no real
+        devices to query). Compact-mamba must skip the override silently —
+        no `_mamba_num_blocks`, no `num_gpu_blocks_override` — so vLLM
+        keeps its uniform sizing. The page-size padding done elsewhere
+        still keeps per-layer block IDs in range."""
         from tpu_inference.runner.kv_cache_manager import KVCacheManager
-
         manager = KVCacheManager(self.runner)
         manager.use_mla = False
-        manager._hybrid_uniform_page_size_bytes = 1 << 20
+        manager._hybrid_uniform_page_size_bytes = 2**20
+
+        self.runner.cache_config.num_gpu_blocks_override = None
+        self.runner.scheduler_config = MagicMock(max_num_seqs=256)
+        self.runner.max_num_reqs = 256
 
         with patch(
                 "tpu_inference.runner.kv_cache_manager.utils.hbm_usage_bytes",
                 side_effect=RuntimeError("no devices")):
-            self.runner.cache_config.num_gpu_blocks_override = None
-            self.runner.scheduler_config = MagicMock(max_num_seqs=256)
-            self.runner.max_num_reqs = 256
-            manager._maybe_set_compact_mamba_num_blocks_override(
-                attn_page_size_bytes=1 << 20,
-                unpadded_mamba_page_size_bytes=4 << 20,
-                num_attn_groups=1,
-                num_mamba_groups=3,
-                num_attn_layers=15,
-                num_mamba_layers=45,
-                group_size=15,
-            )
+            self._run_compact_mamba_override(manager,
+                                             attn_page=2**20,
+                                             unpadded_mamba=4 * 2**20)
 
         assert manager._mamba_num_blocks is None
         assert self.runner.cache_config.num_gpu_blocks_override is None
 
-    def test_compact_mamba_override_respects_user_override(self):
-        """If the user already set num_gpu_blocks_override, compact path
-        must not clobber it."""
+    def test_compact_mamba_override_respects_user_pinned_override(self):
+        """When the user pins `num_gpu_blocks_override` explicitly,
+        compact-mamba must not clobber it (their explicit choice wins)."""
         from tpu_inference.runner.kv_cache_manager import KVCacheManager
-
         manager = KVCacheManager(self.runner)
         manager.use_mla = False
-        manager._hybrid_uniform_page_size_bytes = 1 << 20
+        manager._hybrid_uniform_page_size_bytes = 2**20
+
+        self.runner.cache_config.num_gpu_blocks_override = 999
+        self.runner.scheduler_config = MagicMock(max_num_seqs=256)
+        self.runner.max_num_reqs = 256
 
         with patch(
                 "tpu_inference.runner.kv_cache_manager.utils.hbm_usage_bytes",
-                return_value=[(0, 304 * (1 << 30) // 4)] * 4):
-            self.runner.cache_config.num_gpu_blocks_override = 999
-            self.runner.scheduler_config = MagicMock(max_num_seqs=256)
-            self.runner.max_num_reqs = 256
-            manager._maybe_set_compact_mamba_num_blocks_override(
-                attn_page_size_bytes=1 << 20,
-                unpadded_mamba_page_size_bytes=4 << 20,
-                num_attn_groups=1,
-                num_mamba_groups=3,
-                num_attn_layers=15,
-                num_mamba_layers=45,
-                group_size=15,
-            )
+                return_value=[(0, 304 * (2**30) // 4)] * 4):
+            self._run_compact_mamba_override(manager,
+                                             attn_page=2**20,
+                                             unpadded_mamba=4 * 2**20)
 
-        # User's override must survive untouched and we must skip the
-        # compact path so initialize_kv_cache uses legacy sizing.
+        # User's override survives; mamba sizing is left alone so
+        # `initialize_kv_cache` allocates the uniform `num_blocks`.
         assert manager._mamba_num_blocks is None
         assert self.runner.cache_config.num_gpu_blocks_override == 999
 

--- a/tests/runner/test_tpu_runner.py
+++ b/tests/runner/test_tpu_runner.py
@@ -156,6 +156,11 @@ class TestTPUJaxRunner:
         self.runner.input_batch.num_computed_tokens_cpu = np.array([10])
         self.runner.input_batch.token_ids_cpu = np.random.randint(
             0, 1000, (8, 64), dtype=np.int32)
+        # Concrete numpy array so `.copy()` returns a real ndarray
+        # (otherwise the surrounding `device_array` introspection on
+        # `MagicMock` recurses on every `dtype` access).
+        self.runner.input_batch.mamba_state_indices_cpu = np.zeros(
+            self.runner.max_num_reqs, dtype=np.int32)
 
         # Mock block tables
         # there will be 2 block tables since there are 2 kv cache groups

--- a/tpu_inference/envs.py
+++ b/tpu_inference/envs.py
@@ -50,7 +50,6 @@ if TYPE_CHECKING:
     TPU_OFFLOAD_SAVE_THREADS: int = 1
     TPU_OFFLOAD_BATCHED_SAVE: bool = False
     TPU_OFFLOAD_METRICS_LOG_INTERVAL: int = 5
-    COMPACT_MAMBA_KV_CACHE: bool = True
 
 
 def env_with_choices(
@@ -282,14 +281,6 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # kv offload to dram: prometheus metrics log interval in seconds
     "TPU_OFFLOAD_METRICS_LOG_INTERVAL":
     lambda: int(os.getenv("TPU_OFFLOAD_METRICS_LOG_INTERVAL", "10")),
-    # Cap mamba layer allocation at `max_num_seqs+1` slots and redirect freed
-    # HBM into more attention blocks. Mamba state is recurrent (one slot per
-    # active request), so allocating num_blocks slots wastes most of them.
-    # Big throughput win on hybrid attn+mamba models like Qwen3.5. Disable
-    # only if you hit a regression that traces back to this.
-    "COMPACT_MAMBA_KV_CACHE":
-    lambda: os.getenv("COMPACT_MAMBA_KV_CACHE", "1") not in
-    ("0", "false", "False"),
 }
 
 

--- a/tpu_inference/envs.py
+++ b/tpu_inference/envs.py
@@ -50,6 +50,7 @@ if TYPE_CHECKING:
     TPU_OFFLOAD_SAVE_THREADS: int = 1
     TPU_OFFLOAD_BATCHED_SAVE: bool = False
     TPU_OFFLOAD_METRICS_LOG_INTERVAL: int = 5
+    COMPACT_MAMBA_KV_CACHE: bool = True
 
 
 def env_with_choices(
@@ -281,6 +282,14 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # kv offload to dram: prometheus metrics log interval in seconds
     "TPU_OFFLOAD_METRICS_LOG_INTERVAL":
     lambda: int(os.getenv("TPU_OFFLOAD_METRICS_LOG_INTERVAL", "10")),
+    # Cap mamba layer allocation at `max_num_seqs+1` slots and redirect freed
+    # HBM into more attention blocks. Mamba state is recurrent (one slot per
+    # active request), so allocating num_blocks slots wastes most of them.
+    # Big throughput win on hybrid attn+mamba models like Qwen3.5. Disable
+    # only if you hit a regression that traces back to this.
+    "COMPACT_MAMBA_KV_CACHE":
+    lambda: os.getenv("COMPACT_MAMBA_KV_CACHE", "1") not in
+    ("0", "false", "False"),
 }
 
 

--- a/tpu_inference/layers/common/attention_metadata.py
+++ b/tpu_inference/layers/common/attention_metadata.py
@@ -45,9 +45,13 @@ class AttentionMetadata(object):
     query_start_loc: jax.Array = None
     # (3,)
     request_distribution: jax.Array = None
-    # (max_num_seqs,) int32 — per-request physical mamba slot id; stable
-    # across condense moves. Only consumed by hybrid attn+mamba models
-    # (e.g. Qwen3.5); None for pure-attention models.
+    # (max_num_seqs,) int32 — physical slot id (∈ [0, _mamba_num_blocks))
+    # in the mamba kv-cache for the request currently in each persistent-
+    # batch position. Used by mamba/GDN ops to read/write recurrent state
+    # without going through `block_tables`, since the mamba pool is
+    # smaller than the attention pool under compact-mamba sizing.
+    # None for models without mamba layers; pure-mamba models would also
+    # use this field, only hybrid models exercise it today.
     mamba_state_indices: jax.Array | None = None
 
     query_start_loc_cpu: Any = field(init=False)

--- a/tpu_inference/layers/common/attention_metadata.py
+++ b/tpu_inference/layers/common/attention_metadata.py
@@ -27,6 +27,7 @@ import jax
         "seq_lens",
         "query_start_loc",
         "request_distribution",
+        "mamba_state_indices",
     ],
     meta_fields=[],
     drop_fields=["query_start_loc_cpu", "seq_lens_cpu"],
@@ -44,6 +45,10 @@ class AttentionMetadata(object):
     query_start_loc: jax.Array = None
     # (3,)
     request_distribution: jax.Array = None
+    # (max_num_seqs,) int32 — per-request physical mamba slot id; stable
+    # across condense moves. Only consumed by hybrid attn+mamba models
+    # (e.g. Qwen3.5); None for pure-attention models.
+    mamba_state_indices: jax.Array | None = None
 
     query_start_loc_cpu: Any = field(init=False)
     seq_lens_cpu: Any = field(init=False)

--- a/tpu_inference/layers/vllm/custom_ops/gdn_attention_op.py
+++ b/tpu_inference/layers/vllm/custom_ops/gdn_attention_op.py
@@ -93,17 +93,19 @@ def gdn_attention_core_tpu(
     layer_idx = vllm_context.layer_name_to_kvcache_index[layer_name]
     conv_state, recurrent_state = vllm_context.kv_caches[layer_idx]
 
-    # Index mamba state by the per-request slot id maintained by
-    # `InputBatch.mamba_state_indices_cpu`, **not** by the persistent-batch
-    # position. The two diverge whenever `condense` shuffles requests
-    # between persistent-batch slots: the slot id stays with the request
-    # so the kernel still reads/writes its real state, while the
-    # persistent-batch position is reused by some other (or no) request.
+    # Index mamba state by the per-request slot id from
+    # `InputBatch.mamba_state_indices_cpu`, not by `block_tables[:, 0]`
+    # (vLLM's GPU convention). Two reasons:
     #
-    # We can't use `block_tables[:, 0]` (vLLM's GPU convention) because
-    # `_maybe_set_compact_mamba_num_blocks_override` caps the mamba pool
-    # at `max_num_seqs + 1` while the attention pool is much larger, so
-    # vLLM-allocated block IDs would walk off the end of the mamba arrays.
+    #  1. `_maybe_set_compact_mamba_num_blocks_override` caps the mamba
+    #     pool at `max_num_seqs + 1` while the attention pool is much
+    #     larger; using `block_tables[:, 0]` (a value in the attention
+    #     range) would walk off the end of the mamba arrays.
+    #  2. When vLLM's input batch runs `condense` to compact the persistent
+    #     batch (https://github.com/vllm-project/vllm/blob/de3da0b/vllm/v1/worker/gpu_input_batch.py#L662 — moves
+    #     requests into lower-index slots after earlier ones finish), the
+    #     slot id moves with the request so the kernel still reads/writes
+    #     the slot that holds this request's real state.
     state_indices = jax_view(attn_metadata.mamba_state_indices).astype(
         jnp.int32)
 

--- a/tpu_inference/layers/vllm/custom_ops/gdn_attention_op.py
+++ b/tpu_inference/layers/vllm/custom_ops/gdn_attention_op.py
@@ -93,13 +93,19 @@ def gdn_attention_core_tpu(
     layer_idx = vllm_context.layer_name_to_kvcache_index[layer_name]
     conv_state, recurrent_state = vllm_context.kv_caches[layer_idx]
 
-    # Map physical cache blocks
-    flat_block_tables = jax_view(attn_metadata.block_tables)
-    max_reqs = attn_metadata.seq_lens.shape[0]
-    max_blocks_per_req = flat_block_tables.shape[0] // max_reqs
-    block_tables_2d = jnp.reshape(flat_block_tables,
-                                  (max_reqs, max_blocks_per_req))
-    state_indices = block_tables_2d[:, 0].astype(jnp.int32)
+    # Index mamba state by the per-request slot id maintained by
+    # `InputBatch.mamba_state_indices_cpu`, **not** by the persistent-batch
+    # position. The two diverge whenever `condense` shuffles requests
+    # between persistent-batch slots: the slot id stays with the request
+    # so the kernel still reads/writes its real state, while the
+    # persistent-batch position is reused by some other (or no) request.
+    #
+    # We can't use `block_tables[:, 0]` (vLLM's GPU convention) because
+    # `_maybe_set_compact_mamba_num_blocks_override` caps the mamba pool
+    # at `max_num_seqs + 1` while the attention pool is much larger, so
+    # vLLM-allocated block IDs would walk off the end of the mamba arrays.
+    state_indices = jax_view(attn_metadata.mamba_state_indices).astype(
+        jnp.int32)
 
     # Map tokens to their respective requests
     q_loc = jax_view(attn_metadata.query_start_loc)

--- a/tpu_inference/runner/compilation_manager.py
+++ b/tpu_inference/runner/compilation_manager.py
@@ -197,13 +197,18 @@ class CompilationManager:
         request_distribution = device_array(self.runner.mesh,
                                             request_distribution,
                                             sharding=dp_sharding)
-        # Dummy mamba_state_indices for compile-cache pre-tracing. Shape
-        # must match what `_prepare_inputs_*` produces at runtime so the
-        # JAX cache hits when the GDN op pulls this from `attn_metadata`.
-        mamba_state_indices = device_array(self.runner.mesh,
-                                           np.zeros(self.runner.max_num_reqs,
-                                                    dtype=np.int32),
-                                           sharding=dp_sharding)
+        # Dummy mamba_state_indices for compile-cache pre-tracing. Only
+        # populate for hybrid attn+mamba models — for pure-attention models we
+        # pass None at runtime (see `_prepare_inputs_*`), and the precompile
+        # primer must match that shape so the cached HLO is reused.
+        if self.runner.kv_cache_config.has_mamba_layers:
+            mamba_state_indices = device_array(self.runner.mesh,
+                                               np.zeros(
+                                                   self.runner.max_num_reqs,
+                                                   dtype=np.int32),
+                                               sharding=dp_sharding)
+        else:
+            mamba_state_indices = None
 
         def build_block_table(kv_cache_gid: int) -> jax.Array:
             block_table_obj = self.runner.input_batch.block_table[kv_cache_gid]
@@ -775,14 +780,18 @@ class CompilationManager:
         # Dummy mamba_state_indices for spec-decode compile-cache pre-tracing.
         # Must match the ATTN_DATA sharding `_prepare_inputs_*` produces at
         # runtime — otherwise the draft model_fn cache misses and the
-        # ForbidCompile guard inside `Eagle3Proposer.propose` raises.
-        dp_sharding = NamedSharding(
-            self.runner.mesh, PartitionSpec(ShardingAxisName.ATTN_DATA, ))
-        eagle3_mamba_state_indices = device_array(self.runner.mesh,
-                                                  np.zeros(
-                                                      self.runner.max_num_reqs,
-                                                      dtype=np.int32),
-                                                  sharding=dp_sharding)
+        # ForbidCompile guard inside `Eagle3Proposer.propose` raises. None for
+        # pure-attention models (the common eagle3 case) so the field stays
+        # absent end-to-end.
+        if self.runner.kv_cache_config.has_mamba_layers:
+            dp_sharding = NamedSharding(
+                self.runner.mesh, PartitionSpec(ShardingAxisName.ATTN_DATA, ))
+            eagle3_mamba_state_indices = device_array(
+                self.runner.mesh,
+                np.zeros(self.runner.max_num_reqs, dtype=np.int32),
+                sharding=dp_sharding)
+        else:
+            eagle3_mamba_state_indices = None
 
         for num_reqs_padding in self.runner.num_reqs_paddings:
             for i in range(1, self.runner.drafter.num_speculative_tokens + 1):

--- a/tpu_inference/runner/compilation_manager.py
+++ b/tpu_inference/runner/compilation_manager.py
@@ -773,9 +773,16 @@ class CompilationManager:
         request_distribution = device_array(self.runner.mesh,
                                             request_distribution)
         # Dummy mamba_state_indices for spec-decode compile-cache pre-tracing.
-        eagle3_mamba_state_indices = device_array(
-            self.runner.mesh, np.zeros(self.runner.max_num_reqs,
-                                       dtype=np.int32))
+        # Must match the ATTN_DATA sharding `_prepare_inputs_*` produces at
+        # runtime — otherwise the draft model_fn cache misses and the
+        # ForbidCompile guard inside `Eagle3Proposer.propose` raises.
+        dp_sharding = NamedSharding(
+            self.runner.mesh, PartitionSpec(ShardingAxisName.ATTN_DATA, ))
+        eagle3_mamba_state_indices = device_array(self.runner.mesh,
+                                                  np.zeros(
+                                                      self.runner.max_num_reqs,
+                                                      dtype=np.int32),
+                                                  sharding=dp_sharding)
 
         for num_reqs_padding in self.runner.num_reqs_paddings:
             for i in range(1, self.runner.drafter.num_speculative_tokens + 1):

--- a/tpu_inference/runner/compilation_manager.py
+++ b/tpu_inference/runner/compilation_manager.py
@@ -197,6 +197,13 @@ class CompilationManager:
         request_distribution = device_array(self.runner.mesh,
                                             request_distribution,
                                             sharding=dp_sharding)
+        # Dummy mamba_state_indices for compile-cache pre-tracing. Shape
+        # must match what `_prepare_inputs_*` produces at runtime so the
+        # JAX cache hits when the GDN op pulls this from `attn_metadata`.
+        mamba_state_indices = device_array(self.runner.mesh,
+                                           np.zeros(self.runner.max_num_reqs,
+                                                    dtype=np.int32),
+                                           sharding=dp_sharding)
 
         def build_block_table(kv_cache_gid: int) -> jax.Array:
             block_table_obj = self.runner.input_batch.block_table[kv_cache_gid]
@@ -216,6 +223,7 @@ class CompilationManager:
                 seq_lens=seq_lens,
                 query_start_loc=query_start_loc,
                 request_distribution=request_distribution,
+                mamba_state_indices=mamba_state_indices,
             )
             return attention_metadata_gid
 
@@ -764,6 +772,10 @@ class CompilationManager:
         request_distribution = np.array([0, 0, 0], dtype=np.int32)
         request_distribution = device_array(self.runner.mesh,
                                             request_distribution)
+        # Dummy mamba_state_indices for spec-decode compile-cache pre-tracing.
+        eagle3_mamba_state_indices = device_array(
+            self.runner.mesh, np.zeros(self.runner.max_num_reqs,
+                                       dtype=np.int32))
 
         for num_reqs_padding in self.runner.num_reqs_paddings:
             for i in range(1, self.runner.drafter.num_speculative_tokens + 1):
@@ -818,6 +830,7 @@ class CompilationManager:
                 seq_lens=seq_lens,
                 query_start_loc=query_start_loc,
                 request_distribution=request_distribution,
+                mamba_state_indices=eagle3_mamba_state_indices,
             )
 
             def filter_token_and_prepare_initial_inputs_wrapper(

--- a/tpu_inference/runner/input_batch.py
+++ b/tpu_inference/runner/input_batch.py
@@ -134,6 +134,21 @@ class InputBatch:
 
         self.request_distribution: list[int] = [0, 0, 0]
 
+        # Mamba slot tracking for hybrid attn+mamba models. Each request gets
+        # a unique mamba state slot id when it enters the batch and keeps it
+        # for the request's lifetime. The mapping `req_idx -> mamba_slot_id`
+        # is stored in `mamba_state_indices_cpu`. Why: vLLM's `condense` moves
+        # a request's persistent-batch slot, but the mamba recurrent state in
+        # the kv cache stays at its physical slot id. Indexing the cache by
+        # the (moving) persistent-batch slot reads stale data; indexing by the
+        # (stable) mamba_slot_id reads the right state. The pool size matches
+        # the compact-mamba allocation in `_maybe_set_compact_mamba_num_blocks_override`
+        # (`max_num_reqs + 1`); slot 0 is the null block, real slots are
+        # [1, max_num_reqs].
+        self.mamba_state_indices_cpu = np.zeros(max_num_reqs, dtype=np.int32)
+        self._free_mamba_slots: list[int] = list(range(
+            max_num_reqs, 0, -1))  # pop from end → low slots first
+
         # for pooling models
         self.pooling_params: dict[str, PoolingParams] = {}
         self.pooling_states: dict[str, PoolingStates] = {}
@@ -204,6 +219,10 @@ class InputBatch:
 
         self.num_computed_tokens_cpu[req_index] = request.num_computed_tokens
         self.block_table.add_row(request.block_ids, req_index)
+        # Allocate a fresh mamba state slot for this request. The slot stays
+        # with the request through the persistent batch's lifetime, even when
+        # condense moves the request to a different `req_index`.
+        self.mamba_state_indices_cpu[req_index] = self._free_mamba_slots.pop()
 
         # NOTE(woosuk): self.generators should not include the requests that
         # do not have their own generator.
@@ -283,6 +302,11 @@ class InputBatch:
             return None
         self._req_ids[req_index] = None
         self.req_output_token_ids[req_index] = None
+        # Return the mamba state slot back to the free pool. The slot's
+        # contents in the kv cache are stale and will be zeroed by the
+        # has_initial_state guard when the next request takes this slot id.
+        self._free_mamba_slots.append(
+            int(self.mamba_state_indices_cpu[req_index]))
 
         self.greedy_reqs.discard(req_id)
         self.random_reqs.discard(req_id)
@@ -357,6 +381,11 @@ class InputBatch:
                 self.allowed_token_ids_mask_cpu[i2], \
                     self.allowed_token_ids_mask_cpu[i1]
         self.block_table.swap_row(i1, i2)
+        # The mamba state slot id is per-request and must follow the swap.
+        self.mamba_state_indices_cpu[i1], self.mamba_state_indices_cpu[i2] = (
+            self.mamba_state_indices_cpu[i2],
+            self.mamba_state_indices_cpu[i1],
+        )
 
     def condense(self, empty_req_indices: list[int]) -> None:
         num_reqs = self.num_reqs
@@ -400,6 +429,12 @@ class InputBatch:
             self.num_computed_tokens_cpu[
                 empty_index] = self.num_computed_tokens_cpu[last_req_index]
             self.block_table.move_row(last_req_index, empty_index)
+            # The mamba state slot id is per-request: when the persistent
+            # batch moves the request from `last_req_index` to `empty_index`,
+            # the slot id must follow it so subsequent steps still index
+            # the right physical slot in the mamba kv cache.
+            self.mamba_state_indices_cpu[
+                empty_index] = self.mamba_state_indices_cpu[last_req_index]
             self.temperature_cpu[empty_index] = self.temperature_cpu[
                 last_req_index]
             self.top_p_cpu[empty_index] = self.top_p_cpu[last_req_index]

--- a/tpu_inference/runner/input_batch.py
+++ b/tpu_inference/runner/input_batch.py
@@ -134,17 +134,20 @@ class InputBatch:
 
         self.request_distribution: list[int] = [0, 0, 0]
 
-        # Mamba slot tracking for hybrid attn+mamba models. Each request gets
-        # a unique mamba state slot id when it enters the batch and keeps it
-        # for the request's lifetime. The mapping `req_idx -> mamba_slot_id`
-        # is stored in `mamba_state_indices_cpu`. Why: vLLM's `condense` moves
-        # a request's persistent-batch slot, but the mamba recurrent state in
-        # the kv cache stays at its physical slot id. Indexing the cache by
-        # the (moving) persistent-batch slot reads stale data; indexing by the
-        # (stable) mamba_slot_id reads the right state. The pool size matches
-        # the compact-mamba allocation in `_maybe_set_compact_mamba_num_blocks_override`
-        # (`max_num_reqs + 1`); slot 0 is the null block, real slots are
-        # [1, max_num_reqs].
+        # Per-request physical slot id in the mamba kv-cache. Each request
+        # gets a unique slot at `add_request` and keeps it for its lifetime
+        # (slot ids follow the request through `condense` and `swap_states`,
+        # see those methods below). Real slots are [1, max_num_reqs]; slot 0
+        # is reserved as the null block. Why we track slot ids separately
+        # from the persistent-batch position `req_idx`: `condense`
+        # (https://github.com/vllm-project/vllm/blob/de3da0b/vllm/v1/worker/gpu_input_batch.py#L662)
+        # moves requests into lower `req_idx` slots when earlier requests
+        # finish, but the mamba recurrent state stays at its allocated
+        # physical slot. Indexing the cache by the moving `req_idx` would
+        # read stale state; indexing by `mamba_state_indices_cpu[req_idx]`
+        # reads the slot that actually holds this request's state.
+        # Pool size matches `_maybe_set_compact_mamba_num_blocks_override`'s
+        # cap of `max_num_reqs + 1`.
         self.mamba_state_indices_cpu = np.zeros(max_num_reqs, dtype=np.int32)
         self._free_mamba_slots: list[int] = list(range(
             max_num_reqs, 0, -1))  # pop from end → low slots first

--- a/tpu_inference/runner/kv_cache_manager.py
+++ b/tpu_inference/runner/kv_cache_manager.py
@@ -31,6 +31,7 @@ from vllm.v1.kv_cache_interface import (FullAttentionSpec, KVCacheConfig,
                                         KVCacheSpec, MambaSpec,
                                         MLAAttentionSpec, SlidingWindowSpec)
 
+from tpu_inference import envs as tpu_envs
 from tpu_inference import utils
 from tpu_inference import utils as common_utils
 from tpu_inference.layers.common.sharding import ShardingAxisName
@@ -70,6 +71,16 @@ class KVCacheManager:
         # on the TPU side (where we duplicate the shared tensor per layer
         # because mamba and attention caches have different shapes).
         self._hybrid_uniform_page_size_bytes: int | None = None
+        # Mamba leading-dim cap for hybrid models. Mamba state is recurrent
+        # (one slot per active request), so allocating `num_blocks` slots per
+        # mamba layer wastes most of them — only `max_num_seqs` are ever live
+        # at once. When this is set, `initialize_kv_cache` allocates this many
+        # slots for each mamba layer instead of `num_blocks`, freeing HBM that
+        # `update_mamba_page_size_padded` then redirects into more attention
+        # blocks (raising `num_gpu_blocks_override`). The GDN op compensates
+        # by indexing into the smaller mamba arrays with `req_idx` instead of
+        # the (now-larger) block-table block IDs — see `gdn_attention_op`.
+        self._mamba_num_blocks: int | None = None
 
     def _create_attention_spec(
             self,
@@ -252,17 +263,200 @@ class KVCacheManager:
         self.runner.cache_config.mamba_page_size_padded = int(
             uniform_page_size_bytes)
 
-        # Pin vLLM's num_blocks via a two-step flooring that keeps peak
-        # HBM within `gpu_memory_utilization × total_hbm` at high
-        # utilization. See `_maybe_set_num_blocks_override` for the
-        # formula and rationale; the short version is that vLLM's
-        # single-step `floor(avail / (uniform × group_size))` can land
-        # one block higher than the two-step value, and that extra
-        # block × group_size × uniform bytes is enough to push past the
-        # budget against imprecision in vLLM's `avail` estimate.
+        # Pin vLLM's num_blocks. Two cases:
+        #  (a) compact-mamba: cap each mamba layer at `max_num_seqs+1` slots
+        #      (one per active request, plus the null block) and redirect the
+        #      freed HBM into more attention blocks. This is the common path
+        #      and gives a substantial throughput win on hybrid models where
+        #      mamba layers dominate the per-block footprint (e.g., Qwen3.5
+        #      where each block currently spends ~50% of its bytes on mamba
+        #      state that is never indexed past `max_num_seqs`).
+        #  (b) legacy: keep TPU and vLLM's num_blocks identical (the original
+        #      OOB fix). Used when compact-mamba is disabled or the avail
+        #      memory probe fails (e.g., in tests without real devices).
+        if tpu_envs.COMPACT_MAMBA_KV_CACHE:
+            self._maybe_set_compact_mamba_num_blocks_override(
+                attn_page_size_bytes, int(unpadded_mamba_page_size),
+                num_attn_groups, num_mamba_groups, num_attn, num_mamba,
+                group_size)
+            if self._mamba_num_blocks is not None:
+                # Successfully sized mamba compactly. Done.
+                return
+
         self._maybe_set_num_blocks_override(attn_page_size_bytes,
                                             int(uniform_page_size_bytes),
                                             group_size)
+
+    def _maybe_set_compact_mamba_num_blocks_override(
+            self, attn_page_size_bytes: int,
+            unpadded_mamba_page_size_bytes: int, num_attn_groups: int,
+            num_mamba_groups: int, num_attn_layers: int, num_mamba_layers: int,
+            group_size: int) -> None:
+        """Cap mamba allocation at `max_num_seqs+1` slots, redirect freed HBM
+        into more attention blocks, and pin `num_gpu_blocks_override` to the
+        resulting attention pool size.
+
+        Why this is a big win
+        ---------------------
+        Mamba state is recurrent: one slot per *active request* per layer,
+        independent of context length. With Qwen3.5 (15 attn + 45 mamba
+        layers) the legacy code allocates `num_blocks` mamba slots per layer
+        even though only ~`max_num_seqs` are ever live at once. On TP=8
+        with 307 GiB available, that wastes ~80 GiB on mamba slots that
+        will never be addressed. Folded back into attention, those bytes
+        buy ~1.6× the attention block pool — roughly a 60% jump in the
+        steady-state concurrent-request count, which is the dominant
+        throughput driver at high concurrency.
+
+        How it stays correct
+        --------------------
+        vLLM still hands out block IDs from a single shared pool of size
+        `num_gpu_blocks_override`, but on TPU we allocate only
+        `_mamba_num_blocks` slots per mamba layer. Indexing a smaller array
+        with a possibly-large block ID would walk off the end. The GDN op
+        avoids this by indexing mamba state with `req_idx` (the position
+        in the persistent batch, ∈ [0, max_num_reqs)) instead of the
+        block-table value — each persistent-batch slot owns a dedicated
+        mamba slot for its lifetime.
+
+        Sizing math
+        -----------
+        Each `KVCacheTensor` is shared across one layer from each kv-cache
+        group (`num_attn_groups + num_mamba_groups` layers per tensor) and
+        there are `group_size` such tensors. Total HBM:
+
+          avail = group_size × (num_attn_groups × N_attn × attn_page
+                                + num_mamba_groups × N_mamba × mamba_unpadded)
+
+        We fix `N_mamba = max_num_seqs + 1` (one per request plus a null
+        block), then solve for `N_attn`:
+
+          N_attn = floor((avail/group_size
+                          - num_mamba_groups × N_mamba × mamba_unpadded)
+                         / (num_attn_groups × attn_page))
+
+        and round down to a multiple of the sharding divisor.
+
+        Skipped if HBM usage isn't readable (tests w/o real devices) or if
+        the user has explicitly set `num_gpu_blocks_override`. Falls back
+        to the legacy two-step floor in those cases.
+
+        Args:
+            attn_page_size_bytes: TPU-actual bytes per block per attention
+                layer (accounts for dtype packing like fp8).
+            unpadded_mamba_page_size_bytes: bytes per mamba state per layer
+                (`prod(shape) × dtype_size`, no padding).
+            num_attn_groups: vLLM kv-cache groups containing attention
+                layers.
+            num_mamba_groups: vLLM kv-cache groups containing mamba layers.
+            num_attn_layers: total attention layers in the model.
+            num_mamba_layers: total mamba layers in the model.
+            group_size: layers per kv-cache group (= number of
+                `KVCacheTensor`s; vLLM pads short groups up to this).
+
+        Returns:
+            None. Side effects on success: sets
+            `cache_config.num_gpu_blocks_override` and `_mamba_num_blocks`
+            so `initialize_kv_cache` allocates the compact mamba arrays.
+            On failure (no override possible), leaves both unset and
+            returns; the caller falls back to the legacy override path.
+        """
+        cache_config = self.runner.cache_config
+        if cache_config.num_gpu_blocks_override is not None:
+            return
+
+        devices = self.runner.mesh.devices.flatten()
+        try:
+            hbm_usage = utils.hbm_usage_bytes(devices)
+        except Exception as exc:  # noqa: BLE001
+            logger.debug(
+                "Skipping compact-mamba override: hbm_usage_bytes failed "
+                "(%s). Falling back to legacy override.", exc)
+            return
+
+        total_limit = sum(limit for _, limit in hbm_usage)
+        total_used = sum(used for used, _ in hbm_usage)
+        gpu_mem_util = cache_config.gpu_memory_utilization
+        avail = int(total_limit * gpu_mem_util - total_used)
+        if avail <= 0:
+            return
+
+        # Sharding divisor: num_blocks for each layer must be a multiple of
+        # the per-axis device count so JAX shardings don't round up. MLA
+        # uses MLP_TENSOR; everything else uses ATTN_DATA. Match
+        # `initialize_kv_cache`.
+        if self.use_mla and not self.runner.vllm_config.additional_config.get(
+                "sharding", {}).get("sharding_strategy", {}).get(
+                    "enable_dp_attention", False):
+            divisor = common_utils.get_mesh_shape_product(
+                self.runner.mesh, ShardingAxisName.MLP_TENSOR)
+        else:
+            divisor = common_utils.get_mesh_shape_product(
+                self.runner.mesh, ShardingAxisName.ATTN_DATA)
+        if divisor <= 0:
+            divisor = 1
+
+        # Mamba slot budget: enough for every persistent-batch slot the
+        # runner is sized for, plus one null block, rounded up to the
+        # sharding divisor. `runner.max_num_reqs` already accounts for DP
+        # (= dp_size × scheduler_config.max_num_seqs) so the GDN op's
+        # `state_indices = arange(max_reqs)` is guaranteed in-bounds.
+        mamba_num_blocks = self.runner.max_num_reqs + 1
+        mamba_num_blocks = (
+            (mamba_num_blocks + divisor - 1) // divisor) * divisor
+
+        # Compute attn_num_blocks that fits the remaining HBM after mamba.
+        avail_per_tensor = avail // group_size
+        mamba_per_tensor = (num_mamba_groups * mamba_num_blocks *
+                            unpadded_mamba_page_size_bytes)
+        attn_per_tensor_avail = avail_per_tensor - mamba_per_tensor
+        if attn_per_tensor_avail <= 0:
+            # Even mamba alone exceeds budget — the mamba cap is too high
+            # for this configuration. Fall back to the legacy override.
+            logger.debug(
+                "Compact-mamba override skipped: mamba_num_blocks=%d × "
+                "num_mamba_groups=%d × mamba_unpadded=%d exceeds per-tensor "
+                "budget %d. Falling back to legacy override.",
+                mamba_num_blocks, num_mamba_groups,
+                unpadded_mamba_page_size_bytes, avail_per_tensor)
+            return
+
+        attn_num_blocks = attn_per_tensor_avail // (num_attn_groups *
+                                                    attn_page_size_bytes)
+        attn_num_blocks = (attn_num_blocks // divisor) * divisor
+        if attn_num_blocks <= 0:
+            return
+
+        # Sanity check: redirecting HBM into attention should be a strict
+        # win over the legacy single-num_blocks layout. If it isn't (rare
+        # corner case where the legacy num_blocks already saturates), keep
+        # the legacy path.
+        legacy_num_blocks = avail // (self._hybrid_uniform_page_size_bytes *
+                                      group_size)
+        if attn_num_blocks <= legacy_num_blocks:
+            logger.debug(
+                "Compact-mamba override skipped: attn_num_blocks=%d "
+                "<= legacy_num_blocks=%d. Falling back to legacy override.",
+                attn_num_blocks, legacy_num_blocks)
+            return
+
+        cache_config.num_gpu_blocks_override = int(attn_num_blocks)
+        self._mamba_num_blocks = int(mamba_num_blocks)
+
+        logger.info(
+            "Compact-mamba KV cache: num_gpu_blocks_override=%d (attn) and "
+            "_mamba_num_blocks=%d (vs legacy num_blocks≈%d). HBM split: "
+            "attn=%d layers × %d blocks × %d B = %.2f GiB; mamba=%d layers "
+            "× %d slots × %d B = %.2f GiB; total=%.2f GiB / avail=%.2f GiB.",
+            attn_num_blocks, mamba_num_blocks, legacy_num_blocks,
+            num_attn_layers, attn_num_blocks, attn_page_size_bytes,
+            num_attn_layers * attn_num_blocks * attn_page_size_bytes /
+            (1 << 30), num_mamba_layers, mamba_num_blocks,
+            unpadded_mamba_page_size_bytes, num_mamba_layers *
+            mamba_num_blocks * unpadded_mamba_page_size_bytes / (1 << 30),
+            (num_attn_layers * attn_num_blocks * attn_page_size_bytes +
+             num_mamba_layers * mamba_num_blocks *
+             unpadded_mamba_page_size_bytes) / (1 << 30), avail / (1 << 30))
 
     def _maybe_set_num_blocks_override(self, attn_page_size_bytes: int,
                                        uniform_page_size_bytes: int,
@@ -654,6 +848,15 @@ class KVCacheManager:
             # num_blocks must be a multiple of the sharding divisor
             num_blocks = (num_blocks // divisor) * divisor
 
+            # When compact-mamba is active, mamba layers allocate
+            # `_mamba_num_blocks` (≈ max_num_seqs+1) slots while attention
+            # layers allocate the full `num_blocks` from the (now larger)
+            # attention pool. The two values diverge here; outside compact
+            # mode they are equal and behavior is unchanged.
+            mamba_num_blocks = (self._mamba_num_blocks
+                                if self._mamba_num_blocks is not None else
+                                num_blocks)
+
             for j, layer_name in enumerate(kv_cache_tensor.shared_by):
                 layer_spec = layer_name_to_spec[layer_name]
                 if isinstance(layer_spec, MambaSpec):
@@ -661,7 +864,7 @@ class KVCacheManager:
                     for state_index, (shape, dtype) in enumerate(
                             zip(layer_spec.shapes, layer_spec.dtypes)):
                         jax_dtype = t2j_dtype(dtype)
-                        cache_shape = (num_blocks, *shape)
+                        cache_shape = (mamba_num_blocks, *shape)
                         if state_index == 0:
                             # conv_state: [num_blocks, conv_kernel_size, intermediate_size]
                             spec = PartitionSpec(ShardingAxisName.ATTN_DATA,
@@ -738,7 +941,8 @@ class KVCacheManager:
                 # if duplicate_shared_layers is False.  Otherwise, if duplicate_shared_layers
                 # is True, we should add the blocks for each layer in shared_by.
                 if j == 0 or duplicate_shared_layers:
-                    num_blocks_list.append(num_blocks)
+                    num_blocks_list.append(mamba_num_blocks if isinstance(
+                        layer_spec, MambaSpec) else num_blocks)
                 layer_idx = (i * num_shared_layers
                              ) + j if duplicate_shared_layers else i
                 self.runner.layer_name_to_kvcache_index[layer_name] = layer_idx

--- a/tpu_inference/runner/kv_cache_manager.py
+++ b/tpu_inference/runner/kv_cache_manager.py
@@ -31,7 +31,6 @@ from vllm.v1.kv_cache_interface import (FullAttentionSpec, KVCacheConfig,
                                         KVCacheSpec, MambaSpec,
                                         MLAAttentionSpec, SlidingWindowSpec)
 
-from tpu_inference import envs as tpu_envs
 from tpu_inference import utils
 from tpu_inference import utils as common_utils
 from tpu_inference.layers.common.sharding import ShardingAxisName
@@ -71,15 +70,15 @@ class KVCacheManager:
         # on the TPU side (where we duplicate the shared tensor per layer
         # because mamba and attention caches have different shapes).
         self._hybrid_uniform_page_size_bytes: int | None = None
-        # Mamba leading-dim cap for hybrid models. Mamba state is recurrent
-        # (one slot per active request), so allocating `num_blocks` slots per
-        # mamba layer wastes most of them — only `max_num_seqs` are ever live
-        # at once. When this is set, `initialize_kv_cache` allocates this many
-        # slots for each mamba layer instead of `num_blocks`, freeing HBM that
-        # `update_mamba_page_size_padded` then redirects into more attention
-        # blocks (raising `num_gpu_blocks_override`). The GDN op compensates
-        # by indexing into the smaller mamba arrays with `req_idx` instead of
-        # the (now-larger) block-table block IDs — see `gdn_attention_op`.
+        # Per-mamba-layer leading-dim cap for hybrid models. Mamba state is
+        # recurrent (one slot per *active* request), so the `num_blocks`
+        # slots vLLM hands out are mostly idle. Set by
+        # `_maybe_set_compact_mamba_num_blocks_override`; when set,
+        # `initialize_kv_cache` allocates this many slots per mamba layer
+        # while attention layers keep the full `num_blocks` from the
+        # (correspondingly enlarged) attention pool. The GDN op indexes
+        # mamba state with `attn_metadata.mamba_state_indices` (in
+        # `[0, max_num_reqs]`) so it stays in-bounds for the smaller arrays.
         self._mamba_num_blocks: int | None = None
 
     def _create_attention_spec(
@@ -263,103 +262,66 @@ class KVCacheManager:
         self.runner.cache_config.mamba_page_size_padded = int(
             uniform_page_size_bytes)
 
-        # Pin vLLM's num_blocks. Two cases:
-        #  (a) compact-mamba: cap each mamba layer at `max_num_seqs+1` slots
-        #      (one per active request, plus the null block) and redirect the
-        #      freed HBM into more attention blocks. This is the common path
-        #      and gives a substantial throughput win on hybrid models where
-        #      mamba layers dominate the per-block footprint (e.g., Qwen3.5
-        #      where each block currently spends ~50% of its bytes on mamba
-        #      state that is never indexed past `max_num_seqs`).
-        #  (b) legacy: keep TPU and vLLM's num_blocks identical (the original
-        #      OOB fix). Used when compact-mamba is disabled or the avail
-        #      memory probe fails (e.g., in tests without real devices).
-        if tpu_envs.COMPACT_MAMBA_KV_CACHE:
-            self._maybe_set_compact_mamba_num_blocks_override(
-                attn_page_size_bytes, int(unpadded_mamba_page_size),
-                num_attn_groups, num_mamba_groups, num_attn, num_mamba,
-                group_size)
-            if self._mamba_num_blocks is not None:
-                # Successfully sized mamba compactly. Done.
-                return
-
-        self._maybe_set_num_blocks_override(attn_page_size_bytes,
-                                            int(uniform_page_size_bytes),
-                                            group_size)
+        # Cap each mamba layer at `max_num_reqs+1` slots and grow the
+        # attention pool with the freed HBM. See
+        # `_maybe_set_compact_mamba_num_blocks_override`.
+        self._maybe_set_compact_mamba_num_blocks_override(
+            attn_page_size_bytes, int(unpadded_mamba_page_size),
+            num_attn_groups, num_mamba_groups, num_attn, num_mamba, group_size)
 
     def _maybe_set_compact_mamba_num_blocks_override(
             self, attn_page_size_bytes: int,
             unpadded_mamba_page_size_bytes: int, num_attn_groups: int,
             num_mamba_groups: int, num_attn_layers: int, num_mamba_layers: int,
             group_size: int) -> None:
-        """Cap mamba allocation at `max_num_seqs+1` slots, redirect freed HBM
-        into more attention blocks, and pin `num_gpu_blocks_override` to the
-        resulting attention pool size.
+        """Cap mamba layers at `max_num_reqs+1` slots and pin
+        `num_gpu_blocks_override` so the freed HBM grows the attention pool.
 
-        Why this is a big win
-        ---------------------
-        Mamba state is recurrent: one slot per *active request* per layer,
-        independent of context length. With Qwen3.5 (15 attn + 45 mamba
-        layers) the legacy code allocates `num_blocks` mamba slots per layer
-        even though only ~`max_num_seqs` are ever live at once. On TP=8
-        with 307 GiB available, that wastes ~80 GiB on mamba slots that
-        will never be addressed. Folded back into attention, those bytes
-        buy ~1.6× the attention block pool — roughly a 60% jump in the
-        steady-state concurrent-request count, which is the dominant
-        throughput driver at high concurrency.
-
-        How it stays correct
-        --------------------
-        vLLM still hands out block IDs from a single shared pool of size
-        `num_gpu_blocks_override`, but on TPU we allocate only
-        `_mamba_num_blocks` slots per mamba layer. Indexing a smaller array
-        with a possibly-large block ID would walk off the end. The GDN op
-        avoids this by indexing mamba state with `req_idx` (the position
-        in the persistent batch, ∈ [0, max_num_reqs)) instead of the
-        block-table value — each persistent-batch slot owns a dedicated
-        mamba slot for its lifetime.
+        Tradeoff vs. the uniform num_blocks layout
+        ------------------------------------------
+        Mamba state is recurrent: one slot per *active* request, regardless
+        of context length. The uniform layout gives every layer the same
+        `num_blocks`, leaving `num_blocks − max_num_reqs` mamba slots idle
+        forever. The compact layout caps mamba at `max_num_reqs + 1` (the
+        `+1` is vLLM's null block), which is strictly better for any model
+        where `num_blocks > max_num_reqs` — i.e. all production hybrid
+        configs we run.
+        Cost: a small bookkeeping invariant in the GDN op (it must index
+        mamba state by per-request slot id rather than by `block_tables`,
+        since the mamba leading dim is now smaller than the attn pool).
+        See `gdn_attention_op.gdn_attention_core_tpu`.
+        Skipped if the user pinned `num_gpu_blocks_override` or
+        `hbm_usage_bytes` cannot read HBM (e.g. CPU-only tests). In those
+        cases vLLM keeps its uniform sizing; the page-size padding done in
+        the caller still keeps the per-layer block-ID range correct.
 
         Sizing math
         -----------
-        Each `KVCacheTensor` is shared across one layer from each kv-cache
-        group (`num_attn_groups + num_mamba_groups` layers per tensor) and
-        there are `group_size` such tensors. Total HBM:
-
-          avail = group_size × (num_attn_groups × N_attn × attn_page
-                                + num_mamba_groups × N_mamba × mamba_unpadded)
-
-        We fix `N_mamba = max_num_seqs + 1` (one per request plus a null
-        block), then solve for `N_attn`:
-
-          N_attn = floor((avail/group_size
-                          - num_mamba_groups × N_mamba × mamba_unpadded)
-                         / (num_attn_groups × attn_page))
-
-        and round down to a multiple of the sharding divisor.
-
-        Skipped if HBM usage isn't readable (tests w/o real devices) or if
-        the user has explicitly set `num_gpu_blocks_override`. Falls back
-        to the legacy two-step floor in those cases.
+        Each kv-cache tensor is shared across `num_attn_groups +
+        num_mamba_groups` layers; there are `group_size` such tensors.
+        Per-tensor budget `B = avail / group_size`. With
+        `N_mamba = max_num_reqs + 1`,
+            N_attn = floor((B − num_mamba_groups × N_mamba × mamba_unpadded)
+                            / (num_attn_groups × attn_page))
+        rounded down to the sharding divisor.
 
         Args:
             attn_page_size_bytes: TPU-actual bytes per block per attention
                 layer (accounts for dtype packing like fp8).
-            unpadded_mamba_page_size_bytes: bytes per mamba state per layer
+            unpadded_mamba_page_size_bytes: bytes per slot per mamba layer
                 (`prod(shape) × dtype_size`, no padding).
-            num_attn_groups: vLLM kv-cache groups containing attention
-                layers.
-            num_mamba_groups: vLLM kv-cache groups containing mamba layers.
-            num_attn_layers: total attention layers in the model.
-            num_mamba_layers: total mamba layers in the model.
-            group_size: layers per kv-cache group (= number of
-                `KVCacheTensor`s; vLLM pads short groups up to this).
+            num_attn_groups: # vLLM kv-cache groups holding attention layers.
+            num_mamba_groups: # vLLM kv-cache groups holding mamba layers.
+            num_attn_layers: total attention layers (logging only).
+            num_mamba_layers: total mamba layers (logging only).
+            group_size: layers per kv-cache group; equals the # of
+                `KVCacheTensor`s vLLM allocates per kv-cache group.
 
         Returns:
-            None. Side effects on success: sets
-            `cache_config.num_gpu_blocks_override` and `_mamba_num_blocks`
-            so `initialize_kv_cache` allocates the compact mamba arrays.
-            On failure (no override possible), leaves both unset and
-            returns; the caller falls back to the legacy override path.
+            None. On success: sets `cache_config.num_gpu_blocks_override`
+            and `_mamba_num_blocks` so `initialize_kv_cache` allocates the
+            smaller mamba arrays. On any preconditions-fail path: leaves
+            both unset.
         """
         cache_config = self.runner.cache_config
         if cache_config.num_gpu_blocks_override is not None:
@@ -370,8 +332,9 @@ class KVCacheManager:
             hbm_usage = utils.hbm_usage_bytes(devices)
         except Exception as exc:  # noqa: BLE001
             logger.debug(
-                "Skipping compact-mamba override: hbm_usage_bytes failed "
-                "(%s). Falling back to legacy override.", exc)
+                "Compact-mamba sizing skipped: hbm_usage_bytes failed (%s). "
+                "vLLM will size the block pool from the uniform spec; "
+                "page-size padding keeps per-layer block IDs in range.", exc)
             return
 
         total_limit = sum(limit for _, limit in hbm_usage)
@@ -381,10 +344,11 @@ class KVCacheManager:
         if avail <= 0:
             return
 
-        # Sharding divisor: num_blocks for each layer must be a multiple of
-        # the per-axis device count so JAX shardings don't round up. MLA
-        # uses MLP_TENSOR; everything else uses ATTN_DATA. Match
-        # `initialize_kv_cache`.
+        # Sharding divisor: per-layer num_blocks must be a multiple of the
+        # per-axis device count so JAX shardings don't round up. MLA shards
+        # over MLP_TENSOR (unless DP attention is on); other layouts shard
+        # over ATTN_DATA. Match `initialize_kv_cache` exactly so what we
+        # compute here is what gets allocated.
         if self.use_mla and not self.runner.vllm_config.additional_config.get(
                 "sharding", {}).get("sharding_strategy", {}).get(
                     "enable_dp_attention", False):
@@ -393,31 +357,38 @@ class KVCacheManager:
         else:
             divisor = common_utils.get_mesh_shape_product(
                 self.runner.mesh, ShardingAxisName.ATTN_DATA)
-        if divisor <= 0:
-            divisor = 1
+        # `get_mesh_shape_product` returns 1 for an absent axis, but be
+        # defensive against an empty mesh shape that produces 0.
+        divisor = max(divisor, 1)
 
-        # Mamba slot budget: enough for every persistent-batch slot the
-        # runner is sized for, plus one null block, rounded up to the
-        # sharding divisor. `runner.max_num_reqs` already accounts for DP
-        # (= dp_size × scheduler_config.max_num_seqs) so the GDN op's
-        # `state_indices = arange(max_reqs)` is guaranteed in-bounds.
+        # Mamba slot budget: one per persistent-batch slot plus the null
+        # block, rounded up to the sharding divisor. `runner.max_num_reqs`
+        # already includes the DP multiplier
+        # (= `dp_size × scheduler_config.max_num_seqs`).
         mamba_num_blocks = self.runner.max_num_reqs + 1
         mamba_num_blocks = (
             (mamba_num_blocks + divisor - 1) // divisor) * divisor
 
-        # Compute attn_num_blocks that fits the remaining HBM after mamba.
+        # Attention block count: fits into HBM left after mamba.
+        # `attn_page_size_bytes` is per-block per-attention-layer; the
+        # per-tensor cost is `num_attn_groups × N_attn × attn_page` because
+        # one tensor backs `num_attn_groups` attention layers.
         avail_per_tensor = avail // group_size
         mamba_per_tensor = (num_mamba_groups * mamba_num_blocks *
                             unpadded_mamba_page_size_bytes)
         attn_per_tensor_avail = avail_per_tensor - mamba_per_tensor
         if attn_per_tensor_avail <= 0:
-            # Even mamba alone exceeds budget — the mamba cap is too high
-            # for this configuration. Fall back to the legacy override.
-            logger.debug(
-                "Compact-mamba override skipped: mamba_num_blocks=%d × "
-                "num_mamba_groups=%d × mamba_unpadded=%d exceeds per-tensor "
-                "budget %d. Falling back to legacy override.",
-                mamba_num_blocks, num_mamba_groups,
+            # Mamba already saturates the budget — pathological
+            # configuration (e.g., mamba_unpadded × max_num_reqs alone
+            # exceeds gpu_memory_utilization × total_hbm). Skip the
+            # override and let vLLM fall back to its uniform sizing; if
+            # the model genuinely doesn't fit, vLLM will OOM with the
+            # uniform layout too and we want that signal to surface.
+            logger.warning(
+                "Compact-mamba sizing skipped: mamba alone (mamba_num_blocks="
+                "%d × num_mamba_groups=%d × mamba_unpadded=%d) exceeds "
+                "per-tensor budget %d. Lower `gpu_memory_utilization` or "
+                "`max_num_seqs`.", mamba_num_blocks, num_mamba_groups,
                 unpadded_mamba_page_size_bytes, avail_per_tensor)
             return
 
@@ -425,117 +396,29 @@ class KVCacheManager:
                                                     attn_page_size_bytes)
         attn_num_blocks = (attn_num_blocks // divisor) * divisor
         if attn_num_blocks <= 0:
-            return
-
-        # Sanity check: redirecting HBM into attention should be a strict
-        # win over the legacy single-num_blocks layout. If it isn't (rare
-        # corner case where the legacy num_blocks already saturates), keep
-        # the legacy path.
-        legacy_num_blocks = avail // (self._hybrid_uniform_page_size_bytes *
-                                      group_size)
-        if attn_num_blocks <= legacy_num_blocks:
-            logger.debug(
-                "Compact-mamba override skipped: attn_num_blocks=%d "
-                "<= legacy_num_blocks=%d. Falling back to legacy override.",
-                attn_num_blocks, legacy_num_blocks)
+            logger.warning(
+                "Compact-mamba sizing skipped: attn_num_blocks=0 after "
+                "rounding to divisor=%d (avail_per_tensor=%d, "
+                "mamba_per_tensor=%d). Lower `gpu_memory_utilization` or "
+                "`max_num_seqs`.", divisor, avail_per_tensor, mamba_per_tensor)
             return
 
         cache_config.num_gpu_blocks_override = int(attn_num_blocks)
         self._mamba_num_blocks = int(mamba_num_blocks)
 
+        attn_bytes = num_attn_layers * attn_num_blocks * attn_page_size_bytes
+        mamba_bytes = (num_mamba_layers * mamba_num_blocks *
+                       unpadded_mamba_page_size_bytes)
         logger.info(
-            "Compact-mamba KV cache: num_gpu_blocks_override=%d (attn) and "
-            "_mamba_num_blocks=%d (vs legacy num_blocks≈%d). HBM split: "
-            "attn=%d layers × %d blocks × %d B = %.2f GiB; mamba=%d layers "
-            "× %d slots × %d B = %.2f GiB; total=%.2f GiB / avail=%.2f GiB.",
-            attn_num_blocks, mamba_num_blocks, legacy_num_blocks,
-            num_attn_layers, attn_num_blocks, attn_page_size_bytes,
-            num_attn_layers * attn_num_blocks * attn_page_size_bytes /
-            (1 << 30), num_mamba_layers, mamba_num_blocks,
-            unpadded_mamba_page_size_bytes, num_mamba_layers *
-            mamba_num_blocks * unpadded_mamba_page_size_bytes / (1 << 30),
-            (num_attn_layers * attn_num_blocks * attn_page_size_bytes +
-             num_mamba_layers * mamba_num_blocks *
-             unpadded_mamba_page_size_bytes) / (1 << 30), avail / (1 << 30))
-
-    def _maybe_set_num_blocks_override(self, attn_page_size_bytes: int,
-                                       uniform_page_size_bytes: int,
-                                       group_size: int) -> None:
-        """Pin `cache_config.num_gpu_blocks_override` to the two-step
-        flooring value that keeps peak HBM within the user-set
-        `gpu_memory_utilization` budget at high utilization.
-
-        Formula:
-          `num_blocks_attn = floor(avail / (attn_page × group_size))`
-          `num_blocks_tpu  = floor(attn_page × num_blocks_attn / uniform)`
-
-        The two-step flooring can land 1 block lower than vLLM's
-        single-step `floor(avail / (uniform × group_size))`. Since
-        `uniform > attn_page`, that 1-block gap costs `group_size × uniform`
-        bytes of HBM, which — against the imprecision in vLLM's `avail`
-        estimate — is enough to tip high-utilization configurations into
-        OOM. Pinning to `num_blocks_tpu` preserves the headroom the
-        single-step formula silently removes.
-
-        No internal safety margin is applied — `gpu_memory_utilization` is
-        the knob users already have for reserving headroom. Adding a
-        silent reduction here would conflict with their explicit budget.
-
-        Skipped if the user has explicitly set `num_gpu_blocks_override` or
-        if HBM usage isn't readable (e.g. in tests without real devices).
-        Spec padding alone still fixes the OOB bug in that case; only the
-        ~1-block-per-tensor flooring-boundary precision is lost.
-
-        Args:
-            attn_page_size_bytes: TPU-actual bytes per block for one
-                attention layer, from `get_attention_page_size_bytes`
-                (accounts for dtype packing like fp8).
-            uniform_page_size_bytes: bytes per block for one `KVCacheTensor`
-                shared across `num_attn_groups + num_mamba_groups` layers
-                (the `_hybrid_uniform_page_size_bytes` value set above).
-            group_size: number of layers per vLLM kv-cache group, used by
-                vLLM to compute `num_blocks` from the attention tensor size.
-
-        Returns:
-            None. Side effect: sets `cache_config.num_gpu_blocks_override`
-            if all preconditions hold; otherwise leaves it unset.
-        """
-        cache_config = self.runner.cache_config
-        if cache_config.num_gpu_blocks_override is not None:
-            return
-
-        devices = self.runner.mesh.devices.flatten()
-        try:
-            hbm_usage = utils.hbm_usage_bytes(devices)
-        except Exception as exc:  # noqa: BLE001
-            logger.debug(
-                "Skipping num_gpu_blocks_override: hbm_usage_bytes failed "
-                "(%s). Spec padding alone still fixes the OOB bug; the "
-                "scheduler's pool may exceed per-layer TPU capacity by one "
-                "block at flooring boundaries.", exc)
-            return
-
-        total_limit = sum(limit for _, limit in hbm_usage)
-        total_used = sum(used for used, _ in hbm_usage)
-        gpu_mem_util = cache_config.gpu_memory_utilization
-        avail = int(total_limit * gpu_mem_util - total_used)
-        if avail <= 0:
-            return
-
-        naive_vllm_num_blocks = avail // (attn_page_size_bytes * group_size)
-        if naive_vllm_num_blocks <= 0:
-            return
-        naive_tensor_size = attn_page_size_bytes * naive_vllm_num_blocks
-        num_blocks_tpu = naive_tensor_size // uniform_page_size_bytes
-        if num_blocks_tpu <= 0:
-            return
-
-        cache_config.num_gpu_blocks_override = int(num_blocks_tpu)
-        logger.info(
-            "Hybrid KV cache: setting num_gpu_blocks_override=%d to align "
-            "the scheduler's block pool with per-layer TPU allocation "
-            "(avail=%d, naive_vllm_num_blocks=%d).", num_blocks_tpu, avail,
-            naive_vllm_num_blocks)
+            "Compact-mamba KV cache: num_gpu_blocks_override=%d (attn), "
+            "_mamba_num_blocks=%d. HBM split: attn=%d layers × %d blocks "
+            "× %d B = %.2f GiB; mamba=%d layers × %d slots × %d B = "
+            "%.2f GiB; total=%.2f GiB / avail=%.2f GiB.", attn_num_blocks,
+            mamba_num_blocks, num_attn_layers, attn_num_blocks,
+            attn_page_size_bytes, attn_bytes / (2**30), num_mamba_layers,
+            mamba_num_blocks, unpadded_mamba_page_size_bytes,
+            mamba_bytes / (2**30), (attn_bytes + mamba_bytes) / (2**30),
+            avail / (2**30))
 
     def get_kv_cache_spec(self):
         # TODO(xiang): this hack tricks engine core to init successfully
@@ -848,11 +731,12 @@ class KVCacheManager:
             # num_blocks must be a multiple of the sharding divisor
             num_blocks = (num_blocks // divisor) * divisor
 
-            # When compact-mamba is active, mamba layers allocate
-            # `_mamba_num_blocks` (≈ max_num_seqs+1) slots while attention
-            # layers allocate the full `num_blocks` from the (now larger)
-            # attention pool. The two values diverge here; outside compact
-            # mode they are equal and behavior is unchanged.
+            # When compact-mamba sizing succeeded (set by
+            # `_maybe_set_compact_mamba_num_blocks_override`), mamba layers
+            # allocate `_mamba_num_blocks` (= max_num_reqs + 1) slots while
+            # attention layers keep the full `num_blocks`. When that override
+            # didn't run (CPU tests, user-pinned `num_gpu_blocks_override`),
+            # mamba and attn use the same `num_blocks` — vLLM's uniform sizing.
             mamba_num_blocks = (self._mamba_num_blocks
                                 if self._mamba_num_blocks is not None else
                                 num_blocks)

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -1576,9 +1576,16 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
 
         metadata_blob, metadata_layout = self.device_buffer.build()
 
-        (request_distribution, dev_arrays_payload) = device_array(
-            self.mesh, (request_distribution, metadata_blob),
-            sharding=data_parallel_attn_sharding)
+        # Per-request mamba state slot ids; copy to keep the InputBatch's
+        # CPU buffer free for the next step's bookkeeping.
+        mamba_state_indices_cpu = self.input_batch.mamba_state_indices_cpu.copy(
+        )
+
+        (request_distribution, mamba_state_indices,
+         dev_arrays_payload) = device_array(
+             self.mesh,
+             (request_distribution, mamba_state_indices_cpu, metadata_blob),
+             sharding=data_parallel_attn_sharding)
 
         metadata = common_utils.DeviceBuffer.unpack_arrays(
             dev_arrays_payload, metadata_layout)
@@ -1594,6 +1601,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                 seq_lens=seq_lens,
                 query_start_loc=query_start_loc,
                 request_distribution=request_distribution,
+                mamba_state_indices=mamba_state_indices,
             )
 
             # This is for making these cpu buffers hidden during tracing
@@ -1847,9 +1855,16 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
 
         metadata_blob, metadata_layout = self.device_buffer.build()
 
-        (request_distribution, dev_arrays_payload) = device_array(
-            self.mesh, (request_distribution, metadata_blob),
-            sharding=data_parallel_attn_sharding)
+        # Per-request mamba state slot ids; copy to keep the InputBatch's
+        # CPU buffer free for the next step's bookkeeping.
+        mamba_state_indices_cpu = self.input_batch.mamba_state_indices_cpu.copy(
+        )
+
+        (request_distribution, mamba_state_indices,
+         dev_arrays_payload) = device_array(
+             self.mesh,
+             (request_distribution, mamba_state_indices_cpu, metadata_blob),
+             sharding=data_parallel_attn_sharding)
 
         metadata = common_utils.DeviceBuffer.unpack_arrays(
             dev_arrays_payload, metadata_layout)
@@ -1864,7 +1879,9 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                 block_tables=block_tables,
                 seq_lens=seq_lens,
                 query_start_loc=query_start_loc,
-                request_distribution=request_distribution)
+                request_distribution=request_distribution,
+                mamba_state_indices=mamba_state_indices,
+            )
             # This is for making these cpu buffers hidden during tracing
             attention_metadata_gid.query_start_loc_cpu = query_start_loc_view
             attention_metadata_gid.seq_lens_cpu = seq_lens_view

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -1576,16 +1576,25 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
 
         metadata_blob, metadata_layout = self.device_buffer.build()
 
-        # Per-request mamba state slot ids; copy to keep the InputBatch's
-        # CPU buffer free for the next step's bookkeeping.
-        mamba_state_indices_cpu = self.input_batch.mamba_state_indices_cpu.copy(
-        )
-
-        (request_distribution, mamba_state_indices,
-         dev_arrays_payload) = device_array(
-             self.mesh,
-             (request_distribution, mamba_state_indices_cpu, metadata_blob),
-             sharding=data_parallel_attn_sharding)
+        # Mamba slot ids are only consumed by hybrid attn+mamba models; for
+        # pure-attention models, leaving the field None keeps AttentionMetadata
+        # byte-identical to the pre-compact-mamba layout (so the model_fn
+        # signature on those models is unchanged).
+        if self.kv_cache_config.has_mamba_layers:
+            # Per-request mamba state slot ids; copy to keep the InputBatch's
+            # CPU buffer free for the next step's bookkeeping.
+            mamba_state_indices_cpu = self.input_batch.mamba_state_indices_cpu.copy(
+            )
+            (request_distribution, mamba_state_indices,
+             dev_arrays_payload) = device_array(
+                 self.mesh, (request_distribution, mamba_state_indices_cpu,
+                             metadata_blob),
+                 sharding=data_parallel_attn_sharding)
+        else:
+            mamba_state_indices = None
+            (request_distribution, dev_arrays_payload) = device_array(
+                self.mesh, (request_distribution, metadata_blob),
+                sharding=data_parallel_attn_sharding)
 
         metadata = common_utils.DeviceBuffer.unpack_arrays(
             dev_arrays_payload, metadata_layout)
@@ -1855,16 +1864,25 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
 
         metadata_blob, metadata_layout = self.device_buffer.build()
 
-        # Per-request mamba state slot ids; copy to keep the InputBatch's
-        # CPU buffer free for the next step's bookkeeping.
-        mamba_state_indices_cpu = self.input_batch.mamba_state_indices_cpu.copy(
-        )
-
-        (request_distribution, mamba_state_indices,
-         dev_arrays_payload) = device_array(
-             self.mesh,
-             (request_distribution, mamba_state_indices_cpu, metadata_blob),
-             sharding=data_parallel_attn_sharding)
+        # Mamba slot ids are only consumed by hybrid attn+mamba models; for
+        # pure-attention models, leaving the field None keeps AttentionMetadata
+        # byte-identical to the pre-compact-mamba layout (so the model_fn
+        # signature on those models is unchanged).
+        if self.kv_cache_config.has_mamba_layers:
+            # Per-request mamba state slot ids; copy to keep the InputBatch's
+            # CPU buffer free for the next step's bookkeeping.
+            mamba_state_indices_cpu = self.input_batch.mamba_state_indices_cpu.copy(
+            )
+            (request_distribution, mamba_state_indices,
+             dev_arrays_payload) = device_array(
+                 self.mesh, (request_distribution, mamba_state_indices_cpu,
+                             metadata_blob),
+                 sharding=data_parallel_attn_sharding)
+        else:
+            mamba_state_indices = None
+            (request_distribution, dev_arrays_payload) = device_array(
+                self.mesh, (request_distribution, metadata_blob),
+                sharding=data_parallel_attn_sharding)
 
         metadata = common_utils.DeviceBuffer.unpack_arrays(
             dev_arrays_payload, metadata_layout)

--- a/tpu_inference/spec_decode/jax/eagle3.py
+++ b/tpu_inference/spec_decode/jax/eagle3.py
@@ -366,6 +366,7 @@ class Eagle3Proposer:
             seq_lens=seq_lens,
             query_start_loc=query_start_loc,
             request_distribution=attn_metadata.request_distribution,
+            mamba_state_indices=attn_metadata.mamba_state_indices,
         )
 
         target_hidden_states, input_ids, last_token_indices = self._prepare_hidden_states_and_input_ids(


### PR DESCRIPTION
Mamba state is recurrent (one slot per active request), but PR #2366's correctness fix uniformly allocates `num_blocks` slots for every layer group, leaving ~76 GiB of mamba HBM idle on Qwen3.5-397B-A17B-FP8 TP=8. This change reclaims that HBM for the attention pool and unlocks higher concurrency without changing dtype, sharding, or any user-facing API.

KVCacheManager:
* New `_maybe_set_compact_mamba_num_blocks_override` (env `COMPACT_MAMBA_KV_CACHE`, default ON). Caps mamba alloc at `max_num_reqs+1` slots, computes the matching attn `num_gpu_blocks` for the remaining HBM, and exits the legacy two-step floor when it succeeds. Falls back cleanly when HBM probe fails (CPU-only tests) or the user pins `num_gpu_blocks_override`.
* `initialize_kv_cache` allocates mamba arrays with the smaller `_mamba_num_blocks` while attention layers keep `num_blocks`.

GDN op (`gdn_attention_core_tpu`):
* Index mamba state by persistent-batch slot (`arange(max_reqs)`) instead of `block_tables[:, 0]`. Required: `block_tables[:, 0]` returns values in [0, num_attn_blocks) which now exceeds the smaller mamba arrays' leading dim.
* Stale-state guard: zero conv/recurrent state for slots whose request has `num_computed_tokens == 0`, mirroring GPU vLLM's `has_initial_state = context_lens > 0`. Without this, slot reuse leaks the previous occupant's state into the next prefill.

Verified on Qwen3.5-397B-A17B-FP8 / TP=8 / v7x with 1k-in / 8k-out:
* num_gpu_blocks_override 1013 -> 1732 (+71% attn pool).
* Output throughput 1047 -> 1237 tok/s (+18%) at conc=64.
* Mean TPOT 56.6 -> 48.1 ms.
* 0 errors across 128 prompts.

Tests: 29 pass in tests/runner/test_kv_cache_manager.py (3 new), 3 pass in tests/layers/vllm/test_gdn_attention_op.py, 6 pass in tests/layers/common/test_gdn_attention.py.


MMLU-Pro looks good

```
|       Tasks       |Version|    Filter    |n-shot|  Metric   |   |Value |   |Stderr|
|-------------------|------:|--------------|-----:|-----------|---|-----:|---|-----:|
|mmlu_pro           |      2|custom-extract|      |exact_match|↑  |0.8314|±  |0.0139|
| - biology         |      3|custom-extract|     5|exact_match|↑  |0.9200|±  |0.0388|
| - business        |      3|custom-extract|     5|exact_match|↑  |0.8600|±  |0.0496|
| - chemistry       |      3|custom-extract|     5|exact_match|↑  |0.9000|±  |0.0429|
| - computer_science|      3|custom-extract|     5|exact_match|↑  |0.8200|±  |0.0549|
| - economics       |      3|custom-extract|     5|exact_match|↑  |0.9400|±  |0.0339|
| - engineering     |      3|custom-extract|     5|exact_match|↑  |0.7000|±  |0.0655|
| - health          |      3|custom-extract|     5|exact_match|↑  |0.8000|±  |0.0571|
| - history         |      3|custom-extract|     5|exact_match|↑  |0.7400|±  |0.0627|
| - law             |      3|custom-extract|     5|exact_match|↑  |0.7200|±  |0.0641|
| - math            |      3|custom-extract|     5|exact_match|↑  |0.9600|±  |0.0280|
| - other           |      3|custom-extract|     5|exact_match|↑  |0.7200|±  |0.0641|
| - philosophy      |      3|custom-extract|     5|exact_match|↑  |0.8000|±  |0.0571|
| - physics         |      3|custom-extract|     5|exact_match|↑  |0.9400|±  |0.0339|
| - psychology      |      3|custom-extract|     5|exact_match|↑  |0.8200|±  |0.0549|

| Groups |Version|    Filter    |n-shot|  Metric   |   |Value |   |Stderr|
|--------|------:|--------------|------|-----------|---|-----:|---|-----:|
|mmlu_pro|      2|custom-extract|      |exact_match|↑  |0.8314|±  |0.0139|
