### PR TITLE
platform: override use_custom_op_collectives() to True

### DIFF
--- a/tpu_inference/platforms/tpu_platform.py
+++ b/tpu_inference/platforms/tpu_platform.py
@@ -113,6 +113,16 @@ class TpuPlatform(Platform):
     ]
 
     @classmethod
+    def use_custom_op_collectives(cls) -> bool:
+        # Opt in to `torch.ops.vllm.all_reduce/all_gather` custom collective
+        # ops. This is the override referenced by the TODO in vLLM's
+        # `vllm/distributed/parallel_state.py` at the
+        # `self.use_custom_op_call = current_platform.is_tpu() or ...`
+        # line -- once landed, the `is_tpu()` short-circuit there can be
+        # removed (vllm-project/vllm#35915).
+        return True
+
+    @classmethod
     def get_attn_backend_cls(cls, selected_backend: "AttentionBackendEnum",
                              attn_selector_config: "AttentionSelectorConfig",
                              **kwargs) -> str:


### PR DESCRIPTION
## Summary

Adds an `use_custom_op_collectives()` override on `TpuPlatform` returning `True`, so vLLM's hardcoded `is_tpu()` short-circuit in `vllm/distributed/parallel_state.py` can be removed.

vLLM today computes:
```python
# TODO(#35915): Remove is_tpu() check once tpu_inference
# overrides use_custom_op_collectives() to return True.
self.use_custom_op_call = (
    current_platform.is_tpu() or current_platform.use_custom_op_collectives()
)
```

Adding this override unblocks the upstream cleanup. Today's behavior is unchanged for this repo (we were already getting `use_custom_op_call = True` via the `is_tpu()` branch); after the upstream cleanup lands, we'll go through the override path.

Refs: https://github.com/vllm-project/vllm/issues/35915

## Test plan

- No behavior change in this PR; existing tests continue to pass.
- Validates with the matching upstream-vLLM cleanup (drop `is_tpu()` from the OR) which will be filed separately and should land after this.