### PR TITLE
[DP][Multi-modal] Fix DP in Gemma4 multi-modal input

### DIFF
--- a/.buildkite/benchmark/cases/daily/Gemma4-26B-dataset_custom-inlen_1024-outlen_500.json
+++ b/.buildkite/benchmark/cases/daily/Gemma4-26B-dataset_custom-inlen_1024-outlen_500.json
@@ -30,6 +30,11 @@
           "model": "google/gemma-4-26B-A4B-it",
           "max-num-seqs": 256,
           "max-num-batched-tokens": 4096,
+          "data-parallel-size": {
+              "v6e-8": 2,
+              "v7x-2": 4,
+              "default": 1
+          },
           "tensor-parallel-size": {
             "v7x-2": 2,
             "default": 1
@@ -80,6 +85,11 @@
           "model": "google/gemma-4-26B-A4B-it",
           "max-num-seqs": 256,
           "max-num-batched-tokens": 4096,
+          "data-parallel-size": {
+              "v6e-8": 2,
+              "v7x-2": 4,
+              "default": 1
+          },
           "tensor-parallel-size": {
             "v7x-2": 2,
             "default": 1

--- a/.buildkite/benchmark/cases/daily/Gemma4-31B-dataset_custom-inlen_1024-outlen_500.json
+++ b/.buildkite/benchmark/cases/daily/Gemma4-31B-dataset_custom-inlen_1024-outlen_500.json
@@ -30,6 +30,11 @@
           "model": "google/gemma-4-31B-it",
           "max-num-seqs": 256,
           "max-num-batched-tokens": 4096,
+          "data-parallel-size": {
+              "v6e-8": 2,
+              "v7x-2": 4,
+              "default": 1
+          },
           "tensor-parallel-size": {
             "v6e-8": 4,
             "v7x-2": 2,
@@ -81,6 +86,11 @@
           "model": "google/gemma-4-31B-it",
           "max-num-seqs": 256,
           "max-num-batched-tokens": 4096,
+          "data-parallel-size": {
+              "v6e-8": 2,
+              "v7x-2": 4,
+              "default": 1
+          },
           "tensor-parallel-size": {
             "v6e-8": 4,
             "v7x-2": 2,

--- a/tests/runner/test_multimodal_manager.py
+++ b/tests/runner/test_multimodal_manager.py
@@ -17,6 +17,8 @@ from unittest.mock import MagicMock, patch
 import jax
 import jax.numpy as jnp
 import numpy as np
+import pytest
+from jax._src import test_util as jtu
 from vllm.config import (CacheConfig, ModelConfig, ParallelConfig,
                          SchedulerConfig, SpeculativeConfig, VllmConfig)
 from vllm.model_executor.layers.rotary_embedding import MRotaryEmbedding
@@ -320,7 +322,10 @@ class TestMultiModalManager:
 
         gathered_mm_embeds_1, gathered_is_mm_embed_1 = self.runner.mm_manager.gather_mm_embeddings(
             mock_scheduler_output_1,
-            target_pad_len=mock_scheduler_output_1.total_num_scheduled_tokens)
+            target_pad_len=mock_scheduler_output_1.total_num_scheduled_tokens,
+            req_ids_dp={0: [req_id]},
+            padded_num_scheduled_tokens_per_dp_rank=mock_scheduler_output_1.
+            total_num_scheduled_tokens)
 
         assert gathered_mm_embeds_1 is not None
         assert isinstance(gathered_mm_embeds_1, list)
@@ -345,7 +350,10 @@ class TestMultiModalManager:
 
         gathered_mm_embeds_2, gathered_is_mm_embed_2 = self.runner.mm_manager.gather_mm_embeddings(
             mock_scheduler_output_2,
-            target_pad_len=mock_scheduler_output_2.total_num_scheduled_tokens)
+            target_pad_len=mock_scheduler_output_2.total_num_scheduled_tokens,
+            req_ids_dp={0: [req_id]},
+            padded_num_scheduled_tokens_per_dp_rank=mock_scheduler_output_2.
+            total_num_scheduled_tokens)
 
         assert gathered_mm_embeds_2 is not None
         assert isinstance(gathered_mm_embeds_2, list)
@@ -370,7 +378,10 @@ class TestMultiModalManager:
 
         gathered_mm_embeds_3, gathered_is_mm_embed_3 = self.runner.mm_manager.gather_mm_embeddings(
             mock_scheduler_output_3,
-            target_pad_len=mock_scheduler_output_3.total_num_scheduled_tokens)
+            target_pad_len=mock_scheduler_output_3.total_num_scheduled_tokens,
+            req_ids_dp={0: [req_id]},
+            padded_num_scheduled_tokens_per_dp_rank=mock_scheduler_output_3.
+            total_num_scheduled_tokens)
 
         assert gathered_mm_embeds_3 is not None
         assert isinstance(gathered_mm_embeds_3, list)
@@ -440,7 +451,10 @@ class TestMultiModalManager:
         with patch.object(MRotaryEmbedding,
                           "get_next_input_positions_tensor") as mock_get_next:
             # 2. ===== Act =====
-            self.runner.mm_manager.calc_mrope_positions(mock_scheduler_output)
+            self.runner.mm_manager.calc_mrope_positions(
+                mock_scheduler_output,
+                req_ids_dp={0: [req_id]},
+                padded_num_scheduled_tokens_per_dp_rank=num_scheduled)
 
             # 3. ===== Assert =====
             # The first 5 positions should be copied from the pre-computed prompt positions
@@ -458,3 +472,178 @@ class TestMultiModalManager:
             assert call_kwargs["mrope_position_delta"] == mrope_delta
             assert call_kwargs["context_len"] == prompt_len
             assert call_kwargs["num_new_tokens"] == 5
+
+    # The test is slow on v6e, causing timeouts in presubmit. See b/513860288.
+    @pytest.mark.skipif(not jtu.is_device_tpu_at_least(version=7),
+                        reason="Expect TPUv7+")
+    def test_gather_mm_embeddings_dp_aware(self):
+        """Verifies that with dp_size>1, mm tokens for each request land in
+        that request's rank slot of is_mm_embed (offset = rank * padded_per_rank),
+        and that mm_embeds is emitted in (rank, then req-within-rank) order so
+        a downstream cumsum-based gather aligns."""
+        self.runner.is_multimodal_model = True
+
+        # Two requests, one per DP rank, each with its own image embedding.
+        # Image placeholder slot is offset=5, length=10 within each request.
+        req_id_a, req_id_b = "req-a", "req-b"
+        emb_a = jnp.arange(10 * 128, dtype=jnp.bfloat16).reshape((10, 128))
+        emb_b = (jnp.arange(10 * 128, dtype=jnp.bfloat16) + 1000.0).reshape(
+            (10, 128))
+        self.runner.encoder_cache = {req_id_a: emb_a, req_id_b: emb_b}
+
+        mock_sampling_params = MagicMock()
+        mock_sampling_params.sampling_type = SamplingType.GREEDY
+        mock_sampling_params.top_k = -1
+        mock_sampling_params.top_p = 1.0
+        mock_sampling_params.temperature = 0.0
+        mock_sampling_params.min_tokens = 0
+        mock_sampling_params.logprobs = None
+        mock_sampling_params.logit_bias = None
+        mock_sampling_params.allowed_token_ids = set()
+        mock_sampling_params.bad_words_token_ids = None
+        mock_sampling_params.all_stop_token_ids = set()
+
+        def _make_req(req_id):
+            return CachedRequestState(
+                req_id=req_id,
+                prompt_token_ids=list(range(20)),
+                output_token_ids=[],
+                sampling_params=mock_sampling_params,
+                block_ids=([], ),
+                num_computed_tokens=0,
+                mm_features=[
+                    MultiModalFeatureSpec(
+                        data=None,
+                        identifier=req_id,
+                        modality="image",
+                        mm_position=PlaceholderRange(offset=5, length=10),
+                    )
+                ],
+                lora_request=None,
+                pooling_params=None,
+                generator=None,
+            )
+
+        req_a, req_b = _make_req(req_id_a), _make_req(req_id_b)
+        self.runner.requests = {req_id_a: req_a, req_id_b: req_b}
+        self.runner.input_batch.add_request(req_a)
+        self.runner.input_batch.add_request(req_b)
+
+        mock_scheduler_output = MagicMock(spec=VllmSchedulerOutput)
+        mock_scheduler_output.num_scheduled_tokens = {
+            req_id_a: 20,
+            req_id_b: 20,
+        }
+
+        # padded_per_rank=24 (>20); target_pad_len=48 (= 24 * 2).
+        padded_per_rank = 24
+        target_pad_len = padded_per_rank * 2
+        req_ids_dp = {0: [req_id_a], 1: [req_id_b]}
+
+        mm_embeds, is_mm_embed = self.runner.mm_manager.gather_mm_embeddings(
+            mock_scheduler_output,
+            target_pad_len=target_pad_len,
+            req_ids_dp=req_ids_dp,
+            padded_num_scheduled_tokens_per_dp_rank=padded_per_rank,
+        )
+
+        # Order: rank 0's embed first, rank 1's second.
+        assert mm_embeds is not None and len(mm_embeds) == 2
+        np.testing.assert_array_equal(np.asarray(mm_embeds[0]),
+                                      np.asarray(emb_a))
+        np.testing.assert_array_equal(np.asarray(mm_embeds[1]),
+                                      np.asarray(emb_b))
+
+        # Within each rank's slot, True bits sit at [5, 15). Padding slots
+        # ([20, 24) within each rank) stay False.
+        expected = np.zeros(target_pad_len, dtype=np.bool_)
+        expected[5:15] = True
+        expected[padded_per_rank + 5:padded_per_rank + 15] = True
+        np.testing.assert_array_equal(np.asarray(is_mm_embed), expected)
+        # Sanity: the cumsum-based downstream gather requires the kth True
+        # bit globally to correspond to mm_embeds[k]; this layout satisfies it
+        # because rank 0's True bits precede rank 1's.
+        assert is_mm_embed.shape == (target_pad_len, )
+
+    # The test is slow on v6e, causing timeouts in presubmit. See b/513860288.
+    @pytest.mark.skipif(not jtu.is_device_tpu_at_least(version=7),
+                        reason="Expect TPUv7+")
+    def test_calc_mrope_positions_dp_aware(self):
+        """Verifies that with dp_size>1, each request's mrope_positions are
+        written into its rank's slot of mrope_positions_cpu rather than packed
+        sequentially into rank 0's slot."""
+        self.runner.uses_mrope = True
+
+        req_id_a, req_id_b = "req-a", "req-b"
+        prompt_len = 8
+        num_scheduled = 8
+
+        # Distinguishable mrope_positions for each request.
+        mrope_a = np.arange(3 * prompt_len, dtype=np.int64).reshape(
+            (3, prompt_len))
+        mrope_b = (np.arange(3 * prompt_len, dtype=np.int64) + 1000).reshape(
+            (3, prompt_len))
+
+        mock_sampling_params = MagicMock()
+        mock_sampling_params.sampling_type = SamplingType.GREEDY
+        mock_sampling_params.top_k = -1
+        mock_sampling_params.top_p = 1.0
+        mock_sampling_params.temperature = 0.0
+        mock_sampling_params.min_tokens = 0
+        mock_sampling_params.logprobs = None
+        mock_sampling_params.logit_bias = None
+        mock_sampling_params.allowed_token_ids = set()
+        mock_sampling_params.bad_words_token_ids = None
+        mock_sampling_params.all_stop_token_ids = set()
+
+        def _make_req(req_id, mrope):
+            return CachedRequestState(
+                req_id=req_id,
+                prompt_token_ids=list(range(prompt_len)),
+                output_token_ids=[],
+                sampling_params=mock_sampling_params,
+                block_ids=([], ),
+                num_computed_tokens=0,
+                mm_features=[],
+                lora_request=None,
+                pooling_params=None,
+                generator=None,
+                mrope_positions=mrope,
+                mrope_position_delta=0,
+            )
+
+        req_a = _make_req(req_id_a, mrope_a)
+        req_b = _make_req(req_id_b, mrope_b)
+        self.runner.requests = {req_id_a: req_a, req_id_b: req_b}
+        self.runner.input_batch.add_request(req_a)
+        self.runner.input_batch.add_request(req_b)
+        # Zero num_computed_tokens for both so the full prompt is scheduled.
+        self.runner.input_batch.num_computed_tokens_cpu[0] = 0
+        self.runner.input_batch.num_computed_tokens_cpu[1] = 0
+
+        mock_scheduler_output = MagicMock(spec=VllmSchedulerOutput)
+        mock_scheduler_output.num_scheduled_tokens = {
+            req_id_a: num_scheduled,
+            req_id_b: num_scheduled,
+        }
+
+        padded_per_rank = 16  # > num_scheduled, leaves trailing padding slots
+        req_ids_dp = {0: [req_id_a], 1: [req_id_b]}
+
+        # Pre-fill mrope_positions_cpu with a sentinel so we can detect that
+        # writes only landed in the intended slots.
+        self.runner.mrope_positions_cpu[:] = -7
+        self.runner.mm_manager.calc_mrope_positions(
+            mock_scheduler_output,
+            req_ids_dp=req_ids_dp,
+            padded_num_scheduled_tokens_per_dp_rank=padded_per_rank,
+        )
+
+        # Rank 0's slot: [0, 8) holds mrope_a; [8, 16) untouched.
+        np.testing.assert_array_equal(self.runner.mrope_positions_cpu[:, 0:8],
+                                      mrope_a)
+        assert np.all(self.runner.mrope_positions_cpu[:, 8:16] == -7)
+        # Rank 1's slot: [16, 24) holds mrope_b; [24, 32) untouched.
+        np.testing.assert_array_equal(
+            self.runner.mrope_positions_cpu[:, 16:24], mrope_b)
+        assert np.all(self.runner.mrope_positions_cpu[:, 24:32] == -7)

--- a/tests/runner/test_tpu_runner.py
+++ b/tests/runner/test_tpu_runner.py
@@ -176,8 +176,8 @@ class TestTPUJaxRunner:
         mock_sampling_metadata.from_input_batch.return_value = mock_sampling_instance
 
         output = self.runner._prepare_inputs(scheduler_output)
-        assert len(output) == 8
-        input_ids, positions, attention_metadata, sampling_metadata, logits_indices, spec_decode_metadata, logits_indices_selector, padded_num_reqs = output
+        assert len(output) == 10
+        input_ids, positions, attention_metadata, sampling_metadata, logits_indices, spec_decode_metadata, logits_indices_selector, padded_num_reqs, req_ids_dp, padded_num_scheduled_tokens_per_dp_rank = output
         # assert it will create attention metadata for each layer.
         assert isinstance(attention_metadata, dict)
         assert len(attention_metadata) == 20

--- a/tests/runner/test_tpu_runner_dp.py
+++ b/tests/runner/test_tpu_runner_dp.py
@@ -182,7 +182,7 @@ class TestTPUJaxRunnerDPInputsLightweight:
 
         result = self.runner._prepare_inputs(scheduler_output)
 
-        assert len(result) == 8
+        assert len(result) == 10
 
     @patch('jax.device_put', side_effect=lambda x, y: x)
     @patch('tpu_inference.runner.tpu_runner.NamedSharding')
@@ -209,8 +209,11 @@ class TestTPUJaxRunnerDPInputsLightweight:
         result = self.runner._prepare_inputs(scheduler_output)
 
         # Basic assertions
-        assert len(result) == 8
-        input_ids, positions, attention_metadata, sampling_metadata, logits_indices, spec_decode_metadata, logits_indices_selector, padded_num_reqs = result
+        assert len(result) == 10
+        (input_ids, positions, attention_metadata, sampling_metadata,
+         logits_indices, spec_decode_metadata, logits_indices_selector,
+         padded_num_reqs, req_ids_dp,
+         padded_num_scheduled_tokens_per_dp_rank) = result
 
         # Verify utility functions were called
         mock_runner_utils.get_padded_token_len.assert_called()
@@ -271,8 +274,11 @@ class TestTPUJaxRunnerDPInputsLightweight:
         result = self.runner._prepare_inputs(scheduler_output)
 
         # Basic assertions
-        assert len(result) == 8
-        input_ids, positions, attention_metadata, sampling_metadata, logits_indices, spec_decode_metadata, logits_indices_selector, padded_num_reqs = result
+        assert len(result) == 10
+        (input_ids, positions, attention_metadata, sampling_metadata,
+         logits_indices, spec_decode_metadata, logits_indices_selector,
+         padded_num_reqs, req_ids_dp,
+         padded_num_scheduled_tokens_per_dp_rank) = result
 
         # Verify utility functions were called
         mock_runner_utils.get_padded_token_len.assert_called()
@@ -543,7 +549,10 @@ class TestTPUJaxRunnerDPInputsLightweight:
 
         # Execute the method
         result = self.runner._prepare_inputs(scheduler_output)
-        input_ids, positions, attention_metadata, sampling_metadata, logits_indices, spec_decode_metadata, logits_indices_selector, padded_num_reqs = result
+        (input_ids, positions, attention_metadata, sampling_metadata,
+         logits_indices, spec_decode_metadata, logits_indices_selector,
+         padded_num_reqs, req_ids_dp,
+         padded_num_scheduled_tokens_per_dp_rank) = result
         # 1. Verify input_ids content
         expected_input_ids = np.zeros(16, dtype=np.int32)
         expected_input_ids[:2] = [1006, 1007]
@@ -650,7 +659,10 @@ class TestTPUJaxRunnerDPInputsLightweight:
 
         # Execute the method
         result = self.runner._prepare_inputs(scheduler_output)
-        input_ids, positions, attention_metadata, sampling_metadata, logits_indices, spec_decode_metadata, logits_indices_selector, padded_num_reqs = result
+        (input_ids, positions, attention_metadata, sampling_metadata,
+         logits_indices, spec_decode_metadata, logits_indices_selector,
+         padded_num_reqs, req_ids_dp,
+         padded_num_scheduled_tokens_per_dp_rank) = result
 
         # 1. Verify input_ids
         expected_input_ids = np.zeros(16, dtype=np.int32)
@@ -755,7 +767,10 @@ class TestTPUJaxRunnerDPInputsLightweight:
 
         # Execute the method
         result = self.runner._prepare_inputs(scheduler_output)
-        input_ids, positions, attention_metadata, sampling_metadata, logits_indices, spec_decode_metadata, logits_indices_selector, padded_num_reqs = result
+        (input_ids, positions, attention_metadata, sampling_metadata,
+         logits_indices, spec_decode_metadata, logits_indices_selector,
+         padded_num_reqs, req_ids_dp,
+         padded_num_scheduled_tokens_per_dp_rank) = result
 
         # Verify request_distribution
         # DP rank 0: req1 (decode), req2 (decode) -> [2, 2, 2]
@@ -815,7 +830,10 @@ class TestTPUJaxRunnerDPInputsLightweight:
 
         # Execute the method
         result = self.runner._prepare_inputs(scheduler_output)
-        input_ids, positions, attention_metadata, sampling_metadata, logits_indices, spec_decode_metadata, logits_indices_selector, padded_num_reqs = result
+        (input_ids, positions, attention_metadata, sampling_metadata,
+         logits_indices, spec_decode_metadata, logits_indices_selector,
+         padded_num_reqs, req_ids_dp,
+         padded_num_scheduled_tokens_per_dp_rank) = result
 
         # Verify request_distribution
         # Both ranks have only decode requests

--- a/tpu_inference/layers/common/attention_interface.py
+++ b/tpu_inference/layers/common/attention_interface.py
@@ -72,7 +72,7 @@ def sharded_flash_attention(
             P("data", "model", None, None),  # k
             P("data", "model", None, None),  # v
             P("data", "model", None, None),  # attention_bias
-            P(),  # segment_ids
+            P("data", None),  # segment_ids (B matches q's B, so shard 'data')
         )
         out_specs = P("data", "model", None, None)
 
@@ -92,7 +92,7 @@ def sharded_flash_attention(
             P("data", "model", None, None),  # q
             P("data", "model", None, None),  # k
             P("data", "model", None, None),  # v
-            P(),  # segment_ids
+            P("data", None),  # segment_ids (B matches q's B, so shard 'data')
         )
         out_specs = P("data", "model", None, None)
 

--- a/tpu_inference/models/jax/gemma4_mm.py
+++ b/tpu_inference/models/jax/gemma4_mm.py
@@ -748,26 +748,31 @@ class Gemma4ForConditionalGeneration(JaxModule, LoadableWithIterator):
         if pixel_position_ids.ndim == 2:
             pixel_position_ids = jnp.expand_dims(pixel_position_ids, axis=0)
 
-        # Batch all images into one vision-tower call so DP shards process
-        # different images in parallel. Gemma4VisionFlashAttention's
-        # sharded_flash_attention has in_specs=P('data','model',None,None),
-        # which requires B % data_size == 0; pad the batch axis up with
-        # pixel_position_ids=POSITIONS_PAD_VALUE so input_mask masks the
-        # padded entries out of the encoder.
+        # Process images in fixed-size micro-batches of exactly `dp_size` so
+        # every vision-tower call shares the same (B=dp_size, ...) JIT cache
+        # entry regardless of how many images this step has.
+        # Gemma4VisionFlashAttention's sharded_flash_attention has
+        # in_specs=P('data','model',None,None), which requires
+        # B % dp_size == 0; B=dp_size always satisfies that. The last
+        # micro-batch is right-padded with pixel_position_ids=POSITIONS_PAD_VALUE
+        # entries so input_mask masks the padded entries out of the encoder.
         n_images = pixel_values.shape[0]
         dp_size = self.mesh.shape[ShardingAxisName.BATCH]
-        padded_n = ((n_images + dp_size - 1) // dp_size) * dp_size
-        if padded_n > n_images:
-            pad_count = padded_n - n_images
-            pixel_values = jnp.pad(pixel_values,
-                                   ((0, pad_count), (0, 0), (0, 0)))
-            pixel_position_ids = jnp.pad(pixel_position_ids,
-                                         ((0, pad_count), (0, 0), (0, 0)),
-                                         constant_values=POSITIONS_PAD_VALUE)
-
-        vt_output = self.get_single_image_embedding(pixel_values,
-                                                    pixel_position_ids)
-        return [vt_output[i] for i in range(n_images)]
+        per_image_features = []
+        for chunk_start in range(0, n_images, dp_size):
+            chunk_end = min(chunk_start + dp_size, n_images)
+            chunk_size = chunk_end - chunk_start
+            pv_chunk = pixel_values[chunk_start:chunk_end]
+            pp_chunk = pixel_position_ids[chunk_start:chunk_end]
+            if chunk_size < dp_size:
+                pad_count = dp_size - chunk_size
+                pv_chunk = jnp.pad(pv_chunk, ((0, pad_count), (0, 0), (0, 0)))
+                pp_chunk = jnp.pad(pp_chunk, ((0, pad_count), (0, 0), (0, 0)),
+                                   constant_values=POSITIONS_PAD_VALUE)
+            vt_output = self.get_single_image_embedding(pv_chunk, pp_chunk)
+            for i in range(chunk_size):
+                per_image_features.append(vt_output[i])
+        return per_image_features
 
     def embed_multimodal(self, **kwargs) -> List[jax.Array]:
         image_input = self._parse_and_validate_image_input(**kwargs)

--- a/tpu_inference/models/jax/gemma4_mm.py
+++ b/tpu_inference/models/jax/gemma4_mm.py
@@ -23,19 +23,12 @@ from flax import nnx
 from jax.sharding import Mesh
 from transformers import PretrainedConfig
 from vllm.config import VllmConfig
-
-from tpu_inference.models.jax.jax_intermediate_tensor import \
-    JaxIntermediateTensors
-
-try:
-    from vllm.model_executor.models.gemma4_mm import \
-        Gemma4ForConditionalGeneration as PtGemma4MM
-except ImportError:
-    # TODO(#2308): Remove try-except once we have transformers>=5.5.0
-    PtGemma4MM = None
+from vllm.model_executor.models.gemma4_mm import \
+    Gemma4ForConditionalGeneration as PtGemma4MM
 
 from tpu_inference.layers.common.attention_interface import \
     sharded_flash_attention
+from tpu_inference.layers.common.sharding import ShardingAxisName
 from tpu_inference.layers.jax import JaxModule
 from tpu_inference.layers.jax.linear import JaxEinsum
 from tpu_inference.layers.jax.norm import JaxRmsNorm
@@ -43,6 +36,8 @@ from tpu_inference.layers.jax.pp_utils import make_layers
 from tpu_inference.layers.jax.rope_interface import apply_rope
 from tpu_inference.layers.vllm.quantization.configs import VllmQuantConfig
 from tpu_inference.logger import init_logger
+from tpu_inference.models.jax.jax_intermediate_tensor import \
+    JaxIntermediateTensors
 from tpu_inference.models.jax.utils.multi_modal_utils import \
     merge_multimodal_embeddings
 from tpu_inference.models.jax.utils.weight_utils import (LoadableWithIterator,
@@ -722,8 +717,8 @@ class Gemma4ForConditionalGeneration(JaxModule, LoadableWithIterator):
 
         return projected_vision_features
 
-    def _parse_and_validate_image_input(self,
-                                        **kwargs: object) -> Optional[dict]:
+    def _parse_and_validate_image_input(
+            self, **kwargs: object) -> Optional[Gemma4ImagePixelInputs]:
         pixel_values = kwargs.pop("pixel_values", None)
         pixel_position_ids = kwargs.pop("pixel_position_ids", None)
         image_embeds = kwargs.pop("image_embeds", None)
@@ -743,7 +738,8 @@ class Gemma4ForConditionalGeneration(JaxModule, LoadableWithIterator):
                                       pixel_values=pixel_values,
                                       pixel_position_ids=pixel_position_ids)
 
-    def _process_image_input(self, image_input: dict) -> list[jax.Array]:
+    def _process_image_input(
+            self, image_input: Gemma4ImagePixelInputs) -> list[jax.Array]:
         pixel_values = image_input["pixel_values"]
         pixel_position_ids = image_input["pixel_position_ids"]
 
@@ -752,14 +748,26 @@ class Gemma4ForConditionalGeneration(JaxModule, LoadableWithIterator):
         if pixel_position_ids.ndim == 2:
             pixel_position_ids = jnp.expand_dims(pixel_position_ids, axis=0)
 
-        per_image_features = []
-        batch_size = pixel_values.shape[0]
-        for i in range(batch_size):
-            pv = pixel_values[i:i + 1, ...]
-            pp = pixel_position_ids[i:i + 1, ...]
-            vt_output = self.get_single_image_embedding(pv, pp)
-            per_image_features.append(vt_output[0])
-        return per_image_features
+        # Batch all images into one vision-tower call so DP shards process
+        # different images in parallel. Gemma4VisionFlashAttention's
+        # sharded_flash_attention has in_specs=P('data','model',None,None),
+        # which requires B % data_size == 0; pad the batch axis up with
+        # pixel_position_ids=POSITIONS_PAD_VALUE so input_mask masks the
+        # padded entries out of the encoder.
+        n_images = pixel_values.shape[0]
+        dp_size = self.mesh.shape[ShardingAxisName.BATCH]
+        padded_n = ((n_images + dp_size - 1) // dp_size) * dp_size
+        if padded_n > n_images:
+            pad_count = padded_n - n_images
+            pixel_values = jnp.pad(pixel_values,
+                                   ((0, pad_count), (0, 0), (0, 0)))
+            pixel_position_ids = jnp.pad(pixel_position_ids,
+                                         ((0, pad_count), (0, 0), (0, 0)),
+                                         constant_values=POSITIONS_PAD_VALUE)
+
+        vt_output = self.get_single_image_embedding(pixel_values,
+                                                    pixel_position_ids)
+        return [vt_output[i] for i in range(n_images)]
 
     def embed_multimodal(self, **kwargs) -> List[jax.Array]:
         image_input = self._parse_and_validate_image_input(**kwargs)

--- a/tpu_inference/runner/multimodal_manager.py
+++ b/tpu_inference/runner/multimodal_manager.py
@@ -34,55 +34,78 @@ class MultiModalManager:
     def __init__(self, runner: "TPUModelRunner"):
         self.runner = runner
 
-    def calc_mrope_positions(self, scheduler_output: "VllmSchedulerOutput"):
-        mrope_pos_ptr = 0
-        for index, req_id in enumerate(self.runner.input_batch.req_ids):
-            req = self.runner.requests[req_id]
-            assert req.mrope_positions is not None
+    def calc_mrope_positions(
+        self,
+        scheduler_output: "VllmSchedulerOutput",
+        req_ids_dp: dict[int, list[str]],
+        padded_num_scheduled_tokens_per_dp_rank: int,
+    ):
+        """Calculate and update the mrope_positions for the scheduled tokens in
+        the runner's mrope_positions_cpu array.
 
-            num_computed_tokens = \
-                self.runner.input_batch.num_computed_tokens_cpu[index]
-            num_scheduled_tokens = \
-                scheduler_output.num_scheduled_tokens[req_id]
-            num_prompt_tokens = len(req.prompt_token_ids)
+        Args:
+            scheduler_output: The VllmSchedulerOutput containing scheduling info for the current step.
+            req_ids_dp: A dict mapping DP rank to the list of request IDs assigned to that rank for
+                the current step, in the order they are packed.
+            padded_num_scheduled_tokens_per_dp_rank: The number of tokens scheduled for each DP rank,
+                including padding. This determines the width of each DP rank's slot in the global
+                mrope_positions_cpu array, which should be sufficient to hold all scheduled tokens
+                for that rank.
+        """
+        # Each DP rank owns the slice
+        # mrope_positions_cpu[:, dp_rank*padded_per_rank : (dp_rank+1)*padded_per_rank].
+        # Pack each rank's requests into that slot in order. Mirrors the
+        # token_offset ramp used by _prepare_inputs for input_ids/positions.
+        for dp_rank, req_ids in req_ids_dp.items():
+            mrope_pos_ptr = padded_num_scheduled_tokens_per_dp_rank * dp_rank
+            for req_id in req_ids:
+                req = self.runner.requests[req_id]
+                assert req.mrope_positions is not None
 
-            if num_computed_tokens + num_scheduled_tokens > num_prompt_tokens:
-                prompt_part_len = max(0,
-                                      num_prompt_tokens - num_computed_tokens)
-                completion_part_len = max(
-                    0, num_scheduled_tokens - prompt_part_len)
-            else:
-                prompt_part_len = num_scheduled_tokens
-                completion_part_len = 0
+                index = self.runner.input_batch.req_id_to_index[req_id]
+                num_computed_tokens = \
+                    self.runner.input_batch.num_computed_tokens_cpu[index]
+                num_scheduled_tokens = \
+                    scheduler_output.num_scheduled_tokens[req_id]
+                num_prompt_tokens = len(req.prompt_token_ids)
 
-            assert num_scheduled_tokens == prompt_part_len + completion_part_len
+                if num_computed_tokens + num_scheduled_tokens > num_prompt_tokens:
+                    prompt_part_len = max(
+                        0, num_prompt_tokens - num_computed_tokens)
+                    completion_part_len = max(
+                        0, num_scheduled_tokens - prompt_part_len)
+                else:
+                    prompt_part_len = num_scheduled_tokens
+                    completion_part_len = 0
 
-            if prompt_part_len > 0:
-                # prompt's mrope_positions are pre-computed
-                dst_start = mrope_pos_ptr
-                dst_end = mrope_pos_ptr + prompt_part_len
-                src_start = num_computed_tokens
-                src_end = num_computed_tokens + prompt_part_len
+                assert num_scheduled_tokens == prompt_part_len + completion_part_len
 
-                self.runner.mrope_positions_cpu[:, dst_start:dst_end] = \
-                    req.mrope_positions[:,src_start:src_end]
+                if prompt_part_len > 0:
+                    # prompt's mrope_positions are pre-computed
+                    dst_start = mrope_pos_ptr
+                    dst_end = mrope_pos_ptr + prompt_part_len
+                    src_start = num_computed_tokens
+                    src_end = num_computed_tokens + prompt_part_len
 
-                mrope_pos_ptr += prompt_part_len
+                    self.runner.mrope_positions_cpu[:, dst_start:dst_end] = \
+                        req.mrope_positions[:, src_start:src_end]
 
-            if completion_part_len > 0:
-                # compute completion's mrope_positions on-the-fly
-                dst_start = mrope_pos_ptr
-                dst_end = mrope_pos_ptr + completion_part_len
+                    mrope_pos_ptr += prompt_part_len
 
-                MRotaryEmbedding.get_next_input_positions_tensor(
-                    out=self.runner.mrope_positions_cpu,
-                    out_offset=dst_start,
-                    mrope_position_delta=req.mrope_position_delta,
-                    context_len=num_computed_tokens + prompt_part_len,
-                    num_new_tokens=completion_part_len,
-                )
+                if completion_part_len > 0:
+                    # compute completion's mrope_positions on-the-fly
+                    dst_start = mrope_pos_ptr
+                    dst_end = mrope_pos_ptr + completion_part_len
 
-                mrope_pos_ptr += completion_part_len
+                    MRotaryEmbedding.get_next_input_positions_tensor(
+                        out=self.runner.mrope_positions_cpu,
+                        out_offset=dst_start,
+                        mrope_position_delta=req.mrope_position_delta,
+                        context_len=num_computed_tokens + prompt_part_len,
+                        num_new_tokens=completion_part_len,
+                    )
+
+                    mrope_pos_ptr += completion_part_len
 
     def execute_mm_encoder(self, scheduler_output: "VllmSchedulerOutput"):
         scheduled_encoder_inputs = scheduler_output.scheduled_encoder_inputs
@@ -138,96 +161,111 @@ class MultiModalManager:
             self.runner.encoder_cache[mm_hash] = output
 
     def gather_mm_embeddings(
-        self, scheduler_output: "VllmSchedulerOutput", target_pad_len: int
+        self,
+        scheduler_output: "VllmSchedulerOutput",
+        target_pad_len: int,
+        req_ids_dp: dict[int, list[str]],
+        padded_num_scheduled_tokens_per_dp_rank: int,
     ) -> tuple[list[jax.Array] | None, jax.Array | None]:
         """Gather multimodal_embeddings from the encoder cache with is_multimodal.
 
         Args:
             scheduler_output: The VllmSchedulerOutput.
-            target_pad_len: The target length to pad the resulting boolean mask to.
+            target_pad_len: The target length to pad the resulting boolean mask
+                to. Must equal `padded_num_scheduled_tokens_per_dp_rank * dp_size`
+                so each DP rank's slot is sized correctly.
+            req_ids_dp: dp_rank -> list of req_ids assigned to that rank (in
+                packing order).
+            padded_num_scheduled_tokens_per_dp_rank: per-rank slot width in the
+                global token buffer.
 
         Returns:
             A tuple containing:
                 - mm_embeds: A list of JAX arrays containing the unpadded multimodal
                     embeddings, or None if there are no multimodal embeddings.
-                - is_mm_embed: A boolean JAX array mask indicating which
-                    positions in the input sequence are multimodal embeddings.
+                - is_mm_embed: A boolean JAX array mask of length target_pad_len.
+                    Within each DP rank's slot, True positions appear in the same
+                    order as the corresponding embeddings in mm_embeds, so a
+                    downstream cumsum-based gather aligns correctly.
         """
 
-        total_num_scheduled_tokens = scheduler_output.total_num_scheduled_tokens
-        assert (
-            target_pad_len >= total_num_scheduled_tokens
-        ), f"{target_pad_len=} should >= {total_num_scheduled_tokens=} for output is_mm_embedded"
-
         mm_embeds: list[jax.Array] = []
-        is_mm_embed_cpu = np.zeros((total_num_scheduled_tokens, ),
-                                   dtype=np.bool_)
+        is_mm_embed_cpu = np.zeros((target_pad_len, ), dtype=np.bool_)
 
-        req_start_idx = 0
+        # Pack per DP rank into its dedicated slot. Within a rank, advance
+        # req_start_idx by num_scheduled_tokens as before; the global position
+        # is (rank_token_offset + req_start_idx).
+        for dp_rank, req_ids in req_ids_dp.items():
+            rank_token_offset = (padded_num_scheduled_tokens_per_dp_rank *
+                                 dp_rank)
+            req_start_idx = 0
+            for req_id in req_ids:
+                num_scheduled_tokens = scheduler_output.num_scheduled_tokens[
+                    req_id]
+                req_state = self.runner.requests[req_id]
+                num_computed_tokens = req_state.num_computed_tokens
+                mm_features = req_state.mm_features
+                for _, mm_feature in enumerate(mm_features):
+                    pos_info = mm_feature.mm_position
+                    start_pos = pos_info.offset
+                    num_encoder_tokens = pos_info.length
 
-        for req_id in self.runner.input_batch.req_ids:
-            num_scheduled_tokens = scheduler_output.num_scheduled_tokens[
-                req_id]
-            req_state = self.runner.requests[req_id]
-            num_computed_tokens = req_state.num_computed_tokens
-            mm_features = req_state.mm_features
-            for _, mm_feature in enumerate(mm_features):
-                pos_info = mm_feature.mm_position
-                start_pos = pos_info.offset
-                num_encoder_tokens = pos_info.length
+                    # The encoder output is needed if the two ranges overlap:
+                    # [num_computed_tokens,
+                    #  num_computed_tokens + num_scheduled_tokens) and
+                    # [start_pos, start_pos + num_encoder_tokens)
+                    if start_pos >= num_computed_tokens + num_scheduled_tokens:
+                        # The encoder output is not needed in this step.
+                        break
+                    if start_pos + num_encoder_tokens <= num_computed_tokens:
+                        # The encoder output is already processed and stored
+                        # in the decoder's KV cache.
+                        continue
 
-                # The encoder output is needed if the two ranges overlap:
-                # [num_computed_tokens,
-                #  num_computed_tokens + num_scheduled_tokens) and
-                # [start_pos, start_pos + num_encoder_tokens)
-                if start_pos >= num_computed_tokens + num_scheduled_tokens:
-                    # The encoder output is not needed in this step.
-                    break
-                if start_pos + num_encoder_tokens <= num_computed_tokens:
-                    # The encoder output is already processed and stored
-                    # in the decoder's KV cache.
-                    continue
+                    start_idx = max(num_computed_tokens - start_pos, 0)
+                    end_idx = min(
+                        num_computed_tokens - start_pos + num_scheduled_tokens,
+                        num_encoder_tokens)
+                    assert start_idx < end_idx
+                    curr_embeds_start, curr_embeds_end = (
+                        pos_info.get_embeds_indices_in_range(
+                            start_idx, end_idx))
+                    if curr_embeds_start == curr_embeds_end:
+                        continue
 
-                start_idx = max(num_computed_tokens - start_pos, 0)
-                end_idx = min(
-                    num_computed_tokens - start_pos + num_scheduled_tokens,
-                    num_encoder_tokens)
-                assert start_idx < end_idx
-                curr_embeds_start, curr_embeds_end = (
-                    pos_info.get_embeds_indices_in_range(start_idx, end_idx))
-                if curr_embeds_start == curr_embeds_end:
-                    continue
+                    mm_hash = mm_feature.identifier
+                    encoder_output = self.runner.encoder_cache.get(
+                        mm_hash, None)
+                    assert encoder_output is not None, f"Encoder cache miss for {mm_hash}."
+                    encoder_output = self.runner.encoder_cache[mm_hash]
 
-                mm_hash = mm_feature.identifier
-                encoder_output = self.runner.encoder_cache.get(mm_hash, None)
-                assert encoder_output is not None, f"Encoder cache miss for {mm_hash}."
-                encoder_output = self.runner.encoder_cache[mm_hash]
+                    if (is_embed := pos_info.is_embed) is not None:
+                        is_embed = is_embed[start_idx:end_idx]
+                        mm_embeds_item = encoder_output[
+                            curr_embeds_start:curr_embeds_end]
+                    else:
+                        mm_embeds_item = encoder_output[start_idx:end_idx]
 
-                if (is_embed := pos_info.is_embed) is not None:
-                    is_embed = is_embed[start_idx:end_idx]
-                    mm_embeds_item = encoder_output[
-                        curr_embeds_start:curr_embeds_end]
-                else:
-                    mm_embeds_item = encoder_output[start_idx:end_idx]
+                    mm_embeds.append(mm_embeds_item)
 
-                mm_embeds.append(mm_embeds_item)
+                    req_start_pos = (rank_token_offset + req_start_idx +
+                                     start_pos - num_computed_tokens)
 
-                req_start_pos = req_start_idx + start_pos - num_computed_tokens
+                    # use cpu numpy array for inplace modification
+                    if is_embed is None:
+                        is_mm_embed_cpu[req_start_pos +
+                                        start_idx:req_start_pos +
+                                        end_idx] = True
+                    else:
+                        # is_embed is torch Tensor in cpu
+                        is_mm_embed_cpu[req_start_pos +
+                                        start_idx:req_start_pos +
+                                        end_idx] |= is_embed.numpy()
 
-                # use cpu numpy array for inplace modification
-                if is_embed is None:
-                    is_mm_embed_cpu[req_start_pos + start_idx:req_start_pos +
-                                    end_idx] = True
-                else:
-                    # is_embed is torch Tensor in cpu
-                    is_mm_embed_cpu[req_start_pos + start_idx:req_start_pos +
-                                    end_idx] |= is_embed.numpy()
+                req_start_idx += num_scheduled_tokens
 
-            req_start_idx += num_scheduled_tokens
         if not mm_embeds:
             return None, None
-        is_mm_embed_cpu = np.pad(
-            is_mm_embed_cpu, (0, target_pad_len - is_mm_embed_cpu.shape[0]))
         is_mm_embed = jnp.array(is_mm_embed_cpu, dtype=jnp.bool_)
         assert target_pad_len == is_mm_embed.shape[0]
 

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -944,6 +944,8 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             spec_decode_metadata,
             logits_indices_selector,
             padded_num_reqs,
+            req_ids_dp,
+            padded_num_scheduled_tokens_per_dp_rank,
         ) = self._prepare_inputs(scheduler_output)
 
         # multi-modal support
@@ -952,7 +954,8 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             # We have the modality embeds at this time.
             self.mm_manager.execute_mm_encoder(scheduler_output)
             mm_embeds, is_mm_embed = self.mm_manager.gather_mm_embeddings(
-                scheduler_output, input_ids.shape[0])
+                scheduler_output, input_ids.shape[0], req_ids_dp,
+                padded_num_scheduled_tokens_per_dp_rank)
         else:
             mm_embeds, is_mm_embed = None, None
 
@@ -1603,7 +1606,9 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         # Calculate M-RoPE positions.
         # Only relevant for models using M-RoPE (e.g, Qwen2-VL)
         if self.uses_mrope:
-            self.mm_manager.calc_mrope_positions(scheduler_output)
+            self.mm_manager.calc_mrope_positions(
+                scheduler_output, req_ids_dp,
+                padded_num_scheduled_tokens_per_dp_rank)
 
         # Async scheduling: prepare token substitution indices for DP
         num_draft_tokens = np.zeros(num_reqs, dtype=np.int32)
@@ -1991,6 +1996,8 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             spec_decode_metadata,
             logits_indices_selector,
             padded_num_reqs,
+            req_ids_dp,
+            padded_num_scheduled_tokens_per_dp_rank,
         )
 
     def _get_input_ids_embeds(self, input_ids: jax.Array,


### PR DESCRIPTION
# Description

This PR fixes
1. #2642 
2. properly calculate mrope etc. in DP>1 case


# Tests

| Model | Quant | DP=1 TP=2 | DP=4 TP=2 | ΔDP |
|---|---|---:|---:|---:|
| **Gemma-4-26B-A4B-it** | bf16 (no qwix, no `MOE_REQUANTIZE_*`) | **0.6480** (1121/1730, 961 s, 2521 tok/s) | **0.6468** (1119/1730, 1387 s, 1754 tok/s) | **−0.0012** (−2/1730) |
| **Gemma-4-31B-it** | qwix fp8 (weight+act `float8_e4m3fn`) | **0.7098** (1228/1730, 1103 s, 1052 tok/s) | **0.7006** (1212/1730, 1549 s, 760 tok/s) | **−0.0092** (−16/1730) |

```
USE_BATCHED_RPA_KERNEL=1 \
    MODEL_IMPL_TYPE=flax_nnx HF_HOME=/mnt/pd/ \
    vllm serve google/gemma-4-26B-A4B-it \
      --max-model-len 4096 --max-num-seqs 256 \
      --tensor-parallel-size 2 --data-parallel-size 1 \   # 4 for DP cell
      --max-num-batched-tokens 4096 --no-enable-prefix-caching \
      --kv-cache-dtype=fp8 --gpu-memory-utilization=0.9 --async-scheduling \
      --limit-mm-per-prompt '{"image": 8, "video": 1, "audio": 0}' \
      --mm-processor-kwargs '{"size": {"longest_edge": 262144, "shortest_edge": 3136}}' \
      --block-size=256

python /home/lkchen_google_com/worktree/gemma4/scripts/vllm/benchmarking/benchmark_serving.py \
      --backend vllm-chat \
      --endpoint /v1/chat/completions \
      --model google/gemma-4-31B-it \                     # or google/gemma-4-26B-A4B-it
      --dataset-name mmmu_pro \
      --mmmu-pro-subset 'standard (10 options)' \
      --mmmu-pro-output-len=2000 \
      --run-eval \
      --num-prompts 1730 \
      --max-concurrency 32
```


# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
