### PR TITLE
[Spec decoding] make the mtp drafter propose() as 1 jited fn

### DIFF
--- a/tpu_inference/models/vllm/vllm_model_wrapper.py
+++ b/tpu_inference/models/vllm/vllm_model_wrapper.py
@@ -370,12 +370,6 @@ class VllmModelWrapper:
                 None,  # list of aux hidden states
                 None,  # expert ids
             ),
-            compiler_options={
-                "xla_tpu_all_gather_collective_matmul_mode":
-                "post_spmd_conservative",
-                "xla_tpu_reduce_scatter_collective_matmul_mode":
-                "post_spmd_conservative"
-            },
             static_argnames=("layer_name_to_kvcache_index", ),
         )
         def draft_step_fun(

--- a/tpu_inference/runner/compilation_manager.py
+++ b/tpu_inference/runner/compilation_manager.py
@@ -771,20 +771,10 @@ class CompilationManager:
                                     block_tables,
                                     sharding=PartitionSpec(None, ))
 
-        selected_positions = self._create_dummy_tensor(
-            (self.runner.max_num_reqs, ), jnp.int32)
         seq_lens = self._create_dummy_tensor((self.runner.max_num_reqs, ),
                                              jnp.int32)
         query_start_loc = self._create_dummy_tensor(
             (self.runner.max_num_reqs + 1, ), jnp.int32)
-        self._run_compilation(
-            "_update_inputs_for_loop_speculation for the first loop",
-            self.runner.drafter._update_inputs_for_loop_speculation,
-            selected_positions, seq_lens, block_tables)
-        self._run_compilation(
-            "_update_inputs_for_loop_speculation for the subsequent loops",
-            self.runner.drafter._update_inputs_for_loop_speculation,
-            selected_positions, seq_lens, block_tables)
 
         request_distribution = np.array([0, 0, 0], dtype=np.int32)
         request_distribution = device_array(self.runner.mesh,
@@ -805,38 +795,6 @@ class CompilationManager:
         else:
             eagle3_mamba_state_indices = None
 
-        for num_reqs_padding in self.runner.num_reqs_paddings:
-            for i in range(1, self.runner.drafter.num_speculative_tokens + 1):
-                draft_token_ids_list = [
-                    self._create_dummy_tensor(
-                        (num_reqs_padding, ), jnp.int32,
-                        NamedSharding(self.runner.mesh, PartitionSpec()))
-                    for _ in range(i)
-                ]
-                self._run_compilation(
-                    "eagle3_stack_draft_token_ids",
-                    self.runner.drafter._stack_draft_token_ids,
-                    draft_token_ids_list,
-                    num_reqs=num_reqs_padding,
-                    draft_token_ids_list_length=len(draft_token_ids_list))
-
-        for num_logits in self.runner.num_logits_paddings:
-            hidden_states = self._create_dummy_tensor(
-                (num_logits, draft_hidden_size), jnp.bfloat16)
-            self._run_compilation(
-                "eagle3_get_draft_token_ids",
-                self.runner.drafter._get_draft_token_ids,
-                self.runner.drafter.state,
-                hidden_states,
-                num_logits=num_logits,
-            )
-
-        input_ids_loop = self._create_dummy_tensor(
-            (self.runner.max_num_reqs, ), jnp.int32,
-            NamedSharding(self.runner.mesh, PartitionSpec()))
-        draft_hidden_state_loop = self._create_dummy_tensor(
-            (self.runner.max_num_reqs, draft_hidden_size), dtype,
-            NamedSharding(self.runner.mesh, PartitionSpec(None, None)))
         next_token_ids = self._create_dummy_tensor(
             (self.runner.max_num_reqs, ), jnp.int32)
         last_token_indices = self._create_dummy_tensor(
@@ -892,6 +850,44 @@ class CompilationManager:
                     NamedSharding(self.runner.mesh, PartitionSpec(None,
                                                                   None))),
             ]
+
+            def drafter_propose_fn_wrapper(
+                kv_caches,
+                input_ids,
+                attn_metadata,
+                last_token_indices,
+                target_hidden_states,
+            ):
+                kv_caches, draft_token_ids = self.runner.drafter.propose(
+                    kv_caches,
+                    input_ids,
+                    attn_metadata,
+                    last_token_indices,
+                    target_hidden_states,
+                )
+                self.runner.kv_caches = kv_caches
+                return draft_token_ids
+
+            draft_hidden_states = self._create_dummy_tensor(
+                (num_tokens, draft_hidden_size), dtype,
+                NamedSharding(
+                    self.runner.mesh,
+                    PartitionSpec(ShardingAxisName.MLP_DATA,
+                                  ShardingAxisName.MLP_TENSOR)))
+            input_ids = self._create_dummy_tensor(
+                (num_tokens, ), jnp.int32,
+                NamedSharding(self.runner.mesh, PartitionSpec()))
+            self._run_compilation(
+                "drafter_propose",
+                drafter_propose_fn_wrapper,
+                self.runner.kv_caches,
+                input_ids,
+                attention_metadata,
+                last_token_indices,
+                draft_hidden_states,
+                num_tokens=num_tokens,
+            )
+
             # TODO(ranlihao): This will increase the precompilation latency. Find proper range for token_indices.
             for padded_total_num_tokens in [
                     num_tokens,
@@ -915,41 +911,6 @@ class CompilationManager:
                                    dtype=jnp.int32)),
                     num_tokens=num_tokens,
                 )
-
-            def draft_model_fn_wrapper(
-                state,
-                kv_caches,
-                input_ids,
-                draft_hidden_states,
-                attention_metadata,
-                layer_name_to_kvcache_index,
-            ):
-                kv_caches, hidden_states, _, _ = self.runner.drafter.model_fn(
-                    state, kv_caches, input_ids, draft_hidden_states,
-                    attention_metadata, layer_name_to_kvcache_index)
-                self.runner.kv_caches = kv_caches
-                return hidden_states
-
-            draft_hidden_states = self._create_dummy_tensor(
-                (num_tokens, draft_hidden_size), dtype,
-                NamedSharding(
-                    self.runner.mesh,
-                    PartitionSpec(ShardingAxisName.MLP_DATA,
-                                  ShardingAxisName.MLP_TENSOR)))
-            input_ids = self._create_dummy_tensor(
-                (num_tokens, ), jnp.int32,
-                NamedSharding(self.runner.mesh, PartitionSpec()))
-            self._run_compilation(
-                "eagle3_draft_model_fn",
-                draft_model_fn_wrapper,
-                self.runner.drafter.state,
-                self.runner.kv_caches,
-                input_ids,
-                draft_hidden_states,
-                attention_metadata,
-                tuple(self.runner.layer_name_to_kvcache_index.items()),
-                num_tokens=num_tokens,
-            )
             target_token_ids = self._create_dummy_tensor((num_tokens, ),
                                                          jnp.int32)
 
@@ -965,48 +926,6 @@ class CompilationManager:
                     self.runner.mesh,
                     np.asarray([self.runner.input_batch.num_reqs],
                                dtype=jnp.int32)),
-                num_tokens=num_tokens,
-            )
-
-            attention_metadata.query_start_loc = device_array(
-                self.runner.mesh,
-                attention_metadata.query_start_loc,
-                sharding=PartitionSpec())
-            attention_metadata.input_positions = self._create_dummy_tensor(
-                (self.runner.max_num_reqs, ), jnp.int32)
-            self._run_compilation(
-                "draft_model_fn in a loop",
-                draft_model_fn_wrapper,
-                self.runner.drafter.state,
-                self.runner.kv_caches,
-                input_ids_loop,
-                draft_hidden_state_loop,
-                attention_metadata,
-                tuple(self.runner.layer_name_to_kvcache_index.items()),
-                num_tokens=num_tokens,
-            )
-
-            hidden_states = self._create_dummy_tensor(
-                (num_tokens, draft_hidden_size), jnp.bfloat16,
-                NamedSharding(self.runner.mesh, PartitionSpec(None, None)))
-
-            self._run_compilation(
-                "eagle3_select_inputs_for_loop_speculation",
-                self.runner.drafter._select_inputs_for_loop_speculation,
-                self.runner.drafter.state,
-                positions,
-                hidden_states,
-                hidden_states,
-                last_token_indices,
-                num_tokens=num_tokens,
-            )
-
-            self._run_compilation(
-                "eagle3_select_draft_token_ids",
-                self.runner.drafter._select_draft_token_ids,
-                self.runner.drafter.state,
-                hidden_states,
-                last_token_indices,
                 num_tokens=num_tokens,
             )
 

--- a/tpu_inference/spec_decode/jax/eagle3.py
+++ b/tpu_inference/spec_decode/jax/eagle3.py
@@ -162,7 +162,6 @@ class Eagle3Proposer:
 
         return input_ids, last_token_indices
 
-    @jax.jit(static_argnums=(0, ))
     def _update_inputs_for_loop_speculation(
         self, positions: jax.Array, seq_lens: jax.Array,
         block_tables: jax.Array
@@ -205,7 +204,6 @@ class Eagle3Proposer:
 
         return positions, clamped_positions, new_seq_lens, query_start_loc, new_block_tables
 
-    @jax.jit(static_argnums=(0, ))
     def _stack_draft_token_ids(
             self, draft_token_ids_list: list[jax.Array]) -> jnp.ndarray:
         """JIT-compiled helper for stacking draft token IDs."""
@@ -375,7 +373,6 @@ class Eagle3Proposer:
 
         return target_hidden_states, input_ids, last_token_indices, attn_metadata
 
-    @jax.jit(static_argnums=(0, ))
     def _select_draft_token_ids(
         self,
         state: nnx.State,
@@ -388,7 +385,6 @@ class Eagle3Proposer:
             NamedSharding(self.mesh, PartitionSpec(None, None)))
         return self._get_draft_token_ids(state, sample_hidden_states)
 
-    @jax.jit(static_argnums=(0, ))
     def _get_draft_token_ids(self, state: nnx.State,
                              hidden_states: jax.Array) -> jax.Array:
         lora_metadata = None
@@ -397,7 +393,6 @@ class Eagle3Proposer:
         return lax.with_sharding_constraint(
             draft_token_ids, NamedSharding(self.mesh, PartitionSpec()))
 
-    @jax.jit(static_argnums=(0, ))
     def _select_inputs_for_loop_speculation(
             self, state: nnx.State, positions: jax.Array, residual: jax.Array,
             hidden_states: jax.Array,
@@ -424,6 +419,47 @@ class Eagle3Proposer:
         last_token_indices,
         target_hidden_states,
     ) -> tuple[list[jax.Array], jnp.ndarray]:
+        return self._propose(
+            state=self.state,
+            kv_caches=kv_caches,
+            input_ids=input_ids,
+            attn_metadata=attn_metadata,
+            last_token_indices=last_token_indices,
+            target_hidden_states=target_hidden_states,
+            num_speculative_tokens=self.num_speculative_tokens,
+            layer_name_to_kvcache_index=tuple(
+                self.runner.layer_name_to_kvcache_index.items()),
+        )
+
+    @jax.jit(
+        donate_argnames=("kv_caches", ),
+        out_shardings=(
+            None,  # kv_caches - keep original sharding
+            None,  # draft_token_ids
+        ),
+        compiler_options={
+            "xla_tpu_all_gather_collective_matmul_mode":
+            "post_spmd_conservative",
+            "xla_tpu_reduce_scatter_collective_matmul_mode":
+            "post_spmd_conservative"
+        },
+        static_argnums=(
+            0,
+            7,
+            8,
+        ),
+    )
+    def _propose(
+        self,
+        state: nnx.State,
+        kv_caches: list[jax.Array],
+        input_ids: jax.Array,
+        attn_metadata: AttentionMetadata,
+        last_token_indices,
+        target_hidden_states,
+        num_speculative_tokens: int,
+        layer_name_to_kvcache_index: tuple,
+    ) -> tuple[list[jax.Array], jnp.ndarray]:
         """Proposes draft tokens using the draft model.
         Returns:
             A tuple containing the updated KV caches and a tensor of proposed
@@ -432,25 +468,25 @@ class Eagle3Proposer:
 
         # input_ids and target_hidden_states for the first speculation have been prepared in prepare_inputs() to improve performance.
         kv_caches, hidden_states, residual, _ = self.model_fn(
-            self.state,
+            state,
             kv_caches,
             input_ids,
             target_hidden_states,
             attn_metadata,
-            tuple(self.runner.layer_name_to_kvcache_index.items()),
+            layer_name_to_kvcache_index,
         )
 
-        if self.num_speculative_tokens == 1:
+        if num_speculative_tokens == 1:
             return kv_caches, self._select_draft_token_ids(
-                self.state, hidden_states, last_token_indices)
+                state, hidden_states, last_token_indices)
 
         positions, hidden_states, draft_token_ids = self._select_inputs_for_loop_speculation(
-            self.state, attn_metadata.input_positions, residual[0],
-            hidden_states, last_token_indices)
+            state, attn_metadata.input_positions, residual[0], hidden_states,
+            last_token_indices)
 
         draft_token_ids_list = [draft_token_ids]
 
-        for _ in range(self.num_speculative_tokens - 1):
+        for _ in range(num_speculative_tokens - 1):
             input_ids_loop = draft_token_ids_list[-1]
 
             positions, clamped_positions, new_seq_lens, query_start_loc, new_block_tables = self._update_inputs_for_loop_speculation(
@@ -464,16 +500,16 @@ class Eagle3Proposer:
                 block_tables=new_block_tables,
             )
             kv_caches, new_hidden_states, residual, _ = self.model_fn(
-                self.state,
+                state,
                 kv_caches,
                 input_ids_loop,
                 hidden_states,  # This should be the hidden_states from previous step
                 attn_metadata,
-                tuple(self.runner.layer_name_to_kvcache_index.items()),
+                layer_name_to_kvcache_index,
             )
             hidden_states = residual[0]
             draft_token_ids = self._get_draft_token_ids(
-                self.state, new_hidden_states)
+                state, new_hidden_states)
             draft_token_ids_list.append(draft_token_ids)
 
         # [batch_size, num_speculative_tokens]


### PR DESCRIPTION
jit the whole propose() method of the drafter for performance improvement.

Before this PR, there is gap between each drafter's step:
https://screenshot.googleplex.com/9VTrwkgDM8vmoTU
(gap between 2 consecutive target model's step: ~18ms: https://screenshot.googleplex.com/BJnqJpEb2xTAM8W)

After this PR, gamma number of drafter's step is a single jited-fn:
https://screenshot.googleplex.com/BuS82LYwKVpGoAT
(gap between 2 consecutive target model's step: ~14.6ms)


Spec decoding acceptance rate: https://paste.googleplex.com/5345789326000128
is on par with previous test record in https://screenshot.googleplex.com/yeoqKrZVYGDEgUY