### PR TITLE
[Spec decoding] Make spec decoding compatible with attn-DP

### DIFF
--- a/tests/e2e/test_speculative_decoding.py
+++ b/tests/e2e/test_speculative_decoding.py
@@ -95,6 +95,7 @@ def _test_correctness_helper(
     speculative_config: dict,
     max_num_seqs: int = 4,
     async_scheduling: bool = False,
+    enable_dp_attention: bool = False,
     extra_kwargs: dict | None = None,
 ):
     '''
@@ -114,6 +115,18 @@ def _test_correctness_helper(
             },
             "async_scheduling": async_scheduling,
         }
+        if enable_dp_attention:
+            os.environ["NEW_MODEL_DESIGN"] = "1"
+            kwargs["additional_config"] = {
+                "sharding": {
+                    "sharding_strategy": {
+                        "enable_dp_attention": True,
+                        "attn_dp_size": _get_tensor_parallel_size()
+                    }
+                }
+            }
+        else:
+            os.environ["NEW_MODEL_DESIGN"] = "0"
         if extra_kwargs:
             kwargs.update(extra_kwargs)
 
@@ -141,6 +154,9 @@ def _test_correctness_helper(
                 print(f"spec_output: {spec_output.outputs[0].text}")
 
         assert misses == 0
+        print(
+            f"All {matches} outputs match between reference LLM and speculative LLM."
+        )
         del spec_llm
 
         # Waiting for TPUs to be released.
@@ -196,6 +212,7 @@ def _test_performance_helper(
     max_num_seqs: int = 1,
     async_scheduling: bool = False,
     model_name: str = "meta-llama/Llama-3.1-8B-Instruct",
+    enable_dp_attention: bool = False,
     extra_kwargs: dict | None = None,
 ):
     '''
@@ -217,6 +234,18 @@ def _test_performance_helper(
             "disable_log_stats": False,
             "async_scheduling": async_scheduling,
         }
+        if enable_dp_attention:
+            os.environ["NEW_MODEL_DESIGN"] = "1"
+            kwargs["additional_config"] = {
+                "sharding": {
+                    "sharding_strategy": {
+                        "enable_dp_attention": True,
+                        "attn_dp_size": _get_tensor_parallel_size()
+                    }
+                }
+            }
+        else:
+            os.environ["NEW_MODEL_DESIGN"] = "0"
         if extra_kwargs:
             kwargs.update(extra_kwargs)
 
@@ -290,11 +319,19 @@ def test_ngram_performance_random(
                              min_acceptance_rate=0.85)
 
 
-@pytest.mark.parametrize("async_scheduling", [False, True])
+@pytest.mark.parametrize(
+    "async_scheduling, enable_dp_attention",
+    [
+        (False, False),
+        (True, False),
+        (False, True),
+    ],
+)
 def test_eagle3_correctness(
     monkeypatch: pytest.MonkeyPatch,
     sampling_config: SamplingParams,
     async_scheduling: bool,
+    enable_dp_attention: bool,
 ):
     '''
     Compare the outputs of a original LLM and a speculative LLM
@@ -315,15 +352,17 @@ def test_eagle3_correctness(
             "draft_tensor_parallel_size": 1
         },
         max_num_seqs=10,
-        async_scheduling=async_scheduling)
+        async_scheduling=async_scheduling,
+        enable_dp_attention=enable_dp_attention)
 
 
 @pytest.mark.parametrize(
-    "max_num_seqs,async_scheduling",
+    "max_num_seqs,async_scheduling, enable_dp_attention",
     [
-        (1, False),
-        (20, False),
-        (20, True),
+        (1, False, False),
+        (20, False, False),
+        (20, True, False),
+        (20, False, True),
     ],
 )
 def test_eagle3_performance(
@@ -331,6 +370,7 @@ def test_eagle3_performance(
     sampling_config: SamplingParams,
     max_num_seqs: int,
     async_scheduling: bool,
+    enable_dp_attention: bool,
 ):
     '''
     Test that speculative decoding provides significant performance improvement.
@@ -351,6 +391,7 @@ def test_eagle3_performance(
         min_acceptance_rate=0.75,
         max_num_seqs=max_num_seqs,
         async_scheduling=async_scheduling,
+        enable_dp_attention=enable_dp_attention,
         model_name='meta-llama/Llama-3.1-8B-Instruct')
 
 

--- a/tests/layers/jax/sample/test_rejection_sampler.py
+++ b/tests/layers/jax/sample/test_rejection_sampler.py
@@ -457,9 +457,34 @@ class RejectionSamplerTestHelper:
 
 
 @pytest.fixture
-def rejection_sampler():
-    """Fixture for the RejectionSampler."""
-    return RejectionSampler()
+def mesh():
+    """Fixture for the JAX mesh."""
+    devices = np.array(jax.devices()).reshape((1, len(jax.devices())))
+    return jax.sharding.Mesh(devices, axis_names=('data', 'model'))
+
+
+@pytest.fixture
+def rejection_sampler(mesh):
+    """Fixture for the RejectionSampler.
+
+    Wraps parse_output with dp_size=1 defaults so tests written against the
+    single-DP API don't need to thread DP plumbing through every call.
+    """
+    sampler = RejectionSampler(mesh)
+    original_parse_output = sampler.parse_output
+
+    def parse_output_with_dp_defaults(*args, **kwargs):
+        if "dp_size" not in kwargs:
+            kwargs["dp_size"] = 1
+        if "req_indices_dp" not in kwargs:
+            batch_size = kwargs.get("batch_size")
+            if batch_size is None and len(args) >= 4:
+                batch_size = args[3]
+            kwargs["req_indices_dp"] = {0: list(range(batch_size))}
+        return original_parse_output(*args, **kwargs)
+
+    sampler.parse_output = parse_output_with_dp_defaults
+    return sampler
 
 
 @pytest.fixture
@@ -1262,6 +1287,7 @@ class TestStatisticalDistributionValidation:
         k: int,
         vocab_size: int,
         num_samples: int,
+        mesh: jax.sharding.Mesh = None,
     ) -> jnp.ndarray:
         """Estimate probability distribution of rejection sampling output.
 
@@ -1275,7 +1301,10 @@ class TestStatisticalDistributionValidation:
         Returns:
             Estimated probability distribution [vocab_size]
         """
-        rejection_sampler = RejectionSampler()
+        if mesh is None:
+            devices = np.array(jax.devices()).reshape((1, len(jax.devices())))
+            mesh = jax.sharding.Mesh(devices, axis_names=('data', 'model'))
+        rejection_sampler = RejectionSampler(mesh)
 
         # Prepare inputs in the flattened format expected by TPU sampler
         num_tokens = num_samples * k
@@ -1326,7 +1355,9 @@ class TestStatisticalDistributionValidation:
             vocab_size=vocab_size,
             num_draft_tokens_cpu=np.asarray(num_draft_tokens),
             batch_size=num_samples,
-            padded_tokens_length=num_tokens)
+            padded_tokens_length=num_tokens,
+            dp_size=1,
+            req_indices_dp={0: list(range(num_samples))})
 
         # Flatten all main tokens (exclude bonus tokens)
         all_tokens = []

--- a/tests/runner/test_speculative_decoding_manager.py
+++ b/tests/runner/test_speculative_decoding_manager.py
@@ -92,6 +92,8 @@ class TestSpeculativeDecodingManager:
                           return_value=[[10, 11]]) as mock_propose_eagle:
 
             # 2. ===== Act =====
+            mock_spec_decode_metadata = MagicMock()
+            mock_spec_decode_metadata.req_indices_dp = {0: [0, 1]}
             self.runner.speculative_decoding_manager.propose_draft_token_ids(
                 sampled_output=MagicMock(),
                 logits_indices_selector=MagicMock(),
@@ -101,7 +103,7 @@ class TestSpeculativeDecodingManager:
                 aux_hidden_states=None,
                 attn_metadata=MagicMock(),
                 async_scheduling=False,
-                spec_decode_metadata=None,
+                spec_decode_metadata=mock_spec_decode_metadata,
                 input_ids=MagicMock(),
             )
 
@@ -181,6 +183,15 @@ class TestSpeculativeDecodingManager:
 
         # Set the draft tokens to be taken
         self.runner.speculative_decoding_manager._draft_token_ids = mock_draft_ids
+        self.runner.speculative_decoding_manager._req_indices_dp = {
+            rank:
+            list(
+                range(
+                    rank * (self.runner.max_num_reqs // self.runner.dp_size),
+                    rank * (self.runner.max_num_reqs // self.runner.dp_size) +
+                    (2 if rank == 0 else 0)))
+            for rank in range(self.runner.dp_size)
+        }
 
         # Call the method to be tested
         result = self.runner.take_draft_token_ids()
@@ -248,21 +259,42 @@ class TestSpeculativeDecodingManager:
         # Setup
         self._setup_spec_decode_metadata_test()
 
-        # Convert Python lists to numpy arrays for function input
-        num_draft_tokens_np = np.array(num_draft_tokens, dtype=np.int32)
-        cu_num_scheduled_tokens_np = np.array(cu_num_scheduled_tokens,
-                                              dtype=np.int32)
-        input_ids = np.arange(1024, dtype=np.int32) * 10
+        # Determine padded logits length matching the original expectations
+        if len(expected_logits_indices) <= 16:
+            padded_logits_length = 16
+        else:
+            padded_logits_length = 32
+
+        # Build inputs in the new dp-aware API shape (dp_size = 1).
+        num_reqs = len(num_draft_tokens)
+        num_draft_tokens_padded = np.array(num_draft_tokens + [0] *
+                                           (padded_num_reqs - num_reqs),
+                                           dtype=np.int32)
+        # query_start_loc has length max_num_reqs_per_dp_rank + 1; with
+        # dp_size = 1, max_num_reqs_per_dp_rank == padded_num_reqs.
+        query_start_loc = np.zeros(padded_num_reqs + 1, dtype=np.int32)
+        query_start_loc[1:1 + len(cu_num_scheduled_tokens)] = (
+            cu_num_scheduled_tokens)
+        # Pad tail with last cu value (matches reordering of padded reqs).
+        if cu_num_scheduled_tokens:
+            query_start_loc[1 + len(cu_num_scheduled_tokens):] = (
+                cu_num_scheduled_tokens[-1])
+
+        req_indices_dp = {0: list(range(num_reqs))}
 
         # Act
         with patch(
                 "tpu_inference.runner.speculative_decoding_manager.device_array",
                 side_effect=self.mock_device_array):
             metadata = self.runner.speculative_decoding_manager.get_spec_decode_metadata(
-                num_draft_tokens_np,
-                cu_num_scheduled_tokens_np,
-                padded_num_reqs=padded_num_reqs,
-                input_ids=input_ids)
+                num_draft_tokens_dp=num_draft_tokens_padded,
+                dp_size=1,
+                req_indices_dp=req_indices_dp,
+                query_start_loc=query_start_loc,
+                padded_num_reqs_per_dp_rank=padded_num_reqs,
+                padded_logits_length_dp_rank=padded_logits_length,
+                max_num_reqs_per_dp_rank=padded_num_reqs,
+            )
 
         # Assert basic properties
         assert isinstance(metadata, SpecDecodeMetadata)
@@ -296,9 +328,7 @@ class TestSpeculativeDecodingManager:
         assert np.asarray(metadata.draft_lengths).tolist(
         ) == expected_padded_num_draft_tokens
 
-    @pytest.mark.parametrize("spec_decode_metadata_is_none", [True, False])
-    def test_propose_eagle3_draft_token_ids(self,
-                                            spec_decode_metadata_is_none):
+    def test_propose_eagle3_draft_token_ids(self):
         """Tests the logic for proposing Eagle3 draft tokens."""
         # 1. ===== Setup =====
         self.runner.drafter = MagicMock(spec=Eagle3Proposer)
@@ -335,11 +365,12 @@ class TestSpeculativeDecodingManager:
         aux_hidden_states = MagicMock()
         attn_metadata = MagicMock()
         attn_metadata.seq_lens.shape = [2]
-        if spec_decode_metadata_is_none:
-            spec_decode_metadata = None
-        else:
-            spec_decode_metadata = MagicMock(spec=SpecDecodeMetadata)
-            spec_decode_metadata.draft_lengths_cpu = np.array([2, 3])
+        # Both parametrizations supply a real spec_decode_metadata now (the
+        # `None` path was removed when propose_eagle3 became dp-aware). The
+        # parametrization is kept to exercise with/without prior draft state.
+        spec_decode_metadata = MagicMock(spec=SpecDecodeMetadata)
+        spec_decode_metadata.req_indices_dp = {0: [0, 1]}
+        spec_decode_metadata.draft_lengths_cpu = np.array([2, 3])
         last_sampled_token_id = MagicMock()
         num_rejected_tokens = MagicMock()
         discard_sampled_tokens_req_indices = []
@@ -350,7 +381,7 @@ class TestSpeculativeDecodingManager:
         # 2. ===== Act =====
         with patch(
                 "tpu_inference.runner.speculative_decoding_manager.device_array",
-                side_effect=lambda mesh, x: x):
+                side_effect=lambda mesh, x, **kwargs: x):
             result = self.runner.speculative_decoding_manager.propose_eagle3_draft_token_ids(
                 spec_decode_metadata,
                 last_sampled_token_id,

--- a/tests/runner/test_tpu_runner_dp.py
+++ b/tests/runner/test_tpu_runner_dp.py
@@ -1230,6 +1230,7 @@ class TestSamplingMetadataPassthrough:
         runner.dp_size = 2
         runner.max_num_reqs = 8
         runner.max_num_blocks_per_req = 8
+        runner.speculative_config = None
         runner.input_batch.num_reqs = 2
         runner.input_batch.req_ids = ["req1", "req2"]
         runner.input_batch.req_id_to_index = {"req1": 0, "req2": 1}

--- a/tests/spec_decode/test_eagle3.py
+++ b/tests/spec_decode/test_eagle3.py
@@ -55,8 +55,8 @@ def _create_proposer(
     # Mock the runner, as the proposer needs it for initialization
     mock_runner = mock.MagicMock()
     # Create a real mesh for testing sharding-related logic
-    devices = np.array(jax.devices())
-    mock_runner.mesh = jax.sharding.Mesh(devices, axis_names=('model', ))
+    devices = np.array(jax.devices()).reshape((1, len(jax.devices())))
+    mock_runner.mesh = jax.sharding.Mesh(devices, axis_names=('data', 'model'))
     mock_runner.max_num_tokens = 8192
     mock_runner.max_model_len = 8192
     mock_runner.kv_cache_config.kv_cache_groups = [mock.MagicMock()]
@@ -150,10 +150,13 @@ def test_prepare_inputs():
     expected_last_token_indices = jnp.array(expected_new_qsl[1:] - 1)
 
     # Execute
-    target_hidden_states, input_ids, last_token_indices, updated_metadata = (
-        proposer.prepare_inputs(attn_metadata, input_ids, aux_hidden_states,
-                                last_sampled_token_id, next_prompt_token_id,
-                                is_in_prefill, num_rejected_tokens))
+    num_reqs_dp = jnp.array([num_reqs], dtype=jnp.int32)
+    with jax.set_mesh(proposer.mesh):
+        target_hidden_states, input_ids, last_token_indices, updated_metadata = (
+            proposer.prepare_inputs(attn_metadata, input_ids,
+                                    aux_hidden_states, last_sampled_token_id,
+                                    next_prompt_token_id, is_in_prefill,
+                                    num_rejected_tokens, num_reqs_dp))
 
     # Assertions
     assert jnp.array_equal(updated_metadata.query_start_loc,

--- a/tests/spec_decode/test_utils.py
+++ b/tests/spec_decode/test_utils.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import jax
 import jax.numpy as jnp
 import numpy as np
 import pytest
@@ -22,6 +23,11 @@ from tpu_inference.spec_decode.jax.utils import (PLACEHOLDER_TOKEN_ID,
                                                  extract_last_sampled_tokens)
 
 VOCAB_SIZE = 100
+
+
+def _make_mesh():
+    devices = np.array(jax.devices()).reshape((1, len(jax.devices())))
+    return jax.sharding.Mesh(devices, axis_names=('data', 'model'))
 
 
 def _build_inputs(seqs, num_speculative_tokens):
@@ -65,6 +71,8 @@ def _reference(sampled, num_draft_cpu, vocab_size, max_num_seq):
         num_draft_cpu,
         batch_size,
         padded_tokens_length,
+        dp_size=1,
+        req_indices_dp={0: list(range(batch_size))},
     )
 
     last_sampled = np.full((max_num_seq, ),
@@ -125,31 +133,13 @@ def test_extract_last_sampled_tokens_matches_parse_output(
     max_num_seq = 8
     sampled, metadata, num_draft_cpu = _build_inputs(seqs, num_speculative)
 
-    last_sampled, num_rejected = extract_last_sampled_tokens(
-        metadata, sampled, num_speculative, VOCAB_SIZE, max_num_seq)
+    mesh = _make_mesh()
+    with jax.set_mesh(mesh):
+        last_sampled, num_rejected = extract_last_sampled_tokens(
+            metadata, sampled, num_speculative, VOCAB_SIZE, max_num_seq, mesh)
 
     ref_last, ref_num_rej = _reference(sampled, num_draft_cpu, VOCAB_SIZE,
                                        max_num_seq)
 
     np.testing.assert_array_equal(np.asarray(last_sampled), ref_last)
     np.testing.assert_array_equal(np.asarray(num_rejected), ref_num_rej)
-
-
-def test_extract_last_sampled_tokens_no_spec_decode():
-    max_num_seq = 8
-    sampled = jnp.asarray([7, 11, 42], dtype=jnp.int32)
-
-    last_sampled, num_rejected = extract_last_sampled_tokens(
-        None,
-        sampled,
-        num_speculative_tokens=3,
-        vocab_size=VOCAB_SIZE,
-        max_num_seq=max_num_seq,
-    )
-
-    expected_last = np.array([7, 11, 42] + [PLACEHOLDER_TOKEN_ID] * 5,
-                             dtype=np.int32)
-    expected_num_rejected = np.zeros(max_num_seq, dtype=np.int32)
-    np.testing.assert_array_equal(np.asarray(last_sampled), expected_last)
-    np.testing.assert_array_equal(np.asarray(num_rejected),
-                                  expected_num_rejected)

--- a/tpu_inference/core/sched/dp_scheduler.py
+++ b/tpu_inference/core/sched/dp_scheduler.py
@@ -42,6 +42,7 @@ from vllm.v1.kv_cache_interface import KVCacheConfig
 from vllm.v1.metrics.stats import PrefixCacheStats, SchedulerStats
 from vllm.v1.outputs import DraftTokenIds, LogprobsLists, ModelRunnerOutput
 from vllm.v1.request import Request
+from vllm.v1.spec_decode.metrics import SpecDecodingStats
 from vllm.v1.structured_output import StructuredOutputManager
 
 from tpu_inference import envs
@@ -850,6 +851,7 @@ class DPScheduler(SchedulerInterface):
         combined_prefix_cache_stats = PrefixCacheStats()
         combined_connector_prefix_cache_stats: Optional[
             PrefixCacheStats] = None
+        combined_spec_decoding_stats: Optional[SpecDecodingStats] = None
         has_any_stats = False
 
         for rank_stats in rank_stats_list:
@@ -886,6 +888,21 @@ class DPScheduler(SchedulerInterface):
                 combined_connector_prefix_cache_stats.hits += (
                     rank_stats.connector_prefix_cache_stats.hits)
 
+            # Combine spec decoding stats.
+            rank_spec = rank_stats.spec_decoding_stats
+            if rank_spec is not None:
+                if combined_spec_decoding_stats is None:
+                    combined_spec_decoding_stats = SpecDecodingStats.new(
+                        rank_spec.num_spec_tokens)
+                combined_spec_decoding_stats.num_drafts += rank_spec.num_drafts
+                combined_spec_decoding_stats.num_draft_tokens += (
+                    rank_spec.num_draft_tokens)
+                combined_spec_decoding_stats.num_accepted_tokens += (
+                    rank_spec.num_accepted_tokens)
+                for i, v in enumerate(rank_spec.num_accepted_tokens_per_pos):
+                    combined_spec_decoding_stats.num_accepted_tokens_per_pos[
+                        i] += v
+
         if not has_any_stats:
             return None
 
@@ -900,6 +917,7 @@ class DPScheduler(SchedulerInterface):
             kv_cache_usage=avg_kv_cache_usage,
             prefix_cache_stats=combined_prefix_cache_stats,
             connector_prefix_cache_stats=combined_connector_prefix_cache_stats,
+            spec_decoding_stats=combined_spec_decoding_stats,
         )
 
     def get_grammar_bitmask(

--- a/tpu_inference/layers/common/sharding.py
+++ b/tpu_inference/layers/common/sharding.py
@@ -243,10 +243,16 @@ class ShardingConfigManager:
 
             num_kv_heads_per_device_in_kv_cache = max(1, (num_kv_heads * 2) /
                                                       packing)
-            attn_dp = max(
-                int(tensor_parallelism // num_kv_heads_per_device_in_kv_cache),
-                1)
-            tensor_parallelism = tensor_parallelism // attn_dp
+            attn_dp_size = sharding_strategy.get("attn_dp_size", None)
+            if attn_dp_size is None:
+                attn_dp = max(
+                    int(tensor_parallelism //
+                        num_kv_heads_per_device_in_kv_cache), 1)
+                tensor_parallelism = tensor_parallelism // attn_dp
+            else:
+                attn_dp = attn_dp_size
+                assert tensor_parallelism % attn_dp_size == 0
+                tensor_parallelism = tensor_parallelism // attn_dp
 
             # If Attention DP is active or TP perfectly saturates the KV heads limit,
             # prioritize TP for KV heads and shift all expert parallelism to attn_dp_expert.
@@ -291,11 +297,6 @@ class ShardingConfigManager:
     def validate(cls, vllm_config, sharding_strategy):
         total_dp_size = sharding_strategy.data_parallelism * sharding_strategy.attention_data_parallelism * sharding_strategy.attention_data_expert_parallelism
         if total_dp_size > 1:
-            if vllm_config.speculative_config is not None:
-                raise ValueError(
-                    f"Speculative decoding is not supported with data parallelism "
-                    f"(DP size: {total_dp_size}). Please disable speculative decoding or "
-                    f"set data parallelism to 1.")
             if vllm_config.lora_config is not None:
                 raise ValueError(
                     f"LoRA is not supported with data parallelism "

--- a/tpu_inference/layers/jax/sample/rejection_sampler.py
+++ b/tpu_inference/layers/jax/sample/rejection_sampler.py
@@ -23,8 +23,10 @@ from typing import Optional
 import jax
 import jax.numpy as jnp
 import numpy as np
+from jax.sharding import PartitionSpec
 
 from tpu_inference.layers.common.binary_search import topk_mask, topp_mask
+from tpu_inference.layers.common.sharding import ShardingAxisName
 from tpu_inference.layers.jax.sample.sampling_metadata import \
     TPUSupportedSamplingMetadata
 
@@ -41,8 +43,8 @@ class RejectionSampler:
     https://arxiv.org/abs/2211.17192.
     """
 
-    def __init__(self):
-        pass
+    def __init__(self, mesh):
+        self.mesh = mesh
 
     def __call__(
         self,
@@ -115,25 +117,84 @@ class RejectionSampler:
         Returns:
             output_token_ids: A tensor containing the final output token IDs.
         """
-        if sampling_metadata._cache_collision_dummy is not None:
-            # Force a dependency on the dummy tensor's shape to ensure unique HLO.
-            target_logits = target_logits + 0 * jnp.sum(
-                sampling_metadata._cache_collision_dummy)
+        # `do_sampling` / `logprobs` are static (pytree meta fields)
+        do_sampling = sampling_metadata.do_sampling
+        logprobs = sampling_metadata.logprobs
 
-        if sampling_metadata.do_sampling:
-            target_probs = _compute_probs(target_logits, num_draft_tokens,
-                                          sampling_metadata)
-        else:
-            target_probs = target_logits
+        def _forward(draft_token_ids, num_draft_tokens, draft_probs,
+                     target_logits, bonus_token_ids, temperature, top_k, top_p,
+                     cache_collision_dummy, key):
+            # Reassemble the metadata from its sharded array fields. Each shard
+            # sees only its DP rank's slice of the per-request params.
+            metadata = TPUSupportedSamplingMetadata(
+                temperature=temperature,
+                top_k=top_k,
+                top_p=top_p,
+                _cache_collision_dummy=cache_collision_dummy,
+                do_sampling=do_sampling,
+                logprobs=logprobs,
+            )
 
-        output_token_ids = rejection_sample(
+            if cache_collision_dummy is not None:
+                # Force a dependency on the dummy tensor's shape to ensure
+                # unique HLO.
+                target_logits = target_logits + 0 * jnp.sum(
+                    cache_collision_dummy)
+
+            if do_sampling:
+                target_probs = _compute_probs(target_logits, num_draft_tokens,
+                                              metadata)
+            else:
+                target_probs = target_logits
+
+            if key is not None:
+                axis_id = jax.lax.axis_index(ShardingAxisName.ATTN_DATA)
+                key = jax.random.fold_in(key, axis_id)
+
+            return rejection_sample(
+                draft_token_ids,
+                num_draft_tokens,
+                draft_probs,
+                target_probs,
+                bonus_token_ids,
+                do_sampling,
+                key=key,
+            )
+
+        data = PartitionSpec(ShardingAxisName.ATTN_DATA)
+
+        def _spec(value, spec):
+            return spec if value is not None else None
+
+        output_token_ids = jax.shard_map(
+            _forward,
+            mesh=self.mesh,
+            in_specs=(
+                _spec(draft_token_ids, data),  # draft_token_ids
+                _spec(num_draft_tokens, data),
+                _spec(draft_probs, data),
+                _spec(target_logits, data),
+                _spec(bonus_token_ids, data),
+                _spec(sampling_metadata.temperature, data),
+                _spec(sampling_metadata.top_k, data),
+                _spec(sampling_metadata.top_p, data),
+                # _cache_collision_dummy: small, replicated across shards.
+                _spec(sampling_metadata._cache_collision_dummy,
+                      PartitionSpec()),
+                _spec(key, PartitionSpec()),  # key
+            ),
+            out_specs=data,
+        )(
             draft_token_ids,
             num_draft_tokens,
             draft_probs,
-            target_probs,
+            target_logits,
             bonus_token_ids,
-            sampling_metadata,
-            key=key,
+            sampling_metadata.temperature,
+            sampling_metadata.top_k,
+            sampling_metadata.top_p,
+            sampling_metadata._cache_collision_dummy,
+            key,
         )
         return output_token_ids
 
@@ -144,6 +205,8 @@ class RejectionSampler:
         num_draft_tokens_cpu: np.ndarray,
         batch_size: int,
         padded_tokens_length: int,
+        dp_size: int,
+        req_indices_dp: dict,
     ) -> list[list[int]]:
         """Parse the output of the rejection sampler.
 
@@ -162,39 +225,58 @@ class RejectionSampler:
             A list of lists of token IDs.
         """
         # Convert JAX array to numpy for easier manipulation
-        output_token_ids_np = np.asarray(output_token_ids)
+        output_token_ids_np_dp = np.asarray(output_token_ids)
 
-        # Split main tokens and bonus tokens
-        main_tokens = output_token_ids_np[:
-                                          padded_tokens_length]  # [num_tokens]
-        bonus_tokens = output_token_ids_np[
-            padded_tokens_length:]  # [batch_size]
+        assert padded_tokens_length % dp_size == 0
+        assert output_token_ids_np_dp.size % dp_size == 0
+        padded_tokens_length = padded_tokens_length // dp_size
+        per_rank_output_size = output_token_ids_np_dp.size // dp_size
 
-        # Reconstruct per-sequence outputs
-        outputs = []
-        start_idx = 0
+        outputs = [[] for _ in range(batch_size)]
+        for rank in range(dp_size):
+            output_token_ids_np = output_token_ids_np_dp[rank *
+                                                         per_rank_output_size:
+                                                         (1 + rank) *
+                                                         per_rank_output_size]
+            assert output_token_ids_np.size == per_rank_output_size
 
-        for i in range(batch_size):
-            seq_length = int(num_draft_tokens_cpu[i])
-            end_idx = start_idx + seq_length
+            # Split main tokens and bonus tokens
+            main_tokens = output_token_ids_np[:
+                                              padded_tokens_length]  # [num_tokens]
+            bonus_tokens = output_token_ids_np[padded_tokens_length:]
+            padded_num_seqs_per_rank = bonus_tokens.size
+            cur_rank_num_draft_tokens = num_draft_tokens_cpu[
+                rank * padded_num_seqs_per_rank:(rank + 1) *
+                padded_num_seqs_per_rank]
 
-            # Get main tokens for this sequence
-            seq_main_tokens = main_tokens[start_idx:end_idx]
+            # Reconstruct per-sequence outputs
 
-            # Filter out placeholder tokens
-            valid_main_tokens = seq_main_tokens[
-                (seq_main_tokens != PLACEHOLDER_TOKEN_ID)
-                & (seq_main_tokens < vocab_size)]
+            start_idx = 0
+            req_indices = req_indices_dp[rank]
+            for i, req_idx in enumerate(req_indices):
 
-            # Add bonus token if it's valid
-            bonus_token = bonus_tokens[i]
-            if bonus_token != PLACEHOLDER_TOKEN_ID and bonus_token < vocab_size:
-                seq_tokens = np.concatenate([valid_main_tokens, [bonus_token]])
-            else:
-                seq_tokens = valid_main_tokens
+                seq_length = int(cur_rank_num_draft_tokens[i])
+                end_idx = start_idx + seq_length
 
-            outputs.append(seq_tokens.tolist())
-            start_idx = end_idx
+                # Get main tokens for this sequence
+                seq_main_tokens = main_tokens[start_idx:end_idx]
+
+                # Filter out placeholder tokens
+                valid_main_tokens = seq_main_tokens[
+                    (seq_main_tokens != PLACEHOLDER_TOKEN_ID)
+                    & (seq_main_tokens < vocab_size)]
+
+                # Add bonus token if it's valid
+                bonus_token = bonus_tokens[i]
+                if bonus_token != PLACEHOLDER_TOKEN_ID and bonus_token < vocab_size:
+                    seq_tokens = np.concatenate(
+                        [valid_main_tokens, [bonus_token]])
+                else:
+                    seq_tokens = valid_main_tokens
+
+                # reorders per-rank outputs back to the original batch ordering
+                outputs[req_idx] = seq_tokens.tolist()
+                start_idx = end_idx
 
         return outputs
 
@@ -297,7 +379,7 @@ def rejection_sample(
     target_probs: jnp.ndarray,
     # [batch_size]
     bonus_token_ids: jnp.ndarray,
-    sampling_metadata: TPUSupportedSamplingMetadata,
+    do_sampling: bool,
     key: Optional[jax.random.PRNGKey] = None,
 ) -> jnp.ndarray:
     """
@@ -309,13 +391,13 @@ def rejection_sample(
         draft_probs: Draft probabilities in flattened format [num_tokens, vocab_size].
         target_probs: Target probabilities in flattened format [num_tokens, vocab_size].
         bonus_token_ids: Bonus token IDs [batch_size].
-        sampling_metadata: Sampling metadata.
+        do_sampling: Whether to perform sampling.
         key: JAX random key for non-greedy sampling.
 
     Returns:
         output_token_ids: Output token IDs [num_tokens + batch_size].
     """
-    if sampling_metadata.do_sampling is False:
+    if do_sampling is False:
         greedy_output = _greedy_rejection_sample_with_segment(
             draft_token_ids, target_probs, num_draft_tokens, bonus_token_ids)
         return greedy_output

--- a/tpu_inference/runner/compilation_manager.py
+++ b/tpu_inference/runner/compilation_manager.py
@@ -861,31 +861,15 @@ class CompilationManager:
         vocab_size = self.runner.vocab_size
         num_speculative_tokens = (
             self.runner.speculative_config.num_speculative_tokens)
-        max_num_seq = self.runner.max_num_reqs
+        max_num_reqs_per_dp_rank = (self.runner.max_num_reqs //
+                                    self.runner.dp_size)
 
         data_parallel_attn_sharding = NamedSharding(
             self.runner.mesh, PartitionSpec(ShardingAxisName.ATTN_DATA))
 
-        # Case 1: spec_decode_metadata is None. sampled_token_ids has shape
-        # (num_reqs,) from the regular sample() path on the previous step.
-        for num_reqs in self.runner.num_reqs_paddings:
-            sampled_token_ids = self._create_dummy_tensor(
-                (num_reqs, ), jnp.int32, sharding=data_parallel_attn_sharding)
-            self._run_compilation(
-                f"worker{self.runner.rank} extract_last_sampled_tokens "
-                f"(no spec_decode_metadata)",
-                extract_last_sampled_tokens,
-                None,
-                sampled_token_ids,
-                num_speculative_tokens,
-                vocab_size,
-                max_num_seq,
-                num_reqs=num_reqs,
-            )
-
-        # Case 2: spec_decode_metadata is not None. sampled_token_ids has
-        # shape (num_logits + num_reqs,) from the rejection_sampler output
-        # — [main_tokens (num_logits), bonus_tokens (num_reqs)].
+        # sampled_token_ids has shape (num_logits + num_reqs,) from the
+        # rejection_sampler output — [main_tokens (num_logits),
+        # bonus_tokens (num_reqs)].
         for num_logits in self.runner.num_logits_paddings:
             for num_reqs in self.runner.num_reqs_paddings:
                 sampled_token_ids = self._create_dummy_tensor(
@@ -893,14 +877,22 @@ class CompilationManager:
                     jnp.int32,
                     sharding=data_parallel_attn_sharding)
                 spec_decode_metadata = SpecDecodeMetadata(
-                    draft_lengths=self._create_dummy_tensor((num_reqs, ),
-                                                            jnp.int32),
+                    draft_lengths=self._create_dummy_tensor(
+                        (num_reqs, ),
+                        jnp.int32,
+                        sharding=data_parallel_attn_sharding),
                     target_logits_indices=self._create_dummy_tensor(
-                        (num_logits, ), jnp.int32),
+                        (num_logits, ),
+                        jnp.int32,
+                        sharding=data_parallel_attn_sharding),
                     bonus_logits_indices=self._create_dummy_tensor(
-                        (num_reqs, ), jnp.int32),
+                        (num_reqs, ),
+                        jnp.int32,
+                        sharding=data_parallel_attn_sharding),
                     final_logits_indices=self._create_dummy_tensor(
-                        (num_logits, ), jnp.int32),
+                        (num_logits, ),
+                        jnp.int32,
+                        sharding=data_parallel_attn_sharding),
                 )
                 self._run_compilation(
                     f"worker{self.runner.rank} extract_last_sampled_tokens",
@@ -909,7 +901,8 @@ class CompilationManager:
                     sampled_token_ids,
                     num_speculative_tokens,
                     vocab_size,
-                    max_num_seq,
+                    max_num_reqs_per_dp_rank,
+                    self.runner.mesh,
                     num_logits=num_logits,
                     num_reqs=num_reqs,
                 )
@@ -985,23 +978,31 @@ class CompilationManager:
         draft_hidden_size = self.runner.speculative_config.draft_model_config.get_hidden_size(
         )
         dtype = self.runner.model_config.dtype
+        dp_size = self.runner.dp_size
 
         num_kv_cache_groups = len(self.runner.kv_cache_config.kv_cache_groups)
         draft_kv_cache_group_id = num_kv_cache_groups - 1
         block_tables = self.runner.input_batch.block_table[
             draft_kv_cache_group_id].get_cpu_tensor().reshape(-1)
+        dp_sharding = NamedSharding(
+            self.runner.mesh, PartitionSpec(ShardingAxisName.ATTN_DATA, ))
         block_tables = device_array(self.runner.mesh,
                                     block_tables,
-                                    sharding=PartitionSpec(None, ))
+                                    sharding=dp_sharding)
 
         seq_lens = self._create_dummy_tensor((self.runner.max_num_reqs, ),
-                                             jnp.int32)
+                                             jnp.int32, dp_sharding)
+        # query_start_loc carries one start-of-loc entry per DP rank, matching
+        # the runtime layout produced by `_prepare_inputs`.
         query_start_loc = self._create_dummy_tensor(
-            (self.runner.max_num_reqs + 1, ), jnp.int32)
+            (self.runner.max_num_reqs + dp_size, ), jnp.int32, dp_sharding)
 
-        request_distribution = np.array([0, 0, 0], dtype=np.int32)
+        # request_distribution stores 3 counters per DP rank
+        # (decode/decode/total), so the shape scales with dp_size.
+        request_distribution = np.array([0, 0, 0] * dp_size, dtype=np.int32)
         request_distribution = device_array(self.runner.mesh,
-                                            request_distribution)
+                                            request_distribution,
+                                            sharding=dp_sharding)
         # Dummy mamba_state_indices for spec-decode compile-cache pre-tracing.
         # Must match the ATTN_DATA sharding `_prepare_inputs_*` produces at
         # runtime — otherwise the draft model_fn cache misses and the
@@ -1009,8 +1010,6 @@ class CompilationManager:
         # pure-attention models (the common eagle3 case) so the field stays
         # absent end-to-end.
         if self.runner.kv_cache_config.has_mamba_layers:
-            dp_sharding = NamedSharding(
-                self.runner.mesh, PartitionSpec(ShardingAxisName.ATTN_DATA, ))
             eagle3_mamba_state_indices = device_array(
                 self.runner.mesh,
                 np.zeros(self.runner.max_num_reqs, dtype=np.int32),
@@ -1018,12 +1017,15 @@ class CompilationManager:
         else:
             eagle3_mamba_state_indices = None
 
+        num_reqs_dp = self._create_dummy_tensor((dp_size, ),
+                                                jnp.int32,
+                                                sharding=dp_sharding)
         last_token_indices = self._create_dummy_tensor(
-            (self.runner.max_num_reqs, ), jnp.int32)
+            (self.runner.max_num_reqs, ), jnp.int32, dp_sharding)
         for num_tokens in self.runner.num_tokens_paddings:
             for num_reqs in self.runner.attn_num_reqs_paddings:
                 positions = self._create_dummy_tensor((num_tokens, ),
-                                                      jnp.int32)
+                                                      jnp.int32, dp_sharding)
                 attention_metadata = AttentionMetadata(
                     input_positions=positions,
                     block_tables=block_tables,
@@ -1057,9 +1059,8 @@ class CompilationManager:
                         self.runner.mesh,
                         PartitionSpec(ShardingAxisName.MLP_DATA,
                                       ShardingAxisName.MLP_TENSOR)))
-                input_ids = self._create_dummy_tensor(
-                    (num_tokens, ), jnp.int32,
-                    NamedSharding(self.runner.mesh, PartitionSpec()))
+                input_ids = self._create_dummy_tensor((num_tokens, ),
+                                                      jnp.int32, dp_sharding)
                 self._run_compilation(
                     "drafter_propose",
                     drafter_propose_fn_wrapper,
@@ -1073,25 +1074,32 @@ class CompilationManager:
                 aux_hidden_states = [
                     self._create_dummy_tensor(
                         (num_tokens, target_hidden_size), jnp.bfloat16,
-                        NamedSharding(self.runner.mesh,
-                                      PartitionSpec(None, None))),
+                        NamedSharding(
+                            self.runner.mesh,
+                            PartitionSpec(ShardingAxisName.ATTN_DATA, None))),
                     self._create_dummy_tensor(
                         (num_tokens, target_hidden_size), jnp.bfloat16,
-                        NamedSharding(self.runner.mesh,
-                                      PartitionSpec(None, None))),
+                        NamedSharding(
+                            self.runner.mesh,
+                            PartitionSpec(ShardingAxisName.ATTN_DATA, None))),
                     self._create_dummy_tensor(
                         (num_tokens, target_hidden_size), jnp.bfloat16,
-                        NamedSharding(self.runner.mesh,
-                                      PartitionSpec(None, None))),
+                        NamedSharding(
+                            self.runner.mesh,
+                            PartitionSpec(ShardingAxisName.ATTN_DATA, None))),
                 ]
                 last_sampled_token_id = self._create_dummy_tensor(
-                    (self.runner.max_num_reqs, ), jnp.int32)
+                    (self.runner.max_num_reqs, ), jnp.int32, dp_sharding)
                 next_prompt_token_id = self._create_dummy_tensor(
-                    (self.runner.max_num_reqs, ), jnp.int32)
+                    (self.runner.max_num_reqs, ),
+                    jnp.int32,
+                    sharding=dp_sharding)
                 is_in_prefill = self._create_dummy_tensor(
-                    (self.runner.max_num_reqs, ), jnp.int32)
+                    (self.runner.max_num_reqs, ),
+                    jnp.int32,
+                    sharding=dp_sharding)
                 num_rejected_tokens = self._create_dummy_tensor(
-                    (self.runner.max_num_reqs, ), jnp.int32)
+                    (self.runner.max_num_reqs, ), jnp.int32, dp_sharding)
 
                 self._run_compilation(
                     "drafter_prepare_inputs",
@@ -1103,6 +1111,7 @@ class CompilationManager:
                     next_prompt_token_id,
                     is_in_prefill,
                     num_rejected_tokens,
+                    num_reqs_dp,
                     num_tokens=num_tokens,
                 )
 
@@ -1113,23 +1122,31 @@ class CompilationManager:
         draft_hidden_size = self.runner.speculative_config.draft_model_config.get_hidden_size(
         )
         dtype = self.runner.model_config.dtype
+        dp_size = self.runner.dp_size
 
         num_kv_cache_groups = len(self.runner.kv_cache_config.kv_cache_groups)
         draft_kv_cache_group_id = num_kv_cache_groups - 1
         block_tables = self.runner.input_batch.block_table[
             draft_kv_cache_group_id].get_cpu_tensor().reshape(-1)
+        dp_sharding = NamedSharding(
+            self.runner.mesh, PartitionSpec(ShardingAxisName.ATTN_DATA, ))
         block_tables = device_array(self.runner.mesh,
                                     block_tables,
-                                    sharding=PartitionSpec(None, ))
+                                    sharding=dp_sharding)
 
         seq_lens = self._create_dummy_tensor((self.runner.max_num_reqs, ),
-                                             jnp.int32)
+                                             jnp.int32, dp_sharding)
+        # query_start_loc carries one start-of-loc entry per DP rank, matching
+        # the runtime layout produced by `_prepare_inputs`.
         query_start_loc = self._create_dummy_tensor(
-            (self.runner.max_num_reqs + 1, ), jnp.int32)
+            (self.runner.max_num_reqs + dp_size, ), jnp.int32, dp_sharding)
 
-        request_distribution = np.array([0, 0, 0], dtype=np.int32)
+        # request_distribution stores 3 counters per DP rank
+        # (decode/decode/total), so the shape scales with dp_size.
+        request_distribution = np.array([0, 0, 0] * dp_size, dtype=np.int32)
         request_distribution = device_array(self.runner.mesh,
-                                            request_distribution)
+                                            request_distribution,
+                                            sharding=dp_sharding)
         # Dummy mamba_state_indices for spec-decode compile-cache pre-tracing.
         # Must match the ATTN_DATA sharding `_prepare_inputs_*` produces at
         # runtime — otherwise the draft model_fn cache misses and the
@@ -1137,17 +1154,19 @@ class CompilationManager:
         # pure-attention models (the common eagle3 case) so the field stays
         # absent end-to-end.
         if self.runner.kv_cache_config.has_mamba_layers:
-            dp_sharding = NamedSharding(
-                self.runner.mesh, PartitionSpec(ShardingAxisName.ATTN_DATA, ))
-            eagle3_mamba_state_indices = device_array(
-                self.runner.mesh,
-                np.zeros(self.runner.max_num_reqs, dtype=np.int32),
-                sharding=dp_sharding)
+            mamba_state_indices = device_array(self.runner.mesh,
+                                               np.zeros(
+                                                   self.runner.max_num_reqs,
+                                                   dtype=np.int32),
+                                               sharding=dp_sharding)
         else:
-            eagle3_mamba_state_indices = None
+            mamba_state_indices = None
 
+        num_reqs_dp = self._create_dummy_tensor((dp_size, ),
+                                                jnp.int32,
+                                                sharding=dp_sharding)
         last_token_indices = self._create_dummy_tensor(
-            (self.runner.max_num_reqs, ), jnp.int32)
+            (self.runner.max_num_reqs, ), jnp.int32, dp_sharding)
         for num_tokens in self.runner.num_tokens_paddings:
             for num_reqs in self.runner.attn_num_reqs_paddings:
                 if self.runner.uses_mrope:
@@ -1157,8 +1176,8 @@ class CompilationManager:
                     positions = self._create_dummy_tensor(
                         (3, num_tokens), jnp.int32, mrope_sharding)
                 else:
-                    positions = self._create_dummy_tensor((num_tokens, ),
-                                                          jnp.int32)
+                    positions = self._create_dummy_tensor(
+                        (num_tokens, ), jnp.int32, dp_sharding)
 
                 attention_metadata = AttentionMetadata(
                     input_positions=positions,
@@ -1166,7 +1185,7 @@ class CompilationManager:
                     seq_lens=seq_lens,
                     query_start_loc=query_start_loc,
                     request_distribution=request_distribution,
-                    mamba_state_indices=eagle3_mamba_state_indices,
+                    mamba_state_indices=mamba_state_indices,
                     padded_num_reqs=num_reqs,
                 )
 
@@ -1191,10 +1210,10 @@ class CompilationManager:
                     (num_tokens, draft_hidden_size), dtype,
                     NamedSharding(
                         self.runner.mesh,
-                        PartitionSpec(None, ShardingAxisName.ATTN_DATA)))
+                        PartitionSpec(ShardingAxisName.ATTN_DATA, None)))
 
                 input_ids = self._create_dummy_tensor((num_tokens, ),
-                                                      jnp.int32)
+                                                      jnp.int32, dp_sharding)
                 self._run_compilation(
                     "drafter_propose",
                     drafter_propose_fn_wrapper,
@@ -1212,15 +1231,17 @@ class CompilationManager:
                         self.runner.mesh,
                         PartitionSpec(ShardingAxisName.ATTN_DATA, None))), )
                 last_sampled_token_id = self._create_dummy_tensor(
-                    (self.runner.max_num_reqs, ), jnp.int32,
-                    NamedSharding(self.runner.mesh, PartitionSpec()))
+                    (self.runner.max_num_reqs, ), jnp.int32, dp_sharding)
                 next_prompt_token_id = self._create_dummy_tensor(
-                    (self.runner.max_num_reqs, ), jnp.int32)
+                    (self.runner.max_num_reqs, ),
+                    jnp.int32,
+                    sharding=dp_sharding)
                 is_in_prefill = self._create_dummy_tensor(
-                    (self.runner.max_num_reqs, ), jnp.int32)
+                    (self.runner.max_num_reqs, ),
+                    jnp.int32,
+                    sharding=dp_sharding)
                 num_rejected_tokens = self._create_dummy_tensor(
-                    (self.runner.max_num_reqs, ), jnp.int32,
-                    NamedSharding(self.runner.mesh, PartitionSpec()))
+                    (self.runner.max_num_reqs, ), jnp.int32, dp_sharding)
 
                 self._run_compilation(
                     "drafter_prepare_inputs",
@@ -1232,6 +1253,7 @@ class CompilationManager:
                     next_prompt_token_id,
                     is_in_prefill,
                     num_rejected_tokens,
+                    num_reqs_dp,
                     num_tokens=num_tokens,
                 )
 

--- a/tpu_inference/runner/speculative_decoding_manager.py
+++ b/tpu_inference/runner/speculative_decoding_manager.py
@@ -18,10 +18,12 @@ from typing import TYPE_CHECKING, Optional
 
 import jax.numpy as jnp
 import numpy as np
+from jax.sharding import NamedSharding, PartitionSpec
 from vllm.v1.core.sched.output import SchedulerOutput as VllmSchedulerOutput
 from vllm.v1.outputs import DraftTokenIds
 from vllm.v1.spec_decode.ngram_proposer import NgramProposer
 
+from tpu_inference.layers.common.sharding import ShardingAxisName
 from tpu_inference.runner import utils as runner_utils
 from tpu_inference.runner.utils import SpecDecodeMetadata
 from tpu_inference.spec_decode.jax.eagle3 import Eagle3Proposer
@@ -39,14 +41,30 @@ class SpeculativeDecodingManager:
         self.runner = runner
         # Cached draft tokens.
         self._draft_token_ids: Optional[list[list[int]]] = None
+        self._req_indices_dp: Optional[dict] = None
 
     def take_draft_token_ids(self) -> Optional[DraftTokenIds]:
         if self._draft_token_ids is None:
             return None
         req_ids = self.runner.input_batch.req_ids
         draft_token_ids = self._draft_token_ids
+
+        if self._req_indices_dp is None:
+            self._draft_token_ids = None
+            self._req_indices_dp = None
+            return DraftTokenIds(req_ids, draft_token_ids)
+
+        # reorders per-rank outputs back to the original batch ordering
+        reorded_draft_token_ids = [[] for _ in range(len(draft_token_ids))]
+        max_num_reqs_per_dp_rank = self.runner.max_num_reqs // self.runner.dp_size
+        for rank in range(self.runner.dp_size):
+            req_indices = self._req_indices_dp[rank]
+            for j, req_idx in enumerate(req_indices):
+                reorded_draft_token_ids[req_idx] = draft_token_ids[
+                    j + rank * max_num_reqs_per_dp_rank]
         self._draft_token_ids = None
-        return DraftTokenIds(req_ids, draft_token_ids)
+        self._req_indices_dp = None
+        return DraftTokenIds(req_ids, reorded_draft_token_ids)
 
     def propose_draft_token_ids(
         self,
@@ -58,7 +76,7 @@ class SpeculativeDecodingManager:
         aux_hidden_states: Optional[tuple[jnp.ndarray, ...]],
         attn_metadata: AttentionMetadata,
         async_scheduling: bool,
-        spec_decode_metadata: Optional[SpecDecodeMetadata],
+        spec_decode_metadata: SpecDecodeMetadata,
         scheduler_output: Optional[VllmSchedulerOutput] = None,
         input_ids: Optional[jnp.ndarray] = None,
         hidden_states: Optional[jnp.ndarray] = None,
@@ -93,6 +111,7 @@ class SpeculativeDecodingManager:
                 async_scheduling,
                 hidden_states,
             )
+            self._req_indices_dp = spec_decode_metadata.req_indices_dp
         else:
             raise NotImplementedError(
                 f"Speculative decoding method "
@@ -100,7 +119,7 @@ class SpeculativeDecodingManager:
 
     def propose_eagle3_draft_token_ids(
         self,
-        spec_decode_metadata: Optional[SpecDecodeMetadata],
+        spec_decode_metadata: SpecDecodeMetadata,
         last_sampled_token_id: jnp.ndarray,
         num_rejected_tokens: jnp.ndarray,
         discard_sampled_tokens_req_indices: list[int],
@@ -132,19 +151,32 @@ class SpeculativeDecodingManager:
         max_num_seqs = attn_metadata.seq_lens.shape[0]
         next_prompt_token_id = np.zeros(max_num_seqs, dtype=np.int32)
         is_in_prefill = np.zeros(max_num_seqs, dtype=np.int32)
-        for i in discard_sampled_tokens_req_indices:
-            # Partial prefill
-            # Get the next token id from the request state.
-            req_id = req_ids[i]
-            req_state = self.runner.requests[req_id]
-            seq_len = (req_state.num_computed_tokens +
-                       scheduler_output.num_scheduled_tokens[req_id])
-            next_token_id = req_state.get_token_id(seq_len)
-            next_prompt_token_id[i] = next_token_id
-            is_in_prefill[i] = 1
 
-        next_prompt_token_id, is_in_prefill = device_array(
-            self.runner.mesh, (next_prompt_token_id, is_in_prefill))
+        discard_sampled_tokens_req_indices_set = set(
+            discard_sampled_tokens_req_indices)
+        dp_size = self.runner.dp_size
+        max_num_reqs_per_dp_rank = self.runner.max_num_reqs // dp_size
+        num_reqs_dp = np.zeros((dp_size, ), dtype=np.int32)
+        for rank in range(dp_size):
+            req_indices = spec_decode_metadata.req_indices_dp[rank]
+            num_reqs_dp[rank] = len(req_indices)
+            for j, req_idx in enumerate(req_indices):
+                if req_idx in discard_sampled_tokens_req_indices_set:
+                    # Partial prefill
+                    # Get the next token id from the request state.
+                    req_id = req_ids[req_idx]
+                    req_state = self.runner.requests[req_id]
+                    seq_len = (req_state.num_computed_tokens +
+                               scheduler_output.num_scheduled_tokens[req_id])
+                    next_token_id = req_state.get_token_id(seq_len)
+                    next_prompt_token_id[
+                        j + rank * max_num_reqs_per_dp_rank] = next_token_id
+                    is_in_prefill[j + rank * max_num_reqs_per_dp_rank] = 1
+
+        next_prompt_token_id, is_in_prefill, num_reqs_dp = device_array(
+            self.runner.mesh,
+            (next_prompt_token_id, is_in_prefill, num_reqs_dp),
+            sharding=(PartitionSpec(ShardingAxisName.ATTN_DATA)))
 
         if self.runner.speculative_config.method == "mtp":
             aux_hidden_states_for_drafter = (hidden_states, )
@@ -159,6 +191,7 @@ class SpeculativeDecodingManager:
             next_prompt_token_id,
             is_in_prefill,
             num_rejected_tokens,
+            num_reqs_dp,
         )
 
         self.runner.kv_caches, draft_token_ids = self.runner.drafter.propose(
@@ -181,12 +214,15 @@ class SpeculativeDecodingManager:
 
     def get_spec_decode_metadata(
         self,
-        num_draft_tokens: np.ndarray,
-        cu_num_scheduled_tokens: np.ndarray,
-        padded_num_reqs: int,
-        input_ids: np.ndarray,
+        num_draft_tokens_dp: np.ndarray,
+        dp_size: int,
+        req_indices_dp: dict,
+        query_start_loc: np.ndarray,
+        padded_num_reqs_per_dp_rank: int,
+        padded_logits_length_dp_rank: int,
+        max_num_reqs_per_dp_rank: int,
     ) -> SpecDecodeMetadata:
-        # Inputs:
+        # (dp_size = 1) Example Inputs:
         # cu_num_scheduled_tokens:  [  4, 104, 107, 207, 209]
         # num_draft_tokens:         [  3,   0,   2,   0,   1]
         # Outputs:
@@ -198,60 +234,76 @@ class SpeculativeDecodingManager:
 
         # Compute the logits indices.
         # [4, 1, 3, 1, 2]
-        num_sampled_tokens = num_draft_tokens + 1
+        out_logits_indices = []
+        out_target_logits_indices = []
+        out_bonus_logits_indices = []
+        out_draft_lengths = []
 
-        # Step 1. cu_num_sampled_tokens: [4, 5, 8, 9, 11]
-        # arange: [0, 1, 2, 3, 0, 0, 1, 2, 0, 0, 1]
-        cu_num_sampled_tokens = np.cumsum(num_sampled_tokens)
-        arange = np.concatenate(
-            [self.runner.arange_cpu[:n] for n in num_sampled_tokens])
-        # Step 2. [0, 0, 0, 0, 103, 104, 104, 104, 206, 207, 207]
-        logits_indices = np.repeat(
-            cu_num_scheduled_tokens - num_sampled_tokens, num_sampled_tokens)
-        # Step 3. [0, 1, 2, 3, 103, 104, 105, 106, 206, 207, 208]
-        logits_indices += arange
-        # Compute the bonus logits indices.
-        bonus_logits_indices = cu_num_sampled_tokens - 1
+        def _pad(arr: np.ndarray, target_len: int) -> np.ndarray:
+            pad_len = target_len - arr.shape[0]
+            if pad_len == 0:
+                return arr
+            return np.concatenate([arr, np.zeros(pad_len, dtype=np.int32)])
 
-        # Compute the draft logits indices.
-        # arange: [0, 1, 2, 0, 1, 0]
-        arange = np.concatenate(
-            [self.runner.arange_cpu[:n] for n in num_draft_tokens])
-        # [0, 0, 0, 5, 5, 9]
-        target_logits_indices = np.repeat(
-            cu_num_sampled_tokens - num_sampled_tokens, num_draft_tokens)
-        # [0, 1, 2, 5, 6, 9]
-        target_logits_indices += arange
+        for dp_rank in range(dp_size):
+            per_rank_req_idxs = req_indices_dp[dp_rank]
+            n = len(per_rank_req_idxs)
 
-        # draft_token_indices:      [  1,   2,   3, 105, 106, 208]
-        padded_logits_length = runner_utils.get_padded_token_len(
-            self.runner.num_logits_paddings, logits_indices.shape[0])
-        padded_logits_indices = np.concatenate([
-            logits_indices,
-            np.zeros(padded_logits_length - logits_indices.shape[0],
-                     dtype=np.int32)
-        ])
+            if n > 0:
+                cur_rank_req_idxs = req_indices_dp[dp_rank]
+                num_draft_tokens = num_draft_tokens_dp[cur_rank_req_idxs]
+                num_sampled_tokens = num_draft_tokens + 1
 
-        assert bonus_logits_indices.shape[0] <= padded_num_reqs, (
-            f"bonus_logits_indices.shape[0]={bonus_logits_indices.shape[0]} "
-            f"padded_num_reqs={padded_num_reqs}")
+                req_offset = dp_rank * max_num_reqs_per_dp_rank
+                local_query_start_loc = query_start_loc[
+                    req_offset + dp_rank:req_offset +
+                    max_num_reqs_per_dp_rank + dp_rank + 1]
+                cu_num_scheduled_tokens = local_query_start_loc[1:n + 1]
 
-        padded_bonus_logits_indices = np.concatenate([
-            bonus_logits_indices,
-            np.zeros(padded_num_reqs - bonus_logits_indices.shape[0],
-                     dtype=np.int32)
-        ])
-        padded_num_draft_tokens = np.concatenate([
-            num_draft_tokens,
-            np.zeros(padded_num_reqs - num_draft_tokens.shape[0],
-                     dtype=np.int32)
-        ])
-        padded_target_logits_indices = np.concatenate([
-            target_logits_indices,
-            np.zeros(padded_logits_length - target_logits_indices.shape[0],
-                     dtype=np.int32)
-        ])
+                # Step 1. cu_num_sampled_tokens: [4, 5, 8, 9, 11]
+                # arange: [0, 1, 2, 3, 0, 0, 1, 2, 0, 0, 1]
+                cu_num_sampled_tokens = np.cumsum(num_sampled_tokens)
+                arange = np.concatenate(
+                    [self.runner.arange_cpu[:n] for n in num_sampled_tokens])
+                # Step 2. [0, 0, 0, 0, 103, 104, 104, 104, 206, 207, 207]
+                logits_indices = np.repeat(
+                    cu_num_scheduled_tokens - num_sampled_tokens,
+                    num_sampled_tokens)
+                # Step 3. [0, 1, 2, 3, 103, 104, 105, 106, 206, 207, 208]
+                logits_indices += arange
+                # Compute the bonus logits indices.
+                bonus_logits_indices = cu_num_sampled_tokens - 1
 
+                # Compute the draft logits indices.
+                # arange: [0, 1, 2, 0, 1, 0]
+                arange = np.concatenate(
+                    [self.runner.arange_cpu[:n] for n in num_draft_tokens])
+                # [0, 0, 0, 5, 5, 9]
+                target_logits_indices = np.repeat(
+                    cu_num_sampled_tokens - num_sampled_tokens,
+                    num_draft_tokens)
+                # [0, 1, 2, 5, 6, 9]
+                target_logits_indices += arange
+            else:
+                logits_indices = np.array([], dtype=np.int32)
+                target_logits_indices = np.array([], dtype=np.int32)
+                bonus_logits_indices = np.array([], dtype=np.int32)
+                num_draft_tokens = np.array([], dtype=np.int32)
+
+            out_logits_indices.append(
+                _pad(logits_indices, padded_logits_length_dp_rank))
+            out_target_logits_indices.append(
+                _pad(target_logits_indices, padded_logits_length_dp_rank))
+            out_bonus_logits_indices.append(
+                _pad(bonus_logits_indices, padded_num_reqs_per_dp_rank))
+            out_draft_lengths.append(
+                _pad(num_draft_tokens, padded_num_reqs_per_dp_rank))
+
+        padded_logits_indices = np.concatenate(out_logits_indices)
+        padded_target_logits_indices = np.concatenate(
+            out_target_logits_indices)
+        padded_bonus_logits_indices = np.concatenate(out_bonus_logits_indices)
+        padded_num_draft_tokens = np.concatenate(out_draft_lengths)
         padded_num_draft_tokens_cpu = padded_num_draft_tokens
         # CPU -> TPU copy.
         (padded_num_draft_tokens, padded_logits_indices,
@@ -259,7 +311,9 @@ class SpeculativeDecodingManager:
          padded_bonus_logits_indices) = device_array(
              self.runner.mesh,
              (padded_num_draft_tokens, padded_logits_indices,
-              padded_target_logits_indices, padded_bonus_logits_indices))
+              padded_target_logits_indices, padded_bonus_logits_indices),
+             sharding=NamedSharding(self.runner.mesh,
+                                    PartitionSpec(ShardingAxisName.ATTN_DATA)))
 
         metadata = SpecDecodeMetadata(
             draft_lengths=padded_num_draft_tokens,
@@ -268,4 +322,5 @@ class SpeculativeDecodingManager:
             final_logits_indices=padded_logits_indices,
         )
         metadata.draft_lengths_cpu = padded_num_draft_tokens_cpu
+        metadata.req_indices_dp = req_indices_dp
         return metadata

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -499,7 +499,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                 raise NotImplementedError(
                     "Unsupported speculative decoding method: "
                     f"{self.speculative_config.method}")
-            self.rejection_sampler = RejectionSampler()
+            self.rejection_sampler = RejectionSampler(self.mesh)
 
     def _init_inputs(self) -> None:
         model_config = self.model_config
@@ -1124,10 +1124,6 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                     tpu_sampling_metadata,
                 )
         else:
-            # TODO(gxd3): wrap the spec decode sampling code block
-            # under maybe_forbid_compile as well.
-            # Currently when spec-decoding is enabled, serving-time
-            # jit-recompile might still happen.
             if tpu_sampling_metadata.do_sampling:
                 bonus_rng, rejection_rng = jax.random.split(step_rng)
             else:
@@ -1209,7 +1205,8 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                 last_sampled_token_id, num_rejected_tokens = extract_last_sampled_tokens(
                     spec_decode_metadata, next_tokens,
                     self.speculative_config.num_speculative_tokens,
-                    self.input_batch.vocab_size, self.max_num_reqs)
+                    self.input_batch.vocab_size,
+                    self.max_num_reqs // self.dp_size, self.mesh)
                 self.speculative_decoding_manager.propose_draft_token_ids(
                     next_tokens,
                     logits_indices_selector,
@@ -1621,8 +1618,8 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         assert num_reqs > 0
 
         dp_size = self.dp_size
-        if self.speculative_config and dp_size > 1:
-            assert "Spec decoding not yet support when dp > 1"
+        if self.speculative_config and dp_size > 1 and self.scheduler_config.async_scheduling:
+            assert "Spec decoding + async scheduling not yet support when dp > 1"
 
         data_parallel_attn_sharding = NamedSharding(
             self.mesh, PartitionSpec(ShardingAxisName.ATTN_DATA))
@@ -1669,23 +1666,25 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         seq_lens_view = self.device_buffer.get_view((self.max_num_reqs, ),
                                                     key="seq_lens")
 
-        use_spec_decode = len(
-            scheduler_output.scheduled_spec_decode_tokens) > 0
+        if self.speculative_config:
+            padded_logits_length = None
+            for dp_rank in range(dp_size):
+                cur_rank_req_idxs = req_indices_dp[dp_rank]
+                cur_rank_num_draft_tokens = num_draft_tokens[cur_rank_req_idxs]
 
-        if use_spec_decode:
-            num_draft_tokens = np.zeros(num_reqs, dtype=np.int32)
-            for (
-                    req_id,
-                    draft_token_ids,
-            ) in scheduler_output.scheduled_spec_decode_tokens.items():
-                req_idx = self.input_batch.req_id_to_index[req_id]
-                num_draft_tokens[req_idx] = len(draft_token_ids)
+                num_sampled_tokens = cur_rank_num_draft_tokens + 1
+                total_sampled_tokens = np.sum(num_sampled_tokens)
+                if padded_logits_length is None:
+                    padded_logits_length = runner_utils.get_padded_token_len(
+                        self.num_logits_paddings, total_sampled_tokens)
+                else:
+                    padded_logits_length = max(
+                        padded_logits_length,
+                        runner_utils.get_padded_token_len(
+                            self.num_logits_paddings, total_sampled_tokens))
 
-            num_sampled_tokens = num_draft_tokens + 1
-            total_sampled_tokens = np.sum(num_sampled_tokens)
-            padded_logits_length = runner_utils.get_padded_token_len(
-                self.num_logits_paddings, total_sampled_tokens)
-            logits_indices_shape = (padded_logits_length, )
+            assert padded_logits_length is not None
+            logits_indices_shape = (padded_logits_length * dp_size, )
         else:
             logits_indices_shape = (padded_num_reqs, )
 
@@ -1816,16 +1815,18 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         request_distribution = np.array(_request_distribution,
                                         dtype=np.int32).ravel()
 
-        use_spec_decode = len(
-            scheduler_output.scheduled_spec_decode_tokens) > 0
         spec_decode_metadata = None
-        if use_spec_decode:
+        if self.speculative_config:
             spec_decode_metadata = (
                 self.speculative_decoding_manager.get_spec_decode_metadata(
-                    num_draft_tokens,
-                    query_start_loc_view[1:num_reqs + 1],
-                    padded_num_reqs,
-                    input_ids_view,
+                    num_draft_tokens_dp=num_draft_tokens,
+                    dp_size=dp_size,
+                    req_indices_dp=req_indices_dp,
+                    query_start_loc=query_start_loc_view,
+                    padded_num_reqs_per_dp_rank=padded_num_reqs_per_dp_rank,
+                    padded_logits_length_dp_rank=(logits_indices_shape[0] //
+                                                  dp_size),
+                    max_num_reqs_per_dp_rank=max_num_reqs_per_dp_rank,
                 ))
             logits_indices_view[:] = spec_decode_metadata.final_logits_indices
 

--- a/tpu_inference/runner/utils.py
+++ b/tpu_inference/runner/utils.py
@@ -843,7 +843,7 @@ class PhasedBasedProfiler:
         "final_logits_indices",
     ],
     meta_fields=[],
-    drop_fields=["draft_lengths_cpu"],
+    drop_fields=["draft_lengths_cpu", "req_indices_dp"],
 )
 @dataclass
 class SpecDecodeMetadata:
@@ -854,6 +854,7 @@ class SpecDecodeMetadata:
     final_logits_indices: jnp.ndarray
 
     draft_lengths_cpu: Any = field(init=False, default=None)
+    req_indices_dp: dict = field(init=False, default_factory=dict)
 
 
 def host_extract_sampled_tokens(
@@ -873,7 +874,8 @@ def host_extract_sampled_tokens(
         valid_sampled_token_ids = runner.rejection_sampler.parse_output(
             next_tokens, runner.input_batch.vocab_size,
             spec_decode_metadata.draft_lengths_cpu, num_reqs,
-            spec_decode_metadata.final_logits_indices.shape[0])
+            spec_decode_metadata.final_logits_indices.shape[0], runner.dp_size,
+            spec_decode_metadata.req_indices_dp)
     # Mask out the sampled tokens that should not be sampled.
     for i in discard_sampled_tokens_req_indices:
         valid_sampled_token_ids[i].clear()

--- a/tpu_inference/spec_decode/jax/eagle3.py
+++ b/tpu_inference/spec_decode/jax/eagle3.py
@@ -140,7 +140,8 @@ class Eagle3Proposer:
             num_reqs: jax.Array) -> tuple[jnp.ndarray, jnp.ndarray]:
         """JIT-compiled helper for preparing the input IDs for the draft model."""
 
-        def _body(query_start_loc, target_token_ids, next_token_ids, num_reqs):
+        def _sharded_prepare_input_ids(query_start_loc, target_token_ids,
+                                       next_token_ids, num_reqs):
             last_token_indices = query_start_loc[1:] - 1
             # Shift the input ids by one token.
             rolled_input_ids = jnp.roll(target_token_ids, -1, axis=0)
@@ -164,7 +165,7 @@ class Eagle3Proposer:
 
         data_spec = PartitionSpec(ShardingAxisName.ATTN_DATA)
         return jax.shard_map(
-            _body,
+            _sharded_prepare_input_ids,
             mesh=self.mesh,
             in_specs=(data_spec, data_spec, data_spec, data_spec),
             out_specs=(data_spec, data_spec),
@@ -176,7 +177,8 @@ class Eagle3Proposer:
     ) -> tuple[jax.Array, jax.Array, jax.Array, jax.Array, jax.Array]:
         """JIT-compiled helper for preparing inputs in the loop of prediction."""
 
-        def _body(positions, seq_lens, block_tables):
+        def _sharded_update_inputs_for_loop_speculation(
+                positions, seq_lens, block_tables):
             positions += 1
             exceeds_max_model_len = positions >= self.runner.max_model_len
             if exceeds_max_model_len.ndim == 2:
@@ -214,7 +216,7 @@ class Eagle3Proposer:
         data_spec = PartitionSpec(ShardingAxisName.ATTN_DATA)
         (positions, clamped_positions, new_seq_lens, query_start_loc,
          new_block_tables) = jax.shard_map(
-             _body,
+             _sharded_update_inputs_for_loop_speculation,
              mesh=self.mesh,
              in_specs=(data_spec, data_spec, data_spec),
              out_specs=(data_spec, data_spec, data_spec, data_spec, data_spec),
@@ -413,8 +415,8 @@ class Eagle3Proposer:
                           if attn_metadata.input_positions.ndim == 2 else
                           data_spec)
 
-        def _select(input_ids, token_indices, input_positions,
-                    aux_hidden_states):
+        def _sharded_select_target_tokens_and_hidden_states(
+                input_ids, token_indices, input_positions, aux_hidden_states):
             target_token_ids = input_ids[token_indices]
             # Update positions to match the selected tokens.
             if input_positions.ndim == 2:
@@ -427,7 +429,7 @@ class Eagle3Proposer:
             return target_token_ids, input_positions, aux_states_processed
 
         target_token_ids, input_positions, aux_states_processed = jax.shard_map(
-            _select,
+            _sharded_select_target_tokens_and_hidden_states,
             mesh=self.mesh,
             in_specs=(data_spec, data_spec, positions_spec, data_spec),
             out_specs=(data_spec, positions_spec, data_spec),

--- a/tpu_inference/spec_decode/jax/eagle3.py
+++ b/tpu_inference/spec_decode/jax/eagle3.py
@@ -25,6 +25,7 @@ from vllm.config import VllmConfig
 
 from tpu_inference import envs
 from tpu_inference.layers.common.attention_metadata import AttentionMetadata
+from tpu_inference.layers.common.sharding import ShardingAxisName
 from tpu_inference.logger import init_logger
 from tpu_inference.models.common.model_loader import (
     get_model, resolve_model_architecture)
@@ -139,24 +140,35 @@ class Eagle3Proposer:
             num_reqs: jax.Array) -> tuple[jnp.ndarray, jnp.ndarray]:
         """JIT-compiled helper for preparing the input IDs for the draft model."""
 
-        last_token_indices = query_start_loc[1:] - 1
-        # Shift the input ids by one token.
-        rolled_input_ids = jnp.roll(target_token_ids, -1, axis=0)
+        def _body(query_start_loc, target_token_ids, next_token_ids, num_reqs):
+            last_token_indices = query_start_loc[1:] - 1
+            # Shift the input ids by one token.
+            rolled_input_ids = jnp.roll(target_token_ids, -1, axis=0)
 
-        # To make the update JIT-compatible with a dynamic `num_reqs`, we perform a
-        # scatter update of a static size, using a mask to handle the dynamic part.
-        max_num_reqs = last_token_indices.shape[0]
-        mask = jnp.arange(max_num_reqs) < num_reqs
-        last_token_indices = jnp.where(mask, last_token_indices,
-                                       last_token_indices[num_reqs - 1])
+            # To make the update JIT-compatible with a dynamic `num_reqs`, we
+            # perform a scatter update of a static size, using a mask to handle
+            # the dynamic part.
+            max_num_reqs = last_token_indices.shape[0]
+            mask = jnp.arange(max_num_reqs) < num_reqs
+            last_token_indices = jnp.where(mask, last_token_indices,
+                                           last_token_indices[num_reqs - 1])
 
-        # Mask out the update for the padded requests (where mask is False).
-        values_to_set = jnp.where(mask, next_token_ids,
-                                  next_token_ids[num_reqs - 1])
+            # Mask out the update for the padded requests (where mask is False).
+            values_to_set = jnp.where(mask, next_token_ids,
+                                      next_token_ids[num_reqs - 1])
 
-        input_ids = rolled_input_ids.at[last_token_indices].set(values_to_set)
+            input_ids = rolled_input_ids.at[last_token_indices].set(
+                values_to_set)
 
-        return input_ids, last_token_indices
+            return input_ids, last_token_indices
+
+        data_spec = PartitionSpec(ShardingAxisName.ATTN_DATA)
+        return jax.shard_map(
+            _body,
+            mesh=self.mesh,
+            in_specs=(data_spec, data_spec, data_spec, data_spec),
+            out_specs=(data_spec, data_spec),
+        )(query_start_loc, target_token_ids, next_token_ids, num_reqs)
 
     def _update_inputs_for_loop_speculation(
         self, positions: jax.Array, seq_lens: jax.Array,
@@ -164,47 +176,49 @@ class Eagle3Proposer:
     ) -> tuple[jax.Array, jax.Array, jax.Array, jax.Array, jax.Array]:
         """JIT-compiled helper for preparing inputs in the loop of prediction."""
 
-        positions += 1
-        exceeds_max_model_len = positions >= self.runner.max_model_len
-        if exceeds_max_model_len.ndim == 2:
-            exceeds_max_model_len_reduced = jnp.any(exceeds_max_model_len,
-                                                    axis=0)
-        else:
-            exceeds_max_model_len_reduced = exceeds_max_model_len
+        def _body(positions, seq_lens, block_tables):
+            positions += 1
+            exceeds_max_model_len = positions >= self.runner.max_model_len
+            if exceeds_max_model_len.ndim == 2:
+                exceeds_max_model_len_reduced = jnp.any(exceeds_max_model_len,
+                                                        axis=0)
+            else:
+                exceeds_max_model_len_reduced = exceeds_max_model_len
 
-        clamped_positions = jnp.where(exceeds_max_model_len, 0, positions)
+            clamped_positions = jnp.where(exceeds_max_model_len, 0, positions)
 
-        new_seq_lens = seq_lens + 1
-        new_seq_lens = jnp.minimum(new_seq_lens, self.runner.max_model_len)
-        new_seq_lens = jnp.where(exceeds_max_model_len_reduced, 1,
-                                 new_seq_lens)
+            new_seq_lens = seq_lens + 1
+            new_seq_lens = jnp.minimum(new_seq_lens, self.runner.max_model_len)
+            new_seq_lens = jnp.where(exceeds_max_model_len_reduced, 1,
+                                     new_seq_lens)
 
-        num_reqs = seq_lens.shape[0]
-        query_start_loc = jnp.arange(num_reqs + 1)
+            num_reqs = seq_lens.shape[0]
+            query_start_loc = jnp.arange(num_reqs + 1)
 
-        # Compute the slot mapping.
-        # NOTE(woosuk): We should handle the case where the draft model
-        # generates tokens beyond the max model length. Since it is complex
-        # to remove such requests from the batch, we keep them in the batch
-        # but adjust the position ids and slot mappings to avoid the
-        # out-of-range access during the model execution. The draft tokens
-        # generated with this adjustment should be ignored.
-        max_num_blocks_per_req = block_tables.shape[0] // num_reqs
-        expanded_exceeds_mask = jnp.repeat(exceeds_max_model_len_reduced,
-                                           max_num_blocks_per_req)
-        new_block_tables = jnp.where(expanded_exceeds_mask, -1, block_tables)
+            # Compute the slot mapping.
+            # NOTE(woosuk): We should handle the case where the draft model
+            # generates tokens beyond the max model length. Since it is complex
+            # to remove such requests from the batch, we keep them in the batch
+            # but adjust the position ids and slot mappings to avoid the
+            # out-of-range access during the model execution. The draft tokens
+            # generated with this adjustment should be ignored.
+            max_num_blocks_per_req = block_tables.shape[0] // num_reqs
+            expanded_exceeds_mask = jnp.repeat(exceeds_max_model_len_reduced,
+                                               max_num_blocks_per_req)
+            new_block_tables = jnp.where(expanded_exceeds_mask, -1,
+                                         block_tables)
 
-        positions = lax.with_sharding_constraint(
-            positions, NamedSharding(self.mesh, PartitionSpec(None, )))
-        clamped_positions = lax.with_sharding_constraint(
-            clamped_positions, NamedSharding(self.mesh, PartitionSpec(None, )))
-        new_seq_lens = lax.with_sharding_constraint(
-            new_seq_lens, NamedSharding(self.mesh, PartitionSpec(None, )))
-        query_start_loc = lax.with_sharding_constraint(
-            query_start_loc, NamedSharding(self.mesh, PartitionSpec()))
-        new_block_tables = lax.with_sharding_constraint(
-            new_block_tables, NamedSharding(self.mesh, PartitionSpec(None, )))
+            return (positions, clamped_positions, new_seq_lens,
+                    query_start_loc, new_block_tables)
 
+        data_spec = PartitionSpec(ShardingAxisName.ATTN_DATA)
+        (positions, clamped_positions, new_seq_lens, query_start_loc,
+         new_block_tables) = jax.shard_map(
+             _body,
+             mesh=self.mesh,
+             in_specs=(data_spec, data_spec, data_spec),
+             out_specs=(data_spec, data_spec, data_spec, data_spec, data_spec),
+         )(positions, seq_lens, block_tables)
         return positions, clamped_positions, new_seq_lens, query_start_loc, new_block_tables
 
     def _stack_draft_token_ids(
@@ -243,6 +257,7 @@ class Eagle3Proposer:
         next_prompt_token_id: jax.Array,
         is_in_prefill: jax.Array,
         num_rejected_tokens: jax.Array,
+        num_reqs_dp: jax.Array,
     ) -> tuple[jax.Array, jax.Array, jax.Array, AttentionMetadata]:
         """Prepare drafter inputs based on target forward outputs.
 
@@ -265,10 +280,11 @@ class Eagle3Proposer:
         draft_kv_cache_group_id = num_kv_cache_groups - 1
         block_tables = self.runner.input_batch.block_table[
             draft_kv_cache_group_id].get_cpu_tensor().reshape(-1)
-        # Number of active requests in this step (un-padded count).
-        num_reqs = self.runner.input_batch.num_reqs
-        num_reqs, block_tables = device_array(
-            self.mesh, (np.asarray([num_reqs], dtype=jnp.int32), block_tables))
+        block_tables = device_array(self.mesh,
+                                    block_tables,
+                                    sharding=PartitionSpec(
+                                        ShardingAxisName.ATTN_DATA))
+        num_reqs = num_reqs_dp
         return self._prepare_inputs(
             state_leaves=self.state_leaves,
             num_reqs=num_reqs,
@@ -310,53 +326,67 @@ class Eagle3Proposer:
         assert aux_hidden_states is not None and len(aux_hidden_states) > 0, (
             "EAGLE3 requires auxiliary hidden states from the target model.")
 
-        next_token_ids = jnp.where(is_in_prefill, next_prompt_token_id,
-                                   last_sampled_token_id)
+        def _compute_token_indices(is_in_prefill, next_prompt_token_id,
+                                   last_sampled_token_id, query_start_loc,
+                                   seq_lens, num_reqs, num_rejected_tokens,
+                                   input_ids):
+            next_token_ids = jnp.where(is_in_prefill, next_prompt_token_id,
+                                       last_sampled_token_id)
 
-        query_start_loc = attn_metadata.query_start_loc
-        seq_lens = attn_metadata.seq_lens
+            # Rejection-aware path: compute new per-request lengths and token
+            # indices.
+            # query_len_per_req = [q1, q2, ...]
+            query_len_per_req = (query_start_loc[1:] - query_start_loc[:-1])
 
-        # Rejection-aware path: compute new per-request lengths and token indices.
-        # Convert to host numpy for efficient prefix-sum and repeat ops.
-        # query_len_per_req = [q1, q2, ...]
-        query_len_per_req = (query_start_loc[1:] - query_start_loc[:-1])
+            # query_start_loc and consequentaly query_len_per_req are padded
+            # For padded requests, the query length should be 0.
+            query_len_per_req = jnp.where(
+                jnp.arange(query_len_per_req.shape[0]) < num_reqs,
+                query_len_per_req, 0)
+            num_rejected_tokens = jnp.where(
+                jnp.arange(num_rejected_tokens.shape[0]) < num_reqs,
+                num_rejected_tokens, 0)
+            # num_tokens_per_req = [q1 - n1, q2 - n2, ...]
+            num_tokens_per_req = (query_len_per_req - num_rejected_tokens)
 
-        # query_start_loc and consequentaly query_len_per_req are padded
-        # For padded requests, the query length should be 0.
-        query_len_per_req = jnp.where(
-            jnp.arange(query_len_per_req.shape[0]) < num_reqs,
-            query_len_per_req, 0)
-        num_rejected_tokens = jnp.where(
-            jnp.arange(num_rejected_tokens.shape[0]) < num_reqs,
-            num_rejected_tokens, 0)
-        # num_tokens_per_req = [q1 - n1, q2 - n2, ...]
-        num_tokens_per_req = (query_len_per_req - num_rejected_tokens)
+            # new_query_start_loc = [0, q1-n1, q1+q2-n1-n2, ...]
+            new_query_start_loc = jnp.cumsum(num_tokens_per_req)
+            new_query_start_loc = jnp.pad(new_query_start_loc, (1, 0),
+                                          constant_values=0)
+            total_num_tokens = input_ids.shape[0]
 
-        # new_query_start_loc = [0, q1-n1, q1+q2-n1-n2, ...]
-        # Use numpy for cumsum and then convert back.
-        new_query_start_loc = jnp.cumsum(num_tokens_per_req)
-        new_query_start_loc = jnp.pad(new_query_start_loc, (1, 0),
-                                      constant_values=0)
-        total_num_tokens = input_ids.shape[0]
+            # Expand request starts: [0, 0, q1-n1, ...,]
+            expanded_new_query_start_loc = jnp.repeat(
+                new_query_start_loc[:-1],
+                num_tokens_per_req,
+                total_repeat_length=total_num_tokens)
+            # Offsets within each request window: [0,1,2, 0,1,2,3, ...]
+            token_offsets = jnp.arange(total_num_tokens, dtype=np.int32)
+            token_offsets -= expanded_new_query_start_loc
+            # Map into old flat indices by adding original request starts.
+            old_query_start_loc_expanded = jnp.repeat(
+                query_start_loc[:-1],
+                num_tokens_per_req,
+                total_repeat_length=total_num_tokens)
 
-        # Expand request starts: [0, 0, q1-n1, ...,]
-        expanded_new_query_start_loc = jnp.repeat(
-            new_query_start_loc[:-1],
-            num_tokens_per_req,
-            total_repeat_length=total_num_tokens)
-        # Offsets within each request window: [0,1,2, 0,1,2,3, ...]
-        token_offsets = jnp.arange(total_num_tokens, dtype=np.int32)
-        token_offsets -= expanded_new_query_start_loc
-        # Map into old flat indices by adding original request starts.
-        old_query_start_loc_expanded = jnp.repeat(
-            query_start_loc[:-1],
-            num_tokens_per_req,
-            total_repeat_length=total_num_tokens)
+            token_indices = token_offsets + old_query_start_loc_expanded
 
-        token_indices = token_offsets + old_query_start_loc_expanded
+            # Update seq_lens for active requests only: new_seq_lens = s - n.
+            new_seq_lens = seq_lens - num_rejected_tokens
 
-        # Update seq_lens for active requests only: new_seq_lens = s - n.
-        new_seq_lens = seq_lens - num_rejected_tokens
+            return (next_token_ids, token_indices, new_query_start_loc,
+                    new_seq_lens)
+
+        data_spec = PartitionSpec(ShardingAxisName.ATTN_DATA)
+        (next_token_ids, token_indices, new_query_start_loc,
+         new_seq_lens) = jax.shard_map(
+             _compute_token_indices,
+             mesh=self.mesh,
+             in_specs=(data_spec, ) * 8,
+             out_specs=(data_spec, ) * 4,
+         )(is_in_prefill, next_prompt_token_id, last_sampled_token_id,
+           attn_metadata.query_start_loc, attn_metadata.seq_lens, num_reqs,
+           num_rejected_tokens, input_ids)
 
         attn_metadata = replace(attn_metadata, block_tables=block_tables)
         return self._filter_token_and_prepare_initial_inputs(
@@ -378,24 +408,38 @@ class Eagle3Proposer:
     ) -> tuple[jax.Array, jax.Array, jax.Array, AttentionMetadata]:
 
         # Select tokens and hidden states.
-        target_token_ids = input_ids[token_indices]
-        # Update positions to match the selected tokens.
-        if attn_metadata.input_positions.ndim == 2:
-            input_positions = attn_metadata.input_positions[:, token_indices]
-        else:
-            input_positions = attn_metadata.input_positions[token_indices]
+        data_spec = PartitionSpec(ShardingAxisName.ATTN_DATA)
+        positions_spec = (PartitionSpec(None, ShardingAxisName.ATTN_DATA)
+                          if attn_metadata.input_positions.ndim == 2 else
+                          data_spec)
 
-        attn_metadata = AttentionMetadata(
+        def _select(input_ids, token_indices, input_positions,
+                    aux_hidden_states):
+            target_token_ids = input_ids[token_indices]
+            # Update positions to match the selected tokens.
+            if input_positions.ndim == 2:
+                input_positions = input_positions[:, token_indices]
+            else:
+                input_positions = input_positions[token_indices]
+            aux_states_processed = [
+                h[token_indices] for h in aux_hidden_states
+            ]
+            return target_token_ids, input_positions, aux_states_processed
+
+        target_token_ids, input_positions, aux_states_processed = jax.shard_map(
+            _select,
+            mesh=self.mesh,
+            in_specs=(data_spec, data_spec, positions_spec, data_spec),
+            out_specs=(data_spec, positions_spec, data_spec),
+        )(input_ids, token_indices, attn_metadata.input_positions,
+          aux_hidden_states)
+
+        attn_metadata = replace(
+            attn_metadata,
             input_positions=input_positions,
-            block_tables=attn_metadata.block_tables,
             seq_lens=seq_lens,
             query_start_loc=query_start_loc,
-            request_distribution=attn_metadata.request_distribution,
-            mamba_state_indices=attn_metadata.mamba_state_indices,
-            padded_num_reqs=attn_metadata.padded_num_reqs,
         )
-
-        aux_states_processed = [h[token_indices] for h in aux_hidden_states]
 
         target_hidden_states, input_ids, last_token_indices = self._prepare_hidden_states_and_input_ids(
             state_leaves, aux_states_processed, query_start_loc,
@@ -409,10 +453,17 @@ class Eagle3Proposer:
         hidden_states: jax.Array,
         last_token_indices: jax.Array,
     ) -> jax.Array:
-        sample_hidden_states = hidden_states[last_token_indices]
-        sample_hidden_states = lax.with_sharding_constraint(
-            sample_hidden_states,
-            NamedSharding(self.mesh, PartitionSpec(None, None)))
+
+        def _select(hidden_states, last_token_indices):
+            return hidden_states[last_token_indices]
+
+        sample_hidden_states = jax.shard_map(
+            _select,
+            mesh=self.mesh,
+            in_specs=(PartitionSpec(ShardingAxisName.ATTN_DATA),
+                      PartitionSpec(ShardingAxisName.ATTN_DATA)),
+            out_specs=PartitionSpec(ShardingAxisName.ATTN_DATA),
+        )(hidden_states, last_token_indices)
         return self._get_draft_token_ids(state_leaves, sample_hidden_states)
 
     def _get_draft_token_ids(self, state_leaves: Any,
@@ -422,7 +473,9 @@ class Eagle3Proposer:
                                         lora_metadata)
         draft_token_ids = jnp.argmax(logits, axis=-1)
         return lax.with_sharding_constraint(
-            draft_token_ids, NamedSharding(self.mesh, PartitionSpec()))
+            draft_token_ids,
+            NamedSharding(self.mesh,
+                          PartitionSpec(ShardingAxisName.ATTN_DATA)))
 
     def _select_inputs_for_loop_speculation(
             self, state_leaves: Any, positions: jax.Array, residual: jax.Array,
@@ -431,26 +484,32 @@ class Eagle3Proposer:
         draft_token_ids = self._select_draft_token_ids(state_leaves,
                                                        hidden_states,
                                                        last_token_indices)
-        if self.method == "mtp":
-            # We need a separate branch for MTP because:
-            # 1. MTP uses final target output hidden states directly as inputs for the next step,
-            #    whereas Eagle uses intermediate residuals.
-            # 2. M-RoPE positions are 2D (3, total_tokens), requiring specific dim-1 slicing
-            #    which _select_inputs_for_loop_speculation does not support.
-            positions = positions[:, last_token_indices]
-            hidden_states = hidden_states[last_token_indices]
-            return positions, hidden_states, draft_token_ids
 
-        positions = positions[last_token_indices]
-        residual = residual[last_token_indices]
+        def _select(positions, residual, hidden_states, last_token_indices):
+            if self.method == "mtp":
+                # We need a separate branch for MTP because:
+                # 1. MTP uses final target output hidden states directly as inputs for the next step,
+                #    whereas Eagle uses intermediate residuals.
+                # 2. M-RoPE positions are 2D (3, total_tokens), requiring specific dim-1 slicing
+                #    which _select_inputs_for_loop_speculation does not support.
+                positions = positions[:, last_token_indices]
+                hidden_states = hidden_states[last_token_indices]
+                return positions, hidden_states
 
-        positions = lax.with_sharding_constraint(
-            positions, NamedSharding(self.mesh, PartitionSpec(None, )))
-        residual = lax.with_sharding_constraint(
-            residual, NamedSharding(self.mesh, PartitionSpec(None, None)))
-        draft_token_ids = lax.with_sharding_constraint(
-            draft_token_ids, NamedSharding(self.mesh, PartitionSpec()))
+            positions = positions[last_token_indices]
+            residual = residual[last_token_indices]
+            return positions, residual
 
+        data_spec = PartitionSpec(ShardingAxisName.ATTN_DATA)
+        # M-RoPE positions are 2D (3, total_tokens); shard the token axis.
+        positions_spec = (PartitionSpec(None, ShardingAxisName.ATTN_DATA)
+                          if positions.ndim == 2 else data_spec)
+        positions, residual = jax.shard_map(
+            _select,
+            mesh=self.mesh,
+            in_specs=(positions_spec, data_spec, data_spec, data_spec),
+            out_specs=(positions_spec, data_spec),
+        )(positions, residual, hidden_states, last_token_indices)
         return positions, residual, draft_token_ids
 
     def propose(
@@ -524,7 +583,6 @@ class Eagle3Proposer:
         positions, hidden_states, draft_token_ids = self._select_inputs_for_loop_speculation(
             state_leaves, attn_metadata.input_positions, residual[0],
             hidden_states, last_token_indices)
-
         draft_token_ids_list = [draft_token_ids]
 
         for i in range(num_speculative_tokens - 1):

--- a/tpu_inference/spec_decode/jax/utils.py
+++ b/tpu_inference/spec_decode/jax/utils.py
@@ -12,40 +12,52 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional
-
 import jax
 import jax.numpy as jnp
+from jax.sharding import PartitionSpec
 
+from tpu_inference.layers.common.sharding import ShardingAxisName
 from tpu_inference.runner.utils import SpecDecodeMetadata
 
 PLACEHOLDER_TOKEN_ID = -1
 
 
+@jax.jit(static_argnames=[
+    "num_speculative_tokens", "max_num_reqs_per_dp_rank", "vocab_size", "mesh"
+])
+def extract_last_sampled_tokens(
+        spec_decode_metadata: SpecDecodeMetadata,
+        sampled_token_ids: jnp.ndarray, num_speculative_tokens: int,
+        vocab_size: int, max_num_reqs_per_dp_rank: int,
+        mesh: jax.sharding.Mesh) -> tuple[jnp.ndarray, jnp.ndarray]:
+
+    def _body(draft_lengths, sampled_token_ids):
+        return _extract_last_sampled_tokens(draft_lengths, sampled_token_ids,
+                                            num_speculative_tokens, vocab_size,
+                                            max_num_reqs_per_dp_rank)
+
+    data_spec = PartitionSpec(ShardingAxisName.ATTN_DATA)
+    return jax.shard_map(
+        _body,
+        mesh=mesh,
+        in_specs=(data_spec, data_spec),
+        out_specs=(data_spec, data_spec),
+    )(spec_decode_metadata.draft_lengths, sampled_token_ids)
+
+
 @jax.jit(
     static_argnames=["num_speculative_tokens", "max_num_seq", "vocab_size"])
-def extract_last_sampled_tokens(
-        spec_decode_metadata: Optional[SpecDecodeMetadata],
-        sampled_token_ids: jnp.ndarray, num_speculative_tokens: int,
-        vocab_size: int, max_num_seq: int) -> tuple[jnp.ndarray, jnp.ndarray]:
+def _extract_last_sampled_tokens(
+        draft_lengths: jnp.ndarray, sampled_token_ids: jnp.ndarray,
+        num_speculative_tokens: int, vocab_size: int,
+        max_num_seq: int) -> tuple[jnp.ndarray, jnp.ndarray]:
     """Extract the last sampled token and number rejected tokens per seq. """
-    if spec_decode_metadata is None:
-        # No speculative decoding in the previous step.
-        batch_size = sampled_token_ids.shape[0]
-        last_sampled_tokens = jnp.pad(sampled_token_ids,
-                                      (0, max_num_seq - batch_size),
-                                      constant_values=PLACEHOLDER_TOKEN_ID)
-        num_rejected_tokens = jnp.zeros(max_num_seq, dtype=jnp.int32)
-        return last_sampled_tokens, num_rejected_tokens
-
-    # If `spec_decode_metadata` is not None, `sampled_token_ids`
-    # is the output of the rejection sampler.
-    num_draft_tokens = spec_decode_metadata.draft_lengths
+    # `sampled_token_ids` is the output of the rejection sampler.
+    num_draft_tokens = draft_lengths
     batch_size = num_draft_tokens.shape[0]
     index_range = jax.lax.broadcasted_iota(
         jnp.int32, (batch_size, num_speculative_tokens), 1)
     valid_mask = index_range < num_draft_tokens[:, None]
-
     # `sampled_token_ids` has the flat layout
     # [main_tokens (sum(num_draft_tokens)), bonus_tokens (batch_size)].
     # `segment_starts[i]` is the offset of seq i's main tokens in that flat
@@ -54,16 +66,13 @@ def extract_last_sampled_tokens(
                              constant_values=0)
     main_tokens_indices = segment_starts[:, None] + index_range
     main_tokens_indices = jnp.where(valid_mask, main_tokens_indices, 0)
-
     main_tokens = jnp.where(valid_mask, sampled_token_ids[main_tokens_indices],
                             PLACEHOLDER_TOKEN_ID)
     main_tokens = jnp.where(main_tokens < vocab_size, main_tokens,
                             PLACEHOLDER_TOKEN_ID)
-
     bonus_tokens = sampled_token_ids[-batch_size:]
     bonus_tokens = jnp.where(bonus_tokens < vocab_size, bonus_tokens,
                              PLACEHOLDER_TOKEN_ID)
-
     num_valid_main = jnp.sum(main_tokens != PLACEHOLDER_TOKEN_ID, axis=1)
     last_main_idx = jnp.maximum(num_valid_main - 1, 0)
     last_main = main_tokens[jnp.arange(batch_size), last_main_idx]
@@ -73,7 +82,6 @@ def extract_last_sampled_tokens(
     last_sampled_tokens = jnp.pad(last_sampled_per_seq,
                                   (0, max_num_seq - batch_size),
                                   constant_values=PLACEHOLDER_TOKEN_ID)
-
     num_rejected_per_seq = jnp.where(
         num_draft_tokens > 0,
         num_draft_tokens + 1 - num_valid_main - has_bonus.astype(jnp.int32),


### PR DESCRIPTION
[Spec decoding] Make spec decoding compatible with attn-DP

Made fields under `spec_decode_metadata` to be DP-aware layout: [valid entries + padding] * DP-size. This is done in `get_spec_decode_metadata()`

Adjust all downstream consumers of `spec_decode_metadata` accordingly, 
including rejection-sampling; eagle3 propose draft tokens. Most of the changes are wrapping existing functionalities within a jax.shard_map(...)



eagle3/mtp + attn-dp is supported by this PR.
eagle3/mtp + attn-dp + async schleduing need a bit additional changes, will be done in the next PR.

Tested=Added a E2E test that has DP > 1 + eagle3 spec-decoding
