### PR TITLE
Set MPMD DP as the default for non Pathways environments

### DIFF
--- a/tests/platforms/test_tpu_platform.py
+++ b/tests/platforms/test_tpu_platform.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 from unittest.mock import MagicMock, PropertyMock, patch
 
 import jax.numpy as jnp
@@ -23,6 +24,19 @@ from tpu_inference.platforms.tpu_platform import TpuPlatform
 
 
 class TestTpuPlatform:
+
+    @pytest.fixture(autouse=True)
+    def _restore_multiprocess_dp_env(self):
+        # _resolve_multiprocess_dp writes os.environ directly; restore the
+        # flag and its resolved marker so values do not leak into other tests.
+        keys = ("TPU_MULTIPROCESS_DP", TpuPlatform._RESOLVED_MARKER_ENV)
+        saved = {k: os.environ.get(k) for k in keys}
+        yield
+        for k, v in saved.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
 
     @pytest.fixture
     def vllm_config(self):
@@ -36,6 +50,7 @@ class TestTpuPlatform:
         vllm_config.model_config.use_mla = False
         vllm_config.scheduler_config = MagicMock(is_multimodal_model=False)
         vllm_config.parallel_config = MagicMock()
+        vllm_config.parallel_config.data_parallel_size = 1
         vllm_config.sharding_config = MagicMock()
         vllm_config.compilation_config = MagicMock(mode="dynamo_trace_once",
                                                    backend="openxla")
@@ -302,6 +317,7 @@ class TestTpuPlatform:
     def test_check_and_update_config_mla_checks(self):
         vllm_config = MagicMock()
         vllm_config.model_config.use_mla = True
+        vllm_config.parallel_config.data_parallel_size = 1
         vllm_config.additional_config = {}
 
         expected_msg = r"MLA models require both the NEW_MODEL_DESIGN=1 environment.*"
@@ -390,3 +406,105 @@ class TestTpuPlatform:
                                 pytest.fail(
                                     f"MLA check failed unexpectedly when VLLM_MLA_DISABLE was set: {e}"
                                 )
+
+    @staticmethod
+    def _dp_config(data_parallel_size, enable_dp_attention, api_process_rank):
+        vllm_config = MagicMock()
+        vllm_config.parallel_config.data_parallel_size = data_parallel_size
+        vllm_config.parallel_config._api_process_rank = api_process_rank
+        vllm_config.additional_config = {
+            "sharding": {
+                "sharding_strategy": {
+                    "enable_dp_attention": enable_dp_attention
+                }
+            }
+        }
+        return vllm_config
+
+    @pytest.mark.parametrize(
+        "api_rank,dp_size,dp_attn,pathways,expected",
+        [
+            (-1, 2, False, False, "1"),  # online serve (rank -1), DP>1 -> on
+            (0, 2, False, False, "0"),  # offline LLM() (rank 0) -> off
+            (-1, 1, False, False, "0"),  # no DP -> off
+            (-1, 2, True, False, "0"),  # attention DP -> off
+            (-1, 2, False, True, "0"),  # Pathways -> off
+        ],
+    )
+    def test_resolve_multiprocess_dp_derives_when_unset(
+            self, monkeypatch, api_rank, dp_size, dp_attn, pathways, expected):
+        monkeypatch.delenv("TPU_MULTIPROCESS_DP", raising=False)
+        monkeypatch.setattr(
+            "tpu_inference.platforms.tpu_platform.vllm_envs."
+            "VLLM_TPU_USING_PATHWAYS", pathways)
+        vllm_config = self._dp_config(dp_size, dp_attn, api_rank)
+
+        TpuPlatform._resolve_multiprocess_dp(vllm_config)
+
+        # DP <= 1 is a no-op (left unset); otherwise it pins a concrete value.
+        assert os.environ.get("TPU_MULTIPROCESS_DP") == (expected if dp_size
+                                                         > 1 else None)
+
+    @pytest.mark.parametrize("preset", ["0", "1"])
+    def test_resolve_multiprocess_dp_preserves_explicit(
+            self, monkeypatch, preset):
+        # An explicit setting in a supported (online) context must not be
+        # overwritten.
+        monkeypatch.setenv("TPU_MULTIPROCESS_DP", preset)
+        monkeypatch.setattr(
+            "tpu_inference.platforms.tpu_platform.vllm_envs."
+            "VLLM_TPU_USING_PATHWAYS", False)
+        vllm_config = self._dp_config(data_parallel_size=2,
+                                      enable_dp_attention=False,
+                                      api_process_rank=-1)
+
+        TpuPlatform._resolve_multiprocess_dp(vllm_config)
+
+        assert os.environ["TPU_MULTIPROCESS_DP"] == preset
+
+    def test_resolve_multiprocess_dp_marker_skips_rederivation(
+            self, monkeypatch):
+        # A spawned worker (rank no longer -1, inherited "1") must trust the
+        # value even though its own context now looks offline -> no raise.
+        monkeypatch.setenv("TPU_MULTIPROCESS_DP", "1")
+        monkeypatch.setenv(TpuPlatform._RESOLVED_MARKER_ENV, "1")
+        vllm_config = self._dp_config(data_parallel_size=2,
+                                      enable_dp_attention=False,
+                                      api_process_rank=0)
+
+        TpuPlatform._resolve_multiprocess_dp(vllm_config)  # must not raise
+
+        assert os.environ["TPU_MULTIPROCESS_DP"] == "1"
+
+    @pytest.mark.parametrize(
+        "api_rank,dp_attn,pathways",
+        [
+            (0, False, False),  # offline LLM()
+            (-1, True, False),  # attention DP
+            (-1, False, True),  # Pathways
+        ])
+    def test_resolve_multiprocess_dp_explicit_incompatible_raises(
+            self, monkeypatch, api_rank, dp_attn, pathways):
+        # An explicit TPU_MULTIPROCESS_DP=1 in an unsupported configuration
+        # must fail loudly rather than hang or be silently downgraded.
+        monkeypatch.setenv("TPU_MULTIPROCESS_DP", "1")
+        monkeypatch.setattr(
+            "tpu_inference.platforms.tpu_platform.vllm_envs."
+            "VLLM_TPU_USING_PATHWAYS", pathways)
+        vllm_config = self._dp_config(data_parallel_size=2,
+                                      enable_dp_attention=dp_attn,
+                                      api_process_rank=api_rank)
+
+        with pytest.raises(ValueError, match="TPU_MULTIPROCESS_DP=1"):
+            TpuPlatform._resolve_multiprocess_dp(vllm_config)
+
+    def test_resolve_multiprocess_dp_explicit_incompatible_no_dp_ok(
+            self, monkeypatch):
+        # With DP <= 1 there is no multi-process DP, so an explicit opt-in in
+        # an otherwise-unsupported context is irrelevant and must not raise.
+        monkeypatch.setenv("TPU_MULTIPROCESS_DP", "1")
+        vllm_config = self._dp_config(data_parallel_size=1,
+                                      enable_dp_attention=True,
+                                      api_process_rank=0)
+
+        TpuPlatform._resolve_multiprocess_dp(vllm_config)  # must not raise

--- a/tests/platforms/test_tpu_platform.py
+++ b/tests/platforms/test_tpu_platform.py
@@ -27,16 +27,12 @@ class TestTpuPlatform:
 
     @pytest.fixture(autouse=True)
     def _restore_multiprocess_dp_env(self):
-        # _resolve_multiprocess_dp writes os.environ directly; restore the
-        # flag and its resolved marker so values do not leak into other tests.
-        keys = ("TPU_MULTIPROCESS_DP", TpuPlatform._RESOLVED_MARKER_ENV)
-        saved = {k: os.environ.get(k) for k in keys}
+        saved = os.environ.get("TPU_MULTIPROCESS_DP")
         yield
-        for k, v in saved.items():
-            if v is None:
-                os.environ.pop(k, None)
-            else:
-                os.environ[k] = v
+        if saved is None:
+            os.environ.pop("TPU_MULTIPROCESS_DP", None)
+        else:
+            os.environ["TPU_MULTIPROCESS_DP"] = saved
 
     @pytest.fixture
     def vllm_config(self):
@@ -462,38 +458,40 @@ class TestTpuPlatform:
 
         assert os.environ["TPU_MULTIPROCESS_DP"] == preset
 
-    def test_resolve_multiprocess_dp_marker_skips_rederivation(
+    def test_resolve_multiprocess_dp_explicit_online_worker_ok(
             self, monkeypatch):
-        # A spawned worker (rank no longer -1, inherited "1") must trust the
-        # value even though its own context now looks offline -> no raise.
+        # An online API-server worker has _api_process_rank >= 0 (not -1) but
+        # inherits the explicit "1"; it must NOT be misread as offline and must
+        # not raise.
         monkeypatch.setenv("TPU_MULTIPROCESS_DP", "1")
-        monkeypatch.setenv(TpuPlatform._RESOLVED_MARKER_ENV, "1")
+        monkeypatch.setattr(
+            "tpu_inference.platforms.tpu_platform.vllm_envs."
+            "VLLM_TPU_USING_PATHWAYS", False)
         vllm_config = self._dp_config(data_parallel_size=2,
                                       enable_dp_attention=False,
-                                      api_process_rank=0)
+                                      api_process_rank=2)
 
         TpuPlatform._resolve_multiprocess_dp(vllm_config)  # must not raise
 
         assert os.environ["TPU_MULTIPROCESS_DP"] == "1"
 
     @pytest.mark.parametrize(
-        "api_rank,dp_attn,pathways",
+        "dp_attn,pathways",
         [
-            (0, False, False),  # offline LLM()
-            (-1, True, False),  # attention DP
-            (-1, False, True),  # Pathways
+            (True, False),  # attention DP
+            (False, True),  # Pathways
         ])
     def test_resolve_multiprocess_dp_explicit_incompatible_raises(
-            self, monkeypatch, api_rank, dp_attn, pathways):
-        # An explicit TPU_MULTIPROCESS_DP=1 in an unsupported configuration
-        # must fail loudly rather than hang or be silently downgraded.
+            self, monkeypatch, dp_attn, pathways):
+        # An explicit TPU_MULTIPROCESS_DP=1 with attention DP or on Pathways
+        # must fail loudly rather than be silently downgraded.
         monkeypatch.setenv("TPU_MULTIPROCESS_DP", "1")
         monkeypatch.setattr(
             "tpu_inference.platforms.tpu_platform.vllm_envs."
             "VLLM_TPU_USING_PATHWAYS", pathways)
         vllm_config = self._dp_config(data_parallel_size=2,
                                       enable_dp_attention=dp_attn,
-                                      api_process_rank=api_rank)
+                                      api_process_rank=-1)
 
         with pytest.raises(ValueError, match="TPU_MULTIPROCESS_DP=1"):
             TpuPlatform._resolve_multiprocess_dp(vllm_config)

--- a/tpu_inference/envs.py
+++ b/tpu_inference/envs.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
     TPU_NAME: str | None = None
     TPU_WORKER_ID: str | None = None
     TPU_MULTIHOST_BACKEND: str = ""
-    TPU_MULTIPROCESS_DP: bool = False
+    TPU_MULTIPROCESS_DP: bool | None = None
     PREFILL_SLICES: str = ""
     DECODE_SLICES: str = ""
     SKIP_JAX_PRECOMPILE: bool = False
@@ -112,19 +112,20 @@ def env_with_choices(
 
 
 def env_bool(env_name: str,
-             default: bool = False,
-             requires: list[str] | None = None) -> Callable[[], bool]:
+             default: bool | None = False,
+             requires: list[str] | None = None) -> Callable[[], bool | None]:
     """
     Accepts both numeric strings ("0", "1") and boolean strings
     ("true", "false", "True", "False").
 
     Args:
         env_name: Name of the environment variable
-        default: Default boolean value if not set
+        default: Default value if not set. Pass None for a tri-state flag
+            (unset -> None) that callers resolve themselves.
         requires: List of environment variables that must be set if this is True.
     """
 
-    def _get_bool_env() -> bool:
+    def _get_bool_env() -> bool | None:
         value = os.getenv(env_name)
         if value is None or value == "":
             parsed_value = default
@@ -210,9 +211,12 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Use vLLM-native multi-process data parallelism (one engine process per
     # DP rank, single load-balanced API endpoint) instead of tpu-inference's
     # single-process SPMD data parallelism. Each DP rank is pinned to a
-    # disjoint set of TPU chips. Dense (non-MoE) models only.
+    # disjoint set of TPU chips. Unset (None) means "auto", and
+    # TpuPlatform.check_and_update_config resolves it to a concrete value
+    # (on for online `vllm serve` with DP > 1; off for offline, attention DP,
+    # and Pathways).
     "TPU_MULTIPROCESS_DP":
-    env_bool("TPU_MULTIPROCESS_DP", default=False),
+    env_bool("TPU_MULTIPROCESS_DP", default=None),
     # Slice configuration for disaggregated prefill workers
     "PREFILL_SLICES":
     lambda: os.getenv("PREFILL_SLICES", ""),

--- a/tpu_inference/layers/common/sharding.py
+++ b/tpu_inference/layers/common/sharding.py
@@ -19,7 +19,6 @@ from typing import TYPE_CHECKING, List, Optional
 
 import jax.numpy as jnp
 import numpy as np
-import vllm.envs as vllm_envs
 from jax.sharding import Mesh
 
 from tpu_inference import envs, utils
@@ -177,27 +176,8 @@ class ShardingConfigManager:
         data_parallelism = parallel_config.data_parallel_size
         enable_dp_attention = sharding_strategy.get("enable_dp_attention",
                                                     False)
-        # vLLM-native multi-process data parallelism: one engine process per
-        # DP rank, fronted by a single load-balanced API endpoint.
-        #
-        # It is not used (we fall back to single-process SPMD DP) when:
-        #  - attention DP is enabled
-        #  - running on Pathways
-        multiprocess_dp = (envs.TPU_MULTIPROCESS_DP and data_parallelism > 1
-                           and not enable_dp_attention
-                           and not vllm_envs.VLLM_TPU_USING_PATHWAYS)
-        if (envs.TPU_MULTIPROCESS_DP and data_parallelism > 1
-                and not multiprocess_dp):
-            raise ValueError(
-                "TPU_MULTIPROCESS_DP is set but is not supported with "
-                "attention DP (enable_dp_attention) or on Pathways. "
-                "Please disable TPU_MULTIPROCESS_DP.")
-        if multiprocess_dp:
+        if envs.TPU_MULTIPROCESS_DP:
             data_parallelism = 1
-            logger.warning(
-                "TPU_MULTIPROCESS_DP is enabled: supported for online serving "
-                "only. The offline LLM().generate() API will hang. "
-                "Use `vllm serve` instead.")
         expert_parallelism = sharding_strategy.get("expert_parallelism", 1)
         sequence_parallelism = sharding_strategy.get("sequence_parallelism", 1)
         device_indexes = sharding_strategy.get("device_indexes", None)
@@ -280,7 +260,7 @@ class ShardingConfigManager:
             decode_context_parallelism=decode_context_parallelism)
 
         # Must override here to avoid vLLM spinning up multiple DP engines.
-        if (not multiprocess_dp
+        if (not envs.TPU_MULTIPROCESS_DP
                 and vllm_config.parallel_config.data_parallel_size > 1):
             vllm_config.parallel_config.data_parallel_size = 1
             vllm_config.parallel_config.data_parallel_rank = 0

--- a/tpu_inference/platforms/tpu_platform.py
+++ b/tpu_inference/platforms/tpu_platform.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
+import os
 import random
 from typing import TYPE_CHECKING, Optional, Tuple, Union
 
@@ -192,7 +193,37 @@ class TpuPlatform(Platform):
         logger.info(f"Initialized sharding configuration: {sharding_config}")
 
     @classmethod
+    def _resolve_multiprocess_dp(cls, vllm_config: VllmConfig) -> None:
+        """vLLM-native multi-process DP only works for online `vllm serve` (which
+        sets _api_process_rank to -1) with DP > 1, and not with attention DP or
+        on Pathways.
+        """
+        pc = vllm_config.parallel_config
+        if pc.data_parallel_size <= 1:
+            return
+        enable_dp_attention = vllm_config.additional_config.get(
+            "sharding", {}).get("sharding_strategy",
+                                {}).get("enable_dp_attention", False)
+        online_serving = getattr(pc, "_api_process_rank", 0) == -1
+        incompatible = enable_dp_attention or vllm_envs.VLLM_TPU_USING_PATHWAYS or not online_serving
+
+        requested = envs.TPU_MULTIPROCESS_DP
+        if requested is not None:
+            if requested and incompatible:
+                raise ValueError(
+                    "TPU_MULTIPROCESS_DP=1 is not supported with attention DP "
+                    "(enable_dp_attention), on Pathways, or offline serving. Set "
+                    "TPU_MULTIPROCESS_DP=0 to use single-process SPMD DP.")
+            return
+
+        os.environ["TPU_MULTIPROCESS_DP"] = ("1" if not incompatible else "0")
+        logger.info("Resolved TPU_MULTIPROCESS_DP=%s",
+                    os.environ["TPU_MULTIPROCESS_DP"])
+
+    @classmethod
     def check_and_update_config(cls, vllm_config: VllmConfig) -> None:
+
+        cls._resolve_multiprocess_dp(vllm_config)
 
         if vllm_envs.VLLM_TPU_USING_PATHWAYS:
             assert not vllm_envs.VLLM_ENABLE_V1_MULTIPROCESSING, (

--- a/tpu_inference/platforms/tpu_platform.py
+++ b/tpu_inference/platforms/tpu_platform.py
@@ -204,19 +204,22 @@ class TpuPlatform(Platform):
         enable_dp_attention = vllm_config.additional_config.get(
             "sharding", {}).get("sharding_strategy",
                                 {}).get("enable_dp_attention", False)
-        online_serving = getattr(pc, "_api_process_rank", 0) == -1
-        incompatible = enable_dp_attention or vllm_envs.VLLM_TPU_USING_PATHWAYS or not online_serving
+        incompatible = enable_dp_attention or vllm_envs.VLLM_TPU_USING_PATHWAYS
 
         requested = envs.TPU_MULTIPROCESS_DP
         if requested is not None:
             if requested and incompatible:
                 raise ValueError(
                     "TPU_MULTIPROCESS_DP=1 is not supported with attention DP "
-                    "(enable_dp_attention), on Pathways, or offline serving. Set "
+                    "(enable_dp_attention) or on Pathways. Set "
                     "TPU_MULTIPROCESS_DP=0 to use single-process SPMD DP.")
             return
 
-        os.environ["TPU_MULTIPROCESS_DP"] = ("1" if not incompatible else "0")
+        # Unset: only the `vllm serve` launcher (which sets _api_process_rank to
+        # -1) auto-enables it; offline LLM() (rank 0) falls back to SPMD.
+        online_serving = getattr(pc, "_api_process_rank", 0) == -1
+        os.environ["TPU_MULTIPROCESS_DP"] = ("1" if online_serving
+                                             and not incompatible else "0")
         logger.info("Resolved TPU_MULTIPROCESS_DP=%s",
                     os.environ["TPU_MULTIPROCESS_DP"])
 


### PR DESCRIPTION
# Description

The changes make the MPMD DP mode selection automatic. MPMD DP will be automatically enabled for online serving except for when running on Pathways or when attention dp is enabled. If user wants to use SPMD DP instead, they can manually set `TPU_MULTIPROCESS_DP=False`. 


# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
