### PR TITLE
Display the actual error during wait for server startup

### DIFF
--- a/tests/e2e/benchmarking/bench_utils.sh
+++ b/tests/e2e/benchmarking/bench_utils.sh
@@ -44,7 +44,8 @@ waitForServerReady() {
         fi
 
         if grep -Eq "$error_regex" "$LOG_FILE"; then
-            echo "FATAL ERROR DETECTED: The server log contains a fatal error pattern."
+            echo "FATAL ERROR DETECTED. Last 100 lines of log:"
+            tail -n 100 "$LOG_FILE"
             # Call cleanup and exit (cleanup must be handled by the calling script's trap)
             exit 1
         fi


### PR DESCRIPTION
# Description

Currently, waitForServerReady exit when an unrecoverable error is detected but doesn't actually log out the error. This PR address that

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
