### PR TITLE
add qwen3.5 397b prefill benchmark

### DIFF
--- a/.buildkite/benchmark/cases/Qwen3.5_397B_prefill.json
+++ b/.buildkite/benchmark/cases/Qwen3.5_397B_prefill.json
@@ -1,0 +1,299 @@
+{
+  "global_env": {
+    "GCP_PROJECT_ID": "cloud-tpu-inference-test",
+    "GCS_BUCKET": "vllm-cb-storage2",
+    "GCP_INSTANCE_ID": "vllm-bm-inst",
+    "GCP_DATABASE_ID": "vllm-bm-bk-runs",
+    "SERVER_WAIT_MINS": 180
+  },
+  "benchmark_cases": [
+    {
+      "case_name": "Qwen3_5-397B-Prefill-GBS1",
+      "ci_queue": [
+        "tpu_v7x_8_queue"
+      ],
+      "env": {
+        "MODELTAG": "NEW",
+        "EXPECTED_ETEL": 3600000,
+        "INPUT_LEN": 8192,
+        "OUTPUT_LEN": 1
+      },
+      "server_command_options": {
+        "command_type": "vllm_serve",
+        "env": {
+          "VLLM_USE_V1": "1",
+          "MODEL_IMPL_TYPE": "vllm",
+          "NEW_MODEL_DESIGN": "1"
+        },
+        "args": {
+          "model": "Qwen/Qwen3.5-397B-A17B-FP8",
+          "max-num-seqs": 1,
+          "max-num-batched-tokens": 8192,
+          "tensor-parallel-size": {
+            "v7x-8": 8
+          },
+          "max-model-len": 10240,
+          "kv-cache-dtype": "fp8",
+          "gpu-memory-utilization": 0.9,
+          "enable-expert-parallel": true,
+          "async-scheduling": true
+        }
+      },
+      "client_command_options": {
+        "command_type": "vllm_bench_serve",
+        "args": {
+          "model": "Qwen/Qwen3.5-397B-A17B-FP8",
+          "backend": "vllm",
+          "request-rate": "inf",
+          "dataset-name": "random",
+          "random-input-len": 8192,
+          "random-output-len": 1,
+          "num-prompts": 1000,
+          "percentile-metrics": "ttft,e2el",
+          "ignore-eos": true,
+          "max-concurrency": 1
+        }
+      }
+    },
+    {
+      "case_name": "Qwen3_5-397B-Prefill-GBS2",
+      "ci_queue": [
+        "tpu_v7x_8_queue"
+      ],
+      "env": {
+        "MODELTAG": "NEW",
+        "EXPECTED_ETEL": 3600000,
+        "INPUT_LEN": 8192,
+        "OUTPUT_LEN": 1
+      },
+      "server_command_options": {
+        "command_type": "vllm_serve",
+        "env": {
+          "VLLM_USE_V1": "1",
+          "MODEL_IMPL_TYPE": "vllm",
+          "NEW_MODEL_DESIGN": "1"
+        },
+        "args": {
+          "model": "Qwen/Qwen3.5-397B-A17B-FP8",
+          "max-num-seqs": 2,
+          "max-num-batched-tokens": 16384,
+          "tensor-parallel-size": {
+            "v7x-8": 8
+          },
+          "max-model-len": 10240,
+          "kv-cache-dtype": "fp8",
+          "gpu-memory-utilization": 0.85,
+          "enable-expert-parallel": true,
+          "async-scheduling": true
+        }
+      },
+      "client_command_options": {
+        "command_type": "vllm_bench_serve",
+        "args": {
+          "model": "Qwen/Qwen3.5-397B-A17B-FP8",
+          "backend": "vllm",
+          "request-rate": "inf",
+          "dataset-name": "random",
+          "random-input-len": 8192,
+          "random-output-len": 1,
+          "num-prompts": 1000,
+          "percentile-metrics": "ttft,e2el",
+          "ignore-eos": true,
+          "max-concurrency": 2
+        }
+      }
+    },
+    {
+      "case_name": "Qwen3_5-397B-Prefill-GBS4",
+      "ci_queue": [
+        "tpu_v7x_8_queue"
+      ],
+      "env": {
+        "MODELTAG": "NEW",
+        "EXPECTED_ETEL": 3600000,
+        "INPUT_LEN": 8192,
+        "OUTPUT_LEN": 1
+      },
+      "server_command_options": {
+        "command_type": "vllm_serve",
+        "env": {
+          "VLLM_USE_V1": "1",
+          "MODEL_IMPL_TYPE": "vllm",
+          "NEW_MODEL_DESIGN": "1"
+        },
+        "args": {
+          "model": "Qwen/Qwen3.5-397B-A17B-FP8",
+          "max-num-seqs": 4,
+          "max-num-batched-tokens": 32768,
+          "tensor-parallel-size": {
+            "v7x-8": 8
+          },
+          "max-model-len": 10240,
+          "kv-cache-dtype": "fp8",
+          "gpu-memory-utilization": 0.75,
+          "enable-expert-parallel": true,
+          "async-scheduling": true
+        }
+      },
+      "client_command_options": {
+        "command_type": "vllm_bench_serve",
+        "args": {
+          "model": "Qwen/Qwen3.5-397B-A17B-FP8",
+          "backend": "vllm",
+          "request-rate": "inf",
+          "dataset-name": "random",
+          "random-input-len": 8192,
+          "random-output-len": 1,
+          "num-prompts": 1000,
+          "percentile-metrics": "ttft,e2el",
+          "ignore-eos": true,
+          "max-concurrency": 4
+        }
+      }
+    },
+    {
+      "case_name": "Qwen3_5-397B-Prefill-GBS8",
+      "ci_queue": [
+        "tpu_v7x_8_queue"
+      ],
+      "env": {
+        "MODELTAG": "NEW",
+        "EXPECTED_ETEL": 1000000,
+        "INPUT_LEN": 8192,
+        "OUTPUT_LEN": 1
+      },
+      "server_command_options": {
+        "command_type": "vllm_serve",
+        "env": {
+          "VLLM_USE_V1": "1",
+          "MODEL_IMPL_TYPE": "vllm",
+          "NEW_MODEL_DESIGN": "1"
+        },
+        "args": {
+          "model": "Qwen/Qwen3.5-397B-A17B-FP8",
+          "max-num-seqs": 8,
+          "max-num-batched-tokens": 65536,
+          "tensor-parallel-size": {
+            "v7x-8": 8
+          },
+          "max-model-len": 10240,
+          "kv-cache-dtype": "fp8",
+          "gpu-memory-utilization": 0.55,
+          "enable-expert-parallel": true,
+          "async-scheduling": true
+        }
+      },
+      "client_command_options": {
+        "command_type": "vllm_bench_serve",
+        "args": {
+          "model": "Qwen/Qwen3.5-397B-A17B-FP8",
+          "backend": "vllm",
+          "request-rate": "inf",
+          "dataset-name": "random",
+          "random-input-len": 8192,
+          "random-output-len": 1,
+          "num-prompts": 1000,
+          "percentile-metrics": "ttft,e2el",
+          "ignore-eos": true,
+          "max-concurrency": 8
+        }
+      }
+    },
+    {
+      "case_name": "Qwen3_5-397B-Prefill-GBS16",
+      "ci_queue": [
+        "tpu_v7x_8_queue"
+      ],
+      "env": {
+        "MODELTAG": "NEW",
+        "EXPECTED_ETEL": 1000000,
+        "INPUT_LEN": 8192,
+        "OUTPUT_LEN": 1
+      },
+      "server_command_options": {
+        "command_type": "vllm_serve",
+        "env": {
+          "VLLM_USE_V1": "1",
+          "MODEL_IMPL_TYPE": "vllm",
+          "NEW_MODEL_DESIGN": "1"
+        },
+        "args": {
+          "model": "Qwen/Qwen3.5-397B-A17B-FP8",
+          "max-num-seqs": 16,
+          "max-num-batched-tokens": 65536,
+          "tensor-parallel-size": {
+            "v7x-8": 8
+          },
+          "max-model-len": 10240,
+          "kv-cache-dtype": "fp8",
+          "gpu-memory-utilization": 0.55,
+          "enable-expert-parallel": true,
+          "async-scheduling": true
+        }
+      },
+      "client_command_options": {
+        "command_type": "vllm_bench_serve",
+        "args": {
+          "model": "Qwen/Qwen3.5-397B-A17B-FP8",
+          "backend": "vllm",
+          "request-rate": "inf",
+          "dataset-name": "random",
+          "random-input-len": 8192,
+          "random-output-len": 1,
+          "num-prompts": 1000,
+          "percentile-metrics": "ttft,e2el",
+          "ignore-eos": true,
+          "max-concurrency": 16
+        }
+      }
+    },
+    {
+      "case_name": "Qwen3_5-397B-Prefill-GBS32",
+      "ci_queue": [
+        "tpu_v7x_8_queue"
+      ],
+      "env": {
+        "MODELTAG": "NEW",
+        "EXPECTED_ETEL": 1000000,
+        "INPUT_LEN": 8192,
+        "OUTPUT_LEN": 1
+      },
+      "server_command_options": {
+        "command_type": "vllm_serve",
+        "env": {
+          "VLLM_USE_V1": "1",
+          "MODEL_IMPL_TYPE": "vllm",
+          "NEW_MODEL_DESIGN": "1"
+        },
+        "args": {
+          "model": "Qwen/Qwen3.5-397B-A17B-FP8",
+          "max-num-seqs": 16,
+          "max-num-batched-tokens": 65536,
+          "tensor-parallel-size": {
+            "v7x-8": 8
+          },
+          "max-model-len": 10240,
+          "kv-cache-dtype": "fp8",
+          "gpu-memory-utilization": 0.55,
+          "enable-expert-parallel": true,
+          "async-scheduling": true
+        }
+      },
+      "client_command_options": {
+        "command_type": "vllm_bench_serve",
+        "args": {
+          "model": "Qwen/Qwen3.5-397B-A17B-FP8",
+          "backend": "vllm",
+          "request-rate": "inf",
+          "dataset-name": "random",
+          "random-input-len": 8192,
+          "random-output-len": 1,
+          "num-prompts": 1000,
+          "percentile-metrics": "ttft,e2el",
+          "ignore-eos": true,
+          "max-concurrency": 32
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This PR introduces the benchmarking configurations for the Qwen3.5-397B FP8 model on `v7x-8` TPUs. The tests focus on prefill-only performance across various batch sizes (BS=1 to BS=32). 

To ensure stable server turnup and avoid XLA `CompileTimeHbmOom`, the configurations dynamically adjust hardware utilization and chunking limits based on the target concurrency.

#### **1. Dynamic Parameters by Target Batch Size**
The following table outlines the key parameters that scale with the target workload. 

| Target BS | Client: `max-concurrency` | Server: `max-num-seqs` | Server: `max-num-batched-tokens` | Server: `gpu-memory-utilization` |
| :--- | :--- | :--- | :--- | :--- |
| **BS=1** | 1 | 1 | 8192(8k) | 0.9 |
| **BS=2** | 2 | 2 | 16,384(2*8k) | 0.85 |
| **BS=4** | 4 | 4 | 32,768(4*8k) | 0.75 |
| **BS=8** | 8 | 8 | 65,536(8*8k) | 0.55 |
| **BS=16*** | 16 | 16 | **65,536(8*8k)** | 0.55 |
| **BS=32***| **32** | **16** | **65,536(8*8k)** | 0.55 |

> ***Design Note on BS=16 and BS=32 Setup:** 
> For the BS=16 case, the `max-num-batched-tokens` is capped at BS=8 limits to avoid OOM error. For the BS=32 case, the server's `max-num-seqs` and `max-num-batched-tokens` are intentionally capped at the BS=16 limits (16 and 65,536, respectively). This is a deliberate design choice to prevent the underlying XLA compiler from attempting to build an overly large, OOM-inducing computational graph during server initialization. By pushing `max-concurrency=32` exclusively from the client side, we safely simulate the BS=16, =32 high-load environment wtih the required v7x chips count(4).*

#### **2. Global / Static Parameters**
The following arguments remain constant across all test cases to maintain consistent evaluation baselines:

**Model & Hardware Architecture:**
*   **Model:** `Qwen/Qwen3.5-397B-A17B-FP8`
*   **Tensor Parallel Size:** `8` (Targeting single-host `v7x-8`)
*   **KV Cache Dtype:** `fp8`
*   **Expert Parallel:** Enabled (`enable-expert-parallel: true`)

**Workload Characteristics (Prefill-Only / Decode-Only isolated):**
*   **Input Length:** `8192` (`random-input-len`)
*   **Output Length:** `1` (`random-output-len`)
*   **Dataset:** `random`
*   **Max Model Length:** `10240`

**Engine Configuration:**
*   **Engine Version:** vLLM V1 (`VLLM_USE_V1=1`, `NEW_MODEL_DESIGN=1`)
*   **Async Scheduling:** Enabled (`async-scheduling: true`)