### PR TITLE
[Perf] flax_nnx: extend pre-flatten to compute_logits / embed_input_ids / combine_hidden_states / embed_multimodal / run_draft_model

### DIFF
--- a/tests/runner/test_multimodal_manager.py
+++ b/tests/runner/test_multimodal_manager.py
@@ -88,7 +88,7 @@ class TestMultiModalManager:
         self.mock_get_mm_embed_fn = MagicMock()
         self.runner.embed_multimodal_fn = self.mock_get_mm_embed_fn
 
-        self.runner.state = MagicMock()
+        self.runner.state_leaves = MagicMock()
         # Mock scheduler output
         mock_scheduler_output = MagicMock(spec=VllmSchedulerOutput)
         mock_scheduler_output.scheduled_encoder_inputs = {"req-1": [0]}
@@ -141,12 +141,12 @@ class TestMultiModalManager:
         self.mock_get_mm_embed_fn.assert_called_once()
         call_args = self.mock_get_mm_embed_fn.call_args
 
-        # Positional args: (state, image_grid_thw)
+        # Positional args: (state_leaves,)
         state_arg, = call_args.args
         # Keyword args: **batched_mm_inputs
         kwargs_arg = call_args.kwargs
 
-        assert state_arg == self.runner.state
+        assert state_arg == self.runner.state_leaves
         assert "image_grid_thw" in kwargs_arg
         assert "pixel_values" in kwargs_arg
 
@@ -164,7 +164,7 @@ class TestMultiModalManager:
         self.mock_get_mm_embed_fn = MagicMock()
         self.runner.embed_multimodal_fn = self.mock_get_mm_embed_fn
 
-        self.runner.state = MagicMock()
+        self.runner.state_leaves = MagicMock()
         # Mock scheduler output for two requests
         mock_scheduler_output = MagicMock(spec=VllmSchedulerOutput)
         mock_scheduler_output.scheduled_encoder_inputs = {
@@ -251,7 +251,7 @@ class TestMultiModalManager:
         state_arg, = call_args.args
         kwargs_arg = call_args.kwargs
 
-        assert state_arg == self.runner.state
+        assert state_arg == self.runner.state_leaves
         assert "image_grid_thw" in kwargs_arg
         assert "pixel_values" in kwargs_arg
 

--- a/tests/runner/test_tpu_runner.py
+++ b/tests/runner/test_tpu_runner.py
@@ -93,7 +93,7 @@ class TestTPUJaxRunner:
         self.mock_get_input_embed_fn = MagicMock()
         self.runner.embed_input_ids_fn = self.mock_get_input_embed_fn
         self.mock_get_input_embed_fn.return_value = dummy_final_embeds
-        self.runner.state = MagicMock()
+        self.runner.state_leaves = MagicMock()
 
         # 2. ===== Act & Assert (Multimodal) =====
         self.runner.is_multimodal_model = True
@@ -105,7 +105,7 @@ class TestTPUJaxRunner:
         np.testing.assert_array_equal(np.asarray(inputs_embeds_res),
                                       np.asarray(dummy_final_embeds))
         self.mock_get_input_embed_fn.assert_called_once_with(
-            self.runner.state,
+            self.runner.state_leaves,
             dummy_input_ids,
             dummy_mm_embeds,
             is_multimodal=dummy_is_mm_embed)
@@ -256,14 +256,15 @@ class TestTPUJaxRunnerMultimodalModelLoadedForTextOnly:
             embed_input_ids_fn=None,
             get_mrope_input_positions_fn=None)
         return ModelInterface(
-            MagicMock(),  # TPUModelRunner.model_fn
-            MagicMock(),  # TPUModelRunner.compute_logits_fn
-            MagicMock(),  # TPUModelRunner.pooler_fn
-            MagicMock(),  # TPUModelRunner.combine_hidden_states_fn
-            mock_multimodal_fns,  # TPUModelRunner.multimodal_fns
-            MagicMock(),  # TPUModelRunner.state (model params)
-            None,  # TPUModelRunner.lora_manager
-            None,  # TPUModelRunner.model
+            model_fn=MagicMock(),
+            compute_logits_fn=MagicMock(),
+            pooler_fn=MagicMock(),
+            combine_hidden_states_fn=MagicMock(),
+            multimodal_fns=mock_multimodal_fns,
+            state=MagicMock(),
+            state_leaves=MagicMock(),
+            lora_manager=None,
+            model=None,
         )
 
     def test_is_multimodal_model(self):
@@ -301,14 +302,15 @@ class TestTPUJaxRunnerDisableMM:
             embed_input_ids_fn=MagicMock(),
             get_mrope_input_positions_fn=None)
         return ModelInterface(
-            MagicMock(),  # TPUModelRunner.model_fn
-            MagicMock(),  # TPUModelRunner.compute_logits_fn
-            MagicMock(),  # TPUModelRunner.pooler_fn
-            MagicMock(),  # TPUModelRunner.combine_hidden_states_fn
-            mock_multimodal_fns,  # TPUModelRunner.multimodal_fns
-            MagicMock(),  # TPUModelRunner.state (model params)
-            None,  # TPUModelRunner.lora_manager
-            None,  # TPUModelRunner.model
+            model_fn=MagicMock(),
+            compute_logits_fn=MagicMock(),
+            pooler_fn=MagicMock(),
+            combine_hidden_states_fn=MagicMock(),
+            multimodal_fns=mock_multimodal_fns,
+            state=MagicMock(),
+            state_leaves=MagicMock(),
+            lora_manager=None,
+            model=None,
         )
 
     @pytest.mark.parametrize(

--- a/tests/spec_decode/test_eagle3.py
+++ b/tests/spec_decode/test_eagle3.py
@@ -87,6 +87,7 @@ def test_prepare_inputs():
     # Mocks required by _prepare_draft_inputs helper
     proposer.combine_hidden_states_fn = lambda state, h: h  # Mock passthrough
     proposer.state = None  # Mock state
+    proposer.state_leaves = None  # Mock state leaves
     proposer.runner.input_batch.block_table = [mock.MagicMock()]
     # Mock the block table return value (2D array)
     (proposer.runner.input_batch.block_table[0].get_cpu_tensor.return_value
@@ -253,6 +254,7 @@ def test_propose(method, num_speculative_tokens):
     proposer.compute_logits_fn = mock_compute_logits_fn
     proposer.combine_hidden_states_fn = mock_combine_hidden_states_fn
     proposer.state = None  # Mock state
+    proposer.state_leaves = None  # Mock state leaves
 
     # Inputs
     kv_caches = [None] * 1  # Mock kv_caches

--- a/tpu_inference/models/common/interface.py
+++ b/tpu_inference/models/common/interface.py
@@ -5,6 +5,7 @@ from typing import Any, Callable, Dict, Protocol
 
 import jax
 import numpy as np
+from flax.nnx import GraphState
 from vllm.v1.outputs import PoolerOutput
 from vllm.v1.pool.metadata import PoolingMetadata
 
@@ -43,6 +44,14 @@ class ModelInterface:
     pooler_fn: Callable
     combine_hidden_states_fn: Callable
     multimodal_fns: MultiModalInterface
-    state: Dict
+    # For flax_nnx path, this is a `GraphState` containing the model's parameters and state.
+    # For the vllm-impl path, this is a dict containing the model's parameters
+    state: Dict | GraphState
+    # Pre-flattened leaves of `state` (a tuple of `jax.Array`s for the
+    # flax_nnx path, the same dict as `state` for the vllm-impl path). The
+    # dispatch-side fns (`model_fn`, `compute_logits_fn`, etc.) accept this
+    # form as their first positional arg so per-call jit dispatch skips the
+    # `nnx.Variable` pytree traversal.
+    state_leaves: Any
     lora_manager: Callable
     model: Any

--- a/tpu_inference/models/common/model_loader.py
+++ b/tpu_inference/models/common/model_loader.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import functools
 from typing import Any, Optional
 
 import jax
@@ -383,10 +382,11 @@ def get_flax_model(
             hidden_states_sharding,  # residual
             None,  # expert ids
         ),
-        donate_argnums=2,  # 0 is graphdef, 1 is state, 2 is kv_cache
-        static_argnums=(6, ),  # 6 is layer_name_to_kvcache_index
+        donate_argnums=1,  # 0 is state_leaves, 1 is kv_cache
+        static_argnums=(5, ),  # 5 is layer_name_to_kvcache_index
     )
-    def run_draft_model(graphdef, state, *args):
+    def run_draft_model(state_leaves, *args):
+        state = jax.tree_util.tree_unflatten(_state_treedef, state_leaves)
         model = nnx.merge(graphdef, state)
         return model(*args)
 
@@ -395,46 +395,47 @@ def get_flax_model(
         PartitionSpec(ShardingAxisName.MLP_DATA, ShardingAxisName.MLP_TENSOR))
 
     @jax.jit(out_shardings=(logits_sharding))
-    def run_compute_logits(graphdef, state, *args):
+    def run_compute_logits(state_leaves, *args):
+        state = jax.tree_util.tree_unflatten(_state_treedef, state_leaves)
         model = nnx.merge(graphdef, state)
         hidden_state, *_ = args
         return model.compute_logits(hidden_state)
 
     # Multi-modal support only
     # This function calculates the image token's embeddings by VIT
-    def run_embed_multimodal(graphdef, state, **kwargs):
+    def run_embed_multimodal(state_leaves, **kwargs):
+        state = jax.tree_util.tree_unflatten(_state_treedef, state_leaves)
         model = nnx.merge(graphdef, state)
         return model.embed_multimodal(**kwargs)
 
     embed_sharding = NamedSharding(mesh, PartitionSpec(None))
 
     @jax.jit(out_shardings=(embed_sharding))
-    def jitted_embed_input_ids(graphdef,
-                               state,
+    def jitted_embed_input_ids(state_leaves,
                                input_ids,
                                mm_embeds,
                                is_multimodal=None):
+        state = jax.tree_util.tree_unflatten(_state_treedef, state_leaves)
         model = nnx.merge(graphdef, state)
         return model.embed_input_ids(input_ids,
                                      mm_embeds,
                                      is_multimodal=is_multimodal)
 
-    def run_embed_input_ids(graphdef,
-                            state,
+    def run_embed_input_ids(state_leaves,
                             input_ids,
                             mm_embeds=None,
                             is_multimodal=None):
         mm_embeds = flatten_pad_mm_embeds(mm_embeds,
                                           target_pad_len=input_ids.shape[0])
-        return jitted_embed_input_ids(graphdef,
-                                      state,
+        return jitted_embed_input_ids(state_leaves,
                                       input_ids,
                                       mm_embeds,
                                       is_multimodal=is_multimodal)
 
     # For models that want to work with EAGLE-3 speculative decoding
     @jax.jit(out_shardings=(logits_sharding))
-    def combine_hidden_states(graphdef, state, hidden_states):
+    def combine_hidden_states(state_leaves, hidden_states):
+        state = jax.tree_util.tree_unflatten(_state_treedef, state_leaves)
         model = nnx.merge(graphdef, state)
         return model.combine_hidden_states(hidden_states)
 
@@ -460,8 +461,7 @@ def get_flax_model(
     embed_multimodal_fn = functools.partial(run_embed_multimodal, graphdef)
     embed_input_ids_fn = functools.partial(run_embed_input_ids, graphdef)
     lora_manager, model = None, None
-    combine_hidden_states_fn = functools.partial(combine_hidden_states,
-                                                 graphdef)
+    combine_hidden_states_fn = combine_hidden_states
 
     get_mrope_input_positions_fn = None if not hasattr(
         jit_model,
@@ -508,6 +508,8 @@ def get_flax_model(
     else:
         pooler_fn = _not_support
 
+    state_leaves = tuple(jax.tree_util.tree_leaves(state))
+
     return ModelInterface(
         model_fn=wrapped_model_fn,
         compute_logits_fn=compute_logits_fn,
@@ -515,6 +517,7 @@ def get_flax_model(
         combine_hidden_states_fn=combine_hidden_states_fn,
         multimodal_fns=multimodal_fns,
         state=state,
+        state_leaves=state_leaves,
         lora_manager=lora_manager,
         model=jit_model,
     )
@@ -560,6 +563,8 @@ def get_vllm_model(
     )
 
     # the model needs to be returned because lora weights are neither torch.nn.parameter nor torch.nn.buffer. After we load the lora weights and set it to the torch.nn.Module, we can shard it and move it to TPU.
+    # For the vllm-impl path the dispatch-side fns accept the params dict
+    # directly, so `state_leaves` is just the dict.
     return ModelInterface(
         model_fn=jit_model,
         compute_logits_fn=compute_logits_fn,
@@ -567,6 +572,7 @@ def get_vllm_model(
         combine_hidden_states_fn=combine_hidden_states_fn,
         multimodal_fns=multimodal_fns,
         state=params,
+        state_leaves=params,
         lora_manager=lora_manager,
         model=model,
     )

--- a/tpu_inference/models/common/model_loader.py
+++ b/tpu_inference/models/common/model_loader.py
@@ -442,12 +442,9 @@ def get_flax_model(
     model = nnx.merge(graphdef, state)
     precompile_vision_encoder_fn = getattr(model, "precompile_vision_encoder",
                                            None)
-    # For the draft path, graphdef is still passed positionally (signature
-    # unchanged). For the main path, graphdef and the state treedef are both
-    # captured in the run_model closure; the runner passes pre-flattened
-    # `state_leaves` as the first positional arg.
-    jitted_model_fn = functools.partial(
-        run_draft_model, graphdef) if is_draft_model else run_model
+    # `graphdef` and the state treedef are captured in each closure; the
+    # runner passes pre-flattened `state_leaves` as the first positional arg.
+    jitted_model_fn = run_draft_model if is_draft_model else run_model
 
     model_supports_spec_step = supports_kw(model_class.__call__,
                                            "spec_step_idx")
@@ -457,9 +454,9 @@ def get_flax_model(
             kwargs.pop("spec_step_idx", None)
         return jitted_model_fn(*args, **kwargs)
 
-    compute_logits_fn = functools.partial(run_compute_logits, graphdef)
-    embed_multimodal_fn = functools.partial(run_embed_multimodal, graphdef)
-    embed_input_ids_fn = functools.partial(run_embed_input_ids, graphdef)
+    compute_logits_fn = run_compute_logits
+    embed_multimodal_fn = run_embed_multimodal
+    embed_input_ids_fn = run_embed_input_ids
     lora_manager, model = None, None
     combine_hidden_states_fn = combine_hidden_states
 

--- a/tpu_inference/runner/compilation_manager.py
+++ b/tpu_inference/runner/compilation_manager.py
@@ -168,7 +168,7 @@ class CompilationManager:
             self._run_compilation(
                 "input_embeddings_merger",
                 self.runner.embed_input_ids_fn,
-                self.runner.state,
+                self.runner.state_leaves,
                 dummy_input_ids,
                 dummy_multimodal_embeddings,
                 call_kwargs={"is_multimodal": dummy_is_multimodal},
@@ -178,7 +178,7 @@ class CompilationManager:
             self._run_compilation(
                 "input_embeddings_merger_text_only",
                 self.runner.embed_input_ids_fn,
-                self.runner.state,
+                self.runner.state_leaves,
                 dummy_input_ids,
                 None,
                 call_kwargs={"is_multimodal": None},
@@ -268,7 +268,7 @@ class CompilationManager:
             }
 
         def model_fn_wrapper(
-            state,
+            state_leaves,
             kv_caches,
             input_ids,
             attention_metadata,
@@ -281,9 +281,10 @@ class CompilationManager:
             is_last_rank,
         ):
             kv_caches, hidden_states, *_ = self.runner.model_fn(
-                state, kv_caches, input_ids, attention_metadata, inputs_embeds,
-                positions, layer_name_to_kvcache_index, lora_metadata,
-                intermediate_tensors, is_first_rank, is_last_rank)
+                state_leaves, kv_caches, input_ids, attention_metadata,
+                inputs_embeds, positions, layer_name_to_kvcache_index,
+                lora_metadata, intermediate_tensors, is_first_rank,
+                is_last_rank)
             self.runner.kv_caches = kv_caches
             return hidden_states
 
@@ -643,7 +644,7 @@ class CompilationManager:
                 self._run_compilation(
                     f"worker{self.runner.rank} compute_logits",
                     self.runner.compute_logits_fn,
-                    self.runner.state,
+                    self.runner.state_leaves,
                     hidden_states,
                     lora_metadata,
                     num_reqs=num_reqs,

--- a/tpu_inference/runner/multimodal_manager.py
+++ b/tpu_inference/runner/multimodal_manager.py
@@ -119,7 +119,7 @@ class MultiModalManager:
             # (feature_size, hidden_size) in case the feature size is dynamic
             # depending on the input multimodal items.
             curr_group_outputs = self.runner.embed_multimodal_fn(
-                self.runner.state, **mm_kwargs_group)
+                self.runner.state_leaves, **mm_kwargs_group)
 
             sanity_check_mm_encoder_outputs(
                 curr_group_outputs,

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -651,14 +651,13 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         self.pooler_fn = model.pooler_fn
         self.combine_hidden_states_fn = model.combine_hidden_states_fn
         self.state = model.state
-        # For the flax_nnx path, `model_fn` (== `run_model`) accepts a flat
-        # tuple of array leaves and reconstructs the nnx.State inside the
-        # jit. Pre-flatten here so subsequent dispatches skip the per-call
-        # walk of `nnx.Variable` wrappers
-        if isinstance(self.state, nnx.State):
-            self.state_leaves = tuple(jax.tree_util.tree_leaves(self.state))
-        else:
-            self.state_leaves = self.state
+        # `state_leaves` is the pre-flattened form (a tuple of `jax.Array`s
+        # for the flax_nnx path, the same dict as `state` for vllm-impl).
+        # All dispatch-side fns (`model_fn`, `compute_logits_fn`,
+        # `embed_input_ids_fn`, …) take this as their first positional arg,
+        # which skips the per-call `nnx.Variable` pytree walk that otherwise
+        # costs ~17 ms/step on Gemma-4-31B decode at TP=2.
+        self.state_leaves = model.state_leaves
         self.lora_manager = model.lora_manager
         self.model = model.model
 
@@ -1035,7 +1034,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         hidden_states = self._select_from_array_fn(hidden_states,
                                                    logits_indices)
         logits = self.compute_logits_fn(
-            self.state,
+            self.state_leaves,
             hidden_states,
             lora_metadata,
         )
@@ -2000,7 +1999,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         if self.is_multimodal_model and mm_embeds is not None:
             assert self.embed_input_ids_fn is not None
             inputs_embeds = self.embed_input_ids_fn(
-                self.state,
+                self.state_leaves,
                 input_ids,
                 mm_embeds,
                 is_multimodal=is_mm_embed,

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -651,12 +651,10 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         self.pooler_fn = model.pooler_fn
         self.combine_hidden_states_fn = model.combine_hidden_states_fn
         self.state = model.state
-        # `state_leaves` is the pre-flattened form (a tuple of `jax.Array`s
-        # for the flax_nnx path, the same dict as `state` for vllm-impl).
-        # All dispatch-side fns (`model_fn`, `compute_logits_fn`,
-        # `embed_input_ids_fn`, …) take this as their first positional arg,
-        # which skips the per-call `nnx.Variable` pytree walk that otherwise
-        # costs ~17 ms/step on Gemma-4-31B decode at TP=2.
+        # For the flax_nnx path, `model_fn` (== `run_model`) accepts a flat
+        # tuple of array leaves and reconstructs the nnx.State inside the
+        # jit. Pre-flatten here so subsequent dispatches skip the per-call
+        # walk of `nnx.Variable` wrappers
         self.state_leaves = model.state_leaves
         self.lora_manager = model.lora_manager
         self.model = model.model

--- a/tpu_inference/spec_decode/jax/eagle3.py
+++ b/tpu_inference/spec_decode/jax/eagle3.py
@@ -226,7 +226,7 @@ class Eagle3Proposer:
         else:
             target_hidden_states = jnp.concatenate(aux_hidden_states, axis=-1)
             target_hidden_states = self.combine_hidden_states_fn(
-                state, target_hidden_states)
+                state_leaves, target_hidden_states)
 
         input_ids, last_token_indices = self._prepare_input_ids(
             query_start_loc, target_token_ids, next_token_ids, num_reqs)
@@ -398,8 +398,8 @@ class Eagle3Proposer:
         aux_states_processed = [h[token_indices] for h in aux_hidden_states]
 
         target_hidden_states, input_ids, last_token_indices = self._prepare_hidden_states_and_input_ids(
-            state, aux_states_processed, query_start_loc, target_token_ids,
-            next_token_ids, num_reqs)
+            state_leaves, aux_states_processed, query_start_loc,
+            target_token_ids, next_token_ids, num_reqs)
 
         return target_hidden_states, input_ids, last_token_indices, attn_metadata
 
@@ -428,8 +428,6 @@ class Eagle3Proposer:
             self, state_leaves: Any, positions: jax.Array, residual: jax.Array,
             hidden_states: jax.Array,
             last_token_indices: jax.Array) -> tuple[jax.Array, jax.Array]:
-        positions = positions[last_token_indices]
-        residual = residual[last_token_indices]
         draft_token_ids = self._select_draft_token_ids(state_leaves,
                                                        hidden_states,
                                                        last_token_indices)

--- a/tpu_inference/spec_decode/jax/eagle3.py
+++ b/tpu_inference/spec_decode/jax/eagle3.py
@@ -90,6 +90,7 @@ class Eagle3Proposer:
         self.pooler_fn = model.pooler_fn
         self.combine_hidden_states_fn = model.combine_hidden_states_fn
         self.state = model.state
+        self.state_leaves = model.state_leaves
         self.model = model.model
 
         draft_model_impl = envs.DRAFT_MODEL_IMPL_TYPE
@@ -124,6 +125,13 @@ class Eagle3Proposer:
                 self.state.model.embed_tokens = target_model.model.embed
             else:
                 logger.info("Draft model has its own embed_tokens.")
+
+        # The embed_tokens assignment above may have mutated `self.state`;
+        # re-derive `state_leaves` so the dispatch-side view matches.
+        if isinstance(self.state, nnx.State):
+            self.state_leaves = tuple(jax.tree_util.tree_leaves(self.state))
+        else:
+            self.state_leaves = self.state
 
     def _prepare_input_ids(
             self, query_start_loc: jax.Array, target_token_ids: jax.Array,
@@ -206,7 +214,7 @@ class Eagle3Proposer:
 
     def _prepare_hidden_states_and_input_ids(
         self,
-        state: nnx.State,
+        state_leaves: Any,
         aux_hidden_states: tuple[jax.Array, ...],
         query_start_loc: jax.Array,
         target_token_ids: jax.Array,
@@ -262,7 +270,7 @@ class Eagle3Proposer:
         num_reqs, block_tables = device_array(
             self.mesh, (np.asarray([num_reqs], dtype=jnp.int32), block_tables))
         return self._prepare_inputs(
-            state=self.state,
+            state_leaves=self.state_leaves,
             num_reqs=num_reqs,
             block_tables=block_tables,
             attn_metadata=attn_metadata,
@@ -276,7 +284,7 @@ class Eagle3Proposer:
     @jax.jit(static_argnums=(0, ))
     def _prepare_inputs(
         self,
-        state: nnx.State,
+        state_leaves: Any,
         num_reqs: jax.Array,
         block_tables: jax.Array,
         attn_metadata: AttentionMetadata,
@@ -352,12 +360,13 @@ class Eagle3Proposer:
 
         attn_metadata = replace(attn_metadata, block_tables=block_tables)
         return self._filter_token_and_prepare_initial_inputs(
-            state, token_indices, new_query_start_loc, new_seq_lens, input_ids,
-            aux_hidden_states, attn_metadata, next_token_ids, num_reqs)
+            state_leaves, token_indices, new_query_start_loc, new_seq_lens,
+            input_ids, aux_hidden_states, attn_metadata, next_token_ids,
+            num_reqs)
 
     def _filter_token_and_prepare_initial_inputs(
         self,
-        state: nnx.State,
+        state_leaves: Any,
         token_indices: jax.Array,
         query_start_loc: jax.Array,
         seq_lens: jax.Array,
@@ -396,7 +405,7 @@ class Eagle3Proposer:
 
     def _select_draft_token_ids(
         self,
-        state: nnx.State,
+        state_leaves: Any,
         hidden_states: jax.Array,
         last_token_indices: jax.Array,
     ) -> jax.Array:
@@ -404,21 +413,25 @@ class Eagle3Proposer:
         sample_hidden_states = lax.with_sharding_constraint(
             sample_hidden_states,
             NamedSharding(self.mesh, PartitionSpec(None, None)))
-        return self._get_draft_token_ids(state, sample_hidden_states)
+        return self._get_draft_token_ids(state_leaves, sample_hidden_states)
 
-    def _get_draft_token_ids(self, state: nnx.State,
+    def _get_draft_token_ids(self, state_leaves: Any,
                              hidden_states: jax.Array) -> jax.Array:
         lora_metadata = None
-        logits = self.compute_logits_fn(state, hidden_states, lora_metadata)
+        logits = self.compute_logits_fn(state_leaves, hidden_states,
+                                        lora_metadata)
         draft_token_ids = jnp.argmax(logits, axis=-1)
         return lax.with_sharding_constraint(
             draft_token_ids, NamedSharding(self.mesh, PartitionSpec()))
 
     def _select_inputs_for_loop_speculation(
-            self, state: nnx.State, positions: jax.Array, residual: jax.Array,
+            self, state_leaves: Any, positions: jax.Array, residual: jax.Array,
             hidden_states: jax.Array,
             last_token_indices: jax.Array) -> tuple[jax.Array, jax.Array]:
-        draft_token_ids = self._select_draft_token_ids(state, hidden_states,
+        positions = positions[last_token_indices]
+        residual = residual[last_token_indices]
+        draft_token_ids = self._select_draft_token_ids(state_leaves,
+                                                       hidden_states,
                                                        last_token_indices)
         if self.method == "mtp":
             # We need a separate branch for MTP because:
@@ -451,7 +464,7 @@ class Eagle3Proposer:
         target_hidden_states,
     ) -> tuple[list[jax.Array], jnp.ndarray]:
         return self._propose(
-            state=self.state,
+            state_leaves=self.state_leaves,
             kv_caches=kv_caches,
             input_ids=input_ids,
             attn_metadata=attn_metadata,
@@ -481,7 +494,7 @@ class Eagle3Proposer:
     )
     def _propose(
         self,
-        state: nnx.State,
+        state_leaves: Any,
         kv_caches: list[jax.Array],
         input_ids: jax.Array,
         attn_metadata: AttentionMetadata,
@@ -497,7 +510,7 @@ class Eagle3Proposer:
         """
 
         kv_caches, hidden_states, residual, _ = self.model_fn(
-            state,
+            state_leaves,
             kv_caches,
             input_ids,
             target_hidden_states,
@@ -508,11 +521,12 @@ class Eagle3Proposer:
 
         if num_speculative_tokens == 1:
             return kv_caches, self._select_draft_token_ids(
-                state, hidden_states, last_token_indices)
+                state_leaves, hidden_states, last_token_indices)
 
         positions, hidden_states, draft_token_ids = self._select_inputs_for_loop_speculation(
-            state, attn_metadata.input_positions, residual[0], hidden_states,
-            last_token_indices)
+            state_leaves, attn_metadata.input_positions, residual[0],
+            hidden_states, last_token_indices)
+
         draft_token_ids_list = [draft_token_ids]
 
         for i in range(num_speculative_tokens - 1):
@@ -529,7 +543,7 @@ class Eagle3Proposer:
                 block_tables=new_block_tables,
             )
             kv_caches, new_hidden_states, residual, _ = self.model_fn(
-                state,
+                state_leaves,
                 kv_caches,
                 input_ids_loop,
                 hidden_states,
@@ -540,7 +554,7 @@ class Eagle3Proposer:
             hidden_states = new_hidden_states if self.method == "mtp" else residual[
                 0]
             draft_token_ids = self._get_draft_token_ids(
-                state, new_hidden_states)
+                state_leaves, new_hidden_states)
             draft_token_ids_list.append(draft_token_ids)
 
         # [batch_size, num_speculative_tokens]


### PR DESCRIPTION
FIXED #2607 

## Summary

Follow-up to #2615 — applies the same closure-captured-treedef +
flat-tuple pre-flatten pattern to the remaining state-receiving
dispatch fns on the flax_nnx path:

- `run_compute_logits`
- `jitted_embed_input_ids` / `run_embed_input_ids`
- `combine_hidden_states`
- `run_embed_multimodal`
- `run_draft_model`

All five now accept a `state_leaves` flat tuple of `jax.Array` (the
same form #2615 introduced for `model_fn`) and reconstruct
`nnx.State` via a closure-captured treedef inside the jit, so per-call
dispatch skips the `nnx.Variable` pytree walk for these paths too.

## Plumbing

- `ModelInterface` exposes `state_leaves` (populated by both
  `get_flax_model` and `get_vllm_model`).
- `TPUModelRunner` uses `model.state_leaves` directly; the LoRA-reload
  re-flatten path is preserved.
- `CompilationManager` precompile sites for `input_embeddings_merger`,
  `input_embeddings_merger_text_only`, and `compute_logits` pass
  `runner.state_leaves`.
- `MultiModalManager.embed_multimodal_fn` is fed `state_leaves`.
- `Eagle3Proposer` carries its own `self.state_leaves` (re-derived
  after the load-time `embed_tokens` mutation) and threads it through
  the jit-call boundaries (`_propose`, `_prepare_inputs`, the various
  `_*_draft_token_ids` helpers).

## Throughput delta — flax_nnx, vs #2615

Same setup as #2615 (TPU v7x, TP=2, fp8 KV cache, qwix fp8 weight
quant). Δ columns are vs the §5a numbers measured in #2615.

| Workload | Metric | Gemma-4-31B-it | Δ vs #2615 | Qwen3-32B | Δ vs #2615 |
|---|---|---:|---:|---:|---:|
| **MMMU-Pro** (1730 req, conc=32) | req/s | **1.56** | **+14%** (1.37) | — | — |
|  | total tok/s | **2188** | **+17%** (1866) | — | — |
|  | accuracy | 0.7104 | +0.4pt (0.7064) | — | — |
| **MMLU** (14042 req) | total tok/s | 21498 | −0.2% (21535) | 22633 | −0.1% (22666) |
|  | accuracy | 0.8458 | −0.1pt (0.8465) | 0.8127 | +0.1pt (0.812) |
| **Image only** (320 req, 512×512 → 1 out) | total tok/s | 5527 | +0.1% (5523) | — | — |
|  | mean TTFT (ms) | 9864 | −1.7% (10038) | — | — |
| **Prefill only** (320 req, 1024→1) | total tok/s | 22240 | −0.8% (22420) | 23855 | +0.0% (23847) |
| **Decode only** (320 req, 1→1024) | output tok/s | **6864** | **+18%** (5810) | **8643** | **+5%** (8230) |
|  | mean TPOT (ms) | **25.28** | **−12.5%** (28.90) | **20.54** | **−1.7%** (20.90) |

Headline: another **+18% / −12.5% TPOT** on Gemma flax_nnx decode on
top of #2615 (the residual ~3.9 ms that the issue draft predicted from
`step.compute_logits`). MMLU/prefill/image are within ±1% as expected —
the fix is host-side dispatch and doesn't touch the compute path.

Cumulative vs the pre-#2615 baseline: Gemma flax_nnx decode goes from
3248 tok/s / 50.10 ms to **6864 tok/s / 25.28 ms** (**+111%** throughput,
**−50%** TPOT).

## Test plan
- [x] Decode-only (1 in → 1024 out, batch 320) — Gemma-4-31B-it + Qwen3-32B, 320/320 success
- [x] Prefill-only (1024 in → 1 out) — Gemma + Qwen3, 320/320 success
- [x] MMLU (14042 req) — Gemma + Qwen3, accuracy unchanged
- [x] MMMU-Pro (1730 req, conc=32) — Gemma, accuracy 0.7104 (≈ #2615's 0.7064)
- [x] Image-only (0 txt + 512×512 → 1 out) — Gemma, 320/320 success