### PR TITLE
Implement missing Punica LoRA ops and custom module parsing

### DIFF
--- a/tests/lora/test_env_parsing.py
+++ b/tests/lora/test_env_parsing.py
@@ -1,0 +1,54 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import pytest
+from tpu_inference.models.vllm.vllm_model_wrapper import _parse_lora_module_path_env
+
+def test_parse_lora_module_path_env(monkeypatch):
+    # Test case 1: Missing env var
+    monkeypatch.delenv("LORA_MODULE_PATH", raising=False)
+    assert _parse_lora_module_path_env() is None
+
+    # Test case 2: Standard format with mapping
+    monkeypatch.setenv("LORA_MODULE_PATH", "something/(query|key|value|out)/something")
+    expected = sorted(["q_proj", "k_proj", "v_proj", "o_proj"])
+    result = _parse_lora_module_path_env()
+    assert sorted(result) == expected
+
+    # Test case 3: Fallback for unknown modules
+    monkeypatch.setenv("LORA_MODULE_PATH", "(embed|lm_head|unknown)")
+    expected = sorted(["embed_tokens", "lm_head", "unknown"])
+    result = _parse_lora_module_path_env()
+    assert sorted(result) == expected
+
+    # Test case 4: No matching groups, falls back to splitting
+    monkeypatch.setenv("LORA_MODULE_PATH", "no_groups_here")
+    assert _parse_lora_module_path_env() == ["no_groups_here"]
+
+    # Test case 5: Empty groups
+    monkeypatch.setenv("LORA_MODULE_PATH", "()")
+    assert _parse_lora_module_path_env() is None
+
+    # Test case 6: Comma separated list
+    monkeypatch.setenv("LORA_MODULE_PATH", "q_proj,k_proj,v_proj")
+    expected = sorted(["q_proj", "k_proj", "v_proj"])
+    result = _parse_lora_module_path_env()
+    assert sorted(result) == expected
+
+    # Test case 7: Pipe separated list without parentheses
+    monkeypatch.setenv("LORA_MODULE_PATH", "query|key|value")
+    expected = sorted(["q_proj", "k_proj", "v_proj"])
+    result = _parse_lora_module_path_env()
+    assert sorted(result) == expected

--- a/tests/lora/test_env_parsing.py
+++ b/tests/lora/test_env_parsing.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pytest
 from tpu_inference.lora.lora_manager import parse_lora_module_path_env
+
 
 def test_parse_lora_module_path_env(monkeypatch):
     # Test case 1: Missing env var
@@ -21,7 +21,8 @@ def test_parse_lora_module_path_env(monkeypatch):
     assert parse_lora_module_path_env() is None
 
     # Test case 2: Standard format with mapping
-    monkeypatch.setenv("LORA_MODULE_PATH", "something/(query|key|value|out)/something")
+    monkeypatch.setenv("LORA_MODULE_PATH",
+                       "something/(query|key|value|out)/something")
     expected = sorted(["q_proj", "k_proj", "v_proj", "o_proj"])
     result = parse_lora_module_path_env()
     assert sorted(result) == expected

--- a/tests/lora/test_env_parsing.py
+++ b/tests/lora/test_env_parsing.py
@@ -12,43 +12,42 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 import pytest
-from tpu_inference.lora.lora_manager import parse_lora_module_path_env as _parse_lora_module_path_env
+from tpu_inference.lora.lora_manager import parse_lora_module_path_env
 
 def test_parse_lora_module_path_env(monkeypatch):
     # Test case 1: Missing env var
     monkeypatch.delenv("LORA_MODULE_PATH", raising=False)
-    assert _parse_lora_module_path_env() is None
+    assert parse_lora_module_path_env() is None
 
     # Test case 2: Standard format with mapping
     monkeypatch.setenv("LORA_MODULE_PATH", "something/(query|key|value|out)/something")
     expected = sorted(["q_proj", "k_proj", "v_proj", "o_proj"])
-    result = _parse_lora_module_path_env()
+    result = parse_lora_module_path_env()
     assert sorted(result) == expected
 
     # Test case 3: Fallback for unknown modules
     monkeypatch.setenv("LORA_MODULE_PATH", "(embed|lm_head|unknown)")
     expected = sorted(["embed_tokens", "lm_head", "unknown"])
-    result = _parse_lora_module_path_env()
+    result = parse_lora_module_path_env()
     assert sorted(result) == expected
 
     # Test case 4: No matching groups, falls back to splitting
     monkeypatch.setenv("LORA_MODULE_PATH", "no_groups_here")
-    assert _parse_lora_module_path_env() == ["no_groups_here"]
+    assert parse_lora_module_path_env() == ["no_groups_here"]
 
     # Test case 5: Empty groups
     monkeypatch.setenv("LORA_MODULE_PATH", "()")
-    assert _parse_lora_module_path_env() is None
+    assert parse_lora_module_path_env() is None
 
     # Test case 6: Comma separated list
     monkeypatch.setenv("LORA_MODULE_PATH", "q_proj,k_proj,v_proj")
     expected = sorted(["q_proj", "k_proj", "v_proj"])
-    result = _parse_lora_module_path_env()
+    result = parse_lora_module_path_env()
     assert sorted(result) == expected
 
     # Test case 7: Pipe separated list without parentheses
     monkeypatch.setenv("LORA_MODULE_PATH", "query|key|value")
     expected = sorted(["q_proj", "k_proj", "v_proj"])
-    result = _parse_lora_module_path_env()
+    result = parse_lora_module_path_env()
     assert sorted(result) == expected

--- a/tests/lora/test_env_parsing.py
+++ b/tests/lora/test_env_parsing.py
@@ -14,7 +14,7 @@
 
 import os
 import pytest
-from tpu_inference.models.vllm.vllm_model_wrapper import _parse_lora_module_path_env
+from tpu_inference.lora.lora_manager import parse_lora_module_path_env as _parse_lora_module_path_env
 
 def test_parse_lora_module_path_env(monkeypatch):
     # Test case 1: Missing env var

--- a/tests/lora/test_layers.py
+++ b/tests/lora/test_layers.py
@@ -30,9 +30,7 @@ from vllm.lora.layers import (BaseLayerWithLoRA, ColumnParallelLinearWithLoRA,
                               MergedQKVParallelLinearWithLoRA,
                               QKVParallelLinearWithLoRA,
                               ReplicatedLinearWithLoRA,
-                              RowParallelLinearWithLoRA,
-                              VocabParallelEmbeddingWithLoRA,
-                              LogitsProcessorWithLoRA)
+                              RowParallelLinearWithLoRA)
 # yapf: enable
 from vllm.lora.lora_weights import LoRALayerWeights, PackedLoRALayerWeights
 from vllm.lora.punica_wrapper import get_punica_wrapper
@@ -41,8 +39,6 @@ from vllm.model_executor.layers.linear import (ColumnParallelLinear,
                                                QKVParallelLinear,
                                                ReplicatedLinear,
                                                RowParallelLinear)
-from vllm.model_executor.layers.vocab_parallel_embedding import VocabParallelEmbedding
-from vllm.model_executor.layers.logits_processor import LogitsProcessor
 from vllm.platforms import current_platform
 from vllm.utils.torch_utils import set_random_seed
 
@@ -671,38 +667,46 @@ def test_punica_wrapper_add_lora_embedding(dist_init, num_loras) -> None:
     set_random_seed(6)
     max_loras = 9
     max_lora_rank = 8
-    
+
     max_num_batched_tokens = 8192
     max_batches = 256
     with torchax.default_env():
-        punica_wrapper = get_punica_wrapper(max_num_batched_tokens, max_batches, 'jax', max_loras=max_loras)
-        
+        punica_wrapper = get_punica_wrapper(max_num_batched_tokens,
+                                            max_batches,
+                                            'jax',
+                                            max_loras=max_loras)
+
     index_to_id = get_random_index_to_id(num_loras, max_loras)
-    
+
     num_tokens = 32
     x = torch.rand((num_tokens, max_lora_rank), dtype=torch.bfloat16)
     y = torch.rand((num_tokens, 64), dtype=torch.bfloat16)
-    
-    lora_b_stacked = torch.rand((max_loras, 1, 64, max_lora_rank), dtype=torch.bfloat16)
-    
+
+    lora_b_stacked = torch.rand((max_loras, 1, 64, max_lora_rank),
+                                dtype=torch.bfloat16)
+
     valid_lora_ids = [i for i in index_to_id if i is not None]
     if not valid_lora_ids:
         valid_lora_ids = [1]
         index_to_id[0] = 1
-        
+
     prompt_mapping = [random.choice(valid_lora_ids) for _ in range(num_tokens)]
     index_mapping = prompt_mapping
-    
+
     lora_mapping = LoRAMapping(index_mapping, prompt_mapping, is_prefill=True)
     with torchax.default_env():
         # Convert inputs to torchax tensors
         x_torchax = torch_view(t2j(x))
         y_torchax = torch_view(t2j(y))
         lora_b_stacked_torchax = torch_view(t2j(lora_b_stacked))
-        
-        punica_wrapper.update_metadata(lora_mapping, index_to_id, max_loras, vocab_size=512)
-        actual_result = punica_wrapper.add_lora_embedding(y_torchax.clone(), x_torchax, lora_b_stacked_torchax)
-        
+
+        punica_wrapper.update_metadata(lora_mapping,
+                                       index_to_id,
+                                       max_loras,
+                                       vocab_size=512)
+        actual_result = punica_wrapper.add_lora_embedding(
+            y_torchax.clone(), x_torchax, lora_b_stacked_torchax)
+
     expected_result = y.clone()
     for i in range(num_tokens):
         lora_id = prompt_mapping[i]
@@ -710,11 +714,14 @@ def test_punica_wrapper_add_lora_embedding(dist_init, num_loras) -> None:
             lora_idx = index_to_id.index(lora_id)
             lora_b = lora_b_stacked[lora_idx, 0, :, :]
             expected_result[i] += x[i] @ lora_b.T
-            
+
     rtol, atol = TOLERANCES[actual_result.dtype]
     with torchax.default_env():
         actual_result_cpu = actual_result.to('cpu')
-        torch.testing.assert_close(actual_result_cpu, expected_result, rtol=rtol, atol=atol)
+        torch.testing.assert_close(actual_result_cpu,
+                                   expected_result,
+                                   rtol=rtol,
+                                   atol=atol)
 
 
 @torch.inference_mode()
@@ -723,29 +730,34 @@ def test_punica_wrapper_add_lora_logits(dist_init, num_loras) -> None:
     set_random_seed(6)
     max_loras = 9
     max_lora_rank = 8
-    
+
     max_num_batched_tokens = 8192
     max_batches = 256
     with torchax.default_env():
-        punica_wrapper = get_punica_wrapper(max_num_batched_tokens, max_batches, 'jax', max_loras=max_loras)
-        
+        punica_wrapper = get_punica_wrapper(max_num_batched_tokens,
+                                            max_batches,
+                                            'jax',
+                                            max_loras=max_loras)
+
     index_to_id = get_random_index_to_id(num_loras, max_loras)
-    
+
     num_tokens = 32
     x = torch.rand((num_tokens, 64), dtype=torch.bfloat16)
     y = torch.rand((num_tokens, 512), dtype=torch.bfloat16)
-    
-    lora_a_stacked = torch.rand((max_loras, 1, max_lora_rank, 64), dtype=torch.bfloat16)
-    lora_b_stacked = torch.rand((max_loras, 1, 512, max_lora_rank), dtype=torch.bfloat16)
-    
+
+    lora_a_stacked = torch.rand((max_loras, 1, max_lora_rank, 64),
+                                dtype=torch.bfloat16)
+    lora_b_stacked = torch.rand((max_loras, 1, 512, max_lora_rank),
+                                dtype=torch.bfloat16)
+
     valid_lora_ids = [i for i in index_to_id if i is not None]
     if not valid_lora_ids:
         valid_lora_ids = [1]
         index_to_id[0] = 1
-        
+
     prompt_mapping = [random.choice(valid_lora_ids) for _ in range(num_tokens)]
     index_mapping = prompt_mapping
-    
+
     lora_mapping = LoRAMapping(index_mapping, prompt_mapping, is_prefill=True)
     with torchax.default_env():
         # Convert inputs to torchax tensors
@@ -753,10 +765,17 @@ def test_punica_wrapper_add_lora_logits(dist_init, num_loras) -> None:
         y_torchax = torch_view(t2j(y))
         lora_a_stacked_torchax = torch_view(t2j(lora_a_stacked))
         lora_b_stacked_torchax = torch_view(t2j(lora_b_stacked))
-        
-        punica_wrapper.update_metadata(lora_mapping, index_to_id, max_loras, vocab_size=512)
-        actual_result = punica_wrapper.add_lora_logits(y_torchax.clone(), x_torchax, lora_a_stacked_torchax, lora_b_stacked_torchax, scale=1.0)
-        
+
+        punica_wrapper.update_metadata(lora_mapping,
+                                       index_to_id,
+                                       max_loras,
+                                       vocab_size=512)
+        actual_result = punica_wrapper.add_lora_logits(y_torchax.clone(),
+                                                       x_torchax,
+                                                       lora_a_stacked_torchax,
+                                                       lora_b_stacked_torchax,
+                                                       scale=1.0)
+
     expected_result = y.clone()
     for i in range(num_tokens):
         lora_id = prompt_mapping[i]
@@ -765,8 +784,11 @@ def test_punica_wrapper_add_lora_logits(dist_init, num_loras) -> None:
             lora_a = lora_a_stacked[lora_idx, 0, :, :]
             lora_b = lora_b_stacked[lora_idx, 0, :, :]
             expected_result[i] += (x[i] @ lora_a.T) @ lora_b.T
-            
+
     rtol, atol = TOLERANCES[actual_result.dtype]
     with torchax.default_env():
         actual_result_cpu = actual_result.to('cpu')
-        torch.testing.assert_close(actual_result_cpu, expected_result, rtol=rtol, atol=atol)
+        torch.testing.assert_close(actual_result_cpu,
+                                   expected_result,
+                                   rtol=rtol,
+                                   atol=atol)

--- a/tests/lora/test_layers.py
+++ b/tests/lora/test_layers.py
@@ -30,7 +30,9 @@ from vllm.lora.layers import (BaseLayerWithLoRA, ColumnParallelLinearWithLoRA,
                               MergedQKVParallelLinearWithLoRA,
                               QKVParallelLinearWithLoRA,
                               ReplicatedLinearWithLoRA,
-                              RowParallelLinearWithLoRA)
+                              RowParallelLinearWithLoRA,
+                              VocabParallelEmbeddingWithLoRA,
+                              LogitsProcessorWithLoRA)
 # yapf: enable
 from vllm.lora.lora_weights import LoRALayerWeights, PackedLoRALayerWeights
 from vllm.lora.punica_wrapper import get_punica_wrapper
@@ -39,6 +41,8 @@ from vllm.model_executor.layers.linear import (ColumnParallelLinear,
                                                QKVParallelLinear,
                                                ReplicatedLinear,
                                                RowParallelLinear)
+from vllm.model_executor.layers.vocab_parallel_embedding import VocabParallelEmbedding
+from vllm.model_executor.layers.logits_processor import LogitsProcessor
 from vllm.platforms import current_platform
 from vllm.utils.torch_utils import set_random_seed
 
@@ -659,3 +663,110 @@ def _create_lora_wrapper(linear,
         lora_linear.lora_b_stacked) == n_slices)
 
     return lora_linear
+
+
+@torch.inference_mode()
+@pytest.mark.parametrize("num_loras", [1, 4, 9])
+def test_punica_wrapper_add_lora_embedding(dist_init, num_loras) -> None:
+    set_random_seed(6)
+    max_loras = 9
+    max_lora_rank = 8
+    
+    max_num_batched_tokens = 8192
+    max_batches = 256
+    with torchax.default_env():
+        punica_wrapper = get_punica_wrapper(max_num_batched_tokens, max_batches, 'jax', max_loras=max_loras)
+        
+    index_to_id = get_random_index_to_id(num_loras, max_loras)
+    
+    num_tokens = 32
+    x = torch.rand((num_tokens, max_lora_rank), dtype=torch.bfloat16)
+    y = torch.rand((num_tokens, 64), dtype=torch.bfloat16)
+    
+    lora_b_stacked = torch.rand((max_loras, 1, 64, max_lora_rank), dtype=torch.bfloat16)
+    
+    valid_lora_ids = [i for i in index_to_id if i is not None]
+    if not valid_lora_ids:
+        valid_lora_ids = [1]
+        index_to_id[0] = 1
+        
+    prompt_mapping = [random.choice(valid_lora_ids) for _ in range(num_tokens)]
+    index_mapping = prompt_mapping
+    
+    lora_mapping = LoRAMapping(index_mapping, prompt_mapping, is_prefill=True)
+    with torchax.default_env():
+        # Convert inputs to torchax tensors
+        x_torchax = torch_view(t2j(x))
+        y_torchax = torch_view(t2j(y))
+        lora_b_stacked_torchax = torch_view(t2j(lora_b_stacked))
+        
+        punica_wrapper.update_metadata(lora_mapping, index_to_id, max_loras, vocab_size=512)
+        actual_result = punica_wrapper.add_lora_embedding(y_torchax.clone(), x_torchax, lora_b_stacked_torchax)
+        
+    expected_result = y.clone()
+    for i in range(num_tokens):
+        lora_id = prompt_mapping[i]
+        if lora_id is not None:
+            lora_idx = index_to_id.index(lora_id)
+            lora_b = lora_b_stacked[lora_idx, 0, :, :]
+            expected_result[i] += x[i] @ lora_b.T
+            
+    rtol, atol = TOLERANCES[actual_result.dtype]
+    with torchax.default_env():
+        actual_result_cpu = actual_result.to('cpu')
+        torch.testing.assert_close(actual_result_cpu, expected_result, rtol=rtol, atol=atol)
+
+
+@torch.inference_mode()
+@pytest.mark.parametrize("num_loras", [1, 4, 9])
+def test_punica_wrapper_add_lora_logits(dist_init, num_loras) -> None:
+    set_random_seed(6)
+    max_loras = 9
+    max_lora_rank = 8
+    
+    max_num_batched_tokens = 8192
+    max_batches = 256
+    with torchax.default_env():
+        punica_wrapper = get_punica_wrapper(max_num_batched_tokens, max_batches, 'jax', max_loras=max_loras)
+        
+    index_to_id = get_random_index_to_id(num_loras, max_loras)
+    
+    num_tokens = 32
+    x = torch.rand((num_tokens, 64), dtype=torch.bfloat16)
+    y = torch.rand((num_tokens, 512), dtype=torch.bfloat16)
+    
+    lora_a_stacked = torch.rand((max_loras, 1, max_lora_rank, 64), dtype=torch.bfloat16)
+    lora_b_stacked = torch.rand((max_loras, 1, 512, max_lora_rank), dtype=torch.bfloat16)
+    
+    valid_lora_ids = [i for i in index_to_id if i is not None]
+    if not valid_lora_ids:
+        valid_lora_ids = [1]
+        index_to_id[0] = 1
+        
+    prompt_mapping = [random.choice(valid_lora_ids) for _ in range(num_tokens)]
+    index_mapping = prompt_mapping
+    
+    lora_mapping = LoRAMapping(index_mapping, prompt_mapping, is_prefill=True)
+    with torchax.default_env():
+        # Convert inputs to torchax tensors
+        x_torchax = torch_view(t2j(x))
+        y_torchax = torch_view(t2j(y))
+        lora_a_stacked_torchax = torch_view(t2j(lora_a_stacked))
+        lora_b_stacked_torchax = torch_view(t2j(lora_b_stacked))
+        
+        punica_wrapper.update_metadata(lora_mapping, index_to_id, max_loras, vocab_size=512)
+        actual_result = punica_wrapper.add_lora_logits(y_torchax.clone(), x_torchax, lora_a_stacked_torchax, lora_b_stacked_torchax, scale=1.0)
+        
+    expected_result = y.clone()
+    for i in range(num_tokens):
+        lora_id = prompt_mapping[i]
+        if lora_id is not None:
+            lora_idx = index_to_id.index(lora_id)
+            lora_a = lora_a_stacked[lora_idx, 0, :, :]
+            lora_b = lora_b_stacked[lora_idx, 0, :, :]
+            expected_result[i] += (x[i] @ lora_a.T) @ lora_b.T
+            
+    rtol, atol = TOLERANCES[actual_result.dtype]
+    with torchax.default_env():
+        actual_result_cpu = actual_result.to('cpu')
+        torch.testing.assert_close(actual_result_cpu, expected_result, rtol=rtol, atol=atol)

--- a/tests/lora/test_punica_tpu.py
+++ b/tests/lora/test_punica_tpu.py
@@ -1,0 +1,95 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import jax
+import pytest
+import torch
+import torchax
+from tpu_inference.lora.torch_lora_ops import bgmv_expand_slice, bgmv_shrink
+from tpu_inference.lora.torch_punica_tpu import PunicaWrapperTPU
+
+tpu_available = False
+try:
+    if jax.devices("tpu"):
+        tpu_available = True
+except RuntimeError:
+    pass
+
+pytestmark = pytest.mark.skipif(not tpu_available, reason="No TPU found")
+
+
+def test_add_lora_embedding():
+    class DummyWrapper:
+        def __init__(self, idxs):
+            self.idxs = idxs
+        def _get_token_lora_indices(self, x):
+            return self.idxs
+
+    num_tokens = 16
+    hidden_size = 128
+    max_loras = 9
+    max_lora_rank = 8
+
+    with torchax.default_env(), jax.default_device(jax.devices("tpu")[0]):
+        x = torch.rand(num_tokens, max_lora_rank, device='jax')
+        lora_b_stacked = torch.rand(max_loras, 1, hidden_size, max_lora_rank, device='jax')
+        y = torch.zeros(num_tokens, hidden_size, device='jax')
+        idxs = torch.randint(0, max_loras, (num_tokens,), device='jax', dtype=torch.int32)
+
+        wrapper = DummyWrapper(idxs)
+        
+        actual = PunicaWrapperTPU.add_lora_embedding(wrapper, y.clone(), x, lora_b_stacked)
+        
+        expected = y.clone()
+        for i in range(num_tokens):
+            lora_idx = idxs[i].item()
+            lora_b = lora_b_stacked[lora_idx, 0]
+            expected[i] += torch.matmul(lora_b, x[i])
+
+        torch.testing.assert_close(actual, expected, atol=3e-2, rtol=1e-3)
+
+
+def test_add_lora_logits():
+    class DummyWrapper:
+        def __init__(self, idxs):
+            self.idxs = idxs
+        def _get_sampler_indices(self, x):
+            return self.idxs
+
+    num_tokens = 16
+    hidden_size = 128
+    max_loras = 9
+    max_lora_rank = 8
+
+    with torchax.default_env(), jax.default_device(jax.devices("tpu")[0]):
+        x = torch.rand(num_tokens, hidden_size, device='jax')
+        lora_a_stacked = torch.rand(max_loras, 1, max_lora_rank, hidden_size, device='jax')
+        lora_b_stacked = torch.rand(max_loras, 1, hidden_size, max_lora_rank, device='jax')
+        y = torch.zeros(num_tokens, hidden_size, device='jax')
+        idxs = torch.randint(0, max_loras, (num_tokens,), device='jax', dtype=torch.int32)
+
+        wrapper = DummyWrapper(idxs)
+        
+        actual = PunicaWrapperTPU.add_lora_logits(wrapper, y.clone(), x, lora_a_stacked, lora_b_stacked, scale=1.0)
+        
+        expected = y.clone()
+        for i in range(num_tokens):
+            lora_idx = idxs[i].item()
+            lora_a = lora_a_stacked[lora_idx, 0]
+            lora_b = lora_b_stacked[lora_idx, 0]
+            
+            buffer = torch.matmul(lora_a, x[i])
+            expected[i] += torch.matmul(lora_b, buffer)
+
+        torch.testing.assert_close(actual, expected, atol=5e-1, rtol=1e-2)

--- a/tests/lora/test_punica_tpu.py
+++ b/tests/lora/test_punica_tpu.py
@@ -16,7 +16,7 @@ import jax
 import pytest
 import torch
 import torchax
-from tpu_inference.lora.torch_lora_ops import bgmv_expand_slice, bgmv_shrink
+
 from tpu_inference.lora.torch_punica_tpu import PunicaWrapperTPU
 
 tpu_available = False
@@ -30,9 +30,12 @@ pytestmark = pytest.mark.skipif(not tpu_available, reason="No TPU found")
 
 
 def test_add_lora_embedding():
+
     class DummyWrapper:
+
         def __init__(self, idxs):
             self.idxs = idxs
+
         def _get_token_lora_indices(self, x):
             return self.idxs
 
@@ -43,14 +46,22 @@ def test_add_lora_embedding():
 
     with torchax.default_env(), jax.default_device(jax.devices("tpu")[0]):
         x = torch.rand(num_tokens, max_lora_rank, device='jax')
-        lora_b_stacked = torch.rand(max_loras, 1, hidden_size, max_lora_rank, device='jax')
+        lora_b_stacked = torch.rand(max_loras,
+                                    1,
+                                    hidden_size,
+                                    max_lora_rank,
+                                    device='jax')
         y = torch.zeros(num_tokens, hidden_size, device='jax')
-        idxs = torch.randint(0, max_loras, (num_tokens,), device='jax', dtype=torch.int32)
+        idxs = torch.randint(0,
+                             max_loras, (num_tokens, ),
+                             device='jax',
+                             dtype=torch.int32)
 
         wrapper = DummyWrapper(idxs)
-        
-        actual = PunicaWrapperTPU.add_lora_embedding(wrapper, y.clone(), x, lora_b_stacked)
-        
+
+        actual = PunicaWrapperTPU.add_lora_embedding(wrapper, y.clone(), x,
+                                                     lora_b_stacked)
+
         expected = y.clone()
         for i in range(num_tokens):
             lora_idx = idxs[i].item()
@@ -61,9 +72,12 @@ def test_add_lora_embedding():
 
 
 def test_add_lora_logits():
+
     class DummyWrapper:
+
         def __init__(self, idxs):
             self.idxs = idxs
+
         def _get_sampler_indices(self, x):
             return self.idxs
 
@@ -74,21 +88,37 @@ def test_add_lora_logits():
 
     with torchax.default_env(), jax.default_device(jax.devices("tpu")[0]):
         x = torch.rand(num_tokens, hidden_size, device='jax')
-        lora_a_stacked = torch.rand(max_loras, 1, max_lora_rank, hidden_size, device='jax')
-        lora_b_stacked = torch.rand(max_loras, 1, hidden_size, max_lora_rank, device='jax')
+        lora_a_stacked = torch.rand(max_loras,
+                                    1,
+                                    max_lora_rank,
+                                    hidden_size,
+                                    device='jax')
+        lora_b_stacked = torch.rand(max_loras,
+                                    1,
+                                    hidden_size,
+                                    max_lora_rank,
+                                    device='jax')
         y = torch.zeros(num_tokens, hidden_size, device='jax')
-        idxs = torch.randint(0, max_loras, (num_tokens,), device='jax', dtype=torch.int32)
+        idxs = torch.randint(0,
+                             max_loras, (num_tokens, ),
+                             device='jax',
+                             dtype=torch.int32)
 
         wrapper = DummyWrapper(idxs)
-        
-        actual = PunicaWrapperTPU.add_lora_logits(wrapper, y.clone(), x, lora_a_stacked, lora_b_stacked, scale=1.0)
-        
+
+        actual = PunicaWrapperTPU.add_lora_logits(wrapper,
+                                                  y.clone(),
+                                                  x,
+                                                  lora_a_stacked,
+                                                  lora_b_stacked,
+                                                  scale=1.0)
+
         expected = y.clone()
         for i in range(num_tokens):
             lora_idx = idxs[i].item()
             lora_a = lora_a_stacked[lora_idx, 0]
             lora_b = lora_b_stacked[lora_idx, 0]
-            
+
             buffer = torch.matmul(lora_a, x[i])
             expected[i] += torch.matmul(lora_b, buffer)
 

--- a/tpu_inference/envs.py
+++ b/tpu_inference/envs.py
@@ -61,6 +61,7 @@ if TYPE_CHECKING:
     DP_SCHED_BATCH_PREFILL_FLUSH_TIMEOUT_MS: int = 10000
     ONEHOT_MOE_PERMUTE_THRESHOLD: int = 0
     PROFILE_SINGLE_DEVICE: bool = False
+    LORA_MODULE_PATH: str = ""
 
 
 def env_with_choices(
@@ -380,6 +381,8 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Profile a single device instead of all devices.
     "PROFILE_SINGLE_DEVICE":
     env_bool("PROFILE_SINGLE_DEVICE", default=False),
+    "LORA_MODULE_PATH":
+    lambda: os.getenv("LORA_MODULE_PATH", ""),
 }
 
 

--- a/tpu_inference/lora/lora_manager.py
+++ b/tpu_inference/lora/lora_manager.py
@@ -14,8 +14,10 @@
 
 import re
 from typing import List, Optional
+
 import torchax
 from vllm.lora.worker_manager import LRUCacheWorkerLoRAManager
+
 from tpu_inference import envs
 
 # MaxText/Pax style name to HuggingFace/vLLM canonical target module mapping.
@@ -81,7 +83,8 @@ def parse_lora_module_path_env() -> Optional[List[str]]:
         matches = LORA_GROUP_PATTERN.findall(env_val)
         for group in matches:
             for module in group.split('|'):
-                target_modules.add(MAXTEXT_TO_HF_LORA_MAPPING.get(module, module))
+                target_modules.add(
+                    MAXTEXT_TO_HF_LORA_MAPPING.get(module, module))
     else:
         # No parentheses found, assume standard list
         # Split by comma or pipe

--- a/tpu_inference/lora/lora_manager.py
+++ b/tpu_inference/lora/lora_manager.py
@@ -1,0 +1,68 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import re
+from typing import List, Optional
+import torchax
+from vllm.lora.worker_manager import LRUCacheWorkerLoRAManager
+from tpu_inference import envs
+
+# MaxText/Pax style name to HuggingFace/vLLM canonical target module mapping.
+MAXTEXT_TO_HF_LORA_MAPPING = {
+    "query": "q_proj",
+    "key": "k_proj",
+    "value": "v_proj",
+    "out": "o_proj",
+    "wi_0": "gate_proj",
+    "wi_1": "up_proj",
+    "wo": "down_proj",
+    "embed": "embed_tokens",
+    "lm_head": "lm_head",
+}
+
+
+class TPULRUCacheWorkerLoRAManager(LRUCacheWorkerLoRAManager):
+    """
+    TPU-specific wrapper to ensure dummy LoRA creation happens 
+    within the torchax environment.
+    """
+
+    def add_dummy_lora(self, lora_request, rank: int) -> bool:
+        with torchax.default_env():
+            return super().add_dummy_lora(lora_request, rank)
+
+
+def parse_lora_module_path_env() -> Optional[List[str]]:
+    """Parses LORA_MODULE_PATH env var into vLLM canonical target_modules list."""
+    env_val = envs.LORA_MODULE_PATH
+    if not env_val:
+        return None
+
+    target_modules = set()
+
+    # Extract regex groups like (query|key|value|out)
+    if '(' in env_val or ')' in env_val:
+        matches = re.findall(r'\(([^)]+)\)', env_val)
+        for group in matches:
+            for module in group.split('|'):
+                target_modules.add(MAXTEXT_TO_HF_LORA_MAPPING.get(module, module))
+    else:
+        # No parentheses found, assume standard list
+        # Split by comma or pipe
+        parts = re.split(r'[,|]', env_val)
+        for part in parts:
+            part = part.strip()
+            if part:
+                target_modules.add(MAXTEXT_TO_HF_LORA_MAPPING.get(part, part))
+    return list(target_modules) if target_modules else None

--- a/tpu_inference/lora/lora_manager.py
+++ b/tpu_inference/lora/lora_manager.py
@@ -19,6 +19,9 @@ from vllm.lora.worker_manager import LRUCacheWorkerLoRAManager
 from tpu_inference import envs
 
 # MaxText/Pax style name to HuggingFace/vLLM canonical target module mapping.
+# This mapping is hardcoded to keep tpu-inference self-contained and avoid
+# a heavy dependency on the MaxText repository, which doesn't expose a simple
+# importable mapping for these names.
 MAXTEXT_TO_HF_LORA_MAPPING = {
     "query": "q_proj",
     "key": "k_proj",
@@ -30,6 +33,9 @@ MAXTEXT_TO_HF_LORA_MAPPING = {
     "embed": "embed_tokens",
     "lm_head": "lm_head",
 }
+
+LORA_GROUP_PATTERN = re.compile(r'\(([^)]+)\)')
+LORA_SPLIT_PATTERN = re.compile(r'[,|]')
 
 
 class TPULRUCacheWorkerLoRAManager(LRUCacheWorkerLoRAManager):
@@ -44,7 +50,26 @@ class TPULRUCacheWorkerLoRAManager(LRUCacheWorkerLoRAManager):
 
 
 def parse_lora_module_path_env() -> Optional[List[str]]:
-    """Parses LORA_MODULE_PATH env var into vLLM canonical target_modules list."""
+    """Parses LORA_MODULE_PATH env var into vLLM canonical target_modules list.
+
+    Supported formats for LORA_MODULE_PATH:
+    1. Regex-like with grouped modules in parentheses, e.g.:
+       "decoder/layers/self_attention/(query|key|value|out)"
+       This will extract "query", "key", "value", "out".
+    2. Comma or pipe-separated list, e.g.:
+       "query,key,value" or "query|key|value"
+
+    If the input contains parentheses, it extracts the grouped modules and splits
+    them by '|'. Otherwise, it splits the entire input by ',' or '|'.
+
+    Extracted module names are mapped to their canonical HuggingFace/vLLM names
+    using MAXTEXT_TO_HF_LORA_MAPPING if a mapping exists (e.g., "query" -> "q_proj").
+    If no mapping exists, the original name is kept.
+
+    Returns:
+        A list of canonical target module names (e.g., ["q_proj", "k_proj"]),
+        or None if LORA_MODULE_PATH is not set or empty.
+    """
     env_val = envs.LORA_MODULE_PATH
     if not env_val:
         return None
@@ -53,14 +78,14 @@ def parse_lora_module_path_env() -> Optional[List[str]]:
 
     # Extract regex groups like (query|key|value|out)
     if '(' in env_val or ')' in env_val:
-        matches = re.findall(r'\(([^)]+)\)', env_val)
+        matches = LORA_GROUP_PATTERN.findall(env_val)
         for group in matches:
             for module in group.split('|'):
                 target_modules.add(MAXTEXT_TO_HF_LORA_MAPPING.get(module, module))
     else:
         # No parentheses found, assume standard list
         # Split by comma or pipe
-        parts = re.split(r'[,|]', env_val)
+        parts = LORA_SPLIT_PATTERN.split(env_val)
         for part in parts:
             part = part.strip()
             if part:

--- a/tpu_inference/lora/torch_punica_tpu.py
+++ b/tpu_inference/lora/torch_punica_tpu.py
@@ -52,6 +52,9 @@ class PunicaWrapperTPU(PunicaWrapperBase):
     def _get_token_lora_indices(self, x: torch.Tensor) -> torch.IntTensor:
         return torch.narrow(self._token_lora_indices, 0, 0, x.size(0))
 
+    def _get_sampler_indices(self, x: torch.Tensor) -> torch.IntTensor:
+        return torch.narrow(self._sampler_indices, 0, 0, x.size(0))
+
     @property
     def embeddings_indices(self) -> torch.Tensor:
         """
@@ -148,8 +151,18 @@ class PunicaWrapperTPU(PunicaWrapperBase):
             lora_b_stacked (torch.Tensor): lora_b's weights.
             add_inputs (bool): Default to True.
         """
-        raise NotImplementedError(
-            "NYI: torch_punica_tpu.PunicaWrapperTPU.add_lora_embedding.")
+        y_orig = y
+        y = y.view(-1, y.shape[-1])
+        x = x.view(-1, x.shape[-1])
+        
+        add_input = kwargs.get('add_input', add_inputs)
+        
+        # Embedding layer only needs the expand operation as lookup in LoRA A is done beforehand.
+        y = bgmv_expand_slice(x, lora_b_stacked, y,
+                              self._get_token_lora_indices(x),
+                              0, y.shape[-1],
+                              add_input)
+        return y.view(y_orig.shape)
 
     def add_lora_linear(self,
                         y: torch.Tensor,
@@ -226,8 +239,20 @@ class PunicaWrapperTPU(PunicaWrapperBase):
             scale (float): Scaling factor.
             buffer (Optional[torch.Tensor]):Default to None.
         """
-        raise NotImplementedError(
-            "NYI: torch_punica_tpu.PunicaWrapperTPU.add_lora_logits.")
+
+        # Step 1: Shrink operation
+        buffer = bgmv_shrink(x, lora_a_stacked, self._get_sampler_indices(x), scale)
+        
+        y_orig = y
+        y = y.view(-1, y.shape[-1])
+        
+        # Step 2: Expand operation
+        y = bgmv_expand_slice(buffer, lora_b_stacked, y,
+                              self._get_sampler_indices(x),
+                              0, y.shape[-1],
+                              True)
+        
+        return y.view(y_orig.shape)
 
     @property
     def token_lora_indices(self) -> torch.Tensor:

--- a/tpu_inference/lora/torch_punica_tpu.py
+++ b/tpu_inference/lora/torch_punica_tpu.py
@@ -155,13 +155,13 @@ class PunicaWrapperTPU(PunicaWrapperBase):
         y = y.view(-1, y.shape[-1])
         x = x.view(-1, x.shape[-1])
         
-        add_input = kwargs.get('add_input', add_inputs)
+        add_inputs = kwargs.get('add_inputs', add_inputs)
         
         # Embedding layer only needs the expand operation as lookup in LoRA A is done beforehand.
         y = bgmv_expand_slice(x, lora_b_stacked, y,
                               self._get_token_lora_indices(x),
                               0, y.shape[-1],
-                              add_input)
+                              add_inputs)
         return y.view(y_orig.shape)
 
     def add_lora_linear(self,
@@ -240,6 +240,9 @@ class PunicaWrapperTPU(PunicaWrapperBase):
             buffer (Optional[torch.Tensor]):Default to None.
         """
 
+        # Note: We use per-token indices here because the TPU bgmv ops expect a tensor
+        # of shape [num_tokens].
+        
         # Step 1: Shrink operation
         buffer = bgmv_shrink(x, lora_a_stacked, self._get_sampler_indices(x), scale)
         

--- a/tpu_inference/lora/torch_punica_tpu.py
+++ b/tpu_inference/lora/torch_punica_tpu.py
@@ -154,13 +154,12 @@ class PunicaWrapperTPU(PunicaWrapperBase):
         y_orig = y
         y = y.view(-1, y.shape[-1])
         x = x.view(-1, x.shape[-1])
-        
+
         add_inputs = kwargs.get('add_inputs', add_inputs)
-        
+
         # Embedding layer only needs the expand operation as lookup in LoRA A is done beforehand.
         y = bgmv_expand_slice(x, lora_b_stacked, y,
-                              self._get_token_lora_indices(x),
-                              0, y.shape[-1],
+                              self._get_token_lora_indices(x), 0, y.shape[-1],
                               add_inputs)
         return y.view(y_orig.shape)
 
@@ -242,19 +241,19 @@ class PunicaWrapperTPU(PunicaWrapperBase):
 
         # Note: We use per-token indices here because the TPU bgmv ops expect a tensor
         # of shape [num_tokens].
-        
+
         # Step 1: Shrink operation
-        buffer = bgmv_shrink(x, lora_a_stacked, self._get_sampler_indices(x), scale)
-        
+        buffer = bgmv_shrink(x, lora_a_stacked, self._get_sampler_indices(x),
+                             scale)
+
         y_orig = y
         y = y.view(-1, y.shape[-1])
-        
+
         # Step 2: Expand operation
         y = bgmv_expand_slice(buffer, lora_b_stacked, y,
-                              self._get_sampler_indices(x),
-                              0, y.shape[-1],
+                              self._get_sampler_indices(x), 0, y.shape[-1],
                               True)
-        
+
         return y.view(y_orig.shape)
 
     @property

--- a/tpu_inference/models/vllm/vllm_model_wrapper.py
+++ b/tpu_inference/models/vllm/vllm_model_wrapper.py
@@ -640,6 +640,9 @@ def load_lora_model(model: torch.nn.Module, vllm_config: VllmConfig,
         logger.warning("Regarding multimodal models, vLLM currently "
                        "only supports adding LoRA to language model.")
 
+    # The target_modules list is used by vLLM's LoRA manager to identify
+    # which modules in the base model should have LoRA adapters attached.
+    # Overriding it here allows targeting custom module paths specified via env var on TPU.
     env_modules = _parse_lora_module_path_env()
     if env_modules is not None and vllm_config.lora_config:
         vllm_config.lora_config.target_modules = env_modules

--- a/tpu_inference/models/vllm/vllm_model_wrapper.py
+++ b/tpu_inference/models/vllm/vllm_model_wrapper.py
@@ -619,6 +619,17 @@ class VllmModelWrapper:
         return compute_pooler_output
 
 
+class TPULRUCacheWorkerLoRAManager(LRUCacheWorkerLoRAManager):
+    """
+    TPU-specific wrapper to ensure dummy LoRA creation happens 
+    within the torchax environment.
+    """
+
+    def add_dummy_lora(self, lora_request, rank: int) -> bool:
+        with torchax.default_env():
+            return super().add_dummy_lora(lora_request, rank)
+
+
 def load_lora_model(model: torch.nn.Module, vllm_config: VllmConfig,
                     device: str) -> torch.nn.Module:
     if not supports_lora(model):
@@ -637,7 +648,7 @@ def load_lora_model(model: torch.nn.Module, vllm_config: VllmConfig,
         )
 
     # Add LoRA Manager to the Model Runner
-    lora_manager = LRUCacheWorkerLoRAManager(
+    lora_manager = TPULRUCacheWorkerLoRAManager(
         vllm_config,
         device,
         model.embedding_modules,

--- a/tpu_inference/models/vllm/vllm_model_wrapper.py
+++ b/tpu_inference/models/vllm/vllm_model_wrapper.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 
 import copy
-import os
-import re
 import time
 from collections.abc import Sequence
 from contextlib import nullcontext
@@ -66,6 +64,8 @@ from tpu_inference.models.vllm.experimental.vision_tower_jit import (
 from tpu_inference.models.vllm.vllm_model_wrapper_context import (
     get_vllm_model_wrapper_context, set_vllm_model_wrapper_context)
 from tpu_inference.runner.lora_utils import replace_lora_metadata
+from tpu_inference.lora.lora_manager import (TPULRUCacheWorkerLoRAManager,
+                                             parse_lora_module_path_env)
 
 logger = init_logger(__name__)
 
@@ -619,17 +619,6 @@ class VllmModelWrapper:
         return compute_pooler_output
 
 
-class TPULRUCacheWorkerLoRAManager(LRUCacheWorkerLoRAManager):
-    """
-    TPU-specific wrapper to ensure dummy LoRA creation happens 
-    within the torchax environment.
-    """
-
-    def add_dummy_lora(self, lora_request, rank: int) -> bool:
-        with torchax.default_env():
-            return super().add_dummy_lora(lora_request, rank)
-
-
 def load_lora_model(model: torch.nn.Module, vllm_config: VllmConfig,
                     device: str) -> torch.nn.Module:
     if not supports_lora(model):
@@ -643,7 +632,7 @@ def load_lora_model(model: torch.nn.Module, vllm_config: VllmConfig,
     # The target_modules list is used by vLLM's LoRA manager to identify
     # which modules in the base model should have LoRA adapters attached.
     # Overriding it here allows targeting custom module paths specified via env var on TPU.
-    env_modules = _parse_lora_module_path_env()
+    env_modules = parse_lora_module_path_env()
     if env_modules is not None and vllm_config.lora_config:
         vllm_config.lora_config.target_modules = env_modules
         logger.info(
@@ -683,45 +672,3 @@ def replace_set_lora(model):
             module.set_lora = _tpu_set_lora.__get__(module, module.__class__)
             module.reset_lora = _tpu_reset_lora.__get__(
                 module, module.__class__)
-
-
-def _parse_lora_module_path_env():
-    """Parses LORA_MODULE_PATH env var into vLLM canonical target_modules list."""
-    env_val = os.environ.get("LORA_MODULE_PATH")
-    if not env_val:
-        return None
-    # Map Google/MaxText Pax-style names to canonical HF/vLLM names
-    name_mapping = {
-        "query": "q_proj",
-        "key": "k_proj",
-        "value": "v_proj",
-        "out": "o_proj",
-        "wi_0": "gate_proj",
-        "wi_1": "up_proj",
-        "wo": "down_proj",
-        "embed": "embed_tokens",
-        "lm_head": "lm_head"
-    }
-    target_modules = set()
-
-    # Extract regex groups like (query|key|value|out)
-    if '(' in env_val or ')' in env_val:
-        matches = re.findall(r'\(([^)]+)\)', env_val)
-        for group in matches:
-            for module in group.split('|'):
-                if module in name_mapping:
-                    target_modules.add(name_mapping[module])
-                else:
-                    target_modules.add(module)
-    else:
-        # No parentheses found, assume standard list
-        # Split by comma or pipe
-        parts = re.split(r'[,|]', env_val)
-        for part in parts:
-            part = part.strip()
-            if part:
-                if part in name_mapping:
-                    target_modules.add(name_mapping[part])
-                else:
-                    target_modules.add(part)
-    return list(target_modules) if target_modules else None

--- a/tpu_inference/models/vllm/vllm_model_wrapper.py
+++ b/tpu_inference/models/vllm/vllm_model_wrapper.py
@@ -33,7 +33,6 @@ from vllm.config import VllmConfig, set_current_vllm_config
 from vllm.forward_context import set_forward_context
 from vllm.ir import enable_torch_wrap
 from vllm.lora.layers import BaseLayerWithLoRA
-from vllm.lora.worker_manager import LRUCacheWorkerLoRAManager
 from vllm.model_executor.layers.pooler import Pooler
 from vllm.model_executor.model_loader import get_model as vllm_get_model
 from vllm.model_executor.models import supports_lora, supports_multimodal
@@ -52,6 +51,8 @@ from tpu_inference.layers.vllm.process_weights.cleanup_sharding import \
     shard_model_to_tpu
 from tpu_inference.layers.vllm.quantization import get_tpu_quantization_config
 from tpu_inference.logger import init_logger
+from tpu_inference.lora.lora_manager import (TPULRUCacheWorkerLoRAManager,
+                                             parse_lora_module_path_env)
 from tpu_inference.models.common.interface import PoolerFunc
 from tpu_inference.models.jax.jax_intermediate_tensor import \
     JaxIntermediateTensors
@@ -64,8 +65,6 @@ from tpu_inference.models.vllm.experimental.vision_tower_jit import (
 from tpu_inference.models.vllm.vllm_model_wrapper_context import (
     get_vllm_model_wrapper_context, set_vllm_model_wrapper_context)
 from tpu_inference.runner.lora_utils import replace_lora_metadata
-from tpu_inference.lora.lora_manager import (TPULRUCacheWorkerLoRAManager,
-                                             parse_lora_module_path_env)
 
 logger = init_logger(__name__)
 

--- a/tpu_inference/models/vllm/vllm_model_wrapper.py
+++ b/tpu_inference/models/vllm/vllm_model_wrapper.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 import copy
+import os
+import re
 import time
 from collections.abc import Sequence
 from contextlib import nullcontext
@@ -627,6 +629,13 @@ def load_lora_model(model: torch.nn.Module, vllm_config: VllmConfig,
         logger.warning("Regarding multimodal models, vLLM currently "
                        "only supports adding LoRA to language model.")
 
+    env_modules = _parse_lora_module_path_env()
+    if env_modules is not None and vllm_config.lora_config:
+        vllm_config.lora_config.target_modules = env_modules
+        logger.info(
+            f"Overriding vLLM Engine LoRA target_modules with LORA_MODULE_PATH: {env_modules}"
+        )
+
     # Add LoRA Manager to the Model Runner
     lora_manager = LRUCacheWorkerLoRAManager(
         vllm_config,
@@ -660,3 +669,45 @@ def replace_set_lora(model):
             module.set_lora = _tpu_set_lora.__get__(module, module.__class__)
             module.reset_lora = _tpu_reset_lora.__get__(
                 module, module.__class__)
+
+
+def _parse_lora_module_path_env():
+    """Parses LORA_MODULE_PATH env var into vLLM canonical target_modules list."""
+    env_val = os.environ.get("LORA_MODULE_PATH")
+    if not env_val:
+        return None
+    # Map Google/MaxText Pax-style names to canonical HF/vLLM names
+    name_mapping = {
+        "query": "q_proj",
+        "key": "k_proj",
+        "value": "v_proj",
+        "out": "o_proj",
+        "wi_0": "gate_proj",
+        "wi_1": "up_proj",
+        "wo": "down_proj",
+        "embed": "embed_tokens",
+        "lm_head": "lm_head"
+    }
+    target_modules = set()
+
+    # Extract regex groups like (query|key|value|out)
+    if '(' in env_val or ')' in env_val:
+        matches = re.findall(r'\(([^)]+)\)', env_val)
+        for group in matches:
+            for module in group.split('|'):
+                if module in name_mapping:
+                    target_modules.add(name_mapping[module])
+                else:
+                    target_modules.add(module)
+    else:
+        # No parentheses found, assume standard list
+        # Split by comma or pipe
+        parts = re.split(r'[,|]', env_val)
+        for part in parts:
+            part = part.strip()
+            if part:
+                if part in name_mapping:
+                    target_modules.add(name_mapping[part])
+                else:
+                    target_modules.add(part)
+    return list(target_modules) if target_modules else None


### PR DESCRIPTION
# Description

This PR completes LoRA support in `tpu-inference` by addressing missing Punica implementations, handling custom LoRA module configurations, and fixing `torchax` environment issues. 

Specifically, this change:
- Implements `add_lora_embedding` and `add_lora_logits` in `PunicaWrapperTPU` to fix the `NotImplementedError` raised during inference. The `add_lora_logits` implementation utilizes a down-projection (`bgmv_shrink`) followed by an up-projection (`bgmv_expand_slice`). The `add_lora_embedding` implementation only performs a up-projection (`bgmv_expand_slice`) since the look up in LoRA A is done beforehand in the vLLM embedding layer.
- Adds parsing for the `LORA_MODULE_PATH` environment variable to override the vLLM engine's `target_modules`. This allows users to pass custom paths like `decoder/layers/self_attention/(query|key|value|out)`.
- Introduces `TPULRUCacheWorkerLoRAManager` to ensure dummy LoRA creation happens within the proper `torchax` environment.

FIXES: b/499306719

# Tests

- Validated the fixes on a tpu7-8 node using `examples/features/lora/multilora_offline.py` from vLLM repo.
- Verified that the system correctly parses and targets modules when `LORA_MODULE_PATH` is set.
- Verified model compilation and inference execute successfully, producing the expected text outputs when relying on the new `add_lora_embedding` and `add_lora_logits` methods.
- Added unit tests for environment parsing (`tests/lora/test_env_parsing.py`) and the Punica TPU wrapper (`tests/lora/test_punica_tpu.py`).

# Checklist

Before submitting this PR, please make sure:
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [ ] I have made or will make corresponding changes to any relevant documentation. - N/A
