### PR TITLE
GDN recurrent scan kernel: added async dma for prefill, decode, and transition

### DIFF
--- a/tpu_inference/kernels/gdn/v2/recurrent_scan_v2.py
+++ b/tpu_inference/kernels/gdn/v2/recurrent_scan_v2.py
@@ -214,11 +214,11 @@ def inner_kernel(
             slot = b % 2
             using_slot_0 = (slot == 0)
             cur_slot_inflight = jax.lax.select(using_slot_0, s0_inflight,
-                                                s1_inflight)
+                                               s1_inflight)
 
             @pl.when(is_valid)
             def do_work():
-                # Wait for THIS iter's load (issued by preload or by iter b-2 prefetch).
+                # Wait for this iter's load (issued by preload or by iter b-2 prefetch).
                 wait_load = pltpu.make_async_copy(
                     src_ref=recurrent_state_in.at[pl.ds(0, 1)],
                     dst_ref=decode_load_scratch.at[pl.ds(slot, 1)],
@@ -227,12 +227,11 @@ def inner_kernel(
                 wait_load.wait()
 
                 # Copy loaded state to fp32 compute scratch.
-                decode_state_scratch[pl.ds(
-                    0, 1)] = decode_load_scratch[pl.ds(slot, 1)][...].astype(
-                        jnp.float32)
+                decode_state_scratch[pl.ds(0, 1)] = decode_load_scratch[pl.ds(
+                    slot, 1)][...].astype(jnp.float32)
 
-                # Prefetch load for iter b+2 (same slot, since (b+2) % 2 == b % 2).
-                # This DMA overlaps with the compute below.
+                # Prefetch load for iter b+2 (same slot).
+                # This DMA overlaps with the compute of current iter.
                 next_b = b + 2
 
                 @pl.when(next_b < decode_count)
@@ -402,7 +401,7 @@ def inner_kernel(
                 # No wait — drained after fori_loop.
 
             # Update carry: this iter marked its slot as having an in-flight
-            # store iff is_valid.
+            # store if is_valid.
             next_s0_inflight = jax.lax.select(
                 is_valid & using_slot_0,
                 jnp.int32(1),
@@ -417,7 +416,9 @@ def inner_kernel(
 
         # loop over bt, could be for loop, BT is static anyway, unroll
         final_s0_inflight, final_s1_inflight = jax.lax.fori_loop(
-            0, BT, process_decode,
+            0,
+            BT,
+            process_decode,
             (jnp.int32(0), jnp.int32(0)),
         )
 
@@ -480,7 +481,6 @@ def inner_kernel(
             def _zero_init_state():
                 prefill_scratch[prefill_slot] = jnp.zeros(
                     (n_v, d_k, d_v), dtype=prefill_scratch.dtype)
-
 
             ### Preparataion for chunk wise math,
             ### this kernel design could be optimized lot by not doing this every chunk
@@ -1158,14 +1158,16 @@ def fused_kernel(
         pltpu.VMEM((1, n_v, d_k, d_v), jnp.float32),  # decode_state_scratch
         pltpu.VMEM((1, n_v, d_k, d_v),
                    recurrent_state_ref.dtype),  # state_commit_scratch
-        pltpu.VMEM((2, n_v, d_k, d_v),
-                   recurrent_state_ref.dtype),  # decode_load_scratch (double-buffered)
-        pltpu.VMEM((2, n_v, d_k, d_v),
-                   recurrent_state_ref.dtype),  # decode_store_scratch (double-buffered)
+        pltpu.VMEM((2, n_v, d_k, d_v), recurrent_state_ref.dtype
+                   ),  # decode_load_scratch (double-buffered)
+        pltpu.VMEM((2, n_v, d_k, d_v), recurrent_state_ref.dtype
+                   ),  # decode_store_scratch (double-buffered)
         pltpu.VMEM((BT, n_v * d_v),
                    mixed_qkv_ref.dtype),  # decode_output_scratch
-        pltpu.SemaphoreType.DMA((2, )),  # decode_read_semaphores (one per slot)
-        pltpu.SemaphoreType.DMA((2, )),  # decode_write_semaphore (one per slot)
+        pltpu.SemaphoreType.DMA(
+            (2, )),  # decode_read_semaphores (one per slot)
+        pltpu.SemaphoreType.DMA(
+            (2, )),  # decode_write_semaphore (one per slot)
         pltpu.SemaphoreType.DMA((2, )),  # prefill_semaphore
     )
 
@@ -1326,4 +1328,3 @@ def recurrent_scan(
         total_blocks_arr,
     )
     return updated_recurrent_state, output_padded[:num_tokens]
-  

--- a/tpu_inference/kernels/gdn/v2/recurrent_scan_v2.py
+++ b/tpu_inference/kernels/gdn/v2/recurrent_scan_v2.py
@@ -127,11 +127,17 @@ def inner_kernel(
     # VMEM scratchpad: (1, n_v, d_k, d_v). dtype = recurrent_state dtype
     # TODO: if output dtype of state is always f32 then this can be removed.
     state_commit_scratch,
+    # VMEM scratchpad: (2, n_v, d_k, d_v). Double-buffered staging for
+    # fully-async decode loads. iter b lands in slot (b % 2).
+    decode_load_scratch,
+    # VMEM scratchpad: (2, n_v, d_k, d_v). Double-buffered staging for
+    # fully-async decode stores. iter b uses slot (b % 2).
+    decode_store_scratch,
     # VMEM scratchpad: (BT, n_v * d_v). To hold decode outputs before DMA
     decode_output_scratch,
     # Array of C semaphores for decode state loads
     decode_read_semaphores,
-    # 1 semaphore for decode state stores
+    # 2 semaphores (one per decode_store_scratch slot) for async decode stores
     decode_write_semaphore,
     # 1 semaphore for prefill DMA (stores only)
     prefill_semaphore,
@@ -167,7 +173,6 @@ def inner_kernel(
         return x / norm
 
     # 2. Decode Branch
-    # check current iteration had decode work
     @pl.when(decode_valid > 0)
     def decode_wrapper():
 
@@ -176,24 +181,71 @@ def inner_kernel(
                                       state_indices.shape[0] - 1)
             return state_indices[safe_req_id][...]
 
-        def process_decode(b, _):
-            # token by token check if decode token or not
+        # Pre-loop: kick off async loads for iters 0 and 1.
+        # iter b consumes the load that lands in decode_load_scratch[b % 2].
+        # Subsequent loads (iter b+2 for each iter b) are issued from inside
+        # the loop as prefetches.
+        @pl.when(decode_count >= 1)
+        def _preload_slot_0():
+            tgt = get_target_idx(0)
+            op = pltpu.make_async_copy(
+                src_ref=recurrent_state_in.at[pl.ds(tgt, 1)],
+                dst_ref=decode_load_scratch.at[pl.ds(0, 1)],
+                sem=decode_read_semaphores.at[0],
+            )
+            op.start()
+
+        @pl.when(decode_count >= 2)
+        def _preload_slot_1():
+            tgt = get_target_idx(1)
+            op = pltpu.make_async_copy(
+                src_ref=recurrent_state_in.at[pl.ds(tgt, 1)],
+                dst_ref=decode_load_scratch.at[pl.ds(1, 1)],
+                sem=decode_read_semaphores.at[1],
+            )
+            op.start()
+
+        @jax.named_scope("process_decode_with_prefill_transition_all_async")
+        def process_decode(b, store_inflight):
+            # store_inflight: tuple (s0_inflight, s1_inflight) of int32 scalars.
+            # s{n}_inflight == 1 iff slot n has an in-flight async store DMA.
+            s0_inflight, s1_inflight = store_inflight
             is_valid = b < decode_count
+            slot = b % 2
+            using_slot_0 = (slot == 0)
+            cur_slot_inflight = jax.lax.select(using_slot_0, s0_inflight,
+                                                s1_inflight)
 
             @pl.when(is_valid)
             def do_work():
-                target_idx = get_target_idx(b)
-
-                # Load state TODO: make async
-                copy_op = pltpu.make_async_copy(
-                    src_ref=recurrent_state_in.at[pl.ds(target_idx, 1)],
-                    dst_ref=state_commit_scratch,
-                    sem=decode_read_semaphores.at[0],
+                # Wait for THIS iter's load (issued by preload or by iter b-2 prefetch).
+                wait_load = pltpu.make_async_copy(
+                    src_ref=recurrent_state_in.at[pl.ds(0, 1)],
+                    dst_ref=decode_load_scratch.at[pl.ds(slot, 1)],
+                    sem=decode_read_semaphores.at[slot],
                 )
-                copy_op.start()
-                copy_op.wait()
+                wait_load.wait()
+
+                # Copy loaded state to fp32 compute scratch.
                 decode_state_scratch[pl.ds(
-                    0, 1)] = state_commit_scratch[...].astype(jnp.float32)
+                    0, 1)] = decode_load_scratch[pl.ds(slot, 1)][...].astype(
+                        jnp.float32)
+
+                # Prefetch load for iter b+2 (same slot, since (b+2) % 2 == b % 2).
+                # This DMA overlaps with the compute below.
+                next_b = b + 2
+
+                @pl.when(next_b < decode_count)
+                def _prefetch_next_load():
+                    next_tgt = get_target_idx(next_b)
+                    op = pltpu.make_async_copy(
+                        src_ref=recurrent_state_in.at[pl.ds(next_tgt, 1)],
+                        dst_ref=decode_load_scratch.at[pl.ds(slot, 1)],
+                        sem=decode_read_semaphores.at[slot],
+                    )
+                    op.start()
+
+                target_idx = get_target_idx(b)
 
                 key_dim = n_kq * d_k
                 b_aligned = (b // sublanesize) * sublanesize
@@ -312,20 +364,6 @@ def inner_kernel(
                 new_state = jnp.stack(new_state_list,
                                       axis=0)  # (n_v, d_k, d_v)
 
-                # TODO: remove VPU path if MXU is certified path
-                # decay_exp = decay[..., None]  # (n_v, 1)
-
-                # k_state = jnp.sum(k[..., None] * current_state, axis=1)  # (n_v, d_v)
-                # v_diff = v - decay_exp * k_state
-                # v_new = curr_beta[..., None] * v_diff  # (n_v, d_v)
-
-                # q_state = jnp.sum(q[..., None] * current_state, axis=1)  # (n_v, d_v)
-                # q_k = jnp.sum(q * k, axis=-1, keepdims=True)  # (n_v, 1)
-
-                # out = decay_exp * q_state + q_k * v_new  # (n_v, d_v)
-                # k_v_new = k[..., None] * v_new[:, None, :]
-                # new_state = current_state * decay_exp[..., None] + k_v_new
-
                 decode_state_scratch[pl.ds(
                     0, 1)] = new_state[None, ...].astype(current_state.dtype)
 
@@ -341,23 +379,66 @@ def inner_kernel(
                 decode_output_scratch[...] = new_output.astype(
                     current_output.dtype)
 
-                # Store state (Synchronous)
-                state_commit_scratch[0] = decode_state_scratch[0].astype(
-                    state_commit_scratch.dtype)
+                # Async store. Before writing to decode_store_scratch[slot],
+                # wait for the previous same-slot store DMA (from iter b-2)
+                # so we don't clobber a buffer that's still being read.
+                @pl.when(cur_slot_inflight > 0)
+                def _wait_same_slot_store():
+                    temp_desc = pltpu.make_async_copy(
+                        src_ref=decode_store_scratch.at[pl.ds(slot, 1)],
+                        dst_ref=recurrent_state_out.at[pl.ds(0, 1)],
+                        sem=decode_write_semaphore.at[slot],
+                    )
+                    temp_desc.wait()
+
+                decode_store_scratch[slot] = decode_state_scratch[0].astype(
+                    decode_store_scratch.dtype)
                 copy_op = pltpu.make_async_copy(
-                    src_ref=state_commit_scratch,
+                    src_ref=decode_store_scratch.at[pl.ds(slot, 1)],
                     dst_ref=recurrent_state_out.at[pl.ds(target_idx, 1)],
-                    sem=decode_write_semaphore.at[0],
+                    sem=decode_write_semaphore.at[slot],
                 )
                 copy_op.start()
-                copy_op.wait()
+                # No wait — drained after fori_loop.
 
-                return None
-
-            return None
+            # Update carry: this iter marked its slot as having an in-flight
+            # store iff is_valid.
+            next_s0_inflight = jax.lax.select(
+                is_valid & using_slot_0,
+                jnp.int32(1),
+                s0_inflight,
+            )
+            next_s1_inflight = jax.lax.select(
+                is_valid & (~using_slot_0),
+                jnp.int32(1),
+                s1_inflight,
+            )
+            return (next_s0_inflight, next_s1_inflight)
 
         # loop over bt, could be for loop, BT is static anyway, unroll
-        jax.lax.fori_loop(0, BT, process_decode, None)
+        final_s0_inflight, final_s1_inflight = jax.lax.fori_loop(
+            0, BT, process_decode,
+            (jnp.int32(0), jnp.int32(0)),
+        )
+
+        # Drain any remaining async store DMAs (at most one per slot).
+        @pl.when(final_s0_inflight > 0)
+        def _drain_slot_0():
+            temp_desc = pltpu.make_async_copy(
+                src_ref=decode_store_scratch.at[pl.ds(0, 1)],
+                dst_ref=recurrent_state_out.at[pl.ds(0, 1)],
+                sem=decode_write_semaphore.at[0],
+            )
+            temp_desc.wait()
+
+        @pl.when(final_s1_inflight > 0)
+        def _drain_slot_1():
+            temp_desc = pltpu.make_async_copy(
+                src_ref=decode_store_scratch.at[pl.ds(1, 1)],
+                dst_ref=recurrent_state_out.at[pl.ds(0, 1)],
+                sem=decode_write_semaphore.at[1],
+            )
+            temp_desc.wait()
 
         # Mask and write accumulated outputs to HBM
         mask = (jnp.arange(BT)
@@ -378,29 +459,28 @@ def inner_kernel(
         prefill_slot = prefill_req_id % 2
 
         def process_regular_prefill():
-            # 1. Initialize state if first chunk of the request in this step
-            @pl.when(is_first_chunk > 0)
-            def init_state():
-                has_init = has_initial_state[prefill_req_id][...]
+            # Capture init-load condition + state_idx ONCE so the deferred
+            # wait block uses the same values as the start.
+            init_has_init = has_initial_state[prefill_req_id][...]
+            init_state_idx = state_indices[prefill_req_id][...]
+            should_load_init = (is_first_chunk > 0) & (init_has_init > 0)
+            should_zero_init = (is_first_chunk > 0) & (init_has_init == 0)
 
-                def load_from_hbm():
-                    state_idx = state_indices[prefill_req_id][...]
-                    copy_op = pltpu.make_async_copy(
-                        src_ref=recurrent_state_in.at[pl.ds(state_idx, 1)],
-                        dst_ref=state_commit_scratch,
-                        sem=prefill_semaphore.at[prefill_slot],
-                    )
-                    copy_op.start()
-                    copy_op.wait()
-                    prefill_scratch[prefill_slot] = state_commit_scratch[
-                        0].astype(prefill_scratch.dtype)
+            # Issue async init load — wait deferred to just before consume.
+            @pl.when(should_load_init)
+            def _start_init_load():
+                copy_op = pltpu.make_async_copy(
+                    src_ref=recurrent_state_in.at[pl.ds(init_state_idx, 1)],
+                    dst_ref=state_commit_scratch,
+                    sem=prefill_semaphore.at[prefill_slot],
+                )
+                copy_op.start()
 
-                def zero_state():
-                    prefill_scratch[prefill_slot] = jnp.zeros(
-                        (n_v, d_k, d_v), dtype=prefill_scratch.dtype)
+            @pl.when(should_zero_init)
+            def _zero_init_state():
+                prefill_scratch[prefill_slot] = jnp.zeros(
+                    (n_v, d_k, d_v), dtype=prefill_scratch.dtype)
 
-                jax.lax.cond(has_init > 0, load_from_hbm, zero_state)
-                return None
 
             ### Preparataion for chunk wise math,
             ### this kernel design could be optimized lot by not doing this every chunk
@@ -523,6 +603,19 @@ def inner_kernel(
             )
 
             q_g = q * jnp.exp(g_cumsum)[..., None]
+
+            # Finish async init load before consuming prefill_scratch[prefill_slot].
+            @pl.when(should_load_init)
+            def _finish_init_load():
+                temp_desc = pltpu.make_async_copy(
+                    src_ref=recurrent_state_in.at[pl.ds(init_state_idx, 1)],
+                    dst_ref=state_commit_scratch,
+                    sem=prefill_semaphore.at[prefill_slot],
+                )
+                temp_desc.wait()
+                prefill_scratch[prefill_slot] = state_commit_scratch[0].astype(
+                    prefill_scratch.dtype)
+
             current_state = prefill_scratch[prefill_slot]
             attn_inter = jnp.matmul(
                 q_g.astype(jnp.float32),
@@ -552,22 +645,24 @@ def inner_kernel(
 
             prefill_scratch[prefill_slot] = h_new.astype(prefill_scratch.dtype)
 
-            # Store state only if it's the last chunk of the request
+            # Store state only if it's the last chunk of the request.
+            # Start only — wait deferred to end of process_regular_prefill so
+            # the store DMA overlaps with the prefill_output_ref HBM write below.
+            store_state_idx = state_indices[prefill_req_id][...]
+
             @pl.when(is_last_chunk > 0)
             def store_state():
                 # TODO: if dtype of state in HBM is always f32,
                 # then we can eliminate this copy and directly write from scratch to HBM
                 state_commit_scratch[0] = prefill_scratch[prefill_slot].astype(
                     state_commit_scratch.dtype)
-                state_idx = state_indices[prefill_req_id][...]
                 copy_op = pltpu.make_async_copy(
                     src_ref=state_commit_scratch,
-                    dst_ref=recurrent_state_out.at[pl.ds(state_idx, 1)],
+                    dst_ref=recurrent_state_out.at[pl.ds(store_state_idx, 1)],
                     sem=prefill_semaphore.at[prefill_slot],
                 )
                 copy_op.start()
-                copy_op.wait()
-                return None
+                # No wait — drained at end of process_regular_prefill.
 
             # TODO: eliminate this transpose and reshape by directly writing in the right shape above
             o_c_tr = o_c.transpose(1, 0, 2)
@@ -578,12 +673,42 @@ def inner_kernel(
             o_c_flat_masked = o_c_flat * mask_float[:, None]
             prefill_output_ref[...] = o_c_flat_masked.astype(
                 prefill_output_ref.dtype)
+
+            # Drain async final store (started in store_state above).
+            @pl.when(is_last_chunk > 0)
+            def _finish_store_state():
+                temp_desc = pltpu.make_async_copy(
+                    src_ref=state_commit_scratch,
+                    dst_ref=recurrent_state_out.at[pl.ds(store_state_idx, 1)],
+                    sem=prefill_semaphore.at[prefill_slot],
+                )
+                temp_desc.wait()
+
             return None
 
         def process_transition_prefill():
             # this is processing prefill sequences in a sublane that has multiple sequences
             C_trans = sublanesize
             key_dim = n_kq * d_k
+
+            # Read first-request metadata up front so we can issue the
+            # async initial load BEFORE the chunk-wide compute below.
+            first_req_id = schedule_table[step, 11][...]
+            first_is_first = schedule_table[step, 11 + C_trans][...]
+            first_slot = first_req_id % 2
+            first_has_init = has_initial_state[first_req_id][...]
+            should_load_first = (first_is_first > 0) & (first_has_init > 0)
+            first_state_idx = state_indices[first_req_id][...]
+
+            # Issue async initial load — wait deferred to just before consume.
+            @pl.when(should_load_first)
+            def _start_first_load():
+                copy_op = pltpu.make_async_copy(
+                    src_ref=recurrent_state_in.at[pl.ds(first_state_idx, 1)],
+                    dst_ref=state_commit_scratch,
+                    sem=prefill_semaphore.at[first_slot],
+                )
+                copy_op.start()
 
             # Workaround: Upcast to fp32 to avoid NaNs
             qkv_chunk = prefill_qkv_ref[:C_trans, :].astype(jnp.float32)
@@ -629,22 +754,15 @@ def inner_kernel(
             scale = d_k**-0.5
             q = q * scale
 
-            # state indice for req
-            first_req_id = schedule_table[step, 11][...]
-            first_is_first = schedule_table[step, 11 + C_trans][...]
-            first_slot = first_req_id % 2
-            first_has_init = has_initial_state[first_req_id][...]
-
-            @pl.when((first_is_first > 0) & (first_has_init > 0))
-            def load_first_state():
-                state_idx = state_indices[first_req_id][...]
-                copy_op = pltpu.make_async_copy(
-                    src_ref=recurrent_state_in.at[pl.ds(state_idx, 1)],
+            # Finish async initial load before consuming prefill_scratch[first_slot].
+            @pl.when(should_load_first)
+            def _finish_first_load():
+                temp_desc = pltpu.make_async_copy(
+                    src_ref=recurrent_state_in.at[pl.ds(first_state_idx, 1)],
                     dst_ref=state_commit_scratch,
                     sem=prefill_semaphore.at[first_slot],
                 )
-                copy_op.start()
-                copy_op.wait()
+                temp_desc.wait()
                 prefill_scratch[first_slot] = state_commit_scratch[0].astype(
                     prefill_scratch.dtype)
 
@@ -979,6 +1097,8 @@ def fused_kernel(
         scratch_ref,
         decode_state_scratch_ref,
         state_commit_scratch_ref,
+        decode_load_scratch_ref,
+        decode_store_scratch_ref,
         decode_output_scratch_ref,
         decode_read_sems,
         decode_write_sem,
@@ -1000,6 +1120,8 @@ def fused_kernel(
                 decode_state_scratch=decode_state_scratch_ref,
                 decode_output_scratch=decode_output_scratch_ref,
                 state_commit_scratch=state_commit_scratch_ref,
+                decode_load_scratch=decode_load_scratch_ref,
+                decode_store_scratch=decode_store_scratch_ref,
                 decode_read_semaphores=decode_read_sems,
                 decode_write_semaphore=decode_write_sem,
                 prefill_semaphore=prefill_sem,
@@ -1036,10 +1158,14 @@ def fused_kernel(
         pltpu.VMEM((1, n_v, d_k, d_v), jnp.float32),  # decode_state_scratch
         pltpu.VMEM((1, n_v, d_k, d_v),
                    recurrent_state_ref.dtype),  # state_commit_scratch
+        pltpu.VMEM((2, n_v, d_k, d_v),
+                   recurrent_state_ref.dtype),  # decode_load_scratch (double-buffered)
+        pltpu.VMEM((2, n_v, d_k, d_v),
+                   recurrent_state_ref.dtype),  # decode_store_scratch (double-buffered)
         pltpu.VMEM((BT, n_v * d_v),
                    mixed_qkv_ref.dtype),  # decode_output_scratch
-        pltpu.SemaphoreType.DMA((1, )),  # decode_read_semaphores
-        pltpu.SemaphoreType.DMA((1, )),  # decode_write_semaphore
+        pltpu.SemaphoreType.DMA((2, )),  # decode_read_semaphores (one per slot)
+        pltpu.SemaphoreType.DMA((2, )),  # decode_write_semaphore (one per slot)
         pltpu.SemaphoreType.DMA((2, )),  # prefill_semaphore
     )
 
@@ -1200,3 +1326,4 @@ def recurrent_scan(
         total_blocks_arr,
     )
     return updated_recurrent_state, output_padded[:num_tokens]
+  

--- a/tpu_inference/kernels/gdn/v2/recurrent_scan_v2.py
+++ b/tpu_inference/kernels/gdn/v2/recurrent_scan_v2.py
@@ -15,12 +15,42 @@
 import functools
 
 import jax
-import jax.numpy as jnp
 from jax.experimental import pallas as pl
 from jax.experimental.pallas import tpu as pltpu
+import jax.numpy as jnp
 
 from tpu_inference.kernels.gdn.v2 import \
     compute_schedule_v2 as compute_schedule_table_v2
+
+
+
+# def invert_triangular_matrix(A, block_size=None):
+#   """Inverts a unit lower triangular matrix A using Neumann doubling.
+
+#   Algorithm: Neumann doubling. For L strictly lower triangular of size N x N,
+#   since L^N = 0 we have:
+#     (I + L)^{-1} = (I - L)(I + L^2)(I + L^4) ... (I + L^(N/2))
+
+#   Args:
+#     A: Unit lower triangular matrix of shape (B, N, N).
+#     block_size: Size of the blocks for Gaussian elimination (unused).
+
+#   Returns:
+#     Inverse of A, of shape (B, N, N).
+
+#   For N=128 this is exactly 6 iterations = 12 matmuls, all (B, 128, 128).
+#   """
+#   B, N, _ = A.shape
+#   num_iters = max(1, (N - 1).bit_length() - 1)
+#   in_dtype = A.dtype
+#   A_f32 = A.astype(jnp.float32)
+#   L = jnp.tril(A_f32, k=-1)
+#   eye = jnp.broadcast_to(jnp.eye(N, dtype=jnp.float32), (B, N, N))
+#   Y = eye - L
+#   for _ in range(num_iters):
+#     L = jnp.matmul(L, L, precision=jax.lax.Precision.HIGHEST)
+#     Y = Y + jnp.matmul(Y, L, precision=jax.lax.Precision.HIGHEST)
+#   return Y.astype(in_dtype)
 
 
 def invert_triangular_matrix(A, block_size=16):
@@ -121,11 +151,15 @@ def inner_kernel(
     # VMEM scratchpad: (2, n_v, d_k, d_v). To carry state across chunks
     # (double buffered)
     prefill_scratch,
-    # VMEM scratchpad: (1, 2, n_v, d_k, d_v). TODO: double
-    # buffer or x buffer to to loop over BT in decode without overwriting state and using async copy for state load/store)
+    # VMEM scratchpad: (1, n_v, d_k, d_v). Per-iter safe-copy of the loaded
+    # state. Required as a separate buffer from decode_load_scratch because
+    # the prefetch DMA for iter b+2 writes to the same slot concurrently with
+    # this iter's compute; this buffer isolates the reads. Stored as bf16;
+    # per-head fp32 cast happens in VREG inside the compute loop.
     decode_state_scratch,
-    # VMEM scratchpad: (1, n_v, d_k, d_v). dtype = recurrent_state dtype
-    # TODO: if output dtype of state is always f32 then this can be removed.
+    # VMEM scratchpad: (1, n_v, d_k, d_v). Aliased to slot 0 of
+    # decode_store_scratch in _run_with_scratch (decode drains its stores
+    # before prefill runs, so the slot is free for prefill bf16 staging).
     state_commit_scratch,
     # VMEM scratchpad: (2, n_v, d_k, d_v). Double-buffered staging for
     # fully-async decode loads. iter b lands in slot (b % 2).
@@ -205,20 +239,19 @@ def inner_kernel(
             )
             op.start()
 
-        @jax.named_scope("process_decode_with_prefill_transition_all_async")
         def process_decode(b, store_inflight):
             # store_inflight: tuple (s0_inflight, s1_inflight) of int32 scalars.
             # s{n}_inflight == 1 iff slot n has an in-flight async store DMA.
             s0_inflight, s1_inflight = store_inflight
             is_valid = b < decode_count
             slot = b % 2
-            using_slot_0 = (slot == 0)
+            using_slot_0 = slot == 0
             cur_slot_inflight = jax.lax.select(using_slot_0, s0_inflight,
                                                s1_inflight)
 
             @pl.when(is_valid)
             def do_work():
-                # Wait for this iter's load (issued by preload or by iter b-2 prefetch).
+                # Wait for THIS iter's load (issued by preload or by iter b-2 prefetch).
                 wait_load = pltpu.make_async_copy(
                     src_ref=recurrent_state_in.at[pl.ds(0, 1)],
                     dst_ref=decode_load_scratch.at[pl.ds(slot, 1)],
@@ -226,12 +259,14 @@ def inner_kernel(
                 )
                 wait_load.wait()
 
-                # Copy loaded state to fp32 compute scratch.
+                # Safe-copy of loaded state. Isolates compute from the
+                # prefetch DMA below that writes the same slot of
+                # decode_load_scratch concurrently. bf16 -> bf16, no cast.
                 decode_state_scratch[pl.ds(0, 1)] = decode_load_scratch[pl.ds(
-                    slot, 1)][...].astype(jnp.float32)
+                    slot, 1)][...]
 
-                # Prefetch load for iter b+2 (same slot).
-                # This DMA overlaps with the compute of current iter.
+                # Prefetch load for iter b+2 (same slot, since (b+2) % 2 == b % 2).
+                # This DMA overlaps with the compute below.
                 next_b = b + 2
 
                 @pl.when(next_b < decode_count)
@@ -314,7 +349,8 @@ def inner_kernel(
                     k_h = k[h:h + 1, :]  # (1, d_k)
                     v_h = v[h:h + 1, :]  # (1, d_v)
 
-                    state_h = current_state[h]  # (d_k, d_v)
+                    state_h = current_state[h].astype(
+                        jnp.float32)  # (d_k, d_v)
 
                     k_state_h = pl.dot(
                         k_h, state_h,
@@ -363,9 +399,6 @@ def inner_kernel(
                 new_state = jnp.stack(new_state_list,
                                       axis=0)  # (n_v, d_k, d_v)
 
-                decode_state_scratch[pl.ds(
-                    0, 1)] = new_state[None, ...].astype(current_state.dtype)
-
                 # Accumulate output in scratchpad
                 current_output = decode_output_scratch[...]
                 mask = (jnp.arange(BT) == b).astype(current_output.dtype)[:,
@@ -390,7 +423,7 @@ def inner_kernel(
                     )
                     temp_desc.wait()
 
-                decode_store_scratch[slot] = decode_state_scratch[0].astype(
+                decode_store_scratch[slot] = new_state.astype(
                     decode_store_scratch.dtype)
                 copy_op = pltpu.make_async_copy(
                     src_ref=decode_store_scratch.at[pl.ds(slot, 1)],
@@ -401,7 +434,7 @@ def inner_kernel(
                 # No wait — drained after fori_loop.
 
             # Update carry: this iter marked its slot as having an in-flight
-            # store if is_valid.
+            # store iff is_valid.
             next_s0_inflight = jax.lax.select(
                 is_valid & using_slot_0,
                 jnp.int32(1),
@@ -460,14 +493,11 @@ def inner_kernel(
         prefill_slot = prefill_req_id % 2
 
         def process_regular_prefill():
-            # Capture init-load condition + state_idx ONCE so the deferred
-            # wait block uses the same values as the start.
             init_has_init = has_initial_state[prefill_req_id][...]
             init_state_idx = state_indices[prefill_req_id][...]
             should_load_init = (is_first_chunk > 0) & (init_has_init > 0)
             should_zero_init = (is_first_chunk > 0) & (init_has_init == 0)
 
-            # Issue async init load — wait deferred to just before consume.
             @pl.when(should_load_init)
             def _start_init_load():
                 copy_op = pltpu.make_async_copy(
@@ -504,8 +534,7 @@ def inner_kernel(
             a_raw_processed = a_raw_chunk[:, :n_v].T
             b_raw_processed = b_raw_chunk[:, :n_v].T
 
-            a_raw_processed = a_raw_processed.astype(jnp.float32)
-            b_raw_processed = b_raw_processed.astype(jnp.float32)
+            # Compute gates in VMEM in full fp32, not sure if needed.
             beta = jax.nn.sigmoid(b_raw_processed)
             g = -jnp.exp(a_log_ref[...][:, None].astype(
                 jnp.float32)) * jax.nn.softplus(a_raw_processed + dt_bias_ref[
@@ -531,16 +560,17 @@ def inner_kernel(
                 q = l2_normalize(q)
                 k = l2_normalize(k)
 
-            repeat_factor = n_v // n_kq
-            if repeat_factor > 1:
-                q = jnp.repeat(q, repeat_factor, axis=1)
-                k = jnp.repeat(k, repeat_factor, axis=1)
-
-            # TODO: eliminate these transposes by directly slicing in the right
-            # shape above,
+            # Transpose first, then repeat: the transpose operates on the
+            # smaller (C, n_kq, d_k) tensor; the subsequent repeat on the
+            # (now-leading) axis produces the same final layout.
             q = q.transpose(1, 0, 2)
             k = k.transpose(1, 0, 2)
             v = v.transpose(1, 0, 2)
+
+            repeat_factor = n_v // n_kq
+            if repeat_factor > 1:
+                q = jnp.repeat(q, repeat_factor, axis=0)
+                k = jnp.repeat(k, repeat_factor, axis=0)
 
             scale = d_k**-0.5
             q = q * scale
@@ -554,11 +584,16 @@ def inner_kernel(
             g_cumsum = jnp.stack(g_cumsum_list, axis=-1)
             k_beta = k * beta[..., None]
 
-            S = jnp.matmul(
-                k_beta.astype(jnp.float32),
-                k.transpose(0, 2, 1).astype(jnp.float32),
+            # Fuse S and S_q into a single matmul.
+            k_T = k.transpose(0, 2, 1)
+            kbeta_q = jnp.concatenate([k_beta, q], axis=1)  # (n_v, 2C, d_k)
+            S_both = jnp.matmul(
+                kbeta_q.astype(jnp.float32),
+                k_T.astype(jnp.float32),
                 precision=jax.lax.Precision.HIGHEST,
-            )
+            )  # (n_v, 2C, C)
+            S = S_both[:, :C, :]
+            S_q = S_both[:, C:, :]
 
             g_diff = g_cumsum[..., :, None] - g_cumsum[..., None, :]
             i = jnp.arange(C)[:, None]
@@ -574,11 +609,6 @@ def inner_kernel(
             S = jnp.where(mask_float[None, :, :] > 0, S * jnp.exp(g_diff_safe),
                           0.0)
 
-            S_q = jnp.matmul(
-                q.astype(jnp.float32),
-                k.transpose(0, 2, 1).astype(jnp.float32),
-                precision=jax.lax.Precision.HIGHEST,
-            )
             mask_float_q = (i >= j).astype(jnp.float32)
             g_diff_Sq = g_diff_safe * mask_float_q[None, ...] + (
                 1.0 - mask_float_q[None, ...]) * (-1e30)
@@ -589,22 +619,25 @@ def inner_kernel(
             # TODO: call the function in kernels file
             A_inv = invert_triangular_matrix(I_plus_S, block_size=16)
 
-            # UW
+            # Fuse u and w into a single matmul. Both compute
+            # A_inv @ <something>; stack v_beta and k_beta_g along the last
+            # axis (d_v -> d_v + d_k), do one matmul, then split.
             v_beta = v * beta[..., None]
-            u = jnp.matmul(A_inv,
-                           v_beta.astype(jnp.float32),
-                           precision=jax.lax.Precision.HIGHEST)
-
             k_beta_g = k_beta * jnp.exp(g_cumsum)[..., None]
-            w = jnp.matmul(
-                A_inv,
-                k_beta_g.astype(jnp.float32),
-                precision=jax.lax.Precision.HIGHEST,
-            )
+            vk_in = jnp.concatenate(
+                [
+                    v_beta.astype(jnp.float32),
+                    k_beta_g.astype(jnp.float32),
+                ],
+                axis=2,
+            )  # (n_v, C, d_v + d_k)
+            uw = jnp.matmul(A_inv, vk_in, precision=jax.lax.Precision.HIGHEST)
+            u = uw[..., :d_v]
+            w = uw[..., d_v:]
 
             q_g = q * jnp.exp(g_cumsum)[..., None]
 
-            # Finish async init load before consuming prefill_scratch[prefill_slot].
+            # Fuse attn_inter and v_prime into a single matmul. With attentionDP, the async copy leads to very small perf gain.
             @pl.when(should_load_init)
             def _finish_init_load():
                 temp_desc = pltpu.make_async_copy(
@@ -617,16 +650,15 @@ def inner_kernel(
                     prefill_scratch.dtype)
 
             current_state = prefill_scratch[prefill_slot]
-            attn_inter = jnp.matmul(
-                q_g.astype(jnp.float32),
+            qw = jnp.concatenate([q_g.astype(jnp.float32), w], axis=1)
+            comb = jnp.matmul(
+                qw,
                 current_state.astype(jnp.float32),
                 precision=jax.lax.Precision.HIGHEST,
-            )
-            v_prime = jnp.matmul(
-                w,
-                current_state.astype(jnp.float32),
-                precision=jax.lax.Precision.HIGHEST,
-            )
+            )  # (n_v, 2C, d_v)
+            attn_inter = comb[:, :C, :]
+            v_prime = comb[:, C:, :]
+
             v_new = u - v_prime
             term2 = jnp.matmul(S_q, v_new, precision=jax.lax.Precision.HIGHEST)
             o_c = attn_inter + term2
@@ -646,8 +678,6 @@ def inner_kernel(
             prefill_scratch[prefill_slot] = h_new.astype(prefill_scratch.dtype)
 
             # Store state only if it's the last chunk of the request.
-            # Start only — wait deferred to end of process_regular_prefill so
-            # the store DMA overlaps with the prefill_output_ref HBM write below.
             store_state_idx = state_indices[prefill_req_id][...]
 
             @pl.when(is_last_chunk > 0)
@@ -662,7 +692,7 @@ def inner_kernel(
                     sem=prefill_semaphore.at[prefill_slot],
                 )
                 copy_op.start()
-                # No wait — drained at end of process_regular_prefill.
+                copy_op.wait()
 
             # TODO: eliminate this transpose and reshape by directly writing in the right shape above
             o_c_tr = o_c.transpose(1, 0, 2)
@@ -674,16 +704,6 @@ def inner_kernel(
             prefill_output_ref[...] = o_c_flat_masked.astype(
                 prefill_output_ref.dtype)
 
-            # Drain async final store (started in store_state above).
-            @pl.when(is_last_chunk > 0)
-            def _finish_store_state():
-                temp_desc = pltpu.make_async_copy(
-                    src_ref=state_commit_scratch,
-                    dst_ref=recurrent_state_out.at[pl.ds(store_state_idx, 1)],
-                    sem=prefill_semaphore.at[prefill_slot],
-                )
-                temp_desc.wait()
-
             return None
 
         def process_transition_prefill():
@@ -691,8 +711,6 @@ def inner_kernel(
             C_trans = sublanesize
             key_dim = n_kq * d_k
 
-            # Read first-request metadata up front so we can issue the
-            # async initial load BEFORE the chunk-wide compute below.
             first_req_id = schedule_table[step, 11][...]
             first_is_first = schedule_table[step, 11 + C_trans][...]
             first_slot = first_req_id % 2
@@ -700,7 +718,7 @@ def inner_kernel(
             should_load_first = (first_is_first > 0) & (first_has_init > 0)
             first_state_idx = state_indices[first_req_id][...]
 
-            # Issue async initial load — wait deferred to just before consume.
+            # Async initial load
             @pl.when(should_load_first)
             def _start_first_load():
                 copy_op = pltpu.make_async_copy(
@@ -726,9 +744,9 @@ def inner_kernel(
             a_raw_processed = a_raw_chunk[:C_trans, :n_v].T
             b_raw_processed = b_raw_chunk[:C_trans, :n_v].T
 
-            a_raw_processed = a_raw_processed.astype(jnp.float32)
-            b_raw_processed = b_raw_processed.astype(jnp.float32)
+            # NOTE: b is upcasted to f32 in ref before sigmoid, beta is bf16
             beta_chunk = jax.nn.sigmoid(b_raw_processed)
+            # NOTE: a is upcasted to f32 before add to dt_bias
             g_chunk = -jnp.exp(a_log_ref[...][:, None].astype(
                 jnp.float32)) * jax.nn.softplus(a_raw_processed + dt_bias_ref[
                     ...][:, None].astype(jnp.float32))
@@ -741,20 +759,27 @@ def inner_kernel(
                 q = l2_normalize(q)
                 k = l2_normalize(k)
 
-            repeat_factor = n_v // n_kq
-            if repeat_factor > 1:
-                q = jnp.repeat(q, repeat_factor, axis=1)
-                k = jnp.repeat(k, repeat_factor, axis=1)
-
-            # TODO: eliminate these transposes by directly slicing in the right shape above,
+            # Transpose first, then repeat
             q = q.transpose(1, 0, 2)
             k = k.transpose(1, 0, 2)
             v = v.transpose(1, 0, 2)
 
+            repeat_factor = n_v // n_kq
+            if repeat_factor > 1:
+                q = jnp.repeat(q, repeat_factor, axis=0)
+                k = jnp.repeat(k, repeat_factor, axis=0)
+
             scale = d_k**-0.5
             q = q * scale
 
-            # Finish async initial load before consuming prefill_scratch[first_slot].
+            # Cold-start: zero the slot in place when the first sequence has
+            # no carried-over state, then read.
+            @pl.when((first_is_first > 0) & (first_has_init == 0))
+            def _zero_first_slot():
+                prefill_scratch[first_slot] = jnp.zeros(
+                    (n_v, d_k, d_v), dtype=prefill_scratch.dtype)
+
+            # Finish the async initial load started above
             @pl.when(should_load_first)
             def _finish_first_load():
                 temp_desc = pltpu.make_async_copy(
@@ -767,17 +792,13 @@ def inner_kernel(
                     prefill_scratch.dtype)
 
             h = prefill_scratch[first_slot]
-            h = jnp.where((first_is_first > 0) & (first_has_init == 0),
-                          jnp.zeros_like(h), h)
 
             current_r = first_req_id
             sequence_valid = True
 
-            # loop over token by token
+            # Loop over tokens in the sublane.
             for i in range(sublanesize):
-                # read transition token metadata
                 t_req = schedule_table[step, 11 + i][...]
-                # get sequence index for token i in sublane
                 t_is_first = schedule_table[step, 11 + C_trans + i][...]
                 t_is_last = schedule_table[step, 11 + 2 * C_trans + i][...]
 
@@ -792,18 +813,15 @@ def inner_kernel(
 
                 c_slot = current_r % 2
 
-                h0 = prefill_scratch[0]
-                h1 = prefill_scratch[1]
-                prefill_scratch[0] = jnp.where(c_slot == 0, h, h0)
-                prefill_scratch[1] = jnp.where(c_slot == 1, h, h1)
-
-                # prefill_scratch in f32, state_commit might be in bf16
-                state_commit_scratch[0] = prefill_scratch[c_slot].astype(
-                    state_commit_scratch.dtype)
+                # Commit the previous iter's h to the current request's slot.
+                # The other slot is untouched.
+                prefill_scratch[c_slot] = h
 
                 def do_write():
-                    # TODO: Make async
                     state_idx = state_indices[current_r][...]
+                    # Stage h only when we actually DMA out.
+                    state_commit_scratch[0] = h.astype(
+                        state_commit_scratch.dtype)
                     copy_op = pltpu.make_async_copy(
                         src_ref=state_commit_scratch,
                         dst_ref=recurrent_state_out.at[pl.ds(state_idx, 1)],
@@ -835,13 +853,14 @@ def inner_kernel(
                 should_load_t = (t_is_first > 0) & (t_has_init > 0)
                 jax.lax.cond(should_load_t, load_t_state, lambda: None)
 
-                h0_new = prefill_scratch[0]
-                h1_new = prefill_scratch[1]
-                new_h = jnp.where(t_slot == 0, h0_new, h1_new)
+                # Cold-start: zero the slot in place for a new sequence with
+                # no carried-over state. Mutually exclusive with load_t_state.
+                @pl.when((t_is_first > 0) & (t_has_init == 0))
+                def _zero_t_slot():
+                    prefill_scratch[t_slot] = jnp.zeros(
+                        (n_v, d_k, d_v), dtype=prefill_scratch.dtype)
 
-                new_h = jnp.where((t_is_first > 0) & (t_has_init == 0),
-                                  jnp.zeros_like(new_h), new_h)
-                h = new_h
+                h = prefill_scratch[t_slot]
 
                 current_r = t_req
 
@@ -867,7 +886,7 @@ def inner_kernel(
 
                 h = jnp.where(sequence_valid, h_new, h)
 
-                # Mask output BEFORE invalidating the sequence for the next token
+                # Mask output before invalidating the sequence for the next token.
                 out_i = jnp.where(sequence_valid, out_i, 0.0)
 
                 sequence_valid = jnp.where(t_is_last > 0, False,
@@ -878,15 +897,16 @@ def inner_kernel(
 
             final_slot = current_r % 2
             prefill_scratch[final_slot] = h
-            state_commit_scratch[0] = h.astype(state_commit_scratch.dtype)
 
             is_current_r_prefill = current_r >= decode_tokens
 
-            # Store state if the current request is a prefill
+            # Store state if the current request is a prefill.
+            # At the end of the transition prefill. No need to make this async.
             @pl.when(is_current_r_prefill)
             def do_final_write():
-                # TODO: make async
                 state_idx = state_indices[current_r][...]
+                # Stage h into state_commit only when we actually DMA out.
+                state_commit_scratch[0] = h.astype(state_commit_scratch.dtype)
                 copy_op = pltpu.make_async_copy(
                     src_ref=state_commit_scratch,
                     dst_ref=recurrent_state_out.at[pl.ds(state_idx, 1)],
@@ -1096,7 +1116,6 @@ def fused_kernel(
     def _run_with_scratch(
         scratch_ref,
         decode_state_scratch_ref,
-        state_commit_scratch_ref,
         decode_load_scratch_ref,
         decode_store_scratch_ref,
         decode_output_scratch_ref,
@@ -1104,6 +1123,10 @@ def fused_kernel(
         decode_write_sem,
         prefill_sem,
     ):
+        # Alias state_commit_scratch to slot 0 of decode_store_scratch.
+        # Decode drains its store DMAs before prefill runs in any step, so
+        # the slot is free to use as prefill's bf16 HBM staging.
+        state_commit_scratch_ref = decode_store_scratch_ref.at[pl.ds(0, 1)]
 
         pipeline_func = pltpu.emit_pipeline(
             body=functools.partial(
@@ -1146,7 +1169,9 @@ def fused_kernel(
             output_ref,
             output_ref,
             scratches=[
-                schedule_table_ref, state_indices_ref, has_initial_state_ref
+                schedule_table_ref,
+                state_indices_ref,
+                has_initial_state_ref,
             ],
         )
 
@@ -1155,13 +1180,15 @@ def fused_kernel(
         _run_with_scratch,
         pltpu.VMEM((2, n_v, d_k, d_v),
                    jnp.float32),  # prefill_scratch (double buffered)
-        pltpu.VMEM((1, n_v, d_k, d_v), jnp.float32),  # decode_state_scratch
         pltpu.VMEM((1, n_v, d_k, d_v),
-                   recurrent_state_ref.dtype),  # state_commit_scratch
+                   recurrent_state_ref.dtype),  # decode_state_scratch
+        # state_commit_scratch aliased to slot 0 of decode_store_scratch in
+        # _run_with_scratch; no separate allocation.
         pltpu.VMEM((2, n_v, d_k, d_v), recurrent_state_ref.dtype
                    ),  # decode_load_scratch (double-buffered)
-        pltpu.VMEM((2, n_v, d_k, d_v), recurrent_state_ref.dtype
-                   ),  # decode_store_scratch (double-buffered)
+        pltpu.VMEM(
+            (2, n_v, d_k, d_v), recurrent_state_ref.dtype
+        ),  # decode_store_scratch (double-buffered; slot 0 also used as prefill's state_commit staging)
         pltpu.VMEM((BT, n_v * d_v),
                    mixed_qkv_ref.dtype),  # decode_output_scratch
         pltpu.SemaphoreType.DMA(
@@ -1182,6 +1209,8 @@ def fused_kernel(
         "chunk_size",
         "BT",
         "use_qk_norm_in_gdn",
+        "vmem_limit_bytes",
+        "race_detect_enable",
     ],
 )
 def recurrent_scan(
@@ -1203,6 +1232,8 @@ def recurrent_scan(
     BT: int = 128,
     use_qk_norm_in_gdn: bool = True,
     has_initial_state: jax.Array | None = None,
+    vmem_limit_bytes: int | None = None,
+    race_detect_enable: bool = False,
 ) -> tuple[jax.Array, jax.Array]:
     """Fused recurrent scan kernel for GDN on TPU v7.
 
@@ -1228,6 +1259,9 @@ def recurrent_scan(
     chunk_size: Block size for processing (default 128).
     BT: Block size for decode requests (default 128).
     use_qk_norm_in_gdn: Whether to use QK normalization.
+    vmem_limit_bytes: Per-kernel scoped VMEM ceiling passed to Mosaic.
+    race_detect_enable: If True, run the kernel under Pallas interpret mode with
+      DMA/buffer race detection enabled.
 
   Returns:
     A tuple containing:
@@ -1242,6 +1276,10 @@ def recurrent_scan(
     num_tokens = mixed_qkv.shape[0]
     tpu_info = pltpu.get_tpu_info()
     sublanesize = 4 // mixed_qkv.itemsize * tpu_info.num_sublanes
+
+    # Default the scoped VMEM ceiling. This value could be tuned for different state cache numerics and chunk sizes. 
+    if vmem_limit_bytes is None:
+        vmem_limit_bytes = int(tpu_info.vmem_capacity_bytes * 0.8)
 
     # Pad token dimension so invalid pipeline steps DMA into a safe sink area.
     # Sink offset must be aligned to sublanesize for Mosaic tile compatibility.
@@ -1313,7 +1351,12 @@ def recurrent_scan(
         ),
         grid_spec=grid_spec,
         input_output_aliases={1: 0},
-        compiler_params=pltpu.CompilerParams(disable_bounds_checks=True),
+        interpret=(pltpu.InterpretParams(
+            detect_races=True) if race_detect_enable else False),
+        compiler_params=pltpu.CompilerParams(
+            disable_bounds_checks=True,
+            vmem_limit_bytes=vmem_limit_bytes,
+        ),
     )(
         mixed_qkv,
         recurrent_state,

--- a/tpu_inference/kernels/gdn/v2/recurrent_scan_v2.py
+++ b/tpu_inference/kernels/gdn/v2/recurrent_scan_v2.py
@@ -15,13 +15,12 @@
 import functools
 
 import jax
+import jax.numpy as jnp
 from jax.experimental import pallas as pl
 from jax.experimental.pallas import tpu as pltpu
-import jax.numpy as jnp
 
 from tpu_inference.kernels.gdn.v2 import \
     compute_schedule_v2 as compute_schedule_table_v2
-
 
 # def invert_triangular_matrix(A, block_size=None):
 #   """Inverts a unit lower triangular matrix A using Neumann doubling.
@@ -532,7 +531,6 @@ def inner_kernel(
             # TODO: this transpose can be eliminated
             a_raw_processed = a_raw_chunk[:, :n_v].T
             b_raw_processed = b_raw_chunk[:, :n_v].T
-
 
             a_raw_processed = a_raw_processed.astype(jnp.float32)
             b_raw_processed = b_raw_processed.astype(jnp.float32)
@@ -1278,9 +1276,9 @@ def recurrent_scan(
     tpu_info = pltpu.get_tpu_info()
     sublanesize = 4 // mixed_qkv.itemsize * tpu_info.num_sublanes
 
-    # Default the scoped VMEM ceiling. This value could be tuned for different state cache numerics and chunk sizes. 
-    # if vmem_limit_bytes is None:
-    #     vmem_limit_bytes = int(tpu_info.vmem_capacity_bytes * 0.8)
+    # Default the scoped VMEM ceiling. This value could be tuned for different state cache numerics and chunk sizes.
+    if vmem_limit_bytes is None:
+        vmem_limit_bytes = tpu_info.vmem_capacity_bytes
 
     # Pad token dimension so invalid pipeline steps DMA into a safe sink area.
     # Sink offset must be aligned to sublanesize for Mosaic tile compatibility.
@@ -1356,7 +1354,7 @@ def recurrent_scan(
             detect_races=True) if race_detect_enable else False),
         compiler_params=pltpu.CompilerParams(
             disable_bounds_checks=True,
-            # vmem_limit_bytes=vmem_limit_bytes,
+            vmem_limit_bytes=vmem_limit_bytes,
         ),
     )(
         mixed_qkv,

--- a/tpu_inference/kernels/gdn/v2/recurrent_scan_v2.py
+++ b/tpu_inference/kernels/gdn/v2/recurrent_scan_v2.py
@@ -23,7 +23,6 @@ from tpu_inference.kernels.gdn.v2 import \
     compute_schedule_v2 as compute_schedule_table_v2
 
 
-
 # def invert_triangular_matrix(A, block_size=None):
 #   """Inverts a unit lower triangular matrix A using Neumann doubling.
 
@@ -534,7 +533,9 @@ def inner_kernel(
             a_raw_processed = a_raw_chunk[:, :n_v].T
             b_raw_processed = b_raw_chunk[:, :n_v].T
 
-            # Compute gates in VMEM in full fp32, not sure if needed.
+
+            a_raw_processed = a_raw_processed.astype(jnp.float32)
+            b_raw_processed = b_raw_processed.astype(jnp.float32)
             beta = jax.nn.sigmoid(b_raw_processed)
             g = -jnp.exp(a_log_ref[...][:, None].astype(
                 jnp.float32)) * jax.nn.softplus(a_raw_processed + dt_bias_ref[
@@ -744,9 +745,9 @@ def inner_kernel(
             a_raw_processed = a_raw_chunk[:C_trans, :n_v].T
             b_raw_processed = b_raw_chunk[:C_trans, :n_v].T
 
-            # NOTE: b is upcasted to f32 in ref before sigmoid, beta is bf16
+            a_raw_processed = a_raw_processed.astype(jnp.float32)
+            b_raw_processed = b_raw_processed.astype(jnp.float32)
             beta_chunk = jax.nn.sigmoid(b_raw_processed)
-            # NOTE: a is upcasted to f32 before add to dt_bias
             g_chunk = -jnp.exp(a_log_ref[...][:, None].astype(
                 jnp.float32)) * jax.nn.softplus(a_raw_processed + dt_bias_ref[
                     ...][:, None].astype(jnp.float32))
@@ -1278,8 +1279,8 @@ def recurrent_scan(
     sublanesize = 4 // mixed_qkv.itemsize * tpu_info.num_sublanes
 
     # Default the scoped VMEM ceiling. This value could be tuned for different state cache numerics and chunk sizes. 
-    if vmem_limit_bytes is None:
-        vmem_limit_bytes = int(tpu_info.vmem_capacity_bytes * 0.8)
+    # if vmem_limit_bytes is None:
+    #     vmem_limit_bytes = int(tpu_info.vmem_capacity_bytes * 0.8)
 
     # Pad token dimension so invalid pipeline steps DMA into a safe sink area.
     # Sink offset must be aligned to sublanesize for Mosaic tile compatibility.
@@ -1355,7 +1356,7 @@ def recurrent_scan(
             detect_races=True) if race_detect_enable else False),
         compiler_params=pltpu.CompilerParams(
             disable_bounds_checks=True,
-            vmem_limit_bytes=vmem_limit_bytes,
+            # vmem_limit_bytes=vmem_limit_bytes,
         ),
     )(
         mixed_qkv,


### PR DESCRIPTION
# Description
<img width="2308" height="1187" alt="image" src="https://github.com/user-attachments/assets/5a5b2ab8-7f65-464b-b02f-1866194e154b" />

This pull request optimizes the performance of the Gate Delta Net recurrent scan kernel by introducing asynchronous Direct Memory Access (DMA) for memory operations during the prefill, decode, and transition phases. For decode, the kernel now uses a double-buffering strategy (using slot 0 and slot 1) for loading and storing states. 

However, when combined with attention DP (which drops chunk_size 64->32, and increase the number of v heads 8->64), regular/transition prefill regressed, and the E2E throughput drops by 2% compared to baseline. This is because the CL added ~+8 MB of explicit decode-side scratch buffers in VMEM in this mem bound scenario of attention DP. 

Since the decode async buffers cannot be removed, the strategy is to reduce live transients and redundant VMEM accesses in regular prefill and transition prefill. All changes preserve bit-exactness.

The further optimization I did was:
- Alias state_commit_scratch to decode_store_scratch[0] since prefill and decode happens in serial.
- Transition prefill: per-iter loop cleanup (avoiding a full-state zeros tensor materialization, clean up the unconditional castings) 
- Regular prefill: transpose-before-repeat and matmul fusion. 


## Decode Schedule:
start load(0) -> decode_load_scratch[0] # async 
start load(1) -> decode_load_scratch[1] # async

Per iter b: (1) wait load @ slot    # waits for current iter DMA from iter b-2 
(2) start load @ slot for iter b+2     # prefetch async
(3) ===== COMPUTE: q/k/v, gates, attn, h_new =====
(4) wait store @ slot from iter b-2
(5) decode_store_scratch[slot] = h_new
(6) start store @ slot for iter b -> HBM

drain slot 0 store
drain slot 1 store

## Prefill Schedule:
(1) start init load -> state_commit_scratch # async 
(2) ===== chunk-prep compute (~100 lines): ====
q/k/v extract, gates, g_cumsum, S, S_q, A_inv, u, w, q_g
(3) wait init load -> prefill_scratch[slot]



# GPU comparison
In GPU, it's different - all decodes are padded as prefill if there is a prefill req in the batch. No double buffer or async DMA needed for GPU since all requests are processed in parallel by different CTAs.


# Tests
Kernel benchmark:
decode=13, prefill=[8, 16, 24]: 118.3us -> 96.1us.

Evals: MMLU Pro 
| Groups |Version|    Filter    |n-shot|  Metric   |   |Value |   |Stderr|
|--------|------:|--------------|-----:|-----------|---|-----:|---|-----:|
|mmlu_pro|      2|custom-extract|     5|exact_match|↑  |0.8314|±  |0.0138|

Qwen3.5 E2E Benchmark:
8k/1k, conc 512:
Output token throughput (tok/s):         2,162 -> 2406.59 
Total Token throughput (tok/s):          19,491 -> 21696.41

1k/8k conv 512:
Output token throughput (tok/s):         5,647 -> 5676.48
Total Token throughput (tok/s):          6,352 -> 6385.02
