### PR TITLE
[Feature] Implementation of Prompt Logprobs support for TPU

### DIFF
--- a/examples/rl_inference.py
+++ b/examples/rl_inference.py
@@ -47,6 +47,7 @@ def main(args: dict):
     mixed_logprobs = args.pop("mixed_logprobs")
 
     # Create an LLM
+    args["enable_return_routed_experts"] = True
     llm = LLM(**args)
 
     # Create a sampling params object

--- a/examples/rl_inference.py
+++ b/examples/rl_inference.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import copy
 import os
 
 from vllm import LLM, EngineArgs
@@ -26,6 +27,11 @@ def create_parser():
     sampling_group.add_argument("--top-p", type=float)
     sampling_group.add_argument("--top-k", type=int)
     sampling_group.add_argument("--log-probs", type=int)
+    sampling_group.add_argument("--prompt-logprobs", type=int)
+    sampling_group.add_argument(
+        "--mixed-logprobs",
+        action="store_true",
+        help="Use mixed prompt_logprobs in one batch for testing")
 
     return parser
 
@@ -37,9 +43,10 @@ def main(args: dict):
     top_p = args.pop("top_p")
     top_k = args.pop("top_k")
     log_probs = args.pop("log_probs")
+    prompt_logprobs = args.pop("prompt_logprobs")
+    mixed_logprobs = args.pop("mixed_logprobs")
 
     # Create an LLM
-    args["enable_return_routed_experts"] = True
     llm = LLM(**args)
 
     # Create a sampling params object
@@ -54,6 +61,8 @@ def main(args: dict):
         sampling_params.top_k = top_k
     if log_probs is not None:
         sampling_params.logprobs = log_probs
+    if prompt_logprobs is not None:
+        sampling_params.prompt_logprobs = prompt_logprobs
 
     # Generate texts from the prompts. The output is a list of RequestOutput
     # objects that contain the prompt, generated text, and other information.
@@ -94,6 +103,19 @@ def main(args: dict):
         "Who wrote the American Declaration of Independence?",
         'Who wrote the novel "Pride and Prejudice"?',
     ]
+
+    # To truly test 'mixed' in one batch, we pass a list of sampling_params.
+    if mixed_logprobs:
+        print("--- Running in MIXED LOGPROBS mode ---")
+        base_params = copy.deepcopy(sampling_params)
+        sampling_params = []
+        for i in range(len(prompts)):
+            p = copy.deepcopy(base_params)
+            if i % 2 == 0:
+                p.prompt_logprobs = prompt_logprobs if prompt_logprobs is not None else 10
+            else:
+                p.prompt_logprobs = None
+            sampling_params.append(p)
 
     profiler_config = llm.llm_engine.vllm_config.profiler_config
     if profiler_config.profiler == "torch":
@@ -145,6 +167,10 @@ def main(args: dict):
 
             if completion.logprobs is not None:
                 print(f"Logprobs for first token: {completion.logprobs[0]}")
+
+        if output.prompt_logprobs is not None:
+            print(f"Prompt logprobs count: {len(output.prompt_logprobs)}")
+            print(f"First 5 prompt logprobs: {output.prompt_logprobs[:5]}")
 
         print("-" * 50)
 

--- a/tests/runner/test_tpu_runner.py
+++ b/tests/runner/test_tpu_runner.py
@@ -94,6 +94,7 @@ class TestTPUJaxRunner:
         self.runner.embed_input_ids_fn = self.mock_get_input_embed_fn
         self.mock_get_input_embed_fn.return_value = dummy_final_embeds
         self.runner.state = MagicMock()
+        self.runner.state_leaves = self.runner.state
 
         # 2. ===== Act & Assert (Multimodal) =====
         self.runner.is_multimodal_model = True
@@ -105,7 +106,7 @@ class TestTPUJaxRunner:
         np.testing.assert_array_equal(np.asarray(inputs_embeds_res),
                                       np.asarray(dummy_final_embeds))
         self.mock_get_input_embed_fn.assert_called_once_with(
-            self.runner.state,
+            self.runner.state_leaves,
             dummy_input_ids,
             dummy_mm_embeds,
             is_multimodal=dummy_is_mm_embed)
@@ -261,15 +262,17 @@ class TestTPUJaxRunnerMultimodalModelLoadedForTextOnly:
             embed_multimodal_fn=None,
             embed_input_ids_fn=None,
             get_mrope_input_positions_fn=None)
+        state = MagicMock()
         return ModelInterface(
-            MagicMock(),  # TPUModelRunner.model_fn
-            MagicMock(),  # TPUModelRunner.compute_logits_fn
-            MagicMock(),  # TPUModelRunner.pooler_fn
-            MagicMock(),  # TPUModelRunner.combine_hidden_states_fn
-            mock_multimodal_fns,  # TPUModelRunner.multimodal_fns
-            MagicMock(),  # TPUModelRunner.state (model params)
-            None,  # TPUModelRunner.lora_manager
-            None,  # TPUModelRunner.model
+            model_fn=MagicMock(),
+            compute_logits_fn=MagicMock(),
+            pooler_fn=MagicMock(),
+            combine_hidden_states_fn=MagicMock(),
+            multimodal_fns=mock_multimodal_fns,
+            state=state,
+            state_leaves=state,
+            lora_manager=MagicMock(),
+            model=MagicMock(),
         )
 
     def test_is_multimodal_model(self):
@@ -306,15 +309,17 @@ class TestTPUJaxRunnerDisableMM:
             embed_multimodal_fn=MagicMock(),
             embed_input_ids_fn=MagicMock(),
             get_mrope_input_positions_fn=None)
+        state = MagicMock()
         return ModelInterface(
-            MagicMock(),  # TPUModelRunner.model_fn
-            MagicMock(),  # TPUModelRunner.compute_logits_fn
-            MagicMock(),  # TPUModelRunner.pooler_fn
-            MagicMock(),  # TPUModelRunner.combine_hidden_states_fn
-            mock_multimodal_fns,  # TPUModelRunner.multimodal_fns
-            MagicMock(),  # TPUModelRunner.state (model params)
-            None,  # TPUModelRunner.lora_manager
-            None,  # TPUModelRunner.model
+            model_fn=MagicMock(),
+            compute_logits_fn=MagicMock(),
+            pooler_fn=MagicMock(),
+            combine_hidden_states_fn=MagicMock(),
+            multimodal_fns=mock_multimodal_fns,
+            state=state,
+            state_leaves=state,
+            lora_manager=MagicMock(),
+            model=MagicMock(),
         )
 
     @pytest.mark.parametrize(

--- a/tests/runner/test_tpu_runner.py
+++ b/tests/runner/test_tpu_runner.py
@@ -93,7 +93,7 @@ class TestTPUJaxRunner:
         self.mock_get_input_embed_fn = MagicMock()
         self.runner.embed_input_ids_fn = self.mock_get_input_embed_fn
         self.mock_get_input_embed_fn.return_value = dummy_final_embeds
-        self.runner.state_leaves = MagicMock()
+        self.runner.state = MagicMock()
 
         # 2. ===== Act & Assert (Multimodal) =====
         self.runner.is_multimodal_model = True
@@ -105,7 +105,7 @@ class TestTPUJaxRunner:
         np.testing.assert_array_equal(np.asarray(inputs_embeds_res),
                                       np.asarray(dummy_final_embeds))
         self.mock_get_input_embed_fn.assert_called_once_with(
-            self.runner.state_leaves,
+            self.runner.state,
             dummy_input_ids,
             dummy_mm_embeds,
             is_multimodal=dummy_is_mm_embed)
@@ -175,9 +175,14 @@ class TestTPUJaxRunner:
         mock_sampling_instance = MagicMock()
         mock_sampling_metadata.from_input_batch.return_value = mock_sampling_instance
 
-        output = self.runner._prepare_inputs(scheduler_output)
+        output = self.runner._prepare_inputs_non_dp(scheduler_output,
+                                                    use_spec_decode=False,
+                                                    any_prompt_logprobs=False)
         assert len(output) == 10
-        input_ids, positions, attention_metadata, sampling_metadata, logits_indices, spec_decode_metadata, logits_indices_selector, padded_num_reqs, req_ids_dp, padded_num_scheduled_tokens_per_dp_rank = output
+        (input_ids, positions, attention_metadata, sampling_metadata,
+         logits_indices, spec_decode_metadata, logits_metadata,
+         padded_num_reqs, req_ids_dp,
+         padded_num_scheduled_tokens_per_dp_rank) = output
         # assert it will create attention metadata for each layer.
         assert isinstance(attention_metadata, dict)
         assert len(attention_metadata) == 20
@@ -193,6 +198,7 @@ class TestTPUJaxRunner:
         mock_kv_cache_config.kv_cache_groups = [
             mock_kv_cache_group1, mock_kv_cache_group2
         ]
+        mock_kv_cache_config.has_mamba_layers = False
         mock_kv_cache_config.has_mamba_layers = False
         self.runner.kv_cache_config = mock_kv_cache_config
         self.runner.use_hybrid_kvcache = True
@@ -256,15 +262,14 @@ class TestTPUJaxRunnerMultimodalModelLoadedForTextOnly:
             embed_input_ids_fn=None,
             get_mrope_input_positions_fn=None)
         return ModelInterface(
-            model_fn=MagicMock(),
-            compute_logits_fn=MagicMock(),
-            pooler_fn=MagicMock(),
-            combine_hidden_states_fn=MagicMock(),
-            multimodal_fns=mock_multimodal_fns,
-            state=MagicMock(),
-            state_leaves=MagicMock(),
-            lora_manager=None,
-            model=None,
+            MagicMock(),  # TPUModelRunner.model_fn
+            MagicMock(),  # TPUModelRunner.compute_logits_fn
+            MagicMock(),  # TPUModelRunner.pooler_fn
+            MagicMock(),  # TPUModelRunner.combine_hidden_states_fn
+            mock_multimodal_fns,  # TPUModelRunner.multimodal_fns
+            MagicMock(),  # TPUModelRunner.state (model params)
+            None,  # TPUModelRunner.lora_manager
+            None,  # TPUModelRunner.model
         )
 
     def test_is_multimodal_model(self):
@@ -302,15 +307,14 @@ class TestTPUJaxRunnerDisableMM:
             embed_input_ids_fn=MagicMock(),
             get_mrope_input_positions_fn=None)
         return ModelInterface(
-            model_fn=MagicMock(),
-            compute_logits_fn=MagicMock(),
-            pooler_fn=MagicMock(),
-            combine_hidden_states_fn=MagicMock(),
-            multimodal_fns=mock_multimodal_fns,
-            state=MagicMock(),
-            state_leaves=MagicMock(),
-            lora_manager=None,
-            model=None,
+            MagicMock(),  # TPUModelRunner.model_fn
+            MagicMock(),  # TPUModelRunner.compute_logits_fn
+            MagicMock(),  # TPUModelRunner.pooler_fn
+            MagicMock(),  # TPUModelRunner.combine_hidden_states_fn
+            mock_multimodal_fns,  # TPUModelRunner.multimodal_fns
+            MagicMock(),  # TPUModelRunner.state (model params)
+            None,  # TPUModelRunner.lora_manager
+            None,  # TPUModelRunner.model
         )
 
     @pytest.mark.parametrize(

--- a/tests/runner/test_tpu_runner_dp.py
+++ b/tests/runner/test_tpu_runner_dp.py
@@ -84,10 +84,27 @@ class TestTPUJaxRunnerDPInputsLightweight:
         # Bind the actual methods to our mock
         self.runner._prepare_inputs = TPUModelRunner._prepare_inputs.__get__(
             self.runner)
+        self.runner._prepare_inputs_dp = TPUModelRunner._prepare_inputs_dp.__get__(
+            self.runner)
+        self.runner._prepare_inputs_non_dp = TPUModelRunner._prepare_inputs_non_dp.__get__(
+            self.runner)
         self.runner._prepare_input_metadata = TPUModelRunner._prepare_input_metadata.__get__(
             self.runner)
         self.runner._prepare_async_token_substitution_indices = TPUModelRunner._prepare_async_token_substitution_indices.__get__(
             self.runner)
+        self.runner._build_logits_metadata = TPUModelRunner._build_logits_metadata.__get__(
+            self.runner)
+        self.runner._apply_async_token_substitution = TPUModelRunner._apply_async_token_substitution.__get__(
+            self.runner)
+
+        self.runner.num_tokens_paddings_per_dp = [8, 16, 32]
+        self.runner.num_reqs_paddings_per_dp = [1, 2, 4, 8]
+        self.runner.attn_num_reqs_paddings = [1, 2, 4, 8]
+        self.runner.model_config = MagicMock()
+        self.runner.model_config.max_logprobs = 5
+        self.runner.model_config.logprobs_mode = "logits"
+        self.runner.phase_based_profiler = None
+        self.runner.lora_config = None
 
     def _create_mock_scheduler_output(self,
                                       num_scheduled_tokens_dict,
@@ -180,7 +197,9 @@ class TestTPUJaxRunnerDPInputsLightweight:
         self.runner.mesh = mock_mesh
         self.runner.data_parallel_attn_sharding = MagicMock()
 
-        result = self.runner._prepare_inputs(scheduler_output)
+        result = self.runner._prepare_inputs_dp(scheduler_output,
+                                                use_spec_decode=False,
+                                                any_prompt_logprobs=False)
 
         assert len(result) == 10
 
@@ -206,12 +225,20 @@ class TestTPUJaxRunnerDPInputsLightweight:
             num_scheduled_tokens, assigned_dp_ranks)
 
         # Execute the method
-        result = self.runner._prepare_inputs(scheduler_output)
+        result = self.runner._prepare_inputs_dp(scheduler_output,
+                                                use_spec_decode=False,
+                                                any_prompt_logprobs=False)
 
         # Basic assertions
         assert len(result) == 10
         (input_ids, positions, attention_metadata, sampling_metadata,
-         logits_indices, spec_decode_metadata, logits_indices_selector,
+         logits_indices, spec_decode_metadata, logits_metadata,
+         padded_num_reqs, req_ids_dp,
+         padded_num_scheduled_tokens_per_dp_rank) = result
+        # Basic assertions
+        assert len(result) == 10
+        (input_ids, positions, attention_metadata, sampling_metadata,
+         logits_indices, spec_decode_metadata, logits_metadata,
          padded_num_reqs, req_ids_dp,
          padded_num_scheduled_tokens_per_dp_rank) = result
 
@@ -225,7 +252,9 @@ class TestTPUJaxRunnerDPInputsLightweight:
         scheduler_output.total_num_scheduled_tokens = 0
 
         with pytest.raises(AssertionError):
-            self.runner._prepare_inputs(scheduler_output)
+            self.runner._prepare_inputs_dp(scheduler_output,
+                                           use_spec_decode=False,
+                                           any_prompt_logprobs=False)
 
         # Test with zero requests - should fail assertion: num_reqs > 0
         self.runner.input_batch.num_reqs = 0
@@ -233,7 +262,9 @@ class TestTPUJaxRunnerDPInputsLightweight:
                                                               {"req1": 0})
 
         with pytest.raises(AssertionError):
-            self.runner._prepare_inputs(scheduler_output)
+            self.runner._prepare_inputs_dp(scheduler_output,
+                                           use_spec_decode=False,
+                                           any_prompt_logprobs=False)
 
     @patch('jax.device_put', side_effect=lambda x, y: x)
     @patch('tpu_inference.runner.tpu_runner.NamedSharding')
@@ -271,12 +302,20 @@ class TestTPUJaxRunnerDPInputsLightweight:
         ]
 
         # Execute the method
-        result = self.runner._prepare_inputs(scheduler_output)
+        result = self.runner._prepare_inputs_dp(scheduler_output,
+                                                use_spec_decode=False,
+                                                any_prompt_logprobs=False)
 
         # Basic assertions
         assert len(result) == 10
         (input_ids, positions, attention_metadata, sampling_metadata,
-         logits_indices, spec_decode_metadata, logits_indices_selector,
+         logits_indices, spec_decode_metadata, logits_metadata,
+         padded_num_reqs, req_ids_dp,
+         padded_num_scheduled_tokens_per_dp_rank) = result
+        # Basic assertions
+        assert len(result) == 10
+        (input_ids, positions, attention_metadata, sampling_metadata,
+         logits_indices, spec_decode_metadata, logits_metadata,
          padded_num_reqs, req_ids_dp,
          padded_num_scheduled_tokens_per_dp_rank) = result
 
@@ -308,7 +347,7 @@ class TestTPUJaxRunnerDPInputsLightweight:
              scheduled_tokens_per_dp_rank, num_req_per_dp_rank,
              padded_num_scheduled_tokens_per_dp_rank, padded_num_reqs,
              attn_padded_num_reqs, padded_total_num_scheduled_tokens,
-             padded_num_reqs_per_dp_rank, logits_indices_selector,
+             padded_num_reqs_per_dp_rank, sampling_indices_selector,
              max_num_reqs_per_dp_rank) = result
 
             # 1. req_ids_dp: Dictionary mapping DP rank to request IDs
@@ -352,12 +391,14 @@ class TestTPUJaxRunnerDPInputsLightweight:
             # 9. padded_num_reqs_per_dp_rank: Padded requests per DP rank
             assert padded_num_reqs_per_dp_rank == 16
 
-            # 10. logits_indices_selector: Array to map back to original request order
-            assert isinstance(logits_indices_selector, np.ndarray)
-            assert len(logits_indices_selector) == 4  # One for each request
+            # 10. sampling_indices_selector: Array to map back to original request order
+            assert isinstance(sampling_indices_selector, np.ndarray)
+            assert len(sampling_indices_selector
+                       ) == 8  # Now same as self.max_num_reqs
             # Should map distributed positions back to original order
-            expected_selector = np.array([0, 1, 16, 17])
-            np.testing.assert_array_equal(logits_indices_selector,
+            expected_selector = np.zeros(8, dtype=np.int32)
+            expected_selector[:4] = [0, 1, 16, 17]
+            np.testing.assert_array_equal(sampling_indices_selector,
                                           expected_selector)
 
             # 11. max_num_reqs_per_dp_rank: Maximum requests per DP rank
@@ -386,12 +427,8 @@ class TestTPUJaxRunnerDPInputsLightweight:
              scheduled_tokens_per_dp_rank, num_req_per_dp_rank,
              padded_num_scheduled_tokens_per_dp_rank, padded_num_reqs,
              attn_padded_num_reqs, padded_total_num_scheduled_tokens,
-             padded_num_reqs_per_dp_rank, logits_indices_selector,
+             padded_num_reqs_per_dp_rank, sampling_indices_selector,
              max_num_reqs_per_dp_rank) = result
-
-            # 1. req_ids_dp
-            assert isinstance(req_ids_dp, dict)
-            assert req_ids_dp[0] == ["req1", "req2"]
             assert req_ids_dp[1] == []  # Empty rank
 
             # 2. req_indices_dp
@@ -430,12 +467,13 @@ class TestTPUJaxRunnerDPInputsLightweight:
             # 10. padded_num_reqs_per_dp_rank: Padded requests per DP rank
             assert padded_num_reqs_per_dp_rank == 16
 
-            # 11. logits_indices_selector: Should preserve original order since no reordering needed
-            assert isinstance(logits_indices_selector, np.ndarray)
-            assert len(logits_indices_selector) == 2
+            # 11. sampling_indices_selector: Should preserve original order since no reordering needed
+            assert isinstance(sampling_indices_selector, np.ndarray)
+            assert len(sampling_indices_selector) == 8
             # Both requests on DP rank 0, positions 0 and 1
-            expected_selector = np.array([0, 1])
-            np.testing.assert_array_equal(logits_indices_selector,
+            expected_selector = np.zeros(8, dtype=np.int32)
+            expected_selector[:2] = [0, 1]
+            np.testing.assert_array_equal(sampling_indices_selector,
                                           expected_selector)
 
             # 12. max_num_reqs_per_dp_rank: Maximum requests per DP rank
@@ -464,26 +502,21 @@ class TestTPUJaxRunnerDPInputsLightweight:
             result = self.runner._prepare_input_metadata(scheduler_output)
 
             (req_ids_dp, req_indices_dp, _, _, _, _, _, _, _, _,
-             logits_indices_selector, _) = result
-
-            # Verify request distribution
-            assert req_ids_dp[0] == ["req2"]  # rank 0: req2 (index 1)
-            assert req_ids_dp[1] == [
-                "req1", "req3"
-            ]  # rank 1: req1 (index 0), req3 (index 2)
+             sampling_indices_selector, _) = result
 
             assert req_indices_dp[0] == [1]  # req2 has original index 1
             assert req_indices_dp[1] == [
                 0, 2
             ]  # req1 has index 0, req3 has index 2
 
-            # The logits_indices_selector should map the DP-distributed positions back to original order
+            # The sampling_indices_selector should map the DP-distributed positions back to original order
 
-            assert isinstance(logits_indices_selector, np.ndarray)
-            assert len(logits_indices_selector) == 3
+            assert isinstance(sampling_indices_selector, np.ndarray)
+            assert len(sampling_indices_selector) == 8
 
-            expected_positions = np.array([8, 0, 9])
-            np.testing.assert_array_equal(logits_indices_selector,
+            expected_positions = np.zeros(8, dtype=np.int32)
+            expected_positions[:3] = [8, 0, 9]
+            np.testing.assert_array_equal(sampling_indices_selector,
                                           expected_positions)
 
     @patch('jax.device_put', side_effect=lambda x, y: x)
@@ -550,9 +583,10 @@ class TestTPUJaxRunnerDPInputsLightweight:
         # Execute the method
         result = self.runner._prepare_inputs(scheduler_output)
         (input_ids, positions, attention_metadata, sampling_metadata,
-         logits_indices, spec_decode_metadata, logits_indices_selector,
+         logits_indices, spec_decode_metadata, logits_metadata,
          padded_num_reqs, req_ids_dp,
          padded_num_scheduled_tokens_per_dp_rank) = result
+
         # 1. Verify input_ids content
         expected_input_ids = np.zeros(16, dtype=np.int32)
         expected_input_ids[:2] = [1006, 1007]
@@ -585,16 +619,17 @@ class TestTPUJaxRunnerDPInputsLightweight:
                                       expected_distribution)
 
         # 5. Verify logits_indices content
-        assert len(logits_indices) == 8  # padded_num_reqs
-        expected_logits = np.full(8, -1, dtype=np.int32)
+        assert len(logits_indices) == 16  # padded_total_num_scheduled_tokens
+        expected_logits = np.zeros(16, dtype=np.int32)
         expected_logits[0] = 1  # req1 last token position (2-1)
         expected_logits[
-            4] = 2  # req2 last token position (3-1) at DP rank 1 offset (4*1)
+            8] = 2  # req2 last token position (3-1) at DP rank 1 offset (8*1)
         assert np.array_equal(logits_indices, expected_logits)
 
         # 6. Verify logits_indices_selector
+        logits_indices_selector = logits_metadata.logits_indices_selector
         assert len(logits_indices_selector) == 2
-        assert np.array_equal(logits_indices_selector, np.array([0, 4]))
+        assert np.array_equal(logits_indices_selector, np.array([0, 8]))
 
     @patch('jax.device_put', side_effect=lambda x, y: x)
     @patch('tpu_inference.runner.tpu_runner.NamedSharding')
@@ -660,7 +695,7 @@ class TestTPUJaxRunnerDPInputsLightweight:
         # Execute the method
         result = self.runner._prepare_inputs(scheduler_output)
         (input_ids, positions, attention_metadata, sampling_metadata,
-         logits_indices, spec_decode_metadata, logits_indices_selector,
+         logits_indices, spec_decode_metadata, logits_metadata,
          padded_num_reqs, req_ids_dp,
          padded_num_scheduled_tokens_per_dp_rank) = result
 
@@ -699,16 +734,16 @@ class TestTPUJaxRunnerDPInputsLightweight:
                                       expected_distribution)
 
         # 5. Verify logits_indices
-        assert len(
-            logits_indices) == 8  # padded_num_reqs (8 in this case, not 16)
+        assert len(logits_indices) == 16  # padded_total_num_scheduled_tokens
         # Rank 0: req1 ends at pos 2, req2 ends at pos 4
-        # Rank 1: empty, so -1 padding
-        expected_logits = np.full(8, -1, dtype=np.int32)
+        # Rank 1: empty
+        expected_logits = np.zeros(16, dtype=np.int32)
         expected_logits[0] = 2  # req1 ends at position 2 (3-1)
         expected_logits[1] = 4  # req2 ends at position 4 (5-1)
         assert np.array_equal(logits_indices, expected_logits)
 
         # 6. Verify logits_indices_selector
+        logits_indices_selector = logits_metadata.logits_indices_selector
         assert len(logits_indices_selector) == 2
         expected_selector = np.array([0, 1])
         np.testing.assert_array_equal(logits_indices_selector,
@@ -768,7 +803,11 @@ class TestTPUJaxRunnerDPInputsLightweight:
         # Execute the method
         result = self.runner._prepare_inputs(scheduler_output)
         (input_ids, positions, attention_metadata, sampling_metadata,
-         logits_indices, spec_decode_metadata, logits_indices_selector,
+         logits_indices, spec_decode_metadata, logits_metadata,
+         padded_num_reqs, req_ids_dp,
+         padded_num_scheduled_tokens_per_dp_rank) = result
+        (input_ids, positions, attention_metadata, sampling_metadata,
+         logits_indices, spec_decode_metadata, logits_metadata,
          padded_num_reqs, req_ids_dp,
          padded_num_scheduled_tokens_per_dp_rank) = result
 
@@ -831,7 +870,11 @@ class TestTPUJaxRunnerDPInputsLightweight:
         # Execute the method
         result = self.runner._prepare_inputs(scheduler_output)
         (input_ids, positions, attention_metadata, sampling_metadata,
-         logits_indices, spec_decode_metadata, logits_indices_selector,
+         logits_indices, spec_decode_metadata, logits_metadata,
+         padded_num_reqs, req_ids_dp,
+         padded_num_scheduled_tokens_per_dp_rank) = result
+        (input_ids, positions, attention_metadata, sampling_metadata,
+         logits_indices, spec_decode_metadata, logits_metadata,
          padded_num_reqs, req_ids_dp,
          padded_num_scheduled_tokens_per_dp_rank) = result
 
@@ -991,6 +1034,48 @@ class TestTPUJaxRunnerDPInputsLightweight:
         # Verify placeholder_num
         assert call_args[4] == 2  # Number of actual substitutions
 
+    def test_prepare_inputs_routing_to_dp(self):
+        """Test _prepare_inputs routes to _prepare_inputs_dp when dp_size > 1."""
+
+        # Bind the actual _prepare_inputs method
+        self.runner._prepare_inputs = TPUModelRunner._prepare_inputs.__get__(
+            self.runner)
+
+        self.runner.dp_size = 2
+        self.runner._prepare_inputs_dp = MagicMock(return_value=(None, ) * 8)
+
+        scheduler_output = MagicMock()
+        scheduler_output.scheduled_spec_decode_tokens = {}
+        scheduler_output.num_scheduled_tokens = []
+        self.runner.input_batch.num_prompt_logprobs = {}
+
+        self.runner._prepare_inputs(scheduler_output)
+
+        # Verify _prepare_inputs_dp was called
+        self.runner._prepare_inputs_dp.assert_called_once_with(
+            scheduler_output, False, False)
+
+    def test_prepare_inputs_always_routing_to_dp(self):
+        """Test _prepare_inputs always routes to _prepare_inputs_dp."""
+
+        # Bind the actual _prepare_inputs method
+        self.runner._prepare_inputs = TPUModelRunner._prepare_inputs.__get__(
+            self.runner)
+
+        self.runner.dp_size = 1
+        self.runner._prepare_inputs_dp = MagicMock(return_value=(None, ) * 10)
+
+        scheduler_output = MagicMock()
+        scheduler_output.scheduled_spec_decode_tokens = {}
+        scheduler_output.num_scheduled_tokens = []
+        self.runner.input_batch.num_prompt_logprobs = {}
+
+        self.runner._prepare_inputs(scheduler_output)
+
+        # Verify _prepare_inputs_dp was called
+        self.runner._prepare_inputs_dp.assert_called_once_with(
+            scheduler_output, False, False)
+
     @patch('jax.device_put', side_effect=lambda x, y: x)
     @patch('tpu_inference.runner.tpu_runner.NamedSharding')
     @patch('tpu_inference.runner.tpu_runner.runner_utils')
@@ -1064,7 +1149,9 @@ class TestTPUJaxRunnerDPInputsLightweight:
         self.runner._prepare_async_token_substitution_indices = mock_prepare_async
 
         # Execute the method
-        _ = self.runner._prepare_inputs(scheduler_output)
+        _ = self.runner._prepare_inputs_dp(scheduler_output,
+                                           use_spec_decode=False,
+                                           any_prompt_logprobs=False)
 
         # Verify async token substitution was called
         mock_prepare_async.assert_called_once()
@@ -1133,12 +1220,17 @@ class TestTPUJaxRunnerDPInputsLightweight:
         self.runner._apply_async_token_substitution = mock_apply_async
 
         # Execute the method
-        _ = self.runner._prepare_inputs(scheduler_output)
+        _ = self.runner._prepare_inputs_dp(scheduler_output,
+                                           use_spec_decode=False,
+                                           any_prompt_logprobs=False)
 
         # Verify _apply_async_token_substitution was called
         mock_apply_async.assert_called_once()
         call_args = mock_apply_async.call_args[0]
 
+        # Verify indices were concatenated from both DP ranks.
+        token_in_tpu_cur_input_indices = call_args[2]
+        token_in_tpu_pre_next_tokens_indices = call_args[3]
         # Verify indices were concatenated from both DP ranks.
         token_in_tpu_cur_input_indices = call_args[2]
         token_in_tpu_pre_next_tokens_indices = call_args[3]
@@ -1297,6 +1389,8 @@ class TestSamplingMetadataPassthrough:
             runner)
         runner._prepare_async_token_substitution_indices = TPUModelRunner._prepare_async_token_substitution_indices.__get__(
             runner)
+        runner._build_logits_metadata = TPUModelRunner._build_logits_metadata.__get__(
+            runner)
 
         mock_runner_utils.get_padded_token_len.side_effect = lambda paddings, val: 8
         mock_sampling_metadata.from_input_batch.return_value = MagicMock()
@@ -1308,7 +1402,10 @@ class TestSamplingMetadataPassthrough:
         scheduler_output.total_num_scheduled_tokens = 5
         scheduler_output.scheduled_spec_decode_tokens = {}
 
-        TPUModelRunner._prepare_inputs(runner, scheduler_output)
+        TPUModelRunner._prepare_inputs_dp(runner,
+                                          scheduler_output,
+                                          use_spec_decode=False,
+                                          any_prompt_logprobs=False)
 
         # Verify from_input_batch was called exactly once with the ATTN_DATA sharding
         mock_sampling_metadata.from_input_batch.assert_called_once()

--- a/tpu_inference/core/sched/dp_scheduler.py
+++ b/tpu_inference/core/sched/dp_scheduler.py
@@ -40,7 +40,7 @@ from vllm.v1.core.sched.scheduler import Scheduler
 from vllm.v1.engine import EngineCoreOutputs
 from vllm.v1.kv_cache_interface import KVCacheConfig
 from vllm.v1.metrics.stats import PrefixCacheStats, SchedulerStats
-from vllm.v1.outputs import DraftTokenIds, LogprobsLists, ModelRunnerOutput
+from vllm.v1.outputs import DraftTokenIds, ModelRunnerOutput
 from vllm.v1.request import Request
 from vllm.v1.structured_output import StructuredOutputManager
 
@@ -1007,22 +1007,33 @@ class DPScheduler(SchedulerInterface):
 
     @staticmethod
     def _slice_logprobs(
-        global_logprobs: LogprobsLists,
+        global_logprobs: Any,
         global_indices: list[int],
-    ) -> LogprobsLists:
-        """Slice a global LogprobsLists to only the given request indices."""
+    ) -> Any:
+        """Slice a global logprobs object (Lists or Tensors) to request indices.
+        
+        Handles the name discrepancy in v1: 
+        LogprobsLists uses 'sampled_token_ranks'
+        LogprobsTensors uses 'selected_token_ranks'
+        """
+        # Determine attribute names and output class
+        is_tensors = hasattr(global_logprobs, "selected_token_ranks")
+        rank_attr = "selected_token_ranks" if is_tensors else "sampled_token_ranks"
+        out_cls = type(global_logprobs)
+
         cu = global_logprobs.cu_num_generated_tokens
         if cu is None:
-            # Arrays indexed directly by req_index — just fancy-index rows.
+            # Direct indexing
             idx = np.array(global_indices, dtype=np.intp)
-            return LogprobsLists(
-                logprob_token_ids=global_logprobs.logprob_token_ids[idx],
-                logprobs=global_logprobs.logprobs[idx],
-                sampled_token_ranks=global_logprobs.sampled_token_ranks[idx],
-                cu_num_generated_tokens=None,
-            )
+            kwargs = {
+                "logprob_token_ids": global_logprobs.logprob_token_ids[idx],
+                "logprobs": global_logprobs.logprobs[idx],
+                rank_attr: getattr(global_logprobs, rank_attr)[idx],
+                "cu_num_generated_tokens": None
+            }
+            return out_cls(**kwargs)
 
-        # Variable-length layout: rebuild slices + compact cumulative offsets.
+        # Variable-length layout
         total = global_logprobs.logprob_token_ids.shape[0]
         slices = []
         new_cu = [0]
@@ -1034,14 +1045,17 @@ class DPScheduler(SchedulerInterface):
 
         def _gather(arr):
             parts = [arr[s:e] for s, e in slices]
+            if isinstance(arr, torch.Tensor):
+                return torch.cat(parts, axis=0) if parts else arr[:0]
             return np.concatenate(parts, axis=0) if parts else arr[:0]
 
-        return LogprobsLists(
-            logprob_token_ids=_gather(global_logprobs.logprob_token_ids),
-            logprobs=_gather(global_logprobs.logprobs),
-            sampled_token_ranks=_gather(global_logprobs.sampled_token_ranks),
-            cu_num_generated_tokens=new_cu,
-        )
+        kwargs = {
+            "logprob_token_ids": _gather(global_logprobs.logprob_token_ids),
+            "logprobs": _gather(global_logprobs.logprobs),
+            rank_attr: _gather(getattr(global_logprobs, rank_attr)),
+            "cu_num_generated_tokens": new_cu
+        }
+        return out_cls(**kwargs)
 
     def _split_model_output_by_rank(
             self, scheduler_output: DPSchedulerOutput,

--- a/tpu_inference/models/common/model_loader.py
+++ b/tpu_inference/models/common/model_loader.py
@@ -70,32 +70,78 @@ def _get_model_architecture(config: PretrainedConfig) -> nnx.Module:
     # NOTE: Use inline imports here, otherwise the normal imports
     # would cause JAX init failure when using multi hosts with Ray.
 
-    from tpu_inference.models.jax.deepseek_v3 import DeepseekV3ForCausalLM
-    from tpu_inference.models.jax.gemma4_mm import \
-        Gemma4ForConditionalGeneration
-    from tpu_inference.models.jax.gpt_oss import GptOss
-    from tpu_inference.models.jax.llama3 import LlamaForCausalLM
-    from tpu_inference.models.jax.llama4 import Llama4ForCausalLM
-    from tpu_inference.models.jax.llama_eagle3 import EagleLlama3ForCausalLM
-    from tpu_inference.models.jax.llama_guard_4 import LlamaGuard4ForCausalLM
-    from tpu_inference.models.jax.qwen2 import Qwen2ForCausalLM
-    from tpu_inference.models.jax.qwen2_5_vl import \
-        Qwen2_5_VLForConditionalGeneration
-    from tpu_inference.models.jax.qwen3 import Qwen3ForCausalLM
-    from tpu_inference.models.jax.qwen3_moe import Qwen3MoeForCausalLM
-    _MODEL_REGISTRY["Llama4ForCausalLM"] = Llama4ForCausalLM
-    _MODEL_REGISTRY["DeepseekV3ForCausalLM"] = DeepseekV3ForCausalLM
-    _MODEL_REGISTRY["LlamaForCausalLM"] = LlamaForCausalLM
-    _MODEL_REGISTRY["Llama4ForConditionalGeneration"] = LlamaGuard4ForCausalLM
-    _MODEL_REGISTRY["Qwen3ForCausalLM"] = Qwen3ForCausalLM
-    _MODEL_REGISTRY["Qwen3MoeForCausalLM"] = Qwen3MoeForCausalLM
-    _MODEL_REGISTRY[
-        "Qwen2_5_VLForConditionalGeneration"] = Qwen2_5_VLForConditionalGeneration
-    _MODEL_REGISTRY["Eagle3LlamaForCausalLM"] = EagleLlama3ForCausalLM
-    _MODEL_REGISTRY["GptOssForCausalLM"] = GptOss
-    _MODEL_REGISTRY["Qwen2ForCausalLM"] = Qwen2ForCausalLM
-    _MODEL_REGISTRY[
-        "Gemma4ForConditionalGeneration"] = Gemma4ForConditionalGeneration
+    try:
+        from tpu_inference.models.jax.deepseek_v3 import DeepseekV3ForCausalLM
+        _MODEL_REGISTRY["DeepseekV3ForCausalLM"] = DeepseekV3ForCausalLM
+    except (ImportError, ModuleNotFoundError):
+        pass
+
+    try:
+        from tpu_inference.models.jax.gemma4_mm import \
+            Gemma4ForConditionalGeneration
+        _MODEL_REGISTRY[
+            "Gemma4ForConditionalGeneration"] = Gemma4ForConditionalGeneration
+    except (ImportError, ModuleNotFoundError):
+        pass
+
+    try:
+        from tpu_inference.models.jax.gpt_oss import GptOss
+        _MODEL_REGISTRY["GptOssForCausalLM"] = GptOss
+    except (ImportError, ModuleNotFoundError):
+        pass
+
+    try:
+        from tpu_inference.models.jax.llama3 import LlamaForCausalLM
+        _MODEL_REGISTRY["LlamaForCausalLM"] = LlamaForCausalLM
+    except (ImportError, ModuleNotFoundError):
+        pass
+
+    try:
+        from tpu_inference.models.jax.llama4 import Llama4ForCausalLM
+        _MODEL_REGISTRY["Llama4ForCausalLM"] = Llama4ForCausalLM
+    except (ImportError, ModuleNotFoundError):
+        pass
+
+    try:
+        from tpu_inference.models.jax.llama_eagle3 import \
+            EagleLlama3ForCausalLM
+        _MODEL_REGISTRY["Eagle3LlamaForCausalLM"] = EagleLlama3ForCausalLM
+    except (ImportError, ModuleNotFoundError):
+        pass
+
+    try:
+        from tpu_inference.models.jax.llama_guard_4 import \
+            LlamaGuard4ForCausalLM
+        _MODEL_REGISTRY[
+            "Llama4ForConditionalGeneration"] = LlamaGuard4ForCausalLM
+    except (ImportError, ModuleNotFoundError):
+        pass
+
+    try:
+        from tpu_inference.models.jax.qwen2 import Qwen2ForCausalLM
+        _MODEL_REGISTRY["Qwen2ForCausalLM"] = Qwen2ForCausalLM
+    except (ImportError, ModuleNotFoundError):
+        pass
+
+    try:
+        from tpu_inference.models.jax.qwen2_5_vl import \
+            Qwen2_5_VLForConditionalGeneration
+        _MODEL_REGISTRY[
+            "Qwen2_5_VLForConditionalGeneration"] = Qwen2_5_VLForConditionalGeneration
+    except (ImportError, ModuleNotFoundError):
+        pass
+
+    try:
+        from tpu_inference.models.jax.qwen3 import Qwen3ForCausalLM
+        _MODEL_REGISTRY["Qwen3ForCausalLM"] = Qwen3ForCausalLM
+    except (ImportError, ModuleNotFoundError):
+        pass
+
+    try:
+        from tpu_inference.models.jax.qwen3_moe import Qwen3MoeForCausalLM
+        _MODEL_REGISTRY["Qwen3MoeForCausalLM"] = Qwen3MoeForCausalLM
+    except (ImportError, ModuleNotFoundError):
+        pass
 
     architectures = getattr(config, "architectures", [])
     for arch in architectures:

--- a/tpu_inference/runner/compilation_manager.py
+++ b/tpu_inference/runner/compilation_manager.py
@@ -170,7 +170,7 @@ class CompilationManager:
             self._run_compilation(
                 "input_embeddings_merger",
                 self.runner.embed_input_ids_fn,
-                self.runner.state,
+                self.runner.state_leaves,
                 dummy_input_ids,
                 dummy_multimodal_embeddings,
                 call_kwargs={"is_multimodal": dummy_is_multimodal},
@@ -180,7 +180,7 @@ class CompilationManager:
             self._run_compilation(
                 "input_embeddings_merger_text_only",
                 self.runner.embed_input_ids_fn,
-                self.runner.state,
+                self.runner.state_leaves,
                 dummy_input_ids,
                 None,
                 call_kwargs={"is_multimodal": None},
@@ -656,7 +656,7 @@ class CompilationManager:
                 self._run_compilation(
                     f"worker{self.runner.rank} compute_logits",
                     self.runner.compute_logits_fn,
-                    self.runner.state,
+                    self.runner.state_leaves,
                     hidden_states,
                     lora_metadata,
                     num_reqs=num_reqs,

--- a/tpu_inference/runner/compilation_manager.py
+++ b/tpu_inference/runner/compilation_manager.py
@@ -106,7 +106,9 @@ class CompilationManager:
     def capture_model(self) -> None:
         if envs.SKIP_JAX_PRECOMPILE or self.runner.model_config.enforce_eager:
             return
-        logger.info("Precompile all the subgraphs with possible input shapes.")
+        logger.info(
+            f"Precompile all the subgraphs with possible input shapes. num_tokens_paddings={self.runner.num_tokens_paddings} attn_num_reqs_paddings={self.runner.attn_num_reqs_paddings}"
+        )
         compilation_start_time = time.perf_counter()
 
         with self.runner.maybe_setup_dummy_loras(
@@ -149,32 +151,17 @@ class CompilationManager:
         for num_tokens in self.runner.num_tokens_paddings:
             hidden_size = self.runner.vllm_config.model_config.get_hidden_size(
             )
-            hf_conf = self.runner.vllm_config.model_config.hf_config
-
-            # Identify multimodal embedding size
-            mm_hidden_size = hidden_size
-            vision_config = getattr(hf_conf, "vision_config", None)
-
-            if vision_config:
-                visual_dim = getattr(vision_config, "out_hidden_size", None)
-                deepstack_indexes = getattr(vision_config,
-                                            "deepstack_visual_indexes", None)
-
-                # If both exist, we apply the deepstack concat logic
-                if visual_dim is not None and deepstack_indexes is not None:
-                    deepstack_levels = len(deepstack_indexes)
-                    mm_hidden_size = visual_dim * (1 + deepstack_levels)
-
             sharding = NamedSharding(
                 self.runner.mesh,
                 PartitionSpec(ShardingAxisName.ATTN_DATA, None))
             input_sharding = NamedSharding(
                 self.runner.mesh, PartitionSpec(ShardingAxisName.ATTN_DATA))
 
-            dummy_multimodal_embeddings = self._create_dummy_tensor(
-                (num_tokens, mm_hidden_size),
+            dummy_mm_embeds = self._create_dummy_tensor(
+                (num_tokens, hidden_size),
                 self.runner.vllm_config.model_config.dtype,
                 sharding=sharding)
+            dummy_multimodal_embeddings = [dummy_mm_embeds]
             dummy_input_ids = self._create_dummy_tensor(
                 (num_tokens, ), jnp.int32, sharding=input_sharding)
             dummy_is_multimodal = self._create_dummy_tensor(
@@ -183,10 +170,9 @@ class CompilationManager:
             self._run_compilation(
                 "input_embeddings_merger",
                 self.runner.embed_input_ids_fn,
-                self.runner.state_leaves,
+                self.runner.state,
                 dummy_input_ids,
-                # Make _compute_deepstack_embeds happy.
-                [dummy_multimodal_embeddings],
+                dummy_multimodal_embeddings,
                 call_kwargs={"is_multimodal": dummy_is_multimodal},
                 num_tokens=num_tokens,
             )
@@ -194,7 +180,7 @@ class CompilationManager:
             self._run_compilation(
                 "input_embeddings_merger_text_only",
                 self.runner.embed_input_ids_fn,
-                self.runner.state_leaves,
+                self.runner.state,
                 dummy_input_ids,
                 None,
                 call_kwargs={"is_multimodal": None},
@@ -284,7 +270,7 @@ class CompilationManager:
             }
 
         def model_fn_wrapper(
-            state_leaves,
+            state,
             kv_caches,
             input_ids,
             attention_metadata,
@@ -297,10 +283,9 @@ class CompilationManager:
             is_last_rank,
         ):
             kv_caches, hidden_states, *_ = self.runner.model_fn(
-                state_leaves, kv_caches, input_ids, attention_metadata,
-                inputs_embeds, positions, layer_name_to_kvcache_index,
-                lora_metadata, intermediate_tensors, is_first_rank,
-                is_last_rank)
+                state, kv_caches, input_ids, attention_metadata, inputs_embeds,
+                positions, layer_name_to_kvcache_index, lora_metadata,
+                intermediate_tensors, is_first_rank, is_last_rank)
             self.runner.kv_caches = kv_caches
             return hidden_states
 
@@ -491,39 +476,17 @@ class CompilationManager:
     def _precompile_backbone_with_inputs_embeds(self) -> None:
         hidden_size = self.runner.model_config.get_hidden_size()
         dtype = self.runner.model_config.dtype
+        for num_tokens in self.runner.num_tokens_paddings:
+            for num_reqs in self.runner.attn_num_reqs_paddings:
+                sharding = NamedSharding(
+                    self.runner.mesh,
+                    PartitionSpec(ShardingAxisName.ATTN_DATA, None))
+                input_sharding = NamedSharding(
+                    self.runner.mesh,
+                    PartitionSpec(ShardingAxisName.ATTN_DATA))
 
-        # Identify multimodal embedding size including Deepstack
-        hf_conf = self.runner.vllm_config.model_config.hf_config
-        vision_config = getattr(hf_conf, "vision_config", None)
-        embeds_hidden_size = hidden_size
-
-        if vision_config:
-            visual_dim = getattr(vision_config, "out_hidden_size", None)
-            deepstack_indexes = getattr(vision_config,
-                                        "deepstack_visual_indexes", None)
-
-            # If both exist, we apply the deepstack concat logic
-            if visual_dim is not None and deepstack_indexes is not None:
-                deepstack_levels = len(deepstack_indexes)
-                embeds_hidden_size = visual_dim * (1 + deepstack_levels)
-
-        # Compile for both standard (4k) and Deepstack (16k) dimensions if they differ
-        hidden_sizes_to_compile = [hidden_size]
-        if embeds_hidden_size != hidden_size:
-            hidden_sizes_to_compile.append(embeds_hidden_size)
-
-        for h_size in hidden_sizes_to_compile:
-            for num_tokens in self.runner.num_tokens_paddings:
-                for num_reqs in self.runner.attn_num_reqs_paddings:
-                    sharding = NamedSharding(
-                        self.runner.mesh,
-                        PartitionSpec(ShardingAxisName.ATTN_DATA, None))
-                    input_sharding = NamedSharding(
-                        self.runner.mesh,
-                        PartitionSpec(ShardingAxisName.ATTN_DATA))
-
-                    inputs_embeds = self._create_dummy_tensor(
-                        (num_tokens, h_size), dtype, sharding=sharding)
+                inputs_embeds = self._create_dummy_tensor(
+                    (num_tokens, hidden_size), dtype, sharding=sharding)
                 if self.runner.uses_mrope:
                     mrope_sharding = NamedSharding(
                         self.runner.mesh,
@@ -617,10 +580,15 @@ class CompilationManager:
         logger.info("Compiling select_from_array with different input shapes.")
         hsize = self.runner.model_config.get_hidden_size()
 
+        # index_paddings should cover all possible shapes of logits_indices.
+        # When any_prompt_logprobs is True, it matches num_tokens_paddings.
+        # When False, it matches num_reqs_paddings (or num_logits_paddings for spec decode).
+        index_paddings = set(self.runner.num_reqs_paddings)
+        index_paddings.update(self.runner.num_tokens_paddings)
         if self.runner.speculative_config:
-            index_paddings = self.runner.num_logits_paddings
-        else:
-            index_paddings = self.runner.num_reqs_paddings
+            index_paddings.update(self.runner.num_logits_paddings)
+        index_paddings = sorted(list(index_paddings))
+
         dp_sharding = NamedSharding(self.runner.mesh,
                                     PartitionSpec(ShardingAxisName.ATTN_DATA))
         hidden_states_sharding = NamedSharding(
@@ -663,7 +631,13 @@ class CompilationManager:
     def _precompile_compute_logits(self) -> None:
         logger.info("Compiling compute_logits with different input shapes.")
         hsize = self.runner.model_config.get_hidden_size()
-        leading_shape = self.runner.num_reqs_paddings if not self.runner.speculative_config else self.runner.num_logits_paddings
+
+        leading_shape = set(self.runner.num_reqs_paddings)
+        leading_shape.update(self.runner.num_tokens_paddings)
+        if self.runner.speculative_config:
+            leading_shape.update(self.runner.num_logits_paddings)
+        leading_shape = sorted(list(leading_shape))
+
         # Use PartitionSpec(ATTN_DATA, None) (2D explicit) to match the sharding
         # that _select_from_array_fn produces at inference time. shard_map with
         # out_specs=P('data') returns arrays with spec P('data', None); since
@@ -682,7 +656,7 @@ class CompilationManager:
                 self._run_compilation(
                     f"worker{self.runner.rank} compute_logits",
                     self.runner.compute_logits_fn,
-                    self.runner.state_leaves,
+                    self.runner.state,
                     hidden_states,
                     lora_metadata,
                     num_reqs=num_reqs,
@@ -788,7 +762,12 @@ class CompilationManager:
     def _precompile_gather_logprobs(self) -> None:
         logger.info("Compiling gather_logprobs with different input shapes.")
         hsize = self.runner.vocab_size
-        for num_reqs in self.runner.num_reqs_paddings:
+
+        # gather_logprobs must be compiled for both num_reqs (sampling) and num_tokens (prompt_logprobs)
+        paddings = set(self.runner.num_reqs_paddings)
+        paddings.update(self.runner.num_tokens_paddings)
+
+        for num_reqs in sorted(list(paddings)):
             logits_sharding = NamedSharding(
                 self.runner.mesh,
                 PartitionSpec(ShardingAxisName.MLP_DATA,

--- a/tpu_inference/runner/input_batch.py
+++ b/tpu_inference/runner/input_batch.py
@@ -123,6 +123,7 @@ class InputBatch:
         self.generators: dict[int, Any] = {}
 
         self.num_logprobs: dict[str, int] = {}
+        self.num_prompt_logprobs: dict[str, int] = {}
 
         self.logit_bias: list[Optional[dict[int,
                                             float]]] = [None] * max_num_reqs
@@ -294,6 +295,9 @@ class InputBatch:
 
             if sampling_params.logprobs is not None:
                 self.num_logprobs[req_id] = sampling_params.logprobs
+            if sampling_params.prompt_logprobs is not None:
+                self.num_prompt_logprobs[
+                    req_id] = sampling_params.prompt_logprobs
             if sampling_params.logit_bias is not None:
                 self.logit_bias[req_index] = sampling_params.logit_bias
 
@@ -371,6 +375,7 @@ class InputBatch:
         self.min_tokens.pop(req_index, None)
         self.generators.pop(req_index, None)
         self.num_logprobs.pop(req_id, None)
+        self.num_prompt_logprobs.pop(req_id, None)
 
         # It's ok to pop nothing for non-pooling model.
         self.pooling_params.pop(req_id, None)
@@ -539,7 +544,13 @@ class InputBatch:
 
     @property
     def max_num_logprobs(self) -> Optional[int]:
-        return max(self.num_logprobs.values()) if self.num_logprobs else None
+        max_gen_logprobs = max(
+            self.num_logprobs.values()) if self.num_logprobs else 0
+        max_prompt_logprobs = max(self.num_prompt_logprobs.values()
+                                  ) if self.num_prompt_logprobs else 0
+
+        total_max = max(max_gen_logprobs, max_prompt_logprobs)
+        return total_max if total_max > 0 else None
 
     def make_lora_inputs(
         self, num_scheduled_tokens: np.ndarray

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -23,6 +23,7 @@ import jax
 import jax.numpy as jnp
 import jaxtyping
 import numpy as np
+import torch
 import vllm.envs as vllm_envs
 from flax import nnx
 from jax._src import mesh as mesh_lib
@@ -39,8 +40,8 @@ from vllm.v1.core.sched.output import GrammarOutput
 from vllm.v1.core.sched.output import SchedulerOutput as VllmSchedulerOutput
 from vllm.v1.kv_cache_interface import KVCacheConfig
 from vllm.v1.outputs import (EMPTY_MODEL_RUNNER_OUTPUT, AsyncModelRunnerOutput,
-                             DraftTokenIds, KVConnectorOutput, LogprobsLists,
-                             LogprobsTensors, ModelRunnerOutput)
+                             DraftTokenIds, KVConnectorOutput, LogprobsTensors,
+                             ModelRunnerOutput)
 from vllm.v1.request import Request
 from vllm.v1.spec_decode.ngram_proposer import NgramProposer
 from vllm.v1.worker.kv_connector_model_runner_mixin import \
@@ -92,6 +93,20 @@ INVALID_TOKEN_ID = -1
 MIN_NUM_SEQS = 8
 
 
+@dataclass
+class LogitsMetadata:
+    logits_indices_selector: Optional[List[int]] = None
+    num_logits_per_req: Optional[list[int]] = None
+    any_prompt_logprobs: bool = False
+    sampling_indices_selector: Optional[np.ndarray] = None
+    gi_physical_indices: Optional[np.ndarray] = None
+    gi_relative_indices: Optional[np.ndarray] = None
+    gi_physical_indices_tpu: Optional[jax.Array] = None
+    sampling_indices_selector_tpu: Optional[jax.Array] = None
+    gi_physical_indices_replicated_tpu: Optional[jax.Array] = None
+    sampling_indices_selector_replicated_tpu: Optional[jax.Array] = None
+
+
 class AsyncTPUModelRunnerOutput(AsyncModelRunnerOutput):
     """Holds asynchronous model output specifically from a TPU runner.
 
@@ -109,7 +124,7 @@ class AsyncTPUModelRunnerOutput(AsyncModelRunnerOutput):
                  next_tokens: jax.Array,
                  num_reqs: int,
                  discard_sampled_tokens_req_indices: list[int],
-                 logits_indices_selector: Optional[List[int]] = None,
+                 logits_metadata: Optional[LogitsMetadata] = None,
                  logprobs_tensors: Optional[LogprobsTensors] = None,
                  expert_indices: Optional[jax.Array] = None,
                  total_num_scheduled_tokens: int = 0,
@@ -119,7 +134,7 @@ class AsyncTPUModelRunnerOutput(AsyncModelRunnerOutput):
         self._next_tokens = next_tokens
         self._num_reqs = num_reqs
         self._discard_sampled_tokens_req_indices = discard_sampled_tokens_req_indices
-        self.logits_indices_selector: list[int] = logits_indices_selector
+        self._logits_metadata = logits_metadata
         self._logprobs_tensors = logprobs_tensors
         self._expert_indices = expert_indices
         self._total_num_scheduled_tokens = total_num_scheduled_tokens
@@ -127,17 +142,27 @@ class AsyncTPUModelRunnerOutput(AsyncModelRunnerOutput):
         self._runner = runner
 
     def get_output(self) -> ModelRunnerOutput:
+        sampling_indices_selector = (
+            self._logits_metadata.sampling_indices_selector
+            if self._logits_metadata else None)
+        logits_indices_selector = (
+            self._logits_metadata.logits_indices_selector
+            if self._logits_metadata else None)
         valid_sampled_token_ids = runner_utils.host_extract_sampled_tokens(
             self._runner, self._spec_decode_metadata, self._next_tokens,
-            self.logits_indices_selector,
+            sampling_indices_selector,
             self._discard_sampled_tokens_req_indices, self._num_reqs)
 
         self._model_runner_output.sampled_token_ids = valid_sampled_token_ids
 
         if self._logprobs_tensors is not None:
-            # Use materialize to ensure logprobs are ready on host when we return async results
-            self._model_runner_output.logprobs = _jax_logprobs_materialize(
-                self._logprobs_tensors, self.logits_indices_selector)
+            # Separate prompt logprobs and sampling logprobs
+            materialized_logprobs = _jax_logprobs_materialize(
+                self._logprobs_tensors, logits_indices_selector)
+            self._model_runner_output.logprobs, self._model_runner_output.prompt_logprobs_dict = _separate_logprobs(
+                materialized_logprobs,
+                self._logits_metadata.num_logits_per_req,
+                self._model_runner_output.req_ids)
 
         if self._expert_indices is not None:
             expert_indices_cpu = np.asarray(
@@ -156,7 +181,7 @@ class AsyncPreResults:
     request_seq_lens: list[tuple[int, CachedRequestState, int]]
     discard_sampled_tokens_req_indices: list[int]
     placeholder_req_id_to_index: dict[str, int]
-    logits_indices_selector: Optional[List[int]] = None
+    logits_metadata: Optional[LogitsMetadata] = None
 
     # Only when spec decoding is enabled, the follow variables
     # are populated.
@@ -181,7 +206,7 @@ class ExecuteModelState:
     aux_hidden_states: Optional[jax.Array]
     spec_decode_metadata: Optional[SpecDecodeMetadata]
     kv_connector_output: Optional[KVConnectorOutput]
-    logits_indices_selector: Optional[List[int]] = None
+    logits_metadata: Optional[LogitsMetadata] = None
     padded_num_reqs: Optional[int] = None
     expert_indices: Optional[jax.Array] = None
     full_hidden_states: Optional[jax.Array] = None
@@ -258,8 +283,8 @@ def _jax_logprobs_copy_to_host_async(
 def _jax_logprobs_materialize(
         logprobs_tensors: LogprobsTensors,
         logits_indices_selector: Optional[List[int]] = None,
-        cu_num_generated_tokens: Optional[Any] = None) -> LogprobsLists:
-    """Materializes logprobs from JAX arrays into NumPy-backed LogprobsLists."""
+        cu_num_generated_tokens: Optional[Any] = None) -> LogprobsTensors:
+    """Materializes logprobs from JAX arrays into Torch-backed LogprobsTensors."""
     log_token_ids = np.asarray(
         jax.device_get(logprobs_tensors.logprob_token_ids))
     logprobs_arr = np.asarray(jax.device_get(logprobs_tensors.logprobs))
@@ -271,12 +296,188 @@ def _jax_logprobs_materialize(
         logprobs_arr = logprobs_arr[logits_indices_selector]
         selected_token_ranks = selected_token_ranks[logits_indices_selector]
 
-    return LogprobsLists(
-        logprob_token_ids=np.array(log_token_ids.tolist()),
-        logprobs=np.array(logprobs_arr.tolist()),
-        sampled_token_ranks=np.array(selected_token_ranks.tolist()),
+    # Use CPU tensors for V1 serialization
+    return LogprobsTensors(
+        logprob_token_ids=torch.from_numpy(log_token_ids).to("cpu"),
+        logprobs=torch.from_numpy(logprobs_arr).to("cpu"),
+        selected_token_ranks=torch.from_numpy(selected_token_ranks).to("cpu"),
         cu_num_generated_tokens=cu_num_generated_tokens,
     )
+
+
+def _separate_logprobs(
+    materialized_logprobs: LogprobsTensors,
+    num_logits_per_req: Optional[List[int]],
+    req_ids: List[str],
+) -> Tuple[LogprobsTensors, Dict[str, LogprobsTensors]]:
+    """Separates materialized logprobs into sampling and prompt logprobs.
+
+    Args:
+        materialized_logprobs: Torch-backed LogprobsTensors on CPU.
+        num_logits_per_req: List of token counts for each request.
+        req_ids: List of request IDs.
+    """
+    if num_logits_per_req is None:
+        return materialized_logprobs, {}
+
+    cu_num_logits = [0] + np.cumsum(num_logits_per_req).tolist()
+
+    sampling_logprob_token_ids = []
+    sampling_logprobs = []
+    sampling_token_ranks = []
+    prompt_logprobs_dict = {}
+
+    num_reqs = len(req_ids)
+    for i in range(num_reqs):
+        start = cu_num_logits[i]
+        end = cu_num_logits[i + 1]
+        num_tokens = num_logits_per_req[i]
+
+        # The last one is for sampling
+        sampling_logprob_token_ids.append(
+            materialized_logprobs.logprob_token_ids[end - 1])
+        sampling_logprobs.append(materialized_logprobs.logprobs[end - 1])
+        sampling_token_ranks.append(
+            materialized_logprobs.selected_token_ranks[end - 1])
+
+        if num_tokens > 1:
+            # Everything except the last one is prompt logprobs
+            prompt_logprobs_dict[req_ids[i]] = LogprobsTensors(
+                logprob_token_ids=materialized_logprobs.
+                logprob_token_ids[start:end - 1],
+                logprobs=materialized_logprobs.logprobs[start:end - 1],
+                selected_token_ranks=materialized_logprobs.
+                selected_token_ranks[start:end - 1],
+                cu_num_generated_tokens=None,
+            )
+
+    sampling_result = LogprobsTensors(
+        logprob_token_ids=torch.stack(sampling_logprob_token_ids),
+        logprobs=torch.stack(sampling_logprobs),
+        selected_token_ranks=torch.stack(sampling_token_ranks),
+        cu_num_generated_tokens=materialized_logprobs.cu_num_generated_tokens,
+    )
+    return sampling_result, prompt_logprobs_dict
+
+
+def _get_num_draft_tokens(
+    scheduler_output: VllmSchedulerOutput,
+    req_id_to_index: Dict[str, int],
+    num_reqs: int,
+) -> np.ndarray:
+    """Extracts the number of draft tokens for each request in the batch."""
+    num_draft_tokens = np.zeros(num_reqs, dtype=np.int32)
+    for req_id, draft_token_ids in (
+            scheduler_output.scheduled_spec_decode_tokens.items()):
+        if req_id in req_id_to_index:
+            req_idx = req_id_to_index[req_id]
+            num_draft_tokens[req_idx] = len(draft_token_ids)
+    return num_draft_tokens
+
+
+def _populate_logits_metadata(
+    input_batch: InputBatch,
+    scheduler_output: "VllmSchedulerOutput",
+    query_start_loc_view: np.ndarray,
+    logits_indices_view: np.ndarray,
+    num_reqs: int,
+    dp_size: int,
+    req_ids_dp: Dict[int, List[str]],
+    num_req_per_dp_rank: Dict[int, int],
+    padded_logits_length: int,
+    max_num_reqs_per_dp_rank: int,
+    padded_num_reqs_per_dp_rank: int,
+    any_prompt_logprobs: bool,
+    use_spec_decode: bool,
+) -> Tuple[List[int], List[int], np.ndarray, np.ndarray]:
+    """Standard Interleaved Layout. Ensures compatibility with Async Token Substitution."""
+    logits_indices_selector = []
+    num_logits_per_req = []
+    is_dp = int(dp_size) > 1
+    padded_num_reqs = int(padded_num_reqs_per_dp_rank) * int(dp_size)
+    gi_physical_indices = np.full(padded_num_reqs, -1, dtype=np.int32)
+    gi_relative_indices = np.full(padded_num_reqs, -1, dtype=np.int32)
+
+    if is_dp:
+        padded_logits_length_per_rank = int(padded_logits_length) // int(
+            dp_size)
+        req_id_to_indices = {}
+        req_id_to_count = {}
+        req_id_to_relative_gi = {}
+
+        for dp_rank in range(int(dp_size)):
+            req_offset = dp_rank * padded_logits_length_per_rank
+            query_loc_req_offset = dp_rank * (int(max_num_reqs_per_dp_rank) +
+                                              1)
+            _num_reqs_in_rank = num_req_per_dp_rank[dp_rank]
+            relative_offset = 0
+
+            for i in range(_num_reqs_in_rank):
+                start = query_start_loc_view[query_loc_req_offset + i]
+                end = query_start_loc_view[query_loc_req_offset + i + 1]
+                req_id = req_ids_dp[dp_rank][i]
+
+                # Optimization: If no logprobs and no spec-decode, num_logits is always 1
+                if not (any_prompt_logprobs or use_spec_decode):
+                    num_logits = 1
+                else:
+                    num_logits = (end - start) if (
+                        req_id in input_batch.num_prompt_logprobs
+                        and not use_spec_decode) else 1
+                    if use_spec_decode:
+                        num_logits = len(
+                            scheduler_output.scheduled_spec_decode_tokens.get(
+                                req_id, [])) + 1
+
+                logits_indices_view[req_offset:req_offset +
+                                    num_logits] = np.arange(start,
+                                                            end)[-num_logits:]
+                indices = list(range(req_offset, req_offset + num_logits))
+                req_id_to_indices[req_id] = indices
+                req_id_to_count[req_id] = num_logits
+                req_id_to_relative_gi[
+                    req_id] = relative_offset + num_logits - 1
+
+                # Physical slot i in this rank's Gi-block
+                gi_physical_indices[dp_rank * int(padded_num_reqs_per_dp_rank)
+                                    + i] = relative_offset + num_logits - 1
+                req_offset += num_logits
+                relative_offset += num_logits
+
+        current_relative_base = 0
+        for req_id in input_batch.req_ids[:int(num_reqs)]:
+            logits_indices_selector.extend(req_id_to_indices[req_id])
+            count = req_id_to_count[req_id]
+            num_logits_per_req.append(count)
+
+            batch_idx = input_batch.req_id_to_index[req_id]
+            gi_relative_indices[
+                batch_idx] = current_relative_base + req_id_to_relative_gi[
+                    req_id]
+            current_relative_base += count
+    else:
+        req_offset = 0
+        for i, req_id in enumerate(input_batch.req_ids[:int(num_reqs)]):
+            start, end = query_start_loc_view[i], query_start_loc_view[i + 1]
+
+            if not (any_prompt_logprobs or use_spec_decode):
+                num_logits = 1
+            else:
+                num_logits = (
+                    end - start) if (req_id in input_batch.num_prompt_logprobs
+                                     and not use_spec_decode) else 1
+
+            logits_indices_view[req_offset:req_offset +
+                                num_logits] = np.arange(start,
+                                                        end)[-num_logits:]
+            logits_indices_selector.extend(
+                range(req_offset, req_offset + num_logits))
+            num_logits_per_req.append(num_logits)
+            gi_physical_indices[i] = req_offset + num_logits - 1
+            gi_relative_indices[i] = req_offset + num_logits - 1
+            req_offset += num_logits
+
+    return logits_indices_selector, num_logits_per_req, gi_physical_indices, gi_relative_indices
 
 
 class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
@@ -565,29 +766,32 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         # the max_reqs. If ATTN_BUCKETIZE_NUM_REQS=true, it is the
         # power-of-two between min and max reqs.
         # User can set ATTN_CUSTOM_NUM_REQS_BUCKETS to provide custom buckets.
-        self.attn_num_reqs_paddings_per_dp = runner_utils.get_attn_req_paddings(
-            min_req_size=MIN_NUM_SEQS,
-            max_req_size=scheduler_config.max_num_seqs)
-        self.attn_num_reqs_paddings = [
-            padding * self.dp_size
-            for padding in self.attn_num_reqs_paddings_per_dp
-        ]
-
+        self.attn_num_reqs_paddings = runner_utils.get_attn_req_paddings(
+            min_req_size=min_num_reqs, max_req_size=self.max_num_reqs)
         self.num_reqs_paddings_per_dp = [
             padding // self.dp_size for padding in self.num_reqs_paddings
         ]
 
-        # Padding for logits. Without speculative decoding, each request has one position to select from.
-        # With speculative decoding, each request has multiple positions to select from.
-        max_logits_per_req = 1
+        # Padding for logits. Without speculative decoding or prompt logprobs,
+        # each request has one position to select from.
         if self.speculative_config:
             max_logits_per_req = self.speculative_config.num_speculative_tokens + 1  # Including bonus token
-            self.num_logits_paddings = runner_utils.get_token_paddings(
-                min_token_size=MIN_NUM_SEQS,
-                max_token_size=self.max_num_reqs * max_logits_per_req,
-                padding_gap=0)
+        elif self.model_config.max_logprobs > 0:
+            # If the model config allows logprobs, we prepare for the possibility
+            # of prompt_logprobs, which can have up to max_model_len logits.
+            max_logits_per_req = self.max_model_len
         else:
-            self.num_logits_paddings = None
+            max_logits_per_req = 1
+
+        # The total number of logits in one step cannot exceed the total number
+        # of tokens scheduled in that step.
+        max_logits_total = min(self.max_num_tokens,
+                               self.max_num_reqs * max_logits_per_req)
+
+        self.num_logits_paddings = runner_utils.get_token_paddings(
+            min_token_size=MIN_NUM_SEQS,
+            max_token_size=max_logits_total,
+            padding_gap=0)
 
         # tensors for structured decoding
         self.grammar_bitmask_cpu = np.zeros(
@@ -661,7 +865,10 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         # tuple of array leaves and reconstructs the nnx.State inside the
         # jit. Pre-flatten here so subsequent dispatches skip the per-call
         # walk of `nnx.Variable` wrappers
-        self.state_leaves = model.state_leaves
+        if isinstance(self.state, nnx.State):
+            self.state_leaves = tuple(jax.tree_util.tree_leaves(self.state))
+        else:
+            self.state_leaves = self.state
         self.lora_manager = model.lora_manager
         self.model = model.model
 
@@ -786,25 +993,10 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             # This can happen in pipeline parallel case.
             return EMPTY_MODEL_RUNNER_OUTPUT
 
-        (scheduler_output, attn_metadata, sampling_metadata, input_ids,
-         hidden_states, logits, aux_hidden_states, spec_decode_metadata,
-         kv_connector_output, logits_indices_selector, padded_num_reqs,
-         expert_indices, full_hidden_states) = (
-             self.execute_model_state.scheduler_output,
-             self.execute_model_state.attn_metadata,
-             self.execute_model_state.sampling_metadata,
-             self.execute_model_state.input_ids,
-             self.execute_model_state.hidden_states,
-             self.execute_model_state.logits,
-             self.execute_model_state.aux_hidden_states,
-             self.execute_model_state.spec_decode_metadata,
-             self.execute_model_state.kv_connector_output,
-             self.execute_model_state.logits_indices_selector,
-             self.execute_model_state.padded_num_reqs,
-             self.execute_model_state.expert_indices,
-             self.execute_model_state.full_hidden_states)
+        state = self.execute_model_state
         self.execute_model_state = None
 
+        logits = state.logits
         if grammar_output is not None:
             (
                 require_struct_decoding, grammar_bitmask_padded, arange
@@ -817,10 +1009,12 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                 arange,
             )
         return self._sample_from_logits(
-            scheduler_output, attn_metadata, sampling_metadata, input_ids,
-            hidden_states, logits, aux_hidden_states, spec_decode_metadata,
-            kv_connector_output, logits_indices_selector, padded_num_reqs,
-            expert_indices, full_hidden_states)
+            state.scheduler_output, state.attn_metadata,
+            state.sampling_metadata, state.input_ids, state.hidden_states,
+            logits, state.aux_hidden_states, state.spec_decode_metadata,
+            state.kv_connector_output, state.logits_metadata,
+            state.padded_num_reqs, state.expert_indices,
+            state.full_hidden_states)
 
     def _modify_prev_results(self):
         # If copy to host has not been done, we just wait.
@@ -831,12 +1025,13 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         pre_next_tokens = self._pre_async_results.next_tokens
         pre_request_seq_lens = self._pre_async_results.request_seq_lens
         pre_discard_sampled_tokens_req_indices = self._pre_async_results.discard_sampled_tokens_req_indices
-        pre_logits_indices_selector = self._pre_async_results.logits_indices_selector
+        pre_logits_metadata = self._pre_async_results.logits_metadata
         pre_spec_decode_metadata = self._pre_async_results.spec_decode_metadata
 
         valid_sampled_token_ids = runner_utils.host_extract_sampled_tokens(
             self, pre_spec_decode_metadata, pre_next_tokens,
-            pre_logits_indices_selector,
+            pre_logits_metadata.sampling_indices_selector
+            if pre_logits_metadata else None,
             pre_discard_sampled_tokens_req_indices, pre_num_reqs)
 
         # Append sampled tokens
@@ -883,10 +1078,16 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                             discard_sampled_tokens_req_indices,
                             request_seq_lens,
                             spec_decode_metadata,
-                            logits_indices_selector=None):
+                            sampling_indices_selector=None):
         placeholder_req_id_to_index: dict[str, int] = {}
         discard_sampled_tokens_req_indices_set = set(
             discard_sampled_tokens_req_indices)
+
+        if sampling_indices_selector is not None:
+            # Ensure it is on CPU for indexing
+            sampling_indices_selector = np.asarray(
+                jax.device_get(sampling_indices_selector))
+
         for req_idx, req_state, _ in request_seq_lens:
             if req_idx in discard_sampled_tokens_req_indices_set:
                 continue
@@ -906,11 +1107,12 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
 
             # For placeholder, should be update on next execute.
             req_state.output_token_ids.extend([0] * (end_idx - start_idx))
-            if logits_indices_selector is None:
+            if sampling_indices_selector is None:
                 placeholder_req_id_to_index[req_state.req_id] = req_idx
             else:
+                # Use the sampling selector to find the exact slot in the next_tokens array
                 placeholder_req_id_to_index[
-                    req_state.req_id] = logits_indices_selector[req_idx]
+                    req_state.req_id] = sampling_indices_selector[req_idx]
         return placeholder_req_id_to_index
 
     def _execute_model(
@@ -945,7 +1147,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             sampling_metadata,
             logits_indices,
             spec_decode_metadata,
-            logits_indices_selector,
+            logits_metadata,
             padded_num_reqs,
             req_ids_dp,
             padded_num_scheduled_tokens_per_dp_rank,
@@ -1041,7 +1243,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         hidden_states = self._select_from_array_fn(hidden_states,
                                                    logits_indices)
         logits = self.compute_logits_fn(
-            self.state_leaves,
+            self.state,
             hidden_states,
             lora_metadata,
         )
@@ -1056,7 +1258,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             aux_hidden_states=aux_hidden_states,
             spec_decode_metadata=spec_decode_metadata,
             kv_connector_output=kv_connector_output,
-            logits_indices_selector=logits_indices_selector,
+            logits_metadata=logits_metadata,
             padded_num_reqs=padded_num_reqs,
             expert_indices=expert_indices,
             full_hidden_states=full_hidden_states)
@@ -1073,7 +1275,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         aux_hidden_states: Optional[jax.Array],
         spec_decode_metadata: Optional[SpecDecodeMetadata],
         kv_connector_output: Optional[KVConnectorOutput],
-        logits_indices_selector: Optional[List[int]] = None,
+        logits_metadata: Optional[LogitsMetadata] = None,
         padded_num_reqs: Optional[int] = None,
         expert_indices: Optional[jax.Array] = None,
         full_hidden_states: Optional[jax.Array] = None,
@@ -1088,15 +1290,39 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         else:
             step_rng = self.rng_params_for_sampling
 
+        logits_indices_selector = (logits_metadata.logits_indices_selector
+                                   if logits_metadata else None)
+
         if spec_decode_metadata is None:
             logits = logits.astype(jnp.float32)
+
+            # Use gi_physical_indices_tpu to correctly extract the sampling logits
+            # from the flattened array. This handles both Interleaved and
+            # Generation First layouts, and ensures SPMD alignment across all chips.
+            idx_jax = logits_metadata.gi_physical_indices_tpu if logits_metadata else None
+            if idx_jax is not None:
+                gen_logits = self._select_from_array_fn(logits, idx_jax)
+            else:
+                # Fallback to legacy behavior if gi_physical_indices is missing
+                gen_logits = logits[:padded_num_reqs]
+
             with self.maybe_forbid_compile:
-                next_tokens, processed_logits = sample(
+                next_tokens, processed_gen_logits = sample(
                     step_rng,
                     self.mesh,
-                    logits,
+                    gen_logits,
                     tpu_sampling_metadata,
                 )
+
+            # Reconstruct the full processed_logits by placing sampled results
+            # back into their respective slots.
+            processed_logits = logits
+            if idx_jax is not None:
+                processed_logits = self._update_array_fn(
+                    processed_logits, idx_jax, processed_gen_logits)
+            else:
+                processed_logits = processed_logits.at[:padded_num_reqs].set(
+                    processed_gen_logits)
         else:
             # TODO(gxd3): wrap the spec decode sampling code block
             # under maybe_forbid_compile as well.
@@ -1128,12 +1354,56 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             )
 
         logits = logits.astype(jnp.float32)
-        with self.maybe_forbid_compile:
 
+        if tpu_sampling_metadata.logprobs:
+            logits_to_gather = processed_logits if self.model_config.logprobs_mode == "processed_logprobs" else logits
+
+            # In prompt_logprobs mode, logits are longer than next_tokens.
+            # We pad next_tokens to match the logits shape for broadcasting,
+            # ensuring gather_logprobs doesn't crash.
+            # We do this eager prep outside forbid_compile because JAX compiles
+            # simple eager ops for new shapes and we don't want to crash.
+            if logits_metadata and logits_metadata.any_prompt_logprobs:
+                padded_next_tokens = jnp.zeros((logits_to_gather.shape[0], ),
+                                               dtype=next_tokens.dtype)
+
+                # Use PartitionSpec() for replicated sharding
+                replicated_spec = PartitionSpec()
+                padded_next_tokens = jax.lax.with_sharding_constraint(
+                    padded_next_tokens,
+                    NamedSharding(self.mesh, replicated_spec),
+                )
+
+                idx_jax = logits_metadata.gi_physical_indices_replicated_tpu
+                if idx_jax is not None:
+                    padded_next_tokens = self._update_array_fn(
+                        padded_next_tokens,
+                        idx_jax,
+                        next_tokens,
+                        sharding=replicated_spec)
+                else:
+                    tokens_1d = jnp.reshape(next_tokens, (-1, ))
+                    padded_next_tokens = padded_next_tokens.at[:tokens_1d.
+                                                               shape[0]].set(
+                                                                   tokens_1d)
+
+                token_ids_for_gather = jax.lax.with_sharding_constraint(
+                    padded_next_tokens,
+                    NamedSharding(self.mesh, replicated_spec),
+                )
+            else:
+                # next_tokens is already replicated from the sample() function,
+                # but we re-apply it here to be explicit and match P().
+                token_ids_for_gather = jax.lax.with_sharding_constraint(
+                    next_tokens,
+                    NamedSharding(self.mesh, PartitionSpec()),
+                )
+
+        with self.maybe_forbid_compile:
             if tpu_sampling_metadata.logprobs:
-                logits = processed_logits if self.model_config.logprobs_mode == "processed_logprobs" else logits
                 logprobs = self._compute_and_gather_logprobs(
-                    logits, next_tokens, self.model_config.max_logprobs)
+                    logits_to_gather, token_ids_for_gather,
+                    self.model_config.max_logprobs)
                 logprobs = _jax_logprobs_copy_to_host_async(logprobs)
             else:
                 logprobs = None
@@ -1204,10 +1474,13 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                 self._modify_prev_results()
 
             # Set placeholder for next tokens that is not yet generated
+            sampling_indices_selector = (
+                logits_metadata.sampling_indices_selector
+                if logits_metadata else None)
             placeholder_req_id_to_index: dict[
                 str, int] = self._update_placeholder(
                     discard_sampled_tokens_req_indices, request_seq_lens,
-                    spec_decode_metadata, logits_indices_selector)
+                    spec_decode_metadata, sampling_indices_selector)
 
             spec_decode_next_tokens = None
             if self.speculative_config:
@@ -1226,7 +1499,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                 discard_sampled_tokens_req_indices=
                 discard_sampled_tokens_req_indices,
                 placeholder_req_id_to_index=placeholder_req_id_to_index,
-                logits_indices_selector=logits_indices_selector,
+                logits_metadata=logits_metadata,
                 spec_decode_next_tokens=spec_decode_next_tokens,
                 spec_decode_num_rejected_tokens=spec_decode_num_rejected_tokens,
                 spec_decode_metadata=spec_decode_metadata,
@@ -1248,7 +1521,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                 next_tokens,
                 num_reqs,
                 discard_sampled_tokens_req_indices,
-                logits_indices_selector,
+                logits_metadata=logits_metadata,
                 logprobs_tensors=logprobs,
                 expert_indices=expert_indices,
                 total_num_scheduled_tokens=scheduler_output.
@@ -1257,8 +1530,10 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                 runner=self)
             return async_model_runner_output
 
+        sampling_indices_selector = (logits_metadata.sampling_indices_selector
+                                     if logits_metadata else None)
         valid_sampled_token_ids = runner_utils.host_extract_sampled_tokens(
-            self, spec_decode_metadata, next_tokens, logits_indices_selector,
+            self, spec_decode_metadata, next_tokens, sampling_indices_selector,
             discard_sampled_tokens_req_indices, num_reqs)
 
         # Append sampled tokens
@@ -1281,9 +1556,14 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             req_state.output_token_ids.extend(sampled_ids)
 
         if logprobs is not None:
-            # Use materialize to ensure logprobs are ready on host when we return async results
-            logprobs_lists = _jax_logprobs_materialize(
-                logprobs, logits_indices_selector)
+            # Separate prompt logprobs and sampling logprobs
+            materialized_logprobs = _jax_logprobs_materialize(
+                logprobs, logits_metadata.logits_indices_selector
+                if logits_metadata else None)
+            logprobs_lists, prompt_logprobs_dict_updates = _separate_logprobs(
+                materialized_logprobs, logits_metadata.num_logits_per_req
+                if logits_metadata else None, req_ids)
+            prompt_logprobs_dict.update(prompt_logprobs_dict_updates)
         else:
             logprobs_lists = None
 
@@ -1338,19 +1618,70 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
 
         return model_runner_output
 
-    @jax.jit(static_argnums=(0, ))
-    def _select_from_array_fn(self, array, indices_to_select):
+    def _build_logits_metadata(self,
+                               logits_indices_selector,
+                               num_logits_per_req,
+                               any_prompt_logprobs,
+                               sampling_indices_selector,
+                               gi_physical_indices,
+                               gi_relative_indices,
+                               data_parallel_attn_sharding,
+                               logits_indices_view=None):
+        replicated_sharding = NamedSharding(self.mesh, PartitionSpec())
+        return LogitsMetadata(
+            logits_indices_selector=logits_indices_selector,
+            num_logits_per_req=num_logits_per_req,
+            any_prompt_logprobs=any_prompt_logprobs,
+            sampling_indices_selector=sampling_indices_selector,
+            gi_physical_indices=gi_physical_indices,
+            gi_relative_indices=gi_relative_indices,
+            sampling_indices_selector_tpu=device_array(
+                self.mesh,
+                sampling_indices_selector,
+                sharding=data_parallel_attn_sharding),
+            gi_physical_indices_tpu=device_array(
+                self.mesh,
+                logits_indices_view
+                if logits_indices_view is not None else gi_physical_indices,
+                sharding=data_parallel_attn_sharding),
+            gi_physical_indices_replicated_tpu=device_array(
+                self.mesh,
+                logits_indices_view
+                if logits_indices_view is not None else gi_physical_indices,
+                sharding=replicated_sharding),
+            sampling_indices_selector_replicated_tpu=device_array(
+                self.mesh,
+                sampling_indices_selector,
+                sharding=replicated_sharding),
+        )
+
+    @functools.partial(jax.jit, static_argnums=(0, 3))
+    def _select_from_array_fn(self, array, indices_to_select, sharding=None):
+        if sharding is None:
+            sharding = PartitionSpec(ShardingAxisName.ATTN_DATA)
 
         def select_local_fn(local_array, local_indices):
             return local_array[local_indices]
 
-        ret = jax.shard_map(
-            select_local_fn,
-            mesh=self.mesh,
-            in_specs=(PartitionSpec(ShardingAxisName.ATTN_DATA),
-                      PartitionSpec(ShardingAxisName.ATTN_DATA)),
-            out_specs=PartitionSpec(ShardingAxisName.ATTN_DATA))(
-                array, indices_to_select)
+        ret = jax.shard_map(select_local_fn,
+                            mesh=self.mesh,
+                            in_specs=(sharding, sharding),
+                            out_specs=sharding)(array, indices_to_select)
+
+        return ret
+
+    @functools.partial(jax.jit, static_argnums=(0, 4))
+    def _update_array_fn(self, array, indices, updates, sharding=None):
+        if sharding is None:
+            sharding = PartitionSpec(ShardingAxisName.ATTN_DATA)
+
+        def update_local_fn(local_array, local_indices, local_updates):
+            return local_array.at[local_indices].set(local_updates)
+
+        ret = jax.shard_map(update_local_fn,
+                            mesh=self.mesh,
+                            in_specs=(sharding, sharding, sharding),
+                            out_specs=sharding)(array, indices, updates)
 
         return ret
 
@@ -1408,31 +1739,25 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         padded_num_reqs_per_dp_rank = runner_utils.get_padded_token_len(
             self.num_reqs_paddings_per_dp, max_num_reqs_across_dp)
         padded_num_reqs = padded_num_reqs_per_dp_rank * dp_size
-        attn_padded_num_reqs = runner_utils.get_padded_token_len(
-            self.attn_num_reqs_paddings_per_dp,
-            max_num_reqs_across_dp) * dp_size
 
-        # logits_indices_selector reorders per-rank outputs back to the
-        # original batch ordering; with a single rank the ordering is already
-        # the input-batch ordering, so no selector is needed.
-        if dp_size > 1:
-            all_req_indices = np.concatenate(
-                [req_indices_dp[dp_rank] for dp_rank in range(dp_size)])
-            all_positions = np.concatenate([
-                np.arange(len(req_indices_dp[dp_rank])) +
-                padded_num_reqs_per_dp_rank * dp_rank
-                for dp_rank in range(dp_size)
-            ])
-            sorted_indices = np.argsort(all_req_indices)
-            logits_indices_selector = all_positions[sorted_indices]
-        else:
-            logits_indices_selector = None
+        # sampling_indices_selector: maps [0..num_reqs-1] -> [0..padded_num_reqs-1]
+        # used to unsuffle tokens returned by the sampler back to the original request order.
+        sampling_indices_selector = np.zeros(self.max_num_reqs, dtype=np.int32)
+
+        for dp_rank in range(dp_size):
+            for i, req_idx in enumerate(req_indices_dp[dp_rank]):
+                # The sampler only sees the 'Generation Block' [0..padded_num_reqs-1].
+                # Each rank's portion is padded_num_reqs_per_dp_rank wide.
+                sampling_loc = i + padded_num_reqs_per_dp_rank * dp_rank
+                sampling_indices_selector[req_idx] = sampling_loc
+        attn_padded_num_reqs = runner_utils.get_padded_token_len(
+            self.attn_num_reqs_paddings, padded_num_reqs)
 
         return (req_ids_dp, req_indices_dp, num_scheduled_tokens_per_dp_rank,
                 scheduled_tokens_per_dp_rank, num_req_per_dp_rank,
                 padded_num_scheduled_tokens_per_dp_rank, padded_num_reqs,
                 attn_padded_num_reqs, padded_total_num_scheduled_tokens,
-                padded_num_reqs_per_dp_rank, logits_indices_selector,
+                padded_num_reqs_per_dp_rank, sampling_indices_selector,
                 max_num_reqs_per_dp_rank)
 
     def _prepare_async_token_substitution_indices(
@@ -1474,7 +1799,11 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             for i, req_id in enumerate(req_ids_dp[dp_rank]):
                 acc_cur_len += num_scheduled_tokens_per_req[i]
                 if dp_rank == 0:
-                    draft_tokens_acc_cur_len += num_draft_tokens[i]
+                    if isinstance(num_draft_tokens, dict):
+                        cur_num_draft_tokens = num_draft_tokens.get(i, 0)
+                    else:
+                        cur_num_draft_tokens = num_draft_tokens[i]
+                    draft_tokens_acc_cur_len += cur_num_draft_tokens
                 if req_id not in self._pre_async_results.placeholder_req_id_to_index:
                     continue
 
@@ -1497,9 +1826,13 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                         token_in_tpu_pre_next_tokens_indices_list.append(
                             idx * (max_num_spec_tokens + 1) + j)
 
-                    draft_base_offset = draft_tokens_acc_cur_len - num_draft_tokens[
-                        i]
-                    for j in range(num_draft_tokens[i]):
+                    if isinstance(num_draft_tokens, dict):
+                        cur_num_draft_tokens = num_draft_tokens.get(i, 0)
+                    else:
+                        cur_num_draft_tokens = num_draft_tokens[i]
+
+                    draft_base_offset = draft_tokens_acc_cur_len - cur_num_draft_tokens
+                    for j in range(cur_num_draft_tokens):
                         draft_token_in_tpu_cur_indices_list.append(
                             draft_base_offset + j)
                         draft_token_in_prev_next_tokens_indices_list.append(
@@ -1587,6 +1920,17 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         return seq_lens, positions
 
     def _prepare_inputs(self, scheduler_output: "VllmSchedulerOutput"):
+        use_spec_decode = len(
+            scheduler_output.scheduled_spec_decode_tokens) > 0
+        any_prompt_logprobs = any(
+            req_id in self.input_batch.num_prompt_logprobs
+            for req_id in scheduler_output.num_scheduled_tokens)
+
+        return self._prepare_inputs_dp(scheduler_output, use_spec_decode,
+                                       any_prompt_logprobs)
+
+    def _prepare_inputs_dp(self, scheduler_output: "VllmSchedulerOutput",
+                           use_spec_decode: bool, any_prompt_logprobs: bool):
         total_num_scheduled_tokens = scheduler_output.total_num_scheduled_tokens
         assert total_num_scheduled_tokens > 0
         num_reqs = self.input_batch.num_reqs
@@ -1603,12 +1947,11 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
          scheduled_tokens_per_dp_rank, num_req_per_dp_rank,
          padded_num_scheduled_tokens_per_dp_rank, padded_num_reqs,
          attn_padded_num_reqs, padded_total_num_scheduled_tokens,
-         padded_num_reqs_per_dp_rank, logits_indices_selector,
+         padded_num_reqs_per_dp_rank, sampling_indices_selector,
          max_num_reqs_per_dp_rank
          ) = self._prepare_input_metadata(scheduler_output)
+
         # Multi-modal support
-        # Calculate M-RoPE positions.
-        # Only relevant for models using M-RoPE (e.g, Qwen2-VL)
         if self.uses_mrope:
             self.mm_manager.calc_mrope_positions(
                 scheduler_output, req_ids_dp,
@@ -1620,13 +1963,12 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
              ) in scheduler_output.scheduled_spec_decode_tokens.items():
             req_idx = self.input_batch.req_id_to_index[req_id]
             num_draft_tokens[req_idx] = len(draft_token_ids)
+
         token_in_tpu_cur_input_indices_dp = {}
         token_in_tpu_pre_next_tokens_indices_dp = {}
         draft_token_in_tpu_cur_indices_dp = {}
         draft_token_in_prev_next_tokens_indices_dp = {}
         if self.scheduler_config.async_scheduling and self._pre_async_results is not None:
-            # If async previous results exists, we will prepare for the token substitution here
-            # The actual substitution will be performed in tpu during later parts of this function.
             (token_in_tpu_cur_input_indices_dp,
              token_in_tpu_pre_next_tokens_indices_dp,
              draft_token_in_tpu_cur_indices_dp,
@@ -1645,28 +1987,11 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         seq_lens_view = self.device_buffer.get_view((self.max_num_reqs, ),
                                                     key="seq_lens")
 
-        use_spec_decode = len(
-            scheduler_output.scheduled_spec_decode_tokens) > 0
-
-        if use_spec_decode:
-            num_draft_tokens = np.zeros(num_reqs, dtype=np.int32)
-            for (
-                    req_id,
-                    draft_token_ids,
-            ) in scheduler_output.scheduled_spec_decode_tokens.items():
-                req_idx = self.input_batch.req_id_to_index[req_id]
-                num_draft_tokens[req_idx] = len(draft_token_ids)
-
-            num_sampled_tokens = num_draft_tokens + 1
-            total_sampled_tokens = np.sum(num_sampled_tokens)
-            padded_logits_length = runner_utils.get_padded_token_len(
-                self.num_logits_paddings, total_sampled_tokens)
-            logits_indices_shape = (padded_logits_length, )
-        else:
-            logits_indices_shape = (padded_num_reqs, )
-
+        padded_logits_length = padded_total_num_scheduled_tokens
+        logits_indices_shape = (padded_logits_length, )
         logits_indices_view = self.device_buffer.get_view(logits_indices_shape,
                                                           key="logits_indices")
+        logits_indices_view.fill(0)
 
         # Populates input_ids and positions
         for dp_rank in range(dp_size):
@@ -1675,7 +2000,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             token_offset = padded_num_scheduled_tokens_per_dp_rank * dp_rank
             num_scheduled_tokens_per_req = scheduled_tokens_per_dp_rank[
                 dp_rank]
-            total_num_scheduled_tokens = num_scheduled_tokens_per_dp_rank[
+            total_num_scheduled_tokens_rank = num_scheduled_tokens_per_dp_rank[
                 dp_rank]
             input_ids_cpu = input_ids_view[
                 token_offset:token_offset +
@@ -1683,37 +2008,25 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             positions_cpu = self.positions_cpu[
                 token_offset:token_offset +
                 padded_num_scheduled_tokens_per_dp_rank]
-            # Get request indices.
-            # E.g., [2, 5, 3] -> [0, 0, 1, 1, 1, 1, 1, 2, 2, 2]
-            # For each scheduled token, what are the corresponding req index.
             req_indices = np.repeat(req_indices_dp[dp_rank],
                                     num_scheduled_tokens_per_req)
-            # Get batched arange.
-            # E.g., [2, 5, 3] -> [0, 1, 0, 1, 2, 3, 4, 0, 1, 2]
-            # For each scheduled token, what is its position in corresponding req.
             arange = np.concatenate(
                 [self.arange_cpu[:n] for n in num_scheduled_tokens_per_req])
-            # Get positions.
-            positions_np = positions_cpu[:total_num_scheduled_tokens]
+            positions_np = positions_cpu[:total_num_scheduled_tokens_rank]
             np.add(
                 self.input_batch.num_computed_tokens_cpu[req_indices],
                 arange,
                 out=positions_np,
             )
-            # Get token indices.
-            # E.g., [0, 1, 0, 1, 2, 3, 4, 0, 1, 2]
-            # -> [0, 1, M, M + 1, M + 2, M + 3, M + 4, 2 * M, 2 * M + 1, 2 * M + 2]
-            # where M is the max_model_len.
             token_indices = (
                 positions_np +
                 req_indices * self.input_batch.token_ids_cpu.shape[1])
             np.take(
                 self.input_batch.token_ids_cpu.ravel(),
                 token_indices,
-                out=input_ids_cpu[:total_num_scheduled_tokens],
+                out=input_ids_cpu[:total_num_scheduled_tokens_rank],
             )
-
-            input_ids_cpu[total_num_scheduled_tokens:] = 0
+            input_ids_cpu[total_num_scheduled_tokens_rank:] = 0
 
         # Prepare the attention metadata (query_start_loc_cpu, seq_lens_cpu)
         for dp_rank in range(dp_size):
@@ -1733,8 +2046,6 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                 seq_lens_cpu[:] = 0
                 continue
 
-            # After buffer.reset(), the buffer is still dirty, so we need to zero
-            # Out the starting index.
             query_start_loc_cpu[0] = 0
             np.cumsum(
                 num_scheduled_tokens_per_req,
@@ -1747,28 +2058,23 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                 num_scheduled_tokens_per_req)
             seq_lens_cpu[_num_reqs:] = 0
 
-        # populate logits_indices
-        for dp_rank in range(dp_size):
-            req_offset = dp_rank * padded_num_reqs_per_dp_rank
-            query_loc_req_offset = dp_rank * (max_num_reqs_per_dp_rank + 1)
-            _num_reqs = num_req_per_dp_rank[dp_rank]
+        num_draft_tokens_all = _get_num_draft_tokens(
+            scheduler_output, self.input_batch.req_id_to_index, num_reqs)
 
-            logits_indices_cpu = logits_indices_view[
-                req_offset:req_offset + padded_num_reqs_per_dp_rank]
-            logits_indices_cpu[:_num_reqs] = (
-                query_start_loc_view[query_loc_req_offset +
-                                     1:query_loc_req_offset + _num_reqs + 1] -
-                1)
-            logits_indices_cpu[_num_reqs:] = -1
+        (logits_indices_selector, num_logits_per_req, gi_physical_indices,
+         gi_relative_indices) = _populate_logits_metadata(
+             self.input_batch, scheduler_output, query_start_loc_view,
+             logits_indices_view, num_reqs, dp_size, req_ids_dp,
+             num_req_per_dp_rank, padded_logits_length,
+             max_num_reqs_per_dp_rank, padded_num_reqs_per_dp_rank,
+             any_prompt_logprobs, use_spec_decode)
 
-        # Please see runner_utils.PhasedBasedProfiler for details
         if self.phase_based_profiler:
             self.batch_counter += 1
             batch_composition_stats = runner_utils.get_batch_composition_stats(
                 self.batch_counter, self.input_batch,
                 total_num_scheduled_tokens, num_reqs,
                 padded_total_num_scheduled_tokens, scheduler_output)
-
             self.phase_based_profiler.step(batch_composition_stats)
 
         positions = self.positions_cpu[:padded_total_num_scheduled_tokens]
@@ -1777,31 +2083,31 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         _request_distribution = []
         for dp_rank in range(dp_size):
             _num_reqs = num_req_per_dp_rank[dp_rank]
-            # The batch has been reordered by _reorder_batch so decode requests come first
-            # Count decode requests (those with num_scheduled_tokens == 1) in this DP rank
             num_decode_in_dp_rank = 0
             for req_id in req_ids_dp[dp_rank]:
                 if scheduler_output.num_scheduled_tokens[req_id] == 1:
                     num_decode_in_dp_rank += 1
             _request_distribution.append(
                 [num_decode_in_dp_rank, num_decode_in_dp_rank, _num_reqs])
-        request_distribution = np.array(_request_distribution,
-                                        dtype=np.int32).ravel()
+        request_distribution_np = np.array(_request_distribution,
+                                           dtype=np.int32).ravel()
 
-        use_spec_decode = len(
-            scheduler_output.scheduled_spec_decode_tokens) > 0
         spec_decode_metadata = None
         if use_spec_decode:
             spec_decode_metadata = (
                 self.speculative_decoding_manager.get_spec_decode_metadata(
-                    num_draft_tokens,
+                    num_draft_tokens_all,
                     query_start_loc_view[1:num_reqs + 1],
                     padded_num_reqs,
                     input_ids_view,
                 ))
-            logits_indices_view[:] = spec_decode_metadata.final_logits_indices
+            # logits_indices_view shape is (padded_logits_length, )
+            # spec_decode_metadata.final_logits_indices shape is (padded_num_reqs, )
+            # padded_num_reqs is total padded requests across all DP ranks.
+            logits_indices_view[:spec_decode_metadata.final_logits_indices.
+                                size] = (spec_decode_metadata.
+                                         final_logits_indices.ravel())
 
-        # Put to device
         sampling_metadata = TPUSupportedSamplingMetadata.from_input_batch(
             self.mesh,
             self.input_batch,
@@ -1809,10 +2115,13 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             sharding=data_parallel_attn_sharding,
         )
 
+        logits_metadata = self._build_logits_metadata(
+            logits_indices_selector, num_logits_per_req, any_prompt_logprobs,
+            sampling_indices_selector, gi_physical_indices,
+            gi_relative_indices, data_parallel_attn_sharding,
+            logits_indices_view if use_spec_decode else None)
+
         if self.uses_mrope:
-            # M-RoPE positions are of the shape (3, max_num_tokens).
-            # https://github.com/vllm-project/tpu-inference/blob/efc9608acd925bb3b64db6fda509514f799ab7be/tpu_inference/runner/tpu_runner.py#L555
-            # Shard the positions accordingly.
             mrope_sharding = NamedSharding(
                 self.mesh, PartitionSpec(None, ShardingAxisName.ATTN_DATA))
             positions = device_array(self.mesh,
@@ -1823,25 +2132,18 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                                      positions,
                                      sharding=data_parallel_attn_sharding)
 
-        # Collect block tables host arrays loops zone presence zones legality
         def build_block_table_host(kv_cache_gid: int) -> None:
-
             block_table_obj = self.input_batch.block_table[kv_cache_gid]
             block_tables_view = self.device_buffer.get_view(
                 (self.max_num_reqs, block_table_obj.max_num_blocks_per_req),
                 key=f"block_tables_gid_{kv_cache_gid}")
-
-            # Zero out the view once for correct padding
             block_tables_view.fill(0)
-
             cpu_tensor = block_table_obj.get_cpu_tensor()
             for dp_rank in range(dp_size):
                 _num_reqs = num_req_per_dp_rank[dp_rank]
                 if _num_reqs == 0:
                     continue
-
                 req_offset = dp_rank * max_num_reqs_per_dp_rank
-                # Use np.take with out= to avoid intermediate copies from advanced indexing
                 np.take(cpu_tensor,
                         req_indices_dp[dp_rank],
                         axis=0,
@@ -1859,14 +2161,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
 
         metadata_blob, metadata_layout = self.device_buffer.build()
 
-        # Mamba slot ids are only consumed by hybrid attn+mamba models; for
-        # pure-attention models, leaving the field None keeps AttentionMetadata
-        # byte-identical to the pre-compact-mamba layout (so the model_fn
-        # signature on those models is unchanged).
         if self.kv_cache_config.has_mamba_layers:
-            # Reorder mamba_state_indices per DP rank (like block_tables)
-            # and convert global slot ids to rank-local indices so they
-            # index correctly into the per-rank shard of the mamba state.
             local_slots = self.input_batch._mamba_local_slots
             mamba_state_indices_cpu = np.zeros(self.max_num_reqs,
                                                dtype=np.int32)
@@ -1880,6 +2175,347 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                 mamba_state_indices_cpu[req_offset:req_offset +
                                         _num_reqs] = (global_slots %
                                                       local_slots)
+            (request_distribution, mamba_state_indices,
+             dev_arrays_payload) = device_array(
+                 self.mesh, (request_distribution_np, mamba_state_indices_cpu,
+                             metadata_blob),
+                 sharding=data_parallel_attn_sharding)
+        else:
+            mamba_state_indices = None
+            (request_distribution, dev_arrays_payload) = device_array(
+                self.mesh, (request_distribution_np, metadata_blob),
+                sharding=data_parallel_attn_sharding)
+
+        metadata = common_utils.DeviceBuffer.unpack_arrays(
+            dev_arrays_payload, metadata_layout)
+        input_ids = metadata["input_ids"]
+        query_start_loc = metadata["query_start_loc"]
+        seq_lens = metadata["seq_lens"]
+        logits_indices = metadata["logits_indices"]
+
+        if self.speculative_config and self.scheduler_config.async_scheduling and self._pre_async_results is not None:
+            seq_lens, positions = self._subtract_num_rejected_tokens(
+                seq_lens, positions, scheduled_tokens_per_dp_rank[0])
+
+        def build_attn(block_tables: jax.Array | None) -> AttentionMetadata:
+            attention_metadata_gid = AttentionMetadata(
+                input_positions=positions,
+                block_tables=block_tables,
+                seq_lens=seq_lens,
+                query_start_loc=query_start_loc,
+                request_distribution=request_distribution,
+                mamba_state_indices=mamba_state_indices,
+                padded_num_reqs=attn_padded_num_reqs,
+            )
+            attention_metadata_gid.query_start_loc_cpu = query_start_loc_view
+            return attention_metadata_gid
+
+        attention_metadata: AttentionMetadata | dict[str, AttentionMetadata]
+        if len(self.kv_cache_config.kv_cache_groups) <= 1:
+            no_kv_cache = len(self.kv_cache_config.kv_cache_groups) == 0
+            block_tables = metadata.get(
+                "block_tables_gid_0") if not no_kv_cache else None
+            attention_metadata = build_attn(block_tables)
+        else:
+            attention_metadata = {
+                name: build_attn(metadata[f"block_tables_gid_{gid}"])
+                for gid, kv_cache_group in enumerate(
+                    self.kv_cache_config.kv_cache_groups)
+                for name in kv_cache_group.layer_names
+            }
+
+        # Async scheduling: substitute placeholder tokens for DP
+        if self.scheduler_config.async_scheduling and self._pre_async_results is not None:
+            all_token_indices_to_substitute = []
+            all_pre_next_tokens_indices = []
+            draft_all_token_indices_to_substitute = []
+            draft_all_pre_next_tokens_indices = []
+
+            for dp_rank in range(dp_size):
+                all_token_indices_to_substitute.extend(
+                    token_in_tpu_cur_input_indices_dp[dp_rank])
+                all_pre_next_tokens_indices.extend(
+                    token_in_tpu_pre_next_tokens_indices_dp[dp_rank])
+                draft_all_token_indices_to_substitute.extend(
+                    draft_token_in_tpu_cur_indices_dp[dp_rank])
+                draft_all_pre_next_tokens_indices.extend(
+                    draft_token_in_prev_next_tokens_indices_dp[dp_rank])
+
+            if self.speculative_config:
+                next_tokens = self._pre_async_results.spec_decode_next_tokens
+            else:
+                next_tokens = self._pre_async_results.next_tokens
+
+            input_ids = self._apply_async_token_substitution(
+                input_ids, next_tokens,
+                np.array(all_token_indices_to_substitute, dtype=np.int32),
+                np.array(all_pre_next_tokens_indices, dtype=np.int32))
+
+            if spec_decode_metadata:
+                draft_token_ids = self._apply_async_token_substitution(
+                    spec_decode_metadata.draft_token_ids,
+                    self._pre_async_results.spec_decode_next_tokens,
+                    np.array(draft_all_token_indices_to_substitute,
+                             dtype=np.int32),
+                    np.array(draft_all_pre_next_tokens_indices,
+                             dtype=np.int32))
+                new_md = replace(spec_decode_metadata,
+                                 draft_token_ids=draft_token_ids)
+                new_md.draft_lengths_cpu = spec_decode_metadata.draft_lengths_cpu
+                spec_decode_metadata = new_md
+
+        num_scheduled_tokens_per_req_all = np.concatenate([
+            np.array(scheduled_tokens_per_dp_rank[dp_rank], dtype=np.int32)
+            for dp_rank in range(dp_size)
+        ])
+        if self.lora_config is not None:
+            self.lora_utils.set_active_loras(
+                num_scheduled_tokens_per_req_all,
+                total_num_scheduled_tokens,
+                padded_total_num_scheduled_tokens,
+            )
+
+        logits_metadata = self._build_logits_metadata(
+            logits_indices_selector, num_logits_per_req, any_prompt_logprobs,
+            sampling_indices_selector, gi_physical_indices,
+            gi_relative_indices, data_parallel_attn_sharding, None)
+
+        return (
+            input_ids,
+            positions,
+            attention_metadata,
+            sampling_metadata,
+            logits_indices,
+            spec_decode_metadata,
+            logits_metadata,
+            padded_num_reqs,
+            req_ids_dp,
+            padded_num_scheduled_tokens_per_dp_rank,
+        )
+
+    def _prepare_async_token_substitution_indices_non_dp(
+            self, num_reqs, num_scheduled_tokens_per_req):
+        """Prepare token substitution indices for async scheduling (non-DP)."""
+        token_in_tpu_cur_input_indices = []
+        token_in_tpu_pre_next_tokens_indices = []
+
+        acc_cur_len = 0
+        for i, req_id in enumerate(self.input_batch.req_ids[:num_reqs]):
+            acc_cur_len += num_scheduled_tokens_per_req[i]
+            if req_id not in self._pre_async_results.placeholder_req_id_to_index:
+                continue
+
+            token_in_tpu_cur_input_indices.append(acc_cur_len - 1)
+            token_in_tpu_pre_next_tokens_indices.append(
+                self._pre_async_results.placeholder_req_id_to_index[req_id])
+
+        return (np.array(token_in_tpu_cur_input_indices, dtype=np.int32),
+                np.array(token_in_tpu_pre_next_tokens_indices, dtype=np.int32))
+
+    def _prepare_inputs_non_dp(self, scheduler_output: "VllmSchedulerOutput",
+                               use_spec_decode: bool,
+                               any_prompt_logprobs: bool):
+        total_num_scheduled_tokens = scheduler_output.total_num_scheduled_tokens
+
+        assert total_num_scheduled_tokens > 0
+        num_reqs = self.input_batch.num_reqs
+        assert num_reqs > 0
+
+        data_parallel_attn_sharding = NamedSharding(
+            self.mesh, PartitionSpec(ShardingAxisName.ATTN_DATA))
+
+        # Do the padding and copy the tensors to the TPU.
+        padded_total_num_scheduled_tokens = runner_utils.get_padded_token_len(
+            self.num_tokens_paddings, total_num_scheduled_tokens)
+        padded_num_reqs = runner_utils.get_padded_num_reqs_with_upper_limit(
+            num_reqs, self.max_num_reqs)
+
+        # Please see runner_utils.PhasedBasedProfiler for details
+        if self.phase_based_profiler:
+            self.batch_counter += 1
+            batch_composition_stats = runner_utils.get_batch_composition_stats(
+                self.batch_counter, self.input_batch,
+                total_num_scheduled_tokens, num_reqs,
+                padded_total_num_scheduled_tokens, scheduler_output)
+
+            self.phase_based_profiler.step(batch_composition_stats)
+
+        self.device_buffer.reset()
+
+        input_ids_view = self.device_buffer.get_view(
+            (padded_total_num_scheduled_tokens, ), key="input_ids")
+
+        # Match physical logits buffer with total tokens bucket to avoid recompile
+        padded_logits_length = padded_total_num_scheduled_tokens
+
+        logits_indices_shape = (padded_logits_length, )
+        logits_indices_view = self.device_buffer.get_view(logits_indices_shape,
+                                                          key="logits_indices")
+        logits_indices_view.fill(0)
+        query_start_loc_view = self.device_buffer.get_view(
+            (self.max_num_reqs + 1, ), key="query_start_loc")
+        seq_lens_view = self.device_buffer.get_view((self.max_num_reqs, ),
+                                                    key="seq_lens")
+
+        # Get the number of scheduled tokens for each request.
+        num_scheduled_tokens_per_req = []
+        max_num_scheduled_tokens_all_reqs = 0
+        for req_id in self.input_batch.req_ids[:num_reqs]:
+            assert req_id is not None
+            num_tokens = scheduler_output.num_scheduled_tokens[req_id]
+            num_scheduled_tokens_per_req.append(num_tokens)
+            max_num_scheduled_tokens_all_reqs = max(
+                max_num_scheduled_tokens_all_reqs, num_tokens)
+        num_scheduled_tokens_per_req = np.array(num_scheduled_tokens_per_req,
+                                                dtype=np.int32)
+        assert max_num_scheduled_tokens_all_reqs > 0
+
+        # Get request indices.
+        # E.g., [2, 5, 3] -> [0, 0, 1, 1, 1, 1, 1, 2, 2, 2]
+        # For each scheduled token, what are the corresponding req index.
+        req_indices = np.repeat(self.arange_cpu[:num_reqs],
+                                num_scheduled_tokens_per_req)
+        token_in_tpu_cur_input_indices = np.array([])
+        token_in_tpu_pre_next_tokens_indices = np.array([])
+        if self.scheduler_config.async_scheduling and self._pre_async_results is not None:
+            # If async previous results exists, we will prepare for the token substitution here
+            # The actual substitution will be performed in tpu during later parts of this function.
+            (token_in_tpu_cur_input_indices,
+             token_in_tpu_pre_next_tokens_indices
+             ) = self._prepare_async_token_substitution_indices_non_dp(
+                 num_reqs, num_scheduled_tokens_per_req)
+
+        # Get batched arange.
+        # E.g., [2, 5, 3] -> [0, 1, 0, 1, 2, 3, 4, 0, 1, 2]
+        # For each scheduled token, what is its position in corresponding req.
+        arange = np.concatenate(
+            [self.arange_cpu[:n] for n in num_scheduled_tokens_per_req])
+
+        # Get positions.
+        positions_np = self.positions_cpu[:total_num_scheduled_tokens]
+        np.add(self.input_batch.num_computed_tokens_cpu[req_indices],
+               arange,
+               out=positions_np)
+
+        # Multi-modal support
+        # Calculate M-RoPE positions.
+        # Only relevant for models using M-RoPE (e.g, Qwen2-VL)
+        if self.uses_mrope:
+            self.mm_manager.calc_mrope_positions(scheduler_output)
+
+        # Get token indices.
+        # E.g., [0, 1, 0, 1, 2, 3, 4, 0, 1, 2]
+        # -> [0, 1, M, M + 1, M + 2, M + 3, M + 4, 2 * M, 2 * M + 1, 2 * M + 2]
+        # where M is the max_model_len.
+        token_indices = (positions_np +
+                         req_indices * self.input_batch.token_ids_cpu.shape[1])
+
+        # NOTE(woosuk): We use torch.index_select instead of np.take here
+        # because torch.index_select is much faster than np.take for large
+        # tensors.
+        np.take(self.input_batch.token_ids_cpu.ravel(),
+                token_indices,
+                out=input_ids_view[:total_num_scheduled_tokens])
+        input_ids_view[total_num_scheduled_tokens:] = 0
+
+        # Prepare the attention metadata.
+        query_start_loc_view[0] = 0
+        np.cumsum(num_scheduled_tokens_per_req,
+                  out=query_start_loc_view[1:num_reqs + 1])
+        query_start_loc_view[num_reqs + 1:] = 1
+
+        seq_lens_view[:num_reqs] = (
+            self.input_batch.num_computed_tokens_cpu[:num_reqs] +
+            num_scheduled_tokens_per_req)
+        seq_lens_view[num_reqs:] = 0
+
+        positions = self.positions_cpu[:padded_total_num_scheduled_tokens]
+        mrope_positions = self.mrope_positions_cpu[:, :
+                                                   padded_total_num_scheduled_tokens]
+        num_draft_tokens = _get_num_draft_tokens(
+            scheduler_output, self.input_batch.req_id_to_index, num_reqs)
+
+        # Populate device-side logits_indices_view. We need the selector even in
+        # non-DP to correctly extract prompt logprobs from the flattened array.
+        (logits_indices_selector, num_logits_per_req, gi_physical_indices,
+         gi_relative_indices) = _populate_logits_metadata(
+             self.input_batch, scheduler_output, query_start_loc_view,
+             logits_indices_view, num_reqs, 1, {}, {0: num_reqs},
+             padded_logits_length, 0, padded_num_reqs, any_prompt_logprobs,
+             use_spec_decode)
+
+        spec_decode_metadata = None
+        if use_spec_decode:
+            spec_decode_metadata = self.speculative_decoding_manager.get_spec_decode_metadata(
+                num_draft_tokens, query_start_loc_view[1:num_reqs + 1],
+                padded_num_reqs, input_ids_view)
+            logits_indices_view[:spec_decode_metadata.final_logits_indices.
+                                size] = (spec_decode_metadata.
+                                         final_logits_indices.ravel())
+
+        sampling_metadata = TPUSupportedSamplingMetadata.from_input_batch(
+            self.mesh,
+            self.input_batch,
+            padded_num_reqs,
+            sharding=data_parallel_attn_sharding,
+        )
+
+        # Non-DP sampling selector is just a range
+        sampling_indices_selector = np.arange(num_reqs, dtype=np.int32)
+
+        logits_metadata = self._build_logits_metadata(
+            logits_indices_selector, num_logits_per_req, any_prompt_logprobs,
+            sampling_indices_selector, gi_physical_indices,
+            gi_relative_indices, data_parallel_attn_sharding,
+            logits_indices_view if use_spec_decode else None)
+
+        if self.uses_mrope:
+            # M-RoPE positions are of the shape (3, max_num_tokens).
+            # https://github.com/vllm-project/tpu-inference/blob/efc9608acd925bb3b64db6fda509514f799ab7be/tpu_inference/runner/tpu_runner.py#L555
+            # Shard the positions accordingly.
+            mrope_sharding = NamedSharding(
+                self.mesh, PartitionSpec(None, ShardingAxisName.ATTN_DATA))
+            positions = device_array(self.mesh,
+                                     mrope_positions,
+                                     sharding=mrope_sharding)
+        else:
+            positions = device_array(self.mesh,
+                                     positions,
+                                     sharding=data_parallel_attn_sharding)
+
+        request_distribution = np.array(self.input_batch.request_distribution)
+
+        def build_block_table_host(kv_cache_gid: int) -> None:
+            block_table_obj = self.input_batch.block_table[kv_cache_gid]
+            block_tables_view = self.device_buffer.get_view(
+                (self.max_num_reqs, block_table_obj.max_num_blocks_per_req),
+                key=f"block_tables_gid_{kv_cache_gid}")
+
+            cpu_tensor = block_table_obj.get_cpu_tensor()
+            np.copyto(block_tables_view[:num_reqs], cpu_tensor[:num_reqs])
+            block_tables_view[num_reqs:].fill(0)
+
+        if len(self.kv_cache_config.kv_cache_groups) <= 1:
+            # Pooling model will not using kv cache
+            no_kv_cache = len(self.kv_cache_config.kv_cache_groups) == 0
+            if not no_kv_cache:
+                build_block_table_host(0)
+        else:
+            for gid, kv_cache_group in enumerate(
+                    self.kv_cache_config.kv_cache_groups):
+                build_block_table_host(gid)
+
+        metadata_blob, metadata_layout = self.device_buffer.build()
+
+        # Mamba slot ids are only consumed by hybrid attn+mamba models; for
+        # pure-attention models, leaving the field None keeps AttentionMetadata
+        # byte-identical to the pre-compact-mamba layout (so the model_fn
+        # signature on those models is unchanged).
+        if self.kv_cache_config.has_mamba_layers:
+            # Per-request mamba state slot ids; copy to keep the InputBatch's
+            # CPU buffer free for the next step's bookkeeping.
+            mamba_state_indices_cpu = self.input_batch.mamba_state_indices_cpu.copy(
+            )
             (request_distribution, mamba_state_indices,
              dev_arrays_payload) = device_array(
                  self.mesh, (request_distribution, mamba_state_indices_cpu,
@@ -1898,13 +2534,6 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         seq_lens = metadata["seq_lens"]
         logits_indices = metadata["logits_indices"]
 
-        # The host-side `num_computed_tokens_cpu` assumes all speculatively
-        # proposed tokens from the previous step were accepted. Subtract the
-        # actual rejection counts from `seq_lens` and `positions` on TPU.
-        if self.speculative_config and self.scheduler_config.async_scheduling and self._pre_async_results is not None:
-            seq_lens, positions = self._subtract_num_rejected_tokens(
-                seq_lens, positions, scheduled_tokens_per_dp_rank[0])
-
         def build_attn(block_tables: jax.Array | None) -> AttentionMetadata:
             attention_metadata_gid = AttentionMetadata(
                 input_positions=positions,
@@ -1913,11 +2542,11 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                 query_start_loc=query_start_loc,
                 request_distribution=request_distribution,
                 mamba_state_indices=mamba_state_indices,
-                padded_num_reqs=attn_padded_num_reqs,
+                padded_num_reqs=padded_num_reqs,
             )
-
             # This is for making these cpu buffers hidden during tracing
             attention_metadata_gid.query_start_loc_cpu = query_start_loc_view
+            attention_metadata_gid.seq_lens_cpu = seq_lens_view
             return attention_metadata_gid
 
         attention_metadata: AttentionMetadata | dict[str, AttentionMetadata]
@@ -1935,74 +2564,31 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                 for name in kv_cache_group.layer_names
             }
 
-        # Async scheduling: substitute placeholder tokens for DP
-        if self.scheduler_config.async_scheduling and self._pre_async_results is not None:
-            # Collect all token indices that need substitution across all DP ranks
-            all_token_indices_to_substitute = []
-            all_pre_next_tokens_indices = []
-            draft_all_token_indices_to_substitute = []
-            draft_all_pre_next_tokens_indices = []
+        if self.scheduler_config.async_scheduling and len(
+                token_in_tpu_cur_input_indices) > 0:
+            assert self._pre_async_results is not None
+            if self.speculative_config:
+                next_tokens = self._pre_async_results.spec_decode_next_tokens
+            else:
+                next_tokens = self._pre_async_results.next_tokens
+            input_ids = self._apply_async_token_substitution(
+                input_ids, next_tokens, token_in_tpu_cur_input_indices,
+                token_in_tpu_pre_next_tokens_indices)
 
-            for dp_rank in range(dp_size):
-                cur_indices = token_in_tpu_cur_input_indices_dp[dp_rank]
-                pre_indices = token_in_tpu_pre_next_tokens_indices_dp[dp_rank]
-                all_token_indices_to_substitute.extend(cur_indices)
-                all_pre_next_tokens_indices.extend(pre_indices)
-                draft_all_token_indices_to_substitute.extend(
-                    draft_token_in_tpu_cur_indices_dp[dp_rank])
-                draft_all_pre_next_tokens_indices.extend(
-                    draft_token_in_prev_next_tokens_indices_dp[dp_rank])
-
-            if self.scheduler_config.async_scheduling and self._pre_async_results:
-                if self.speculative_config:
-                    next_tokens = self._pre_async_results.spec_decode_next_tokens
-                else:
-                    next_tokens = self._pre_async_results.next_tokens
-                token_in_tpu_cur_input_indices = np.array(
-                    all_token_indices_to_substitute)
-                token_in_tpu_pre_next_tokens_indices = np.array(
-                    all_pre_next_tokens_indices)
-                input_ids = self._apply_async_token_substitution(
-                    input_ids, next_tokens, token_in_tpu_cur_input_indices,
-                    token_in_tpu_pre_next_tokens_indices)
-                if spec_decode_metadata:
-                    draft_token_in_tpu_cur_input_indices = np.array(
-                        draft_all_token_indices_to_substitute)
-                    draft_token_in_tpu_pre_next_tokens_indices = np.array(
-                        draft_all_pre_next_tokens_indices)
-                    draft_token_ids = self._apply_async_token_substitution(
-                        spec_decode_metadata.draft_token_ids,
-                        self._pre_async_results.spec_decode_next_tokens,
-                        draft_token_in_tpu_cur_input_indices,
-                        draft_token_in_tpu_pre_next_tokens_indices)
-                    new_md = replace(spec_decode_metadata,
-                                     draft_token_ids=draft_token_ids)
-                    new_md.draft_lengths_cpu = spec_decode_metadata.draft_lengths_cpu
-                    spec_decode_metadata = new_md
-
-        num_scheduled_tokens_per_req = np.concatenate([
-            np.array(scheduled_tokens_per_dp_rank[dp_rank], dtype=np.int32)
-            for dp_rank in range(dp_size)
-        ])
         if self.lora_config is not None:
             self.lora_utils.set_active_loras(
-                num_scheduled_tokens_per_req,
-                total_num_scheduled_tokens,
-                padded_total_num_scheduled_tokens,
-            )
+                num_scheduled_tokens_per_req, total_num_scheduled_tokens,
+                padded_total_num_scheduled_tokens)
 
-        return (
-            input_ids,
-            positions,
-            attention_metadata,
-            sampling_metadata,
-            logits_indices,
-            spec_decode_metadata,
-            logits_indices_selector,
-            padded_num_reqs,
-            req_ids_dp,
-            padded_num_scheduled_tokens_per_dp_rank,
-        )
+        logits_metadata = self._build_logits_metadata(
+            logits_indices_selector, num_logits_per_req, any_prompt_logprobs,
+            sampling_indices_selector, gi_physical_indices,
+            gi_relative_indices, data_parallel_attn_sharding, None)
+
+        req_ids_dp = {0: self.input_batch.req_ids[:num_reqs]}
+        return (input_ids, positions, attention_metadata, sampling_metadata,
+                logits_indices, spec_decode_metadata, logits_metadata,
+                padded_num_reqs, req_ids_dp, padded_total_num_scheduled_tokens)
 
     def _get_input_ids_embeds(self, input_ids: jax.Array,
                               mm_embeds: list[jax.Array] | None,
@@ -2011,7 +2597,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         if self.is_multimodal_model and mm_embeds is not None:
             assert self.embed_input_ids_fn is not None
             inputs_embeds = self.embed_input_ids_fn(
-                self.state_leaves,
+                self.state,
                 input_ids,
                 mm_embeds,
                 is_multimodal=is_mm_embed,

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -1243,7 +1243,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         hidden_states = self._select_from_array_fn(hidden_states,
                                                    logits_indices)
         logits = self.compute_logits_fn(
-            self.state,
+            self.state_leaves,
             hidden_states,
             lora_metadata,
         )
@@ -2597,7 +2597,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         if self.is_multimodal_model and mm_embeds is not None:
             assert self.embed_input_ids_fn is not None
             inputs_embeds = self.embed_input_ids_fn(
-                self.state,
+                self.state_leaves,
                 input_ids,
                 mm_embeds,
                 is_multimodal=is_mm_embed,


### PR DESCRIPTION
# Description

This PR introduces comprehensive support for Prompt Logprobs on TPU, allowing users to retrieve log probabilities for both prompt tokens and generated tokens. The implementation handles the complex memory layout requirements of TPU SPMD alignment, Data Parallelism, and Asynchronous Scheduling.

Related bug: b/508315177

# Tests

Test results matched for both DP and non DP.

Results replay: 
- `python tpu-inference/examples/rl_inference.py --model meta-llama/Llama-3.2-1B-Instruct --data-parallel-size 1 --prompt-logprobs 3`
- `python tpu-inference/examples/rl_inference.py --model meta-llama/Llama-3.2-1B-Instruct --data-parallel-size 4 --prompt-logprobs 3`
- `python tpu-inference/examples/offline_inference.py --model meta-llama/Llama-3.2-1B-Instruct --data-parallel-size 1`
- `python tpu-inference/examples/offline_inference.py --model meta-llama/Llama-3.2-1B-Instruct --data-parallel-size 4`

Current version also works for `python tpu-inference/examples/rl_inference.py --data-parallel-size 4 --mixed-logprobs`

Passed tests:
- `pytest tpu-inference/tests/runner/test_tpu_runner.py`
- `pytest tpu-inference/tests/runner/test_tpu_runner_dp.py`
- `pytest tpu-inference/tests/layers/jax/sample/test_sampling.py`
- `pytest tpu-inference/tests/core/test_dp_scheduler.py`
- `pytest tpu-inference/tests/runner/test_structured_decoding_manager.py`
- `pytest tpu-inference/tests/runner/test_speculative_decoding_manager.py`
- `pytest tpu-inference/tests/spec_decode/test_eagle3.py`
- `pytest tpu-inference/tests/runner/test_utils.py`
- `pytest tpu-inference/tests/runner/test_input_batch.py`
- `pytest tpu-inference/tests/runner/test_kv_cache_manager.py`
- `pytest -s -v tpu-inference/tests/e2e/test_speculative_decoding.py`

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
