### PR TITLE
add short conv1d kernel

### DIFF
--- a/tests/kernels/short_conv1d_test.py
+++ b/tests/kernels/short_conv1d_test.py
@@ -1,0 +1,179 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import jax.numpy as jnp
+import numpy as np
+from absl.testing import absltest, parameterized
+from jax._src import test_util as jtu
+from tpu_inference.kernels.causal_conv1d import causal_conv1d
+from tpu_inference.kernels.experimental.short_conv1d import short_conv1d
+
+
+def _make_inputs(
+    *,
+    lengths: list[int],
+    H: int = 2,
+    max_reqs: int | None = None,
+    has_initial_state: list[bool] | None = None,
+):
+    rng = np.random.default_rng(123)
+    D, W = 128, 4
+    total = len(lengths)
+    num_tokens = sum(lengths)
+    max_reqs = max(max_reqs or total, total)
+    n_states = max_reqs + 5
+
+    cu_seqlens = np.full((max_reqs + 1, ), num_tokens, dtype=np.int32)
+    cu_seqlens[:total + 1] = np.concatenate([[0], np.cumsum(lengths)])
+
+    state_indices = np.zeros((max_reqs, ), dtype=np.int32)
+    slots = np.array([3, 1, 5, 2, 7, 4, 6, 8], dtype=np.int32)
+    state_indices[:] = slots[np.arange(max_reqs) % slots.size] % n_states
+
+    has_init = np.ones((max_reqs, ), dtype=np.int32)
+    if has_initial_state is not None:
+        has_init[:total] = np.array(has_initial_state, dtype=np.int32)
+
+    x = (rng.normal(size=(num_tokens, H, D)) * 0.2).astype(np.float32)
+    weight = (rng.normal(size=(W, H, D)) * 0.2).astype(np.float32)
+    conv_state = (rng.normal(size=(n_states, W - 1, H, D)) * 0.2).astype(
+        np.float32)
+    return x, weight, conv_state, cu_seqlens, state_indices, has_init
+
+
+@jtu.with_config(jax_numpy_dtype_promotion="standard")
+class ShortConv1dTest(jtu.JaxTestCase):
+
+    @parameterized.named_parameters(
+        dict(
+            testcase_name="decode_only",
+            lengths=[1, 1, 1, 1, 1, 1, 1, 1],
+            decode_end=8,
+            has_initial_state=None,
+            max_reqs=None,
+            H=2,
+            decoding_block_n=None,
+            prefill_block_n=None,
+        ),
+        dict(
+            testcase_name="decode_only_partial_tile",
+            lengths=[1] * 10,
+            decode_end=10,
+            has_initial_state=None,
+            max_reqs=None,
+            H=2,
+            decoding_block_n=None,
+            prefill_block_n=None,
+        ),
+        dict(
+            testcase_name="prefill_only_with_fresh_slots",
+            lengths=[5, 7, 3],
+            decode_end=0,
+            has_initial_state=[True, False, True],
+            max_reqs=None,
+            H=2,
+            decoding_block_n=None,
+            prefill_block_n=None,
+        ),
+        dict(
+            testcase_name="prefill_multi_block_forced_tile",
+            lengths=[20],
+            decode_end=0,
+            has_initial_state=[False],
+            max_reqs=None,
+            H=2,
+            decoding_block_n=None,
+            prefill_block_n=8,
+        ),
+        dict(
+            testcase_name="mixed_large_token_count_small_req_count",
+            lengths=[1, 1, 35, 35],
+            decode_end=2,
+            has_initial_state=[True, True, False, True],
+            max_reqs=16,
+            H=2,
+            decoding_block_n=None,
+            prefill_block_n=None,
+        ),
+        dict(
+            testcase_name="mixed_qwen_head_shape",
+            lengths=[1, 1, 5, 7],
+            decode_end=2,
+            has_initial_state=[True, True, False, True],
+            max_reqs=16,
+            H=96,
+            decoding_block_n=None,
+            prefill_block_n=None,
+        ),
+    )
+    def test_matches_legacy_causal_conv1d(
+        self,
+        lengths,
+        decode_end,
+        has_initial_state,
+        max_reqs,
+        H,
+        decoding_block_n,
+        prefill_block_n,
+    ):
+        x, weight, conv_state, cu_seqlens, state_indices, has_init = _make_inputs(
+            lengths=lengths,
+            H=H,
+            max_reqs=max_reqs,
+            has_initial_state=has_initial_state,
+        )
+        H, D = x.shape[1:]
+        W = weight.shape[0]
+        total = len(lengths)
+
+        out, new_conv_state = short_conv1d(
+            jnp.array(x, dtype=jnp.bfloat16),
+            jnp.array(weight, dtype=jnp.bfloat16),
+            jnp.array(conv_state, dtype=jnp.bfloat16),
+            jnp.array(cu_seqlens),
+            jnp.array(state_indices),
+            jnp.array([decode_end, total], dtype=jnp.int32),
+            jnp.array(has_init),
+            decoding_block_n=decoding_block_n,
+            prefill_block_n=prefill_block_n,
+        )
+
+        flat_weight = weight.transpose(1, 2, 0).reshape(H * D, 1, W)
+        ref_out, ref_conv_state = causal_conv1d.ragged_causal_conv1d(
+            jnp.array(x.reshape(x.shape[0], H * D), dtype=jnp.bfloat16),
+            jnp.array(conv_state.reshape(conv_state.shape[0], W - 1, H * D),
+                      dtype=jnp.bfloat16),
+            jnp.array(flat_weight, dtype=jnp.bfloat16),
+            None,
+            jnp.array(cu_seqlens),
+            jnp.array(state_indices),
+            jnp.array([decode_end, decode_end, total], dtype=jnp.int32),
+            jnp.array(has_init.astype(bool)),
+            kernel_size=W,
+        )
+
+        self.assertAllClose(out,
+                            ref_out.reshape(x.shape),
+                            atol=4e-2,
+                            rtol=4e-2,
+                            check_dtypes=False)
+        self.assertAllClose(new_conv_state,
+                            ref_conv_state.reshape(conv_state.shape),
+                            atol=4e-2,
+                            rtol=4e-2,
+                            check_dtypes=False)
+
+
+if __name__ == "__main__":
+    absltest.main(testLoader=jtu.JaxTestLoader())

--- a/tests/layers/common/test_gdn_attention.py
+++ b/tests/layers/common/test_gdn_attention.py
@@ -16,7 +16,6 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 from absl.testing import parameterized
-
 from tpu_inference.layers.common.gdn_attention import (
     GdnAttentionConfig, RaggedGatedDeltaRuleImpl, run_jax_gdn_attention_local)
 from tpu_inference.layers.common.ragged_gated_delta_rule_chunked import \
@@ -33,7 +32,7 @@ class GDNAttentionTest(parameterized.TestCase):
             max_reqs=1,
             lengths=[8192],
             q_loc=[0, 8192],
-            distribution=[0, 0, 3],
+            distribution=[0, 0, 1],
             test_config=GdnAttentionConfig(
                 ragged_gated_delta_rule_impl=RaggedGatedDeltaRuleImpl.
                 CHUNKED_JAX_PD),
@@ -105,7 +104,7 @@ class GDNAttentionTest(parameterized.TestCase):
             max_reqs=1,
             lengths=[8192],
             q_loc=[0, 8192],
-            distribution=[0, 0, 3],
+            distribution=[0, 0, 1],
             test_config=GdnAttentionConfig(
                 ragged_gated_delta_rule_impl=RaggedGatedDeltaRuleImpl.
                 CHUNKED_KERNEL_P_RECURRENT_KERNEL_D),
@@ -152,12 +151,9 @@ class GDNAttentionTest(parameterized.TestCase):
         b = jax.random.normal(next(rngs), (num_tokens, n_v))
         a = jax.random.normal(next(rngs), (num_tokens, n_v))
 
-        conv_state_q = jnp.zeros(
-            (num_blocks, kernel_size - 1, n_kq * kq_head_dim))
-        conv_state_k = jnp.zeros(
-            (num_blocks, kernel_size - 1, n_kq * kq_head_dim))
-        conv_state_v = jnp.zeros(
-            (num_blocks, kernel_size - 1, n_v * v_head_dim))
+        conv_head_num = 2 * n_kq + n_v
+        conv_state = jnp.zeros(
+            (num_blocks, kernel_size - 1, conv_head_num, kq_head_dim))
         recurrent_state = jnp.zeros((num_blocks, n_v, kq_head_dim, v_head_dim))
 
         conv_weight_q = jax.random.normal(next(rngs),
@@ -175,8 +171,6 @@ class GDNAttentionTest(parameterized.TestCase):
         dt_bias = jax.random.normal(jax.random.key(0), (n_v, ))
 
         mixed_qkv = jnp.concatenate([query, key, value], axis=-1)
-        conv_state = jnp.concatenate(
-            [conv_state_q, conv_state_k, conv_state_v], axis=-1)
         conv_weight = jnp.concatenate(
             [conv_weight_q, conv_weight_k, conv_weight_v], axis=0)
         conv_bias = jnp.concatenate([conv_bias_q, conv_bias_k, conv_bias_v],
@@ -299,15 +293,18 @@ class GDNAttentionTest(parameterized.TestCase):
         a = jax.random.normal(next(rngs), (num_tokens, n_v))
 
         conv_dim = (n_kq * kq_head_dim) * 2 + n_v * v_head_dim
-        conv_state_fresh = jnp.zeros((num_blocks, kernel_size - 1, conv_dim))
+        conv_head_num = conv_dim // kq_head_dim
+        conv_state_fresh = jnp.zeros(
+            (num_blocks, kernel_size - 1, conv_head_num, kq_head_dim))
         recurrent_state_fresh = jnp.zeros(
             (num_blocks, n_v, kq_head_dim, v_head_dim))
 
         # Build a "stale" pair where the slots that the two new requests
         # land on are filled with arbitrary nonzero values (simulating a
         # prior request that finished without the pool clearing the slot).
-        stale_conv = jax.random.normal(next(rngs),
-                                       (num_blocks, kernel_size - 1, conv_dim))
+        stale_conv = jax.random.normal(
+            next(rngs),
+            (num_blocks, kernel_size - 1, conv_head_num, kq_head_dim))
         stale_recurrent = jax.random.normal(
             next(rngs), (num_blocks, n_v, kq_head_dim, v_head_dim))
         # Slot 0 is the null block; leave it zero.
@@ -449,7 +446,9 @@ class GDNAttentionTest(parameterized.TestCase):
         mixed_qkv_a = mixed_qkv_full[:half]
         mixed_qkv_b = mixed_qkv_full[half:]
 
-        conv_state_zero = jnp.zeros((num_blocks, kernel_size - 1, conv_dim))
+        conv_head_num = conv_dim // kq_head_dim
+        conv_state_zero = jnp.zeros(
+            (num_blocks, kernel_size - 1, conv_head_num, kq_head_dim))
         recurrent_state_zero = jnp.zeros(
             (num_blocks, n_v, kq_head_dim, v_head_dim))
 

--- a/tests/runner/test_kv_cache_manager.py
+++ b/tests/runner/test_kv_cache_manager.py
@@ -844,7 +844,7 @@ class TestKVCacheManager:
             assert len(mamba_states) == 2
 
             expected_num_blocks = num_blocks // len(layer_names)
-            assert mamba_states[0].shape == (expected_num_blocks, 4, 128)
+            assert mamba_states[0].shape == (expected_num_blocks, 4, 2, 64)
             assert mamba_states[1].shape == (expected_num_blocks, 8, 64, 32)
 
             assert self.runner.layer_name_to_kvcache_index[f'layer.{i}'] == i

--- a/tpu_inference/kernels/benchmark_utils.py
+++ b/tpu_inference/kernels/benchmark_utils.py
@@ -1,0 +1,119 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Benchmark helpers for TPU kernels."""
+
+from __future__ import annotations
+
+import gzip
+import json
+import os
+import tempfile
+from pathlib import Path
+from typing import Any, Callable
+
+import jax
+import jax.numpy as jnp
+from jax.experimental.pallas import tpu as pltpu
+
+
+def get_device_name() -> str:
+    return jax.devices()[0].device_kind
+
+
+def get_peak_mem_bw_gbs() -> float | None:
+    return pltpu.get_tpu_info().mem_bw_bytes_per_second / 1e9
+
+
+def _block_until_ready(result: Any) -> None:
+    if isinstance(result, tuple):
+        for item in result:
+            jax.block_until_ready(item)
+    else:
+        jax.block_until_ready(result)
+
+
+def _extract_trace_latency_ms(trace_dir: str, event_name: str) -> float:
+    trace_path = Path(trace_dir)
+    candidates = sorted(trace_path.rglob("*.trace.json.gz"))
+    if not candidates:
+        candidates = sorted(trace_path.rglob("*.json.gz"))
+    if not candidates:
+        raise FileNotFoundError(f"No trace JSON found in {trace_dir}")
+
+    with gzip.open(candidates[0], "rt") as f:
+        trace_data = json.load(f)
+
+    events = trace_data.get("traceEvents", [])
+    tpu_pids: set[int] = set()
+    for event in events:
+        if event.get("ph") != "M" or event.get("name") != "process_name":
+            continue
+        if "/device:TPU:" in event.get("args", {}).get("name", ""):
+            tpu_pids.add(event["pid"])
+
+    if not tpu_pids:
+        raise RuntimeError("No TPU devices found in trace")
+
+    first_pid = min(tpu_pids)
+    durations_us = [
+        event["dur"]
+        for event in events
+        if event.get("ph") == "X"
+        and event.get("pid") == first_pid
+        and event.get("name", "").startswith(event_name)
+        and event.get("dur", 0) > 0
+    ]
+    if not durations_us:
+        raise RuntimeError(f"No events named '{event_name}' found in trace")
+
+    return (sum(durations_us) / len(durations_us)) / 1000.0
+
+
+def benchmark(
+    kernel_fn: Callable[[], Any],
+    *,
+    iters: int,
+    trace_dir: str | None = None,
+    event_name: str | None = None,
+) -> float:
+    """Runs a JAX kernel benchmark and returns mean latency in milliseconds."""
+    if iters < 1:
+        raise ValueError(f"iters must be >= 1, got {iters}")
+    if event_name is None:
+        raise ValueError("event_name is required")
+
+    for _ in range(5):
+        result = kernel_fn()
+    _block_until_ready(result)
+
+    if trace_dir is None:
+        tmp_dir = tempfile.TemporaryDirectory()
+        profile_dir = tmp_dir.name
+    else:
+        tmp_dir = None
+        profile_dir = trace_dir
+
+    os.makedirs(profile_dir, exist_ok=True)
+    profile_options = jax.profiler.ProfileOptions()
+    profile_options.python_tracer_level = 1
+    jax.profiler.start_trace(profile_dir, profiler_options=profile_options)
+    for _ in range(iters):
+        result = kernel_fn()
+    _block_until_ready(result)
+    jax.profiler.stop_trace()
+
+    latency_ms = _extract_trace_latency_ms(profile_dir, event_name)
+    if tmp_dir is not None:
+        tmp_dir.cleanup()
+    return latency_ms

--- a/tpu_inference/kernels/experimental/short_conv1d/__init__.py
+++ b/tpu_inference/kernels/experimental/short_conv1d/__init__.py
@@ -1,0 +1,19 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Short causal 1D convolution kernels."""
+
+from tpu_inference.kernels.experimental.short_conv1d.short_conv1d_wrapper import \
+    short_conv1d
+
+__all__ = ["short_conv1d"]

--- a/tpu_inference/kernels/experimental/short_conv1d/decoding_short_conv1d_benchmark.py
+++ b/tpu_inference/kernels/experimental/short_conv1d/decoding_short_conv1d_benchmark.py
@@ -1,0 +1,267 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Benchmark decoding_short_conv1d.
+
+Decode case: each token is its own sequence. All ``N`` tokens are decoded;
+per-token state is gathered from ``conv_state[state_indices[t]]`` and scattered
+back after the conv step.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import json
+import os
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from tpu_inference.kernels.experimental.short_conv1d import short_conv1d
+from tpu_inference.kernels.benchmark_utils import (benchmark, get_device_name,
+                                                   get_peak_mem_bw_gbs)
+
+BASELINE_PATH = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)),
+    "decoding_short_conv1d_benchmark_results.json",
+)
+DEFAULT_HEAD_NUM = 8
+DEFAULT_ITERS = 100
+
+
+@dataclasses.dataclass
+class BenchmarkResult:
+    N: int
+    H: int
+    D: int
+    W: int
+    block_n: int
+    dtype: str
+    mean_ms: float
+    mem_bytes: int
+    mem_bw_gbs: float
+    mbu: float
+
+
+def compute_mem_bytes(
+    x: jax.Array,
+    weight: jax.Array,
+    conv_state_slot_size_bytes: int,
+    n_decode: int,
+) -> int:
+    state_io = 2 * n_decode * conv_state_slot_size_bytes
+    return (
+        x.size * x.dtype.itemsize
+        + weight.size * weight.dtype.itemsize
+        + x.size * x.dtype.itemsize
+        + state_io
+    )
+
+
+def _build_inputs(n: int, h: int, d: int, w: int, dtype, *, seed: int = 0):
+    max_reqs = n
+    n_states = max(n, 8)
+
+    state_indices = jnp.asarray(
+        np.random.default_rng(seed).permutation(n_states)[:max_reqs].astype(
+            np.int32))
+    has_initial_state = jnp.asarray(np.ones(max_reqs, dtype=np.int32))
+    distribution = jnp.asarray(np.array([n, n], dtype=np.int32))
+    cu_seqlens = jnp.asarray(np.arange(max_reqs + 1, dtype=np.int32))
+
+    key_x, key_w, key_state = jax.random.split(jax.random.key(seed), 3)
+    x = jax.random.normal(key_x, (n, h, d), dtype=dtype) * 0.1
+    weight = jax.random.normal(key_w, (w, h, d), dtype=dtype) * 0.1
+    conv_state = (
+        jax.random.normal(key_state, (n_states, w - 1, h, d), dtype=dtype) *
+        0.1)
+    return (
+        x,
+        weight,
+        conv_state,
+        cu_seqlens,
+        state_indices,
+        distribution,
+        has_initial_state,
+    )
+
+
+def run_one(
+    n: int,
+    h: int,
+    d: int,
+    w: int,
+    block_n: int | None,
+    *,
+    dtype=jnp.bfloat16,
+    iters: int = DEFAULT_ITERS,
+    trace_dir: str | None = None,
+) -> BenchmarkResult:
+    (
+        x,
+        weight,
+        conv_state,
+        cu_seqlens,
+        state_indices,
+        distribution,
+        has_initial_state,
+    ) = _build_inputs(n, h, d, w, dtype)
+
+    state_slot_bytes = (w - 1) * h * d * conv_state.dtype.itemsize
+    mem_bytes = compute_mem_bytes(x, weight, state_slot_bytes, n)
+    peak_bw = get_peak_mem_bw_gbs()
+    dtype_str = str(dtype.dtype.name)
+
+    fn = lambda: short_conv1d(
+        jnp.copy(x),
+        weight,
+        jnp.copy(conv_state),
+        cu_seqlens,
+        state_indices,
+        distribution,
+        has_initial_state,
+        decoding_block_n=block_n,
+    )
+
+    sub_trace = os.path.join(trace_dir, f"N{n}_H{h}_D{d}") if trace_dir else None
+    mean_ms = benchmark(
+        fn,
+        iters=iters,
+        trace_dir=sub_trace,
+        event_name="jit_short_conv1d",
+    )
+    mem_bw_gbs = mem_bytes / (mean_ms / 1000.0) / 1e9
+    mbu = mem_bw_gbs / peak_bw * 100 if peak_bw else float("nan")
+
+    if block_n is None:
+        from tpu_inference.kernels.experimental.short_conv1d.decoding_short_conv1d_kernel import \
+            get_default_block_sizes
+
+        block_n = get_default_block_sizes(n, h, d, w, dtype)
+
+    return BenchmarkResult(
+        N=n,
+        H=h,
+        D=d,
+        W=w,
+        block_n=block_n,
+        dtype=dtype_str,
+        mean_ms=mean_ms,
+        mem_bytes=mem_bytes,
+        mem_bw_gbs=mem_bw_gbs,
+        mbu=mbu,
+    )
+
+
+def load_baseline(path: str) -> dict[tuple[int, int], BenchmarkResult]:
+    if not os.path.exists(path):
+        return {}
+    with open(path) as f:
+        data = json.load(f)
+    fields = {field.name for field in dataclasses.fields(BenchmarkResult)}
+    baseline = {}
+    for result in data["results"]:
+        benchmark_result = BenchmarkResult(
+            **{key: value for key, value in result.items() if key in fields})
+        baseline[(benchmark_result.N, benchmark_result.H)] = benchmark_result
+    return baseline
+
+
+def print_results(
+    results: list[BenchmarkResult],
+    baseline: dict[tuple[int, int], BenchmarkResult],
+) -> None:
+    has_baseline = bool(baseline)
+    header = (
+        f"{'N':>5} {'H':>3} {'D':>4} {'W':>2} {'bt':>5} "
+        f"{'Time(us)':>10} {'BW(GB/s)':>10} {'MBU(%)':>7}")
+    if has_baseline:
+        header += f"  {'old(us)':>10} {'delta':>8}"
+    print(header)
+    print("-" * len(header))
+    for result in results:
+        line = (
+            f"{result.N:>5} {result.H:>3} {result.D:>4} {result.W:>2} "
+            f"{result.block_n:>5} {result.mean_ms * 1000:>10.2f} "
+            f"{result.mem_bw_gbs:>10.1f} {result.mbu:>7.2f}")
+        if has_baseline:
+            old = baseline.get((result.N, result.H))
+            if old:
+                delta_pct = (result.mean_ms - old.mean_ms) / old.mean_ms * 100
+                sign = "+" if delta_pct >= 0 else ""
+                line += f"  {old.mean_ms * 1000:>10.2f} {sign}{delta_pct:>6.1f}%"
+            else:
+                line += f"  {'n/a':>10} {'':>8}"
+        print(line)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Benchmark decoding_short_conv1d kernel")
+    parser.add_argument("--iters", type=int, default=DEFAULT_ITERS)
+    parser.add_argument("--baseline", type=str, default=BASELINE_PATH)
+    parser.add_argument("--output", type=str, default=None)
+    parser.add_argument("--trace-dir", type=str, default=None)
+    parser.add_argument("--head-num", type=int, default=DEFAULT_HEAD_NUM)
+    args = parser.parse_args()
+
+    print(f"Device: {get_device_name()}")
+    print("Benchmarking decoding_short_conv1d "
+          "(dtype=bfloat16, all-decode, 1 token / seq)")
+    print(f"Using head_num={args.head_num}")
+    print(f"Using iters={args.iters}")
+    print("Using trace-based latency extraction")
+    if args.trace_dir:
+        print(f"Saving traces to {args.trace_dir}")
+    print()
+
+    cases = [(512, args.head_num, 128, 4, None)]
+    dtype = jnp.bfloat16
+
+    results: list[BenchmarkResult] = []
+    for n, h, d, w, block_n in cases:
+        result = run_one(
+            n,
+            h,
+            d,
+            w,
+            block_n,
+            dtype=dtype,
+            iters=args.iters,
+            trace_dir=args.trace_dir,
+        )
+        results.append(result)
+        print(
+            f"N={result.N:>5}, H={result.H:>3}, bt={result.block_n}: "
+            f"{result.mean_ms * 1000:.2f} us, "
+            f"{result.mem_bw_gbs:.1f} GB/s, MBU={result.mbu:.2f}%")
+
+    baseline = load_baseline(args.baseline)
+    print("\n-- Summary --\n")
+    print_results(results, baseline)
+
+    data = {
+        "device": get_device_name(),
+        "results": [dataclasses.asdict(result) for result in results],
+    }
+    out_path = args.output or args.baseline
+    with open(out_path, "w") as f:
+        json.dump(data, f, indent=2)
+        f.write("\n")
+    print(f"\nResults saved to {out_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tpu_inference/kernels/experimental/short_conv1d/decoding_short_conv1d_kernel.py
+++ b/tpu_inference/kernels/experimental/short_conv1d/decoding_short_conv1d_kernel.py
@@ -1,0 +1,335 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Decode-optimized short causal 1D convolution on TPU."""
+
+from __future__ import annotations
+
+import functools
+
+import jax
+import jax.numpy as jnp
+from jax._src import dtypes
+from jax.experimental import pallas as pl
+from jax.experimental.pallas import tpu as pltpu
+
+
+def get_default_block_sizes(N: int, H: int, D: int, W: int, dtype) -> int:
+    """Choose ``bt`` (decode tokens per pallas iteration) for the decode kernel."""
+    N = max(1, N)
+    ibits = dtypes.itemsize_bits(dtype)
+    fixed_bits = W * H * D * ibits  # weight tile (loaded once)
+    # Per-bt: x and out tiles double-buffered, plus the
+    # double-buffered state scratch (2 * bt * (W-1) * H * D * ibits).
+    per_bt_bits = 2 * (2 * H * D * ibits) + 2 * (W - 1) * H * D * ibits
+    vmem_bytes_limit = int(pltpu.get_tpu_info().vmem_capacity_bytes * 0.9)
+    bt = max(1, (vmem_bytes_limit * 8 - fixed_bits) // per_bt_bits)
+    # Cap bt: keep at least ~4 chunks so emit_pipeline can double-buffer DMAs
+    # against compute.
+    bt = min(bt, N, max(128, N // 4), 1024)
+    return 1 << (bt.bit_length() - 1)
+
+
+def _decoding_short_conv1d_main(
+    x_hbm,
+    weight_hbm,
+    state_indices_smem,
+    has_initial_state_smem,
+    distribution_smem,
+    conv_state_in_hbm,
+    out_hbm,
+    new_conv_state_hbm,
+    state_bufs,
+    load_sems,
+    store_sems,
+    *,
+    H: int,
+    D: int,
+    W: int,
+    bt: int,
+):
+    decode_end = distribution_smem[0]
+    nb_t = (decode_end + bt - 1) // bt
+
+    bounded_bt = pl.BoundedSlice(bt)
+
+    def token_map(i):
+        t_start = i * bt
+        t_size = jnp.minimum(bt, decode_end - t_start)
+        return (pl.ds(t_start, t_size), 0, 0)
+
+    x_spec = pl.BlockSpec((bounded_bt, H, D), token_map)
+    o_spec = pl.BlockSpec((bounded_bt, H, D), token_map)
+    weight_spec = pl.BlockSpec((W, H, D), lambda _: (0, 0, 0))
+
+    # Prologue: prefetch the first tile's state slots.
+    first_block_len = jnp.minimum(bt, decode_end)
+    for i_t in range(bt):
+
+        @pl.when(i_t < first_block_len)
+        def _first_load():
+            si = state_indices_smem[i_t]
+            pltpu.make_async_copy(
+                conv_state_in_hbm.at[si],
+                state_bufs.at[0, i_t],
+                load_sems.at[0],
+            ).start()
+
+    def _inner_kernel(
+        x_ref,
+        weight_ref,
+        o_ref,
+        state_bufs_s,
+        load_sems_s,
+        store_sems_s,
+    ):
+        block_id = pl.program_id(0)
+        t_start = block_id * bt
+        block_len = jnp.minimum(bt, decode_end - t_start)
+        buf_idx = block_id % 2
+        next_buf_idx = (block_id + 1) % 2
+
+        # Step 1: prefetch the next tile's state slots (if any).
+        next_t_start = t_start + bt
+        next_block_len = jnp.maximum(
+            jnp.minimum(bt, decode_end - next_t_start), 0)
+        for i_t in range(bt):
+
+            @pl.when(i_t < next_block_len)
+            def _prefetch():
+                next_si = state_indices_smem[next_t_start + i_t]
+                pltpu.make_async_copy(
+                    conv_state_in_hbm.at[next_si],
+                    state_bufs_s.at[next_buf_idx, i_t],
+                    load_sems_s.at[next_buf_idx],
+                ).start()
+
+        # Step 2: wait for the current tile's state loads (single drain).
+        pltpu.make_async_copy(
+            conv_state_in_hbm.at[pl.ds(0, block_len)],
+            state_bufs_s.at[buf_idx, pl.ds(0, block_len)],
+            load_sems_s.at[buf_idx],
+        ).wait()
+
+        # Step 3: compute. state_tile shape (bt, W-1, H, D).
+        state_tile = state_bufs_s[buf_idx][...]
+        x_chunk = x_ref[...]
+        weight_block = weight_ref[...]
+
+        # Mask out rows whose seq has no initial state. Read SMEM scalars
+        # one-by-one so the lowering stays trivial; the compiler vectorizes
+        # the resulting selects. The final decode tile can be partial, so keep
+        # metadata reads in-bounds for inactive rows.
+        masked_rows = []
+        for i in range(bt):
+            req_idx = t_start + i
+            safe_req_idx = jnp.minimum(req_idx, jnp.maximum(decode_end - 1, 0))
+            use_loaded_state = (i < block_len) & (
+                has_initial_state_smem[safe_req_idx] != 0)
+            masked_rows.append(
+                jnp.where(
+                    use_loaded_state,
+                    state_tile[i],
+                    jnp.zeros_like(state_tile[i]),
+                ))
+        masked_state = jnp.stack(masked_rows, axis=0)  # (bt, W-1, H, D)
+
+        # out[t] = weight[W-1] * x[t] + sum_{k<W-1} weight[k] * masked_state[t, k]
+        # Upcast operands to fp32 before the multiply so the product is computed
+        # in fp32; the bf16 multiplier's mantissa error is otherwise visible.
+        acc = x_chunk.astype(
+            jnp.float32) * weight_block[W - 1][None, :, :].astype(jnp.float32)
+        for k in range(W - 1):
+            acc = acc + masked_state[:, k].astype(
+                jnp.float32) * weight_block[k][None, :, :].astype(jnp.float32)
+        o_ref[...] = acc.astype(o_ref.dtype)
+
+        # New state: shift the (masked) state left by one and append x.
+        # new_state[:, k] = masked_state[:, k+1] for k in [0, W-2)
+        # new_state[:, W-2] = x_chunk
+        new_state = jnp.concatenate(
+            [masked_state[:, 1:, :, :], x_chunk[:, None, :, :]],
+            axis=1,
+        )
+        state_bufs_s[buf_idx] = new_state.astype(state_bufs_s.dtype)
+
+        # Step 4: wait for stores from 2 iterations ago (single drain).
+        prev_t_start = jnp.maximum((block_id - 2) * bt, 0)
+        prev_block_len = jnp.where(
+            block_id >= 2,
+            jnp.minimum(bt, decode_end - prev_t_start),
+            0,
+        )
+
+        @pl.when(prev_block_len > 0)
+        def _wait_prev_store():
+            pltpu.make_async_copy(
+                state_bufs_s.at[buf_idx, pl.ds(0, prev_block_len)],
+                new_conv_state_hbm.at[pl.ds(0, prev_block_len)],
+                store_sems_s.at[buf_idx],
+            ).wait()
+
+        # Step 5: start scatter stores back to conv_state.
+        for i_t in range(bt):
+
+            @pl.when(i_t < block_len)
+            def _start_store():
+                si = state_indices_smem[t_start + i_t]
+                pltpu.make_async_copy(
+                    state_bufs_s.at[buf_idx, i_t],
+                    new_conv_state_hbm.at[si],
+                    store_sems_s.at[buf_idx],
+                ).start()
+
+    pltpu.emit_pipeline(
+        _inner_kernel,
+        grid=(nb_t, ),
+        in_specs=[x_spec, weight_spec],
+        out_specs=o_spec,
+    )(
+        x_hbm,
+        weight_hbm,
+        out_hbm,
+        scratches=[state_bufs, load_sems, store_sems],
+    )
+
+    # Epilogue: drain the last two pending store batches.  Guarded so the
+    # outer kernel is fully inert when ``decode_end == 0`` (nb_t == 0).
+    @pl.when(nb_t > 0)
+    def _epilogue_last():
+        last_buf_idx = (nb_t - 1) % 2
+        last_block_len = jnp.minimum(bt, decode_end - (nb_t - 1) * bt)
+        pltpu.make_async_copy(
+            state_bufs.at[last_buf_idx, pl.ds(0, last_block_len)],
+            new_conv_state_hbm.at[pl.ds(0, last_block_len)],
+            store_sems.at[last_buf_idx],
+        ).wait()
+
+    @pl.when(nb_t >= 2)
+    def _drain_other():
+        other_buf_idx = nb_t % 2
+        other_block_len = jnp.minimum(bt, decode_end - (nb_t - 2) * bt)
+        pltpu.make_async_copy(
+            state_bufs.at[other_buf_idx,
+                          pl.ds(0, other_block_len)],
+            new_conv_state_hbm.at[pl.ds(0, other_block_len)],
+            store_sems.at[other_buf_idx],
+        ).wait()
+
+
+@functools.partial(
+    jax.jit,
+    static_argnames=("block_n", ),
+    donate_argnames=("x", "conv_state"),
+)
+def decoding_short_conv1d(
+    x: jax.Array,
+    weight: jax.Array,
+    conv_state: jax.Array,
+    state_indices: jax.Array,
+    distribution: jax.Array,
+    has_initial_state: jax.Array,
+    *,
+    block_n: int | None = None,
+):
+    """Decode-optimized short causal 1D convolution.
+
+    ``x`` is donated and aliased to the output: tokens in
+    ``[0, distribution[0])`` are overwritten in place with the conv
+    output; the rest of ``x`` is returned unchanged.  The ``out`` return
+    value IS the same buffer as the input ``x``.
+
+    Args:
+        x: ``[T, H, D]`` packed token activations (donated).
+        weight: ``[W, H, D]`` causal kernel.
+        conv_state: ``[N_states, W-1, H, D]`` history slots.
+        state_indices: ``[max_reqs]`` int32, request -> conv_state slot.
+        distribution: int32 array; ``distribution[0]`` is the decode end.
+        has_initial_state: ``[max_reqs]`` int32.
+        block_n: tokens processed per pallas iteration. ``None`` -> use
+            ``get_default_block_sizes``.
+
+    Returns:
+        ``(out, new_conv_state)``.  ``out[:distribution[0]]`` is freshly
+        written; the rest of ``out`` matches the input ``x`` (carried
+        through via aliasing).  The ``state_indices[:distribution[0]]``
+        slots of ``new_conv_state`` are written; the rest are unchanged.
+    """
+    if x.ndim != 3:
+        raise ValueError(f"x must be [T, H, D]; got {x.shape}")
+    T, H, D = x.shape
+    W = weight.shape[0]
+    if weight.shape != (W, H, D):
+        raise ValueError(
+            f"weight must be [W, H, D]={W, H, D}; got {weight.shape}")
+    if conv_state.shape[1:] != (W - 1, H, D):
+        raise ValueError(
+            f"conv_state must be [N, W-1, H, D]; got {conv_state.shape}")
+    N_states = conv_state.shape[0]
+    max_reqs = state_indices.shape[0]
+    if block_n is None:
+        block_n = get_default_block_sizes(min(T, max_reqs), H, D, W, x.dtype)
+    # Decode metadata is indexed by request id, while ``T`` includes prefill
+    # tokens in mixed batches. Keep the tile within both static capacities.
+    bt = max(1, min(block_n, T, max_reqs))
+
+    hbm_spec = pl.BlockSpec(memory_space=pl.ANY)
+    smem_spec = pl.BlockSpec(memory_space=pltpu.SMEM)
+
+    # Skip the kernel entirely when there are no decode tokens.
+    decode_end = distribution[0]
+    grid_dim = jnp.where(decode_end > 0, 1, 0)
+
+    out, new_conv_state = pl.pallas_call(
+        functools.partial(_decoding_short_conv1d_main, H=H, D=D, W=W, bt=bt),
+        grid_spec=pltpu.PrefetchScalarGridSpec(
+            num_scalar_prefetch=0,
+            in_specs=[
+                hbm_spec,  # x
+                hbm_spec,  # weight
+                smem_spec,  # state_indices
+                smem_spec,  # has_initial_state
+                smem_spec,  # distribution
+                hbm_spec,  # conv_state (input, aliased to output 1)
+            ],
+            out_specs=[hbm_spec, hbm_spec],
+            grid=(grid_dim, ),
+            scratch_shapes=[
+                pltpu.VMEM((2, bt, W - 1, H, D), x.dtype),
+                pltpu.SemaphoreType.DMA((2, )),
+                pltpu.SemaphoreType.DMA((2, )),
+            ],
+        ),
+        input_output_aliases={
+            0: 0,
+            5: 1
+        },
+        out_shape=[
+            jax.ShapeDtypeStruct((T, H, D), x.dtype),
+            jax.ShapeDtypeStruct((N_states, W - 1, H, D), conv_state.dtype),
+        ],
+        compiler_params=pltpu.CompilerParams(
+            disable_bounds_checks=True,
+            vmem_limit_bytes=pltpu.get_tpu_info().vmem_capacity_bytes,
+        ),
+        name=f"decoding_short_conv1d-bt_{bt}",
+    )(
+        x,
+        weight,
+        state_indices,
+        has_initial_state,
+        distribution,
+        conv_state,
+    )
+
+    return out, new_conv_state

--- a/tpu_inference/kernels/experimental/short_conv1d/jax_ref.py
+++ b/tpu_inference/kernels/experimental/short_conv1d/jax_ref.py
@@ -1,0 +1,101 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Pure-JAX reference for short_conv1d kernels (prefill and decode).
+
+The prefill formulation handles decoding for free: a decode token is
+just a sequence of length 1.  Build ``cu_seqlens = jnp.arange(N+1)``
+(plus any trailing pad-to-``max_reqs+1``) and the same reference
+produces the decode result.
+"""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+
+
+def short_conv1d_reference(
+    x: jax.Array,
+    weight: jax.Array,
+    conv_state: jax.Array,
+    cu_seqlens: jax.Array,
+    state_indices: jax.Array,
+    distribution: jax.Array,
+    has_initial_state: jax.Array,
+    *,
+    region_start_idx: int = 1,
+):
+    """Pure-JAX reference matching ``prefill_short_conv1d`` semantics.
+
+    Iterates the sequences in
+    ``[distribution[region_start_idx], distribution[region_start_idx + 1])``;
+    for each sequence ``s`` (length ``seq_len = cu_seqlens[s+1] - cu_seqlens[s]``):
+
+      * loads ``conv_state[state_indices[s]]`` if ``has_initial_state[s]``
+        is set, else uses zeros;
+      * convolves ``[state | x_seq]`` with ``weight``;
+      * writes the convolved ``seq_len`` rows back to ``out``;
+      * stores the trailing ``W-1`` rows of ``[state | x_seq]`` into
+        ``new_conv_state[state_indices[s]]``.
+
+    Decode-only callers can pass ``cu_seqlens = jnp.arange(N+1, ...)``
+    (one token per sequence) and ``distribution = [0, 0, N]`` with
+    ``region_start_idx=1``; the reference handles ``seq_len == 1``
+    correctly via the same merged convolution.
+
+    Args:
+        x: ``[T, H, D]`` packed tokens.
+        weight: ``[W, H, D]``.
+        conv_state: ``[N_states, W-1, H, D]``.
+        cu_seqlens: ``[max_reqs+1]`` int.
+        state_indices: ``[max_reqs]`` int.
+        distribution: int array; ``distribution[region_start_idx]`` and
+            ``distribution[region_start_idx + 1]`` give the sequence range.
+        has_initial_state: ``[max_reqs]`` int/bool.
+        region_start_idx: which slice of ``distribution`` to iterate.
+
+    Returns:
+        ``(out, new_conv_state)`` with shapes matching the inputs.
+    """
+    T, H, D = x.shape
+    W = weight.shape[0]
+    seq_lo = int(distribution[region_start_idx])
+    seq_hi = int(distribution[region_start_idx + 1])
+
+    out = jnp.zeros_like(x)
+    new_conv_state = conv_state
+
+    for s in range(seq_lo, seq_hi):
+        seq_start = int(cu_seqlens[s])
+        seq_end = int(cu_seqlens[s + 1])
+        seq_len = seq_end - seq_start
+        state_idx = int(state_indices[s])
+
+        x_seq = x[seq_start:seq_end]
+        if bool(has_initial_state[s]):
+            state_seq = conv_state[state_idx]
+        else:
+            state_seq = jnp.zeros((W - 1, H, D), dtype=x.dtype)
+
+        full = jnp.concatenate([state_seq, x_seq], axis=0)
+
+        out_seq = jnp.zeros((seq_len, H, D), jnp.float32)
+        for k in range(W):
+            out_seq = out_seq + full[k : k + seq_len].astype(jnp.float32) * weight[k]
+        out = out.at[seq_start:seq_end].set(out_seq.astype(x.dtype))
+
+        new_state_seq = full[-(W - 1) :]
+        new_conv_state = new_conv_state.at[state_idx].set(new_state_seq)
+
+    return out, new_conv_state

--- a/tpu_inference/kernels/experimental/short_conv1d/prefill_short_conv1d_benchmark.py
+++ b/tpu_inference/kernels/experimental/short_conv1d/prefill_short_conv1d_benchmark.py
@@ -1,0 +1,262 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Benchmark prefill_short_conv1d.
+
+Single prefill sequence covering all ``N`` tokens, with initial conv state.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import json
+import os
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from tpu_inference.kernels.experimental.short_conv1d import short_conv1d
+from tpu_inference.kernels.benchmark_utils import (benchmark, get_device_name,
+                                                   get_peak_mem_bw_gbs)
+
+BASELINE_PATH = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)),
+    "prefill_short_conv1d_benchmark_results.json",
+)
+DEFAULT_HEAD_NUM = 8
+DEFAULT_ITERS = 100
+
+
+@dataclasses.dataclass
+class BenchmarkResult:
+    N: int
+    H: int
+    D: int
+    W: int
+    block_n: int
+    dtype: str
+    mean_ms: float
+    mem_bytes: int
+    mem_bw_gbs: float
+    mbu: float
+
+
+def compute_mem_bytes(x: jax.Array, weight: jax.Array,
+                      conv_state: jax.Array) -> int:
+    state_slot_elems = conv_state.shape[1] * conv_state.shape[
+        2] * conv_state.shape[3]
+    read_bytes = (
+        x.size * x.dtype.itemsize +
+        weight.size * weight.dtype.itemsize +
+        state_slot_elems * conv_state.dtype.itemsize)
+    write_bytes = (
+        x.size * x.dtype.itemsize +
+        state_slot_elems * conv_state.dtype.itemsize)
+    return read_bytes + write_bytes
+
+
+def _build_inputs(n: int, h: int, d: int, w: int, dtype, *, seed: int = 0):
+    max_reqs = 4
+    n_states = 8
+    cu_seqlens = jnp.asarray(
+        np.array([0, n] + [n] * (max_reqs - 1), dtype=np.int32))
+    state_indices = jnp.asarray(np.arange(max_reqs, dtype=np.int32))
+    has_initial_state = jnp.asarray(
+        np.array([1] + [0] * (max_reqs - 1), dtype=np.int32))
+    distribution = jnp.asarray(np.array([0, 1], dtype=np.int32))
+
+    key_x, key_w, key_state = jax.random.split(jax.random.key(seed), 3)
+    x = jax.random.normal(key_x, (n, h, d), dtype=dtype) * 0.1
+    weight = jax.random.normal(key_w, (w, h, d), dtype=dtype) * 0.1
+    conv_state = (
+        jax.random.normal(key_state, (n_states, w - 1, h, d), dtype=dtype) *
+        0.1)
+    return (
+        x,
+        weight,
+        conv_state,
+        cu_seqlens,
+        state_indices,
+        distribution,
+        has_initial_state,
+    )
+
+
+def run_one(
+    n: int,
+    h: int,
+    d: int,
+    w: int,
+    block_n: int | None,
+    *,
+    dtype=jnp.bfloat16,
+    iters: int = DEFAULT_ITERS,
+    trace_dir: str | None = None,
+) -> BenchmarkResult:
+    (
+        x,
+        weight,
+        conv_state,
+        cu_seqlens,
+        state_indices,
+        distribution,
+        has_initial_state,
+    ) = _build_inputs(n, h, d, w, dtype)
+
+    mem_bytes = compute_mem_bytes(x, weight, conv_state)
+    peak_bw = get_peak_mem_bw_gbs()
+    dtype_str = str(dtype.dtype.name)
+
+    fn = lambda: short_conv1d(
+        jnp.copy(x),
+        weight,
+        jnp.copy(conv_state),
+        cu_seqlens,
+        state_indices,
+        distribution,
+        has_initial_state,
+        prefill_block_n=block_n,
+    )
+
+    sub_trace = os.path.join(trace_dir, f"N{n}_H{h}_D{d}") if trace_dir else None
+    mean_ms = benchmark(
+        fn,
+        iters=iters,
+        trace_dir=sub_trace,
+        event_name="jit_short_conv1d",
+    )
+    mem_bw_gbs = mem_bytes / (mean_ms / 1000.0) / 1e9
+    mbu = mem_bw_gbs / peak_bw * 100 if peak_bw else float("nan")
+
+    if block_n is None:
+        from tpu_inference.kernels.experimental.short_conv1d.prefill_short_conv1d_kernel import \
+            get_default_block_sizes
+
+        block_n = get_default_block_sizes(h, d, w, dtype)
+
+    return BenchmarkResult(
+        N=n,
+        H=h,
+        D=d,
+        W=w,
+        block_n=block_n,
+        dtype=dtype_str,
+        mean_ms=mean_ms,
+        mem_bytes=mem_bytes,
+        mem_bw_gbs=mem_bw_gbs,
+        mbu=mbu,
+    )
+
+
+def load_baseline(path: str) -> dict[tuple[int, int], BenchmarkResult]:
+    if not os.path.exists(path):
+        return {}
+    with open(path) as f:
+        data = json.load(f)
+    fields = {field.name for field in dataclasses.fields(BenchmarkResult)}
+    baseline = {}
+    for result in data["results"]:
+        benchmark_result = BenchmarkResult(
+            **{key: value for key, value in result.items() if key in fields})
+        baseline[(benchmark_result.N, benchmark_result.H)] = benchmark_result
+    return baseline
+
+
+def print_results(
+    results: list[BenchmarkResult],
+    baseline: dict[tuple[int, int], BenchmarkResult],
+) -> None:
+    has_baseline = bool(baseline)
+    header = (
+        f"{'N':>5} {'H':>3} {'D':>4} {'W':>2} {'bt':>5} "
+        f"{'Time(us)':>10} {'BW(GB/s)':>10} {'MBU(%)':>7}")
+    if has_baseline:
+        header += f"  {'old(us)':>10} {'delta':>8}"
+    print(header)
+    print("-" * len(header))
+    for result in results:
+        line = (
+            f"{result.N:>5} {result.H:>3} {result.D:>4} {result.W:>2} "
+            f"{result.block_n:>5} {result.mean_ms * 1000:>10.2f} "
+            f"{result.mem_bw_gbs:>10.1f} {result.mbu:>7.2f}")
+        if has_baseline:
+            old = baseline.get((result.N, result.H))
+            if old:
+                delta_pct = (result.mean_ms - old.mean_ms) / old.mean_ms * 100
+                sign = "+" if delta_pct >= 0 else ""
+                line += f"  {old.mean_ms * 1000:>10.2f} {sign}{delta_pct:>6.1f}%"
+            else:
+                line += f"  {'n/a':>10} {'':>8}"
+        print(line)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Benchmark prefill_short_conv1d kernel")
+    parser.add_argument("--iters", type=int, default=DEFAULT_ITERS)
+    parser.add_argument("--baseline", type=str, default=BASELINE_PATH)
+    parser.add_argument("--output", type=str, default=None)
+    parser.add_argument("--trace-dir", type=str, default=None)
+    parser.add_argument("--head-num", type=int, default=DEFAULT_HEAD_NUM)
+    args = parser.parse_args()
+
+    print(f"Device: {get_device_name()}")
+    print("Benchmarking prefill_short_conv1d "
+          "(dtype=bfloat16, single prefill seq)")
+    print(f"Using head_num={args.head_num}")
+    print(f"Using iters={args.iters}")
+    print("Using trace-based latency extraction")
+    if args.trace_dir:
+        print(f"Saving traces to {args.trace_dir}")
+    print()
+
+    cases = [(8192, args.head_num, 128, 4, None)]
+    dtype = jnp.bfloat16
+
+    results: list[BenchmarkResult] = []
+    for n, h, d, w, block_n in cases:
+        result = run_one(
+            n,
+            h,
+            d,
+            w,
+            block_n,
+            dtype=dtype,
+            iters=args.iters,
+            trace_dir=args.trace_dir,
+        )
+        results.append(result)
+        print(
+            f"N={result.N:>5}, H={result.H:>3}, bt={result.block_n}: "
+            f"{result.mean_ms * 1000:.2f} us, "
+            f"{result.mem_bw_gbs:.1f} GB/s, MBU={result.mbu:.2f}%")
+
+    baseline = load_baseline(args.baseline)
+    print("\n-- Summary --\n")
+    print_results(results, baseline)
+
+    data = {
+        "device": get_device_name(),
+        "results": [dataclasses.asdict(result) for result in results],
+    }
+    out_path = args.output or args.baseline
+    with open(out_path, "w") as f:
+        json.dump(data, f, indent=2)
+        f.write("\n")
+    print(f"\nResults saved to {out_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tpu_inference/kernels/experimental/short_conv1d/prefill_short_conv1d_kernel.py
+++ b/tpu_inference/kernels/experimental/short_conv1d/prefill_short_conv1d_kernel.py
@@ -1,0 +1,363 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Ragged short causal 1D convolution with conv_state I/O on TPU."""
+
+from __future__ import annotations
+
+import functools
+
+import jax
+import jax.numpy as jnp
+from jax._src import dtypes
+from jax.experimental import pallas as pl
+from jax.experimental.pallas import tpu as pltpu
+from tpu_inference.kernels.experimental.short_conv1d.util import (
+    GDNChunkIndices, calculate_chunk_indices)
+
+
+def get_default_block_sizes(H: int, D: int, W: int, dtype) -> int:
+    """Choose a chunk size (``bt``) for ``prefill_short_conv1d``.
+
+    Mirrors ``fused_recurrent_gdn_kernel.get_default_block_sizes``: budget
+    VMEM as fixed bits (history slots + weight tile) plus per-bt bits
+    (x and out tiles, both double-buffered by ``pltpu.emit_pipeline``),
+    pick the largest ``bt`` that fits, then floor to the nearest power of 2.
+    """
+    ibits = dtypes.itemsize_bits(dtype)
+    # Fixed VMEM (bits): two double-buffered history slots + weight tile.
+    fixed_bits = 2 * (W - 1) * H * D * ibits + W * H * D * ibits
+    # Per-bt VMEM: x and out tiles, both managed by emit_pipeline. Empirically
+    # the pipeline allocates ~4x per tile (double-buffer with separate prefetch
+    # and store buffers, plus alignment padding).
+    per_bt_bits = 4 * (2 * H * D * ibits)
+    vmem_bytes_limit = int(pltpu.get_tpu_info().vmem_capacity_bytes * 0.9)
+    bt = max(1, (vmem_bytes_limit * 8 - fixed_bits) // per_bt_bits)
+    # Cap bt at 512: empirically the largest bt where MBU is highest
+    bt = min(bt, 512)
+    return 1 << (bt.bit_length() - 1)
+
+
+def _prefill_short_conv1d_main(
+    chunk_indices_smem,
+    x_hbm,  # aliased to out_hbm; positions outside the active region
+    weight_hbm,  # carry through unchanged from x_hbm.
+    state_indices_smem,
+    has_initial_state_smem,
+    conv_state_in_hbm,
+    out_hbm,
+    new_conv_state_hbm,
+    history_bufs,  # (2, W-1, H, D) double-buffered for state load
+    load_sems,  # SemaphoreType.DMA(2) one per history_bufs slot
+    store_sem,
+    *,
+    W: int,
+    H: int,
+    D: int,
+    bt: int,
+):
+    bounded_bt = pl.BoundedSlice(bt)
+
+    def token_map(block_id):
+        t_start = chunk_indices_smem.block_id_to_t_offset[block_id]
+        t_end = chunk_indices_smem.block_id_to_t_offset[block_id + 1]
+        t_size = t_end - t_start
+        return (pl.ds(t_start, t_size), 0, 0)
+
+    x_spec = pl.BlockSpec((bounded_bt, H, D), token_map)
+    o_spec = pl.BlockSpec((bounded_bt, H, D), token_map)
+    weight_spec = pl.BlockSpec((W, H, D), lambda _: (0, 0, 0))
+
+    num_blocks = chunk_indices_smem.num_blocks[0]
+
+    # Prefetch the first sequence's state before entering the pipeline so it
+    # overlaps with the first chunk's x DMA. Mirrors fused_recurrent_gdn.
+    first_seq = chunk_indices_smem.block_id_to_seq_idx[0]
+    first_state_idx = state_indices_smem[first_seq]
+    first_buf = first_seq % 2
+    pltpu.make_async_copy(
+        conv_state_in_hbm.at[first_state_idx],
+        history_bufs.at[first_buf],
+        load_sems.at[first_buf],
+    ).start()
+
+    def kernel_body(
+        x_ref,
+        weight_ref,
+        o_ref,
+        history_bufs_s,
+        load_sems_s,
+        store_sem_s,
+    ):
+        block_id = pl.program_id(0)
+        seq_idx = chunk_indices_smem.block_id_to_seq_idx[block_id]
+        t_start = chunk_indices_smem.block_id_to_t_offset[block_id]
+        t_end = chunk_indices_smem.block_id_to_t_offset[block_id + 1]
+        block_len = t_end - t_start
+
+        prev_seq_idx = chunk_indices_smem.block_id_to_seq_idx[jnp.maximum(
+            block_id - 1, 0)]
+        is_new_seq = (block_id == 0) | (seq_idx != prev_seq_idx)
+        next_seq_idx = chunk_indices_smem.block_id_to_seq_idx[block_id + 1]
+        is_seq_end = seq_idx != next_seq_idx
+
+        buf_idx = seq_idx % 2
+        safe_next_seq = jnp.maximum(next_seq_idx, 0)
+        next_buf_idx = safe_next_seq % 2
+        state_idx = state_indices_smem[seq_idx]
+        next_state_idx = state_indices_smem[safe_next_seq]
+        has_init = has_initial_state_smem[seq_idx]
+
+        prefetch_cp = pltpu.make_async_copy(
+            conv_state_in_hbm.at[next_state_idx],
+            history_bufs_s.at[next_buf_idx],
+            load_sems_s.at[next_buf_idx],
+        )
+        load_wait_cp = pltpu.make_async_copy(
+            conv_state_in_hbm.at[state_idx],
+            history_bufs_s.at[buf_idx],
+            load_sems_s.at[buf_idx],
+        )
+
+        # Prefetch the next sequence's state on seq_end (if there is a next
+        # sequence). The first sequence was prefetched outside the loop.
+        @pl.when(is_seq_end & (next_seq_idx >= 0))
+        def _prefetch_next():
+            prefetch_cp.start()
+
+        # Wait for the current sequence's load to land before reading history.
+        @pl.when(is_new_seq)
+        def _wait_load():
+            load_wait_cp.wait()
+
+        # Zero out history if the sequence has no initial state. Loaded data
+        # from `conv_state_in_hbm[state_idx]` may be stale garbage in that case.
+        @pl.when(is_new_seq & (has_init == 0))
+        def _zero_state():
+            history_bufs_s[buf_idx, :, :, :] = jnp.zeros(
+                (W - 1, H, D), dtype=history_bufs_s.dtype)
+
+        # Conv split into head (first W-1 rows, depend on history) and body
+        # (rest, depend only on x_chunk). The body uses STATIC slices of
+        # x_chunk: `x_chunk[k : k + bt - W + 1]` for each k, avoiding the
+        # per-k jnp.concatenate that materialized a fresh (bt, H, D) bf16
+        # tile every iteration. The head builds one (2(W-1), H, D) merged
+        # tile once and reuses static slices of it. Result is written to
+        # o_ref in two parts.
+        history = history_bufs_s[buf_idx, :, :, :]
+        x_chunk = x_ref[...]
+        weight_block = weight_ref[...]
+        # Upcast operands to fp32 before the multiply so the product is computed
+        # in fp32; the bf16 multiplier's mantissa error is otherwise visible.
+        body_len = bt - (W - 1)
+        # Body: out_body[t] = sum_k weight[k] * x_chunk[t + k]  for t in [0, body_len)
+        acc_body = jnp.zeros((body_len, H, D), jnp.float32)
+        for k in range(W):
+            cur_body = x_chunk[k:k + body_len, :, :]
+            acc_body = acc_body + cur_body.astype(
+                jnp.float32) * weight_block[k][None, :, :].astype(jnp.float32)
+        # Head: build merged = [history; x_chunk[:W-1]] of length 2*(W-1)
+        # and slice statically. head[i] depends on merged[i..i+W-1].
+        merged_head = jnp.concatenate([history, x_chunk[:W - 1, :, :]], axis=0)
+        acc_head = jnp.zeros((W - 1, H, D), jnp.float32)
+        for k in range(W):
+            cur_head = merged_head[k:k + W - 1, :, :]
+            acc_head = acc_head + cur_head.astype(
+                jnp.float32) * weight_block[k][None, :, :].astype(jnp.float32)
+        # Write head and body to non-overlapping ranges of o_ref.
+        o_ref[:W - 1, :, :] = acc_head.astype(o_ref.dtype)
+        o_ref[W - 1:, :, :] = acc_body.astype(o_ref.dtype)
+
+        # Update history slot in-place. The new history is the W-1 rows of
+        # the "merged" stream [history; x_chunk] at indices [block_len,
+        # block_len + W - 1). In the common case block_len >= W-1, all W-1
+        # rows come from the tail of x_chunk: x_chunk[block_len - (W-1) :
+        # block_len]. Issue this as a single (W-1)-row VMEM copy. The slow
+        # path (block_len < W-1) only fires for sequences shorter than W-1
+        # tokens (rare on prefill); it keeps the per-row dispatch from the
+        # original implementation.
+        @pl.when(block_len >= W - 1)
+        def _history_update_fast():
+            history_bufs_s[buf_idx, :, :, :] = x_ref[
+                pl.ds(block_len - (W - 1), W - 1), :, :]
+
+        @pl.when(block_len < W - 1)
+        def _history_update_short_seq():
+            for i in range(W - 1):
+                src_idx = block_len + i
+
+                @pl.when(src_idx < W - 1)
+                def _from_history():
+                    history_bufs_s[buf_idx,
+                                   i, :, :] = history_bufs_s[buf_idx,
+                                                             src_idx, :, :]
+
+                @pl.when(src_idx >= W - 1)
+                def _from_x():
+                    history_bufs_s[buf_idx,
+                                   i, :, :] = x_ref[src_idx - (W - 1), :, :]
+
+        # On seq end: persist trailing state to HBM (sync).
+        store_cp = pltpu.make_async_copy(
+            history_bufs_s.at[buf_idx],
+            new_conv_state_hbm.at[state_idx],
+            store_sem_s,
+        )
+
+        @pl.when(is_seq_end)
+        def _store_state():
+            store_cp.start()
+            store_cp.wait()
+
+    pltpu.emit_pipeline(
+        kernel_body,
+        grid=(num_blocks, ),
+        in_specs=[x_spec, weight_spec],
+        out_specs=o_spec,
+    )(
+        x_hbm,
+        weight_hbm,
+        out_hbm,
+        scratches=[history_bufs, load_sems, store_sem],
+    )
+
+
+@functools.partial(
+    jax.jit,
+    static_argnames=("block_n", "region_start_idx"),
+    donate_argnames=("x", "conv_state"),
+)
+def prefill_short_conv1d(
+    x: jax.Array,
+    weight: jax.Array,
+    conv_state: jax.Array,
+    cu_seqlens: jax.Array,
+    state_indices: jax.Array,
+    distribution: jax.Array,
+    has_initial_state: jax.Array,
+    *,
+    block_n: int | None = None,
+    region_start_idx: int = 1,
+):
+    """Ragged per-channel short causal 1D convolution with state I/O.
+
+    ``x`` is donated and aliased to the output: tokens in the active
+    region are overwritten in place with the conv output; tokens outside
+    the active region are returned unchanged.  The ``out`` return value
+    IS the same buffer as the input ``x``.
+
+    Args:
+        x: ``[T, H, D]`` packed token activations (donated).
+        weight: ``[W, H, D]`` causal kernel; ``weight[W-1]`` is the
+            current-token coefficient.
+        conv_state: ``[N_states, W-1, H, D]`` history slots, indexed by
+            ``state_indices``.
+        cu_seqlens: ``[num_seqs+1]`` int32 cumulative sequence lengths.
+        state_indices: ``[max_reqs]`` int32, request -> conv_state slot.
+        distribution: ``[3]`` int32 ``[decoding, recurrent, total]``.
+        has_initial_state: ``[max_reqs]`` int32 / bool, whether to read
+            ``conv_state[state_indices[s]]`` (else use zeros).
+        block_n: chunk size on the token axis. ``None`` -> use
+            ``get_default_block_sizes`` based on VMEM budget.
+        region_start_idx: which slice of ``distribution`` to iterate; ``1``
+            processes ``[distribution[1], distribution[2])``.
+
+    Returns:
+        ``(out, new_conv_state)`` with shapes matching the inputs.
+    """
+    if x.ndim != 3:
+        raise ValueError(f"x must be [T, H, D]; got {x.shape}")
+    T, H, D = x.shape
+    W = weight.shape[0]
+    if block_n is None:
+        block_n = get_default_block_sizes(H, D, W, x.dtype)
+    if weight.shape != (W, H, D):
+        raise ValueError(
+            f"weight must be [W, H, D]={W, H, D}; got {weight.shape}")
+    if conv_state.shape[1:] != (W - 1, H, D):
+        raise ValueError(
+            f"conv_state must be [N, W-1, H, D]; got {conv_state.shape}")
+    N_states = conv_state.shape[0]
+    max_reqs = state_indices.shape[0]
+
+    bt = block_n
+    # Upper bound on chunks: ceil(T / bt) chunks for the densest packing,
+    # plus up to max_reqs extra splits where a sequence boundary falls
+    # mid-block.
+    max_num_blocks = (T + bt - 1) // bt + max_reqs
+
+    chunk_indices = calculate_chunk_indices(
+        cu_seqlens,
+        distribution,
+        max_num_blocks,
+        bt,
+        region_start_idx=region_start_idx,
+    )
+
+    hbm_spec = pl.BlockSpec(memory_space=pl.ANY)
+    smem_spec = pl.BlockSpec(memory_space=pltpu.SMEM)
+
+    # Skip the kernel entirely when this region has no sequences to process.
+    n_seqs = distribution[region_start_idx +
+                          1] - distribution[region_start_idx]
+    grid_dim = jnp.where(n_seqs > 0, 1, 0)
+
+    out, new_conv_state = pl.pallas_call(
+        functools.partial(_prefill_short_conv1d_main, W=W, H=H, D=D, bt=bt),
+        grid_spec=pltpu.PrefetchScalarGridSpec(
+            num_scalar_prefetch=0,
+            in_specs=[
+                GDNChunkIndices(
+                    num_blocks=smem_spec,
+                    block_id_to_seq_idx=smem_spec,
+                    block_id_to_t_offset=smem_spec,
+                ),
+                hbm_spec,  # x (input, aliased to output 0)
+                hbm_spec,  # weight
+                smem_spec,  # state_indices
+                smem_spec,  # has_initial_state
+                hbm_spec,  # conv_state (input, aliased to output 1)
+            ],
+            out_specs=[hbm_spec, hbm_spec],
+            grid=(grid_dim, ),
+            scratch_shapes=[
+                pltpu.VMEM((2, W - 1, H, D), x.dtype),
+                pltpu.SemaphoreType.DMA((2, )),
+                pltpu.SemaphoreType.DMA,
+            ],
+        ),
+        # flat: 0..2=chunk_indices, 3=x, 4=weight, 5=state_indices,
+        #       6=has_init, 7=conv_state.
+        input_output_aliases={
+            3: 0,
+            7: 1
+        },
+        out_shape=[
+            jax.ShapeDtypeStruct((T, H, D), x.dtype),
+            jax.ShapeDtypeStruct((N_states, W - 1, H, D), conv_state.dtype),
+        ],
+        compiler_params=pltpu.CompilerParams(
+            disable_bounds_checks=True,
+            vmem_limit_bytes=pltpu.get_tpu_info().vmem_capacity_bytes,
+        ),
+        name="prefill_short_conv1d",
+    )(
+        chunk_indices,
+        x,
+        weight,
+        state_indices,
+        has_initial_state,
+        conv_state,
+    )
+
+    return out, new_conv_state

--- a/tpu_inference/kernels/experimental/short_conv1d/short_conv1d_wrapper.py
+++ b/tpu_inference/kernels/experimental/short_conv1d/short_conv1d_wrapper.py
@@ -1,0 +1,143 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Short causal 1D convolution wrapper -- dispatch and public API."""
+
+from __future__ import annotations
+
+import functools
+
+import jax
+import jax.numpy as jnp
+
+from tpu_inference.kernels.experimental.short_conv1d.decoding_short_conv1d_kernel import \
+    decoding_short_conv1d
+from tpu_inference.kernels.experimental.short_conv1d.prefill_short_conv1d_kernel import \
+    prefill_short_conv1d
+
+
+@functools.partial(
+    jax.jit,
+    static_argnames=("decoding_block_n", "prefill_block_n"),
+    donate_argnames=("x", "conv_state"),
+)
+def short_conv1d(
+    x: jax.Array,
+    weight: jax.Array,
+    conv_state: jax.Array,
+    cu_seqlens: jax.Array,
+    state_indices: jax.Array,
+    distribution: jax.Array,
+    has_initial_state: jax.Array,
+    *,
+    decoding_block_n: int | None = None,
+    prefill_block_n: int | None = None,
+):
+    """Short causal 1D conv with mixed decode + prefill dispatch.
+
+    Args:
+        x: ``[T, H, D]`` packed token activations.
+        weight: ``[W, H, D]`` causal kernel.
+        conv_state: ``[N_states, W-1, H, D]`` history slots.
+        cu_seqlens: ``[num_seqs+1]`` int32 cumulative sequence lengths.
+        state_indices: ``[max_reqs]`` int32, request -> conv_state slot.
+        distribution: ``[2]`` int32 ``[decoding, total]``: ``[0, decoding)``
+            is dispatched to the decode kernel, ``[decoding, total)`` to
+            the prefill kernel.
+        has_initial_state: ``[max_reqs]`` int32 / bool.
+        decoding_block_n: chunk size for the decode kernel (``None`` ->
+            its default).
+        prefill_block_n: chunk size for the prefill kernel (``None`` ->
+            its default).
+
+    Returns:
+        ``(out, new_conv_state)``.  Decode and prefill regions touch
+        disjoint sets of ``conv_state`` slots, so the chained donation
+        leaves both regions correctly written.
+    """
+    # Each sub-kernel aliases its input ``x`` to its output, so x is
+    # overwritten in place in the active region only:
+    #   * decoding kernel writes ``x[:decode_end]`` in place
+    #   * prefill kernel writes ``x[decode_end:total]`` in place
+    # ``lax.cond`` skips the entire pallas_call dispatch (incl. its setup
+    # cost ~5us) when the corresponding region is empty.  The kernels are
+    # also internally no-ops via ``grid_dim=0`` -- the cond is purely a
+    # host-side optimization.
+    decode_end = distribution[0]
+    total = distribution[1]
+
+    def _do_decode(operands):
+        x_, weight_, conv_state_, state_indices_, distribution_, has_init_ = operands
+        return decoding_short_conv1d(
+            x_,
+            weight_,
+            conv_state_,
+            state_indices_,
+            distribution_,
+            has_init_,
+            block_n=decoding_block_n,
+        )
+
+    def _skip_decode(operands):
+        x_, _, conv_state_, _, _, _ = operands
+        return x_, conv_state_
+
+    x, state_after_decode = jax.lax.cond(
+        decode_end > 0,
+        _do_decode,
+        _skip_decode,
+        (x, weight, conv_state, state_indices, distribution, has_initial_state),
+    )
+
+    def _do_prefill(operands):
+        (
+            x_,
+            weight_,
+            state_,
+            cu_,
+            si_,
+            distribution_,
+            has_init_,
+        ) = operands
+        return prefill_short_conv1d(
+            x_,
+            weight_,
+            state_,
+            cu_,
+            si_,
+            distribution_,
+            has_init_,
+            block_n=prefill_block_n,
+            region_start_idx=0,
+        )
+
+    def _skip_prefill(operands):
+        x_, _, state_, _, _, _, _ = operands
+        return x_, state_
+
+    out, state_out = jax.lax.cond(
+        decode_end < total,
+        _do_prefill,
+        _skip_prefill,
+        (
+            x,
+            weight,
+            state_after_decode,
+            cu_seqlens,
+            state_indices,
+            distribution,
+            has_initial_state,
+        ),
+    )
+
+    return out, state_out

--- a/tpu_inference/kernels/experimental/short_conv1d/util.py
+++ b/tpu_inference/kernels/experimental/short_conv1d/util.py
@@ -1,0 +1,120 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Shared utilities for short Conv1D kernels."""
+
+from __future__ import annotations
+
+import dataclasses
+import functools
+
+import jax
+import jax.numpy as jnp
+from jax.experimental import pallas as pl
+from jax.experimental.pallas import tpu as pltpu
+
+
+@jax.tree_util.register_dataclass
+@dataclasses.dataclass(frozen=True)
+class GDNChunkIndices:
+    num_blocks: jax.Array
+    block_id_to_seq_idx: jax.Array
+    block_id_to_t_offset: jax.Array
+
+
+@jax.named_scope("calculate_chunk_indices")
+def calculate_chunk_indices(
+    cu_seqlens: jax.Array,
+    distribution: jax.Array,
+    max_num_blocks: int,
+    bt: int,
+    region_start_idx: int = 0,
+) -> GDNChunkIndices:
+    """Pre-computes per-block sequence and token offsets."""
+
+    def _kernel(
+        cu_seqlens_ref,
+        distribution_ref,
+        meta_out,
+        *,
+        bt: int,
+        region_start_idx: int,
+    ):
+        seq_start = distribution_ref[region_start_idx]
+        seq_end = distribution_ref[region_start_idx + 1]
+        n_seqs = seq_end - seq_start
+
+        @jax.named_scope("inner_block_loop")
+        def inner_block_loop(blk_rel, carry, *, seq_idx, eos):
+            num_blocks, t_cursor = carry
+            block_id = num_blocks + blk_rel
+
+            t_start = t_cursor + blk_rel * bt
+            t_end = jnp.minimum(t_start + bt, eos)
+
+            meta_out.block_id_to_seq_idx[block_id] = seq_idx
+            meta_out.block_id_to_t_offset[block_id] = t_start
+            meta_out.block_id_to_t_offset[block_id + 1] = t_end
+
+            return num_blocks, t_cursor
+
+        @jax.named_scope("outer_seq_loop")
+        def outer_seq_loop(seq_rel, carry):
+            num_blocks, t_cursor = carry
+            seq_idx = seq_start + seq_rel
+            eos = cu_seqlens_ref[seq_idx + 1]
+
+            seq_len_from_cursor = eos - t_cursor
+            n_seq_blocks = pl.cdiv(seq_len_from_cursor, bt)
+
+            loop_fn = functools.partial(
+                inner_block_loop,
+                seq_idx=seq_idx,
+                eos=eos,
+            )
+            jax.lax.fori_loop(0, n_seq_blocks, loop_fn,
+                              (num_blocks, t_cursor))
+
+            return num_blocks + n_seq_blocks, eos
+
+        first_token = cu_seqlens_ref[seq_start]
+        num_blocks, _ = jax.lax.fori_loop(
+            0,
+            n_seqs,
+            outer_seq_loop,
+            (jnp.int32(0), first_token),
+        )
+        meta_out.block_id_to_seq_idx[num_blocks] = jnp.int32(-1)
+        meta_out.num_blocks[0] = num_blocks
+
+    smem_spec = pl.BlockSpec(memory_space=pltpu.SMEM)
+    return pl.pallas_call(
+        functools.partial(_kernel, bt=bt, region_start_idx=region_start_idx),
+        grid_spec=pltpu.PrefetchScalarGridSpec(
+            num_scalar_prefetch=2,
+            out_specs=GDNChunkIndices(
+                num_blocks=smem_spec,
+                block_id_to_seq_idx=smem_spec,
+                block_id_to_t_offset=smem_spec,
+            ),
+            grid=(1, ),
+        ),
+        out_shape=GDNChunkIndices(
+            num_blocks=jax.ShapeDtypeStruct((1, ), jnp.int32),
+            block_id_to_seq_idx=jax.ShapeDtypeStruct((max_num_blocks + 1, ),
+                                                     jnp.int32),
+            block_id_to_t_offset=jax.ShapeDtypeStruct((max_num_blocks + 1, ),
+                                                      jnp.int32),
+        ),
+        compiler_params=pltpu.CompilerParams(disable_bounds_checks=True),
+    )(cu_seqlens, distribution)

--- a/tpu_inference/kernels/gdn/v2/gdn_decode_kernel.py
+++ b/tpu_inference/kernels/gdn/v2/gdn_decode_kernel.py
@@ -669,11 +669,22 @@ def ragged_gated_delta_rule_decode_only(
         *output* is ``(num_tokens, n_v*d_v)``.
     """
     num_tokens = mixed_qkv.shape[0]
-    key_dim = n_kq * d_k
-
-    q = mixed_qkv[..., :key_dim].reshape(num_tokens, n_kq, d_k)
-    k = mixed_qkv[..., key_dim:key_dim * 2].reshape(num_tokens, n_kq, d_k)
-    v = mixed_qkv[..., key_dim * 2:].reshape(num_tokens, n_v, d_v)
+    if mixed_qkv.ndim == 3:
+        if d_k != d_v:
+            raise ValueError("3D mixed_qkv requires d_k == d_v")
+        expected_shape = (2 * n_kq + n_v, d_k)
+        if mixed_qkv.shape[1:] != expected_shape:
+            raise ValueError(
+                f"3D mixed_qkv must be [num_tokens, {expected_shape[0]}, "
+                f"{expected_shape[1]}], got {mixed_qkv.shape}")
+        q = mixed_qkv[:, :n_kq, :]
+        k = mixed_qkv[:, n_kq:2 * n_kq, :]
+        v = mixed_qkv[:, 2 * n_kq:, :]
+    else:
+        key_dim = n_kq * d_k
+        q = mixed_qkv[..., :key_dim].reshape(num_tokens, n_kq, d_k)
+        k = mixed_qkv[..., key_dim:key_dim * 2].reshape(num_tokens, n_kq, d_k)
+        v = mixed_qkv[..., key_dim * 2:].reshape(num_tokens, n_v, d_v)
 
     g = a
     if g.shape == (num_tokens, n_v):

--- a/tpu_inference/kernels/gdn/v2/recurrent_scan_v2.py
+++ b/tpu_inference/kernels/gdn/v2/recurrent_scan_v2.py
@@ -1079,8 +1079,9 @@ def recurrent_scan(
     """Fused recurrent scan kernel for GDN on TPU v7.
 
   Args:
-    mixed_qkv: jax.Array of shape [num_tokens, 2 * n_kq * d_k + n_v * d_v].
-      Packed Query, Key, and Value tokens.
+    mixed_qkv: jax.Array of shape [num_tokens, 2 * n_kq * d_k + n_v * d_v],
+      or [num_tokens, 2 * n_kq + n_v, d_k] when d_k == d_v. Packed Query,
+      Key, and Value tokens.
     b: jax.Array of shape [num_tokens, n_v]. Input for beta gate.
     a: jax.Array of shape [num_tokens, n_v]. Input for g gate.
     recurrent_state: jax.Array of shape [max_reqs, n_v, d_k, d_v]. Current
@@ -1112,6 +1113,16 @@ def recurrent_scan(
         has_initial_state = has_initial_state.astype(jnp.int32)
 
     num_tokens = mixed_qkv.shape[0]
+    if mixed_qkv.ndim == 3:
+        if d_k != d_v:
+            raise ValueError("3D mixed_qkv requires d_k == d_v")
+        expected_shape = (2 * n_kq + n_v, d_k)
+        if mixed_qkv.shape[1:] != expected_shape:
+            raise ValueError(
+                f"3D mixed_qkv must be [num_tokens, {expected_shape[0]}, "
+                f"{expected_shape[1]}], got {mixed_qkv.shape}")
+        mixed_qkv = mixed_qkv.reshape(num_tokens, 2 * n_kq * d_k + n_v * d_v)
+
     tpu_info = pltpu.get_tpu_info()
     sublanesize = 4 // mixed_qkv.itemsize * tpu_info.num_sublanes
 

--- a/tpu_inference/layers/common/gdn_attention.py
+++ b/tpu_inference/layers/common/gdn_attention.py
@@ -24,7 +24,7 @@ import jax.numpy as jnp
 from jax.sharding import PartitionSpec as P
 
 import tpu_inference.layers.common.ragged_gated_delta_rule_wrapper as ragged_gated_delta_rule_wrapper
-from tpu_inference.kernels.causal_conv1d import causal_conv1d
+from tpu_inference.kernels.experimental.short_conv1d import short_conv1d
 from tpu_inference.layers.common.ragged_gated_delta_rule_ref import \
     ragged_gated_delta_rule as ragged_gated_delta_rule_ref
 from tpu_inference.layers.common.sharding import ShardingAxisName
@@ -68,9 +68,9 @@ def run_jax_gdn_attention_local(
         b: B tensor of shape `(num_tokens, n_v)`.
         a: A tensor of shape `(num_tokens, n_v)`.
         conv_state: Combined convolutional state of shape `(num_blocks,
-          kernel_size - 1, dim)`. `num_blocks` is always equal or larger than
-          `max_seqs + 1`. The first block is a null_block and only used for
-          padded / invalid tokens.
+          kernel_size - 1, head_num, head_dim)`. `num_blocks` is always equal
+          or larger than `max_seqs + 1`. The first block is a null_block and
+          only used for padded / invalid tokens.
         recurrent_state: Recurrent state of shape `(num_blocks, n_v, d_k, d_v)`.
         conv_weight: Combined convolutional weight of shape `(dim, 1,
           kernel_size)`.
@@ -112,17 +112,33 @@ def run_jax_gdn_attention_local(
     query_lens = query_start_loc[1:max_reqs + 1] - query_start_loc[:max_reqs]
     has_initial_state = (seq_lens - query_lens) > 0
 
-    out_mixed_qkv, new_conv_state = causal_conv1d.ragged_causal_conv1d(
-        mixed_qkv,
+    num_tokens = mixed_qkv.shape[0]
+    if conv_state.ndim != 4:
+        raise ValueError(
+            "conv_state must be [num_blocks, kernel_size - 1, head_num, "
+            f"head_dim], got {conv_state.shape}")
+    conv_head_num = conv_state.shape[2]
+    conv_head_dim = conv_state.shape[3]
+    conv_dim = conv_head_num * conv_head_dim
+    if mixed_qkv.shape[-1] != conv_dim:
+        raise ValueError(
+            f"mixed_qkv dim {mixed_qkv.shape[-1]} does not match "
+            f"conv_state head_num * head_dim {conv_dim}")
+
+    short_conv_distribution = jnp.stack([distribution[0], distribution[2]])
+    short_conv_weight = conv_weight[:, 0, :].reshape(
+        conv_head_num, conv_head_dim, kernel_size).transpose(2, 0, 1)
+    out_mixed_qkv, new_conv_state = short_conv1d(
+        mixed_qkv.reshape(num_tokens, conv_head_num, conv_head_dim),
+        short_conv_weight,
         conv_state,
-        conv_weight,
-        conv_bias,
         query_start_loc,
         state_indices,
-        distribution,
-        has_initial_state,
-        kernel_size=kernel_size,
+        short_conv_distribution,
+        has_initial_state.astype(jnp.int32),
     )
+    if conv_bias is not None:
+        out_mixed_qkv += conv_bias.reshape(conv_head_num, conv_head_dim)
 
     if config.ragged_gated_delta_rule_impl == RaggedGatedDeltaRuleImpl.REF:
         ragged_gdn_impl = functools.partial(
@@ -197,9 +213,9 @@ def run_jax_gdn_attention(
         j_b: Input tensor of shape `(num_tokens, n_v)`.
         j_a: Input tensor of shape `(num_tokens, n_v)`.
         conv_state: Convolutional state tensor of shape `(num_blocks, kernel_size
-          - 1, dim)`. `num_blocks` is always equal or larger than `max_seqs +
-          1`. The first block is a null_block and only used for padded / invalid
-          tokens.
+          - 1, head_num, head_dim)`. `num_blocks` is always equal or larger than
+          `max_seqs + 1`. The first block is a null_block and only used for
+          padded / invalid tokens.
         recurrent_state: Recurrent state tensor of shape `(num_blocks, n_v, d_k,
           d_v)`.
         j_conv_weight: Convolutional weight tensor of shape `(dim, 1,
@@ -227,7 +243,7 @@ def run_jax_gdn_attention(
     Returns:
         A tuple containing:
         - A tuple of (new_conv_state, new_recurrent_state).
-          - new_conv_state: `(num_blocks, kernel_size - 1, dim)`
+          - new_conv_state: `(num_blocks, kernel_size - 1, head_num, head_dim)`
           - new_recurrent_state: `(num_blocks, n_v, d_k, d_v)`
         - The output tensor of shape `(num_tokens, n_v * d_v)`.
     """
@@ -237,7 +253,7 @@ def run_jax_gdn_attention(
         P(ShardingAxisName.ATTN_DATA, ShardingAxisName.ATTN_HEAD),  # j_b
         P(ShardingAxisName.ATTN_DATA, ShardingAxisName.ATTN_HEAD),  # j_a
         P(ShardingAxisName.ATTN_DATA, None,
-          ShardingAxisName.ATTN_HEAD),  # conv_state
+          ShardingAxisName.ATTN_HEAD, None),  # conv_state
         P(ShardingAxisName.ATTN_DATA, ShardingAxisName.ATTN_HEAD, None,
           None),  # recurrent_state
         P(ShardingAxisName.ATTN_HEAD, None, None),  # j_conv_weight
@@ -254,7 +270,7 @@ def run_jax_gdn_attention(
     out_specs = (
         (
             P(ShardingAxisName.ATTN_DATA, None,
-              ShardingAxisName.ATTN_HEAD),  # new_conv_state
+              ShardingAxisName.ATTN_HEAD, None),  # new_conv_state
             P(ShardingAxisName.ATTN_DATA, ShardingAxisName.ATTN_HEAD, None,
               None),  # new_recurrent_state
         ),

--- a/tpu_inference/layers/common/ragged_gated_delta_rule_ref.py
+++ b/tpu_inference/layers/common/ragged_gated_delta_rule_ref.py
@@ -37,6 +37,35 @@ def _l2_normalize(x: jnp.ndarray, eps: float = 1e-6) -> jnp.ndarray:
     return (x_f32 / norm).astype(x.dtype)
 
 
+def _split_mixed_qkv(
+    mixed_qkv: jnp.ndarray,
+    *,
+    n_kq: int,
+    n_v: int,
+    d_k: int,
+    d_v: int,
+) -> Tuple[jnp.ndarray, jnp.ndarray, jnp.ndarray]:
+    num_tokens = mixed_qkv.shape[0]
+    if mixed_qkv.ndim == 3:
+        if d_k != d_v:
+            raise ValueError("3D mixed_qkv requires d_k == d_v")
+        expected_shape = (2 * n_kq + n_v, d_k)
+        if mixed_qkv.shape[1:] != expected_shape:
+            raise ValueError(
+                f"3D mixed_qkv must be [num_tokens, {expected_shape[0]}, "
+                f"{expected_shape[1]}], got {mixed_qkv.shape}")
+        query = mixed_qkv[:, :n_kq, :]
+        key = mixed_qkv[:, n_kq:2 * n_kq, :]
+        value = mixed_qkv[:, 2 * n_kq:, :]
+        return query, key, value
+
+    key_dim = n_kq * d_k
+    query = mixed_qkv[..., :key_dim].reshape(num_tokens, n_kq, d_k)
+    key = mixed_qkv[..., key_dim:key_dim * 2].reshape(num_tokens, n_kq, d_k)
+    value = mixed_qkv[..., key_dim * 2:].reshape(num_tokens, n_v, d_v)
+    return query, key, value
+
+
 def _recurrent_gated_delta_rule_step(
     query: jnp.ndarray,
     key: jnp.ndarray,
@@ -118,7 +147,7 @@ def ragged_gated_delta_rule(
 
     Args:
       mixed_qkv: Combined QKV tensor of shape `(num_tokens, 2 * n_kq * d_k + n_v *
-        d_v)`.
+        d_v)` or `(num_tokens, 2 * n_kq + n_v, d_k)` when `d_k == d_v`.
       b: B tensor of shape `(num_tokens, n_v)`.
       a: A tensor of shape `(num_tokens, n_v)`.
       recurrent_state: Recurrent state of shape `(num_blocks, n_v, d_k, d_v)`.
@@ -154,10 +183,8 @@ def ragged_gated_delta_rule(
     """
     mixed_qkv = jax.nn.silu(mixed_qkv)
     num_tokens = mixed_qkv.shape[0]
-    key_dim = n_kq * d_k
-    query = mixed_qkv[..., :key_dim]
-    key = mixed_qkv[..., key_dim:key_dim * 2]
-    value = mixed_qkv[..., key_dim * 2:]
+    query, key, value = _split_mixed_qkv(
+        mixed_qkv, n_kq=n_kq, n_v=n_v, d_k=d_k, d_v=d_v)
     max_reqs = state_indices.shape[0]
     token_idx = jnp.arange(num_tokens)
 
@@ -199,9 +226,9 @@ def ragged_gated_delta_rule(
             is_valid_token,
         ) = xs
 
-        curr_q = curr_q[None, None, :]
-        curr_k = curr_k[None, None, :]
-        curr_v = curr_v[None, None, :]
+        curr_q = curr_q[None, None, :, :]
+        curr_k = curr_k[None, None, :, :]
+        curr_v = curr_v[None, None, :, :]
         curr_b = curr_b[None, None, :]
         curr_a = curr_a[None, None, :]
 
@@ -209,9 +236,9 @@ def ragged_gated_delta_rule(
         recurrent_state = recurrent_state_all[state_index][None, ...]
 
         B, T = 1, 1
-        query_reshaped = curr_q.reshape(B, T, n_kq, d_k)
-        key_reshaped = curr_k.reshape(B, T, n_kq, d_k)
-        value_reshaped = curr_v.reshape(B, T, n_v, d_v)
+        query_reshaped = curr_q
+        key_reshaped = curr_k
+        value_reshaped = curr_v
 
         # Cast b to fp32 before sigmoid to match GPU's
         # `fused_gdn_gating_kernel`

--- a/tpu_inference/layers/common/ragged_gated_delta_rule_wrapper.py
+++ b/tpu_inference/layers/common/ragged_gated_delta_rule_wrapper.py
@@ -68,6 +68,35 @@ class RaggedGatedDeltaRuleImpl(enum.Enum):
         )
 
 
+def _split_mixed_qkv(
+    mixed_qkv: jnp.ndarray,
+    *,
+    n_kq: int,
+    n_v: int,
+    d_k: int,
+    d_v: int,
+) -> tuple[jnp.ndarray, jnp.ndarray, jnp.ndarray]:
+    num_tokens = mixed_qkv.shape[0]
+    if mixed_qkv.ndim == 3:
+        if d_k != d_v:
+            raise ValueError("3D mixed_qkv requires d_k == d_v")
+        expected_shape = (2 * n_kq + n_v, d_k)
+        if mixed_qkv.shape[1:] != expected_shape:
+            raise ValueError(
+                f"3D mixed_qkv must be [num_tokens, {expected_shape[0]}, "
+                f"{expected_shape[1]}], got {mixed_qkv.shape}")
+        query = mixed_qkv[:, :n_kq, :]
+        key = mixed_qkv[:, n_kq:2 * n_kq, :]
+        value = mixed_qkv[:, 2 * n_kq:, :]
+        return query, key, value
+
+    key_dim = n_kq * d_k
+    query = mixed_qkv[..., :key_dim].reshape(num_tokens, n_kq, d_k)
+    key = mixed_qkv[..., key_dim:key_dim * 2].reshape(num_tokens, n_kq, d_k)
+    value = mixed_qkv[..., key_dim * 2:].reshape(num_tokens, n_v, d_v)
+    return query, key, value
+
+
 @jax.jit(
     # because , recurrent_scan_v2 call pltpu.get_tpu_info().num_lanes
     donate_argnames=('recurrent_state', ),
@@ -172,14 +201,9 @@ def ragged_gated_delta_rule_wrapper(
             return new_state, output
         elif impl == 'jax':
             qkv_in = jax.nn.silu(mixed_qkv)
+            q_reshaped, k_reshaped, v_reshaped = _split_mixed_qkv(
+                qkv_in, n_kq=n_kq, n_v=n_v, d_k=d_k, d_v=d_v)
             num_tokens = qkv_in.shape[0]
-            key_dim = n_kq * d_k
-            query = qkv_in[..., :key_dim]
-            key = qkv_in[..., key_dim:key_dim * 2]
-            value = qkv_in[..., key_dim * 2:]
-            q_reshaped = query.reshape(num_tokens, n_kq, d_k)
-            k_reshaped = key.reshape(num_tokens, n_kq, d_k)
-            v_reshaped = value.reshape(num_tokens, n_v, d_v)
             repeat_factor = n_v // n_kq
             if repeat_factor > 1:
                 q_reshaped = jnp.repeat(q_reshaped, repeat_factor, axis=1)
@@ -209,14 +233,9 @@ def ragged_gated_delta_rule_wrapper(
         impl = config.prefill_impl
         if impl == 'jax':
             qkv_in = jax.nn.silu(mixed_qkv)
+            q_reshaped, k_reshaped, v_reshaped = _split_mixed_qkv(
+                qkv_in, n_kq=n_kq, n_v=n_v, d_k=d_k, d_v=d_v)
             num_tokens = qkv_in.shape[0]
-            key_dim = n_kq * d_k
-            query = qkv_in[..., :key_dim]
-            key = qkv_in[..., key_dim:key_dim * 2]
-            value = qkv_in[..., key_dim * 2:]
-            q_reshaped = query.reshape(num_tokens, n_kq, d_k)
-            k_reshaped = key.reshape(num_tokens, n_kq, d_k)
-            v_reshaped = value.reshape(num_tokens, n_v, d_v)
             repeat_factor = n_v // n_kq
             if repeat_factor > 1:
                 q_reshaped = jnp.repeat(q_reshaped, repeat_factor, axis=1)

--- a/tpu_inference/layers/vllm/custom_ops/gdn_attention_op.py
+++ b/tpu_inference/layers/vllm/custom_ops/gdn_attention_op.py
@@ -101,7 +101,7 @@ def gdn_attention_core_tpu(
     conv_state, recurrent_state = vllm_context.kv_caches[layer_idx]
     state_len = conv_state.shape[1]
     if state_len > kernel_size - 1:
-        conv_state_in = conv_state[:, :kernel_size - 1, :]
+        conv_state_in = conv_state[:, :kernel_size - 1, ...]
     else:
         conv_state_in = conv_state
 
@@ -160,7 +160,7 @@ def gdn_attention_core_tpu(
          mesh=mesh,
          config=config)
     if state_len > kernel_size - 1:
-        remaining_old_state = conv_state[:, kernel_size - 1:, :]
+        remaining_old_state = conv_state[:, kernel_size - 1:, ...]
         new_conv_state = jnp.concatenate(
             [new_conv_state_extracted, remaining_old_state], axis=1)
     else:

--- a/tpu_inference/runner/kv_cache_manager.py
+++ b/tpu_inference/runner/kv_cache_manager.py
@@ -54,6 +54,24 @@ logger = init_logger(__name__)
 DEFAULT_KV_CACHE_LAYOUT = "NHD"
 
 
+def _get_mamba_conv_cache_shape(layer_spec: MambaSpec) -> tuple[int, ...]:
+    """Returns the TPU conv-state shape as [conv_len, heads, head_dim]."""
+    conv_shape = tuple(layer_spec.shapes[0])
+    if len(conv_shape) != 2 or len(layer_spec.shapes) < 2:
+        return conv_shape
+
+    ssm_shape = tuple(layer_spec.shapes[1])
+    if len(ssm_shape) < 2:
+        return conv_shape
+
+    conv_len, conv_dim = conv_shape
+    head_dim = ssm_shape[1]
+    if head_dim <= 0 or conv_dim % head_dim != 0:
+        return conv_shape
+
+    return (conv_len, conv_dim // head_dim, head_dim)
+
+
 class KVCacheManager:
 
     def __init__(self, runner: "TPUModelRunner"):
@@ -782,18 +800,22 @@ class KVCacheManager:
                     for state_index, (shape, dtype) in enumerate(
                             zip(layer_spec.shapes, layer_spec.dtypes)):
                         jax_dtype = t2j_dtype(dtype)
-                        cache_shape = (mamba_num_blocks, *shape)
                         if state_index == 0:
-                            # conv_state: [num_blocks, conv_kernel_size, intermediate_size]
+                            shape = _get_mamba_conv_cache_shape(layer_spec)
+                            # conv_state: [num_blocks, conv_len, head_num, head_dim]
+                            cache_shape = (mamba_num_blocks, *shape)
                             spec = PartitionSpec(ShardingAxisName.ATTN_DATA,
                                                  None,
-                                                 ShardingAxisName.ATTN_HEAD)
+                                                 ShardingAxisName.ATTN_HEAD,
+                                                 None)
                         elif state_index == 1:
+                            cache_shape = (mamba_num_blocks, *shape)
                             # ssm_state: [num_blocks, num_heads, head_dim, state_size]
                             spec = PartitionSpec(ShardingAxisName.ATTN_DATA,
                                                  ShardingAxisName.ATTN_HEAD,
                                                  None, None)
                         else:
+                            cache_shape = (mamba_num_blocks, *shape)
                             spec = PartitionSpec(
                                 None, *([None] * (len(cache_shape) - 1)))
 


### PR DESCRIPTION
# Description

Adds TPU short causal Conv1D kernels for GDN and changes the mamba conv cache
state from a flat shape to `[num_blocks, conv_len, head_num, head_dim]`.

# Checklist

Before submitting this PR, please make sure:
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have made or will make corresponding changes to any relevant documentation.
