### PR TITLE
[tests] Pre-warm JAX compilation cache to stabilize cache identity

### DIFF
--- a/.buildkite/pipeline_jax.yml
+++ b/.buildkite/pipeline_jax.yml
@@ -179,7 +179,7 @@ steps:
             FILES_CHANGED=$$(buildkite-agent meta-data get "changed_files" --default "" | tr ',' '\n')
             echo "$${FILES_CHANGED}"
 
-            if [[ "$$NIGHTLY" == "1" ]] || echo "$$FILES_CHANGED" | grep -qE '^(tpu_inference/kernels|tests/kernels|requirements.txt)'; then
+            if [[ "$$NIGHTLY" == "1" ]] || echo "$$FILES_CHANGED" | grep -qE '^(tpu_inference/kernels|tests/kernels|tests/conftest.py|requirements.txt)'; then
               .buildkite/scripts/run_in_docker.sh \
                 python3 -m pytest -s -v -x /workspace/tpu_inference/tests/kernels \
                 --ignore=/workspace/tpu_inference/tests/kernels/ragged_paged_attention_kernel_v2_test.py \
@@ -187,7 +187,7 @@ steps:
                 --ignore=/workspace/tpu_inference/tests/kernels/collectives \
                 --ignore=/workspace/tpu_inference/tests/kernels/spmm_v1_test.py
             else
-              echo "Skipping: Step requires either a NIGHTLY build or changes in kernels, kernel tests, or requirements.txt."
+              echo "Skipping: Step requires either a NIGHTLY build or changes in kernels, kernel tests, shared conftest, or requirements.txt."
               exit 0
             fi
 
@@ -206,11 +206,11 @@ steps:
             FILES_CHANGED=$$(buildkite-agent meta-data get "changed_files" --default "" | tr ',' '\n')
             echo "$${FILES_CHANGED}"
 
-            if [[ "$$NIGHTLY" == "1" ]] || echo "$$FILES_CHANGED" | grep -qE '^(tpu_inference/kernels/collectives|tests/kernels/collectives|requirements.txt)'; then
+            if [[ "$$NIGHTLY" == "1" ]] || echo "$$FILES_CHANGED" | grep -qE '^(tpu_inference/kernels/collectives|tests/kernels/collectives|tests/conftest.py|requirements.txt)'; then
               .buildkite/scripts/run_in_docker.sh \
                 python3 -m pytest -s -v -x /workspace/tpu_inference/tests/kernels/collectives
             else
-              echo "Skipping: Step requires either a NIGHTLY build or changes in kernels/collectives, tests, or requirements.txt."
+              echo "Skipping: Step requires either a NIGHTLY build or changes in kernels/collectives, tests, shared conftest, or requirements.txt."
               exit 0
             fi
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -61,13 +61,22 @@ def _prewarm_jax_compilation_cache():
     asserts that `jax._src.compilation_cache._cache` is the same object before
     and after the test. With `JAX_COMPILATION_CACHE_DIR` set, the cache is
     lazily initialized on the first JIT call, so the first test to JIT would
-    transition `_cache` from None to LRUCache and trip the assertion. Forcing
-    one tiny JIT here makes the transition happen at session setup, so
-    `_cache` has a stable identity for every test that follows. Tests that
-    need to opt out can still use the `@pytest.mark.disable_jax_cache` marker.
+    transition `_cache` from None to LRUCache and trip the assertion. Force
+    that initialization at session setup so `_cache` has a stable identity
+    for every test that follows. Tests that need to opt out can still use
+    the `@pytest.mark.disable_jax_cache` marker.
+
+    Use `compilation_cache._initialize_cache()` (JAX's own lazy-init helper)
+    instead of a dummy `jax.jit(...)` because a JIT would also initialize the
+    backend (libtpu on TPU) in the pytest parent process, which conflicts with
+    tests that fork worker processes (e.g. Ray's RayDistributedExecutor, vLLM
+    MultiProcExecutor) and produces `Internal error when accessing libtpu
+    multi-process lockfile`. `_initialize_cache` only constructs the LRUCache
+    object from the configured cache dir — no backend touched.
     """
     if jax.config.jax_compilation_cache_dir:
-        jax.jit(lambda x: x)(0)
+        from jax._src import compilation_cache
+        compilation_cache._initialize_cache()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -52,6 +52,24 @@ def pytest_configure(config):
     )
 
 
+@pytest.fixture(scope="session", autouse=True)
+def _prewarm_jax_compilation_cache():
+    """
+    Pre-warms the JAX compilation cache singleton before any tests run.
+
+    JaxTestCase wraps every test in `assert_global_configs_unchanged`, which
+    asserts that `jax._src.compilation_cache._cache` is the same object before
+    and after the test. With `JAX_COMPILATION_CACHE_DIR` set, the cache is
+    lazily initialized on the first JIT call, so the first test to JIT would
+    transition `_cache` from None to LRUCache and trip the assertion. Forcing
+    one tiny JIT here makes the transition happen at session setup, so
+    `_cache` has a stable identity for every test that follows. Tests that
+    need to opt out can still use the `@pytest.mark.disable_jax_cache` marker.
+    """
+    if jax.config.jax_compilation_cache_dir:
+        jax.jit(lambda x: x)(0)
+
+
 @pytest.fixture(autouse=True)
 def _handle_disable_jax_cache_marker(request):
     """


### PR DESCRIPTION
## Summary

Fixes the four kernel-test failures in recent nightlies caused by `JaxTestCase`'s `assert_global_configs_unchanged` guard tripping on the lazy `compilation_cache._cache` initialization. Approach: add a session-scoped autouse fixture in `tests/conftest.py` that forces one tiny JIT at session setup when `JAX_COMPILATION_CACHE_DIR` is set, so `_cache` has a stable identity before any test body runs.

## Failing jobs being fixed

Nightly [#18148](https://buildkite.com/tpu-commons/tpu-inference-ci/builds/18148) — second consecutive nightly with this pattern (also in #18039):

| Job | First failing test |
|---|---|
| [tpu7x JAX unit tests - kernels](https://buildkite.com/tpu-commons/tpu-inference-ci/builds/18148#019e442f-57f0-49e0-85eb-3d8eba7b24b2) | `tests/kernels/fused_gdn_kernel_test.py::FusedGdnKernelTest::test_basic0` |
| [tpu7x JAX unit tests - collective kernels](https://buildkite.com/tpu-commons/tpu-inference-ci/builds/18148#019e442f-57f1-41e8-a91d-79daf729e1d1) | `tests/kernels/collectives/all_gather_matmul_kernel_test.py::AllGatherMatmulTest::test_all_gather_matmul0` |
| [tpu6e JAX unit tests - kernels](https://buildkite.com/tpu-commons/tpu-inference-ci/builds/18148#019e442f-4e52-4c57-81bc-aaf6db2555ae) | same `fused_gdn_kernel_test.py::test_basic0` |
| [tpu6e JAX unit tests - collective kernels](https://buildkite.com/tpu-commons/tpu-inference-ci/builds/18148#019e442f-4e53-453a-b322-6217483d55d1) | same `all_gather_matmul_kernel_test.py::test_all_gather_matmul0` |

All four end with the same assertion at `jax/_src/test_util.py:1224`:

```
AssertionError: Test changed the compilation cache object: before test it was None,
now it is <jax._src.lru_cache.LRUCache object at 0x...>
```

## Root cause

1. `JaxTestCase` wraps every test in `assert_global_configs_unchanged`. This helper asserts that `jax._src.compilation_cache._cache` is the **same object** before and after the test.
2. The CI docker env exports `JAX_COMPILATION_CACHE_DIR="$LOCAL_JAX_CACHE_DIR"` (added by #2644).
3. JAX initializes `compilation_cache._cache` **lazily** — on the first `jit()` call. The first test in the suite to JIT therefore mutates `_cache` from `None` to `LRUCache(...)` while the helper is watching, and the identity check fires.

The issue is not kernel-specific: any `JaxTestCase`-derived test that runs first in its pytest session would trigger it. Kernel tests are the visible failure today because of how the suites are split.

## Fix

`tests/conftest.py`:

```python
@pytest.fixture(scope="session", autouse=True)
def _prewarm_jax_compilation_cache():
    """Pre-warm JAX compilation cache singleton before any tests run."""
    if jax.config.jax_compilation_cache_dir:
        jax.jit(lambda x: x)(0)
```

A single tiny JIT at session setup forces JAX's lazy `_cache` init to happen **before** any test body executes. `assert_global_configs_unchanged`'s before/after snapshots are then the same `LRUCache` instance for every test, and the guard passes. The persistent cache stays enabled, so tests still benefit from cross-build cache hits.

Tests that need to opt out keep using the existing `@pytest.mark.disable_jax_cache` marker from #2644.

## Gating change

The kernel-job gating regexes in `.buildkite/pipeline_jax.yml` are extended to include `tests/conftest.py`, so a change to the shared conftest triggers both the `kernels` and `collective kernels` jobs on PR validation. Without this, a `tests/conftest.py`-only change would skip both kernel jobs and the fix would be unverified.

## Credit

Approach suggested by @yiw-wang in PR review. (Earlier iterations of this PR tried a kernel-scoped conftest that disabled caching; Yiwei pointed out that the issue is a general `JaxTestCase` limitation, the pre-warm is the right architectural fix, and kernel tests should keep the cache speedup.)

## Test plan

- [ ] Re-run `{tpu6e,tpu7x} JAX unit tests - kernels` and `... - collective kernels` on this PR — expect green.
- [ ] No regression in other suites (the fixture is a no-op when `JAX_COMPILATION_CACHE_DIR` is unset).
- [ ] Follow-up nightly on `main` after merge no longer flags these jobs.

## Related

- #2644 — added `JAX_COMPILATION_CACHE_DIR` (the trigger).
