### PR TITLE
Fixes for TPU device topology and GMM kernel shape mismatch

### DIFF
--- a/tests/distributed/test_distributed_utils.py
+++ b/tests/distributed/test_distributed_utils.py
@@ -118,3 +118,26 @@ def test_get_device_topology_order_id_not_in_global():
     ]
     with pytest.raises(ValueError, match="do not exist in the global device:"):
         get_device_topology_order_id(local_devices, global_devices)
+
+
+def test_get_device_topology_order_id_missing_coords():
+    """
+    Tests fallback to process_index when coords is missing.
+    """
+
+    class TpuDeviceNoCoords:
+
+        def __init__(self, id, process_index):
+            self.id = id
+            self.process_index = process_index
+
+    global_devices = [
+        TpuDeviceNoCoords(id=0, process_index=0),
+        TpuDeviceNoCoords(id=1, process_index=1),
+    ]
+
+    local_devices = [TpuDeviceNoCoords(id=0, process_index=0)]
+    assert get_device_topology_order_id(local_devices, global_devices) == 0
+
+    local_devices = [TpuDeviceNoCoords(id=1, process_index=1)]
+    assert get_device_topology_order_id(local_devices, global_devices) == 1

--- a/tests/kernels/gmm_test.py
+++ b/tests/kernels/gmm_test.py
@@ -738,6 +738,49 @@ class GmmTest(jtu.JaxTestCase):
 
         self.assertArraysAllClose(actual, expected, atol=atol, rtol=rtol)
 
+    def test_gmm_weight_quantized_tile_k_not_divisible_by_block_size(self):
+        """Test GMM with tile_k not a multiple of block_size."""
+        batch_size = 128
+        in_size = 320
+        out_size = 512
+        num_groups = 8
+        weight_dtype = jnp.int8
+        block_size = 160
+        tile_k = 256
+
+        num_local_groups = num_groups
+        key = jax.random.key(0)
+
+        lhs = jax.random.uniform(key, (batch_size, in_size), jnp.bfloat16, -1,
+                                 1)
+        rhs = jax.random.uniform(key, (num_local_groups, in_size, out_size),
+                                 jnp.bfloat16, -1, 1)
+        rhs_q, rhs_scale = quantize_tensor(rhs,
+                                           weight_dtype,
+                                           axis=1,
+                                           block_size=block_size)
+        rhs_scale = jnp.expand_dims(rhs_scale, axis=2)
+
+        group_sizes = get_group_sizes(batch_size, num_groups)
+        group_offset = jnp.array(0, dtype=jnp.int32)
+
+        tile_info = TileSizes(tile_m=128, tile_k=tile_k, tile_n=out_size)
+
+        # Trace the kernel using jax.make_jaxpr to verify it compiles/traces without shape mismatch.
+        # This is safe to run on any backend (CPU/GPU/TPU) because it doesn't execute or lower.
+        try:
+            jax.make_jaxpr(lambda lhs_in, rhs_in, gs_in, rs_in, go_in: gmm_v2(
+                lhs_in,
+                rhs_in,
+                gs_in,
+                rhs_scale=rs_in,
+                group_offset=go_in,
+                tile_info=tile_info,
+                maybe_quantize_lhs=False,
+            ))(lhs, rhs_q, group_sizes, rhs_scale, group_offset)
+        except TypeError as e:
+            self.fail(f"gmm_v2 failed to trace: {e}")
+
 
 if __name__ == "__main__":
     absltest.main(testLoader=jtu.JaxTestLoader())

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -262,3 +262,26 @@ def poison_tpu_memory():
         ],
         compiler_params=pltpu.CompilerParams(disable_bounds_checks=True),
     )(jnp.zeros((1, ), dtype=jnp.float32))
+
+
+def test_make_optimized_mesh_missing_coords():
+    """Tests fallback to sorting by process_index and id in make_optimized_mesh when coords is missing."""
+    from tpu_inference.utils import make_optimized_mesh
+
+    class MockDeviceNoCoords:
+
+        def __init__(self, id, process_index, device_kind="TPU v7"):
+            self.id = id
+            self.process_index = process_index
+            self.device_kind = device_kind
+
+    devices = [
+        MockDeviceNoCoords(id=1, process_index=1),
+        MockDeviceNoCoords(id=0, process_index=0),
+    ]
+
+    mesh = make_optimized_mesh([2], ["axis"], devices=devices)
+
+    ordered_devices = mesh.devices.flatten()
+    assert ordered_devices[0].process_index == 0
+    assert ordered_devices[1].process_index == 1

--- a/tpu_inference/distributed/utils.py
+++ b/tpu_inference/distributed/utils.py
@@ -122,15 +122,26 @@ def get_device_topology_order_id(local_devices, global_devices) -> int:
 
     # 1. Find the 'anchor' (minimum coordinate) for the local devices.
     #    This represents the physical top-left corner of the local machine.
-    local_anchor = min(d.coords for d in local_devices)
+    try:
+        local_anchor = min(d.coords for d in local_devices)
+    except AttributeError:
+        logger.warning(
+            "TPU devices do not have 'coords' attribute. Falling back to process_index."
+        )
+        local_anchor = min(d.process_index for d in local_devices)
 
     # 2. Group global devices by process to find the anchor for EVERY process.
     process_anchors = {}
     for d in global_devices:
         pid = d.process_index
+        try:
+            coords = d.coords
+        except AttributeError:
+            coords = d.process_index
+
         # Update the minimum coordinate found for this process so far
-        if pid not in process_anchors or d.coords < process_anchors[pid]:
-            process_anchors[pid] = d.coords
+        if pid not in process_anchors or coords < process_anchors[pid]:
+            process_anchors[pid] = coords
 
     # 3. Sort the unique anchors to establish the canonical topology order.
     #    Tuples (x, y, z) sort lexicographically (x first, then y, then z).

--- a/tpu_inference/distributed/utils.py
+++ b/tpu_inference/distributed/utils.py
@@ -122,6 +122,8 @@ def get_device_topology_order_id(local_devices, global_devices) -> int:
 
     # 1. Find the 'anchor' (minimum coordinate) for the local devices.
     #    This represents the physical top-left corner of the local machine.
+    #    Fallback to process_index if JAX devices do not have 'coords' attribute
+    #    (e.g., in some Ray or GKE environments).
     try:
         local_anchor = min(d.coords for d in local_devices)
     except AttributeError:

--- a/tpu_inference/kernels/megablox/gmm_v2.py
+++ b/tpu_inference/kernels/megablox/gmm_v2.py
@@ -383,11 +383,21 @@ def inner_kernel(
             rhs_qbs = cfgs.rhs_cfgs.quant_block_size
             tiled_rhs_scale = tiled_rhs_ref.get_scale().astype(acc_ref.dtype)
             num_blocks = cfgs.num_quant_blocks_per_tile_k
-            tiled_rhs_dequant = tiled_rhs.astype(acc_ref.dtype).reshape(
+
+            pad_len = num_blocks * rhs_qbs - cfgs.tiles.tile_k
+            if pad_len > 0:
+                zeros = jnp.zeros((pad_len, rhs_tile_n), dtype=tiled_rhs.dtype)
+                padded_rhs = jnp.concatenate([tiled_rhs, zeros], axis=0)
+            else:
+                padded_rhs = tiled_rhs
+
+            tiled_rhs_dequant = padded_rhs.astype(acc_ref.dtype).reshape(
                 num_blocks, rhs_qbs, rhs_tile_n)
             tiled_rhs_dequant = tiled_rhs_dequant * tiled_rhs_scale
-            tiled_rhs = tiled_rhs_dequant.reshape(cfgs.tiles.tile_k,
-                                                  rhs_tile_n)
+
+            tiled_rhs = tiled_rhs_dequant.reshape(-1, rhs_tile_n)
+            if pad_len > 0:
+                tiled_rhs = tiled_rhs[:cfgs.tiles.tile_k, :]
 
         valid_k = cfgs.dims.size_k % cfgs.tiles.tile_k
         if is_last_k_step and valid_k != 0:

--- a/tpu_inference/kernels/megablox/gmm_v2.py
+++ b/tpu_inference/kernels/megablox/gmm_v2.py
@@ -384,6 +384,8 @@ def inner_kernel(
             tiled_rhs_scale = tiled_rhs_ref.get_scale().astype(acc_ref.dtype)
             num_blocks = cfgs.num_quant_blocks_per_tile_k
 
+            # Pad tiled_rhs along K dimension if tile_k is not a multiple of quant_block_size,
+            # to avoid shape mismatch during reshape.
             pad_len = num_blocks * rhs_qbs - cfgs.tiles.tile_k
             if pad_len > 0:
                 zeros = jnp.zeros((pad_len, rhs_tile_n), dtype=tiled_rhs.dtype)

--- a/tpu_inference/utils.py
+++ b/tpu_inference/utils.py
@@ -247,7 +247,8 @@ def make_optimized_mesh(axis_shapes: Sequence[int],
                         devices: Sequence[xc.Device] | None = None):
     if devices is None:
         devices = xb.devices()
-    # Sort the devices in case it's passed in an arbitary order
+    # Sort the devices in case it's passed in an arbitary order.
+    # Fallback to sorting by process_index and id if 'coords' is missing
     try:
         devices = sorted(devices, key=lambda x: x.coords)
     except AttributeError:

--- a/tpu_inference/utils.py
+++ b/tpu_inference/utils.py
@@ -248,7 +248,13 @@ def make_optimized_mesh(axis_shapes: Sequence[int],
     if devices is None:
         devices = xb.devices()
     # Sort the devices in case it's passed in an arbitary order
-    devices = sorted(devices, key=lambda x: x.coords)
+    try:
+        devices = sorted(devices, key=lambda x: x.coords)
+    except AttributeError:
+        logger.warning(
+            "TPU devices do not have 'coords' attribute. Falling back to sorting by process_index and id."
+        )
+        devices = sorted(devices, key=lambda x: (x.process_index, x.id))
 
     def _is_1D(axis_shapes):
         return sum(x > 1 for x in axis_shapes) == 1


### PR DESCRIPTION
# Description

Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8 failed to start with multi-host v7 on GKE

* Fix AttributeError in utils.py and distributed/utils.py when JAX devices lack coords attribute by falling back to process_index or process_index and id for sorting.
* Fix TypeError in gmm_v2.py by padding tensors before reshape when tile_k is not a multiple of quant_block_size.

# Tests

tests/distributed/test_distributed_utils.py
tests/test_utils.py


# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
