### PR TITLE
[MTP] Implements JAX-native MTP drafter for Gemma4 

### DIFF
--- a/tests/models/jax/test_gemma4_mtp.py
+++ b/tests/models/jax/test_gemma4_mtp.py
@@ -137,7 +137,14 @@ class TestGemma4MTPForCausalLM:
         with jax.set_mesh(mesh):
             loader = get_model_loader(vllm_config.load_config)
             with set_current_vllm_config(vllm_config):
-                loader.load_weights(model, model_config)
+                if use_ordered_embeddings and load_format == "skip_layers_model_loader_for_test":
+                    with pytest.raises(
+                            ValueError,
+                            match="Ordered embeddings masking is enabled"):
+                        loader.load_weights(model, model_config)
+                    return
+                else:
+                    loader.load_weights(model, model_config)
 
         # Validate layer counts and partitioning
         assert model.model is not None

--- a/tests/models/jax/test_gemma4_mtp.py
+++ b/tests/models/jax/test_gemma4_mtp.py
@@ -42,6 +42,7 @@ class DummyTextConfig:
             "full_attention"
         ]
         self.rope_theta = 10000.0
+        self.rope_local_base_freq = 10000.0
         self.rope_scaling = None
         self.head_dim = 256
         self.global_head_dim = 512

--- a/tests/models/jax/test_gemma4_mtp.py
+++ b/tests/models/jax/test_gemma4_mtp.py
@@ -1,0 +1,191 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import MagicMock
+
+import jax
+import jax.numpy as jnp
+import pytest
+from vllm.config import set_current_vllm_config
+from vllm.model_executor.model_loader import get_model_loader
+
+from tpu_inference.distributed.jax_parallel_state import \
+    init_pp_distributed_environment
+from tpu_inference.kernels.ragged_paged_attention.v3.kernel import \
+    get_kv_cache_shape
+from tpu_inference.layers.common.attention_metadata import AttentionMetadata
+from tpu_inference.layers.jax.pp_utils import PPMissingLayer
+from tpu_inference.models.jax.gemma4_mtp import (Gemma4MTPDecoderLayer,
+                                                 Gemma4MTPForCausalLM)
+
+
+class DummyTextConfig:
+
+    def __init__(self):
+        self.hidden_size = 1024
+        self.vocab_size = 262144
+        self.num_hidden_layers = 4
+        self.rms_norm_eps = 1e-6
+        self.layer_types = [
+            "sliding_attention", "sliding_attention", "sliding_attention",
+            "full_attention"
+        ]
+        self.rope_theta = 10000.0
+        self.rope_scaling = None
+        self.head_dim = 256
+        self.global_head_dim = 512
+        self.num_attention_heads = 32
+        self.num_key_value_heads = 16
+        self.num_global_key_value_heads = 4
+        self.attention_bias = False
+        self.attention_k_eq_v = True
+        self.intermediate_size = 8192
+        self.final_logit_softcapping = None
+        self.sliding_window = 1024
+
+
+class DummyDraftConfig:
+
+    def __init__(self, use_ordered_embeddings=True):
+        self.text_config = DummyTextConfig()
+        self.backbone_hidden_size = 5376
+        self.tie_word_embeddings = True
+        self.use_ordered_embeddings = use_ordered_embeddings
+        self.num_centroids = 2048
+        self.centroid_intermediate_top_k = 32
+
+
+class TestGemma4MTPForCausalLM:
+
+    @pytest.mark.parametrize("model_name", [
+        "google/gemma-4-31B-it",
+    ])
+    @pytest.mark.parametrize("pp_rank,pp_world_size", [(0, 1), (0, 4), (1, 4),
+                                                       (3, 4)])
+    @pytest.mark.parametrize(
+        "load_format", ["skip_layers_model_loader_for_test", "jax_dummy"])
+    @pytest.mark.parametrize("use_ordered_embeddings", [True, False])
+    def test_model_loading(
+            self,
+            model_name,
+            pp_rank,
+            pp_world_size,
+            load_format,
+            use_ordered_embeddings,
+            # following are defined in conftest.py
+            rng,
+            mesh,
+            mock_vllm_config):
+        """Tests loading weights and running forward pass of the MTP model following test_gemma4.py"""
+        kv_cache_type = "auto"
+        vllm_config = mock_vllm_config(model_name, kv_cache_type)
+
+        # Lightweight config for target/verifier layers
+        vllm_config.model_config.hf_config.text_config.num_hidden_layers = 4
+        vllm_config.load_config.load_format = load_format
+        vllm_config.load_config.num_layers_to_load_for_test = 4
+        vllm_config.parallel_config = MagicMock()
+        vllm_config.parallel_config.enable_expert_parallel = False
+
+        # For HF loader testing, we redirect the model to point to the real assistant draft checkpoint
+        if load_format == "skip_layers_model_loader_for_test":
+            vllm_config.model_config.model = "google/gemma-4-31B-it-assistant"
+
+        # Construct Speculative Draft Config using solid, concrete Python classes to avoid MagicMock leakages
+        vllm_config.speculative_config = MagicMock()
+        draft_model_config = MagicMock()
+
+        draft_hf_config = DummyDraftConfig(
+            use_ordered_embeddings=use_ordered_embeddings)
+        draft_hf_config.text_config.vocab_size = vllm_config.model_config.get_vocab_size(
+        )
+        draft_hf_config.backbone_hidden_size = vllm_config.model_config.get_hidden_size(
+        )
+
+        draft_model_config.hf_config = draft_hf_config
+        draft_model_config.get_hidden_size = lambda: 1024
+        vllm_config.speculative_config.draft_model_config = draft_model_config
+
+        # Initialize Pipeline Parallel group
+        init_pp_distributed_environment(
+            ip="",
+            rank=pp_rank,
+            world_size=pp_world_size,
+            device=jax.devices()[0],
+            need_pp=False,
+        )
+
+        model_config = vllm_config.model_config
+        kv_dtype = jnp.bfloat16
+
+        with jax.set_mesh(mesh):
+            model = Gemma4MTPForCausalLM(vllm_config, rng, mesh)
+
+        # Load weights
+        with jax.set_mesh(mesh):
+            loader = get_model_loader(vllm_config.load_config)
+            with set_current_vllm_config(vllm_config):
+                loader.load_weights(model, model_config)
+
+        # Validate layer counts and partitioning
+        assert model.model is not None
+        assert len(model.model.layers) == 4
+
+        # Fetch the active MTP layer index on this pipeline parallel rank
+        start_layer_idx = model.model.start_layer
+        end_layer_idx = model.model.end_layer
+
+        if start_layer_idx < end_layer_idx:
+            # Verify that the active layer is loaded
+            layer_0: Gemma4MTPDecoderLayer = model.model.layers[
+                start_layer_idx]
+            assert not isinstance(layer_0, PPMissingLayer)
+
+            num_key_value_heads = layer_0.self_attn.num_kv_heads
+            qk_head_dim = layer_0.self_attn.head_dim_original
+
+            # Run forward pass on active layer
+            seq_len = 2
+            input_tensor = jnp.ones(
+                (seq_len, draft_hf_config.text_config.hidden_size),
+                dtype=jnp.bfloat16)
+
+            block_size = 16
+            num_blocks = 8
+            cache_shape = get_kv_cache_shape(num_blocks, block_size,
+                                             num_key_value_heads, qk_head_dim,
+                                             kv_dtype)
+
+            # Populate centroids ordering if enabled to avoid sparse projection crashes
+            if use_ordered_embeddings and model.masked_embedding is not None:
+                model.masked_embedding.token_ordering.value = jnp.arange(
+                    draft_hf_config.text_config.vocab_size, dtype=jnp.int32)
+
+            with jax.set_mesh(mesh):
+                _, jax_output, _ = layer_0(
+                    kv_cache=jnp.zeros(cache_shape, dtype=kv_dtype),
+                    x=input_tensor,
+                    attention_metadata=AttentionMetadata(
+                        input_positions=jnp.arange(seq_len),
+                        block_tables=jnp.array(list(range(1))),
+                        seq_lens=jnp.array([seq_len]),
+                        query_start_loc=jnp.array([0, seq_len]),
+                        request_distribution=jnp.array([0, 0, 1]),
+                    ),
+                )
+            assert jax_output is not None
+        else:
+            # Verify that all layers are missing on this rank (PPMissingLayer)
+            for idx in range(4):
+                assert isinstance(model.model.layers[idx], PPMissingLayer)

--- a/tpu_inference/models/common/model_loader.py
+++ b/tpu_inference/models/common/model_loader.py
@@ -73,6 +73,7 @@ def _get_model_architecture(config: PretrainedConfig) -> nnx.Module:
     from tpu_inference.models.jax.deepseek_v3 import DeepseekV3ForCausalLM
     from tpu_inference.models.jax.gemma4_mm import \
         Gemma4ForConditionalGeneration
+    from tpu_inference.models.jax.gemma4_mtp import Gemma4MTPForCausalLM
     from tpu_inference.models.jax.gpt_oss import GptOss
     from tpu_inference.models.jax.llama3 import LlamaForCausalLM
     from tpu_inference.models.jax.llama4 import Llama4ForCausalLM
@@ -96,6 +97,7 @@ def _get_model_architecture(config: PretrainedConfig) -> nnx.Module:
     _MODEL_REGISTRY["Qwen2ForCausalLM"] = Qwen2ForCausalLM
     _MODEL_REGISTRY[
         "Gemma4ForConditionalGeneration"] = Gemma4ForConditionalGeneration
+    _MODEL_REGISTRY["Gemma4MTPModel"] = Gemma4MTPForCausalLM
 
     architectures = getattr(config, "architectures", [])
     for arch in architectures:
@@ -114,6 +116,7 @@ def _get_nnx_model(
     rng: jax.Array,
     mesh: Mesh,
     pooler: Optional[Any] = None,
+    is_draft_model: bool = False,
 ) -> nnx.Module:
     """Instantiate the nnx JAX model and optionally pass the embedding/pooling layer.
 
@@ -127,6 +130,9 @@ def _get_nnx_model(
     Returns:
         nnx.Module: The instantiated JAX module.
     """
+
+    model_config = (vllm_config.speculative_config.draft_model_config
+                    if is_draft_model else vllm_config.model_config)
 
     def create_abstract_model() -> nnx.Module:
         """
@@ -269,22 +275,22 @@ def _get_nnx_model(
             loader = get_model_loader(vllm_config.load_config)
             if isinstance(model, LoadableWithIterator):
                 assert isinstance(model, JaxModule)
-                loader.load_weights(model, vllm_config.model_config)
+                loader.load_weights(model, model_config)
             elif isinstance(loader, RunaiModelStreamerLoader):
-                model_weights = vllm_config.model_config.model
-                if hasattr(vllm_config.model_config, "model_weights"):
-                    model_weights = vllm_config.model_config.model_weights
+                model_weights = model_config.model
+                if hasattr(model_config, "model_weights"):
+                    model_weights = model_config.model_weights
                 weights_iterator = loader._get_weights_iterator(
-                    model_weights, vllm_config.model_config.revision)
+                    model_weights, model_config.revision)
 
                 # We set the weights iterator at runtime, to prevent having to change
                 # every model's load_weights signature. This also prevents us from hitting
                 # a TypeError at runtime if you use the RunaiModelStreamerLoader with any
                 # flax_nnx model whose load_weights function does not accept the
                 # weights_iterator keyword argument.
-                vllm_config.model_config.runai_model_weights_iterator = weights_iterator
+                model_config.runai_model_weights_iterator = weights_iterator
                 model.load_weights(rng)
-                del vllm_config.model_config.runai_model_weights_iterator
+                del model_config.runai_model_weights_iterator
             else:
                 model.load_weights(rng)
             if hasattr(vllm_config, "pytorch_pooler"):
@@ -336,7 +342,8 @@ def get_flax_model(
                                vllm_config,
                                rng,
                                mesh,
-                               pooler=pooler)
+                               pooler=pooler,
+                               is_draft_model=is_draft_model)
     vllm_config.model_config.dtype = original_dtype
     kv_cache_sharding = NamedSharding(
         mesh,

--- a/tpu_inference/models/jax/gemma4_mtp.py
+++ b/tpu_inference/models/jax/gemma4_mtp.py
@@ -176,7 +176,7 @@ class Gemma4MTPAttention(JaxModule):
             self.rope_proportion = rope_parameters.get("partial_rotary_factor",
                                                        1.0)
         else:
-            self.rope_theta = (config.rope_local_base_freq
+            self.rope_theta = (getattr(config, "rope_local_base_freq", 10000.0)
                                if self.is_sliding else config.rope_theta)
             self.rope_scaling = getattr(config, "rope_scaling", None)
             self.rope_proportion = 0.25 if not self.is_sliding else 1.0
@@ -345,6 +345,7 @@ class Gemma4MTPDecoderLayer(JaxModule):
             dtype=dtype,
             rng=rng,
             quant_config=quant_config,
+            intermediate_size=config.intermediate_size,
             prefix=prefix + ".mlp",
         )
         self.post_feedforward_layernorm = JaxRmsNorm(

--- a/tpu_inference/models/jax/gemma4_mtp.py
+++ b/tpu_inference/models/jax/gemma4_mtp.py
@@ -1,0 +1,681 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Any, Iterable, List, Optional, Sequence, Tuple
+
+import jax
+import jax.numpy as jnp
+from flax import nnx
+from jax.sharding import Mesh
+from transformers import Gemma4TextConfig
+from vllm.config import VllmConfig
+
+from tpu_inference import utils
+from tpu_inference.layers.common.attention_interface import attention
+from tpu_inference.layers.common.attention_metadata import AttentionMetadata
+from tpu_inference.layers.jax import JaxModule
+from tpu_inference.layers.jax.embed import JaxEmbed
+from tpu_inference.layers.jax.linear import JaxEinsum, JaxLinear
+from tpu_inference.layers.jax.norm import JaxRmsNorm
+from tpu_inference.layers.jax.pp_utils import make_layers
+from tpu_inference.layers.jax.rope_interface import apply_rope
+from tpu_inference.layers.vllm.quantization.configs import VllmQuantConfig
+from tpu_inference.logger import init_logger
+from tpu_inference.models.jax.gemma4 import Gemma4MLP
+from tpu_inference.models.jax.utils.weight_utils import (LoadableWithIterator,
+                                                         StandardWeightLoader)
+
+logger = init_logger(__name__)
+
+init_fn = nnx.initializers.uniform()
+
+
+class Gemma4MTPMaskedEmbedder(JaxModule):
+    """Sparse logit computation via centroid-based vocabulary masking in JAX.
+
+    Projects hidden states to centroid scores, selects the top centroids, and
+    computes logits only for the subset of tokens belonging to those centroids.
+    """
+
+    def __init__(
+        self,
+        hidden_size: int,
+        vocab_size: int,
+        num_centroids: int,
+        centroid_intermediate_top_k: int,
+        dtype: jnp.dtype,
+        rngs: nnx.Rngs,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+        self.hidden_size = hidden_size
+        self.vocab_size = vocab_size
+        self.num_centroids = num_centroids
+        self.centroid_intermediate_top_k = centroid_intermediate_top_k
+        self.vocab_size_per_centroid = vocab_size // num_centroids
+        self.num_selected = centroid_intermediate_top_k * self.vocab_size_per_centroid
+
+        self.centroids = JaxLinear(
+            hidden_size,
+            num_centroids,
+            use_bias=False,
+            param_dtype=dtype,
+            rngs=rngs,
+            prefix=prefix + ".centroids",
+        )
+        # token_ordering is loaded as a buffer/weight
+        self.token_ordering = nnx.Param(
+            jnp.zeros((vocab_size, ), dtype=jnp.int32),
+            eager_sharding=False,
+        )
+
+    def _select_and_score(
+        self,
+        hidden_states: jax.Array,
+        lm_head_weight: jax.Array,
+    ) -> Tuple[jax.Array, jax.Array]:
+        """Centroid selection + sparse dot product."""
+        num_tokens = hidden_states.shape[0]
+        centroid_logits = self.centroids(
+            hidden_states)  # (num_tokens, num_centroids)
+        _, top_k_indices = jax.lax.top_k(
+            centroid_logits,
+            k=self.centroid_intermediate_top_k)  # (num_tokens, top_k)
+
+        clusters = self.token_ordering.value.reshape(
+            self.num_centroids, self.vocab_size_per_centroid)
+        selected = clusters[
+            top_k_indices]  # (num_tokens, top_k, vocab_size_per_centroid)
+        selected_flat = selected.reshape(num_tokens, self.num_selected)
+
+        embeddings = jnp.take(
+            lm_head_weight, selected_flat,
+            axis=0)  # (num_tokens, num_selected, hidden_size)
+        logits = jnp.einsum("td,tsd->ts", hidden_states, embeddings)
+        return logits, selected_flat
+
+    def __call__(
+        self,
+        hidden_states: jax.Array,
+        lm_head_weight: jax.Array,
+    ) -> jax.Array:
+        """Full-vocab logits with non-selected positions masked to -inf."""
+        logits, indices = self._select_and_score(hidden_states, lm_head_weight)
+        num_tokens = hidden_states.shape[0]
+        output = jnp.full(
+            (num_tokens, self.vocab_size),
+            jnp.finfo(hidden_states.dtype).min,
+            dtype=hidden_states.dtype,
+        )
+        row_indices = jnp.arange(num_tokens)[:, None]
+        output = output.at[row_indices, indices].set(logits)
+        return output
+
+    def get_top_tokens(
+        self,
+        hidden_states: jax.Array,
+        lm_head_weight: jax.Array,
+    ) -> jax.Array:
+        """Sparse argmax — returns vocab token IDs directly."""
+        logits, indices = self._select_and_score(hidden_states, lm_head_weight)
+        best_idx = jnp.argmax(logits, axis=-1, keepdims=True)
+        return jnp.take_along_axis(indices, best_idx, axis=-1).squeeze(-1)
+
+
+class Gemma4MTPAttention(JaxModule):
+    """Q-only attention for Gemma4 MTP layers.
+
+    K/V come from the target model's KV cache, queried at runtime by passing
+    update_kv_cache=False.
+    """
+
+    def __init__(
+        self,
+        config: Gemma4TextConfig,
+        layer_idx: int,
+        dtype: jnp.dtype,
+        rng: nnx.Rngs,
+        mesh: Mesh,
+        kv_cache_dtype: str,
+        quant_config: VllmQuantConfig,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+        self.hidden_size = config.hidden_size
+        self.num_heads = config.num_attention_heads
+        self.rms_norm_eps = config.rms_norm_eps
+
+        self.scaling = 1.0
+
+        self.layer_type = "full_attention"
+        if hasattr(config, "layer_types") and layer_idx < len(
+                config.layer_types):
+            self.layer_type = config.layer_types[layer_idx]
+
+        self.is_sliding = self.layer_type == "sliding_attention"
+        self.sliding_window = config.sliding_window if self.is_sliding else None
+
+        rope_parameters = getattr(config, "rope_parameters", {})
+        if self.layer_type in rope_parameters:
+            rope_parameters = rope_parameters[self.layer_type]
+            self.rope_theta = rope_parameters.get(
+                "rope_theta", getattr(config, "rope_theta", 10000.0))
+            self.rope_scaling = rope_parameters.get(
+                "rope_scaling", getattr(config, "rope_scaling", None))
+            self.rope_proportion = rope_parameters.get("partial_rotary_factor",
+                                                       1.0)
+        else:
+            self.rope_theta = (config.rope_local_base_freq
+                               if self.is_sliding else config.rope_theta)
+            self.rope_scaling = getattr(config, "rope_scaling", None)
+            self.rope_proportion = 0.25 if not self.is_sliding else 1.0
+
+        if not self.is_sliding:
+            self.head_dim_original = config.global_head_dim
+        else:
+            self.head_dim_original = config.head_dim
+
+        use_k_eq_v = (not self.is_sliding) and getattr(
+            config, "attention_k_eq_v", False)
+        if use_k_eq_v:
+            self.num_kv_heads = (config.num_global_key_value_heads
+                                 or config.num_key_value_heads)
+        else:
+            self.num_kv_heads = config.num_key_value_heads
+
+        self.head_dim = utils.get_padded_head_dim(self.head_dim_original)
+        self.mesh = mesh
+
+        self.q_proj = JaxEinsum(
+            "TD,DNH->TNH",
+            (self.hidden_size, self.num_heads, self.head_dim),
+            bias_shape=(self.num_heads,
+                        self.head_dim) if config.attention_bias else None,
+            param_dtype=dtype,
+            kernel_init=nnx.with_partitioning(init_fn, (None, "model", None)),
+            bias_init=nnx.with_partitioning(init_fn, ("model", None))
+            if config.attention_bias else None,
+            rngs=rng,
+            quant_config=quant_config,
+            prefix=prefix + ".q_proj",
+        )
+        self.q_norm = JaxRmsNorm(
+            self.head_dim,
+            epsilon=self.rms_norm_eps,
+            param_dtype=dtype,
+            scale_init=nnx.with_partitioning(init_fn, (None, )),
+            rngs=rng,
+            quant_config=quant_config,
+            prefix=prefix + ".q_norm",
+        )
+
+        self.o_proj = JaxEinsum(
+            "TNH,NHD->TD",
+            (self.num_heads, self.head_dim, self.hidden_size),
+            bias_shape=(self.hidden_size, ) if config.attention_bias else None,
+            param_dtype=dtype,
+            kernel_init=nnx.with_partitioning(init_fn, (None, "model", None)),
+            bias_init=nnx.with_partitioning(init_fn, (None, ))
+            if config.attention_bias else None,
+            rngs=rng,
+            quant_config=quant_config,
+            prefix=prefix + ".o_proj",
+        )
+
+        self.is_kv_shared_layer = True
+
+    def __call__(
+        self,
+        kv_cache: jax.Array,
+        x: jax.Array,
+        attention_metadata: AttentionMetadata,
+    ) -> Tuple[jax.Array, jax.Array]:
+        md = attention_metadata
+        q = self.q_proj(x)
+        q = self.q_norm(q)
+
+        q = apply_rope(
+            q,
+            md.input_positions,
+            self.head_dim_original,
+            self.rope_theta,
+            self.rope_scaling,
+            rope_proportion=self.rope_proportion,
+        )
+
+        num_tokens = q.shape[0]
+        dummy_k = jnp.zeros((num_tokens, self.num_kv_heads, self.head_dim),
+                            dtype=q.dtype)
+        dummy_v = jnp.zeros((num_tokens, self.num_kv_heads, self.head_dim),
+                            dtype=q.dtype)
+
+        new_kv_cache, outputs = attention(
+            kv_cache,
+            q,
+            dummy_k,
+            dummy_v,
+            attention_metadata,
+            self.mesh,
+            self.head_dim_original,
+            sm_scale=self.scaling,
+            attention_chunk_size=self.sliding_window,
+            update_kv_cache=False,  # Read-only shared cache query
+        )
+        o = self.o_proj(outputs)
+        return new_kv_cache, o
+
+
+class Gemma4MTPDecoderLayer(JaxModule):
+
+    def __init__(
+        self,
+        config: Gemma4TextConfig,
+        layer_idx: int,
+        dtype: jnp.dtype,
+        rng: nnx.Rngs,
+        mesh: Mesh,
+        kv_cache_dtype: str,
+        quant_config: VllmQuantConfig,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+        rms_norm_eps = config.rms_norm_eps
+        hidden_size = config.hidden_size
+
+        self.layer_type = "full_attention"
+        if hasattr(config, "layer_types") and layer_idx < len(
+                config.layer_types):
+            self.layer_type = config.layer_types[layer_idx]
+
+        self.is_sliding = self.layer_type == "sliding_attention"
+        self.layer_scalar = nnx.Param(jnp.ones((1, ), dtype=dtype))
+
+        self.input_layernorm = JaxRmsNorm(
+            hidden_size,
+            epsilon=rms_norm_eps,
+            param_dtype=dtype,
+            scale_init=nnx.with_partitioning(init_fn, (None, )),
+            rngs=rng,
+            quant_config=quant_config,
+            prefix=prefix + ".input_layernorm",
+        )
+        self.self_attn = Gemma4MTPAttention(
+            config=config,
+            layer_idx=layer_idx,
+            dtype=dtype,
+            rng=rng,
+            mesh=mesh,
+            kv_cache_dtype=kv_cache_dtype,
+            quant_config=quant_config,
+            prefix=prefix + ".self_attn",
+        )
+        self.post_attention_layernorm = JaxRmsNorm(
+            hidden_size,
+            epsilon=rms_norm_eps,
+            dtype=dtype,
+            param_dtype=dtype,
+            scale_init=nnx.with_partitioning(init_fn, (None, )),
+            rngs=rng,
+            quant_config=quant_config,
+            prefix=prefix + ".post_attention_layernorm",
+        )
+        self.pre_feedforward_layernorm = JaxRmsNorm(
+            hidden_size,
+            epsilon=rms_norm_eps,
+            dtype=dtype,
+            param_dtype=dtype,
+            scale_init=nnx.with_partitioning(init_fn, (None, )),
+            rngs=rng,
+            quant_config=quant_config,
+            prefix=prefix + ".pre_feedforward_layernorm",
+        )
+        self.mlp = Gemma4MLP(
+            config=config,
+            dtype=dtype,
+            rng=rng,
+            quant_config=quant_config,
+            prefix=prefix + ".mlp",
+        )
+        self.post_feedforward_layernorm = JaxRmsNorm(
+            hidden_size,
+            epsilon=rms_norm_eps,
+            dtype=dtype,
+            param_dtype=dtype,
+            scale_init=nnx.with_partitioning(init_fn, (None, )),
+            rngs=rng,
+            quant_config=quant_config,
+            prefix=prefix + ".post_feedforward_layernorm",
+        )
+
+    def __call__(
+        self,
+        kv_cache: jax.Array,
+        x: jax.Array,
+        attention_metadata: AttentionMetadata,
+    ) -> Tuple[jax.Array, jax.Array, Optional[jax.Array]]:
+        residual = x
+        hidden_states = self.input_layernorm(x)
+        kv_cache, attn_output = self.self_attn(
+            kv_cache,
+            hidden_states,
+            attention_metadata,
+        )
+        attn_output = self.post_attention_layernorm(attn_output)
+        hidden_states = residual + attn_output
+        residual = hidden_states
+
+        hidden_states = self.pre_feedforward_layernorm(residual)
+        hidden_states = self.mlp(hidden_states)
+
+        mlp_output = self.post_feedforward_layernorm(hidden_states)
+        outputs = residual + mlp_output
+
+        outputs = outputs * self.layer_scalar.value
+
+        return kv_cache, outputs, None
+
+
+class Gemma4MultiTokenPredictor(JaxModule):
+
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        rng: nnx.Rngs,
+        mesh: Mesh,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+
+        draft_config = vllm_config.speculative_config.draft_model_config.hf_config
+        text_config = draft_config.text_config
+        self.config = text_config
+        dtype = vllm_config.model_config.dtype
+
+        self.hidden_size = text_config.hidden_size
+        self.backbone_hidden_size = getattr(draft_config,
+                                            "backbone_hidden_size",
+                                            self.hidden_size)
+        self.vocab_size = text_config.vocab_size
+        self.num_mtp_layers = text_config.num_hidden_layers
+
+        self.embed_tokens = JaxEmbed(
+            num_embeddings=self.vocab_size,
+            features=self.hidden_size,
+            param_dtype=dtype,
+            embedding_init=nnx.with_partitioning(init_fn, ("model", None)),
+            rngs=rng,
+            quant_config=vllm_config.quant_config,
+            prefix=prefix + ".embed_tokens",
+        )
+
+        self.pre_projection = JaxLinear(
+            2 * self.backbone_hidden_size,
+            self.hidden_size,
+            use_bias=False,
+            param_dtype=dtype,
+            rngs=rng,
+            quant_config=vllm_config.quant_config,
+            prefix=prefix + ".pre_projection",
+        )
+
+        self.post_projection = JaxLinear(
+            self.hidden_size,
+            self.backbone_hidden_size,
+            use_bias=False,
+            param_dtype=dtype,
+            rngs=rng,
+            quant_config=vllm_config.quant_config,
+            prefix=prefix + ".post_projection",
+        )
+
+        self.start_layer, self.end_layer, self.layers = make_layers(
+            self.num_mtp_layers,
+            lambda layer_index: Gemma4MTPDecoderLayer(
+                config=self.config,
+                layer_idx=layer_index,
+                dtype=dtype,
+                rng=rng,
+                mesh=mesh,
+                kv_cache_dtype=vllm_config.cache_config.cache_dtype,
+                quant_config=vllm_config.quant_config,
+                prefix=f"{prefix}.layers.{layer_index}",
+            ),
+        )
+
+        self.norm = JaxRmsNorm(
+            self.hidden_size,
+            epsilon=text_config.rms_norm_eps,
+            param_dtype=dtype,
+            scale_init=nnx.with_partitioning(init_fn, (None, )),
+            rngs=rng,
+            quant_config=vllm_config.quant_config,
+            prefix=prefix + ".norm",
+        )
+
+        self.normalizer = self.backbone_hidden_size**0.5
+
+    def embed_input_ids(self, input_ids: jax.Array) -> jax.Array:
+        return self.embed_tokens(input_ids) * self.normalizer
+
+    def __call__(
+        self,
+        kv_caches: List[jax.Array],
+        input_ids: jax.Array,
+        hidden_states: jax.Array,
+        attention_metadata: AttentionMetadata,
+        layer_name_to_kv_cache: Optional[dict] = None,
+        spec_step_idx: int = 0,
+    ) -> Tuple[List[jax.Array], jax.Array, jax.Array]:
+        inputs_embeds = self.embed_input_ids(input_ids)
+
+        combined = jnp.concatenate([inputs_embeds, hidden_states], axis=-1)
+        hidden_states = self.pre_projection(combined)
+
+        for i, layer in enumerate(self.layers):
+            layer_name = f"layer.{i}"
+            if layer_name_to_kv_cache and layer_name in layer_name_to_kv_cache:
+                cache_idx = layer_name_to_kv_cache[layer_name]
+            else:
+                cache_idx = i
+
+            kv_cache = kv_caches[cache_idx]
+            kv_cache, hidden_states, _ = layer(
+                kv_cache,
+                hidden_states,
+                attention_metadata,
+            )
+            kv_caches[cache_idx] = kv_cache
+
+        draft_hidden_states = self.norm(hidden_states)
+        backbone_hidden_states = self.post_projection(draft_hidden_states)
+
+        return kv_caches, draft_hidden_states, backbone_hidden_states
+
+
+class Gemma4MTPForCausalLM(JaxModule, LoadableWithIterator):
+    WeightLoader = StandardWeightLoader
+
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        rng_key: jax.Array,
+        mesh: Mesh,
+    ) -> None:
+        super().__init__()
+        self.vllm_config = vllm_config
+        rng = nnx.Rngs(rng_key)
+        self.mesh = mesh
+
+        self.model = Gemma4MultiTokenPredictor(
+            vllm_config=vllm_config,
+            rng=rng,
+            mesh=mesh,
+            prefix="model",
+        )
+
+        draft_config = vllm_config.speculative_config.draft_model_config.hf_config
+        text_config = draft_config.text_config
+        dtype = vllm_config.model_config.dtype
+
+        self.final_logit_softcapping = getattr(text_config,
+                                               "final_logit_softcapping", None)
+
+        if not getattr(draft_config, "tie_word_embeddings", True):
+            self.lm_head = JaxEinsum(
+                einsum_str="TD,DV->TV",
+                kernel_shape=(text_config.hidden_size, text_config.vocab_size),
+                dtype=dtype,
+                rngs=rng,
+                quant_config=vllm_config.quant_config,
+                prefix="lm_head",
+            )
+
+        if getattr(draft_config, "use_ordered_embeddings", False):
+            num_centroids = getattr(draft_config, "num_centroids", 2048)
+            top_k = getattr(draft_config, "centroid_intermediate_top_k", 32)
+            self.masked_embedding = Gemma4MTPMaskedEmbedder(
+                hidden_size=text_config.hidden_size,
+                vocab_size=text_config.vocab_size,
+                num_centroids=num_centroids,
+                centroid_intermediate_top_k=top_k,
+                dtype=dtype,
+                rngs=rng,
+                prefix="masked_embedding",
+            )
+        else:
+            self.masked_embedding = None
+
+    def load_weights(self, weights: Iterable[Tuple[str, Any]]):
+        allowed_layers = set(f"layers.{i}."
+                             for i in range(len(self.model.layers)))
+
+        def clean_and_map(w_iter):
+            loaded_keys = set()
+            for name, tensor in w_iter:
+                clean_name = name.replace("language_model.", "")
+                if clean_name.startswith("mtp."):
+                    clean_name = clean_name.replace("mtp.", "model.")
+                if clean_name.startswith("pre_projection."):
+                    clean_name = "model." + clean_name
+                elif clean_name.startswith("post_projection."):
+                    clean_name = "model." + clean_name
+
+                if clean_name.startswith(
+                    ("model.", "lm_head", "masked_embedding")):
+                    loaded_keys.add(clean_name)
+                    yield clean_name, tensor
+
+            # If ordered embeddings are enabled but missing in PyTorch checkpoint files,
+            # dynamically yield dummy tensors for them to satisfy default loader tracking.
+            if getattr(self, "masked_embedding", None) is not None:
+                import torch
+                from vllm.logger import init_logger
+                logger = init_logger(__name__)
+                for key in [
+                        "masked_embedding.token_ordering",
+                        "masked_embedding.centroids.weight"
+                ]:
+                    if key not in loaded_keys:
+                        logger.info(
+                            f"Checkpoint is missing parameter '{key}'. Injecting dummy weight."
+                        )
+                        param = dict(self.named_parameters())[key]
+                        if "token_ordering" in key:
+                            dummy_tensor = torch.zeros(param.value.shape,
+                                                       dtype=torch.int32)
+                        else:
+                            dummy_tensor = torch.zeros(param.value.shape,
+                                                       dtype=torch.float32)
+                        yield key, dummy_tensor
+
+        mapped_weights = clean_and_map(weights)
+
+        filtered_weights = ((name, tensor) for name, tensor in mapped_weights
+                            if not ("layers." in name and not any(
+                                layer_prefix in name
+                                for layer_prefix in allowed_layers)))
+
+        from tpu_inference.models.jax.utils.weight_utils import \
+            JaxAutoWeightsLoader
+
+        pytorch_pooler = getattr(getattr(self, "vllm_config", None),
+                                 "pytorch_pooler", None)
+
+        loader = JaxAutoWeightsLoader(
+            self,
+            pytorch_pooler=pytorch_pooler,
+            skip_prefixes=(["lm_head"]
+                           if not hasattr(self, 'lm_head') else None),
+            ignore_unexpected_prefixes=[
+                "model.embed_vision", "model.vision_tower"
+            ],
+        )
+        return loader.load_weights(filtered_weights)
+
+    def __call__(
+        self,
+        kv_caches: List[jax.Array],
+        input_ids: jax.Array,
+        hidden_states: jax.Array,
+        attention_metadata: AttentionMetadata,
+        layer_name_to_kvcache_index: Optional[Sequence[Tuple[str,
+                                                             int]]] = None,
+        spec_step_idx: int = 0,
+        *args,
+    ) -> Tuple[List[jax.Array], jax.Array, List[jax.Array],
+               Optional[jax.Array]]:
+        layer_name_to_kv_cache = (dict(layer_name_to_kvcache_index)
+                                  if layer_name_to_kvcache_index else None)
+
+        kv_caches, draft_hidden_states, backbone_hidden_states = self.model(
+            kv_caches,
+            input_ids,
+            hidden_states,
+            attention_metadata,
+            layer_name_to_kv_cache=layer_name_to_kv_cache,
+            spec_step_idx=spec_step_idx,
+        )
+
+        return kv_caches, draft_hidden_states, [backbone_hidden_states], None
+
+    def _get_full_lm_head_weight(self) -> jax.Array:
+        if hasattr(self, "lm_head"):
+            return self.lm_head.kernel.value
+        else:
+            return self.model.embed_tokens.embedding.value
+
+    def compute_logits(self, hidden_states: jax.Array) -> jax.Array:
+        if self.masked_embedding is not None:
+            return self.masked_embedding(
+                hidden_states,
+                self._get_full_lm_head_weight(),
+            )
+
+        if hasattr(self, "lm_head"):
+            logits = self.lm_head(hidden_states)
+        else:
+            logits = self.model.embed_tokens.decode(hidden_states)
+
+        if self.final_logit_softcapping is not None:
+            logits = (jnp.tanh(logits / self.final_logit_softcapping) *
+                      self.final_logit_softcapping)
+        return logits
+
+    def get_top_tokens(self, hidden_states: jax.Array) -> jax.Array:
+        if self.masked_embedding is not None:
+            return self.masked_embedding.get_top_tokens(
+                hidden_states,
+                self._get_full_lm_head_weight(),
+            )
+        return jnp.argmax(self.compute_logits(hidden_states), axis=-1)

--- a/tpu_inference/models/jax/gemma4_mtp.py
+++ b/tpu_inference/models/jax/gemma4_mtp.py
@@ -577,30 +577,17 @@ class Gemma4MTPForCausalLM(JaxModule, LoadableWithIterator):
                     loaded_keys.add(clean_name)
                     yield clean_name, tensor
 
-            # If ordered embeddings are enabled but missing in PyTorch checkpoint files,
-            # dynamically yield dummy tensors for them to satisfy default loader tracking.
             if getattr(self, "masked_embedding", None) is not None:
-                import torch
-                from vllm.logger import init_logger
-                logger = init_logger(__name__)
                 for key in [
                         "masked_embedding.token_ordering",
                         "masked_embedding.centroids.weight"
                 ]:
                     if key not in loaded_keys:
-                        logger.info(
-                            f"Checkpoint is missing parameter '{key}'. Injecting dummy weight."
+                        raise ValueError(
+                            f"Ordered embeddings masking is enabled at runtime, but the "
+                            f"required parameter '{key}' is missing from the loaded checkpoint. "
+                            f"Please use a draft checkpoint that was trained with centroids masking."
                         )
-                        param = dict(self.named_parameters())[key]
-                        if "token_ordering" in key:
-                            dummy_tensor = torch.zeros(param.value.shape,
-                                                       dtype=torch.int32)
-                        else:
-                            # centroids.weight must be generated in PyTorch layout
-                            # (out_features, in_features), which is transposed compared to JAX.
-                            dummy_tensor = torch.zeros(param.value.shape[::-1],
-                                                       dtype=torch.float32)
-                        yield key, dummy_tensor
 
         mapped_weights = clean_and_map(weights)
 

--- a/tpu_inference/models/jax/gemma4_mtp.py
+++ b/tpu_inference/models/jax/gemma4_mtp.py
@@ -596,7 +596,9 @@ class Gemma4MTPForCausalLM(JaxModule, LoadableWithIterator):
                             dummy_tensor = torch.zeros(param.value.shape,
                                                        dtype=torch.int32)
                         else:
-                            dummy_tensor = torch.zeros(param.value.shape,
+                            # centroids.weight must be generated in PyTorch layout
+                            # (out_features, in_features), which is transposed compared to JAX.
+                            dummy_tensor = torch.zeros(param.value.shape[::-1],
                                                        dtype=torch.float32)
                         yield key, dummy_tensor
 

--- a/tpu_inference/models/jax/utils/weight_utils.py
+++ b/tpu_inference/models/jax/utils/weight_utils.py
@@ -1044,15 +1044,24 @@ class JaxDummyModelLoader(DummyModelLoader):
                     num_experts, input_dim, intermediate_dim = param_shape
                     param_shape = (num_experts, intermediate_dim, input_dim)
 
-                dummy_weight = jax.random.uniform(
-                    key=jax.random.PRNGKey(0),
-                    shape=param_shape,
-                    dtype=param.value.dtype,
-                    # upstream claims this range works well
-                    # https://github.com/vllm-project/vllm/blob/7291d1b288558d48508e1a17c37b0aa170332264/vllm/model_executor/model_loader/weight_utils.py#L1088
-                    minval=-1e-3,
-                    maxval=1e-3,
-                )
+                if jnp.issubdtype(param.value.dtype, jnp.integer):
+                    dummy_weight = jax.random.randint(
+                        key=jax.random.PRNGKey(0),
+                        shape=param_shape,
+                        minval=0,
+                        maxval=100,
+                        dtype=param.value.dtype,
+                    )
+                else:
+                    dummy_weight = jax.random.uniform(
+                        key=jax.random.PRNGKey(0),
+                        shape=param_shape,
+                        dtype=param.value.dtype,
+                        # upstream claims this range works well
+                        # https://github.com/vllm-project/vllm/blob/7291d1b288558d48508e1a17c37b0aa170332264/vllm/model_executor/model_loader/weight_utils.py#L1088
+                        minval=-1e-3,
+                        maxval=1e-3,
+                    )
 
                 if is_moe:
                     param._weights_to_load[:] = jnp.vsplit(

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -668,13 +668,12 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                         _ = torch_view(dummy_jax).to('cpu', non_blocking=False)
                 logger.debug("Universal StepPooler pre-warming successful.")
 
-
             self.state = model.state
-            
+
             if self.drafter is not None:
                 logger.info("Loading drafter model...")
                 self.drafter.load_model(self.state)
-                
+
         self.model_fn = model.model_fn
         self.compute_logits_fn = model.compute_logits_fn
         self.pooler_fn = model.pooler_fn
@@ -691,7 +690,6 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         self.embed_multimodal_fn = model.multimodal_fns.embed_multimodal_fn
         self.embed_input_ids_fn = model.multimodal_fns.embed_input_ids_fn
         self.get_mrope_input_positions_fn = model.multimodal_fns.get_mrope_input_positions_fn
-
 
         rng_key = nnx.Rngs(jax.random.key(self.model_config.seed)).params()
         self.rng_params_for_sampling = device_array(self.mesh,

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -668,11 +668,17 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                         _ = torch_view(dummy_jax).to('cpu', non_blocking=False)
                 logger.debug("Universal StepPooler pre-warming successful.")
 
+
+            self.state = model.state
+            
+            if self.drafter is not None:
+                logger.info("Loading drafter model...")
+                self.drafter.load_model(self.state)
+                
         self.model_fn = model.model_fn
         self.compute_logits_fn = model.compute_logits_fn
         self.pooler_fn = model.pooler_fn
         self.combine_hidden_states_fn = model.combine_hidden_states_fn
-        self.state = model.state
         # For the flax_nnx path, `model_fn` (== `run_model`) accepts a flat
         # tuple of array leaves and reconstructs the nnx.State inside the
         # jit. Pre-flatten here so subsequent dispatches skip the per-call
@@ -686,9 +692,6 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         self.embed_input_ids_fn = model.multimodal_fns.embed_input_ids_fn
         self.get_mrope_input_positions_fn = model.multimodal_fns.get_mrope_input_positions_fn
 
-        if self.drafter is not None:
-            logger.info("Loading drafter model...")
-            self.drafter.load_model(self.state)
 
         rng_key = nnx.Rngs(jax.random.key(self.model_config.seed)).params()
         self.rng_params_for_sampling = device_array(self.mesh,

--- a/tpu_inference/spec_decode/jax/eagle3.py
+++ b/tpu_inference/spec_decode/jax/eagle3.py
@@ -109,22 +109,48 @@ class Eagle3Proposer:
         # Reuse the target model's embedding if the draft model doesn't have its own or if they are identical, to save memory.
         # TODO(ranlihao): Unify the weight loading process for jax and torchax path.
         if draft_model_impl == "flax_nnx":
-            draft_embed_tokens = getattr(self.state.model, 'embed_tokens',
-                                         None)
-            if draft_embed_tokens is None or ~jnp.any(
-                    draft_embed_tokens.embedding):
-                logger.info(
-                    "Draft model does not have embedding. Setting draft model's embed_tokens to target model's embed"
-                )
-                self.state.model.embed_tokens = target_model.model.embed
-            elif jnp.array_equal(draft_embed_tokens.embedding,
-                                 target_model.model.embed.embedding):
-                logger.info(
-                    "Draft model's embed_tokens is identical to target model's embed. Sharing the embedding."
-                )
-                self.state.model.embed_tokens = target_model.model.embed
+            from tpu_inference.models.jax.utils.weight_utils import get_param
+
+            # 1. Resolve draft embed param in self.state
+            draft_embed_param = None
+            for path in ["model.embed_tokens.weight", "model.embed.embedding"]:
+                try:
+                    draft_embed_param = get_param(self.state, path)
+                    logger.info(f"Resolved draft model embedding path: {path}")
+                    break
+                except ValueError:
+                    continue
+
+            # 2. Resolve target embed param in target_model (which is already the target state)
+            target_embed_param = None
+            for path in ["model.embed_tokens.weight", "model.embed.embedding"]:
+                try:
+                    target_embed_param = get_param(target_model, path)
+                    logger.info(
+                        f"Resolved target model embedding path: {path}")
+                    break
+                except ValueError:
+                    continue
+
+            # 3. Check and share embedding values directly in the State trees
+            if draft_embed_param is not None and target_embed_param is not None:
+                if not jnp.any(draft_embed_param.value):
+                    logger.info(
+                        "Draft model does not have embedding. Setting draft model's embed_tokens to target model's embed"
+                    )
+                    draft_embed_param.value = target_embed_param.value
+                elif jnp.array_equal(draft_embed_param.value,
+                                     target_embed_param.value):
+                    logger.info(
+                        "Draft model's embed_tokens is identical to target model's embed. Sharing the embedding."
+                    )
+                    draft_embed_param.value = target_embed_param.value
+                else:
+                    logger.info("Draft model has its own embed_tokens.")
             else:
-                logger.info("Draft model has its own embed_tokens.")
+                logger.warning(
+                    "Failed to locate draft or target embedding parameter in State objects."
+                )
 
         # The embed_tokens assignment above may have mutated `self.state`;
         # re-derive `state_leaves` so the dispatch-side view matches.

--- a/tpu_inference/spec_decode/jax/eagle3.py
+++ b/tpu_inference/spec_decode/jax/eagle3.py
@@ -113,7 +113,10 @@ class Eagle3Proposer:
 
             # 1. Resolve draft embed param in self.state
             draft_embed_param = None
-            for path in ["model.embed_tokens.weight", "model.embed.embedding"]:
+            for path in [
+                    "model.embed_tokens.weight", "model.embed.embedding",
+                    "model.embed_tokens.embedding"
+            ]:
                 try:
                     draft_embed_param = get_param(self.state, path)
                     logger.info(f"Resolved draft model embedding path: {path}")
@@ -123,7 +126,10 @@ class Eagle3Proposer:
 
             # 2. Resolve target embed param in target_model (which is already the target state)
             target_embed_param = None
-            for path in ["model.embed_tokens.weight", "model.embed.embedding"]:
+            for path in [
+                    "model.embed_tokens.weight", "model.embed.embedding",
+                    "model.embed_tokens.embedding"
+            ]:
                 try:
                     target_embed_param = get_param(target_model, path)
                     logger.info(


### PR DESCRIPTION
# Description
This PR implements and registers the JAX-native **Gemma4 MTP (Multi-Token Prediction) draft/assistant model** (Drafter) in `tpu-inference`. It establishes the basic model architecture, parameter tree-based embedding sharing, and weights loading registry, and includes a comprehensive multi-host weight loading unit test suite.

> [!NOTE]
> **Scope Clarification**: This PR strictly covers the **MTP draft model architecture implementation, registry, and weight loading**. Full speculative decoding serving execution (speculative proposer orchestrators and runtime loops) for Gemma4 is *not* supported yet and will be integrated in subsequent PRs. 

### Key Changes

#### 1. JAX-Native Gemma4 Speculative Draft Model (`tpu_inference/models/jax/gemma4_mtp.py`)
* Implemented the JAX-native speculative draft/assistant model (`Gemma4MTPForCausalLM` / `Gemma4MultiTokenPredictor` / `Gemma4MTPDecoderLayer`).
* Implemented **Q-only attention layers** (`Gemma4MTPAttention`) designed for cross-model KV cache sharing at runtime.
* Implemented **Centroid-Based Vocabulary Masking** (`Gemma4MTPMaskedEmbedder`) to sparsely calculate top-K centroid scores and dot-product vocabulary logits.

#### 2. Architecture Registration & Drafting Context (`tpu_inference/models/common/model_loader.py`)
* Registered `"Gemma4MTPModel"` under the standard JAX model architecture registry, mapping to JAX-native class `Gemma4MTPForCausalLM`.
* Adjusted `_get_nnx_model` to resolve the speculative draft configuration state dynamically during instantiations.

#### 3. Speculative Embedding Sharing (`tpu_inference/spec_decode/jax/eagle3.py`)
* Refactored speculative embedding sharing to dynamically query and bind JAX-native parameters directly using state parameter trees.
* Safely links target model token embeddings when draft embeddings are zeroed/missing, significantly reducing TPU memory footprint.

#### 4. Model Verification & Pipeline Parallel Tests (`tests/models/jax/test_gemma4_mtp.py`)
* Created a complete pipeline-parallel unit test suite specifically verifying the Gemma4 MTP draft model.
* Verifies model construction, weights loading, JAX device mesh array partitioning, and compiles/executes forward passes under pipeline parallel shapes (`pp_rank` and `pp_world_size` up to 4).
* Validates that weight loading correctly fails fast with a matching `ValueError` when serving with ordered embeddings enabled against standard (non-centroids) draft checkpoints.

---

### Test Plan & Results

Verified successfully on the Cloud TPU VM environment. 

#### Test Command:
```bash
python3 -m pytest -s -v tests/models/jax/test_gemma4_mtp.py
```

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
