### PR TITLE
[DeeSeek V4] The 2nd PR for DS V4 bring up

### DIFF
--- a/tpu_inference/kernels/megablox/gmm_v2.py
+++ b/tpu_inference/kernels/megablox/gmm_v2.py
@@ -39,6 +39,17 @@ def swigluoai(gate: jax.Array,
     return (up + 1.0) * glu
 
 
+def silu_and_mul_with_clamp(gate: jax.Array,
+                            up: jax.Array,
+                            limit: float = 10.0) -> jax.Array:
+    """Activation used in some models DeepSeek V4."""
+    # The limit value is from DSV4's config.
+    # TODO: pass limit from model config, instead of hardcoding here.
+    gate = jnp.clip(gate, max=limit)
+    up = jnp.clip(up, min=-limit, max=limit)
+    return jax.nn.silu(gate) * up
+
+
 def apply_act_fn(acc: jax.Array, fuse_act: str | None):
     """Applies a fused activation function to the accumulator.
 
@@ -69,6 +80,8 @@ def apply_act_fn(acc: jax.Array, fuse_act: str | None):
             return jax.nn.gelu(acc_gate) * acc_up
         case "swigluoai":
             return swigluoai(acc_gate, acc_up)
+        case "silu_and_mul_with_clamp":
+            return silu_and_mul_with_clamp(acc_gate, acc_up)
         case _:
             raise NotImplementedError(
                 f"Unsupported activation function: {fuse_act}")

--- a/tpu_inference/layers/common/fused_moe_gmm.py
+++ b/tpu_inference/layers/common/fused_moe_gmm.py
@@ -494,6 +494,8 @@ def fused_moe_func(
     enable_rs_kernel: bool = False,
     onehot_moe_permute_threshold: int = 0,
     scatter_results: bool = False,
+    hash_based_topk_indices: jax.Array | None = None,
+    e_score_correction_bias: jax.Array | None = None,
 ) -> jax.Array:
     """Route tokens in hidden_states into each experts based on routing.
 
@@ -528,13 +530,24 @@ def fused_moe_func(
     assert gating_output.shape == (num_tokens, global_num_experts)
 
     topk_weights = apply_scoring_fn(scoring_fn, gating_output)
-    if envs.MOE_APPROX_TOPK:
+    if hash_based_topk_indices is not None:
+        topk_indices = hash_based_topk_indices
+        topk_weights = jnp.take_along_axis(topk_weights, topk_indices, axis=-1)
+    elif envs.MOE_APPROX_TOPK:
         topk_weights, topk_indices = jax.lax.approx_max_k(
             topk_weights,
             k=topk,
             recall_target=envs.MOE_APPROX_TOPK_RECALL_TARGET)
     else:
-        topk_weights, topk_indices = jax.lax.top_k(topk_weights, k=topk)
+        if e_score_correction_bias is not None:
+            _, topk_indices = jax.lax.top_k(topk_weights +
+                                            e_score_correction_bias[None, :],
+                                            k=topk)
+            topk_weights = jnp.take_along_axis(topk_weights,
+                                               topk_indices,
+                                               axis=-1)
+        else:
+            topk_weights, topk_indices = jax.lax.top_k(topk_weights, k=topk)
     if renormalize:
         topk_weights = topk_weights / topk_weights.sum(axis=-1, keepdims=True)
     # All gathering topk_indices and topk_weights if attention dp is used.

--- a/tpu_inference/layers/common/fused_moe_gmm.py
+++ b/tpu_inference/layers/common/fused_moe_gmm.py
@@ -495,7 +495,7 @@ def fused_moe_func(
     onehot_moe_permute_threshold: int = 0,
     scatter_results: bool = False,
     hash_based_topk_indices: jax.Array | None = None,
-    e_score_correction_bias: jax.Array | None = None,
+    expert_score_correction_bias: jax.Array | None = None,
 ) -> jax.Array:
     """Route tokens in hidden_states into each experts based on routing.
 
@@ -539,10 +539,9 @@ def fused_moe_func(
             k=topk,
             recall_target=envs.MOE_APPROX_TOPK_RECALL_TARGET)
     else:
-        if e_score_correction_bias is not None:
-            _, topk_indices = jax.lax.top_k(topk_weights +
-                                            e_score_correction_bias[None, :],
-                                            k=topk)
+        if expert_score_correction_bias is not None:
+            _, topk_indices = jax.lax.top_k(
+                topk_weights + expert_score_correction_bias[None, :], k=topk)
             topk_weights = jnp.take_along_axis(topk_weights,
                                                topk_indices,
                                                axis=-1)

--- a/tpu_inference/layers/common/moe.py
+++ b/tpu_inference/layers/common/moe.py
@@ -86,6 +86,8 @@ def moe_apply(
     with jax.named_scope(layer._get_name()):
         activation = layer.activation if isinstance(
             layer.activation, str) else layer.activation.value
+        if activation == "silu" and getattr(layer, "swiglu_limit", 0) > 0:
+            activation = "silu_and_mul_with_clamp"
         match moe_backend:
             case MoEBackend.FUSED_MOE:
                 subc_quant_w1_sz = None
@@ -153,6 +155,10 @@ def moe_apply(
                     onehot_moe_permute_threshold=envs.
                     ONEHOT_MOE_PERMUTE_THRESHOLD,
                     scatter_results=scatter_results,
+                    hash_based_topk_indices=extra_backend_kwargs.get(
+                        "hash_based_topk_indices", None),
+                    e_score_correction_bias=extra_backend_kwargs.get(
+                        "e_score_correction_bias", None),
                 )
             case MoEBackend.DENSE_MAT:
                 # NOTE: circular import avoidance

--- a/tpu_inference/layers/common/moe.py
+++ b/tpu_inference/layers/common/moe.py
@@ -86,8 +86,10 @@ def moe_apply(
     with jax.named_scope(layer._get_name()):
         activation = layer.activation if isinstance(
             layer.activation, str) else layer.activation.value
-        if activation == "silu" and getattr(layer, "swiglu_limit", 0) > 0:
-            activation = "silu_and_mul_with_clamp"
+        if activation == "silu":
+            swiglu_limit = getattr(layer, "swiglu_limit", None)
+            if swiglu_limit is not None and swiglu_limit > 0:
+                activation = "silu_and_mul_with_clamp"
         match moe_backend:
             case MoEBackend.FUSED_MOE:
                 subc_quant_w1_sz = None
@@ -157,7 +159,7 @@ def moe_apply(
                     scatter_results=scatter_results,
                     hash_based_topk_indices=extra_backend_kwargs.get(
                         "hash_based_topk_indices", None),
-                    e_score_correction_bias=extra_backend_kwargs.get(
+                    expert_score_correction_bias=extra_backend_kwargs.get(
                         "e_score_correction_bias", None),
                 )
             case MoEBackend.DENSE_MAT:

--- a/tpu_inference/layers/vllm/custom_ops/fused_moe.py
+++ b/tpu_inference/layers/vllm/custom_ops/fused_moe.py
@@ -54,4 +54,4 @@ class VllmFusedMoE(FusedMoE):
         hidden_states: torch.Tensor,
         router_logits: torch.Tensor,
     ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
-        return super().forward(hidden_states, router_logits)
+        return super().forward(hidden_states, router_logits, input_ids)

--- a/tpu_inference/layers/vllm/custom_ops/fused_moe.py
+++ b/tpu_inference/layers/vllm/custom_ops/fused_moe.py
@@ -53,5 +53,6 @@ class VllmFusedMoE(FusedMoE):
         self,
         hidden_states: torch.Tensor,
         router_logits: torch.Tensor,
+        input_ids: torch.Tensor | None = None,
     ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
         return super().forward(hidden_states, router_logits, input_ids)

--- a/tpu_inference/layers/vllm/interface/moe.py
+++ b/tpu_inference/layers/vllm/interface/moe.py
@@ -59,9 +59,12 @@ def select_moe_backend_from_fused_moe_config(
     return MoEBackend.GMM_TP
 
 
-def vllm_moe_apply(layer: FusedMoE, weights: FusedMoEWeights,
-                   quant_method_instance: FusedMoEMethodBase, x: torch.Tensor,
-                   router_logits: torch.Tensor) -> torch.Tensor:
+def vllm_moe_apply(layer: FusedMoE,
+                   weights: FusedMoEWeights,
+                   quant_method_instance: FusedMoEMethodBase,
+                   x: torch.Tensor,
+                   router_logits: torch.Tensor,
+                   input_ids: torch.Tensor | None = None) -> torch.Tensor:
     """
     Shared function for applying a FusedMoE layer for the TorchAX/vLLM backend.
 
@@ -107,6 +110,16 @@ def vllm_moe_apply(layer: FusedMoE, weights: FusedMoEWeights,
 
     extra_kwargs = dict(quant_method_instance.extra_backend_kwargs)
     extra_kwargs["scatter_results"] = is_dp
+
+    if getattr(layer, "hash_indices_table", None) is not None:
+        assert input_ids is not None, "input_ids must be provided when hash_indices_table is present in the layer"
+        hash_table = layer.hash_indices_table
+        hash_based_topk_indices = jax_view(hash_table)[jax_view(input_ids)]
+        extra_kwargs["hash_based_topk_indices"] = hash_based_topk_indices
+
+    if getattr(layer, "e_score_correction_bias", None) is not None:
+        extra_kwargs["e_score_correction_bias"] = jax_view(
+            layer.e_score_correction_bias)
 
     return torch_view(
         moe_apply(

--- a/tpu_inference/layers/vllm/process_weights/cleanup_sharding.py
+++ b/tpu_inference/layers/vllm/process_weights/cleanup_sharding.py
@@ -26,6 +26,7 @@ from vllm.lora.layers import (ColumnParallelLinearWithLoRA,
                               ReplicatedLinearWithLoRA,
                               RowParallelLinearWithLoRA)
 from vllm.lora.layers.base_linear import BaseLinearLayerWithLoRA
+from vllm.model_executor.layers.fused_moe import FusedMoE
 
 from tpu_inference.layers.common.utils import general_device_put
 from tpu_inference.logger import init_logger
@@ -178,6 +179,23 @@ def _shard_row_parallel_linear_lora(layer: RowParallelLinearWithLoRA,
     _shard_base_linear_lora_replicated(layer, mesh)
 
 
+def _replicate_fused_moe_hash_indices_tables_and_e_score_correction_bias(
+        module: torch.nn.Module, mesh: Mesh) -> None:
+    if isinstance(module, FusedMoE):
+        table = getattr(module, "hash_indices_table", None)
+        if table is not None:
+            sharded = _shard_tensor_to_tpu_replicated(table, mesh)
+            module.hash_indices_table = torch.nn.Parameter(sharded,
+                                                           requires_grad=False)
+        e_score_correction_bias = getattr(module, "e_score_correction_bias",
+                                          None)
+        if e_score_correction_bias is not None:
+            sharded = _shard_tensor_to_tpu_replicated(e_score_correction_bias,
+                                                      mesh)
+            module.e_score_correction_bias = torch.nn.Parameter(
+                sharded, requires_grad=False)
+
+
 # NOTE: Ordering is important as it calls first matched type of a given module
 MODULE_TYPE_TO_SHARDING_FUNC = [
     # Shard LoRA layers
@@ -193,6 +211,8 @@ MODULE_TYPE_TO_SHARDING_FUNC = [
 
 def _shard_module_to_tpu(model: torch.nn.Module, mesh: Mesh) -> None:
     for path, module in model.named_modules():
+        _replicate_fused_moe_hash_indices_tables_and_e_score_correction_bias(
+            module, mesh)
         for module_type, sharding_func in MODULE_TYPE_TO_SHARDING_FUNC:
             if type(module) is module_type:
                 logger.debug("shard %s with %s", path, sharding_func)

--- a/tpu_inference/layers/vllm/quantization/awq.py
+++ b/tpu_inference/layers/vllm/quantization/awq.py
@@ -496,4 +496,5 @@ class VllmAWQMoEMethod(FusedMoEMethodBase):
                               weights=weights,
                               quant_method_instance=self,
                               x=x,
-                              router_logits=router_logits)
+                              router_logits=router_logits,
+                              input_ids=input_ids)

--- a/tpu_inference/layers/vllm/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_w4a8.py
+++ b/tpu_inference/layers/vllm/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_w4a8.py
@@ -321,4 +321,5 @@ class VllmCompressedTensorsW4A8MoEMethod(CompressedTensorsMoEMethod,
                               weights=weights,
                               quant_method_instance=self,
                               x=x,
-                              router_logits=router_logits)
+                              router_logits=router_logits,
+                              input_ids=input_ids)

--- a/tpu_inference/layers/vllm/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_w8a8_fp8.py
+++ b/tpu_inference/layers/vllm/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_w8a8_fp8.py
@@ -147,4 +147,5 @@ class VllmCompressedTensorsW8A8Fp8MoEMethod(CompressedTensorsW8A8Fp8MoEMethod,
                               weights=weights,
                               quant_method_instance=self,
                               x=x,
-                              router_logits=router_logits)
+                              router_logits=router_logits,
+                              input_ids=input_ids)

--- a/tpu_inference/layers/vllm/quantization/fp8.py
+++ b/tpu_inference/layers/vllm/quantization/fp8.py
@@ -316,4 +316,5 @@ class VllmFp8MoEMethod(vllm_fp8.Fp8MoEMethod):
                               weights=weights,
                               quant_method_instance=self,
                               x=x,
-                              router_logits=router_logits)
+                              router_logits=router_logits,
+                              input_ids=input_ids)

--- a/tpu_inference/layers/vllm/quantization/mxfp4.py
+++ b/tpu_inference/layers/vllm/quantization/mxfp4.py
@@ -221,4 +221,5 @@ class VllmMxfp4MoEMethod(Mxfp4MoEMethod):
                               weights=weights,
                               quant_method_instance=self,
                               x=x,
-                              router_logits=router_logits)
+                              router_logits=router_logits,
+                              input_ids=input_ids)

--- a/tpu_inference/layers/vllm/quantization/nvfp4.py
+++ b/tpu_inference/layers/vllm/quantization/nvfp4.py
@@ -466,4 +466,5 @@ class VllmNvfp4MoEMethod(FusedMoEMethodBase):
                               weights=weights,
                               quant_method_instance=self,
                               x=x,
-                              router_logits=router_logits)
+                              router_logits=router_logits,
+                              input_ids=kwargs.get("input_ids", None))

--- a/tpu_inference/layers/vllm/quantization/unquantized.py
+++ b/tpu_inference/layers/vllm/quantization/unquantized.py
@@ -453,4 +453,5 @@ class VllmUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod,
                               weights=weights,
                               quant_method_instance=self,
                               x=x,
-                              router_logits=router_logits)
+                              router_logits=router_logits,
+                              input_ids=input_ids)


### PR DESCRIPTION
[DeeSeek V4] The 2nd PR for DS V4 bring up

The main changes:
* Supoprt `silu_and_mul_with_clamp` activation fn in GMM v2

* Support Hash Table based token routing For MOE (DS V4's bottom 3 layer used Hash Table lookup based token routing instead of topk routiing)

* Support adding bias terms before topk selection (bias term is e_score_correction_bias of FusedMoE)

DS V4 need all 3 new structures.