### PR TITLE
[releases/v0.21.0] Cherry-pick #2686: Add EP to Kimi-K2.6 unit test

### DIFF
--- a/tests/e2e/benchmarking/mlperf.sh
+++ b/tests/e2e/benchmarking/mlperf.sh
@@ -150,7 +150,7 @@ if [ -z "$dataset_path" ]; then
 
     if [ ! -f "$dataset_path" ]; then
         echo "Downloading and verifying the MLPerf dataset..."
-        
+
         # Check if rclone is installed; if not, install it via package manager for security
         if ! command -v rclone &> /dev/null; then
             echo "rclone not found. Installing..."
@@ -325,7 +325,7 @@ for model_name in $model_list; do
             if [[ "${model_name,,}" == *"kimi"* ]]; then
                 served_name=moonshotai/Kimi-K2.6
                 current_serve_args+=(--kv-cache-dtype=fp8 --gpu-memory-utilization 0.977 --limit-mm-per-prompt='{"image": 0, "video": 0, "vision_chunk": 0}' )
-                current_serve_args+=(--served-model-name "${served_name}"  --load-format=runai_streamer   --trust-remote-code --kv-cache-dtype=fp8 --additional-config '{"sharding": {"sharding_strategy": {"enable_dp_attention": true, "tensor_parallelism": '"${DEVICE_COUNT}"'}}}')
+                current_serve_args+=(--served-model-name "${served_name}"  --load-format=runai_streamer --enable-expert-parallel  --trust-remote-code --kv-cache-dtype=fp8 --additional-config '{"sharding": {"sharding_strategy": {"enable_dp_attention": true, "tensor_parallelism": '"${DEVICE_COUNT}"'}}}')
             else
                 served_name=deepseek-ai/DeepSeek-R1
                 current_serve_args+=(--served-model-name "${served_name}"  --load-format=runai_streamer   --trust-remote-code --kv-cache-dtype=fp8 )


### PR DESCRIPTION
Cherry-pick of #2686 onto `releases/v0.21.0`.

## Why
Nightly build [#18145](https://buildkite.com/tpu-commons/tpu-inference-ci/builds/18145) on `releases/v0.21.0` failed on `tpu7x Unit tests for moonshotai/Kimi-K2.6` with `jax.IndivisibleError` — NamedSharding spec wants 8 partitions on axis 1 but the dimension is size 4. The same failure was also present on `main` nightly #18148 the same day; the fix landed on `main` as #2686 and has not yet been brought to the release branch.

## What
Single-file change to `tests/e2e/benchmarking/mlperf.sh` (2 lines) — adds EP configuration for the Kimi-K2.6 unit test path.

Original PR: vllm-project/tpu-inference#2686