### PR TITLE
Fix Mistral Small 4 FP8 loading and dynamically register V2 weight loading

### DIFF
--- a/tpu_inference/layers/common/process_weights/moe_weights.py
+++ b/tpu_inference/layers/common/process_weights/moe_weights.py
@@ -879,10 +879,21 @@ def _requant_expert_batch_fn(
     else:
         w2_s_batch = None
 
-    w13_fp32 = dequantize_tensor(w13_batch,
-                                 w13_s_batch, (1, 2),
-                                 jnp.float32,
-                                 block_size=weight_block_size)
+    if weight_block_size is None and w13_s_batch is not None and w13_s_batch.ndim == 2 and w13_s_batch.shape[
+            -1] == 2:
+        # Mistral Small 4 manual splitting for fused per-channel scales during TPU scan
+        w1 = w13_batch[:, :orig_intermediate_size, :]
+        w3 = w13_batch[:, orig_intermediate_size:, :]
+        s1 = w13_s_batch[:, 0]
+        s3 = w13_s_batch[:, 1]
+        w1_fp32 = dequantize_tensor(w1, s1, (1, 2), jnp.float32)
+        w3_fp32 = dequantize_tensor(w3, s3, (1, 2), jnp.float32)
+        w13_fp32 = jnp.concatenate([w1_fp32, w3_fp32], axis=1)
+    else:
+        w13_fp32 = dequantize_tensor(w13_batch,
+                                     w13_s_batch, (1, 2),
+                                     jnp.float32,
+                                     block_size=weight_block_size)
     w2_fp32 = dequantize_tensor(w2_batch,
                                 w2_s_batch, (1, 2),
                                 jnp.float32,

--- a/tpu_inference/layers/vllm/quantization/awq.py
+++ b/tpu_inference/layers/vllm/quantization/awq.py
@@ -20,6 +20,7 @@ import torch
 from jax.sharding import Mesh, PartitionSpec
 from torch.nn.parameter import Parameter
 from torchax.interop import jax_view, torch_view
+from vllm.model_executor.layers import linear
 from vllm.model_executor.layers.fused_moe import FusedMoE, FusedMoEMethodBase
 from vllm.model_executor.layers.fused_moe.activation import MoEActivation
 from vllm.model_executor.layers.fused_moe.layer import \
@@ -89,6 +90,10 @@ class VllmAWQConfig(AWQConfig, VllmQuantConfig):
 
 
 class VllmAWQLinearMethod(AWQLinearMethod):
+
+    # Dynamically register this method to support weight_loader_v2 in vLLM.
+    if "VllmAWQLinearMethod" not in linear.WEIGHT_LOADER_V2_SUPPORTED:
+        linear.WEIGHT_LOADER_V2_SUPPORTED.append("VllmAWQLinearMethod")
 
     def __init__(self, quant_config: VllmAWQConfig,
                  linear_config: VllmQuantLinearConfig):

--- a/tpu_inference/layers/vllm/quantization/fp8.py
+++ b/tpu_inference/layers/vllm/quantization/fp8.py
@@ -33,7 +33,8 @@ from vllm.model_executor.layers.quantization.utils.quant_utils import \
 
 from tpu_inference.layers.common.moe import MoEBackend
 from tpu_inference.layers.common.process_weights.linear_weights import (
-    shard_linear_weights, to_parameter_list)
+    LinearWeights, process_linear_weights, shard_linear_weights,
+    to_parameter_list)
 from tpu_inference.layers.common.process_weights.moe_weights import (
     FusedMoEWeights, process_quantized_moe_weights, shard_moe_weights)
 from tpu_inference.layers.common.quant_methods import FP8
@@ -96,6 +97,11 @@ class VllmFp8Config(vllm_fp8.Fp8Config, VllmQuantConfig):
 class VllmFp8LinearMethod(vllm_fp8.Fp8LinearMethod,
                           common_fp8.Fp8LinearMethod):
 
+    # Dynamically register this method to support weight_loader_v2 in vLLM.
+    # This avoids hardcoding TPU-specific methods in the upstream vLLM repository.
+    if "VllmFp8LinearMethod" not in vllm_linear.WEIGHT_LOADER_V2_SUPPORTED:
+        vllm_linear.WEIGHT_LOADER_V2_SUPPORTED.append("VllmFp8LinearMethod")
+
     def __init__(
         self,
         quant_config: VllmFp8Config,
@@ -145,19 +151,25 @@ class VllmFp8LinearMethod(vllm_fp8.Fp8LinearMethod,
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
         assert isinstance(layer, vllm_linear.LinearBase)
 
-        assert self.block_quant
         weight = t2j(layer.weight, use_dlpack=False)
         weight = jnp.transpose(weight)
         delattr(layer, "weight")
 
-        weight_scale_inv = layer.weight_scale_inv
-        # Float8_e8m0fnu (ue8m0) scales cannot be converted via numpy in t2j.
-        # TODO: consider get rid of the f32 conversion, to optimize the HBM usage.
-        if weight_scale_inv.dtype == torch.float8_e8m0fnu:
-            weight_scale_inv = weight_scale_inv.to(torch.float32)
-        weight_scale = t2j(weight_scale_inv, use_dlpack=False)
-        weight_scale = jnp.transpose(weight_scale)
-        delattr(layer, "weight_scale_inv")
+        if self.block_quant:
+            weight_scale_inv = layer.weight_scale_inv
+            # Float8_e8m0fnu (ue8m0) scales cannot be converted via numpy in t2j.
+            # TODO: consider get rid of the f32 conversion, to optimize the HBM usage.
+            if weight_scale_inv.dtype == torch.float8_e8m0fnu:
+                weight_scale_inv = weight_scale_inv.to(torch.float32)
+            weight_scale = t2j(weight_scale_inv, use_dlpack=False)
+            weight_scale = jnp.transpose(weight_scale)
+            delattr(layer, "weight_scale_inv")
+        else:
+            weight_scale = layer.weight_scale
+            if weight_scale.dtype == torch.float8_e8m0fnu:
+                weight_scale = weight_scale.to(torch.float32)
+            weight_scale = t2j(weight_scale, use_dlpack=False)
+            delattr(layer, "weight_scale")
 
         if layer.bias is not None and not layer.skip_bias_add:
             if layer.return_bias:
@@ -167,23 +179,51 @@ class VllmFp8LinearMethod(vllm_fp8.Fp8LinearMethod,
         else:
             bias = None
 
-        weights = common_fp8.process_blockwise_fp8_linear_weights(
-            weight,
-            weight_scale,
-            bias=bias,
-            weight_block_size=tuple(self.weight_block_size),
-            requant_block_size=self.linear_config.requant_block_size,
-            output_sizes=tuple(self.linear_config.output_sizes),
-            requant_weight_dtype=self.linear_config.requant_weight_dtype,
-            fuse_matmuls=self.linear_config.fuse_matmuls,
-            n_shards=self.linear_config.n_shards,
-            enable_kernel=self.linear_config.enable_quantized_matmul_kernel)
+        if self.block_quant:
+            weights = common_fp8.process_blockwise_fp8_linear_weights(
+                weight,
+                weight_scale,
+                bias=bias,
+                weight_block_size=tuple(self.weight_block_size),
+                requant_block_size=self.linear_config.requant_block_size,
+                output_sizes=tuple(self.linear_config.output_sizes),
+                requant_weight_dtype=self.linear_config.requant_weight_dtype,
+                fuse_matmuls=self.linear_config.fuse_matmuls,
+                n_shards=self.linear_config.n_shards,
+                enable_kernel=self.linear_config.enable_quantized_matmul_kernel
+            )
+        else:
+            if self.linear_config.fuse_matmuls and weight_scale.ndim == 1:
+                # Handle fused scales for non-block quantized weights (e.g. Mistral Small 4).
+                # Models might provide a single 1D scale vector for a fused layer
+                # (like qkv_proj where there are multiple output partitions).
+                # We need to replicate these scales so that `process_linear_weights`
+                # can slice them correctly alongside the concatenated weights.
+                weight_scale = jnp.concatenate([
+                    jnp.full((size, ), s) for size, s in zip(
+                        self.linear_config.output_sizes, weight_scale)
+                ])
+
+            weights = process_linear_weights(
+                LinearWeights(
+                    weight=weight,
+                    weight_scale=weight_scale,
+                    zero_point=None,
+                    bias=bias,
+                ),
+                fused=self.linear_config.fuse_matmuls,
+                output_sizes=tuple(self.linear_config.output_sizes),
+                reorder_size=self.linear_config.n_shards,
+                per_tensor=weight_scale.ndim == 0,
+            )
+
         weights = torch_view(
             shard_linear_weights(
                 weights,
                 mesh=self.linear_config.mesh,
                 weight_p_spec=self.linear_config.weight_sharding,
                 bias_p_spec=self.linear_config.bias_sharding,
+                per_tensor=not self.block_quant,
             ))
 
         if self.linear_config.fuse_matmuls:
@@ -259,14 +299,18 @@ class VllmFp8MoEMethod(vllm_fp8.Fp8MoEMethod):
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
         assert isinstance(layer, FusedMoE)
 
-        assert self.block_quant
         assert not self.moe.has_bias
 
         w13_weight = t2j(layer.w13_weight, use_dlpack=False)
-        w13_weight_scale = t2j(layer.w13_weight_scale_inv, use_dlpack=False)
-
         w2_weight = t2j(layer.w2_weight, use_dlpack=False)
-        w2_weight_scale = t2j(layer.w2_weight_scale_inv, use_dlpack=False)
+
+        if self.block_quant:
+            w13_weight_scale = t2j(layer.w13_weight_scale_inv,
+                                   use_dlpack=False)
+            w2_weight_scale = t2j(layer.w2_weight_scale_inv, use_dlpack=False)
+        else:
+            w13_weight_scale = t2j(layer.w13_weight_scale, use_dlpack=False)
+            w2_weight_scale = t2j(layer.w2_weight_scale, use_dlpack=False)
 
         # TODO: do we need to support bias?
         input_weights = FusedMoEWeights(
@@ -296,10 +340,13 @@ class VllmFp8MoEMethod(vllm_fp8.Fp8MoEMethod):
         layer.w13_weight = Parameter(weights.w13_weight, requires_grad=False)
         layer.w2_weight = Parameter(weights.w2_weight, requires_grad=False)
 
-        layer.w13_weight_scale_inv = Parameter(weights.w13_weight_scale,
-                                               requires_grad=False)
-        layer.w2_weight_scale_inv = Parameter(weights.w2_weight_scale,
-                                              requires_grad=False)
+        # Use setattr to dynamically assign the correct scale parameter name
+        # based on the quantization type. vLLM uses 'weight_scale_inv' for
+        # block-quantized scales and 'weight_scale' for per-tensor/per-channel scales.
+        setattr(layer, f"w13_{self.weight_scale_name}",
+                Parameter(weights.w13_weight_scale, requires_grad=False))
+        setattr(layer, f"w2_{self.weight_scale_name}",
+                Parameter(weights.w2_weight_scale, requires_grad=False))
 
     def apply_monolithic(
         self,
@@ -309,12 +356,16 @@ class VllmFp8MoEMethod(vllm_fp8.Fp8MoEMethod):
         input_ids: torch.Tensor | None = None,
     ) -> torch.Tensor:
 
+        # Use getattr to retrieve the scales dynamically since the attribute
+        # name varies depending on if block quantization is active.
         weights = FusedMoEWeights(
             w13_weight=jax_view(layer.w13_weight),
-            w13_weight_scale=jax_view(layer.w13_weight_scale_inv),
+            w13_weight_scale=jax_view(
+                getattr(layer, f"w13_{self.weight_scale_name}")),
             w13_bias=jax_view(layer.w13_bias) if self.moe.has_bias else None,
             w2_weight=jax_view(layer.w2_weight),
-            w2_weight_scale=jax_view(layer.w2_weight_scale_inv),
+            w2_weight_scale=jax_view(
+                getattr(layer, f"w2_{self.weight_scale_name}")),
             w2_bias=jax_view(layer.w2_bias) if self.moe.has_bias else None,
         )
         return vllm_moe_apply(layer=layer,

--- a/tpu_inference/layers/vllm/quantization/unquantized.py
+++ b/tpu_inference/layers/vllm/quantization/unquantized.py
@@ -199,6 +199,11 @@ class VllmUnquantizedLinearMethod(vllm_linear.UnquantizedLinearMethod,
                                   common_unquantized.UnquantizedLinearMethod,
                                   VllmQuantizationMethod):
 
+    # Dynamically register this method to support weight_loader_v2 in vLLM.
+    if "VllmUnquantizedLinearMethod" not in vllm_linear.WEIGHT_LOADER_V2_SUPPORTED:
+        vllm_linear.WEIGHT_LOADER_V2_SUPPORTED.append(
+            "VllmUnquantizedLinearMethod")
+
     def __init__(self, linear_config: VllmQuantLinearConfig):
         super().__init__(linear_config)
 


### PR DESCRIPTION
# Description

Adds support on Ironwood TPUs for mistral small 4. Specifically:

* Dynamically register TPU quantization methods (`VllmFp8LinearMethod`, `VllmAWQLinearMethod`, `VllmUnquantizedLinearMethod`) into vLLM's `WEIGHT_LOADER_V2_SUPPORTED` list. This resolves AssertionErrors during weight loading by properly handling parameter-level sharding for PerTensorScaleParameter without requiring upstream vLLM changes.
* Updated `VllmFp8LinearMethod` to correctly replicate and broadcast 1D per-channel weight scales across partitioned output_sizes for fused linear layers (e.g., `qkv_proj`).
* Implemented a workaround in `process_fp8_moe_weights` to handle non-block-quantized fused expert weights. The logic now safely slices the fused w13 tensor into w1 and w3, dequantizes them individually with their respective 1D scales, and re-concatenates them.
* Refactored `VllmFp8MoEMethod` to use `getattr` and `setattr` to dynamically target the correct weight scale attribute (`weight_scale_inv` for block quantization vs `weight_scale` for per-channel) during parameter assignment and application.

# Tests

Running on v7x-8 (4 chips).

Server startup:

```bash
VLLM_TPU_PATCH_MM_EMBEDDINGS=1 \
VLLM_DISABLE_SHARED_EXPERTS_STREAM=0 \
MOE_REQUANTIZE_BLOCK_SIZE=512 \
NEW_MODEL_DESIGN=1 \
MODEL_IMPL_TYPE=vllm \
HF_HOME="/mnt/disks/persist/hf" \
TPU_BACKEND_TYPE=jax \
vllm serve \
    --model mistralai/Mistral-Small-4-119B-2603 \
    --download-dir /mnt/disks/persist/hf/hub \
    --max-model-len 10240 \
    --max-num-batched-tokens 4096 \
    --max-num-seqs 16 \
    --no-enable-prefix-caching \
    --tensor-parallel-size 8 \
    --kv-cache-dtype "fp8" \
    --no-async-scheduling \
    --gpu-memory-utilization 0.90 \
    --enable-expert-parallel \
    --additional_config='{"sharding": {"sharding_strategy": {"enable_dp_attention": true}}}' \
    --trust-remote-code \
    --port 8000
```

Basic test:

```bash
$ curl http://localhost:8000/v1/chat/completions     -H "Content-Type: application/json"     -d '{
      "model": "mistralai/Mistral-Small-4-119B-2603",
      "messages": [
        {"role": "system", "content": "You are a helpful assistant."},
        {"role": "user", "content": "What are the top 5 most popular programming languages? Be brief."}
      ],
      "temperature": 0.7
}'
{"id":"chatcmpl-98620c609f4ffbd3","object":"chat.completion","created":1777413283,"model":"mistralai/Mistral-Small-4-119B-2603","choices":[{"index":0,"message":{"role":"assistant","content":"Here are the top 5 most popular programming languages as of 2023, based on various rankings (TIOBE, PYPL, Stack Overflow, etc.):\n\n1. **Python** – Versatile, easy to learn, and widely used in AI, web dev, and data science.\n2. **JavaScript** – Dominates web development (frontend & backend with Node.js).\n3. **Java** – Strong in enterprise applications, Android, and large systems.\n4. **C#** – Popular for game development (Unity), Windows apps, and backend services.\n5. **C/C++** – High-performance applications (systems programming, game engines, embedded systems).\n\n*Note: Rankings fluctuate; others like Go, Rust, and Swift are also widely used.*","refusal":null,"annotations":null,"audio":null,"function_call":null,"tool_calls":[],"reasoning":null},"logprobs":null,"finish_reason":"stop","stop_reason":null,"token_ids":null}],"service_tier":null,"system_fingerprint":null,"usage":{"prompt_tokens":37,"total_tokens":198,"completion_tokens":161,"prompt_tokens_details":null},"prompt_logprobs":null,"prompt_token_ids":null,"kv_transfer_params":null}

$ curl http://localhost:8000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
    "model": "mistralai/Mistral-Small-4-119B-2603",
    "messages": [
      {
        "role": "user",
        "content": [
          { "type": "text", "text": "What is in this image?" },
          {
            "type": "image_url",
            "image_url": { "url": "https://a-z-animals.com/media/swan-3.jpg" }
          }
        ]
      }
    ],
    "max_tokens": 50
  }'
{"id":"chatcmpl-895d05a19a23b4d5","object":"chat.completion","created":1777413473,"model":"mistralai/Mistral-Small-4-119B-2603","choices":[{"index":0,"message":{"role":"assistant","content":"The image depicts a person engaging in water activities, possibly kite surfing or wakeboarding, and performing a jump in the air. They are above the surface of a calm body of water and above a bodyboard. The person's attire includes a","refusal":null,"annotations":null,"audio":null,"function_call":null,"tool_calls":[],"reasoning":null},"logprobs":null,"finish_reason":"length","stop_reason":null,"token_ids":null}],"service_tier":null,"system_fingerprint":null,"usage":{"prompt_tokens":909,"total_tokens":959,"completion_tokens":50,"pr
```

Quick benchmark:

```bash
============ Serving Benchmark Result ============
Successful requests:                     320
Failed requests:                         0
Benchmark duration (s):                  60.27
Total input tokens:                      327680
Total generated tokens:                  327680
Request throughput (req/s):              5.31
Output token throughput (tok/s):         5436.44
Peak output token throughput (tok/s):    7168.00
Peak concurrent requests:                320.00
Total token throughput (tok/s):          10872.88
---------------Time to First Token----------------
Mean TTFT (ms):                          18213.89
Median TTFT (ms):                        22157.85
P99 TTFT (ms):                           43108.79
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          19.28
Median TPOT (ms):                        19.85
P99 TPOT (ms):                           20.25
---------------Inter-token Latency----------------
Mean ITL (ms):                           19.28
Median ITL (ms):                         17.96
P99 ITL (ms):                            20.57
==================================================
```

Correctness test:

```bash
$ lm_eval --model local-completions \
	--model_args model=mistralai/Mistral-Small-4-119B-2603,base_url=http://localhost:8000/v1/completions,num_concurrent=16,max_length=5120,tokenizer=mistralai/Mistral-Nemo-Instruct-2407 \
	--tasks gsm8k  --apply_chat_template --num_fewshot 8 --limit 200

|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|-----|------:|----------------|-----:|-----------|---|----:|---|-----:|
|gsm8k|      3|flexible-extract|     8|exact_match|↑  |0.905|±  |0.0208|
|     |       |strict-match    |     8|exact_match|↑  |0.805|±  |0.0281|
```

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
