### PR TITLE
Feat: Enable Qwen3-VL-Embedding-8B Support via meta tensor materialization and Deepstack device patching

### DIFF
--- a/tpu_inference/layers/vllm/quantization/unquantized.py
+++ b/tpu_inference/layers/vllm/quantization/unquantized.py
@@ -21,6 +21,7 @@ from jax.sharding import Mesh, NamedSharding, PartitionSpec
 from torch.nn import Parameter
 from torchax.interop import jax_view, torch_view
 from torchax.ops.mappings import t2j
+from vllm.config import get_current_vllm_config
 from vllm.model_executor.layers import linear as vllm_linear
 from vllm.model_executor.layers.attention import Attention
 from vllm.model_executor.layers.fused_moe import (FusedMoE, FusedMoEConfig,
@@ -68,6 +69,33 @@ def _load_weight_for_layer(
     """Load a layer's weight parameter onto the TPU mesh.
     """
     tensor = getattr(layer, param_name)
+
+    if tensor.device == torch.device("meta"):
+        vllm_config = get_current_vllm_config()
+
+        # Hardening for Multimodal Embedding models (e.g., Qwen3-VL-Embedding-8B):
+        # vLLM V1 uses lazy loading which may leave some tensors on the 'meta' device.
+        # Since the TPU/JAX backend requires concrete data to perform t2j (Torch-to-JAX)
+        # sharding, we must force materialization to CPU memory for pooling tasks.
+        # Note: we cannot use `is_pooling_model` here because a model instance is not available
+        # in this layer-level loading function.
+        if vllm_config.model_config.runner_type == "pooling":
+            logger.warning(
+                f"Materializing meta tensor '{param_name}' for layer "
+                f"{layer.__class__.__name__} to CPU RAM for StepPooler compatibility."
+            )
+            # Allocate real memory on CPU
+            real_data = torch.empty_like(tensor, device='cpu')
+            new_param = torch.nn.Parameter(real_data, requires_grad=False)
+
+            # Bypass setters to satisfy PyTorch registration rules.
+            # pop from __dict__ avoids shadowing KeyError;
+            # inject into _parameters establishes Parameter identity.
+            layer.__dict__.pop(param_name, None)
+            layer._parameters[param_name] = new_param
+
+            # Synchronize local handle for the subsequent t2j call
+            tensor = new_param
 
     if not vllm_envs.VLLM_TPU_USING_PATHWAYS:
         return t2j(tensor, use_dlpack=False)
@@ -141,7 +169,15 @@ class VllmUnquantizedEmbeddingMethod(UnquantizedEmbeddingMethod):
         weight = _load_weight_for_layer(layer, "weight", weight_sharding)
         delattr(layer, 'weight')
         weight = general_device_put(weight, weight_sharding)
-        layer.weight = Parameter(torch_view(weight), requires_grad=False)
+        is_pooling = get_current_vllm_config(
+        ).model_config.runner_type == "pooling"
+
+        if is_pooling:
+            layer.__dict__.pop("weight", None)
+            layer._parameters["weight"] = Parameter(torch_view(weight),
+                                                    requires_grad=False)
+        else:
+            layer.weight = Parameter(torch_view(weight), requires_grad=False)
 
         if isinstance(layer, ParallelLMHead) and layer.bias is not None:
             bias_sharding = NamedSharding(self.mesh,
@@ -149,7 +185,13 @@ class VllmUnquantizedEmbeddingMethod(UnquantizedEmbeddingMethod):
             bias = _load_weight_for_layer(layer, "bias", bias_sharding)
             delattr(layer, 'bias')
             bias = general_device_put(bias, bias_sharding)
-            layer.bias = Parameter(torch_view(bias), requires_grad=False)
+
+            if is_pooling:
+                layer.__dict__.pop("bias", None)
+                layer._parameters["bias"] = Parameter(torch_view(bias),
+                                                      requires_grad=False)
+            else:
+                layer.bias = Parameter(torch_view(bias), requires_grad=False)
 
 
 class VllmUnquantizedLinearMethod(vllm_linear.UnquantizedLinearMethod,

--- a/tpu_inference/models/vllm/experimental/qwen3_vl_patcher.py
+++ b/tpu_inference/models/vllm/experimental/qwen3_vl_patcher.py
@@ -48,6 +48,9 @@ from vllm.sequence import IntermediateTensors
 
 from tpu_inference.distributed.jax_parallel_state import \
     get_pp_group as jax_get_pp_group
+from tpu_inference.logger import init_logger
+
+logger = init_logger(__name__)
 
 
 def _patched_set_deepstack(vllm_model, deepstack_input_embeds):
@@ -239,3 +242,17 @@ def is_qwen3_vl(vllm_model) -> bool:
 def maybe_apply_qwen3_vl_patches(vllm_model):
     if is_qwen3_vl(vllm_model):
         apply_qwen3_vl_patches(vllm_model)
+
+        if hasattr(vllm_model, "deepstack_input_embeds"):
+            # Force the deepstack placeholder buffers to the correct TPU device
+            # (via Torchax/JAX) to resolve device mismatch during the forward pass.
+            # This is required because the ModelForEmbedding adapter can cause
+            # the standard weight loader to skip these non-parameter buffers.
+            target_device = next(vllm_model.parameters()).device
+            logger.info(
+                f"Patching Qwen3-VL deepstack buffers to device: {target_device}"
+            )
+            vllm_model.deepstack_input_embeds = [
+                t.to(device=target_device)
+                for t in vllm_model.deepstack_input_embeds
+            ]


### PR DESCRIPTION
### Description

#### **Summary**
This PR introduces full end-to-end support for the **Qwen3-VL-Embedding-8B** model on TPU. It addresses the current **Qwen3-VL** gaps between vLLM V1's lazy loading mechanism (which uses `meta` device tensors) and *Qwen3-VL-Embedding* weight loading and pooling workflow. 
Additionally, it resolves device mismatch errors in the Qwen3-VL multimodal components when running in Torchax mode.

#### **Key Changes**

**1. Universal Weight Materialization in `unquantized.py`**
*   Implemented a robust **"Attribute Promotion"** strategy at the layer level to intercept `meta` tensors before JAX sharding and conversion begin.
*   This resolves the `NotImplementedError: Cannot copy out of meta tensor` issue encountered during initialization.

**2. Deepstack Device Patching in `qwen3_vl_patcher.py`**
*   Resolved a `TypeError` where model hidden states (on TPU) were being added to deepstack buffers.
*   Refactored the patcher to manually force the `deepstack_input_embeds` buffer list to the correct TPU device (via Torchax/JAX) to address the issue caused by ModelForEmbedding adapter.

**3. Functional Scoping (Pooling Guard)**
*   Ensured the materialization hardening logic is scoped to `is_pooling`. This ensures zero logic changes or performance impact for standard generative models.

#### **Validation & Correctness**
*   **E2E Verified on v7 Hardware**: Successfully validated Qwen3-VL-Embedding end-to-end on a `tpu7-8` node.
*   **Chunked Prefill Parity**: Confirmed that `pooling_states` are correctly preserved and accumulated across step boundaries during multi-step multimodal embedding tasks.

- [mm embedding/pooling e2e test result](https://paste.googleplex.com/4553021745922048)
- [qwen3-vl-embedding-8b server log - success](https://paste.googleplex.com/4989306268680192)

NOTE: I will create a follow-up(another) PR to introduce the formal Nightly CI tests for this model.