### PR TITLE
Use newer mm-data encoder interface when possible

### DIFF
--- a/tests/models/vllm/test_mm_encoder_manager.py
+++ b/tests/models/vllm/test_mm_encoder_manager.py
@@ -1,0 +1,80 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+from vllm.config import (CompilationConfig, ModelConfig, MultiModalConfig,
+                         VllmConfig)
+from vllm.model_executor.models.interfaces import SupportsEncoderCudaGraph
+from vllm.v1.worker.encoder_cudagraph_defs import EncoderCudaGraphConfig
+
+from tpu_inference.models.vllm.mm_encoder_manager import MMEncoderManager
+
+
+def test_mm_encoder_manager_init():
+
+    class DummyModel(SupportsEncoderCudaGraph):
+
+        def get_encoder_cudagraph_config(self) -> EncoderCudaGraphConfig:
+            return EncoderCudaGraphConfig(
+                modalities=["image", "video"],
+                buffer_keys=["input_tensors"],
+                out_hidden_size=768,
+                max_frames_per_video=5,
+            )
+
+        def get_encoder_cudagraph_budget_range(
+            self,
+            vllm_config: VllmConfig,
+        ) -> tuple[int, int]:
+            return (128, 512)
+
+        def prepare_encoder_cudagraph_capture_inputs(
+            self,
+            token_budget: int,
+            max_batch_size: int,
+            max_frames_per_batch: int,
+            device: torch.device,
+            dtype: torch.dtype,
+        ):
+            return {"input_tensors": torch.zeros((1, ))}
+
+    vllm_config = VllmConfig(
+        model_config=ModelConfig(
+            dtype=torch.float16,
+            multimodal_config=MultiModalConfig(limit_per_prompt={
+                "video": 0,
+            }, ),
+        ),
+        compilation_config=CompilationConfig(
+            encoder_cudagraph_token_budgets=[],
+            encoder_cudagraph_max_vision_items_per_batch=0,
+            encoder_cudagraph_max_frames_per_batch=None,
+        ),
+    )
+
+    # Initialize MMEncoderManager
+    manager = MMEncoderManager(vllm_config, DummyModel())
+
+    assert manager.dtype == torch.float16
+    assert manager.token_budgets == [128, 256, 512]
+    assert manager.max_batch_size == 4  # 512 // 128 = 4
+    assert manager.max_frames_per_batch == 0
+    assert list(manager.by_budget) == [128, 256, 512]
+
+
+def test_generate_budgets():
+    budgets = MMEncoderManager._generate_budgets(100, 1000)
+
+    # Note that we always include the max budget
+    assert budgets == [100, 200, 400, 800, 1000]

--- a/tpu_inference/models/vllm/mm_encoder_manager.py
+++ b/tpu_inference/models/vllm/mm_encoder_manager.py
@@ -1,0 +1,166 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Any
+
+import torch
+from vllm.config import VllmConfig
+from vllm.model_executor.models.interfaces import SupportsEncoderCudaGraph
+from vllm.utils.torch_utils import set_default_torch_num_threads
+
+
+class MMEncoderManager:
+    """
+    The helper for multi-modal data processing.
+    
+    Responsible for most initialization task from vllm EncoderCudaGraphManager.
+    """
+
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        model: SupportsEncoderCudaGraph,
+    ):
+
+        self.config = model.get_encoder_cudagraph_config()
+        self.dtype = vllm_config.model_config.dtype
+
+        multimodal_config = vllm_config.model_config.multimodal_config
+        assert multimodal_config is not None
+
+        token_budgets, max_batch_size = self._build_budgets_and_batch(
+            vllm_config,
+            model,
+        )
+        self.token_budgets = token_budgets
+        """Sorted (ascending) list of token budgets."""
+        self.max_batch_size = max_batch_size
+
+        self.max_frames_per_batch = self._build_max_frames(
+            vllm_config,
+            self.max_batch_size,
+            self.config,
+        )
+
+        self.by_budget = {
+            budget:
+            self._build_inputs(
+                model,
+                budget,
+                self.max_batch_size,
+                self.max_frames_per_batch,
+                self.dtype,
+            )
+            for budget in self.token_budgets
+        }
+        """The "input tensors" for each token budget."""
+
+    @staticmethod
+    def _build_budgets_and_batch(
+        vllm_config: VllmConfig,
+        model: SupportsEncoderCudaGraph,
+    ) -> tuple[list[int], int]:
+        comp_config = vllm_config.compilation_config
+        user_budgets = comp_config.encoder_cudagraph_token_budgets
+        user_max_vision_items = comp_config.encoder_cudagraph_max_vision_items_per_batch
+        min_budget, max_budget = model.get_encoder_cudagraph_budget_range(
+            vllm_config)
+        assert min_budget > 0 and max_budget > 0
+        assert min_budget <= max_budget
+
+        if user_max_vision_items > 0:
+            # User provided max_vision_items only; adjust auto-inferred
+            # budgets so min(budgets) >= max_batch_size.
+            effective_min = max(min_budget, user_max_vision_items)
+            token_budgets = MMEncoderManager._generate_budgets(
+                effective_min,
+                max_budget,
+            )
+            return token_budgets, user_max_vision_items
+        elif user_budgets:
+            # User provided budgets only; cap auto-inferred
+            # max_batch_size to min(user_budgets).
+            token_budgets = sorted(user_budgets)
+            max_batch_size = min(
+                max_budget // min_budget,
+                min(token_budgets),
+            )
+            return token_budgets, max_batch_size
+        else:
+            # Fully auto-inferred.
+            token_budgets = MMEncoderManager._generate_budgets(
+                min_budget,
+                max_budget,
+            )
+            max_batch_size = min(
+                max_budget // min_budget,
+                min(token_budgets),
+            )
+            return token_budgets, max_batch_size
+
+    @staticmethod
+    def _build_max_frames(
+        vllm_config: VllmConfig,
+        max_batch_size: int,
+        config: Any,
+    ) -> int:
+        comp_config = vllm_config.compilation_config
+        multimodal_config = vllm_config.model_config.multimodal_config
+        assert multimodal_config is not None
+
+        user_max_frames = comp_config.encoder_cudagraph_max_frames_per_batch
+
+        if multimodal_config.get_limit_per_prompt("video") == 0:
+            return 0
+        elif user_max_frames is not None:
+            return user_max_frames
+        else:
+            # Set it to the model-specific value from config.
+            return max_batch_size * config.max_frames_per_video
+
+    @staticmethod
+    def _build_inputs(
+        model: SupportsEncoderCudaGraph,
+        token_budget: int,
+        max_batch_size: int,
+        max_frames_per_batch: int,
+        dtype: torch.dtype,
+    ) -> dict[str, torch.Tensor]:
+        # Temporary overriding this value here can help mitigate an
+        # assertion error in OpenMP (libgomp) shipped with PyTorch (2.10).
+        # that breaks for budget 512 for model Qwen/Qwen3-VL-2B-Thinking.
+        with set_default_torch_num_threads(None):
+            inputs = model.prepare_encoder_cudagraph_capture_inputs(
+                token_budget,
+                max_batch_size,
+                max_frames_per_batch,
+                device=torch.device("cpu"),
+                dtype=dtype,
+            ).values
+
+        return inputs
+
+    @staticmethod
+    def _generate_budgets(min_budget: int, max_budget: int) -> list[int]:
+        """Generate power-of-2 token budgets from min_budget to max_budget."""
+        # Copied from EncoderCudaGraphManager directly.
+        budgets: list[int] = []
+        b = min_budget
+        while b <= max_budget:
+            budgets.append(b)
+            b *= 2
+        # Always include max_budget if it's not already a power-of-2 boundary
+        if not budgets or budgets[-1] < max_budget:
+            budgets.append(max_budget)
+        return budgets

--- a/tpu_inference/runner/multimodal_manager.py
+++ b/tpu_inference/runner/multimodal_manager.py
@@ -12,21 +12,58 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Protocol, cast
 
 import jax
 import jax.numpy as jnp
 import numpy as np
+import torch
+import torchax
+from torchax.interop import jax_view, torch_view
+from torchax.ops.mappings import t2j
+from vllm.ir import enable_torch_wrap
 from vllm.model_executor.layers.rotary_embedding import MRotaryEmbedding
-from vllm.multimodal.inputs import MultiModalKwargsItem, PlaceholderRange
+from vllm.multimodal.inputs import (MultiModalKwargsItem, NestedTensors,
+                                    PlaceholderRange)
 from vllm.multimodal.utils import group_and_batch_mm_kwargs
 from vllm.v1.core.sched.output import SchedulerOutput as VllmSchedulerOutput
 
+import tpu_inference.envs
+from tpu_inference.logger import init_logger
 from tpu_inference.models.jax.utils.multi_modal_utils import \
     sanity_check_mm_encoder_outputs
+from tpu_inference.models.vllm.mm_encoder_manager import MMEncoderManager
 
 if TYPE_CHECKING:
+    from vllm.model_executor.models.interfaces import SupportsEncoderCudaGraph
+
+    from tpu_inference.models.common.interface import ModelInterface
+    from tpu_inference.models.vllm.vllm_model_wrapper import _VllmRunner
     from tpu_inference.runner.tpu_runner import TPUModelRunner
+
+logger = init_logger(__name__)
+
+
+class _EncoderGraphForward(Protocol):
+
+    def __call__(
+        self,
+        params_and_buffers: dict[str, jax.Array],
+        inputs: dict[str, jax.Array],
+    ) -> jax.Array:
+        """The forward function for encoder graph of multi modal data."""
+        ...
+
+
+def _to_tpu(v: torch.Tensor | None) -> torch.Tensor | None:
+    """Move the tensor to TPU and replicate it across the mesh."""
+
+    # None does occur as some field values of mm_kwargs in some model,
+    # like Qwen 3 VL, during prepare_encoder_cudagraph_replay_buffers.
+    if v is None:
+        return None
+
+    return torch_view(t2j(v, use_dlpack=False))
 
 
 class MultiModalManager:
@@ -270,3 +307,248 @@ class MultiModalManager:
         assert target_pad_len == is_mm_embed.shape[0]
 
         return mm_embeds, is_mm_embed
+
+    def optional_encoder_graph_optimization(
+        self,
+        embed_multimodal_fn,
+        precompile_vision_encoder_fn,
+    ):
+        original_functions = (
+            embed_multimodal_fn,
+            precompile_vision_encoder_fn,
+        )
+
+        # Only support using SupportsEncoderCudaGraph in torchax path.
+        if tpu_inference.envs.MODEL_IMPL_TYPE != "vllm":
+            return original_functions
+
+        runner = self.runner
+
+        from vllm.model_executor.models.interfaces import \
+            supports_encoder_cudagraph
+
+        # Try detect the support of SupportsEncoderCudaGraph
+        # and initialized required fields.
+        model_interface: "ModelInterface" = runner.model
+        vllm_runner: "_VllmRunner" = model_interface.model
+        use_graph_feature: bool = all([
+            supports_encoder_cudagraph(vllm_runner.vllm_model),
+            runner.vllm_config.compilation_config.cudagraph_mm_encoder,
+        ])
+        if not use_graph_feature:
+            return original_functions
+
+        logger.warning(
+            "Detect the implementation of SupportsEncoderCudaGraph. "
+            "Overriding embed_multimodal_fn and precompile_vision_encoder_fn.",
+        )
+
+        model: "SupportsEncoderCudaGraph" = vllm_runner.vllm_model
+        manager = MMEncoderManager(
+            runner.vllm_config,
+            model,
+        )
+        graph_config = manager.config
+        padding_logics = graph_config.padding_logics
+
+        @jax.jit
+        def graph_forward_wrapper(
+            params_and_buffers: dict[str, jax.Array],
+            inputs: dict[str, jax.Array],
+        ) -> jax.Array:
+
+            torch_inputs = torch_view(inputs)
+            # Note that we didn't activate torchax environment here,
+            # as we leaves the responsibility to the caller of this func.
+            torch_results = torch.func.functional_call(
+                vllm_runner,
+                torch_view(params_and_buffers),
+                kwargs={
+                    "call_method": "encoder_cudagraph_forward",
+                    "call_args": (torch_inputs, ),
+                    "call_kwargs": {},
+                },
+                tie_weights=False,
+            )
+            results = jax_view(torch_results)
+
+            return results
+
+        encoder_graph_forward = cast(
+            _EncoderGraphForward,
+            graph_forward_wrapper,
+        )
+
+        params: dict[str, jax.Array] = runner.state
+
+        def precompile_encoder_graph(
+                run_compilation: Any,  # see CompilationManger._run_compilation
+        ) -> None:
+
+            def job(budget: int) -> None:
+                inputs = manager.by_budget[budget]
+                with (
+                        torchax.default_env(),
+                        enable_torch_wrap(False),
+                ):
+                    inputs = jax.tree.map(_to_tpu, inputs)
+                    _ = encoder_graph_forward(params, jax_view(inputs))
+
+            for budget in manager.token_budgets:
+                run_compilation(
+                    "multimodal_encoder_graph_forward",
+                    job,
+                    budget,
+                    budget=budget,
+                )
+
+        def embed_multimodal_graph_forward_all(
+            jax_params_and_buffers: dict[str, jax.Array],
+            **mm_kwargs: dict[str, NestedTensors],
+        ) -> list[jax.Array]:
+
+            def get_fit_val(values: list[int], value: int) -> int | None:
+                # assume the values are ascending sorted.
+                for v in values:
+                    if v >= value:
+                        return v
+                return None
+
+            item_specs = model.get_encoder_cudagraph_item_specs(mm_kwargs)
+            num_items = len(item_specs)
+            out_tokens = [spec.output_tokens for spec in item_specs]
+
+            # batches is a list of (expected budget, list of item ID)"""
+            batches: list[tuple[int | None, list[int]]] = []
+            sorted_indices = sorted(
+                range(num_items),
+                key=lambda i: out_tokens[i],
+            )
+
+            # Greedy packing into batches.
+            max_budget = manager.token_budgets[-1]
+            idx = 0
+            while idx < num_items:
+                indexes: list[int] = []
+                count = 0
+                used = 0
+                has_space = [
+                    count < manager.max_batch_size,
+                    used + out_tokens[sorted_indices[idx]] < max_budget
+                ]
+                while (idx < num_items and all(has_space)):
+                    count += 1
+                    used += out_tokens[sorted_indices[idx]]
+                    indexes.append(sorted_indices[idx])
+
+                    idx += 1
+
+                budget = get_fit_val(manager.token_budgets, used)
+                batches.append((budget, indexes))
+
+            def run_batch(
+                budget: int | None,
+                output_tokens: list[int],
+                mm_kwargs: dict[str, NestedTensors],
+            ) -> list[jax.Array]:
+                if budget is None:  # Budget size not supported
+                    return embed_multimodal_fn(
+                        jax_params_and_buffers,
+                        **mm_kwargs,
+                    )
+                # Now, for normal cases.
+                local_indexes = list(range(len(output_tokens)))
+                outputs = run_graph_forward(
+                    jax_params_and_buffers,
+                    mm_kwargs,
+                    budget,
+                    local_indexes,
+                    output_tokens,
+                )
+
+                return jax_view(outputs)
+
+            outputs: dict[int, jax.Array] = {}
+            for budget, indexes in batches:
+                batch_mm_kwargs = model.select_encoder_cudagraph_items(
+                    mm_kwargs,
+                    indexes,
+                )
+                batch_outputs = run_batch(
+                    budget,
+                    [out_tokens[i] for i in indexes],
+                    batch_mm_kwargs,
+                )
+                outputs |= {
+                    index: output
+                    for index, output in zip(indexes, batch_outputs)
+                }
+
+            return [outputs[i] for i in range(len(item_specs))]
+
+        def run_graph_forward(
+            jax_params_and_buffers: dict[str, jax.Array],
+            mm_kwargs: dict[str, NestedTensors],
+            token_budget: int,
+            indexes: list[int],
+            output_tokens: list[int],
+        ) -> list[torch.Tensor]:
+            # The return tensor contains result from (possibly) multiple items.
+
+            # Duplication of EncoderCudaGraphManager._copy_padded_buffer
+            def copy_padded_buffer(
+                dst: torch.Tensor,
+                src: torch.Tensor,
+            ) -> None:
+                dst.zero_()
+                dst[:src.shape[0]].copy_(src)
+
+            values = model.prepare_encoder_cudagraph_replay_buffers(
+                mm_kwargs,
+                manager.max_batch_size,
+                manager.max_frames_per_batch,
+            ).values
+
+            inputs = manager.by_budget[token_budget]
+            # Move per-req states into fixed-sized tensor buffers.
+            for key in graph_config.buffer_keys:
+                src = values.get(key)
+                if src is None:
+                    continue
+                buf = inputs[key]
+                if src.ndim == 0:
+                    buf.copy_(src)
+                    continue
+                else:
+                    pad = padding_logics.get(key, copy_padded_buffer)
+                    pad(buf, src)
+
+            with (
+                    torchax.default_env(),
+                    enable_torch_wrap(False),
+            ):
+
+                inputs = jax.tree.map(_to_tpu, inputs)
+
+                jax_outputs = encoder_graph_forward(
+                    jax_params_and_buffers,
+                    jax_view(inputs),
+                )
+                outputs = torch_view(jax_outputs)
+
+                by_idx: dict[int, torch.Tensor] = {}
+                model.postprocess_encoder_output(
+                    outputs,
+                    indexes,
+                    output_tokens,
+                    dest=by_idx,  # the output parameter
+                    clone=True,
+                    batch_mm_kwargs=mm_kwargs,
+                )
+
+            return [by_idx[i] for i in indexes]
+
+        return (
+            embed_multimodal_graph_forward_all,
+            precompile_encoder_graph,
+        )

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -835,6 +835,14 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         self.embed_input_ids_fn = model.multimodal_fns.embed_input_ids_fn
         self.get_mrope_input_positions_fn = model.multimodal_fns.get_mrope_input_positions_fn
 
+        (
+            self.embed_multimodal_fn,
+            self.precompile_vision_encoder_fn,
+        ) = self.mm_manager.optional_encoder_graph_optimization(
+            self.embed_multimodal_fn,
+            self.precompile_vision_encoder_fn,
+        )
+
         rng_key = nnx.Rngs(jax.random.key(self.model_config.seed)).params()
         self.rng_params_for_sampling = device_array(self.mesh,
                                                     rng_key,


### PR DESCRIPTION
# Description

If user explicitly specifies using "Encoder CUDA Graph" feature (and the model does support the interface),
use the new interface to achieve better performance and avoid runtime re-compilation that slows down online-inference services.

- Use `SupportsEncoderCudaGraph.encoder_cudagraph_forward` instead of `SupportsMultiModal.embed_multimodal`
- Implement pre-compilation for supported token budgets
- Split mm-data into multiple batches when necessary
- Move the encoder CUDA graph logic into `MultiModalManager` so it can also be leveraged by the JAX path in the future
- Extract mm encoder manager into a separate file (`tpu_inference/models/vllm/mm_encoder_manager.py`) with unit tests
- Patch encoder forward and corresponding pre-compile function in `TPURunner` when appropriate

Corp internal doc: <a href="https://docs.google.com/document/d/10cYjQllhOhRPhtzuKLxS4G6HbpHz9lu56P6KA4zZve8/edit?usp=sharing">link</a>

### Performance

| Metric | Before | After |
|--------|--------|-------|
| Throughput (req/s) | 0.78 | 3.05 |

# Tests

A command to trigger corresponding logic.

```shell
MODEL_IMPL_TYPE=vllm python examples/generate/multimodal/vision_language_offline.py --model-type=qwen3_vl --num-prompts=1 --modality=image --time-generate  -tp=4 --enable-vit-cuda-graph
```

Also, for benchmarking.

```shell
MODEL_IMPL_TYPE=vllm vllm serve Qwen/Qwen3-VL-2B-Instruct \
  --max-model-len 8192 --disable-uvicorn-access-log \
  --max-num-batched-tokens 4096 --max-num-seqs 256 \
  --tensor-parallel-size 8 --trust-remote-code \
  --limit-mm-per-prompt '{"image": 8}' \
  --no-enable-prefix-caching --mm-processor-cache-gb=0 --gpu-memory-utilization 0.9 \
  --disable-chunked-mm-input \
  --mm-processor-kwargs '{"max_pixels": 512000}' \
  --compilation-config '{"cudagraph_mm_encoder": true}'

client:
time python scripts/vllm/benchmarking/benchmark_serving.py \
  --backend vllm-chat \
  --endpoint /v1/chat/completions \
  --model Qwen/Qwen3-VL-2B-Instruct \
  --dataset-name mmmu_pro \
  --mmmu-pro-subset 'standard (10 options)' \
  --mmmu-pro-output-len=1 \
  --run-eval \
  --num-prompts 1730 \
  --max-concurrency 32
```

Unit tests for the extracted mm encoder manager:

```shell
pytest tests/models/vllm/test_mm_encoder_manager.py
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have made or will make corresponding changes to any relevant documentation.
- [ ] I have reviewed the uLLM modeling code checklist: https://docs.google.com/document/d/1DGQBVvr2bh4G8tBUO1YH8pO7Dd_myw5rfEMfVDymEk8/edit?resourcekey=0-V7MGHu3aQjJH6YrI3-y8Hg&tab=t.t91cyovog2mr#heading=h.cqdzv8mlszca
- [ ] I have received at least 1 readability approval and 1 correctness approval.