### PR TITLE
Limit SC tracing to 1 core and 1 tile

### DIFF
--- a/tpu_inference/runner/utils.py
+++ b/tpu_inference/runner/utils.py
@@ -514,6 +514,11 @@ class PhasedBasedProfiler:
         }
         self.default_profiling_options = jax.profiler.ProfileOptions()
         self.default_profiling_options.python_tracer_level = envs.PYTHON_TRACER_LEVEL
+        self.default_profiling_options.advanced_configuration = {
+            "tpu_trace_mode": "TRACE_COMPUTE",
+            "tpu_num_sparse_cores_to_trace": 1,
+            "tpu_num_sparse_core_tiles_to_trace": 1,
+        }
 
         self.current_phase: str = ""
 


### PR DESCRIPTION
With SC profiling enabled, the profiled result got too big, so it fails to capture important events like collectives. This change will make sure we have a proper limit for SC profiling.

# Description

Start with a short description of what the PR does and how this is a change from
the past.

The rest of the description includes relevant details and context, examples:
- why is this change being made,
- the problem being solved and any relevant context,
- why this is a good solution,
- some information about the specific implementation,
- shortcomings of the solution and possible future improvements.

If the change fixes a Github issue, please include a link, e.g.,:
FIXES: #123456

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
