### PR TITLE
[Bug fix] Fix RL Integration tests by setting vllm_config context

### DIFF
--- a/tpu_inference/runner/kv_cache_manager.py
+++ b/tpu_inference/runner/kv_cache_manager.py
@@ -19,7 +19,7 @@ import jax.numpy as jnp
 import vllm.envs as envs
 from jax.sharding import NamedSharding, PartitionSpec
 from torchax.ops.mappings import t2j_dtype
-from vllm.config import get_layers_from_vllm_config
+from vllm.config import get_layers_from_vllm_config, set_current_vllm_config
 from vllm.model_executor.layers.attention import Attention
 from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
 from vllm.model_executor.layers.mamba.abstract import MambaBase
@@ -838,7 +838,8 @@ class KVCacheManager:
             f"hbm_before="
             f"{utils.hbm_usage_gb(self.runner.mesh.devices.flatten())}Gb")
 
-        self.initialize_kv_cache(kv_cache_config)
+        with set_current_vllm_config(self.runner.vllm_config):
+            self.initialize_kv_cache(kv_cache_config)
 
     @staticmethod
     @jax.jit


### PR DESCRIPTION
# Description

This PR updates `tpu_inference/runner/kv_cache_manager.py` to ensure that the correct vllm configuration context is set when reinitializing KV cache. 

This fixed the rl_integration nightly test 

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
