### PR TITLE
[Scripts] Validate TIMEOUT_SECONDS and HEAD_NODE_ADDRESS early

### DIFF
--- a/scripts/multihost/run_cluster.sh
+++ b/scripts/multihost/run_cluster.sh
@@ -78,6 +78,16 @@ if [ "${NODE_TYPE}" != "--head" ] && [ "${NODE_TYPE}" != "--worker" ]; then
     exit 1
 fi
 
+# Validate HEAD_NODE_ADDRESS as a hostname / IP-like token before splicing it
+# into the Ray --address string. A typo or stray character would otherwise
+# either silently produce a broken --address=...:6379 or be interpreted by the
+# shell inside the container's `bash -c "${RAY_START_CMD}"`.
+if [[ ! "${HEAD_NODE_ADDRESS}" =~ ^[A-Za-z0-9.:-]+$ ]]; then
+    echo "Error: HEAD_NODE_ADDRESS contains unexpected characters: '${HEAD_NODE_ADDRESS}'" >&2
+    echo "Expected a hostname or IP (alphanumerics, '.', ':', '-')." >&2
+    exit 1
+fi
+
 # Set up Docker authentication for Google Container Registry.
 # Modify the hostname to accomodate your specific docker region.
 gcloud auth configure-docker us-east5-docker.pkg.dev

--- a/tests/e2e/benchmarking/bench_utils.sh
+++ b/tests/e2e/benchmarking/bench_utils.sh
@@ -10,6 +10,15 @@
 # waitForServerReady: Blocks execution until the server prints the READY_MESSAGE or times out.
 # This logic is shared across all benchmark scripts.
 waitForServerReady() {
+    # Reject non-integer TIMEOUT_SECONDS up front. Inside `[[ x -ge y ]]` the
+    # operands go through bash arithmetic evaluation, which will execute
+    # command-substitution syntax in the value if a caller ever sets it to
+    # something exotic. Easier to fail loudly than to rely on the caller.
+    if [[ ! "${TIMEOUT_SECONDS:-}" =~ ^[0-9]+$ ]]; then
+        echo "ERROR: TIMEOUT_SECONDS must be a non-negative integer, got: '${TIMEOUT_SECONDS:-}'" >&2
+        exit 1
+    fi
+
     # shellcheck disable=SC2155
     local start_time=$(date +%s)
     echo "Waiting for server ready message: '$READY_MESSAGE'"


### PR DESCRIPTION
## Summary

Two small input-validation guards on shell helpers that interpolate caller-supplied values into commands. Both are input-hygiene improvements that surface bad input as a clear error instead of relying on the caller to pass sane values.

### `tests/e2e/benchmarking/bench_utils.sh:waitForServerReady`

`TIMEOUT_SECONDS` is consumed by `[[ "$elapsed_time" -ge "$TIMEOUT_SECONDS" ]]`. Operands inside `[[ -ge ]]` go through bash arithmetic evaluation, which will execute command-substitution syntax in malformed values. Reject anything that isn't `^[0-9]+$` up front so a misconfigured caller fails loudly with a clear message instead of looping silently or doing something unexpected.

### `scripts/multihost/run_cluster.sh`

`HEAD_NODE_ADDRESS` (positional `$2`, an IP or hostname for the Ray head node) is spliced into the `--address=...:6379` argument that ends up inside the container's `bash -c \"\${RAY_START_CMD}\"`. Restrict it to `^[A-Za-z0-9.:-]+$` (covers IPv4, IPv6, and hostnames) so a typo or stray character fails loudly with a clear message instead of producing a broken cluster bring-up.

Both scripts continue to pass `bash -n` and `shellcheck`.

## Test plan

- [ ] Existing benchmark scripts (`mlperf.sh`, `llama_guard_perf_recipe.sh`, etc.) still source `bench_utils.sh` and pass — they already set `TIMEOUT_SECONDS` to a plain integer.
- [ ] `bash run_cluster.sh <image> 10.0.0.1 --head /path/to/hf` still works (well-formed IP passes the regex).
- [ ] `bash run_cluster.sh <image> 'bad value' --head /path/to/hf` now fails fast with the new error message.