### PR TITLE
[runner] kv_cache_manager: handle None text_config attributes

### DIFF
--- a/tests/runner/test_kv_cache_manager.py
+++ b/tests/runner/test_kv_cache_manager.py
@@ -367,6 +367,53 @@ class TestKVCacheManager:
             assert kv_cache_spec[f'layer.{i}'] == expected_full_attn_spec
         assert len(self.runner.kv_cache_manager.shared_kv_cache_layers) == 0
 
+    def test_get_kv_cache_spec_without_compilation_cfg_none_text_config_attrs(
+            self):
+        # Regression: when the HF text_config declares one of the head-shape
+        # attributes (num_global_key_value_heads / global_head_dim /
+        # num_key_value_heads / head_dim) but sets it to None, the
+        # non-compilation-config branch must fall back to the model_config
+        # base values. Without the fix, None propagates into
+        # common_utils.get_padded_num_heads / get_padded_head_dim and raises.
+        #
+        # Real example: Gemma-4 E2B's HF config has
+        # num_global_key_value_heads=None.
+        mock_hf_text_config = MagicMock()
+        mock_hf_text_config.num_global_key_value_heads = None
+        mock_hf_text_config.global_head_dim = None
+        mock_hf_text_config.num_key_value_heads = None
+        mock_hf_text_config.head_dim = None
+        # Mix sliding and full so both branches of the if/else execute.
+        mock_hf_text_config.layer_types = [
+            "full_attention",
+            "sliding_attention",
+            "full_attention",
+            "sliding_attention",
+        ]
+        self.runner.model_config.hf_text_config = mock_hf_text_config
+
+        self.runner.vllm_config.compilation_config.static_forward_context = {}
+        kv_cache_spec = self.runner.get_kv_cache_spec()
+
+        model_config = self.runner.vllm_config.model_config
+        parallel_config = self.runner.vllm_config.parallel_config
+        num_layers = model_config.get_num_layers(parallel_config)
+        expected_num_kv_heads = common_utils.get_padded_num_heads(
+            model_config.get_total_num_kv_heads(),
+            self.runner.mesh.shape["model"])
+        expected_head_size = common_utils.get_padded_head_dim(
+            model_config.get_head_size())
+
+        assert len(kv_cache_spec) == num_layers
+        for i in range(num_layers):
+            spec = kv_cache_spec[f"layer.{i}"]
+            assert spec.num_kv_heads == expected_num_kv_heads, (
+                f"layer.{i}: num_kv_heads={spec.num_kv_heads} "
+                f"(expected base fallback {expected_num_kv_heads})")
+            assert spec.head_size == expected_head_size, (
+                f"layer.{i}: head_size={spec.head_size} "
+                f"(expected base fallback {expected_head_size})")
+
     def test_get_kv_cache_spec_without_compilation_cfg_mla(self):
         self.runner.kv_cache_manager.use_mla = True
         model_config = self.runner.vllm_config.model_config

--- a/tpu_inference/runner/kv_cache_manager.py
+++ b/tpu_inference/runner/kv_cache_manager.py
@@ -466,6 +466,9 @@ class KVCacheManager:
                     # Use `or` instead of getattr default so we also handle
                     # the case where the attribute is present but None
                     # (e.g. Gemma-4 E2B has num_global_key_value_heads=None).
+                    # `or` also coerces 0 → fallback, which is fine because
+                    # 0 num_kv_heads / head_dim is never a valid config and
+                    # would crash get_padded_num_heads downstream anyway.
                     if not is_sliding:
                         num_kv_heads = (getattr(
                             text_config, "num_global_key_value_heads", None)

--- a/tpu_inference/runner/kv_cache_manager.py
+++ b/tpu_inference/runner/kv_cache_manager.py
@@ -463,18 +463,21 @@ class KVCacheManager:
                         layer_type = text_config.layer_types[i]
 
                     is_sliding = layer_type == "sliding_attention"
+                    # Use `or` instead of getattr default so we also handle
+                    # the case where the attribute is present but None
+                    # (e.g. Gemma-4 E2B has num_global_key_value_heads=None).
                     if not is_sliding:
-                        num_kv_heads = getattr(text_config,
-                                               "num_global_key_value_heads",
-                                               base_num_kv_heads)
-                        head_size = getattr(text_config, "global_head_dim",
-                                            base_head_size)
+                        num_kv_heads = (getattr(
+                            text_config, "num_global_key_value_heads", None)
+                                        or base_num_kv_heads)
+                        head_size = (getattr(text_config, "global_head_dim",
+                                             None) or base_head_size)
                     else:
-                        num_kv_heads = getattr(text_config,
-                                               "num_key_value_heads",
-                                               base_num_kv_heads)
-                        head_size = getattr(text_config, "head_dim",
-                                            base_head_size)
+                        num_kv_heads = (getattr(text_config,
+                                                "num_key_value_heads", None)
+                                        or base_num_kv_heads)
+                        head_size = (getattr(text_config, "head_dim", None)
+                                     or base_head_size)
                     # Pad num_kv_heads to multiple of TP size.
                     num_kv_heads = common_utils.get_padded_num_heads(
                         num_kv_heads, model_cnt)


### PR DESCRIPTION
## Summary

When a model's HF text_config declares an attribute like `num_global_key_value_heads` but sets it to `None` (rather than omitting it), `getattr(text_config, "...", default)` returns `None` — not the default. The downstream code then tries to use `None` as an integer and crashes.

Switch to `getattr(..., None) or default` so a present-but-None attribute falls back to the base `num_kv_heads` / `head_size`. Affects:
- `num_global_key_value_heads` / `num_key_value_heads`
- `global_head_dim` / `head_dim`

## Why

Concrete repro: Gemma-4 E2B's HF config has `num_global_key_value_heads=None` (only `num_key_value_heads` is meaningful for that variant). Without this fix `_gen_kv_cache_spec` crashes when E2B loads.

This is purely defensive — no behavior change for models whose configs either omit the attributes or set them to real ints.

## Test plan
- [x] Local unit tests for `kv_cache_manager` still pass
- [ ] Pre-commit CI green

## Stack
Part 2 of a 3-PR split of #2572:
- #2601 — kernel update_kv_cache feature
- (this PR) — kv_cache_manager None-handling
- #2572 — Gemma-4 model (to be trimmed; depends on the other two)