### PR TITLE
Add MOE_ALL_GATHER_ACTIVATION_DTYPE to TpuPlatform

### DIFF
--- a/tpu_inference/platforms/tpu_platform.py
+++ b/tpu_inference/platforms/tpu_platform.py
@@ -110,6 +110,7 @@ class TpuPlatform(Platform):
         "USE_JAX_PROFILER_SERVER",
         "JAX_PROFILER_SERVER_PORT",
         "ENABLE_RS_KERNEL",
+        "MOE_ALL_GATHER_ACTIVATION_DTYPE",
     ]
 
     @classmethod


### PR DESCRIPTION
# Description

This PR adds `MOE_ALL_GATHER_ACTIVATION_DTYPE` to the list of additional environment variables in `TpuPlatform`. Previously, this variable was not propagated from the driver node to remote Ray workers in multi-host setups, causing JAX FP8 all-gather logic on the workers to fall back to empty strings and fail to trigger.

- **Why is this change being made:** To ensure environment variable configurations like `MOE_ALL_GATHER_ACTIVATION_DTYPE=fp8` are correctly synchronized and honored across all remote Ray nodes in a TPU multi-host cluster.
- **Problem solved:** Remote Ray workers were not receiving the JAX FP8 all-gather dtype variable during actor initialization, disabling critical FP8 communication optimizations.

# Tests

- Checked out the change on a multi-host TPU v7x node configuration.

# Checklist

- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have made or will make corresponding changes to any relevant documentation.
