### PR TITLE
Bump RunAI model streamer to 0.15.9 to pick up GRPC GCS client support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ torchvision==0.25.0
 pathwaysutils
 parameterized
 numba==0.62.1
-runai-model-streamer[s3,gcs]==0.15.4
+runai-model-streamer[s3,gcs]==0.15.9
 gcsfs==2026.1.0
 hypothesis==6.151.9
 sortedcontainers==2.4.0

--- a/tests/e2e/test_runai_model_streamer_loader.py
+++ b/tests/e2e/test_runai_model_streamer_loader.py
@@ -56,7 +56,8 @@ def test_correctness_jax_uni_proc_executor(
     Compare the outputs of a model loaded from GCS via runai_model_streamer
     and a model loaded from Hugging Face. The outputs should be the same.
     These tests attempt to use tensor_parallel_size=1. The model is 16GB,
-    # and v6e has 32GB of HBM, so it will fit.
+    # and v6e has 32GB of HBM, so it will fit. This test uses the default 
+    HTTP GCS RunAI model streamer client.
     '''
     # TODO(amacaskill): Replace with GKE owned GCS bucket.
     gcs_model_name = "gs://vertex-model-garden-public-us/llama3/llama3-8b-hf"
@@ -68,6 +69,7 @@ def test_correctness_jax_uni_proc_executor(
     monkeypatch.setenv("RUNAI_STREAMER_GCS_USE_ANONYMOUS_CREDENTIALS", "true")
     monkeypatch.setenv("CLOUD_STORAGE_EMULATOR_ENDPOINT",
                        "https://storage.googleapis.com")
+    monkeypatch.setenv("MODEL_IMPL_TYPE", "flax_nnx")
     gcs_llm = LLM(model=gcs_model_name,
                   load_format="runai_streamer",
                   max_model_len=128,
@@ -99,7 +101,8 @@ def test_correctness_torchax_uni_proc_executor(
 ):
     """
     Compare the outputs of a codegemma model loaded from GCS via runai_model_streamer
-    and a model loaded from Hugging Face. The outputs should be the same.
+    and a model loaded from Hugging Face. The outputs should be the same. This test
+    uses the GRPC GCS RunAI model streamer client by setting RUNAI_STREAMER_GCS_USE_GRPC.
     """
     # TODO(amacaskill): Replace with GKE owned GCS bucket.
     gcs_model_name = "gs://vertex-model-garden-public-us/codegemma/codegemma-2b"
@@ -111,6 +114,12 @@ def test_correctness_torchax_uni_proc_executor(
     monkeypatch.setenv("RUNAI_STREAMER_GCS_USE_ANONYMOUS_CREDENTIALS", "true")
     monkeypatch.setenv("CLOUD_STORAGE_EMULATOR_ENDPOINT",
                        "https://storage.googleapis.com")
+    monkeypatch.setenv("MODEL_IMPL_TYPE", "vllm")
+    # All 3 of these env variables are needed to see the log that confirms gRPC
+    # is being used: 'GCS client initialized with gRPC transport.'
+    monkeypatch.setenv("RUNAI_STREAMER_GCS_USE_GRPC", "1")
+    monkeypatch.setenv("RUNAI_STREAMER_LOG_LEVEL", "DEBUG")
+    monkeypatch.setenv("RUNAI_STREAMER_LOG_TO_STDERR", "1")
 
     gcs_llm = LLM(model=gcs_model_name,
                   load_format="runai_streamer",
@@ -146,11 +155,12 @@ def test_correctness_torchax_ray_distributed_executor(
     runai_model_streamer, and a model loaded from
     Hugging Face, both using RayDistributedExecutor. The outputs should be the same.
     Note that these are run on the same node since a multi-node TPU setup would
-    require additional changes to the CI pipeline.
+    require additional changes to the CI pipeline. This test uses the default 
+    HTTP GCS RunAI model streamer client.
     """
     # TODO(amacaskill): Replace with GKE owned GCS bucket.
-    gcs_model_name = "gs://vertex-model-garden-public-us/llama3/llama3-8b-hf"
-    hf_model_name = "meta-llama/Meta-Llama-3-8B"
+    gcs_model_name = "gs://vertex-model-garden-public-us/codegemma/codegemma-2b"
+    hf_model_name = "google/codegemma-2b"
     prompt = "def fibonacci("
 
     # Set ENV variables so that runai_model_streamer uses anonymous GCS access.
@@ -158,6 +168,9 @@ def test_correctness_torchax_ray_distributed_executor(
     monkeypatch.setenv("RUNAI_STREAMER_GCS_USE_ANONYMOUS_CREDENTIALS", "true")
     monkeypatch.setenv("CLOUD_STORAGE_EMULATOR_ENDPOINT",
                        "https://storage.googleapis.com")
+    monkeypatch.setenv("MODEL_IMPL_TYPE", "vllm")
+    monkeypatch.setenv("TPU_MULTIHOST_BACKEND", "ray")
+    monkeypatch.setenv("TPU_BACKEND_TYPE", "jax")
 
     gcs_llm = LLM(model=gcs_model_name,
                   load_format="runai_streamer",


### PR DESCRIPTION
# Description


This PR bumps the RunAI model streamer version to 0.15.9 to pick up GRPC GCS client support that was added in https://github.com/run-ai/runai-model-streamer/pull/143. This change is being made because for some customers, gRPC direct path is a requirement. Additionally, gRPC direct path is a higher performance streaming option than the default HTTP client. The GRPC client can be enabled with the `RUNAI_STREAMER_GCS_USE_GRPC` runai env variable (which is already documented in RunAI public docs). It is not the default because if the customer enables GRPC and doesn't have direct path enabled, then its possible their performance will be worse than the default HTTP client. I looked into having RUNAI_STREAMER_GCS_USE_GRPC enabled by default if direct path is enabled within RunAI code, but this check turned out to be non trivial, so this will be done later if I find a good way to do this. 


We also made some e2e test changes: 
- changed the test_correctness_torchax_ray_distributed_executor test to use the codegemma model instead of the llama model to match what the test_correctness_torchax_uni_proc_executor test does. 
- set MODEL_IMPL_TYPE=flax_nnx for jax tests and MODEL_IMPL_TYPE=vllm for the torchax tests since they were all resolving to MODEL_IMPL_TYPE=flax_nnx by default, but we want to test both implementations.
- set RUNAI_STREAMER_GCS_USE_GRPC for the test_correctness_torchax_uni_proc_executor test so we have some tests that run on the GRPC client. 
- Set TPU_BACKEND_TYPE: jax and TPU_MULTIHOST_BACKEND: ray to actually `Force using RayDistributedExecutor for JAX on multihost.` Note, this test still doesn't run on multi-host, but I will update it to use real multi-host in a follow up PR now that [Multi-host CI is supported](https://github.com/vllm-project/tpu-inference/pull/1677)


# Tests

I ran all of the runai model streamer tests, and confirmed they passed: 

```
 pytest -s -v tests/e2e/test_runai_model_streamer_loader.py
================================================== 3 passed, 23 warnings in 322.28s (0:05:22) ==================================================
```

Also built custom image and tested: 
```
DOCKER_BUILDKIT=1 docker build --build-arg IS_FOR_V7X=true -f docker/Dockerfile . -t amacaskill-vllm-tpu-grpc-1 --load
export REGION_NAME=us-central1
gcloud auth configure-docker $REGION_NAME-docker.pkg.dev && \
docker image tag amacaskill-vllm-tpu-grpc-1 \
  $REGION_NAME-docker.pkg.dev/$PROJECT_ID/amacaskill-vllm-tpu/amacaskill-vllm-tpu-grpc-1:latest && \
docker push $REGION_NAME-docker.pkg.dev/$PROJECT_ID/amacaskill-vllm-tpu/amacaskill-vllm-tpu-grpc-1:latest
```

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have made or will make corresponding changes to any relevant documentation.
