### PR TITLE
fix: support fused weight loading without shard_id for Qwen3-VL / Qwe…

### DIFF
--- a/tpu_inference/layers/vllm/quantization/unquantized.py
+++ b/tpu_inference/layers/vllm/quantization/unquantized.py
@@ -161,16 +161,37 @@ class VllmUnquantizedLinearMethod(vllm_linear.UnquantizedLinearMethod,
 
     def maybe_process_weights(self, layer: torch.nn.Module, param_name: str,
                               args, kwargs):
-        """Check if all weights are loaded for the layer. If so, process and shard the weights."""
+        """Check if all weights are loaded for the layer. If so, process and shard the weights.
+
+        Note on Fused Weight Loading (e.g., Qwen3-VL / Qwen3-VL-MoE / Qwen2.5-VL Vision Encoder):
+        Historically, LLMs stored attention Q/K/V weights separately in HuggingFace checkpoints,
+        and vLLM loaded them per shard (passing shard_id in `args`).
+        However, newer multimodal models like Qwen3-VL / Qwen3-VL-MoE store vision attention weights
+        already fused on disk (e.g., `attn.qkv.weight`). In such cases, vLLM's weight loader is invoked
+        without a shard_id (`args` is empty), and vLLM internally slices and copies the fused weight.
+        To support TPU incremental sharding for these fused weights, we detect when `args` is empty
+        and immediately register all underlying shards ('q', 'k', 'v') as loaded to satisfy the sharding trigger.
+        """
         if isinstance(layer, vllm_linear.QKVParallelLinear):
-            assert len(args) == 1, "Expecting shard_id as the only argument"
-            shard_id = args[0]
-            # Keep track of loaded weights for QKVLinear, e.g. (('weight', 'q'), ('bias', 'q'), ('weight', 'k'), ('bias', 'k'), ...)
-            layer._loaded_weights.add((param_name, shard_id))
+            if len(args) == 1:
+                shard_id = args[0]
+                layer._loaded_weights.add((param_name, shard_id))
+            else:
+                # Fused weight loaded in one go (e.g., Qwen3-VL / Qwen3-VL-MoE vision encoder `attn.qkv.weight`).
+                # vLLM's QKVParallelLinear.weight_loader internally slices the weight into q, k, v.
+                # We register all 3 shards to immediately trigger process_weights_after_loading.
+                layer._loaded_weights.add((param_name, 'q'))
+                layer._loaded_weights.add((param_name, 'k'))
+                layer._loaded_weights.add((param_name, 'v'))
         elif isinstance(layer, vllm_linear.MergedColumnParallelLinear):
-            assert len(args) == 1, "Expecting shard_id as the only argument"
-            shard_id = args[0]
-            layer._loaded_weights.add((param_name, shard_id))
+            if len(args) == 1:
+                shard_id = args[0]
+                layer._loaded_weights.add((param_name, shard_id))
+            else:
+                # Fused weight loaded in one go (e.g., MLP gate_up_proj fused on disk).
+                # Register all output partitions to immediately trigger process_weights_after_loading.
+                for i in range(len(layer.output_sizes)):
+                    layer._loaded_weights.add((param_name, i))
         else:
             # Keep track of loaded weights for other linear layers, e.g. ('weight', 'bias')
             layer._loaded_weights.add(param_name)


### PR DESCRIPTION
Model download from huggin face for Qwen3-VL has fused vision model weights

"model.visual.blocks.21.attn.qkv.bias": "model-00001-of-00096.safetensors",
   
Without the fix the model loading will fail at

(EngineCore pid=550) ERROR 05-15 21:21:53 [core.py:1140]                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=550) ERROR 05-15 21:21:53 [core.py:1140]   File "/workspace/vllm/vllm/model_executor/models/utils.py", line 302, in _load_module
(EngineCore pid=550) ERROR 05-15 21:21:53 [core.py:1140]     yield from self._load_module(
(EngineCore pid=550) ERROR 05-15 21:21:53 [core.py:1140]   File "/workspace/vllm/vllm/model_executor/models/utils.py", line 275, in _load_module
(EngineCore pid=550) ERROR 05-15 21:21:53 [core.py:1140]     loaded_params = module_load_weights(weights)
(EngineCore pid=550) ERROR 05-15 21:21:53 [core.py:1140]                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=550) ERROR 05-15 21:21:53 [core.py:1140]   File "/workspace/vllm/vllm/model_executor/models/qwen3_vl.py", line 858, in load_weights
(EngineCore pid=550) ERROR 05-15 21:21:53 [core.py:1140]     weight_loader(param, loaded_weight)
(EngineCore pid=550) ERROR 05-15 21:21:53 [core.py:1140]   File "/workspace/tpu_inference/tpu_inference/models/vllm/vllm_model_loader.py", line 50, in weight_loader_wrapper
(EngineCore pid=550) ERROR 05-15 21:21:53 [core.py:1140]     quant_method.maybe_process_weights(layer, param_name, args,
(EngineCore pid=550) ERROR 05-15 21:21:53 [core.py:1140]   File "/workspace/tpu_inference/tpu_inference/layers/vllm/quantization/unquantized.py", line 166, in maybe_process_weights
(EngineCore pid=550) ERROR 05-15 21:21:53 [core.py:1140]     assert len(args) == 1, "Expecting shard_id as the only argument"
(EngineCore pid=550) ERROR 05-15 21:21:53 [core.py:1140]            ^^^^^^^^^^^^^^
(EngineCore pid=550) ERROR 05-15 21:21:53 [core.py:1140] AssertionError: Expecting shard_id as the only argument
(EngineCore pid=550) Process EngineCore:
   
