### PR TITLE
[DP] Unlock MPMD for MoE model

### DIFF
--- a/tpu_inference/layers/common/sharding.py
+++ b/tpu_inference/layers/common/sharding.py
@@ -181,21 +181,19 @@ class ShardingConfigManager:
         # DP rank, fronted by a single load-balanced API endpoint.
         #
         # It is not used (we fall back to single-process SPMD DP) when:
-        #  - the model is MoE
         #  - attention DP is enabled
         #  - running on Pathways
-        model_config = vllm_config.model_config
+        # MoE without attention DP is fine — experts shard inside each replica
+        # so each MPMD process still owns a self-contained model.
         multiprocess_dp = (envs.TPU_MULTIPROCESS_DP and data_parallelism > 1
-                           and model_config is not None
-                           and not model_config.is_moe
                            and not enable_dp_attention
                            and not vllm_envs.VLLM_TPU_USING_PATHWAYS)
         if (envs.TPU_MULTIPROCESS_DP and data_parallelism > 1
                 and not multiprocess_dp):
             raise ValueError(
-                "TPU_MULTIPROCESS_DP is set but is not supported for MoE "
-                "models, with attention DP (enable_dp_attention), or on "
-                "Pathways. Please disable TPU_MULTIPROCESS_DP.")
+                "TPU_MULTIPROCESS_DP is set but is not supported with "
+                "attention DP (enable_dp_attention) or on Pathways. "
+                "Please disable TPU_MULTIPROCESS_DP.")
         if multiprocess_dp:
             data_parallelism = 1
             logger.warning(

--- a/tpu_inference/layers/common/sharding.py
+++ b/tpu_inference/layers/common/sharding.py
@@ -183,8 +183,6 @@ class ShardingConfigManager:
         # It is not used (we fall back to single-process SPMD DP) when:
         #  - attention DP is enabled
         #  - running on Pathways
-        # MoE without attention DP is fine — experts shard inside each replica
-        # so each MPMD process still owns a self-contained model.
         multiprocess_dp = (envs.TPU_MULTIPROCESS_DP and data_parallelism > 1
                            and not enable_dp_attention
                            and not vllm_envs.VLLM_TPU_USING_PATHWAYS)

--- a/tpu_inference/worker/tpu_worker.py
+++ b/tpu_inference/worker/tpu_worker.py
@@ -309,19 +309,32 @@ class TPUWorker(WorkerBase):
 
         # Initialize the vLLM distribution layer as a single chip environment,
         # we'll swap the model's parallel modules with TPU SPMD equivalents.
-        with set_current_vllm_config(self.vllm_config):
-            temp_file = tempfile.mkstemp()[1]
-            init_distributed_environment(
-                world_size=1,
-                rank=0,
-                local_rank=0,
-                distributed_init_method=f"file://{temp_file}",
-                backend="gloo",
-            )
-            ensure_model_parallel_initialized(
-                tensor_model_parallel_size=1,
-                pipeline_model_parallel_size=1,
-            )
+        #
+        # For MoE under MPMD, vllm keeps parallel_config.data_parallel_size = N
+        # inside each spawned engine (so DPEngineCoreProc can coordinate across
+        # DP ranks). Without this guard, init_distributed_environment would see
+        # data_parallel_size > 1 and override our file:// init into a cross-DP
+        # gloo PG of size DP*TP, but only DP processes exist — TP=N is internal
+        # JAX sharding — so the gloo TCPStore blocks forever waiting for the
+        # missing TP-partner ranks. Force a singleton view for this init only.
+        saved_dp_size = self.parallel_config.data_parallel_size
+        self.parallel_config.data_parallel_size = 1
+        try:
+            with set_current_vllm_config(self.vllm_config):
+                temp_file = tempfile.mkstemp()[1]
+                init_distributed_environment(
+                    world_size=1,
+                    rank=0,
+                    local_rank=0,
+                    distributed_init_method=f"file://{temp_file}",
+                    backend="gloo",
+                )
+                ensure_model_parallel_initialized(
+                    tensor_model_parallel_size=1,
+                    pipeline_model_parallel_size=1,
+                )
+        finally:
+            self.parallel_config.data_parallel_size = saved_dp_size
 
         jax_parallel_state.init_pp_distributed_environment(
             self.pp_config.ip,
@@ -483,6 +496,14 @@ class TPUWorker(WorkerBase):
 
     def take_draft_token_ids(self) -> Optional[DraftTokenIds]:
         return self.model_runner.take_draft_token_ids()
+
+    def execute_dummy_batch(self) -> None:
+        # DPEngineCoreProc (used for MoE) invokes this when this rank is idle
+        # while other DP ranks have work, to keep ranks in lockstep across any
+        # cross-DP collective inside the model step. In MPMD on TPU, JAX has
+        # data_parallelism=1 inside each process, so the model step contains
+        # no cross-DP collective and no sync work is required here.
+        return
 
     def profile(self,
                 is_start: bool = True,


### PR DESCRIPTION
# Description

MPMD was added in #2700 but restrict MoE models. This PR lifts the restriction if `enable_dp_attention==False`

# Tests

```
TPU_MULTIPROCESS_DP=1 \
USE_BATCHED_RPA_KERNEL=1 \
MODEL_IMPL_TYPE=flax_nnx \
vllm \
    serve google/gemma-4-26B-A4B-it \
    --max-model-len=1804 \
    --max-num-seqs=1024 \
    --data-parallel-size 4 \
    --tensor-parallel-size 2 \
    --max-num-batched-tokens 16384 \
    --no-enable-prefix-caching \
    --additional_config='{"quantization": { "qwix": { "rules": [{ "module_path": ".*", "weight_qtype": "float8_e4m3fn", "act_qtype": "float8_e4m3fn"}]}}}' \
    --kv-cache-dtype=fp8 \
    --gpu-memory-utilization=0.9 \
    --async-scheduling \
    --limit-mm-per-prompt '{"image": 1, "video": 0, "audio": 0}' \
    --mm-processor-kwargs '{"size": {"longest_edge": 262144, "shortest_edge": 3136}}' \
    --block-size=256
```

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
