### PR TITLE
Cherry-pick #2443 to releases/v0.19.0: Multimodal test tp-aware + revert PR #1947 expected text

### DIFF
--- a/tests/e2e/test_multi_modal_inference.py
+++ b/tests/e2e/test_multi_modal_inference.py
@@ -13,11 +13,14 @@ from vllm import LLM, EngineArgs, SamplingParams
 from vllm.assets.image import ImageAsset
 from vllm.multimodal.image import convert_image_mode
 
-# Expected partial text output from the model. This is based on a query to
-# vllm 0.17.0 on A100. The test is considered passed if the
+# Expected partial text output from the model. This is based on a previous
+# run and is used for verification. The test is considered passed if the
 # generated output match with this text.
+# NOTE: this reverts PR #1947 — the "Tokyo Skytree" caption it introduced
+# (captured on vllm 0.17.0 on A100) no longer matches TPU output after
+# upstream changes; restoring the prior expected text.
 EXPECTED_TEXT = (
-    "The image depicts a stunning view of the Tokyo Skytree, a tall tower located in Tokyo, Japan. The sky is clear and blue, providing a beautiful backdrop for the tower. In the foreground, there are cherry blossom trees in full bloom, with pink flowers covering the branches. The cherry blossoms are in full bloom"
+    "The image depicts a tall, cylindrical tower with a lattice-like structure, surrounded by cherry blossom trees in full bloom. The cherry blossoms are in various stages of opening, with pink petals covering the branches. The sky is clear and blue, providing a vibrant backdrop to the scene. The tower appears to be a significant landmark"
 )
 
 
@@ -35,7 +38,8 @@ def test_multi_modal_inference(monkeypatch, enable_dynamic_image_sizes):
 
     # --- Configuration ---
     model = "Qwen/Qwen2.5-VL-3B-Instruct"
-    tensor_parallel_size = 1
+    # tp=2 for tpu7x, tp=1 for tpu6e (matches accuracy test convention)
+    tensor_parallel_size = 2 if os.environ.get('TPU_VERSION') == 'tpu7x' else 1
     temperature = 0.0
     max_tokens = 64
     max_model_len = 4096


### PR DESCRIPTION
## Summary

Cherry-pick of #2443 to `releases/v0.19.0`.

- Make `tensor_parallel_size` depend on `TPU_VERSION` env var (tp=2 on tpu7x, tp=1 on tpu6e), matching the convention in `tests/e2e/test_model_loader.py`.
- Revert the `EXPECTED_TEXT` change introduced by #1947. The Tokyo Skytree caption (captured on vllm 0.17.0 on A100) no longer matches TPU output after upstream changes.

## Test plan

- [x] tpu-inference-dev build [#226](https://buildkite.com/tpu-commons/tpu-inference-dev/builds/226) — both passed:
  - `tpu7x Correctness tests for Multimodal Inputs (TP=2)` — passed
  - `tpu6e Correctness tests for Multimodal Inputs (TP=1)` — passed
- [ ] CI nightly tpu6e + tpu7x Multimodal Inputs both passing on `releases/v0.19.0`