### PR TITLE
Enable centralized JAX persistent compilation cache

### DIFF
--- a/.buildkite/scripts/run_in_docker.sh
+++ b/.buildkite/scripts/run_in_docker.sh
@@ -93,6 +93,10 @@ TEST_SUITE_VARS=(
 
 DOCKER_HF_HOME="/tmp/hf_home"
 
+# ==========================================
+# 1. Cache Setup (HF Models & JAX Compilations)
+# ==========================================
+
 # Try to cache HF models
 persist_cache_dir="/mnt/disks/persist/models"
 
@@ -107,16 +111,50 @@ fi
 KERNEL_TUNING_TMP_DIR="/tmp/kernel_tuning"
 mkdir -p "$KERNEL_TUNING_TMP_DIR"
 
+# Try to cache the JAX compilations.
+GCS_CACHE_BASE="gs://ullm-ci-cache/jax_cache"
+echo "[INFO] Probing JAX version from docker image..."
+JAX_VERSION=$(docker run --rm "$FULL_IMAGE_TAG" python3 -c "import jax; print(jax.__version__)")
+echo "[INFO] Detected JAX Version: ${JAX_VERSION}"
+
+# Centralized GCS cache path
+CACHE_NAMESPACE="jax${JAX_VERSION}_tpu${TPU_VERSION:-tpu6e}"
+FINAL_CACHE_PATH="${GCS_CACHE_BASE}/${CACHE_NAMESPACE}"
+
+LOCAL_JAX_CACHE_DIR="/tmp/tpu_jax_cache/${CACHE_NAMESPACE}"
+mkdir -p "$LOCAL_JAX_CACHE_DIR"
+echo "[INFO] Pulling JAX Cache from GCS to local directory..."
+# Parallel CI builds‘ pushes are safe because JAX's compilation cache 
+# entries are content-addressed. Concurrent pushes are thus idempotent;
+gsutil -m rsync -r "$FINAL_CACHE_PATH" "$LOCAL_JAX_CACHE_DIR" || echo "[WARN] Failed to pull JAX Cache from GCS. Proceeding with cold start."
+
+# ==========================================
+# 2. Run Docker Container
+# ==========================================
+set +e # Temporarily disable exit on error to capture exit code
+
+# Ensure the docker container is killed if the wrapper script exits, fails, or is cancelled.
+trap 'docker kill "$IMAGE_NAME" 2>/dev/null || true' EXIT INT TERM
+
 # Some test scripts set tp=2 on TPU_VERSION=tpu7x to mitigate test failures.
 # TODO (Qiliang Cui) Investigate why tensor-parallel-size=1 breaks in tpu7x.
 
-exec docker run \
+# -----------------------------------------------------------------------------
+# JAX Cache Env Variables Explanation:
+# - VLLM_XLA_CACHE_PATH: Prevents vLLM's CompilationManager from overriding our 
+#   path with its default.
+# - JAX_COMPILATION_CACHE_DIR: Serves as a global catch-all for unit tests that 
+#   initiate models and bypass vLLM's CompilationManager logic entirely.
+# -----------------------------------------------------------------------------
+
+docker run \
   --name "$IMAGE_NAME" \
   --privileged \
   --net host \
   --shm-size=16G \
   --rm \
   -v "$LOCAL_HF_HOME":"$DOCKER_HF_HOME" \
+  -v "$LOCAL_JAX_CACHE_DIR":"$LOCAL_JAX_CACHE_DIR" \
   -v "$KERNEL_TUNING_TMP_DIR":"$KERNEL_TUNING_TMP_DIR" \
   "${DEV_MOUNT[@]}" \
   "${ENV_VARS[@]}" \
@@ -124,7 +162,8 @@ exec docker run \
   -e HF_HOME="$DOCKER_HF_HOME" \
   -e MODEL_IMPL_TYPE="$MODEL_IMPL_TYPE" \
   -e HF_TOKEN="$HF_TOKEN" \
-  -e VLLM_XLA_CACHE_PATH="$DOCKER_HF_HOME/.cache/jax_cache" \
+  -e VLLM_XLA_CACHE_PATH="$LOCAL_JAX_CACHE_DIR" \
+  -e JAX_COMPILATION_CACHE_DIR="$LOCAL_JAX_CACHE_DIR" \
   -e VLLM_XLA_CHECK_RECOMPILATION=1 \
   ${QUANTIZATION:+-e QUANTIZATION="$QUANTIZATION"} \
   ${NEW_MODEL_DESIGN:+-e NEW_MODEL_DESIGN="$NEW_MODEL_DESIGN"} \
@@ -138,3 +177,16 @@ exec docker run \
    "${BENCHMARK_DOCKER_ARGS[@]}" \
   "$FULL_IMAGE_TAG" \
   "$@" # Pass all script arguments as the command to run in the container
+DOCKER_EXIT_CODE=$?
+
+set -e
+
+# ==========================================
+# 3. Post-Docker Actions
+# ==========================================
+echo "[INFO] Docker finished with exit code ${DOCKER_EXIT_CODE}."
+
+echo "[INFO] Syncing local JAX Cache back to GCS..."
+gsutil -m rsync -r "$LOCAL_JAX_CACHE_DIR" "$FINAL_CACHE_PATH" || echo "[WARN] Failed to sync JAX Cache back to GCS."
+
+exit $DOCKER_EXIT_CODE

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,81 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+======================================================================
+Opt-out of Global JAX Compilation Cache
+======================================================================
+By default, CI tests utilize a global GCS-backed JAX compilation cache
+to accelerate execution. If a test needs to safely bypass this cache,
+simply decorate the test function or class with `@pytest.mark.disable_jax_cache`.
+
+Example Usage:
+
+    import pytest
+
+    # Apply to a single test function
+    @pytest.mark.disable_jax_cache
+    def test_fucntion():
+        ...
+
+    # Or apply to an entire test class
+    @pytest.mark.disable_jax_cache
+    class TestClass:
+        ...
+======================================================================
+"""
+
+import os
+from unittest.mock import patch
+
+import jax
+import pytest
+
+
+def pytest_configure(config):
+    """
+    Register the custom marker to prevent Pytest from throwing 'Unknown marker' warnings.
+    """
+    config.addinivalue_line(
+        "markers",
+        "disable_jax_cache: explicitly bypass the global JAX compilation cache for this test."
+    )
+
+
+@pytest.fixture(autouse=True)
+def _handle_disable_jax_cache_marker(request):
+    """
+    A globally auto-used fixture that intercepts tests marked with @pytest.mark.disable_jax_cache.
+    It temporarily disables the compilation cache at both the vLLM environment level and the JAX core level.
+    """
+    marker = request.node.get_closest_marker("disable_jax_cache")
+
+    if marker:
+        # Safely read the original JAX config state
+        orig_jax_cache_dir = getattr(jax.config, "jax_compilation_cache_dir",
+                                     None)
+
+        # Force disable at the JAX level (for unit tests that bypass vLLM's CompilationManager)
+        jax.config.update("jax_compilation_cache_dir", None)
+
+        # Force disable at the vLLM level (for end-to-end tests that use CompilationManager)
+        # Using patch.dict safely isolates the environment variable modification to the scope of this test
+        with patch.dict(os.environ, {"VLLM_DISABLE_COMPILE_CACHE": "1"}):
+            yield  # -> Hand over control to run the test
+
+        # Teardown - Restore the original JAX config state for subsequent tests
+        jax.config.update("jax_compilation_cache_dir", orig_jax_cache_dir)
+
+    else:
+        # If the marker is not present, just run the test normally
+        yield

--- a/tests/distributed/test_kv_transfer.py
+++ b/tests/distributed/test_kv_transfer.py
@@ -20,7 +20,6 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 from absl.testing import absltest, parameterized
-from jax._src import compilation_cache as cc
 from jax._src import test_util as jtu
 
 from tpu_inference.distributed.kv_transfer import (copy_to_host,
@@ -88,7 +87,6 @@ class KVTransferTest(jtu.JaxTestCase):
 
     def tearDown(self):
         super().tearDown()
-        cc.reset_cache()
         jax.clear_caches()
 
         # Force Python GC

--- a/tests/offload/tpu_offload_connector_worker_test.py
+++ b/tests/offload/tpu_offload_connector_worker_test.py
@@ -24,7 +24,6 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 from absl.testing import parameterized
-from jax._src import compilation_cache as cc
 from jax._src import test_util as jtu
 from jax.sharding import Mesh, NamedSharding, PartitionSpec
 from vllm.distributed.kv_transfer.kv_connector.v1.base import KVConnectorRole
@@ -113,7 +112,6 @@ class TestTPUOffloadConnectorWorker(jtu.JaxTestCase):
             del self.connector
 
         # Force JAX to release memory
-        cc.reset_cache()
         jax.clear_caches()
 
         # Force Python GC


### PR DESCRIPTION
Enable centralized JAX persistent compilation cache to accelerate CI/BM and introduce a safe cache opt-out marker

Design: [go/centralized-cache-ullm-pipeline](http://goto.google.com/centralized-cache-ullm-pipeline)

### Key Steps

1. Updated .buildkite/run_in_docker.sh to pull/push JAX compilation cache from/to gs://ullm-ci-cache/jax_cache.

2. Corrected the cache enablement setup. Currently the cache is injected via [CompilationManager here,](https://github.com/vllm-project/tpu-inference/blob/61f00c4d0bb507a6f63f6163f9f1b9fd21e17671/tpu_inference/runner/compilation_manager.py#L53) which means most of our heavy tests that don't start with init the CompilationManager(TPUModelRunner, LLMEngine..) class won't benefit from the cache at all.

3. Safe Opt-out Mechanism: Introduced `@pytest.mark.disable_jax_cache in tests/conftest.py`. This fixture safely bypasses cache lookups via public `jax.config` updates without destroying global singleton objects, ensuring test isolation.

4. State Cleanup: Cleaned up `cc.reset_cache()` teardown calls from `KVTransferTest` and `TestTPUOffloadConnectorWorker` to preserve global cache pointer integrity across the Pytest run within same process. This is further explained at the end of the PR description.

### Impact

1. **~30x Speedup per Compilation need**: Heavy operators (e.g., FusedMoE) currently take ~90 seconds to compile from scratch per parameterized test case. With the centralized cache, this drops to <3 seconds for **subsequent runs** globally. Check [prototype log](https://buildkite.com/tpu-commons/tpu-inference-ci/builds/16605/canvas?sid=019df9a2-69d6-4626-9eb0-40aad0c2b6a3&tab=output)

2. **~50% Reduction in TPU Usage**: By eliminating redundant JIT compilations, we project to cut the current 3.5 hours of total TPU usage time (per tpuv6e / tpuv7x build) by half. Check [prototype log](https://buildkite.com/tpu-commons/tpu-inference-ci/builds/16605/canvas?sid=019df9a2-69d6-4626-9eb0-40aad0c2b6a3&tab=output)

3. **Slashing the 200-Min Queue Time**: Faster test completions should improve machine turnover rates by X%. Can be monitored by our CI monitor: [go/vllm-ci-latency](http://goto.google.com/vllm-ci-latency)

### Test

- [Build #16605](https://buildkite.com/tpu-commons/tpu-inference-ci/builds/16605) functional test with compilation log printed.

- [Build #17759](https://buildkite.com/tpu-commons/tpu-inference-ci/builds/17759/canvas?sid=019e2ce1-f985-42ff-9a28-6df0a0ac9055&tab=output) prove `cc.reset_cache()`is breaking the current HEAD if we change the test order.

### Explanation for removing cc.reset_cache

Under the hood, `cc.reset_cache()` does not clear any physical cache files on the disk. Instead, it aggressively hardcodes the internal JAX global singleton pointer (compilation_cache._cache) to None [Code Ref](https://github.com/jax-ml/jax/blob/991b35ab92f530a50c09baf9aff81de0d6c9e57a/jax/_src/compilation_cache.py#L420).

JAX's JaxTestCase strictly asserts that global configurations and states (including the cache singleton) remain unchanged before and after a test execution. As proven in [CI Test #17759](https://buildkite.com/tpu-commons/tpu-inference-ci/builds/17759/canvas?sid=019e2ce1-f985-42ff-9a28-6df0a0ac9055&tab=output) — which was run on HEAD with zero code changes([branch](https://github.com/vllm-project/tpu-inference/commit/a7cdaca59a6380dcf5823e588c83f5bb0939c3ee)), simply by renaming a `runner` folder to alter Pytest's default alphabetical execution order — this was a pre-existing issue. If any prior test initializes the CompilationManager (creating the global LRUCache object), the subsequent cc.reset_cache() call violently destroys it. JaxTestCase detects this mutation (<LRUCache object> != None) and throws an AssertionError. This bug was historically masked purely because there is no cached enabled test executed before the tests with `cc.reset_cache()`.

The remaining `jax.clear_caches()` and `gc.collect()` in the tearDown are preserved, as they correctly flushes the in-memory JIT and dispatch caches to free up Host RAM and release the HBM buffer.

### Opt-out 

To safely bypass the JAX persistent compilation cache for specific tests:

```
@pytest.mark.disable_jax_cache
def test_func():
    ...

@pytest.mark.disable_jax_cache
class TestClass:
    ...
```
