### PR TITLE
Support bucketized req size with Attention DP

### DIFF
--- a/tests/layers/common/test_utils.py
+++ b/tests/layers/common/test_utils.py
@@ -23,7 +23,8 @@ from jax.sharding import Mesh, NamedSharding
 from jax.sharding import PartitionSpec as P
 
 from tpu_inference import envs
-from tpu_inference.layers.common.utils import general_device_put
+from tpu_inference.layers.common.utils import (general_device_put,
+                                               truncate_sharded_tensor)
 
 
 class UtilsTest(jtu.JaxTestCase):
@@ -93,6 +94,20 @@ class UtilsTest(jtu.JaxTestCase):
                 self.assertEqual(mock_make_array.call_count, 2)
                 self.assertIsInstance(result, list)
                 self.assertEqual(len(result), 2)
+
+    def test_truncate_sharded_tensor(self):
+        # Shape: (2, 20), n_shards=4, so each shard has size 5 on the last dim
+        t = jnp.arange(40).reshape(2, 20)
+        n_shards = 4
+        truncate_size = 3
+
+        result = truncate_sharded_tensor(t, truncate_size, n_shards)
+
+        # Expected: reshape to (2, 4, 5), truncate to (2, 4, 3), reshape to (2, 12)
+        expected = t.reshape(2, 4, 5)[:, :, :truncate_size].reshape(2, 12)
+
+        self.assertEqual(result.shape, (2, 12))
+        self.assertAllClose(result, expected)
 
 
 if __name__ == "__main__":

--- a/tpu_inference/layers/common/utils.py
+++ b/tpu_inference/layers/common/utils.py
@@ -103,6 +103,28 @@ def slice_sharded_tensor_for_concatenation(sharded_tensor: jax.Array,
     return split_tensors
 
 
+def truncate_sharded_tensor(sharded_tensor: jax.Array, truncate_size: int,
+                            n_shards: int):
+    """
+    Truncate each shard of a sharded tensor to a specified size.
+    For example, let the sharded_tensor be:
+        AAAAA | BBBBB | CCCCC | DDDDD
+        Shard0   Shard1   Shard2   Shard3
+    and let truncate_size = 3 and n_shards = 4.
+    The output is:
+         AAA   |  BBB   |  CCC   |  DDD
+        Shard0   Shard1   Shard2   Shard3
+    Args:
+        sharded_tensor: the input tensor, sharded on the last dim.
+        truncate_size: the new size of each shard on the last dim.
+        n_shards: num of shards.
+    """
+    new_shape = sharded_tensor.shape[:-1] + (n_shards, -1)
+    sharded_tensor = sharded_tensor.reshape(new_shape)
+    truncated_tensor = sharded_tensor[..., :truncate_size]
+    return truncated_tensor.reshape(sharded_tensor.shape[:-2] + (-1, ))
+
+
 def general_device_put(tensor: jax.Array,
                        sharding: Sharding,
                        *,

--- a/tpu_inference/layers/vllm/custom_ops/gdn_attention_op.py
+++ b/tpu_inference/layers/vllm/custom_ops/gdn_attention_op.py
@@ -29,8 +29,8 @@ from tpu_inference.layers.common.gdn_attention import (GdnAttentionConfig,
 from tpu_inference.layers.common.ragged_gated_delta_rule_wrapper import \
     RaggedGatedDeltaRuleImpl
 from tpu_inference.layers.common.sharding import ShardingAxisName
-from tpu_inference.layers.common.utils import \
-    reorder_concatenated_tensor_for_sharding
+from tpu_inference.layers.common.utils import (
+    reorder_concatenated_tensor_for_sharding, truncate_sharded_tensor)
 from tpu_inference.logger import init_logger
 from tpu_inference.models.vllm.vllm_model_wrapper_context import \
     get_vllm_model_wrapper_context
@@ -125,14 +125,17 @@ def gdn_attention_core_tpu(
             envs.RAGGED_GATED_DELTA_RULE_IMPL))
     logger.info_once(f"GDN Attention Config: {config}")
 
-    padded_num_reqs = attn_metadata.padded_num_reqs
+    padded_num_reqs_per_dp = attn_metadata.padded_num_reqs // dp_size
 
     # Slice the state indices to the padded_num_reqs, which is the actual number
     # of requests padded to the bucket.
-    state_indices_sliced = state_indices[:padded_num_reqs]
-    query_start_loc_sliced = attn_metadata.query_start_loc[:padded_num_reqs +
-                                                           dp_size]
-    seq_lens_sliced = attn_metadata.seq_lens[:padded_num_reqs]
+    state_indices_sliced = truncate_sharded_tensor(state_indices,
+                                                   padded_num_reqs_per_dp,
+                                                   dp_size)
+    query_start_loc_sliced = truncate_sharded_tensor(
+        attn_metadata.query_start_loc, padded_num_reqs_per_dp + 1, dp_size)
+    seq_lens_sliced = truncate_sharded_tensor(attn_metadata.seq_lens,
+                                              padded_num_reqs_per_dp, dp_size)
 
     (new_conv_state_extracted,
      new_recurrent_state), j_output = run_jax_gdn_attention(

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -565,8 +565,14 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         # the max_reqs. If ATTN_BUCKETIZE_NUM_REQS=true, it is the
         # power-of-two between min and max reqs.
         # User can set ATTN_CUSTOM_NUM_REQS_BUCKETS to provide custom buckets.
-        self.attn_num_reqs_paddings = runner_utils.get_attn_req_paddings(
-            min_req_size=min_num_reqs, max_req_size=self.max_num_reqs)
+        self.attn_num_reqs_paddings_per_dp = runner_utils.get_attn_req_paddings(
+            min_req_size=MIN_NUM_SEQS,
+            max_req_size=scheduler_config.max_num_seqs)
+        self.attn_num_reqs_paddings = [
+            padding * self.dp_size
+            for padding in self.attn_num_reqs_paddings_per_dp
+        ]
+
         self.num_reqs_paddings_per_dp = [
             padding // self.dp_size for padding in self.num_reqs_paddings
         ]
@@ -1406,7 +1412,8 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             self.num_reqs_paddings_per_dp, max_num_reqs_across_dp)
         padded_num_reqs = padded_num_reqs_per_dp_rank * dp_size
         attn_padded_num_reqs = runner_utils.get_padded_token_len(
-            self.attn_num_reqs_paddings, padded_num_reqs)
+            self.attn_num_reqs_paddings_per_dp,
+            max_num_reqs_across_dp) * dp_size
 
         # logits_indices_selector reorders per-rank outputs back to the
         # original batch ordering; with a single rank the ordering is already

--- a/tpu_inference/runner/utils.py
+++ b/tpu_inference/runner/utils.py
@@ -132,7 +132,7 @@ def get_padded_token_len(paddings: list[int], x: int) -> int:
     """Return the first element in paddings list greater or equal to x.
     """
     index = bisect.bisect_left(paddings, x)
-    assert index < len(paddings)
+    assert index < len(paddings), f"{paddings=}, {x=}"
     return paddings[index]
 
 


### PR DESCRIPTION
# Description
With attention DP, the metadata tensors are sharded on ATTN_DATA axis and slicing the tensor needs to slice each shard first and then combine (No collective involved). This PR add util to slice sharded tensor and use it in linear attn metadata.

# Tests

Tested quality of different request size 10  / 16/ 60 / 64 / 500 / 555 with bucket 32, 64, 256, 512 and quality is on par with bucket size.

```
|       Tasks       |Version|    Filter    |n-shot|  Metric   |   |Value |   |Stderr|
|-------------------|------:|--------------|-----:|-----------|---|-----:|---|-----:|
|mmlu_pro           |    2.0|custom-extract|     5|exact_match|↑  |0.8214|±  |0.0141|
| - biology         |    3.1|custom-extract|     5|exact_match|↑  |0.9400|±  |0.0339|
| - business        |    3.1|custom-extract|     5|exact_match|↑  |0.8800|±  |0.0464|
| - chemistry       |    3.1|custom-extract|     5|exact_match|↑  |0.9000|±  |0.0429|
| - computer_science|    3.1|custom-extract|     5|exact_match|↑  |0.8400|±  |0.0524|
| - economics       |    3.1|custom-extract|     5|exact_match|↑  |0.8800|±  |0.0464|
| - engineering     |    3.1|custom-extract|     5|exact_match|↑  |0.6600|±  |0.0677|
| - health          |    3.1|custom-extract|     5|exact_match|↑  |0.7800|±  |0.0592|
| - history         |    3.1|custom-extract|     5|exact_match|↑  |0.7000|±  |0.0655|
| - law             |    3.1|custom-extract|     5|exact_match|↑  |0.7000|±  |0.0655|
| - math            |    3.1|custom-extract|     5|exact_match|↑  |0.9600|±  |0.0280|
| - other           |    3.1|custom-extract|     5|exact_match|↑  |0.7200|±  |0.0641|
| - philosophy      |    3.1|custom-extract|     5|exact_match|↑  |0.8400|±  |0.0524|
| - physics         |    3.1|custom-extract|     5|exact_match|↑  |0.9600|±  |0.0280|
| - psychology      |    3.1|custom-extract|     5|exact_match|↑  |0.7400|±  |0.0627|

| Groups |Version|    Filter    |n-shot|  Metric   |   |Value |   |Stderr|
|--------|------:|--------------|-----:|-----------|---|-----:|---|-----:|
|mmlu_pro|      2|custom-extract|     5|exact_match|↑  |0.8214|±  |0.0141|
```

Benchmarked with Attention DP and no perf regression.




# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
