### PR TITLE
[Spec decoding] Refactoring to simplify logics

### DIFF
--- a/tests/e2e/test_speculative_decoding.py
+++ b/tests/e2e/test_speculative_decoding.py
@@ -113,7 +113,6 @@ def _test_correctness_helper(
                 "enable_weights_track": False
             },
             "async_scheduling": async_scheduling,
-            "download_dir": "/mnt/pd",
         }
         if extra_kwargs:
             kwargs.update(extra_kwargs)
@@ -217,7 +216,6 @@ def _test_performance_helper(
             },
             "disable_log_stats": False,
             "async_scheduling": async_scheduling,
-            "download_dir": "/mnt/pd",
         }
         if extra_kwargs:
             kwargs.update(extra_kwargs)

--- a/tests/e2e/test_speculative_decoding.py
+++ b/tests/e2e/test_speculative_decoding.py
@@ -113,6 +113,7 @@ def _test_correctness_helper(
                 "enable_weights_track": False
             },
             "async_scheduling": async_scheduling,
+            "download_dir": "/mnt/pd",
         }
         if extra_kwargs:
             kwargs.update(extra_kwargs)
@@ -216,6 +217,7 @@ def _test_performance_helper(
             },
             "disable_log_stats": False,
             "async_scheduling": async_scheduling,
+            "download_dir": "/mnt/pd",
         }
         if extra_kwargs:
             kwargs.update(extra_kwargs)
@@ -318,8 +320,14 @@ def test_eagle3_correctness(
         async_scheduling=async_scheduling)
 
 
-@pytest.mark.parametrize("max_num_seqs", [1, 20])
-@pytest.mark.parametrize("async_scheduling", [False, True])
+@pytest.mark.parametrize(
+    "max_num_seqs,async_scheduling",
+    [
+        (1, False),
+        (20, False),
+        (20, True),
+    ],
+)
 def test_eagle3_performance(
     monkeypatch: pytest.MonkeyPatch,
     sampling_config: SamplingParams,
@@ -350,7 +358,7 @@ def test_eagle3_performance(
 
 @pytest.mark.skipif(os.environ.get("MODEL_IMPL_TYPE", "auto") != "vllm",
                     reason="MTP is only supported with vllm model impl.")
-@pytest.mark.parametrize("async_scheduling", [False])
+@pytest.mark.parametrize("async_scheduling", [False, True])
 def test_mtp_correctness(
     monkeypatch: pytest.MonkeyPatch,
     sampling_config: SamplingParams,
@@ -389,8 +397,14 @@ def test_mtp_correctness(
 
 @pytest.mark.skipif(os.environ.get("MODEL_IMPL_TYPE", "auto") != "vllm",
                     reason="MTP is only supported with vllm model impl.")
-@pytest.mark.parametrize("max_num_seqs", [1, 20])
-@pytest.mark.parametrize("async_scheduling", [False])
+@pytest.mark.parametrize(
+    "max_num_seqs,async_scheduling",
+    [
+        (1, False),
+        (20, False),
+        (20, True),
+    ],
+)
 def test_mtp_performance(
     monkeypatch: pytest.MonkeyPatch,
     sampling_config: SamplingParams,

--- a/tests/runner/test_speculative_decoding_manager.py
+++ b/tests/runner/test_speculative_decoding_manager.py
@@ -102,6 +102,7 @@ class TestSpeculativeDecodingManager:
                 attn_metadata=MagicMock(),
                 async_scheduling=False,
                 spec_decode_metadata=None,
+                input_ids=MagicMock(),
             )
 
             # 3. ===== Assert =====
@@ -214,7 +215,7 @@ class TestSpeculativeDecodingManager:
         self.mock_device_array = mock_device_array
 
     @pytest.mark.parametrize(
-        "num_draft_tokens,cu_num_scheduled_tokens,padded_num_reqs,expected_logits_indices,expected_bonus_logits_indices,expected_target_logits_indices,expected_draft_token_ids",
+        "num_draft_tokens,cu_num_scheduled_tokens,padded_num_reqs,expected_logits_indices,expected_bonus_logits_indices,expected_target_logits_indices",
         [
             (
                 # Normal case
@@ -223,8 +224,7 @@ class TestSpeculativeDecodingManager:
                 8,
                 [0, 1, 2, 3, 103, 104, 105, 106, 206, 207, 208],
                 [3, 4, 7, 8, 10, 0, 0, 0],
-                [0, 1, 2, 5, 6, 9, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-                [10, 20, 30, 1050, 1060, 2080, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
+                [0, 1, 2, 5, 6, 9, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
             (
                 # High speculative tokens case
                 [5, 3, 4, 2, 1],
@@ -238,16 +238,12 @@ class TestSpeculativeDecodingManager:
                 [
                     0, 1, 2, 3, 4, 6, 7, 8, 10, 11, 12, 13, 15, 16, 18, 0, 0,
                     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
-                ],
-                [
-                    10, 20, 30, 40, 50, 70, 80, 90, 140, 150, 160, 170, 200,
-                    210, 250
                 ]),
         ])
     def test_get_spec_decode_metadata_parametrized(
             self, num_draft_tokens, cu_num_scheduled_tokens, padded_num_reqs,
             expected_logits_indices, expected_bonus_logits_indices,
-            expected_target_logits_indices, expected_draft_token_ids):
+            expected_target_logits_indices):
         """Comprehensive parametrized test for _get_spec_decode_metadata function."""
         # Setup
         self._setup_spec_decode_metadata_test()
@@ -293,12 +289,6 @@ class TestSpeculativeDecodingManager:
         ] * (padded_len - len(expected_target_logits_indices))
         assert np.asarray(metadata.target_logits_indices).tolist(
         ) == expected_padded_target_logits_indices
-
-        # draft_token_ids - pad the expected values to the correct length and compare as Python lists
-        expected_padded_draft_token_ids = expected_draft_token_ids + [0] * (
-            padded_len - len(expected_draft_token_ids))
-        assert np.asarray(metadata.draft_token_ids).tolist(
-        ) == expected_padded_draft_token_ids
 
         # draft_lengths - pad and compare as Python lists
         expected_padded_num_draft_tokens = num_draft_tokens + [0] * (

--- a/tests/runner/test_tpu_runner_dp.py
+++ b/tests/runner/test_tpu_runner_dp.py
@@ -566,25 +566,12 @@ class TestTPUJaxRunnerDPInputsLightweight:
         assert np.array_equal(attention_metadata.input_positions,
                               expected_positions)
 
-        # 3. Verify query_start_loc content
-        query_start_loc = attention_metadata.query_start_loc_cpu
-        max_num_reqs_per_dp = self.runner.max_num_reqs // 2
-        expected_query_start = np.zeros(self.runner.max_num_reqs + 2,
-                                        dtype=np.int32)
-        # DP rank 0: cumsum([2]) = [2] at positions [1:2] → [0, 2, 1, 1, 1]
-        expected_query_start[1] = 2  # req1 has 2 tokens
-        expected_query_start[2:max_num_reqs_per_dp + 1] = 1
-        # DP rank 1: cumsum([3]) = [3] at positions [6:7] → [0, 3, 1, 1, 1]
-        expected_query_start[max_num_reqs_per_dp + 2] = 3  # req2 has 3 tokens
-        expected_query_start[max_num_reqs_per_dp + 3:] = 1
-        assert np.array_equal(query_start_loc, expected_query_start)
-
-        # 4. Verify request_distribution content
+        # 3. Verify request_distribution content
         expected_distribution = np.array([[0, 0, 1], [0, 0, 1]]).flatten()
         np.testing.assert_array_equal(attention_metadata.request_distribution,
                                       expected_distribution)
 
-        # 5. Verify logits_indices content
+        # 4. Verify logits_indices content
         assert len(logits_indices) == 8  # padded_num_reqs
         expected_logits = np.full(8, -1, dtype=np.int32)
         expected_logits[0] = 1  # req1 last token position (2-1)
@@ -592,7 +579,7 @@ class TestTPUJaxRunnerDPInputsLightweight:
             4] = 2  # req2 last token position (3-1) at DP rank 1 offset (4*1)
         assert np.array_equal(logits_indices, expected_logits)
 
-        # 6. Verify logits_indices_selector
+        # 5. Verify logits_indices_selector
         assert len(logits_indices_selector) == 2
         assert np.array_equal(logits_indices_selector, np.array([0, 4]))
 
@@ -679,26 +666,12 @@ class TestTPUJaxRunnerDPInputsLightweight:
         assert np.array_equal(attention_metadata.input_positions,
                               expected_positions)
 
-        # 3. Verify query_start_loc
-        query_start_loc = attention_metadata.query_start_loc_cpu
-        max_num_reqs_per_dp = self.runner.max_num_reqs // 2  # 4
-        expected_query_start = np.zeros(self.runner.max_num_reqs + 2,
-                                        dtype=np.int32)
-        # Rank 0: req1 (3 tokens), req2 (2 tokens)
-        expected_query_start[1] = 3  # req1 has 3 tokens
-        expected_query_start[2] = 5  # cumulative: 3 + 2 = 5
-        expected_query_start[3:max_num_reqs_per_dp + 1] = 1  # padding
-        # Rank 1: empty (all zeros)
-        expected_query_start[max_num_reqs_per_dp +
-                             1:] = 0  # Empty rank sets to 0
-        assert np.array_equal(query_start_loc, expected_query_start)
-
-        # 4. Verify request_distribution
+        # 3. Verify request_distribution
         expected_distribution = np.array([[0, 0, 2], [0, 0, 0]]).flatten()
         np.testing.assert_array_equal(attention_metadata.request_distribution,
                                       expected_distribution)
 
-        # 5. Verify logits_indices
+        # 4. Verify logits_indices
         assert len(
             logits_indices) == 8  # padded_num_reqs (8 in this case, not 16)
         # Rank 0: req1 ends at pos 2, req2 ends at pos 4
@@ -708,7 +681,7 @@ class TestTPUJaxRunnerDPInputsLightweight:
         expected_logits[1] = 4  # req2 ends at position 4 (5-1)
         assert np.array_equal(logits_indices, expected_logits)
 
-        # 6. Verify logits_indices_selector
+        # 5. Verify logits_indices_selector
         assert len(logits_indices_selector) == 2
         expected_selector = np.array([0, 1])
         np.testing.assert_array_equal(logits_indices_selector,
@@ -857,7 +830,6 @@ class TestTPUJaxRunnerDPInputsLightweight:
         req_ids_dp = {0: ["req1", "req2"], 1: ["req3"]}
         scheduled_tokens_per_dp_rank = {0: [3, 2], 1: [4]}
         padded_num_scheduled_tokens_per_dp_rank = 8
-        num_draft_tokens_per_dp_rank = {0: np.array([0, 0], dtype=np.int32)}
         dp_size = 2
 
         # Setup _pre_async_results with placeholder mapping
@@ -870,11 +842,10 @@ class TestTPUJaxRunnerDPInputsLightweight:
         # Call the method
         result = self.runner._prepare_async_token_substitution_indices(
             req_ids_dp, scheduled_tokens_per_dp_rank,
-            padded_num_scheduled_tokens_per_dp_rank,
-            num_draft_tokens_per_dp_rank, dp_size)
+            padded_num_scheduled_tokens_per_dp_rank, dp_size)
 
         (token_in_tpu_cur_input_indices_dp,
-         token_in_tpu_pre_next_tokens_indices_dp, _, _) = result
+         token_in_tpu_pre_next_tokens_indices_dp) = result
 
         # Verify DP rank 0
         # req1: token_offset=0, acc_cur_len starts at 0, after 3 tokens: 3, so last token at 2
@@ -901,7 +872,6 @@ class TestTPUJaxRunnerDPInputsLightweight:
         req_ids_dp = {0: ["req1", "req2"], 1: ["req3"]}
         scheduled_tokens_per_dp_rank = {0: [3, 2], 1: [4]}
         padded_num_scheduled_tokens_per_dp_rank = 8
-        num_draft_tokens_per_dp_rank = {0: np.array([0, 0], dtype=np.int32)}
         dp_size = 2
 
         # No placeholders
@@ -910,11 +880,10 @@ class TestTPUJaxRunnerDPInputsLightweight:
 
         result = self.runner._prepare_async_token_substitution_indices(
             req_ids_dp, scheduled_tokens_per_dp_rank,
-            padded_num_scheduled_tokens_per_dp_rank,
-            num_draft_tokens_per_dp_rank, dp_size)
+            padded_num_scheduled_tokens_per_dp_rank, dp_size)
 
         (token_in_tpu_cur_input_indices_dp,
-         token_in_tpu_pre_next_tokens_indices_dp, _, _) = result
+         token_in_tpu_pre_next_tokens_indices_dp) = result
 
         # All lists should be empty since no placeholders
         assert token_in_tpu_cur_input_indices_dp[0] == []
@@ -1053,12 +1022,6 @@ class TestTPUJaxRunnerDPInputsLightweight:
             1: []
         }, {
             0: [0],
-            1: []
-        }, {
-            0: [],
-            1: []
-        }, {
-            0: [],
             1: []
         }))
         self.runner._prepare_async_token_substitution_indices = mock_prepare_async

--- a/tests/spec_decode/test_eagle3.py
+++ b/tests/spec_decode/test_eagle3.py
@@ -132,8 +132,6 @@ def test_prepare_inputs():
         block_tables=jnp.array([]),  # This will be replaced by the mock
         request_distribution=None,
     )
-    attn_metadata.query_start_loc_cpu = qsl_cpu
-    attn_metadata.seq_lens_cpu = sl_cpu
 
     # Expected results
     expected_new_qsl = np.zeros(max_num_seqs + 1, dtype=np.int32)

--- a/tests/spec_decode/test_utils.py
+++ b/tests/spec_decode/test_utils.py
@@ -45,7 +45,6 @@ def _build_inputs(seqs, num_speculative_tokens):
     num_draft_cpu = np.asarray(num_draft, dtype=np.int32)
 
     metadata = SpecDecodeMetadata(
-        draft_token_ids=jnp.zeros(int(num_draft_cpu.sum()), dtype=jnp.int32),
         draft_lengths=jnp.asarray(num_draft_cpu),
         target_logits_indices=jnp.zeros(int(num_draft_cpu.sum()),
                                         dtype=jnp.int32),

--- a/tpu_inference/layers/common/attention_metadata.py
+++ b/tpu_inference/layers/common/attention_metadata.py
@@ -13,8 +13,7 @@
 # limitations under the License.
 
 import functools
-from dataclasses import dataclass, field
-from typing import Any
+from dataclasses import dataclass
 
 import jax
 
@@ -30,7 +29,6 @@ import jax
         "mamba_state_indices",
     ],
     meta_fields=["padded_num_reqs"],
-    drop_fields=["query_start_loc_cpu", "seq_lens_cpu"],
 )
 @dataclass
 class AttentionMetadata(object):
@@ -60,5 +58,3 @@ class AttentionMetadata(object):
     # power of 2 between min and max requests.
     # Env var ATTN_CUSTOM_NUM_REQS_BUCKETS can manually override the buckets.
     padded_num_reqs: int = -1
-
-    query_start_loc_cpu: Any = field(init=False)

--- a/tpu_inference/layers/common/attention_metadata.py
+++ b/tpu_inference/layers/common/attention_metadata.py
@@ -13,7 +13,8 @@
 # limitations under the License.
 
 import functools
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from typing import Any
 
 import jax
 
@@ -29,6 +30,7 @@ import jax
         "mamba_state_indices",
     ],
     meta_fields=["padded_num_reqs"],
+    drop_fields=["query_start_loc_cpu", "seq_lens_cpu"],
 )
 @dataclass
 class AttentionMetadata(object):
@@ -58,3 +60,5 @@ class AttentionMetadata(object):
     # power of 2 between min and max requests.
     # Env var ATTN_CUSTOM_NUM_REQS_BUCKETS can manually override the buckets.
     padded_num_reqs: int = -1
+
+    query_start_loc_cpu: Any = field(init=False)

--- a/tpu_inference/runner/compilation_manager.py
+++ b/tpu_inference/runner/compilation_manager.py
@@ -815,10 +815,44 @@ class CompilationManager:
             "Compiling speculative_decoding with different input shapes.")
         self._precompile_rejection_sampler()
         self._precompile_extract_last_sampled_tokens()
+        self._precompile_extract_draft_token_ids()
         if self.runner.speculative_config.method == "eagle3":
             self._precompile_eagle3_helpers()
         if self.runner.speculative_config.method == "mtp":
             self._precompile_mtp_helpers()
+
+    def _precompile_extract_draft_token_ids(self) -> None:
+        logger.info(
+            "Compiling extract_draft_token_ids with different input shapes.")
+        data_parallel_attn_sharding = NamedSharding(
+            self.runner.mesh, PartitionSpec(ShardingAxisName.ATTN_DATA))
+        for num_tokens in self.runner.num_tokens_paddings:
+            for num_logits in self.runner.num_logits_paddings:
+                if self._should_skip_padding_combination(num_tokens,
+                                                         num_logits,
+                                                         only_equal=False):
+                    continue
+                input_ids = self._create_dummy_tensor(
+                    (num_tokens, ),
+                    jnp.int32,
+                    sharding=data_parallel_attn_sharding)
+                final_logits_indices = self._create_dummy_tensor(
+                    (num_logits, ),
+                    jnp.int32,
+                    sharding=data_parallel_attn_sharding)
+                target_logits_indices = self._create_dummy_tensor(
+                    (num_logits, ),
+                    jnp.int32,
+                    sharding=data_parallel_attn_sharding)
+                self._run_compilation(
+                    f"worker{self.runner.rank} extract_draft_token_ids",
+                    self.runner._extract_draft_token_ids,
+                    input_ids,
+                    final_logits_indices,
+                    target_logits_indices,
+                    num_tokens=num_tokens,
+                    num_logits=num_logits,
+                )
 
     def _precompile_extract_last_sampled_tokens(self) -> None:
         logger.info(
@@ -859,8 +893,6 @@ class CompilationManager:
                     jnp.int32,
                     sharding=data_parallel_attn_sharding)
                 spec_decode_metadata = SpecDecodeMetadata(
-                    draft_token_ids=self._create_dummy_tensor((num_logits, ),
-                                                              jnp.int32),
                     draft_lengths=self._create_dummy_tensor((num_reqs, ),
                                                             jnp.int32),
                     target_logits_indices=self._create_dummy_tensor(

--- a/tpu_inference/runner/speculative_decoding_manager.py
+++ b/tpu_inference/runner/speculative_decoding_manager.py
@@ -80,6 +80,7 @@ class SpeculativeDecodingManager:
                 self.runner.input_batch.num_tokens_no_spec,
                 self.runner.input_batch.token_ids_cpu)
         elif self.runner.speculative_config.use_eagle():
+            assert input_ids is not None
             self._draft_token_ids = self.propose_eagle3_draft_token_ids(
                 spec_decode_metadata,
                 last_sampled_token_id,
@@ -222,10 +223,7 @@ class SpeculativeDecodingManager:
         # [0, 1, 2, 5, 6, 9]
         target_logits_indices += arange
 
-        # Compute the draft token ids.
         # draft_token_indices:      [  1,   2,   3, 105, 106, 208]
-        draft_token_ids = input_ids[logits_indices]
-        draft_token_ids = draft_token_ids[target_logits_indices + 1]
         padded_logits_length = runner_utils.get_padded_token_len(
             self.runner.num_logits_paddings, logits_indices.shape[0])
         padded_logits_indices = np.concatenate([
@@ -248,11 +246,6 @@ class SpeculativeDecodingManager:
             np.zeros(padded_num_reqs - num_draft_tokens.shape[0],
                      dtype=np.int32)
         ])
-        padded_draft_token_ids = np.concatenate([
-            draft_token_ids,
-            np.zeros(padded_logits_length - draft_token_ids.shape[0],
-                     dtype=np.int32)
-        ])
         padded_target_logits_indices = np.concatenate([
             target_logits_indices,
             np.zeros(padded_logits_length - target_logits_indices.shape[0],
@@ -261,16 +254,14 @@ class SpeculativeDecodingManager:
 
         padded_num_draft_tokens_cpu = padded_num_draft_tokens
         # CPU -> TPU copy.
-        (padded_num_draft_tokens, padded_draft_token_ids,
-         padded_logits_indices, padded_target_logits_indices,
+        (padded_num_draft_tokens, padded_logits_indices,
+         padded_target_logits_indices,
          padded_bonus_logits_indices) = device_array(
              self.runner.mesh,
-             (padded_num_draft_tokens, padded_draft_token_ids,
-              padded_logits_indices, padded_target_logits_indices,
-              padded_bonus_logits_indices))
+             (padded_num_draft_tokens, padded_logits_indices,
+              padded_target_logits_indices, padded_bonus_logits_indices))
 
         metadata = SpecDecodeMetadata(
-            draft_token_ids=padded_draft_token_ids,
             draft_lengths=padded_num_draft_tokens,
             target_logits_indices=padded_target_logits_indices,
             bonus_logits_indices=padded_bonus_logits_indices,

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -16,7 +16,7 @@ import functools
 import logging
 import random
 from contextlib import nullcontext
-from dataclasses import dataclass, replace
+from dataclasses import dataclass
 from typing import Any, Callable, Dict, List, Optional, Tuple, cast
 
 import jax
@@ -1138,8 +1138,12 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             )
             target_logits = self._select_from_array_fn(
                 logits, spec_decode_metadata.target_logits_indices)
+            assert input_ids is not None
+            draft_token_ids = self._extract_draft_token_ids(
+                input_ids, spec_decode_metadata.final_logits_indices,
+                spec_decode_metadata.target_logits_indices)
             next_tokens = self.rejection_sampler(
-                draft_token_ids=spec_decode_metadata.draft_token_ids,
+                draft_token_ids=draft_token_ids,
                 num_draft_tokens=spec_decode_metadata.draft_lengths,
                 draft_probs=None,
                 target_logits=target_logits,
@@ -1375,6 +1379,26 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
 
         return ret
 
+    @jax.jit(static_argnums=(0, ))
+    def _extract_draft_token_ids(self, input_ids, logits_indices,
+                                 target_logits_indices):
+
+        def _fn(local_input_ids, local_logits_indices,
+                local_target_logits_indices):
+            draft_token_ids = local_input_ids[local_logits_indices]
+            return draft_token_ids[local_target_logits_indices + 1]
+
+        ret = jax.shard_map(
+            _fn,
+            mesh=self.mesh,
+            in_specs=(PartitionSpec(ShardingAxisName.ATTN_DATA),
+                      PartitionSpec(ShardingAxisName.ATTN_DATA),
+                      PartitionSpec(ShardingAxisName.ATTN_DATA)),
+            out_specs=PartitionSpec(ShardingAxisName.ATTN_DATA))(
+                input_ids, logits_indices, target_logits_indices)
+
+        return ret
+
     @staticmethod
     @jax.jit(static_argnames=("max_logprobs", ))
     def _compute_and_gather_logprobs(logits, next_tokens, max_logprobs):
@@ -1458,44 +1482,30 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
 
     def _prepare_async_token_substitution_indices(
             self, req_ids_dp, scheduled_tokens_per_dp_rank,
-            padded_num_scheduled_tokens_per_dp_rank,
-            num_draft_tokens_per_dp_rank, dp_size):
+            padded_num_scheduled_tokens_per_dp_rank, dp_size):
         """Prepare token substitution indices for async scheduling."""
         # For input_ids substitution.
         token_in_tpu_cur_input_indices_dp = {}
         token_in_tpu_pre_next_tokens_indices_dp = {}
-        # For SpecDecodeMetadata.draft_token_ids substitution.
-        draft_token_in_tpu_cur_indices_dp = {}
-        draft_token_in_prev_next_tokens_indices_dp = {}
         spec_decode_enabled = (self.speculative_config is not None)
 
         for dp_rank in range(dp_size):
             token_in_tpu_cur_input_indices_dp[dp_rank] = []
             token_in_tpu_pre_next_tokens_indices_dp[dp_rank] = []
-            draft_token_in_tpu_cur_indices_dp[dp_rank] = []
-            draft_token_in_prev_next_tokens_indices_dp[dp_rank] = []
 
             num_scheduled_tokens_per_req = scheduled_tokens_per_dp_rank[
                 dp_rank]
-            num_draft_tokens = num_draft_tokens_per_dp_rank.get(dp_rank, {})
             token_in_tpu_cur_input_indices_list = token_in_tpu_cur_input_indices_dp[
                 dp_rank]
             token_in_tpu_pre_next_tokens_indices_list = token_in_tpu_pre_next_tokens_indices_dp[
-                dp_rank]
-            draft_token_in_tpu_cur_indices_list = draft_token_in_tpu_cur_indices_dp[
-                dp_rank]
-            draft_token_in_prev_next_tokens_indices_list = draft_token_in_prev_next_tokens_indices_dp[
                 dp_rank]
 
             token_offset = padded_num_scheduled_tokens_per_dp_rank * dp_rank
             acc_cur_len = token_offset
             # TODO(gxd3): support spec-decoding with DP.
-            draft_tokens_acc_cur_len = 0
 
             for i, req_id in enumerate(req_ids_dp[dp_rank]):
                 acc_cur_len += num_scheduled_tokens_per_req[i]
-                if dp_rank == 0:
-                    draft_tokens_acc_cur_len += num_draft_tokens[i]
                 if req_id not in self._pre_async_results.placeholder_req_id_to_index:
                     continue
 
@@ -1518,15 +1528,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                         token_in_tpu_pre_next_tokens_indices_list.append(
                             idx * (max_num_spec_tokens + 1) + j)
 
-                    draft_base_offset = draft_tokens_acc_cur_len - num_draft_tokens[
-                        i]
-                    for j in range(num_draft_tokens[i]):
-                        draft_token_in_tpu_cur_indices_list.append(
-                            draft_base_offset + j)
-                        draft_token_in_prev_next_tokens_indices_list.append(
-                            idx * (max_num_spec_tokens + 1) + j + 1)
-
-        return token_in_tpu_cur_input_indices_dp, token_in_tpu_pre_next_tokens_indices_dp, draft_token_in_tpu_cur_indices_dp, draft_token_in_prev_next_tokens_indices_dp
+        return token_in_tpu_cur_input_indices_dp, token_in_tpu_pre_next_tokens_indices_dp
 
     def _apply_async_token_substitution(self, input, next_tokens_in_tpu,
                                         token_in_tpu_cur_input_indices,
@@ -1643,19 +1645,15 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             num_draft_tokens[req_idx] = len(draft_token_ids)
         token_in_tpu_cur_input_indices_dp = {}
         token_in_tpu_pre_next_tokens_indices_dp = {}
-        draft_token_in_tpu_cur_indices_dp = {}
-        draft_token_in_prev_next_tokens_indices_dp = {}
         if self.scheduler_config.async_scheduling and self._pre_async_results is not None:
             # If async previous results exists, we will prepare for the token substitution here
             # The actual substitution will be performed in tpu during later parts of this function.
-            (token_in_tpu_cur_input_indices_dp,
-             token_in_tpu_pre_next_tokens_indices_dp,
-             draft_token_in_tpu_cur_indices_dp,
-             draft_token_in_prev_next_tokens_indices_dp
-             ) = self._prepare_async_token_substitution_indices(
-                 req_ids_dp, scheduled_tokens_per_dp_rank,
-                 padded_num_scheduled_tokens_per_dp_rank,
-                 {0: num_draft_tokens}, dp_size)
+            (
+                token_in_tpu_cur_input_indices_dp,
+                token_in_tpu_pre_next_tokens_indices_dp,
+            ) = self._prepare_async_token_substitution_indices(
+                req_ids_dp, scheduled_tokens_per_dp_rank,
+                padded_num_scheduled_tokens_per_dp_rank, dp_size)
 
         self.device_buffer.reset()
 
@@ -1941,8 +1939,6 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                 padded_num_reqs=attn_padded_num_reqs,
             )
 
-            # This is for making these cpu buffers hidden during tracing
-            attention_metadata_gid.query_start_loc_cpu = query_start_loc_view
             return attention_metadata_gid
 
         attention_metadata: AttentionMetadata | dict[str, AttentionMetadata]
@@ -1965,18 +1961,12 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             # Collect all token indices that need substitution across all DP ranks
             all_token_indices_to_substitute = []
             all_pre_next_tokens_indices = []
-            draft_all_token_indices_to_substitute = []
-            draft_all_pre_next_tokens_indices = []
 
             for dp_rank in range(dp_size):
                 cur_indices = token_in_tpu_cur_input_indices_dp[dp_rank]
                 pre_indices = token_in_tpu_pre_next_tokens_indices_dp[dp_rank]
                 all_token_indices_to_substitute.extend(cur_indices)
                 all_pre_next_tokens_indices.extend(pre_indices)
-                draft_all_token_indices_to_substitute.extend(
-                    draft_token_in_tpu_cur_indices_dp[dp_rank])
-                draft_all_pre_next_tokens_indices.extend(
-                    draft_token_in_prev_next_tokens_indices_dp[dp_rank])
 
             if self.scheduler_config.async_scheduling and self._pre_async_results:
                 if self.speculative_config:
@@ -1990,20 +1980,6 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                 input_ids = self._apply_async_token_substitution(
                     input_ids, next_tokens, token_in_tpu_cur_input_indices,
                     token_in_tpu_pre_next_tokens_indices)
-                if spec_decode_metadata:
-                    draft_token_in_tpu_cur_input_indices = np.array(
-                        draft_all_token_indices_to_substitute)
-                    draft_token_in_tpu_pre_next_tokens_indices = np.array(
-                        draft_all_pre_next_tokens_indices)
-                    draft_token_ids = self._apply_async_token_substitution(
-                        spec_decode_metadata.draft_token_ids,
-                        self._pre_async_results.spec_decode_next_tokens,
-                        draft_token_in_tpu_cur_input_indices,
-                        draft_token_in_tpu_pre_next_tokens_indices)
-                    new_md = replace(spec_decode_metadata,
-                                     draft_token_ids=draft_token_ids)
-                    new_md.draft_lengths_cpu = spec_decode_metadata.draft_lengths_cpu
-                    spec_decode_metadata = new_md
 
         num_scheduled_tokens_per_req = np.concatenate([
             np.array(scheduled_tokens_per_dp_rank[dp_rank], dtype=np.int32)

--- a/tpu_inference/runner/utils.py
+++ b/tpu_inference/runner/utils.py
@@ -763,7 +763,6 @@ class PhasedBasedProfiler:
 @functools.partial(
     jax.tree_util.register_dataclass,
     data_fields=[
-        "draft_token_ids",
         "draft_lengths",
         "target_logits_indices",
         "bonus_logits_indices",
@@ -775,7 +774,6 @@ class PhasedBasedProfiler:
 @dataclass
 class SpecDecodeMetadata:
     """Metadata for speculative decoding on JAX/TPU, containing all necessary indices."""
-    draft_token_ids: jnp.ndarray
     draft_lengths: jnp.ndarray
     target_logits_indices: jnp.ndarray
     bonus_logits_indices: jnp.ndarray
@@ -801,7 +799,7 @@ def host_extract_sampled_tokens(
         valid_sampled_token_ids = runner.rejection_sampler.parse_output(
             next_tokens, runner.input_batch.vocab_size,
             spec_decode_metadata.draft_lengths_cpu, num_reqs,
-            spec_decode_metadata.draft_token_ids.shape[0])
+            spec_decode_metadata.final_logits_indices.shape[0])
     # Mask out the sampled tokens that should not be sampled.
     for i in discard_sampled_tokens_req_indices:
         valid_sampled_token_ids[i].clear()


### PR DESCRIPTION
[Spec decoding] Refactoring to simplify logics

simplification:
* No need to include `draft_token_ids` as part of `SpecDecodeMetadata`. Instead, extract draft token ids using `SpecDecodeMetadata.{final_logits_indices, target_logits_indices}` and `input_ids` just before rejection_sample() where draft_token_ids is needed.
In doing this way, we can avoid `_apply_async_token_substitution` on `SpecDecodeMetadata.draft_token_ids` and the associated indices calculation in `_prepare_async_token_substitution_indices`.

Also removed some fields in `AttentionMetadata` that are no longer used.


TESTED=all tests in https://buildkite.com/tpu-commons/tpu-inference-ci/builds/18484/list