### PR TITLE
Ignore intentional exit for benchmark error logging

### DIFF
--- a/.buildkite/benchmark/scripts/report_result.sh
+++ b/.buildkite/benchmark/scripts/report_result.sh
@@ -29,6 +29,12 @@ on_crash() {
         return
     fi
 
+
+    # Ignore explicit 'exit' commands as these are controlled intentional exits
+    if [[ "$command" == exit* ]]; then
+        return
+    fi
+
     echo ""
     echo "================================================================"
     echo "🚨 [FATAL ERROR] Bash Script Crashed Unexpectedly!"

--- a/.buildkite/benchmark/scripts/run_bm.sh
+++ b/.buildkite/benchmark/scripts/run_bm.sh
@@ -29,6 +29,11 @@ on_crash() {
         return
     fi
 
+    # Ignore explicit 'exit' commands as these are controlled intentional exits
+    if [[ "$command" == exit* ]]; then
+        return
+    fi
+
     echo ""
     echo "================================================================"
     echo "🚨 [FATAL ERROR] Bash Script Crashed Unexpectedly!"


### PR DESCRIPTION
Ignore the intentional exit and only keep the unexpected crashes to be reported by on_crash()
