### PR TITLE
Example: dev pipeline + lm_eval mmlu_pro on Qwen3.5-397B-A17B-FP8

### DIFF
--- a/.buildkite/pipeline_dev.yml
+++ b/.buildkite/pipeline_dev.yml
@@ -12,34 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Dev pipeline for tpu-inference-dev.
-# Demo/sample steps showing how to run custom tests on tpu7x.
-# Copy and adapt any step for your own experiments.
-#
-# HOW TO TRIGGER THIS PIPELINE
-# ─────────────────────────────
-# Option A — Buildkite UI:
-#   Go to https://buildkite.com/tpu-commons/tpu-inference-dev
-#   Click "New Build", set branch to your branch, click "Create Build".
-#
-# Option B — Buildkite API (requires BUILDKITE_API_TOKEN in your env):
-#   curl -s -X POST \
-#     -H "Authorization: Bearer $BUILDKITE_API_TOKEN" \
-#     -H "Content-Type: application/json" \
-#     "https://api.buildkite.com/v2/organizations/tpu-commons/pipelines/tpu-inference-dev/builds" \
-#     -d "{\"commit\": \"$(git rev-parse HEAD)\", \"branch\": \"$(git rev-parse --abbrev-ref HEAD)\", \"message\": \"my test\"}"
-#
-# HOW TO CUSTOMIZE
-# ─────────────────
-# 1. On your branch, edit this file — use any demo step below as a starting point.
-# 2. Change the command, model, env vars, or queue as needed.
-# 3. Trigger the pipeline — only your branch's file is used.
+# Dev pipeline (cuiq-haowen-test branch): run lm_eval mmlu_pro against
+# Qwen/Qwen3.5-397B-A17B-FP8 served on tpu7x with TP=8 + custom env knobs.
 
 steps:
 
-  # -----------------------------------------------------------------
-  # Build Step (required by all demo steps below)
-  # -----------------------------------------------------------------
   - label: ":docker: Build and Push Base Image (tpu7x)"
     key: tpu7x_build_docker
     agents:
@@ -49,100 +26,15 @@ steps:
     commands:
       - bash -c 'source .buildkite/scripts/setup_docker_env.sh && setup_environment "vllm-tpu" "false" "true"'
 
-  # -----------------------------------------------------------------
-  # Demo 1: offline_inference.py
-  # Shows the simplest pattern: run a Python script inside Docker.
-  # Use this as a starting point for any offline batch inference test.
-  # -----------------------------------------------------------------
-  - label: "tpu7x [demo] offline_inference.py"
-    key: tpu7x_demo_offline_inference
+  - label: "tpu7x haowen: Qwen3.5-397B-A17B-FP8 mmlu_pro (TP=8)"
+    key: tpu7x_haowen_qwen35_397b_mmlu_pro
     depends_on: tpu7x_build_docker
     env:
       USE_PREBUILT_IMAGE: "1"
       TPU_VERSION: "tpu7x"
-    agents:
-      queue: tpu_v7x_2_queue
-    commands:
-      - |
-        # Run offline inference with a small model.
-        # --tensor-parallel-size 2: tp=1 is currently unsupported on tpu7x.
-        # Customize --model, --max-model-len, --max-tokens as needed.
-        .buildkite/scripts/run_in_docker.sh bash -c '
-          python3 examples/offline_inference.py \
-            --model Qwen/Qwen3-0.6B \
-            --tensor-parallel-size 2 \
-            --max-model-len 1024 \
-            --max-tokens 128'
-
-  # -----------------------------------------------------------------
-  # Demo 2: vllm serve + vllm bench serve
-  # Shows how to start a server and run a benchmark against it.
-  # Uses --dataset-name random so no dataset file is needed.
-  # -----------------------------------------------------------------
-  - label: "tpu7x [demo] vllm serve + vllm bench serve"
-    key: tpu7x_demo_serve_bench
-    depends_on: tpu7x_build_docker
-    env:
-      USE_PREBUILT_IMAGE: "1"
-      TPU_VERSION: "tpu7x"
-    agents:
-      queue: tpu_v7x_2_queue
-    commands:
-      - |
-        # Customize behaviour via env vars: MODEL, PORT, TENSOR_PARALLEL_SIZE,
-        # MAX_MODEL_LEN, RANDOM_INPUT_LEN, RANDOM_OUTPUT_LEN, NUM_PROMPTS, NUM_WARMUPS.
-        .buildkite/scripts/run_in_docker.sh bash .buildkite/scripts/run_benchmark_demo.sh
-
-  # -----------------------------------------------------------------
-  # Demo 3: DCN-based P/D disaggregation
-  # Mirrors test_25 in pipeline_jax.yml.
-  # Uses run_disagg.sh which delegates to examples/disagg/.
-  # Requires a multi-chip queue (tpu_v7x_8_queue).
-  # -----------------------------------------------------------------
-  - label: "tpu7x [demo] E2E disaggregation (DCN P/D)"
-    key: tpu7x_demo_disagg
-    depends_on: tpu7x_build_docker
-    env:
-      USE_PREBUILT_IMAGE: "1"
-      TPU_VERSION: "tpu7x"
-      # Customize these to change the disagg benchmark behaviour.
-      MODEL: "Qwen/Qwen3-0.6B"
-      INPUT_LEN: 1024
-      OUTPUT_LEN: 128
-      NUM_PROMPTS: 5
-      RANDOM_SEED: 10
-      MAX_CONCURRENCY: 4
-      TEST_MODE: 1
+      MODEL_IMPL_TYPE: "vllm"
+      NEW_MODEL_DESIGN: "1"
     agents:
       queue: tpu_v7x_8_queue
     commands:
-      - .buildkite/scripts/run_disagg.sh
-
-  # -----------------------------------------------------------------
-  # Demo 4: Ray-based multi-host inference
-  # Mirrors test_26 in pipeline_jax.yml.
-  # Uses run_multihost.sh to serve a large model across 16 chips (2 hosts).
-  # Requires a 16-chip queue (tpu_v7x_16_queue).
-  # -----------------------------------------------------------------
-  - label: "tpu7x [demo] Ray-based multi-host"
-    key: tpu7x_demo_multihost
-    env:
-      TPU_VERSION: "tpu7x"
-    agents:
-      queue: tpu_v7x_16_queue
-    commands:
-      - |
-        MODEL="gs://tpu-commons-ci/qwen/models--Qwen--Qwen3-30B-A3B/snapshots/ad44e777bcd18fa416d9da3bd8f70d33ebb85d39"
-        .buildkite/scripts/run_multihost.sh \
-          "vllm serve \${MODEL} \
-            --port 8000 \
-            --tensor-parallel-size 16 \
-            --trust-remote-code \
-            --max-model-len 1024 \
-            --no-async-scheduling \
-            --load-format=runai_streamer \
-            --no-enable-prefix-caching" \
-          "curl http://localhost:8000/v1/completions \
-            -X POST \
-            -H 'Content-Type: application/json' \
-            -d '{\"model\": \"${MODEL}\", \"prompt\": \"San Francisco is a\", \"max_tokens\": 50}'"
+      - .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/.buildkite/scripts/run_haowen_test.sh

--- a/.buildkite/scripts/run_haowen_test.sh
+++ b/.buildkite/scripts/run_haowen_test.sh
@@ -1,0 +1,109 @@
+#!/bin/bash
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Start vllm serve with a Qwen3.5-397B-A17B-FP8 config + custom env vars,
+# wait for /health, then drive mmlu_pro through lm_eval.
+
+set -u
+set -o pipefail
+
+MODEL="Qwen/Qwen3.5-397B-A17B-FP8"
+PORT=8000
+SERVER_LOG=/tmp/vllm_serve.log
+
+# Custom env vars consumed by vllm + tpu-inference internals.
+export MODEL_IMPL_TYPE=vllm
+export USE_MOE_EP_KERNEL=0
+export ATTN_BUCKETIZED_NUM_REQS=true
+export ATTN_CUSTOM_NUM_REQS_BUCKETS=8,16,32,64
+export ONEHOT_MOE_PERMUTE_THRESHOLD=32768
+export RAGGED_GATED_DELTA_RULE_IMPL=chunked_kernel_p_recurrent_kernel_d
+export NEW_MODEL_DESIGN=1
+
+echo "--- Installing lm-eval (idempotent) ---"
+python3 -m pip install --quiet lm-eval || {
+  echo "[ERROR] Failed to install lm-eval"
+  exit 1
+}
+
+echo "--- Starting vllm serve in background ---"
+vllm serve "${MODEL}" \
+  --max-model-len=9216 \
+  --max-num-batched-tokens=1024 \
+  --max-num-seqs=64 \
+  --no-enable-prefix-caching \
+  --gpu-memory-utilization=0.9 \
+  --tensor-parallel-size=8 \
+  --async-scheduling \
+  --port="${PORT}" \
+  --language-model-only \
+  --enable-auto-tool-choice \
+  --tool-call-parser=qwen3_coder \
+  --reasoning-parser=qwen3 \
+  --limit-mm-per-prompt='{"image": 0, "video": 0}' \
+  --kv-cache-dtype=fp8 \
+  --enable-expert-parallel \
+  --additional_config='{"sharding": {"sharding_strategy": {"enable_dp_attention": true}}}' \
+  --mamba-ssm-cache-dtype=bfloat16 \
+  > "${SERVER_LOG}" 2>&1 &
+SERVER_PID=$!
+
+trap 'echo "--- Tearing down server (pid=${SERVER_PID}) ---"; kill "${SERVER_PID}" 2>/dev/null || true; sleep 5; kill -9 "${SERVER_PID}" 2>/dev/null || true' EXIT INT TERM
+
+echo "--- Waiting for server /health (server pid=${SERVER_PID}) ---"
+# 397B + cold JAX compilation can take 30+ min on first run.
+# 180 * 30s = 90 min max wait.
+HEALTHY=0
+for i in $(seq 1 180); do
+  if curl -sf "http://localhost:${PORT}/health" > /dev/null 2>&1; then
+    echo "Server healthy after ~$((i * 30))s"
+    HEALTHY=1
+    break
+  fi
+  if ! kill -0 "${SERVER_PID}" 2>/dev/null; then
+    echo "[ERROR] Server process died. Last 200 log lines:"
+    tail -n 200 "${SERVER_LOG}"
+    exit 1
+  fi
+  sleep 30
+done
+
+if [ "${HEALTHY}" -ne 1 ]; then
+  echo "[ERROR] Server did not become healthy in time. Last 200 log lines:"
+  tail -n 200 "${SERVER_LOG}"
+  exit 1
+fi
+
+echo "--- Running lm_eval mmlu_pro --limit 50 ---"
+set +e
+lm_eval --model local-chat-completions \
+  --model_args '{"model": "Qwen/Qwen3.5-397B-A17B-FP8", "base_url": "http://localhost:8000/v1/chat/completions", "enable_thinking": false, "num_concurrent": 500}' \
+  --tasks mmlu_pro \
+  --apply_chat_template \
+  --log_samples \
+  --gen_kwargs '{"chat_template_kwargs": {"enable_thinking": false}}' \
+  --limit 50 \
+  --seed 42
+LM_EVAL_EXIT=$?
+set -e
+
+echo "--- lm_eval exit code: ${LM_EVAL_EXIT} ---"
+
+if [ "${LM_EVAL_EXIT}" -ne 0 ]; then
+  echo "[ERROR] lm_eval failed. Last 200 server log lines:"
+  tail -n 200 "${SERVER_LOG}"
+fi
+
+exit "${LM_EVAL_EXIT}"

--- a/.buildkite/scripts/run_haowen_test.sh
+++ b/.buildkite/scripts/run_haowen_test.sh
@@ -64,7 +64,8 @@ trap 'echo "--- Tearing down server (pid=${SERVER_PID}) ---"; kill "${SERVER_PID
 
 echo "--- Waiting for server /health (server pid=${SERVER_PID}) ---"
 # 397B + cold JAX compilation can take 30+ min on first run.
-# 180 * 30s = 90 min max wait.
+# 180 * 30s = 90 min max wait. Every 10 polls (~5 min) we tail the server
+# log into stdout so progress is visible in Buildkite.
 HEALTHY=0
 for i in $(seq 1 180); do
   if curl -sf "http://localhost:${PORT}/health" > /dev/null 2>&1; then
@@ -77,6 +78,10 @@ for i in $(seq 1 180); do
     tail -n 200 "${SERVER_LOG}"
     exit 1
   fi
+  if [ $((i % 10)) -eq 0 ]; then
+    echo "--- still waiting (${i}/180, ~$((i * 30))s elapsed); last 30 server log lines ---"
+    tail -n 30 "${SERVER_LOG}" 2>/dev/null || echo "(server log not yet readable)"
+  fi
   sleep 30
 done
 
@@ -87,12 +92,16 @@ if [ "${HEALTHY}" -ne 1 ]; then
 fi
 
 echo "--- Running lm_eval mmlu_pro --limit 50 ---"
+# --output_path is required by lm-eval whenever --log_samples is set.
+LM_EVAL_OUTPUT=/tmp/lm_eval_results
+mkdir -p "${LM_EVAL_OUTPUT}"
 set +e
 lm_eval --model local-chat-completions \
   --model_args '{"model": "Qwen/Qwen3.5-397B-A17B-FP8", "base_url": "http://localhost:8000/v1/chat/completions", "enable_thinking": false, "num_concurrent": 500}' \
   --tasks mmlu_pro \
   --apply_chat_template \
   --log_samples \
+  --output_path "${LM_EVAL_OUTPUT}" \
   --gen_kwargs '{"chat_template_kwargs": {"enable_thinking": false}}' \
   --limit 50 \
   --seed 42


### PR DESCRIPTION
**Not for merge — reference example for using the dev pipeline.**

Shows how to drive a custom `vllm serve` + `lm_eval` run through
`tpu-inference-dev` on `tpu_v7x_8_queue` (TP=8).

### Files

- `.buildkite/pipeline_dev.yml` — replaces the demo steps with only the
  build step + a single test step on `tpu_v7x_8_queue`.
- `.buildkite/scripts/run_haowen_test.sh` — starts `vllm serve` with a
  Qwen3.5-397B-A17B-FP8 config + custom env knobs, waits for `/health`,
  then runs `lm_eval --tasks mmlu_pro --limit 50` against it.

### Custom env knobs exported before `vllm serve`

```
MODEL_IMPL_TYPE=vllm
USE_MOE_EP_KERNEL=0
ATTN_BUCKETIZED_NUM_REQS=true
ATTN_CUSTOM_NUM_REQS_BUCKETS=8,16,32,64
ONEHOT_MOE_PERMUTE_THRESHOLD=32768
RAGGED_GATED_DELTA_RULE_IMPL=chunked_kernel_p_recurrent_kernel_d
NEW_MODEL_DESIGN=1
```

### Trigger

```
COMMIT=$(git rev-parse cuiq-haowen-test)
curl -s -X POST -H "Authorization: Bearer \$BUILDKITE_API_TOKEN" \
  -H "Content-Type: application/json" \
  "https://api.buildkite.com/v2/organizations/tpu-commons/pipelines/tpu-inference-dev/builds" \
  -d "{\"commit\": \"\$COMMIT\", \"branch\": \"cuiq-haowen-test\", \"message\": \"haowen test\"}"
```

### Passing build

[tpu-inference-dev #527](https://buildkite.com/tpu-commons/tpu-inference-dev/builds/527)
— server ready in 19.5 min (JAX cache warm from prior run, HF model cold),
lm_eval finished with `mmlu_pro exact_match = 0.83 ± 0.0139` on 50 samples.

### Gotchas surfaced while building this

1. `run_in_docker.sh` only propagates an allowlist of env vars into the
   container. Custom vars consumed by the server process can be `export`ed
   inside the script that runs the `vllm serve` (as done here) instead of
   modifying `run_in_docker.sh`.
2. `lm_eval` requires `--output_path` whenever `--log_samples` is passed,
   or it dies at argument validation before sending any prompt.
3. `vllm serve`'s stdout has to be tee'd into the script's stdout (or
   periodically tailed) — otherwise the Buildkite job log shows nothing
   during the cold-compile wait, and a hang is indistinguishable from
   progress. This script tails the last 30 lines every ~5 min.
4. JAX cache is GCS-shared across all `tpu_v7x_8_queue` agents
   (`gs://ullm-ci-cache/jax_cache/jax<ver>_tpu<v>`), so a cold first run
   for a unique env-var combo benefits every subsequent run.
   HF model weights cache is per-agent only — the first agent to pick up
   any new large model pays the download.