### PR TITLE
Enable non-aligned hidden dimensions in ragged_gather

### DIFF
--- a/tests/kernels/ragged_gather_test.py
+++ b/tests/kernels/ragged_gather_test.py
@@ -28,7 +28,7 @@ class GatherTest(jtu.JaxTestCase):
     @parameterized.product(
         in_out_size=[(512, 400), (512, 1024)],
         start_end=[(3, 338), (10, 422)],
-        hidden_size=[128, 512, 8192],
+        hidden_size=[128, 512, 2880, 8192],
         dtype=[jnp.int4, jnp.int8, jnp.bfloat16, jnp.float32],
     )
     def test_sc_gather(self, in_out_size, hidden_size, start_end, dtype):

--- a/tpu_inference/kernels/sparse_core/ragged_gather.py
+++ b/tpu_inference/kernels/sparse_core/ragged_gather.py
@@ -113,7 +113,8 @@ def main_kernel(
         out_32b_hbm_ref = out_hbm_ref.bitcast(jnp.uint32)
 
         for col_vmem_start in range(0, col_size, num_lanes):
-            col_hbm_start = pl.multiple_of(col_tile_start + col_vmem_start, num_lanes)
+            col_hbm_start = pl.multiple_of(col_tile_start + col_vmem_start,
+                                           num_lanes)
             for row_vmem in range(num_simd_lanes):
                 row_hbm = indices[row_vmem] // packing
                 # Since we have changed layout from (8, 128) to (1, 128), continuous

--- a/tpu_inference/kernels/sparse_core/ragged_gather.py
+++ b/tpu_inference/kernels/sparse_core/ragged_gather.py
@@ -113,7 +113,7 @@ def main_kernel(
         out_32b_hbm_ref = out_hbm_ref.bitcast(jnp.uint32)
 
         for col_vmem_start in range(0, col_size, num_lanes):
-            col_hbm_start = col_tile_start + col_vmem_start
+            col_hbm_start = pl.multiple_of(col_tile_start + col_vmem_start, num_lanes)
             for row_vmem in range(num_simd_lanes):
                 row_hbm = indices[row_vmem] // packing
                 # Since we have changed layout from (8, 128) to (1, 128), continuous


### PR DESCRIPTION
### Summary
This PR updates the SparseCore `ragged_gather` kernel to enable support for hidden dimensions that are not exact multiples of the lane size.

### Testing
- Added a new test case for `hidden_size=2880` in `ragged_gather_test.py` to verify the behavior with unaligned hidden dimensions.