### PR TITLE
[Gemma4] Reduce Gemma4 MoE load-time HBM peak

### DIFF
--- a/tests/layers/jax/quantization/test_unquantized.py
+++ b/tests/layers/jax/quantization/test_unquantized.py
@@ -26,7 +26,8 @@ from tpu_inference.layers.common.process_weights.moe_weights import \
 from tpu_inference.layers.common.sharding import ShardingAxisName
 from tpu_inference.layers.jax.linear import JaxEinsum, JaxLinear
 from tpu_inference.layers.jax.quantization import QuantizeMethodBase
-from tpu_inference.layers.jax.quantization.unquantized import UnquantizedConfig
+from tpu_inference.layers.jax.quantization.unquantized import (
+    UnquantizedConfig, _concat_staged_moe_weights, _moe_staged_weights_ready)
 
 
 @pytest.fixture
@@ -141,6 +142,29 @@ class TestUnquantizedJaxMoe:
                                (num_experts, hidden_size, intermediate_size),
                                dtype=jnp.bfloat16)
         return w13, w2
+
+    def test_concat_staged_moe_weights_concatenates_per_expert_chunks(self):
+        chunks = [
+            jnp.full((1, 3, 4), expert_id, dtype=jnp.bfloat16)
+            for expert_id in range(4)
+        ]
+        param = nnx.Param(jnp.zeros((4, 3, 4), dtype=jnp.bfloat16))
+        param.set_metadata("_weights_to_load", chunks)
+
+        assert _moe_staged_weights_ready(param)
+        weights = _concat_staged_moe_weights(param)
+
+        assert weights.shape == (4, 3, 4)
+        np.testing.assert_array_equal(np.asarray(weights[:, 0, 0]),
+                                      np.arange(4))
+
+    def test_concat_staged_moe_weights_returns_single_chunk(self):
+        chunk = jnp.ones((4, 3, 4), dtype=jnp.bfloat16)
+        param = nnx.Param(jnp.zeros((4, 3, 4), dtype=jnp.bfloat16))
+        param.set_metadata("_weights_to_load", [chunk])
+
+        assert _moe_staged_weights_ready(param)
+        assert _concat_staged_moe_weights(param) is chunk
 
     @pytest.mark.parametrize("requantize_dtype,expect_w_dtype,expect_scale", [
         ("", jnp.bfloat16, None),

--- a/tests/models/jax/test_gemma4.py
+++ b/tests/models/jax/test_gemma4.py
@@ -12,10 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import jax
 import pytest
+import torch
+from flax import nnx
 from jax import numpy as jnp
 from vllm.config import set_current_vllm_config
 from vllm.model_executor.model_loader import get_model_loader
@@ -25,9 +28,116 @@ from tpu_inference.distributed.jax_parallel_state import \
 from tpu_inference.kernels.ragged_paged_attention.v3.kernel import \
     get_kv_cache_shape
 from tpu_inference.layers.common.attention_metadata import AttentionMetadata
+from tpu_inference.layers.common.process_weights.moe_weights import \
+    get_w13_padding_config
 from tpu_inference.layers.jax.quantization import get_tpu_quantization_config
-from tpu_inference.models.jax.gemma4 import Gemma4DecoderLayer
+from tpu_inference.layers.jax.quantization.unquantized import (
+    MOE_WEIGHTS_STAGED_ON_HOST, UnquantizedConfig)
+from tpu_inference.models.jax.gemma4 import Gemma4DecoderLayer, Gemma4MoE
 from tpu_inference.models.jax.gemma4_mm import Gemma4ForConditionalGeneration
+
+
+class TestGemma4MoE:
+
+    def test_load_weights_stages_fused_weights_until_postprocess(self, mesh):
+        config = SimpleNamespace(num_experts=4,
+                                 hidden_size=8,
+                                 moe_intermediate_size=16,
+                                 top_k_experts=2)
+        with jax.set_mesh(mesh):
+            layer = Gemma4MoE(config=config,
+                              dtype=jnp.bfloat16,
+                              mesh=mesh,
+                              rngs=nnx.Rngs(0),
+                              quant_config=UnquantizedConfig({}),
+                              prefix="layers.0.mlp")
+
+        gate_up_proj = torch.zeros(
+            (config.num_experts, 2 * config.moe_intermediate_size,
+             config.hidden_size),
+            dtype=torch.bfloat16)
+        down_proj = torch.zeros(
+            (config.num_experts, config.hidden_size,
+             config.moe_intermediate_size),
+            dtype=torch.bfloat16,
+        )
+
+        loaded = layer.load_weights([
+            ("gate_up_proj", gate_up_proj),
+            ("down_proj", down_proj),
+        ])
+
+        assert loaded == {
+            "kernel_gating_EDF",
+            "kernel_up_proj_EDF",
+            "kernel_down_proj_EFD",
+        }
+        assert layer.kernel_gating_EDF.value.shape == (
+            config.num_experts, config.hidden_size,
+            config.moe_intermediate_size)
+        assert layer.kernel_down_proj_EFD.value.shape == (
+            config.num_experts, config.moe_intermediate_size,
+            config.hidden_size)
+        assert layer.kernel_gating_EDF._weights_to_load[0].shape == (
+            config.num_experts, config.moe_intermediate_size,
+            config.hidden_size)
+        assert layer.kernel_up_proj_EDF._weights_to_load[0].shape == (
+            config.num_experts, config.moe_intermediate_size,
+            config.hidden_size)
+        assert layer.kernel_down_proj_EFD._weights_to_load[0].shape == (
+            config.num_experts, config.hidden_size,
+            config.moe_intermediate_size)
+        assert layer.kernel_gating_EDF.get_metadata(
+        )[MOE_WEIGHTS_STAGED_ON_HOST]
+        assert layer.kernel_up_proj_EDF.get_metadata(
+        )[MOE_WEIGHTS_STAGED_ON_HOST]
+        assert layer.kernel_down_proj_EFD.get_metadata(
+        )[MOE_WEIGHTS_STAGED_ON_HOST]
+
+        with jax.set_mesh(mesh):
+            assert layer.quant_method.process_weights_after_loading(layer)
+
+        assert not hasattr(layer, "kernel_gating_EDF")
+        assert not hasattr(layer, "kernel_up_proj_EDF")
+        assert hasattr(layer, "kernel_gating_upproj_EDF")
+        assert hasattr(layer, "kernel_down_proj_EFD")
+        padding_config = get_w13_padding_config(
+            config.moe_intermediate_size,
+            reorder_size=mesh.shape["model"],
+            align=128,
+        )
+        assert layer.kernel_gating_upproj_EDF.value.shape == (
+            config.num_experts,
+            config.hidden_size,
+            2 * padding_config.padded_intermediate_size,
+        )
+        assert layer.kernel_down_proj_EFD.value.shape == (
+            config.num_experts,
+            config.moe_intermediate_size,
+            config.hidden_size,
+        )
+
+    def test_load_weights_rejects_bad_staged_weight_shape(self, mesh):
+        config = SimpleNamespace(num_experts=4,
+                                 hidden_size=8,
+                                 moe_intermediate_size=16,
+                                 top_k_experts=2)
+        with jax.set_mesh(mesh):
+            layer = Gemma4MoE(config=config,
+                              dtype=jnp.bfloat16,
+                              mesh=mesh,
+                              rngs=nnx.Rngs(0),
+                              quant_config=UnquantizedConfig({}),
+                              prefix="layers.0.mlp")
+
+        bad_gate_up_proj = torch.zeros(
+            (config.num_experts, 2 * config.moe_intermediate_size,
+             config.hidden_size + 1),
+            dtype=torch.bfloat16)
+
+        with pytest.raises(ValueError,
+                           match="Unexpected Gemma4 MoE weight shape"):
+            layer.load_weights([("gate_up_proj", bad_gate_up_proj)])
 
 
 class TestGemma4ForConditionalGeneration:

--- a/tpu_inference/layers/jax/quantization/unquantized.py
+++ b/tpu_inference/layers/jax/quantization/unquantized.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import gc
+from contextlib import nullcontext
 from typing import Optional
 
 import jax
@@ -27,6 +28,7 @@ from tpu_inference.layers.common.process_weights.moe_weights import (
     shard_moe_weights)
 from tpu_inference.layers.common.quantization import unquantized as jax_common
 from tpu_inference.layers.common.quantization.configs import QuantLinearConfig
+from tpu_inference.layers.common.utils import cpu_mesh_context
 from tpu_inference.layers.jax import JaxModule
 from tpu_inference.layers.jax.linear import JaxEinsum
 from tpu_inference.layers.jax.moe.moe import JaxMoE
@@ -36,6 +38,25 @@ from tpu_inference.logger import init_logger
 from tpu_inference.models.jax.utils.weight_utils import shard_put
 
 logger = init_logger(__name__)
+
+MOE_WEIGHTS_STAGED_ON_HOST = "_moe_weights_staged_on_host"
+
+
+def _moe_staged_weights_ready(param: nnx.Param) -> bool:
+    weights_to_load = getattr(param, "_weights_to_load", None)
+    return bool(weights_to_load) and all(w is not None
+                                         for w in weights_to_load)
+
+
+def _concat_staged_moe_weights(param: nnx.Param) -> jax.Array:
+    weights_to_load = param._weights_to_load
+    if len(weights_to_load) == 1:
+        return weights_to_load[0]
+    return jnp.concatenate(weights_to_load, axis=0)
+
+
+def _param_is_staged_on_host(param: nnx.Param) -> bool:
+    return bool(param.get_metadata().get(MOE_WEIGHTS_STAGED_ON_HOST, False))
 
 
 class UnquantizedLinearMethod(QuantizeMethodBase,
@@ -114,35 +135,58 @@ class UnquantizedFusedMoEMethod(QuantizeMethodBase):
             }
 
         elif layer.moe_backend in [MoEBackend.GMM_EP, MoEBackend.GMM_TP]:
-            if any(
-                    any(w is None for w in param._weights_to_load)
-                    for param in [
-                        layer.kernel_gating_EDF, layer.kernel_up_proj_EDF,
-                        layer.kernel_down_proj_EFD
-                    ]):
+
+            moe_params = [
+                layer.kernel_gating_EDF, layer.kernel_up_proj_EDF,
+                layer.kernel_down_proj_EFD
+            ]
+            if any(not _moe_staged_weights_ready(param)
+                   for param in moe_params):
                 return False
-            w_gate = layer.kernel_gating_EDF.get_value()
-            w_up = layer.kernel_up_proj_EDF.get_value()
-            w2_val = layer.kernel_down_proj_EFD.get_value()
+
+            use_staged_host_weights = all(
+                _param_is_staged_on_host(param) for param in moe_params)
+            if use_staged_host_weights:
+                with cpu_mesh_context():
+                    w_gate = _concat_staged_moe_weights(
+                        layer.kernel_gating_EDF)
+                    w_up = _concat_staged_moe_weights(layer.kernel_up_proj_EDF)
+                    w2_val = _concat_staged_moe_weights(
+                        layer.kernel_down_proj_EFD)
+            else:
+                w_gate = layer.kernel_gating_EDF.get_value()
+                w_up = layer.kernel_up_proj_EDF.get_value()
+                w2_val = layer.kernel_down_proj_EFD.get_value()
 
             # Free old params before processing to reduce peak memory.
             del layer.kernel_gating_EDF
             del layer.kernel_up_proj_EDF
+            del layer.kernel_down_proj_EFD
 
             # Fuse the weights into w13: [Gate, Up]
-            w13_val = jnp.concatenate([w_gate, w_up], axis=1)
-            del w_gate, w_up
-
+            # Capture the target TPU mesh outside cpu_mesh_context(); the CPU
+            # mesh is only for temporary host-side processing.
             mesh = jax.sharding.get_mesh()
-            weights = process_unquantized_moe_weights(
-                mesh=mesh,
-                moe_backend=layer.moe_backend,
-                activation=layer.activation,
-                w13_weight=w13_val,
-                w13_bias=None,
-                w2_weight=w2_val,
-                w2_bias=None,
-            )
+            if use_staged_host_weights:
+                mesh_context = cpu_mesh_context()
+            else:
+                mesh_context = nullcontext()
+            with mesh_context:
+                w13_val = jnp.concatenate([w_gate, w_up], axis=1)
+                del w_gate, w_up
+                weights = process_unquantized_moe_weights(
+                    mesh=mesh,
+                    moe_backend=layer.moe_backend,
+                    activation=layer.activation,
+                    w13_weight=w13_val,
+                    w13_bias=None,
+                    w2_weight=w2_val,
+                    w2_bias=None,
+                )
+                if use_staged_host_weights:
+                    # Drop CPU sharding metadata before the final layout-aware
+                    # transfer to the TPU mesh.
+                    weights = jax.device_get(weights)
 
             sharded_weights = shard_moe_weights(weights,
                                                 moe_backend=layer.moe_backend,
@@ -162,6 +206,10 @@ class UnquantizedFusedMoEMethod(QuantizeMethodBase):
             if sharded_weights.w2_weight_scale is not None:
                 layer.kernel_down_proj_EFD_weight_scale = nnx.Param(
                     sharded_weights.w2_weight_scale)
+
+            # Wait for final transfers so the next MoE layer does not overlap
+            # with transient buffers from this layer during weight loading.
+            jax.block_until_ready(sharded_weights)
 
             del weights
             del w13_val

--- a/tpu_inference/models/jax/gemma4.py
+++ b/tpu_inference/models/jax/gemma4.py
@@ -36,14 +36,15 @@ from tpu_inference.layers.jax.linear import JaxEinsum, JaxLinear
 from tpu_inference.layers.jax.moe.moe import JaxMoE
 from tpu_inference.layers.jax.norm import JaxRmsNorm
 from tpu_inference.layers.jax.pp_utils import PPMissingLayer, make_layers
+from tpu_inference.layers.jax.quantization.unquantized import \
+    MOE_WEIGHTS_STAGED_ON_HOST
 from tpu_inference.layers.jax.rope_interface import apply_rope
 from tpu_inference.layers.vllm.quantization.configs import VllmQuantConfig
 from tpu_inference.logger import init_logger
 from tpu_inference.models.jax.jax_intermediate_tensor import \
     JaxIntermediateTensors
 from tpu_inference.models.jax.utils.weight_utils import (
-    LoadableWithIterator, StandardWeightLoader,
-    load_nnx_param_from_reshaped_torch)
+    LoadableWithIterator, StandardWeightLoader, jax_array_from_reshaped_torch)
 
 logger = init_logger(__name__)
 
@@ -217,39 +218,35 @@ class Gemma4MoE(JaxMoE):
 
         Unlike other MoE, Gemma4 didn't provide per-expert weights, but already fuse projection weight in the checkpoint.
         """
+
+        def stage_weight_for_processing(param: nnx.Param, tensor,
+                                        param_name: str) -> None:
+            # Keep the fused expert tensors off TPU until GMM post-processing
+            # can produce the final sharded layout.
+            jax_weight = jax_array_from_reshaped_torch(tensor)
+            expected_shape = (param.value.shape[0], param.value.shape[2],
+                              param.value.shape[1])
+            if tuple(jax_weight.shape) != expected_shape:
+                raise ValueError(
+                    f"Unexpected Gemma4 MoE weight shape for {param_name}: "
+                    f"{jax_weight.shape}; expected {expected_shape}")
+            param.set_metadata("_weights_to_load", [jax_weight])
+            param.set_metadata(MOE_WEIGHTS_STAGED_ON_HOST, True)
+
         loaded = set()
         for name, tensor in weights:
             if name.endswith("down_proj"):
-                load_nnx_param_from_reshaped_torch(self.kernel_down_proj_EFD,
-                                                   tensor,
-                                                   permute_dims=(0, 2, 1),
-                                                   param_name=name)
+                stage_weight_for_processing(self.kernel_down_proj_EFD, tensor,
+                                            name)
                 loaded.add("kernel_down_proj_EFD")
-                self.kernel_down_proj_EFD._weights_to_load.clear()
-                # Other MoE models store expert weights in shape (D, F) and permute in *FusedMoEMethod.process_weights_after_loading.
-                # For compatibility, we permute here then expect another permute in process_weights_after_loading.
-                self.kernel_down_proj_EFD.value = jnp.swapaxes(
-                    self.kernel_down_proj_EFD.value, 1, 2)
             elif name.endswith("gate_up_proj"):
                 F = tensor.shape[1] // 2
-                load_nnx_param_from_reshaped_torch(self.kernel_gating_EDF,
-                                                   tensor[:, :F, :],
-                                                   permute_dims=(0, 2, 1),
-                                                   param_name=name)
-                load_nnx_param_from_reshaped_torch(self.kernel_up_proj_EDF,
-                                                   tensor[:, F:, :],
-                                                   permute_dims=(0, 2, 1),
-                                                   param_name=name)
+                stage_weight_for_processing(self.kernel_gating_EDF,
+                                            tensor[:, :F, :], name)
+                stage_weight_for_processing(self.kernel_up_proj_EDF,
+                                            tensor[:, F:, :], name)
                 loaded.add("kernel_up_proj_EDF")
-                self.kernel_up_proj_EDF._weights_to_load.clear()
                 loaded.add("kernel_gating_EDF")
-                self.kernel_gating_EDF._weights_to_load.clear()
-                # Other MoE models store expert weights in shape (F, D) and permute in *FusedMoEMethod.process_weights_after_loading.
-                # For compatibility, we permute here then expect another permute in process_weights_after_loading.
-                self.kernel_up_proj_EDF.value = jnp.swapaxes(
-                    self.kernel_up_proj_EDF.value, 1, 2)
-                self.kernel_gating_EDF.value = jnp.swapaxes(
-                    self.kernel_gating_EDF.value, 1, 2)
         return loaded
 
 


### PR DESCRIPTION
# Description

Reduce Gemma4 MoE load-time HBM peak by staging raw fused expert checkpoint weights off TPU until the GMM MoE post-processing step produces the final sharded TPU layout.

Previously, `Gemma4MoE.load_weights()` loaded the fused `gate_up_proj` and `down_proj` tensors into TPU-backed params before `process_weights_after_loading()` reshaped, padded, fused, and sharded them. This created a large transient HBM spike during model loading even though the final resident model weights were much smaller.

This PR changes Gemma4 MoE loading to:
- stage raw `gate`, `up`, and `down` expert tensors in `_weights_to_load`
- mark Gemma4 staged tensors with `MOE_WEIGHTS_STAGED_ON_HOST`
- run GMM MoE post-processing from the staged tensors under `cpu_mesh_context()`
- free the old intermediate params before installing the final sharded weights
- keep the final resident weight layout unchanged

The staged-host path is guarded by metadata, so existing non-Gemma4 GMM MoE loading continues to use the existing `param.get_value()` path. 

On `v6e-8`, this reduced measured load-time peak HBM from `12.82 GiB/chip` to `8.02 GiB/chip`, while final model HBM stayed unchanged at `7.91 GiB/chip`.

This intentionally trades some load-time asynchrony and host RAM for lower TPU HBM peak during initialization. In the v6e-8 measurement, load time was not worse in practice (`123.96s` baseline vs `102.56s` patched), but the main goal is avoiding the transient accelerator-memory spike rather than optimizing load latency.

Addresses #2453 to some extent.

# Tests

Added regression coverage for Gemma4 MoE fused-weight staging and post-load processing:

    python -m pytest tests/models/jax/test_gemma4.py::TestGemma4MoE::test_load_weights_stages_fused_weights_until_postprocess -q -s

Result: `1 passed`

Added helper coverage for staged MoE weight concatenation:
- single staged tensor
- per-expert staged tensor chunks

Verified patched full model load on `v6e-8`:

    vllm serve google/gemma-4-26B-A4B-it \
      --tensor_parallel_size 8 \
      --max-num-batched-tokens 4096 \
      --max-model-len 4096 \
      --disable_chunked_mm_input

Result:
- `Loading weights took 102.56 seconds`
- `Init model | hbm=[(7.91, 31.25), ...]GiB`
- `total_hbm_used_gb=63.3GiB`

Measured load-time peak HBM with `jax.devices()[i].memory_stats()` inside the EngineCore process:
- baseline: `12.82 GiB/chip`
- patched: `8.02 GiB/chip`

Could not verify on `v5e-8` because v5e resources were unavailable.

# Checklist

Before submitting this PR, please make sure:
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have made or will make corresponding changes to any relevant documentation.
```