### PR TITLE
Fix routed_expert performance

### DIFF
--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -1221,13 +1221,24 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                                                   end_idx, :].transpose(
                                                       1, 0, 2)
 
-                if not hasattr(req_state, "_accumulated_experts"):
-                    req_state._accumulated_experts = []
-                req_state._accumulated_experts.append(step_experts)
+                if not hasattr(req_state, "_routed_experts_buf"):
+                    _, layers, top_k = step_experts.shape
+                    req_state._routed_experts_buf = np.zeros(
+                        (self.max_model_len, layers, top_k),
+                        dtype=step_experts.dtype)
+                    req_state._routed_experts_len = 0
 
-                # Send the FULL accumulated history for every request in the batch
-                routed_experts_dict[req_id] = np.concatenate(
-                    req_state._accumulated_experts, axis=0)
+                offset = req_state._routed_experts_len
+                allowed = min(num_tokens_scheduled,
+                              self.max_model_len - offset)
+                if allowed > 0:
+                    req_state._routed_experts_buf[offset:offset + allowed] = (
+                        step_experts[:allowed])
+                    req_state._routed_experts_len += allowed
+
+                routed_experts_dict[
+                    req_id] = req_state._routed_experts_buf[:req_state.
+                                                            _routed_experts_len]
 
             model_runner_output.routed_experts_dict = routed_experts_dict
 


### PR DESCRIPTION
# Description

Fix performance dip from https://github.com/vllm-project/tpu-inference/pull/2552/changes#diff-201f8c8fa90b561bb9195a0265a3d7b9802db7ea2046a608b9db7b24c929fdfb

Optimizes host-side MoE routed expert collection in `TPUModelRunner` by replacing dynamic list appending and per-step array concatenation with a pre-allocated numpy buffer on `req_state`.

## Problem & Solution
- **Problem**: Previously, `req_state._accumulated_experts` accumulated per-step expert arrays in a Python list and re-concatenated them (`np.concatenate(..., axis=0)`) on every step. This created significant CPU memory allocation and copying overhead during MoE inference.
- **Solution**:
  - Pre-allocates a contiguous numpy array buffer `_routed_experts_buf` of shape `(max_model_len, layers, top_k)` on request initialization.
  - Slices incoming step expert data directly into the pre-allocated buffer in-place (`_routed_experts_buf[offset:offset + allowed]`).
  - Returns a zero-copy slice view (`_routed_experts_buf[:_routed_experts_len]`) for `routed_experts_dict`.

# Tests

before
```
============ Serving Benchmark Result ============
Successful requests:                     1000
Benchmark duration (s):                  134.83
Total input tokens:                      510681
Total generated tokens:                  512000
Request throughput (req/s):              7.42
Output token throughput (tok/s):         3797.28
Total token throughput (tok/s):          7584.78
---------------Time to First Token----------------
Mean TTFT (ms):                          34954.41
Median TTFT (ms):                        5555.13
P99 TTFT (ms):                           71772.32
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          125.35
Median TPOT (ms):                        126.05
P99 TPOT (ms):                           129.43
---------------Inter-token Latency----------------
Mean ITL (ms):                           125.35
Median ITL (ms):                         125.21
P99 ITL (ms):                            253.00
----------------End-to-end Latency----------------
Mean E2EL (ms):                          99007.25
Median E2EL (ms):                        71690.62
P99 E2EL (ms):                           134712.95
==================================================
```

after
```
============ Serving Benchmark Result ============
Successful requests:                     1000
Benchmark duration (s):                  33.93
Total input tokens:                      510681
Total generated tokens:                  512000
Request throughput (req/s):              29.47
Output token throughput (tok/s):         15088.35
Total token throughput (tok/s):          30137.83
---------------Time to First Token----------------
Mean TTFT (ms):                          11137.56
Median TTFT (ms):                        5404.71
P99 TTFT (ms):                           20516.94
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          28.52
Median TPOT (ms):                        29.42
P99 TPOT (ms):                           30.84
---------------Inter-token Latency----------------
Mean ITL (ms):                           28.52
Median ITL (ms):                         25.89
P99 ITL (ms):                            51.79
----------------End-to-end Latency----------------
Mean E2EL (ms):                          25711.27
Median E2EL (ms):                        20439.80
P99 E2EL (ms):                           33811.86
==================================================
```

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
