### PR TITLE
QKVParallelLinear: derive tp size from sharding_config  rather than parallel_config

### DIFF
--- a/tests/layers/vllm/test_qkv_kv_replication.py
+++ b/tests/layers/vllm/test_qkv_kv_replication.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import torch
 
@@ -71,6 +71,67 @@ def test_tile_kv_2d_weight_along_output_dim_0():
     )
     assert out.shape == (16, 3)
     assert torch.equal(out, expected)
+
+
+def _build_qkv(*, tp, total_num_kv_heads, enable_dp_attention):
+    """Construct VllmQKVParallelLinear with parent init stubbed.
+
+    Returns (layer, parent_kv_heads) where `parent_kv_heads` records the
+    (inflated) kv-head count handed to `QKVParallelLinear.__init__`.
+    """
+    cfg = MagicMock()
+    cfg.sharding_config = None
+    cfg.parallel_config.tensor_parallel_size = tp
+    cfg.parallel_config.data_parallel_size = 1
+    cfg.parallel_config.decode_context_parallel_size = 1
+    cfg.model_config.use_mla = False
+    cfg.model_config.get_total_num_kv_heads.return_value = total_num_kv_heads
+    cfg.model_config.get_head_size.return_value = 128
+    cfg.cache_config.cache_dtype = "bfloat16"
+    cfg.speculative_config = None
+    cfg.lora_config = None
+    cfg.additional_config = {
+        "sharding": {
+            "sharding_strategy": {
+                "enable_dp_attention": enable_dp_attention
+            }
+        }
+    }
+
+    parent_kv_heads = []
+    mod = "tpu_inference.layers.vllm.custom_ops.linear"
+    with patch(f"{mod}.QKVParallelLinear.__init__",
+               lambda *args, **_: parent_kv_heads.append(args[4])), \
+         patch(f"{mod}.get_current_vllm_config", return_value=cfg), \
+         patch("tpu_inference.layers.common.sharding.envs.NEW_MODEL_DESIGN", True):
+        layer = VllmQKVParallelLinear(
+            hidden_size=256,
+            head_size=128,
+            total_num_heads=8,
+            total_num_kv_heads=total_num_kv_heads,
+        )
+    return layer, parent_kv_heads
+
+
+def test_replicas_no_dp_attention():
+    # TP=8 > num_kv_heads=2, no DP → replicate each KV head 4x.
+    layer, parent_kv_heads = _build_qkv(tp=8,
+                                        total_num_kv_heads=2,
+                                        enable_dp_attention=False)
+    assert layer.tp_size == 8
+    assert layer.num_kv_head_replicas == 4
+    # Inflated kv-heads passed to parent: 2 * 4 = 8.
+    assert parent_kv_heads == [8]
+
+
+def test_replicas_dp_attention():
+    # TP=8 > num_kv_heads=2, no DP → replicate each KV head 4x.
+    layer, parent_kv_heads = _build_qkv(tp=8,
+                                        total_num_kv_heads=2,
+                                        enable_dp_attention=True)
+    assert layer.tp_size == 2
+    assert layer.num_kv_head_replicas == 1
+    assert parent_kv_heads == [2]
 
 
 def test_tile_kv_along_output_dim_1():

--- a/tests/layers/vllm/test_qkv_kv_replication.py
+++ b/tests/layers/vllm/test_qkv_kv_replication.py
@@ -73,37 +73,24 @@ def test_tile_kv_2d_weight_along_output_dim_0():
     assert torch.equal(out, expected)
 
 
-def _build_qkv(*, tp, total_num_kv_heads, enable_dp_attention):
+def _build_qkv(*, mesh_shape, total_num_kv_heads):
     """Construct VllmQKVParallelLinear with parent init stubbed.
+
+    `mesh_shape` is the dict of mesh-axis → size exposed on
+    `vllm_config.quant_config.mesh.shape`. Only the ATTN_HEAD axes
+    ('model', 'expert', 'dcp') are read by the layer.
 
     Returns (layer, parent_kv_heads) where `parent_kv_heads` records the
     (inflated) kv-head count handed to `QKVParallelLinear.__init__`.
     """
     cfg = MagicMock()
-    cfg.sharding_config = None
-    cfg.parallel_config.tensor_parallel_size = tp
-    cfg.parallel_config.data_parallel_size = 1
-    cfg.parallel_config.decode_context_parallel_size = 1
-    cfg.model_config.use_mla = False
-    cfg.model_config.get_total_num_kv_heads.return_value = total_num_kv_heads
-    cfg.model_config.get_head_size.return_value = 128
-    cfg.cache_config.cache_dtype = "bfloat16"
-    cfg.speculative_config = None
-    cfg.lora_config = None
-    cfg.additional_config = {
-        "sharding": {
-            "sharding_strategy": {
-                "enable_dp_attention": enable_dp_attention
-            }
-        }
-    }
+    cfg.quant_config.mesh.shape = mesh_shape
 
     parent_kv_heads = []
     mod = "tpu_inference.layers.vllm.custom_ops.linear"
     with patch(f"{mod}.QKVParallelLinear.__init__",
                lambda *args, **_: parent_kv_heads.append(args[4])), \
-         patch(f"{mod}.get_current_vllm_config", return_value=cfg), \
-         patch("tpu_inference.layers.common.sharding.envs.NEW_MODEL_DESIGN", True):
+         patch(f"{mod}.get_current_vllm_config", return_value=cfg):
         layer = VllmQKVParallelLinear(
             hidden_size=256,
             head_size=128,
@@ -113,22 +100,20 @@ def _build_qkv(*, tp, total_num_kv_heads, enable_dp_attention):
     return layer, parent_kv_heads
 
 
-def test_replicas_no_dp_attention():
-    # TP=8 > num_kv_heads=2, no DP → replicate each KV head 4x.
-    layer, parent_kv_heads = _build_qkv(tp=8,
-                                        total_num_kv_heads=2,
-                                        enable_dp_attention=False)
+def test_replicas_tp_exceeds_kv_heads():
+    # mesh ATTN_HEAD product = 8 > num_kv_heads=2 → replicate each KV head 4x.
+    layer, parent_kv_heads = _build_qkv(mesh_shape={"model": 8},
+                                        total_num_kv_heads=2)
     assert layer.tp_size == 8
     assert layer.num_kv_head_replicas == 4
     # Inflated kv-heads passed to parent: 2 * 4 = 8.
     assert parent_kv_heads == [8]
 
 
-def test_replicas_dp_attention():
-    # TP=8 > num_kv_heads=2, no DP → replicate each KV head 4x.
-    layer, parent_kv_heads = _build_qkv(tp=8,
-                                        total_num_kv_heads=2,
-                                        enable_dp_attention=True)
+def test_replicas_tp_equals_kv_heads():
+    # mesh ATTN_HEAD product = 2 == num_kv_heads=2 → no replication.
+    layer, parent_kv_heads = _build_qkv(mesh_shape={"model": 2},
+                                        total_num_kv_heads=2)
     assert layer.tp_size == 2
     assert layer.num_kv_head_replicas == 1
     assert parent_kv_heads == [2]

--- a/tests/layers/vllm/test_unquantized.py
+++ b/tests/layers/vllm/test_unquantized.py
@@ -334,6 +334,7 @@ def test_qkv_parallel_linear(model, bias, num_devices, enable_sp, fuse_matmuls,
 
     vllm_config.model_config.dtype = dtype
     quant_config = get_tpu_quantization_config(vllm_config, mesh)
+    vllm_config.quant_config = quant_config
     with set_current_vllm_config(vllm_config):
         jax_qkv_linear = QKVParallelLinear(
             hidden_size=4096,

--- a/tpu_inference/layers/vllm/custom_ops/linear.py
+++ b/tpu_inference/layers/vllm/custom_ops/linear.py
@@ -24,7 +24,8 @@ from vllm.model_executor.layers.linear import (ColumnParallelLinear,
                                                ReplicatedLinear,
                                                RowParallelLinear)
 
-from tpu_inference.layers.common.sharding import ShardingAxisName2D
+from tpu_inference.layers.common.sharding import (ShardingAxisName2D,
+                                                  ShardingConfigManager)
 from tpu_inference.layers.common.utils import (
     reorder_concatenated_tensor_for_sharding,
     slice_sharded_tensor_for_concatenation)
@@ -90,8 +91,10 @@ class VllmQKVParallelLinear(QKVParallelLinear):
                  **kwargs):
         if total_num_kv_heads is None:
             total_num_kv_heads = total_num_heads
-
-        tp = get_current_vllm_config().parallel_config.tensor_parallel_size
+        vllm_config = get_current_vllm_config()
+        sharding_config = (getattr(vllm_config, "sharding_config", None) or
+                           ShardingConfigManager.from_vllm_config(vllm_config))
+        tp = sharding_config.tp_size
         if tp > total_num_kv_heads:
             assert tp % total_num_kv_heads == 0, (
                 f"tp_size ({tp}) must be divisible by total_num_kv_heads "

--- a/tpu_inference/layers/vllm/custom_ops/linear.py
+++ b/tpu_inference/layers/vllm/custom_ops/linear.py
@@ -24,11 +24,11 @@ from vllm.model_executor.layers.linear import (ColumnParallelLinear,
                                                ReplicatedLinear,
                                                RowParallelLinear)
 
-from tpu_inference.layers.common.sharding import (ShardingAxisName2D,
-                                                  ShardingConfigManager)
+from tpu_inference.layers.common.sharding import ShardingAxisName
 from tpu_inference.layers.common.utils import (
     reorder_concatenated_tensor_for_sharding,
     slice_sharded_tensor_for_concatenation)
+from tpu_inference.utils import get_mesh_shape_product
 
 
 @RowParallelLinear.register_oot
@@ -92,9 +92,8 @@ class VllmQKVParallelLinear(QKVParallelLinear):
         if total_num_kv_heads is None:
             total_num_kv_heads = total_num_heads
         vllm_config = get_current_vllm_config()
-        sharding_config = (getattr(vllm_config, "sharding_config", None) or
-                           ShardingConfigManager.from_vllm_config(vllm_config))
-        tp = sharding_config.tp_size
+        tp = get_mesh_shape_product(vllm_config.quant_config.mesh,
+                                    ShardingAxisName.ATTN_HEAD)
         if tp > total_num_kv_heads:
             assert tp % total_num_kv_heads == 0, (
                 f"tp_size ({tp}) must be divisible by total_num_kv_heads "
@@ -167,8 +166,8 @@ class VllmQKVParallelLinear(QKVParallelLinear):
         )
 
         mesh = jax.sharding.get_abstract_mesh()
-        kv_head_axis = ShardingAxisName2D.ATTN_HEAD
-        data_axis = ShardingAxisName2D.ATTN_DATA
+        kv_head_axis = ShardingAxisName.ATTN_HEAD
+        data_axis = ShardingAxisName.ATTN_DATA
         replica_axis = 'replica'
 
         # Split the `kv_head` mesh axis (size kv_size) into a pair

--- a/tpu_inference/layers/vllm/custom_ops/linear.py
+++ b/tpu_inference/layers/vllm/custom_ops/linear.py
@@ -91,16 +91,21 @@ class VllmQKVParallelLinear(QKVParallelLinear):
                  **kwargs):
         if total_num_kv_heads is None:
             total_num_kv_heads = total_num_heads
+        replicas = 1
+
         vllm_config = get_current_vllm_config()
-        tp = get_mesh_shape_product(vllm_config.quant_config.mesh,
-                                    ShardingAxisName.ATTN_HEAD)
+        mesh = vllm_config.quant_config.mesh if vllm_config.quant_config else None
+        if mesh is not None:
+            tp = get_mesh_shape_product(vllm_config.quant_config.mesh,
+                                        ShardingAxisName.ATTN_HEAD)
+        else:
+            tp = 1
+
         if tp > total_num_kv_heads:
             assert tp % total_num_kv_heads == 0, (
                 f"tp_size ({tp}) must be divisible by total_num_kv_heads "
                 f"({total_num_kv_heads}) for KV-head replication")
             replicas = tp // total_num_kv_heads
-        else:
-            replicas = 1
 
         super().__init__(hidden_size, head_size, total_num_heads,
                          total_num_kv_heads * replicas, *args, **kwargs)


### PR DESCRIPTION
# Description

TP size was originally derived from `parallel_config`.  This PR will change it to use `sharding_config` instead.
This is necessary because if attention DP is enabled, TP size will change accordingly. 

https://github.com/vllm-project/tpu-inference/blob/4d54e71116e10e542c257c55916c1fd2dfca7bc1/tpu_inference/platforms/tpu_platform.py#L187


# Tests

Added unit tests on `tests/layers/vllm/test_qkv_kv_replication.py`.

Also conducted a quick smoke test using Qwen/Qwen3.5-35B-A3B-FP8. Specifically,
```
MODEL_IMPL_TYPE=vllm USE_MOE_EP_KERNEL=0 NEW_MODEL_DESIGN=1 vllm serve Qwen/Qwen3.5-35B-A3B-FP8 --max-model-len=9216 --max-num-batched-tokens=1024 --max-num-seqs=64 --no-enable-prefix-caching --gpu-memory-utilization=0.95 --tensor-parallel-size=8 --async-scheduling --port=8000 --language-model-only --enable-auto-tool-choice --tool-call-parser=qwen3_coder --reasoning-parser=qwen3 '--limit-mm-per-prompt={"image": 0, "video": 0}' --kv-cache-dtype=fp8 --enable-expert-parallel '--additional_config={"sharding": {"sharding_strategy": {"enable_dp_attention": true}}}' --mamba-cache-dtype=bfloat16
```
