### PR TITLE
Fix VMEM weight dequantization shape mismatch and device topology sor…

### DIFF
--- a/tests/kernels/gmm_test.py
+++ b/tests/kernels/gmm_test.py
@@ -767,7 +767,6 @@ class GmmTest(jtu.JaxTestCase):
         tile_info = TileSizes(tile_m=128, tile_k=tile_k, tile_n=out_size)
 
         # Trace the kernel using jax.make_jaxpr to verify it compiles/traces without shape mismatch.
-        # This is safe to run on any backend (CPU/GPU/TPU) because it doesn't execute or lower.
         try:
             jax.make_jaxpr(lambda lhs_in, rhs_in, gs_in, rs_in, go_in: gmm_v2(
                 lhs_in,

--- a/tests/kernels/gmm_test.py
+++ b/tests/kernels/gmm_test.py
@@ -738,6 +738,49 @@ class GmmTest(jtu.JaxTestCase):
 
         self.assertArraysAllClose(actual, expected, atol=atol, rtol=rtol)
 
+    def test_gmm_weight_quantized_tile_k_not_divisible_by_block_size(self):
+        """Test GMM with tile_k not a multiple of block_size."""
+        batch_size = 128
+        in_size = 320
+        out_size = 512
+        num_groups = 8
+        weight_dtype = jnp.int8
+        block_size = 160
+        tile_k = 256
+
+        num_local_groups = num_groups
+        key = jax.random.key(0)
+
+        lhs = jax.random.uniform(key, (batch_size, in_size), jnp.bfloat16, -1,
+                                 1)
+        rhs = jax.random.uniform(key, (num_local_groups, in_size, out_size),
+                                 jnp.bfloat16, -1, 1)
+        rhs_q, rhs_scale = quantize_tensor(rhs,
+                                           weight_dtype,
+                                           axis=1,
+                                           block_size=block_size)
+        rhs_scale = jnp.expand_dims(rhs_scale, axis=2)
+
+        group_sizes = get_group_sizes(batch_size, num_groups)
+        group_offset = jnp.array(0, dtype=jnp.int32)
+
+        tile_info = TileSizes(tile_m=128, tile_k=tile_k, tile_n=out_size)
+
+        # Trace the kernel using jax.make_jaxpr to verify it compiles/traces without shape mismatch.
+        # This is safe to run on any backend (CPU/GPU/TPU) because it doesn't execute or lower.
+        try:
+            jax.make_jaxpr(lambda lhs_in, rhs_in, gs_in, rs_in, go_in: gmm_v2(
+                lhs_in,
+                rhs_in,
+                gs_in,
+                rhs_scale=rs_in,
+                group_offset=go_in,
+                tile_info=tile_info,
+                maybe_quantize_lhs=False,
+            ))(lhs, rhs_q, group_sizes, rhs_scale, group_offset)
+        except TypeError as e:
+            self.fail(f"gmm_v2 failed to trace: {e}")
+
 
 if __name__ == "__main__":
     absltest.main(testLoader=jtu.JaxTestLoader())

--- a/tpu_inference/kernels/megablox/gmm_v2.py
+++ b/tpu_inference/kernels/megablox/gmm_v2.py
@@ -396,11 +396,27 @@ def inner_kernel(
         if cfgs.rhs_cfgs.should_dequantize_before_matmul:
             tiled_rhs_scale = tiled_rhs_ref.get_scale().astype(acc_ref.dtype)
             num_blocks = cfgs.num_quant_blocks_per_tile_k
-            tiled_rhs_dequant = tiled_rhs.astype(acc_ref.dtype).reshape(
+
+            # Pad tiled_rhs along K dimension if tile_k is not a multiple of quant_block_size,
+            # to avoid shape mismatch during reshape. For example, if tile_k = 256
+            # and quant_block_size = 160 (num_blocks = 2), pad 64 rows to reach 320.
+            pad_len = num_blocks * rhs_qbs - cfgs.tiles.tile_k
+            if pad_len > 0:
+                zeros = jnp.zeros((pad_len, rhs_tile_n), dtype=tiled_rhs.dtype)
+                padded_rhs = jnp.concatenate([tiled_rhs, zeros], axis=0)
+            else:
+                padded_rhs = tiled_rhs
+
+            tiled_rhs_dequant = padded_rhs.astype(acc_ref.dtype).reshape(
                 num_blocks, rhs_qbs, rhs_tile_n)
             tiled_rhs_dequant = tiled_rhs_dequant * tiled_rhs_scale
-            tiled_rhs = tiled_rhs_dequant.reshape(cfgs.tiles.tile_k,
-                                                  rhs_tile_n)
+
+            # Flatten the block-dequantized weights back to 2D and slice off
+            # the zero-padding rows to restore the original tile_k dimension
+            # (e.g., flatten 320 rows back to 2D and slice [:256, :] to trim 64 rows).
+            tiled_rhs = tiled_rhs_dequant.reshape(-1, rhs_tile_n)
+            if pad_len > 0:
+                tiled_rhs = tiled_rhs[:cfgs.tiles.tile_k, :]
             rhs_step_k = cfgs.tiles.tile_k
         else:
             rhs_step_k = rhs_qbs

--- a/tpu_inference/kernels/megablox/gmm_v2.py
+++ b/tpu_inference/kernels/megablox/gmm_v2.py
@@ -397,26 +397,21 @@ def inner_kernel(
             tiled_rhs_scale = tiled_rhs_ref.get_scale().astype(acc_ref.dtype)
             num_blocks = cfgs.num_quant_blocks_per_tile_k
 
-            # Pad tiled_rhs along K dimension if tile_k is not a multiple of quant_block_size,
-            # to avoid shape mismatch during reshape. For example, if tile_k = 256
-            # and quant_block_size = 160 (num_blocks = 2), pad 64 rows to reach 320.
-            pad_len = num_blocks * rhs_qbs - cfgs.tiles.tile_k
-            if pad_len > 0:
-                zeros = jnp.zeros((pad_len, rhs_tile_n), dtype=tiled_rhs.dtype)
-                padded_rhs = jnp.concatenate([tiled_rhs, zeros], axis=0)
-            else:
-                padded_rhs = tiled_rhs
+            # Squeeze out the middle singleton dimension (axis 1) from the BlockSpec layout
+            # so that tiled_rhs_scale becomes a clean 2D matrix
+            if tiled_rhs_scale.ndim == 3:
+                tiled_rhs_scale = jnp.squeeze(tiled_rhs_scale, axis=1)
 
-            tiled_rhs_dequant = padded_rhs.astype(acc_ref.dtype).reshape(
-                num_blocks, rhs_qbs, rhs_tile_n)
-            tiled_rhs_dequant = tiled_rhs_dequant * tiled_rhs_scale
+            # Determine the exact safe upper bound for the K dimension
+            k_bound = min(num_blocks * rhs_qbs, cfgs.tiles.tile_k)
 
-            # Flatten the block-dequantized weights back to 2D and slice off
-            # the zero-padding rows to restore the original tile_k dimension
-            # (e.g., flatten 320 rows back to 2D and slice [:256, :] to trim 64 rows).
-            tiled_rhs = tiled_rhs_dequant.reshape(-1, rhs_tile_n)
-            if pad_len > 0:
-                tiled_rhs = tiled_rhs[:cfgs.tiles.tile_k, :]
+            # Stretch the small scale matrix along the K axis to match the blocks,
+            # then slice it to match the weight matrix tile size exactly.
+            expanded_scale = jnp.repeat(tiled_rhs_scale, rhs_qbs,
+                                        axis=0)[:k_bound, :]
+
+            # Dequantize directly—no padding, no weight reshaping, zero VMEM allocation overhead
+            tiled_rhs = tiled_rhs.astype(acc_ref.dtype) * expanded_scale
             rhs_step_k = cfgs.tiles.tile_k
         else:
             rhs_step_k = rhs_qbs


### PR DESCRIPTION
# Description

The vLLM server crashes when attempting to deploy the Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8 model on a TPU v7 machine with multi-host

vllm command
```
bash /workspace/vllm/examples/online_serving/multi-node-serving.sh leader --ray_cluster_size=$(LWS_GROUP_SIZE);
                VLLM_DISABLE_SHARED_EXPERTS_STREAM=1 vllm serve --port 8000 \
                  --model=Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8 \
                  --enable-chunked-prefill \
                  --seed 42 \
                  --enable_prefix_caching \
                  --tensor-parallel-size 16 \
                  --no-async-scheduling \
                  --gpu-memory-utilization=0.9 \
                  --kv_cache_dtype=fp8 \
                  --max-model-len=8192
```
Error log
```
(EngineCore pid=15772) Process EngineCore:
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]                                   ^^^^^^^^^^^^^^^^^^^
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]   File "/usr/local/lib/python3.12/site-packages/ray/_private/worker.py", line 1023, in get_objects
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]     raise value.as_instanceof_cause()
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165] ray.exceptions.RayTaskError(TypeError): [36mray::RayWorkerWrapper.execute_method()[39m (pid=364, ip=10.56.0.61, actor_id=b135c4a8a8cb1a7cad3d151802000000, repr=<tpu_inference.executors.ray_distributed_executor.RayWorkerWrapper object at 0x7c0256836c30>)
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]   File "/workspace/vllm/vllm/v1/executor/ray_utils.py", line 91, in execute_method
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]     raise e
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]   File "/workspace/vllm/vllm/v1/executor/ray_utils.py", line 81, in execute_method
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]     return run_method(self, method, args, kwargs)
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]   File "/workspace/vllm/vllm/v1/serial_utils.py", line 510, in run_method
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]     return func(*args, **kwargs)
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]            ^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]   File "/workspace/tpu_inference/tpu_inference/worker/tpu_worker.py", line 504, in compile_or_warm_up_model
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]     self.model_runner.capture_model()
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]   File "/workspace/tpu_inference/tpu_inference/runner/tpu_runner.py", line 783, in capture_model
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]     self.compilation_manager.capture_model()
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]   File "/workspace/tpu_inference/tpu_inference/runner/compilation_manager.py", line 114, in capture_model
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]     self._precompile_backbone_text_only()
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]   File "/workspace/tpu_inference/tpu_inference/runner/compilation_manager.py", line 481, in _precompile_backbone_text_only
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]     self._precompile_backbone_helper(
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]   File "/workspace/tpu_inference/tpu_inference/runner/compilation_manager.py", line 311, in _precompile_backbone_helper
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]     self._run_compilation(
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]   File "/workspace/tpu_inference/tpu_inference/runner/compilation_manager.py", line 101, in _run_compilation
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]     result = fn(*args, **call_kwargs)
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]              ^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]   File "/workspace/tpu_inference/tpu_inference/runner/compilation_manager.py", line 299, in model_fn_wrapper
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]     kv_caches, hidden_states, *_ = self.runner.model_fn(
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]                                    ^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]   File "/workspace/tpu_inference/tpu_inference/models/vllm/vllm_model_wrapper.py", line 331, in step_fun
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]     output_from_torch = torch.func.functional_call(
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]   File "/usr/local/lib/python3.12/site-packages/torch/_functorch/functional_call.py", line 153, in functional_call
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]     return nn.utils.stateless._functional_call(
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]   File "/usr/local/lib/python3.12/site-packages/torch/nn/utils/stateless.py", line 279, in _functional_call
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]     return module(*args, **kwargs)
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]            ^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]   File "/usr/local/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1776, in _wrapped_call_impl
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]     return self._call_impl(*args, **kwargs)
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]   File "/usr/local/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1787, in _call_impl
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]     return forward_call(*args, **kwargs)
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]   File "/workspace/tpu_inference/tpu_inference/models/vllm/vllm_model_wrapper.py", line 94, in forward
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]     return self.compute_hidden_state(kwargs)
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]   File "/workspace/tpu_inference/tpu_inference/models/vllm/vllm_model_wrapper.py", line 97, in compute_hidden_state
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]     return self.vllm_model(**kwargs)
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]            ^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]   File "/usr/local/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1776, in _wrapped_call_impl
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]     return self._call_impl(*args, **kwargs)
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]   File "/usr/local/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1787, in _call_impl
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]     return forward_call(*args, **kwargs)
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]   File "/workspace/vllm/vllm/model_executor/models/qwen3_moe.py", line 771, in forward
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]     hidden_states = self.model(
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]                     ^^^^^^^^^^^
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]   File "/workspace/vllm/vllm/compilation/decorators.py", line 678, in __call__
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]     output = TorchCompileWithNoGuardsWrapper.__call__(
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]   File "/workspace/vllm/vllm/compilation/wrapper.py", line 181, in __call__
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]     return self._call_with_optional_nvtx_range(
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]   File "/workspace/vllm/vllm/compilation/wrapper.py", line 70, in _call_with_optional_nvtx_range
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]     return callable_fn(*args, **kwargs)
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]   File "/usr/local/lib/python3.12/site-packages/torch/_dynamo/eval_frame.py", line 981, in compile_wrapper
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]     _maybe_set_eval_frame(prior)
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]   File "/workspace/vllm/vllm/model_executor/models/qwen3_moe.py", line 503, in forward
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]     hidden_states, residual = layer(positions, hidden_states, residual)
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]   File "/usr/local/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1776, in _wrapped_call_impl
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]     return self._call_impl(*args, **kwargs)
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]   File "/usr/local/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1787, in _call_impl
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]     return forward_call(*args, **kwargs)
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]   File "/workspace/vllm/vllm/model_executor/models/qwen3_moe.py", line 435, in forward
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]     hidden_states = self.mlp(hidden_states)
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]                     ^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]   File "/usr/local/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1776, in _wrapped_call_impl
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]     return self._call_impl(*args, **kwargs)
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]   File "/usr/local/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1787, in _call_impl
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]     return forward_call(*args, **kwargs)
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]   File "/workspace/vllm/vllm/model_executor/models/qwen3_moe.py", line 239, in forward
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]     final_hidden_states = self.experts(
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]                           ^^^^^^^^^^^^^
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]   File "/usr/local/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1776, in _wrapped_call_impl
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]     return self._call_impl(*args, **kwargs)
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]   File "/usr/local/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1787, in _call_impl
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]     return forward_call(*args, **kwargs)
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]   File "/workspace/tpu_inference/tpu_inference/layers/vllm/custom_ops/fused_moe.py", line 57, in forward
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]     return super().forward(hidden_states, router_logits)
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]   File "/workspace/vllm/vllm/model_executor/layers/fused_moe/layer.py", line 1312, in forward
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]     return self.runner.forward(
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]            ^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]   File "/workspace/vllm/vllm/model_executor/layers/fused_moe/runner/moe_runner.py", line 637, in forward
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]     result = self._forward_entry(
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]              ^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]   File "/workspace/vllm/vllm/model_executor/layers/fused_moe/runner/moe_runner.py", line 99, in _moe_forward
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]     return layer.runner._forward_impl(
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]   File "/workspace/vllm/vllm/model_executor/layers/fused_moe/runner/moe_runner.py", line 790, in _forward_impl
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]     shared_output, hidden_states = self._apply_quant_method(
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]                                    ^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]   File "/workspace/vllm/vllm/model_executor/layers/fused_moe/runner/moe_runner.py", line 517, in _apply_quant_method
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]     fused_out = self._quant_method.apply_monolithic(
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]   File "/workspace/tpu_inference/tpu_inference/layers/vllm/quantization/fp8.py", line 318, in apply_monolithic
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]     return vllm_moe_apply(layer=layer,
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]   File "/workspace/tpu_inference/tpu_inference/layers/vllm/interface/moe.py", line 112, in vllm_moe_apply
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]     moe_apply(
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]   File "/workspace/tpu_inference/tpu_inference/layers/common/moe.py", line 136, in moe_apply
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]     output = fused_moe_func(
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]              ^^^^^^^^^^^^^^^
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]   File "/workspace/tpu_inference/tpu_inference/layers/common/fused_moe_gmm.py", line 653, in fused_moe_func
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]     x = tensor_parallel_gmm(
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]         ^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]   File "/workspace/tpu_inference/tpu_inference/layers/common/fused_moe_gmm.py", line 321, in tensor_parallel_gmm
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]     return jax.shard_map(
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]            ^^^^^^^^^^^^^^
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]   File "/workspace/tpu_inference/tpu_inference/layers/common/fused_moe_gmm.py", line 179, in moe_gmm_local
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]     gmm2_res = gmm_wrapper(gmm1_res, w2, w2_scale, w2_bias, group_sizes,
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]   File "/workspace/tpu_inference/tpu_inference/layers/common/fused_moe_gmm.py", line 107, in gmm_wrapper
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]     gmm_res = gmm_v2(
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]               ^^^^^^^
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]   File "/workspace/tpu_inference/tpu_inference/kernels/megablox/gmm_v2.py", line 1325, in gmm_v2
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]     return pl.pallas_call(
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]            ^^^^^^^^^^^^^^^
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]   File "/usr/local/lib/python3.12/site-packages/jax/_src/pallas/pallas_call.py", line 1561, in wrapped
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]     jaxpr, consts = _trace_kernel_to_jaxpr(
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]                     ^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]   File "/usr/local/lib/python3.12/site-packages/jax/_src/pallas/pallas_call.py", line 1069, in _trace_kernel_to_jaxpr
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]     jaxpr, _, consts = pe.trace_to_jaxpr_dynamic(
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]                        ^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]   File "/usr/local/lib/python3.12/site-packages/jax/_src/pallas/primitives.py", line 650, in wrap_with_transforms
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]     return f(*new_args)
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]            ^^^^^^^^^^^^
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]   File "/workspace/tpu_inference/tpu_inference/kernels/megablox/gmm_v2.py", line 872, in kernel_main
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]     pipeline_fn(lhs_in, rhs_ref, out_in, scratches=scratches)
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]   File "/usr/local/lib/python3.12/site-packages/jax/_src/pallas/mosaic/pipeline.py", line 1634, in pipeline
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]     return primitives.run_scoped(
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]            ^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]   File "/usr/local/lib/python3.12/site-packages/jax/_src/pallas/primitives.py", line 710, in run_scoped
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]     jaxpr, _, consts = pe.trace_to_jaxpr_dynamic(flat_fun, avals)
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]   File "/usr/local/lib/python3.12/site-packages/jax/_src/pallas/primitives.py", line 650, in wrap_with_transforms
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]     return f(*new_args)
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]            ^^^^^^^^^^^^
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]   File "/usr/local/lib/python3.12/site-packages/jax/_src/pallas/mosaic/pipeline.py", line 1635, in <lambda>
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]     lambda allocations: pipeline(
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]                         ^^^^^^^^^
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]   File "/usr/local/lib/python3.12/site-packages/jax/_src/pallas/mosaic/pipeline.py", line 1730, in pipeline
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]     @pl.when(num_steps > 0)
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]      ^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]   File "/usr/local/lib/python3.12/site-packages/jax/_src/pallas/helpers.py", line 86, in _wrapped
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]     conditionals.cond(condition, f, lambda: None)
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]   File "/usr/local/lib/python3.12/site-packages/jax/_src/pallas/mosaic/pipeline.py", line 1751, in _
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]     brefs, next_indices = lax.fori_loop(
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]                           ^^^^^^^^^^^^^^
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]   File "/usr/local/lib/python3.12/site-packages/jax/_src/pallas/mosaic/pipeline.py", line 1681, in loop_body
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]     body(*current_refs, *scratches)
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]   File "/workspace/tpu_inference/tpu_inference/kernels/megablox/gmm_v2.py", line 587, in inner_kernel
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]     lax.cond(
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]   File "/workspace/tpu_inference/tpu_inference/kernels/megablox/gmm_v2.py", line 589, in <lambda>
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]     lambda: lax.cond(
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]             ^^^^^^^^^
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]   File "/usr/local/lib/python3.12/contextlib.py", line 81, in inner
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]     return func(*args, **kwds)
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]            ^^^^^^^^^^^^^^^^^^^
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]   File "/workspace/tpu_inference/tpu_inference/kernels/megablox/gmm_v2.py", line 566, in matmul_first_last
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]     _matmul(is_first_k_step=True, is_last_k_step=True)
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]   File "/workspace/tpu_inference/tpu_inference/kernels/megablox/gmm_v2.py", line 386, in _matmul
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]     tiled_rhs_dequant = tiled_rhs.astype(acc_ref.dtype).reshape(
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]   File "/usr/local/lib/python3.12/site-packages/jax/_src/numpy/array_methods.py", line 1473, in meth
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]     return getattr(self.aval, name).fun(self, *args, **kwargs)
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]   File "/usr/local/lib/python3.12/site-packages/jax/_src/numpy/array_methods.py", line 375, in _reshape
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]     newshape = _compute_newshape(self, args[0] if len(args) == 1 else args)
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]   File "/usr/local/lib/python3.12/site-packages/jax/_src/numpy/array_methods.py", line 542, in _compute_newshape
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165]     raise TypeError(f"cannot reshape array of shape {arr.shape} (size {arr.size}) "
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165] TypeError: cannot reshape array of shape (256, 6144) (size 1572864) into shape (2, 160, 6144) (size 1966080)
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165] --------------------
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165] For simplicity, JAX has removed its internal frames from the traceback of the following exception. Set JAX_TRACEBACK_FILTERING=off to include these.
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165] --------------------
(EngineCore pid=15772) ERROR 05-27 23:12:23 [v1/engine/core.py:1165] For simplicity, JAX has removed its internal frames from the traceback of the following exception. Set JAX_TRACEBACK_FILTERING=off to include these.
```
Analysis:

The problem occurs in quantized model execution (specifically Grouped Matrix Multiplication / MoE kernels) when the tile size of the reduction/matrix multiplication dimension is not a multiple of the quantization block size.

Based on the error traceback on 

> `TypeError: cannot reshape array of shape (256, 6144) (size 1572864) into shape (2, 160, 6144) (size 1966080)`

We can extract the values by mapping the shapes back to the code logic in `gmm_v2.py`:

1. **`tile_k` = 256**
   * The input `tiled_rhs` has the shape `(cfgs.tiles.tile_k, rhs_tile_n)`. 
   * In the error log, the source shape is `(256, 6144)`. This means **`cfgs.tiles.tile_k` (tile_k) is 256**.

2. **`quant_block_size` = 160**
   * The dequantization code attempts to reshape `tiled_rhs` into `(num_blocks, rhs_qbs, rhs_tile_n)`.
   * In the error log, the target shape is `(2, 160, 6144)`. 
   * This means **`rhs_qbs` (the quantization block size) is 160**, and the number of blocks calculated per tile (`num_blocks`) is `2`. 

### Summary of the mismatch:
* The kernel tries to process 256 elements along the reduction dimension.
* The quantization block size is 160. To cover all 256 elements, the kernel requires 2 quantization blocks (total of 2 * 160 = 320 elements). 
* Since the actual tile size (256) is smaller than the required size of two full blocks (320), the reshape fails because JAX cannot reshape a size-1,572,864 array into a size-1,966,800 array.

# Tests

tests/kernels/gmm_test.py

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
