### PR TITLE
feat: support Qwen3-VL Deepstack stateless JIT precompilation on TPU

### DIFF
--- a/tests/models/vllm/experimental/test_qwen3_vl_patcher.py
+++ b/tests/models/vllm/experimental/test_qwen3_vl_patcher.py
@@ -1,0 +1,104 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+import pytest
+from tpu_inference.models.vllm.experimental.qwen3_vl_patcher import _patched_flatten_embeddings
+
+def test_patched_flatten_embeddings_2d():
+    # Standard 2D embedding tensor (num_tokens, hidden_dim)
+    t = torch.ones((5, 10))
+    res = _patched_flatten_embeddings(t)
+    
+    # Should flatten all but the last dimension.
+    # For 2D (5, 10), all but last dim is just dim 0 (size 5).
+    # Result shape should be (5, 10).
+    assert res.shape == (5, 10)
+    assert torch.allclose(res, t)
+
+def test_patched_flatten_embeddings_3d():
+    # 3D embedding tensor (batch, num_tokens, hidden_dim)
+    t = torch.ones((2, 5, 10))
+    res = _patched_flatten_embeddings(t)
+    
+    # Should flatten dimensions 0 and 1 -> 2 * 5 = 10.
+    # Result shape should be (10, 10).
+    assert res.shape == (10, 10)
+
+def test_patched_flatten_embeddings_nested_list():
+    # Nested list/tuple of tensors
+    t1 = torch.ones((2, 5))
+    t2 = torch.ones((3, 5))
+    embeddings = [t1, t2]
+    
+    res = _patched_flatten_embeddings(embeddings)
+    # Should flatten each and concatenate them -> (2+3, 5) = (5, 5)
+    assert res.shape == (5, 5)
+
+def test_patched_flatten_embeddings_empty_and_1d():
+    # 1D tensor of shape (L,) representing edge cases / 1D sequences
+    t = torch.ones((5,))
+    res = _patched_flatten_embeddings(t)
+    
+    # ndim = 1. start_dim = 0, end_dim = -2.
+    # start_dim = 0. end_dim = -2 + 1 = -1.
+    # Returns t.flatten(0, -1) which is a 1D tensor.
+    assert res.shape == (5,)
+
+    # Empty 1D tensor
+    t_empty = torch.ones((0,))
+    res_empty = _patched_flatten_embeddings(t_empty)
+    assert res_empty.shape == (0,)
+
+
+def test_patched_get_deepstack_none():
+    from tpu_inference.models.vllm.experimental.qwen3_vl_patcher import _patched_get_deepstack
+    class MockModel:
+        pass
+    model = MockModel()
+    
+    # Case 1: orig_get_deepstack returns None, and there are no cached deepstack tensors
+    orig_get_deepstack = lambda tokens: None
+    res = _patched_get_deepstack(model, orig_get_deepstack, 10)
+    assert res is None
+
+
+def test_patched_get_deepstack_with_cache():
+    from tpu_inference.models.vllm.experimental.qwen3_vl_patcher import _patched_get_deepstack
+    class MockModel:
+        _deepstack_tensors = {"deepstack_input_embeds_0": torch.ones((5, 10))}
+    model = MockModel()
+    
+    # Case 2: cached deepstack tensors exist, orig_get_deepstack should not be called
+    def orig_get_deepstack(tokens):
+        raise AssertionError("Should not be called")
+        
+    res = _patched_get_deepstack(model, orig_get_deepstack, 10)
+    assert res is not None
+    assert "deepstack_input_embeds_0" in res
+
+
+def test_patched_get_deepstack_fallback():
+    from tpu_inference.models.vllm.experimental.qwen3_vl_patcher import _patched_get_deepstack
+    class MockModel:
+        pass
+    model = MockModel()
+    
+    # Case 3: no cached deepstack tensors, orig_get_deepstack returns a dictionary
+    t1 = torch.ones((5, 10))
+    orig_get_deepstack = lambda tokens: {"layer_0": t1}
+    res = _patched_get_deepstack(model, orig_get_deepstack, 10)
+    assert res is not None
+    assert "layer_0" in res
+

--- a/tests/models/vllm/experimental/test_qwen3_vl_patcher.py
+++ b/tests/models/vllm/experimental/test_qwen3_vl_patcher.py
@@ -13,92 +13,110 @@
 # limitations under the License.
 
 import torch
-import pytest
-from tpu_inference.models.vllm.experimental.qwen3_vl_patcher import _patched_flatten_embeddings
+
+from tpu_inference.models.vllm.experimental.qwen3_vl_patcher import \
+    _patched_flatten_embeddings
+
 
 def test_patched_flatten_embeddings_2d():
     # Standard 2D embedding tensor (num_tokens, hidden_dim)
     t = torch.ones((5, 10))
     res = _patched_flatten_embeddings(t)
-    
+
     # Should flatten all but the last dimension.
     # For 2D (5, 10), all but last dim is just dim 0 (size 5).
     # Result shape should be (5, 10).
     assert res.shape == (5, 10)
     assert torch.allclose(res, t)
 
+
 def test_patched_flatten_embeddings_3d():
     # 3D embedding tensor (batch, num_tokens, hidden_dim)
     t = torch.ones((2, 5, 10))
     res = _patched_flatten_embeddings(t)
-    
+
     # Should flatten dimensions 0 and 1 -> 2 * 5 = 10.
     # Result shape should be (10, 10).
     assert res.shape == (10, 10)
+
 
 def test_patched_flatten_embeddings_nested_list():
     # Nested list/tuple of tensors
     t1 = torch.ones((2, 5))
     t2 = torch.ones((3, 5))
     embeddings = [t1, t2]
-    
+
     res = _patched_flatten_embeddings(embeddings)
     # Should flatten each and concatenate them -> (2+3, 5) = (5, 5)
     assert res.shape == (5, 5)
 
+
 def test_patched_flatten_embeddings_empty_and_1d():
     # 1D tensor of shape (L,) representing edge cases / 1D sequences
-    t = torch.ones((5,))
+    t = torch.ones((5, ))
     res = _patched_flatten_embeddings(t)
-    
+
     # ndim = 1. start_dim = 0, end_dim = -2.
     # start_dim = 0. end_dim = -2 + 1 = -1.
     # Returns t.flatten(0, -1) which is a 1D tensor.
-    assert res.shape == (5,)
+    assert res.shape == (5, )
 
     # Empty 1D tensor
-    t_empty = torch.ones((0,))
+    t_empty = torch.ones((0, ))
     res_empty = _patched_flatten_embeddings(t_empty)
-    assert res_empty.shape == (0,)
+    assert res_empty.shape == (0, )
 
 
 def test_patched_get_deepstack_none():
-    from tpu_inference.models.vllm.experimental.qwen3_vl_patcher import _patched_get_deepstack
+    from tpu_inference.models.vllm.experimental.qwen3_vl_patcher import \
+        _patched_get_deepstack
+
     class MockModel:
         pass
+
     model = MockModel()
-    
+
     # Case 1: orig_get_deepstack returns None, and there are no cached deepstack tensors
-    orig_get_deepstack = lambda tokens: None
+    def orig_get_deepstack(tokens):
+        return None
+
     res = _patched_get_deepstack(model, orig_get_deepstack, 10)
     assert res is None
 
 
 def test_patched_get_deepstack_with_cache():
-    from tpu_inference.models.vllm.experimental.qwen3_vl_patcher import _patched_get_deepstack
+    from tpu_inference.models.vllm.experimental.qwen3_vl_patcher import \
+        _patched_get_deepstack
+
     class MockModel:
         _deepstack_tensors = {"deepstack_input_embeds_0": torch.ones((5, 10))}
+
     model = MockModel()
-    
+
     # Case 2: cached deepstack tensors exist, orig_get_deepstack should not be called
     def orig_get_deepstack(tokens):
         raise AssertionError("Should not be called")
-        
+
     res = _patched_get_deepstack(model, orig_get_deepstack, 10)
     assert res is not None
     assert "deepstack_input_embeds_0" in res
 
 
 def test_patched_get_deepstack_fallback():
-    from tpu_inference.models.vllm.experimental.qwen3_vl_patcher import _patched_get_deepstack
+    from tpu_inference.models.vllm.experimental.qwen3_vl_patcher import \
+        _patched_get_deepstack
+
     class MockModel:
         pass
+
     model = MockModel()
-    
+
     # Case 3: no cached deepstack tensors, orig_get_deepstack returns a dictionary
     t1 = torch.ones((5, 10))
-    orig_get_deepstack = lambda tokens: {"layer_0": t1}
+
+    def orig_get_deepstack(tokens):
+        return {"layer_0": t1}
+
     res = _patched_get_deepstack(model, orig_get_deepstack, 10)
     assert res is not None
     assert "layer_0" in res
-

--- a/tests/models/vllm/experimental/test_qwen3_vl_patcher.py
+++ b/tests/models/vllm/experimental/test_qwen3_vl_patcher.py
@@ -99,7 +99,7 @@ def test_patched_get_deepstack_with_cache():
 
     res = _patched_get_deepstack(model, orig_get_deepstack, 10)
     assert res is not None
-    assert "deepstack_input_embeds_0" in res
+    assert "deepstack_input_embeds_0" in res.tensors
 
 
 def test_patched_get_deepstack_fallback():
@@ -119,4 +119,4 @@ def test_patched_get_deepstack_fallback():
 
     res = _patched_get_deepstack(model, orig_get_deepstack, 10)
     assert res is not None
-    assert "layer_0" in res
+    assert "layer_0" in res.tensors

--- a/tpu_inference/models/vllm/experimental/qwen3_vl_patcher.py
+++ b/tpu_inference/models/vllm/experimental/qwen3_vl_patcher.py
@@ -42,9 +42,11 @@ making sure they go through standard function arguments:
 """
 
 import torch
+import torch.nn as nn
 from torchax.interop import jax_view, torch_view
 from vllm.model_executor.models.qwen3_vl import Qwen3VLForConditionalGeneration
 from vllm.sequence import IntermediateTensors
+from vllm.multimodal import NestedTensors
 
 from tpu_inference.distributed.jax_parallel_state import \
     get_pp_group as jax_get_pp_group
@@ -102,6 +104,8 @@ def _patched_get_deepstack(vllm_model, orig_get_deepstack, num_tokens: int):
     # If the cache is empty (e.g., during eager initialization), we fetch the raw vLLM
     # PyTorch tensors and convert them to Torchax tensors to ensure JIT compatibility.
     orig_output = orig_get_deepstack(num_tokens)
+    if orig_output is None:
+        return None
     converted = {
         k: _convert_to_torchax_tensor(v)
         for k, v in orig_output.items()
@@ -200,6 +204,45 @@ def _patched_forward(vllm_model,
                         **kwargs)
 
 
+def _patched_flatten_embeddings(embeddings: NestedTensors) -> torch.Tensor:
+    """Patched version of vLLM's `_flatten_embeddings` to prevent JAX/Torchax ZeroDivisionError.
+
+    Why this patch is necessary:
+    At model warmup/precompilation or during empty multimodal inputs, the sequence dimension
+    can evaluate to 0 (e.g., shape `(num_tokens,)` where `num_tokens=0`, yielding a 1D or empty
+    dimension tensor).
+    
+    When `_flatten_embeddings` calls standard PyTorch `embeddings.flatten(0, -2)` to flatten
+    all but the last dimension, `torchax.Tensor.flatten` fails to map the negative `end_dim=-2`
+    to a positive index (it only maps `end_dim=-1`). This leaves `end_dim=-2` unresolved.
+
+    Under JAX/Torchax tracing:
+    - `end_dim + 1` becomes `-1`.
+    - `self._elem.shape[end_dim + 1 :]` resolves to `shape[-1:]` -> `(0,)` for a 1D or 0-size tensor.
+    - The resulting target shape becomes `(-1, 0)`.
+    - During shape resolution, JAX calculates the product of non-negative dimensions (`0`),
+      and checks `arr.size % math.prod(other_sizes) != 0`, which evaluates to `0 % 0` and
+      raises `ZeroDivisionError: integer modulo by zero`.
+
+    By pre-converting negative `start_dim` and `end_dim` to positive index equivalents based
+    on the tensor's `ndim` before calling `.flatten`, we pass positive arguments to Torchax.
+    This allows it to compute the target shape correctly without producing 0-size dimensions,
+    preventing the JAX compiler from crashing at startup.
+    """
+    if isinstance(embeddings, torch.Tensor):
+        if embeddings.numel() == 0 or 0 in embeddings.shape:
+            return embeddings.view(0, embeddings.shape[-1])
+        ndim = embeddings.ndim
+        start_dim = 0
+        end_dim = -2
+        if start_dim < 0:
+            start_dim += ndim
+        if end_dim < 0:
+            end_dim += ndim
+        return embeddings.flatten(start_dim, end_dim)
+    return torch.cat(tuple(_patched_flatten_embeddings(t) for t in embeddings))
+
+
 def apply_qwen3_vl_patches(vllm_model):
     """Apply Qwen3-VL specific patches for stateless Deepstack support."""
     if not getattr(vllm_model, "use_deepstack", False):
@@ -230,12 +273,19 @@ def apply_qwen3_vl_patches(vllm_model):
     vllm_model.forward = lambda *args, **kwargs: _patched_forward(
         vllm_model, orig_forward, *args, **kwargs)
 
+    # 5. Patch _flatten_embeddings in vllm utils to handle negative indexes correctly in torchax
+    import vllm.model_executor.models.utils as vllm_utils
+    vllm_utils._flatten_embeddings = _patched_flatten_embeddings
+
+    # 6. Force HAS_TRITON to False to prevent JAX/Triton active driver crash on TPU
+    import vllm.model_executor.models.qwen3_vl as qwen3_vl_mod
+    qwen3_vl_mod.HAS_TRITON = False
 
 def is_qwen3_vl(vllm_model) -> bool:
     """Check if the given vLLM model is of architecture Qwen3VLForConditionalGeneration."""
     return isinstance(vllm_model, Qwen3VLForConditionalGeneration)
 
 
-def maybe_apply_qwen3_vl_patches(vllm_model):
+def maybe_apply_qwen3_vl_patches(vllm_model: nn.Module) -> None:
     if is_qwen3_vl(vllm_model):
         apply_qwen3_vl_patches(vllm_model)

--- a/tpu_inference/models/vllm/experimental/qwen3_vl_patcher.py
+++ b/tpu_inference/models/vllm/experimental/qwen3_vl_patcher.py
@@ -43,10 +43,12 @@ making sure they go through standard function arguments:
 
 import torch
 import torch.nn as nn
+import vllm.model_executor.models.qwen3_vl as qwen3_vl_mod
+import vllm.model_executor.models.utils as vllm_utils
 from torchax.interop import jax_view, torch_view
 from vllm.model_executor.models.qwen3_vl import Qwen3VLForConditionalGeneration
-from vllm.sequence import IntermediateTensors
 from vllm.multimodal import NestedTensors
+from vllm.sequence import IntermediateTensors
 
 from tpu_inference.distributed.jax_parallel_state import \
     get_pp_group as jax_get_pp_group
@@ -274,12 +276,11 @@ def apply_qwen3_vl_patches(vllm_model):
         vllm_model, orig_forward, *args, **kwargs)
 
     # 5. Patch _flatten_embeddings in vllm utils to handle negative indexes correctly in torchax
-    import vllm.model_executor.models.utils as vllm_utils
     vllm_utils._flatten_embeddings = _patched_flatten_embeddings
 
     # 6. Force HAS_TRITON to False to prevent JAX/Triton active driver crash on TPU
-    import vllm.model_executor.models.qwen3_vl as qwen3_vl_mod
     qwen3_vl_mod.HAS_TRITON = False
+
 
 def is_qwen3_vl(vllm_model) -> bool:
     """Check if the given vLLM model is of architecture Qwen3VLForConditionalGeneration."""

--- a/tpu_inference/models/vllm/experimental/qwen3_vl_patcher.py
+++ b/tpu_inference/models/vllm/experimental/qwen3_vl_patcher.py
@@ -232,6 +232,8 @@ def _patched_flatten_embeddings(embeddings: NestedTensors) -> torch.Tensor:
     preventing the JAX compiler from crashing at startup.
     """
     if isinstance(embeddings, torch.Tensor):
+        if embeddings.ndim < 2:
+            return embeddings
         if embeddings.numel() == 0 or 0 in embeddings.shape:
             return embeddings.view(0, embeddings.shape[-1])
         ndim = embeddings.ndim

--- a/tpu_inference/runner/compilation_manager.py
+++ b/tpu_inference/runner/compilation_manager.py
@@ -149,17 +149,32 @@ class CompilationManager:
         for num_tokens in self.runner.num_tokens_paddings:
             hidden_size = self.runner.vllm_config.model_config.get_hidden_size(
             )
+            hf_conf = self.runner.vllm_config.model_config.hf_config
+
+            # Identify multimodal embedding size
+            mm_hidden_size = hidden_size
+            vision_config = getattr(hf_conf, "vision_config", None)
+
+            if vision_config:
+                visual_dim = getattr(vision_config, "out_hidden_size", None)
+                deepstack_indexes = getattr(vision_config,
+                                            "deepstack_visual_indexes", None)
+
+                # If both exist, we apply the deepstack concat logic
+                if visual_dim is not None and deepstack_indexes is not None:
+                    deepstack_levels = len(deepstack_indexes)
+                    mm_hidden_size = visual_dim * (1 + deepstack_levels)
+
             sharding = NamedSharding(
                 self.runner.mesh,
                 PartitionSpec(ShardingAxisName.ATTN_DATA, None))
             input_sharding = NamedSharding(
                 self.runner.mesh, PartitionSpec(ShardingAxisName.ATTN_DATA))
 
-            dummy_mm_embeds = self._create_dummy_tensor(
-                (num_tokens, hidden_size),
+            dummy_multimodal_embeddings = self._create_dummy_tensor(
+                (num_tokens, mm_hidden_size),
                 self.runner.vllm_config.model_config.dtype,
                 sharding=sharding)
-            dummy_multimodal_embeddings = [dummy_mm_embeds]
             dummy_input_ids = self._create_dummy_tensor(
                 (num_tokens, ), jnp.int32, sharding=input_sharding)
             dummy_is_multimodal = self._create_dummy_tensor(
@@ -170,7 +185,8 @@ class CompilationManager:
                 self.runner.embed_input_ids_fn,
                 self.runner.state,
                 dummy_input_ids,
-                dummy_multimodal_embeddings,
+                # Make _compute_deepstack_embeds happy. 
+                [dummy_multimodal_embeddings],
                 call_kwargs={"is_multimodal": dummy_is_multimodal},
                 num_tokens=num_tokens,
             )
@@ -474,17 +490,39 @@ class CompilationManager:
     def _precompile_backbone_with_inputs_embeds(self) -> None:
         hidden_size = self.runner.model_config.get_hidden_size()
         dtype = self.runner.model_config.dtype
-        for num_tokens in self.runner.num_tokens_paddings:
-            for num_reqs in self.runner.attn_num_reqs_paddings:
-                sharding = NamedSharding(
-                    self.runner.mesh,
-                    PartitionSpec(ShardingAxisName.ATTN_DATA, None))
-                input_sharding = NamedSharding(
-                    self.runner.mesh,
-                    PartitionSpec(ShardingAxisName.ATTN_DATA))
 
-                inputs_embeds = self._create_dummy_tensor(
-                    (num_tokens, hidden_size), dtype, sharding=sharding)
+        # Identify multimodal embedding size including Deepstack
+        hf_conf = self.runner.vllm_config.model_config.hf_config
+        vision_config = getattr(hf_conf, "vision_config", None)
+        embeds_hidden_size = hidden_size
+
+        if vision_config:
+            visual_dim = getattr(vision_config, "out_hidden_size", None)
+            deepstack_indexes = getattr(vision_config,
+                                        "deepstack_visual_indexes", None)
+
+            # If both exist, we apply the deepstack concat logic
+            if visual_dim is not None and deepstack_indexes is not None:
+                deepstack_levels = len(deepstack_indexes)
+                embeds_hidden_size = visual_dim * (1 + deepstack_levels)
+
+        # Compile for both standard (4k) and Deepstack (16k) dimensions if they differ
+        hidden_sizes_to_compile = [hidden_size]
+        if embeds_hidden_size != hidden_size:
+            hidden_sizes_to_compile.append(embeds_hidden_size)
+
+        for h_size in hidden_sizes_to_compile:
+            for num_tokens in self.runner.num_tokens_paddings:
+                for num_reqs in self.runner.attn_num_reqs_paddings:
+                    sharding = NamedSharding(
+                        self.runner.mesh,
+                        PartitionSpec(ShardingAxisName.ATTN_DATA, None))
+                    input_sharding = NamedSharding(
+                        self.runner.mesh,
+                        PartitionSpec(ShardingAxisName.ATTN_DATA))
+
+                    inputs_embeds = self._create_dummy_tensor(
+                        (num_tokens, h_size), dtype, sharding=sharding)
                 if self.runner.uses_mrope:
                     mrope_sharding = NamedSharding(
                         self.runner.mesh,

--- a/tpu_inference/runner/compilation_manager.py
+++ b/tpu_inference/runner/compilation_manager.py
@@ -185,7 +185,7 @@ class CompilationManager:
                 self.runner.embed_input_ids_fn,
                 self.runner.state,
                 dummy_input_ids,
-                # Make _compute_deepstack_embeds happy. 
+                # Make _compute_deepstack_embeds happy.
                 [dummy_multimodal_embeddings],
                 call_kwargs={"is_multimodal": dummy_is_multimodal},
                 num_tokens=num_tokens,


### PR DESCRIPTION
This commit adds fixes to Qwen3-VL JAX patches for JIT compatibility and stable warmup on TPUs:
1. Support both standard (4k) and Deepstack-concatenated (16k) hidden dimensions in backbone precompilation/warmup.
2. Handle None return values gracefully in _patched_get_deepstack fallback to prevent AttributeError during text-only decode steps.
3. Add unit tests covering all deepstack getter cache and fallback states.

Part of 1 is coping from unmerged change.
https://github.com/vllm-project/tpu-inference/pull/1974/changes

Now Qwen/Qwen3-VL-235B-A22B-Instruct is runnable on multihost

<img width="2447" height="984" alt="image" src="https://github.com/user-attachments/assets/a32c97c1-cbb6-417e-bd28-8cb61ede015d" />
