### PR TITLE
Cap down proj weight block size under GMM_TP

### DIFF
--- a/tests/layers/common/test_process_weights.py
+++ b/tests/layers/common/test_process_weights.py
@@ -20,10 +20,13 @@ import numpy as np
 from jax.sharding import Mesh, NamedSharding
 from jax.sharding import PartitionSpec as P
 
+from tpu_inference.layers.common.moe import MoEBackend
 from tpu_inference.layers.common.process_weights.linear_weights import (
     LinearWeights, shard_linear_weights)
 from tpu_inference.layers.common.process_weights.moe_weights import (
-    W13PaddingConfig, get_w13_padding_config, process_w13_for_gmm)
+    FusedMoEWeights, W13PaddingConfig, _process_quantized_moe_weights_impl,
+    get_w13_padding_config, process_w13_for_gmm)
+from tpu_inference.layers.common.sharding import ShardingAxisName
 
 
 class TestProcessWeights(unittest.TestCase):
@@ -145,6 +148,62 @@ class TestProcessWeights(unittest.TestCase):
         self.assertEqual(processed[0, 1], 1)
         self.assertEqual(processed[0, 2], 2)
         self.assertEqual(processed[0, 3], 3)
+
+    def test_process_weights_requant_512(self):
+        """Test process_quantized_moe_weights with MOE_REQUANTIZE_BLOCK_SIZE = 512."""
+        # Dynamically adapt the mesh size to the physical devices available (CPU or TPU)
+        devices = jax.devices()
+        tp_size = len(devices)
+        mock_mesh = Mesh(
+            np.array(devices).reshape(1, tp_size), ('data', 'model'))
+
+        # Create FusedMoEWeights with dynamically adapted shapes:
+        # hidden_size = 7168, intermediate_size = 256 * tp_size
+        # block_size = 128
+        input_weights = FusedMoEWeights(
+            w13_weight=jnp.ones((128, 512 * tp_size, 7168),
+                                dtype=jnp.float8_e4m3fn),
+            w13_weight_scale=jnp.ones((128, 4 * tp_size, 56),
+                                      dtype=jnp.float32),
+            w13_bias=None,
+            w2_weight=jnp.ones((128, 7168, 256 * tp_size),
+                               dtype=jnp.float8_e4m3fn),
+            w2_weight_scale=jnp.ones((128, 56, 2 * tp_size),
+                                     dtype=jnp.float32),
+            w2_bias=None,
+        )
+
+        # Process the weights under GMM_TP by calling the JIT implementation directly
+        processed_weights = _process_quantized_moe_weights_impl(
+            input_weights,
+            moe_backend=MoEBackend.GMM_TP,
+            mesh=mock_mesh,
+            activation="silu",
+            weight_block_size=(128, ),
+            desired_quant_dtype=jnp.float8_e4m3fn,
+            requant_block_size=512,
+        )
+
+        # Assertions:
+        # w2 scale: global shape
+        self.assertEqual(processed_weights.w2_weight_scale.shape,
+                         (128, tp_size, 1, 7168))
+
+        # w2 scale: sharding spec and local shard shapes
+        if tp_size == 1:
+            expected_w2_sharding = NamedSharding(mock_mesh, P())
+        else:
+            expected_w2_sharding = NamedSharding(
+                mock_mesh, P(None, ShardingAxisName.MLP_TENSOR))
+        self.assertEqual(processed_weights.w2_weight_scale.sharding,
+                         expected_w2_sharding)
+        w2_local_shapes = [
+            s.data.shape[1]
+            for s in processed_weights.w2_weight_scale.addressable_shards
+        ]
+        self.assertEqual(sum(w2_local_shapes), tp_size)
+        for s_size in w2_local_shapes:
+            self.assertEqual(s_size, 1)
 
 
 if __name__ == "__main__":

--- a/tpu_inference/layers/common/process_weights/moe_weights.py
+++ b/tpu_inference/layers/common/process_weights/moe_weights.py
@@ -1092,11 +1092,12 @@ def _process_quantized_moe_weights_impl(
     else:
         w13_block_size = w2_block_size = requant_block_size
 
-    tp_size = get_mesh_shape_product(mesh, ShardingAxisName.MLP_TENSOR)
-    max_w2_block_size = orig_intermediate_size // tp_size
+    if requant_block_size is not None and moe_backend == MoEBackend.GMM_TP:
+        tp_size = get_mesh_shape_product(mesh, ShardingAxisName.MLP_TENSOR)
+        max_w2_block_size = orig_intermediate_size // tp_size
 
-    # Cap the block size to avoid sharding indivisible errors
-    w2_block_size = min(w2_block_size, max_w2_block_size)
+        # Cap the block size to avoid sharding indivisible errors
+        w2_block_size = min(w2_block_size, max_w2_block_size)
     hidden_size = align_to(orig_hidden_size, w13_block_size)
     intermediate_size = align_to(orig_intermediate_size, w2_block_size)
 
@@ -1204,7 +1205,7 @@ def process_unquantized_moe_weights(
         if requant_block_size_from_env := envs.MOE_REQUANTIZE_BLOCK_SIZE:
             requant_block_size = (int(requant_block_size_from_env)
                                   if requant_block_size_from_env else None)
-            if requant_block_size is not None:
+            if requant_block_size is not None and moe_backend == MoEBackend.GMM_TP:
                 tp_size = get_mesh_shape_product(mesh,
                                                  ShardingAxisName.MLP_TENSOR)
                 orig_intermediate_size = w2_weight.shape[1]

--- a/tpu_inference/layers/common/process_weights/moe_weights.py
+++ b/tpu_inference/layers/common/process_weights/moe_weights.py
@@ -100,10 +100,15 @@ def quantize_moe_weights(
         # Use per-channel quantizaiton.
         w13_block_size = w13_weight.shape[-1]
         w2_block_size = w2_weight.shape[-1]
+    elif isinstance(block_size, tuple):
+        w13_block_size, w2_block_size = block_size
     else:
         w13_block_size = w2_block_size = block_size
 
     _, orig_hidden_size, orig_intermediate_size = w2_weight.shape
+
+    # Cap the block size for w2 at its contracting dimension size
+    w2_block_size = min(w2_block_size, orig_intermediate_size)
 
     hidden_size = align_to(orig_hidden_size, w13_block_size)
     intermediate_size = align_to(orig_intermediate_size, w2_block_size)
@@ -1082,8 +1087,16 @@ def _process_quantized_moe_weights_impl(
     if requant_block_size is None:
         w13_block_size = w13_weight.shape[-1]
         w2_block_size = w2_weight.shape[-1]
+    elif isinstance(requant_block_size, tuple):
+        w13_block_size, w2_block_size = requant_block_size
     else:
         w13_block_size = w2_block_size = requant_block_size
+
+    tp_size = get_mesh_shape_product(mesh, ShardingAxisName.MLP_TENSOR)
+    max_w2_block_size = orig_intermediate_size // tp_size
+
+    # Cap the block size to avoid sharding indivisible errors
+    w2_block_size = min(w2_block_size, max_w2_block_size)
     hidden_size = align_to(orig_hidden_size, w13_block_size)
     intermediate_size = align_to(orig_intermediate_size, w2_block_size)
 
@@ -1191,6 +1204,13 @@ def process_unquantized_moe_weights(
         if requant_block_size_from_env := envs.MOE_REQUANTIZE_BLOCK_SIZE:
             requant_block_size = (int(requant_block_size_from_env)
                                   if requant_block_size_from_env else None)
+            if requant_block_size is not None:
+                tp_size = get_mesh_shape_product(mesh,
+                                                 ShardingAxisName.MLP_TENSOR)
+                orig_intermediate_size = w2_weight.shape[1]
+                max_w2_block_size = orig_intermediate_size // tp_size
+                w2_block_size = min(requant_block_size, max_w2_block_size)
+                requant_block_size = (requant_block_size, w2_block_size)
         moe_logging_str = (
             "[MoE requantization]: re-quantizing MoE weights to "
             f"{desired_quant_dtype}")


### PR DESCRIPTION
# Description

This PR dynamically caps the down-projection ($w_2$) block-wise requantization size to the device-local dimension size under `GMM_TP` tensor parallelism. This is a change from the past where `MOE_REQUANTIZE_BLOCK_SIZE=512` was applied, which failed with shape errors when the TP mesh was larger than the block size.

* **Why this change is being made**: To prevent JAX sharding indivisibility errors when using block-wise quantization on larger tensor parallel meshes (such as `TP=16`).
* **The problem being solved**: When using a static block size (e.g., `512`), the scale only has `4096 // 512 = 8` elements. On a model partitioned across 16 chips under TP, it will cause indivislbe error.
* **Why this is a good solution**: By dynamically capping the $w_2$ block size to the local partitioned dimension size on the mesh, we eliminate the sharding error completely while preserving the maximum possible block-wise quantization precision on any TP mesh configuration.
* **Specific implementation details**:
  - Modified `tpu_inference/layers/common/process_weights/moe_weights.py` to compute the local dimension size on the target mesh and cap `w2_block_size` accordingly.

# Tests
* I launched Mistral 3 Large on a multi-host setup with TP=16 and hidden dim=4096
* I added a new, fully self-adaptive unit test `test_process_weights_requant_512` in `tests/layers/common/test_process_weights.py` which dynamically adjusts weight shapes and mesh sizes to the physical devices available (`tp_size = len(devices)`), asserting global shapes, sharding specs, and addressable local shard shapes.

### Commands to Reproduce:

* **Test standard CPU fallback (TP=16)**:
``` 
JAX_PLATFORMS='cpu' XLA_FLAGS='--xla_force_host_platform_device_count=16' python3 -m unittest tests.layers.common.test_process_weights.TestProcessWeights.test_process_weights_requant_512
```
# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
