### PR TITLE
[tests] Pre-warm JAX compilation cache to stabilize cache identity under JAX 0.10

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -52,6 +52,30 @@ def pytest_configure(config):
     )
 
 
+@pytest.fixture(scope="session", autouse=True)
+def _prewarm_jax_compilation_cache():
+    """Initialize the JAX compilation cache once at session start.
+
+    On JAX 0.10, JaxTestCase wraps each test in ``assert_global_configs_unchanged``,
+    which checks that ``jax._src.compilation_cache._cache`` is the same object
+    before and after the test. When ``JAX_COMPILATION_CACHE_DIR`` is set, the
+    cache is lazily initialized on the first JIT call — so the first test to
+    JIT transitions ``_cache`` from ``None`` to an ``LRUCache`` and the helper
+    raises ``AssertionError: Test changed the compilation cache object``.
+
+    Forcing one JIT here ensures ``_cache`` has a stable identity before any
+    test body runs, so the assertion holds across the whole session. No-op if
+    the env var is unset (cache stays ``None`` everywhere) or if JAX/devices
+    are unavailable.
+    """
+    if not os.environ.get("JAX_COMPILATION_CACHE_DIR"):
+        return
+    try:
+        jax.jit(lambda x: x + jax.numpy.float32(1.0))(jax.numpy.float32(0.0))
+    except Exception:
+        pass
+
+
 @pytest.fixture(autouse=True)
 def _handle_disable_jax_cache_marker(request):
     """


### PR DESCRIPTION
## Summary

Adds a session-scoped autouse fixture in `tests/conftest.py` that performs one JIT call at pytest session start when `JAX_COMPILATION_CACHE_DIR` is set, so `jax._src.compilation_cache._cache` has a stable identity before any test body runs.

## Problem

`JaxTestCase` wraps every test in `jax._src.test_util.assert_global_configs_unchanged`. On JAX 0.10 this helper also checks that `jax._src.compilation_cache._cache` is the **same object** before and after the test:

```
jax/_src/test_util.py
    if starting_cache is not ending_cache:
        raise AssertionError(
            f"Test changed the compilation cache object: before test it was "
            f"{starting_cache}, now it is {ending_cache}"
        )
```

PR #2644 set `JAX_COMPILATION_CACHE_DIR` in the CI docker env so the cache is shared across builds. JAX initializes that cache lazily on the **first JIT call**. The first test in the run to JIT therefore transitions `_cache` from `None` → `LRUCache`, and the assertion fires:

```
AssertionError: Test changed the compilation cache object: before test it was None,
now it is <jax._src.lru_cache.LRUCache object at 0x...>
```

## Where it has been observed

| Build | Branch / Trigger | Failing suites |
|---|---|---|
| [#18148](https://buildkite.com/tpu-commons/tpu-inference-ci/builds/18148) | `main` (nightly) | `tpu7x/tpu6e JAX unit tests - kernels`, `... - collective kernels` |
| [#18160](https://buildkite.com/tpu-commons/tpu-inference-ci/builds/18160) | PR re-enabling JAX 0.10 | same |

Failing first-tests in each suite (after which `_cache` is non-None and subsequent tests pass):
- `tests/kernels/fused_gdn_kernel_test.py::FusedGdnKernelTest::test_basic0`
- `tests/kernels/collectives/all_gather_matmul_kernel_test.py::AllGatherMatmulTest::test_all_gather_matmul0`

## Fix

```python
@pytest.fixture(scope="session", autouse=True)
def _prewarm_jax_compilation_cache():
    if not os.environ.get("JAX_COMPILATION_CACHE_DIR"):
        return
    try:
        jax.jit(lambda x: x + jax.numpy.float32(1.0))(jax.numpy.float32(0.0))
    except Exception:
        pass
```

Why this works:
- The single JIT triggers JAX's lazy cache init **before any test body runs**, so `compilation_cache._cache` is already an `LRUCache` by the time `assert_global_configs_unchanged` records `starting_cache`. All subsequent tests then see `starting_cache is ending_cache` (same `LRUCache` instance).
- No-op when `JAX_COMPILATION_CACHE_DIR` is unset (the cache stays `None` everywhere, so there's no transition to worry about).
- Wrapped in `try/except` so that environments without devices don't get masked errors — tests that need devices will fail on their own assertions with clearer messages.

## Why not the existing `@pytest.mark.disable_jax_cache` marker

That marker (also from #2644) is opt-in per test. It would require decorating every `JaxTestCase`-derived first-test in every suite, and future tests would silently break again. The session-level pre-warm is one place, applies globally, and adds no per-test boilerplate.

## Test plan

- [ ] CI runs `tpu7x/tpu6e JAX unit tests - kernels` and `... - collective kernels` green
- [ ] Other unit-test suites continue to pass (no behavior change when env var unset; cache-using tests get the same cache as before)
- [ ] Nightly on `main` after this lands no longer flags these two test classes

## Related

- #2644 — added `JAX_COMPILATION_CACHE_DIR` (the trigger)
- #2683 — re-enable JAX 0.10.0 (the PR that surfaced this in regular builds)