### PR TITLE
[MLA] Use pad and slice for transpose inside MLA kernel so that the Pallas kernel verison of the transpose is triggered

### DIFF
--- a/tpu_inference/kernels/mla/v2/kernel.py
+++ b/tpu_inference/kernels/mla/v2/kernel.py
@@ -1355,14 +1355,19 @@ def prepare_q_nope_inputs(
 
     Returns: [max_num_tokens, num_q_heads, head_dim]
     """
-    actual_num_q_heads, _, actual_head_dim = q.shape
+    actual_num_q_heads, actual_max_num_tokens, actual_head_dim = q.shape
     num_q_heads = align_to(actual_num_q_heads, get_dtype_packing(q.dtype))
     head_dim = align_to(actual_head_dim, 128)
+
+    # Align T to sublane_multiple (i.e. dtype_packing * 8).
+    # This is needed for xpose_pipeline to work efficiently.
+    sublane_multiple = get_dtype_packing(q.dtype) * 8
+    max_num_tokens = align_to(actual_max_num_tokens, sublane_multiple)
     q = jnp.pad(
         q,
         (
             (0, num_q_heads - actual_num_q_heads),
-            (0, 0),
+            (0, max_num_tokens - actual_max_num_tokens),
             (0, head_dim - actual_head_dim),
         ),
         constant_values=0,
@@ -1372,7 +1377,6 @@ def prepare_q_nope_inputs(
         q = xpose_pipeline(q, transpose_axes=(1, 0, 2), n_tile=128,
                            m_tile=32)[0]
     except ValueError as e:
-        sublane_multiple = get_dtype_packing(q.dtype) * 8
         logger.warning(
             f"xpose_pipeline failed for shape={q.shape} dtype={q.dtype} "
             f"(sublane_multiple={sublane_multiple}): {e}. "
@@ -1399,6 +1403,7 @@ def prepare_kv_inputs(kv: jax.Array):
 def prepare_outputs(
     out,  # [max_num_tokens, num_q_heads, head_dim]
     actual_num_q_heads: int,
+    actual_max_num_tokens: int,
     actual_head_dim: int,
 ):
     # Physical transpose: (T, N, D) -> (N, T, D), pipelined over T.
@@ -1417,7 +1422,7 @@ def prepare_outputs(
             f"(sublane_multiple={sublane_multiple}): {e}. "
             f"Falling back to jnp.transpose — this may be slower.")
         out = jnp.transpose(out, (1, 0, 2))
-    return out[:actual_num_q_heads, :, :actual_head_dim]
+    return out[:actual_num_q_heads, :actual_max_num_tokens, :actual_head_dim]
 
 
 @functools.partial(
@@ -1559,7 +1564,7 @@ def mla_ragged_paged_attention(
         decode_batch_size=decode_batch_size,
         debug_mode=debug_mode,
     )
-    actual_num_q_heads, _, actual_lkv_dim = ql_nope.shape
+    actual_num_q_heads, actual_max_num_tokens, actual_lkv_dim = ql_nope.shape
 
     ql_nope = prepare_q_nope_inputs(
         ql_nope)  # [max_num_tokens, num_q_heads, lkv_dim]
@@ -1836,7 +1841,7 @@ def mla_ragged_paged_attention(
         case=MlaCase.MIXED,
     )
     output = prepare_outputs(
-        ql_nope, actual_num_q_heads,
+        ql_nope, actual_num_q_heads, actual_max_num_tokens,
         actual_lkv_dim)  # [max_num_tokens, actual_num_q_heads, actual_lkv_dim]
 
     return output, updated_kv


### PR DESCRIPTION
[MLA] Use pad and slice for MLA transpose so that Pallas kernel transpose is triggered, which is more efficient than jax.transpose

This is mostly merging https://github.com/vllm-project/tpu-inference/compare/gpolovets/pad_xpose_kernel?expand=1 on behalf of George.

There is ~1.65% E2E throughput increase from this PR:
with this PR: https://paste.googleplex.com/5804913534828544
before this PR: https://paste.googleplex.com/6219680221102080 
server cmd: https://paste.googleplex.com/5244667884077056

Xprof:
with this PR: https://screenshot.googleplex.com/3dQ2TRANPr3nE4j
before this PR: https://screenshot.googleplex.com/GG5UYTTPSuegfxd