### PR TITLE
[Fix][Jax] Qwen3 perf benchmarks: implement named_modules() on JaxModule

### DIFF
--- a/.buildkite/pipeline_dev.yml
+++ b/.buildkite/pipeline_dev.yml
@@ -12,34 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Dev pipeline for tpu-inference-dev.
-# Demo/sample steps showing how to run custom tests on tpu7x.
-# Copy and adapt any step for your own experiments.
-#
-# HOW TO TRIGGER THIS PIPELINE
-# ─────────────────────────────
-# Option A — Buildkite UI:
-#   Go to https://buildkite.com/tpu-commons/tpu-inference-dev
-#   Click "New Build", set branch to your branch, click "Create Build".
-#
-# Option B — Buildkite API (requires BUILDKITE_API_TOKEN in your env):
-#   curl -s -X POST \
-#     -H "Authorization: Bearer $BUILDKITE_API_TOKEN" \
-#     -H "Content-Type: application/json" \
-#     "https://api.buildkite.com/v2/organizations/tpu-commons/pipelines/tpu-inference-dev/builds" \
-#     -d "{\"commit\": \"$(git rev-parse HEAD)\", \"branch\": \"$(git rev-parse --abbrev-ref HEAD)\", \"message\": \"my test\"}"
-#
-# HOW TO CUSTOMIZE
-# ─────────────────
-# 1. On your branch, edit this file — use any demo step below as a starting point.
-# 2. Change the command, model, env vars, or queue as needed.
-# 3. Trigger the pipeline — only your branch's file is used.
+# Dev pipeline (per-branch). On fix-jax-named-modules: reproduce the
+# Cat 1 nightly failure (Qwen3-4B perf benchmark on tpu7x) to confirm
+# that adding named_modules() to JaxModule unblocks vLLM's
+# track_weights_loading path.
 
 steps:
 
-  # -----------------------------------------------------------------
-  # Build Step (required by all demo steps below)
-  # -----------------------------------------------------------------
   - label: ":docker: Build and Push Base Image (tpu7x)"
     key: tpu7x_build_docker
     agents:
@@ -49,100 +28,24 @@ steps:
     commands:
       - bash -c 'source .buildkite/scripts/setup_docker_env.sh && setup_environment "vllm-tpu" "false" "true"'
 
-  # -----------------------------------------------------------------
-  # Demo 1: offline_inference.py
-  # Shows the simplest pattern: run a Python script inside Docker.
-  # Use this as a starting point for any offline batch inference test.
-  # -----------------------------------------------------------------
-  - label: "tpu7x [demo] offline_inference.py"
-    key: tpu7x_demo_offline_inference
+  - label: "tpu7x Performance benchmarks for Qwen/Qwen3-4B (Cat 1 repro)"
+    key: tpu7x_qwen3_4b_perf
     depends_on: tpu7x_build_docker
-    env:
-      USE_PREBUILT_IMAGE: "1"
-      TPU_VERSION: "tpu7x"
     agents:
       queue: tpu_v7x_2_queue
-    commands:
-      - |
-        # Run offline inference with a small model.
-        # --tensor-parallel-size 2: tp=1 is currently unsupported on tpu7x.
-        # Customize --model, --max-model-len, --max-tokens as needed.
-        .buildkite/scripts/run_in_docker.sh bash -c '
-          python3 examples/offline_inference.py \
-            --model Qwen/Qwen3-0.6B \
-            --tensor-parallel-size 2 \
-            --max-model-len 1024 \
-            --max-tokens 128'
-
-  # -----------------------------------------------------------------
-  # Demo 2: vllm serve + vllm bench serve
-  # Shows how to start a server and run a benchmark against it.
-  # Uses --dataset-name random so no dataset file is needed.
-  # -----------------------------------------------------------------
-  - label: "tpu7x [demo] vllm serve + vllm bench serve"
-    key: tpu7x_demo_serve_bench
-    depends_on: tpu7x_build_docker
     env:
       USE_PREBUILT_IMAGE: "1"
       TPU_VERSION: "tpu7x"
-    agents:
-      queue: tpu_v7x_2_queue
-    commands:
-      - |
-        # Customize behaviour via env vars: MODEL, PORT, TENSOR_PARALLEL_SIZE,
-        # MAX_MODEL_LEN, RANDOM_INPUT_LEN, RANDOM_OUTPUT_LEN, NUM_PROMPTS, NUM_WARMUPS.
-        .buildkite/scripts/run_in_docker.sh bash .buildkite/scripts/run_benchmark_demo.sh
-
-  # -----------------------------------------------------------------
-  # Demo 3: DCN-based P/D disaggregation
-  # Mirrors test_25 in pipeline_jax.yml.
-  # Uses run_disagg.sh which delegates to examples/disagg/.
-  # Requires a multi-chip queue (tpu_v7x_8_queue).
-  # -----------------------------------------------------------------
-  - label: "tpu7x [demo] E2E disaggregation (DCN P/D)"
-    key: tpu7x_demo_disagg
-    depends_on: tpu7x_build_docker
-    env:
-      USE_PREBUILT_IMAGE: "1"
-      TPU_VERSION: "tpu7x"
-      # Customize these to change the disagg benchmark behaviour.
-      MODEL: "Qwen/Qwen3-0.6B"
-      INPUT_LEN: 1024
+      TEST_MODEL: Qwen/Qwen3-4B
+      TENSOR_PARALLEL_SIZE: "2"
+      # Permissive threshold: this run is about validating that model
+      # loading succeeds (no AttributeError on named_modules), not perf.
+      MINIMUM_THROUGHPUT_THRESHOLD: "0.01"
+      INPUT_LEN: 1800
       OUTPUT_LEN: 128
-      NUM_PROMPTS: 5
-      RANDOM_SEED: 10
-      MAX_CONCURRENCY: 4
-      TEST_MODE: 1
-    agents:
-      queue: tpu_v7x_8_queue
+      PREFIX_LEN: 0
+      MAX_MODEL_LEN: 2048
+      MAX_NUM_SEQS: 94
+      MAX_NUM_BATCHED_TOKENS: 4096
     commands:
-      - .buildkite/scripts/run_disagg.sh
-
-  # -----------------------------------------------------------------
-  # Demo 4: Ray-based multi-host inference
-  # Mirrors test_26 in pipeline_jax.yml.
-  # Uses run_multihost.sh to serve a large model across 16 chips (2 hosts).
-  # Requires a 16-chip queue (tpu_v7x_16_queue).
-  # -----------------------------------------------------------------
-  - label: "tpu7x [demo] Ray-based multi-host"
-    key: tpu7x_demo_multihost
-    env:
-      TPU_VERSION: "tpu7x"
-    agents:
-      queue: tpu_v7x_16_queue
-    commands:
-      - |
-        MODEL="gs://tpu-commons-ci/qwen/models--Qwen--Qwen3-30B-A3B/snapshots/ad44e777bcd18fa416d9da3bd8f70d33ebb85d39"
-        .buildkite/scripts/run_multihost.sh \
-          "vllm serve \${MODEL} \
-            --port 8000 \
-            --tensor-parallel-size 16 \
-            --trust-remote-code \
-            --max-model-len 1024 \
-            --no-async-scheduling \
-            --load-format=runai_streamer \
-            --no-enable-prefix-caching" \
-          "curl http://localhost:8000/v1/completions \
-            -X POST \
-            -H 'Content-Type: application/json' \
-            -d '{\"model\": \"${MODEL}\", \"prompt\": \"San Francisco is a\", \"max_tokens\": 50}'"
+      - .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/benchmark.sh

--- a/.buildkite/pipeline_dev.yml
+++ b/.buildkite/pipeline_dev.yml
@@ -12,13 +12,34 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Dev pipeline (per-branch). On fix-jax-named-modules: reproduce the
-# Cat 1 nightly failure (Qwen3-4B perf benchmark on tpu7x) to confirm
-# that adding named_modules() to JaxModule unblocks vLLM's
-# track_weights_loading path.
+# Dev pipeline for tpu-inference-dev.
+# Demo/sample steps showing how to run custom tests on tpu7x.
+# Copy and adapt any step for your own experiments.
+#
+# HOW TO TRIGGER THIS PIPELINE
+# ─────────────────────────────
+# Option A — Buildkite UI:
+#   Go to https://buildkite.com/tpu-commons/tpu-inference-dev
+#   Click "New Build", set branch to your branch, click "Create Build".
+#
+# Option B — Buildkite API (requires BUILDKITE_API_TOKEN in your env):
+#   curl -s -X POST \
+#     -H "Authorization: Bearer $BUILDKITE_API_TOKEN" \
+#     -H "Content-Type: application/json" \
+#     "https://api.buildkite.com/v2/organizations/tpu-commons/pipelines/tpu-inference-dev/builds" \
+#     -d "{\"commit\": \"$(git rev-parse HEAD)\", \"branch\": \"$(git rev-parse --abbrev-ref HEAD)\", \"message\": \"my test\"}"
+#
+# HOW TO CUSTOMIZE
+# ─────────────────
+# 1. On your branch, edit this file — use any demo step below as a starting point.
+# 2. Change the command, model, env vars, or queue as needed.
+# 3. Trigger the pipeline — only your branch's file is used.
 
 steps:
 
+  # -----------------------------------------------------------------
+  # Build Step (required by all demo steps below)
+  # -----------------------------------------------------------------
   - label: ":docker: Build and Push Base Image (tpu7x)"
     key: tpu7x_build_docker
     agents:
@@ -28,24 +49,100 @@ steps:
     commands:
       - bash -c 'source .buildkite/scripts/setup_docker_env.sh && setup_environment "vllm-tpu" "false" "true"'
 
-  - label: "tpu7x Performance benchmarks for Qwen/Qwen3-4B (Cat 1 repro)"
-    key: tpu7x_qwen3_4b_perf
+  # -----------------------------------------------------------------
+  # Demo 1: offline_inference.py
+  # Shows the simplest pattern: run a Python script inside Docker.
+  # Use this as a starting point for any offline batch inference test.
+  # -----------------------------------------------------------------
+  - label: "tpu7x [demo] offline_inference.py"
+    key: tpu7x_demo_offline_inference
     depends_on: tpu7x_build_docker
-    agents:
-      queue: tpu_v7x_2_queue
     env:
       USE_PREBUILT_IMAGE: "1"
       TPU_VERSION: "tpu7x"
-      TEST_MODEL: Qwen/Qwen3-4B
-      TENSOR_PARALLEL_SIZE: "2"
-      # Permissive threshold: this run is about validating that model
-      # loading succeeds (no AttributeError on named_modules), not perf.
-      MINIMUM_THROUGHPUT_THRESHOLD: "0.01"
-      INPUT_LEN: 1800
-      OUTPUT_LEN: 128
-      PREFIX_LEN: 0
-      MAX_MODEL_LEN: 2048
-      MAX_NUM_SEQS: 94
-      MAX_NUM_BATCHED_TOKENS: 4096
+    agents:
+      queue: tpu_v7x_2_queue
     commands:
-      - .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/benchmark.sh
+      - |
+        # Run offline inference with a small model.
+        # --tensor-parallel-size 2: tp=1 is currently unsupported on tpu7x.
+        # Customize --model, --max-model-len, --max-tokens as needed.
+        .buildkite/scripts/run_in_docker.sh bash -c '
+          python3 examples/offline_inference.py \
+            --model Qwen/Qwen3-0.6B \
+            --tensor-parallel-size 2 \
+            --max-model-len 1024 \
+            --max-tokens 128'
+
+  # -----------------------------------------------------------------
+  # Demo 2: vllm serve + vllm bench serve
+  # Shows how to start a server and run a benchmark against it.
+  # Uses --dataset-name random so no dataset file is needed.
+  # -----------------------------------------------------------------
+  - label: "tpu7x [demo] vllm serve + vllm bench serve"
+    key: tpu7x_demo_serve_bench
+    depends_on: tpu7x_build_docker
+    env:
+      USE_PREBUILT_IMAGE: "1"
+      TPU_VERSION: "tpu7x"
+    agents:
+      queue: tpu_v7x_2_queue
+    commands:
+      - |
+        # Customize behaviour via env vars: MODEL, PORT, TENSOR_PARALLEL_SIZE,
+        # MAX_MODEL_LEN, RANDOM_INPUT_LEN, RANDOM_OUTPUT_LEN, NUM_PROMPTS, NUM_WARMUPS.
+        .buildkite/scripts/run_in_docker.sh bash .buildkite/scripts/run_benchmark_demo.sh
+
+  # -----------------------------------------------------------------
+  # Demo 3: DCN-based P/D disaggregation
+  # Mirrors test_25 in pipeline_jax.yml.
+  # Uses run_disagg.sh which delegates to examples/disagg/.
+  # Requires a multi-chip queue (tpu_v7x_8_queue).
+  # -----------------------------------------------------------------
+  - label: "tpu7x [demo] E2E disaggregation (DCN P/D)"
+    key: tpu7x_demo_disagg
+    depends_on: tpu7x_build_docker
+    env:
+      USE_PREBUILT_IMAGE: "1"
+      TPU_VERSION: "tpu7x"
+      # Customize these to change the disagg benchmark behaviour.
+      MODEL: "Qwen/Qwen3-0.6B"
+      INPUT_LEN: 1024
+      OUTPUT_LEN: 128
+      NUM_PROMPTS: 5
+      RANDOM_SEED: 10
+      MAX_CONCURRENCY: 4
+      TEST_MODE: 1
+    agents:
+      queue: tpu_v7x_8_queue
+    commands:
+      - .buildkite/scripts/run_disagg.sh
+
+  # -----------------------------------------------------------------
+  # Demo 4: Ray-based multi-host inference
+  # Mirrors test_26 in pipeline_jax.yml.
+  # Uses run_multihost.sh to serve a large model across 16 chips (2 hosts).
+  # Requires a 16-chip queue (tpu_v7x_16_queue).
+  # -----------------------------------------------------------------
+  - label: "tpu7x [demo] Ray-based multi-host"
+    key: tpu7x_demo_multihost
+    env:
+      TPU_VERSION: "tpu7x"
+    agents:
+      queue: tpu_v7x_16_queue
+    commands:
+      - |
+        MODEL="gs://tpu-commons-ci/qwen/models--Qwen--Qwen3-30B-A3B/snapshots/ad44e777bcd18fa416d9da3bd8f70d33ebb85d39"
+        .buildkite/scripts/run_multihost.sh \
+          "vllm serve \${MODEL} \
+            --port 8000 \
+            --tensor-parallel-size 16 \
+            --trust-remote-code \
+            --max-model-len 1024 \
+            --no-async-scheduling \
+            --load-format=runai_streamer \
+            --no-enable-prefix-caching" \
+          "curl http://localhost:8000/v1/completions \
+            -X POST \
+            -H 'Content-Type: application/json' \
+            -d '{\"model\": \"${MODEL}\", \"prompt\": \"San Francisco is a\", \"max_tokens\": 50}'"

--- a/tests/layers/test_jax.py
+++ b/tests/layers/test_jax.py
@@ -82,6 +82,57 @@ class TestJaxModule(unittest.TestCase):
                 "nested_module_b", "layers"
             })
 
+    def test_named_modules_yields_self_first(self):
+        """Top-level module is yielded with empty prefix before any children."""
+
+        module = NestedModule()
+        names = [name for name, _ in module.named_modules()]
+        self.assertEqual(names[0], "")
+        self.assertIn("inner", names)
+
+    def test_named_modules_in_nested_module(self):
+        """Walks self + descendants, including JaxModuleList and its items."""
+
+        class Depth3Module(JaxModule):
+
+            def __init__(self):
+                super().__init__()
+                self.my_module = MyModule()
+                self.nested_module = NestedModule()
+                self.layers = nnx.List([MyModule() for _ in range(3)])
+
+        module = Depth3Module()
+        names = set(name for name, _ in module.named_modules())
+        self.assertEqual(
+            names,
+            {
+                "",  # self
+                "my_module",
+                "nested_module",
+                "nested_module.inner",
+                "layers",  # JaxModuleList itself
+                "layers.0",
+                "layers.1",
+                "layers.2",
+            })
+
+    def test_named_modules_dedups_shared_submodule(self):
+        """Shared submodules are yielded only once (matches torch semantics)."""
+
+        shared = MyModule()
+
+        class SharedRefModule(JaxModule):
+
+            def __init__(self):
+                super().__init__()
+                self.a = shared
+                self.b = shared
+
+        module = SharedRefModule()
+        names = [name for name, _ in module.named_modules()]
+        # 'a' and 'b' point to the same module; only the first is yielded.
+        self.assertEqual(names.count("a") + names.count("b"), 1)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/models/jax/conftest.py
+++ b/tests/models/jax/conftest.py
@@ -69,9 +69,6 @@ def mock_vllm_config():
             self.model_config.dtype = jnp.bfloat16
             self.load_config = LoadConfig(load_format="auto")
             self.load_config.download_dir = None
-            self.load_config.model_loader_extra_config = {
-                "enable_weights_track": False
-            }
             self.cache_config = MagicMock(cache_dtype=kv_cache_dtype)
             self.quant_config = None
             self.additional_config = {}

--- a/tests/models/jax/test_gemma4.py
+++ b/tests/models/jax/test_gemma4.py
@@ -56,6 +56,7 @@ class TestGemma4ForConditionalGeneration:
         vllm_config = mock_vllm_config(model_name, kv_cache_type)
         # No need to load full model.
         vllm_config.model_config.hf_config.text_config.num_hidden_layers = 4
+        vllm_config.model_config.hf_config.vision_config.num_hidden_layers = 4
         vllm_config.load_config.load_format = load_format
         vllm_config.load_config.num_layers_to_load_for_test = 4
         vllm_config.parallel_config = MagicMock()

--- a/tpu_inference/layers/jax/__init__.py
+++ b/tpu_inference/layers/jax/__init__.py
@@ -73,6 +73,11 @@ class JaxModule(nnx.Module):
         Mirrors ``torch.nn.Module.named_modules`` semantics so vLLM's
         upstream loader code (which calls ``model.named_modules()`` from
         ``track_weights_loading``) works against JAX models.
+
+        Note: traversal goes through ``named_children``, which walks
+        ``self.__dict__`` and only recognises ``JaxModule`` /
+        list / ``nnx.List`` attributes. Submodules registered inside
+        dicts, tuples, or non-``JaxModule`` containers are not visible.
         """
         if memo is None:
             memo = set()
@@ -131,9 +136,17 @@ class JaxModuleList(nnx.List):
         prefix: str = "",
         remove_duplicate: bool = True,
     ) -> Iterator[tuple[str, "JaxModule | JaxModuleList"]]:
-        """Yields (name, module) for every module in the list and its descendants."""
+        """Yields (name, module) for self, every module in the list, and their descendants.
+
+        Mirrors ``torch.nn.ModuleList.named_modules``: the list itself
+        is yielded first, then each contained module recursively.
+        """
         if memo is None:
             memo = set()
+        if remove_duplicate and id(self) in memo:
+            return
+        memo.add(id(self))
+        yield prefix, self
         for idx, module in enumerate(self):
             module_prefix = f"{prefix}.{idx}" if prefix else str(idx)
             yield from module.named_modules(memo, module_prefix,

--- a/tpu_inference/layers/jax/__init__.py
+++ b/tpu_inference/layers/jax/__init__.py
@@ -62,6 +62,29 @@ class JaxModule(nnx.Module):
             elif isinstance(value, list) or isinstance(value, nnx.List):
                 yield name, JaxModuleList(value)
 
+    def named_modules(
+        self,
+        memo: set | None = None,
+        prefix: str = "",
+        remove_duplicate: bool = True,
+    ) -> Iterator[tuple[str, "JaxModule | JaxModuleList"]]:
+        """Yields (name, module) for self and every descendant module.
+
+        Mirrors ``torch.nn.Module.named_modules`` semantics so vLLM's
+        upstream loader code (which calls ``model.named_modules()`` from
+        ``track_weights_loading``) works against JAX models.
+        """
+        if memo is None:
+            memo = set()
+        if remove_duplicate and id(self) in memo:
+            return
+        memo.add(id(self))
+        yield prefix, self
+        for name, child in self.named_children():
+            child_prefix = f"{prefix}.{name}" if prefix else name
+            yield from child.named_modules(memo, child_prefix,
+                                           remove_duplicate)
+
 
 class JaxModuleList(nnx.List):
     """A list container for JaxModule objects."""
@@ -101,3 +124,17 @@ class JaxModuleList(nnx.List):
                 yield str(idx), item
             elif isinstance(item, list):
                 yield str(idx), JaxModuleList(item)
+
+    def named_modules(
+        self,
+        memo: set | None = None,
+        prefix: str = "",
+        remove_duplicate: bool = True,
+    ) -> Iterator[tuple[str, "JaxModule | JaxModuleList"]]:
+        """Yields (name, module) for every module in the list and its descendants."""
+        if memo is None:
+            memo = set()
+        for idx, module in enumerate(self):
+            module_prefix = f"{prefix}.{idx}" if prefix else str(idx)
+            yield from module.named_modules(memo, module_prefix,
+                                            remove_duplicate)


### PR DESCRIPTION
## Summary

Adds `named_modules()` to `JaxModule` and `JaxModuleList`, mirroring `torch.nn.Module.named_modules` semantics. This unblocks all unquantized JAX models against vLLM's upstream loader.

## Why this is needed

vLLM PR [vllm-project/vllm#41086](https://github.com/vllm-project/vllm/pull/41086) (commit `99255f3cb`, merged 2026-04-29) refactored `DefaultModelLoader.load_weights` and extracted the strict-check into a new `track_weights_loading` method. The new method adds a loop over `model.named_modules()`:

```python
for name, module in model.named_modules():
    quant_method = getattr(module, "quant_method", None)
    ...
```

`JaxModule` defines `named_parameters` and `named_children` but had no `named_modules`. Since the JAX `Qwen3ForCausalLM` (etc.) is the model handed to upstream `DefaultModelLoader.load_weights`, the strict-check path crashes:

```
AttributeError: 'Qwen3ForCausalLM' object has no attribute 'named_modules'.
                Did you mean: 'iter_modules'?
```

This blocked all unquantized Qwen3 perf benchmarks (Qwen3-4B, Qwen3-32B) on both `tpu7x` and `tpu6e`, plus the PyPI perf job. The strict-check default is `quantization is None and loaded_weights is not None`, so quantized variants (FP8 etc.) were not affected.

Failing nightlies that motivated this fix:
- `releases/v0.20.0` — [build 16360](https://buildkite.com/tpu-commons/tpu-inference-ci/builds/16360)
- `main` — [build 16372](https://buildkite.com/tpu-commons/tpu-inference-ci/builds/16372)

## Implementation

`named_modules` semantics match `torch.nn.Module.named_modules`:
- Yields `(prefix, self)` first, then descends into children depth-first.
- Uses a `memo` set to avoid yielding the same module twice when `remove_duplicate=True` (default).
- `JaxModuleList.named_modules` delegates to children with index-based names, the same pattern as its existing `named_parameters` override.

## Verification

Reproduced the exact failing job (`tpu7x Performance benchmarks for Qwen/Qwen3-4B`) on the dev pipeline against this branch:

- **Build [tpu-inference-dev #269](https://buildkite.com/tpu-commons/tpu-inference-dev/builds/269) — passed end-to-end** (commit `e0ef6bce6`).
  - Docker build: passed (~7 min).
  - Qwen3-4B perf benchmark on tpu7x: passed (~5 min). `vllm serve` came up, model loaded, KV cache initialized, JIT precompilation completed, benchmark ran. Log shows zero `named_modules` / `AttributeError` hits — i.e. `track_weights_loading` traversed the JAX module tree cleanly.

This is the same code path that crashed on every prior nightly (16360 / 16372) with the upstream `default_loader.py:414` `AttributeError`.

## Test plan

- [x] Reproduce the failing job on the dev pipeline against this branch and confirm it passes — done in [build #269](https://buildkite.com/tpu-commons/tpu-inference-dev/builds/269).
- [ ] After merge, trigger nightly on `main` and confirm `tpu7x Performance benchmarks for Qwen/Qwen3-4B`, `Qwen/Qwen3-32B`, `tpu6e` equivalents, and `PyPI Test Performance benchmarks for Qwen/Qwen3-4B` all pass.
- [ ] Cherry-pick to `releases/v0.20.0`.