### PR TITLE
[MTP] Implement Multi-Token Prediction (MTP) Speculative Decoding

### DIFF
--- a/tests/e2e/test_speculative_decoding.py
+++ b/tests/e2e/test_speculative_decoding.py
@@ -63,7 +63,7 @@ def get_eagle3_test_prompts():
 def get_test_prompts(speculative_config: dict):
     if speculative_config['method'] == 'ngram':
         return get_ngram_test_prompts()
-    elif speculative_config['method'] == 'eagle3':
+    elif speculative_config['method'] in ('eagle3', 'qwen3_next_mtp', 'mtp'):
         return get_eagle3_test_prompts()
     else:
         raise NotImplementedError(
@@ -95,6 +95,7 @@ def _test_correctness_helper(
     speculative_config: dict,
     max_num_seqs: int = 4,
     async_scheduling: bool = False,
+    extra_kwargs: dict | None = None,
 ):
     '''
     Helper function to test ngram correctness.
@@ -104,13 +105,19 @@ def _test_correctness_helper(
     with monkeypatch.context():
         test_prompts = get_test_prompts(speculative_config)
 
-        ref_llm = LLM(
-            model=model_name,
-            max_model_len=1024,
-            max_num_seqs=max_num_seqs,
-            tensor_parallel_size=_get_tensor_parallel_size(),
-            model_loader_extra_config={"enable_weights_track": False},
-            async_scheduling=async_scheduling)
+        kwargs = {
+            "max_model_len": 1024,
+            "max_num_seqs": max_num_seqs,
+            "tensor_parallel_size": _get_tensor_parallel_size(),
+            "model_loader_extra_config": {
+                "enable_weights_track": False
+            },
+            "async_scheduling": async_scheduling,
+        }
+        if extra_kwargs:
+            kwargs.update(extra_kwargs)
+
+        ref_llm = LLM(model=model_name, **kwargs)
         ref_outputs = ref_llm.generate(test_prompts, sampling_config)
 
         del ref_llm
@@ -118,14 +125,9 @@ def _test_correctness_helper(
         # Waiting for TPUs to be released.
         time.sleep(10)
 
-        spec_llm = LLM(
-            model=model_name,
-            speculative_config=speculative_config,
-            max_model_len=1024,
-            max_num_seqs=max_num_seqs,
-            tensor_parallel_size=_get_tensor_parallel_size(),
-            model_loader_extra_config={"enable_weights_track": False},
-            async_scheduling=async_scheduling)
+        spec_llm = LLM(model=model_name,
+                       speculative_config=speculative_config,
+                       **kwargs)
         spec_outputs = spec_llm.generate(test_prompts, sampling_config)
 
         matches = 0
@@ -186,32 +188,41 @@ def test_ngram_correctness_random(
         })
 
 
-def _test_performance_helper(monkeypatch: pytest.MonkeyPatch,
-                             sampling_config: SamplingParams,
-                             speculative_config: dict,
-                             min_acceptance_rate: float,
-                             max_num_seqs: int = 1,
-                             async_scheduling: bool = False):
+def _test_performance_helper(
+    monkeypatch: pytest.MonkeyPatch,
+    sampling_config: SamplingParams,
+    speculative_config: dict,
+    min_acceptance_rate: float,
+    max_num_seqs: int = 1,
+    async_scheduling: bool = False,
+    model_name: str = "meta-llama/Llama-3.1-8B-Instruct",
+    extra_kwargs: dict | None = None,
+):
     '''
     Helper function to test speculative decoding performance.
     Compares timing between reference LLM and speculative LLM using Llama 3 8B.
     '''
-    model_name = "meta-llama/Llama-3.1-8B-Instruct"
-
     with monkeypatch.context():
         # Use a smaller set of prompts for performance testing
         test_prompts = get_test_prompts(speculative_config)
 
-        spec_llm = LLM(
-            model=model_name,
-            speculative_config=speculative_config,
-            max_model_len=1024,
-            max_num_seqs=max_num_seqs,
-            tensor_parallel_size=_get_tensor_parallel_size(),
-            enable_prefix_caching=False,
-            model_loader_extra_config={"enable_weights_track": False},
-            disable_log_stats=False,
-            async_scheduling=async_scheduling)
+        kwargs = {
+            "max_model_len": 1024,
+            "max_num_seqs": max_num_seqs,
+            "tensor_parallel_size": _get_tensor_parallel_size(),
+            "enable_prefix_caching": False,
+            "model_loader_extra_config": {
+                "enable_weights_track": False
+            },
+            "disable_log_stats": False,
+            "async_scheduling": async_scheduling,
+        }
+        if extra_kwargs:
+            kwargs.update(extra_kwargs)
+
+        spec_llm = LLM(model=model_name,
+                       speculative_config=speculative_config,
+                       **kwargs)
 
         spec_llm.generate(test_prompts, sampling_config)
 
@@ -333,4 +344,85 @@ def test_eagle3_performance(
         },
         min_acceptance_rate=0.75,
         max_num_seqs=max_num_seqs,
-        async_scheduling=async_scheduling)
+        async_scheduling=async_scheduling,
+        model_name='meta-llama/Llama-3.1-8B-Instruct')
+
+
+@pytest.mark.skipif(os.environ.get("MODEL_IMPL_TYPE", "auto") != "vllm",
+                    reason="MTP is only supported with vllm model impl.")
+@pytest.mark.parametrize("async_scheduling", [False])
+def test_mtp_correctness(
+    monkeypatch: pytest.MonkeyPatch,
+    sampling_config: SamplingParams,
+    async_scheduling: bool,
+):
+    '''
+    Compare the outputs of an original LLM and a speculative LLM;
+    they should be the same when using MTP speculative decoding.
+    '''
+    model_name = "Qwen/Qwen3.5-4B"
+    model_impl = os.environ.get("MODEL_IMPL_TYPE", "auto")
+    monkeypatch.setenv("DRAFT_MODEL_IMPL_TYPE", model_impl)
+
+    extra_kwargs = {
+        "seed": 42,
+        "max_model_len": 2048,
+        "max_num_batched_tokens": 16384,
+        "enable_prefix_caching": False,
+        "kv_cache_dtype": "fp8",
+        "gpu_memory_utilization": 0.70,
+    }
+
+    _test_correctness_helper(
+        monkeypatch,
+        sampling_config,
+        model_name,
+        speculative_config={
+            "method": "mtp",
+            "num_speculative_tokens": 3,
+        },
+        max_num_seqs=10,
+        async_scheduling=async_scheduling,
+        extra_kwargs=extra_kwargs,
+    )
+
+
+@pytest.mark.skipif(os.environ.get("MODEL_IMPL_TYPE", "auto") != "vllm",
+                    reason="MTP is only supported with vllm model impl.")
+@pytest.mark.parametrize("max_num_seqs", [1, 20])
+@pytest.mark.parametrize("async_scheduling", [False])
+def test_mtp_performance(
+    monkeypatch: pytest.MonkeyPatch,
+    sampling_config: SamplingParams,
+    max_num_seqs: int,
+    async_scheduling: bool,
+):
+    '''
+    Test that MTP speculative decoding achieves the expected acceptance rate.
+    '''
+    model_name = "Qwen/Qwen3.5-4B"
+    model_impl = os.environ.get("MODEL_IMPL_TYPE", "auto")
+    monkeypatch.setenv("DRAFT_MODEL_IMPL_TYPE", model_impl)
+
+    extra_kwargs = {
+        "seed": 42,
+        "max_model_len": 2048,
+        "max_num_batched_tokens": 16384,
+        "enable_prefix_caching": False,
+        "kv_cache_dtype": "fp8",
+        "gpu_memory_utilization": 0.70,
+    }
+
+    _test_performance_helper(
+        monkeypatch,
+        sampling_config,
+        speculative_config={
+            "method": "mtp",
+            "num_speculative_tokens": 3,
+        },
+        min_acceptance_rate=0.99,
+        max_num_seqs=max_num_seqs,
+        async_scheduling=async_scheduling,
+        model_name=model_name,
+        extra_kwargs=extra_kwargs,
+    )

--- a/tests/models/common/test_model_loader.py
+++ b/tests/models/common/test_model_loader.py
@@ -411,7 +411,8 @@ class TestGetModel:
         result = model_loader.get_model(vllm_config, rng, mesh)
 
         mock_get_flax.assert_not_called()
-        mock_get_vllm.assert_called_once_with(vllm_config, rng, mesh, False)
+        mock_get_vllm.assert_called_once_with(vllm_config, rng, mesh, False,
+                                              None)
         assert result == "vllm_model_sentinel"
 
     @patch.dict(os.environ, {"MODEL_IMPL_TYPE": "flax_nnx"}, clear=True)
@@ -441,7 +442,8 @@ class TestGetModel:
         result = model_loader.get_model(vllm_config, rng, mesh)
 
         mock_get_flax.assert_not_called()
-        mock_get_vllm.assert_called_once_with(vllm_config, rng, mesh, False)
+        mock_get_vllm.assert_called_once_with(vllm_config, rng, mesh, False,
+                                              None)
         assert result == "vllm_model_sentinel"
 
     @patch.dict(os.environ, {"MODEL_IMPL_TYPE": "flax_nnx"}, clear=True)
@@ -462,7 +464,8 @@ class TestGetModel:
 
         # Check that both were called
         mock_get_flax.assert_called_once_with(vllm_config, rng, mesh, False)
-        mock_get_vllm.assert_called_once_with(vllm_config, rng, mesh, False)
+        mock_get_vllm.assert_called_once_with(vllm_config, rng, mesh, False,
+                                              None)
         assert result == "vllm_fallback_sentinel"
 
     @patch.dict(os.environ, {"MODEL_IMPL_TYPE": "flax_nnx"}, clear=True)
@@ -534,5 +537,6 @@ class TestGetModel:
         result = model_loader.get_model(vllm_config, rng, mesh)
 
         mock_get_flax.assert_not_called()
-        mock_get_vllm.assert_called_once_with(vllm_config, rng, mesh, False)
+        mock_get_vllm.assert_called_once_with(vllm_config, rng, mesh, False,
+                                              None)
         assert result == "vllm_model_sentinel"

--- a/tests/runner/test_kv_cache_manager.py
+++ b/tests/runner/test_kv_cache_manager.py
@@ -496,6 +496,49 @@ class TestKVCacheManager:
             assert self.runner.layer_name_to_kvcache_index[
                 f'layer.{i + 10}'] == i
 
+    def test_initialize_kv_cache_capped_by_override(self):
+        # create a kv cache config with 1 layer full attention.
+        block_size = self.runner.vllm_config.cache_config.block_size
+        num_kv_heads = 8
+        head_size = 128
+        num_blocks = 100
+        kv_packing = 2  #bf16
+        full_attn_spec = FullAttentionSpec(
+            block_size=block_size,
+            num_kv_heads=num_kv_heads,
+            head_size=head_size,
+            dtype=torch.bfloat16,
+        )
+        kv_cache_groups = [
+            KVCacheGroupSpec(layer_names=['layer.0'],
+                             kv_cache_spec=full_attn_spec),
+        ]
+        page_size_bytes = full_attn_spec.page_size_bytes
+        kv_cache_tensors = [
+            KVCacheTensor(
+                size=num_blocks * page_size_bytes,
+                shared_by=['layer.0'],
+            )
+        ]
+        kv_cache_config = KVCacheConfig(
+            num_blocks=num_blocks,
+            kv_cache_tensors=kv_cache_tensors,
+            kv_cache_groups=kv_cache_groups,
+        )
+
+        # Set num_gpu_blocks_override to a smaller value!
+        override_blocks = 50
+        self.runner.cache_config.num_gpu_blocks_override = override_blocks
+
+        self.runner.initialize_kv_cache(kv_cache_config)
+
+        # Assert that the allocated KV cache has size equal to override_blocks, not num_blocks!
+        assert len(self.runner.kv_caches) == 1
+        assert self.runner.kv_caches[0].shape == (override_blocks, block_size,
+                                                  num_kv_heads * 2 //
+                                                  kv_packing, kv_packing,
+                                                  head_size)
+
     def test_get_kv_cache_spec_with_eagle3(self):
         # tests we create kv cache spec for eagle3 draft model
         self.runner.vllm_config.compilation_config.static_forward_context = {}

--- a/tests/runner/test_speculative_decoding_manager.py
+++ b/tests/runner/test_speculative_decoding_manager.py
@@ -355,6 +355,7 @@ class TestSpeculativeDecodingManager:
         discard_sampled_tokens_req_indices = []
         scheduler_output = MagicMock()
         input_ids = MagicMock()
+        hidden_states = MagicMock()
 
         # 2. ===== Act =====
         with patch(
@@ -370,6 +371,7 @@ class TestSpeculativeDecodingManager:
                 scheduler_output,
                 input_ids,
                 async_scheduling=False,
+                hidden_states=hidden_states,
             )
 
         # 3. ===== Assert =====

--- a/tests/spec_decode/test_eagle3.py
+++ b/tests/spec_decode/test_eagle3.py
@@ -173,7 +173,7 @@ def test_prepare_inputs():
                                           hidden_size * 3)
 
 
-@pytest.mark.parametrize("method", ["eagle3"])
+@pytest.mark.parametrize("method", ["eagle3", "mtp"])
 @pytest.mark.parametrize("num_speculative_tokens", [1, 3, 8])
 def test_propose(method, num_speculative_tokens):
     proposer = _create_proposer(method, num_speculative_tokens)
@@ -188,7 +188,8 @@ def test_propose(method, num_speculative_tokens):
     base_token_ids = [42, 60]
 
     def mock_model_fn(state, kv_caches, input_ids, target_hidden_states,
-                      attn_metadata, layer_name_to_kvcache_index):
+                      attn_metadata, layer_name_to_kvcache_index,
+                      spec_step_idx):
         """
         Mock model_fn.
         Returns: (kv_caches, hidden_states_for_logits, residual_tuple)
@@ -313,3 +314,54 @@ def test_propose(method, num_speculative_tokens):
             expected_tokens[i, j] = base_token_ids[i] + j
 
     assert jnp.array_equal(draft_token_ids, jnp.array(expected_tokens))
+
+
+def test_update_inputs_for_loop_speculation_mrope():
+    proposer = _create_proposer("mtp", 2)
+
+    # Setup 2D positions (M-RoPE)
+    max_model_len = 10
+    proposer.runner.max_model_len = max_model_len
+
+    # positions shape: (3, num_reqs) -> (3, 2)
+    positions = jnp.array([[1, 5], [2, 6], [3, 7]])
+
+    seq_lens = jnp.array([5, 8])
+
+    # block_tables shape: (num_reqs * max_num_blocks_per_req,)
+    # Let's say max_num_blocks_per_req = 2. So shape (4,)
+    block_tables = jnp.array([1, 2, 3, 4])
+
+    # Execute
+    positions_out, clamped_positions, new_seq_lens, query_start_loc, new_block_tables = proposer._update_inputs_for_loop_speculation(
+        positions, seq_lens, block_tables)
+
+    # Assertions
+    # 1. positions_out should be positions + 1
+    expected_positions_out = positions + 1
+    assert jnp.array_equal(positions_out, expected_positions_out)
+
+    # Let's test a case where it DOES exceed!
+    positions_exceed = jnp.array([[1, 9], [2, 9], [3, 9]])
+
+    positions_out, clamped_positions, new_seq_lens, query_start_loc, new_block_tables = proposer._update_inputs_for_loop_speculation(
+        positions_exceed, seq_lens, block_tables)
+
+    # exceeds_max_model_len_reduced should be [False, True]
+    # So for request 1 (index 1):
+    # new_seq_lens[1] should be set to 1!
+    # clamped_positions[:, 1] should be set to 0!
+    # new_block_tables for request 1 should be set to -1!
+
+    assert new_seq_lens[1] == 1
+    assert jnp.array_equal(clamped_positions[:, 1], jnp.array([0, 0, 0]))
+
+    # block_tables for request 1 are at indices 2, 3. They should be -1.
+    assert new_block_tables[2] == -1
+    assert new_block_tables[3] == -1
+
+    # For request 0 (index 0), it does not exceed.
+    assert jnp.array_equal(clamped_positions[:, 0], jnp.array([2, 3, 4]))
+    assert new_seq_lens[0] == 6
+    assert new_block_tables[0] == 1
+    assert new_block_tables[1] == 2

--- a/tpu_inference/models/common/model_loader.py
+++ b/tpu_inference/models/common/model_loader.py
@@ -445,8 +445,17 @@ def get_flax_model(
     # unchanged). For the main path, graphdef and the state treedef are both
     # captured in the run_model closure; the runner passes pre-flattened
     # `state_leaves` as the first positional arg.
-    model_fn = functools.partial(run_draft_model,
-                                 graphdef) if is_draft_model else run_model
+    jitted_model_fn = functools.partial(
+        run_draft_model, graphdef) if is_draft_model else run_model
+
+    model_supports_spec_step = supports_kw(model_class.__call__,
+                                           "spec_step_idx")
+
+    def wrapped_model_fn(*args, **kwargs):
+        if not model_supports_spec_step:
+            kwargs.pop("spec_step_idx", None)
+        return jitted_model_fn(*args, **kwargs)
+
     compute_logits_fn = functools.partial(run_compute_logits, graphdef)
     embed_multimodal_fn = functools.partial(run_embed_multimodal, graphdef)
     embed_input_ids_fn = functools.partial(run_embed_input_ids, graphdef)
@@ -500,7 +509,7 @@ def get_flax_model(
         pooler_fn = _not_support
 
     return ModelInterface(
-        model_fn=model_fn,
+        model_fn=wrapped_model_fn,
         compute_logits_fn=compute_logits_fn,
         pooler_fn=pooler_fn,
         combine_hidden_states_fn=combine_hidden_states_fn,
@@ -516,6 +525,7 @@ def get_vllm_model(
     rng: jax.Array,
     mesh: Mesh,
     is_draft_model: bool = False,
+    shared_params: Optional[dict[str, jax.Array]] = None,
 ) -> ModelInterface:
     model_dtype = to_torch_dtype(vllm_config.model_config.dtype)
     vllm_config.model_config.dtype = model_dtype
@@ -527,7 +537,7 @@ def get_vllm_model(
         mesh=mesh,
         is_draft_model=is_draft_model,
     )
-    params, lora_manager = model.load_weights()
+    params, lora_manager = model.load_weights(shared_params=shared_params)
 
     jit_model = model.jit_step_func()
     compute_logits_fn = model.jit_compute_logits_func()
@@ -567,6 +577,7 @@ def get_model(
     rng: jax.Array,
     mesh: Mesh,
     is_draft_model: bool = False,
+    shared_params: Optional[dict[str, jax.Array]] = None,
 ) -> ModelInterface:
     if is_draft_model:
         impl = envs.DRAFT_MODEL_IMPL_TYPE
@@ -587,7 +598,7 @@ def get_model(
                         "PP is not fully supported on Jax flax_nnx %s models yet, fallback to vllm models.",
                         arch)
                     return get_vllm_model(vllm_config, rng, mesh,
-                                          is_draft_model)
+                                          is_draft_model, shared_params)
                 try:
                     # Try to load the flax model first
                     return get_flax_model(vllm_config, rng, mesh,
@@ -600,9 +611,10 @@ def get_model(
 
                     # Fall back to the vLLM model and updating the dtype accordingly
                     return get_vllm_model(vllm_config, rng, mesh,
-                                          is_draft_model)
+                                          is_draft_model, shared_params)
         case "vllm":
-            return get_vllm_model(vllm_config, rng, mesh, is_draft_model)
+            return get_vllm_model(vllm_config, rng, mesh, is_draft_model,
+                                  shared_params)
         case _:
             raise NotImplementedError(f"Unsupported MODEL_IMPL_TYPE: {impl}")
 

--- a/tpu_inference/models/vllm/vllm_model_wrapper.py
+++ b/tpu_inference/models/vllm/vllm_model_wrapper.py
@@ -38,7 +38,6 @@ from vllm.model_executor.layers.pooler import Pooler
 from vllm.model_executor.model_loader import get_model as vllm_get_model
 from vllm.model_executor.models import supports_lora, supports_multimodal
 from vllm.model_executor.models.interfaces_base import is_pooling_model
-from vllm.sequence import IntermediateTensors
 from vllm.v1.outputs import PoolerOutput
 from vllm.v1.pool.metadata import PoolingMetadata
 from vllm.v1.worker.gpu.spec_decode.eagle.eagle3_utils import \
@@ -71,10 +70,14 @@ logger = init_logger(__name__)
 
 class _VllmRunner(torch.nn.Module):
 
-    def __init__(self, vllm_model: torch.nn.Module):
+    def __init__(self,
+                 vllm_model: torch.nn.Module,
+                 vllm_config: VllmConfig,
+                 is_draft_model: bool = False):
         super().__init__()
         self.vllm_model = vllm_model
-
+        self.vllm_config = vllm_config
+        self.is_draft_model = is_draft_model
         has_pooler = is_pooling_model(vllm_model)
         self.pooler = vllm_model.pooler if has_pooler else None
 
@@ -88,23 +91,10 @@ class _VllmRunner(torch.nn.Module):
             method = getattr(self.vllm_model, method_name)
             return method(*call_args, **call_kwargs)
         else:
-            return self.compute_hidden_state(
-                kwargs["input_ids"],
-                kwargs["positions"],
-                kwargs["intermediate_tensors"],
-                kwargs["inputs_embeds"],
-            )
+            return self.compute_hidden_state(kwargs)
 
-    def compute_hidden_state(
-        self,
-        input_ids: torch.Tensor,
-        positions: torch.Tensor,
-        intermediate_tensors: Optional[IntermediateTensors],
-        inputs_embeds: Optional[torch.Tensor],
-    ) -> torch.Tensor:
-        hidden_state = self.vllm_model(input_ids, positions,
-                                       intermediate_tensors, inputs_embeds)
-        return hidden_state
+    def compute_hidden_state(self, kwargs: dict) -> torch.Tensor:
+        return self.vllm_model(**kwargs)
 
     def compute_logits(self, hidden_state: torch.Tensor) -> torch.Tensor:
         return self.vllm_model.compute_logits(hidden_state)
@@ -146,7 +136,8 @@ class VllmModelWrapper:
                 if hasattr(module, "get_pp_group"):
                     setattr(module, "get_pp_group", jax_get_pp_group)
 
-    def load_weights(self):
+    def load_weights(self,
+                     shared_params: Optional[dict[str, jax.Array]] = None):
         loading_start = time.time()
         # Set up to load the model into CPU first.
         # Cache device slice config since device config cannot be deepcopied
@@ -236,11 +227,23 @@ class VllmModelWrapper:
         self.vllm_config.compilation_config.static_all_moe_layers.extend(
             vllm_config_for_load.compilation_config.static_all_moe_layers)
 
+        if shared_params:
+            assert self.is_draft_model, "Shared params should only be applied to draft model."
+            logger.info("Applying weight sharing with target model.")
+            for name, param in vllm_model.named_parameters():
+                full_name = f"vllm_model.{name}"
+                if full_name in shared_params:
+                    logger.info(f"Sharing parameter: {full_name}")
+                    # torch_view creates a torchax tensor sharing memory with the JAX array
+                    param.data = torchax.interop.torch_view(
+                        shared_params[full_name])
+
         if self.vllm_config.speculative_config and self.vllm_config.speculative_config.method == "eagle3" and not self.is_draft_model:
             set_eagle3_aux_hidden_state_layers(
                 vllm_model, self.vllm_config.speculative_config)
 
-        self.model = _VllmRunner(vllm_model)
+        self.model = _VllmRunner(vllm_model, self.vllm_config,
+                                 self.is_draft_model)
         params_and_buffers = shard_model_to_tpu(self.model, self.mesh)
 
         self._pooler: Pooler | None = self.model.pooler
@@ -370,7 +373,7 @@ class VllmModelWrapper:
                 None,  # list of aux hidden states
                 None,  # expert ids
             ),
-            static_argnames=("layer_name_to_kvcache_index", ),
+            static_argnames=("layer_name_to_kvcache_index", "spec_step_idx"),
         )
         def draft_step_fun(
             params_and_buffers,
@@ -379,6 +382,7 @@ class VllmModelWrapper:
             hidden_states: jax.Array,
             attn_metadata: AttentionMetadata,
             layer_name_to_kvcache_index: Sequence[Tuple[str, int]],
+            spec_step_idx: int = 0,
         ) -> Tuple[List[jax.Array], jax.Array, List[jax.Array],
                    Optional[jax.Array]]:
             layer_name_to_kvcache_index = dict(layer_name_to_kvcache_index)
@@ -388,23 +392,29 @@ class VllmModelWrapper:
                     layer_name_to_kvcache_index=layer_name_to_kvcache_index
             ), set_forward_context(attn_metadata=attn_metadata,
                                    vllm_config=self.vllm_config):
+                kwargs = {
+                    "input_ids": torch_view(input_ids),
+                    "positions": torch_view(attn_metadata.input_positions),
+                    "hidden_states": torch_view(hidden_states),
+                    "inputs_embeds": None,
+                }
+                if self.vllm_config.speculative_config.method == "mtp":
+                    kwargs["spec_step_idx"] = spec_step_idx
+
                 output_from_torch = torch.func.functional_call(
                     self.model,
                     torch_view(params_and_buffers),
-                    kwargs={
-                        "input_ids": torch_view(input_ids),
-                        "positions": torch_view(attn_metadata.input_positions),
-                        "intermediate_tensors": torch_view(hidden_states),
-                        "inputs_embeds": None,
-                    },
+                    kwargs=kwargs,
                     tie_weights=False,
                 )
                 vllm_model_wrapper_context = get_vllm_model_wrapper_context()
                 new_kv_caches = vllm_model_wrapper_context.kv_caches
 
-            hidden_states, hidden_prenorm = output_from_torch
-            hidden_states = jax_view(hidden_states)
-            hidden_prenorm = jax_view(hidden_prenorm)
+            if self.vllm_config.speculative_config.method == "mtp":
+                hidden_states = jax_view(output_from_torch)
+                hidden_prenorm = hidden_states
+            else:
+                hidden_states, hidden_prenorm = jax_view(output_from_torch)
             return new_kv_caches, hidden_states, [hidden_prenorm], None
 
         return draft_step_fun if self.is_draft_model else step_fun

--- a/tpu_inference/runner/compilation_manager.py
+++ b/tpu_inference/runner/compilation_manager.py
@@ -778,6 +778,8 @@ class CompilationManager:
         self._precompile_extract_last_sampled_tokens()
         if self.runner.speculative_config.method == "eagle3":
             self._precompile_eagle3_helpers()
+        if self.runner.speculative_config.method == "mtp":
+            self._precompile_mtp_helpers()
 
     def _precompile_extract_last_sampled_tokens(self) -> None:
         logger.info(
@@ -788,11 +790,14 @@ class CompilationManager:
             self.runner.speculative_config.num_speculative_tokens)
         max_num_seq = self.runner.max_num_reqs
 
+        data_parallel_attn_sharding = NamedSharding(
+            self.runner.mesh, PartitionSpec(ShardingAxisName.ATTN_DATA))
+
         # Case 1: spec_decode_metadata is None. sampled_token_ids has shape
         # (num_reqs,) from the regular sample() path on the previous step.
         for num_reqs in self.runner.num_reqs_paddings:
-            sampled_token_ids = self._create_dummy_tensor((num_reqs, ),
-                                                          jnp.int32)
+            sampled_token_ids = self._create_dummy_tensor(
+                (num_reqs, ), jnp.int32, sharding=data_parallel_attn_sharding)
             self._run_compilation(
                 f"worker{self.runner.rank} extract_last_sampled_tokens "
                 f"(no spec_decode_metadata)",
@@ -811,7 +816,9 @@ class CompilationManager:
         for num_logits in self.runner.num_logits_paddings:
             for num_reqs in self.runner.num_reqs_paddings:
                 sampled_token_ids = self._create_dummy_tensor(
-                    (num_logits + num_reqs, ), jnp.int32)
+                    (num_logits + num_reqs, ),
+                    jnp.int32,
+                    sharding=data_parallel_attn_sharding)
                 spec_decode_metadata = SpecDecodeMetadata(
                     draft_token_ids=self._create_dummy_tensor((num_logits, ),
                                                               jnp.int32),
@@ -956,9 +963,6 @@ class CompilationManager:
                     padded_num_reqs=num_reqs,
                 )
 
-                input_ids = self._create_dummy_tensor((num_tokens, ),
-                                                      jnp.int32)
-
                 def drafter_propose_fn_wrapper(
                     kv_caches,
                     input_ids,
@@ -995,7 +999,6 @@ class CompilationManager:
                     draft_hidden_states,
                     num_tokens=num_tokens,
                 )
-
                 aux_hidden_states = [
                     self._create_dummy_tensor(
                         (num_tokens, target_hidden_size), jnp.bfloat16,
@@ -1018,6 +1021,135 @@ class CompilationManager:
                     (self.runner.max_num_reqs, ), jnp.int32)
                 num_rejected_tokens = self._create_dummy_tensor(
                     (self.runner.max_num_reqs, ), jnp.int32)
+
+                self._run_compilation(
+                    "drafter_prepare_inputs",
+                    self.runner.drafter.prepare_inputs,
+                    attention_metadata,
+                    input_ids,
+                    aux_hidden_states,
+                    last_sampled_token_id,
+                    next_prompt_token_id,
+                    is_in_prefill,
+                    num_rejected_tokens,
+                    num_tokens=num_tokens,
+                )
+
+    def _precompile_mtp_helpers(self) -> None:
+        logger.info(
+            "Compiling mtp jitted helpers with different input shapes.")
+        target_hidden_size = self.runner.model_config.get_hidden_size()
+        draft_hidden_size = self.runner.speculative_config.draft_model_config.get_hidden_size(
+        )
+        dtype = self.runner.model_config.dtype
+
+        num_kv_cache_groups = len(self.runner.kv_cache_config.kv_cache_groups)
+        draft_kv_cache_group_id = num_kv_cache_groups - 1
+        block_tables = self.runner.input_batch.block_table[
+            draft_kv_cache_group_id].get_cpu_tensor().reshape(-1)
+        block_tables = device_array(self.runner.mesh,
+                                    block_tables,
+                                    sharding=PartitionSpec(None, ))
+
+        seq_lens = self._create_dummy_tensor((self.runner.max_num_reqs, ),
+                                             jnp.int32)
+        query_start_loc = self._create_dummy_tensor(
+            (self.runner.max_num_reqs + 1, ), jnp.int32)
+
+        request_distribution = np.array([0, 0, 0], dtype=np.int32)
+        request_distribution = device_array(self.runner.mesh,
+                                            request_distribution)
+        # Dummy mamba_state_indices for spec-decode compile-cache pre-tracing.
+        # Must match the ATTN_DATA sharding `_prepare_inputs_*` produces at
+        # runtime — otherwise the draft model_fn cache misses and the
+        # ForbidCompile guard inside `Eagle3Proposer.propose` raises. None for
+        # pure-attention models (the common eagle3 case) so the field stays
+        # absent end-to-end.
+        if self.runner.kv_cache_config.has_mamba_layers:
+            dp_sharding = NamedSharding(
+                self.runner.mesh, PartitionSpec(ShardingAxisName.ATTN_DATA, ))
+            eagle3_mamba_state_indices = device_array(
+                self.runner.mesh,
+                np.zeros(self.runner.max_num_reqs, dtype=np.int32),
+                sharding=dp_sharding)
+        else:
+            eagle3_mamba_state_indices = None
+
+        last_token_indices = self._create_dummy_tensor(
+            (self.runner.max_num_reqs, ), jnp.int32)
+        for num_tokens in self.runner.num_tokens_paddings:
+            for num_reqs in self.runner.attn_num_reqs_paddings:
+                if self.runner.uses_mrope:
+                    mrope_sharding = NamedSharding(
+                        self.runner.mesh,
+                        PartitionSpec(None, ShardingAxisName.ATTN_DATA))
+                    positions = self._create_dummy_tensor(
+                        (3, num_tokens), jnp.int32, mrope_sharding)
+                else:
+                    positions = self._create_dummy_tensor((num_tokens, ),
+                                                          jnp.int32)
+
+                attention_metadata = AttentionMetadata(
+                    input_positions=positions,
+                    block_tables=block_tables,
+                    seq_lens=seq_lens,
+                    query_start_loc=query_start_loc,
+                    request_distribution=request_distribution,
+                    mamba_state_indices=eagle3_mamba_state_indices,
+                    padded_num_reqs=num_reqs,
+                )
+
+                def drafter_propose_fn_wrapper(
+                    kv_caches,
+                    input_ids,
+                    attn_metadata,
+                    last_token_indices,
+                    target_hidden_states,
+                ):
+                    kv_caches, draft_token_ids = self.runner.drafter.propose(
+                        kv_caches,
+                        input_ids,
+                        attn_metadata,
+                        last_token_indices,
+                        target_hidden_states,
+                    )
+                    self.runner.kv_caches = kv_caches
+                    return draft_token_ids
+
+                draft_hidden_states = self._create_dummy_tensor(
+                    (num_tokens, draft_hidden_size), dtype,
+                    NamedSharding(
+                        self.runner.mesh,
+                        PartitionSpec(None, ShardingAxisName.ATTN_DATA)))
+
+                input_ids = self._create_dummy_tensor((num_tokens, ),
+                                                      jnp.int32)
+                self._run_compilation(
+                    "drafter_propose",
+                    drafter_propose_fn_wrapper,
+                    self.runner.kv_caches,
+                    input_ids,
+                    attention_metadata,
+                    last_token_indices,
+                    draft_hidden_states,
+                    num_tokens=num_tokens,
+                )
+
+                aux_hidden_states = (self._create_dummy_tensor(
+                    (num_tokens, target_hidden_size), jnp.bfloat16,
+                    NamedSharding(
+                        self.runner.mesh,
+                        PartitionSpec(ShardingAxisName.ATTN_DATA, None))), )
+                last_sampled_token_id = self._create_dummy_tensor(
+                    (self.runner.max_num_reqs, ), jnp.int32,
+                    NamedSharding(self.runner.mesh, PartitionSpec()))
+                next_prompt_token_id = self._create_dummy_tensor(
+                    (self.runner.max_num_reqs, ), jnp.int32)
+                is_in_prefill = self._create_dummy_tensor(
+                    (self.runner.max_num_reqs, ), jnp.int32)
+                num_rejected_tokens = self._create_dummy_tensor(
+                    (self.runner.max_num_reqs, ), jnp.int32,
+                    NamedSharding(self.runner.mesh, PartitionSpec()))
 
                 self._run_compilation(
                     "drafter_prepare_inputs",

--- a/tpu_inference/runner/kv_cache_manager.py
+++ b/tpu_inference/runner/kv_cache_manager.py
@@ -741,6 +741,11 @@ class KVCacheManager:
             # num_blocks must be a multiple of the sharding divisor
             num_blocks = (num_blocks // divisor) * divisor
 
+            if self.runner.cache_config.num_gpu_blocks_override is not None:
+                num_blocks = min(
+                    num_blocks,
+                    self.runner.cache_config.num_gpu_blocks_override)
+
             # When compact-mamba sizing succeeded (set by
             # `_maybe_set_compact_mamba_num_blocks_override`), mamba layers
             # allocate `_mamba_num_blocks` (= max_num_reqs + 1) slots while
@@ -814,6 +819,7 @@ class KVCacheManager:
                                 text_config.qk_rope_head_dim
                         else:
                             head_size = layer_spec.head_size
+
                         kv_cache = create_kv_caches(
                             num_blocks=num_blocks,
                             block_size=layer_spec.block_size,

--- a/tpu_inference/runner/speculative_decoding_manager.py
+++ b/tpu_inference/runner/speculative_decoding_manager.py
@@ -61,6 +61,7 @@ class SpeculativeDecodingManager:
         spec_decode_metadata: Optional[SpecDecodeMetadata],
         scheduler_output: Optional[VllmSchedulerOutput] = None,
         input_ids: Optional[jnp.ndarray] = None,
+        hidden_states: Optional[jnp.ndarray] = None,
     ) -> None:
         if async_scheduling:
             assert self.runner.speculative_config.use_eagle(
@@ -89,6 +90,7 @@ class SpeculativeDecodingManager:
                 scheduler_output,
                 input_ids,
                 async_scheduling,
+                hidden_states,
             )
         else:
             raise NotImplementedError(
@@ -96,15 +98,35 @@ class SpeculativeDecodingManager:
                 f"'{self.runner.speculative_config.method}' is not supported.")
 
     def propose_eagle3_draft_token_ids(
-            self, spec_decode_metadata: Optional[SpecDecodeMetadata],
-            last_sampled_token_id: jnp.ndarray,
-            num_rejected_tokens: jnp.ndarray,
-            discard_sampled_tokens_req_indices: list[int],
-            aux_hidden_states: Optional[tuple[jnp.ndarray, ...]],
-            attn_metadata: AttentionMetadata,
-            scheduler_output: VllmSchedulerOutput, input_ids: jnp.ndarray,
-            async_scheduling: bool) -> list[list[int]] | jnp.ndarray:
+        self,
+        spec_decode_metadata: Optional[SpecDecodeMetadata],
+        last_sampled_token_id: jnp.ndarray,
+        num_rejected_tokens: jnp.ndarray,
+        discard_sampled_tokens_req_indices: list[int],
+        aux_hidden_states: Optional[tuple[jnp.ndarray, ...]],
+        attn_metadata: AttentionMetadata | dict[str, AttentionMetadata],
+        scheduler_output: VllmSchedulerOutput,
+        input_ids: jnp.ndarray,
+        async_scheduling: bool,
+        hidden_states: jnp.ndarray,
+    ) -> list[list[int]] | jnp.ndarray:
         assert isinstance(self.runner.drafter, Eagle3Proposer)
+        if isinstance(attn_metadata, dict):
+            # When multiple KV cache groups are used (e.g., in hybrid models),
+            # attn_metadata becomes a dict mapping layer names to AttentionMetadata.
+            # Since all groups share the same seq_lens and input_positions, any would work for those.
+            # However, we specifically look for an attention layer key to get the correct
+            # block_tables structure, just in case the draft model (which is all attention) needs it.
+            attn_key = None
+            for key in attn_metadata.keys():
+                if ".self_attn." in key:
+                    attn_key = key
+                    break
+            if attn_key is not None:
+                attn_metadata = attn_metadata[attn_key]
+            else:
+                attn_metadata = next(iter(attn_metadata.values()))
+
         req_ids = self.runner.input_batch.req_ids
         max_num_seqs = attn_metadata.seq_lens.shape[0]
         next_prompt_token_id = np.zeros(max_num_seqs, dtype=np.int32)
@@ -123,10 +145,15 @@ class SpeculativeDecodingManager:
         next_prompt_token_id, is_in_prefill = device_array(
             self.runner.mesh, (next_prompt_token_id, is_in_prefill))
 
+        if self.runner.speculative_config.method == "mtp":
+            aux_hidden_states_for_drafter = (hidden_states, )
+        else:
+            aux_hidden_states_for_drafter = aux_hidden_states
+
         target_hidden_states, input_ids, last_token_indices, attn_metadata = self.runner.drafter.prepare_inputs(
             attn_metadata,
             input_ids,
-            aux_hidden_states,
+            aux_hidden_states_for_drafter,
             last_sampled_token_id,
             next_prompt_token_id,
             is_in_prefill,

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -184,6 +184,7 @@ class ExecuteModelState:
     logits_indices_selector: Optional[List[int]] = None
     padded_num_reqs: Optional[int] = None
     expert_indices: Optional[jax.Array] = None
+    full_hidden_states: Optional[jax.Array] = None
 
 
 @jax.jit(donate_argnums=(0, 1, 2))
@@ -476,7 +477,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         if self.speculative_config:
             if self.speculative_config.method == "ngram":
                 self.drafter = NgramProposer(self.vllm_config)
-            elif self.speculative_config.method == "eagle3":
+            elif self.speculative_config.use_eagle():
                 self.drafter = Eagle3Proposer(self.vllm_config, self)
             else:
                 raise NotImplementedError(
@@ -535,6 +536,9 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
 
         self.vocab_size = common_utils.align_to(model_config.get_vocab_size(),
                                                 tp_size)
+        num_speculative_tokens = 0
+        if self.vllm_config.speculative_config:
+            num_speculative_tokens = self.vllm_config.speculative_config.num_speculative_tokens
 
         self.input_batch = InputBatch(
             max_num_reqs=self.max_num_reqs,
@@ -544,6 +548,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             vocab_size=self.vocab_size,
             block_sizes=[self.block_size],
             is_spec_decode=bool(self.vllm_config.speculative_config),
+            num_speculative_tokens=num_speculative_tokens,
             dp_size=self.dp_size,
         )
 
@@ -781,18 +786,20 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         (scheduler_output, attn_metadata, sampling_metadata, input_ids,
          hidden_states, logits, aux_hidden_states, spec_decode_metadata,
          kv_connector_output, logits_indices_selector, padded_num_reqs,
-         expert_indices) = (self.execute_model_state.scheduler_output,
-                            self.execute_model_state.attn_metadata,
-                            self.execute_model_state.sampling_metadata,
-                            self.execute_model_state.input_ids,
-                            self.execute_model_state.hidden_states,
-                            self.execute_model_state.logits,
-                            self.execute_model_state.aux_hidden_states,
-                            self.execute_model_state.spec_decode_metadata,
-                            self.execute_model_state.kv_connector_output,
-                            self.execute_model_state.logits_indices_selector,
-                            self.execute_model_state.padded_num_reqs,
-                            self.execute_model_state.expert_indices)
+         expert_indices, full_hidden_states) = (
+             self.execute_model_state.scheduler_output,
+             self.execute_model_state.attn_metadata,
+             self.execute_model_state.sampling_metadata,
+             self.execute_model_state.input_ids,
+             self.execute_model_state.hidden_states,
+             self.execute_model_state.logits,
+             self.execute_model_state.aux_hidden_states,
+             self.execute_model_state.spec_decode_metadata,
+             self.execute_model_state.kv_connector_output,
+             self.execute_model_state.logits_indices_selector,
+             self.execute_model_state.padded_num_reqs,
+             self.execute_model_state.expert_indices,
+             self.execute_model_state.full_hidden_states)
         self.execute_model_state = None
 
         if grammar_output is not None:
@@ -810,7 +817,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             scheduler_output, attn_metadata, sampling_metadata, input_ids,
             hidden_states, logits, aux_hidden_states, spec_decode_metadata,
             kv_connector_output, logits_indices_selector, padded_num_reqs,
-            expert_indices)
+            expert_indices, full_hidden_states)
 
     def _modify_prev_results(self):
         # If copy to host has not been done, we just wait.
@@ -1024,6 +1031,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                 pooler_output=pooler_output,
             )
 
+        full_hidden_states = hidden_states
         hidden_states = self._select_from_array_fn(hidden_states,
                                                    logits_indices)
         logits = self.compute_logits_fn(
@@ -1044,7 +1052,8 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             kv_connector_output=kv_connector_output,
             logits_indices_selector=logits_indices_selector,
             padded_num_reqs=padded_num_reqs,
-            expert_indices=expert_indices)
+            expert_indices=expert_indices,
+            full_hidden_states=full_hidden_states)
         return None
 
     def _sample_from_logits(
@@ -1061,6 +1070,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         logits_indices_selector: Optional[List[int]] = None,
         padded_num_reqs: Optional[int] = None,
         expert_indices: Optional[jax.Array] = None,
+        full_hidden_states: Optional[jax.Array] = None,
     ) -> ModelRunnerOutput | AsyncTPUModelRunnerOutput:
         if padded_num_reqs is None:
             padded_num_reqs = runner_utils.get_padded_num_reqs_with_upper_limit(
@@ -1176,6 +1186,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                     spec_decode_metadata,
                     scheduler_output,
                     input_ids,
+                    full_hidden_states,
                 )
                 spec_decode_last_sampled_token_id = last_sampled_token_id
                 spec_decode_num_rejected_tokens = num_rejected_tokens

--- a/tpu_inference/spec_decode/jax/eagle3.py
+++ b/tpu_inference/spec_decode/jax/eagle3.py
@@ -68,11 +68,21 @@ class Eagle3Proposer:
 
     def load_model(self, target_model: Any) -> None:
         """Loads the draft model."""
+        shared_names = [
+            "vllm_model.language_model.model.embed_tokens.weight",
+            "vllm_model.model.embed_tokens.weight"
+        ]
+        shared_params = {
+            k: v
+            for k, v in self.runner.state.items() if k in shared_names
+        }
+
         model = get_model(
             self.vllm_config,
             self.rng_key,
             self.mesh,
             is_draft_model=True,
+            shared_params=shared_params,
         )
 
         self.model_fn = model.model_fn
@@ -96,6 +106,7 @@ class Eagle3Proposer:
             )
         # TODO(ranlihao): Handles the case where the draft model and target model have different implementations. This may require converting the parameters of the target model to match the draft model's format.
         # Reuse the target model's embedding if the draft model doesn't have its own or if they are identical, to save memory.
+        # TODO(ranlihao): Unify the weight loading process for jax and torchax path.
         if draft_model_impl == "flax_nnx":
             draft_embed_tokens = getattr(self.state.model, 'embed_tokens',
                                          None)
@@ -111,27 +122,6 @@ class Eagle3Proposer:
                     "Draft model's embed_tokens is identical to target model's embed. Sharing the embedding."
                 )
                 self.state.model.embed_tokens = target_model.model.embed
-            else:
-                logger.info("Draft model has its own embed_tokens.")
-        else:
-            EMBED_TOKENS_KEY = 'vllm_model.model.embed_tokens.weight'
-            if hasattr(self.model.model.vllm_model, 'has_own_embed_tokens'
-                       ) and self.model.model.vllm_model.has_own_embed_tokens:
-                draft_embed_tokens = self.state.get(EMBED_TOKENS_KEY, None)
-            else:
-                draft_embed_tokens = None
-            target_embed_tokens = target_model.get(EMBED_TOKENS_KEY, None)
-            assert target_embed_tokens is not None
-            if draft_embed_tokens is None or ~jnp.any(draft_embed_tokens):
-                logger.info(
-                    "Draft model does not have embedding. Setting draft model's embed_tokens to target model's embed"
-                )
-                self.state[EMBED_TOKENS_KEY] = target_embed_tokens
-            elif jnp.array_equal(draft_embed_tokens, target_embed_tokens):
-                logger.info(
-                    "Draft model's embed_tokens is identical to target model's embed. Sharing the embedding."
-                )
-                self.state[EMBED_TOKENS_KEY] = target_embed_tokens
             else:
                 logger.info("Draft model has its own embed_tokens.")
 
@@ -168,11 +158,18 @@ class Eagle3Proposer:
 
         positions += 1
         exceeds_max_model_len = positions >= self.runner.max_model_len
+        if exceeds_max_model_len.ndim == 2:
+            exceeds_max_model_len_reduced = jnp.any(exceeds_max_model_len,
+                                                    axis=0)
+        else:
+            exceeds_max_model_len_reduced = exceeds_max_model_len
+
         clamped_positions = jnp.where(exceeds_max_model_len, 0, positions)
 
         new_seq_lens = seq_lens + 1
         new_seq_lens = jnp.minimum(new_seq_lens, self.runner.max_model_len)
-        new_seq_lens = jnp.where(exceeds_max_model_len, 1, new_seq_lens)
+        new_seq_lens = jnp.where(exceeds_max_model_len_reduced, 1,
+                                 new_seq_lens)
 
         num_reqs = seq_lens.shape[0]
         query_start_loc = jnp.arange(num_reqs + 1)
@@ -185,7 +182,7 @@ class Eagle3Proposer:
         # out-of-range access during the model execution. The draft tokens
         # generated with this adjustment should be ignored.
         max_num_blocks_per_req = block_tables.shape[0] // num_reqs
-        expanded_exceeds_mask = jnp.repeat(exceeds_max_model_len,
+        expanded_exceeds_mask = jnp.repeat(exceeds_max_model_len_reduced,
                                            max_num_blocks_per_req)
         new_block_tables = jnp.where(expanded_exceeds_mask, -1, block_tables)
 
@@ -216,9 +213,12 @@ class Eagle3Proposer:
         next_token_ids: jax.Array,
         num_reqs: jax.Array,
     ) -> tuple[jax.Array, jax.Array, jax.Array]:
-        target_hidden_states = jnp.concatenate(aux_hidden_states, axis=-1)
-        target_hidden_states = self.combine_hidden_states_fn(
-            state, target_hidden_states)
+        if self.method == "mtp":
+            target_hidden_states = aux_hidden_states[0]
+        else:
+            target_hidden_states = jnp.concatenate(aux_hidden_states, axis=-1)
+            target_hidden_states = self.combine_hidden_states_fn(
+                state, target_hidden_states)
 
         input_ids, last_token_indices = self._prepare_input_ids(
             query_start_loc, target_token_ids, next_token_ids, num_reqs)
@@ -249,7 +249,8 @@ class Eagle3Proposer:
         and the selected `target_token_ids` and `target_hidden_states`.
         """
         assert aux_hidden_states is not None and len(aux_hidden_states) > 0, (
-            "EAGLE3 requires auxiliary hidden states from the target model.")
+            f"{self.method} requires auxiliary hidden states from the target model."
+        )
 
         # The last KV cache group is for the draft model.
         num_kv_cache_groups = len(self.runner.kv_cache_config.kv_cache_groups)
@@ -382,9 +383,11 @@ class Eagle3Proposer:
             padded_num_reqs=attn_metadata.padded_num_reqs,
         )
 
+        aux_states_processed = [h[token_indices] for h in aux_hidden_states]
+
         target_hidden_states, input_ids, last_token_indices = self._prepare_hidden_states_and_input_ids(
-            state, [h[token_indices] for h in aux_hidden_states],
-            query_start_loc, target_token_ids, next_token_ids, num_reqs)
+            state, aux_states_processed, query_start_loc, target_token_ids,
+            next_token_ids, num_reqs)
 
         return target_hidden_states, input_ids, last_token_indices, attn_metadata
 
@@ -412,10 +415,20 @@ class Eagle3Proposer:
             self, state: nnx.State, positions: jax.Array, residual: jax.Array,
             hidden_states: jax.Array,
             last_token_indices: jax.Array) -> tuple[jax.Array, jax.Array]:
-        positions = positions[last_token_indices]
-        residual = residual[last_token_indices]
         draft_token_ids = self._select_draft_token_ids(state, hidden_states,
                                                        last_token_indices)
+        if self.method == "mtp":
+            # We need a separate branch for MTP because:
+            # 1. MTP uses final target output hidden states directly as inputs for the next step,
+            #    whereas Eagle uses intermediate residuals.
+            # 2. M-RoPE positions are 2D (3, total_tokens), requiring specific dim-1 slicing
+            #    which _select_inputs_for_loop_speculation does not support.
+            positions = positions[:, last_token_indices]
+            hidden_states = hidden_states[last_token_indices]
+            return positions, hidden_states, draft_token_ids
+
+        positions = positions[last_token_indices]
+        residual = residual[last_token_indices]
 
         positions = lax.with_sharding_constraint(
             positions, NamedSharding(self.mesh, PartitionSpec(None, )))
@@ -443,8 +456,7 @@ class Eagle3Proposer:
             target_hidden_states=target_hidden_states,
             num_speculative_tokens=self.num_speculative_tokens,
             layer_name_to_kvcache_index=tuple(
-                self.runner.layer_name_to_kvcache_index.items()),
-        )
+                self.runner.layer_name_to_kvcache_index.items()))
 
     @jax.jit(
         donate_argnames=("kv_caches", ),
@@ -481,7 +493,6 @@ class Eagle3Proposer:
             draft token IDs.
         """
 
-        # input_ids and target_hidden_states for the first speculation have been prepared in prepare_inputs() to improve performance.
         kv_caches, hidden_states, residual, _ = self.model_fn(
             state,
             kv_caches,
@@ -489,6 +500,7 @@ class Eagle3Proposer:
             target_hidden_states,
             attn_metadata,
             layer_name_to_kvcache_index,
+            spec_step_idx=0,
         )
 
         if num_speculative_tokens == 1:
@@ -498,10 +510,9 @@ class Eagle3Proposer:
         positions, hidden_states, draft_token_ids = self._select_inputs_for_loop_speculation(
             state, attn_metadata.input_positions, residual[0], hidden_states,
             last_token_indices)
-
         draft_token_ids_list = [draft_token_ids]
 
-        for _ in range(num_speculative_tokens - 1):
+        for i in range(num_speculative_tokens - 1):
             input_ids_loop = draft_token_ids_list[-1]
 
             positions, clamped_positions, new_seq_lens, query_start_loc, new_block_tables = self._update_inputs_for_loop_speculation(
@@ -518,11 +529,13 @@ class Eagle3Proposer:
                 state,
                 kv_caches,
                 input_ids_loop,
-                hidden_states,  # This should be the hidden_states from previous step
+                hidden_states,
                 attn_metadata,
                 layer_name_to_kvcache_index,
+                spec_step_idx=i + 1,
             )
-            hidden_states = residual[0]
+            hidden_states = new_hidden_states if self.method == "mtp" else residual[
+                0]
             draft_token_ids = self._get_draft_token_ids(
                 state, new_hidden_states)
             draft_token_ids_list.append(draft_token_ids)


### PR DESCRIPTION
# Overview
This PR introduces end-to-end support for Multi-Token Prediction (MTP) speculative decoding. Unlike standard EAGLE draft models that rely on intermediate residual states, MTP directly utilizes final target output hidden states across multi-step speculation. This implementation also adds robust support for M-RoPE (2D positions), parameter weight sharing between draft and target models, and dedicated JAX precompilation helpers.

# Key Changes

### 1. Speculative Decoding Proposer & Manager
* `Eagle3Proposer` (`tpu_inference/spec_decode/jax/eagle3.py`): Extended to support `method == "mtp"`. Updated the loop speculation logic to feed final target hidden states directly into the next speculation step. Added M-RoPE support by properly reducing 2D `exceeds_max_model_len` masks across positional dimensions and passing `spec_step_idx` to identify MTP step indices.
* `SpeculativeDecodingManager` (`tpu_inference/runner/speculative_decoding_manager.py`): Updated input preparation to pass target hidden states for MTP and handle hybrid attention metadata mappings.

### 2. Model Execution & Weight Sharing
* `VllmModelWrapper` & `_VllmRunner` (`tpu_inference/models/vllm/vllm_model_wrapper.py`): Implemented support for weight sharing via `shared_params`, allowing draft MTP modules to share base model embeddings and weights in memory using `torchax.interop.torch_view`. Plumbed `spec_step_idx` and `hidden_states` into the draft forward pass.
* `get_model` & `get_vllm_model` (`tpu_inference/models/common/model_loader.py`): Plumbed `shared_params` during model weight loading.

### 3. Runner & Compilation
* `CompilationManager` (`tpu_inference/runner/compilation_manager.py`): Added `_precompile_mtp_helpers` to precompile JAX jitted `drafter_propose` and `drafter_prepare_inputs` functions with proper MTP input shapes and M-RoPE sharding specifications.
* `TPUModelRunner` & `ExecuteModelState` (`tpu_inference/runner/tpu_runner.py`): Tracked `full_hidden_states` across execution steps to ensure availability during MTP draft proposal.
* `KVCacheManager` (`tpu_inference/runner/kv_cache_manager.py`): Added support for `num_gpu_blocks_override` to cap allocated KV cache blocks when overridden by configuration.

## Testing & Verification

### End-to-End Tests
* `test_speculative_decoding.py` (`tests/e2e/test_speculative_decoding.py`): Added `test_mtp_correctness` and `test_mtp_performance` using `Qwen/Qwen3.5-4B` to verify exact output matching and acceptance rate performance (>99%).

### Unit Tests
* `test_eagle3.py` (`tests/spec_decode/test_eagle3.py`): Added unit tests for MTP proposal generation and `_update_inputs_for_loop_speculation` with 2D M-RoPE positions.
* `test_kv_cache_manager.py` (`tests/runner/test_kv_cache_manager.py`): Added `test_initialize_kv_cache_capped_by_override` to verify correct KV cache block allocation truncation.


# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
