### PR TITLE
[Fix] pass scatter_results back to expert and tensor GMM calls in fused_moe_func

### DIFF
--- a/tpu_inference/layers/common/fused_moe_gmm.py
+++ b/tpu_inference/layers/common/fused_moe_gmm.py
@@ -648,6 +648,7 @@ def fused_moe_func(
             mesh=mesh,
             enable_rs_kernel=actual_enable_rs_kernel,
             onehot_moe_permute_threshold=onehot_moe_permute_threshold,
+            scatter_results=scatter_results,
         )
     else:
         x = tensor_parallel_gmm(
@@ -666,6 +667,7 @@ def fused_moe_func(
             mesh=mesh,
             enable_rs_kernel=actual_enable_rs_kernel,
             onehot_moe_permute_threshold=onehot_moe_permute_threshold,
+            scatter_results=scatter_results,
         )
 
     return x[:num_tokens, :hidden_size]


### PR DESCRIPTION
accidental regression when merging with onehot PR #2674 and #2679 

# Description

Fix accidental regression when merging PR 2679 with onehot moe PR 2674.

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
