### PR TITLE
[Feature] JaxLayerNorm

### DIFF
--- a/tests/layers/jax/test_norm.py
+++ b/tests/layers/jax/test_norm.py
@@ -108,14 +108,12 @@ class TestJaxLayerNorm:
             num_features=16,
             rngs=rngs,
         )
-        # 1. 'scale' attribute should NOT exist directly in __dict__
         assert "scale" not in jax_ln.__dict__
-        # 2. 'weight' attribute should exist and be an nnx.Param
         assert "weight" in jax_ln.__dict__
         assert isinstance(jax_ln.weight, nnx.Param)
-        # 3. Accessing .scale should fall back to returning .weight via __getattr__
         assert jax_ln.scale is jax_ln.weight
-        # 4. Check named_parameters yields 'weight' and NOT 'scale'
+
         named_params = dict(jax_ln.named_parameters())
+
         assert "weight" in named_params
         assert "scale" not in named_params

--- a/tests/layers/jax/test_norm.py
+++ b/tests/layers/jax/test_norm.py
@@ -18,7 +18,7 @@ from flax import nnx
 from jax.sharding import Mesh
 from vllm.config import ModelConfig, VllmConfig
 
-from tpu_inference.layers.jax.norm import JaxRmsNorm
+from tpu_inference.layers.jax.norm import JaxLayerNorm, JaxRmsNorm
 from tpu_inference.layers.vllm.quantization import get_tpu_quantization_config
 
 
@@ -63,3 +63,59 @@ class TestJaxRmsNorm:
                                   flax_output,
                                   rtol=1e-5,
                                   atol=1e-5)
+
+
+class TestJaxLayerNorm:
+    """Test for JaxLayerNorm layer."""
+
+    @pytest.mark.parametrize(
+        "rng_key",
+        [jax.random.PRNGKey(0), jax.random.PRNGKey(1)])
+    @pytest.mark.parametrize("num_features", [16, 32, 64])
+    @pytest.mark.parametrize(
+        "dtype", [jax.numpy.float32, jax.numpy.float16, jax.numpy.bfloat16])
+    def test_numerical_correctness_against_flax(self, rng_key, num_features,
+                                                dtype):
+        """Run the same input through JaxLayerNorm vs. flax LayerNorm and compare outputs.
+        """
+        kwargs = {
+            "num_features": num_features,
+            "epsilon": 1e-6,
+            "dtype": dtype,
+            "param_dtype": dtype,
+            "rngs": nnx.Rngs(0)
+        }
+        layer = JaxLayerNorm(**kwargs)
+        layer.weight[...] = jax.random.uniform(rng_key, (num_features, ),
+                                               dtype=dtype)
+        layer.bias[...] = jax.random.uniform(rng_key, (num_features, ),
+                                             dtype=dtype)
+        flax_layer = nnx.LayerNorm(**kwargs)
+        flax_layer.scale[...] = layer.weight[...]
+        flax_layer.bias[...] = layer.bias[...]
+        x = jax.random.uniform(rng_key, (2, 8, num_features), dtype=dtype)
+        jax_output = layer(x)
+        flax_output = flax_layer(x)
+        assert jax.numpy.allclose(jax_output,
+                                  flax_output,
+                                  rtol=1e-5,
+                                  atol=1e-5)
+
+    def test_parameter_aliasing(self):
+        """Verifies weight aliasing, scale deletion, and named_parameters matching."""
+        rngs = nnx.Rngs(0)
+        jax_ln = JaxLayerNorm(
+            num_features=16,
+            rngs=rngs,
+        )
+        # 1. 'scale' attribute should NOT exist directly in __dict__
+        assert "scale" not in jax_ln.__dict__
+        # 2. 'weight' attribute should exist and be an nnx.Param
+        assert "weight" in jax_ln.__dict__
+        assert isinstance(jax_ln.weight, nnx.Param)
+        # 3. Accessing .scale should fall back to returning .weight via __getattr__
+        assert jax_ln.scale is jax_ln.weight
+        # 4. Check named_parameters yields 'weight' and NOT 'scale'
+        named_params = dict(jax_ln.named_parameters())
+        assert "weight" in named_params
+        assert "scale" not in named_params

--- a/tpu_inference/layers/jax/norm.py
+++ b/tpu_inference/layers/jax/norm.py
@@ -63,3 +63,24 @@ class JaxRmsNorm(nnx.RMSNorm, JaxModule):
         if self.quant_method is None:
             return nnx.RMSNorm.__call__(self, x, mask=mask)
         return self.quant_method.apply_jax(self, x, mask=mask)
+
+
+class JaxLayerNorm(nnx.LayerNorm, JaxModule):
+    """LayerNorm layer that inherits from JaxModule and maps scale to weight for compatibility."""
+
+    def __init__(self, *args, **kwargs):
+        # nnx.LayerNorm uses `param_dtype` for parameter initialization dtype.
+        # Accept `dtype` as an alias for backward compatibility.
+        if "dtype" in kwargs and "param_dtype" not in kwargs:
+            kwargs["param_dtype"] = kwargs.pop("dtype")
+        nnx.LayerNorm.__init__(self, *args, **kwargs)
+
+        # For compatibility, alias scale to weight
+        self.weight = self.scale
+        delattr(self, 'scale')
+
+    def __getattr__(self, name: str):
+        if name == "scale":
+            return self.weight
+        raise AttributeError(
+            f"'{self.__class__.__name__}' object has no attribute '{name}'")


### PR DESCRIPTION
# Description

This PR adds the `JaxLayerNorm` layer and its unit tests.

Flax calls the normalization scaling parameter `scale`, but PyTorch/HuggingFace checkpoints call it `weight`. This PR adds `JaxLayerNorm` inside `norm.py` to map `scale` to `weight`.

Files added/modified:
- `tpu_inference/layers/jax/norm.py`
- `tests/layers/jax/test_norm.py`


FIXES: #1330

# Tests

Tested using newly defined unit tests.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
