### PR TITLE
[Gemma4] Fix for the updated interface (due to #2343)

### DIFF
--- a/tests/models/jax/test_gemma4.py
+++ b/tests/models/jax/test_gemma4.py
@@ -20,29 +20,18 @@ from jax import numpy as jnp
 from vllm.config import set_current_vllm_config
 from vllm.model_executor.model_loader import get_model_loader
 
-try:
-    from transformers import Gemma4TextConfig
-except ImportError:
-    Gemma4TextConfig = None
-
 from tpu_inference.distributed.jax_parallel_state import \
     init_pp_distributed_environment
 from tpu_inference.kernels.ragged_paged_attention.v3.kernel import \
     get_kv_cache_shape
 from tpu_inference.layers.common.attention_metadata import AttentionMetadata
 from tpu_inference.layers.jax.quantization import get_tpu_quantization_config
-from tpu_inference.models.jax.gemma4 import (Gemma4DecoderLayer,
-                                             Gemma4ForCausalLM)
+from tpu_inference.models.jax.gemma4 import Gemma4DecoderLayer
+from tpu_inference.models.jax.gemma4_mm import Gemma4ForConditionalGeneration
 
 
-class TestGemma4ForCausalLM:
+class TestGemma4ForConditionalGeneration:
 
-    # TODO(https://github.com/vllm-project/vllm/issues/38379): Re-enable the test after addressing the issue.
-    @pytest.mark.skipif(
-        condition=Gemma4TextConfig is None,
-        reason=
-        "Gemma4 requires transformers v5.5.0, which will break other models. This test cannot be enabled until vLLM upgrades to transformers v5.5.0 or later."
-    )
     @pytest.mark.parametrize("model_name", [
         "google/gemma-4-31B-it",
         "google/gemma-4-26B-A4B-it",
@@ -90,7 +79,7 @@ class TestGemma4ForCausalLM:
         input = [[0.01 * i for i in range(model_dim)] for _ in range(seq_len)]
 
         with jax.set_mesh(mesh):
-            model = Gemma4ForCausalLM(vllm_config, rng, mesh)
+            model = Gemma4ForConditionalGeneration(vllm_config, rng, mesh)
             start_layer_idx = model.model.start_layer
             layer_0: Gemma4DecoderLayer = model.model.layers[start_layer_idx]
             num_key_value_heads = layer_0.self_attn.num_kv_heads
@@ -124,7 +113,7 @@ class TestGemma4ForCausalLM:
                                          kv_dtype)
 
         with jax.set_mesh(mesh):
-            jax_output, _ = jax_layer_0(
+            _, jax_output, _ = jax_layer_0(
                 kv_cache=jnp.zeros(cache_shape, dtype=kv_dtype),
                 x=input_tensor_jax,
                 attention_metadata=AttentionMetadata(

--- a/tpu_inference/layers/jax/moe/moe.py
+++ b/tpu_inference/layers/jax/moe/moe.py
@@ -171,30 +171,37 @@ class JaxMoE(JaxModule):
     prefix: str = ""
     enable_return_routed_experts: bool = False
 
-    def __call__(self, x_TD: jax.Array) -> jax.Array:
+    def __call__(
+        self,
+        x_TD: jax.Array,
+        router_logits: Optional[jax.Array] = None
+    ) -> tuple[jax.Array, Optional[jax.Array]]:
         """Performs the forward pass of the MoE layer.
 
         Args:
             x_TD: Input array of shape (sequence_length, d_model).
+            router_logits: Optional pre-computed router logits. If not provided, logits will be computed using the router.
 
         Returns:
             Output array of shape (sequence_length, d_model) after passing through MoE.
+            If `enable_return_routed_experts` is True, also returns the indices of the selected experts.
         """
-        if self.quant_method is not None:
+        if self.quant_method is None:
+            raise ValueError("Expected quant_method to be set!")
+        if router_logits is None:
             router_logits = self.router(x_TD)
-            x_TD = self.quant_method.apply_jax(self,
-                                               x_TD,
-                                               router_logits=router_logits)
-            if self.enable_return_routed_experts:
-                if self.moe_backend in MoEBackend.fused_moe_backends():
-                    _, selected_experts_TX = jax.lax.top_k(
-                        router_logits, self.num_experts_per_tok)
-                else:
-                    _, selected_experts_TX = router_logits
-                return x_TD, selected_experts_TX
+        x_TD = self.quant_method.apply_jax(self,
+                                           x_TD,
+                                           router_logits=router_logits)
+        if self.enable_return_routed_experts:
+            if self.moe_backend in MoEBackend.fused_moe_backends():
+                _, selected_experts_TX = jax.lax.top_k(
+                    router_logits, self.num_experts_per_tok)
             else:
-                return x_TD, None
-        raise ValueError("Expected quant_method to be set!")
+                _, selected_experts_TX = router_logits
+            return x_TD, selected_experts_TX
+        else:
+            return x_TD, None
 
     def __post_init__(self, rngs: nnx.Rngs):
         """Generates the kernels (weights) for the router and experts (gating, up-projection, and down-projection layers)."""

--- a/tpu_inference/models/jax/gemma4.py
+++ b/tpu_inference/models/jax/gemma4.py
@@ -20,18 +20,7 @@ import jax
 import jax.numpy as jnp
 from flax import nnx
 from jax.sharding import Mesh
-
-try:
-    from transformers import Gemma4TextConfig
-except ImportError:
-    print(
-        "Gemma4 is not available until transformers v5.5.0. Please upgrade transformers to use Gemma4 model."
-    )
-
-    class Gemma4TextConfig:
-        pass
-
-
+from transformers import Gemma4TextConfig
 from vllm.config import VllmConfig
 
 from tpu_inference import utils
@@ -184,7 +173,7 @@ class Gemma4MoE(JaxMoE):
 
     def __init__(
         self,
-        config,
+        config: Gemma4TextConfig,
         dtype,
         mesh,
         rngs: nnx.Rngs,
@@ -218,24 +207,10 @@ class Gemma4MoE(JaxMoE):
             scoring_func=
             "softmax",  # vLLM implementation has a custom routing function, here we just use "softmax" for MVP
             renormalize=True,
+            enable_return_routed_experts=True,
+            num_experts_per_tok=config.top_k_experts,
             quant_config=quant_config,
             prefix=prefix)
-
-    def __call__(self, x_TD: jax.Array, router_logits: jax.Array):
-        """Performs the forward pass of the MoE layer.
-
-        Args:
-            x_TD: Input array of shape (sequence_length, d_model).
-            router_logits: Router logits of shape (sequence_length, num_experts).
-
-        Returns:
-            Output array of shape (sequence_length, d_model) after passing through MoE.
-        """
-        if self.quant_method is not None:
-            return self.quant_method.apply_jax(self,
-                                               x_TD,
-                                               router_logits=router_logits)
-        raise ValueError("Expected quant_method to be set!")
 
     def load_weights(self, weights: Iterable):
         """Load weights for Gemma4 MoE layer.
@@ -638,7 +613,7 @@ class Gemma4DecoderLayer(JaxModule):
         kv_cache: jax.Array,
         x: jax.Array,
         attention_metadata: AttentionMetadata,
-    ) -> Tuple[jax.Array, jax.Array]:
+    ) -> Tuple[jax.Array, jax.Array, Optional[jax.Array]]:
         residual = x
         hidden_states = self.input_layernorm(x)
         kv_cache, attn_output = self.self_attn(
@@ -650,6 +625,7 @@ class Gemma4DecoderLayer(JaxModule):
         hidden_states = residual + attn_output
         residual = hidden_states
 
+        expert_ids = None
         if self.enable_moe_block:
             # Dense MLP branch
             hidden_states_1 = self.pre_feedforward_layernorm(hidden_states)
@@ -661,7 +637,8 @@ class Gemma4DecoderLayer(JaxModule):
             # norm + scale internally); experts see separately normed input
             router_logits = self.router(hidden_states)
             hidden_states_2 = self.pre_feedforward_layernorm_2(hidden_states)
-            hidden_states_2 = self.experts(hidden_states_2, router_logits)
+            hidden_states_2, expert_ids = self.experts(hidden_states_2,
+                                                       router_logits)
             hidden_states_2 = self.post_feedforward_layernorm_2(
                 hidden_states_2)
 
@@ -677,7 +654,7 @@ class Gemma4DecoderLayer(JaxModule):
 
         outputs = outputs * self.layer_scalar.value
 
-        return kv_cache, outputs
+        return kv_cache, outputs, expert_ids
 
 
 class Gemma4Model(JaxModule):
@@ -748,7 +725,7 @@ class Gemma4Model(JaxModule):
         attention_metadata: AttentionMetadata,
         inputs_embeds: Optional[jax.Array] = None,
         layer_name_to_kv_cache: Optional[dict] = None,
-    ) -> Tuple[List[jax.Array], jax.Array]:
+    ) -> Tuple[List[jax.Array], jax.Array, Optional[jax.Array]]:
 
         if inputs_embeds is not None:
             x = inputs_embeds
@@ -757,6 +734,7 @@ class Gemma4Model(JaxModule):
             # Gemma4: Apply embedding scaling
             x = x * self.embedding_scale
 
+        all_expert_ids = []
         for i, layer in enumerate(
                 islice(self.layers, self.start_layer, self.end_layer)):
             layer_name = f"layer.{i + self.start_layer}"
@@ -771,14 +749,18 @@ class Gemma4Model(JaxModule):
                 cache_idx = i + self.start_layer
 
             kv_cache = kv_caches[cache_idx]
-            kv_cache, x = layer(
+            kv_cache, x, expert_ids = layer(
                 kv_cache,
                 x,
                 layer_attn_metadata,
             )
+            if expert_ids is not None:
+                all_expert_ids.append(expert_ids)
             kv_caches[cache_idx] = kv_cache
         x = self.norm(x)
-        return kv_caches, x
+        stacked_expert_ids = jnp.stack(all_expert_ids,
+                                       axis=0) if all_expert_ids else None
+        return kv_caches, x, stacked_expert_ids
 
 
 class Gemma4ForCausalLM(JaxModule, LoadableWithIterator):
@@ -854,7 +836,7 @@ class Gemma4ForCausalLM(JaxModule, LoadableWithIterator):
 
         layer_name_to_kv_cache = dict(
             _layer_name_to_kv_cache) if _layer_name_to_kv_cache else None
-        kv_caches, x = self.model(
+        kv_caches, x, expert_indices = self.model(
             kv_caches,
             input_ids,
             attention_metadata,
@@ -865,7 +847,7 @@ class Gemma4ForCausalLM(JaxModule, LoadableWithIterator):
         if not is_last_rank:
             x = JaxIntermediateTensors(tensors={"hidden_states": x}, )
 
-        return kv_caches, x, []
+        return kv_caches, x, [], expert_indices
 
     def compute_logits(self, hidden_states: jax.Array) -> jax.Array:
         if hasattr(self, 'lm_head'):

--- a/tpu_inference/models/jax/gemma4.py
+++ b/tpu_inference/models/jax/gemma4.py
@@ -828,7 +828,7 @@ class Gemma4ForCausalLM(JaxModule, LoadableWithIterator):
         is_last_rank: bool = True,
         *args,
     ) -> Tuple[List[jax.Array], jax.Array | JaxIntermediateTensors,
-               List[jax.Array]]:
+               List[jax.Array], Optional[jax.Array]]:
 
         if not is_first_rank:
             assert intermediate_tensors is not None

--- a/tpu_inference/models/jax/gemma4_mm.py
+++ b/tpu_inference/models/jax/gemma4_mm.py
@@ -806,7 +806,7 @@ class Gemma4ForConditionalGeneration(JaxModule, LoadableWithIterator):
                 JaxIntermediateTensors
             x = JaxIntermediateTensors(tensors={"hidden_states": x})
 
-        return kv_caches, x, []
+        return kv_caches, x, [], None
 
     def compute_logits(self, hidden_states: jax.Array) -> jax.Array:
         if hasattr(self, 'lm_head'):

--- a/tpu_inference/models/jax/gemma4_mm.py
+++ b/tpu_inference/models/jax/gemma4_mm.py
@@ -24,6 +24,9 @@ from jax.sharding import Mesh
 from transformers import PretrainedConfig
 from vllm.config import VllmConfig
 
+from tpu_inference.models.jax.jax_intermediate_tensor import \
+    JaxIntermediateTensors
+
 try:
     from vllm.model_executor.models.gemma4_mm import \
         Gemma4ForConditionalGeneration as PtGemma4MM
@@ -774,11 +777,12 @@ class Gemma4ForConditionalGeneration(JaxModule, LoadableWithIterator):
         _input_positions=None,
         _layer_name_to_kv_cache=None,
         _lora_metadata=None,
-        intermediate_tensors: Any | None = None,
+        intermediate_tensors: JaxIntermediateTensors | None = None,
         is_first_rank: bool = True,
         is_last_rank: bool = True,
         *args,
-    ) -> Tuple[List[jax.Array], jax.Array | Any, List[jax.Array]]:
+    ) -> Tuple[List[jax.Array], jax.Array | JaxIntermediateTensors,
+               List[jax.Array], Optional[jax.Array]]:
 
         multimodal_embeddings = getattr(attention_metadata,
                                         "multimodal_embeddings", None)
@@ -793,7 +797,7 @@ class Gemma4ForConditionalGeneration(JaxModule, LoadableWithIterator):
         layer_name_to_kv_cache = dict(
             _layer_name_to_kv_cache) if _layer_name_to_kv_cache else None
 
-        kv_caches, x = self.model(
+        kv_caches, x, expert_indices = self.model(
             kv_caches,
             input_ids,
             attention_metadata,
@@ -806,7 +810,7 @@ class Gemma4ForConditionalGeneration(JaxModule, LoadableWithIterator):
                 JaxIntermediateTensors
             x = JaxIntermediateTensors(tensors={"hidden_states": x})
 
-        return kv_caches, x, [], None
+        return kv_caches, x, [], expert_indices
 
     def compute_logits(self, hidden_states: jax.Array) -> jax.Array:
         if hasattr(self, 'lm_head'):


### PR DESCRIPTION
# Description

https://github.com/vllm-project/tpu-inference/pull/2343 updated interface but skipped Gemma4, this PR:
- updated `Gemma4Moe` and `JaxMoe` to prevent divergence
- updated test to be able to catch this kind of error


# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
