### PR TITLE
[Perf] flax_nnx: pre-flatten nnx.State to skip per-dispatch _variable_flatten

### DIFF
--- a/tpu_inference/models/common/model_loader.py
+++ b/tpu_inference/models/common/model_loader.py
@@ -352,6 +352,13 @@ def get_flax_model(
     # https://flax.readthedocs.io/en/latest/guides/performance.html
     graphdef, state = nnx.split(jit_model)
 
+    # Capture the nnx.State treedef once. `run_model` accepts a flat tuple
+    # of array leaves at dispatch time and reconstructs the state via this
+    # treedef. The runner does the flatten of `state` once at init, which
+    # avoids the per-call `nnx.Variable` pytree traversal that otherwise
+    # costs ~17 ms/step on Gemma-4-31B decode at TP=2.
+    _state_treedef = jax.tree_util.tree_structure(state)
+
     @jax.jit(
         out_shardings=(
             kv_cache_sharding,
@@ -359,12 +366,13 @@ def get_flax_model(
             hidden_states_sharding,  # aux hidden states
             None,  # expert ids
         ),
-        donate_argnums=2,  # 0 is graphdef, 1 is state, 2 is kv_cache
+        donate_argnums=1,  # 0 is state_leaves, 1 is kv_cache
         static_argnums=(
-            7, 10, 11
-        ),  #7 is layer_name_to_kvcache_index, 10 is is_first_rank, 11 is is_last_rank
+            6, 9, 10
+        ),  # 6 is layer_name_to_kvcache_index, 9 is is_first_rank, 10 is is_last_rank
     )
-    def run_model(graphdef, state, *args):
+    def run_model(state_leaves, *args):
+        state = jax.tree_util.tree_unflatten(_state_treedef, state_leaves)
         model = nnx.merge(graphdef, state)
         return model(*args)
 
@@ -433,9 +441,12 @@ def get_flax_model(
     model = nnx.merge(graphdef, state)
     precompile_vision_encoder_fn = getattr(model, "precompile_vision_encoder",
                                            None)
-    model_fn = functools.partial(
-        run_draft_model, graphdef) if is_draft_model else functools.partial(
-            run_model, graphdef)
+    # For the draft path, graphdef is still passed positionally (signature
+    # unchanged). For the main path, graphdef and the state treedef are both
+    # captured in the run_model closure; the runner passes pre-flattened
+    # `state_leaves` as the first positional arg.
+    model_fn = functools.partial(run_draft_model,
+                                 graphdef) if is_draft_model else run_model
     compute_logits_fn = functools.partial(run_compute_logits, graphdef)
     embed_multimodal_fn = functools.partial(run_embed_multimodal, graphdef)
     embed_input_ids_fn = functools.partial(run_embed_input_ids, graphdef)

--- a/tpu_inference/runner/compilation_manager.py
+++ b/tpu_inference/runner/compilation_manager.py
@@ -289,7 +289,7 @@ class CompilationManager:
             self._run_compilation(
                 name,
                 model_fn_wrapper,
-                self.runner.state,
+                self.runner.state_leaves,
                 self.runner.kv_caches,
                 input_ids,
                 attention_metadata,

--- a/tpu_inference/runner/lora_utils.py
+++ b/tpu_inference/runner/lora_utils.py
@@ -16,7 +16,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import jax
 import numpy as np
+from flax import nnx
 from torchax.interop import jax_view
 from vllm.lora.layers.base_linear import BaseLinearLayerWithLoRA
 from vllm.lora.request import LoRARequest
@@ -59,6 +61,15 @@ class LoraUtils:
         params_and_buffers = update_lora(
             self.runner.model.model, initial_params_buffers=self.runner.state)
         self.runner.state = jax_view(params_and_buffers)
+        # Keep the dispatch-side view in sync: `model_fn` etc. take
+        # `state_leaves` as their first arg, which for vllm-impl aliases
+        # `state`. The LoRA load above reassigned `state` to a new dict, so
+        # the prior `state_leaves` reference is stale.
+        if isinstance(self.runner.state, nnx.State):
+            self.runner.state_leaves = tuple(
+                jax.tree_util.tree_leaves(self.runner.state))
+        else:
+            self.runner.state_leaves = self.runner.state
 
     def extract_lora_metadata(self):
         if self.runner.lora_config is None:

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -615,6 +615,14 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         self.pooler_fn = model.pooler_fn
         self.combine_hidden_states_fn = model.combine_hidden_states_fn
         self.state = model.state
+        # For the flax_nnx path, `model_fn` (== `run_model`) accepts a flat
+        # tuple of array leaves and reconstructs the nnx.State inside the
+        # jit. Pre-flatten here so subsequent dispatches skip the per-call
+        # walk of `nnx.Variable` wrappers
+        if isinstance(self.state, nnx.State):
+            self.state_leaves = tuple(jax.tree_util.tree_leaves(self.state))
+        else:
+            self.state_leaves = self.state
         self.lora_manager = model.lora_manager
         self.model = model.model
 
@@ -919,7 +927,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                 # but one of them would be `None`
                 (self.kv_caches, hidden_states, aux_hidden_states,
                  expert_indices) = self.model_fn(
-                     self.state,
+                     self.state_leaves,
                      self.kv_caches,
                      input_ids,
                      attn_metadata,
@@ -1814,6 +1822,12 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             mappings=mappings,
             transpose_keys=transpose_keys,
             shard=shard)
+        # Keep the dispatch-side view in sync with the updated state so
+        # subsequent jit dispatches see the new weights.
+        if isinstance(self.state, nnx.State):
+            self.state_leaves = tuple(jax.tree_util.tree_leaves(self.state))
+        else:
+            self.state_leaves = self.state
 
     def _get_padded_total_tokens(
             self, scheduler_output: "VllmSchedulerOutput") -> int:


### PR DESCRIPTION
## Summary

#2607 shows host side dispatch overhead

Avoid the per-jit-dispatch `_variable_flatten` Python callback (~7,600
calls per Gemma-4-31B-it decode step) by flattening `nnx.State` once at
init and reconstructing the state inside the jit via a closure-captured
treedef. This closes the host-side dispatch gap that was making the
`flax_nnx` decode path host-bound vs the `vllm` impl.

## Mechanism

- `get_flax_model` (`tpu_inference/models/common/model_loader.py`)
  captures `_state_treedef = jax.tree_util.tree_structure(state)` once,
  right after `nnx.split(jit_model)`.
- `run_model` accepts a flat tuple `state_leaves` and reconstructs
  state via `jax.tree_util.tree_unflatten(_state_treedef, state_leaves)`
  + `nnx.merge(graphdef, state)` inside the jit. The reconstruction is
  traced once and cached, so subsequent dispatches skip the Python walk
  of `nnx.Variable` wrappers entirely.
- Donation indices shifted (`donate_argnums=1`, `static_argnums=(6,9,10)`)
  to reflect the dropped `graphdef` positional.
- `TPUModelRunner` (`tpu_inference/runner/tpu_runner.py`) pre-flattens
  `model.state` into `self.state_leaves` at load time and re-flattens
  after weight-mutating events (LoRA reload). The compilation manager
  and `_execute_model` pass `self.state_leaves` instead of `self.state`.
- Falls through `isinstance(self.state, nnx.State)` for the `vllm` impl
  — that path is functionally unchanged.

## Throughput delta — flax_nnx (TPU v7x, TP=2, fp8 KV cache)

Δ columns are vs the prior baseline; numbers are from #2607 .

| Workload | Metric | Gemma-4-31B-it | Δ | Qwen3-32B | Δ |
|---|---|---:|---:|---:|---:|
| **MMMU-Pro** (1730 req, conc=32) | req/s | 1.37 | **+63%** | — | — |
|  | total tok/s | 1866 | **+86%** | — | — |
|  | accuracy | 0.7064 | −0.6pt | — | — |
| **MMLU** (14042 req) | total tok/s | 21535 | +4% | 22666 | +0.3% |
|  | accuracy | 0.8465 | +0.4pt | 0.812 | −0.0pt |
| **Image only** (320 req, 512×512 → 1 out) | req/s | 20.30 | **+33%** | — | — |
|  | total tok/s | 5523 | **+33%** | — | — |
|  | mean TTFT (ms) | 10038 | **−33%** | — | — |
| **Prefill only** (320 req, 1024→1) | total tok/s | 22420 | +4% | 23847 | +0.3% |
| **Decode only** (320 req, 1→1024) | output tok/s | **5810** | **+79%** | **8230** | **+68%** |
|  | mean TPOT (ms) | **28.90** | **−42%** | **20.90** | **−37%** |

Headline: decode (the targeted workload) — Gemma flax_nnx TPOT
50.10 → **28.90 ms (−42%)**, throughput +79%; Qwen3 flax_nnx TPOT
33.45 → **20.90 ms (−37%)**, throughput +68%. Prefill-bound rows are
within ±6% as expected (the fix is host-side dispatch, doesn't touch
the compute path). Accuracy unchanged within run variance.

## Test plan
- [x] Decode-only (1 in → 1024 out, batch 320) — Gemma-4-31B-it + Qwen3-32B, 320/320 success
- [x] Prefill-only (1024 in → 1 out) — Gemma + Qwen3, 320/320 success
- [x] MMLU (14042 req) — Gemma + Qwen3, accuracy unchanged
- [x] MMMU-Pro (1730 req, conc=32) — Gemma, accuracy 0.7064 (baseline 0.7127)
- [x] Image-only (0 txt + 512×512 → 1 out) — Gemma, 320/320 success