### PR TITLE
[Bug][Qwen3.5] Honor has_initial_state in fused GDN kernel

### DIFF
--- a/tests/kernels/fused_gdn_kernel_test.py
+++ b/tests/kernels/fused_gdn_kernel_test.py
@@ -314,15 +314,18 @@ class FusedGdnKernelTest(jtu.JaxTestCase):
                             check_dtypes=False)
 
     @parameterized.named_parameters(
-        # `all_true` covers the True-preserves-loaded-state path;
-        # `alternating` exercises the per-slot SMEM lookup (catches
-        # off-by-one or uniformly-applied conditional). The all-False
-        # case is covered by `test_has_initial_state_zeros_stale_slot`
-        # (which is a stronger test — fused-with-stale vs
-        # fused-with-fresh, directly validating the kernel's zeroing
-        # rather than just matching ref). Extra positional patterns
-        # (first-only / last-only / etc.) add CI time without new
-        # coverage given the kernel's per-seq SMEM-indexed conditional.
+        # Two patterns chosen for orthogonal coverage:
+        #   * `all_true` — every slot uses its loaded h0 (no
+        #     zeroing); the continuation case.
+        #   * `alternating` — has_initial_state varies by slot, so
+        #     the kernel must look up the right SMEM entry per
+        #     seq; catches off-by-one or uniformly-applied
+        #     conditional bugs.
+        # The all-False case is covered by
+        # `test_has_initial_state_zeros_stale_slot`, which directly
+        # compares fused-with-stale vs fused-with-fresh rather than
+        # matching the ref. Extra patterns (first-only, last-only,
+        # ...) add CI time without new coverage.
         dict(testcase_name="all_true", pattern=[True, True, True, True]),
         dict(testcase_name="alternating", pattern=[True, False, True, False]),
     )

--- a/tests/kernels/fused_gdn_kernel_test.py
+++ b/tests/kernels/fused_gdn_kernel_test.py
@@ -105,6 +105,7 @@ class FusedGdnKernelTest(jtu.JaxTestCase):
         use_dt_bias=False,
         lower_bound=None,
         atol=1e-2,
+        has_initial_state_active=None,
     ):
         rng = np.random.RandomState(42)
         q, k, v, a, b, A_log, h0, cu_seqlens, state_indices, N = _make_inputs(
@@ -121,6 +122,24 @@ class FusedGdnKernelTest(jtu.JaxTestCase):
 
         dt_bias = (jnp.array(rng.randn(H_v).astype(np.float32))
                    if use_dt_bias else jnp.zeros(H_v, dtype=jnp.float32))
+
+        # `has_initial_state_active` is a python list of bools for the
+        # ACTIVE sequences only (length N); we pad to `max_num_req` with
+        # True for the padded slots (their state isn't read by either
+        # impl, but the array shape must match `state_indices`). Default
+        # behaviour (None) is all-True, which matches the pre-fix path
+        # and keeps the existing baseline tests valid.
+        max_num_req_padded = state_indices.shape[0]
+        if has_initial_state_active is None:
+            has_initial_state = jnp.ones((max_num_req_padded, ),
+                                         dtype=jnp.bool_)
+        else:
+            assert len(has_initial_state_active) == N, (
+                f"has_initial_state_active must have length N={N}, got "
+                f"{len(has_initial_state_active)}")
+            full = np.ones(max_num_req_padded, dtype=np.bool_)
+            full[:N] = np.array(has_initial_state_active, dtype=np.bool_)
+            has_initial_state = jnp.array(full)
 
         # ── Reference (ragged_gated_delta_rule_ref) ──
         mixed_qkv = jnp.concatenate(
@@ -141,6 +160,7 @@ class FusedGdnKernelTest(jtu.JaxTestCase):
             cu_seqlens,
             state_indices,
             distribution_ref,
+            has_initial_state,
             n_kq=H_qk,
             n_v=H_v,
             d_k=K,
@@ -158,6 +178,7 @@ class FusedGdnKernelTest(jtu.JaxTestCase):
             h0,
             state_indices,
             b=b,
+            has_initial_state=has_initial_state,
             distribution=jnp.array([decode_N, N], dtype=jnp.int32),
             use_qk_l2norm_in_kernel=True,
             use_gate_in_kernel=True,
@@ -219,6 +240,139 @@ class FusedGdnKernelTest(jtu.JaxTestCase):
     )
     def test_gqa(self, decode_N, mixed_seqlens):
         self._test_fused_gdn(decode_N, mixed_seqlens, 2, 8, 128, 128)
+
+    # ── has_initial_state masking ──
+
+    def test_has_initial_state_zeros_stale_slot(self):
+        """When ``has_initial_state[i]`` is False, the recurrent kernel
+        must treat the slot's prior contents as zero — even though the
+        DMA-loaded h0 holds whatever a previous tenant left there.
+
+        Compares two runs over identical token inputs:
+          * fresh: h0 is zero everywhere (slot already cleared).
+          * stale: h0 is random nonzero at the active slots, with
+            has_initial_state=False so the kernel zeros h0 in VMEM.
+
+        The per-token outputs and the written-back state for active
+        slots must match — if they don't, stale state is leaking into
+        the recurrent update and a freshly-allocated mamba slot would
+        corrupt the new request's trajectory.
+        """
+        H_qk, H_v, K, V = 2, 8, 128, 128
+        # Two prefill sequences, no decodes.
+        decode_N = 0
+        mixed_seqlens = [9, 15]
+        rng = np.random.RandomState(123)
+        q, k, v, a, b, A_log, _h0_ignored, cu_seqlens, state_indices, N = (
+            _make_inputs(rng, decode_N, mixed_seqlens, H_qk, H_v, K, V))
+        max_num_req = state_indices.shape[0]
+
+        h0_fresh = jnp.zeros((max_num_req, H_v, K, V), dtype=jnp.float32)
+        # Stale h0: nonzero at every active slot. The kernel must
+        # ignore these values when has_initial_state is False.
+        h0_stale = jnp.array(
+            rng.randn(max_num_req, H_v, K, V).astype(np.float32))
+
+        has_initial_state = jnp.zeros((max_num_req, ), dtype=jnp.bool_)
+        distribution = jnp.array([decode_N, N], dtype=jnp.int32)
+
+        common_kwargs = dict(
+            cu_seqlens=cu_seqlens,
+            g=a,
+            state_indices=state_indices,
+            distribution=distribution,
+            b=b,
+            has_initial_state=has_initial_state,
+            use_qk_l2norm_in_kernel=True,
+            use_gate_in_kernel=True,
+            A_log=A_log,
+        )
+
+        # Re-create q, k, v each call — fused_gdn donates `v` so we
+        # must hand it a fresh buffer per invocation.
+        o_fresh, state_fresh = fused_gdn(jnp.array(q),
+                                         jnp.array(k),
+                                         jnp.array(v),
+                                         initial_state=h0_fresh,
+                                         **common_kwargs)
+        o_stale, state_stale = fused_gdn(jnp.array(q),
+                                         jnp.array(k),
+                                         jnp.array(v),
+                                         initial_state=h0_stale,
+                                         **common_kwargs)
+
+        self.assertAllClose(o_stale,
+                            o_fresh,
+                            atol=1e-4,
+                            rtol=1e-4,
+                            check_dtypes=False)
+        # Compare the active slots; padding slots are not exercised.
+        self.assertAllClose(state_stale[:N],
+                            state_fresh[:N],
+                            atol=1e-4,
+                            rtol=1e-4,
+                            check_dtypes=False)
+
+    @parameterized.named_parameters(
+        # `all_true` covers the True-preserves-loaded-state path;
+        # `alternating` exercises the per-slot SMEM lookup (catches
+        # off-by-one or uniformly-applied conditional). The all-False
+        # case is covered by `test_has_initial_state_zeros_stale_slot`
+        # (which is a stronger test — fused-with-stale vs
+        # fused-with-fresh, directly validating the kernel's zeroing
+        # rather than just matching ref). Extra positional patterns
+        # (first-only / last-only / etc.) add CI time without new
+        # coverage given the kernel's per-seq SMEM-indexed conditional.
+        dict(testcase_name="all_true", pattern=[True, True, True, True]),
+        dict(testcase_name="alternating", pattern=[True, False, True, False]),
+    )
+    def test_has_initial_state_pattern_matches_ref(self, pattern):
+        """fused_gdn vs ragged_gated_delta_rule_ref across per-slot
+        has_initial_state patterns. The ref impl's masking is well-
+        validated (PR #2408), so any mismatch points at the kernel.
+        """
+        self._test_fused_gdn(decode_N=0,
+                             mixed_seqlens=[9, 15, 33, 7],
+                             H_qk=2,
+                             H_v=8,
+                             K=128,
+                             V=128,
+                             has_initial_state_active=pattern)
+
+    def test_has_initial_state_long_sequence_multi_block(self):
+        """A single sequence of 2200 tokens spans 2 blocks (bt=2048 for
+        H_qk=2, H_v=8, K=V=128). The kernel must zero h0 only at the
+        first block (`is_new_seq`); subsequent blocks of the same seq
+        carry the running state in `h_bufs[buf_idx]` and must NOT
+        re-zero, otherwise the second-block tokens see zero state and
+        output diverges from ref. The continuation case (True) is
+        already covered by `pattern_matches_ref_all_true`.
+        """
+        self._test_fused_gdn(decode_N=0,
+                             mixed_seqlens=[2200],
+                             H_qk=2,
+                             H_v=8,
+                             K=128,
+                             V=128,
+                             has_initial_state_active=[False])
+
+    def test_has_initial_state_decode_plus_new_prefill(self):
+        """Decodes (always has_initial_state=True) interleaved with new
+        prefills (has_initial_state=False). The decode kernel writes
+        state for decode positions first; the recurrent kernel must
+        zero only the prefill slots, leaving decode slots' updated
+        state intact.
+        """
+        decode_N = 5
+        prefill_lens = [9, 15, 33]
+        pattern = [True] * decode_N + [False] * len(prefill_lens)
+        self._test_fused_gdn(decode_N=decode_N,
+                             mixed_seqlens=prefill_lens,
+                             H_qk=2,
+                             H_v=8,
+                             K=128,
+                             V=128,
+                             has_initial_state_active=pattern)
 
 
 if __name__ == "__main__":

--- a/tests/layers/common/test_gdn_attention.py
+++ b/tests/layers/common/test_gdn_attention.py
@@ -221,6 +221,11 @@ class GDNAttentionTest(parameterized.TestCase):
             test_config=GdnAttentionConfig(
                 ragged_gated_delta_rule_impl=RaggedGatedDeltaRuleImpl.REF),
         ),
+        dict(
+            testcase_name="fused",
+            test_config=GdnAttentionConfig(
+                ragged_gated_delta_rule_impl=RaggedGatedDeltaRuleImpl.FUSED),
+        ),
     )
     def test_has_initial_state_zeros_stale_slot(self, test_config):
         """A new prefill landing on a slot whose previous tenant left
@@ -350,6 +355,11 @@ class GDNAttentionTest(parameterized.TestCase):
             testcase_name="ref",
             test_config=GdnAttentionConfig(
                 ragged_gated_delta_rule_impl=RaggedGatedDeltaRuleImpl.REF),
+        ),
+        dict(
+            testcase_name="fused",
+            test_config=GdnAttentionConfig(
+                ragged_gated_delta_rule_impl=RaggedGatedDeltaRuleImpl.FUSED),
         ),
     )
     def test_has_initial_state_preserves_continuation(self, test_config):

--- a/tpu_inference/kernels/gdn/fused_gdn_kernel_wrapper.py
+++ b/tpu_inference/kernels/gdn/fused_gdn_kernel_wrapper.py
@@ -120,7 +120,7 @@ def fused_gdn(
     state_indices: jax.Array,  # [max_num_req] int32
     distribution: jax.Array,  # [2] int32
     b: jax.Array | None = None,  # [T, H_v] or None
-    has_initial_state: jax.Array | None = None,  # [max_num_req] bool/int
+    has_initial_state: jax.Array | None = None,  # [max_num_req] bool
     scale: float | None = None,
     use_qk_l2norm_in_kernel: bool = False,
     use_gate_in_kernel: bool = False,
@@ -145,8 +145,8 @@ def fused_gdn(
         distribution: ``i32[2]`` — ``(decode_end, total)``.
         b: Raw betas ``[T, H_v]`` (sigmoid applied inside kernel).
             ``None`` means beta=1 (no beta gating).
-        has_initial_state: Boolean / int32 ``[max_num_req]``. ``True`` /
-            non-zero when the request's recurrent slot already holds a
+        has_initial_state: Boolean tensor of shape ``[max_num_req]``.
+            ``True`` when the request's recurrent slot already holds a
             valid prior state (chunked-prefill continuation, prefix-cache
             hit, or running decode). ``False`` for brand-new prefills,
             whose slot is zeroed inside the recurrent kernel before the
@@ -202,9 +202,10 @@ def fused_gdn(
         A_log = jnp.broadcast_to(A_log[:, None], (H_v, num_lanes)).astype(
             jnp.float32)  # [H_v, num_lanes]
 
-    # Default to all-True (no masking), matching the pre-fix behaviour.
-    # Cast to int32 for SMEM compatibility — the recurrent kernel checks
-    # `has_init == 0` to decide whether to zero h0.
+    # Public contract is Boolean (matching the chunked / ref impls);
+    # cast to int32 here for SMEM compatibility — the recurrent kernel
+    # checks `has_init == 0` to decide whether to zero h0. Default to
+    # all-True (no masking), matching the pre-fix behaviour.
     max_num_req = state_indices.shape[0]
     if has_initial_state is None:
         has_initial_state = jnp.ones((max_num_req, ), dtype=jnp.int32)
@@ -264,14 +265,14 @@ def ragged_gated_delta_rule(
         query_start_loc: ``(num_seqs+1,)`` int32.
         state_indices: ``(num_seqs,)`` int32.
         distribution: ``(3,)`` int32 — ``(decode_end, prefill_end, mixed_end)``.
-        has_initial_state: Optional ``(max_reqs,)`` bool / int32. ``True``
-            / non-zero when the request's slot already holds a valid
-            prior recurrent state; ``False`` for brand-new prefills (the
-            recurrent kernel zeros h0 for those slots so stale data from
-            a reused mamba slot doesn't leak). ``None`` (default) is
-            treated as all-True, preserving the pre-PR-#2408 behaviour.
-            Pass it when you want the same stale-slot guard the chunked
-            and ref impls already enforce.
+        has_initial_state: Optional Boolean tensor of shape
+            ``(max_reqs,)``. ``True`` when the request's slot already
+            holds a valid prior recurrent state; ``False`` for brand-new
+            prefills (the recurrent kernel zeros h0 for those slots so
+            stale data from a reused mamba slot doesn't leak). ``None``
+            (default) is treated as all-True, preserving the
+            pre-PR-#2408 behaviour. Pass it when you want the same
+            stale-slot guard the chunked and ref impls already enforce.
         n_kq: Number of key/query heads.
         n_v: Number of value heads.
         d_k: Key dimension.

--- a/tpu_inference/kernels/gdn/fused_gdn_kernel_wrapper.py
+++ b/tpu_inference/kernels/gdn/fused_gdn_kernel_wrapper.py
@@ -36,6 +36,7 @@ def _dispatch_with_distribution(
     initial_state,
     state_indices,
     b,
+    has_initial_state,
     *,
     scale,
     use_qk_l2norm,
@@ -50,6 +51,10 @@ def _dispatch_with_distribution(
     Both kernels update the state cache in-place via ``input_output_aliases``.
     The decode kernel runs first, then its updated state and output are
     chained to the recurrent kernel.
+
+    ``has_initial_state`` is consumed only by the recurrent kernel: decode
+    tokens always have a valid prior state (a request must finish prefill
+    before it can decode), so masking is unnecessary on the decode path.
     """
     # ── Decode kernel → updates state in-place ──
     o_d, state_1 = fused_decoding_gdn(
@@ -79,6 +84,7 @@ def _dispatch_with_distribution(
         state_1,
         state_indices,
         b,
+        has_initial_state,
         scale=scale,
         use_qk_l2norm=use_qk_l2norm,
         use_gate_in_kernel=use_gate_in_kernel,
@@ -114,6 +120,7 @@ def fused_gdn(
     state_indices: jax.Array,  # [max_num_req] int32
     distribution: jax.Array,  # [2] int32
     b: jax.Array | None = None,  # [T, H_v] or None
+    has_initial_state: jax.Array | None = None,  # [max_num_req] bool/int
     scale: float | None = None,
     use_qk_l2norm_in_kernel: bool = False,
     use_gate_in_kernel: bool = False,
@@ -138,6 +145,14 @@ def fused_gdn(
         distribution: ``i32[2]`` — ``(decode_end, total)``.
         b: Raw betas ``[T, H_v]`` (sigmoid applied inside kernel).
             ``None`` means beta=1 (no beta gating).
+        has_initial_state: Boolean / int32 ``[max_num_req]``. ``True`` /
+            non-zero when the request's recurrent slot already holds a
+            valid prior state (chunked-prefill continuation, prefix-cache
+            hit, or running decode). ``False`` for brand-new prefills,
+            whose slot is zeroed inside the recurrent kernel before the
+            update so stale data from a previous tenant doesn't leak.
+            ``None`` (default) is treated as all-True, preserving the
+            pre-fix behaviour for callers that don't manage slot reuse.
         scale: Scale factor.  Default ``K ** -0.5``.
         use_qk_l2norm_in_kernel: L2-normalize q, k inside the kernel.
         use_gate_in_kernel: Apply gate transformation inside kernel.
@@ -187,6 +202,15 @@ def fused_gdn(
         A_log = jnp.broadcast_to(A_log[:, None], (H_v, num_lanes)).astype(
             jnp.float32)  # [H_v, num_lanes]
 
+    # Default to all-True (no masking), matching the pre-fix behaviour.
+    # Cast to int32 for SMEM compatibility — the recurrent kernel checks
+    # `has_init == 0` to decide whether to zero h0.
+    max_num_req = state_indices.shape[0]
+    if has_initial_state is None:
+        has_initial_state = jnp.ones((max_num_req, ), dtype=jnp.int32)
+    else:
+        has_initial_state = has_initial_state.astype(jnp.int32)
+
     o, state = _dispatch_with_distribution(
         q,
         k,
@@ -196,6 +220,7 @@ def fused_gdn(
         initial_state,
         state_indices,
         b,
+        has_initial_state,
         scale=scale,
         use_qk_l2norm=use_qk_l2norm_in_kernel,
         use_gate_in_kernel=use_gate_in_kernel,
@@ -218,6 +243,7 @@ def ragged_gated_delta_rule(
     query_start_loc,
     state_indices,
     distribution,
+    has_initial_state=None,
     *,
     n_kq,
     n_v,
@@ -238,6 +264,14 @@ def ragged_gated_delta_rule(
         query_start_loc: ``(num_seqs+1,)`` int32.
         state_indices: ``(num_seqs,)`` int32.
         distribution: ``(3,)`` int32 — ``(decode_end, prefill_end, mixed_end)``.
+        has_initial_state: Optional ``(max_reqs,)`` bool / int32. ``True``
+            / non-zero when the request's slot already holds a valid
+            prior recurrent state; ``False`` for brand-new prefills (the
+            recurrent kernel zeros h0 for those slots so stale data from
+            a reused mamba slot doesn't leak). ``None`` (default) is
+            treated as all-True, preserving the pre-PR-#2408 behaviour.
+            Pass it when you want the same stale-slot guard the chunked
+            and ref impls already enforce.
         n_kq: Number of key/query heads.
         n_v: Number of value heads.
         d_k: Key dimension.
@@ -270,6 +304,7 @@ def ragged_gated_delta_rule(
         state_indices=state_indices,
         distribution=fused_distribution,
         b=b,
+        has_initial_state=has_initial_state,
         use_qk_l2norm_in_kernel=True,
         use_gate_in_kernel=True,
         A_log=A_log,

--- a/tpu_inference/kernels/gdn/fused_gdn_recurrent_kernel.py
+++ b/tpu_inference/kernels/gdn/fused_gdn_recurrent_kernel.py
@@ -198,6 +198,7 @@ def _recurrent_gdn_main(
     a_log_hbm,  # [H_v, num_lanes] or None
     dt_bias_hbm,  # [H_v, num_lanes] or None
     _state_init_ref,  # [num_states, H_v, K, V] aliased to state_hbm
+    has_initial_state_ref,  # [max_num_req] int32 (SMEM); 0 = zero out h0
     o_hbm,  # [T, H_v, V]
     state_hbm,  # [num_states, H_v, K, V]
     h_bufs,  # [2, H_v, K, V] VMEM scratch (double buffer)
@@ -253,6 +254,7 @@ def _recurrent_gdn_main(
             h_bufs_s,  # [2, H_v, K, V] VMEM scratch
             meta_s,  # GDNChunkIndices (SMEM)
             state_indices_s,  # [max_num_req] int32 (SMEM)
+            has_initial_state_s,  # [max_num_req] int32 (SMEM)
             h_load_sems_s,  # [2] DMA semaphores
             h_store_sems_s,  # [2] DMA semaphores
     ):
@@ -298,6 +300,19 @@ def _recurrent_gdn_main(
         @pl.when(is_new_seq)
         def _wait_h0():
             load_wait_cp.wait()
+
+        # If the request has no prior recurrent state (brand-new prefill
+        # landing on a freshly-allocated mamba slot), the DMA-loaded h0
+        # is stale data from a previous tenant. Overwrite with zeros so
+        # the recurrent update starts from zero, mirroring the chunked
+        # path's `init_states_for_seqs = jnp.where(has_initial_state,
+        # ..., 0)` and GPU's `initial_state[~has_initial_state, ...] = 0`
+        # in `gdn_linear_attn._forward_core`.
+        has_init = has_initial_state_s[seq_idx]
+
+        @pl.when(is_new_seq & (has_init == 0))
+        def _zero_h0():
+            h_bufs_s[buf_idx] = jnp.zeros((H_v, K, V), dtype=h_bufs_s.dtype)
 
         # ── Step 2: Compute ──
         h = h_bufs_s[buf_idx].astype(jnp.float32)
@@ -418,7 +433,10 @@ def _recurrent_gdn_main(
         a_log_hbm,
         dt_bias_hbm,
         o_hbm,
-        scratches=[h_bufs, meta, state_indices_ref, h_load_sems, h_store_sems],
+        scratches=[
+            h_bufs, meta, state_indices_ref, has_initial_state_ref,
+            h_load_sems, h_store_sems
+        ],
     )
 
     # ── Epilogue: wait for outstanding stores ──
@@ -455,6 +473,7 @@ def fused_recurrent_gdn(
         initial_state,  # [num_states, H_v, K, V] float32
         state_indices,  # [max_num_req] int32
         b,  # [T, H_v, num_lanes] or None
+        has_initial_state,  # [max_num_req] int32 (0/1)
         *,
         scale,  # float
         use_qk_l2norm,  # bool
@@ -465,6 +484,15 @@ def fused_recurrent_gdn(
         distribution,  # [2] int32
 ):
     """Run the pre-computed-metadata recurrent GDN pallas kernel.
+
+    ``has_initial_state[i]`` indicates whether request ``i``'s recurrent
+    slot already holds a valid prior state (continuation, prefix-cache
+    hit) or whether the slot is freshly allocated and its contents must
+    be treated as zeros for this call. Mirrors the chunked path's
+    `init_states_for_seqs = jnp.where(has_initial_state, ..., 0)` and
+    GPU's `initial_state[~has_initial_state, ...] = 0` in
+    ``gdn_linear_attn._forward_core``. Pass an all-ones array if the
+    caller wants the previous (no-op) behaviour.
     """
     T, H_qk, H_v, K, V, dtype, num_states, num_lanes, _ = (validate_gdn_inputs(
         q,
@@ -530,6 +558,7 @@ def fused_recurrent_gdn(
                 any_spec if A_log is not None else None,
                 any_spec if dt_bias is not None else None,
                 any_spec,  # state_init (= initial_state)
+                smem_spec,  # has_initial_state
             ],
             out_specs=[any_spec, any_spec],
             grid=(grid_dim, ),
@@ -540,6 +569,10 @@ def fused_recurrent_gdn(
                 pltpu.SemaphoreType.DMA((2, )),  # h_store_sems
             ],
         ),
+        # Aliases reference flat positional inputs. `meta` is a 3-leaf
+        # pytree, so the absolute index of `v` is 5 (3 meta leaves + q, k)
+        # and the absolute index of `initial_state` is 8 + n_b + n_gate.
+        # `has_initial_state` is appended to the end and is not aliased.
         input_output_aliases={
             5: 0,
             8 + n_b + n_gate: 1
@@ -561,6 +594,7 @@ def fused_recurrent_gdn(
         A_log,
         dt_bias,
         initial_state,
+        has_initial_state,
     )
 
     return o, state

--- a/tpu_inference/layers/common/gdn_attention.py
+++ b/tpu_inference/layers/common/gdn_attention.py
@@ -169,37 +169,18 @@ def run_jax_gdn_attention_local(
             use_qk_norm_in_gdn=True,
         )
 
-    if config.ragged_gated_delta_rule_impl == RaggedGatedDeltaRuleImpl.FUSED:
-        # All three impls (fused / chunked / ref) honor `has_initial_state`
-        # — the fused recurrent kernel zeros h0 in VMEM for slots whose
-        # flag is 0. The branch is preserved (rather than unified into a
-        # single call) so each path stays explicitly visible in the
-        # dispatch in case one impl ever needs a different call shape.
-        new_recurrent_state, output = ragged_gdn_impl(
-            out_mixed_qkv,
-            b,
-            a,
-            recurrent_state,
-            A_log,
-            dt_bias,
-            query_start_loc,
-            state_indices,
-            distribution,
-            has_initial_state,
-        )
-    else:
-        new_recurrent_state, output = ragged_gdn_impl(
-            out_mixed_qkv,
-            b,
-            a,
-            recurrent_state,
-            A_log,
-            dt_bias,
-            query_start_loc,
-            state_indices,
-            distribution,
-            has_initial_state,
-        )
+    new_recurrent_state, output = ragged_gdn_impl(
+        out_mixed_qkv,
+        b,
+        a,
+        recurrent_state,
+        A_log,
+        dt_bias,
+        query_start_loc,
+        state_indices,
+        distribution,
+        has_initial_state,
+    )
 
     return (new_conv_state, new_recurrent_state), output
 

--- a/tpu_inference/layers/common/gdn_attention.py
+++ b/tpu_inference/layers/common/gdn_attention.py
@@ -117,9 +117,11 @@ def run_jax_gdn_attention_local(
     """
     # has_initial_state[i] = True iff request i already has computed
     # tokens in its mamba slot (chunked-prefill continuation, prefix-cache
-    # hit, or running decode). False for brand-new prefills, whose
-    # gathered conv/recurrent state is then masked to zero by the
-    # ragged kernels. context_len = seq_len - query_len.
+    # hit, or running decode). False for brand-new prefills, in which
+    # case the conv1d, the chunked / ref delta-rule impls, and the fused
+    # Pallas recurrent kernel all zero the slot's prior state before
+    # the update so a freshly-allocated mamba slot can't leak its
+    # previous tenant's state. context_len = seq_len - query_len.
     max_reqs = seq_lens.shape[0]
     query_lens = query_start_loc[1:max_reqs + 1] - query_start_loc[:max_reqs]
     has_initial_state = (seq_lens - query_lens) > 0
@@ -168,9 +170,11 @@ def run_jax_gdn_attention_local(
         )
 
     if config.ragged_gated_delta_rule_impl == RaggedGatedDeltaRuleImpl.FUSED:
-        # The fused kernel does not yet honor `has_initial_state`. Fall
-        # through with the existing call signature; the chunked/ref paths
-        # used in production already mask via the new argument below.
+        # All three impls (fused / chunked / ref) honor `has_initial_state`
+        # — the fused recurrent kernel zeros h0 in VMEM for slots whose
+        # flag is 0. The branch is preserved (rather than unified into a
+        # single call) so each path stays explicitly visible in the
+        # dispatch in case one impl ever needs a different call shape.
         new_recurrent_state, output = ragged_gdn_impl(
             out_mixed_qkv,
             b,
@@ -181,6 +185,7 @@ def run_jax_gdn_attention_local(
             query_start_loc,
             state_indices,
             distribution,
+            has_initial_state,
         )
     else:
         new_recurrent_state, output = ragged_gdn_impl(


### PR DESCRIPTION
PR #2408 plumbed `has_initial_state` through the chunked / ref GDN paths to fix stale-slot leakage on freshly-allocated mamba slots, but explicitly skipped the fused Pallas kernel ("does not yet honor has_initial_state"). With compact-mamba shrinking the mamba pool to `max_num_reqs+1`, slot reuse is the common case and the FUSED path silently consumes a freed slot's prior state on every brand-new prefill — the same kind of silent corruption that hit the chunked path before PR #2408.

Closes that gap on the FUSED path:

- `fused_gdn_recurrent_kernel.py`: add a `has_initial_state` SMEM input; after the DMA load, `@pl.when(is_new_seq & ~has_init)` overwrites `h_bufs[buf_idx]` with zeros so the recurrent update starts from zero instead of stale tenant data. The decode kernel is unchanged — decodes always have a valid prior state.
- `fused_gdn_kernel_wrapper.py`: forward `has_initial_state` through `fused_gdn`, `_dispatch_with_distribution`, and the `ragged_gated_delta_rule` adapter. Default `None` materializes a static all-True ones array, preserving the pre-fix behaviour for any callers that don't manage slot reuse.
- `gdn_attention.py`: flip the FUSED branch to pass `has_initial_state`, matching the chunked / ref branches.

Perf (apples-to-apples microbench on v7x-8, median of 200 reps, H_qk=2 H_v=8 K=V=128):

  pure_decode_128       2.437 -> 2.447 ms  (+0.4%)
  mixed_64dec_4x256pre  3.668 -> 3.664 ms  (-0.1%)
  pure_prefill_4x1024   5.879 -> 5.877 ms  (-0.0%)
  decode_256            4.237 -> 4.197 ms  (-0.9%)

All within ±1% noise — the SMEM input + conditional adds no measurable cost, and `_zero_h0` only fires on `is_new_seq` for slots flagged False.

Tests (5 new in tests/kernels/fused_gdn_kernel_test.py + 2 FUSED parametrize entries on the existing dispatcher-level `test_has_initial_state_*` tests in tests/layers/common/test_gdn_attention.py; all pass on TPU v7x-8):

- `test_has_initial_state_zeros_stale_slot` — fused-with-stale h0 vs fused-with-fresh h0, the strongest direct test that the kernel zeros stale state.
- `test_has_initial_state_pattern_matches_ref_all_true` — True path preserves the loaded h0.
- `test_has_initial_state_pattern_matches_ref_alternating` — per-slot SMEM lookup (catches off-by-one or uniform-apply bugs).
- `test_has_initial_state_long_sequence_multi_block` — kernel zeros only on `is_new_seq`; subsequent blocks of the same prefill must not re-zero (or the running state gets wiped mid-sequence).
- `test_has_initial_state_decode_plus_new_prefill` — decode kernel + recurrent kernel interaction; decode-slot state survives the recurrent kernel zeroing prefill slots.

Eval - MMLU-Pro looks good

|       Tasks       |Version|    Filter    |n-shot|  Metric   |   |Value |   |Stderr|
|-------------------|------:|--------------|-----:|-----------|---|-----:|---|-----:|
|mmlu_pro           |      2|custom-extract|      |exact_match|↑  |0.8321|±  |0.0224|
| - biology         |      3|custom-extract|     5|exact_match|↑  |0.8500|±  |0.0819|
| - business        |      3|custom-extract|     5|exact_match|↑  |0.7500|±  |0.0993|
| - chemistry       |      3|custom-extract|     5|exact_match|↑  |0.8500|±  |0.0819|
| - computer_science|      3|custom-extract|     5|exact_match|↑  |0.8500|±  |0.0819|
| - economics       |      3|custom-extract|     5|exact_match|↑  |0.9000|±  |0.0688|
| - engineering     |      3|custom-extract|     5|exact_match|↑  |0.7500|±  |0.0993|
| - health          |      3|custom-extract|     5|exact_match|↑  |0.8000|±  |0.0918|
| - history         |      3|custom-extract|     5|exact_match|↑  |0.7500|±  |0.0993|
| - law             |      3|custom-extract|     5|exact_match|↑  |0.8000|±  |0.0918|
| - math            |      3|custom-extract|     5|exact_match|↑  |0.9500|±  |0.0500|
| - other           |      3|custom-extract|     5|exact_match|↑  |0.7000|±  |0.1051|
| - philosophy      |      3|custom-extract|     5|exact_match|↑  |0.9000|±  |0.0688|
| - physics         |      3|custom-extract|     5|exact_match|↑  |1.0000|±  |0.0000|
| - psychology      |      3|custom-extract|     5|exact_match|↑  |0.8000|±  |0.0918|

| Groups |Version|    Filter    |n-shot|  Metric   |   |Value |   |Stderr|
|--------|------:|--------------|------|-----------|---|-----:|---|-----:|
|mmlu_pro|      2|custom-extract|      |exact_match|↑  |0.8321|±  |0.0224|