### PR TITLE
Unjit unpack_array

### DIFF
--- a/tpu_inference/utils.py
+++ b/tpu_inference/utils.py
@@ -492,7 +492,6 @@ class DeviceBuffer:
                       metadata: DeviceBufferMetadata) -> Dict[str, jax.Array]:
         """
         Unpack a 1D blob into a dictionary of arrays based on provided metadata.
-        Uses JIT and jnp.split to minimize dispatch overhead.
         """
         indices = tuple(np.cumsum(metadata.sizes)[:-1])
         parts = jnp.split(blob, indices)

--- a/tpu_inference/utils.py
+++ b/tpu_inference/utils.py
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
-import functools
 import time
 from collections import defaultdict
 from collections.abc import Sequence
@@ -489,7 +488,6 @@ class DeviceBuffer:
         self._sizes = []
 
     @staticmethod
-    @functools.partial(jax.jit, static_argnums=(1, ))
     def unpack_arrays(blob: jax.Array,
                       metadata: DeviceBufferMetadata) -> Dict[str, jax.Array]:
         """


### PR DESCRIPTION
# Description

Remove unnecessary jit decoration on unpack_arrays causing long compilation times.

# Tests

```
SKIP_JAX_PRECOMPILE=1 MODEL_IMPL_TYPE=flax_nnx python3 examples/tpu_profiling.py --model=Qwen/Qwen3-30B-A3B-Instruct-2507 --profile-result-dir=gs://piv-test/tpu-profile/may4/3/ --data_parallel_size=8 --no-async-scheduling
```

## Before

DP=1 http://xprof.corp.google.com/trace_viewer/piv-11424799029370372546

DP=8 http://xprof.corp.google.com/trace_viewer/piv-1803042148146822708

Before 80us, after 180us

## After

DP=1 http://xprof.corp.google.com/trace_viewer/piv-16381496923539837505

DP=8 http://xprof.corp.google.com/trace_viewer/piv-5019854990287657134

Before 350us, after 470us 

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
