### PR TITLE
Add README content for BM_CASE_TYPE

### DIFF
--- a/.buildkite/benchmark/README.md
+++ b/.buildkite/benchmark/README.md
@@ -104,4 +104,6 @@ Case JSON files should be placed under `.buildkite/benchmark/cases/${BM_CASE_TYP
 
 Buildkite CI schedules are configured to execute cases under `daily` at fixed times every day, and cases under `hourly` every hour. `ci` is used for pipeline `tpu_inference_ci` validation, while `dev` can be used by developers when adding new cases.
 
-When triggering a manual New Build, you need to set the value of `BM_CASE_TYPE`, otherwise only the cases under `daily` will be executed. During development, using `BM_CASE_TYPE=DEV` allows you to execute only the cases in the `dev` folder. The `dev` folder is for temporary use; once development is complete, please move the cases to `daily` or `hourly` before checking in. There should be no case JSON files under the `dev` folder in the `main` branch.
+During development, place the case JSON files currently being developed under `.buildkite/benchmark/cases/dev`. When clicking "New Build" on Buildkite, set `BM_CASE_TYPE=DEV` so that this build will only upload the case JSON files from the `dev` folder.
+
+The `dev` folder is for temporary use; once development is complete, please move the cases to `daily` or `hourly` before checking in. There should be no case JSON files under the `dev` folder in the `main` branch.

--- a/.buildkite/benchmark/README.md
+++ b/.buildkite/benchmark/README.md
@@ -93,3 +93,15 @@ When supplying a custom dataset file via `dataset-path`:
 
 #### D. Implicit DB Tracking Variables
 While variables like `EXPECTED_ETEL`, `INPUT_LEN`, `OUTPUT_LEN`, and `PREFIX_LEN` might not be directly passed to the `vllm` CLI, they are rigorously parsed and injected into the GCP Spanner `RunRecord` table by `report_result.sh` to track historical performance variations. Please ensure that the values of these variables remain consistent with the corresponding parameter settings in the args of the Case JSON file.
+
+## 4. **Test Case File Hierarchy**
+
+Case JSON files should be placed under `.buildkite/benchmark/cases/${BM_CASE_TYPE}`. Four case type folders have been designed here. During test execution, setting `BM_CASE_TYPE` determines which folder's cases are uploaded, with the default being `DAILY`. The following is the mapping between folder names and `BM_CASE_TYPE`:
+* `daily`: `BM_CASE_TYPE=DAILY`
+* `hourly`: `BM_CASE_TYPE=HOURLY`
+* `ci`: `BM_CASE_TYPE=CI`
+* `dev`: `BM_CASE_TYPE=DEV`
+
+Buildkite CI schedules are configured to execute cases under `daily` at fixed times every day, and cases under `hourly` every hour. `ci` is used for pipeline `tpu_inference_ci` validation, while `dev` can be used by developers when adding new cases.
+
+When triggering a manual New Build, you need to set the value of `BM_CASE_TYPE`, otherwise only the cases under `daily` will be executed. During development, using `BM_CASE_TYPE=DEV` allows you to execute only the cases in the `dev` folder. The `dev` folder is for temporary use; once development is complete, please move the cases to `daily` or `hourly` before checking in. There should be no case JSON files under the `dev` folder in the `main` branch.

--- a/.buildkite/benchmark/scripts/benchmark_bootstrap.sh
+++ b/.buildkite/benchmark/scripts/benchmark_bootstrap.sh
@@ -28,10 +28,10 @@ BM_CASE_TYPE="${BM_CASE_TYPE:-DAILY}"
 
 # Validate BM_CASE_TYPE input.
 case "${BM_CASE_TYPE}" in
-    DAILY|HOURLY|CI)
+    DAILY|HOURLY|CI|DEV)
         ;;
     *)
-        echo "🚨 Error: Invalid BM_CASE_TYPE '${BM_CASE_TYPE}'. Allowed values are DAILY, HOURLY, CI." >&2
+        echo "🚨 Error: Invalid BM_CASE_TYPE '${BM_CASE_TYPE}'. Allowed values are DAILY, HOURLY, CI, DEV." >&2
         exit 1
         ;;
 esac


### PR DESCRIPTION
# Description

Add README content explaining that the case folder is divided into daily, hourly, ci, and dev, and that `BM_CASE_TYPE` can be set to specify which folder's cases to execute.

# Tests



# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
