### PR TITLE
Profiler: Automatically merge multi-host JAX profiling subdirectories…

### DIFF
--- a/tests/runner/test_utils.py
+++ b/tests/runner/test_utils.py
@@ -569,3 +569,35 @@ def test_phased_profiler_skips_decode_only_steps_based_on_kv_len(
         profiler.step(stats)
     mock_stop.assert_called_once()
     assert profiler.current_phase == ""
+
+
+def test_merge_multihost_profile_directories(tmp_path):
+    """Tests that multi-host profile directories with different timestamps are consolidated correctly."""
+    profiler = PhasedBasedProfiler(profile_dir=str(tmp_path))
+    phase_dir = tmp_path / "prefill_heavy"
+    profiler.profile_dir_with_phase_suffix = str(phase_dir)
+
+    profile_path = phase_dir / "plugins" / "profile"
+    dir_early = profile_path / "2026_05_06_04_47_36"
+    dir_late = profile_path / "2026_05_06_04_47_38"
+
+    # Create the nested timestamped directories
+    dir_early.mkdir(parents=True, exist_ok=True)
+    dir_late.mkdir(parents=True, exist_ok=True)
+
+    # Create dummy host files inside each directory
+    file_early = dir_early / "node-1-0.xplane.pb"
+    file_late = dir_late / "node-0-0.xplane.pb"
+    file_early.write_text("dummy_trace_data_1")
+    file_late.write_text("dummy_trace_data_0")
+
+    # Execute consolidation merge
+    profiler._merge_multihost_profile_directories()
+
+    # Verify that the trailing directory is deleted and all files are merged into the earliest directory
+    assert dir_early.exists()
+    assert not dir_late.exists()
+    assert (dir_early / "node-1-0.xplane.pb").exists()
+    assert (dir_early / "node-0-0.xplane.pb").exists()
+    assert (dir_early / "node-1-0.xplane.pb").read_text() == "dummy_trace_data_1"
+    assert (dir_early / "node-0-0.xplane.pb").read_text() == "dummy_trace_data_0"

--- a/tests/runner/test_utils.py
+++ b/tests/runner/test_utils.py
@@ -599,5 +599,7 @@ def test_merge_multihost_profile_directories(tmp_path):
     assert not dir_late.exists()
     assert (dir_early / "node-1-0.xplane.pb").exists()
     assert (dir_early / "node-0-0.xplane.pb").exists()
-    assert (dir_early / "node-1-0.xplane.pb").read_text() == "dummy_trace_data_1"
-    assert (dir_early / "node-0-0.xplane.pb").read_text() == "dummy_trace_data_0"
+    assert (dir_early /
+            "node-1-0.xplane.pb").read_text() == "dummy_trace_data_1"
+    assert (dir_early /
+            "node-0-0.xplane.pb").read_text() == "dummy_trace_data_0"

--- a/tpu_inference/runner/utils.py
+++ b/tpu_inference/runner/utils.py
@@ -7,6 +7,7 @@ import datetime
 import functools
 import json
 import os
+import shutil
 import time
 from enum import Enum
 from typing import Any
@@ -449,9 +450,52 @@ class PhasedBasedProfiler:
             self.profiling_n_steps_left -= 1
             if self.profiling_n_steps_left <= 0:
                 jax.profiler.stop_trace()
+                self._merge_multihost_profile_directories()
                 logger.info(
                     f"Profiling for {self.current_phase} phase finished")
                 self.current_phase = ""
+
+    def _merge_multihost_profile_directories(self) -> None:
+        """
+        Merges multi-host JAX profiler timestamp subdirectories that drift due to asynchronous step trigger times.
+
+        Fixes issues where separate host nodes create disjoint timestamp folders due to 1-2 seconds startup
+        skew, which blocks downstream multi-host profile analysis tools (e.g., c2xprof or TensorBoard profile plugins)
+        from recognizing them as a single concurrent distributed profiling session.
+
+        Example split state before merge:
+          .../plugins/profile/2026_05_06_04_47_36/j-1b8d22de-2250-4697-9dfc-ray-node-1-0.xplane.pb
+          .../plugins/profile/2026_05_06_04_47_38/j-1b8d22de-2250-4697-9dfc-ray-node-0-0.xplane.pb
+
+        After merge:
+          All host trace artifacts are consolidated under the earliest timestamp folder (2026_05_06_04_47_36/).
+        """
+        profile_path = os.path.join(self.profile_dir_with_phase_suffix, "plugins", "profile")
+        if not os.path.exists(profile_path):
+            return
+        try:
+            # Get all timestamp subdirectories sorted by time
+            dirs = sorted([d for d in os.listdir(profile_path) if os.path.isdir(os.path.join(profile_path, d))])
+            if len(dirs) <= 1:
+                return
+            
+            # Use the earliest directory as the canonical destination target
+            target_dir = os.path.join(profile_path, dirs[0])
+            
+            # Move all files from trailing directories into the canonical target directory
+            for src in dirs[1:]:
+                src_dir = os.path.join(profile_path, src)
+                for f in os.listdir(src_dir):
+                    src_file = os.path.join(src_dir, f)
+                    dst_file = os.path.join(target_dir, f)
+                    shutil.move(src_file, dst_file)
+                try:
+                    os.rmdir(src_dir)
+                except Exception:
+                    pass
+            logger.info("Successfully merged multi-host profile directories into: %s", dirs[0])
+        except Exception as e:
+            logger.warning("Failed to merge multi-host profile directories: %s", e)
 
     def step(self, batch_composition_stats: dict) -> None:
         """

--- a/tpu_inference/runner/utils.py
+++ b/tpu_inference/runner/utils.py
@@ -450,7 +450,8 @@ class PhasedBasedProfiler:
             self.profiling_n_steps_left -= 1
             if self.profiling_n_steps_left <= 0:
                 jax.profiler.stop_trace()
-                self._merge_multihost_profile_directories()
+                if envs.TPU_MULTIHOST_BACKEND == "ray":
+                    self._merge_multihost_profile_directories()
                 logger.info(
                     f"Profiling for {self.current_phase} phase finished")
                 self.current_phase = ""

--- a/tpu_inference/runner/utils.py
+++ b/tpu_inference/runner/utils.py
@@ -471,18 +471,22 @@ class PhasedBasedProfiler:
         After merge:
           All host trace artifacts are consolidated under the earliest timestamp folder (2026_05_06_04_47_36/).
         """
-        profile_path = os.path.join(self.profile_dir_with_phase_suffix, "plugins", "profile")
+        profile_path = os.path.join(self.profile_dir_with_phase_suffix,
+                                    "plugins", "profile")
         if not os.path.exists(profile_path):
             return
         try:
             # Get all timestamp subdirectories sorted by time
-            dirs = sorted([d for d in os.listdir(profile_path) if os.path.isdir(os.path.join(profile_path, d))])
+            dirs = sorted([
+                d for d in os.listdir(profile_path)
+                if os.path.isdir(os.path.join(profile_path, d))
+            ])
             if len(dirs) <= 1:
                 return
-            
+
             # Use the earliest directory as the canonical destination target
             target_dir = os.path.join(profile_path, dirs[0])
-            
+
             # Move all files from trailing directories into the canonical target directory
             for src in dirs[1:]:
                 src_dir = os.path.join(profile_path, src)
@@ -494,9 +498,12 @@ class PhasedBasedProfiler:
                     os.rmdir(src_dir)
                 except Exception:
                     pass
-            logger.info("Successfully merged multi-host profile directories into: %s", dirs[0])
+            logger.info(
+                "Successfully merged multi-host profile directories into: %s",
+                dirs[0])
         except Exception as e:
-            logger.warning("Failed to merge multi-host profile directories: %s", e)
+            logger.warning(
+                "Failed to merge multi-host profile directories: %s", e)
 
     def step(self, batch_composition_stats: dict) -> None:
         """


### PR DESCRIPTION
Fix multihost xprof separate directory issue

# Description

Without this PR, the xprof file will be like (each node will put it at different timestamp):

 .../plugins/profile/2026_05_06_04_47_36/j-1b8d22de-2250-4697-9dfc-ray-node-1-0.xplane.pb
 .../plugins/profile/2026_05_06_04_47_38/j-1b8d22de-2250-4697-9dfc-ray-node-0-0.xplane.pb

Then xprof at google will not be able to display the multihost joint view.

The cl will now merge multihost directories into a single directory.

# Tests
Unittest
