### PR TITLE
Unify `prepare_inputs_dp` and `prepare_inputs_non_dp`

### DIFF
--- a/tests/runner/test_tpu_runner.py
+++ b/tests/runner/test_tpu_runner.py
@@ -175,7 +175,7 @@ class TestTPUJaxRunner:
         mock_sampling_instance = MagicMock()
         mock_sampling_metadata.from_input_batch.return_value = mock_sampling_instance
 
-        output = self.runner._prepare_inputs_non_dp(scheduler_output)
+        output = self.runner._prepare_inputs(scheduler_output)
         assert len(output) == 8
         input_ids, positions, attention_metadata, sampling_metadata, logits_indices, spec_decode_metadata, logits_indices_selector, padded_num_reqs = output
         # assert it will create attention metadata for each layer.

--- a/tests/runner/test_tpu_runner_dp.py
+++ b/tests/runner/test_tpu_runner_dp.py
@@ -80,11 +80,11 @@ class TestTPUJaxRunnerDPInputsLightweight:
         self.runner._pre_async_results = None  # Default to None for most tests
 
         # Bind the actual methods to our mock
-        self.runner._prepare_inputs_dp = TPUModelRunner._prepare_inputs_dp.__get__(
+        self.runner._prepare_inputs = TPUModelRunner._prepare_inputs.__get__(
             self.runner)
-        self.runner._prepare_dp_input_metadata = TPUModelRunner._prepare_dp_input_metadata.__get__(
+        self.runner._prepare_input_metadata = TPUModelRunner._prepare_input_metadata.__get__(
             self.runner)
-        self.runner._prepare_async_token_substitution_indices_dp = TPUModelRunner._prepare_async_token_substitution_indices_dp.__get__(
+        self.runner._prepare_async_token_substitution_indices = TPUModelRunner._prepare_async_token_substitution_indices.__get__(
             self.runner)
 
     def _create_mock_scheduler_output(self,
@@ -177,7 +177,7 @@ class TestTPUJaxRunnerDPInputsLightweight:
         self.runner.mesh = mock_mesh
         self.runner.data_parallel_attn_sharding = MagicMock()
 
-        result = self.runner._prepare_inputs_dp(scheduler_output)
+        result = self.runner._prepare_inputs(scheduler_output)
 
         assert len(result) == 8
 
@@ -203,7 +203,7 @@ class TestTPUJaxRunnerDPInputsLightweight:
             num_scheduled_tokens, assigned_dp_ranks)
 
         # Execute the method
-        result = self.runner._prepare_inputs_dp(scheduler_output)
+        result = self.runner._prepare_inputs(scheduler_output)
 
         # Basic assertions
         assert len(result) == 8
@@ -219,7 +219,7 @@ class TestTPUJaxRunnerDPInputsLightweight:
         scheduler_output.total_num_scheduled_tokens = 0
 
         with pytest.raises(AssertionError):
-            self.runner._prepare_inputs_dp(scheduler_output)
+            self.runner._prepare_inputs(scheduler_output)
 
         # Test with zero requests - should fail assertion: num_reqs > 0
         self.runner.input_batch.num_reqs = 0
@@ -227,7 +227,7 @@ class TestTPUJaxRunnerDPInputsLightweight:
                                                               {"req1": 0})
 
         with pytest.raises(AssertionError):
-            self.runner._prepare_inputs_dp(scheduler_output)
+            self.runner._prepare_inputs(scheduler_output)
 
     @patch('jax.device_put', side_effect=lambda x, y: x)
     @patch('tpu_inference.runner.tpu_runner.NamedSharding')
@@ -265,7 +265,7 @@ class TestTPUJaxRunnerDPInputsLightweight:
         ]
 
         # Execute the method
-        result = self.runner._prepare_inputs_dp(scheduler_output)
+        result = self.runner._prepare_inputs(scheduler_output)
 
         # Basic assertions
         assert len(result) == 8
@@ -293,7 +293,7 @@ class TestTPUJaxRunnerDPInputsLightweight:
                    ) as mock_runner_utils:
             mock_runner_utils.get_padded_token_len.side_effect = lambda paddings_list, val: 16 if val <= 15 else 32  # Padded tokens per DP rank
 
-            result = self.runner._prepare_dp_input_metadata(scheduler_output)
+            result = self.runner._prepare_input_metadata(scheduler_output)
 
             (req_ids_dp, req_indices_dp, num_scheduled_tokens_per_dp_rank,
              scheduled_tokens_per_dp_rank, num_req_per_dp_rank,
@@ -367,7 +367,7 @@ class TestTPUJaxRunnerDPInputsLightweight:
                    ) as mock_runner_utils:
             mock_runner_utils.get_padded_token_len.side_effect = lambda paddings_list, val: 16 if val <= 15 else 32
 
-            result = self.runner._prepare_dp_input_metadata(scheduler_output)
+            result = self.runner._prepare_input_metadata(scheduler_output)
 
             (req_ids_dp, req_indices_dp, num_scheduled_tokens_per_dp_rank,
              scheduled_tokens_per_dp_rank, num_req_per_dp_rank,
@@ -444,7 +444,7 @@ class TestTPUJaxRunnerDPInputsLightweight:
                    ) as mock_runner_utils:
             mock_runner_utils.get_padded_token_len.side_effect = lambda paddings_list, val: 8 if val <= 6 else 16
 
-            result = self.runner._prepare_dp_input_metadata(scheduler_output)
+            result = self.runner._prepare_input_metadata(scheduler_output)
 
             (req_ids_dp, req_indices_dp, _, _, _, _, _, _, _,
              logits_indices_selector, _) = result
@@ -531,7 +531,7 @@ class TestTPUJaxRunnerDPInputsLightweight:
         # self.runner.mrope_positions_cpu = np.zeros((3, 64), dtype=np.int64)
 
         # Execute the method
-        result = self.runner._prepare_inputs_dp(scheduler_output)
+        result = self.runner._prepare_inputs(scheduler_output)
         input_ids, positions, attention_metadata, sampling_metadata, logits_indices, spec_decode_metadata, logits_indices_selector, padded_num_reqs = result
         # 1. Verify input_ids content
         expected_input_ids = np.zeros(16, dtype=np.int32)
@@ -646,7 +646,7 @@ class TestTPUJaxRunnerDPInputsLightweight:
         self.runner.lora_utils = MagicMock()
 
         # Execute the method
-        result = self.runner._prepare_inputs_dp(scheduler_output)
+        result = self.runner._prepare_inputs(scheduler_output)
         input_ids, positions, attention_metadata, sampling_metadata, logits_indices, spec_decode_metadata, logits_indices_selector, padded_num_reqs = result
 
         # 1. Verify input_ids
@@ -762,7 +762,7 @@ class TestTPUJaxRunnerDPInputsLightweight:
         self.runner.lora_utils = MagicMock()
 
         # Execute the method
-        result = self.runner._prepare_inputs_dp(scheduler_output)
+        result = self.runner._prepare_inputs(scheduler_output)
         input_ids, positions, attention_metadata, sampling_metadata, logits_indices, spec_decode_metadata, logits_indices_selector, padded_num_reqs = result
 
         # Verify request_distribution
@@ -822,7 +822,7 @@ class TestTPUJaxRunnerDPInputsLightweight:
         self.runner.lora_utils = MagicMock()
 
         # Execute the method
-        result = self.runner._prepare_inputs_dp(scheduler_output)
+        result = self.runner._prepare_inputs(scheduler_output)
         input_ids, positions, attention_metadata, sampling_metadata, logits_indices, spec_decode_metadata, logits_indices_selector, padded_num_reqs = result
 
         # Verify request_distribution
@@ -857,7 +857,7 @@ class TestTPUJaxRunnerDPInputsLightweight:
         }  # req2 is not a placeholder
 
         # Call the method
-        result = self.runner._prepare_async_token_substitution_indices_dp(
+        result = self.runner._prepare_async_token_substitution_indices(
             req_ids_dp, scheduled_tokens_per_dp_rank,
             padded_num_scheduled_tokens_per_dp_rank, dp_size)
 
@@ -894,7 +894,7 @@ class TestTPUJaxRunnerDPInputsLightweight:
         self.runner._pre_async_results = MagicMock()
         self.runner._pre_async_results.placeholder_req_id_to_index = {}
 
-        result = self.runner._prepare_async_token_substitution_indices_dp(
+        result = self.runner._prepare_async_token_substitution_indices(
             req_ids_dp, scheduled_tokens_per_dp_rank,
             padded_num_scheduled_tokens_per_dp_rank, dp_size)
 
@@ -973,43 +973,6 @@ class TestTPUJaxRunnerDPInputsLightweight:
         # Verify placeholder_num
         assert call_args[4] == 2  # Number of actual substitutions
 
-    def test_prepare_inputs_routing_to_dp(self):
-        """Test _prepare_inputs routes to _prepare_inputs_dp when dp_size > 1."""
-
-        # Bind the actual _prepare_inputs method
-        self.runner._prepare_inputs = TPUModelRunner._prepare_inputs.__get__(
-            self.runner)
-
-        self.runner.dp_size = 2
-        self.runner._prepare_inputs_dp = MagicMock(return_value=(None, None,
-                                                                 None, None,
-                                                                 None, None))
-
-        scheduler_output = MagicMock()
-        self.runner._prepare_inputs(scheduler_output)
-
-        # Verify _prepare_inputs_dp was called
-        self.runner._prepare_inputs_dp.assert_called_once_with(
-            scheduler_output)
-
-    def test_prepare_inputs_routing_to_non_dp(self):
-        """Test _prepare_inputs routes to _prepare_inputs_non_dp when dp_size == 1."""
-
-        # Bind the actual _prepare_inputs method
-        self.runner._prepare_inputs = TPUModelRunner._prepare_inputs.__get__(
-            self.runner)
-
-        self.runner.dp_size = 1
-        self.runner._prepare_inputs_non_dp = MagicMock(
-            return_value=(None, None, None, None, None, None, None))
-
-        scheduler_output = MagicMock()
-        self.runner._prepare_inputs(scheduler_output)
-
-        # Verify _prepare_inputs_non_dp was called
-        self.runner._prepare_inputs_non_dp.assert_called_once_with(
-            scheduler_output)
-
     @patch('jax.device_put', side_effect=lambda x, y: x)
     @patch('tpu_inference.runner.tpu_runner.NamedSharding')
     @patch('tpu_inference.runner.tpu_runner.runner_utils')
@@ -1074,10 +1037,10 @@ class TestTPUJaxRunnerDPInputsLightweight:
             0: [0],
             1: []
         }))
-        self.runner._prepare_async_token_substitution_indices_dp = mock_prepare_async
+        self.runner._prepare_async_token_substitution_indices = mock_prepare_async
 
         # Execute the method
-        _ = self.runner._prepare_inputs_dp(scheduler_output)
+        _ = self.runner._prepare_inputs(scheduler_output)
 
         # Verify async token substitution was called
         mock_prepare_async.assert_called_once()
@@ -1146,7 +1109,7 @@ class TestTPUJaxRunnerDPInputsLightweight:
         self.runner._apply_async_token_substitution = mock_apply_async
 
         # Execute the method
-        _ = self.runner._prepare_inputs_dp(scheduler_output)
+        _ = self.runner._prepare_inputs(scheduler_output)
 
         # Verify _apply_async_token_substitution was called
         mock_apply_async.assert_called_once()
@@ -1305,9 +1268,9 @@ class TestSamplingMetadataPassthrough:
         mock_kv_cache_config = MagicMock()
         mock_kv_cache_config.kv_cache_groups = [MagicMock()]
         runner.kv_cache_config = mock_kv_cache_config
-        runner._prepare_dp_input_metadata = TPUModelRunner._prepare_dp_input_metadata.__get__(
+        runner._prepare_input_metadata = TPUModelRunner._prepare_input_metadata.__get__(
             runner)
-        runner._prepare_async_token_substitution_indices_dp = TPUModelRunner._prepare_async_token_substitution_indices_dp.__get__(
+        runner._prepare_async_token_substitution_indices = TPUModelRunner._prepare_async_token_substitution_indices.__get__(
             runner)
 
         mock_runner_utils.get_padded_token_len.side_effect = lambda paddings, val: 8
@@ -1320,7 +1283,7 @@ class TestSamplingMetadataPassthrough:
         scheduler_output.total_num_scheduled_tokens = 5
         scheduler_output.scheduled_spec_decode_tokens = {}
 
-        TPUModelRunner._prepare_inputs_dp(runner, scheduler_output)
+        TPUModelRunner._prepare_inputs(runner, scheduler_output)
 
         # Verify from_input_batch was called exactly once with the ATTN_DATA sharding
         mock_sampling_metadata.from_input_batch.assert_called_once()

--- a/tpu_inference/runner/compilation_manager.py
+++ b/tpu_inference/runner/compilation_manager.py
@@ -211,7 +211,7 @@ class CompilationManager:
                                             sharding=dp_sharding)
         # Dummy mamba_state_indices for compile-cache pre-tracing. Only
         # populate for hybrid attn+mamba models — for pure-attention models we
-        # pass None at runtime (see `_prepare_inputs_*`), and the precompile
+        # pass None at runtime (see `_prepare_inputs`), and the precompile
         # primer must match that shape so the cached HLO is reused.
         if self.runner.kv_cache_config.has_mamba_layers:
             mamba_state_indices = device_array(self.runner.mesh,

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -1258,8 +1258,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         logprobs = compute_logprobs(logits)
         return gather_logprobs(logprobs, next_tokens, max_logprobs)
 
-    def _prepare_dp_input_metadata(self,
-                                   scheduler_output: "VllmSchedulerOutput"):
+    def _prepare_input_metadata(self, scheduler_output: "VllmSchedulerOutput"):
 
         dp_size = self.dp_size
         num_reqs = self.input_batch.num_reqs
@@ -1277,7 +1276,8 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         num_req_per_dp_rank = {dp_rank: 0 for dp_rank in range(dp_size)}
 
         for req_id in self.input_batch.req_ids[:num_reqs]:
-            dp_rank = scheduler_output.assigned_dp_rank[req_id]
+            dp_rank = (scheduler_output.assigned_dp_rank[req_id]
+                       if dp_size > 1 else 0)
             req_ids_dp[dp_rank].append(req_id)
             req_indices_dp[dp_rank].append(
                 self.input_batch.req_id_to_index[req_id])
@@ -1307,16 +1307,21 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             self.num_reqs_paddings_per_dp, max_num_reqs_across_dp)
         padded_num_reqs = padded_num_reqs_per_dp_rank * dp_size
 
-        all_req_indices = np.concatenate(
-            [req_indices_dp[dp_rank] for dp_rank in range(dp_size)])
-        all_positions = np.concatenate([
-            np.arange(len(req_indices_dp[dp_rank])) +
-            padded_num_reqs_per_dp_rank * dp_rank for dp_rank in range(dp_size)
-        ])
-
-        # Sort positions by request indices
-        sorted_indices = np.argsort(all_req_indices)
-        logits_indices_selector = all_positions[sorted_indices]
+        # logits_indices_selector reorders per-rank outputs back to the
+        # original batch ordering; with a single rank the ordering is already
+        # the input-batch ordering, so no selector is needed.
+        if dp_size > 1:
+            all_req_indices = np.concatenate(
+                [req_indices_dp[dp_rank] for dp_rank in range(dp_size)])
+            all_positions = np.concatenate([
+                np.arange(len(req_indices_dp[dp_rank])) +
+                padded_num_reqs_per_dp_rank * dp_rank
+                for dp_rank in range(dp_size)
+            ])
+            sorted_indices = np.argsort(all_req_indices)
+            logits_indices_selector = all_positions[sorted_indices]
+        else:
+            logits_indices_selector = None
 
         return (req_ids_dp, req_indices_dp, num_scheduled_tokens_per_dp_rank,
                 scheduled_tokens_per_dp_rank, num_req_per_dp_rank,
@@ -1324,10 +1329,10 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                 padded_total_num_scheduled_tokens, padded_num_reqs_per_dp_rank,
                 logits_indices_selector, max_num_reqs_per_dp_rank)
 
-    def _prepare_async_token_substitution_indices_dp(
+    def _prepare_async_token_substitution_indices(
             self, req_ids_dp, scheduled_tokens_per_dp_rank,
             padded_num_scheduled_tokens_per_dp_rank, dp_size):
-        """Prepare token substitution indices for async scheduling in DP mode."""
+        """Prepare token substitution indices for async scheduling."""
         token_in_tpu_cur_input_indices_dp = {}
         token_in_tpu_pre_next_tokens_indices_dp = {}
 
@@ -1350,29 +1355,6 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                 )
 
         return token_in_tpu_cur_input_indices_dp, token_in_tpu_pre_next_tokens_indices_dp
-
-    def _prepare_async_token_substitution_indices_non_dp(
-            self, num_reqs, num_scheduled_tokens_per_req):
-        """Prepare token substitution indices for async scheduling in non-DP mode."""
-        token_in_tpu_cur_input_indices_list = []
-        token_in_tpu_pre_next_tokens_indices_list = []
-        acc_cur_len = 0
-
-        for i, req_id in enumerate(self.input_batch.req_ids[:num_reqs]):
-            acc_cur_len += num_scheduled_tokens_per_req[i]
-            assert req_id is not None
-            if req_id not in self._pre_async_results.placeholder_req_id_to_index:
-                continue
-
-            token_in_tpu_cur_input_indices_list.append(acc_cur_len - 1)
-            token_in_tpu_pre_next_tokens_indices_list.append(
-                self._pre_async_results.placeholder_req_id_to_index[req_id])
-
-        if len(token_in_tpu_cur_input_indices_list) > 0:
-            return (np.array(token_in_tpu_cur_input_indices_list),
-                    np.array(token_in_tpu_pre_next_tokens_indices_list))
-        else:
-            return np.array([]), np.array([])
 
     def _apply_async_token_substitution(self, input_ids,
                                         token_in_tpu_cur_input_indices,
@@ -1411,12 +1393,6 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         return input_ids
 
     def _prepare_inputs(self, scheduler_output: "VllmSchedulerOutput"):
-        if self.dp_size > 1:
-            return self._prepare_inputs_dp(scheduler_output)
-        else:
-            return self._prepare_inputs_non_dp(scheduler_output)
-
-    def _prepare_inputs_dp(self, scheduler_output: "VllmSchedulerOutput"):
         total_num_scheduled_tokens = scheduler_output.total_num_scheduled_tokens
         assert total_num_scheduled_tokens > 0
         num_reqs = self.input_batch.num_reqs
@@ -1431,7 +1407,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
          padded_num_scheduled_tokens_per_dp_rank, padded_num_reqs,
          padded_total_num_scheduled_tokens, padded_num_reqs_per_dp_rank,
          logits_indices_selector, max_num_reqs_per_dp_rank
-         ) = self._prepare_dp_input_metadata(scheduler_output)
+         ) = self._prepare_input_metadata(scheduler_output)
         # Multi-modal support
         # Calculate M-RoPE positions.
         # Only relevant for models using M-RoPE (e.g, Qwen2-VL)
@@ -1446,7 +1422,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             # The actual substitution will be performed in tpu during later parts of this function.
             (token_in_tpu_cur_input_indices_dp,
              token_in_tpu_pre_next_tokens_indices_dp
-             ) = self._prepare_async_token_substitution_indices_dp(
+             ) = self._prepare_async_token_substitution_indices(
                  req_ids_dp, scheduled_tokens_per_dp_rank,
                  padded_num_scheduled_tokens_per_dp_rank, dp_size)
 
@@ -1521,9 +1497,6 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             token_indices = (
                 positions_np +
                 req_indices * self.input_batch.token_ids_cpu.shape[1])
-            # NOTE(woosuk): We use torch.index_select instead of np.take here
-            # because torch.index_select is much faster than np.take for large
-            # tensors.
             np.take(
                 self.input_batch.token_ids_cpu.ravel(),
                 token_indices,
@@ -1776,267 +1749,6 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             logits_indices_selector,
             padded_num_reqs,
         )
-
-    def _prepare_inputs_non_dp(self, scheduler_output: "VllmSchedulerOutput"):
-        total_num_scheduled_tokens = scheduler_output.total_num_scheduled_tokens
-        assert total_num_scheduled_tokens > 0
-        num_reqs = self.input_batch.num_reqs
-        assert num_reqs > 0
-
-        data_parallel_attn_sharding = NamedSharding(
-            self.mesh, PartitionSpec(ShardingAxisName.ATTN_DATA))
-
-        # Do the padding and copy the tensors to the TPU.
-        padded_total_num_scheduled_tokens = runner_utils.get_padded_token_len(
-            self.num_tokens_paddings, total_num_scheduled_tokens)
-        padded_num_reqs = runner_utils.get_padded_num_reqs_with_upper_limit(
-            num_reqs, self.max_num_reqs)
-
-        # Please see runner_utils.PhasedBasedProfiler for details
-        if self.phase_based_profiler:
-            self.batch_counter += 1
-            batch_composition_stats = runner_utils.get_batch_composition_stats(
-                self.batch_counter, self.input_batch,
-                total_num_scheduled_tokens, num_reqs,
-                padded_total_num_scheduled_tokens, scheduler_output)
-
-            self.phase_based_profiler.step(batch_composition_stats)
-
-        self.device_buffer.reset()
-
-        input_ids_view = self.device_buffer.get_view(
-            (padded_total_num_scheduled_tokens, ), key="input_ids")
-
-        use_spec_decode = len(
-            scheduler_output.scheduled_spec_decode_tokens) > 0
-
-        if use_spec_decode:
-            num_draft_tokens = np.zeros(num_reqs, dtype=np.int32)
-            for req_id, draft_token_ids in (
-                    scheduler_output.scheduled_spec_decode_tokens.items()):
-                req_idx = self.input_batch.req_id_to_index[req_id]
-                num_draft_tokens[req_idx] = len(draft_token_ids)
-
-            num_sampled_tokens = num_draft_tokens + 1
-            total_sampled_tokens = np.sum(num_sampled_tokens)
-            padded_logits_length = runner_utils.get_padded_token_len(
-                self.num_logits_paddings, total_sampled_tokens)
-            logits_indices_shape = (padded_logits_length, )
-        else:
-            logits_indices_shape = (padded_num_reqs, )
-
-        logits_indices_view = self.device_buffer.get_view(logits_indices_shape,
-                                                          key="logits_indices")
-        query_start_loc_view = self.device_buffer.get_view(
-            (self.max_num_reqs + 1, ), key="query_start_loc")
-        seq_lens_view = self.device_buffer.get_view((self.max_num_reqs, ),
-                                                    key="seq_lens")
-
-        # Get the number of scheduled tokens for each request.
-        num_scheduled_tokens_per_req = []
-        max_num_scheduled_tokens_all_reqs = 0
-        for req_id in self.input_batch.req_ids[:num_reqs]:
-            assert req_id is not None
-            num_tokens = scheduler_output.num_scheduled_tokens[req_id]
-            num_scheduled_tokens_per_req.append(num_tokens)
-            max_num_scheduled_tokens_all_reqs = max(
-                max_num_scheduled_tokens_all_reqs, num_tokens)
-        num_scheduled_tokens_per_req = np.array(num_scheduled_tokens_per_req,
-                                                dtype=np.int32)
-        assert max_num_scheduled_tokens_all_reqs > 0
-
-        # Get request indices.
-        # E.g., [2, 5, 3] -> [0, 0, 1, 1, 1, 1, 1, 2, 2, 2]
-        # For each scheduled token, what are the corresponding req index.
-        req_indices = np.repeat(self.arange_cpu[:num_reqs],
-                                num_scheduled_tokens_per_req)
-        token_in_tpu_cur_input_indices = np.array([])
-        token_in_tpu_pre_next_tokens_indices = np.array([])
-        if self.scheduler_config.async_scheduling and self._pre_async_results is not None:
-            # If async previous results exists, we will prepare for the token substitution here
-            # The actual substitution will be performed in tpu during later parts of this function.
-            (token_in_tpu_cur_input_indices,
-             token_in_tpu_pre_next_tokens_indices
-             ) = self._prepare_async_token_substitution_indices_non_dp(
-                 num_reqs, num_scheduled_tokens_per_req)
-
-        # Get batched arange.
-        # E.g., [2, 5, 3] -> [0, 1, 0, 1, 2, 3, 4, 0, 1, 2]
-        # For each scheduled token, what is its position in corresponding req.
-        arange = np.concatenate(
-            [self.arange_cpu[:n] for n in num_scheduled_tokens_per_req])
-
-        # Get positions.
-        positions_np = self.positions_cpu[:total_num_scheduled_tokens]
-        np.add(self.input_batch.num_computed_tokens_cpu[req_indices],
-               arange,
-               out=positions_np)
-
-        # Multi-modal support
-        # Calculate M-RoPE positions.
-        # Only relevant for models using M-RoPE (e.g, Qwen2-VL)
-        if self.uses_mrope:
-            self.mm_manager.calc_mrope_positions(scheduler_output)
-
-        # Get token indices.
-        # E.g., [0, 1, 0, 1, 2, 3, 4, 0, 1, 2]
-        # -> [0, 1, M, M + 1, M + 2, M + 3, M + 4, 2 * M, 2 * M + 1, 2 * M + 2]
-        # where M is the max_model_len.
-        token_indices = (positions_np +
-                         req_indices * self.input_batch.token_ids_cpu.shape[1])
-
-        # NOTE(woosuk): We use torch.index_select instead of np.take here
-        # because torch.index_select is much faster than np.take for large
-        # tensors.
-        np.take(self.input_batch.token_ids_cpu.ravel(),
-                token_indices,
-                out=input_ids_view[:total_num_scheduled_tokens])
-        input_ids_view[total_num_scheduled_tokens:] = 0
-
-        # Prepare the attention metadata.
-        query_start_loc_view[0] = 0
-        np.cumsum(num_scheduled_tokens_per_req,
-                  out=query_start_loc_view[1:num_reqs + 1])
-        query_start_loc_view[num_reqs + 1:] = 1
-
-        seq_lens_view[:num_reqs] = (
-            self.input_batch.num_computed_tokens_cpu[:num_reqs] +
-            num_scheduled_tokens_per_req)
-        seq_lens_view[num_reqs:] = 0
-
-        positions = self.positions_cpu[:padded_total_num_scheduled_tokens]
-        mrope_positions = self.mrope_positions_cpu[:, :
-                                                   padded_total_num_scheduled_tokens]
-        use_spec_decode = len(
-            scheduler_output.scheduled_spec_decode_tokens) > 0
-        spec_decode_metadata = None
-        if not use_spec_decode:
-            logits_indices_view[:padded_num_reqs] = (
-                query_start_loc_view[1:padded_num_reqs + 1] - 1)
-        else:
-            spec_decode_metadata = self.speculative_decoding_manager.get_spec_decode_metadata(
-                num_draft_tokens, query_start_loc_view[1:num_reqs + 1],
-                padded_num_reqs, input_ids_view)
-            logits_indices_view[:] = spec_decode_metadata.final_logits_indices.ravel(
-            )
-
-        sampling_metadata = TPUSupportedSamplingMetadata.from_input_batch(
-            self.mesh,
-            self.input_batch,
-            padded_num_reqs,
-            sharding=data_parallel_attn_sharding,
-        )
-
-        if self.uses_mrope:
-            # M-RoPE positions are of the shape (3, max_num_tokens).
-            # https://github.com/vllm-project/tpu-inference/blob/efc9608acd925bb3b64db6fda509514f799ab7be/tpu_inference/runner/tpu_runner.py#L555
-            # Shard the positions accordingly.
-            mrope_sharding = NamedSharding(
-                self.mesh, PartitionSpec(None, ShardingAxisName.ATTN_DATA))
-            positions = device_array(self.mesh,
-                                     mrope_positions,
-                                     sharding=mrope_sharding)
-        else:
-            positions = device_array(self.mesh,
-                                     positions,
-                                     sharding=data_parallel_attn_sharding)
-
-        request_distribution = np.array(self.input_batch.request_distribution)
-
-        def build_block_table_host(kv_cache_gid: int) -> None:
-            block_table_obj = self.input_batch.block_table[kv_cache_gid]
-            block_tables_view = self.device_buffer.get_view(
-                (self.max_num_reqs, block_table_obj.max_num_blocks_per_req),
-                key=f"block_tables_gid_{kv_cache_gid}")
-
-            cpu_tensor = block_table_obj.get_cpu_tensor()
-            np.copyto(block_tables_view[:num_reqs], cpu_tensor[:num_reqs])
-            block_tables_view[num_reqs:].fill(0)
-
-        if len(self.kv_cache_config.kv_cache_groups) <= 1:
-            # Pooling model will not using kv cache
-            no_kv_cache = len(self.kv_cache_config.kv_cache_groups) == 0
-            if not no_kv_cache:
-                build_block_table_host(0)
-        else:
-            for gid, kv_cache_group in enumerate(
-                    self.kv_cache_config.kv_cache_groups):
-                build_block_table_host(gid)
-
-        metadata_blob, metadata_layout = self.device_buffer.build()
-
-        # Mamba slot ids are only consumed by hybrid attn+mamba models; for
-        # pure-attention models, leaving the field None keeps AttentionMetadata
-        # byte-identical to the pre-compact-mamba layout (so the model_fn
-        # signature on those models is unchanged).
-        if self.kv_cache_config.has_mamba_layers:
-            # Per-request mamba state slot ids; copy to keep the InputBatch's
-            # CPU buffer free for the next step's bookkeeping.
-            mamba_state_indices_cpu = self.input_batch.mamba_state_indices_cpu.copy(
-            )
-            (request_distribution, mamba_state_indices,
-             dev_arrays_payload) = device_array(
-                 self.mesh, (request_distribution, mamba_state_indices_cpu,
-                             metadata_blob),
-                 sharding=data_parallel_attn_sharding)
-        else:
-            mamba_state_indices = None
-            (request_distribution, dev_arrays_payload) = device_array(
-                self.mesh, (request_distribution, metadata_blob),
-                sharding=data_parallel_attn_sharding)
-
-        metadata = common_utils.DeviceBuffer.unpack_arrays(
-            dev_arrays_payload, metadata_layout)
-        input_ids = metadata["input_ids"]
-        query_start_loc = metadata["query_start_loc"]
-        seq_lens = metadata["seq_lens"]
-        logits_indices = metadata["logits_indices"]
-
-        def build_attn(block_tables: jax.Array | None) -> AttentionMetadata:
-            attention_metadata_gid = AttentionMetadata(
-                input_positions=positions,
-                block_tables=block_tables,
-                seq_lens=seq_lens,
-                query_start_loc=query_start_loc,
-                request_distribution=request_distribution,
-                mamba_state_indices=mamba_state_indices,
-            )
-            # This is for making these cpu buffers hidden during tracing
-            attention_metadata_gid.query_start_loc_cpu = query_start_loc_view
-            attention_metadata_gid.seq_lens_cpu = seq_lens_view
-            return attention_metadata_gid
-
-        attention_metadata: AttentionMetadata | dict[str, AttentionMetadata]
-        if len(self.kv_cache_config.kv_cache_groups) <= 1:
-            # Pooling model will not using kv cache
-            no_kv_cache = len(self.kv_cache_config.kv_cache_groups) == 0
-            block_tables = metadata.get(
-                "block_tables_gid_0") if not no_kv_cache else None
-            attention_metadata = build_attn(block_tables)
-        else:
-            attention_metadata = {
-                name: build_attn(metadata[f"block_tables_gid_{gid}"])
-                for gid, kv_cache_group in enumerate(
-                    self.kv_cache_config.kv_cache_groups)
-                for name in kv_cache_group.layer_names
-            }
-
-        if self.scheduler_config.async_scheduling and len(
-                token_in_tpu_cur_input_indices) > 0:
-            assert self._pre_async_results is not None
-            input_ids = self._apply_async_token_substitution(
-                input_ids, token_in_tpu_cur_input_indices,
-                token_in_tpu_pre_next_tokens_indices)
-
-        if self.lora_config is not None:
-            self.lora_utils.set_active_loras(
-                num_scheduled_tokens_per_req, total_num_scheduled_tokens,
-                padded_total_num_scheduled_tokens)
-        logits_indices_selector = None
-
-        return (input_ids, positions, attention_metadata, sampling_metadata,
-                logits_indices, spec_decode_metadata, logits_indices_selector,
-                padded_num_reqs)
 
     def _get_input_ids_embeds(self, input_ids: jax.Array,
                               mm_embeds: list[jax.Array] | None,


### PR DESCRIPTION
# Description

This PR refactors the input preparation logic, consolidating previously separate data-parallel (DP) and non-DP code paths. 

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

verify nightly tests: https://buildkite.com/tpu-commons/tpu-inference-ci/builds/17227/canvas

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
