### PR TITLE
Pin transformers to 5.5.3 in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,6 @@ runai-model-streamer[s3,gcs]==0.15.4
 gcsfs==2026.1.0
 hypothesis==6.151.9
 sortedcontainers==2.4.0
+# Upstream pins to 5.5.3 https://github.com/vllm-project/vllm/blob/de3fe8dc62f3d77eb8dab8125ca90436f606bccb/requirements/test/nightly-torch.txt#L32
+# TODO: unpin once transformers release with the fix https://github.com/huggingface/transformers/pull/45680
+transformers==5.5.3


### PR DESCRIPTION
Pin transformers==5.5.3 to fix tokenization issues (e.g. DeepSeek-R1).

# Tests

Confirmed fix improves MMLU: https://buildkite.com/tpu-commons/tpu-inference-ci/builds/15990#019dd668-cd1e-475f-8f3f-5baa8bff6147 

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
