### PR TITLE
Updating dashboard MMLU command to use longer output length.

### DIFF
--- a/scripts/multihost/benchmarks/torchax/run_deepseek_v3_1k_8k.sh
+++ b/scripts/multihost/benchmarks/torchax/run_deepseek_v3_1k_8k.sh
@@ -33,4 +33,5 @@ bash "${NIGHTLY_SCRIPT}" \
   --moe-requantize-weight-dtype "fp4" \
   --api-server-count 3 \
   --moe-all-gather-activation-dtype "fp8" \
-  --run-accuracy "mmlu"
+  --run-accuracy "mmlu" \
+  --mmlu-output-len "4"

--- a/scripts/multihost/benchmarks/torchax/run_deepseek_v3_1k_8k_random_routing.sh
+++ b/scripts/multihost/benchmarks/torchax/run_deepseek_v3_1k_8k_random_routing.sh
@@ -34,4 +34,5 @@ bash "${NIGHTLY_SCRIPT}" \
   --moe-all-gather-activation-dtype "fp8" \
   --api-server-count 3 \
   --force-moe-random-routing "1" \
-  --run-accuracy "mmlu"
+  --run-accuracy "mmlu" \
+  --mmlu-output-len "4"

--- a/scripts/multihost/nightly_benchmarking.sh
+++ b/scripts/multihost/nightly_benchmarking.sh
@@ -70,6 +70,7 @@ export PHASED_PROFILING_DIR=""
 export PHASED_PROFILING_DIR_ENV=""
 export SKIP_DB_UPLOAD="false"
 export RUN_ACCURACY=""
+export MMLU_OUTPUT_LEN=""
 export MODEL_IMPL_TYPE_ENV="MODEL_IMPL_TYPE=vllm"
 export USE_UNFUSED_MEGABLOCKS_ENV=""
 export HF_CONFIG=""
@@ -109,6 +110,7 @@ while [[ $# -gt 0 ]]; do
     --phased-profiling-dir) export PHASED_PROFILING_DIR="$2"; PHASED_PROFILING_DIR_ENV="PHASED_PROFILING_DIR=$2"; shift 2 ;;
     --skip-db-upload) export SKIP_DB_UPLOAD="true"; shift 1 ;;
     --run-accuracy) export RUN_ACCURACY="$2"; shift 2 ;;
+    --mmlu-output-len) export MMLU_OUTPUT_LEN="$2"; shift 2 ;;
     --model-impl-type) export MODEL_IMPL_TYPE_ENV="MODEL_IMPL_TYPE=$2"; shift 2 ;;
     --use-unfused-megablocks) export USE_UNFUSED_MEGABLOCKS_ENV="USE_UNFUSED_MEGABLOCKS=$2"; shift 2 ;;
     --hf-config) export HF_CONFIG="$2"; shift 2 ;;
@@ -199,6 +201,10 @@ if [[ "${RUN_ACCURACY}" == "mmlu" ]]; then
       --num-prompts 14000 \
       --run_eval \
       --temperature 0"
+  if [[ -n "${MMLU_OUTPUT_LEN}" ]]; then
+    BENCHMARK_CMD="${BENCHMARK_CMD} --mmlu-output-len ${MMLU_OUTPUT_LEN}"
+  fi
+
 fi
 
 


### PR DESCRIPTION
# Description

DeepSeek has recently started outputting MMLU results in format "(A)" instead of "A" which caused the score to drop to 0. Increasing the MMLU output length brings it back to [85.7](https://buildkite.com/tpu-commons/tpu-inference-ci/builds/15990#019dd668-cd1e-475f-8f3f-5baa8bff6147)

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
