### PR TITLE
[xprof] Add env option to allow setting advanced profiling options

### DIFF
--- a/tpu_inference/envs.py
+++ b/tpu_inference/envs.py
@@ -60,6 +60,7 @@ if TYPE_CHECKING:
     DP_SCHED_BATCH_PREFILL: bool = False
     DP_SCHED_BATCH_PREFILL_FLUSH_TIMEOUT_MS: int = 10000
     ONEHOT_MOE_PERMUTE_THRESHOLD: int = 0
+    PROFILE_SINGLE_DEVICE: bool = False
 
 
 def env_with_choices(
@@ -376,6 +377,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # is effectively disabled.
     "ONEHOT_MOE_PERMUTE_THRESHOLD":
     lambda: int(os.getenv("ONEHOT_MOE_PERMUTE_THRESHOLD", "0")),
+    # Profile a single device instead of all devices.
+    "PROFILE_SINGLE_DEVICE":
+    env_bool("PROFILE_SINGLE_DEVICE", default=False),
 }
 
 

--- a/tpu_inference/runner/utils.py
+++ b/tpu_inference/runner/utils.py
@@ -566,6 +566,12 @@ class PhasedBasedProfiler:
             "tpu_num_sparse_cores_to_trace": 1,
             "tpu_num_sparse_core_tiles_to_trace": 1,
         }
+        if envs.PROFILE_SINGLE_DEVICE:
+            self.default_profiling_options.advanced_configuration = {
+                "tpu_num_chips_to_profile_per_task": 1,
+                "tpu_num_sparse_cores_to_trace": 1,
+                "tpu_num_sparse_core_tiles_to_trace": 1,
+            }
 
         self.current_phase: str = ""
 

--- a/tpu_inference/worker/tpu_worker.py
+++ b/tpu_inference/worker/tpu_worker.py
@@ -491,7 +491,12 @@ class TPUWorker(WorkerBase):
             options = jax.profiler.ProfileOptions()
             # default: https://docs.jax.dev/en/latest/profiling.html#general-options
             options.python_tracer_level = envs.PYTHON_TRACER_LEVEL
-            options.host_tracer_level = os.getenv("HOST_TRACER_LEVEL", 1)
+            if envs.PROFILE_SINGLE_DEVICE:
+                options.advanced_configuration = {
+                    "tpu_num_chips_to_profile_per_task": 1,
+                    "tpu_num_sparse_cores_to_trace": 1,
+                    "tpu_num_sparse_core_tiles_to_trace": 1,
+                }
             jax.profiler.start_trace(self.profile_dir,
                                      profiler_options=options)
         else:


### PR DESCRIPTION
Disabled by default. When enabled, restricted the profiling to one tpu and one sparsecore.

why:
Reduce the xprof size to allow profiling more steps without hitting the
protobuf limit causing trace being dropped.