### PR TITLE
Add DEV_MODE to streamline the development process

### DIFF
--- a/.buildkite/scripts/run_in_docker.sh
+++ b/.buildkite/scripts/run_in_docker.sh
@@ -65,7 +65,13 @@ if [ -z "${MODEL_IMPL_TYPE:-}" ]; then
 fi
 
 IMAGE_NAME='vllm-tpu'
-FULL_IMAGE_TAG="${IMAGE_NAME}:${BUILDKITE_COMMIT}"
+declare -a DEV_MOUNT=()
+if [[ "${DEV_MODE:-false}" == "true" ]]; then
+    FULL_IMAGE_TAG="${IMAGE_NAME}:dev"
+    DEV_MOUNT+=("-v" "$(pwd):/workspace/tpu_inference")
+else
+    FULL_IMAGE_TAG="${IMAGE_NAME}:${BUILDKITE_COMMIT}"
+fi
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 # Source the environment setup script
 # shellcheck disable=SC1091
@@ -103,12 +109,14 @@ mkdir -p "$KERNEL_TUNING_TMP_DIR"
 # TODO (Qiliang Cui) Investigate why tensor-parallel-size=1 breaks in tpu7x.
 
 exec docker run \
+  --name "$IMAGE_NAME" \
   --privileged \
   --net host \
   --shm-size=16G \
   --rm \
   -v "$LOCAL_HF_HOME":"$DOCKER_HF_HOME" \
   -v "$KERNEL_TUNING_TMP_DIR":"$KERNEL_TUNING_TMP_DIR" \
+  "${DEV_MOUNT[@]}" \
   "${ENV_VARS[@]}" \
   "${TEST_SUITE_VARS[@]}" \
   -e HF_HOME="$DOCKER_HF_HOME" \

--- a/.buildkite/scripts/setup_docker_env.sh
+++ b/.buildkite/scripts/setup_docker_env.sh
@@ -83,6 +83,17 @@ setup_environment() {
   local should_push=${2:-"false"}
   local push_to_ci_cache=${3:-"false"}
   IMAGE_NAME="$image_name_param"
+
+  # ==========================================
+  # Skip Build and Cleanup in DEV_MODE if image already exists
+  # ==========================================
+  if [[ "${DEV_MODE:-false}" == "true" ]]; then
+    if docker image inspect "${IMAGE_NAME}:dev" >/dev/null 2>&1; then
+      echo "[DEV_MODE] Base image ${IMAGE_NAME}:dev already exists. Skipping cleanup and build."
+      return 0
+    fi
+  fi
+
   local CI_IMAGE_REPO="us-central1-docker.pkg.dev/cloud-ullm-inference-ci-cd/tpu-inference-ci/${IMAGE_NAME}"
   local LOCAL_TPU_VERSION="${TPU_VERSION:-tpu6e}" 
 
@@ -114,7 +125,11 @@ setup_environment() {
       else
           VLLM_COMMIT_HASH=""
       fi
-      TPU_INFERENCE_HASH=$(git log -n 1 --pretty="%H")
+      if [[ "${DEV_MODE:-false}" == "true" ]]; then
+          TPU_INFERENCE_HASH="dev"
+      else
+          TPU_INFERENCE_HASH=$(git log -n 1 --pretty="%H")
+      fi
   else
       VLLM_COMMIT_HASH=$(buildkite-agent meta-data get "VLLM_COMMIT_HASH" --default "")
       TPU_INFERENCE_HASH="$BUILDKITE_COMMIT"

--- a/scripts/vllm/benchmarking/benchmark_dataset.py
+++ b/scripts/vllm/benchmarking/benchmark_dataset.py
@@ -852,6 +852,7 @@ class SonnetDataset(BenchmarkDataset):
                     SampleRequest(
                         prompt=prompt_formatted
                         if return_prompt_formatted else prompt,
+                        messages=None if return_prompt_formatted else msg,
                         prompt_len=prompt_len,
                         expected_output_len=output_len,
                         request_id=request_id_prefix + str(ind),

--- a/scripts/vllm/benchmarking/benchmark_serving.py
+++ b/scripts/vllm/benchmarking/benchmark_serving.py
@@ -513,7 +513,7 @@ def main(args: argparse.Namespace):
     if args.dataset_name == "sonnet":
         dataset = SonnetDataset(dataset_path=args.dataset_path)
         # For the "sonnet" dataset, formatting depends on the backend.
-        if args.backend == "openai-chat":
+        if args.backend == "vllm-chat":
             input_requests = dataset.sample(
                 num_requests=args.num_prompts,
                 input_len=args.sonnet_input_len,


### PR DESCRIPTION
# Description

Given TPU vms are somewhat expensive to hold, I'd like to keep them as an ephemeral resources where I can turn down/up quickly.

This implies that
1. We don't want to setup our development workflow on the TPU vms, as after the turn down/up, those configurations/settings will be wiped out.
2. Similar to the buildkite workflow, we just treat TPU vms as executors of our tests.

This changes is to help streamline the workflow based on the above idea. To do this, we need to 
1. Be able to quickly start the server / benchmark service. We already have script to quickly allow us to install all the dependencies in container. Let's just reuse that by adding a dev mode.
2. Make changes on our dedicated development env (be it local Mac, remote linux) and can quickly sync those changes to the TPU vms. So we relax the assumption that the script has to run in a git repo as we could just rsync or mutagen to files from development env to TPU vms.
3. Quickly rebuild the image and restart the server after the changes, by not copying the file as part of the docker build but read them dynamically as part of docker run in dev mode, which helps us bypass the expensive docker build operation.

Also fix two issues encountered when trying to do the benchmark with vllm-chat backend.


### With the pr included, my day to day development workflow becomes

1.  on my local machine, run the following to automatically sync all the changes I made locally to the tpu vm, without having to commit to the change, set up git on the tpu and then pull the changes
```
mutagen sync create --name=tpu-sync \
  ~/repos/tpu-inference \
  $SSH_HOST_NAME:~/tpu-inference \
  --ignore-vcs
```
2. on the TPU vm, run the following to start the vllm server. And if we made some code changes, we will need to rerun it but the docker image does not need to be rebuilt (unless we change the VLLM_LKG)
```
DEV_MODE=true USE_VLLM_LKG=true  .buildkite/scripts/run_in_docker.sh vllm serve meta-llama/Llama-3.1-8B-Instruct --port 8000 --tensor-parallel-size 8
```
3. Run something like the following to do a quick benchmark test
```
docker exec -it vllm-tpu python3 scripts/vllm/benchmarking/benchmark_serving.py   --backend vllm-chat   --endpoint /v1/chat/completions   --port 8000   --model meta-llama/Llama-3.1-8B-Instruct   --dataset-name sonnet   --dataset-path /workspace/vllm/benchmarks/sonnet.txt   --request-rate 5.0
```

As we can see, we are bypassing all the buildkite ci stack but still use the same script buildkite agent would've use, giving us release confidence while expediting the development/test cycle 

# Tests

CI Tests

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
