### PR TITLE
[Spec decoding] make spec decoding compatible with async scheduling

### DIFF
--- a/tests/e2e/test_speculative_decoding.py
+++ b/tests/e2e/test_speculative_decoding.py
@@ -110,7 +110,6 @@ def _test_correctness_helper(
             max_num_seqs=max_num_seqs,
             tensor_parallel_size=_get_tensor_parallel_size(),
             model_loader_extra_config={"enable_weights_track": False},
-            download_dir="/mnt/pd",
             async_scheduling=async_scheduling)
         ref_outputs = ref_llm.generate(test_prompts, sampling_config)
 
@@ -126,7 +125,6 @@ def _test_correctness_helper(
             max_num_seqs=max_num_seqs,
             tensor_parallel_size=_get_tensor_parallel_size(),
             model_loader_extra_config={"enable_weights_track": False},
-            download_dir="/mnt/pd",
             async_scheduling=async_scheduling)
         spec_outputs = spec_llm.generate(test_prompts, sampling_config)
 
@@ -213,7 +211,6 @@ def _test_performance_helper(monkeypatch: pytest.MonkeyPatch,
             enable_prefix_caching=False,
             model_loader_extra_config={"enable_weights_track": False},
             disable_log_stats=False,
-            download_dir="/mnt/pd",
             async_scheduling=async_scheduling)
 
         spec_llm.generate(test_prompts, sampling_config)

--- a/tests/e2e/test_speculative_decoding.py
+++ b/tests/e2e/test_speculative_decoding.py
@@ -108,6 +108,7 @@ def _test_correctness_helper(
             max_num_seqs=4,
             tensor_parallel_size=_get_tensor_parallel_size(),
             model_loader_extra_config={"enable_weights_track": False},
+            download_dir="/mnt/pd",
             async_scheduling=0)
         ref_outputs = ref_llm.generate(test_prompts, sampling_config)
 
@@ -123,6 +124,7 @@ def _test_correctness_helper(
             max_num_seqs=4,
             tensor_parallel_size=_get_tensor_parallel_size(),
             model_loader_extra_config={"enable_weights_track": False},
+            download_dir="/mnt/pd",
             async_scheduling=0)
         spec_outputs = spec_llm.generate(test_prompts, sampling_config)
 
@@ -210,6 +212,7 @@ def _test_performance_helper(
             enable_prefix_caching=False,
             model_loader_extra_config={"enable_weights_track": False},
             disable_log_stats=False,
+            download_dir="/mnt/pd",
             async_scheduling=0)
 
         _ = spec_llm.generate(test_prompts, sampling_config)

--- a/tests/e2e/test_speculative_decoding.py
+++ b/tests/e2e/test_speculative_decoding.py
@@ -93,6 +93,8 @@ def _test_correctness_helper(
     sampling_config: SamplingParams,
     model_name: str,
     speculative_config: dict,
+    max_num_seqs: int = 4,
+    async_scheduling: bool = False,
 ):
     '''
     Helper function to test ngram correctness.
@@ -105,11 +107,11 @@ def _test_correctness_helper(
         ref_llm = LLM(
             model=model_name,
             max_model_len=1024,
-            max_num_seqs=4,
+            max_num_seqs=max_num_seqs,
             tensor_parallel_size=_get_tensor_parallel_size(),
             model_loader_extra_config={"enable_weights_track": False},
             download_dir="/mnt/pd",
-            async_scheduling=0)
+            async_scheduling=async_scheduling)
         ref_outputs = ref_llm.generate(test_prompts, sampling_config)
 
         del ref_llm
@@ -121,11 +123,11 @@ def _test_correctness_helper(
             model=model_name,
             speculative_config=speculative_config,
             max_model_len=1024,
-            max_num_seqs=4,
+            max_num_seqs=max_num_seqs,
             tensor_parallel_size=_get_tensor_parallel_size(),
             model_loader_extra_config={"enable_weights_track": False},
             download_dir="/mnt/pd",
-            async_scheduling=0)
+            async_scheduling=async_scheduling)
         spec_outputs = spec_llm.generate(test_prompts, sampling_config)
 
         matches = 0
@@ -186,12 +188,12 @@ def test_ngram_correctness_random(
         })
 
 
-def _test_performance_helper(
-    monkeypatch: pytest.MonkeyPatch,
-    sampling_config: SamplingParams,
-    speculative_config: dict,
-    min_acceptance_rate: float,
-):
+def _test_performance_helper(monkeypatch: pytest.MonkeyPatch,
+                             sampling_config: SamplingParams,
+                             speculative_config: dict,
+                             min_acceptance_rate: float,
+                             max_num_seqs: int = 1,
+                             async_scheduling: bool = False):
     '''
     Helper function to test speculative decoding performance.
     Compares timing between reference LLM and speculative LLM using Llama 3 8B.
@@ -202,20 +204,19 @@ def _test_performance_helper(
         # Use a smaller set of prompts for performance testing
         test_prompts = get_test_prompts(speculative_config)
 
-        # Test speculative LLM timing with max_num_seqs=1
         spec_llm = LLM(
             model=model_name,
             speculative_config=speculative_config,
             max_model_len=1024,
-            max_num_seqs=1,
+            max_num_seqs=max_num_seqs,
             tensor_parallel_size=_get_tensor_parallel_size(),
             enable_prefix_caching=False,
             model_loader_extra_config={"enable_weights_track": False},
             disable_log_stats=False,
             download_dir="/mnt/pd",
-            async_scheduling=0)
+            async_scheduling=async_scheduling)
 
-        _ = spec_llm.generate(test_prompts, sampling_config)
+        spec_llm.generate(test_prompts, sampling_config)
 
         metrics = spec_llm.get_metrics()
         num_draft_tokens = num_accepted_tokens = 0
@@ -230,6 +231,8 @@ def _test_performance_helper(
         if num_draft_tokens > 0:
             acceptance_rate = num_accepted_tokens / num_draft_tokens
             print(f"Acceptance rate: {acceptance_rate:.2%}")
+            print("num_accepted_tokens:" + str(num_accepted_tokens))
+            print("num_draft_tokens:" + str(num_draft_tokens))
 
         del spec_llm
         # Waiting for TPUs to be released
@@ -279,9 +282,11 @@ def test_ngram_performance_random(
                              min_acceptance_rate=0.85)
 
 
+@pytest.mark.parametrize("async_scheduling", [False, True])
 def test_eagle3_correctness(
     monkeypatch: pytest.MonkeyPatch,
     sampling_config: SamplingParams,
+    async_scheduling: bool,
 ):
     '''
     Compare the outputs of a original LLM and a speculative LLM
@@ -293,17 +298,25 @@ def test_eagle3_correctness(
     monkeypatch.setenv("DRAFT_MODEL_IMPL_TYPE", model_impl)
 
     _test_correctness_helper(
-        monkeypatch, sampling_config, model_name, {
+        monkeypatch,
+        sampling_config,
+        model_name, {
             'model': "unkmaster/EAGLE3-LLaMA3.1-Instruct-8B",
             "num_speculative_tokens": 3,
             "method": "eagle3",
             "draft_tensor_parallel_size": 1
-        })
+        },
+        max_num_seqs=10,
+        async_scheduling=async_scheduling)
 
 
+@pytest.mark.parametrize("max_num_seqs", [1, 20])
+@pytest.mark.parametrize("async_scheduling", [False, True])
 def test_eagle3_performance(
     monkeypatch: pytest.MonkeyPatch,
     sampling_config: SamplingParams,
+    max_num_seqs: int,
+    async_scheduling: bool,
 ):
     '''
     Test that speculative decoding provides significant performance improvement.
@@ -321,4 +334,6 @@ def test_eagle3_performance(
             "num_speculative_tokens": 2,
             "draft_tensor_parallel_size": 1
         },
-        min_acceptance_rate=0.75)
+        min_acceptance_rate=0.75,
+        max_num_seqs=max_num_seqs,
+        async_scheduling=async_scheduling)

--- a/tests/runner/test_speculative_decoding_manager.py
+++ b/tests/runner/test_speculative_decoding_manager.py
@@ -89,19 +89,18 @@ class TestSpeculativeDecodingManager:
         # Mock the eagle-specific proposal method
         with patch.object(self.runner.speculative_decoding_manager,
                           'propose_eagle3_draft_token_ids',
-                          return_value=[[10, 11]]) as mock_propose_eagle, \
-             patch(
-                 'tpu_inference.runner.speculative_decoding_manager'
-                 '.extract_last_sampled_tokens',
-                 return_value=(MagicMock(), MagicMock())):
+                          return_value=[[10, 11]]) as mock_propose_eagle:
 
             # 2. ===== Act =====
             self.runner.speculative_decoding_manager.propose_draft_token_ids(
                 sampled_output=MagicMock(),
                 logits_indices_selector=MagicMock(),
+                last_sampled_token_id=MagicMock(),
+                num_rejected_tokens=MagicMock(),
                 discard_sampled_tokens_req_indices=[],
                 aux_hidden_states=None,
                 attn_metadata=MagicMock(),
+                async_scheduling=False,
                 spec_decode_metadata=None,
             )
 
@@ -118,7 +117,8 @@ class TestSpeculativeDecodingManager:
         self.runner.speculative_config.method = "ngram"
         with pytest.raises(AssertionError):
             self.runner.speculative_decoding_manager.propose_draft_token_ids(
-                MagicMock(), MagicMock(), [], None, MagicMock(), None)
+                MagicMock(), MagicMock(), MagicMock(), MagicMock(), [], None,
+                MagicMock(), False, None)
 
     def test_take_draft_token_ids(self):
         """Tests the take_draft_token_ids method for speculative decoding."""
@@ -369,6 +369,7 @@ class TestSpeculativeDecodingManager:
                 attn_metadata,
                 scheduler_output,
                 input_ids,
+                async_scheduling=False,
             )
 
         # 3. ===== Assert =====

--- a/tests/runner/test_tpu_runner_dp.py
+++ b/tests/runner/test_tpu_runner_dp.py
@@ -78,6 +78,7 @@ class TestTPUJaxRunnerDPInputsLightweight:
         self.runner.scheduler_config = MagicMock()
         self.runner.scheduler_config.async_scheduling = False  # Default to False for most tests
         self.runner._pre_async_results = None  # Default to None for most tests
+        self.runner.speculative_config = None  # Default to None (no spec decode)
 
         # Bind the actual methods to our mock
         self.runner._prepare_inputs = TPUModelRunner._prepare_inputs.__get__(
@@ -559,20 +560,12 @@ class TestTPUJaxRunnerDPInputsLightweight:
         expected_query_start[max_num_reqs_per_dp + 3:] = 1
         assert np.array_equal(query_start_loc, expected_query_start)
 
-        # 4. Verify seq_lens content
-        seq_lens = attention_metadata.seq_lens_cpu
-        # Should be computed_tokens + scheduled_tokens for each request
-        # DP rank 0: req1 at position 0, DP rank 1: req2 at position 4
-        expected_seq_lens = np.array([7, 0, 0, 0, 9, 0, 0,
-                                      0])  # req1: 5+2=7, req2: 6+3=9
-        assert np.array_equal(seq_lens, expected_seq_lens)
-
-        # 5. Verify request_distribution content
+        # 4. Verify request_distribution content
         expected_distribution = np.array([[0, 0, 1], [0, 0, 1]]).flatten()
         np.testing.assert_array_equal(attention_metadata.request_distribution,
                                       expected_distribution)
 
-        # 6. Verify logits_indices content
+        # 5. Verify logits_indices content
         assert len(logits_indices) == 8  # padded_num_reqs
         expected_logits = np.full(8, -1, dtype=np.int32)
         expected_logits[0] = 1  # req1 last token position (2-1)
@@ -580,7 +573,7 @@ class TestTPUJaxRunnerDPInputsLightweight:
             4] = 2  # req2 last token position (3-1) at DP rank 1 offset (4*1)
         assert np.array_equal(logits_indices, expected_logits)
 
-        # 7. Verify logits_indices_selector
+        # 6. Verify logits_indices_selector
         assert len(logits_indices_selector) == 2
         assert np.array_equal(logits_indices_selector, np.array([0, 4]))
 
@@ -678,23 +671,12 @@ class TestTPUJaxRunnerDPInputsLightweight:
                              1:] = 0  # Empty rank sets to 0
         assert np.array_equal(query_start_loc, expected_query_start)
 
-        # 4. Verify seq_lens
-        seq_lens = attention_metadata.seq_lens_cpu
-        expected_seq_lens = np.zeros(8, dtype=np.int32)
-        # Rank 0: req1 (4+3=7), req2 (6+2=8), then padding
-        expected_seq_lens[
-            0] = 7  # req1: computed_tokens(4) + scheduled_tokens(3)
-        expected_seq_lens[
-            1] = 8  # req2: computed_tokens(6) + scheduled_tokens(2)
-        # Rank 1: all zeros
-        assert np.array_equal(seq_lens, expected_seq_lens)
-
-        # 5. Verify request_distribution
+        # 4. Verify request_distribution
         expected_distribution = np.array([[0, 0, 2], [0, 0, 0]]).flatten()
         np.testing.assert_array_equal(attention_metadata.request_distribution,
                                       expected_distribution)
 
-        # 6. Verify logits_indices
+        # 5. Verify logits_indices
         assert len(
             logits_indices) == 8  # padded_num_reqs (8 in this case, not 16)
         # Rank 0: req1 ends at pos 2, req2 ends at pos 4
@@ -704,7 +686,7 @@ class TestTPUJaxRunnerDPInputsLightweight:
         expected_logits[1] = 4  # req2 ends at position 4 (5-1)
         assert np.array_equal(logits_indices, expected_logits)
 
-        # 7. Verify logits_indices_selector
+        # 6. Verify logits_indices_selector
         assert len(logits_indices_selector) == 2
         expected_selector = np.array([0, 1])
         np.testing.assert_array_equal(logits_indices_selector,
@@ -847,6 +829,7 @@ class TestTPUJaxRunnerDPInputsLightweight:
         req_ids_dp = {0: ["req1", "req2"], 1: ["req3"]}
         scheduled_tokens_per_dp_rank = {0: [3, 2], 1: [4]}
         padded_num_scheduled_tokens_per_dp_rank = 8
+        num_draft_tokens_per_dp_rank = {0: np.array([0, 0], dtype=np.int32)}
         dp_size = 2
 
         # Setup _pre_async_results with placeholder mapping
@@ -859,9 +842,11 @@ class TestTPUJaxRunnerDPInputsLightweight:
         # Call the method
         result = self.runner._prepare_async_token_substitution_indices(
             req_ids_dp, scheduled_tokens_per_dp_rank,
-            padded_num_scheduled_tokens_per_dp_rank, dp_size)
+            padded_num_scheduled_tokens_per_dp_rank,
+            num_draft_tokens_per_dp_rank, dp_size)
 
-        token_in_tpu_cur_input_indices_dp, token_in_tpu_pre_next_tokens_indices_dp = result
+        (token_in_tpu_cur_input_indices_dp,
+         token_in_tpu_pre_next_tokens_indices_dp, _, _) = result
 
         # Verify DP rank 0
         # req1: token_offset=0, acc_cur_len starts at 0, after 3 tokens: 3, so last token at 2
@@ -888,6 +873,7 @@ class TestTPUJaxRunnerDPInputsLightweight:
         req_ids_dp = {0: ["req1", "req2"], 1: ["req3"]}
         scheduled_tokens_per_dp_rank = {0: [3, 2], 1: [4]}
         padded_num_scheduled_tokens_per_dp_rank = 8
+        num_draft_tokens_per_dp_rank = {0: np.array([0, 0], dtype=np.int32)}
         dp_size = 2
 
         # No placeholders
@@ -896,9 +882,11 @@ class TestTPUJaxRunnerDPInputsLightweight:
 
         result = self.runner._prepare_async_token_substitution_indices(
             req_ids_dp, scheduled_tokens_per_dp_rank,
-            padded_num_scheduled_tokens_per_dp_rank, dp_size)
+            padded_num_scheduled_tokens_per_dp_rank,
+            num_draft_tokens_per_dp_rank, dp_size)
 
-        token_in_tpu_cur_input_indices_dp, token_in_tpu_pre_next_tokens_indices_dp = result
+        (token_in_tpu_cur_input_indices_dp,
+         token_in_tpu_pre_next_tokens_indices_dp, _, _) = result
 
         # All lists should be empty since no placeholders
         assert token_in_tpu_cur_input_indices_dp[0] == []
@@ -914,16 +902,17 @@ class TestTPUJaxRunnerDPInputsLightweight:
             self.runner)
 
         input_ids = np.array([1, 2, 3, 4, 5])
+        next_tokens_in_tpu = np.array([10, 20, 30])
         token_in_tpu_cur_input_indices = np.array([])
         token_in_tpu_pre_next_tokens_indices = np.array([])
 
         # Setup _pre_async_results
         self.runner._pre_async_results = MagicMock()
-        self.runner._pre_async_results.next_tokens = np.array([10, 20, 30])
+        self.runner._pre_async_results.next_tokens = next_tokens_in_tpu
         self.runner.mesh = MagicMock()
 
         result = self.runner._apply_async_token_substitution(
-            input_ids, token_in_tpu_cur_input_indices,
+            input_ids, next_tokens_in_tpu, token_in_tpu_cur_input_indices,
             token_in_tpu_pre_next_tokens_indices)
 
         # Should return input_ids unchanged
@@ -940,13 +929,14 @@ class TestTPUJaxRunnerDPInputsLightweight:
             self.runner)
 
         input_ids = np.array([1, 2, 3, 4, 5, 6, 7, 8])
+        next_tokens_in_tpu = np.array([100, 200, 300])
         # Substitute positions 2 and 5
         token_in_tpu_cur_input_indices = np.array([2, 5])
         token_in_tpu_pre_next_tokens_indices = np.array([0, 1])
 
         # Setup _pre_async_results
         self.runner._pre_async_results = MagicMock()
-        self.runner._pre_async_results.next_tokens = np.array([100, 200, 300])
+        self.runner._pre_async_results.next_tokens = next_tokens_in_tpu
         self.runner.mesh = MagicMock()
         self.runner.maybe_forbid_compile = nullcontext()
 
@@ -956,7 +946,7 @@ class TestTPUJaxRunnerDPInputsLightweight:
         self.runner._substitute_placeholder_token_fn = mock_substitute_fn
 
         _ = self.runner._apply_async_token_substitution(
-            input_ids, token_in_tpu_cur_input_indices,
+            input_ids, next_tokens_in_tpu, token_in_tpu_cur_input_indices,
             token_in_tpu_pre_next_tokens_indices)
 
         # Verify the substitute function was called
@@ -1035,6 +1025,12 @@ class TestTPUJaxRunnerDPInputsLightweight:
             1: []
         }, {
             0: [0],
+            1: []
+        }, {
+            0: [],
+            1: []
+        }, {
+            0: [],
             1: []
         }))
         self.runner._prepare_async_token_substitution_indices = mock_prepare_async
@@ -1115,9 +1111,9 @@ class TestTPUJaxRunnerDPInputsLightweight:
         mock_apply_async.assert_called_once()
         call_args = mock_apply_async.call_args[0]
 
-        # Verify indices were concatenated from both DP ranks
-        token_in_tpu_cur_input_indices = call_args[1]
-        token_in_tpu_pre_next_tokens_indices = call_args[2]
+        # Verify indices were concatenated from both DP ranks.
+        token_in_tpu_cur_input_indices = call_args[2]
+        token_in_tpu_pre_next_tokens_indices = call_args[3]
 
         # Should have indices from both ranks
         assert len(token_in_tpu_cur_input_indices) == 2

--- a/tpu_inference/layers/common/attention_metadata.py
+++ b/tpu_inference/layers/common/attention_metadata.py
@@ -55,4 +55,3 @@ class AttentionMetadata(object):
     mamba_state_indices: jax.Array | None = None
 
     query_start_loc_cpu: Any = field(init=False)
-    seq_lens_cpu: Any = field(init=False)

--- a/tpu_inference/runner/compilation_manager.py
+++ b/tpu_inference/runner/compilation_manager.py
@@ -32,7 +32,8 @@ from tpu_inference.logger import init_logger
 from tpu_inference.models.jax.jax_intermediate_tensor import \
     JaxIntermediateTensors
 from tpu_inference.runner.utils import SpecDecodeMetadata
-from tpu_inference.spec_decode.jax.utils import extract_last_sampled_tokens
+from tpu_inference.spec_decode.jax.utils import (
+    concat_last_sampled_tokens_and_draft_tokens, extract_last_sampled_tokens)
 from tpu_inference.utils import device_array, to_jax_dtype
 
 if TYPE_CHECKING:
@@ -121,6 +122,8 @@ class CompilationManager:
                 self._precompile_substitute_placeholder_token()
                 if self.runner.speculative_config:
                     self._precompile_subtract_num_rejected_tokens()
+                    self._precompile_concat_last_sampled_tokens_and_draft_tokens(
+                    )
             if not self.runner.is_last_rank:
                 return
             self._precompile_select_from_array()
@@ -388,6 +391,33 @@ class CompilationManager:
                 positions_subtract_indices,
                 num_tokens=num_tokens,
             )
+
+    def _precompile_concat_last_sampled_tokens_and_draft_tokens(self) -> None:
+        logger.info(
+            "Compiling concat_last_sampled_tokens_and_draft_tokens with "
+            "different input shapes.")
+        num_spec_tokens = (
+            self.runner.speculative_config.num_speculative_tokens)
+        max_num_reqs = self.runner.max_num_reqs
+        replicated_sharding = NamedSharding(self.runner.mesh, PartitionSpec())
+
+        last_sampled_tokens = device_array(self.runner.mesh,
+                                           jnp.ones((max_num_reqs, ),
+                                                    dtype=jnp.int32),
+                                           sharding=replicated_sharding)
+        draft_tokens = device_array(self.runner.mesh,
+                                    jnp.ones((max_num_reqs, num_spec_tokens),
+                                             dtype=jnp.int32),
+                                    sharding=replicated_sharding)
+        self._run_compilation(
+            f"worker{self.runner.rank} "
+            "concat_last_sampled_tokens_and_draft_tokens",
+            concat_last_sampled_tokens_and_draft_tokens,
+            last_sampled_tokens,
+            draft_tokens,
+            max_num_reqs=max_num_reqs,
+            num_spec_tokens=num_spec_tokens,
+        )
 
     def _precompile_backbone_text_only(self) -> None:
         hidden_size = self.runner.model_config.get_hidden_size()

--- a/tpu_inference/runner/compilation_manager.py
+++ b/tpu_inference/runner/compilation_manager.py
@@ -732,8 +732,8 @@ class CompilationManager:
         logger.info(
             "Compiling speculative_decoding with different input shapes.")
         self._precompile_rejection_sampler()
+        self._precompile_extract_last_sampled_tokens()
         if self.runner.speculative_config.method == "eagle3":
-            self._precompile_extract_last_sampled_tokens()
             self._precompile_eagle3_helpers()
 
     def _precompile_extract_last_sampled_tokens(self) -> None:

--- a/tpu_inference/runner/compilation_manager.py
+++ b/tpu_inference/runner/compilation_manager.py
@@ -119,6 +119,8 @@ class CompilationManager:
                 self._precompile_backbone_with_inputs_embeds()
             if self.runner.scheduler_config.async_scheduling:
                 self._precompile_substitute_placeholder_token()
+                if self.runner.speculative_config:
+                    self._precompile_subtract_num_rejected_tokens()
             if not self.runner.is_last_rank:
                 return
             self._precompile_select_from_array()
@@ -302,50 +304,90 @@ class CompilationManager:
             )
 
     def _precompile_substitute_placeholder_token(self) -> None:
-        """Precompiles the token substitution function for all expected input shapes.
+        dp_sharding = NamedSharding(
+            self.runner.mesh, PartitionSpec(ShardingAxisName.ATTN_DATA, ))
+        replicated_sharding = NamedSharding(self.runner.mesh, PartitionSpec())
+        indices_sharding = NamedSharding(self.runner.mesh, PartitionSpec(None))
 
-        It iterates through all potential padded token lengths
-        (`num_tokens_paddings`) and request batch sizes (`num_reqs_paddings`)
-        that the scheduler is expected to handle, ensuring a compiled version
-        is ready for each combination.
-        """
+        def _compile_one(input_padding: int, input_sharding: NamedSharding,
+                         next_tokens_size: int) -> None:
+            padded_token_in_tpu_cur_input_indices = np.zeros((input_padding, ),
+                                                             dtype=np.int32)
+            padded_token_in_tpu_pre_next_tokens_indices = np.zeros(
+                (input_padding, ), dtype=np.int32)
+            (padded_token_in_tpu_cur_input_indices,
+             padded_token_in_tpu_pre_next_tokens_indices) = device_array(
+                 self.runner.mesh,
+                 (padded_token_in_tpu_cur_input_indices,
+                  padded_token_in_tpu_pre_next_tokens_indices),
+                 sharding=indices_sharding)
+
+            input_ids = self._create_dummy_tensor((input_padding, ), jnp.int32,
+                                                  input_sharding)
+            next_tokens = self._create_dummy_tensor(
+                (next_tokens_size, ), jnp.int32, sharding=replicated_sharding)
+            placeholder_num = device_array(self.runner.mesh,
+                                           np.array([1], dtype=np.int32))
+            self._run_compilation(
+                "_substitute_placeholder_token_fn",
+                self.runner._substitute_placeholder_token_fn,
+                input_ids,
+                padded_token_in_tpu_cur_input_indices,
+                padded_token_in_tpu_pre_next_tokens_indices,
+                next_tokens,
+                placeholder_num,
+                num_tokens=input_padding,
+                next_tokens_size=next_tokens_size,
+            )
+
+        if self.runner.speculative_config:
+            num_spec_tokens = (
+                self.runner.speculative_config.num_speculative_tokens)
+            spec_next_tokens_size = self.runner.max_num_reqs * (
+                num_spec_tokens + 1)
+            for num_tokens in self.runner.num_tokens_paddings:
+                _compile_one(num_tokens, dp_sharding, spec_next_tokens_size)
+            for num_logits in self.runner.num_logits_paddings:
+                _compile_one(num_logits, replicated_sharding,
+                             spec_next_tokens_size)
+        else:
+            for num_tokens in self.runner.num_tokens_paddings:
+                for num_reqs in self.runner.num_reqs_paddings:
+                    _compile_one(num_tokens, dp_sharding, num_reqs)
+
+    def _precompile_subtract_num_rejected_tokens(self) -> None:
+        from tpu_inference.runner.tpu_runner import \
+            _subtract_num_rejected_tokens_fn
+
+        dp_sharding = NamedSharding(
+            self.runner.mesh, PartitionSpec(ShardingAxisName.ATTN_DATA, ))
+        replicated_sharding = NamedSharding(self.runner.mesh,
+                                            PartitionSpec(None))
 
         for num_tokens in self.runner.num_tokens_paddings:
-            dp_sharding = NamedSharding(
-                self.runner.mesh, PartitionSpec(ShardingAxisName.ATTN_DATA, ))
+            # `_subtract_num_rejected_tokens_fn` donates seq_lens and positions
+            # (donate_argnums=(0, 1)) so a fresh pair must be created per call.
+            seq_lens = self._create_dummy_tensor((self.runner.max_num_reqs, ),
+                                                 jnp.int32, dp_sharding)
+            positions = self._create_dummy_tensor((num_tokens, ), jnp.int32,
+                                                  dp_sharding)
+            num_rejected_tokens = self._create_dummy_tensor(
+                (self.runner.max_num_reqs, ), jnp.int32, replicated_sharding)
+            seq_lens_subtract_indices = self._create_dummy_tensor(
+                (self.runner.max_num_reqs, ), jnp.int32, replicated_sharding)
+            positions_subtract_indices = self._create_dummy_tensor(
+                (num_tokens, ), jnp.int32, replicated_sharding)
 
-            for num_reqs in self.runner.num_reqs_paddings:
-                padded_token_in_tpu_cur_input_indices = np.zeros(
-                    (num_tokens, ), dtype=np.int32)
-                padded_token_in_tpu_pre_next_tokens_indices = np.zeros(
-                    (num_tokens, ), dtype=jnp.int32)
-                (padded_token_in_tpu_cur_input_indices,
-                 padded_token_in_tpu_pre_next_tokens_indices) = device_array(
-                     self.runner.mesh,
-                     (padded_token_in_tpu_cur_input_indices,
-                      padded_token_in_tpu_pre_next_tokens_indices),
-                     sharding=NamedSharding(self.runner.mesh,
-                                            PartitionSpec(None)))
-
-                input_ids = self._create_dummy_tensor((num_tokens, ),
-                                                      jnp.int32, dp_sharding)
-                next_tokens = self._create_dummy_tensor(
-                    (num_reqs, ),
-                    jnp.int32,
-                    sharding=NamedSharding(self.runner.mesh, PartitionSpec()))
-
-                placeholder_num = jnp.asarray(1, dtype=jnp.int32)
-                self._run_compilation(
-                    "_substitute_placeholder_token_fn",
-                    self.runner._substitute_placeholder_token_fn,
-                    input_ids,
-                    padded_token_in_tpu_cur_input_indices,
-                    padded_token_in_tpu_pre_next_tokens_indices,
-                    next_tokens,
-                    placeholder_num,
-                    num_tokens=num_tokens,
-                    num_reqs=num_reqs,
-                )
+            self._run_compilation(
+                "_subtract_num_rejected_tokens_fn",
+                _subtract_num_rejected_tokens_fn,
+                seq_lens,
+                positions,
+                num_rejected_tokens,
+                seq_lens_subtract_indices,
+                positions_subtract_indices,
+                num_tokens=num_tokens,
+            )
 
     def _precompile_backbone_text_only(self) -> None:
         hidden_size = self.runner.model_config.get_hidden_size()

--- a/tpu_inference/runner/speculative_decoding_manager.py
+++ b/tpu_inference/runner/speculative_decoding_manager.py
@@ -25,7 +25,6 @@ from vllm.v1.spec_decode.ngram_proposer import NgramProposer
 from tpu_inference.runner import utils as runner_utils
 from tpu_inference.runner.utils import SpecDecodeMetadata
 from tpu_inference.spec_decode.jax.eagle3 import Eagle3Proposer
-from tpu_inference.spec_decode.jax.utils import extract_last_sampled_tokens
 from tpu_inference.utils import device_array
 
 if TYPE_CHECKING:
@@ -53,13 +52,18 @@ class SpeculativeDecodingManager:
         self,
         sampled_output: jnp.ndarray,
         logits_indices_selector: np.ndarray,
+        last_sampled_token_id: jnp.ndarray,
+        num_rejected_tokens: jnp.ndarray,
         discard_sampled_tokens_req_indices: list,
         aux_hidden_states: Optional[tuple[jnp.ndarray, ...]],
         attn_metadata: AttentionMetadata,
+        async_scheduling: bool,
         spec_decode_metadata: Optional[SpecDecodeMetadata],
         scheduler_output: Optional[VllmSchedulerOutput] = None,
         input_ids: Optional[jnp.ndarray] = None,
     ) -> None:
+        if async_scheduling:
+            assert self.runner.speculative_config.method == "eagle3", "async scheduling is only supported with eagle3 spec decoding"
         if self.runner.speculative_config.method == "ngram":
             assert isinstance(self.runner.drafter, NgramProposer)
             # For n-gram based proposer, the drafter run on host
@@ -67,16 +71,13 @@ class SpeculativeDecodingManager:
             # token ids from device to host, then run the ngram proposer.
             valid_sampled_token_ids = runner_utils.host_extract_sampled_tokens(
                 self.runner, spec_decode_metadata, sampled_output,
-                logits_indices_selector, discard_sampled_tokens_req_indices)
+                logits_indices_selector, discard_sampled_tokens_req_indices,
+                self.runner.input_batch.num_reqs)
             self._draft_token_ids = self.runner.drafter.propose(
                 valid_sampled_token_ids[:self.runner.input_batch.num_reqs],
                 self.runner.input_batch.num_tokens_no_spec,
                 self.runner.input_batch.token_ids_cpu)
         elif self.runner.speculative_config.method == "eagle3":
-            last_sampled_token_id, num_rejected_tokens = extract_last_sampled_tokens(
-                spec_decode_metadata, sampled_output,
-                self.runner.speculative_config.num_speculative_tokens,
-                self.runner.input_batch.vocab_size, self.runner.max_num_reqs)
             self._draft_token_ids = self.propose_eagle3_draft_token_ids(
                 spec_decode_metadata,
                 last_sampled_token_id,
@@ -86,6 +87,7 @@ class SpeculativeDecodingManager:
                 attn_metadata,
                 scheduler_output,
                 input_ids,
+                async_scheduling,
             )
         else:
             raise NotImplementedError(
@@ -93,16 +95,14 @@ class SpeculativeDecodingManager:
                 f"'{self.runner.speculative_config.method}' is not supported.")
 
     def propose_eagle3_draft_token_ids(
-        self,
-        spec_decode_metadata: Optional[SpecDecodeMetadata],
-        last_sampled_token_id: jnp.ndarray,
-        num_rejected_tokens: jnp.ndarray,
-        discard_sampled_tokens_req_indices: list[int],
-        aux_hidden_states: Optional[tuple[jnp.ndarray, ...]],
-        attn_metadata: AttentionMetadata,
-        scheduler_output: VllmSchedulerOutput,
-        input_ids: jnp.ndarray,
-    ) -> list[list[int]]:
+            self, spec_decode_metadata: Optional[SpecDecodeMetadata],
+            last_sampled_token_id: jnp.ndarray,
+            num_rejected_tokens: jnp.ndarray,
+            discard_sampled_tokens_req_indices: list[int],
+            aux_hidden_states: Optional[tuple[jnp.ndarray, ...]],
+            attn_metadata: AttentionMetadata,
+            scheduler_output: VllmSchedulerOutput, input_ids: jnp.ndarray,
+            async_scheduling: bool) -> list[list[int]] | jnp.ndarray:
         assert isinstance(self.runner.drafter, Eagle3Proposer)
         req_ids = self.runner.input_batch.req_ids
         max_num_seqs = attn_metadata.seq_lens.shape[0]
@@ -139,10 +139,16 @@ class SpeculativeDecodingManager:
             last_token_indices=last_token_indices,
             target_hidden_states=target_hidden_states,
         )
-        draft_token_ids = np.array(draft_token_ids)
-        if draft_token_ids.ndim == 1:
-            draft_token_ids = np.expand_dims(draft_token_ids, axis=-1)
-        return draft_token_ids.tolist()
+
+        if not async_scheduling:
+            draft_token_ids = np.array(draft_token_ids)
+            if draft_token_ids.ndim == 1:
+                draft_token_ids = np.expand_dims(draft_token_ids, axis=-1)
+            return draft_token_ids.tolist()
+        else:
+            if jnp.ndim(draft_token_ids) == 1:
+                draft_token_ids = jnp.expand_dims(draft_token_ids, 1)
+            return draft_token_ids
 
     def get_spec_decode_metadata(
         self,

--- a/tpu_inference/runner/speculative_decoding_manager.py
+++ b/tpu_inference/runner/speculative_decoding_manager.py
@@ -63,7 +63,8 @@ class SpeculativeDecodingManager:
         input_ids: Optional[jnp.ndarray] = None,
     ) -> None:
         if async_scheduling:
-            assert self.runner.speculative_config.method == "eagle3", "async scheduling is only supported with eagle3 spec decoding"
+            assert self.runner.speculative_config.use_eagle(
+            ), "async scheduling is only supported with eagle3 spec decoding"
         if self.runner.speculative_config.method == "ngram":
             assert isinstance(self.runner.drafter, NgramProposer)
             # For n-gram based proposer, the drafter run on host
@@ -77,7 +78,7 @@ class SpeculativeDecodingManager:
                 valid_sampled_token_ids[:self.runner.input_batch.num_reqs],
                 self.runner.input_batch.num_tokens_no_spec,
                 self.runner.input_batch.token_ids_cpu)
-        elif self.runner.speculative_config.method == "eagle3":
+        elif self.runner.speculative_config.use_eagle():
             self._draft_token_ids = self.propose_eagle3_draft_token_ids(
                 spec_decode_metadata,
                 last_sampled_token_id,
@@ -140,15 +141,15 @@ class SpeculativeDecodingManager:
             target_hidden_states=target_hidden_states,
         )
 
-        if not async_scheduling:
+        if async_scheduling:
+            if jnp.ndim(draft_token_ids) == 1:
+                draft_token_ids = jnp.expand_dims(draft_token_ids, 1)
+            return draft_token_ids
+        else:
             draft_token_ids = np.array(draft_token_ids)
             if draft_token_ids.ndim == 1:
                 draft_token_ids = np.expand_dims(draft_token_ids, axis=-1)
             return draft_token_ids.tolist()
-        else:
-            if jnp.ndim(draft_token_ids) == 1:
-                draft_token_ids = jnp.expand_dims(draft_token_ids, 1)
-            return draft_token_ids
 
     def get_spec_decode_metadata(
         self,

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -16,7 +16,7 @@ import functools
 import logging
 import random
 from contextlib import nullcontext
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Any, Callable, Dict, List, Optional, Tuple, cast
 
 import jax
@@ -78,6 +78,8 @@ from tpu_inference.runner.speculative_decoding_manager import (
 from tpu_inference.runner.structured_decoding_manager import \
     StructuredDecodingManager
 from tpu_inference.spec_decode.jax.eagle3 import Eagle3Proposer
+from tpu_inference.spec_decode.jax.utils import (
+    concat_last_sampled_tokens_and_draft_tokens, extract_last_sampled_tokens)
 from tpu_inference.utils import (device_array, make_optimized_mesh,
                                  time_function, to_jax_dtype, to_torch_dtype)
 
@@ -102,17 +104,17 @@ class AsyncTPUModelRunnerOutput(AsyncModelRunnerOutput):
     the final `ModelRunnerOutput` object.
     """
 
-    def __init__(
-        self,
-        model_runner_output: ModelRunnerOutput,
-        next_tokens: jax.Array,
-        num_reqs: int,
-        discard_sampled_tokens_req_indices: list[int],
-        logits_indices_selector: Optional[List[int]] = None,
-        logprobs_tensors: Optional[LogprobsTensors] = None,
-        expert_indices: Optional[jax.Array] = None,
-        total_num_scheduled_tokens: int = 0,
-    ):
+    def __init__(self,
+                 model_runner_output: ModelRunnerOutput,
+                 next_tokens: jax.Array,
+                 num_reqs: int,
+                 discard_sampled_tokens_req_indices: list[int],
+                 logits_indices_selector: Optional[List[int]] = None,
+                 logprobs_tensors: Optional[LogprobsTensors] = None,
+                 expert_indices: Optional[jax.Array] = None,
+                 total_num_scheduled_tokens: int = 0,
+                 spec_decode_metadata: Optional[SpecDecodeMetadata] = None,
+                 runner=None):
         self._model_runner_output = model_runner_output
         self._next_tokens = next_tokens
         self._num_reqs = num_reqs
@@ -121,16 +123,15 @@ class AsyncTPUModelRunnerOutput(AsyncModelRunnerOutput):
         self._logprobs_tensors = logprobs_tensors
         self._expert_indices = expert_indices
         self._total_num_scheduled_tokens = total_num_scheduled_tokens
+        self._spec_decode_metadata = spec_decode_metadata
+        self._runner = runner
 
     def get_output(self) -> ModelRunnerOutput:
-        next_tokens_cpu = np.asarray(jax.device_get(self._next_tokens))
-        if self.logits_indices_selector is not None:
-            next_tokens_cpu = next_tokens_cpu[self.logits_indices_selector]
-        selected_token_ids = np.expand_dims(next_tokens_cpu[:self._num_reqs],
-                                            1)
-        valid_sampled_token_ids = selected_token_ids.tolist()
-        for i in self._discard_sampled_tokens_req_indices:
-            valid_sampled_token_ids[i].clear()
+        valid_sampled_token_ids = runner_utils.host_extract_sampled_tokens(
+            self._runner, self._spec_decode_metadata, self._next_tokens,
+            self.logits_indices_selector,
+            self._discard_sampled_tokens_req_indices, self._num_reqs)
+
         self._model_runner_output.sampled_token_ids = valid_sampled_token_ids
 
         if self._logprobs_tensors is not None:
@@ -156,6 +157,14 @@ class AsyncPreResults:
     discard_sampled_tokens_req_indices: list[int]
     placeholder_req_id_to_index: dict[str, int]
     logits_indices_selector: Optional[List[int]] = None
+
+    # Only when spec decoding is enabled, the follow variables
+    # are populated.
+    spec_decode_next_tokens: Optional[
+        jax.Array] = None  # [max_num_reqs * (gamma + 1)]
+    spec_decode_num_rejected_tokens: Optional[
+        jax.Array] = None  # [max_num_reqs]
+    spec_decode_metadata: Optional[SpecDecodeMetadata] = None
 
 
 @dataclass
@@ -210,6 +219,27 @@ def _substitute_placeholder_token(
     original_values = input_ids[token_in_tpu_cur_input_indices]
     update_values = jnp.where(mask, new_token_values, original_values)
     return input_ids.at[token_in_tpu_cur_input_indices].set(update_values)
+
+
+@jax.jit(donate_argnums=(0, 1))
+def _subtract_num_rejected_tokens_fn(seq_lens: jax.Array, positions: jax.Array,
+                                     num_rejected_tokens: jax.Array,
+                                     seq_lens_subtract_indices: jax.Array,
+                                     positions_subtract_indices: jax.Array):
+    """Subtract the previous step's rejected-token counts from `seq_lens` and
+    `positions`.
+    """
+    seq_valid = seq_lens_subtract_indices >= 0
+    seq_subtract = jnp.where(seq_valid,
+                             num_rejected_tokens[seq_lens_subtract_indices], 0)
+    seq_lens = seq_lens - seq_subtract
+
+    pos_valid = positions_subtract_indices >= 0
+    pos_subtract = jnp.where(pos_valid,
+                             num_rejected_tokens[positions_subtract_indices],
+                             0)
+    positions = positions - pos_subtract
+    return seq_lens, positions
 
 
 def _jax_logprobs_copy_to_host_async(
@@ -767,21 +797,18 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         # device_get should return immediately as we have scheduled it in previous function call.
         assert self._pre_async_results is not None, "When we call _modify_prev_results(), self._pre_async_results should already exist"
         pre_req_ids = self._pre_async_results.req_ids
+        pre_num_reqs = len(pre_req_ids)
         pre_next_tokens = self._pre_async_results.next_tokens
         pre_request_seq_lens = self._pre_async_results.request_seq_lens
         pre_discard_sampled_tokens_req_indices = self._pre_async_results.discard_sampled_tokens_req_indices
         pre_logits_indices_selector = self._pre_async_results.logits_indices_selector
+        pre_spec_decode_metadata = self._pre_async_results.spec_decode_metadata
 
-        next_tokens_cpu = np.asarray(jax.device_get(pre_next_tokens))
-        if pre_logits_indices_selector is not None:
-            next_tokens_cpu = next_tokens_cpu[pre_logits_indices_selector]
-        selected_token_ids = np.expand_dims(next_tokens_cpu[:len(pre_req_ids)],
-                                            1)
-        valid_sampled_token_ids = selected_token_ids.tolist()
+        valid_sampled_token_ids = runner_utils.host_extract_sampled_tokens(
+            self, pre_spec_decode_metadata, pre_next_tokens,
+            pre_logits_indices_selector,
+            pre_discard_sampled_tokens_req_indices, pre_num_reqs)
 
-        # Mask out the sampled tokens that should not be sampled.
-        for i in pre_discard_sampled_tokens_req_indices:
-            valid_sampled_token_ids[i].clear()
         # Append sampled tokens
         for pre_req_idx, req_state, _ in pre_request_seq_lens:
             sampled_ids = valid_sampled_token_ids[pre_req_idx]
@@ -798,22 +825,34 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                 req_id], "The req_state should be valid and identical"
 
             # Updated on previous execute
+            pre_num_placeholder_tokens = 1
+            if pre_spec_decode_metadata is not None:
+                pre_num_placeholder_tokens += pre_spec_decode_metadata.draft_lengths_cpu[
+                    pre_req_idx]
             end_idx = self.input_batch.num_tokens_no_spec[req_idx]
-            assert len(sampled_ids) == 1, "do not support spec decode yet"
-            start_idx = end_idx - 1
+            num_sampled_tokens = len(sampled_ids)
+            assert num_sampled_tokens <= pre_num_placeholder_tokens
+            start_idx = end_idx - pre_num_placeholder_tokens
             assert end_idx <= self.max_model_len, (
                 "Sampled token IDs exceed the max model length. "
                 f"Total number of tokens: {end_idx} > max_model_len: "
                 f"{self.max_model_len}")
 
-            self.input_batch.token_ids_cpu[req_idx,
-                                           start_idx:end_idx] = sampled_ids
+            self.input_batch.token_ids_cpu[req_idx, start_idx:start_idx +
+                                           num_sampled_tokens] = sampled_ids
+            self.input_batch.num_tokens_no_spec[
+                req_idx] = start_idx + num_sampled_tokens
+            self.input_batch.num_tokens[
+                req_idx] = start_idx + num_sampled_tokens
             # Replace previous placeholder
-            req_state.output_token_ids[-1] = sampled_ids[-1]
+            for j in range(pre_num_placeholder_tokens):
+                req_state.output_token_ids.pop()
+            req_state.output_token_ids.extend(sampled_ids)
 
     def _update_placeholder(self,
                             discard_sampled_tokens_req_indices,
                             request_seq_lens,
+                            spec_decode_metadata,
                             logits_indices_selector=None):
         placeholder_req_id_to_index: dict[str, int] = {}
         discard_sampled_tokens_req_indices_set = set(
@@ -823,8 +862,9 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                 continue
 
             start_idx = self.input_batch.num_tokens_no_spec[req_idx]
-            # Not supporting spec decode yet, assume only 1 new token
             end_idx = start_idx + 1
+            if spec_decode_metadata is not None:
+                end_idx += spec_decode_metadata.draft_lengths_cpu[req_idx]
             assert end_idx <= self.max_model_len, (
                 "Sampled token IDs exceed the max model length. "
                 f"Total number of tokens: {end_idx} > max_model_len: "
@@ -835,7 +875,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             self.input_batch.num_tokens[req_idx] = end_idx
 
             # For placeholder, should be update on next execute.
-            req_state.output_token_ids.extend([0])
+            req_state.output_token_ids.extend([0] * (end_idx - start_idx))
             if logits_indices_selector is None:
                 placeholder_req_id_to_index[req_state.req_id] = req_idx
             else:
@@ -1096,31 +1136,48 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         for req_id in self.input_batch.req_ids[:num_reqs]:
             prompt_logprobs_dict[req_id] = None
 
+        spec_decode_last_sampled_token_id = None
+        spec_decode_num_rejected_tokens = None
         if self.speculative_config:
             with self.maybe_forbid_compile, jax.set_mesh(self.mesh):
+                last_sampled_token_id, num_rejected_tokens = extract_last_sampled_tokens(
+                    spec_decode_metadata, next_tokens,
+                    self.speculative_config.num_speculative_tokens,
+                    self.input_batch.vocab_size, self.max_num_reqs)
                 self.speculative_decoding_manager.propose_draft_token_ids(
                     next_tokens,
                     logits_indices_selector,
+                    last_sampled_token_id,
+                    num_rejected_tokens,
                     discard_sampled_tokens_req_indices,
                     aux_hidden_states,
                     attn_metadata,
+                    bool(self.scheduler_config.async_scheduling),
                     spec_decode_metadata,
                     scheduler_output,
                     input_ids,
                 )
+                spec_decode_last_sampled_token_id = last_sampled_token_id
+                spec_decode_num_rejected_tokens = num_rejected_tokens
 
         # If async scheduler enabled
         if self.scheduler_config.async_scheduling:
             # Get previous results from TPU and replace the placeholder.
             if self._pre_async_results is not None:
-                assert not self.speculative_config and spec_decode_metadata is None, "Async scheduler does not support speculative decoding yet."
                 self._modify_prev_results()
 
             # Set placeholder for next tokens that is not yet generated
             placeholder_req_id_to_index: dict[
                 str, int] = self._update_placeholder(
                     discard_sampled_tokens_req_indices, request_seq_lens,
-                    logits_indices_selector)
+                    spec_decode_metadata, logits_indices_selector)
+
+            spec_decode_next_tokens = None
+            if self.speculative_config:
+                assert spec_decode_last_sampled_token_id is not None
+                spec_decode_next_tokens = concat_last_sampled_tokens_and_draft_tokens(
+                    spec_decode_last_sampled_token_id,
+                    self.speculative_decoding_manager._draft_token_ids)
 
             # Save the previous results
             next_tokens = jax.copy_to_host_async(next_tokens)
@@ -1131,7 +1188,11 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                 discard_sampled_tokens_req_indices=
                 discard_sampled_tokens_req_indices,
                 placeholder_req_id_to_index=placeholder_req_id_to_index,
-                logits_indices_selector=logits_indices_selector)
+                logits_indices_selector=logits_indices_selector,
+                spec_decode_next_tokens=spec_decode_next_tokens,
+                spec_decode_num_rejected_tokens=spec_decode_num_rejected_tokens,
+                spec_decode_metadata=spec_decode_metadata,
+            )
 
             # Return Model output to executor
             model_runner_output = ModelRunnerOutput(
@@ -1153,12 +1214,14 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                 logprobs_tensors=logprobs,
                 expert_indices=expert_indices,
                 total_num_scheduled_tokens=scheduler_output.
-                total_num_scheduled_tokens)
+                total_num_scheduled_tokens,
+                spec_decode_metadata=spec_decode_metadata,
+                runner=self)
             return async_model_runner_output
 
         valid_sampled_token_ids = runner_utils.host_extract_sampled_tokens(
             self, spec_decode_metadata, next_tokens, logits_indices_selector,
-            discard_sampled_tokens_req_indices)
+            discard_sampled_tokens_req_indices, num_reqs)
 
         # Append sampled tokens
         for req_idx, req_state, _ in request_seq_lens:
@@ -1321,42 +1384,86 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
 
     def _prepare_async_token_substitution_indices(
             self, req_ids_dp, scheduled_tokens_per_dp_rank,
-            padded_num_scheduled_tokens_per_dp_rank, dp_size):
+            padded_num_scheduled_tokens_per_dp_rank,
+            num_draft_tokens_per_dp_rank, dp_size):
         """Prepare token substitution indices for async scheduling."""
+        # For input_ids substitution.
         token_in_tpu_cur_input_indices_dp = {}
         token_in_tpu_pre_next_tokens_indices_dp = {}
+        # For SpecDecodeMetadata.draft_token_ids substitution.
+        draft_token_in_tpu_cur_indices_dp = {}
+        draft_token_in_prev_next_tokens_indices_dp = {}
+        spec_decode_enabled = (self.speculative_config is not None)
 
         for dp_rank in range(dp_size):
             token_in_tpu_cur_input_indices_dp[dp_rank] = []
             token_in_tpu_pre_next_tokens_indices_dp[dp_rank] = []
+            draft_token_in_tpu_cur_indices_dp[dp_rank] = []
+            draft_token_in_prev_next_tokens_indices_dp[dp_rank] = []
+
+            num_scheduled_tokens_per_req = scheduled_tokens_per_dp_rank[
+                dp_rank]
+            num_draft_tokens = num_draft_tokens_per_dp_rank[dp_rank]
+            token_in_tpu_cur_input_indices_list = token_in_tpu_cur_input_indices_dp[
+                dp_rank]
+            token_in_tpu_pre_next_tokens_indices_list = token_in_tpu_pre_next_tokens_indices_dp[
+                dp_rank]
+            draft_token_in_tpu_cur_indices_list = draft_token_in_tpu_cur_indices_dp[
+                dp_rank]
+            draft_token_in_prev_next_tokens_indices_list = draft_token_in_prev_next_tokens_indices_dp[
+                dp_rank]
 
             token_offset = padded_num_scheduled_tokens_per_dp_rank * dp_rank
             acc_cur_len = token_offset
+            # TODO(gxd3): support spec-decoding with DP.
+            draft_tokens_acc_cur_len = 0
 
             for i, req_id in enumerate(req_ids_dp[dp_rank]):
-                acc_cur_len += scheduled_tokens_per_dp_rank[dp_rank][i]
+                acc_cur_len += num_scheduled_tokens_per_req[i]
+                draft_tokens_acc_cur_len += num_draft_tokens[i]
                 if req_id not in self._pre_async_results.placeholder_req_id_to_index:
                     continue
 
-                token_in_tpu_cur_input_indices_dp[dp_rank].append(acc_cur_len -
-                                                                  1)
-                token_in_tpu_pre_next_tokens_indices_dp[dp_rank].append(
-                    self._pre_async_results.placeholder_req_id_to_index[req_id]
-                )
+                if not spec_decode_enabled:
+                    token_in_tpu_cur_input_indices_list.append(acc_cur_len - 1)
+                    token_in_tpu_pre_next_tokens_indices_list.append(
+                        self._pre_async_results.
+                        placeholder_req_id_to_index[req_id])
+                else:
+                    max_num_spec_tokens = self.speculative_config.num_speculative_tokens
+                    assert num_scheduled_tokens_per_req[
+                        i] <= max_num_spec_tokens + 1
+                    idx = self._pre_async_results.placeholder_req_id_to_index[
+                        req_id]
 
-        return token_in_tpu_cur_input_indices_dp, token_in_tpu_pre_next_tokens_indices_dp
+                    base_offset = acc_cur_len - num_scheduled_tokens_per_req[i]
+                    for j in range(num_scheduled_tokens_per_req[i]):
+                        token_in_tpu_cur_input_indices_list.append(
+                            base_offset + j)
+                        token_in_tpu_pre_next_tokens_indices_list.append(
+                            idx * (max_num_spec_tokens + 1) + j)
 
-    def _apply_async_token_substitution(self, input_ids,
+                    draft_base_offset = draft_tokens_acc_cur_len - num_draft_tokens[
+                        i]
+                    for j in range(num_draft_tokens[i]):
+                        draft_token_in_tpu_cur_indices_list.append(
+                            draft_base_offset + j)
+                        draft_token_in_prev_next_tokens_indices_list.append(
+                            idx * (max_num_spec_tokens + 1) + j + 1)
+
+        return token_in_tpu_cur_input_indices_dp, token_in_tpu_pre_next_tokens_indices_dp, draft_token_in_tpu_cur_indices_dp, draft_token_in_prev_next_tokens_indices_dp
+
+    def _apply_async_token_substitution(self, input, next_tokens_in_tpu,
                                         token_in_tpu_cur_input_indices,
                                         token_in_tpu_pre_next_tokens_indices):
         """Apply async token substitution if needed."""
         if len(token_in_tpu_cur_input_indices) == 0:
-            return input_ids
+            return input
 
-        idx_pad_len = len(input_ids) - len(token_in_tpu_cur_input_indices)
+        idx_pad_len = len(input) - len(token_in_tpu_cur_input_indices)
 
         # Pad according to the instructions written inside self._substitute_placeholder_token_fn
-        full_range = np.arange(0, len(input_ids), dtype=np.int32)
+        full_range = np.arange(0, len(input), dtype=np.int32)
         missing_values = np.setdiff1d(full_range,
                                       token_in_tpu_cur_input_indices)
         padded_token_in_tpu_cur_input_indices = np.concatenate(
@@ -1366,21 +1473,64 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             token_in_tpu_pre_next_tokens_indices, (0, idx_pad_len),
             mode='constant',
             constant_values=-1).astype(np.int32)
+        placeholder_num = np.array([len(token_in_tpu_cur_input_indices)
+                                    ]).astype(np.int32)
 
         (padded_token_in_tpu_cur_input_indices,
-         padded_token_in_tpu_pre_next_tokens_indices) = device_array(
-             self.mesh, (padded_token_in_tpu_cur_input_indices,
-                         padded_token_in_tpu_pre_next_tokens_indices))
+         padded_token_in_tpu_pre_next_tokens_indices,
+         placeholder_num) = device_array(
+             self.mesh,
+             (padded_token_in_tpu_cur_input_indices,
+              padded_token_in_tpu_pre_next_tokens_indices, placeholder_num))
 
         with self.maybe_forbid_compile:
-            input_ids = self._substitute_placeholder_token_fn(
-                input_ids, padded_token_in_tpu_cur_input_indices,
+            input = self._substitute_placeholder_token_fn(
+                input, padded_token_in_tpu_cur_input_indices,
                 padded_token_in_tpu_pre_next_tokens_indices,
-                self._pre_async_results.next_tokens,
-                jnp.asarray(len(token_in_tpu_cur_input_indices),
-                            dtype=jnp.int32))
+                next_tokens_in_tpu, placeholder_num)
+        return input
 
-        return input_ids
+    def _subtract_num_rejected_tokens(self, seq_lens, positions,
+                                      num_scheduled_tokens_per_req):
+        """Apply rejection-count subtraction to seq_lens and positions if needed.
+
+        `num_computed_tokens_cpu` was advanced on the host assuming every
+        speculatively proposed token from the previous step was accepted. Here
+        we subtract the actual rejection counts on TPU for the requests that
+        ran spec decoding in the previous step.
+        """
+        assert self._pre_async_results is not None
+        assert self._pre_async_results.spec_decode_num_rejected_tokens is not None
+        num_reqs = len(num_scheduled_tokens_per_req)
+        seq_lens_subtract_indices = np.full(self.max_num_reqs,
+                                            -1,
+                                            dtype=np.int32)
+        positions_subtract_indices = np.full(positions.size,
+                                             -1,
+                                             dtype=np.int32)
+
+        acc_cur_len = 0
+        for i, req_id in enumerate(self.input_batch.req_ids[:num_reqs]):
+            acc_cur_len += num_scheduled_tokens_per_req[i]
+            assert req_id is not None
+            if req_id not in self._pre_async_results.placeholder_req_id_to_index:
+                continue
+            idx = self._pre_async_results.placeholder_req_id_to_index[req_id]
+            seq_lens_subtract_indices[i] = idx
+            base_offset = acc_cur_len - num_scheduled_tokens_per_req[i]
+            for j in range(num_scheduled_tokens_per_req[i]):
+                positions_subtract_indices[base_offset + j] = idx
+
+        seq_lens_subtract_indices, positions_subtract_indices = device_array(
+            self.mesh, (seq_lens_subtract_indices, positions_subtract_indices))
+
+        with self.maybe_forbid_compile:
+            seq_lens, positions = _subtract_num_rejected_tokens_fn(
+                seq_lens, positions,
+                self._pre_async_results.spec_decode_num_rejected_tokens,
+                seq_lens_subtract_indices, positions_subtract_indices)
+
+        return seq_lens, positions
 
     def _prepare_inputs(self, scheduler_output: "VllmSchedulerOutput"):
         total_num_scheduled_tokens = scheduler_output.total_num_scheduled_tokens
@@ -1389,6 +1539,9 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         assert num_reqs > 0
 
         dp_size = self.dp_size
+        if self.speculative_config and dp_size > 1:
+            assert "Spec decoding not yet support when dp > 1"
+
         data_parallel_attn_sharding = NamedSharding(
             self.mesh, PartitionSpec(ShardingAxisName.ATTN_DATA))
 
@@ -1405,16 +1558,26 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             self.mm_manager.calc_mrope_positions(scheduler_output)
 
         # Async scheduling: prepare token substitution indices for DP
+        num_draft_tokens = np.zeros(num_reqs, dtype=np.int32)
+        for (req_id, draft_token_ids
+             ) in scheduler_output.scheduled_spec_decode_tokens.items():
+            req_idx = self.input_batch.req_id_to_index[req_id]
+            num_draft_tokens[req_idx] = len(draft_token_ids)
         token_in_tpu_cur_input_indices_dp = {}
         token_in_tpu_pre_next_tokens_indices_dp = {}
+        draft_token_in_tpu_cur_indices_dp = {}
+        draft_token_in_prev_next_tokens_indices_dp = {}
         if self.scheduler_config.async_scheduling and self._pre_async_results is not None:
             # If async previous results exists, we will prepare for the token substitution here
             # The actual substitution will be performed in tpu during later parts of this function.
             (token_in_tpu_cur_input_indices_dp,
-             token_in_tpu_pre_next_tokens_indices_dp
+             token_in_tpu_pre_next_tokens_indices_dp,
+             draft_token_in_tpu_cur_indices_dp,
+             draft_token_in_prev_next_tokens_indices_dp
              ) = self._prepare_async_token_substitution_indices(
                  req_ids_dp, scheduled_tokens_per_dp_rank,
-                 padded_num_scheduled_tokens_per_dp_rank, dp_size)
+                 padded_num_scheduled_tokens_per_dp_rank,
+                 {0: num_draft_tokens}, dp_size)
 
         self.device_buffer.reset()
 
@@ -1579,8 +1742,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                     padded_num_reqs,
                     input_ids_view,
                 ))
-            logits_indices_view[:] = spec_decode_metadata.final_logits_indices.ravel(
-            )
+            logits_indices_view[:] = spec_decode_metadata.final_logits_indices
 
         # Put to device
         sampling_metadata = TPUSupportedSamplingMetadata.from_input_batch(
@@ -1667,6 +1829,13 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         seq_lens = metadata["seq_lens"]
         logits_indices = metadata["logits_indices"]
 
+        # The host-side `num_computed_tokens_cpu` assumes all speculatively
+        # proposed tokens from the previous step were accepted. Subtract the
+        # actual rejection counts from `seq_lens` and `positions` on TPU.
+        if self.speculative_config and self.scheduler_config.async_scheduling and self._pre_async_results is not None:
+            seq_lens, positions = self._subtract_num_rejected_tokens(
+                seq_lens, positions, scheduled_tokens_per_dp_rank[0])
+
         def build_attn(block_tables: jax.Array | None) -> AttentionMetadata:
             attention_metadata_gid = AttentionMetadata(
                 input_positions=positions,
@@ -1679,7 +1848,6 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
 
             # This is for making these cpu buffers hidden during tracing
             attention_metadata_gid.query_start_loc_cpu = query_start_loc_view
-            attention_metadata_gid.seq_lens_cpu = seq_lens_view
             return attention_metadata_gid
 
         attention_metadata: AttentionMetadata | dict[str, AttentionMetadata]
@@ -1702,21 +1870,45 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             # Collect all token indices that need substitution across all DP ranks
             all_token_indices_to_substitute = []
             all_pre_next_tokens_indices = []
+            draft_all_token_indices_to_substitute = []
+            draft_all_pre_next_tokens_indices = []
 
             for dp_rank in range(dp_size):
                 cur_indices = token_in_tpu_cur_input_indices_dp[dp_rank]
                 pre_indices = token_in_tpu_pre_next_tokens_indices_dp[dp_rank]
                 all_token_indices_to_substitute.extend(cur_indices)
                 all_pre_next_tokens_indices.extend(pre_indices)
+                draft_all_token_indices_to_substitute.extend(
+                    draft_token_in_tpu_cur_indices_dp[dp_rank])
+                draft_all_pre_next_tokens_indices.extend(
+                    draft_token_in_prev_next_tokens_indices_dp[dp_rank])
 
-            if len(all_token_indices_to_substitute) > 0:
+            if self.scheduler_config.async_scheduling and self._pre_async_results:
+                if self.speculative_config:
+                    next_tokens = self._pre_async_results.spec_decode_next_tokens
+                else:
+                    next_tokens = self._pre_async_results.next_tokens
                 token_in_tpu_cur_input_indices = np.array(
                     all_token_indices_to_substitute)
                 token_in_tpu_pre_next_tokens_indices = np.array(
                     all_pre_next_tokens_indices)
                 input_ids = self._apply_async_token_substitution(
-                    input_ids, token_in_tpu_cur_input_indices,
+                    input_ids, next_tokens, token_in_tpu_cur_input_indices,
                     token_in_tpu_pre_next_tokens_indices)
+                if spec_decode_metadata:
+                    draft_token_in_tpu_cur_input_indices = np.array(
+                        draft_all_token_indices_to_substitute)
+                    draft_token_in_tpu_pre_next_tokens_indices = np.array(
+                        draft_all_pre_next_tokens_indices)
+                    draft_token_ids = self._apply_async_token_substitution(
+                        spec_decode_metadata.draft_token_ids,
+                        self._pre_async_results.spec_decode_next_tokens,
+                        draft_token_in_tpu_cur_input_indices,
+                        draft_token_in_tpu_pre_next_tokens_indices)
+                    new_md = replace(spec_decode_metadata,
+                                     draft_token_ids=draft_token_ids)
+                    new_md.draft_lengths_cpu = spec_decode_metadata.draft_lengths_cpu
+                    spec_decode_metadata = new_md
 
         num_scheduled_tokens_per_req = np.concatenate([
             np.array(scheduled_tokens_per_dp_rank[dp_rank], dtype=np.int32)

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -1175,7 +1175,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             spec_decode_next_tokens = None
             if self.speculative_config:
                 assert spec_decode_last_sampled_token_id is not None
-                with self.maybe_forbid_compile:
+                with self.maybe_forbid_compile, jax.set_mesh(self.mesh):
                     spec_decode_next_tokens = concat_last_sampled_tokens_and_draft_tokens(
                         spec_decode_last_sampled_token_id,
                         self.speculative_decoding_manager._draft_token_ids)

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -1175,9 +1175,10 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             spec_decode_next_tokens = None
             if self.speculative_config:
                 assert spec_decode_last_sampled_token_id is not None
-                spec_decode_next_tokens = concat_last_sampled_tokens_and_draft_tokens(
-                    spec_decode_last_sampled_token_id,
-                    self.speculative_decoding_manager._draft_token_ids)
+                with self.maybe_forbid_compile:
+                    spec_decode_next_tokens = concat_last_sampled_tokens_and_draft_tokens(
+                        spec_decode_last_sampled_token_id,
+                        self.speculative_decoding_manager._draft_token_ids)
 
             # Save the previous results
             next_tokens = jax.copy_to_host_async(next_tokens)

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -1403,7 +1403,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
 
             num_scheduled_tokens_per_req = scheduled_tokens_per_dp_rank[
                 dp_rank]
-            num_draft_tokens = num_draft_tokens_per_dp_rank[dp_rank]
+            num_draft_tokens = num_draft_tokens_per_dp_rank.get(dp_rank, {})
             token_in_tpu_cur_input_indices_list = token_in_tpu_cur_input_indices_dp[
                 dp_rank]
             token_in_tpu_pre_next_tokens_indices_list = token_in_tpu_pre_next_tokens_indices_dp[
@@ -1420,7 +1420,8 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
 
             for i, req_id in enumerate(req_ids_dp[dp_rank]):
                 acc_cur_len += num_scheduled_tokens_per_req[i]
-                draft_tokens_acc_cur_len += num_draft_tokens[i]
+                if dp_rank == 0:
+                    draft_tokens_acc_cur_len += num_draft_tokens[i]
                 if req_id not in self._pre_async_results.placeholder_req_id_to_index:
                     continue
 

--- a/tpu_inference/runner/utils.py
+++ b/tpu_inference/runner/utils.py
@@ -558,16 +558,14 @@ class SpecDecodeMetadata:
     bonus_logits_indices: jnp.ndarray
     final_logits_indices: jnp.ndarray
 
-    draft_lengths_cpu: Any = field(init=False)
+    draft_lengths_cpu: Any = field(init=False, default=None)
 
 
 def host_extract_sampled_tokens(
         runner, spec_decode_metadata: Optional[SpecDecodeMetadata],
         sampled_output: jnp.ndarray, logits_indices_selector: np.ndarray,
-        discard_sampled_tokens_req_indices: list):
+        discard_sampled_tokens_req_indices: list, num_reqs):
     """host retrieve the sampled tokens for the current step."""
-
-    num_reqs = runner.input_batch.num_reqs
     next_tokens = sampled_output
     if spec_decode_metadata is None:
         next_tokens = np.asarray(jax.device_get(next_tokens))

--- a/tpu_inference/runner/utils.py
+++ b/tpu_inference/runner/utils.py
@@ -564,7 +564,7 @@ class SpecDecodeMetadata:
 def host_extract_sampled_tokens(
         runner, spec_decode_metadata: Optional[SpecDecodeMetadata],
         sampled_output: jnp.ndarray, logits_indices_selector: np.ndarray,
-        discard_sampled_tokens_req_indices: list, num_reqs):
+        discard_sampled_tokens_req_indices: list, num_reqs: int):
     """host retrieve the sampled tokens for the current step."""
     next_tokens = sampled_output
     if spec_decode_metadata is None:

--- a/tpu_inference/spec_decode/jax/utils.py
+++ b/tpu_inference/spec_decode/jax/utils.py
@@ -82,3 +82,10 @@ def extract_last_sampled_tokens(
                                   (0, max_num_seq - batch_size),
                                   constant_values=0)
     return last_sampled_tokens, num_rejected_tokens
+
+
+@jax.jit
+def concat_last_sampled_tokens_and_draft_tokens(last_sampled_tokens,
+                                                draft_tokens):
+    return jnp.concat([last_sampled_tokens[:, None], draft_tokens],
+                      axis=1).reshape(-1)


### PR DESCRIPTION
Make spec decoding compatible with async scheduling.

The key changes are in `tpu_inference/runner/tpu_runner.py`.

Due to async scheduling, in the n-th step's schedule / execute_model, host does not have the n-1-th step's sampled tokens and draft tokens, we'll need to use `_substitute_placeholder_token` HLO to update `input_ids`, `spec_decode_metadata.draft_token_ids.`

Also, `seq-len` & `position` set by the host in the n-th step is not accurate, because host is not aware of num-accepted-draft-tokens in the n-1-th step yet. Need to use `_subtract_num_rejected_tokens_fn` HLO to update `seq-len` & `position` accordingly before calling the target model.

Note that spec-decoding is NOT yet compatible with attn-dp; defer that support to later PR.

xprof before: https://screenshot.googleplex.com/9a5ehQMMtgw8uBC
xprof with this PR: https://screenshot.googleplex.com/66jVTnShKKpahpA (no TPU bubble now)

# Tests
unit test.
added parameterized test in `tests/e2e/test_speculative_decoding.py` for E2E coverage.
Verified acceptance rate of spec bench dataset: https://paste.googleplex.com/6748805522391040

