### PR TITLE
Use jnp.tile instead of the deprecated pltpu.repeat

### DIFF
--- a/tpu_inference/kernels/flash_attention/kernel.py
+++ b/tpu_inference/kernels/flash_attention/kernel.py
@@ -270,9 +270,8 @@ def _flash_attention_kernel_single_batch(
                 if rem:
                     raise NotImplementedError(
                         f"kv block size must be a multiple of {NUM_LANES}")
-                q_segment_ids = pltpu.repeat(
-                    q_segment_ids_tile_ref[batch_idx[0]], repeats,
-                    axis=1)  # [block_q, block_k].
+                q_segment_ids = jnp.tile(q_segment_ids_tile_ref[batch_idx[0]],
+                                         (1, repeats))  # [block_q, block_k].
                 kv_segment_ids = kv_segment_ids_tile_ref[
                     batch_idx[0], :1,
                     pl.dslice(start_k, block_k)]  # [1, block_k].
@@ -299,7 +298,7 @@ def _flash_attention_kernel_single_batch(
             if rem:
                 raise NotImplementedError(
                     f"{block_k=} should be a multiple of {MIN_BLOCK_SIZE}")
-            p = jnp.exp(s - pltpu.repeat(m_next, block_k_repeats, 1))
+            p = jnp.exp(s - jnp.tile(m_next, (1, block_k_repeats)))
 
             alpha = jnp.exp(m_prev - m_next)  # Shape [block_q, 128].
 
@@ -309,7 +308,7 @@ def _flash_attention_kernel_single_batch(
                                         None] + l_corr  # Shape [block_q, 128]
 
             head_dim_repeats, rem = divmod(head_dim, MIN_BLOCK_SIZE)
-            l_broadcast = lambda l: pltpu.repeat(l, head_dim_repeats, 1)
+            l_broadcast = lambda l: jnp.tile(l, (1, head_dim_repeats))
             if rem:
                 if head_dim_repeats == 0:
                     l_broadcast = lambda l: l[:, :head_dim]
@@ -383,8 +382,8 @@ def _flash_attention_kernel_single_batch_single_step(
                 f"kv block size must be a multiple of {NUM_LANES}")
         q_segment_ids = q_segment_ids_tile_ref[
             batch_idx[0]]  # [block_q, NUM_LANES].
-        q_segment_ids = pltpu.repeat(q_segment_ids, repeats,
-                                     axis=1)  # [block_q, block_k].
+        q_segment_ids = jnp.tile(q_segment_ids,
+                                 (1, repeats))  # [block_q, block_k].
         kv_segment_ids = kv_segment_ids_tile_ref[batch_idx[0], :
                                                  1]  # [1, block_k].
         mask = jnp.equal(q_segment_ids, kv_segment_ids).astype(jnp.bool_)


### PR DESCRIPTION
Use `jnp.tile` instead of the deprecated `pltpu.repeat` in `tpu_inference/kernels/flash_attention/kernel.py`.

## Test plan
- [ ] Existing flash attention tests pass on CI