### PR TITLE
[MTP] Fix conv_state shape handling in gdn_attention_core_tpu for MTP

### DIFF
--- a/tpu_inference/layers/vllm/custom_ops/gdn_attention_op.py
+++ b/tpu_inference/layers/vllm/custom_ops/gdn_attention_op.py
@@ -92,6 +92,11 @@ def gdn_attention_core_tpu(
 
     layer_idx = vllm_context.layer_name_to_kvcache_index[layer_name]
     conv_state, recurrent_state = vllm_context.kv_caches[layer_idx]
+    state_len = conv_state.shape[1]
+    if state_len > kernel_size - 1:
+        conv_state_in = conv_state[:, :kernel_size - 1, :]
+    else:
+        conv_state_in = conv_state
 
     # Index mamba state by the per-request slot id from
     # `InputBatch.mamba_state_indices_cpu`, not by `block_tables[:, 0]`
@@ -118,11 +123,11 @@ def gdn_attention_core_tpu(
         ragged_gated_delta_rule_impl=RaggedGatedDeltaRuleImpl(
             envs.RAGGED_GATED_DELTA_RULE_IMPL))
 
-    (new_conv_state,
+    (new_conv_state_extracted,
      new_recurrent_state), j_output = run_jax_gdn_attention(j_mixed_qkv,
                                                             j_b,
                                                             j_a,
-                                                            conv_state,
+                                                            conv_state_in,
                                                             recurrent_state,
                                                             j_conv_weight,
                                                             j_conv_bias,
@@ -139,6 +144,12 @@ def gdn_attention_core_tpu(
                                                             kernel_size,
                                                             mesh=mesh,
                                                             config=config)
+    if state_len > kernel_size - 1:
+        remaining_old_state = conv_state[:, kernel_size - 1:, :]
+        new_conv_state = jnp.concatenate(
+            [new_conv_state_extracted, remaining_old_state], axis=1)
+    else:
+        new_conv_state = new_conv_state_extracted
 
     vllm_context.kv_caches[layer_idx] = (new_conv_state, new_recurrent_state)
 


### PR DESCRIPTION
# Description

This PR fixes a shape mismatch issue in gdn_attention_core_tpu when running models with Gated Delta Net (GDN) attention and Speculative Decoding (MTP) enabled.

**Problem**: In vLLM, when speculative decoding is enabled, the conv_state buffer for GDN/Mamba layers is allocated with an extended size of conv_kernel_size - 1 + num_speculative_tokens (defined in vLLM's mamba_utils.py as conv_kernel_size - 1 + num_spec). This extra space is needed by vLLM to hold the history of a full chunk of speculative tokens during parallel verification.

However, our optimized TPU JAX kernels (run_jax_gdn_attention and ragged_conv1d) were written assuming non-speculative decoding and expect the conv_state to have a length of exactly conv_kernel_size - 1 to match the convolution weight shapes. Passing the larger buffer directly causes JAX to crash with shape mismatch errors (e.g., in einsum or conv_general_dilated).

**Solution**: This PR introduces a slicing adapter in gdn_attention_core_tpu to bridge this gap:

It checks if the conv_state is larger than kernel_size - 1.
If so, it slices the state to exactly kernel_size - 1 before passing it to run_jax_gdn_attention, satisfying JAX's strict shape requirements.
After the JAX call, it concatenates the newly updated state with the remaining old state that was not passed to JAX. This preserves the full buffer size so that vLLM's other MTP operations are not broken.

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
