### PR TITLE
[DP] Use rank-0-elected canonical ts for MPMD xprof merge

### DIFF
--- a/scripts/merge_xprof.py
+++ b/scripts/merge_xprof.py
@@ -1,0 +1,200 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Combine multiple .xplane.pb captures into a single XSpace .xplane.pb.
+
+Phased MPMD profiling writes one xplane.pb per DP rank into
+`<phase>/plugins/profile/<ts>/dp{0,1,...}_*.xplane.pb`. Tools like the
+TensorBoard profile plugin and `xprof` can already read that whole
+directory as one distributed session, but some workflows want a single
+artifact — e.g. attaching to a bug, feeding into a tool that takes
+exactly one file, or sharing via a single URL. This script merges the
+XSpaces from each input into one output proto.
+
+Plane names are taken from each input as-is; xprof identifies devices/
+hosts by plane name, so coinciding names from peer DP ranks (e.g.
+`/device:TPU:0` on a single host) would conflict. Pass `--prefix-planes`
+to namespace each input's planes with its filename stem (e.g.
+`dp0_t1v-..-w-0: /device:TPU:0`) if you need to keep them distinct.
+
+Usage:
+    # Merge specific files
+    python scripts/merge_xprof.py a.xplane.pb b.xplane.pb -o merged.xplane.pb
+
+    # Merge every .xplane.pb under a dir (typically plugins/profile/<ts>/)
+    python scripts/merge_xprof.py path/to/plugins/profile/<ts> -o merged.xplane.pb
+
+    # Namespace per-input planes to avoid name collisions
+    python scripts/merge_xprof.py <inputs> -o merged.xplane.pb --prefix-planes
+"""
+
+import argparse
+import os
+import sys
+from typing import List
+
+
+def _load_xplane_pb2():
+    """Locate XSpace proto bindings.
+
+    xprof / tensorboard-plugin-profile read xplane.pb via a C++ extension
+    and don't ship Python bindings. TensorFlow does — but importing TF
+    eagerly pulls in many heavy deps (gast, astunparse, etc.). We first
+    try the regular import paths and, if those fail, fall back to loading
+    the `xplane_pb2.py` file directly from site-packages, bypassing any
+    parent `__init__.py` chain.
+    """
+    candidates_modules = (
+        "tensorflow.tsl.profiler.protobuf.xplane_pb2",
+        "tensorflow.core.profiler.protobuf.xplane_pb2",
+        "xprof.protobuf.xplane_pb2",
+        "tensorboard_plugin_profile.protobuf.xplane_pb2",
+        "tensorboard.plugins.profile.protobuf.xplane_pb2",
+    )
+    for modname in candidates_modules:
+        try:
+            return __import__(modname, fromlist=["XSpace"])
+        except ImportError:
+            continue
+
+    # Direct file load — searches site-packages for the generated pb2
+    # without executing any package `__init__.py` along the way.
+    import importlib.util
+    import site
+    candidate_rel_paths = (
+        "tensorflow/tsl/profiler/protobuf/xplane_pb2.py",
+        "tensorflow/core/profiler/protobuf/xplane_pb2.py",
+        "xprof/protobuf/xplane_pb2.py",
+        "tensorboard_plugin_profile/protobuf/xplane_pb2.py",
+    )
+    search_dirs = list(site.getsitepackages())
+    user_sp = site.getusersitepackages()
+    if user_sp:
+        search_dirs.append(user_sp)
+    for sp_dir in search_dirs:
+        for rel in candidate_rel_paths:
+            full = os.path.join(sp_dir, rel)
+            if not os.path.exists(full):
+                continue
+            spec = importlib.util.spec_from_file_location(
+                "_merge_xprof_xplane_pb2", full)
+            module = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(module)
+            if hasattr(module, "XSpace"):
+                return module
+
+    raise ImportError(
+        "Could not find XSpace proto bindings. Install one of:\n"
+        "    pip install tensorflow  # ships xplane_pb2.py\n"
+        "    pip install tensorflow-cpu  # same, no GPU/TPU runtime\n"
+        "Note: `xprof` and `tensorboard-plugin-profile` do NOT ship the "
+        "XSpace Python proto — they read xplane.pb via a C++ extension.")
+
+
+def _collect_inputs(paths: List[str]) -> List[str]:
+    """Expand input list: directories → every .xplane.pb under them (recursive)."""
+    files = []
+    for p in paths:
+        if os.path.isdir(p):
+            for root, _, fnames in os.walk(p):
+                for fn in sorted(fnames):
+                    if fn.endswith(".xplane.pb"):
+                        files.append(os.path.join(root, fn))
+        elif os.path.isfile(p):
+            files.append(p)
+        else:
+            raise FileNotFoundError(p)
+    return files
+
+
+def _prefix_for(path: str) -> str:
+    """Return a short prefix derived from the file's stem (drop .xplane.pb)."""
+    base = os.path.basename(path)
+    if base.endswith(".xplane.pb"):
+        base = base[:-len(".xplane.pb")]
+    return base
+
+
+def merge(inputs: List[str], output: str, prefix_planes: bool) -> None:
+    xplane_pb2 = _load_xplane_pb2()
+    merged = xplane_pb2.XSpace()
+    total_planes = 0
+
+    for path in inputs:
+        with open(path, "rb") as fh:
+            xs = xplane_pb2.XSpace()
+            xs.ParseFromString(fh.read())
+        if prefix_planes:
+            prefix = _prefix_for(path)
+            for plane in xs.planes:
+                plane.name = f"{prefix}: {plane.name}"
+        merged.planes.extend(xs.planes)
+        merged.errors.extend(xs.errors)
+        merged.warnings.extend(xs.warnings)
+        merged.hostnames.extend(xs.hostnames)
+        print(f"  + {path}: {len(xs.planes)} plane(s)")
+        total_planes += len(xs.planes)
+
+    out_dir = os.path.dirname(os.path.abspath(output))
+    if out_dir:
+        os.makedirs(out_dir, exist_ok=True)
+    with open(output, "wb") as fh:
+        fh.write(merged.SerializeToString())
+
+    out_size_mb = os.path.getsize(output) / (1024 * 1024)
+    print(f"Merged {len(inputs)} file(s) → {output} "
+          f"({total_planes} planes, {out_size_mb:.1f} MB)")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__.splitlines()[0],
+        formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument(
+        "inputs",
+        nargs="+",
+        help="One or more .xplane.pb files, or a directory containing them "
+        "(walked recursively).")
+    parser.add_argument("-o",
+                        "--output",
+                        required=True,
+                        help="Output path for the merged .xplane.pb.")
+    parser.add_argument(
+        "--prefix-planes",
+        action="store_true",
+        help="Prefix each input's plane names with the input's filename "
+        "stem so coinciding names across DP ranks stay distinct in the "
+        "merged XSpace. Off by default to preserve original device names "
+        "(some xprof tools key off them).")
+    args = parser.parse_args()
+
+    try:
+        inputs = _collect_inputs(args.inputs)
+    except FileNotFoundError as e:
+        print(f"error: input not found: {e}", file=sys.stderr)
+        return 2
+    if not inputs:
+        print("error: no .xplane.pb files found in the given inputs",
+              file=sys.stderr)
+        return 2
+
+    try:
+        merge(inputs, args.output, args.prefix_planes)
+    except ImportError as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 3
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/runner/test_utils.py
+++ b/tests/runner/test_utils.py
@@ -494,7 +494,7 @@ def profiler_fixture(tmp_path):
          patch(f"{target_module}.determine_phase_from_batch_composition_stats") as mock_determine_phase, \
          patch.object(PhasedBasedProfiler, "_resolve_canonical_dst_ts",
                       return_value="2024_01_01_12_00_00"), \
-         patch.object(PhasedBasedProfiler, "_move_capture_to_dst_dir"):
+         patch.object(PhasedBasedProfiler, "_merge_profile_directories"):
 
         mock_now = MagicMock()
         mock_now.strftime.return_value = "2024_01_01_12_00_00"
@@ -767,7 +767,7 @@ def test_resolve_canonical_dst_ts_non_zero_rank_falls_back_on_timeout(
     _dt.datetime.strptime(ts, "%Y_%m_%d_%H_%M_%S")
 
 
-def test_move_capture_to_dst_dir_single_rank(tmp_path):
+def test_merge_profile_directories_single_rank(tmp_path):
     """Single rank, non-MPMD: capture moves from sandbox to <phase>/plugins/
     profile/<canonical_ts>/ with original filename preserved."""
     profiler = PhasedBasedProfiler(profile_dir=str(tmp_path), worker_rank=0)
@@ -779,7 +779,7 @@ def test_move_capture_to_dst_dir_single_rank(tmp_path):
     _stage_dp_rank_capture(rank_dir, "2026_05_06_04_47_36_jax",
                            "t1v-n-host-w-0.xplane.pb", "data_0")
 
-    profiler._move_capture_to_dst_dir()
+    profiler._merge_profile_directories()
 
     dst = phase_dir / "plugins" / "profile" / "2026_05_06_04_47_36"
     assert (dst / "t1v-n-host-w-0.xplane.pb").read_text() == "data_0"
@@ -788,7 +788,7 @@ def test_move_capture_to_dst_dir_single_rank(tmp_path):
     assert rank_dir.exists()
 
 
-def test_move_capture_to_dst_dir_mpmd(tmp_path, monkeypatch):
+def test_merge_profile_directories_mpmd(tmp_path, monkeypatch):
     """MPMD: 4 ranks captured to their own sandboxes with identical
     filenames; each moves to the SAME canonical ts dir with dp{N}_ prefix."""
     monkeypatch.setenv("TPU_MULTIPROCESS_DP", "1")
@@ -809,7 +809,7 @@ def test_move_capture_to_dst_dir_mpmd(tmp_path, monkeypatch):
         # Add the trace file in the same staged ts dir.
         (rank_dir / "plugins" / "profile" / f"jax_ts_{rank}" /
          "t1v-n-host-w-0.trace.json.gz").write_text(f"rank_{rank}_trace")
-        profiler._move_capture_to_dst_dir()
+        profiler._merge_profile_directories()
 
     dst = phase_dir / "plugins" / "profile" / canonical_ts
     assert dst.exists()
@@ -821,7 +821,7 @@ def test_move_capture_to_dst_dir_mpmd(tmp_path, monkeypatch):
         assert not (phase_dir / f"dp_rank_{rank}" / "plugins").exists()
 
 
-def test_move_capture_does_not_touch_stale_prior_run_data(tmp_path):
+def test_merge_profile_directories_ignores_stale_prior_run_data(tmp_path):
     """Stale ts dirs from prior runs in <phase>/plugins/profile/ stay put;
     the new run lands in its own canonical ts dir and never reads stale dirs."""
     phase_dir = tmp_path / "prefill_heavy"
@@ -837,7 +837,7 @@ def test_move_capture_does_not_touch_stale_prior_run_data(tmp_path):
     profiler._canonical_dst_ts = "2026_05_06_04_47_36"
     _stage_dp_rank_capture(rank_dir, "jax_ts", "new.xplane.pb", "NEW")
 
-    profiler._move_capture_to_dst_dir()
+    profiler._merge_profile_directories()
 
     # Stale data untouched.
     assert (stale / "old_data.xplane.pb").read_text() == "OLD"

--- a/tests/runner/test_utils.py
+++ b/tests/runner/test_utils.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 import io
 import logging
+import os
 import time
 from pathlib import Path
 from unittest.mock import MagicMock, mock_open, patch
@@ -490,7 +491,10 @@ def profiler_fixture(tmp_path):
          patch("builtins.open", mock_open()) as mock_file, \
          patch(f"{target_module}.datetime") as mock_datetime, \
          patch(f"{target_module}.InferencePhase", InferencePhase), \
-         patch(f"{target_module}.determine_phase_from_batch_composition_stats") as mock_determine_phase:
+         patch(f"{target_module}.determine_phase_from_batch_composition_stats") as mock_determine_phase, \
+         patch.object(PhasedBasedProfiler, "_resolve_canonical_dst_ts",
+                      return_value="2024_01_01_12_00_00"), \
+         patch.object(PhasedBasedProfiler, "_move_capture_to_dst_dir"):
 
         mock_now = MagicMock()
         mock_now.strftime.return_value = "2024_01_01_12_00_00"
@@ -711,78 +715,132 @@ def test_phased_profiler_skips_decode_only_steps_based_on_kv_len(
     assert profiler.current_phase == ""
 
 
-def test_merge_profile_directories_ray_multihost(tmp_path):
-    """Ray multi-host: per-host timestamp dirs collapse into the earliest one.
+def _stage_dp_rank_capture(rank_dir, ts_name, filename, content):
+    """Helper: simulate JAX writing one xplane file under dp_rank_N/plugins/profile/<ts>/."""
+    ts_dir = rank_dir / "plugins" / "profile" / ts_name
+    ts_dir.mkdir(parents=True)
+    (ts_dir / filename).write_text(content)
+    return ts_dir
 
-    Under the current code, profile_dir_with_phase_suffix always has a
-    dp_rank_N segment. The merge first hoists files up from
-    <phase>/dp_rank_0/plugins/profile/<ts>/ to <phase>/plugins/profile/<ts>/,
-    then collapses the timestamp dirs. Host-id-tagged filenames are
-    preserved (no dp{N}_ prefix is injected because TPU_MULTIPROCESS_DP is
-    off).
-    """
-    profiler = PhasedBasedProfiler(profile_dir=str(tmp_path))
+
+def test_resolve_canonical_dst_ts_rank_zero_writes_marker(tmp_path):
+    """Rank 0 picks the canonical ts and writes a marker keyed by ppid."""
+    profiler = PhasedBasedProfiler(profile_dir=str(tmp_path), worker_rank=0)
+    phase_dir = tmp_path / "prefill_heavy"
+    phase_dir.mkdir()
+
+    ts = profiler._resolve_canonical_dst_ts(str(phase_dir))
+
+    marker = phase_dir / f".canonical_ts_{os.getppid()}"
+    assert marker.exists()
+    assert marker.read_text().strip() == ts
+
+
+def test_resolve_canonical_dst_ts_non_zero_rank_reads_marker(tmp_path):
+    """Non-zero rank reads whatever rank 0 already published."""
+    phase_dir = tmp_path / "prefill_heavy"
+    phase_dir.mkdir()
+    marker = phase_dir / f".canonical_ts_{os.getppid()}"
+    marker.write_text("2026_05_06_04_47_36")
+
+    profiler = PhasedBasedProfiler(profile_dir=str(tmp_path), worker_rank=2)
+    ts = profiler._resolve_canonical_dst_ts(str(phase_dir))
+
+    assert ts == "2026_05_06_04_47_36"
+
+
+def test_resolve_canonical_dst_ts_non_zero_rank_falls_back_on_timeout(
+        tmp_path):
+    """When rank 0 never publishes, a non-zero rank falls back to own ts."""
+    phase_dir = tmp_path / "prefill_heavy"
+    phase_dir.mkdir()
+
+    profiler = PhasedBasedProfiler(profile_dir=str(tmp_path), worker_rank=1)
+    # Speed the test up by shrinking the timeout.
+    profiler._CANONICAL_TS_POLL_TIMEOUT_S = 0.1
+    profiler._CANONICAL_TS_POLL_INTERVAL_S = 0.02
+
+    ts = profiler._resolve_canonical_dst_ts(str(phase_dir))
+
+    # Format check: looks like a strftime("%Y_%m_%d_%H_%M_%S") string.
+    import datetime as _dt
+    _dt.datetime.strptime(ts, "%Y_%m_%d_%H_%M_%S")
+
+
+def test_move_capture_to_dst_dir_single_rank(tmp_path):
+    """Single rank, non-MPMD: capture moves from sandbox to <phase>/plugins/
+    profile/<canonical_ts>/ with original filename preserved."""
+    profiler = PhasedBasedProfiler(profile_dir=str(tmp_path), worker_rank=0)
     phase_dir = tmp_path / "prefill_heavy"
     rank_dir = phase_dir / "dp_rank_0"
+    rank_dir.mkdir(parents=True)
     profiler.profile_dir_with_phase_suffix = str(rank_dir)
+    profiler._canonical_dst_ts = "2026_05_06_04_47_36"
+    _stage_dp_rank_capture(rank_dir, "2026_05_06_04_47_36_jax",
+                           "t1v-n-host-w-0.xplane.pb", "data_0")
 
-    profile_path = rank_dir / "plugins" / "profile"
-    dir_early = profile_path / "2026_05_06_04_47_36"
-    dir_late = profile_path / "2026_05_06_04_47_38"
-    dir_early.mkdir(parents=True, exist_ok=True)
-    dir_late.mkdir(parents=True, exist_ok=True)
-    (dir_early / "node-1-0.xplane.pb").write_text("dummy_trace_data_1")
-    (dir_late / "node-0-0.xplane.pb").write_text("dummy_trace_data_0")
+    profiler._move_capture_to_dst_dir()
 
-    profiler._merge_profile_directories()
-
-    # Files end up at <phase>/plugins/profile/<earliest_ts>/, not under dp_rank_0.
-    merged_dir = phase_dir / "plugins" / "profile" / "2026_05_06_04_47_36"
-    assert merged_dir.exists()
-    assert not dir_late.exists()
+    dst = phase_dir / "plugins" / "profile" / "2026_05_06_04_47_36"
+    assert (dst / "t1v-n-host-w-0.xplane.pb").read_text() == "data_0"
+    # Sandbox plugins/ subtree cleaned up; dp_rank_0/ itself remains for stats.
     assert not (rank_dir / "plugins").exists()
-    assert (merged_dir /
-            "node-1-0.xplane.pb").read_text() == "dummy_trace_data_1"
-    assert (merged_dir /
-            "node-0-0.xplane.pb").read_text() == "dummy_trace_data_0"
+    assert rank_dir.exists()
 
 
-def test_merge_profile_directories_mpmd(tmp_path, monkeypatch):
-    """MPMD: 4 ranks each capture to their own dp_rank_N/plugins/profile/<ts>/
-    with identical filenames; merge hoists each up with dp{N}_ prefix so
-    they coexist in one <phase>/plugins/profile/<earliest_ts>/ dir."""
+def test_move_capture_to_dst_dir_mpmd(tmp_path, monkeypatch):
+    """MPMD: 4 ranks captured to their own sandboxes with identical
+    filenames; each moves to the SAME canonical ts dir with dp{N}_ prefix."""
     monkeypatch.setenv("TPU_MULTIPROCESS_DP", "1")
-
     phase_dir = tmp_path / "prefill_heavy"
-    profilers = []
+
+    canonical_ts = "2026_05_06_04_47_36"
     for rank in range(4):
-        rank_dir = phase_dir / f"dp_rank_{rank}"
         profiler = PhasedBasedProfiler(profile_dir=str(tmp_path),
                                        worker_rank=rank)
+        rank_dir = phase_dir / f"dp_rank_{rank}"
+        rank_dir.mkdir(parents=True)
         profiler.profile_dir_with_phase_suffix = str(rank_dir)
-        # Each rank's stop_trace lands in its own second-resolution dir.
-        ts_dir = rank_dir / "plugins" / "profile" / f"2026_05_06_04_47_{36 + rank:02d}"
-        ts_dir.mkdir(parents=True)
-        # Identical filename across ranks — the collision the fix avoids.
-        (ts_dir / "t1v-n-host-w-0.xplane.pb").write_text(f"rank_{rank}_xplane")
-        (ts_dir /
+        profiler._canonical_dst_ts = canonical_ts
+        # Each rank's stop_trace lands in its own jax ts dir, identical filenames.
+        _stage_dp_rank_capture(rank_dir, f"jax_ts_{rank}",
+                               "t1v-n-host-w-0.xplane.pb",
+                               f"rank_{rank}_xplane")
+        # Add the trace file in the same staged ts dir.
+        (rank_dir / "plugins" / "profile" / f"jax_ts_{rank}" /
          "t1v-n-host-w-0.trace.json.gz").write_text(f"rank_{rank}_trace")
-        profilers.append(profiler)
+        profiler._move_capture_to_dst_dir()
 
-    for profiler in profilers:
-        profiler._merge_profile_directories()
-
-    merged_dir = phase_dir / "plugins" / "profile" / "2026_05_06_04_47_36"
-    assert merged_dir.exists()
+    dst = phase_dir / "plugins" / "profile" / canonical_ts
+    assert dst.exists()
     for rank in range(4):
-        xplane = merged_dir / f"dp{rank}_t1v-n-host-w-0.xplane.pb"
-        trace = merged_dir / f"dp{rank}_t1v-n-host-w-0.trace.json.gz"
-        assert xplane.read_text() == f"rank_{rank}_xplane"
-        assert trace.read_text() == f"rank_{rank}_trace"
-        # Per-rank plugins/ subtree cleaned up; dp_rank_N/ remains for the
-        # batch_composition_stats JSONs (which this test doesn't stage).
+        assert (dst / f"dp{rank}_t1v-n-host-w-0.xplane.pb"
+                ).read_text() == f"rank_{rank}_xplane"
+        assert (dst / f"dp{rank}_t1v-n-host-w-0.trace.json.gz"
+                ).read_text() == f"rank_{rank}_trace"
         assert not (phase_dir / f"dp_rank_{rank}" / "plugins").exists()
-    # Trailing timestamp dirs collapsed into the earliest.
-    for rank in range(1, 4):
-        assert not (phase_dir / "plugins" / "profile" /
-                    f"2026_05_06_04_47_{36 + rank:02d}").exists()
+
+
+def test_move_capture_does_not_touch_stale_prior_run_data(tmp_path):
+    """Stale ts dirs from prior runs in <phase>/plugins/profile/ stay put;
+    the new run lands in its own canonical ts dir and never reads stale dirs."""
+    phase_dir = tmp_path / "prefill_heavy"
+    # Prior run leftover.
+    stale = phase_dir / "plugins" / "profile" / "2025_01_01_00_00_00"
+    stale.mkdir(parents=True)
+    (stale / "old_data.xplane.pb").write_text("OLD")
+
+    profiler = PhasedBasedProfiler(profile_dir=str(tmp_path), worker_rank=0)
+    rank_dir = phase_dir / "dp_rank_0"
+    rank_dir.mkdir()
+    profiler.profile_dir_with_phase_suffix = str(rank_dir)
+    profiler._canonical_dst_ts = "2026_05_06_04_47_36"
+    _stage_dp_rank_capture(rank_dir, "jax_ts", "new.xplane.pb", "NEW")
+
+    profiler._move_capture_to_dst_dir()
+
+    # Stale data untouched.
+    assert (stale / "old_data.xplane.pb").read_text() == "OLD"
+    # New data lands in its own canonical dir.
+    new_dst = phase_dir / "plugins" / "profile" / "2026_05_06_04_47_36"
+    assert (new_dst / "new.xplane.pb").read_text() == "NEW"

--- a/tpu_inference/runner/utils.py
+++ b/tpu_inference/runner/utils.py
@@ -694,7 +694,8 @@ class PhasedBasedProfiler:
     def _merge_profile_directories(self) -> None:
         """
         Consolidates phase trace artifacts so downstream tools (c2xprof,
-        TensorBoard profile plugin) see a single distributed session.
+        TensorBoard profile plugin, `scripts/merge_xprof.py`) see a single
+        distributed session.
 
         Two split states are handled in sequence; the function is safe to
         call from every rank after its own jax.profiler.stop_trace.
@@ -746,8 +747,10 @@ class PhasedBasedProfiler:
                     os.rmdir(cleanup)
                 except OSError:
                     pass
+            logger.info(
+                f"Successfully merged profile directories into: {dst_ts_dir}")
         except Exception as e:
-            logger.warning("Failed to move profile capture to dst dir: %s", e)
+            logger.warning("Failed to merge profile directories: %s", e)
 
     def step(self, batch_composition_stats: dict) -> None:
         """

--- a/tpu_inference/runner/utils.py
+++ b/tpu_inference/runner/utils.py
@@ -639,7 +639,7 @@ class PhasedBasedProfiler:
             self.profiling_n_steps_left -= 1
             if self.profiling_n_steps_left <= 0:
                 jax.profiler.stop_trace()
-                self._move_capture_to_dst_dir()
+                self._merge_profile_directories()
                 logger.info(
                     f"Profiling for {self.current_phase} phase finished")
                 self.current_phase = ""
@@ -691,26 +691,43 @@ class PhasedBasedProfiler:
             fallback_ts)
         return fallback_ts
 
-    def _move_capture_to_dst_dir(self) -> None:
-        """Move this rank's capture from the dp_rank_<N> sandbox to the
-        user-facing <phase>/plugins/profile/<canonical_dst_ts>/ dir.
-
-        Under MPMD, prefixes the filename with dp{N}_ so per-rank captures
-        coexist in the same ts dir without clobbering. Cleans up the now-
-        empty plugins/ subtree under the sandbox; the dp_rank_<N>/ dir
-        itself is kept for the per-rank batch_composition_stats JSONs.
+    def _merge_profile_directories(self) -> None:
         """
-        sandbox = os.path.join(self.profile_dir_with_phase_suffix, "plugins",
-                               "profile")
-        if not os.path.exists(sandbox):
+        Consolidates phase trace artifacts so downstream tools (c2xprof,
+        TensorBoard profile plugin) see a single distributed session.
+
+        Two split states are handled in sequence; the function is safe to
+        call from every rank after its own jax.profiler.stop_trace.
+
+        1. MPMD on a single host: each DP rank captured into
+           <phase>/dp_rank_<N>/plugins/profile/<ts>/ with an identically-
+           named xplane.pb (same hostname + same JAX worker id across
+           ranks). Hoist each rank's files up to
+           <phase>/plugins/profile/<ts>/ under TPU_MULTIPROCESS_DP, with
+           `dp<N>` injected into the filename so per-rank captures
+           coexist instead of clobbering each other.
+
+        2. Disjoint timestamp dirs: ray multi-host startup skew (or, after
+           step 1, the per-rank stop_trace timestamps in MPMD) produces
+           multiple <ts>/ subdirs under <phase>/plugins/profile/. Collapse
+           them into the earliest timestamp dir.
+
+        Example multi-host split state before merge:
+          .../plugins/profile/2026_05_06_04_47_36/j-1b8d22de-2250-4697-9dfc-ray-node-1-0.xplane.pb
+          .../plugins/profile/2026_05_06_04_47_38/j-1b8d22de-2250-4697-9dfc-ray-node-0-0.xplane.pb
+        After merge: both files under 2026_05_06_04_47_36/.
+        """
+        source_profile_path = os.path.join(self.profile_dir_with_phase_suffix,
+                                           "plugins", "profile")
+        if not os.path.exists(source_profile_path):
             return
         phase_dir = os.path.dirname(self.profile_dir_with_phase_suffix)
         dst_ts_dir = os.path.join(phase_dir, "plugins", "profile",
                                   self._canonical_dst_ts)
         try:
             os.makedirs(dst_ts_dir, exist_ok=True)
-            for ts in os.listdir(sandbox):
-                src_ts_dir = os.path.join(sandbox, ts)
+            for ts in os.listdir(source_profile_path):
+                src_ts_dir = os.path.join(source_profile_path, ts)
                 if not os.path.isdir(src_ts_dir):
                     continue
                 for fname in os.listdir(src_ts_dir):
@@ -723,7 +740,8 @@ class PhasedBasedProfiler:
                     os.rmdir(src_ts_dir)
                 except OSError:
                     pass
-            for cleanup in (sandbox, os.path.dirname(sandbox)):
+            for cleanup in (source_profile_path,
+                            os.path.dirname(source_profile_path)):
                 try:
                     os.rmdir(cleanup)
                 except OSError:

--- a/tpu_inference/runner/utils.py
+++ b/tpu_inference/runner/utils.py
@@ -594,13 +594,16 @@ class PhasedBasedProfiler:
 
             logger.info(f"Starting profiling for {self.current_phase} phase")
             logger.info(f"Batch composition stats: {batch_composition_stats}")
-            self.profile_dir_with_phase_suffix = os.path.join(
-                self.profile_dir, self.current_phase)
-            self.profile_dir_with_phase_suffix = os.path.join(
-                self.profile_dir_with_phase_suffix,
-                f"dp_rank_{self.worker_rank}")
+            phase_dir = os.path.join(self.profile_dir, self.current_phase)
+            os.makedirs(phase_dir, exist_ok=True)
 
-            # Create the profile subdirectory if it doesn't exist
+            # Resolve the canonical destination ts before start_trace so all
+            # DP ranks land in the same <phase>/plugins/profile/<ts>/ dir
+            # when capture is moved out of the sandbox.
+            self._canonical_dst_ts = self._resolve_canonical_dst_ts(phase_dir)
+
+            self.profile_dir_with_phase_suffix = os.path.join(
+                phase_dir, f"dp_rank_{self.worker_rank}")
             os.makedirs(self.profile_dir_with_phase_suffix, exist_ok=True)
 
             # Write the batch composition stats to a file to make it easier to
@@ -636,99 +639,97 @@ class PhasedBasedProfiler:
             self.profiling_n_steps_left -= 1
             if self.profiling_n_steps_left <= 0:
                 jax.profiler.stop_trace()
-                self._merge_profile_directories()
+                self._move_capture_to_dst_dir()
                 logger.info(
                     f"Profiling for {self.current_phase} phase finished")
                 self.current_phase = ""
 
-    def _merge_profile_directories(self) -> None:
+    # How long non-zero DP ranks will wait for rank 0 to publish the
+    # canonical-ts marker before falling back to their own timestamp.
+    _CANONICAL_TS_POLL_TIMEOUT_S = 5.0
+    _CANONICAL_TS_POLL_INTERVAL_S = 0.05
+
+    def _resolve_canonical_dst_ts(self, phase_dir: str) -> str:
+        """Resolve the canonical destination timestamp for this phase.
+
+        Rank 0 picks the ts (wall clock now) and writes it atomically to a
+        marker file keyed by parent PID; non-zero ranks poll for the marker
+        and read the ts so all ranks end up moving their captures into the
+        same <phase>/plugins/profile/<canonical_ts>/ dir.
+
+        The parent PID in the marker name keeps a current-session marker
+        distinct from any leftover marker from a prior `vllm serve` run
+        sharing the same PHASED_PROFILING_DIR.
         """
-        Consolidates phase trace artifacts so downstream tools (c2xprof,
-        TensorBoard profile plugin) see a single distributed session.
+        marker = os.path.join(phase_dir, f".canonical_ts_{os.getppid()}")
+        if self.worker_rank == 0:
+            canonical_ts = datetime.datetime.now().strftime(
+                "%Y_%m_%d_%H_%M_%S")
+            marker_tmp = f"{marker}.tmp"
+            with open(marker_tmp, "w") as f:
+                f.write(canonical_ts)
+            os.replace(marker_tmp, marker)
+            return canonical_ts
 
-        Two split states are handled in sequence; the function is safe to
-        call from every rank after its own jax.profiler.stop_trace.
-
-        1. MPMD on a single host: each DP rank captured into
-           <phase>/dp_rank_<N>/plugins/profile/<ts>/ with an identically-
-           named xplane.pb (same hostname + same JAX worker id across
-           ranks). Hoist each rank's files up to
-           <phase>/plugins/profile/<ts>/ under TPU_MULTIPROCESS_DP, with
-           `dp<N>` injected into the filename so per-rank captures
-           coexist instead of clobbering each other.
-
-        2. Disjoint timestamp dirs: ray multi-host startup skew (or, after
-           step 1, the per-rank stop_trace timestamps in MPMD) produces
-           multiple <ts>/ subdirs under <phase>/plugins/profile/. Collapse
-           them into the earliest timestamp dir.
-
-        Example multi-host split state before merge:
-          .../plugins/profile/2026_05_06_04_47_36/j-1b8d22de-2250-4697-9dfc-ray-node-1-0.xplane.pb
-          .../plugins/profile/2026_05_06_04_47_38/j-1b8d22de-2250-4697-9dfc-ray-node-0-0.xplane.pb
-        After merge: both files under 2026_05_06_04_47_36/.
-        """
-        source_profile_path = os.path.join(self.profile_dir_with_phase_suffix,
-                                           "plugins", "profile")
-        if not os.path.exists(source_profile_path):
-            return
-
-        # Step 1: hoist this rank's files up out of the dp_rank_N segment so
-        # the multi-timestamp merge below sees all ranks at the shared level.
-        phase_dir = os.path.dirname(self.profile_dir_with_phase_suffix)
-        target_profile_path = os.path.join(phase_dir, "plugins", "profile")
-        if os.path.realpath(source_profile_path) != os.path.realpath(
-                target_profile_path):
+        deadline = time.monotonic() + self._CANONICAL_TS_POLL_TIMEOUT_S
+        while time.monotonic() < deadline:
             try:
-                for ts in os.listdir(source_profile_path):
-                    src_ts_dir = os.path.join(source_profile_path, ts)
-                    if not os.path.isdir(src_ts_dir):
-                        continue
-                    dst_ts_dir = os.path.join(target_profile_path, ts)
-                    os.makedirs(dst_ts_dir, exist_ok=True)
-                    for fname in os.listdir(src_ts_dir):
-                        new_fname = (_inject_dp_rank_into_filename(
-                            fname, self.worker_rank)
-                                     if envs.TPU_MULTIPROCESS_DP else fname)
-                        shutil.move(os.path.join(src_ts_dir, fname),
-                                    os.path.join(dst_ts_dir, new_fname))
-                    try:
-                        os.rmdir(src_ts_dir)
-                    except OSError:
-                        pass
-                for cleanup in (source_profile_path,
-                                os.path.dirname(source_profile_path)):
-                    try:
-                        os.rmdir(cleanup)
-                    except OSError:
-                        pass
-            except Exception as e:
-                logger.warning("Failed to hoist DP profile directories: %s", e)
+                with open(marker) as f:
+                    ts = f.read().strip()
+                if ts:
+                    return ts
+            except OSError:
+                pass
+            time.sleep(self._CANONICAL_TS_POLL_INTERVAL_S)
 
-        # Step 2: collapse multiple timestamp subdirs (from multi-host skew
-        # or per-rank stop_trace times under MPMD) into the earliest one.
+        fallback_ts = datetime.datetime.now().strftime("%Y_%m_%d_%H_%M_%S")
+        logger.warning(
+            "dp_rank %d did not find rank 0's canonical-ts marker at %s "
+            "within %.1fs; falling back to own timestamp %s — this rank's "
+            "capture will land in a separate ts dir from rank 0's.",
+            self.worker_rank, marker, self._CANONICAL_TS_POLL_TIMEOUT_S,
+            fallback_ts)
+        return fallback_ts
+
+    def _move_capture_to_dst_dir(self) -> None:
+        """Move this rank's capture from the dp_rank_<N> sandbox to the
+        user-facing <phase>/plugins/profile/<canonical_dst_ts>/ dir.
+
+        Under MPMD, prefixes the filename with dp{N}_ so per-rank captures
+        coexist in the same ts dir without clobbering. Cleans up the now-
+        empty plugins/ subtree under the sandbox; the dp_rank_<N>/ dir
+        itself is kept for the per-rank batch_composition_stats JSONs.
+        """
+        sandbox = os.path.join(self.profile_dir_with_phase_suffix, "plugins",
+                               "profile")
+        if not os.path.exists(sandbox):
+            return
+        phase_dir = os.path.dirname(self.profile_dir_with_phase_suffix)
+        dst_ts_dir = os.path.join(phase_dir, "plugins", "profile",
+                                  self._canonical_dst_ts)
         try:
-            dirs = sorted([
-                d for d in os.listdir(target_profile_path)
-                if os.path.isdir(os.path.join(target_profile_path, d))
-            ])
-            if len(dirs) <= 1:
-                return
-
-            target_dir = os.path.join(target_profile_path, dirs[0])
-            for src in dirs[1:]:
-                src_dir = os.path.join(target_profile_path, src)
-                for f in os.listdir(src_dir):
-                    src_file = os.path.join(src_dir, f)
-                    dst_file = os.path.join(target_dir, f)
-                    shutil.move(src_file, dst_file)
+            os.makedirs(dst_ts_dir, exist_ok=True)
+            for ts in os.listdir(sandbox):
+                src_ts_dir = os.path.join(sandbox, ts)
+                if not os.path.isdir(src_ts_dir):
+                    continue
+                for fname in os.listdir(src_ts_dir):
+                    new_fname = (_inject_dp_rank_into_filename(
+                        fname, self.worker_rank)
+                                 if envs.TPU_MULTIPROCESS_DP else fname)
+                    shutil.move(os.path.join(src_ts_dir, fname),
+                                os.path.join(dst_ts_dir, new_fname))
                 try:
-                    os.rmdir(src_dir)
-                except Exception:
+                    os.rmdir(src_ts_dir)
+                except OSError:
                     pass
-            logger.info("Successfully merged profile directories into: %s",
-                        dirs[0])
+            for cleanup in (sandbox, os.path.dirname(sandbox)):
+                try:
+                    os.rmdir(cleanup)
+                except OSError:
+                    pass
         except Exception as e:
-            logger.warning("Failed to merge profile directories: %s", e)
+            logger.warning("Failed to move profile capture to dst dir: %s", e)
 
     def step(self, batch_composition_stats: dict) -> None:
         """


### PR DESCRIPTION
# Description

Follow-up to #2705 that hardens the MPMD profile-merge layout against pre-existing data in `PHASED_PROFILING_DIR`.

The previous approach hoisted each rank's capture from `dp_rank_<N>/plugins/profile/<ts>/` up to `<phase>/plugins/profile/<ts>/` and then collapsed timestamp subdirs into the earliest one. That step enumerated *every* timestamp subdir under `<phase>/plugins/profile/`, including ones left behind by an earlier run, and used `dirs[0]` (sorted) as the canonical target — so a stale dir from a prior session could become the destination and the current run's files would be moved into it, producing a misleading layout under a stale timestamp name.

This PR keeps the function (`_merge_profile_directories`) and call site but replaces the internals: instead of discovering a destination via enumeration, rank 0 elects a single canonical destination timestamp up front and every rank moves into it. Each session writes to a fresh ts dir that rank 0 picks itself; we never enumerate `<phase>/plugins/profile/` to discover a destination, so any stale leftovers there are inert.

## Flow

1. **`_start_profiling`** (per phase): rank 0 picks `datetime.now()` as the canonical ts and writes `<phase>/.canonical_ts_<ppid>` atomically (tmp + `os.replace`). Non-zero DP ranks poll the marker (5 s timeout, 50 ms interval) and read it. PPID in the marker name prevents a prior `vllm serve` run's marker from contaminating the current session.
2. **Capture** lands in the per-rank sandbox `<phase>/dp_rank_<N>/plugins/profile/<jax_ts>/<files>` (unchanged from #2705).
3. **`_merge_profile_directories`** (called after `stop_trace`): each rank moves its files from the sandbox into `<phase>/plugins/profile/<canonical_ts>/dp{N}_<file>` (`dp{N}_` prefix only under `TPU_MULTIPROCESS_DP`). The "merge" is implicit — every rank targets the same `<canonical_ts>` so concurrent moves from different ranks converge in one dir without further coordination. The empty `plugins/` subtree inside `dp_rank_<N>/` is removed; the rank dir keeps its `batch_composition_stats_*.json` files.

## Result after all ranks finish

| Case | Layout |
|---|---|
| Non-MPMD, single host | `<phase>/plugins/profile/<canonical_ts>/t1v-X-w-0.xplane.pb` |
| MPMD single host (4 DPs) | `<phase>/plugins/profile/<canonical_ts>/dp{0,1,2,3}_t1v-X-w-0.xplane.pb` (4 coexist) |

`<canonical_ts>` is picked fresh by rank 0 every session, so subsequent runs land in their own ts dir without touching earlier captures.

## Edge cases

- **Non-zero rank arrives at a phase before rank 0**: 5 s poll covers normal timing skew; on true timeout the rank falls back to its own ts and logs a warning (its capture lands in a separate ts dir from rank 0's — visible split, not corrupt).
- **Ray multi-host**: hosts have different ppids → each host's rank 0 elects independently, so cross-host unification is lost. Worth a follow-up that uses a ray-specific shared coordination point (e.g. via Ray's job id or a shared marker on the cluster filesystem).

# Tests

Replaced the two old `_merge_profile_directories_*` tests (which covered the old hoist+collapse internals) with 6 new ones covering the new internals:

- `test_resolve_canonical_dst_ts_rank_zero_writes_marker`
- `test_resolve_canonical_dst_ts_non_zero_rank_reads_marker`
- `test_resolve_canonical_dst_ts_non_zero_rank_falls_back_on_timeout`
- `test_merge_profile_directories_single_rank`
- `test_merge_profile_directories_mpmd`
- `test_merge_profile_directories_ignores_stale_prior_run_data`

`profiler_fixture` updated to stub the new helpers (`_resolve_canonical_dst_ts`, `_merge_profile_directories`) so the existing state-machine tests don't need a real filesystem for the new code paths.

```bash
pytest tests/runner/test_utils.py -k "phased or profiler or canonical or merge_profile"
# 12 passed
```

Verified end-to-end with 31B MPMD text + MM phased-profile runs (`vllm serve google/gemma-4-31B-it` + `PHASED_PROFILING_DIR`): all 4 DP captures coexist in one canonical ts dir per phase with `dp{0..3}_` prefixes; re-running with the same `PHASED_PROFILING_DIR` leaves the earlier session's ts dir untouched and lands in a new one.

# Checklist

Before submitting this PR, please make sure:
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have made or will make corresponding changes to any relevant documentation.
