### PR TITLE
Prevent double patch for routed_expert IDs

### DIFF
--- a/examples/rl_inference.py
+++ b/examples/rl_inference.py
@@ -111,6 +111,9 @@ def main(args: dict):
         generated_text = output.outputs[0].text
         print(f"Prompt: {prompt!r}\nGenerated text: {generated_text!r}")
 
+        P = len(output.prompt_token_ids)
+        print(f"Prompt token count (P): {P}")
+
         for completion in output.outputs:
             if completion.routed_experts is not None:
                 # Shape will be [len(completion.token_ids), num_layers, top_k]
@@ -119,6 +122,21 @@ def main(args: dict):
                 print(
                     f"First token expert selection: {completion.routed_experts[0]}"
                 )
+
+            G = len(completion.token_ids)
+            print(f"Generated token count (G): {G}")
+            if completion.routed_experts is not None:
+                actual_len = completion.routed_experts.shape[0]
+                expected_len = P + G - 1
+                print(
+                    f"Expected routed experts 0-th dim (P + G - 1): {expected_len}"
+                )
+                print(
+                    f"Actual routed experts shape: {completion.routed_experts.shape}"
+                )
+
+                assert actual_len == expected_len, f"Shape mismatch! Expected {expected_len}, got {actual_len}"
+                print("✓ Shape verified successfully!")
 
             if completion.logprobs is not None:
                 print(f"Logprobs for first token: {completion.logprobs[0]}")

--- a/examples/rl_inference.py
+++ b/examples/rl_inference.py
@@ -126,7 +126,6 @@ def main(args: dict):
             G = len(completion.token_ids)
             print(f"Generated token count (G): {G}")
             if completion.routed_experts is not None:
-                actual_len = completion.routed_experts.shape[0]
                 expected_len = P + G - 1
                 print(
                     f"Expected routed experts 0-th dim (P + G - 1): {expected_len}"
@@ -134,9 +133,6 @@ def main(args: dict):
                 print(
                     f"Actual routed experts shape: {completion.routed_experts.shape}"
                 )
-
-                assert actual_len == expected_len, f"Shape mismatch! Expected {expected_len}, got {actual_len}"
-                print("✓ Shape verified successfully!")
 
             if completion.logprobs is not None:
                 print(f"Logprobs for first token: {completion.logprobs[0]}")

--- a/tests/e2e/test_rl_integration.py
+++ b/tests/e2e/test_rl_integration.py
@@ -302,6 +302,15 @@ class TestMoEExpertIds:
                 "MoE models must populate routed_experts when enabled")
             assert len(output.routed_experts.shape) == 3, (
                 f"Expected 3D expert shape, got {output.routed_experts.shape}")
+
+            # Verify that the token dimension has size P + G - 1
+            P = len(outputs[0].prompt_token_ids)
+            G = len(output.token_ids)
+            expected_len = P + G - 1
+            actual_len = output.routed_experts.shape[0]
+            assert actual_len == expected_len, (
+                f"Expected expert 0-th dim to be P + G - 1 ({expected_len}), "
+                f"got {actual_len}")
         else:
             assert output.routed_experts is None, (
                 "Non-MoE models must not populate routed_experts")

--- a/tpu_inference/core/sched/utils.py
+++ b/tpu_inference/core/sched/utils.py
@@ -15,9 +15,14 @@
 
 def update_vllm_scheduler_for_exporting_expert_ids():
     # Monkeypatch vLLM Scheduler to attach expert indices to outputs
+    from vllm.v1.core.sched.scheduler import Scheduler
+
+    if getattr(Scheduler, "_expert_ids_patched", False):
+        return
+    Scheduler._expert_ids_patched = True
+
     from vllm.model_executor.layers.fused_moe.routed_experts_capturer import \
         RoutedExpertsReader
-    from vllm.v1.core.sched.scheduler import Scheduler
 
     class DummyRoutedExpertsReader:
 


### PR DESCRIPTION
# Description

Fix bug where scheduler can get double patched

Add test to check expert dimensions, also update rl_inference

# Tests

```
VLLM_LOGGING_LEVEL=DEBUG MODEL_IMPL_TYPE=vllm SKIP_JAX_PRECOMPILE=1 python examples/rl_inference.py --model Qwen/Qwen3-30B-A3B-Instruct-2507  --data-parallel-size=1 --log_probs 5
```
```
--------------------------------------------------
Prompt: 'Who was the first person to walk on the moon?'
Generated text: ' The first person to walk on the moon was **Neil Armstrong**. He stepped'
  Prompt token count (P): 11
  Generated token count (G): 16
  Expected routed experts 0-th dim (P + G - 1): 26
  Actual routed experts shape: (26, 48, 8)
  ✓ Shape verified successfully!
  Logprobs for first token: {576: Logprob(logprob=-0.05733104422688484, rank=1, decoded_token=' The'), 10479: Logprob(logprob=-4.932331085205078, rank=2, decoded_token=' Who'), 220: Logprob(logprob=-5.182331085205078, rank=3, decoded_token=' '), 7281: Logprob(logprob=-5.557331085205078, rank=4, decoded_token=' Also'), 2303: Logprob(logprob=-5.682331085205078, rank=5, decoded_token='  \n')}
--------------------------------------------------
Prompt: 'Who wrote the American Declaration of Independence?'
Generated text: ' The American Declaration of Independence was primarily written by **Thomas Jefferson**. He was'
  Prompt token count (P): 8
  Generated token count (G): 16
  Expected routed experts 0-th dim (P + G - 1): 23
  Actual routed experts shape: (23, 48, 8)
  ✓ Shape verified successfully!
  Logprobs for first token: {576: Logprob(logprob=-0.6245213747024536, rank=1, decoded_token=' The'), 10479: Logprob(logprob=-1.7495213747024536, rank=2, decoded_token=' Who'), 3555: Logprob(logprob=-2.874521255493164, rank=3, decoded_token=' What'), 22406: Logprob(logprob=-2.999521255493164, rank=4, decoded_token=' Additionally'), 2585: Logprob(logprob=-3.874521255493164, rank=5, decoded_token=' How')}
--------------------------------------------------
```



# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
