### PR TITLE
[Doc] Fix 404 links in custom JAX model onboarding guide

### DIFF
--- a/docs/getting_started/out-of-tree.md
+++ b/docs/getting_started/out-of-tree.md
@@ -46,7 +46,7 @@ def __call__(
     …
 ```
 
-For reference, check out [our Llama implementation](https://github.com/vllm-project/tpu-inference/blob/aad6cc2a36a2cf0de681f76055ce632d5abeca5f/tpu_inference/models/jax/llama3.py).
+For reference, check out [our Llama implementation](https://github.com/vllm-project/tpu-inference/blob/main/tpu_inference/models/jax/llama3.py).
 
 ## 3. Implement the weight loading logic
 
@@ -54,7 +54,7 @@ You now need to implement the `load_weights` method in your `*ForCausalLM` class
 
 ## 4. Register your model
 
-TPU Inference relies on a model registry to determine how to run each model. A list of pre-registered architectures can be found [here](https://github.com/vllm-project/tpu-inference/blob/aad6cc2a36a2cf0de681f76055ce632d5abeca5f/tpu_inference/models/jax/model_loader.py#L22).
+TPU Inference relies on a model registry to determine how to run each model. A list of pre-registered architectures can be found [here](https://github.com/vllm-project/tpu-inference/blob/main/tpu_inference/models/common/model_loader.py).
 
 If your model is not on this list, you must register it to TPU Inference. You can load an external model using a plugin (similar to [vLLM’s plugins](https://docs.vllm.ai/en/latest/contributing/model/registration.html)) without modifying the TPU Inference codebase.
 


### PR DESCRIPTION
# Description

Two reference links in the custom JAX model onboarding guide
(`docs/getting_started/out-of-tree.md`) pointed to a pinned commit
(`aad6cc2a…`) that no longer resolves, so both returned **404**:

- *"our Llama implementation"* → updated to `blob/main/tpu_inference/models/jax/llama3.py` (the file still exists on `main`).
- *"pre-registered architectures"* → the model registry moved, so this now points to `blob/main/tpu_inference/models/common/model_loader.py` (which contains `_MODEL_REGISTRY`). The guide itself already imports `register_model` from `tpu_inference.models.common.model_loader`, and `developer_guides/jax_model_development.md` links to the same path. Dropped the stale `#L22` line anchor so the link won't rot again.

FIXES: #2451

# Tests

Documentation-only change. Verified link reachability:

- new `…/blob/main/tpu_inference/models/jax/llama3.py` → 200
- new `…/blob/main/tpu_inference/models/common/model_loader.py` → 200
- old pinned-SHA links → 404

`pre-commit run pymarkdown` passes on the edited file.

# Checklist

- [x] I have performed a self-review of my code.
- [x] N/A — documentation-only change (no code comments needed).
- [x] This PR *is* the corresponding documentation change.
