### PR TITLE
Cherry-pick: Update installation to specify --no-build-isolation (#2624)

### DIFF
--- a/docs/getting_started/installation.md
+++ b/docs/getting_started/installation.md
@@ -87,7 +87,7 @@ For debugging or development purposes, you can install `tpu-inference` from sour
     ```shell
     cd vllm
     uv pip install -r requirements/tpu.txt --torch-backend=cpu
-    VLLM_TARGET_DEVICE="tpu" uv pip install -e .
+    VLLM_TARGET_DEVICE="tpu" uv pip install -e . --no-build-isolation
     cd ..
     ```
 


### PR DESCRIPTION
# Description

Cherry-pick [#2624](https://github.com/vllm-project/tpu-inference/pull/2624)
