### PR TITLE
[Speculative decoding] Jit the whole "propose()" and prepare_inputs() method of the drafter

### DIFF
--- a/tests/spec_decode/test_eagle3.py
+++ b/tests/spec_decode/test_eagle3.py
@@ -104,12 +104,11 @@ def test_prepare_inputs():
     # Inputs
     total_tokens = 16
     hidden_size = 128
-    # The input_ids should be large enough to be indexed by token_indices,
-    # which can access up to total_tokens for padded requests.
-    input_ids = jnp.arange(total_tokens + 1)
-    aux_hidden_states = (jnp.ones((total_tokens + 1, hidden_size)),
-                         jnp.ones((total_tokens + 1, hidden_size)),
-                         jnp.ones((total_tokens + 1, hidden_size)))
+    input_ids = jnp.arange(total_tokens)
+    aux_hidden_states = (jnp.ones(
+        (total_tokens, hidden_size)), jnp.ones(
+            (total_tokens, hidden_size)), jnp.ones(
+                (total_tokens, hidden_size)))
 
     num_rejected_tokens_cpu = np.zeros(max_num_seqs, dtype=np.int32)
     num_rejected_tokens_cpu[:num_reqs] = [1, 3, 2]
@@ -131,12 +130,11 @@ def test_prepare_inputs():
     attn_metadata.seq_lens_cpu = sl_cpu
 
     # Expected results
+    # Padded requests have query_len=0 and num_rejected=0, so they contribute
+    # 0 tokens to the new query_start_loc.
     expected_new_qsl = np.zeros(max_num_seqs + 1, dtype=np.int32)
     num_tokens_per_req = np.zeros(max_num_seqs, dtype=np.int32)
     num_tokens_per_req[:num_reqs] = [3, 4, 3]
-    # The implementation sets padded query lengths to 1, and rejected tokens
-    # are 0 for padded requests.
-    num_tokens_per_req[num_reqs:] = 1
     expected_new_qsl[1:] = np.cumsum(num_tokens_per_req)
 
     expected_new_seq_lens = np.zeros(max_num_seqs, dtype=np.int32)

--- a/tpu_inference/models/vllm/vllm_model_wrapper.py
+++ b/tpu_inference/models/vllm/vllm_model_wrapper.py
@@ -370,12 +370,6 @@ class VllmModelWrapper:
                 None,  # list of aux hidden states
                 None,  # expert ids
             ),
-            compiler_options={
-                "xla_tpu_all_gather_collective_matmul_mode":
-                "post_spmd_conservative",
-                "xla_tpu_reduce_scatter_collective_matmul_mode":
-                "post_spmd_conservative"
-            },
             static_argnames=("layer_name_to_kvcache_index", ),
         )
         def draft_step_fun(

--- a/tpu_inference/runner/compilation_manager.py
+++ b/tpu_inference/runner/compilation_manager.py
@@ -64,6 +64,17 @@ class CompilationManager:
                              dtype: Any,
                              sharding: Optional[NamedSharding] = None) -> Any:
         """Helper to create dummy tensors for precompilation."""
+        if len(shape) > 1:
+            # Use parallel_config as the primary source of truth during initialization
+            # to avoid AttributeError when self.runner.mesh is not yet assigned (common in unit tests).
+            tp_size = 1
+            if self.runner.vllm_config.parallel_config is not None:
+                tp_size = self.runner.vllm_config.parallel_config.tensor_parallel_size
+            elif hasattr(self.runner, 'mesh') and self.runner.mesh is not None:
+                tp_size = self.runner.mesh.shape.get(ShardingAxisName.MODEL, 1)
+            assert shape[
+                1] % tp_size == 0, f"Dimension size {shape[1]} is not divisible by TP size {tp_size} for shape {shape}"
+
         tensor = jnp.ones(shape, dtype=to_jax_dtype(dtype))
         if sharding:
             return device_array(self.runner.mesh, tensor, sharding=sharding)
@@ -197,6 +208,18 @@ class CompilationManager:
         request_distribution = device_array(self.runner.mesh,
                                             request_distribution,
                                             sharding=dp_sharding)
+        # Dummy mamba_state_indices for compile-cache pre-tracing. Only
+        # populate for hybrid attn+mamba models — for pure-attention models we
+        # pass None at runtime (see `_prepare_inputs_*`), and the precompile
+        # primer must match that shape so the cached HLO is reused.
+        if self.runner.kv_cache_config.has_mamba_layers:
+            mamba_state_indices = device_array(self.runner.mesh,
+                                               np.zeros(
+                                                   self.runner.max_num_reqs,
+                                                   dtype=np.int32),
+                                               sharding=dp_sharding)
+        else:
+            mamba_state_indices = None
 
         def build_block_table(kv_cache_gid: int) -> jax.Array:
             block_table_obj = self.runner.input_batch.block_table[kv_cache_gid]
@@ -216,6 +239,7 @@ class CompilationManager:
                 seq_lens=seq_lens,
                 query_start_loc=query_start_loc,
                 request_distribution=request_distribution,
+                mamba_state_indices=mamba_state_indices,
             )
             return attention_metadata_gid
 
@@ -246,7 +270,7 @@ class CompilationManager:
             is_first_rank,
             is_last_rank,
         ):
-            kv_caches, hidden_states, _ = self.runner.model_fn(
+            kv_caches, hidden_states, *_ = self.runner.model_fn(
                 state, kv_caches, input_ids, attention_metadata, inputs_embeds,
                 positions, layer_name_to_kvcache_index, lora_metadata,
                 intermediate_tensors, is_first_rank, is_last_rank)
@@ -484,7 +508,7 @@ class CompilationManager:
         )
 
         if self.runner.speculative_config:
-            vocab_size = self.runner.model_config.get_vocab_size()
+            vocab_size = self.runner.vocab_size
             self._precompile_select_from_array_helper(
                 name=
                 f"worker{self.runner.rank} select bonus tokens for spec decoding",
@@ -548,7 +572,7 @@ class CompilationManager:
 
     def _precompile_sampling(self) -> None:
         logger.info("Compiling sampling with different input shapes.")
-        hsize = self.runner.model_config.get_vocab_size()
+        hsize = self.runner.vocab_size
         for num_reqs in self.runner.num_reqs_paddings:
             # `logits_sharding` need to be consistent with
             # compute_logits_fn's output sharding to avoid serving
@@ -636,7 +660,7 @@ class CompilationManager:
 
     def _precompile_gather_logprobs(self) -> None:
         logger.info("Compiling gather_logprobs with different input shapes.")
-        hsize = self.runner.model_config.get_vocab_size()
+        hsize = self.runner.vocab_size
         for num_reqs in self.runner.num_reqs_paddings:
             logits_sharding = NamedSharding(
                 self.runner.mesh,
@@ -668,7 +692,7 @@ class CompilationManager:
 
     def _precompile_rejection_sampler(self) -> None:
         logger.info("Compiling rejection_sampler with different input shapes.")
-        vocab_size = self.runner.model_config.get_vocab_size()
+        vocab_size = self.runner.vocab_size
         for num_logits in self.runner.num_logits_paddings:
             for num_reqs in self.runner.num_reqs_paddings:
                 sharding = NamedSharding(
@@ -754,8 +778,7 @@ class CompilationManager:
         request_distribution = np.array([0, 0, 0], dtype=np.int32)
         request_distribution = device_array(self.runner.mesh,
                                             request_distribution)
-<<<<<<< HEAD
-=======
+
         # Dummy mamba_state_indices for spec-decode compile-cache pre-tracing.
         # Must match the ATTN_DATA sharding `_prepare_inputs_*` produces at
         # runtime — otherwise the draft model_fn cache misses and the
@@ -771,27 +794,13 @@ class CompilationManager:
                 sharding=dp_sharding)
         else:
             eagle3_mamba_state_indices = None
->>>>>>> e844b9fac (make drafter prepare-inputs jited fn)
 
         next_token_ids = self._create_dummy_tensor(
             (self.runner.max_num_reqs, ), jnp.int32)
         last_token_indices = self._create_dummy_tensor(
             (self.runner.max_num_reqs, ), jnp.int32)
-<<<<<<< HEAD
-        for num_tokens in self.runner.num_tokens_paddings:
-            aux_hidden_states = [
-                self._create_dummy_tensor((num_tokens, target_hidden_size),
-                                          dtype),
-                self._create_dummy_tensor((num_tokens, target_hidden_size),
-                                          dtype),
-                self._create_dummy_tensor((num_tokens, target_hidden_size),
-                                          dtype),
-            ]
-
-=======
 
         for num_tokens in self.runner.num_tokens_paddings:
->>>>>>> e844b9fac (make drafter prepare-inputs jited fn)
             positions = self._create_dummy_tensor((num_tokens, ), jnp.int32)
             attention_metadata = AttentionMetadata(
                 input_positions=positions,
@@ -799,6 +808,7 @@ class CompilationManager:
                 seq_lens=seq_lens,
                 query_start_loc=query_start_loc,
                 request_distribution=request_distribution,
+                mamba_state_indices=eagle3_mamba_state_indices,
             )
 
             def drafter_propose_fn_wrapper(
@@ -815,7 +825,6 @@ class CompilationManager:
                     last_token_indices,
                     target_hidden_states,
                 )
->>>>>>> 25f7ec753 (MTP jit drafter's propose)
                 self.runner.kv_caches = kv_caches
                 return draft_token_ids
 

--- a/tpu_inference/runner/compilation_manager.py
+++ b/tpu_inference/runner/compilation_manager.py
@@ -761,8 +761,6 @@ class CompilationManager:
         draft_hidden_size = self.runner.speculative_config.draft_model_config.get_hidden_size(
         )
         dtype = self.runner.model_config.dtype
-        data_parallel_attn_sharding = NamedSharding(
-            self.runner.mesh, PartitionSpec(ShardingAxisName.ATTN_DATA))
 
         num_kv_cache_groups = len(self.runner.kv_cache_config.kv_cache_groups)
         draft_kv_cache_group_id = num_kv_cache_groups - 1
@@ -773,16 +771,13 @@ class CompilationManager:
                                     sharding=PartitionSpec(None, ))
 
         seq_lens = self._create_dummy_tensor((self.runner.max_num_reqs, ),
-                                             jnp.int32,
-                                             data_parallel_attn_sharding)
+                                             jnp.int32)
         query_start_loc = self._create_dummy_tensor(
-            (self.runner.max_num_reqs + 1, ), jnp.int32,
-            data_parallel_attn_sharding)
+            (self.runner.max_num_reqs + 1, ), jnp.int32)
 
-        request_distribution = device_array(
-            self.runner.mesh,
-            np.array([0, 0, 0], dtype=np.int32),
-            sharding=data_parallel_attn_sharding)
+        request_distribution = np.array([0, 0, 0], dtype=np.int32)
+        request_distribution = device_array(self.runner.mesh,
+                                            request_distribution)
         # Dummy mamba_state_indices for spec-decode compile-cache pre-tracing.
         # Must match the ATTN_DATA sharding `_prepare_inputs_*` produces at
         # runtime — otherwise the draft model_fn cache misses and the
@@ -802,20 +797,10 @@ class CompilationManager:
         next_token_ids = self._create_dummy_tensor(
             (self.runner.max_num_reqs, ), jnp.int32)
         last_token_indices = self._create_dummy_tensor(
-            (self.runner.max_num_reqs, ), jnp.int32,
-            data_parallel_attn_sharding)
-        for num_tokens in self.runner.num_tokens_paddings:
-            aux_hidden_states = [
-                self._create_dummy_tensor((num_tokens, target_hidden_size),
-                                          dtype),
-                self._create_dummy_tensor((num_tokens, target_hidden_size),
-                                          dtype),
-                self._create_dummy_tensor((num_tokens, target_hidden_size),
-                                          dtype),
-            ]
+            (self.runner.max_num_reqs, ), jnp.int32)
 
-            positions = self._create_dummy_tensor((num_tokens, ), jnp.int32,
-                                                  data_parallel_attn_sharding)
+        for num_tokens in self.runner.num_tokens_paddings:
+            positions = self._create_dummy_tensor((num_tokens, ), jnp.int32)
             attention_metadata = AttentionMetadata(
                 input_positions=positions,
                 block_tables=block_tables,
@@ -825,83 +810,19 @@ class CompilationManager:
                 mamba_state_indices=eagle3_mamba_state_indices,
             )
 
-            def filter_token_and_prepare_initial_inputs_wrapper(
-                token_indices,
-                query_start_loc,
-                seq_lens,
-                input_ids,
-                aux_hidden_states,
-                attention_metadata,
-                next_token_ids,
-                num_reqs,
-            ):
-                target_hidden_states, input_ids, last_token_indices, _ = self.runner.drafter._filter_token_and_prepare_initial_inputs(
-                    self.runner.drafter.state, token_indices, query_start_loc,
-                    seq_lens, input_ids, aux_hidden_states, attention_metadata,
-                    next_token_ids, num_reqs)
-                return target_hidden_states, input_ids, last_token_indices
-
-            input_ids = self._create_dummy_tensor((num_tokens, ), jnp.int32)
-            aux_hidden_states = [
-                self._create_dummy_tensor(
-                    (num_tokens, target_hidden_size), jnp.bfloat16,
-                    NamedSharding(self.runner.mesh, PartitionSpec(None,
-                                                                  None))),
-                self._create_dummy_tensor(
-                    (num_tokens, target_hidden_size), jnp.bfloat16,
-                    NamedSharding(self.runner.mesh, PartitionSpec(None,
-                                                                  None))),
-                self._create_dummy_tensor(
-                    (num_tokens, target_hidden_size), jnp.bfloat16,
-                    NamedSharding(self.runner.mesh, PartitionSpec(None,
-                                                                  None))),
-            ]
-            # TODO(ranlihao): This will increase the precompilation latency. Find proper range for token_indices.
-            for padded_total_num_tokens in [
-                    num_tokens,
-                    min(num_tokens * 2, self.runner.num_tokens_paddings[-1])
-            ]:
-                token_indices = self._create_dummy_tensor(
-                    (padded_total_num_tokens, ), jnp.int32)
-                self._run_compilation(
-                    "eagle3_filter_token_and_prepare_initial_inputs",
-                    filter_token_and_prepare_initial_inputs_wrapper,
-                    token_indices,
-                    query_start_loc,
-                    seq_lens,
-                    input_ids,
-                    aux_hidden_states,
-                    attention_metadata,
-                    next_token_ids,
-                    device_array(
-                        self.runner.mesh,
-                        np.asarray([self.runner.input_batch.num_reqs],
-                                   dtype=jnp.int32)),
-                    num_tokens=num_tokens,
-                )
-
             def drafter_propose_fn_wrapper(
-                state,
                 kv_caches,
                 input_ids,
                 attn_metadata,
                 last_token_indices,
                 target_hidden_states,
             ):
-<<<<<<< HEAD
-                kv_caches, hidden_states, _, _ = self.runner.drafter.model_fn(
-                    state, kv_caches, input_ids, draft_hidden_states,
-                    attention_metadata, layer_name_to_kvcache_index)
-=======
-                kv_caches, draft_token_ids = self.runner.drafter._propose(
-                    state,
+                kv_caches, draft_token_ids = self.runner.drafter.propose(
                     kv_caches,
                     input_ids,
                     attn_metadata,
                     last_token_indices,
                     target_hidden_states,
-                    self.runner.drafter.num_speculative_tokens,
-                    tuple(self.runner.layer_name_to_kvcache_index.items()),
                 )
 >>>>>>> 25f7ec753 (MTP jit drafter's propose)
                 self.runner.kv_caches = kv_caches
@@ -916,11 +837,12 @@ class CompilationManager:
             input_ids = self._create_dummy_tensor(
                 (num_tokens, ), jnp.int32,
                 NamedSharding(self.runner.mesh, PartitionSpec()))
+            last_token_indices = self._create_dummy_tensor(
+                (self.runner.max_num_reqs, ), jnp.int32)
 
             self._run_compilation(
                 "drafter_propose",
                 drafter_propose_fn_wrapper,
-                self.runner.drafter.state,
                 self.runner.kv_caches,
                 input_ids,
                 attention_metadata,
@@ -929,23 +851,41 @@ class CompilationManager:
                 num_tokens=num_tokens,
             )
 
-            target_token_ids = self._create_dummy_tensor((num_tokens, ),
-                                                         jnp.int32)
-
-            self._run_compilation(
-                "eagle3_prepare_hidden_states_and_input_ids",
-                self.runner.drafter._prepare_hidden_states_and_input_ids,
-                self.runner.drafter.state,
-                aux_hidden_states,
-                query_start_loc,
-                target_token_ids,
-                next_token_ids,
-                device_array(
-                    self.runner.mesh,
-                    np.asarray([self.runner.input_batch.num_reqs],
-                               dtype=jnp.int32)),
-                num_tokens=num_tokens,
-            )
+            for num_rejected_tokens in [
+                    None,
+                    self._create_dummy_tensor((self.runner.max_num_reqs, ),
+                                              jnp.int32)
+            ]:
+                aux_hidden_states = [
+                    self._create_dummy_tensor(
+                        (num_tokens, target_hidden_size), jnp.bfloat16,
+                        NamedSharding(self.runner.mesh,
+                                      PartitionSpec(None, None))),
+                    self._create_dummy_tensor(
+                        (num_tokens, target_hidden_size), jnp.bfloat16,
+                        NamedSharding(self.runner.mesh,
+                                      PartitionSpec(None, None))),
+                    self._create_dummy_tensor(
+                        (num_tokens, target_hidden_size), jnp.bfloat16,
+                        NamedSharding(self.runner.mesh,
+                                      PartitionSpec(None, None))),
+                ]
+                self._run_compilation(
+                    "drafter_prepare_inputs",
+                    self.runner.drafter._prepare_inputs,
+                    self.runner.drafter.state,
+                    attention_metadata,
+                    input_ids,
+                    aux_hidden_states,
+                    next_token_ids,
+                    block_tables,
+                    device_array(
+                        self.runner.mesh,
+                        np.asarray([self.runner.input_batch.num_reqs],
+                                   dtype=jnp.int32)),
+                    num_rejected_tokens,
+                    num_tokens=num_tokens,
+                )
 
     def _precompile_structured_decoding(self) -> None:
         logger.info(

--- a/tpu_inference/runner/compilation_manager.py
+++ b/tpu_inference/runner/compilation_manager.py
@@ -64,17 +64,6 @@ class CompilationManager:
                              dtype: Any,
                              sharding: Optional[NamedSharding] = None) -> Any:
         """Helper to create dummy tensors for precompilation."""
-        if len(shape) > 1:
-            # Use parallel_config as the primary source of truth during initialization
-            # to avoid AttributeError when self.runner.mesh is not yet assigned (common in unit tests).
-            tp_size = 1
-            if self.runner.vllm_config.parallel_config is not None:
-                tp_size = self.runner.vllm_config.parallel_config.tensor_parallel_size
-            elif hasattr(self.runner, 'mesh') and self.runner.mesh is not None:
-                tp_size = self.runner.mesh.shape.get(ShardingAxisName.MODEL, 1)
-            assert shape[
-                1] % tp_size == 0, f"Dimension size {shape[1]} is not divisible by TP size {tp_size} for shape {shape}"
-
         tensor = jnp.ones(shape, dtype=to_jax_dtype(dtype))
         if sharding:
             return device_array(self.runner.mesh, tensor, sharding=sharding)
@@ -208,18 +197,6 @@ class CompilationManager:
         request_distribution = device_array(self.runner.mesh,
                                             request_distribution,
                                             sharding=dp_sharding)
-        # Dummy mamba_state_indices for compile-cache pre-tracing. Only
-        # populate for hybrid attn+mamba models — for pure-attention models we
-        # pass None at runtime (see `_prepare_inputs_*`), and the precompile
-        # primer must match that shape so the cached HLO is reused.
-        if self.runner.kv_cache_config.has_mamba_layers:
-            mamba_state_indices = device_array(self.runner.mesh,
-                                               np.zeros(
-                                                   self.runner.max_num_reqs,
-                                                   dtype=np.int32),
-                                               sharding=dp_sharding)
-        else:
-            mamba_state_indices = None
 
         def build_block_table(kv_cache_gid: int) -> jax.Array:
             block_table_obj = self.runner.input_batch.block_table[kv_cache_gid]
@@ -239,7 +216,6 @@ class CompilationManager:
                 seq_lens=seq_lens,
                 query_start_loc=query_start_loc,
                 request_distribution=request_distribution,
-                mamba_state_indices=mamba_state_indices,
             )
             return attention_metadata_gid
 
@@ -270,7 +246,7 @@ class CompilationManager:
             is_first_rank,
             is_last_rank,
         ):
-            kv_caches, hidden_states, *_ = self.runner.model_fn(
+            kv_caches, hidden_states, _ = self.runner.model_fn(
                 state, kv_caches, input_ids, attention_metadata, inputs_embeds,
                 positions, layer_name_to_kvcache_index, lora_metadata,
                 intermediate_tensors, is_first_rank, is_last_rank)
@@ -508,7 +484,7 @@ class CompilationManager:
         )
 
         if self.runner.speculative_config:
-            vocab_size = self.runner.vocab_size
+            vocab_size = self.runner.model_config.get_vocab_size()
             self._precompile_select_from_array_helper(
                 name=
                 f"worker{self.runner.rank} select bonus tokens for spec decoding",
@@ -572,7 +548,7 @@ class CompilationManager:
 
     def _precompile_sampling(self) -> None:
         logger.info("Compiling sampling with different input shapes.")
-        hsize = self.runner.vocab_size
+        hsize = self.runner.model_config.get_vocab_size()
         for num_reqs in self.runner.num_reqs_paddings:
             # `logits_sharding` need to be consistent with
             # compute_logits_fn's output sharding to avoid serving
@@ -660,7 +636,7 @@ class CompilationManager:
 
     def _precompile_gather_logprobs(self) -> None:
         logger.info("Compiling gather_logprobs with different input shapes.")
-        hsize = self.runner.vocab_size
+        hsize = self.runner.model_config.get_vocab_size()
         for num_reqs in self.runner.num_reqs_paddings:
             logits_sharding = NamedSharding(
                 self.runner.mesh,
@@ -692,7 +668,7 @@ class CompilationManager:
 
     def _precompile_rejection_sampler(self) -> None:
         logger.info("Compiling rejection_sampler with different input shapes.")
-        vocab_size = self.runner.vocab_size
+        vocab_size = self.runner.model_config.get_vocab_size()
         for num_logits in self.runner.num_logits_paddings:
             for num_reqs in self.runner.num_reqs_paddings:
                 sharding = NamedSharding(
@@ -778,28 +754,21 @@ class CompilationManager:
         request_distribution = np.array([0, 0, 0], dtype=np.int32)
         request_distribution = device_array(self.runner.mesh,
                                             request_distribution)
-        # Dummy mamba_state_indices for spec-decode compile-cache pre-tracing.
-        # Must match the ATTN_DATA sharding `_prepare_inputs_*` produces at
-        # runtime — otherwise the draft model_fn cache misses and the
-        # ForbidCompile guard inside `Eagle3Proposer.propose` raises. None for
-        # pure-attention models (the common eagle3 case) so the field stays
-        # absent end-to-end.
-        if self.runner.kv_cache_config.has_mamba_layers:
-            dp_sharding = NamedSharding(
-                self.runner.mesh, PartitionSpec(ShardingAxisName.ATTN_DATA, ))
-            eagle3_mamba_state_indices = device_array(
-                self.runner.mesh,
-                np.zeros(self.runner.max_num_reqs, dtype=np.int32),
-                sharding=dp_sharding)
-        else:
-            eagle3_mamba_state_indices = None
 
         next_token_ids = self._create_dummy_tensor(
             (self.runner.max_num_reqs, ), jnp.int32)
         last_token_indices = self._create_dummy_tensor(
             (self.runner.max_num_reqs, ), jnp.int32)
-
         for num_tokens in self.runner.num_tokens_paddings:
+            aux_hidden_states = [
+                self._create_dummy_tensor((num_tokens, target_hidden_size),
+                                          dtype),
+                self._create_dummy_tensor((num_tokens, target_hidden_size),
+                                          dtype),
+                self._create_dummy_tensor((num_tokens, target_hidden_size),
+                                          dtype),
+            ]
+
             positions = self._create_dummy_tensor((num_tokens, ), jnp.int32)
             attention_metadata = AttentionMetadata(
                 input_positions=positions,
@@ -807,22 +776,80 @@ class CompilationManager:
                 seq_lens=seq_lens,
                 query_start_loc=query_start_loc,
                 request_distribution=request_distribution,
-                mamba_state_indices=eagle3_mamba_state_indices,
             )
 
+            def filter_token_and_prepare_initial_inputs_wrapper(
+                token_indices,
+                query_start_loc,
+                seq_lens,
+                input_ids,
+                aux_hidden_states,
+                attention_metadata,
+                next_token_ids,
+                num_reqs,
+            ):
+                target_hidden_states, input_ids, last_token_indices, _ = self.runner.drafter._filter_token_and_prepare_initial_inputs(
+                    self.runner.drafter.state, token_indices, query_start_loc,
+                    seq_lens, input_ids, aux_hidden_states, attention_metadata,
+                    next_token_ids, num_reqs)
+                return target_hidden_states, input_ids, last_token_indices
+
+            input_ids = self._create_dummy_tensor((num_tokens, ), jnp.int32)
+            aux_hidden_states = [
+                self._create_dummy_tensor(
+                    (num_tokens, target_hidden_size), jnp.bfloat16,
+                    NamedSharding(self.runner.mesh, PartitionSpec(None,
+                                                                  None))),
+                self._create_dummy_tensor(
+                    (num_tokens, target_hidden_size), jnp.bfloat16,
+                    NamedSharding(self.runner.mesh, PartitionSpec(None,
+                                                                  None))),
+                self._create_dummy_tensor(
+                    (num_tokens, target_hidden_size), jnp.bfloat16,
+                    NamedSharding(self.runner.mesh, PartitionSpec(None,
+                                                                  None))),
+            ]
+            # TODO(ranlihao): This will increase the precompilation latency. Find proper range for token_indices.
+            for padded_total_num_tokens in [
+                    num_tokens,
+                    min(num_tokens * 2, self.runner.num_tokens_paddings[-1])
+            ]:
+                token_indices = self._create_dummy_tensor(
+                    (padded_total_num_tokens, ), jnp.int32)
+                self._run_compilation(
+                    "eagle3_filter_token_and_prepare_initial_inputs",
+                    filter_token_and_prepare_initial_inputs_wrapper,
+                    token_indices,
+                    query_start_loc,
+                    seq_lens,
+                    input_ids,
+                    aux_hidden_states,
+                    attention_metadata,
+                    next_token_ids,
+                    device_array(
+                        self.runner.mesh,
+                        np.asarray([self.runner.input_batch.num_reqs],
+                                   dtype=jnp.int32)),
+                    num_tokens=num_tokens,
+                )
+
             def drafter_propose_fn_wrapper(
+                state,
                 kv_caches,
                 input_ids,
                 attn_metadata,
                 last_token_indices,
                 target_hidden_states,
             ):
-                kv_caches, draft_token_ids = self.runner.drafter.propose(
+                kv_caches, draft_token_ids = self.runner.drafter._propose(
+                    state,
                     kv_caches,
                     input_ids,
                     attn_metadata,
                     last_token_indices,
                     target_hidden_states,
+                    self.runner.drafter.num_speculative_tokens,
+                    tuple(self.runner.layer_name_to_kvcache_index.items()),
                 )
 >>>>>>> 25f7ec753 (MTP jit drafter's propose)
                 self.runner.kv_caches = kv_caches
@@ -837,12 +864,11 @@ class CompilationManager:
             input_ids = self._create_dummy_tensor(
                 (num_tokens, ), jnp.int32,
                 NamedSharding(self.runner.mesh, PartitionSpec()))
-            last_token_indices = self._create_dummy_tensor(
-                (self.runner.max_num_reqs, ), jnp.int32)
 
             self._run_compilation(
                 "drafter_propose",
                 drafter_propose_fn_wrapper,
+                self.runner.drafter.state,
                 self.runner.kv_caches,
                 input_ids,
                 attention_metadata,
@@ -851,41 +877,23 @@ class CompilationManager:
                 num_tokens=num_tokens,
             )
 
-            for num_rejected_tokens in [
-                    None,
-                    self._create_dummy_tensor((self.runner.max_num_reqs, ),
-                                              jnp.int32)
-            ]:
-                aux_hidden_states = [
-                    self._create_dummy_tensor(
-                        (num_tokens, target_hidden_size), jnp.bfloat16,
-                        NamedSharding(self.runner.mesh,
-                                      PartitionSpec(None, None))),
-                    self._create_dummy_tensor(
-                        (num_tokens, target_hidden_size), jnp.bfloat16,
-                        NamedSharding(self.runner.mesh,
-                                      PartitionSpec(None, None))),
-                    self._create_dummy_tensor(
-                        (num_tokens, target_hidden_size), jnp.bfloat16,
-                        NamedSharding(self.runner.mesh,
-                                      PartitionSpec(None, None))),
-                ]
-                self._run_compilation(
-                    "drafter_prepare_inputs",
-                    self.runner.drafter._prepare_inputs,
-                    self.runner.drafter.state,
-                    attention_metadata,
-                    input_ids,
-                    aux_hidden_states,
-                    next_token_ids,
-                    block_tables,
-                    device_array(
-                        self.runner.mesh,
-                        np.asarray([self.runner.input_batch.num_reqs],
-                                   dtype=jnp.int32)),
-                    num_rejected_tokens,
-                    num_tokens=num_tokens,
-                )
+            target_token_ids = self._create_dummy_tensor((num_tokens, ),
+                                                         jnp.int32)
+
+            self._run_compilation(
+                "eagle3_prepare_hidden_states_and_input_ids",
+                self.runner.drafter._prepare_hidden_states_and_input_ids,
+                self.runner.drafter.state,
+                aux_hidden_states,
+                query_start_loc,
+                target_token_ids,
+                next_token_ids,
+                device_array(
+                    self.runner.mesh,
+                    np.asarray([self.runner.input_batch.num_reqs],
+                               dtype=jnp.int32)),
+                num_tokens=num_tokens,
+            )
 
     def _precompile_structured_decoding(self) -> None:
         logger.info(

--- a/tpu_inference/runner/compilation_manager.py
+++ b/tpu_inference/runner/compilation_manager.py
@@ -770,20 +770,10 @@ class CompilationManager:
                                     block_tables,
                                     sharding=PartitionSpec(None, ))
 
-        selected_positions = self._create_dummy_tensor(
-            (self.runner.max_num_reqs, ), jnp.int32)
         seq_lens = self._create_dummy_tensor((self.runner.max_num_reqs, ),
                                              jnp.int32)
         query_start_loc = self._create_dummy_tensor(
             (self.runner.max_num_reqs + 1, ), jnp.int32)
-        self._run_compilation(
-            "_update_inputs_for_loop_speculation for the first loop",
-            self.runner.drafter._update_inputs_for_loop_speculation,
-            selected_positions, seq_lens, block_tables)
-        self._run_compilation(
-            "_update_inputs_for_loop_speculation for the subsequent loops",
-            self.runner.drafter._update_inputs_for_loop_speculation,
-            selected_positions, seq_lens, block_tables)
 
         request_distribution = np.array([0, 0, 0], dtype=np.int32)
         request_distribution = device_array(self.runner.mesh,
@@ -804,38 +794,6 @@ class CompilationManager:
         else:
             eagle3_mamba_state_indices = None
 
-        for num_reqs_padding in self.runner.num_reqs_paddings:
-            for i in range(1, self.runner.drafter.num_speculative_tokens + 1):
-                draft_token_ids_list = [
-                    self._create_dummy_tensor(
-                        (num_reqs_padding, ), jnp.int32,
-                        NamedSharding(self.runner.mesh, PartitionSpec()))
-                    for _ in range(i)
-                ]
-                self._run_compilation(
-                    "eagle3_stack_draft_token_ids",
-                    self.runner.drafter._stack_draft_token_ids,
-                    draft_token_ids_list,
-                    num_reqs=num_reqs_padding,
-                    draft_token_ids_list_length=len(draft_token_ids_list))
-
-        for num_logits in self.runner.num_logits_paddings:
-            hidden_states = self._create_dummy_tensor(
-                (num_logits, draft_hidden_size), jnp.bfloat16)
-            self._run_compilation(
-                "eagle3_get_draft_token_ids",
-                self.runner.drafter._get_draft_token_ids,
-                self.runner.drafter.state,
-                hidden_states,
-                num_logits=num_logits,
-            )
-
-        input_ids_loop = self._create_dummy_tensor(
-            (self.runner.max_num_reqs, ), jnp.int32,
-            NamedSharding(self.runner.mesh, PartitionSpec()))
-        draft_hidden_state_loop = self._create_dummy_tensor(
-            (self.runner.max_num_reqs, draft_hidden_size), dtype,
-            NamedSharding(self.runner.mesh, PartitionSpec(None, None)))
         next_token_ids = self._create_dummy_tensor(
             (self.runner.max_num_reqs, ), jnp.int32)
         last_token_indices = self._create_dummy_tensor(
@@ -915,19 +873,32 @@ class CompilationManager:
                     num_tokens=num_tokens,
                 )
 
-            def draft_model_fn_wrapper(
+            def drafter_propose_fn_wrapper(
                 state,
                 kv_caches,
                 input_ids,
-                draft_hidden_states,
-                attention_metadata,
-                layer_name_to_kvcache_index,
+                attn_metadata,
+                last_token_indices,
+                target_hidden_states,
             ):
+<<<<<<< HEAD
                 kv_caches, hidden_states, _, _ = self.runner.drafter.model_fn(
                     state, kv_caches, input_ids, draft_hidden_states,
                     attention_metadata, layer_name_to_kvcache_index)
+=======
+                kv_caches, draft_token_ids = self.runner.drafter._propose(
+                    state,
+                    kv_caches,
+                    input_ids,
+                    attn_metadata,
+                    last_token_indices,
+                    target_hidden_states,
+                    self.runner.drafter.num_speculative_tokens,
+                    tuple(self.runner.layer_name_to_kvcache_index.items()),
+                )
+>>>>>>> 25f7ec753 (MTP jit drafter's propose)
                 self.runner.kv_caches = kv_caches
-                return hidden_states
+                return draft_token_ids
 
             draft_hidden_states = self._create_dummy_tensor(
                 (num_tokens, draft_hidden_size), dtype,
@@ -938,17 +909,19 @@ class CompilationManager:
             input_ids = self._create_dummy_tensor(
                 (num_tokens, ), jnp.int32,
                 NamedSharding(self.runner.mesh, PartitionSpec()))
+
             self._run_compilation(
-                "eagle3_draft_model_fn",
-                draft_model_fn_wrapper,
+                "drafter_propose",
+                drafter_propose_fn_wrapper,
                 self.runner.drafter.state,
                 self.runner.kv_caches,
                 input_ids,
-                draft_hidden_states,
                 attention_metadata,
-                tuple(self.runner.layer_name_to_kvcache_index.items()),
+                last_token_indices,
+                draft_hidden_states,
                 num_tokens=num_tokens,
             )
+
             target_token_ids = self._create_dummy_tensor((num_tokens, ),
                                                          jnp.int32)
 
@@ -964,48 +937,6 @@ class CompilationManager:
                     self.runner.mesh,
                     np.asarray([self.runner.input_batch.num_reqs],
                                dtype=jnp.int32)),
-                num_tokens=num_tokens,
-            )
-
-            attention_metadata.query_start_loc = device_array(
-                self.runner.mesh,
-                attention_metadata.query_start_loc,
-                sharding=PartitionSpec())
-            attention_metadata.input_positions = self._create_dummy_tensor(
-                (self.runner.max_num_reqs, ), jnp.int32)
-            self._run_compilation(
-                "draft_model_fn in a loop",
-                draft_model_fn_wrapper,
-                self.runner.drafter.state,
-                self.runner.kv_caches,
-                input_ids_loop,
-                draft_hidden_state_loop,
-                attention_metadata,
-                tuple(self.runner.layer_name_to_kvcache_index.items()),
-                num_tokens=num_tokens,
-            )
-
-            hidden_states = self._create_dummy_tensor(
-                (num_tokens, draft_hidden_size), jnp.bfloat16,
-                NamedSharding(self.runner.mesh, PartitionSpec(None, None)))
-
-            self._run_compilation(
-                "eagle3_select_inputs_for_loop_speculation",
-                self.runner.drafter._select_inputs_for_loop_speculation,
-                self.runner.drafter.state,
-                positions,
-                hidden_states,
-                hidden_states,
-                last_token_indices,
-                num_tokens=num_tokens,
-            )
-
-            self._run_compilation(
-                "eagle3_select_draft_token_ids",
-                self.runner.drafter._select_draft_token_ids,
-                self.runner.drafter.state,
-                hidden_states,
-                last_token_indices,
                 num_tokens=num_tokens,
             )
 

--- a/tpu_inference/runner/compilation_manager.py
+++ b/tpu_inference/runner/compilation_manager.py
@@ -754,11 +754,30 @@ class CompilationManager:
         request_distribution = np.array([0, 0, 0], dtype=np.int32)
         request_distribution = device_array(self.runner.mesh,
                                             request_distribution)
+<<<<<<< HEAD
+=======
+        # Dummy mamba_state_indices for spec-decode compile-cache pre-tracing.
+        # Must match the ATTN_DATA sharding `_prepare_inputs_*` produces at
+        # runtime — otherwise the draft model_fn cache misses and the
+        # ForbidCompile guard inside `Eagle3Proposer.propose` raises. None for
+        # pure-attention models (the common eagle3 case) so the field stays
+        # absent end-to-end.
+        if self.runner.kv_cache_config.has_mamba_layers:
+            dp_sharding = NamedSharding(
+                self.runner.mesh, PartitionSpec(ShardingAxisName.ATTN_DATA, ))
+            eagle3_mamba_state_indices = device_array(
+                self.runner.mesh,
+                np.zeros(self.runner.max_num_reqs, dtype=np.int32),
+                sharding=dp_sharding)
+        else:
+            eagle3_mamba_state_indices = None
+>>>>>>> e844b9fac (make drafter prepare-inputs jited fn)
 
         next_token_ids = self._create_dummy_tensor(
             (self.runner.max_num_reqs, ), jnp.int32)
         last_token_indices = self._create_dummy_tensor(
             (self.runner.max_num_reqs, ), jnp.int32)
+<<<<<<< HEAD
         for num_tokens in self.runner.num_tokens_paddings:
             aux_hidden_states = [
                 self._create_dummy_tensor((num_tokens, target_hidden_size),
@@ -769,6 +788,10 @@ class CompilationManager:
                                           dtype),
             ]
 
+=======
+
+        for num_tokens in self.runner.num_tokens_paddings:
+>>>>>>> e844b9fac (make drafter prepare-inputs jited fn)
             positions = self._create_dummy_tensor((num_tokens, ), jnp.int32)
             attention_metadata = AttentionMetadata(
                 input_positions=positions,
@@ -778,78 +801,19 @@ class CompilationManager:
                 request_distribution=request_distribution,
             )
 
-            def filter_token_and_prepare_initial_inputs_wrapper(
-                token_indices,
-                query_start_loc,
-                seq_lens,
-                input_ids,
-                aux_hidden_states,
-                attention_metadata,
-                next_token_ids,
-                num_reqs,
-            ):
-                target_hidden_states, input_ids, last_token_indices, _ = self.runner.drafter._filter_token_and_prepare_initial_inputs(
-                    self.runner.drafter.state, token_indices, query_start_loc,
-                    seq_lens, input_ids, aux_hidden_states, attention_metadata,
-                    next_token_ids, num_reqs)
-                return target_hidden_states, input_ids, last_token_indices
-
-            input_ids = self._create_dummy_tensor((num_tokens, ), jnp.int32)
-            aux_hidden_states = [
-                self._create_dummy_tensor(
-                    (num_tokens, target_hidden_size), jnp.bfloat16,
-                    NamedSharding(self.runner.mesh, PartitionSpec(None,
-                                                                  None))),
-                self._create_dummy_tensor(
-                    (num_tokens, target_hidden_size), jnp.bfloat16,
-                    NamedSharding(self.runner.mesh, PartitionSpec(None,
-                                                                  None))),
-                self._create_dummy_tensor(
-                    (num_tokens, target_hidden_size), jnp.bfloat16,
-                    NamedSharding(self.runner.mesh, PartitionSpec(None,
-                                                                  None))),
-            ]
-            # TODO(ranlihao): This will increase the precompilation latency. Find proper range for token_indices.
-            for padded_total_num_tokens in [
-                    num_tokens,
-                    min(num_tokens * 2, self.runner.num_tokens_paddings[-1])
-            ]:
-                token_indices = self._create_dummy_tensor(
-                    (padded_total_num_tokens, ), jnp.int32)
-                self._run_compilation(
-                    "eagle3_filter_token_and_prepare_initial_inputs",
-                    filter_token_and_prepare_initial_inputs_wrapper,
-                    token_indices,
-                    query_start_loc,
-                    seq_lens,
-                    input_ids,
-                    aux_hidden_states,
-                    attention_metadata,
-                    next_token_ids,
-                    device_array(
-                        self.runner.mesh,
-                        np.asarray([self.runner.input_batch.num_reqs],
-                                   dtype=jnp.int32)),
-                    num_tokens=num_tokens,
-                )
-
             def drafter_propose_fn_wrapper(
-                state,
                 kv_caches,
                 input_ids,
                 attn_metadata,
                 last_token_indices,
                 target_hidden_states,
             ):
-                kv_caches, draft_token_ids = self.runner.drafter._propose(
-                    state,
+                kv_caches, draft_token_ids = self.runner.drafter.propose(
                     kv_caches,
                     input_ids,
                     attn_metadata,
                     last_token_indices,
                     target_hidden_states,
-                    self.runner.drafter.num_speculative_tokens,
-                    tuple(self.runner.layer_name_to_kvcache_index.items()),
                 )
 >>>>>>> 25f7ec753 (MTP jit drafter's propose)
                 self.runner.kv_caches = kv_caches
@@ -864,11 +828,12 @@ class CompilationManager:
             input_ids = self._create_dummy_tensor(
                 (num_tokens, ), jnp.int32,
                 NamedSharding(self.runner.mesh, PartitionSpec()))
+            last_token_indices = self._create_dummy_tensor(
+                (self.runner.max_num_reqs, ), jnp.int32)
 
             self._run_compilation(
                 "drafter_propose",
                 drafter_propose_fn_wrapper,
-                self.runner.drafter.state,
                 self.runner.kv_caches,
                 input_ids,
                 attention_metadata,
@@ -877,23 +842,41 @@ class CompilationManager:
                 num_tokens=num_tokens,
             )
 
-            target_token_ids = self._create_dummy_tensor((num_tokens, ),
-                                                         jnp.int32)
-
-            self._run_compilation(
-                "eagle3_prepare_hidden_states_and_input_ids",
-                self.runner.drafter._prepare_hidden_states_and_input_ids,
-                self.runner.drafter.state,
-                aux_hidden_states,
-                query_start_loc,
-                target_token_ids,
-                next_token_ids,
-                device_array(
-                    self.runner.mesh,
-                    np.asarray([self.runner.input_batch.num_reqs],
-                               dtype=jnp.int32)),
-                num_tokens=num_tokens,
-            )
+            for num_rejected_tokens in [
+                    None,
+                    self._create_dummy_tensor((self.runner.max_num_reqs, ),
+                                              jnp.int32)
+            ]:
+                aux_hidden_states = [
+                    self._create_dummy_tensor(
+                        (num_tokens, target_hidden_size), jnp.bfloat16,
+                        NamedSharding(self.runner.mesh,
+                                      PartitionSpec(None, None))),
+                    self._create_dummy_tensor(
+                        (num_tokens, target_hidden_size), jnp.bfloat16,
+                        NamedSharding(self.runner.mesh,
+                                      PartitionSpec(None, None))),
+                    self._create_dummy_tensor(
+                        (num_tokens, target_hidden_size), jnp.bfloat16,
+                        NamedSharding(self.runner.mesh,
+                                      PartitionSpec(None, None))),
+                ]
+                self._run_compilation(
+                    "drafter_prepare_inputs",
+                    self.runner.drafter._prepare_inputs,
+                    self.runner.drafter.state,
+                    attention_metadata,
+                    input_ids,
+                    aux_hidden_states,
+                    next_token_ids,
+                    block_tables,
+                    device_array(
+                        self.runner.mesh,
+                        np.asarray([self.runner.input_batch.num_reqs],
+                                   dtype=jnp.int32)),
+                    num_rejected_tokens,
+                    num_tokens=num_tokens,
+                )
 
     def _precompile_structured_decoding(self) -> None:
         logger.info(

--- a/tpu_inference/runner/compilation_manager.py
+++ b/tpu_inference/runner/compilation_manager.py
@@ -761,6 +761,8 @@ class CompilationManager:
         draft_hidden_size = self.runner.speculative_config.draft_model_config.get_hidden_size(
         )
         dtype = self.runner.model_config.dtype
+        data_parallel_attn_sharding = NamedSharding(
+            self.runner.mesh, PartitionSpec(ShardingAxisName.ATTN_DATA))
 
         num_kv_cache_groups = len(self.runner.kv_cache_config.kv_cache_groups)
         draft_kv_cache_group_id = num_kv_cache_groups - 1
@@ -771,13 +773,16 @@ class CompilationManager:
                                     sharding=PartitionSpec(None, ))
 
         seq_lens = self._create_dummy_tensor((self.runner.max_num_reqs, ),
-                                             jnp.int32)
+                                             jnp.int32,
+                                             data_parallel_attn_sharding)
         query_start_loc = self._create_dummy_tensor(
-            (self.runner.max_num_reqs + 1, ), jnp.int32)
+            (self.runner.max_num_reqs + 1, ), jnp.int32,
+            data_parallel_attn_sharding)
 
-        request_distribution = np.array([0, 0, 0], dtype=np.int32)
-        request_distribution = device_array(self.runner.mesh,
-                                            request_distribution)
+        request_distribution = device_array(
+            self.runner.mesh,
+            np.array([0, 0, 0], dtype=np.int32),
+            sharding=data_parallel_attn_sharding)
         # Dummy mamba_state_indices for spec-decode compile-cache pre-tracing.
         # Must match the ATTN_DATA sharding `_prepare_inputs_*` produces at
         # runtime — otherwise the draft model_fn cache misses and the
@@ -797,7 +802,8 @@ class CompilationManager:
         next_token_ids = self._create_dummy_tensor(
             (self.runner.max_num_reqs, ), jnp.int32)
         last_token_indices = self._create_dummy_tensor(
-            (self.runner.max_num_reqs, ), jnp.int32)
+            (self.runner.max_num_reqs, ), jnp.int32,
+            data_parallel_attn_sharding)
         for num_tokens in self.runner.num_tokens_paddings:
             aux_hidden_states = [
                 self._create_dummy_tensor((num_tokens, target_hidden_size),
@@ -808,7 +814,8 @@ class CompilationManager:
                                           dtype),
             ]
 
-            positions = self._create_dummy_tensor((num_tokens, ), jnp.int32)
+            positions = self._create_dummy_tensor((num_tokens, ), jnp.int32,
+                                                  data_parallel_attn_sharding)
             attention_metadata = AttentionMetadata(
                 input_positions=positions,
                 block_tables=block_tables,

--- a/tpu_inference/spec_decode/jax/eagle3.py
+++ b/tpu_inference/spec_decode/jax/eagle3.py
@@ -28,7 +28,6 @@ from tpu_inference.layers.common.attention_metadata import AttentionMetadata
 from tpu_inference.logger import init_logger
 from tpu_inference.models.common.model_loader import (
     get_model, resolve_model_architecture)
-from tpu_inference.runner import utils as runner_utils
 from tpu_inference.utils import device_array
 
 logger = init_logger(__name__)
@@ -152,11 +151,10 @@ class Eagle3Proposer:
         max_num_reqs = last_token_indices.shape[0]
         mask = jnp.arange(max_num_reqs) < num_reqs
 
-        # For padded requests (where mask is False), we use the original value from
-        # the rolled array, making the update a no-op for them.
-        original_values_at_indices = rolled_input_ids[last_token_indices]
+        # For padded requests (where mask is False), we use the last token ID of the
+        # last active request.
         values_to_set = jnp.where(mask, next_token_ids,
-                                  original_values_at_indices)
+                                  next_token_ids[num_reqs - 1])
 
         input_ids = rolled_input_ids.at[last_token_indices].set(values_to_set)
 
@@ -209,7 +207,6 @@ class Eagle3Proposer:
         """JIT-compiled helper for stacking draft token IDs."""
         return jnp.stack(draft_token_ids_list, axis=1)
 
-    @jax.jit(static_argnums=(0, ))
     def _prepare_hidden_states_and_input_ids(
         self,
         state: nnx.State,
@@ -259,84 +256,89 @@ class Eagle3Proposer:
             draft_kv_cache_group_id].get_cpu_tensor().reshape(-1)
         # Number of active requests in this step (un-padded count).
         num_reqs = self.runner.input_batch.num_reqs
+        num_reqs = device_array(self.mesh,
+                                np.asarray([num_reqs], dtype=jnp.int32))
+        block_tables = block_tables = device_array(self.mesh, block_tables)
+        return self._prepare_inputs(self.state, attn_metadata, input_ids,
+                                    aux_hidden_states, next_token_ids,
+                                    block_tables, num_reqs,
+                                    num_rejected_tokens)
 
+    @jax.jit(static_argnums=(0, ))
+    def _prepare_inputs(
+        self,
+        state: nnx.State,
+        attn_metadata: AttentionMetadata,
+        input_ids: jax.Array,
+        aux_hidden_states: tuple[jax.Array, ...],
+        next_token_ids: jax.Array,
+        block_tables: jax.Array,
+        num_reqs: jax.Array,
+        num_rejected_tokens: Optional[jax.Array] = None,
+    ) -> tuple[jax.Array, jax.Array, jax.Array, AttentionMetadata]:
+        """Prepare drafter inputs based on target forward outputs.
+
+        Mirrors the GPU reference logic but adapted to TPU/JAX types:
+        - When no rejection happened, select the first N scheduled tokens.
+        - When rejections happened, trim the per-request tail tokens and
+          update attention metadata accordingly.
+        - Build the EAGLE3 hidden input by concatenating auxiliary hidden
+          states along the last dimension.
+
+        Returns updated AttentionMetadata (positions, query_start_loc, seq_lens)
+        and the selected `target_token_ids` and `target_hidden_states`.
+        """
         if num_rejected_tokens is None:
-            num_reqs = device_array(self.mesh,
-                                    np.asarray([num_reqs], dtype=jnp.int32))
-            # block_tables = device_array(self.mesh, block_tables)
-            attn_metadata = replace(attn_metadata,
-                                    block_tables=device_array(
-                                        self.mesh, block_tables))
+            attn_metadata = replace(attn_metadata, block_tables=block_tables)
             target_hidden_states, input_ids, last_token_indices = self._prepare_hidden_states_and_input_ids(
-                self.state, aux_hidden_states, attn_metadata.query_start_loc,
+                state, aux_hidden_states, attn_metadata.query_start_loc,
                 input_ids, next_token_ids, num_reqs)
             return target_hidden_states, input_ids, last_token_indices, attn_metadata
 
         # Host copies from the metadata prepared by the runner.
-        query_start_loc_cpu = attn_metadata.query_start_loc_cpu
-        seq_lens_cpu = attn_metadata.seq_lens_cpu
-        assert query_start_loc_cpu is not None and seq_lens_cpu is not None
+        query_start_loc = attn_metadata.query_start_loc
+        seq_lens = attn_metadata.seq_lens
+        assert query_start_loc is not None and seq_lens is not None
 
         # Rejection-aware path: compute new per-request lengths and token indices.
         # Convert to host numpy for efficient prefix-sum and repeat ops.
-        nrt_cpu = jax.device_get(num_rejected_tokens).astype("int32")
-
         # query_len_per_req = [q1, q2, ...]
-        query_len_per_req = (query_start_loc_cpu[1:] -
-                             query_start_loc_cpu[:-1])
+        query_len_per_req = (query_start_loc[1:] - query_start_loc[:-1])
 
-        # query_start_loc_cpu and consequentaly query_len_per_req are padded
+        # query_start_loc and consequentaly query_len_per_req are padded
         # For padded requests, the query length should be 0.
-        query_len_per_req[num_reqs:] = 1
         # num_tokens_per_req = [q1 - n1, q2 - n2, ...]
-        num_tokens_per_req = (query_len_per_req - nrt_cpu)
-        assert (num_tokens_per_req
-                >= 0).all(), ("num_tokens_per_req must be non-negative")
+        num_tokens_per_req = (query_len_per_req - num_rejected_tokens)
 
         # new_query_start_loc = [0, q1-n1, q1+q2-n1-n2, ...]
-        # Use numpy for cumsum and then convert back.
-        new_query_start_loc_cpu = np.zeros_like(query_start_loc_cpu)
-        np.cumsum(num_tokens_per_req, out=new_query_start_loc_cpu[1:])
-
-        # Build token indices selecting the kept tokens from each request.
-        total_num_tokens = int(new_query_start_loc_cpu[-1])
-
-        # Pad to total_num_tokens.
-        padded_total_num_tokens = runner_utils.get_padded_token_len(
-            self.runner.num_tokens_paddings, total_num_tokens)
-        pad_width = padded_total_num_tokens - total_num_tokens
-        assert pad_width >= 0, (
-            f"total_num_tokens {total_num_tokens} exceeds "
-            f"num_tokens_paddings {self.runner.num_tokens_paddings}")
+        new_query_start_loc = jnp.cumsum(num_tokens_per_req)
+        new_query_start_loc = jnp.pad(new_query_start_loc, (1, 0),
+                                      constant_values=0)
+        total_num_tokens = input_ids.shape[0]
 
         # Expand request starts: [0, 0, q1-n1, ...,]
-        expanded_new_query_start_loc = np.repeat(new_query_start_loc_cpu[:-1],
-                                                 num_tokens_per_req)
+        expanded_new_query_start_loc = jnp.repeat(
+            new_query_start_loc[:-1],
+            num_tokens_per_req,
+            total_repeat_length=total_num_tokens)
         # Offsets within each request window: [0,1,2, 0,1,2,3, ...]
-        token_offsets = np.arange(total_num_tokens, dtype=np.int32)
+        token_offsets = jnp.arange(total_num_tokens, dtype=jnp.int32)
         token_offsets -= expanded_new_query_start_loc
         # Map into old flat indices by adding original request starts.
-        old_query_start_loc_expanded = np.repeat(query_start_loc_cpu[:-1],
-                                                 num_tokens_per_req)
+        old_query_start_loc_expanded = jnp.repeat(
+            query_start_loc[:-1],
+            num_tokens_per_req,
+            total_repeat_length=total_num_tokens)
+        token_indices = token_offsets + old_query_start_loc_expanded
 
-        token_indices_cpu = token_offsets + old_query_start_loc_expanded
-        token_indices_cpu = np.pad(token_indices_cpu, (0, pad_width),
-                                   "constant",
-                                   constant_values=0)
         # Update seq_lens for active requests only: new_seq_lens = s - n.
-        new_seq_lens_cpu = seq_lens_cpu - nrt_cpu
-
-        query_start_loc, seq_lens, token_indices, num_reqs, block_tables = device_array(
-            self.mesh,
-            (new_query_start_loc_cpu, new_seq_lens_cpu, token_indices_cpu,
-             np.asarray([num_reqs], dtype=jnp.int32), block_tables))
+        new_seq_lens = seq_lens - num_rejected_tokens
 
         attn_metadata = replace(attn_metadata, block_tables=block_tables)
         return self._filter_token_and_prepare_initial_inputs(
-            self.state, token_indices, query_start_loc, seq_lens, input_ids,
+            state, token_indices, new_query_start_loc, new_seq_lens, input_ids,
             aux_hidden_states, attn_metadata, next_token_ids, num_reqs)
 
-    @jax.jit(static_argnums=(0, ))
     def _filter_token_and_prepare_initial_inputs(
         self,
         state: nnx.State,
@@ -468,7 +470,7 @@ class Eagle3Proposer:
 
         # input_ids and target_hidden_states for the first speculation have been prepared in prepare_inputs() to improve performance.
         kv_caches, hidden_states, residual, _ = self.model_fn(
-            self.state,
+            state,
             kv_caches,
             input_ids,
             target_hidden_states,
@@ -500,7 +502,7 @@ class Eagle3Proposer:
                 block_tables=new_block_tables,
             )
             kv_caches, new_hidden_states, residual, _ = self.model_fn(
-                self.state,
+                state,
                 kv_caches,
                 input_ids_loop,
                 hidden_states,  # This should be the hidden_states from previous step

--- a/tpu_inference/spec_decode/jax/eagle3.py
+++ b/tpu_inference/spec_decode/jax/eagle3.py
@@ -469,17 +469,8 @@ class Eagle3Proposer:
         """
 
         # input_ids and target_hidden_states for the first speculation have been prepared in prepare_inputs() to improve performance.
-<<<<<<< HEAD
         kv_caches, hidden_states, residual, _ = self.model_fn(
-<<<<<<< HEAD
-            state,
-=======
             self.state,
-=======
-        kv_caches, hidden_states, residual = self.model_fn(
-            state,
->>>>>>> 25f7ec753 (MTP jit drafter's propose)
->>>>>>> 07372dab2 (MTP jit drafter's propose)
             kv_caches,
             input_ids,
             target_hidden_states,
@@ -510,17 +501,8 @@ class Eagle3Proposer:
                 query_start_loc=query_start_loc,
                 block_tables=new_block_tables,
             )
-<<<<<<< HEAD
             kv_caches, new_hidden_states, residual, _ = self.model_fn(
-<<<<<<< HEAD
-                state,
-=======
                 self.state,
-=======
-            kv_caches, new_hidden_states, residual = self.model_fn(
-                state,
->>>>>>> 25f7ec753 (MTP jit drafter's propose)
->>>>>>> 07372dab2 (MTP jit drafter's propose)
                 kv_caches,
                 input_ids_loop,
                 hidden_states,  # This should be the hidden_states from previous step

--- a/tpu_inference/spec_decode/jax/eagle3.py
+++ b/tpu_inference/spec_decode/jax/eagle3.py
@@ -470,7 +470,7 @@ class Eagle3Proposer:
 
         # input_ids and target_hidden_states for the first speculation have been prepared in prepare_inputs() to improve performance.
         kv_caches, hidden_states, residual, _ = self.model_fn(
-            self.state,
+            state,
             kv_caches,
             input_ids,
             target_hidden_states,
@@ -502,7 +502,7 @@ class Eagle3Proposer:
                 block_tables=new_block_tables,
             )
             kv_caches, new_hidden_states, residual, _ = self.model_fn(
-                self.state,
+                state,
                 kv_caches,
                 input_ids_loop,
                 hidden_states,  # This should be the hidden_states from previous step

--- a/tpu_inference/spec_decode/jax/eagle3.py
+++ b/tpu_inference/spec_decode/jax/eagle3.py
@@ -469,8 +469,17 @@ class Eagle3Proposer:
         """
 
         # input_ids and target_hidden_states for the first speculation have been prepared in prepare_inputs() to improve performance.
+<<<<<<< HEAD
         kv_caches, hidden_states, residual, _ = self.model_fn(
+<<<<<<< HEAD
             state,
+=======
+            self.state,
+=======
+        kv_caches, hidden_states, residual = self.model_fn(
+            state,
+>>>>>>> 25f7ec753 (MTP jit drafter's propose)
+>>>>>>> 07372dab2 (MTP jit drafter's propose)
             kv_caches,
             input_ids,
             target_hidden_states,
@@ -501,8 +510,17 @@ class Eagle3Proposer:
                 query_start_loc=query_start_loc,
                 block_tables=new_block_tables,
             )
+<<<<<<< HEAD
             kv_caches, new_hidden_states, residual, _ = self.model_fn(
+<<<<<<< HEAD
                 state,
+=======
+                self.state,
+=======
+            kv_caches, new_hidden_states, residual = self.model_fn(
+                state,
+>>>>>>> 25f7ec753 (MTP jit drafter's propose)
+>>>>>>> 07372dab2 (MTP jit drafter's propose)
                 kv_caches,
                 input_ids_loop,
                 hidden_states,  # This should be the hidden_states from previous step

--- a/tpu_inference/spec_decode/jax/eagle3.py
+++ b/tpu_inference/spec_decode/jax/eagle3.py
@@ -162,7 +162,6 @@ class Eagle3Proposer:
 
         return input_ids, last_token_indices
 
-    @jax.jit(static_argnums=(0, ))
     def _update_inputs_for_loop_speculation(
         self, positions: jax.Array, seq_lens: jax.Array,
         block_tables: jax.Array
@@ -205,7 +204,6 @@ class Eagle3Proposer:
 
         return positions, clamped_positions, new_seq_lens, query_start_loc, new_block_tables
 
-    @jax.jit(static_argnums=(0, ))
     def _stack_draft_token_ids(
             self, draft_token_ids_list: list[jax.Array]) -> jnp.ndarray:
         """JIT-compiled helper for stacking draft token IDs."""
@@ -375,7 +373,6 @@ class Eagle3Proposer:
 
         return target_hidden_states, input_ids, last_token_indices, attn_metadata
 
-    @jax.jit(static_argnums=(0, ))
     def _select_draft_token_ids(
         self,
         state: nnx.State,
@@ -388,7 +385,6 @@ class Eagle3Proposer:
             NamedSharding(self.mesh, PartitionSpec(None, None)))
         return self._get_draft_token_ids(state, sample_hidden_states)
 
-    @jax.jit(static_argnums=(0, ))
     def _get_draft_token_ids(self, state: nnx.State,
                              hidden_states: jax.Array) -> jax.Array:
         lora_metadata = None
@@ -397,7 +393,6 @@ class Eagle3Proposer:
         return lax.with_sharding_constraint(
             draft_token_ids, NamedSharding(self.mesh, PartitionSpec()))
 
-    @jax.jit(static_argnums=(0, ))
     def _select_inputs_for_loop_speculation(
             self, state: nnx.State, positions: jax.Array, residual: jax.Array,
             hidden_states: jax.Array,
@@ -424,6 +419,47 @@ class Eagle3Proposer:
         last_token_indices,
         target_hidden_states,
     ) -> tuple[list[jax.Array], jnp.ndarray]:
+        return self._propose(
+            state=self.state,
+            kv_caches=kv_caches,
+            input_ids=input_ids,
+            attn_metadata=attn_metadata,
+            last_token_indices=last_token_indices,
+            target_hidden_states=target_hidden_states,
+            num_speculative_tokens=self.num_speculative_tokens,
+            layer_name_to_kvcache_index=tuple(
+                self.runner.layer_name_to_kvcache_index.items()),
+        )
+
+    @jax.jit(
+        donate_argnames=("kv_caches", ),
+        out_shardings=(
+            None,  # kv_caches - keep original sharding
+            None,  # draft_token_ids
+        ),
+        compiler_options={
+            "xla_tpu_all_gather_collective_matmul_mode":
+            "post_spmd_conservative",
+            "xla_tpu_reduce_scatter_collective_matmul_mode":
+            "post_spmd_conservative"
+        },
+        static_argnums=(
+            0,
+            7,
+            8,
+        ),
+    )
+    def _propose(
+        self,
+        state: nnx.State,
+        kv_caches: list[jax.Array],
+        input_ids: jax.Array,
+        attn_metadata: AttentionMetadata,
+        last_token_indices,
+        target_hidden_states,
+        num_speculative_tokens: int,
+        layer_name_to_kvcache_index: tuple,
+    ) -> tuple[list[jax.Array], jnp.ndarray]:
         """Proposes draft tokens using the draft model.
         Returns:
             A tuple containing the updated KV caches and a tensor of proposed
@@ -437,20 +473,20 @@ class Eagle3Proposer:
             input_ids,
             target_hidden_states,
             attn_metadata,
-            tuple(self.runner.layer_name_to_kvcache_index.items()),
+            layer_name_to_kvcache_index,
         )
 
-        if self.num_speculative_tokens == 1:
+        if num_speculative_tokens == 1:
             return kv_caches, self._select_draft_token_ids(
-                self.state, hidden_states, last_token_indices)
+                state, hidden_states, last_token_indices)
 
         positions, hidden_states, draft_token_ids = self._select_inputs_for_loop_speculation(
-            self.state, attn_metadata.input_positions, residual[0],
-            hidden_states, last_token_indices)
+            state, attn_metadata.input_positions, residual[0], hidden_states,
+            last_token_indices)
 
         draft_token_ids_list = [draft_token_ids]
 
-        for _ in range(self.num_speculative_tokens - 1):
+        for _ in range(num_speculative_tokens - 1):
             input_ids_loop = draft_token_ids_list[-1]
 
             positions, clamped_positions, new_seq_lens, query_start_loc, new_block_tables = self._update_inputs_for_loop_speculation(
@@ -469,11 +505,11 @@ class Eagle3Proposer:
                 input_ids_loop,
                 hidden_states,  # This should be the hidden_states from previous step
                 attn_metadata,
-                tuple(self.runner.layer_name_to_kvcache_index.items()),
+                layer_name_to_kvcache_index,
             )
             hidden_states = residual[0]
             draft_token_ids = self._get_draft_token_ids(
-                self.state, new_hidden_states)
+                state, new_hidden_states)
             draft_token_ids_list.append(draft_token_ids)
 
         # [batch_size, num_speculative_tokens]


### PR DESCRIPTION
# Description
jit the whole `propose()`  and `prepare_inputs()` method of the drafter for performance improvement.

Before this PR, there is gap between each drafter's step:
https://screenshot.googleplex.com/9VTrwkgDM8vmoTU
(gap between 2 consecutive target model's step: ~18ms: https://screenshot.googleplex.com/BJnqJpEb2xTAM8W)

After this PR, gamma number of drafter's step is a single jited-fn:
https://screenshot.googleplex.com/ADXRhTviByMUdkV
(gap between 2 consecutive target model's step: ~12ms)


# Tests
Spec decoding acceptance rate: https://paste.googleplex.com/5224862240079872
is on par with previous test record in https://screenshot.googleplex.com/yeoqKrZVYGDEgUY
