### PR TITLE
jitted _select_kv_caches_jit for qwen 3.5

### DIFF
--- a/tpu_inference/distributed/tpu_connector_hma.py
+++ b/tpu_inference/distributed/tpu_connector_hma.py
@@ -506,6 +506,22 @@ class TPUConnectorHMAWorker(TPUConnectorWorker):
         return specs
 
 
+@jax.jit
+def _select_kv_caches_jit(
+        kv_caches: list,
+        indices_per_layer: list[jax.Array]) -> list[jax.Array]:
+    """Select KV caches based on indices."""
+    selected: list[jax.Array] = []
+    for layer, cache in enumerate(kv_caches):
+        indices = indices_per_layer[layer]
+        if isinstance(cache, tuple):
+            for state in cache:
+                selected.append(state.at[indices].get())
+        else:
+            selected.append(cache.at[indices].get())
+    return selected
+
+
 def _select_from_kv_caches_per_group(
     kv_caches: list,
     block_ids_per_group: list[list[int]],
@@ -519,16 +535,13 @@ def _select_from_kv_caches_per_group(
     indices_per_group = [
         jnp.asarray(ids, dtype=jnp.int32) for ids in block_ids_per_group
     ]
-    selected: list[jax.Array] = []
-    for layer, cache in enumerate(kv_caches):
-        group_id = layer_to_group_id[layer]
-        indices = indices_per_group[group_id]
-        if isinstance(cache, tuple):
-            for state in cache:
-                selected.append(state.at[indices].get())
-        else:
-            selected.append(cache.at[indices].get())
-    return selected
+
+    indices_per_layer = [
+        indices_per_group[layer_to_group_id[layer]]
+        for layer in range(len(kv_caches))
+    ]
+
+    return _select_kv_caches_jit(kv_caches, indices_per_layer)
 
 
 # TODO(wyzhang): Evaluate how to leverage `insert_kv_chunks`


### PR DESCRIPTION
# Description

selecting kv cache from device to host was introducing delays before this PR. This PR improves the mean TTFT from 9.9s to 3.2s for qwen3.5-0.8b model.

# Tests

Before this PR, we have https://screenshot.googleplex.com/8b3TxD8GiuoPFRx (job id, j-86467ce4-ea9b-4486-8c30). 

After this PR, we have https://screenshot.googleplex.com/3Mox5Vm6so422Vv (job id, j-a106c424-3b48-458a-a697)

Signed-off-by: Wangyuan Zhang <wyzhang@google.com>

