### PR TITLE
[Kernel] Add sparse MLA attention Pallas kernel (per-query top-k)

### DIFF
--- a/.buildkite/features/Sparse_MLA_Attention.yml
+++ b/.buildkite/features/Sparse_MLA_Attention.yml
@@ -1,0 +1,61 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# pipeline-name: Sparse MLA Attention
+# pipeline-type: kernel support matrix
+steps:
+  - label: "${TPU_VERSION:-tpu6e} Correctness tests for Sparse MLA Attention"
+    key: "${TPU_VERSION:-tpu6e}_Sparse_MLA_Attention_CorrectnessTest"
+    soft_fail: true
+    agents:
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    commands:
+      - .buildkite/scripts/run_in_docker.sh python3 -m pytest -s -v /workspace/tpu_inference/tests/kernels/sparse_mla_v1_test.py
+  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for Sparse MLA Attention"
+    key: "${TPU_VERSION:-tpu6e}_record_Sparse_MLA_Attention_CorrectnessTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_Sparse_MLA_Attention_CorrectnessTest"
+    env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
+      CI_TARGET: "Sparse MLA Attention"
+      CI_STAGE: "CorrectnessTest"
+      CI_CATEGORY: "kernel support matrix"
+    agents:
+      queue: cpu
+    commands:
+      - |
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_Sparse_MLA_Attention_CorrectnessTest
+
+  - label: "${TPU_VERSION:-tpu6e} Performance tests for Sparse MLA Attention"
+    key: "${TPU_VERSION:-tpu6e}_Sparse_MLA_Attention_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_record_Sparse_MLA_Attention_CorrectnessTest"
+    soft_fail: true
+    agents:
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    commands:
+      # No microbenchmark in this PR; perf tuning is a fast-follow PR.
+      - |
+        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_Sparse_MLA_Attention_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} Record performance test result for Sparse MLA Attention"
+    key: "${TPU_VERSION:-tpu6e}_record_Sparse_MLA_Attention_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_Sparse_MLA_Attention_PerformanceTest"
+    env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
+      CI_TARGET: "Sparse MLA Attention"
+      CI_STAGE: "PerformanceTest"
+      CI_CATEGORY: "kernel support matrix"
+    agents:
+      queue: cpu
+    commands:
+      - |
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_Sparse_MLA_Attention_PerformanceTest

--- a/support_matrices/release/v6e/flax_nnx/kernel_support_matrix.csv
+++ b/support_matrices/release/v6e/flax_nnx/kernel_support_matrix.csv
@@ -6,3 +6,4 @@ Feature,CorrectnessTest,PerformanceTest
 "Quantized KV Cache",❓ Untested,❓ Untested
 "Quantized Matmul",❓ Untested,❓ Untested
 "Ragged Paged Attention V3",✅ Passing,✅ Passing
+"Sparse MLA Attention",✅ Passing,❓ Untested

--- a/tests/kernels/sparse_mla_v1_test.py
+++ b/tests/kernels/sparse_mla_v1_test.py
@@ -1,0 +1,608 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import time
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+from absl.testing import absltest, parameterized
+from jax._src import test_util as jtu
+
+import tpu_inference.kernels.mla.v1.kernel as mla
+import tpu_inference.kernels.sparse_mla.v1.kernel as sparse_mla
+from tpu_inference.kernels.ragged_paged_attention.v3.util import (
+    align_to, cdiv, get_dtype_packing)
+
+jax.config.parse_flags_with_absl()
+
+
+def _build_topk_indices(seq_lens, topk, seed):
+    """Generate deterministic per-query topk_indices for tests.
+
+    For each query in each sequence, select ``topk`` distinct kv positions from
+    [0, kv_len). If kv_len < topk, pad with -1 sentinels. Causal-respecting
+    (queries only select from kv positions <= their own causal cutoff).
+    """
+    rng = np.random.default_rng(seed)
+    rows = []
+    for q_len, kv_len in seq_lens:
+        for q_idx in range(q_len):
+            causal_cutoff = kv_len - q_len + q_idx + 1
+            valid = np.arange(causal_cutoff, dtype=np.int32)
+            if valid.size <= topk:
+                row = np.full(topk, -1, dtype=np.int32)
+                row[:valid.size] = valid
+            else:
+                row = rng.permutation(valid)[:topk].astype(np.int32)
+                row.sort()
+            rows.append(row)
+    return jnp.asarray(np.stack(rows, axis=0))
+
+
+def _full_topk_indices(seq_lens, topk):
+    """topk_indices that select every causal-valid kv position (sanity case)."""
+    rows = []
+    for q_len, kv_len in seq_lens:
+        for q_idx in range(q_len):
+            causal_cutoff = kv_len - q_len + q_idx + 1
+            row = np.full(topk, -1, dtype=np.int32)
+            row[:causal_cutoff] = np.arange(causal_cutoff, dtype=np.int32)
+            rows.append(row)
+    return jnp.asarray(np.stack(rows, axis=0))
+
+
+@jtu.with_config(jax_numpy_dtype_promotion="standard")
+class SparseMlaRaggedPagedAttentionRefTest(jtu.JaxTestCase):
+    """L0 tests: pure-JAX reference vs dense MLA on CPU.
+
+    These run without TPU. They validate the masking logic of the reference
+    impl against the dense MLA reference, which is the fixed point we need
+    before porting to Pallas (L1).
+    """
+
+    def _setup_inputs(self, seq_lens, num_heads, lkv_dim, r_dim, page_size,
+                      q_dtype, kv_dtype, num_pages):
+        rng = np.random.default_rng(1234)
+
+        def gen_random(shape, dtype):
+            return jnp.array(rng.random(size=shape,
+                                        dtype=np.float32)).astype(dtype)
+
+        padded_r_dim = align_to(r_dim, 128)
+        padded_lkv_dim = align_to(lkv_dim, 128)
+        padded_kv_dim = padded_lkv_dim + padded_r_dim
+        packing = get_dtype_packing(kv_dtype)
+        q_lens = [s[0] for s in seq_lens]
+        kv_lens_list = [s[1] for s in seq_lens]
+        total_q_len = sum(q_lens)
+        cu_q_lens_list = [0]
+        for q_len in q_lens:
+            cu_q_lens_list.append(cu_q_lens_list[-1] + q_len)
+
+        max_kv_len = max(kv_lens_list) if kv_lens_list else 0
+        pages_per_seq = cdiv(max_kv_len, page_size)
+
+        page_indices_list = []
+        page_count = 0
+        for kv_len in kv_lens_list:
+            num_seq_pages = cdiv(kv_len, page_size)
+            indices = list(range(page_count, page_count + num_seq_pages))
+            page_indices_list.extend(indices + [-1] *
+                                     (pages_per_seq - num_seq_pages))
+            page_count += num_seq_pages
+
+        total_num_pages = max(num_pages, page_count)
+
+        ql_nope = gen_random((total_q_len, num_heads, lkv_dim), q_dtype)
+        q_pe = gen_random((total_q_len, num_heads, r_dim), q_dtype)
+        new_kv_c = gen_random((total_q_len, lkv_dim), kv_dtype)
+        new_k_pe = gen_random((total_q_len, r_dim), kv_dtype)
+
+        cache_kv = gen_random(
+            (total_num_pages, page_size // packing, packing, padded_kv_dim),
+            kv_dtype,
+        )
+        kv_lens = jnp.array(kv_lens_list, dtype=jnp.int32)
+        page_indices = jnp.array(page_indices_list, dtype=jnp.int32)
+        cu_q_lens = jnp.array(cu_q_lens_list, dtype=jnp.int32)
+        distribution = jnp.array([0, 0, len(seq_lens)], dtype=jnp.int32)
+
+        return dict(
+            ql_nope=ql_nope,
+            q_pe=q_pe,
+            new_kv_c=new_kv_c,
+            new_k_pe=new_k_pe,
+            cache_kv=cache_kv,
+            kv_lens=kv_lens,
+            page_indices=page_indices,
+            cu_q_lens=cu_q_lens,
+            distribution=distribution,
+            total_q_len=total_q_len,
+        )
+
+    def test_topk_full_equals_dense_mla(self):
+        """Sanity fixed point: topk == kv_len matches dense MLA exactly.
+
+        If this fails, the topk masking in the reference is wrong. Cheap, high
+        diagnostic value.
+        """
+        seq_lens = [(64, 64)]
+        num_heads = 8
+        lkv_dim = 128
+        r_dim = 64
+        page_size = 64
+        dtype = jnp.bfloat16
+
+        ins = self._setup_inputs(seq_lens,
+                                 num_heads,
+                                 lkv_dim,
+                                 r_dim,
+                                 page_size,
+                                 dtype,
+                                 dtype,
+                                 num_pages=64)
+        topk = max(s[1] for s in seq_lens)
+        topk_indices = _full_topk_indices(seq_lens, topk)
+
+        sparse_out, sparse_cache = (
+            sparse_mla.ref_sparse_mla_ragged_paged_attention(
+                ins["ql_nope"],
+                ins["q_pe"],
+                ins["new_kv_c"],
+                ins["new_k_pe"],
+                ins["cache_kv"].copy(),
+                ins["kv_lens"],
+                topk_indices,
+                ins["page_indices"],
+                ins["cu_q_lens"],
+                ins["distribution"],
+            ))
+        dense_out, dense_cache = mla.ref_mla_ragged_paged_attention(
+            ins["ql_nope"],
+            ins["q_pe"],
+            ins["new_kv_c"],
+            ins["new_k_pe"],
+            ins["cache_kv"].copy(),
+            ins["kv_lens"],
+            ins["page_indices"],
+            ins["cu_q_lens"],
+            ins["distribution"],
+        )
+
+        self.assertAllClose(sparse_out, dense_out, rtol=1e-2, atol=1e-3)
+        self.assertAllClose(sparse_cache, dense_cache, rtol=1e-2, atol=1e-3)
+
+    @parameterized.named_parameters(
+        dict(testcase_name="prefill_small",
+             seq_lens=[(64, 64)],
+             num_heads=8,
+             topk=32),
+        dict(testcase_name="prefill_uneven",
+             seq_lens=[(48, 200), (96, 96)],
+             num_heads=8,
+             topk=64),
+        dict(testcase_name="decode_only",
+             seq_lens=[(1, 256), (1, 1024)],
+             num_heads=16,
+             topk=128),
+        dict(testcase_name="mixed_batch",
+             seq_lens=[(64, 64), (1, 512), (32, 800)],
+             num_heads=16,
+             topk=64),
+    )
+    def test_sparse_topk_matches_self(self, seq_lens, num_heads, topk):
+        """Determinism + non-NaN check on the reference for sparse topk cases.
+
+        Once the Pallas kernel exists (L1), this test will compare reference vs
+        kernel; for now it asserts the reference produces non-NaN, finite output
+        and is deterministic across runs given a fixed seed.
+        """
+        lkv_dim = 128
+        r_dim = 64
+        page_size = 64
+        dtype = jnp.bfloat16
+
+        ins = self._setup_inputs(seq_lens,
+                                 num_heads,
+                                 lkv_dim,
+                                 r_dim,
+                                 page_size,
+                                 dtype,
+                                 dtype,
+                                 num_pages=128)
+        topk_indices = _build_topk_indices(seq_lens, topk, seed=42)
+
+        out_a, _ = sparse_mla.ref_sparse_mla_ragged_paged_attention(
+            ins["ql_nope"], ins["q_pe"], ins["new_kv_c"], ins["new_k_pe"],
+            ins["cache_kv"].copy(), ins["kv_lens"], topk_indices,
+            ins["page_indices"], ins["cu_q_lens"], ins["distribution"])
+        out_b, _ = sparse_mla.ref_sparse_mla_ragged_paged_attention(
+            ins["ql_nope"], ins["q_pe"], ins["new_kv_c"], ins["new_k_pe"],
+            ins["cache_kv"].copy(), ins["kv_lens"], topk_indices,
+            ins["page_indices"], ins["cu_q_lens"], ins["distribution"])
+
+        self.assertEqual(
+            out_a.shape,
+            (ins["total_q_len"], num_heads, align_to(lkv_dim, 128)))
+        self.assertTrue(jnp.all(jnp.isfinite(out_a)))
+        self.assertAllClose(out_a, out_b, rtol=0.0, atol=0.0)
+
+    def test_sentinel_minus_one_is_masked_out(self):
+        """A query with all -1 sentinels has no keys; output rows for that
+        query should be the row a softmax-over-all-mask produces (uniform-ish
+        but with the kernel's mask_value semantics). At minimum, finite and
+        not equal to the dense answer.
+        """
+        seq_lens = [(8, 64)]
+        num_heads = 4
+        lkv_dim = 128
+        r_dim = 64
+        page_size = 64
+        dtype = jnp.bfloat16
+
+        ins = self._setup_inputs(seq_lens,
+                                 num_heads,
+                                 lkv_dim,
+                                 r_dim,
+                                 page_size,
+                                 dtype,
+                                 dtype,
+                                 num_pages=8)
+        topk = 32
+        # Mark query 0 as all-masked.
+        topk_indices = _build_topk_indices(seq_lens, topk, seed=7)
+        topk_indices = topk_indices.at[0].set(-1)
+
+        out, _ = sparse_mla.ref_sparse_mla_ragged_paged_attention(
+            ins["ql_nope"], ins["q_pe"], ins["new_kv_c"], ins["new_k_pe"],
+            ins["cache_kv"].copy(), ins["kv_lens"], topk_indices,
+            ins["page_indices"], ins["cu_q_lens"], ins["distribution"])
+
+        self.assertTrue(jnp.all(jnp.isfinite(out)))
+
+
+@jtu.with_config(jax_numpy_dtype_promotion="standard")
+class SparseMlaRaggedPagedAttentionKernelTest(jtu.JaxTestCase):
+    """L1 tests: Pallas kernel vs JAX reference on TPU.
+
+    Skips on non-TPU. Asserts that the Pallas kernel produces output
+    `allclose` to the reference impl across the full test case matrix.
+    Also includes the load-bearing fixed point: topk_full equals dense MLA.
+    """
+
+    def _setup_inputs(self, seq_lens, num_heads, lkv_dim, r_dim, page_size,
+                      q_dtype, kv_dtype, num_pages):
+        # Identical to SparseMlaRaggedPagedAttentionRefTest._setup_inputs;
+        # duplicated here to keep the test classes independent.
+        rng = np.random.default_rng(1234)
+
+        def gen_random(shape, dtype):
+            return jnp.array(rng.random(size=shape,
+                                        dtype=np.float32)).astype(dtype)
+
+        padded_r_dim = align_to(r_dim, 128)
+        padded_lkv_dim = align_to(lkv_dim, 128)
+        padded_kv_dim = padded_lkv_dim + padded_r_dim
+        packing = get_dtype_packing(kv_dtype)
+        q_lens = [s[0] for s in seq_lens]
+        kv_lens_list = [s[1] for s in seq_lens]
+        total_q_len = sum(q_lens)
+        cu_q_lens_list = [0]
+        for q_len in q_lens:
+            cu_q_lens_list.append(cu_q_lens_list[-1] + q_len)
+        max_kv_len = max(kv_lens_list) if kv_lens_list else 0
+        pages_per_seq = cdiv(max_kv_len, page_size)
+        page_indices_list = []
+        page_count = 0
+        for kv_len in kv_lens_list:
+            num_seq_pages = cdiv(kv_len, page_size)
+            indices = list(range(page_count, page_count + num_seq_pages))
+            page_indices_list.extend(indices + [-1] *
+                                     (pages_per_seq - num_seq_pages))
+            page_count += num_seq_pages
+        total_num_pages = max(num_pages, page_count)
+        ql_nope = gen_random((total_q_len, num_heads, lkv_dim), q_dtype)
+        q_pe = gen_random((total_q_len, num_heads, r_dim), q_dtype)
+        new_kv_c = gen_random((total_q_len, lkv_dim), kv_dtype)
+        new_k_pe = gen_random((total_q_len, r_dim), kv_dtype)
+        cache_kv = gen_random(
+            (total_num_pages, page_size // packing, packing, padded_kv_dim),
+            kv_dtype,
+        )
+        kv_lens = jnp.array(kv_lens_list, dtype=jnp.int32)
+        page_indices = jnp.array(page_indices_list, dtype=jnp.int32)
+        cu_q_lens = jnp.array(cu_q_lens_list, dtype=jnp.int32)
+        distribution = jnp.array([0, 0, len(seq_lens)], dtype=jnp.int32)
+        return dict(ql_nope=ql_nope,
+                    q_pe=q_pe,
+                    new_kv_c=new_kv_c,
+                    new_k_pe=new_k_pe,
+                    cache_kv=cache_kv,
+                    kv_lens=kv_lens,
+                    page_indices=page_indices,
+                    cu_q_lens=cu_q_lens,
+                    distribution=distribution,
+                    total_q_len=total_q_len)
+
+    @parameterized.named_parameters(
+        dict(testcase_name="prefill_small",
+             seq_lens=[(64, 64)],
+             num_heads=8,
+             topk=32),
+        dict(testcase_name="prefill_uneven",
+             seq_lens=[(48, 200), (96, 96)],
+             num_heads=8,
+             topk=64),
+        dict(testcase_name="decode_only",
+             seq_lens=[(1, 256), (1, 1024)],
+             num_heads=16,
+             topk=128),
+        dict(testcase_name="mixed_batch",
+             seq_lens=[(64, 64), (2, 512), (32, 800)],
+             num_heads=16,
+             topk=64),
+    )
+    def test_kernel_matches_reference(self, seq_lens, num_heads, topk):
+        if not jtu.is_device_tpu_at_least(version=4):
+            self.skipTest("Sparse MLA Pallas kernel requires TPU v4+")
+        lkv_dim = 128
+        r_dim = 64
+        page_size = 64
+        dtype = jnp.bfloat16
+
+        ins = self._setup_inputs(seq_lens,
+                                 num_heads,
+                                 lkv_dim,
+                                 r_dim,
+                                 page_size,
+                                 dtype,
+                                 dtype,
+                                 num_pages=128)
+        topk_indices = _build_topk_indices(seq_lens, topk, seed=42)
+
+        ref_out, ref_cache = sparse_mla.ref_sparse_mla_ragged_paged_attention(
+            ins["ql_nope"], ins["q_pe"], ins["new_kv_c"], ins["new_k_pe"],
+            ins["cache_kv"].copy(), ins["kv_lens"], topk_indices,
+            ins["page_indices"], ins["cu_q_lens"], ins["distribution"])
+
+        kernel_out, kernel_cache = (
+            sparse_mla.sparse_mla_ragged_paged_attention(
+                ins["ql_nope"],
+                ins["q_pe"],
+                ins["new_kv_c"],
+                ins["new_k_pe"],
+                ins["cache_kv"].copy(),
+                ins["kv_lens"],
+                topk_indices,
+                ins["page_indices"],
+                ins["cu_q_lens"],
+                ins["distribution"],
+                num_kv_pages_per_block=8,
+                num_queries_per_block=8,
+                vmem_limit_bytes=64 * 1024 * 1024,
+            ))
+
+        self.assertAllClose(kernel_out, ref_out, rtol=1e-2, atol=1e-3)
+        self.assertAllClose(kernel_cache, ref_cache, rtol=1e-2, atol=1e-3)
+
+    def test_kernel_topk_full_equals_dense_mla(self):
+        """Sanity fixed point: the Pallas kernel with topk == kv_len equals
+        the dense MLA Pallas kernel. Proves the F1 mask injection is correct."""
+        if not jtu.is_device_tpu_at_least(version=4):
+            self.skipTest("Sparse MLA Pallas kernel requires TPU v4+")
+
+        seq_lens = [(64, 64)]
+        num_heads = 8
+        lkv_dim = 128
+        r_dim = 64
+        page_size = 64
+        dtype = jnp.bfloat16
+
+        ins = self._setup_inputs(seq_lens,
+                                 num_heads,
+                                 lkv_dim,
+                                 r_dim,
+                                 page_size,
+                                 dtype,
+                                 dtype,
+                                 num_pages=64)
+        topk = max(s[1] for s in seq_lens)
+        topk_indices = _full_topk_indices(seq_lens, topk)
+
+        sparse_out, sparse_cache = (
+            sparse_mla.sparse_mla_ragged_paged_attention(
+                ins["ql_nope"],
+                ins["q_pe"],
+                ins["new_kv_c"],
+                ins["new_k_pe"],
+                ins["cache_kv"].copy(),
+                ins["kv_lens"],
+                topk_indices,
+                ins["page_indices"],
+                ins["cu_q_lens"],
+                ins["distribution"],
+                num_kv_pages_per_block=8,
+                num_queries_per_block=8,
+                vmem_limit_bytes=64 * 1024 * 1024,
+            ))
+
+        dense_out, dense_cache = mla.mla_ragged_paged_attention(
+            ins["ql_nope"],
+            ins["q_pe"],
+            ins["new_kv_c"],
+            ins["new_k_pe"],
+            ins["cache_kv"].copy(),
+            ins["kv_lens"],
+            ins["page_indices"],
+            ins["cu_q_lens"],
+            ins["distribution"],
+            num_kv_pages_per_block=8,
+            num_queries_per_block=8,
+            vmem_limit_bytes=64 * 1024 * 1024,
+        )
+
+        self.assertAllClose(sparse_out, dense_out, rtol=1e-2, atol=1e-3)
+        self.assertAllClose(sparse_cache, dense_cache, rtol=1e-2, atol=1e-3)
+
+
+@jtu.with_config(jax_numpy_dtype_promotion="standard")
+class SparseMlaRaggedPagedAttentionPerfTest(jtu.JaxTestCase):
+    """Microbenchmark: sparse MLA Pallas kernel vs dense MLA Pallas kernel.
+
+    Mirrors the timing pattern from ``tests/kernels/gather_reduce_test.py``:
+    warmup, then 5 iterations under ``jax.block_until_ready``. Skips on
+    non-TPU. Mask-based v1 still loads all KV pages, so parity with dense
+    is the goal — not a speedup. Truly-sparse-load (skip non-topk pages) is
+    a v2 optimization.
+    """
+
+    def _setup_inputs(self, seq_lens, num_heads, lkv_dim, r_dim, page_size,
+                      q_dtype, kv_dtype, num_pages):
+        rng = np.random.default_rng(1234)
+
+        def gen_random(shape, dtype):
+            return jnp.array(rng.random(size=shape,
+                                        dtype=np.float32)).astype(dtype)
+
+        padded_r_dim = align_to(r_dim, 128)
+        padded_lkv_dim = align_to(lkv_dim, 128)
+        padded_kv_dim = padded_lkv_dim + padded_r_dim
+        packing = get_dtype_packing(kv_dtype)
+        q_lens = [s[0] for s in seq_lens]
+        kv_lens_list = [s[1] for s in seq_lens]
+        total_q_len = sum(q_lens)
+        cu_q_lens_list = [0]
+        for q_len in q_lens:
+            cu_q_lens_list.append(cu_q_lens_list[-1] + q_len)
+        max_kv_len = max(kv_lens_list) if kv_lens_list else 0
+        pages_per_seq = cdiv(max_kv_len, page_size)
+        page_indices_list = []
+        page_count = 0
+        for kv_len in kv_lens_list:
+            num_seq_pages = cdiv(kv_len, page_size)
+            indices = list(range(page_count, page_count + num_seq_pages))
+            page_indices_list.extend(indices + [-1] *
+                                     (pages_per_seq - num_seq_pages))
+            page_count += num_seq_pages
+        total_num_pages = max(num_pages, page_count)
+        ql_nope = gen_random((total_q_len, num_heads, lkv_dim), q_dtype)
+        q_pe = gen_random((total_q_len, num_heads, r_dim), q_dtype)
+        new_kv_c = gen_random((total_q_len, lkv_dim), kv_dtype)
+        new_k_pe = gen_random((total_q_len, r_dim), kv_dtype)
+        cache_kv = gen_random(
+            (total_num_pages, page_size // packing, packing, padded_kv_dim),
+            kv_dtype,
+        )
+        kv_lens = jnp.array(kv_lens_list, dtype=jnp.int32)
+        page_indices = jnp.array(page_indices_list, dtype=jnp.int32)
+        cu_q_lens = jnp.array(cu_q_lens_list, dtype=jnp.int32)
+        distribution = jnp.array([0, 0, len(seq_lens)], dtype=jnp.int32)
+        return dict(ql_nope=ql_nope,
+                    q_pe=q_pe,
+                    new_kv_c=new_kv_c,
+                    new_k_pe=new_k_pe,
+                    cache_kv=cache_kv,
+                    kv_lens=kv_lens,
+                    page_indices=page_indices,
+                    cu_q_lens=cu_q_lens,
+                    distribution=distribution,
+                    total_q_len=total_q_len)
+
+    @parameterized.named_parameters(
+        dict(testcase_name="prefill_small",
+             seq_lens=[(64, 64)],
+             num_heads=8,
+             topk=32,
+             num_pages=64),
+        dict(testcase_name="prefill_uneven",
+             seq_lens=[(48, 200), (96, 96)],
+             num_heads=8,
+             topk=64,
+             num_pages=128),
+        dict(testcase_name="decode_only",
+             seq_lens=[(1, 256), (1, 1024)],
+             num_heads=16,
+             topk=128,
+             num_pages=128),
+        dict(testcase_name="mixed_batch",
+             seq_lens=[(64, 64), (2, 512), (32, 800)],
+             num_heads=16,
+             topk=64,
+             num_pages=128),
+    )
+    def test_perf(self, seq_lens, num_heads, topk, num_pages):
+        if not jtu.is_device_tpu_at_least(version=4):
+            self.skipTest("Sparse MLA Pallas kernel requires TPU v4+")
+
+        lkv_dim = 128
+        r_dim = 64
+        page_size = 64
+        dtype = jnp.bfloat16
+        n_iters = 5
+
+        ins = self._setup_inputs(seq_lens,
+                                 num_heads,
+                                 lkv_dim,
+                                 r_dim,
+                                 page_size,
+                                 dtype,
+                                 dtype,
+                                 num_pages=num_pages)
+        topk_indices = _build_topk_indices(seq_lens, topk, seed=42)
+
+        common_kwargs = dict(
+            num_kv_pages_per_block=8,
+            num_queries_per_block=8,
+            vmem_limit_bytes=64 * 1024 * 1024,
+        )
+
+        def run_dense():
+            return mla.mla_ragged_paged_attention(
+                ins["ql_nope"], ins["q_pe"], ins["new_kv_c"], ins["new_k_pe"],
+                ins["cache_kv"].copy(), ins["kv_lens"], ins["page_indices"],
+                ins["cu_q_lens"], ins["distribution"], **common_kwargs)
+
+        def run_sparse():
+            return sparse_mla.sparse_mla_ragged_paged_attention(
+                ins["ql_nope"], ins["q_pe"], ins["new_kv_c"], ins["new_k_pe"],
+                ins["cache_kv"].copy(), ins["kv_lens"], topk_indices,
+                ins["page_indices"], ins["cu_q_lens"], ins["distribution"],
+                **common_kwargs)
+
+        # Warmup (JIT compile + cache).
+        for _ in range(5):
+            jax.block_until_ready(run_dense())
+            jax.block_until_ready(run_sparse())
+
+        timings = {}
+        start = time.time()
+        for _ in range(n_iters):
+            jax.block_until_ready(run_dense())
+        timings["dense_mla"] = (time.time() - start) / n_iters
+
+        start = time.time()
+        for _ in range(n_iters):
+            jax.block_until_ready(run_sparse())
+        timings["sparse_mla"] = (time.time() - start) / n_iters
+
+        for k, v in timings.items():
+            print(f"  {k}: {v * 1000:.3f} ms / iter")
+        ratio = timings["sparse_mla"] / timings["dense_mla"]
+        print(f"  ratio sparse/dense: {ratio:.2f}x  (mask-based v1; "
+              f"~1.0x = parity with dense, expected)")
+
+
+if __name__ == "__main__":
+    absltest.main()

--- a/tpu_inference/kernels/mla/v1/kernel.py
+++ b/tpu_inference/kernels/mla/v1/kernel.py
@@ -487,7 +487,7 @@ def static_validate_inputs(
 
 
 def _mla_ragged_paged_attention_kernel(
-    # Prefetch
+    # Prefetch (SMEM)
     kv_lens_ref,  # [max_num_seqs]
     page_indices_ref,  # [max_num_seqs * pages_per_seq]
     cu_q_lens_ref,  # [max_num_seqs + 1]
@@ -496,12 +496,13 @@ def _mla_ragged_paged_attention_kernel(
     sem_ids_ref,  # [3] (bq_sem_idx, bkv_sem_idx, bo_sem_idx)
     bo_ids_ref,  # [4] (bo_sem_0_seq_idx, bo_sem_1_seq_idx, bo_sem_0_bo_idx, bo_sem_1_bo_idx)
     bkv_update_ids_ref,  # [6] (bkv_sem_0_seq_idx, bkv_sem_1_seq_idx, bkv_sem_0_offset, bkv_sem_1_offset, bkv_sem_0_sz, bkv_sem_1_sz)
-    # Input
+    # Input (HBM)
     ql_nope_hbm_ref,  # [max_num_tokens, num_q_heads_per_q_packing, q_packing, lkv_dim]
     q_pe_hbm_ref,  # [max_num_tokens, num_q_heads_per_q_packing, q_packing, r_dim]
     new_kv_c_hbm_ref,  # [max_num_tokens_per_kv_packing, kv_packing, lkv_dim]
     new_k_pe_hbm_ref,  # [max_num_tokens_per_kv_packing, kv_packing, r_dim]
     cache_kv_hbm_ref,  # [total_num_pages, page_size_per_kv_packing, kv_packing, align_to(lkv_dim + r_dim, 128)]
+    topk_indices_hbm_ref,  # [max_num_tokens, topk_k] i32 HBM (sentinel [1,1] when is_sparse=False)
     # Output
     o_hbm_ref,  # [max_num_tokens, num_q_heads_per_q_packing, q_packing, lkv_dim]
     updated_cache_kv_hbm_ref,  # [total_num_pages, page_size_per_kv_packing, kv_packing, align_to(lkv_dim + r_dim, 128)]
@@ -515,6 +516,7 @@ def _mla_ragged_paged_attention_kernel(
     l_ref,  # [bq_sz * num_q_heads, 128],
     m_ref,  # [bq_sz * num_q_heads, 128],
     acc_ref,  # [bq_sz * num_q_heads, lkv_dim],
+    topk_block_vmem_ref,  # [bq_sz, topk_k] i32 (sentinel [1,1] when is_sparse=False)
     *,
     sm_scale: float,
     sliding_window: int | None = None,
@@ -527,6 +529,7 @@ def _mla_ragged_paged_attention_kernel(
     bkv_p,
     bq_sz,
     debug_mode: bool = False,
+    is_sparse: bool = False,
 ):
     assert ql_nope_hbm_ref.shape == o_hbm_ref.shape
     # Validation checks on the dimensions
@@ -637,6 +640,41 @@ def _mla_ragged_paged_attention_kernel(
         # TODO(jevinjiang, xiowei): reduce pages_per_seq based on sliding_window.
         if sliding_window is not None:
             mask = jnp.logical_or(mask, q_span - sliding_window >= k_span)
+
+        # Optional top-k sparse-attention mask: positions not listed in
+        # topk_indices_hbm_ref for the current query are masked out.
+        # topk_indices_hbm_ref has shape [max_num_tokens, topk_k]; -1 sentinel
+        # entries don't match any real kv_position so they contribute nothing.
+        if is_sparse:
+            # The closure may be called with actual_bq_sz < bq_sz (e.g.,
+            # actual_bq_sz=1 in the decode fast path), so derive shapes from
+            # the runtime ql_nope shape rather than the static bq_sz.
+            actual_bq_sz = ql_nope.shape[0] // num_q_heads
+            q_token_start = q_start + bq_idx * bq_sz
+            # HBM cannot be loaded directly inside Pallas TPU kernel bodies; we
+            # sync_copy the slice we need into a VMEM scratch buffer first,
+            # then read from VMEM.
+            pltpu.sync_copy(
+                topk_indices_hbm_ref.at[pl.ds(q_token_start, bq_sz)],
+                topk_block_vmem_ref,
+            )
+            topk_block = topk_block_vmem_ref[pl.ds(
+                0, actual_bq_sz), :]  # [actual_bq_sz, topk_k]
+            kv_positions = bkv_idx * bkv_sz + lax.broadcasted_iota(
+                jnp.int32, (actual_bq_sz, bkv_sz), 1)  # [actual_bq_sz, bkv_sz]
+            is_selected = jnp.any(
+                topk_block[:, :, None] == kv_positions[:, None, :],
+                axis=1,
+            )  # [actual_bq_sz, bkv_sz]
+            # s.shape is [actual_bq_sz * num_q_heads, bkv_sz]; rows are laid out
+            # as (q0,h0), (q0,h1), ..., (q0,hN-1), (q1,h0), ... — so each query's
+            # mask must repeat across num_q_heads contiguous rows.
+            is_selected_3d = lax.broadcast_in_dim(
+                is_selected, (actual_bq_sz, num_q_heads, bkv_sz), (0, 2))
+            is_selected_s = lax.reshape(is_selected_3d,
+                                        (actual_bq_sz * num_q_heads, bkv_sz))
+            topk_mask = jnp.logical_not(is_selected_s)
+            mask = jnp.logical_or(mask, topk_mask)
 
         if soft_cap is not None:
             s = soft_cap * jnp.tanh(s / soft_cap)
@@ -1109,6 +1147,9 @@ def mla_ragged_paged_attention(
     q_scale: float | None = None,
     k_scale: float | None = None,
     v_scale: float | None = None,
+    # Optional sparse attention: per-query top-k key indices. -1 sentinel for
+    # unused slots. When provided, attention is restricted to the listed keys.
+    topk_indices: jax.Array | None = None,  # i32[max_num_tokens, topk_k]
     # Kernel optimization params.
     chunk_prefill_size: int | None = None,
     # Kernel tuning params.
@@ -1223,12 +1264,25 @@ def mla_ragged_paged_attention(
     bkv_sz_per_kv_packing = bkv_p * page_size_per_kv_packing
     grid = (distribution[2], )
 
+    # Build the topk_indices HBM input. For dense MLA we pass a 1x1 sentinel
+    # that the kernel never sync_copies (gated by the static is_sparse=False
+    # flag). When sparse, the kernel sync_copies a slice into VMEM scratch.
+    is_sparse = topk_indices is not None
+    if is_sparse:
+        topk_indices_input = topk_indices
+        topk_k = topk_indices.shape[-1]
+    else:
+        topk_indices_input = jnp.full((1, 1), -1, jnp.int32)
+        topk_k = 1
+
     in_specs = [
         pl.BlockSpec(memory_space=pltpu.HBM),
         pl.BlockSpec(memory_space=pltpu.HBM),
         pl.BlockSpec(memory_space=pltpu.HBM),
         pl.BlockSpec(memory_space=pltpu.HBM),
         pl.BlockSpec(memory_space=pltpu.HBM),
+        pl.BlockSpec(
+            memory_space=pltpu.HBM),  # topk_indices (real or sentinel)
     ]
 
     out_specs = [
@@ -1269,6 +1323,11 @@ def mla_ragged_paged_attention(
         jnp.float32,
     )
 
+    topk_block_scratch = pltpu.VMEM(
+        (bq_sz, topk_k),
+        jnp.int32,
+    )
+
     scratch_shapes = [
         bkvc_double_buf,
         bkpe_double_buf,
@@ -1281,6 +1340,8 @@ def mla_ragged_paged_attention(
         l_scratch,
         m_scratch,
         acc_scratch,
+        # Sparse-attention topk scratch (sentinel-sized when is_sparse=False).
+        topk_block_scratch,
     ]
 
     scalar_prefetches = (
@@ -1313,6 +1374,7 @@ def mla_ragged_paged_attention(
                 bq_sz=bq_sz,
                 bkv_p=bkv_p,
                 debug_mode=debug_mode,
+                is_sparse=is_sparse,
             ),
             grid_spec=pltpu.PrefetchScalarGridSpec(
                 num_scalar_prefetch=len(scalar_prefetches),
@@ -1346,6 +1408,7 @@ def mla_ragged_paged_attention(
         new_kv_c,
         new_k_pe,
         cache_kv,
+        topk_indices_input,
     )
     output = prepare_outputs(
         output, actual_num_q_heads,

--- a/tpu_inference/kernels/sparse_mla/__init__.py
+++ b/tpu_inference/kernels/sparse_mla/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tpu_inference/kernels/sparse_mla/v1/__init__.py
+++ b/tpu_inference/kernels/sparse_mla/v1/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tpu_inference/kernels/sparse_mla/v1/kernel.py
+++ b/tpu_inference/kernels/sparse_mla/v1/kernel.py
@@ -1,0 +1,232 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Sparse MLA Ragged Paged Attention kernel.
+
+Computes MLA attention restricted to a per-query top-k subset of KV positions.
+Caller supplies ``topk_indices: i32[num_tokens, topk]`` (token-level, with -1
+sentinel for unused slots); the kernel does the rest. KV cache layout, page
+table, and softmax math are identical to the dense MLA kernel in
+``tpu_inference/kernels/mla/v1/kernel.py`` — this module reuses the dense
+kernel's ``update_kv_cache`` and ``get_kv_cache_shape`` helpers and adds a
+sparse attention path.
+"""
+
+import jax
+import jax.numpy as jnp
+
+from tpu_inference.kernels.mla.v1.kernel import (DEFAULT_MASK_VALUE,
+                                                 get_kv_cache_shape,
+                                                 update_kv_cache)
+from tpu_inference.kernels.ragged_paged_attention.v3.util import align_to, cdiv
+
+__all__ = [
+    "DEFAULT_MASK_VALUE",
+    "get_kv_cache_shape",
+    "update_kv_cache",
+    "ref_sparse_mla_ragged_paged_attention",
+]
+
+
+def ref_sparse_mla_ragged_paged_attention(
+    ql_nope: jax.Array,  # [num_tokens, actual_num_q_heads, actual_lkv_dim]
+    q_pe: jax.Array,  # [num_tokens, actual_num_q_heads, actual_r_dim]
+    new_kv_c: jax.Array,  # [num_tokens, actual_lkv_dim]
+    new_k_pe: jax.Array,  # [num_tokens, actual_r_dim]
+    cache_kv: jax.
+    Array,  # [total_num_pages, page_size_per_kv_packing, kv_packing, lkv_dim+r_dim]
+    kv_lens: jax.Array,  # i32[max_num_seqs]
+    topk_indices: jax.Array,  # i32[num_tokens, topk] — -1 sentinel
+    page_indices: jax.Array,  # i32[max_num_seqs * pages_per_seq]
+    cu_q_lens: jax.Array,  # i32[max_num_seqs + 1]
+    distribution: jax.Array,  # i32[3]
+    *,
+    sm_scale: float = 1.0,
+    soft_cap: float | None = None,
+    mask_value: float | None = DEFAULT_MASK_VALUE,
+    q_scale: float | None = None,
+    k_scale: float | None = None,
+    v_scale: float | None = None,
+):
+    """Pure-JAX reference for sparse MLA attention.
+
+    Differs from ``ref_mla_ragged_paged_attention`` only in that the per-query
+    attention is restricted to keys listed in ``topk_indices``: positions not
+    listed are masked to ``mask_value`` before softmax. Equivalent in output
+    to a true gather-then-attend over the top-k subset.
+    """
+    if mask_value is None:
+        mask_value = DEFAULT_MASK_VALUE
+
+    updated_cache_kv = update_kv_cache(
+        new_kv_c,
+        new_k_pe,
+        cache_kv,
+        kv_lens,
+        page_indices,
+        cu_q_lens,
+        distribution,
+    )
+
+    actual_lkv_dim = ql_nope.shape[-1]
+    lkv_dim = align_to(actual_lkv_dim, 128)
+    if lkv_dim != actual_lkv_dim:
+        ql_nope = jnp.pad(
+            ql_nope,
+            ((0, 0), (0, 0), (0, lkv_dim - actual_lkv_dim)),
+            constant_values=0,
+        )
+    actual_r_dim = q_pe.shape[-1]
+    r_dim = align_to(actual_r_dim, 128)
+    if actual_r_dim != r_dim:
+        q_pe = jnp.pad(q_pe, ((0, 0), (0, 0), (0, r_dim - actual_r_dim)),
+                       constant_values=0)
+
+    q = jnp.concatenate([ql_nope, q_pe], axis=-1)
+    max_num_seqs = kv_lens.shape[0]
+    num_page_indices = page_indices.shape[0]
+    assert num_page_indices % max_num_seqs == 0
+    pages_per_seq = num_page_indices // max_num_seqs
+
+    total_num_pages, page_size_per_kv_packing, kv_packing, _ = updated_cache_kv.shape
+    page_size = page_size_per_kv_packing * kv_packing
+    assert lkv_dim == ql_nope.shape[-1]
+    assert r_dim == q_pe.shape[-1]
+    assert lkv_dim + r_dim == updated_cache_kv.shape[-1]
+
+    kv_c_cache = updated_cache_kv[..., :lkv_dim].reshape(
+        total_num_pages, page_size, lkv_dim)
+    k_pe_cache = updated_cache_kv[...,
+                                  lkv_dim:].reshape(total_num_pages, page_size,
+                                                    r_dim)
+
+    outputs = []
+
+    for i in range(distribution[-1]):
+        q_start, q_end = cu_q_lens[i], cu_q_lens[i + 1]
+        q_len = q_end - q_start
+        kv_len = kv_lens[i]
+
+        q_i = q[q_start:q_end]  # [q_len, actual_num_q_heads, lkv_dim+r_dim]
+
+        indices_start = i * pages_per_seq
+        num_pages_i = cdiv(kv_len, page_size)
+        indices_end = indices_start + num_pages_i
+        indices = page_indices[indices_start:indices_end]
+
+        gathered_kv_c = kv_c_cache[indices]
+        gathered_k_pe = k_pe_cache[indices]
+
+        flat_kv_c = gathered_kv_c.reshape(-1, lkv_dim)
+        flat_k_pe = gathered_k_pe.reshape(-1, r_dim)
+
+        k_i = jnp.concatenate([flat_kv_c[:kv_len], flat_k_pe[:kv_len]],
+                              axis=-1)
+        v_i = flat_kv_c[:kv_len]
+
+        # MQA attention; attn shape: [num_heads, q_len, kv_len]
+        attn = jnp.einsum("qnh,kh->nqk",
+                          q_i,
+                          k_i,
+                          preferred_element_type=jnp.float32)
+        attn *= sm_scale
+        if k_scale is not None:
+            attn *= k_scale
+        if q_scale is not None:
+            attn *= q_scale
+
+        # Causal mask.
+        q_span = kv_len - q_len + jax.lax.broadcasted_iota(
+            jnp.int32, attn.shape, 1)
+        kv_span = jax.lax.broadcasted_iota(jnp.int32, attn.shape, 2)
+        causal_mask = q_span < kv_span
+
+        # Top-k selection mask: positions not listed in topk_indices are masked.
+        # topk_indices_i: [q_len, topk]; -1 entries don't match any kv position.
+        topk_indices_i = topk_indices[q_start:q_end]
+        kv_positions = jnp.arange(kv_len, dtype=jnp.int32)
+        is_selected = jnp.any(
+            topk_indices_i[:, :, None] == kv_positions[None, None, :],
+            axis=1,
+        )  # [q_len, kv_len]
+        topk_mask = jnp.logical_not(is_selected)[
+            None, :, :]  # broadcast over heads
+
+        mask = jnp.logical_or(causal_mask, topk_mask)
+        if soft_cap is not None:
+            attn = soft_cap * jnp.tanh(attn / soft_cap)
+        attn = jnp.where(mask, mask_value, attn)
+        attn = jax.nn.softmax(attn, axis=-1).astype(v_i.dtype)
+
+        out_i = jnp.einsum("nqk,kl->qnl", attn, v_i).astype(q_i.dtype)
+        if v_scale is not None:
+            out_i *= v_scale
+        outputs.append(out_i)
+
+    return (
+        jnp.concatenate(outputs, axis=0),
+        updated_cache_kv,
+    )
+
+
+def sparse_mla_ragged_paged_attention(
+    ql_nope: jax.Array,
+    q_pe: jax.Array,
+    new_kv_c: jax.Array,
+    new_k_pe: jax.Array,
+    cache_kv: jax.Array,
+    kv_lens: jax.Array,
+    topk_indices: jax.Array,
+    page_indices: jax.Array,
+    cu_q_lens: jax.Array,
+    distribution: jax.Array,
+    *,
+    sm_scale: float = 1.0,
+    soft_cap: float | None = None,
+    mask_value: float | None = DEFAULT_MASK_VALUE,
+    q_scale: float | None = None,
+    k_scale: float | None = None,
+    v_scale: float | None = None,
+    num_kv_pages_per_block: int | None = None,
+    num_queries_per_block: int | None = None,
+    vmem_limit_bytes: int | None = None,
+):
+    """Pallas-backed sparse MLA attention.
+
+    Thin wrapper that delegates to ``mla_ragged_paged_attention`` with the
+    optional ``topk_indices`` argument set, which activates the per-query
+    top-k mask path inside the existing MLA kernel (F1 architecture: one
+    Pallas kernel parameterized by ``is_sparse``).
+    """
+    from tpu_inference.kernels.mla.v1.kernel import mla_ragged_paged_attention
+    return mla_ragged_paged_attention(
+        ql_nope,
+        q_pe,
+        new_kv_c,
+        new_k_pe,
+        cache_kv,
+        kv_lens,
+        page_indices,
+        cu_q_lens,
+        distribution,
+        sm_scale=sm_scale,
+        soft_cap=soft_cap,
+        mask_value=mask_value,
+        q_scale=q_scale,
+        k_scale=k_scale,
+        v_scale=v_scale,
+        topk_indices=topk_indices,
+        num_kv_pages_per_block=num_kv_pages_per_block,
+        num_queries_per_block=num_queries_per_block,
+        vmem_limit_bytes=vmem_limit_bytes,
+    )


### PR DESCRIPTION
# Description

* Add sparse MLA attention Pallas kernel under `tpu_inference/kernels/sparse_mla/v1/`. Does MLA attention restricted to a per-query top-k subset of KV positions, given a `topk_indices: i32[num_tokens, topk]` index list with -1 sentinel for unused slots. KV cache layout, paging, and FlashAttention-2 online softmax are identical to the existing dense MLA kernel.

* Architecture: parameterized MLA kernel. Adds an optional `topk_indices` HBM input + `is_sparse` static flag to the existing `mla_ragged_paged_attention`. Sparse path `pltpu.sync_copy`s a per-Q-block slice of `topk_indices` into a VMEM scratch buffer, builds a membership-test mask, and ORs with the existing causal mask inside `flash_attention` before softmax. Dense path passes a 1×1 sentinel; the `is_sparse=False` branch is elided at JIT time — no behavior change for existing callers.

* `tpu_inference/kernels/sparse_mla/v1/kernel.py` is a thin wrapper that delegates to the parameterized MLA kernel with `topk_indices` set. Pure-JAX reference impl included as the correctness oracle.

* Adds a row to `support_matrices/release/v6e/flax_nnx/kernel_support_matrix.csv` and a feature yaml at `.buildkite/features/Sparse_MLA_Attention.yml` (generated via `add_feature_to_ci.py`).

Motivation: top-k sparse attention is the consumer side of the scheme used in DeepSeek V3.2 (`index_topk`) and inherited by GLM-5.1. This kernel is the TPU implementation of that primitive — model-agnostic, callable by any layer that wants top-k sparse attention on top of an MLA-shaped KV cache. The producer (FP8 indexer) is planned as a follow-up.

Targets v6e and v7x. v4 deferred.

# Tests

All run on v6e-8.

Correctness — `pytest tests/kernels/sparse_mla_v1_test.py` — **15/15 green**:
* 6 reference-impl correctness cases (CPU + TPU compatible), including the load-bearing `topk_full == dense_MLA reference` sanity.
* 5 Pallas-kernel-vs-reference cases on TPU, including `kernel(topk_full) == dense_MLA kernel` — proves the mask injection is correct via two independent code paths.
* 4 perf cases following the timing pattern from `tests/kernels/gather_reduce_test.py`.

No regression — `pytest tests/kernels/mla_v1_test.py` — **14/14 green** (pre-existing dense MLA suite).

Performance (v6e-8, bf16, 5-iter median, after warmup):

| Case | Dense MLA (ms/iter) | Sparse MLA (ms/iter) | Ratio |
|------|---------------------|----------------------|-------|
| `decode_only` `[(1, 256), (1, 1024)]` | 0.274 | 0.286 | 1.04× |
| `mixed_batch` `[(64, 64), (1, 512), (32, 800)]` | 1.168 | 1.181 | 1.01× |
| `prefill_small` `[(64, 64)]` | 0.655 | 0.657 | 1.00× |
| `prefill_uneven` `[(48, 200), (96, 96)]` | 1.579 | 1.580 | 1.00× |

Mask-based v1 still loads all KV pages (same DMA as dense), so parity with dense is the goal — not a speedup. Topk-mask compute overhead ≤4% on the smallest decode case, ≤1% otherwise. Truly-sparse-load (skip non-topk pages, realize the bandwidth win) is a v2 optimization.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
