### PR TITLE
Remove forcing --disable-chunked-mm-input for multimodal model

### DIFF
--- a/tests/platforms/test_tpu_platform.py
+++ b/tests/platforms/test_tpu_platform.py
@@ -180,7 +180,7 @@ class TestTpuPlatform:
         assert vllm_config.compilation_config.mode == CompilationMode.DYNAMO_TRACE_ONCE
         assert vllm_config.compilation_config.backend == "openxla"
         assert vllm_config.parallel_config.distributed_executor_backend == "uni"
-        assert vllm_config.scheduler_config.disable_chunked_mm_input is True
+        assert vllm_config.scheduler_config.disable_chunked_mm_input is False
 
         mock_sharding.from_vllm_config.assert_called_once_with(vllm_config)
         assert vllm_config.sharding_config == mock_sharding.from_vllm_config.return_value

--- a/tpu_inference/platforms/tpu_platform.py
+++ b/tpu_inference/platforms/tpu_platform.py
@@ -287,10 +287,12 @@ class TpuPlatform(Platform):
 
         if scheduler_config.is_multimodal_model and not \
             scheduler_config.disable_chunked_mm_input:
-            logger.warning("TPU does not support running Multimodal models"
-                           " without setting `--disable_chunked_mm_input`. "
-                           "Forcing --disable_chunked_mm_input.")
-            scheduler_config.disable_chunked_mm_input = True
+            logger.warning(
+                "TPU does not support running Multimodal models"
+                " without setting `--disable_chunked_mm_input`. "
+                "If you are serving a multimodal model, please explicitly add the "
+                "`--disable-chunked-mm-input` flag to your server command to avoid execution failures."
+            )
 
         kv_transfer_config = vllm_config.kv_transfer_config
         if kv_transfer_config is not None:


### PR DESCRIPTION
Remove the logic to force enabling the --disable-chunked-mm-input for multimodal model. Instead, user will see the warning message and can adding the server argument manually.