### PR TITLE
Refactor the report architecture of the support matrix

### DIFF
--- a/.buildkite/excluded/meta-llama_Llama-4-Maverick-17B-128E-Instruct_multimodal.yml
+++ b/.buildkite/excluded/meta-llama_Llama-4-Maverick-17B-128E-Instruct_multimodal.yml
@@ -39,7 +39,7 @@ steps:
         .buildkite/scripts/record_step_result.sh ${BK_KEY}_meta-llama_Llama-4-Maverick-17B-128E-Instruct_multimodal_UnitTest
 
   - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Accuracy for meta-llama/Llama-4-Maverick-17B-128E-Instruct/multimodal"
-    key: "${BK_KEY}_meta-llama_Llama-4-Maverick-17B-128E-Instruct_multimodal_Accuracy"
+    key: "${BK_KEY}_meta-llama_Llama-4-Maverick-17B-128E-Instruct_multimodal_Accuracy_Correctness"
     depends_on: "${BK_KEY}_record_meta-llama_Llama-4-Maverick-17B-128E-Instruct_multimodal_UnitTest"
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
@@ -48,10 +48,10 @@ steps:
       MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     commands:
       - |
-        buildkite-agent meta-data set "${BK_KEY}_meta-llama_Llama-4-Maverick-17B-128E-Instruct_multimodal_Accuracy" "unverified"
+        buildkite-agent meta-data set "${BK_KEY}_meta-llama_Llama-4-Maverick-17B-128E-Instruct_multimodal_Accuracy_Correctness" "unverified"
   - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record accuracy result for meta-llama/Llama-4-Maverick-17B-128E-Instruct/multimodal"
-    key: "${BK_KEY}_record_meta-llama_Llama-4-Maverick-17B-128E-Instruct_multimodal_Accuracy"
-    depends_on: "${BK_KEY}_meta-llama_Llama-4-Maverick-17B-128E-Instruct_multimodal_Accuracy"
+    key: "${BK_KEY}_record_meta-llama_Llama-4-Maverick-17B-128E-Instruct_multimodal_Accuracy_Correctness"
+    depends_on: "${BK_KEY}_meta-llama_Llama-4-Maverick-17B-128E-Instruct_multimodal_Accuracy_Correctness"
     env:
       MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
@@ -62,11 +62,11 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${BK_KEY}_meta-llama_Llama-4-Maverick-17B-128E-Instruct_multimodal_Accuracy
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_meta-llama_Llama-4-Maverick-17B-128E-Instruct_multimodal_Accuracy_Correctness
 
   - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance benchmarks for meta-llama/Llama-4-Maverick-17B-128E-Instruct/multimodal"
     key: "${BK_KEY}_meta-llama_Llama-4-Maverick-17B-128E-Instruct_multimodal_Benchmark"
-    depends_on: "${BK_KEY}_record_meta-llama_Llama-4-Maverick-17B-128E-Instruct_multimodal_Accuracy"
+    depends_on: "${BK_KEY}_record_meta-llama_Llama-4-Maverick-17B-128E-Instruct_multimodal_Accuracy_Correctness"
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
     soft_fail: true

--- a/.buildkite/excluded/meta-llama_Llama-4-Maverick-17B-128E-Instruct_multimodal.yml
+++ b/.buildkite/excluded/meta-llama_Llama-4-Maverick-17B-128E-Instruct_multimodal.yml
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Unit tests for meta-llama/Llama-4-Maverick-17B-128E-Instruct/multimodal"
-    key: "${TPU_VERSION:-tpu6e}_meta-llama_Llama-4-Maverick-17B-128E-Instruct_multimodal_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Unit tests for meta-llama/Llama-4-Maverick-17B-128E-Instruct/multimodal"
+    key: "${BK_KEY}_meta-llama_Llama-4-Maverick-17B-128E-Instruct_multimodal_UnitTest"
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_meta-llama_Llama-4-Maverick-17B-128E-Instruct_multimodal_UnitTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record unit test result for meta-llama/Llama-4-Maverick-17B-128E-Instruct/multimodal"
-    key: "${TPU_VERSION:-tpu6e}_record_meta-llama_Llama-4-Maverick-17B-128E-Instruct_multimodal_UnitTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_meta-llama_Llama-4-Maverick-17B-128E-Instruct_multimodal_UnitTest"
+        buildkite-agent meta-data set "${BK_KEY}_meta-llama_Llama-4-Maverick-17B-128E-Instruct_multimodal_UnitTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record unit test result for meta-llama/Llama-4-Maverick-17B-128E-Instruct/multimodal"
+    key: "${BK_KEY}_record_meta-llama_Llama-4-Maverick-17B-128E-Instruct_multimodal_UnitTest"
+    depends_on: "${BK_KEY}_meta-llama_Llama-4-Maverick-17B-128E-Instruct_multimodal_UnitTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "meta-llama/Llama-4-Maverick-17B-128E-Instruct/multimodal"
       CI_STAGE: "UnitTest"
@@ -33,21 +36,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_meta-llama_Llama-4-Maverick-17B-128E-Instruct_multimodal_UnitTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_meta-llama_Llama-4-Maverick-17B-128E-Instruct_multimodal_UnitTest
 
-  - label: "${TPU_VERSION:-tpu6e} Accuracy for meta-llama/Llama-4-Maverick-17B-128E-Instruct/multimodal"
-    key: "${TPU_VERSION:-tpu6e}_meta-llama_Llama-4-Maverick-17B-128E-Instruct_multimodal_Accuracy"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_meta-llama_Llama-4-Maverick-17B-128E-Instruct_multimodal_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Accuracy for meta-llama/Llama-4-Maverick-17B-128E-Instruct/multimodal"
+    key: "${BK_KEY}_meta-llama_Llama-4-Maverick-17B-128E-Instruct_multimodal_Accuracy"
+    depends_on: "${BK_KEY}_record_meta-llama_Llama-4-Maverick-17B-128E-Instruct_multimodal_UnitTest"
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_meta-llama_Llama-4-Maverick-17B-128E-Instruct_multimodal_Accuracy" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record accuracy result for meta-llama/Llama-4-Maverick-17B-128E-Instruct/multimodal"
-    key: "${TPU_VERSION:-tpu6e}_record_meta-llama_Llama-4-Maverick-17B-128E-Instruct_multimodal_Accuracy"
-    depends_on: "${TPU_VERSION:-tpu6e}_meta-llama_Llama-4-Maverick-17B-128E-Instruct_multimodal_Accuracy"
+        buildkite-agent meta-data set "${BK_KEY}_meta-llama_Llama-4-Maverick-17B-128E-Instruct_multimodal_Accuracy" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record accuracy result for meta-llama/Llama-4-Maverick-17B-128E-Instruct/multimodal"
+    key: "${BK_KEY}_record_meta-llama_Llama-4-Maverick-17B-128E-Instruct_multimodal_Accuracy"
+    depends_on: "${BK_KEY}_meta-llama_Llama-4-Maverick-17B-128E-Instruct_multimodal_Accuracy"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "meta-llama/Llama-4-Maverick-17B-128E-Instruct/multimodal"
       CI_STAGE: "Accuracy/Correctness"
@@ -56,21 +62,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_meta-llama_Llama-4-Maverick-17B-128E-Instruct_multimodal_Accuracy
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_meta-llama_Llama-4-Maverick-17B-128E-Instruct_multimodal_Accuracy
 
-  - label: "${TPU_VERSION:-tpu6e} Performance benchmarks for meta-llama/Llama-4-Maverick-17B-128E-Instruct/multimodal"
-    key: "${TPU_VERSION:-tpu6e}_meta-llama_Llama-4-Maverick-17B-128E-Instruct_multimodal_Benchmark"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_meta-llama_Llama-4-Maverick-17B-128E-Instruct_multimodal_Accuracy"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance benchmarks for meta-llama/Llama-4-Maverick-17B-128E-Instruct/multimodal"
+    key: "${BK_KEY}_meta-llama_Llama-4-Maverick-17B-128E-Instruct_multimodal_Benchmark"
+    depends_on: "${BK_KEY}_record_meta-llama_Llama-4-Maverick-17B-128E-Instruct_multimodal_Accuracy"
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_meta-llama_Llama-4-Maverick-17B-128E-Instruct_multimodal_Benchmark" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance benchmark result for meta-llama/Llama-4-Maverick-17B-128E-Instruct/multimodal"
-    key: "${TPU_VERSION:-tpu6e}_record_meta-llama_Llama-4-Maverick-17B-128E-Instruct_multimodal_Benchmark"
-    depends_on: "${TPU_VERSION:-tpu6e}_meta-llama_Llama-4-Maverick-17B-128E-Instruct_multimodal_Benchmark"
+        buildkite-agent meta-data set "${BK_KEY}_meta-llama_Llama-4-Maverick-17B-128E-Instruct_multimodal_Benchmark" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance benchmark result for meta-llama/Llama-4-Maverick-17B-128E-Instruct/multimodal"
+    key: "${BK_KEY}_record_meta-llama_Llama-4-Maverick-17B-128E-Instruct_multimodal_Benchmark"
+    depends_on: "${BK_KEY}_meta-llama_Llama-4-Maverick-17B-128E-Instruct_multimodal_Benchmark"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "meta-llama/Llama-4-Maverick-17B-128E-Instruct/multimodal"
       CI_STAGE: "Benchmark"
@@ -79,4 +88,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_meta-llama_Llama-4-Maverick-17B-128E-Instruct_multimodal_Benchmark
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_meta-llama_Llama-4-Maverick-17B-128E-Instruct_multimodal_Benchmark

--- a/.buildkite/excluded/meta-llama_Llama-4-Maverick-17B-128E-Instruct_multimodal.yml
+++ b/.buildkite/excluded/meta-llama_Llama-4-Maverick-17B-128E-Instruct_multimodal.yml
@@ -39,7 +39,7 @@ steps:
         .buildkite/scripts/record_step_result.sh ${BK_KEY}_meta-llama_Llama-4-Maverick-17B-128E-Instruct_multimodal_UnitTest
 
   - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Accuracy for meta-llama/Llama-4-Maverick-17B-128E-Instruct/multimodal"
-    key: "${BK_KEY}_meta-llama_Llama-4-Maverick-17B-128E-Instruct_multimodal_Accuracy"
+    key: "${BK_KEY}_meta-llama_Llama-4-Maverick-17B-128E-Instruct_multimodal_Accuracy_Correctness"
     depends_on: "${BK_KEY}_record_meta-llama_Llama-4-Maverick-17B-128E-Instruct_multimodal_UnitTest"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}")
@@ -48,10 +48,10 @@ steps:
       MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     commands:
       - |
-        buildkite-agent meta-data set "${BK_KEY}_meta-llama_Llama-4-Maverick-17B-128E-Instruct_multimodal_Accuracy" "unverified"
+        buildkite-agent meta-data set "${BK_KEY}_meta-llama_Llama-4-Maverick-17B-128E-Instruct_multimodal_Accuracy_Correctness" "unverified"
   - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record accuracy result for meta-llama/Llama-4-Maverick-17B-128E-Instruct/multimodal"
-    key: "${BK_KEY}_record_meta-llama_Llama-4-Maverick-17B-128E-Instruct_multimodal_Accuracy"
-    depends_on: "${BK_KEY}_meta-llama_Llama-4-Maverick-17B-128E-Instruct_multimodal_Accuracy"
+    key: "${BK_KEY}_record_meta-llama_Llama-4-Maverick-17B-128E-Instruct_multimodal_Accuracy_Correctness"
+    depends_on: "${BK_KEY}_meta-llama_Llama-4-Maverick-17B-128E-Instruct_multimodal_Accuracy_Correctness"
     env:
       MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
@@ -62,11 +62,11 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${BK_KEY}_meta-llama_Llama-4-Maverick-17B-128E-Instruct_multimodal_Accuracy
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_meta-llama_Llama-4-Maverick-17B-128E-Instruct_multimodal_Accuracy_Correctness
 
   - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance benchmarks for meta-llama/Llama-4-Maverick-17B-128E-Instruct/multimodal"
     key: "${BK_KEY}_meta-llama_Llama-4-Maverick-17B-128E-Instruct_multimodal_Benchmark"
-    depends_on: "${BK_KEY}_record_meta-llama_Llama-4-Maverick-17B-128E-Instruct_multimodal_Accuracy"
+    depends_on: "${BK_KEY}_record_meta-llama_Llama-4-Maverick-17B-128E-Instruct_multimodal_Accuracy_Correctness"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}")
     soft_fail: true

--- a/.buildkite/excluded/meta-llama_Llama-4-Maverick-17B-128E-Instruct_multimodal.yml
+++ b/.buildkite/excluded/meta-llama_Llama-4-Maverick-17B-128E-Instruct_multimodal.yml
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Unit tests for meta-llama/Llama-4-Maverick-17B-128E-Instruct/multimodal"
-    key: "${TPU_VERSION:-tpu6e}_meta-llama_Llama-4-Maverick-17B-128E-Instruct_multimodal_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Unit tests for meta-llama/Llama-4-Maverick-17B-128E-Instruct/multimodal"
+    key: "${BK_KEY}_meta-llama_Llama-4-Maverick-17B-128E-Instruct_multimodal_UnitTest"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}")
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_meta-llama_Llama-4-Maverick-17B-128E-Instruct_multimodal_UnitTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record unit test result for meta-llama/Llama-4-Maverick-17B-128E-Instruct/multimodal"
-    key: "${TPU_VERSION:-tpu6e}_record_meta-llama_Llama-4-Maverick-17B-128E-Instruct_multimodal_UnitTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_meta-llama_Llama-4-Maverick-17B-128E-Instruct_multimodal_UnitTest"
+        buildkite-agent meta-data set "${BK_KEY}_meta-llama_Llama-4-Maverick-17B-128E-Instruct_multimodal_UnitTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record unit test result for meta-llama/Llama-4-Maverick-17B-128E-Instruct/multimodal"
+    key: "${BK_KEY}_record_meta-llama_Llama-4-Maverick-17B-128E-Instruct_multimodal_UnitTest"
+    depends_on: "${BK_KEY}_meta-llama_Llama-4-Maverick-17B-128E-Instruct_multimodal_UnitTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "meta-llama/Llama-4-Maverick-17B-128E-Instruct/multimodal"
       CI_STAGE: "UnitTest"
@@ -33,21 +36,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_meta-llama_Llama-4-Maverick-17B-128E-Instruct_multimodal_UnitTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_meta-llama_Llama-4-Maverick-17B-128E-Instruct_multimodal_UnitTest
 
-  - label: "${TPU_VERSION:-tpu6e} Accuracy for meta-llama/Llama-4-Maverick-17B-128E-Instruct/multimodal"
-    key: "${TPU_VERSION:-tpu6e}_meta-llama_Llama-4-Maverick-17B-128E-Instruct_multimodal_Accuracy"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_meta-llama_Llama-4-Maverick-17B-128E-Instruct_multimodal_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Accuracy for meta-llama/Llama-4-Maverick-17B-128E-Instruct/multimodal"
+    key: "${BK_KEY}_meta-llama_Llama-4-Maverick-17B-128E-Instruct_multimodal_Accuracy"
+    depends_on: "${BK_KEY}_record_meta-llama_Llama-4-Maverick-17B-128E-Instruct_multimodal_UnitTest"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}")
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_meta-llama_Llama-4-Maverick-17B-128E-Instruct_multimodal_Accuracy" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record accuracy result for meta-llama/Llama-4-Maverick-17B-128E-Instruct/multimodal"
-    key: "${TPU_VERSION:-tpu6e}_record_meta-llama_Llama-4-Maverick-17B-128E-Instruct_multimodal_Accuracy"
-    depends_on: "${TPU_VERSION:-tpu6e}_meta-llama_Llama-4-Maverick-17B-128E-Instruct_multimodal_Accuracy"
+        buildkite-agent meta-data set "${BK_KEY}_meta-llama_Llama-4-Maverick-17B-128E-Instruct_multimodal_Accuracy" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record accuracy result for meta-llama/Llama-4-Maverick-17B-128E-Instruct/multimodal"
+    key: "${BK_KEY}_record_meta-llama_Llama-4-Maverick-17B-128E-Instruct_multimodal_Accuracy"
+    depends_on: "${BK_KEY}_meta-llama_Llama-4-Maverick-17B-128E-Instruct_multimodal_Accuracy"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "meta-llama/Llama-4-Maverick-17B-128E-Instruct/multimodal"
       CI_STAGE: "Accuracy/Correctness"
@@ -56,21 +62,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_meta-llama_Llama-4-Maverick-17B-128E-Instruct_multimodal_Accuracy
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_meta-llama_Llama-4-Maverick-17B-128E-Instruct_multimodal_Accuracy
 
-  - label: "${TPU_VERSION:-tpu6e} Performance benchmarks for meta-llama/Llama-4-Maverick-17B-128E-Instruct/multimodal"
-    key: "${TPU_VERSION:-tpu6e}_meta-llama_Llama-4-Maverick-17B-128E-Instruct_multimodal_Benchmark"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_meta-llama_Llama-4-Maverick-17B-128E-Instruct_multimodal_Accuracy"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance benchmarks for meta-llama/Llama-4-Maverick-17B-128E-Instruct/multimodal"
+    key: "${BK_KEY}_meta-llama_Llama-4-Maverick-17B-128E-Instruct_multimodal_Benchmark"
+    depends_on: "${BK_KEY}_record_meta-llama_Llama-4-Maverick-17B-128E-Instruct_multimodal_Accuracy"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}")
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_meta-llama_Llama-4-Maverick-17B-128E-Instruct_multimodal_Benchmark" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance benchmark result for meta-llama/Llama-4-Maverick-17B-128E-Instruct/multimodal"
-    key: "${TPU_VERSION:-tpu6e}_record_meta-llama_Llama-4-Maverick-17B-128E-Instruct_multimodal_Benchmark"
-    depends_on: "${TPU_VERSION:-tpu6e}_meta-llama_Llama-4-Maverick-17B-128E-Instruct_multimodal_Benchmark"
+        buildkite-agent meta-data set "${BK_KEY}_meta-llama_Llama-4-Maverick-17B-128E-Instruct_multimodal_Benchmark" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance benchmark result for meta-llama/Llama-4-Maverick-17B-128E-Instruct/multimodal"
+    key: "${BK_KEY}_record_meta-llama_Llama-4-Maverick-17B-128E-Instruct_multimodal_Benchmark"
+    depends_on: "${BK_KEY}_meta-llama_Llama-4-Maverick-17B-128E-Instruct_multimodal_Benchmark"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "meta-llama/Llama-4-Maverick-17B-128E-Instruct/multimodal"
       CI_STAGE: "Benchmark"
@@ -79,4 +88,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_meta-llama_Llama-4-Maverick-17B-128E-Instruct_multimodal_Benchmark
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_meta-llama_Llama-4-Maverick-17B-128E-Instruct_multimodal_Benchmark

--- a/.buildkite/excluded/meta-llama_Llama-Guard-4-12B_multimodal.yml
+++ b/.buildkite/excluded/meta-llama_Llama-Guard-4-12B_multimodal.yml
@@ -13,16 +13,18 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Unit tests for meta-llama/Llama-Guard-4-12B/multimodal"
-    key: "${TPU_VERSION:-tpu6e}_meta-llama_Llama-Guard-4-12B_multimodal_UnitTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_meta-llama_Llama-Guard-4-12B_text-only_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Unit tests for meta-llama/Llama-Guard-4-12B/multimodal"
+    key: "${BK_KEY}_meta-llama_Llama-Guard-4-12B_multimodal_UnitTest"
+    depends_on: "${BK_KEY}_meta-llama_Llama-Guard-4-12B_text-only_UnitTest"
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     commands:
       - |
         # multimodal runs the same unit test as text-only for Llama-Guard-4-12B
-        mirroring_text_only_step="${TPU_VERSION:-tpu6e}_meta-llama_Llama-Guard-4-12B_text-only_UnitTest"
+        mirroring_text_only_step="${BK_KEY}_meta-llama_Llama-Guard-4-12B_text-only_UnitTest"
         OUTCOME=$$(buildkite-agent step get "outcome" --step "$$mirroring_text_only_step")
 
         if [ "$$OUTCOME" = "passed" ]; then
@@ -33,10 +35,11 @@ steps:
           exit 1
         fi
           
-  - label: "${TPU_VERSION:-tpu6e} Record unit test result for meta-llama/Llama-Guard-4-12B/multimodal"
-    key: "${TPU_VERSION:-tpu6e}_record_meta-llama_Llama-Guard-4-12B_multimodal_UnitTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_meta-llama_Llama-Guard-4-12B_multimodal_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} ${MODEL_IMPL_TYPE:-vllm} Record unit test result for meta-llama/Llama-Guard-4-12B/multimodal"
+    key: "${BK_KEY}_record_meta-llama_Llama-Guard-4-12B_multimodal_UnitTest"
+    depends_on: "${BK_KEY}_meta-llama_Llama-Guard-4-12B_multimodal_UnitTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "meta-llama/Llama-Guard-4-12B/multimodal"
       CI_STAGE: "UnitTest"
@@ -45,25 +48,27 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_meta-llama_Llama-Guard-4-12B_text-only_UnitTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_meta-llama_Llama-Guard-4-12B_text-only_UnitTest
 
-  - label: "${TPU_VERSION:-tpu6e} Accuracy for meta-llama/Llama-Guard-4-12B/multimodal"
-    key: "${TPU_VERSION:-tpu6e}_meta-llama_Llama-Guard-4-12B_multimodal_Accuracy"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_meta-llama_Llama-Guard-4-12B_multimodal_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Accuracy for meta-llama/Llama-Guard-4-12B/multimodal"
+    key: "${BK_KEY}_meta-llama_Llama-Guard-4-12B_multimodal_Accuracy"
+    depends_on: "${BK_KEY}_record_meta-llama_Llama-Guard-4-12B_multimodal_UnitTest"
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       TEST_MODEL: meta-llama/Llama-Guard-4-12B
       TENSOR_PARALLEL_SIZE: "${TENSOR_PARALLEL_SIZE_SINGLE:-1}"
       MINIMUM_ACCURACY_THRESHOLD: 0.02 #TODO: increase threshold when this model becomes higher priority 
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/safety_model_benchmark.sh --mode accuracy --benchmark multimodal
-  - label: "${TPU_VERSION:-tpu6e} Record accuracy result for meta-llama/Llama-Guard-4-12B/multimodal"
-    key: "${TPU_VERSION:-tpu6e}_record_meta-llama_Llama-Guard-4-12B_multimodal_Accuracy"
-    depends_on: "${TPU_VERSION:-tpu6e}_meta-llama_Llama-Guard-4-12B_multimodal_Accuracy"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record accuracy result for meta-llama/Llama-Guard-4-12B/multimodal"
+    key: "${BK_KEY}_record_meta-llama_Llama-Guard-4-12B_multimodal_Accuracy"
+    depends_on: "${BK_KEY}_meta-llama_Llama-Guard-4-12B_multimodal_Accuracy"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "meta-llama/Llama-Guard-4-12B/multimodal"
       CI_STAGE: "Accuracy/Correctness"
@@ -72,24 +77,26 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_meta-llama_Llama-Guard-4-12B_multimodal_Accuracy
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_meta-llama_Llama-Guard-4-12B_multimodal_Accuracy
 
-  - label: "${TPU_VERSION:-tpu6e} Performance benchmarks for meta-llama/Llama-Guard-4-12B/multimodal"
-    key: "${TPU_VERSION:-tpu6e}_meta-llama_Llama-Guard-4-12B_multimodal_Benchmark"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_meta-llama_Llama-Guard-4-12B_multimodal_Accuracy"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance benchmarks for meta-llama/Llama-Guard-4-12B/multimodal"
+    key: "${BK_KEY}_meta-llama_Llama-Guard-4-12B_multimodal_Benchmark"
+    depends_on: "${BK_KEY}_record_meta-llama_Llama-Guard-4-12B_multimodal_Accuracy"
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       TEST_MODEL: meta-llama/Llama-Guard-4-12B
       TENSOR_PARALLEL_SIZE: "${TENSOR_PARALLEL_SIZE_SINGLE:-1}"
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/safety_model_benchmark.sh --mode performance --benchmark multimodal
-  - label: "${TPU_VERSION:-tpu6e} Record performance benchmark result for meta-llama/Llama-Guard-4-12B/multimodal"
-    key: "${TPU_VERSION:-tpu6e}_record_meta-llama_Llama-Guard-4-12B_multimodal_Benchmark"
-    depends_on: "${TPU_VERSION:-tpu6e}_meta-llama_Llama-Guard-4-12B_multimodal_Benchmark"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance benchmark result for meta-llama/Llama-Guard-4-12B/multimodal"
+    key: "${BK_KEY}_record_meta-llama_Llama-Guard-4-12B_multimodal_Benchmark"
+    depends_on: "${BK_KEY}_meta-llama_Llama-Guard-4-12B_multimodal_Benchmark"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "meta-llama/Llama-Guard-4-12B/multimodal"
       CI_STAGE: "Benchmark"
@@ -98,4 +105,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_meta-llama_Llama-Guard-4-12B_multimodal_Benchmark
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_meta-llama_Llama-Guard-4-12B_multimodal_Benchmark

--- a/.buildkite/excluded/meta-llama_Llama-Guard-4-12B_multimodal.yml
+++ b/.buildkite/excluded/meta-llama_Llama-Guard-4-12B_multimodal.yml
@@ -51,7 +51,7 @@ steps:
         .buildkite/scripts/record_step_result.sh ${BK_KEY}_meta-llama_Llama-Guard-4-12B_text-only_UnitTest
 
   - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Accuracy for meta-llama/Llama-Guard-4-12B/multimodal"
-    key: "${BK_KEY}_meta-llama_Llama-Guard-4-12B_multimodal_Accuracy"
+    key: "${BK_KEY}_meta-llama_Llama-Guard-4-12B_multimodal_Accuracy_Correctness"
     depends_on: "${BK_KEY}_record_meta-llama_Llama-Guard-4-12B_multimodal_UnitTest"
     soft_fail: true
     agents:
@@ -65,8 +65,8 @@ steps:
       - |
         .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/safety_model_benchmark.sh --mode accuracy --benchmark multimodal
   - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record accuracy result for meta-llama/Llama-Guard-4-12B/multimodal"
-    key: "${BK_KEY}_record_meta-llama_Llama-Guard-4-12B_multimodal_Accuracy"
-    depends_on: "${BK_KEY}_meta-llama_Llama-Guard-4-12B_multimodal_Accuracy"
+    key: "${BK_KEY}_record_meta-llama_Llama-Guard-4-12B_multimodal_Accuracy_Correctness"
+    depends_on: "${BK_KEY}_meta-llama_Llama-Guard-4-12B_multimodal_Accuracy_Correctness"
     env:
       MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
@@ -77,11 +77,11 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${BK_KEY}_meta-llama_Llama-Guard-4-12B_multimodal_Accuracy
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_meta-llama_Llama-Guard-4-12B_multimodal_Accuracy_Correctness
 
   - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance benchmarks for meta-llama/Llama-Guard-4-12B/multimodal"
     key: "${BK_KEY}_meta-llama_Llama-Guard-4-12B_multimodal_Benchmark"
-    depends_on: "${BK_KEY}_record_meta-llama_Llama-Guard-4-12B_multimodal_Accuracy"
+    depends_on: "${BK_KEY}_record_meta-llama_Llama-Guard-4-12B_multimodal_Accuracy_Correctness"
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"

--- a/.buildkite/excluded/meta-llama_Llama-Guard-4-12B_text-only.yml
+++ b/.buildkite/excluded/meta-llama_Llama-Guard-4-12B_text-only.yml
@@ -13,19 +13,22 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Unit tests for meta-llama/Llama-Guard-4-12B/text-only"
-    key: "${TPU_VERSION:-tpu6e}_meta-llama_Llama-Guard-4-12B_text-only_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Unit tests for meta-llama/Llama-Guard-4-12B/text-only"
+    key: "${BK_KEY}_meta-llama_Llama-Guard-4-12B_text-only_UnitTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh \
           bash -c 'python3 -m pytest -s -v -x /workspace/tpu_inference/tests/models/jax/test_llama_guard_4.py'
-  - label: "${TPU_VERSION:-tpu6e} Record unit test result for meta-llama/Llama-Guard-4-12B/text-only"
-    key: "${TPU_VERSION:-tpu6e}_record_meta-llama_Llama-Guard-4-12B_text-only_UnitTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_meta-llama_Llama-Guard-4-12B_text-only_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record unit test result for meta-llama/Llama-Guard-4-12B/text-only"
+    key: "${BK_KEY}_record_meta-llama_Llama-Guard-4-12B_text-only_UnitTest"
+    depends_on: "${BK_KEY}_meta-llama_Llama-Guard-4-12B_text-only_UnitTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "meta-llama/Llama-Guard-4-12B/text-only"
       CI_STAGE: "UnitTest"
@@ -34,25 +37,27 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_meta-llama_Llama-Guard-4-12B_text-only_UnitTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_meta-llama_Llama-Guard-4-12B_text-only_UnitTest
 
-  - label: "${TPU_VERSION:-tpu6e} Accuracy for meta-llama/Llama-Guard-4-12B/text-only"
-    key: "${TPU_VERSION:-tpu6e}_meta-llama_Llama-Guard-4-12B_text-only_Accuracy"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_meta-llama_Llama-Guard-4-12B_text-only_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Accuracy for meta-llama/Llama-Guard-4-12B/text-only"
+    key: "${BK_KEY}_meta-llama_Llama-Guard-4-12B_text-only_Accuracy"
+    depends_on: "${BK_KEY}_record_meta-llama_Llama-Guard-4-12B_text-only_UnitTest"
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       TEST_MODEL: meta-llama/Llama-Guard-4-12B
       TENSOR_PARALLEL_SIZE: "${TENSOR_PARALLEL_SIZE_SINGLE:-1}"
       MINIMUM_ACCURACY_THRESHOLD: 0.31 #TODO: This will be updated later with a true threshold
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/safety_model_benchmark.sh --mode accuracy --benchmark text-only
-  - label: "${TPU_VERSION:-tpu6e} Record accuracy result for meta-llama/Llama-Guard-4-12B/text-only"
-    key: "${TPU_VERSION:-tpu6e}_record_meta-llama_Llama-Guard-4-12B_text-only_Accuracy"
-    depends_on: "${TPU_VERSION:-tpu6e}_meta-llama_Llama-Guard-4-12B_text-only_Accuracy"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record accuracy result for meta-llama/Llama-Guard-4-12B/text-only"
+    key: "${BK_KEY}_record_meta-llama_Llama-Guard-4-12B_text-only_Accuracy"
+    depends_on: "${BK_KEY}_meta-llama_Llama-Guard-4-12B_text-only_Accuracy"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "meta-llama/Llama-Guard-4-12B/text-only"
       CI_STAGE: "Accuracy/Correctness"
@@ -61,24 +66,26 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_meta-llama_Llama-Guard-4-12B_text-only_Accuracy
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_meta-llama_Llama-Guard-4-12B_text-only_Accuracy
 
-  - label: "${TPU_VERSION:-tpu6e} Performance benchmarks for meta-llama/Llama-Guard-4-12B/text-only"
-    key: "${TPU_VERSION:-tpu6e}_meta-llama_Llama-Guard-4-12B_text-only_Benchmark"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_meta-llama_Llama-Guard-4-12B_text-only_Accuracy"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance benchmarks for meta-llama/Llama-Guard-4-12B/text-only"
+    key: "${BK_KEY}_meta-llama_Llama-Guard-4-12B_text-only_Benchmark"
+    depends_on: "${BK_KEY}_record_meta-llama_Llama-Guard-4-12B_text-only_Accuracy"
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       TEST_MODEL: meta-llama/Llama-Guard-4-12B
       TENSOR_PARALLEL_SIZE: "${TENSOR_PARALLEL_SIZE_SINGLE:-1}"
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/safety_model_benchmark.sh --mode performance --benchmark text-only
-  - label: "${TPU_VERSION:-tpu6e} Record performance benchmark result for meta-llama/Llama-Guard-4-12B/text-only"
-    key: "${TPU_VERSION:-tpu6e}_record_meta-llama_Llama-Guard-4-12B_text-only_Benchmark"
-    depends_on: "${TPU_VERSION:-tpu6e}_meta-llama_Llama-Guard-4-12B_text-only_Benchmark"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance benchmark result for meta-llama/Llama-Guard-4-12B/text-only"
+    key: "${BK_KEY}_record_meta-llama_Llama-Guard-4-12B_text-only_Benchmark"
+    depends_on: "${BK_KEY}_meta-llama_Llama-Guard-4-12B_text-only_Benchmark"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "meta-llama/Llama-Guard-4-12B/text-only"
       CI_STAGE: "Benchmark"
@@ -87,4 +94,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_meta-llama_Llama-Guard-4-12B_text-only_Benchmark
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_meta-llama_Llama-Guard-4-12B_text-only_Benchmark

--- a/.buildkite/excluded/meta-llama_Llama-Guard-4-12B_text-only.yml
+++ b/.buildkite/excluded/meta-llama_Llama-Guard-4-12B_text-only.yml
@@ -40,7 +40,7 @@ steps:
         .buildkite/scripts/record_step_result.sh ${BK_KEY}_meta-llama_Llama-Guard-4-12B_text-only_UnitTest
 
   - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Accuracy for meta-llama/Llama-Guard-4-12B/text-only"
-    key: "${BK_KEY}_meta-llama_Llama-Guard-4-12B_text-only_Accuracy"
+    key: "${BK_KEY}_meta-llama_Llama-Guard-4-12B_text-only_Accuracy_Correctness"
     depends_on: "${BK_KEY}_record_meta-llama_Llama-Guard-4-12B_text-only_UnitTest"
     soft_fail: true
     agents:
@@ -54,8 +54,8 @@ steps:
       - |
         .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/safety_model_benchmark.sh --mode accuracy --benchmark text-only
   - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record accuracy result for meta-llama/Llama-Guard-4-12B/text-only"
-    key: "${BK_KEY}_record_meta-llama_Llama-Guard-4-12B_text-only_Accuracy"
-    depends_on: "${BK_KEY}_meta-llama_Llama-Guard-4-12B_text-only_Accuracy"
+    key: "${BK_KEY}_record_meta-llama_Llama-Guard-4-12B_text-only_Accuracy_Correctness"
+    depends_on: "${BK_KEY}_meta-llama_Llama-Guard-4-12B_text-only_Accuracy_Correctness"
     env:
       MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
@@ -66,11 +66,11 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${BK_KEY}_meta-llama_Llama-Guard-4-12B_text-only_Accuracy
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_meta-llama_Llama-Guard-4-12B_text-only_Accuracy_Correctness
 
   - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance benchmarks for meta-llama/Llama-Guard-4-12B/text-only"
     key: "${BK_KEY}_meta-llama_Llama-Guard-4-12B_text-only_Benchmark"
-    depends_on: "${BK_KEY}_record_meta-llama_Llama-Guard-4-12B_text-only_Accuracy"
+    depends_on: "${BK_KEY}_record_meta-llama_Llama-Guard-4-12B_text-only_Accuracy_Correctness"
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"

--- a/.buildkite/features/Collective_Communication_Matmul.yml
+++ b/.buildkite/features/Collective_Communication_Matmul.yml
@@ -13,17 +13,20 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for Collective Communication Matmul"
-    key: "${TPU_VERSION:-tpu6e}_Collective_Communication_Matmul_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for Collective Communication Matmul"
+    key: "${BK_KEY}_Collective_Communication_Matmul_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - .buildkite/scripts/run_in_docker.sh python3 -m pytest -s -v /workspace/tpu_inference/tests/kernels/collectives/all_gather_matmul_kernel_test.py
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for Collective Communication Matmul"
-    key: "${TPU_VERSION:-tpu6e}_record_Collective_Communication_Matmul_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_Collective_Communication_Matmul_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for Collective Communication Matmul"
+    key: "${BK_KEY}_record_Collective_Communication_Matmul_CorrectnessTest"
+    depends_on: "${BK_KEY}_Collective_Communication_Matmul_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "Collective Communication Matmul"
       CI_STAGE: "CorrectnessTest"
@@ -32,21 +35,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_Collective_Communication_Matmul_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_Collective_Communication_Matmul_CorrectnessTest
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for Collective Communication Matmul"
-    key: "${TPU_VERSION:-tpu6e}_Collective_Communication_Matmul_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_Collective_Communication_Matmul_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for Collective Communication Matmul"
+    key: "${BK_KEY}_Collective_Communication_Matmul_PerformanceTest"
+    depends_on: "${BK_KEY}_record_Collective_Communication_Matmul_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_Collective_Communication_Matmul_PerformanceTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for Collective Communication Matmul"
-    key: "${TPU_VERSION:-tpu6e}_record_Collective_Communication_Matmul_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_Collective_Communication_Matmul_PerformanceTest"
+        buildkite-agent meta-data set "${BK_KEY}_Collective_Communication_Matmul_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for Collective Communication Matmul"
+    key: "${BK_KEY}_record_Collective_Communication_Matmul_PerformanceTest"
+    depends_on: "${BK_KEY}_Collective_Communication_Matmul_PerformanceTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "Collective Communication Matmul"
       CI_STAGE: "PerformanceTest"
@@ -55,4 +61,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_Collective_Communication_Matmul_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_Collective_Communication_Matmul_PerformanceTest

--- a/.buildkite/features/Collective_Communication_Matmul.yml
+++ b/.buildkite/features/Collective_Communication_Matmul.yml
@@ -13,17 +13,20 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for Collective Communication Matmul"
-    key: "${TPU_VERSION:-tpu6e}_Collective_Communication_Matmul_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for Collective Communication Matmul"
+    key: "${BK_KEY}_Collective_Communication_Matmul_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - .buildkite/scripts/run_in_docker.sh python3 -m pytest -s -v /workspace/tpu_inference/tests/kernels/collectives/all_gather_matmul_kernel_test.py
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for Collective Communication Matmul"
-    key: "${TPU_VERSION:-tpu6e}_record_Collective_Communication_Matmul_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_Collective_Communication_Matmul_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for Collective Communication Matmul"
+    key: "${BK_KEY}_record_Collective_Communication_Matmul_CorrectnessTest"
+    depends_on: "${BK_KEY}_Collective_Communication_Matmul_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "Collective Communication Matmul"
       CI_STAGE: "CorrectnessTest"
@@ -32,21 +35,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_Collective_Communication_Matmul_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_Collective_Communication_Matmul_CorrectnessTest
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for Collective Communication Matmul"
-    key: "${TPU_VERSION:-tpu6e}_Collective_Communication_Matmul_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_Collective_Communication_Matmul_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for Collective Communication Matmul"
+    key: "${BK_KEY}_Collective_Communication_Matmul_PerformanceTest"
+    depends_on: "${BK_KEY}_record_Collective_Communication_Matmul_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_Collective_Communication_Matmul_PerformanceTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for Collective Communication Matmul"
-    key: "${TPU_VERSION:-tpu6e}_record_Collective_Communication_Matmul_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_Collective_Communication_Matmul_PerformanceTest"
+        buildkite-agent meta-data set "${BK_KEY}_Collective_Communication_Matmul_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for Collective Communication Matmul"
+    key: "${BK_KEY}_record_Collective_Communication_Matmul_PerformanceTest"
+    depends_on: "${BK_KEY}_Collective_Communication_Matmul_PerformanceTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "Collective Communication Matmul"
       CI_STAGE: "PerformanceTest"
@@ -55,4 +61,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_Collective_Communication_Matmul_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_Collective_Communication_Matmul_PerformanceTest

--- a/.buildkite/features/DCN-Based_P-D_disaggregation.yml
+++ b/.buildkite/features/DCN-Based_P-D_disaggregation.yml
@@ -13,10 +13,11 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for DCN-based P/D disaggregation"
-    key: "${TPU_VERSION:-tpu6e}_DCN_based_P-D_disaggregation_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for DCN-based P/D disaggregation"
+    key: "${BK_KEY}_DCN_based_P-D_disaggregation_CorrectnessTest"
     soft_fail: true
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       MODEL: "Qwen/Qwen3-0.6B"
       INPUT_LEN: 100
@@ -29,10 +30,11 @@ steps:
       - |
         .buildkite/scripts/run_disagg.sh
 
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for DCN-based P/D disaggregation"
-    key: "${TPU_VERSION:-tpu6e}_record_DCN_based_P-D_disaggregation_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_DCN_based_P-D_disaggregation_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for DCN-based P/D disaggregation"
+    key: "${BK_KEY}_record_DCN_based_P-D_disaggregation_CorrectnessTest"
+    depends_on: "${BK_KEY}_DCN_based_P-D_disaggregation_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "DCN-based P/D disaggregation"
       CI_STAGE: "CorrectnessTest"
@@ -41,12 +43,13 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_DCN_based_P-D_disaggregation_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_DCN_based_P-D_disaggregation_CorrectnessTest
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for DCN-based P/D disaggregation"
-    key: "${TPU_VERSION:-tpu6e}_DCN_based_P-D_disaggregation_PerformanceTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for DCN-based P/D disaggregation"
+    key: "${BK_KEY}_DCN_based_P-D_disaggregation_PerformanceTest"
     soft_fail: true
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       MODEL: "Qwen/Qwen3-0.6B"
       INPUT_LEN: 1024
@@ -61,10 +64,11 @@ steps:
       - |
         .buildkite/scripts/run_disagg.sh
 
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for DCN-based P/D disaggregation"
-    key: "${TPU_VERSION:-tpu6e}_record_DCN_based_P-D_disaggregation_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_DCN_based_P-D_disaggregation_PerformanceTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for DCN-based P/D disaggregation"
+    key: "${BK_KEY}_record_DCN_based_P-D_disaggregation_PerformanceTest"
+    depends_on: "${BK_KEY}_DCN_based_P-D_disaggregation_PerformanceTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "DCN-based P/D disaggregation"
       CI_STAGE: "PerformanceTest"
@@ -73,4 +77,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_DCN_based_P-D_disaggregation_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_DCN_based_P-D_disaggregation_PerformanceTest

--- a/.buildkite/features/Hybrid_kvcache.yml
+++ b/.buildkite/features/Hybrid_kvcache.yml
@@ -18,9 +18,11 @@
 # with full + sliding window attn) to save HBM memory for kv cache and be able
 # to accomodate more requests. 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for hybrid kv cache allocation"
-    key: "${TPU_VERSION:-tpu6e}_hybrid_kvcache_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for hybrid kv cache allocation"
+    key: "${BK_KEY}_hybrid_kvcache_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
     commands:
@@ -28,10 +30,11 @@ steps:
         .buildkite/scripts/run_in_docker.sh \
           python3 -m pytest -s -v /workspace/tpu_inference/tests/e2e/test_hybrid_kvcache.py::test_hybrid_kv_cache \
           /workspace/tpu_inference/tests/e2e/test_hybrid_kvcache.py::test_hybrid_kv_cache_correctness
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for hybrid kv cache allocation"
-    key: "${TPU_VERSION:-tpu6e}_record_hybrid_kvcache_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_hybrid_kvcache_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for hybrid kv cache allocation"
+    key: "${BK_KEY}_record_hybrid_kvcache_CorrectnessTest"
+    depends_on: "${BK_KEY}_hybrid_kvcache_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "hybrid kv cache"
       CI_STAGE: "CorrectnessTest"
@@ -40,4 +43,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_hybrid_kvcache_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_hybrid_kvcache_CorrectnessTest

--- a/.buildkite/features/KV_Cache_Offload.yml
+++ b/.buildkite/features/KV_Cache_Offload.yml
@@ -13,10 +13,11 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for KV Cache Offload"
-    key: "${TPU_VERSION:-tpu6e}KV_Cache_Offload_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for KV Cache Offload"
+    key: "${BK_KEY}KV_Cache_Offload_CorrectnessTest"
     soft_fail: true
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       USE_V6E8_QUEUE: "True"
     agents:
       queue: tpu_v6e_8_queue
@@ -24,10 +25,11 @@ steps:
       - |
         .buildkite/scripts/run_in_docker.sh \
           python3 -m pytest -s -v /workspace/tpu_inference/tests/offload/tpu_offload_accuracy_test.py
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for KV Cache Offload"
-    key: "${TPU_VERSION:-tpu6e}record_KV_Cache_Offload_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}KV_Cache_Offload_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for KV Cache Offload"
+    key: "${BK_KEY}record_KV_Cache_Offload_CorrectnessTest"
+    depends_on: "${BK_KEY}KV_Cache_Offload_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "KV Cache Offload"
       CI_STAGE: "CorrectnessTest"
@@ -36,22 +38,25 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}KV_Cache_Offload_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}KV_Cache_Offload_CorrectnessTest
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for KV Cache Offload"
-    key: "${TPU_VERSION:-tpu6e}KV_Cache_Offload_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}record_KV_Cache_Offload_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for KV Cache Offload"
+    key: "${BK_KEY}KV_Cache_Offload_PerformanceTest"
+    depends_on: "${BK_KEY}record_KV_Cache_Offload_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: tpu_v6e_8_queue
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh \
           python3 -m pytest -s -v /workspace/tpu_inference/tests/offload/tpu_offload_performance_test.py
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for KV Cache Offload"
-    key: "${TPU_VERSION:-tpu6e}record_KV_Cache_Offload_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}KV_Cache_Offload_PerformanceTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for KV Cache Offload"
+    key: "${BK_KEY}record_KV_Cache_Offload_PerformanceTest"
+    depends_on: "${BK_KEY}KV_Cache_Offload_PerformanceTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "KV Cache Offload"
       CI_STAGE: "PerformanceTest"
@@ -60,4 +65,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}KV_Cache_Offload_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}KV_Cache_Offload_PerformanceTest

--- a/.buildkite/features/LoRA_Torch.yml
+++ b/.buildkite/features/LoRA_Torch.yml
@@ -13,19 +13,22 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for LoRA_Torch"
-    key: "${TPU_VERSION:-tpu6e}_LoRA_Torch_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for LoRA_Torch"
+    key: "${BK_KEY}_LoRA_Torch_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh \
           bash -c 'MODEL_IMPL_TYPE=vllm TPU_BACKEND_TYPE=jax python3 -m pytest -s -v -x /workspace/tpu_inference/tests/lora/test_lora.py'
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for LoRA_Torch"
-    key: "${TPU_VERSION:-tpu6e}_record_LoRA_Torch_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_LoRA_Torch_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for LoRA_Torch"
+    key: "${BK_KEY}_record_LoRA_Torch_CorrectnessTest"
+    depends_on: "${BK_KEY}_LoRA_Torch_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "LoRA_Torch"
       CI_STAGE: "CorrectnessTest"
@@ -34,22 +37,25 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_LoRA_Torch_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_LoRA_Torch_CorrectnessTest
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for LoRA_Torch"
-    key: "${TPU_VERSION:-tpu6e}_LoRA_Torch_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_LoRA_Torch_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for LoRA_Torch"
+    key: "${BK_KEY}_LoRA_Torch_PerformanceTest"
+    depends_on: "${BK_KEY}_record_LoRA_Torch_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh \
           bash -c 'MODEL_IMPL_TYPE=vllm TPU_BACKEND_TYPE=jax python3 -m pytest -s -v -x /workspace/tpu_inference/tests/lora/test_lora_perf.py'
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for LoRA_Torch"
-    key: "${TPU_VERSION:-tpu6e}_record_LoRA_Torch_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_LoRA_Torch_PerformanceTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for LoRA_Torch"
+    key: "${BK_KEY}_record_LoRA_Torch_PerformanceTest"
+    depends_on: "${BK_KEY}_LoRA_Torch_PerformanceTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "LoRA_Torch"
       CI_STAGE: "PerformanceTest"
@@ -58,4 +64,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_LoRA_Torch_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_LoRA_Torch_PerformanceTest

--- a/.buildkite/features/MLA.yml
+++ b/.buildkite/features/MLA.yml
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for MLA"
-    key: "${TPU_VERSION:-tpu6e}_MLA_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for MLA"
+    key: "${BK_KEY}_MLA_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_MLA_CorrectnessTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for MLA"
-    key: "${TPU_VERSION:-tpu6e}_record_MLA_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_MLA_CorrectnessTest"
+        buildkite-agent meta-data set "${BK_KEY}_MLA_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for MLA"
+    key: "${BK_KEY}_record_MLA_CorrectnessTest"
+    depends_on: "${BK_KEY}_MLA_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "MLA"
       CI_STAGE: "CorrectnessTest"
@@ -33,21 +36,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_MLA_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_MLA_CorrectnessTest
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for MLA"
-    key: "${TPU_VERSION:-tpu6e}_MLA_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_MLA_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for MLA"
+    key: "${BK_KEY}_MLA_PerformanceTest"
+    depends_on: "${BK_KEY}_record_MLA_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_MLA_PerformanceTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for MLA"
-    key: "${TPU_VERSION:-tpu6e}_record_MLA_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_MLA_PerformanceTest"
+        buildkite-agent meta-data set "${BK_KEY}_MLA_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for MLA"
+    key: "${BK_KEY}_record_MLA_PerformanceTest"
+    depends_on: "${BK_KEY}_MLA_PerformanceTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "MLA"
       CI_STAGE: "PerformanceTest"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_MLA_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_MLA_PerformanceTest

--- a/.buildkite/features/MLA.yml
+++ b/.buildkite/features/MLA.yml
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for MLA"
-    key: "${TPU_VERSION:-tpu6e}_MLA_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for MLA"
+    key: "${BK_KEY}_MLA_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_MLA_CorrectnessTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for MLA"
-    key: "${TPU_VERSION:-tpu6e}_record_MLA_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_MLA_CorrectnessTest"
+        buildkite-agent meta-data set "${BK_KEY}_MLA_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for MLA"
+    key: "${BK_KEY}_record_MLA_CorrectnessTest"
+    depends_on: "${BK_KEY}_MLA_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "MLA"
       CI_STAGE: "CorrectnessTest"
@@ -33,21 +36,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_MLA_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_MLA_CorrectnessTest
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for MLA"
-    key: "${TPU_VERSION:-tpu6e}_MLA_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_MLA_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for MLA"
+    key: "${BK_KEY}_MLA_PerformanceTest"
+    depends_on: "${BK_KEY}_record_MLA_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_MLA_PerformanceTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for MLA"
-    key: "${TPU_VERSION:-tpu6e}_record_MLA_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_MLA_PerformanceTest"
+        buildkite-agent meta-data set "${BK_KEY}_MLA_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for MLA"
+    key: "${BK_KEY}_record_MLA_PerformanceTest"
+    depends_on: "${BK_KEY}_MLA_PerformanceTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "MLA"
       CI_STAGE: "PerformanceTest"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_MLA_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_MLA_PerformanceTest

--- a/.buildkite/features/MoE.yml
+++ b/.buildkite/features/MoE.yml
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for MoE"
-    key: "${TPU_VERSION:-tpu6e}_MoE_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for MoE"
+    key: "${BK_KEY}_MoE_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_MoE_CorrectnessTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for MoE"
-    key: "${TPU_VERSION:-tpu6e}_record_MoE_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_MoE_CorrectnessTest"
+        buildkite-agent meta-data set "${BK_KEY}_MoE_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for MoE"
+    key: "${BK_KEY}_record_MoE_CorrectnessTest"
+    depends_on: "${BK_KEY}_MoE_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "MoE"
       CI_STAGE: "CorrectnessTest"
@@ -33,21 +36,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_MoE_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_MoE_CorrectnessTest
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for MoE"
-    key: "${TPU_VERSION:-tpu6e}_MoE_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_MoE_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for MoE"
+    key: "${BK_KEY}_MoE_PerformanceTest"
+    depends_on: "${BK_KEY}_record_MoE_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_MoE_PerformanceTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for MoE"
-    key: "${TPU_VERSION:-tpu6e}_record_MoE_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_MoE_PerformanceTest"
+        buildkite-agent meta-data set "${BK_KEY}_MoE_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for MoE"
+    key: "${BK_KEY}_record_MoE_PerformanceTest"
+    depends_on: "${BK_KEY}_MoE_PerformanceTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "MoE"
       CI_STAGE: "PerformanceTest"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_MoE_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_MoE_PerformanceTest

--- a/.buildkite/features/MoE.yml
+++ b/.buildkite/features/MoE.yml
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for MoE"
-    key: "${TPU_VERSION:-tpu6e}_MoE_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for MoE"
+    key: "${BK_KEY}_MoE_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_MoE_CorrectnessTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for MoE"
-    key: "${TPU_VERSION:-tpu6e}_record_MoE_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_MoE_CorrectnessTest"
+        buildkite-agent meta-data set "${BK_KEY}_MoE_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for MoE"
+    key: "${BK_KEY}_record_MoE_CorrectnessTest"
+    depends_on: "${BK_KEY}_MoE_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "MoE"
       CI_STAGE: "CorrectnessTest"
@@ -33,21 +36,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_MoE_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_MoE_CorrectnessTest
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for MoE"
-    key: "${TPU_VERSION:-tpu6e}_MoE_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_MoE_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for MoE"
+    key: "${BK_KEY}_MoE_PerformanceTest"
+    depends_on: "${BK_KEY}_record_MoE_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_MoE_PerformanceTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for MoE"
-    key: "${TPU_VERSION:-tpu6e}_record_MoE_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_MoE_PerformanceTest"
+        buildkite-agent meta-data set "${BK_KEY}_MoE_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for MoE"
+    key: "${BK_KEY}_record_MoE_PerformanceTest"
+    depends_on: "${BK_KEY}_MoE_PerformanceTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "MoE"
       CI_STAGE: "PerformanceTest"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_MoE_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_MoE_PerformanceTest

--- a/.buildkite/features/Multimodal_Inputs.yml
+++ b/.buildkite/features/Multimodal_Inputs.yml
@@ -13,19 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for Multimodal Inputs"
-    key: "${TPU_VERSION:-tpu6e}_Multimodal_Inputs_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for Multimodal Inputs"
+    key: "${BK_KEY}_Multimodal_Inputs_CorrectnessTest"
     soft_fail: true
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       TPU_VERSION: "${TPU_VERSION:-tpu6e}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - .buildkite/scripts/run_in_docker.sh python3 -m pytest -s -v /workspace/tpu_inference/tests/e2e/test_multi_modal_inference.py
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for Multimodal Inputs"
-    key: "${TPU_VERSION:-tpu6e}_record_Multimodal_Inputs_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_Multimodal_Inputs_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for Multimodal Inputs"
+    key: "${BK_KEY}_record_Multimodal_Inputs_CorrectnessTest"
+    depends_on: "${BK_KEY}_Multimodal_Inputs_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "Multimodal Inputs"
       CI_STAGE: "CorrectnessTest"
@@ -34,20 +36,23 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_Multimodal_Inputs_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_Multimodal_Inputs_CorrectnessTest
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for Multimodal Inputs"
-    key: "${TPU_VERSION:-tpu6e}_Multimodal_Inputs_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_Multimodal_Inputs_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for Multimodal Inputs"
+    key: "${BK_KEY}_Multimodal_Inputs_PerformanceTest"
+    depends_on: "${BK_KEY}_record_Multimodal_Inputs_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/mm_bench.sh
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for Multimodal Inputs"
-    key: "${TPU_VERSION:-tpu6e}_record_Multimodal_Inputs_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_Multimodal_Inputs_PerformanceTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for Multimodal Inputs"
+    key: "${BK_KEY}_record_Multimodal_Inputs_PerformanceTest"
+    depends_on: "${BK_KEY}_Multimodal_Inputs_PerformanceTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "Multimodal Inputs"
       CI_STAGE: "PerformanceTest"
@@ -56,4 +61,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_Multimodal_Inputs_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_Multimodal_Inputs_PerformanceTest

--- a/.buildkite/features/Out_Of_Tree_Model_Support.yml
+++ b/.buildkite/features/Out_Of_Tree_Model_Support.yml
@@ -13,9 +13,11 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for Out-of-tree model support"
-    key: "${TPU_VERSION:-tpu6e}_out_of_tree_model_support_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for Out-of-tree model support"
+    key: "${BK_KEY}_out_of_tree_model_support_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
@@ -24,10 +26,11 @@ steps:
           python3 -m pytest -s -v /workspace/tpu_inference/tests/e2e/test_model_loader.py::test_register_model_success \
           /workspace/tpu_inference/tests/e2e/test_model_loader.py::test_registered_model_passes_vllm_interface_check
 
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for Out-of-tree model support"
-    key: "${TPU_VERSION:-tpu6e}_record_out_of_tree_model_support_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_out_of_tree_model_support_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for Out-of-tree model support"
+    key: "${BK_KEY}_record_out_of_tree_model_support_CorrectnessTest"
+    depends_on: "${BK_KEY}_out_of_tree_model_support_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "Out-of-tree model support"
       CI_STAGE: "CorrectnessTest"
@@ -36,12 +39,13 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_out_of_tree_model_support_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_out_of_tree_model_support_CorrectnessTest
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for Out-of-tree model support"
-    key: "${TPU_VERSION:-tpu6e}_out_of_tree_model_support_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_out_of_tree_model_support_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for Out-of-tree model support"
+    key: "${BK_KEY}_out_of_tree_model_support_PerformanceTest"
+    depends_on: "${BK_KEY}_record_out_of_tree_model_support_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       TPU_VERSION: "${TPU_VERSION:-tpu6e}"
     soft_fail: true
     agents:
@@ -51,10 +55,11 @@ steps:
         .buildkite/scripts/run_in_docker.sh \
           python3 -m pytest -s -v /workspace/tpu_inference/tests/e2e/test_model_loader.py::test_flax_nnx_vs_vllm_performance
 
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for Out-of-tree model support"
-    key: "${TPU_VERSION:-tpu6e}_record_out_of_tree_model_support_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_out_of_tree_model_support_PerformanceTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for Out-of-tree model support"
+    key: "${BK_KEY}_record_out_of_tree_model_support_PerformanceTest"
+    depends_on: "${BK_KEY}_out_of_tree_model_support_PerformanceTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "Out-of-tree model support"
       CI_STAGE: "PerformanceTest"
@@ -63,4 +68,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_out_of_tree_model_support_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_out_of_tree_model_support_PerformanceTest

--- a/.buildkite/features/Quantized_Attention.yml
+++ b/.buildkite/features/Quantized_Attention.yml
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for Quantized Attention"
-    key: "${TPU_VERSION:-tpu6e}_Quantized_Attention_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for Quantized Attention"
+    key: "${BK_KEY}_Quantized_Attention_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_Quantized_Attention_CorrectnessTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for Quantized Attention"
-    key: "${TPU_VERSION:-tpu6e}_record_Quantized_Attention_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_Quantized_Attention_CorrectnessTest"
+        buildkite-agent meta-data set "${BK_KEY}_Quantized_Attention_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for Quantized Attention"
+    key: "${BK_KEY}_record_Quantized_Attention_CorrectnessTest"
+    depends_on: "${BK_KEY}_Quantized_Attention_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "Quantized Attention"
       CI_STAGE: "CorrectnessTest"
@@ -33,21 +36,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_Quantized_Attention_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_Quantized_Attention_CorrectnessTest
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for Quantized Attention"
-    key: "${TPU_VERSION:-tpu6e}_Quantized_Attention_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_Quantized_Attention_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for Quantized Attention"
+    key: "${BK_KEY}_Quantized_Attention_PerformanceTest"
+    depends_on: "${BK_KEY}_record_Quantized_Attention_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_Quantized_Attention_PerformanceTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for Quantized Attention"
-    key: "${TPU_VERSION:-tpu6e}_record_Quantized_Attention_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_Quantized_Attention_PerformanceTest"
+        buildkite-agent meta-data set "${BK_KEY}_Quantized_Attention_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for Quantized Attention"
+    key: "${BK_KEY}_record_Quantized_Attention_PerformanceTest"
+    depends_on: "${BK_KEY}_Quantized_Attention_PerformanceTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "Quantized Attention"
       CI_STAGE: "PerformanceTest"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_Quantized_Attention_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_Quantized_Attention_PerformanceTest

--- a/.buildkite/features/Quantized_Attention.yml
+++ b/.buildkite/features/Quantized_Attention.yml
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for Quantized Attention"
-    key: "${TPU_VERSION:-tpu6e}_Quantized_Attention_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for Quantized Attention"
+    key: "${BK_KEY}_Quantized_Attention_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_Quantized_Attention_CorrectnessTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for Quantized Attention"
-    key: "${TPU_VERSION:-tpu6e}_record_Quantized_Attention_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_Quantized_Attention_CorrectnessTest"
+        buildkite-agent meta-data set "${BK_KEY}_Quantized_Attention_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for Quantized Attention"
+    key: "${BK_KEY}_record_Quantized_Attention_CorrectnessTest"
+    depends_on: "${BK_KEY}_Quantized_Attention_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "Quantized Attention"
       CI_STAGE: "CorrectnessTest"
@@ -33,21 +36,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_Quantized_Attention_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_Quantized_Attention_CorrectnessTest
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for Quantized Attention"
-    key: "${TPU_VERSION:-tpu6e}_Quantized_Attention_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_Quantized_Attention_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for Quantized Attention"
+    key: "${BK_KEY}_Quantized_Attention_PerformanceTest"
+    depends_on: "${BK_KEY}_record_Quantized_Attention_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_Quantized_Attention_PerformanceTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for Quantized Attention"
-    key: "${TPU_VERSION:-tpu6e}_record_Quantized_Attention_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_Quantized_Attention_PerformanceTest"
+        buildkite-agent meta-data set "${BK_KEY}_Quantized_Attention_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for Quantized Attention"
+    key: "${BK_KEY}_record_Quantized_Attention_PerformanceTest"
+    depends_on: "${BK_KEY}_Quantized_Attention_PerformanceTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "Quantized Attention"
       CI_STAGE: "PerformanceTest"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_Quantized_Attention_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_Quantized_Attention_PerformanceTest

--- a/.buildkite/features/Quantized_KV_Cache.yml
+++ b/.buildkite/features/Quantized_KV_Cache.yml
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for Quantized KV Cache"
-    key: "${TPU_VERSION:-tpu6e}_Quantized_KV_Cache_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for Quantized KV Cache"
+    key: "${BK_KEY}_Quantized_KV_Cache_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_Quantized_KV_Cache_CorrectnessTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for Quantized KV Cache"
-    key: "${TPU_VERSION:-tpu6e}_record_Quantized_KV_Cache_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_Quantized_KV_Cache_CorrectnessTest"
+        buildkite-agent meta-data set "${BK_KEY}_Quantized_KV_Cache_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for Quantized KV Cache"
+    key: "${BK_KEY}_record_Quantized_KV_Cache_CorrectnessTest"
+    depends_on: "${BK_KEY}_Quantized_KV_Cache_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "Quantized KV Cache"
       CI_STAGE: "CorrectnessTest"
@@ -33,21 +36,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_Quantized_KV_Cache_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_Quantized_KV_Cache_CorrectnessTest
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for Quantized KV Cache"
-    key: "${TPU_VERSION:-tpu6e}_Quantized_KV_Cache_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_Quantized_KV_Cache_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for Quantized KV Cache"
+    key: "${BK_KEY}_Quantized_KV_Cache_PerformanceTest"
+    depends_on: "${BK_KEY}_record_Quantized_KV_Cache_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_Quantized_KV_Cache_PerformanceTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for Quantized KV Cache"
-    key: "${TPU_VERSION:-tpu6e}_record_Quantized_KV_Cache_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_Quantized_KV_Cache_PerformanceTest"
+        buildkite-agent meta-data set "${BK_KEY}_Quantized_KV_Cache_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for Quantized KV Cache"
+    key: "${BK_KEY}_record_Quantized_KV_Cache_PerformanceTest"
+    depends_on: "${BK_KEY}_Quantized_KV_Cache_PerformanceTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "Quantized KV Cache"
       CI_STAGE: "PerformanceTest"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_Quantized_KV_Cache_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_Quantized_KV_Cache_PerformanceTest

--- a/.buildkite/features/Quantized_KV_Cache.yml
+++ b/.buildkite/features/Quantized_KV_Cache.yml
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for Quantized KV Cache"
-    key: "${TPU_VERSION:-tpu6e}_Quantized_KV_Cache_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for Quantized KV Cache"
+    key: "${BK_KEY}_Quantized_KV_Cache_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_Quantized_KV_Cache_CorrectnessTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for Quantized KV Cache"
-    key: "${TPU_VERSION:-tpu6e}_record_Quantized_KV_Cache_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_Quantized_KV_Cache_CorrectnessTest"
+        buildkite-agent meta-data set "${BK_KEY}_Quantized_KV_Cache_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for Quantized KV Cache"
+    key: "${BK_KEY}_record_Quantized_KV_Cache_CorrectnessTest"
+    depends_on: "${BK_KEY}_Quantized_KV_Cache_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "Quantized KV Cache"
       CI_STAGE: "CorrectnessTest"
@@ -33,21 +36,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_Quantized_KV_Cache_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_Quantized_KV_Cache_CorrectnessTest
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for Quantized KV Cache"
-    key: "${TPU_VERSION:-tpu6e}_Quantized_KV_Cache_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_Quantized_KV_Cache_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for Quantized KV Cache"
+    key: "${BK_KEY}_Quantized_KV_Cache_PerformanceTest"
+    depends_on: "${BK_KEY}_record_Quantized_KV_Cache_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_Quantized_KV_Cache_PerformanceTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for Quantized KV Cache"
-    key: "${TPU_VERSION:-tpu6e}_record_Quantized_KV_Cache_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_Quantized_KV_Cache_PerformanceTest"
+        buildkite-agent meta-data set "${BK_KEY}_Quantized_KV_Cache_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for Quantized KV Cache"
+    key: "${BK_KEY}_record_Quantized_KV_Cache_PerformanceTest"
+    depends_on: "${BK_KEY}_Quantized_KV_Cache_PerformanceTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "Quantized KV Cache"
       CI_STAGE: "PerformanceTest"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_Quantized_KV_Cache_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_Quantized_KV_Cache_PerformanceTest

--- a/.buildkite/features/Quantized_Matmul.yml
+++ b/.buildkite/features/Quantized_Matmul.yml
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for Quantized Matmul"
-    key: "${TPU_VERSION:-tpu6e}_Quantized_Matmul_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for Quantized Matmul"
+    key: "${BK_KEY}_Quantized_Matmul_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_Quantized_Matmul_CorrectnessTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for Quantized Matmul"
-    key: "${TPU_VERSION:-tpu6e}_record_Quantized_Matmul_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_Quantized_Matmul_CorrectnessTest"
+        buildkite-agent meta-data set "${BK_KEY}_Quantized_Matmul_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for Quantized Matmul"
+    key: "${BK_KEY}_record_Quantized_Matmul_CorrectnessTest"
+    depends_on: "${BK_KEY}_Quantized_Matmul_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "Quantized Matmul"
       CI_STAGE: "CorrectnessTest"
@@ -33,21 +36,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_Quantized_Matmul_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_Quantized_Matmul_CorrectnessTest
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for Quantized Matmul"
-    key: "${TPU_VERSION:-tpu6e}_Quantized_Matmul_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_Quantized_Matmul_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for Quantized Matmul"
+    key: "${BK_KEY}_Quantized_Matmul_PerformanceTest"
+    depends_on: "${BK_KEY}_record_Quantized_Matmul_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_Quantized_Matmul_PerformanceTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for Quantized Matmul"
-    key: "${TPU_VERSION:-tpu6e}_record_Quantized_Matmul_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_Quantized_Matmul_PerformanceTest"
+        buildkite-agent meta-data set "${BK_KEY}_Quantized_Matmul_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for Quantized Matmul"
+    key: "${BK_KEY}_record_Quantized_Matmul_PerformanceTest"
+    depends_on: "${BK_KEY}_Quantized_Matmul_PerformanceTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "Quantized Matmul"
       CI_STAGE: "PerformanceTest"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_Quantized_Matmul_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_Quantized_Matmul_PerformanceTest

--- a/.buildkite/features/Quantized_Matmul.yml
+++ b/.buildkite/features/Quantized_Matmul.yml
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for Quantized Matmul"
-    key: "${TPU_VERSION:-tpu6e}_Quantized_Matmul_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for Quantized Matmul"
+    key: "${BK_KEY}_Quantized_Matmul_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_Quantized_Matmul_CorrectnessTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for Quantized Matmul"
-    key: "${TPU_VERSION:-tpu6e}_record_Quantized_Matmul_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_Quantized_Matmul_CorrectnessTest"
+        buildkite-agent meta-data set "${BK_KEY}_Quantized_Matmul_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for Quantized Matmul"
+    key: "${BK_KEY}_record_Quantized_Matmul_CorrectnessTest"
+    depends_on: "${BK_KEY}_Quantized_Matmul_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "Quantized Matmul"
       CI_STAGE: "CorrectnessTest"
@@ -33,21 +36,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_Quantized_Matmul_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_Quantized_Matmul_CorrectnessTest
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for Quantized Matmul"
-    key: "${TPU_VERSION:-tpu6e}_Quantized_Matmul_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_Quantized_Matmul_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for Quantized Matmul"
+    key: "${BK_KEY}_Quantized_Matmul_PerformanceTest"
+    depends_on: "${BK_KEY}_record_Quantized_Matmul_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_Quantized_Matmul_PerformanceTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for Quantized Matmul"
-    key: "${TPU_VERSION:-tpu6e}_record_Quantized_Matmul_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_Quantized_Matmul_PerformanceTest"
+        buildkite-agent meta-data set "${BK_KEY}_Quantized_Matmul_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for Quantized Matmul"
+    key: "${BK_KEY}_record_Quantized_Matmul_PerformanceTest"
+    depends_on: "${BK_KEY}_Quantized_Matmul_PerformanceTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "Quantized Matmul"
       CI_STAGE: "PerformanceTest"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_Quantized_Matmul_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_Quantized_Matmul_PerformanceTest

--- a/.buildkite/features/Speculative_Decoding-_Eagle3.yml
+++ b/.buildkite/features/Speculative_Decoding-_Eagle3.yml
@@ -13,21 +13,23 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for Speculative Decoding: Eagle3"
-    key: "${TPU_VERSION:-tpu6e}_Speculative_Decoding-_Eagle3_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for Speculative Decoding: Eagle3"
+    key: "${BK_KEY}_Speculative_Decoding-_Eagle3_CorrectnessTest"
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       TPU_VERSION: "${TPU_VERSION:-tpu6e}"
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh \
           python3 -m pytest -s -v /workspace/tpu_inference/tests/e2e/test_speculative_decoding.py::test_eagle3_correctness
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for Speculative Decoding: Eagle3"
-    key: "${TPU_VERSION:-tpu6e}_record_Speculative_Decoding-_Eagle3_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_Speculative_Decoding-_Eagle3_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for Speculative Decoding: Eagle3"
+    key: "${BK_KEY}_record_Speculative_Decoding-_Eagle3_CorrectnessTest"
+    depends_on: "${BK_KEY}_Speculative_Decoding-_Eagle3_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "Speculative Decoding: Eagle3"
       CI_STAGE: "CorrectnessTest"
@@ -36,25 +38,27 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_Speculative_Decoding-_Eagle3_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_Speculative_Decoding-_Eagle3_CorrectnessTest
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for Speculative Decoding: Eagle3"
-    key: "${TPU_VERSION:-tpu6e}_Speculative_Decoding-_Eagle3_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_Speculative_Decoding-_Eagle3_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for Speculative Decoding: Eagle3"
+    key: "${BK_KEY}_Speculative_Decoding-_Eagle3_PerformanceTest"
+    depends_on: "${BK_KEY}_record_Speculative_Decoding-_Eagle3_CorrectnessTest"
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       TPU_VERSION: "${TPU_VERSION:-tpu6e}"
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh \
           python3 -m pytest -s -v /workspace/tpu_inference/tests/e2e/test_speculative_decoding.py::test_eagle3_performance
 
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for Speculative Decoding: Eagle3"
-    key: "${TPU_VERSION:-tpu6e}_record_Speculative_Decoding-_Eagle3_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_Speculative_Decoding-_Eagle3_PerformanceTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for Speculative Decoding: Eagle3"
+    key: "${BK_KEY}_record_Speculative_Decoding-_Eagle3_PerformanceTest"
+    depends_on: "${BK_KEY}_Speculative_Decoding-_Eagle3_PerformanceTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "Speculative Decoding: Eagle3"
       CI_STAGE: "PerformanceTest"
@@ -63,4 +67,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_Speculative_Decoding-_Eagle3_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_Speculative_Decoding-_Eagle3_PerformanceTest

--- a/.buildkite/features/Speculative_Decoding-_Ngram.yml
+++ b/.buildkite/features/Speculative_Decoding-_Ngram.yml
@@ -13,22 +13,24 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for Speculative Decoding: Ngram"
-    key: "${TPU_VERSION:-tpu6e}_Speculative_Decoding-_Ngram_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for Speculative Decoding: Ngram"
+    key: "${BK_KEY}_Speculative_Decoding-_Ngram_CorrectnessTest"
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       TPU_VERSION: "${TPU_VERSION:-tpu6e}"
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh \
           python3 -m pytest -s -v /workspace/tpu_inference/tests/e2e/test_speculative_decoding.py::test_ngram_correctness_greedy \
           /workspace/tpu_inference/tests/e2e/test_speculative_decoding.py::test_ngram_correctness_random
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for Speculative Decoding: Ngram"
-    key: "${TPU_VERSION:-tpu6e}_record_Speculative_Decoding-_Ngram_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_Speculative_Decoding-_Ngram_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for Speculative Decoding: Ngram"
+    key: "${BK_KEY}_record_Speculative_Decoding-_Ngram_CorrectnessTest"
+    depends_on: "${BK_KEY}_Speculative_Decoding-_Ngram_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "Speculative Decoding: Ngram"
       CI_STAGE: "CorrectnessTest"
@@ -37,15 +39,16 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_Speculative_Decoding-_Ngram_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_Speculative_Decoding-_Ngram_CorrectnessTest
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for Speculative Decoding: Ngram"
-    key: "${TPU_VERSION:-tpu6e}_Speculative_Decoding-_Ngram_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_Speculative_Decoding-_Ngram_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for Speculative Decoding: Ngram"
+    key: "${BK_KEY}_Speculative_Decoding-_Ngram_PerformanceTest"
+    depends_on: "${BK_KEY}_record_Speculative_Decoding-_Ngram_CorrectnessTest"
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       TPU_VERSION: "${TPU_VERSION:-tpu6e}"
     commands:
       - |
@@ -53,10 +56,11 @@ steps:
           python3 -m pytest -s -v /workspace/tpu_inference/tests/e2e/test_speculative_decoding.py::test_ngram_performance_greedy \
           /workspace/tpu_inference/tests/e2e/test_speculative_decoding.py::test_ngram_performance_random
 
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for Speculative Decoding: Ngram"
-    key: "${TPU_VERSION:-tpu6e}_record_Speculative_Decoding-_Ngram_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_Speculative_Decoding-_Ngram_PerformanceTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for Speculative Decoding: Ngram"
+    key: "${BK_KEY}_record_Speculative_Decoding-_Ngram_PerformanceTest"
+    depends_on: "${BK_KEY}_Speculative_Decoding-_Ngram_PerformanceTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "Speculative Decoding: Ngram"
       CI_STAGE: "PerformanceTest"
@@ -65,4 +69,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_Speculative_Decoding-_Ngram_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_Speculative_Decoding-_Ngram_PerformanceTest

--- a/.buildkite/features/Step_Pooling_Embedding.yml
+++ b/.buildkite/features/Step_Pooling_Embedding.yml
@@ -13,17 +13,20 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for Step Pooling (Embedding)"
-    key: "${TPU_VERSION:-tpu6e}_Step_Pooling_Embedding_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for Step Pooling (Embedding)"
+    key: "${BK_KEY}_Step_Pooling_Embedding_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - .buildkite/scripts/run_in_docker.sh python3 -m pytest -s -v /workspace/tpu_inference/tests/e2e/test_step_pooling.py
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for Step Pooling (Embedding)"
-    key: "${TPU_VERSION:-tpu6e}_record_Step_Pooling_Embedding_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_Step_Pooling_Embedding_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for Step Pooling (Embedding)"
+    key: "${BK_KEY}_record_Step_Pooling_Embedding_CorrectnessTest"
+    depends_on: "${BK_KEY}_Step_Pooling_Embedding_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "Step Pooling (Embedding)"
       CI_STAGE: "CorrectnessTest"
@@ -32,21 +35,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_Step_Pooling_Embedding_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_Step_Pooling_Embedding_CorrectnessTest
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for Step Pooling (Embedding)"
-    key: "${TPU_VERSION:-tpu6e}_Step_Pooling_Embedding_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_Step_Pooling_Embedding_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for Step Pooling (Embedding)"
+    key: "${BK_KEY}_Step_Pooling_Embedding_PerformanceTest"
+    depends_on: "${BK_KEY}_record_Step_Pooling_Embedding_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_Step_Pooling_Embedding_PerformanceTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for Step Pooling (Embedding)"
-    key: "${TPU_VERSION:-tpu6e}_record_Step_Pooling_Embedding_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_Step_Pooling_Embedding_PerformanceTest"
+        buildkite-agent meta-data set "${BK_KEY}_Step_Pooling_Embedding_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for Step Pooling (Embedding)"
+    key: "${BK_KEY}_record_Step_Pooling_Embedding_PerformanceTest"
+    depends_on: "${BK_KEY}_Step_Pooling_Embedding_PerformanceTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "Step Pooling (Embedding)"
       CI_STAGE: "PerformanceTest"
@@ -55,4 +61,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_Step_Pooling_Embedding_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_Step_Pooling_Embedding_PerformanceTest

--- a/.buildkite/features/Step_Pooling_Embedding.yml
+++ b/.buildkite/features/Step_Pooling_Embedding.yml
@@ -13,17 +13,20 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for Step Pooling (Embedding)"
-    key: "${TPU_VERSION:-tpu6e}_Step_Pooling_Embedding_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for Step Pooling (Embedding)"
+    key: "${BK_KEY}_Step_Pooling_Embedding_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - .buildkite/scripts/run_in_docker.sh python3 -m pytest -s -v /workspace/tpu_inference/tests/e2e/test_step_pooling.py
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for Step Pooling (Embedding)"
-    key: "${TPU_VERSION:-tpu6e}_record_Step_Pooling_Embedding_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_Step_Pooling_Embedding_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for Step Pooling (Embedding)"
+    key: "${BK_KEY}_record_Step_Pooling_Embedding_CorrectnessTest"
+    depends_on: "${BK_KEY}_Step_Pooling_Embedding_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "Step Pooling (Embedding)"
       CI_STAGE: "CorrectnessTest"
@@ -32,21 +35,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_Step_Pooling_Embedding_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_Step_Pooling_Embedding_CorrectnessTest
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for Step Pooling (Embedding)"
-    key: "${TPU_VERSION:-tpu6e}_Step_Pooling_Embedding_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_Step_Pooling_Embedding_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for Step Pooling (Embedding)"
+    key: "${BK_KEY}_Step_Pooling_Embedding_PerformanceTest"
+    depends_on: "${BK_KEY}_record_Step_Pooling_Embedding_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_Step_Pooling_Embedding_PerformanceTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for Step Pooling (Embedding)"
-    key: "${TPU_VERSION:-tpu6e}_record_Step_Pooling_Embedding_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_Step_Pooling_Embedding_PerformanceTest"
+        buildkite-agent meta-data set "${BK_KEY}_Step_Pooling_Embedding_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for Step Pooling (Embedding)"
+    key: "${BK_KEY}_record_Step_Pooling_Embedding_PerformanceTest"
+    depends_on: "${BK_KEY}_Step_Pooling_Embedding_PerformanceTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "Step Pooling (Embedding)"
       CI_STAGE: "PerformanceTest"
@@ -55,4 +61,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_Step_Pooling_Embedding_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_Step_Pooling_Embedding_PerformanceTest

--- a/.buildkite/features/Structured_Decoding.yml
+++ b/.buildkite/features/Structured_Decoding.yml
@@ -17,17 +17,20 @@
 # following a JSON schema. This is useful for classification tasks,
 # structured data extraction, and ensuring outputs conform to expected formats.
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for structured_decoding"
-    key: "${TPU_VERSION:-tpu6e}_structured_decoding_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for structured_decoding"
+    key: "${BK_KEY}_structured_decoding_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - .buildkite/scripts/run_in_docker.sh python3 -m pytest -s -v /workspace/tpu_inference/tests/e2e/test_structured_decoding.py::test_structured_decoding
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for structured_decoding"
-    key: "${TPU_VERSION:-tpu6e}_record_structured_decoding_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_structured_decoding_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for structured_decoding"
+    key: "${BK_KEY}_record_structured_decoding_CorrectnessTest"
+    depends_on: "${BK_KEY}_structured_decoding_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "structured_decoding"
       CI_STAGE: "CorrectnessTest"
@@ -36,4 +39,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_structured_decoding_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_structured_decoding_CorrectnessTest

--- a/.buildkite/features/async_scheduler.yml
+++ b/.buildkite/features/async_scheduler.yml
@@ -13,17 +13,20 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for async scheduler"
-    key: "${TPU_VERSION:-tpu6e}_async_scheduler_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for async scheduler"
+    key: "${BK_KEY}_async_scheduler_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - .buildkite/scripts/run_in_docker.sh python3 -m pytest -s -v /workspace/tpu_inference/tests/e2e/test_async_scheduler.py::test_async_correctness
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for async scheduler"
-    key: "${TPU_VERSION:-tpu6e}_record_async_scheduler_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_async_scheduler_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for async scheduler"
+    key: "${BK_KEY}_record_async_scheduler_CorrectnessTest"
+    depends_on: "${BK_KEY}_async_scheduler_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "async scheduler"
       CI_STAGE: "CorrectnessTest"
@@ -32,20 +35,23 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_async_scheduler_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_async_scheduler_CorrectnessTest
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for async scheduler"
-    key: "${TPU_VERSION:-tpu6e}_async_scheduler_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_async_scheduler_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for async scheduler"
+    key: "${BK_KEY}_async_scheduler_PerformanceTest"
+    depends_on: "${BK_KEY}_record_async_scheduler_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - .buildkite/scripts/run_in_docker.sh python3 -m pytest -s -v /workspace/tpu_inference/tests/e2e/test_async_scheduler.py::test_performance
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for async scheduler"
-    key: "${TPU_VERSION:-tpu6e}_record_async_scheduler_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_async_scheduler_PerformanceTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for async scheduler"
+    key: "${BK_KEY}_record_async_scheduler_PerformanceTest"
+    depends_on: "${BK_KEY}_async_scheduler_PerformanceTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "async scheduler"
       CI_STAGE: "PerformanceTest"
@@ -54,4 +60,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_async_scheduler_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_async_scheduler_PerformanceTest

--- a/.buildkite/features/multi-host.yml
+++ b/.buildkite/features/multi-host.yml
@@ -13,13 +13,14 @@
 # limitations under the License.
 
 steps: 
-  - label: "${TPU_VERSION:-tpu7x} Correctness tests for multi-host"
-    key: "${TPU_VERSION:-tpu7x}_multi-host_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu7x} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for multi-host"
+    key: "${BK_KEY}_multi-host_CorrectnessTest"
     soft_fail: true
     agents:
       queue: tpu_v7x_16_queue
     env:
-      TPU_VERSION: "${TPU_VERSION:-tpu6e}"
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
+      TPU_VERSION: "${TPU_VERSION:-tpu7x}"
       HEAD_SSH_IP: ""
       HEAD_INTERNAL_IP: ""
       WORKER_SSH_IPS: ""
@@ -43,10 +44,11 @@ steps:
             -H 'Content-Type: application/json' \
             -d '{\"model\": \"${MODEL}\", \"prompt\": \"San Francisco is a\", \"max_tokens\": 50}'
           "
-  - label: "${TPU_VERSION:-tpu7x} Record correctness test result for multi-host"
-    key: "${TPU_VERSION:-tpu7x}_record_multi-host_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu7x}_multi-host_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu7x} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for multi-host"
+    key: "${BK_KEY}_record_multi-host_CorrectnessTest"
+    depends_on: "${BK_KEY}_multi-host_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu7x}"
       CI_TARGET: "multi-host"
       CI_STAGE: "CorrectnessTest"
@@ -55,20 +57,23 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu7x}_multi-host_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_multi-host_CorrectnessTest
 
-  - label: "${TPU_VERSION:-tpu7x} Performance tests for multi-host"
-    key: "${TPU_VERSION:-tpu7x}_multi-host_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu7x}_record_multi-host_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu7x} ${MODEL_IMPL_TYPE:-vllm} Performance tests for multi-host"
+    key: "${BK_KEY}_multi-host_PerformanceTest"
+    depends_on: "${BK_KEY}_record_multi-host_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: tpu_v7x_16_queue
     commands:
-      - buildkite-agent meta-data set "${TPU_VERSION:-tpu7x}_multi-host_PerformanceTest" "unverified"
-  - label: "${TPU_VERSION:-tpu7x} Record performance test result for multi-host"
-    key: "${TPU_VERSION:-tpu7x}_record_multi-host_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu7x}_multi-host_PerformanceTest"
+      - buildkite-agent meta-data set "${BK_KEY}_multi-host_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu7x} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for multi-host"
+    key: "${BK_KEY}_record_multi-host_PerformanceTest"
+    depends_on: "${BK_KEY}_multi-host_PerformanceTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu7x}"
       CI_TARGET: "multi-host"
       CI_STAGE: "PerformanceTest"
@@ -77,4 +82,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu7x}_multi-host_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_multi-host_PerformanceTest

--- a/.buildkite/features/runai_model_streamer_loader.yml
+++ b/.buildkite/features/runai_model_streamer_loader.yml
@@ -18,17 +18,20 @@
 # GPU memory. This streaming process is significantly faster than the traditional
 # disk-based loading method.
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness Test | Runai Model Streamer JAX UniProcExecutor"
-    key: "${TPU_VERSION:-tpu6e}_runai_model_streamer_loader_jax_uniproc"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness Test | Runai Model Streamer JAX UniProcExecutor"
+    key: "${BK_KEY}_runai_model_streamer_loader_jax_uniproc"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - .buildkite/scripts/run_in_docker.sh python3 -m pytest -s -v /workspace/tpu_inference/tests/e2e/test_runai_model_streamer_loader.py::test_correctness_jax_uni_proc_executor
-  - label: "${TPU_VERSION:-tpu6e} Record Result | Runai Model Streamer JAX UniProcExecutor"
-    key: "${TPU_VERSION:-tpu6e}_record_runai_model_streamer_loader_jax_uniproc"
-    depends_on: "${TPU_VERSION:-tpu6e}_runai_model_streamer_loader_jax_uniproc"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record Result | Runai Model Streamer JAX UniProcExecutor"
+    key: "${BK_KEY}_record_runai_model_streamer_loader_jax_uniproc"
+    depends_on: "${BK_KEY}_runai_model_streamer_loader_jax_uniproc"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "runai_model_streamer_loader"
       CI_STAGE: "CorrectnessTest"
@@ -37,18 +40,21 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_runai_model_streamer_loader_jax_uniproc
-  - label: "${TPU_VERSION:-tpu6e} Correctness Test | Runai Model Streamer Torchax UniProcExecutor"
-    key: "${TPU_VERSION:-tpu6e}_runai_model_streamer_loader_torchax_uniproc"
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_runai_model_streamer_loader_jax_uniproc
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness Test | Runai Model Streamer Torchax UniProcExecutor"
+    key: "${BK_KEY}_runai_model_streamer_loader_torchax_uniproc"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - .buildkite/scripts/run_in_docker.sh python3 -m pytest -s -v /workspace/tpu_inference/tests/e2e/test_runai_model_streamer_loader.py::test_correctness_torchax_uni_proc_executor
-  - label: "${TPU_VERSION:-tpu6e} Record Result | Runai Model Streamer Torchax UniProcExecutor"
-    key: "${TPU_VERSION:-tpu6e}_record_runai_model_streamer_loader_torchax_uniproc"
-    depends_on: "${TPU_VERSION:-tpu6e}_runai_model_streamer_loader_torchax_uniproc"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record Result | Runai Model Streamer Torchax UniProcExecutor"
+    key: "${BK_KEY}_record_runai_model_streamer_loader_torchax_uniproc"
+    depends_on: "${BK_KEY}_runai_model_streamer_loader_torchax_uniproc"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "runai_model_streamer_loader"
       CI_STAGE: "CorrectnessTest"
@@ -57,18 +63,21 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_runai_model_streamer_loader_torchax_uniproc
-  - label: "${TPU_VERSION:-tpu6e} Correctness Test | Runai Model Streamer Torchax RayDistributedExecutor"
-    key: "${TPU_VERSION:-tpu6e}_runai_model_streamer_loader_torchax_ray_distributed"
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_runai_model_streamer_loader_torchax_uniproc
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness Test | Runai Model Streamer Torchax RayDistributedExecutor"
+    key: "${BK_KEY}_runai_model_streamer_loader_torchax_ray_distributed"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}" # Using a queue with more devices for distributed tests
     commands:
       - .buildkite/scripts/run_in_docker.sh python3 -m pytest -s -v /workspace/tpu_inference/tests/e2e/test_runai_model_streamer_loader.py::test_correctness_torchax_ray_distributed_executor
-  - label: "${TPU_VERSION:-tpu6e} Record Result | Runai Model Streamer Torchax RayDistributedExecutor"
-    key: "${TPU_VERSION:-tpu6e}_record_runai_model_streamer_loader_torchax_ray_distributed"
-    depends_on: "${TPU_VERSION:-tpu6e}_runai_model_streamer_loader_torchax_ray_distributed"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record Result | Runai Model Streamer Torchax RayDistributedExecutor"
+    key: "${BK_KEY}_record_runai_model_streamer_loader_torchax_ray_distributed"
+    depends_on: "${BK_KEY}_runai_model_streamer_loader_torchax_ray_distributed"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "runai_model_streamer_loader"
       CI_STAGE: "CorrectnessTest"
@@ -77,4 +86,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_runai_model_streamer_loader_torchax_ray_distributed
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_runai_model_streamer_loader_torchax_ray_distributed

--- a/.buildkite/features/sampling_params.yml
+++ b/.buildkite/features/sampling_params.yml
@@ -15,17 +15,20 @@
 # Sampling parameters control how the model selects tokens during generation.
 # These tests verify that temperature, top_p, top_k, and logprobs work correctly.
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for sampling_params"
-    key: "${TPU_VERSION:-tpu6e}_sampling_params_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for sampling_params"
+    key: "${BK_KEY}_sampling_params_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - .buildkite/scripts/run_in_docker.sh python3 -m pytest -s -v /workspace/tpu_inference/tests/e2e/test_sampling_params.py
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for sampling_params"
-    key: "${TPU_VERSION:-tpu6e}_record_sampling_params_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_sampling_params_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for sampling_params"
+    key: "${BK_KEY}_record_sampling_params_CorrectnessTest"
+    depends_on: "${BK_KEY}_sampling_params_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "sampling_params"
       CI_STAGE: "CorrectnessTest"
@@ -34,4 +37,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_sampling_params_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_sampling_params_CorrectnessTest

--- a/.buildkite/kernel_microbenchmarks/all_gather_matmul/w16a16.yml
+++ b/.buildkite/kernel_microbenchmarks/all_gather_matmul/w16a16.yml
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for all-gather-matmul-w16a16"
-    key: "${TPU_VERSION:-tpu6e}_all-gather-matmul-w16a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for all-gather-matmul-w16a16"
+    key: "${BK_KEY}_all-gather-matmul-w16a16_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_all-gather-matmul-w16a16_CorrectnessTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for all-gather-matmul-w16a16"
-    key: "${TPU_VERSION:-tpu6e}_record_all-gather-matmul-w16a16_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_all-gather-matmul-w16a16_CorrectnessTest"
+        buildkite-agent meta-data set "${BK_KEY}_all-gather-matmul-w16a16_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for all-gather-matmul-w16a16"
+    key: "${BK_KEY}_record_all-gather-matmul-w16a16_CorrectnessTest"
+    depends_on: "${BK_KEY}_all-gather-matmul-w16a16_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "all-gather-matmul-w16a16"
       CI_STAGE: "CorrectnessTest"
@@ -33,21 +36,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_all-gather-matmul-w16a16_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_all-gather-matmul-w16a16_CorrectnessTest
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for all-gather-matmul-w16a16"
-    key: "${TPU_VERSION:-tpu6e}_all-gather-matmul-w16a16_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_all-gather-matmul-w16a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for all-gather-matmul-w16a16"
+    key: "${BK_KEY}_all-gather-matmul-w16a16_PerformanceTest"
+    depends_on: "${BK_KEY}_record_all-gather-matmul-w16a16_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_all-gather-matmul-w16a16_PerformanceTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for all-gather-matmul-w16a16"
-    key: "${TPU_VERSION:-tpu6e}_record_all-gather-matmul-w16a16_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_all-gather-matmul-w16a16_PerformanceTest"
+        buildkite-agent meta-data set "${BK_KEY}_all-gather-matmul-w16a16_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for all-gather-matmul-w16a16"
+    key: "${BK_KEY}_record_all-gather-matmul-w16a16_PerformanceTest"
+    depends_on: "${BK_KEY}_all-gather-matmul-w16a16_PerformanceTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "all-gather-matmul-w16a16"
       CI_STAGE: "PerformanceTest"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_all-gather-matmul-w16a16_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_all-gather-matmul-w16a16_PerformanceTest

--- a/.buildkite/kernel_microbenchmarks/all_gather_matmul/w16a16.yml
+++ b/.buildkite/kernel_microbenchmarks/all_gather_matmul/w16a16.yml
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for all-gather-matmul-w16a16"
-    key: "${TPU_VERSION:-tpu6e}_all-gather-matmul-w16a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for all-gather-matmul-w16a16"
+    key: "${BK_KEY}_all-gather-matmul-w16a16_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_all-gather-matmul-w16a16_CorrectnessTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for all-gather-matmul-w16a16"
-    key: "${TPU_VERSION:-tpu6e}_record_all-gather-matmul-w16a16_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_all-gather-matmul-w16a16_CorrectnessTest"
+        buildkite-agent meta-data set "${BK_KEY}_all-gather-matmul-w16a16_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for all-gather-matmul-w16a16"
+    key: "${BK_KEY}_record_all-gather-matmul-w16a16_CorrectnessTest"
+    depends_on: "${BK_KEY}_all-gather-matmul-w16a16_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "all-gather-matmul-w16a16"
       CI_STAGE: "CorrectnessTest"
@@ -33,21 +36,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_all-gather-matmul-w16a16_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_all-gather-matmul-w16a16_CorrectnessTest
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for all-gather-matmul-w16a16"
-    key: "${TPU_VERSION:-tpu6e}_all-gather-matmul-w16a16_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_all-gather-matmul-w16a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for all-gather-matmul-w16a16"
+    key: "${BK_KEY}_all-gather-matmul-w16a16_PerformanceTest"
+    depends_on: "${BK_KEY}_record_all-gather-matmul-w16a16_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_all-gather-matmul-w16a16_PerformanceTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for all-gather-matmul-w16a16"
-    key: "${TPU_VERSION:-tpu6e}_record_all-gather-matmul-w16a16_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_all-gather-matmul-w16a16_PerformanceTest"
+        buildkite-agent meta-data set "${BK_KEY}_all-gather-matmul-w16a16_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for all-gather-matmul-w16a16"
+    key: "${BK_KEY}_record_all-gather-matmul-w16a16_PerformanceTest"
+    depends_on: "${BK_KEY}_all-gather-matmul-w16a16_PerformanceTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "all-gather-matmul-w16a16"
       CI_STAGE: "PerformanceTest"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_all-gather-matmul-w16a16_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_all-gather-matmul-w16a16_PerformanceTest

--- a/.buildkite/kernel_microbenchmarks/all_gather_matmul/w4a16.yml
+++ b/.buildkite/kernel_microbenchmarks/all_gather_matmul/w4a16.yml
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for all-gather-matmul-w4a16"
-    key: "${TPU_VERSION:-tpu6e}_all-gather-matmul-w4a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for all-gather-matmul-w4a16"
+    key: "${BK_KEY}_all-gather-matmul-w4a16_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_all-gather-matmul-w4a16_CorrectnessTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for all-gather-matmul-w4a16"
-    key: "${TPU_VERSION:-tpu6e}_record_all-gather-matmul-w4a16_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_all-gather-matmul-w4a16_CorrectnessTest"
+        buildkite-agent meta-data set "${BK_KEY}_all-gather-matmul-w4a16_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for all-gather-matmul-w4a16"
+    key: "${BK_KEY}_record_all-gather-matmul-w4a16_CorrectnessTest"
+    depends_on: "${BK_KEY}_all-gather-matmul-w4a16_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "all-gather-matmul-w4a16"
       CI_STAGE: "CorrectnessTest"
@@ -33,21 +36,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_all-gather-matmul-w4a16_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_all-gather-matmul-w4a16_CorrectnessTest
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for all-gather-matmul-w4a16"
-    key: "${TPU_VERSION:-tpu6e}_all-gather-matmul-w4a16_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_all-gather-matmul-w4a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for all-gather-matmul-w4a16"
+    key: "${BK_KEY}_all-gather-matmul-w4a16_PerformanceTest"
+    depends_on: "${BK_KEY}_record_all-gather-matmul-w4a16_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_all-gather-matmul-w4a16_PerformanceTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for all-gather-matmul-w4a16"
-    key: "${TPU_VERSION:-tpu6e}_record_all-gather-matmul-w4a16_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_all-gather-matmul-w4a16_PerformanceTest"
+        buildkite-agent meta-data set "${BK_KEY}_all-gather-matmul-w4a16_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for all-gather-matmul-w4a16"
+    key: "${BK_KEY}_record_all-gather-matmul-w4a16_PerformanceTest"
+    depends_on: "${BK_KEY}_all-gather-matmul-w4a16_PerformanceTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "all-gather-matmul-w4a16"
       CI_STAGE: "PerformanceTest"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_all-gather-matmul-w4a16_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_all-gather-matmul-w4a16_PerformanceTest

--- a/.buildkite/kernel_microbenchmarks/all_gather_matmul/w4a16.yml
+++ b/.buildkite/kernel_microbenchmarks/all_gather_matmul/w4a16.yml
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for all-gather-matmul-w4a16"
-    key: "${TPU_VERSION:-tpu6e}_all-gather-matmul-w4a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for all-gather-matmul-w4a16"
+    key: "${BK_KEY}_all-gather-matmul-w4a16_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_all-gather-matmul-w4a16_CorrectnessTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for all-gather-matmul-w4a16"
-    key: "${TPU_VERSION:-tpu6e}_record_all-gather-matmul-w4a16_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_all-gather-matmul-w4a16_CorrectnessTest"
+        buildkite-agent meta-data set "${BK_KEY}_all-gather-matmul-w4a16_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for all-gather-matmul-w4a16"
+    key: "${BK_KEY}_record_all-gather-matmul-w4a16_CorrectnessTest"
+    depends_on: "${BK_KEY}_all-gather-matmul-w4a16_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "all-gather-matmul-w4a16"
       CI_STAGE: "CorrectnessTest"
@@ -33,21 +36,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_all-gather-matmul-w4a16_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_all-gather-matmul-w4a16_CorrectnessTest
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for all-gather-matmul-w4a16"
-    key: "${TPU_VERSION:-tpu6e}_all-gather-matmul-w4a16_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_all-gather-matmul-w4a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for all-gather-matmul-w4a16"
+    key: "${BK_KEY}_all-gather-matmul-w4a16_PerformanceTest"
+    depends_on: "${BK_KEY}_record_all-gather-matmul-w4a16_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_all-gather-matmul-w4a16_PerformanceTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for all-gather-matmul-w4a16"
-    key: "${TPU_VERSION:-tpu6e}_record_all-gather-matmul-w4a16_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_all-gather-matmul-w4a16_PerformanceTest"
+        buildkite-agent meta-data set "${BK_KEY}_all-gather-matmul-w4a16_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for all-gather-matmul-w4a16"
+    key: "${BK_KEY}_record_all-gather-matmul-w4a16_PerformanceTest"
+    depends_on: "${BK_KEY}_all-gather-matmul-w4a16_PerformanceTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "all-gather-matmul-w4a16"
       CI_STAGE: "PerformanceTest"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_all-gather-matmul-w4a16_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_all-gather-matmul-w4a16_PerformanceTest

--- a/.buildkite/kernel_microbenchmarks/all_gather_matmul/w4a4.yml
+++ b/.buildkite/kernel_microbenchmarks/all_gather_matmul/w4a4.yml
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for all-gather-matmul-w4a4"
-    key: "${TPU_VERSION:-tpu6e}_all-gather-matmul-w4a4_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for all-gather-matmul-w4a4"
+    key: "${BK_KEY}_all-gather-matmul-w4a4_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_all-gather-matmul-w4a4_CorrectnessTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for all-gather-matmul-w4a4"
-    key: "${TPU_VERSION:-tpu6e}_record_all-gather-matmul-w4a4_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_all-gather-matmul-w4a4_CorrectnessTest"
+        buildkite-agent meta-data set "${BK_KEY}_all-gather-matmul-w4a4_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for all-gather-matmul-w4a4"
+    key: "${BK_KEY}_record_all-gather-matmul-w4a4_CorrectnessTest"
+    depends_on: "${BK_KEY}_all-gather-matmul-w4a4_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "all-gather-matmul-w4a4"
       CI_STAGE: "CorrectnessTest"
@@ -33,21 +36,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_all-gather-matmul-w4a4_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_all-gather-matmul-w4a4_CorrectnessTest
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for all-gather-matmul-w4a4"
-    key: "${TPU_VERSION:-tpu6e}_all-gather-matmul-w4a4_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_all-gather-matmul-w4a4_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for all-gather-matmul-w4a4"
+    key: "${BK_KEY}_all-gather-matmul-w4a4_PerformanceTest"
+    depends_on: "${BK_KEY}_record_all-gather-matmul-w4a4_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_all-gather-matmul-w4a4_PerformanceTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for all-gather-matmul-w4a4"
-    key: "${TPU_VERSION:-tpu6e}_record_all-gather-matmul-w4a4_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_all-gather-matmul-w4a4_PerformanceTest"
+        buildkite-agent meta-data set "${BK_KEY}_all-gather-matmul-w4a4_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for all-gather-matmul-w4a4"
+    key: "${BK_KEY}_record_all-gather-matmul-w4a4_PerformanceTest"
+    depends_on: "${BK_KEY}_all-gather-matmul-w4a4_PerformanceTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "all-gather-matmul-w4a4"
       CI_STAGE: "PerformanceTest"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_all-gather-matmul-w4a4_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_all-gather-matmul-w4a4_PerformanceTest

--- a/.buildkite/kernel_microbenchmarks/all_gather_matmul/w4a4.yml
+++ b/.buildkite/kernel_microbenchmarks/all_gather_matmul/w4a4.yml
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for all-gather-matmul-w4a4"
-    key: "${TPU_VERSION:-tpu6e}_all-gather-matmul-w4a4_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for all-gather-matmul-w4a4"
+    key: "${BK_KEY}_all-gather-matmul-w4a4_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_all-gather-matmul-w4a4_CorrectnessTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for all-gather-matmul-w4a4"
-    key: "${TPU_VERSION:-tpu6e}_record_all-gather-matmul-w4a4_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_all-gather-matmul-w4a4_CorrectnessTest"
+        buildkite-agent meta-data set "${BK_KEY}_all-gather-matmul-w4a4_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for all-gather-matmul-w4a4"
+    key: "${BK_KEY}_record_all-gather-matmul-w4a4_CorrectnessTest"
+    depends_on: "${BK_KEY}_all-gather-matmul-w4a4_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "all-gather-matmul-w4a4"
       CI_STAGE: "CorrectnessTest"
@@ -33,21 +36,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_all-gather-matmul-w4a4_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_all-gather-matmul-w4a4_CorrectnessTest
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for all-gather-matmul-w4a4"
-    key: "${TPU_VERSION:-tpu6e}_all-gather-matmul-w4a4_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_all-gather-matmul-w4a4_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for all-gather-matmul-w4a4"
+    key: "${BK_KEY}_all-gather-matmul-w4a4_PerformanceTest"
+    depends_on: "${BK_KEY}_record_all-gather-matmul-w4a4_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_all-gather-matmul-w4a4_PerformanceTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for all-gather-matmul-w4a4"
-    key: "${TPU_VERSION:-tpu6e}_record_all-gather-matmul-w4a4_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_all-gather-matmul-w4a4_PerformanceTest"
+        buildkite-agent meta-data set "${BK_KEY}_all-gather-matmul-w4a4_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for all-gather-matmul-w4a4"
+    key: "${BK_KEY}_record_all-gather-matmul-w4a4_PerformanceTest"
+    depends_on: "${BK_KEY}_all-gather-matmul-w4a4_PerformanceTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "all-gather-matmul-w4a4"
       CI_STAGE: "PerformanceTest"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_all-gather-matmul-w4a4_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_all-gather-matmul-w4a4_PerformanceTest

--- a/.buildkite/kernel_microbenchmarks/all_gather_matmul/w4a8.yml
+++ b/.buildkite/kernel_microbenchmarks/all_gather_matmul/w4a8.yml
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for all-gather-matmul-w4a8"
-    key: "${TPU_VERSION:-tpu6e}_all-gather-matmul-w4a8_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for all-gather-matmul-w4a8"
+    key: "${BK_KEY}_all-gather-matmul-w4a8_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_all-gather-matmul-w4a8_CorrectnessTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for all-gather-matmul-w4a8"
-    key: "${TPU_VERSION:-tpu6e}_record_all-gather-matmul-w4a8_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_all-gather-matmul-w4a8_CorrectnessTest"
+        buildkite-agent meta-data set "${BK_KEY}_all-gather-matmul-w4a8_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for all-gather-matmul-w4a8"
+    key: "${BK_KEY}_record_all-gather-matmul-w4a8_CorrectnessTest"
+    depends_on: "${BK_KEY}_all-gather-matmul-w4a8_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "all-gather-matmul-w4a8"
       CI_STAGE: "CorrectnessTest"
@@ -33,21 +36,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_all-gather-matmul-w4a8_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_all-gather-matmul-w4a8_CorrectnessTest
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for all-gather-matmul-w4a8"
-    key: "${TPU_VERSION:-tpu6e}_all-gather-matmul-w4a8_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_all-gather-matmul-w4a8_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for all-gather-matmul-w4a8"
+    key: "${BK_KEY}_all-gather-matmul-w4a8_PerformanceTest"
+    depends_on: "${BK_KEY}_record_all-gather-matmul-w4a8_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_all-gather-matmul-w4a8_PerformanceTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for all-gather-matmul-w4a8"
-    key: "${TPU_VERSION:-tpu6e}_record_all-gather-matmul-w4a8_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_all-gather-matmul-w4a8_PerformanceTest"
+        buildkite-agent meta-data set "${BK_KEY}_all-gather-matmul-w4a8_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for all-gather-matmul-w4a8"
+    key: "${BK_KEY}_record_all-gather-matmul-w4a8_PerformanceTest"
+    depends_on: "${BK_KEY}_all-gather-matmul-w4a8_PerformanceTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "all-gather-matmul-w4a8"
       CI_STAGE: "PerformanceTest"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_all-gather-matmul-w4a8_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_all-gather-matmul-w4a8_PerformanceTest

--- a/.buildkite/kernel_microbenchmarks/all_gather_matmul/w4a8.yml
+++ b/.buildkite/kernel_microbenchmarks/all_gather_matmul/w4a8.yml
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for all-gather-matmul-w4a8"
-    key: "${TPU_VERSION:-tpu6e}_all-gather-matmul-w4a8_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for all-gather-matmul-w4a8"
+    key: "${BK_KEY}_all-gather-matmul-w4a8_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_all-gather-matmul-w4a8_CorrectnessTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for all-gather-matmul-w4a8"
-    key: "${TPU_VERSION:-tpu6e}_record_all-gather-matmul-w4a8_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_all-gather-matmul-w4a8_CorrectnessTest"
+        buildkite-agent meta-data set "${BK_KEY}_all-gather-matmul-w4a8_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for all-gather-matmul-w4a8"
+    key: "${BK_KEY}_record_all-gather-matmul-w4a8_CorrectnessTest"
+    depends_on: "${BK_KEY}_all-gather-matmul-w4a8_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "all-gather-matmul-w4a8"
       CI_STAGE: "CorrectnessTest"
@@ -33,21 +36,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_all-gather-matmul-w4a8_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_all-gather-matmul-w4a8_CorrectnessTest
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for all-gather-matmul-w4a8"
-    key: "${TPU_VERSION:-tpu6e}_all-gather-matmul-w4a8_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_all-gather-matmul-w4a8_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for all-gather-matmul-w4a8"
+    key: "${BK_KEY}_all-gather-matmul-w4a8_PerformanceTest"
+    depends_on: "${BK_KEY}_record_all-gather-matmul-w4a8_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_all-gather-matmul-w4a8_PerformanceTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for all-gather-matmul-w4a8"
-    key: "${TPU_VERSION:-tpu6e}_record_all-gather-matmul-w4a8_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_all-gather-matmul-w4a8_PerformanceTest"
+        buildkite-agent meta-data set "${BK_KEY}_all-gather-matmul-w4a8_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for all-gather-matmul-w4a8"
+    key: "${BK_KEY}_record_all-gather-matmul-w4a8_PerformanceTest"
+    depends_on: "${BK_KEY}_all-gather-matmul-w4a8_PerformanceTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "all-gather-matmul-w4a8"
       CI_STAGE: "PerformanceTest"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_all-gather-matmul-w4a8_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_all-gather-matmul-w4a8_PerformanceTest

--- a/.buildkite/kernel_microbenchmarks/all_gather_matmul/w8a16.yml
+++ b/.buildkite/kernel_microbenchmarks/all_gather_matmul/w8a16.yml
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for all-gather-matmul-w8a16"
-    key: "${TPU_VERSION:-tpu6e}_all-gather-matmul-w8a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for all-gather-matmul-w8a16"
+    key: "${BK_KEY}_all-gather-matmul-w8a16_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_all-gather-matmul-w8a16_CorrectnessTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for all-gather-matmul-w8a16"
-    key: "${TPU_VERSION:-tpu6e}_record_all-gather-matmul-w8a16_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_all-gather-matmul-w8a16_CorrectnessTest"
+        buildkite-agent meta-data set "${BK_KEY}_all-gather-matmul-w8a16_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for all-gather-matmul-w8a16"
+    key: "${BK_KEY}_record_all-gather-matmul-w8a16_CorrectnessTest"
+    depends_on: "${BK_KEY}_all-gather-matmul-w8a16_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "all-gather-matmul-w8a16"
       CI_STAGE: "CorrectnessTest"
@@ -33,21 +36,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_all-gather-matmul-w8a16_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_all-gather-matmul-w8a16_CorrectnessTest
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for all-gather-matmul-w8a16"
-    key: "${TPU_VERSION:-tpu6e}_all-gather-matmul-w8a16_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_all-gather-matmul-w8a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for all-gather-matmul-w8a16"
+    key: "${BK_KEY}_all-gather-matmul-w8a16_PerformanceTest"
+    depends_on: "${BK_KEY}_record_all-gather-matmul-w8a16_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_all-gather-matmul-w8a16_PerformanceTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for all-gather-matmul-w8a16"
-    key: "${TPU_VERSION:-tpu6e}_record_all-gather-matmul-w8a16_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_all-gather-matmul-w8a16_PerformanceTest"
+        buildkite-agent meta-data set "${BK_KEY}_all-gather-matmul-w8a16_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for all-gather-matmul-w8a16"
+    key: "${BK_KEY}_record_all-gather-matmul-w8a16_PerformanceTest"
+    depends_on: "${BK_KEY}_all-gather-matmul-w8a16_PerformanceTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "all-gather-matmul-w8a16"
       CI_STAGE: "PerformanceTest"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_all-gather-matmul-w8a16_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_all-gather-matmul-w8a16_PerformanceTest

--- a/.buildkite/kernel_microbenchmarks/all_gather_matmul/w8a16.yml
+++ b/.buildkite/kernel_microbenchmarks/all_gather_matmul/w8a16.yml
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for all-gather-matmul-w8a16"
-    key: "${TPU_VERSION:-tpu6e}_all-gather-matmul-w8a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for all-gather-matmul-w8a16"
+    key: "${BK_KEY}_all-gather-matmul-w8a16_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_all-gather-matmul-w8a16_CorrectnessTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for all-gather-matmul-w8a16"
-    key: "${TPU_VERSION:-tpu6e}_record_all-gather-matmul-w8a16_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_all-gather-matmul-w8a16_CorrectnessTest"
+        buildkite-agent meta-data set "${BK_KEY}_all-gather-matmul-w8a16_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for all-gather-matmul-w8a16"
+    key: "${BK_KEY}_record_all-gather-matmul-w8a16_CorrectnessTest"
+    depends_on: "${BK_KEY}_all-gather-matmul-w8a16_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "all-gather-matmul-w8a16"
       CI_STAGE: "CorrectnessTest"
@@ -33,21 +36,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_all-gather-matmul-w8a16_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_all-gather-matmul-w8a16_CorrectnessTest
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for all-gather-matmul-w8a16"
-    key: "${TPU_VERSION:-tpu6e}_all-gather-matmul-w8a16_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_all-gather-matmul-w8a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for all-gather-matmul-w8a16"
+    key: "${BK_KEY}_all-gather-matmul-w8a16_PerformanceTest"
+    depends_on: "${BK_KEY}_record_all-gather-matmul-w8a16_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_all-gather-matmul-w8a16_PerformanceTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for all-gather-matmul-w8a16"
-    key: "${TPU_VERSION:-tpu6e}_record_all-gather-matmul-w8a16_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_all-gather-matmul-w8a16_PerformanceTest"
+        buildkite-agent meta-data set "${BK_KEY}_all-gather-matmul-w8a16_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for all-gather-matmul-w8a16"
+    key: "${BK_KEY}_record_all-gather-matmul-w8a16_PerformanceTest"
+    depends_on: "${BK_KEY}_all-gather-matmul-w8a16_PerformanceTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "all-gather-matmul-w8a16"
       CI_STAGE: "PerformanceTest"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_all-gather-matmul-w8a16_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_all-gather-matmul-w8a16_PerformanceTest

--- a/.buildkite/kernel_microbenchmarks/all_gather_matmul/w8a8.yml
+++ b/.buildkite/kernel_microbenchmarks/all_gather_matmul/w8a8.yml
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for all-gather-matmul-w8a8"
-    key: "${TPU_VERSION:-tpu6e}_all-gather-matmul-w8a8_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for all-gather-matmul-w8a8"
+    key: "${BK_KEY}_all-gather-matmul-w8a8_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_all-gather-matmul-w8a8_CorrectnessTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for all-gather-matmul-w8a8"
-    key: "${TPU_VERSION:-tpu6e}_record_all-gather-matmul-w8a8_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_all-gather-matmul-w8a8_CorrectnessTest"
+        buildkite-agent meta-data set "${BK_KEY}_all-gather-matmul-w8a8_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for all-gather-matmul-w8a8"
+    key: "${BK_KEY}_record_all-gather-matmul-w8a8_CorrectnessTest"
+    depends_on: "${BK_KEY}_all-gather-matmul-w8a8_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "all-gather-matmul-w8a8"
       CI_STAGE: "CorrectnessTest"
@@ -33,21 +36,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_all-gather-matmul-w8a8_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_all-gather-matmul-w8a8_CorrectnessTest
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for all-gather-matmul-w8a8"
-    key: "${TPU_VERSION:-tpu6e}_all-gather-matmul-w8a8_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_all-gather-matmul-w8a8_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for all-gather-matmul-w8a8"
+    key: "${BK_KEY}_all-gather-matmul-w8a8_PerformanceTest"
+    depends_on: "${BK_KEY}_record_all-gather-matmul-w8a8_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_all-gather-matmul-w8a8_PerformanceTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for all-gather-matmul-w8a8"
-    key: "${TPU_VERSION:-tpu6e}_record_all-gather-matmul-w8a8_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_all-gather-matmul-w8a8_PerformanceTest"
+        buildkite-agent meta-data set "${BK_KEY}_all-gather-matmul-w8a8_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for all-gather-matmul-w8a8"
+    key: "${BK_KEY}_record_all-gather-matmul-w8a8_PerformanceTest"
+    depends_on: "${BK_KEY}_all-gather-matmul-w8a8_PerformanceTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "all-gather-matmul-w8a8"
       CI_STAGE: "PerformanceTest"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_all-gather-matmul-w8a8_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_all-gather-matmul-w8a8_PerformanceTest

--- a/.buildkite/kernel_microbenchmarks/all_gather_matmul/w8a8.yml
+++ b/.buildkite/kernel_microbenchmarks/all_gather_matmul/w8a8.yml
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for all-gather-matmul-w8a8"
-    key: "${TPU_VERSION:-tpu6e}_all-gather-matmul-w8a8_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for all-gather-matmul-w8a8"
+    key: "${BK_KEY}_all-gather-matmul-w8a8_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_all-gather-matmul-w8a8_CorrectnessTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for all-gather-matmul-w8a8"
-    key: "${TPU_VERSION:-tpu6e}_record_all-gather-matmul-w8a8_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_all-gather-matmul-w8a8_CorrectnessTest"
+        buildkite-agent meta-data set "${BK_KEY}_all-gather-matmul-w8a8_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for all-gather-matmul-w8a8"
+    key: "${BK_KEY}_record_all-gather-matmul-w8a8_CorrectnessTest"
+    depends_on: "${BK_KEY}_all-gather-matmul-w8a8_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "all-gather-matmul-w8a8"
       CI_STAGE: "CorrectnessTest"
@@ -33,21 +36,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_all-gather-matmul-w8a8_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_all-gather-matmul-w8a8_CorrectnessTest
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for all-gather-matmul-w8a8"
-    key: "${TPU_VERSION:-tpu6e}_all-gather-matmul-w8a8_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_all-gather-matmul-w8a8_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for all-gather-matmul-w8a8"
+    key: "${BK_KEY}_all-gather-matmul-w8a8_PerformanceTest"
+    depends_on: "${BK_KEY}_record_all-gather-matmul-w8a8_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_all-gather-matmul-w8a8_PerformanceTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for all-gather-matmul-w8a8"
-    key: "${TPU_VERSION:-tpu6e}_record_all-gather-matmul-w8a8_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_all-gather-matmul-w8a8_PerformanceTest"
+        buildkite-agent meta-data set "${BK_KEY}_all-gather-matmul-w8a8_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for all-gather-matmul-w8a8"
+    key: "${BK_KEY}_record_all-gather-matmul-w8a8_PerformanceTest"
+    depends_on: "${BK_KEY}_all-gather-matmul-w8a8_PerformanceTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "all-gather-matmul-w8a8"
       CI_STAGE: "PerformanceTest"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_all-gather-matmul-w8a8_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_all-gather-matmul-w8a8_PerformanceTest

--- a/.buildkite/kernel_microbenchmarks/fused_moe/w16a16.yml
+++ b/.buildkite/kernel_microbenchmarks/fused_moe/w16a16.yml
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for fused moe-w16a16"
-    key: "${TPU_VERSION:-tpu6e}_fused_moe-w16a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for fused moe-w16a16"
+    key: "${BK_KEY}_fused_moe-w16a16_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_fused_moe-w16a16_CorrectnessTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for fused moe w16a16"
-    key: "${TPU_VERSION:-tpu6e}_record_fused_moe-w16a16_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_fused_moe-w16a16_CorrectnessTest"
+        buildkite-agent meta-data set "${BK_KEY}_fused_moe-w16a16_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for fused moe w16a16"
+    key: "${BK_KEY}_record_fused_moe-w16a16_CorrectnessTest"
+    depends_on: "${BK_KEY}_fused_moe-w16a16_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "fused moe-w16a16"
       CI_STAGE: "CorrectnessTest"
@@ -33,21 +36,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_fused_moe-w16a16_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_fused_moe-w16a16_CorrectnessTest
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for fused moe-w16a16"
-    key: "${TPU_VERSION:-tpu6e}_fused_moe-w16a16_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_fused_moe-w16a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for fused moe-w16a16"
+    key: "${BK_KEY}_fused_moe-w16a16_PerformanceTest"
+    depends_on: "${BK_KEY}_record_fused_moe-w16a16_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_fused_moe-w16a16_PerformanceTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for fused moe-w16a16"
-    key: "${TPU_VERSION:-tpu6e}_record_fused_moe-w16a16_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_fused_moe-w16a16_PerformanceTest"
+        buildkite-agent meta-data set "${BK_KEY}_fused_moe-w16a16_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for fused moe-w16a16"
+    key: "${BK_KEY}_record_fused_moe-w16a16_PerformanceTest"
+    depends_on: "${BK_KEY}_fused_moe-w16a16_PerformanceTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "fused moe-w16a16"
       CI_STAGE: "PerformanceTest"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_fused_moe-w16a16_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_fused_moe-w16a16_PerformanceTest

--- a/.buildkite/kernel_microbenchmarks/fused_moe/w16a16.yml
+++ b/.buildkite/kernel_microbenchmarks/fused_moe/w16a16.yml
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for fused moe-w16a16"
-    key: "${TPU_VERSION:-tpu6e}_fused_moe-w16a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for fused moe-w16a16"
+    key: "${BK_KEY}_fused_moe-w16a16_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_fused_moe-w16a16_CorrectnessTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for fused moe w16a16"
-    key: "${TPU_VERSION:-tpu6e}_record_fused_moe-w16a16_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_fused_moe-w16a16_CorrectnessTest"
+        buildkite-agent meta-data set "${BK_KEY}_fused_moe-w16a16_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for fused moe w16a16"
+    key: "${BK_KEY}_record_fused_moe-w16a16_CorrectnessTest"
+    depends_on: "${BK_KEY}_fused_moe-w16a16_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "fused moe-w16a16"
       CI_STAGE: "CorrectnessTest"
@@ -33,21 +36,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_fused_moe-w16a16_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_fused_moe-w16a16_CorrectnessTest
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for fused moe-w16a16"
-    key: "${TPU_VERSION:-tpu6e}_fused_moe-w16a16_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_fused_moe-w16a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for fused moe-w16a16"
+    key: "${BK_KEY}_fused_moe-w16a16_PerformanceTest"
+    depends_on: "${BK_KEY}_record_fused_moe-w16a16_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_fused_moe-w16a16_PerformanceTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for fused moe-w16a16"
-    key: "${TPU_VERSION:-tpu6e}_record_fused_moe-w16a16_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_fused_moe-w16a16_PerformanceTest"
+        buildkite-agent meta-data set "${BK_KEY}_fused_moe-w16a16_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for fused moe-w16a16"
+    key: "${BK_KEY}_record_fused_moe-w16a16_PerformanceTest"
+    depends_on: "${BK_KEY}_fused_moe-w16a16_PerformanceTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "fused moe-w16a16"
       CI_STAGE: "PerformanceTest"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_fused_moe-w16a16_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_fused_moe-w16a16_PerformanceTest

--- a/.buildkite/kernel_microbenchmarks/fused_moe/w4a16.yml
+++ b/.buildkite/kernel_microbenchmarks/fused_moe/w4a16.yml
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for fused moe-w4a16"
-    key: "${TPU_VERSION:-tpu6e}_fused_moe-w4a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for fused moe-w4a16"
+    key: "${BK_KEY}_fused_moe-w4a16_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_fused_moe-w4a16_CorrectnessTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for fused moe w4a16"
-    key: "${TPU_VERSION:-tpu6e}_record_fused_moe-w4a16_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_fused_moe-w4a16_CorrectnessTest"
+        buildkite-agent meta-data set "${BK_KEY}_fused_moe-w4a16_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for fused moe w4a16"
+    key: "${BK_KEY}_record_fused_moe-w4a16_CorrectnessTest"
+    depends_on: "${BK_KEY}_fused_moe-w4a16_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "fused moe-w4a16"
       CI_STAGE: "CorrectnessTest"
@@ -33,21 +36,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_fused_moe-w4a16_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_fused_moe-w4a16_CorrectnessTest
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for fused moe-w4a16"
-    key: "${TPU_VERSION:-tpu6e}_fused_moe-w4a16_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_fused_moe-w4a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for fused moe-w4a16"
+    key: "${BK_KEY}_fused_moe-w4a16_PerformanceTest"
+    depends_on: "${BK_KEY}_record_fused_moe-w4a16_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_fused_moe-w4a16_PerformanceTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for fused moe-w4a16"
-    key: "${TPU_VERSION:-tpu6e}_record_fused_moe-w4a16_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_fused_moe-w4a16_PerformanceTest"
+        buildkite-agent meta-data set "${BK_KEY}_fused_moe-w4a16_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for fused moe-w4a16"
+    key: "${BK_KEY}_record_fused_moe-w4a16_PerformanceTest"
+    depends_on: "${BK_KEY}_fused_moe-w4a16_PerformanceTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "fused moe-w4a16"
       CI_STAGE: "PerformanceTest"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_fused_moe-w4a16_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_fused_moe-w4a16_PerformanceTest

--- a/.buildkite/kernel_microbenchmarks/fused_moe/w4a16.yml
+++ b/.buildkite/kernel_microbenchmarks/fused_moe/w4a16.yml
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for fused moe-w4a16"
-    key: "${TPU_VERSION:-tpu6e}_fused_moe-w4a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for fused moe-w4a16"
+    key: "${BK_KEY}_fused_moe-w4a16_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_fused_moe-w4a16_CorrectnessTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for fused moe w4a16"
-    key: "${TPU_VERSION:-tpu6e}_record_fused_moe-w4a16_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_fused_moe-w4a16_CorrectnessTest"
+        buildkite-agent meta-data set "${BK_KEY}_fused_moe-w4a16_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for fused moe w4a16"
+    key: "${BK_KEY}_record_fused_moe-w4a16_CorrectnessTest"
+    depends_on: "${BK_KEY}_fused_moe-w4a16_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "fused moe-w4a16"
       CI_STAGE: "CorrectnessTest"
@@ -33,21 +36,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_fused_moe-w4a16_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_fused_moe-w4a16_CorrectnessTest
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for fused moe-w4a16"
-    key: "${TPU_VERSION:-tpu6e}_fused_moe-w4a16_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_fused_moe-w4a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for fused moe-w4a16"
+    key: "${BK_KEY}_fused_moe-w4a16_PerformanceTest"
+    depends_on: "${BK_KEY}_record_fused_moe-w4a16_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_fused_moe-w4a16_PerformanceTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for fused moe-w4a16"
-    key: "${TPU_VERSION:-tpu6e}_record_fused_moe-w4a16_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_fused_moe-w4a16_PerformanceTest"
+        buildkite-agent meta-data set "${BK_KEY}_fused_moe-w4a16_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for fused moe-w4a16"
+    key: "${BK_KEY}_record_fused_moe-w4a16_PerformanceTest"
+    depends_on: "${BK_KEY}_fused_moe-w4a16_PerformanceTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "fused moe-w4a16"
       CI_STAGE: "PerformanceTest"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_fused_moe-w4a16_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_fused_moe-w4a16_PerformanceTest

--- a/.buildkite/kernel_microbenchmarks/fused_moe/w4a4.yml
+++ b/.buildkite/kernel_microbenchmarks/fused_moe/w4a4.yml
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for fused moe-w4a4"
-    key: "${TPU_VERSION:-tpu6e}_fused_moe-w4a4_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for fused moe-w4a4"
+    key: "${BK_KEY}_fused_moe-w4a4_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_fused_moe-w4a4_CorrectnessTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for fused moe w4a4"
-    key: "${TPU_VERSION:-tpu6e}_record_fused_moe-w4a4_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_fused_moe-w4a4_CorrectnessTest"
+        buildkite-agent meta-data set "${BK_KEY}_fused_moe-w4a4_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for fused moe w4a4"
+    key: "${BK_KEY}_record_fused_moe-w4a4_CorrectnessTest"
+    depends_on: "${BK_KEY}_fused_moe-w4a4_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "fused moe-w4a4"
       CI_STAGE: "CorrectnessTest"
@@ -33,21 +36,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_fused_moe-w4a4_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_fused_moe-w4a4_CorrectnessTest
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for fused moe-w4a4"
-    key: "${TPU_VERSION:-tpu6e}_fused_moe-w4a4_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_fused_moe-w4a4_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for fused moe-w4a4"
+    key: "${BK_KEY}_fused_moe-w4a4_PerformanceTest"
+    depends_on: "${BK_KEY}_record_fused_moe-w4a4_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_fused_moe-w4a4_PerformanceTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for fused moe-w4a4"
-    key: "${TPU_VERSION:-tpu6e}_record_fused_moe-w4a4_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_fused_moe-w4a4_PerformanceTest"
+        buildkite-agent meta-data set "${BK_KEY}_fused_moe-w4a4_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for fused moe-w4a4"
+    key: "${BK_KEY}_record_fused_moe-w4a4_PerformanceTest"
+    depends_on: "${BK_KEY}_fused_moe-w4a4_PerformanceTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "fused moe-w4a4"
       CI_STAGE: "PerformanceTest"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_fused_moe-w4a4_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_fused_moe-w4a4_PerformanceTest

--- a/.buildkite/kernel_microbenchmarks/fused_moe/w4a4.yml
+++ b/.buildkite/kernel_microbenchmarks/fused_moe/w4a4.yml
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for fused moe-w4a4"
-    key: "${TPU_VERSION:-tpu6e}_fused_moe-w4a4_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for fused moe-w4a4"
+    key: "${BK_KEY}_fused_moe-w4a4_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_fused_moe-w4a4_CorrectnessTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for fused moe w4a4"
-    key: "${TPU_VERSION:-tpu6e}_record_fused_moe-w4a4_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_fused_moe-w4a4_CorrectnessTest"
+        buildkite-agent meta-data set "${BK_KEY}_fused_moe-w4a4_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for fused moe w4a4"
+    key: "${BK_KEY}_record_fused_moe-w4a4_CorrectnessTest"
+    depends_on: "${BK_KEY}_fused_moe-w4a4_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "fused moe-w4a4"
       CI_STAGE: "CorrectnessTest"
@@ -33,21 +36,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_fused_moe-w4a4_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_fused_moe-w4a4_CorrectnessTest
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for fused moe-w4a4"
-    key: "${TPU_VERSION:-tpu6e}_fused_moe-w4a4_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_fused_moe-w4a4_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for fused moe-w4a4"
+    key: "${BK_KEY}_fused_moe-w4a4_PerformanceTest"
+    depends_on: "${BK_KEY}_record_fused_moe-w4a4_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_fused_moe-w4a4_PerformanceTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for fused moe-w4a4"
-    key: "${TPU_VERSION:-tpu6e}_record_fused_moe-w4a4_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_fused_moe-w4a4_PerformanceTest"
+        buildkite-agent meta-data set "${BK_KEY}_fused_moe-w4a4_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for fused moe-w4a4"
+    key: "${BK_KEY}_record_fused_moe-w4a4_PerformanceTest"
+    depends_on: "${BK_KEY}_fused_moe-w4a4_PerformanceTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "fused moe-w4a4"
       CI_STAGE: "PerformanceTest"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_fused_moe-w4a4_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_fused_moe-w4a4_PerformanceTest

--- a/.buildkite/kernel_microbenchmarks/fused_moe/w4a8.yml
+++ b/.buildkite/kernel_microbenchmarks/fused_moe/w4a8.yml
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for fused moe-w4a8"
-    key: "${TPU_VERSION:-tpu6e}_fused_moe-w4a8_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for fused moe-w4a8"
+    key: "${BK_KEY}_fused_moe-w4a8_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_fused_moe-w4a8_CorrectnessTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for fused moe w4a8"
-    key: "${TPU_VERSION:-tpu6e}_record_fused_moe-w4a8_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_fused_moe-w4a8_CorrectnessTest"
+        buildkite-agent meta-data set "${BK_KEY}_fused_moe-w4a8_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for fused moe w4a8"
+    key: "${BK_KEY}_record_fused_moe-w4a8_CorrectnessTest"
+    depends_on: "${BK_KEY}_fused_moe-w4a8_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "fused moe-w4a8"
       CI_STAGE: "CorrectnessTest"
@@ -33,21 +36,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_fused_moe-w4a8_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_fused_moe-w4a8_CorrectnessTest
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for fused moe-w4a8"
-    key: "${TPU_VERSION:-tpu6e}_fused_moe-w4a8_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_fused_moe-w4a8_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for fused moe-w4a8"
+    key: "${BK_KEY}_fused_moe-w4a8_PerformanceTest"
+    depends_on: "${BK_KEY}_record_fused_moe-w4a8_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_fused_moe-w4a8_PerformanceTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for fused moe-w4a8"
-    key: "${TPU_VERSION:-tpu6e}_record_fused_moe-w4a8_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_fused_moe-w4a8_PerformanceTest"
+        buildkite-agent meta-data set "${BK_KEY}_fused_moe-w4a8_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for fused moe-w4a8"
+    key: "${BK_KEY}_record_fused_moe-w4a8_PerformanceTest"
+    depends_on: "${BK_KEY}_fused_moe-w4a8_PerformanceTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "fused moe-w4a8"
       CI_STAGE: "PerformanceTest"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_fused_moe-w4a8_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_fused_moe-w4a8_PerformanceTest

--- a/.buildkite/kernel_microbenchmarks/fused_moe/w4a8.yml
+++ b/.buildkite/kernel_microbenchmarks/fused_moe/w4a8.yml
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for fused moe-w4a8"
-    key: "${TPU_VERSION:-tpu6e}_fused_moe-w4a8_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for fused moe-w4a8"
+    key: "${BK_KEY}_fused_moe-w4a8_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_fused_moe-w4a8_CorrectnessTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for fused moe w4a8"
-    key: "${TPU_VERSION:-tpu6e}_record_fused_moe-w4a8_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_fused_moe-w4a8_CorrectnessTest"
+        buildkite-agent meta-data set "${BK_KEY}_fused_moe-w4a8_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for fused moe w4a8"
+    key: "${BK_KEY}_record_fused_moe-w4a8_CorrectnessTest"
+    depends_on: "${BK_KEY}_fused_moe-w4a8_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "fused moe-w4a8"
       CI_STAGE: "CorrectnessTest"
@@ -33,21 +36,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_fused_moe-w4a8_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_fused_moe-w4a8_CorrectnessTest
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for fused moe-w4a8"
-    key: "${TPU_VERSION:-tpu6e}_fused_moe-w4a8_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_fused_moe-w4a8_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for fused moe-w4a8"
+    key: "${BK_KEY}_fused_moe-w4a8_PerformanceTest"
+    depends_on: "${BK_KEY}_record_fused_moe-w4a8_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_fused_moe-w4a8_PerformanceTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for fused moe-w4a8"
-    key: "${TPU_VERSION:-tpu6e}_record_fused_moe-w4a8_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_fused_moe-w4a8_PerformanceTest"
+        buildkite-agent meta-data set "${BK_KEY}_fused_moe-w4a8_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for fused moe-w4a8"
+    key: "${BK_KEY}_record_fused_moe-w4a8_PerformanceTest"
+    depends_on: "${BK_KEY}_fused_moe-w4a8_PerformanceTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "fused moe-w4a8"
       CI_STAGE: "PerformanceTest"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_fused_moe-w4a8_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_fused_moe-w4a8_PerformanceTest

--- a/.buildkite/kernel_microbenchmarks/fused_moe/w8a16.yml
+++ b/.buildkite/kernel_microbenchmarks/fused_moe/w8a16.yml
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for fused moe-w8a16"
-    key: "${TPU_VERSION:-tpu6e}_fused_moe-w8a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for fused moe-w8a16"
+    key: "${BK_KEY}_fused_moe-w8a16_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_fused_moe-w8a16_CorrectnessTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for fused moe w8a16"
-    key: "${TPU_VERSION:-tpu6e}_record_fused_moe-w8a16_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_fused_moe-w8a16_CorrectnessTest"
+        buildkite-agent meta-data set "${BK_KEY}_fused_moe-w8a16_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for fused moe w8a16"
+    key: "${BK_KEY}_record_fused_moe-w8a16_CorrectnessTest"
+    depends_on: "${BK_KEY}_fused_moe-w8a16_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "fused moe-w8a16"
       CI_STAGE: "CorrectnessTest"
@@ -33,21 +36,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_fused_moe-w8a16_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_fused_moe-w8a16_CorrectnessTest
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for fused moe-w8a16"
-    key: "${TPU_VERSION:-tpu6e}_fused_moe-w8a16_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_fused_moe-w8a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for fused moe-w8a16"
+    key: "${BK_KEY}_fused_moe-w8a16_PerformanceTest"
+    depends_on: "${BK_KEY}_record_fused_moe-w8a16_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_fused_moe-w8a16_PerformanceTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for fused moe-w8a16"
-    key: "${TPU_VERSION:-tpu6e}_record_fused_moe-w8a16_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_fused_moe-w8a16_PerformanceTest"
+        buildkite-agent meta-data set "${BK_KEY}_fused_moe-w8a16_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for fused moe-w8a16"
+    key: "${BK_KEY}_record_fused_moe-w8a16_PerformanceTest"
+    depends_on: "${BK_KEY}_fused_moe-w8a16_PerformanceTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "fused moe-w8a16"
       CI_STAGE: "PerformanceTest"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_fused_moe-w8a16_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_fused_moe-w8a16_PerformanceTest

--- a/.buildkite/kernel_microbenchmarks/fused_moe/w8a16.yml
+++ b/.buildkite/kernel_microbenchmarks/fused_moe/w8a16.yml
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for fused moe-w8a16"
-    key: "${TPU_VERSION:-tpu6e}_fused_moe-w8a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for fused moe-w8a16"
+    key: "${BK_KEY}_fused_moe-w8a16_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_fused_moe-w8a16_CorrectnessTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for fused moe w8a16"
-    key: "${TPU_VERSION:-tpu6e}_record_fused_moe-w8a16_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_fused_moe-w8a16_CorrectnessTest"
+        buildkite-agent meta-data set "${BK_KEY}_fused_moe-w8a16_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for fused moe w8a16"
+    key: "${BK_KEY}_record_fused_moe-w8a16_CorrectnessTest"
+    depends_on: "${BK_KEY}_fused_moe-w8a16_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "fused moe-w8a16"
       CI_STAGE: "CorrectnessTest"
@@ -33,21 +36,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_fused_moe-w8a16_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_fused_moe-w8a16_CorrectnessTest
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for fused moe-w8a16"
-    key: "${TPU_VERSION:-tpu6e}_fused_moe-w8a16_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_fused_moe-w8a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for fused moe-w8a16"
+    key: "${BK_KEY}_fused_moe-w8a16_PerformanceTest"
+    depends_on: "${BK_KEY}_record_fused_moe-w8a16_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_fused_moe-w8a16_PerformanceTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for fused moe-w8a16"
-    key: "${TPU_VERSION:-tpu6e}_record_fused_moe-w8a16_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_fused_moe-w8a16_PerformanceTest"
+        buildkite-agent meta-data set "${BK_KEY}_fused_moe-w8a16_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for fused moe-w8a16"
+    key: "${BK_KEY}_record_fused_moe-w8a16_PerformanceTest"
+    depends_on: "${BK_KEY}_fused_moe-w8a16_PerformanceTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "fused moe-w8a16"
       CI_STAGE: "PerformanceTest"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_fused_moe-w8a16_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_fused_moe-w8a16_PerformanceTest

--- a/.buildkite/kernel_microbenchmarks/fused_moe/w8a8.yml
+++ b/.buildkite/kernel_microbenchmarks/fused_moe/w8a8.yml
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for fused moe-w8a8"
-    key: "${TPU_VERSION:-tpu6e}_fused_moe-w8a8_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for fused moe-w8a8"
+    key: "${BK_KEY}_fused_moe-w8a8_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_fused_moe-w8a8_CorrectnessTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for fused moe w8a8"
-    key: "${TPU_VERSION:-tpu6e}_record_fused_moe-w8a8_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_fused_moe-w8a8_CorrectnessTest"
+        buildkite-agent meta-data set "${BK_KEY}_fused_moe-w8a8_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for fused moe w8a8"
+    key: "${BK_KEY}_record_fused_moe-w8a8_CorrectnessTest"
+    depends_on: "${BK_KEY}_fused_moe-w8a8_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "fused moe-w8a8"
       CI_STAGE: "CorrectnessTest"
@@ -33,21 +36,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_fused_moe-w8a8_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_fused_moe-w8a8_CorrectnessTest
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for fused moe-w8a8"
-    key: "${TPU_VERSION:-tpu6e}_fused_moe-w8a8_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_fused_moe-w8a8_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for fused moe-w8a8"
+    key: "${BK_KEY}_fused_moe-w8a8_PerformanceTest"
+    depends_on: "${BK_KEY}_record_fused_moe-w8a8_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_fused_moe-w8a8_PerformanceTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for fused moe-w8a8"
-    key: "${TPU_VERSION:-tpu6e}_record_fused_moe-w8a8_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_fused_moe-w8a8_PerformanceTest"
+        buildkite-agent meta-data set "${BK_KEY}_fused_moe-w8a8_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for fused moe-w8a8"
+    key: "${BK_KEY}_record_fused_moe-w8a8_PerformanceTest"
+    depends_on: "${BK_KEY}_fused_moe-w8a8_PerformanceTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "fused moe-w8a8"
       CI_STAGE: "PerformanceTest"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_fused_moe-w8a8_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_fused_moe-w8a8_PerformanceTest

--- a/.buildkite/kernel_microbenchmarks/fused_moe/w8a8.yml
+++ b/.buildkite/kernel_microbenchmarks/fused_moe/w8a8.yml
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for fused moe-w8a8"
-    key: "${TPU_VERSION:-tpu6e}_fused_moe-w8a8_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for fused moe-w8a8"
+    key: "${BK_KEY}_fused_moe-w8a8_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_fused_moe-w8a8_CorrectnessTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for fused moe w8a8"
-    key: "${TPU_VERSION:-tpu6e}_record_fused_moe-w8a8_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_fused_moe-w8a8_CorrectnessTest"
+        buildkite-agent meta-data set "${BK_KEY}_fused_moe-w8a8_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for fused moe w8a8"
+    key: "${BK_KEY}_record_fused_moe-w8a8_CorrectnessTest"
+    depends_on: "${BK_KEY}_fused_moe-w8a8_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "fused moe-w8a8"
       CI_STAGE: "CorrectnessTest"
@@ -33,21 +36,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_fused_moe-w8a8_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_fused_moe-w8a8_CorrectnessTest
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for fused moe-w8a8"
-    key: "${TPU_VERSION:-tpu6e}_fused_moe-w8a8_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_fused_moe-w8a8_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for fused moe-w8a8"
+    key: "${BK_KEY}_fused_moe-w8a8_PerformanceTest"
+    depends_on: "${BK_KEY}_record_fused_moe-w8a8_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_fused_moe-w8a8_PerformanceTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for fused moe-w8a8"
-    key: "${TPU_VERSION:-tpu6e}_record_fused_moe-w8a8_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_fused_moe-w8a8_PerformanceTest"
+        buildkite-agent meta-data set "${BK_KEY}_fused_moe-w8a8_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for fused moe-w8a8"
+    key: "${BK_KEY}_record_fused_moe-w8a8_PerformanceTest"
+    depends_on: "${BK_KEY}_fused_moe-w8a8_PerformanceTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "fused moe-w8a8"
       CI_STAGE: "PerformanceTest"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_fused_moe-w8a8_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_fused_moe-w8a8_PerformanceTest

--- a/.buildkite/kernel_microbenchmarks/generic_ragged_paged_attention_v3/w16a16.yml
+++ b/.buildkite/kernel_microbenchmarks/generic_ragged_paged_attention_v3/w16a16.yml
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for generic ragged paged attention v3-w16a16"
-    key: "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w16a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for generic ragged paged attention v3-w16a16"
+    key: "${BK_KEY}_generic_ragged_paged_attention_v3-w16a16_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w16a16_CorrectnessTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for generic ragged paged attention v3 w16a16"
-    key: "${TPU_VERSION:-tpu6e}_record_generic_ragged_paged_attention_v3-w16a16_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w16a16_CorrectnessTest"
+        buildkite-agent meta-data set "${BK_KEY}_generic_ragged_paged_attention_v3-w16a16_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for generic ragged paged attention v3 w16a16"
+    key: "${BK_KEY}_record_generic_ragged_paged_attention_v3-w16a16_CorrectnessTest"
+    depends_on: "${BK_KEY}_generic_ragged_paged_attention_v3-w16a16_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "generic ragged paged attention v3-w16a16"
       CI_STAGE: "CorrectnessTest"
@@ -33,21 +36,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w16a16_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_generic_ragged_paged_attention_v3-w16a16_CorrectnessTest
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for generic ragged paged attention v3-w16a16"
-    key: "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w16a16_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_generic_ragged_paged_attention_v3-w16a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for generic ragged paged attention v3-w16a16"
+    key: "${BK_KEY}_generic_ragged_paged_attention_v3-w16a16_PerformanceTest"
+    depends_on: "${BK_KEY}_record_generic_ragged_paged_attention_v3-w16a16_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w16a16_PerformanceTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for generic ragged paged attention v3-w16a16"
-    key: "${TPU_VERSION:-tpu6e}_record_generic_ragged_paged_attention_v3-w16a16_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w16a16_PerformanceTest"
+        buildkite-agent meta-data set "${BK_KEY}_generic_ragged_paged_attention_v3-w16a16_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for generic ragged paged attention v3-w16a16"
+    key: "${BK_KEY}_record_generic_ragged_paged_attention_v3-w16a16_PerformanceTest"
+    depends_on: "${BK_KEY}_generic_ragged_paged_attention_v3-w16a16_PerformanceTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "generic ragged paged attention v3-w16a16"
       CI_STAGE: "PerformanceTest"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w16a16_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_generic_ragged_paged_attention_v3-w16a16_PerformanceTest

--- a/.buildkite/kernel_microbenchmarks/generic_ragged_paged_attention_v3/w16a16.yml
+++ b/.buildkite/kernel_microbenchmarks/generic_ragged_paged_attention_v3/w16a16.yml
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for generic ragged paged attention v3-w16a16"
-    key: "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w16a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for generic ragged paged attention v3-w16a16"
+    key: "${BK_KEY}_generic_ragged_paged_attention_v3-w16a16_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w16a16_CorrectnessTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for generic ragged paged attention v3 w16a16"
-    key: "${TPU_VERSION:-tpu6e}_record_generic_ragged_paged_attention_v3-w16a16_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w16a16_CorrectnessTest"
+        buildkite-agent meta-data set "${BK_KEY}_generic_ragged_paged_attention_v3-w16a16_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for generic ragged paged attention v3 w16a16"
+    key: "${BK_KEY}_record_generic_ragged_paged_attention_v3-w16a16_CorrectnessTest"
+    depends_on: "${BK_KEY}_generic_ragged_paged_attention_v3-w16a16_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "generic ragged paged attention v3-w16a16"
       CI_STAGE: "CorrectnessTest"
@@ -33,21 +36,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w16a16_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_generic_ragged_paged_attention_v3-w16a16_CorrectnessTest
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for generic ragged paged attention v3-w16a16"
-    key: "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w16a16_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_generic_ragged_paged_attention_v3-w16a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for generic ragged paged attention v3-w16a16"
+    key: "${BK_KEY}_generic_ragged_paged_attention_v3-w16a16_PerformanceTest"
+    depends_on: "${BK_KEY}_record_generic_ragged_paged_attention_v3-w16a16_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w16a16_PerformanceTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for generic ragged paged attention v3-w16a16"
-    key: "${TPU_VERSION:-tpu6e}_record_generic_ragged_paged_attention_v3-w16a16_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w16a16_PerformanceTest"
+        buildkite-agent meta-data set "${BK_KEY}_generic_ragged_paged_attention_v3-w16a16_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for generic ragged paged attention v3-w16a16"
+    key: "${BK_KEY}_record_generic_ragged_paged_attention_v3-w16a16_PerformanceTest"
+    depends_on: "${BK_KEY}_generic_ragged_paged_attention_v3-w16a16_PerformanceTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "generic ragged paged attention v3-w16a16"
       CI_STAGE: "PerformanceTest"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w16a16_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_generic_ragged_paged_attention_v3-w16a16_PerformanceTest

--- a/.buildkite/kernel_microbenchmarks/generic_ragged_paged_attention_v3/w4a16.yml
+++ b/.buildkite/kernel_microbenchmarks/generic_ragged_paged_attention_v3/w4a16.yml
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for generic ragged paged attention v3-w4a16"
-    key: "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w4a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for generic ragged paged attention v3-w4a16"
+    key: "${BK_KEY}_generic_ragged_paged_attention_v3-w4a16_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w4a16_CorrectnessTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for generic ragged paged attention v3 w4a16"
-    key: "${TPU_VERSION:-tpu6e}_record_generic_ragged_paged_attention_v3-w4a16_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w4a16_CorrectnessTest"
+        buildkite-agent meta-data set "${BK_KEY}_generic_ragged_paged_attention_v3-w4a16_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for generic ragged paged attention v3 w4a16"
+    key: "${BK_KEY}_record_generic_ragged_paged_attention_v3-w4a16_CorrectnessTest"
+    depends_on: "${BK_KEY}_generic_ragged_paged_attention_v3-w4a16_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "generic ragged paged attention v3-w4a16"
       CI_STAGE: "CorrectnessTest"
@@ -33,21 +36,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w4a16_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_generic_ragged_paged_attention_v3-w4a16_CorrectnessTest
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for generic ragged paged attention v3-w4a16"
-    key: "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w4a16_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_generic_ragged_paged_attention_v3-w4a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for generic ragged paged attention v3-w4a16"
+    key: "${BK_KEY}_generic_ragged_paged_attention_v3-w4a16_PerformanceTest"
+    depends_on: "${BK_KEY}_record_generic_ragged_paged_attention_v3-w4a16_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w4a16_PerformanceTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for generic ragged paged attention v3-w4a16"
-    key: "${TPU_VERSION:-tpu6e}_record_generic_ragged_paged_attention_v3-w4a16_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w4a16_PerformanceTest"
+        buildkite-agent meta-data set "${BK_KEY}_generic_ragged_paged_attention_v3-w4a16_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for generic ragged paged attention v3-w4a16"
+    key: "${BK_KEY}_record_generic_ragged_paged_attention_v3-w4a16_PerformanceTest"
+    depends_on: "${BK_KEY}_generic_ragged_paged_attention_v3-w4a16_PerformanceTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "generic ragged paged attention v3-w4a16"
       CI_STAGE: "PerformanceTest"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w4a16_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_generic_ragged_paged_attention_v3-w4a16_PerformanceTest

--- a/.buildkite/kernel_microbenchmarks/generic_ragged_paged_attention_v3/w4a16.yml
+++ b/.buildkite/kernel_microbenchmarks/generic_ragged_paged_attention_v3/w4a16.yml
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for generic ragged paged attention v3-w4a16"
-    key: "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w4a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for generic ragged paged attention v3-w4a16"
+    key: "${BK_KEY}_generic_ragged_paged_attention_v3-w4a16_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w4a16_CorrectnessTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for generic ragged paged attention v3 w4a16"
-    key: "${TPU_VERSION:-tpu6e}_record_generic_ragged_paged_attention_v3-w4a16_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w4a16_CorrectnessTest"
+        buildkite-agent meta-data set "${BK_KEY}_generic_ragged_paged_attention_v3-w4a16_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for generic ragged paged attention v3 w4a16"
+    key: "${BK_KEY}_record_generic_ragged_paged_attention_v3-w4a16_CorrectnessTest"
+    depends_on: "${BK_KEY}_generic_ragged_paged_attention_v3-w4a16_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "generic ragged paged attention v3-w4a16"
       CI_STAGE: "CorrectnessTest"
@@ -33,21 +36,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w4a16_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_generic_ragged_paged_attention_v3-w4a16_CorrectnessTest
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for generic ragged paged attention v3-w4a16"
-    key: "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w4a16_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_generic_ragged_paged_attention_v3-w4a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for generic ragged paged attention v3-w4a16"
+    key: "${BK_KEY}_generic_ragged_paged_attention_v3-w4a16_PerformanceTest"
+    depends_on: "${BK_KEY}_record_generic_ragged_paged_attention_v3-w4a16_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w4a16_PerformanceTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for generic ragged paged attention v3-w4a16"
-    key: "${TPU_VERSION:-tpu6e}_record_generic_ragged_paged_attention_v3-w4a16_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w4a16_PerformanceTest"
+        buildkite-agent meta-data set "${BK_KEY}_generic_ragged_paged_attention_v3-w4a16_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for generic ragged paged attention v3-w4a16"
+    key: "${BK_KEY}_record_generic_ragged_paged_attention_v3-w4a16_PerformanceTest"
+    depends_on: "${BK_KEY}_generic_ragged_paged_attention_v3-w4a16_PerformanceTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "generic ragged paged attention v3-w4a16"
       CI_STAGE: "PerformanceTest"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w4a16_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_generic_ragged_paged_attention_v3-w4a16_PerformanceTest

--- a/.buildkite/kernel_microbenchmarks/generic_ragged_paged_attention_v3/w4a4.yml
+++ b/.buildkite/kernel_microbenchmarks/generic_ragged_paged_attention_v3/w4a4.yml
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for generic ragged paged attention v3-w4a4"
-    key: "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w4a4_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for generic ragged paged attention v3-w4a4"
+    key: "${BK_KEY}_generic_ragged_paged_attention_v3-w4a4_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w4a4_CorrectnessTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for generic ragged paged attention v3 w4a4"
-    key: "${TPU_VERSION:-tpu6e}_record_generic_ragged_paged_attention_v3-w4a4_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w4a4_CorrectnessTest"
+        buildkite-agent meta-data set "${BK_KEY}_generic_ragged_paged_attention_v3-w4a4_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for generic ragged paged attention v3 w4a4"
+    key: "${BK_KEY}_record_generic_ragged_paged_attention_v3-w4a4_CorrectnessTest"
+    depends_on: "${BK_KEY}_generic_ragged_paged_attention_v3-w4a4_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "generic ragged paged attention v3-w4a4"
       CI_STAGE: "CorrectnessTest"
@@ -33,21 +36,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w4a4_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_generic_ragged_paged_attention_v3-w4a4_CorrectnessTest
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for generic ragged paged attention v3-w4a4"
-    key: "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w4a4_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_generic_ragged_paged_attention_v3-w4a4_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for generic ragged paged attention v3-w4a4"
+    key: "${BK_KEY}_generic_ragged_paged_attention_v3-w4a4_PerformanceTest"
+    depends_on: "${BK_KEY}_record_generic_ragged_paged_attention_v3-w4a4_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w4a4_PerformanceTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for generic ragged paged attention v3-w4a4"
-    key: "${TPU_VERSION:-tpu6e}_record_generic_ragged_paged_attention_v3-w4a4_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w4a4_PerformanceTest"
+        buildkite-agent meta-data set "${BK_KEY}_generic_ragged_paged_attention_v3-w4a4_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for generic ragged paged attention v3-w4a4"
+    key: "${BK_KEY}_record_generic_ragged_paged_attention_v3-w4a4_PerformanceTest"
+    depends_on: "${BK_KEY}_generic_ragged_paged_attention_v3-w4a4_PerformanceTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "generic ragged paged attention v3-w4a4"
       CI_STAGE: "PerformanceTest"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w4a4_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_generic_ragged_paged_attention_v3-w4a4_PerformanceTest

--- a/.buildkite/kernel_microbenchmarks/generic_ragged_paged_attention_v3/w4a4.yml
+++ b/.buildkite/kernel_microbenchmarks/generic_ragged_paged_attention_v3/w4a4.yml
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for generic ragged paged attention v3-w4a4"
-    key: "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w4a4_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for generic ragged paged attention v3-w4a4"
+    key: "${BK_KEY}_generic_ragged_paged_attention_v3-w4a4_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w4a4_CorrectnessTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for generic ragged paged attention v3 w4a4"
-    key: "${TPU_VERSION:-tpu6e}_record_generic_ragged_paged_attention_v3-w4a4_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w4a4_CorrectnessTest"
+        buildkite-agent meta-data set "${BK_KEY}_generic_ragged_paged_attention_v3-w4a4_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for generic ragged paged attention v3 w4a4"
+    key: "${BK_KEY}_record_generic_ragged_paged_attention_v3-w4a4_CorrectnessTest"
+    depends_on: "${BK_KEY}_generic_ragged_paged_attention_v3-w4a4_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "generic ragged paged attention v3-w4a4"
       CI_STAGE: "CorrectnessTest"
@@ -33,21 +36,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w4a4_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_generic_ragged_paged_attention_v3-w4a4_CorrectnessTest
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for generic ragged paged attention v3-w4a4"
-    key: "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w4a4_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_generic_ragged_paged_attention_v3-w4a4_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for generic ragged paged attention v3-w4a4"
+    key: "${BK_KEY}_generic_ragged_paged_attention_v3-w4a4_PerformanceTest"
+    depends_on: "${BK_KEY}_record_generic_ragged_paged_attention_v3-w4a4_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w4a4_PerformanceTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for generic ragged paged attention v3-w4a4"
-    key: "${TPU_VERSION:-tpu6e}_record_generic_ragged_paged_attention_v3-w4a4_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w4a4_PerformanceTest"
+        buildkite-agent meta-data set "${BK_KEY}_generic_ragged_paged_attention_v3-w4a4_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for generic ragged paged attention v3-w4a4"
+    key: "${BK_KEY}_record_generic_ragged_paged_attention_v3-w4a4_PerformanceTest"
+    depends_on: "${BK_KEY}_generic_ragged_paged_attention_v3-w4a4_PerformanceTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "generic ragged paged attention v3-w4a4"
       CI_STAGE: "PerformanceTest"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w4a4_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_generic_ragged_paged_attention_v3-w4a4_PerformanceTest

--- a/.buildkite/kernel_microbenchmarks/generic_ragged_paged_attention_v3/w4a8.yml
+++ b/.buildkite/kernel_microbenchmarks/generic_ragged_paged_attention_v3/w4a8.yml
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for generic ragged paged attention v3-w4a8"
-    key: "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w4a8_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for generic ragged paged attention v3-w4a8"
+    key: "${BK_KEY}_generic_ragged_paged_attention_v3-w4a8_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w4a8_CorrectnessTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for generic ragged paged attention v3 w4a8"
-    key: "${TPU_VERSION:-tpu6e}_record_generic_ragged_paged_attention_v3-w4a8_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w4a8_CorrectnessTest"
+        buildkite-agent meta-data set "${BK_KEY}_generic_ragged_paged_attention_v3-w4a8_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for generic ragged paged attention v3 w4a8"
+    key: "${BK_KEY}_record_generic_ragged_paged_attention_v3-w4a8_CorrectnessTest"
+    depends_on: "${BK_KEY}_generic_ragged_paged_attention_v3-w4a8_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "generic ragged paged attention v3-w4a8"
       CI_STAGE: "CorrectnessTest"
@@ -33,21 +36,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w4a8_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_generic_ragged_paged_attention_v3-w4a8_CorrectnessTest
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for generic ragged paged attention v3-w4a8"
-    key: "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w4a8_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_generic_ragged_paged_attention_v3-w4a8_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for generic ragged paged attention v3-w4a8"
+    key: "${BK_KEY}_generic_ragged_paged_attention_v3-w4a8_PerformanceTest"
+    depends_on: "${BK_KEY}_record_generic_ragged_paged_attention_v3-w4a8_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w4a8_PerformanceTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for generic ragged paged attention v3-w4a8"
-    key: "${TPU_VERSION:-tpu6e}_record_generic_ragged_paged_attention_v3-w4a8_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w4a8_PerformanceTest"
+        buildkite-agent meta-data set "${BK_KEY}_generic_ragged_paged_attention_v3-w4a8_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for generic ragged paged attention v3-w4a8"
+    key: "${BK_KEY}_record_generic_ragged_paged_attention_v3-w4a8_PerformanceTest"
+    depends_on: "${BK_KEY}_generic_ragged_paged_attention_v3-w4a8_PerformanceTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "generic ragged paged attention v3-w4a8"
       CI_STAGE: "PerformanceTest"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w4a8_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_generic_ragged_paged_attention_v3-w4a8_PerformanceTest

--- a/.buildkite/kernel_microbenchmarks/generic_ragged_paged_attention_v3/w4a8.yml
+++ b/.buildkite/kernel_microbenchmarks/generic_ragged_paged_attention_v3/w4a8.yml
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for generic ragged paged attention v3-w4a8"
-    key: "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w4a8_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for generic ragged paged attention v3-w4a8"
+    key: "${BK_KEY}_generic_ragged_paged_attention_v3-w4a8_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w4a8_CorrectnessTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for generic ragged paged attention v3 w4a8"
-    key: "${TPU_VERSION:-tpu6e}_record_generic_ragged_paged_attention_v3-w4a8_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w4a8_CorrectnessTest"
+        buildkite-agent meta-data set "${BK_KEY}_generic_ragged_paged_attention_v3-w4a8_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for generic ragged paged attention v3 w4a8"
+    key: "${BK_KEY}_record_generic_ragged_paged_attention_v3-w4a8_CorrectnessTest"
+    depends_on: "${BK_KEY}_generic_ragged_paged_attention_v3-w4a8_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "generic ragged paged attention v3-w4a8"
       CI_STAGE: "CorrectnessTest"
@@ -33,21 +36,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w4a8_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_generic_ragged_paged_attention_v3-w4a8_CorrectnessTest
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for generic ragged paged attention v3-w4a8"
-    key: "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w4a8_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_generic_ragged_paged_attention_v3-w4a8_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for generic ragged paged attention v3-w4a8"
+    key: "${BK_KEY}_generic_ragged_paged_attention_v3-w4a8_PerformanceTest"
+    depends_on: "${BK_KEY}_record_generic_ragged_paged_attention_v3-w4a8_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w4a8_PerformanceTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for generic ragged paged attention v3-w4a8"
-    key: "${TPU_VERSION:-tpu6e}_record_generic_ragged_paged_attention_v3-w4a8_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w4a8_PerformanceTest"
+        buildkite-agent meta-data set "${BK_KEY}_generic_ragged_paged_attention_v3-w4a8_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for generic ragged paged attention v3-w4a8"
+    key: "${BK_KEY}_record_generic_ragged_paged_attention_v3-w4a8_PerformanceTest"
+    depends_on: "${BK_KEY}_generic_ragged_paged_attention_v3-w4a8_PerformanceTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "generic ragged paged attention v3-w4a8"
       CI_STAGE: "PerformanceTest"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w4a8_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_generic_ragged_paged_attention_v3-w4a8_PerformanceTest

--- a/.buildkite/kernel_microbenchmarks/generic_ragged_paged_attention_v3/w8a16.yml
+++ b/.buildkite/kernel_microbenchmarks/generic_ragged_paged_attention_v3/w8a16.yml
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for generic ragged paged attention v3-w8a16"
-    key: "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w8a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for generic ragged paged attention v3-w8a16"
+    key: "${BK_KEY}_generic_ragged_paged_attention_v3-w8a16_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w8a16_CorrectnessTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for generic ragged paged attention v3 w8a16"
-    key: "${TPU_VERSION:-tpu6e}_record_generic_ragged_paged_attention_v3-w8a16_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w8a16_CorrectnessTest"
+        buildkite-agent meta-data set "${BK_KEY}_generic_ragged_paged_attention_v3-w8a16_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for generic ragged paged attention v3 w8a16"
+    key: "${BK_KEY}_record_generic_ragged_paged_attention_v3-w8a16_CorrectnessTest"
+    depends_on: "${BK_KEY}_generic_ragged_paged_attention_v3-w8a16_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "generic ragged paged attention v3-w8a16"
       CI_STAGE: "CorrectnessTest"
@@ -33,21 +36,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w8a16_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_generic_ragged_paged_attention_v3-w8a16_CorrectnessTest
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for generic ragged paged attention v3-w8a16"
-    key: "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w8a16_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_generic_ragged_paged_attention_v3-w8a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for generic ragged paged attention v3-w8a16"
+    key: "${BK_KEY}_generic_ragged_paged_attention_v3-w8a16_PerformanceTest"
+    depends_on: "${BK_KEY}_record_generic_ragged_paged_attention_v3-w8a16_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w8a16_PerformanceTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for generic ragged paged attention v3-w8a16"
-    key: "${TPU_VERSION:-tpu6e}_record_generic_ragged_paged_attention_v3-w8a16_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w8a16_PerformanceTest"
+        buildkite-agent meta-data set "${BK_KEY}_generic_ragged_paged_attention_v3-w8a16_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for generic ragged paged attention v3-w8a16"
+    key: "${BK_KEY}_record_generic_ragged_paged_attention_v3-w8a16_PerformanceTest"
+    depends_on: "${BK_KEY}_generic_ragged_paged_attention_v3-w8a16_PerformanceTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "generic ragged paged attention v3-w8a16"
       CI_STAGE: "PerformanceTest"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w8a16_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_generic_ragged_paged_attention_v3-w8a16_PerformanceTest

--- a/.buildkite/kernel_microbenchmarks/generic_ragged_paged_attention_v3/w8a16.yml
+++ b/.buildkite/kernel_microbenchmarks/generic_ragged_paged_attention_v3/w8a16.yml
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for generic ragged paged attention v3-w8a16"
-    key: "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w8a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for generic ragged paged attention v3-w8a16"
+    key: "${BK_KEY}_generic_ragged_paged_attention_v3-w8a16_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w8a16_CorrectnessTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for generic ragged paged attention v3 w8a16"
-    key: "${TPU_VERSION:-tpu6e}_record_generic_ragged_paged_attention_v3-w8a16_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w8a16_CorrectnessTest"
+        buildkite-agent meta-data set "${BK_KEY}_generic_ragged_paged_attention_v3-w8a16_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for generic ragged paged attention v3 w8a16"
+    key: "${BK_KEY}_record_generic_ragged_paged_attention_v3-w8a16_CorrectnessTest"
+    depends_on: "${BK_KEY}_generic_ragged_paged_attention_v3-w8a16_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "generic ragged paged attention v3-w8a16"
       CI_STAGE: "CorrectnessTest"
@@ -33,21 +36,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w8a16_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_generic_ragged_paged_attention_v3-w8a16_CorrectnessTest
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for generic ragged paged attention v3-w8a16"
-    key: "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w8a16_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_generic_ragged_paged_attention_v3-w8a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for generic ragged paged attention v3-w8a16"
+    key: "${BK_KEY}_generic_ragged_paged_attention_v3-w8a16_PerformanceTest"
+    depends_on: "${BK_KEY}_record_generic_ragged_paged_attention_v3-w8a16_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w8a16_PerformanceTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for generic ragged paged attention v3-w8a16"
-    key: "${TPU_VERSION:-tpu6e}_record_generic_ragged_paged_attention_v3-w8a16_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w8a16_PerformanceTest"
+        buildkite-agent meta-data set "${BK_KEY}_generic_ragged_paged_attention_v3-w8a16_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for generic ragged paged attention v3-w8a16"
+    key: "${BK_KEY}_record_generic_ragged_paged_attention_v3-w8a16_PerformanceTest"
+    depends_on: "${BK_KEY}_generic_ragged_paged_attention_v3-w8a16_PerformanceTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "generic ragged paged attention v3-w8a16"
       CI_STAGE: "PerformanceTest"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w8a16_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_generic_ragged_paged_attention_v3-w8a16_PerformanceTest

--- a/.buildkite/kernel_microbenchmarks/generic_ragged_paged_attention_v3/w8a8.yml
+++ b/.buildkite/kernel_microbenchmarks/generic_ragged_paged_attention_v3/w8a8.yml
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for generic ragged paged attention v3-w8a8"
-    key: "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w8a8_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for generic ragged paged attention v3-w8a8"
+    key: "${BK_KEY}_generic_ragged_paged_attention_v3-w8a8_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w8a8_CorrectnessTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for generic ragged paged attention v3 w8a8"
-    key: "${TPU_VERSION:-tpu6e}_record_generic_ragged_paged_attention_v3-w8a8_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w8a8_CorrectnessTest"
+        buildkite-agent meta-data set "${BK_KEY}_generic_ragged_paged_attention_v3-w8a8_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for generic ragged paged attention v3 w8a8"
+    key: "${BK_KEY}_record_generic_ragged_paged_attention_v3-w8a8_CorrectnessTest"
+    depends_on: "${BK_KEY}_generic_ragged_paged_attention_v3-w8a8_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "generic ragged paged attention v3-w8a8"
       CI_STAGE: "CorrectnessTest"
@@ -33,21 +36,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w8a8_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_generic_ragged_paged_attention_v3-w8a8_CorrectnessTest
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for generic ragged paged attention v3-w8a8"
-    key: "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w8a8_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_generic_ragged_paged_attention_v3-w8a8_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for generic ragged paged attention v3-w8a8"
+    key: "${BK_KEY}_generic_ragged_paged_attention_v3-w8a8_PerformanceTest"
+    depends_on: "${BK_KEY}_record_generic_ragged_paged_attention_v3-w8a8_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w8a8_PerformanceTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for generic ragged paged attention v3-w8a8"
-    key: "${TPU_VERSION:-tpu6e}_record_generic_ragged_paged_attention_v3-w8a8_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w8a8_PerformanceTest"
+        buildkite-agent meta-data set "${BK_KEY}_generic_ragged_paged_attention_v3-w8a8_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for generic ragged paged attention v3-w8a8"
+    key: "${BK_KEY}_record_generic_ragged_paged_attention_v3-w8a8_PerformanceTest"
+    depends_on: "${BK_KEY}_generic_ragged_paged_attention_v3-w8a8_PerformanceTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "generic ragged paged attention v3-w8a8"
       CI_STAGE: "PerformanceTest"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w8a8_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_generic_ragged_paged_attention_v3-w8a8_PerformanceTest

--- a/.buildkite/kernel_microbenchmarks/generic_ragged_paged_attention_v3/w8a8.yml
+++ b/.buildkite/kernel_microbenchmarks/generic_ragged_paged_attention_v3/w8a8.yml
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for generic ragged paged attention v3-w8a8"
-    key: "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w8a8_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for generic ragged paged attention v3-w8a8"
+    key: "${BK_KEY}_generic_ragged_paged_attention_v3-w8a8_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w8a8_CorrectnessTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for generic ragged paged attention v3 w8a8"
-    key: "${TPU_VERSION:-tpu6e}_record_generic_ragged_paged_attention_v3-w8a8_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w8a8_CorrectnessTest"
+        buildkite-agent meta-data set "${BK_KEY}_generic_ragged_paged_attention_v3-w8a8_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for generic ragged paged attention v3 w8a8"
+    key: "${BK_KEY}_record_generic_ragged_paged_attention_v3-w8a8_CorrectnessTest"
+    depends_on: "${BK_KEY}_generic_ragged_paged_attention_v3-w8a8_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "generic ragged paged attention v3-w8a8"
       CI_STAGE: "CorrectnessTest"
@@ -33,21 +36,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w8a8_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_generic_ragged_paged_attention_v3-w8a8_CorrectnessTest
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for generic ragged paged attention v3-w8a8"
-    key: "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w8a8_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_generic_ragged_paged_attention_v3-w8a8_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for generic ragged paged attention v3-w8a8"
+    key: "${BK_KEY}_generic_ragged_paged_attention_v3-w8a8_PerformanceTest"
+    depends_on: "${BK_KEY}_record_generic_ragged_paged_attention_v3-w8a8_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w8a8_PerformanceTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for generic ragged paged attention v3-w8a8"
-    key: "${TPU_VERSION:-tpu6e}_record_generic_ragged_paged_attention_v3-w8a8_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w8a8_PerformanceTest"
+        buildkite-agent meta-data set "${BK_KEY}_generic_ragged_paged_attention_v3-w8a8_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for generic ragged paged attention v3-w8a8"
+    key: "${BK_KEY}_record_generic_ragged_paged_attention_v3-w8a8_PerformanceTest"
+    depends_on: "${BK_KEY}_generic_ragged_paged_attention_v3-w8a8_PerformanceTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "generic ragged paged attention v3-w8a8"
       CI_STAGE: "PerformanceTest"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w8a8_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_generic_ragged_paged_attention_v3-w8a8_PerformanceTest

--- a/.buildkite/kernel_microbenchmarks/gmm/w16a16.yml
+++ b/.buildkite/kernel_microbenchmarks/gmm/w16a16.yml
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for gmm-w16a16"
-    key: "${TPU_VERSION:-tpu6e}_gmm-w16a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for gmm-w16a16"
+    key: "${BK_KEY}_gmm-w16a16_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_gmm-w16a16_CorrectnessTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for gmm-w16a16"
-    key: "${TPU_VERSION:-tpu6e}_record_gmm-w16a16_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_gmm-w16a16_CorrectnessTest"
+        buildkite-agent meta-data set "${BK_KEY}_gmm-w16a16_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for gmm-w16a16"
+    key: "${BK_KEY}_record_gmm-w16a16_CorrectnessTest"
+    depends_on: "${BK_KEY}_gmm-w16a16_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "gmm-w16a16"
       CI_STAGE: "CorrectnessTest"
@@ -33,21 +36,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_gmm-w16a16_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_gmm-w16a16_CorrectnessTest
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for gmm-w16a16"
-    key: "${TPU_VERSION:-tpu6e}_gmm-w16a16_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_gmm-w16a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for gmm-w16a16"
+    key: "${BK_KEY}_gmm-w16a16_PerformanceTest"
+    depends_on: "${BK_KEY}_record_gmm-w16a16_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_gmm-w16a16_PerformanceTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for gmm-w16a16"
-    key: "${TPU_VERSION:-tpu6e}_record_gmm-w16a16_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_gmm-w16a16_PerformanceTest"
+        buildkite-agent meta-data set "${BK_KEY}_gmm-w16a16_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for gmm-w16a16"
+    key: "${BK_KEY}_record_gmm-w16a16_PerformanceTest"
+    depends_on: "${BK_KEY}_gmm-w16a16_PerformanceTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "gmm-w16a16"
       CI_STAGE: "PerformanceTest"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_gmm-w16a16_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_gmm-w16a16_PerformanceTest

--- a/.buildkite/kernel_microbenchmarks/gmm/w16a16.yml
+++ b/.buildkite/kernel_microbenchmarks/gmm/w16a16.yml
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for gmm-w16a16"
-    key: "${TPU_VERSION:-tpu6e}_gmm-w16a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for gmm-w16a16"
+    key: "${BK_KEY}_gmm-w16a16_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_gmm-w16a16_CorrectnessTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for gmm-w16a16"
-    key: "${TPU_VERSION:-tpu6e}_record_gmm-w16a16_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_gmm-w16a16_CorrectnessTest"
+        buildkite-agent meta-data set "${BK_KEY}_gmm-w16a16_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for gmm-w16a16"
+    key: "${BK_KEY}_record_gmm-w16a16_CorrectnessTest"
+    depends_on: "${BK_KEY}_gmm-w16a16_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "gmm-w16a16"
       CI_STAGE: "CorrectnessTest"
@@ -33,21 +36,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_gmm-w16a16_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_gmm-w16a16_CorrectnessTest
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for gmm-w16a16"
-    key: "${TPU_VERSION:-tpu6e}_gmm-w16a16_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_gmm-w16a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for gmm-w16a16"
+    key: "${BK_KEY}_gmm-w16a16_PerformanceTest"
+    depends_on: "${BK_KEY}_record_gmm-w16a16_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_gmm-w16a16_PerformanceTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for gmm-w16a16"
-    key: "${TPU_VERSION:-tpu6e}_record_gmm-w16a16_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_gmm-w16a16_PerformanceTest"
+        buildkite-agent meta-data set "${BK_KEY}_gmm-w16a16_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for gmm-w16a16"
+    key: "${BK_KEY}_record_gmm-w16a16_PerformanceTest"
+    depends_on: "${BK_KEY}_gmm-w16a16_PerformanceTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "gmm-w16a16"
       CI_STAGE: "PerformanceTest"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_gmm-w16a16_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_gmm-w16a16_PerformanceTest

--- a/.buildkite/kernel_microbenchmarks/gmm/w4a16.yml
+++ b/.buildkite/kernel_microbenchmarks/gmm/w4a16.yml
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for gmm-w4a16"
-    key: "${TPU_VERSION:-tpu6e}_gmm-w4a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for gmm-w4a16"
+    key: "${BK_KEY}_gmm-w4a16_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_gmm-w4a16_CorrectnessTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for gmm-w4a16"
-    key: "${TPU_VERSION:-tpu6e}_record_gmm-w4a16_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_gmm-w4a16_CorrectnessTest"
+        buildkite-agent meta-data set "${BK_KEY}_gmm-w4a16_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for gmm-w4a16"
+    key: "${BK_KEY}_record_gmm-w4a16_CorrectnessTest"
+    depends_on: "${BK_KEY}_gmm-w4a16_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "gmm-w4a16"
       CI_STAGE: "CorrectnessTest"
@@ -33,21 +36,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_gmm-w4a16_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_gmm-w4a16_CorrectnessTest
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for gmm-w4a16"
-    key: "${TPU_VERSION:-tpu6e}_gmm-w4a16_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_gmm-w4a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for gmm-w4a16"
+    key: "${BK_KEY}_gmm-w4a16_PerformanceTest"
+    depends_on: "${BK_KEY}_record_gmm-w4a16_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_gmm-w4a16_PerformanceTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for gmm-w4a16"
-    key: "${TPU_VERSION:-tpu6e}_record_gmm-w4a16_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_gmm-w4a16_PerformanceTest"
+        buildkite-agent meta-data set "${BK_KEY}_gmm-w4a16_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for gmm-w4a16"
+    key: "${BK_KEY}_record_gmm-w4a16_PerformanceTest"
+    depends_on: "${BK_KEY}_gmm-w4a16_PerformanceTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "gmm-w4a16"
       CI_STAGE: "PerformanceTest"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_gmm-w4a16_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_gmm-w4a16_PerformanceTest

--- a/.buildkite/kernel_microbenchmarks/gmm/w4a16.yml
+++ b/.buildkite/kernel_microbenchmarks/gmm/w4a16.yml
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for gmm-w4a16"
-    key: "${TPU_VERSION:-tpu6e}_gmm-w4a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for gmm-w4a16"
+    key: "${BK_KEY}_gmm-w4a16_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_gmm-w4a16_CorrectnessTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for gmm-w4a16"
-    key: "${TPU_VERSION:-tpu6e}_record_gmm-w4a16_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_gmm-w4a16_CorrectnessTest"
+        buildkite-agent meta-data set "${BK_KEY}_gmm-w4a16_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for gmm-w4a16"
+    key: "${BK_KEY}_record_gmm-w4a16_CorrectnessTest"
+    depends_on: "${BK_KEY}_gmm-w4a16_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "gmm-w4a16"
       CI_STAGE: "CorrectnessTest"
@@ -33,21 +36,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_gmm-w4a16_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_gmm-w4a16_CorrectnessTest
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for gmm-w4a16"
-    key: "${TPU_VERSION:-tpu6e}_gmm-w4a16_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_gmm-w4a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for gmm-w4a16"
+    key: "${BK_KEY}_gmm-w4a16_PerformanceTest"
+    depends_on: "${BK_KEY}_record_gmm-w4a16_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_gmm-w4a16_PerformanceTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for gmm-w4a16"
-    key: "${TPU_VERSION:-tpu6e}_record_gmm-w4a16_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_gmm-w4a16_PerformanceTest"
+        buildkite-agent meta-data set "${BK_KEY}_gmm-w4a16_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for gmm-w4a16"
+    key: "${BK_KEY}_record_gmm-w4a16_PerformanceTest"
+    depends_on: "${BK_KEY}_gmm-w4a16_PerformanceTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "gmm-w4a16"
       CI_STAGE: "PerformanceTest"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_gmm-w4a16_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_gmm-w4a16_PerformanceTest

--- a/.buildkite/kernel_microbenchmarks/gmm/w4a4.yml
+++ b/.buildkite/kernel_microbenchmarks/gmm/w4a4.yml
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for gmm-w4a4"
-    key: "${TPU_VERSION:-tpu6e}_gmm-w4a4_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for gmm-w4a4"
+    key: "${BK_KEY}_gmm-w4a4_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_gmm-w4a4_CorrectnessTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for gmm-w4a4"
-    key: "${TPU_VERSION:-tpu6e}_record_gmm-w4a4_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_gmm-w4a4_CorrectnessTest"
+        buildkite-agent meta-data set "${BK_KEY}_gmm-w4a4_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for gmm-w4a4"
+    key: "${BK_KEY}_record_gmm-w4a4_CorrectnessTest"
+    depends_on: "${BK_KEY}_gmm-w4a4_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "gmm-w4a4"
       CI_STAGE: "CorrectnessTest"
@@ -33,21 +36,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_gmm-w4a4_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_gmm-w4a4_CorrectnessTest
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for gmm-w4a4"
-    key: "${TPU_VERSION:-tpu6e}_gmm-w4a4_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_gmm-w4a4_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for gmm-w4a4"
+    key: "${BK_KEY}_gmm-w4a4_PerformanceTest"
+    depends_on: "${BK_KEY}_record_gmm-w4a4_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_gmm-w4a4_PerformanceTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for gmm-w4a4"
-    key: "${TPU_VERSION:-tpu6e}_record_gmm-w4a4_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_gmm-w4a4_PerformanceTest"
+        buildkite-agent meta-data set "${BK_KEY}_gmm-w4a4_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for gmm-w4a4"
+    key: "${BK_KEY}_record_gmm-w4a4_PerformanceTest"
+    depends_on: "${BK_KEY}_gmm-w4a4_PerformanceTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "gmm-w4a4"
       CI_STAGE: "PerformanceTest"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_gmm-w4a4_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_gmm-w4a4_PerformanceTest

--- a/.buildkite/kernel_microbenchmarks/gmm/w4a4.yml
+++ b/.buildkite/kernel_microbenchmarks/gmm/w4a4.yml
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for gmm-w4a4"
-    key: "${TPU_VERSION:-tpu6e}_gmm-w4a4_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for gmm-w4a4"
+    key: "${BK_KEY}_gmm-w4a4_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_gmm-w4a4_CorrectnessTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for gmm-w4a4"
-    key: "${TPU_VERSION:-tpu6e}_record_gmm-w4a4_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_gmm-w4a4_CorrectnessTest"
+        buildkite-agent meta-data set "${BK_KEY}_gmm-w4a4_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for gmm-w4a4"
+    key: "${BK_KEY}_record_gmm-w4a4_CorrectnessTest"
+    depends_on: "${BK_KEY}_gmm-w4a4_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "gmm-w4a4"
       CI_STAGE: "CorrectnessTest"
@@ -33,21 +36,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_gmm-w4a4_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_gmm-w4a4_CorrectnessTest
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for gmm-w4a4"
-    key: "${TPU_VERSION:-tpu6e}_gmm-w4a4_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_gmm-w4a4_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for gmm-w4a4"
+    key: "${BK_KEY}_gmm-w4a4_PerformanceTest"
+    depends_on: "${BK_KEY}_record_gmm-w4a4_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_gmm-w4a4_PerformanceTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for gmm-w4a4"
-    key: "${TPU_VERSION:-tpu6e}_record_gmm-w4a4_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_gmm-w4a4_PerformanceTest"
+        buildkite-agent meta-data set "${BK_KEY}_gmm-w4a4_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for gmm-w4a4"
+    key: "${BK_KEY}_record_gmm-w4a4_PerformanceTest"
+    depends_on: "${BK_KEY}_gmm-w4a4_PerformanceTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "gmm-w4a4"
       CI_STAGE: "PerformanceTest"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_gmm-w4a4_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_gmm-w4a4_PerformanceTest

--- a/.buildkite/kernel_microbenchmarks/gmm/w4a8.yml
+++ b/.buildkite/kernel_microbenchmarks/gmm/w4a8.yml
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for gmm-w4a8"
-    key: "${TPU_VERSION:-tpu6e}_gmm-w4a8_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for gmm-w4a8"
+    key: "${BK_KEY}_gmm-w4a8_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_gmm-w4a8_CorrectnessTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for gmm-w4a8"
-    key: "${TPU_VERSION:-tpu6e}_record_gmm-w4a8_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_gmm-w4a8_CorrectnessTest"
+        buildkite-agent meta-data set "${BK_KEY}_gmm-w4a8_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for gmm-w4a8"
+    key: "${BK_KEY}_record_gmm-w4a8_CorrectnessTest"
+    depends_on: "${BK_KEY}_gmm-w4a8_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "gmm-w4a8"
       CI_STAGE: "CorrectnessTest"
@@ -33,21 +36,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_gmm-w4a8_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_gmm-w4a8_CorrectnessTest
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for gmm-w4a8"
-    key: "${TPU_VERSION:-tpu6e}_gmm-w4a8_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_gmm-w4a8_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for gmm-w4a8"
+    key: "${BK_KEY}_gmm-w4a8_PerformanceTest"
+    depends_on: "${BK_KEY}_record_gmm-w4a8_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_gmm-w4a8_PerformanceTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for gmm-w4a8"
-    key: "${TPU_VERSION:-tpu6e}_record_gmm-w4a8_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_gmm-w4a8_PerformanceTest"
+        buildkite-agent meta-data set "${BK_KEY}_gmm-w4a8_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for gmm-w4a8"
+    key: "${BK_KEY}_record_gmm-w4a8_PerformanceTest"
+    depends_on: "${BK_KEY}_gmm-w4a8_PerformanceTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "gmm-w4a8"
       CI_STAGE: "PerformanceTest"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_gmm-w4a8_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_gmm-w4a8_PerformanceTest

--- a/.buildkite/kernel_microbenchmarks/gmm/w4a8.yml
+++ b/.buildkite/kernel_microbenchmarks/gmm/w4a8.yml
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for gmm-w4a8"
-    key: "${TPU_VERSION:-tpu6e}_gmm-w4a8_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for gmm-w4a8"
+    key: "${BK_KEY}_gmm-w4a8_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_gmm-w4a8_CorrectnessTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for gmm-w4a8"
-    key: "${TPU_VERSION:-tpu6e}_record_gmm-w4a8_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_gmm-w4a8_CorrectnessTest"
+        buildkite-agent meta-data set "${BK_KEY}_gmm-w4a8_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for gmm-w4a8"
+    key: "${BK_KEY}_record_gmm-w4a8_CorrectnessTest"
+    depends_on: "${BK_KEY}_gmm-w4a8_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "gmm-w4a8"
       CI_STAGE: "CorrectnessTest"
@@ -33,21 +36,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_gmm-w4a8_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_gmm-w4a8_CorrectnessTest
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for gmm-w4a8"
-    key: "${TPU_VERSION:-tpu6e}_gmm-w4a8_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_gmm-w4a8_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for gmm-w4a8"
+    key: "${BK_KEY}_gmm-w4a8_PerformanceTest"
+    depends_on: "${BK_KEY}_record_gmm-w4a8_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_gmm-w4a8_PerformanceTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for gmm-w4a8"
-    key: "${TPU_VERSION:-tpu6e}_record_gmm-w4a8_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_gmm-w4a8_PerformanceTest"
+        buildkite-agent meta-data set "${BK_KEY}_gmm-w4a8_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for gmm-w4a8"
+    key: "${BK_KEY}_record_gmm-w4a8_PerformanceTest"
+    depends_on: "${BK_KEY}_gmm-w4a8_PerformanceTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "gmm-w4a8"
       CI_STAGE: "PerformanceTest"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_gmm-w4a8_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_gmm-w4a8_PerformanceTest

--- a/.buildkite/kernel_microbenchmarks/gmm/w8a16.yml
+++ b/.buildkite/kernel_microbenchmarks/gmm/w8a16.yml
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for gmm-w8a16"
-    key: "${TPU_VERSION:-tpu6e}_gmm-w8a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for gmm-w8a16"
+    key: "${BK_KEY}_gmm-w8a16_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_gmm-w8a16_CorrectnessTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for gmm-w8a16"
-    key: "${TPU_VERSION:-tpu6e}_record_gmm-w8a16_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_gmm-w8a16_CorrectnessTest"
+        buildkite-agent meta-data set "${BK_KEY}_gmm-w8a16_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for gmm-w8a16"
+    key: "${BK_KEY}_record_gmm-w8a16_CorrectnessTest"
+    depends_on: "${BK_KEY}_gmm-w8a16_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "gmm-w8a16"
       CI_STAGE: "CorrectnessTest"
@@ -33,21 +36,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_gmm-w8a16_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_gmm-w8a16_CorrectnessTest
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for gmm-w8a16"
-    key: "${TPU_VERSION:-tpu6e}_gmm-w8a16_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_gmm-w8a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for gmm-w8a16"
+    key: "${BK_KEY}_gmm-w8a16_PerformanceTest"
+    depends_on: "${BK_KEY}_record_gmm-w8a16_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_gmm-w8a16_PerformanceTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for gmm-w8a16"
-    key: "${TPU_VERSION:-tpu6e}_record_gmm-w8a16_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_gmm-w8a16_PerformanceTest"
+        buildkite-agent meta-data set "${BK_KEY}_gmm-w8a16_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for gmm-w8a16"
+    key: "${BK_KEY}_record_gmm-w8a16_PerformanceTest"
+    depends_on: "${BK_KEY}_gmm-w8a16_PerformanceTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "gmm-w8a16"
       CI_STAGE: "PerformanceTest"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_gmm-w8a16_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_gmm-w8a16_PerformanceTest

--- a/.buildkite/kernel_microbenchmarks/gmm/w8a16.yml
+++ b/.buildkite/kernel_microbenchmarks/gmm/w8a16.yml
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for gmm-w8a16"
-    key: "${TPU_VERSION:-tpu6e}_gmm-w8a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for gmm-w8a16"
+    key: "${BK_KEY}_gmm-w8a16_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_gmm-w8a16_CorrectnessTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for gmm-w8a16"
-    key: "${TPU_VERSION:-tpu6e}_record_gmm-w8a16_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_gmm-w8a16_CorrectnessTest"
+        buildkite-agent meta-data set "${BK_KEY}_gmm-w8a16_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for gmm-w8a16"
+    key: "${BK_KEY}_record_gmm-w8a16_CorrectnessTest"
+    depends_on: "${BK_KEY}_gmm-w8a16_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "gmm-w8a16"
       CI_STAGE: "CorrectnessTest"
@@ -33,21 +36,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_gmm-w8a16_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_gmm-w8a16_CorrectnessTest
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for gmm-w8a16"
-    key: "${TPU_VERSION:-tpu6e}_gmm-w8a16_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_gmm-w8a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for gmm-w8a16"
+    key: "${BK_KEY}_gmm-w8a16_PerformanceTest"
+    depends_on: "${BK_KEY}_record_gmm-w8a16_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_gmm-w8a16_PerformanceTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for gmm-w8a16"
-    key: "${TPU_VERSION:-tpu6e}_record_gmm-w8a16_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_gmm-w8a16_PerformanceTest"
+        buildkite-agent meta-data set "${BK_KEY}_gmm-w8a16_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for gmm-w8a16"
+    key: "${BK_KEY}_record_gmm-w8a16_PerformanceTest"
+    depends_on: "${BK_KEY}_gmm-w8a16_PerformanceTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "gmm-w8a16"
       CI_STAGE: "PerformanceTest"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_gmm-w8a16_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_gmm-w8a16_PerformanceTest

--- a/.buildkite/kernel_microbenchmarks/gmm/w8a8.yml
+++ b/.buildkite/kernel_microbenchmarks/gmm/w8a8.yml
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for gmm-w8a8"
-    key: "${TPU_VERSION:-tpu6e}_gmm-w8a8_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for gmm-w8a8"
+    key: "${BK_KEY}_gmm-w8a8_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_gmm-w8a8_CorrectnessTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for gmm-w8a8"
-    key: "${TPU_VERSION:-tpu6e}_record_gmm-w8a8_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_gmm-w8a8_CorrectnessTest"
+        buildkite-agent meta-data set "${BK_KEY}_gmm-w8a8_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for gmm-w8a8"
+    key: "${BK_KEY}_record_gmm-w8a8_CorrectnessTest"
+    depends_on: "${BK_KEY}_gmm-w8a8_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "gmm-w8a8"
       CI_STAGE: "CorrectnessTest"
@@ -33,21 +36,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_gmm-w8a8_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_gmm-w8a8_CorrectnessTest
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for gmm-w8a8"
-    key: "${TPU_VERSION:-tpu6e}_gmm-w8a8_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_gmm-w8a8_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for gmm-w8a8"
+    key: "${BK_KEY}_gmm-w8a8_PerformanceTest"
+    depends_on: "${BK_KEY}_record_gmm-w8a8_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_gmm-w8a8_PerformanceTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for gmm-w8a8"
-    key: "${TPU_VERSION:-tpu6e}_record_gmm-w8a8_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_gmm-w8a8_PerformanceTest"
+        buildkite-agent meta-data set "${BK_KEY}_gmm-w8a8_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for gmm-w8a8"
+    key: "${BK_KEY}_record_gmm-w8a8_PerformanceTest"
+    depends_on: "${BK_KEY}_gmm-w8a8_PerformanceTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "gmm-w8a8"
       CI_STAGE: "PerformanceTest"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_gmm-w8a8_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_gmm-w8a8_PerformanceTest

--- a/.buildkite/kernel_microbenchmarks/gmm/w8a8.yml
+++ b/.buildkite/kernel_microbenchmarks/gmm/w8a8.yml
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for gmm-w8a8"
-    key: "${TPU_VERSION:-tpu6e}_gmm-w8a8_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for gmm-w8a8"
+    key: "${BK_KEY}_gmm-w8a8_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_gmm-w8a8_CorrectnessTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for gmm-w8a8"
-    key: "${TPU_VERSION:-tpu6e}_record_gmm-w8a8_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_gmm-w8a8_CorrectnessTest"
+        buildkite-agent meta-data set "${BK_KEY}_gmm-w8a8_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for gmm-w8a8"
+    key: "${BK_KEY}_record_gmm-w8a8_CorrectnessTest"
+    depends_on: "${BK_KEY}_gmm-w8a8_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "gmm-w8a8"
       CI_STAGE: "CorrectnessTest"
@@ -33,21 +36,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_gmm-w8a8_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_gmm-w8a8_CorrectnessTest
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for gmm-w8a8"
-    key: "${TPU_VERSION:-tpu6e}_gmm-w8a8_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_gmm-w8a8_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for gmm-w8a8"
+    key: "${BK_KEY}_gmm-w8a8_PerformanceTest"
+    depends_on: "${BK_KEY}_record_gmm-w8a8_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_gmm-w8a8_PerformanceTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for gmm-w8a8"
-    key: "${TPU_VERSION:-tpu6e}_record_gmm-w8a8_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_gmm-w8a8_PerformanceTest"
+        buildkite-agent meta-data set "${BK_KEY}_gmm-w8a8_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for gmm-w8a8"
+    key: "${BK_KEY}_record_gmm-w8a8_PerformanceTest"
+    depends_on: "${BK_KEY}_gmm-w8a8_PerformanceTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "gmm-w8a8"
       CI_STAGE: "PerformanceTest"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_gmm-w8a8_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_gmm-w8a8_PerformanceTest

--- a/.buildkite/kernel_microbenchmarks/mla/w16a16.yml
+++ b/.buildkite/kernel_microbenchmarks/mla/w16a16.yml
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for mla-w16a16"
-    key: "${TPU_VERSION:-tpu6e}_mla-w16a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for mla-w16a16"
+    key: "${BK_KEY}_mla-w16a16_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_mla-w16a16_CorrectnessTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for mla-w16a16"
-    key: "${TPU_VERSION:-tpu6e}_record_mla-w16a16_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_mla-w16a16_CorrectnessTest"
+        buildkite-agent meta-data set "${BK_KEY}_mla-w16a16_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for mla-w16a16"
+    key: "${BK_KEY}_record_mla-w16a16_CorrectnessTest"
+    depends_on: "${BK_KEY}_mla-w16a16_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "mla-w16a16"
       CI_STAGE: "CorrectnessTest"
@@ -33,21 +36,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_mla-w16a16_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_mla-w16a16_CorrectnessTest
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for mla-w16a16"
-    key: "${TPU_VERSION:-tpu6e}_mla-w16a16_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_mla-w16a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for mla-w16a16"
+    key: "${BK_KEY}_mla-w16a16_PerformanceTest"
+    depends_on: "${BK_KEY}_record_mla-w16a16_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_mla-w16a16_PerformanceTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for mla-w16a16"
-    key: "${TPU_VERSION:-tpu6e}_record_mla-w16a16_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_mla-w16a16_PerformanceTest"
+        buildkite-agent meta-data set "${BK_KEY}_mla-w16a16_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for mla-w16a16"
+    key: "${BK_KEY}_record_mla-w16a16_PerformanceTest"
+    depends_on: "${BK_KEY}_mla-w16a16_PerformanceTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "mla-w16a16"
       CI_STAGE: "PerformanceTest"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_mla-w16a16_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_mla-w16a16_PerformanceTest

--- a/.buildkite/kernel_microbenchmarks/mla/w16a16.yml
+++ b/.buildkite/kernel_microbenchmarks/mla/w16a16.yml
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for mla-w16a16"
-    key: "${TPU_VERSION:-tpu6e}_mla-w16a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for mla-w16a16"
+    key: "${BK_KEY}_mla-w16a16_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_mla-w16a16_CorrectnessTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for mla-w16a16"
-    key: "${TPU_VERSION:-tpu6e}_record_mla-w16a16_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_mla-w16a16_CorrectnessTest"
+        buildkite-agent meta-data set "${BK_KEY}_mla-w16a16_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for mla-w16a16"
+    key: "${BK_KEY}_record_mla-w16a16_CorrectnessTest"
+    depends_on: "${BK_KEY}_mla-w16a16_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "mla-w16a16"
       CI_STAGE: "CorrectnessTest"
@@ -33,21 +36,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_mla-w16a16_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_mla-w16a16_CorrectnessTest
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for mla-w16a16"
-    key: "${TPU_VERSION:-tpu6e}_mla-w16a16_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_mla-w16a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for mla-w16a16"
+    key: "${BK_KEY}_mla-w16a16_PerformanceTest"
+    depends_on: "${BK_KEY}_record_mla-w16a16_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_mla-w16a16_PerformanceTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for mla-w16a16"
-    key: "${TPU_VERSION:-tpu6e}_record_mla-w16a16_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_mla-w16a16_PerformanceTest"
+        buildkite-agent meta-data set "${BK_KEY}_mla-w16a16_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for mla-w16a16"
+    key: "${BK_KEY}_record_mla-w16a16_PerformanceTest"
+    depends_on: "${BK_KEY}_mla-w16a16_PerformanceTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "mla-w16a16"
       CI_STAGE: "PerformanceTest"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_mla-w16a16_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_mla-w16a16_PerformanceTest

--- a/.buildkite/kernel_microbenchmarks/mla/w4a16.yml
+++ b/.buildkite/kernel_microbenchmarks/mla/w4a16.yml
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for mla-w4a16"
-    key: "${TPU_VERSION:-tpu6e}_mla-w4a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for mla-w4a16"
+    key: "${BK_KEY}_mla-w4a16_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_mla-w4a16_CorrectnessTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for mla-w4a16"
-    key: "${TPU_VERSION:-tpu6e}_record_mla-w4a16_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_mla-w4a16_CorrectnessTest"
+        buildkite-agent meta-data set "${BK_KEY}_mla-w4a16_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for mla-w4a16"
+    key: "${BK_KEY}_record_mla-w4a16_CorrectnessTest"
+    depends_on: "${BK_KEY}_mla-w4a16_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "mla-w4a16"
       CI_STAGE: "CorrectnessTest"
@@ -33,21 +36,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_mla-w4a16_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_mla-w4a16_CorrectnessTest
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for mla-w4a16"
-    key: "${TPU_VERSION:-tpu6e}_mla-w4a16_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_mla-w4a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for mla-w4a16"
+    key: "${BK_KEY}_mla-w4a16_PerformanceTest"
+    depends_on: "${BK_KEY}_record_mla-w4a16_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_mla-w4a16_PerformanceTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for mla-w4a16"
-    key: "${TPU_VERSION:-tpu6e}_record_mla-w4a16_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_mla-w4a16_PerformanceTest"
+        buildkite-agent meta-data set "${BK_KEY}_mla-w4a16_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for mla-w4a16"
+    key: "${BK_KEY}_record_mla-w4a16_PerformanceTest"
+    depends_on: "${BK_KEY}_mla-w4a16_PerformanceTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "mla-w4a16"
       CI_STAGE: "PerformanceTest"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_mla-w4a16_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_mla-w4a16_PerformanceTest

--- a/.buildkite/kernel_microbenchmarks/mla/w4a16.yml
+++ b/.buildkite/kernel_microbenchmarks/mla/w4a16.yml
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for mla-w4a16"
-    key: "${TPU_VERSION:-tpu6e}_mla-w4a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for mla-w4a16"
+    key: "${BK_KEY}_mla-w4a16_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_mla-w4a16_CorrectnessTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for mla-w4a16"
-    key: "${TPU_VERSION:-tpu6e}_record_mla-w4a16_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_mla-w4a16_CorrectnessTest"
+        buildkite-agent meta-data set "${BK_KEY}_mla-w4a16_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for mla-w4a16"
+    key: "${BK_KEY}_record_mla-w4a16_CorrectnessTest"
+    depends_on: "${BK_KEY}_mla-w4a16_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "mla-w4a16"
       CI_STAGE: "CorrectnessTest"
@@ -33,21 +36,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_mla-w4a16_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_mla-w4a16_CorrectnessTest
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for mla-w4a16"
-    key: "${TPU_VERSION:-tpu6e}_mla-w4a16_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_mla-w4a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for mla-w4a16"
+    key: "${BK_KEY}_mla-w4a16_PerformanceTest"
+    depends_on: "${BK_KEY}_record_mla-w4a16_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_mla-w4a16_PerformanceTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for mla-w4a16"
-    key: "${TPU_VERSION:-tpu6e}_record_mla-w4a16_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_mla-w4a16_PerformanceTest"
+        buildkite-agent meta-data set "${BK_KEY}_mla-w4a16_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for mla-w4a16"
+    key: "${BK_KEY}_record_mla-w4a16_PerformanceTest"
+    depends_on: "${BK_KEY}_mla-w4a16_PerformanceTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "mla-w4a16"
       CI_STAGE: "PerformanceTest"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_mla-w4a16_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_mla-w4a16_PerformanceTest

--- a/.buildkite/kernel_microbenchmarks/mla/w4a4.yml
+++ b/.buildkite/kernel_microbenchmarks/mla/w4a4.yml
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for mla-w4a4"
-    key: "${TPU_VERSION:-tpu6e}_mla-w4a4_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for mla-w4a4"
+    key: "${BK_KEY}_mla-w4a4_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_mla-w4a4_CorrectnessTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for mla-w4a4"
-    key: "${TPU_VERSION:-tpu6e}_record_mla-w4a4_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_mla-w4a4_CorrectnessTest"
+        buildkite-agent meta-data set "${BK_KEY}_mla-w4a4_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for mla-w4a4"
+    key: "${BK_KEY}_record_mla-w4a4_CorrectnessTest"
+    depends_on: "${BK_KEY}_mla-w4a4_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "mla-w4a4"
       CI_STAGE: "CorrectnessTest"
@@ -33,21 +36,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_mla-w4a4_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_mla-w4a4_CorrectnessTest
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for mla-w4a4"
-    key: "${TPU_VERSION:-tpu6e}_mla-w4a4_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_mla-w4a4_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for mla-w4a4"
+    key: "${BK_KEY}_mla-w4a4_PerformanceTest"
+    depends_on: "${BK_KEY}_record_mla-w4a4_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_mla-w4a4_PerformanceTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for mla-w4a4"
-    key: "${TPU_VERSION:-tpu6e}_record_mla-w4a4_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_mla-w4a4_PerformanceTest"
+        buildkite-agent meta-data set "${BK_KEY}_mla-w4a4_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for mla-w4a4"
+    key: "${BK_KEY}_record_mla-w4a4_PerformanceTest"
+    depends_on: "${BK_KEY}_mla-w4a4_PerformanceTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "mla-w4a4"
       CI_STAGE: "PerformanceTest"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_mla-w4a4_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_mla-w4a4_PerformanceTest

--- a/.buildkite/kernel_microbenchmarks/mla/w4a4.yml
+++ b/.buildkite/kernel_microbenchmarks/mla/w4a4.yml
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for mla-w4a4"
-    key: "${TPU_VERSION:-tpu6e}_mla-w4a4_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for mla-w4a4"
+    key: "${BK_KEY}_mla-w4a4_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_mla-w4a4_CorrectnessTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for mla-w4a4"
-    key: "${TPU_VERSION:-tpu6e}_record_mla-w4a4_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_mla-w4a4_CorrectnessTest"
+        buildkite-agent meta-data set "${BK_KEY}_mla-w4a4_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for mla-w4a4"
+    key: "${BK_KEY}_record_mla-w4a4_CorrectnessTest"
+    depends_on: "${BK_KEY}_mla-w4a4_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "mla-w4a4"
       CI_STAGE: "CorrectnessTest"
@@ -33,21 +36,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_mla-w4a4_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_mla-w4a4_CorrectnessTest
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for mla-w4a4"
-    key: "${TPU_VERSION:-tpu6e}_mla-w4a4_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_mla-w4a4_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for mla-w4a4"
+    key: "${BK_KEY}_mla-w4a4_PerformanceTest"
+    depends_on: "${BK_KEY}_record_mla-w4a4_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_mla-w4a4_PerformanceTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for mla-w4a4"
-    key: "${TPU_VERSION:-tpu6e}_record_mla-w4a4_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_mla-w4a4_PerformanceTest"
+        buildkite-agent meta-data set "${BK_KEY}_mla-w4a4_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for mla-w4a4"
+    key: "${BK_KEY}_record_mla-w4a4_PerformanceTest"
+    depends_on: "${BK_KEY}_mla-w4a4_PerformanceTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "mla-w4a4"
       CI_STAGE: "PerformanceTest"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_mla-w4a4_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_mla-w4a4_PerformanceTest

--- a/.buildkite/kernel_microbenchmarks/mla/w4a8.yml
+++ b/.buildkite/kernel_microbenchmarks/mla/w4a8.yml
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for mla-w4a8"
-    key: "${TPU_VERSION:-tpu6e}_mla-w4a8_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for mla-w4a8"
+    key: "${BK_KEY}_mla-w4a8_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_mla-w4a8_CorrectnessTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for mla-w4a8"
-    key: "${TPU_VERSION:-tpu6e}_record_mla-w4a8_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_mla-w4a8_CorrectnessTest"
+        buildkite-agent meta-data set "${BK_KEY}_mla-w4a8_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for mla-w4a8"
+    key: "${BK_KEY}_record_mla-w4a8_CorrectnessTest"
+    depends_on: "${BK_KEY}_mla-w4a8_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "mla-w4a8"
       CI_STAGE: "CorrectnessTest"
@@ -33,21 +36,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_mla-w4a8_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_mla-w4a8_CorrectnessTest
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for mla-w4a8"
-    key: "${TPU_VERSION:-tpu6e}_mla-w4a8_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_mla-w4a8_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for mla-w4a8"
+    key: "${BK_KEY}_mla-w4a8_PerformanceTest"
+    depends_on: "${BK_KEY}_record_mla-w4a8_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_mla-w4a8_PerformanceTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for mla-w4a8"
-    key: "${TPU_VERSION:-tpu6e}_record_mla-w4a8_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_mla-w4a8_PerformanceTest"
+        buildkite-agent meta-data set "${BK_KEY}_mla-w4a8_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for mla-w4a8"
+    key: "${BK_KEY}_record_mla-w4a8_PerformanceTest"
+    depends_on: "${BK_KEY}_mla-w4a8_PerformanceTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "mla-w4a8"
       CI_STAGE: "PerformanceTest"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_mla-w4a8_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_mla-w4a8_PerformanceTest

--- a/.buildkite/kernel_microbenchmarks/mla/w4a8.yml
+++ b/.buildkite/kernel_microbenchmarks/mla/w4a8.yml
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for mla-w4a8"
-    key: "${TPU_VERSION:-tpu6e}_mla-w4a8_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for mla-w4a8"
+    key: "${BK_KEY}_mla-w4a8_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_mla-w4a8_CorrectnessTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for mla-w4a8"
-    key: "${TPU_VERSION:-tpu6e}_record_mla-w4a8_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_mla-w4a8_CorrectnessTest"
+        buildkite-agent meta-data set "${BK_KEY}_mla-w4a8_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for mla-w4a8"
+    key: "${BK_KEY}_record_mla-w4a8_CorrectnessTest"
+    depends_on: "${BK_KEY}_mla-w4a8_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "mla-w4a8"
       CI_STAGE: "CorrectnessTest"
@@ -33,21 +36,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_mla-w4a8_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_mla-w4a8_CorrectnessTest
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for mla-w4a8"
-    key: "${TPU_VERSION:-tpu6e}_mla-w4a8_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_mla-w4a8_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for mla-w4a8"
+    key: "${BK_KEY}_mla-w4a8_PerformanceTest"
+    depends_on: "${BK_KEY}_record_mla-w4a8_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_mla-w4a8_PerformanceTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for mla-w4a8"
-    key: "${TPU_VERSION:-tpu6e}_record_mla-w4a8_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_mla-w4a8_PerformanceTest"
+        buildkite-agent meta-data set "${BK_KEY}_mla-w4a8_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for mla-w4a8"
+    key: "${BK_KEY}_record_mla-w4a8_PerformanceTest"
+    depends_on: "${BK_KEY}_mla-w4a8_PerformanceTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "mla-w4a8"
       CI_STAGE: "PerformanceTest"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_mla-w4a8_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_mla-w4a8_PerformanceTest

--- a/.buildkite/kernel_microbenchmarks/mla/w8a16.yml
+++ b/.buildkite/kernel_microbenchmarks/mla/w8a16.yml
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for mla-w8a16"
-    key: "${TPU_VERSION:-tpu6e}_mla-w8a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for mla-w8a16"
+    key: "${BK_KEY}_mla-w8a16_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_mla-w8a16_CorrectnessTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for mla-w8a16"
-    key: "${TPU_VERSION:-tpu6e}_record_mla-w8a16_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_mla-w8a16_CorrectnessTest"
+        buildkite-agent meta-data set "${BK_KEY}_mla-w8a16_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for mla-w8a16"
+    key: "${BK_KEY}_record_mla-w8a16_CorrectnessTest"
+    depends_on: "${BK_KEY}_mla-w8a16_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "mla-w8a16"
       CI_STAGE: "CorrectnessTest"
@@ -33,21 +36,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_mla-w8a16_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_mla-w8a16_CorrectnessTest
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for mla-w8a16"
-    key: "${TPU_VERSION:-tpu6e}_mla-w8a16_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_mla-w8a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for mla-w8a16"
+    key: "${BK_KEY}_mla-w8a16_PerformanceTest"
+    depends_on: "${BK_KEY}_record_mla-w8a16_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_mla-w8a16_PerformanceTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for mla-w8a16"
-    key: "${TPU_VERSION:-tpu6e}_record_mla-w8a16_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_mla-w8a16_PerformanceTest"
+        buildkite-agent meta-data set "${BK_KEY}_mla-w8a16_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for mla-w8a16"
+    key: "${BK_KEY}_record_mla-w8a16_PerformanceTest"
+    depends_on: "${BK_KEY}_mla-w8a16_PerformanceTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "mla-w8a16"
       CI_STAGE: "PerformanceTest"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_mla-w8a16_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_mla-w8a16_PerformanceTest

--- a/.buildkite/kernel_microbenchmarks/mla/w8a16.yml
+++ b/.buildkite/kernel_microbenchmarks/mla/w8a16.yml
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for mla-w8a16"
-    key: "${TPU_VERSION:-tpu6e}_mla-w8a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for mla-w8a16"
+    key: "${BK_KEY}_mla-w8a16_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_mla-w8a16_CorrectnessTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for mla-w8a16"
-    key: "${TPU_VERSION:-tpu6e}_record_mla-w8a16_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_mla-w8a16_CorrectnessTest"
+        buildkite-agent meta-data set "${BK_KEY}_mla-w8a16_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for mla-w8a16"
+    key: "${BK_KEY}_record_mla-w8a16_CorrectnessTest"
+    depends_on: "${BK_KEY}_mla-w8a16_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "mla-w8a16"
       CI_STAGE: "CorrectnessTest"
@@ -33,21 +36,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_mla-w8a16_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_mla-w8a16_CorrectnessTest
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for mla-w8a16"
-    key: "${TPU_VERSION:-tpu6e}_mla-w8a16_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_mla-w8a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for mla-w8a16"
+    key: "${BK_KEY}_mla-w8a16_PerformanceTest"
+    depends_on: "${BK_KEY}_record_mla-w8a16_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_mla-w8a16_PerformanceTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for mla-w8a16"
-    key: "${TPU_VERSION:-tpu6e}_record_mla-w8a16_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_mla-w8a16_PerformanceTest"
+        buildkite-agent meta-data set "${BK_KEY}_mla-w8a16_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for mla-w8a16"
+    key: "${BK_KEY}_record_mla-w8a16_PerformanceTest"
+    depends_on: "${BK_KEY}_mla-w8a16_PerformanceTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "mla-w8a16"
       CI_STAGE: "PerformanceTest"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_mla-w8a16_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_mla-w8a16_PerformanceTest

--- a/.buildkite/kernel_microbenchmarks/mla/w8a8.yml
+++ b/.buildkite/kernel_microbenchmarks/mla/w8a8.yml
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for mla-w8a8"
-    key: "${TPU_VERSION:-tpu6e}_mla-w8a8_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for mla-w8a8"
+    key: "${BK_KEY}_mla-w8a8_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_mla-w8a8_CorrectnessTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for mla-w8a8"
-    key: "${TPU_VERSION:-tpu6e}_record_mla-w8a8_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_mla-w8a8_CorrectnessTest"
+        buildkite-agent meta-data set "${BK_KEY}_mla-w8a8_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for mla-w8a8"
+    key: "${BK_KEY}_record_mla-w8a8_CorrectnessTest"
+    depends_on: "${BK_KEY}_mla-w8a8_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "mla-w8a8"
       CI_STAGE: "CorrectnessTest"
@@ -33,21 +36,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_mla-w8a8_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_mla-w8a8_CorrectnessTest
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for mla-w8a8"
-    key: "${TPU_VERSION:-tpu6e}_mla-w8a8_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_mla-w8a8_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for mla-w8a8"
+    key: "${BK_KEY}_mla-w8a8_PerformanceTest"
+    depends_on: "${BK_KEY}_record_mla-w8a8_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_mla-w8a8_PerformanceTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for mla-w8a8"
-    key: "${TPU_VERSION:-tpu6e}_record_mla-w8a8_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_mla-w8a8_PerformanceTest"
+        buildkite-agent meta-data set "${BK_KEY}_mla-w8a8_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for mla-w8a8"
+    key: "${BK_KEY}_record_mla-w8a8_PerformanceTest"
+    depends_on: "${BK_KEY}_mla-w8a8_PerformanceTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "mla-w8a8"
       CI_STAGE: "PerformanceTest"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_mla-w8a8_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_mla-w8a8_PerformanceTest

--- a/.buildkite/kernel_microbenchmarks/mla/w8a8.yml
+++ b/.buildkite/kernel_microbenchmarks/mla/w8a8.yml
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for mla-w8a8"
-    key: "${TPU_VERSION:-tpu6e}_mla-w8a8_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for mla-w8a8"
+    key: "${BK_KEY}_mla-w8a8_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_mla-w8a8_CorrectnessTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for mla-w8a8"
-    key: "${TPU_VERSION:-tpu6e}_record_mla-w8a8_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_mla-w8a8_CorrectnessTest"
+        buildkite-agent meta-data set "${BK_KEY}_mla-w8a8_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for mla-w8a8"
+    key: "${BK_KEY}_record_mla-w8a8_CorrectnessTest"
+    depends_on: "${BK_KEY}_mla-w8a8_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "mla-w8a8"
       CI_STAGE: "CorrectnessTest"
@@ -33,21 +36,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_mla-w8a8_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_mla-w8a8_CorrectnessTest
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for mla-w8a8"
-    key: "${TPU_VERSION:-tpu6e}_mla-w8a8_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_mla-w8a8_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for mla-w8a8"
+    key: "${BK_KEY}_mla-w8a8_PerformanceTest"
+    depends_on: "${BK_KEY}_record_mla-w8a8_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_mla-w8a8_PerformanceTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for mla-w8a8"
-    key: "${TPU_VERSION:-tpu6e}_record_mla-w8a8_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_mla-w8a8_PerformanceTest"
+        buildkite-agent meta-data set "${BK_KEY}_mla-w8a8_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for mla-w8a8"
+    key: "${BK_KEY}_record_mla-w8a8_PerformanceTest"
+    depends_on: "${BK_KEY}_mla-w8a8_PerformanceTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "mla-w8a8"
       CI_STAGE: "PerformanceTest"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_mla-w8a8_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_mla-w8a8_PerformanceTest

--- a/.buildkite/kernel_microbenchmarks/ragged_paged_attention_v3_head_dim_64/w16a16.yml
+++ b/.buildkite/kernel_microbenchmarks/ragged_paged_attention_v3_head_dim_64/w16a16.yml
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for ragged paged attention v3 head_dim 64-w16a16"
-    key: "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w16a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for ragged paged attention v3 head_dim 64-w16a16"
+    key: "${BK_KEY}_ragged_paged_attention_v3_head_dim_64-w16a16_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w16a16_CorrectnessTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for ragged paged attention v3 head_dim 64 w16a16"
-    key: "${TPU_VERSION:-tpu6e}_record_ragged_paged_attention_v3_head_dim_64-w16a16_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w16a16_CorrectnessTest"
+        buildkite-agent meta-data set "${BK_KEY}_ragged_paged_attention_v3_head_dim_64-w16a16_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for ragged paged attention v3 head_dim 64 w16a16"
+    key: "${BK_KEY}_record_ragged_paged_attention_v3_head_dim_64-w16a16_CorrectnessTest"
+    depends_on: "${BK_KEY}_ragged_paged_attention_v3_head_dim_64-w16a16_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "ragged paged attention v3 head_dim 64-w16a16"
       CI_STAGE: "CorrectnessTest"
@@ -33,21 +36,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w16a16_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_ragged_paged_attention_v3_head_dim_64-w16a16_CorrectnessTest
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for ragged paged attention v3 head_dim 64-w16a16"
-    key: "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w16a16_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_ragged_paged_attention_v3_head_dim_64-w16a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for ragged paged attention v3 head_dim 64-w16a16"
+    key: "${BK_KEY}_ragged_paged_attention_v3_head_dim_64-w16a16_PerformanceTest"
+    depends_on: "${BK_KEY}_record_ragged_paged_attention_v3_head_dim_64-w16a16_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w16a16_PerformanceTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for ragged paged attention v3 head_dim 64-w16a16"
-    key: "${TPU_VERSION:-tpu6e}_record_ragged_paged_attention_v3_head_dim_64-w16a16_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w16a16_PerformanceTest"
+        buildkite-agent meta-data set "${BK_KEY}_ragged_paged_attention_v3_head_dim_64-w16a16_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for ragged paged attention v3 head_dim 64-w16a16"
+    key: "${BK_KEY}_record_ragged_paged_attention_v3_head_dim_64-w16a16_PerformanceTest"
+    depends_on: "${BK_KEY}_ragged_paged_attention_v3_head_dim_64-w16a16_PerformanceTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "ragged paged attention v3 head_dim 64-w16a16"
       CI_STAGE: "PerformanceTest"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w16a16_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_ragged_paged_attention_v3_head_dim_64-w16a16_PerformanceTest

--- a/.buildkite/kernel_microbenchmarks/ragged_paged_attention_v3_head_dim_64/w16a16.yml
+++ b/.buildkite/kernel_microbenchmarks/ragged_paged_attention_v3_head_dim_64/w16a16.yml
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for ragged paged attention v3 head_dim 64-w16a16"
-    key: "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w16a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for ragged paged attention v3 head_dim 64-w16a16"
+    key: "${BK_KEY}_ragged_paged_attention_v3_head_dim_64-w16a16_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w16a16_CorrectnessTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for ragged paged attention v3 head_dim 64 w16a16"
-    key: "${TPU_VERSION:-tpu6e}_record_ragged_paged_attention_v3_head_dim_64-w16a16_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w16a16_CorrectnessTest"
+        buildkite-agent meta-data set "${BK_KEY}_ragged_paged_attention_v3_head_dim_64-w16a16_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for ragged paged attention v3 head_dim 64 w16a16"
+    key: "${BK_KEY}_record_ragged_paged_attention_v3_head_dim_64-w16a16_CorrectnessTest"
+    depends_on: "${BK_KEY}_ragged_paged_attention_v3_head_dim_64-w16a16_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "ragged paged attention v3 head_dim 64-w16a16"
       CI_STAGE: "CorrectnessTest"
@@ -33,21 +36,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w16a16_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_ragged_paged_attention_v3_head_dim_64-w16a16_CorrectnessTest
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for ragged paged attention v3 head_dim 64-w16a16"
-    key: "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w16a16_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_ragged_paged_attention_v3_head_dim_64-w16a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for ragged paged attention v3 head_dim 64-w16a16"
+    key: "${BK_KEY}_ragged_paged_attention_v3_head_dim_64-w16a16_PerformanceTest"
+    depends_on: "${BK_KEY}_record_ragged_paged_attention_v3_head_dim_64-w16a16_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w16a16_PerformanceTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for ragged paged attention v3 head_dim 64-w16a16"
-    key: "${TPU_VERSION:-tpu6e}_record_ragged_paged_attention_v3_head_dim_64-w16a16_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w16a16_PerformanceTest"
+        buildkite-agent meta-data set "${BK_KEY}_ragged_paged_attention_v3_head_dim_64-w16a16_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for ragged paged attention v3 head_dim 64-w16a16"
+    key: "${BK_KEY}_record_ragged_paged_attention_v3_head_dim_64-w16a16_PerformanceTest"
+    depends_on: "${BK_KEY}_ragged_paged_attention_v3_head_dim_64-w16a16_PerformanceTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "ragged paged attention v3 head_dim 64-w16a16"
       CI_STAGE: "PerformanceTest"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w16a16_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_ragged_paged_attention_v3_head_dim_64-w16a16_PerformanceTest

--- a/.buildkite/kernel_microbenchmarks/ragged_paged_attention_v3_head_dim_64/w4a16.yml
+++ b/.buildkite/kernel_microbenchmarks/ragged_paged_attention_v3_head_dim_64/w4a16.yml
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for ragged paged attention v3 head_dim 64-w4a16"
-    key: "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w4a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for ragged paged attention v3 head_dim 64-w4a16"
+    key: "${BK_KEY}_ragged_paged_attention_v3_head_dim_64-w4a16_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w4a16_CorrectnessTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for ragged paged attention v3 head_dim 64 w4a16"
-    key: "${TPU_VERSION:-tpu6e}_record_ragged_paged_attention_v3_head_dim_64-w4a16_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w4a16_CorrectnessTest"
+        buildkite-agent meta-data set "${BK_KEY}_ragged_paged_attention_v3_head_dim_64-w4a16_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for ragged paged attention v3 head_dim 64 w4a16"
+    key: "${BK_KEY}_record_ragged_paged_attention_v3_head_dim_64-w4a16_CorrectnessTest"
+    depends_on: "${BK_KEY}_ragged_paged_attention_v3_head_dim_64-w4a16_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "ragged paged attention v3 head_dim 64-w4a16"
       CI_STAGE: "CorrectnessTest"
@@ -33,21 +36,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w4a16_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_ragged_paged_attention_v3_head_dim_64-w4a16_CorrectnessTest
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for ragged paged attention v3 head_dim 64-w4a16"
-    key: "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w4a16_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_ragged_paged_attention_v3_head_dim_64-w4a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for ragged paged attention v3 head_dim 64-w4a16"
+    key: "${BK_KEY}_ragged_paged_attention_v3_head_dim_64-w4a16_PerformanceTest"
+    depends_on: "${BK_KEY}_record_ragged_paged_attention_v3_head_dim_64-w4a16_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w4a16_PerformanceTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for ragged paged attention v3 head_dim 64-w4a16"
-    key: "${TPU_VERSION:-tpu6e}_record_ragged_paged_attention_v3_head_dim_64-w4a16_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w4a16_PerformanceTest"
+        buildkite-agent meta-data set "${BK_KEY}_ragged_paged_attention_v3_head_dim_64-w4a16_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for ragged paged attention v3 head_dim 64-w4a16"
+    key: "${BK_KEY}_record_ragged_paged_attention_v3_head_dim_64-w4a16_PerformanceTest"
+    depends_on: "${BK_KEY}_ragged_paged_attention_v3_head_dim_64-w4a16_PerformanceTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "ragged paged attention v3 head_dim 64-w4a16"
       CI_STAGE: "PerformanceTest"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w4a16_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_ragged_paged_attention_v3_head_dim_64-w4a16_PerformanceTest

--- a/.buildkite/kernel_microbenchmarks/ragged_paged_attention_v3_head_dim_64/w4a16.yml
+++ b/.buildkite/kernel_microbenchmarks/ragged_paged_attention_v3_head_dim_64/w4a16.yml
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for ragged paged attention v3 head_dim 64-w4a16"
-    key: "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w4a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for ragged paged attention v3 head_dim 64-w4a16"
+    key: "${BK_KEY}_ragged_paged_attention_v3_head_dim_64-w4a16_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w4a16_CorrectnessTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for ragged paged attention v3 head_dim 64 w4a16"
-    key: "${TPU_VERSION:-tpu6e}_record_ragged_paged_attention_v3_head_dim_64-w4a16_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w4a16_CorrectnessTest"
+        buildkite-agent meta-data set "${BK_KEY}_ragged_paged_attention_v3_head_dim_64-w4a16_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for ragged paged attention v3 head_dim 64 w4a16"
+    key: "${BK_KEY}_record_ragged_paged_attention_v3_head_dim_64-w4a16_CorrectnessTest"
+    depends_on: "${BK_KEY}_ragged_paged_attention_v3_head_dim_64-w4a16_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "ragged paged attention v3 head_dim 64-w4a16"
       CI_STAGE: "CorrectnessTest"
@@ -33,21 +36,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w4a16_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_ragged_paged_attention_v3_head_dim_64-w4a16_CorrectnessTest
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for ragged paged attention v3 head_dim 64-w4a16"
-    key: "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w4a16_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_ragged_paged_attention_v3_head_dim_64-w4a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for ragged paged attention v3 head_dim 64-w4a16"
+    key: "${BK_KEY}_ragged_paged_attention_v3_head_dim_64-w4a16_PerformanceTest"
+    depends_on: "${BK_KEY}_record_ragged_paged_attention_v3_head_dim_64-w4a16_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w4a16_PerformanceTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for ragged paged attention v3 head_dim 64-w4a16"
-    key: "${TPU_VERSION:-tpu6e}_record_ragged_paged_attention_v3_head_dim_64-w4a16_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w4a16_PerformanceTest"
+        buildkite-agent meta-data set "${BK_KEY}_ragged_paged_attention_v3_head_dim_64-w4a16_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for ragged paged attention v3 head_dim 64-w4a16"
+    key: "${BK_KEY}_record_ragged_paged_attention_v3_head_dim_64-w4a16_PerformanceTest"
+    depends_on: "${BK_KEY}_ragged_paged_attention_v3_head_dim_64-w4a16_PerformanceTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "ragged paged attention v3 head_dim 64-w4a16"
       CI_STAGE: "PerformanceTest"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w4a16_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_ragged_paged_attention_v3_head_dim_64-w4a16_PerformanceTest

--- a/.buildkite/kernel_microbenchmarks/ragged_paged_attention_v3_head_dim_64/w4a4.yml
+++ b/.buildkite/kernel_microbenchmarks/ragged_paged_attention_v3_head_dim_64/w4a4.yml
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for ragged paged attention v3 head_dim 64-w4a4"
-    key: "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w4a4_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for ragged paged attention v3 head_dim 64-w4a4"
+    key: "${BK_KEY}_ragged_paged_attention_v3_head_dim_64-w4a4_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w4a4_CorrectnessTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for ragged paged attention v3 head_dim 64 w4a4"
-    key: "${TPU_VERSION:-tpu6e}_record_ragged_paged_attention_v3_head_dim_64-w4a4_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w4a4_CorrectnessTest"
+        buildkite-agent meta-data set "${BK_KEY}_ragged_paged_attention_v3_head_dim_64-w4a4_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for ragged paged attention v3 head_dim 64 w4a4"
+    key: "${BK_KEY}_record_ragged_paged_attention_v3_head_dim_64-w4a4_CorrectnessTest"
+    depends_on: "${BK_KEY}_ragged_paged_attention_v3_head_dim_64-w4a4_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "ragged paged attention v3 head_dim 64-w4a4"
       CI_STAGE: "CorrectnessTest"
@@ -33,21 +36,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w4a4_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_ragged_paged_attention_v3_head_dim_64-w4a4_CorrectnessTest
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for ragged paged attention v3 head_dim 64-w4a4"
-    key: "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w4a4_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_ragged_paged_attention_v3_head_dim_64-w4a4_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for ragged paged attention v3 head_dim 64-w4a4"
+    key: "${BK_KEY}_ragged_paged_attention_v3_head_dim_64-w4a4_PerformanceTest"
+    depends_on: "${BK_KEY}_record_ragged_paged_attention_v3_head_dim_64-w4a4_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w4a4_PerformanceTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for ragged paged attention v3 head_dim 64-w4a4"
-    key: "${TPU_VERSION:-tpu6e}_record_ragged_paged_attention_v3_head_dim_64-w4a4_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w4a4_PerformanceTest"
+        buildkite-agent meta-data set "${BK_KEY}_ragged_paged_attention_v3_head_dim_64-w4a4_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for ragged paged attention v3 head_dim 64-w4a4"
+    key: "${BK_KEY}_record_ragged_paged_attention_v3_head_dim_64-w4a4_PerformanceTest"
+    depends_on: "${BK_KEY}_ragged_paged_attention_v3_head_dim_64-w4a4_PerformanceTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "ragged paged attention v3 head_dim 64-w4a4"
       CI_STAGE: "PerformanceTest"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w4a4_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_ragged_paged_attention_v3_head_dim_64-w4a4_PerformanceTest

--- a/.buildkite/kernel_microbenchmarks/ragged_paged_attention_v3_head_dim_64/w4a4.yml
+++ b/.buildkite/kernel_microbenchmarks/ragged_paged_attention_v3_head_dim_64/w4a4.yml
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for ragged paged attention v3 head_dim 64-w4a4"
-    key: "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w4a4_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for ragged paged attention v3 head_dim 64-w4a4"
+    key: "${BK_KEY}_ragged_paged_attention_v3_head_dim_64-w4a4_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w4a4_CorrectnessTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for ragged paged attention v3 head_dim 64 w4a4"
-    key: "${TPU_VERSION:-tpu6e}_record_ragged_paged_attention_v3_head_dim_64-w4a4_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w4a4_CorrectnessTest"
+        buildkite-agent meta-data set "${BK_KEY}_ragged_paged_attention_v3_head_dim_64-w4a4_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for ragged paged attention v3 head_dim 64 w4a4"
+    key: "${BK_KEY}_record_ragged_paged_attention_v3_head_dim_64-w4a4_CorrectnessTest"
+    depends_on: "${BK_KEY}_ragged_paged_attention_v3_head_dim_64-w4a4_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "ragged paged attention v3 head_dim 64-w4a4"
       CI_STAGE: "CorrectnessTest"
@@ -33,21 +36,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w4a4_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_ragged_paged_attention_v3_head_dim_64-w4a4_CorrectnessTest
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for ragged paged attention v3 head_dim 64-w4a4"
-    key: "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w4a4_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_ragged_paged_attention_v3_head_dim_64-w4a4_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for ragged paged attention v3 head_dim 64-w4a4"
+    key: "${BK_KEY}_ragged_paged_attention_v3_head_dim_64-w4a4_PerformanceTest"
+    depends_on: "${BK_KEY}_record_ragged_paged_attention_v3_head_dim_64-w4a4_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w4a4_PerformanceTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for ragged paged attention v3 head_dim 64-w4a4"
-    key: "${TPU_VERSION:-tpu6e}_record_ragged_paged_attention_v3_head_dim_64-w4a4_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w4a4_PerformanceTest"
+        buildkite-agent meta-data set "${BK_KEY}_ragged_paged_attention_v3_head_dim_64-w4a4_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for ragged paged attention v3 head_dim 64-w4a4"
+    key: "${BK_KEY}_record_ragged_paged_attention_v3_head_dim_64-w4a4_PerformanceTest"
+    depends_on: "${BK_KEY}_ragged_paged_attention_v3_head_dim_64-w4a4_PerformanceTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "ragged paged attention v3 head_dim 64-w4a4"
       CI_STAGE: "PerformanceTest"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w4a4_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_ragged_paged_attention_v3_head_dim_64-w4a4_PerformanceTest

--- a/.buildkite/kernel_microbenchmarks/ragged_paged_attention_v3_head_dim_64/w4a8.yml
+++ b/.buildkite/kernel_microbenchmarks/ragged_paged_attention_v3_head_dim_64/w4a8.yml
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for ragged paged attention v3 head_dim 64-w4a8"
-    key: "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w4a8_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for ragged paged attention v3 head_dim 64-w4a8"
+    key: "${BK_KEY}_ragged_paged_attention_v3_head_dim_64-w4a8_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w4a8_CorrectnessTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for ragged paged attention v3 head_dim 64 w4a8"
-    key: "${TPU_VERSION:-tpu6e}_record_ragged_paged_attention_v3_head_dim_64-w4a8_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w4a8_CorrectnessTest"
+        buildkite-agent meta-data set "${BK_KEY}_ragged_paged_attention_v3_head_dim_64-w4a8_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for ragged paged attention v3 head_dim 64 w4a8"
+    key: "${BK_KEY}_record_ragged_paged_attention_v3_head_dim_64-w4a8_CorrectnessTest"
+    depends_on: "${BK_KEY}_ragged_paged_attention_v3_head_dim_64-w4a8_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "ragged paged attention v3 head_dim 64-w4a8"
       CI_STAGE: "CorrectnessTest"
@@ -33,21 +36,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w4a8_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_ragged_paged_attention_v3_head_dim_64-w4a8_CorrectnessTest
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for ragged paged attention v3 head_dim 64-w4a8"
-    key: "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w4a8_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_ragged_paged_attention_v3_head_dim_64-w4a8_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for ragged paged attention v3 head_dim 64-w4a8"
+    key: "${BK_KEY}_ragged_paged_attention_v3_head_dim_64-w4a8_PerformanceTest"
+    depends_on: "${BK_KEY}_record_ragged_paged_attention_v3_head_dim_64-w4a8_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w4a8_PerformanceTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for ragged paged attention v3 head_dim 64-w4a8"
-    key: "${TPU_VERSION:-tpu6e}_record_ragged_paged_attention_v3_head_dim_64-w4a8_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w4a8_PerformanceTest"
+        buildkite-agent meta-data set "${BK_KEY}_ragged_paged_attention_v3_head_dim_64-w4a8_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for ragged paged attention v3 head_dim 64-w4a8"
+    key: "${BK_KEY}_record_ragged_paged_attention_v3_head_dim_64-w4a8_PerformanceTest"
+    depends_on: "${BK_KEY}_ragged_paged_attention_v3_head_dim_64-w4a8_PerformanceTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "ragged paged attention v3 head_dim 64-w4a8"
       CI_STAGE: "PerformanceTest"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w4a8_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_ragged_paged_attention_v3_head_dim_64-w4a8_PerformanceTest

--- a/.buildkite/kernel_microbenchmarks/ragged_paged_attention_v3_head_dim_64/w4a8.yml
+++ b/.buildkite/kernel_microbenchmarks/ragged_paged_attention_v3_head_dim_64/w4a8.yml
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for ragged paged attention v3 head_dim 64-w4a8"
-    key: "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w4a8_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for ragged paged attention v3 head_dim 64-w4a8"
+    key: "${BK_KEY}_ragged_paged_attention_v3_head_dim_64-w4a8_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w4a8_CorrectnessTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for ragged paged attention v3 head_dim 64 w4a8"
-    key: "${TPU_VERSION:-tpu6e}_record_ragged_paged_attention_v3_head_dim_64-w4a8_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w4a8_CorrectnessTest"
+        buildkite-agent meta-data set "${BK_KEY}_ragged_paged_attention_v3_head_dim_64-w4a8_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for ragged paged attention v3 head_dim 64 w4a8"
+    key: "${BK_KEY}_record_ragged_paged_attention_v3_head_dim_64-w4a8_CorrectnessTest"
+    depends_on: "${BK_KEY}_ragged_paged_attention_v3_head_dim_64-w4a8_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "ragged paged attention v3 head_dim 64-w4a8"
       CI_STAGE: "CorrectnessTest"
@@ -33,21 +36,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w4a8_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_ragged_paged_attention_v3_head_dim_64-w4a8_CorrectnessTest
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for ragged paged attention v3 head_dim 64-w4a8"
-    key: "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w4a8_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_ragged_paged_attention_v3_head_dim_64-w4a8_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for ragged paged attention v3 head_dim 64-w4a8"
+    key: "${BK_KEY}_ragged_paged_attention_v3_head_dim_64-w4a8_PerformanceTest"
+    depends_on: "${BK_KEY}_record_ragged_paged_attention_v3_head_dim_64-w4a8_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w4a8_PerformanceTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for ragged paged attention v3 head_dim 64-w4a8"
-    key: "${TPU_VERSION:-tpu6e}_record_ragged_paged_attention_v3_head_dim_64-w4a8_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w4a8_PerformanceTest"
+        buildkite-agent meta-data set "${BK_KEY}_ragged_paged_attention_v3_head_dim_64-w4a8_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for ragged paged attention v3 head_dim 64-w4a8"
+    key: "${BK_KEY}_record_ragged_paged_attention_v3_head_dim_64-w4a8_PerformanceTest"
+    depends_on: "${BK_KEY}_ragged_paged_attention_v3_head_dim_64-w4a8_PerformanceTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "ragged paged attention v3 head_dim 64-w4a8"
       CI_STAGE: "PerformanceTest"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w4a8_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_ragged_paged_attention_v3_head_dim_64-w4a8_PerformanceTest

--- a/.buildkite/kernel_microbenchmarks/ragged_paged_attention_v3_head_dim_64/w8a16.yml
+++ b/.buildkite/kernel_microbenchmarks/ragged_paged_attention_v3_head_dim_64/w8a16.yml
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for ragged paged attention v3 head_dim 64-w8a16"
-    key: "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w8a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for ragged paged attention v3 head_dim 64-w8a16"
+    key: "${BK_KEY}_ragged_paged_attention_v3_head_dim_64-w8a16_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w8a16_CorrectnessTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for ragged paged attention v3 head_dim 64 w8a16"
-    key: "${TPU_VERSION:-tpu6e}_record_ragged_paged_attention_v3_head_dim_64-w8a16_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w8a16_CorrectnessTest"
+        buildkite-agent meta-data set "${BK_KEY}_ragged_paged_attention_v3_head_dim_64-w8a16_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for ragged paged attention v3 head_dim 64 w8a16"
+    key: "${BK_KEY}_record_ragged_paged_attention_v3_head_dim_64-w8a16_CorrectnessTest"
+    depends_on: "${BK_KEY}_ragged_paged_attention_v3_head_dim_64-w8a16_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "ragged paged attention v3 head_dim 64-w8a16"
       CI_STAGE: "CorrectnessTest"
@@ -33,21 +36,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w8a16_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_ragged_paged_attention_v3_head_dim_64-w8a16_CorrectnessTest
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for ragged paged attention v3 head_dim 64-w8a16"
-    key: "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w8a16_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_ragged_paged_attention_v3_head_dim_64-w8a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for ragged paged attention v3 head_dim 64-w8a16"
+    key: "${BK_KEY}_ragged_paged_attention_v3_head_dim_64-w8a16_PerformanceTest"
+    depends_on: "${BK_KEY}_record_ragged_paged_attention_v3_head_dim_64-w8a16_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w8a16_PerformanceTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for ragged paged attention v3 head_dim 64-w8a16"
-    key: "${TPU_VERSION:-tpu6e}_record_ragged_paged_attention_v3_head_dim_64-w8a16_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w8a16_PerformanceTest"
+        buildkite-agent meta-data set "${BK_KEY}_ragged_paged_attention_v3_head_dim_64-w8a16_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for ragged paged attention v3 head_dim 64-w8a16"
+    key: "${BK_KEY}_record_ragged_paged_attention_v3_head_dim_64-w8a16_PerformanceTest"
+    depends_on: "${BK_KEY}_ragged_paged_attention_v3_head_dim_64-w8a16_PerformanceTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "ragged paged attention v3 head_dim 64-w8a16"
       CI_STAGE: "PerformanceTest"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w8a16_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_ragged_paged_attention_v3_head_dim_64-w8a16_PerformanceTest

--- a/.buildkite/kernel_microbenchmarks/ragged_paged_attention_v3_head_dim_64/w8a16.yml
+++ b/.buildkite/kernel_microbenchmarks/ragged_paged_attention_v3_head_dim_64/w8a16.yml
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for ragged paged attention v3 head_dim 64-w8a16"
-    key: "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w8a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for ragged paged attention v3 head_dim 64-w8a16"
+    key: "${BK_KEY}_ragged_paged_attention_v3_head_dim_64-w8a16_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w8a16_CorrectnessTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for ragged paged attention v3 head_dim 64 w8a16"
-    key: "${TPU_VERSION:-tpu6e}_record_ragged_paged_attention_v3_head_dim_64-w8a16_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w8a16_CorrectnessTest"
+        buildkite-agent meta-data set "${BK_KEY}_ragged_paged_attention_v3_head_dim_64-w8a16_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for ragged paged attention v3 head_dim 64 w8a16"
+    key: "${BK_KEY}_record_ragged_paged_attention_v3_head_dim_64-w8a16_CorrectnessTest"
+    depends_on: "${BK_KEY}_ragged_paged_attention_v3_head_dim_64-w8a16_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "ragged paged attention v3 head_dim 64-w8a16"
       CI_STAGE: "CorrectnessTest"
@@ -33,21 +36,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w8a16_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_ragged_paged_attention_v3_head_dim_64-w8a16_CorrectnessTest
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for ragged paged attention v3 head_dim 64-w8a16"
-    key: "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w8a16_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_ragged_paged_attention_v3_head_dim_64-w8a16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for ragged paged attention v3 head_dim 64-w8a16"
+    key: "${BK_KEY}_ragged_paged_attention_v3_head_dim_64-w8a16_PerformanceTest"
+    depends_on: "${BK_KEY}_record_ragged_paged_attention_v3_head_dim_64-w8a16_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w8a16_PerformanceTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for ragged paged attention v3 head_dim 64-w8a16"
-    key: "${TPU_VERSION:-tpu6e}_record_ragged_paged_attention_v3_head_dim_64-w8a16_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w8a16_PerformanceTest"
+        buildkite-agent meta-data set "${BK_KEY}_ragged_paged_attention_v3_head_dim_64-w8a16_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for ragged paged attention v3 head_dim 64-w8a16"
+    key: "${BK_KEY}_record_ragged_paged_attention_v3_head_dim_64-w8a16_PerformanceTest"
+    depends_on: "${BK_KEY}_ragged_paged_attention_v3_head_dim_64-w8a16_PerformanceTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "ragged paged attention v3 head_dim 64-w8a16"
       CI_STAGE: "PerformanceTest"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w8a16_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_ragged_paged_attention_v3_head_dim_64-w8a16_PerformanceTest

--- a/.buildkite/kernel_microbenchmarks/ragged_paged_attention_v3_head_dim_64/w8a8.yml
+++ b/.buildkite/kernel_microbenchmarks/ragged_paged_attention_v3_head_dim_64/w8a8.yml
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for ragged paged attention v3 head_dim 64-w8a8"
-    key: "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w8a8_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for ragged paged attention v3 head_dim 64-w8a8"
+    key: "${BK_KEY}_ragged_paged_attention_v3_head_dim_64-w8a8_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w8a8_CorrectnessTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for ragged paged attention v3 head_dim 64 w8a8"
-    key: "${TPU_VERSION:-tpu6e}_record_ragged_paged_attention_v3_head_dim_64-w8a8_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w8a8_CorrectnessTest"
+        buildkite-agent meta-data set "${BK_KEY}_ragged_paged_attention_v3_head_dim_64-w8a8_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for ragged paged attention v3 head_dim 64 w8a8"
+    key: "${BK_KEY}_record_ragged_paged_attention_v3_head_dim_64-w8a8_CorrectnessTest"
+    depends_on: "${BK_KEY}_ragged_paged_attention_v3_head_dim_64-w8a8_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "ragged paged attention v3 head_dim 64-w8a8"
       CI_STAGE: "CorrectnessTest"
@@ -33,21 +36,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w8a8_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_ragged_paged_attention_v3_head_dim_64-w8a8_CorrectnessTest
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for ragged paged attention v3 head_dim 64-w8a8"
-    key: "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w8a8_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_ragged_paged_attention_v3_head_dim_64-w8a8_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for ragged paged attention v3 head_dim 64-w8a8"
+    key: "${BK_KEY}_ragged_paged_attention_v3_head_dim_64-w8a8_PerformanceTest"
+    depends_on: "${BK_KEY}_record_ragged_paged_attention_v3_head_dim_64-w8a8_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w8a8_PerformanceTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for ragged paged attention v3 head_dim 64-w8a8"
-    key: "${TPU_VERSION:-tpu6e}_record_ragged_paged_attention_v3_head_dim_64-w8a8_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w8a8_PerformanceTest"
+        buildkite-agent meta-data set "${BK_KEY}_ragged_paged_attention_v3_head_dim_64-w8a8_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for ragged paged attention v3 head_dim 64-w8a8"
+    key: "${BK_KEY}_record_ragged_paged_attention_v3_head_dim_64-w8a8_PerformanceTest"
+    depends_on: "${BK_KEY}_ragged_paged_attention_v3_head_dim_64-w8a8_PerformanceTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "ragged paged attention v3 head_dim 64-w8a8"
       CI_STAGE: "PerformanceTest"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w8a8_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_ragged_paged_attention_v3_head_dim_64-w8a8_PerformanceTest

--- a/.buildkite/kernel_microbenchmarks/ragged_paged_attention_v3_head_dim_64/w8a8.yml
+++ b/.buildkite/kernel_microbenchmarks/ragged_paged_attention_v3_head_dim_64/w8a8.yml
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for ragged paged attention v3 head_dim 64-w8a8"
-    key: "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w8a8_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for ragged paged attention v3 head_dim 64-w8a8"
+    key: "${BK_KEY}_ragged_paged_attention_v3_head_dim_64-w8a8_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w8a8_CorrectnessTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for ragged paged attention v3 head_dim 64 w8a8"
-    key: "${TPU_VERSION:-tpu6e}_record_ragged_paged_attention_v3_head_dim_64-w8a8_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w8a8_CorrectnessTest"
+        buildkite-agent meta-data set "${BK_KEY}_ragged_paged_attention_v3_head_dim_64-w8a8_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for ragged paged attention v3 head_dim 64 w8a8"
+    key: "${BK_KEY}_record_ragged_paged_attention_v3_head_dim_64-w8a8_CorrectnessTest"
+    depends_on: "${BK_KEY}_ragged_paged_attention_v3_head_dim_64-w8a8_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "ragged paged attention v3 head_dim 64-w8a8"
       CI_STAGE: "CorrectnessTest"
@@ -33,21 +36,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w8a8_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_ragged_paged_attention_v3_head_dim_64-w8a8_CorrectnessTest
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for ragged paged attention v3 head_dim 64-w8a8"
-    key: "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w8a8_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_ragged_paged_attention_v3_head_dim_64-w8a8_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for ragged paged attention v3 head_dim 64-w8a8"
+    key: "${BK_KEY}_ragged_paged_attention_v3_head_dim_64-w8a8_PerformanceTest"
+    depends_on: "${BK_KEY}_record_ragged_paged_attention_v3_head_dim_64-w8a8_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w8a8_PerformanceTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for ragged paged attention v3 head_dim 64-w8a8"
-    key: "${TPU_VERSION:-tpu6e}_record_ragged_paged_attention_v3_head_dim_64-w8a8_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w8a8_PerformanceTest"
+        buildkite-agent meta-data set "${BK_KEY}_ragged_paged_attention_v3_head_dim_64-w8a8_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for ragged paged attention v3 head_dim 64-w8a8"
+    key: "${BK_KEY}_record_ragged_paged_attention_v3_head_dim_64-w8a8_PerformanceTest"
+    depends_on: "${BK_KEY}_ragged_paged_attention_v3_head_dim_64-w8a8_PerformanceTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "ragged paged attention v3 head_dim 64-w8a8"
       CI_STAGE: "PerformanceTest"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w8a8_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_ragged_paged_attention_v3_head_dim_64-w8a8_PerformanceTest

--- a/.buildkite/models/MiniMaxAI_MiniMax-M2_5.yml
+++ b/.buildkite/models/MiniMaxAI_MiniMax-M2_5.yml
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Unit tests for MiniMaxAI/MiniMax-M2.5"
-    key: "${TPU_VERSION:-tpu6e}_MiniMaxAI_MiniMax-M2_5_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Unit tests for MiniMaxAI/MiniMax-M2.5"
+    key: "${BK_KEY}_MiniMaxAI_MiniMax-M2_5_UnitTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_MiniMaxAI_MiniMax-M2_5_UnitTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record unit test result for MiniMaxAI/MiniMax-M2.5"
-    key: "${TPU_VERSION:-tpu6e}_record_MiniMaxAI_MiniMax-M2_5_UnitTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_MiniMaxAI_MiniMax-M2_5_UnitTest"
+        buildkite-agent meta-data set "${BK_KEY}_MiniMaxAI_MiniMax-M2_5_UnitTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record unit test result for MiniMaxAI/MiniMax-M2.5"
+    key: "${BK_KEY}_record_MiniMaxAI_MiniMax-M2_5_UnitTest"
+    depends_on: "${BK_KEY}_MiniMaxAI_MiniMax-M2_5_UnitTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "MiniMaxAI/MiniMax-M2.5"
       CI_STAGE: "UnitTest"
@@ -33,25 +36,27 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_MiniMaxAI_MiniMax-M2_5_UnitTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_MiniMaxAI_MiniMax-M2_5_UnitTest
 
-  - label: "${TPU_VERSION:-tpu6e} Accuracy for MiniMaxAI/MiniMax-M2.5"
-    key: "${TPU_VERSION:-tpu6e}_MiniMaxAI_MiniMax-M2_5_Accuracy"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_MiniMaxAI_MiniMax-M2_5_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Accuracy for MiniMaxAI/MiniMax-M2.5"
+    key: "${BK_KEY}_MiniMaxAI_MiniMax-M2_5_Accuracy"
+    depends_on: "${BK_KEY}_record_MiniMaxAI_MiniMax-M2_5_UnitTest"
     soft_fail: true
     agents:
       queue: cpu  # TODO: replace with execution environment
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       TEST_MODEL: MiniMaxAI/MiniMax-M2.5
       TENSOR_PARALLEL_SIZE: "${TENSOR_PARALLEL_SIZE_SINGLE:-1}"
       MINIMUM_ACCURACY_THRESHOLD: 0  # TODO : replace 0 with your accuracy threshold
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_MiniMaxAI_MiniMax-M2_5_Accuracy" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record accuracy result for MiniMaxAI/MiniMax-M2.5"
-    key: "${TPU_VERSION:-tpu6e}_record_MiniMaxAI_MiniMax-M2_5_Accuracy"
-    depends_on: "${TPU_VERSION:-tpu6e}_MiniMaxAI_MiniMax-M2_5_Accuracy"
+        buildkite-agent meta-data set "${BK_KEY}_MiniMaxAI_MiniMax-M2_5_Accuracy" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record accuracy result for MiniMaxAI/MiniMax-M2.5"
+    key: "${BK_KEY}_record_MiniMaxAI_MiniMax-M2_5_Accuracy"
+    depends_on: "${BK_KEY}_MiniMaxAI_MiniMax-M2_5_Accuracy"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "MiniMaxAI/MiniMax-M2.5"
       CI_STAGE: "Accuracy/Correctness"
@@ -60,25 +65,27 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_MiniMaxAI_MiniMax-M2_5_Accuracy
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_MiniMaxAI_MiniMax-M2_5_Accuracy
 
-  - label: "${TPU_VERSION:-tpu6e} Performance benchmarks for MiniMaxAI/MiniMax-M2.5"
-    key: "${TPU_VERSION:-tpu6e}_MiniMaxAI_MiniMax-M2_5_Benchmark"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_MiniMaxAI_MiniMax-M2_5_Accuracy"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance benchmarks for MiniMaxAI/MiniMax-M2.5"
+    key: "${BK_KEY}_MiniMaxAI_MiniMax-M2_5_Benchmark"
+    depends_on: "${BK_KEY}_record_MiniMaxAI_MiniMax-M2_5_Accuracy"
     soft_fail: true
     agents:
       queue: cpu  # TODO: replace with execution environment
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       TEST_MODEL: MiniMaxAI/MiniMax-M2.5
       TENSOR_PARALLEL_SIZE: "${TENSOR_PARALLEL_SIZE_SINGLE:-1}"
       MINIMUM_THROUGHPUT_THRESHOLD: 0  # TODO : replace 0 with your performance threshold
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_MiniMaxAI_MiniMax-M2_5_Benchmark" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance benchmark result for MiniMaxAI/MiniMax-M2.5"
-    key: "${TPU_VERSION:-tpu6e}_record_MiniMaxAI_MiniMax-M2_5_Benchmark"
-    depends_on: "${TPU_VERSION:-tpu6e}_MiniMaxAI_MiniMax-M2_5_Benchmark"
+        buildkite-agent meta-data set "${BK_KEY}_MiniMaxAI_MiniMax-M2_5_Benchmark" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance benchmark result for MiniMaxAI/MiniMax-M2.5"
+    key: "${BK_KEY}_record_MiniMaxAI_MiniMax-M2_5_Benchmark"
+    depends_on: "${BK_KEY}_MiniMaxAI_MiniMax-M2_5_Benchmark"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "MiniMaxAI/MiniMax-M2.5"
       CI_STAGE: "Benchmark"
@@ -87,4 +94,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_MiniMaxAI_MiniMax-M2_5_Benchmark
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_MiniMaxAI_MiniMax-M2_5_Benchmark

--- a/.buildkite/models/MiniMaxAI_MiniMax-M2_5.yml
+++ b/.buildkite/models/MiniMaxAI_MiniMax-M2_5.yml
@@ -39,7 +39,7 @@ steps:
         .buildkite/scripts/record_step_result.sh ${BK_KEY}_MiniMaxAI_MiniMax-M2_5_UnitTest
 
   - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Accuracy for MiniMaxAI/MiniMax-M2.5"
-    key: "${BK_KEY}_MiniMaxAI_MiniMax-M2_5_Accuracy"
+    key: "${BK_KEY}_MiniMaxAI_MiniMax-M2_5_Accuracy_Correctness"
     depends_on: "${BK_KEY}_record_MiniMaxAI_MiniMax-M2_5_UnitTest"
     soft_fail: true
     agents:
@@ -51,10 +51,10 @@ steps:
       MINIMUM_ACCURACY_THRESHOLD: 0  # TODO : replace 0 with your accuracy threshold
     commands:
       - |
-        buildkite-agent meta-data set "${BK_KEY}_MiniMaxAI_MiniMax-M2_5_Accuracy" "unverified"
+        buildkite-agent meta-data set "${BK_KEY}_MiniMaxAI_MiniMax-M2_5_Accuracy_Correctness" "unverified"
   - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record accuracy result for MiniMaxAI/MiniMax-M2.5"
-    key: "${BK_KEY}_record_MiniMaxAI_MiniMax-M2_5_Accuracy"
-    depends_on: "${BK_KEY}_MiniMaxAI_MiniMax-M2_5_Accuracy"
+    key: "${BK_KEY}_record_MiniMaxAI_MiniMax-M2_5_Accuracy_Correctness"
+    depends_on: "${BK_KEY}_MiniMaxAI_MiniMax-M2_5_Accuracy_Correctness"
     env:
       MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
@@ -65,11 +65,11 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${BK_KEY}_MiniMaxAI_MiniMax-M2_5_Accuracy
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_MiniMaxAI_MiniMax-M2_5_Accuracy_Correctness
 
   - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance benchmarks for MiniMaxAI/MiniMax-M2.5"
     key: "${BK_KEY}_MiniMaxAI_MiniMax-M2_5_Benchmark"
-    depends_on: "${BK_KEY}_record_MiniMaxAI_MiniMax-M2_5_Accuracy"
+    depends_on: "${BK_KEY}_record_MiniMaxAI_MiniMax-M2_5_Accuracy_Correctness"
     soft_fail: true
     agents:
       queue: cpu  # TODO: replace with execution environment

--- a/.buildkite/models/Qwen_Qwen2_5-VL-7B-Instruct.yml
+++ b/.buildkite/models/Qwen_Qwen2_5-VL-7B-Instruct.yml
@@ -40,7 +40,7 @@ steps:
         .buildkite/scripts/record_step_result.sh ${BK_KEY}_Qwen_Qwen2_5-VL-7B-Instruct_UnitTest
 
   - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Accuracy for Qwen/Qwen2.5-VL-7B-Instruct"
-    key: "${BK_KEY}_Qwen_Qwen2_5-VL-7B-Instruct_Accuracy"
+    key: "${BK_KEY}_Qwen_Qwen2_5-VL-7B-Instruct_Accuracy_Correctness"
     depends_on: "${BK_KEY}_record_Qwen_Qwen2_5-VL-7B-Instruct_UnitTest"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
@@ -54,8 +54,8 @@ steps:
       - |
         .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/test_accuracy.sh
   - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record accuracy result for Qwen/Qwen2.5-VL-7B-Instruct"
-    key: "${BK_KEY}_record_Qwen_Qwen2_5-VL-7B-Instruct_Accuracy"
-    depends_on: "${BK_KEY}_Qwen_Qwen2_5-VL-7B-Instruct_Accuracy"
+    key: "${BK_KEY}_record_Qwen_Qwen2_5-VL-7B-Instruct_Accuracy_Correctness"
+    depends_on: "${BK_KEY}_Qwen_Qwen2_5-VL-7B-Instruct_Accuracy_Correctness"
     env:
       MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
@@ -66,11 +66,11 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${BK_KEY}_Qwen_Qwen2_5-VL-7B-Instruct_Accuracy
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_Qwen_Qwen2_5-VL-7B-Instruct_Accuracy_Correctness
 
   - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance benchmarks for Qwen/Qwen2.5-VL-7B-Instruct"
     key: "${BK_KEY}_Qwen_Qwen2_5-VL-7B-Instruct_Benchmark"
-    depends_on: "${BK_KEY}_record_Qwen_Qwen2_5-VL-7B-Instruct_Accuracy"
+    depends_on: "${BK_KEY}_record_Qwen_Qwen2_5-VL-7B-Instruct_Accuracy_Correctness"
     soft_fail: true
     env:
       MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"

--- a/.buildkite/models/Qwen_Qwen2_5-VL-7B-Instruct.yml
+++ b/.buildkite/models/Qwen_Qwen2_5-VL-7B-Instruct.yml
@@ -13,8 +13,10 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Unit tests for Qwen/Qwen2.5-VL-7B-Instruct"
-    key: "${TPU_VERSION:-tpu6e}_Qwen_Qwen2_5-VL-7B-Instruct_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Unit tests for Qwen/Qwen2.5-VL-7B-Instruct"
+    key: "${BK_KEY}_Qwen_Qwen2_5-VL-7B-Instruct_UnitTest"
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     soft_fail: true
@@ -22,10 +24,11 @@ steps:
       - |
         .buildkite/scripts/run_in_docker.sh \
           bash -c 'python3 -m pytest -s -v -x /workspace/tpu_inference/tests/models/jax/test_qwen2_5_vl.py'
-  - label: "${TPU_VERSION:-tpu6e} Record unit test result for Qwen/Qwen2.5-VL-7B-Instruct"
-    key: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen2_5-VL-7B-Instruct_UnitTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_Qwen_Qwen2_5-VL-7B-Instruct_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record unit test result for Qwen/Qwen2.5-VL-7B-Instruct"
+    key: "${BK_KEY}_record_Qwen_Qwen2_5-VL-7B-Instruct_UnitTest"
+    depends_on: "${BK_KEY}_Qwen_Qwen2_5-VL-7B-Instruct_UnitTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "Qwen/Qwen2.5-VL-7B-Instruct"
       CI_STAGE: "UnitTest"
@@ -34,25 +37,27 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_Qwen_Qwen2_5-VL-7B-Instruct_UnitTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_Qwen_Qwen2_5-VL-7B-Instruct_UnitTest
 
-  - label: "${TPU_VERSION:-tpu6e} Accuracy for Qwen/Qwen2.5-VL-7B-Instruct"
-    key: "${TPU_VERSION:-tpu6e}_Qwen_Qwen2_5-VL-7B-Instruct_Accuracy"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen2_5-VL-7B-Instruct_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Accuracy for Qwen/Qwen2.5-VL-7B-Instruct"
+    key: "${BK_KEY}_Qwen_Qwen2_5-VL-7B-Instruct_Accuracy"
+    depends_on: "${BK_KEY}_record_Qwen_Qwen2_5-VL-7B-Instruct_UnitTest"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     soft_fail: true
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       TEST_MODEL: Qwen/Qwen2.5-VL-7B-Instruct
       TENSOR_PARALLEL_SIZE: "${TENSOR_PARALLEL_SIZE_SINGLE:-1}"
       MINIMUM_ACCURACY_THRESHOLD: 0.72
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/test_accuracy.sh
-  - label: "${TPU_VERSION:-tpu6e} Record accuracy result for Qwen/Qwen2.5-VL-7B-Instruct"
-    key: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen2_5-VL-7B-Instruct_Accuracy"
-    depends_on: "${TPU_VERSION:-tpu6e}_Qwen_Qwen2_5-VL-7B-Instruct_Accuracy"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record accuracy result for Qwen/Qwen2.5-VL-7B-Instruct"
+    key: "${BK_KEY}_record_Qwen_Qwen2_5-VL-7B-Instruct_Accuracy"
+    depends_on: "${BK_KEY}_Qwen_Qwen2_5-VL-7B-Instruct_Accuracy"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "Qwen/Qwen2.5-VL-7B-Instruct"
       CI_STAGE: "Accuracy/Correctness"
@@ -61,21 +66,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_Qwen_Qwen2_5-VL-7B-Instruct_Accuracy
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_Qwen_Qwen2_5-VL-7B-Instruct_Accuracy
 
-  - label: "${TPU_VERSION:-tpu6e} Performance benchmarks for Qwen/Qwen2.5-VL-7B-Instruct"
-    key: "${TPU_VERSION:-tpu6e}_Qwen_Qwen2_5-VL-7B-Instruct_Benchmark"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen2_5-VL-7B-Instruct_Accuracy"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance benchmarks for Qwen/Qwen2.5-VL-7B-Instruct"
+    key: "${BK_KEY}_Qwen_Qwen2_5-VL-7B-Instruct_Benchmark"
+    depends_on: "${BK_KEY}_record_Qwen_Qwen2_5-VL-7B-Instruct_Accuracy"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/mm_bench_recipe.sh
-  - label: "${TPU_VERSION:-tpu6e} Record performance benchmark result for Qwen/Qwen2.5-VL-7B-Instruct"
-    key: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen2_5-VL-7B-Instruct_Benchmark"
-    depends_on: "${TPU_VERSION:-tpu6e}_Qwen_Qwen2_5-VL-7B-Instruct_Benchmark"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance benchmark result for Qwen/Qwen2.5-VL-7B-Instruct"
+    key: "${BK_KEY}_record_Qwen_Qwen2_5-VL-7B-Instruct_Benchmark"
+    depends_on: "${BK_KEY}_Qwen_Qwen2_5-VL-7B-Instruct_Benchmark"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "Qwen/Qwen2.5-VL-7B-Instruct"
       CI_STAGE: "Benchmark"
@@ -84,4 +92,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_Qwen_Qwen2_5-VL-7B-Instruct_Benchmark
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_Qwen_Qwen2_5-VL-7B-Instruct_Benchmark

--- a/.buildkite/models/Qwen_Qwen3-30B-A3B.yml
+++ b/.buildkite/models/Qwen_Qwen3-30B-A3B.yml
@@ -40,7 +40,7 @@ steps:
         .buildkite/scripts/record_step_result.sh ${BK_KEY}_Qwen_Qwen3-30B-A3B_UnitTest
 
   - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Accuracy for Qwen/Qwen3-30B-A3B"
-    key: "${BK_KEY}_Qwen_Qwen3-30B-A3B_Accuracy"
+    key: "${BK_KEY}_Qwen_Qwen3-30B-A3B_Accuracy_Correctness"
     depends_on: "${BK_KEY}_record_Qwen_Qwen3-30B-A3B_UnitTest"
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
@@ -54,8 +54,8 @@ steps:
       - |
         .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/test_accuracy.sh
   - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record accuracy result for Qwen/Qwen3-30B-A3B"
-    key: "${BK_KEY}_record_Qwen_Qwen3-30B-A3B_Accuracy"
-    depends_on: "${BK_KEY}_Qwen_Qwen3-30B-A3B_Accuracy"
+    key: "${BK_KEY}_record_Qwen_Qwen3-30B-A3B_Accuracy_Correctness"
+    depends_on: "${BK_KEY}_Qwen_Qwen3-30B-A3B_Accuracy_Correctness"
     env:
       MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
@@ -66,11 +66,11 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${BK_KEY}_Qwen_Qwen3-30B-A3B_Accuracy
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_Qwen_Qwen3-30B-A3B_Accuracy_Correctness
 
   - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance benchmarks for Qwen/Qwen3-30B-A3B"
     key: "${BK_KEY}_Qwen_Qwen3-30B-A3B_Benchmark"
-    depends_on: "${BK_KEY}_record_Qwen_Qwen3-30B-A3B_Accuracy"
+    depends_on: "${BK_KEY}_record_Qwen_Qwen3-30B-A3B_Accuracy_Correctness"
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"

--- a/.buildkite/models/Qwen_Qwen3-30B-A3B.yml
+++ b/.buildkite/models/Qwen_Qwen3-30B-A3B.yml
@@ -13,8 +13,10 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Unit tests for Qwen/Qwen3-30B-A3B"
-    key: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-30B-A3B_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Unit tests for Qwen/Qwen3-30B-A3B"
+    key: "${BK_KEY}_Qwen_Qwen3-30B-A3B_UnitTest"
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     soft_fail: true
@@ -22,10 +24,11 @@ steps:
       - |
         .buildkite/scripts/run_in_docker.sh \
           bash -c 'python3 -m pytest -s -v -x /workspace/tpu_inference/tests/models/jax/test_qwen3.py'
-  - label: "${TPU_VERSION:-tpu6e} Record unit test result for Qwen/Qwen3-30B-A3B"
-    key: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen3-30B-A3B_UnitTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-30B-A3B_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record unit test result for Qwen/Qwen3-30B-A3B"
+    key: "${BK_KEY}_record_Qwen_Qwen3-30B-A3B_UnitTest"
+    depends_on: "${BK_KEY}_Qwen_Qwen3-30B-A3B_UnitTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "Qwen/Qwen3-30B-A3B"
       CI_STAGE: "UnitTest"
@@ -34,11 +37,11 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_Qwen_Qwen3-30B-A3B_UnitTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_Qwen_Qwen3-30B-A3B_UnitTest
 
-  - label: "${TPU_VERSION:-tpu6e} Accuracy for Qwen/Qwen3-30B-A3B"
-    key: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-30B-A3B_Accuracy"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen3-30B-A3B_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Accuracy for Qwen/Qwen3-30B-A3B"
+    key: "${BK_KEY}_Qwen_Qwen3-30B-A3B_Accuracy"
+    depends_on: "${BK_KEY}_record_Qwen_Qwen3-30B-A3B_UnitTest"
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
     soft_fail: true
@@ -50,10 +53,11 @@ steps:
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/test_accuracy.sh
-  - label: "${TPU_VERSION:-tpu6e} Record accuracy result for Qwen/Qwen3-30B-A3B"
-    key: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen3-30B-A3B_Accuracy"
-    depends_on: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-30B-A3B_Accuracy"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record accuracy result for Qwen/Qwen3-30B-A3B"
+    key: "${BK_KEY}_record_Qwen_Qwen3-30B-A3B_Accuracy"
+    depends_on: "${BK_KEY}_Qwen_Qwen3-30B-A3B_Accuracy"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "Qwen/Qwen3-30B-A3B"
       CI_STAGE: "Accuracy/Correctness"
@@ -62,11 +66,11 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_Qwen_Qwen3-30B-A3B_Accuracy
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_Qwen_Qwen3-30B-A3B_Accuracy
 
-  - label: "${TPU_VERSION:-tpu6e} Performance benchmarks for Qwen/Qwen3-30B-A3B"
-    key: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-30B-A3B_Benchmark"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen3-30B-A3B_Accuracy"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance benchmarks for Qwen/Qwen3-30B-A3B"
+    key: "${BK_KEY}_Qwen_Qwen3-30B-A3B_Benchmark"
+    depends_on: "${BK_KEY}_record_Qwen_Qwen3-30B-A3B_Accuracy"
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
@@ -84,10 +88,11 @@ steps:
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/benchmark.sh
-  - label: "${TPU_VERSION:-tpu6e} Record performance benchmark result for Qwen/Qwen3-30B-A3B"
-    key: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen3-30B-A3B_Benchmark"
-    depends_on: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-30B-A3B_Benchmark"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance benchmark result for Qwen/Qwen3-30B-A3B"
+    key: "${BK_KEY}_record_Qwen_Qwen3-30B-A3B_Benchmark"
+    depends_on: "${BK_KEY}_Qwen_Qwen3-30B-A3B_Benchmark"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "Qwen/Qwen3-30B-A3B"
       CI_STAGE: "Benchmark"
@@ -96,4 +101,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_Qwen_Qwen3-30B-A3B_Benchmark
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_Qwen_Qwen3-30B-A3B_Benchmark

--- a/.buildkite/models/Qwen_Qwen3-32B.yml
+++ b/.buildkite/models/Qwen_Qwen3-32B.yml
@@ -13,19 +13,22 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Unit tests for Qwen/Qwen3-32B"
-    key: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-32B_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Unit tests for Qwen/Qwen3-32B"
+    key: "${BK_KEY}_Qwen_Qwen3-32B_UnitTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh \
           bash -c 'python3 -m pytest -s -v -x /workspace/tpu_inference/tests/models/jax/test_qwen3.py'
-  - label: "${TPU_VERSION:-tpu6e} Record unit test result for Qwen/Qwen3-32B"
-    key: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen3-32B_UnitTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-32B_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record unit test result for Qwen/Qwen3-32B"
+    key: "${BK_KEY}_record_Qwen_Qwen3-32B_UnitTest"
+    depends_on: "${BK_KEY}_Qwen_Qwen3-32B_UnitTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "Qwen/Qwen3-32B"
       CI_STAGE: "UnitTest"
@@ -34,25 +37,27 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_Qwen_Qwen3-32B_UnitTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_Qwen_Qwen3-32B_UnitTest
 
-  - label: "${TPU_VERSION:-tpu6e} Accuracy for Qwen/Qwen3-32B"
-    key: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-32B_Accuracy"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen3-32B_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Accuracy for Qwen/Qwen3-32B"
+    key: "${BK_KEY}_Qwen_Qwen3-32B_Accuracy"
+    depends_on: "${BK_KEY}_record_Qwen_Qwen3-32B_UnitTest"
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
     soft_fail: true
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       TEST_MODEL: Qwen/Qwen3-32B
       TENSOR_PARALLEL_SIZE: "${TENSOR_PARALLEL_SIZE_MULTI:-8}"
       MINIMUM_ACCURACY_THRESHOLD: 0.74
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/test_accuracy.sh
-  - label: "${TPU_VERSION:-tpu6e} Record accuracy result for Qwen/Qwen3-32B"
-    key: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen3-32B_Accuracy"
-    depends_on: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-32B_Accuracy"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record accuracy result for Qwen/Qwen3-32B"
+    key: "${BK_KEY}_record_Qwen_Qwen3-32B_Accuracy"
+    depends_on: "${BK_KEY}_Qwen_Qwen3-32B_Accuracy"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "Qwen/Qwen3-32B"
       CI_STAGE: "Accuracy/Correctness"
@@ -61,15 +66,16 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_Qwen_Qwen3-32B_Accuracy
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_Qwen_Qwen3-32B_Accuracy
 
-  - label: "${TPU_VERSION:-tpu6e} Performance benchmarks for Qwen/Qwen3-32B"
-    key: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-32B_Benchmark"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen3-32B_Accuracy"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance benchmarks for Qwen/Qwen3-32B"
+    key: "${BK_KEY}_Qwen_Qwen3-32B_Benchmark"
+    depends_on: "${BK_KEY}_record_Qwen_Qwen3-32B_Accuracy"
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
     soft_fail: true
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       TEST_MODEL: Qwen/Qwen3-32B
       TENSOR_PARALLEL_SIZE: "${TENSOR_PARALLEL_SIZE_MULTI:-8}"
       MINIMUM_THROUGHPUT_THRESHOLD: 12.46
@@ -82,10 +88,11 @@ steps:
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/benchmark.sh
-  - label: "${TPU_VERSION:-tpu6e} Record performance benchmark result for Qwen/Qwen3-32B"
-    key: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen3-32B_Benchmark"
-    depends_on: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-32B_Benchmark"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance benchmark result for Qwen/Qwen3-32B"
+    key: "${BK_KEY}_record_Qwen_Qwen3-32B_Benchmark"
+    depends_on: "${BK_KEY}_Qwen_Qwen3-32B_Benchmark"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "Qwen/Qwen3-32B"
       CI_STAGE: "Benchmark"
@@ -94,4 +101,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_Qwen_Qwen3-32B_Benchmark
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_Qwen_Qwen3-32B_Benchmark

--- a/.buildkite/models/Qwen_Qwen3-32B.yml
+++ b/.buildkite/models/Qwen_Qwen3-32B.yml
@@ -40,7 +40,7 @@ steps:
         .buildkite/scripts/record_step_result.sh ${BK_KEY}_Qwen_Qwen3-32B_UnitTest
 
   - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Accuracy for Qwen/Qwen3-32B"
-    key: "${BK_KEY}_Qwen_Qwen3-32B_Accuracy"
+    key: "${BK_KEY}_Qwen_Qwen3-32B_Accuracy_Correctness"
     depends_on: "${BK_KEY}_record_Qwen_Qwen3-32B_UnitTest"
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
@@ -54,8 +54,8 @@ steps:
       - |
         .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/test_accuracy.sh
   - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record accuracy result for Qwen/Qwen3-32B"
-    key: "${BK_KEY}_record_Qwen_Qwen3-32B_Accuracy"
-    depends_on: "${BK_KEY}_Qwen_Qwen3-32B_Accuracy"
+    key: "${BK_KEY}_record_Qwen_Qwen3-32B_Accuracy_Correctness"
+    depends_on: "${BK_KEY}_Qwen_Qwen3-32B_Accuracy_Correctness"
     env:
       MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
@@ -66,11 +66,11 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${BK_KEY}_Qwen_Qwen3-32B_Accuracy
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_Qwen_Qwen3-32B_Accuracy_Correctness
 
   - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance benchmarks for Qwen/Qwen3-32B"
     key: "${BK_KEY}_Qwen_Qwen3-32B_Benchmark"
-    depends_on: "${BK_KEY}_record_Qwen_Qwen3-32B_Accuracy"
+    depends_on: "${BK_KEY}_record_Qwen_Qwen3-32B_Accuracy_Correctness"
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
     soft_fail: true

--- a/.buildkite/models/Qwen_Qwen3-4B.yml
+++ b/.buildkite/models/Qwen_Qwen3-4B.yml
@@ -13,19 +13,22 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Unit tests for Qwen/Qwen3-4B"
-    key: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-4B_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Unit tests for Qwen/Qwen3-4B"
+    key: "${BK_KEY}_Qwen_Qwen3-4B_UnitTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh \
           bash -c 'python3 -m pytest -s -v -x /workspace/tpu_inference/tests/models/jax/test_qwen3.py'
-  - label: "${TPU_VERSION:-tpu6e} Record unit test result for Qwen/Qwen3-4B"
-    key: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen3-4B_UnitTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-4B_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record unit test result for Qwen/Qwen3-4B"
+    key: "${BK_KEY}_record_Qwen_Qwen3-4B_UnitTest"
+    depends_on: "${BK_KEY}_Qwen_Qwen3-4B_UnitTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "Qwen/Qwen3-4B"
       CI_STAGE: "UnitTest"
@@ -34,25 +37,27 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_Qwen_Qwen3-4B_UnitTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_Qwen_Qwen3-4B_UnitTest
 
-  - label: "${TPU_VERSION:-tpu6e} Accuracy for Qwen/Qwen3-4B"
-    key: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-4B_Accuracy"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen3-4B_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Accuracy for Qwen/Qwen3-4B"
+    key: "${BK_KEY}_Qwen_Qwen3-4B_Accuracy"
+    depends_on: "${BK_KEY}_record_Qwen_Qwen3-4B_UnitTest"
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       TEST_MODEL: Qwen/Qwen3-4B
       TENSOR_PARALLEL_SIZE: "${TENSOR_PARALLEL_SIZE_SINGLE:-1}"
       MINIMUM_ACCURACY_THRESHOLD: 0.85
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/test_accuracy.sh
-  - label: "${TPU_VERSION:-tpu6e} Record accuracy test result for Qwen/Qwen3-4B"
-    key: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen3-4B_Accuracy"
-    depends_on: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-4B_Accuracy"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record accuracy test result for Qwen/Qwen3-4B"
+    key: "${BK_KEY}_record_Qwen_Qwen3-4B_Accuracy"
+    depends_on: "${BK_KEY}_Qwen_Qwen3-4B_Accuracy"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "Qwen/Qwen3-4B"
       CI_STAGE: "Accuracy/Correctness"
@@ -61,15 +66,16 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_Qwen_Qwen3-4B_Accuracy
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_Qwen_Qwen3-4B_Accuracy
 
-  - label: "${TPU_VERSION:-tpu6e} Performance benchmarks for Qwen/Qwen3-4B"
-    key: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-4B_Benchmark"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen3-4B_Accuracy"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance benchmarks for Qwen/Qwen3-4B"
+    key: "${BK_KEY}_Qwen_Qwen3-4B_Benchmark"
+    depends_on: "${BK_KEY}_record_Qwen_Qwen3-4B_Accuracy"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     soft_fail: true
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       TEST_MODEL: Qwen/Qwen3-4B
       TENSOR_PARALLEL_SIZE: "${TENSOR_PARALLEL_SIZE_SINGLE:-1}"
       MINIMUM_THROUGHPUT_THRESHOLD: 11.00
@@ -82,10 +88,11 @@ steps:
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/benchmark.sh
-  - label: "${TPU_VERSION:-tpu6e} Record performance benchmark result for Qwen/Qwen3-4B"
-    key: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen3-4B_Benchmark"
-    depends_on: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-4B_Benchmark"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance benchmark result for Qwen/Qwen3-4B"
+    key: "${BK_KEY}_record_Qwen_Qwen3-4B_Benchmark"
+    depends_on: "${BK_KEY}_Qwen_Qwen3-4B_Benchmark"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "Qwen/Qwen3-4B"
       CI_STAGE: "Benchmark"
@@ -94,4 +101,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_Qwen_Qwen3-4B_Benchmark
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_Qwen_Qwen3-4B_Benchmark

--- a/.buildkite/models/Qwen_Qwen3-4B.yml
+++ b/.buildkite/models/Qwen_Qwen3-4B.yml
@@ -40,7 +40,7 @@ steps:
         .buildkite/scripts/record_step_result.sh ${BK_KEY}_Qwen_Qwen3-4B_UnitTest
 
   - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Accuracy for Qwen/Qwen3-4B"
-    key: "${BK_KEY}_Qwen_Qwen3-4B_Accuracy"
+    key: "${BK_KEY}_Qwen_Qwen3-4B_Accuracy_Correctness"
     depends_on: "${BK_KEY}_record_Qwen_Qwen3-4B_UnitTest"
     soft_fail: true
     agents:
@@ -54,8 +54,8 @@ steps:
       - |
         .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/test_accuracy.sh
   - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record accuracy test result for Qwen/Qwen3-4B"
-    key: "${BK_KEY}_record_Qwen_Qwen3-4B_Accuracy"
-    depends_on: "${BK_KEY}_Qwen_Qwen3-4B_Accuracy"
+    key: "${BK_KEY}_record_Qwen_Qwen3-4B_Accuracy_Correctness"
+    depends_on: "${BK_KEY}_Qwen_Qwen3-4B_Accuracy_Correctness"
     env:
       MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
@@ -66,11 +66,11 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${BK_KEY}_Qwen_Qwen3-4B_Accuracy
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_Qwen_Qwen3-4B_Accuracy_Correctness
 
   - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance benchmarks for Qwen/Qwen3-4B"
     key: "${BK_KEY}_Qwen_Qwen3-4B_Benchmark"
-    depends_on: "${BK_KEY}_record_Qwen_Qwen3-4B_Accuracy"
+    depends_on: "${BK_KEY}_record_Qwen_Qwen3-4B_Accuracy_Correctness"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     soft_fail: true

--- a/.buildkite/models/Qwen_Qwen3-Coder-480B-A35B-Instruct.yml
+++ b/.buildkite/models/Qwen_Qwen3-Coder-480B-A35B-Instruct.yml
@@ -44,7 +44,7 @@ steps:
         .buildkite/scripts/record_step_result.sh ${BK_KEY}_Qwen_Qwen3-Coder-480B-A35B-Instruct_UnitTest
 
   - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Accuracy for Qwen/Qwen3-Coder-480B-A35B-Instruct"
-    key: "${BK_KEY}_Qwen_Qwen3-Coder-480B-A35B-Instruct_Accuracy"
+    key: "${BK_KEY}_Qwen_Qwen3-Coder-480B-A35B-Instruct_Accuracy_Correctness"
     depends_on: "${BK_KEY}_record_Qwen_Qwen3-Coder-480B-A35B-Instruct_UnitTest"
     env:
       MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
@@ -54,13 +54,13 @@ steps:
     commands:
       - |
         if [ "${TPU_VERSION:-tpu6e}" = "tpu6e" ]; then
-          buildkite-agent meta-data set "${BK_KEY}_Qwen_Qwen3-Coder-480B-A35B-Instruct_Accuracy" "not enough HBM"
+          buildkite-agent meta-data set "${BK_KEY}_Qwen_Qwen3-Coder-480B-A35B-Instruct_Accuracy_Correctness" "not enough HBM"
         else
           .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/check_lm_eval.sh  --model_name "Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8" --use_moe_ep_kernel 0 --tensor_parallel_size 8 --max_model_len 2048 --max_num_batched_tokens 2048 --max_gen_toks 256 --enable_expert_parallel 1 --flex_threshold 0.85 --strict_threshold 0.70
         fi
   - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record integration test result for Qwen/Qwen3-Coder-480B-A35B-Instruct"
-    key: "${BK_KEY}_record_Qwen_Qwen3-Coder-480B-A35B-Instruct_Accuracy"
-    depends_on: "${BK_KEY}_Qwen_Qwen3-Coder-480B-A35B-Instruct_Accuracy"
+    key: "${BK_KEY}_record_Qwen_Qwen3-Coder-480B-A35B-Instruct_Accuracy_Correctness"
+    depends_on: "${BK_KEY}_Qwen_Qwen3-Coder-480B-A35B-Instruct_Accuracy_Correctness"
     env:
       MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
@@ -71,11 +71,11 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${BK_KEY}_Qwen_Qwen3-Coder-480B-A35B-Instruct_Accuracy
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_Qwen_Qwen3-Coder-480B-A35B-Instruct_Accuracy_Correctness
 
   - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance benchmarks for Qwen/Qwen3-Coder-480B-A35B-Instruct"
     key: "${BK_KEY}_Qwen_Qwen3-Coder-480B-A35B-Instruct_Benchmark"
-    depends_on: "${BK_KEY}_record_Qwen_Qwen3-Coder-480B-A35B-Instruct_Accuracy"
+    depends_on: "${BK_KEY}_record_Qwen_Qwen3-Coder-480B-A35B-Instruct_Accuracy_Correctness"
     env:
       MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:

--- a/.buildkite/models/Qwen_Qwen3-Coder-480B-A35B-Instruct.yml
+++ b/.buildkite/models/Qwen_Qwen3-Coder-480B-A35B-Instruct.yml
@@ -13,23 +13,26 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Unit tests for Qwen/Qwen3-Coder-480B-A35B-Instruct"
-    key: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-Coder-480B-A35B-Instruct_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Unit tests for Qwen/Qwen3-Coder-480B-A35B-Instruct"
+    key: "${BK_KEY}_Qwen_Qwen3-Coder-480B-A35B-Instruct_UnitTest"
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
     soft_fail: true
     commands:
        - |
         if [ "${TPU_VERSION:-tpu6e}" = "tpu6e" ]; then
-          buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-Coder-480B-A35B-Instruct_UnitTest" "not enough HBM"
+          buildkite-agent meta-data set "${BK_KEY}_Qwen_Qwen3-Coder-480B-A35B-Instruct_UnitTest" "not enough HBM"
         else
           .buildkite/scripts/run_in_docker.sh \
             bash -c 'SKIP_JAX_PRECOMPILE=1 VLLM_XLA_CHECK_RECOMPILATION=0 MODEL_IMPL_TYPE=vllm python /workspace/tpu_inference/examples/offline_inference.py --model Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8 --tensor-parallel-size 8 --enable-expert-parallel  --max-num-batched-tokens 256 --max-num-seqs 256'
         fi
-  - label: "${TPU_VERSION:-tpu6e} Record unit test result for Qwen/Qwen3-Coder-480B-A35B-Instruct"
-    key: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen3-Coder-480B-A35B-Instruct_UnitTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-Coder-480B-A35B-Instruct_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record unit test result for Qwen/Qwen3-Coder-480B-A35B-Instruct"
+    key: "${BK_KEY}_record_Qwen_Qwen3-Coder-480B-A35B-Instruct_UnitTest"
+    depends_on: "${BK_KEY}_Qwen_Qwen3-Coder-480B-A35B-Instruct_UnitTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "Qwen/Qwen3-Coder-480B-A35B-Instruct"
       CI_STAGE: "UnitTest"
@@ -38,25 +41,28 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_Qwen_Qwen3-Coder-480B-A35B-Instruct_UnitTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_Qwen_Qwen3-Coder-480B-A35B-Instruct_UnitTest
 
-  - label: "${TPU_VERSION:-tpu6e} Accuracy for Qwen/Qwen3-Coder-480B-A35B-Instruct"
-    key: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-Coder-480B-A35B-Instruct_Accuracy"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen3-Coder-480B-A35B-Instruct_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Accuracy for Qwen/Qwen3-Coder-480B-A35B-Instruct"
+    key: "${BK_KEY}_Qwen_Qwen3-Coder-480B-A35B-Instruct_Accuracy"
+    depends_on: "${BK_KEY}_record_Qwen_Qwen3-Coder-480B-A35B-Instruct_UnitTest"
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
     soft_fail: true
     commands:
       - |
         if [ "${TPU_VERSION:-tpu6e}" = "tpu6e" ]; then
-          buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-Coder-480B-A35B-Instruct_Accuracy" "not enough HBM"
+          buildkite-agent meta-data set "${BK_KEY}_Qwen_Qwen3-Coder-480B-A35B-Instruct_Accuracy" "not enough HBM"
         else
           .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/check_lm_eval.sh  --model_name "Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8" --use_moe_ep_kernel 0 --tensor_parallel_size 8 --max_model_len 2048 --max_num_batched_tokens 2048 --max_gen_toks 256 --enable_expert_parallel 1 --flex_threshold 0.85 --strict_threshold 0.70
         fi
-  - label: "${TPU_VERSION:-tpu6e} Record integration test result for Qwen/Qwen3-Coder-480B-A35B-Instruct"
-    key: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen3-Coder-480B-A35B-Instruct_Accuracy"
-    depends_on: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-Coder-480B-A35B-Instruct_Accuracy"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record integration test result for Qwen/Qwen3-Coder-480B-A35B-Instruct"
+    key: "${BK_KEY}_record_Qwen_Qwen3-Coder-480B-A35B-Instruct_Accuracy"
+    depends_on: "${BK_KEY}_Qwen_Qwen3-Coder-480B-A35B-Instruct_Accuracy"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "Qwen/Qwen3-Coder-480B-A35B-Instruct"
       CI_STAGE: "Accuracy/Correctness"
@@ -65,25 +71,28 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_Qwen_Qwen3-Coder-480B-A35B-Instruct_Accuracy
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_Qwen_Qwen3-Coder-480B-A35B-Instruct_Accuracy
 
-  - label: "${TPU_VERSION:-tpu6e} Performance benchmarks for Qwen/Qwen3-Coder-480B-A35B-Instruct"
-    key: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-Coder-480B-A35B-Instruct_Benchmark"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen3-Coder-480B-A35B-Instruct_Accuracy"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance benchmarks for Qwen/Qwen3-Coder-480B-A35B-Instruct"
+    key: "${BK_KEY}_Qwen_Qwen3-Coder-480B-A35B-Instruct_Benchmark"
+    depends_on: "${BK_KEY}_record_Qwen_Qwen3-Coder-480B-A35B-Instruct_Accuracy"
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
     soft_fail: true
     commands:
       - |
         if [ "${TPU_VERSION:-tpu6e}" = "tpu6e" ]; then
-          buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-Coder-480B-A35B-Instruct_Benchmark" "not enough HBM"
+          buildkite-agent meta-data set "${BK_KEY}_Qwen_Qwen3-Coder-480B-A35B-Instruct_Benchmark" "not enough HBM"
         else
           .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/bm_qwen3_coder.sh --model Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8 --tp 8 --req_tput_limit 0.16  --output_token_tput_limit 1226 --total_token_tput_limit 1378 --input_len 1024 --output_len 8192 --use_moe_ep_kernel 0
         fi
-  - label: "${TPU_VERSION:-tpu6e} Record performance benchmark result for Qwen/Qwen3-Coder-480B-A35B-Instruct"
-    key: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen3-Coder-480B-A35B-Instruct_Benchmark"
-    depends_on: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-Coder-480B-A35B-Instruct_Benchmark"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance benchmark result for Qwen/Qwen3-Coder-480B-A35B-Instruct"
+    key: "${BK_KEY}_record_Qwen_Qwen3-Coder-480B-A35B-Instruct_Benchmark"
+    depends_on: "${BK_KEY}_Qwen_Qwen3-Coder-480B-A35B-Instruct_Benchmark"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "Qwen/Qwen3-Coder-480B-A35B-Instruct"
       CI_STAGE: "Benchmark"
@@ -92,4 +101,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_Qwen_Qwen3-Coder-480B-A35B-Instruct_Benchmark
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_Qwen_Qwen3-Coder-480B-A35B-Instruct_Benchmark

--- a/.buildkite/models/Qwen_Qwen3-Embedding-8B.yml
+++ b/.buildkite/models/Qwen_Qwen3-Embedding-8B.yml
@@ -38,7 +38,7 @@ steps:
         .buildkite/scripts/record_step_result.sh ${BK_KEY}_Qwen_Qwen3-Embedding-8B_UnitTest
 
   - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Accuracy for Qwen/Qwen3-Embedding-8B"
-    key: "${BK_KEY}_Qwen_Qwen3-Embedding-8B_Accuracy"
+    key: "${BK_KEY}_Qwen_Qwen3-Embedding-8B_Accuracy_Correctness"
     depends_on: "${BK_KEY}_record_Qwen_Qwen3-Embedding-8B_UnitTest"
     soft_fail: true
     agents:
@@ -51,8 +51,8 @@ steps:
       - |
         .buildkite/scripts/run_in_docker.sh python3 -m pytest -s -v /workspace/tpu_inference/tests/e2e/test_step_pooling.py
   - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record accuracy result for Qwen/Qwen3-Embedding-8B"
-    key: "${BK_KEY}_record_Qwen_Qwen3-Embedding-8B_Accuracy"
-    depends_on: "${BK_KEY}_Qwen_Qwen3-Embedding-8B_Accuracy"
+    key: "${BK_KEY}_record_Qwen_Qwen3-Embedding-8B_Accuracy_Correctness"
+    depends_on: "${BK_KEY}_Qwen_Qwen3-Embedding-8B_Accuracy_Correctness"
     env:
       MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
@@ -63,11 +63,11 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${BK_KEY}_Qwen_Qwen3-Embedding-8B_Accuracy
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_Qwen_Qwen3-Embedding-8B_Accuracy_Correctness
 
   - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance benchmarks for Qwen/Qwen3-Embedding-8B"
     key: "${BK_KEY}_Qwen_Qwen3-Embedding-8B_Benchmark"
-    depends_on: "${BK_KEY}_record_Qwen_Qwen3-Embedding-8B_Accuracy"
+    depends_on: "${BK_KEY}_record_Qwen_Qwen3-Embedding-8B_Accuracy_Correctness"
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"

--- a/.buildkite/models/Qwen_Qwen3-Embedding-8B.yml
+++ b/.buildkite/models/Qwen_Qwen3-Embedding-8B.yml
@@ -13,17 +13,20 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Unit tests for Qwen/Qwen3-Embedding-8B"
-    key: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-Embedding-8B_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Unit tests for Qwen/Qwen3-Embedding-8B"
+    key: "${BK_KEY}_Qwen_Qwen3-Embedding-8B_UnitTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - .buildkite/scripts/run_in_docker.sh python3 -m pytest -s -v /workspace/tpu_inference/tests/models/jax/test_qwen3.py::TestQwen3ForCausalLM::test_vocab_padding_for_sharding
-  - label: "${TPU_VERSION:-tpu6e} Record unit test result for Qwen/Qwen3-Embedding-8B"
-    key: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen3-Embedding-8B_UnitTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-Embedding-8B_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record unit test result for Qwen/Qwen3-Embedding-8B"
+    key: "${BK_KEY}_record_Qwen_Qwen3-Embedding-8B_UnitTest"
+    depends_on: "${BK_KEY}_Qwen_Qwen3-Embedding-8B_UnitTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "Qwen/Qwen3-Embedding-8B"
       CI_STAGE: "UnitTest"
@@ -32,24 +35,26 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_Qwen_Qwen3-Embedding-8B_UnitTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_Qwen_Qwen3-Embedding-8B_UnitTest
 
-  - label: "${TPU_VERSION:-tpu6e} Accuracy for Qwen/Qwen3-Embedding-8B"
-    key: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-Embedding-8B_Accuracy"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen3-Embedding-8B_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Accuracy for Qwen/Qwen3-Embedding-8B"
+    key: "${BK_KEY}_Qwen_Qwen3-Embedding-8B_Accuracy"
+    depends_on: "${BK_KEY}_record_Qwen_Qwen3-Embedding-8B_UnitTest"
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       TEST_MODEL: Qwen/Qwen3-Embedding-8B
       TENSOR_PARALLEL_SIZE: "${TENSOR_PARALLEL_SIZE_SINGLE:-1}"
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh python3 -m pytest -s -v /workspace/tpu_inference/tests/e2e/test_step_pooling.py
-  - label: "${TPU_VERSION:-tpu6e} Record accuracy result for Qwen/Qwen3-Embedding-8B"
-    key: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen3-Embedding-8B_Accuracy"
-    depends_on: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-Embedding-8B_Accuracy"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record accuracy result for Qwen/Qwen3-Embedding-8B"
+    key: "${BK_KEY}_record_Qwen_Qwen3-Embedding-8B_Accuracy"
+    depends_on: "${BK_KEY}_Qwen_Qwen3-Embedding-8B_Accuracy"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "Qwen/Qwen3-Embedding-8B"
       CI_STAGE: "Accuracy/Correctness"
@@ -58,24 +63,26 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_Qwen_Qwen3-Embedding-8B_Accuracy
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_Qwen_Qwen3-Embedding-8B_Accuracy
 
-  - label: "${TPU_VERSION:-tpu6e} Performance benchmarks for Qwen/Qwen3-Embedding-8B"
-    key: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-Embedding-8B_Benchmark"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen3-Embedding-8B_Accuracy"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance benchmarks for Qwen/Qwen3-Embedding-8B"
+    key: "${BK_KEY}_Qwen_Qwen3-Embedding-8B_Benchmark"
+    depends_on: "${BK_KEY}_record_Qwen_Qwen3-Embedding-8B_Accuracy"
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       TEST_MODEL: Qwen/Qwen3-Embedding-8B
       TENSOR_PARALLEL_SIZE: "${TENSOR_PARALLEL_SIZE_SINGLE:-1}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-Embedding-8B_Benchmark" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance benchmark result for Qwen/Qwen3-Embedding-8B"
-    key: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen3-Embedding-8B_Benchmark"
-    depends_on: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-Embedding-8B_Benchmark"
+        buildkite-agent meta-data set "${BK_KEY}_Qwen_Qwen3-Embedding-8B_Benchmark" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance benchmark result for Qwen/Qwen3-Embedding-8B"
+    key: "${BK_KEY}_record_Qwen_Qwen3-Embedding-8B_Benchmark"
+    depends_on: "${BK_KEY}_Qwen_Qwen3-Embedding-8B_Benchmark"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "Qwen/Qwen3-Embedding-8B"
       CI_STAGE: "Benchmark"
@@ -84,4 +91,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_Qwen_Qwen3-Embedding-8B_Benchmark
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_Qwen_Qwen3-Embedding-8B_Benchmark

--- a/.buildkite/models/Qwen_Qwen3-Embedding-8B.yml
+++ b/.buildkite/models/Qwen_Qwen3-Embedding-8B.yml
@@ -13,17 +13,20 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Unit tests for Qwen/Qwen3-Embedding-8B"
-    key: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-Embedding-8B_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Unit tests for Qwen/Qwen3-Embedding-8B"
+    key: "${BK_KEY}_Qwen_Qwen3-Embedding-8B_UnitTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - .buildkite/scripts/run_in_docker.sh python3 -m pytest -s -v /workspace/tpu_inference/tests/models/jax/test_qwen3.py::TestQwen3ForCausalLM::test_vocab_padding_for_sharding
-  - label: "${TPU_VERSION:-tpu6e} Record unit test result for Qwen/Qwen3-Embedding-8B"
-    key: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen3-Embedding-8B_UnitTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-Embedding-8B_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record unit test result for Qwen/Qwen3-Embedding-8B"
+    key: "${BK_KEY}_record_Qwen_Qwen3-Embedding-8B_UnitTest"
+    depends_on: "${BK_KEY}_Qwen_Qwen3-Embedding-8B_UnitTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "Qwen/Qwen3-Embedding-8B"
       CI_STAGE: "UnitTest"
@@ -32,24 +35,26 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_Qwen_Qwen3-Embedding-8B_UnitTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_Qwen_Qwen3-Embedding-8B_UnitTest
 
-  - label: "${TPU_VERSION:-tpu6e} Accuracy for Qwen/Qwen3-Embedding-8B"
-    key: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-Embedding-8B_Accuracy"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen3-Embedding-8B_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Accuracy for Qwen/Qwen3-Embedding-8B"
+    key: "${BK_KEY}_Qwen_Qwen3-Embedding-8B_Accuracy"
+    depends_on: "${BK_KEY}_record_Qwen_Qwen3-Embedding-8B_UnitTest"
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       TEST_MODEL: Qwen/Qwen3-Embedding-8B
       TENSOR_PARALLEL_SIZE: "${TENSOR_PARALLEL_SIZE_SINGLE:-1}"
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh python3 -m pytest -s -v /workspace/tpu_inference/tests/e2e/test_step_pooling.py
-  - label: "${TPU_VERSION:-tpu6e} Record accuracy result for Qwen/Qwen3-Embedding-8B"
-    key: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen3-Embedding-8B_Accuracy"
-    depends_on: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-Embedding-8B_Accuracy"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record accuracy result for Qwen/Qwen3-Embedding-8B"
+    key: "${BK_KEY}_record_Qwen_Qwen3-Embedding-8B_Accuracy"
+    depends_on: "${BK_KEY}_Qwen_Qwen3-Embedding-8B_Accuracy"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "Qwen/Qwen3-Embedding-8B"
       CI_STAGE: "Accuracy/Correctness"
@@ -58,24 +63,26 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_Qwen_Qwen3-Embedding-8B_Accuracy
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_Qwen_Qwen3-Embedding-8B_Accuracy
 
-  - label: "${TPU_VERSION:-tpu6e} Performance benchmarks for Qwen/Qwen3-Embedding-8B"
-    key: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-Embedding-8B_Benchmark"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen3-Embedding-8B_Accuracy"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance benchmarks for Qwen/Qwen3-Embedding-8B"
+    key: "${BK_KEY}_Qwen_Qwen3-Embedding-8B_Benchmark"
+    depends_on: "${BK_KEY}_record_Qwen_Qwen3-Embedding-8B_Accuracy"
     soft_fail: true
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       TEST_MODEL: Qwen/Qwen3-Embedding-8B
       TENSOR_PARALLEL_SIZE: "${TENSOR_PARALLEL_SIZE_SINGLE:-1}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-Embedding-8B_Benchmark" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance benchmark result for Qwen/Qwen3-Embedding-8B"
-    key: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen3-Embedding-8B_Benchmark"
-    depends_on: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-Embedding-8B_Benchmark"
+        buildkite-agent meta-data set "${BK_KEY}_Qwen_Qwen3-Embedding-8B_Benchmark" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance benchmark result for Qwen/Qwen3-Embedding-8B"
+    key: "${BK_KEY}_record_Qwen_Qwen3-Embedding-8B_Benchmark"
+    depends_on: "${BK_KEY}_Qwen_Qwen3-Embedding-8B_Benchmark"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "Qwen/Qwen3-Embedding-8B"
       CI_STAGE: "Benchmark"
@@ -84,4 +91,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_Qwen_Qwen3-Embedding-8B_Benchmark
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_Qwen_Qwen3-Embedding-8B_Benchmark

--- a/.buildkite/models/Qwen_Qwen3-Embedding-8B.yml
+++ b/.buildkite/models/Qwen_Qwen3-Embedding-8B.yml
@@ -38,7 +38,7 @@ steps:
         .buildkite/scripts/record_step_result.sh ${BK_KEY}_Qwen_Qwen3-Embedding-8B_UnitTest
 
   - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Accuracy for Qwen/Qwen3-Embedding-8B"
-    key: "${BK_KEY}_Qwen_Qwen3-Embedding-8B_Accuracy"
+    key: "${BK_KEY}_Qwen_Qwen3-Embedding-8B_Accuracy_Correctness"
     depends_on: "${BK_KEY}_record_Qwen_Qwen3-Embedding-8B_UnitTest"
     soft_fail: true
     agents:
@@ -51,8 +51,8 @@ steps:
       - |
         .buildkite/scripts/run_in_docker.sh python3 -m pytest -s -v /workspace/tpu_inference/tests/e2e/test_step_pooling.py
   - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record accuracy result for Qwen/Qwen3-Embedding-8B"
-    key: "${BK_KEY}_record_Qwen_Qwen3-Embedding-8B_Accuracy"
-    depends_on: "${BK_KEY}_Qwen_Qwen3-Embedding-8B_Accuracy"
+    key: "${BK_KEY}_record_Qwen_Qwen3-Embedding-8B_Accuracy_Correctness"
+    depends_on: "${BK_KEY}_Qwen_Qwen3-Embedding-8B_Accuracy_Correctness"
     env:
       MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
@@ -63,11 +63,11 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${BK_KEY}_Qwen_Qwen3-Embedding-8B_Accuracy
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_Qwen_Qwen3-Embedding-8B_Accuracy_Correctness
 
   - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance benchmarks for Qwen/Qwen3-Embedding-8B"
     key: "${BK_KEY}_Qwen_Qwen3-Embedding-8B_Benchmark"
-    depends_on: "${BK_KEY}_record_Qwen_Qwen3-Embedding-8B_Accuracy"
+    depends_on: "${BK_KEY}_record_Qwen_Qwen3-Embedding-8B_Accuracy_Correctness"
     soft_fail: true
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")

--- a/.buildkite/models/Qwen_Qwen3-Omni-30B-A3B-Instruct.yml
+++ b/.buildkite/models/Qwen_Qwen3-Omni-30B-A3B-Instruct.yml
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Unit tests for Qwen/Qwen3-Omni-30B-A3B-Instruct"
-    key: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-Omni-30B-A3B-Instruct_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Unit tests for Qwen/Qwen3-Omni-30B-A3B-Instruct"
+    key: "${BK_KEY}_Qwen_Qwen3-Omni-30B-A3B-Instruct_UnitTest"
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
     soft_fail: true
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-Omni-30B-A3B-Instruct_UnitTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record unit test result for Qwen/Qwen3-Omni-30B-A3B-Instruct"
-    key: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen3-Omni-30B-A3B-Instruct_UnitTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-Omni-30B-A3B-Instruct_UnitTest"
+        buildkite-agent meta-data set "${BK_KEY}_Qwen_Qwen3-Omni-30B-A3B-Instruct_UnitTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record unit test result for Qwen/Qwen3-Omni-30B-A3B-Instruct"
+    key: "${BK_KEY}_record_Qwen_Qwen3-Omni-30B-A3B-Instruct_UnitTest"
+    depends_on: "${BK_KEY}_Qwen_Qwen3-Omni-30B-A3B-Instruct_UnitTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "Qwen/Qwen3-Omni-30B-A3B-Instruct"
       CI_STAGE: "UnitTest"
@@ -33,21 +36,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_Qwen_Qwen3-Omni-30B-A3B-Instruct_UnitTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_Qwen_Qwen3-Omni-30B-A3B-Instruct_UnitTest
 
-  - label: "${TPU_VERSION:-tpu6e} Accuracy for Qwen/Qwen3-Omni-30B-A3B-Instruct"
-    key: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-Omni-30B-A3B-Instruct_Accuracy"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen3-Omni-30B-A3B-Instruct_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Accuracy for Qwen/Qwen3-Omni-30B-A3B-Instruct"
+    key: "${BK_KEY}_Qwen_Qwen3-Omni-30B-A3B-Instruct_Accuracy"
+    depends_on: "${BK_KEY}_record_Qwen_Qwen3-Omni-30B-A3B-Instruct_UnitTest"
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
     soft_fail: true
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-Omni-30B-A3B-Instruct_Accuracy" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record accuracy result for Qwen/Qwen3-Omni-30B-A3B-Instruct"
-    key: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen3-Omni-30B-A3B-Instruct_Accuracy"
-    depends_on: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-Omni-30B-A3B-Instruct_Accuracy"
+        buildkite-agent meta-data set "${BK_KEY}_Qwen_Qwen3-Omni-30B-A3B-Instruct_Accuracy" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record accuracy result for Qwen/Qwen3-Omni-30B-A3B-Instruct"
+    key: "${BK_KEY}_record_Qwen_Qwen3-Omni-30B-A3B-Instruct_Accuracy"
+    depends_on: "${BK_KEY}_Qwen_Qwen3-Omni-30B-A3B-Instruct_Accuracy"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "Qwen/Qwen3-Omni-30B-A3B-Instruct"
       CI_STAGE: "Accuracy/Correctness"
@@ -56,21 +62,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_Qwen_Qwen3-Omni-30B-A3B-Instruct_Accuracy
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_Qwen_Qwen3-Omni-30B-A3B-Instruct_Accuracy
 
-  - label: "${TPU_VERSION:-tpu6e} Performance benchmarks for Qwen/Qwen3-Omni-30B-A3B-Instruct"
-    key: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-Omni-30B-A3B-Instruct_Benchmark"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen3-Omni-30B-A3B-Instruct_Accuracy"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance benchmarks for Qwen/Qwen3-Omni-30B-A3B-Instruct"
+    key: "${BK_KEY}_Qwen_Qwen3-Omni-30B-A3B-Instruct_Benchmark"
+    depends_on: "${BK_KEY}_record_Qwen_Qwen3-Omni-30B-A3B-Instruct_Accuracy"
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
     soft_fail: true
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-Omni-30B-A3B-Instruct_Benchmark" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance benchmark result for Qwen/Qwen3-Omni-30B-A3B-Instruct"
-    key: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen3-Omni-30B-A3B-Instruct_Benchmark"
-    depends_on: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-Omni-30B-A3B-Instruct_Benchmark"
+        buildkite-agent meta-data set "${BK_KEY}_Qwen_Qwen3-Omni-30B-A3B-Instruct_Benchmark" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance benchmark result for Qwen/Qwen3-Omni-30B-A3B-Instruct"
+    key: "${BK_KEY}_record_Qwen_Qwen3-Omni-30B-A3B-Instruct_Benchmark"
+    depends_on: "${BK_KEY}_Qwen_Qwen3-Omni-30B-A3B-Instruct_Benchmark"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "Qwen/Qwen3-Omni-30B-A3B-Instruct"
       CI_STAGE: "Benchmark"
@@ -79,4 +88,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_Qwen_Qwen3-Omni-30B-A3B-Instruct_Benchmark
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_Qwen_Qwen3-Omni-30B-A3B-Instruct_Benchmark

--- a/.buildkite/models/Qwen_Qwen3-Omni-30B-A3B-Instruct.yml
+++ b/.buildkite/models/Qwen_Qwen3-Omni-30B-A3B-Instruct.yml
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Unit tests for Qwen/Qwen3-Omni-30B-A3B-Instruct"
-    key: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-Omni-30B-A3B-Instruct_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Unit tests for Qwen/Qwen3-Omni-30B-A3B-Instruct"
+    key: "${BK_KEY}_Qwen_Qwen3-Omni-30B-A3B-Instruct_UnitTest"
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}")
     soft_fail: true
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-Omni-30B-A3B-Instruct_UnitTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record unit test result for Qwen/Qwen3-Omni-30B-A3B-Instruct"
-    key: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen3-Omni-30B-A3B-Instruct_UnitTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-Omni-30B-A3B-Instruct_UnitTest"
+        buildkite-agent meta-data set "${BK_KEY}_Qwen_Qwen3-Omni-30B-A3B-Instruct_UnitTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record unit test result for Qwen/Qwen3-Omni-30B-A3B-Instruct"
+    key: "${BK_KEY}_record_Qwen_Qwen3-Omni-30B-A3B-Instruct_UnitTest"
+    depends_on: "${BK_KEY}_Qwen_Qwen3-Omni-30B-A3B-Instruct_UnitTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "Qwen/Qwen3-Omni-30B-A3B-Instruct"
       CI_STAGE: "UnitTest"
@@ -33,21 +36,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_Qwen_Qwen3-Omni-30B-A3B-Instruct_UnitTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_Qwen_Qwen3-Omni-30B-A3B-Instruct_UnitTest
 
-  - label: "${TPU_VERSION:-tpu6e} Accuracy for Qwen/Qwen3-Omni-30B-A3B-Instruct"
-    key: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-Omni-30B-A3B-Instruct_Accuracy"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen3-Omni-30B-A3B-Instruct_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Accuracy for Qwen/Qwen3-Omni-30B-A3B-Instruct"
+    key: "${BK_KEY}_Qwen_Qwen3-Omni-30B-A3B-Instruct_Accuracy"
+    depends_on: "${BK_KEY}_record_Qwen_Qwen3-Omni-30B-A3B-Instruct_UnitTest"
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}")
     soft_fail: true
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-Omni-30B-A3B-Instruct_Accuracy" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record accuracy result for Qwen/Qwen3-Omni-30B-A3B-Instruct"
-    key: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen3-Omni-30B-A3B-Instruct_Accuracy"
-    depends_on: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-Omni-30B-A3B-Instruct_Accuracy"
+        buildkite-agent meta-data set "${BK_KEY}_Qwen_Qwen3-Omni-30B-A3B-Instruct_Accuracy" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record accuracy result for Qwen/Qwen3-Omni-30B-A3B-Instruct"
+    key: "${BK_KEY}_record_Qwen_Qwen3-Omni-30B-A3B-Instruct_Accuracy"
+    depends_on: "${BK_KEY}_Qwen_Qwen3-Omni-30B-A3B-Instruct_Accuracy"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "Qwen/Qwen3-Omni-30B-A3B-Instruct"
       CI_STAGE: "Accuracy/Correctness"
@@ -56,21 +62,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_Qwen_Qwen3-Omni-30B-A3B-Instruct_Accuracy
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_Qwen_Qwen3-Omni-30B-A3B-Instruct_Accuracy
 
-  - label: "${TPU_VERSION:-tpu6e} Performance benchmarks for Qwen/Qwen3-Omni-30B-A3B-Instruct"
-    key: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-Omni-30B-A3B-Instruct_Benchmark"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen3-Omni-30B-A3B-Instruct_Accuracy"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance benchmarks for Qwen/Qwen3-Omni-30B-A3B-Instruct"
+    key: "${BK_KEY}_Qwen_Qwen3-Omni-30B-A3B-Instruct_Benchmark"
+    depends_on: "${BK_KEY}_record_Qwen_Qwen3-Omni-30B-A3B-Instruct_Accuracy"
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}")
     soft_fail: true
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-Omni-30B-A3B-Instruct_Benchmark" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance benchmark result for Qwen/Qwen3-Omni-30B-A3B-Instruct"
-    key: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen3-Omni-30B-A3B-Instruct_Benchmark"
-    depends_on: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-Omni-30B-A3B-Instruct_Benchmark"
+        buildkite-agent meta-data set "${BK_KEY}_Qwen_Qwen3-Omni-30B-A3B-Instruct_Benchmark" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance benchmark result for Qwen/Qwen3-Omni-30B-A3B-Instruct"
+    key: "${BK_KEY}_record_Qwen_Qwen3-Omni-30B-A3B-Instruct_Benchmark"
+    depends_on: "${BK_KEY}_Qwen_Qwen3-Omni-30B-A3B-Instruct_Benchmark"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "Qwen/Qwen3-Omni-30B-A3B-Instruct"
       CI_STAGE: "Benchmark"
@@ -79,4 +88,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_Qwen_Qwen3-Omni-30B-A3B-Instruct_Benchmark
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_Qwen_Qwen3-Omni-30B-A3B-Instruct_Benchmark

--- a/.buildkite/models/Qwen_Qwen3-Omni-30B-A3B-Instruct.yml
+++ b/.buildkite/models/Qwen_Qwen3-Omni-30B-A3B-Instruct.yml
@@ -39,7 +39,7 @@ steps:
         .buildkite/scripts/record_step_result.sh ${BK_KEY}_Qwen_Qwen3-Omni-30B-A3B-Instruct_UnitTest
 
   - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Accuracy for Qwen/Qwen3-Omni-30B-A3B-Instruct"
-    key: "${BK_KEY}_Qwen_Qwen3-Omni-30B-A3B-Instruct_Accuracy"
+    key: "${BK_KEY}_Qwen_Qwen3-Omni-30B-A3B-Instruct_Accuracy_Correctness"
     depends_on: "${BK_KEY}_record_Qwen_Qwen3-Omni-30B-A3B-Instruct_UnitTest"
     env:
       MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
@@ -48,10 +48,10 @@ steps:
     soft_fail: true
     commands:
       - |
-        buildkite-agent meta-data set "${BK_KEY}_Qwen_Qwen3-Omni-30B-A3B-Instruct_Accuracy" "unverified"
+        buildkite-agent meta-data set "${BK_KEY}_Qwen_Qwen3-Omni-30B-A3B-Instruct_Accuracy_Correctness" "unverified"
   - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record accuracy result for Qwen/Qwen3-Omni-30B-A3B-Instruct"
-    key: "${BK_KEY}_record_Qwen_Qwen3-Omni-30B-A3B-Instruct_Accuracy"
-    depends_on: "${BK_KEY}_Qwen_Qwen3-Omni-30B-A3B-Instruct_Accuracy"
+    key: "${BK_KEY}_record_Qwen_Qwen3-Omni-30B-A3B-Instruct_Accuracy_Correctness"
+    depends_on: "${BK_KEY}_Qwen_Qwen3-Omni-30B-A3B-Instruct_Accuracy_Correctness"
     env:
       MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
@@ -62,11 +62,11 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${BK_KEY}_Qwen_Qwen3-Omni-30B-A3B-Instruct_Accuracy
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_Qwen_Qwen3-Omni-30B-A3B-Instruct_Accuracy_Correctness
 
   - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance benchmarks for Qwen/Qwen3-Omni-30B-A3B-Instruct"
     key: "${BK_KEY}_Qwen_Qwen3-Omni-30B-A3B-Instruct_Benchmark"
-    depends_on: "${BK_KEY}_record_Qwen_Qwen3-Omni-30B-A3B-Instruct_Accuracy"
+    depends_on: "${BK_KEY}_record_Qwen_Qwen3-Omni-30B-A3B-Instruct_Accuracy_Correctness"
     env:
       MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:

--- a/.buildkite/models/Qwen_Qwen3-VL-8B-Instruct.yml
+++ b/.buildkite/models/Qwen_Qwen3-VL-8B-Instruct.yml
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Unit tests for Qwen/Qwen3-VL-8B-Instruct"
-    key: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-VL-8B-Instruct_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Unit tests for Qwen/Qwen3-VL-8B-Instruct"
+    key: "${BK_KEY}_Qwen_Qwen3-VL-8B-Instruct_UnitTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-VL-8B-Instruct_UnitTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record unit test result for Qwen/Qwen3-VL-8B-Instruct"
-    key: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen3-VL-8B-Instruct_UnitTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-VL-8B-Instruct_UnitTest"
+        buildkite-agent meta-data set "${BK_KEY}_Qwen_Qwen3-VL-8B-Instruct_UnitTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record unit test result for Qwen/Qwen3-VL-8B-Instruct"
+    key: "${BK_KEY}_record_Qwen_Qwen3-VL-8B-Instruct_UnitTest"
+    depends_on: "${BK_KEY}_Qwen_Qwen3-VL-8B-Instruct_UnitTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "Qwen/Qwen3-VL-8B-Instruct"
       CI_STAGE: "UnitTest"
@@ -33,25 +36,27 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_Qwen_Qwen3-VL-8B-Instruct_UnitTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_Qwen_Qwen3-VL-8B-Instruct_UnitTest
 
-  - label: "${TPU_VERSION:-tpu6e} Accuracy for Qwen/Qwen3-VL-8B-Instruct"
-    key: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-VL-8B-Instruct_Accuracy"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen3-VL-8B-Instruct_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Accuracy for Qwen/Qwen3-VL-8B-Instruct"
+    key: "${BK_KEY}_Qwen_Qwen3-VL-8B-Instruct_Accuracy"
+    depends_on: "${BK_KEY}_record_Qwen_Qwen3-VL-8B-Instruct_UnitTest"
     soft_fail: true
     agents:
       queue: cpu  # TODO: replace with execution environment
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       TEST_MODEL: Qwen/Qwen3-VL-8B-Instruct
       TENSOR_PARALLEL_SIZE: "${TENSOR_PARALLEL_SIZE_SINGLE:-1}"
       MINIMUM_ACCURACY_THRESHOLD: 0  # TODO : replace 0 with your accuracy threshold
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-VL-8B-Instruct_Accuracy" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record accuracy result for Qwen/Qwen3-VL-8B-Instruct"
-    key: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen3-VL-8B-Instruct_Accuracy"
-    depends_on: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-VL-8B-Instruct_Accuracy"
+        buildkite-agent meta-data set "${BK_KEY}_Qwen_Qwen3-VL-8B-Instruct_Accuracy" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record accuracy result for Qwen/Qwen3-VL-8B-Instruct"
+    key: "${BK_KEY}_record_Qwen_Qwen3-VL-8B-Instruct_Accuracy"
+    depends_on: "${BK_KEY}_Qwen_Qwen3-VL-8B-Instruct_Accuracy"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "Qwen/Qwen3-VL-8B-Instruct"
       CI_STAGE: "Accuracy/Correctness"
@@ -60,25 +65,27 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_Qwen_Qwen3-VL-8B-Instruct_Accuracy
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_Qwen_Qwen3-VL-8B-Instruct_Accuracy
 
-  - label: "${TPU_VERSION:-tpu6e} Performance benchmarks for Qwen/Qwen3-VL-8B-Instruct"
-    key: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-VL-8B-Instruct_Benchmark"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen3-VL-8B-Instruct_Accuracy"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance benchmarks for Qwen/Qwen3-VL-8B-Instruct"
+    key: "${BK_KEY}_Qwen_Qwen3-VL-8B-Instruct_Benchmark"
+    depends_on: "${BK_KEY}_record_Qwen_Qwen3-VL-8B-Instruct_Accuracy"
     soft_fail: true
     agents:
       queue: cpu  # TODO: replace with execution environment
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       TEST_MODEL: Qwen/Qwen3-VL-8B-Instruct
       TENSOR_PARALLEL_SIZE: "${TENSOR_PARALLEL_SIZE_SINGLE:-1}"
       MINIMUM_THROUGHPUT_THRESHOLD: 0  # TODO : replace 0 with your performance threshold
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-VL-8B-Instruct_Benchmark" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance benchmark result for Qwen/Qwen3-VL-8B-Instruct"
-    key: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen3-VL-8B-Instruct_Benchmark"
-    depends_on: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-VL-8B-Instruct_Benchmark"
+        buildkite-agent meta-data set "${BK_KEY}_Qwen_Qwen3-VL-8B-Instruct_Benchmark" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance benchmark result for Qwen/Qwen3-VL-8B-Instruct"
+    key: "${BK_KEY}_record_Qwen_Qwen3-VL-8B-Instruct_Benchmark"
+    depends_on: "${BK_KEY}_Qwen_Qwen3-VL-8B-Instruct_Benchmark"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "Qwen/Qwen3-VL-8B-Instruct"
       CI_STAGE: "Benchmark"
@@ -87,4 +94,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_Qwen_Qwen3-VL-8B-Instruct_Benchmark
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_Qwen_Qwen3-VL-8B-Instruct_Benchmark

--- a/.buildkite/models/Qwen_Qwen3-VL-8B-Instruct.yml
+++ b/.buildkite/models/Qwen_Qwen3-VL-8B-Instruct.yml
@@ -39,7 +39,7 @@ steps:
         .buildkite/scripts/record_step_result.sh ${BK_KEY}_Qwen_Qwen3-VL-8B-Instruct_UnitTest
 
   - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Accuracy for Qwen/Qwen3-VL-8B-Instruct"
-    key: "${BK_KEY}_Qwen_Qwen3-VL-8B-Instruct_Accuracy"
+    key: "${BK_KEY}_Qwen_Qwen3-VL-8B-Instruct_Accuracy_Correctness"
     depends_on: "${BK_KEY}_record_Qwen_Qwen3-VL-8B-Instruct_UnitTest"
     soft_fail: true
     agents:
@@ -51,10 +51,10 @@ steps:
       MINIMUM_ACCURACY_THRESHOLD: 0  # TODO : replace 0 with your accuracy threshold
     commands:
       - |
-        buildkite-agent meta-data set "${BK_KEY}_Qwen_Qwen3-VL-8B-Instruct_Accuracy" "unverified"
+        buildkite-agent meta-data set "${BK_KEY}_Qwen_Qwen3-VL-8B-Instruct_Accuracy_Correctness" "unverified"
   - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record accuracy result for Qwen/Qwen3-VL-8B-Instruct"
-    key: "${BK_KEY}_record_Qwen_Qwen3-VL-8B-Instruct_Accuracy"
-    depends_on: "${BK_KEY}_Qwen_Qwen3-VL-8B-Instruct_Accuracy"
+    key: "${BK_KEY}_record_Qwen_Qwen3-VL-8B-Instruct_Accuracy_Correctness"
+    depends_on: "${BK_KEY}_Qwen_Qwen3-VL-8B-Instruct_Accuracy_Correctness"
     env:
       MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
@@ -65,11 +65,11 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${BK_KEY}_Qwen_Qwen3-VL-8B-Instruct_Accuracy
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_Qwen_Qwen3-VL-8B-Instruct_Accuracy_Correctness
 
   - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance benchmarks for Qwen/Qwen3-VL-8B-Instruct"
     key: "${BK_KEY}_Qwen_Qwen3-VL-8B-Instruct_Benchmark"
-    depends_on: "${BK_KEY}_record_Qwen_Qwen3-VL-8B-Instruct_Accuracy"
+    depends_on: "${BK_KEY}_record_Qwen_Qwen3-VL-8B-Instruct_Accuracy_Correctness"
     soft_fail: true
     agents:
       queue: cpu  # TODO: replace with execution environment

--- a/.buildkite/models/Qwen_Qwen3_5-397B-A17B.yml
+++ b/.buildkite/models/Qwen_Qwen3_5-397B-A17B.yml
@@ -13,24 +13,27 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Unit tests for Qwen/Qwen3.5-397B-A17B-FP8"
-    key: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3_5-397B-A17B_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Unit tests for Qwen/Qwen3.5-397B-A17B-FP8"
+    key: "${BK_KEY}_Qwen_Qwen3_5-397B-A17B_UnitTest"
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
     soft_fail: true
     commands:
       - |
         if [ "${TPU_VERSION:-tpu6e}" = "tpu6e" ]; then
-          buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_Qwen_Qwen3_5-397B-A17B_UnitTest" "not enough HBM"
+          buildkite-agent meta-data set "${BK_KEY}_Qwen_Qwen3_5-397B-A17B_UnitTest" "not enough HBM"
         else
           .buildkite/scripts/run_in_docker.sh \
             bash -c 'SKIP_JAX_PRECOMPILE=1 VLLM_XLA_CHECK_RECOMPILATION=0 MODEL_IMPL_TYPE=vllm python /workspace/tpu_inference/examples/offline_inference.py --model Qwen/Qwen3.5-397B-A17B-FP8 --tensor-parallel-size 8 --enable-expert-parallel  --max-num-batched-tokens 256 --max-num-seqs 256  --limit-mm-per-prompt "{\"image\": 0, \"video\": 0}" --chat-template-kwargs="{\"enable_thinking\": false}"'
         fi
 
-  - label: "${TPU_VERSION:-tpu6e} Record unit test result for Qwen/Qwen3.5-397B-A17B-FP8"
-    key: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen3_5-397B-A17B_UnitTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3_5-397B-A17B_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record unit test result for Qwen/Qwen3.5-397B-A17B-FP8"
+    key: "${BK_KEY}_record_Qwen_Qwen3_5-397B-A17B_UnitTest"
+    depends_on: "${BK_KEY}_Qwen_Qwen3_5-397B-A17B_UnitTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "Qwen/Qwen3.5-397B-A17B"
       CI_STAGE: "UnitTest"
@@ -39,26 +42,29 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_Qwen_Qwen3_5-397B-A17B_UnitTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_Qwen_Qwen3_5-397B-A17B_UnitTest
 
-  - label: "${TPU_VERSION:-tpu6e} Accuracy for Qwen/Qwen3.5-397B-A17B-FP8"
-    key: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3_5-397B-A17B_Accuracy"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen3_5-397B-A17B_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Accuracy for Qwen/Qwen3.5-397B-A17B-FP8"
+    key: "${BK_KEY}_Qwen_Qwen3_5-397B-A17B_Accuracy"
+    depends_on: "${BK_KEY}_record_Qwen_Qwen3_5-397B-A17B_UnitTest"
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
     soft_fail: true
     commands:
       - |
         if [ "${TPU_VERSION:-tpu6e}" = "tpu6e" ]; then
-          buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_Qwen_Qwen3_5-397B-A17B_Accuracy" "not enough HBM"
+          buildkite-agent meta-data set "${BK_KEY}_Qwen_Qwen3_5-397B-A17B_Accuracy" "not enough HBM"
         else
           .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/check_lm_eval.sh  --model_name "Qwen/Qwen3.5-397B-A17B-FP8" --use_moe_ep_kernel 0 --tensor_parallel_size 8 --max_model_len 4096 --max_num_batched_tokens 4096 --max_gen_toks 2048 --enable_expert_parallel 1 --flex_threshold 0.63 --strict_threshold 0.63 --limit_mm_per_prompt '{"image": 0, "video": 0}' --block_size 256 --limit 100 --enable_thinking false
         fi
 
-  - label: "${TPU_VERSION:-tpu6e} Record integration test result for Qwen/Qwen3.5-397B-A17B-FP8"
-    key: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen3_5-397B-A17B_Accuracy"
-    depends_on: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3_5-397B-A17B_Accuracy"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record integration test result for Qwen/Qwen3.5-397B-A17B-FP8"
+    key: "${BK_KEY}_record_Qwen_Qwen3_5-397B-A17B_Accuracy"
+    depends_on: "${BK_KEY}_Qwen_Qwen3_5-397B-A17B_Accuracy"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "Qwen/Qwen3.5-397B-A17B"
       CI_STAGE: "Accuracy/Correctness"
@@ -67,11 +73,13 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_Qwen_Qwen3_5-397B-A17B_Accuracy
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_Qwen_Qwen3_5-397B-A17B_Accuracy
 
-  - label: "${TPU_VERSION:-tpu6e} Performance benchmarks for Qwen/Qwen3.5-397B-A17B-FP8"
-    key: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3_5-397B-A17B_Benchmark"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen3_5-397B-A17B_Accuracy"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance benchmarks for Qwen/Qwen3.5-397B-A17B-FP8"
+    key: "${BK_KEY}_Qwen_Qwen3_5-397B-A17B_Benchmark"
+    depends_on: "${BK_KEY}_record_Qwen_Qwen3_5-397B-A17B_Accuracy"
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
     soft_fail: true
@@ -80,15 +88,16 @@ steps:
     commands:
       - |
         if [ "${TPU_VERSION:-tpu6e}" = "tpu6e" ]; then
-          buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_Qwen_Qwen3_5-397B-A17B_Benchmark" "not enough HBM"
+          buildkite-agent meta-data set "${BK_KEY}_Qwen_Qwen3_5-397B-A17B_Benchmark" "not enough HBM"
         else
               .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/bm_qwen3_coder.sh --model Qwen/Qwen3.5-397B-A17B-FP8 --tp 8 --req_tput_limit 0.04  --output_token_tput_limit 300 --total_token_tput_limit 345 --input_len 1024 --output_len 8192 --use_moe_ep_kernel 0 --limit_mm_per_prompt '{"image": 0, "video": 0}' --block_size 256 --num_prompts 64 --timeout 52 --gpu-memory-utilization 0.9
         fi
 
-  - label: "${TPU_VERSION:-tpu6e} Record performance benchmark result for Qwen/Qwen3.5-397B-A17B-FP8"
-    key: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen3_5-397B-A17B_Benchmark"
-    depends_on: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3_5-397B-A17B_Benchmark"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance benchmark result for Qwen/Qwen3.5-397B-A17B-FP8"
+    key: "${BK_KEY}_record_Qwen_Qwen3_5-397B-A17B_Benchmark"
+    depends_on: "${BK_KEY}_Qwen_Qwen3_5-397B-A17B_Benchmark"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "Qwen/Qwen3.5-397B-A17B"
       CI_STAGE: "Benchmark"
@@ -97,4 +106,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_Qwen_Qwen3_5-397B-A17B_Benchmark
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_Qwen_Qwen3_5-397B-A17B_Benchmark

--- a/.buildkite/models/Qwen_Qwen3_5-397B-A17B.yml
+++ b/.buildkite/models/Qwen_Qwen3_5-397B-A17B.yml
@@ -45,7 +45,7 @@ steps:
         .buildkite/scripts/record_step_result.sh ${BK_KEY}_Qwen_Qwen3_5-397B-A17B_UnitTest
 
   - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Accuracy for Qwen/Qwen3.5-397B-A17B-FP8"
-    key: "${BK_KEY}_Qwen_Qwen3_5-397B-A17B_Accuracy"
+    key: "${BK_KEY}_Qwen_Qwen3_5-397B-A17B_Accuracy_Correctness"
     depends_on: "${BK_KEY}_record_Qwen_Qwen3_5-397B-A17B_UnitTest"
     env:
       MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
@@ -55,14 +55,14 @@ steps:
     commands:
       - |
         if [ "${TPU_VERSION:-tpu6e}" = "tpu6e" ]; then
-          buildkite-agent meta-data set "${BK_KEY}_Qwen_Qwen3_5-397B-A17B_Accuracy" "not enough HBM"
+          buildkite-agent meta-data set "${BK_KEY}_Qwen_Qwen3_5-397B-A17B_Accuracy_Correctness" "not enough HBM"
         else
           .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/check_lm_eval.sh  --model_name "Qwen/Qwen3.5-397B-A17B-FP8" --use_moe_ep_kernel 0 --tensor_parallel_size 8 --max_model_len 4096 --max_num_batched_tokens 4096 --max_gen_toks 2048 --enable_expert_parallel 1 --flex_threshold 0.63 --strict_threshold 0.63 --limit_mm_per_prompt '{"image": 0, "video": 0}' --block_size 256 --limit 100 --enable_thinking false
         fi
 
   - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record integration test result for Qwen/Qwen3.5-397B-A17B-FP8"
-    key: "${BK_KEY}_record_Qwen_Qwen3_5-397B-A17B_Accuracy"
-    depends_on: "${BK_KEY}_Qwen_Qwen3_5-397B-A17B_Accuracy"
+    key: "${BK_KEY}_record_Qwen_Qwen3_5-397B-A17B_Accuracy_Correctness"
+    depends_on: "${BK_KEY}_Qwen_Qwen3_5-397B-A17B_Accuracy_Correctness"
     env:
       MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
@@ -73,11 +73,11 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${BK_KEY}_Qwen_Qwen3_5-397B-A17B_Accuracy
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_Qwen_Qwen3_5-397B-A17B_Accuracy_Correctness
 
   - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance benchmarks for Qwen/Qwen3.5-397B-A17B-FP8"
     key: "${BK_KEY}_Qwen_Qwen3_5-397B-A17B_Benchmark"
-    depends_on: "${BK_KEY}_record_Qwen_Qwen3_5-397B-A17B_Accuracy"
+    depends_on: "${BK_KEY}_record_Qwen_Qwen3_5-397B-A17B_Accuracy_Correctness"
     env:
       MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:

--- a/.buildkite/models/Qwen_Qwen3_5-397B-A17B.yml
+++ b/.buildkite/models/Qwen_Qwen3_5-397B-A17B.yml
@@ -13,24 +13,27 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Unit tests for Qwen/Qwen3.5-397B-A17B-FP8"
-    key: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3_5-397B-A17B_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Unit tests for Qwen/Qwen3.5-397B-A17B-FP8"
+    key: "${BK_KEY}_Qwen_Qwen3_5-397B-A17B_UnitTest"
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
     soft_fail: true
     commands:
       - |
         if [ "${TPU_VERSION:-tpu6e}" = "tpu6e" ]; then
-          buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_Qwen_Qwen3_5-397B-A17B_UnitTest" "not enough HBM"
+          buildkite-agent meta-data set "${BK_KEY}_Qwen_Qwen3_5-397B-A17B_UnitTest" "not enough HBM"
         else
           .buildkite/scripts/run_in_docker.sh \
             bash -c 'SKIP_JAX_PRECOMPILE=1 VLLM_XLA_CHECK_RECOMPILATION=0 MODEL_IMPL_TYPE=vllm python /workspace/tpu_inference/examples/offline_inference.py --model Qwen/Qwen3.5-397B-A17B-FP8 --tensor-parallel-size 8 --enable-expert-parallel  --max-num-batched-tokens 256 --max-num-seqs 256  --limit-mm-per-prompt "{\"image\": 0, \"video\": 0}" --chat-template-kwargs="{\"enable_thinking\": false}"'
         fi
 
-  - label: "${TPU_VERSION:-tpu6e} Record unit test result for Qwen/Qwen3.5-397B-A17B-FP8"
-    key: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen3_5-397B-A17B_UnitTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3_5-397B-A17B_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record unit test result for Qwen/Qwen3.5-397B-A17B-FP8"
+    key: "${BK_KEY}_record_Qwen_Qwen3_5-397B-A17B_UnitTest"
+    depends_on: "${BK_KEY}_Qwen_Qwen3_5-397B-A17B_UnitTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "Qwen/Qwen3.5-397B-A17B"
       CI_STAGE: "UnitTest"
@@ -39,26 +42,29 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_Qwen_Qwen3_5-397B-A17B_UnitTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_Qwen_Qwen3_5-397B-A17B_UnitTest
 
-  - label: "${TPU_VERSION:-tpu6e} Accuracy for Qwen/Qwen3.5-397B-A17B-FP8"
-    key: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3_5-397B-A17B_Accuracy"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen3_5-397B-A17B_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Accuracy for Qwen/Qwen3.5-397B-A17B-FP8"
+    key: "${BK_KEY}_Qwen_Qwen3_5-397B-A17B_Accuracy"
+    depends_on: "${BK_KEY}_record_Qwen_Qwen3_5-397B-A17B_UnitTest"
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
     soft_fail: true
     commands:
       - |
         if [ "${TPU_VERSION:-tpu6e}" = "tpu6e" ]; then
-          buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_Qwen_Qwen3_5-397B-A17B_Accuracy" "not enough HBM"
+          buildkite-agent meta-data set "${BK_KEY}_Qwen_Qwen3_5-397B-A17B_Accuracy" "not enough HBM"
         else
           .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/check_lm_eval.sh  --model_name "Qwen/Qwen3.5-397B-A17B-FP8" --use_moe_ep_kernel 0 --tensor_parallel_size 8 --max_model_len 4096 --max_num_batched_tokens 4096 --max_gen_toks 2048 --enable_expert_parallel 1 --flex_threshold 0.63 --strict_threshold 0.63 --limit_mm_per_prompt '{"image": 0, "video": 0}' --block_size 256 --limit 100 --enable_thinking false
         fi
 
-  - label: "${TPU_VERSION:-tpu6e} Record integration test result for Qwen/Qwen3.5-397B-A17B-FP8"
-    key: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen3_5-397B-A17B_Accuracy"
-    depends_on: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3_5-397B-A17B_Accuracy"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record integration test result for Qwen/Qwen3.5-397B-A17B-FP8"
+    key: "${BK_KEY}_record_Qwen_Qwen3_5-397B-A17B_Accuracy"
+    depends_on: "${BK_KEY}_Qwen_Qwen3_5-397B-A17B_Accuracy"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "Qwen/Qwen3.5-397B-A17B"
       CI_STAGE: "Accuracy/Correctness"
@@ -67,11 +73,13 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_Qwen_Qwen3_5-397B-A17B_Accuracy
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_Qwen_Qwen3_5-397B-A17B_Accuracy
 
-  - label: "${TPU_VERSION:-tpu6e} Performance benchmarks for Qwen/Qwen3.5-397B-A17B-FP8"
-    key: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3_5-397B-A17B_Benchmark"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen3_5-397B-A17B_Accuracy"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance benchmarks for Qwen/Qwen3.5-397B-A17B-FP8"
+    key: "${BK_KEY}_Qwen_Qwen3_5-397B-A17B_Benchmark"
+    depends_on: "${BK_KEY}_record_Qwen_Qwen3_5-397B-A17B_Accuracy"
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
     soft_fail: true
@@ -80,15 +88,16 @@ steps:
     commands:
       - |
         if [ "${TPU_VERSION:-tpu6e}" = "tpu6e" ]; then
-          buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_Qwen_Qwen3_5-397B-A17B_Benchmark" "not enough HBM"
+          buildkite-agent meta-data set "${BK_KEY}_Qwen_Qwen3_5-397B-A17B_Benchmark" "not enough HBM"
         else
               .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/bm_qwen3_coder.sh --model Qwen/Qwen3.5-397B-A17B-FP8 --tp 8 --req_tput_limit 0.04  --output_token_tput_limit 300 --total_token_tput_limit 345 --input_len 1024 --output_len 8192 --use_moe_ep_kernel 0 --limit_mm_per_prompt '{"image": 0, "video": 0}' --block_size 256 --num_prompts 64 --timeout 52 --gpu-memory-utilization 0.88
         fi
 
-  - label: "${TPU_VERSION:-tpu6e} Record performance benchmark result for Qwen/Qwen3.5-397B-A17B-FP8"
-    key: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen3_5-397B-A17B_Benchmark"
-    depends_on: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3_5-397B-A17B_Benchmark"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance benchmark result for Qwen/Qwen3.5-397B-A17B-FP8"
+    key: "${BK_KEY}_record_Qwen_Qwen3_5-397B-A17B_Benchmark"
+    depends_on: "${BK_KEY}_Qwen_Qwen3_5-397B-A17B_Benchmark"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "Qwen/Qwen3.5-397B-A17B"
       CI_STAGE: "Benchmark"
@@ -97,4 +106,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_Qwen_Qwen3_5-397B-A17B_Benchmark
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_Qwen_Qwen3_5-397B-A17B_Benchmark

--- a/.buildkite/models/Qwen_Qwen3_5-9B.yml
+++ b/.buildkite/models/Qwen_Qwen3_5-9B.yml
@@ -39,7 +39,7 @@ steps:
         .buildkite/scripts/record_step_result.sh ${BK_KEY}_Qwen_Qwen3_5-9B_UnitTest
 
   - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Accuracy for Qwen/Qwen3.5-9B"
-    key: "${BK_KEY}_Qwen_Qwen3_5-9B_Accuracy"
+    key: "${BK_KEY}_Qwen_Qwen3_5-9B_Accuracy_Correctness"
     depends_on: "${BK_KEY}_record_Qwen_Qwen3_5-9B_UnitTest"
     soft_fail: true
     agents:
@@ -51,10 +51,10 @@ steps:
       MINIMUM_ACCURACY_THRESHOLD: 0  # TODO : replace 0 with your accuracy threshold
     commands:
       - |
-        buildkite-agent meta-data set "${BK_KEY}_Qwen_Qwen3_5-9B_Accuracy" "unverified"
+        buildkite-agent meta-data set "${BK_KEY}_Qwen_Qwen3_5-9B_Accuracy_Correctness" "unverified"
   - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record accuracy result for Qwen/Qwen3.5-9B"
-    key: "${BK_KEY}_record_Qwen_Qwen3_5-9B_Accuracy"
-    depends_on: "${BK_KEY}_Qwen_Qwen3_5-9B_Accuracy"
+    key: "${BK_KEY}_record_Qwen_Qwen3_5-9B_Accuracy_Correctness"
+    depends_on: "${BK_KEY}_Qwen_Qwen3_5-9B_Accuracy_Correctness"
     env:
       MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
@@ -65,11 +65,11 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${BK_KEY}_Qwen_Qwen3_5-9B_Accuracy
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_Qwen_Qwen3_5-9B_Accuracy_Correctness
 
   - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance benchmarks for Qwen/Qwen3.5-9B"
     key: "${BK_KEY}_Qwen_Qwen3_5-9B_Benchmark"
-    depends_on: "${BK_KEY}_record_Qwen_Qwen3_5-9B_Accuracy"
+    depends_on: "${BK_KEY}_record_Qwen_Qwen3_5-9B_Accuracy_Correctness"
     soft_fail: true
     agents:
       queue: cpu  # TODO: replace with execution environment

--- a/.buildkite/models/Qwen_Qwen3_5-9B.yml
+++ b/.buildkite/models/Qwen_Qwen3_5-9B.yml
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Unit tests for Qwen/Qwen3.5-9B"
-    key: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3_5-9B_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Unit tests for Qwen/Qwen3.5-9B"
+    key: "${BK_KEY}_Qwen_Qwen3_5-9B_UnitTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_Qwen_Qwen3_5-9B_UnitTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record unit test result for Qwen/Qwen3.5-9B"
-    key: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen3_5-9B_UnitTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3_5-9B_UnitTest"
+        buildkite-agent meta-data set "${BK_KEY}_Qwen_Qwen3_5-9B_UnitTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record unit test result for Qwen/Qwen3.5-9B"
+    key: "${BK_KEY}_record_Qwen_Qwen3_5-9B_UnitTest"
+    depends_on: "${BK_KEY}_Qwen_Qwen3_5-9B_UnitTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "Qwen/Qwen3.5-9B"
       CI_STAGE: "UnitTest"
@@ -33,25 +36,27 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_Qwen_Qwen3_5-9B_UnitTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_Qwen_Qwen3_5-9B_UnitTest
 
-  - label: "${TPU_VERSION:-tpu6e} Accuracy for Qwen/Qwen3.5-9B"
-    key: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3_5-9B_Accuracy"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen3_5-9B_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Accuracy for Qwen/Qwen3.5-9B"
+    key: "${BK_KEY}_Qwen_Qwen3_5-9B_Accuracy"
+    depends_on: "${BK_KEY}_record_Qwen_Qwen3_5-9B_UnitTest"
     soft_fail: true
     agents:
       queue: cpu  # TODO: replace with execution environment
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       TEST_MODEL: Qwen/Qwen3.5-9B
       TENSOR_PARALLEL_SIZE: "${TENSOR_PARALLEL_SIZE_SINGLE:-1}"
       MINIMUM_ACCURACY_THRESHOLD: 0  # TODO : replace 0 with your accuracy threshold
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_Qwen_Qwen3_5-9B_Accuracy" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record accuracy result for Qwen/Qwen3.5-9B"
-    key: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen3_5-9B_Accuracy"
-    depends_on: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3_5-9B_Accuracy"
+        buildkite-agent meta-data set "${BK_KEY}_Qwen_Qwen3_5-9B_Accuracy" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record accuracy result for Qwen/Qwen3.5-9B"
+    key: "${BK_KEY}_record_Qwen_Qwen3_5-9B_Accuracy"
+    depends_on: "${BK_KEY}_Qwen_Qwen3_5-9B_Accuracy"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "Qwen/Qwen3.5-9B"
       CI_STAGE: "Accuracy/Correctness"
@@ -60,25 +65,27 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_Qwen_Qwen3_5-9B_Accuracy
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_Qwen_Qwen3_5-9B_Accuracy
 
-  - label: "${TPU_VERSION:-tpu6e} Performance benchmarks for Qwen/Qwen3.5-9B"
-    key: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3_5-9B_Benchmark"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen3_5-9B_Accuracy"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance benchmarks for Qwen/Qwen3.5-9B"
+    key: "${BK_KEY}_Qwen_Qwen3_5-9B_Benchmark"
+    depends_on: "${BK_KEY}_record_Qwen_Qwen3_5-9B_Accuracy"
     soft_fail: true
     agents:
       queue: cpu  # TODO: replace with execution environment
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       TEST_MODEL: Qwen/Qwen3.5-9B
       TENSOR_PARALLEL_SIZE: "${TENSOR_PARALLEL_SIZE_SINGLE:-1}"
       MINIMUM_THROUGHPUT_THRESHOLD: 0  # TODO : replace 0 with your performance threshold
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_Qwen_Qwen3_5-9B_Benchmark" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance benchmark result for Qwen/Qwen3.5-9B"
-    key: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen3_5-9B_Benchmark"
-    depends_on: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3_5-9B_Benchmark"
+        buildkite-agent meta-data set "${BK_KEY}_Qwen_Qwen3_5-9B_Benchmark" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance benchmark result for Qwen/Qwen3.5-9B"
+    key: "${BK_KEY}_record_Qwen_Qwen3_5-9B_Benchmark"
+    depends_on: "${BK_KEY}_Qwen_Qwen3_5-9B_Benchmark"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "Qwen/Qwen3.5-9B"
       CI_STAGE: "Benchmark"
@@ -87,4 +94,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_Qwen_Qwen3_5-9B_Benchmark
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_Qwen_Qwen3_5-9B_Benchmark

--- a/.buildkite/models/deepseek-ai_DeepSeek-Math-V2.yml
+++ b/.buildkite/models/deepseek-ai_DeepSeek-Math-V2.yml
@@ -39,7 +39,7 @@ steps:
         .buildkite/scripts/record_step_result.sh ${BK_KEY}_deepseek-ai_DeepSeek-Math-V2_UnitTest
 
   - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Accuracy for deepseek-ai/DeepSeek-Math-V2"
-    key: "${BK_KEY}_deepseek-ai_DeepSeek-Math-V2_Accuracy"
+    key: "${BK_KEY}_deepseek-ai_DeepSeek-Math-V2_Accuracy_Correctness"
     depends_on: "${BK_KEY}_record_deepseek-ai_DeepSeek-Math-V2_UnitTest"
     soft_fail: true
     agents:
@@ -51,10 +51,10 @@ steps:
       MINIMUM_ACCURACY_THRESHOLD: 0  # TODO : replace 0 with your accuracy threshold
     commands:
       - |
-        buildkite-agent meta-data set "${BK_KEY}_deepseek-ai_DeepSeek-Math-V2_Accuracy" "unverified"
+        buildkite-agent meta-data set "${BK_KEY}_deepseek-ai_DeepSeek-Math-V2_Accuracy_Correctness" "unverified"
   - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record accuracy result for deepseek-ai/DeepSeek-Math-V2"
-    key: "${BK_KEY}_record_deepseek-ai_DeepSeek-Math-V2_Accuracy"
-    depends_on: "${BK_KEY}_deepseek-ai_DeepSeek-Math-V2_Accuracy"
+    key: "${BK_KEY}_record_deepseek-ai_DeepSeek-Math-V2_Accuracy_Correctness"
+    depends_on: "${BK_KEY}_deepseek-ai_DeepSeek-Math-V2_Accuracy_Correctness"
     env:
       MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
@@ -65,11 +65,11 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${BK_KEY}_deepseek-ai_DeepSeek-Math-V2_Accuracy
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_deepseek-ai_DeepSeek-Math-V2_Accuracy_Correctness
 
   - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance benchmarks for deepseek-ai/DeepSeek-Math-V2"
     key: "${BK_KEY}_deepseek-ai_DeepSeek-Math-V2_Benchmark"
-    depends_on: "${BK_KEY}_record_deepseek-ai_DeepSeek-Math-V2_Accuracy"
+    depends_on: "${BK_KEY}_record_deepseek-ai_DeepSeek-Math-V2_Accuracy_Correctness"
     soft_fail: true
     agents:
       queue: cpu  # TODO: replace with execution environment

--- a/.buildkite/models/deepseek-ai_DeepSeek-Math-V2.yml
+++ b/.buildkite/models/deepseek-ai_DeepSeek-Math-V2.yml
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Unit tests for deepseek-ai/DeepSeek-Math-V2"
-    key: "${TPU_VERSION:-tpu6e}_deepseek-ai_DeepSeek-Math-V2_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Unit tests for deepseek-ai/DeepSeek-Math-V2"
+    key: "${BK_KEY}_deepseek-ai_DeepSeek-Math-V2_UnitTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_deepseek-ai_DeepSeek-Math-V2_UnitTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record unit test result for deepseek-ai/DeepSeek-Math-V2"
-    key: "${TPU_VERSION:-tpu6e}_record_deepseek-ai_DeepSeek-Math-V2_UnitTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_deepseek-ai_DeepSeek-Math-V2_UnitTest"
+        buildkite-agent meta-data set "${BK_KEY}_deepseek-ai_DeepSeek-Math-V2_UnitTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record unit test result for deepseek-ai/DeepSeek-Math-V2"
+    key: "${BK_KEY}_record_deepseek-ai_DeepSeek-Math-V2_UnitTest"
+    depends_on: "${BK_KEY}_deepseek-ai_DeepSeek-Math-V2_UnitTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "deepseek-ai/DeepSeek-Math-V2"
       CI_STAGE: "UnitTest"
@@ -33,25 +36,27 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_deepseek-ai_DeepSeek-Math-V2_UnitTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_deepseek-ai_DeepSeek-Math-V2_UnitTest
 
-  - label: "${TPU_VERSION:-tpu6e} Accuracy for deepseek-ai/DeepSeek-Math-V2"
-    key: "${TPU_VERSION:-tpu6e}_deepseek-ai_DeepSeek-Math-V2_Accuracy"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_deepseek-ai_DeepSeek-Math-V2_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Accuracy for deepseek-ai/DeepSeek-Math-V2"
+    key: "${BK_KEY}_deepseek-ai_DeepSeek-Math-V2_Accuracy"
+    depends_on: "${BK_KEY}_record_deepseek-ai_DeepSeek-Math-V2_UnitTest"
     soft_fail: true
     agents:
       queue: cpu  # TODO: replace with execution environment
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       TEST_MODEL: deepseek-ai/DeepSeek-Math-V2
       TENSOR_PARALLEL_SIZE: "${TENSOR_PARALLEL_SIZE_SINGLE:-1}"
       MINIMUM_ACCURACY_THRESHOLD: 0  # TODO : replace 0 with your accuracy threshold
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_deepseek-ai_DeepSeek-Math-V2_Accuracy" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record accuracy result for deepseek-ai/DeepSeek-Math-V2"
-    key: "${TPU_VERSION:-tpu6e}_record_deepseek-ai_DeepSeek-Math-V2_Accuracy"
-    depends_on: "${TPU_VERSION:-tpu6e}_deepseek-ai_DeepSeek-Math-V2_Accuracy"
+        buildkite-agent meta-data set "${BK_KEY}_deepseek-ai_DeepSeek-Math-V2_Accuracy" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record accuracy result for deepseek-ai/DeepSeek-Math-V2"
+    key: "${BK_KEY}_record_deepseek-ai_DeepSeek-Math-V2_Accuracy"
+    depends_on: "${BK_KEY}_deepseek-ai_DeepSeek-Math-V2_Accuracy"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "deepseek-ai/DeepSeek-Math-V2"
       CI_STAGE: "Accuracy/Correctness"
@@ -60,25 +65,27 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_deepseek-ai_DeepSeek-Math-V2_Accuracy
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_deepseek-ai_DeepSeek-Math-V2_Accuracy
 
-  - label: "${TPU_VERSION:-tpu6e} Performance benchmarks for deepseek-ai/DeepSeek-Math-V2"
-    key: "${TPU_VERSION:-tpu6e}_deepseek-ai_DeepSeek-Math-V2_Benchmark"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_deepseek-ai_DeepSeek-Math-V2_Accuracy"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance benchmarks for deepseek-ai/DeepSeek-Math-V2"
+    key: "${BK_KEY}_deepseek-ai_DeepSeek-Math-V2_Benchmark"
+    depends_on: "${BK_KEY}_record_deepseek-ai_DeepSeek-Math-V2_Accuracy"
     soft_fail: true
     agents:
       queue: cpu  # TODO: replace with execution environment
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       TEST_MODEL: deepseek-ai/DeepSeek-Math-V2
       TENSOR_PARALLEL_SIZE: "${TENSOR_PARALLEL_SIZE_SINGLE:-1}"
       MINIMUM_THROUGHPUT_THRESHOLD: 0  # TODO : replace 0 with your performance threshold
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_deepseek-ai_DeepSeek-Math-V2_Benchmark" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance benchmark result for deepseek-ai/DeepSeek-Math-V2"
-    key: "${TPU_VERSION:-tpu6e}_record_deepseek-ai_DeepSeek-Math-V2_Benchmark"
-    depends_on: "${TPU_VERSION:-tpu6e}_deepseek-ai_DeepSeek-Math-V2_Benchmark"
+        buildkite-agent meta-data set "${BK_KEY}_deepseek-ai_DeepSeek-Math-V2_Benchmark" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance benchmark result for deepseek-ai/DeepSeek-Math-V2"
+    key: "${BK_KEY}_record_deepseek-ai_DeepSeek-Math-V2_Benchmark"
+    depends_on: "${BK_KEY}_deepseek-ai_DeepSeek-Math-V2_Benchmark"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "deepseek-ai/DeepSeek-Math-V2"
       CI_STAGE: "Benchmark"
@@ -87,4 +94,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_deepseek-ai_DeepSeek-Math-V2_Benchmark
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_deepseek-ai_DeepSeek-Math-V2_Benchmark

--- a/.buildkite/models/deepseek-ai_DeepSeek-OCR.yml
+++ b/.buildkite/models/deepseek-ai_DeepSeek-OCR.yml
@@ -39,7 +39,7 @@ steps:
         .buildkite/scripts/record_step_result.sh ${BK_KEY}_deepseek-ai_DeepSeek-OCR_UnitTest
 
   - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Accuracy for deepseek-ai/DeepSeek-OCR"
-    key: "${BK_KEY}_deepseek-ai_DeepSeek-OCR_Accuracy"
+    key: "${BK_KEY}_deepseek-ai_DeepSeek-OCR_Accuracy_Correctness"
     depends_on: "${BK_KEY}_record_deepseek-ai_DeepSeek-OCR_UnitTest"
     soft_fail: true
     agents:
@@ -51,10 +51,10 @@ steps:
       MINIMUM_ACCURACY_THRESHOLD: 0  # TODO : replace 0 with your accuracy threshold
     commands:
       - |
-        buildkite-agent meta-data set "${BK_KEY}_deepseek-ai_DeepSeek-OCR_Accuracy" "unverified"
+        buildkite-agent meta-data set "${BK_KEY}_deepseek-ai_DeepSeek-OCR_Accuracy_Correctness" "unverified"
   - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record accuracy result for deepseek-ai/DeepSeek-OCR"
-    key: "${BK_KEY}_record_deepseek-ai_DeepSeek-OCR_Accuracy"
-    depends_on: "${BK_KEY}_deepseek-ai_DeepSeek-OCR_Accuracy"
+    key: "${BK_KEY}_record_deepseek-ai_DeepSeek-OCR_Accuracy_Correctness"
+    depends_on: "${BK_KEY}_deepseek-ai_DeepSeek-OCR_Accuracy_Correctness"
     env:
       MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
@@ -65,11 +65,11 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${BK_KEY}_deepseek-ai_DeepSeek-OCR_Accuracy
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_deepseek-ai_DeepSeek-OCR_Accuracy_Correctness
 
   - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance benchmarks for deepseek-ai/DeepSeek-OCR"
     key: "${BK_KEY}_deepseek-ai_DeepSeek-OCR_Benchmark"
-    depends_on: "${BK_KEY}_record_deepseek-ai_DeepSeek-OCR_Accuracy"
+    depends_on: "${BK_KEY}_record_deepseek-ai_DeepSeek-OCR_Accuracy_Correctness"
     soft_fail: true
     agents:
       queue: cpu  # TODO: replace with execution environment

--- a/.buildkite/models/deepseek-ai_DeepSeek-OCR.yml
+++ b/.buildkite/models/deepseek-ai_DeepSeek-OCR.yml
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Unit tests for deepseek-ai/DeepSeek-OCR"
-    key: "${TPU_VERSION:-tpu6e}_deepseek-ai_DeepSeek-OCR_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Unit tests for deepseek-ai/DeepSeek-OCR"
+    key: "${BK_KEY}_deepseek-ai_DeepSeek-OCR_UnitTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_deepseek-ai_DeepSeek-OCR_UnitTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record unit test result for deepseek-ai/DeepSeek-OCR"
-    key: "${TPU_VERSION:-tpu6e}_record_deepseek-ai_DeepSeek-OCR_UnitTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_deepseek-ai_DeepSeek-OCR_UnitTest"
+        buildkite-agent meta-data set "${BK_KEY}_deepseek-ai_DeepSeek-OCR_UnitTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record unit test result for deepseek-ai/DeepSeek-OCR"
+    key: "${BK_KEY}_record_deepseek-ai_DeepSeek-OCR_UnitTest"
+    depends_on: "${BK_KEY}_deepseek-ai_DeepSeek-OCR_UnitTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "deepseek-ai/DeepSeek-OCR"
       CI_STAGE: "UnitTest"
@@ -33,25 +36,27 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_deepseek-ai_DeepSeek-OCR_UnitTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_deepseek-ai_DeepSeek-OCR_UnitTest
 
-  - label: "${TPU_VERSION:-tpu6e} Accuracy for deepseek-ai/DeepSeek-OCR"
-    key: "${TPU_VERSION:-tpu6e}_deepseek-ai_DeepSeek-OCR_Accuracy"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_deepseek-ai_DeepSeek-OCR_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Accuracy for deepseek-ai/DeepSeek-OCR"
+    key: "${BK_KEY}_deepseek-ai_DeepSeek-OCR_Accuracy"
+    depends_on: "${BK_KEY}_record_deepseek-ai_DeepSeek-OCR_UnitTest"
     soft_fail: true
     agents:
       queue: cpu  # TODO: replace with execution environment
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       TEST_MODEL: deepseek-ai/DeepSeek-OCR
       TENSOR_PARALLEL_SIZE: "${TENSOR_PARALLEL_SIZE_SINGLE:-1}"
       MINIMUM_ACCURACY_THRESHOLD: 0  # TODO : replace 0 with your accuracy threshold
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_deepseek-ai_DeepSeek-OCR_Accuracy" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record accuracy result for deepseek-ai/DeepSeek-OCR"
-    key: "${TPU_VERSION:-tpu6e}_record_deepseek-ai_DeepSeek-OCR_Accuracy"
-    depends_on: "${TPU_VERSION:-tpu6e}_deepseek-ai_DeepSeek-OCR_Accuracy"
+        buildkite-agent meta-data set "${BK_KEY}_deepseek-ai_DeepSeek-OCR_Accuracy" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record accuracy result for deepseek-ai/DeepSeek-OCR"
+    key: "${BK_KEY}_record_deepseek-ai_DeepSeek-OCR_Accuracy"
+    depends_on: "${BK_KEY}_deepseek-ai_DeepSeek-OCR_Accuracy"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "deepseek-ai/DeepSeek-OCR"
       CI_STAGE: "Accuracy/Correctness"
@@ -60,25 +65,27 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_deepseek-ai_DeepSeek-OCR_Accuracy
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_deepseek-ai_DeepSeek-OCR_Accuracy
 
-  - label: "${TPU_VERSION:-tpu6e} Performance benchmarks for deepseek-ai/DeepSeek-OCR"
-    key: "${TPU_VERSION:-tpu6e}_deepseek-ai_DeepSeek-OCR_Benchmark"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_deepseek-ai_DeepSeek-OCR_Accuracy"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance benchmarks for deepseek-ai/DeepSeek-OCR"
+    key: "${BK_KEY}_deepseek-ai_DeepSeek-OCR_Benchmark"
+    depends_on: "${BK_KEY}_record_deepseek-ai_DeepSeek-OCR_Accuracy"
     soft_fail: true
     agents:
       queue: cpu  # TODO: replace with execution environment
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       TEST_MODEL: deepseek-ai/DeepSeek-OCR
       TENSOR_PARALLEL_SIZE: "${TENSOR_PARALLEL_SIZE_SINGLE:-1}"
       MINIMUM_THROUGHPUT_THRESHOLD: 0  # TODO : replace 0 with your performance threshold
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_deepseek-ai_DeepSeek-OCR_Benchmark" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance benchmark result for deepseek-ai/DeepSeek-OCR"
-    key: "${TPU_VERSION:-tpu6e}_record_deepseek-ai_DeepSeek-OCR_Benchmark"
-    depends_on: "${TPU_VERSION:-tpu6e}_deepseek-ai_DeepSeek-OCR_Benchmark"
+        buildkite-agent meta-data set "${BK_KEY}_deepseek-ai_DeepSeek-OCR_Benchmark" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance benchmark result for deepseek-ai/DeepSeek-OCR"
+    key: "${BK_KEY}_record_deepseek-ai_DeepSeek-OCR_Benchmark"
+    depends_on: "${BK_KEY}_deepseek-ai_DeepSeek-OCR_Benchmark"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "deepseek-ai/DeepSeek-OCR"
       CI_STAGE: "Benchmark"
@@ -87,4 +94,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_deepseek-ai_DeepSeek-OCR_Benchmark
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_deepseek-ai_DeepSeek-OCR_Benchmark

--- a/.buildkite/models/deepseek-ai_DeepSeek-R1.yml
+++ b/.buildkite/models/deepseek-ai_DeepSeek-R1.yml
@@ -13,15 +13,15 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Unit tests for deepseek-ai/DeepSeek-R1"
-    key: "${TPU_VERSION:-tpu6e}_deepseek-ai_DeepSeek-R1_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Unit tests for deepseek-ai/DeepSeek-R1"
+    key: "${BK_KEY}_deepseek-ai_DeepSeek-R1_UnitTest"
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
         if [ "${TPU_VERSION:-tpu6e}" = "tpu6e" ]; then
-          buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_deepseek-ai_DeepSeek-R1_UnitTest" "not enough HBM"
+          buildkite-agent meta-data set "${BK_KEY}_deepseek-ai_DeepSeek-R1_UnitTest" "not enough HBM"
         else
           .buildkite/scripts/run_in_docker.sh \
             bash /workspace/tpu_inference/tests/e2e/benchmarking/mlperf.sh -m "gs://tpu-commons-ci/deepseek/r1"
@@ -36,10 +36,11 @@ steps:
       MOE_REQUANTIZE_WEIGHT_DTYPE: "fp4"
       MODEL_IMPL_TYPE: "flax_nnx"
 
-  - label: "${TPU_VERSION:-tpu6e} Record unit test result for deepseek-ai/DeepSeek-R1"
-    key: "${TPU_VERSION:-tpu6e}_record_deepseek-ai_DeepSeek-R1_UnitTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_deepseek-ai_DeepSeek-R1_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record unit test result for deepseek-ai/DeepSeek-R1"
+    key: "${BK_KEY}_record_deepseek-ai_DeepSeek-R1_UnitTest"
+    depends_on: "${BK_KEY}_deepseek-ai_DeepSeek-R1_UnitTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "deepseek-ai/DeepSeek-R1"
       CI_STAGE: "UnitTest"
@@ -48,11 +49,11 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_deepseek-ai_DeepSeek-R1_UnitTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_deepseek-ai_DeepSeek-R1_UnitTest
 
-  - label: "${TPU_VERSION:-tpu6e} Accuracy for deepseek-ai/DeepSeek-R1"
-    key: "${TPU_VERSION:-tpu6e}_deepseek-ai_DeepSeek-R1_Accuracy"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_deepseek-ai_DeepSeek-R1_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Accuracy for deepseek-ai/DeepSeek-R1"
+    key: "${BK_KEY}_deepseek-ai_DeepSeek-R1_Accuracy"
+    depends_on: "${BK_KEY}_record_deepseek-ai_DeepSeek-R1_UnitTest"
     soft_fail: true
     agents:
       queue: ${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}
@@ -69,15 +70,16 @@ steps:
     commands:
       - |
         if [ "${TPU_VERSION:-tpu6e}" = "tpu6e" ]; then
-          buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_deepseek-ai_DeepSeek-R1_Accuracy" "not enough HBM"
+          buildkite-agent meta-data set "${BK_KEY}_deepseek-ai_DeepSeek-R1_Accuracy" "not enough HBM"
         else
           .buildkite/scripts/run_in_docker.sh \
             bash /workspace/tpu_inference/tests/e2e/benchmarking/mmlu.sh -m  "gs://tpu-commons-ci/deepseek/r1" -n 14042 -l 4
         fi
-  - label: "${TPU_VERSION:-tpu6e} Record accuracy result for deepseek-ai/DeepSeek-R1"
-    key: "${TPU_VERSION:-tpu6e}_record_deepseek-ai_DeepSeek-R1_Accuracy"
-    depends_on: "${TPU_VERSION:-tpu6e}_deepseek-ai_DeepSeek-R1_Accuracy"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record accuracy result for deepseek-ai/DeepSeek-R1"
+    key: "${BK_KEY}_record_deepseek-ai_DeepSeek-R1_Accuracy"
+    depends_on: "${BK_KEY}_deepseek-ai_DeepSeek-R1_Accuracy"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "deepseek-ai/DeepSeek-R1"
       CI_STAGE: "Accuracy/Correctness"
@@ -86,25 +88,27 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_deepseek-ai_DeepSeek-R1_Accuracy
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_deepseek-ai_DeepSeek-R1_Accuracy
 
-  - label: "${TPU_VERSION:-tpu6e} Performance benchmarks for deepseek-ai/DeepSeek-R1"
-    key: "${TPU_VERSION:-tpu6e}_deepseek-ai_DeepSeek-R1_Benchmark"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_deepseek-ai_DeepSeek-R1_Accuracy"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance benchmarks for deepseek-ai/DeepSeek-R1"
+    key: "${BK_KEY}_deepseek-ai_DeepSeek-R1_Benchmark"
+    depends_on: "${BK_KEY}_record_deepseek-ai_DeepSeek-R1_Accuracy"
     soft_fail: true
     agents:
       queue: cpu  # TODO: replace with execution environment
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       TEST_MODEL: deepseek-ai/DeepSeek-R1
       TENSOR_PARALLEL_SIZE: "${TENSOR_PARALLEL_SIZE_SINGLE:-1}"
       MINIMUM_THROUGHPUT_THRESHOLD: 0  # TODO : replace 0 with your performance threshold
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_deepseek-ai_DeepSeek-R1_Benchmark" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance benchmark result for deepseek-ai/DeepSeek-R1"
-    key: "${TPU_VERSION:-tpu6e}_record_deepseek-ai_DeepSeek-R1_Benchmark"
-    depends_on: "${TPU_VERSION:-tpu6e}_deepseek-ai_DeepSeek-R1_Benchmark"
+        buildkite-agent meta-data set "${BK_KEY}_deepseek-ai_DeepSeek-R1_Benchmark" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance benchmark result for deepseek-ai/DeepSeek-R1"
+    key: "${BK_KEY}_record_deepseek-ai_DeepSeek-R1_Benchmark"
+    depends_on: "${BK_KEY}_deepseek-ai_DeepSeek-R1_Benchmark"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "deepseek-ai/DeepSeek-R1"
       CI_STAGE: "Benchmark"
@@ -113,4 +117,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_deepseek-ai_DeepSeek-R1_Benchmark
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_deepseek-ai_DeepSeek-R1_Benchmark

--- a/.buildkite/models/deepseek-ai_DeepSeek-R1.yml
+++ b/.buildkite/models/deepseek-ai_DeepSeek-R1.yml
@@ -52,7 +52,7 @@ steps:
         .buildkite/scripts/record_step_result.sh ${BK_KEY}_deepseek-ai_DeepSeek-R1_UnitTest
 
   - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Accuracy for deepseek-ai/DeepSeek-R1"
-    key: "${BK_KEY}_deepseek-ai_DeepSeek-R1_Accuracy"
+    key: "${BK_KEY}_deepseek-ai_DeepSeek-R1_Accuracy_Correctness"
     depends_on: "${BK_KEY}_record_deepseek-ai_DeepSeek-R1_UnitTest"
     soft_fail: true
     agents:
@@ -70,14 +70,14 @@ steps:
     commands:
       - |
         if [ "${TPU_VERSION:-tpu6e}" = "tpu6e" ]; then
-          buildkite-agent meta-data set "${BK_KEY}_deepseek-ai_DeepSeek-R1_Accuracy" "not enough HBM"
+          buildkite-agent meta-data set "${BK_KEY}_deepseek-ai_DeepSeek-R1_Accuracy_Correctness" "not enough HBM"
         else
           .buildkite/scripts/run_in_docker.sh \
             bash /workspace/tpu_inference/tests/e2e/benchmarking/mmlu.sh -m  "gs://tpu-commons-ci/deepseek/r1" -n 14042 -l 4
         fi
   - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record accuracy result for deepseek-ai/DeepSeek-R1"
-    key: "${BK_KEY}_record_deepseek-ai_DeepSeek-R1_Accuracy"
-    depends_on: "${BK_KEY}_deepseek-ai_DeepSeek-R1_Accuracy"
+    key: "${BK_KEY}_record_deepseek-ai_DeepSeek-R1_Accuracy_Correctness"
+    depends_on: "${BK_KEY}_deepseek-ai_DeepSeek-R1_Accuracy_Correctness"
     env:
       MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
@@ -88,11 +88,11 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${BK_KEY}_deepseek-ai_DeepSeek-R1_Accuracy
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_deepseek-ai_DeepSeek-R1_Accuracy_Correctness
 
   - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance benchmarks for deepseek-ai/DeepSeek-R1"
     key: "${BK_KEY}_deepseek-ai_DeepSeek-R1_Benchmark"
-    depends_on: "${BK_KEY}_record_deepseek-ai_DeepSeek-R1_Accuracy"
+    depends_on: "${BK_KEY}_record_deepseek-ai_DeepSeek-R1_Accuracy_Correctness"
     soft_fail: true
     agents:
       queue: cpu  # TODO: replace with execution environment

--- a/.buildkite/models/deepseek-ai_DeepSeek-V3.1.yml
+++ b/.buildkite/models/deepseek-ai_DeepSeek-V3.1.yml
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Unit tests for deepseek-ai/DeepSeek-V3.1"
-    key: "${TPU_VERSION:-tpu6e}_deepseek-ai_DeepSeek-V3_1_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Unit tests for deepseek-ai/DeepSeek-V3.1"
+    key: "${BK_KEY}_deepseek-ai_DeepSeek-V3_1_UnitTest"
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}")
     soft_fail: true
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_deepseek-ai_DeepSeek-V3_1_UnitTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record unit test result for deepseek-ai/DeepSeek-V3.1"
-    key: "${TPU_VERSION:-tpu6e}_record_deepseek-ai_DeepSeek-V3_1_UnitTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_deepseek-ai_DeepSeek-V3_1_UnitTest"
+        buildkite-agent meta-data set "${BK_KEY}_deepseek-ai_DeepSeek-V3_1_UnitTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record unit test result for deepseek-ai/DeepSeek-V3.1"
+    key: "${BK_KEY}_record_deepseek-ai_DeepSeek-V3_1_UnitTest"
+    depends_on: "${BK_KEY}_deepseek-ai_DeepSeek-V3_1_UnitTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "deepseek-ai/DeepSeek-V3.1"
       CI_STAGE: "UnitTest"
@@ -33,21 +36,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_deepseek-ai_DeepSeek-V3_1_UnitTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_deepseek-ai_DeepSeek-V3_1_UnitTest
 
-  - label: "${TPU_VERSION:-tpu6e} Accuracy for deepseek-ai/DeepSeek-V3.1"
-    key: "${TPU_VERSION:-tpu6e}_deepseek-ai_DeepSeek-V3_1_Accuracy"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_deepseek-ai_DeepSeek-V3_1_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Accuracy for deepseek-ai/DeepSeek-V3.1"
+    key: "${BK_KEY}_deepseek-ai_DeepSeek-V3_1_Accuracy"
+    depends_on: "${BK_KEY}_record_deepseek-ai_DeepSeek-V3_1_UnitTest"
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}")
     soft_fail: true
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_deepseek-ai_DeepSeek-V3_1_Accuracy" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record accuracy result for deepseek-ai/DeepSeek-V3.1"
-    key: "${TPU_VERSION:-tpu6e}_record_deepseek-ai_DeepSeek-V3_1_Accuracy"
-    depends_on: "${TPU_VERSION:-tpu6e}_deepseek-ai_DeepSeek-V3_1_Accuracy"
+        buildkite-agent meta-data set "${BK_KEY}_deepseek-ai_DeepSeek-V3_1_Accuracy" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record accuracy result for deepseek-ai/DeepSeek-V3.1"
+    key: "${BK_KEY}_record_deepseek-ai_DeepSeek-V3_1_Accuracy"
+    depends_on: "${BK_KEY}_deepseek-ai_DeepSeek-V3_1_Accuracy"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "deepseek-ai/DeepSeek-V3.1"
       CI_STAGE: "Accuracy/Correctness"
@@ -56,21 +62,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_deepseek-ai_DeepSeek-V3_1_Accuracy
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_deepseek-ai_DeepSeek-V3_1_Accuracy
 
-  - label: "${TPU_VERSION:-tpu6e} Performance benchmarks for deepseek-ai/DeepSeek-V3.1"
-    key: "${TPU_VERSION:-tpu6e}_deepseek-ai_DeepSeek-V3_1_Benchmark"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_deepseek-ai_DeepSeek-V3_1_Accuracy"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance benchmarks for deepseek-ai/DeepSeek-V3.1"
+    key: "${BK_KEY}_deepseek-ai_DeepSeek-V3_1_Benchmark"
+    depends_on: "${BK_KEY}_record_deepseek-ai_DeepSeek-V3_1_Accuracy"
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}")
     soft_fail: true
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_deepseek-ai_DeepSeek-V3_1_Benchmark" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance benchmark result for deepseek-ai/DeepSeek-V3.1"
-    key: "${TPU_VERSION:-tpu6e}_record_deepseek-ai_DeepSeek-V3_1_Benchmark"
-    depends_on: "${TPU_VERSION:-tpu6e}_deepseek-ai_DeepSeek-V3_1_Benchmark"
+        buildkite-agent meta-data set "${BK_KEY}_deepseek-ai_DeepSeek-V3_1_Benchmark" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance benchmark result for deepseek-ai/DeepSeek-V3.1"
+    key: "${BK_KEY}_record_deepseek-ai_DeepSeek-V3_1_Benchmark"
+    depends_on: "${BK_KEY}_deepseek-ai_DeepSeek-V3_1_Benchmark"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "deepseek-ai/DeepSeek-V3.1"
       CI_STAGE: "Benchmark"
@@ -79,4 +88,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_deepseek-ai_DeepSeek-V3_1_Benchmark
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_deepseek-ai_DeepSeek-V3_1_Benchmark

--- a/.buildkite/models/deepseek-ai_DeepSeek-V3.1.yml
+++ b/.buildkite/models/deepseek-ai_DeepSeek-V3.1.yml
@@ -39,7 +39,7 @@ steps:
         .buildkite/scripts/record_step_result.sh ${BK_KEY}_deepseek-ai_DeepSeek-V3_1_UnitTest
 
   - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Accuracy for deepseek-ai/DeepSeek-V3.1"
-    key: "${BK_KEY}_deepseek-ai_DeepSeek-V3_1_Accuracy"
+    key: "${BK_KEY}_deepseek-ai_DeepSeek-V3_1_Accuracy_Correctness"
     depends_on: "${BK_KEY}_record_deepseek-ai_DeepSeek-V3_1_UnitTest"
     env:
       MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
@@ -48,10 +48,10 @@ steps:
     soft_fail: true
     commands:
       - |
-        buildkite-agent meta-data set "${BK_KEY}_deepseek-ai_DeepSeek-V3_1_Accuracy" "unverified"
+        buildkite-agent meta-data set "${BK_KEY}_deepseek-ai_DeepSeek-V3_1_Accuracy_Correctness" "unverified"
   - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record accuracy result for deepseek-ai/DeepSeek-V3.1"
-    key: "${BK_KEY}_record_deepseek-ai_DeepSeek-V3_1_Accuracy"
-    depends_on: "${BK_KEY}_deepseek-ai_DeepSeek-V3_1_Accuracy"
+    key: "${BK_KEY}_record_deepseek-ai_DeepSeek-V3_1_Accuracy_Correctness"
+    depends_on: "${BK_KEY}_deepseek-ai_DeepSeek-V3_1_Accuracy_Correctness"
     env:
       MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
@@ -62,11 +62,11 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${BK_KEY}_deepseek-ai_DeepSeek-V3_1_Accuracy
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_deepseek-ai_DeepSeek-V3_1_Accuracy_Correctness
 
   - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance benchmarks for deepseek-ai/DeepSeek-V3.1"
     key: "${BK_KEY}_deepseek-ai_DeepSeek-V3_1_Benchmark"
-    depends_on: "${BK_KEY}_record_deepseek-ai_DeepSeek-V3_1_Accuracy"
+    depends_on: "${BK_KEY}_record_deepseek-ai_DeepSeek-V3_1_Accuracy_Correctness"
     env:
       MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:

--- a/.buildkite/models/deepseek-ai_DeepSeek-V3.1.yml
+++ b/.buildkite/models/deepseek-ai_DeepSeek-V3.1.yml
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Unit tests for deepseek-ai/DeepSeek-V3.1"
-    key: "${TPU_VERSION:-tpu6e}_deepseek-ai_DeepSeek-V3_1_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Unit tests for deepseek-ai/DeepSeek-V3.1"
+    key: "${BK_KEY}_deepseek-ai_DeepSeek-V3_1_UnitTest"
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
     soft_fail: true
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_deepseek-ai_DeepSeek-V3_1_UnitTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record unit test result for deepseek-ai/DeepSeek-V3.1"
-    key: "${TPU_VERSION:-tpu6e}_record_deepseek-ai_DeepSeek-V3_1_UnitTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_deepseek-ai_DeepSeek-V3_1_UnitTest"
+        buildkite-agent meta-data set "${BK_KEY}_deepseek-ai_DeepSeek-V3_1_UnitTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record unit test result for deepseek-ai/DeepSeek-V3.1"
+    key: "${BK_KEY}_record_deepseek-ai_DeepSeek-V3_1_UnitTest"
+    depends_on: "${BK_KEY}_deepseek-ai_DeepSeek-V3_1_UnitTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "deepseek-ai/DeepSeek-V3.1"
       CI_STAGE: "UnitTest"
@@ -33,21 +36,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_deepseek-ai_DeepSeek-V3_1_UnitTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_deepseek-ai_DeepSeek-V3_1_UnitTest
 
-  - label: "${TPU_VERSION:-tpu6e} Accuracy for deepseek-ai/DeepSeek-V3.1"
-    key: "${TPU_VERSION:-tpu6e}_deepseek-ai_DeepSeek-V3_1_Accuracy"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_deepseek-ai_DeepSeek-V3_1_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Accuracy for deepseek-ai/DeepSeek-V3.1"
+    key: "${BK_KEY}_deepseek-ai_DeepSeek-V3_1_Accuracy"
+    depends_on: "${BK_KEY}_record_deepseek-ai_DeepSeek-V3_1_UnitTest"
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
     soft_fail: true
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_deepseek-ai_DeepSeek-V3_1_Accuracy" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record accuracy result for deepseek-ai/DeepSeek-V3.1"
-    key: "${TPU_VERSION:-tpu6e}_record_deepseek-ai_DeepSeek-V3_1_Accuracy"
-    depends_on: "${TPU_VERSION:-tpu6e}_deepseek-ai_DeepSeek-V3_1_Accuracy"
+        buildkite-agent meta-data set "${BK_KEY}_deepseek-ai_DeepSeek-V3_1_Accuracy" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record accuracy result for deepseek-ai/DeepSeek-V3.1"
+    key: "${BK_KEY}_record_deepseek-ai_DeepSeek-V3_1_Accuracy"
+    depends_on: "${BK_KEY}_deepseek-ai_DeepSeek-V3_1_Accuracy"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "deepseek-ai/DeepSeek-V3.1"
       CI_STAGE: "Accuracy/Correctness"
@@ -56,21 +62,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_deepseek-ai_DeepSeek-V3_1_Accuracy
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_deepseek-ai_DeepSeek-V3_1_Accuracy
 
-  - label: "${TPU_VERSION:-tpu6e} Performance benchmarks for deepseek-ai/DeepSeek-V3.1"
-    key: "${TPU_VERSION:-tpu6e}_deepseek-ai_DeepSeek-V3_1_Benchmark"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_deepseek-ai_DeepSeek-V3_1_Accuracy"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance benchmarks for deepseek-ai/DeepSeek-V3.1"
+    key: "${BK_KEY}_deepseek-ai_DeepSeek-V3_1_Benchmark"
+    depends_on: "${BK_KEY}_record_deepseek-ai_DeepSeek-V3_1_Accuracy"
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
     soft_fail: true
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_deepseek-ai_DeepSeek-V3_1_Benchmark" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance benchmark result for deepseek-ai/DeepSeek-V3.1"
-    key: "${TPU_VERSION:-tpu6e}_record_deepseek-ai_DeepSeek-V3_1_Benchmark"
-    depends_on: "${TPU_VERSION:-tpu6e}_deepseek-ai_DeepSeek-V3_1_Benchmark"
+        buildkite-agent meta-data set "${BK_KEY}_deepseek-ai_DeepSeek-V3_1_Benchmark" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance benchmark result for deepseek-ai/DeepSeek-V3.1"
+    key: "${BK_KEY}_record_deepseek-ai_DeepSeek-V3_1_Benchmark"
+    depends_on: "${BK_KEY}_deepseek-ai_DeepSeek-V3_1_Benchmark"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "deepseek-ai/DeepSeek-V3.1"
       CI_STAGE: "Benchmark"
@@ -79,4 +88,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_deepseek-ai_DeepSeek-V3_1_Benchmark
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_deepseek-ai_DeepSeek-V3_1_Benchmark

--- a/.buildkite/models/deepseek-ai_DeepSeek-V3_2-Speciale.yml
+++ b/.buildkite/models/deepseek-ai_DeepSeek-V3_2-Speciale.yml
@@ -39,7 +39,7 @@ steps:
         .buildkite/scripts/record_step_result.sh ${BK_KEY}_deepseek-ai_DeepSeek-V3_2-Speciale_UnitTest
 
   - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Accuracy for deepseek-ai/DeepSeek-V3.2-Speciale"
-    key: "${BK_KEY}_deepseek-ai_DeepSeek-V3_2-Speciale_Accuracy"
+    key: "${BK_KEY}_deepseek-ai_DeepSeek-V3_2-Speciale_Accuracy_Correctness"
     depends_on: "${BK_KEY}_record_deepseek-ai_DeepSeek-V3_2-Speciale_UnitTest"
     soft_fail: true
     agents:
@@ -51,10 +51,10 @@ steps:
       MINIMUM_ACCURACY_THRESHOLD: 0  # TODO : replace 0 with your accuracy threshold
     commands:
       - |
-        buildkite-agent meta-data set "${BK_KEY}_deepseek-ai_DeepSeek-V3_2-Speciale_Accuracy" "unverified"
+        buildkite-agent meta-data set "${BK_KEY}_deepseek-ai_DeepSeek-V3_2-Speciale_Accuracy_Correctness" "unverified"
   - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record accuracy result for deepseek-ai/DeepSeek-V3.2-Speciale"
-    key: "${BK_KEY}_record_deepseek-ai_DeepSeek-V3_2-Speciale_Accuracy"
-    depends_on: "${BK_KEY}_deepseek-ai_DeepSeek-V3_2-Speciale_Accuracy"
+    key: "${BK_KEY}_record_deepseek-ai_DeepSeek-V3_2-Speciale_Accuracy_Correctness"
+    depends_on: "${BK_KEY}_deepseek-ai_DeepSeek-V3_2-Speciale_Accuracy_Correctness"
     env:
       MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
@@ -65,11 +65,11 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${BK_KEY}_deepseek-ai_DeepSeek-V3_2-Speciale_Accuracy
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_deepseek-ai_DeepSeek-V3_2-Speciale_Accuracy_Correctness
 
   - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance benchmarks for deepseek-ai/DeepSeek-V3.2-Speciale"
     key: "${BK_KEY}_deepseek-ai_DeepSeek-V3_2-Speciale_Benchmark"
-    depends_on: "${BK_KEY}_record_deepseek-ai_DeepSeek-V3_2-Speciale_Accuracy"
+    depends_on: "${BK_KEY}_record_deepseek-ai_DeepSeek-V3_2-Speciale_Accuracy_Correctness"
     soft_fail: true
     agents:
       queue: cpu  # TODO: replace with execution environment

--- a/.buildkite/models/deepseek-ai_DeepSeek-V3_2-Speciale.yml
+++ b/.buildkite/models/deepseek-ai_DeepSeek-V3_2-Speciale.yml
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Unit tests for deepseek-ai/DeepSeek-V3.2-Speciale"
-    key: "${TPU_VERSION:-tpu6e}_deepseek-ai_DeepSeek-V3_2-Speciale_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Unit tests for deepseek-ai/DeepSeek-V3.2-Speciale"
+    key: "${BK_KEY}_deepseek-ai_DeepSeek-V3_2-Speciale_UnitTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_deepseek-ai_DeepSeek-V3_2-Speciale_UnitTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record unit test result for deepseek-ai/DeepSeek-V3.2-Speciale"
-    key: "${TPU_VERSION:-tpu6e}_record_deepseek-ai_DeepSeek-V3_2-Speciale_UnitTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_deepseek-ai_DeepSeek-V3_2-Speciale_UnitTest"
+        buildkite-agent meta-data set "${BK_KEY}_deepseek-ai_DeepSeek-V3_2-Speciale_UnitTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record unit test result for deepseek-ai/DeepSeek-V3.2-Speciale"
+    key: "${BK_KEY}_record_deepseek-ai_DeepSeek-V3_2-Speciale_UnitTest"
+    depends_on: "${BK_KEY}_deepseek-ai_DeepSeek-V3_2-Speciale_UnitTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "deepseek-ai/DeepSeek-V3.2-Speciale"
       CI_STAGE: "UnitTest"
@@ -33,25 +36,27 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_deepseek-ai_DeepSeek-V3_2-Speciale_UnitTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_deepseek-ai_DeepSeek-V3_2-Speciale_UnitTest
 
-  - label: "${TPU_VERSION:-tpu6e} Accuracy for deepseek-ai/DeepSeek-V3.2-Speciale"
-    key: "${TPU_VERSION:-tpu6e}_deepseek-ai_DeepSeek-V3_2-Speciale_Accuracy"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_deepseek-ai_DeepSeek-V3_2-Speciale_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Accuracy for deepseek-ai/DeepSeek-V3.2-Speciale"
+    key: "${BK_KEY}_deepseek-ai_DeepSeek-V3_2-Speciale_Accuracy"
+    depends_on: "${BK_KEY}_record_deepseek-ai_DeepSeek-V3_2-Speciale_UnitTest"
     soft_fail: true
     agents:
       queue: cpu  # TODO: replace with execution environment
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       TEST_MODEL: deepseek-ai/DeepSeek-V3.2-Speciale
       TENSOR_PARALLEL_SIZE: "${TENSOR_PARALLEL_SIZE_SINGLE:-1}"
       MINIMUM_ACCURACY_THRESHOLD: 0  # TODO : replace 0 with your accuracy threshold
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_deepseek-ai_DeepSeek-V3_2-Speciale_Accuracy" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record accuracy result for deepseek-ai/DeepSeek-V3.2-Speciale"
-    key: "${TPU_VERSION:-tpu6e}_record_deepseek-ai_DeepSeek-V3_2-Speciale_Accuracy"
-    depends_on: "${TPU_VERSION:-tpu6e}_deepseek-ai_DeepSeek-V3_2-Speciale_Accuracy"
+        buildkite-agent meta-data set "${BK_KEY}_deepseek-ai_DeepSeek-V3_2-Speciale_Accuracy" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record accuracy result for deepseek-ai/DeepSeek-V3.2-Speciale"
+    key: "${BK_KEY}_record_deepseek-ai_DeepSeek-V3_2-Speciale_Accuracy"
+    depends_on: "${BK_KEY}_deepseek-ai_DeepSeek-V3_2-Speciale_Accuracy"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "deepseek-ai/DeepSeek-V3.2-Speciale"
       CI_STAGE: "Accuracy/Correctness"
@@ -60,25 +65,27 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_deepseek-ai_DeepSeek-V3_2-Speciale_Accuracy
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_deepseek-ai_DeepSeek-V3_2-Speciale_Accuracy
 
-  - label: "${TPU_VERSION:-tpu6e} Performance benchmarks for deepseek-ai/DeepSeek-V3.2-Speciale"
-    key: "${TPU_VERSION:-tpu6e}_deepseek-ai_DeepSeek-V3_2-Speciale_Benchmark"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_deepseek-ai_DeepSeek-V3_2-Speciale_Accuracy"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance benchmarks for deepseek-ai/DeepSeek-V3.2-Speciale"
+    key: "${BK_KEY}_deepseek-ai_DeepSeek-V3_2-Speciale_Benchmark"
+    depends_on: "${BK_KEY}_record_deepseek-ai_DeepSeek-V3_2-Speciale_Accuracy"
     soft_fail: true
     agents:
       queue: cpu  # TODO: replace with execution environment
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       TEST_MODEL: deepseek-ai/DeepSeek-V3.2-Speciale
       TENSOR_PARALLEL_SIZE: "${TENSOR_PARALLEL_SIZE_SINGLE:-1}"
       MINIMUM_THROUGHPUT_THRESHOLD: 0  # TODO : replace 0 with your performance threshold
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_deepseek-ai_DeepSeek-V3_2-Speciale_Benchmark" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance benchmark result for deepseek-ai/DeepSeek-V3.2-Speciale"
-    key: "${TPU_VERSION:-tpu6e}_record_deepseek-ai_DeepSeek-V3_2-Speciale_Benchmark"
-    depends_on: "${TPU_VERSION:-tpu6e}_deepseek-ai_DeepSeek-V3_2-Speciale_Benchmark"
+        buildkite-agent meta-data set "${BK_KEY}_deepseek-ai_DeepSeek-V3_2-Speciale_Benchmark" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance benchmark result for deepseek-ai/DeepSeek-V3.2-Speciale"
+    key: "${BK_KEY}_record_deepseek-ai_DeepSeek-V3_2-Speciale_Benchmark"
+    depends_on: "${BK_KEY}_deepseek-ai_DeepSeek-V3_2-Speciale_Benchmark"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "deepseek-ai/DeepSeek-V3.2-Speciale"
       CI_STAGE: "Benchmark"
@@ -87,4 +94,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_deepseek-ai_DeepSeek-V3_2-Speciale_Benchmark
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_deepseek-ai_DeepSeek-V3_2-Speciale_Benchmark

--- a/.buildkite/models/deepseek-ai_DeepSeek-V3_2.yml
+++ b/.buildkite/models/deepseek-ai_DeepSeek-V3_2.yml
@@ -39,7 +39,7 @@ steps:
         .buildkite/scripts/record_step_result.sh ${BK_KEY}_deepseek-ai_DeepSeek-V3_2_UnitTest
 
   - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Accuracy for deepseek-ai/DeepSeek-V3.2"
-    key: "${BK_KEY}_deepseek-ai_DeepSeek-V3_2_Accuracy"
+    key: "${BK_KEY}_deepseek-ai_DeepSeek-V3_2_Accuracy_Correctness"
     depends_on: "${BK_KEY}_record_deepseek-ai_DeepSeek-V3_2_UnitTest"
     soft_fail: true
     agents:
@@ -51,10 +51,10 @@ steps:
       MINIMUM_ACCURACY_THRESHOLD: 0  # TODO : replace 0 with your accuracy threshold
     commands:
       - |
-        buildkite-agent meta-data set "${BK_KEY}_deepseek-ai_DeepSeek-V3_2_Accuracy" "unverified"
+        buildkite-agent meta-data set "${BK_KEY}_deepseek-ai_DeepSeek-V3_2_Accuracy_Correctness" "unverified"
   - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record accuracy result for deepseek-ai/DeepSeek-V3.2"
-    key: "${BK_KEY}_record_deepseek-ai_DeepSeek-V3_2_Accuracy"
-    depends_on: "${BK_KEY}_deepseek-ai_DeepSeek-V3_2_Accuracy"
+    key: "${BK_KEY}_record_deepseek-ai_DeepSeek-V3_2_Accuracy_Correctness"
+    depends_on: "${BK_KEY}_deepseek-ai_DeepSeek-V3_2_Accuracy_Correctness"
     env:
       MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
@@ -65,11 +65,11 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${BK_KEY}_deepseek-ai_DeepSeek-V3_2_Accuracy
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_deepseek-ai_DeepSeek-V3_2_Accuracy_Correctness
 
   - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance benchmarks for deepseek-ai/DeepSeek-V3.2"
     key: "${BK_KEY}_deepseek-ai_DeepSeek-V3_2_Benchmark"
-    depends_on: "${BK_KEY}_record_deepseek-ai_DeepSeek-V3_2_Accuracy"
+    depends_on: "${BK_KEY}_record_deepseek-ai_DeepSeek-V3_2_Accuracy_Correctness"
     soft_fail: true
     agents:
       queue: cpu  # TODO: replace with execution environment

--- a/.buildkite/models/deepseek-ai_DeepSeek-V3_2.yml
+++ b/.buildkite/models/deepseek-ai_DeepSeek-V3_2.yml
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Unit tests for deepseek-ai/DeepSeek-V3.2"
-    key: "${TPU_VERSION:-tpu6e}_deepseek-ai_DeepSeek-V3_2_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Unit tests for deepseek-ai/DeepSeek-V3.2"
+    key: "${BK_KEY}_deepseek-ai_DeepSeek-V3_2_UnitTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_deepseek-ai_DeepSeek-V3_2_UnitTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record unit test result for deepseek-ai/DeepSeek-V3.2"
-    key: "${TPU_VERSION:-tpu6e}_record_deepseek-ai_DeepSeek-V3_2_UnitTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_deepseek-ai_DeepSeek-V3_2_UnitTest"
+        buildkite-agent meta-data set "${BK_KEY}_deepseek-ai_DeepSeek-V3_2_UnitTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record unit test result for deepseek-ai/DeepSeek-V3.2"
+    key: "${BK_KEY}_record_deepseek-ai_DeepSeek-V3_2_UnitTest"
+    depends_on: "${BK_KEY}_deepseek-ai_DeepSeek-V3_2_UnitTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "deepseek-ai/DeepSeek-V3.2"
       CI_STAGE: "UnitTest"
@@ -33,25 +36,27 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_deepseek-ai_DeepSeek-V3_2_UnitTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_deepseek-ai_DeepSeek-V3_2_UnitTest
 
-  - label: "${TPU_VERSION:-tpu6e} Accuracy for deepseek-ai/DeepSeek-V3.2"
-    key: "${TPU_VERSION:-tpu6e}_deepseek-ai_DeepSeek-V3_2_Accuracy"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_deepseek-ai_DeepSeek-V3_2_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Accuracy for deepseek-ai/DeepSeek-V3.2"
+    key: "${BK_KEY}_deepseek-ai_DeepSeek-V3_2_Accuracy"
+    depends_on: "${BK_KEY}_record_deepseek-ai_DeepSeek-V3_2_UnitTest"
     soft_fail: true
     agents:
       queue: cpu  # TODO: replace with execution environment
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       TEST_MODEL: deepseek-ai/DeepSeek-V3.2
       TENSOR_PARALLEL_SIZE: "${TENSOR_PARALLEL_SIZE_SINGLE:-1}"
       MINIMUM_ACCURACY_THRESHOLD: 0  # TODO : replace 0 with your accuracy threshold
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_deepseek-ai_DeepSeek-V3_2_Accuracy" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record accuracy result for deepseek-ai/DeepSeek-V3.2"
-    key: "${TPU_VERSION:-tpu6e}_record_deepseek-ai_DeepSeek-V3_2_Accuracy"
-    depends_on: "${TPU_VERSION:-tpu6e}_deepseek-ai_DeepSeek-V3_2_Accuracy"
+        buildkite-agent meta-data set "${BK_KEY}_deepseek-ai_DeepSeek-V3_2_Accuracy" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record accuracy result for deepseek-ai/DeepSeek-V3.2"
+    key: "${BK_KEY}_record_deepseek-ai_DeepSeek-V3_2_Accuracy"
+    depends_on: "${BK_KEY}_deepseek-ai_DeepSeek-V3_2_Accuracy"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "deepseek-ai/DeepSeek-V3.2"
       CI_STAGE: "Accuracy/Correctness"
@@ -60,25 +65,27 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_deepseek-ai_DeepSeek-V3_2_Accuracy
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_deepseek-ai_DeepSeek-V3_2_Accuracy
 
-  - label: "${TPU_VERSION:-tpu6e} Performance benchmarks for deepseek-ai/DeepSeek-V3.2"
-    key: "${TPU_VERSION:-tpu6e}_deepseek-ai_DeepSeek-V3_2_Benchmark"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_deepseek-ai_DeepSeek-V3_2_Accuracy"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance benchmarks for deepseek-ai/DeepSeek-V3.2"
+    key: "${BK_KEY}_deepseek-ai_DeepSeek-V3_2_Benchmark"
+    depends_on: "${BK_KEY}_record_deepseek-ai_DeepSeek-V3_2_Accuracy"
     soft_fail: true
     agents:
       queue: cpu  # TODO: replace with execution environment
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       TEST_MODEL: deepseek-ai/DeepSeek-V3.2
       TENSOR_PARALLEL_SIZE: "${TENSOR_PARALLEL_SIZE_SINGLE:-1}"
       MINIMUM_THROUGHPUT_THRESHOLD: 0  # TODO : replace 0 with your performance threshold
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_deepseek-ai_DeepSeek-V3_2_Benchmark" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance benchmark result for deepseek-ai/DeepSeek-V3.2"
-    key: "${TPU_VERSION:-tpu6e}_record_deepseek-ai_DeepSeek-V3_2_Benchmark"
-    depends_on: "${TPU_VERSION:-tpu6e}_deepseek-ai_DeepSeek-V3_2_Benchmark"
+        buildkite-agent meta-data set "${BK_KEY}_deepseek-ai_DeepSeek-V3_2_Benchmark" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance benchmark result for deepseek-ai/DeepSeek-V3.2"
+    key: "${BK_KEY}_record_deepseek-ai_DeepSeek-V3_2_Benchmark"
+    depends_on: "${BK_KEY}_deepseek-ai_DeepSeek-V3_2_Benchmark"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "deepseek-ai/DeepSeek-V3.2"
       CI_STAGE: "Benchmark"
@@ -87,4 +94,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_deepseek-ai_DeepSeek-V3_2_Benchmark
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_deepseek-ai_DeepSeek-V3_2_Benchmark

--- a/.buildkite/models/google_gemma-3-27b-it.yml
+++ b/.buildkite/models/google_gemma-3-27b-it.yml
@@ -13,8 +13,10 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Unit tests for google/gemma-3-27b-it"
-    key: "${TPU_VERSION:-tpu6e}_google_gemma-3-27b-it_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Unit tests for google/gemma-3-27b-it"
+    key: "${BK_KEY}_google_gemma-3-27b-it_UnitTest"
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
     soft_fail: true
@@ -22,10 +24,11 @@ steps:
       - |
         .buildkite/scripts/run_in_docker.sh \
           bash -c 'SKIP_JAX_PRECOMPILE=1 VLLM_XLA_CHECK_RECOMPILATION=0 python3 /workspace/tpu_inference/examples/offline_inference.py --model=google/gemma-3-27b-it --tensor_parallel_size=8 --max_model_len=1024 --max_num_seqs=1'
-  - label: "${TPU_VERSION:-tpu6e} Record unit test result for google/gemma-3-27b-it"
-    key: "${TPU_VERSION:-tpu6e}_record_google_gemma-3-27b-it_UnitTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_google_gemma-3-27b-it_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record unit test result for google/gemma-3-27b-it"
+    key: "${BK_KEY}_record_google_gemma-3-27b-it_UnitTest"
+    depends_on: "${BK_KEY}_google_gemma-3-27b-it_UnitTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "google/gemma-3-27b-it"
       CI_STAGE: "UnitTest"
@@ -34,25 +37,27 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_google_gemma-3-27b-it_UnitTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_google_gemma-3-27b-it_UnitTest
 
-  - label: "${TPU_VERSION:-tpu6e} Accuracy for google/gemma-3-27b-it"
-    key: "${TPU_VERSION:-tpu6e}_google_gemma-3-27b-it_Accuracy"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_google_gemma-3-27b-it_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Accuracy for google/gemma-3-27b-it"
+    key: "${BK_KEY}_google_gemma-3-27b-it_Accuracy"
+    depends_on: "${BK_KEY}_record_google_gemma-3-27b-it_UnitTest"
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
     soft_fail: true
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       TEST_MODEL: google/gemma-3-27b-it
       TENSOR_PARALLEL_SIZE: "${TENSOR_PARALLEL_SIZE_MULTI:-8}"
       MINIMUM_ACCURACY_THRESHOLD: 0.56
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/test_accuracy.sh
-  - label: "${TPU_VERSION:-tpu6e} Record accuracy result for google/gemma-3-27b-it"
-    key: "${TPU_VERSION:-tpu6e}_record_google_gemma-3-27b-it_Accuracy"
-    depends_on: "${TPU_VERSION:-tpu6e}_google_gemma-3-27b-it_Accuracy"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record accuracy result for google/gemma-3-27b-it"
+    key: "${BK_KEY}_record_google_gemma-3-27b-it_Accuracy"
+    depends_on: "${BK_KEY}_google_gemma-3-27b-it_Accuracy"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "google/gemma-3-27b-it"
       CI_STAGE: "Accuracy/Correctness"
@@ -61,15 +66,16 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_google_gemma-3-27b-it_Accuracy
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_google_gemma-3-27b-it_Accuracy
 
-  - label: "${TPU_VERSION:-tpu6e} Performance benchmarks for google/gemma-3-27b-it"
-    key: "${TPU_VERSION:-tpu6e}_google_gemma-3-27b-it_Benchmark"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_google_gemma-3-27b-it_Accuracy"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance benchmarks for google/gemma-3-27b-it"
+    key: "${BK_KEY}_google_gemma-3-27b-it_Benchmark"
+    depends_on: "${BK_KEY}_record_google_gemma-3-27b-it_Accuracy"
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
     soft_fail: true
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       TEST_MODEL: google/gemma-3-27b-it
       TENSOR_PARALLEL_SIZE: "${TENSOR_PARALLEL_SIZE_MULTI:-8}"
       MINIMUM_THROUGHPUT_THRESHOLD: 21
@@ -82,10 +88,11 @@ steps:
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/benchmark.sh
-  - label: "${TPU_VERSION:-tpu6e} Record performance benchmark result for google/gemma-3-27b-it"
-    key: "${TPU_VERSION:-tpu6e}_record_google_gemma-3-27b-it_Benchmark"
-    depends_on: "${TPU_VERSION:-tpu6e}_google_gemma-3-27b-it_Benchmark"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance benchmark result for google/gemma-3-27b-it"
+    key: "${BK_KEY}_record_google_gemma-3-27b-it_Benchmark"
+    depends_on: "${BK_KEY}_google_gemma-3-27b-it_Benchmark"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "google/gemma-3-27b-it"
       CI_STAGE: "Benchmark"
@@ -94,4 +101,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_google_gemma-3-27b-it_Benchmark
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_google_gemma-3-27b-it_Benchmark

--- a/.buildkite/models/google_gemma-3-27b-it.yml
+++ b/.buildkite/models/google_gemma-3-27b-it.yml
@@ -40,7 +40,7 @@ steps:
         .buildkite/scripts/record_step_result.sh ${BK_KEY}_google_gemma-3-27b-it_UnitTest
 
   - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Accuracy for google/gemma-3-27b-it"
-    key: "${BK_KEY}_google_gemma-3-27b-it_Accuracy"
+    key: "${BK_KEY}_google_gemma-3-27b-it_Accuracy_Correctness"
     depends_on: "${BK_KEY}_record_google_gemma-3-27b-it_UnitTest"
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
@@ -54,8 +54,8 @@ steps:
       - |
         .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/test_accuracy.sh
   - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record accuracy result for google/gemma-3-27b-it"
-    key: "${BK_KEY}_record_google_gemma-3-27b-it_Accuracy"
-    depends_on: "${BK_KEY}_google_gemma-3-27b-it_Accuracy"
+    key: "${BK_KEY}_record_google_gemma-3-27b-it_Accuracy_Correctness"
+    depends_on: "${BK_KEY}_google_gemma-3-27b-it_Accuracy_Correctness"
     env:
       MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
@@ -66,11 +66,11 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${BK_KEY}_google_gemma-3-27b-it_Accuracy
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_google_gemma-3-27b-it_Accuracy_Correctness
 
   - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance benchmarks for google/gemma-3-27b-it"
     key: "${BK_KEY}_google_gemma-3-27b-it_Benchmark"
-    depends_on: "${BK_KEY}_record_google_gemma-3-27b-it_Accuracy"
+    depends_on: "${BK_KEY}_record_google_gemma-3-27b-it_Accuracy_Correctness"
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
     soft_fail: true

--- a/.buildkite/models/google_gemma-4-26B-A4B-it.yml
+++ b/.buildkite/models/google_gemma-4-26B-A4B-it.yml
@@ -52,7 +52,7 @@ steps:
         .buildkite/scripts/record_step_result.sh ${BK_KEY}_google_gemma-4-26B-A4B-it_UnitTest
 
   - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Accuracy for google/gemma-4-26B-A4B-it"
-    key: "${BK_KEY}_google_gemma-4-26B-A4B-it_Accuracy"
+    key: "${BK_KEY}_google_gemma-4-26B-A4B-it_Accuracy_Correctness"
     depends_on: "${BK_KEY}_record_google_gemma-4-26B-A4B-it_UnitTest"
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
@@ -66,14 +66,14 @@ steps:
     commands:
       - |
         if [ "${TPU_VERSION:-tpu6e}" = "tpu6e" ]; then
-          buildkite-agent meta-data set "${BK_KEY}_google_gemma-4-26B-A4B-it_Accuracy" "not enough HBM"
+          buildkite-agent meta-data set "${BK_KEY}_google_gemma-4-26B-A4B-it_Accuracy_Correctness" "not enough HBM"
           exit 0
         fi
         .buildkite/scripts/run_in_docker.sh bash -c 'USE_BATCHED_RPA_KERNEL=1 bash /workspace/tpu_inference/tests/e2e/benchmarking/test_accuracy.sh'
 
   - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record integration test result for google/gemma-4-26B-A4B-it"
-    key: "${BK_KEY}_record_google_gemma-4-26B-A4B-it_Accuracy"
-    depends_on: "${BK_KEY}_google_gemma-4-26B-A4B-it_Accuracy"
+    key: "${BK_KEY}_record_google_gemma-4-26B-A4B-it_Accuracy_Correctness"
+    depends_on: "${BK_KEY}_google_gemma-4-26B-A4B-it_Accuracy_Correctness"
     env:
       MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
@@ -84,11 +84,11 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${BK_KEY}_google_gemma-4-26B-A4B-it_Accuracy
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_google_gemma-4-26B-A4B-it_Accuracy_Correctness
 
   - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance benchmarks for google/gemma-4-26B-A4B-it"
     key: "${BK_KEY}_google_gemma-4-26B-A4B-it_Benchmark"
-    depends_on: "${BK_KEY}_record_google_gemma-4-26B-A4B-it_Accuracy"
+    depends_on: "${BK_KEY}_record_google_gemma-4-26B-A4B-it_Accuracy_Correctness"
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
     soft_fail: true

--- a/.buildkite/models/google_gemma-4-26B-A4B-it.yml
+++ b/.buildkite/models/google_gemma-4-26B-A4B-it.yml
@@ -13,8 +13,10 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Unit tests for google/gemma-4-26B-A4B-it"
-    key: "${TPU_VERSION:-tpu6e}_google_gemma-4-26B-A4B-it_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Unit tests for google/gemma-4-26B-A4B-it"
+    key: "${BK_KEY}_google_gemma-4-26B-A4B-it_UnitTest"
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
     soft_fail: true
@@ -24,20 +26,21 @@ steps:
     commands:
       - |
         if pip install "transformers>=5.5.0" --dry-run | grep -q "Would install transformers-"; then
-          buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_google_gemma-4-26B-A4B-it_UnitTest" "transformers version too low"
+          buildkite-agent meta-data set "${BK_KEY}_google_gemma-4-26B-A4B-it_UnitTest" "transformers version too low"
           exit 0
         fi
         if [ "${TPU_VERSION:-tpu6e}" = "tpu6e" ]; then
-          buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_google_gemma-4-26B-A4B-it_UnitTest" "not enough HBM"
+          buildkite-agent meta-data set "${BK_KEY}_google_gemma-4-26B-A4B-it_UnitTest" "not enough HBM"
           exit 0
         fi
         .buildkite/scripts/run_in_docker.sh \
           bash -c 'USE_BATCHED_RPA_KERNEL=1 JITTED_MM_MODULE_KEYS="model.vision_tower.encoder" REGISTER_MM_MODULE_CUSTOM_PYTREE_CLASSES="transformers.modeling_outputs.BaseModelOutputWithPast" SKIP_JAX_PRECOMPILE=1 VLLM_XLA_CHECK_RECOMPILATION=0 python /workspace/tpu_inference/examples/offline_inference.py --model google/gemma-4-26B-A4B-it --tensor-parallel-size 8 --max-num-batched-tokens 4096 --max-model-len 4096'
 
-  - label: "${TPU_VERSION:-tpu6e} Record unit test result for google/gemma-4-26B-A4B-it"
-    key: "${TPU_VERSION:-tpu6e}_record_google_gemma-4-26B-A4B-it_UnitTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_google_gemma-4-26B-A4B-it_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record unit test result for google/gemma-4-26B-A4B-it"
+    key: "${BK_KEY}_record_google_gemma-4-26B-A4B-it_UnitTest"
+    depends_on: "${BK_KEY}_google_gemma-4-26B-A4B-it_UnitTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "google/gemma-4-26B-A4B-it"
       CI_STAGE: "UnitTest"
@@ -46,15 +49,16 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_google_gemma-4-26B-A4B-it_UnitTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_google_gemma-4-26B-A4B-it_UnitTest
 
-  - label: "${TPU_VERSION:-tpu6e} Accuracy for google/gemma-4-26B-A4B-it"
-    key: "${TPU_VERSION:-tpu6e}_google_gemma-4-26B-A4B-it_Accuracy"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_google_gemma-4-26B-A4B-it_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Accuracy for google/gemma-4-26B-A4B-it"
+    key: "${BK_KEY}_google_gemma-4-26B-A4B-it_Accuracy"
+    depends_on: "${BK_KEY}_record_google_gemma-4-26B-A4B-it_UnitTest"
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
     soft_fail: true
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       TEST_MODEL: google/gemma-4-26B-A4B-it
       TENSOR_PARALLEL_SIZE: 8
       # TODO(#2332): Adjust this threshold after we fix the accuracy.
@@ -62,15 +66,16 @@ steps:
     commands:
       - |
         if [ "${TPU_VERSION:-tpu6e}" = "tpu6e" ]; then
-          buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_google_gemma-4-26B-A4B-it_Accuracy" "not enough HBM"
+          buildkite-agent meta-data set "${BK_KEY}_google_gemma-4-26B-A4B-it_Accuracy" "not enough HBM"
           exit 0
         fi
         .buildkite/scripts/run_in_docker.sh bash -c 'USE_BATCHED_RPA_KERNEL=1 bash /workspace/tpu_inference/tests/e2e/benchmarking/test_accuracy.sh'
 
-  - label: "${TPU_VERSION:-tpu6e} Record integration test result for google/gemma-4-26B-A4B-it"
-    key: "${TPU_VERSION:-tpu6e}_record_google_gemma-4-26B-A4B-it_Accuracy"
-    depends_on: "${TPU_VERSION:-tpu6e}_google_gemma-4-26B-A4B-it_Accuracy"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record integration test result for google/gemma-4-26B-A4B-it"
+    key: "${BK_KEY}_record_google_gemma-4-26B-A4B-it_Accuracy"
+    depends_on: "${BK_KEY}_google_gemma-4-26B-A4B-it_Accuracy"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "google/gemma-4-26B-A4B-it"
       CI_STAGE: "Accuracy/Correctness"
@@ -79,30 +84,32 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_google_gemma-4-26B-A4B-it_Accuracy
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_google_gemma-4-26B-A4B-it_Accuracy
 
-  - label: "${TPU_VERSION:-tpu6e} Performance benchmarks for google/gemma-4-26B-A4B-it"
-    key: "${TPU_VERSION:-tpu6e}_google_gemma-4-26B-A4B-it_Benchmark"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_google_gemma-4-26B-A4B-it_Accuracy"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance benchmarks for google/gemma-4-26B-A4B-it"
+    key: "${BK_KEY}_google_gemma-4-26B-A4B-it_Benchmark"
+    depends_on: "${BK_KEY}_record_google_gemma-4-26B-A4B-it_Accuracy"
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
     soft_fail: true
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       TEST_MODEL: google/gemma-4-26B-A4B-it
       TENSOR_PARALLEL_SIZE: 8
       MINIMUM_THROUGHPUT_THRESHOLD: 2
     commands:
       - |
         if [ "${TPU_VERSION:-tpu6e}" = "tpu6e" ]; then
-          buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_google_gemma-4-26B-A4B-it_Benchmark" "not enough HBM"
+          buildkite-agent meta-data set "${BK_KEY}_google_gemma-4-26B-A4B-it_Benchmark" "not enough HBM"
           exit 0
         fi
         .buildkite/scripts/run_in_docker.sh bash -c 'TIMEOUT_SECONDS=960 USE_BATCHED_RPA_KERNEL=1 JITTED_MM_MODULE_KEYS="model.vision_tower.encoder" REGISTER_MM_MODULE_CUSTOM_PYTREE_CLASSES="transformers.modeling_outputs.BaseModelOutputWithPast" /workspace/tpu_inference/tests/e2e/benchmarking/mm_bench_recipe.sh'
 
-  - label: "${TPU_VERSION:-tpu6e} Record performance benchmark result for google/gemma-4-26B-A4B-it"
-    key: "${TPU_VERSION:-tpu6e}_record_google_gemma-4-26B-A4B-it_Benchmark"
-    depends_on: "${TPU_VERSION:-tpu6e}_google_gemma-4-26B-A4B-it_Benchmark"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance benchmark result for google/gemma-4-26B-A4B-it"
+    key: "${BK_KEY}_record_google_gemma-4-26B-A4B-it_Benchmark"
+    depends_on: "${BK_KEY}_google_gemma-4-26B-A4B-it_Benchmark"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "google/gemma-4-26B-A4B-it"
       CI_STAGE: "Benchmark"
@@ -111,4 +118,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_google_gemma-4-26B-A4B-it_Benchmark
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_google_gemma-4-26B-A4B-it_Benchmark

--- a/.buildkite/models/google_gemma-4-31B-it.yml
+++ b/.buildkite/models/google_gemma-4-31B-it.yml
@@ -47,7 +47,7 @@ steps:
         .buildkite/scripts/record_step_result.sh ${BK_KEY}_google_gemma-4-31B-it_UnitTest
 
   - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Accuracy for google/gemma-4-31B-it"
-    key: "${BK_KEY}_google_gemma-4-31B-it_Accuracy"
+    key: "${BK_KEY}_google_gemma-4-31B-it_Accuracy_Correctness"
     depends_on: "${BK_KEY}_record_google_gemma-4-31B-it_UnitTest"
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
@@ -62,8 +62,8 @@ steps:
         .buildkite/scripts/run_in_docker.sh bash -c 'USE_BATCHED_RPA_KERNEL=1 bash /workspace/tpu_inference/tests/e2e/benchmarking/test_accuracy.sh'
 
   - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record integration test result for google/gemma-4-31B-it"
-    key: "${BK_KEY}_record_google_gemma-4-31B-it_Accuracy"
-    depends_on: "${BK_KEY}_google_gemma-4-31B-it_Accuracy"
+    key: "${BK_KEY}_record_google_gemma-4-31B-it_Accuracy_Correctness"
+    depends_on: "${BK_KEY}_google_gemma-4-31B-it_Accuracy_Correctness"
     env:
       MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
@@ -74,11 +74,11 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${BK_KEY}_google_gemma-4-31B-it_Accuracy
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_google_gemma-4-31B-it_Accuracy_Correctness
 
   - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance benchmarks for google/gemma-4-31B-it"
     key: "${BK_KEY}_google_gemma-4-31B-it_Benchmark"
-    depends_on: "${BK_KEY}_record_google_gemma-4-31B-it_Accuracy"
+    depends_on: "${BK_KEY}_record_google_gemma-4-31B-it_Accuracy_Correctness"
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
     soft_fail: true

--- a/.buildkite/models/google_gemma-4-31B-it.yml
+++ b/.buildkite/models/google_gemma-4-31B-it.yml
@@ -13,8 +13,10 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Unit tests for google/gemma-4-31B-it"
-    key: "${TPU_VERSION:-tpu6e}_google_gemma-4-31B-it_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Unit tests for google/gemma-4-31B-it"
+    key: "${BK_KEY}_google_gemma-4-31B-it_UnitTest"
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
     soft_fail: true
@@ -23,16 +25,17 @@ steps:
     commands:
       - |
         if pip install "transformers>=5.5.0" --dry-run | grep -q "Would install transformers-"; then
-          buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_google_gemma-4-31B-it_UnitTest" "transformers version too low"
+          buildkite-agent meta-data set "${BK_KEY}_google_gemma-4-31B-it_UnitTest" "transformers version too low"
           exit 0
         fi
         .buildkite/scripts/run_in_docker.sh \
           bash -c 'USE_BATCHED_RPA_KERNEL=1 JITTED_MM_MODULE_KEYS="model.vision_tower.encoder" REGISTER_MM_MODULE_CUSTOM_PYTREE_CLASSES="transformers.modeling_outputs.BaseModelOutputWithPast" SKIP_JAX_PRECOMPILE=1 VLLM_XLA_CHECK_RECOMPILATION=0 python /workspace/tpu_inference/examples/offline_inference.py --model google/gemma-4-31B-it --tensor-parallel-size 8 --max-num-batched-tokens 4096 --max-model-len 4096'
 
-  - label: "${TPU_VERSION:-tpu6e} Record unit test result for google/gemma-4-31B-it"
-    key: "${TPU_VERSION:-tpu6e}_record_google_gemma-4-31B-it_UnitTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_google_gemma-4-31B-it_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record unit test result for google/gemma-4-31B-it"
+    key: "${BK_KEY}_record_google_gemma-4-31B-it_UnitTest"
+    depends_on: "${BK_KEY}_google_gemma-4-31B-it_UnitTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "google/gemma-4-31B-it"
       CI_STAGE: "UnitTest"
@@ -41,15 +44,16 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_google_gemma-4-31B-it_UnitTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_google_gemma-4-31B-it_UnitTest
 
-  - label: "${TPU_VERSION:-tpu6e} Accuracy for google/gemma-4-31B-it"
-    key: "${TPU_VERSION:-tpu6e}_google_gemma-4-31B-it_Accuracy"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_google_gemma-4-31B-it_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Accuracy for google/gemma-4-31B-it"
+    key: "${BK_KEY}_google_gemma-4-31B-it_Accuracy"
+    depends_on: "${BK_KEY}_record_google_gemma-4-31B-it_UnitTest"
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
     soft_fail: true
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       TEST_MODEL: google/gemma-4-31B-it
       TENSOR_PARALLEL_SIZE: 8
       MINIMUM_ACCURACY_THRESHOLD: 0.56
@@ -57,10 +61,11 @@ steps:
       - |
         .buildkite/scripts/run_in_docker.sh bash -c 'USE_BATCHED_RPA_KERNEL=1 bash /workspace/tpu_inference/tests/e2e/benchmarking/test_accuracy.sh'
 
-  - label: "${TPU_VERSION:-tpu6e} Record integration test result for google/gemma-4-31B-it"
-    key: "${TPU_VERSION:-tpu6e}_record_google_gemma-4-31B-it_Accuracy"
-    depends_on: "${TPU_VERSION:-tpu6e}_google_gemma-4-31B-it_Accuracy"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record integration test result for google/gemma-4-31B-it"
+    key: "${BK_KEY}_record_google_gemma-4-31B-it_Accuracy"
+    depends_on: "${BK_KEY}_google_gemma-4-31B-it_Accuracy"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "google/gemma-4-31B-it"
       CI_STAGE: "Accuracy/Correctness"
@@ -69,30 +74,32 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_google_gemma-4-31B-it_Accuracy
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_google_gemma-4-31B-it_Accuracy
 
-  - label: "${TPU_VERSION:-tpu6e} Performance benchmarks for google/gemma-4-31B-it"
-    key: "${TPU_VERSION:-tpu6e}_google_gemma-4-31B-it_Benchmark"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_google_gemma-4-31B-it_Accuracy"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance benchmarks for google/gemma-4-31B-it"
+    key: "${BK_KEY}_google_gemma-4-31B-it_Benchmark"
+    depends_on: "${BK_KEY}_record_google_gemma-4-31B-it_Accuracy"
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
     soft_fail: true
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       TEST_MODEL: google/gemma-4-31B-it
       TENSOR_PARALLEL_SIZE: 8
       MINIMUM_THROUGHPUT_THRESHOLD: 1.80
     commands:
       - |
         if [ "${TPU_VERSION:-tpu6e}" = "tpu6e" ]; then
-          buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_google_gemma-4-31B-it_Benchmark" "not enough HBM"
+          buildkite-agent meta-data set "${BK_KEY}_google_gemma-4-31B-it_Benchmark" "not enough HBM"
           exit 0
         fi
         .buildkite/scripts/run_in_docker.sh bash -c 'TIMEOUT_SECONDS=960 USE_BATCHED_RPA_KERNEL=1 JITTED_MM_MODULE_KEYS="model.vision_tower.encoder" REGISTER_MM_MODULE_CUSTOM_PYTREE_CLASSES="transformers.modeling_outputs.BaseModelOutputWithPast" /workspace/tpu_inference/tests/e2e/benchmarking/mm_bench_recipe.sh'
 
-  - label: "${TPU_VERSION:-tpu6e} Record performance benchmark result for google/gemma-4-31B-it"
-    key: "${TPU_VERSION:-tpu6e}_record_google_gemma-4-31B-it_Benchmark"
-    depends_on: "${TPU_VERSION:-tpu6e}_google_gemma-4-31B-it_Benchmark"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance benchmark result for google/gemma-4-31B-it"
+    key: "${BK_KEY}_record_google_gemma-4-31B-it_Benchmark"
+    depends_on: "${BK_KEY}_google_gemma-4-31B-it_Benchmark"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "google/gemma-4-31B-it"
       CI_STAGE: "Benchmark"
@@ -101,4 +108,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_google_gemma-4-31B-it_Benchmark
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_google_gemma-4-31B-it_Benchmark

--- a/.buildkite/models/google_gemma-4-E2B-it.yml
+++ b/.buildkite/models/google_gemma-4-E2B-it.yml
@@ -18,8 +18,8 @@
 # correctness bug in our path).
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Unit tests for google/gemma-4-E2B-it"
-    key: "${TPU_VERSION:-tpu6e}_google_gemma-4-E2B-it_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Unit tests for google/gemma-4-E2B-it"
+    key: "${BK_KEY}_google_gemma-4-E2B-it_UnitTest"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     soft_fail: true
@@ -35,10 +35,11 @@ steps:
         .buildkite/scripts/run_in_docker.sh \
           bash -c 'JITTED_MM_MODULE_KEYS="model.vision_tower.encoder" REGISTER_MM_MODULE_CUSTOM_PYTREE_CLASSES="transformers.modeling_outputs.BaseModelOutputWithPast" SKIP_JAX_PRECOMPILE=1 VLLM_XLA_CHECK_RECOMPILATION=0 python /workspace/tpu_inference/examples/offline_inference.py --model google/gemma-4-E2B-it --tensor-parallel-size 1 --max-num-batched-tokens 4096 --max-model-len 4096 --use-chat-template'
 
-  - label: "${TPU_VERSION:-tpu6e} Record unit test result for google/gemma-4-E2B-it"
-    key: "${TPU_VERSION:-tpu6e}_record_google_gemma-4-E2B-it_UnitTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_google_gemma-4-E2B-it_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record unit test result for google/gemma-4-E2B-it"
+    key: "${BK_KEY}_record_google_gemma-4-E2B-it_UnitTest"
+    depends_on: "${BK_KEY}_google_gemma-4-E2B-it_UnitTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "google/gemma-4-E2B-it"
       CI_STAGE: "UnitTest"
@@ -47,15 +48,16 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_google_gemma-4-E2B-it_UnitTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_google_gemma-4-E2B-it_UnitTest
 
-  - label: "${TPU_VERSION:-tpu6e} Accuracy for google/gemma-4-E2B-it"
-    key: "${TPU_VERSION:-tpu6e}_google_gemma-4-E2B-it_Accuracy"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_google_gemma-4-E2B-it_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Accuracy for google/gemma-4-E2B-it"
+    key: "${BK_KEY}_google_gemma-4-E2B-it_Accuracy"
+    depends_on: "${BK_KEY}_record_google_gemma-4-E2B-it_UnitTest"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     soft_fail: true
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       TEST_MODEL: google/gemma-4-E2B-it
       TENSOR_PARALLEL_SIZE: 1
       # USE_CHAT_TEMPLATE=1 routes lm_eval through apply_chat_template +
@@ -69,10 +71,11 @@ steps:
       - |
         .buildkite/scripts/run_in_docker.sh bash -c 'bash /workspace/tpu_inference/tests/e2e/benchmarking/test_accuracy.sh'
 
-  - label: "${TPU_VERSION:-tpu6e} Record integration test result for google/gemma-4-E2B-it"
-    key: "${TPU_VERSION:-tpu6e}_record_google_gemma-4-E2B-it_Accuracy"
-    depends_on: "${TPU_VERSION:-tpu6e}_google_gemma-4-E2B-it_Accuracy"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record integration test result for google/gemma-4-E2B-it"
+    key: "${BK_KEY}_record_google_gemma-4-E2B-it_Accuracy"
+    depends_on: "${BK_KEY}_google_gemma-4-E2B-it_Accuracy"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "google/gemma-4-E2B-it"
       CI_STAGE: "Accuracy/Correctness"
@@ -81,15 +84,16 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_google_gemma-4-E2B-it_Accuracy
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_google_gemma-4-E2B-it_Accuracy
 
-  - label: "${TPU_VERSION:-tpu6e} Performance benchmarks for google/gemma-4-E2B-it"
-    key: "${TPU_VERSION:-tpu6e}_google_gemma-4-E2B-it_Benchmark"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_google_gemma-4-E2B-it_Accuracy"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance benchmarks for google/gemma-4-E2B-it"
+    key: "${BK_KEY}_google_gemma-4-E2B-it_Benchmark"
+    depends_on: "${BK_KEY}_record_google_gemma-4-E2B-it_Accuracy"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     soft_fail: true
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       TEST_MODEL: google/gemma-4-E2B-it
       TENSOR_PARALLEL_SIZE: 1
       # BENCH_DATASET unset -> mm_bench_recipe.sh defaults to the random-mm
@@ -115,10 +119,11 @@ steps:
       - |
         .buildkite/scripts/run_in_docker.sh bash -c 'TIMEOUT_SECONDS=960 JITTED_MM_MODULE_KEYS="model.vision_tower.encoder" REGISTER_MM_MODULE_CUSTOM_PYTREE_CLASSES="transformers.modeling_outputs.BaseModelOutputWithPast" /workspace/tpu_inference/tests/e2e/benchmarking/mm_bench_recipe.sh'
 
-  - label: "${TPU_VERSION:-tpu6e} Record performance benchmark result for google/gemma-4-E2B-it"
-    key: "${TPU_VERSION:-tpu6e}_record_google_gemma-4-E2B-it_Benchmark"
-    depends_on: "${TPU_VERSION:-tpu6e}_google_gemma-4-E2B-it_Benchmark"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance benchmark result for google/gemma-4-E2B-it"
+    key: "${BK_KEY}_record_google_gemma-4-E2B-it_Benchmark"
+    depends_on: "${BK_KEY}_google_gemma-4-E2B-it_Benchmark"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "google/gemma-4-E2B-it"
       CI_STAGE: "Benchmark"
@@ -127,4 +132,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_google_gemma-4-E2B-it_Benchmark
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_google_gemma-4-E2B-it_Benchmark

--- a/.buildkite/models/google_gemma-4-E2B-it.yml
+++ b/.buildkite/models/google_gemma-4-E2B-it.yml
@@ -51,7 +51,7 @@ steps:
         .buildkite/scripts/record_step_result.sh ${BK_KEY}_google_gemma-4-E2B-it_UnitTest
 
   - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Accuracy for google/gemma-4-E2B-it"
-    key: "${BK_KEY}_google_gemma-4-E2B-it_Accuracy"
+    key: "${BK_KEY}_google_gemma-4-E2B-it_Accuracy_Correctness"
     depends_on: "${BK_KEY}_record_google_gemma-4-E2B-it_UnitTest"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
@@ -72,8 +72,8 @@ steps:
         .buildkite/scripts/run_in_docker.sh bash -c 'bash /workspace/tpu_inference/tests/e2e/benchmarking/test_accuracy.sh'
 
   - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record integration test result for google/gemma-4-E2B-it"
-    key: "${BK_KEY}_record_google_gemma-4-E2B-it_Accuracy"
-    depends_on: "${BK_KEY}_google_gemma-4-E2B-it_Accuracy"
+    key: "${BK_KEY}_record_google_gemma-4-E2B-it_Accuracy_Correctness"
+    depends_on: "${BK_KEY}_google_gemma-4-E2B-it_Accuracy_Correctness"
     env:
       MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
@@ -84,11 +84,11 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${BK_KEY}_google_gemma-4-E2B-it_Accuracy
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_google_gemma-4-E2B-it_Accuracy_Correctness
 
   - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance benchmarks for google/gemma-4-E2B-it"
     key: "${BK_KEY}_google_gemma-4-E2B-it_Benchmark"
-    depends_on: "${BK_KEY}_record_google_gemma-4-E2B-it_Accuracy"
+    depends_on: "${BK_KEY}_record_google_gemma-4-E2B-it_Accuracy_Correctness"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     soft_fail: true

--- a/.buildkite/models/google_gemma-4-E4B-it.yml
+++ b/.buildkite/models/google_gemma-4-E4B-it.yml
@@ -21,8 +21,10 @@
 # prompts produce token-repetition garbage on both GPU vllm-pytorch and JAX.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Unit tests for google/gemma-4-E4B-it"
-    key: "${TPU_VERSION:-tpu6e}_google_gemma-4-E4B-it_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Unit tests for google/gemma-4-E4B-it"
+    key: "${BK_KEY}_google_gemma-4-E4B-it_UnitTest"
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     soft_fail: true
@@ -31,10 +33,11 @@ steps:
         .buildkite/scripts/run_in_docker.sh \
           bash -c 'JITTED_MM_MODULE_KEYS="model.vision_tower.encoder" REGISTER_MM_MODULE_CUSTOM_PYTREE_CLASSES="transformers.modeling_outputs.BaseModelOutputWithPast" SKIP_JAX_PRECOMPILE=1 VLLM_XLA_CHECK_RECOMPILATION=0 python /workspace/tpu_inference/examples/offline_inference.py --model google/gemma-4-E4B-it --tensor-parallel-size ${TENSOR_PARALLEL_SIZE_SINGLE:-1} --max-num-batched-tokens 4096 --max-model-len 4096 --use-chat-template'
 
-  - label: "${TPU_VERSION:-tpu6e} Record unit test result for google/gemma-4-E4B-it"
-    key: "${TPU_VERSION:-tpu6e}_record_google_gemma-4-E4B-it_UnitTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_google_gemma-4-E4B-it_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record unit test result for google/gemma-4-E4B-it"
+    key: "${BK_KEY}_record_google_gemma-4-E4B-it_UnitTest"
+    depends_on: "${BK_KEY}_google_gemma-4-E4B-it_UnitTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "google/gemma-4-E4B-it"
       CI_STAGE: "UnitTest"
@@ -43,15 +46,16 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_google_gemma-4-E4B-it_UnitTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_google_gemma-4-E4B-it_UnitTest
 
-  - label: "${TPU_VERSION:-tpu6e} Accuracy for google/gemma-4-E4B-it"
-    key: "${TPU_VERSION:-tpu6e}_google_gemma-4-E4B-it_Accuracy"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_google_gemma-4-E4B-it_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Accuracy for google/gemma-4-E4B-it"
+    key: "${BK_KEY}_google_gemma-4-E4B-it_Accuracy"
+    depends_on: "${BK_KEY}_record_google_gemma-4-E4B-it_UnitTest"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     soft_fail: true
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       TEST_MODEL: google/gemma-4-E4B-it
       TENSOR_PARALLEL_SIZE: "${TENSOR_PARALLEL_SIZE_SINGLE:-1}"
       # USE_CHAT_TEMPLATE=1 routes lm_eval through apply_chat_template +
@@ -67,10 +71,11 @@ steps:
       - |
         .buildkite/scripts/run_in_docker.sh bash -c 'bash /workspace/tpu_inference/tests/e2e/benchmarking/test_accuracy.sh'
 
-  - label: "${TPU_VERSION:-tpu6e} Record integration test result for google/gemma-4-E4B-it"
-    key: "${TPU_VERSION:-tpu6e}_record_google_gemma-4-E4B-it_Accuracy"
-    depends_on: "${TPU_VERSION:-tpu6e}_google_gemma-4-E4B-it_Accuracy"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record integration test result for google/gemma-4-E4B-it"
+    key: "${BK_KEY}_record_google_gemma-4-E4B-it_Accuracy"
+    depends_on: "${BK_KEY}_google_gemma-4-E4B-it_Accuracy"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "google/gemma-4-E4B-it"
       CI_STAGE: "Accuracy/Correctness"
@@ -79,15 +84,16 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_google_gemma-4-E4B-it_Accuracy
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_google_gemma-4-E4B-it_Accuracy
 
-  - label: "${TPU_VERSION:-tpu6e} Performance benchmarks for google/gemma-4-E4B-it"
-    key: "${TPU_VERSION:-tpu6e}_google_gemma-4-E4B-it_Benchmark"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_google_gemma-4-E4B-it_Accuracy"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance benchmarks for google/gemma-4-E4B-it"
+    key: "${BK_KEY}_google_gemma-4-E4B-it_Benchmark"
+    depends_on: "${BK_KEY}_record_google_gemma-4-E4B-it_Accuracy"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     soft_fail: true
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       TEST_MODEL: google/gemma-4-E4B-it
       TENSOR_PARALLEL_SIZE: "${TENSOR_PARALLEL_SIZE_SINGLE:-1}"
       # BENCH_DATASET unset -> mm_bench_recipe.sh defaults to the random-mm
@@ -110,10 +116,11 @@ steps:
       - |
         .buildkite/scripts/run_in_docker.sh bash -c 'TIMEOUT_SECONDS=960 JITTED_MM_MODULE_KEYS="model.vision_tower.encoder" REGISTER_MM_MODULE_CUSTOM_PYTREE_CLASSES="transformers.modeling_outputs.BaseModelOutputWithPast" /workspace/tpu_inference/tests/e2e/benchmarking/mm_bench_recipe.sh'
 
-  - label: "${TPU_VERSION:-tpu6e} Record performance benchmark result for google/gemma-4-E4B-it"
-    key: "${TPU_VERSION:-tpu6e}_record_google_gemma-4-E4B-it_Benchmark"
-    depends_on: "${TPU_VERSION:-tpu6e}_google_gemma-4-E4B-it_Benchmark"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance benchmark result for google/gemma-4-E4B-it"
+    key: "${BK_KEY}_record_google_gemma-4-E4B-it_Benchmark"
+    depends_on: "${BK_KEY}_google_gemma-4-E4B-it_Benchmark"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "google/gemma-4-E4B-it"
       CI_STAGE: "Benchmark"
@@ -122,4 +129,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_google_gemma-4-E4B-it_Benchmark
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_google_gemma-4-E4B-it_Benchmark

--- a/.buildkite/models/google_gemma-4-E4B-it.yml
+++ b/.buildkite/models/google_gemma-4-E4B-it.yml
@@ -49,7 +49,7 @@ steps:
         .buildkite/scripts/record_step_result.sh ${BK_KEY}_google_gemma-4-E4B-it_UnitTest
 
   - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Accuracy for google/gemma-4-E4B-it"
-    key: "${BK_KEY}_google_gemma-4-E4B-it_Accuracy"
+    key: "${BK_KEY}_google_gemma-4-E4B-it_Accuracy_Correctness"
     depends_on: "${BK_KEY}_record_google_gemma-4-E4B-it_UnitTest"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
@@ -72,8 +72,8 @@ steps:
         .buildkite/scripts/run_in_docker.sh bash -c 'bash /workspace/tpu_inference/tests/e2e/benchmarking/test_accuracy.sh'
 
   - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record integration test result for google/gemma-4-E4B-it"
-    key: "${BK_KEY}_record_google_gemma-4-E4B-it_Accuracy"
-    depends_on: "${BK_KEY}_google_gemma-4-E4B-it_Accuracy"
+    key: "${BK_KEY}_record_google_gemma-4-E4B-it_Accuracy_Correctness"
+    depends_on: "${BK_KEY}_google_gemma-4-E4B-it_Accuracy_Correctness"
     env:
       MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
@@ -84,11 +84,11 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${BK_KEY}_google_gemma-4-E4B-it_Accuracy
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_google_gemma-4-E4B-it_Accuracy_Correctness
 
   - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance benchmarks for google/gemma-4-E4B-it"
     key: "${BK_KEY}_google_gemma-4-E4B-it_Benchmark"
-    depends_on: "${BK_KEY}_record_google_gemma-4-E4B-it_Accuracy"
+    depends_on: "${BK_KEY}_record_google_gemma-4-E4B-it_Accuracy_Correctness"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     soft_fail: true

--- a/.buildkite/models/meta-llama_Llama-3_1-8B-Instruct.yml
+++ b/.buildkite/models/meta-llama_Llama-3_1-8B-Instruct.yml
@@ -40,7 +40,7 @@ steps:
         .buildkite/scripts/record_step_result.sh ${BK_KEY}_meta-llama_Llama-3_1-8B-Instruct_UnitTest
 
   - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Accuracy for meta-llama/Llama-3.1-8B-Instruct"
-    key: "${BK_KEY}_meta-llama_Llama-3_1-8B-Instruct_Accuracy"
+    key: "${BK_KEY}_meta-llama_Llama-3_1-8B-Instruct_Accuracy_Correctness"
     depends_on: "${BK_KEY}_record_meta-llama_Llama-3_1-8B-Instruct_UnitTest"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
@@ -54,8 +54,8 @@ steps:
       - |
         .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/test_accuracy.sh
   - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record accuracy result for meta-llama/Llama-3.1-8B-Instruct"
-    key: "${BK_KEY}_record_meta-llama_Llama-3_1-8B-Instruct_Accuracy"
-    depends_on: "${BK_KEY}_meta-llama_Llama-3_1-8B-Instruct_Accuracy"
+    key: "${BK_KEY}_record_meta-llama_Llama-3_1-8B-Instruct_Accuracy_Correctness"
+    depends_on: "${BK_KEY}_meta-llama_Llama-3_1-8B-Instruct_Accuracy_Correctness"
     env:
       MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
@@ -66,11 +66,11 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${BK_KEY}_meta-llama_Llama-3_1-8B-Instruct_Accuracy
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_meta-llama_Llama-3_1-8B-Instruct_Accuracy_Correctness
 
   - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance benchmarks for meta-llama/Llama-3.1-8B-Instruct"
     key: "${BK_KEY}_meta-llama_Llama-3_1-8B-Instruct_Benchmark"
-    depends_on: "${BK_KEY}_record_meta-llama_Llama-3_1-8B-Instruct_Accuracy"
+    depends_on: "${BK_KEY}_record_meta-llama_Llama-3_1-8B-Instruct_Accuracy_Correctness"
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"

--- a/.buildkite/models/meta-llama_Llama-3_1-8B-Instruct.yml
+++ b/.buildkite/models/meta-llama_Llama-3_1-8B-Instruct.yml
@@ -13,19 +13,22 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Unit tests for meta-llama/Llama-3.1-8B-Instruct"
-    key: "${TPU_VERSION:-tpu6e}_meta-llama_Llama-3_1-8B-Instruct_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Unit tests for meta-llama/Llama-3.1-8B-Instruct"
+    key: "${BK_KEY}_meta-llama_Llama-3_1-8B-Instruct_UnitTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh \
           bash -c 'python3 -m pytest -s -v -x /workspace/tpu_inference/tests/models/jax/test_llama3.py'
-  - label: "${TPU_VERSION:-tpu6e} Record unit test result for meta-llama/Llama-3.1-8B-Instruct"
-    key: "${TPU_VERSION:-tpu6e}_record_meta-llama_Llama-3_1-8B-Instruct_UnitTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_meta-llama_Llama-3_1-8B-Instruct_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record unit test result for meta-llama/Llama-3.1-8B-Instruct"
+    key: "${BK_KEY}_record_meta-llama_Llama-3_1-8B-Instruct_UnitTest"
+    depends_on: "${BK_KEY}_meta-llama_Llama-3_1-8B-Instruct_UnitTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "meta-llama/Llama-3.1-8B-Instruct"
       CI_STAGE: "UnitTest"
@@ -34,25 +37,27 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_meta-llama_Llama-3_1-8B-Instruct_UnitTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_meta-llama_Llama-3_1-8B-Instruct_UnitTest
 
-  - label: "${TPU_VERSION:-tpu6e} Accuracy for meta-llama/Llama-3.1-8B-Instruct"
-    key: "${TPU_VERSION:-tpu6e}_meta-llama_Llama-3_1-8B-Instruct_Accuracy"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_meta-llama_Llama-3_1-8B-Instruct_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Accuracy for meta-llama/Llama-3.1-8B-Instruct"
+    key: "${BK_KEY}_meta-llama_Llama-3_1-8B-Instruct_Accuracy"
+    depends_on: "${BK_KEY}_record_meta-llama_Llama-3_1-8B-Instruct_UnitTest"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     soft_fail: true
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       TEST_MODEL: meta-llama/Llama-3.1-8B-Instruct
       TENSOR_PARALLEL_SIZE: "${TENSOR_PARALLEL_SIZE_SINGLE:-1}"
       MINIMUM_ACCURACY_THRESHOLD: 0.75
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/test_accuracy.sh
-  - label: "${TPU_VERSION:-tpu6e} Record accuracy result for meta-llama/Llama-3.1-8B-Instruct"
-    key: "${TPU_VERSION:-tpu6e}_record_meta-llama_Llama-3_1-8B-Instruct_Accuracy"
-    depends_on: "${TPU_VERSION:-tpu6e}_meta-llama_Llama-3_1-8B-Instruct_Accuracy"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record accuracy result for meta-llama/Llama-3.1-8B-Instruct"
+    key: "${BK_KEY}_record_meta-llama_Llama-3_1-8B-Instruct_Accuracy"
+    depends_on: "${BK_KEY}_meta-llama_Llama-3_1-8B-Instruct_Accuracy"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "meta-llama/Llama-3.1-8B-Instruct"
       CI_STAGE: "Accuracy/Correctness"
@@ -61,15 +66,16 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_meta-llama_Llama-3_1-8B-Instruct_Accuracy
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_meta-llama_Llama-3_1-8B-Instruct_Accuracy
 
-  - label: "${TPU_VERSION:-tpu6e} Performance benchmarks for meta-llama/Llama-3.1-8B-Instruct"
-    key: "${TPU_VERSION:-tpu6e}_meta-llama_Llama-3_1-8B-Instruct_Benchmark"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_meta-llama_Llama-3_1-8B-Instruct_Accuracy"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance benchmarks for meta-llama/Llama-3.1-8B-Instruct"
+    key: "${BK_KEY}_meta-llama_Llama-3_1-8B-Instruct_Benchmark"
+    depends_on: "${BK_KEY}_record_meta-llama_Llama-3_1-8B-Instruct_Accuracy"
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       TEST_MODEL: meta-llama/Llama-3.1-8B-Instruct
       TENSOR_PARALLEL_SIZE: "${TENSOR_PARALLEL_SIZE_SINGLE:-1}"
       MINIMUM_THROUGHPUT_THRESHOLD: 10.77
@@ -82,10 +88,11 @@ steps:
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/benchmark.sh
-  - label: "${TPU_VERSION:-tpu6e} Record performance benchmark result for meta-llama/Llama-3.1-8B-Instruct"
-    key: "${TPU_VERSION:-tpu6e}_record_meta-llama_Llama-3_1-8B-Instruct_Benchmark"
-    depends_on: "${TPU_VERSION:-tpu6e}_meta-llama_Llama-3_1-8B-Instruct_Benchmark"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance benchmark result for meta-llama/Llama-3.1-8B-Instruct"
+    key: "${BK_KEY}_record_meta-llama_Llama-3_1-8B-Instruct_Benchmark"
+    depends_on: "${BK_KEY}_meta-llama_Llama-3_1-8B-Instruct_Benchmark"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "meta-llama/Llama-3.1-8B-Instruct"
       CI_STAGE: "Benchmark"
@@ -94,4 +101,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_meta-llama_Llama-3_1-8B-Instruct_Benchmark
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_meta-llama_Llama-3_1-8B-Instruct_Benchmark

--- a/.buildkite/models/meta-llama_Llama-3_3-70B-Instruct.yml
+++ b/.buildkite/models/meta-llama_Llama-3_3-70B-Instruct.yml
@@ -40,7 +40,7 @@ steps:
         .buildkite/scripts/record_step_result.sh ${BK_KEY}_meta-llama_Llama-3_3-70B-Instruct_UnitTest
 
   - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Accuracy for meta-llama/Llama-3.3-70B-Instruct"
-    key: "${BK_KEY}_meta-llama_Llama-3_3-70B-Instruct_Accuracy"
+    key: "${BK_KEY}_meta-llama_Llama-3_3-70B-Instruct_Accuracy_Correctness"
     depends_on: "${BK_KEY}_record_meta-llama_Llama-3_3-70B-Instruct_UnitTest"
     soft_fail: true
     agents:
@@ -54,8 +54,8 @@ steps:
       - |
         .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/test_accuracy.sh
   - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record accuracy result for meta-llama/Llama-3.3-70B-Instruct"
-    key: "${BK_KEY}_record_meta-llama_Llama-3_3-70B-Instruct_Accuracy"
-    depends_on: "${BK_KEY}_meta-llama_Llama-3_3-70B-Instruct_Accuracy"
+    key: "${BK_KEY}_record_meta-llama_Llama-3_3-70B-Instruct_Accuracy_Correctness"
+    depends_on: "${BK_KEY}_meta-llama_Llama-3_3-70B-Instruct_Accuracy_Correctness"
     env:
       MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
@@ -66,11 +66,11 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${BK_KEY}_meta-llama_Llama-3_3-70B-Instruct_Accuracy
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_meta-llama_Llama-3_3-70B-Instruct_Accuracy_Correctness
 
   - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance benchmarks for meta-llama/Llama-3.3-70B-Instruct"
     key: "${BK_KEY}_meta-llama_Llama-3_3-70B-Instruct_Benchmark"
-    depends_on: "${BK_KEY}_record_meta-llama_Llama-3_3-70B-Instruct_Accuracy"
+    depends_on: "${BK_KEY}_record_meta-llama_Llama-3_3-70B-Instruct_Accuracy_Correctness"
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"

--- a/.buildkite/models/meta-llama_Llama-3_3-70B-Instruct.yml
+++ b/.buildkite/models/meta-llama_Llama-3_3-70B-Instruct.yml
@@ -13,19 +13,22 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Unit tests for meta-llama/Llama-3.3-70B-Instruct"
-    key: "${TPU_VERSION:-tpu6e}_meta-llama_Llama-3_3-70B-Instruct_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Unit tests for meta-llama/Llama-3.3-70B-Instruct"
+    key: "${BK_KEY}_meta-llama_Llama-3_3-70B-Instruct_UnitTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh \
           bash -c 'python3 -m pytest -s -v -x /workspace/tpu_inference/tests/models/jax/test_llama3.py'
-  - label: "${TPU_VERSION:-tpu6e} Record unit test result for meta-llama/Llama-3.3-70B-Instruct"
-    key: "${TPU_VERSION:-tpu6e}_record_meta-llama_Llama-3_3-70B-Instruct_UnitTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_meta-llama_Llama-3_3-70B-Instruct_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record unit test result for meta-llama/Llama-3.3-70B-Instruct"
+    key: "${BK_KEY}_record_meta-llama_Llama-3_3-70B-Instruct_UnitTest"
+    depends_on: "${BK_KEY}_meta-llama_Llama-3_3-70B-Instruct_UnitTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "meta-llama/Llama-3.3-70B-Instruct"
       CI_STAGE: "UnitTest"
@@ -34,25 +37,27 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_meta-llama_Llama-3_3-70B-Instruct_UnitTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_meta-llama_Llama-3_3-70B-Instruct_UnitTest
 
-  - label: "${TPU_VERSION:-tpu6e} Accuracy for meta-llama/Llama-3.3-70B-Instruct"
-    key: "${TPU_VERSION:-tpu6e}_meta-llama_Llama-3_3-70B-Instruct_Accuracy"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_meta-llama_Llama-3_3-70B-Instruct_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Accuracy for meta-llama/Llama-3.3-70B-Instruct"
+    key: "${BK_KEY}_meta-llama_Llama-3_3-70B-Instruct_Accuracy"
+    depends_on: "${BK_KEY}_record_meta-llama_Llama-3_3-70B-Instruct_UnitTest"
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       TEST_MODEL: meta-llama/Llama-3.3-70B-Instruct
       TENSOR_PARALLEL_SIZE: "${TENSOR_PARALLEL_SIZE_MULTI:-8}"
       MINIMUM_ACCURACY_THRESHOLD: 0.90
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/test_accuracy.sh
-  - label: "${TPU_VERSION:-tpu6e} Record accuracy result for meta-llama/Llama-3.3-70B-Instruct"
-    key: "${TPU_VERSION:-tpu6e}_record_meta-llama_Llama-3_3-70B-Instruct_Accuracy"
-    depends_on: "${TPU_VERSION:-tpu6e}_meta-llama_Llama-3_3-70B-Instruct_Accuracy"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record accuracy result for meta-llama/Llama-3.3-70B-Instruct"
+    key: "${BK_KEY}_record_meta-llama_Llama-3_3-70B-Instruct_Accuracy"
+    depends_on: "${BK_KEY}_meta-llama_Llama-3_3-70B-Instruct_Accuracy"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "meta-llama/Llama-3.3-70B-Instruct"
       CI_STAGE: "Accuracy/Correctness"
@@ -61,15 +66,16 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_meta-llama_Llama-3_3-70B-Instruct_Accuracy
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_meta-llama_Llama-3_3-70B-Instruct_Accuracy
 
-  - label: "${TPU_VERSION:-tpu6e} Performance benchmarks for meta-llama/Llama-3.3-70B-Instruct"
-    key: "${TPU_VERSION:-tpu6e}_meta-llama_Llama-3_3-70B-Instruct_Benchmark"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_meta-llama_Llama-3_3-70B-Instruct_Accuracy"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance benchmarks for meta-llama/Llama-3.3-70B-Instruct"
+    key: "${BK_KEY}_meta-llama_Llama-3_3-70B-Instruct_Benchmark"
+    depends_on: "${BK_KEY}_record_meta-llama_Llama-3_3-70B-Instruct_Accuracy"
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       TEST_MODEL: meta-llama/Llama-3.3-70B-Instruct
       TENSOR_PARALLEL_SIZE: "${TENSOR_PARALLEL_SIZE_MULTI:-8}"
       MINIMUM_THROUGHPUT_THRESHOLD: 7.0
@@ -82,10 +88,11 @@ steps:
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/benchmark.sh
-  - label: "${TPU_VERSION:-tpu6e} Record performance benchmark result for meta-llama/Llama-3.3-70B-Instruct"
-    key: "${TPU_VERSION:-tpu6e}_record_meta-llama_Llama-3_3-70B-Instruct_Benchmark"
-    depends_on: "${TPU_VERSION:-tpu6e}_meta-llama_Llama-3_3-70B-Instruct_Benchmark"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance benchmark result for meta-llama/Llama-3.3-70B-Instruct"
+    key: "${BK_KEY}_record_meta-llama_Llama-3_3-70B-Instruct_Benchmark"
+    depends_on: "${BK_KEY}_meta-llama_Llama-3_3-70B-Instruct_Benchmark"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "meta-llama/Llama-3.3-70B-Instruct"
       CI_STAGE: "Benchmark"
@@ -94,4 +101,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_meta-llama_Llama-3_3-70B-Instruct_Benchmark
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_meta-llama_Llama-3_3-70B-Instruct_Benchmark

--- a/.buildkite/models/moonshotai_Kimi-K2-Thinking.yml
+++ b/.buildkite/models/moonshotai_Kimi-K2-Thinking.yml
@@ -39,7 +39,7 @@ steps:
         .buildkite/scripts/record_step_result.sh ${BK_KEY}_moonshotai_Kimi-K2-Thinking_UnitTest
 
   - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Accuracy for moonshotai/Kimi-K2-Thinking"
-    key: "${BK_KEY}_moonshotai_Kimi-K2-Thinking_Accuracy"
+    key: "${BK_KEY}_moonshotai_Kimi-K2-Thinking_Accuracy_Correctness"
     depends_on: "${BK_KEY}_record_moonshotai_Kimi-K2-Thinking_UnitTest"
     env:
       MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
@@ -48,10 +48,10 @@ steps:
     soft_fail: true
     commands:
       - |
-        buildkite-agent meta-data set "${BK_KEY}_moonshotai_Kimi-K2-Thinking_Accuracy" "unverified"
+        buildkite-agent meta-data set "${BK_KEY}_moonshotai_Kimi-K2-Thinking_Accuracy_Correctness" "unverified"
   - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record integration test result for moonshotai/Kimi-K2-Thinking"
-    key: "${BK_KEY}_record_moonshotai_Kimi-K2-Thinking_Accuracy"
-    depends_on: "${BK_KEY}_moonshotai_Kimi-K2-Thinking_Accuracy"
+    key: "${BK_KEY}_record_moonshotai_Kimi-K2-Thinking_Accuracy_Correctness"
+    depends_on: "${BK_KEY}_moonshotai_Kimi-K2-Thinking_Accuracy_Correctness"
     env:
       MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
@@ -62,11 +62,11 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${BK_KEY}_moonshotai_Kimi-K2-Thinking_Accuracy
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_moonshotai_Kimi-K2-Thinking_Accuracy_Correctness
 
   - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance benchmarks for moonshotai/Kimi-K2-Thinking"
     key: "${BK_KEY}_moonshotai_Kimi-K2-Thinking_Benchmark"
-    depends_on: "${BK_KEY}_record_moonshotai_Kimi-K2-Thinking_Accuracy"
+    depends_on: "${BK_KEY}_record_moonshotai_Kimi-K2-Thinking_Accuracy_Correctness"
     env:
       MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:

--- a/.buildkite/models/moonshotai_Kimi-K2-Thinking.yml
+++ b/.buildkite/models/moonshotai_Kimi-K2-Thinking.yml
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Unit tests for moonshotai/Kimi-K2-Thinking"
-    key: "${TPU_VERSION:-tpu6e}_moonshotai_Kimi-K2-Thinking_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Unit tests for moonshotai/Kimi-K2-Thinking"
+    key: "${BK_KEY}_moonshotai_Kimi-K2-Thinking_UnitTest"
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
     soft_fail: true
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_moonshotai_Kimi-K2-Thinking_UnitTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record unit test result for moonshotai/Kimi-K2-Thinking"
-    key: "${TPU_VERSION:-tpu6e}_record_moonshotai_Kimi-K2-Thinking_UnitTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_moonshotai_Kimi-K2-Thinking_UnitTest"
+        buildkite-agent meta-data set "${BK_KEY}_moonshotai_Kimi-K2-Thinking_UnitTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record unit test result for moonshotai/Kimi-K2-Thinking"
+    key: "${BK_KEY}_record_moonshotai_Kimi-K2-Thinking_UnitTest"
+    depends_on: "${BK_KEY}_moonshotai_Kimi-K2-Thinking_UnitTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "moonshotai/Kimi-K2-Thinking"
       CI_STAGE: "UnitTest"
@@ -33,21 +36,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_moonshotai_Kimi-K2-Thinking_UnitTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_moonshotai_Kimi-K2-Thinking_UnitTest
 
-  - label: "${TPU_VERSION:-tpu6e} Accuracy for moonshotai/Kimi-K2-Thinking"
-    key: "${TPU_VERSION:-tpu6e}_moonshotai_Kimi-K2-Thinking_Accuracy"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_moonshotai_Kimi-K2-Thinking_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Accuracy for moonshotai/Kimi-K2-Thinking"
+    key: "${BK_KEY}_moonshotai_Kimi-K2-Thinking_Accuracy"
+    depends_on: "${BK_KEY}_record_moonshotai_Kimi-K2-Thinking_UnitTest"
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
     soft_fail: true
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_moonshotai_Kimi-K2-Thinking_Accuracy" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record integration test result for moonshotai/Kimi-K2-Thinking"
-    key: "${TPU_VERSION:-tpu6e}_record_moonshotai_Kimi-K2-Thinking_Accuracy"
-    depends_on: "${TPU_VERSION:-tpu6e}_moonshotai_Kimi-K2-Thinking_Accuracy"
+        buildkite-agent meta-data set "${BK_KEY}_moonshotai_Kimi-K2-Thinking_Accuracy" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record integration test result for moonshotai/Kimi-K2-Thinking"
+    key: "${BK_KEY}_record_moonshotai_Kimi-K2-Thinking_Accuracy"
+    depends_on: "${BK_KEY}_moonshotai_Kimi-K2-Thinking_Accuracy"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "moonshotai/Kimi-K2-Thinking"
       CI_STAGE: "Accuracy/Correctness"
@@ -56,21 +62,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_moonshotai_Kimi-K2-Thinking_Accuracy
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_moonshotai_Kimi-K2-Thinking_Accuracy
 
-  - label: "${TPU_VERSION:-tpu6e} Performance benchmarks for moonshotai/Kimi-K2-Thinking"
-    key: "${TPU_VERSION:-tpu6e}_moonshotai_Kimi-K2-Thinking_Benchmark"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_moonshotai_Kimi-K2-Thinking_Accuracy"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance benchmarks for moonshotai/Kimi-K2-Thinking"
+    key: "${BK_KEY}_moonshotai_Kimi-K2-Thinking_Benchmark"
+    depends_on: "${BK_KEY}_record_moonshotai_Kimi-K2-Thinking_Accuracy"
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
     soft_fail: true
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_moonshotai_Kimi-K2-Thinking_Benchmark" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance benchmark result for moonshotai/Kimi-K2-Thinking"
-    key: "${TPU_VERSION:-tpu6e}_record_moonshotai_Kimi-K2-Thinking_Benchmark"
-    depends_on: "${TPU_VERSION:-tpu6e}_moonshotai_Kimi-K2-Thinking_Benchmark"
+        buildkite-agent meta-data set "${BK_KEY}_moonshotai_Kimi-K2-Thinking_Benchmark" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance benchmark result for moonshotai/Kimi-K2-Thinking"
+    key: "${BK_KEY}_record_moonshotai_Kimi-K2-Thinking_Benchmark"
+    depends_on: "${BK_KEY}_moonshotai_Kimi-K2-Thinking_Benchmark"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "moonshotai/Kimi-K2-Thinking"
       CI_STAGE: "Benchmark"
@@ -79,4 +88,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_moonshotai_Kimi-K2-Thinking_Benchmark
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_moonshotai_Kimi-K2-Thinking_Benchmark

--- a/.buildkite/models/moonshotai_Kimi-K2-Thinking.yml
+++ b/.buildkite/models/moonshotai_Kimi-K2-Thinking.yml
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Unit tests for moonshotai/Kimi-K2-Thinking"
-    key: "${TPU_VERSION:-tpu6e}_moonshotai_Kimi-K2-Thinking_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Unit tests for moonshotai/Kimi-K2-Thinking"
+    key: "${BK_KEY}_moonshotai_Kimi-K2-Thinking_UnitTest"
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}")
     soft_fail: true
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_moonshotai_Kimi-K2-Thinking_UnitTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record unit test result for moonshotai/Kimi-K2-Thinking"
-    key: "${TPU_VERSION:-tpu6e}_record_moonshotai_Kimi-K2-Thinking_UnitTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_moonshotai_Kimi-K2-Thinking_UnitTest"
+        buildkite-agent meta-data set "${BK_KEY}_moonshotai_Kimi-K2-Thinking_UnitTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record unit test result for moonshotai/Kimi-K2-Thinking"
+    key: "${BK_KEY}_record_moonshotai_Kimi-K2-Thinking_UnitTest"
+    depends_on: "${BK_KEY}_moonshotai_Kimi-K2-Thinking_UnitTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "moonshotai/Kimi-K2-Thinking"
       CI_STAGE: "UnitTest"
@@ -33,21 +36,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_moonshotai_Kimi-K2-Thinking_UnitTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_moonshotai_Kimi-K2-Thinking_UnitTest
 
-  - label: "${TPU_VERSION:-tpu6e} Accuracy for moonshotai/Kimi-K2-Thinking"
-    key: "${TPU_VERSION:-tpu6e}_moonshotai_Kimi-K2-Thinking_Accuracy"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_moonshotai_Kimi-K2-Thinking_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Accuracy for moonshotai/Kimi-K2-Thinking"
+    key: "${BK_KEY}_moonshotai_Kimi-K2-Thinking_Accuracy"
+    depends_on: "${BK_KEY}_record_moonshotai_Kimi-K2-Thinking_UnitTest"
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}")
     soft_fail: true
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_moonshotai_Kimi-K2-Thinking_Accuracy" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record integration test result for moonshotai/Kimi-K2-Thinking"
-    key: "${TPU_VERSION:-tpu6e}_record_moonshotai_Kimi-K2-Thinking_Accuracy"
-    depends_on: "${TPU_VERSION:-tpu6e}_moonshotai_Kimi-K2-Thinking_Accuracy"
+        buildkite-agent meta-data set "${BK_KEY}_moonshotai_Kimi-K2-Thinking_Accuracy" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record integration test result for moonshotai/Kimi-K2-Thinking"
+    key: "${BK_KEY}_record_moonshotai_Kimi-K2-Thinking_Accuracy"
+    depends_on: "${BK_KEY}_moonshotai_Kimi-K2-Thinking_Accuracy"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "moonshotai/Kimi-K2-Thinking"
       CI_STAGE: "Accuracy/Correctness"
@@ -56,21 +62,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_moonshotai_Kimi-K2-Thinking_Accuracy
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_moonshotai_Kimi-K2-Thinking_Accuracy
 
-  - label: "${TPU_VERSION:-tpu6e} Performance benchmarks for moonshotai/Kimi-K2-Thinking"
-    key: "${TPU_VERSION:-tpu6e}_moonshotai_Kimi-K2-Thinking_Benchmark"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_moonshotai_Kimi-K2-Thinking_Accuracy"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance benchmarks for moonshotai/Kimi-K2-Thinking"
+    key: "${BK_KEY}_moonshotai_Kimi-K2-Thinking_Benchmark"
+    depends_on: "${BK_KEY}_record_moonshotai_Kimi-K2-Thinking_Accuracy"
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}")
     soft_fail: true
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_moonshotai_Kimi-K2-Thinking_Benchmark" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance benchmark result for moonshotai/Kimi-K2-Thinking"
-    key: "${TPU_VERSION:-tpu6e}_record_moonshotai_Kimi-K2-Thinking_Benchmark"
-    depends_on: "${TPU_VERSION:-tpu6e}_moonshotai_Kimi-K2-Thinking_Benchmark"
+        buildkite-agent meta-data set "${BK_KEY}_moonshotai_Kimi-K2-Thinking_Benchmark" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance benchmark result for moonshotai/Kimi-K2-Thinking"
+    key: "${BK_KEY}_record_moonshotai_Kimi-K2-Thinking_Benchmark"
+    depends_on: "${BK_KEY}_moonshotai_Kimi-K2-Thinking_Benchmark"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "moonshotai/Kimi-K2-Thinking"
       CI_STAGE: "Benchmark"
@@ -79,4 +88,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_moonshotai_Kimi-K2-Thinking_Benchmark
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_moonshotai_Kimi-K2-Thinking_Benchmark

--- a/.buildkite/models/moonshotai_Kimi-K2_6.yml
+++ b/.buildkite/models/moonshotai_Kimi-K2_6.yml
@@ -51,7 +51,7 @@ steps:
         .buildkite/scripts/record_step_result.sh ${BK_KEY}_moonshotai_Kimi-K2_6_UnitTest
 
   - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Accuracy for moonshotai/Kimi-K2.6"
-    key: "${BK_KEY}_moonshotai_Kimi-K2_6_Accuracy"
+    key: "${BK_KEY}_moonshotai_Kimi-K2_6_Accuracy_Correctness"
     depends_on: "${BK_KEY}_record_moonshotai_Kimi-K2_6_UnitTest"
     soft_fail: true
     agents:
@@ -71,14 +71,14 @@ steps:
     commands:
       - |
         if [ "${TPU_VERSION:-tpu6e}" = "tpu6e" ]; then
-          buildkite-agent meta-data set "${BK_KEY}_moonshotai_Kimi-K2_6_Accuracy" "not enough HBM"
+          buildkite-agent meta-data set "${BK_KEY}_moonshotai_Kimi-K2_6_Accuracy_Correctness" "not enough HBM"
         else
           .buildkite/scripts/run_in_docker.sh \
             bash /workspace/tpu_inference/tests/e2e/benchmarking/mmlu.sh -m  "gs://tpu-commons-ci/moonshootai/kimi/2.6" -n 14042 -l 4
         fi
   - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record accuracy result for moonshotai/Kimi-K2_6"
-    key: "${BK_KEY}_record_moonshotai_Kimi-K2_6_Accuracy"
-    depends_on: "${BK_KEY}_moonshotai_Kimi-K2_6_Accuracy"
+    key: "${BK_KEY}_record_moonshotai_Kimi-K2_6_Accuracy_Correctness"
+    depends_on: "${BK_KEY}_moonshotai_Kimi-K2_6_Accuracy_Correctness"
     env:
       MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
@@ -89,11 +89,11 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${BK_KEY}_moonshotai_Kimi-K2_6_Accuracy
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_moonshotai_Kimi-K2_6_Accuracy_Correctness
 
   - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance benchmarks for moonshotai/Kimi-K2.6"
     key: "${BK_KEY}_moonshotai_Kimi-K2_6_Benchmark"
-    depends_on: "${BK_KEY}_record_moonshotai_Kimi-K2_6_Accuracy"
+    depends_on: "${BK_KEY}_record_moonshotai_Kimi-K2_6_Accuracy_Correctness"
     soft_fail: true
     agents:
       queue: cpu  # TODO: replace with execution environment

--- a/.buildkite/models/moonshotai_Kimi-K2_6.yml
+++ b/.buildkite/models/moonshotai_Kimi-K2_6.yml
@@ -13,15 +13,15 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Unit tests for moonshotai/Kimi-K2.6"
-    key: "${TPU_VERSION:-tpu6e}_moonshotai_Kimi-K2_6_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Unit tests for moonshotai/Kimi-K2.6"
+    key: "${BK_KEY}_moonshotai_Kimi-K2_6_UnitTest"
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v6e_queue}"
     commands:
       - |
         if [ "${TPU_VERSION:-tpu6e}" = "tpu6e" ]; then
-          buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_moonshotai_Kimi-K2_6_UnitTest" "not enough HBM"
+          buildkite-agent meta-data set "${BK_KEY}_moonshotai_Kimi-K2_6_UnitTest" "not enough HBM"
         else
           .buildkite/scripts/run_in_docker.sh \
             bash /workspace/tpu_inference/tests/e2e/benchmarking/mlperf.sh -m "gs://tpu-commons-ci/moonshootai/kimi/2.6" -t 2750
@@ -35,10 +35,11 @@ steps:
       MODEL_IMPL_TYPE: "vllm"
       USE_V7X8_QUEUE: "True"
 
-  - label: "${TPU_VERSION:-tpu6e} Record unit test result for moonshotai/Kimi-K2_6"
-    key: "${TPU_VERSION:-tpu6e}_record_moonshotai_Kimi-K2_6_UnitTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_moonshotai_Kimi-K2_6_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record unit test result for moonshotai/Kimi-K2_6"
+    key: "${BK_KEY}_record_moonshotai_Kimi-K2_6_UnitTest"
+    depends_on: "${BK_KEY}_moonshotai_Kimi-K2_6_UnitTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "moonshotai/Kimi-K2.6"
       CI_STAGE: "UnitTest"
@@ -47,11 +48,11 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_moonshotai_Kimi-K2_6_UnitTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_moonshotai_Kimi-K2_6_UnitTest
 
-  - label: "${TPU_VERSION:-tpu6e} Accuracy for moonshotai/Kimi-K2.6"
-    key: "${TPU_VERSION:-tpu6e}_moonshotai_Kimi-K2_6_Accuracy"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_moonshotai_Kimi-K2_6_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Accuracy for moonshotai/Kimi-K2.6"
+    key: "${BK_KEY}_moonshotai_Kimi-K2_6_Accuracy"
+    depends_on: "${BK_KEY}_record_moonshotai_Kimi-K2_6_UnitTest"
     soft_fail: true
     agents:
       queue: ${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}
@@ -64,21 +65,22 @@ steps:
       MOE_REQUANTIZE_BLOCK_SIZE: "512"
       MOE_REQUANTIZE_WEIGHT_DTYPE: "fp4"
       DEVICE_COUNT: "8"
-      MODEL_IMPL_TYPE: "vllm"
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       USE_V7X8_QUEUE: "True"
       MINIMUM_ACCURACY_THRESHOLD: "0.86"
     commands:
       - |
         if [ "${TPU_VERSION:-tpu6e}" = "tpu6e" ]; then
-          buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_moonshotai_Kimi-K2_6_Accuracy" "not enough HBM"
+          buildkite-agent meta-data set "${BK_KEY}_moonshotai_Kimi-K2_6_Accuracy" "not enough HBM"
         else
           .buildkite/scripts/run_in_docker.sh \
             bash /workspace/tpu_inference/tests/e2e/benchmarking/mmlu.sh -m  "gs://tpu-commons-ci/moonshootai/kimi/2.6" -n 14042 -l 4
         fi
-  - label: "${TPU_VERSION:-tpu6e} Record accuracy result for moonshotai/Kimi-K2_6"
-    key: "${TPU_VERSION:-tpu6e}_record_moonshotai_Kimi-K2_6_Accuracy"
-    depends_on: "${TPU_VERSION:-tpu6e}_moonshotai_Kimi-K2_6_Accuracy"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record accuracy result for moonshotai/Kimi-K2_6"
+    key: "${BK_KEY}_record_moonshotai_Kimi-K2_6_Accuracy"
+    depends_on: "${BK_KEY}_moonshotai_Kimi-K2_6_Accuracy"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "moonshotai/Kimi-K2.6"
       CI_STAGE: "Accuracy/Correctness"
@@ -87,25 +89,27 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_moonshotai_Kimi-K2_6_Accuracy
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_moonshotai_Kimi-K2_6_Accuracy
 
-  - label: "${TPU_VERSION:-tpu6e} Performance benchmarks for moonshotai/Kimi-K2.6"
-    key: "${TPU_VERSION:-tpu6e}_moonshotai_Kimi-K2_6_Benchmark"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_moonshotai_Kimi-K2_6_Accuracy"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance benchmarks for moonshotai/Kimi-K2.6"
+    key: "${BK_KEY}_moonshotai_Kimi-K2_6_Benchmark"
+    depends_on: "${BK_KEY}_record_moonshotai_Kimi-K2_6_Accuracy"
     soft_fail: true
     agents:
       queue: cpu  # TODO: replace with execution environment
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       TEST_MODEL: moonshotai/Kimi-K2.6
       TENSOR_PARALLEL_SIZE: "${TENSOR_PARALLEL_SIZE_SINGLE:-1}"
       MINIMUM_THROUGHPUT_THRESHOLD: 0  # TODO : replace 0 with your performance threshold
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_moonshotai_Kimi-K2_6_Benchmark" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance benchmark result for moonshotai/Kimi-K2.6"
-    key: "${TPU_VERSION:-tpu6e}_record_moonshotai_Kimi-K2_6_Benchmark"
-    depends_on: "${TPU_VERSION:-tpu6e}_moonshotai_Kimi-K2_6_Benchmark"
+        buildkite-agent meta-data set "${BK_KEY}_moonshotai_Kimi-K2_6_Benchmark" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance benchmark result for moonshotai/Kimi-K2.6"
+    key: "${BK_KEY}_record_moonshotai_Kimi-K2_6_Benchmark"
+    depends_on: "${BK_KEY}_moonshotai_Kimi-K2_6_Benchmark"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "moonshotai/Kimi-K2.6"
       CI_STAGE: "Benchmark"
@@ -114,4 +118,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_moonshotai_Kimi-K2_6_Benchmark
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_moonshotai_Kimi-K2_6_Benchmark

--- a/.buildkite/models/openai_gpt-oss-120b.yml
+++ b/.buildkite/models/openai_gpt-oss-120b.yml
@@ -46,7 +46,7 @@ steps:
         .buildkite/scripts/record_step_result.sh ${BK_KEY}_openai_gpt-oss-120b_UnitTest
 
   - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Accuracy for openai/gpt-oss-120b"
-    key: "${BK_KEY}_openai_gpt-oss-120b_Accuracy"
+    key: "${BK_KEY}_openai_gpt-oss-120b_Accuracy_Correctness"
     depends_on: "${BK_KEY}_record_openai_gpt-oss-120b_UnitTest"
     env:
       MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
@@ -55,9 +55,9 @@ steps:
     soft_fail: true
     commands:
       - |
-        buildkite-agent meta-data set "${BK_KEY}_openai_gpt-oss-120b_Accuracy" "unverified"
+        buildkite-agent meta-data set "${BK_KEY}_openai_gpt-oss-120b_Accuracy_Correctness" "unverified"
   - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record accuracy result for openai/gpt-oss-120b"
-    key: "${BK_KEY}_record_openai_gpt-oss-120b_Accuracy"
+    key: "${BK_KEY}_record_openai_gpt-oss-120b_Accuracy_Correctness"
     depends_on: "${BK_KEY}_openai_gpt-oss-120b_UnitTest"
     env:
       MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
@@ -73,7 +73,7 @@ steps:
 
   - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance benchmarks for openai/gpt-oss-120b"
     key: "${BK_KEY}_openai_gpt-oss-120b_Benchmark"
-    depends_on: "${BK_KEY}_record_openai_gpt-oss-120b_Accuracy"
+    depends_on: "${BK_KEY}_record_openai_gpt-oss-120b_Accuracy_Correctness"
     env:
       MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:

--- a/.buildkite/models/openai_gpt-oss-120b.yml
+++ b/.buildkite/models/openai_gpt-oss-120b.yml
@@ -13,8 +13,10 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Unit tests for openai/gpt-oss-120b"
-    key: "${TPU_VERSION:-tpu6e}_openai_gpt-oss-120b_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Unit tests for openai/gpt-oss-120b"
+    key: "${BK_KEY}_openai_gpt-oss-120b_UnitTest"
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: ${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}
     soft_fail: true
@@ -23,15 +25,16 @@ steps:
     commands:
       - |
         if [ "${TPU_VERSION:-tpu6e}" = "tpu6e" ]; then
-          buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_openai_gpt-oss-120b_UnitTest" "not enough HBM"
+          buildkite-agent meta-data set "${BK_KEY}_openai_gpt-oss-120b_UnitTest" "not enough HBM"
         else
           .buildkite/scripts/run_in_docker.sh \
             bash /workspace/tpu_inference/tests/e2e/check_lm_eval.sh  --model_name "openai/gpt-oss-120b" --use_moe_ep_kernel 1 --tensor_parallel_size 8 --max_model_len 2048 --max_num_batched_tokens 2048 --max_gen_toks 256 --enable_expert_parallel 1 --flex_threshold 0.50 --strict_threshold 0.0
         fi
-  - label: "${TPU_VERSION:-tpu6e} Record unit test result for openai/gpt-oss-120b"
-    key: "${TPU_VERSION:-tpu6e}_record_openai_gpt-oss-120b_UnitTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_openai_gpt-oss-120b_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record unit test result for openai/gpt-oss-120b"
+    key: "${BK_KEY}_record_openai_gpt-oss-120b_UnitTest"
+    depends_on: "${BK_KEY}_openai_gpt-oss-120b_UnitTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "openai/gpt-oss-120b"
       CI_STAGE: "UnitTest"
@@ -40,21 +43,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_openai_gpt-oss-120b_UnitTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_openai_gpt-oss-120b_UnitTest
 
-  - label: "${TPU_VERSION:-tpu6e} Accuracy for openai/gpt-oss-120b"
-    key: "${TPU_VERSION:-tpu6e}_openai_gpt-oss-120b_Accuracy"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_openai_gpt-oss-120b_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Accuracy for openai/gpt-oss-120b"
+    key: "${BK_KEY}_openai_gpt-oss-120b_Accuracy"
+    depends_on: "${BK_KEY}_record_openai_gpt-oss-120b_UnitTest"
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment
     soft_fail: true
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_openai_gpt-oss-120b_Accuracy" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record accuracy result for openai/gpt-oss-120b"
-    key: "${TPU_VERSION:-tpu6e}_record_openai_gpt-oss-120b_Accuracy"
-    depends_on: "${TPU_VERSION:-tpu6e}_openai_gpt-oss-120b_UnitTest"
+        buildkite-agent meta-data set "${BK_KEY}_openai_gpt-oss-120b_Accuracy" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record accuracy result for openai/gpt-oss-120b"
+    key: "${BK_KEY}_record_openai_gpt-oss-120b_Accuracy"
+    depends_on: "${BK_KEY}_openai_gpt-oss-120b_UnitTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "openai/gpt-oss-120b"
       CI_STAGE: "Accuracy/Correctness"
@@ -63,21 +69,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_openai_gpt-oss-120b_UnitTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_openai_gpt-oss-120b_UnitTest
 
-  - label: "${TPU_VERSION:-tpu6e} Performance benchmarks for openai/gpt-oss-120b"
-    key: "${TPU_VERSION:-tpu6e}_openai_gpt-oss-120b_Benchmark"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_openai_gpt-oss-120b_Accuracy"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance benchmarks for openai/gpt-oss-120b"
+    key: "${BK_KEY}_openai_gpt-oss-120b_Benchmark"
+    depends_on: "${BK_KEY}_record_openai_gpt-oss-120b_Accuracy"
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment
     soft_fail: true
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_openai_gpt-oss-120b_Benchmark" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance benchmark result for openai/gpt-oss-120b"
-    key: "${TPU_VERSION:-tpu6e}_record_openai_gpt-oss-120b_Benchmark"
-    depends_on: "${TPU_VERSION:-tpu6e}_openai_gpt-oss-120b_Benchmark"
+        buildkite-agent meta-data set "${BK_KEY}_openai_gpt-oss-120b_Benchmark" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance benchmark result for openai/gpt-oss-120b"
+    key: "${BK_KEY}_record_openai_gpt-oss-120b_Benchmark"
+    depends_on: "${BK_KEY}_openai_gpt-oss-120b_Benchmark"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "openai/gpt-oss-120b"
       CI_STAGE: "Benchmark"
@@ -86,4 +95,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_openai_gpt-oss-120b_Benchmark
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_openai_gpt-oss-120b_Benchmark

--- a/.buildkite/models/openai_gpt-oss-20b.yml
+++ b/.buildkite/models/openai_gpt-oss-20b.yml
@@ -39,7 +39,7 @@ steps:
         .buildkite/scripts/record_step_result.sh ${BK_KEY}_openai_gpt-oss-20b_UnitTest
 
   - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Accuracy for openai/gpt-oss-20b"
-    key: "${BK_KEY}_openai_gpt-oss-20b_Accuracy"
+    key: "${BK_KEY}_openai_gpt-oss-20b_Accuracy_Correctness"
     depends_on: "${BK_KEY}_record_openai_gpt-oss-20b_UnitTest"
     soft_fail: true
     agents:
@@ -51,10 +51,10 @@ steps:
       MINIMUM_ACCURACY_THRESHOLD: 0  # TODO : replace 0 with your accuracy threshold
     commands:
       - |
-        buildkite-agent meta-data set "${BK_KEY}_openai_gpt-oss-20b_Accuracy" "unverified"
+        buildkite-agent meta-data set "${BK_KEY}_openai_gpt-oss-20b_Accuracy_Correctness" "unverified"
   - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record accuracy result for openai/gpt-oss-20b"
-    key: "${BK_KEY}_record_openai_gpt-oss-20b_Accuracy"
-    depends_on: "${BK_KEY}_openai_gpt-oss-20b_Accuracy"
+    key: "${BK_KEY}_record_openai_gpt-oss-20b_Accuracy_Correctness"
+    depends_on: "${BK_KEY}_openai_gpt-oss-20b_Accuracy_Correctness"
     env:
       MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
@@ -65,11 +65,11 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${BK_KEY}_openai_gpt-oss-20b_Accuracy
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_openai_gpt-oss-20b_Accuracy_Correctness
 
   - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance benchmarks for openai/gpt-oss-20b"
     key: "${BK_KEY}_openai_gpt-oss-20b_Benchmark"
-    depends_on: "${BK_KEY}_record_openai_gpt-oss-20b_Accuracy"
+    depends_on: "${BK_KEY}_record_openai_gpt-oss-20b_Accuracy_Correctness"
     soft_fail: true
     agents:
       queue: cpu  # TODO: replace with execution environment

--- a/.buildkite/models/openai_gpt-oss-20b.yml
+++ b/.buildkite/models/openai_gpt-oss-20b.yml
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Unit tests for openai/gpt-oss-20b"
-    key: "${TPU_VERSION:-tpu6e}_openai_gpt-oss-20b_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Unit tests for openai/gpt-oss-20b"
+    key: "${BK_KEY}_openai_gpt-oss-20b_UnitTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_openai_gpt-oss-20b_UnitTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record unit test result for openai/gpt-oss-20b"
-    key: "${TPU_VERSION:-tpu6e}_record_openai_gpt-oss-20b_UnitTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_openai_gpt-oss-20b_UnitTest"
+        buildkite-agent meta-data set "${BK_KEY}_openai_gpt-oss-20b_UnitTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record unit test result for openai/gpt-oss-20b"
+    key: "${BK_KEY}_record_openai_gpt-oss-20b_UnitTest"
+    depends_on: "${BK_KEY}_openai_gpt-oss-20b_UnitTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "openai/gpt-oss-20b"
       CI_STAGE: "UnitTest"
@@ -33,25 +36,27 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_openai_gpt-oss-20b_UnitTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_openai_gpt-oss-20b_UnitTest
 
-  - label: "${TPU_VERSION:-tpu6e} Accuracy for openai/gpt-oss-20b"
-    key: "${TPU_VERSION:-tpu6e}_openai_gpt-oss-20b_Accuracy"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_openai_gpt-oss-20b_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Accuracy for openai/gpt-oss-20b"
+    key: "${BK_KEY}_openai_gpt-oss-20b_Accuracy"
+    depends_on: "${BK_KEY}_record_openai_gpt-oss-20b_UnitTest"
     soft_fail: true
     agents:
       queue: cpu  # TODO: replace with execution environment
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       TEST_MODEL: openai/gpt-oss-20b
       TENSOR_PARALLEL_SIZE: "${TENSOR_PARALLEL_SIZE_SINGLE:-1}"
       MINIMUM_ACCURACY_THRESHOLD: 0  # TODO : replace 0 with your accuracy threshold
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_openai_gpt-oss-20b_Accuracy" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record accuracy result for openai/gpt-oss-20b"
-    key: "${TPU_VERSION:-tpu6e}_record_openai_gpt-oss-20b_Accuracy"
-    depends_on: "${TPU_VERSION:-tpu6e}_openai_gpt-oss-20b_Accuracy"
+        buildkite-agent meta-data set "${BK_KEY}_openai_gpt-oss-20b_Accuracy" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record accuracy result for openai/gpt-oss-20b"
+    key: "${BK_KEY}_record_openai_gpt-oss-20b_Accuracy"
+    depends_on: "${BK_KEY}_openai_gpt-oss-20b_Accuracy"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "openai/gpt-oss-20b"
       CI_STAGE: "Accuracy/Correctness"
@@ -60,25 +65,27 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_openai_gpt-oss-20b_Accuracy
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_openai_gpt-oss-20b_Accuracy
 
-  - label: "${TPU_VERSION:-tpu6e} Performance benchmarks for openai/gpt-oss-20b"
-    key: "${TPU_VERSION:-tpu6e}_openai_gpt-oss-20b_Benchmark"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_openai_gpt-oss-20b_Accuracy"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance benchmarks for openai/gpt-oss-20b"
+    key: "${BK_KEY}_openai_gpt-oss-20b_Benchmark"
+    depends_on: "${BK_KEY}_record_openai_gpt-oss-20b_Accuracy"
     soft_fail: true
     agents:
       queue: cpu  # TODO: replace with execution environment
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       TEST_MODEL: openai/gpt-oss-20b
       TENSOR_PARALLEL_SIZE: "${TENSOR_PARALLEL_SIZE_SINGLE:-1}"
       MINIMUM_THROUGHPUT_THRESHOLD: 0  # TODO : replace 0 with your performance threshold
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_openai_gpt-oss-20b_Benchmark" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance benchmark result for openai/gpt-oss-20b"
-    key: "${TPU_VERSION:-tpu6e}_record_openai_gpt-oss-20b_Benchmark"
-    depends_on: "${TPU_VERSION:-tpu6e}_openai_gpt-oss-20b_Benchmark"
+        buildkite-agent meta-data set "${BK_KEY}_openai_gpt-oss-20b_Benchmark" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance benchmark result for openai/gpt-oss-20b"
+    key: "${BK_KEY}_record_openai_gpt-oss-20b_Benchmark"
+    depends_on: "${BK_KEY}_openai_gpt-oss-20b_Benchmark"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "openai/gpt-oss-20b"
       CI_STAGE: "Benchmark"
@@ -87,4 +94,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_openai_gpt-oss-20b_Benchmark
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_openai_gpt-oss-20b_Benchmark

--- a/.buildkite/models/zai-org_GLM-5.yml
+++ b/.buildkite/models/zai-org_GLM-5.yml
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Unit tests for zai-org/GLM-5"
-    key: "${TPU_VERSION:-tpu6e}_zai-org_GLM-5_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Unit tests for zai-org/GLM-5"
+    key: "${BK_KEY}_zai-org_GLM-5_UnitTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_zai-org_GLM-5_UnitTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record unit test result for zai-org/GLM-5"
-    key: "${TPU_VERSION:-tpu6e}_record_zai-org_GLM-5_UnitTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_zai-org_GLM-5_UnitTest"
+        buildkite-agent meta-data set "${BK_KEY}_zai-org_GLM-5_UnitTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record unit test result for zai-org/GLM-5"
+    key: "${BK_KEY}_record_zai-org_GLM-5_UnitTest"
+    depends_on: "${BK_KEY}_zai-org_GLM-5_UnitTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "zai-org/GLM-5"
       CI_STAGE: "UnitTest"
@@ -33,25 +36,27 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_zai-org_GLM-5_UnitTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_zai-org_GLM-5_UnitTest
 
-  - label: "${TPU_VERSION:-tpu6e} Accuracy for zai-org/GLM-5"
-    key: "${TPU_VERSION:-tpu6e}_zai-org_GLM-5_Accuracy"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_zai-org_GLM-5_UnitTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Accuracy for zai-org/GLM-5"
+    key: "${BK_KEY}_zai-org_GLM-5_Accuracy"
+    depends_on: "${BK_KEY}_record_zai-org_GLM-5_UnitTest"
     soft_fail: true
     agents:
       queue: cpu  # TODO: replace with execution environment
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       TEST_MODEL: zai-org/GLM-5
       TENSOR_PARALLEL_SIZE: "${TENSOR_PARALLEL_SIZE_SINGLE:-1}"
       MINIMUM_ACCURACY_THRESHOLD: 0  # TODO : replace 0 with your accuracy threshold
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_zai-org_GLM-5_Accuracy" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record accuracy result for zai-org/GLM-5"
-    key: "${TPU_VERSION:-tpu6e}_record_zai-org_GLM-5_Accuracy"
-    depends_on: "${TPU_VERSION:-tpu6e}_zai-org_GLM-5_Accuracy"
+        buildkite-agent meta-data set "${BK_KEY}_zai-org_GLM-5_Accuracy" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record accuracy result for zai-org/GLM-5"
+    key: "${BK_KEY}_record_zai-org_GLM-5_Accuracy"
+    depends_on: "${BK_KEY}_zai-org_GLM-5_Accuracy"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "zai-org/GLM-5"
       CI_STAGE: "Accuracy/Correctness"
@@ -60,25 +65,27 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_zai-org_GLM-5_Accuracy
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_zai-org_GLM-5_Accuracy
 
-  - label: "${TPU_VERSION:-tpu6e} Performance benchmarks for zai-org/GLM-5"
-    key: "${TPU_VERSION:-tpu6e}_zai-org_GLM-5_Benchmark"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_zai-org_GLM-5_Accuracy"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance benchmarks for zai-org/GLM-5"
+    key: "${BK_KEY}_zai-org_GLM-5_Benchmark"
+    depends_on: "${BK_KEY}_record_zai-org_GLM-5_Accuracy"
     soft_fail: true
     agents:
       queue: cpu  # TODO: replace with execution environment
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       TEST_MODEL: zai-org/GLM-5
       TENSOR_PARALLEL_SIZE: "${TENSOR_PARALLEL_SIZE_SINGLE:-1}"
       MINIMUM_THROUGHPUT_THRESHOLD: 0  # TODO : replace 0 with your performance threshold
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_zai-org_GLM-5_Benchmark" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance benchmark result for zai-org/GLM-5"
-    key: "${TPU_VERSION:-tpu6e}_record_zai-org_GLM-5_Benchmark"
-    depends_on: "${TPU_VERSION:-tpu6e}_zai-org_GLM-5_Benchmark"
+        buildkite-agent meta-data set "${BK_KEY}_zai-org_GLM-5_Benchmark" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance benchmark result for zai-org/GLM-5"
+    key: "${BK_KEY}_record_zai-org_GLM-5_Benchmark"
+    depends_on: "${BK_KEY}_zai-org_GLM-5_Benchmark"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "zai-org/GLM-5"
       CI_STAGE: "Benchmark"
@@ -87,4 +94,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_zai-org_GLM-5_Benchmark
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_zai-org_GLM-5_Benchmark

--- a/.buildkite/models/zai-org_GLM-5.yml
+++ b/.buildkite/models/zai-org_GLM-5.yml
@@ -39,7 +39,7 @@ steps:
         .buildkite/scripts/record_step_result.sh ${BK_KEY}_zai-org_GLM-5_UnitTest
 
   - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Accuracy for zai-org/GLM-5"
-    key: "${BK_KEY}_zai-org_GLM-5_Accuracy"
+    key: "${BK_KEY}_zai-org_GLM-5_Accuracy_Correctness"
     depends_on: "${BK_KEY}_record_zai-org_GLM-5_UnitTest"
     soft_fail: true
     agents:
@@ -51,10 +51,10 @@ steps:
       MINIMUM_ACCURACY_THRESHOLD: 0  # TODO : replace 0 with your accuracy threshold
     commands:
       - |
-        buildkite-agent meta-data set "${BK_KEY}_zai-org_GLM-5_Accuracy" "unverified"
+        buildkite-agent meta-data set "${BK_KEY}_zai-org_GLM-5_Accuracy_Correctness" "unverified"
   - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record accuracy result for zai-org/GLM-5"
-    key: "${BK_KEY}_record_zai-org_GLM-5_Accuracy"
-    depends_on: "${BK_KEY}_zai-org_GLM-5_Accuracy"
+    key: "${BK_KEY}_record_zai-org_GLM-5_Accuracy_Correctness"
+    depends_on: "${BK_KEY}_zai-org_GLM-5_Accuracy_Correctness"
     env:
       MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
@@ -65,11 +65,11 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${BK_KEY}_zai-org_GLM-5_Accuracy
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_zai-org_GLM-5_Accuracy_Correctness
 
   - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance benchmarks for zai-org/GLM-5"
     key: "${BK_KEY}_zai-org_GLM-5_Benchmark"
-    depends_on: "${BK_KEY}_record_zai-org_GLM-5_Accuracy"
+    depends_on: "${BK_KEY}_record_zai-org_GLM-5_Accuracy_Correctness"
     soft_fail: true
     agents:
       queue: cpu  # TODO: replace with execution environment

--- a/.buildkite/nightly_verify.yml
+++ b/.buildkite/nightly_verify.yml
@@ -16,7 +16,7 @@ x-run-condition: &run-on-nightly-or-tag
   if: build.env("NIGHTLY") == "1" || build.tag =~ /^v?[0-9]+(\.[a-zA-Z0-9]+)*([a-zA-Z]+[0-9]*)?$/
 
 steps:
-   - label: "Upload Tests for Models & Features (${MODEL_IMPL_TYPE:-auto})"
+   - label: "Upload Tests for Models & Features (${MODEL_IMPL_TYPE:-vllm})"
      <<: *run-on-nightly-or-tag
      agents:
        queue: cpu
@@ -37,41 +37,20 @@ steps:
           exit 1
         fi
         echo "✅ Metadata healthy. Proceeding..."
-
-   - label: "v6 Generate support matrices"
+    
+   - label: "Generate all support matrices"
      <<: *run-on-nightly-or-tag
-     key: "v6_generate_matrices"
+     key: "generate_matrices"
      depends_on: "check_metadata_health"
      agents: { queue: cpu }
-     env:
-       TPU_VERSION: "v6e"
      command: |
-      if [ "$(buildkite-agent meta-data get run_v6_matrix --default 'false')" = "true" ]; then
-          bash .buildkite/scripts/generate_support_matrices.sh
-        else
-          echo "--- Skipping v6 matrix generation (No v6 test data found)"
-        fi
+       bash .buildkite/scripts/generate_support_matrices.sh
 
-   - label: "v7 Generate support matrices"
-     <<: *run-on-nightly-or-tag
-     key: "v7_generate_matrices"
-     depends_on: "check_metadata_health"
-     agents: { queue: cpu }
-     env:
-      TPU_VERSION: "v7x"
-     command: |
-      if [ "$(buildkite-agent meta-data get run_v7_matrix --default 'false')" = "true" ]; then
-        bash .buildkite/scripts/generate_support_matrices.sh
-      else
-        echo "--- Skipping v7 matrix generation (No v7 test data found)"
-      fi
-  
    - label: "Commit support matrices if is nightly build or release tag specified"
      <<: *run-on-nightly-or-tag
      key: commit_support_matrices
      depends_on:
-       - "v6_generate_matrices"
-       - "v7_generate_matrices"
+       - "generate_matrices"
      agents:
        queue: cpu
      secrets:

--- a/.buildkite/nightly_verify.yml
+++ b/.buildkite/nightly_verify.yml
@@ -16,7 +16,7 @@ x-run-condition: &run-on-nightly-or-tag
   if: build.env("NIGHTLY") == "1" || build.tag =~ /^v?[0-9]+(\.[a-zA-Z0-9]+)*([a-zA-Z]+[0-9]*)?$/
 
 steps:
-   - label: "Upload Tests for Models & Features (${MODEL_IMPL_TYPE:-vllm})"
+   - label: "Upload Tests for Models & Features (flax_nnx and vllm)"
      <<: *run-on-nightly-or-tag
      agents:
        queue: cpu

--- a/.buildkite/parallelism/CP.yml
+++ b/.buildkite/parallelism/CP.yml
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for CP (single-host)"
-    key: "${TPU_VERSION:-tpu6e}_CP_CorrectnessTest_Single_Host"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for CP (single-host)"
+    key: "${BK_KEY}_CP_CorrectnessTest_Single_Host"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_CP_CorrectnessTest_Single_Host" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for CP (single-host)"
-    key: "${TPU_VERSION:-tpu6e}_record_CP_CorrectnessTest_Single_Host"
-    depends_on: "${TPU_VERSION:-tpu6e}_CP_CorrectnessTest_Single_Host"
+        buildkite-agent meta-data set "${BK_KEY}_CP_CorrectnessTest_Single_Host" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for CP (single-host)"
+    key: "${BK_KEY}_record_CP_CorrectnessTest_Single_Host"
+    depends_on: "${BK_KEY}_CP_CorrectnessTest_Single_Host"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "CP"
       CI_STAGE: "Single-Host CorrectnessTest"
@@ -33,21 +36,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_CP_CorrectnessTest_Single_Host
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_CP_CorrectnessTest_Single_Host
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for CP (single-host)"
-    key: "${TPU_VERSION:-tpu6e}_CP_PerformanceTest_Single_Host"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_CP_CorrectnessTest_Single_Host"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for CP (single-host)"
+    key: "${BK_KEY}_CP_PerformanceTest_Single_Host"
+    depends_on: "${BK_KEY}_record_CP_CorrectnessTest_Single_Host"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_CP_PerformanceTest_Single_Host" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for CP (single-host)"
-    key: "${TPU_VERSION:-tpu6e}_record_CP_PerformanceTest_Single_Host"
-    depends_on: "${TPU_VERSION:-tpu6e}_CP_PerformanceTest_Single_Host"
+        buildkite-agent meta-data set "${BK_KEY}_CP_PerformanceTest_Single_Host" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for CP (single-host)"
+    key: "${BK_KEY}_record_CP_PerformanceTest_Single_Host"
+    depends_on: "${BK_KEY}_CP_PerformanceTest_Single_Host"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "CP"
       CI_STAGE: "Single-Host PerformanceTest"
@@ -56,20 +62,23 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_CP_PerformanceTest_Single_Host
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_CP_PerformanceTest_Single_Host
 
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for CP (multi-host)"
-    key: "${TPU_VERSION:-tpu6e}_CP_CorrectnessTest_Multi_Host"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for CP (multi-host)"
+    key: "${BK_KEY}_CP_CorrectnessTest_Multi_Host"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_CP_CorrectnessTest_Multi_Host" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for CP (multi-host)"
-    key: "${TPU_VERSION:-tpu6e}_record_CP_CorrectnessTest_Multi_Host"
-    depends_on: "${TPU_VERSION:-tpu6e}_CP_CorrectnessTest_Multi_Host"
+        buildkite-agent meta-data set "${BK_KEY}_CP_CorrectnessTest_Multi_Host" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for CP (multi-host)"
+    key: "${BK_KEY}_record_CP_CorrectnessTest_Multi_Host"
+    depends_on: "${BK_KEY}_CP_CorrectnessTest_Multi_Host"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "CP"
       CI_STAGE: "Multi-Host CorrectnessTest"
@@ -78,20 +87,23 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_CP_CorrectnessTest_Multi_Host
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for CP (multi-host)"
-    key: "${TPU_VERSION:-tpu6e}_CP_PerformanceTest_Multi_Host"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_CP_CorrectnessTest_Multi_Host"
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_CP_CorrectnessTest_Multi_Host
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for CP (multi-host)"
+    key: "${BK_KEY}_CP_PerformanceTest_Multi_Host"
+    depends_on: "${BK_KEY}_record_CP_CorrectnessTest_Multi_Host"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_CP_PerformanceTest_Multi_Host" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for CP (multi-host)"
-    key: "${TPU_VERSION:-tpu6e}_record_CP_PerformanceTest_Multi_Host"
-    depends_on: "${TPU_VERSION:-tpu6e}_CP_PerformanceTest_Multi_Host"
+        buildkite-agent meta-data set "${BK_KEY}_CP_PerformanceTest_Multi_Host" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for CP (multi-host)"
+    key: "${BK_KEY}_record_CP_PerformanceTest_Multi_Host"
+    depends_on: "${BK_KEY}_CP_PerformanceTest_Multi_Host"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "CP"
       CI_STAGE: "Multi-Host PerformanceTest"
@@ -100,4 +112,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_CP_PerformanceTest_Multi_Host
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_CP_PerformanceTest_Multi_Host

--- a/.buildkite/parallelism/CP.yml
+++ b/.buildkite/parallelism/CP.yml
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for CP (single-host)"
-    key: "${TPU_VERSION:-tpu6e}_CP_CorrectnessTest_Single_Host"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for CP (single-host)"
+    key: "${BK_KEY}_CP_CorrectnessTest_Single_Host"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_CP_CorrectnessTest_Single_Host" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for CP (single-host)"
-    key: "${TPU_VERSION:-tpu6e}_record_CP_CorrectnessTest_Single_Host"
-    depends_on: "${TPU_VERSION:-tpu6e}_CP_CorrectnessTest_Single_Host"
+        buildkite-agent meta-data set "${BK_KEY}_CP_CorrectnessTest_Single_Host" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for CP (single-host)"
+    key: "${BK_KEY}_record_CP_CorrectnessTest_Single_Host"
+    depends_on: "${BK_KEY}_CP_CorrectnessTest_Single_Host"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "CP"
       CI_STAGE: "Single-Host CorrectnessTest"
@@ -33,21 +36,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_CP_CorrectnessTest_Single_Host
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_CP_CorrectnessTest_Single_Host
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for CP (single-host)"
-    key: "${TPU_VERSION:-tpu6e}_CP_PerformanceTest_Single_Host"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_CP_CorrectnessTest_Single_Host"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for CP (single-host)"
+    key: "${BK_KEY}_CP_PerformanceTest_Single_Host"
+    depends_on: "${BK_KEY}_record_CP_CorrectnessTest_Single_Host"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_CP_PerformanceTest_Single_Host" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for CP (single-host)"
-    key: "${TPU_VERSION:-tpu6e}_record_CP_PerformanceTest_Single_Host"
-    depends_on: "${TPU_VERSION:-tpu6e}_CP_PerformanceTest_Single_Host"
+        buildkite-agent meta-data set "${BK_KEY}_CP_PerformanceTest_Single_Host" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for CP (single-host)"
+    key: "${BK_KEY}_record_CP_PerformanceTest_Single_Host"
+    depends_on: "${BK_KEY}_CP_PerformanceTest_Single_Host"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "CP"
       CI_STAGE: "Single-Host PerformanceTest"
@@ -56,20 +62,23 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_CP_PerformanceTest_Single_Host
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_CP_PerformanceTest_Single_Host
 
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for CP (multi-host)"
-    key: "${TPU_VERSION:-tpu6e}_CP_CorrectnessTest_Multi_Host"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for CP (multi-host)"
+    key: "${BK_KEY}_CP_CorrectnessTest_Multi_Host"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_CP_CorrectnessTest_Multi_Host" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for CP (multi-host)"
-    key: "${TPU_VERSION:-tpu6e}_record_CP_CorrectnessTest_Multi_Host"
-    depends_on: "${TPU_VERSION:-tpu6e}_CP_CorrectnessTest_Multi_Host"
+        buildkite-agent meta-data set "${BK_KEY}_CP_CorrectnessTest_Multi_Host" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for CP (multi-host)"
+    key: "${BK_KEY}_record_CP_CorrectnessTest_Multi_Host"
+    depends_on: "${BK_KEY}_CP_CorrectnessTest_Multi_Host"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "CP"
       CI_STAGE: "Multi-Host CorrectnessTest"
@@ -78,20 +87,23 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_CP_CorrectnessTest_Multi_Host
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for CP (multi-host)"
-    key: "${TPU_VERSION:-tpu6e}_CP_PerformanceTest_Multi_Host"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_CP_CorrectnessTest_Multi_Host"
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_CP_CorrectnessTest_Multi_Host
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for CP (multi-host)"
+    key: "${BK_KEY}_CP_PerformanceTest_Multi_Host"
+    depends_on: "${BK_KEY}_record_CP_CorrectnessTest_Multi_Host"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_CP_PerformanceTest_Multi_Host" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for CP (multi-host)"
-    key: "${TPU_VERSION:-tpu6e}_record_CP_PerformanceTest_Multi_Host"
-    depends_on: "${TPU_VERSION:-tpu6e}_CP_PerformanceTest_Multi_Host"
+        buildkite-agent meta-data set "${BK_KEY}_CP_PerformanceTest_Multi_Host" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for CP (multi-host)"
+    key: "${BK_KEY}_record_CP_PerformanceTest_Multi_Host"
+    depends_on: "${BK_KEY}_CP_PerformanceTest_Multi_Host"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "CP"
       CI_STAGE: "Multi-Host PerformanceTest"
@@ -100,4 +112,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_CP_PerformanceTest_Multi_Host
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_CP_PerformanceTest_Multi_Host

--- a/.buildkite/parallelism/DP.yml
+++ b/.buildkite/parallelism/DP.yml
@@ -13,10 +13,11 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for DP (single-host)"
-    key: "${TPU_VERSION:-tpu6e}_DP_CorrectnessTest_Single_Host"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for DP (single-host)"
+    key: "${BK_KEY}_DP_CorrectnessTest_Single_Host"
     soft_fail: true
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       NEW_MODEL_DESIGN: "1"
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
@@ -24,10 +25,11 @@ steps:
       - |
         .buildkite/scripts/run_in_docker.sh \
           bash -c 'python3 -m pytest -s -v -x /workspace/tpu_inference/tests/e2e/test_data_parallel.py::test_dp_correctness'
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for DP (single-host)"
-    key: "${TPU_VERSION:-tpu6e}_record_DP_CorrectnessTest_Single_Host"
-    depends_on: "${TPU_VERSION:-tpu6e}_DP_CorrectnessTest_Single_Host"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for DP (single-host)"
+    key: "${BK_KEY}_record_DP_CorrectnessTest_Single_Host"
+    depends_on: "${BK_KEY}_DP_CorrectnessTest_Single_Host"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "DP"
       CI_STAGE: "Single-Host CorrectnessTest"
@@ -36,13 +38,14 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_DP_CorrectnessTest_Single_Host
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_DP_CorrectnessTest_Single_Host
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for DP (single-host)"
-    key: "${TPU_VERSION:-tpu6e}_DP_PerformanceTest_Single_Host"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_DP_CorrectnessTest_Single_Host"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for DP (single-host)"
+    key: "${BK_KEY}_DP_PerformanceTest_Single_Host"
+    depends_on: "${BK_KEY}_record_DP_CorrectnessTest_Single_Host"
     soft_fail: true
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       NEW_MODEL_DESIGN: "1"
     agents:
       queue: ${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}
@@ -50,10 +53,11 @@ steps:
       - |
         .buildkite/scripts/run_in_docker.sh \
           bash -c 'python3 -m pytest -s -v -x /workspace/tpu_inference/tests/e2e/test_data_parallel.py::test_dp_performance'
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for DP (single-host)"
-    key: "${TPU_VERSION:-tpu6e}_record_DP_PerformanceTest_Single_Host"
-    depends_on: "${TPU_VERSION:-tpu6e}_DP_PerformanceTest_Single_Host"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for DP (single-host)"
+    key: "${BK_KEY}_record_DP_PerformanceTest_Single_Host"
+    depends_on: "${BK_KEY}_DP_PerformanceTest_Single_Host"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "DP"
       CI_STAGE: "Single-Host PerformanceTest"
@@ -62,22 +66,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_DP_PerformanceTest_Single_Host
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_DP_PerformanceTest_Single_Host
 
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for DP (multi-host)"
-    key: "${TPU_VERSION:-tpu6e}_DP_CorrectnessTest_Multi_Host"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for DP (multi-host)"
+    key: "${BK_KEY}_DP_CorrectnessTest_Multi_Host"
     soft_fail: true
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       NEW_MODEL_DESIGN: "1"
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_DP_CorrectnessTest_Multi_Host" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for DP (multi-host)"
-    key: "${TPU_VERSION:-tpu6e}_record_DP_CorrectnessTest_Multi_Host"
-    depends_on: "${TPU_VERSION:-tpu6e}_DP_CorrectnessTest_Multi_Host"
+        buildkite-agent meta-data set "${BK_KEY}_DP_CorrectnessTest_Multi_Host" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for DP (multi-host)"
+    key: "${BK_KEY}_record_DP_CorrectnessTest_Multi_Host"
+    depends_on: "${BK_KEY}_DP_CorrectnessTest_Multi_Host"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "DP"
       CI_STAGE: "Multi-Host CorrectnessTest"
@@ -86,23 +92,25 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_DP_CorrectnessTest_Multi_Host
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_DP_CorrectnessTest_Multi_Host
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for DP (multi-host)"
-    key: "${TPU_VERSION:-tpu6e}_DP_PerformanceTest_Multi_Host"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_DP_CorrectnessTest_Multi_Host"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for DP (multi-host)"
+    key: "${BK_KEY}_DP_PerformanceTest_Multi_Host"
+    depends_on: "${BK_KEY}_record_DP_CorrectnessTest_Multi_Host"
     soft_fail: true
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       NEW_MODEL_DESIGN: "1"
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_DP_PerformanceTest_Multi_Host" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for DP (multi-host)"
-    key: "${TPU_VERSION:-tpu6e}_record_DP_PerformanceTest_Multi_Host"
-    depends_on: "${TPU_VERSION:-tpu6e}_DP_PerformanceTest_Multi_Host"
+        buildkite-agent meta-data set "${BK_KEY}_DP_PerformanceTest_Multi_Host" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for DP (multi-host)"
+    key: "${BK_KEY}_record_DP_PerformanceTest_Multi_Host"
+    depends_on: "${BK_KEY}_DP_PerformanceTest_Multi_Host"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "DP"
       CI_STAGE: "Multi-Host PerformanceTest"
@@ -111,4 +119,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_DP_PerformanceTest_Multi_Host
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_DP_PerformanceTest_Multi_Host

--- a/.buildkite/parallelism/DP.yml
+++ b/.buildkite/parallelism/DP.yml
@@ -13,10 +13,11 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for DP (single-host)"
-    key: "${TPU_VERSION:-tpu6e}_DP_CorrectnessTest_Single_Host"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for DP (single-host)"
+    key: "${BK_KEY}_DP_CorrectnessTest_Single_Host"
     soft_fail: true
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       NEW_MODEL_DESIGN: "1"
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
@@ -24,10 +25,11 @@ steps:
       - |
         .buildkite/scripts/run_in_docker.sh \
           bash -c 'python3 -m pytest -s -v -x /workspace/tpu_inference/tests/e2e/test_data_parallel.py::test_dp_correctness'
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for DP (single-host)"
-    key: "${TPU_VERSION:-tpu6e}_record_DP_CorrectnessTest_Single_Host"
-    depends_on: "${TPU_VERSION:-tpu6e}_DP_CorrectnessTest_Single_Host"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for DP (single-host)"
+    key: "${BK_KEY}_record_DP_CorrectnessTest_Single_Host"
+    depends_on: "${BK_KEY}_DP_CorrectnessTest_Single_Host"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "DP"
       CI_STAGE: "Single-Host CorrectnessTest"
@@ -36,13 +38,14 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_DP_CorrectnessTest_Single_Host
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_DP_CorrectnessTest_Single_Host
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for DP (single-host)"
-    key: "${TPU_VERSION:-tpu6e}_DP_PerformanceTest_Single_Host"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_DP_CorrectnessTest_Single_Host"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for DP (single-host)"
+    key: "${BK_KEY}_DP_PerformanceTest_Single_Host"
+    depends_on: "${BK_KEY}_record_DP_CorrectnessTest_Single_Host"
     soft_fail: true
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       NEW_MODEL_DESIGN: "1"
     agents:
       queue: ${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}
@@ -50,10 +53,11 @@ steps:
       - |
         .buildkite/scripts/run_in_docker.sh \
           bash -c 'python3 -m pytest -s -v -x /workspace/tpu_inference/tests/e2e/test_data_parallel.py::test_dp_performance'
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for DP (single-host)"
-    key: "${TPU_VERSION:-tpu6e}_record_DP_PerformanceTest_Single_Host"
-    depends_on: "${TPU_VERSION:-tpu6e}_DP_PerformanceTest_Single_Host"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for DP (single-host)"
+    key: "${BK_KEY}_record_DP_PerformanceTest_Single_Host"
+    depends_on: "${BK_KEY}_DP_PerformanceTest_Single_Host"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "DP"
       CI_STAGE: "Single-Host PerformanceTest"
@@ -62,22 +66,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_DP_PerformanceTest_Single_Host
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_DP_PerformanceTest_Single_Host
 
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for DP (multi-host)"
-    key: "${TPU_VERSION:-tpu6e}_DP_CorrectnessTest_Multi_Host"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for DP (multi-host)"
+    key: "${BK_KEY}_DP_CorrectnessTest_Multi_Host"
     soft_fail: true
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       NEW_MODEL_DESIGN: "1"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}")
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_DP_CorrectnessTest_Multi_Host" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for DP (multi-host)"
-    key: "${TPU_VERSION:-tpu6e}_record_DP_CorrectnessTest_Multi_Host"
-    depends_on: "${TPU_VERSION:-tpu6e}_DP_CorrectnessTest_Multi_Host"
+        buildkite-agent meta-data set "${BK_KEY}_DP_CorrectnessTest_Multi_Host" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for DP (multi-host)"
+    key: "${BK_KEY}_record_DP_CorrectnessTest_Multi_Host"
+    depends_on: "${BK_KEY}_DP_CorrectnessTest_Multi_Host"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "DP"
       CI_STAGE: "Multi-Host CorrectnessTest"
@@ -86,23 +92,25 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_DP_CorrectnessTest_Multi_Host
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_DP_CorrectnessTest_Multi_Host
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for DP (multi-host)"
-    key: "${TPU_VERSION:-tpu6e}_DP_PerformanceTest_Multi_Host"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_DP_CorrectnessTest_Multi_Host"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for DP (multi-host)"
+    key: "${BK_KEY}_DP_PerformanceTest_Multi_Host"
+    depends_on: "${BK_KEY}_record_DP_CorrectnessTest_Multi_Host"
     soft_fail: true
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       NEW_MODEL_DESIGN: "1"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}")
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_DP_PerformanceTest_Multi_Host" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for DP (multi-host)"
-    key: "${TPU_VERSION:-tpu6e}_record_DP_PerformanceTest_Multi_Host"
-    depends_on: "${TPU_VERSION:-tpu6e}_DP_PerformanceTest_Multi_Host"
+        buildkite-agent meta-data set "${BK_KEY}_DP_PerformanceTest_Multi_Host" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for DP (multi-host)"
+    key: "${BK_KEY}_record_DP_PerformanceTest_Multi_Host"
+    depends_on: "${BK_KEY}_DP_PerformanceTest_Multi_Host"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "DP"
       CI_STAGE: "Multi-Host PerformanceTest"
@@ -111,4 +119,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_DP_PerformanceTest_Multi_Host
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_DP_PerformanceTest_Multi_Host

--- a/.buildkite/parallelism/EP.yml
+++ b/.buildkite/parallelism/EP.yml
@@ -13,9 +13,11 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for EP (single-host)"
-    key: "${TPU_VERSION:-tpu6e}_EP_CorrectnessTest_Single_Host"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for EP (single-host)"
+    key: "${BK_KEY}_EP_CorrectnessTest_Single_Host"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v7x_8_queue}"
     commands:
@@ -25,10 +27,11 @@ steps:
       - |
         .buildkite/scripts/run_in_docker.sh \
           bash /workspace/tpu_inference/tests/e2e/check_lm_eval.sh  --model_name "Qwen/Qwen1.5-MoE-A2.7B" --use_moe_ep_kernel 0 --tensor_parallel_size 4 --max_model_len 1024 --max_num_batched_tokens 128 --max_gen_toks 128 --enable_expert_parallel 1 --flex_threshold 0.37 --strict_threshold 0.06
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for EP (single-host)"
-    key: "${TPU_VERSION:-tpu6e}_record_EP_CorrectnessTest_Single_Host"
-    depends_on: "${TPU_VERSION:-tpu6e}_EP_CorrectnessTest_Single_Host"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for EP (single-host)"
+    key: "${BK_KEY}_record_EP_CorrectnessTest_Single_Host"
+    depends_on: "${BK_KEY}_EP_CorrectnessTest_Single_Host"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "EP"
       CI_STAGE: "Single-Host CorrectnessTest"
@@ -37,22 +40,25 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_EP_CorrectnessTest_Single_Host
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_EP_CorrectnessTest_Single_Host
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for EP (single-host)"
-    key: "${TPU_VERSION:-tpu6e}_EP_PerformanceTest_Single_Host"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_EP_CorrectnessTest_Single_Host"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for EP (single-host)"
+    key: "${BK_KEY}_EP_PerformanceTest_Single_Host"
+    depends_on: "${BK_KEY}_record_EP_CorrectnessTest_Single_Host"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v7x_8_queue}"
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh \
           bash -c 'python3 -m pytest -s -v -x /workspace/tpu_inference/tests/e2e/test_expert_parallel.py'
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for EP (single-host)"
-    key: "${TPU_VERSION:-tpu6e}_record_EP_PerformanceTest_Single_Host"
-    depends_on: "${TPU_VERSION:-tpu6e}_EP_PerformanceTest_Single_Host"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for EP (single-host)"
+    key: "${BK_KEY}_record_EP_PerformanceTest_Single_Host"
+    depends_on: "${BK_KEY}_EP_PerformanceTest_Single_Host"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "EP"
       CI_STAGE: "Single-Host PerformanceTest"
@@ -61,20 +67,23 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_EP_PerformanceTest_Single_Host
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_EP_PerformanceTest_Single_Host
 
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for EP (multi-host)"
-    key: "${TPU_VERSION:-tpu6e}_EP_CorrectnessTest_Multi_Host"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for EP (multi-host)"
+    key: "${BK_KEY}_EP_CorrectnessTest_Multi_Host"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_MULTI:-tpu_v7x_8_queue}")
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_EP_CorrectnessTest_Multi_Host" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for EP (multi-host)"
-    key: "${TPU_VERSION:-tpu6e}_record_EP_CorrectnessTest_Multi_Host"
-    depends_on: "${TPU_VERSION:-tpu6e}_EP_CorrectnessTest_Multi_Host"
+        buildkite-agent meta-data set "${BK_KEY}_EP_CorrectnessTest_Multi_Host" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for EP (multi-host)"
+    key: "${BK_KEY}_record_EP_CorrectnessTest_Multi_Host"
+    depends_on: "${BK_KEY}_EP_CorrectnessTest_Multi_Host"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "EP"
       CI_STAGE: "Multi-Host CorrectnessTest"
@@ -83,20 +92,23 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_EP_CorrectnessTest_Multi_Host
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for EP (multi-host)"
-    key: "${TPU_VERSION:-tpu6e}_EP_PerformanceTest_Multi_Host"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_EP_CorrectnessTest_Multi_Host"
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_EP_CorrectnessTest_Multi_Host
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for EP (multi-host)"
+    key: "${BK_KEY}_EP_PerformanceTest_Multi_Host"
+    depends_on: "${BK_KEY}_record_EP_CorrectnessTest_Multi_Host"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_MULTI:-tpu_v7x_8_queue}")
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_EP_PerformanceTest_Multi_Host" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for EP (multi-host)"
-    key: "${TPU_VERSION:-tpu6e}_record_EP_PerformanceTest_Multi_Host"
-    depends_on: "${TPU_VERSION:-tpu6e}_EP_PerformanceTest_Multi_Host"
+        buildkite-agent meta-data set "${BK_KEY}_EP_PerformanceTest_Multi_Host" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for EP (multi-host)"
+    key: "${BK_KEY}_record_EP_PerformanceTest_Multi_Host"
+    depends_on: "${BK_KEY}_EP_PerformanceTest_Multi_Host"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "EP"
       CI_STAGE: "Multi-Host PerformanceTest"
@@ -105,4 +117,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_EP_PerformanceTest_Multi_Host
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_EP_PerformanceTest_Multi_Host

--- a/.buildkite/parallelism/EP.yml
+++ b/.buildkite/parallelism/EP.yml
@@ -13,9 +13,11 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for EP (single-host)"
-    key: "${TPU_VERSION:-tpu6e}_EP_CorrectnessTest_Single_Host"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for EP (single-host)"
+    key: "${BK_KEY}_EP_CorrectnessTest_Single_Host"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v7x_8_queue}"
     commands:
@@ -25,10 +27,11 @@ steps:
       - |
         .buildkite/scripts/run_in_docker.sh \
           bash /workspace/tpu_inference/tests/e2e/check_lm_eval.sh  --model_name "Qwen/Qwen1.5-MoE-A2.7B" --use_moe_ep_kernel 0 --tensor_parallel_size 4 --max_model_len 1024 --max_num_batched_tokens 128 --max_gen_toks 128 --enable_expert_parallel 1 --flex_threshold 0.37 --strict_threshold 0.06
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for EP (single-host)"
-    key: "${TPU_VERSION:-tpu6e}_record_EP_CorrectnessTest_Single_Host"
-    depends_on: "${TPU_VERSION:-tpu6e}_EP_CorrectnessTest_Single_Host"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for EP (single-host)"
+    key: "${BK_KEY}_record_EP_CorrectnessTest_Single_Host"
+    depends_on: "${BK_KEY}_EP_CorrectnessTest_Single_Host"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "EP"
       CI_STAGE: "Single-Host CorrectnessTest"
@@ -37,22 +40,25 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_EP_CorrectnessTest_Single_Host
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_EP_CorrectnessTest_Single_Host
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for EP (single-host)"
-    key: "${TPU_VERSION:-tpu6e}_EP_PerformanceTest_Single_Host"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_EP_CorrectnessTest_Single_Host"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for EP (single-host)"
+    key: "${BK_KEY}_EP_PerformanceTest_Single_Host"
+    depends_on: "${BK_KEY}_record_EP_CorrectnessTest_Single_Host"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v7x_8_queue}"
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh \
           bash -c 'python3 -m pytest -s -v -x /workspace/tpu_inference/tests/e2e/test_expert_parallel.py'
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for EP (single-host)"
-    key: "${TPU_VERSION:-tpu6e}_record_EP_PerformanceTest_Single_Host"
-    depends_on: "${TPU_VERSION:-tpu6e}_EP_PerformanceTest_Single_Host"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for EP (single-host)"
+    key: "${BK_KEY}_record_EP_PerformanceTest_Single_Host"
+    depends_on: "${BK_KEY}_EP_PerformanceTest_Single_Host"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "EP"
       CI_STAGE: "Single-Host PerformanceTest"
@@ -61,20 +67,23 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_EP_PerformanceTest_Single_Host
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_EP_PerformanceTest_Single_Host
 
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for EP (multi-host)"
-    key: "${TPU_VERSION:-tpu6e}_EP_CorrectnessTest_Multi_Host"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for EP (multi-host)"
+    key: "${BK_KEY}_EP_CorrectnessTest_Multi_Host"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v7x_8_queue}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_EP_CorrectnessTest_Multi_Host" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for EP (multi-host)"
-    key: "${TPU_VERSION:-tpu6e}_record_EP_CorrectnessTest_Multi_Host"
-    depends_on: "${TPU_VERSION:-tpu6e}_EP_CorrectnessTest_Multi_Host"
+        buildkite-agent meta-data set "${BK_KEY}_EP_CorrectnessTest_Multi_Host" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for EP (multi-host)"
+    key: "${BK_KEY}_record_EP_CorrectnessTest_Multi_Host"
+    depends_on: "${BK_KEY}_EP_CorrectnessTest_Multi_Host"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "EP"
       CI_STAGE: "Multi-Host CorrectnessTest"
@@ -83,20 +92,23 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_EP_CorrectnessTest_Multi_Host
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for EP (multi-host)"
-    key: "${TPU_VERSION:-tpu6e}_EP_PerformanceTest_Multi_Host"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_EP_CorrectnessTest_Multi_Host"
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_EP_CorrectnessTest_Multi_Host
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for EP (multi-host)"
+    key: "${BK_KEY}_EP_PerformanceTest_Multi_Host"
+    depends_on: "${BK_KEY}_record_EP_CorrectnessTest_Multi_Host"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v7x_8_queue}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_EP_PerformanceTest_Multi_Host" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for EP (multi-host)"
-    key: "${TPU_VERSION:-tpu6e}_record_EP_PerformanceTest_Multi_Host"
-    depends_on: "${TPU_VERSION:-tpu6e}_EP_PerformanceTest_Multi_Host"
+        buildkite-agent meta-data set "${BK_KEY}_EP_PerformanceTest_Multi_Host" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for EP (multi-host)"
+    key: "${BK_KEY}_record_EP_PerformanceTest_Multi_Host"
+    depends_on: "${BK_KEY}_EP_PerformanceTest_Multi_Host"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "EP"
       CI_STAGE: "Multi-Host PerformanceTest"
@@ -105,4 +117,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_EP_PerformanceTest_Multi_Host
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_EP_PerformanceTest_Multi_Host

--- a/.buildkite/parallelism/PP.yml
+++ b/.buildkite/parallelism/PP.yml
@@ -13,19 +13,22 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for PP (single-host)"
-    key: "${TPU_VERSION:-tpu6e}_PP_CorrectnessTest_Single_Host"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for PP (single-host)"
+    key: "${BK_KEY}_PP_CorrectnessTest_Single_Host"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh \
           python3 -m pytest -s -v -x /workspace/tpu_inference/tests/e2e/test_pipeline_parallel.py
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for PP (single-host)"
-    key: "${TPU_VERSION:-tpu6e}_record_PP_CorrectnessTest_Single_Host"
-    depends_on: "${TPU_VERSION:-tpu6e}_PP_CorrectnessTest_Single_Host"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for PP (single-host)"
+    key: "${BK_KEY}_record_PP_CorrectnessTest_Single_Host"
+    depends_on: "${BK_KEY}_PP_CorrectnessTest_Single_Host"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "PP"
       CI_STAGE: "Single-Host CorrectnessTest"
@@ -34,22 +37,25 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_PP_CorrectnessTest_Single_Host
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_PP_CorrectnessTest_Single_Host
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for PP (single-host)"
-    key: "${TPU_VERSION:-tpu6e}_PP_PerformanceTest_Single_Host"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_PP_CorrectnessTest_Single_Host"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for PP (single-host)"
+    key: "${BK_KEY}_PP_PerformanceTest_Single_Host"
+    depends_on: "${BK_KEY}_record_PP_CorrectnessTest_Single_Host"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh \
           python3 -m pytest -s -v -x /workspace/tpu_inference/tests/e2e/test_pipeline_parallel.py
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for PP (single-host)"
-    key: "${TPU_VERSION:-tpu6e}_record_PP_PerformanceTest_Single_Host"
-    depends_on: "${TPU_VERSION:-tpu6e}_PP_PerformanceTest_Single_Host"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for PP (single-host)"
+    key: "${BK_KEY}_record_PP_PerformanceTest_Single_Host"
+    depends_on: "${BK_KEY}_PP_PerformanceTest_Single_Host"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "PP"
       CI_STAGE: "Single-Host PerformanceTest"
@@ -58,21 +64,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_PP_PerformanceTest_Single_Host
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_PP_PerformanceTest_Single_Host
 
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for PP (multi-host)"
-    key: "${TPU_VERSION:-tpu6e}_PP_CorrectnessTest_Multi_Host"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for PP (multi-host)"
+    key: "${BK_KEY}_PP_CorrectnessTest_Multi_Host"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh \
           python3 -m pytest -s -v -x /workspace/tpu_inference/tests/e2e/test_pipeline_parallel.py
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for PP (multi-host)"
-    key: "${TPU_VERSION:-tpu6e}_record_PP_CorrectnessTest_Multi_Host"
-    depends_on: "${TPU_VERSION:-tpu6e}_PP_CorrectnessTest_Multi_Host"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for PP (multi-host)"
+    key: "${BK_KEY}_record_PP_CorrectnessTest_Multi_Host"
+    depends_on: "${BK_KEY}_PP_CorrectnessTest_Multi_Host"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "PP"
       CI_STAGE: "Multi-Host CorrectnessTest"
@@ -81,21 +90,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_PP_CorrectnessTest_Multi_Host
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for PP (multi-host)"
-    key: "${TPU_VERSION:-tpu6e}_PP_PerformanceTest_Multi_Host"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_PP_CorrectnessTest_Multi_Host"
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_PP_CorrectnessTest_Multi_Host
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for PP (multi-host)"
+    key: "${BK_KEY}_PP_PerformanceTest_Multi_Host"
+    depends_on: "${BK_KEY}_record_PP_CorrectnessTest_Multi_Host"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh \
           python3 -m pytest -s -v -x /workspace/tpu_inference/tests/e2e/test_pipeline_parallel.py
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for PP (multi-host)"
-    key: "${TPU_VERSION:-tpu6e}_record_PP_PerformanceTest_Multi_Host"
-    depends_on: "${TPU_VERSION:-tpu6e}_PP_PerformanceTest_Multi_Host"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for PP (multi-host)"
+    key: "${BK_KEY}_record_PP_PerformanceTest_Multi_Host"
+    depends_on: "${BK_KEY}_PP_PerformanceTest_Multi_Host"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "PP"
       CI_STAGE: "Multi-Host PerformanceTest"
@@ -104,4 +116,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_PP_PerformanceTest_Multi_Host
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_PP_PerformanceTest_Multi_Host

--- a/.buildkite/parallelism/SP.yml
+++ b/.buildkite/parallelism/SP.yml
@@ -13,19 +13,22 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for SP (single-host)"
-    key: "${TPU_VERSION:-tpu6e}_SP_CorrectnessTest_Single_Host"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for SP (single-host)"
+    key: "${BK_KEY}_SP_CorrectnessTest_Single_Host"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v7x_8_queue}"
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh \
           bash -c 'python3 -m pytest -s -v -x /workspace/tpu_inference/tests/e2e/test_sequence_parallelism.py::test_sp_correctness'
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for SP (single-host)"
-    key: "${TPU_VERSION:-tpu6e}_record_SP_CorrectnessTest_Single_Host"
-    depends_on: "${TPU_VERSION:-tpu6e}_SP_CorrectnessTest_Single_Host"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for SP (single-host)"
+    key: "${BK_KEY}_record_SP_CorrectnessTest_Single_Host"
+    depends_on: "${BK_KEY}_SP_CorrectnessTest_Single_Host"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "SP"
       CI_STAGE: "Single-Host CorrectnessTest"
@@ -34,21 +37,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_SP_CorrectnessTest_Single_Host
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_SP_CorrectnessTest_Single_Host
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for SP (single-host)"
-    key: "${TPU_VERSION:-tpu6e}_SP_PerformanceTest_Single_Host"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_SP_CorrectnessTest_Single_Host"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for SP (single-host)"
+    key: "${BK_KEY}_SP_PerformanceTest_Single_Host"
+    depends_on: "${BK_KEY}_record_SP_CorrectnessTest_Single_Host"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_SP_PerformanceTest_Single_Host" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for SP (single-host)"
-    key: "${TPU_VERSION:-tpu6e}_record_SP_PerformanceTest_Single_Host"
-    depends_on: "${TPU_VERSION:-tpu6e}_SP_PerformanceTest_Single_Host"
+        buildkite-agent meta-data set "${BK_KEY}_SP_PerformanceTest_Single_Host" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for SP (single-host)"
+    key: "${BK_KEY}_record_SP_PerformanceTest_Single_Host"
+    depends_on: "${BK_KEY}_SP_PerformanceTest_Single_Host"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "SP"
       CI_STAGE: "Single-Host PerformanceTest"
@@ -57,20 +63,23 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_SP_PerformanceTest_Single_Host
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_SP_PerformanceTest_Single_Host
 
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for SP (multi-host)"
-    key: "${TPU_VERSION:-tpu6e}_SP_CorrectnessTest_Multi_Host"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for SP (multi-host)"
+    key: "${BK_KEY}_SP_CorrectnessTest_Multi_Host"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_MULTI:-tpu_v7x_8_queue}")
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_SP_CorrectnessTest_Multi_Host" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for SP (multi-host)"
-    key: "${TPU_VERSION:-tpu6e}_record_SP_CorrectnessTest_Multi_Host"
-    depends_on: "${TPU_VERSION:-tpu6e}_SP_CorrectnessTest_Multi_Host"
+        buildkite-agent meta-data set "${BK_KEY}_SP_CorrectnessTest_Multi_Host" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for SP (multi-host)"
+    key: "${BK_KEY}_record_SP_CorrectnessTest_Multi_Host"
+    depends_on: "${BK_KEY}_SP_CorrectnessTest_Multi_Host"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "SP"
       CI_STAGE: "Multi-Host CorrectnessTest"
@@ -79,20 +88,23 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_SP_CorrectnessTest_Multi_Host
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for SP (multi-host)"
-    key: "${TPU_VERSION:-tpu6e}_SP_PerformanceTest_Multi_Host"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_SP_CorrectnessTest_Multi_Host"
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_SP_CorrectnessTest_Multi_Host
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for SP (multi-host)"
+    key: "${BK_KEY}_SP_PerformanceTest_Multi_Host"
+    depends_on: "${BK_KEY}_record_SP_CorrectnessTest_Multi_Host"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_SP_PerformanceTest_Multi_Host" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for SP (multi-host)"
-    key: "${TPU_VERSION:-tpu6e}_record_SP_PerformanceTest_Multi_Host"
-    depends_on: "${TPU_VERSION:-tpu6e}_SP_PerformanceTest_Multi_Host"
+        buildkite-agent meta-data set "${BK_KEY}_SP_PerformanceTest_Multi_Host" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for SP (multi-host)"
+    key: "${BK_KEY}_record_SP_PerformanceTest_Multi_Host"
+    depends_on: "${BK_KEY}_SP_PerformanceTest_Multi_Host"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "SP"
       CI_STAGE: "Multi-Host PerformanceTest"
@@ -101,4 +113,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_SP_PerformanceTest_Multi_Host
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_SP_PerformanceTest_Multi_Host

--- a/.buildkite/parallelism/SP.yml
+++ b/.buildkite/parallelism/SP.yml
@@ -13,19 +13,22 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for SP (single-host)"
-    key: "${TPU_VERSION:-tpu6e}_SP_CorrectnessTest_Single_Host"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for SP (single-host)"
+    key: "${BK_KEY}_SP_CorrectnessTest_Single_Host"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v7x_8_queue}"
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh \
           bash -c 'python3 -m pytest -s -v -x /workspace/tpu_inference/tests/e2e/test_sequence_parallelism.py::test_sp_correctness'
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for SP (single-host)"
-    key: "${TPU_VERSION:-tpu6e}_record_SP_CorrectnessTest_Single_Host"
-    depends_on: "${TPU_VERSION:-tpu6e}_SP_CorrectnessTest_Single_Host"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for SP (single-host)"
+    key: "${BK_KEY}_record_SP_CorrectnessTest_Single_Host"
+    depends_on: "${BK_KEY}_SP_CorrectnessTest_Single_Host"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "SP"
       CI_STAGE: "Single-Host CorrectnessTest"
@@ -34,21 +37,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_SP_CorrectnessTest_Single_Host
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_SP_CorrectnessTest_Single_Host
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for SP (single-host)"
-    key: "${TPU_VERSION:-tpu6e}_SP_PerformanceTest_Single_Host"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_SP_CorrectnessTest_Single_Host"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for SP (single-host)"
+    key: "${BK_KEY}_SP_PerformanceTest_Single_Host"
+    depends_on: "${BK_KEY}_record_SP_CorrectnessTest_Single_Host"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_SP_PerformanceTest_Single_Host" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for SP (single-host)"
-    key: "${TPU_VERSION:-tpu6e}_record_SP_PerformanceTest_Single_Host"
-    depends_on: "${TPU_VERSION:-tpu6e}_SP_PerformanceTest_Single_Host"
+        buildkite-agent meta-data set "${BK_KEY}_SP_PerformanceTest_Single_Host" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for SP (single-host)"
+    key: "${BK_KEY}_record_SP_PerformanceTest_Single_Host"
+    depends_on: "${BK_KEY}_SP_PerformanceTest_Single_Host"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "SP"
       CI_STAGE: "Single-Host PerformanceTest"
@@ -57,20 +63,23 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_SP_PerformanceTest_Single_Host
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_SP_PerformanceTest_Single_Host
 
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for SP (multi-host)"
-    key: "${TPU_VERSION:-tpu6e}_SP_CorrectnessTest_Multi_Host"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for SP (multi-host)"
+    key: "${BK_KEY}_SP_CorrectnessTest_Multi_Host"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v7x_8_queue}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_SP_CorrectnessTest_Multi_Host" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for SP (multi-host)"
-    key: "${TPU_VERSION:-tpu6e}_record_SP_CorrectnessTest_Multi_Host"
-    depends_on: "${TPU_VERSION:-tpu6e}_SP_CorrectnessTest_Multi_Host"
+        buildkite-agent meta-data set "${BK_KEY}_SP_CorrectnessTest_Multi_Host" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for SP (multi-host)"
+    key: "${BK_KEY}_record_SP_CorrectnessTest_Multi_Host"
+    depends_on: "${BK_KEY}_SP_CorrectnessTest_Multi_Host"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "SP"
       CI_STAGE: "Multi-Host CorrectnessTest"
@@ -79,20 +88,23 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_SP_CorrectnessTest_Multi_Host
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for SP (multi-host)"
-    key: "${TPU_VERSION:-tpu6e}_SP_PerformanceTest_Multi_Host"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_SP_CorrectnessTest_Multi_Host"
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_SP_CorrectnessTest_Multi_Host
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for SP (multi-host)"
+    key: "${BK_KEY}_SP_PerformanceTest_Multi_Host"
+    depends_on: "${BK_KEY}_record_SP_CorrectnessTest_Multi_Host"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_SP_PerformanceTest_Multi_Host" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for SP (multi-host)"
-    key: "${TPU_VERSION:-tpu6e}_record_SP_PerformanceTest_Multi_Host"
-    depends_on: "${TPU_VERSION:-tpu6e}_SP_PerformanceTest_Multi_Host"
+        buildkite-agent meta-data set "${BK_KEY}_SP_PerformanceTest_Multi_Host" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for SP (multi-host)"
+    key: "${BK_KEY}_record_SP_PerformanceTest_Multi_Host"
+    depends_on: "${BK_KEY}_SP_PerformanceTest_Multi_Host"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "SP"
       CI_STAGE: "Multi-Host PerformanceTest"
@@ -101,4 +113,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_SP_PerformanceTest_Multi_Host
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_SP_PerformanceTest_Multi_Host

--- a/.buildkite/parallelism/TP.yml
+++ b/.buildkite/parallelism/TP.yml
@@ -13,19 +13,22 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for TP (single-host)"
-    key: "${TPU_VERSION:-tpu6e}_TP_CorrectnessTest_Single_Host"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for TP (single-host)"
+    key: "${BK_KEY}_TP_CorrectnessTest_Single_Host"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh \
           bash /workspace/tpu_inference/tests/e2e/check_lm_eval.sh --model_name "meta-llama/Llama-3.1-8B-Instruct" --use_moe_ep_kernel 0 --tensor_parallel_size 4 --max_model_len 1024 --max_num_batched_tokens 128 --max_gen_toks 128 --enable_expert_parallel 0 --flex_threshold 0.3 --strict_threshold 0.2
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for TP (single-host)"
-    key: "${TPU_VERSION:-tpu6e}_record_TP_CorrectnessTest_Single_Host"
-    depends_on: "${TPU_VERSION:-tpu6e}_TP_CorrectnessTest_Single_Host"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for TP (single-host)"
+    key: "${BK_KEY}_record_TP_CorrectnessTest_Single_Host"
+    depends_on: "${BK_KEY}_TP_CorrectnessTest_Single_Host"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "TP"
       CI_STAGE: "Single-Host CorrectnessTest"
@@ -34,22 +37,25 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_TP_CorrectnessTest_Single_Host
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_TP_CorrectnessTest_Single_Host
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for TP (single-host)"
-    key: "${TPU_VERSION:-tpu6e}_TP_PerformanceTest_Single_Host"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_TP_CorrectnessTest_Single_Host"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for TP (single-host)"
+    key: "${BK_KEY}_TP_PerformanceTest_Single_Host"
+    depends_on: "${BK_KEY}_record_TP_CorrectnessTest_Single_Host"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh \
           bash -c 'python3 -m pytest -s -v -x /workspace/tpu_inference/tests/e2e/test_tensor_parallel.py'
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for TP (single-host)"
-    key: "${TPU_VERSION:-tpu6e}_record_TP_PerformanceTest_Single_Host"
-    depends_on: "${TPU_VERSION:-tpu6e}_TP_PerformanceTest_Single_Host"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for TP (single-host)"
+    key: "${BK_KEY}_record_TP_PerformanceTest_Single_Host"
+    depends_on: "${BK_KEY}_TP_PerformanceTest_Single_Host"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "TP"
       CI_STAGE: "Single-Host PerformanceTest"
@@ -58,20 +64,23 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_TP_PerformanceTest_Single_Host
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_TP_PerformanceTest_Single_Host
 
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for TP (multi-host)"
-    key: "${TPU_VERSION:-tpu6e}_TP_CorrectnessTest_Multi_Host"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for TP (multi-host)"
+    key: "${BK_KEY}_TP_CorrectnessTest_Multi_Host"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}")
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_TP_CorrectnessTest_Multi_Host" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for TP (multi-host)"
-    key: "${TPU_VERSION:-tpu6e}_record_TP_CorrectnessTest_Multi_Host"
-    depends_on: "${TPU_VERSION:-tpu6e}_TP_CorrectnessTest_Multi_Host"
+        buildkite-agent meta-data set "${BK_KEY}_TP_CorrectnessTest_Multi_Host" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for TP (multi-host)"
+    key: "${BK_KEY}_record_TP_CorrectnessTest_Multi_Host"
+    depends_on: "${BK_KEY}_TP_CorrectnessTest_Multi_Host"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "TP"
       CI_STAGE: "Multi-Host CorrectnessTest"
@@ -80,21 +89,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_TP_CorrectnessTest_Multi_Host
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_TP_CorrectnessTest_Multi_Host
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for TP (multi-host)"
-    key: "${TPU_VERSION:-tpu6e}_TP_PerformanceTest_Multi_Host"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_TP_CorrectnessTest_Multi_Host"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for TP (multi-host)"
+    key: "${BK_KEY}_TP_PerformanceTest_Multi_Host"
+    depends_on: "${BK_KEY}_record_TP_CorrectnessTest_Multi_Host"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}")
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_TP_PerformanceTest_Multi_Host" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for TP (multi-host)"
-    key: "${TPU_VERSION:-tpu6e}_record_TP_PerformanceTest_Multi_Host"
-    depends_on: "${TPU_VERSION:-tpu6e}_TP_PerformanceTest_Multi_Host"
+        buildkite-agent meta-data set "${BK_KEY}_TP_PerformanceTest_Multi_Host" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for TP (multi-host)"
+    key: "${BK_KEY}_record_TP_PerformanceTest_Multi_Host"
+    depends_on: "${BK_KEY}_TP_PerformanceTest_Multi_Host"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "TP"
       CI_STAGE: "Multi-Host PerformanceTest"
@@ -103,4 +115,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_TP_PerformanceTest_Multi_Host
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_TP_PerformanceTest_Multi_Host

--- a/.buildkite/parallelism/TP.yml
+++ b/.buildkite/parallelism/TP.yml
@@ -13,19 +13,22 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for TP (single-host)"
-    key: "${TPU_VERSION:-tpu6e}_TP_CorrectnessTest_Single_Host"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for TP (single-host)"
+    key: "${BK_KEY}_TP_CorrectnessTest_Single_Host"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh \
           bash /workspace/tpu_inference/tests/e2e/check_lm_eval.sh --model_name "meta-llama/Llama-3.1-8B-Instruct" --use_moe_ep_kernel 0 --tensor_parallel_size 4 --max_model_len 1024 --max_num_batched_tokens 128 --max_gen_toks 128 --enable_expert_parallel 0 --flex_threshold 0.3 --strict_threshold 0.2
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for TP (single-host)"
-    key: "${TPU_VERSION:-tpu6e}_record_TP_CorrectnessTest_Single_Host"
-    depends_on: "${TPU_VERSION:-tpu6e}_TP_CorrectnessTest_Single_Host"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for TP (single-host)"
+    key: "${BK_KEY}_record_TP_CorrectnessTest_Single_Host"
+    depends_on: "${BK_KEY}_TP_CorrectnessTest_Single_Host"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "TP"
       CI_STAGE: "Single-Host CorrectnessTest"
@@ -34,22 +37,25 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_TP_CorrectnessTest_Single_Host
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_TP_CorrectnessTest_Single_Host
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for TP (single-host)"
-    key: "${TPU_VERSION:-tpu6e}_TP_PerformanceTest_Single_Host"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_TP_CorrectnessTest_Single_Host"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for TP (single-host)"
+    key: "${BK_KEY}_TP_PerformanceTest_Single_Host"
+    depends_on: "${BK_KEY}_record_TP_CorrectnessTest_Single_Host"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh \
           bash -c 'python3 -m pytest -s -v -x /workspace/tpu_inference/tests/e2e/test_tensor_parallel.py'
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for TP (single-host)"
-    key: "${TPU_VERSION:-tpu6e}_record_TP_PerformanceTest_Single_Host"
-    depends_on: "${TPU_VERSION:-tpu6e}_TP_PerformanceTest_Single_Host"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for TP (single-host)"
+    key: "${BK_KEY}_record_TP_PerformanceTest_Single_Host"
+    depends_on: "${BK_KEY}_TP_PerformanceTest_Single_Host"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "TP"
       CI_STAGE: "Single-Host PerformanceTest"
@@ -58,20 +64,23 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_TP_PerformanceTest_Single_Host
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_TP_PerformanceTest_Single_Host
 
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for TP (multi-host)"
-    key: "${TPU_VERSION:-tpu6e}_TP_CorrectnessTest_Multi_Host"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for TP (multi-host)"
+    key: "${BK_KEY}_TP_CorrectnessTest_Multi_Host"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_TP_CorrectnessTest_Multi_Host" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for TP (multi-host)"
-    key: "${TPU_VERSION:-tpu6e}_record_TP_CorrectnessTest_Multi_Host"
-    depends_on: "${TPU_VERSION:-tpu6e}_TP_CorrectnessTest_Multi_Host"
+        buildkite-agent meta-data set "${BK_KEY}_TP_CorrectnessTest_Multi_Host" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for TP (multi-host)"
+    key: "${BK_KEY}_record_TP_CorrectnessTest_Multi_Host"
+    depends_on: "${BK_KEY}_TP_CorrectnessTest_Multi_Host"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "TP"
       CI_STAGE: "Multi-Host CorrectnessTest"
@@ -80,21 +89,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_TP_CorrectnessTest_Multi_Host
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_TP_CorrectnessTest_Multi_Host
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for TP (multi-host)"
-    key: "${TPU_VERSION:-tpu6e}_TP_PerformanceTest_Multi_Host"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_TP_CorrectnessTest_Multi_Host"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for TP (multi-host)"
+    key: "${BK_KEY}_TP_PerformanceTest_Multi_Host"
+    depends_on: "${BK_KEY}_record_TP_CorrectnessTest_Multi_Host"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_TP_PerformanceTest_Multi_Host" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for TP (multi-host)"
-    key: "${TPU_VERSION:-tpu6e}_record_TP_PerformanceTest_Multi_Host"
-    depends_on: "${TPU_VERSION:-tpu6e}_TP_PerformanceTest_Multi_Host"
+        buildkite-agent meta-data set "${BK_KEY}_TP_PerformanceTest_Multi_Host" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for TP (multi-host)"
+    key: "${BK_KEY}_record_TP_PerformanceTest_Multi_Host"
+    depends_on: "${BK_KEY}_TP_PerformanceTest_Multi_Host"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "TP"
       CI_STAGE: "Multi-Host PerformanceTest"
@@ -103,4 +115,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_TP_PerformanceTest_Multi_Host
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_TP_PerformanceTest_Multi_Host

--- a/.buildkite/pipeline_generation/add_feature_to_ci.py
+++ b/.buildkite/pipeline_generation/add_feature_to_ci.py
@@ -183,7 +183,7 @@ def get_interactive_input():
             f"\n{BOLD}[Step 3/4]{RESET} {DIM}Group Name: (Not required for this category){RESET}"
         )
 
-    # --- STEP 4: Host Scale (Now matches model script style) ---
+    # --- STEP 4: Host Scale ---
     print(
         f"\n{BOLD}[Step 4/4]{RESET} {CYAN}Specify the host scale for running tests:{RESET}"
     )

--- a/.buildkite/pipeline_generation/feature_template.yml
+++ b/.buildkite/pipeline_generation/feature_template.yml
@@ -13,17 +13,20 @@
 # limitations under the License.
 
 steps:
-  - label: "${{TPU_VERSION:-tpu6e}} Correctness tests for {FEATURE_NAME}"
-    key: "${{TPU_VERSION:-tpu6e}}_{SANITIZED_FEATURE_NAME}_CorrectnessTest"
+  - label: "${{TPU_VERSION:-tpu6e}} ${{MODEL_IMPL_TYPE:-vllm}} Correctness tests for {FEATURE_NAME}"
+    key: "${{BK_KEY}}_{SANITIZED_FEATURE_NAME}_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${{MODEL_IMPL_TYPE:-vllm}}"
     agents:
       queue: "{QUEUE}"
     commands:
       - echo "placeholder"  # TODO : replace with your correctness test command
-  - label: "${{TPU_VERSION:-tpu6e}} Record correctness test result for {FEATURE_NAME}"
-    key: "${{TPU_VERSION:-tpu6e}}_record_{SANITIZED_FEATURE_NAME}_CorrectnessTest"
-    depends_on: "${{TPU_VERSION:-tpu6e}}_{SANITIZED_FEATURE_NAME}_CorrectnessTest"
+  - label: "${{TPU_VERSION:-tpu6e}} ${{MODEL_IMPL_TYPE:-vllm}} Record correctness test result for {FEATURE_NAME}"
+    key: "${{BK_KEY}}_record_{SANITIZED_FEATURE_NAME}_CorrectnessTest"
+    depends_on: "${{BK_KEY}}_{SANITIZED_FEATURE_NAME}_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${{MODEL_IMPL_TYPE:-vllm}}"
       CI_TPU_VERSION: "${{TPU_VERSION:-tpu6e}}"
       CI_TARGET: "{FEATURE_NAME}"
       CI_STAGE: "CorrectnessTest"
@@ -32,20 +35,23 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${{TPU_VERSION:-tpu6e}}_{SANITIZED_FEATURE_NAME}_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${{BK_KEY}}_{SANITIZED_FEATURE_NAME}_CorrectnessTest
 
-  - label: "${{TPU_VERSION:-tpu6e}} Performance tests for {FEATURE_NAME}"
-    key: "${{TPU_VERSION:-tpu6e}}_{SANITIZED_FEATURE_NAME}_PerformanceTest"
-    depends_on: "${{TPU_VERSION:-tpu6e}}_record_{SANITIZED_FEATURE_NAME}_CorrectnessTest"
+  - label: "${{TPU_VERSION:-tpu6e}} ${{MODEL_IMPL_TYPE:-vllm}} Performance tests for {FEATURE_NAME}"
+    key: "${{BK_KEY}}_{SANITIZED_FEATURE_NAME}_PerformanceTest"
+    depends_on: "${{BK_KEY}}_record_{SANITIZED_FEATURE_NAME}_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${{MODEL_IMPL_TYPE:-vllm}}"
     agents:
       queue: "{QUEUE}"
     commands:
       - echo "placeholder"  # TODO : replace with your performance test command
-  - label: "${{TPU_VERSION:-tpu6e}} Record performance test result for {FEATURE_NAME}"
-    key: "${{TPU_VERSION:-tpu6e}}_record_{SANITIZED_FEATURE_NAME}_PerformanceTest"
-    depends_on: "${{TPU_VERSION:-tpu6e}}_{SANITIZED_FEATURE_NAME}_PerformanceTest"
+  - label: "${{TPU_VERSION:-tpu6e}} ${{MODEL_IMPL_TYPE:-vllm}} Record performance test result for {FEATURE_NAME}"
+    key: "${{BK_KEY}}_record_{SANITIZED_FEATURE_NAME}_PerformanceTest"
+    depends_on: "${{BK_KEY}}_{SANITIZED_FEATURE_NAME}_PerformanceTest"
     env:
+      MODEL_IMPL_TYPE: "${{MODEL_IMPL_TYPE:-vllm}}"
       CI_TPU_VERSION: "${{TPU_VERSION:-tpu6e}}"
       CI_TARGET: "{FEATURE_NAME}"
       CI_STAGE: "PerformanceTest"
@@ -54,4 +60,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${{TPU_VERSION:-tpu6e}}_{SANITIZED_FEATURE_NAME}_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${{BK_KEY}}_{SANITIZED_FEATURE_NAME}_PerformanceTest

--- a/.buildkite/pipeline_generation/feature_template.yml
+++ b/.buildkite/pipeline_generation/feature_template.yml
@@ -13,17 +13,20 @@
 # limitations under the License.
 
 steps:
-  - label: "${{TPU_VERSION:-tpu6e}} Correctness tests for {FEATURE_NAME}"
-    key: "${{TPU_VERSION:-tpu6e}}_{SANITIZED_FEATURE_NAME}_CorrectnessTest"
+  - label: "${{TPU_VERSION:-tpu6e}} ${{MODEL_IMPL_TYPE:-vllm}} Correctness tests for {FEATURE_NAME}"
+    key: "${{BK_KEY}}_{SANITIZED_FEATURE_NAME}_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${{MODEL_IMPL_TYPE:-vllm}}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "{QUEUE}")
     commands:
       - echo "placeholder"  # TODO : replace with your correctness test command
-  - label: "${{TPU_VERSION:-tpu6e}} Record correctness test result for {FEATURE_NAME}"
-    key: "${{TPU_VERSION:-tpu6e}}_record_{SANITIZED_FEATURE_NAME}_CorrectnessTest"
-    depends_on: "${{TPU_VERSION:-tpu6e}}_{SANITIZED_FEATURE_NAME}_CorrectnessTest"
+  - label: "${{TPU_VERSION:-tpu6e}} ${{MODEL_IMPL_TYPE:-vllm}} Record correctness test result for {FEATURE_NAME}"
+    key: "${{BK_KEY}}_record_{SANITIZED_FEATURE_NAME}_CorrectnessTest"
+    depends_on: "${{BK_KEY}}_{SANITIZED_FEATURE_NAME}_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${{MODEL_IMPL_TYPE:-vllm}}"
       CI_TPU_VERSION: "${{TPU_VERSION:-tpu6e}}"
       CI_TARGET: "{FEATURE_NAME}"
       CI_STAGE: "CorrectnessTest"
@@ -32,20 +35,23 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${{TPU_VERSION:-tpu6e}}_{SANITIZED_FEATURE_NAME}_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${{BK_KEY}}_{SANITIZED_FEATURE_NAME}_CorrectnessTest
 
-  - label: "${{TPU_VERSION:-tpu6e}} Performance tests for {FEATURE_NAME}"
-    key: "${{TPU_VERSION:-tpu6e}}_{SANITIZED_FEATURE_NAME}_PerformanceTest"
-    depends_on: "${{TPU_VERSION:-tpu6e}}_record_{SANITIZED_FEATURE_NAME}_CorrectnessTest"
+  - label: "${{TPU_VERSION:-tpu6e}} ${{MODEL_IMPL_TYPE:-vllm}} Performance tests for {FEATURE_NAME}"
+    key: "${{BK_KEY}}_{SANITIZED_FEATURE_NAME}_PerformanceTest"
+    depends_on: "${{BK_KEY}}_record_{SANITIZED_FEATURE_NAME}_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${{MODEL_IMPL_TYPE:-vllm}}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "{QUEUE}")
     commands:
       - echo "placeholder"  # TODO : replace with your performance test command
-  - label: "${{TPU_VERSION:-tpu6e}} Record performance test result for {FEATURE_NAME}"
-    key: "${{TPU_VERSION:-tpu6e}}_record_{SANITIZED_FEATURE_NAME}_PerformanceTest"
-    depends_on: "${{TPU_VERSION:-tpu6e}}_{SANITIZED_FEATURE_NAME}_PerformanceTest"
+  - label: "${{TPU_VERSION:-tpu6e}} ${{MODEL_IMPL_TYPE:-vllm}} Record performance test result for {FEATURE_NAME}"
+    key: "${{BK_KEY}}_record_{SANITIZED_FEATURE_NAME}_PerformanceTest"
+    depends_on: "${{BK_KEY}}_{SANITIZED_FEATURE_NAME}_PerformanceTest"
     env:
+      MODEL_IMPL_TYPE: "${{MODEL_IMPL_TYPE:-vllm}}"
       CI_TPU_VERSION: "${{TPU_VERSION:-tpu6e}}"
       CI_TARGET: "{FEATURE_NAME}"
       CI_STAGE: "PerformanceTest"
@@ -54,4 +60,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${{TPU_VERSION:-tpu6e}}_{SANITIZED_FEATURE_NAME}_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${{BK_KEY}}_{SANITIZED_FEATURE_NAME}_PerformanceTest

--- a/.buildkite/pipeline_generation/parallelism_template.yml
+++ b/.buildkite/pipeline_generation/parallelism_template.yml
@@ -14,18 +14,21 @@
 
 steps:
   # --- Single-Host Tests ---
-  - label: "${{TPU_VERSION:-tpu6e}} Correctness tests for {FEATURE_NAME} (single-host)"
-    key: "${{TPU_VERSION:-tpu6e}}_{SANITIZED_FEATURE_NAME}_CorrectnessTest_Single_Host"
+  - label: "${{TPU_VERSION:-tpu6e}} ${{MODEL_IMPL_TYPE:-vllm}} Correctness tests for {FEATURE_NAME} (single-host)"
+    key: "${{BK_KEY}}_{SANITIZED_FEATURE_NAME}_CorrectnessTest_Single_Host"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${{MODEL_IMPL_TYPE:-vllm}}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "{QUEUE}")
     commands:
       - echo "placeholder" # TODO : replace with your single-host correctness test command
 
-  - label: "${{TPU_VERSION:-tpu6e}} Record correctness test result for {FEATURE_NAME} (single-host)"
-    key: "${{TPU_VERSION:-tpu6e}}_record_{SANITIZED_FEATURE_NAME}_CorrectnessTest_Single_Host"
-    depends_on: "${{TPU_VERSION:-tpu6e}}_{SANITIZED_FEATURE_NAME}_CorrectnessTest_Single_Host"
+  - label: "${{TPU_VERSION:-tpu6e}} ${{MODEL_IMPL_TYPE:-vllm}} Record correctness test result for {FEATURE_NAME} (single-host)"
+    key: "${{BK_KEY}}_record_{SANITIZED_FEATURE_NAME}_CorrectnessTest_Single_Host"
+    depends_on: "${{BK_KEY}}_{SANITIZED_FEATURE_NAME}_CorrectnessTest_Single_Host"
     env:
+      MODEL_IMPL_TYPE: "${{MODEL_IMPL_TYPE:-vllm}}"
       CI_TPU_VERSION: "${{TPU_VERSION:-tpu6e}}"
       CI_TARGET: "{FEATURE_NAME}"
       CI_STAGE: "Single-Host CorrectnessTest"
@@ -34,21 +37,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${{TPU_VERSION:-tpu6e}}_{SANITIZED_FEATURE_NAME}_CorrectnessTest_Single_Host
+        .buildkite/scripts/record_step_result.sh ${{BK_KEY}}_{SANITIZED_FEATURE_NAME}_CorrectnessTest_Single_Host
 
-  - label: "${{TPU_VERSION:-tpu6e}} Performance tests for {FEATURE_NAME} (single-host)"
-    key: "${{TPU_VERSION:-tpu6e}}_{SANITIZED_FEATURE_NAME}_PerformanceTest_Single_Host"
-    depends_on: "${{TPU_VERSION:-tpu6e}}_record_{SANITIZED_FEATURE_NAME}_CorrectnessTest_Single_Host"
+  - label: "${{TPU_VERSION:-tpu6e}} ${{MODEL_IMPL_TYPE:-vllm}} Performance tests for {FEATURE_NAME} (single-host)"
+    key: "${{BK_KEY}}_{SANITIZED_FEATURE_NAME}_PerformanceTest_Single_Host"
+    depends_on: "${{BK_KEY}}_record_{SANITIZED_FEATURE_NAME}_CorrectnessTest_Single_Host"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${{MODEL_IMPL_TYPE:-vllm}}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "{QUEUE}")
     commands:
       - echo "placeholder" # TODO : replace with your single-host performance test command
 
-  - label: "${{TPU_VERSION:-tpu6e}} Record performance test result for {FEATURE_NAME} (single-host)"
-    key: "${{TPU_VERSION:-tpu6e}}_record_{SANITIZED_FEATURE_NAME}_PerformanceTest_Single_Host"
-    depends_on: "${{TPU_VERSION:-tpu6e}}_{SANITIZED_FEATURE_NAME}_PerformanceTest_Single_Host"
+  - label: "${{TPU_VERSION:-tpu6e}} ${{MODEL_IMPL_TYPE:-vllm}} Record performance test result for {FEATURE_NAME} (single-host)"
+    key: "${{BK_KEY}}_record_{SANITIZED_FEATURE_NAME}_PerformanceTest_Single_Host"
+    depends_on: "${{BK_KEY}}_{SANITIZED_FEATURE_NAME}_PerformanceTest_Single_Host"
     env:
+      MODEL_IMPL_TYPE: "${{MODEL_IMPL_TYPE:-vllm}}"
       CI_TPU_VERSION: "${{TPU_VERSION:-tpu6e}}"
       CI_TARGET: "{FEATURE_NAME}"
       CI_STAGE: "Single-Host PerformanceTest"
@@ -57,21 +63,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${{TPU_VERSION:-tpu6e}}_{SANITIZED_FEATURE_NAME}_PerformanceTest_Single_Host
+        .buildkite/scripts/record_step_result.sh ${{BK_KEY}}_{SANITIZED_FEATURE_NAME}_PerformanceTest_Single_Host
 
   # --- Multi-Host Tests ---
-  - label: "${{TPU_VERSION:-tpu6e}} Correctness tests for {FEATURE_NAME} (multi-host)"
-    key: "${{TPU_VERSION:-tpu6e}}_{SANITIZED_FEATURE_NAME}_CorrectnessTest_Multi_Host"
+  - label: "${{TPU_VERSION:-tpu6e}} ${{MODEL_IMPL_TYPE:-vllm}} Correctness tests for {FEATURE_NAME} (multi-host)"
+    key: "${{BK_KEY}}_{SANITIZED_FEATURE_NAME}_CorrectnessTest_Multi_Host"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${{MODEL_IMPL_TYPE:-vllm}}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "{QUEUE}")
     commands:
       - echo "placeholder" # TODO : replace with your multi-host correctness test command
 
-  - label: "${{TPU_VERSION:-tpu6e}} Record correctness test result for {FEATURE_NAME} (multi-host)"
-    key: "${{TPU_VERSION:-tpu6e}}_record_{SANITIZED_FEATURE_NAME}_CorrectnessTest_Multi_Host"
-    depends_on: "${{TPU_VERSION:-tpu6e}}_{SANITIZED_FEATURE_NAME}_CorrectnessTest_Multi_Host"
+  - label: "${{TPU_VERSION:-tpu6e}} ${{MODEL_IMPL_TYPE:-vllm}} Record correctness test result for {FEATURE_NAME} (multi-host)"
+    key: "${{BK_KEY}}_record_{SANITIZED_FEATURE_NAME}_CorrectnessTest_Multi_Host"
+    depends_on: "${{BK_KEY}}_{SANITIZED_FEATURE_NAME}_CorrectnessTest_Multi_Host"
     env:
+      MODEL_IMPL_TYPE: "${{MODEL_IMPL_TYPE:-vllm}}"
       CI_TPU_VERSION: "${{TPU_VERSION:-tpu6e}}"
       CI_TARGET: "{FEATURE_NAME}"
       CI_STAGE: "Multi-Host CorrectnessTest"
@@ -80,21 +89,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${{TPU_VERSION:-tpu6e}}_{SANITIZED_FEATURE_NAME}_CorrectnessTest_Multi_Host
+        .buildkite/scripts/record_step_result.sh ${{BK_KEY}}_{SANITIZED_FEATURE_NAME}_CorrectnessTest_Multi_Host
 
-  - label: "${{TPU_VERSION:-tpu6e}} Performance tests for {FEATURE_NAME} (multi-host)"
-    key: "${{TPU_VERSION:-tpu6e}}_{SANITIZED_FEATURE_NAME}_PerformanceTest_Multi_Host"
-    depends_on: "${{TPU_VERSION:-tpu6e}}_record_{SANITIZED_FEATURE_NAME}_CorrectnessTest_Multi_Host"
+  - label: "${{TPU_VERSION:-tpu6e}} ${{MODEL_IMPL_TYPE:-vllm}} Performance tests for {FEATURE_NAME} (multi-host)"
+    key: "${{BK_KEY}}_{SANITIZED_FEATURE_NAME}_PerformanceTest_Multi_Host"
+    depends_on: "${{BK_KEY}}_record_{SANITIZED_FEATURE_NAME}_CorrectnessTest_Multi_Host"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${{MODEL_IMPL_TYPE:-vllm}}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "{QUEUE}")
     commands:
       - echo "placeholder" # TODO : replace with your multi-host performance test command
 
-  - label: "${{TPU_VERSION:-tpu6e}} Record performance test result for {FEATURE_NAME} (multi-host)"
-    key: "${{TPU_VERSION:-tpu6e}}_record_{SANITIZED_FEATURE_NAME}_PerformanceTest_Multi_Host"
-    depends_on: "${{TPU_VERSION:-tpu6e}}_{SANITIZED_FEATURE_NAME}_PerformanceTest_Multi_Host"
+  - label: "${{TPU_VERSION:-tpu6e}} ${{MODEL_IMPL_TYPE:-vllm}} Record performance test result for {FEATURE_NAME} (multi-host)"
+    key: "${{BK_KEY}}_record_{SANITIZED_FEATURE_NAME}_PerformanceTest_Multi_Host"
+    depends_on: "${{BK_KEY}}_{SANITIZED_FEATURE_NAME}_PerformanceTest_Multi_Host"
     env:
+      MODEL_IMPL_TYPE: "${{MODEL_IMPL_TYPE:-vllm}}"
       CI_TPU_VERSION: "${{TPU_VERSION:-tpu6e}}"
       CI_TARGET: "{FEATURE_NAME}"
       CI_STAGE: "Multi-Host PerformanceTest"
@@ -103,4 +115,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${{TPU_VERSION:-tpu6e}}_{SANITIZED_FEATURE_NAME}_PerformanceTest_Multi_Host
+        .buildkite/scripts/record_step_result.sh ${{BK_KEY}}_{SANITIZED_FEATURE_NAME}_PerformanceTest_Multi_Host

--- a/.buildkite/pipeline_generation/parallelism_template.yml
+++ b/.buildkite/pipeline_generation/parallelism_template.yml
@@ -14,18 +14,21 @@
 
 steps:
   # --- Single-Host Tests ---
-  - label: "${{TPU_VERSION:-tpu6e}} Correctness tests for {FEATURE_NAME} (single-host)"
-    key: "${{TPU_VERSION:-tpu6e}}_{SANITIZED_FEATURE_NAME}_CorrectnessTest_Single_Host"
+  - label: "${{TPU_VERSION:-tpu6e}} ${{MODEL_IMPL_TYPE:-vllm}} Correctness tests for {FEATURE_NAME} (single-host)"
+    key: "${{BK_KEY}}_{SANITIZED_FEATURE_NAME}_CorrectnessTest_Single_Host"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${{MODEL_IMPL_TYPE:-vllm}}"
     agents:
       queue: "{QUEUE}"
     commands:
       - echo "placeholder" # TODO : replace with your single-host correctness test command
 
-  - label: "${{TPU_VERSION:-tpu6e}} Record correctness test result for {FEATURE_NAME} (single-host)"
-    key: "${{TPU_VERSION:-tpu6e}}_record_{SANITIZED_FEATURE_NAME}_CorrectnessTest_Single_Host"
-    depends_on: "${{TPU_VERSION:-tpu6e}}_{SANITIZED_FEATURE_NAME}_CorrectnessTest_Single_Host"
+  - label: "${{TPU_VERSION:-tpu6e}} ${{MODEL_IMPL_TYPE:-vllm}} Record correctness test result for {FEATURE_NAME} (single-host)"
+    key: "${{BK_KEY}}_record_{SANITIZED_FEATURE_NAME}_CorrectnessTest_Single_Host"
+    depends_on: "${{BK_KEY}}_{SANITIZED_FEATURE_NAME}_CorrectnessTest_Single_Host"
     env:
+      MODEL_IMPL_TYPE: "${{MODEL_IMPL_TYPE:-vllm}}"
       CI_TPU_VERSION: "${{TPU_VERSION:-tpu6e}}"
       CI_TARGET: "{FEATURE_NAME}"
       CI_STAGE: "Single-Host CorrectnessTest"
@@ -34,21 +37,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${{TPU_VERSION:-tpu6e}}_{SANITIZED_FEATURE_NAME}_CorrectnessTest_Single_Host
+        .buildkite/scripts/record_step_result.sh ${{BK_KEY}}_{SANITIZED_FEATURE_NAME}_CorrectnessTest_Single_Host
 
-  - label: "${{TPU_VERSION:-tpu6e}} Performance tests for {FEATURE_NAME} (single-host)"
-    key: "${{TPU_VERSION:-tpu6e}}_{SANITIZED_FEATURE_NAME}_PerformanceTest_Single_Host"
-    depends_on: "${{TPU_VERSION:-tpu6e}}_record_{SANITIZED_FEATURE_NAME}_CorrectnessTest_Single_Host"
+  - label: "${{TPU_VERSION:-tpu6e}} ${{MODEL_IMPL_TYPE:-vllm}} Performance tests for {FEATURE_NAME} (single-host)"
+    key: "${{BK_KEY}}_{SANITIZED_FEATURE_NAME}_PerformanceTest_Single_Host"
+    depends_on: "${{BK_KEY}}_record_{SANITIZED_FEATURE_NAME}_CorrectnessTest_Single_Host"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${{MODEL_IMPL_TYPE:-vllm}}"
     agents:
       queue: "{QUEUE}"
     commands:
       - echo "placeholder" # TODO : replace with your single-host performance test command
 
-  - label: "${{TPU_VERSION:-tpu6e}} Record performance test result for {FEATURE_NAME} (single-host)"
-    key: "${{TPU_VERSION:-tpu6e}}_record_{SANITIZED_FEATURE_NAME}_PerformanceTest_Single_Host"
-    depends_on: "${{TPU_VERSION:-tpu6e}}_{SANITIZED_FEATURE_NAME}_PerformanceTest_Single_Host"
+  - label: "${{TPU_VERSION:-tpu6e}} ${{MODEL_IMPL_TYPE:-vllm}} Record performance test result for {FEATURE_NAME} (single-host)"
+    key: "${{BK_KEY}}_record_{SANITIZED_FEATURE_NAME}_PerformanceTest_Single_Host"
+    depends_on: "${{BK_KEY}}_{SANITIZED_FEATURE_NAME}_PerformanceTest_Single_Host"
     env:
+      MODEL_IMPL_TYPE: "${{MODEL_IMPL_TYPE:-vllm}}"
       CI_TPU_VERSION: "${{TPU_VERSION:-tpu6e}}"
       CI_TARGET: "{FEATURE_NAME}"
       CI_STAGE: "Single-Host PerformanceTest"
@@ -57,21 +63,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${{TPU_VERSION:-tpu6e}}_{SANITIZED_FEATURE_NAME}_PerformanceTest_Single_Host
+        .buildkite/scripts/record_step_result.sh ${{BK_KEY}}_{SANITIZED_FEATURE_NAME}_PerformanceTest_Single_Host
 
   # --- Multi-Host Tests ---
-  - label: "${{TPU_VERSION:-tpu6e}} Correctness tests for {FEATURE_NAME} (multi-host)"
-    key: "${{TPU_VERSION:-tpu6e}}_{SANITIZED_FEATURE_NAME}_CorrectnessTest_Multi_Host"
+  - label: "${{TPU_VERSION:-tpu6e}} ${{MODEL_IMPL_TYPE:-vllm}} Correctness tests for {FEATURE_NAME} (multi-host)"
+    key: "${{BK_KEY}}_{SANITIZED_FEATURE_NAME}_CorrectnessTest_Multi_Host"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${{MODEL_IMPL_TYPE:-vllm}}"
     agents:
       queue: "{QUEUE}"
     commands:
       - echo "placeholder" # TODO : replace with your multi-host correctness test command
 
-  - label: "${{TPU_VERSION:-tpu6e}} Record correctness test result for {FEATURE_NAME} (multi-host)"
-    key: "${{TPU_VERSION:-tpu6e}}_record_{SANITIZED_FEATURE_NAME}_CorrectnessTest_Multi_Host"
-    depends_on: "${{TPU_VERSION:-tpu6e}}_{SANITIZED_FEATURE_NAME}_CorrectnessTest_Multi_Host"
+  - label: "${{TPU_VERSION:-tpu6e}} ${{MODEL_IMPL_TYPE:-vllm}} Record correctness test result for {FEATURE_NAME} (multi-host)"
+    key: "${{BK_KEY}}_record_{SANITIZED_FEATURE_NAME}_CorrectnessTest_Multi_Host"
+    depends_on: "${{BK_KEY}}_{SANITIZED_FEATURE_NAME}_CorrectnessTest_Multi_Host"
     env:
+      MODEL_IMPL_TYPE: "${{MODEL_IMPL_TYPE:-vllm}}"
       CI_TPU_VERSION: "${{TPU_VERSION:-tpu6e}}"
       CI_TARGET: "{FEATURE_NAME}"
       CI_STAGE: "Multi-Host CorrectnessTest"
@@ -80,21 +89,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${{TPU_VERSION:-tpu6e}}_{SANITIZED_FEATURE_NAME}_CorrectnessTest_Multi_Host
+        .buildkite/scripts/record_step_result.sh ${{BK_KEY}}_{SANITIZED_FEATURE_NAME}_CorrectnessTest_Multi_Host
 
-  - label: "${{TPU_VERSION:-tpu6e}} Performance tests for {FEATURE_NAME} (multi-host)"
-    key: "${{TPU_VERSION:-tpu6e}}_{SANITIZED_FEATURE_NAME}_PerformanceTest_Multi_Host"
-    depends_on: "${{TPU_VERSION:-tpu6e}}_record_{SANITIZED_FEATURE_NAME}_CorrectnessTest_Multi_Host"
+  - label: "${{TPU_VERSION:-tpu6e}} ${{MODEL_IMPL_TYPE:-vllm}} Performance tests for {FEATURE_NAME} (multi-host)"
+    key: "${{BK_KEY}}_{SANITIZED_FEATURE_NAME}_PerformanceTest_Multi_Host"
+    depends_on: "${{BK_KEY}}_record_{SANITIZED_FEATURE_NAME}_CorrectnessTest_Multi_Host"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${{MODEL_IMPL_TYPE:-vllm}}"
     agents:
       queue: "{QUEUE}"
     commands:
       - echo "placeholder" # TODO : replace with your multi-host performance test command
 
-  - label: "${{TPU_VERSION:-tpu6e}} Record performance test result for {FEATURE_NAME} (multi-host)"
-    key: "${{TPU_VERSION:-tpu6e}}_record_{SANITIZED_FEATURE_NAME}_PerformanceTest_Multi_Host"
-    depends_on: "${{TPU_VERSION:-tpu6e}}_{SANITIZED_FEATURE_NAME}_PerformanceTest_Multi_Host"
+  - label: "${{TPU_VERSION:-tpu6e}} ${{MODEL_IMPL_TYPE:-vllm}} Record performance test result for {FEATURE_NAME} (multi-host)"
+    key: "${{BK_KEY}}_record_{SANITIZED_FEATURE_NAME}_PerformanceTest_Multi_Host"
+    depends_on: "${{BK_KEY}}_{SANITIZED_FEATURE_NAME}_PerformanceTest_Multi_Host"
     env:
+      MODEL_IMPL_TYPE: "${{MODEL_IMPL_TYPE:-vllm}}"
       CI_TPU_VERSION: "${{TPU_VERSION:-tpu6e}}"
       CI_TARGET: "{FEATURE_NAME}"
       CI_STAGE: "Multi-Host PerformanceTest"
@@ -103,4 +115,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${{TPU_VERSION:-tpu6e}}_{SANITIZED_FEATURE_NAME}_PerformanceTest_Multi_Host
+        .buildkite/scripts/record_step_result.sh ${{BK_KEY}}_{SANITIZED_FEATURE_NAME}_PerformanceTest_Multi_Host

--- a/.buildkite/pipeline_generation/tpu_optimized_model_template.yml
+++ b/.buildkite/pipeline_generation/tpu_optimized_model_template.yml
@@ -38,7 +38,7 @@ steps:
         .buildkite/scripts/record_step_result.sh ${{BK_KEY}}_{SANITIZED_MODEL_NAME}_{CATEGORY}_UnitTest
 
   - label: "${{TPU_VERSION:-tpu6e}} ${{MODEL_IMPL_TYPE:-vllm}} Accuracy for {MODEL_NAME}/{CATEGORY}"
-    key: "${{BK_KEY}}_{SANITIZED_MODEL_NAME}_{CATEGORY}_Accuracy"
+    key: "${{BK_KEY}}_{SANITIZED_MODEL_NAME}_{CATEGORY}_Accuracy_Correctness"
     depends_on: "${{BK_KEY}}_record_{SANITIZED_MODEL_NAME}_{CATEGORY}_UnitTest"
     soft_fail: true
     agents:
@@ -53,8 +53,8 @@ steps:
       - |
         .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/test_accuracy.sh
   - label: "${{TPU_VERSION:-tpu6e}} ${{MODEL_IMPL_TYPE:-vllm}} Record accuracy result for {MODEL_NAME}/{CATEGORY}"
-    key: "${{BK_KEY}}_record_{SANITIZED_MODEL_NAME}_{CATEGORY}_Accuracy"
-    depends_on: "${{BK_KEY}}_{SANITIZED_MODEL_NAME}_{CATEGORY}_Accuracy"
+    key: "${{BK_KEY}}_record_{SANITIZED_MODEL_NAME}_{CATEGORY}_Accuracy_Correctness"
+    depends_on: "${{BK_KEY}}_{SANITIZED_MODEL_NAME}_{CATEGORY}_Accuracy_Correctness"
     env:
       MODEL_IMPL_TYPE: "${{MODEL_IMPL_TYPE:-vllm}}"
       CI_TPU_VERSION: "${{TPU_VERSION:-tpu6e}}"
@@ -65,11 +65,11 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${{BK_KEY}}_{SANITIZED_MODEL_NAME}_{CATEGORY}_Accuracy
+        .buildkite/scripts/record_step_result.sh ${{BK_KEY}}_{SANITIZED_MODEL_NAME}_{CATEGORY}_Accuracy_Correctness
 
   - label: "${{TPU_VERSION:-tpu6e}} ${{MODEL_IMPL_TYPE:-vllm}} Performance benchmarks for {MODEL_NAME}/{CATEGORY}"
     key: "${{BK_KEY}}_{SANITIZED_MODEL_NAME}_{CATEGORY}_Benchmark"
-    depends_on: "${{BK_KEY}}_record_{SANITIZED_MODEL_NAME}_{CATEGORY}_Accuracy"
+    depends_on: "${{BK_KEY}}_record_{SANITIZED_MODEL_NAME}_{CATEGORY}_Accuracy_Correctness"
     soft_fail: true
     agents:
       queue: "{QUEUE}"

--- a/.buildkite/pipeline_generation/tpu_optimized_model_template.yml
+++ b/.buildkite/pipeline_generation/tpu_optimized_model_template.yml
@@ -13,17 +13,20 @@
 # limitations under the License.
 
 steps:
-  - label: "${{TPU_VERSION:-tpu6e}} Unit tests for {MODEL_NAME}/{CATEGORY}"
-    key: "${{TPU_VERSION:-tpu6e}}_{SANITIZED_MODEL_NAME}_{CATEGORY}_UnitTest"
+  - label: "${{TPU_VERSION:-tpu6e}} ${{MODEL_IMPL_TYPE:-vllm}} Unit tests for {MODEL_NAME}/{CATEGORY}"
+    key: "${{BK_KEY}}_{SANITIZED_MODEL_NAME}_{CATEGORY}_UnitTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${{MODEL_IMPL_TYPE:-vllm}}"
     agents:
       queue: "{QUEUE}"
     commands:
       - echo "placeholder"  # TODO: replace with your unit test command
-  - label: "${{TPU_VERSION:-tpu6e}} Record unit test result for {MODEL_NAME}/{CATEGORY}"
-    key: "${{TPU_VERSION:-tpu6e}}_record_{SANITIZED_MODEL_NAME}_{CATEGORY}_UnitTest"
-    depends_on: "${{TPU_VERSION:-tpu6e}}_{SANITIZED_MODEL_NAME}_{CATEGORY}_UnitTest"
+  - label: "${{TPU_VERSION:-tpu6e}} ${{MODEL_IMPL_TYPE:-vllm}} Record unit test result for {MODEL_NAME}/{CATEGORY}"
+    key: "${{BK_KEY}}_record_{SANITIZED_MODEL_NAME}_{CATEGORY}_UnitTest"
+    depends_on: "${{BK_KEY}}_{SANITIZED_MODEL_NAME}_{CATEGORY}_UnitTest"
     env:
+      MODEL_IMPL_TYPE: "${{MODEL_IMPL_TYPE:-vllm}}"
       CI_TPU_VERSION: "${{TPU_VERSION:-tpu6e}}"
       CI_TARGET: "{MODEL_NAME}/{CATEGORY}"
       CI_STAGE: "UnitTest"
@@ -32,11 +35,11 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${{TPU_VERSION:-tpu6e}}_{SANITIZED_MODEL_NAME}_{CATEGORY}_UnitTest
+        .buildkite/scripts/record_step_result.sh ${{BK_KEY}}_{SANITIZED_MODEL_NAME}_{CATEGORY}_UnitTest
 
-  - label: "${{TPU_VERSION:-tpu6e}} Accuracy for {MODEL_NAME}/{CATEGORY}"
-    key: "${{TPU_VERSION:-tpu6e}}_{SANITIZED_MODEL_NAME}_{CATEGORY}_Accuracy"
-    depends_on: "${{TPU_VERSION:-tpu6e}}_record_{SANITIZED_MODEL_NAME}_{CATEGORY}_UnitTest"
+  - label: "${{TPU_VERSION:-tpu6e}} ${{MODEL_IMPL_TYPE:-vllm}} Accuracy for {MODEL_NAME}/{CATEGORY}"
+    key: "${{BK_KEY}}_{SANITIZED_MODEL_NAME}_{CATEGORY}_Accuracy"
+    depends_on: "${{BK_KEY}}_record_{SANITIZED_MODEL_NAME}_{CATEGORY}_UnitTest"
     soft_fail: true
     agents:
       queue: "{QUEUE}"
@@ -45,13 +48,15 @@ steps:
       # The default values are for tpu6e. For tpu7x, the CI procedure will export TENSOR_PARALLEL_SIZE_SINGLE=2, TENSOR_PARALLEL_SIZE_MULTI=8 automatically
       TENSOR_PARALLEL_SIZE: "{TP_SIZE}"
       MINIMUM_ACCURACY_THRESHOLD: 0  # TODO : replace 0 with your accuracy threshold
+      MODEL_IMPL_TYPE: "${{MODEL_IMPL_TYPE:-vllm}}"
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/test_accuracy.sh
-  - label: "${{TPU_VERSION:-tpu6e}} Record accuracy result for {MODEL_NAME}/{CATEGORY}"
-    key: "${{TPU_VERSION:-tpu6e}}_record_{SANITIZED_MODEL_NAME}_{CATEGORY}_Accuracy"
-    depends_on: "${{TPU_VERSION:-tpu6e}}_{SANITIZED_MODEL_NAME}_{CATEGORY}_Accuracy"
+  - label: "${{TPU_VERSION:-tpu6e}} ${{MODEL_IMPL_TYPE:-vllm}} Record accuracy result for {MODEL_NAME}/{CATEGORY}"
+    key: "${{BK_KEY}}_record_{SANITIZED_MODEL_NAME}_{CATEGORY}_Accuracy"
+    depends_on: "${{BK_KEY}}_{SANITIZED_MODEL_NAME}_{CATEGORY}_Accuracy"
     env:
+      MODEL_IMPL_TYPE: "${{MODEL_IMPL_TYPE:-vllm}}"
       CI_TPU_VERSION: "${{TPU_VERSION:-tpu6e}}"
       CI_TARGET: "{MODEL_NAME}/{CATEGORY}"
       CI_STAGE: "Accuracy/Correctness"
@@ -60,11 +65,11 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${{TPU_VERSION:-tpu6e}}_{SANITIZED_MODEL_NAME}_{CATEGORY}_Accuracy
+        .buildkite/scripts/record_step_result.sh ${{BK_KEY}}_{SANITIZED_MODEL_NAME}_{CATEGORY}_Accuracy
 
-  - label: "${{TPU_VERSION:-tpu6e}} Performance benchmarks for {MODEL_NAME}/{CATEGORY}"
-    key: "${{TPU_VERSION:-tpu6e}}_{SANITIZED_MODEL_NAME}_{CATEGORY}_Benchmark"
-    depends_on: "${{TPU_VERSION:-tpu6e}}_record_{SANITIZED_MODEL_NAME}_{CATEGORY}_Accuracy"
+  - label: "${{TPU_VERSION:-tpu6e}} ${{MODEL_IMPL_TYPE:-vllm}} Performance benchmarks for {MODEL_NAME}/{CATEGORY}"
+    key: "${{BK_KEY}}_{SANITIZED_MODEL_NAME}_{CATEGORY}_Benchmark"
+    depends_on: "${{BK_KEY}}_record_{SANITIZED_MODEL_NAME}_{CATEGORY}_Accuracy"
     soft_fail: true
     agents:
       queue: "{QUEUE}"
@@ -73,13 +78,15 @@ steps:
       # The default values are for tpu6e. For tpu7x, the CI procedure will export TENSOR_PARALLEL_SIZE_SINGLE=2, TENSOR_PARALLEL_SIZE_MULTI=8 automatically
       TENSOR_PARALLEL_SIZE: "{TP_SIZE}"
       MINIMUM_THROUGHPUT_THRESHOLD: 0  # TODO : replace 0 with your performance threshold
+      MODEL_IMPL_TYPE: "${{MODEL_IMPL_TYPE:-vllm}}"
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/benchmark.sh
-  - label: "${{TPU_VERSION:-tpu6e}} Record performance benchmark result for {MODEL_NAME}/{CATEGORY}"
-    key: "${{TPU_VERSION:-tpu6e}}_record_{SANITIZED_MODEL_NAME}_{CATEGORY}_Benchmark"
-    depends_on: "${{TPU_VERSION:-tpu6e}}_{SANITIZED_MODEL_NAME}_{CATEGORY}_Benchmark"
+  - label: "${{TPU_VERSION:-tpu6e}} ${{MODEL_IMPL_TYPE:-vllm}} Record performance benchmark result for {MODEL_NAME}/{CATEGORY}"
+    key: "${{BK_KEY}}_record_{SANITIZED_MODEL_NAME}_{CATEGORY}_Benchmark"
+    depends_on: "${{BK_KEY}}_{SANITIZED_MODEL_NAME}_{CATEGORY}_Benchmark"
     env:
+      MODEL_IMPL_TYPE: "${{MODEL_IMPL_TYPE:-vllm}}"
       CI_TPU_VERSION: "${{TPU_VERSION:-tpu6e}}"
       CI_TARGET: "{MODEL_NAME}/{CATEGORY}"
       CI_STAGE: "Benchmark"
@@ -88,4 +95,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${{TPU_VERSION:-tpu6e}}_{SANITIZED_MODEL_NAME}_{CATEGORY}_Benchmark
+        .buildkite/scripts/record_step_result.sh ${{BK_KEY}}_{SANITIZED_MODEL_NAME}_{CATEGORY}_Benchmark

--- a/.buildkite/pipeline_generation/tpu_optimized_model_template.yml
+++ b/.buildkite/pipeline_generation/tpu_optimized_model_template.yml
@@ -13,17 +13,20 @@
 # limitations under the License.
 
 steps:
-  - label: "${{TPU_VERSION:-tpu6e}} Unit tests for {MODEL_NAME}/{CATEGORY}"
-    key: "${{TPU_VERSION:-tpu6e}}_{SANITIZED_MODEL_NAME}_{CATEGORY}_UnitTest"
+  - label: "${{TPU_VERSION:-tpu6e}} ${{MODEL_IMPL_TYPE:-vllm}} Unit tests for {MODEL_NAME}/{CATEGORY}"
+    key: "${{BK_KEY}}_{SANITIZED_MODEL_NAME}_{CATEGORY}_UnitTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${{MODEL_IMPL_TYPE:-vllm}}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "{QUEUE}")
     commands:
       - echo "placeholder"  # TODO: replace with your unit test command
-  - label: "${{TPU_VERSION:-tpu6e}} Record unit test result for {MODEL_NAME}/{CATEGORY}"
-    key: "${{TPU_VERSION:-tpu6e}}_record_{SANITIZED_MODEL_NAME}_{CATEGORY}_UnitTest"
-    depends_on: "${{TPU_VERSION:-tpu6e}}_{SANITIZED_MODEL_NAME}_{CATEGORY}_UnitTest"
+  - label: "${{TPU_VERSION:-tpu6e}} ${{MODEL_IMPL_TYPE:-vllm}} Record unit test result for {MODEL_NAME}/{CATEGORY}"
+    key: "${{BK_KEY}}_record_{SANITIZED_MODEL_NAME}_{CATEGORY}_UnitTest"
+    depends_on: "${{BK_KEY}}_{SANITIZED_MODEL_NAME}_{CATEGORY}_UnitTest"
     env:
+      MODEL_IMPL_TYPE: "${{MODEL_IMPL_TYPE:-vllm}}"
       CI_TPU_VERSION: "${{TPU_VERSION:-tpu6e}}"
       CI_TARGET: "{MODEL_NAME}/{CATEGORY}"
       CI_STAGE: "UnitTest"
@@ -32,11 +35,11 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${{TPU_VERSION:-tpu6e}}_{SANITIZED_MODEL_NAME}_{CATEGORY}_UnitTest
+        .buildkite/scripts/record_step_result.sh ${{BK_KEY}}_{SANITIZED_MODEL_NAME}_{CATEGORY}_UnitTest
 
-  - label: "${{TPU_VERSION:-tpu6e}} Accuracy for {MODEL_NAME}/{CATEGORY}"
-    key: "${{TPU_VERSION:-tpu6e}}_{SANITIZED_MODEL_NAME}_{CATEGORY}_Accuracy"
-    depends_on: "${{TPU_VERSION:-tpu6e}}_record_{SANITIZED_MODEL_NAME}_{CATEGORY}_UnitTest"
+  - label: "${{TPU_VERSION:-tpu6e}} ${{MODEL_IMPL_TYPE:-vllm}} Accuracy for {MODEL_NAME}/{CATEGORY}"
+    key: "${{BK_KEY}}_{SANITIZED_MODEL_NAME}_{CATEGORY}_Accuracy"
+    depends_on: "${{BK_KEY}}_record_{SANITIZED_MODEL_NAME}_{CATEGORY}_UnitTest"
     soft_fail: true
     agents:
       queue: "{QUEUE}"
@@ -45,13 +48,15 @@ steps:
       # The default values are for tpu6e. For tpu7x, the CI procedure will export TENSOR_PARALLEL_SIZE_SINGLE=2, TENSOR_PARALLEL_SIZE_MULTI=8 automatically
       TENSOR_PARALLEL_SIZE: "{TP_SIZE}"
       MINIMUM_ACCURACY_THRESHOLD: 0  # TODO : replace 0 with your accuracy threshold
+      MODEL_IMPL_TYPE: "${{MODEL_IMPL_TYPE:-vllm}}"
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/test_accuracy.sh
-  - label: "${{TPU_VERSION:-tpu6e}} Record accuracy result for {MODEL_NAME}/{CATEGORY}"
-    key: "${{TPU_VERSION:-tpu6e}}_record_{SANITIZED_MODEL_NAME}_{CATEGORY}_Accuracy"
-    depends_on: "${{TPU_VERSION:-tpu6e}}_{SANITIZED_MODEL_NAME}_{CATEGORY}_Accuracy"
+  - label: "${{TPU_VERSION:-tpu6e}} ${{MODEL_IMPL_TYPE:-vllm}} Record accuracy result for {MODEL_NAME}/{CATEGORY}"
+    key: "${{BK_KEY}}_record_{SANITIZED_MODEL_NAME}_{CATEGORY}_Accuracy"
+    depends_on: "${{BK_KEY}}_{SANITIZED_MODEL_NAME}_{CATEGORY}_Accuracy"
     env:
+      MODEL_IMPL_TYPE: "${{MODEL_IMPL_TYPE:-vllm}}"
       CI_TPU_VERSION: "${{TPU_VERSION:-tpu6e}}"
       CI_TARGET: "{MODEL_NAME}/{CATEGORY}"
       CI_STAGE: "Accuracy/Correctness"
@@ -60,11 +65,11 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${{TPU_VERSION:-tpu6e}}_{SANITIZED_MODEL_NAME}_{CATEGORY}_Accuracy
+        .buildkite/scripts/record_step_result.sh ${{BK_KEY}}_{SANITIZED_MODEL_NAME}_{CATEGORY}_Accuracy
 
-  - label: "${{TPU_VERSION:-tpu6e}} Performance benchmarks for {MODEL_NAME}/{CATEGORY}"
-    key: "${{TPU_VERSION:-tpu6e}}_{SANITIZED_MODEL_NAME}_{CATEGORY}_Benchmark"
-    depends_on: "${{TPU_VERSION:-tpu6e}}_record_{SANITIZED_MODEL_NAME}_{CATEGORY}_Accuracy"
+  - label: "${{TPU_VERSION:-tpu6e}} ${{MODEL_IMPL_TYPE:-vllm}} Performance benchmarks for {MODEL_NAME}/{CATEGORY}"
+    key: "${{BK_KEY}}_{SANITIZED_MODEL_NAME}_{CATEGORY}_Benchmark"
+    depends_on: "${{BK_KEY}}_record_{SANITIZED_MODEL_NAME}_{CATEGORY}_Accuracy"
     soft_fail: true
     agents:
       queue: "{QUEUE}"
@@ -73,13 +78,15 @@ steps:
       # The default values are for tpu6e. For tpu7x, the CI procedure will export TENSOR_PARALLEL_SIZE_SINGLE=2, TENSOR_PARALLEL_SIZE_MULTI=8 automatically
       TENSOR_PARALLEL_SIZE: "{TP_SIZE}"
       MINIMUM_THROUGHPUT_THRESHOLD: 0  # TODO : replace 0 with your performance threshold
+      MODEL_IMPL_TYPE: "${{MODEL_IMPL_TYPE:-vllm}}"
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/benchmark.sh
-  - label: "${{TPU_VERSION:-tpu6e}} Record performance benchmark result for {MODEL_NAME}/{CATEGORY}"
-    key: "${{TPU_VERSION:-tpu6e}}_record_{SANITIZED_MODEL_NAME}_{CATEGORY}_Benchmark"
-    depends_on: "${{TPU_VERSION:-tpu6e}}_{SANITIZED_MODEL_NAME}_{CATEGORY}_Benchmark"
+  - label: "${{TPU_VERSION:-tpu6e}} ${{MODEL_IMPL_TYPE:-vllm}} Record performance benchmark result for {MODEL_NAME}/{CATEGORY}"
+    key: "${{BK_KEY}}_record_{SANITIZED_MODEL_NAME}_{CATEGORY}_Benchmark"
+    depends_on: "${{BK_KEY}}_{SANITIZED_MODEL_NAME}_{CATEGORY}_Benchmark"
     env:
+      MODEL_IMPL_TYPE: "${{MODEL_IMPL_TYPE:-vllm}}"
       CI_TPU_VERSION: "${{TPU_VERSION:-tpu6e}}"
       CI_TARGET: "{MODEL_NAME}/{CATEGORY}"
       CI_STAGE: "Benchmark"
@@ -88,4 +95,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${{TPU_VERSION:-tpu6e}}_{SANITIZED_MODEL_NAME}_{CATEGORY}_Benchmark
+        .buildkite/scripts/record_step_result.sh ${{BK_KEY}}_{SANITIZED_MODEL_NAME}_{CATEGORY}_Benchmark

--- a/.buildkite/pipeline_generation/vllm_native_model_template.yml
+++ b/.buildkite/pipeline_generation/vllm_native_model_template.yml
@@ -38,7 +38,7 @@ steps:
         .buildkite/scripts/record_step_result.sh ${{BK_KEY}}_{SANITIZED_MODEL_NAME}_{CATEGORY}_UnitTest
 
   - label: "${{TPU_VERSION:-tpu6e}} ${{MODEL_IMPL_TYPE:-vllm}} Accuracy for {MODEL_NAME}/{CATEGORY}"
-    key: "${{BK_KEY}}_{SANITIZED_MODEL_NAME}_{CATEGORY}_Accuracy"
+    key: "${{BK_KEY}}_{SANITIZED_MODEL_NAME}_{CATEGORY}_Accuracy_Correctness"
     depends_on: "${{BK_KEY}}_record_{SANITIZED_MODEL_NAME}_{CATEGORY}_UnitTest"
     agents:
       queue: "{QUEUE}"
@@ -53,8 +53,8 @@ steps:
       - |
         .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/test_accuracy.sh
   - label: "${{TPU_VERSION:-tpu6e}} ${{MODEL_IMPL_TYPE:-vllm}} Record accuracy result for {MODEL_NAME}/{CATEGORY}"
-    key: "${{BK_KEY}}_record_{SANITIZED_MODEL_NAME}_{CATEGORY}_Accuracy"
-    depends_on: "${{BK_KEY}}_{SANITIZED_MODEL_NAME}_{CATEGORY}_Accuracy"
+    key: "${{BK_KEY}}_record_{SANITIZED_MODEL_NAME}_{CATEGORY}_Accuracy_Correctness"
+    depends_on: "${{BK_KEY}}_{SANITIZED_MODEL_NAME}_{CATEGORY}_Accuracy_Correctness"
     env:
       MODEL_IMPL_TYPE: "${{MODEL_IMPL_TYPE:-vllm}}"
       CI_TPU_VERSION: "${{TPU_VERSION:-tpu6e}}"
@@ -65,4 +65,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${{BK_KEY}}_{SANITIZED_MODEL_NAME}_{CATEGORY}_Accuracy
+        .buildkite/scripts/record_step_result.sh ${{BK_KEY}}_{SANITIZED_MODEL_NAME}_{CATEGORY}_Accuracy_Correctness

--- a/.buildkite/pipeline_generation/vllm_native_model_template.yml
+++ b/.buildkite/pipeline_generation/vllm_native_model_template.yml
@@ -13,17 +13,20 @@
 # limitations under the License.
 
 steps:
-  - label: "${{TPU_VERSION:-tpu6e}} Unit tests for {MODEL_NAME}/{CATEGORY}"
-    key: "${{TPU_VERSION:-tpu6e}}_{SANITIZED_MODEL_NAME}_{CATEGORY}_UnitTest"
+  - label: "${{TPU_VERSION:-tpu6e}} ${{MODEL_IMPL_TYPE:-vllm}} Unit tests for {MODEL_NAME}/{CATEGORY}"
+    key: "${{BK_KEY}}_{SANITIZED_MODEL_NAME}_{CATEGORY}_UnitTest"
+    env:
+      MODEL_IMPL_TYPE: "${{MODEL_IMPL_TYPE:-vllm}}"
     agents:
       queue: "{QUEUE}"
     soft_fail: true
     commands:
       - echo "placeholder"  # TODO: replace with your unit test command
-  - label: "${{TPU_VERSION:-tpu6e}} Record unit test result for {MODEL_NAME}/{CATEGORY}"
-    key: "${{TPU_VERSION:-tpu6e}}_record_{SANITIZED_MODEL_NAME}_{CATEGORY}_UnitTest"
-    depends_on: "${{TPU_VERSION:-tpu6e}}_{SANITIZED_MODEL_NAME}_{CATEGORY}_UnitTest"
+  - label: "${{TPU_VERSION:-tpu6e}} ${{MODEL_IMPL_TYPE:-vllm}} Record unit test result for {MODEL_NAME}/{CATEGORY}"
+    key: "${{BK_KEY}}_record_{SANITIZED_MODEL_NAME}_{CATEGORY}_UnitTest"
+    depends_on: "${{BK_KEY}}_{SANITIZED_MODEL_NAME}_{CATEGORY}_UnitTest"
     env:
+      MODEL_IMPL_TYPE: "${{MODEL_IMPL_TYPE:-vllm}}"
       CI_TPU_VERSION: "${{TPU_VERSION:-tpu6e}}"
       CI_TARGET: "{MODEL_NAME}/{CATEGORY}"
       CI_STAGE: "UnitTest"
@@ -32,11 +35,11 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${{TPU_VERSION:-tpu6e}}_{SANITIZED_MODEL_NAME}_{CATEGORY}_UnitTest
+        .buildkite/scripts/record_step_result.sh ${{BK_KEY}}_{SANITIZED_MODEL_NAME}_{CATEGORY}_UnitTest
 
-  - label: "${{TPU_VERSION:-tpu6e}} Accuracy for {MODEL_NAME}/{CATEGORY}"
-    key: "${{TPU_VERSION:-tpu6e}}_{SANITIZED_MODEL_NAME}_{CATEGORY}_Accuracy"
-    depends_on: "${{TPU_VERSION:-tpu6e}}_record_{SANITIZED_MODEL_NAME}_{CATEGORY}_UnitTest"
+  - label: "${{TPU_VERSION:-tpu6e}} ${{MODEL_IMPL_TYPE:-vllm}} Accuracy for {MODEL_NAME}/{CATEGORY}"
+    key: "${{BK_KEY}}_{SANITIZED_MODEL_NAME}_{CATEGORY}_Accuracy"
+    depends_on: "${{BK_KEY}}_record_{SANITIZED_MODEL_NAME}_{CATEGORY}_UnitTest"
     agents:
       queue: "{QUEUE}"
     soft_fail: true
@@ -45,13 +48,15 @@ steps:
       # The default values are for tpu6e. For tpu7x, the CI procedure will export TENSOR_PARALLEL_SIZE_SINGLE=2, TENSOR_PARALLEL_SIZE_MULTI=8 automatically
       TENSOR_PARALLEL_SIZE: "{TP_SIZE}"
       MINIMUM_ACCURACY_THRESHOLD: 0  # TODO : replace 0 with your accuracy threshold
+      MODEL_IMPL_TYPE: "${{MODEL_IMPL_TYPE:-vllm}}"
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/test_accuracy.sh
-  - label: "${{TPU_VERSION:-tpu6e}} Record accuracy result for {MODEL_NAME}/{CATEGORY}"
-    key: "${{TPU_VERSION:-tpu6e}}_record_{SANITIZED_MODEL_NAME}_{CATEGORY}_Accuracy"
-    depends_on: "${{TPU_VERSION:-tpu6e}}_{SANITIZED_MODEL_NAME}_{CATEGORY}_Accuracy"
+  - label: "${{TPU_VERSION:-tpu6e}} ${{MODEL_IMPL_TYPE:-vllm}} Record accuracy result for {MODEL_NAME}/{CATEGORY}"
+    key: "${{BK_KEY}}_record_{SANITIZED_MODEL_NAME}_{CATEGORY}_Accuracy"
+    depends_on: "${{BK_KEY}}_{SANITIZED_MODEL_NAME}_{CATEGORY}_Accuracy"
     env:
+      MODEL_IMPL_TYPE: "${{MODEL_IMPL_TYPE:-vllm}}"
       CI_TPU_VERSION: "${{TPU_VERSION:-tpu6e}}"
       CI_TARGET: "{MODEL_NAME}/{CATEGORY}"
       CI_STAGE: "Accuracy/Correctness"
@@ -60,4 +65,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${{TPU_VERSION:-tpu6e}}_{SANITIZED_MODEL_NAME}_{CATEGORY}_Accuracy
+        .buildkite/scripts/record_step_result.sh ${{BK_KEY}}_{SANITIZED_MODEL_NAME}_{CATEGORY}_Accuracy

--- a/.buildkite/pipeline_generation/vllm_native_model_template.yml
+++ b/.buildkite/pipeline_generation/vllm_native_model_template.yml
@@ -13,17 +13,20 @@
 # limitations under the License.
 
 steps:
-  - label: "${{TPU_VERSION:-tpu6e}} Unit tests for {MODEL_NAME}/{CATEGORY}"
-    key: "${{TPU_VERSION:-tpu6e}}_{SANITIZED_MODEL_NAME}_{CATEGORY}_UnitTest"
+  - label: "${{TPU_VERSION:-tpu6e}} ${{MODEL_IMPL_TYPE:-vllm}} Unit tests for {MODEL_NAME}/{CATEGORY}"
+    key: "${{BK_KEY}}_{SANITIZED_MODEL_NAME}_{CATEGORY}_UnitTest"
+    env:
+      MODEL_IMPL_TYPE: "${{MODEL_IMPL_TYPE:-vllm}}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "{QUEUE}")
     soft_fail: true
     commands:
       - echo "placeholder"  # TODO: replace with your unit test command
-  - label: "${{TPU_VERSION:-tpu6e}} Record unit test result for {MODEL_NAME}/{CATEGORY}"
-    key: "${{TPU_VERSION:-tpu6e}}_record_{SANITIZED_MODEL_NAME}_{CATEGORY}_UnitTest"
-    depends_on: "${{TPU_VERSION:-tpu6e}}_{SANITIZED_MODEL_NAME}_{CATEGORY}_UnitTest"
+  - label: "${{TPU_VERSION:-tpu6e}} ${{MODEL_IMPL_TYPE:-vllm}} Record unit test result for {MODEL_NAME}/{CATEGORY}"
+    key: "${{BK_KEY}}_record_{SANITIZED_MODEL_NAME}_{CATEGORY}_UnitTest"
+    depends_on: "${{BK_KEY}}_{SANITIZED_MODEL_NAME}_{CATEGORY}_UnitTest"
     env:
+      MODEL_IMPL_TYPE: "${{MODEL_IMPL_TYPE:-vllm}}"
       CI_TPU_VERSION: "${{TPU_VERSION:-tpu6e}}"
       CI_TARGET: "{MODEL_NAME}/{CATEGORY}"
       CI_STAGE: "UnitTest"
@@ -32,11 +35,11 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${{TPU_VERSION:-tpu6e}}_{SANITIZED_MODEL_NAME}_{CATEGORY}_UnitTest
+        .buildkite/scripts/record_step_result.sh ${{BK_KEY}}_{SANITIZED_MODEL_NAME}_{CATEGORY}_UnitTest
 
-  - label: "${{TPU_VERSION:-tpu6e}} Accuracy for {MODEL_NAME}/{CATEGORY}"
-    key: "${{TPU_VERSION:-tpu6e}}_{SANITIZED_MODEL_NAME}_{CATEGORY}_Accuracy"
-    depends_on: "${{TPU_VERSION:-tpu6e}}_record_{SANITIZED_MODEL_NAME}_{CATEGORY}_UnitTest"
+  - label: "${{TPU_VERSION:-tpu6e}} ${{MODEL_IMPL_TYPE:-vllm}} Accuracy for {MODEL_NAME}/{CATEGORY}"
+    key: "${{BK_KEY}}_{SANITIZED_MODEL_NAME}_{CATEGORY}_Accuracy"
+    depends_on: "${{BK_KEY}}_record_{SANITIZED_MODEL_NAME}_{CATEGORY}_UnitTest"
     agents:
       queue: "{QUEUE}"
     soft_fail: true
@@ -45,13 +48,15 @@ steps:
       # The default values are for tpu6e. For tpu7x, the CI procedure will export TENSOR_PARALLEL_SIZE_SINGLE=2, TENSOR_PARALLEL_SIZE_MULTI=8 automatically
       TENSOR_PARALLEL_SIZE: "{TP_SIZE}"
       MINIMUM_ACCURACY_THRESHOLD: 0  # TODO : replace 0 with your accuracy threshold
+      MODEL_IMPL_TYPE: "${{MODEL_IMPL_TYPE:-vllm}}"
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/test_accuracy.sh
-  - label: "${{TPU_VERSION:-tpu6e}} Record accuracy result for {MODEL_NAME}/{CATEGORY}"
-    key: "${{TPU_VERSION:-tpu6e}}_record_{SANITIZED_MODEL_NAME}_{CATEGORY}_Accuracy"
-    depends_on: "${{TPU_VERSION:-tpu6e}}_{SANITIZED_MODEL_NAME}_{CATEGORY}_Accuracy"
+  - label: "${{TPU_VERSION:-tpu6e}} ${{MODEL_IMPL_TYPE:-vllm}} Record accuracy result for {MODEL_NAME}/{CATEGORY}"
+    key: "${{BK_KEY}}_record_{SANITIZED_MODEL_NAME}_{CATEGORY}_Accuracy"
+    depends_on: "${{BK_KEY}}_{SANITIZED_MODEL_NAME}_{CATEGORY}_Accuracy"
     env:
+      MODEL_IMPL_TYPE: "${{MODEL_IMPL_TYPE:-vllm}}"
       CI_TPU_VERSION: "${{TPU_VERSION:-tpu6e}}"
       CI_TARGET: "{MODEL_NAME}/{CATEGORY}"
       CI_STAGE: "Accuracy/Correctness"
@@ -60,4 +65,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${{TPU_VERSION:-tpu6e}}_{SANITIZED_MODEL_NAME}_{CATEGORY}_Accuracy
+        .buildkite/scripts/record_step_result.sh ${{BK_KEY}}_{SANITIZED_MODEL_NAME}_{CATEGORY}_Accuracy

--- a/.buildkite/quantization/FP4_W4A16.yml
+++ b/.buildkite/quantization/FP4_W4A16.yml
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for FP4 W4A16"
-    key: "${TPU_VERSION:-tpu6e}_FP4_W4A16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for FP4 W4A16"
+    key: "${BK_KEY}_FP4_W4A16_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_FP4_W4A16_CorrectnessTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for FP4 W4A16"
-    key: "${TPU_VERSION:-tpu6e}_record_FP4_W4A16_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_FP4_W4A16_CorrectnessTest"
+        buildkite-agent meta-data set "${BK_KEY}_FP4_W4A16_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for FP4 W4A16"
+    key: "${BK_KEY}_record_FP4_W4A16_CorrectnessTest"
+    depends_on: "${BK_KEY}_FP4_W4A16_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "FP4 W4A16"
       CI_STAGE: "CorrectnessTest"
@@ -33,21 +36,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_FP4_W4A16_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_FP4_W4A16_CorrectnessTest
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for FP4 W4A16"
-    key: "${TPU_VERSION:-tpu6e}_FP4_W4A16_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_FP4_W4A16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for FP4 W4A16"
+    key: "${BK_KEY}_FP4_W4A16_PerformanceTest"
+    depends_on: "${BK_KEY}_record_FP4_W4A16_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_FP4_W4A16_PerformanceTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for FP4 W4A16"
-    key: "${TPU_VERSION:-tpu6e}_record_FP4_W4A16_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_FP4_W4A16_PerformanceTest"
+        buildkite-agent meta-data set "${BK_KEY}_FP4_W4A16_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for FP4 W4A16"
+    key: "${BK_KEY}_record_FP4_W4A16_PerformanceTest"
+    depends_on: "${BK_KEY}_FP4_W4A16_PerformanceTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "FP4 W4A16"
       CI_STAGE: "PerformanceTest"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_FP4_W4A16_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_FP4_W4A16_PerformanceTest

--- a/.buildkite/quantization/FP4_W4A16.yml
+++ b/.buildkite/quantization/FP4_W4A16.yml
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for FP4 W4A16"
-    key: "${TPU_VERSION:-tpu6e}_FP4_W4A16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for FP4 W4A16"
+    key: "${BK_KEY}_FP4_W4A16_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_FP4_W4A16_CorrectnessTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for FP4 W4A16"
-    key: "${TPU_VERSION:-tpu6e}_record_FP4_W4A16_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_FP4_W4A16_CorrectnessTest"
+        buildkite-agent meta-data set "${BK_KEY}_FP4_W4A16_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for FP4 W4A16"
+    key: "${BK_KEY}_record_FP4_W4A16_CorrectnessTest"
+    depends_on: "${BK_KEY}_FP4_W4A16_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "FP4 W4A16"
       CI_STAGE: "CorrectnessTest"
@@ -33,21 +36,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_FP4_W4A16_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_FP4_W4A16_CorrectnessTest
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for FP4 W4A16"
-    key: "${TPU_VERSION:-tpu6e}_FP4_W4A16_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_FP4_W4A16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for FP4 W4A16"
+    key: "${BK_KEY}_FP4_W4A16_PerformanceTest"
+    depends_on: "${BK_KEY}_record_FP4_W4A16_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_FP4_W4A16_PerformanceTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for FP4 W4A16"
-    key: "${TPU_VERSION:-tpu6e}_record_FP4_W4A16_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_FP4_W4A16_PerformanceTest"
+        buildkite-agent meta-data set "${BK_KEY}_FP4_W4A16_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for FP4 W4A16"
+    key: "${BK_KEY}_record_FP4_W4A16_PerformanceTest"
+    depends_on: "${BK_KEY}_FP4_W4A16_PerformanceTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "FP4 W4A16"
       CI_STAGE: "PerformanceTest"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_FP4_W4A16_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_FP4_W4A16_PerformanceTest

--- a/.buildkite/quantization/FP8_W8A16.yml
+++ b/.buildkite/quantization/FP8_W8A16.yml
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for FP8 W8A16"
-    key: "${TPU_VERSION:-tpu6e}_FP8_W8A16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for FP8 W8A16"
+    key: "${BK_KEY}_FP8_W8A16_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_FP8_W8A16_CorrectnessTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for FP8 W8A16"
-    key: "${TPU_VERSION:-tpu6e}_record_FP8_W8A16_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_FP8_W8A16_CorrectnessTest"
+        buildkite-agent meta-data set "${BK_KEY}_FP8_W8A16_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for FP8 W8A16"
+    key: "${BK_KEY}_record_FP8_W8A16_CorrectnessTest"
+    depends_on: "${BK_KEY}_FP8_W8A16_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "FP8 W8A16"
       CI_STAGE: "CorrectnessTest"
@@ -33,21 +36,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_FP8_W8A16_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_FP8_W8A16_CorrectnessTest
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for FP8 W8A16"
-    key: "${TPU_VERSION:-tpu6e}_FP8_W8A16_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_FP8_W8A16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for FP8 W8A16"
+    key: "${BK_KEY}_FP8_W8A16_PerformanceTest"
+    depends_on: "${BK_KEY}_record_FP8_W8A16_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_FP8_W8A16_PerformanceTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for FP8 W8A16"
-    key: "${TPU_VERSION:-tpu6e}_record_FP8_W8A16_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_FP8_W8A16_PerformanceTest"
+        buildkite-agent meta-data set "${BK_KEY}_FP8_W8A16_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for FP8 W8A16"
+    key: "${BK_KEY}_record_FP8_W8A16_PerformanceTest"
+    depends_on: "${BK_KEY}_FP8_W8A16_PerformanceTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "FP8 W8A16"
       CI_STAGE: "PerformanceTest"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_FP8_W8A16_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_FP8_W8A16_PerformanceTest

--- a/.buildkite/quantization/FP8_W8A16.yml
+++ b/.buildkite/quantization/FP8_W8A16.yml
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for FP8 W8A16"
-    key: "${TPU_VERSION:-tpu6e}_FP8_W8A16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for FP8 W8A16"
+    key: "${BK_KEY}_FP8_W8A16_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_FP8_W8A16_CorrectnessTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for FP8 W8A16"
-    key: "${TPU_VERSION:-tpu6e}_record_FP8_W8A16_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_FP8_W8A16_CorrectnessTest"
+        buildkite-agent meta-data set "${BK_KEY}_FP8_W8A16_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for FP8 W8A16"
+    key: "${BK_KEY}_record_FP8_W8A16_CorrectnessTest"
+    depends_on: "${BK_KEY}_FP8_W8A16_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "FP8 W8A16"
       CI_STAGE: "CorrectnessTest"
@@ -33,21 +36,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_FP8_W8A16_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_FP8_W8A16_CorrectnessTest
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for FP8 W8A16"
-    key: "${TPU_VERSION:-tpu6e}_FP8_W8A16_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_FP8_W8A16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for FP8 W8A16"
+    key: "${BK_KEY}_FP8_W8A16_PerformanceTest"
+    depends_on: "${BK_KEY}_record_FP8_W8A16_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_FP8_W8A16_PerformanceTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for FP8 W8A16"
-    key: "${TPU_VERSION:-tpu6e}_record_FP8_W8A16_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_FP8_W8A16_PerformanceTest"
+        buildkite-agent meta-data set "${BK_KEY}_FP8_W8A16_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for FP8 W8A16"
+    key: "${BK_KEY}_record_FP8_W8A16_PerformanceTest"
+    depends_on: "${BK_KEY}_FP8_W8A16_PerformanceTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "FP8 W8A16"
       CI_STAGE: "PerformanceTest"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_FP8_W8A16_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_FP8_W8A16_PerformanceTest

--- a/.buildkite/quantization/FP8_W8A8.yml
+++ b/.buildkite/quantization/FP8_W8A8.yml
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for FP8 W8A8"
-    key: "${TPU_VERSION:-tpu6e}_FP8_W8A8_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for FP8 W8A8"
+    key: "${BK_KEY}_FP8_W8A8_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_FP8_W8A8_CorrectnessTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for FP8 W8A8"
-    key: "${TPU_VERSION:-tpu6e}_record_FP8_W8A8_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_FP8_W8A8_CorrectnessTest"
+        buildkite-agent meta-data set "${BK_KEY}_FP8_W8A8_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for FP8 W8A8"
+    key: "${BK_KEY}_record_FP8_W8A8_CorrectnessTest"
+    depends_on: "${BK_KEY}_FP8_W8A8_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "FP8 W8A8"
       CI_STAGE: "CorrectnessTest"
@@ -33,21 +36,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_FP8_W8A8_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_FP8_W8A8_CorrectnessTest
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for FP8 W8A8"
-    key: "${TPU_VERSION:-tpu6e}_FP8_W8A8_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_FP8_W8A8_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for FP8 W8A8"
+    key: "${BK_KEY}_FP8_W8A8_PerformanceTest"
+    depends_on: "${BK_KEY}_record_FP8_W8A8_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_FP8_W8A8_PerformanceTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for FP8 W8A8"
-    key: "${TPU_VERSION:-tpu6e}_record_FP8_W8A8_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_FP8_W8A8_PerformanceTest"
+        buildkite-agent meta-data set "${BK_KEY}_FP8_W8A8_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for FP8 W8A8"
+    key: "${BK_KEY}_record_FP8_W8A8_PerformanceTest"
+    depends_on: "${BK_KEY}_FP8_W8A8_PerformanceTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "FP8 W8A8"
       CI_STAGE: "PerformanceTest"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_FP8_W8A8_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_FP8_W8A8_PerformanceTest

--- a/.buildkite/quantization/FP8_W8A8.yml
+++ b/.buildkite/quantization/FP8_W8A8.yml
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for FP8 W8A8"
-    key: "${TPU_VERSION:-tpu6e}_FP8_W8A8_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for FP8 W8A8"
+    key: "${BK_KEY}_FP8_W8A8_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_FP8_W8A8_CorrectnessTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for FP8 W8A8"
-    key: "${TPU_VERSION:-tpu6e}_record_FP8_W8A8_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_FP8_W8A8_CorrectnessTest"
+        buildkite-agent meta-data set "${BK_KEY}_FP8_W8A8_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for FP8 W8A8"
+    key: "${BK_KEY}_record_FP8_W8A8_CorrectnessTest"
+    depends_on: "${BK_KEY}_FP8_W8A8_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "FP8 W8A8"
       CI_STAGE: "CorrectnessTest"
@@ -33,21 +36,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_FP8_W8A8_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_FP8_W8A8_CorrectnessTest
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for FP8 W8A8"
-    key: "${TPU_VERSION:-tpu6e}_FP8_W8A8_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_FP8_W8A8_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for FP8 W8A8"
+    key: "${BK_KEY}_FP8_W8A8_PerformanceTest"
+    depends_on: "${BK_KEY}_record_FP8_W8A8_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_FP8_W8A8_PerformanceTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for FP8 W8A8"
-    key: "${TPU_VERSION:-tpu6e}_record_FP8_W8A8_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_FP8_W8A8_PerformanceTest"
+        buildkite-agent meta-data set "${BK_KEY}_FP8_W8A8_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for FP8 W8A8"
+    key: "${BK_KEY}_record_FP8_W8A8_PerformanceTest"
+    depends_on: "${BK_KEY}_FP8_W8A8_PerformanceTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "FP8 W8A8"
       CI_STAGE: "PerformanceTest"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_FP8_W8A8_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_FP8_W8A8_PerformanceTest

--- a/.buildkite/quantization/INT4_W4A16.yml
+++ b/.buildkite/quantization/INT4_W4A16.yml
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for INT4 W4A16"
-    key: "${TPU_VERSION:-tpu6e}_INT4_W4A16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for INT4 W4A16"
+    key: "${BK_KEY}_INT4_W4A16_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_INT4_W4A16_CorrectnessTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for INT4 W4A16"
-    key: "${TPU_VERSION:-tpu6e}_record_INT4_W4A16_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_INT4_W4A16_CorrectnessTest"
+        buildkite-agent meta-data set "${BK_KEY}_INT4_W4A16_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for INT4 W4A16"
+    key: "${BK_KEY}_record_INT4_W4A16_CorrectnessTest"
+    depends_on: "${BK_KEY}_INT4_W4A16_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "INT4 W4A16"
       CI_STAGE: "CorrectnessTest"
@@ -33,21 +36,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_INT4_W4A16_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_INT4_W4A16_CorrectnessTest
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for INT4 W4A16"
-    key: "${TPU_VERSION:-tpu6e}_INT4_W4A16_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_INT4_W4A16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for INT4 W4A16"
+    key: "${BK_KEY}_INT4_W4A16_PerformanceTest"
+    depends_on: "${BK_KEY}_record_INT4_W4A16_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_INT4_W4A16_PerformanceTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for INT4 W4A16"
-    key: "${TPU_VERSION:-tpu6e}_record_INT4_W4A16_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_INT4_W4A16_PerformanceTest"
+        buildkite-agent meta-data set "${BK_KEY}_INT4_W4A16_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for INT4 W4A16"
+    key: "${BK_KEY}_record_INT4_W4A16_PerformanceTest"
+    depends_on: "${BK_KEY}_INT4_W4A16_PerformanceTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "INT4 W4A16"
       CI_STAGE: "PerformanceTest"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_INT4_W4A16_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_INT4_W4A16_PerformanceTest

--- a/.buildkite/quantization/INT4_W4A16.yml
+++ b/.buildkite/quantization/INT4_W4A16.yml
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for INT4 W4A16"
-    key: "${TPU_VERSION:-tpu6e}_INT4_W4A16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for INT4 W4A16"
+    key: "${BK_KEY}_INT4_W4A16_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_INT4_W4A16_CorrectnessTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for INT4 W4A16"
-    key: "${TPU_VERSION:-tpu6e}_record_INT4_W4A16_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_INT4_W4A16_CorrectnessTest"
+        buildkite-agent meta-data set "${BK_KEY}_INT4_W4A16_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for INT4 W4A16"
+    key: "${BK_KEY}_record_INT4_W4A16_CorrectnessTest"
+    depends_on: "${BK_KEY}_INT4_W4A16_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "INT4 W4A16"
       CI_STAGE: "CorrectnessTest"
@@ -33,21 +36,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_INT4_W4A16_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_INT4_W4A16_CorrectnessTest
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for INT4 W4A16"
-    key: "${TPU_VERSION:-tpu6e}_INT4_W4A16_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_INT4_W4A16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for INT4 W4A16"
+    key: "${BK_KEY}_INT4_W4A16_PerformanceTest"
+    depends_on: "${BK_KEY}_record_INT4_W4A16_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_INT4_W4A16_PerformanceTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for INT4 W4A16"
-    key: "${TPU_VERSION:-tpu6e}_record_INT4_W4A16_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_INT4_W4A16_PerformanceTest"
+        buildkite-agent meta-data set "${BK_KEY}_INT4_W4A16_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for INT4 W4A16"
+    key: "${BK_KEY}_record_INT4_W4A16_PerformanceTest"
+    depends_on: "${BK_KEY}_INT4_W4A16_PerformanceTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "INT4 W4A16"
       CI_STAGE: "PerformanceTest"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_INT4_W4A16_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_INT4_W4A16_PerformanceTest

--- a/.buildkite/quantization/INT8_W8A8.yml
+++ b/.buildkite/quantization/INT8_W8A8.yml
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for INT8 W8A8"
-    key: "${TPU_VERSION:-tpu6e}_INT8_W8A8_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for INT8 W8A8"
+    key: "${BK_KEY}_INT8_W8A8_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_INT8_W8A8_CorrectnessTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for INT8 W8A8"
-    key: "${TPU_VERSION:-tpu6e}_record_INT8_W8A8_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_INT8_W8A8_CorrectnessTest"
+        buildkite-agent meta-data set "${BK_KEY}_INT8_W8A8_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for INT8 W8A8"
+    key: "${BK_KEY}_record_INT8_W8A8_CorrectnessTest"
+    depends_on: "${BK_KEY}_INT8_W8A8_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "INT8 W8A8"
       CI_STAGE: "CorrectnessTest"
@@ -33,21 +36,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_INT8_W8A8_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_INT8_W8A8_CorrectnessTest
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for INT8 W8A8"
-    key: "${TPU_VERSION:-tpu6e}_INT8_W8A8_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_INT8_W8A8_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for INT8 W8A8"
+    key: "${BK_KEY}_INT8_W8A8_PerformanceTest"
+    depends_on: "${BK_KEY}_record_INT8_W8A8_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_INT8_W8A8_PerformanceTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for INT8 W8A8"
-    key: "${TPU_VERSION:-tpu6e}_record_INT8_W8A8_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_INT8_W8A8_PerformanceTest"
+        buildkite-agent meta-data set "${BK_KEY}_INT8_W8A8_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for INT8 W8A8"
+    key: "${BK_KEY}_record_INT8_W8A8_PerformanceTest"
+    depends_on: "${BK_KEY}_INT8_W8A8_PerformanceTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "INT8 W8A8"
       CI_STAGE: "PerformanceTest"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_INT8_W8A8_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_INT8_W8A8_PerformanceTest

--- a/.buildkite/quantization/INT8_W8A8.yml
+++ b/.buildkite/quantization/INT8_W8A8.yml
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for INT8 W8A8"
-    key: "${TPU_VERSION:-tpu6e}_INT8_W8A8_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for INT8 W8A8"
+    key: "${BK_KEY}_INT8_W8A8_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_INT8_W8A8_CorrectnessTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for INT8 W8A8"
-    key: "${TPU_VERSION:-tpu6e}_record_INT8_W8A8_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_INT8_W8A8_CorrectnessTest"
+        buildkite-agent meta-data set "${BK_KEY}_INT8_W8A8_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for INT8 W8A8"
+    key: "${BK_KEY}_record_INT8_W8A8_CorrectnessTest"
+    depends_on: "${BK_KEY}_INT8_W8A8_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "INT8 W8A8"
       CI_STAGE: "CorrectnessTest"
@@ -33,21 +36,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_INT8_W8A8_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_INT8_W8A8_CorrectnessTest
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for INT8 W8A8"
-    key: "${TPU_VERSION:-tpu6e}_INT8_W8A8_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_INT8_W8A8_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for INT8 W8A8"
+    key: "${BK_KEY}_INT8_W8A8_PerformanceTest"
+    depends_on: "${BK_KEY}_record_INT8_W8A8_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_INT8_W8A8_PerformanceTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for INT8 W8A8"
-    key: "${TPU_VERSION:-tpu6e}_record_INT8_W8A8_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_INT8_W8A8_PerformanceTest"
+        buildkite-agent meta-data set "${BK_KEY}_INT8_W8A8_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for INT8 W8A8"
+    key: "${BK_KEY}_record_INT8_W8A8_PerformanceTest"
+    depends_on: "${BK_KEY}_INT8_W8A8_PerformanceTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "INT8 W8A8"
       CI_STAGE: "PerformanceTest"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_INT8_W8A8_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_INT8_W8A8_PerformanceTest

--- a/.buildkite/quantization/NVFP4_W4A16.yml
+++ b/.buildkite/quantization/NVFP4_W4A16.yml
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for NVFP4 W4A16"
-    key: "${TPU_VERSION:-tpu6e}_NVFP4_W4A16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for NVFP4 W4A16"
+    key: "${BK_KEY}_NVFP4_W4A16_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_NVFP4_W4A16_CorrectnessTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for NVFP4 W4A16"
-    key: "${TPU_VERSION:-tpu6e}_record_NVFP4_W4A16_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_NVFP4_W4A16_CorrectnessTest"
+        buildkite-agent meta-data set "${BK_KEY}_NVFP4_W4A16_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for NVFP4 W4A16"
+    key: "${BK_KEY}_record_NVFP4_W4A16_CorrectnessTest"
+    depends_on: "${BK_KEY}_NVFP4_W4A16_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "NVFP4 W4A16"
       CI_STAGE: "CorrectnessTest"
@@ -33,21 +36,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_NVFP4_W4A16_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_NVFP4_W4A16_CorrectnessTest
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for NVFP4 W4A16"
-    key: "${TPU_VERSION:-tpu6e}_NVFP4_W4A16_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_NVFP4_W4A16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for NVFP4 W4A16"
+    key: "${BK_KEY}_NVFP4_W4A16_PerformanceTest"
+    depends_on: "${BK_KEY}_record_NVFP4_W4A16_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_NVFP4_W4A16_PerformanceTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for NVFP4 W4A16"
-    key: "${TPU_VERSION:-tpu6e}_record_NVFP4_W4A16_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_NVFP4_W4A16_PerformanceTest"
+        buildkite-agent meta-data set "${BK_KEY}_NVFP4_W4A16_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for NVFP4 W4A16"
+    key: "${BK_KEY}_record_NVFP4_W4A16_PerformanceTest"
+    depends_on: "${BK_KEY}_NVFP4_W4A16_PerformanceTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "NVFP4 W4A16"
       CI_STAGE: "PerformanceTest"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_NVFP4_W4A16_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_NVFP4_W4A16_PerformanceTest

--- a/.buildkite/quantization/NVFP4_W4A16.yml
+++ b/.buildkite/quantization/NVFP4_W4A16.yml
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for NVFP4 W4A16"
-    key: "${TPU_VERSION:-tpu6e}_NVFP4_W4A16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for NVFP4 W4A16"
+    key: "${BK_KEY}_NVFP4_W4A16_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_NVFP4_W4A16_CorrectnessTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for NVFP4 W4A16"
-    key: "${TPU_VERSION:-tpu6e}_record_NVFP4_W4A16_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_NVFP4_W4A16_CorrectnessTest"
+        buildkite-agent meta-data set "${BK_KEY}_NVFP4_W4A16_CorrectnessTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for NVFP4 W4A16"
+    key: "${BK_KEY}_record_NVFP4_W4A16_CorrectnessTest"
+    depends_on: "${BK_KEY}_NVFP4_W4A16_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "NVFP4 W4A16"
       CI_STAGE: "CorrectnessTest"
@@ -33,21 +36,24 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_NVFP4_W4A16_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_NVFP4_W4A16_CorrectnessTest
 
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for NVFP4 W4A16"
-    key: "${TPU_VERSION:-tpu6e}_NVFP4_W4A16_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_NVFP4_W4A16_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for NVFP4 W4A16"
+    key: "${BK_KEY}_NVFP4_W4A16_PerformanceTest"
+    depends_on: "${BK_KEY}_record_NVFP4_W4A16_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_NVFP4_W4A16_PerformanceTest" "unverified"
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for NVFP4 W4A16"
-    key: "${TPU_VERSION:-tpu6e}_record_NVFP4_W4A16_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_NVFP4_W4A16_PerformanceTest"
+        buildkite-agent meta-data set "${BK_KEY}_NVFP4_W4A16_PerformanceTest" "unverified"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for NVFP4 W4A16"
+    key: "${BK_KEY}_record_NVFP4_W4A16_PerformanceTest"
+    depends_on: "${BK_KEY}_NVFP4_W4A16_PerformanceTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "NVFP4 W4A16"
       CI_STAGE: "PerformanceTest"
@@ -56,4 +62,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_NVFP4_W4A16_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_NVFP4_W4A16_PerformanceTest

--- a/.buildkite/rl/async_logprobs.yml
+++ b/.buildkite/rl/async_logprobs.yml
@@ -16,18 +16,21 @@ steps:
   # ------------------------------------------------------------------
   # Correctness tests
   # ------------------------------------------------------------------
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for async_logprobs"
-    key: "${TPU_VERSION:-tpu6e}_async_logprobs_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for async_logprobs"
+    key: "${BK_KEY}_async_logprobs_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - .buildkite/scripts/run_in_docker.sh python3 -m pytest -s -v /workspace/tpu_inference/tests/runner/test_async_logprobs.py
 
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for async_logprobs"
-    key: "${TPU_VERSION:-tpu6e}_record_async_logprobs_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_async_logprobs_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for async_logprobs"
+    key: "${BK_KEY}_record_async_logprobs_CorrectnessTest"
+    depends_on: "${BK_KEY}_async_logprobs_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "async_logprobs"
       CI_STAGE: "CorrectnessTest"
@@ -36,4 +39,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_async_logprobs_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_async_logprobs_CorrectnessTest

--- a/.buildkite/rl/group_sampling_prefix_cache.yml
+++ b/.buildkite/rl/group_sampling_prefix_cache.yml
@@ -19,18 +19,20 @@ steps:
   # ------------------------------------------------------------------
   # Correctness tests
   # ------------------------------------------------------------------
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for group_sampling_prefix_cache"
-    key: "${TPU_VERSION:-tpu6e}_group_sampling_prefix_cache_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for group_sampling_prefix_cache"
+    key: "${BK_KEY}_group_sampling_prefix_cache_CorrectnessTest"
     soft_fail: true
-    if: build.env("NIGHTLY") == "1"
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
     commands:
       - .buildkite/scripts/run_in_docker.sh python3 -m pytest -s -v /workspace/tpu_inference/tests/core/test_dp_group_sampling_prefix_cache.py::TestGroupSamplingPrefixCache::test_group_sampling_produces_diverse_outputs
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for group_sampling_prefix_cache"
-    key: "${TPU_VERSION:-tpu6e}_record_group_sampling_prefix_cache_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_group_sampling_prefix_cache_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for group_sampling_prefix_cache"
+    key: "${BK_KEY}_record_group_sampling_prefix_cache_CorrectnessTest"
+    depends_on: "${BK_KEY}_group_sampling_prefix_cache_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "Group sampling prefix cache"
       CI_STAGE: "CorrectnessTest"
@@ -39,24 +41,26 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_group_sampling_prefix_cache_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_group_sampling_prefix_cache_CorrectnessTest
 
   # ------------------------------------------------------------------
   # Performance tests
   # ------------------------------------------------------------------
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for group_sampling_prefix_cache"
-    key: "${TPU_VERSION:-tpu6e}_group_sampling_prefix_cache_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_group_sampling_prefix_cache_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for group_sampling_prefix_cache"
+    key: "${BK_KEY}_group_sampling_prefix_cache_PerformanceTest"
+    depends_on: "${BK_KEY}_record_group_sampling_prefix_cache_CorrectnessTest"
     soft_fail: true
-    if: build.env("NIGHTLY") == "1"
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
     commands:
       - .buildkite/scripts/run_in_docker.sh python3 -m pytest -s -v /workspace/tpu_inference/tests/core/test_dp_group_sampling_prefix_cache.py::TestGroupSamplingPrefixCache::test_group_sampling_hits_prefix_cache
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for group_sampling_prefix_cache"
-    key: "${TPU_VERSION:-tpu6e}_record_group_sampling_prefix_cache_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_group_sampling_prefix_cache_PerformanceTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for group_sampling_prefix_cache"
+    key: "${BK_KEY}_record_group_sampling_prefix_cache_PerformanceTest"
+    depends_on: "${BK_KEY}_group_sampling_prefix_cache_PerformanceTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "Group sampling prefix cache"
       CI_STAGE: "PerformanceTest"
@@ -65,4 +69,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_group_sampling_prefix_cache_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_group_sampling_prefix_cache_PerformanceTest

--- a/.buildkite/rl/moe_expert_ids.yml
+++ b/.buildkite/rl/moe_expert_ids.yml
@@ -16,17 +16,20 @@ steps:
   # ------------------------------------------------------------------
   # Correctness tests
   # ------------------------------------------------------------------
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for moe_expert_ids"
-    key: "${TPU_VERSION:-tpu6e}_moe_expert_ids_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for moe_expert_ids"
+    key: "${BK_KEY}_moe_expert_ids_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - .buildkite/scripts/run_in_docker.sh python3 -m pytest -s -v /workspace/tpu_inference/tests/runner/test_moe_expert_ids.py
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for moe_expert_ids"
-    key: "${TPU_VERSION:-tpu6e}_record_moe_expert_ids_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_moe_expert_ids_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for moe_expert_ids"
+    key: "${BK_KEY}_record_moe_expert_ids_CorrectnessTest"
+    depends_on: "${BK_KEY}_moe_expert_ids_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "MoE Expert IDs"
       CI_STAGE: "CorrectnessTest"
@@ -35,4 +38,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_moe_expert_ids_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_moe_expert_ids_CorrectnessTest

--- a/.buildkite/rl/processed_logprobs.yml
+++ b/.buildkite/rl/processed_logprobs.yml
@@ -16,18 +16,21 @@ steps:
   # ------------------------------------------------------------------
   # Correctness tests
   # ------------------------------------------------------------------
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for processed_logprobs"
-    key: "${TPU_VERSION:-tpu6e}_processed_logprobs_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for processed_logprobs"
+    key: "${BK_KEY}_processed_logprobs_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - .buildkite/scripts/run_in_docker.sh python3 -m pytest -s -v /workspace/tpu_inference/tests/runner/test_processed_logprobs.py
 
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for processed_logprobs"
-    key: "${TPU_VERSION:-tpu6e}_record_processed_logprobs_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_processed_logprobs_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for processed_logprobs"
+    key: "${BK_KEY}_record_processed_logprobs_CorrectnessTest"
+    depends_on: "${BK_KEY}_processed_logprobs_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "processed_logprobs"
       CI_STAGE: "CorrectnessTest"
@@ -36,4 +39,4 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_processed_logprobs_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_processed_logprobs_CorrectnessTest

--- a/.buildkite/rl/rl_integration.yml
+++ b/.buildkite/rl/rl_integration.yml
@@ -19,17 +19,20 @@ steps:
   # ------------------------------------------------------------------
   # Correctness tests
   # ------------------------------------------------------------------
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for rl_integration"
-    key: "${TPU_VERSION:-tpu6e}_rl_integration_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for rl_integration"
+    key: "${BK_KEY}_rl_integration_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - .buildkite/scripts/run_in_docker.sh python3 -m pytest -s -v /workspace/tpu_inference/tests/e2e/test_rl_integration.py::TestDeleteReinitializeHBM /workspace/tpu_inference/tests/e2e/test_rl_integration.py::TestLogprobsNoRecompilation
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for rl_integration"
-    key: "${TPU_VERSION:-tpu6e}_record_rl_integration_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_rl_integration_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for rl_integration"
+    key: "${BK_KEY}_record_rl_integration_CorrectnessTest"
+    depends_on: "${BK_KEY}_rl_integration_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "rl_integration"
       CI_STAGE: "CorrectnessTest"
@@ -38,23 +41,26 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_rl_integration_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_rl_integration_CorrectnessTest
 
   # ------------------------------------------------------------------
   # Performance tests
   # ------------------------------------------------------------------
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for rl_integration"
-    key: "${TPU_VERSION:-tpu6e}_rl_integration_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_rl_integration_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for rl_integration"
+    key: "${BK_KEY}_rl_integration_PerformanceTest"
+    depends_on: "${BK_KEY}_record_rl_integration_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - .buildkite/scripts/run_in_docker.sh python3 -m pytest -s -v /workspace/tpu_inference/tests/e2e/test_rl_integration.py::TestLogprobsLatency
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for rl_integration"
-    key: "${TPU_VERSION:-tpu6e}_record_rl_integration_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_rl_integration_PerformanceTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for rl_integration"
+    key: "${BK_KEY}_record_rl_integration_PerformanceTest"
+    depends_on: "${BK_KEY}_rl_integration_PerformanceTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "rl_integration"
       CI_STAGE: "PerformanceTest"
@@ -63,17 +69,17 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_rl_integration_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_rl_integration_PerformanceTest
 
-  - label: "${TPU_VERSION:-tpu6e} E2E MMLU for Llama-3.1-8B continue_decode"
-    key: "${TPU_VERSION:-tpu6e}_rl_integration_continue_decode_mmlu"
-    depends_on: "${TPU_VERSION:-tpu6e}_build_docker"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} E2E MMLU for Llama-3.1-8B continue_decode"
+    key: "${BK_KEY}_rl_integration_continue_decode_mmlu"
+    depends_on: "${BK_KEY}_build_docker"
     soft_fail: true
     env:
       USE_PREBUILT_IMAGE: "1"
       NEW_MODEL_DESIGN: "1"
       SKIP_ACCURACY_TESTS: "False"
-      MODEL_IMPL_TYPE: "vllm"
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       EXTRA_SERVE_ARGS: "--additional-config='{\"enable_continue_decode\": true}'"
     agents:

--- a/.buildkite/rl/rl_integration.yml
+++ b/.buildkite/rl/rl_integration.yml
@@ -19,17 +19,20 @@ steps:
   # ------------------------------------------------------------------
   # Correctness tests
   # ------------------------------------------------------------------
-  - label: "${TPU_VERSION:-tpu6e} Correctness tests for rl_integration"
-    key: "${TPU_VERSION:-tpu6e}_rl_integration_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Correctness tests for rl_integration"
+    key: "${BK_KEY}_rl_integration_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - .buildkite/scripts/run_in_docker.sh python3 -m pytest -s -v /workspace/tpu_inference/tests/e2e/test_rl_integration.py::TestDeleteReinitializeHBM /workspace/tpu_inference/tests/e2e/test_rl_integration.py::TestLogprobsNoRecompilation
-  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for rl_integration"
-    key: "${TPU_VERSION:-tpu6e}_record_rl_integration_CorrectnessTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_rl_integration_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record correctness test result for rl_integration"
+    key: "${BK_KEY}_record_rl_integration_CorrectnessTest"
+    depends_on: "${BK_KEY}_rl_integration_CorrectnessTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "rl_integration"
       CI_STAGE: "CorrectnessTest"
@@ -38,23 +41,26 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_rl_integration_CorrectnessTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_rl_integration_CorrectnessTest
 
   # ------------------------------------------------------------------
   # Performance tests
   # ------------------------------------------------------------------
-  - label: "${TPU_VERSION:-tpu6e} Performance tests for rl_integration"
-    key: "${TPU_VERSION:-tpu6e}_rl_integration_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_record_rl_integration_CorrectnessTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Performance tests for rl_integration"
+    key: "${BK_KEY}_rl_integration_PerformanceTest"
+    depends_on: "${BK_KEY}_record_rl_integration_CorrectnessTest"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - .buildkite/scripts/run_in_docker.sh python3 -m pytest -s -v /workspace/tpu_inference/tests/e2e/test_rl_integration.py::TestLogprobsLatency
-  - label: "${TPU_VERSION:-tpu6e} Record performance test result for rl_integration"
-    key: "${TPU_VERSION:-tpu6e}_record_rl_integration_PerformanceTest"
-    depends_on: "${TPU_VERSION:-tpu6e}_rl_integration_PerformanceTest"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} Record performance test result for rl_integration"
+    key: "${BK_KEY}_record_rl_integration_PerformanceTest"
+    depends_on: "${BK_KEY}_rl_integration_PerformanceTest"
     env:
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "rl_integration"
       CI_STAGE: "PerformanceTest"
@@ -63,16 +69,16 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_rl_integration_PerformanceTest
+        .buildkite/scripts/record_step_result.sh ${BK_KEY}_rl_integration_PerformanceTest
 
-  - label: "${TPU_VERSION:-tpu6e} E2E MMLU for Llama-3.1-8B continue_decode"
-    key: "${TPU_VERSION:-tpu6e}_rl_integration_continue_decode_mmlu"
+  - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} E2E MMLU for Llama-3.1-8B continue_decode"
+    key: "${BK_KEY}_rl_integration_continue_decode_mmlu"
     soft_fail: true
     env:
       USE_PREBUILT_IMAGE: "1"
       NEW_MODEL_DESIGN: "1"
       SKIP_ACCURACY_TESTS: "False"
-      MODEL_IMPL_TYPE: "vllm"
+      MODEL_IMPL_TYPE: "${MODEL_IMPL_TYPE:-vllm}"
       TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       EXTRA_SERVE_ARGS: "--additional-config='{\"enable_continue_decode\": true}'"
     agents:

--- a/.buildkite/rl/rl_integration.yml
+++ b/.buildkite/rl/rl_integration.yml
@@ -73,7 +73,7 @@ steps:
 
   - label: "${TPU_VERSION:-tpu6e} ${MODEL_IMPL_TYPE:-vllm} E2E MMLU for Llama-3.1-8B continue_decode"
     key: "${BK_KEY}_rl_integration_continue_decode_mmlu"
-    depends_on: "${BK_KEY}_build_docker"
+    depends_on: "${TPU_VERSION:-tpu6e}_build_docker"
     soft_fail: true
     env:
       USE_PREBUILT_IMAGE: "1"

--- a/.buildkite/scripts/bootstrap.sh
+++ b/.buildkite/scripts/bootstrap.sh
@@ -156,22 +156,19 @@ set_jax_envs() {
 }
 
 upload_pipeline() {
-    if [ "${MODEL_IMPL_TYPE:-auto}" == "auto" ]; then
-      # Upload JAX pipeline for v6 (default)
-      set_jax_envs v6
-      upload_with_priority .buildkite/pipeline_jax.yml "$JOB_PRIORITY"
-      set_jax_envs unset
+    # Upload JAX pipeline for v6 (default)
+    set_jax_envs v6
+    upload_with_priority .buildkite/pipeline_jax.yml "$JOB_PRIORITY"
+    set_jax_envs unset
 
-      # Upload JAX pipeline for v7
-      set_jax_envs v7
-      upload_with_priority .buildkite/pipeline_jax.yml "$JOB_PRIORITY"
-      set_jax_envs unset
+    # Upload JAX pipeline for v7
+    set_jax_envs v7
+    upload_with_priority .buildkite/pipeline_jax.yml "$JOB_PRIORITY"
+    set_jax_envs unset
 
-      # buildkite-agent pipeline upload .buildkite/pipeline_torch.yml
-      upload_with_priority .buildkite/nightly_releases.yml "$JOB_PRIORITY"
-      upload_with_priority .buildkite/pipeline_pypi.yml "$JOB_PRIORITY"
-    fi
-
+    # buildkite-agent pipeline upload .buildkite/pipeline_torch.yml
+    upload_with_priority .buildkite/nightly_releases.yml "$JOB_PRIORITY"
+    upload_with_priority .buildkite/pipeline_pypi.yml "$JOB_PRIORITY"
     upload_with_priority .buildkite/nightly_verify.yml "$JOB_PRIORITY"
 }
 

--- a/.buildkite/scripts/bootstrap.sh
+++ b/.buildkite/scripts/bootstrap.sh
@@ -175,22 +175,19 @@ set_jax_envs() {
 }
 
 upload_pipeline() {
-    if [ "${MODEL_IMPL_TYPE:-auto}" == "auto" ]; then
-      # Upload JAX pipeline for v6 (default)
-      set_jax_envs v6
-      upload_with_priority .buildkite/pipeline_jax.yml "$JOB_PRIORITY"
-      set_jax_envs unset
+    # Upload JAX pipeline for v6 (default)
+    set_jax_envs v6
+    upload_with_priority .buildkite/pipeline_jax.yml "$JOB_PRIORITY"
+    set_jax_envs unset
 
-      # Upload JAX pipeline for v7
-      set_jax_envs v7
-      upload_with_priority .buildkite/pipeline_jax.yml "$JOB_PRIORITY"
-      set_jax_envs unset
+    # Upload JAX pipeline for v7
+    set_jax_envs v7
+    upload_with_priority .buildkite/pipeline_jax.yml "$JOB_PRIORITY"
+    set_jax_envs unset
 
-      # buildkite-agent pipeline upload .buildkite/pipeline_torch.yml
-      upload_with_priority .buildkite/nightly_releases.yml "$JOB_PRIORITY"
-      upload_with_priority .buildkite/pipeline_pypi.yml "$JOB_PRIORITY"
-    fi
-
+    # buildkite-agent pipeline upload .buildkite/pipeline_torch.yml
+    upload_with_priority .buildkite/nightly_releases.yml "$JOB_PRIORITY"
+    upload_with_priority .buildkite/pipeline_pypi.yml "$JOB_PRIORITY"
     upload_with_priority .buildkite/nightly_verify.yml "$JOB_PRIORITY"
 }
 

--- a/.buildkite/scripts/commit_support_matrices.sh
+++ b/.buildkite/scripts/commit_support_matrices.sh
@@ -22,18 +22,8 @@ TARGET_BRANCH="${BUILDKITE_BRANCH:-main}"
 # Conditional Configuration for Release vs. Nightly
 if [ "${NIGHTLY}" = "1" ]; then
   # Set path and commit message for nightly builds.
-  BASE_PATH="support_matrices/nightly"
-  IMPL_TYPE_SUBDIR="default" # Default implementation subdir
-
-  # Check for specific model implementation type to enable directory isolation.
-  # If MODEL_IMPL_TYPE is 'vllm' or 'flax_nnx', use a implementation-specific subfolder.
-  if [ "${MODEL_IMPL_TYPE:-auto}" = "vllm" ] || [ "${MODEL_IMPL_TYPE:-auto}" = "flax_nnx" ]; then
-    IMPL_TYPE_SUBDIR="${MODEL_IMPL_TYPE}"
-    COMMIT_MESSAGE="[skip ci] Update nightly support matrices for ${MODEL_IMPL_TYPE} (v6e/v7x)"
-  else
-    # Default case: support_matrices/nightly/default
-    COMMIT_MESSAGE="[skip ci] Update nightly support matrices (v6e/v7x)"
-  fi
+  ARTIFACT_DOWNLOAD_PATH="support_matrices/nightly"
+  COMMIT_MESSAGE="[skip ci] Update nightly support matrices (v6e/v7x)"
 else
   # Set path and commit message for release tag builds.
   COMMIT_TAG="${BUILDKITE_TAG:-unknown-tag}"
@@ -59,35 +49,11 @@ git checkout "${TARGET_BRANCH}"
 git reset --hard origin/"${TARGET_BRANCH}"
 
 echo "--- Downloading CSV artifacts"
-# Download without --flat to preserve v6e/ or v7x/ folder structure
-buildkite-agent artifact download "v*/*.csv" "."
+mkdir -p "${ARTIFACT_DOWNLOAD_PATH}"
+buildkite-agent artifact download "*.csv" "${ARTIFACT_DOWNLOAD_PATH}/" --flat
 
-# Iterate through v6 and v7 folders if they exist
-for ver in v6e v7x; do
-  if [ -d "$ver" ]; then
-    if [ "${NIGHTLY}" = "1" ]; then
-      # Nightly layout: support_matrices/nightly/{ver}/{impl_type}
-      TARGET_DIR="${BASE_PATH}/${ver}/${IMPL_TYPE_SUBDIR}"
-    else
-      # Release layout: support_matrices/{ver}
-      TARGET_DIR="${ARTIFACT_DOWNLOAD_PATH}/${ver}"
-    fi
-    echo "Syncing ${ver} artifacts to ${TARGET_DIR}..."
-
-    mkdir -p "${TARGET_DIR}"
-
-    # Move the files to the final destination in the repo
-    mv "${ver}"/*.csv "${TARGET_DIR}/"
-
-    # Clean up the temporary download directory
-    rmdir "${ver}"
-  else
-    echo "No artifacts found for version: ${ver}. Skipping."
-  fi
-done
-
-echo "--- Staging changes"
-git add support_matrices/
+echo "--- Staging downloaded artifacts"
+git add "${ARTIFACT_DOWNLOAD_PATH}"/*.csv
 
 # --- Check for changes before committing ---
 if git diff --quiet --cached; then

--- a/.buildkite/scripts/generate_support_matrices.sh
+++ b/.buildkite/scripts/generate_support_matrices.sh
@@ -163,7 +163,7 @@ process_models() {
                         safe_model_name=$(sanitize_name "$model")
                         local safe_stage_name
                         safe_stage_name=$(sanitize_name "$stage")
-                        local meta_key="${ci_tpu_version}_${framework}_${safe_model_name}_${safe_stage_name}"
+                        local meta_key="result_${ci_tpu_version}_${framework}_${safe_model_name}_${safe_stage_name}"
                         result=$(buildkite-agent meta-data get "${meta_key}" --default "❓ Untested")
                     fi
                     
@@ -253,7 +253,7 @@ process_features() {
                         safe_feature=$(sanitize_name "$feature")
                         local safe_stage
                         safe_stage=$(sanitize_name "$stage")
-                        local meta_key="${ci_tpu_version}_${framework}_${safe_feature}_${safe_stage}"
+                        local meta_key="result_${ci_tpu_version}_${framework}_${safe_feature}_${safe_stage}"
                         result=$(buildkite-agent meta-data get "${meta_key}" --default "❓ Untested")
 
                         # Format any remaining custom strings from upstream configs

--- a/.buildkite/scripts/generate_support_matrices.sh
+++ b/.buildkite/scripts/generate_support_matrices.sh
@@ -17,18 +17,27 @@ set -euo pipefail
 
 ANY_FAILED=false
 
+RUN_V6=$(buildkite-agent meta-data get run_v6_matrix --default 'false')
+RUN_V7=$(buildkite-agent meta-data get run_v7_matrix --default 'false')
+
+if [[ "$RUN_V6" != "true" && "$RUN_V7" != "true" ]]; then
+    echo "--- Skipping matrix generation (No v6 or v7 test data found)"
+    exit 0
+fi
+
 MODEL_LIST_KEY="model-list"
 FEATURE_LIST_KEY="feature-list"
 DEFAULT_FEATURES_FILE=".buildkite/features/default_features.txt"
+FRAMEWORKS=("vllm" "flax_nnx")
 
 # Note: This script assumes the metadata keys contain newline-separated lists.
 mapfile -t model_list < <(buildkite-agent meta-data get "${MODEL_LIST_KEY}" --default "")
 mapfile -t metadata_feature_list < <(buildkite-agent meta-data get "${FEATURE_LIST_KEY}" --default "")
-MODEL_STAGES=("Type" "UnitTest" "Accuracy/Correctness" "Benchmark")
-FEATURE_STAGES=("CorrectnessTest" "PerformanceTest")
-FEATURE_STAGES_QUANTIZATION=("QuantizationMethods" "RecommendedTPUGenerations" "CorrectnessTest" "PerformanceTest")
-FEATURE_STAGES_MICROBENCHMARKS=("CorrectnessTest" "PerformanceTest")
-PARALLELISM_STAGES=("Single-Host CorrectnessTest" "Single-Host PerformanceTest" "Multi-Host CorrectnessTest" "Multi-Host PerformanceTest")
+MODEL_STAGES=("Type" "Machine Type" "Framework" "UnitTest" "Accuracy/Correctness" "Benchmark")
+FEATURE_STAGES=("Machine Type" "Framework" "CorrectnessTest" "PerformanceTest")
+FEATURE_STAGES_QUANTIZATION=("Machine Type" "Framework" "QuantizationMethods" "RecommendedTPUGenerations" "CorrectnessTest" "PerformanceTest")
+FEATURE_STAGES_MICROBENCHMARKS=("Machine Type" "Framework" "CorrectnessTest" "PerformanceTest")
+PARALLELISM_STAGES=("Machine Type" "Framework" "Single-Host CorrectnessTest" "Single-Host PerformanceTest" "Multi-Host CorrectnessTest" "Multi-Host PerformanceTest")
 
 get_tpu_generation() {
     local key="$1"
@@ -55,21 +64,24 @@ get_quantization_method() {
         *) echo "N/A" ;;
     esac
 }
+
+# Helper function to sanitize strings for metadata keys
+sanitize_name() {
+    echo "$1" | tr '/:.[[:space:]]' '_' | sed 's/^_//;s/_$//;s/__\+/_/g'
+}
+
 declare -a model_csv_files=()
 declare -a feature_csv_files=()
 declare -a default_feature_names=()
+declare -a ACTIVE_TPU_CONFIGS=()
 
-# Determine sub-directory based on TPU_VERSION
-if [[ "${TPU_VERSION:-tpu6e}" == "v7"* ]]; then
-    TPU_DIR="v7x"
-    TPU_METADATA_PREFIX="v7"
-else
-    TPU_DIR="v6e"
-    TPU_METADATA_PREFIX="v6"
+if [[ "$RUN_V6" == "true" ]]; then
+    ACTIVE_TPU_CONFIGS+=("tpu6e")
 fi
 
-mkdir -p "${TPU_DIR}"
-echo "Output directory set to: ${TPU_DIR} (Prefix: '${TPU_METADATA_PREFIX}')"
+if [[ "$RUN_V7" == "true" ]]; then
+    ACTIVE_TPU_CONFIGS+=("tpu7x")
+fi
 
 # Parse Default Features File & Set Categories
 if [[ -f "${DEFAULT_FEATURES_FILE}" ]]; then
@@ -83,9 +95,16 @@ if [[ -f "${DEFAULT_FEATURES_FILE}" ]]; then
             feature_name="${BASH_REMATCH[1]}"
             category="${BASH_REMATCH[2]}"
             default_feature_names+=("$feature_name")
-            # Set metadata so we know which CSV to put it in later
-            echo "Setting category for '$feature_name': $category"
-            buildkite-agent meta-data set "${TPU_METADATA_PREFIX}${feature_name}_category" "$category"
+            
+            # Sanitize the feature name for safe use in CI metadata keys
+            safe_feature=$(sanitize_name "$feature_name")
+            
+            # Register the category against all active hardware targets
+            for ci_tpu_version in "${ACTIVE_TPU_CONFIGS[@]}"; do
+                category_key="${ci_tpu_version}_${safe_feature}_category"
+                echo "Setting category for '$feature_name' ($ci_tpu_version): $category"
+                buildkite-agent meta-data set "$category_key" "$category"
+            done
         else
             # Fallback if no category found
             default_feature_names+=("$line")
@@ -98,43 +117,70 @@ fi
 
 # Process Models (Split by Category)
 process_models() {
-    for model in "${model_list[@]:-}"; do
-        if [[ -z "$model" ]]; then continue; fi
-        # Get category (default: text-only)
-        local category
-        category=$(buildkite-agent meta-data get "${TPU_METADATA_PREFIX}${model}_category" --default "text-only")
-        # Use the TPU_DIR prefix for the CSV path
-        local category_csv="${TPU_DIR}/model_support_matrix.csv"
-        # Initialize CSV if not exists
-        if [ ! -f "$category_csv" ]; then
-            echo "Model,Type,UnitTest,Accuracy/Correctness,Benchmark" > "$category_csv"
-            model_csv_files+=("$category_csv")
-        fi
-        # Build Row
-        local row="\"$model\""
-        for stage in "${MODEL_STAGES[@]}"; do
-            local result
-            if [ "$stage" == "Type" ]; then
-                if [ "$category" == "multimodal" ]; then
-                    result="Multimodal"
-                elif [ "$category" == "embedding" ]; then
-                    result="Embedding"
-                elif [ "$category" == "diffusion" ]; then
-                    result="Diffusion"
-                else 
-                    result="Text"
-                fi
-            else
-                result=$(buildkite-agent meta-data get "${TPU_METADATA_PREFIX}${model}:${stage}" --default "❓ Untested")
-            fi
-            row="$row,$result"
+    local category_csv="model_support_matrix.csv"
+    if [ ! -f "$category_csv" ]; then
+        echo "Model,Type,Machine Type,Framework,UnitTest,Accuracy/Correctness,Benchmark" > "$category_csv"
+        model_csv_files+=("$category_csv")
+    fi
 
-            if [ "$stage" != "Type" ] && [ "${result}" != "✅ Passing" ] && [ "${result}" != "⚪ N/A" ] && [ "${result}" != "❓ Untested" ] && [ "${result}" != "not enough HBM" ]; then
+    # Return directly if the model list is empty
+    if [ ${#model_list[@]} -eq 0 ]; then return; fi
 
-                ANY_FAILED=true
-            fi
+    # Iterate through all permutations of frameworks, TPU configs, and models
+    for framework in "${FRAMEWORKS[@]}"; do
+        for ci_tpu_version in "${ACTIVE_TPU_CONFIGS[@]}"; do
+            for model in "${model_list[@]:-}"; do
+                if [[ -z "$model" ]]; then continue; fi
+
+                # Sanitize the model name for Buildkite metadata keys (e.g., replaces / : . with _)
+                local safe_model
+                safe_model=$(sanitize_name "$model")
+
+                # Get the category (default: text-only)
+                local category_key="${ci_tpu_version}_${safe_model}_category"
+                local category
+                category=$(buildkite-agent meta-data get "${category_key}" --default "text-only")
+
+                local row="\"$model\""
+                for stage in "${MODEL_STAGES[@]}"; do
+                    local result
+                    if [ "$stage" == "Type" ]; then
+                        if [ "$category" == "multimodal" ]; then result="Multimodal"
+                        elif [ "$category" == "embedding" ]; then result="Embedding"
+                        elif [ "$category" == "diffusion" ]; then result="Diffusion"
+                        else result="Text"
+                        fi
+                    elif [ "$stage" == "Machine Type" ]; then
+                        if [ "${ci_tpu_version}" == "tpu7x" ]; then
+                            result="v7x"
+                        else
+                            result="v6e"
+                        fi
+                    elif [ "$stage" == "Framework" ]; then
+                        result="${framework}"
+                    else
+                        local safe_model_name
+                        safe_model_name=$(sanitize_name "$model")
+                        local safe_stage_name
+                        safe_stage_name=$(sanitize_name "$stage")
+                        local meta_key="${ci_tpu_version}_${framework}_${safe_model_name}_${safe_stage_name}"
+                        result=$(buildkite-agent meta-data get "${meta_key}" --default "❓ Untested")
+                    fi
+                    
+                    row="$row,$result"
+
+                    # Record if there are any failed tests (excluding Type, Machine Type, and Framework fields)
+                    if [ "$stage" != "Type" ] && [ "$stage" != "Machine Type" ] && [ "$stage" != "Framework" ] && \
+                       [ "${result}" != "✅ Passing" ] && [ "${result}" != "⚪ N/A" ] && \
+                       [ "${result}" != "❓ Untested" ] && [ "${result}" != "not enough HBM" ] && [ "${result}" != "transformers version too low" ]; then
+                        ANY_FAILED=true
+                    fi
+                done
+                
+                # Write the assembled row data into the CSV
+                echo "$row" >> "$category_csv"
+            done
         done
-        echo "$row" >> "$category_csv"
     done
 }
 
@@ -143,85 +189,109 @@ process_features() {
     local mode="$1"
     shift # Shift $1 so $@ now contains only the feature list
 
-    for feature in "$@"; do
-        if [[ -z "$feature" ]]; then continue; fi
+    # Iterate through all permutations of frameworks, TPU environments, and target features
+    for framework in "${FRAMEWORKS[@]}"; do
+        for ci_tpu_version in "${ACTIVE_TPU_CONFIGS[@]}"; do
+            for feature in "$@"; do
+                if [[ -z "$feature" ]]; then continue; fi
 
-        # Get Category (default: feature support matrix)
-        local category
-        category=$(buildkite-agent meta-data get "${TPU_METADATA_PREFIX}${feature}_category" --default "feature support matrix")
+                # Sanitize the feature name for Buildkite metadata lookups
+                local safe_feature
+                safe_feature=$(sanitize_name "$feature")
+                
+                # Get Category (default: feature support matrix)
+                local category_key="${ci_tpu_version}_${safe_feature}_category"
+                local category
+                category=$(buildkite-agent meta-data get "${category_key}" --default "feature support matrix")
+                local category_filename=${category// /_}
+                local category_csv="${category_filename}.csv"
 
-        local category_filename=${category// /_}
-        # Use the TPU_DIR prefix for the CSV path
-        local category_csv="${TPU_DIR}/${category_filename}.csv"
+                # Determine which stages array and header to use
+                local stages_to_use=("${FEATURE_STAGES[@]}")
+                local header="Feature,Machine Type,Framework,CorrectnessTest,PerformanceTest"
+                local is_quantization_matrix=false
 
-        # Determine which stages array and header to use
-        local stages_to_use=("${FEATURE_STAGES[@]}")
-        local header="Feature,CorrectnessTest,PerformanceTest"
-        local is_quantization_matrix=false
-
-        if [ "$category" == "quantization support matrix" ]; then
-            is_quantization_matrix=true
-            stages_to_use=("${FEATURE_STAGES_QUANTIZATION[@]}")
-            header="Quantization dtype,Quantization methods,Recommended TPU Generations,CorrectnessTest,PerformanceTest"
-        elif [ "$category" == "kernel support matrix microbenchmarks" ]; then
-            stages_to_use=("${FEATURE_STAGES_MICROBENCHMARKS[@]}")
-            header="kernels,CorrectnessTest,PerformanceTest"
-        elif [ "$category" == "parallelism support matrix" ]; then
-            stages_to_use=("${PARALLELISM_STAGES[@]}")
-            header="Feature,Single-Host CorrectnessTest,Single-Host PerformanceTest,Multi-Host CorrectnessTest,Multi-Host PerformanceTest"
-        fi
-
-        if [ ! -f "$category_csv" ]; then
-            echo "$header" > "$category_csv"
-            feature_csv_files+=("$category_csv")
-        fi
-
-        # Build Row
-        local row="\"$feature\""
-        local stage_index=0
-        for stage in "${stages_to_use[@]}"; do
-            local result
-            if [ "$is_quantization_matrix" = true ] && [ "$stage" == "RecommendedTPUGenerations" ]; then
-                # If it's the quantization matrix, hardcode the TPU generation
-                result="$(get_tpu_generation "$feature")"
-            elif [ "$is_quantization_matrix" = true ] && [ "$stage" == "QuantizationMethods" ]; then
-                # If it's the quantization matrix, hardcode the quantization methods
-                result="$(get_quantization_method "$feature")"
-
-            elif [[ "$mode" == "DEFAULT" ]]; then
-                result="✅ Passing"
-            else
-                result=$(buildkite-agent meta-data get "${TPU_METADATA_PREFIX}${feature}:${stage}" --default "❓ Untested")
-                # Format any remaining custom strings from upstream configs
-                local result_lower
-                result_lower="$(echo "$result" | tr '[:upper:]' '[:lower:]')"
-                if [[ "$result_lower" == "beta" ]]; then
-                    result="⚠️ Beta"
-                elif [[ "$result_lower" == "experimental" ]]; then
-                    result="🧪 Experimental"
-                elif [[ "$result_lower" == "planned" ]]; then
-                    result="📝 Planned"
-                elif [[ "$result_lower" == "unplanned" ]]; then
-                    result="⛔️ Unplanned"
+                if [ "$category" == "quantization support matrix" ]; then
+                    is_quantization_matrix=true
+                    stages_to_use=("${FEATURE_STAGES_QUANTIZATION[@]}")
+                    header="Quantization dtype,Machine Type,Framework,Quantization methods,Recommended TPU Generations,CorrectnessTest,PerformanceTest"
+                elif [ "$category" == "kernel support matrix microbenchmarks" ]; then
+                    stages_to_use=("${FEATURE_STAGES_MICROBENCHMARKS[@]}")
+                    header="kernels,Machine Type,Framework,CorrectnessTest,PerformanceTest"
+                elif [ "$category" == "parallelism support matrix" ]; then
+                    stages_to_use=("${PARALLELISM_STAGES[@]}")
+                    header="Feature,Machine Type,Framework,Single-Host CorrectnessTest,Single-Host PerformanceTest,Multi-Host CorrectnessTest,Multi-Host PerformanceTest"
                 fi
-            fi
-            row="$row,$result"
 
-            # Check for failure (exclude the hardcoded TPU generation column and Quantization Methods column)
-            if [ "$stage" != "QuantizationMethods" ] && [ "$stage" != "RecommendedTPUGenerations" ] && [[ "${result}" != "✅ Passing" && "${result}" != "⚪ N/A" && "${result}" != "❓ Untested" && "${result}" != "⚠️ Beta" && "${result}" != "🧪 Experimental" && "${result}" != "📝 Planned" && "${result}" != "⛔️ Unplanned" ]]; then
-                ANY_FAILED=true
-            fi
+                if [ ! -f "$category_csv" ]; then
+                    echo "$header" > "$category_csv"
+                    feature_csv_files+=("$category_csv")
+                fi
 
-            stage_index=$((stage_index + 1))
+                # Build Row
+                local row="\"$feature\""
+                local stage_index=0
+                for stage in "${stages_to_use[@]}"; do
+                    local result
+                    
+                    if [ "$is_quantization_matrix" = true ] && [ "$stage" == "RecommendedTPUGenerations" ]; then
+                        result="$(get_tpu_generation "$feature")"
+                    elif [ "$is_quantization_matrix" = true ] && [ "$stage" == "QuantizationMethods" ]; then
+                        result="$(get_quantization_method "$feature")"
+                    elif [ "$stage" == "Machine Type" ]; then
+                        if [ "${ci_tpu_version}" == "tpu7x" ]; then
+                            result="v7x"
+                        else
+                            result="v6e"
+                        fi
+                    elif [ "$stage" == "Framework" ]; then
+                        result="${framework}"
+                    elif [[ "$mode" == "DEFAULT" ]]; then
+                        result="✅ Passing"
+                    else
+                        local safe_feature
+                        safe_feature=$(sanitize_name "$feature")
+                        local safe_stage
+                        safe_stage=$(sanitize_name "$stage")
+                        local meta_key="${ci_tpu_version}_${framework}_${safe_feature}_${safe_stage}"
+                        result=$(buildkite-agent meta-data get "${meta_key}" --default "❓ Untested")
+
+                        # Format any remaining custom strings from upstream configs
+                        local result_lower
+                        result_lower="$(echo "$result" | tr '[:upper:]' '[:lower:]')"
+                        if [[ "$result_lower" == "beta" ]]; then
+                            result="⚠️ Beta"
+                        elif [[ "$result_lower" == "experimental" ]]; then
+                            result="🧪 Experimental"
+                        elif [[ "$result_lower" == "planned" ]]; then
+                            result="📝 Planned"
+                        elif [[ "$result_lower" == "unplanned" ]]; then
+                            result="⛔️ Unplanned"
+                        fi
+                    fi
+                    row="$row,$result"
+
+                    # Check for failure (exclude the descriptive structural columns)
+                    if [ "$stage" != "QuantizationMethods" ] && \
+                       [ "$stage" != "RecommendedTPUGenerations" ] && \
+                       [ "$stage" != "Machine Type" ] && \
+                       [ "$stage" != "Framework" ] && \
+                       [[ "${result}" != "✅ Passing" && "${result}" != "⚪ N/A" && "${result}" != "❓ Untested" && "${result}" != "⚠️ Beta" && "${result}" != "🧪 Experimental" && "${result}" != "📝 Planned" && "${result}" != "⛔️ Unplanned" ]]; then
+                        ANY_FAILED=true
+                    fi
+
+                    stage_index=$((stage_index + 1))
+                done
+                echo "$row" >> "$category_csv"
+            done
         done
-        echo "$row" >> "$category_csv"
     done
 }
 
 # Pivot Logic (Microbenchmarks)
 process_kernel_matrix_to_pivot() {
-    local input_csv="${TPU_DIR}/kernel_support_matrix_microbenchmarks.csv"
-    local output_file="${TPU_DIR}/kernel_support_matrix-microbenchmarks.csv"
+    local input_csv="kernel_support_matrix_microbenchmarks.csv"
+    local output_file="kernel_support_matrix-microbenchmarks.csv"
 
     if [ ! -f "$input_csv" ]; then
         echo "Warning: Input CSV $input_csv not found. Skipping pivot."
@@ -229,12 +299,11 @@ process_kernel_matrix_to_pivot() {
     fi
 
     # Define Headers for Display
-    local header="Kernel,W16 A16 (Corr),W16 A16 (Perf),W8 A8 (Corr),W8 A8 (Perf),W8 A16 (Corr),W8 A16 (Perf),W4 A4 (Corr),W4 A4 (Perf),W4 A8 (Corr),W4 A8 (Perf),W4 A16 (Corr),W4 A16 (Perf)"
+    local header="Kernel microbenchmark,Machine Type,Framework,W16 A16 (Corr),W16 A16 (Perf),W8 A8 (Corr),W8 A8 (Perf),W8 A16 (Corr),W8 A16 (Perf),W4 A4 (Corr),W4 A4 (Perf),W4 A8 (Corr),W4 A8 (Perf),W4 A16 (Corr),W4 A16 (Perf)"
     echo "$header" > "$output_file"
 
     # Define the quantization order to match the header
     local quant_cols_list="w16a16 w8a8 w8a16 w4a4 w4a8 w4a16"
-
 
     # Awk Script for Pivoting (Data Rows)
     awk -v AWK_QUANT_COLS="$quant_cols_list" '
@@ -244,26 +313,42 @@ process_kernel_matrix_to_pivot() {
         }
         
         NR > 1 {
-            gsub(/"/, "", $1);
-            if (match($1, /-(w[0-9]+a[0-9]+)$/)) {
-                quant_type = substr($1, RSTART + 1, RLENGTH - 1);
-                base_kernel_key = substr($1, 1, RSTART - 1);
+            # Map the new 5-column structure from process_features():
+            # $1: Kernel, $2: Machine Type, $3: Framework, $4: Correctness, $5: Performance
+            
+            raw_kernel = $1;
+            gsub(/"/, "", raw_kernel);
+            machine_type = $2;
+            framework = $3;
+            
+            if (match(raw_kernel, /-(w[0-9]+a[0-9]+)$/)) {
+                quant_type = substr(raw_kernel, RSTART + 1, RLENGTH - 1);
+                base_kernel_key = substr(raw_kernel, 1, RSTART - 1);
             } else {
-                 base_kernel_key = $1;
+                 base_kernel_key = raw_kernel;
                  quant_type = "w16a16";
             }
 
-            # Store original Correctness ($2) and Performance ($3)
-            matrix[base_kernel_key, quant_type] = $2 OFS $3;
+            # Create a composite key to group by Kernel + Machine Type + Framework
+            composite_key = base_kernel_key SUBSEP machine_type SUBSEP framework;
 
-            if (! (base_kernel_key in kernels)) {
-                kernels[base_kernel_key] = 1;
-                kernel_list[num_kernels++] = base_kernel_key;
+            # Store Correctness ($4) and Performance ($5) based on the composite key
+            matrix[composite_key, quant_type] = $4 OFS $5;
+
+            # Track unique composite keys to preserve insertion order
+            if (! (composite_key in seen_keys)) {
+                seen_keys[composite_key] = 1;
+                key_list[num_keys++] = composite_key;
             }
         }
         END {
-            for (i=0; i<num_kernels; i++) {
-                k = kernel_list[i];
+            for (i=0; i<num_keys; i++) {
+                composite_key = key_list[i];
+                split(composite_key, parts, SUBSEP);
+                k = parts[1];
+                m_type = parts[2];
+                fw = parts[3];
+                
                 out_name = k;
                 if (out_name == "generic ragged paged attention v3") {
                     out_name = "\"generic ragged paged<br>attention v3*\"";
@@ -275,11 +360,13 @@ process_kernel_matrix_to_pivot() {
                     out_name = "\"" out_name "\"";
                 }
 
-                row = out_name;
+                # Construct the starting row with the new axes
+                row = out_name OFS m_type OFS fw;
+                
                 for (j=1; j<=6; j++) {
                     q = q_order[j];
                     # Use formatted N/A if data is missing
-                    data = (matrix[k, q] == "") ? "❓ Untested,❓ Untested" : matrix[k, q];
+                    data = (matrix[composite_key, q] == "") ? "❓ Untested,❓ Untested" : matrix[composite_key, q];
                     row = row OFS data;
                 }
                 print row >> "'"$output_file"'";
@@ -311,9 +398,8 @@ buildkite-agent meta-data set "CI_TESTS_FAILED" "${ANY_FAILED}"
 for csv_file in "${model_csv_files[@]:-}"; do
     if [[ -n "$csv_file" && -f "$csv_file" ]]; then
         header=$(head -n 1 "$csv_file")
-        # Sort data rows based on the 'Type' column
-        sorted_content=$(tail -n +2 "$csv_file" | sort -t',' -k2,2)
-
+        # Sort by Framework (k4 asc), Machine Type (k3 desc), Type (k2 asc), then Model Name (k1 asc)
+        sorted_content=$(tail -n +2 "$csv_file" | sort -t',' -k4,4 -k3,3r -k2,2 -k1,1V)
         # Reconstruct the file with sorted data
         echo "$header" > "$csv_file"
         echo "$sorted_content" >> "$csv_file"
@@ -328,7 +414,15 @@ done
 for csv_file in "${feature_csv_files[@]:-}"; do
     if [[ -n "$csv_file" && -f "$csv_file" ]]; then
         header=$(head -n 1 "$csv_file")
-        sorted_content=$(tail -n +2 "$csv_file" | sort -V)
+        # Conditionally apply the correct sort pattern based on the matrix type
+        if [[ "$csv_file" == *"quantization"* || "$csv_file" == *"rl_support"* ]]; then
+            # Framework (k3 asc) -> Machine Type (k2 desc) -> Feature (k1 asc)
+            sorted_content=$(tail -n +2 "$csv_file" | sort -t',' -k3,3 -k2,2r -k1,1V)
+        else
+            # Machine Type (k2 desc) -> Framework (k3 asc) -> Feature (k1 asc)
+            sorted_content=$(tail -n +2 "$csv_file" | sort -t',' -k2,2r -k3,3 -k1,1V)
+        fi
+
         echo "$header" > "$csv_file"
         echo "$sorted_content" >> "$csv_file"
         
@@ -349,4 +443,4 @@ process_kernel_matrix_to_pivot
 echo "Reports uploaded successfully."
 
 # Cleanup
-rm -rf "${TPU_DIR}"
+rm -f "${model_csv_files[@]}" "${feature_csv_files[@]}"

--- a/.buildkite/scripts/record_step_result.sh
+++ b/.buildkite/scripts/record_step_result.sh
@@ -60,7 +60,7 @@ esac
 # Save the results using the hardware-specific prefix.
 SAFE_TARGET=$(echo "$CI_TARGET" | tr '/:.[[:space:]]' '_' | sed 's/^_//;s/_$//;s/__\+/_/g')
 SAFE_STAGE=$(echo "$CI_STAGE" | tr '/:.[[:space:]]' '_' | sed 's/^_//;s/_$//;s/__\+/_/g')
-SAFE_META_KEY="${CI_TPU_VERSION}_${MODEL_IMPL_TYPE}_${SAFE_TARGET}_${SAFE_STAGE}"
+SAFE_META_KEY="result_${CI_TPU_VERSION}_${MODEL_IMPL_TYPE}_${SAFE_TARGET}_${SAFE_STAGE}"
 
 buildkite-agent meta-data set "${CI_TPU_VERSION}_${SAFE_TARGET}_category" "${CI_CATEGORY}"
 buildkite-agent meta-data set "${SAFE_META_KEY}" "${message}"

--- a/.buildkite/scripts/record_step_result.sh
+++ b/.buildkite/scripts/record_step_result.sh
@@ -22,12 +22,6 @@ fi
 
 STEP_KEY="$1"
 
-# Determine the prefix based on hardware version to prevent data collisions.
-TPU_METADATA_PREFIX="v6"
-if echo "${CI_TPU_VERSION}" | grep -qi "tpu7x"; then
-  TPU_METADATA_PREFIX="v7"
-fi
-
 echo "--- Checking ${STEP_KEY} Outcome (Hardware: ${CI_TPU_VERSION:-v6})"
 
 # Try to get the custom string you saved
@@ -55,15 +49,22 @@ case $OUTCOME in
   "not enough HBM")
     message="not enough HBM"
     ;;
+  "transformers version too low")
+    message="transformers version too low"
+    ;;
   *)
     message="❌ Failing"
     ;;
 esac
 
 # Save the results using the hardware-specific prefix.
-buildkite-agent meta-data set "${TPU_METADATA_PREFIX}${CI_TARGET}_category" "${CI_CATEGORY}"
-buildkite-agent meta-data set "${TPU_METADATA_PREFIX}${CI_TARGET}:${CI_STAGE}" "${message}"
+SAFE_TARGET=$(echo "$CI_TARGET" | tr '/:.[[:space:]]' '_' | sed 's/^_//;s/_$//;s/__\+/_/g')
+SAFE_STAGE=$(echo "$CI_STAGE" | tr '/:.[[:space:]]' '_' | sed 's/^_//;s/_$//;s/__\+/_/g')
+SAFE_META_KEY="${CI_TPU_VERSION}_${MODEL_IMPL_TYPE}_${SAFE_TARGET}_${SAFE_STAGE}"
 
-if [ "${OUTCOME}" != "passed" ] && [ "${OUTCOME}" != "skipped" ] && [ "${OUTCOME}" != "unverified" ] && [ "${OUTCOME}" != "not enough HBM" ]; then
+buildkite-agent meta-data set "${CI_TPU_VERSION}_${SAFE_TARGET}_category" "${CI_CATEGORY}"
+buildkite-agent meta-data set "${SAFE_META_KEY}" "${message}"
+
+if [ "${OUTCOME}" != "passed" ] && [ "${OUTCOME}" != "skipped" ] && [ "${OUTCOME}" != "unverified" ] && [ "${OUTCOME}" != "not enough HBM" ] && [ "${OUTCOME}" != "transformers version too low" ]; then
     exit 1
 fi

--- a/.buildkite/scripts/upload_models_and_features.sh
+++ b/.buildkite/scripts/upload_models_and_features.sh
@@ -20,18 +20,9 @@ BUILDKITE_DIR=".buildkite"
 MODEL_LIST_KEY="model-list"
 FEATURE_LIST_KEY="feature-list"
 
-MODEL_IMPL_TYPE="${MODEL_IMPL_TYPE:-auto}"
-
-# Validate inputs that will later be interpolated into uploaded pipeline YAML.
-# Reject anything that isn't on the allowlist / numeric to prevent injection of
-# extra YAML keys (e.g. via embedded newlines or quotes) through env vars.
-case "${MODEL_IMPL_TYPE}" in
-  auto|flax_nnx|vllm) ;;
-  *)
-    echo "ERROR: MODEL_IMPL_TYPE must be one of auto|flax_nnx|vllm, got: '${MODEL_IMPL_TYPE}'"
-    exit 1
-    ;;
-esac
+# Define the target execution frameworks. 
+# The script iterates through these to set MODEL_IMPL_TYPE and generate separate pipeline groups.
+FRAMEWORKS=("vllm" "flax_nnx")
 
 if [[ ! "${JOB_PRIORITY:-1}" =~ ^-?[0-9]+$ ]]; then
   echo "ERROR: JOB_PRIORITY must be an integer, got: '${JOB_PRIORITY:-}'"
@@ -64,18 +55,8 @@ add_kernel_microbenchmarks() {
   fi
 }
 
-case "${MODEL_IMPL_TYPE}" in
-  "auto")
-    TARGET_FOLDERS=("parallelism" "models" "features" "rl")
-    add_kernel_microbenchmarks
-    ;;
-  "flax_nnx")
-    TARGET_FOLDERS=("quantization" "parallelism" "features")
-    ;;
-  "vllm")
-    TARGET_FOLDERS=("quantization" "parallelism" "models" "features")
-    ;;
-esac
+TARGET_FOLDERS=("quantization" "parallelism" "models" "features" "rl")
+add_kernel_microbenchmarks
 
 # Arrays to store YAML content fragments (without 'steps:' header)
 pipeline_v6e_fragments=()
@@ -84,7 +65,6 @@ pipeline_v7x_fragments=()
 # Declare separate arrays for each list
 declare -a model_list
 declare -a feature_list
-
 
 for folder_path in "${TARGET_FOLDERS[@]}"; do
   folder=$BUILDKITE_DIR/$folder_path
@@ -158,14 +138,22 @@ if [[ "${#pipeline_v6e_fragments[@]}" -gt 0 ]]; then
   export TENSOR_PARALLEL_SIZE_SINGLE=1
   export TENSOR_PARALLEL_SIZE_MULTI=8
   buildkite-agent meta-data set "run_v6_matrix" "true"
-  {
-    echo "priority: ${JOB_PRIORITY:-1}"
-    echo "steps:"
-    echo "  - group: \"TPU v6e nightly Tests (${MODEL_IMPL_TYPE:-auto})\""
-    echo "    key: \"v6e-group\""
-    echo "    steps:"
-    printf "%s\n" "${pipeline_v6e_fragments[@]}" | sed 's/^/      /'
-  } | buildkite-agent pipeline upload
+  
+  # Loop through each model implementation type
+  for IMPL_TYPE in "${FRAMEWORKS[@]}"; do
+    export MODEL_IMPL_TYPE="${IMPL_TYPE}"
+    # Standardize prefix to keep buildkite step keys under the 100-character linter limit
+    export BK_KEY="${TPU_VERSION}_${MODEL_IMPL_TYPE}"
+    echo "Uploading v6e pipeline group for: ${MODEL_IMPL_TYPE}"
+    {
+      echo "priority: ${JOB_PRIORITY:-1}"
+      echo "steps:"
+      echo "  - group: \"TPU v6e nightly Tests (${MODEL_IMPL_TYPE})\""
+      echo "    key: \"v6e-group-${MODEL_IMPL_TYPE}\""
+      echo "    steps:"
+      printf "%s\n" "${pipeline_v6e_fragments[@]}" | sed 's/^/      /'
+    } | buildkite-agent pipeline upload
+  done
 else
   echo "--- No .yml files found, nothing to upload."
   exit 0
@@ -180,14 +168,22 @@ if [[ "${#pipeline_v7x_fragments[@]}" -gt 0 ]]; then
   export TENSOR_PARALLEL_SIZE_SINGLE=2
   export TENSOR_PARALLEL_SIZE_MULTI=8
   buildkite-agent meta-data set "run_v7_matrix" "true"
-  {
-    echo "priority: ${JOB_PRIORITY:-1}"
-    echo "steps:"
-    echo "  - group: \"TPU v7x nightly Tests (${MODEL_IMPL_TYPE:-auto})\""
-    echo "    key: \"v7x-group\""
-    echo "    steps:"
-    printf "%s\n" "${pipeline_v7x_fragments[@]}" | sed 's/^/      /'
-  } | buildkite-agent pipeline upload
+
+  # Loop through each model implementation type
+  for IMPL_TYPE in "${FRAMEWORKS[@]}"; do
+    export MODEL_IMPL_TYPE="${IMPL_TYPE}"
+    # Standardize prefix to keep buildkite step keys under the 100-character linter limit
+    export BK_KEY="${TPU_VERSION}_${MODEL_IMPL_TYPE}"
+    echo "Uploading v7x pipeline group for: ${MODEL_IMPL_TYPE}"
+    {
+      echo "priority: ${JOB_PRIORITY:-1}"
+      echo "steps:"
+      echo "  - group: \"TPU v7x nightly Tests (${MODEL_IMPL_TYPE})\""
+      echo "    key: \"v7x-group-${MODEL_IMPL_TYPE}\""
+      echo "    steps:"
+      printf "%s\n" "${pipeline_v7x_fragments[@]}" | sed 's/^/      /'
+    } | buildkite-agent pipeline upload
+  done
 else
   echo "--- No .yml files found, nothing to upload."
   exit 0

--- a/.buildkite/scripts/upload_models_and_features.sh
+++ b/.buildkite/scripts/upload_models_and_features.sh
@@ -20,18 +20,9 @@ BUILDKITE_DIR=".buildkite"
 MODEL_LIST_KEY="model-list"
 FEATURE_LIST_KEY="feature-list"
 
-MODEL_IMPL_TYPE="${MODEL_IMPL_TYPE:-auto}"
-
-# Validate inputs that will later be interpolated into uploaded pipeline YAML.
-# Reject anything that isn't on the allowlist / numeric to prevent injection of
-# extra YAML keys (e.g. via embedded newlines or quotes) through env vars.
-case "${MODEL_IMPL_TYPE}" in
-  auto|flax_nnx|vllm) ;;
-  *)
-    echo "ERROR: MODEL_IMPL_TYPE must be one of auto|flax_nnx|vllm, got: '${MODEL_IMPL_TYPE}'"
-    exit 1
-    ;;
-esac
+# Define the target execution frameworks. 
+# The script iterates through these to set MODEL_IMPL_TYPE and generate separate pipeline groups.
+FRAMEWORKS=("vllm" "flax_nnx")
 
 if [[ ! "${JOB_PRIORITY:-1}" =~ ^-?[0-9]+$ ]]; then
   echo "ERROR: JOB_PRIORITY must be an integer, got: '${JOB_PRIORITY:-}'"
@@ -64,18 +55,8 @@ add_kernel_microbenchmarks() {
   fi
 }
 
-case "${MODEL_IMPL_TYPE}" in
-  "auto")
-    TARGET_FOLDERS=("parallelism" "models" "features" "rl")
-    add_kernel_microbenchmarks
-    ;;
-  "flax_nnx")
-    TARGET_FOLDERS=("quantization" "parallelism" "features")
-    ;;
-  "vllm")
-    TARGET_FOLDERS=("quantization" "parallelism" "models" "features")
-    ;;
-esac
+TARGET_FOLDERS=("quantization" "parallelism" "models" "features" "rl")
+add_kernel_microbenchmarks
 
 # Arrays to store YAML content fragments (without 'steps:' header)
 pipeline_v6e_fragments=()
@@ -84,7 +65,6 @@ pipeline_v7x_fragments=()
 # Declare separate arrays for each list
 declare -a model_list
 declare -a feature_list
-
 
 for folder_path in "${TARGET_FOLDERS[@]}"; do
   folder=$BUILDKITE_DIR/$folder_path
@@ -158,15 +138,23 @@ if [[ "${#pipeline_v6e_fragments[@]}" -gt 0 ]]; then
   export TENSOR_PARALLEL_SIZE_SINGLE=1
   export TENSOR_PARALLEL_SIZE_MULTI=8
   buildkite-agent meta-data set "run_v6_matrix" "true"
-  {
-    echo "priority: ${JOB_PRIORITY:-1}"
-    echo "steps:"
-    echo "  - group: \"TPU v6e nightly Tests (${MODEL_IMPL_TYPE:-auto})\""
-    echo "    key: \"v6e-group\""
-    echo "    depends_on: \"build_docker\""
-    echo "    steps:"
-    printf "%s\n" "${pipeline_v6e_fragments[@]}" | sed 's/^/      /'
-  } | buildkite-agent pipeline upload
+  
+  # Loop through each model implementation type
+  for IMPL_TYPE in "${FRAMEWORKS[@]}"; do
+    export MODEL_IMPL_TYPE="${IMPL_TYPE}"
+    # Standardize prefix to keep buildkite step keys under the 100-character linter limit
+    export BK_KEY="${TPU_VERSION}_${MODEL_IMPL_TYPE}"
+    echo "Uploading v6e pipeline group for: ${MODEL_IMPL_TYPE}"
+    {
+      echo "priority: ${JOB_PRIORITY:-1}"
+      echo "steps:"
+      echo "  - group: \"TPU v6e nightly Tests (${MODEL_IMPL_TYPE})\""
+      echo "    key: \"v6e-group-${MODEL_IMPL_TYPE}\""
+      echo "    depends_on: \"build_docker\""
+      echo "    steps:"
+      printf "%s\n" "${pipeline_v6e_fragments[@]}" | sed 's/^/      /'
+    } | buildkite-agent pipeline upload
+  done
 else
   echo "--- No .yml files found, nothing to upload."
   exit 0
@@ -181,15 +169,23 @@ if [[ "${#pipeline_v7x_fragments[@]}" -gt 0 ]]; then
   export TENSOR_PARALLEL_SIZE_SINGLE=2
   export TENSOR_PARALLEL_SIZE_MULTI=8
   buildkite-agent meta-data set "run_v7_matrix" "true"
-  {
-    echo "priority: ${JOB_PRIORITY:-1}"
-    echo "steps:"
-    echo "  - group: \"TPU v7x nightly Tests (${MODEL_IMPL_TYPE:-auto})\""
-    echo "    key: \"v7x-group\""
-    echo "    depends_on: \"build_docker\""
-    echo "    steps:"
-    printf "%s\n" "${pipeline_v7x_fragments[@]}" | sed 's/^/      /'
-  } | buildkite-agent pipeline upload
+
+  # Loop through each model implementation type
+  for IMPL_TYPE in "${FRAMEWORKS[@]}"; do
+    export MODEL_IMPL_TYPE="${IMPL_TYPE}"
+    # Standardize prefix to keep buildkite step keys under the 100-character linter limit
+    export BK_KEY="${TPU_VERSION}_${MODEL_IMPL_TYPE}"
+    echo "Uploading v7x pipeline group for: ${MODEL_IMPL_TYPE}"
+    {
+      echo "priority: ${JOB_PRIORITY:-1}"
+      echo "steps:"
+      echo "  - group: \"TPU v7x nightly Tests (${MODEL_IMPL_TYPE})\""
+      echo "    key: \"v7x-group-${MODEL_IMPL_TYPE}\""
+      echo "    depends_on: \"build_docker\""
+      echo "    steps:"
+      printf "%s\n" "${pipeline_v7x_fragments[@]}" | sed 's/^/      /'
+    } | buildkite-agent pipeline upload
+  done
 else
   echo "--- No .yml files found, nothing to upload."
   exit 0

--- a/.buildkite/scripts/validate_pipeline_metadata.sh
+++ b/.buildkite/scripts/validate_pipeline_metadata.sh
@@ -171,6 +171,7 @@ while IFS= read -r file; do
         validate_field "CI_TPU_VERSION" "$file" "Specifies the TPU hardware generation (e.g., tpu6e, tpu7x) required for this test."
         validate_field "CI_STAGE"      "$file" "Defines the testing phase (e.g., UnitTest, Accuracy/Correctness, Benchmark, CorrectnessTest, PerformanceTest, Single-Host CorrectnessTest, Single-Host PerformanceTest, Multi-Host CorrectnessTest, Multi-Host PerformanceTest."
         validate_field "CI_CATEGORY"   "$file" "Determines which support matrix (e.g., multimodal, text-only, feature support matrix) the results belong to."
+        validate_field "MODEL_IMPL_TYPE" "$file" "Defines the model implementation type (e.g., vllm, flax_nnx)."
 
         # Extract values for consistency checks
         C_CAT=$(yq '.steps[].env.CI_CATEGORY | select(. != null)' "$file" | head -1 || true)
@@ -246,11 +247,11 @@ while IFS= read -r file; do
         done < <(echo "$ALL_FILE_STAGES")
 
         # Step key and label format (prefix check)
-        INVALID_KEYS=$(yq '.steps[] | select(.key != null and (.key | test("^\$\{TPU_VERSION(:-|\})") | not)) | .key' "$file")
+        INVALID_KEYS=$(yq '.steps[] | select(.key != null and (.key | test("^\$\{BK_KEY(:-|\})") | not)) | .key' "$file")
         if [[ -n "$INVALID_KEYS" ]]; then
             echo "+++ ❌ Error: Invalid key format in $file"
-            echo "Found keys: $INVALID_KEYS"
-            echo "💡 Tip: All step keys must start with '\${TPU_VERSION}'."
+            echo "Found keys without \${BK_KEY} prefix: $INVALID_KEYS"
+            echo "💡 Tip: All step keys must start with \${BK_KEY} to ensure unique identification."
             echo ""
             ERRORS_FOUND=1
         fi
@@ -263,7 +264,7 @@ while IFS= read -r file; do
             echo ""
             ERRORS_FOUND=1
         fi
-
+        
         # Recording step consistency (record_step_result.sh)
         RECORD_STEPS_JSON=$(yq '[.steps[] | select(.commands != null) | select(.commands[] | test("record_step_result.sh"))]' -o json "$file" || echo "[]")
 


### PR DESCRIPTION
# Description

[b/517804528](https://buganizer.corp.google.com/issues/517804528)

Refactor the report architecture of the support matrix to save information such as the TPU version and MODEL_IMPL_TYPE into a CSV file instead of categorizing them by folders.

The nightly build will also remove the build for MODEL_IMPL_TYPE="auto", leaving only vllm + flax_nnx, and will use the same Buildkite scheduler trigger.

[mockup support matrices](https://docs.google.com/spreadsheets/d/1Iropa_9ru6xC8OVTeYocXbOLzxOiWIv5WVLOuBSrmsY/edit?gid=429837327#gid=429837327)

(A subsequent PR will be created to clean up and remove the legacy nightly support_matrices.)


# Tests

[BuildKite](https://buildkite.com/tpu-commons/tpu-inference-ci/builds/20132/list?sid=019eca10-313b-4c9e-b3f1-64bc0c56a39e&tab=output)

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
