### PR TITLE
make bm metrics selection logic flexible

### DIFF
--- a/.buildkite/benchmark/scripts/report_result.sh
+++ b/.buildkite/benchmark/scripts/report_result.sh
@@ -13,7 +13,37 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -euo pipefail
+set -Eeuo pipefail
+
+# ==============================================================================
+# 0. Global Panic Handler (Crash Interceptor)
+# ==============================================================================
+# shellcheck disable=SC2317
+on_crash() {
+    local exit_code=$?
+    local line_no=$1
+    local command="$2"
+    
+    # Ignore normal exits (Fixed SC2086 by adding double quotes)
+    if [ "$exit_code" -eq 0 ]; then
+        return
+    fi
+
+    echo ""
+    echo "================================================================"
+    echo "🚨 [FATAL ERROR] Bash Script Crashed Unexpectedly!"
+    echo "================================================================"
+    echo "File:     $(basename "$0")"
+    echo "Line:     $line_no"
+    echo "Command:  $command"
+    echo "ExitCode: $exit_code"
+    echo "================================================================"
+    echo ""
+}
+
+# Bind the ERR signal: Triggers on_crash immediately if any command fails 
+# and is not explicitly caught by an 'if' statement or '||' operator.
+trap 'on_crash ${LINENO} "$BASH_COMMAND"' ERR
 
 # Helper function to escape single quotes and handle defaults for SQL
 prepare_sql_val() {
@@ -124,7 +154,7 @@ fi
       local section="$1"
       local label="$2"  # Mean, Median, or P99
       grep "$section (ms):" "$BM_LOG" | \
-      awk -v label="$label" '$0 ~ label { print $NF }'
+      awk -v label="$label" '$0 ~ label { print $NF }' || true
     }
 
     # Median values

--- a/.buildkite/benchmark/scripts/run_bm.sh
+++ b/.buildkite/benchmark/scripts/run_bm.sh
@@ -13,7 +13,37 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -euo pipefail
+set -Eeuo pipefail
+
+# ==============================================================================
+# 0. Global Panic Handler (Crash Interceptor)
+# ==============================================================================
+# shellcheck disable=SC2317
+on_crash() {
+    local exit_code=$?
+    local line_no=$1
+    local command="$2"
+    
+    # Ignore normal exits (Fixed SC2086 by adding double quotes)
+    if [ "$exit_code" -eq 0 ]; then
+        return
+    fi
+
+    echo ""
+    echo "================================================================"
+    echo "🚨 [FATAL ERROR] Bash Script Crashed Unexpectedly!"
+    echo "================================================================"
+    echo "File:     $(basename "$0")"
+    echo "Line:     $line_no"
+    echo "Command:  $command"
+    echo "ExitCode: $exit_code"
+    echo "================================================================"
+    echo ""
+}
+
+# Bind the ERR signal: Triggers on_crash immediately if any command fails 
+# and is not explicitly caught by an 'if' statement or '||' operator.
+trap 'on_crash ${LINENO} "$BASH_COMMAND"' ERR
 
 CASE_FILE="$1"
 TARGET_CASE_NAME=${2:-""}


### PR DESCRIPTION
Make bm metrics selection logic flexible by not exit when metrics are not present. 

The key logic change is the " || true" added to the function extract_value(). The below `if [[ -n "$key" && -n "$value" ]]; then insert_cols+=", $key"` should be able to skip the unselected metrics.

The on_crash() is aimed to enhance the debuggability, without this the failure from the report_result.sh is silent and no log at all.

### Test

tested the on_crash() functionality w/o the fix
BK build: https://buildkite.com/tpu-commons/tpu-inference-benchmark/builds/220

```

2026-05-01 11:32:11 PDT | ================================================================
-- | --
2026-05-01 11:32:11 PDT | 🚨 [FATAL ERROR] Bash Script Crashed Unexpectedly!
2026-05-01 11:32:11 PDT | ================================================================
2026-05-01 11:32:11 PDT | File:     report_result.sh
2026-05-01 11:32:11 PDT | Line:     160
2026-05-01 11:32:11 PDT | Command:  MedianITL=$(extract_value "ITL" "Median")
2026-05-01 11:32:11 PDT | ExitCode: 1
2026-05-01 11:32:11 PDT | ================================================================

```