### PR TITLE
Revert "[DP] Merge xprof files in MPMD case"

### DIFF
--- a/tests/runner/test_utils.py
+++ b/tests/runner/test_utils.py
@@ -711,78 +711,35 @@ def test_phased_profiler_skips_decode_only_steps_based_on_kv_len(
     assert profiler.current_phase == ""
 
 
-def test_merge_profile_directories_ray_multihost(tmp_path):
-    """Ray multi-host: per-host timestamp dirs collapse into the earliest one.
-
-    Under the current code, profile_dir_with_phase_suffix always has a
-    dp_rank_N segment. The merge first hoists files up from
-    <phase>/dp_rank_0/plugins/profile/<ts>/ to <phase>/plugins/profile/<ts>/,
-    then collapses the timestamp dirs. Host-id-tagged filenames are
-    preserved (no dp{N}_ prefix is injected because TPU_MULTIPROCESS_DP is
-    off).
-    """
+def test_merge_multihost_profile_directories(tmp_path):
+    """Tests that multi-host profile directories with different timestamps are consolidated correctly."""
     profiler = PhasedBasedProfiler(profile_dir=str(tmp_path))
     phase_dir = tmp_path / "prefill_heavy"
-    rank_dir = phase_dir / "dp_rank_0"
-    profiler.profile_dir_with_phase_suffix = str(rank_dir)
+    profiler.profile_dir_with_phase_suffix = str(phase_dir)
 
-    profile_path = rank_dir / "plugins" / "profile"
+    profile_path = phase_dir / "plugins" / "profile"
     dir_early = profile_path / "2026_05_06_04_47_36"
     dir_late = profile_path / "2026_05_06_04_47_38"
+
+    # Create the nested timestamped directories
     dir_early.mkdir(parents=True, exist_ok=True)
     dir_late.mkdir(parents=True, exist_ok=True)
-    (dir_early / "node-1-0.xplane.pb").write_text("dummy_trace_data_1")
-    (dir_late / "node-0-0.xplane.pb").write_text("dummy_trace_data_0")
 
-    profiler._merge_profile_directories()
+    # Create dummy host files inside each directory
+    file_early = dir_early / "node-1-0.xplane.pb"
+    file_late = dir_late / "node-0-0.xplane.pb"
+    file_early.write_text("dummy_trace_data_1")
+    file_late.write_text("dummy_trace_data_0")
 
-    # Files end up at <phase>/plugins/profile/<earliest_ts>/, not under dp_rank_0.
-    merged_dir = phase_dir / "plugins" / "profile" / "2026_05_06_04_47_36"
-    assert merged_dir.exists()
+    # Execute consolidation merge
+    profiler._merge_multihost_profile_directories()
+
+    # Verify that the trailing directory is deleted and all files are merged into the earliest directory
+    assert dir_early.exists()
     assert not dir_late.exists()
-    assert not (rank_dir / "plugins").exists()
-    assert (merged_dir /
+    assert (dir_early / "node-1-0.xplane.pb").exists()
+    assert (dir_early / "node-0-0.xplane.pb").exists()
+    assert (dir_early /
             "node-1-0.xplane.pb").read_text() == "dummy_trace_data_1"
-    assert (merged_dir /
+    assert (dir_early /
             "node-0-0.xplane.pb").read_text() == "dummy_trace_data_0"
-
-
-def test_merge_profile_directories_mpmd(tmp_path, monkeypatch):
-    """MPMD: 4 ranks each capture to their own dp_rank_N/plugins/profile/<ts>/
-    with identical filenames; merge hoists each up with dp{N}_ prefix so
-    they coexist in one <phase>/plugins/profile/<earliest_ts>/ dir."""
-    monkeypatch.setenv("TPU_MULTIPROCESS_DP", "1")
-
-    phase_dir = tmp_path / "prefill_heavy"
-    profilers = []
-    for rank in range(4):
-        rank_dir = phase_dir / f"dp_rank_{rank}"
-        profiler = PhasedBasedProfiler(profile_dir=str(tmp_path),
-                                       worker_rank=rank)
-        profiler.profile_dir_with_phase_suffix = str(rank_dir)
-        # Each rank's stop_trace lands in its own second-resolution dir.
-        ts_dir = rank_dir / "plugins" / "profile" / f"2026_05_06_04_47_{36 + rank:02d}"
-        ts_dir.mkdir(parents=True)
-        # Identical filename across ranks — the collision the fix avoids.
-        (ts_dir / "t1v-n-host-w-0.xplane.pb").write_text(f"rank_{rank}_xplane")
-        (ts_dir /
-         "t1v-n-host-w-0.trace.json.gz").write_text(f"rank_{rank}_trace")
-        profilers.append(profiler)
-
-    for profiler in profilers:
-        profiler._merge_profile_directories()
-
-    merged_dir = phase_dir / "plugins" / "profile" / "2026_05_06_04_47_36"
-    assert merged_dir.exists()
-    for rank in range(4):
-        xplane = merged_dir / f"dp{rank}_t1v-n-host-w-0.xplane.pb"
-        trace = merged_dir / f"dp{rank}_t1v-n-host-w-0.trace.json.gz"
-        assert xplane.read_text() == f"rank_{rank}_xplane"
-        assert trace.read_text() == f"rank_{rank}_trace"
-        # Per-rank plugins/ subtree cleaned up; dp_rank_N/ remains for the
-        # batch_composition_stats JSONs (which this test doesn't stage).
-        assert not (phase_dir / f"dp_rank_{rank}" / "plugins").exists()
-    # Trailing timestamp dirs collapsed into the earliest.
-    for rank in range(1, 4):
-        assert not (phase_dir / "plugins" / "profile" /
-                    f"2026_05_06_04_47_{36 + rank:02d}").exists()

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -30,7 +30,6 @@ from jax._src.pallas.utils import next_power_of_2
 from jax.experimental import mesh_utils
 from jax.sharding import NamedSharding, PartitionSpec
 from vllm.config import VllmConfig, set_current_vllm_config
-from vllm.config.parallel import ParallelConfig
 from vllm.distributed.kv_transfer import (get_kv_transfer_group,
                                           has_kv_transfer_group)
 from vllm.forward_context import set_forward_context
@@ -296,7 +295,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         self.cache_config = vllm_config.cache_config
         self.lora_config = vllm_config.lora_config
         self.load_config = vllm_config.load_config
-        self.parallel_config: ParallelConfig = vllm_config.parallel_config
+        self.parallel_config = vllm_config.parallel_config
         self.scheduler_config = vllm_config.scheduler_config
         self.speculative_config = vllm_config.speculative_config
         self.observability_config = vllm_config.observability_config
@@ -466,14 +465,8 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         self.phased_profiling_dir = envs.PHASED_PROFILING_DIR
         self.phase_based_profiler = None
         if self.phased_profiling_dir:
-            # Under MPMD each DP rank runs its own profiler on the same host
-            # and produces an identically-named xplane.pb (same hostname,
-            # same JAX worker id). Without a per-rank segment they collide on
-            # the second-resolution timestamp dir and one rank's capture
-            # overwrites another's.
-            dp_rank = self.parallel_config.data_parallel_index if envs.TPU_MULTIPROCESS_DP else 0
             self.phase_based_profiler = runner_utils.PhasedBasedProfiler(
-                self.phased_profiling_dir, worker_rank=dp_rank)
+                self.phased_profiling_dir)
 
     def _init_aggregated_stats_logging(self) -> None:
         self.aggregated_stats_dir = envs.AGGREGATED_STATS_DIR

--- a/tpu_inference/runner/utils.py
+++ b/tpu_inference/runner/utils.py
@@ -57,19 +57,6 @@ class InferencePhase(Enum):
     DECODE_ONLY = 5
 
 
-def _inject_dp_rank_into_filename(fname: str, dp_rank: int) -> str:
-    """Prefix `dp<N>_` to an xplane or trace filename, e.g.
-
-        t1v-n-3312659f-w-0.xplane.pb       -> dp0_t1v-n-3312659f-w-0.xplane.pb
-        t1v-n-3312659f-w-0.trace.json.gz   -> dp0_t1v-n-3312659f-w-0.trace.json.gz
-
-    Used by PhasedBasedProfiler under MPMD so per-DP-rank captures (which
-    otherwise share an identical hostname+worker filename on a single host)
-    can coexist in one `plugins/profile/<ts>/` dir for xprof.
-    """
-    return f"dp{dp_rank}_{fname}"
-
-
 def get_padded_num_reqs_with_upper_limit(x: int, upper_limit: int) -> int:
     res = MIN_NUM_SEQS if x <= MIN_NUM_SEQS else 1 << (x - 1).bit_length()
     return min(res, upper_limit)
@@ -596,9 +583,6 @@ class PhasedBasedProfiler:
             logger.info(f"Batch composition stats: {batch_composition_stats}")
             self.profile_dir_with_phase_suffix = os.path.join(
                 self.profile_dir, self.current_phase)
-            self.profile_dir_with_phase_suffix = os.path.join(
-                self.profile_dir_with_phase_suffix,
-                f"dp_rank_{self.worker_rank}")
 
             # Create the profile subdirectory if it doesn't exist
             os.makedirs(self.profile_dir_with_phase_suffix, exist_ok=True)
@@ -636,87 +620,46 @@ class PhasedBasedProfiler:
             self.profiling_n_steps_left -= 1
             if self.profiling_n_steps_left <= 0:
                 jax.profiler.stop_trace()
-                self._merge_profile_directories()
+                if envs.TPU_MULTIHOST_BACKEND == "ray":
+                    self._merge_multihost_profile_directories()
                 logger.info(
                     f"Profiling for {self.current_phase} phase finished")
                 self.current_phase = ""
 
-    def _merge_profile_directories(self) -> None:
+    def _merge_multihost_profile_directories(self) -> None:
         """
-        Consolidates phase trace artifacts so downstream tools (c2xprof,
-        TensorBoard profile plugin) see a single distributed session.
+        Merges multi-host JAX profiler timestamp subdirectories that drift due to asynchronous step trigger times.
 
-        Two split states are handled in sequence; the function is safe to
-        call from every rank after its own jax.profiler.stop_trace.
+        Fixes issues where separate host nodes create disjoint timestamp folders due to 1-2 seconds startup
+        skew, which blocks downstream multi-host profile analysis tools (e.g., c2xprof or TensorBoard profile plugins)
+        from recognizing them as a single concurrent distributed profiling session.
 
-        1. MPMD on a single host: each DP rank captured into
-           <phase>/dp_rank_<N>/plugins/profile/<ts>/ with an identically-
-           named xplane.pb (same hostname + same JAX worker id across
-           ranks). Hoist each rank's files up to
-           <phase>/plugins/profile/<ts>/ under TPU_MULTIPROCESS_DP, with
-           `dp<N>` injected into the filename so per-rank captures
-           coexist instead of clobbering each other.
-
-        2. Disjoint timestamp dirs: ray multi-host startup skew (or, after
-           step 1, the per-rank stop_trace timestamps in MPMD) produces
-           multiple <ts>/ subdirs under <phase>/plugins/profile/. Collapse
-           them into the earliest timestamp dir.
-
-        Example multi-host split state before merge:
+        Example split state before merge:
           .../plugins/profile/2026_05_06_04_47_36/j-1b8d22de-2250-4697-9dfc-ray-node-1-0.xplane.pb
           .../plugins/profile/2026_05_06_04_47_38/j-1b8d22de-2250-4697-9dfc-ray-node-0-0.xplane.pb
-        After merge: both files under 2026_05_06_04_47_36/.
+
+        After merge:
+          All host trace artifacts are consolidated under the earliest timestamp folder (2026_05_06_04_47_36/).
         """
-        source_profile_path = os.path.join(self.profile_dir_with_phase_suffix,
-                                           "plugins", "profile")
-        if not os.path.exists(source_profile_path):
+        profile_path = os.path.join(self.profile_dir_with_phase_suffix,
+                                    "plugins", "profile")
+        if not os.path.exists(profile_path):
             return
-
-        # Step 1: hoist this rank's files up out of the dp_rank_N segment so
-        # the multi-timestamp merge below sees all ranks at the shared level.
-        phase_dir = os.path.dirname(self.profile_dir_with_phase_suffix)
-        target_profile_path = os.path.join(phase_dir, "plugins", "profile")
-        if os.path.realpath(source_profile_path) != os.path.realpath(
-                target_profile_path):
-            try:
-                for ts in os.listdir(source_profile_path):
-                    src_ts_dir = os.path.join(source_profile_path, ts)
-                    if not os.path.isdir(src_ts_dir):
-                        continue
-                    dst_ts_dir = os.path.join(target_profile_path, ts)
-                    os.makedirs(dst_ts_dir, exist_ok=True)
-                    for fname in os.listdir(src_ts_dir):
-                        new_fname = (_inject_dp_rank_into_filename(
-                            fname, self.worker_rank)
-                                     if envs.TPU_MULTIPROCESS_DP else fname)
-                        shutil.move(os.path.join(src_ts_dir, fname),
-                                    os.path.join(dst_ts_dir, new_fname))
-                    try:
-                        os.rmdir(src_ts_dir)
-                    except OSError:
-                        pass
-                for cleanup in (source_profile_path,
-                                os.path.dirname(source_profile_path)):
-                    try:
-                        os.rmdir(cleanup)
-                    except OSError:
-                        pass
-            except Exception as e:
-                logger.warning("Failed to hoist DP profile directories: %s", e)
-
-        # Step 2: collapse multiple timestamp subdirs (from multi-host skew
-        # or per-rank stop_trace times under MPMD) into the earliest one.
         try:
+            # Get all timestamp subdirectories sorted by time
             dirs = sorted([
-                d for d in os.listdir(target_profile_path)
-                if os.path.isdir(os.path.join(target_profile_path, d))
+                d for d in os.listdir(profile_path)
+                if os.path.isdir(os.path.join(profile_path, d))
             ])
             if len(dirs) <= 1:
                 return
 
-            target_dir = os.path.join(target_profile_path, dirs[0])
+            # Use the earliest directory as the canonical destination target
+            target_dir = os.path.join(profile_path, dirs[0])
+
+            # Move all files from trailing directories into the canonical target directory
             for src in dirs[1:]:
-                src_dir = os.path.join(target_profile_path, src)
+                src_dir = os.path.join(profile_path, src)
                 for f in os.listdir(src_dir):
                     src_file = os.path.join(src_dir, f)
                     dst_file = os.path.join(target_dir, f)
@@ -725,10 +668,12 @@ class PhasedBasedProfiler:
                     os.rmdir(src_dir)
                 except Exception:
                     pass
-            logger.info("Successfully merged profile directories into: %s",
-                        dirs[0])
+            logger.info(
+                "Successfully merged multi-host profile directories into: %s",
+                dirs[0])
         except Exception as e:
-            logger.warning("Failed to merge profile directories: %s", e)
+            logger.warning(
+                "Failed to merge multi-host profile directories: %s", e)
 
     def step(self, batch_composition_stats: dict) -> None:
         """


### PR DESCRIPTION
Reverts vllm-project/tpu-inference#2705

Reason: This PR does not take consideration into a possibility of an existing profile data in a directory and deletes them.

example

Before: directory has both old and new profile data
```
# Old profile data
 .../plugins/profile/2026_05_01_02_00_36/j-1b8d22de-2250-4697-9dfc-ray-node-1-0.xplane.pb
# New profile data
.../plugins/profile/2026_05_06_04_47_38/j-1b8d22de-2250-4697-9dfc-ray-node-0-0.xplane.pb
```

After: old profile data is deleted and new profile data is renamed
```
# New profile data but with the old path name
 .../plugins/profile/2026_05_01_02_00_36/j-1b8d22de-2250-4697-9dfc-ray-node-1-0.xplane.pb
```