### PR TITLE
[MTP] Support speculative tokens in BlockTable and fix shared layer check

### DIFF
--- a/tpu_inference/runner/block_table.py
+++ b/tpu_inference/runner/block_table.py
@@ -84,13 +84,19 @@ class BlockTable:
 class MultiGroupBlockTable:
     """The BlockTables for each KV cache group."""
 
-    def __init__(self, max_num_reqs: int, max_model_len: int,
-                 max_num_batched_tokens: int, pin_memory: bool,
-                 block_sizes: list[int]) -> None:
+    def __init__(self,
+                 max_num_reqs: int,
+                 max_model_len: int,
+                 max_num_batched_tokens: int,
+                 pin_memory: bool,
+                 block_sizes: list[int],
+                 num_speculative_tokens: int = 0) -> None:
         self.block_tables = [
-            BlockTable(max_num_reqs, cdiv(max_model_len, block_size),
-                       max_num_batched_tokens, pin_memory)
-            for block_size in block_sizes
+            BlockTable(
+                max_num_reqs,
+                max(cdiv(max_model_len, block_size),
+                    1 + num_speculative_tokens), max_num_batched_tokens,
+                pin_memory) for block_size in block_sizes
         ]
 
     def append_row(self, block_ids: list[list[int]], row_idx: int) -> None:

--- a/tpu_inference/runner/input_batch.py
+++ b/tpu_inference/runner/input_batch.py
@@ -56,6 +56,7 @@ class InputBatch:
         vocab_size: int,
         block_sizes: list[int],
         is_spec_decode: bool = False,
+        num_speculative_tokens: int = 0,
     ):
         self.is_spec_decode = is_spec_decode
         self.max_num_reqs = max_num_reqs
@@ -90,6 +91,7 @@ class InputBatch:
             max_num_batched_tokens=max_num_batched_tokens,
             pin_memory=pin_memory,
             block_sizes=block_sizes,
+            num_speculative_tokens=num_speculative_tokens,
         )
 
         # Sampling-related.

--- a/tpu_inference/runner/kv_cache_manager.py
+++ b/tpu_inference/runner/kv_cache_manager.py
@@ -612,6 +612,9 @@ class KVCacheManager:
                 "Cannot re-initialize the input batch when CPU weight "
                 "offloading is enabled. See https://github.com/vllm-project/vllm/pull/18298 "  # noqa: E501
                 "for more details.")
+            num_speculative_tokens = 0
+            if self.runner.vllm_config.speculative_config:
+                num_speculative_tokens = self.runner.vllm_config.speculative_config.num_speculative_tokens
             new_input_batch = InputBatch(
                 max_num_reqs=self.runner.max_num_reqs,
                 max_model_len=self.runner.max_model_len,
@@ -619,6 +622,7 @@ class KVCacheManager:
                 pin_memory=False,
                 vocab_size=self.runner.model_config.get_vocab_size(),
                 block_sizes=block_sizes,
+                num_speculative_tokens=num_speculative_tokens,
             )
             self.runner.input_batch = new_input_batch
             self.runner.persistent_batch_manager.input_batch = new_input_batch
@@ -677,14 +681,18 @@ class KVCacheManager:
                         "MambaSpec does not support shared layers for now, defaulting to single KV cache per layer..."
                     )
                     duplicate_shared_layers = True
-                    # assert that each kv_cache_tensor in kv_cache_config.kv_cache_tensors has the same number of shared layers
-                    # This is needed for models like Qwen3.5 where every 4 layers share the same KV cache (3 linear attn and 1 full attn)
-                    num_shared_layers = len(
-                        kv_cache_config.kv_cache_tensors[0].shared_by)
-                    for kv_cache_tensor in kv_cache_config.kv_cache_tensors:
-                        assert len(
-                            kv_cache_tensor.shared_by
-                        ) == num_shared_layers, f"Expected all kv_cache_tensors to have the same number of shared layers {num_shared_layers}, but found {len(kv_cache_tensor.shared_by)}"
+                    non_mtp_tensors = [
+                        t for t in kv_cache_config.kv_cache_tensors
+                        if not any("mtp" in name for name in t.shared_by)
+                    ]
+                    if non_mtp_tensors:
+                        # assert that each kv_cache_tensor in kv_cache_config.kv_cache_tensors has the same number of shared layers
+                        # This is needed for models like Qwen3.5 where every 4 layers share the same KV cache (3 linear attn and 1 full attn)
+                        num_shared_layers = len(non_mtp_tensors[0].shared_by)
+                        for kv_cache_tensor in non_mtp_tensors:
+                            assert len(
+                                kv_cache_tensor.shared_by
+                            ) == num_shared_layers, f"Expected all non-MTP kv_cache_tensors to have the same number of shared layers {num_shared_layers}, but found {len(kv_cache_tensor.shared_by)}"
                     break
 
         for i, kv_cache_tensor in enumerate(kv_cache_config.kv_cache_tensors):


### PR DESCRIPTION
# Description

This PR introduces two main modifications to support Multi-Token Prediction (MTP) and speculative decoding:

* It passes num_speculative_tokens down to the `BlockTable` to ensure sufficient block allocation.
* It relaxes the shared layer assertion in `kv_cache_manager.py` to exclude MTP-specific tensors, which may have different sharing patterns.

## Details
1. Speculative Token Support in Block Table
* In `kv_cache_manager.py`, we now extract num_speculative_tokens from the speculative configuration if it exists. 
* This value is passed to `InputBatch` and subsequently to `MultiGroupBlockTable`
* In MultiGroupBlockTable, the number of blocks is now guaranteed to be at least 1 + num_speculative_tokens, ensuring that we don't under-allocate blocks when running with speculative decoding.

2. MTP-aware Shared Layer Assertion
* Previously, the assertion in `KVCacheManager` required all KV cache tensors to have the same number of shared layers.
* Since MTP modules might not follow the same sharing pattern as the base model (e.g., Qwen3.5 sharing pattern), this PR updates the check to only apply to non-MTP tensors. MTP tensors are identified by checking if "mtp" is present in the names of the layers they are shared by.

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
