### PR TITLE
Fix data-parallel-size configuration typo for Gemma4 on v7x-2

### DIFF
--- a/.buildkite/benchmark/cases/daily/Gemma4-26B-dataset_custom-inlen_1024-outlen_500.json
+++ b/.buildkite/benchmark/cases/daily/Gemma4-26B-dataset_custom-inlen_1024-outlen_500.json
@@ -24,16 +24,17 @@
           "VLLM_USE_V1": "1",
           "MODEL_IMPL_TYPE": "flax_nnx",
           "USE_BATCHED_RPA_KERNEL": "1",
-          "MOE_REQUANTIZE_WEIGHT_DTYPE": "float8_e4m3fn"
+          "MOE_REQUANTIZE_WEIGHT_DTYPE": "float8_e4m3fn",
+          "VLLM_ENGINE_READY_TIMEOUT_S": "1800"
         },
         "args": {
           "model": "google/gemma-4-26B-A4B-it",
           "max-num-seqs": 256,
           "max-num-batched-tokens": 4096,
           "data-parallel-size": {
-              "v6e-8": 2,
-              "v7x-2": 4,
-              "default": 1
+            "v6e-8": 2,
+            "v7x-2": 1,
+            "default": 1
           },
           "tensor-parallel-size": {
             "v7x-2": 2,
@@ -79,16 +80,17 @@
           "VLLM_USE_V1": "1",
           "MODEL_IMPL_TYPE": "flax_nnx",
           "USE_BATCHED_RPA_KERNEL": "1",
-          "MOE_REQUANTIZE_WEIGHT_DTYPE": "float8_e4m3fn"
+          "MOE_REQUANTIZE_WEIGHT_DTYPE": "float8_e4m3fn",
+          "VLLM_ENGINE_READY_TIMEOUT_S": "1800"
         },
         "args": {
           "model": "google/gemma-4-26B-A4B-it",
           "max-num-seqs": 256,
           "max-num-batched-tokens": 4096,
           "data-parallel-size": {
-              "v6e-8": 2,
-              "v7x-2": 4,
-              "default": 1
+            "v6e-8": 2,
+            "v7x-2": 1,
+            "default": 1
           },
           "tensor-parallel-size": {
             "v7x-2": 2,

--- a/.buildkite/benchmark/cases/daily/Gemma4-31B-dataset_custom-inlen_1024-outlen_500.json
+++ b/.buildkite/benchmark/cases/daily/Gemma4-31B-dataset_custom-inlen_1024-outlen_500.json
@@ -24,7 +24,8 @@
         "env": {
           "VLLM_USE_V1": "1",
           "MODEL_IMPL_TYPE": "flax_nnx",
-          "USE_BATCHED_RPA_KERNEL": "1"
+          "USE_BATCHED_RPA_KERNEL": "1",
+          "VLLM_ENGINE_READY_TIMEOUT_S": "1800"
         },
         "args": {
           "model": "google/gemma-4-31B-it",
@@ -32,7 +33,7 @@
           "max-num-batched-tokens": 4096,
           "data-parallel-size": {
               "v6e-8": 2,
-              "v7x-2": 4,
+              "v7x-2": 1,
               "default": 1
           },
           "tensor-parallel-size": {
@@ -80,7 +81,8 @@
         "env": {
           "VLLM_USE_V1": "1",
           "MODEL_IMPL_TYPE": "flax_nnx",
-          "USE_BATCHED_RPA_KERNEL": "1"
+          "USE_BATCHED_RPA_KERNEL": "1",
+          "VLLM_ENGINE_READY_TIMEOUT_S": "1800"
         },
         "args": {
           "model": "google/gemma-4-31B-it",
@@ -88,7 +90,7 @@
           "max-num-batched-tokens": 4096,
           "data-parallel-size": {
               "v6e-8": 2,
-              "v7x-2": 4,
+              "v7x-2": 1,
               "default": 1
           },
           "tensor-parallel-size": {


### PR DESCRIPTION
v7x-2 only has two devices so cant use (2, 4) dp tp. Fix that accordingly

# Description

Start with a short description of what the PR does and how this is a change from
the past.

The rest of the description includes relevant details and context, examples:
- why is this change being made,
- the problem being solved and any relevant context,
- why this is a good solution,
- some information about the specific implementation,
- shortcomings of the solution and possible future improvements.

If the change fixes a Github issue, please include a link, e.g.,:
FIXES: #123456

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [ ] I have performed a self-review of my code.
- [ ] I have necessary comments in my code, particularly in hard-to-understand areas.
- [ ] I have made or will make corresponding changes to any relevant documentation.
- [ ] I have reviewed the uLLM modeling code checklist: https://docs.google.com/document/d/1DGQBVvr2bh4G8tBUO1YH8pO7Dd_myw5rfEMfVDymEk8/edit?resourcekey=0-V7MGHu3aQjJH6YrI3-y8Hg&tab=t.t91cyovog2mr#heading=h.cqdzv8mlszca
- [ ] I have received at least 1 readability approval and 1 correctness approval.
