### PR TITLE
[NVFP4] Add NVFP4 for non-standard config models

### DIFF
--- a/tests/layers/vllm/test_nvfp4.py
+++ b/tests/layers/vllm/test_nvfp4.py
@@ -165,6 +165,27 @@ def setup_environment():
              test_utils.get_spmd_mesh(2)])
 def test_quant_override(mesh):
     """VllmNvfp4Config.override_quantization_method detects NVFP4."""
+    # 1. New style: quant_library + quant_algo (ModelOpt)
+    result = VllmNvfp4Config.override_quantization_method(
+        {
+            "quant_library": "MODELOPT",
+            "quant_algo": "NVFP4"
+        },
+        user_quant=None,
+    )
+    assert result == NVFP4
+
+    # 2. Case insensitivity check
+    result = VllmNvfp4Config.override_quantization_method(
+        {
+            "quant_library": "modelopt",
+            "quant_algo": "nvfp4"
+        },
+        user_quant=None,
+    )
+    assert result == NVFP4
+
+    # 3. Old style: quant_method (fallback to super)
     result = VllmNvfp4Config.override_quantization_method(
         {
             "quant_method": "modelopt",
@@ -174,12 +195,19 @@ def test_quant_override(mesh):
     )
     assert result == NVFP4
 
-    # Non-NVFP4 should return None.
+    # 4. Non-NVFP4 should return None (or whatever super returns).
     result = VllmNvfp4Config.override_quantization_method(
         {
-            "quant_method": "modelopt",
+            "quant_library": "MODELOPT",
             "quant_algo": "FP8"
         },
+        user_quant=None,
+    )
+    assert result is None
+
+    # 5. hf_quant_cfg=None should return None (fallback to super).
+    result = VllmNvfp4Config.override_quantization_method(
+        None,
         user_quant=None,
     )
     assert result is None

--- a/tpu_inference/layers/vllm/quantization/nvfp4.py
+++ b/tpu_inference/layers/vllm/quantization/nvfp4.py
@@ -39,8 +39,8 @@ from vllm.model_executor.layers.attention import Attention
 from vllm.model_executor.layers.fused_moe import FusedMoE, FusedMoEMethodBase
 from vllm.model_executor.layers.fused_moe.activation import MoEActivation
 from vllm.model_executor.layers.linear import LinearBase
-from vllm.model_executor.layers.quantization import \
-    register_quantization_config
+from vllm.model_executor.layers.quantization import (
+    QuantizationMethods, register_quantization_config)
 from vllm.model_executor.layers.quantization.base_config import \
     QuantizeMethodBase
 from vllm.model_executor.layers.quantization.modelopt import (
@@ -78,6 +78,20 @@ class VllmNvfp4Config(ModelOptNvFp4Config, VllmQuantConfig):
     @classmethod
     def get_name(cls):
         return NVFP4
+
+    @classmethod
+    def override_quantization_method(
+            cls,
+            hf_quant_cfg,
+            user_quant,
+            hf_config=None) -> Optional[QuantizationMethods]:
+        if hf_quant_cfg is not None:
+            quant_library = str(hf_quant_cfg.get("quant_library", "")).upper()
+            quant_algo = str(hf_quant_cfg.get("quant_algo", "")).upper()
+            if quant_library == "MODELOPT" and quant_algo == "NVFP4":
+                return NVFP4
+        return super().override_quantization_method(hf_quant_cfg, user_quant,
+                                                    hf_config)
 
     def get_quant_method(self, layer: torch.nn.Module,
                          prefix: str) -> Optional[Union[QuantizeMethodBase]]:


### PR DESCRIPTION
# Description

Some NVFP4 models, like [480B](https://huggingface.co/NVFP4/Qwen3-Coder-480B-A35B-Instruct-FP4/blob/main/config.json), use a slightly different config format to indicate the quant method.  This PR adds support for that.

Exmaple:

<img width="1354" height="307" alt="image" src="https://github.com/user-attachments/assets/04f2d5d9-b1fa-4c39-b0a0-84ca19bb7e65" />

# Tests

Ran:

```
# server
USE_BATCHED_RPA_KERNEL=1    MODEL_IMPL_TYPE=vllm  vllm serve NVFP4/Qwen3-Coder-480B-A35B-Instruct-FP4 --max-model-len=9216 --max-num-batched-tokens=8192 --max-num-seqs=512 --kv-cache-dtype=fp8 --no-enable-prefix-caching --gpu-memory-utilization=0.8 --tensor-parallel-size=8 --async-scheduling --block-size=256 --enable-expert-parallel 

# client

DEFAULT_HOST=[0.0.0.0](https://www.google.com/url?sa=D&q=http%3A%2F%2F0.0.0.0)
DEFAULT_PORT=8000

nc -zv $DEFAULT_HOST $DEFAULT_PORT
while [ $? -ne 0 ]; do
  echo "Waiting for the server to start..."
  sleep 15
  nc -zv $DEFAULT_HOST $DEFAULT_PORT
done


for config in "1024 1024" "8192 1024" "1024 8192"; do
  set -- $config
  echo "Running benchmark with input_len=$1 and output_len=$2"

  args=(
      --ignore-eos
      --model=Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8
      --backend=vllm
      --port=$DEFAULT_PORT
      --dataset-name=random
      --random-input-len=$1
      --random-output-len=$2
      --random-range-ratio=0.8
      --num-prompts=320
      --max-concurrency=64
      --request-rate=inf
      --ignore-eos
      --percentile-metrics='ttft,tpot,itl,e2el'
  )
  # git clone [https://github.com/kimbochen/bench_serving.git](https://www.google.com/url?sa=D&q=https%3A%2F%2Fgithub.com%2Fkimbochen%2Fbench_serving.git)
  python3 /home/kyuyeunk_google_com/workspace/bench_serving/benchmark_serving.py "${args[@]}"
done

```


# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
