### PR TITLE
[Kernel] Clamp scratch-ref indices in rpa_body for padded steps

### DIFF
--- a/tpu_inference/kernels/experimental/batched_rpa/kernel.py
+++ b/tpu_inference/kernels/experimental/batched_rpa/kernel.py
@@ -136,12 +136,17 @@ def rpa_body(
     for b_idx in range(cfgs.batch_size):
         s_idx = schedule_ref.s_idx[step, b_idx]
         is_valid = s_idx != -1
+        # Clamp the sentinel (-1, written by mask_out_steps for padded steps)
+        # so the eager arm of jnp.where below reads an in-bounds slot. The
+        # kernel runs with disable_bounds_checks=True, which assumes indices
+        # are already in range.
+        safe_s_idx = jnp.maximum(0, s_idx)
         q_idx = schedule_ref.q_idx[step, b_idx]
         k_idx = schedule_ref.k_idx[step, b_idx]
         k_id = jnp.where(is_valid, k_idx * cfgs.bkv_sz, 0)
-        kv_len = jnp.where(is_valid, kv_lens_ref[s_idx], 0)
-        q_start = jnp.where(is_valid, cu_q_lens_ref[s_idx], 0)
-        q_end = jnp.where(is_valid, cu_q_lens_ref[s_idx + 1], 0)
+        kv_len = jnp.where(is_valid, kv_lens_ref[safe_s_idx], 0)
+        q_start = jnp.where(is_valid, cu_q_lens_ref[safe_s_idx], 0)
+        q_end = jnp.where(is_valid, cu_q_lens_ref[safe_s_idx + 1], 0)
         q_len = q_end - q_start
         offset = kv_len - q_len
 


### PR DESCRIPTION
## Summary

In `tpu_inference/kernels/experimental/batched_rpa/kernel.py:rpa_body`, three lookups read `kv_lens_ref[s_idx]`, `cu_q_lens_ref[s_idx]`, and `cu_q_lens_ref[s_idx + 1]` inside `jnp.where(is_valid, ..., 0)`. `s_idx` is set to `-1` by `schedule.py:mask_out_steps` for padded / unvisited steps (the `is_valid` mask is supposed to discard the result), but `jnp.where` evaluates both arms eagerly so the indexed loads still run.

The kernel's `pallas_call` sets `disable_bounds_checks=True` (kernel.py:510), which tells the compiler the user has already proven all indices in-bounds. The negative-index reads violate that contract — today they happen to wrap to a value the mask throws away, but the behavior is implementation-defined and could become a hardware fault or silent corruption on a future compiler / TPU revision.

Fix: introduce `safe_s_idx = jnp.maximum(0, s_idx)` and use it in the three lookups. On well-formed (`is_valid`) steps `safe_s_idx == s_idx`, so this is a no-op; on padded steps we now read slot 0 and the existing mask discards it.

The other ref reads in the same loop (`schedule_ref.s_idx[step, b_idx]`, `.q_idx`, `.k_idx`, `.is_last_k`, `m_scratch_ref[b_idx]`, etc.) use `step` and `b_idx`, both of which are already bounded — only the `s_idx`-derived lookups needed the clamp.

## On unit-test coverage

No new unit test is added because the fix is unobservable from Python:

- On well-formed inputs (`is_valid == True`), `safe_s_idx == s_idx`, so output is bit-identical to the unclamped version.
- On padded steps (`s_idx == -1`), the eager OOB load today wraps to some adjacent SMEM cell and the existing `jnp.where` mask discards the value — so output is still correct.

The change is defensive against future compiler / hardware behavior under `disable_bounds_checks=True`, not a fix for any currently-observable wrong output. A test that asserts "kernel produces correct output on a padded batch" would pass both with and without the fix and therefore wouldn't actually exercise it. Existing `tests/kernels/ragged_paged_attention_kernel_v3_test.py` covers correctness of the broader RPA family; the batched_rpa wrapper itself currently has only signature-level tests in `tests/layers/common/test_attention_interface.py`. Broader end-to-end coverage of the batched_rpa wrapper is worth doing separately as a test-coverage hygiene PR, not bundled here.

## Test plan

- [ ] `tests/kernels/ragged_paged_attention_kernel_v3_test.py` still passes (the existing RPA-family kernel test).
- [ ] No change in `tpu7x Accuracy` or RPA microbenchmark numbers in CI (fix is a no-op on well-formed inputs).
