### PR TITLE
Fix upstream vLLM break for PyPI build

### DIFF
--- a/docker/Dockerfile.pypi
+++ b/docker/Dockerfile.pypi
@@ -31,6 +31,9 @@ RUN apt-get update && apt-get install -y \
     rclone \
     wget \
     ca-certificates \
+    build-essential \
+    cmake \
+    g++ \
     && rm -rf /var/lib/apt/lists/*
 
 # Install tpu_inference


### PR DESCRIPTION
# Description

related vllm PR: https://github.com/vllm-project/vllm/pull/43038
Fix upstream vLLM break for PyPI build
reference PR: https://github.com/vllm-project/tpu-inference/pull/2595

# Tests
passed on [Buildkite](https://buildkite.com/tpu-commons/tpu-inference-ci/builds/18386/canvas?sid=019e4e98-fd6c-4a51-87c9-bd6fb1f6dc6c&tab=output)

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
