### PR TITLE
[kernel] RPA v3: add update_kv_cache=False for KV-shared layers

### DIFF
--- a/tests/kernels/ragged_paged_attention_kernel_v3_test.py
+++ b/tests/kernels/ragged_paged_attention_kernel_v3_test.py
@@ -593,10 +593,10 @@ class RaggedPagedAttentionKernelTest(jtu.JaxTestCase):
                              dtype=np.float32)).astype(dtype)
 
         cache_data = jnp.array(
-            rng_cache.random((pages_per_seq * page_size,
-                              num_kv_heads_x2 // kv_packing, kv_packing,
-                              padded_hd),
-                             dtype=np.float32)).astype(dtype)
+            rng_cache.random(
+                (pages_per_seq * page_size, num_kv_heads_x2 // kv_packing,
+                 kv_packing, padded_hd),
+                dtype=np.float32)).astype(dtype)
         cache_pages = cache_data.reshape(pages_per_seq, page_size,
                                          num_kv_heads_x2 // kv_packing,
                                          kv_packing, padded_hd)

--- a/tests/kernels/ragged_paged_attention_kernel_v3_test.py
+++ b/tests/kernels/ragged_paged_attention_kernel_v3_test.py
@@ -529,6 +529,213 @@ class RaggedPagedAttentionKernelTest(jtu.JaxTestCase):
                 soft_cap=0.0,
             )
 
+    # ------------------------------------------------------------------
+    # KV-share path (`update_kv_cache=False`) regression tests.
+    #
+    # Used by gemma-4 KV-shared layers: the cache slot is redirected to
+    # a source layer that has already written its normed/roped K,V, and
+    # the shared layer must read attention K,V *only* from the cache.
+    # The kernel must (1) compute attention using cache K,V (2) ignore
+    # the input `keys` / `values` arrays entirely (3) leave the cache
+    # unchanged. The pre-fix kernel split each block into
+    # `(past from cache, current from input k,v)`, producing a corrupt
+    # mix of source-normed-roped-K with shared-raw-K. The fix is in
+    # kernel.py `_fetch_bkv`: when `update_kv_cache=False`, force all of
+    # `kv_left` to come from the cache.
+    #
+    # Note on path coverage: the non-shared (`update_kv_cache=True`)
+    # path's `_fetch_bkv` expression is unchanged from before the fix,
+    # so the existing prefill / decode / mixed tests above continue to
+    # cover it.
+    # ------------------------------------------------------------------
+
+    def _build_kv_share_inputs(
+        self,
+        *,
+        q_len: int,
+        kv_len: int,
+        kv_input_seed: int,
+        num_q_heads: int = 8,
+        num_kv_heads: int = 1,
+        head_dim: int = 128,
+        page_size: int = 16,
+        num_pages: int = 8,
+        max_num_seqs: int = 8,
+        cache_seed: int = 42,
+        q_seed: int = 123,
+        dtype=jnp.bfloat16,
+    ):
+        """Build a single-seq kernel input tuple with a pre-populated cache.
+
+        Cache contents are determined by `cache_seed`; q is determined by
+        `q_seed`. Input k,v are determined by `kv_input_seed` — varying
+        this between calls lets us check the output is invariant to input
+        k,v when `update_kv_cache=False`.
+        """
+        rng_q = np.random.default_rng(q_seed)
+        rng_cache = np.random.default_rng(cache_seed)
+        rng_input = np.random.default_rng(kv_input_seed)
+
+        pages_per_seq = cdiv(kv_len, page_size)
+        max_num_batched_tokens = max(align_to(q_len, 128), 128)
+        kv_packing = get_dtype_packing(dtype)
+        num_kv_heads_x2 = align_to(num_kv_heads * 2, kv_packing)
+        padded_hd = align_to(head_dim, 128)
+
+        q = jnp.array(
+            rng_q.random((max_num_batched_tokens, num_q_heads, head_dim),
+                         dtype=np.float32)).astype(dtype)
+        k = jnp.array(
+            rng_input.random((max_num_batched_tokens, num_kv_heads, head_dim),
+                             dtype=np.float32)).astype(dtype)
+        v = jnp.array(
+            rng_input.random((max_num_batched_tokens, num_kv_heads, head_dim),
+                             dtype=np.float32)).astype(dtype)
+
+        cache_data = jnp.array(
+            rng_cache.random((pages_per_seq * page_size,
+                              num_kv_heads_x2 // kv_packing, kv_packing,
+                              padded_hd),
+                             dtype=np.float32)).astype(dtype)
+        cache_pages = cache_data.reshape(pages_per_seq, page_size,
+                                         num_kv_heads_x2 // kv_packing,
+                                         kv_packing, padded_hd)
+        # Padding pages stay nan to surface any out-of-bounds reads.
+        kv_cache = jnp.pad(
+            cache_pages,
+            ((0, num_pages - pages_per_seq), (0, 0), (0, 0), (0, 0), (0, 0)),
+            constant_values=jnp.nan,
+        )
+
+        page_indices = jnp.zeros((max_num_seqs * pages_per_seq, ),
+                                 dtype=jnp.int32)
+        page_indices = page_indices.at[:pages_per_seq].set(
+            jnp.arange(pages_per_seq, dtype=jnp.int32))
+
+        kv_lens_arr = jnp.zeros((max_num_seqs, ),
+                                dtype=jnp.int32).at[0].set(kv_len)
+        cu_q_lens_arr = jnp.zeros((max_num_seqs + 1, ),
+                                  dtype=jnp.int32).at[1].set(q_len)
+        # distribution[3] = (decode_end, prefill_end, mixed_end). One seq:
+        # decode if q_len==1 else prefill.
+        if q_len == 1:
+            distribution = jnp.array([1, 1, 1], dtype=jnp.int32)
+        else:
+            distribution = jnp.array([0, 1, 1], dtype=jnp.int32)
+
+        return (q, k, v, kv_cache, kv_lens_arr, page_indices, cu_q_lens_arr,
+                distribution)
+
+    def _kv_share_kwargs(self, head_dim: int = 128):
+        return dict(
+            sm_scale=1.0 / float(head_dim)**0.5,
+            update_kv_cache=False,
+            m_block_sizes=(64, 256, 32, 128),
+        )
+
+    def test_kv_share_prefill_input_kv_is_ignored(self):
+        """q_len == kv_len. Two calls with different input k,v but the same
+        pre-populated cache and same q produce bit-identical outputs."""
+        if not jtu.is_device_tpu_at_least(version=4):
+            self.skipTest("Expect TPUv4+")
+        args1 = self._build_kv_share_inputs(q_len=16,
+                                            kv_len=16,
+                                            kv_input_seed=11)
+        args2 = self._build_kv_share_inputs(q_len=16,
+                                            kv_len=16,
+                                            kv_input_seed=99)
+        # Sanity (must happen BEFORE the kernel call — kernel donates
+        # queries/keys/values/kv_cache). Skip the kv_cache equality check:
+        # _build_kv_share_inputs zero-pads unused trailing pages with NaN,
+        # and assert_array_equal treats NaN!=NaN. Cache is identical by
+        # construction (same cache_seed).
+        np.testing.assert_array_equal(args1[0], args2[0])
+        self.assertFalse(np.array_equal(args1[1], args2[1]))
+        self.assertFalse(np.array_equal(args1[2], args2[2]))
+        cache_before = np.asarray(args1[3])
+
+        out1, cache_after_1 = ragged_paged_attention(*args1,
+                                                     **self._kv_share_kwargs())
+        out2, cache_after_2 = ragged_paged_attention(*args2,
+                                                     **self._kv_share_kwargs())
+
+        # Output invariant to input k,v.
+        self.assertArraysEqual(out1, out2)
+        # Sanity: outputs are real attention values, not all-zero / NaN
+        # (regression catch for a kernel that silently fails closed).
+        out1_np = np.asarray(out1[:16]).astype(np.float32)
+        assert np.all(np.isfinite(out1_np)), "outputs contain non-finite"
+        assert float(np.abs(out1_np).max()) > 0.0, (
+            "outputs are all zero — kernel likely failed closed")
+        # Cache unchanged in both runs (use the pre-donation snapshot).
+        mask = ~np.isnan(cache_before)
+        np.testing.assert_array_equal(
+            np.asarray(cache_after_1)[mask], cache_before[mask])
+        np.testing.assert_array_equal(
+            np.asarray(cache_after_2)[mask], cache_before[mask])
+
+    def test_kv_share_chunked_prefill_input_kv_is_ignored(self):
+        """q_len < kv_len (chunked / continued prefill). This is the regime
+        the pre-fix kernel got wrong: cache holds source's normed/roped
+        K,V for the past portion, and the kernel must NOT mix in the
+        layer's own raw input k,v for the 'current step' portion."""
+        if not jtu.is_device_tpu_at_least(version=4):
+            self.skipTest("Expect TPUv4+")
+        args1 = self._build_kv_share_inputs(q_len=8,
+                                            kv_len=24,
+                                            kv_input_seed=11)
+        args2 = self._build_kv_share_inputs(q_len=8,
+                                            kv_len=24,
+                                            kv_input_seed=99)
+        cache_before = np.asarray(args1[3])
+
+        out1, cache_after_1 = ragged_paged_attention(*args1,
+                                                     **self._kv_share_kwargs())
+        out2, cache_after_2 = ragged_paged_attention(*args2,
+                                                     **self._kv_share_kwargs())
+
+        # Output invariant to input k,v. The pre-fix kernel would mix
+        # source K,V (past 16 positions from cache) with shared raw K,V
+        # (current 8 positions from input k,v), so different input k,v
+        # would give different outputs.
+        self.assertArraysEqual(out1[:8], out2[:8])
+        # Sanity: outputs are real (not all-zero / NaN).
+        out1_np = np.asarray(out1[:8]).astype(np.float32)
+        assert np.all(np.isfinite(out1_np))
+        assert float(np.abs(out1_np).max()) > 0.0
+        # Cache unchanged.
+        mask = ~np.isnan(cache_before)
+        np.testing.assert_array_equal(
+            np.asarray(cache_after_1)[mask], cache_before[mask])
+
+    def test_kv_share_decode_input_kv_is_ignored(self):
+        """q_len == 1, kv_len > 1 (decode step). Same invariance."""
+        if not jtu.is_device_tpu_at_least(version=4):
+            self.skipTest("Expect TPUv4+")
+        args1 = self._build_kv_share_inputs(q_len=1,
+                                            kv_len=33,
+                                            kv_input_seed=11)
+        args2 = self._build_kv_share_inputs(q_len=1,
+                                            kv_len=33,
+                                            kv_input_seed=99)
+        cache_before = np.asarray(args1[3])
+
+        out1, cache_after_1 = ragged_paged_attention(*args1,
+                                                     **self._kv_share_kwargs())
+        out2, cache_after_2 = ragged_paged_attention(*args2,
+                                                     **self._kv_share_kwargs())
+
+        # Decode emits q_len = 1 token. Compare just that token (the rest of
+        # the max_num_batched_tokens buffer is junk padding).
+        self.assertArraysEqual(out1[:1], out2[:1])
+        # Sanity: output is real.
+        out1_np = np.asarray(out1[:1]).astype(np.float32)
+        assert np.all(np.isfinite(out1_np))
+        assert float(np.abs(out1_np).max()) > 0.0
+        mask = ~np.isnan(cache_before)
+        np.testing.assert_array_equal(
+            np.asarray(cache_after_1)[mask], cache_before[mask])
+
 
 if __name__ == "__main__":
     absltest.main(testLoader=jtu.JaxTestLoader())

--- a/tpu_inference/kernels/ragged_paged_attention/v3/kernel.py
+++ b/tpu_inference/kernels/ragged_paged_attention/v3/kernel.py
@@ -288,6 +288,14 @@ def _ragged_paged_attention_kernel(*args, **kwargs):
         )
 
 
+# update_kv_cache=False is the KV-share path: shared layers read the
+# entire kv_len from the (redirected) cache slot — their own input k,v
+# is unused. The cache slot already contains the source layer's K,V
+# (source's call ran first in the same step and wrote them). Mirrors
+# vllm-pytorch where unified_attention reads only from key_cache /
+# value_cache regardless of the input k,v.
+
+
 def _ragged_paged_attention_kernel_loop(
     seq_idx,
     # Prefetch
@@ -317,6 +325,7 @@ def _ragged_paged_attention_kernel_loop(
     acc_ref,  # [actual_num_kv_heads, bq_sz * num_q_heads_per_kv_head, head_dim],
     *,
     use_causal_mask: bool = True,
+    update_kv_cache: bool = True,  # KV-share: False = skip cache writes
     skip_kv_mask: bool = False,
     sm_scale: float,
     sliding_window: int | None = None,
@@ -559,7 +568,16 @@ def _ragged_paged_attention_kernel_loop(
         q_len = q_end - q_start
 
         kv_left = kv_len - kv_len_start
-        kv_left_frm_cache = jnp.maximum(kv_left - q_len, 0)
+        if update_kv_cache:
+            kv_left_frm_cache = jnp.maximum(kv_left - q_len, 0)
+        else:
+            # KV-share: source layer already wrote the full K/V for the
+            # current step into the (redirected) cache slot before this
+            # layer's call, so read everything from cache. The shared
+            # layer's input k,v is unused. Mirrors vllm-pytorch behavior
+            # where unified_attention reads from key_cache/value_cache
+            # only, regardless of the layer's own k,v projections.
+            kv_left_frm_cache = kv_left
         kv_left_frm_new = kv_left - kv_left_frm_cache
 
         bkv_sz_frm_cache = jnp.minimum(kv_left_frm_cache, bkv_sz)
@@ -969,10 +987,15 @@ def _ragged_paged_attention_kernel_loop(
 
                 # Start updating bkv to kv cache if applicable.
                 # Only needed in last bq loop.
-                @pl.when(jnp.logical_and(update_sz > 0, bq_idx == num_bq - 1))
-                def update_cur_bkv_to_cache():
-                    start_update_kv_cache(seq_idx, bkv_sem_idx, offset,
-                                          update_sz)
+                # KV-share: skip the cache write when update_kv_cache=False
+                # so shared layers don't overwrite the source layer's slot.
+                if update_kv_cache:
+
+                    @pl.when(
+                        jnp.logical_and(update_sz > 0, bq_idx == num_bq - 1))
+                    def update_cur_bkv_to_cache():
+                        start_update_kv_cache(seq_idx, bkv_sem_idx, offset,
+                                              update_sz)
 
                 debug_print(
                     "[RPA debug] -----------flash attention-----------")
@@ -1545,6 +1568,7 @@ def get_default_block_sizes(
 @jax.jit(
     static_argnames=(
         "use_causal_mask",
+        "update_kv_cache",
         "skip_kv_mask",
         "sm_scale",
         "sliding_window",
@@ -1579,6 +1603,7 @@ def ragged_paged_attention(
     distribution: jax.Array,  # i32[3]
     *,
     use_causal_mask: bool = True,
+    update_kv_cache: bool = True,
     skip_kv_mask: bool = False,
     sm_scale: float = 1.0,
     sliding_window: int | None = None,
@@ -1793,6 +1818,7 @@ def ragged_paged_attention(
             functools.partial(
                 _ragged_paged_attention_kernel,
                 use_causal_mask=use_causal_mask,
+                update_kv_cache=update_kv_cache,
                 skip_kv_mask=skip_kv_mask,
                 sm_scale=sm_scale,
                 sliding_window=sliding_window,

--- a/tpu_inference/kernels/ragged_paged_attention/v3/kernel.py
+++ b/tpu_inference/kernels/ragged_paged_attention/v3/kernel.py
@@ -288,14 +288,6 @@ def _ragged_paged_attention_kernel(*args, **kwargs):
         )
 
 
-# update_kv_cache=False is the KV-share path: shared layers read the
-# entire kv_len from the (redirected) cache slot — their own input k,v
-# is unused. The cache slot already contains the source layer's K,V
-# (source's call ran first in the same step and wrote them). Mirrors
-# vllm-pytorch where unified_attention reads only from key_cache /
-# value_cache regardless of the input k,v.
-
-
 def _ragged_paged_attention_kernel_loop(
     seq_idx,
     # Prefetch

--- a/tpu_inference/layers/common/attention_interface.py
+++ b/tpu_inference/layers/common/attention_interface.py
@@ -385,6 +385,14 @@ def sharded_ragged_paged_attention(
         in_specs += (P(ShardingAxisName.ATTN_HEAD), )
         args += (attention_sink, )
 
+    # KV-share (update_kv_cache=False) is only supported by the non-hd64
+    # kernel. Fail loud if a caller tries to use it on the hd64 path so
+    # the bug surfaces immediately rather than silently writing to cache.
+    if use_hd64 and not update_kv_cache:
+        raise NotImplementedError(
+            "update_kv_cache=False (KV-share) is not supported on the "
+            "head_dim==64 RPA kernel.")
+
     def _ragged_paged_attention(*args):
         kwargs = dict(
             sm_scale=sm_scale,
@@ -393,9 +401,10 @@ def sharded_ragged_paged_attention(
             k_scale=k_scale,
             v_scale=v_scale,
         )
-        # update_kv_cache is only supported by the non-hd64 path. hd64 (head
-        # dim 64) doesn't need KV-share for any current model; pass the kwarg
-        # only when present in the underlying kernel signature.
+        # update_kv_cache is only supported by the non-hd64 path; the
+        # guard above rejects update_kv_cache=False on hd64. The default
+        # True is a no-op and we don't forward it to the hd64 signature
+        # (which doesn't accept it).
         if not use_hd64:
             kwargs["update_kv_cache"] = update_kv_cache
         return func(*args, **kwargs)

--- a/tpu_inference/layers/common/attention_interface.py
+++ b/tpu_inference/layers/common/attention_interface.py
@@ -339,6 +339,7 @@ def sharded_ragged_paged_attention(
     q_scale: float | None = None,
     k_scale: float | None = None,
     v_scale: float | None = None,
+    update_kv_cache: bool = True,
 ):
     """Shards along KV heads."""
     # Handle GQA/MQA where num_kv_heads < tp_size
@@ -385,14 +386,19 @@ def sharded_ragged_paged_attention(
         args += (attention_sink, )
 
     def _ragged_paged_attention(*args):
-        return func(
-            *args,
+        kwargs = dict(
             sm_scale=sm_scale,
             sliding_window=attention_chunk_size,
             q_scale=q_scale,
             k_scale=k_scale,
             v_scale=v_scale,
         )
+        # update_kv_cache is only supported by the non-hd64 path. hd64 (head
+        # dim 64) doesn't need KV-share for any current model; pass the kwarg
+        # only when present in the underlying kernel signature.
+        if not use_hd64:
+            kwargs["update_kv_cache"] = update_kv_cache
+        return func(*args, **kwargs)
 
     return jax.shard_map(
         _ragged_paged_attention,
@@ -417,6 +423,7 @@ def attention(
     k_scale: float | None = None,
     v_scale: float | None = None,
     sinks: jax.Array | None = None,
+    update_kv_cache: bool = True,
 ) -> Tuple[jax.Array, jax.Array]:
     # T: seq_len
     # N: num_heads
@@ -455,6 +462,7 @@ def attention(
         q_scale=q_scale,
         k_scale=k_scale,
         v_scale=v_scale,
+        update_kv_cache=update_kv_cache,
     )
 
     return kv_cache, output


### PR DESCRIPTION
## Summary

Adds an `update_kv_cache` flag to the v3 ragged-paged-attention kernel so KV-shared layers can read from a previously-written cache slot without overwriting it.

When `update_kv_cache=False`:
- Skip the cache write at the end of the bq loop (`kernel.py:990-997`).
- Read the full `kv_len` from cache instead of splitting `q_len` out from the new K/V (`kernel.py:568-579`).

This mirrors vllm-pytorch's `unified_attention`, which reads only from `key_cache` / `value_cache` regardless of the layer's own k/v projections.

## Why

Models with KV-shared layers (HF text_config's `num_kv_shared_layers > 0`; e.g. Gemma-4 E2B / E4B) need this. For a shared layer, the source layer ran first in the same forward and already populated the cache slot. The shared layer's locally-computed K/V is unused; without this flag the kernel would overwrite the source layer's cache slot.

The kwarg is plumbed through `attention_interface.attention()` and `sharded_ragged_paged_attention()`. The hd64 path doesn't support the flag and isn't needed by any current model — the kwarg is only forwarded to the non-hd64 kernel.

## Tests

3 new unit tests in `tests/kernels/ragged_paged_attention_kernel_v3_test.py` (folded into the existing v3 test file):
- `test_kv_share_prefill_input_kv_is_ignored`
- `test_kv_share_decode_input_kv_is_ignored`
- `test_kv_share_chunked_prefill_input_kv_is_ignored`

Each runs the shared-layer call twice with two different input K/V seeds and asserts the output is identical (because input K/V is ignored) and that the cache is not mutated by the shared layer's call.

Run locally:
\`\`\`
pytest tests/kernels/ragged_paged_attention_kernel_v3_test.py -k kv_share -v
\`\`\`

## Test plan
- [x] Unit tests pass on the new KV-share paths
- [x] No regression on existing v3 RPA tests (full file still passes)
- [ ] Pre-commit CI green

## Stack
This is part 1 of a 3-PR split of #2572. Follow-ups:
- kv_cache_manager None-handling (independent, can land in any order)
- Gemma-4 E2B model (depends on this + the kv_cache_manager PR)