### PR TITLE
Use previously unused test parameter.

### DIFF
--- a/tests/layers/vllm/test_compressed_tensors_moe.py
+++ b/tests/layers/vllm/test_compressed_tensors_moe.py
@@ -120,9 +120,8 @@ def initialize_layer_weights(layer: torch.nn.Module):
 @pytest.mark.parametrize("hidden_size", [128])
 @pytest.mark.parametrize("num_experts", [8])
 @pytest.mark.parametrize("topk", [2])
-@pytest.mark.parametrize("use_ep", [True, False])
 def test_fused_moe_method(mesh, num_tokens, intermediate_size, hidden_size,
-                          num_experts, topk, use_ep):
+                          num_experts, topk):
     engine_args = EngineArgs(
         model=MODEL,
         max_model_len=64,

--- a/tests/layers/vllm/test_compressed_tensors_moe.py
+++ b/tests/layers/vllm/test_compressed_tensors_moe.py
@@ -140,6 +140,7 @@ def test_fused_moe_method(mesh, num_tokens, intermediate_size, hidden_size,
                          top_k=topk,
                          hidden_size=hidden_size,
                          intermediate_size=intermediate_size)
+        layer.moe_parallel_config.use_ep = use_ep
     weight_quant = quant_config.target_scheme_map['Linear']['weights']
     input_quant = quant_config.target_scheme_map['Linear']['input_activations']
     moe = quant_config.get_moe_config(layer)

--- a/tests/layers/vllm/test_compressed_tensors_moe.py
+++ b/tests/layers/vllm/test_compressed_tensors_moe.py
@@ -120,8 +120,9 @@ def initialize_layer_weights(layer: torch.nn.Module):
 @pytest.mark.parametrize("hidden_size", [128])
 @pytest.mark.parametrize("num_experts", [8])
 @pytest.mark.parametrize("topk", [2])
+@pytest.mark.parametrize("use_ep", [True, False])
 def test_fused_moe_method(mesh, num_tokens, intermediate_size, hidden_size,
-                          num_experts, topk):
+                          num_experts, topk, use_ep):
     engine_args = EngineArgs(
         model=MODEL,
         max_model_len=64,

--- a/tests/layers/vllm/test_compressed_tensors_moe_w4a8.py
+++ b/tests/layers/vllm/test_compressed_tensors_moe_w4a8.py
@@ -175,6 +175,7 @@ def test_fused_moe_method_w4(mesh, num_tokens, intermediate_size, hidden_size,
                          top_k=topk,
                          hidden_size=hidden_size,
                          intermediate_size=intermediate_size)
+        layer.moe_parallel_config.use_ep = use_ep
         moe = quant_config.get_moe_config(layer)
         method = VllmCompressedTensorsW4A8MoEMethod(weight_quant, input_quant,
                                                     moe, mesh)


### PR DESCRIPTION
# Description
Removed 'use_ep' parameter from test_fused_moe_method. This argument was unused and removing it halves the parameterized test cases.

# Tests

Tested locally. Only modifies a test.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
