### PR TITLE
Enhance error message of benchmark

### DIFF
--- a/.buildkite/benchmark/scripts/run_bm.sh
+++ b/.buildkite/benchmark/scripts/run_bm.sh
@@ -330,6 +330,7 @@ PREFIX_LEN=${PREFIX_LEN:-0}
 # so any unexpected error stack traces cannot be properly caught by the parent process.
 # When adding commands, ensure they do not throw errors, proactively validate expected errors, 
 # and print error logs for easier debugging.
+# For example, please refer to how throughput and p99_e2el are parsed in this file
 run_benchmark(){
   echo "running benchmark..." >&2
   echo "logging to $BM_LOG" >&2
@@ -372,6 +373,9 @@ run_benchmark(){
     return $client_exit_code
   fi
 
+  # If these two commands throw an error, they will not be properly caught.
+  # We use `|| true` to ignore the command's error, and then actively check throughput and p99_e2el.
+  # If the values do not meet expectations, it will print an error message and then return an error.
   throughput=$(grep "Request throughput (req/s):" "$BM_LOG" | sed 's/[^0-9.]//g' || true)
   p99_e2el=$(grep "P99 E2EL (ms):" "$BM_LOG" | awk '{print $NF}' || true)
   echo "throughput: $throughput, P99 E2EL: $p99_e2el" >&2

--- a/.buildkite/benchmark/scripts/run_bm.sh
+++ b/.buildkite/benchmark/scripts/run_bm.sh
@@ -370,7 +370,19 @@ run_benchmark(){
 
   throughput=$(grep "Request throughput (req/s):" "$BM_LOG" | sed 's/[^0-9.]//g')
   p99_e2el=$(grep "P99 E2EL (ms):" "$BM_LOG" | awk '{print $NF}')
-  echo "throughput: $throughput, P99 E2EL:$p99_e2el"
+
+  if [ -z "$throughput" ] || [ -z "$p99_e2el" ]; then
+    echo "[ERROR] Unable to extract metrics from the log. Please check if $BM_LOG is correctly formatted or if the test failed." >&2
+    return 1
+  fi
+
+  local re='^[0-9]+([.][0-9]+)?$'
+  if ! [[ $throughput =~ $re ]] || ! [[ $p99_e2el =~ $re ]]; then
+    echo "[ERROR] Extracted values are not valid numbers (Throughput: '$throughput', P99: '$p99_e2el')" >&2
+    return 1
+  fi
+
+  echo "throughput: $throughput, P99 E2EL: $p99_e2el" >&2
   echo "$throughput $p99_e2el"
 }
 

--- a/.buildkite/benchmark/scripts/run_bm.sh
+++ b/.buildkite/benchmark/scripts/run_bm.sh
@@ -327,9 +327,8 @@ NUM_PROMPTS=${NUM_PROMPTS:-1000}
 PREFIX_LEN=${PREFIX_LEN:-0}
 
 run_benchmark(){
-  echo "running benchmark..."
-  echo "logging to $BM_LOG"
-  echo
+  echo "running benchmark..." >&2
+  echo "logging to $BM_LOG" >&2
 
   local request_rate=${1:-""}
 
@@ -365,24 +364,25 @@ run_benchmark(){
   set -e
 
   if [ $client_exit_code -ne 0 ]; then
-      return $client_exit_code
+    echo "[ERROR] An error occurred while executing client_cmd." >&2
+    return $client_exit_code
   fi
 
-  throughput=$(grep "Request throughput (req/s):" "$BM_LOG" | sed 's/[^0-9.]//g')
-  p99_e2el=$(grep "P99 E2EL (ms):" "$BM_LOG" | awk '{print $NF}')
+  throughput=$(grep "Request throughput (req/s):" "$BM_LOG" | sed 's/[^0-9.]//g' || true)
+  p99_e2el=$(grep "P99 E2EL (ms):" "$BM_LOG" | awk '{print $NF}' || true)
+  echo "throughput: $throughput, P99 E2EL: $p99_e2el" >&2
 
   if [ -z "$throughput" ] || [ -z "$p99_e2el" ]; then
     echo "[ERROR] Unable to extract metrics from the log. Please check if $BM_LOG is correctly formatted or if the test failed." >&2
     return 1
   fi
 
-  local re='^[0-9]+([.][0-9]+)?$'
-  if ! [[ $throughput =~ $re ]] || ! [[ $p99_e2el =~ $re ]]; then
+  local num_reg='^[0-9]+([.][0-9]+)?$'
+  if ! [[ $throughput =~ $num_reg ]] || ! [[ $p99_e2el =~ $num_reg ]]; then
     echo "[ERROR] Extracted values are not valid numbers (Throughput: '$throughput', P99: '$p99_e2el')" >&2
     return 1
   fi
 
-  echo "throughput: $throughput, P99 E2EL: $p99_e2el" >&2
   echo "$throughput $p99_e2el"
 }
 

--- a/.buildkite/benchmark/scripts/run_bm.sh
+++ b/.buildkite/benchmark/scripts/run_bm.sh
@@ -326,6 +326,10 @@ EXPECTED_ETEL=${EXPECTED_ETEL:-3600000}
 NUM_PROMPTS=${NUM_PROMPTS:-1000}
 PREFIX_LEN=${PREFIX_LEN:-0}
 
+# When modifying run_benchmark(), please note that it is executed in a subshell, 
+# so any unexpected error stack traces cannot be properly caught by the parent process.
+# When adding commands, ensure they do not throw errors, proactively validate expected errors, 
+# and print error logs for easier debugging.
 run_benchmark(){
   echo "running benchmark..." >&2
   echo "logging to $BM_LOG" >&2
@@ -373,7 +377,7 @@ run_benchmark(){
   echo "throughput: $throughput, P99 E2EL: $p99_e2el" >&2
 
   if [ -z "$throughput" ] || [ -z "$p99_e2el" ]; then
-    echo "[ERROR] Unable to extract metrics from the log. Please check if $BM_LOG is correctly formatted or if the test failed." >&2
+    echo "[ERROR] Unable to extract metrics from the log. Please check the format of the statistical results in $BM_LOG, or if the test failed." >&2
     return 1
   fi
 


### PR DESCRIPTION
# Description

Enhance error messages in the benchmark subshell and validate whether the grepped statistics are valid to make debugging easier.
Validate the obtained statistics in `run_benchmark` and correctly report errors.

# Tests

Focus on the failed cases in this build, and proactively validate the values of throughput and p99e2el instead.
[Buildkite CI](https://buildkite.com/tpu-commons/tpu-inference-benchmark/builds/535#019e2535-e671-43e5-b0a4-d3ead2a9ad12)

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
