### PR TITLE
[Gemma4] bump timeout in nightly performance test

### DIFF
--- a/.buildkite/models/google_gemma-4-26B-A4B-it.yml
+++ b/.buildkite/models/google_gemma-4-26B-A4B-it.yml
@@ -97,7 +97,7 @@ steps:
           buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_google_gemma-4-26B-A4B-it_Benchmark" "not enough HBM"
           exit 0
         fi
-        .buildkite/scripts/run_in_docker.sh bash -c 'USE_BATCHED_RPA_KERNEL=1 JITTED_MM_MODULE_KEYS="model.vision_tower.encoder" REGISTER_MM_MODULE_CUSTOM_PYTREE_CLASSES="transformers.modeling_outputs.BaseModelOutputWithPast" /workspace/tpu_inference/tests/e2e/benchmarking/mm_bench_recipe.sh'
+        .buildkite/scripts/run_in_docker.sh bash -c 'TIMEOUT_SECONDS=960 USE_BATCHED_RPA_KERNEL=1 JITTED_MM_MODULE_KEYS="model.vision_tower.encoder" REGISTER_MM_MODULE_CUSTOM_PYTREE_CLASSES="transformers.modeling_outputs.BaseModelOutputWithPast" /workspace/tpu_inference/tests/e2e/benchmarking/mm_bench_recipe.sh'
 
   - label: "${TPU_VERSION:-tpu6e} Record performance benchmark result for google/gemma-4-26B-A4B-it"
     key: "${TPU_VERSION:-tpu6e}_record_google_gemma-4-26B-A4B-it_Benchmark"

--- a/.buildkite/models/google_gemma-4-31B-it.yml
+++ b/.buildkite/models/google_gemma-4-31B-it.yml
@@ -87,7 +87,7 @@ steps:
           buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_google_gemma-4-31B-it_Benchmark" "not enough HBM"
           exit 0
         fi
-        .buildkite/scripts/run_in_docker.sh bash -c 'TIMEOUT_SECONDS=720 USE_BATCHED_RPA_KERNEL=1 JITTED_MM_MODULE_KEYS="model.vision_tower.encoder" REGISTER_MM_MODULE_CUSTOM_PYTREE_CLASSES="transformers.modeling_outputs.BaseModelOutputWithPast" /workspace/tpu_inference/tests/e2e/benchmarking/mm_bench_recipe.sh'
+        .buildkite/scripts/run_in_docker.sh bash -c 'TIMEOUT_SECONDS=960 USE_BATCHED_RPA_KERNEL=1 JITTED_MM_MODULE_KEYS="model.vision_tower.encoder" REGISTER_MM_MODULE_CUSTOM_PYTREE_CLASSES="transformers.modeling_outputs.BaseModelOutputWithPast" /workspace/tpu_inference/tests/e2e/benchmarking/mm_bench_recipe.sh'
 
   - label: "${TPU_VERSION:-tpu6e} Record performance benchmark result for google/gemma-4-31B-it"
     key: "${TPU_VERSION:-tpu6e}_record_google_gemma-4-31B-it_Benchmark"


### PR DESCRIPTION
# Description

It took [~6min](https://buildkite.com/tpu-commons/tpu-inference-ci/builds/16572#019df955-af23-4cdf-ae00-a98a77c59ab1/L134-L140) to load weights, but on local run should take ~2 min

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
