### PR TITLE
[CI] Skip DB reporting on benchmark failure

### DIFF
--- a/.buildkite/benchmark/scripts/report_result.sh
+++ b/.buildkite/benchmark/scripts/report_result.sh
@@ -118,12 +118,13 @@ safe_numeric_or_null() {
     fi
 }
 
-if [ $# -ne 1 ]; then
-  echo "Usage: $0 <RECORD_ID>"
+if [ $# -lt 1 ]; then
+  echo "Usage: $0 <RECORD_ID> [EXIT_CODE]"
   exit 1
 fi
 
 RECORD_ID=$1
+EXIT_CODE=${2:-0} # Default to 0 if not provided
 RUN_TYPE="${RUN_TYPE:-DAILY}"
 
 # Define Result_file name
@@ -247,6 +248,10 @@ fi
 
 # Database Reporting Logic (ON CONFLICT (RecordId) DO UPDATE SET)
 if [[ -n "${GCP_DATABASE_ID:-}" && -n "${GCP_PROJECT_ID:-}" && -n "${GCP_INSTANCE_ID:-}" ]]; then
+  if [ "$EXIT_CODE" -ne 0 ]; then
+    echo "--- Run failed with exit code $EXIT_CODE. Skipping DB reporting as requested."
+    exit 0
+  fi
   BUILDKITE_AGENT_NAME="${BUILDKITE_AGENT_NAME:-local-test}"
 
   # Parse metric assignments for dynamic columns

--- a/.buildkite/benchmark/scripts/report_result.sh
+++ b/.buildkite/benchmark/scripts/report_result.sh
@@ -249,7 +249,7 @@ fi
 # Database Reporting Logic (ON CONFLICT (RecordId) DO UPDATE SET)
 if [[ -n "${GCP_DATABASE_ID:-}" && -n "${GCP_PROJECT_ID:-}" && -n "${GCP_INSTANCE_ID:-}" ]]; then
   if [ "$EXIT_CODE" -ne 0 ]; then
-    echo "--- Run failed with exit code $EXIT_CODE. Skipping DB reporting as requested."
+    echo "--- run_bm.sh failed with exit code $EXIT_CODE. Skipping DB reporting."
     exit 0
   fi
   BUILDKITE_AGENT_NAME="${BUILDKITE_AGENT_NAME:-local-test}"

--- a/.buildkite/benchmark/scripts/run_bm.sh
+++ b/.buildkite/benchmark/scripts/run_bm.sh
@@ -133,17 +133,10 @@ export VLLM_TORCH_PROFILER_DIR
 report_and_exit() {
   local exit_code=${1:-0}
   local record_id="${RECORD_ID:-local}"
-  local report_exit_code
-
-  echo "--- Calling report_result.sh for RECORD_ID=${record_id}"
-  bash "$SCRIPT_DIR/report_result.sh" "$record_id"
-  report_exit_code=$?
-
-  # Exit with the reporting script's failure code if it did not succeed.
-  if [ "$report_exit_code" -ne 0 ]; then
-    exit "$report_exit_code"
-  fi
-
+  
+  echo "--- Calling report_result.sh for RECORD_ID=${record_id} with exit_code=${exit_code}"
+  bash "$SCRIPT_DIR/report_result.sh" "$record_id" "$exit_code" || exit $?
+  
   # Exit with the originally provided exit code.
   exit "$exit_code"
 }


### PR DESCRIPTION
# Description

[CI] Skip DB reporting on benchmark failure

Pass exit code to report_result.sh to ensure DB records align with
Buildkite job status and skip updates if the benchmark fails.

# Tests

[buildkite](https://buildkite.com/tpu-commons/tpu-inference-benchmark/builds/438#019e1a3b-b26e-4251-ab9b-143842b5d1fb)

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
