### PR TITLE
Add DECODE_ONLY mode support within bm workflow

### DIFF
--- a/.buildkite/benchmark/scripts/generate_decode_only_bm_dataset.py
+++ b/.buildkite/benchmark/scripts/generate_decode_only_bm_dataset.py
@@ -63,7 +63,13 @@ def main():
     with open(args.output_file, "w") as f:
         for i in range(args.num_prompts):
             prompt_ids = distinct_prompts[i % args.num_distinct]
-            json_record = {"prompt_token_ids": prompt_ids}
+            # vLLM's dataset parser strictly requires a 'prompt' key to pass schema validation
+            # 'prompt_token_ids' will override it.
+            json_record = {
+                "prompt":
+                f"decode_only_dummy_bypass_seq_{i % args.num_distinct}",
+                "prompt_token_ids": prompt_ids
+            }
             f.write(json.dumps(json_record) + "\n")
 
     print(

--- a/.buildkite/benchmark/scripts/run_bm.sh
+++ b/.buildkite/benchmark/scripts/run_bm.sh
@@ -172,6 +172,100 @@ contains_element () {
   return 1
 }
 
+# ---------------------------------------------------------
+# DECODE_ONLY Mode Configuration Validation & Dataset Injection
+# ---------------------------------------------------------
+if [[ "${DECODE_ONLY:-false}" == "true" ]]; then
+    echo "====================================================================="
+    echo "[INFO] DECODE_ONLY mode activated. Validating configuration..."
+    
+    # Extract configurations from SERVER_CMD
+    MAX_NUM_SEQS=""
+    PREFIX_CACHING_ENABLED="false"
+    for i in "${!SERVER_CMD[@]}"; do
+        arg="${SERVER_CMD[$i]}"
+        if [[ "$arg" == "--max-num-seqs" ]]; then
+            MAX_NUM_SEQS="${SERVER_CMD[i+1]}"
+        elif [[ "$arg" == --max-num-seqs=* ]]; then
+            MAX_NUM_SEQS="${arg#*=}"
+        elif [[ "$arg" == "--enable-prefix-caching" ]]; then
+            PREFIX_CACHING_ENABLED="true"
+        fi
+    done
+
+    # Read DECODE_INPUT_LEN directly from the environment variable
+    DECODE_INPUT_LEN="${INPUT_LEN:-}"
+
+    # Extract configurations from CLIENT_CMD for dataset validations
+    DATASET_NAME_VALID="false"
+    HAS_DATASET_PATH="false"
+    for i in "${!CLIENT_CMD[@]}"; do
+        arg="${CLIENT_CMD[$i]}"
+        if [[ "$arg" == "--dataset-name" && "${CLIENT_CMD[i+1]}" == "custom" ]]; then
+            DATASET_NAME_VALID="true"
+        elif [[ "$arg" == "--dataset-name=custom" ]]; then
+            DATASET_NAME_VALID="true"
+        elif [[ "$arg" == "--dataset-path" || "$arg" == --dataset-path=* ]]; then
+            HAS_DATASET_PATH="true"
+        fi
+    done
+
+    # Assertions
+    if [[ -z "$MAX_NUM_SEQS" ]]; then
+        echo "[ERROR] DECODE_ONLY validation failed: Missing '--max-num-seqs' in SERVER_CMD."
+        echo "Reason: The exact cache boundary must be defined to prevent Cache Eviction during generation."
+        exit 1
+    fi
+
+    if [[ "$PREFIX_CACHING_ENABLED" == "false" ]]; then
+        echo "[ERROR] DECODE_ONLY validation failed: Missing '--enable-prefix-caching' in SERVER_CMD."
+        echo "Reason: Without prefix caching, the KV Cache seeded during warmup will be ignored, and vLLM will recompute the prefill for every request. This defeats the purpose of Decode-Only testing."
+        echo "Fix: Add '\"enable-prefix-caching\": true' to server_command_options.args in your JSON."
+        exit 1
+    fi
+
+    if [[ -z "$DECODE_INPUT_LEN" ]]; then
+        echo "[ERROR] DECODE_ONLY validation failed: Missing 'INPUT_LEN' in the environment variables."
+        echo "Reason: The dataset generator needs to know the exact token length to construct the prompt_token_ids array."
+        echo "Fix: Add 'INPUT_LEN' to the 'env' section of your case JSON."
+        exit 1
+    fi
+
+    if [[ "$DATASET_NAME_VALID" == "false" ]]; then
+        echo "[ERROR] DECODE_ONLY validation failed: Missing '--dataset-name custom' in CLIENT_CMD."
+        echo "Reason: vLLM can only read the generated JSONL with prompt_token_ids if the custom parser is enforced."
+        exit 1
+    fi
+
+    if [[ "$HAS_DATASET_PATH" == "true" ]]; then
+        echo "[ERROR] DECODE_ONLY validation failed: Found '--dataset-path' in CLIENT_CMD."
+        echo "Reason: DECODE_ONLY dynamically generates and injects its own dataset file. Providing one will cause a conflict."
+        exit 1
+    fi
+
+    # Generate decode-only mode dataset and Inject
+    echo "[INFO] Validation passed. Generating dataset..."
+
+    DECODE_DATASET_PATH="/tmp/decode_only_dataset.jsonl"
+    
+    python3 "$SCRIPT_DIR/generate_decode_only_bm_dataset.py" \
+        --input-len "$DECODE_INPUT_LEN" \
+        --num-distinct "$MAX_NUM_SEQS" \
+        --output-file "$DECODE_DATASET_PATH"
+        
+    CLIENT_CMD+=( "--dataset-path" "$DECODE_DATASET_PATH" )
+    
+    # Disable shuffle here to strictly preserve the round-robin order to guarantee that every request
+    # in a concurrent batch is completely distinct.
+    if ! contains_element "--disable-shuffle" "${CLIENT_CMD[@]}"; then
+        CLIENT_CMD+=( "--disable-shuffle" )
+    fi
+    
+    DATASET="decode_only_override"
+    echo "[INFO] Interception complete. Dataset path and shuffle disabled."
+    echo "====================================================================="
+fi
+
 # Download Datasets
 DATASET_DIR="$ARTIFACT_FOLDER/dataset"
 mkdir -p "$DATASET_DIR"
@@ -319,6 +413,55 @@ if [[ "$SERVER_STARTED" == "false" ]]; then
     echo "--- Dumping VLLM_LOG for debugging ---"
     cat "$VLLM_LOG"
     exit 1
+fi
+
+# ---------------------------------------------------------
+# DECODE_ONLY Warmup Execution (Cache Seeding)
+# ---------------------------------------------------------
+if [[ "${DECODE_ONLY:-false}" == "true" ]]; then
+    echo "====================================================================="
+    echo "[INFO] DECODE_ONLY: Executing Warmup Phase"
+    echo "====================================================================="
+    echo "Warming up HBM Cache with exactly $MAX_NUM_SEQS distinct requests to prevent Cache Eviction..."
+    
+    # Copy the array for safe modification
+    WARMUP_CMD=("${CLIENT_CMD[@]}")
+    
+    found_prompts=false
+    
+    # In-place modification of existing flags
+    for i in "${!WARMUP_CMD[@]}"; do
+        arg="${WARMUP_CMD[$i]}"
+        if [[ "$arg" == "--num-prompts" ]]; then
+            WARMUP_CMD[i+1]="$MAX_NUM_SEQS"
+            found_prompts=true
+        elif [[ "$arg" == --num-prompts=* ]]; then
+            WARMUP_CMD[i]="--num-prompts=$MAX_NUM_SEQS"
+            found_prompts=true
+        fi
+    done
+    
+    # Append the flags if they were not found in the original command
+    if [[ "$found_prompts" == false ]]; then
+        WARMUP_CMD+=( "--num-prompts" "$MAX_NUM_SEQS" )
+    fi
+    
+    echo "[DEBUG] WARMUP_CMD: ${CLIENT_CMD_ENVS[*]} ${WARMUP_CMD[*]}"
+    set +e
+    env "${CLIENT_CMD_ENVS[@]}" "${WARMUP_CMD[@]}" > "$LOG_FOLDER/warmup_log.txt" 2>&1
+    warmup_exit_code=$?
+    set -e
+    
+    if [[ "$warmup_exit_code" -ne 0 ]]; then
+        echo "[ERROR] Warmup phase failed with exit code $warmup_exit_code!"
+        echo "--- Dumping Warmup Log ---"
+        cat "$LOG_FOLDER/warmup_log.txt"
+        exit 1
+    fi
+    
+    echo "[INFO] Warmup Phase Completed Successfully. Cache is strictly seeded."
+    echo "[INFO] Proceeding to Decode-Only concurrency stress testing."
+    echo "====================================================================="
 fi
 
 # Set Default


### PR DESCRIPTION
Introduces the automated end-to-end workflow setup for **Decode-Only benchmarking**. It isolates memory-bound Decode performance by using vLLM's prefix caching combined with a pre-seeding warmup phase. Injecting identical prompt sequences across concurrent requests completely bypasses prefill computation costs

## Key Steps
* **Configuration Validation:** Intercepts execution when `DECODE_ONLY=true`. Asserts mandatory server/client flags.
* **Dynamic Dataset Injection:** Automatically triggers `generate_decode_only_bm_dataset.py` to build a specialized JSONL dataset populated with distinct `prompt_token_ids`.
* **Execution Guardrails:** Appends `--dataset-path` overrides and enforces `--disable-shuffle` to strictly preserve round-robin request ordering and prevent cache eviction.
* **Warmup Execution (Cache Seeding):** Prior to the regular BM test, executes an initial run sending exactly `max-num-seqs` distinct requests to force full prefill computation. This fully populates the HBM with the required KV Cache blocks and registers their hashes with the prefix cache mechanism.

---

## Test
**Buildkite Run:** [TPU Inference Benchmark - Build #472](https://buildkite.com/tpu-commons/tpu-inference-benchmark/builds/472/canvas?sid=019e1dc2-ca9e-4f1a-a797-c7ab0f2bf628&tab=output)

To verify the script infrastructure independently, `--enable-prefix-caching` was temporarily disabled and the strict assertion validations in `run_bm.sh` were bypassed because of the below model level blocker.

### Qwen3.5 onboarding blocker
Currently, `Qwen3.5-397B` is incorrectly classified as `is_multimodal_model` by the backend. This triggers a hardware-level override on the TPU platform layer that automatically forces `--disable_chunked_mm_input`. 

Because vLLM's core engine strictly asserts that chunked input cannot be disabled when Prefix Caching is active, server turnup validation currently fails under required production flags. 

The model onboarding will be done by separate PR when the blocker is resolved.