### PR TITLE
Add job priority for kernel tuning

### DIFF
--- a/.buildkite/scripts/configs/pipeline_config.sh
+++ b/.buildkite/scripts/configs/pipeline_config.sh
@@ -21,6 +21,7 @@ export PRIORITY_INTEGRATION=3
 export PRIORITY_BENCHMARK=2
 export PRIORITY_DEFAULT=1
 export PRIORITY_NIGHTLY=0
+export PRIORITY_KERNEL_TUNING=-1
 
 # Implemented dynamic job prioritization by injecting integers during upload
 upload_with_priority() {


### PR DESCRIPTION
Add job priority for kernel tuning. BuildKite job can support negative number as job priority and the lower the job priority number the lower priority it will run. Kernel tuning will use this lowest priority number so we can reuse the ci-cd machines without impacting the ci-cd jobs when kernel tuning is running.

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
