### PR TITLE
[spec decoding] seq-len in drafter's input for padding seq should be 0 to avoid wasteful work in paged-attn

### DIFF
--- a/tests/spec_decode/test_eagle3.py
+++ b/tests/spec_decode/test_eagle3.py
@@ -138,9 +138,9 @@ def test_prepare_inputs():
     expected_new_qsl = np.zeros(max_num_seqs + 1, dtype=np.int32)
     num_tokens_per_req = np.zeros(max_num_seqs, dtype=np.int32)
     num_tokens_per_req[:num_reqs] = [3, 4, 3]
-    # The implementation sets padded query lengths to 1, and rejected tokens
+    # The implementation sets padded query lengths to 0, and rejected tokens
     # are 0 for padded requests.
-    num_tokens_per_req[num_reqs:] = 1
+    num_tokens_per_req[num_reqs:] = 0
     expected_new_qsl[1:] = np.cumsum(num_tokens_per_req)
 
     expected_new_seq_lens = np.zeros(max_num_seqs, dtype=np.int32)

--- a/tpu_inference/spec_decode/jax/eagle3.py
+++ b/tpu_inference/spec_decode/jax/eagle3.py
@@ -149,12 +149,12 @@ class Eagle3Proposer:
         # scatter update of a static size, using a mask to handle the dynamic part.
         max_num_reqs = last_token_indices.shape[0]
         mask = jnp.arange(max_num_reqs) < num_reqs
+        last_token_indices = jnp.where(mask, last_token_indices,
+                                       last_token_indices[num_reqs - 1])
 
-        # For padded requests (where mask is False), we use the original value from
-        # the rolled array, making the update a no-op for them.
-        original_values_at_indices = rolled_input_ids[last_token_indices]
+        # Mask out the update for the padded requests (where mask is False).
         values_to_set = jnp.where(mask, next_token_ids,
-                                  original_values_at_indices)
+                                  next_token_ids[num_reqs - 1])
 
         input_ids = rolled_input_ids.at[last_token_indices].set(values_to_set)
 
@@ -316,7 +316,10 @@ class Eagle3Proposer:
         # For padded requests, the query length should be 0.
         query_len_per_req = jnp.where(
             jnp.arange(query_len_per_req.shape[0]) < num_reqs,
-            query_len_per_req, 1)
+            query_len_per_req, 0)
+        num_rejected_tokens = jnp.where(
+            jnp.arange(num_rejected_tokens.shape[0]) < num_reqs,
+            num_rejected_tokens, 0)
         # num_tokens_per_req = [q1 - n1, q2 - n2, ...]
         num_tokens_per_req = (query_len_per_req - num_rejected_tokens)
 


### PR DESCRIPTION
seq-len in drafter's input for padding seqs should be 0 to avoid wasteful work in paged-attn

# Tests
unit tests.
