### PR TITLE
[releases/v0.21.0][Gemma4][MoE] Fix accuracy regression under jax 0.10 without reverting jax

### DIFF
--- a/tpu_inference/layers/common/process_weights/moe_weights.py
+++ b/tpu_inference/layers/common/process_weights/moe_weights.py
@@ -15,7 +15,7 @@ from dataclasses import dataclass, fields
 
 import jax
 import jax.numpy as jnp
-from jax.experimental.layout import Layout, with_layout_constraint
+from jax.experimental.layout import Layout
 from jax.sharding import Mesh, NamedSharding, PartitionSpec
 from torchax.tensor import Tensor
 from vllm.model_executor.layers.fused_moe.activation import MoEActivation
@@ -322,9 +322,13 @@ def process_moe_weights(
     w13_weight = jnp.swapaxes(w13_weight, 1, 2)
     w2_weight = jnp.swapaxes(w2_weight, 1, 2)
 
-    # Workaround for JAX error "must have valid byte strides"
-    w13_weight = with_layout_constraint(w13_weight, Layout((0, 1, 2)))
-    w2_weight = with_layout_constraint(w2_weight, Layout((0, 1, 2)))
+    # `with_layout_constraint` here was a jax-0.9.2 workaround for a "must have
+    # valid byte strides" error. On jax 0.10 (commit 83ac59f16 / d1eb0fb07),
+    # `layout_constraint_p` is now read by `get_out_layouts_via_propagation` and
+    # actually pins the requested layout — which is the WRONG layout for the
+    # MoE kernel's weight reads and silently miscomputes (gemma-4-26B-A4B
+    # accuracy → 0). Removed; the natural C-order layout is what the kernel
+    # expects on jax 0.10.
 
     if w13_weight_scale is not None:
         # For block scales (experts, out_blocks, in_blocks), we need to maintain
@@ -373,8 +377,6 @@ def process_moe_weights(
                 intermediate_size,
             )
             w13_weight = jnp.swapaxes(w13_weight, 1, 2)
-            w13_weight = with_layout_constraint(w13_weight, Layout(
-                (0, 1, 2, 3)))
 
             # Fused moe kernel expects dims to be multiple of 256.
             pad_width_intermediate_size = (align_to(intermediate_size, 256) -

--- a/tpu_inference/layers/common/process_weights/moe_weights.py
+++ b/tpu_inference/layers/common/process_weights/moe_weights.py
@@ -322,14 +322,6 @@ def process_moe_weights(
     w13_weight = jnp.swapaxes(w13_weight, 1, 2)
     w2_weight = jnp.swapaxes(w2_weight, 1, 2)
 
-    # `with_layout_constraint` here was a jax-0.9.2 workaround for a "must have
-    # valid byte strides" error. On jax 0.10 (commit 83ac59f16 / d1eb0fb07),
-    # `layout_constraint_p` is now read by `get_out_layouts_via_propagation` and
-    # actually pins the requested layout — which is the WRONG layout for the
-    # MoE kernel's weight reads and silently miscomputes (gemma-4-26B-A4B
-    # accuracy → 0). Removed; the natural C-order layout is what the kernel
-    # expects on jax 0.10.
-
     if w13_weight_scale is not None:
         # For block scales (experts, out_blocks, in_blocks), we need to maintain
         # the block dims


### PR DESCRIPTION
## Summary

- Removes three `with_layout_constraint(...)` calls in `process_moe_weights` that were a jax-0.9.x workaround for a "must have valid byte strides" error. On jax 0.10 those calls now silently miscompute and cause gemma-4-26B-A4B-it GSM8K accuracy to drop from 0.41 → 0.0 (see [build 17856](https://buildkite.com/tpu-commons/tpu-inference-ci/builds/17856#019e2f96-31cd-4d78-b917-3aeb6fb22fc6/L579)).
- Fix is in tpu-inference only — **no jax revert required**, supersedes PR #2655 if this lands.

## Root cause

The jax-0.10 release added `layout_constraint_p` to `get_out_layouts_via_propagation` in `jax/_src/interpreters/pxla.py` (re-landed by Yash Katariya's commit `83ac59f16` after `04c2d9147` had reverted the earlier `d1eb0fb07`). Under jax 0.9.x the `with_layout_constraint(weight, Layout((0, 1, 2)))` calls were effectively no-ops for layout propagation; under jax 0.10 the requested layout is actually pinned on the jit output, and that layout doesn't match what the MoE GMM/fused-MoE kernels expect when reading the weights — so weight bytes are reinterpreted incorrectly at every layer and tokens come out garbled.

Identified by bisecting jax between v0.9.2 and v0.10.0, then adding `raise AssertionError` in the new `elif eqn.primitive is pjit.layout_constraint_p:` branch and re-running the model with `JAX_TRACEBACK_FILTERING=off`. The traceback pointed straight at the call sites in `process_moe_weights`.

## The change

Three call sites removed (and the `with_layout_constraint` import dropped). The MoE kernel paths now use the auto-layout pass's natural C-order, which is what they actually want on jax 0.10. All quantization variants (`UNQUANTIZED`, `FUSED_MOE`, `MXFP4`, `NVFP4`, `AWQ`, `compressed_tensors_moe_w4a8`) route through `process_moe_weights`, so they all pick up the fix.

## Test plan

- [x] Local repro on tpu7x-8, gemma-4-26B-A4B-it with the exact failing command (`USE_BATCHED_RPA_KERNEL=1`, fp8 KV, tp=2, etc.). Before this change: `'-idhedral, actually-to-redage'` garbage. After: `'4'` for `2+2`, `'7 times 8 is **56**.'`, coherent haiku.
- [ ] Re-run nightly `tpu-inference-ci` gemma-4-26B-A4B-it accuracy job — expected back at ≥ 0.41 (was 0.0 on #17856, passed on the jax-revert build #17868).
- [ ] Spot-check other MoE quantization paths (mxfp4, nvfp4) on dev pipeline since they share `process_moe_weights`.