### PR TITLE
refactor the bm vllm server start wait logic

### DIFF
--- a/.buildkite/benchmark/scripts/run_bm.sh
+++ b/.buildkite/benchmark/scripts/run_bm.sh
@@ -237,21 +237,61 @@ if ! kill -0 "$VLLM_PID" 2>/dev/null; then
     exit 1
 fi
 
-echo "wait for 60 minutes.."
-echo
-for _ in {1..360}; do
-    if grep -Fq "raise RuntimeError" "$VLLM_LOG"; then
-        echo "Detected RuntimeError, exiting."
-        cat "$VLLM_LOG"
+# ---------------------------------------------------------
+# Server startup wait logic
+# ---------------------------------------------------------
+SERVER_WAIT_MINS=${SERVER_WAIT_MINS:-60}
+
+MAX_WAIT_SECONDS=$((SERVER_WAIT_MINS * 60))
+WAIT_START_TIME=$(date +%s)
+ELAPSED=0
+
+echo "Waiting up to ${SERVER_WAIT_MINS} minutes for server to start (PID: ${VLLM_PID})..."
+
+# Initial state set to not started
+SERVER_STARTED="false"
+
+# Loop continues as long as elapsed time is within the maximum allowed
+while (( ELAPSED <= MAX_WAIT_SECONDS )); do
+    
+    # 1. [Fail-Fast Check] Ask the OS if the process is still alive
+    if ! kill -0 "$VLLM_PID" 2>/dev/null; then
+        echo "[ERROR] vLLM process (PID=$VLLM_PID) has exited unexpectedly!"
+        echo "--- Last 20 lines of VLLM_LOG for debugging ---"
+        tail -n 20 "$VLLM_LOG"
         exit 1
-    elif grep -Fq "Application startup complete" "$VLLM_LOG"; then
-        echo "Application started"
-        break
-    else
-        echo "wait for 10 seconds..."
-        sleep 10
     fi
+
+    # 2. [Success Check] Look for the startup completion flag
+    if grep -Fq "Application startup complete" "$VLLM_LOG"; then
+        echo "Application started successfully."
+        SERVER_STARTED="true"
+        break
+    fi
+
+    # 3. Print progress approximately every 1 minute (every 6 iterations) to keep logs clean
+    ITERATION=$((ELAPSED / 10))
+    if (( ITERATION % 6 == 0 )); then
+        ELAPSED_MIN=$((ELAPSED / 60))
+        ELAPSED_SEC=$((ELAPSED % 60))
+        printf "Still waiting... Elapsed: %02d:%02d / %02d:00\n" "$ELAPSED_MIN" "$ELAPSED_SEC" "$SERVER_WAIT_MINS"
+    fi
+
+    # 4. Wait 10 seconds before the next check
+    sleep 10
+
+    # 5. Update elapsed time for the next while loop condition evaluation
+    CURRENT_TIME=$(date +%s)
+    ELAPSED=$((CURRENT_TIME - WAIT_START_TIME))
 done
+
+# Direct exit if server is not started to prevent fetching the dirty bm result
+if [[ "$SERVER_STARTED" == "false" ]]; then
+    echo "[ERROR] Server failed to start within ${SERVER_WAIT_MINS} minutes! Timeout reached."
+    echo "--- Dumping VLLM_LOG for debugging ---"
+    cat "$VLLM_LOG"
+    exit 1
+fi
 
 # Set Default
 EXPECTED_ETEL=${EXPECTED_ETEL:-3600000}


### PR DESCRIPTION
Refactor the vllm server startup waiting logic.

This change aims to increase the waiting time for large model like Qwen/Qwen3.5-397B which may need more than 60 mins for turnup. And also directly exit with status 1 if the server cannot be turn up within the MAX_WAIT_SECONDS. During the test, we found out the later steps may fetch and pass dirty(e.g. 0ms) metrics to the Spanner DB if the vllm_bench_serve starts but the server is not up.

b/505124705

# Tests

[First Revision] - https://buildkite.com/tpu-commons/tpu-inference-benchmark/builds/211/canvas

[Second Revision] - https://buildkite.com/tpu-commons/tpu-inference-benchmark/builds/212/canvas

# Checklist

- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
