### PR TITLE
[profiling] add KV transfer metadata to traces

### DIFF
--- a/tpu_inference/distributed/tpu_connector.py
+++ b/tpu_inference/distributed/tpu_connector.py
@@ -96,6 +96,8 @@ from tpu_inference.distributed.tpu_connector_stats import (
     TpuKVConnectorPromMetrics, TpuKVConnectorStats)
 from tpu_inference.logger import init_logger
 from tpu_inference.runner.tpu_runner import TPUModelRunner
+from tpu_inference.runner.utils import (get_kv_transfer_metadata,
+                                        trim_request_id_suffix)
 from tpu_inference.utils import device_array
 
 ReqId = str
@@ -707,7 +709,19 @@ class TPUConnectorWorker:
                 kv, req_meta.expiration_time, buffer_idx
             ]
             self.kv_pull_uuid_to_req_id_map[req_meta.uuid] = req_id
-            self.kv_transfer_server.await_pull(req_meta.uuid, kv)
+
+            if jax.profiler.TraceAnnotation.is_enabled():
+                dims_str, kv_size_bytes = get_kv_transfer_metadata(kv)
+
+                with jax.profiler.TraceAnnotation(
+                        "KV_Cache_Await_Pull",
+                        uuid=req_meta.uuid,
+                        request_id=trim_request_id_suffix(req_id),
+                        bytes=kv_size_bytes,
+                        dimensions=dims_str):
+                    self.kv_transfer_server.await_pull(req_meta.uuid, kv)
+            else:
+                self.kv_transfer_server.await_pull(req_meta.uuid, kv)
 
     def _async_d2h_and_transfer(self, req_id: str, req_meta: SendMeta,
                                 kv_src: list[jax.Array],
@@ -757,7 +771,22 @@ class TPUConnectorWorker:
             dest_buffer, req_meta.expiration_time, buffer_idx
         ]
         self.kv_pull_uuid_to_req_id_map[req_meta.uuid] = req_id
-        self.kv_transfer_server.await_pull(req_meta.uuid, updated_dest_buffer)
+
+        if jax.profiler.TraceAnnotation.is_enabled():
+            dims_str, kv_size_bytes = get_kv_transfer_metadata(
+                updated_dest_buffer)
+
+            with jax.profiler.TraceAnnotation(
+                    "KV_Cache_Await_Pull",
+                    uuid=req_meta.uuid,
+                    request_id=trim_request_id_suffix(req_id),
+                    bytes=kv_size_bytes,
+                    dimensions=dims_str):
+                self.kv_transfer_server.await_pull(req_meta.uuid,
+                                                   updated_dest_buffer)
+        else:
+            self.kv_transfer_server.await_pull(req_meta.uuid,
+                                               updated_dest_buffer)
 
     def _maybe_build_kv_connection(self, req_meta: LoadMeta) -> Any:
         if isinstance(req_meta.remote_host, list):
@@ -790,7 +819,18 @@ class TPUConnectorWorker:
             f"Worker {self.node_id} --> kv transfer | start pull req_id={req_id} | uuid={req_meta.uuid}"
         )
         start_time = time.perf_counter()
-        kv = conn.pull(req_meta.uuid, kv_spec)
+        if jax.profiler.TraceAnnotation.is_enabled():
+            dims_str, expected_bytes = get_kv_transfer_metadata(kv_spec)
+            with jax.profiler.TraceAnnotation(
+                    "KV_Cache_Pull",
+                    uuid=req_meta.uuid,
+                    request_id=trim_request_id_suffix(req_id),
+                    bytes=expected_bytes,
+                    dimensions=dims_str,
+                    source=f"{req_meta.remote_host}:{req_meta.remote_port}"):
+                kv = conn.pull(req_meta.uuid, kv_spec)
+        else:
+            kv = conn.pull(req_meta.uuid, kv_spec)
         kv_size_mb = sum(k.nbytes for k in kv) / (1024 * 1024)
         end_time_0, end_time_1 = time.perf_counter(), None
         prepare_time_ms = (end_time_0 - start_time) * 1000

--- a/tpu_inference/runner/utils.py
+++ b/tpu_inference/runner/utils.py
@@ -29,14 +29,37 @@ from tpu_inference.runner.input_batch import InputBatch
 
 def trim_request_id_suffix(request_id: str) -> str:
     """Trims the suffix from a request ID, keeping only the base ID.
-    
-    Example: cmpl-f0d75fed-c25e-4ccf-b369-9bd0226021b3-0-a9cb3cca 
+
+    Example: cmpl-f0d75fed-c25e-4ccf-b369-9bd0226021b3-0-a9cb3cca
           -> cmpl-f0d75fed-c25e-4ccf-b369-9bd0226021b3
     """
     parts = request_id.split("-")
     if len(parts) >= 6 and parts[0] == "cmpl":
         return "-".join(parts[:6])
     return request_id
+
+
+def get_kv_transfer_metadata(kv: list[Any]) -> tuple[str, int]:
+    """Returns the dimensions string and size in bytes for a list of KV cache tensors.
+
+    Dimensions format: (num_layers, num_blocks, block_size, num_heads, 2 (K/V), head_dim)
+    """
+    if not kv:
+        return "()", 0
+
+    # Dimensions string
+    dims_str = str((len(kv), ) + tuple(kv[0].shape))
+
+    # Calculate bytes robustly (supports JAX/NumPy Tensors and ShapeDtypeStruct specs)
+    kv_size_bytes = 0
+    for k in kv:
+        if hasattr(k, "nbytes"):
+            kv_size_bytes += k.nbytes
+        else:
+            # Fallback for ShapeDtypeStruct specs
+            kv_size_bytes += int(np.prod(k.shape) * np.dtype(k.dtype).itemsize)
+
+    return dims_str, kv_size_bytes
 
 
 def extract_request_ids_for_tracing(


### PR DESCRIPTION
# Description
This PR adds detailed, searchable metadata to KV cache transfer traces (`KV_Cache_Pull` and `KV_Cache_Await_Pull`) in the `tpu-inference` plugin. Previously, these traces lacked specific details about the data being transferred, making it difficult to analyze performance and correlate transfers with specific requests.

**Why is this change being made:**
To improve the performance analysis and debuggability of remote KV pulls in XProf by providing context such as size, dimensions, and source directly in the trace annotations.

**Mechanism:**
*   **Consuming Side (Pull)**: Wrapped the `conn.pull` call in `_pull_kv` with `jax.profiler.TraceAnnotation`, adding `uuid`, `request_id`, `bytes` (expected), `dimensions`, and `source` (host:port) as metadata.
*   **Producing Side (Await Pull)**: Wrapped the `self.kv_transfer_server.await_pull` call with `jax.profiler.TraceAnnotation`, adding `uuid`, `request_id`, `bytes` (actual), and `dimensions`.
*   **Dimensions**: Extracted dimensions from `kv_spec` or the `kv` tensor list shape, represented as a string (`#layers, #blocks, block size, #heads, 2 (K/V), head dimension`).


# Tests
**Manual Verification (Benchmark & Profile):**
Verified the changes by deploying a custom [llm-d](https://github.com/llm-d/llm-d) deployment using 1 prefill and 1 decode vllm + tpu-inference image on GKE using the Qwen3-32B model and running the 3 inference requests concurrently using the gateway to facilitate the disaggregated serving.

**Results:**
The profiling was successful and generated two trace profiles (xplane.pb), each on prefill and decode pod containing the expected profiling data. Uploaded and visualized it in the Tensorboard XProf UI. The `KV_Cache_Pull` and `KV_Cache_Await_Pull` trace annotations are visible along with the transfer related details in the event metadata.

**Prefill Node**
<img width="1783" height="1036" alt="kv-decode2" src="https://github.com/user-attachments/assets/bce6a9d6-ce0d-460e-9cdd-92efe9a42583" />
Refer https://screenshot.googleplex.com/AqZD34VCevpnLFS 

<br>

**Decode Node**
<img width="1734" height="1045" alt="kv-prefill" src="https://github.com/user-attachments/assets/acbea265-3a11-4598-8896-7c02a40a5025" />
Refer https://screenshot.googleplex.com/Q8Hrke5rCeXUE2U
