### PR TITLE
Refactor torchax path to use reparametrize helper

### DIFF
--- a/tests/layers/vllm/process_weights/test_cleanup_sharding.py
+++ b/tests/layers/vllm/process_weights/test_cleanup_sharding.py
@@ -14,10 +14,13 @@
 
 from unittest.mock import MagicMock, patch
 
+import jax
+import jax.sharding
 import torch
+import torchax
 
-from tpu_inference.layers.vllm.process_weights.cleanup_sharding import \
-    shard_model_to_tpu
+from tpu_inference.layers.vllm.process_weights.cleanup_sharding import (
+    reparametrize, shard_model_to_tpu)
 
 
 def test_shard_model_to_tpu_simplification():
@@ -32,51 +35,66 @@ def test_shard_model_to_tpu_simplification():
     model = DummyModel()
     dummy_mesh = MagicMock()
 
+    PREFIX = "tpu_inference.layers.vllm.process_weights.cleanup_sharding"
     # Mock jax device calls to prevent TPU multi-host initialization hangs
     with (
-            patch(
-                "tpu_inference.layers.vllm.process_weights.cleanup_sharding.jax.devices"
-            ) as mock_jax_devices,
-            patch(
-                "tpu_inference.layers.vllm.process_weights.cleanup_sharding.jax.default_device"
-            ),
+            patch(PREFIX + ".jax.devices") as mock_jax_devices,
+            patch(PREFIX + ".jax.default_device"),
+            patch(PREFIX + "._shard_module_to_tpu") as mock_shard_module,
+            patch(PREFIX + "._tensor_is_in_cpu") as mock_is_cpu,
+            patch(PREFIX + "._shard_tensor_to_tpu_replicated") as
+            mock_shard_replicated,
     ):
         mock_jax_devices.return_value = ["mock_cpu_device"]
 
-        # Mock the internal functions that do the actual sharding/device checks
-        with patch(
-                "tpu_inference.layers.vllm.process_weights.cleanup_sharding._shard_module_to_tpu"
-        ) as mock_shard_module:
-            with patch(
-                    "tpu_inference.layers.vllm.process_weights.cleanup_sharding._tensor_is_in_cpu"
-            ) as mock_is_cpu:
-                with patch(
-                        "tpu_inference.layers.vllm.process_weights.cleanup_sharding._shard_tensor_to_tpu_replicated"
-                ) as mock_shard_replicated:
-                    # Pretend the parameter is on CPU (needs sharding) but buffer is not
-                    def mock_is_in_cpu_side_effect(tensor):
-                        return tensor is model.weight
+        # Pretend the parameter is on CPU (needs sharding) but buffer is not
+        def mock_is_in_cpu_side_effect(tensor):
+            return tensor is model.weight
 
-                    mock_is_cpu.side_effect = mock_is_in_cpu_side_effect
+        mock_is_cpu.side_effect = mock_is_in_cpu_side_effect
 
-                    # Pretend sharded tensor returns a special string
-                    mock_shard_replicated.return_value = "sharded_tensor"
+        # Pretend sharded tensor returns a special string
+        mock_shard_replicated.return_value = "sharded_tensor"
 
-                    result = shard_model_to_tpu(model, dummy_mesh)
+        result = shard_model_to_tpu(model, dummy_mesh)
 
-                    # Check that special sharding was called for any LoRA/custom layers
-                    mock_shard_module.assert_called_once_with(
-                        model, dummy_mesh)
+        # Check that special sharding was called for any LoRA/custom layers
+        mock_shard_module.assert_called_once_with(model, dummy_mesh)
 
-                    # Verify exactly the expected dictionary keys
-                    assert set(result.keys()) == {"weight", "my_buffer"}
+        # Verify exactly the expected dictionary keys
+        assert set(result.keys()) == {"weight", "my_buffer"}
 
-                    # Verify the parameter was sharded (because is_in_cpu returned True)
-                    assert result["weight"] == "sharded_tensor"
+        # Verify the parameter was sharded (because is_in_cpu returned True)
+        assert result["weight"] == "sharded_tensor"
 
-                    # Verify the buffer passed straight through (because is_in_cpu returned False)
-                    assert result["my_buffer"] is model.my_buffer
+        # Verify the buffer passed straight through (because is_in_cpu returned False)
+        assert result["my_buffer"] is model.my_buffer
 
-                    # Verify _shard_tensor_to_tpu_replicated was only called once
-                    mock_shard_replicated.assert_called_once_with(
-                        model.weight, dummy_mesh)
+        # Verify _shard_tensor_to_tpu_replicated was only called once
+        mock_shard_replicated.assert_called_once_with(model.weight, dummy_mesh)
+
+
+def test_extract_and_reparametrize():
+
+    class DummyModel(torch.nn.Module):
+
+        def __init__(self, param: int):
+            super().__init__()
+            self.some_param = torch.nn.Parameter(torch.tensor(param))
+            self.tied_param = self.some_param
+            self.some_buffer = torch.nn.Buffer(torch.tensor(1.))
+
+        def forward(self, val: torch.Tensor) -> torch.Tensor:
+            """Return val * param + 1"""
+            return val * self.tied_param + self.some_buffer
+
+    mesh = jax.sharding.Mesh(jax.devices(), axis_names=("x", ))
+    model_foo = DummyModel(param=3.)
+    model_bar = DummyModel(param=5.)
+
+    params_and_buffers = shard_model_to_tpu(model_foo, mesh)
+
+    with (torchax.default_env(), reparametrize(model_bar, params_and_buffers)):
+        # 7 = 2 * 3 + 1
+        out = model_bar(torch.tensor(2.))
+        assert torch.allclose(torch.tensor(7.), out)

--- a/tpu_inference/layers/vllm/process_weights/cleanup_sharding.py
+++ b/tpu_inference/layers/vllm/process_weights/cleanup_sharding.py
@@ -12,10 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import contextlib
+
 import jax
 import torch
 import torchax
 from jax.sharding import Mesh, NamedSharding, PartitionSpec
+from torch.nn.utils import stateless as torch_stateless
 from torch.utils import _pytree as pytree
 from torchax.interop import jax_view, torch_view
 from vllm import envs as vllm_envs
@@ -39,8 +42,32 @@ P = PartitionSpec
 logger = init_logger(__name__)
 
 
-def shard_model_to_tpu(model: torch.nn.Module,
-                       mesh: Mesh) -> dict[str, torchax.torch.Tensor]:
+@contextlib.contextmanager
+def reparametrize(
+    model: torch.nn.Module,
+    params_and_buffers: dict[str, torch.Tensor],
+):
+    """Temporary replace the parameters and buffers for the give model."""
+    # While we are using a "private" interface _reparametrize_module here,
+    # it's quite stable since the first introduction from 2021.
+    # See: https://github.com/pytorch/pytorch/pull/61447
+
+    # Note: Coupled with the implementation of shard_model_to_tpu.
+    # The tie_weights need to be True, since we are using the interfaces,
+    # named_parameters and named_buffers, and the linked parameter/buffer
+    # is not included in the extracted tensors.
+    with torch_stateless._reparametrize_module(
+            model,
+            params_and_buffers,
+            tie_weights=True,
+    ):
+        yield
+
+
+def shard_model_to_tpu(
+    model: torch.nn.Module,
+    mesh: Mesh,
+) -> dict[str, torch.Tensor]:
     """
     Shard the model weights and move them to TPU.
     At the same time, also turn the weight tensors into torchax tensors so that
@@ -81,6 +108,7 @@ def update_lora(model: torch.nn.Module,
 
 
 def _extract_all_params_buffers(model: torch.nn.Module):
+    # Note: Coupled with reparametrize context manger.
     return dict(model.named_parameters()), dict(model.named_buffers())
 
 

--- a/tpu_inference/models/common/model_loader.py
+++ b/tpu_inference/models/common/model_loader.py
@@ -553,14 +553,14 @@ def get_vllm_model(
 
     multimodal_fns = MultiModalInterface(
         precompile_vision_encoder_fn=getattr(
-            model.model.vllm_model,
+            model.model,
             "precompile_vision_encoder",
             model.wrap_precompile_vision_encoder_fn(params),
         ),
         embed_multimodal_fn=model.wrap_embed_multimodal_func(),
         embed_input_ids_fn=model.wrap_embed_input_ids_func(),
         get_mrope_input_positions_fn=getattr(
-            model.model.vllm_model,
+            model.model,
             "get_mrope_input_positions",
             None,
         ),

--- a/tpu_inference/models/vllm/experimental/model_patcher.py
+++ b/tpu_inference/models/vllm/experimental/model_patcher.py
@@ -22,9 +22,10 @@ the rest of the model in eager mode.
 
 import functools
 import importlib
-from typing import TYPE_CHECKING, Sequence
+from typing import Sequence
 
 import jax
+import torch
 import torchax
 from torchax.interop import JittableModule, torch_view
 
@@ -35,19 +36,16 @@ from tpu_inference.models.vllm.experimental.qwen3_omni_patcher import \
 from tpu_inference.models.vllm.experimental.qwen3_vl_patcher import \
     maybe_apply_qwen3_vl_patches
 
-if TYPE_CHECKING:
-    from tpu_inference.models.vllm.vllm_model_wrapper import _VllmRunner
-
 logger = init_logger(__name__)
 
 
 def patch_mm_model(
-    model: "_VllmRunner",
+    model: torch.nn.Module,
     params_and_buffers: dict[str, torchax.torch.Tensor],
     *,
     jitted_mm_module_keys: Sequence[str],
     register_mm_module_custom_pytree_classes: Sequence[str],
-) -> tuple["_VllmRunner", dict[str, torchax.torch.Tensor]]:
+) -> tuple[torch.nn.Module, dict[str, torchax.torch.Tensor]]:
     """Jit some modules in the multimodal.
 
     We add a wrapper to change the submodule call,
@@ -157,7 +155,7 @@ def patch_mm_model(
         # module_key expect to be start with model
         # eg. "model.vision_tower.encoder" -> "vllm_model.vision_tower.encoder"
 
-        cur_module = model.vllm_model
+        cur_module = model
         module_names = module_key.split('.')
         if len(module_names) <= 1:
             raise ValueError(

--- a/tpu_inference/models/vllm/vllm_model_wrapper.py
+++ b/tpu_inference/models/vllm/vllm_model_wrapper.py
@@ -36,7 +36,9 @@ from vllm.lora.layers import BaseLayerWithLoRA
 from vllm.model_executor.layers.pooler import Pooler
 from vllm.model_executor.model_loader import get_model as vllm_get_model
 from vllm.model_executor.models import supports_lora, supports_multimodal
-from vllm.model_executor.models.interfaces_base import is_pooling_model
+from vllm.model_executor.models.interfaces import SupportsMultiModal
+from vllm.model_executor.models.interfaces_base import (
+    VllmModelForPooling, VllmModelForTextGeneration, is_pooling_model)
 from vllm.platforms import current_platform
 from vllm.v1.outputs import PoolerOutput
 from vllm.v1.pool.metadata import PoolingMetadata
@@ -48,8 +50,8 @@ from tpu_inference.distributed.jax_parallel_state import \
     get_pp_group as jax_get_pp_group
 from tpu_inference.layers.common.attention_metadata import AttentionMetadata
 from tpu_inference.layers.common.sharding import ShardingAxisName
-from tpu_inference.layers.vllm.process_weights.cleanup_sharding import \
-    shard_model_to_tpu
+from tpu_inference.layers.vllm.process_weights.cleanup_sharding import (
+    reparametrize, shard_model_to_tpu)
 from tpu_inference.layers.vllm.quantization import get_tpu_quantization_config
 from tpu_inference.logger import init_logger
 from tpu_inference.lora.lora_manager import (TPULRUCacheWorkerLoRAManager,
@@ -167,31 +169,18 @@ def _disable_ds_v4_mtp_buffer(vllm_config: VllmConfig,
         inner._mtp_hidden_buffer = _NoOpBuffer()
 
 
-class _VllmRunner(torch.nn.Module):
-
-    def __init__(self, vllm_model: torch.nn.Module):
-        super().__init__()
-        self.vllm_model = vllm_model
-        has_pooler = is_pooling_model(vllm_model)
-        self.pooler = vllm_model.pooler if has_pooler else None
-
-    def forward(self, **kwargs) -> torch.Tensor:
-        if "hidden_state" in kwargs:
-            return self.compute_logits(kwargs["hidden_state"])
-        elif "call_method" in kwargs:
-            method_name = kwargs["call_method"]
-            call_args = kwargs.get("call_args", tuple())
-            call_kwargs = kwargs.get("call_kwargs", {})
-            method = getattr(self.vllm_model, method_name)
-            return method(*call_args, **call_kwargs)
-        else:
-            return self.compute_hidden_state(kwargs)
-
-    def compute_hidden_state(self, kwargs: dict) -> torch.Tensor:
-        return self.vllm_model(**kwargs)
-
-    def compute_logits(self, hidden_state: torch.Tensor) -> torch.Tensor:
-        return self.vllm_model.compute_logits(hidden_state)
+class _MetaModel(
+        torch.nn.Module,
+        VllmModelForTextGeneration,
+        VllmModelForPooling,
+        SupportsMultiModal,
+):
+    """An abstract interface for we to have better developer experience."""
+    # It's used during working on vLLM models in our VllmModelWrapper.
+    # The model object in runtime may or may not implement all the interfaces
+    # here, but at least we can have better readability, and have better support
+    # in IDE like auto-complete and go-definition ... etc.
+    # If we find some interface is good for developer experience, add it here.
 
 
 class VllmModelWrapper:
@@ -199,7 +188,7 @@ class VllmModelWrapper:
 
     rng: PRNGKey
     mesh: Mesh
-    model: _VllmRunner
+    model: _MetaModel
 
     def __init__(self,
                  vllm_config: VllmConfig,
@@ -345,10 +334,11 @@ class VllmModelWrapper:
             set_eagle3_aux_hidden_state_layers(
                 vllm_model, self.vllm_config.speculative_config)
 
-        self.model = _VllmRunner(vllm_model)
+        self.model = vllm_model
         params_and_buffers = shard_model_to_tpu(self.model, self.mesh)
 
-        self._pooler: Pooler | None = self.model.pooler
+        has_pooler = is_pooling_model(vllm_model)
+        self._pooler: Pooler | None = self.model.pooler if has_pooler else None
 
         if self.vllm_config.model_config.is_multimodal_model:
             # NOTE: It patch mm models to be JITtable within some submodule.
@@ -364,7 +354,7 @@ class VllmModelWrapper:
             )
 
         # NOTE: Apply Qwen3-VL model specific patches
-        apply_model_specific_patches(self.model.vllm_model)
+        apply_model_specific_patches(self.model)
 
         loading_end = time.time()
         total_loading_time = loading_end - loading_start
@@ -442,17 +432,13 @@ class VllmModelWrapper:
                     self.model, lora_metadata, self.vllm_config.lora_config)
                 if not is_first_rank:
                     intermediate_tensors = intermediate_tensors.to_torch()
-                output_from_torch = torch.func.functional_call(
-                    self.model,
-                    torch_view(params_and_buffers),
-                    kwargs={
-                        "input_ids": torch_view(input_ids),
-                        "positions": torch_view(input_positions),
-                        "intermediate_tensors": intermediate_tensors,
-                        "inputs_embeds": torch_view(input_embeds),
-                    },
-                    tie_weights=False,
-                )
+                with reparametrize(self.model, torch_view(params_and_buffers)):
+                    output_from_torch = self.model(
+                        input_ids=torch_view(input_ids),
+                        positions=torch_view(input_positions),
+                        intermediate_tensors=intermediate_tensors,
+                        inputs_embeds=torch_view(input_embeds),
+                    )
                 replace_lora_metadata(self.model, original_lora_metadata,
                                       self.vllm_config.lora_config)
                 vllm_model_wrapper_context = get_vllm_model_wrapper_context()
@@ -516,12 +502,8 @@ class VllmModelWrapper:
                 if self.vllm_config.speculative_config.method == "mtp":
                     kwargs["spec_step_idx"] = spec_step_idx
 
-                output_from_torch = torch.func.functional_call(
-                    self.model,
-                    torch_view(params_and_buffers),
-                    kwargs=kwargs,
-                    tie_weights=False,
-                )
+                with reparametrize(self.model, torch_view(params_and_buffers)):
+                    output_from_torch = self.model(**kwargs)
                 vllm_model_wrapper_context = get_vllm_model_wrapper_context()
                 new_kv_caches = vllm_model_wrapper_context.kv_caches
 
@@ -543,8 +525,7 @@ class VllmModelWrapper:
             return None
         embed_multimodal_fn = self.wrap_embed_multimodal_func()
         return maybe_precompile_vision_encoder_fn(params, embed_multimodal_fn,
-                                                  self.model.vllm_model,
-                                                  self.vllm_config)
+                                                  self.model, self.vllm_config)
 
     def wrap_embed_multimodal_func(self):
         if not self.vllm_config.model_config.is_multimodal_model:
@@ -559,16 +540,9 @@ class VllmModelWrapper:
                 for k, v in kwargs.items()
             }
 
-            output_from_torch = torch.func.functional_call(
-                self.model,
-                torch_view(params_and_buffers),
-                kwargs={
-                    "call_method": "embed_multimodal",
-                    "call_args": (),
-                    "call_kwargs": call_kwargs,
-                },
-                tie_weights=False,
-            )
+            with reparametrize(self.model, torch_view(params_and_buffers)):
+                output_from_torch = self.model.embed_multimodal(
+                    **call_kwargs, )
 
             return jax_view(output_from_torch)
 
@@ -578,7 +552,7 @@ class VllmModelWrapper:
             # Here we move_to_jax, then call (maybe jit'ed) embed_multimodal_func_jax.
             with torchax.default_env(), enable_torch_wrap(False):
 
-                kwargs = maybe_prepare_for_jit(kwargs, self.model.vllm_model)
+                kwargs = maybe_prepare_for_jit(kwargs, self.model)
 
                 def move(v: torch.Tensor) -> torch.Tensor:
                     if not isinstance(v, torch.Tensor):
@@ -594,8 +568,8 @@ class VllmModelWrapper:
                 }
 
                 return maybe_jit_embed_multimodal_func(
-                    embed_multimodal_func_jax,
-                    self.model.vllm_model)(params_and_buffers, **call_kwargs)
+                    embed_multimodal_func_jax, self.model)(params_and_buffers,
+                                                           **call_kwargs)
 
         return embed_multimodal_func_torch
 
@@ -621,18 +595,15 @@ class VllmModelWrapper:
                 else:
                     call_args = (torch_view(input_ids), )
 
-                output_from_torch = torch.func.functional_call(
-                    self.model,
-                    torch_view(params_and_buffers),
-                    kwargs={
-                        "call_method": "embed_input_ids",
-                        "call_args": call_args,
-                        "call_kwargs": {
-                            "is_multimodal": torch_view(is_multimodal)
-                        } if is_multimodal is not None else {},
-                    },
-                    tie_weights=False,
-                )
+                call_kwargs = {
+                    "is_multimodal": torch_view(is_multimodal)
+                } if is_multimodal is not None else {}
+
+                with reparametrize(self.model, torch_view(params_and_buffers)):
+                    output_from_torch = self.model.embed_input_ids(
+                        *call_args,
+                        **call_kwargs,
+                    )
 
                 return jax_view(output_from_torch)
 
@@ -656,14 +627,9 @@ class VllmModelWrapper:
                     kv_caches=None, mesh=self.mesh):
                 original_lora_metadata = replace_lora_metadata(
                     self.model, lora_metadata, self.vllm_config.lora_config)
-                logits = torch.func.functional_call(
-                    self.model,
-                    torch_view(params_and_buffers),
-                    kwargs={
-                        "hidden_state": torch_view(hidden_states),
-                    },
-                    tie_weights=False,
-                )
+                with reparametrize(self.model, torch_view(params_and_buffers)):
+                    logits = self.model.compute_logits(
+                        hidden_states=torch_view(hidden_states), )
                 replace_lora_metadata(self.model, original_lora_metadata,
                                       self.vllm_config.lora_config)
             return jax_view(logits)
@@ -680,17 +646,9 @@ class VllmModelWrapper:
                                        hidden_states: jax.Array) -> jax.Array:
             with torchax.default_env(), set_vllm_model_wrapper_context(
                     kv_caches=None, mesh=self.mesh):
-                logits = torch.func.functional_call(
-                    self.model,
-                    torch_view(params_and_buffers),
-                    kwargs={
-                        "call_method": "combine_hidden_states",
-                        "call_args": (),
-                        "call_kwargs": {
-                            "hidden_states": torch_view(hidden_states),
-                        },
-                    },
-                )
+                with reparametrize(self.model, torch_view(params_and_buffers)):
+                    logits = self.model.combine_hidden_states(
+                        hidden_states=torch_view(hidden_states), )
             return jax_view(logits)
 
         return combine_hidden_states_func


### PR DESCRIPTION
# Description

Replaces functional_call with a cleaner reparametrize context manager
using PyTorch's _reparametrize_module. Thus, we can call the required
method as usual and the IDE support can be back to us.

With this change, we simply the code structure by removing unnecessary indirection,
increase the readability and maintainability.
Also, developers can relies on rich IDE support such as auto-complete and pick-definition.

# Tests

A sample workload to cover sufficient potion of changes in this PR.

```sh
MODEL_IMPL_TYPE=vllm python examples/generate/multimodal/vision_language_offline.py --model-type=qwen3_vl --num-prompts=1 --modality=image --time-generate  -tp=4
```

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
