### PR TITLE
Offload index gathering to the SparseCore in the ragged gather-reduce…

### DIFF
--- a/tpu_inference/kernels/sparse_core/ragged_gather_reduce.py
+++ b/tpu_inference/kernels/sparse_core/ragged_gather_reduce.py
@@ -553,7 +553,7 @@ def ragged_gather_reduce(
             num_row_partitions=num_row_partitions,
             num_column_partitions=num_column_partitions,
         ),
-        out_type=jax.ShapeDtypeStruct(
+        out_shape=jax.ShapeDtypeStruct(
             (x.shape[0] // reduce_group_size, x.shape[1]),
             jnp.float32,
         ),
@@ -561,18 +561,16 @@ def ragged_gather_reduce(
             use_tc_tiling_on_sc=True,
             disable_bounds_checks=True,
         ),
-        scratch_types=dict(
-            num_rows_per_row_partition_vmem_ref=pltpu.VMEM((num_simd_lanes, ),
-                                                           jnp.int32),
-            out_vmem_ref=pltpu.VMEM((num_simd_lanes, col_size), jnp.uint32),
-            prev_iter_last_row_vmem_ref=pltpu.VMEM((1, col_size), jnp.uint32),
-            src_indices_vmem_ref=pltpu.VMEM((num_simd_lanes, ), jnp.int32),
-            dst_indices_vmem_ref=pltpu.VMEM((num_simd_lanes, ), jnp.int32),
-            topk_weights_vmem_ref=pltpu.VMEM((num_simd_lanes, ), jnp.float32),
-            sorted_by_validity_vmem_ref=pltpu.VMEM((num_simd_lanes, ),
-                                                   jnp.int32),
-            sem_ref=pltpu.SemaphoreType.DMA((2, )),
-        ),
+        scratch_shapes=[
+            pltpu.VMEM((num_simd_lanes, ), jnp.int32),
+            pltpu.VMEM((num_simd_lanes, col_size), jnp.uint32),
+            pltpu.VMEM((1, col_size), jnp.uint32),
+            pltpu.VMEM((num_simd_lanes, ), jnp.int32),
+            pltpu.VMEM((num_simd_lanes, ), jnp.int32),
+            pltpu.VMEM((num_simd_lanes, ), jnp.float32),
+            pltpu.VMEM((num_simd_lanes, ), jnp.int32),
+            pltpu.SemaphoreType.DMA((2, )),
+        ],
         mesh=vector_mesh,
         name="sc_ragged_gather_reduce",
     )(

--- a/tpu_inference/kernels/sparse_core/ragged_gather_reduce.py
+++ b/tpu_inference/kernels/sparse_core/ragged_gather_reduce.py
@@ -99,9 +99,10 @@ def main_kernel(
     # Inputs.
     num_rows_per_row_partition_ref: jax.Ref,
     in_hbm_ref: jax.Ref,
-    src_indices_hbm_ref: jax.Ref,
+    indices_hbm_ref: jax.Ref,
     dst_indices_hbm_ref: jax.Ref,
     topk_weights_hbm_ref: jax.Ref,
+    sorted_by_validity_hbm_ref: jax.Ref,
     # Outputs.
     out_hbm_ref: jax.Ref,
     # Scratch.
@@ -111,6 +112,7 @@ def main_kernel(
     src_indices_vmem_ref: jax.Ref,
     dst_indices_vmem_ref: jax.Ref,
     topk_weights_vmem_ref: jax.Ref,
+    sorted_by_validity_vmem_ref: jax.Ref,
     sem_ref: jax.Ref,
     *,
     core_axis_name: str,
@@ -176,9 +178,9 @@ def main_kernel(
             dma_list = []
             dma_list.append(
                 pltpu.make_async_copy(
-                    src_indices_hbm_ref.at[pl.ds(row_tile_start,
-                                                 num_simd_lanes)],
-                    src_indices_vmem_ref,
+                    sorted_by_validity_hbm_ref.at[pl.ds(
+                        row_tile_start, num_simd_lanes)],
+                    sorted_by_validity_vmem_ref,
                     recv_sem,
                 ))
             dma_list.append(
@@ -188,11 +190,20 @@ def main_kernel(
                     dst_indices_vmem_ref,
                     recv_sem,
                 ))
+            jax.tree.map(lambda x: x.start(), dma_list)
+            jax.tree.map(lambda x: x.wait(), dma_list)
+
+            dma_list = []
             dma_list.append(
                 pltpu.make_async_copy(
-                    topk_weights_hbm_ref.at[pl.ds(row_tile_start,
-                                                  num_simd_lanes)],
+                    topk_weights_hbm_ref.at[sorted_by_validity_vmem_ref],
                     topk_weights_vmem_ref,
+                    recv_sem,
+                ))
+            dma_list.append(
+                pltpu.make_async_copy(
+                    indices_hbm_ref.at[sorted_by_validity_vmem_ref],
+                    src_indices_vmem_ref,
                     recv_sem,
                 ))
             jax.tree.map(lambda x: x.start(), dma_list)
@@ -227,9 +238,12 @@ def main_kernel(
 
             # VMEM to HBM transfer.
             # Use dynamic loop to minimize register spills.
+            @pl.loop(0,
+                     col_size,
+                     step=num_lanes,
+                     init_carry=(prev_dst_row_hbm, ))
             @jax.named_scope("dma_write_loop")
-            def dma_write_loop(i, carry):
-                col_vmem_start = i * num_lanes
+            def dma_write_loop(col_vmem_start, carry):
                 col_hbm_start = col_start + col_vmem_start
 
                 for _ in range(num_simd_lanes):
@@ -359,12 +373,6 @@ def main_kernel(
 
                 return carry
 
-            jax.lax.fori_loop(
-                0,
-                pl.cdiv(col_size, num_lanes),
-                dma_write_loop,
-                init_val=(prev_dst_row_hbm, ),
-            )
             # Wait for dma write to finish.
             for _ in range(0, col_size, num_lanes):
                 for _ in range(num_simd_lanes):
@@ -380,12 +388,11 @@ def main_kernel(
 # TODO(gxd): investigate if we can make the preprocessing more efficient.
 def _preprocess(
     indices: jax.Array,
-    topk_weights: jax.Array,
     valid_rows_mask: jax.Array,
     reduce_group_size: int,
     num_row_partitions: int,
     num_simd_lanes: int,
-) -> tuple[jax.Array, jax.Array, jax.Array, jax.Array, jax.Array]:
+) -> tuple[jax.Array, jax.Array, jax.Array, jax.Array]:
     """Preprocesses indices for ragged gather reduce."""
     assert indices.ndim == 1, "Ragged scatter only supports 1d indices."
 
@@ -403,12 +410,10 @@ def _preprocess(
     ) * row_partition_size)
     sorted_by_validity = sorted_by_validity.reshape(-1)
 
-    src_indices = indices[sorted_by_validity]
     # `reduce_group_size` source rows are mapped (and reduced) to the same output
     # row.
     dst_indices = sorted_by_validity // reduce_group_size
-    topk_weights = topk_weights[sorted_by_validity]
-    topk_weights = topk_weights.astype(jnp.float32)
+    sorted_by_validity = sorted_by_validity.astype(jnp.int32)
 
     num_src_rows_per_row_partition = jnp.sum(valid_rows_mask, axis=-1)
     assert num_row_partitions <= num_simd_lanes
@@ -421,9 +426,8 @@ def _preprocess(
     mask = jnp.any(valid_rows_mask.reshape(-1, reduce_group_size), axis=-1)
 
     return (
-        src_indices,
         dst_indices,
-        topk_weights,
+        sorted_by_validity,
         num_src_rows_per_row_partition,
         mask,
     )
@@ -521,14 +525,12 @@ def ragged_gather_reduce(
     col_size = x.shape[-1] // num_column_partitions
 
     (
-        src_indices,
         dst_indices,
-        topk_weights,
+        sorted_by_validity,
         num_src_rows_per_row_partition,
         mask,
     ) = _preprocess(
         indices,
-        topk_weights,
         valid_rows_mask,
         reduce_group_size,
         num_row_partitions,
@@ -551,7 +553,7 @@ def ragged_gather_reduce(
             num_row_partitions=num_row_partitions,
             num_column_partitions=num_column_partitions,
         ),
-        out_shape=jax.ShapeDtypeStruct(
+        out_type=jax.ShapeDtypeStruct(
             (x.shape[0] // reduce_group_size, x.shape[1]),
             jnp.float32,
         ),
@@ -559,19 +561,28 @@ def ragged_gather_reduce(
             use_tc_tiling_on_sc=True,
             disable_bounds_checks=True,
         ),
-        scratch_shapes=[
-            pltpu.VMEM((num_simd_lanes, ), jnp.int32),
-            pltpu.VMEM((num_simd_lanes, col_size), jnp.uint32),
-            pltpu.VMEM((1, col_size), jnp.uint32),
-            pltpu.VMEM((num_simd_lanes, ), jnp.int32),
-            pltpu.VMEM((num_simd_lanes, ), jnp.int32),
-            pltpu.VMEM((num_simd_lanes, ), jnp.float32),
-            pltpu.SemaphoreType.DMA((2, )),
-        ],
+        scratch_types=dict(
+            num_rows_per_row_partition_vmem_ref=pltpu.VMEM((num_simd_lanes, ),
+                                                           jnp.int32),
+            out_vmem_ref=pltpu.VMEM((num_simd_lanes, col_size), jnp.uint32),
+            prev_iter_last_row_vmem_ref=pltpu.VMEM((1, col_size), jnp.uint32),
+            src_indices_vmem_ref=pltpu.VMEM((num_simd_lanes, ), jnp.int32),
+            dst_indices_vmem_ref=pltpu.VMEM((num_simd_lanes, ), jnp.int32),
+            topk_weights_vmem_ref=pltpu.VMEM((num_simd_lanes, ), jnp.float32),
+            sorted_by_validity_vmem_ref=pltpu.VMEM((num_simd_lanes, ),
+                                                   jnp.int32),
+            sem_ref=pltpu.SemaphoreType.DMA((2, )),
+        ),
         mesh=vector_mesh,
         name="sc_ragged_gather_reduce",
-    )(num_src_rows_per_row_partition, x, src_indices, dst_indices,
-      topk_weights)
+    )(
+        num_src_rows_per_row_partition,
+        x,
+        indices,
+        dst_indices,
+        topk_weights.astype(jnp.float32),
+        sorted_by_validity,
+    )
 
     # If there is no valid source row in a reduce group, set that group's output
     # to zero.


### PR DESCRIPTION
Currently, the topk_weights gather is performed on the TensorCore during preprocessing, which prevents TC/SC overlap. This PR offloads the gather directly to the SparseCore to decouple the execution and reduce TC overhead.

**Performance (DeepSeekV3 microbenchmark, bs=2k, EP=16):**
TC Overhead: 29µs → 14µs
Overall Latency: 146µs → 137µs