### PR TITLE
Fix daily_qwen3_32B_random_tpu7x_2.json

### DIFF
--- a/.buildkite/benchmark/cases/daily/daily_qwen3_32B_random_tpu7x_2.json
+++ b/.buildkite/benchmark/cases/daily/daily_qwen3_32B_random_tpu7x_2.json
@@ -31,7 +31,7 @@
           "max-num-seqs": 256,
           "max-num-batched-tokens": 4096,
           "tensor-parallel-size": {
-            "v7x-8": 8
+            "v7x-2": 2
           },
           "max-model-len": 2048,
           "kv-cache-dtype": "fp8",
@@ -54,7 +54,6 @@
           "request-rate": "inf",
           "percentile-metrics": "ttft,tpot,itl,e2el",
           "ignore-eos": true
-
         }
       }
     },


### PR DESCRIPTION
# Description

Correct the tensor-parallel-size to v7x-2

# Tests

[buildkite](https://buildkite.com/tpu-commons/tpu-inference-ci/builds/18697/canvas?sid=019e6d92-42a9-42a3-859a-fb5655a7f0c2&open=false)

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
