### PR TITLE
[MoE] Extend MOE_REQUANTIZE_WEIGHT_DTYPE for unquantized checkpoint

### DIFF
--- a/tests/layers/jax/quantization/test_unquantized.py
+++ b/tests/layers/jax/quantization/test_unquantized.py
@@ -157,15 +157,15 @@ class TestUnquantizedJaxMoe:
         jax.clear_caches()
 
         w13, w2 = self._make_inputs()
-        with jax.set_mesh(mesh):
-            weights = process_unquantized_moe_weights(
-                moe_backend=MoEBackend.GMM_EP,
-                activation=MoEActivation.SILU,
-                w13_weight=w13,
-                w13_bias=None,
-                w2_weight=w2,
-                w2_bias=None,
-            )
+        weights = process_unquantized_moe_weights(
+            mesh=mesh,
+            moe_backend=MoEBackend.GMM_EP,
+            activation=MoEActivation.SILU,
+            w13_weight=w13,
+            w13_bias=None,
+            w2_weight=w2,
+            w2_bias=None,
+        )
 
         assert weights.w13_weight.dtype == expect_w_dtype
         assert weights.w2_weight.dtype == expect_w_dtype

--- a/tests/layers/jax/quantization/test_unquantized.py
+++ b/tests/layers/jax/quantization/test_unquantized.py
@@ -13,10 +13,17 @@
 # limitations under the License.
 
 import jax
+import jax.numpy as jnp
 import numpy as np
 import pytest
 from flax import nnx
+from jax.sharding import Mesh
+from vllm.model_executor.layers.fused_moe.activation import MoEActivation
 
+from tpu_inference.layers.common.moe import MoEBackend
+from tpu_inference.layers.common.process_weights.moe_weights import \
+    process_unquantized_moe_weights
+from tpu_inference.layers.common.sharding import ShardingAxisName
 from tpu_inference.layers.jax.linear import JaxEinsum, JaxLinear
 from tpu_inference.layers.jax.quantization import QuantizeMethodBase
 from tpu_inference.layers.jax.quantization.unquantized import UnquantizedConfig
@@ -111,3 +118,60 @@ class TestUnquantizedJaxLinear:
                                    y_from_method,
                                    rtol=1e-5,
                                    atol=1e-5)
+
+
+class TestUnquantizedJaxMoe:
+
+    @pytest.fixture
+    def mesh(self):
+        devices = jax.devices()
+        return Mesh(
+            np.array([devices[0]]).reshape(1), (ShardingAxisName.MLP_TENSOR, ))
+
+    @staticmethod
+    def _make_inputs(num_experts: int = 4,
+                     hidden_size: int = 128,
+                     intermediate_size: int = 256):
+        key = jax.random.PRNGKey(0)
+        k1, k2 = jax.random.split(key)
+        w13 = jax.random.normal(
+            k1, (num_experts, 2 * intermediate_size, hidden_size),
+            dtype=jnp.bfloat16)
+        w2 = jax.random.normal(k2,
+                               (num_experts, hidden_size, intermediate_size),
+                               dtype=jnp.bfloat16)
+        return w13, w2
+
+    @pytest.mark.parametrize("requantize_dtype,expect_w_dtype,expect_scale", [
+        ("", jnp.bfloat16, None),
+        ("fp8_e4m3", jnp.float8_e4m3fn, jnp.float32),
+    ])
+    def test_no_requantize_when_env_unset(self, mesh, monkeypatch,
+                                          requantize_dtype, expect_w_dtype,
+                                          expect_scale):
+        """No moe weights requantization -> weights stay bf16 and scales stay None."""
+        monkeypatch.setenv("MOE_REQUANTIZE_WEIGHT_DTYPE", requantize_dtype)
+        monkeypatch.delenv("MOE_REQUANTIZE_BLOCK_SIZE", raising=False)
+        # The function is jax.jit'ed and reads the env at trace time, so a
+        # cached trace from a prior test would otherwise mask the env change.
+        jax.clear_caches()
+
+        w13, w2 = self._make_inputs()
+        with jax.set_mesh(mesh):
+            weights = process_unquantized_moe_weights(
+                moe_backend=MoEBackend.GMM_EP,
+                activation=MoEActivation.SILU,
+                w13_weight=w13,
+                w13_bias=None,
+                w2_weight=w2,
+                w2_bias=None,
+            )
+
+        assert weights.w13_weight.dtype == expect_w_dtype
+        assert weights.w2_weight.dtype == expect_w_dtype
+        if expect_scale is None:
+            assert weights.w13_weight_scale is None
+            assert weights.w2_weight_scale is None
+        else:
+            assert weights.w13_weight_scale.dtype == expect_scale
+            assert weights.w2_weight_scale.dtype == expect_scale

--- a/tests/layers/vllm/test_unquantized.py
+++ b/tests/layers/vllm/test_unquantized.py
@@ -521,7 +521,8 @@ def test_fused_moe(use_ep, num_devices, num_tokens, intermediate_size,
                                   vllm_fused_moe.renormalize,
                                   vllm_fused_moe.activation.value)
 
-    with torchax.default_env(), set_forward_context(None, vllm_config):
+    with torchax.default_env(), set_forward_context(
+            None, vllm_config), jax.set_mesh(mesh):
         assert isinstance(vllm_fused_moe.quant_method,
                           VllmUnquantizedFusedMoEMethod)
         if use_ep:

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -242,7 +242,7 @@ def test_string_env_vars_defaults(monkeypatch: pytest.MonkeyPatch):
     assert envs.DECODE_SLICES == ""
     assert envs.PHASED_PROFILING_DIR == ""
     assert envs.REQUANTIZE_WEIGHT_DTYPE == "float8_e4m3fn"
-    assert envs.MOE_REQUANTIZE_WEIGHT_DTYPE == "float8_e4m3fn"
+    assert envs.MOE_REQUANTIZE_WEIGHT_DTYPE == ""
 
 
 def test_none_default_env_vars(monkeypatch: pytest.MonkeyPatch):

--- a/tpu_inference/envs.py
+++ b/tpu_inference/envs.py
@@ -231,8 +231,8 @@ environment_variables: dict[str, Callable[[], Any]] = {
     lambda: os.getenv("MOE_REQUANTIZE_WEIGHT_DTYPE", ""),
     # Specify requantization block size for MoE weights
     "MOE_REQUANTIZE_BLOCK_SIZE":
-    lambda: int(block_size) if (block_size := os.getenv(
-        "MOE_REQUANTIZE_BLOCK_SIZE")) is not None else None,
+    lambda: int(block_size)
+    if (block_size := os.getenv("MOE_REQUANTIZE_BLOCK_SIZE")) else None,
     # dictates whether to layout q-proj as NDH (q-heads, model dim, head dim)
     # or DNH (model dim, q-heads, head dim), which is the default (False)
     "LAYOUT_Q_PROJ_AS_NDH":

--- a/tpu_inference/envs.py
+++ b/tpu_inference/envs.py
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
     REQUANTIZE_BLOCK_SIZE: int | None = None
     REQUANTIZE_WEIGHT_DTYPE: str = "float8_e4m3fn"
     MOE_REQUANTIZE_BLOCK_SIZE: int | None = None
-    MOE_REQUANTIZE_WEIGHT_DTYPE: str = "float8_e4m3fn"
+    MOE_REQUANTIZE_WEIGHT_DTYPE: str = ""
     LAYOUT_Q_PROJ_AS_NDH: bool = False
     USE_JAX_PROFILER_SERVER: bool = False
     JAX_PROFILER_SERVER_PORT: int = 9999
@@ -228,7 +228,7 @@ environment_variables: dict[str, Callable[[], Any]] = {
     lambda: os.getenv("REQUANTIZE_WEIGHT_DTYPE", "float8_e4m3fn"),
     # Specify dtype for quantized MoE weights
     "MOE_REQUANTIZE_WEIGHT_DTYPE":
-    lambda: os.getenv("MOE_REQUANTIZE_WEIGHT_DTYPE", "float8_e4m3fn"),
+    lambda: os.getenv("MOE_REQUANTIZE_WEIGHT_DTYPE", ""),
     # Specify requantization block size for MoE weights
     "MOE_REQUANTIZE_BLOCK_SIZE":
     lambda: int(block_size) if (block_size := os.getenv(

--- a/tpu_inference/kernels/megablox/gmm_v2.py
+++ b/tpu_inference/kernels/megablox/gmm_v2.py
@@ -1022,9 +1022,8 @@ def validate_inputs(
         num_lanes = pltpu.get_tpu_info().num_lanes
         if size_n % (2 * num_lanes) != 0:
             raise ValueError(
-                f"{size_n=} should be divisible by 2 * num_lanes ({num_lanes=}) when fuse_act is "
-                f"enabled since we need to split n dimension for gate and up. {rhs.shape=}"
-            )
+                f"{size_n=} should be divisible by 2 * num_lanes when fuse_act is "
+                "enabled since we need to split n dimension for gate and up.")
 
     return Dimensions(
         size_m=size_m,

--- a/tpu_inference/kernels/megablox/gmm_v2.py
+++ b/tpu_inference/kernels/megablox/gmm_v2.py
@@ -1022,8 +1022,9 @@ def validate_inputs(
         num_lanes = pltpu.get_tpu_info().num_lanes
         if size_n % (2 * num_lanes) != 0:
             raise ValueError(
-                f"{size_n=} should be divisible by 2 * num_lanes when fuse_act is "
-                "enabled since we need to split n dimension for gate and up.")
+                f"{size_n=} should be divisible by 2 * num_lanes ({num_lanes=}) when fuse_act is "
+                f"enabled since we need to split n dimension for gate and up. {rhs.shape=}"
+            )
 
     return Dimensions(
         size_m=size_m,

--- a/tpu_inference/layers/common/process_weights/moe_weights.py
+++ b/tpu_inference/layers/common/process_weights/moe_weights.py
@@ -630,6 +630,9 @@ def process_fp8_moe_weights(
 
     if envs.DISABLE_WEIGHT_REQUANTIZATION:
         logger.info_once("Disabled weight requantization")
+        assert not envs.MOE_REQUANTIZE_WEIGHT_DTYPE, (
+            "MOE_REQUANTIZE_WEIGHT_DTYPE should not be set when weight "
+            "requantization is disabled.")
 
         assert weight_block_size is not None
         in_block_size = weight_block_size[1]
@@ -674,25 +677,22 @@ def process_fp8_moe_weights(
                                   if requant_block_size_from_env else None)
 
         moe_logging_str = (
-            f"[MoE requantization]: re-quantizing MoE weights to {desired_quant_dtype}"
-        )
+            f"[MoE requantization]: re-quantizing MoE weights to "
+            f"{desired_quant_dtype}")
         if requant_block_size is not None:
             moe_logging_str += f" with block size {requant_block_size}"
         logger.info_once(moe_logging_str)
 
         # Dequantize fp8 2d block quantized weights into fp32.
         w13_weight = dequantize_tensor(w13_weight,
-                                        w13_weight_scale, (1, 2),
-                                        jnp.float32,
-                                        block_size=weight_block_size)
+                                       w13_weight_scale, (1, 2),
+                                       jnp.float32,
+                                       block_size=weight_block_size)
         w2_weight = dequantize_tensor(w2_weight,
-                                        w2_weight_scale, (1, 2),
-                                        jnp.float32,
-                                        block_size=weight_block_size)
+                                      w2_weight_scale, (1, 2),
+                                      jnp.float32,
+                                      block_size=weight_block_size)
 
-        w13_interleave = activation == "swigluoai"
-        w13_reorder_size = get_mesh_shape_product(mesh,
-                                                ShardingAxisName.MLP_TENSOR)
         weights = quantize_moe_weights(
             FusedMoEWeights(
                 w13_weight=w13_weight,
@@ -710,6 +710,7 @@ def process_fp8_moe_weights(
         moe_backend=moe_backend,
         w13_reorder_size=w13_reorder_size,
         w13_interleave=w13_interleave,
+        disable_weight_requantization=envs.DISABLE_WEIGHT_REQUANTIZATION,
     )
 
 
@@ -725,6 +726,11 @@ def process_unquantized_moe_weights(
 ) -> FusedMoEWeights:
     """Jit'ed version to process unquantized moe weights. See `process_moe_weights` for details.
     """
+    if envs.DISABLE_WEIGHT_REQUANTIZATION:
+        logger.info_once("Disabled weight requantization")
+        assert not envs.MOE_REQUANTIZE_WEIGHT_DTYPE, (
+            "MOE_REQUANTIZE_WEIGHT_DTYPE should not be set when weight "
+            "requantization is disabled.")
     if desired_quant_dtype_from_env := envs.MOE_REQUANTIZE_WEIGHT_DTYPE:
         desired_quant_dtype = to_jax_dtype(desired_quant_dtype_from_env)
         requant_block_size = None
@@ -732,8 +738,8 @@ def process_unquantized_moe_weights(
             requant_block_size = (int(requant_block_size_from_env)
                                   if requant_block_size_from_env else None)
         moe_logging_str = (
-            f"[MoE requantization]: re-quantizing MoE weights to {desired_quant_dtype}"
-        )
+            f"[MoE requantization]: re-quantizing MoE weights to "
+            f"{desired_quant_dtype}")
         if requant_block_size is not None:
             moe_logging_str += f" with block size {requant_block_size}"
         logger.info_once(moe_logging_str)
@@ -771,4 +777,5 @@ def process_unquantized_moe_weights(
         moe_backend=moe_backend,
         w13_reorder_size=w13_reorder_size,
         w13_interleave=w13_interleave,
+        disable_weight_requantization=envs.DISABLE_WEIGHT_REQUANTIZATION,
     )

--- a/tpu_inference/layers/common/process_weights/moe_weights.py
+++ b/tpu_inference/layers/common/process_weights/moe_weights.py
@@ -677,7 +677,7 @@ def process_fp8_moe_weights(
                                   if requant_block_size_from_env else None)
 
         moe_logging_str = (
-            f"[MoE requantization]: re-quantizing MoE weights to "
+            "[MoE requantization]: re-quantizing MoE weights to "
             f"{desired_quant_dtype}")
         if requant_block_size is not None:
             moe_logging_str += f" with block size {requant_block_size}"
@@ -714,9 +714,10 @@ def process_fp8_moe_weights(
     )
 
 
-@jax.jit(static_argnames=('activation', 'moe_backend'))
+@jax.jit(static_argnames=('mesh', 'activation', 'moe_backend'))
 def process_unquantized_moe_weights(
     *,
+    mesh: Mesh,
     moe_backend: MoEBackend,
     activation: MoEActivation,
     w13_weight: jax.Array,
@@ -738,7 +739,7 @@ def process_unquantized_moe_weights(
             requant_block_size = (int(requant_block_size_from_env)
                                   if requant_block_size_from_env else None)
         moe_logging_str = (
-            f"[MoE requantization]: re-quantizing MoE weights to "
+            "[MoE requantization]: re-quantizing MoE weights to "
             f"{desired_quant_dtype}")
         if requant_block_size is not None:
             moe_logging_str += f" with block size {requant_block_size}"
@@ -767,9 +768,7 @@ def process_unquantized_moe_weights(
         )
 
     w13_interleave = activation == MoEActivation.SWIGLUOAI
-    # Inside jax.jit only the abstract mesh is accessible; that's enough since
-    # get_mesh_shape_product only needs axis sizes.
-    w13_reorder_size = get_mesh_shape_product(jax.sharding.get_abstract_mesh(),
+    w13_reorder_size = get_mesh_shape_product(mesh,
                                               ShardingAxisName.MLP_TENSOR)
 
     return process_moe_weights(

--- a/tpu_inference/layers/common/process_weights/moe_weights.py
+++ b/tpu_inference/layers/common/process_weights/moe_weights.py
@@ -18,6 +18,7 @@ import jax.numpy as jnp
 from jax.experimental.layout import Layout, with_layout_constraint
 from jax.sharding import Mesh, NamedSharding, PartitionSpec
 from torchax.tensor import Tensor
+from vllm.model_executor.layers.fused_moe.activation import MoEActivation
 
 import tpu_inference.envs as envs
 from tpu_inference.layers.common.moe import MoEBackend
@@ -673,21 +674,69 @@ def process_fp8_moe_weights(
                                   if requant_block_size_from_env else None)
 
         moe_logging_str = (
-            "[MoE requantization]: re-quantizing MoE weights to "
-            f"{desired_quant_dtype}")
+            f"[MoE requantization]: re-quantizing MoE weights to {desired_quant_dtype}"
+        )
         if requant_block_size is not None:
             moe_logging_str += f" with block size {requant_block_size}"
-        logger.info(moe_logging_str)
+        logger.info_once(moe_logging_str)
 
         # Dequantize fp8 2d block quantized weights into fp32.
         w13_weight = dequantize_tensor(w13_weight,
-                                       w13_weight_scale, (1, 2),
-                                       jnp.float32,
-                                       block_size=weight_block_size)
+                                        w13_weight_scale, (1, 2),
+                                        jnp.float32,
+                                        block_size=weight_block_size)
         w2_weight = dequantize_tensor(w2_weight,
-                                      w2_weight_scale, (1, 2),
-                                      jnp.float32,
-                                      block_size=weight_block_size)
+                                        w2_weight_scale, (1, 2),
+                                        jnp.float32,
+                                        block_size=weight_block_size)
+
+        w13_interleave = activation == "swigluoai"
+        w13_reorder_size = get_mesh_shape_product(mesh,
+                                                ShardingAxisName.MLP_TENSOR)
+        weights = quantize_moe_weights(
+            FusedMoEWeights(
+                w13_weight=w13_weight,
+                w13_weight_scale=None,
+                w13_bias=None,
+                w2_weight=w2_weight,
+                w2_weight_scale=None,
+                w2_bias=None,
+            ),
+            desired_quant_dtype,
+            requant_block_size,
+        )
+    return process_moe_weights(
+        weights,
+        moe_backend=moe_backend,
+        w13_reorder_size=w13_reorder_size,
+        w13_interleave=w13_interleave,
+    )
+
+
+@jax.jit(static_argnames=('activation', 'moe_backend'))
+def process_unquantized_moe_weights(
+    *,
+    moe_backend: MoEBackend,
+    activation: MoEActivation,
+    w13_weight: jax.Array,
+    w13_bias: jax.Array | None,
+    w2_weight: jax.Array,
+    w2_bias: jax.Array | None,
+) -> FusedMoEWeights:
+    """Jit'ed version to process unquantized moe weights. See `process_moe_weights` for details.
+    """
+    if desired_quant_dtype_from_env := envs.MOE_REQUANTIZE_WEIGHT_DTYPE:
+        desired_quant_dtype = to_jax_dtype(desired_quant_dtype_from_env)
+        requant_block_size = None
+        if requant_block_size_from_env := envs.MOE_REQUANTIZE_BLOCK_SIZE:
+            requant_block_size = (int(requant_block_size_from_env)
+                                  if requant_block_size_from_env else None)
+        moe_logging_str = (
+            f"[MoE requantization]: re-quantizing MoE weights to {desired_quant_dtype}"
+        )
+        if requant_block_size is not None:
+            moe_logging_str += f" with block size {requant_block_size}"
+        logger.info_once(moe_logging_str)
 
         weights = quantize_moe_weights(
             FusedMoEWeights(
@@ -701,11 +750,23 @@ def process_fp8_moe_weights(
             desired_quant_dtype,
             requant_block_size,
         )
+    else:
+        weights = FusedMoEWeights(
+            w13_weight=w13_weight,
+            w13_weight_scale=None,
+            w13_bias=w13_bias,
+            w2_weight=w2_weight,
+            w2_weight_scale=None,
+            w2_bias=w2_bias,
+        )
+
+    w13_interleave = activation == MoEActivation.SWIGLUOAI
+    w13_reorder_size = get_mesh_shape_product(jax.sharding.get_mesh(),
+                                              ShardingAxisName.MLP_TENSOR)
 
     return process_moe_weights(
         weights,
         moe_backend=moe_backend,
         w13_reorder_size=w13_reorder_size,
         w13_interleave=w13_interleave,
-        disable_weight_requantization=envs.DISABLE_WEIGHT_REQUANTIZATION,
     )

--- a/tpu_inference/layers/common/process_weights/moe_weights.py
+++ b/tpu_inference/layers/common/process_weights/moe_weights.py
@@ -761,7 +761,9 @@ def process_unquantized_moe_weights(
         )
 
     w13_interleave = activation == MoEActivation.SWIGLUOAI
-    w13_reorder_size = get_mesh_shape_product(jax.sharding.get_mesh(),
+    # Inside jax.jit only the abstract mesh is accessible; that's enough since
+    # get_mesh_shape_product only needs axis sizes.
+    w13_reorder_size = get_mesh_shape_product(jax.sharding.get_abstract_mesh(),
                                               ShardingAxisName.MLP_TENSOR)
 
     return process_moe_weights(

--- a/tpu_inference/layers/common/quantization/unquantized.py
+++ b/tpu_inference/layers/common/quantization/unquantized.py
@@ -16,17 +16,10 @@ from typing import Optional, Sequence
 
 import jax
 from jax import numpy as jnp
-from jax.sharding import Mesh
-from vllm.model_executor.layers.fused_moe.activation import MoEActivation
 
-from tpu_inference.layers.common.moe import MoEBackend
-from tpu_inference.layers.common.process_weights.moe_weights import (
-    FusedMoEWeights, process_moe_weights)
 from tpu_inference.layers.common.quantization.configs import QuantLinearConfig
-from tpu_inference.layers.common.sharding import ShardingAxisName
 from tpu_inference.layers.common.utils import \
     slice_sharded_tensor_for_concatenation
-from tpu_inference.utils import get_mesh_shape_product
 
 
 class UnquantizedLinearMethod:
@@ -93,35 +86,3 @@ class UnquantizedLinearMethod:
             outs.append(out)
         out = jnp.concatenate(outs, axis=-1)
         return out
-
-
-@jax.jit(static_argnames=('mesh', 'activation', 'moe_backend'))
-def process_unquantized_moe_weights(
-    *,
-    mesh: Mesh,
-    moe_backend: MoEBackend,
-    activation: MoEActivation,
-    w13_weight: jax.Array,
-    w13_bias: jax.Array | None,
-    w2_weight: jax.Array,
-    w2_bias: jax.Array | None,
-) -> FusedMoEWeights:
-    """Jit'ed version to process unquantized moe weights. See `process_moe_weights` for details.
-    """
-    w13_interleave = activation == MoEActivation.SWIGLUOAI
-    w13_reorder_size = get_mesh_shape_product(mesh,
-                                              ShardingAxisName.MLP_TENSOR)
-
-    return process_moe_weights(
-        FusedMoEWeights(
-            w13_weight=w13_weight,
-            w13_weight_scale=None,
-            w13_bias=w13_bias,
-            w2_weight=w2_weight,
-            w2_weight_scale=None,
-            w2_bias=w2_bias,
-        ),
-        moe_backend=moe_backend,
-        w13_reorder_size=w13_reorder_size,
-        w13_interleave=w13_interleave,
-    )

--- a/tpu_inference/layers/jax/quantization/unquantized.py
+++ b/tpu_inference/layers/jax/quantization/unquantized.py
@@ -133,7 +133,9 @@ class UnquantizedFusedMoEMethod(QuantizeMethodBase):
             w13_val = jnp.concatenate([w_gate, w_up], axis=1)
             del w_gate, w_up
 
+            mesh = jax.sharding.get_mesh()
             weights = process_unquantized_moe_weights(
+                mesh=mesh,
                 moe_backend=layer.moe_backend,
                 activation=layer.activation,
                 w13_weight=w13_val,
@@ -144,7 +146,7 @@ class UnquantizedFusedMoEMethod(QuantizeMethodBase):
 
             sharded_weights = shard_moe_weights(weights,
                                                 moe_backend=layer.moe_backend,
-                                                mesh=jax.sharding.get_mesh())
+                                                mesh=mesh)
 
             layer.kernel_gating_upproj_EDF = nnx.Param(
                 sharded_weights.w13_weight)

--- a/tpu_inference/layers/jax/quantization/unquantized.py
+++ b/tpu_inference/layers/jax/quantization/unquantized.py
@@ -190,6 +190,8 @@ class UnquantizedFusedMoEMethod(QuantizeMethodBase):
 
             w13_weight = layer.kernel_gating_upproj_E2DF.value if layer.moe_backend == MoEBackend.FUSED_MOE else layer.kernel_gating_upproj_EDF.value
             w2_weight = layer.kernel_down_proj_EFD.value
+            # Although this is UnquantizedMethod, when MOE_REQUANTIZE_WEIGHT_DTYPE
+            # is set, the weights are quantized on the fly and scales are produced
             w13_scale = getattr(layer, "kernel_gating_upproj_EDF_weight_scale",
                                 None)
             w2_scale = getattr(layer, "kernel_down_proj_EFD_weight_scale",
@@ -197,12 +199,10 @@ class UnquantizedFusedMoEMethod(QuantizeMethodBase):
             # TODO (jacobplatin/bzgoogle): we should support bias
             weights = FusedMoEWeights(
                 w13_weight=w13_weight,
-                w13_weight_scale=w13_scale.value
-                if w13_scale is not None else None,
+                w13_weight_scale=getattr(w13_scale, "value", None),
                 w13_bias=None,
                 w2_weight=w2_weight,
-                w2_weight_scale=w2_scale.value
-                if w2_scale is not None else None,
+                w2_weight_scale=getattr(w2_scale, "value", None),
                 w2_bias=None,
             )
         elif layer.moe_backend in [

--- a/tpu_inference/layers/jax/quantization/unquantized.py
+++ b/tpu_inference/layers/jax/quantization/unquantized.py
@@ -23,7 +23,8 @@ from jax.sharding import PartitionSpec as P
 
 from tpu_inference.layers.common.moe import MoEBackend, moe_apply
 from tpu_inference.layers.common.process_weights.moe_weights import (
-    FusedMoEWeights, UnfusedMoEWeights, shard_moe_weights)
+    FusedMoEWeights, UnfusedMoEWeights, process_unquantized_moe_weights,
+    shard_moe_weights)
 from tpu_inference.layers.common.quantization import unquantized as jax_common
 from tpu_inference.layers.common.quantization.configs import QuantLinearConfig
 from tpu_inference.layers.jax import JaxModule
@@ -31,7 +32,10 @@ from tpu_inference.layers.jax.linear import JaxEinsum
 from tpu_inference.layers.jax.moe.moe import JaxMoE
 from tpu_inference.layers.jax.quantization import QuantizeMethodBase
 from tpu_inference.layers.jax.quantization.configs import QuantizationConfig
+from tpu_inference.logger import init_logger
 from tpu_inference.models.jax.utils.weight_utils import shard_put
+
+logger = init_logger(__name__)
 
 
 class UnquantizedLinearMethod(QuantizeMethodBase,
@@ -129,8 +133,7 @@ class UnquantizedFusedMoEMethod(QuantizeMethodBase):
             w13_val = jnp.concatenate([w_gate, w_up], axis=1)
             del w_gate, w_up
 
-            weights = jax_common.process_unquantized_moe_weights(
-                mesh=jax.sharding.get_mesh(),
+            weights = process_unquantized_moe_weights(
                 moe_backend=layer.moe_backend,
                 activation=layer.activation,
                 w13_weight=w13_val,
@@ -146,6 +149,17 @@ class UnquantizedFusedMoEMethod(QuantizeMethodBase):
             layer.kernel_gating_upproj_EDF = nnx.Param(
                 sharded_weights.w13_weight)
             layer.kernel_down_proj_EFD = nnx.Param(sharded_weights.w2_weight)
+
+            # When MOE_REQUANTIZE_WEIGHT_DTYPE quantizes the bf16 weights at
+            # load time, scales are produced by process_unquantized_moe_weights
+            # and need to be stored alongside the weights so apply_jax can pass
+            # them to the MoE kernel.
+            if sharded_weights.w13_weight_scale is not None:
+                layer.kernel_gating_upproj_EDF_weight_scale = nnx.Param(
+                    sharded_weights.w13_weight_scale)
+            if sharded_weights.w2_weight_scale is not None:
+                layer.kernel_down_proj_EFD_weight_scale = nnx.Param(
+                    sharded_weights.w2_weight_scale)
 
             del weights
             del w13_val
@@ -176,13 +190,19 @@ class UnquantizedFusedMoEMethod(QuantizeMethodBase):
 
             w13_weight = layer.kernel_gating_upproj_E2DF.value if layer.moe_backend == MoEBackend.FUSED_MOE else layer.kernel_gating_upproj_EDF.value
             w2_weight = layer.kernel_down_proj_EFD.value
+            w13_scale = getattr(layer, "kernel_gating_upproj_EDF_weight_scale",
+                                None)
+            w2_scale = getattr(layer, "kernel_down_proj_EFD_weight_scale",
+                               None)
             # TODO (jacobplatin/bzgoogle): we should support bias
             weights = FusedMoEWeights(
                 w13_weight=w13_weight,
-                w13_weight_scale=None,
+                w13_weight_scale=w13_scale.value
+                if w13_scale is not None else None,
                 w13_bias=None,
                 w2_weight=w2_weight,
-                w2_weight_scale=None,
+                w2_weight_scale=w2_scale.value
+                if w2_scale is not None else None,
                 w2_bias=None,
             )
         elif layer.moe_backend in [

--- a/tpu_inference/layers/vllm/quantization/unquantized.py
+++ b/tpu_inference/layers/vllm/quantization/unquantized.py
@@ -37,7 +37,7 @@ from tpu_inference.layers.common.process_weights.linear_weights import (
     LinearWeights, process_linear_weights, shard_linear_weights,
     to_parameter_list)
 from tpu_inference.layers.common.process_weights.moe_weights import (
-    FusedMoEWeights, shard_moe_weights)
+    FusedMoEWeights, process_unquantized_moe_weights, shard_moe_weights)
 from tpu_inference.layers.common.quant_methods import UNQUANTIZED
 from tpu_inference.layers.common.quantization import \
     unquantized as common_unquantized
@@ -342,14 +342,12 @@ class VllmUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod,
         else:
             w13_bias = w2_bias = None
 
-        weights = common_unquantized.process_unquantized_moe_weights(
-            mesh=self.mesh,
-            moe_backend=self.moe_backend,
-            activation=layer.activation,
-            w13_weight=w13_weight,
-            w13_bias=w13_bias,
-            w2_weight=w2_weight,
-            w2_bias=w2_bias)
+        weights = process_unquantized_moe_weights(moe_backend=self.moe_backend,
+                                                  activation=layer.activation,
+                                                  w13_weight=w13_weight,
+                                                  w13_bias=w13_bias,
+                                                  w2_weight=w2_weight,
+                                                  w2_bias=w2_bias)
 
         del w13_weight, w2_weight, w13_bias, w2_bias
 

--- a/tpu_inference/layers/vllm/quantization/unquantized.py
+++ b/tpu_inference/layers/vllm/quantization/unquantized.py
@@ -342,7 +342,8 @@ class VllmUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod,
         else:
             w13_bias = w2_bias = None
 
-        weights = process_unquantized_moe_weights(moe_backend=self.moe_backend,
+        weights = process_unquantized_moe_weights(mesh=self.mesh,
+                                                  moe_backend=self.moe_backend,
                                                   activation=layer.activation,
                                                   w13_weight=w13_weight,
                                                   w13_bias=w13_bias,


### PR DESCRIPTION
# Description

The env var was introduced in #1756 for FP8, this PR extends to unquantized model, which (if set) quantize MoE weights to target dtype on the fly.

# Tests

1. unit test
2.
```bash
MOE_REQUANTIZE_WEIGHT_DTYPE=float8_e4m3fn USE_BATCHED_RPA_KERNEL=1 MODEL_IMPL_TYPE=flax_nnx vllm \
    serve google/gemma-4-26B-A4B-it \
    --max-model-len=16384 \
    --max-num-seqs=320 \
    --tensor-parallel-size 2 \
    --max-num-batched-tokens 4096 \
    --no-enable-prefix-caching \
    --kv-cache-dtype=fp8
```

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
