### PR TITLE
Use ragged-gather-reduce in MOE layer

### DIFF
--- a/tests/kernels/ragged_gather_reduce_test.py
+++ b/tests/kernels/ragged_gather_reduce_test.py
@@ -1,0 +1,112 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import itertools
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+from absl.testing import absltest, parameterized
+from jax._src import test_util as jtu
+
+from tpu_inference.kernels.sparse_core.ragged_gather_reduce import \
+    ragged_gather_reduce
+
+jax.config.parse_flags_with_absl()
+
+
+def reference_ragged_gather_reduce(
+    x: jax.Array,
+    indices: jax.Array,
+    topk_weights: jax.Array,
+    valid_rows_mask: jax.Array,
+    reduce_group_size: int,
+) -> jax.Array:
+    """Reference implementation of ragged gather reduce."""
+    out = x[indices] * topk_weights[:, None].astype(jnp.float32)
+    out = jnp.where(valid_rows_mask[:, None], out, 0)
+    out = out.reshape(-1, reduce_group_size, out.shape[-1])
+    out = jnp.sum(out, axis=1).astype(jnp.bfloat16)
+    return out
+
+
+@jtu.with_config(jax_numpy_dtype_promotion="standard")
+class ScatterTest(jtu.JaxTestCase):
+    _test_cases = [
+        dict(out_size=o,
+             start_end=se,
+             hidden_size=h,
+             dtype=d,
+             reduce_group_size=rg) for o, se, h, d, rg in itertools.chain(
+                 itertools.product(
+                     [400, 840],
+                     [(3, 338), (10, 255)],
+                     [128, 512, 8192],
+                     [jnp.bfloat16, jnp.float32],
+                     [8, 5],
+                 ),
+                 itertools.product(
+                     [16384],
+                     [(99, 1120)],
+                     [7168],
+                     [jnp.bfloat16],
+                     [8],
+                 ),
+                 itertools.product(
+                     [16384],
+                     [(300, 2358)],
+                     [6144],
+                     [jnp.bfloat16],
+                     [8],
+                 ),
+                 itertools.product(
+                     [20480],
+                     [(300, 2850)],
+                     [4096],
+                     [jnp.bfloat16],
+                     [10],
+                 ),
+             )
+    ]
+
+    @parameterized.parameters(*_test_cases)
+    def test_sc_ragged_gather_reduce(self, out_size, hidden_size, start_end,
+                                     dtype, reduce_group_size):
+        start, end = start_end
+        start = min(start, out_size)
+        end = min(end, out_size)
+        key = jax.random.key(0)
+        x = jax.random.normal(key, (out_size, hidden_size), jnp.float32)
+        x = x.astype(dtype)
+        indices = jax.random.permutation(key, out_size)
+        topk_weights = jax.random.normal(key, (out_size, ), jnp.bfloat16)
+        valid_rows_mask = jnp.where(
+            jnp.logical_and(
+                jnp.array([start], jnp.int32) <= indices,
+                indices < jnp.array([end], jnp.int32),
+            ),
+            True,
+            False,
+        )
+        actual = ragged_gather_reduce(x, indices, topk_weights,
+                                      valid_rows_mask, reduce_group_size)
+        # Correctness check.
+        desired = reference_ragged_gather_reduce(x, indices, topk_weights,
+                                                 valid_rows_mask,
+                                                 reduce_group_size)
+        np.testing.assert_allclose(actual, desired, atol=1e-2, rtol=1e-2)
+
+
+if __name__ == "__main__":
+    absltest.main(testLoader=jtu.JaxTestLoader())

--- a/tpu_inference/env_override.py
+++ b/tpu_inference/env_override.py
@@ -12,7 +12,8 @@ os.environ["VLLM_DISABLE_SHARED_EXPERTS_STREAM"] = "1"
 os.environ["VLLM_USE_AOT_COMPILE"] = "0"
 
 # Handle XLA CPU compilation warning.
-os.environ["XLA_FLAGS"] = "--xla_cpu_max_isa=AVX2 " + os.environ.get("XLA_FLAGS", "")
+os.environ["XLA_FLAGS"] = "--xla_cpu_max_isa=AVX2 " + os.environ.get(
+    "XLA_FLAGS", "")
 
 # Monkeypatch vLLM to avoid ImportError: cannot import name 'SamplingParams' from 'vllm'
 # in vllm/v1/... submodules due to circular imports or lazy loading failures.

--- a/tpu_inference/env_override.py
+++ b/tpu_inference/env_override.py
@@ -7,12 +7,6 @@ import os
 # This prevents errors when trying to create CUDA streams on TPU hardware
 # The issue was introduced by vllm-project/vllm#26440
 os.environ["VLLM_DISABLE_SHARED_EXPERTS_STREAM"] = "1"
-# yapf: disable
-# NOTE: if the user specifies a custom --xla_tpu_use_tc_device_shape_on_sc value, the second value
-# will be used by default, effectively overriding this value
-# TODO (jrplatin/clee1994): remove this after https://github.com/vllm-project/tpu-inference/blob/main/tpu_inference/kernels/gather/gather_reduce.py
-# is moved to Pallas
-os.environ["LIBTPU_INIT_ARGS"] = "--xla_tpu_use_tc_device_shape_on_sc=true " + os.environ.get("LIBTPU_INIT_ARGS", "")
 # AOT compile is currently a Torch-only feature and thus we should not enable it
 # for TPU
 os.environ["VLLM_USE_AOT_COMPILE"] = "0"

--- a/tpu_inference/kernels/sparse_core/ragged_gather_reduce.py
+++ b/tpu_inference/kernels/sparse_core/ragged_gather_reduce.py
@@ -1,0 +1,582 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import functools
+import math
+
+import jax
+import jax.numpy as jnp
+from jax.experimental import pallas as pl
+from jax.experimental.pallas import tpu as pltpu
+from jax.experimental.pallas import tpu_sc as plsc
+
+
+# ceil up to the nearest multiple of b.
+def _align_to(a, b):
+    return pl.cdiv(a, b) * b
+
+
+def _fallback_implementation(
+    x: jax.Array,
+    indices: jax.Array,
+    topk_weights: jax.Array,
+    valid_rows_mask: jax.Array,
+    reduce_group_size: int,
+) -> jax.Array:
+    out = x[indices] * topk_weights[:, None].astype(jnp.float32)
+    out = jnp.where(valid_rows_mask[:, None], out, 0)
+    out = out.reshape(-1, reduce_group_size, out.shape[-1])
+    out = jnp.sum(out, axis=1).astype(jnp.bfloat16)
+    return out
+
+
+def _pad_inputs_if_needed(
+    x: jax.Array,
+    indices: jax.Array,
+    topk_weights: jax.Array,
+    valid_rows_mask: jax.Array,
+    reduce_group_size: int,
+    num_column_partitions: int,
+    num_row_partitions: int,
+    num_simd_lanes: int,
+) -> tuple[jax.Array, jax.Array, jax.Array, jax.Array]:
+    """Pads inputs if needed."""
+    input_size = x.shape[0]
+    hidden_size = x.shape[1]
+    aligned_hidden_size = _align_to(hidden_size, 128 * num_column_partitions)
+    row_tile_size = num_simd_lanes
+    padded_input_size = _align_to(
+        input_size,
+        math.lcm(num_row_partitions * row_tile_size, reduce_group_size),
+    )
+    pad_input_size = padded_input_size - input_size
+
+    x = jnp.pad(
+        x,
+        ((0, pad_input_size), (0, aligned_hidden_size - hidden_size)),
+        constant_values=0,
+    )
+    indices = jnp.pad(indices, (0, pad_input_size), constant_values=0)
+    topk_weights = jnp.pad(topk_weights, (0, pad_input_size),
+                           constant_values=0)
+    valid_rows_mask = jnp.pad(valid_rows_mask, (0, pad_input_size),
+                              constant_values=False)
+    return x, indices, topk_weights, valid_rows_mask
+
+
+def _calculate_num_col_column_partitions(hidden_size: int, num_cores: int,
+                                         num_lanes: int) -> int:
+    """Calculates the number of row partitions."""
+    # Each column partition should be multiple of 128 (number of lanes) due to
+    # DMA requirements.
+    # Prefer to use a large number of column partitions, as long as each
+    # partition's size is not too small for DMA pipeline efficiency and each
+    # partition's size can divide the hidden size.
+
+    # Each column partition will do DMA pipelining on col_size.
+    preferred_num_stages = 4
+    num_column_partitions = 1
+    while (num_cores % (num_column_partitions * 2) == 0
+           and hidden_size % (num_lanes * num_column_partitions * 2) == 0
+           and hidden_size //
+           (num_column_partitions * 2 * num_lanes) >= preferred_num_stages):
+        num_column_partitions *= 2
+    return num_column_partitions
+
+
+def main_kernel(
+    # Inputs.
+    num_rows_per_row_partition_ref: jax.Ref,
+    in_hbm_ref: jax.Ref,
+    src_indices_hbm_ref: jax.Ref,
+    dst_indices_hbm_ref: jax.Ref,
+    topk_weights_hbm_ref: jax.Ref,
+    # Outputs.
+    out_hbm_ref: jax.Ref,
+    # Scratch.
+    num_rows_per_row_partition_vmem_ref: jax.Ref,
+    out_vmem_ref: jax.Ref,
+    prev_iter_last_row_vmem_ref: jax.Ref,
+    src_indices_vmem_ref: jax.Ref,
+    dst_indices_vmem_ref: jax.Ref,
+    topk_weights_vmem_ref: jax.Ref,
+    sem_ref: jax.Ref,
+    *,
+    core_axis_name: str,
+    subcore_axis_name: str,
+    num_row_partitions: int,
+    num_column_partitions: int,
+):
+    tpu_info = pltpu.get_tpu_info()
+    sc_info = tpu_info.sparse_core
+    assert sc_info is not None
+    num_simd_lanes = sc_info.num_lanes
+    num_lanes = tpu_info.num_lanes
+    col_size = out_vmem_ref.shape[-1]
+    num_cores = jax.lax.axis_size((core_axis_name, subcore_axis_name))
+
+    recv_sem = sem_ref.at[0]
+    send_sem = sem_ref.at[1]
+
+    # TODO(gxd): Investigate on using `pl.Indirect`, which may bring us additional
+    # performance benefit.
+    @functools.partial(
+        pltpu.emit_pipeline,
+        grid=(num_cores, ),
+        core_axis_name=(core_axis_name, subcore_axis_name),
+        dimension_semantics=(pltpu.PARALLEL, ),
+    )
+    def inner_kernel():
+        core_id = pl.program_id(0)
+        row_partition_size = in_hbm_ref.shape[0] // num_row_partitions
+        row_partition_id = core_id // num_column_partitions
+        col_partition_id = core_id % num_column_partitions
+
+        # Read total number of valid source rows for the current row partition.
+        dma = pltpu.make_async_copy(
+            num_rows_per_row_partition_ref.at[pl.ds(0, num_simd_lanes)],
+            num_rows_per_row_partition_vmem_ref,
+            recv_sem,
+        )
+        dma.start()
+        dma.wait()
+        num_rows_current_row_partition = jnp.array(0, jnp.int32)
+        num_rows_per_row_partition = num_rows_per_row_partition_vmem_ref[...]
+        for i in range(num_row_partitions):
+            num_rows_current_row_partition = jnp.where(
+                row_partition_id == i,
+                num_rows_per_row_partition[i],
+                num_rows_current_row_partition,
+            )
+
+        row_tile_size = num_simd_lanes
+        num_row_tiles = pl.cdiv(num_rows_current_row_partition, row_tile_size)
+        row_start = row_partition_id * row_partition_size
+        col_start = col_partition_id * col_size
+
+        @pl.loop(0, num_row_tiles)
+        def row_loop(row_block_id):
+            row_tile_start = row_start + row_block_id * num_simd_lanes
+            # The destination row from the last source row in the previous row tile,
+            # retrieve it before DMA the new data into `dst_indices_vmem_ref`.
+            prev_dst_row_hbm = jnp.where(
+                row_block_id == 0, -1,
+                dst_indices_vmem_ref[...][num_simd_lanes - 1])
+            dma_list = []
+            dma_list.append(
+                pltpu.make_async_copy(
+                    src_indices_hbm_ref.at[pl.ds(row_tile_start,
+                                                 num_simd_lanes)],
+                    src_indices_vmem_ref,
+                    recv_sem,
+                ))
+            dma_list.append(
+                pltpu.make_async_copy(
+                    dst_indices_hbm_ref.at[pl.ds(row_tile_start,
+                                                 num_simd_lanes)],
+                    dst_indices_vmem_ref,
+                    recv_sem,
+                ))
+            dma_list.append(
+                pltpu.make_async_copy(
+                    topk_weights_hbm_ref.at[pl.ds(row_tile_start,
+                                                  num_simd_lanes)],
+                    topk_weights_vmem_ref,
+                    recv_sem,
+                ))
+            jax.tree.map(lambda x: x.start(), dma_list)
+            jax.tree.map(lambda x: x.wait(), dma_list)
+
+            # HBM to VMEM transfer.
+            src_indices = src_indices_vmem_ref[...]
+            dst_indices = dst_indices_vmem_ref[...]
+            topk_weights = topk_weights_vmem_ref[...]
+
+            in_dtype = in_hbm_ref.dtype
+            input_dtype_bits = jax.dtypes.itemsize_bits(in_dtype)
+            input_packing = 32 // input_dtype_bits
+
+            in_32b_hbm_ref = in_hbm_ref.bitcast(jnp.uint32)
+            out_32b_hbm_ref = out_hbm_ref.bitcast(jnp.uint32)
+
+            for col_vmem_start in range(0, col_size, num_lanes):
+                col_hbm_start = col_start + col_vmem_start
+                for row_vmem in range(num_simd_lanes):
+                    row_hbm = src_indices[row_vmem] // input_packing
+                    # Since we have changed layout from (8, 128) to (1, 128), continuous
+                    # memory addresss does not yield desired values anymore. Therefore,
+                    # we break up a dmas into multiple num_lanes sized requests.
+                    pltpu.make_async_copy(
+                        in_32b_hbm_ref.at[row_hbm,
+                                          pl.ds(col_hbm_start, num_lanes)],
+                        out_vmem_ref.at[row_vmem,
+                                        pl.ds(col_vmem_start, num_lanes)],
+                        recv_sem,
+                    ).start()
+
+            # VMEM to HBM transfer.
+            # Use dynamic loop to minimize register spills.
+            @jax.named_scope("dma_write_loop")
+            def dma_write_loop(i, carry):
+                col_vmem_start = i * num_lanes
+                col_hbm_start = col_start + col_vmem_start
+
+                for _ in range(num_simd_lanes):
+                    pltpu.make_async_copy(
+                        in_32b_hbm_ref.at[0, :num_lanes],
+                        out_vmem_ref.at[0, :num_lanes],
+                        recv_sem,
+                    ).wait()
+
+                for col_compute_offset in range(0, num_lanes, num_simd_lanes):
+                    col_slice = pl.ds(col_vmem_start + col_compute_offset,
+                                      num_simd_lanes)
+
+                    previous_accumulated_data = None
+                    for row_src in range(num_simd_lanes):
+                        row_src_pack = src_indices[row_src] % input_packing
+
+                        # Load data from vmem.
+                        data = out_vmem_ref[row_src, col_slice]
+
+                        # Extract data and cast to float32.
+                        if in_dtype == jnp.bfloat16:
+                            shift_bits = jnp.where(row_src_pack == 0, 16, 0)
+                            data = jnp.bitwise_left_shift(data, shift_bits)
+                            # Mask out the lower 16 bits.
+                            data = jnp.bitwise_and(
+                                data, jnp.uint32((2**16 - 1) << 16))
+                            data = plsc.bitcast(data, jnp.float32)
+                        elif in_dtype == jnp.float32:
+                            data = plsc.bitcast(data, jnp.float32)
+                        else:
+                            raise ValueError(
+                                "Not yet support extracting data from dtype: ",
+                                in_dtype)
+                        # Accumulate at float32 precision
+                        data = data * topk_weights[row_src]
+
+                        dst_row_hbm = dst_indices[row_src]
+                        if row_src == 0:
+                            # carry[0] is the last dst_row_hbm from the previous row_tile.
+                            prev_row_hbm = carry[0]
+                            previous_accumulated_data = plsc.bitcast(
+                                prev_iter_last_row_vmem_ref[0, col_slice],
+                                jnp.float32)
+                        else:
+                            prev_row_hbm = dst_indices[row_src - 1]
+                            assert previous_accumulated_data is not None
+
+                        # We guarantee source rows that contribute to the same destination
+                        # row are adjacent to each other in the order of being processed.
+                        # If the current src row contributes to the same destination row as
+                        # the previous src row, we accumulate the data with the previously
+                        # accumulated data.
+                        accumulated_data = jnp.where(
+                            dst_row_hbm == prev_row_hbm,
+                            previous_accumulated_data + data,
+                            data,
+                        )
+                        previous_accumulated_data = accumulated_data
+                        data_to_write = plsc.bitcast(accumulated_data,
+                                                     jnp.uint32)
+                        out_vmem_ref[row_src, col_slice] = data_to_write
+
+                        # We write the last row (within a row tile)'s accumulated data to
+                        # the prev_iter_last_row_vmem_ref. If the first src row in the next
+                        # row_tile contributes to the same destination row as the last src
+                        # row in the current row_tile, the lastest accumulated data in
+                        # prev_iter_last_row_vmem_ref will get used.
+                        if row_src == num_simd_lanes - 1:
+                            prev_iter_last_row_vmem_ref[
+                                0, col_slice] = data_to_write
+
+                # Start dma write.
+                # When there are multiple sources rows in the current row_tile that
+                # contribute to the same destination row, the accumulated data is
+                # stored in the last row's idx in `out_vmem_ref`.
+                # Logically, we could skip all the source rows that are not the last
+                # for each destination row, but we want to avoid using `pl.when` for
+                # efficiency. We just repeat the write of lastest accumulated data
+                # multiple times.
+                # `src_row_idx_in_vmem` tracks the right idx in vmem for each hbm write.
+                src_row_idx_in_vmem = []
+                row_valid_vec = []
+                for row_vmem_idx in reversed(range(num_simd_lanes)):
+                    row_idx = row_block_id * num_simd_lanes + row_vmem_idx
+                    row_valid = row_idx < num_rows_current_row_partition
+                    row_valid_vec.append(row_valid)
+                    if row_vmem_idx == num_simd_lanes - 1:
+                        src_row_idx_in_vmem.append(row_vmem_idx)
+                    else:
+                        next_row_valid = row_valid_vec[-2]
+                        valid_data_in_next_row_vmem = jnp.logical_and(
+                            next_row_valid,
+                            (dst_indices[row_vmem_idx]
+                             == dst_indices[row_vmem_idx + 1]),
+                        )
+                        src_row_idx_in_vmem.append(
+                            jnp.where(
+                                valid_data_in_next_row_vmem,
+                                src_row_idx_in_vmem[-1],
+                                row_vmem_idx,
+                            ))
+                src_row_idx_in_vmem.reverse()
+                row_valid_vec.reverse()
+
+                # There must be at least one valid row to write in the current row_tile.
+                # When num valid writes is not a multiple of row_tile_size, we repeat
+                # the last valid write to avoid valid data in hbm being overwritten
+                # (and to avoid using `pl.when`).
+                last_valid_src_row_vmem = -1
+                last_valid_dst_row_hbm = -1
+                for i, (src_row_idx_in_vmem, row_valid) in enumerate(
+                        zip(src_row_idx_in_vmem, row_valid_vec, strict=True)):
+                    src_row_vmem = jnp.where(row_valid, src_row_idx_in_vmem,
+                                             last_valid_src_row_vmem)
+                    dst_row_hbm = jnp.where(row_valid, dst_indices[i],
+                                            last_valid_dst_row_hbm)
+                    pltpu.make_async_copy(
+                        out_vmem_ref.at[src_row_vmem,
+                                        pl.ds(col_vmem_start, num_lanes)],
+                        out_32b_hbm_ref.at[dst_row_hbm,
+                                           pl.ds(col_hbm_start, num_lanes)],
+                        send_sem,
+                    ).start()
+                    last_valid_src_row_vmem = src_row_vmem
+                    last_valid_dst_row_hbm = dst_row_hbm
+
+                return carry
+
+            jax.lax.fori_loop(
+                0,
+                pl.cdiv(col_size, num_lanes),
+                dma_write_loop,
+                init_val=(prev_dst_row_hbm, ),
+            )
+            # Wait for dma write to finish.
+            for _ in range(0, col_size, num_lanes):
+                for _ in range(num_simd_lanes):
+                    pltpu.make_async_copy(
+                        out_vmem_ref.at[0, :num_lanes],
+                        out_32b_hbm_ref.at[0, :num_lanes],
+                        send_sem,
+                    ).wait()
+
+    inner_kernel()
+
+
+# TODO(gxd): investigate if we can make the preprocessing more efficient.
+def _preprocess(
+    indices: jax.Array,
+    topk_weights: jax.Array,
+    valid_rows_mask: jax.Array,
+    reduce_group_size: int,
+    num_row_partitions: int,
+    num_simd_lanes: int,
+) -> tuple[jax.Array, jax.Array, jax.Array, jax.Array, jax.Array]:
+    """Preprocesses indices for ragged gather reduce."""
+    assert indices.ndim == 1, "Ragged scatter only supports 1d indices."
+
+    row_partition_size = indices.shape[0] // num_row_partitions
+    valid_rows_mask = valid_rows_mask.reshape(num_row_partitions, -1)
+
+    # Move all the valid source rows to the beginning of each row partition.
+    sorted_by_validity = jnp.argsort(~valid_rows_mask,
+                                     descending=False,
+                                     stable=True,
+                                     axis=-1)
+    sorted_by_validity += (jnp.broadcast_to(
+        jnp.arange(num_row_partitions)[:, None],
+        (num_row_partitions, row_partition_size),
+    ) * row_partition_size)
+    sorted_by_validity = sorted_by_validity.reshape(-1)
+
+    src_indices = indices[sorted_by_validity]
+    # `reduce_group_size` source rows are mapped (and reduced) to the same output
+    # row.
+    dst_indices = sorted_by_validity // reduce_group_size
+    topk_weights = topk_weights[sorted_by_validity]
+    topk_weights = topk_weights.astype(jnp.float32)
+
+    num_src_rows_per_row_partition = jnp.sum(valid_rows_mask, axis=-1)
+    assert num_row_partitions <= num_simd_lanes
+    num_src_rows_per_row_partition = jnp.pad(
+        num_src_rows_per_row_partition.astype(jnp.int32),
+        (0, num_simd_lanes - num_row_partitions),
+    )
+    # If there is no valid source row in a reduce group, we set the mask to
+    # False, so that the output for that group is set to zero.
+    mask = jnp.any(valid_rows_mask.reshape(-1, reduce_group_size), axis=-1)
+
+    return (
+        src_indices,
+        dst_indices,
+        topk_weights,
+        num_src_rows_per_row_partition,
+        mask,
+    )
+
+
+@jax.jit(static_argnames=("reduce_group_size", ))
+def ragged_gather_reduce(
+    x: jax.Array,
+    indices: jax.Array,
+    topk_weights: jax.Array,
+    valid_rows_mask: jax.Array,
+    reduce_group_size: int,
+) -> jax.Array:
+    """Gathers `x` according to `indices`, applies weights and masks, and reduces.
+
+  This function performs a gathered lookup from `x` using `indices`, scales the
+  obtained rows by `topk_weights`, masks out any rows where `valid_rows_mask` is
+  False, and then groups every `reduce_group_size` rows together and reduces
+  them via summation.
+
+  The typical use case of this kernel is unpermute + local-reduction in the
+  MOE after GMM. Compared to maxtext.src.maxtext.kernels.gather_reduce_sc,
+  this kernel provides better performance if large sparsity exists in
+  `valid_rows_mask`. For example, expert_parallelism =8, 16 etc.
+
+  Args:
+    x: A 2D JAX array of input features with shape `(input_size, hidden_size)`.
+    indices: A 1D JAX array of indices to gather with shape `(input_size,)`.
+    topk_weights: A 1D JAX array of weights to scale the gathered rows with
+      shape `(input_size,)`.
+    valid_rows_mask: A 1D boolean JAX array indicating which gathered rows are
+      valid, with shape `(input_size,)`.
+    reduce_group_size: An integer representing the number of consecutive rows to
+      reduce (sum) together.
+
+  Returns:
+    A 2D JAX array of reduced data with shape
+    `(input_size // reduce_group_size, hidden_size)`.
+  """
+
+    assert x.ndim == 2, "ragged_gather_reduce only supports 2d inputs."
+    assert indices.ndim == 1, "ragged_gather_reduce only supports 1d indices."
+    assert (topk_weights.ndim == 1
+            ), "ragged_gather_reduce only supports 1d topk_weights."
+    assert (valid_rows_mask.ndim == 1
+            ), "ragged_gather_reduce only supports 1d valid_rows_mask."
+
+    sc_info = pltpu.get_tpu_info().sparse_core
+    if sc_info is None:
+        return _fallback_implementation(x, indices, topk_weights,
+                                        valid_rows_mask, reduce_group_size)
+
+    # Heuristic threshold on whether to fallback for small inputs.
+    dtype = x.dtype
+    dtype_bytes = jax.dtypes.itemsize_bits(dtype) // 8
+    if (jnp.size(x) * dtype_bytes * 2
+            < pltpu.get_tpu_info().vmem_capacity_bytes * 0.6):
+        # For small {input + output}, it's likely that both can be put in TC VMEM,
+        # so it's likely faster to run TC-based implementation on it than going
+        # through SC, without data movement to/from HBM.
+        return _fallback_implementation(x, indices, topk_weights,
+                                        valid_rows_mask, reduce_group_size)
+
+    hidden_size = x.shape[-1]
+    input_size = indices.size
+    num_simd_lanes = sc_info.num_lanes
+    num_cores = sc_info.num_cores * sc_info.num_subcores
+
+    # This kernel partitions the output's columns into `num_column_partitions` and
+    # partition the output's rows into `num_row_partitions` and run each
+    # {row_partition} x {column_partition} combination on a separate SC subcore
+    # for parallelism. With such work partitioning, we guarantee that there won't
+    # be write collision (from different subcores) to the any output row X column.
+    #
+    # A larger `num_column_partitions` (thus smaller `num_row_partitions` given
+    # fixed num_cores) is more preferable because large row partition may lead to
+    # imbalanced load (valid_rows_mask may have more rows in some partitions than
+    # others).
+    num_column_partitions = _calculate_num_col_column_partitions(
+        hidden_size, num_cores,
+        pltpu.get_tpu_info().num_lanes)
+    assert num_cores % num_column_partitions == 0
+    num_row_partitions = num_cores // num_column_partitions
+
+    x, indices, topk_weights, valid_rows_mask = _pad_inputs_if_needed(
+        x,
+        indices,
+        topk_weights,
+        valid_rows_mask,
+        reduce_group_size,
+        num_column_partitions,
+        num_row_partitions,
+        num_simd_lanes,
+    )
+    col_size = x.shape[-1] // num_column_partitions
+
+    (
+        src_indices,
+        dst_indices,
+        topk_weights,
+        num_src_rows_per_row_partition,
+        mask,
+    ) = _preprocess(
+        indices,
+        topk_weights,
+        valid_rows_mask,
+        reduce_group_size,
+        num_row_partitions,
+        num_simd_lanes,
+    )
+
+    vector_mesh = plsc.VectorSubcoreMesh(
+        num_cores=sc_info.num_cores,
+        num_subcores=sc_info.num_subcores,
+        core_axis_name="core",
+        subcore_axis_name="subcore",
+    )
+    # Each output row from `main_kernel` will be of type float32, and then casted
+    # to the input dtype when doing the filter operation.
+    out = pl.kernel(
+        functools.partial(
+            main_kernel,
+            core_axis_name=vector_mesh.core_axis_name,
+            subcore_axis_name=vector_mesh.subcore_axis_name,
+            num_row_partitions=num_row_partitions,
+            num_column_partitions=num_column_partitions,
+        ),
+        out_shape=jax.ShapeDtypeStruct(
+            (x.shape[0] // reduce_group_size, x.shape[1]),
+            jnp.float32,
+        ),
+        compiler_params=pltpu.CompilerParams(
+            use_tc_tiling_on_sc=True,
+            disable_bounds_checks=True,
+        ),
+        scratch_shapes=[
+            pltpu.VMEM((num_simd_lanes, ), jnp.int32),
+            pltpu.VMEM((num_simd_lanes, col_size), jnp.uint32),
+            pltpu.VMEM((1, col_size), jnp.uint32),
+            pltpu.VMEM((num_simd_lanes, ), jnp.int32),
+            pltpu.VMEM((num_simd_lanes, ), jnp.int32),
+            pltpu.VMEM((num_simd_lanes, ), jnp.float32),
+            pltpu.SemaphoreType.DMA((2, )),
+        ],
+        mesh=vector_mesh,
+        name="sc_ragged_gather_reduce",
+    )(num_src_rows_per_row_partition, x, src_indices, dst_indices,
+      topk_weights)
+
+    # If there is no valid source row in a reduce group, set that group's output
+    # to zero.
+    return jnp.where(
+        mask[:, None],
+        out.astype(x.dtype),
+        jnp.zeros_like(out, dtype=x.dtype),
+    )[:(input_size // reduce_group_size), :hidden_size]

--- a/tpu_inference/layers/common/fused_moe_gmm.py
+++ b/tpu_inference/layers/common/fused_moe_gmm.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import functools
-import math
 from typing import Literal
 
 import jax
@@ -23,9 +22,9 @@ from jax.sharding import PartitionSpec as P
 
 import tpu_inference.envs as envs
 from tpu_inference.kernels.megablox.gmm_v2 import gmm_v2
-from tpu_inference.kernels.sparse_core import gather_reduce as gather_reduce_sc
 from tpu_inference.kernels.sparse_core.ragged_gather import ragged_gather
-from tpu_inference.kernels.sparse_core.ragged_scatter import ragged_scatter
+from tpu_inference.kernels.sparse_core.ragged_gather_reduce import \
+    ragged_gather_reduce
 from tpu_inference.layers.common.quantization import quantize_tensor
 from tpu_inference.layers.common.sharding import ShardingAxisName
 from tpu_inference.logger import init_logger
@@ -183,98 +182,19 @@ def moe_gmm_local(x: jax.Array, w1: jax.Array, w1_scale: jax.Array | None,
     reduction_axis = (ShardingAxisName.MLP_TENSOR
                       if parallelism == "tp" else ShardingAxisName.EXPERT)
 
-    lcm = (128 * topk) // math.gcd(128, topk)
-    chunk_size = max(lcm, (TARGET_SLOT_CHUNK_SIZE + lcm // 2) // lcm * lcm)
-
-    use_sc = gather_reduce_sc.is_supported_by_sc_gather_reduce(
-        gmm1_res.shape[0], chunk_size) and topk == 8
-
-    if batch_size <= chunk_size:
-        # Path 3: No pipeline at all no kernel
-        if local_group_size < group_sizes.size:
-            group_offsets = jnp.cumulative_sum(group_sizes,
-                                               include_initial=True)
-            experts_start = group_offset[0]
-            experts_end = group_offset[0] + local_group_size
-            shard_output_start = group_offsets[experts_start]
-            shard_output_end = group_offsets[experts_end]
-            token_hidden_full = ragged_scatter(gmm2_res,
-                                               topk_argsort_revert_indices,
-                                               shard_output_start,
-                                               shard_output_end)
-        else:
-            token_hidden_full = gmm2_res[topk_argsort_revert_indices]
-
+    if local_group_size < group_sizes.size:
+        out = ragged_gather_reduce(gmm2_res, topk_argsort_revert_indices,
+                                   topk_weights.reshape(-1), mask.reshape(-1),
+                                   topk)
+    else:
+        token_hidden_full = gmm2_res[topk_argsort_revert_indices]
         cur_sorted = token_hidden_full.reshape((-1, topk, gmm2_res.shape[-1]))
         cur_topk_weights = jnp.expand_dims(topk_weights, axis=-1)
         cur_weighted = cur_sorted * cur_topk_weights
         cur_masked = jnp.where(mask, cur_weighted, 0.0)
-        cur_reduced = cur_masked.sum(axis=-2)
-        out = jax.lax.psum(cur_reduced, axis_name=reduction_axis)
-        return out
-
-    # Pipelined paths
-    if use_sc:
-        # Path 1: Kernel pipeline
-        hidden_size = gmm2_res.shape[1]
-        sc_kernel_col_chunk_size = gather_reduce_sc.get_valid_col_chunk_size(
-            hidden_size)
-
-        if local_group_size < group_sizes.size:
-            mask_flat = mask.reshape(-1, topk)
-            topk_weights_sc = jnp.where(mask_flat, topk_weights, 0)
-            topk_wgt_zero_nan = True
-        else:
-            topk_weights_sc = topk_weights
-            topk_wgt_zero_nan = False
-        topk_weights_flat = topk_weights_sc.flatten()
-    else:
-        # Path 2: No kernel pipeline
-        if local_group_size < group_sizes.size:
-            group_offsets = jnp.cumulative_sum(group_sizes,
-                                               include_initial=True)
-            experts_start = group_offset[0]
-            experts_end = group_offset[0] + local_group_size
-            shard_output_start = group_offsets[experts_start]
-            shard_output_end = group_offsets[experts_end]
-            token_hidden_full = ragged_scatter(gmm2_res,
-                                               topk_argsort_revert_indices,
-                                               shard_output_start,
-                                               shard_output_end)
-        else:
-            token_hidden_full = gmm2_res[topk_argsort_revert_indices]
-
-    out_list = []
-    for start in range(0, batch_size, chunk_size):
-        end = min(batch_size, start + chunk_size)
-        start_tok = start // topk
-        end_tok = end // topk
-        cur_indices = topk_argsort_revert_indices[start:end]
-
-        if use_sc:
-            cur_weights = topk_weights_flat[start:end].reshape(-1, 128)
-            cur_reduced = gather_reduce_sc.sc_gather_reduce(
-                op=gmm2_res,
-                idx=cur_indices,
-                reduce_group_size=topk,
-                topk_weights=cur_weights,
-                col_chunk_size=sc_kernel_col_chunk_size,
-                topk_wgt_zero_nan=topk_wgt_zero_nan,
-            )
-        else:
-            cur_topk_weights = topk_weights[start_tok:end_tok]
-            cur_mask = mask[start_tok:end_tok]
-            cur_sorted = token_hidden_full[start:end].reshape(
-                (-1, topk, gmm2_res.shape[-1]))
-            cur_topk_weights = jnp.expand_dims(cur_topk_weights, axis=-1)
-            cur_weighted = cur_sorted * cur_topk_weights
-            cur_masked = jnp.where(cur_mask, cur_weighted, 0.0)
-            cur_reduced = cur_masked.sum(axis=-2)
-
-        out = jax.lax.psum(cur_reduced, axis_name=reduction_axis)
-        out_list.append(out)
-
-    return jnp.concat(out_list, axis=0)
+        out = cur_masked.sum(axis=-2)
+    out = jax.lax.psum(out, axis_name=reduction_axis)
+    return out
 
 
 def tensor_parallel_gmm(
@@ -557,7 +477,7 @@ def fused_moe_func(
 
         return x, group_sizes_local, topk_argsort_revert_indices
 
-    if all_gather_fp8:
+    if True:
         hidden_states = _apply_all_gather_fp8(hidden_states, mesh, dtype)
 
     x, group_sizes, topk_argsort_revert_indices = jax.shard_map(

--- a/tpu_inference/layers/common/fused_moe_gmm.py
+++ b/tpu_inference/layers/common/fused_moe_gmm.py
@@ -477,7 +477,7 @@ def fused_moe_func(
 
         return x, group_sizes_local, topk_argsort_revert_indices
 
-    if True:
+    if all_gather_fp8:
         hidden_states = _apply_all_gather_fp8(hidden_states, mesh, dtype)
 
     x, group_sizes, topk_argsort_revert_indices = jax.shard_map(


### PR DESCRIPTION
Use ragged-gather-reduce in MOE layer.

Temporary revert the pipelineing code-path in https://github.com/vllm-project/tpu-inference/pull/2083 as we see some performance regression (at least for DS: https://screenshot.googleplex.com/4dvXSUY3uj8TzKv)

See about ~6% performance gain for DS 1k/8k workload: (20297.21 t/s vs 19148.49 t/s):
with this PR (ragged unpermute fused with local-sum): https://paste.googleplex.com/6213282995240960 
ragged-unpermute + dense-local-sum: https://screenshot.googleplex.com/6yxaBSGrNXKuffy 

# Tests
Quality verified for MMLU DS R1: https://paste.googleplex.com/6517071283355648