### PR TITLE
[FIX][TPU Offloading] avoid recompile when `MODEL_IMPL_TYPE=vllm`

### DIFF
--- a/.buildkite/features/KV_Cache_Offload.yml
+++ b/.buildkite/features/KV_Cache_Offload.yml
@@ -20,7 +20,6 @@ steps:
     soft_fail: true
     env:
       USE_V6E8_QUEUE: "True"
-      VLLM_LOG_LEVEL: "INFO"
     agents:
       queue: tpu_v6e_8_queue
     commands:

--- a/tpu_inference/offload/tpu_offload_connector.py
+++ b/tpu_inference/offload/tpu_offload_connector.py
@@ -133,9 +133,7 @@ from tpu_inference.offload.cpu_backend import LocalCPUBackend
 from tpu_inference.offload.offload_manager import (LRUCacheManager,
                                                    StagingBufferManager)
 from tpu_inference.offload.utils import (CpuChunkId, ReqId,
-                                         pre_update_kv_caches,
                                          stack_kv_cache_cross_layers,
-                                         update_kv_caches,
                                          update_kv_caches_one)
 from tpu_inference.runner.tpu_runner import TPUModelRunner
 
@@ -1287,29 +1285,43 @@ class TPUOffloadConnectorWorker:
             self.device_sharding = kv_layer.sharding
             self.num_kv_blocks = self.shape[0]
 
+            # Cache the kv sharding spec at initialization
+            # to prevent recompilation. This avoids deriving
+            # kv_caches[0].sharding.spec in update_kv_caches_one at runtime,
+            # which can differ due to buffer donation side effects
+            self.cached_kv_sharding_spec = kv_layer.sharding.spec
+
             # NOTE(jcgu): shardings for the output of D2H / H2D transfer
             # default: [num_blocks, block_size, num_head, 2, head_dim]
             self.host_sharding = jax.sharding.NamedSharding(
                 mesh=self.device_sharding.mesh,
-                spec=jax.sharding.PartitionSpec(None, None, "model"),
+                spec=self.device_sharding.spec,
                 memory_kind="pinned_host")
+
+            flatten_spec = (None, ) + self.device_sharding.spec[2:] if len(
+                self.device_sharding.spec) >= 2 else (None, )
             # [num_blocks * block_size, num_head, 2, head_dim]
             self.flatten_device_sharding = jax.sharding.NamedSharding(
                 mesh=self.device_sharding.mesh,
-                spec=jax.sharding.PartitionSpec(None, "model"),
+                spec=jax.sharding.PartitionSpec(*flatten_spec),
                 memory_kind="device")
             self.flatten_host_sharding = jax.sharding.NamedSharding(
                 mesh=self.device_sharding.mesh,
-                spec=jax.sharding.PartitionSpec(None, "model"),
+                spec=jax.sharding.PartitionSpec(*flatten_spec),
                 memory_kind="pinned_host")
+
+            expanded_spec = (None,
+                             None) + self.device_sharding.spec[1:] if len(
+                                 self.device_sharding.spec) >= 1 else (None,
+                                                                       None)
             # [1, num_layers, block_size, num_head, 2, head_dim]
             self.expanded_host_sharding = jax.sharding.NamedSharding(
                 mesh=self.device_sharding.mesh,
-                spec=jax.sharding.PartitionSpec(None, None, None, "model"),
+                spec=jax.sharding.PartitionSpec(*expanded_spec),
                 memory_kind="pinned_host")
             self.expanded_device_sharding = jax.sharding.NamedSharding(
                 mesh=self.device_sharding.mesh,
-                spec=jax.sharding.PartitionSpec(None, None, None, "model"),
+                spec=jax.sharding.PartitionSpec(*expanded_spec),
                 memory_kind="device")
             self.indices_sharding = jax.sharding.NamedSharding(
                 mesh=self.device_sharding.mesh,
@@ -1328,6 +1340,7 @@ class TPUOffloadConnectorWorker:
             logger.info(f"  - Shape per layer: {self.shape}")
             logger.info(f"  - DType: {self.dtype}")
             logger.info(f"  - Device sharding: {self.device_sharding}")
+            logger.info(f"  - Sharding Spec: {self.cached_kv_sharding_spec}")
             logger.info(f"  - Layout: {self.kv_cache_layout}")
             logger.info(f"  - Total KV blocks: {self.num_kv_blocks}")
         else:
@@ -1381,23 +1394,27 @@ class TPUOffloadConnectorWorker:
 
                     # Warm up
                     for _ in range(num_warmup):
-                        dummy_block_ids = jnp.array(
-                            random.sample(all_block_ids, num_blocks))
+                        dummy_block_ids = random.sample(
+                            all_block_ids, num_blocks)
+                        dummy_block_ids_arr = jnp.array(dummy_block_ids)
+
                         # 1. gather / stack (for save)
                         paged_kv_for_compilation, stacked_dummy_kv_caches_tpu = stack_kv_cache_cross_layers(
-                            paged_kv_for_compilation, dummy_block_ids,
+                            paged_kv_for_compilation, dummy_block_ids_arr,
                             num_blocks)
+                        stacked_dummy_kv_caches_tpu = [
+                            jax.device_put(chunk,
+                                           self.expanded_device_sharding)
+                            for chunk in stacked_dummy_kv_caches_tpu
+                        ]
                         jax.block_until_ready(stacked_dummy_kv_caches_tpu)
+
                         # 2. update / insert  kv (for load)
-                        src_offsets, dest_offsets, chunk_sizes, num_chunks = pre_update_kv_caches(
-                            dummy_block_ids, self.mesh, self.indices_sharding)
-                        updated_kv_caches = update_kv_caches(
+                        updated_kv_caches = update_kv_caches_one(
                             paged_kv_for_compilation,
-                            stacked_dummy_kv_caches_tpu, src_offsets,
-                            dest_offsets, chunk_sizes, num_chunks, self.mesh,
-                            self.device_sharding.spec,
-                            self.device_sharding.spec,
-                            self.indices_sharding.spec)
+                            stacked_dummy_kv_caches_tpu, dummy_block_ids,
+                            self.mesh, self.cached_kv_sharding_spec,
+                            self.indices_sharding)
 
                         jax.block_until_ready(updated_kv_caches)
                         paged_kv_for_compilation = updated_kv_caches
@@ -1466,7 +1483,9 @@ class TPUOffloadConnectorWorker:
             return kv_caches
         if num_blocks in BLOCK_SIZE_BUCKETS:
             return update_kv_caches_one(kv_caches, kv_cache_slices, dst_blocks,
-                                        self.mesh, self.indices_sharding)
+                                        self.mesh,
+                                        self.cached_kv_sharding_spec,
+                                        self.indices_sharding)
 
         decomposed_block_buckets = self._decompose_into_buckets(dst_blocks)
         logger.debug(
@@ -1479,11 +1498,9 @@ class TPUOffloadConnectorWorker:
             bucket_size = len(decomposed_block_bucket)
             next_offset = block_offset + bucket_size
             slices_for_bucket = kv_cache_slices[block_offset:next_offset]
-            updated_kv_caches = update_kv_caches_one(updated_kv_caches,
-                                                     slices_for_bucket,
-                                                     decomposed_block_bucket,
-                                                     self.mesh,
-                                                     self.indices_sharding)
+            updated_kv_caches = update_kv_caches_one(
+                updated_kv_caches, slices_for_bucket, decomposed_block_bucket,
+                self.mesh, self.cached_kv_sharding_spec, self.indices_sharding)
             block_offset = next_offset
 
         return updated_kv_caches
@@ -2094,6 +2111,7 @@ class TPUOffloadConnectorWorker:
                     raw_chunked_kv_on_tpu,
                     dst_blocks,
                     self.mesh,
+                    self.cached_kv_sharding_spec,
                     self.indices_sharding,
                 )
             jax.block_until_ready(self.runner.kv_caches)

--- a/tpu_inference/offload/utils.py
+++ b/tpu_inference/offload/utils.py
@@ -164,8 +164,23 @@ def update_kv_caches_one(
     stacked_blocks: List[jax.Array],
     block_indices: List[int],
     mesh: Mesh,
+    cached_kv_sharding_spec: PartitionSpec | None = None,
     replicated_sharding: PartitionSpec | None = None,
 ) -> List[jax.Array]:
+    """Update KV caches using cached sharding spec to avoid recompilation.
+    
+    Args:
+        kv_caches: List of KV cache arrays
+        stacked_blocks: List of stacked KV blocks
+        block_indices: List of destination block indices
+        mesh: JAX mesh for sharding
+        cached_kv_sharding_spec: Pre-cached sharding spec from initialization.
+                                 If None, derived from kv_caches[0].sharding.spec (fallback).
+        replicated_sharding: PartitionSpec for replicated sharding
+    """
+    # Use cached spec if provided, otherwise fall back to extracting from input
+    if cached_kv_sharding_spec is None:
+        cached_kv_sharding_spec = kv_caches[0].sharding.spec
 
     src_offsets, dest_offsets, chunk_sizes, num_chunks = pre_update_kv_caches(
         block_indices, mesh, replicated_sharding)
@@ -177,8 +192,8 @@ def update_kv_caches_one(
         chunk_sizes,
         num_chunks,
         mesh,
-        kv_caches[0].sharding.spec,
-        kv_caches[0].sharding.spec,
+        cached_kv_sharding_spec,
+        cached_kv_sharding_spec,
         replicated_sharding.spec,
     )
 
@@ -219,12 +234,19 @@ def update_kv_caches(kv_caches: List[jax.Array],
                      dest_sharding_spec,
                      replicated_sharding_spec) -> List[jax.Array]:
     """
-    Updates KV caches by unstacking gathered blocks and inserting slices using scatter.
+    Updates KV caches by unstacking gathered blocks and copying slices.
 
     Args:
       kv_caches: List of original KV caches for each layer.
       stacked_blocks: List of gathered blocks, each with shape (1, num_layers, ...).
-      block_indices: Array of block indices to update.
+      src_offsets: Source offsets for copying.
+      dest_offsets: Destination offsets for copying.
+      chunk_sizes: Sizes of chunks to copy.
+      num_chunks: Number of chunks.
+      mesh: JAX mesh for sharding.
+      src_sharding_spec: PartitionSpec for source arrays.
+      dest_sharding_spec: PartitionSpec for destination arrays.
+      replicated_sharding_spec: PartitionSpec for replicated sharding.
 
     Returns:
       List of updated KV caches for each layer.


### PR DESCRIPTION
# Description

The original `update_kv_caches_one` drives kv_cache sharding_spec from input kv_caches, whose sharding_spec may be different from the warmup phase due to buffer donation. It leads to recompile `update_kv_caches` at runtime  (when MODEL_IMPL_TYPE=vllm). 

This PR records kv_cache sharding_spec when registering runner and use it in `update_kv_caches_one`.

# Tests

`MODEL_IMPL_TYPE=vllm pytest -sv tests/offload/tpu_offload_accuracy_test.py`

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
