### PR TITLE
fix test failures due to unable to remove the docker container

### DIFF
--- a/.buildkite/scripts/setup_docker_env.sh
+++ b/.buildkite/scripts/setup_docker_env.sh
@@ -61,7 +61,25 @@ cleanup_docker_resource() {
       CLEANED_CONTAINERS=$(echo "$TOTAL_CONTAINERS" | tr ' ' '\n' | grep -v '^$' | sort -u || true)
       if [[ -n "$CLEANED_CONTAINERS" ]]; then
         echo "Removing leftover containers using ${IMG} image(s)..."
-        echo "$CLEANED_CONTAINERS" | xargs -r docker rm -f
+
+        for container in $CLEANED_CONTAINERS; do
+          # 1. Attempt standard force removal
+          if ! docker rm -f "$container" 2>/dev/null; then
+            echo "⚠️ Standard 'docker rm' failed for $container. Attempting PID kill..."
+            
+            # 2. Try to find the PID and kill it directly on the host
+            local PID
+            PID=$(docker inspect -f '{{.State.Pid}}' "$container" 2>/dev/null || echo "0")
+            
+            if [[ "$PID" -gt 0 ]]; then
+              echo "Killing process $PID for container $container..."
+              sudo kill -9 "$PID" 2>/dev/null || true
+              sleep 2
+              # Final attempt to clear metadata
+              docker rm -f "$container" || true
+            fi
+          fi
+        done
       fi
       
       echo "Removing old ${IMG} image(s) by ID..."


### PR DESCRIPTION
# Description

Some tests are failing before running because of the below error 
"
Removing leftover containers using vllm-tpu image(s)...
Error response from daemon: cannot remove container "0d740566428c": could not kill container: tried to kill container, but did not receive an exit event
🚨 Error: The command exited with status 123
""

This PR try to kill the docker container using same docker -rm command first. if fail, use kill command and wait for few second and retry the docker -rm again. 

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
