### PR TITLE
[CI] Enforce e2el in percentile-metrics for vllm_bench_serve

### DIFF
--- a/.buildkite/benchmark/scripts/generate_bk_pipeline.py
+++ b/.buildkite/benchmark/scripts/generate_bk_pipeline.py
@@ -148,7 +148,7 @@ def validate_parameter_dependencies(case_data: Dict[str, Any], file_path: str,
             if "e2el" not in metrics_list:
                 errors.append(
                     f"Validation Error: {file_path} has 'percentile-metrics' set to '{percentile_metrics}' "
-                    f"but it must include 'e2el' for proper infrastructure reporting."
+                    f"but it must include 'e2el' for proper benchmark reporting."
                 )
 
         # Model consistency check to ensure client/server are aligned

--- a/.buildkite/benchmark/scripts/generate_bk_pipeline.py
+++ b/.buildkite/benchmark/scripts/generate_bk_pipeline.py
@@ -136,6 +136,21 @@ def validate_parameter_dependencies(case_data: Dict[str, Any], file_path: str,
 
     # Specific Rules for `vllm_bench_serve`
     if client_cmd_type == "vllm_bench_serve":
+        # Ensure percentile-metrics is present and contains 'e2el'
+        percentile_metrics = client_args.get("percentile-metrics")
+        if not percentile_metrics:
+            errors.append(
+                f"Validation Error: {file_path} is missing 'percentile-metrics' in client_command_options. "
+                f"It must be defined and include 'e2el'.")
+        else:
+            # Check if 'e2el' is in the comma-separated string
+            metrics_list = [m.strip() for m in percentile_metrics.split(",")]
+            if "e2el" not in metrics_list:
+                errors.append(
+                    f"Validation Error: {file_path} has 'percentile-metrics' set to '{percentile_metrics}' "
+                    f"but it must include 'e2el' for proper infrastructure reporting."
+                )
+
         # Model consistency check to ensure client/server are aligned
         server_model = server_args.get("model")
         client_model = client_args.get("model")


### PR DESCRIPTION
# Description

[CI] Enforce e2el in percentile-metrics for vllm_bench_serve

 - Add validation to `generate_bk_pipeline.py` to ensure `percentile-metrics` is defined and include `e2el` for `vllm_bench_serve` cases.

# Tests

[buildkite](https://buildkite.com/tpu-commons/tpu-inference-ci/builds/18542#019e6751-b462-4d60-b1ad-004a53716447) (simulate wrong json block PR merged)

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
