### PR TITLE
Fix crash in phased profiling due to composition stats

### DIFF
--- a/tpu_inference/runner/utils.py
+++ b/tpu_inference/runner/utils.py
@@ -227,7 +227,8 @@ def get_batch_composition_stats(
         num_scheduled_tokens_per_req_list.append(num_scheduled_for_req)
 
         # This is the number of tokens already processed for this request (before this step)
-        num_already_computed = num_computed_tokens_per_req[i]
+        num_already_computed = int(
+            num_computed_tokens_per_req[i])  # Cast from np.int32
         min_kv_len = min(min_kv_len, num_already_computed)
 
         if num_already_computed == 0:


### PR DESCRIPTION
# Description

Fix crash error 
```
EngineCore pid=1520600)   File "/mnt/pd/home-mp/vllm-test/tpu-inference/tpu_inference/runner/utils.py", line 368, in _write_batch_composition_stats_to_file_helper
(EngineCore pid=1520600)     f.write(json.dumps(batch_composition_stats) + "\n")
(EngineCore pid=1520600)             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=1520600)   File "/usr/lib/python3.12/json/__init__.py", line 231, in dumps
(EngineCore pid=1520600)     return _default_encoder.encode(obj)
(EngineCore pid=1520600)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=1520600)   File "/usr/lib/python3.12/json/encoder.py", line 200, in encode
(EngineCore pid=1520600)     chunks = self.iterencode(o, _one_shot=True)
(EngineCore pid=1520600)              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=1520600)   File "/usr/lib/python3.12/json/encoder.py", line 258, in iterencode
(EngineCore pid=1520600)     return _iterencode(o, 0)
(EngineCore pid=1520600)            ^^^^^^^^^^^^^^^^^
(EngineCore pid=1520600)   File "/usr/lib/python3.12/json/encoder.py", line 180, in default
(EngineCore pid=1520600)     raise TypeError(f'Object of type {o.__class__.__name__} '
(EngineCore pid=1520600) TypeError: Object of type int32 is not JSON serializable
```


# Tests
Tested locally, no crashing on profiling anymore


# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
