### PR TITLE
[releases/v0.21.0][CI] Bump gemma-4-31B-it perf benchmark startup timeout to 1800s

### DIFF
--- a/.buildkite/models/google_gemma-4-31B-it.yml
+++ b/.buildkite/models/google_gemma-4-31B-it.yml
@@ -87,7 +87,7 @@ steps:
           buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_google_gemma-4-31B-it_Benchmark" "not enough HBM"
           exit 0
         fi
-        .buildkite/scripts/run_in_docker.sh bash -c 'TIMEOUT_SECONDS=960 USE_BATCHED_RPA_KERNEL=1 JITTED_MM_MODULE_KEYS="model.vision_tower.encoder" REGISTER_MM_MODULE_CUSTOM_PYTREE_CLASSES="transformers.modeling_outputs.BaseModelOutputWithPast" /workspace/tpu_inference/tests/e2e/benchmarking/mm_bench_recipe.sh'
+        .buildkite/scripts/run_in_docker.sh bash -c 'TIMEOUT_SECONDS=1800 USE_BATCHED_RPA_KERNEL=1 JITTED_MM_MODULE_KEYS="model.vision_tower.encoder" REGISTER_MM_MODULE_CUSTOM_PYTREE_CLASSES="transformers.modeling_outputs.BaseModelOutputWithPast" /workspace/tpu_inference/tests/e2e/benchmarking/mm_bench_recipe.sh'
 
   - label: "${TPU_VERSION:-tpu6e} Record performance benchmark result for google/gemma-4-31B-it"
     key: "${TPU_VERSION:-tpu6e}_record_google_gemma-4-31B-it_Benchmark"


### PR DESCRIPTION
## Summary
- The \`tpu7x Performance benchmarks for google/gemma-4-31B-it\` job in nightly build [#18491](https://buildkite.com/tpu-commons/tpu-inference-ci/builds/18491) on \`releases/v0.21.0\` failed **on both attempts** with the recipe's startup-readiness check timing out:

  > \`TIMEOUT: Waited 961 seconds (limit was 960). The string 'Application startup complete.' was NOT found.\`

- Engine-core init alone took **~550 s** (compilation ~415 s) in both attempts; the subsequent precompile of \`compute_logits\` / \`structured_decode\` plus chat-template detection pushed the API server past the 16-min budget before it could bind. No crash, no OOM — purely slow startup on the multimodal compile path.
- Bumps \`TIMEOUT_SECONDS\` from \`960\` to \`1800\` in \`.buildkite/models/google_gemma-4-31B-it.yml\`, matching the 30-min default already used by \`mmlu.sh\` and \`mlperf.sh\`.

## Notes
- \`.buildkite/models/google_gemma-4-26B-A4B-it.yml\` carries the same \`TIMEOUT_SECONDS=960\` and is at risk of the same regression; left untouched here to keep the diff scoped to the actual nightly failure — happy to bundle if preferred.
- \`main\` has the same value; a parallel PR can follow if reviewers want it consistent.

## Test plan
- [ ] Re-trigger the failing nightly job on \`releases/v0.21.0\` and confirm the perf benchmark step reaches \`Application startup complete.\` within the new 1800s budget.