### PR TITLE
Support MPMD DP 

### DIFF
--- a/.buildkite/pipeline_jax.yml
+++ b/.buildkite/pipeline_jax.yml
@@ -631,6 +631,41 @@ steps:
           - |
             .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/examples/disagg/run_disagg_single_host.sh
 
+      - label: "${TPU_VERSION:-tpu6e} E2E test for MPMD data parallelism"
+        key: ${TPU_VERSION:-tpu6e}_test_35
+        depends_on: "${TPU_VERSION:-tpu6e}_build_docker"
+        soft_fail: true
+        env:
+          USE_PREBUILT_IMAGE: "1"
+          NEW_MODEL_DESIGN: "1"
+          TPU_VERSION: "${TPU_VERSION:-tpu6e}"
+        agents:
+          queue: ${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}
+        commands:
+          - |
+            .buildkite/scripts/run_in_docker.sh bash -c '
+              set -eu
+              MODEL=meta-llama/Llama-3.1-8B-Instruct
+              TPU_MULTIPROCESS_DP=1 \
+                VLLM_ENGINE_READY_TIMEOUT_S=60000 \
+                MODEL_IMPL_TYPE=flax_nnx \
+                vllm serve $$MODEL \
+                  --port 8000 \
+                  --data-parallel-size 4 \
+                  --tensor-parallel-size 1 \
+                  --max-model-len 1024 \
+                  --no-enable-prefix-caching \
+                  --gpu-memory-utilization 0.9 &
+              trap "kill %1 2>/dev/null || true" EXIT
+              for _ in $$(seq 1 180); do
+                curl -fs localhost:8000/health > /dev/null && break || sleep 10
+              done
+              curl -fsS http://localhost:8000/v1/completions \
+                -X POST \
+                -H "Content-Type: application/json" \
+                -d "{\"model\": \"$$MODEL\", \"prompt\": \"San Francisco is a\", \"max_tokens\": 50}"
+            '
+
       # -----------------------------------------------------------------
       # NOTIFICATION STEP
       # -----------------------------------------------------------------
@@ -673,9 +708,10 @@ steps:
           - ${TPU_VERSION:-tpu6e}_test_32
           - ${TPU_VERSION:-tpu6e}_test_33
           - ${TPU_VERSION:-tpu6e}_test_34
+          - ${TPU_VERSION:-tpu6e}_test_35
         agents:
           queue: cpu
         commands:
           - |
             .buildkite/scripts/check_results.sh \
-              "TPU JAX Tests Failed" ${TPU_VERSION:-tpu6e}_test_0 ${TPU_VERSION:-tpu6e}_test_1 ${TPU_VERSION:-tpu6e}_test_2 ${TPU_VERSION:-tpu6e}_test_3 ${TPU_VERSION:-tpu6e}_test_4 ${TPU_VERSION:-tpu6e}_test_6 ${TPU_VERSION:-tpu6e}_test_7_1 ${TPU_VERSION:-tpu6e}_test_7_2 ${TPU_VERSION:-tpu6e}_test_7_3 ${TPU_VERSION:-tpu6e}_test_8 ${TPU_VERSION:-tpu6e}_test_9 ${TPU_VERSION:-tpu6e}_test_10 ${TPU_VERSION:-tpu6e}_test_11 ${TPU_VERSION:-tpu6e}_test_12 ${TPU_VERSION:-tpu6e}_test_13 ${TPU_VERSION:-tpu6e}_test_14 ${TPU_VERSION:-tpu6e}_test_15 ${TPU_VERSION:-tpu6e}_test_16 ${TPU_VERSION:-tpu6e}_test_17 ${TPU_VERSION:-tpu6e}_test_18 ${TPU_VERSION:-tpu6e}_test_19 ${TPU_VERSION:-tpu6e}_test_20 ${TPU_VERSION:-tpu6e}_test_21 ${TPU_VERSION:-tpu6e}_test_22 ${TPU_VERSION:-tpu6e}_test_23 ${TPU_VERSION:-tpu6e}_test_24 ${TPU_VERSION:-tpu6e}_test_25 ${TPU_VERSION:-tpu6e}_test_26 ${TPU_VERSION:-tpu6e}_test_27 ${TPU_VERSION:-tpu6e}_test_28 ${TPU_VERSION:-tpu6e}_test_29 ${TPU_VERSION:-tpu6e}_test_30 ${TPU_VERSION:-tpu6e}_test_31 ${TPU_VERSION:-tpu6e}_test_32 ${TPU_VERSION:-tpu6e}_test_33 ${TPU_VERSION:-tpu6e}_test_34
+              "TPU JAX Tests Failed" ${TPU_VERSION:-tpu6e}_test_0 ${TPU_VERSION:-tpu6e}_test_1 ${TPU_VERSION:-tpu6e}_test_2 ${TPU_VERSION:-tpu6e}_test_3 ${TPU_VERSION:-tpu6e}_test_4 ${TPU_VERSION:-tpu6e}_test_6 ${TPU_VERSION:-tpu6e}_test_7_1 ${TPU_VERSION:-tpu6e}_test_7_2 ${TPU_VERSION:-tpu6e}_test_7_3 ${TPU_VERSION:-tpu6e}_test_8 ${TPU_VERSION:-tpu6e}_test_9 ${TPU_VERSION:-tpu6e}_test_10 ${TPU_VERSION:-tpu6e}_test_11 ${TPU_VERSION:-tpu6e}_test_12 ${TPU_VERSION:-tpu6e}_test_13 ${TPU_VERSION:-tpu6e}_test_14 ${TPU_VERSION:-tpu6e}_test_15 ${TPU_VERSION:-tpu6e}_test_16 ${TPU_VERSION:-tpu6e}_test_17 ${TPU_VERSION:-tpu6e}_test_18 ${TPU_VERSION:-tpu6e}_test_19 ${TPU_VERSION:-tpu6e}_test_20 ${TPU_VERSION:-tpu6e}_test_21 ${TPU_VERSION:-tpu6e}_test_22 ${TPU_VERSION:-tpu6e}_test_23 ${TPU_VERSION:-tpu6e}_test_24 ${TPU_VERSION:-tpu6e}_test_25 ${TPU_VERSION:-tpu6e}_test_26 ${TPU_VERSION:-tpu6e}_test_27 ${TPU_VERSION:-tpu6e}_test_28 ${TPU_VERSION:-tpu6e}_test_29 ${TPU_VERSION:-tpu6e}_test_30 ${TPU_VERSION:-tpu6e}_test_31 ${TPU_VERSION:-tpu6e}_test_32 ${TPU_VERSION:-tpu6e}_test_33 ${TPU_VERSION:-tpu6e}_test_34 ${TPU_VERSION:-tpu6e}_test_35

--- a/tpu_inference/envs.py
+++ b/tpu_inference/envs.py
@@ -12,6 +12,7 @@ if TYPE_CHECKING:
     TPU_NAME: str | None = None
     TPU_WORKER_ID: str | None = None
     TPU_MULTIHOST_BACKEND: str = ""
+    TPU_MULTIPROCESS_DP: bool = False
     PREFILL_SLICES: str = ""
     DECODE_SLICES: str = ""
     SKIP_JAX_PRECOMPILE: bool = False
@@ -203,6 +204,12 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Backend for multi-host communication on TPU
     "TPU_MULTIHOST_BACKEND":
     env_with_choices("TPU_MULTIHOST_BACKEND", "", ["ray"]),
+    # Use vLLM-native multi-process data parallelism (one engine process per
+    # DP rank, single load-balanced API endpoint) instead of tpu-inference's
+    # single-process SPMD data parallelism. Each DP rank is pinned to a
+    # disjoint set of TPU chips. Dense (non-MoE) models only.
+    "TPU_MULTIPROCESS_DP":
+    env_bool("TPU_MULTIPROCESS_DP", default=False),
     # Slice configuration for disaggregated prefill workers
     "PREFILL_SLICES":
     lambda: os.getenv("PREFILL_SLICES", ""),

--- a/tpu_inference/layers/common/sharding.py
+++ b/tpu_inference/layers/common/sharding.py
@@ -19,6 +19,7 @@ from typing import TYPE_CHECKING, List, Optional
 
 import jax.numpy as jnp
 import numpy as np
+import vllm.envs as vllm_envs
 from jax.sharding import Mesh
 
 from tpu_inference import envs, utils
@@ -177,23 +178,25 @@ class ShardingConfigManager:
         enable_dp_attention = sharding_strategy.get("enable_dp_attention",
                                                     False)
         # vLLM-native multi-process data parallelism: one engine process per
-        # DP rank, fronted by a single load-balanced API endpoint. 
+        # DP rank, fronted by a single load-balanced API endpoint.
         #
         # It is not used (we fall back to single-process SPMD DP) when:
-        #  - the model is MoE 
+        #  - the model is MoE
         #  - attention DP is enabled
+        #  - running on Pathways
         model_config = vllm_config.model_config
         multiprocess_dp = (envs.TPU_MULTIPROCESS_DP and data_parallelism > 1
                            and model_config is not None
                            and not model_config.is_moe
-                           and not enable_dp_attention)
+                           and not enable_dp_attention
+                           and not vllm_envs.VLLM_TPU_USING_PATHWAYS)
         if (envs.TPU_MULTIPROCESS_DP and data_parallelism > 1
                 and not multiprocess_dp):
             logger.warning(
                 "TPU_MULTIPROCESS_DP is set but is not supported for MoE "
-                "models or with attention DP (enable_dp_attention). " 
-                "Falling back to single-process "
-                "SPMD data parallelism.")
+                "models, with attention DP (enable_dp_attention), or on "
+                "Pathways. Falling back to single-process SPMD data "
+                "parallelism.")
         if multiprocess_dp:
             # Each engine process is tensor-parallel only.
             data_parallelism = 1

--- a/tpu_inference/layers/common/sharding.py
+++ b/tpu_inference/layers/common/sharding.py
@@ -22,9 +22,12 @@ import numpy as np
 from jax.sharding import Mesh
 
 from tpu_inference import envs, utils
+from tpu_inference.logger import init_logger
 
 if TYPE_CHECKING:
     from vllm.config import VllmConfig
+
+logger = init_logger(__name__)
 
 MESH_AXIS_NAMES = ("data", "attn_dp", "attn_dp_expert", "expert", "model",
                    "dcp")
@@ -171,14 +174,41 @@ class ShardingConfigManager:
         ss_tensor_parallelsim = sharding_strategy.get("tensor_parallelism",
                                                       None)
         data_parallelism = parallel_config.data_parallel_size
+        enable_dp_attention = sharding_strategy.get("enable_dp_attention",
+                                                    False)
+        # vLLM-native multi-process data parallelism: one engine process per
+        # DP rank, fronted by a single load-balanced API endpoint. 
+        #
+        # It is not used (we fall back to single-process SPMD DP) when:
+        #  - the model is MoE 
+        #  - attention DP is enabled
+        model_config = vllm_config.model_config
+        multiprocess_dp = (envs.TPU_MULTIPROCESS_DP and data_parallelism > 1
+                           and model_config is not None
+                           and not model_config.is_moe
+                           and not enable_dp_attention)
+        if (envs.TPU_MULTIPROCESS_DP and data_parallelism > 1
+                and not multiprocess_dp):
+            logger.warning(
+                "TPU_MULTIPROCESS_DP is set but is not supported for MoE "
+                "models or with attention DP (enable_dp_attention). " 
+                "Falling back to single-process "
+                "SPMD data parallelism.")
+        if multiprocess_dp:
+            # Each engine process is tensor-parallel only.
+            data_parallelism = 1
+            logger.warning(
+                "TPU_MULTIPROCESS_DP is enabled: vLLM will spawn one engine "
+                "process per DP rank with internal load balancing. This is "
+                "supported for online serving (`vllm serve` / AsyncLLM) "
+                "only -- vLLM has no synchronous DP client, so the offline "
+                "LLM().generate() API will hang. Use `vllm serve` instead.")
         expert_parallelism = sharding_strategy.get("expert_parallelism", 1)
         sequence_parallelism = sharding_strategy.get("sequence_parallelism", 1)
         device_indexes = sharding_strategy.get("device_indexes", None)
 
         decode_context_parallelism = parallel_config.decode_context_parallel_size
 
-        enable_dp_attention = sharding_strategy.get("enable_dp_attention",
-                                                    False)
         if pc_tensor_parallelism != ss_tensor_parallelsim and ss_tensor_parallelsim:
             # The user has explicitly set the tensor parallelism in the sharding config.
             tensor_parallelism = ss_tensor_parallelsim
@@ -249,7 +279,10 @@ class ShardingConfigManager:
             decode_context_parallelism=decode_context_parallelism)
 
         # Must override here to avoid vLLM spinning up multiple DP engines.
-        if vllm_config.parallel_config.data_parallel_size > 1:
+        # In multiprocess-DP mode this is exactly what we want, so the
+        # override is skipped and vLLM spawns one engine per DP rank.
+        if (not multiprocess_dp
+                and vllm_config.parallel_config.data_parallel_size > 1):
             vllm_config.parallel_config.data_parallel_size = 1
             vllm_config.parallel_config.data_parallel_rank = 0
             vllm_config.parallel_config.data_parallel_size_local = 1

--- a/tpu_inference/layers/common/sharding.py
+++ b/tpu_inference/layers/common/sharding.py
@@ -192,20 +192,16 @@ class ShardingConfigManager:
                            and not vllm_envs.VLLM_TPU_USING_PATHWAYS)
         if (envs.TPU_MULTIPROCESS_DP and data_parallelism > 1
                 and not multiprocess_dp):
-            logger.warning(
+            raise ValueError(
                 "TPU_MULTIPROCESS_DP is set but is not supported for MoE "
                 "models, with attention DP (enable_dp_attention), or on "
-                "Pathways. Falling back to single-process SPMD data "
-                "parallelism.")
+                "Pathways. Please disable TPU_MULTIPROCESS_DP.")
         if multiprocess_dp:
-            # Each engine process is tensor-parallel only.
             data_parallelism = 1
             logger.warning(
-                "TPU_MULTIPROCESS_DP is enabled: vLLM will spawn one engine "
-                "process per DP rank with internal load balancing. This is "
-                "supported for online serving (`vllm serve` / AsyncLLM) "
-                "only -- vLLM has no synchronous DP client, so the offline "
-                "LLM().generate() API will hang. Use `vllm serve` instead.")
+                "TPU_MULTIPROCESS_DP is enabled: supported for online serving "
+                "only. The offline LLM().generate() API will hang. "
+                "Use `vllm serve` instead.")
         expert_parallelism = sharding_strategy.get("expert_parallelism", 1)
         sequence_parallelism = sharding_strategy.get("sequence_parallelism", 1)
         device_indexes = sharding_strategy.get("device_indexes", None)
@@ -282,8 +278,6 @@ class ShardingConfigManager:
             decode_context_parallelism=decode_context_parallelism)
 
         # Must override here to avoid vLLM spinning up multiple DP engines.
-        # In multiprocess-DP mode this is exactly what we want, so the
-        # override is skipped and vLLM spawns one engine per DP rank.
         if (not multiprocess_dp
                 and vllm_config.parallel_config.data_parallel_size > 1):
             vllm_config.parallel_config.data_parallel_size = 1

--- a/tpu_inference/worker/tpu_worker.py
+++ b/tpu_inference/worker/tpu_worker.py
@@ -165,10 +165,8 @@ class TPUWorker(WorkerBase):
         self.cache_config.num_cpu_blocks = num_cpu_blocks
 
     def _setup_dp_chip_isolation(self) -> None:
-        """Sets libtpu env vars so the process initializes JAX as a standalone
-        single-process cluster owning a disjoint slice of physical chips,
-        instead of every engine grabbing the same devices. Must run before
-        JAX initializes its TPU backend.
+        """Sets libtpu env vars so the process initializes JAX on a subset of
+        physical chips. Must run before JAX initializes its TPU backend.
         """
         from tpu_inference import tpu_info
 

--- a/tpu_inference/worker/tpu_worker.py
+++ b/tpu_inference/worker/tpu_worker.py
@@ -165,11 +165,7 @@ class TPUWorker(WorkerBase):
         self.cache_config.num_cpu_blocks = num_cpu_blocks
 
     def _setup_dp_chip_isolation(self) -> None:
-        """Pin this data-parallel rank's engine process to its own TPU chips.
-
-        With vLLM-native multi-process DP (TPU_MULTIPROCESS_DP=1) each DP
-        rank runs as a separate engine process spawned by vLLM. This sets
-        the libtpu env vars so the process initializes JAX as a standalone
+        """Sets libtpu env vars so the process initializes JAX as a standalone
         single-process cluster owning a disjoint slice of physical chips,
         instead of every engine grabbing the same devices. Must run before
         JAX initializes its TPU backend.

--- a/tpu_inference/worker/tpu_worker.py
+++ b/tpu_inference/worker/tpu_worker.py
@@ -164,10 +164,60 @@ class TPUWorker(WorkerBase):
         self.cache_config.num_gpu_blocks = num_gpu_blocks
         self.cache_config.num_cpu_blocks = num_cpu_blocks
 
+    def _setup_dp_chip_isolation(self) -> None:
+        """Pin this data-parallel rank's engine process to its own TPU chips.
+
+        With vLLM-native multi-process DP (TPU_MULTIPROCESS_DP=1) each DP
+        rank runs as a separate engine process spawned by vLLM. This sets
+        the libtpu env vars so the process initializes JAX as a standalone
+        single-process cluster owning a disjoint slice of physical chips,
+        instead of every engine grabbing the same devices. Must run before
+        JAX initializes its TPU backend.
+        """
+        from tpu_inference import tpu_info
+
+        parallel_config = self.vllm_config.parallel_config
+        dp_rank = getattr(parallel_config, "data_parallel_index", 0) or 0
+
+        sharding_config = getattr(self.vllm_config, "sharding_config", None)
+        num_devices = sharding_config.total_devices
+
+        cores_per_chip = tpu_info.get_num_cores_per_chip()
+        chips_per_rank = math.ceil(num_devices / cores_per_chip)
+        total_chips = tpu_info.get_num_chips()
+
+        start_chip = dp_rank * chips_per_rank
+        end_chip = start_chip + chips_per_rank
+        if total_chips and end_chip > total_chips:
+            raise ValueError(
+                f"Multi-process DP rank {dp_rank} needs TPU chips "
+                f"[{start_chip}, {end_chip}) but the host only has "
+                f"{total_chips} chips. Reduce --data-parallel-size or "
+                f"--tensor-parallel-size.")
+
+        visible_chips = ",".join(str(c) for c in range(start_chip, end_chip))
+        # Unique libtpu port per rank so the runtimes can coexist on a host.
+        tpu_port = jax_parallel_state.BASE_JAX_PORT + dp_rank
+
+        os.environ["TPU_VISIBLE_CHIPS"] = visible_chips
+        os.environ["TPU_CHIPS_PER_PROCESS_BOUNDS"] = f"1,{chips_per_rank},1"
+        os.environ["TPU_PROCESS_BOUNDS"] = "1,1,1"
+        os.environ["TPU_PROCESS_PORT"] = str(tpu_port)
+        os.environ["TPU_PROCESS_ADDRESSES"] = f"localhost:{tpu_port}"
+        os.environ["CLOUD_TPU_TASK_ID"] = "0"
+        logger.info(
+            "Multi-process DP | rank=%d | TPU_VISIBLE_CHIPS=%s | "
+            "TPU_CHIPS_PER_PROCESS_BOUNDS=1,%d,1 | TPU_PROCESS_PORT=%d",
+            dp_rank, visible_chips, chips_per_rank, tpu_port)
+
     def init_device(self,
                     tpu_process_bounds="",
                     tpu_chips_per_process_bounds="",
                     tpu_visible_chips=""):
+
+        if (envs.TPU_MULTIPROCESS_DP
+                and self.parallel_config.pipeline_parallel_size == 1):
+            self._setup_dp_chip_isolation()
 
         # set tpu visible devices for Jax runtime in PP.
         multihost_backend = envs.TPU_MULTIHOST_BACKEND

--- a/tpu_inference/worker/tpu_worker.py
+++ b/tpu_inference/worker/tpu_worker.py
@@ -173,7 +173,7 @@ class TPUWorker(WorkerBase):
         parallel_config = self.vllm_config.parallel_config
         dp_rank = getattr(parallel_config, "data_parallel_index", 0) or 0
 
-        sharding_config = getattr(self.vllm_config, "sharding_config", None)
+        sharding_config = self.vllm_config.sharding_config
         num_devices = sharding_config.total_devices
 
         cores_per_chip = tpu_info.get_num_cores_per_chip()


### PR DESCRIPTION
# Description

This pull request introduces support for vLLM-native multi-process data parallelism (DP) on TPU, allowing each data parallel rank to run in its own process, each pinned to a disjoint set of TPU chips. This is enabled via the new `TPU_MULTIPROCESS_DP` environment variable:

MPMD DP will not work for attention DP or Pathways. 

Follow up PR will enable MPMD DP for MoE models in non-attention-dp settings. 

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
