### PR TITLE
Flush pending async TPU outputs on empty schedules

### DIFF
--- a/tests/runner/test_tpu_runner.py
+++ b/tests/runner/test_tpu_runner.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import jax
@@ -24,7 +25,7 @@ from vllm.config.multimodal import BaseDummyOptions
 
 from tpu_inference.models.common.interface import (ModelInterface,
                                                    MultiModalInterface)
-from tpu_inference.runner.tpu_runner import TPUModelRunner
+from tpu_inference.runner.tpu_runner import AsyncPreResults, TPUModelRunner
 
 
 class TestTPUJaxRunner:
@@ -196,6 +197,47 @@ class TestTPUJaxRunner:
         mock_kv_cache_config.has_mamba_layers = False
         self.runner.kv_cache_config = mock_kv_cache_config
         self.runner.use_hybrid_kvcache = True
+
+
+def test_flush_prev_async_results_returns_pending_output_and_clears_state():
+    runner = object.__new__(TPUModelRunner)
+    runner.max_model_len = 16
+    runner.scheduler_config = SimpleNamespace(async_scheduling=True)
+    runner.input_batch = SimpleNamespace(
+        req_id_to_index={"req1": 0},
+        token_ids_cpu=np.zeros((1, 16), dtype=np.int32),
+        num_tokens_no_spec=np.array([2], dtype=np.int32),
+        num_tokens=np.array([2], dtype=np.int32),
+    )
+    runner.requests = {}
+
+    req_state = SimpleNamespace(req_id="req1", output_token_ids=[0, 0])
+    runner.requests["req1"] = req_state
+    runner._pre_async_results = AsyncPreResults(
+        req_ids=["req1"],
+        next_tokens=np.array([7], dtype=np.int32),
+        request_seq_lens=[(0, req_state, 2)],
+        discard_sampled_tokens_req_indices=[],
+        placeholder_req_id_to_index={"req1": 0},
+        scheduler_output=SimpleNamespace(
+            scheduled_spec_decode_tokens={"req1": [0]},
+        ),
+    )
+
+    with patch(
+            "tpu_inference.runner.tpu_runner.runner_utils.host_extract_sampled_tokens",
+            return_value=[[7]],
+    ) as mock_extract:
+        output = runner._flush_prev_async_results()
+
+    mock_extract.assert_called_once()
+    assert runner._pre_async_results is None
+    assert output.req_ids == ["req1"]
+    assert output.sampled_token_ids == [[7]]
+    assert req_state.output_token_ids == [7]
+    assert runner.input_batch.token_ids_cpu[0, 0] == 7
+    assert runner.input_batch.num_tokens_no_spec[0] == 1
+    assert runner.input_batch.num_tokens[0] == 1
 
 
 class TestTPUJaxRunnerMultimodalModelLoadedForTextOnly:

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -1017,6 +1017,26 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                 req_state.output_token_ids.pop()
             req_state.output_token_ids.extend(sampled_ids)
 
+        return valid_sampled_token_ids
+
+    def _flush_prev_async_results(
+        self,
+        kv_connector_output: Optional[KVConnectorOutput] = None,
+    ) -> ModelRunnerOutput:
+        assert self._pre_async_results is not None
+        pre_req_ids = self._pre_async_results.req_ids
+        valid_sampled_token_ids = self._modify_prev_results()
+        self._pre_async_results = None
+        return ModelRunnerOutput(
+            req_ids=pre_req_ids,
+            req_id_to_index=self.input_batch.req_id_to_index.copy(),
+            sampled_token_ids=valid_sampled_token_ids,
+            logprobs=None,
+            prompt_logprobs_dict={req_id: None for req_id in pre_req_ids},
+            pooler_output=[],
+            kv_connector_output=kv_connector_output,
+        )
+
     def _update_placeholder(
             self,
             discard_sampled_tokens_req_indices,
@@ -1071,6 +1091,12 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         self.persistent_batch_manager.update_states(
             scheduler_output, self.get_mrope_input_positions_fn)
         if not scheduler_output.total_num_scheduled_tokens:
+            if (self.scheduler_config.async_scheduling
+                    and self._pre_async_results is not None):
+                logger.debug(
+                    "No tokens scheduled; flushing pending async TPU output.")
+                return self._flush_prev_async_results()
+
             if has_kv_transfer_group():
                 return self.kv_connector_no_forward(scheduler_output,
                                                     self.vllm_config)


### PR DESCRIPTION
## Summary
When TPU async scheduling reaches a step with no scheduled tokens, the runner currently returns an empty output immediately. If a previous async TPU result is still pending, that result is never materialized and vLLM can keep a request in RUNNING with no schedulable work, causing repeated `Should not schedule a request that does nothing!` warnings.

This drains the pending async TPU result before returning from a no-work step and clears the pending async state. That lets the scheduler consume the real sampled tokens and finish or advance the request instead of spinning on empty schedules.

## Test Plan
- `python -m py_compile tpu_inference/runner/tpu_runner.py tests/runner/test_tpu_runner.py`
- `git diff --check`
- `python -m pytest tests/runner/test_tpu_runner.py::test_flush_prev_async_results_returns_pending_output_and_clears_state -q` could not be run locally because pytest is not installed in this checkout's default Python environment.