### PR TITLE
fix the flaky single host P/D issue

### DIFF
--- a/examples/disagg/run_disagg_single_host.sh
+++ b/examples/disagg/run_disagg_single_host.sh
@@ -113,18 +113,15 @@ check_failed_requests() {
 
 cleanup_instances() {
   echo "Cleaning up any running vLLM instances..."
+  pkill -f "vllm" || true
+  pkill -f "toy_proxy_server" || true
+  sleep 5
   pkill -9 -f "vllm" || true
   pkill -9 -f "toy_proxy_server" || true
-  pkill -9 -f "multiprocess" || true
-  # Check if any accel devices exist before trying to kill processes on them
-  for dev in /dev/accel*; do
-    if [ -e "$dev" ]; then
-      fuser -k "$dev" || true
-    fi
-  done
-
-  rm -f /dev/shm/vllm_* || true
-  sleep 10
+  sudo fuser -k -9 /dev/vfio/* 2>/dev/null || true
+  sudo fuser -k -9 /dev/accel* 2>/dev/null || true
+  sudo rm -rf /tmp/jax_cache_* || true
+  sudo rm -f /tmp/libtpu_lockfile || true
 }
 
 LOG_DIR=$HOME/logs
@@ -177,9 +174,6 @@ for i in $(seq 0 $((NUM_PREFILL_INSTANCES-1))); do
     PREFILL_HOSTS+=("localhost")
     PREFILL_PORTS+=($PORT)
     PREFILL_PIDS+=($!)
-
-    # Pause between starting each instance to relieve host memory pressure
-    sleep 30
 done
 
 
@@ -220,9 +214,6 @@ for i in $(seq 0 $((NUM_DECODE_INSTANCES-1))); do
     DECODE_HOSTS+=("localhost")
     DECODE_PORTS+=($PORT)
     DECODE_PIDS+=($!)
-
-    # Pause between starting each instance to relieve host memory pressure
-    sleep 30
 done
 
 # Wait for all instances to start


### PR DESCRIPTION
# Description

pkill -9 brutally killing TPU processes prevents libtpu from gracefully shutting down and resetting the TPU stats. we try with pkill -> wait -> kill -9 then doing some cleaning work, which will use the max effort to reset TPU status.

Before the fix: script almost always failed in second try.

After the fix:
Retried 10 times, still succeeded.


Successful requests:                     200       
Failed requests:                         0         
Request rate configured (RPS):           4.00      
Benchmark duration (s):                  50.52     
Total input tokens:                      102400    
Total generated tokens:                  25600     
Request throughput (req/s):              3.96      
Output token throughput (tok/s):         506.75    
Peak output token throughput (tok/s):    1182.00   
Peak concurrent requests:                14.00     
Total token throughput (tok/s):          2533.76   
---------------Time to First Token----------------
Mean TTFT (ms):                          59.44     
Median TTFT (ms):                        56.83     
P99 TTFT (ms):                           91.19     
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          3.51      
Median TPOT (ms):                        3.52      
P99 TPOT (ms):                           3.76      
---------------Inter-token Latency----------------
Mean ITL (ms):                           3.51      
Median ITL (ms):                         3.40      
P99 ITL (ms):                            5.06      


If the change fixes a Github issue, please include a link, e.g.,:
FIXES: #123456

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
