### PR TITLE
[RPA v3] Fix int16 overflow in position computation for sequences > 32K tokens

### DIFF
--- a/tpu_inference/kernels/ragged_paged_attention/v3/kernel.py
+++ b/tpu_inference/kernels/ragged_paged_attention/v3/kernel.py
@@ -467,7 +467,9 @@ def _ragged_paged_attention_kernel_loop(
             s = soft_cap * jnp.tanh(s / soft_cap)
 
         int_ty = jnp.int32
-        if get_dtype_packing(q_dtype) != 1 and get_tpu_version() >= 6:
+        max_kv_len = pages_per_seq * page_size
+        if (get_dtype_packing(q_dtype) != 1 and get_tpu_version() >= 6
+                and max_kv_len <= jnp.iinfo(jnp.int16).max):
             int_ty = jnp.int16
         processed_q_len_int = processed_q_len.astype(int_ty)
         processed_kv_len_int = processed_kv_len.astype(int_ty)


### PR DESCRIPTION
## Summary

Fix int16 overflow in RPA v3 decode kernel position computation that causes incorrect attention masks for sequences longer than 32,767 tokens.

The kernel uses `int16` for position indices as a VMEM optimization on TPU v6+/v7 with packed dtypes (bf16/fp16). However, `int16` overflows for sequences beyond 32,767 tokens, corrupting both the causal mask (`q_span >= k_span`) and sliding window mask (`q_span < k_span + sliding_window`). This produces severe recency bias for models with sliding window attention (Gemma 3, Gemma 4) when serving long prompts.

## Fix

Guard the `int16` optimization with a max sequence length check (`pages_per_seq * page_size <= 32767`). For longer sequences, `int32` is used — correct but slightly less VMEM-efficient.

## Test plan

Validated on TPU v7x (4 chips, `vllm/vllm-tpu:nightly`):

| Model | Output distribution (before fix) | Output distribution (after fix) | GPU reference |
|---|---|---|---|
| Gemma 3 4B IT | 71% concentrated at end of prompt | Matches GPU distribution | ✅ |
| Gemma 4 E4B IT | 95% concentrated at end of prompt | Matches GPU distribution | ✅ |
| Qwen3 4B (no sliding window) | Correct (unaffected) | Correct | ✅ |

Benchmark: Long prompts (~37K tokens) with structured content. Prompts exceed int16 max (32,767), triggering the overflow. After fix, TPU and GPU produce matching output distributions for all tested models.

Fixes #2755