### PR TITLE
Skip post-rank-1 matmul in fused GDN kernels via algebraic identity

### DIFF
--- a/tpu_inference/kernels/gdn/fused_gdn_decode_kernel.py
+++ b/tpu_inference/kernels/gdn/fused_gdn_decode_kernel.py
@@ -243,22 +243,31 @@ def _decode_kernel_main(
                 else:
                     gk = g_t
 
-                h_new = h0 * jnp.exp(gk[:, :, None])
+                h_pre = h0 * jnp.exp(gk[:, :, None])
                 kh = jax.lax.dot_general(
                     k_t.reshape(H_v, 1, K),
-                    h_new,
+                    h_pre,
                     (((2, ), (1, )), ((0, ), (0, ))),
                     preferred_element_type=jnp.float32,
                 ).reshape(H_v, V)
                 v_diff = v_t - kh
                 b_v = beta_t * v_diff if b_ref is not None else v_diff
-                h_new = h_new + k_t[:, :, None] * b_v[:, None, :]
-                o_t = jax.lax.dot_general(
+
+                # Algebraic identity to skip the post-rank-1-update matmul:
+                # o = q @ (h_pre + outer(k, b_v))
+                #   = q @ h_pre + (q . k) * b_v
+                # (q . k)[h] is a per-head scalar, so the second term is a
+                # cheap HV*V scaled-add instead of a full HV*K*V matmul.
+                # This lets MXU(o) and VPU(rank-1 update) run in parallel.
+                o_step1 = jax.lax.dot_general(
                     q_t.reshape(H_v, 1, K),
-                    h_new,
+                    h_pre,
                     (((2, ), (1, )), ((0, ), (0, ))),
                     preferred_element_type=jnp.float32,
                 ).reshape(H_v, V)
+                qk_dot = jnp.sum(q_t * k_t, axis=-1, keepdims=True)
+                o_t = o_step1 + qk_dot * b_v
+                h_new = h_pre + k_t[:, :, None] * b_v[:, None, :]
 
                 o_ref[i_t] = o_t.astype(o_ref.dtype)
                 h_bufs_s[buf_idx, i_t] = h_new.astype(h_bufs_s.dtype)

--- a/tpu_inference/kernels/gdn/fused_gdn_recurrent_kernel.py
+++ b/tpu_inference/kernels/gdn/fused_gdn_recurrent_kernel.py
@@ -366,22 +366,28 @@ def _recurrent_gdn_main(
             else:
                 gk = g_t
 
-            h = h * jnp.exp(gk[:, :, None])
+            # Same algebraic identity as fused_gdn_decode_kernel.py:
+            # o = q @ h_pre + (q . k) * b_v
+            # Lets MXU(o) and VPU(rank-1 update) run in parallel.
+            h_pre = h * jnp.exp(gk[:, :, None])
             kh = jax.lax.dot_general(
                 k_t.reshape(H_v, 1, K),
-                h,
+                h_pre,
                 (((2, ), (1, )), ((0, ), (0, ))),
                 preferred_element_type=jnp.float32,
             ).reshape(H_v, V)
             v_diff = v_t - kh
             b_v = beta_t * v_diff if b_ref is not None else v_diff
-            h = h + k_t[:, :, None] * b_v[:, None, :]
-            o_t = jax.lax.dot_general(
+
+            o_step1 = jax.lax.dot_general(
                 q_t.reshape(H_v, 1, K),
-                h,
+                h_pre,
                 (((2, ), (1, )), ((0, ), (0, ))),
                 preferred_element_type=jnp.float32,
             ).reshape(H_v, V)
+            qk_dot = jnp.sum(q_t * k_t, axis=-1, keepdims=True)
+            o_t = o_step1 + qk_dot * b_v
+            h = h_pre + k_t[:, :, None] * b_v[:, None, :]
 
             o_ref[local_t] = o_t.astype(o_ref.dtype)
             return h


### PR DESCRIPTION
Reorder the output projection in the fused GDN decode and recurrent
kernels to break a data dependency between the MXU and VPU, improving
throughput on hybrid attention+mamba models (e.g. Qwen3.5).

## Problem

The GDN recurrent step computes:

    h_pre = h * exp(gk)                  # decay
    kh    = k @ h_pre                    # MXU
    b_v   = sigmoid(beta) * (v - kh)
    h_new = h_pre + outer(k, b_v)        # rank-1 update (VPU)
    o     = q @ h_new                    # output projection (MXU)

The output projection `q @ h_new` cannot start until the rank-1 update
finishes, serialising MXU behind VPU.

## Solution

Expand the output projection using the distributive property:

    o = q @ (h_pre + outer(k, b_v))
      = q @ h_pre + (q · k) * b_v

`q @ h_pre` depends only on the decayed state (available earlier), and
`(q · k)` is a per-head scalar dot product — essentially free. The
rank-1 update (`h_new = h_pre + outer(k, b_v)`) is still computed for
HBM storage, but now MXU(o) and VPU(h_new) can run in parallel.

The identity is exact in fp32 arithmetic — no approximation involved.

## Results

Qwen3.5-397B-A17B-FP8, TPU v7-8, TP=8, EP, fp8 KV, bf16 SSM,
1k/8k random, 640 prompts:

    conc=512: +2.70% tok/s, -2.83% TPOT, -4.87% TTFT (1k/8k)
              +4.48% tok/s (8k/1k)
    conc=64:  +1.05% tok/s (1k/8k), +2.79% tok/s (8k/1k)

Quality: mmlu_pro (limit=50, seed=42) 0.8314 vs 0.8286 baseline
(within stderr — no regression).

Correctness: all 15 tests in tests/kernels/fused_gdn_kernel_test.py pass.