### PR TITLE
[NVFP4] Use fast sharding/requant path for NVFP4 models

### DIFF
--- a/tests/layers/vllm/test_nvfp4.py
+++ b/tests/layers/vllm/test_nvfp4.py
@@ -31,6 +31,7 @@ from vllm.distributed.parallel_state import (ensure_model_parallel_initialized,
 from vllm.engine.arg_utils import EngineArgs
 from vllm.forward_context import set_forward_context
 from vllm.model_executor.layers.fused_moe import FusedMoE
+from vllm.model_executor.layers.fused_moe.activation import MoEActivation
 from vllm.model_executor.layers.linear import (ColumnParallelLinear,
                                                RowParallelLinear)
 
@@ -324,14 +325,17 @@ def test_column_parallel_linear(bias, num_devices):
 # ----------------------------------------------------------------
 # Test 4: MoE layer
 # ----------------------------------------------------------------
-@pytest.mark.parametrize("num_devices", [1])
+@pytest.mark.parametrize("num_devices", [1, 2])
 @pytest.mark.parametrize("num_tokens", [8])
 @pytest.mark.parametrize("intermediate_size", [256])
 @pytest.mark.parametrize("hidden_size", [128])
 @pytest.mark.parametrize("num_experts", [4])
 @pytest.mark.parametrize("topk", [2])
+@pytest.mark.parametrize("has_bias", [False, True])
+@pytest.mark.parametrize("activation",
+                         [MoEActivation.SILU, MoEActivation.SWIGLUOAI])
 def test_fused_moe(num_devices, num_tokens, intermediate_size, hidden_size,
-                   num_experts, topk):
+                   num_experts, topk, has_bias, activation):
     mesh = test_utils.get_spmd_mesh(num_devices)
     torch.manual_seed(42)
     dtype = torch.bfloat16
@@ -369,8 +373,9 @@ def test_fused_moe(num_devices, num_tokens, intermediate_size, hidden_size,
             tp_size=1,
             dp_size=1,
             quant_config=config,
-            has_bias=False,
+            has_bias=has_bias,
         )
+        moe_layer.activation = activation
 
     # Quantize w1 and w2 per-expert to NVFP4.
     group_size = NVFP4_GROUP_SIZE
@@ -389,8 +394,17 @@ def test_fused_moe(num_devices, num_tokens, intermediate_size, hidden_size,
         moe_layer.w2_weight_scale.data[e] = w2_scale
         moe_layer.w2_weight_scale_2.data[e] = w2_gs.item()
 
+    if has_bias:
+        moe_layer.w13_bias.data = torch.randn(
+            (num_experts, 2 * intermediate_size), dtype=dtype) / 10
+        moe_layer.w2_bias.data = torch.randn(
+            (num_experts, hidden_size), dtype=dtype) / 10
+
+    w1_bias = moe_layer.w13_bias.data if has_bias else None
+    w2_bias = moe_layer.w2_bias.data if has_bias else None
+
     # Reference MoE computation.
-    expected = test_utils.ref_moe(a, score, w1, w2, None, None, topk,
+    expected = test_utils.ref_moe(a, score, w1, w2, w1_bias, w2_bias, topk,
                                   moe_layer.renormalize,
                                   moe_layer.activation.value)
 

--- a/tpu_inference/layers/common/process_weights/moe_weights.py
+++ b/tpu_inference/layers/common/process_weights/moe_weights.py
@@ -693,7 +693,7 @@ def process_quantized_moe_weights(
     weights: FusedMoEWeights,
     moe_backend: MoEBackend,
     mesh: Mesh,
-    activation: str,
+    activation: str | MoEActivation,
     weight_block_size: tuple[int, ...] | None = None,
     desired_quant_dtype: jnp.dtype | None = None,
     requant_block_size: int | None = None,
@@ -1036,7 +1036,7 @@ def _process_quantized_moe_weights_impl(
     weights: FusedMoEWeights,
     moe_backend: MoEBackend,
     mesh: Mesh,
-    activation: str,
+    activation: str | MoEActivation,
     weight_block_size: tuple[int, ...] | None = None,
     desired_quant_dtype: jnp.dtype | None = None,
     requant_block_size: int | None = None,
@@ -1049,7 +1049,8 @@ def _process_quantized_moe_weights_impl(
     w13_bias = weights.w13_bias
     w2_bias = weights.w2_bias
 
-    w13_interleave = activation == "swigluoai"
+    w13_interleave = (activation == "swigluoai"
+                      or activation == MoEActivation.SWIGLUOAI)
     w13_reorder_size = get_mesh_shape_product(mesh,
                                               ShardingAxisName.MLP_TENSOR)
 

--- a/tpu_inference/layers/vllm/quantization/nvfp4.py
+++ b/tpu_inference/layers/vllm/quantization/nvfp4.py
@@ -37,7 +37,6 @@ from torch.nn.parameter import Parameter
 from torchax.interop import jax_view, torch_view
 from vllm.model_executor.layers.attention import Attention
 from vllm.model_executor.layers.fused_moe import FusedMoE, FusedMoEMethodBase
-from vllm.model_executor.layers.fused_moe.activation import MoEActivation
 from vllm.model_executor.layers.linear import LinearBase
 from vllm.model_executor.layers.quantization import (
     QuantizationMethods, register_quantization_config)
@@ -47,16 +46,16 @@ from vllm.model_executor.layers.quantization.modelopt import (
     ModelOptNvFp4Config, ModelOptNvFp4FusedMoE, ModelOptNvFp4LinearMethod)
 from vllm.model_executor.utils import set_weight_attrs
 
+import tpu_inference.envs as envs
 from tpu_inference.layers.common.linear import sharded_quantized_matmul
 from tpu_inference.layers.common.moe import MoEBackend
 from tpu_inference.layers.common.process_weights.linear_weights import (
     LinearWeights, process_linear_weights, shard_linear_weights,
     to_parameter_list)
 from tpu_inference.layers.common.process_weights.moe_weights import (
-    FusedMoEWeights, process_moe_weights, shard_moe_weights)
+    FusedMoEWeights, process_quantized_moe_weights, shard_moe_weights_to_tpu)
 from tpu_inference.layers.common.quant_methods import NVFP4
 from tpu_inference.layers.common.quantization import u8_unpack_e2m1
-from tpu_inference.layers.common.sharding import ShardingAxisName
 from tpu_inference.layers.common.utils import \
     slice_sharded_tensor_for_concatenation
 from tpu_inference.layers.vllm.interface.moe import (
@@ -66,7 +65,7 @@ from tpu_inference.layers.vllm.quantization.configs import (
 from tpu_inference.layers.vllm.quantization.unquantized import (
     VllmUnquantizedFusedMoEMethod, VllmUnquantizedLinearMethod)
 from tpu_inference.logger import init_logger
-from tpu_inference.utils import get_mesh_shape_product, t2j
+from tpu_inference.utils import t2j, to_jax_dtype
 
 logger = init_logger(__name__)
 
@@ -367,52 +366,79 @@ class VllmNvfp4MoEMethod(FusedMoEMethodBase):
         w2_bias = t2j(layer.w2_bias,
                       use_dlpack=False) if self.moe.has_bias else None
 
-        @jax.jit
-        def process_nvfp4_moe_weights(w13_weight, w13_weight_scale,
-                                      w13_global_scale, w2_weight,
-                                      w2_weight_scale, w2_global_scale,
-                                      w13_bias, w2_bias):
+        # Create FusedMoEWeights with original weights
+        weights = FusedMoEWeights(
+            w13_weight=w13_weight,
+            w13_weight_scale=w13_weight_scale,
+            w13_bias=w13_bias,
+            w2_weight=w2_weight,
+            w2_weight_scale=w2_weight_scale,
+            w2_bias=w2_bias,
+        )
+
+        # Shard weights to TPU before processing to avoid OOM
+        weights = shard_moe_weights_to_tpu(weights, self.mesh)
+
+        desired_quant_dtype = to_jax_dtype(
+            envs.MOE_REQUANTIZE_WEIGHT_DTYPE
+        ) if envs.MOE_REQUANTIZE_WEIGHT_DTYPE else None
+        requant_block_size = int(envs.MOE_REQUANTIZE_BLOCK_SIZE
+                                 ) if envs.MOE_REQUANTIZE_BLOCK_SIZE else None
+
+        @jax.jit(static_argnames=("desired_quant_dtype", "requant_block_size"))
+        def unpack_and_process(
+            weights: FusedMoEWeights,
+            w13_global_scale: jax.Array,
+            w2_global_scale: jax.Array,
+            desired_quant_dtype: jnp.dtype | None,
+            requant_block_size: int | None,
+        ) -> FusedMoEWeights:
             # Unpack packed uint8 -> native float4_e2m1fn (no value change).
-            w13_fp4 = u8_unpack_e2m1(w13_weight)
-            w2_fp4 = u8_unpack_e2m1(w2_weight)
+            w13_fp4 = u8_unpack_e2m1(weights.w13_weight)
+            w2_fp4 = u8_unpack_e2m1(weights.w2_weight)
 
             # Combine FP32 global × FP8 block -> single FP32 block scale.
             if w13_global_scale.ndim == 2:  # (E, 2) — separate w1/w3 globals.
-                half = w13_weight_scale.shape[1] // 2
-                w1_eff = w13_weight_scale[:, :half].astype(
+                half = weights.w13_weight_scale.shape[1] // 2
+                w1_eff = weights.w13_weight_scale[:, :half].astype(
                     jnp.float32) * w13_global_scale[:, 0:1].reshape(-1, 1, 1)
-                w3_eff = w13_weight_scale[:, half:].astype(
+                w3_eff = weights.w13_weight_scale[:, half:].astype(
                     jnp.float32) * w13_global_scale[:, 1:2].reshape(-1, 1, 1)
                 w13_scale_eff = jnp.concatenate([w1_eff, w3_eff], axis=1)
             else:
-                w13_scale_eff = w13_weight_scale.astype(
+                w13_scale_eff = weights.w13_weight_scale.astype(
                     jnp.float32) * w13_global_scale.reshape(-1, 1, 1)
-            w2_scale_eff = w2_weight_scale.astype(
+            w2_scale_eff = weights.w2_weight_scale.astype(
                 jnp.float32) * w2_global_scale.reshape(-1, 1, 1)
 
-            w13_interleave = layer.activation == MoEActivation.SWIGLUOAI
-            w13_reorder_size = get_mesh_shape_product(
-                self.mesh, ShardingAxisName.MLP_TENSOR)
-
-            weights = FusedMoEWeights(
+            weights_unpacked = FusedMoEWeights(
                 w13_weight=w13_fp4,
                 w13_weight_scale=w13_scale_eff,
-                w13_bias=w13_bias,
+                w13_bias=weights.w13_bias,
                 w2_weight=w2_fp4,
                 w2_weight_scale=w2_scale_eff,
-                w2_bias=w2_bias,
+                w2_bias=weights.w2_bias,
             )
-            return process_moe_weights(weights,
-                                       moe_backend=self.moe_backend,
-                                       w13_reorder_size=w13_reorder_size,
-                                       w13_interleave=w13_interleave)
 
-        weights = process_nvfp4_moe_weights(w13_weight, w13_weight_scale,
-                                            w13_global_scale, w2_weight,
-                                            w2_weight_scale, w2_global_scale,
-                                            w13_bias, w2_bias)
-        weights = torch_view(
-            shard_moe_weights(weights, self.moe_backend, self.mesh))
+            return process_quantized_moe_weights(
+                weights=weights_unpacked,
+                moe_backend=self.moe_backend,
+                mesh=self.mesh,
+                activation=layer.activation,
+                weight_block_size=(1, 16),  # NVFP4 block size is 16
+                desired_quant_dtype=desired_quant_dtype,
+                requant_block_size=requant_block_size,
+            )
+
+        weights = unpack_and_process(
+            weights,
+            w13_global_scale,
+            w2_global_scale,
+            desired_quant_dtype,
+            requant_block_size,
+        )
+
+        weights = torch_view(weights)
 
         layer.w13_weight = Parameter(weights.w13_weight, requires_grad=False)
         layer.w2_weight = Parameter(weights.w2_weight, requires_grad=False)


### PR DESCRIPTION
# Description

Applies same logic from https://github.com/vllm-project/tpu-inference/pull/2659/ for the NVFP4 path, reducing post-model loading times significantly.

# Tests

Ran:

```
 MODEL_IMPL_TYPE=vllm nohup  vllm serve --seed 42 --model NVFP4/Qwen3-Coder-30B-A3B-Instruct-FP4  --max-num-batched-tokens 1028 --max-num-seqs 128 --no-enable-prefix-caching --tensor-parallel-size 2 --enable-expert-parallel  &


 nohup evalplus.evaluate --model NVFP4/Qwen3-Coder-30B-A3B-Instruct-FP4 --dataset humaneval --backend openai -base-url http://localhost:8000/v1 --greedy  &
```

And obtained expected results:

```
humaneval (base tests)
pass@1:	0.933
humaneval+ (base + extra tests)
pass@1:	0.872
```


# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
