### PR TITLE
[Qwen3.5/dp-scheduler] Route reqs by considering inflight count and   completed tokens

### DIFF
--- a/tests/core/test_dp_scheduler.py
+++ b/tests/core/test_dp_scheduler.py
@@ -256,23 +256,66 @@ class TestDPScheduler:
     def test_find_best_rank_without_cache_hit(self, mock_vllm_config,
                                               mock_kv_cache_config,
                                               mock_structured_output_manager):
-        """Test _find_best_rank_for_request uses pending prefill token counts."""
+        """_find_best_rank_for_request sorts by
+        (pending_prefill, inflight, min_remaining_output)."""
         scheduler = self._create_scheduler(mock_vllm_config,
                                            mock_kv_cache_config,
                                            mock_structured_output_manager)
 
         mock_request = MagicMock(spec=Request)
 
-        # Simulate rank 0 having more pending prefill tokens than rank 1
-        scheduler._get_rank_pending_prefill_tokens = MagicMock(return_value={
-            0: 100,
-            1: 50
-        })
+        # Primary key wins: rank 1 has fewer pending prefill tokens.
+        scheduler._get_rank_routing_state = MagicMock(return_value=(
+            {
+                0: 100,
+                1: 50
+            },  # pending
+            {
+                0: 5,
+                1: 5
+            },  # inflight
+            {
+                0: 1000,
+                1: 1000
+            }  # min_remaining
+        ))
+        assert scheduler._find_best_rank_for_request(mock_request) == 1
 
-        rank = scheduler._find_best_rank_for_request(mock_request)
+        # Primary ties; secondary key wins: rank 0 has fewer inflight.
+        scheduler._get_rank_routing_state = MagicMock(return_value=(
+            {
+                0: 50,
+                1: 50
+            },
+            {
+                0: 3,
+                1: 7
+            },
+            {
+                0: 1000,
+                1: 1000
+            },
+        ))
+        assert scheduler._find_best_rank_for_request(mock_request) == 0
 
-        # Should choose rank with fewer pending prefill tokens (rank 1)
-        assert rank == 1
+        # Primary and secondary tie; tertiary wins: rank 1 has the running
+        # req with the fewest remaining output tokens (closest to its
+        # max_tokens), so it is most likely to free a slot soonest.
+        scheduler._get_rank_routing_state = MagicMock(return_value=(
+            {
+                0: 0,
+                1: 0
+            },
+            {
+                0: 4,
+                1: 4
+            },
+            {
+                0: 9100,
+                1: 500
+            },
+        ))
+        assert scheduler._find_best_rank_for_request(mock_request) == 1
 
     def test_add_request_assigns_to_best_rank(self, mock_vllm_config,
                                               mock_kv_cache_config,

--- a/tpu_inference/core/sched/dp_scheduler.py
+++ b/tpu_inference/core/sched/dp_scheduler.py
@@ -68,6 +68,7 @@ class SchedulerCommand(Enum):
     GET_REQUEST_COUNTS = "get_request_counts"
     GET_TOKEN_COUNT = "get_token_count"
     GET_PENDING_PREFILL_TOKENS = "get_pending_prefill_tokens"
+    GET_MIN_REMAINING_OUTPUT = "get_min_remaining_output"
     PROBE_COMPUTED_BLOCKS = "probe_computed_blocks"
     RESET_ENCODER_CACHE = "reset_encoder_cache"
     SET_PAUSE_STATE = "set_pause_state"
@@ -252,6 +253,19 @@ def _scheduler_worker_process(
                     for req in scheduler.waiting:
                         pending += req.num_prompt_tokens
                     _send_result(pending)
+
+                case SchedulerCommand.GET_MIN_REMAINING_OUTPUT:
+                    # Smallest (max_tokens - len(output_token_ids)) across
+                    # this rank's running reqs. Used as an admission
+                    # tiebreaker: lower = a running req closer to its
+                    # max_tokens, so this rank will likely free a slot
+                    # soonest.
+                    if not scheduler.running:
+                        _send_result(2**31 - 1)
+                    else:
+                        _send_result(
+                            min(r.max_tokens - len(r.output_token_ids)
+                                for r in scheduler.running))
 
                 case SchedulerCommand.PROBE_COMPUTED_BLOCKS:
                     # Probe for cached blocks without recording prefix cache stats.
@@ -598,12 +612,70 @@ class DPScheduler(SchedulerInterface):
 
         return pending
 
+    def _get_rank_inflight_reqs(self) -> Dict[int, int]:
+        """Per-rank count of in-flight requests (running + waiting)."""
+        for rank in range(self.dp_size):
+            self._send_command(rank, SchedulerCommand.GET_REQUEST_COUNTS)
+
+        inflight: Dict[int, int] = {}
+        for rank in range(self.dp_size):
+            running, waiting = self._get_result(
+                rank, SchedulerCommand.GET_REQUEST_COUNTS)
+            inflight[rank] = running + waiting
+
+        return inflight
+
+    def _get_rank_min_remaining_output(self) -> Dict[int, int]:
+        """Per-rank min (max_tokens - len(output_token_ids)) across running
+        reqs. Lower = a running req closer to its max_tokens, so this rank
+        will likely free a slot soonest. Used as an admission tiebreaker."""
+        for rank in range(self.dp_size):
+            self._send_command(rank, SchedulerCommand.GET_MIN_REMAINING_OUTPUT)
+        result: Dict[int, int] = {}
+        for rank in range(self.dp_size):
+            result[rank] = self._get_result(
+                rank, SchedulerCommand.GET_MIN_REMAINING_OUTPUT)
+        return result
+
+    def _get_rank_routing_state(
+            self) -> Tuple[Dict[int, int], Dict[int, int], Dict[int, int]]:
+        """Per-rank (pending_prefill_tokens, inflight_reqs,
+        min_remaining_output) collected in a single round-trip.
+
+        Send all comments first and collect all results after to
+        allow pipelinening across ranks, minimizing the overhead."""
+        for rank in range(self.dp_size):
+            self._send_command(rank,
+                               SchedulerCommand.GET_PENDING_PREFILL_TOKENS)
+            self._send_command(rank, SchedulerCommand.GET_REQUEST_COUNTS)
+            self._send_command(rank, SchedulerCommand.GET_MIN_REMAINING_OUTPUT)
+
+        pending: Dict[int, int] = {}
+        inflight: Dict[int, int] = {}
+        min_remaining: Dict[int, int] = {}
+        for rank in range(self.dp_size):
+            pending[rank] = self._get_result(
+                rank, SchedulerCommand.GET_PENDING_PREFILL_TOKENS)
+            running, waiting = self._get_result(
+                rank, SchedulerCommand.GET_REQUEST_COUNTS)
+            inflight[rank] = running + waiting
+            min_remaining[rank] = self._get_result(
+                rank, SchedulerCommand.GET_MIN_REMAINING_OUTPUT)
+        return pending, inflight, min_remaining
+
     def _find_best_rank_for_request(self, request: Request) -> int:
         """Find the best DP rank for a new request based on load balancing.
 
         Two-tier strategy:
         1. Prefix cache hit: assign to rank with best cache hit.
-        2. Otherwise: pick rank with the fewest pending prefill tokens.
+        2. Otherwise:
+           - Primary key: fewest pending prefill tokens (keeps prefill
+             balanced across ranks).
+           - Secondary key: fewest in-flight reqs (balances decode load
+             across ranks under DP lockstep once prefills finish).
+           - Tertiary key: rank whose running req is closest to its
+             max_tokens (smallest remaining output tokens), which is
+             most likely to free a slot soon.
         """
         # First, try to find a rank with prefix cache hit.
         if self.vllm_config.cache_config.enable_prefix_caching:
@@ -623,8 +695,9 @@ class DPScheduler(SchedulerInterface):
             if best_cache_tokens > 0:
                 return best_cache_rank
 
-        pending = self._get_rank_pending_prefill_tokens()
-        return min(pending, key=pending.get)
+        pending, inflight, min_remaining = self._get_rank_routing_state()
+        return min(range(self.dp_size),
+                   key=lambda r: (pending[r], inflight[r], min_remaining[r]))
 
     def add_request(self, request: Request) -> None:
         """


### PR DESCRIPTION
Why:
For DP attention, consider inflight count for scheduling which will
improve balance across dp ranks.
Adding rank's max completed-output tokens as a tertiary key biases
admission toward the rank closest to finishing a req -- the rank most
likely to free a slot soon, so any momentary bump resolves quickly.

Benchmark results
* Concurrency 256 variance much smaller ~1.2% (down from 5.3%)
* Concurrency 256 total token throughput improved by ~13.27% to 7,727 (from average 6822 before)
* Concurrency 64 and 128 also gained 4-5% 

| workload | concurrency | total (baseline → +PR) | output (baseline → +PR) | Δ |
  |---|---|---|---|---|
  | 1k/8k | 64  | 2,566 → 2,691 | 2,281 → 2,392 | **+4.88%** |
  | 8k/1k | 64  | 12,832 → 12,861 | 1,424 → 1,427 | +0.20% |
  | 1k/8k | 128 | 4,160 → 4,351 | 3,698 → 3,868 | **+4.60%** |
  | 8k/1k | 128 | 17,074 → 17,264 | 1,894 → 1,915 | +1.13% |
  | 1k/8k | 256 | 6,822 → 7,727 | 6,064 → 6,869 | **+13.27%** |
  | 8k/1k | 256 | 18,686 → 18,713 | 2,073 → 2,076 | +0.15% |
  | 1k/8k | 512 | 8,244 → 8,286 | 7,329 → 7,367 | +0.51% |
  | 8k/1k | 512 | 19,948 → 20,048 | 2,213 → 2,224 | +0.50% |