### PR TITLE
GDN Decode kernel optimization

### DIFF
--- a/tpu_inference/kernels/gdn/fused_gdn_decode_kernel.py
+++ b/tpu_inference/kernels/gdn/fused_gdn_decode_kernel.py
@@ -45,7 +45,7 @@ def get_default_block_sizes(
 ) -> int:
     """Choose bt to balance pipelining and VMEM utilization to minimize latency
 
-    Accounts for state scratch ``(bt, H_v, K, V)`` float32, optional
+    Accounts for state scratch ``(bt, H_v, K, V)`` of ``state_dtype``, optional
     a_log / dt_bias, and bt-proportional tiles that ``emit_pipeline``
     double-buffers (q, k, v, g, b, o).
     """
@@ -60,7 +60,7 @@ def get_default_block_sizes(
         fixed_bits += 2 * H_v * num_lanes * 32  # dt_bias: (H_v, num_lanes) f32
 
     # bt-proportional (in bits):
-    #   state scratch: (2*bt, H_v, K, V) float32 (double buffer)
+    #   state scratch: (2*bt, H_v, K, V) state_dtype (double buffer)
     #   pipeline tiles (×2 for emit_pipeline double buffering):
     #     q(bt,H_qk,K) + k(bt,H_qk,K)           -> 2·H_qk·K·ibits
     #     g(bt,H_v,K) float32                     -> H_v·K·32
@@ -401,7 +401,7 @@ def fused_decoding_gdn(
     k: jax.Array,  # [T, H_qk, K]
     v: jax.Array,  # [T, H_v, V]
     g: jax.Array,  # [T, H_v, K] float32
-    initial_state: jax.Array,  # [num_states, H_v, K, V] float32
+    initial_state: jax.Array,  # [num_states, H_v, K, V]
     state_indices: jax.Array,  # [max_num_req] int32
     distribution: jax.Array,  # [2] int32
     b: jax.Array | None,  # [T, H_v, num_lanes] or None
@@ -421,7 +421,7 @@ def fused_decoding_gdn(
         k: Keys ``[T, H_qk, K]``.
         v: Values ``[T, H_v, V]``.
         g: Per-key gating ``[T, H_v, K]``, float32.
-        initial_state: State cache ``[num_states, H_v, K, V]`` float32.
+        initial_state: State cache ``[num_states, H_v, K, V]``
         state_indices: ``i32[max_num_req]`` — indices into the state cache.
         distribution: ``i32[2]`` — ``(decode_end, total)``.
         b: Raw betas ``[T, H_v, num_lanes]`` (sigmoid applied inside kernel).

--- a/tpu_inference/kernels/gdn/fused_gdn_decode_kernel.py
+++ b/tpu_inference/kernels/gdn/fused_gdn_decode_kernel.py
@@ -24,7 +24,6 @@ import functools
 
 import jax
 import jax.numpy as jnp
-from jax._src import dtypes
 from jax.experimental import pallas as pl
 from jax.experimental.pallas import tpu as pltpu
 
@@ -33,24 +32,24 @@ from tpu_inference.kernels.gdn.fused_gdn_kernel_common import \
 
 
 def get_default_block_sizes(
+    T: int,
     H_qk: int,
     H_v: int,
     K: int,
     V: int,
     dtype,
+    state_dtype,
     use_gate_in_kernel: bool,
     has_dt_bias: bool,
     vmem_bytes_limit: int,
-    state_dtype=jnp.float32,
 ) -> int:
-    """Choose bt to maximize VMEM utilization within vmem_bytes_limit.
+    """Choose bt to balance pipelining and VMEM utilization to minimize latency
 
-    Accounts for state scratch ``(bt, H_v, K, V)`` of ``state_dtype``, optional
+    Accounts for state scratch ``(bt, H_v, K, V)`` float32, optional
     a_log / dt_bias, and bt-proportional tiles that ``emit_pipeline``
     double-buffers (q, k, v, g, b, o).
     """
-    ibits = dtypes.itemsize_bits(dtype)
-    sbits = dtypes.itemsize_bits(state_dtype)
+    ibits = dtype.itemsize * 8
 
     # Fixed (not bt-dependent), in bits
     num_lanes = pltpu.get_tpu_info().num_lanes
@@ -61,19 +60,33 @@ def get_default_block_sizes(
         fixed_bits += 2 * H_v * num_lanes * 32  # dt_bias: (H_v, num_lanes) f32
 
     # bt-proportional (in bits):
-    #   state scratch: (2*bt, H_v, K, V) state_dtype (double buffer)
+    #   state scratch: (2*bt, H_v, K, V) float32 (double buffer)
     #   pipeline tiles (×2 for emit_pipeline double buffering):
     #     q(bt,H_qk,K) + k(bt,H_qk,K)           -> 2·H_qk·K·ibits
     #     g(bt,H_v,K) float32                     -> H_v·K·32
     #     v(bt,H_v,V) + o(bt,H_v,V)              -> 2·H_v·V·ibits
     #     b(bt,H_v,num_lanes)                     -> H_v·num_lanes·ibits
-    per_bt_bits = 2 * H_v * K * V * sbits + 2 * (
-        2 * H_qk * K * ibits + H_v * K * 32 + 2 * H_v * V * ibits +
-        H_v * num_lanes * ibits)
+    sbits = state_dtype.itemsize * 8
+    per_bt_bits = (
+        # State scratch: 2 (double buffer) * bt * H_v * K * V * sbits bits
+        2 * H_v * K * V * sbits +
+        # Pipeline tiles (multiplied by 2 for double buffering in emit_pipeline)
+        2 * (
+            2 * H_qk * K * ibits  # q and k
+            + H_v * K * 32  # g (float32)
+            + 2 * H_v * V * ibits  # v and o
+            + H_v * num_lanes * ibits  # b
+        ))
 
-    bt = max(1, (vmem_bytes_limit * 8 - fixed_bits) // per_bt_bits)
-    # Round down to nearest power of 2
-    return 1 << (bt.bit_length() - 1)
+    bt_max = max(1, (vmem_bytes_limit * 8 - fixed_bits) // per_bt_bits)
+
+    # bt_max is not the optimal bt size because it limits the pipelining capability
+    # The first step needs to load synchronously from HBM to start and last step needs
+    # to write to HBM.
+    bt_adjusted = min(pl.cdiv(T, 8), bt_max)
+
+    # Round down to the nearest power of 2
+    return 1 << (bt_adjusted.bit_length() - 1)
 
 
 # ── Outer kernel ──────────────────────────────────────────────────────
@@ -105,9 +118,10 @@ def _decode_kernel_main(
     use_gate_in_kernel: bool,
     lower_bound: float | None,
     bt: int,
+    apply_silu: bool,
 ):
     decode_end = distribution_ref[0]
-    nb_t = (decode_end + bt - 1) // bt
+    nb_t = pl.cdiv(decode_end, bt)
     repeat_factor = H_v // H_qk
 
     bounded_bt = pl.BoundedSlice(bt)
@@ -202,36 +216,48 @@ def _decode_kernel_main(
         ).wait()
 
         # ── Step 3: Compute ──
+        q_all = q_ref[...].astype(jnp.float32)
+        k_all = k_ref[...].astype(jnp.float32)
+        v_all = v_ref[...].astype(jnp.float32)
+        g_all = g_ref[...].astype(jnp.float32)
+
+        if apply_silu:
+            q_all = jax.nn.silu(q_all)
+            k_all = jax.nn.silu(k_all)
+            v_all = jax.nn.silu(v_all)
+
+        if b_ref is not None:
+            b_all = b_ref[...].astype(jnp.float32)
+            if V > b_all.shape[-1]:
+                beta_all = jax.nn.sigmoid(
+                    jnp.concatenate([b_all] * (V // b_all.shape[-1]), axis=-1))
+            else:
+                beta_all = jax.nn.sigmoid(b_all)
+
+        if use_qk_l2norm:
+            q_all = q_all / jnp.sqrt(
+                jnp.sum(q_all * q_all, axis=-1, keepdims=True) + 1e-6)
+            k_all = k_all / jnp.sqrt(
+                jnp.sum(k_all * k_all, axis=-1, keepdims=True) + 1e-6)
+        q_all = q_all * scale
+
+        qk_dot_all = jnp.sum(q_all * k_all, axis=-1, keepdims=True)
+
+        if repeat_factor > 1:
+            q_all = jnp.repeat(q_all, repeat_factor, axis=1)
+            k_all = jnp.repeat(k_all, repeat_factor, axis=1)
+            qk_dot_all = jnp.repeat(qk_dot_all, repeat_factor, axis=1)
+
         for i_t in range(bt):
 
             @pl.when(i_t < block_len)
             def _process_token():
                 h0 = h_bufs_s[buf_idx, i_t].astype(jnp.float32)
-                q_t = q_ref[i_t].astype(jnp.float32)
-                k_t = k_ref[i_t].astype(jnp.float32)
-                v_t = v_ref[i_t].astype(jnp.float32)
-                g_t = g_ref[i_t].astype(jnp.float32)
-                if b_ref is not None:
-                    b_tile = b_ref[i_t].astype(jnp.float32)  # [H_v, num_lanes]
-                    if V > b_tile.shape[-1]:
-                        beta_t = jax.nn.sigmoid(
-                            jnp.concatenate([b_tile] * (V // b_tile.shape[-1]),
-                                            axis=-1))  # [H_v, V]
-                    else:
-                        beta_t = jax.nn.sigmoid(
-                            b_tile)  # [H_v, num_lanes] (== [H_v, V])
-
-                if use_qk_l2norm:
-                    q_t = q_t / jnp.sqrt(
-                        jnp.sum(q_t * q_t, axis=-1, keepdims=True) + 1e-6)
-                    k_t = k_t / jnp.sqrt(
-                        jnp.sum(k_t * k_t, axis=-1, keepdims=True) + 1e-6)
-                q_t = q_t * scale
-
-                # GQA: repeat q/k from H_qk to H_v heads
-                if repeat_factor > 1:
-                    q_t = jnp.repeat(q_t, repeat_factor, axis=0)
-                    k_t = jnp.repeat(k_t, repeat_factor, axis=0)
+                q_t = q_all[i_t]
+                k_t = k_all[i_t]
+                v_t = v_all[i_t]
+                g_t = g_all[i_t]
+                qk_dot = qk_dot_all[i_t]
 
                 if use_gate_in_kernel:
                     g_val = g_t
@@ -245,31 +271,33 @@ def _decode_kernel_main(
                 else:
                     gk = g_t
 
-                h_pre = h0 * jnp.exp(gk[:, :, None])
-                kh = jax.lax.dot_general(
-                    k_t.reshape(H_v, 1, K),
-                    h_pre,
-                    (((2, ), (1, )), ((0, ), (0, ))),
-                    preferred_element_type=jnp.float32,
-                ).reshape(H_v, V)
-                v_diff = v_t - kh
-                b_v = beta_t * v_diff if b_ref is not None else v_diff
+                exp_gk = jnp.exp(gk)
+                k_t_scaled = k_t * exp_gk
 
-                # Algebraic identity to skip the post-rank-1-update matmul:
-                # o = q @ (h_pre + outer(k, b_v))
-                #   = q @ h_pre + (q . k) * b_v
-                # (q . k)[h] is a per-head scalar, so the second term is a
-                # cheap HV*V scaled-add instead of a full HV*K*V matmul.
-                # This lets MXU(o) and VPU(rank-1 update) run in parallel.
-                o_step1 = jax.lax.dot_general(
-                    q_t.reshape(H_v, 1, K),
-                    h_pre,
+                kh = jax.lax.dot_general(
+                    k_t_scaled.reshape(H_v, 1, K),
+                    h0,
                     (((2, ), (1, )), ((0, ), (0, ))),
                     preferred_element_type=jnp.float32,
                 ).reshape(H_v, V)
-                qk_dot = jnp.sum(q_t * k_t, axis=-1, keepdims=True)
+
+                v_diff = v_t - kh
+                if b_ref is not None:
+                    b_v = beta_all[i_t] * v_diff
+                else:
+                    b_v = v_diff
+
+                q_t_scaled = q_t * exp_gk
+                o_step1 = jax.lax.dot_general(
+                    q_t_scaled.reshape(H_v, 1, K),
+                    h0,
+                    (((2, ), (1, )), ((0, ), (0, ))),
+                    preferred_element_type=jnp.float32,
+                ).reshape(H_v, V)
+
                 o_t = o_step1 + qk_dot * b_v
-                h_new = h_pre + k_t[:, :, None] * b_v[:, None, :]
+                h_new = h0 * exp_gk[:, :, None] + k_t[:, :,
+                                                      None] * b_v[:, None, :]
 
                 o_ref[i_t] = o_t.astype(o_ref.dtype)
                 h_bufs_s[buf_idx, i_t] = h_new.astype(h_bufs_s.dtype)
@@ -307,7 +335,13 @@ def _decode_kernel_main(
         _inner_kernel,
         grid=(nb_t, ),
         in_specs=[
-            qk_spec, qk_spec, v_spec, g_spec, b_spec, a_log_spec, dt_bias_spec
+            qk_spec,
+            qk_spec,
+            v_spec,
+            g_spec,
+            b_spec,
+            a_log_spec,
+            dt_bias_spec,
         ],
         out_specs=v_spec,
     )(
@@ -359,6 +393,7 @@ def _decode_kernel_main(
         "use_qk_l2norm_in_kernel",
         "use_gate_in_kernel",
         "lower_bound",
+        "apply_silu",
     ],
 )
 def fused_decoding_gdn(
@@ -377,8 +412,9 @@ def fused_decoding_gdn(
     A_log: jax.Array | None = None,  # [H_v, num_lanes] float32 or None
     dt_bias: jax.Array | None = None,  # [H_v, num_lanes] float32 or None
     lower_bound: float | None = None,
+    apply_silu: bool = False,
 ) -> tuple[jax.Array, jax.Array]:
-    r"""Fused recurrent GDN single-step decode.
+    """Fused recurrent GDN single-step decode.
 
     Args:
         q: Queries ``[T, H_qk, K]``.
@@ -395,6 +431,7 @@ def fused_decoding_gdn(
         A_log: Per-head log gate ``[H_v, num_lanes]`` float32.
         dt_bias: Per-head bias ``[H_v, num_lanes]`` float32.
         lower_bound: If set, use sigmoid gate instead of softplus.
+        apply_silu: Apply SiLU activation to q, k, v inside the kernel.
 
     Returns:
         ``(o, updated_state)`` — *o* is ``[T, H_v, V]``,
@@ -415,15 +452,16 @@ def fused_decoding_gdn(
 
     vmem_bytes_limit = int(pltpu.get_tpu_info().vmem_capacity_bytes * 0.9)
     bt = get_default_block_sizes(
+        T,
         H_qk,
         H_v,
         K,
         V,
         dtype,
+        initial_state.dtype,
         use_gate_in_kernel,
         dt_bias is not None,
         vmem_bytes_limit,
-        state_dtype=initial_state.dtype,
     )
 
     any_spec = pl.BlockSpec(memory_space=pl.ANY)
@@ -449,6 +487,7 @@ def fused_decoding_gdn(
             use_gate_in_kernel=use_gate_in_kernel,
             lower_bound=lower_bound,
             bt=bt,
+            apply_silu=apply_silu,
         ),
         grid_spec=pltpu.PrefetchScalarGridSpec(
             num_scalar_prefetch=0,
@@ -464,10 +503,6 @@ def fused_decoding_gdn(
             out_specs=[any_spec, any_spec],
             grid=(grid_dim, ),
             scratch_shapes=[
-                # h_bufs match HBM dtype so the DMAs don't need conversion.
-                # The per-token compute path upcasts to fp32 on each load
-                # (see h0 = h_bufs_s[..., i_t].astype(fp32) above), so on-chip
-                # math is fp32 regardless of HBM storage dtype.
                 pltpu.VMEM((2, bt, H_v, K, V),
                            initial_state.dtype),  # h_bufs (double buffer)
                 pltpu.SemaphoreType.DMA((2, )),  # h_load_sems
@@ -475,8 +510,8 @@ def fused_decoding_gdn(
             ],
         ),
         input_output_aliases={
-            2: 0,
-            6 + n_b + n_gate: 1
+            2: 0,  # v aliases o
+            6 + n_b + n_gate: 1,  # initial_state aliases updated_state
         },
         out_shape=[
             jax.ShapeDtypeStruct((T, H_v, V), dtype),
@@ -501,3 +536,96 @@ def fused_decoding_gdn(
     )
 
     return o, state
+
+
+def ragged_gated_delta_rule_decode_only(
+    mixed_qkv,
+    b,
+    a,
+    recurrent_state,
+    A_log,
+    dt_bias,
+    query_start_loc,
+    state_indices,
+    distribution,
+    has_initial_state=None,
+    *,
+    n_kq,
+    n_v,
+    d_k,
+    d_v,
+    apply_silu=False,
+):
+    """Adapter for decode-only branch matching ragged_gated_delta_rule interface.
+
+    Internally reshapes inputs and delegates to :func:`fused_decoding_gdn`.
+
+    Args:
+        mixed_qkv: ``(num_tokens, 2*n_kq*d_k + n_v*d_v)`` post-conv/silu.
+        b: ``(num_tokens, n_v)`` — raw beta (sigmoid applied in kernel).
+        a: ``(num_tokens, n_v)`` — raw alpha (gate transform in kernel).
+        recurrent_state: ``(num_states, n_v, d_k, d_v)``.
+        A_log: ``(n_v,)`` float32.
+        dt_bias: ``(n_v,)`` float32.
+        query_start_loc: ``(num_seqs+1,)`` int32.
+        state_indices: ``(num_seqs,)`` int32.
+        distribution: ``(3,)`` int32 — ``(decode_end, prefill_end, mixed_end)``.
+        has_initial_state: Ignored on decode path.
+        n_kq: Number of key/query heads.
+        n_v: Number of value heads.
+        d_k: Key dimension.
+        d_v: Value dimension.
+        apply_silu: Whether to apply silu in-kernel
+
+    Returns:
+        ``(updated_recurrent_state, output)`` where
+        *updated_recurrent_state* is ``(num_states, n_v, d_k, d_v)`` and
+        *output* is ``(num_tokens, n_v*d_v)``.
+    """
+    num_tokens = mixed_qkv.shape[0]
+    key_dim = n_kq * d_k
+
+    q = mixed_qkv[..., :key_dim].reshape(num_tokens, n_kq, d_k)
+    k = mixed_qkv[..., key_dim:key_dim * 2].reshape(num_tokens, n_kq, d_k)
+    v = mixed_qkv[..., key_dim * 2:].reshape(num_tokens, n_v, d_v)
+
+    g = a
+    if g.shape == (num_tokens, n_v):
+        g = jnp.broadcast_to(g[..., None], (num_tokens, n_v, d_k))
+
+    num_lanes = pltpu.get_tpu_info().num_lanes
+    if b is not None:
+        b = jnp.broadcast_to(b[:, :, None], (num_tokens, n_v, num_lanes))
+
+    if A_log is not None:
+        A_log = jnp.broadcast_to(A_log[:, None],
+                                 (n_v, num_lanes)).astype(jnp.float32)
+
+    if dt_bias is not None:
+        dt_bias = jnp.broadcast_to(dt_bias[:, None],
+                                   (n_v, num_lanes)).astype(jnp.float32)
+
+    # (decode_end, prefill_end, mixed_end) → (decode_end, total)
+    fused_distribution = jnp.stack([distribution[0], distribution[2]])
+
+    scale = d_k**-0.5
+
+    output, new_recurrent_state = fused_decoding_gdn(
+        q,
+        k,
+        v,
+        g,
+        recurrent_state,
+        state_indices,
+        distribution=fused_distribution,
+        b=b,
+        scale=scale,
+        use_qk_l2norm_in_kernel=True,
+        use_gate_in_kernel=True,
+        A_log=A_log,
+        dt_bias=dt_bias,
+        apply_silu=apply_silu,
+    )
+
+    output = output.reshape(num_tokens, n_v * d_v)
+    return new_recurrent_state, output

--- a/tpu_inference/kernels/gdn/fused_gdn_kernel_common.py
+++ b/tpu_inference/kernels/gdn/fused_gdn_kernel_common.py
@@ -16,7 +16,6 @@
 from __future__ import annotations
 
 import jax.numpy as jnp
-from jax._src import dtypes
 from jax.experimental.pallas import tpu as pltpu
 
 
@@ -39,8 +38,8 @@ def validate_gdn_inputs(
         q: ``[T, H_qk, K]``.
         k: ``[T, H_qk, K]``.
         v: ``[T, H_v, V]``.
-        g: ``[T, H_v, K]`` float32.
-        initial_state: ``[num_states, H_v, K, V]`` float32.
+        g: ``[T, H_v, K]``.
+        initial_state: ``[num_states, H_v, K, V]``.
         state_indices: ``[max_num_req]`` int32.
         b: ``[T, H_v, num_lanes]`` or ``None``.
         use_gate_in_kernel: Whether gate transformation is applied inside kernel.
@@ -56,7 +55,7 @@ def validate_gdn_inputs(
     dtype = q.dtype
     num_states = initial_state.shape[0]
     num_lanes = pltpu.get_tpu_info().num_lanes
-    packing = 32 // dtypes.itemsize_bits(dtype)
+    packing = 32 // (dtype.itemsize * 8)
 
     # Shape checks
     if k.shape != (T, H_qk, K):
@@ -87,12 +86,7 @@ def validate_gdn_inputs(
     if k.dtype != dtype or v.dtype != dtype:
         raise ValueError(f"q/k/v must share the same dtype, got q={dtype}, "
                          f"k={k.dtype}, v={v.dtype}")
-    if g.dtype != jnp.float32:
-        raise ValueError(f"g must be float32, got {g.dtype}")
-    if initial_state.dtype not in (jnp.float32, jnp.bfloat16, jnp.float16):
-        raise ValueError(
-            f"initial_state must be float32, bfloat16, or float16, "
-            f"got {initial_state.dtype}")
+
     if state_indices.dtype != jnp.int32:
         raise ValueError(
             f"state_indices must be int32, got {state_indices.dtype}")

--- a/tpu_inference/kernels/gdn/fused_gdn_kernel_wrapper.py
+++ b/tpu_inference/kernels/gdn/fused_gdn_kernel_wrapper.py
@@ -57,16 +57,12 @@ def _dispatch_with_distribution(
     before it can decode), so masking is unnecessary on the decode path.
     """
     # ── Decode kernel → updates state in-place ──
-    # NOTE: pass `initial_state` through as-is. The kernels upcast to fp32
-    # on VMEM load for compute precision; HBM storage stays at the array's
-    # dtype. An `astype(jnp.float32)` here would materialize an fp32 copy
-    # of a bf16 state and undo the storage win before the kernel runs.
     o_d, state_1 = fused_decoding_gdn(
         q,
         k,
         v,
         g.astype(jnp.float32),
-        initial_state,
+        initial_state.astype(jnp.float32),
         state_indices,
         distribution,
         b,
@@ -147,22 +143,21 @@ def fused_gdn(
         initial_state: State cache ``[num_states, H_v, K, V]``.
         state_indices: ``i32[max_num_req]`` — indices into the state cache.
         distribution: ``i32[2]`` — ``(decode_end, total)``.
-        b: Raw betas ``[T, H_v]`` (sigmoid applied inside kernel).
-            ``None`` means beta=1 (no beta gating).
-        has_initial_state: Boolean tensor of shape ``[max_num_req]``.
-            ``True`` when the request's recurrent slot already holds a
-            valid prior state (chunked-prefill continuation, prefix-cache
-            hit, or running decode). ``False`` for brand-new prefills,
-            whose slot is zeroed inside the recurrent kernel before the
-            update so stale data from a previous tenant doesn't leak.
-            ``None`` (default) is treated as all-True, preserving the
-            pre-fix behaviour for callers that don't manage slot reuse.
+        b: Raw betas ``[T, H_v]`` (sigmoid applied inside kernel). ``None`` means
+          beta=1 (no beta gating).
+        has_initial_state: Boolean tensor of shape ``[max_num_req]``. ``True``
+          when the request's recurrent slot already holds a valid prior state
+          (chunked-prefill continuation, prefix-cache hit, or running decode).
+          ``False`` for brand-new prefills, whose slot is zeroed inside the
+          recurrent kernel before the update so stale data from a previous tenant
+          doesn't leak. ``None`` (default) is treated as all-True, preserving the
+          pre-fix behaviour for callers that don't manage slot reuse.
         scale: Scale factor.  Default ``K ** -0.5``.
         use_qk_l2norm_in_kernel: L2-normalize q, k inside the kernel.
         use_gate_in_kernel: Apply gate transformation inside kernel.
         A_log: Per-head log gate ``[H_v]`` float32.
-        dt_bias: Per-head bias ``[H_v]`` float32. Optional.
-            Broadcast to ``[H_v, num_lanes]`` internally.
+        dt_bias: Per-head bias ``[H_v]`` float32. Optional. Broadcast to ``[H_v,
+          num_lanes]`` internally.
         lower_bound: If set, use sigmoid gate instead of softplus.
 
     Returns:
@@ -269,14 +264,13 @@ def ragged_gated_delta_rule(
         query_start_loc: ``(num_seqs+1,)`` int32.
         state_indices: ``(num_seqs,)`` int32.
         distribution: ``(3,)`` int32 — ``(decode_end, prefill_end, mixed_end)``.
-        has_initial_state: Optional Boolean tensor of shape
-            ``(max_reqs,)``. ``True`` when the request's slot already
-            holds a valid prior recurrent state; ``False`` for brand-new
-            prefills (the recurrent kernel zeros h0 for those slots so
-            stale data from a reused mamba slot doesn't leak). ``None``
-            (default) is treated as all-True, preserving the
-            pre-PR-#2408 behaviour. Pass it when you want the same
-            stale-slot guard the chunked and ref impls already enforce.
+        has_initial_state: Optional Boolean tensor of shape ``(max_reqs,)``.
+          ``True`` when the request's slot already holds a valid prior recurrent
+          state; ``False`` for brand-new prefills (the recurrent kernel zeros h0
+          for those slots so stale data from a reused mamba slot doesn't leak).
+          ``None`` (default) is treated as all-True, preserving the pre-PR-#2408
+          behaviour. Pass it when you want the same stale-slot guard the chunked
+          and ref impls already enforce.
         n_kq: Number of key/query heads.
         n_v: Number of value heads.
         d_k: Key dimension.

--- a/tpu_inference/layers/common/ragged_gated_delta_rule_wrapper.py
+++ b/tpu_inference/layers/common/ragged_gated_delta_rule_wrapper.py
@@ -20,6 +20,8 @@ import jax
 import jax.numpy as jnp
 
 from tpu_inference.kernels.gdn import triangle_solver
+from tpu_inference.kernels.gdn.fused_gdn_decode_kernel import \
+    ragged_gated_delta_rule_decode_only
 from tpu_inference.kernels.gdn.fused_gdn_kernel_wrapper import \
     ragged_gated_delta_rule as fused_impl
 from tpu_inference.kernels.gdn.recurrent_scan_v2 import recurrent_scan
@@ -36,6 +38,7 @@ class RaggedGatedDeltaRuleConfig:
 
 class RaggedGatedDeltaRuleImpl(enum.Enum):
     """Implementation options for the ragged gated delta rule."""
+
     REF = 'ref'
     CHUNKED_JAX_PD = 'chunked_jax_pd'
     CHUNKED_KERNEL_PD = 'chunked_kernel_pd'
@@ -110,51 +113,50 @@ def ragged_gated_delta_rule_wrapper(
 ) -> tuple[jnp.ndarray, jnp.ndarray]:
     """Applies the gated delta rule over ragged seq lengths using various implementations.
 
-  This function separates mixed QKV, handles repeating for multi-query attention
-  if needed, and routes to either the decode-only or mixed-prefill branch
-  depending on sequence lengths and config.
+    This function separates mixed QKV, handles repeating for multi-query attention
+    if needed, and routes to either the decode-only or mixed-prefill branch
+    depending on sequence lengths and config.
 
-  Args:
-    config: Configuration for ragged gated delta rule.
-    mixed_qkv: Mixed query, key, value tensor.
-    b: b tensor (for beta).
-    a: a tensor (for g).
-    recurrent_state: Recurrent state tensor of shape `(num_blocks, n_v, d_k,
-      d_v)`. `num_blocks` is always equal or larger than `max_seqs + 1`. The
-      first block is a null_block and only used for padded / invalid tokens.
-    A_log: A_log tensor.
-    dt_bias: dt_bias tensor.
-    query_start_loc: Start locations of sequences.
-    state_indices: Indices mapping sequences to recurrent state slots.
-    distribution: Tensor of shape `(3,)` int32 — `(decode_end, prefill_end,
-      mixed_end)`.
-    has_initial_state: Boolean tensor of shape `(max_reqs,)`. ``True`` when the
-      request has prior recurrent state to use (chunked-prefill continuation or
-      prefix-cache hit). ``False`` for brand-new prefills, in which case the
-      gathered recurrent state is treated as zeros — matching GPU's
-      `initial_state[~has_initial_state, ...] = 0` in
-      `gdn_linear_attn._forward_core`.
-    chunk_size: Chunk size for padding.
-    triangle_solver_impl: Which triangle solver implementation to use.
-    n_kq: Number of key/query heads.
-    n_v: Number of value heads.
-    d_k: Key/query dimension.
-    d_v: Value dimension.
+    Args:
+      config: Configuration for ragged gated delta rule.
+      mixed_qkv: Mixed query, key, value tensor.
+      b: b tensor (for beta).
+      a: a tensor (for g).
+      recurrent_state: Recurrent state tensor of shape `(num_blocks, n_v, d_k,
+        d_v)`. `num_blocks` is always equal or larger than `max_seqs + 1`. The
+        first block is a null_block and only used for padded / invalid tokens.
+      A_log: A_log tensor.
+      dt_bias: dt_bias tensor.
+      query_start_loc: Start locations of sequences.
+      state_indices: Indices mapping sequences to recurrent state slots.
+      distribution: Tensor of shape `(3,)` int32 — `(decode_end, prefill_end,
+        mixed_end)`.
+      has_initial_state: Boolean tensor of shape `(max_reqs,)`. ``True`` when the
+        request has prior recurrent state to use (chunked-prefill continuation or
+        prefix-cache hit). ``False`` for brand-new prefills, in which case the
+        gathered recurrent state is treated as zeros — matching GPU's
+        `initial_state[~has_initial_state, ...] = 0` in
+        `gdn_linear_attn._forward_core`.
+      chunk_size: Chunk size for padding.
+      triangle_solver_impl: Which triangle solver implementation to use.
+      n_kq: Number of key/query heads.
+      n_v: Number of value heads.
+      d_k: Key/query dimension.
+      d_v: Value dimension.
 
-  Returns:
-    A tuple containing:
-      - updated_recurrent_state: Updated recurrent state tensor of shape
-        `(num_blocks, n_v, d_k, d_v)`.
-      - output: Output tensor.
-  """
+    Returns:
+      A tuple containing:
+        - updated_recurrent_state: Updated recurrent state tensor of shape
+          `(num_blocks, n_v, d_k, d_v)`.
+        - output: Output tensor.
+    """
     is_decode_only = distribution[0] == distribution[2]
 
     def decode_only_branch(_):
         impl = config.decode_impl
         if impl == 'fused':
-            qkv_in = jax.nn.silu(mixed_qkv)
-            new_state, output = fused_impl(
-                mixed_qkv=qkv_in,
+            new_state, output = ragged_gated_delta_rule_decode_only(
+                mixed_qkv=mixed_qkv,
                 b=b,
                 a=a,
                 recurrent_state=recurrent_state,
@@ -168,6 +170,7 @@ def ragged_gated_delta_rule_wrapper(
                 n_v=n_v,
                 d_k=d_k,
                 d_v=d_v,
+                apply_silu=True,
             )
             return new_state, output
         elif impl == 'jax':


### PR DESCRIPTION
# Description

Optimize gdn decode kernel

* Fuse silu in decode kernel, this is almost free to do in kernel 
* For GQA, compute qk first and then repeat instead of repeat qk and then compute.
* Default block size is not optimal for pipelining. We have enough VMEM to fit everything in 1 block but we want more blocks to overlap the DMAs in first / last block

+--------+---------+---------+--------------+------------+------------+--------------+
| Decode | GDN Old | GDN New | GDN %        | Kernel Old | Kernel New | Kernel %     |
| Tokens | (us)    | (us)    | Difference   | (us)       | (us)       | Difference   |
+--------+---------+---------+--------------+------------+------------+--------------+
| 64     | 88.9    | 61.3    | -31.05%      | 53.6       | 36.7       | -31.53%      |
| 128    | 130.8   | 93.7    | -28.36%      | 93.6       | 66.6       | -28.85%      |
| 256    | 218.8   | 164     | -25.05%      | 173.4      | 126        | -27.34%      |
| 512    | 377     | 283     | -24.93%      | 332        | 239        | -28.01%      |
+--------+---------+---------+--------------+------------+------------+--------------+


# Tests

Tested E2E benchmark.
Qwen 3.5 397B, total token throughput
1K/8K c64:  2051 -> 2163  (+5.5%)
8K/1K c64: 10745 -> 11522 (+7.2%)


Tested lm_eval mmlu_pro no regression
```
|       Tasks       |Version|    Filter    |n-shot|  Metric   |   |Value |   |Stderr|
|-------------------|------:|--------------|-----:|-----------|---|-----:|---|-----:|
|mmlu_pro           |    2.0|custom-extract|     5|exact_match|↑  |0.8286|±  |0.0139|
| - biology         |    3.1|custom-extract|     5|exact_match|↑  |0.9400|±  |0.0339|
| - business        |    3.1|custom-extract|     5|exact_match|↑  |0.8800|±  |0.0464|
| - chemistry       |    3.1|custom-extract|     5|exact_match|↑  |0.9400|±  |0.0339|
| - computer_science|    3.1|custom-extract|     5|exact_match|↑  |0.8400|±  |0.0524|
| - economics       |    3.1|custom-extract|     5|exact_match|↑  |0.9000|±  |0.0429|
| - engineering     |    3.1|custom-extract|     5|exact_match|↑  |0.6600|±  |0.0677|
| - health          |    3.1|custom-extract|     5|exact_match|↑  |0.7800|±  |0.0592|
| - history         |    3.1|custom-extract|     5|exact_match|↑  |0.6800|±  |0.0666|
| - law             |    3.1|custom-extract|     5|exact_match|↑  |0.7400|±  |0.0627|
| - math            |    3.1|custom-extract|     5|exact_match|↑  |0.9600|±  |0.0280|
| - other           |    3.1|custom-extract|     5|exact_match|↑  |0.7400|±  |0.0627|
| - philosophy      |    3.1|custom-extract|     5|exact_match|↑  |0.8200|±  |0.0549|
| - physics         |    3.1|custom-extract|     5|exact_match|↑  |0.9400|±  |0.0339|
| - psychology      |    3.1|custom-extract|     5|exact_match|↑  |0.7800|±  |0.0592|

| Groups |Version|    Filter    |n-shot|  Metric   |   |Value |   |Stderr|
|--------|------:|--------------|-----:|-----------|---|-----:|---|-----:|
|mmlu_pro|      2|custom-extract|     5|exact_match|↑  |0.8286|±  |0.0139|
```


# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
