### PR TITLE
RPA v3 + batched: support update_kv_cache=False (KV-share) on both kernels

### DIFF
--- a/tests/kernels/ragged_paged_attention_kernel_v3_test.py
+++ b/tests/kernels/ragged_paged_attention_kernel_v3_test.py
@@ -529,6 +529,213 @@ class RaggedPagedAttentionKernelTest(jtu.JaxTestCase):
                 soft_cap=0.0,
             )
 
+    # ------------------------------------------------------------------
+    # KV-share path (`update_kv_cache=False`) regression tests.
+    #
+    # Used by gemma-4 KV-shared layers: the cache slot is redirected to
+    # a source layer that has already written its normed/roped K,V, and
+    # the shared layer must read attention K,V *only* from the cache.
+    # The kernel must (1) compute attention using cache K,V (2) ignore
+    # the input `keys` / `values` arrays entirely (3) leave the cache
+    # unchanged. The pre-fix kernel split each block into
+    # `(past from cache, current from input k,v)`, producing a corrupt
+    # mix of source-normed-roped-K with shared-raw-K. The fix is in
+    # kernel.py `_fetch_bkv`: when `update_kv_cache=False`, force all of
+    # `kv_left` to come from the cache.
+    #
+    # Note on path coverage: the non-shared (`update_kv_cache=True`)
+    # path's `_fetch_bkv` expression is unchanged from before the fix,
+    # so the existing prefill / decode / mixed tests above continue to
+    # cover it.
+    # ------------------------------------------------------------------
+
+    def _build_kv_share_inputs(
+        self,
+        *,
+        q_len: int,
+        kv_len: int,
+        kv_input_seed: int,
+        num_q_heads: int = 8,
+        num_kv_heads: int = 1,
+        head_dim: int = 128,
+        page_size: int = 16,
+        num_pages: int = 8,
+        max_num_seqs: int = 8,
+        cache_seed: int = 42,
+        q_seed: int = 123,
+        dtype=jnp.bfloat16,
+    ):
+        """Build a single-seq kernel input tuple with a pre-populated cache.
+
+        Cache contents are determined by `cache_seed`; q is determined by
+        `q_seed`. Input k,v are determined by `kv_input_seed` — varying
+        this between calls lets us check the output is invariant to input
+        k,v when `update_kv_cache=False`.
+        """
+        rng_q = np.random.default_rng(q_seed)
+        rng_cache = np.random.default_rng(cache_seed)
+        rng_input = np.random.default_rng(kv_input_seed)
+
+        pages_per_seq = cdiv(kv_len, page_size)
+        max_num_batched_tokens = max(align_to(q_len, 128), 128)
+        kv_packing = get_dtype_packing(dtype)
+        num_kv_heads_x2 = align_to(num_kv_heads * 2, kv_packing)
+        padded_hd = align_to(head_dim, 128)
+
+        q = jnp.array(
+            rng_q.random((max_num_batched_tokens, num_q_heads, head_dim),
+                         dtype=np.float32)).astype(dtype)
+        k = jnp.array(
+            rng_input.random((max_num_batched_tokens, num_kv_heads, head_dim),
+                             dtype=np.float32)).astype(dtype)
+        v = jnp.array(
+            rng_input.random((max_num_batched_tokens, num_kv_heads, head_dim),
+                             dtype=np.float32)).astype(dtype)
+
+        cache_data = jnp.array(
+            rng_cache.random(
+                (pages_per_seq * page_size, num_kv_heads_x2 // kv_packing,
+                 kv_packing, padded_hd),
+                dtype=np.float32)).astype(dtype)
+        cache_pages = cache_data.reshape(pages_per_seq, page_size,
+                                         num_kv_heads_x2 // kv_packing,
+                                         kv_packing, padded_hd)
+        # Padding pages stay nan to surface any out-of-bounds reads.
+        kv_cache = jnp.pad(
+            cache_pages,
+            ((0, num_pages - pages_per_seq), (0, 0), (0, 0), (0, 0), (0, 0)),
+            constant_values=jnp.nan,
+        )
+
+        page_indices = jnp.zeros((max_num_seqs * pages_per_seq, ),
+                                 dtype=jnp.int32)
+        page_indices = page_indices.at[:pages_per_seq].set(
+            jnp.arange(pages_per_seq, dtype=jnp.int32))
+
+        kv_lens_arr = jnp.zeros((max_num_seqs, ),
+                                dtype=jnp.int32).at[0].set(kv_len)
+        cu_q_lens_arr = jnp.zeros((max_num_seqs + 1, ),
+                                  dtype=jnp.int32).at[1].set(q_len)
+        # distribution[3] = (decode_end, prefill_end, mixed_end). One seq:
+        # decode if q_len==1 else prefill.
+        if q_len == 1:
+            distribution = jnp.array([1, 1, 1], dtype=jnp.int32)
+        else:
+            distribution = jnp.array([0, 1, 1], dtype=jnp.int32)
+
+        return (q, k, v, kv_cache, kv_lens_arr, page_indices, cu_q_lens_arr,
+                distribution)
+
+    def _kv_share_kwargs(self, head_dim: int = 128):
+        return dict(
+            sm_scale=1.0 / float(head_dim)**0.5,
+            update_kv_cache=False,
+            m_block_sizes=(64, 256, 32, 128),
+        )
+
+    def test_kv_share_prefill_input_kv_is_ignored(self):
+        """q_len == kv_len. Two calls with different input k,v but the same
+        pre-populated cache and same q produce bit-identical outputs."""
+        if not jtu.is_device_tpu_at_least(version=4):
+            self.skipTest("Expect TPUv4+")
+        args1 = self._build_kv_share_inputs(q_len=16,
+                                            kv_len=16,
+                                            kv_input_seed=11)
+        args2 = self._build_kv_share_inputs(q_len=16,
+                                            kv_len=16,
+                                            kv_input_seed=99)
+        # Sanity (must happen BEFORE the kernel call — kernel donates
+        # queries/keys/values/kv_cache). Skip the kv_cache equality check:
+        # _build_kv_share_inputs zero-pads unused trailing pages with NaN,
+        # and assert_array_equal treats NaN!=NaN. Cache is identical by
+        # construction (same cache_seed).
+        np.testing.assert_array_equal(args1[0], args2[0])
+        self.assertFalse(np.array_equal(args1[1], args2[1]))
+        self.assertFalse(np.array_equal(args1[2], args2[2]))
+        cache_before = np.asarray(args1[3])
+
+        out1, cache_after_1 = ragged_paged_attention(*args1,
+                                                     **self._kv_share_kwargs())
+        out2, cache_after_2 = ragged_paged_attention(*args2,
+                                                     **self._kv_share_kwargs())
+
+        # Output invariant to input k,v.
+        self.assertArraysEqual(out1, out2)
+        # Sanity: outputs are real attention values, not all-zero / NaN
+        # (regression catch for a kernel that silently fails closed).
+        out1_np = np.asarray(out1[:16]).astype(np.float32)
+        assert np.all(np.isfinite(out1_np)), "outputs contain non-finite"
+        assert float(np.abs(out1_np).max()) > 0.0, (
+            "outputs are all zero — kernel likely failed closed")
+        # Cache unchanged in both runs (use the pre-donation snapshot).
+        mask = ~np.isnan(cache_before)
+        np.testing.assert_array_equal(
+            np.asarray(cache_after_1)[mask], cache_before[mask])
+        np.testing.assert_array_equal(
+            np.asarray(cache_after_2)[mask], cache_before[mask])
+
+    def test_kv_share_chunked_prefill_input_kv_is_ignored(self):
+        """q_len < kv_len (chunked / continued prefill). This is the regime
+        the pre-fix kernel got wrong: cache holds source's normed/roped
+        K,V for the past portion, and the kernel must NOT mix in the
+        layer's own raw input k,v for the 'current step' portion."""
+        if not jtu.is_device_tpu_at_least(version=4):
+            self.skipTest("Expect TPUv4+")
+        args1 = self._build_kv_share_inputs(q_len=8,
+                                            kv_len=24,
+                                            kv_input_seed=11)
+        args2 = self._build_kv_share_inputs(q_len=8,
+                                            kv_len=24,
+                                            kv_input_seed=99)
+        cache_before = np.asarray(args1[3])
+
+        out1, cache_after_1 = ragged_paged_attention(*args1,
+                                                     **self._kv_share_kwargs())
+        out2, cache_after_2 = ragged_paged_attention(*args2,
+                                                     **self._kv_share_kwargs())
+
+        # Output invariant to input k,v. The pre-fix kernel would mix
+        # source K,V (past 16 positions from cache) with shared raw K,V
+        # (current 8 positions from input k,v), so different input k,v
+        # would give different outputs.
+        self.assertArraysEqual(out1[:8], out2[:8])
+        # Sanity: outputs are real (not all-zero / NaN).
+        out1_np = np.asarray(out1[:8]).astype(np.float32)
+        assert np.all(np.isfinite(out1_np))
+        assert float(np.abs(out1_np).max()) > 0.0
+        # Cache unchanged.
+        mask = ~np.isnan(cache_before)
+        np.testing.assert_array_equal(
+            np.asarray(cache_after_1)[mask], cache_before[mask])
+
+    def test_kv_share_decode_input_kv_is_ignored(self):
+        """q_len == 1, kv_len > 1 (decode step). Same invariance."""
+        if not jtu.is_device_tpu_at_least(version=4):
+            self.skipTest("Expect TPUv4+")
+        args1 = self._build_kv_share_inputs(q_len=1,
+                                            kv_len=33,
+                                            kv_input_seed=11)
+        args2 = self._build_kv_share_inputs(q_len=1,
+                                            kv_len=33,
+                                            kv_input_seed=99)
+        cache_before = np.asarray(args1[3])
+
+        out1, cache_after_1 = ragged_paged_attention(*args1,
+                                                     **self._kv_share_kwargs())
+        out2, cache_after_2 = ragged_paged_attention(*args2,
+                                                     **self._kv_share_kwargs())
+
+        # Decode emits q_len = 1 token. Compare just that token (the rest of
+        # the max_num_batched_tokens buffer is junk padding).
+        self.assertArraysEqual(out1[:1], out2[:1])
+        # Sanity: output is real.
+        out1_np = np.asarray(out1[:1]).astype(np.float32)
+        assert np.all(np.isfinite(out1_np))
+        assert float(np.abs(out1_np).max()) > 0.0
+        mask = ~np.isnan(cache_before)
+        np.testing.assert_array_equal(
+            np.asarray(cache_after_1)[mask], cache_before[mask])
+
 
 if __name__ == "__main__":
     absltest.main(testLoader=jtu.JaxTestLoader())

--- a/tests/layers/common/test_attention_interface.py
+++ b/tests/layers/common/test_attention_interface.py
@@ -306,6 +306,126 @@ def test_sharded_ragged_paged_attention_gqa_incompatible_raises_error(
         )
 
 
+def _run_sharded_rpa_capturing_kwargs(monkeypatch, gqa_mesh, update_kv_cache):
+    """Helper: run `sharded_ragged_paged_attention` with a stubbed
+    `ragged_paged_attention` (the module-level binding) and a passthrough
+    `jax.shard_map`. Returns the kwargs forwarded by the closure to the
+    underlying kernel.
+    """
+    head_dim = 128  # non-hd64
+    num_kv_heads = 4
+    q = jnp.ones((TOTAL_TOKENS, NUM_HEADS, head_dim))
+    k = jnp.ones((TOTAL_TOKENS, num_kv_heads, head_dim))
+    v = jnp.ones((TOTAL_TOKENS, num_kv_heads, head_dim))
+    kv_cache = jnp.zeros((num_kv_heads, NUM_BLOCKS, BLOCK_SIZE, head_dim))
+    kv_lens = jnp.zeros((MAX_NUM_SEQS, ), dtype=jnp.int32)
+    page_indices = jnp.zeros((MAX_NUM_SEQS, MAX_BLOCKS_PER_SEQ),
+                             dtype=jnp.int32)
+    cu_q_lens = jnp.zeros((MAX_NUM_SEQS + 1, ), dtype=jnp.int32)
+    distribution = jnp.zeros((3, ), dtype=jnp.int32)
+
+    captured = {}
+
+    def fake_kernel(*_args, **kwargs):
+        captured.update(kwargs)
+        return jnp.ones_like(q), kv_cache
+
+    monkeypatch.setattr(
+        "tpu_inference.layers.common.attention_interface.ragged_paged_attention",
+        fake_kernel,
+    )
+
+    # Passthrough shard_map so the closure actually executes.
+    def passthrough_shard_map(inner_fn, **_):
+        return inner_fn
+
+    monkeypatch.setattr("jax.shard_map", passthrough_shard_map)
+
+    sharded_ragged_paged_attention(
+        mesh=gqa_mesh,
+        q=q,
+        k=k,
+        v=v,
+        kv_cache=kv_cache,
+        kv_lens=kv_lens,
+        page_indices=page_indices,
+        cu_q_lens=cu_q_lens,
+        distribution=distribution,
+        attention_sink=None,
+        sm_scale=1.0,
+        update_kv_cache=update_kv_cache,
+    )
+    return captured
+
+
+def test_sharded_rpa_forwards_update_kv_cache_when_not_hd64(
+        monkeypatch, gqa_mesh):
+    """`sharded_ragged_paged_attention` must forward `update_kv_cache`
+    to the underlying kernel on the non-hd64 path. Both kernels (v3 and
+    batched) accept the kwarg after this fix; the wrapper forwards it
+    unconditionally for non-hd64 head sizes."""
+    captured = _run_sharded_rpa_capturing_kwargs(monkeypatch,
+                                                 gqa_mesh,
+                                                 update_kv_cache=False)
+
+    assert captured.get("update_kv_cache") is False, (
+        f"non-hd64 path must forward update_kv_cache=False; got {captured!r}")
+
+
+def test_batched_rpa_wrapper_accepts_update_kv_cache():
+    """Direct signature check that catches the original #2601 crash:
+    the batched RPA wrapper's `ragged_paged_attention` must declare an
+    `update_kv_cache` keyword parameter. `sharded_ragged_paged_attention`
+    always forwards the kwarg on the non-hd64 path; without this
+    signature, that forwarding crashed at trace time with
+    `TypeError: ragged_paged_attention() got an unexpected keyword
+    argument 'update_kv_cache'`."""
+    import inspect
+
+    from tpu_inference.kernels.experimental.batched_rpa import wrapper
+    params = inspect.signature(wrapper.ragged_paged_attention).parameters
+    assert "update_kv_cache" in params, (
+        f"batched RPA wrapper must accept update_kv_cache as a kwarg; "
+        f"got params: {list(params.keys())}")
+    assert params["update_kv_cache"].default is True, (
+        f"update_kv_cache should default to True (no-op for non-KV-share "
+        f"callers); got default={params['update_kv_cache'].default!r}")
+
+
+def test_sharded_rpa_rejects_update_kv_cache_false_on_hd64(gqa_mesh):
+    """The hd64 RPA kernel doesn't support KV-share; passing
+    update_kv_cache=False must raise rather than silently writing to
+    cache. (Currently no model uses head_dim=64 + KV-share, but the
+    guard is cheap insurance.)"""
+    head_dim = 64
+    num_kv_heads = 4
+    q = jnp.ones((TOTAL_TOKENS, NUM_HEADS, head_dim))
+    k = jnp.ones((TOTAL_TOKENS, num_kv_heads, head_dim))
+    v = jnp.ones((TOTAL_TOKENS, num_kv_heads, head_dim))
+    kv_cache = jnp.zeros((num_kv_heads, NUM_BLOCKS, BLOCK_SIZE, head_dim))
+    kv_lens = jnp.zeros((MAX_NUM_SEQS, ), dtype=jnp.int32)
+    page_indices = jnp.zeros((MAX_NUM_SEQS, MAX_BLOCKS_PER_SEQ),
+                             dtype=jnp.int32)
+    cu_q_lens = jnp.zeros((MAX_NUM_SEQS + 1, ), dtype=jnp.int32)
+    distribution = jnp.zeros((3, ), dtype=jnp.int32)
+
+    with pytest.raises(NotImplementedError, match="head_dim==64"):
+        sharded_ragged_paged_attention(
+            mesh=gqa_mesh,
+            q=q,
+            k=k,
+            v=v,
+            kv_cache=kv_cache,
+            kv_lens=kv_lens,
+            page_indices=page_indices,
+            cu_q_lens=cu_q_lens,
+            distribution=distribution,
+            attention_sink=None,
+            sm_scale=1.0,
+            update_kv_cache=False,
+        )
+
+
 def test_mla_attention(monkeypatch, mesh):
     """
     Tests the `mla_attention` function.

--- a/tpu_inference/kernels/experimental/batched_rpa/schedule.py
+++ b/tpu_inference/kernels/experimental/batched_rpa/schedule.py
@@ -166,8 +166,17 @@ def compute_metadata(
     lane_lengths_ref: jax.Ref,
     *,
     cfgs: configs.RpaConfigs,
+    update_kv_cache: bool = True,
 ):
-    """Fill metadata using triple nested loop of seq->q->k loop."""
+    """Fill metadata using triple nested loop of seq->q->k loop.
+
+    When `update_kv_cache=False` (KV-share path): the current step's
+    K/V tokens are NOT pulled from the input k/v tensors, the whole
+    `kv_len` is read from the (redirected) cache slot, and `do_writeback`
+    is forced to 0 so the kernel doesn't overwrite the source layer's
+    cache contents. Mirrors the v3 RPA kernel's `update_kv_cache=False`
+    semantics.
+    """
 
     @jax.named_scope("k_loop")
     def k_loop(
@@ -198,7 +207,14 @@ def compute_metadata(
         kv_len_start = k_idx * cfgs.bkv_sz
         kv_p_start = k_idx * cfgs.bkv_p
         kv_left = k_len - kv_len_start
-        kv_left_frm_cache = jnp.maximum(kv_left - q_len, 0)
+        if update_kv_cache:
+            kv_left_frm_cache = jnp.maximum(kv_left - q_len, 0)
+        else:
+            # KV-share: read everything from cache; the source layer's
+            # call ran earlier in this step and already wrote the
+            # current-step K/V into the (redirected) cache slot. The
+            # shared layer's locally-computed k/v is unused.
+            kv_left_frm_cache = kv_left
         p_offset = s_idx * cfgs.serve.pages_per_seq + kv_p_start
 
         for i in range(cfgs.bkv_p_cache):
@@ -339,6 +355,7 @@ def rpa_metadata_schedule_kernel(
     dma_sem: jax.Ref,
     *,
     cfgs: configs.RpaConfigs,
+    update_kv_cache: bool = True,
 ):
     """Generates the HBM-to-VMEM DMA schedule.
 
@@ -380,6 +397,7 @@ def rpa_metadata_schedule_kernel(
         schedule_ref,
         lane_lengths_ref,
         cfgs=cfgs,
+        update_kv_cache=update_kv_cache,
     )
 
     # Step 2: Compute actual number of steps.
@@ -447,11 +465,14 @@ def generate_rpa_metadata(
     cfgs: configs.RpaConfigs,
     *,
     interpret=False,
+    update_kv_cache: bool = True,
 ) -> RpaSchedule:
     schedule_shaped_dtype = RpaSchedule.create_shape_dtype(cfgs)
 
     return pl.pallas_call(
-        functools.partial(rpa_metadata_schedule_kernel, cfgs=cfgs),
+        functools.partial(rpa_metadata_schedule_kernel,
+                          cfgs=cfgs,
+                          update_kv_cache=update_kv_cache),
         out_shape=schedule_shaped_dtype,
         grid_spec=pltpu.PrefetchScalarGridSpec(
             num_scalar_prefetch=3,

--- a/tpu_inference/kernels/experimental/batched_rpa/wrapper.py
+++ b/tpu_inference/kernels/experimental/batched_rpa/wrapper.py
@@ -348,6 +348,7 @@ def calculate_block_sizes(
         "debug_mode",
         "out_dtype",
         "use_causal_mask",
+        "update_kv_cache",
     ),
     donate_argnames=("queries", "keys", "values", "kv_cache"),
 )
@@ -375,6 +376,7 @@ def ragged_paged_attention(
     debug_mode: bool = False,
     out_dtype: jnp.dtype | None = None,
     use_causal_mask: bool = True,
+    update_kv_cache: bool = True,
 ) -> tuple[jax.Array, jax.Array]:
     """Perform batched ragged paged attention.
 
@@ -502,6 +504,7 @@ def ragged_paged_attention(
             kv_lens,
             distribution,
             cfgs=cfgs,
+            update_kv_cache=update_kv_cache,
         )
         return kernel.rpa_kernel(
             cu_q_lens,

--- a/tpu_inference/kernels/ragged_paged_attention/v3/kernel.py
+++ b/tpu_inference/kernels/ragged_paged_attention/v3/kernel.py
@@ -317,6 +317,7 @@ def _ragged_paged_attention_kernel_loop(
     acc_ref,  # [actual_num_kv_heads, bq_sz * num_q_heads_per_kv_head, head_dim],
     *,
     use_causal_mask: bool = True,
+    update_kv_cache: bool = True,  # KV-share: False = skip cache writes
     skip_kv_mask: bool = False,
     sm_scale: float,
     sliding_window: int | None = None,
@@ -559,7 +560,16 @@ def _ragged_paged_attention_kernel_loop(
         q_len = q_end - q_start
 
         kv_left = kv_len - kv_len_start
-        kv_left_frm_cache = jnp.maximum(kv_left - q_len, 0)
+        if update_kv_cache:
+            kv_left_frm_cache = jnp.maximum(kv_left - q_len, 0)
+        else:
+            # KV-share: source layer already wrote the full K/V for the
+            # current step into the (redirected) cache slot before this
+            # layer's call, so read everything from cache. The shared
+            # layer's input k,v is unused. Mirrors vllm-pytorch behavior
+            # where unified_attention reads from key_cache/value_cache
+            # only, regardless of the layer's own k,v projections.
+            kv_left_frm_cache = kv_left
         kv_left_frm_new = kv_left - kv_left_frm_cache
 
         bkv_sz_frm_cache = jnp.minimum(kv_left_frm_cache, bkv_sz)
@@ -969,10 +979,15 @@ def _ragged_paged_attention_kernel_loop(
 
                 # Start updating bkv to kv cache if applicable.
                 # Only needed in last bq loop.
-                @pl.when(jnp.logical_and(update_sz > 0, bq_idx == num_bq - 1))
-                def update_cur_bkv_to_cache():
-                    start_update_kv_cache(seq_idx, bkv_sem_idx, offset,
-                                          update_sz)
+                # KV-share: skip the cache write when update_kv_cache=False
+                # so shared layers don't overwrite the source layer's slot.
+                if update_kv_cache:
+
+                    @pl.when(
+                        jnp.logical_and(update_sz > 0, bq_idx == num_bq - 1))
+                    def update_cur_bkv_to_cache():
+                        start_update_kv_cache(seq_idx, bkv_sem_idx, offset,
+                                              update_sz)
 
                 debug_print(
                     "[RPA debug] -----------flash attention-----------")
@@ -1545,6 +1560,7 @@ def get_default_block_sizes(
 @jax.jit(
     static_argnames=(
         "use_causal_mask",
+        "update_kv_cache",
         "skip_kv_mask",
         "sm_scale",
         "sliding_window",
@@ -1579,6 +1595,7 @@ def ragged_paged_attention(
     distribution: jax.Array,  # i32[3]
     *,
     use_causal_mask: bool = True,
+    update_kv_cache: bool = True,
     skip_kv_mask: bool = False,
     sm_scale: float = 1.0,
     sliding_window: int | None = None,
@@ -1793,6 +1810,7 @@ def ragged_paged_attention(
             functools.partial(
                 _ragged_paged_attention_kernel,
                 use_causal_mask=use_causal_mask,
+                update_kv_cache=update_kv_cache,
                 skip_kv_mask=skip_kv_mask,
                 sm_scale=sm_scale,
                 sliding_window=sliding_window,

--- a/tpu_inference/layers/common/attention_interface.py
+++ b/tpu_inference/layers/common/attention_interface.py
@@ -339,6 +339,7 @@ def sharded_ragged_paged_attention(
     q_scale: float | None = None,
     k_scale: float | None = None,
     v_scale: float | None = None,
+    update_kv_cache: bool = True,
 ):
     """Shards along KV heads."""
     # Handle GQA/MQA where num_kv_heads < tp_size
@@ -384,15 +385,28 @@ def sharded_ragged_paged_attention(
         in_specs += (P(ShardingAxisName.ATTN_HEAD), )
         args += (attention_sink, )
 
+    # update_kv_cache=False (KV-share) is supported by the v3 default RPA
+    # kernel and by the experimental batched RPA kernel. The hd64 path
+    # doesn't accept it; fail loud rather than silently ignoring.
+    if use_hd64 and not update_kv_cache:
+        raise NotImplementedError(
+            "update_kv_cache=False (KV-share) is not supported on the "
+            "head_dim==64 RPA kernel.")
+
     def _ragged_paged_attention(*args):
-        return func(
-            *args,
+        kwargs = dict(
             sm_scale=sm_scale,
             sliding_window=attention_chunk_size,
             q_scale=q_scale,
             k_scale=k_scale,
             v_scale=v_scale,
         )
+        # update_kv_cache is supported by both the v3 default and batched
+        # RPA kernels; only the hd64 path doesn't accept it. Default True
+        # is a no-op so we don't forward it to the hd64 signature.
+        if not use_hd64:
+            kwargs["update_kv_cache"] = update_kv_cache
+        return func(*args, **kwargs)
 
     return jax.shard_map(
         _ragged_paged_attention,
@@ -417,6 +431,7 @@ def attention(
     k_scale: float | None = None,
     v_scale: float | None = None,
     sinks: jax.Array | None = None,
+    update_kv_cache: bool = True,
 ) -> Tuple[jax.Array, jax.Array]:
     # T: seq_len
     # N: num_heads
@@ -455,6 +470,7 @@ def attention(
         q_scale=q_scale,
         k_scale=k_scale,
         v_scale=v_scale,
+        update_kv_cache=update_kv_cache,
     )
 
     return kv_cache, output


### PR DESCRIPTION
## Summary

Enables `update_kv_cache=False` (KV-share: skip cache write, read full kv_len from the redirected cache slot) on **both** the default v3 RPA kernel and the experimental batched RPA kernel.

- Re-lands the v3-kernel support originally added by #2601 (reverted in #2628 because the wrapper-level kwarg-forwarding crashed the batched path with `TypeError: ragged_paged_attention() got an unexpected keyword argument 'update_kv_cache'`).
- Adds matching `update_kv_cache=False` semantics to the batched RPA kernel so the wrapper can safely forward the kwarg to whichever kernel is bound.

With this PR, KV-share models (Gemma-4 E2B / E4B, etc.) work on `MODEL_IMPL_TYPE=flax_nnx` regardless of whether `USE_BATCHED_RPA_KERNEL=1` is set.

The originally-reported nightly regression (req/s 4.76 → 2.94 on Gemma4-31B with `USE_BATCHED_RPA_KERNEL=1`) was the TypeError killing the server at trace time, misclassified by the harness as throughput. With this PR the server boots cleanly on both kernels.

## Approach

### v3 default kernel (re-lands #2601)

- `kernels/ragged_paged_attention/v3/kernel.py`: new `update_kv_cache: bool = True` static argument on `ragged_paged_attention`. When `False`, read all `kv_len` from cache and skip the bq-loop's cache-write block.

### Batched RPA kernel (new)

The batched kernel already had the right hooks: its schedule kernel pre-computes a per-`(step, batch)` `do_writeback` flag, and `KVBufferedRef.copy_out` respects it. Adding `update_kv_cache=False` semantics is then just: in `compute_metadata::k_loop`, set `kv_left_frm_cache = kv_len` (instead of `max(kv_len - q_len, 0)`). `kv_left_frm_new` then becomes 0, `new_sz` is 0, and the existing
```python
do_writeback = where((new_sz > 0) & (q_idx == q_wb), 1, 0)
```
line naturally produces 0 — no extra gate needed.

`update_kv_cache: bool = True` is plumbed as a Python-level static through:
- `kernels/experimental/batched_rpa/wrapper.py::ragged_paged_attention` (new `static_argname`)
- `schedule.py::generate_rpa_metadata`
- `schedule.py::rpa_metadata_schedule_kernel`
- `schedule.py::compute_metadata` (gates the `kv_left_frm_cache` branch)

### Wrapper

`layers/common/attention_interface.py`:
- `sharded_ragged_paged_attention` and `attention()` accept `update_kv_cache: bool = True` and forward it to **both** kernels on the non-hd64 path.
- hd64 path raises `NotImplementedError` for `update_kv_cache=False` (no current model uses head_dim=64 + KV-share).

## Tests

- `tests/kernels/ragged_paged_attention_kernel_v3_test.py` — 3 v3-kernel KV-share unit tests (prefill, decode, chunked-prefill) verifying input k/v is unused and the cache is unmutated. (Re-landed from #2601.)
- `tests/layers/common/test_attention_interface.py`:
  - `test_sharded_rpa_forwards_update_kv_cache_when_not_hd64` — wrapper forwards the kwarg.
  - `test_batched_rpa_wrapper_accepts_update_kv_cache` — `inspect.signature` check that directly catches the original regression (batched wrapper missing the kwarg).
  - `test_sharded_rpa_rejects_update_kv_cache_false_on_hd64` — hd64 fails loud.

## E2B end-to-end (Gemma-4 E2B-it offline_inference on v6e)

With #2572 rebased on top of this PR (earlier integration BK [#448](https://buildkite.com/tpu-commons/tpu-inference-dev/builds/448)):

| probe | kernel | errors | generated | sample |
|---|---|---|---|---|
| default RPA | `Using default RPA kernel` | 0 | 35/35 | "...The capital of France is **Paris**." |
| batched RPA | `Using experimental batched RPA kernel` | 0 | 35/35 | "...The capital of France is **Paris**." |

Outputs are byte-identical across the two paths.

## Stack

- This PR unblocks #2572 (Gemma-4 E2B JAX-path) — E2B's KV-shared layers work on both kernels.
- Supersedes #2628 (the full revert). After this PR merges, no further action needed on #2628.