### PR TITLE
[releases/v0.19.0] Set TPU_VERSION env on Multimodal_Inputs CorrectnessTest

### DIFF
--- a/.buildkite/features/Multimodal_Inputs.yml
+++ b/.buildkite/features/Multimodal_Inputs.yml
@@ -18,6 +18,8 @@ steps:
   - label: "${TPU_VERSION:-tpu6e} Correctness tests for Multimodal Inputs"
     key: "${TPU_VERSION:-tpu6e}_Multimodal_Inputs_CorrectnessTest"
     soft_fail: true
+    env:
+      TPU_VERSION: "${TPU_VERSION:-tpu6e}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:


### PR DESCRIPTION
## Summary

Follow-up to #2444 (cherry-pick of #2443).

The Multimodal correctness test now reads `os.environ['TPU_VERSION']` to pick `tensor_parallel_size` (tp=2 on tpu7x, tp=1 on tpu6e), but the CI step in `.buildkite/features/Multimodal_Inputs.yml` did not propagate `TPU_VERSION` into the step env. Without it, the test silently falls back to tp=1 even on tpu7x.

This PR adds:
```yaml
env:
  TPU_VERSION: "${TPU_VERSION:-tpu6e}"
```
to the CorrectnessTest step.

The same fix is being added to `main` in #2443.

## Test plan

- [ ] CI nightly tpu7x Multimodal Inputs runs with TP=2 and passes on `releases/v0.19.0`
- [ ] CI nightly tpu6e Multimodal Inputs continues to pass