### PR TITLE
Upgrade torchax to 0.0.12

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ jaxlib==0.10.0
 libtpu==0.0.40
 jaxtyping
 flax==0.12.4
-torchax==0.0.11
+torchax==0.0.12
 qwix==0.1.2
 torchvision==0.25.0
 pathwaysutils


### PR DESCRIPTION

# Description

This resolves a long-standing issue with misleading startup warning logs.

```text
WARNING:absl:Tensorflow library not found, tensorflow.io.gfile operations will use native shim calls. GCS paths (i.e. 'gs://...') cannot be accessed.
```

```text
WARNING:root:Duplicate op registration for aten.__and__
```

- https://github.com/google/torchax/pull/70
- https://github.com/google/torchax/pull/71

# Tests

There should be no significant difference between 0.0.11 and 0.0.12 regarding the computation.
Leave the testing to CI pipeline.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
