### PR TITLE
[Gemma4] quantize_kv() to avoid layout error from batch RPA kernel

### DIFF
--- a/tests/models/jax/test_gemma4.py
+++ b/tests/models/jax/test_gemma4.py
@@ -50,8 +50,10 @@ class TestGemma4ForConditionalGeneration:
             rng,
             mesh,
             mock_vllm_config,
+            monkeypatch: pytest.MonkeyPatch,
             assert_weight_loading_memory_bounded):
         """Tests loading weights from HF model"""
+        monkeypatch.setenv("USE_BATCHED_RPA_KERNEL", "1")
         kv_cache_type = "auto"
         vllm_config = mock_vllm_config(model_name, kv_cache_type)
         # No need to load full model.

--- a/tpu_inference/layers/common/attention_interface.py
+++ b/tpu_inference/layers/common/attention_interface.py
@@ -42,22 +42,6 @@ MAX_ALLOWED_PAGE_INDICES_N = (
     128 * 1024
 )  # Based on experiments on v5e, 256x1024 results in smem oom but 128x1024 not. TODO: Adjust this based on TPU version.
 
-# NOTE: this kernel is experimental and not fully tested.  See
-# tpu-inference/tpu_inference/kernels/experimental/batched_rpa/wrapper.py
-# for details
-if envs.USE_BATCHED_RPA_KERNEL:
-    import tpu_inference.kernels.experimental.batched_rpa.wrapper as rpa
-    logger.info_once("Using experimental batched RPA kernel")
-else:
-    import tpu_inference.kernels.ragged_paged_attention.v3.kernel as rpa
-    logger.info_once("Using default RPA kernel")
-
-ragged_paged_attention = rpa.ragged_paged_attention
-get_kv_cache_shape = rpa.get_kv_cache_shape
-
-ragged_paged_attention_hd64 = rpa_hd64.ragged_paged_attention_hd64
-get_kv_cache_shape_hd64 = rpa_hd64.get_kv_cache_shape
-
 
 def sharded_flash_attention(
     mesh: Mesh,
@@ -374,7 +358,20 @@ def sharded_ragged_paged_attention(
     args = (q, k, v, kv_cache, kv_lens, page_indices, cu_q_lens, distribution)
 
     use_hd64 = q.shape[-1] == 64
-    func = ragged_paged_attention_hd64 if use_hd64 else ragged_paged_attention
+    # NOTE: this import is late such that we can mock the env var in tests to
+    # switch between different kernel implementations. Some models prefers
+    # batched RPA kernel while some models prefers default RPA kernel.
+    if envs.USE_BATCHED_RPA_KERNEL:
+        # NOTE: this kernel is experimental and not fully tested.  See
+        # tpu-inference/tpu_inference/kernels/experimental/batched_rpa/wrapper.py
+        # for details
+        import tpu_inference.kernels.experimental.batched_rpa.wrapper as rpa
+        logger.info_once("Using experimental batched RPA kernel")
+    else:
+        import tpu_inference.kernels.ragged_paged_attention.v3.kernel as rpa
+        logger.info_once("Using default RPA kernel")
+
+    func = rpa_hd64.ragged_paged_attention_hd64 if use_hd64 else rpa.ragged_paged_attention
 
     if attention_sink is not None:
         if not use_hd64:

--- a/tpu_inference/models/jax/gemma4.py
+++ b/tpu_inference/models/jax/gemma4.py
@@ -456,12 +456,13 @@ class Gemma4Attention(JaxModule):
             raise NotImplementedError("Expect no shared layers")
 
         q_scale = k_scale = v_scale = None
-        if self.kv_cache_quantized_dtype:
-            # q_scale = self._q_scale
-            k_scale = self._k_scale
-            v_scale = self._v_scale
-            k, v = quantize_kv(self.kv_cache_quantized_dtype, k, v, k_scale,
-                               v_scale)
+        # Apply quantize_kv even if kv_cache_type is None or "auto",
+        # the intermediate clip+divide ops force k/v to have a layout that
+        # prevents issue in #2506
+        target_kv_dtype = self.kv_cache_quantized_dtype or k.dtype
+        k_scale = self._k_scale
+        v_scale = self._v_scale
+        k, v = quantize_kv(target_kv_dtype, k, v, k_scale, v_scale)
         new_kv_cache, outputs = attention(
             kv_cache,
             q,


### PR DESCRIPTION
# Description

Issue in #2506 surfaces using this command
```
USE_BATCHED_RPA_KERNEL=1 \
  vllm serve google/gemma-4-26B-A4B-it \
    --tensor-parallel-size 2 --pipeline-parallel-size 1 \
    --max-model-len 16384 \
    --dtype bfloat16 \
    --gpu-memory-utilization 0.98 \
    --limit-mm-per-prompt '{"image": 10, "video": 0}' \
    --mm-processor-kwargs '{"size": {"longest_edge": 1003520, "shortest_edge": 3136}}' \
    --disable-chunked-mm-input
```

kv-cache-dtype is "auto" and TP=2

# Tests

1. above command
2.
```
TIMEOUT_SECONDS=720 TEST_MODEL=google/gemma-4-26B-A4B-it TENSOR_PARALLEL_SIZE=2 MINIMUM_THROUGHPUT_THRESHOLD=2 \
  USE_BATCHED_RPA_KERNEL=1 JITTED_MM_MODULE_KEYS="model.vision_tower.encoder" \
  REGISTER_MM_MODULE_CUSTOM_PYTREE_CLASSES="transformers.modeling_outputs.BaseModelOutputWithPast" MAX_MODEL_LEN=4096  bash \
  tests/e2e/benchmarking/mm_bench_recipe.sh
```

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
