### PR TITLE
Remove bf16 Mamba Env

### DIFF
--- a/tpu_inference/envs.py
+++ b/tpu_inference/envs.py
@@ -43,7 +43,6 @@ if TYPE_CHECKING:
     REGISTER_MM_MODULE_CUSTOM_PYTREE_CLASSES: list[str] = []
     RAGGED_GATED_DELTA_RULE_IMPL: str = "chunked_jax_pd"
     MOE_ALL_GATHER_ACTIVATION_DTYPE: str = ""
-    TPU_MAMBA_SSM_CACHE_DTYPE: str = "bfloat16"
     TPU_OFFLOAD_SKIP_JAX_PRECOMPILE: bool = False
     TPU_OFFLOAD_DECODE_SAVE: bool = False
     TPU_OFFLOAD_NUM_CPU_CHUNKS: int = 1024
@@ -306,12 +305,6 @@ environment_variables: dict[str, Callable[[], Any]] = {
     ]),
     "MOE_ALL_GATHER_ACTIVATION_DTYPE":
     lambda: os.getenv("MOE_ALL_GATHER_ACTIVATION_DTYPE", ""),
-    # Override cache_config.mamba_ssm_cache_dtype on TPU. Default "bfloat16"
-    # halves SSM state HBM; set "float32" to opt out, "" to defer to vLLM.
-    # TODO: remove once vLLM MambaDType includes bfloat16
-    # (https://github.com/vllm-project/vllm/pull/41680).
-    "TPU_MAMBA_SSM_CACHE_DTYPE":
-    lambda: os.getenv("TPU_MAMBA_SSM_CACHE_DTYPE", "bfloat16"),
     # kv offload to dram: skip pre-compiling swap-related jax functions
     "TPU_OFFLOAD_SKIP_JAX_PRECOMPILE":
     lambda: bool(int(os.getenv("TPU_OFFLOAD_SKIP_JAX_PRECOMPILE", "0"))),

--- a/tpu_inference/platforms/tpu_platform.py
+++ b/tpu_inference/platforms/tpu_platform.py
@@ -246,16 +246,6 @@ class TpuPlatform(Platform):
             if envs.USE_BATCHED_RPA_KERNEL and cache_config.block_size < 256:
                 cache_config.block_size = 256
 
-        if cache_config and envs.TPU_MAMBA_SSM_CACHE_DTYPE:
-            override = envs.TPU_MAMBA_SSM_CACHE_DTYPE
-            current = cache_config.mamba_ssm_cache_dtype
-            if current != override:
-                logger.info(
-                    "TPU_MAMBA_SSM_CACHE_DTYPE=%s overriding "
-                    "cache_config.mamba_ssm_cache_dtype (was %r)", override,
-                    current)
-                cache_config.mamba_ssm_cache_dtype = override
-
         parallel_config = vllm_config.parallel_config
         scheduler_config = vllm_config.scheduler_config
         parallel_config.worker_cls = \


### PR DESCRIPTION
# Description

As https://github.com/vllm-project/vllm/pull/41680 has landed, we can simply specify mamba cache as bf16 using `--mamba-cache-dtype=bfloat16`

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
