### PR TITLE
[CI] relax flax_nnx vs vllm perf threshold from 8% to 10%

### DIFF
--- a/tests/e2e/test_model_loader.py
+++ b/tests/e2e/test_model_loader.py
@@ -253,8 +253,11 @@ def test_flax_nnx_vs_vllm_performance():
     difference is within a reasonable threshold.
     """
     model_name = "Qwen/Qwen3-4B"
-    # This should be 2-3% but 8% reduces flakiness.
-    percentage_difference_threshold = 0.08
+    # Ideally 2-3%, but we keep headroom because the vllm path's matmul
+    # layout was recently rebased onto the canonical (k, n) layout (#2706),
+    # which sped up vllm throughput while flax_nnx stayed put. Across 10
+    # runs on tpu6e the measured gap is 9.0-9.2%; 10% keeps the test stable.
+    percentage_difference_threshold = 0.10
 
     # Warmup each backend before measuring to populate JAX compilation cache.
     # Without this, the first-run backend pays the compilation cost and


### PR DESCRIPTION
## Summary

Raises the threshold in `tests/e2e/test_model_loader.py::test_flax_nnx_vs_vllm_performance` from 8% to 10%.

## Why

The vllm path's matmul weight layout was rebased onto the canonical `(k, n)` layout in #2706. That change sped up the vllm baseline by ~1.7% while flax_nnx throughput was unchanged, widening the relative `|flax - vllm| / vllm` gap. Across 10 dev-pipeline runs on tpu6e the measured gap landed in **9.0%-9.2%** consistently (mean 9.08%, σ 0.06pt) — every run above the previous 8% bar.

Result: `tpu6e Performance tests for Out-of-tree model support` started failing on every nightly since 2026-05-30 (first bad nightly [#18956](https://buildkite.com/tpu-commons/tpu-inference-ci/builds/18956)). It is also failing on `releases/v0.22.0` nightlies.

10% gives headroom over the post-#2706 baseline without losing all sensitivity to future regressions. Once flax_nnx catches up on the same matmul layout we should tighten this back down.

## Test plan

- [ ] dev-pipeline run of just this test should pass (measured gap ~9% is now well under the new 10% bar)