### PR TITLE
Qwen optimizations kernel

### DIFF
--- a/tpu_inference/kernels/flash_attention/kernel.py
+++ b/tpu_inference/kernels/flash_attention/kernel.py
@@ -72,6 +72,30 @@ class BlockSizes:
         )
 
 
+def _estimate_single_step_vmem_bytes(
+    q_seq_len: int,
+    kv_seq_len: int,
+    d_model: int,
+    has_ab: bool,
+    has_segment_ids: bool,
+) -> int:
+    """Estimate VMEM bytes used by the single-step flash attention kernel."""
+    block_q = 128
+    q_bytes = block_q * d_model * 2
+    k_bytes = kv_seq_len * d_model * 2
+    v_bytes = kv_seq_len * d_model * 2
+    s_bytes = block_q * kv_seq_len * 4
+    p_bytes = block_q * kv_seq_len * 4
+    o_bytes = block_q * d_model * 2
+    ab_bytes = block_q * kv_seq_len * 4 if has_ab else 0
+    seg_bytes = (block_q * 128 * 4 + 8 * kv_seq_len * 4) if has_segment_ids else 0
+
+    total = (
+        q_bytes + k_bytes + v_bytes + s_bytes + p_bytes + o_bytes + ab_bytes + seg_bytes
+    )
+    return int(total * 1.10)
+
+
 @jax.jit(static_argnames=[
     "causal",
     "sm_scale",
@@ -131,8 +155,19 @@ def flash_attention(
     if block_sizes is None:
         block_sizes = BlockSizes.get_default(batch_size, num_heads, q_seq_len,
                                              kv_seq_len, d_model)
-        # TODO (KWang1998 & hfan): tune the block sizes properly.
-        if kv_seq_len <= 92800:
+        # Determine the safe VMEM budget for single-step kernel
+        # Use vmem_limit_bytes if specified, otherwise default to 14MB (safe limit for 16MB TPU v5e)
+        budget = vmem_limit_bytes if vmem_limit_bytes is not None else 14 * 1024 * 1024
+
+        estimated_bytes = _estimate_single_step_vmem_bytes(
+            q_seq_len=q_seq_len,
+            kv_seq_len=kv_seq_len,
+            d_model=d_model,
+            has_ab=(ab is not None),
+            has_segment_ids=(segment_ids is not None),
+        )
+
+        if estimated_bytes <= budget:
             # Override block_k/block_k_major to use `_flash_attention_kernel_single_batch_single_step`.
             block_sizes = BlockSizes(block_q=block_sizes.block_q,
                                      block_b=block_sizes.block_b,

--- a/tpu_inference/kernels/megablox/gmm_v2.py
+++ b/tpu_inference/kernels/megablox/gmm_v2.py
@@ -914,9 +914,12 @@ def calculate_tiling(
         tile_n_limit //= fuse_act_factor
 
     def _is_tile_k_quant_block_compatible(tk: int) -> bool:
-        if (tk % rhs_cfgs.quant_block_size != 0
-                and rhs_cfgs.quant_block_size % tk != 0):
-            return False
+        if rhs_cfgs.has_scale and rhs_cfgs.quant_block_size is not None:
+            if rhs_cfgs.should_dequantize_before_matmul:
+                return tk % rhs_cfgs.quant_block_size == 0
+            if (tk % rhs_cfgs.quant_block_size != 0
+                    and rhs_cfgs.quant_block_size % tk != 0):
+                return False
         return True
 
     # Initialize tile_k and tile_n to their maximum valid values.
@@ -924,6 +927,14 @@ def calculate_tiling(
     num_lanes = pltpu.get_tpu_info().num_lanes
     tile_k = align_to(dims.size_k, num_lanes)
     tile_n = align_to(size_n_per_rhs, num_lanes)
+
+    # Ensure the initial tile_k is compatible with the quantization block size.
+    if not _is_tile_k_quant_block_compatible(tile_k):
+        if rhs_cfgs.has_scale and rhs_cfgs.quant_block_size is not None:
+            if rhs_cfgs.should_dequantize_before_matmul:
+                tile_k = align_to(tile_k, rhs_cfgs.quant_block_size)
+            else:
+                tile_k = align_to(tile_k, rhs_cfgs.quant_block_size)
 
     def _gmm_vmem_estimate(tn: int, tk: int) -> int:
         # 1. LHS tile (double-buffered)
@@ -973,12 +984,29 @@ def calculate_tiling(
                           num_n_tiles * num_lanes) // num_n_tiles
 
         # Decrease tile_k until total memory fits in vmem limit and tile_k is valid.
+        prev_tile_k = None
         while _gmm_vmem_estimate(
                 tile_n, tile_k
         ) > vmem_limit_bytes or not _is_tile_k_quant_block_compatible(tile_k):
+            if tile_k == prev_tile_k:
+                raise ValueError(
+                    f"Could not find valid tile sizes within VMEM limit. "
+                    f"tile_k is stuck at {tile_k} (limit: {vmem_limit_bytes})."
+                )
+            prev_tile_k = tile_k
             num_k_tiles += 1
             tile_k = align_to(dims.size_k,
                               num_k_tiles * num_lanes) // num_k_tiles
+            if not _is_tile_k_quant_block_compatible(tile_k):
+                if rhs_cfgs.should_dequantize_before_matmul:
+                    qbs = rhs_cfgs.quant_block_size
+                    tile_k = max(qbs, (tile_k // qbs) * qbs)
+                else:
+                    qbs = rhs_cfgs.quant_block_size
+                    for div in sorted([d for d in range(1, qbs + 1) if qbs % d == 0], reverse=True):
+                        if div <= tile_k:
+                            tile_k = div
+                            break
 
     if tile_n == 0 or tile_k == 0:
         final_estimate = _gmm_vmem_estimate(tile_n, tile_k)


### PR DESCRIPTION
# Description

Adds fixes and optimizations for `Qwen3-VL-235B-A22B-Thinking-FP8` . 

1. Fix the tile_k block compatibility issue in the gmm_v2 kernel.
2. Fixes OOM for batching failing for High throughput cases in multimodal scenarios.


# Tests

Tested on TPU v7-8

1. Time to First Token (Mean TTFT)
    Baseline: 335.20 ms
    Optimized: 216.36 ms
    Improvement: 35.45% reduction in time to first token.
2. Time per Output Token (Mean TPOT)
    Baseline: 35.04 ms
    Optimized: 20.03 ms
    Improvement: 42.84% reduction in time per output token.
3. Inter-token Latency (Mean ITL)
    Baseline: 31.54 ms
    Optimized: 18.02 ms
    Improvement: 42.87% reduction in inter-token latency.

Overall, the optimization yielded a ~35% improvement in initial response time and a ~43% improvement in generation speed and smoothness.



# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.