### PR TITLE
Add support for mistral 3 large 

### DIFF
--- a/tests/layers/vllm/process_weights/test_cleanup_sharding.py
+++ b/tests/layers/vllm/process_weights/test_cleanup_sharding.py
@@ -1,0 +1,86 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+os.environ["JAX_PLATFORMS"] = "cpu"
+
+from unittest.mock import MagicMock, patch
+
+import torch
+
+from tpu_inference.layers.vllm.process_weights.cleanup_sharding import \
+    shard_model_to_tpu
+
+
+def test_shard_model_to_tpu_simplification():
+    # Setup dummy model with a parameter and a buffer
+    class DummyModel(torch.nn.Module):
+
+        def __init__(self):
+            super().__init__()
+            self.weight = torch.nn.Parameter(torch.ones(10))
+            self.register_buffer("my_buffer", torch.zeros(5))
+
+    model = DummyModel()
+    dummy_mesh = MagicMock()
+
+    # Mock jax device calls to prevent TPU multi-host initialization hangs
+    with (
+            patch(
+                "tpu_inference.layers.vllm.process_weights.cleanup_sharding.jax.devices"
+            ) as mock_jax_devices,
+            patch(
+                "tpu_inference.layers.vllm.process_weights.cleanup_sharding.jax.default_device"
+            ),
+    ):
+        mock_jax_devices.return_value = ["mock_cpu_device"]
+
+        # Mock the internal functions that do the actual sharding/device checks
+        with patch(
+                "tpu_inference.layers.vllm.process_weights.cleanup_sharding._shard_module_to_tpu"
+        ) as mock_shard_module:
+            with patch(
+                    "tpu_inference.layers.vllm.process_weights.cleanup_sharding._tensor_is_in_cpu"
+            ) as mock_is_cpu:
+                with patch(
+                        "tpu_inference.layers.vllm.process_weights.cleanup_sharding._shard_tensor_to_tpu_replicated"
+                ) as mock_shard_replicated:
+                    # Pretend the parameter is on CPU (needs sharding) but buffer is not
+                    def mock_is_in_cpu_side_effect(tensor):
+                        return tensor is model.weight
+
+                    mock_is_cpu.side_effect = mock_is_in_cpu_side_effect
+
+                    # Pretend sharded tensor returns a special string
+                    mock_shard_replicated.return_value = "sharded_tensor"
+
+                    result = shard_model_to_tpu(model, dummy_mesh)
+
+                    # Check that special sharding was called for any LoRA/custom layers
+                    mock_shard_module.assert_called_once_with(
+                        model, dummy_mesh)
+
+                    # Verify exactly the expected dictionary keys
+                    assert set(result.keys()) == {"weight", "my_buffer"}
+
+                    # Verify the parameter was sharded (because is_in_cpu returned True)
+                    assert result["weight"] == "sharded_tensor"
+
+                    # Verify the buffer passed straight through (because is_in_cpu returned False)
+                    assert result["my_buffer"] is model.my_buffer
+
+                    # Verify _shard_tensor_to_tpu_replicated was only called once
+                    mock_shard_replicated.assert_called_once_with(
+                        model.weight, dummy_mesh)

--- a/tests/layers/vllm/process_weights/test_cleanup_sharding.py
+++ b/tests/layers/vllm/process_weights/test_cleanup_sharding.py
@@ -12,10 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-
-os.environ["JAX_PLATFORMS"] = "cpu"
-
 from unittest.mock import MagicMock, patch
 
 import torch

--- a/tests/layers/vllm/test_compressed_tensors_w8a8_fp8.py
+++ b/tests/layers/vllm/test_compressed_tensors_w8a8_fp8.py
@@ -12,6 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+
+os.environ["JAX_PLATFORMS"] = "cpu"
+
 import tempfile
 from typing import Optional
 from unittest.mock import MagicMock, patch
@@ -437,3 +441,47 @@ def test_merged_column_parallel_linear(model, bias, num_devices, fuse_matmuls,
     initialize_layer_weights(linear_layer)
     ref_output, layer_output = return_ref_and_layer_output(linear_layer)
     torch.testing.assert_close(ref_output, layer_output)
+
+
+def test_fp8_kernel_registry_injection():
+    import vllm.model_executor.kernels.linear as vllm_linear
+    from vllm.platforms import PlatformEnum
+
+    assert hasattr(vllm_linear, "_POSSIBLE_FP8_BLOCK_KERNELS")
+    assert PlatformEnum.TPU in vllm_linear._POSSIBLE_FP8_BLOCK_KERNELS
+
+    registered_kernels = vllm_linear._POSSIBLE_FP8_BLOCK_KERNELS[
+        PlatformEnum.TPU]
+    assert any(k.__name__ == "TpuFP8ScaledMMLinearKernel"
+               for k in registered_kernels)
+
+
+def test_blockwise_config_construction():
+    from unittest.mock import MagicMock, patch
+
+    from compressed_tensors.quantization import (QuantizationArgs,
+                                                 QuantizationStrategy)
+
+    from tpu_inference.layers.vllm.quantization.compressed_tensors.schemes.compressed_tensors_w8a8_fp8 import \
+        VllmCompressedTensorsW8A8Fp8
+    from tpu_inference.layers.vllm.quantization.configs import \
+        VllmQuantLinearConfig
+
+    weight_quant = QuantizationArgs(num_bits=8,
+                                    type="float",
+                                    strategy=QuantizationStrategy.BLOCK,
+                                    block_structure=(128, 128))
+    mock_linear_config = MagicMock(spec=VllmQuantLinearConfig)
+
+    with patch(
+            'vllm.model_executor.layers.quantization.compressed_tensors.schemes.compressed_tensors_w8a8_fp8.get_current_vllm_config'
+    ) as mock_get_config:
+        mock_get_config.return_value.model_config.dtype = "float32"
+        scheme = VllmCompressedTensorsW8A8Fp8(weight_quant=weight_quant,
+                                              is_static_input_scheme=False,
+                                              linear_config=mock_linear_config)
+
+    assert scheme.weight_block_size == [128, 128]
+    assert scheme.cutlass_block_fp8_supported is False
+    assert not scheme.use_aiter_and_is_supported
+    assert scheme.act_q_group_shape == (1, 128)

--- a/tests/layers/vllm/test_compressed_tensors_w8a8_fp8.py
+++ b/tests/layers/vllm/test_compressed_tensors_w8a8_fp8.py
@@ -12,10 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-
-os.environ["JAX_PLATFORMS"] = "cpu"
-
 import tempfile
 from typing import Optional
 from unittest.mock import MagicMock, patch
@@ -441,19 +437,6 @@ def test_merged_column_parallel_linear(model, bias, num_devices, fuse_matmuls,
     initialize_layer_weights(linear_layer)
     ref_output, layer_output = return_ref_and_layer_output(linear_layer)
     torch.testing.assert_close(ref_output, layer_output)
-
-
-def test_fp8_kernel_registry_injection():
-    import vllm.model_executor.kernels.linear as vllm_linear
-    from vllm.platforms import PlatformEnum
-
-    assert hasattr(vllm_linear, "_POSSIBLE_FP8_BLOCK_KERNELS")
-    assert PlatformEnum.TPU in vllm_linear._POSSIBLE_FP8_BLOCK_KERNELS
-
-    registered_kernels = vllm_linear._POSSIBLE_FP8_BLOCK_KERNELS[
-        PlatformEnum.TPU]
-    assert any(k.__name__ == "TpuFP8ScaledMMLinearKernel"
-               for k in registered_kernels)
 
 
 def test_blockwise_config_construction():

--- a/tests/layers/vllm/test_mla_attention.py
+++ b/tests/layers/vllm/test_mla_attention.py
@@ -122,7 +122,8 @@ class TestVllmTPUMLAAttention:
                                             env=torchax.default_env())
         attn.W_UV = torchax.tensor.Tensor(jnp.ones((10, 10)),
                                           env=torchax.default_env())
-        attn.kv_b_proj = MagicMock()
+        attn.kv_b_proj = MagicMock(spec=torch.nn.Module)
+        attn.kv_b_proj.quant_method = MagicMock()
         attn.kv_b_proj.quant_method.linear_config.mesh = mesh
         attn.kv_b_proj.named_parameters.return_value = {}
 

--- a/tpu_inference/envs.py
+++ b/tpu_inference/envs.py
@@ -52,6 +52,7 @@ if TYPE_CHECKING:
     TPU_OFFLOAD_USE_UNPINNED_HOST: bool = False
     MOE_APPROX_TOPK: bool = False
     MOE_APPROX_TOPK_RECALL_TARGET: float | None = None
+    VLLM_TPU_PATCH_MM_EMBEDDINGS: bool = False
 
 
 def env_with_choices(
@@ -298,6 +299,8 @@ environment_variables: dict[str, Callable[[], Any]] = {
     lambda: float(os.getenv("MOE_APPROX_TOPK_RECALL_TARGET", "0.9")),
     "DISABLE_WEIGHT_REQUANTIZATION":
     env_bool("DISABLE_WEIGHT_REQUANTIZATION", default=False),
+    "VLLM_TPU_PATCH_MM_EMBEDDINGS":
+    env_bool("VLLM_TPU_PATCH_MM_EMBEDDINGS", default=False),
 }
 
 

--- a/tpu_inference/layers/common/process_weights/linear_weights.py
+++ b/tpu_inference/layers/common/process_weights/linear_weights.py
@@ -114,6 +114,8 @@ def process_linear_weights(
     else:
 
         def slice_tensor(tensor):
+            if tensor is None:
+                return None
             tensors = []
             start = 0
             for size in output_sizes:

--- a/tpu_inference/layers/common/process_weights/moe_weights.py
+++ b/tpu_inference/layers/common/process_weights/moe_weights.py
@@ -533,6 +533,12 @@ def process_moe_weights(
                 "process_moe_weights is not yet implemented for megablox gmm "
                 "backend")
 
+    # Covert scales to jax arrays (they may be torch.Tensors)
+    if w13_weight_scale is not None:
+        w13_weight_scale = jnp.array(w13_weight_scale)
+    if w2_weight_scale is not None:
+        w2_weight_scale = jnp.array(w2_weight_scale)
+
     return FusedMoEWeights(
         w13_weight=w13_weight,
         w13_weight_scale=w13_weight_scale,
@@ -674,10 +680,10 @@ def process_fp8_moe_weights(
         weights = FusedMoEWeights(
             w13_weight=w13_weight,
             w13_weight_scale=w13_weight_scale,
-            w13_bias=None,
+            w13_bias=weights.w13_bias,
             w2_weight=w2_weight,
             w2_weight_scale=w2_weight_scale,
-            w2_bias=None,
+            w2_bias=weights.w2_bias,
         )
 
     else:
@@ -715,10 +721,10 @@ def process_fp8_moe_weights(
             FusedMoEWeights(
                 w13_weight=w13_weight,
                 w13_weight_scale=None,
-                w13_bias=None,
+                w13_bias=weights.w13_bias,
                 w2_weight=w2_weight,
                 w2_weight_scale=None,
-                w2_bias=None,
+                w2_bias=weights.w2_bias,
             ),
             desired_quant_dtype,
             requant_block_size,

--- a/tpu_inference/layers/vllm/custom_ops/mla_attention.py
+++ b/tpu_inference/layers/vllm/custom_ops/mla_attention.py
@@ -92,10 +92,25 @@ class VllmMLAAttention(MLAAttention):
 
             # NOTE: vLLM dequantizes kv_b_proj weights which causes more memory
             # usage than expected.
-
             # quantize W_UK_T, W_UV back to cache type and transfer
             # `W_UK_T`, `W_UV` to TPUs
-            mesh = self.kv_b_proj.quant_method.linear_config.mesh
+            # Try to get the mesh from the first possible path.
+            quant_method = getattr(self.kv_b_proj, 'quant_method', None)
+            linear_config = getattr(quant_method, 'linear_config', None)
+            mesh = getattr(linear_config, 'mesh', None)
+            if mesh is None:
+                # If the first path failed, mesh will be None. Try the second path.
+                scheme = getattr(self.kv_b_proj, 'scheme', None)
+                linear_config = getattr(scheme, 'linear_config', None)
+                mesh = getattr(linear_config, 'mesh', None)
+
+            if mesh is None:
+                # If mesh is still None after trying all paths, raise an error.
+                raise ValueError(
+                    "Could not find JAX Mesh. Failed to access "
+                    "'.quant_method.linear_config.mesh' or "
+                    "'.scheme.linear_config.mesh' on the kv_b_proj layer.")
+
             sharding = NamedSharding(mesh, P(ShardingAxisName.ATTN_HEAD, ))
             self.W_UK_T, self.W_UK_T_scale = quantize_tensor(
                 self.kv_cache_quantized_dtype, jax_view(self.W_UK_T), axis=1)

--- a/tpu_inference/layers/vllm/ops/scaled_dot_product_attention.py
+++ b/tpu_inference/layers/vllm/ops/scaled_dot_product_attention.py
@@ -39,6 +39,9 @@ def scaled_dot_product_attention(
     if enable_gqa is not False:
         raise NotImplementedError("patched_sdpa does not support enable_gqa")
 
+    if scale is None:
+        scale = 1.0
+
     mesh = jax.sharding.get_abstract_mesh()
 
     # Q, K, V shapes: (batch, num_heads, seq_len, head_dim)
@@ -105,6 +108,9 @@ def vllm_vit_sdpa(
     query = jnp.swapaxes(query, 1, 2)
     key = jnp.swapaxes(key, 1, 2)
     value = jnp.swapaxes(value, 1, 2)
+
+    if scale is None:
+        scale = 1.0
 
     mesh = jax.sharding.get_abstract_mesh()
 

--- a/tpu_inference/layers/vllm/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_w8a8_fp8.py
+++ b/tpu_inference/layers/vllm/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_w8a8_fp8.py
@@ -12,26 +12,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import jax
 import torch
 from compressed_tensors.quantization import QuantizationArgs
 from jax.sharding import Mesh
 from torch.nn.parameter import Parameter
 from torchax.interop import jax_view, torch_view
 from vllm.model_executor.layers.fused_moe import FusedMoE, FusedMoEConfig
-from vllm.model_executor.layers.fused_moe.activation import MoEActivation
 from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tensors_moe.compressed_tensors_moe_w8a8_fp8 import \
     CompressedTensorsW8A8Fp8MoEMethod
 
 from tpu_inference.layers.common.moe import MoEBackend
 from tpu_inference.layers.common.process_weights.moe_weights import (
-    FusedMoEWeights, process_moe_weights, shard_moe_weights)
-from tpu_inference.layers.common.sharding import ShardingAxisName
+    FusedMoEWeights, process_fp8_moe_weights, shard_moe_weights)
 from tpu_inference.layers.vllm.interface.moe import (
     select_moe_backend_from_fused_moe_config, vllm_moe_apply)
 from tpu_inference.layers.vllm.quantization.configs import VllmQuantConfig
 from tpu_inference.logger import init_logger
-from tpu_inference.utils import get_mesh_shape_product, t2j
+from tpu_inference.utils import t2j
 
 logger = init_logger(__name__)
 
@@ -94,40 +91,26 @@ class VllmCompressedTensorsW8A8Fp8MoEMethod(CompressedTensorsW8A8Fp8MoEMethod,
         else:
             w13_bias = w2_bias = None
 
-        @jax.jit
-        def process_fp8_moe_weights(
-            w13_weight: jax.Array,
-            w13_weight_scale: jax.Array,
-            w13_bias: jax.Array | None,
-            w2_weight: jax.Array,
-            w2_weight_scale: jax.Array,
-            w2_bias: jax.Array | None,
-        ) -> FusedMoEWeights:
-            w13_interleave = layer.activation == MoEActivation.SWIGLUOAI
-            w13_reorder_size = get_mesh_shape_product(
-                self.mesh, ShardingAxisName.MLP_TENSOR)
+        # Support for blockwise quantization (e.g. 128x128 blocks) used by
+        # DeepSeek V3 / Mistral 3 Large models.
+        weight_block_size = None
+        if self.weight_quant.block_structure is not None:
+            weight_block_size = tuple(self.weight_quant.block_structure)
 
-            return process_moe_weights(
-                weights=FusedMoEWeights(
-                    w13_weight=w13_weight,
-                    w13_weight_scale=w13_weight_scale,
-                    w13_bias=w13_bias,
-                    w2_weight=w2_weight,
-                    w2_weight_scale=w2_weight_scale,
-                    w2_bias=w2_bias,
-                ),
-                moe_backend=self.moe_backend,
-                w13_reorder_size=w13_reorder_size,
-                w13_interleave=w13_interleave,
-            )
-
+        input_weights = FusedMoEWeights(
+            w13_weight=w13_weight,
+            w13_weight_scale=w13_weight_scale,
+            w13_bias=w13_bias,
+            w2_weight=w2_weight,
+            w2_weight_scale=w2_weight_scale,
+            w2_bias=w2_bias,
+        )
         weights = process_fp8_moe_weights(
-            w13_weight,
-            w13_weight_scale,
-            w13_bias,
-            w2_weight,
-            w2_weight_scale,
-            w2_bias,
+            input_weights,
+            moe_backend=self.moe_backend,
+            mesh=self.mesh,
+            activation=layer.activation.value,
+            weight_block_size=weight_block_size,
         )
         weights = torch_view(
             shard_moe_weights(weights, self.moe_backend, self.mesh))

--- a/tpu_inference/layers/vllm/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_fp8.py
+++ b/tpu_inference/layers/vllm/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_fp8.py
@@ -22,13 +22,8 @@ from compressed_tensors.quantization import (QuantizationArgs,
 from jax.sharding import NamedSharding, PartitionSpec
 from torch.nn.parameter import Parameter
 from torchax.interop import jax_view, torch_view
-from vllm.model_executor.kernels.linear import (FP8ScaledMMLinearKernel,
-                                                register_linear_kernel)
-from vllm.model_executor.kernels.linear.scaled_mm import \
-    FP8ScaledMMLinearLayerConfig
 from vllm.model_executor.layers.quantization.compressed_tensors.schemes.compressed_tensors_w8a8_fp8 import \
     CompressedTensorsW8A8Fp8
-from vllm.platforms import PlatformEnum
 
 from tpu_inference.layers.common.linear import sharded_quantized_matmul
 from tpu_inference.layers.common.process_weights.linear_weights import (
@@ -36,6 +31,8 @@ from tpu_inference.layers.common.process_weights.linear_weights import (
     to_parameter_list)
 from tpu_inference.layers.common.quantization import (dequantize_tensor,
                                                       quantize_tensor)
+from tpu_inference.layers.common.quantization.fp8 import \
+    process_blockwise_fp8_linear_weights
 from tpu_inference.layers.common.utils import \
     slice_sharded_tensor_for_concatenation
 from tpu_inference.layers.vllm.quantization.configs import \
@@ -48,37 +45,6 @@ P = PartitionSpec
 logger = init_logger(__name__)
 
 
-class TpuFP8ScaledMMLinearKernel(FP8ScaledMMLinearKernel):
-    """Stub FP8 kernel registered for TPU platform.
-
-    VllmCompressedTensorsW8A8Fp8 fully overrides apply_weights and
-    process_weights_after_loading, so apply_scaled_mm is never called.
-    This class exists solely so that init_fp8_linear_kernel (called by the
-    upstream create_weights) can select a kernel without raising a KeyError
-    for the TPU platform.
-    """
-
-    @classmethod
-    def is_supported(
-            cls,
-            compute_capability: int | None = None) -> tuple[bool, str | None]:
-        return True, None
-
-    @classmethod
-    def can_implement(
-            cls, c: FP8ScaledMMLinearLayerConfig) -> tuple[bool, str | None]:
-        return True, None
-
-    def apply_scaled_mm(self, *, A, B, out_dtype, As, Bs, bias,
-                        output_shape) -> torch.Tensor:
-        raise NotImplementedError(
-            "TpuFP8ScaledMMLinearKernel.apply_scaled_mm should never be called"
-        )
-
-
-register_linear_kernel(TpuFP8ScaledMMLinearKernel, PlatformEnum.TPU, "fp8")
-
-
 class VllmCompressedTensorsW8A8Fp8(CompressedTensorsW8A8Fp8):
 
     def __init__(
@@ -87,12 +53,43 @@ class VllmCompressedTensorsW8A8Fp8(CompressedTensorsW8A8Fp8):
         is_static_input_scheme: bool,
         linear_config: VllmQuantLinearConfig,
     ):
+        # Per https://github.com/vllm-project/vllm/pull/32929,
+        # init_fp8_linear_kernel is now called by super().__init__
+        # but does not support TPU backends as expected.
+        # use_marlin was also changed to be determined via isinstance(self.fp8_linear, MarlinFP8ScaledMMLinearKernel).
+        # We need to monkeypatch init_fp8_linear_kernel and explicitly set use_marlin = True
+        # in order to bypass using native vLLM's vllm/vllm/model_executor/layers/quantization/utils/quant_utils.py:scaled_quantize.
+        from vllm.model_executor.layers.quantization.compressed_tensors.schemes import \
+            compressed_tensors_w8a8_fp8 as vllm_ct_fp8
+        vllm_ct_fp8.init_fp8_linear_kernel = lambda *args, **kwargs: None
+
         CompressedTensorsW8A8Fp8.__init__(
             self,
             weight_quant=weight_quant,
             is_static_input_scheme=is_static_input_scheme)
+        self.use_marlin = True
 
         self.linear_config = linear_config
+
+    def create_weights(
+        self,
+        layer: torch.nn.Module,
+        input_size_per_partition: int,
+        output_partition_sizes: list[int],
+        input_size: int,
+        output_size: int,
+        params_dtype: torch.dtype,
+        **extra_weight_attrs,
+    ):
+        # Per https://github.com/vllm-project/vllm/pull/33892, use_marlin is set again
+        # in vllm/model_executor/layers/quantization/fp8.py `create_weights`.
+        # The flag is set on whether a specific type of GPU kernel is being used which
+        # means it is set to False for TPU.
+        # We need to return it back to True here.
+        super().create_weights(layer, input_size_per_partition,
+                               output_partition_sizes, input_size, output_size,
+                               params_dtype, **extra_weight_attrs)
+        self.use_marlin = True
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
         weight = t2j(layer.weight, use_dlpack=False)
@@ -132,7 +129,14 @@ class VllmCompressedTensorsW8A8Fp8(CompressedTensorsW8A8Fp8):
                 weight, weight_scale = quantize_tensor(jnp.float8_e4m3fn,
                                                        weight, None)
             else:
-                weight_scale = jnp.squeeze(weight_scale, -1)
+                # Handle 2D blockwise scales correctly for quantized_matmul_kernel
+                # which expects 3D dims for blockwise ops.
+                # In standard per-channel quantization, the weight_scale is
+                # typically 2D with a singleton dimension which can be safely
+                # squeezed to 1D. However, in blockwise quantization, the
+                # scale is truly 2D.
+                if weight_scale.ndim == 2:
+                    weight_scale = jnp.squeeze(weight_scale)
 
             return process_linear_weights(
                 LinearWeights(
@@ -147,7 +151,37 @@ class VllmCompressedTensorsW8A8Fp8(CompressedTensorsW8A8Fp8):
                 per_tensor=per_tensor,
             )
 
-        weights = process_fp8_linear_weights(weight, weight_scale, bias)
+        if self.weight_block_size is not None:
+            weights = process_blockwise_fp8_linear_weights(
+                weight=weight,
+                weight_scale=weight_scale,
+                bias=bias,
+                weight_block_size=tuple(self.weight_block_size),
+                requant_block_size=self.linear_config.requant_block_size,
+                output_sizes=tuple(self.linear_config.output_sizes),
+                requant_weight_dtype=self.linear_config.requant_weight_dtype,
+                fuse_matmuls=self.linear_config.fuse_matmuls,
+                n_shards=self.linear_config.n_shards)
+        else:
+            weights = process_fp8_linear_weights(weight, weight_scale, bias)
+
+        if self.linear_config.enable_quantized_matmul_kernel and weights.weight_scale.ndim == 2:
+            if weights.weight_scale.shape[
+                    0] > 1 and weights.weight_scale.shape[1] > 1:
+                # The quantized_matmul_kernel expects weight scales shaped (n_blocks, 1, n_out_features) for blockwisze quantization.
+                if self.weight_block_size is not None:
+                    # process_blockwise_fp8_linear_weights returns weight_scale shaped (n_out_features, n_blocks)
+                    # We need it shaped (n_blocks, 1, n_out_features)
+                    weights.weight_scale = jnp.expand_dims(
+                        jnp.transpose(weights.weight_scale),
+                        axis=1,
+                    )
+                else:
+                    weights.weight_scale = jnp.expand_dims(
+                        jnp.transpose(weights.weight_scale),
+                        axis=1,
+                    )
+
         weights = torch_view(
             shard_linear_weights(
                 weights,

--- a/tpu_inference/models/vllm/experimental/model_patcher.py
+++ b/tpu_inference/models/vllm/experimental/model_patcher.py
@@ -28,6 +28,7 @@ import jax
 import torchax
 from torchax.interop import JittableModule, torch_view
 
+from tpu_inference import envs
 from tpu_inference.logger import init_logger
 
 if TYPE_CHECKING:
@@ -66,6 +67,59 @@ def patch_mm_model(
     Returns:
         The patched model and the updated parameters and buffers.
     """
+    # Monkey patch vLLM's _merge_multimodal_embeddings to support JAX/torchax
+    # broadcasting limitations with boolean masks.
+    if envs.VLLM_TPU_PATCH_MM_EMBEDDINGS:
+        try:
+            import vllm.model_executor.models.utils as vllm_utils
+
+            # Save the original to avoid recursion if patched multiple times
+            if not hasattr(vllm_utils,
+                           "_original_merge_multimodal_embeddings"):
+                vllm_utils._original_merge_multimodal_embeddings = vllm_utils._merge_multimodal_embeddings
+
+                def _jax_compatible_merge_multimodal_embeddings(
+                        inputs_embeds, multimodal_embeddings, is_multimodal):
+                    if len(multimodal_embeddings) == 0:
+                        return inputs_embeds
+
+                    import torch
+
+                    mm_embeds_flat = vllm_utils._flatten_embeddings(
+                        multimodal_embeddings)
+                    input_dtype = inputs_embeds.dtype
+                    mm_embeds_flat = mm_embeds_flat.to(dtype=input_dtype)
+
+                    # PyTorch boolean indexing (inputs[mask] = values) requires dynamic
+                    # host-synchronization. We use static math ops (cumsum, where)
+                    # which trace perfectly via torchax into JAX without deadlocking.
+
+                    # Create a dummy row to handle indices for non-multimodal tokens.
+                    dummy_row = torch.zeros_like(mm_embeds_flat[0:1])
+                    # Prepend the dummy row.
+                    flattened_padded = torch.cat([dummy_row, mm_embeds_flat],
+                                                 dim=0)
+
+                    # For non-multimodal tokens, cumsum points to 0.
+                    # For multimodal tokens, it points to their 1-based index in the padded array.
+                    gather_indices = is_multimodal.to(
+                        torch.int64).cumsum(dim=0)
+                    update_values = flattened_padded[gather_indices]
+
+                    condition = is_multimodal.unsqueeze(-1)
+                    new_embeds = torch.where(condition, update_values,
+                                             inputs_embeds)
+
+                    return new_embeds
+
+                vllm_utils._merge_multimodal_embeddings = _jax_compatible_merge_multimodal_embeddings
+                logger.info(
+                    "Patched vLLM's _merge_multimodal_embeddings with static JAX logic."
+                )
+        except Exception as e:
+            logger.warning(
+                f"Failed to patch vLLM's _merge_multimodal_embeddings: {e}")
+
     if not jitted_mm_module_keys:
         return model, params_and_buffers
 

--- a/tpu_inference/models/vllm/vllm_model_wrapper.py
+++ b/tpu_inference/models/vllm/vllm_model_wrapper.py
@@ -502,7 +502,9 @@ class VllmModelWrapper:
                         "call_method": "embed_input_ids",
                         "call_args": call_args,
                         "call_kwargs": {
-                            "is_multimodal": torch_view(is_multimodal),
+                            "is_multimodal":
+                            torch_view(is_multimodal)
+                            if is_multimodal is not None else False,
                         },
                     },
                     tie_weights=False,

--- a/tpu_inference/runner/compilation_manager.py
+++ b/tpu_inference/runner/compilation_manager.py
@@ -156,7 +156,7 @@ class CompilationManager:
             dummy_input_ids = self._create_dummy_tensor(
                 (num_tokens, ), jnp.int32, sharding=input_sharding)
             dummy_is_multimodal = self._create_dummy_tensor(
-                (num_tokens, ), jnp.int32, sharding=input_sharding)
+                (num_tokens, ), jnp.bool_, sharding=input_sharding)
 
             self._run_compilation(
                 "input_embeddings_merger",


### PR DESCRIPTION
# Description

Adds support for mistral 3 large, tested on v7x-16.

# Tests

Full model (takes 90+ mins to start up):

```bash
VLLM_DISABLE_SHARED_EXPERTS_STREAM=0 \
MOE_REQUANTIZE_BLOCK_SIZE=512 \
NEW_MODEL_DESIGN=1 \
MODEL_IMPL_TYPE=vllm \
HF_HOME="/mnt/disks/persist/hf" \
TPU_BACKEND_TYPE=jax \
vllm serve \
    --model mistralai/Mistral-Large-3-675B-Instruct-2512 \
    --download-dir /mnt/disks/persist/hf/hub \
    --max-model-len 5120 \
    --max-num-batched-tokens 4096 \
    --max-num-seqs 16 \
    --no-enable-prefix-caching \
    --tensor-parallel-size 16 \
    --kv-cache-dtype "fp8" \
    --no-async-scheduling \
    --gpu-memory-utilization 0.90 \
    --enable-expert-parallel \
    --additional_config='{"sharding": {"sharding_strategy": {"enable_dp_attention": true}}}' \
    --trust-remote-code \
    --tokenizer-mode mistral \
    --config_format mistral \
    --load_format mistral \
    --port 8000
```

Text-to-text:

```bash
$ curl http://localhost:8000/v1/chat/completions \
    -H "Content-Type: application/json" \
    -d '{
      "model": "mistralai/Mistral-Large-3-675B-Instruct-2512",
      "messages": [
        {"role": "system", "content": "You are a helpful assistant."},
        {"role": "user", "content": "What are the top 5 most popular programming languages? Be brief."}
      ],
      "temperature": 0.7
}'
{"id":"chatcmpl-a0adc67a720a1011","object":"chat.completion","created":1777305131,"model":"mistralai/Mistral-Large-3-675B-Instruct-2512","choices":[{"index":0,"message":{"role":"assistant","content":"Here are the top 5 most popular programming languages as of recent rankings:\n\n1. **Python**\n2. **JavaScript**\n3. **Java**\n4. **C#**\n5. **C/C++**\n\n(Source: TIOBE Index, Stack Overflow Developer Survey, and GitHub's Octoverse)","refusal":null,"annotations":null,"audio":null,"function_call":null,"tool_calls":[],"reasoning":null},"logprobs":null,"finish_reason":"stop","stop_reason":null,"token_ids":null}],"service_tier":null,"system_fingerprint":null,"usage":{"prompt_tokens":25,"total_tokens":91,"completion_tokens":66,"prompt_tokens_details":null},"prompt_logprobs":null,"prompt_token_ids":null,"kv_transfer_params":null}r
```

Image-to-text:

```bash
$ curl http://localhost:8000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
    "model": "mistralai/Mistral-Large-3-675B-Instruct-2512",
    "messages": [
      {
        "role": "user",
        "content": [
          { "type": "text", "text": "What is in this image?" },
          {
            "type": "image_url",
            "image_url": { "url": "https://a-z-animals.com/media/swan-3.jpg" }
          }
        ]
      }
    ],
    "max_tokens": 50
  }'
{"id":"chatcmpl-8ce6a7fd895be7f4","object":"chat.completion","created":1777305287,"model":"mistralai/Mistral-Large-3-675B-Instruct-2512","choices":[{"index":0,"message":{"role":"assistant","content":"The image shows a swan, more specifically a mute swan (Cygnus olor), swimming on a body of water. Mute swans are known for their elegant, all-white plumage, orange beak with a black base,","refusal":null,"annotations":null,"audio":null,"function_call":null,"tool_calls":[],"reasoning":null},"logprobs":null,"finish_reason":"length","stop_reason":null,"token_ids":null}],"service_tier":null,"system_fingerprint":null,"usage":{"prompt_tokens":897,"total_tokens":947,"completion_tokens":50,"prompt_tokens_details":null},"prompt_logprobs":null,"prompt_token_ids":null,"kv_transfer_params":null}
```

vLLM benchmark:

```bash
$ vllm bench serve --model mistralai/Mistral-Large-3-675B-Instruct-2512 --dataset-name random --random-input-len 1024 --random-output-len 1024 --num-prompts 320 --ignore-eos --skip-chat-template

============ Serving Benchmark Result ============
Successful requests:                     320
Failed requests:                         0
Benchmark duration (s):                  115.43
Total input tokens:                      327680
Total generated tokens:                  327680
Request throughput (req/s):              2.77
Output token throughput (tok/s):         2838.89
Peak output token throughput (tok/s):    5054.00
Peak concurrent requests:                320.00
Total token throughput (tok/s):          5677.77
---------------Time to First Token----------------
Mean TTFT (ms):                          20404.53
Median TTFT (ms):                        8991.31
P99 TTFT (ms):                           70148.74
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          56.90
Median TPOT (ms):                        59.80
P99 TPOT (ms):                           61.81
---------------Inter-token Latency----------------
Mean ITL (ms):                           56.90
Median ITL (ms):                         52.38
P99 ITL (ms):                            55.80
==================================================
```

Correctness check


```bash
lm_eval --model local-completions \
	--model_args model=mistralai/Mistral-Large-3-675B-Instruct-2512,base_url=http://localhost:8000/v1/completions,num_concurrent=16,max_length=5120 \
	--tasks gsm8k  --apply_chat_template --num_fewshot 8 \
	--limit 100
```

Result

```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|-----|------:|----------------|-----:|-----------|---|----:|---|-----:|
|gsm8k|      3|flexible-extract|     8|exact_match|↑  | 0.93|±  |0.0256|
|     |       |strict-match    |     8|exact_match|↑  | 0.10|±  |0.0302|
```

There's no official results that I can find for this specific benchmark and model, but anything >70% is considered great. Low `strict-match` score is expected for instruct models, but the very high `flexible-extract` is a good sign.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
