### PR TITLE
[Qwen3.5/perf] SC allreduce and allgather offload threshold.

### DIFF
--- a/tpu_inference/envs.py
+++ b/tpu_inference/envs.py
@@ -62,6 +62,7 @@ if TYPE_CHECKING:
     ONEHOT_MOE_PERMUTE_THRESHOLD: int = 0
     PROFILE_SINGLE_DEVICE: bool = False
     LORA_MODULE_PATH: str = ""
+    SC_ALLREDUCE_ALLGATHER_OFFLOAD_MIN_BYTES: str = "auto"
 
 
 def env_with_choices(
@@ -385,6 +386,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
     lambda: os.getenv("LORA_MODULE_PATH", ""),
     "MLA_KV_PACKING_SIZE":
     lambda: int(os.getenv("MLA_KV_PACKING_SIZE", "32")),
+    # When set to a value, override XLA SparseCore offload minimum size (in Bytes) for all-reduce
+    # and all-gather. When set to 0, use default XLA offload threshold. When set to auto,
+    # use VMEM size as the threshold.
+    "SC_ALLREDUCE_ALLGATHER_OFFLOAD_MIN_BYTES":
+    lambda: os.getenv("SC_ALLREDUCE_ALLGATHER_OFFLOAD_MIN_BYTES", "auto"),
 }
 
 

--- a/tpu_inference/models/vllm/vllm_model_wrapper.py
+++ b/tpu_inference/models/vllm/vllm_model_wrapper.py
@@ -68,6 +68,27 @@ from tpu_inference.runner.lora_utils import replace_lora_metadata
 logger = init_logger(__name__)
 
 
+def _get_sc_allreduce_allgather_offload_min_size_bytes() -> int:
+    """Returns the SparseCore all-reduce/all-gather offload minimum size in bytes.
+
+    Returns 0 if we use default XLA offload threshold.
+    """
+    sc_threshold_val = envs.SC_ALLREDUCE_ALLGATHER_OFFLOAD_MIN_BYTES
+    sc_threshold_bytes = 0
+    if sc_threshold_val == "auto":
+        from tpu_inference.tpu_info import get_tpu_vmem_size_bytes
+        sc_threshold_bytes = get_tpu_vmem_size_bytes()
+    else:
+        try:
+            sc_threshold_bytes = int(sc_threshold_val)
+        except ValueError:
+            logger.warning(
+                f"Invalid value for SC_ALLREDUCE_ALLGATHER_OFFLOAD_MIN_BYTES: "
+                f"'{sc_threshold_val}'. Defaulting to 0 (always offload).")
+            sc_threshold_bytes = 0
+    return sc_threshold_bytes
+
+
 class _VllmRunner(torch.nn.Module):
 
     def __init__(self, vllm_model: torch.nn.Module):
@@ -270,6 +291,24 @@ class VllmModelWrapper:
 
     def jit_step_func(self):
 
+        compiler_options = {
+            "xla_tpu_all_gather_collective_matmul_mode":
+            "post_spmd_conservative",
+            "xla_tpu_reduce_scatter_collective_matmul_mode":
+            "post_spmd_conservative",
+            "xla_tpu_use_minor_sharding_for_major_trivial_input": "true",
+        }
+
+        sc_offload_bytes = _get_sc_allreduce_allgather_offload_min_size_bytes()
+        if sc_offload_bytes > 0:
+            threshold_bytes = str(sc_offload_bytes)
+            compiler_options[
+                "xla_tpu_sparse_core_all_reduce_offload_min_size_in_bytes"] = (
+                    threshold_bytes)
+            compiler_options[
+                "xla_tpu_sparse_core_all_gather_offload_min_size_in_bytes"] = (
+                    threshold_bytes)
+
         @jax.jit(
             donate_argnames=("kv_caches", ),
             out_shardings=(
@@ -279,13 +318,7 @@ class VllmModelWrapper:
                 None,  # empty list
                 None,  # expert ids
             ),
-            compiler_options={
-                "xla_tpu_all_gather_collective_matmul_mode":
-                "post_spmd_conservative",
-                "xla_tpu_reduce_scatter_collective_matmul_mode":
-                "post_spmd_conservative",
-                "xla_tpu_use_minor_sharding_for_major_trivial_input": "true"
-            },
+            compiler_options=compiler_options,
             static_argnames=(
                 "layer_name_to_kvcache_index",
                 "is_first_rank",

--- a/tpu_inference/tpu_info.py
+++ b/tpu_inference/tpu_info.py
@@ -90,3 +90,16 @@ def get_num_chips() -> int:
     except FileNotFoundError as e:
         logger.error("Failed to detect number of TPUs: %s", e)
         return 0
+
+
+def get_tpu_vmem_size_bytes() -> int:
+    """Returns the TPU Vector Memory (VMEM) size in Bytes per Tensor Core.
+
+    Defaults to 0 if the capacity cannot be programmatically retrieved.
+    """
+    try:
+        from jax.experimental.pallas import tpu as pltpu
+        return pltpu.get_tpu_info().vmem_capacity_bytes
+    except Exception as e:
+        logger.warning("Failed to programmatically get TPU VMEM size: %s", e)
+        return 0


### PR DESCRIPTION
Change:
`SC_ALLREDUCE_ALLGATHER_OFFLOAD_MIN_BYTES` to allow overriding SC offload threshold. By defeault set to `auto` which will use vmem size as the threshold. To disable, set it to `0` which will use xla's default threshold.

Why:
When data size is small and can fit in vmem, sc offload can be slower. 
Keeping small collectives on the Tensor Core (TC) avoids sc overhead

Benchmark: 
| Workload | Concurrency | Before | After | Improvement |
| :--- | ---: | ---: | ---: | :--- |
| `8k/1k` | `64` | `12,757` | `13,105` | **+2.7%** |
| `8k/1k` | `128` | `16,374` | `17,305` | **+5.7%** |
| `1k/8k` | `64` | `2,557` | `2,649` | **+3.6%** |
| `1k/8k` | `128` | `4,146` | `4,212` | **+1.6%** |
