### PR TITLE
Add support for bucketized req size for attention metadata

### DIFF
--- a/tests/runner/test_tpu_runner_dp.py
+++ b/tests/runner/test_tpu_runner_dp.py
@@ -298,8 +298,9 @@ class TestTPUJaxRunnerDPInputsLightweight:
             (req_ids_dp, req_indices_dp, num_scheduled_tokens_per_dp_rank,
              scheduled_tokens_per_dp_rank, num_req_per_dp_rank,
              padded_num_scheduled_tokens_per_dp_rank, padded_num_reqs,
-             padded_total_num_scheduled_tokens, padded_num_reqs_per_dp_rank,
-             logits_indices_selector, max_num_reqs_per_dp_rank) = result
+             attn_padded_num_reqs, padded_total_num_scheduled_tokens,
+             padded_num_reqs_per_dp_rank, logits_indices_selector,
+             max_num_reqs_per_dp_rank) = result
 
             # 1. req_ids_dp: Dictionary mapping DP rank to request IDs
             assert isinstance(req_ids_dp, dict)
@@ -332,6 +333,9 @@ class TestTPUJaxRunnerDPInputsLightweight:
 
             # 7. padded_num_reqs: Total padded requests across all ranks
             assert padded_num_reqs == 32  # 2 DP ranks * 16 padded reqs per rank
+
+            # By default attn_padded_num_reqs is the same as padded_num_reqs
+            assert attn_padded_num_reqs == 32
 
             # 8. padded_total_num_scheduled_tokens: Total padded tokens across all ranks
             assert padded_total_num_scheduled_tokens == 32  # 2 DP ranks * 16 padded tokens per rank
@@ -372,8 +376,9 @@ class TestTPUJaxRunnerDPInputsLightweight:
             (req_ids_dp, req_indices_dp, num_scheduled_tokens_per_dp_rank,
              scheduled_tokens_per_dp_rank, num_req_per_dp_rank,
              padded_num_scheduled_tokens_per_dp_rank, padded_num_reqs,
-             padded_total_num_scheduled_tokens, padded_num_reqs_per_dp_rank,
-             logits_indices_selector, max_num_reqs_per_dp_rank) = result
+             attn_padded_num_reqs, padded_total_num_scheduled_tokens,
+             padded_num_reqs_per_dp_rank, logits_indices_selector,
+             max_num_reqs_per_dp_rank) = result
 
             # 1. req_ids_dp
             assert isinstance(req_ids_dp, dict)
@@ -406,6 +411,9 @@ class TestTPUJaxRunnerDPInputsLightweight:
 
             # 7. padded_num_reqs
             assert padded_num_reqs == 32  # 2 DP ranks * 16 padded reqs per rank
+
+            # By default attn_padded_num_reqs is the same as padded_num_reqs
+            assert attn_padded_num_reqs == 32
 
             # 8. padded_total_num_scheduled_tokens
             assert padded_total_num_scheduled_tokens == 32  # 2 DP ranks * 16 padded tokens per rank
@@ -446,7 +454,7 @@ class TestTPUJaxRunnerDPInputsLightweight:
 
             result = self.runner._prepare_input_metadata(scheduler_output)
 
-            (req_ids_dp, req_indices_dp, _, _, _, _, _, _, _,
+            (req_ids_dp, req_indices_dp, _, _, _, _, _, _, _, _,
              logits_indices_selector, _) = result
 
             # Verify request distribution

--- a/tpu_inference/envs.py
+++ b/tpu_inference/envs.py
@@ -32,6 +32,8 @@ if TYPE_CHECKING:
     REQUANTIZE_WEIGHT_DTYPE: str = "float8_e4m3fn"
     MOE_REQUANTIZE_BLOCK_SIZE: int | None = None
     MOE_REQUANTIZE_WEIGHT_DTYPE: str = ""
+    ATTN_BUCKETIZED_NUM_REQS: bool = False
+    ATTN_CUSTOM_NUM_REQS_BUCKETS: list[int] = []
     LAYOUT_Q_PROJ_AS_NDH: bool = False
     USE_JAX_PROFILER_SERVER: bool = False
     JAX_PROFILER_SERVER_PORT: int = 9999
@@ -150,6 +152,25 @@ def env_str_list(env_name: str) -> Callable[[], list[str]]:
     return _get_str_list_env
 
 
+def env_int_list(env_name: str) -> Callable[[], list[int]]:
+    """
+    Accepts a comma-separated string and returns a list of strings.
+
+    Args:
+        env_name: Name of the environment variable
+        default: Default list of strings if not set
+    """
+
+    def _get_int_list_env() -> list[int]:
+        value = os.getenv(env_name)
+        if value is None or value == "":
+            return []
+
+        return [int(v.strip()) for v in value.split(",")]
+
+    return _get_int_list_env
+
+
 environment_variables: dict[str, Callable[[], Any]] = {
     # JAX platform selection (e.g., "tpu", "cpu", "proxy", "proxy,cpu")
     "JAX_PLATFORMS":
@@ -235,6 +256,18 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "MOE_REQUANTIZE_BLOCK_SIZE":
     lambda: int(block_size)
     if (block_size := os.getenv("MOE_REQUANTIZE_BLOCK_SIZE")) else None,
+    # By default, it only use max_reqs for attentions. But if set true, it
+    # will precompile max_reqs to power-of-twos between min and max reqs,
+    # and attention will have the num_reqs closer to actual num_reqs. This
+    # makes attention more efficient for num_reqs less than max_reqs but at
+    # the cost of longer model precompilation time.
+    "ATTN_BUCKETIZED_NUM_REQS":
+    env_bool("ATTN_BUCKETIZED_NUM_REQS"),
+    # ATTN_BUCKETIZED_NUM_REQS set to true but the compilation time is too
+    # long, user can set a list of custom buckets (num_reqs to precompile)
+    # separated by comma. The max_reqs will alwasy be added to the buckets
+    "ATTN_CUSTOM_NUM_REQS_BUCKETS":
+    env_int_list("ATTN_CUSTOM_NUM_REQS_BUCKETS"),
     # dictates whether to layout q-proj as NDH (q-heads, model dim, head dim)
     # or DNH (model dim, q-heads, head dim), which is the default (False)
     "LAYOUT_Q_PROJ_AS_NDH":

--- a/tpu_inference/layers/common/attention_metadata.py
+++ b/tpu_inference/layers/common/attention_metadata.py
@@ -29,7 +29,7 @@ import jax
         "request_distribution",
         "mamba_state_indices",
     ],
-    meta_fields=[],
+    meta_fields=["padded_num_reqs"],
     drop_fields=["query_start_loc_cpu", "seq_lens_cpu"],
 )
 @dataclass
@@ -53,6 +53,13 @@ class AttentionMetadata(object):
     # None for models without mamba layers; pure-mamba models would also
     # use this field, only hybrid models exercise it today.
     mamba_state_indices: jax.Array | None = None
+
+    # The actual number of requests padded to the compiled buckets. The bucket
+    # contains only max_reqs by default to reduce model precompilation time.
+    # If env var ATTN_BUCKETIZED_NUM_REQS=true, the buckets are the
+    # power of 2 between min and max requests.
+    # Env var ATTN_CUSTOM_NUM_REQS_BUCKETS can manually override the buckets.
+    padded_num_reqs: int = -1
 
     query_start_loc_cpu: Any = field(init=False)
     seq_lens_cpu: Any = field(init=False)

--- a/tpu_inference/layers/vllm/custom_ops/gdn_attention_op.py
+++ b/tpu_inference/layers/vllm/custom_ops/gdn_attention_op.py
@@ -90,6 +90,8 @@ def gdn_attention_core_tpu(
     key_dim = n_kq * d_k
     value_dim = n_v * d_v
     tp_size = get_mesh_shape_product(mesh, ShardingAxisName.ATTN_HEAD)
+    dp_size = get_mesh_shape_product(mesh, ShardingAxisName.ATTN_DATA)
+
     j_mixed_qkv = reorder_concatenated_tensor_for_sharding(
         j_mixed_qkv, [key_dim, key_dim, value_dim], tp_size, -1)
     j_conv_weight = reorder_concatenated_tensor_for_sharding(
@@ -116,40 +118,44 @@ def gdn_attention_core_tpu(
     #     requests into lower-index slots after earlier ones finish), the
     #     slot id moves with the request so the kernel still reads/writes
     #     the slot that holds this request's real state.
-    state_indices = jax_view(attn_metadata.mamba_state_indices).astype(
-        jnp.int32)
-
-    # Map tokens to their respective requests
-    q_loc = jax_view(attn_metadata.query_start_loc)
-    distribution = jax_view(attn_metadata.request_distribution)
-    j_seq_lens = jax_view(attn_metadata.seq_lens)
+    state_indices = attn_metadata.mamba_state_indices.astype(jnp.int32)
 
     config = GdnAttentionConfig(
         ragged_gated_delta_rule_impl=RaggedGatedDeltaRuleImpl(
             envs.RAGGED_GATED_DELTA_RULE_IMPL))
     logger.info_once(f"GDN Attention Config: {config}")
 
+    padded_num_reqs = attn_metadata.padded_num_reqs
+
+    # Slice the state indices to the padded_num_reqs, which is the actual number
+    # of requests padded to the bucket.
+    state_indices_sliced = state_indices[:padded_num_reqs]
+    query_start_loc_sliced = attn_metadata.query_start_loc[:padded_num_reqs +
+                                                           dp_size]
+    seq_lens_sliced = attn_metadata.seq_lens[:padded_num_reqs]
+
     (new_conv_state_extracted,
-     new_recurrent_state), j_output = run_jax_gdn_attention(j_mixed_qkv,
-                                                            j_b,
-                                                            j_a,
-                                                            conv_state_in,
-                                                            recurrent_state,
-                                                            j_conv_weight,
-                                                            j_conv_bias,
-                                                            j_A_log,
-                                                            j_dt_bias,
-                                                            state_indices,
-                                                            q_loc,
-                                                            distribution,
-                                                            j_seq_lens,
-                                                            n_kq,
-                                                            n_v,
-                                                            d_k,
-                                                            d_v,
-                                                            kernel_size,
-                                                            mesh=mesh,
-                                                            config=config)
+     new_recurrent_state), j_output = run_jax_gdn_attention(
+         j_mixed_qkv,
+         j_b,
+         j_a,
+         conv_state_in,
+         recurrent_state,
+         j_conv_weight,
+         j_conv_bias,
+         j_A_log,
+         j_dt_bias,
+         state_indices_sliced,
+         query_start_loc_sliced,
+         attn_metadata.request_distribution,
+         seq_lens_sliced,
+         n_kq,
+         n_v,
+         d_k,
+         d_v,
+         kernel_size,
+         mesh=mesh,
+         config=config)
     if state_len > kernel_size - 1:
         remaining_old_state = conv_state[:, kernel_size - 1:, :]
         new_conv_state = jnp.concatenate(

--- a/tpu_inference/runner/compilation_manager.py
+++ b/tpu_inference/runner/compilation_manager.py
@@ -188,7 +188,8 @@ class CompilationManager:
                                     inputs_embeds,
                                     intermediate_tensors=None,
                                     is_first_rank=True,
-                                    is_last_rank=True) -> None:
+                                    is_last_rank=True,
+                                    num_reqs: int) -> None:
         num_tokens = None
         if input_ids is not None:
             num_tokens = input_ids.shape[0]
@@ -243,6 +244,7 @@ class CompilationManager:
                 query_start_loc=query_start_loc,
                 request_distribution=request_distribution,
                 mamba_state_indices=mamba_state_indices,
+                padded_num_reqs=num_reqs,
             )
             return attention_metadata_gid
 
@@ -299,6 +301,7 @@ class CompilationManager:
                 is_first_rank,
                 is_last_rank,
                 num_tokens=num_tokens,
+                num_reqs=num_reqs,
             )
 
     def _precompile_substitute_placeholder_token(self) -> None:
@@ -350,92 +353,102 @@ class CompilationManager:
     def _precompile_backbone_text_only(self) -> None:
         hidden_size = self.runner.model_config.get_hidden_size()
         for num_tokens in self.runner.num_tokens_paddings:
-            dp_sharding = NamedSharding(
-                self.runner.mesh, PartitionSpec(ShardingAxisName.ATTN_DATA, ))
-            input_ids = self._create_dummy_tensor((num_tokens, ), jnp.int32,
-                                                  dp_sharding)
-            if self.runner.uses_mrope:
-                mrope_sharding = NamedSharding(
+            for num_reqs in self.runner.attn_num_reqs_paddings:
+                dp_sharding = NamedSharding(
                     self.runner.mesh,
-                    PartitionSpec(None, ShardingAxisName.ATTN_DATA))
-                positions = self._create_dummy_tensor(
-                    (3, num_tokens), jnp.int32, mrope_sharding)
-            else:
-                positions = self._create_dummy_tensor((num_tokens, ),
+                    PartitionSpec(ShardingAxisName.ATTN_DATA, ))
+                input_ids = self._create_dummy_tensor((num_tokens, ),
                                                       jnp.int32, dp_sharding)
-            is_first_rank = self.runner.is_first_rank
-            is_last_rank = self.runner.is_last_rank
-            if is_first_rank:
-                intermediate_tensors = None
-            else:
-                sharding = NamedSharding(
-                    self.runner.mesh,
-                    PartitionSpec(ShardingAxisName.ATTN_DATA, None))
-                hidden_states = self._create_dummy_tensor(
-                    (num_tokens, hidden_size), jnp.bfloat16, sharding=sharding)
-                residual = self._create_dummy_tensor((num_tokens, hidden_size),
-                                                     jnp.bfloat16,
-                                                     sharding=sharding)
-                intermediate_tensors = JaxIntermediateTensors(
-                    tensors={
-                        "hidden_states": hidden_states,
-                        "residual": residual
-                    })
-            self._precompile_backbone_helper(
-                f"worker{self.runner.rank} backbone",
-                input_ids=input_ids,
-                positions=positions,
-                inputs_embeds=None,
-                intermediate_tensors=intermediate_tensors,
-                is_first_rank=is_first_rank,
-                is_last_rank=is_last_rank)
+                if self.runner.uses_mrope:
+                    mrope_sharding = NamedSharding(
+                        self.runner.mesh,
+                        PartitionSpec(None, ShardingAxisName.ATTN_DATA))
+                    positions = self._create_dummy_tensor(
+                        (3, num_tokens), jnp.int32, mrope_sharding)
+                else:
+                    positions = self._create_dummy_tensor(
+                        (num_tokens, ), jnp.int32, dp_sharding)
+                is_first_rank = self.runner.is_first_rank
+                is_last_rank = self.runner.is_last_rank
+                if is_first_rank:
+                    intermediate_tensors = None
+                else:
+                    sharding = NamedSharding(
+                        self.runner.mesh,
+                        PartitionSpec(ShardingAxisName.ATTN_DATA, None))
+                    hidden_states = self._create_dummy_tensor(
+                        (num_tokens, hidden_size),
+                        jnp.bfloat16,
+                        sharding=sharding)
+                    residual = self._create_dummy_tensor(
+                        (num_tokens, hidden_size),
+                        jnp.bfloat16,
+                        sharding=sharding)
+                    intermediate_tensors = JaxIntermediateTensors(
+                        tensors={
+                            "hidden_states": hidden_states,
+                            "residual": residual
+                        })
+                self._precompile_backbone_helper(
+                    f"worker{self.runner.rank} backbone",
+                    input_ids=input_ids,
+                    positions=positions,
+                    inputs_embeds=None,
+                    intermediate_tensors=intermediate_tensors,
+                    is_first_rank=is_first_rank,
+                    is_last_rank=is_last_rank,
+                    num_reqs=num_reqs)
 
     def _precompile_backbone_with_inputs_embeds(self) -> None:
         hidden_size = self.runner.model_config.get_hidden_size()
         dtype = self.runner.model_config.dtype
         for num_tokens in self.runner.num_tokens_paddings:
-            sharding = NamedSharding(
-                self.runner.mesh,
-                PartitionSpec(ShardingAxisName.ATTN_DATA, None))
-            input_sharding = NamedSharding(
-                self.runner.mesh, PartitionSpec(ShardingAxisName.ATTN_DATA))
-
-            inputs_embeds = self._create_dummy_tensor(
-                (num_tokens, hidden_size), dtype, sharding=sharding)
-            if self.runner.uses_mrope:
-                mrope_sharding = NamedSharding(
+            for num_reqs in self.runner.attn_num_reqs_paddings:
+                sharding = NamedSharding(
                     self.runner.mesh,
-                    PartitionSpec(None, ShardingAxisName.ATTN_DATA))
-                positions = self._create_dummy_tensor((3, num_tokens),
-                                                      jnp.int32,
-                                                      sharding=mrope_sharding)
-            else:
-                positions = self._create_dummy_tensor((num_tokens, ),
-                                                      jnp.int32,
-                                                      sharding=input_sharding)
-            is_first_rank = self.runner.is_first_rank
-            is_last_rank = self.runner.is_last_rank
-            if not is_first_rank:
-                hidden_states = self._create_dummy_tensor(
-                    (num_tokens, hidden_size), jnp.bfloat16, sharding=sharding)
-                residual = self._create_dummy_tensor((num_tokens, hidden_size),
-                                                     jnp.bfloat16,
-                                                     sharding=sharding)
-                intermediate_tensors = JaxIntermediateTensors(
-                    tensors={
-                        "hidden_states": hidden_states,
-                        "residual": residual
-                    })
-            else:
-                intermediate_tensors = None
-            self._precompile_backbone_helper(
-                f"worker{self.runner.rank} backbone with embeds",
-                input_ids=None,
-                positions=positions,
-                inputs_embeds=inputs_embeds,
-                intermediate_tensors=intermediate_tensors,
-                is_first_rank=is_first_rank,
-                is_last_rank=is_last_rank)
+                    PartitionSpec(ShardingAxisName.ATTN_DATA, None))
+                input_sharding = NamedSharding(
+                    self.runner.mesh,
+                    PartitionSpec(ShardingAxisName.ATTN_DATA))
+
+                inputs_embeds = self._create_dummy_tensor(
+                    (num_tokens, hidden_size), dtype, sharding=sharding)
+                if self.runner.uses_mrope:
+                    mrope_sharding = NamedSharding(
+                        self.runner.mesh,
+                        PartitionSpec(None, ShardingAxisName.ATTN_DATA))
+                    positions = self._create_dummy_tensor(
+                        (3, num_tokens), jnp.int32, sharding=mrope_sharding)
+                else:
+                    positions = self._create_dummy_tensor(
+                        (num_tokens, ), jnp.int32, sharding=input_sharding)
+                is_first_rank = self.runner.is_first_rank
+                is_last_rank = self.runner.is_last_rank
+                if not is_first_rank:
+                    hidden_states = self._create_dummy_tensor(
+                        (num_tokens, hidden_size),
+                        jnp.bfloat16,
+                        sharding=sharding)
+                    residual = self._create_dummy_tensor(
+                        (num_tokens, hidden_size),
+                        jnp.bfloat16,
+                        sharding=sharding)
+                    intermediate_tensors = JaxIntermediateTensors(
+                        tensors={
+                            "hidden_states": hidden_states,
+                            "residual": residual
+                        })
+                else:
+                    intermediate_tensors = None
+                self._precompile_backbone_helper(
+                    f"worker{self.runner.rank} backbone with embeds",
+                    input_ids=None,
+                    positions=positions,
+                    inputs_embeds=inputs_embeds,
+                    intermediate_tensors=intermediate_tensors,
+                    is_first_rank=is_first_rank,
+                    is_last_rank=is_last_rank,
+                    num_reqs=num_reqs)
 
     def _precompile_select_from_array_helper(
         self,

--- a/tpu_inference/runner/compilation_manager.py
+++ b/tpu_inference/runner/compilation_manager.py
@@ -871,90 +871,94 @@ class CompilationManager:
         last_token_indices = self._create_dummy_tensor(
             (self.runner.max_num_reqs, ), jnp.int32)
         for num_tokens in self.runner.num_tokens_paddings:
-            positions = self._create_dummy_tensor((num_tokens, ), jnp.int32)
-            attention_metadata = AttentionMetadata(
-                input_positions=positions,
-                block_tables=block_tables,
-                seq_lens=seq_lens,
-                query_start_loc=query_start_loc,
-                request_distribution=request_distribution,
-                mamba_state_indices=eagle3_mamba_state_indices,
-            )
+            for num_reqs in self.runner.attn_num_reqs_paddings:
+                positions = self._create_dummy_tensor((num_tokens, ),
+                                                      jnp.int32)
+                attention_metadata = AttentionMetadata(
+                    input_positions=positions,
+                    block_tables=block_tables,
+                    seq_lens=seq_lens,
+                    query_start_loc=query_start_loc,
+                    request_distribution=request_distribution,
+                    mamba_state_indices=eagle3_mamba_state_indices,
+                    padded_num_reqs=num_reqs,
+                )
 
-            input_ids = self._create_dummy_tensor((num_tokens, ), jnp.int32)
+                input_ids = self._create_dummy_tensor((num_tokens, ),
+                                                      jnp.int32)
 
-            def drafter_propose_fn_wrapper(
-                kv_caches,
-                input_ids,
-                attn_metadata,
-                last_token_indices,
-                target_hidden_states,
-            ):
-                kv_caches, draft_token_ids = self.runner.drafter.propose(
+                def drafter_propose_fn_wrapper(
                     kv_caches,
                     input_ids,
                     attn_metadata,
                     last_token_indices,
                     target_hidden_states,
+                ):
+                    kv_caches, draft_token_ids = self.runner.drafter.propose(
+                        kv_caches,
+                        input_ids,
+                        attn_metadata,
+                        last_token_indices,
+                        target_hidden_states,
+                    )
+                    self.runner.kv_caches = kv_caches
+                    return draft_token_ids
+
+                draft_hidden_states = self._create_dummy_tensor(
+                    (num_tokens, draft_hidden_size), dtype,
+                    NamedSharding(
+                        self.runner.mesh,
+                        PartitionSpec(ShardingAxisName.MLP_DATA,
+                                      ShardingAxisName.MLP_TENSOR)))
+                input_ids = self._create_dummy_tensor(
+                    (num_tokens, ), jnp.int32,
+                    NamedSharding(self.runner.mesh, PartitionSpec()))
+                self._run_compilation(
+                    "drafter_propose",
+                    drafter_propose_fn_wrapper,
+                    self.runner.kv_caches,
+                    input_ids,
+                    attention_metadata,
+                    last_token_indices,
+                    draft_hidden_states,
+                    num_tokens=num_tokens,
                 )
-                self.runner.kv_caches = kv_caches
-                return draft_token_ids
 
-            draft_hidden_states = self._create_dummy_tensor(
-                (num_tokens, draft_hidden_size), dtype,
-                NamedSharding(
-                    self.runner.mesh,
-                    PartitionSpec(ShardingAxisName.MLP_DATA,
-                                  ShardingAxisName.MLP_TENSOR)))
-            input_ids = self._create_dummy_tensor(
-                (num_tokens, ), jnp.int32,
-                NamedSharding(self.runner.mesh, PartitionSpec()))
-            self._run_compilation(
-                "drafter_propose",
-                drafter_propose_fn_wrapper,
-                self.runner.kv_caches,
-                input_ids,
-                attention_metadata,
-                last_token_indices,
-                draft_hidden_states,
-                num_tokens=num_tokens,
-            )
+                aux_hidden_states = [
+                    self._create_dummy_tensor(
+                        (num_tokens, target_hidden_size), jnp.bfloat16,
+                        NamedSharding(self.runner.mesh,
+                                      PartitionSpec(None, None))),
+                    self._create_dummy_tensor(
+                        (num_tokens, target_hidden_size), jnp.bfloat16,
+                        NamedSharding(self.runner.mesh,
+                                      PartitionSpec(None, None))),
+                    self._create_dummy_tensor(
+                        (num_tokens, target_hidden_size), jnp.bfloat16,
+                        NamedSharding(self.runner.mesh,
+                                      PartitionSpec(None, None))),
+                ]
+                last_sampled_token_id = self._create_dummy_tensor(
+                    (self.runner.max_num_reqs, ), jnp.int32)
+                next_prompt_token_id = self._create_dummy_tensor(
+                    (self.runner.max_num_reqs, ), jnp.int32)
+                is_in_prefill = self._create_dummy_tensor(
+                    (self.runner.max_num_reqs, ), jnp.int32)
+                num_rejected_tokens = self._create_dummy_tensor(
+                    (self.runner.max_num_reqs, ), jnp.int32)
 
-            aux_hidden_states = [
-                self._create_dummy_tensor(
-                    (num_tokens, target_hidden_size), jnp.bfloat16,
-                    NamedSharding(self.runner.mesh, PartitionSpec(None,
-                                                                  None))),
-                self._create_dummy_tensor(
-                    (num_tokens, target_hidden_size), jnp.bfloat16,
-                    NamedSharding(self.runner.mesh, PartitionSpec(None,
-                                                                  None))),
-                self._create_dummy_tensor(
-                    (num_tokens, target_hidden_size), jnp.bfloat16,
-                    NamedSharding(self.runner.mesh, PartitionSpec(None,
-                                                                  None))),
-            ]
-            last_sampled_token_id = self._create_dummy_tensor(
-                (self.runner.max_num_reqs, ), jnp.int32)
-            next_prompt_token_id = self._create_dummy_tensor(
-                (self.runner.max_num_reqs, ), jnp.int32)
-            is_in_prefill = self._create_dummy_tensor(
-                (self.runner.max_num_reqs, ), jnp.int32)
-            num_rejected_tokens = self._create_dummy_tensor(
-                (self.runner.max_num_reqs, ), jnp.int32)
-
-            self._run_compilation(
-                "drafter_prepare_inputs",
-                self.runner.drafter.prepare_inputs,
-                attention_metadata,
-                input_ids,
-                aux_hidden_states,
-                last_sampled_token_id,
-                next_prompt_token_id,
-                is_in_prefill,
-                num_rejected_tokens,
-                num_tokens=num_tokens,
-            )
+                self._run_compilation(
+                    "drafter_prepare_inputs",
+                    self.runner.drafter.prepare_inputs,
+                    attention_metadata,
+                    input_ids,
+                    aux_hidden_states,
+                    last_sampled_token_id,
+                    next_prompt_token_id,
+                    is_in_prefill,
+                    num_rejected_tokens,
+                    num_tokens=num_tokens,
+                )
 
     def _precompile_structured_decoding(self) -> None:
         logger.info(

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -524,6 +524,13 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         min_num_reqs = max(MIN_NUM_SEQS, next_power_of_2(self.dp_size))
         self.num_reqs_paddings = runner_utils.get_req_paddings(
             min_req_size=min_num_reqs, max_req_size=self.max_num_reqs)
+
+        # The num_reqs paddings for attention only, by default it is
+        # the max_reqs. If ATTN_BUCKETIZE_NUM_REQS=true, it is the
+        # power-of-two between min and max reqs.
+        # User can set ATTN_CUSTOM_NUM_REQS_BUCKETS to provide custom buckets.
+        self.attn_num_reqs_paddings = runner_utils.get_attn_req_paddings(
+            min_req_size=min_num_reqs, max_req_size=self.max_num_reqs)
         self.num_reqs_paddings_per_dp = [
             padding // self.dp_size for padding in self.num_reqs_paddings
         ]
@@ -1296,6 +1303,8 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         padded_num_reqs_per_dp_rank = runner_utils.get_padded_token_len(
             self.num_reqs_paddings_per_dp, max_num_reqs_across_dp)
         padded_num_reqs = padded_num_reqs_per_dp_rank * dp_size
+        attn_padded_num_reqs = runner_utils.get_padded_token_len(
+            self.attn_num_reqs_paddings, padded_num_reqs)
 
         # logits_indices_selector reorders per-rank outputs back to the
         # original batch ordering; with a single rank the ordering is already
@@ -1316,8 +1325,9 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         return (req_ids_dp, req_indices_dp, num_scheduled_tokens_per_dp_rank,
                 scheduled_tokens_per_dp_rank, num_req_per_dp_rank,
                 padded_num_scheduled_tokens_per_dp_rank, padded_num_reqs,
-                padded_total_num_scheduled_tokens, padded_num_reqs_per_dp_rank,
-                logits_indices_selector, max_num_reqs_per_dp_rank)
+                attn_padded_num_reqs, padded_total_num_scheduled_tokens,
+                padded_num_reqs_per_dp_rank, logits_indices_selector,
+                max_num_reqs_per_dp_rank)
 
     def _prepare_async_token_substitution_indices(
             self, req_ids_dp, scheduled_tokens_per_dp_rank,
@@ -1395,8 +1405,9 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         (req_ids_dp, req_indices_dp, num_scheduled_tokens_per_dp_rank,
          scheduled_tokens_per_dp_rank, num_req_per_dp_rank,
          padded_num_scheduled_tokens_per_dp_rank, padded_num_reqs,
-         padded_total_num_scheduled_tokens, padded_num_reqs_per_dp_rank,
-         logits_indices_selector, max_num_reqs_per_dp_rank
+         attn_padded_num_reqs, padded_total_num_scheduled_tokens,
+         padded_num_reqs_per_dp_rank, logits_indices_selector,
+         max_num_reqs_per_dp_rank
          ) = self._prepare_input_metadata(scheduler_output)
         # Multi-modal support
         # Calculate M-RoPE positions.
@@ -1675,6 +1686,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                 query_start_loc=query_start_loc,
                 request_distribution=request_distribution,
                 mamba_state_indices=mamba_state_indices,
+                padded_num_reqs=attn_padded_num_reqs,
             )
 
             # This is for making these cpu buffers hidden during tracing

--- a/tpu_inference/runner/utils.py
+++ b/tpu_inference/runner/utils.py
@@ -71,6 +71,26 @@ def get_req_paddings(min_req_size: int, max_req_size: int) -> list[int]:
     return paddings
 
 
+def get_attn_req_paddings(min_req_size: int, max_req_size: int) -> list[int]:
+    """Get num reqs paddings with custom override to reduce compilation time"""
+    if not envs.ATTN_BUCKETIZED_NUM_REQS:
+        reqs = [max_req_size]
+    elif envs.ATTN_CUSTOM_NUM_REQS_BUCKETS:
+        reqs = envs.ATTN_CUSTOM_NUM_REQS_BUCKETS
+    else:
+        reqs = get_req_paddings(min_req_size, max_req_size)
+
+    if max_req_size not in reqs:
+        logger.info(
+            "max_num_reqs must be supported but is not in ATTN_CUSTOM_NUM_REQS_BUCKETS. Adding max_num_reqs to the num_reqs buckets."
+        )
+        reqs.append(max_req_size)
+
+    logger.info(f"Prepared attn request paddings: {reqs}")
+
+    return reqs
+
+
 def get_token_paddings(min_token_size: int, max_token_size: int,
                        padding_gap: int) -> list[int]:
     """Generate a list of padding size, starting from min_token_size,

--- a/tpu_inference/spec_decode/jax/eagle3.py
+++ b/tpu_inference/spec_decode/jax/eagle3.py
@@ -379,6 +379,7 @@ class Eagle3Proposer:
             query_start_loc=query_start_loc,
             request_distribution=attn_metadata.request_distribution,
             mamba_state_indices=attn_metadata.mamba_state_indices,
+            padded_num_reqs=attn_metadata.padded_num_reqs,
         )
 
         target_hidden_states, input_ids, last_token_indices = self._prepare_hidden_states_and_input_ids(


### PR DESCRIPTION
# Description

Many attention preprocessing are done on max_req_len. But if the actual req_len is much less than max_seq_lens, the padding added is a big waste of resource to compute them. 

In this PR, we will slice the q_start_loc and seq_len to the closest power of two of the actual req lens (padded_req_lens). This will greatly reduce the preprocessing time in attention

If the change fixes a Github issue, please include a link, e.g.,:
FIXES: #123456

# Tests

mmlu_pro evaluated, request rate 16, 64, 512 on bucket 64, max_req_size=512

Below shows req rate 64
```
|       Tasks       |Version|    Filter    |n-shot|  Metric   |   |Value |   |Stderr|
|-------------------|------:|--------------|-----:|-----------|---|-----:|---|-----:|
|mmlu_pro           |    2.0|custom-extract|     5|exact_match|↑  |0.8329|±  |0.0139|
| - biology         |    3.1|custom-extract|     5|exact_match|↑  |0.9400|±  |0.0339|
| - business        |    3.1|custom-extract|     5|exact_match|↑  |0.8600|±  |0.0496|
| - chemistry       |    3.1|custom-extract|     5|exact_match|↑  |0.9000|±  |0.0429|
| - computer_science|    3.1|custom-extract|     5|exact_match|↑  |0.8200|±  |0.0549|
| - economics       |    3.1|custom-extract|     5|exact_match|↑  |0.9200|±  |0.0388|
| - engineering     |    3.1|custom-extract|     5|exact_match|↑  |0.6800|±  |0.0666|
| - health          |    3.1|custom-extract|     5|exact_match|↑  |0.7800|±  |0.0592|
| - history         |    3.1|custom-extract|     5|exact_match|↑  |0.6800|±  |0.0666|
| - law             |    3.1|custom-extract|     5|exact_match|↑  |0.8000|±  |0.0571|
| - math            |    3.1|custom-extract|     5|exact_match|↑  |0.9600|±  |0.0280|
| - other           |    3.1|custom-extract|     5|exact_match|↑  |0.7800|±  |0.0592|
| - philosophy      |    3.1|custom-extract|     5|exact_match|↑  |0.8400|±  |0.0524|
| - physics         |    3.1|custom-extract|     5|exact_match|↑  |0.9200|±  |0.0388|
| - psychology      |    3.1|custom-extract|     5|exact_match|↑  |0.7800|±  |0.0592|

| Groups |Version|    Filter    |n-shot|  Metric   |   |Value |   |Stderr|
|--------|------:|--------------|-----:|-----------|---|-----:|---|-----:|
|mmlu_pro|      2|custom-extract|     5|exact_match|↑  |0.8329|±  |0.0139|
```

8K/1K Prefill, max_concurrency=64, max_req_size=512

Before:
conv1d: 301 us
gdn schedule: 283 us
gdn kernel: 834 us
gdn+conv: 1418us


After (With bucket [64,512]):
conv1d: 126us
gdn schedule: 97us
gdn kernel: 855 us
gdn+conv: 1078 us

E2E:
Before: 2328 total tokens / chip / s 
After: 2516 total tokens / chip / s


# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
