### PR TITLE
Remove the logic to force change the compilation_config

### DIFF
--- a/tests/platforms/test_tpu_platform.py
+++ b/tests/platforms/test_tpu_platform.py
@@ -176,7 +176,6 @@ class TestTpuPlatform:
 
         TpuPlatform.check_and_update_config(vllm_config)
 
-        assert vllm_config.compilation_config.backend == "eager"
         assert vllm_config.parallel_config.distributed_executor_backend == "uni"
         assert vllm_config.scheduler_config.disable_chunked_mm_input is False
 

--- a/tests/platforms/test_tpu_platform.py
+++ b/tests/platforms/test_tpu_platform.py
@@ -17,7 +17,7 @@ from unittest.mock import MagicMock, PropertyMock, patch
 import jax.numpy as jnp
 import pytest
 import torch
-from vllm.config import CacheConfig, CompilationMode, ModelConfig, VllmConfig
+from vllm.config import CacheConfig, ModelConfig, VllmConfig
 
 from tpu_inference.platforms.tpu_platform import TpuPlatform
 
@@ -37,8 +37,7 @@ class TestTpuPlatform:
         vllm_config.scheduler_config = MagicMock(is_multimodal_model=False)
         vllm_config.parallel_config = MagicMock()
         vllm_config.sharding_config = MagicMock()
-        vllm_config.compilation_config = MagicMock(mode="dynamo_trace_once",
-                                                   backend="openxla")
+        vllm_config.compilation_config = MagicMock(backend="eager")
         vllm_config.kv_transfer_config = None
         return vllm_config
 
@@ -177,8 +176,7 @@ class TestTpuPlatform:
 
         TpuPlatform.check_and_update_config(vllm_config)
 
-        assert vllm_config.compilation_config.mode == CompilationMode.DYNAMO_TRACE_ONCE
-        assert vllm_config.compilation_config.backend == "openxla"
+        assert vllm_config.compilation_config.backend == "eager"
         assert vllm_config.parallel_config.distributed_executor_backend == "uni"
         assert vllm_config.scheduler_config.disable_chunked_mm_input is False
 

--- a/tpu_inference/platforms/tpu_platform.py
+++ b/tpu_inference/platforms/tpu_platform.py
@@ -89,6 +89,7 @@ class TpuPlatform(Platform):
     dispatch_key: str = "XLA"
     ray_device_key: str = "TPU"
     device_control_env_var: str = "TPU_VISIBLE_CHIPS"
+    # Bypass torch.compile; torchax defers all compilation to JAX
     simple_compile_backend: str = "eager"
 
     supported_quantization: list[str] = [

--- a/tpu_inference/platforms/tpu_platform.py
+++ b/tpu_inference/platforms/tpu_platform.py
@@ -89,7 +89,7 @@ class TpuPlatform(Platform):
     dispatch_key: str = "XLA"
     ray_device_key: str = "TPU"
     device_control_env_var: str = "TPU_VISIBLE_CHIPS"
-    simple_compile_backend: str = "openxla"
+    simple_compile_backend: str = "eager"
 
     supported_quantization: list[str] = [
         "compressed-tensors", "awq", "fp8", "gpt_oss_mxfp4", "modelopt_fp4",
@@ -209,18 +209,6 @@ class TpuPlatform(Platform):
                     "variable to be set and DP attention set via: --additional_config \'{\"sharding\": {\"sharding_strategy\": {\"enable_dp_attention\": true}}}\'"
                 )
         cls._initialize_sharding_config(vllm_config)
-
-        from vllm.config import CompilationMode
-
-        compilation_config = vllm_config.compilation_config
-
-        # TPU only supports DYNAMO_TRACE_ONCE compilation level
-        # NOTE(xiang): the compilation_config is not used by jax.
-        if compilation_config.mode != CompilationMode.DYNAMO_TRACE_ONCE:
-            compilation_config.mode = CompilationMode.DYNAMO_TRACE_ONCE
-
-        if compilation_config.backend == "":
-            compilation_config.backend = "openxla"
 
         cache_config = vllm_config.cache_config
         # For v0, the default block size is 16.


### PR DESCRIPTION
### Description
This PR removes the hardcoded CompilationMode.DYNAMO_TRACE_ONCE override in TpuPlatform and sets simple_compile_backend = "eager". This prevents torch.compile from interfering with the torchax JAX compilation pipeline and enhance the robustness of the system.

### Why the original author forced change to CompilationMode.DynamoOnce
The original override was a workaround to bypass a string parsing crash. By forcing DYNAMO_TRACE_ONCE, the config initialization returns early on vllm side [vllm/config/compilation.py](https://github.com/vllm-project/vllm/blob/main/vllm/config/compilation.py#L1065):

```
# vllm/config/compilation.py
if self.mode in [
    CompilationMode.STOCK_TORCH_COMPILE,
    CompilationMode.DYNAMO_TRACE_ONCE,  # <--- Returns early here
]:
    if self.backend in torch_backends:
        return self.backend
    return resolve_obj_by_qualname(self.backend)

assert self.mode == CompilationMode.VLLM_COMPILE
# If it proceeds to VllmBackend, it will later crash on resolve_obj_by_qualname("openxla")
# because "openxla" does not contain a module path ('.').
return VllmBackend(vllm_config, prefix=prefix, is_encoder=is_encoder)
```
While this successfully bypassed the resolve_obj_by_qualname error, it introduced redundant compilations.

### What the redundant compilation does to the current system

We caught this issue while importing vllm to google internal (i.e., certain Triton kernels are missing from google internal), where Dynamo crashes immediately during tracing (found no compiled frames) at the early stage. Since TPU performance purely relies on JAX's `@jax.jit` compiling the XLA graph for both torchax and Jax models, neither path requires `torch.compile(backend="openxla")`—native Jax models bypass Torch inherently, and torchax models seamlessly defer XLA compilation to JAX via dispatch modes. Therefore, any `torch.compile` intervention is meaningless and makes the system fragile.

### What is the eager backend
By setting `simple_compile_backend = "eager"` in TpuPlatform and removing the forced overrides, we elegantly route the pipeline to vLLM's internal `EagerAdaptor`.

As shown in [vllm/compilation/backends.py](https://github.com/vllm-project/vllm/blob/main/vllm/compilation/backends.py#L96,L116):
```
def make_compiler(compilation_config: CompilationConfig) -> CompilerInterface:
    # ...
    elif compilation_config.backend == "eager":
        logger.debug("Using EagerAdaptor")
        return EagerAdaptor()  # <--- 
```
The EagerAdaptor is a pure No-Op compiler leaving the torchax environment intact so that PyTorch ops can seamlessly flow into JAX's compilation, [vllm/compilation/compiler_interface.py](https://github.com/vllm-project/vllm/blob/a55fccfc7cefc2d085d3557bace0e345cef67961/vllm/compilation/compiler_interface.py#L768-L782):

```
class EagerAdaptor(CompilerInterface):
    name = "eager"

    def compile(self, graph: fx.GraphModule, ...) -> tuple[Callable[..., Any] | None, Any | None]:
        compilation_counter.num_eager_compiles += 1
        # we don't need to compile the graph, just return the graph itself.
        # It does not support caching, return None for the handle.
        return graph, None
```

### Tests
#### Functional Tests
- All PR tests passed. Shown as current PR checks.
- Nightly tests has only 6 tests(3 per tpu type) failed, exactly **same error**(main has 2 more failiures) as current main's nightly Build
  - Nightly tests for this PR - https://buildkite.com/tpu-commons/tpu-inference-ci/builds/19470/list
  - Nightly tests for main - https://buildkite.com/tpu-commons/tpu-inference-ci/builds/19403/list
  
#### Performance Tests
check the benchmark Build from the PR nightly and main HEAD nightly above
- benchmark with this PR - [bm_log](https://buildkite.com/tpu-commons/tpu-inference-ci/builds/19470/canvas?sid=019e951f-6ae5-4ffa-b5fc-ad113fd91e58&tab=artifacts)
- benchmark at main HEAD - [bm_log](https://buildkite.com/tpu-commons/tpu-inference-ci/builds/19403/canvas?sid=019e916e-e310-41f0-be11-7ab194aa0c42&tab=artifacts)

All the metrics(throughput, TTFT, TPOT,ITL,E2EL) variance are **less than 1%**. On tpuv7x, the benchmark with this PR **is better on every metrics** for the benchmark at main HEAD.