### PR TITLE
[Spec decoding] Make Spec decoding + attn-dp + async scheduling compatible

### DIFF
--- a/tests/e2e/test_speculative_decoding.py
+++ b/tests/e2e/test_speculative_decoding.py
@@ -88,24 +88,22 @@ def model_name():
 
 
 # TODO(pooyam): run vLLM engine with InProcClient (`VLLM_ENABLE_V1_MULTIPROCESSING = 0`) mode to avoid TPU contention among processes.
-def _test_correctness_helper(
+def _get_baseline_results(
     monkeypatch: pytest.MonkeyPatch,
     sampling_config: SamplingParams,
     model_name: str,
-    speculative_config: dict,
+    test_prompts: list,
     max_num_seqs: int = 4,
     async_scheduling: bool = False,
     enable_dp_attention: bool = False,
     extra_kwargs: dict | None = None,
 ):
     '''
-    Helper function to test ngram correctness.
-    Compare the outputs of a original LLM and a speculative LLM
-    should be the same when using ngram speculative decoding.
+    Generate reference outputs from a non-speculative LLM, to be compared
+    against the speculative LLM outputs in _test_correctness_helper. The caller
+    must pass the same test_prompts to both so the comparison lines up.
     '''
     with monkeypatch.context():
-        test_prompts = get_test_prompts(speculative_config)
-
         kwargs = {
             "max_model_len": 1024,
             "max_num_seqs": max_num_seqs,
@@ -137,6 +135,51 @@ def _test_correctness_helper(
 
         # Waiting for TPUs to be released.
         time.sleep(10)
+        return ref_outputs
+
+
+# TODO(pooyam): run vLLM engine with InProcClient (`VLLM_ENABLE_V1_MULTIPROCESSING = 0`) mode to avoid TPU contention among processes.
+def _test_correctness_helper(
+    monkeypatch: pytest.MonkeyPatch,
+    sampling_config: SamplingParams,
+    model_name: str,
+    speculative_config: dict,
+    test_prompts: list,
+    ref_outputs: list,
+    max_num_seqs: int = 4,
+    async_scheduling: bool = False,
+    enable_dp_attention: bool = False,
+    extra_kwargs: dict | None = None,
+):
+    '''
+    Helper function to test ngram correctness.
+    Compare the outputs of a original LLM and a speculative LLM
+    should be the same when using ngram speculative decoding.
+    '''
+    with monkeypatch.context():
+        kwargs = {
+            "max_model_len": 1024,
+            "max_num_seqs": max_num_seqs,
+            "tensor_parallel_size": _get_tensor_parallel_size(),
+            "model_loader_extra_config": {
+                "enable_weights_track": False
+            },
+            "async_scheduling": async_scheduling,
+        }
+        if enable_dp_attention:
+            os.environ["NEW_MODEL_DESIGN"] = "1"
+            kwargs["additional_config"] = {
+                "sharding": {
+                    "sharding_strategy": {
+                        "enable_dp_attention": True,
+                        "attn_dp_size": _get_tensor_parallel_size()
+                    }
+                }
+            }
+        else:
+            os.environ["NEW_MODEL_DESIGN"] = "0"
+        if extra_kwargs:
+            kwargs.update(extra_kwargs)
 
         spec_llm = LLM(model=model_name,
                        speculative_config=speculative_config,
@@ -172,13 +215,23 @@ def test_ngram_correctness_greedy(
     Compare the outputs of a original LLM and a speculative LLM
     should be the same when using ngram speculative decoding with greedy sampling.
     '''
-    _test_correctness_helper(
-        monkeypatch, sampling_config, model_name, {
-            "method": "ngram",
-            "prompt_lookup_max": 5,
-            "prompt_lookup_min": 3,
-            "num_speculative_tokens": 3,
-        })
+    speculative_config = {
+        "method": "ngram",
+        "prompt_lookup_max": 5,
+        "prompt_lookup_min": 3,
+        "num_speculative_tokens": 3,
+    }
+    test_prompts = get_test_prompts(speculative_config)
+
+    ref_outputs = _get_baseline_results(monkeypatch, sampling_config,
+                                        model_name, test_prompts)
+
+    _test_correctness_helper(monkeypatch,
+                             sampling_config,
+                             model_name,
+                             speculative_config,
+                             test_prompts,
+                             ref_outputs=ref_outputs)
 
 
 def test_ngram_correctness_random(
@@ -195,13 +248,23 @@ def test_ngram_correctness_random(
     sampling_config.top_p = 0.9
     sampling_config.top_k = 5
 
-    _test_correctness_helper(
-        monkeypatch, sampling_config, model_name, {
-            "method": "ngram",
-            "prompt_lookup_max": 5,
-            "prompt_lookup_min": 3,
-            "num_speculative_tokens": 3,
-        })
+    speculative_config = {
+        "method": "ngram",
+        "prompt_lookup_max": 5,
+        "prompt_lookup_min": 3,
+        "num_speculative_tokens": 3,
+    }
+    test_prompts = get_test_prompts(speculative_config)
+
+    ref_outputs = _get_baseline_results(monkeypatch, sampling_config,
+                                        model_name, test_prompts)
+
+    _test_correctness_helper(monkeypatch,
+                             sampling_config,
+                             model_name,
+                             speculative_config,
+                             test_prompts,
+                             ref_outputs=ref_outputs)
 
 
 def _test_performance_helper(
@@ -319,9 +382,40 @@ def test_ngram_performance_random(
                              min_acceptance_rate=0.85)
 
 
+@pytest.fixture(scope="module")
+def eagle3_baseline():
+    '''
+    Compute the eagle3 reference prompts and baseline outputs once and share
+    them across all parametrized test_eagle3_correctness cases. The baseline is
+    non-speculative and greedy, so its outputs are deterministic regardless of
+    async_scheduling or enable_dp_attention.
+
+    Note: mirrors the default `sampling_config` fixture; that fixture is
+    function-scoped (and mutated by other tests) so it can't be injected here.
+    '''
+    model_name = 'meta-llama/Meta-Llama-3-8B-Instruct'
+    sampling_config = SamplingParams(temperature=0,
+                                     max_tokens=32,
+                                     ignore_eos=True,
+                                     repetition_penalty=1,
+                                     frequency_penalty=0,
+                                     presence_penalty=0,
+                                     min_p=0,
+                                     logprobs=None)
+    test_prompts = get_eagle3_test_prompts()
+    with pytest.MonkeyPatch.context() as mp:
+        ref_outputs = _get_baseline_results(mp,
+                                            sampling_config,
+                                            model_name,
+                                            test_prompts,
+                                            max_num_seqs=10)
+    return test_prompts, ref_outputs
+
+
 @pytest.mark.parametrize(
     "async_scheduling, enable_dp_attention",
     [
+        (True, True),
         (False, False),
         (True, False),
         (False, True),
@@ -332,6 +426,7 @@ def test_eagle3_correctness(
     sampling_config: SamplingParams,
     async_scheduling: bool,
     enable_dp_attention: bool,
+    eagle3_baseline: tuple,
 ):
     '''
     Compare the outputs of a original LLM and a speculative LLM
@@ -342,28 +437,29 @@ def test_eagle3_correctness(
     model_impl = os.environ.get("MODEL_IMPL_TYPE", "auto")
     monkeypatch.setenv("DRAFT_MODEL_IMPL_TYPE", model_impl)
 
-    _test_correctness_helper(
-        monkeypatch,
-        sampling_config,
-        model_name, {
-            'model': "unkmaster/EAGLE3-LLaMA3.1-Instruct-8B",
-            "num_speculative_tokens": 3,
-            "method": "eagle3",
-            "draft_tensor_parallel_size": 1
-        },
-        max_num_seqs=10,
-        async_scheduling=async_scheduling,
-        enable_dp_attention=enable_dp_attention)
+    speculative_config = {
+        'model': "unkmaster/EAGLE3-LLaMA3.1-Instruct-8B",
+        "num_speculative_tokens": 3,
+        "method": "eagle3",
+        "draft_tensor_parallel_size": 1
+    }
+    test_prompts, ref_outputs = eagle3_baseline
+
+    _test_correctness_helper(monkeypatch,
+                             sampling_config,
+                             model_name,
+                             speculative_config,
+                             test_prompts,
+                             ref_outputs=ref_outputs,
+                             max_num_seqs=10,
+                             async_scheduling=async_scheduling,
+                             enable_dp_attention=enable_dp_attention)
 
 
 @pytest.mark.parametrize(
     "max_num_seqs,async_scheduling, enable_dp_attention",
-    [
-        (1, False, False),
-        (20, False, False),
-        (20, True, False),
-        (20, False, True),
-    ],
+    [(1, False, False), (20, False, False), (20, True, False),
+     (20, False, True), (20, True, True)],
 )
 def test_eagle3_performance(
     monkeypatch: pytest.MonkeyPatch,
@@ -395,11 +491,54 @@ def test_eagle3_performance(
         model_name='meta-llama/Llama-3.1-8B-Instruct')
 
 
+@pytest.fixture(scope="module")
+def mtp_baseline():
+    '''
+    Compute the mtp reference prompts, baseline outputs and the LLM extra_kwargs
+    once and share them across all parametrized test_mtp_correctness cases. The
+    baseline is non-speculative and greedy, so its outputs are deterministic
+    regardless of async_scheduling. extra_kwargs is returned so the spec LLM in
+    the test reuses the exact same config.
+
+    Note: mirrors the default `sampling_config` fixture; that fixture is
+    function-scoped (and mutated by other tests) so it can't be injected here.
+    '''
+    model_name = "Qwen/Qwen3.5-4B"
+    sampling_config = SamplingParams(temperature=0,
+                                     max_tokens=32,
+                                     ignore_eos=True,
+                                     repetition_penalty=1,
+                                     frequency_penalty=0,
+                                     presence_penalty=0,
+                                     min_p=0,
+                                     logprobs=None)
+    extra_kwargs = {
+        "seed": 42,
+        "max_model_len": 128,
+        "max_num_batched_tokens": 1024,
+        "enable_prefix_caching": False,
+        "kv_cache_dtype": "fp8",
+        "gpu_memory_utilization": 0.90,
+    }
+    test_prompts = get_eagle3_test_prompts()
+    with pytest.MonkeyPatch.context() as mp:
+        ref_outputs = _get_baseline_results(
+            mp,
+            sampling_config,
+            model_name,
+            test_prompts,
+            max_num_seqs=10,
+            extra_kwargs=extra_kwargs,
+        )
+    return test_prompts, ref_outputs, extra_kwargs
+
+
 @pytest.mark.parametrize("async_scheduling", [False])
 def test_mtp_correctness(
     monkeypatch: pytest.MonkeyPatch,
     sampling_config: SamplingParams,
     async_scheduling: bool,
+    mtp_baseline: tuple,
 ):
     '''
     Compare the outputs of an original LLM and a speculative LLM;
@@ -409,23 +548,19 @@ def test_mtp_correctness(
     monkeypatch.setenv("MODEL_IMPL_TYPE", "vllm")
     monkeypatch.setenv("DRAFT_MODEL_IMPL_TYPE", "vllm")
 
-    extra_kwargs = {
-        "seed": 42,
-        "max_model_len": 128,
-        "max_num_batched_tokens": 1024,
-        "enable_prefix_caching": False,
-        "kv_cache_dtype": "fp8",
-        "gpu_memory_utilization": 0.90,
+    speculative_config = {
+        "method": "mtp",
+        "num_speculative_tokens": 3,
     }
+    test_prompts, ref_outputs, extra_kwargs = mtp_baseline
 
     _test_correctness_helper(
         monkeypatch,
         sampling_config,
         model_name,
-        speculative_config={
-            "method": "mtp",
-            "num_speculative_tokens": 3,
-        },
+        speculative_config=speculative_config,
+        test_prompts=test_prompts,
+        ref_outputs=ref_outputs,
         max_num_seqs=10,
         async_scheduling=async_scheduling,
         extra_kwargs=extra_kwargs,

--- a/tests/runner/test_speculative_decoding_manager.py
+++ b/tests/runner/test_speculative_decoding_manager.py
@@ -281,6 +281,7 @@ class TestSpeculativeDecodingManager:
                 cu_num_scheduled_tokens[-1])
 
         req_indices_dp = {0: list(range(num_reqs))}
+        req_ids_dp = {0: [str(i) for i in range(num_reqs)]}
 
         # Act
         with patch(
@@ -290,6 +291,7 @@ class TestSpeculativeDecodingManager:
                 num_draft_tokens_dp=num_draft_tokens_padded,
                 dp_size=1,
                 req_indices_dp=req_indices_dp,
+                req_ids_dp=req_ids_dp,
                 query_start_loc=query_start_loc,
                 padded_num_reqs_per_dp_rank=padded_num_reqs,
                 padded_logits_length_dp_rank=padded_logits_length,

--- a/tests/runner/test_tpu_runner_dp.py
+++ b/tests/runner/test_tpu_runner_dp.py
@@ -915,10 +915,12 @@ class TestTPUJaxRunnerDPInputsLightweight:
         # Should return input_ids unchanged
         np.testing.assert_array_equal(result, input_ids)
 
+    @patch('jax.lax.with_sharding_constraint',
+           side_effect=lambda x, *args, **kwargs: x)
     @patch('tpu_inference.runner.tpu_runner.device_array',
            side_effect=lambda mesh, tensors, **kwargs: tensors)
     def test_apply_async_token_substitution_with_padding(
-            self, mock_device_array):
+            self, mock_device_array, mock_with_sharding_constraint):
         """Test _apply_async_token_substitution with padding."""
 
         # Bind the actual method

--- a/tpu_inference/runner/compilation_manager.py
+++ b/tpu_inference/runner/compilation_manager.py
@@ -334,7 +334,8 @@ class CompilationManager:
         indices_sharding = NamedSharding(self.runner.mesh, PartitionSpec(None))
 
         def _compile_one(input_padding: int, input_sharding: NamedSharding,
-                         next_tokens_size: int) -> None:
+                         next_tokens_size: int,
+                         next_tokens_sharding: NamedSharding) -> None:
             padded_token_in_tpu_cur_input_indices = np.zeros((input_padding, ),
                                                              dtype=np.int32)
             padded_token_in_tpu_pre_next_tokens_indices = np.zeros(
@@ -349,7 +350,7 @@ class CompilationManager:
             input_ids = self._create_dummy_tensor((input_padding, ), jnp.int32,
                                                   input_sharding)
             next_tokens = self._create_dummy_tensor(
-                (next_tokens_size, ), jnp.int32, sharding=replicated_sharding)
+                (next_tokens_size, ), jnp.int32, sharding=next_tokens_sharding)
             placeholder_num = device_array(self.runner.mesh,
                                            np.array([1], dtype=np.int32))
             self._run_compilation(
@@ -370,14 +371,16 @@ class CompilationManager:
             spec_next_tokens_size = self.runner.max_num_reqs * (
                 num_spec_tokens + 1)
             for num_tokens in self.runner.num_tokens_paddings:
-                _compile_one(num_tokens, dp_sharding, spec_next_tokens_size)
+                _compile_one(num_tokens, dp_sharding, spec_next_tokens_size,
+                             dp_sharding)
             for num_logits in self.runner.num_logits_paddings:
                 _compile_one(num_logits, replicated_sharding,
-                             spec_next_tokens_size)
+                             spec_next_tokens_size, dp_sharding)
         else:
             for num_tokens in self.runner.num_tokens_paddings:
                 for num_reqs in self.runner.num_reqs_paddings:
-                    _compile_one(num_tokens, dp_sharding, num_reqs)
+                    _compile_one(num_tokens, dp_sharding, num_reqs,
+                                 replicated_sharding)
 
     def _precompile_subtract_num_rejected_tokens(self) -> None:
         from tpu_inference.runner.tpu_runner import \
@@ -403,7 +406,7 @@ class CompilationManager:
                 positions = self._create_dummy_tensor((num_tokens, ),
                                                       jnp.int32, dp_sharding)
             num_rejected_tokens = self._create_dummy_tensor(
-                (self.runner.max_num_reqs, ), jnp.int32, replicated_sharding)
+                (self.runner.max_num_reqs, ), jnp.int32, dp_sharding)
             seq_lens_subtract_indices = self._create_dummy_tensor(
                 (self.runner.max_num_reqs, ), jnp.int32, replicated_sharding)
             positions_subtract_indices = self._create_dummy_tensor(
@@ -427,16 +430,17 @@ class CompilationManager:
         num_spec_tokens = (
             self.runner.speculative_config.num_speculative_tokens)
         max_num_reqs = self.runner.max_num_reqs
-        replicated_sharding = NamedSharding(self.runner.mesh, PartitionSpec())
+        data_sharding = NamedSharding(
+            self.runner.mesh, PartitionSpec(ShardingAxisName.ATTN_DATA))
 
         last_sampled_tokens = device_array(self.runner.mesh,
                                            jnp.ones((max_num_reqs, ),
                                                     dtype=jnp.int32),
-                                           sharding=replicated_sharding)
+                                           sharding=data_sharding)
         draft_tokens = device_array(self.runner.mesh,
                                     jnp.ones((max_num_reqs, num_spec_tokens),
                                              dtype=jnp.int32),
-                                    sharding=replicated_sharding)
+                                    sharding=data_sharding)
         self._run_compilation(
             f"worker{self.runner.rank} "
             "concat_last_sampled_tokens_and_draft_tokens",

--- a/tpu_inference/runner/speculative_decoding_manager.py
+++ b/tpu_inference/runner/speculative_decoding_manager.py
@@ -217,6 +217,7 @@ class SpeculativeDecodingManager:
         num_draft_tokens_dp: np.ndarray,
         dp_size: int,
         req_indices_dp: dict,
+        req_ids_dp: dict,
         query_start_loc: np.ndarray,
         padded_num_reqs_per_dp_rank: int,
         padded_logits_length_dp_rank: int,
@@ -323,4 +324,5 @@ class SpeculativeDecodingManager:
         )
         metadata.draft_lengths_cpu = padded_num_draft_tokens_cpu
         metadata.req_indices_dp = req_indices_dp
+        metadata.req_ids_dp = req_ids_dp
         return metadata

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -169,6 +169,7 @@ class AsyncPreResults:
     discard_sampled_tokens_req_indices: list[int]
     placeholder_req_id_to_index: dict[str, int]
     logits_indices_selector: Optional[List[int]] = None
+    scheduler_output: "VllmSchedulerOutput" = None
 
     # Only when spec decoding is enabled, the follow variables
     # are populated.
@@ -245,6 +246,7 @@ def _subtract_num_rejected_tokens_fn(seq_lens: jax.Array, positions: jax.Array,
     """Subtract the previous step's rejected-token counts from `seq_lens` and
     `positions`.
     """
+    assert positions.ndim == 1, "2d positions not supported by _subtract_num_rejected_tokens_fn yet."
     seq_valid = seq_lens_subtract_indices >= 0
     seq_subtract = jnp.where(seq_valid,
                              num_rejected_tokens[seq_lens_subtract_indices], 0)
@@ -866,6 +868,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         pre_discard_sampled_tokens_req_indices = self._pre_async_results.discard_sampled_tokens_req_indices
         pre_logits_indices_selector = self._pre_async_results.logits_indices_selector
         pre_spec_decode_metadata = self._pre_async_results.spec_decode_metadata
+        pre_scheduler_output = self._pre_async_results.scheduler_output
 
         valid_sampled_token_ids = runner_utils.host_extract_sampled_tokens(
             self, pre_spec_decode_metadata, pre_next_tokens,
@@ -889,9 +892,11 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
 
             # Updated on previous execute
             pre_num_placeholder_tokens = 1
-            if pre_spec_decode_metadata is not None:
-                pre_num_placeholder_tokens += pre_spec_decode_metadata.draft_lengths_cpu[
-                    pre_req_idx]
+            assert pre_scheduler_output is not None
+            pre_num_placeholder_tokens += len(
+                pre_scheduler_output.scheduled_spec_decode_tokens.get(
+                    req_id, []))
+
             end_idx = self.input_batch.num_tokens_no_spec[req_idx]
             num_sampled_tokens = len(sampled_ids)
             assert num_sampled_tokens <= pre_num_placeholder_tokens
@@ -912,11 +917,13 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                 req_state.output_token_ids.pop()
             req_state.output_token_ids.extend(sampled_ids)
 
-    def _update_placeholder(self,
-                            discard_sampled_tokens_req_indices,
-                            request_seq_lens,
-                            spec_decode_metadata,
-                            logits_indices_selector=None):
+    def _update_placeholder(
+            self,
+            discard_sampled_tokens_req_indices,
+            request_seq_lens,
+            scheduler_output: "VllmSchedulerOutput",
+            logits_indices_selector=None,
+            spec_decode_metadata: Optional[SpecDecodeMetadata] = None):
         placeholder_req_id_to_index: dict[str, int] = {}
         discard_sampled_tokens_req_indices_set = set(
             discard_sampled_tokens_req_indices)
@@ -926,8 +933,9 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
 
             start_idx = self.input_batch.num_tokens_no_spec[req_idx]
             end_idx = start_idx + 1
-            if spec_decode_metadata is not None:
-                end_idx += spec_decode_metadata.draft_lengths_cpu[req_idx]
+            if req_state.req_id in scheduler_output.scheduled_spec_decode_tokens:
+                end_idx += len(scheduler_output.scheduled_spec_decode_tokens[
+                    req_state.req_id])
             assert end_idx <= self.max_model_len, (
                 "Sampled token IDs exceed the max model length. "
                 f"Total number of tokens: {end_idx} > max_model_len: "
@@ -944,6 +952,15 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             else:
                 placeholder_req_id_to_index[
                     req_state.req_id] = logits_indices_selector[req_idx]
+
+        if spec_decode_metadata is not None:
+            placeholder_req_id_to_index.clear()
+            for rank in range(self.dp_size):
+                for i, req_id in enumerate(
+                        spec_decode_metadata.req_ids_dp[rank]):
+                    placeholder_req_id_to_index[req_id] = i + rank * (
+                        self.max_num_reqs // self.dp_size)
+
         return placeholder_req_id_to_index
 
     def _execute_model(
@@ -1277,7 +1294,8 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             placeholder_req_id_to_index: dict[
                 str, int] = self._update_placeholder(
                     discard_sampled_tokens_req_indices, request_seq_lens,
-                    spec_decode_metadata, logits_indices_selector)
+                    scheduler_output, logits_indices_selector,
+                    spec_decode_metadata)
 
             spec_decode_next_tokens = None
             if self.speculative_config:
@@ -1297,6 +1315,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                 discard_sampled_tokens_req_indices,
                 placeholder_req_id_to_index=placeholder_req_id_to_index,
                 logits_indices_selector=logits_indices_selector,
+                scheduler_output=scheduler_output,
                 spec_decode_next_tokens=spec_decode_next_tokens,
                 spec_decode_num_rejected_tokens=spec_decode_num_rejected_tokens,
                 spec_decode_metadata=spec_decode_metadata,
@@ -1595,7 +1614,6 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
 
             token_offset = padded_num_scheduled_tokens_per_dp_rank * dp_rank
             acc_cur_len = token_offset
-            # TODO(gxd3): support spec-decoding with DP.
 
             for i, req_id in enumerate(req_ids_dp[dp_rank]):
                 acc_cur_len += num_scheduled_tokens_per_req[i]
@@ -1660,8 +1678,8 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                 next_tokens_in_tpu, placeholder_num)
         return input
 
-    def _subtract_num_rejected_tokens(self, seq_lens, positions,
-                                      num_scheduled_tokens_per_req):
+    def _subtract_num_rejected_tokens(self, seq_lens, positions, req_ids_dp,
+                                      scheduled_tokens_per_dp_rank):
         """Apply rejection-count subtraction to seq_lens and positions if needed.
 
         `num_computed_tokens_cpu` was advanced on the host assuming every
@@ -1671,7 +1689,6 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         """
         assert self._pre_async_results is not None
         assert self._pre_async_results.spec_decode_num_rejected_tokens is not None
-        num_reqs = len(num_scheduled_tokens_per_req)
         seq_lens_subtract_indices = np.full(self.max_num_reqs,
                                             -1,
                                             dtype=np.int32)
@@ -1679,17 +1696,23 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                                              -1,
                                              dtype=np.int32)
 
-        acc_cur_len = 0
-        for i, req_id in enumerate(self.input_batch.req_ids[:num_reqs]):
-            acc_cur_len += num_scheduled_tokens_per_req[i]
-            assert req_id is not None
-            if req_id not in self._pre_async_results.placeholder_req_id_to_index:
-                continue
-            idx = self._pre_async_results.placeholder_req_id_to_index[req_id]
-            seq_lens_subtract_indices[i] = idx
-            base_offset = acc_cur_len - num_scheduled_tokens_per_req[i]
-            for j in range(num_scheduled_tokens_per_req[i]):
-                positions_subtract_indices[base_offset + j] = idx
+        for rank in range(self.dp_size):
+            acc_cur_len = 0
+            scheduled_tokens_cur_rank = scheduled_tokens_per_dp_rank[rank]
+            for i, req_id in enumerate(req_ids_dp[rank]):
+                acc_cur_len += scheduled_tokens_cur_rank[i]
+                if req_id not in self._pre_async_results.placeholder_req_id_to_index:
+                    continue
+
+                idx = self._pre_async_results.placeholder_req_id_to_index[
+                    req_id]
+                seq_lens_subtract_indices[
+                    i + rank * (self.max_num_reqs // self.dp_size)] = idx
+                base_offset = acc_cur_len - scheduled_tokens_cur_rank[i]
+                for j in range(scheduled_tokens_cur_rank[i]):
+                    positions_subtract_indices[
+                        base_offset + j + rank *
+                        (positions.size // self.dp_size)] = idx
 
         seq_lens_subtract_indices, positions_subtract_indices = device_array(
             self.mesh, (seq_lens_subtract_indices, positions_subtract_indices))
@@ -1699,7 +1722,6 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                 seq_lens, positions,
                 self._pre_async_results.spec_decode_num_rejected_tokens,
                 seq_lens_subtract_indices, positions_subtract_indices)
-
         return seq_lens, positions
 
     def _prepare_inputs(self, scheduler_output: "VllmSchedulerOutput"):
@@ -1709,9 +1731,6 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         assert num_reqs > 0
 
         dp_size = self.dp_size
-        if self.speculative_config and dp_size > 1 and self.scheduler_config.async_scheduling:
-            assert "Spec decoding + async scheduling not yet support when dp > 1"
-
         data_parallel_attn_sharding = NamedSharding(
             self.mesh, PartitionSpec(ShardingAxisName.ATTN_DATA))
 
@@ -1913,6 +1932,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                     num_draft_tokens_dp=num_draft_tokens,
                     dp_size=dp_size,
                     req_indices_dp=req_indices_dp,
+                    req_ids_dp=req_ids_dp,
                     query_start_loc=query_start_loc_view,
                     padded_num_reqs_per_dp_rank=padded_num_reqs_per_dp_rank,
                     padded_logits_length_dp_rank=(logits_indices_shape[0] //
@@ -2023,7 +2043,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         # actual rejection counts from `seq_lens` and `positions` on TPU.
         if self.speculative_config and self.scheduler_config.async_scheduling and self._pre_async_results is not None:
             seq_lens, positions = self._subtract_num_rejected_tokens(
-                seq_lens, positions, scheduled_tokens_per_dp_rank[0])
+                seq_lens, positions, req_ids_dp, scheduled_tokens_per_dp_rank)
 
         def build_attn(block_tables: jax.Array | None) -> AttentionMetadata:
             attention_metadata_gid = AttentionMetadata(

--- a/tpu_inference/runner/utils.py
+++ b/tpu_inference/runner/utils.py
@@ -849,7 +849,7 @@ class PhasedBasedProfiler:
         "final_logits_indices",
     ],
     meta_fields=[],
-    drop_fields=["draft_lengths_cpu", "req_indices_dp"],
+    drop_fields=["draft_lengths_cpu", "req_indices_dp", "req_ids_dp"],
 )
 @dataclass
 class SpecDecodeMetadata:
@@ -861,6 +861,7 @@ class SpecDecodeMetadata:
 
     draft_lengths_cpu: Any = field(init=False, default=None)
     req_indices_dp: dict = field(init=False, default_factory=dict)
+    req_ids_dp: dict = field(init=False, default_factory=dict)
 
 
 def host_extract_sampled_tokens(

--- a/tpu_inference/spec_decode/jax/eagle3.py
+++ b/tpu_inference/spec_decode/jax/eagle3.py
@@ -246,12 +246,15 @@ class Eagle3Proposer:
                     query_start_loc, new_block_tables)
 
         data_spec = PartitionSpec(ShardingAxisName.ATTN_DATA)
+        positions_spec = (PartitionSpec(None, ShardingAxisName.ATTN_DATA)
+                          if positions.ndim == 2 else data_spec)
         (positions, clamped_positions, new_seq_lens, query_start_loc,
          new_block_tables) = jax.shard_map(
              _sharded_update_inputs_for_loop_speculation,
              mesh=self.mesh,
-             in_specs=(data_spec, data_spec, data_spec),
-             out_specs=(data_spec, data_spec, data_spec, data_spec, data_spec),
+             in_specs=(positions_spec, data_spec, data_spec),
+             out_specs=(positions_spec, positions_spec, data_spec, data_spec,
+                        data_spec),
          )(positions, seq_lens, block_tables)
         return positions, clamped_positions, new_seq_lens, query_start_loc, new_block_tables
 


### PR DESCRIPTION
[Spec decoding] Make Spec decoding + attn-dp + async scheduling compatible

Added E2E test for  Spec decoding + attn-dp + async scheduling  combination

Also optimize the `test_eagle3_correctness` and `test_mtp_correctness` to generate the reference output (run the LLM without spec decoding) once instead of once per parameterized test case, to make the test run faster.

