### PR TITLE
Update kv_packing size for MLA.

### DIFF
--- a/tests/runner/test_kv_cache.py
+++ b/tests/runner/test_kv_cache.py
@@ -142,18 +142,19 @@ def test_get_kv_cache_shape_with_mesh_mla(mesh: Mesh):
     Tests `get_kv_cache_shape_with_mesh` with `use_mla=True`.
     """
     total_num_pages = 64
-    page_size = 16
+    page_size = 128
     actual_num_kv_heads = 1  # Not used for MLA
     actual_head_dim = 512 + 128  # lkv_dim + r_dim
     kv_dtype = jnp.bfloat16
 
     # Expected shape calculation for MLA:
-    # kv_packing = 2 (for bfloat16)
+    # kv_packing = 32 (envs.MLA_KV_PACKING_SIZE)
+
     # shape[0] = total_num_pages = 64
-    # shape[1] = align_to(page_size, 2) // 2 = 16 // 2 = 8
-    # shape[2] = 2
+    # shape[1] = align_to(page_size, kv_packing) // kv_packing = 4
+    # shape[2] = kv_packing = 32
     # shape[3] = align_to(actual_head_dim, 128) = align_to(640, 128) = 640
-    expected_shape = (64, 8, 2, 640)
+    expected_shape = (64, 4, 32, 640)
 
     shape = get_kv_cache_shape_with_mesh(
         mesh,

--- a/tpu_inference/envs.py
+++ b/tpu_inference/envs.py
@@ -383,6 +383,8 @@ environment_variables: dict[str, Callable[[], Any]] = {
     env_bool("PROFILE_SINGLE_DEVICE", default=False),
     "LORA_MODULE_PATH":
     lambda: os.getenv("LORA_MODULE_PATH", ""),
+    "MLA_KV_PACKING_SIZE":
+    lambda: int(os.getenv("MLA_KV_PACKING_SIZE", "32")),
 }
 
 

--- a/tpu_inference/runner/kv_cache.py
+++ b/tpu_inference/runner/kv_cache.py
@@ -20,7 +20,8 @@ import numpy as np
 from jax._src import dtypes
 from jax.sharding import Mesh, NamedSharding, PartitionSpec
 
-import tpu_inference.kernels.mla.v1.kernel as mla
+import tpu_inference.envs as envs
+import tpu_inference.kernels.mla.v2.kernel as mla
 import tpu_inference.kernels.ragged_paged_attention.v3.kernel as rpa
 import tpu_inference.kernels.ragged_paged_attention.v3.kernel_hd64 as rpa_hd64
 from tpu_inference import utils
@@ -68,7 +69,7 @@ def get_kv_cache_shape_with_mesh(mesh: Mesh,
         get_kv_cache_shape_fn = mla.get_kv_cache_shape
         shape = list(
             get_kv_cache_shape_fn(total_num_pages, block_size, actual_head_dim,
-                                  kv_dtype))
+                                  kv_dtype, envs.MLA_KV_PACKING_SIZE))
     else:
         assert actual_num_kv_heads % model_cnt == 0
         get_kv_cache_shape_fn = (


### PR DESCRIPTION
# Description
Add env var `MLA_KV_PACKING_SIZE` to set kv_packing size for kv_cache and set default as 32 (it was 4.) to get best performance.

Benchmark with decode_batch_size=8 here:
```
# 4 chip DSV3 results:
============ Serving Benchmark Result ============
Successful requests:                     896       
Failed requests:                         0         
Benchmark duration (s):                  596.35    
Total input tokens:                      917504    
Total generated tokens:                  7340032   
Request throughput (req/s):              1.50      
Output token throughput (tok/s):         12308.27  
Peak output token throughput (tok/s):    15987.00  
Peak concurrent requests:                896.00    
Total token throughput (tok/s):          13846.80  
```