### PR TITLE
Ignore benchamrk bk pipeline generation error

### DIFF
--- a/.buildkite/scripts/configs/pipeline_config.sh
+++ b/.buildkite/scripts/configs/pipeline_config.sh
@@ -71,7 +71,6 @@ process_json_benchmark_cases() {
       echo "Successfully uploaded pipeline for $case_file"
     else
       echo "🚨 Error: Failed to generate or upload pipeline for $case_file"
-      exit 1
     fi
   done
 }


### PR DESCRIPTION
# Description

Ignore benchmark bk pipeline generation errors to prevent the entire process from failing due to a single case error.

# Tests

[Buildkite CI](https://buildkite.com/tpu-commons/tpu-inference-benchmark/builds/402)

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
