### PR TITLE
Investigate failed gpt-oss-120b cases

### DIFF
--- a/.buildkite/benchmark/cases/dev/gpt_oss_120b.json
+++ b/.buildkite/benchmark/cases/dev/gpt_oss_120b.json
@@ -1,0 +1,114 @@
+{
+  "global_env": {
+    "GCP_PROJECT_ID": "cloud-tpu-inference-test",
+    "GCS_BUCKET": "vllm-cb-storage2",
+    "GCP_INSTANCE_ID": "vllm-bm-inst",
+    "GCP_DATABASE_ID": "vllm-bm-bk-runs"
+  },
+  "benchmark_cases": [
+    {
+      "case_name": "gpt-oss-120b-dataset_random-inlen_1024-outlen_8192-C2",
+      "ci_queue": [
+        "tpu_v7x_8_queue"
+      ],
+      "env": {
+        "RUN_TYPE": "DAILY",
+        "MODELTAG": "NEW",
+        "EXPECTED_ETEL": 43200000,
+        "INPUT_LEN": 1024,
+        "OUTPUT_LEN": 8192,
+        "PREFIX_LEN": 0
+      },
+      "server_command_options": {
+        "command_type": "vllm_serve",
+        "env": {
+          "VLLM_USE_V1": "1",
+          "MODEL_IMPL_TYPE": "vllm",
+          "USE_MOE_EP_KERNEL": "0"
+        },
+        "args": {
+          "model": "openai/gpt-oss-120b",
+          "seed": 42,
+          "max-num-seqs": 1024,
+          "max-num-batched-tokens": 16384,
+          "tensor-parallel-size": {
+            "v7x-8": 2,
+            "default": 1
+          },
+          "data-parallel-size": 4,
+          "max-model-len": 9216,
+          "kv-cache-dtype": "fp8",
+          "gpu-memory-utilization": 0.97,
+          "no-enable-prefix-caching": true,
+          "async-scheduling": true
+        }
+      },
+      "client_command_options": {
+        "command_type": "vllm_bench_serve",
+        "args": {
+          "model": "openai/gpt-oss-120b",
+          "backend": "vllm",
+          "request-rate": "inf",
+          "dataset-name": "random",
+          "num-prompts": 4096,
+          "percentile-metrics": "ttft,tpot,itl,e2el",
+          "ignore-eos": true,
+          "random-input-len": 1024,
+          "random-output-len": 8192
+        }
+      }
+    },
+    {
+      "case_name": "gpt-oss-120b-dataset_random-inlen_8192-outlen_1024-C2",
+      "ci_queue": [
+        "tpu_v7x_8_queue"
+      ],
+      "env": {
+        "RUN_TYPE": "DAILY",
+        "MODELTAG": "NEW",
+        "EXPECTED_ETEL": 43200000,
+        "INPUT_LEN": 8192,
+        "OUTPUT_LEN": 1024,
+        "PREFIX_LEN": 0
+      },
+      "server_command_options": {
+        "command_type": "vllm_serve",
+        "env": {
+          "VLLM_USE_V1": "1",
+          "MODEL_IMPL_TYPE": "vllm",
+          "USE_MOE_EP_KERNEL": "0"
+        },
+        "args": {
+          "model": "openai/gpt-oss-120b",
+          "seed": 42,
+          "max-num-seqs": 1024,
+          "max-num-batched-tokens": 8192,
+          "tensor-parallel-size": {
+            "v7x-8": 2,
+            "default": 1
+          },
+          "data-parallel-size": 4,
+          "max-model-len": 9216,
+          "kv-cache-dtype": "fp8",
+          "gpu-memory-utilization": 0.95,
+          "no-enable-prefix-caching": true,
+          "async-scheduling": true
+        }
+      },
+      "client_command_options": {
+        "command_type": "vllm_bench_serve",
+        "args": {
+          "model": "openai/gpt-oss-120b",
+          "backend": "vllm",
+          "request-rate": "inf",
+          "dataset-name": "random",
+          "num-prompts": 4096,
+          "percentile-metrics": "ttft,tpot,itl,e2el",
+          "ignore-eos": true,
+          "random-input-len": 8192,
+          "random-output-len": 1024
+        }
+      }
+    }
+  ]
+}

--- a/.buildkite/benchmark/cases/dev/gpt_oss_120b.json
+++ b/.buildkite/benchmark/cases/dev/gpt_oss_120b.json
@@ -17,7 +17,8 @@
         "EXPECTED_ETEL": 43200000,
         "INPUT_LEN": 1024,
         "OUTPUT_LEN": 8192,
-        "PREFIX_LEN": 0
+        "PREFIX_LEN": 0,
+        "VLLM_ENGINE_READY_TIMEOUT_S": 1800
       },
       "server_command_options": {
         "command_type": "vllm_serve",
@@ -69,7 +70,8 @@
         "EXPECTED_ETEL": 43200000,
         "INPUT_LEN": 8192,
         "OUTPUT_LEN": 1024,
-        "PREFIX_LEN": 0
+        "PREFIX_LEN": 0,
+        "VLLM_ENGINE_READY_TIMEOUT_S": 1800
       },
       "server_command_options": {
         "command_type": "vllm_serve",


### PR DESCRIPTION
# Description

Add `gpt-oss-120b` cases, but currently these cases fail to execute successfully. Need to investigate the cause and fix them.
The two cases originally in `daily_gpt_oss_120b_tpu7x.csv`

# Tests

[Buildkite CI](https://buildkite.com/tpu-commons/tpu-inference-benchmark/builds/539)

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
