### PR TITLE
Fix MOE routed experts

### DIFF
--- a/tpu_inference/core/sched/dp_scheduler.py
+++ b/tpu_inference/core/sched/dp_scheduler.py
@@ -40,7 +40,8 @@ from vllm.v1.core.sched.scheduler import Scheduler
 from vllm.v1.engine import EngineCoreOutputs
 from vllm.v1.kv_cache_interface import KVCacheConfig
 from vllm.v1.metrics.stats import PrefixCacheStats, SchedulerStats
-from vllm.v1.outputs import DraftTokenIds, LogprobsLists, ModelRunnerOutput
+from vllm.v1.outputs import (DraftTokenIds, LogprobsLists, ModelRunnerOutput,
+                             RoutedExpertsLists)
 from vllm.v1.request import Request
 from vllm.v1.spec_decode.metrics import SpecDecodingStats
 from vllm.v1.structured_output import StructuredOutputManager
@@ -1069,16 +1070,17 @@ class DPScheduler(SchedulerInterface):
 
         outputs = []
 
-        expert_indices = getattr(g, "expert_indices", None)
-        req_id_to_token_range = {}
-        if expert_indices is not None:
+        routed_experts = getattr(g, "routed_experts", None)
+        req_id_to_routed_experts_range = {}
+        if routed_experts is not None:
             current_token_offset = 0
-            for req_id, num_tokens_scheduled in scheduler_output.num_scheduled_tokens.items(
-            ):
+            for req_id in g.req_ids:
+                num_tokens_scheduled = scheduler_output.num_scheduled_tokens[
+                    req_id]
                 start_idx = current_token_offset
                 end_idx = start_idx + num_tokens_scheduled
                 current_token_offset = end_idx
-                req_id_to_token_range[req_id] = (start_idx, end_idx)
+                req_id_to_routed_experts_range[req_id] = (start_idx, end_idx)
 
         for rank in range(self.dp_size):
             req_ids = scheduler_output.req_ids_per_rank.get(rank, [])
@@ -1108,20 +1110,26 @@ class DPScheduler(SchedulerInterface):
                 kv_connector_output=g.kv_connector_output,
             )
 
-            if expert_indices is not None:
-                rank_expert_indices = []
+            if routed_experts is not None:
+                rank_routing_data = []
+                rank_slot_mapping = []
                 for rid in req_ids:
-                    if rid in req_id_to_token_range:
-                        start_idx, end_idx = req_id_to_token_range[rid]
-                        rank_expert_indices.append(
-                            expert_indices[:, start_idx:end_idx, :])
-                if rank_expert_indices:
-                    rank_model_runner_output.expert_indices = np.concatenate(
-                        rank_expert_indices, axis=1)
+                    if rid in req_id_to_routed_experts_range:
+                        start_idx, end_idx = req_id_to_routed_experts_range[
+                            rid]
+                        rank_routing_data.append(routed_experts.routing_data[
+                            start_idx:end_idx, :, :])
+                        rank_slot_mapping.append(
+                            routed_experts.slot_mapping[start_idx:end_idx])
+
+                if rank_routing_data:
+                    rank_model_runner_output.routed_experts = RoutedExpertsLists(
+                        routing_data=np.concatenate(rank_routing_data, axis=0),
+                        slot_mapping=np.concatenate(rank_slot_mapping, axis=0))
                 else:
-                    rank_model_runner_output.expert_indices = None
+                    rank_model_runner_output.routed_experts = None
             else:
-                rank_model_runner_output.expert_indices = None
+                rank_model_runner_output.routed_experts = None
 
             outputs.append(rank_model_runner_output)
 

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -161,14 +161,13 @@ class AsyncTPUModelRunnerOutput(AsyncModelRunnerOutput):
                 jax.device_get(self._expert_indices))
 
             if self._scheduler_output is not None:
-                routed_experts_dict, routed_experts = _reconstruct_routed_experts(
+                routed_experts = _reconstruct_routed_experts(
                     runner=self._runner,
                     scheduler_output=self._scheduler_output,
                     expert_indices_cpu=expert_indices_cpu,
                     req_ids=self._model_runner_output.req_ids,
                     req_ids_dp=self._req_ids_dp,
                 )
-                self._model_runner_output.routed_experts_dict = routed_experts_dict
                 self._model_runner_output.routed_experts = routed_experts
 
         return self._model_runner_output
@@ -390,39 +389,10 @@ def _reconstruct_routed_experts(
     expert_indices_reordered = expert_indices_cpu[:, indices_map, :].transpose(
         1, 0, 2)
 
-    # 4. Slice the reordered array to update request history buffers
-    routed_experts_dict = {}
-    for req_id in req_ids:
-        req_state = runner.requests[req_id]
-        n = scheduler_output.num_scheduled_tokens[req_id]
-        global_start = global_start_offsets[req_id]
-        global_end = global_start + n
-
-        step_experts = expert_indices_reordered[global_start:global_end, :, :]
-
-        # Maintain old history buffer
-        if not hasattr(req_state, "_routed_experts_buf"):
-            _, layers, top_k = step_experts.shape
-            req_state._routed_experts_buf = np.zeros(
-                (runner.max_model_len, layers, top_k),
-                dtype=step_experts.dtype)
-            req_state._routed_experts_len = 0
-
-        offset = req_state._routed_experts_len
-        allowed = min(n, runner.max_model_len - offset)
-        if allowed > 0:
-            req_state._routed_experts_buf[offset:offset +
-                                          allowed] = (step_experts[:allowed])
-            req_state._routed_experts_len += allowed
-
-        routed_experts_dict[
-            req_id] = req_state._routed_experts_buf[:req_state.
-                                                    _routed_experts_len]
-
     routed_experts = RoutedExpertsLists(routing_data=expert_indices_reordered,
                                         slot_mapping=global_slots)
 
-    return routed_experts_dict, routed_experts
+    return routed_experts
 
 
 class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
@@ -1535,14 +1505,13 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         if self.model_config.enable_return_routed_experts and expert_indices is not None:
             expert_indices_cpu = np.asarray(jax.device_get(expert_indices))
 
-            routed_experts_dict, routed_experts = _reconstruct_routed_experts(
+            routed_experts = _reconstruct_routed_experts(
                 runner=self,
                 scheduler_output=scheduler_output,
                 expert_indices_cpu=expert_indices_cpu,
                 req_ids=self.input_batch.req_ids[:num_reqs],
                 req_ids_dp=req_ids_dp,
             )
-            model_runner_output.routed_experts_dict = routed_experts_dict
             model_runner_output.routed_experts = routed_experts
 
         return model_runner_output

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -123,6 +123,7 @@ class AsyncTPUModelRunnerOutput(AsyncModelRunnerOutput):
                  spec_decode_metadata: Optional[SpecDecodeMetadata] = None,
                  scheduler_output: Optional["VllmSchedulerOutput"] = None,
                  req_ids_dp: Optional[Dict] = None,
+                 padded_num_scheduled_tokens_per_dp_rank: int = 0,
                  runner=None):
         self._model_runner_output = model_runner_output
         self._next_tokens = next_tokens
@@ -136,6 +137,7 @@ class AsyncTPUModelRunnerOutput(AsyncModelRunnerOutput):
         self._spec_decode_metadata = spec_decode_metadata
         self._scheduler_output = scheduler_output
         self._req_ids_dp = req_ids_dp
+        self._padded_num_scheduled_tokens_per_dp_rank = padded_num_scheduled_tokens_per_dp_rank
         self._runner = runner
 
     def get_output(self) -> ModelRunnerOutput:
@@ -167,6 +169,8 @@ class AsyncTPUModelRunnerOutput(AsyncModelRunnerOutput):
                     expert_indices_cpu=expert_indices_cpu,
                     req_ids=self._model_runner_output.req_ids,
                     req_ids_dp=self._req_ids_dp,
+                    padded_num_scheduled_tokens_per_dp_rank=self.
+                    _padded_num_scheduled_tokens_per_dp_rank,
                 )
                 self._model_runner_output.routed_experts = routed_experts
 
@@ -213,6 +217,7 @@ class ExecuteModelState:
     # Prompt logprobs fields: populated only when any request has prompt_logprobs set.
     full_logits: Optional[jax.Array] = None
     req_ids_dp: Optional[Dict] = None
+    padded_num_scheduled_tokens_per_dp_rank: int = 0
 
 
 @jax.jit(donate_argnums=(0, 1, 2))
@@ -302,33 +307,14 @@ def _reconstruct_routed_experts(
     scheduler_output: "VllmSchedulerOutput",
     expert_indices_cpu: np.ndarray,
     req_ids: List[str],
-    req_ids_dp: Optional[Dict] = None,
-) -> Tuple[Dict[str, np.ndarray], RoutedExpertsLists]:
+    req_ids_dp: Dict,
+    padded_num_scheduled_tokens_per_dp_rank: int,
+) -> RoutedExpertsLists:
     """Reconstructs physical slot mappings and performs DP-rank reordering for MoE routed expert indices."""
     num_layers, _, top_k = expert_indices_cpu.shape
     block_size = runner.block_size
     total_active_tokens = scheduler_output.total_num_scheduled_tokens
     dp_size = runner.dp_size
-
-    if dp_size > 1:
-        num_scheduled_tokens_per_dp_rank = {
-            dp_rank: 0
-            for dp_rank in range(dp_size)
-        }
-        for req_id in req_ids:
-            dp_rank = scheduler_output.assigned_dp_rank[req_id]
-            num_scheduled_tokens_per_dp_rank[
-                dp_rank] += scheduler_output.num_scheduled_tokens[req_id]
-
-        max_num_scheduled_tokens_across_dp = max(
-            num_scheduled_tokens_per_dp_rank.values())
-        padded_num_scheduled_tokens_per_dp_rank = runner_utils.get_padded_token_len(
-            runner.num_tokens_paddings_per_dp,
-            max_num_scheduled_tokens_across_dp)
-    else:
-        padded_num_scheduled_tokens_per_dp_rank = total_active_tokens
-
-    req_ids_dp_local = req_ids_dp if req_ids_dp is not None else {0: req_ids}
 
     # 1. Compute global start offsets of every request in input batch order
     global_start_offsets = {}
@@ -343,13 +329,13 @@ def _reconstruct_routed_experts(
     global_slots = np.zeros(total_active_tokens, dtype=np.int32)
 
     for dp_rank in range(dp_size):
-        if dp_rank not in req_ids_dp_local:
+        if dp_rank not in req_ids_dp:
             continue
 
         token_offset = padded_num_scheduled_tokens_per_dp_rank * dp_rank
         current_dp_offset = token_offset
 
-        for req_id in req_ids_dp_local[dp_rank]:
+        for req_id in req_ids_dp[dp_rank]:
             n = scheduler_output.num_scheduled_tokens[req_id]
             dp_start = current_dp_offset
             dp_end = dp_start + n
@@ -932,7 +918,8 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         (scheduler_output, attn_metadata, sampling_metadata, input_ids,
          hidden_states, logits, aux_hidden_states, spec_decode_metadata,
          kv_connector_output, logits_indices_selector, padded_num_reqs,
-         expert_indices, full_hidden_states, full_logits, req_ids_dp) = (
+         expert_indices, full_hidden_states, full_logits, req_ids_dp,
+         padded_num_scheduled_tokens_per_dp_rank) = (
              self.execute_model_state.scheduler_output,
              self.execute_model_state.attn_metadata,
              self.execute_model_state.sampling_metadata,
@@ -948,6 +935,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
              self.execute_model_state.full_hidden_states,
              self.execute_model_state.full_logits,
              self.execute_model_state.req_ids_dp,
+             self.execute_model_state.padded_num_scheduled_tokens_per_dp_rank,
          )
         self.execute_model_state = None
 
@@ -966,7 +954,8 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             scheduler_output, attn_metadata, sampling_metadata, input_ids,
             hidden_states, logits, aux_hidden_states, spec_decode_metadata,
             kv_connector_output, logits_indices_selector, padded_num_reqs,
-            expert_indices, full_hidden_states, full_logits, req_ids_dp)
+            expert_indices, full_hidden_states, full_logits, req_ids_dp,
+            padded_num_scheduled_tokens_per_dp_rank)
 
     def _modify_prev_results(self):
         # If copy to host has not been done, we just wait.
@@ -1241,6 +1230,8 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             full_hidden_states=full_hidden_states,
             full_logits=full_logits,
             req_ids_dp=req_ids_dp,
+            padded_num_scheduled_tokens_per_dp_rank=
+            padded_num_scheduled_tokens_per_dp_rank,
         )
         return None
 
@@ -1261,6 +1252,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         full_hidden_states: Optional[jax.Array] = None,
         full_logits: Optional[jax.Array] = None,
         req_ids_dp: Optional[Dict] = None,
+        padded_num_scheduled_tokens_per_dp_rank: int = 0,
     ) -> ModelRunnerOutput | AsyncTPUModelRunnerOutput:
         if padded_num_reqs is None:
             padded_num_reqs = runner_utils.get_padded_num_reqs_with_upper_limit(
@@ -1457,6 +1449,8 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                 spec_decode_metadata=spec_decode_metadata,
                 scheduler_output=scheduler_output,
                 req_ids_dp=req_ids_dp,
+                padded_num_scheduled_tokens_per_dp_rank=
+                padded_num_scheduled_tokens_per_dp_rank,
                 runner=self)
             return async_model_runner_output
 
@@ -1511,6 +1505,8 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                 expert_indices_cpu=expert_indices_cpu,
                 req_ids=self.input_batch.req_ids[:num_reqs],
                 req_ids_dp=req_ids_dp,
+                padded_num_scheduled_tokens_per_dp_rank=
+                padded_num_scheduled_tokens_per_dp_rank,
             )
             model_runner_output.routed_experts = routed_experts
 

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -42,7 +42,8 @@ from vllm.v1.core.sched.output import SchedulerOutput as VllmSchedulerOutput
 from vllm.v1.kv_cache_interface import KVCacheConfig
 from vllm.v1.outputs import (EMPTY_MODEL_RUNNER_OUTPUT, AsyncModelRunnerOutput,
                              DraftTokenIds, KVConnectorOutput, LogprobsLists,
-                             LogprobsTensors, ModelRunnerOutput)
+                             LogprobsTensors, ModelRunnerOutput,
+                             RoutedExpertsLists)
 from vllm.v1.request import Request
 from vllm.v1.spec_decode.ngram_proposer import NgramProposer
 from vllm.v1.worker.kv_connector_model_runner_mixin import \
@@ -120,6 +121,8 @@ class AsyncTPUModelRunnerOutput(AsyncModelRunnerOutput):
                  expert_indices: Optional[jax.Array] = None,
                  total_num_scheduled_tokens: int = 0,
                  spec_decode_metadata: Optional[SpecDecodeMetadata] = None,
+                 scheduler_output: Optional["VllmSchedulerOutput"] = None,
+                 req_ids_dp: Optional[Dict] = None,
                  runner=None):
         self._model_runner_output = model_runner_output
         self._next_tokens = next_tokens
@@ -131,6 +134,8 @@ class AsyncTPUModelRunnerOutput(AsyncModelRunnerOutput):
         self._expert_indices = expert_indices
         self._total_num_scheduled_tokens = total_num_scheduled_tokens
         self._spec_decode_metadata = spec_decode_metadata
+        self._scheduler_output = scheduler_output
+        self._req_ids_dp = req_ids_dp
         self._runner = runner
 
     def get_output(self) -> ModelRunnerOutput:
@@ -151,12 +156,20 @@ class AsyncTPUModelRunnerOutput(AsyncModelRunnerOutput):
                 self._runner._get_prompt_logprobs_dict(
                     self._prompt_logprobs_async_data))
 
-        if self._expert_indices is not None:
+        if self._runner.model_config.enable_return_routed_experts and self._expert_indices is not None:
             expert_indices_cpu = np.asarray(
                 jax.device_get(self._expert_indices))
-            expert_indices_cpu = expert_indices_cpu[:, :self.
-                                                    _total_num_scheduled_tokens, :]
-            self._model_runner_output.expert_indices = expert_indices_cpu
+
+            if self._scheduler_output is not None:
+                routed_experts_dict, routed_experts = _reconstruct_routed_experts(
+                    runner=self._runner,
+                    scheduler_output=self._scheduler_output,
+                    expert_indices_cpu=expert_indices_cpu,
+                    req_ids=self._model_runner_output.req_ids,
+                    req_ids_dp=self._req_ids_dp,
+                )
+                self._model_runner_output.routed_experts_dict = routed_experts_dict
+                self._model_runner_output.routed_experts = routed_experts
 
         return self._model_runner_output
 
@@ -283,6 +296,133 @@ def _jax_logprobs_materialize(
         sampled_token_ranks=np.array(selected_token_ranks.tolist()),
         cu_num_generated_tokens=cu_num_generated_tokens,
     )
+
+
+def _reconstruct_routed_experts(
+    runner,
+    scheduler_output: "VllmSchedulerOutput",
+    expert_indices_cpu: np.ndarray,
+    req_ids: List[str],
+    req_ids_dp: Optional[Dict] = None,
+) -> Tuple[Dict[str, np.ndarray], RoutedExpertsLists]:
+    """Reconstructs physical slot mappings and performs DP-rank reordering for MoE routed expert indices."""
+    num_layers, _, top_k = expert_indices_cpu.shape
+    block_size = runner.block_size
+    total_active_tokens = scheduler_output.total_num_scheduled_tokens
+    dp_size = runner.dp_size
+
+    if dp_size > 1:
+        num_scheduled_tokens_per_dp_rank = {
+            dp_rank: 0
+            for dp_rank in range(dp_size)
+        }
+        for req_id in req_ids:
+            dp_rank = scheduler_output.assigned_dp_rank[req_id]
+            num_scheduled_tokens_per_dp_rank[
+                dp_rank] += scheduler_output.num_scheduled_tokens[req_id]
+
+        max_num_scheduled_tokens_across_dp = max(
+            num_scheduled_tokens_per_dp_rank.values())
+        padded_num_scheduled_tokens_per_dp_rank = runner_utils.get_padded_token_len(
+            runner.num_tokens_paddings_per_dp,
+            max_num_scheduled_tokens_across_dp)
+    else:
+        padded_num_scheduled_tokens_per_dp_rank = total_active_tokens
+
+    req_ids_dp_local = req_ids_dp if req_ids_dp is not None else {0: req_ids}
+
+    # 1. Compute global start offsets of every request in input batch order
+    global_start_offsets = {}
+    current_global_offset = 0
+    for req_id in req_ids:
+        global_start_offsets[req_id] = current_global_offset
+        current_global_offset += scheduler_output.num_scheduled_tokens[req_id]
+
+    # 2. Map DP-sharded indices to global contiguous input batch order,
+    # and reconstruct physical slots in a single pre-allocated array.
+    indices_map = np.zeros(total_active_tokens, dtype=np.int32)
+    global_slots = np.zeros(total_active_tokens, dtype=np.int32)
+
+    for dp_rank in range(dp_size):
+        if dp_rank not in req_ids_dp_local:
+            continue
+
+        token_offset = padded_num_scheduled_tokens_per_dp_rank * dp_rank
+        current_dp_offset = token_offset
+
+        for req_id in req_ids_dp_local[dp_rank]:
+            n = scheduler_output.num_scheduled_tokens[req_id]
+            dp_start = current_dp_offset
+            dp_end = dp_start + n
+            current_dp_offset = dp_end
+
+            global_start = global_start_offsets[req_id]
+            global_end = global_start + n
+
+            # Map sharded JAX positions to global contiguous positions
+            indices_map[global_start:global_end] = np.arange(dp_start,
+                                                             dp_end,
+                                                             dtype=np.int32)
+
+            # Reconstruct slots for this request using vectorized NumPy
+            req_state = runner.requests[req_id]
+            start_pos = req_state.num_computed_tokens
+            block_ids = req_state.block_ids[0] if req_state.block_ids else []
+
+            if n > 0:
+                pos = np.arange(start_pos, start_pos + n, dtype=np.int32)
+                block_idx = pos // block_size
+
+                if block_ids:
+                    # Pad block_ids with 0s up to the max required index to avoid IndexError
+                    block_ids_arr = np.zeros(max(len(block_ids),
+                                                 int(block_idx[-1]) + 1),
+                                             dtype=np.int32)
+                    block_ids_arr[:len(block_ids)] = block_ids
+                    block_id = block_ids_arr[block_idx]
+                    slots_arr = block_id * block_size + (pos % block_size)
+                else:
+                    slots_arr = np.zeros_like(pos, dtype=np.int32)
+
+                global_slots[global_start:global_end] = slots_arr
+
+    # 3. Perform global rank reordering and transpose in a single fancy indexing sweep!
+    expert_indices_reordered = expert_indices_cpu[:, indices_map, :].transpose(
+        1, 0, 2)
+
+    # 4. Slice the reordered array to update request history buffers
+    routed_experts_dict = {}
+    for req_id in req_ids:
+        req_state = runner.requests[req_id]
+        n = scheduler_output.num_scheduled_tokens[req_id]
+        global_start = global_start_offsets[req_id]
+        global_end = global_start + n
+
+        step_experts = expert_indices_reordered[global_start:global_end, :, :]
+
+        # Maintain old history buffer
+        if not hasattr(req_state, "_routed_experts_buf"):
+            _, layers, top_k = step_experts.shape
+            req_state._routed_experts_buf = np.zeros(
+                (runner.max_model_len, layers, top_k),
+                dtype=step_experts.dtype)
+            req_state._routed_experts_len = 0
+
+        offset = req_state._routed_experts_len
+        allowed = min(n, runner.max_model_len - offset)
+        if allowed > 0:
+            req_state._routed_experts_buf[offset:offset +
+                                          allowed] = (step_experts[:allowed])
+            req_state._routed_experts_len += allowed
+
+        routed_experts_dict[
+            req_id] = req_state._routed_experts_buf[:req_state.
+                                                    _routed_experts_len]
+
+    routed_experts = RoutedExpertsLists(routing_data=expert_indices_reordered,
+                                        slot_mapping=global_slots)
+
+    return routed_experts_dict, routed_experts
 
 
 class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
@@ -1345,6 +1485,8 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                 total_num_scheduled_tokens=scheduler_output.
                 total_num_scheduled_tokens,
                 spec_decode_metadata=spec_decode_metadata,
+                scheduler_output=scheduler_output,
+                req_ids_dp=req_ids_dp,
                 runner=self)
             return async_model_runner_output
 
@@ -1390,44 +1532,18 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             kv_connector_output=kv_connector_output,
         )
 
-        if expert_indices is not None:
+        if self.model_config.enable_return_routed_experts and expert_indices is not None:
             expert_indices_cpu = np.asarray(jax.device_get(expert_indices))
 
-            routed_experts_dict = {}
-            current_token_offset = 0
-            for req_id in self.input_batch.req_ids[:num_reqs]:
-                req_state = self.requests[req_id]
-                num_tokens_scheduled = scheduler_output.num_scheduled_tokens[
-                    req_id]
-                start_idx = current_token_offset
-                end_idx = start_idx + num_tokens_scheduled
-                current_token_offset = end_idx
-
-                # Shape: (num_tokens_scheduled, num_layers, top_k)
-                step_experts = expert_indices_cpu[:, start_idx:
-                                                  end_idx, :].transpose(
-                                                      1, 0, 2)
-
-                if not hasattr(req_state, "_routed_experts_buf"):
-                    _, layers, top_k = step_experts.shape
-                    req_state._routed_experts_buf = np.zeros(
-                        (self.max_model_len, layers, top_k),
-                        dtype=step_experts.dtype)
-                    req_state._routed_experts_len = 0
-
-                offset = req_state._routed_experts_len
-                allowed = min(num_tokens_scheduled,
-                              self.max_model_len - offset)
-                if allowed > 0:
-                    req_state._routed_experts_buf[offset:offset + allowed] = (
-                        step_experts[:allowed])
-                    req_state._routed_experts_len += allowed
-
-                routed_experts_dict[
-                    req_id] = req_state._routed_experts_buf[:req_state.
-                                                            _routed_experts_len]
-
+            routed_experts_dict, routed_experts = _reconstruct_routed_experts(
+                runner=self,
+                scheduler_output=scheduler_output,
+                expert_indices_cpu=expert_indices_cpu,
+                req_ids=self.input_batch.req_ids[:num_reqs],
+                req_ids_dp=req_ids_dp,
+            )
             model_runner_output.routed_experts_dict = routed_experts_dict
+            model_runner_output.routed_experts = routed_experts
 
         return model_runner_output
 


### PR DESCRIPTION
# Description

Upstream expert routing had a few changes that broke our routed expert IDs.

https://github.com/vllm-project/vllm/commit/8c79ad65804d042dfaf7ce0e9fd28f503f9266a9
https://github.com/vllm-project/vllm/commit/c7560af42487b1570c4e6f4cea5df1605a4d59fc

Now vLLM scheduler expects `RoutedExpertsLists` which requires slot mapping as well as the experts.

# Tests

Profiling

```
VLLM_DISABLE_COMPILE_CACHE=1  SKIP_JAX_PRECOMPILE=1 MODEL_IMPL_TYPE=flax_nnx python3 examples/tpu_profiling.py --profile-result-dir=gs://piv-test/tpu-profile/may26/1/ --model=Qwen/Qwen3-30B-A3B-Instruct-2507 --no-async-scheduling --data-parallel-size=8 --enable_return_routed_experts
```

disabled https://xprof.corp.google.com/trace_viewer/piv-160669453725893345

enabled https://xprof.corp.google.com/trace_viewer/piv-8573643791819346944

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
