### PR TITLE
Qwen optimizations base changes

### DIFF
--- a/tpu_inference/layers/common/sharding.py
+++ b/tpu_inference/layers/common/sharding.py
@@ -109,6 +109,22 @@ class LazyShardingAxisName:
 
     def __getattr__(self, name):
         self._initialize()
+        if name == "KV_CACHE_HEAD" and self._cls is ShardingAxisNameBase:
+            from vllm.config import get_current_vllm_config
+            try:
+                vllm_config = get_current_vllm_config()
+            except Exception:
+                vllm_config = None
+
+            enable_dp_attention = False
+            if vllm_config is not None:
+                enable_dp_attention = vllm_config.additional_config.get(
+                    "sharding", {}).get("sharding_strategy", {}).get(
+                        "enable_dp_attention", False)
+
+            if not enable_dp_attention:
+                return getattr(self._cls, "MODEL", "model")
+
         return getattr(self._cls, name)
 
 

--- a/tpu_inference/models/vllm/experimental/qwen3_vl_patcher.py
+++ b/tpu_inference/models/vllm/experimental/qwen3_vl_patcher.py
@@ -41,6 +41,9 @@ making sure they go through standard function arguments:
    model's cache just-in-time for the execution, and proceed with the original forward pass.
 """
 
+from functools import partial
+import jax
+import jax.numpy as jnp
 import torch
 import torch.nn as nn
 import vllm.model_executor.models.qwen3_vl as qwen3_vl_mod
@@ -250,41 +253,173 @@ def _patched_flatten_embeddings(embeddings: NestedTensors) -> torch.Tensor:
     return torch.cat(tuple(_patched_flatten_embeddings(t) for t in embeddings))
 
 
+@partial(jax.jit, static_argnums=(1, 2, 3, 4, 5))
+def pos_embed_interpolate_jax(
+    embed_weight: jax.Array,
+    t: int,
+    h: int,
+    w: int,
+    num_grid_per_side: int,
+    m_size: int,
+) -> jax.Array:
+    hidden_dim = embed_weight.shape[1]
+
+    h_idxs = jnp.linspace(0, num_grid_per_side - 1, h, dtype=jnp.float32)
+    w_idxs = jnp.linspace(0, num_grid_per_side - 1, w, dtype=jnp.float32)
+
+    h_floor = h_idxs.astype(jnp.int32)
+    w_floor = w_idxs.astype(jnp.int32)
+    h_ceil = jnp.clip(h_floor + 1, 0, num_grid_per_side - 1)
+    w_ceil = jnp.clip(w_floor + 1, 0, num_grid_per_side - 1)
+
+    dh = h_idxs - h_floor
+    dw = w_idxs - w_floor
+
+    dh_grid, dw_grid = jnp.meshgrid(dh, dw, indexing="ij")
+    h_floor_grid, w_floor_grid = jnp.meshgrid(h_floor, w_floor, indexing="ij")
+    h_ceil_grid, w_ceil_grid = jnp.meshgrid(h_ceil, w_ceil, indexing="ij")
+
+    w11 = dh_grid * dw_grid
+    w10 = dh_grid - w11
+    w01 = dw_grid - w11
+    w00 = 1.0 - dh_grid - w01
+
+    h_grid = jnp.stack([h_floor_grid, h_floor_grid, h_ceil_grid, h_ceil_grid])
+    w_grid = jnp.stack([w_floor_grid, w_ceil_grid, w_floor_grid, w_ceil_grid])
+    h_grid_idx = h_grid * num_grid_per_side
+
+    indices = (h_grid_idx + w_grid).reshape(4, -1)
+    weights = jnp.stack([w00, w01, w10, w11], axis=0).reshape(4, -1, 1)
+    weights = weights.astype(embed_weight.dtype)
+
+    embeds = embed_weight[indices]
+    embeds = embeds * weights
+    combined = embeds.sum(axis=0)
+
+    combined = combined.reshape(h // m_size, m_size, w // m_size, m_size, hidden_dim)
+    combined = combined.transpose(0, 2, 1, 3, 4).reshape(-1, hidden_dim)
+    
+    repeated = jnp.tile(combined, (t, 1))
+    return repeated
+
+
+@partial(jax.jit, static_argnums=(1, 2))
+def rot_pos_ids_jax(h: int, w: int, spatial_merge_size: int) -> jax.Array:
+    h_div = h // spatial_merge_size
+    w_div = w // spatial_merge_size
+
+    hpos_ids = jnp.broadcast_to(jnp.arange(h).reshape(h, 1), (h, w))
+    hpos_ids = hpos_ids.reshape(h_div, spatial_merge_size, w_div, spatial_merge_size)
+    hpos_ids = hpos_ids.transpose(0, 2, 1, 3).flatten()
+
+    wpos_ids = jnp.broadcast_to(jnp.arange(w).reshape(1, w), (h, w))
+    wpos_ids = wpos_ids.reshape(h_div, spatial_merge_size, w_div, spatial_merge_size)
+    wpos_ids = wpos_ids.transpose(0, 2, 1, 3).flatten()
+
+    return jnp.stack([hpos_ids, wpos_ids], axis=-1)
+
+
+@partial(jax.jit, static_argnums=(3, 4))
+def rot_pos_emb_jax(
+    cos_cache: jax.Array,
+    sin_cache: jax.Array,
+    grid_thw: tuple,
+    spatial_merge_size: int,
+    max_grid_size: int,
+) -> tuple[jax.Array, jax.Array]:
+    pos_ids_list = []
+    for t, h, w in grid_thw:
+        ids = rot_pos_ids_jax(h, w, spatial_merge_size)
+        if t > 1:
+            ids = jnp.tile(ids, (t, 1))
+        pos_ids_list.append(ids)
+    pos_ids = jnp.concatenate(pos_ids_list, axis=0)
+
+    cos_combined = cos_cache[pos_ids].reshape(pos_ids.shape[0], -1)
+    sin_combined = sin_cache[pos_ids].reshape(pos_ids.shape[0], -1)
+
+    return cos_combined, sin_combined
+
+
+def _patched_fast_pos_embed_interpolate(self, grid_thw: list[list[int]]) -> torch.Tensor:
+    embed_weight_jax = jax_view(self.pos_embed.weight)
+    
+    outputs = []
+    for t, h, w in grid_thw:
+        res_jax = pos_embed_interpolate_jax(
+            embed_weight_jax,
+            t,
+            h,
+            w,
+            self.num_grid_per_side,
+            self.spatial_merge_size,
+        )
+        outputs.append(torch_view(res_jax))
+        
+    return torch.cat(outputs, dim=0)
+
+
+def _patched_rot_pos_emb(self, grid_thw: list[list[int]]):
+    max_grid_size = max(max(h, w) for _, h, w in grid_thw)
+    
+    cos, sin = self.rotary_pos_emb.get_cos_sin(max_grid_size)
+    cos_cache_jax = jax_view(cos)
+    sin_cache_jax = jax_view(sin)
+    
+    grid_thw_tuple = tuple(tuple(x) for x in grid_thw)
+    
+    cos_jax, sin_jax = rot_pos_emb_jax(
+        cos_cache_jax,
+        sin_cache_jax,
+        grid_thw_tuple,
+        self.spatial_merge_size,
+        max_grid_size,
+    )
+    
+    return torch_view(cos_jax), torch_view(sin_jax)
+
+
 def apply_qwen3_vl_patches(vllm_model):
-    """Apply Qwen3-VL specific patches for stateless Deepstack support."""
-    if not getattr(vllm_model, "use_deepstack", False):
-        return
+    """Apply Qwen3-VL specific patches for stateless Deepstack support and JIT compilation."""
+    if getattr(vllm_model, "use_deepstack", False):
 
-    # 1. Override deepstack setter to avoid stateful updates of native vLLM variables
-    orig_set_deepstack = getattr(vllm_model, "_set_deepstack_input_embeds",
-                                 None)
-    if orig_set_deepstack is not None:
-        vllm_model._set_deepstack_input_embeds = lambda embeds: _patched_set_deepstack(
-            vllm_model, embeds)
+        # 1. Override deepstack setter to avoid stateful updates of native vLLM variables
+        orig_set_deepstack = getattr(vllm_model, "_set_deepstack_input_embeds",
+                                     None)
+        if orig_set_deepstack is not None:
+            vllm_model._set_deepstack_input_embeds = lambda embeds: _patched_set_deepstack(
+                vllm_model, embeds)
 
-    # 2. Override deepstack getter to prefer JAX-compatible cached tensors
-    orig_get_deepstack = getattr(vllm_model, "_get_deepstack_input_embeds",
-                                 None)
-    if orig_get_deepstack is not None:
-        vllm_model._get_deepstack_input_embeds = lambda num_tokens: _patched_get_deepstack(
-            vllm_model, orig_get_deepstack, num_tokens)
+        # 2. Override deepstack getter to prefer JAX-compatible cached tensors
+        orig_get_deepstack = getattr(vllm_model, "_get_deepstack_input_embeds",
+                                     None)
+        if orig_get_deepstack is not None:
+            vllm_model._get_deepstack_input_embeds = lambda num_tokens: _patched_get_deepstack(
+                vllm_model, orig_get_deepstack, num_tokens)
 
-    # 3. Patch embed_input_ids to pack Deepstack vision features into main text embeddings
-    orig_embed_input_ids = getattr(vllm_model, "embed_input_ids", None)
-    if orig_embed_input_ids is not None:
-        vllm_model.embed_input_ids = lambda *args, **kwargs: _patched_embed_input_ids(
-            vllm_model, orig_embed_input_ids, *args, **kwargs)
+        # 3. Patch embed_input_ids to pack Deepstack vision features into main text embeddings
+        orig_embed_input_ids = getattr(vllm_model, "embed_input_ids", None)
+        if orig_embed_input_ids is not None:
+            vllm_model.embed_input_ids = lambda *args, **kwargs: _patched_embed_input_ids(
+                vllm_model, orig_embed_input_ids, *args, **kwargs)
 
-    # 4. Patch forward to unpack vision features and restore them before execution
-    orig_forward = vllm_model.forward
-    vllm_model.forward = lambda *args, **kwargs: _patched_forward(
-        vllm_model, orig_forward, *args, **kwargs)
+        # 4. Patch forward to unpack vision features and restore them before execution
+        orig_forward = vllm_model.forward
+        vllm_model.forward = lambda *args, **kwargs: _patched_forward(
+            vllm_model, orig_forward, *args, **kwargs)
 
     # 5. Patch _flatten_embeddings in vllm utils to handle negative indexes correctly in torchax
     vllm_utils._flatten_embeddings = _patched_flatten_embeddings
 
     # 6. Force HAS_TRITON to False to prevent JAX/Triton active driver crash on TPU
     qwen3_vl_mod.HAS_TRITON = False
+
+    # 7. Patch position embedding interpolation and rotary position embedding to use JAX JIT compiled implementations
+    if hasattr(vllm_model, "visual"):
+        vllm_model.visual.fast_pos_embed_interpolate = _patched_fast_pos_embed_interpolate.__get__(
+            vllm_model.visual, vllm_model.visual.__class__)
+        vllm_model.visual.rot_pos_emb = _patched_rot_pos_emb.__get__(
+            vllm_model.visual, vllm_model.visual.__class__)
 
 
 def is_qwen3_vl(vllm_model) -> bool:

--- a/tpu_inference/models/vllm/experimental/qwen3_vl_patcher.py
+++ b/tpu_inference/models/vllm/experimental/qwen3_vl_patcher.py
@@ -253,6 +253,34 @@ def _patched_flatten_embeddings(embeddings: NestedTensors) -> torch.Tensor:
     return torch.cat(tuple(_patched_flatten_embeddings(t) for t in embeddings))
 
 
+def _jax_compatible_merge_multimodal_embeddings(
+    inputs_embeds, multimodal_embeddings, is_multimodal
+):
+    if len(multimodal_embeddings) == 0:
+        return inputs_embeds
+
+    import torch
+
+    mm_embeds_flat = vllm_utils._flatten_embeddings(multimodal_embeddings)
+    input_dtype = inputs_embeds.dtype
+    mm_embeds_flat = mm_embeds_flat.to(dtype=input_dtype)
+
+    # Create a dummy row to handle indices for non-multimodal tokens.
+    dummy_row = torch.zeros_like(mm_embeds_flat[0:1])
+    # Prepend the dummy row.
+    flattened_padded = torch.cat([dummy_row, mm_embeds_flat], dim=0)
+
+    # For non-multimodal tokens, cumsum points to 0.
+    # For multimodal tokens, it points to their 1-based index in the padded array.
+    gather_indices = is_multimodal.to(torch.int64).cumsum(dim=0)
+    update_values = flattened_padded[gather_indices]
+
+    condition = is_multimodal.unsqueeze(-1)
+    new_embeds = torch.where(condition, update_values, inputs_embeds)
+
+    return new_embeds
+
+
 @partial(jax.jit, static_argnums=(1, 2, 3, 4, 5))
 def pos_embed_interpolate_jax(
     embed_weight: jax.Array,
@@ -411,7 +439,15 @@ def apply_qwen3_vl_patches(vllm_model):
     # 5. Patch _flatten_embeddings in vllm utils to handle negative indexes correctly in torchax
     vllm_utils._flatten_embeddings = _patched_flatten_embeddings
 
-    # 6. Force HAS_TRITON to False to prevent JAX/Triton active driver crash on TPU
+    # 6. Patch merge_multimodal_embeddings in both utils and locally imported references to support JAX static math ops
+    vllm_utils._merge_multimodal_embeddings = (
+        _jax_compatible_merge_multimodal_embeddings
+    )
+    qwen3_vl_mod._merge_multimodal_embeddings = (
+        _jax_compatible_merge_multimodal_embeddings
+    )
+
+    # 7. Force HAS_TRITON to False to prevent JAX/Triton active driver crash on TPU
     qwen3_vl_mod.HAS_TRITON = False
 
     # 7. Patch position embedding interpolation and rotary position embedding to use JAX JIT compiled implementations

--- a/tpu_inference/models/vllm/experimental/vision_tower_jit.py
+++ b/tpu_inference/models/vllm/experimental/vision_tower_jit.py
@@ -23,6 +23,7 @@ import numpy as np
 from vllm.config import VllmConfig
 from vllm.model_executor.models.qwen3_5 import \
     Qwen3_5MoeForConditionalGeneration
+from vllm.model_executor.models.qwen3_vl import Qwen3VLForConditionalGeneration
 
 from tpu_inference.logger import init_logger
 from tpu_inference.utils import to_jax_dtype
@@ -32,6 +33,7 @@ logger = init_logger(__name__)
 # Architectures whose embed_multimodal function is safe to wrap with jax.jit.
 JITTABLE_ARCHS = {
     Qwen3_5MoeForConditionalGeneration,
+    Qwen3VLForConditionalGeneration,
 }
 
 

--- a/tpu_inference/models/vllm/vllm_model_wrapper.py
+++ b/tpu_inference/models/vllm/vllm_model_wrapper.py
@@ -488,7 +488,7 @@ class VllmModelWrapper:
         if not self.vllm_config.model_config.is_multimodal_model:
             return None
 
-        # The function cannot be JITted directly due to its dynamic implementation
+        @jax.jit
         def embed_input_ids_func(
             params_and_buffers: Any,
             input_ids: jax.Array,

--- a/tpu_inference/worker/tpu_worker.py
+++ b/tpu_inference/worker/tpu_worker.py
@@ -392,6 +392,15 @@ class TPUWorker(WorkerBase):
         total_hbm_limit_cap = total_hbm_limit * gpu_memory_utilization
         total_hbm_avail = int(total_hbm_limit_cap - total_hbm_used)
 
+        # Scale down the total HBM available by the KV Cache replication factor
+        # to prevent over-allocating blocks when EP/SP are active.
+        sharding_cfg = getattr(self.vllm_config, "sharding_config", None)
+        expert_size = getattr(sharding_cfg, "expert_size", None) if sharding_cfg else None
+        sequence_size = getattr(sharding_cfg, "sequence_size", None) if sharding_cfg else None
+        replication_factor = (expert_size * sequence_size) if (expert_size is not None and sequence_size is not None) else 1
+
+        total_hbm_avail = total_hbm_avail // replication_factor
+
         total_hbm_limit_gb = round(total_hbm_limit / utils.GBYTES, 2)
         total_hbm_limit_cap_gb = round(total_hbm_limit_cap / utils.GBYTES, 2)
         total_hbm_used_gb = round(total_hbm_used / utils.GBYTES, 2)
@@ -421,11 +430,14 @@ class TPUWorker(WorkerBase):
 
         total_hbm_avail_gb = round(total_hbm_avail / utils.GBYTES, 2)
 
-        logger.info(f"Memory statistics | "
-                    f"{total_hbm_limit_gb=}GiB | "
-                    f"{total_hbm_limit_cap_gb=}GiB | "
-                    f"{total_hbm_used_gb=}GiB | "
-                    f"{total_hbm_avail_gb=}GiB")
+        logger.info(
+            f"Memory statistics | "
+            f"{total_hbm_limit_gb=}GiB | "
+            f"{total_hbm_limit_cap_gb=}GiB | "
+            f"{total_hbm_used_gb=}GiB | "
+            f"replication_factor={replication_factor} | "
+            f"{total_hbm_avail_gb=}GiB"
+        )
 
         if total_hbm_avail <= 0:
             raise ValueError(f"{total_hbm_used_gb=}GiB exceeds "


### PR DESCRIPTION
# Description

Adds fixes and optimizations for `Qwen3-VL-235B-A22B-Thinking-FP8` . 

1. Adds accounting for parallelism for identifying remaining HBM available for KV Cache.
2. Fix Sharding configuration for cases where head size is smaller than parallelism.
3. Implement `PositionalEmbeddingGeneration` in pure JAX translated from [original_vllm_impl](https://github.com/vllm-project/vllm/blob/771e1e48b153df0e5e4334061deb1cb2ebde8fab/vllm/model_executor/models/qwen3_vl.py#L278).
   - Similar optimization by adding `embed_input_ids_func`.


# Tests

Tested on TPU v7-8

1. Time to First Token (Mean TTFT)
    Baseline: 335.20 ms
    Optimized: 216.36 ms
    Improvement: 35.45% reduction in time to first token.
2. Time per Output Token (Mean TPOT)
    Baseline: 35.04 ms
    Optimized: 20.03 ms
    Improvement: 42.84% reduction in time per output token.
3. Inter-token Latency (Mean ITL)
    Baseline: 31.54 ms
    Optimized: 18.02 ms
    Improvement: 42.87% reduction in inter-token latency.

Overall, the optimization yielded a ~35% improvement in initial response time and a ~43% improvement in generation speed and smoothness.

# Profiling results (TTFT improvements)
<img width="2764" height="788" alt="before" src="https://github.com/user-attachments/assets/97d91108-17ec-4229-bce5-4738554b0713" />
<img width="2546" height="644" alt="after" src="https://github.com/user-attachments/assets/a341b31a-cb0e-47d4-88ac-2cfcf590a73d" />


# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.