### PR TITLE
[spec decoding] drafter input preparation logic no need to retrieve sampled tokens from the main model to host first

### DIFF
--- a/tests/e2e/test_speculative_decoding.py
+++ b/tests/e2e/test_speculative_decoding.py
@@ -108,7 +108,6 @@ def _test_correctness_helper(
             max_num_seqs=4,
             tensor_parallel_size=_get_tensor_parallel_size(),
             model_loader_extra_config={"enable_weights_track": False},
-            download_dir="/mnt/pd",
             async_scheduling=0)
         ref_outputs = ref_llm.generate(test_prompts, sampling_config)
 
@@ -124,7 +123,6 @@ def _test_correctness_helper(
             max_num_seqs=4,
             tensor_parallel_size=_get_tensor_parallel_size(),
             model_loader_extra_config={"enable_weights_track": False},
-            download_dir="/mnt/pd",
             async_scheduling=0)
         spec_outputs = spec_llm.generate(test_prompts, sampling_config)
 
@@ -212,7 +210,6 @@ def _test_performance_helper(
             enable_prefix_caching=False,
             model_loader_extra_config={"enable_weights_track": False},
             disable_log_stats=False,
-            download_dir="/mnt/pd",
             async_scheduling=0)
 
         _ = spec_llm.generate(test_prompts, sampling_config)

--- a/tests/e2e/test_speculative_decoding.py
+++ b/tests/e2e/test_speculative_decoding.py
@@ -108,6 +108,7 @@ def _test_correctness_helper(
             max_num_seqs=4,
             tensor_parallel_size=_get_tensor_parallel_size(),
             model_loader_extra_config={"enable_weights_track": False},
+            download_dir="/mnt/pd",
             async_scheduling=0)
         ref_outputs = ref_llm.generate(test_prompts, sampling_config)
 
@@ -123,6 +124,7 @@ def _test_correctness_helper(
             max_num_seqs=4,
             tensor_parallel_size=_get_tensor_parallel_size(),
             model_loader_extra_config={"enable_weights_track": False},
+            download_dir="/mnt/pd",
             async_scheduling=0)
         spec_outputs = spec_llm.generate(test_prompts, sampling_config)
 
@@ -200,25 +202,6 @@ def _test_performance_helper(
         # Use a smaller set of prompts for performance testing
         test_prompts = get_test_prompts(speculative_config)
 
-        # Test reference LLM timing
-        ref_llm = LLM(
-            model=model_name,
-            max_model_len=1024,
-            max_num_seqs=1,
-            enable_prefix_caching=False,
-            tensor_parallel_size=_get_tensor_parallel_size(),
-            model_loader_extra_config={"enable_weights_track": False},
-            async_scheduling=0)
-
-        start_time = time.time()
-        _ = ref_llm.generate(test_prompts, sampling_config)
-        ref_time = time.time() - start_time
-
-        del ref_llm
-
-        # Waiting for TPUs to be released
-        time.sleep(30)
-
         # Test speculative LLM timing with max_num_seqs=1
         spec_llm = LLM(
             model=model_name,
@@ -229,11 +212,10 @@ def _test_performance_helper(
             enable_prefix_caching=False,
             model_loader_extra_config={"enable_weights_track": False},
             disable_log_stats=False,
+            download_dir="/mnt/pd",
             async_scheduling=0)
 
-        start_time = time.time()
         _ = spec_llm.generate(test_prompts, sampling_config)
-        spec_time = time.time() - start_time
 
         metrics = spec_llm.get_metrics()
         num_draft_tokens = num_accepted_tokens = 0
@@ -252,11 +234,6 @@ def _test_performance_helper(
         del spec_llm
         # Waiting for TPUs to be released
         time.sleep(30)
-
-        speedup = ref_time / spec_time
-        print(f"Reference LLM time: {ref_time:.2f}s")
-        print(f"Speculative LLM time: {spec_time:.2f}s")
-        print(f"Speedup: {speedup:.2f}x")
 
         assert acceptance_rate >= min_acceptance_rate, f"Expected at least {min_acceptance_rate:.2%} acceptance rate for {speculative_config['method']}, got {acceptance_rate:.2%}"
 

--- a/tests/runner/test_speculative_decoding_manager.py
+++ b/tests/runner/test_speculative_decoding_manager.py
@@ -89,11 +89,17 @@ class TestSpeculativeDecodingManager:
         # Mock the eagle-specific proposal method
         with patch.object(self.runner.speculative_decoding_manager,
                           'propose_eagle3_draft_token_ids',
-                          return_value=[[10, 11]]) as mock_propose_eagle:
+                          return_value=[[10, 11]]) as mock_propose_eagle, \
+             patch(
+                 'tpu_inference.runner.speculative_decoding_manager'
+                 '.extract_last_sampled_tokens',
+                 return_value=(MagicMock(), MagicMock())):
 
             # 2. ===== Act =====
             self.runner.speculative_decoding_manager.propose_draft_token_ids(
-                sampled_token_ids=[[1]],
+                sampled_output=MagicMock(),
+                logits_indices_selector=MagicMock(),
+                discard_sampled_tokens_req_indices=[],
                 aux_hidden_states=None,
                 attn_metadata=MagicMock(),
                 spec_decode_metadata=None,
@@ -112,7 +118,7 @@ class TestSpeculativeDecodingManager:
         self.runner.speculative_config.method = "ngram"
         with pytest.raises(AssertionError):
             self.runner.speculative_decoding_manager.propose_draft_token_ids(
-                [[1]], None, MagicMock(), None)
+                MagicMock(), MagicMock(), [], None, MagicMock(), None)
 
     def test_take_draft_token_ids(self):
         """Tests the take_draft_token_ids method for speculative decoding."""
@@ -336,7 +342,6 @@ class TestSpeculativeDecodingManager:
         )
 
         # Inputs
-        sampled_token_ids = [[1], [2]]
         aux_hidden_states = MagicMock()
         attn_metadata = MagicMock()
         attn_metadata.seq_lens.shape = [2]
@@ -345,6 +350,9 @@ class TestSpeculativeDecodingManager:
         else:
             spec_decode_metadata = MagicMock(spec=SpecDecodeMetadata)
             spec_decode_metadata.draft_lengths_cpu = np.array([2, 3])
+        last_sampled_token_id = MagicMock()
+        num_rejected_tokens = MagicMock()
+        discard_sampled_tokens_req_indices = []
         scheduler_output = MagicMock()
         input_ids = MagicMock()
 
@@ -353,10 +361,12 @@ class TestSpeculativeDecodingManager:
                 "tpu_inference.runner.speculative_decoding_manager.device_array",
                 side_effect=lambda mesh, x: x):
             result = self.runner.speculative_decoding_manager.propose_eagle3_draft_token_ids(
-                sampled_token_ids,
+                spec_decode_metadata,
+                last_sampled_token_id,
+                num_rejected_tokens,
+                discard_sampled_tokens_req_indices,
                 aux_hidden_states,
                 attn_metadata,
-                spec_decode_metadata,
                 scheduler_output,
                 input_ids,
             )

--- a/tests/spec_decode/test_eagle3.py
+++ b/tests/spec_decode/test_eagle3.py
@@ -116,9 +116,13 @@ def test_prepare_inputs():
     num_rejected_tokens = jnp.array(num_rejected_tokens_cpu)
     # This is only used in the _prepare_input_ids helper
     # It must be padded to max_num_seqs (128) to match the mask in jnp.where
-    next_token_ids_cpu = np.zeros(max_num_seqs, dtype=np.int32)
-    next_token_ids_cpu[:num_reqs] = [1, 2, 3]  # Valid tokens for active reqs
-    next_token_ids = jnp.array(next_token_ids_cpu)
+    last_sampled_token_id_cpu = np.zeros(max_num_seqs, dtype=np.int32)
+    last_sampled_token_id_cpu[:num_reqs] = [1, 2,
+                                            3]  # Valid tokens for active reqs
+    last_sampled_token_id = jnp.array(last_sampled_token_id_cpu)
+    next_prompt_token_id = jnp.zeros(max_num_seqs, dtype=jnp.int32)
+    # All requests are in decode (not prefill), so last_sampled_token_id is used.
+    is_in_prefill = jnp.zeros(max_num_seqs, dtype=jnp.bool_)
 
     attn_metadata = AttentionMetadata(
         seq_lens=jnp.array(sl_cpu),
@@ -149,7 +153,8 @@ def test_prepare_inputs():
     # Execute
     target_hidden_states, input_ids, last_token_indices, updated_metadata = (
         proposer.prepare_inputs(attn_metadata, input_ids, aux_hidden_states,
-                                next_token_ids, num_rejected_tokens))
+                                last_sampled_token_id, next_prompt_token_id,
+                                is_in_prefill, num_rejected_tokens))
 
     # Assertions
     assert jnp.array_equal(updated_metadata.query_start_loc,

--- a/tests/spec_decode/test_utils.py
+++ b/tests/spec_decode/test_utils.py
@@ -1,0 +1,156 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from tpu_inference.layers.jax.sample.rejection_sampler import RejectionSampler
+from tpu_inference.runner.utils import SpecDecodeMetadata
+from tpu_inference.spec_decode.jax.utils import (PLACEHOLDER_TOKEN_ID,
+                                                 extract_last_sampled_tokens)
+
+VOCAB_SIZE = 100
+
+
+def _build_inputs(seqs, num_speculative_tokens):
+    """Build (sampled_token_ids, metadata, num_draft_tokens_cpu).
+
+    `seqs` is a list of (main_tokens, bonus_token). `main_tokens` contains the
+    per-position outputs of the rejection sampler for that sequence (with
+    PLACEHOLDER_TOKEN_ID at rejected positions); its length is the number of
+    draft tokens for that sequence and must be <= num_speculative_tokens.
+    """
+    main_flat = []
+    bonus_flat = []
+    num_draft = []
+    for main_tokens, bonus_token in seqs:
+        assert len(main_tokens) <= num_speculative_tokens
+        main_flat.extend(main_tokens)
+        bonus_flat.append(bonus_token)
+        num_draft.append(len(main_tokens))
+
+    sampled = jnp.asarray(main_flat + bonus_flat, dtype=jnp.int32)
+    num_draft_cpu = np.asarray(num_draft, dtype=np.int32)
+
+    metadata = SpecDecodeMetadata(
+        draft_token_ids=jnp.zeros(int(num_draft_cpu.sum()), dtype=jnp.int32),
+        draft_lengths=jnp.asarray(num_draft_cpu),
+        target_logits_indices=jnp.zeros(int(num_draft_cpu.sum()),
+                                        dtype=jnp.int32),
+        bonus_logits_indices=jnp.zeros(len(num_draft_cpu), dtype=jnp.int32),
+        final_logits_indices=jnp.zeros(len(num_draft_cpu), dtype=jnp.int32),
+    )
+    metadata.draft_lengths_cpu = num_draft_cpu
+    return sampled, metadata, num_draft_cpu
+
+
+def _reference(sampled, num_draft_cpu, vocab_size, max_num_seq):
+    """Compute the reference (last_sampled, num_rejected) using parse_output."""
+    batch_size = len(num_draft_cpu)
+    padded_tokens_length = int(num_draft_cpu.sum())
+    per_seq_tokens = RejectionSampler.parse_output(
+        sampled,
+        vocab_size,
+        num_draft_cpu,
+        batch_size,
+        padded_tokens_length,
+    )
+
+    last_sampled = np.full((max_num_seq, ),
+                           PLACEHOLDER_TOKEN_ID,
+                           dtype=np.int32)
+    num_rejected = np.zeros((max_num_seq, ), dtype=np.int32)
+    for i, toks in enumerate(per_seq_tokens):
+        if toks:
+            last_sampled[i] = toks[-1]
+        if num_draft_cpu[i] > 0:
+            num_rejected[i] = int(num_draft_cpu[i]) + 1 - len(toks)
+    return last_sampled, num_rejected
+
+
+@pytest.mark.parametrize(
+    "case_name, seqs, num_speculative",
+    [
+        (
+            "all_accepted_full_drafts",
+            [([10, 20, 30], 40), ([5, 15, 25], 35)],
+            3,
+        ),
+        (
+            "all_accepted_partial_drafts",
+            [([10, 20, 30], 40), ([5, 15], 25)],
+            3,
+        ),
+        (
+            "with_rejection_no_bonus",
+            [
+                ([10, 20, PLACEHOLDER_TOKEN_ID], PLACEHOLDER_TOKEN_ID),
+                ([5, PLACEHOLDER_TOKEN_ID, PLACEHOLDER_TOKEN_ID
+                  ], PLACEHOLDER_TOKEN_ID),
+            ],
+            3,
+        ),
+        (
+            "some_seq_no_draft_tokens",
+            [
+                ([10, 20], 30),
+                ([5, PLACEHOLDER_TOKEN_ID], PLACEHOLDER_TOKEN_ID),
+                ([], 99),
+            ],
+            2,
+        ),
+        (
+            "bonus_vocab_overflow_falls_back_to_last_main",
+            [
+                ([10, 20, 30], VOCAB_SIZE + 1),
+                ([5, 15], VOCAB_SIZE + 7),
+            ],
+            3,
+        ),
+    ],
+)
+def test_extract_last_sampled_tokens_matches_parse_output(
+        case_name, seqs, num_speculative):
+    max_num_seq = 8
+    sampled, metadata, num_draft_cpu = _build_inputs(seqs, num_speculative)
+
+    last_sampled, num_rejected = extract_last_sampled_tokens(
+        metadata, sampled, num_speculative, VOCAB_SIZE, max_num_seq)
+
+    ref_last, ref_num_rej = _reference(sampled, num_draft_cpu, VOCAB_SIZE,
+                                       max_num_seq)
+
+    np.testing.assert_array_equal(np.asarray(last_sampled), ref_last)
+    np.testing.assert_array_equal(np.asarray(num_rejected), ref_num_rej)
+
+
+def test_extract_last_sampled_tokens_no_spec_decode():
+    max_num_seq = 8
+    sampled = jnp.asarray([7, 11, 42], dtype=jnp.int32)
+
+    last_sampled, num_rejected = extract_last_sampled_tokens(
+        None,
+        sampled,
+        num_speculative_tokens=3,
+        vocab_size=VOCAB_SIZE,
+        max_num_seq=max_num_seq,
+    )
+
+    expected_last = np.array([7, 11, 42] + [PLACEHOLDER_TOKEN_ID] * 5,
+                             dtype=np.int32)
+    expected_num_rejected = np.zeros(max_num_seq, dtype=np.int32)
+    np.testing.assert_array_equal(np.asarray(last_sampled), expected_last)
+    np.testing.assert_array_equal(np.asarray(num_rejected),
+                                  expected_num_rejected)

--- a/tpu_inference/runner/compilation_manager.py
+++ b/tpu_inference/runner/compilation_manager.py
@@ -31,6 +31,8 @@ from tpu_inference.layers.jax.sample.sampling_metadata import \
 from tpu_inference.logger import init_logger
 from tpu_inference.models.jax.jax_intermediate_tensor import \
     JaxIntermediateTensors
+from tpu_inference.runner.utils import SpecDecodeMetadata
+from tpu_inference.spec_decode.jax.utils import extract_last_sampled_tokens
 from tpu_inference.utils import device_array, to_jax_dtype
 
 if TYPE_CHECKING:
@@ -689,7 +691,65 @@ class CompilationManager:
             "Compiling speculative_decoding with different input shapes.")
         self._precompile_rejection_sampler()
         if self.runner.speculative_config.method == "eagle3":
+            self._precompile_extract_last_sampled_tokens()
             self._precompile_eagle3_helpers()
+
+    def _precompile_extract_last_sampled_tokens(self) -> None:
+        logger.info(
+            "Compiling extract_last_sampled_tokens with different input shapes."
+        )
+        vocab_size = self.runner.vocab_size
+        num_speculative_tokens = (
+            self.runner.speculative_config.num_speculative_tokens)
+        max_num_seq = self.runner.max_num_reqs
+
+        # Case 1: spec_decode_metadata is None. sampled_token_ids has shape
+        # (num_reqs,) from the regular sample() path on the previous step.
+        for num_reqs in self.runner.num_reqs_paddings:
+            sampled_token_ids = self._create_dummy_tensor((num_reqs, ),
+                                                          jnp.int32)
+            self._run_compilation(
+                f"worker{self.runner.rank} extract_last_sampled_tokens "
+                f"(no spec_decode_metadata)",
+                extract_last_sampled_tokens,
+                None,
+                sampled_token_ids,
+                num_speculative_tokens,
+                vocab_size,
+                max_num_seq,
+                num_reqs=num_reqs,
+            )
+
+        # Case 2: spec_decode_metadata is not None. sampled_token_ids has
+        # shape (num_logits + num_reqs,) from the rejection_sampler output
+        # — [main_tokens (num_logits), bonus_tokens (num_reqs)].
+        for num_logits in self.runner.num_logits_paddings:
+            for num_reqs in self.runner.num_reqs_paddings:
+                sampled_token_ids = self._create_dummy_tensor(
+                    (num_logits + num_reqs, ), jnp.int32)
+                spec_decode_metadata = SpecDecodeMetadata(
+                    draft_token_ids=self._create_dummy_tensor((num_logits, ),
+                                                              jnp.int32),
+                    draft_lengths=self._create_dummy_tensor((num_reqs, ),
+                                                            jnp.int32),
+                    target_logits_indices=self._create_dummy_tensor(
+                        (num_logits, ), jnp.int32),
+                    bonus_logits_indices=self._create_dummy_tensor(
+                        (num_reqs, ), jnp.int32),
+                    final_logits_indices=self._create_dummy_tensor(
+                        (num_logits, ), jnp.int32),
+                )
+                self._run_compilation(
+                    f"worker{self.runner.rank} extract_last_sampled_tokens",
+                    extract_last_sampled_tokens,
+                    spec_decode_metadata,
+                    sampled_token_ids,
+                    num_speculative_tokens,
+                    vocab_size,
+                    max_num_seq,
+                    num_logits=num_logits,
+                    num_reqs=num_reqs,
+                )
 
     def _precompile_rejection_sampler(self) -> None:
         logger.info("Compiling rejection_sampler with different input shapes.")
@@ -795,8 +855,6 @@ class CompilationManager:
         else:
             eagle3_mamba_state_indices = None
 
-        next_token_ids = self._create_dummy_tensor(
-            (self.runner.max_num_reqs, ), jnp.int32)
         last_token_indices = self._create_dummy_tensor(
             (self.runner.max_num_reqs, ), jnp.int32)
         for num_tokens in self.runner.num_tokens_paddings:
@@ -849,35 +907,41 @@ class CompilationManager:
                 num_tokens=num_tokens,
             )
 
-            for num_rejected_tokens in [
-                    None,
-                    self._create_dummy_tensor((self.runner.max_num_reqs, ),
-                                              jnp.int32)
-            ]:
-                aux_hidden_states = [
-                    self._create_dummy_tensor(
-                        (num_tokens, target_hidden_size), jnp.bfloat16,
-                        NamedSharding(self.runner.mesh,
-                                      PartitionSpec(None, None))),
-                    self._create_dummy_tensor(
-                        (num_tokens, target_hidden_size), jnp.bfloat16,
-                        NamedSharding(self.runner.mesh,
-                                      PartitionSpec(None, None))),
-                    self._create_dummy_tensor(
-                        (num_tokens, target_hidden_size), jnp.bfloat16,
-                        NamedSharding(self.runner.mesh,
-                                      PartitionSpec(None, None))),
-                ]
-                self._run_compilation(
-                    "drafter_prepare_inputs",
-                    self.runner.drafter.prepare_inputs,
-                    attention_metadata,
-                    input_ids,
-                    aux_hidden_states,
-                    next_token_ids,
-                    num_rejected_tokens,
-                    num_tokens=num_tokens,
-                )
+            aux_hidden_states = [
+                self._create_dummy_tensor(
+                    (num_tokens, target_hidden_size), jnp.bfloat16,
+                    NamedSharding(self.runner.mesh, PartitionSpec(None,
+                                                                  None))),
+                self._create_dummy_tensor(
+                    (num_tokens, target_hidden_size), jnp.bfloat16,
+                    NamedSharding(self.runner.mesh, PartitionSpec(None,
+                                                                  None))),
+                self._create_dummy_tensor(
+                    (num_tokens, target_hidden_size), jnp.bfloat16,
+                    NamedSharding(self.runner.mesh, PartitionSpec(None,
+                                                                  None))),
+            ]
+            last_sampled_token_id = self._create_dummy_tensor(
+                (self.runner.max_num_reqs, ), jnp.int32)
+            next_prompt_token_id = self._create_dummy_tensor(
+                (self.runner.max_num_reqs, ), jnp.int32)
+            is_in_prefill = self._create_dummy_tensor(
+                (self.runner.max_num_reqs, ), jnp.int32)
+            num_rejected_tokens = self._create_dummy_tensor(
+                (self.runner.max_num_reqs, ), jnp.int32)
+
+            self._run_compilation(
+                "drafter_prepare_inputs",
+                self.runner.drafter.prepare_inputs,
+                attention_metadata,
+                input_ids,
+                aux_hidden_states,
+                last_sampled_token_id,
+                next_prompt_token_id,
+                is_in_prefill,
+                num_rejected_tokens,
+                num_tokens=num_tokens,
+            )
 
     def _precompile_structured_decoding(self) -> None:
         logger.info(

--- a/tpu_inference/runner/speculative_decoding_manager.py
+++ b/tpu_inference/runner/speculative_decoding_manager.py
@@ -14,7 +14,6 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 from typing import TYPE_CHECKING, Optional
 
 import jax.numpy as jnp
@@ -24,24 +23,15 @@ from vllm.v1.outputs import DraftTokenIds
 from vllm.v1.spec_decode.ngram_proposer import NgramProposer
 
 from tpu_inference.runner import utils as runner_utils
+from tpu_inference.runner.utils import SpecDecodeMetadata
 from tpu_inference.spec_decode.jax.eagle3 import Eagle3Proposer
+from tpu_inference.spec_decode.jax.utils import extract_last_sampled_tokens
 from tpu_inference.utils import device_array
 
 if TYPE_CHECKING:
     from tpu_inference.layers.common.attention_metadata import \
         AttentionMetadata
     from tpu_inference.runner.tpu_runner import TPUModelRunner
-
-
-@dataclass
-class SpecDecodeMetadata:
-    """Metadata for speculative decoding on JAX/TPU, containing all necessary indices."""
-    draft_token_ids: jnp.ndarray
-    draft_lengths: jnp.ndarray
-    draft_lengths_cpu: np.ndarray
-    target_logits_indices: jnp.ndarray
-    bonus_logits_indices: jnp.ndarray
-    final_logits_indices: jnp.ndarray
 
 
 class SpeculativeDecodingManager:
@@ -61,7 +51,9 @@ class SpeculativeDecodingManager:
 
     def propose_draft_token_ids(
         self,
-        sampled_token_ids: list[list[int]],
+        sampled_output: jnp.ndarray,
+        logits_indices_selector: np.ndarray,
+        discard_sampled_tokens_req_indices: list,
         aux_hidden_states: Optional[tuple[jnp.ndarray, ...]],
         attn_metadata: AttentionMetadata,
         spec_decode_metadata: Optional[SpecDecodeMetadata],
@@ -70,16 +62,28 @@ class SpeculativeDecodingManager:
     ) -> None:
         if self.runner.speculative_config.method == "ngram":
             assert isinstance(self.runner.drafter, NgramProposer)
+            # For n-gram based proposer, the drafter run on host
+            # cpu, therefore, we need to first copy the sampled
+            # token ids from device to host, then run the ngram proposer.
+            valid_sampled_token_ids = runner_utils.host_extract_sampled_tokens(
+                self.runner, spec_decode_metadata, sampled_output,
+                logits_indices_selector, discard_sampled_tokens_req_indices)
             self._draft_token_ids = self.runner.drafter.propose(
-                sampled_token_ids[:self.runner.input_batch.num_reqs],
+                valid_sampled_token_ids[:self.runner.input_batch.num_reqs],
                 self.runner.input_batch.num_tokens_no_spec,
                 self.runner.input_batch.token_ids_cpu)
         elif self.runner.speculative_config.method == "eagle3":
+            last_sampled_token_id, num_rejected_tokens = extract_last_sampled_tokens(
+                spec_decode_metadata, sampled_output,
+                self.runner.speculative_config.num_speculative_tokens,
+                self.runner.input_batch.vocab_size, self.runner.max_num_reqs)
             self._draft_token_ids = self.propose_eagle3_draft_token_ids(
-                sampled_token_ids,
+                spec_decode_metadata,
+                last_sampled_token_id,
+                num_rejected_tokens,
+                discard_sampled_tokens_req_indices,
                 aux_hidden_states,
                 attn_metadata,
-                spec_decode_metadata,
                 scheduler_output,
                 input_ids,
             )
@@ -90,60 +94,41 @@ class SpeculativeDecodingManager:
 
     def propose_eagle3_draft_token_ids(
         self,
-        sampled_token_ids: list[list[int]],
+        spec_decode_metadata: Optional[SpecDecodeMetadata],
+        last_sampled_token_id: jnp.ndarray,
+        num_rejected_tokens: jnp.ndarray,
+        discard_sampled_tokens_req_indices: list[int],
         aux_hidden_states: Optional[tuple[jnp.ndarray, ...]],
         attn_metadata: AttentionMetadata,
-        spec_decode_metadata: Optional[SpecDecodeMetadata],
         scheduler_output: VllmSchedulerOutput,
         input_ids: jnp.ndarray,
     ) -> list[list[int]]:
         assert isinstance(self.runner.drafter, Eagle3Proposer)
-
-        # TODO(woosuk): Refactor the loop.
         req_ids = self.runner.input_batch.req_ids
-        next_token_ids: list[int] = []
-        for i, token_ids in enumerate(sampled_token_ids):
-            if token_ids:
-                # Common case.
-                next_token_id = token_ids[-1]
-            else:
-                # Partial prefill (rare case).
-                # Get the next token id from the request state.
-                req_id = req_ids[i]
-                req_state = self.runner.requests[req_id]
-                seq_len = (req_state.num_computed_tokens +
-                           scheduler_output.num_scheduled_tokens[req_id])
-                next_token_id = req_state.get_token_id(seq_len)
-            next_token_ids.append(next_token_id)
+        max_num_seqs = attn_metadata.seq_lens.shape[0]
+        next_prompt_token_id = np.zeros(max_num_seqs, dtype=np.int32)
+        is_in_prefill = np.zeros(max_num_seqs, dtype=np.int32)
+        for i in discard_sampled_tokens_req_indices:
+            # Partial prefill
+            # Get the next token id from the request state.
+            req_id = req_ids[i]
+            req_state = self.runner.requests[req_id]
+            seq_len = (req_state.num_computed_tokens +
+                       scheduler_output.num_scheduled_tokens[req_id])
+            next_token_id = req_state.get_token_id(seq_len)
+            next_prompt_token_id[i] = next_token_id
+            is_in_prefill[i] = 1
 
-        # Pad the batch size to match with existing padding for target model
-        pad_len = attn_metadata.seq_lens.shape[0] - len(next_token_ids)
-        assert pad_len >= 0
-        next_token_ids += [0] * pad_len
-
-        next_token_ids = device_array(
-            self.runner.mesh, np.array(next_token_ids, dtype=jnp.int32))
-
-        if spec_decode_metadata is None:
-            num_rejected_tokens = None
-        else:
-            num_draft_tokens = spec_decode_metadata.draft_lengths_cpu
-            num_rejected_tokens = [
-                int(n) + 1 - len(sampled_token_ids[i]) if n > 0 else 0
-                for i, n in enumerate(num_draft_tokens)
-            ]
-
-            pad_len = self.runner.max_num_reqs - len(num_rejected_tokens)
-            num_rejected_tokens += [0] * pad_len
-            num_rejected_tokens = device_array(
-                self.runner.mesh, np.array(num_rejected_tokens,
-                                           dtype=jnp.int32))
+        next_prompt_token_id, is_in_prefill = device_array(
+            self.runner.mesh, (next_prompt_token_id, is_in_prefill))
 
         target_hidden_states, input_ids, last_token_indices, attn_metadata = self.runner.drafter.prepare_inputs(
             attn_metadata,
             input_ids,
             aux_hidden_states,
-            next_token_ids,
+            last_sampled_token_id,
+            next_prompt_token_id,
+            is_in_prefill,
             num_rejected_tokens,
         )
 
@@ -253,9 +238,9 @@ class SpeculativeDecodingManager:
         metadata = SpecDecodeMetadata(
             draft_token_ids=padded_draft_token_ids,
             draft_lengths=padded_num_draft_tokens,
-            draft_lengths_cpu=padded_num_draft_tokens_cpu,
             target_logits_indices=padded_target_logits_indices,
             bonus_logits_indices=padded_bonus_logits_indices,
             final_logits_indices=padded_logits_indices,
         )
+        metadata.draft_lengths_cpu = padded_num_draft_tokens_cpu
         return metadata

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -1066,6 +1066,19 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         for req_id in self.input_batch.req_ids[:num_reqs]:
             prompt_logprobs_dict[req_id] = None
 
+        if self.speculative_config:
+            with self.maybe_forbid_compile, jax.set_mesh(self.mesh):
+                self.speculative_decoding_manager.propose_draft_token_ids(
+                    next_tokens,
+                    logits_indices_selector,
+                    discard_sampled_tokens_req_indices,
+                    aux_hidden_states,
+                    attn_metadata,
+                    spec_decode_metadata,
+                    scheduler_output,
+                    input_ids,
+                )
+
         # If async scheduler enabled
         if self.scheduler_config.async_scheduling:
             # Get previous results from TPU and replace the placeholder.
@@ -1113,22 +1126,10 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                 total_num_scheduled_tokens)
             return async_model_runner_output
 
-        if spec_decode_metadata is None:
-            next_tokens = np.asarray(jax.device_get(next_tokens))
-            # Map tokens back to the pre-dp shuffling order
-            if logits_indices_selector is not None:
-                next_tokens = next_tokens[logits_indices_selector]
-            selected_token_ids = np.expand_dims(next_tokens[:num_reqs], 1)
-            valid_sampled_token_ids = selected_token_ids.tolist()
-        else:
-            valid_sampled_token_ids = self.rejection_sampler.parse_output(
-                next_tokens, self.input_batch.vocab_size,
-                spec_decode_metadata.draft_lengths_cpu, num_reqs,
-                spec_decode_metadata.draft_token_ids.shape[0])
+        valid_sampled_token_ids = runner_utils.host_extract_sampled_tokens(
+            self, spec_decode_metadata, next_tokens, logits_indices_selector,
+            discard_sampled_tokens_req_indices)
 
-        # Mask out the sampled tokens that should not be sampled.
-        for i in discard_sampled_tokens_req_indices:
-            valid_sampled_token_ids[i].clear()
         # Append sampled tokens
         for req_idx, req_state, _ in request_seq_lens:
             sampled_ids = valid_sampled_token_ids[req_idx]
@@ -1154,17 +1155,6 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                 logprobs, logits_indices_selector)
         else:
             logprobs_lists = None
-
-        if self.speculative_config:
-            with self.maybe_forbid_compile, jax.set_mesh(self.mesh):
-                self.speculative_decoding_manager.propose_draft_token_ids(
-                    valid_sampled_token_ids,
-                    aux_hidden_states,
-                    attn_metadata,
-                    spec_decode_metadata,
-                    scheduler_output,
-                    input_ids,
-                )
 
         model_runner_output = ModelRunnerOutput(
             req_ids=req_ids,

--- a/tpu_inference/runner/utils.py
+++ b/tpu_inference/runner/utils.py
@@ -9,10 +9,13 @@ import json
 import os
 import shutil
 import time
+from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any
+from typing import Any, Optional
 
 import jax
+import jax.numpy as jnp
+import numpy as np
 from jax._src.interpreters import pxla
 from vllm.v1.core.sched.output import SchedulerOutput as VllmSchedulerOutput
 
@@ -532,3 +535,54 @@ class PhasedBasedProfiler:
             # We are in the middle of profiling a given phase
             else:
                 self._step_or_stop_profiling(batch_composition_stats)
+
+
+@functools.partial(
+    jax.tree_util.register_dataclass,
+    data_fields=[
+        "draft_token_ids",
+        "draft_lengths",
+        "target_logits_indices",
+        "bonus_logits_indices",
+        "final_logits_indices",
+    ],
+    meta_fields=[],
+    drop_fields=["draft_lengths_cpu"],
+)
+@dataclass
+class SpecDecodeMetadata:
+    """Metadata for speculative decoding on JAX/TPU, containing all necessary indices."""
+    draft_token_ids: jnp.ndarray
+    draft_lengths: jnp.ndarray
+    target_logits_indices: jnp.ndarray
+    bonus_logits_indices: jnp.ndarray
+    final_logits_indices: jnp.ndarray
+
+    draft_lengths_cpu: Any = field(init=False)
+
+
+def host_extract_sampled_tokens(
+        runner, spec_decode_metadata: Optional[SpecDecodeMetadata],
+        sampled_output: jnp.ndarray, logits_indices_selector: np.ndarray,
+        discard_sampled_tokens_req_indices: list):
+    """host retrieve the sampled tokens for the current step."""
+
+    num_reqs = runner.input_batch.num_reqs
+    next_tokens = sampled_output
+    if spec_decode_metadata is None:
+        next_tokens = np.asarray(jax.device_get(next_tokens))
+        # Map tokens back to the pre-dp shuffling order
+        if logits_indices_selector is not None:
+            next_tokens = next_tokens[logits_indices_selector]
+        selected_token_ids = np.expand_dims(next_tokens[:num_reqs], 1)
+        valid_sampled_token_ids = selected_token_ids.tolist()
+    else:
+        valid_sampled_token_ids = runner.rejection_sampler.parse_output(
+            next_tokens, runner.input_batch.vocab_size,
+            spec_decode_metadata.draft_lengths_cpu, num_reqs,
+            spec_decode_metadata.draft_token_ids.shape[0])
+    # Mask out the sampled tokens that should not be sampled.
+    for i in discard_sampled_tokens_req_indices:
+        valid_sampled_token_ids[i].clear()
+
+    return valid_sampled_token_ids

--- a/tpu_inference/spec_decode/jax/eagle3.py
+++ b/tpu_inference/spec_decode/jax/eagle3.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 """Implements the Eagle3 proposer for speculative decoding on JAX/TPU."""
 from dataclasses import replace
-from typing import Any, Optional
+from typing import Any
 
 import jax
 import jax.numpy as jnp
@@ -231,8 +231,10 @@ class Eagle3Proposer:
         attn_metadata: AttentionMetadata,
         input_ids: jax.Array,
         aux_hidden_states: tuple[jax.Array, ...],
-        next_token_ids: jax.Array,
-        num_rejected_tokens: Optional[jax.Array] = None,
+        last_sampled_token_id: jax.Array,
+        next_prompt_token_id: jax.Array,
+        is_in_prefill: jax.Array,
+        num_rejected_tokens: jax.Array,
     ) -> tuple[jax.Array, jax.Array, jax.Array, AttentionMetadata]:
         """Prepare drafter inputs based on target forward outputs.
 
@@ -258,14 +260,17 @@ class Eagle3Proposer:
         num_reqs = self.runner.input_batch.num_reqs
         num_reqs, block_tables = device_array(
             self.mesh, (np.asarray([num_reqs], dtype=jnp.int32), block_tables))
-        return self._prepare_inputs(state=self.state,
-                                    num_reqs=num_reqs,
-                                    block_tables=block_tables,
-                                    attn_metadata=attn_metadata,
-                                    input_ids=input_ids,
-                                    aux_hidden_states=aux_hidden_states,
-                                    next_token_ids=next_token_ids,
-                                    num_rejected_tokens=num_rejected_tokens)
+        return self._prepare_inputs(
+            state=self.state,
+            num_reqs=num_reqs,
+            block_tables=block_tables,
+            attn_metadata=attn_metadata,
+            input_ids=input_ids,
+            aux_hidden_states=aux_hidden_states,
+            last_sampled_token_id=last_sampled_token_id,
+            next_prompt_token_id=next_prompt_token_id,
+            is_in_prefill=is_in_prefill,
+            num_rejected_tokens=num_rejected_tokens)
 
     @jax.jit(static_argnums=(0, ))
     def _prepare_inputs(
@@ -276,8 +281,10 @@ class Eagle3Proposer:
         attn_metadata: AttentionMetadata,
         input_ids: jax.Array,
         aux_hidden_states: tuple[jax.Array, ...],
-        next_token_ids: jax.Array,
-        num_rejected_tokens: Optional[jax.Array] = None,
+        last_sampled_token_id: jax.Array,
+        next_prompt_token_id: jax.Array,
+        is_in_prefill: jax.Array,
+        num_rejected_tokens: jax.Array,
     ) -> tuple[jax.Array, jax.Array, jax.Array, AttentionMetadata]:
         """Prepare drafter inputs based on target forward outputs.
 
@@ -294,13 +301,8 @@ class Eagle3Proposer:
         assert aux_hidden_states is not None and len(aux_hidden_states) > 0, (
             "EAGLE3 requires auxiliary hidden states from the target model.")
 
-        if num_rejected_tokens is None:
-            # block_tables = device_array(self.mesh, block_tables)
-            attn_metadata = replace(attn_metadata, block_tables=block_tables)
-            target_hidden_states, input_ids, last_token_indices = self._prepare_hidden_states_and_input_ids(
-                state, aux_hidden_states, attn_metadata.query_start_loc,
-                input_ids, next_token_ids, num_reqs)
-            return target_hidden_states, input_ids, last_token_indices, attn_metadata
+        next_token_ids = jnp.where(is_in_prefill, next_prompt_token_id,
+                                   last_sampled_token_id)
 
         query_start_loc = attn_metadata.query_start_loc
         seq_lens = attn_metadata.seq_lens

--- a/tpu_inference/spec_decode/jax/utils.py
+++ b/tpu_inference/spec_decode/jax/utils.py
@@ -1,0 +1,84 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Optional
+
+import jax
+import jax.numpy as jnp
+
+from tpu_inference.runner.utils import SpecDecodeMetadata
+
+PLACEHOLDER_TOKEN_ID = -1
+
+
+@jax.jit(
+    static_argnames=["num_speculative_tokens", "max_num_seq", "vocab_size"])
+def extract_last_sampled_tokens(
+        spec_decode_metadata: Optional[SpecDecodeMetadata],
+        sampled_token_ids: jnp.ndarray, num_speculative_tokens: int,
+        vocab_size: int, max_num_seq: int) -> tuple[jnp.ndarray, jnp.ndarray]:
+    """Extract the last sampled token and number rejected tokens per seq. """
+    if spec_decode_metadata is None:
+        # No speculative decoding in the previous step.
+        batch_size = sampled_token_ids.shape[0]
+        last_sampled_tokens = jnp.pad(sampled_token_ids,
+                                      (0, max_num_seq - batch_size),
+                                      constant_values=PLACEHOLDER_TOKEN_ID)
+        num_rejected_tokens = jnp.zeros(max_num_seq, dtype=jnp.int32)
+        return last_sampled_tokens, num_rejected_tokens
+
+    # If `spec_decode_metadata` is not None, `sampled_token_ids`
+    # is the output of the rejection sampler.
+    num_draft_tokens = spec_decode_metadata.draft_lengths
+    batch_size = num_draft_tokens.shape[0]
+    index_range = jax.lax.broadcasted_iota(
+        jnp.int32, (batch_size, num_speculative_tokens), 1)
+    valid_mask = index_range < num_draft_tokens[:, None]
+
+    # `sampled_token_ids` has the flat layout
+    # [main_tokens (sum(num_draft_tokens)), bonus_tokens (batch_size)].
+    # `segment_starts[i]` is the offset of seq i's main tokens in that flat
+    # array, so main_tokens_indices[i, j] = segment_starts[i] + j.
+    segment_starts = jnp.pad(jnp.cumsum(num_draft_tokens)[:-1], (1, 0),
+                             constant_values=0)
+    main_tokens_indices = segment_starts[:, None] + index_range
+    main_tokens_indices = jnp.where(valid_mask, main_tokens_indices, 0)
+
+    main_tokens = jnp.where(valid_mask, sampled_token_ids[main_tokens_indices],
+                            PLACEHOLDER_TOKEN_ID)
+    main_tokens = jnp.where(main_tokens < vocab_size, main_tokens,
+                            PLACEHOLDER_TOKEN_ID)
+
+    bonus_tokens = sampled_token_ids[-batch_size:]
+    bonus_tokens = jnp.where(bonus_tokens < vocab_size, bonus_tokens,
+                             PLACEHOLDER_TOKEN_ID)
+
+    num_valid_main = jnp.sum(main_tokens != PLACEHOLDER_TOKEN_ID, axis=1)
+    last_main_idx = jnp.maximum(num_valid_main - 1, 0)
+    last_main = main_tokens[jnp.arange(batch_size), last_main_idx]
+    last_main = jnp.where(num_valid_main > 0, last_main, PLACEHOLDER_TOKEN_ID)
+    has_bonus = bonus_tokens != PLACEHOLDER_TOKEN_ID
+    last_sampled_per_seq = jnp.where(has_bonus, bonus_tokens, last_main)
+    last_sampled_tokens = jnp.pad(last_sampled_per_seq,
+                                  (0, max_num_seq - batch_size),
+                                  constant_values=PLACEHOLDER_TOKEN_ID)
+
+    num_rejected_per_seq = jnp.where(
+        num_draft_tokens > 0,
+        num_draft_tokens + 1 - num_valid_main - has_bonus.astype(jnp.int32),
+        jnp.zeros_like(num_draft_tokens))
+    num_rejected_tokens = jnp.pad(num_rejected_per_seq,
+                                  (0, max_num_seq - batch_size),
+                                  constant_values=0)
+    return last_sampled_tokens, num_rejected_tokens


### PR DESCRIPTION
[spec decoding]  drafter input preparation logic no need to retrieve sampled tokens from the main model to host first

The key changes are tpu_inference/spec_decode/jax/utils.py::extract_last_sampled_tokens.
The sampled tokens are already in TPU, directly passed from main model -> drafter (both in TPU). No need to have an extra hop of TPU -> host, host -> TPU.

gap between 2 consecutive step:
(before) https://screenshot.googleplex.com/BuS82LYwKVpGoAT (14.6ms)
(with this PR): https://screenshot.googleplex.com/9a5ehQMMtgw8uBC (11.4ms)

# Tests
unit tests.
Spec decoding acceptance rate for the Spec-bench dataset: https://paste.googleplex.com/5061250326331392


