### PR TITLE
Gemma-4 E4B-it on JAX path

### DIFF
--- a/.buildkite/models/google_gemma-4-E2B-it.yml
+++ b/.buildkite/models/google_gemma-4-E2B-it.yml
@@ -16,12 +16,6 @@
 # gemma-4-it is BOS-sensitive — raw prompts produce token-repetition
 # garbage on both GPU vllm-pytorch and JAX (model property, not a
 # correctness bug in our path).
-#
-# The UnitTest step exercises the vision tower end-to-end via
-# examples/multi_modal_inference_gemma.py (chat-with-image smoke test).
-# Audio is not wired on the JAX path (the gemma4_mm loader skips
-# audio_tower / embed_audio weights and there is no audio_token_id branch
-# in __call__), so we don't test it.
 
 steps:
   - label: "${TPU_VERSION:-tpu6e} Unit tests for google/gemma-4-E2B-it"
@@ -39,7 +33,7 @@ steps:
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh \
-          bash -c 'JITTED_MM_MODULE_KEYS="model.vision_tower.encoder" REGISTER_MM_MODULE_CUSTOM_PYTREE_CLASSES="transformers.modeling_outputs.BaseModelOutputWithPast" SKIP_JAX_PRECOMPILE=1 VLLM_XLA_CHECK_RECOMPILATION=0 python /workspace/tpu_inference/examples/multi_modal_inference_gemma.py --model google/gemma-4-E2B-it --tensor-parallel-size 1 --max-model-len 4096 --max-num-batched-tokens 4096'
+          bash -c 'JITTED_MM_MODULE_KEYS="model.vision_tower.encoder" REGISTER_MM_MODULE_CUSTOM_PYTREE_CLASSES="transformers.modeling_outputs.BaseModelOutputWithPast" SKIP_JAX_PRECOMPILE=1 VLLM_XLA_CHECK_RECOMPILATION=0 python /workspace/tpu_inference/examples/offline_inference.py --model google/gemma-4-E2B-it --tensor-parallel-size 1 --max-num-batched-tokens 4096 --max-model-len 4096 --use-chat-template'
 
   - label: "${TPU_VERSION:-tpu6e} Record unit test result for google/gemma-4-E2B-it"
     key: "${TPU_VERSION:-tpu6e}_record_google_gemma-4-E2B-it_UnitTest"

--- a/.buildkite/models/google_gemma-4-E2B-it.yml
+++ b/.buildkite/models/google_gemma-4-E2B-it.yml
@@ -32,10 +32,6 @@ steps:
     # Both kernels are verified equivalent in BK #459-#462.
     commands:
       - |
-        if pip install "transformers>=5.5.0" --dry-run | grep -q "Would install transformers-"; then
-          buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_google_gemma-4-E2B-it_UnitTest" "transformers version too low"
-          exit 0
-        fi
         .buildkite/scripts/run_in_docker.sh \
           bash -c 'JITTED_MM_MODULE_KEYS="model.vision_tower.encoder" REGISTER_MM_MODULE_CUSTOM_PYTREE_CLASSES="transformers.modeling_outputs.BaseModelOutputWithPast" SKIP_JAX_PRECOMPILE=1 VLLM_XLA_CHECK_RECOMPILATION=0 python /workspace/tpu_inference/examples/offline_inference.py --model google/gemma-4-E2B-it --tensor-parallel-size 1 --max-num-batched-tokens 4096 --max-model-len 4096 --use-chat-template'
 
@@ -46,7 +42,7 @@ steps:
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "google/gemma-4-E2B-it"
       CI_STAGE: "UnitTest"
-      CI_CATEGORY: "multimodal"
+      CI_CATEGORY: "text-only"
     agents:
       queue: cpu
     commands:
@@ -80,7 +76,7 @@ steps:
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "google/gemma-4-E2B-it"
       CI_STAGE: "Accuracy/Correctness"
-      CI_CATEGORY: "multimodal"
+      CI_CATEGORY: "text-only"
     agents:
       queue: cpu
     commands:
@@ -128,7 +124,7 @@ steps:
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "google/gemma-4-E2B-it"
       CI_STAGE: "Benchmark"
-      CI_CATEGORY: "multimodal"
+      CI_CATEGORY: "text-only"
     agents:
       queue: cpu
     commands:

--- a/.buildkite/models/google_gemma-4-E2B-it.yml
+++ b/.buildkite/models/google_gemma-4-E2B-it.yml
@@ -92,13 +92,10 @@ steps:
     env:
       TEST_MODEL: google/gemma-4-E2B-it
       TENSOR_PARALLEL_SIZE: 1
-      # BENCH_DATASET=text routes mm_bench_recipe through the plain-text
-      # "random" dataset, skipping the vision tower entirely. E2B's
-      # generation path is what we want to measure here; the vision tower
-      # is exercised separately by other gemma-4 nightlies.
-      BENCH_DATASET: "text"
-      INPUT_LEN: "1024"
-      OUTPUT_LEN: "128"
+      # BENCH_DATASET unset -> mm_bench_recipe.sh defaults to the random-mm
+      # dataset (6 images @ 736x736 per prompt, 128 prompts), exercising
+      # the vision tower end-to-end. Validated on both v6e (TP=1) and v7x_2
+      # (TP=2) in tpu-inference-dev #475.
       # v6e is memory-tight: default mm_bench_recipe (max_model_len=16384,
       # max_num_seqs=256) OOMs during the jit_structured_decode_fn precompile
       # (needs ~384M reservable, v6e has ~380M free at that point). The 4096
@@ -112,6 +109,7 @@ steps:
       # headroom for both kernels.
       GPU_MEMORY_UTILIZATION: "0.94"
       # No perf bar to start. Set after first measured run.
+      # Dev #475 measurements: req/s = 2.57 (v6e), 3.03 (v7x_2).
       MINIMUM_THROUGHPUT_THRESHOLD: 0.0
     commands:
       - |

--- a/.buildkite/models/google_gemma-4-E2B-it.yml
+++ b/.buildkite/models/google_gemma-4-E2B-it.yml
@@ -16,6 +16,12 @@
 # gemma-4-it is BOS-sensitive — raw prompts produce token-repetition
 # garbage on both GPU vllm-pytorch and JAX (model property, not a
 # correctness bug in our path).
+#
+# The UnitTest step exercises the vision tower end-to-end via
+# examples/multi_modal_inference_gemma.py (chat-with-image smoke test).
+# Audio is not wired on the JAX path (the gemma4_mm loader skips
+# audio_tower / embed_audio weights and there is no audio_token_id branch
+# in __call__), so we don't test it.
 
 steps:
   - label: "${TPU_VERSION:-tpu6e} Unit tests for google/gemma-4-E2B-it"
@@ -33,7 +39,7 @@ steps:
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh \
-          bash -c 'JITTED_MM_MODULE_KEYS="model.vision_tower.encoder" REGISTER_MM_MODULE_CUSTOM_PYTREE_CLASSES="transformers.modeling_outputs.BaseModelOutputWithPast" SKIP_JAX_PRECOMPILE=1 VLLM_XLA_CHECK_RECOMPILATION=0 python /workspace/tpu_inference/examples/offline_inference.py --model google/gemma-4-E2B-it --tensor-parallel-size 1 --max-num-batched-tokens 4096 --max-model-len 4096 --use-chat-template'
+          bash -c 'JITTED_MM_MODULE_KEYS="model.vision_tower.encoder" REGISTER_MM_MODULE_CUSTOM_PYTREE_CLASSES="transformers.modeling_outputs.BaseModelOutputWithPast" SKIP_JAX_PRECOMPILE=1 VLLM_XLA_CHECK_RECOMPILATION=0 python /workspace/tpu_inference/examples/multi_modal_inference_gemma.py --model google/gemma-4-E2B-it --tensor-parallel-size 1 --max-model-len 4096 --max-num-batched-tokens 4096'
 
   - label: "${TPU_VERSION:-tpu6e} Record unit test result for google/gemma-4-E2B-it"
     key: "${TPU_VERSION:-tpu6e}_record_google_gemma-4-E2B-it_UnitTest"
@@ -42,7 +48,7 @@ steps:
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "google/gemma-4-E2B-it"
       CI_STAGE: "UnitTest"
-      CI_CATEGORY: "text-only"
+      CI_CATEGORY: "multimodal"
     agents:
       queue: cpu
     commands:
@@ -76,7 +82,7 @@ steps:
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "google/gemma-4-E2B-it"
       CI_STAGE: "Accuracy/Correctness"
-      CI_CATEGORY: "text-only"
+      CI_CATEGORY: "multimodal"
     agents:
       queue: cpu
     commands:
@@ -124,7 +130,7 @@ steps:
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "google/gemma-4-E2B-it"
       CI_STAGE: "Benchmark"
-      CI_CATEGORY: "text-only"
+      CI_CATEGORY: "multimodal"
     agents:
       queue: cpu
     commands:

--- a/.buildkite/models/google_gemma-4-E4B-it.yml
+++ b/.buildkite/models/google_gemma-4-E4B-it.yml
@@ -90,13 +90,10 @@ steps:
     env:
       TEST_MODEL: google/gemma-4-E4B-it
       TENSOR_PARALLEL_SIZE: "${TENSOR_PARALLEL_SIZE_SINGLE:-1}"
-      # BENCH_DATASET=text routes mm_bench_recipe through the plain-text
-      # "random" dataset, skipping the vision tower entirely. E4B's
-      # generation path is what we want to measure here; the vision tower
-      # is exercised separately by other gemma-4 nightlies.
-      BENCH_DATASET: "text"
-      INPUT_LEN: "1024"
-      OUTPUT_LEN: "128"
+      # BENCH_DATASET unset -> mm_bench_recipe.sh defaults to the random-mm
+      # dataset (6 images @ 736x736 per prompt, 128 prompts), exercising
+      # the vision tower end-to-end. Validated on both v6e (TP=1) and v7x_2
+      # (TP=2) in tpu-inference-dev #475.
       MAX_MODEL_LEN: "4096"
       MAX_NUM_SEQS: "64"
       # 0.85 was the most permissive value at which both v6e TP=1 and
@@ -107,6 +104,7 @@ steps:
       # measured workload needs longer context.
       GPU_MEMORY_UTILIZATION: "0.85"
       # No perf bar to start. Set after first measured run.
+      # Dev #475 measurements: req/s = 2.40 (v6e), 2.88 (v7x_2).
       MINIMUM_THROUGHPUT_THRESHOLD: 0.0
     commands:
       - |

--- a/.buildkite/models/google_gemma-4-E4B-it.yml
+++ b/.buildkite/models/google_gemma-4-E4B-it.yml
@@ -12,34 +12,30 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# E4B is ~2x the params of E2B. Both v6e (TP=1, single chip) and v7x_2
-# (TP=2) are verified to work; v7x_2 is faster but v6e is the cheaper
-# fallback. The TENSOR_PARALLEL_SIZE / TPU_QUEUE_SINGLE / TPU_VERSION
-# placeholders are filled by upload_models_and_features.sh at upload time
+# E4B is ~2x the params of E2B. v6e (TP=1, single chip) is the default
+# topology; v7x_2 (TP=2) is also verified and runs faster. The
+# TENSOR_PARALLEL_SIZE / TPU_QUEUE_SINGLE / TPU_VERSION placeholders are
+# filled by upload_models_and_features.sh at upload time
 # (TENSOR_PARALLEL_SIZE_SINGLE=1 for v6e, =2 for v7x).
 # Uses --use-chat-template because gemma-4-it is BOS-sensitive — raw
 # prompts produce token-repetition garbage on both GPU vllm-pytorch and JAX.
 
 steps:
-  - label: "${TPU_VERSION:-tpu7x} Unit tests for google/gemma-4-E4B-it"
-    key: "${TPU_VERSION:-tpu7x}_google_gemma-4-E4B-it_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} Unit tests for google/gemma-4-E4B-it"
+    key: "${TPU_VERSION:-tpu6e}_google_gemma-4-E4B-it_UnitTest"
     agents:
-      queue: "${TPU_QUEUE_SINGLE:-tpu_v7x_2_queue}"
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     soft_fail: true
     commands:
       - |
-        if pip install "transformers>=5.5.0" --dry-run | grep -q "Would install transformers-"; then
-          buildkite-agent meta-data set "${TPU_VERSION:-tpu7x}_google_gemma-4-E4B-it_UnitTest" "transformers version too low"
-          exit 0
-        fi
         .buildkite/scripts/run_in_docker.sh \
-          bash -c 'JITTED_MM_MODULE_KEYS="model.vision_tower.encoder" REGISTER_MM_MODULE_CUSTOM_PYTREE_CLASSES="transformers.modeling_outputs.BaseModelOutputWithPast" SKIP_JAX_PRECOMPILE=1 VLLM_XLA_CHECK_RECOMPILATION=0 python /workspace/tpu_inference/examples/offline_inference.py --model google/gemma-4-E4B-it --tensor-parallel-size ${TENSOR_PARALLEL_SIZE_SINGLE:-2} --max-num-batched-tokens 4096 --max-model-len 4096 --use-chat-template'
+          bash -c 'JITTED_MM_MODULE_KEYS="model.vision_tower.encoder" REGISTER_MM_MODULE_CUSTOM_PYTREE_CLASSES="transformers.modeling_outputs.BaseModelOutputWithPast" SKIP_JAX_PRECOMPILE=1 VLLM_XLA_CHECK_RECOMPILATION=0 python /workspace/tpu_inference/examples/offline_inference.py --model google/gemma-4-E4B-it --tensor-parallel-size ${TENSOR_PARALLEL_SIZE_SINGLE:-1} --max-num-batched-tokens 4096 --max-model-len 4096 --use-chat-template'
 
-  - label: "${TPU_VERSION:-tpu7x} Record unit test result for google/gemma-4-E4B-it"
-    key: "${TPU_VERSION:-tpu7x}_record_google_gemma-4-E4B-it_UnitTest"
-    depends_on: "${TPU_VERSION:-tpu7x}_google_gemma-4-E4B-it_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} Record unit test result for google/gemma-4-E4B-it"
+    key: "${TPU_VERSION:-tpu6e}_record_google_gemma-4-E4B-it_UnitTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_google_gemma-4-E4B-it_UnitTest"
     env:
-      CI_TPU_VERSION: "${TPU_VERSION:-tpu7x}"
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "google/gemma-4-E4B-it"
       CI_STAGE: "UnitTest"
       CI_CATEGORY: "multimodal"
@@ -47,35 +43,35 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu7x}_google_gemma-4-E4B-it_UnitTest
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_google_gemma-4-E4B-it_UnitTest
 
-  - label: "${TPU_VERSION:-tpu7x} Accuracy for google/gemma-4-E4B-it"
-    key: "${TPU_VERSION:-tpu7x}_google_gemma-4-E4B-it_Accuracy"
-    depends_on: "${TPU_VERSION:-tpu7x}_record_google_gemma-4-E4B-it_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} Accuracy for google/gemma-4-E4B-it"
+    key: "${TPU_VERSION:-tpu6e}_google_gemma-4-E4B-it_Accuracy"
+    depends_on: "${TPU_VERSION:-tpu6e}_record_google_gemma-4-E4B-it_UnitTest"
     agents:
-      queue: "${TPU_QUEUE_SINGLE:-tpu_v7x_2_queue}"
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     soft_fail: true
     env:
       TEST_MODEL: google/gemma-4-E4B-it
-      TENSOR_PARALLEL_SIZE: "${TENSOR_PARALLEL_SIZE_SINGLE:-2}"
+      TENSOR_PARALLEL_SIZE: "${TENSOR_PARALLEL_SIZE_SINGLE:-1}"
       # USE_CHAT_TEMPLATE=1 routes lm_eval through apply_chat_template +
       # fewshot_as_multiturn. Required for gemma-4-it because the model is
       # BOS/chat-template-sensitive — raw prompts produce token-repetition
       # garbage. Floor below is set from the minimum chat-templated
-      # measurement × 0.7 across topologies in BK dev #473
+      # measurement × ~0.92 across topologies in BK dev #473
       # (min strict-match = 0.7074 on v6e TP=1; v6e_8 TP=8 and v7x_2 TP=2
       # both scored 0.7119-0.7127).
       USE_CHAT_TEMPLATE: "1"
-      MINIMUM_ACCURACY_THRESHOLD: 0.49
+      MINIMUM_ACCURACY_THRESHOLD: 0.65
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh bash -c 'bash /workspace/tpu_inference/tests/e2e/benchmarking/test_accuracy.sh'
 
-  - label: "${TPU_VERSION:-tpu7x} Record integration test result for google/gemma-4-E4B-it"
-    key: "${TPU_VERSION:-tpu7x}_record_google_gemma-4-E4B-it_Accuracy"
-    depends_on: "${TPU_VERSION:-tpu7x}_google_gemma-4-E4B-it_Accuracy"
+  - label: "${TPU_VERSION:-tpu6e} Record integration test result for google/gemma-4-E4B-it"
+    key: "${TPU_VERSION:-tpu6e}_record_google_gemma-4-E4B-it_Accuracy"
+    depends_on: "${TPU_VERSION:-tpu6e}_google_gemma-4-E4B-it_Accuracy"
     env:
-      CI_TPU_VERSION: "${TPU_VERSION:-tpu7x}"
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "google/gemma-4-E4B-it"
       CI_STAGE: "Accuracy/Correctness"
       CI_CATEGORY: "multimodal"
@@ -83,17 +79,17 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu7x}_google_gemma-4-E4B-it_Accuracy
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_google_gemma-4-E4B-it_Accuracy
 
-  - label: "${TPU_VERSION:-tpu7x} Performance benchmarks for google/gemma-4-E4B-it"
-    key: "${TPU_VERSION:-tpu7x}_google_gemma-4-E4B-it_Benchmark"
-    depends_on: "${TPU_VERSION:-tpu7x}_record_google_gemma-4-E4B-it_Accuracy"
+  - label: "${TPU_VERSION:-tpu6e} Performance benchmarks for google/gemma-4-E4B-it"
+    key: "${TPU_VERSION:-tpu6e}_google_gemma-4-E4B-it_Benchmark"
+    depends_on: "${TPU_VERSION:-tpu6e}_record_google_gemma-4-E4B-it_Accuracy"
     agents:
-      queue: "${TPU_QUEUE_SINGLE:-tpu_v7x_2_queue}"
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     soft_fail: true
     env:
       TEST_MODEL: google/gemma-4-E4B-it
-      TENSOR_PARALLEL_SIZE: "${TENSOR_PARALLEL_SIZE_SINGLE:-2}"
+      TENSOR_PARALLEL_SIZE: "${TENSOR_PARALLEL_SIZE_SINGLE:-1}"
       # BENCH_DATASET=text routes mm_bench_recipe through the plain-text
       # "random" dataset, skipping the vision tower entirely. E4B's
       # generation path is what we want to measure here; the vision tower
@@ -116,11 +112,11 @@ steps:
       - |
         .buildkite/scripts/run_in_docker.sh bash -c 'TIMEOUT_SECONDS=960 JITTED_MM_MODULE_KEYS="model.vision_tower.encoder" REGISTER_MM_MODULE_CUSTOM_PYTREE_CLASSES="transformers.modeling_outputs.BaseModelOutputWithPast" /workspace/tpu_inference/tests/e2e/benchmarking/mm_bench_recipe.sh'
 
-  - label: "${TPU_VERSION:-tpu7x} Record performance benchmark result for google/gemma-4-E4B-it"
-    key: "${TPU_VERSION:-tpu7x}_record_google_gemma-4-E4B-it_Benchmark"
-    depends_on: "${TPU_VERSION:-tpu7x}_google_gemma-4-E4B-it_Benchmark"
+  - label: "${TPU_VERSION:-tpu6e} Record performance benchmark result for google/gemma-4-E4B-it"
+    key: "${TPU_VERSION:-tpu6e}_record_google_gemma-4-E4B-it_Benchmark"
+    depends_on: "${TPU_VERSION:-tpu6e}_google_gemma-4-E4B-it_Benchmark"
     env:
-      CI_TPU_VERSION: "${TPU_VERSION:-tpu7x}"
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "google/gemma-4-E4B-it"
       CI_STAGE: "Benchmark"
       CI_CATEGORY: "multimodal"
@@ -128,4 +124,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu7x}_google_gemma-4-E4B-it_Benchmark
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_google_gemma-4-E4B-it_Benchmark

--- a/.buildkite/models/google_gemma-4-E4B-it.yml
+++ b/.buildkite/models/google_gemma-4-E4B-it.yml
@@ -1,0 +1,131 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# E4B is ~2x the params of E2B. Both v6e (TP=1, single chip) and v7x_2
+# (TP=2) are verified to work; v7x_2 is faster but v6e is the cheaper
+# fallback. The TENSOR_PARALLEL_SIZE / TPU_QUEUE_SINGLE / TPU_VERSION
+# placeholders are filled by upload_models_and_features.sh at upload time
+# (TENSOR_PARALLEL_SIZE_SINGLE=1 for v6e, =2 for v7x).
+# Uses --use-chat-template because gemma-4-it is BOS-sensitive — raw
+# prompts produce token-repetition garbage on both GPU vllm-pytorch and JAX.
+
+steps:
+  - label: "${TPU_VERSION:-tpu7x} Unit tests for google/gemma-4-E4B-it"
+    key: "${TPU_VERSION:-tpu7x}_google_gemma-4-E4B-it_UnitTest"
+    agents:
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v7x_2_queue}"
+    soft_fail: true
+    commands:
+      - |
+        if pip install "transformers>=5.5.0" --dry-run | grep -q "Would install transformers-"; then
+          buildkite-agent meta-data set "${TPU_VERSION:-tpu7x}_google_gemma-4-E4B-it_UnitTest" "transformers version too low"
+          exit 0
+        fi
+        .buildkite/scripts/run_in_docker.sh \
+          bash -c 'JITTED_MM_MODULE_KEYS="model.vision_tower.encoder" REGISTER_MM_MODULE_CUSTOM_PYTREE_CLASSES="transformers.modeling_outputs.BaseModelOutputWithPast" SKIP_JAX_PRECOMPILE=1 VLLM_XLA_CHECK_RECOMPILATION=0 python /workspace/tpu_inference/examples/offline_inference.py --model google/gemma-4-E4B-it --tensor-parallel-size ${TENSOR_PARALLEL_SIZE_SINGLE:-2} --max-num-batched-tokens 4096 --max-model-len 4096 --use-chat-template'
+
+  - label: "${TPU_VERSION:-tpu7x} Record unit test result for google/gemma-4-E4B-it"
+    key: "${TPU_VERSION:-tpu7x}_record_google_gemma-4-E4B-it_UnitTest"
+    depends_on: "${TPU_VERSION:-tpu7x}_google_gemma-4-E4B-it_UnitTest"
+    env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu7x}"
+      CI_TARGET: "google/gemma-4-E4B-it"
+      CI_STAGE: "UnitTest"
+      CI_CATEGORY: "multimodal"
+    agents:
+      queue: cpu
+    commands:
+      - |
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu7x}_google_gemma-4-E4B-it_UnitTest
+
+  - label: "${TPU_VERSION:-tpu7x} Accuracy for google/gemma-4-E4B-it"
+    key: "${TPU_VERSION:-tpu7x}_google_gemma-4-E4B-it_Accuracy"
+    depends_on: "${TPU_VERSION:-tpu7x}_record_google_gemma-4-E4B-it_UnitTest"
+    agents:
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v7x_2_queue}"
+    soft_fail: true
+    env:
+      TEST_MODEL: google/gemma-4-E4B-it
+      TENSOR_PARALLEL_SIZE: "${TENSOR_PARALLEL_SIZE_SINGLE:-2}"
+      # USE_CHAT_TEMPLATE=1 routes lm_eval through apply_chat_template +
+      # fewshot_as_multiturn. Required for gemma-4-it because the model is
+      # BOS/chat-template-sensitive — raw prompts produce token-repetition
+      # garbage. Floor below is set from the minimum chat-templated
+      # measurement × 0.7 across topologies in BK dev #473
+      # (min strict-match = 0.7074 on v6e TP=1; v6e_8 TP=8 and v7x_2 TP=2
+      # both scored 0.7119-0.7127).
+      USE_CHAT_TEMPLATE: "1"
+      MINIMUM_ACCURACY_THRESHOLD: 0.49
+    commands:
+      - |
+        .buildkite/scripts/run_in_docker.sh bash -c 'bash /workspace/tpu_inference/tests/e2e/benchmarking/test_accuracy.sh'
+
+  - label: "${TPU_VERSION:-tpu7x} Record integration test result for google/gemma-4-E4B-it"
+    key: "${TPU_VERSION:-tpu7x}_record_google_gemma-4-E4B-it_Accuracy"
+    depends_on: "${TPU_VERSION:-tpu7x}_google_gemma-4-E4B-it_Accuracy"
+    env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu7x}"
+      CI_TARGET: "google/gemma-4-E4B-it"
+      CI_STAGE: "Accuracy/Correctness"
+      CI_CATEGORY: "multimodal"
+    agents:
+      queue: cpu
+    commands:
+      - |
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu7x}_google_gemma-4-E4B-it_Accuracy
+
+  - label: "${TPU_VERSION:-tpu7x} Performance benchmarks for google/gemma-4-E4B-it"
+    key: "${TPU_VERSION:-tpu7x}_google_gemma-4-E4B-it_Benchmark"
+    depends_on: "${TPU_VERSION:-tpu7x}_record_google_gemma-4-E4B-it_Accuracy"
+    agents:
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v7x_2_queue}"
+    soft_fail: true
+    env:
+      TEST_MODEL: google/gemma-4-E4B-it
+      TENSOR_PARALLEL_SIZE: "${TENSOR_PARALLEL_SIZE_SINGLE:-2}"
+      # BENCH_DATASET=text routes mm_bench_recipe through the plain-text
+      # "random" dataset, skipping the vision tower entirely. E4B's
+      # generation path is what we want to measure here; the vision tower
+      # is exercised separately by other gemma-4 nightlies.
+      BENCH_DATASET: "text"
+      INPUT_LEN: "1024"
+      OUTPUT_LEN: "128"
+      MAX_MODEL_LEN: "4096"
+      MAX_NUM_SEQS: "64"
+      # 0.85 was the most permissive value at which both v6e TP=1 and
+      # v7x_2 TP=2 cleanly completed `vllm serve` + `vllm bench serve`
+      # without OOM in BK dev #473. v6e TP=1 is the tighter constraint
+      # (one chip, ~10GB weights + KV + JIT precompile); 0.85 leaves
+      # enough headroom for `jit_structured_decode_fn` there. Bump if a
+      # measured workload needs longer context.
+      GPU_MEMORY_UTILIZATION: "0.85"
+      # No perf bar to start. Set after first measured run.
+      MINIMUM_THROUGHPUT_THRESHOLD: 0.0
+    commands:
+      - |
+        .buildkite/scripts/run_in_docker.sh bash -c 'TIMEOUT_SECONDS=960 JITTED_MM_MODULE_KEYS="model.vision_tower.encoder" REGISTER_MM_MODULE_CUSTOM_PYTREE_CLASSES="transformers.modeling_outputs.BaseModelOutputWithPast" /workspace/tpu_inference/tests/e2e/benchmarking/mm_bench_recipe.sh'
+
+  - label: "${TPU_VERSION:-tpu7x} Record performance benchmark result for google/gemma-4-E4B-it"
+    key: "${TPU_VERSION:-tpu7x}_record_google_gemma-4-E4B-it_Benchmark"
+    depends_on: "${TPU_VERSION:-tpu7x}_google_gemma-4-E4B-it_Benchmark"
+    env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu7x}"
+      CI_TARGET: "google/gemma-4-E4B-it"
+      CI_STAGE: "Benchmark"
+      CI_CATEGORY: "multimodal"
+    agents:
+      queue: cpu
+    commands:
+      - |
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu7x}_google_gemma-4-E4B-it_Benchmark

--- a/.buildkite/models/google_gemma-4-E4B-it.yml
+++ b/.buildkite/models/google_gemma-4-E4B-it.yml
@@ -19,12 +19,6 @@
 # (TENSOR_PARALLEL_SIZE_SINGLE=1 for v6e, =2 for v7x).
 # Uses --use-chat-template because gemma-4-it is BOS-sensitive — raw
 # prompts produce token-repetition garbage on both GPU vllm-pytorch and JAX.
-#
-# The UnitTest step exercises the vision tower end-to-end via
-# examples/multi_modal_inference_gemma.py (chat-with-image smoke test).
-# Audio is not wired on the JAX path (the gemma4_mm loader skips
-# audio_tower / embed_audio weights and there is no audio_token_id branch
-# in __call__), so we don't test it.
 
 steps:
   - label: "${TPU_VERSION:-tpu6e} Unit tests for google/gemma-4-E4B-it"
@@ -35,7 +29,7 @@ steps:
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh \
-          bash -c 'JITTED_MM_MODULE_KEYS="model.vision_tower.encoder" REGISTER_MM_MODULE_CUSTOM_PYTREE_CLASSES="transformers.modeling_outputs.BaseModelOutputWithPast" SKIP_JAX_PRECOMPILE=1 VLLM_XLA_CHECK_RECOMPILATION=0 python /workspace/tpu_inference/examples/multi_modal_inference_gemma.py --model google/gemma-4-E4B-it --tensor-parallel-size ${TENSOR_PARALLEL_SIZE_SINGLE:-1} --max-model-len 4096 --max-num-batched-tokens 4096'
+          bash -c 'JITTED_MM_MODULE_KEYS="model.vision_tower.encoder" REGISTER_MM_MODULE_CUSTOM_PYTREE_CLASSES="transformers.modeling_outputs.BaseModelOutputWithPast" SKIP_JAX_PRECOMPILE=1 VLLM_XLA_CHECK_RECOMPILATION=0 python /workspace/tpu_inference/examples/offline_inference.py --model google/gemma-4-E4B-it --tensor-parallel-size ${TENSOR_PARALLEL_SIZE_SINGLE:-1} --max-num-batched-tokens 4096 --max-model-len 4096 --use-chat-template'
 
   - label: "${TPU_VERSION:-tpu6e} Record unit test result for google/gemma-4-E4B-it"
     key: "${TPU_VERSION:-tpu6e}_record_google_gemma-4-E4B-it_UnitTest"

--- a/.buildkite/models/google_gemma-4-E4B-it.yml
+++ b/.buildkite/models/google_gemma-4-E4B-it.yml
@@ -38,7 +38,7 @@ steps:
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "google/gemma-4-E4B-it"
       CI_STAGE: "UnitTest"
-      CI_CATEGORY: "multimodal"
+      CI_CATEGORY: "text-only"
     agents:
       queue: cpu
     commands:
@@ -74,7 +74,7 @@ steps:
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "google/gemma-4-E4B-it"
       CI_STAGE: "Accuracy/Correctness"
-      CI_CATEGORY: "multimodal"
+      CI_CATEGORY: "text-only"
     agents:
       queue: cpu
     commands:
@@ -119,7 +119,7 @@ steps:
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "google/gemma-4-E4B-it"
       CI_STAGE: "Benchmark"
-      CI_CATEGORY: "multimodal"
+      CI_CATEGORY: "text-only"
     agents:
       queue: cpu
     commands:

--- a/.buildkite/models/google_gemma-4-E4B-it.yml
+++ b/.buildkite/models/google_gemma-4-E4B-it.yml
@@ -19,6 +19,12 @@
 # (TENSOR_PARALLEL_SIZE_SINGLE=1 for v6e, =2 for v7x).
 # Uses --use-chat-template because gemma-4-it is BOS-sensitive — raw
 # prompts produce token-repetition garbage on both GPU vllm-pytorch and JAX.
+#
+# The UnitTest step exercises the vision tower end-to-end via
+# examples/multi_modal_inference_gemma.py (chat-with-image smoke test).
+# Audio is not wired on the JAX path (the gemma4_mm loader skips
+# audio_tower / embed_audio weights and there is no audio_token_id branch
+# in __call__), so we don't test it.
 
 steps:
   - label: "${TPU_VERSION:-tpu6e} Unit tests for google/gemma-4-E4B-it"
@@ -29,7 +35,7 @@ steps:
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh \
-          bash -c 'JITTED_MM_MODULE_KEYS="model.vision_tower.encoder" REGISTER_MM_MODULE_CUSTOM_PYTREE_CLASSES="transformers.modeling_outputs.BaseModelOutputWithPast" SKIP_JAX_PRECOMPILE=1 VLLM_XLA_CHECK_RECOMPILATION=0 python /workspace/tpu_inference/examples/offline_inference.py --model google/gemma-4-E4B-it --tensor-parallel-size ${TENSOR_PARALLEL_SIZE_SINGLE:-1} --max-num-batched-tokens 4096 --max-model-len 4096 --use-chat-template'
+          bash -c 'JITTED_MM_MODULE_KEYS="model.vision_tower.encoder" REGISTER_MM_MODULE_CUSTOM_PYTREE_CLASSES="transformers.modeling_outputs.BaseModelOutputWithPast" SKIP_JAX_PRECOMPILE=1 VLLM_XLA_CHECK_RECOMPILATION=0 python /workspace/tpu_inference/examples/multi_modal_inference_gemma.py --model google/gemma-4-E4B-it --tensor-parallel-size ${TENSOR_PARALLEL_SIZE_SINGLE:-1} --max-model-len 4096 --max-num-batched-tokens 4096'
 
   - label: "${TPU_VERSION:-tpu6e} Record unit test result for google/gemma-4-E4B-it"
     key: "${TPU_VERSION:-tpu6e}_record_google_gemma-4-E4B-it_UnitTest"
@@ -38,7 +44,7 @@ steps:
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "google/gemma-4-E4B-it"
       CI_STAGE: "UnitTest"
-      CI_CATEGORY: "text-only"
+      CI_CATEGORY: "multimodal"
     agents:
       queue: cpu
     commands:
@@ -74,7 +80,7 @@ steps:
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "google/gemma-4-E4B-it"
       CI_STAGE: "Accuracy/Correctness"
-      CI_CATEGORY: "text-only"
+      CI_CATEGORY: "multimodal"
     agents:
       queue: cpu
     commands:
@@ -119,7 +125,7 @@ steps:
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "google/gemma-4-E4B-it"
       CI_STAGE: "Benchmark"
-      CI_CATEGORY: "text-only"
+      CI_CATEGORY: "multimodal"
     agents:
       queue: cpu
     commands:

--- a/examples/multi_modal_inference_gemma.py
+++ b/examples/multi_modal_inference_gemma.py
@@ -1,5 +1,16 @@
-# SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """Vision smoke test for Gemma-4 multimodal checkpoints on the JAX path.
 
 Loads the requested gemma-4-*-it model, runs a single chat-with-image

--- a/examples/multi_modal_inference_gemma.py
+++ b/examples/multi_modal_inference_gemma.py
@@ -1,0 +1,75 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Vision smoke test for Gemma-4 multimodal checkpoints on the JAX path.
+
+Loads the requested gemma-4-*-it model, runs a single chat-with-image
+request against the vllm `cherry_blossom` asset, and asserts that the
+generation is non-empty. Exits non-zero on any failure so the surrounding
+CI step fails fast.
+
+Example:
+  python examples/multi_modal_inference_gemma.py \\
+    --model google/gemma-4-E4B-it \\
+    --tensor-parallel-size 1
+"""
+
+import argparse
+
+from vllm import LLM, SamplingParams
+from vllm.assets.image import ImageAsset
+from vllm.multimodal.image import convert_image_mode
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--tensor-parallel-size", type=int, default=1)
+    parser.add_argument("--max-model-len", type=int, default=4096)
+    parser.add_argument("--max-num-batched-tokens", type=int, default=4096)
+    parser.add_argument("--max-num-seqs", type=int, default=4)
+    parser.add_argument("--gpu-memory-utilization", type=float, default=0.85)
+    parser.add_argument("--max-tokens", type=int, default=64)
+    args = parser.parse_args()
+
+    llm = LLM(
+        model=args.model,
+        tensor_parallel_size=args.tensor_parallel_size,
+        max_model_len=args.max_model_len,
+        max_num_batched_tokens=args.max_num_batched_tokens,
+        max_num_seqs=args.max_num_seqs,
+        gpu_memory_utilization=args.gpu_memory_utilization,
+        limit_mm_per_prompt={"image": 1},
+        disable_chunked_mm_input=True,
+    )
+
+    img = convert_image_mode(ImageAsset("cherry_blossom").pil_image, "RGB")
+    messages = [{
+        "role":
+        "user",
+        "content": [
+            {
+                "type": "image_pil",
+                "image_pil": img
+            },
+            {
+                "type": "text",
+                "text": "Describe what is in this image in one sentence."
+            },
+        ],
+    }]
+
+    outputs = llm.chat(
+        messages=messages,
+        sampling_params=SamplingParams(temperature=0.0,
+                                       max_tokens=args.max_tokens),
+    )
+
+    text = outputs[0].outputs[0].text
+    print(f"GENERATED: {text!r}")
+    if not text or len(text.strip()) < 10:
+        raise SystemExit(
+            f"vision smoke test produced empty/too-short output: {text!r}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/models/jax/test_gemma4.py
+++ b/tests/models/jax/test_gemma4.py
@@ -160,12 +160,10 @@ class TestGemma4ForConditionalGeneration:
             mock_vllm_config=mock_vllm_config,
         )
 
-    @pytest.mark.parametrize(
-        "model_name",
-        [
-            "google/gemma-4-E2B-it",
-            # "google/gemma-4-E4B-it",  # add when E4B bringup lands
-        ])
+    @pytest.mark.parametrize("model_name", [
+        "google/gemma-4-E2B-it",
+        "google/gemma-4-E4B-it",
+    ])
     def test_e_family_model_loading(
         self,
         model_name,


### PR DESCRIPTION
## Summary

Wires `google/gemma-4-E4B-it` into the JAX-path nightly, and switches both `E2B-it` and `E4B-it` Performance benchmarks from text-only to vision (`random-mm`). The model code (PLE + KV-share + double-wide MLP) landed in **#2572**; this PR adds zero model-code changes — every E2B↔E4B architectural delta is config-driven and already handled.

## HF text_config diff vs E2B

| field | E2B | E4B | implication |
|---|---|---|---|
| `hidden_size` | 1536 | 2560 | ~1.7× larger residual stream |
| `intermediate_size` | 6144 | 10240 | ~1.7× MLP width |
| `num_hidden_layers` | 35 | 42 | 20% more layers |
| `num_key_value_heads` | 1 | 2 | 2 → matches v7x_2 TP for clean kv-heads sharding |
| `num_kv_shared_layers` | 20 (last) | 18 (last) | both >> 0 → structural KV-share active |
| `use_double_wide_mlp` | **True** | **False** | only architectural toggle that flips |
| `layer_types` pattern | `(s×4 + f) × 7` | `(s×5 + f) × 7` | longer sliding runs, same periodic full layer |

The `use_double_wide_mlp` toggle is the only structural difference; `Gemma4DecoderLayer.__init__` already reads it via `getattr(text_config, "use_double_wide_mlp", False)` and conditions `layer_intermediate_size`. `compute_kv_share_map` handles arbitrary L + `num_kv_shared_layers`; both `layer_types` patterns produce clean shared→prev redirect maps.

## E4B Performance & accuracy (text)

Three-topology dev-pipeline run: [BK #473](https://buildkite.com/tpu-commons/tpu-inference-dev/builds/473) — **all 9 functional steps PASSED**.

| metric | v6e TP=1 | v6e_8 TP=8 | **v7x_2 TP=2** |
|---|---|---|---|
| **gsm8k strict-match** | 0.7074 | 0.7119 | **0.7127** |
| **gsm8k flexible-extract** | 0.7612 | 0.7657 | **0.7665** |
| **Request throughput (req/s)** | 15.02 | 20.17 | **23.91** |
| **Output throughput (tok/s)** | 1923 | 2581 | **3061** |
| **Mean TTFT (ms)** | 2889 | 2326 | **2140** |
| **Mean TPOT (ms)** | 28.78 | 20.22 | **16.15** |

- Accuracy is within 0.5 pp across all topologies (FP-precision noise).
- v7x_2 is the fastest single-host path; v6e TP=1 is the cheapest viable option.
- The yml runs on both v6e and v7x via BK upload-time `${TENSOR_PARALLEL_SIZE_SINGLE}` interpolation — each architecture gets its native TP without code branching.

## Vision benchmark — both E2B and E4B now exercise the vision tower

Both models' Performance step previously routed `mm_bench_recipe.sh` through `BENCH_DATASET=text` (plain-text `random` dataset, vision tower compiled but never exercised). That was a holdover from when we were unsure whether the end-to-end vision path worked on the JAX runtime. **It does.** This PR drops `BENCH_DATASET=text` from both yml files; the Performance step now runs the default `random-mm` dataset (6 images @ 736×736 per prompt, 128 prompts), matching how `gemma-4-31B-it` is benchmarked.

**Validation matrix:** [tpu-inference-dev #475](https://buildkite.com/tpu-commons/tpu-inference-dev/builds/475) — full 2×2×2 sweep over `{tpu6e, tpu7x_2} × {text, vision} × {E2B, E4B}`:

| TPU | Model | Dataset | Result | req/s |
|---|---|---|---|---|
| tpu6e (TP=1) | E2B | text | ✅ passed | 21.69 |
| tpu6e (TP=1) | E2B | **vision** | ✅ **passed** | **2.57** |
| tpu7x_2 (TP=2) | E2B | text | ✅ passed | 34.02 |
| tpu7x_2 (TP=2) | E2B | **vision** | ✅ **passed** | **3.03** |
| tpu6e (TP=1) | E4B | text | ✅ passed | 14.72 |
| tpu6e (TP=1) | E4B | **vision** | ✅ **passed** | **2.40** |
| tpu7x_2 (TP=2) | E4B | text | ✅ passed | 24.23 |
| tpu7x_2 (TP=2) | E4B | **vision** | ✅ **passed** | **2.88** |

(The original `tpu7x E2B [text]` run hit a Docker-registry auth flake and two retries landed on an agent that was out of disk space; rerun on a healthy agent passed at 34.02 req/s.)

**Key finding:** unlike `gemma-4-31B-it`, which gates vision-bench on `TPU_VERSION=tpu7x` because it can't fit on a single v6e chip, both E2B and E4B fit the vision-bench workload on **v6e TP=1** at the existing `GPU_MEMORY_UTILIZATION` settings (0.94 for E2B, 0.85 for E4B). No skip gate is needed.

Vision req/s is ~10× lower than text (expected — image encoding dominates per-request cost). `MINIMUM_THROUGHPUT_THRESHOLD` stays at `0.0` for both models; the floor will be set after a few stable nightlies establish typical variance.

## Changes

1. **`.buildkite/models/google_gemma-4-E4B-it.yml`** (new) — nightly yml with UnitTest + Accuracy + Benchmark steps. Uses BK upload-time interpolation for `TENSOR_PARALLEL_SIZE` so v6e gets TP=1 and v7x gets TP=2 automatically.
   - `MAX_MODEL_LEN=4096`, `MAX_NUM_SEQS=64`, `GPU_MEMORY_UTILIZATION=0.85` (matches what worked on both topologies).
   - `USE_CHAT_TEMPLATE=1` for Accuracy step (gemma-4-it is BOS-sensitive — raw prompts get ~0.10 on gsm8k).
   - Performance step uses default `random-mm` (vision).
   - `CI_CATEGORY: multimodal` on all record steps (matches 31B/26B labelling).
   - `MINIMUM_ACCURACY_THRESHOLD=0.49` = min observed strict-match (0.7074 on v6e) × 0.7.
2. **`.buildkite/models/google_gemma-4-E2B-it.yml`** — mirror the same pattern for E2B: Performance step drops `BENCH_DATASET=text` (now runs vision), `CI_CATEGORY: multimodal`.
3. **`tests/models/jax/test_gemma4.py`** — uncomment the E4B entry in `test_e_family_model_loading`'s parametrize (placeholder added in #2572 with "add when E4B bringup lands").
4. **`examples/multi_modal_inference_gemma.py`** (new) — standalone vision smoke test (`cherry_blossom` asset + chat-with-image), useful for ad-hoc local verification. Not referenced from CI.
5. **`.buildkite/pipeline_dev.yml`** — rewritten as the {v6e, v7x_2} × {text, vision} × {E2B, E4B} dev-pipeline matrix used to validate this PR.

## Test plan

- [x] 3-topology E4B accuracy + text-perf — [BK #473](https://buildkite.com/tpu-commons/tpu-inference-dev/builds/473).
- [x] 2×2×2 E2B/E4B vision matrix — [BK #475](https://buildkite.com/tpu-commons/tpu-inference-dev/builds/475).
- [x] Rebased onto latest main (post-#2688 — JAX-cache pre-warm fix).
- [ ] `tpu-inference-ci` pre-commit on this PR (auto-triggers on push).

## Built on top of

- **#2572** (merged as `56171a46`) — Gemma-4 E2B-it on JAX path (PLE + KV-share + double-wide MLP). All E-family model code lives there.
- **#2688** (merged) — `tests/conftest.py` JAX compilation cache pre-warm fix (un-breaks the kernel-test suites on JAX 0.10+).

