### PR TITLE
assert page_size must be power of 2 when the mask is used.

### DIFF
--- a/tpu_inference/kernels/experimental/batched_rpa/configs.py
+++ b/tpu_inference/kernels/experimental/batched_rpa/configs.py
@@ -76,6 +76,7 @@ class ServingConfigs:
 
     @property
     def page_size_mask(self) -> int:
+        assert self.page_size & (self.page_size - 1) == 0, f"Page {self.page_size} is not a power of 2."
         return self.page_size - 1
 
     @property


### PR DESCRIPTION
# Description

page_size_mask is only valid when the page_size is power of 2.

# Tests

Add assert only, rely on ci tests

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
