### PR TITLE
[releases/v0.22.0] Cherry-pick #2786: [Bugfix] Transpose unquantized kv_b_proj for upstream layout

### DIFF
--- a/tpu_inference/layers/vllm/custom_ops/mla_attention.py
+++ b/tpu_inference/layers/vllm/custom_ops/mla_attention.py
@@ -100,6 +100,17 @@ class VllmMLAAttention(MLAAttention):
 
     def process_weights_after_loading(self, act_dtype: torch.dtype):
         with torchax.default_env():
+            # tpu-inference's linear methods store layer.weight in [in_features,
+            # out_features] layout. Upstream MLA's process_weights_after_loading reads
+            # kv_b_proj.weight assuming [out_features, in_features] vLLM layout.
+            from vllm.model_executor.layers.linear import \
+                UnquantizedLinearMethod
+            if isinstance(self.kv_b_proj.quant_method,
+                          UnquantizedLinearMethod):
+                self.kv_b_proj.weight = Parameter(
+                    self.kv_b_proj.weight.transpose(0, 1).contiguous(),
+                    requires_grad=False,
+                )
             super().process_weights_after_loading(act_dtype)
 
             # NOTE: vLLM dequantizes kv_b_proj weights which causes more memory


### PR DESCRIPTION
Cherry-picks #2786 onto releases/v0.22.0.

Original PR: https://github.com/vllm-project/tpu-inference/pull/2786

## Why

\`tpu7x Unit tests for moonshotai/Kimi-K2.6\` has been failing on every nightly with:
\`\`\`
AssertionError: kv_b_proj_weight.shape=torch.Size([16384, 512]),
  self.kv_lora_rank=512, self.num_heads=64,
  self.qk_nope_head_dim=128, self.v_head_dim=128
\`\`\`
at \`vllm/model_executor/layers/attention/mla_attention.py:843\`.

The failure is pre-existing on \`main\` (e.g. tpu-inference-ci #18956, #18975, #19012) and reproduced on \`releases/v0.22.0\` nightly [tpu-inference-ci #18948](https://buildkite.com/tpu-commons/tpu-inference-ci/builds/18948) — both tpu7x runs failed identically. The tpu6e variant passes.

#2786 adds the missing \`kv_b_proj\` transpose so the unquantized MLA weight matches the layout the upstream vllm assertion expects.

## Test plan

- [ ] Trigger \`NIGHTLY=1\` build on \`releases/v0.22.0\` after merge; confirm \`tpu7x Unit tests for moonshotai/Kimi-K2.6\` passes.