### PR TITLE
[benchmark] Fix Total input tokens reporting for chat/multimodal datasets

### DIFF
--- a/scripts/vllm/benchmarking/backend_request_func.py
+++ b/scripts/vllm/benchmarking/backend_request_func.py
@@ -189,6 +189,8 @@ async def _openai_fetch(
                             if usage := data.get("usage"):
                                 output.output_tokens = usage.get(
                                     "completion_tokens")
+                                output.prompt_tokens = usage.get(
+                                    "prompt_tokens") or 0
                     if first_chunk_received:
                         output.success = True
                     else:

--- a/scripts/vllm/benchmarking/benchmark_core.py
+++ b/scripts/vllm/benchmarking/benchmark_core.py
@@ -84,6 +84,14 @@ class RequestFuncOutput:
     success: bool = False
     latency: float = 0.0
     output_tokens: int = 0
+    prompt_tokens: int = 0
+    """Server-reported prompt tokens (from `usage.prompt_tokens`).
+
+    0 if the backend did not report it. When non-zero, this is preferred over
+    `input_request.prompt_len` for input-token accounting, since it reflects
+    the actual tokenization done server-side (chat template, image tokens,
+    etc.).
+    """
     ttft: float = 0.0  # Time to first token
     itl: list[float] = field(
         default_factory=list)  # list of inter-token latencies

--- a/scripts/vllm/benchmarking/benchmark_serving.py
+++ b/scripts/vllm/benchmarking/benchmark_serving.py
@@ -146,7 +146,7 @@ def calculate_metrics(
     tokenizer: PreTrainedTokenizerBase,
     selected_percentiles: list[float],
     goodput_config_dict: dict[str, float],
-) -> tuple[BenchmarkMetrics, list[int]]:
+) -> tuple[BenchmarkMetrics, list[int], list[int]]:
     actual_output_lens: list[int] = []
     actual_input_lens: list[int] = []
     total_input = 0
@@ -349,7 +349,7 @@ async def benchmark(
 
     benchmark_duration = time.perf_counter() - benchmark_start_time
 
-    metrics, actual_output_lens, actual_input_lens = calculate_metrics(
+    metrics, actual_output_lens, input_lens = calculate_metrics(
         input_requests=input_requests,
         outputs=outputs,
         dur_s=benchmark_duration,
@@ -385,7 +385,7 @@ async def benchmark(
         metrics.request_goodput if goodput_config_dict else None,
         "output_throughput": metrics.output_throughput,
         "total_token_throughput": metrics.total_token_throughput,
-        "input_lens": actual_input_lens,
+        "input_lens": input_lens,
         "output_lens": actual_output_lens,
         "ttfts": [output.ttft for output in outputs],
         "itls": [output.itl for output in outputs],

--- a/scripts/vllm/benchmarking/benchmark_serving.py
+++ b/scripts/vllm/benchmarking/benchmark_serving.py
@@ -148,6 +148,7 @@ def calculate_metrics(
     goodput_config_dict: dict[str, float],
 ) -> tuple[BenchmarkMetrics, list[int]]:
     actual_output_lens: list[int] = []
+    actual_input_lens: list[int] = []
     total_input = 0
     completed = 0
     good_completed = 0
@@ -171,7 +172,12 @@ def calculate_metrics(
                     tokenizer(outputs[i].generated_text,
                               add_special_tokens=False).input_ids)
             actual_output_lens.append(output_len)
-            total_input += input_requests[i].prompt_len
+            # Prefer server-reported prompt_tokens (accounts for chat template
+            # and multimodal tokens); fall back to client-side prompt_len.
+            input_len = (outputs[i].prompt_tokens
+                         or input_requests[i].prompt_len)
+            actual_input_lens.append(input_len)
+            total_input += input_len
             tpot = 0
             if output_len > 1:
                 latency_minus_ttft = outputs[i].latency - outputs[i].ttft
@@ -185,6 +191,7 @@ def calculate_metrics(
             completed += 1
         else:
             actual_output_lens.append(0)
+            actual_input_lens.append(0)
 
     if goodput_config_dict:
         valid_metrics = []
@@ -245,7 +252,7 @@ def calculate_metrics(
                              for p in selected_percentiles],
     )
 
-    return metrics, actual_output_lens
+    return metrics, actual_output_lens, actual_input_lens
 
 
 async def benchmark(
@@ -342,7 +349,7 @@ async def benchmark(
 
     benchmark_duration = time.perf_counter() - benchmark_start_time
 
-    metrics, actual_output_lens = calculate_metrics(
+    metrics, actual_output_lens, actual_input_lens = calculate_metrics(
         input_requests=input_requests,
         outputs=outputs,
         dur_s=benchmark_duration,
@@ -378,7 +385,7 @@ async def benchmark(
         metrics.request_goodput if goodput_config_dict else None,
         "output_throughput": metrics.output_throughput,
         "total_token_throughput": metrics.total_token_throughput,
-        "input_lens": [output.input_request.prompt_len for output in outputs],
+        "input_lens": actual_input_lens,
         "output_lens": actual_output_lens,
         "ttfts": [output.ttft for output in outputs],
         "itls": [output.itl for output in outputs],


### PR DESCRIPTION
## Summary

- Capture `usage.prompt_tokens` from the streamed OpenAI response in `_openai_fetch` (vLLM emits it in the trailing chunk when `stream_options.include_usage=true`).
- Prefer the server-reported value over the client-side `SampleRequest.prompt_len` in `calculate_metrics`, falling back to `prompt_len` when the server doesn't report usage.
- This fixes "Total input tokens: 0" for `MMMUProDataset` (which never set `prompt_len`), and gives a more accurate count for any chat/multimodal dataset since the server count includes chat-template and image tokens that the client tokenizer doesn't see.

Fixes #2525.

## Verification

Before, with `--dataset-name mmmu_pro --num-prompts 4`:
```
Total input tokens:                      0
Total generated tokens:                  256
```

After:
```
Total input tokens:                      1704
Total generated tokens:                  256
```

## Test plan

- [x] Repro with `mmmu_pro` (`standard (10 options)`) — `Total input tokens` is non-zero and matches `usage.prompt_tokens`.
- [ ] Spot-check that an existing completion-API dataset (e.g. `mlperf`) still reports the same `total_input` (server value, when present, equals client `prompt_len`).