### PR TITLE
Fixes for TPU device topology

### DIFF
--- a/tests/distributed/test_distributed_utils.py
+++ b/tests/distributed/test_distributed_utils.py
@@ -118,3 +118,26 @@ def test_get_device_topology_order_id_not_in_global():
     ]
     with pytest.raises(ValueError, match="do not exist in the global device:"):
         get_device_topology_order_id(local_devices, global_devices)
+
+
+def test_get_device_topology_order_id_missing_coords():
+    """
+    Tests fallback to process_index when coords is missing.
+    """
+
+    class TpuDeviceNoCoords:
+
+        def __init__(self, id, process_index):
+            self.id = id
+            self.process_index = process_index
+
+    global_devices = [
+        TpuDeviceNoCoords(id=0, process_index=0),
+        TpuDeviceNoCoords(id=1, process_index=1),
+    ]
+
+    local_devices = [TpuDeviceNoCoords(id=0, process_index=0)]
+    assert get_device_topology_order_id(local_devices, global_devices) == 0
+
+    local_devices = [TpuDeviceNoCoords(id=1, process_index=1)]
+    assert get_device_topology_order_id(local_devices, global_devices) == 1

--- a/tests/kernels/gmm_test.py
+++ b/tests/kernels/gmm_test.py
@@ -738,6 +738,49 @@ class GmmTest(jtu.JaxTestCase):
 
         self.assertArraysAllClose(actual, expected, atol=atol, rtol=rtol)
 
+    def test_gmm_weight_quantized_tile_k_not_divisible_by_block_size(self):
+        """Test GMM with tile_k not a multiple of block_size."""
+        batch_size = 128
+        in_size = 320
+        out_size = 512
+        num_groups = 8
+        weight_dtype = jnp.int8
+        block_size = 160
+        tile_k = 256
+
+        num_local_groups = num_groups
+        key = jax.random.key(0)
+
+        lhs = jax.random.uniform(key, (batch_size, in_size), jnp.bfloat16, -1,
+                                 1)
+        rhs = jax.random.uniform(key, (num_local_groups, in_size, out_size),
+                                 jnp.bfloat16, -1, 1)
+        rhs_q, rhs_scale = quantize_tensor(rhs,
+                                           weight_dtype,
+                                           axis=1,
+                                           block_size=block_size)
+        rhs_scale = jnp.expand_dims(rhs_scale, axis=2)
+
+        group_sizes = get_group_sizes(batch_size, num_groups)
+        group_offset = jnp.array(0, dtype=jnp.int32)
+
+        tile_info = TileSizes(tile_m=128, tile_k=tile_k, tile_n=out_size)
+
+        # Trace the kernel using jax.make_jaxpr to verify it compiles/traces without shape mismatch.
+        # This is safe to run on any backend (CPU/GPU/TPU) because it doesn't execute or lower.
+        try:
+            jax.make_jaxpr(lambda lhs_in, rhs_in, gs_in, rs_in, go_in: gmm_v2(
+                lhs_in,
+                rhs_in,
+                gs_in,
+                rhs_scale=rs_in,
+                group_offset=go_in,
+                tile_info=tile_info,
+                maybe_quantize_lhs=False,
+            ))(lhs, rhs_q, group_sizes, rhs_scale, group_offset)
+        except TypeError as e:
+            self.fail(f"gmm_v2 failed to trace: {e}")
+
 
 if __name__ == "__main__":
     absltest.main(testLoader=jtu.JaxTestLoader())

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -262,3 +262,26 @@ def poison_tpu_memory():
         ],
         compiler_params=pltpu.CompilerParams(disable_bounds_checks=True),
     )(jnp.zeros((1, ), dtype=jnp.float32))
+
+
+def test_make_optimized_mesh_missing_coords():
+    """Tests fallback to sorting by process_index and id in make_optimized_mesh when coords is missing."""
+    from tpu_inference.utils import make_optimized_mesh
+
+    class MockDeviceNoCoords:
+
+        def __init__(self, id, process_index, device_kind="TPU v7"):
+            self.id = id
+            self.process_index = process_index
+            self.device_kind = device_kind
+
+    devices = [
+        MockDeviceNoCoords(id=1, process_index=1),
+        MockDeviceNoCoords(id=0, process_index=0),
+    ]
+
+    mesh = make_optimized_mesh([2], ["axis"], devices=devices)
+
+    ordered_devices = mesh.devices.flatten()
+    assert ordered_devices[0].process_index == 0
+    assert ordered_devices[1].process_index == 1

--- a/tpu_inference/distributed/utils.py
+++ b/tpu_inference/distributed/utils.py
@@ -122,15 +122,28 @@ def get_device_topology_order_id(local_devices, global_devices) -> int:
 
     # 1. Find the 'anchor' (minimum coordinate) for the local devices.
     #    This represents the physical top-left corner of the local machine.
-    local_anchor = min(d.coords for d in local_devices)
+    #    Fallback to process_index if JAX devices do not have 'coords' attribute
+    #    (e.g., in some Ray or GKE environments).
+    try:
+        local_anchor = min(d.coords for d in local_devices)
+    except AttributeError:
+        logger.warning(
+            "TPU devices do not have 'coords' attribute. Falling back to process_index."
+        )
+        local_anchor = min(d.process_index for d in local_devices)
 
     # 2. Group global devices by process to find the anchor for EVERY process.
     process_anchors = {}
     for d in global_devices:
         pid = d.process_index
+        try:
+            coords = d.coords
+        except AttributeError:
+            coords = d.process_index
+
         # Update the minimum coordinate found for this process so far
-        if pid not in process_anchors or d.coords < process_anchors[pid]:
-            process_anchors[pid] = d.coords
+        if pid not in process_anchors or coords < process_anchors[pid]:
+            process_anchors[pid] = coords
 
     # 3. Sort the unique anchors to establish the canonical topology order.
     #    Tuples (x, y, z) sort lexicographically (x first, then y, then z).

--- a/tpu_inference/kernels/megablox/gmm_v2.py
+++ b/tpu_inference/kernels/megablox/gmm_v2.py
@@ -396,11 +396,27 @@ def inner_kernel(
         if cfgs.rhs_cfgs.should_dequantize_before_matmul:
             tiled_rhs_scale = tiled_rhs_ref.get_scale().astype(acc_ref.dtype)
             num_blocks = cfgs.num_quant_blocks_per_tile_k
-            tiled_rhs_dequant = tiled_rhs.astype(acc_ref.dtype).reshape(
+
+            # Pad tiled_rhs along K dimension if tile_k is not a multiple of quant_block_size,
+            # to avoid shape mismatch during reshape. For example, if tile_k = 256
+            # and quant_block_size = 160 (num_blocks = 2), pad 64 rows to reach 320.
+            pad_len = num_blocks * rhs_qbs - cfgs.tiles.tile_k
+            if pad_len > 0:
+                zeros = jnp.zeros((pad_len, rhs_tile_n), dtype=tiled_rhs.dtype)
+                padded_rhs = jnp.concatenate([tiled_rhs, zeros], axis=0)
+            else:
+                padded_rhs = tiled_rhs
+
+            tiled_rhs_dequant = padded_rhs.astype(acc_ref.dtype).reshape(
                 num_blocks, rhs_qbs, rhs_tile_n)
             tiled_rhs_dequant = tiled_rhs_dequant * tiled_rhs_scale
-            tiled_rhs = tiled_rhs_dequant.reshape(cfgs.tiles.tile_k,
-                                                  rhs_tile_n)
+
+            # Flatten the block-dequantized weights back to 2D and slice off
+            # the zero-padding rows to restore the original tile_k dimension
+            # (e.g., flatten 320 rows back to 2D and slice [:256, :] to trim 64 rows).
+            tiled_rhs = tiled_rhs_dequant.reshape(-1, rhs_tile_n)
+            if pad_len > 0:
+                tiled_rhs = tiled_rhs[:cfgs.tiles.tile_k, :]
             rhs_step_k = cfgs.tiles.tile_k
         else:
             rhs_step_k = rhs_qbs

--- a/tpu_inference/utils.py
+++ b/tpu_inference/utils.py
@@ -247,8 +247,15 @@ def make_optimized_mesh(axis_shapes: Sequence[int],
                         devices: Sequence[xc.Device] | None = None):
     if devices is None:
         devices = xb.devices()
-    # Sort the devices in case it's passed in an arbitary order
-    devices = sorted(devices, key=lambda x: x.coords)
+    # Sort the devices in case it's passed in an arbitary order.
+    # Fallback to sorting by process_index and id if 'coords' is missing
+    try:
+        devices = sorted(devices, key=lambda x: x.coords)
+    except AttributeError:
+        logger.warning(
+            "TPU devices do not have 'coords' attribute. Falling back to sorting by process_index and id."
+        )
+        devices = sorted(devices, key=lambda x: (x.process_index, x.id))
 
     def _is_1D(axis_shapes):
         return sum(x > 1 for x in axis_shapes) == 1


### PR DESCRIPTION
# Description

The vLLM server crashes when attempting to deploy the Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8 model on a TPU v7 multi-host machine

vllm command:
```
              bash /workspace/vllm/examples/online_serving/multi-node-serving.sh leader --ray_cluster_size=$(LWS_GROUP_SIZE);
                VLLM_DISABLE_SHARED_EXPERTS_STREAM=1 vllm serve --port 8000 \
                  --model=Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8 \
                  --enable-chunked-prefill \
                  --seed 42 \
                  --enable_prefix_caching \
                  --tensor-parallel-size 16 \
                  --no-async-scheduling \
                  --gpu-memory-utilization=0.9 \
                  --kv_cache_dtype=fp8 \
                  --max-model-len=8192
```

Error logs:
```
(EngineCore pid=576) Traceback (most recent call last):
(EngineCore pid=576)   File "/usr/local/lib/python3.12/multiprocessing/process.py", line 314, in _bootstrap
(EngineCore pid=576)     self.run()
(EngineCore pid=576)   File "/usr/local/lib/python3.12/multiprocessing/process.py", line 108, in run
(EngineCore pid=576)     self._target(*self._args, **self._kwargs)
(EngineCore pid=576)   File "/workspace/vllm/vllm/v1/engine/core.py", line 1169, in run_engine_core
(EngineCore pid=576)     raise e
(EngineCore pid=576)   File "/workspace/vllm/vllm/v1/engine/core.py", line 1139, in run_engine_core
(EngineCore pid=576)     engine_core = EngineCoreProc(*args, engine_index=dp_rank, **kwargs)
(EngineCore pid=576)                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=576)   File "/workspace/vllm/vllm/tracing/otel.py", line 178, in sync_wrapper
(EngineCore pid=576)     return func(*args, **kwargs)
(EngineCore pid=576)            ^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=576)   File "/workspace/vllm/vllm/v1/engine/core.py", line 905, in __init__
(EngineCore pid=576)     super().__init__(
(EngineCore pid=576)   File "/workspace/vllm/vllm/v1/engine/core.py", line 121, in __init__
(EngineCore pid=576)     self.model_executor = executor_class(vllm_config)
(EngineCore pid=576)                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=576)   File "/workspace/vllm/vllm/tracing/otel.py", line 178, in sync_wrapper
(EngineCore pid=576)     return func(*args, **kwargs)
(EngineCore pid=576)            ^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=576)   File "/workspace/vllm/vllm/v1/executor/abstract.py", line 109, in __init__
(EngineCore pid=576)     self._init_executor()
(EngineCore pid=576)   File "/workspace/tpu_inference/tpu_inference/executors/ray_distributed_executor.py", line 119, in _init_executor
(EngineCore pid=576)     self._init_workers_ray(placement_group)
(EngineCore pid=576)   File "/workspace/tpu_inference/tpu_inference/executors/ray_distributed_executor.py", line 440, in _init_workers_ray
(EngineCore pid=576)     self.collective_rpc("init_device")
(EngineCore pid=576)   File "/workspace/vllm/vllm/v1/executor/ray_executor.py", line 512, in collective_rpc
(EngineCore pid=576)     return ray.get(ray_worker_outputs, timeout=timeout)
(EngineCore pid=576)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=576)   File "/usr/local/lib/python3.12/site-packages/ray/_private/auto_init_hook.py", line 22, in auto_init_wrapper
(EngineCore pid=576)     return fn(*args, **kwargs)
(EngineCore pid=576)            ^^^^^^^^^^^^^^^^^^^
(EngineCore pid=576)   File "/usr/local/lib/python3.12/site-packages/ray/_private/client_mode_hook.py", line 107, in wrapper
(EngineCore pid=576)     return func(*args, **kwargs)
(EngineCore pid=576)            ^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=576)   File "/usr/local/lib/python3.12/site-packages/ray/_private/worker.py", line 2980, in get
(EngineCore pid=576)     values, debugger_breakpoint = worker.get_objects(
(EngineCore pid=576)                                   ^^^^^^^^^^^^^^^^^^^
(EngineCore pid=576)   File "/usr/local/lib/python3.12/site-packages/ray/_private/worker.py", line 1023, in get_objects
(EngineCore pid=576)     raise value.as_instanceof_cause()
(EngineCore pid=576) ray.exceptions.RayTaskError(AttributeError): [36mray::RayWorkerWrapper.execute_method()[39m (pid=2022, ip=10.56.0.237, actor_id=08d0bb2b32d12a26328b32f501000000, repr=<tpu_inference.executors.ray_distributed_executor.RayWorkerWrapper object at 0x7b32a2f4b770>)
(EngineCore pid=576)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=576)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=576)   File "/workspace/vllm/vllm/v1/executor/ray_utils.py", line 91, in execute_method
(EngineCore pid=576)     raise e
(EngineCore pid=576)   File "/workspace/vllm/vllm/v1/executor/ray_utils.py", line 81, in execute_method
(EngineCore pid=576)     return run_method(self, method, args, kwargs)
(EngineCore pid=576)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=576)   File "/workspace/vllm/vllm/v1/serial_utils.py", line 510, in run_method
(EngineCore pid=576)     return func(*args, **kwargs)
(EngineCore pid=576)            ^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=576)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=576)   File "/workspace/vllm/vllm/v1/worker/worker_base.py", line 325, in init_device
(EngineCore pid=576)     self.worker.init_device()  # type: ignore
(EngineCore pid=576)     ^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=576)   File "/workspace/tpu_inference/tpu_inference/worker/tpu_worker.py", line 343, in init_device
(EngineCore pid=576)     self.topology_order_id = get_device_topology_order_id(
(EngineCore pid=576)                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=576)   File "/workspace/tpu_inference/tpu_inference/distributed/utils.py", line 125, in get_device_topology_order_id
(EngineCore pid=576)     local_anchor = min(d.coords for d in local_devices)
(EngineCore pid=576)                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=576)   File "/workspace/tpu_inference/tpu_inference/distributed/utils.py", line 125, in <genexpr>
(EngineCore pid=576)     local_anchor = min(d.coords for d in local_devices)
(EngineCore pid=576)  
```

```
(EngineCore pid=577) Traceback (most recent call last):
(EngineCore pid=577)   File "/usr/local/lib/python3.12/multiprocessing/process.py", line 314, in _bootstrap
(EngineCore pid=577)     self.run()
(EngineCore pid=577)   File "/usr/local/lib/python3.12/multiprocessing/process.py", line 108, in run
(EngineCore pid=577)     self._target(*self._args, **self._kwargs)
(EngineCore pid=577)   File "/workspace/vllm/vllm/v1/engine/core.py", line 1169, in run_engine_core
(EngineCore pid=577)     raise e
(EngineCore pid=577)   File "/workspace/vllm/vllm/v1/engine/core.py", line 1139, in run_engine_core
(EngineCore pid=577)     engine_core = EngineCoreProc(*args, engine_index=dp_rank, **kwargs)
(EngineCore pid=577)                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=577)   File "/workspace/vllm/vllm/tracing/otel.py", line 178, in sync_wrapper
(EngineCore pid=577)     return func(*args, **kwargs)
(EngineCore pid=577)            ^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=577)   File "/workspace/vllm/vllm/v1/engine/core.py", line 905, in __init__
(EngineCore pid=577)     super().__init__(
(EngineCore pid=577)   File "/workspace/vllm/vllm/v1/engine/core.py", line 121, in __init__
(EngineCore pid=577)     self.model_executor = executor_class(vllm_config)
(EngineCore pid=577)                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=577)   File "/workspace/vllm/vllm/tracing/otel.py", line 178, in sync_wrapper
(EngineCore pid=577)     return func(*args, **kwargs)
(EngineCore pid=577)            ^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=577)   File "/workspace/vllm/vllm/v1/executor/abstract.py", line 109, in __init__
(EngineCore pid=577)     self._init_executor()
(EngineCore pid=577)   File "/workspace/tpu_inference/tpu_inference/executors/ray_distributed_executor.py", line 119, in _init_executor
(EngineCore pid=577)     self._init_workers_ray(placement_group)
(EngineCore pid=577)   File "/workspace/tpu_inference/tpu_inference/executors/ray_distributed_executor.py", line 440, in _init_workers_ray
(EngineCore pid=577)     self.collective_rpc("init_device")
(EngineCore pid=577)   File "/workspace/vllm/vllm/v1/executor/ray_executor.py", line 512, in collective_rpc
(EngineCore pid=577)     return ray.get(ray_worker_outputs, timeout=timeout)
(EngineCore pid=577)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=577)   File "/usr/local/lib/python3.12/site-packages/ray/_private/auto_init_hook.py", line 22, in auto_init_wrapper
(EngineCore pid=577)     return fn(*args, **kwargs)
(EngineCore pid=577)            ^^^^^^^^^^^^^^^^^^^
(EngineCore pid=577)   File "/usr/local/lib/python3.12/site-packages/ray/_private/client_mode_hook.py", line 107, in wrapper
(EngineCore pid=577)     return func(*args, **kwargs)
(EngineCore pid=577)            ^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=577)   File "/usr/local/lib/python3.12/site-packages/ray/_private/worker.py", line 2980, in get
(EngineCore pid=577)     values, debugger_breakpoint = worker.get_objects(
(EngineCore pid=577)                                   ^^^^^^^^^^^^^^^^^^^
(EngineCore pid=577)   File "/usr/local/lib/python3.12/site-packages/ray/_private/worker.py", line 1023, in get_objects
(EngineCore pid=577)     raise value.as_instanceof_cause()
(EngineCore pid=577) ray.exceptions.RayTaskError(AttributeError): [36mray::RayWorkerWrapper.execute_method()[39m (pid=1961, ip=10.56.0.244, actor_id=7b81bdd17cd86ed0129dd08601000000, repr=<tpu_inference.executors.ray_distributed_executor.RayWorkerWrapper object at 0x7eda942736e0>)
(EngineCore pid=577)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=577)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=577)   File "/workspace/vllm/vllm/v1/executor/ray_utils.py", line 91, in execute_method
(EngineCore pid=577)     raise e
(EngineCore pid=577)   File "/workspace/vllm/vllm/v1/executor/ray_utils.py", line 81, in execute_method
(EngineCore pid=577)     return run_method(self, method, args, kwargs)
(EngineCore pid=577)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=577)   File "/workspace/vllm/vllm/v1/serial_utils.py", line 510, in run_method
(EngineCore pid=577)     return func(*args, **kwargs)
(EngineCore pid=577)            ^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=577)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=577)   File "/workspace/vllm/vllm/v1/worker/worker_base.py", line 325, in init_device
(EngineCore pid=577)     self.worker.init_device()  # type: ignore
(EngineCore pid=577)     ^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=577)   File "/workspace/tpu_inference/tpu_inference/worker/tpu_worker.py", line 346, in init_device
(EngineCore pid=577)     self.model_runner = TPUModelRunner(self.vllm_config, self.devices,
(EngineCore pid=577)                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=577)   File "/workspace/tpu_inference/tpu_inference/runner/tpu_runner.py", line 315, in __init__
(EngineCore pid=577)     self._init_mesh()
(EngineCore pid=577)   File "/workspace/tpu_inference/tpu_inference/runner/tpu_runner.py", line 365, in _init_mesh
(EngineCore pid=577)     self.mesh = self._create_2d_mesh()
(EngineCore pid=577)                 ^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=577)   File "/workspace/tpu_inference/tpu_inference/runner/tpu_runner.py", line 461, in _create_2d_mesh
(EngineCore pid=577)     return make_optimized_mesh(mesh_shape,
(EngineCore pid=577)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=577)   File "/workspace/tpu_inference/tpu_inference/utils.py", line 251, in make_optimized_mesh
(EngineCore pid=577)     devices = sorted(devices, key=lambda x: x.coords)
(EngineCore pid=577)               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=577)   File "/workspace/tpu_inference/tpu_inference/utils.py", line 251, in <lambda>
(EngineCore pid=577)     devices = sorted(devices, key=lambda x: x.coords)
(EngineCore pid=577) 
```

Analysis: JAX cannot resolve the physical 3D/4D torus coordinate topology of the accelerators.

# Tests

tests/test_utils.py
tests/distributed/test_distributed_utils.py

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.