### PR TITLE
[profiling] enable request ID tracing in the ModelForward pass

### DIFF
--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -793,8 +793,14 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                                "after execute_model() returns None.")
         reqs = self.input_batch.num_reqs
         toks = scheduler_output.total_num_scheduled_tokens
+
+        req_id_kwargs = {}
+        if jax.profiler.TraceAnnotation.is_enabled():
+            req_id_kwargs = runner_utils.extract_request_ids_for_tracing(
+                self.input_batch, scheduler_output)
+
         with jax.set_mesh(self.mesh), jax.profiler.TraceAnnotation(
-                f"execute_model: {reqs} reqs, {toks} toks"):
+                f"execute_model: {reqs} reqs, {toks} toks", **req_id_kwargs):
             output = self._execute_model(scheduler_output,
                                          intermediate_tensors)
         return output
@@ -996,7 +1002,6 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         # NOTE: right now, mm model will use embeddings as the input,
         # but text-only model will use input_ids
         with self.maybe_forbid_compile:
-
             with set_forward_context(
                     None,
                     self.vllm_config,

--- a/tpu_inference/runner/utils.py
+++ b/tpu_inference/runner/utils.py
@@ -26,6 +26,53 @@ from tpu_inference import envs
 from tpu_inference.logger import init_logger
 from tpu_inference.runner.input_batch import InputBatch
 
+
+def trim_request_id_suffix(request_id: str) -> str:
+    """Trims the suffix from a request ID, keeping only the base ID.
+    
+    Example: cmpl-f0d75fed-c25e-4ccf-b369-9bd0226021b3-0-a9cb3cca 
+          -> cmpl-f0d75fed-c25e-4ccf-b369-9bd0226021b3
+    """
+    parts = request_id.split("-")
+    if len(parts) >= 6 and parts[0] == "cmpl":
+        return "-".join(parts[:6])
+    return request_id
+
+
+def extract_request_ids_for_tracing(
+    input_batch: InputBatch,
+    scheduler_output: Optional[Any] = None,
+) -> dict[str, str]:
+    """Extracts request IDs from an InputBatch and formats them for XProf tracing."""
+    req_id_kwargs = {}
+    try:
+        num_reqs = input_batch.num_reqs
+        raw_req_ids = [
+            str(rid) for rid in input_batch.req_ids[:num_reqs]
+            if rid is not None
+        ]
+
+        active_req_ids = []
+        for rid in raw_req_ids:
+            # Only trace requests that have non-zero scheduled tokens in this step
+            if scheduler_output is not None:
+                num_tokens = scheduler_output.num_scheduled_tokens.get(rid, 0)
+                if num_tokens == 0:
+                    continue
+            active_req_ids.append(rid)
+
+        trimmed_req_ids = [
+            trim_request_id_suffix(rid) for rid in active_req_ids
+        ]
+        for i, rid in enumerate(trimmed_req_ids):
+            req_id_kwargs[f"request_id{i+1}"] = rid
+    except Exception as e:
+        logger.warning(
+            f"Failed to extract request IDs for tracing from input_batch. Error: {e}"
+        )
+    return req_id_kwargs
+
+
 MIN_NUM_SEQS = 8
 
 # These are used for determining the inference phase for a given batch in


### PR DESCRIPTION
# Description

This PR introduces searchable request ID tracing directly to the host-side execution loop (`execute_model`) in the JAX `TPUModelRunner`. Previously, trace annotations for TPU execution did not contain any request metadata, making it difficult to correlate profiling timelines with specific user queries inside TensorBoard / XProf.

**Why is this change being made:**
To improve the observability and debuggability of TPU inference. By adding request IDs to traces, developers can trace the lifecycle of a specific request across different nodes and execution steps in XProf.

**Mechanism:**
*   **Request ID Extraction**: We extract the request IDs from **`self.input_batch.req_ids`** for the active requests in the batch. These request IDs are extracted and filtered using **`scheduler_output.num_scheduled_tokens > 0`**.
*   **ID Trimming**: Added a helper `trim_request_id_suffix` in `runner/utils.py` to remove batching and proxy suffixes (e.g., `-0-xxyyzz`) to ensure consistent base IDs across prefill and decode nodes.
*   **Trace Annotation**: We inject request ID metadata directly into the high-level `execute_model` trace.


# Tests

**Manual Verification (Benchmark & Profile):**
Verified the changes by deploying a custom image on GKE using the Qwen3-32B model and running the benchmark serving workload with profiling enabled:
```bash
vllm bench serve \
  --model Qwen/Qwen3-32B \
  --dataset-name random \
  --num-prompts 10 \
  --profile
```

**Results:**
The benchmark completed successfully (10/10 requests) and generated a trace profile (xplane.pb) containing the expected profiling data. Uploaded and visualized it in the Tensorboard XProf UI. The `ModelForward` trace annotations are visible along with the request IDs in the event metadata.

**Xprof UI Screenshot**
<img width="2001" height="2944" alt="AqrK3dXFaPfpp5C" src="https://github.com/user-attachments/assets/e7983db0-23b8-45da-8521-dc21ac4fccc1" />

**Xprof snipit**
https://screenshot.googleplex.com/AqrK3dXFaPfpp5C
