### PR TITLE
[bm-infra] Adds CaseName field to Spanner reporting for future dashboard group_by

### DIFF
--- a/.buildkite/benchmark/README.md
+++ b/.buildkite/benchmark/README.md
@@ -17,10 +17,10 @@ The CI pipeline dynamically constructs its execution matrix based on the JSON co
 Developers can bypass the CI/Docker abstraction and run the benchmark directly on a local TPU VM using the core runner:
 
 ```bash
-bash run_bm.sh <path_to_case.json> [TARGET_CASE_NAME]
+bash run_bm.sh <path_to_case.json> <TARGET_CASE_NAME>
 ```
 
-*Note: `TARGET_CASE_NAME` is only required if the JSON file uses the multi-case structure.*
+*Note: TARGET_CASE_NAME is mandatory for all benchmark runs.*
 
 ## 2. Local Execution Prerequisites & Caveats
 
@@ -46,11 +46,11 @@ The `run_bm.sh` script is designed to be environment-aware. When running locally
 
 ## 3. Configuration Guide (JSON Cases)
 
-The feature is driven by JSON configuration files. A case file can define a single benchmark or multiple benchmarks using the `benchmark_cases` array.
+The framework is driven by JSON configuration files. Each file defines one or more benchmarks within the `benchmark_cases` array.
 
 ### Configuration Structure & Parameter Definitions
 
-* `global_env` (or `env` in single-case): Environment variables applied globally.
+* `global_env`: Environment variables applied globally to all cases in the file.
   * `GCP_PROJECT_ID`, `GCP_INSTANCE_ID`, `GCP_DATABASE_ID`, `GCS_BUCKET`: Cloud routing for logs, datasets, and DB.
   * `MODELTAG`: Identifier tag for the model state (e.g., `NEW`, `PROD`).
   * `EXPECTED_ETEL`: The target goal for End-to-End Latency (P99 in ms). The script adjusts the request rate via binary search to stay within this limit.
@@ -93,7 +93,11 @@ When supplying a custom dataset file via `dataset-path`:
 * **Local Execution**: The path should be an absolute path or relative to the directory where `run_bm.sh` is executed.
 
 #### D. Implicit DB Tracking Variables
-While variables like `EXPECTED_ETEL`, `INPUT_LEN`, `OUTPUT_LEN`, and `PREFIX_LEN` might not be directly passed to the `vllm` CLI, they are rigorously parsed and injected into the GCP Spanner `RunRecord` table by `report_result.sh` to track historical performance variations. Please ensure that the values of these variables remain consistent with the corresponding parameter settings in the args of the Case JSON file.
+While variables like `EXPECTED_ETEL`, `INPUT_LEN`, `OUTPUT_LEN`, and `PREFIX_LEN` might not be directly passed to the `vllm` CLI, they are rigorously parsed and injected into the GCP Spanner `RunRecord` table by `report_result.sh` to track historical performance variations.
+
+Please ensure that the values of these variables remain consistent with the corresponding parameter settings in the args of the Case JSON file.
+
+Additionally, `DirName`, `FileName`, and `CaseName` are automatically extracted from the json path and `case_name` field and reported to GCP Spanner `RunRecord` table.
 
 ## 4. **Test Case File Hierarchy**
 

--- a/.buildkite/benchmark/README.md
+++ b/.buildkite/benchmark/README.md
@@ -97,7 +97,7 @@ While variables like `EXPECTED_ETEL`, `INPUT_LEN`, `OUTPUT_LEN`, and `PREFIX_LEN
 
 Please ensure that the values of these variables remain consistent with the corresponding parameter settings in the args of the Case JSON file.
 
-Additionally, `DirName`, `FileName`, and `CaseName` are automatically extracted from the json path and `case_name` field and reported to GCP Spanner `RunRecord` table.
+Additionally, it will extract the json `case_name` value and reported to GCP Spanner `RunRecord` table for `CaseName` column.
 
 ## 4. **Test Case File Hierarchy**
 

--- a/.buildkite/benchmark/README.md
+++ b/.buildkite/benchmark/README.md
@@ -97,7 +97,12 @@ While variables like `EXPECTED_ETEL`, `INPUT_LEN`, `OUTPUT_LEN`, and `PREFIX_LEN
 
 Please ensure that the values of these variables remain consistent with the corresponding parameter settings in the args of the Case JSON file.
 
-Additionally, it will extract the json `case_name` value and reported to GCP Spanner `RunRecord` table for `CaseName` column.
+Additionally, the `case_name` defined in the JSON will be extracted and reported to the `CaseName` column in the Spanner `RunRecord` table.
+
+> **Important Note on `case_name` Modification:**
+> * **For new cases:** You can define and modify the `case_name` freely during initial development. (Please make it similar to current cases name convention as possible)
+> * **For established cases:** If a case has been running for a long time and has historical data in the database, **strongly recommend NOT to modify its `case_name`**.
+> * **Data Migration:** If a name change is strictly necessary for an established case, you must coordinate and execute a data migration in the database to link the old records to the new name. Modifying the name without migration will cause the dashboard to treat it as a brand-new entity, breaking historical performance tracking.
 
 ## 4. **Test Case File Hierarchy**
 

--- a/.buildkite/benchmark/cases/ci/Qwen3-4B-dataset_custom-inlen_4096-outlen_1024.json
+++ b/.buildkite/benchmark/cases/ci/Qwen3-4B-dataset_custom-inlen_4096-outlen_1024.json
@@ -1,54 +1,59 @@
 {
-  "env": {
-    "GCS_BUCKET": "vllm-cb-storage2",
-    "MODELTAG": "NEW",
-    "EXPECTED_ETEL": 3600000,
-    "INPUT_LEN": 4096,
-    "OUTPUT_LEN": 1024,
-    "PREFIX_LEN": 3600
-  },
-  "ci_queue": [
-    "tpu_v6e_queue",
-    "tpu_v7x_2_queue"
-  ],
-  "server_command_options": {
-    "command_type": "vllm_serve",
-    "env": {
-      "VLLM_USE_V1": "1",
-      "MODEL_IMPL_TYPE": "vllm",
-      "NEW_MODEL_DESIGN": "1"
-    },
-    "args": {
-      "model": "Qwen/Qwen3-4B",
-      "seed": 42,
-      "max-num-seqs": 128,
-      "max-num-batched-tokens": 8192,
-      "tensor-parallel-size": {
-        "v6e-1": 1,
-        "v7x-2": 2,
-        "default": 1
+  "benchmark_cases": [
+    {
+      "case_name": "Qwen3-4B-dataset_custom-inlen_4096-outlen_1024",
+      "env": {
+        "GCS_BUCKET": "vllm-cb-storage2",
+        "MODELTAG": "NEW",
+        "EXPECTED_ETEL": 3600000,
+        "INPUT_LEN": 4096,
+        "OUTPUT_LEN": 1024,
+        "PREFIX_LEN": 3600
       },
-      "no-enable-prefix-caching": false,
-      "max-model-len": 5120,
-      "kv-cache-dtype": "fp8",
-      "gpu-memory-utilization": 0.90,
-      "async-scheduling": true,
-      "additional-config": "{\"quantization\": { \"qwix\": { \"rules\": [{ \"module_path\": \".*\", \"weight_qtype\": \"float8_e4m3fn\", \"act_qtype\": \"float8_e4m3fn\"}]}}}"
+      "ci_queue": [
+        "tpu_v6e_queue",
+        "tpu_v7x_2_queue"
+      ],
+      "server_command_options": {
+        "command_type": "vllm_serve",
+        "env": {
+          "VLLM_USE_V1": "1",
+          "MODEL_IMPL_TYPE": "vllm",
+          "NEW_MODEL_DESIGN": "1"
+        },
+        "args": {
+          "model": "Qwen/Qwen3-4B",
+          "seed": 42,
+          "max-num-seqs": 128,
+          "max-num-batched-tokens": 8192,
+          "tensor-parallel-size": {
+            "v6e-1": 1,
+            "v7x-2": 2,
+            "default": 1
+          },
+          "no-enable-prefix-caching": false,
+          "max-model-len": 5120,
+          "kv-cache-dtype": "fp8",
+          "gpu-memory-utilization": 0.9,
+          "async-scheduling": true,
+          "additional-config": "{\"quantization\": { \"qwix\": { \"rules\": [{ \"module_path\": \".*\", \"weight_qtype\": \"float8_e4m3fn\", \"act_qtype\": \"float8_e4m3fn\"}]}}}"
+        }
+      },
+      "client_command_options": {
+        "command_type": "vllm_bench_serve",
+        "args": {
+          "model": "Qwen/Qwen3-4B",
+          "backend": "vllm",
+          "request-rate": "inf",
+          "dataset-name": "custom",
+          "dataset-path": "/workspace/tpu_inference/artifacts/dataset/Qwen3-4B/inlen4096_outlen1024_prefixlen3600.jsonl",
+          "num-prompts": 1000,
+          "percentile-metrics": "ttft,tpot,itl,e2el",
+          "ignore-eos": true,
+          "custom-output-len": 1024,
+          "skip-chat-template": true
+        }
+      }
     }
-  },
-  "client_command_options": {
-    "command_type": "vllm_bench_serve",
-    "args": {
-      "model": "Qwen/Qwen3-4B",
-      "backend": "vllm",
-      "request-rate": "inf",
-      "dataset-name": "custom",
-      "dataset-path": "/workspace/tpu_inference/artifacts/dataset/Qwen3-4B/inlen4096_outlen1024_prefixlen3600.jsonl",
-      "num-prompts": 1000,
-      "percentile-metrics": "ttft,tpot,itl,e2el",
-      "ignore-eos": true,
-      "custom-output-len": 1024,
-      "skip-chat-template": true
-    }
-  }
+  ]
 }

--- a/.buildkite/benchmark/cases/ci/Qwen3-4B-dataset_custom-inlen_4096-outlen_1024.json
+++ b/.buildkite/benchmark/cases/ci/Qwen3-4B-dataset_custom-inlen_4096-outlen_1024.json
@@ -1,7 +1,7 @@
 {
   "benchmark_cases": [
     {
-      "case_name": "Qwen3-4B-dataset_custom-inlen_4096-outlen_1024",
+      "case_name": "Qwen3-4B-dataset_custom-inlen_4096-outlen_1024-CI",
       "env": {
         "GCS_BUCKET": "vllm-cb-storage2",
         "MODELTAG": "NEW",

--- a/.buildkite/benchmark/cases/daily/Llama-3.3-70B-dataset_mmlu-inlen_1800-outlen_128.json
+++ b/.buildkite/benchmark/cases/daily/Llama-3.3-70B-dataset_mmlu-inlen_1800-outlen_128.json
@@ -1,34 +1,39 @@
 {
-  "env": {
-    "GCP_PROJECT_ID": "cloud-tpu-inference-test",
-    "GCS_BUCKET": "vllm-cb-storage2",
-    "GCP_INSTANCE_ID": "vllm-bm-inst",
-    "GCP_DATABASE_ID": "vllm-bm-bk-runs",
-    "EXPECTED_ETEL": 3600000,
-    "INPUT_LEN": 1800,
-    "OUTPUT_LEN": 128,
-    "MAX_NUM_SEQS": 128,
-    "MAX_NUM_BATCHED_TOKENS": 1024,
-    "MAX_MODEL_LEN": 2048,
-    "RUN_TYPE": "JAX_ACCURACY"
-  },
-  "ci_queue": [
-    "tpu_v6e_8_queue",
-    "tpu_v7x_8_queue"
-  ],
-  "client_command_options": {
-    "command_type": "lm_eval",
-    "env": {
-      "TPU_BACKEND_TYPE": "jax"
-    },
-    "args": {
-      "model": "meta-llama/Llama-3.3-70B-Instruct",
-      "dataset-name": "mmlu",
-      "tensor-parallel-size": {
-        "v6e-8": 8,
-        "v7x-8": 8,
-        "default": 8
+  "benchmark_cases": [
+    {
+      "case_name": "Llama-3.3-70B-dataset_mmlu-inlen_1800-outlen_128",
+      "env": {
+        "GCP_PROJECT_ID": "cloud-tpu-inference-test",
+        "GCS_BUCKET": "vllm-cb-storage2",
+        "GCP_INSTANCE_ID": "vllm-bm-inst",
+        "GCP_DATABASE_ID": "vllm-bm-bk-runs",
+        "EXPECTED_ETEL": 3600000,
+        "INPUT_LEN": 1800,
+        "OUTPUT_LEN": 128,
+        "MAX_NUM_SEQS": 128,
+        "MAX_NUM_BATCHED_TOKENS": 1024,
+        "MAX_MODEL_LEN": 2048,
+        "RUN_TYPE": "JAX_ACCURACY"
+      },
+      "ci_queue": [
+        "tpu_v6e_8_queue",
+        "tpu_v7x_8_queue"
+      ],
+      "client_command_options": {
+        "command_type": "lm_eval",
+        "env": {
+          "TPU_BACKEND_TYPE": "jax"
+        },
+        "args": {
+          "model": "meta-llama/Llama-3.3-70B-Instruct",
+          "dataset-name": "mmlu",
+          "tensor-parallel-size": {
+            "v6e-8": 8,
+            "v7x-8": 8,
+            "default": 8
+          }
+        }
       }
     }
-  }
+  ]
 }

--- a/.buildkite/benchmark/cases/dev/mlcompass-example.json
+++ b/.buildkite/benchmark/cases/dev/mlcompass-example.json
@@ -10,7 +10,7 @@
   },
   "benchmark_cases": [
     {
-      "case_name": "Qwen3-32B-dataset_random-inlen_1024-outlen_1024-max-concurrency-64",
+      "case_name": "Qwen3-32B-dataset_random-inlen_1024-outlen_1024-max-concurrency-64-dev",
       "ci_queue": [
         "tpu_v7x_2_queue"
       ],

--- a/.buildkite/benchmark/scripts/generate_bk_pipeline.py
+++ b/.buildkite/benchmark/scripts/generate_bk_pipeline.py
@@ -171,16 +171,14 @@ def validate_parameter_dependencies(case_data: Dict[str, Any], file_path: str,
             )
 
 
-def create_benchmark_steps(
-        case_data: Dict[str, Any],
-        global_env: Dict[str, Any],
-        file_path: str,
-        file_basename: str,
-        parent_dir: str,
-        used_keys: Set[str],
-        errors: List[str],
-        no_verify: bool = False,
-        is_single_case: bool = False) -> List[Dict[str, Any]]:
+def create_benchmark_steps(case_data: Dict[str, Any],
+                           global_env: Dict[str, Any],
+                           file_path: str,
+                           file_basename: str,
+                           parent_dir: str,
+                           used_keys: Set[str],
+                           errors: List[str],
+                           no_verify: bool = False) -> List[Dict[str, Any]]:
     """
     Generates a list of Buildkite steps for a case.
     """
@@ -219,18 +217,11 @@ def create_benchmark_steps(
         # Build the environment for this specific step
         step_env = {**combined_env, "ci_queue": agent}
 
-        if is_single_case:
-            # Include parent_dir in label for uniqueness
-            step_label = f"[{parent_dir}] {agent} {file_basename}"
-            case_parameter = f"{file_path}"
-            benchmark_name = file_basename
-        else:
-            step_env["TARGET_CASE_NAME"] = case_name
-            # Include parent_dir in label for uniqueness
-            step_label = f"[{parent_dir}] {agent} {file_basename} {case_name}"
-            case_parameter = f"{file_path} {case_name}"
-            benchmark_name = case_name
-        step_env["MLCOMPASS_TEST_NAME"] = f"vllm:{agent}:{benchmark_name}"
+        step_env["TARGET_CASE_NAME"] = case_name
+        # Include parent_dir in label for uniqueness
+        step_label = f"[{parent_dir}] {agent} {file_basename} {case_name}"
+        case_parameter = f"{file_path} {case_name}"
+        step_env["MLCOMPASS_TEST_NAME"] = f"vllm:{agent}:{case_name}"
 
         # Define step key and check for internal collisions
         step_safe_key = clean_key_string(step_label)
@@ -291,31 +282,22 @@ def main():
     errors = []
 
     # Process cases
-    if "benchmark_cases" in data:
-        for case in data["benchmark_cases"]:
-            # Aggregate all steps from all cases
-            all_steps.extend(
-                create_benchmark_steps(case,
-                                       global_env,
-                                       file_path,
-                                       file_basename,
-                                       parent_dir,
-                                       used_keys,
-                                       errors,
-                                       no_verify=args.no_verify,
-                                       is_single_case=False))
-    else:
-        # Single-case
+    if "benchmark_cases" not in data:
+        print(f"Error: 'benchmark_cases' is missing in {file_path}",
+              file=sys.stderr)
+        sys.exit(1)
+
+    for case in data["benchmark_cases"]:
+        # Aggregate all steps from all cases
         all_steps.extend(
-            create_benchmark_steps(data,
+            create_benchmark_steps(case,
                                    global_env,
                                    file_path,
                                    file_basename,
                                    parent_dir,
                                    used_keys,
                                    errors,
-                                   no_verify=args.no_verify,
-                                   is_single_case=True))
+                                   no_verify=args.no_verify))
 
     # Final check: Ensure we actually produced steps and no errors occurred
     if errors:

--- a/.buildkite/benchmark/scripts/generate_bk_pipeline.py
+++ b/.buildkite/benchmark/scripts/generate_bk_pipeline.py
@@ -231,7 +231,7 @@ def create_benchmark_steps(case_data: Dict[str, Any],
                 f"within {file_path}. Ensure all of case_name are unique.")
         used_keys.add(step_safe_key)
 
-        child_steps.append({
+        step = {
             "label":
             step_label,
             "key":
@@ -243,7 +243,13 @@ def create_benchmark_steps(case_data: Dict[str, Any],
             },
             "command":
             f"bash .buildkite/benchmark/scripts/run_job.sh {case_parameter}",
-        })
+        }
+
+        # Add dependency on global case name validation if it was uploaded in bootstrap
+        if os.environ.get("BENCHMARK_VALIDATION_UPLOADED") == "true":
+            step["depends_on"] = "validate_benchmark_case_name"
+
+        child_steps.append(step)
 
     return child_steps
 

--- a/.buildkite/benchmark/scripts/parser_case.py
+++ b/.buildkite/benchmark/scripts/parser_case.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 # yapf: disable
 import json
+import os
 import shlex
 import sys
 
@@ -127,32 +128,32 @@ def main():
         print(f"echo 'Error reading JSON: {e}' >&2; exit 1")
         sys.exit(1)
 
-    is_multi_case = "benchmark_cases" in data
-
     # Resolve target case data
-    if is_multi_case:
-        if not target_case:
-            print(
-                "echo 'Error: TARGET_CASE_NAME required for multi-case config.' >&2; exit 1"
-            )
-            sys.exit(1)
+    if not target_case:
+        print(
+            "echo 'Error: TARGET_CASE_NAME required.' >&2; exit 1"
+        )
+        sys.exit(1)
 
-        cases = data.get("benchmark_cases", [])
-        case_data = next(
-            (c for c in cases if c.get("case_name") == target_case), None)
-        if not case_data:
-            print(
-                f"echo 'Error: Case \"{target_case}\" not found.' >&2; exit 1")
-            sys.exit(1)
+    cases = data.get("benchmark_cases", [])
+    case_data = next(
+        (c for c in cases if c.get("case_name") == target_case), None)
+    if not case_data:
+        print(
+            f"echo 'Error: Case \"{target_case}\" not found in \"{config_file}\".' >&2; exit 1")
+        sys.exit(1)
 
-        merged_env = data.get("global_env", {}).copy()
-        merged_env.update(case_data.get("env", {}))
+    merged_env = data.get("global_env", {}).copy()
+    merged_env.update(case_data.get("env", {}))
 
-        # Inject global_env into case_data so it will be included in the DB `Config`
-        case_data["global_env"] = data.get("global_env", {})
-    else:
-        case_data = data
-        merged_env = case_data.get("env", {})
+    # Inject global_env into case_data so it will be included in the DB `Config`
+    case_data["global_env"] = data.get("global_env", {})
+
+    dir_name = os.path.basename(os.path.dirname(config_file))
+    file_name = os.path.basename(config_file)
+    print(f"export DIR_NAME={shlex.quote(dir_name)}")
+    print(f"export FILE_NAME={shlex.quote(file_name)}")
+    print(f"export TARGET_CASE_NAME={shlex.quote(target_case)}")
 
     config_json_str = json.dumps(case_data)
     print(f"export CASE_CONFIG_JSON={shlex.quote(config_json_str)}")

--- a/.buildkite/benchmark/scripts/parser_case.py
+++ b/.buildkite/benchmark/scripts/parser_case.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 # yapf: disable
 import json
-import os
 import shlex
 import sys
 
@@ -148,12 +147,6 @@ def main():
 
     # Inject global_env into case_data so it will be included in the DB `Config`
     case_data["global_env"] = data.get("global_env", {})
-
-    dir_name = os.path.basename(os.path.dirname(config_file))
-    file_name = os.path.basename(config_file)
-    print(f"export DIR_NAME={shlex.quote(dir_name)}")
-    print(f"export FILE_NAME={shlex.quote(file_name)}")
-    print(f"export TARGET_CASE_NAME={shlex.quote(target_case)}")
 
     config_json_str = json.dumps(case_data)
     print(f"export CASE_CONFIG_JSON={shlex.quote(config_json_str)}")

--- a/.buildkite/benchmark/scripts/report_result.sh
+++ b/.buildkite/benchmark/scripts/report_result.sh
@@ -320,8 +320,6 @@ if [[ "${UPLOAD_DB:-true}" == "true" && -n "${GCP_DATABASE_ID:-}" && -n "${GCP_P
   SQL_MODEL=$(prepare_sql_val "${MODEL:-}" "")
   SQL_RUN_TYPE=$(prepare_sql_val "${RUN_TYPE:-DAILY}" "DAILY")
   SQL_CODE_HASH=$(prepare_sql_val "${CODE_HASH:-}" "")
-  SQL_DIR_NAME=$(prepare_sql_val "${DIR_NAME:-}" "")
-  SQL_FILE_NAME=$(prepare_sql_val "${FILE_NAME:-}" "")
   SQL_CASE_NAME=$(prepare_sql_val "${TARGET_CASE_NAME:-}" "")
   SQL_DATASET=$(prepare_sql_val "${DATASET:-}" "")
   SQL_MODELTAG=$(prepare_sql_val "${MODELTAG:-PROD}" "PROD")
@@ -341,7 +339,7 @@ if [[ "${UPLOAD_DB:-true}" == "true" && -n "${GCP_DATABASE_ID:-}" && -n "${GCP_P
   SQL="INSERT INTO RunRecord (
       RecordId, Status, CreatedTime, LastUpdate, CreatedBy, JobReference, RunBy,
       Device, Model, RunType, CodeHash,
-      DirName, FileName, CaseName,
+      CaseName,
       MaxNumSeqs, MaxNumBatchedTokens, TensorParallelSize, MaxModelLen,
       Dataset, InputLen, OutputLen,
       ExpectedETEL, NumPrompts, ModelTag, PrefixLen,
@@ -349,7 +347,7 @@ if [[ "${UPLOAD_DB:-true}" == "true" && -n "${GCP_DATABASE_ID:-}" && -n "${GCP_P
     ) VALUES (
       $SQL_RECORD_ID, $SQL_STATUS, PENDING_COMMIT_TIMESTAMP(), PENDING_COMMIT_TIMESTAMP(), $SQL_USER, $SQL_JOB_REFERENCE, $SQL_AGENT_NAME,
       $SQL_DEVICE, $SQL_MODEL, $SQL_RUN_TYPE, $SQL_CODE_HASH,
-      $SQL_DIR_NAME, $SQL_FILE_NAME, $SQL_CASE_NAME,
+      $SQL_CASE_NAME,
       $SQL_MAX_NUM_SEQS, $SQL_MAX_NUM_BATCHED_TOKENS, $SQL_TENSOR_PARALLEL_SIZE, $SQL_MAX_MODEL_LEN,
       $SQL_DATASET, $SQL_INPUT_LEN, $SQL_OUTPUT_LEN,
       $SQL_EXPECTED_ETEL, $SQL_NUM_PROMPTS, $SQL_MODELTAG, $SQL_PREFIX_LEN,

--- a/.buildkite/benchmark/scripts/report_result.sh
+++ b/.buildkite/benchmark/scripts/report_result.sh
@@ -320,6 +320,9 @@ if [[ "${UPLOAD_DB:-true}" == "true" && -n "${GCP_DATABASE_ID:-}" && -n "${GCP_P
   SQL_MODEL=$(prepare_sql_val "${MODEL:-}" "")
   SQL_RUN_TYPE=$(prepare_sql_val "${RUN_TYPE:-DAILY}" "DAILY")
   SQL_CODE_HASH=$(prepare_sql_val "${CODE_HASH:-}" "")
+  SQL_DIR_NAME=$(prepare_sql_val "${DIR_NAME:-}" "")
+  SQL_FILE_NAME=$(prepare_sql_val "${FILE_NAME:-}" "")
+  SQL_CASE_NAME=$(prepare_sql_val "${TARGET_CASE_NAME:-}" "")
   SQL_DATASET=$(prepare_sql_val "${DATASET:-}" "")
   SQL_MODELTAG=$(prepare_sql_val "${MODELTAG:-PROD}" "PROD")
   SQL_CONFIG=$(prepare_sql_val "${CASE_CONFIG_JSON:-}" "{}")
@@ -338,6 +341,7 @@ if [[ "${UPLOAD_DB:-true}" == "true" && -n "${GCP_DATABASE_ID:-}" && -n "${GCP_P
   SQL="INSERT INTO RunRecord (
       RecordId, Status, CreatedTime, LastUpdate, CreatedBy, JobReference, RunBy,
       Device, Model, RunType, CodeHash,
+      DirName, FileName, CaseName,
       MaxNumSeqs, MaxNumBatchedTokens, TensorParallelSize, MaxModelLen,
       Dataset, InputLen, OutputLen,
       ExpectedETEL, NumPrompts, ModelTag, PrefixLen,
@@ -345,6 +349,7 @@ if [[ "${UPLOAD_DB:-true}" == "true" && -n "${GCP_DATABASE_ID:-}" && -n "${GCP_P
     ) VALUES (
       $SQL_RECORD_ID, $SQL_STATUS, PENDING_COMMIT_TIMESTAMP(), PENDING_COMMIT_TIMESTAMP(), $SQL_USER, $SQL_JOB_REFERENCE, $SQL_AGENT_NAME,
       $SQL_DEVICE, $SQL_MODEL, $SQL_RUN_TYPE, $SQL_CODE_HASH,
+      $SQL_DIR_NAME, $SQL_FILE_NAME, $SQL_CASE_NAME,
       $SQL_MAX_NUM_SEQS, $SQL_MAX_NUM_BATCHED_TOKENS, $SQL_TENSOR_PARALLEL_SIZE, $SQL_MAX_MODEL_LEN,
       $SQL_DATASET, $SQL_INPUT_LEN, $SQL_OUTPUT_LEN,
       $SQL_EXPECTED_ETEL, $SQL_NUM_PROMPTS, $SQL_MODELTAG, $SQL_PREFIX_LEN,

--- a/.buildkite/benchmark/scripts/report_result.sh
+++ b/.buildkite/benchmark/scripts/report_result.sh
@@ -258,6 +258,29 @@ if [[ "${UPLOAD_DB:-true}" == "true" && -n "${GCP_DATABASE_ID:-}" && -n "${GCP_P
     echo "--- run_bm.sh failed with exit code $EXIT_CODE. Skipping DB reporting."
     exit 0
   fi
+
+  MANDATORY_VARS=(
+    "RECORD_ID"
+    "DEVICE"
+    "MODEL"
+    "CODE_HASH"
+    "TARGET_CASE_NAME"
+    "DATASET"
+    "TENSOR_PARALLEL_SIZE"
+    "INPUT_LEN"
+    "OUTPUT_LEN"
+    "MAX_NUM_SEQS"
+    "MAX_NUM_BATCHED_TOKENS"
+    "MAX_MODEL_LEN"
+  )
+
+  for var_name in "${MANDATORY_VARS[@]}"; do
+    if [[ -z "${!var_name:-}" ]]; then
+      echo "Error: Environment variable $var_name is not set or empty. This is mandatory for database reporting." >&2
+      exit 1
+    fi
+  done
+
   BUILDKITE_AGENT_NAME="${BUILDKITE_AGENT_NAME:-local-test}"
 
   # Parse metric assignments for dynamic columns
@@ -311,17 +334,17 @@ if [[ "${UPLOAD_DB:-true}" == "true" && -n "${GCP_DATABASE_ID:-}" && -n "${GCP_P
   SQL_ADDITIONAL_CONFIG=$(prepare_sql_val "${ADDITIONAL_CONFIG:-}" "'{}'")
   SQL_EXTRA_ARGS=$(prepare_sql_val "${EXTRA_ARGS:-}" "''")
   SQL_EXTRA_ENVS=$(prepare_sql_val "${EXTRA_ENVS:-}" "''")
-  SQL_RECORD_ID=$(prepare_sql_val "$RECORD_ID" "")
+  SQL_RECORD_ID=$(prepare_sql_val "$RECORD_ID" "''")
   SQL_STATUS=$(prepare_sql_val "$FINAL_STATUS" "FAILED")
   SQL_USER=$(prepare_sql_val "${USER:-buildkite-agent}" "buildkite-agent")
-  SQL_JOB_REFERENCE=$(prepare_sql_val "${JOB_REFERENCE:-}" "")
-  SQL_AGENT_NAME=$(prepare_sql_val "${BUILDKITE_AGENT_NAME:-}" "")
-  SQL_DEVICE=$(prepare_sql_val "${DEVICE:-}" "")
-  SQL_MODEL=$(prepare_sql_val "${MODEL:-}" "")
+  SQL_JOB_REFERENCE=$(prepare_sql_val "${JOB_REFERENCE:-}" "''")
+  SQL_AGENT_NAME=$(prepare_sql_val "${BUILDKITE_AGENT_NAME:-}" "''")
+  SQL_DEVICE=$(prepare_sql_val "${DEVICE:-}" "''")
+  SQL_MODEL=$(prepare_sql_val "${MODEL:-}" "''")
   SQL_RUN_TYPE=$(prepare_sql_val "${RUN_TYPE:-DAILY}" "DAILY")
-  SQL_CODE_HASH=$(prepare_sql_val "${CODE_HASH:-}" "")
-  SQL_CASE_NAME=$(prepare_sql_val "${TARGET_CASE_NAME:-}" "")
-  SQL_DATASET=$(prepare_sql_val "${DATASET:-}" "")
+  SQL_CODE_HASH=$(prepare_sql_val "${CODE_HASH:-}" "''")
+  SQL_CASE_NAME=$(prepare_sql_val "${TARGET_CASE_NAME:-}" "''")
+  SQL_DATASET=$(prepare_sql_val "${DATASET:-}" "''")
   SQL_MODELTAG=$(prepare_sql_val "${MODELTAG:-PROD}" "PROD")
   SQL_CONFIG=$(prepare_sql_val "${CASE_CONFIG_JSON:-}" "{}")
 

--- a/.buildkite/benchmark/scripts/run_bm.sh
+++ b/.buildkite/benchmark/scripts/run_bm.sh
@@ -55,10 +55,13 @@ TARGET_CASE_NAME=${2:-""}
 VLLM_PID=""
 CLEANUP_DONE="false"
 
-if [ -z "$CASE_FILE" ]; then
-    echo "Usage: $0 <case.json> [TARGET_CASE_NAME]"
+if [ -z "$CASE_FILE" ] || [ -z "$TARGET_CASE_NAME" ]; then
+    echo "Usage: $0 <case.json> <TARGET_CASE_NAME>"
     exit 1
 fi
+
+export TARGET_CASE_NAME
+echo "TARGET_CASE_NAME: $TARGET_CASE_NAME"
 
 # shellcheck disable=SC2317
 cleanup() {

--- a/.buildkite/benchmark/scripts/run_job.sh
+++ b/.buildkite/benchmark/scripts/run_job.sh
@@ -19,10 +19,10 @@ readonly EXIT_SUCCESS=0
 readonly EXIT_FAILURE=1
 
 CASE_FILE="$1"
-TARGET_CASE_NAME=${2:-""}
+TARGET_CASE_NAME="$2"
 
-if [ -z "$CASE_FILE" ]; then
-    echo "Usage: $0 <case.json> [TARGET_CASE_NAME]"
+if [ -z "$CASE_FILE" ] || [ -z "$TARGET_CASE_NAME" ]; then
+    echo "Usage: $0 <case.json> <TARGET_CASE_NAME>"
     exit 1
 fi
 

--- a/.buildkite/benchmark/scripts/validate_case_names.py
+++ b/.buildkite/benchmark/scripts/validate_case_names.py
@@ -1,0 +1,104 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import os
+import sys
+from collections import defaultdict
+
+
+def validate_global_case_names(cases_root):
+    """
+    Validates that all case_name values across all JSON files in the 
+    cases_root directory are globally unique.
+    """
+    case_name_to_files = defaultdict(list)
+    files_processed = 0
+
+    print(f"Starting global case_name validation in: {cases_root}")
+
+    if not os.path.exists(cases_root):
+        print(f"Error: Directory {cases_root} not found.")
+        return False
+
+    has_errors = False
+    for root, _, files in os.walk(cases_root):
+        for file in files:
+            if file.endswith('.json'):
+                file_path = os.path.join(root, file)
+                files_processed += 1
+                try:
+                    with open(file_path, 'r') as f:
+                        data = json.load(f)
+                        if 'benchmark_cases' in data:
+                            for case in data['benchmark_cases']:
+                                case_name = case.get('case_name')
+                                if case_name:
+                                    case_name_to_files[case_name].append(
+                                        file_path)
+                                else:
+                                    print(
+                                        f"Error: Missing 'case_name' in {file_path}"
+                                    )
+                                    has_errors = True
+                except Exception as e:
+                    print(f"Error reading {file_path}: {e}")
+                    has_errors = True
+
+    if has_errors:
+        print("❌ Validation failed. Please fix the errors and try again.")
+        return False
+
+    duplicates = {
+        name: files
+        for name, files in case_name_to_files.items() if len(files) > 1
+    }
+
+    if duplicates:
+        print(
+            "❌ Validation Error: Duplicate case_names found across benchmark files!"
+        )
+        print(
+            "Each benchmark case must have a unique 'case_name' for database reporting."
+        )
+        for name, files in duplicates.items():
+            print(f"Duplicate Name: '{name}'")
+            print("Found in:")
+            for f in sorted(files):
+                print(f"  - {f}")
+        print(f"Total duplicate names found: {len(duplicates)}")
+        return False
+
+    print(f"✅ All {len(case_name_to_files)} case_names are globally unique.")
+    print(f"Processed {files_processed} files.")
+    return True
+
+
+if __name__ == "__main__":
+    # Dynamically find the git repository root
+    import subprocess
+    try:
+        repo_root = subprocess.check_output(
+            ['git', 'rev-parse', '--show-toplevel'],
+            stderr=subprocess.STDOUT).decode('utf-8').strip()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        # Fallback to structure-based detection if git is not available
+        script_dir = os.path.dirname(os.path.abspath(__file__))
+        repo_root = os.path.abspath(os.path.join(script_dir, "..", "..", ".."))
+
+    # Target directory for benchmark cases relative to repo root
+    target_dir = os.path.join(repo_root, ".buildkite/benchmark/cases")
+
+    if not validate_global_case_names(target_dir):
+        sys.exit(1)

--- a/.buildkite/scripts/bootstrap.sh
+++ b/.buildkite/scripts/bootstrap.sh
@@ -201,6 +201,10 @@ upload_benchmark_pipeline() {
             echo "$changed_cases"
             # Note: We keep changed_cases as a newline-separated string
             # to correctly handle filenames with spaces in process_json_benchmark_cases.
+
+            # Upload global case name validation step
+            upload_with_priority .buildkite/validate_benchmark_case_name.yml "$JOB_PRIORITY"
+            export BENCHMARK_VALIDATION_UPLOADED="true"
         fi
     fi
 

--- a/.buildkite/validate_benchmark_case_name.yml
+++ b/.buildkite/validate_benchmark_case_name.yml
@@ -1,0 +1,21 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+steps:
+  - label: "Validate Global Case Names Uniqueness"
+    key: "validate_benchmark_case_name"
+    agents:
+      queue: cpu
+    commands:
+      - "python3 .buildkite/benchmark/scripts/validate_case_names.py"


### PR DESCRIPTION
# Description

This PR aims to upload the CaseName field for Spanner reporting, and do the following changes:
    
 - Unified Parsing Logic: Refactored parsing scripts (parser_case.py, generate_bk_pipeline.py) to exclusively support the multi-case JSON structure (requiring the benchmark_cases key), removing legacy single-case handling.
 - Format Unification: Converted existing single-case JSONs to the multi-case format; the single-case structure is now deprecated in favor of a unified schema.
 - CaseName Integrity: 
     - Added a global validation step (validate_case_names.py) to ensure all case_name values are unique across the repository, preventing grouping collisions in bm-infra dashboards.
     - Integrated this validation as a mandatory Buildkite gate for PRs modifying benchmark configs.
 - Hardened DB Reporting: 
     - Updated report_result.sh to include `CaseName` in database reporting.
     - Ensures all mandatory environment variables (e.g., RECORD_ID, MODEL, INPUT_LEN, OUTPUT_LEN) are present and correctly handled in SQL (e.g., using '' as default for string values).
- Update the `.buildkite/benchmark/README.md` for new structure

# Tests

[buildkite](https://buildkite.com/tpu-commons/tpu-inference-ci/builds/19505/canvas) (duplicate case_name)

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
