### PR TITLE
[MLA] Add option to bypass Q activation quantization

### DIFF
--- a/tests/layers/vllm/backends/test_flash_attn_mla.py
+++ b/tests/layers/vllm/backends/test_flash_attn_mla.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import jax
 import jax.numpy as jnp
@@ -349,6 +349,63 @@ class TestPallasMLAttentionBackendImpl:
             outputs, new_kv_cache = impl.forward(q, kv_c_normed, k_pe,
                                                  kv_cache, metadata, mesh,
                                                  layer)
+
+        assert outputs is not None
+        assert new_kv_cache is not None
+
+    def test_forward_with_fp8_kv_cache_DISABLE_MLA_Q_ACTIVATION_QUANTIZATION(
+            self, mesh):
+        impl = PallasMLAttentionBackendImpl(
+            num_heads=NUM_HEADS,
+            head_size=KV_LORA_RANK + QK_ROPE_HEAD_DIM,
+            scale=0.088,
+            num_kv_heads=1,
+            alibi_slopes=None,
+            sliding_window=None,
+            kv_cache_dtype="fp8",
+            logits_soft_cap=None,
+            attn_type=AttentionType.DECODER,
+            kv_sharing_target_layer_name=None,
+            q_lora_rank=Q_LORA_RANK,
+            kv_lora_rank=KV_LORA_RANK,
+            qk_nope_head_dim=QK_NOPE_HEAD_DIM,
+            qk_rope_head_dim=QK_ROPE_HEAD_DIM,
+            qk_head_dim=QK_NOPE_HEAD_DIM + QK_ROPE_HEAD_DIM,
+            v_head_dim=V_HEAD_DIM,
+        )
+
+        layer = MagicMock()
+        layer.kv_cache_quantized_dtype = jnp.float8_e4m3fn
+        layer._q_scale_float = 1.0
+        layer._k_scale_float = 1.0
+        layer._v_scale_float = 1.0
+
+        q, kv_c_normed, k_pe, kv_cache, metadata = create_mla_inputs(
+            mesh, kv_dtype=jnp.float8_e4m3fn)
+
+        with torchax.default_env():
+            key = jax.random.key(0)
+            layer.W_UK_T = torchax.tensor.Tensor(jax.random.normal(
+                key, (NUM_HEADS, QK_NOPE_HEAD_DIM, KV_LORA_RANK),
+                dtype=jnp.bfloat16),
+                                                 env=torchax.default_env())
+            layer.W_UV = torchax.tensor.Tensor(
+                jax.random.normal(key, (NUM_HEADS, KV_LORA_RANK, V_HEAD_DIM),
+                                  dtype=jnp.bfloat16),
+                env=torchax.default_env())
+            layer.W_UK_T_scale = torchax.tensor.Tensor(
+                jnp.ones((NUM_HEADS, 1, KV_LORA_RANK), dtype=jnp.float32),
+                env=torchax.default_env())
+            layer.W_UV_scale = torchax.tensor.Tensor(jnp.ones(
+                (1, NUM_HEADS, V_HEAD_DIM), dtype=jnp.float32),
+                                                     env=torchax.default_env())
+
+            with patch(
+                    "tpu_inference.layers.vllm.backends.flash_attn_mla.envs.DISABLE_MLA_Q_ACTIVATION_QUANTIZATION",
+                    True):
+                outputs, new_kv_cache = impl.forward(q, kv_c_normed, k_pe,
+                                                     kv_cache, metadata, mesh,
+                                                     layer)
 
         assert outputs is not None
         assert new_kv_cache is not None

--- a/tpu_inference/envs.py
+++ b/tpu_inference/envs.py
@@ -301,6 +301,8 @@ environment_variables: dict[str, Callable[[], Any]] = {
     env_bool("DISABLE_WEIGHT_REQUANTIZATION", default=False),
     "VLLM_TPU_PATCH_MM_EMBEDDINGS":
     env_bool("VLLM_TPU_PATCH_MM_EMBEDDINGS", default=False),
+    "DISABLE_MLA_Q_ACTIVATION_QUANTIZATION":
+    env_bool("DISABLE_MLA_Q_ACTIVATION_QUANTIZATION", default=False),
 }
 
 

--- a/tpu_inference/layers/vllm/backends/flash_attn_mla.py
+++ b/tpu_inference/layers/vllm/backends/flash_attn_mla.py
@@ -24,6 +24,7 @@ from vllm.v1.attention.backend import (AttentionBackend, AttentionLayer,
 from vllm.v1.attention.backends.registry import (AttentionBackendEnum,
                                                  register_backend)
 
+import tpu_inference.envs as envs
 from tpu_inference.layers.common.attention_interface import mla_attention
 from tpu_inference.layers.common.attention_metadata import AttentionMetadata
 from tpu_inference.layers.common.quantization import (
@@ -161,10 +162,14 @@ class PallasMLAttentionBackendImpl(MLAAttentionImpl):
             k_scale = layer._k_scale_float
             v_scale = layer._v_scale_float
 
-            q_nope = static_per_tensor_quantize_tensor(
-                layer.kv_cache_quantized_dtype, q_nope, q_scale)
-            q_pe = static_per_tensor_quantize_tensor(
-                layer.kv_cache_quantized_dtype, q_pe, q_scale)
+            if not envs.DISABLE_MLA_Q_ACTIVATION_QUANTIZATION:
+                q_nope = static_per_tensor_quantize_tensor(
+                    layer.kv_cache_quantized_dtype, q_nope, q_scale)
+                q_pe = static_per_tensor_quantize_tensor(
+                    layer.kv_cache_quantized_dtype, q_pe, q_scale)
+            else:
+                # Needed because q_pe comes in as FP32, so we cast down to BF16
+                q_pe = q_pe.astype(input_dtype)
 
             kv_c_normed, _ = quantize_kv(layer.kv_cache_quantized_dtype,
                                          kv_c_normed,


### PR DESCRIPTION
# Description

In this PR, I add an env var option to bypass quantizing Q, which has been found (on models like Kimi-K2.6) to show a 3-4% regression on certain sets

CMDS:

```
NEW_MODEL_DESIGN=1  MODEL_IMPL_TYPE=vllm  nohup lm_eval   --model vllm     --model_args '{"pretrained": "moonshotai/Kimi-K2.6", "trust_remote_code": true, "gpu_memory_utilization": 0.978, "max_model_len": 35000, "kv_cache_dtype": "fp8", "tensor_parallel_size": 8, "max_num_seqs": 64, "max_num_batched_tokens": 1024, "block_size": 256, "limit_mm_per_prompt": {"image": 0, "video": 0, "vision_chunk": 0}, "additional_config": {"sharding": {"sharding_strategy": {"enable_dp_attention": true}}}}' --tasks gpqa_diamond_cot_zeroshot --apply_chat_template --log_samples --output_path gpqa_diamond_cot_zeroshot  --seed 42  --gen_kwargs "max_new_tokens=32768,until=['<|im_end|>']" --batch_size=32 &
```

Result:

| Quantized QKV? | Accuracy (Score) |
| :--- | :--- |
| KV | 0.8182 |
| QKV | 0.7727 |



# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
