### PR TITLE
[Batched RPA] Fix "Reshape should have supported layout" during Gemma4 inference

### DIFF
--- a/tpu_inference/kernels/experimental/batched_rpa/wrapper.py
+++ b/tpu_inference/kernels/experimental/batched_rpa/wrapper.py
@@ -32,6 +32,7 @@ Note: batched_rpa is build on top / derived from RPA3.
 import jax
 import jax.numpy as jnp
 from jax.experimental import pallas as pl
+from jax.experimental.layout import Layout, with_layout_constraint
 from jax.experimental.pallas import tpu as pltpu
 
 from tpu_inference.kernels.experimental.batched_rpa import (configs, kernel,
@@ -85,17 +86,35 @@ def prepare_inputs(
     actual_num_kv_heads_x2 = actual_num_kv_heads * 2
     num_kv_heads_x2_aligned = utils.align_to(actual_num_kv_heads_x2,
                                              kv_packing)
-    new_kv_hbm = jnp.pad(
-        jnp.concatenate([k, v], axis=-1).reshape(total_q_tokens,
-                                                 actual_num_kv_heads_x2,
-                                                 actual_head_dim),
-        (
-            (0, 0),
-            (0, num_kv_heads_x2_aligned - actual_num_kv_heads_x2),
-            (0, aligned_head_dim - actual_head_dim),
-        ),
-        constant_values=0,
-    ).reshape(
+    assert num_kv_heads_x2_aligned % 2 == 0, (
+        f"kv_packing={kv_packing} produces an odd aligned head count "
+        f"{num_kv_heads_x2_aligned}")
+    num_kv_heads_aligned = num_kv_heads_x2_aligned // 2
+
+    # `jnp.stack` introduces the K/V axis as a fresh axis, keeping
+    # the data 4D `[T, H_kv, 2, D]` through the pad. The final reshape
+    # `[T, H_kv, 2, D] -> [T, A/P, P, D]` becomes a pure factor merge of
+    # axes (h, kv) -> packed_dim with no head_dim involvement, which is a
+    # clean bitcast for the layout assigner.
+    kv_stacked = jnp.stack([k, v], axis=2)  # [T, H_kv, 2, D]
+    # `with_layout_constraint` on `kv_padded` pins the pad output
+    # to major-to-minor (0, 1, 2, 3) — i.e., T majormost, head_dim minor.
+    # Without it XLA's auto-layout placed the pad in SMEM with a
+    # transposed dim order, requiring a layout-changing copy to reach the
+    # kernel's required HBM layout — and the LLO emitter cannot lower
+    # that simultaneous axis-swap + tile-resize + memory-space migration.
+    kv_padded = with_layout_constraint(
+        jnp.pad(
+            kv_stacked,
+            (
+                (0, 0),
+                (0, num_kv_heads_aligned - actual_num_kv_heads),
+                (0, 0),
+                (0, aligned_head_dim - actual_head_dim),
+            ),
+            constant_values=0,
+        ), Layout(major_to_minor=(0, 1, 2, 3)))
+    new_kv_hbm = kv_padded.reshape(
         total_q_tokens,
         num_kv_heads_x2_aligned // kv_packing,
         kv_packing,


### PR DESCRIPTION
# Description

Gemma-4-26B had "Reshape should have supported layout" error at TP=2, this PR fixed the error.

See analysis in b/508918952

# Tests

```bash
USE_BATCHED_RPA_KERNEL=1 MODEL_IMPL_TYPE=flax_nnx vllm \
    serve google/Gemma-4-26B-A4B-it \
    --max-model-len=16384 \
    --max-num-seqs=320 \
    --tensor-parallel-size 2 \
    --max-num-batched-tokens 4096 \
    --no-enable-prefix-caching \
    --kv-cache-dtype=fp8
```

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
