### PR TITLE
Move persistent jax cache to attached disk

### DIFF
--- a/.buildkite/scripts/run_in_docker.sh
+++ b/.buildkite/scripts/run_in_docker.sh
@@ -125,12 +125,16 @@ echo "[INFO] Detected JAX Version: ${JAX_VERSION}"
 CACHE_NAMESPACE="jax${JAX_VERSION}_tpu${TPU_VERSION:-tpu6e}"
 FINAL_CACHE_PATH="${GCS_CACHE_BASE}/${CACHE_NAMESPACE}"
 
-LOCAL_JAX_CACHE_DIR="/tmp/tpu_jax_cache/${CACHE_NAMESPACE}"
-mkdir -p "$LOCAL_JAX_CACHE_DIR"
+LOCAL_JAX_CACHE_DIR="/mnt/disks/persist/tpu_jax_cache/${CACHE_NAMESPACE}"
+
+if ! mkdir -p "$LOCAL_JAX_CACHE_DIR"; then
+  echo "[ERROR] Failed to create $LOCAL_JAX_CACHE_DIR on persistent disk."
+  exit 1
+fi
 echo "[INFO] Pulling JAX Cache from GCS to local directory..."
 # Parallel CI builds‘ pushes are safe because JAX's compilation cache 
 # entries are content-addressed. Concurrent pushes are thus idempotent;
-gsutil -m rsync -r "$FINAL_CACHE_PATH" "$LOCAL_JAX_CACHE_DIR" || echo "[WARN] Failed to pull JAX Cache from GCS. Proceeding with cold start."
+gsutil -m rsync -d -r "$FINAL_CACHE_PATH" "$LOCAL_JAX_CACHE_DIR" || echo "[WARN] Failed to pull JAX Cache from GCS. Proceeding with cold start."
 
 # ==========================================
 # 2. Run Docker Container


### PR DESCRIPTION
Move the JAX persistent cache from /tmp to attached disk. And delete the legacy cache files during the pull phase.

We will have followup PRs on the ci-infra side to managed the lifecycle of the legacy cache files on disk.