### PR TITLE
Enable bf16 SSM state in fused GDN kernels by default on TPU

### DIFF
--- a/tests/kernels/fused_gdn_kernel_test.py
+++ b/tests/kernels/fused_gdn_kernel_test.py
@@ -42,6 +42,7 @@ def _make_inputs(
     V,
     dtype=jnp.bfloat16,
     max_num_req=None,
+    state_dtype=jnp.float32,
 ):
     """Build inputs for fused_gdn tests."""
     all_seqlens = [1] * decode_N + list(mixed_seqlens)
@@ -77,7 +78,7 @@ def _make_inputs(
         a,
         b,
         jnp.array(A_log),
-        jnp.array(h0),
+        jnp.array(h0, dtype=state_dtype),
         jnp.array(cu_seqlens),
         jnp.array(state_indices),
         N,
@@ -106,6 +107,7 @@ class FusedGdnKernelTest(jtu.JaxTestCase):
         lower_bound=None,
         atol=1e-2,
         has_initial_state_active=None,
+        state_dtype=jnp.float32,
     ):
         rng = np.random.RandomState(42)
         q, k, v, a, b, A_log, h0, cu_seqlens, state_indices, N = _make_inputs(
@@ -117,6 +119,7 @@ class FusedGdnKernelTest(jtu.JaxTestCase):
             K,
             V,
             max_num_req=max_num_req,
+            state_dtype=state_dtype,
         )
         T = q.shape[0]
 
@@ -211,6 +214,35 @@ class FusedGdnKernelTest(jtu.JaxTestCase):
     )
     def test_basic(self, decode_N, mixed_seqlens):
         self._test_fused_gdn(decode_N, mixed_seqlens, 2, 2, 128, 128)
+
+    # ── bf16 state storage ──
+
+    def test_state_dtype_bf16_decode_and_mixed(self):
+        self._test_fused_gdn(3, [9, 15],
+                             2,
+                             2,
+                             128,
+                             128,
+                             state_dtype=jnp.bfloat16,
+                             atol=5e-2)
+
+    def test_state_dtype_bf16_gqa(self):
+        self._test_fused_gdn(5, [9, 15],
+                             2,
+                             8,
+                             128,
+                             128,
+                             state_dtype=jnp.bfloat16,
+                             atol=5e-2)
+
+    def test_state_dtype_bf16_decode_only(self):
+        self._test_fused_gdn(8, [],
+                             2,
+                             2,
+                             128,
+                             128,
+                             state_dtype=jnp.bfloat16,
+                             atol=5e-2)
 
     # ── Padded max_num_req ──
 

--- a/tpu_inference/envs.py
+++ b/tpu_inference/envs.py
@@ -265,14 +265,8 @@ environment_variables: dict[str, Callable[[], Any]] = {
                      ]),
     "MOE_ALL_GATHER_ACTIVATION_DTYPE":
     lambda: os.getenv("MOE_ALL_GATHER_ACTIVATION_DTYPE", ""),
-    # Override for cache_config.mamba_ssm_cache_dtype on TPU. Default
-    # "bfloat16" halves mamba SSM state HBM and grows the attention KV pool
-    # ~2x on hybrid models (compute still runs fp32 internally via per-token
-    # / per-block cast in the GDN kernels). Set to "float32" (or "float16")
-    # to opt out, or to "" to defer to whatever vLLM/HF config decides
-    # (typically "float32" for Qwen3.5). At the pinned vLLM LKG,
-    # --mamba-ssm-cache-dtype's CLI parser does not accept "bfloat16", so
-    # this env var is the way to set bf16 without vendoring vLLM.
+    # Override cache_config.mamba_ssm_cache_dtype on TPU. Default "bfloat16"
+    # halves SSM state HBM; set "float32" to opt out, "" to defer to vLLM.
     "TPU_MAMBA_SSM_CACHE_DTYPE":
     lambda: os.getenv("TPU_MAMBA_SSM_CACHE_DTYPE", "bfloat16"),
     # kv offload to dram: skip pre-compiling swap-related jax functions

--- a/tpu_inference/envs.py
+++ b/tpu_inference/envs.py
@@ -267,6 +267,8 @@ environment_variables: dict[str, Callable[[], Any]] = {
     lambda: os.getenv("MOE_ALL_GATHER_ACTIVATION_DTYPE", ""),
     # Override cache_config.mamba_ssm_cache_dtype on TPU. Default "bfloat16"
     # halves SSM state HBM; set "float32" to opt out, "" to defer to vLLM.
+    # TODO: remove once vLLM MambaDType includes bfloat16
+    # (https://github.com/vllm-project/vllm/pull/41680).
     "TPU_MAMBA_SSM_CACHE_DTYPE":
     lambda: os.getenv("TPU_MAMBA_SSM_CACHE_DTYPE", "bfloat16"),
     # kv offload to dram: skip pre-compiling swap-related jax functions

--- a/tpu_inference/envs.py
+++ b/tpu_inference/envs.py
@@ -43,6 +43,7 @@ if TYPE_CHECKING:
     REGISTER_MM_MODULE_CUSTOM_PYTREE_CLASSES: list[str] = []
     RAGGED_GATED_DELTA_RULE_IMPL: str = "ragged_gated_delta_rule_chunked"
     MOE_ALL_GATHER_ACTIVATION_DTYPE: str = ""
+    TPU_MAMBA_SSM_CACHE_DTYPE: str = "bfloat16"
     TPU_OFFLOAD_SKIP_JAX_PRECOMPILE: bool = False
     TPU_OFFLOAD_DECODE_SAVE: bool = False
     TPU_OFFLOAD_NUM_CPU_CHUNKS: int = 1024
@@ -264,6 +265,16 @@ environment_variables: dict[str, Callable[[], Any]] = {
                      ]),
     "MOE_ALL_GATHER_ACTIVATION_DTYPE":
     lambda: os.getenv("MOE_ALL_GATHER_ACTIVATION_DTYPE", ""),
+    # Override for cache_config.mamba_ssm_cache_dtype on TPU. Default
+    # "bfloat16" halves mamba SSM state HBM and grows the attention KV pool
+    # ~2x on hybrid models (compute still runs fp32 internally via per-token
+    # / per-block cast in the GDN kernels). Set to "float32" (or "float16")
+    # to opt out, or to "" to defer to whatever vLLM/HF config decides
+    # (typically "float32" for Qwen3.5). At the pinned vLLM LKG,
+    # --mamba-ssm-cache-dtype's CLI parser does not accept "bfloat16", so
+    # this env var is the way to set bf16 without vendoring vLLM.
+    "TPU_MAMBA_SSM_CACHE_DTYPE":
+    lambda: os.getenv("TPU_MAMBA_SSM_CACHE_DTYPE", "bfloat16"),
     # kv offload to dram: skip pre-compiling swap-related jax functions
     "TPU_OFFLOAD_SKIP_JAX_PRECOMPILE":
     lambda: bool(int(os.getenv("TPU_OFFLOAD_SKIP_JAX_PRECOMPILE", "0"))),

--- a/tpu_inference/kernels/gdn/fused_gdn_decode_kernel.py
+++ b/tpu_inference/kernels/gdn/fused_gdn_decode_kernel.py
@@ -41,14 +41,16 @@ def get_default_block_sizes(
     use_gate_in_kernel: bool,
     has_dt_bias: bool,
     vmem_bytes_limit: int,
+    state_dtype=jnp.float32,
 ) -> int:
     """Choose bt to maximize VMEM utilization within vmem_bytes_limit.
 
-    Accounts for state scratch ``(bt, H_v, K, V)`` float32, optional
+    Accounts for state scratch ``(bt, H_v, K, V)`` of ``state_dtype``, optional
     a_log / dt_bias, and bt-proportional tiles that ``emit_pipeline``
     double-buffers (q, k, v, g, b, o).
     """
     ibits = dtypes.itemsize_bits(dtype)
+    sbits = dtypes.itemsize_bits(state_dtype)
 
     # Fixed (not bt-dependent), in bits
     num_lanes = pltpu.get_tpu_info().num_lanes
@@ -59,13 +61,13 @@ def get_default_block_sizes(
         fixed_bits += 2 * H_v * num_lanes * 32  # dt_bias: (H_v, num_lanes) f32
 
     # bt-proportional (in bits):
-    #   state scratch: (2*bt, H_v, K, V) float32 (double buffer)
+    #   state scratch: (2*bt, H_v, K, V) state_dtype (double buffer)
     #   pipeline tiles (×2 for emit_pipeline double buffering):
     #     q(bt,H_qk,K) + k(bt,H_qk,K)           -> 2·H_qk·K·ibits
     #     g(bt,H_v,K) float32                     -> H_v·K·32
     #     v(bt,H_v,V) + o(bt,H_v,V)              -> 2·H_v·V·ibits
     #     b(bt,H_v,num_lanes)                     -> H_v·num_lanes·ibits
-    per_bt_bits = 2 * H_v * K * V * 32 + 2 * (
+    per_bt_bits = 2 * H_v * K * V * sbits + 2 * (
         2 * H_qk * K * ibits + H_v * K * 32 + 2 * H_v * V * ibits +
         H_v * num_lanes * ibits)
 
@@ -412,6 +414,7 @@ def fused_decoding_gdn(
         use_gate_in_kernel,
         dt_bias is not None,
         vmem_bytes_limit,
+        state_dtype=initial_state.dtype,
     )
 
     any_spec = pl.BlockSpec(memory_space=pl.ANY)
@@ -452,8 +455,12 @@ def fused_decoding_gdn(
             out_specs=[any_spec, any_spec],
             grid=(grid_dim, ),
             scratch_shapes=[
+                # h_bufs match HBM dtype so the DMAs don't need conversion.
+                # The per-token compute path upcasts to fp32 on each load
+                # (see h0 = h_bufs_s[..., i_t].astype(fp32) above), so on-chip
+                # math is fp32 regardless of HBM storage dtype.
                 pltpu.VMEM((2, bt, H_v, K, V),
-                           jnp.float32),  # h_bufs (double buffer)
+                           initial_state.dtype),  # h_bufs (double buffer)
                 pltpu.SemaphoreType.DMA((2, )),  # h_load_sems
                 pltpu.SemaphoreType.DMA((2, )),  # h_store_sems
             ],
@@ -464,7 +471,7 @@ def fused_decoding_gdn(
         },
         out_shape=[
             jax.ShapeDtypeStruct((T, H_v, V), dtype),
-            jax.ShapeDtypeStruct((num_states, H_v, K, V), jnp.float32),
+            jax.ShapeDtypeStruct((num_states, H_v, K, V), initial_state.dtype),
         ],
         compiler_params=pltpu.CompilerParams(
             disable_bounds_checks=True,

--- a/tpu_inference/kernels/gdn/fused_gdn_kernel_common.py
+++ b/tpu_inference/kernels/gdn/fused_gdn_kernel_common.py
@@ -89,9 +89,14 @@ def validate_gdn_inputs(
                          f"k={k.dtype}, v={v.dtype}")
     if g.dtype != jnp.float32:
         raise ValueError(f"g must be float32, got {g.dtype}")
-    if initial_state.dtype != jnp.float32:
+    # Storage may be fp32, bf16, or fp16; compute is always fp32 on-chip via
+    # cast in h_bufs scratch. The half-precision options halve HBM bandwidth
+    # and footprint at the cost of recurrent-state precision (bf16: 7
+    # mantissa bits, fp16: 10 mantissa bits but reduced exponent range).
+    if initial_state.dtype not in (jnp.float32, jnp.bfloat16, jnp.float16):
         raise ValueError(
-            f"initial_state must be float32, got {initial_state.dtype}")
+            f"initial_state must be float32, bfloat16, or float16, "
+            f"got {initial_state.dtype}")
     if state_indices.dtype != jnp.int32:
         raise ValueError(
             f"state_indices must be int32, got {state_indices.dtype}")

--- a/tpu_inference/kernels/gdn/fused_gdn_kernel_common.py
+++ b/tpu_inference/kernels/gdn/fused_gdn_kernel_common.py
@@ -89,10 +89,6 @@ def validate_gdn_inputs(
                          f"k={k.dtype}, v={v.dtype}")
     if g.dtype != jnp.float32:
         raise ValueError(f"g must be float32, got {g.dtype}")
-    # Storage may be fp32, bf16, or fp16; compute is always fp32 on-chip via
-    # cast in h_bufs scratch. The half-precision options halve HBM bandwidth
-    # and footprint at the cost of recurrent-state precision (bf16: 7
-    # mantissa bits, fp16: 10 mantissa bits but reduced exponent range).
     if initial_state.dtype not in (jnp.float32, jnp.bfloat16, jnp.float16):
         raise ValueError(
             f"initial_state must be float32, bfloat16, or float16, "

--- a/tpu_inference/kernels/gdn/fused_gdn_kernel_wrapper.py
+++ b/tpu_inference/kernels/gdn/fused_gdn_kernel_wrapper.py
@@ -57,12 +57,16 @@ def _dispatch_with_distribution(
     before it can decode), so masking is unnecessary on the decode path.
     """
     # ── Decode kernel → updates state in-place ──
+    # NOTE: pass `initial_state` through as-is. The kernels upcast to fp32
+    # on VMEM load for compute precision; HBM storage stays at the array's
+    # dtype. An `astype(jnp.float32)` here would materialize an fp32 copy
+    # of a bf16 state and undo the storage win before the kernel runs.
     o_d, state_1 = fused_decoding_gdn(
         q,
         k,
         v,
         g.astype(jnp.float32),
-        initial_state.astype(jnp.float32),
+        initial_state,
         state_indices,
         distribution,
         b,

--- a/tpu_inference/kernels/gdn/fused_gdn_recurrent_kernel.py
+++ b/tpu_inference/kernels/gdn/fused_gdn_recurrent_kernel.py
@@ -38,17 +38,19 @@ def get_default_block_sizes(
     use_gate_in_kernel: bool,
     has_dt_bias: bool,
     vmem_bytes_limit: int,
+    state_dtype=jnp.float32,
 ) -> int:
     """Choose bt to maximize VMEM utilization.
 
     The recurrent kernel uses a fixed ``(2, H_v, K, V)`` state double
-    buffer regardless of bt.  Only pipeline tiles scale with bt.
+    buffer of ``state_dtype`` regardless of bt.  Only pipeline tiles scale with bt.
     """
     ibits = dtypes.itemsize_bits(dtype)
+    sbits = dtypes.itemsize_bits(state_dtype)
 
-    # Fixed (in bits): h_bufs (2, H_v, K, V) float32 — always 2 buffers
+    # Fixed (in bits): h_bufs (2, H_v, K, V) of state_dtype — always 2 buffers
     num_lanes = pltpu.get_tpu_info().num_lanes
-    fixed_bits = 2 * H_v * K * V * 32
+    fixed_bits = 2 * H_v * K * V * sbits
     if use_gate_in_kernel:
         fixed_bits += 2 * H_v * num_lanes * 32  # a_log: (H_v, num_lanes) f32
     if has_dt_bias:
@@ -508,8 +510,15 @@ def fused_recurrent_gdn(
     max_num_req = cu_seqlens.shape[0] - 1
 
     vmem_bytes_limit = int(pltpu.get_tpu_info().vmem_capacity_bytes * 0.9)
-    bt = get_default_block_sizes(H_qk, H_v, K, V, dtype, use_gate_in_kernel,
-                                 dt_bias is not None, vmem_bytes_limit)
+    bt = get_default_block_sizes(H_qk,
+                                 H_v,
+                                 K,
+                                 V,
+                                 dtype,
+                                 use_gate_in_kernel,
+                                 dt_bias is not None,
+                                 vmem_bytes_limit,
+                                 state_dtype=initial_state.dtype)
 
     # Worst case: cdiv(T, bt) base blocks + up to max_num_req-1 boundary splits
     max_num_blocks = (T + bt - 1) // bt + max_num_req - 1
@@ -518,7 +527,8 @@ def fused_recurrent_gdn(
     smem_spec = pl.BlockSpec(memory_space=pltpu.SMEM)
 
     o_shape = jax.ShapeDtypeStruct((T, H_v, V), dtype)
-    state_shape = jax.ShapeDtypeStruct((num_states, H_v, K, V), jnp.float32)
+    state_shape = jax.ShapeDtypeStruct((num_states, H_v, K, V),
+                                       initial_state.dtype)
 
     meta = calculate_chunk_indices(cu_seqlens, distribution, max_num_blocks,
                                    bt)
@@ -563,8 +573,13 @@ def fused_recurrent_gdn(
             out_specs=[any_spec, any_spec],
             grid=(grid_dim, ),
             scratch_shapes=[
+                # h_bufs match HBM dtype so the DMAs don't need conversion.
+                # The compute path upcasts h_bufs to fp32 once per block
+                # (h = h_bufs_s[buf_idx].astype(fp32) above) and carries it
+                # as fp32 across the per-token fori_loop, so on-chip math is
+                # fp32 regardless of HBM storage dtype.
                 pltpu.VMEM((2, H_v, K, V),
-                           jnp.float32),  # h_bufs (double buffer)
+                           initial_state.dtype),  # h_bufs (double buffer)
                 pltpu.SemaphoreType.DMA((2, )),  # h_load_sems
                 pltpu.SemaphoreType.DMA((2, )),  # h_store_sems
             ],

--- a/tpu_inference/platforms/tpu_platform.py
+++ b/tpu_inference/platforms/tpu_platform.py
@@ -247,6 +247,27 @@ class TpuPlatform(Platform):
             logger.info(
                 f"Using KV cache block size: {cache_config.block_size}")
 
+        # Override mamba_ssm_cache_dtype via env var. Defaults to "bfloat16"
+        # (see envs.py): halves SSM state HBM and ~2x's the attention KV
+        # pool on hybrid models. Set TPU_MAMBA_SSM_CACHE_DTYPE=float32 to
+        # opt out, or TPU_MAMBA_SSM_CACHE_DTYPE="" to defer to whatever
+        # vLLM/HF config decided. At the pinned vLLM LKG,
+        # --mamba-ssm-cache-dtype's MambaDType Literal does not include
+        # "bfloat16", but CacheConfig is a pydantic dataclass without
+        # validate_assignment, so programmatic assignment bypasses
+        # validation. The fused GDN kernels accept fp32/bf16/fp16
+        # initial_state and run on-chip math at fp32 regardless of HBM
+        # storage dtype.
+        if cache_config and envs.TPU_MAMBA_SSM_CACHE_DTYPE:
+            override = envs.TPU_MAMBA_SSM_CACHE_DTYPE
+            current = cache_config.mamba_ssm_cache_dtype
+            if current != override:
+                logger.info(
+                    "TPU_MAMBA_SSM_CACHE_DTYPE=%s overriding "
+                    "cache_config.mamba_ssm_cache_dtype (was %r)", override,
+                    current)
+                cache_config.mamba_ssm_cache_dtype = override
+
         parallel_config = vllm_config.parallel_config
         scheduler_config = vllm_config.scheduler_config
         parallel_config.worker_cls = \

--- a/tpu_inference/platforms/tpu_platform.py
+++ b/tpu_inference/platforms/tpu_platform.py
@@ -247,17 +247,6 @@ class TpuPlatform(Platform):
             logger.info(
                 f"Using KV cache block size: {cache_config.block_size}")
 
-        # Override mamba_ssm_cache_dtype via env var. Defaults to "bfloat16"
-        # (see envs.py): halves SSM state HBM and ~2x's the attention KV
-        # pool on hybrid models. Set TPU_MAMBA_SSM_CACHE_DTYPE=float32 to
-        # opt out, or TPU_MAMBA_SSM_CACHE_DTYPE="" to defer to whatever
-        # vLLM/HF config decided. At the pinned vLLM LKG,
-        # --mamba-ssm-cache-dtype's MambaDType Literal does not include
-        # "bfloat16", but CacheConfig is a pydantic dataclass without
-        # validate_assignment, so programmatic assignment bypasses
-        # validation. The fused GDN kernels accept fp32/bf16/fp16
-        # initial_state and run on-chip math at fp32 regardless of HBM
-        # storage dtype.
         if cache_config and envs.TPU_MAMBA_SSM_CACHE_DTYPE:
             override = envs.TPU_MAMBA_SSM_CACHE_DTYPE
             current = cache_config.mamba_ssm_cache_dtype


### PR DESCRIPTION
Adds end-to-end support for storing the GDN recurrent state at bf16 (or fp16) in HBM on TPU and makes bf16 the default. Compute precision is unchanged: the kernels upcast h_bufs to fp32 inside VMEM (per-token in the decode kernel, per-block in the recurrent kernel), so on-chip math runs at fp32 regardless of HBM storage dtype.

   Relax the fp32-only restriction on initial_state in the fused GDN
   decode and recurrent kernels:
   - fused_gdn_kernel_common.py: validate_gdn_inputs accepts fp32/bf16/fp16.
   - fused_gdn_decode_kernel.py: h_bufs scratch and state out_shape match initial_state.dtype; get_default_block_sizes takes a state_dtype param so VMEM budgeting accounts for the smaller scratch.
   - fused_gdn_recurrent_kernel.py: same pattern as decode.
   - fused_gdn_kernel_wrapper.py: drop the unconditional .astype(jnp.float32) cast on initial_state - that cast would materialize an fp32 copy of a bf16 state in HBM and defeat the storage savings. These patches are inert when callers pass fp32 initial_state.

   Opt-out: TPU_MAMBA_SSM_CACHE_DTYPE=float32 vllm serve ...
   Defer to vLLM/HF config: TPU_MAMBA_SSM_CACHE_DTYPE="" vllm serve ...

On Qwen3.5-397B-A17B-FP8 (60 layers: 15 full attn + 45 GDN) with TP=8, halving the SSM state shrinks the mamba page (4.27 -> 2.17 MB/slot), which under vLLM's hybrid-cache attn_page >= mamba_page constraint also shrinks the attn block_size (1088 -> 576) and grows the attention pool with the freed HBM. Empirical comparison from the kv_cache_manager init log, same hardware/command, only TPU_MAMBA_SSM_CACHE_DTYPE differs (--gpu-memory-utilization=0.95 --max-num-seqs=512 --max-model-len=9216 --kv-cache-dtype=fp8 --enable-expert-parallel, TP=8 on tpu7x-8):

  |                       | mamba_dtype          | mamba HBM | attn HBM  | attn blocks/layer |
  |-----------------------|----------------------|-----------|-----------|-------------------|
  | TPU_MAMBA_SSM=float32 | (bfloat16, float32)  | 91.8 GiB  | 253.6 GiB | 2037              |
  | bf16 (default)        | (bfloat16, bfloat16) | 46.7 GiB  | 298.8 GiB | 4533 (+122%)      |

At the conc=512 production bench (1k in / 8k out, num-prompts=640) this yields +15% total throughput (3510 -> 4029 tok/s).

Eval:
mmlu GPU baseline: 0.8186

|       Tasks       |Version|    Filter    |n-shot|  Metric   |   |Value |   |Stderr|
|-------------------|------:|--------------|-----:|-----------|---|-----:|---|-----:|
|mmlu_pro           |      2|custom-extract|      |exact_match|↑  |0.8286|±  |0.0140|
| - biology         |      3|custom-extract|     5|exact_match|↑  |0.9200|±  |0.0388|
| - business        |      3|custom-extract|     5|exact_match|↑  |0.8600|±  |0.0496|
| - chemistry       |      3|custom-extract|     5|exact_match|↑  |0.9200|±  |0.0388|
| - computer_science|      3|custom-extract|     5|exact_match|↑  |0.8400|±  |0.0524|
| - economics       |      3|custom-extract|     5|exact_match|↑  |0.8800|±  |0.0464|
| - engineering     |      3|custom-extract|     5|exact_match|↑  |0.7200|±  |0.0641|
| - health          |      3|custom-extract|     5|exact_match|↑  |0.7400|±  |0.0627|
| - history         |      3|custom-extract|     5|exact_match|↑  |0.6600|±  |0.0677|
| - law             |      3|custom-extract|     5|exact_match|↑  |0.7600|±  |0.0610|
| - math            |      3|custom-extract|     5|exact_match|↑  |0.9600|±  |0.0280|
| - other           |      3|custom-extract|     5|exact_match|↑  |0.7600|±  |0.0610|
| - philosophy      |      3|custom-extract|     5|exact_match|↑  |0.8200|±  |0.0549|
| - physics         |      3|custom-extract|     5|exact_match|↑  |0.9600|±  |0.0280|
| - psychology      |      3|custom-extract|     5|exact_match|↑  |0.8000|±  |0.0571|

| Groups |Version|    Filter    |n-shot|  Metric   |   |Value |   |Stderr|
|--------|------:|--------------|------|-----------|---|-----:|---|-----:|
|mmlu_pro|      2|custom-extract|      |exact_match|↑  |0.8286|±  | 0.014|


AIME26 GPU baseline: 0.8

|Tasks |Version|Filter|n-shot|  Metric   |   |Value|   |Stderr|
|------|------:|------|-----:|-----------|---|----:|---|-----:|
|aime26|      0|none  |     0|exact_match|↑  |    1|±  |     0|


GPAQ GPU baseline: 0.8434

|          Tasks          |Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|-------------------------|------:|----------------|-----:|-----------|---|----:|---|-----:|
|gpqa_diamond_cot_zeroshot|      1|flexible-extract|     0|exact_match|↑  |  0.9|±  |0.0557|
|                         |       |strict-match    |     0|exact_match|↑  |  0.0|±  |0.0000|