### PR TITLE
Add a check for benchmark file changes

### DIFF
--- a/.buildkite/scripts/bootstrap.sh
+++ b/.buildkite/scripts/bootstrap.sh
@@ -91,6 +91,9 @@ if [ "$BUILDKITE_PULL_REQUEST" != "false" ]; then
     else
       echo "Code files changed. Proceeding with pipeline upload."
     fi
+
+    # Count files not matching the benchmark prefix
+    NON_BENCHMARK_COUNT=$(printf "%s\n" "$NON_SKIPPABLE_FILES" | grep -c -v "^\.buildkite/benchmark" || true)
     
     # Validate custom pipeline metadata (Uniqueness & Completeness)
     if .buildkite/scripts/validate_pipeline_metadata.sh "$NON_SKIPPABLE_FILES"; then
@@ -277,7 +280,10 @@ else
     # If it's a PR, check for the specific label
     if [[ $PR_LABELS == *"ready"* ]]; then
       echo "Found 'ready' label on PR. Uploading main pipeline..."
-      upload_pipeline
+      # Upload main pipeline if file list is empty or contains non-benchmark files
+      if [ -z "${NON_SKIPPABLE_FILES:-}" ] || [ "${NON_BENCHMARK_COUNT:--1}" -ne 0 ]; then
+        upload_pipeline
+      fi
       upload_benchmark_pipeline
     else
       # Explicitly fail the build because the required 'ready' label is missing.


### PR DESCRIPTION
# Description

Add a check in `bootstrap.sh` to skip executing the main pipeline and only execute the benchmark pipeline if the file changes are only in `.buildkite/benchmark` and it is a PR.

# Tests

[Buildkite CI](https://buildkite.com/tpu-commons/tpu-inference-ci/builds/16702)

Test the [results](https://buildkite.com/tpu-commons/tpu-inference-ci/builds/16835) on a PR when only `.buildkite/benchmark` has changed.


# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
