### PR TITLE
Fix Accuracy test failure for gemma-4-31B-it

### DIFF
--- a/tpu_inference/models/vllm/vllm_model_wrapper.py
+++ b/tpu_inference/models/vllm/vllm_model_wrapper.py
@@ -514,10 +514,8 @@ class VllmModelWrapper:
                         "call_method": "embed_input_ids",
                         "call_args": call_args,
                         "call_kwargs": {
-                            "is_multimodal":
-                            torch_view(is_multimodal)
-                            if is_multimodal is not None else False,
-                        },
+                            "is_multimodal": torch_view(is_multimodal)
+                        } if is_multimodal is not None else {},
                     },
                     tie_weights=False,
                 )


### PR DESCRIPTION
The upstream vllm `vllm/model_executor/models/gemma4_mm.py` expecting a `torch.Tensor` rather than a python bool.

This will fix the failures shown up in the nightly runs. e.g. https://buildkite.com/tpu-commons/tpu-inference-ci/builds/18558/canvas?jid=019e688e-484e-4595-959e-7729dd7e52da&tab=output


### Test

https://buildkite.com/tpu-commons/tpu-inference-ci/builds/18907/canvas