### PR TITLE
[FIX][KV Offloading] Fix kv offloading performance test in nightly tests

### DIFF
--- a/tests/offload/tpu_offload_accuracy_test.py
+++ b/tests/offload/tpu_offload_accuracy_test.py
@@ -86,6 +86,19 @@ def _test_kv_cache_cpu_offloading_accuracy(
         pass1_time = t1 - t0
         print(f"Pass 1 generate took {pass1_time:.4f} seconds")
         out_texts1, out_tokens1 = parse_outputs(outputs1)
+        time.sleep(10)
+
+        # Intermediate generate
+        print("\n--- Intermediate Pass: Generating for new requests ---")
+        new_prompt = [
+            "What is the capital of France?",
+            "Explain quantum computing in simple terms.",
+            "Write a short poem about a robot."
+        ]
+        outputs_mid = llm.generate(new_prompt, sampling_config)
+        out_texts_mid, out_tokens_mid = parse_outputs(outputs_mid)
+        for i, text in enumerate(out_texts_mid):
+            print(f"Intermediate Output {i}: {text!r}")
         time.sleep(1)
 
         # manually let llm scheduler's kv_cache_manager forget all prefixes' hash

--- a/tests/offload/tpu_offload_performance_test.py
+++ b/tests/offload/tpu_offload_performance_test.py
@@ -42,7 +42,7 @@ def test_kv_cache_cpu_offloading_performance(
             batched_save,
             "10",  # TPU_OFFLOAD_NUM_CPU_CHUNKS
             prompts,
-            max_output_len=1,
+            max_output_len=10,
         )
 
         print("\nPerformance Results:")


### PR DESCRIPTION
# Description

Previously, kv offloading perf test only generates one token and compare the TTFT latency; but async-save may not complete after one step and the offloading scheduler hasn't received the updated saving information. Now, we enforce to generate 10 tokens and insert several intermediate requests between the two runs to make sure the offloading scheduler mark the cpu chunks "read_to_load" and has prefix hit in the next run.

# Tests

`pytest -sv tests/offload/tpu_offload_performance_test.py`

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
