### PR TITLE
[KV Offload] Enable KV offloading for attention data parallelism

### DIFF
--- a/tests/offload/tpu_offload_connector_scheduler_test.py
+++ b/tests/offload/tpu_offload_connector_scheduler_test.py
@@ -489,7 +489,9 @@ class TestTPUOffloadConnectorScheduler:
 
         assert req_id not in scheduler._unfinished_requests
         assert req_id not in scheduler._request_trackers
-        assert len(metadata.requests_meta) == 0
+        assert len(metadata.requests_meta) == 1
+        assert metadata.requests_meta[0].save_spec.skip_save is True
+        assert metadata.requests_meta[0].save_spec.is_final_save is True
 
 
 @pytest.fixture

--- a/tests/offload/tpu_offload_utils_test.py
+++ b/tests/offload/tpu_offload_utils_test.py
@@ -20,6 +20,8 @@ import numpy as np
 from jax.sharding import NamedSharding, PartitionSpec
 
 from tpu_inference.offload.utils import (pre_update_kv_caches,
+                                         pure_jax_stack_kv_cache_cross_layers,
+                                         pure_jax_update_kv_caches_one,
                                          stack_kv_cache_cross_layers,
                                          update_kv_caches)
 
@@ -215,6 +217,256 @@ class TestTPUOffloadUtilsFn(unittest.TestCase):
                                                atol=1e-2)
 
         print("\nTest passed: update_kv_caches correctly updated the cache.")
+
+    def test_pure_jax_stack_kv_cache_cross_layers(self):
+        """
+        Verify gathering and stacking KV blocks using pure_jax_stack_kv_cache_cross_layers.
+        """
+        num_blocks_to_gather = 3
+        src_blocks = [2, 4, 6]
+
+        initial_kv_caches = []
+        for i in range(self.num_layers):
+            layer_data = jax.random.normal(jax.random.key(i + 100),
+                                           shape=self.cache_shape,
+                                           dtype=self.cache_dtype)
+            initial_kv_caches.append(
+                jax.device_put(layer_data, self.device_sharding))
+
+        jax.block_until_ready(initial_kv_caches)
+
+        initial_kv_caches_baseline = [
+            np.array(cache) for cache in initial_kv_caches
+        ]
+        src_blocks_array = jnp.array(src_blocks)
+
+        kv_caches_out, output = pure_jax_stack_kv_cache_cross_layers(
+            initial_kv_caches, src_blocks_array, num_blocks_to_gather)
+        jax.block_until_ready(output)
+        jax.block_until_ready(kv_caches_out)
+
+        self.assertEqual(len(output), num_blocks_to_gather)
+        for i in range(num_blocks_to_gather):
+            self.assertEqual(output[i].shape[1], self.num_layers)
+            self.assertEqual(output[i].shape[2:], self.cache_shape[1:])
+
+            block_id = src_blocks[i]
+            for j in range(self.num_layers):
+                output_np = np.array(output[i])
+                initial_np = np.array(initial_kv_caches_baseline[j])
+                np.testing.assert_array_equal(output_np[0, j],
+                                              initial_np[block_id])
+
+        for j in range(self.num_layers):
+            np.testing.assert_array_equal(np.array(kv_caches_out[j]),
+                                          initial_kv_caches_baseline[j])
+
+        print("\nTest passed: pure_jax_stack_kv_cache_cross_layers "
+              "correctly gathered blocks and passed through kv_caches.")
+
+    def test_pure_jax_update_kv_caches_one(self):
+        """
+        Verify pure_jax_update_kv_caches_one correctly scatters the blocks back into the KV cache.
+        """
+        num_blocks_to_update = 2
+        update_indices = [2, 5]
+
+        initial_kv_caches = [
+            jax.device_put(jnp.zeros(self.cache_shape, dtype=self.cache_dtype),
+                           self.device_sharding)
+            for _ in range(self.num_layers)
+        ]
+
+        stacked_blocks = [
+            jax.device_put(
+                jax.random.uniform(jax.random.PRNGKey(i + 200),
+                                   shape=(1, self.num_layers,
+                                          *self.block_shape),
+                                   dtype=self.cache_dtype),
+                self.expand_device_sharding)
+            for i in range(num_blocks_to_update)
+        ]
+        stacked_blocks_backup = [jnp.copy(sb) for sb in stacked_blocks]
+
+        jax.block_until_ready(initial_kv_caches)
+        jax.block_until_ready(stacked_blocks)
+        jax.block_until_ready(stacked_blocks_backup)
+
+        updated_caches = pure_jax_update_kv_caches_one(
+            initial_kv_caches,
+            stacked_blocks,
+            update_indices,
+            self.mesh,
+            indices_sharding=jax.sharding.PartitionSpec())
+
+        jax.block_until_ready(updated_caches)
+
+        for layer_idx in range(self.num_layers):
+            layer_cache = np.array(updated_caches[layer_idx])
+
+            for i, block_idx in enumerate(update_indices):
+                expected_block = np.array(stacked_blocks_backup[i])[0,
+                                                                    layer_idx]
+                actual_block = layer_cache[block_idx]
+                np.testing.assert_allclose(actual_block,
+                                           expected_block,
+                                           rtol=1e-2,
+                                           atol=1e-2)
+
+            for block_idx in range(self.num_blocks):
+                if block_idx not in update_indices:
+                    np.testing.assert_allclose(layer_cache[block_idx],
+                                               0,
+                                               rtol=1e-2,
+                                               atol=1e-2)
+
+        print("\nTest passed: pure_jax_update_kv_caches_one "
+              "correctly scattered the blocks.")
+
+    def test_pure_jax_stack_kv_cache_cross_layers_single_block(self):
+        """
+        Edge Case: Verify gathering exactly 1 block.
+        """
+        num_blocks_to_gather = 1
+        src_blocks = [5]
+
+        initial_kv_caches = []
+        for i in range(self.num_layers):
+            layer_data = jax.random.normal(jax.random.key(i + 300),
+                                           shape=self.cache_shape,
+                                           dtype=self.cache_dtype)
+            initial_kv_caches.append(
+                jax.device_put(layer_data, self.device_sharding))
+
+        jax.block_until_ready(initial_kv_caches)
+        initial_kv_caches_baseline = [
+            np.array(cache) for cache in initial_kv_caches
+        ]
+        src_blocks_array = jnp.array(src_blocks)
+
+        kv_caches_out, output = pure_jax_stack_kv_cache_cross_layers(
+            initial_kv_caches, src_blocks_array, num_blocks_to_gather)
+        jax.block_until_ready(output)
+
+        self.assertEqual(len(output), 1)
+        self.assertEqual(output[0].shape[1], self.num_layers)
+
+        for j in range(self.num_layers):
+            output_np = np.array(output[0])
+            initial_np = np.array(initial_kv_caches_baseline[j])
+            np.testing.assert_array_equal(output_np[0, j], initial_np[5])
+
+    def test_pure_jax_update_kv_caches_one_out_of_order(self):
+        """
+        Edge Case: Verify pure_jax_update_kv_caches_one scatters correctly when indices are out of order.
+        """
+        num_blocks_to_update = 2
+        update_indices = [5, 2]  # Out of order!
+
+        initial_kv_caches = [
+            jax.device_put(jnp.zeros(self.cache_shape, dtype=self.cache_dtype),
+                           self.device_sharding)
+            for _ in range(self.num_layers)
+        ]
+
+        stacked_blocks = [
+            jax.device_put(
+                jax.random.uniform(jax.random.PRNGKey(i + 400),
+                                   shape=(1, self.num_layers,
+                                          *self.block_shape),
+                                   dtype=self.cache_dtype),
+                self.expand_device_sharding)
+            for i in range(num_blocks_to_update)
+        ]
+        stacked_blocks_backup = [jnp.copy(sb) for sb in stacked_blocks]
+        jax.block_until_ready(stacked_blocks)
+
+        updated_caches = pure_jax_update_kv_caches_one(
+            initial_kv_caches,
+            stacked_blocks,
+            update_indices,
+            self.mesh,
+            indices_sharding=jax.sharding.PartitionSpec())
+        jax.block_until_ready(updated_caches)
+
+        for layer_idx in range(self.num_layers):
+            layer_cache = np.array(updated_caches[layer_idx])
+            # Check block 5 is stacked_blocks[0]
+            np.testing.assert_allclose(
+                layer_cache[5],
+                np.array(stacked_blocks_backup[0])[0, layer_idx],
+                rtol=1e-2,
+                atol=1e-2)
+            # Check block 2 is stacked_blocks[1]
+            np.testing.assert_allclose(
+                layer_cache[2],
+                np.array(stacked_blocks_backup[1])[0, layer_idx],
+                rtol=1e-2,
+                atol=1e-2)
+
+    def test_pure_jax_update_kv_caches_one_sharding_types(self):
+        """
+        Edge Case: Verify pure_jax_update_kv_caches_one accepts None, PartitionSpec, and NamedSharding for indices_sharding.
+        """
+        update_indices = [1]
+
+        def get_fresh_inputs():
+            caches = [
+                jax.device_put(
+                    jnp.zeros(self.cache_shape, dtype=self.cache_dtype),
+                    self.device_sharding) for _ in range(self.num_layers)
+            ]
+            blocks = [
+                jax.device_put(
+                    jnp.ones((1, self.num_layers, *self.block_shape),
+                             dtype=self.cache_dtype),
+                    self.expand_device_sharding)
+            ]
+            return caches, blocks
+
+        # Test None
+        c1, b1 = get_fresh_inputs()
+        out_none = pure_jax_update_kv_caches_one(c1,
+                                                 b1,
+                                                 update_indices,
+                                                 self.mesh,
+                                                 indices_sharding=None)
+
+        # Test PartitionSpec
+        c2, b2 = get_fresh_inputs()
+        out_ps = pure_jax_update_kv_caches_one(
+            c2,
+            b2,
+            update_indices,
+            self.mesh,
+            indices_sharding=jax.sharding.PartitionSpec())
+
+        # Test NamedSharding
+        c3, b3 = get_fresh_inputs()
+        named_sharding = NamedSharding(self.mesh,
+                                       jax.sharding.PartitionSpec(),
+                                       memory_kind='device')
+        out_ns = pure_jax_update_kv_caches_one(c3,
+                                               b3,
+                                               update_indices,
+                                               self.mesh,
+                                               indices_sharding=named_sharding)
+
+        jax.block_until_ready([out_none, out_ps, out_ns])
+
+        # All should have successfully scattered 1 into index 1
+        np.testing.assert_allclose(np.array(out_none[0])[1],
+                                   1.0,
+                                   rtol=1e-2,
+                                   atol=1e-2)
+        np.testing.assert_allclose(np.array(out_ps[0])[1],
+                                   1.0,
+                                   rtol=1e-2,
+                                   atol=1e-2)
+        np.testing.assert_allclose(np.array(out_ns[0])[1],
+                                   1.0,
+                                   rtol=1e-2,
+                                   atol=1e-2)
 
 
 if __name__ == "__main__":

--- a/tpu_inference/core/sched/dp_scheduler.py
+++ b/tpu_inference/core/sched/dp_scheduler.py
@@ -876,6 +876,53 @@ class DPScheduler(SchedulerInterface):
         for rank, output in enumerate(rank_outputs):
             req_ids_per_rank[rank] = list(output.num_scheduled_tokens.keys())
 
+        # Combine kv_connector_metadata from all DP rank outputs
+        combined_kv_connector_metadata = None
+        if rank_outputs:
+            num_blocks_per_rank = self.per_rank_kv_cache_configs[0].num_blocks
+
+        for rank, output in enumerate(rank_outputs):
+            meta = output.kv_connector_metadata
+            if meta is not None:
+                if combined_kv_connector_metadata is None:
+                    combined_kv_connector_metadata = type(meta)()
+
+                # Dynamically merge fields depending on the active connector type
+                if hasattr(meta, "requests_meta"):
+                    # Translate local block IDs to global logical block IDs
+                    rank_offset = rank * num_blocks_per_rank
+                    for req_meta in meta.requests_meta:
+                        if hasattr(req_meta, "local_block_ids"
+                                   ) and req_meta.local_block_ids:
+                            req_meta.local_block_ids = [
+                                b + rank_offset
+                                for b in req_meta.local_block_ids
+                            ]
+                        if hasattr(req_meta, "save_spec"
+                                   ) and req_meta.save_spec is not None:
+                            if hasattr(req_meta.save_spec, "src_blocks"
+                                       ) and req_meta.save_spec.src_blocks:
+                                req_meta.save_spec.src_blocks = [
+                                    b + rank_offset
+                                    for b in req_meta.save_spec.src_blocks
+                                ]
+                        if hasattr(req_meta, "load_spec"
+                                   ) and req_meta.load_spec is not None:
+                            if hasattr(req_meta.load_spec, "dst_blocks"
+                                       ) and req_meta.load_spec.dst_blocks:
+                                req_meta.load_spec.dst_blocks = [
+                                    b + rank_offset
+                                    for b in req_meta.load_spec.dst_blocks
+                                ]
+                    combined_kv_connector_metadata.requests_meta.extend(
+                        meta.requests_meta)
+                if hasattr(meta, "reqs_to_send"):
+                    combined_kv_connector_metadata.reqs_to_send.update(
+                        meta.reqs_to_send)
+                if hasattr(meta, "reqs_to_load"):
+                    combined_kv_connector_metadata.reqs_to_load.update(
+                        meta.reqs_to_load)
+
         return DPSchedulerOutput(
             scheduled_new_reqs=all_new_reqs,
             scheduled_cached_reqs=combined_cached_data,
@@ -889,6 +936,7 @@ class DPScheduler(SchedulerInterface):
             assigned_dp_rank=assigned_dp_rank,
             max_num_scheduled_tokens_per_dp_rank=max_scheduled_tokens_per_rank,
             req_ids_per_rank=req_ids_per_rank,
+            kv_connector_metadata=combined_kv_connector_metadata,
         )
 
     def _combine_cached_request_data(

--- a/tpu_inference/envs.py
+++ b/tpu_inference/envs.py
@@ -53,6 +53,7 @@ if TYPE_CHECKING:
     TPU_OFFLOAD_BATCHED_SAVE: bool = False
     TPU_OFFLOAD_METRICS_LOG_INTERVAL: int = 5
     TPU_OFFLOAD_USE_UNPINNED_HOST: bool = False
+    TPU_OFFLOAD_BLOCK_SIZE_BUCKETS: list[int] = []
     MOE_APPROX_TOPK: bool = False
     MOE_APPROX_TOPK_RECALL_TARGET: float | None = None
     VLLM_TPU_PATCH_MM_EMBEDDINGS: bool = False
@@ -352,6 +353,10 @@ environment_variables: dict[str, Callable[[], Any]] = {
     lambda: bool(int(os.getenv("TPU_OFFLOAD_USE_UNPINNED_HOST", "0"))),
     "AGGREGATED_STATS_DIR":
     lambda: os.getenv("AGGREGATED_STATS_DIR", ""),
+    # kv offload to dram: buckets of sizes for pre-compilation
+    "TPU_OFFLOAD_BLOCK_SIZE_BUCKETS":
+    lambda: env_int_list("TPU_OFFLOAD_BLOCK_SIZE_BUCKETS")
+    () or [1, 2, 4, 8, 16, 32, 64],
     # MoE: whether to use approximate top-k for expert selection.
     # Enabling this may speedup the expert selection at the risk of accuracy loss.
     "MOE_APPROX_TOPK":

--- a/tpu_inference/offload/tpu_offload_connector.py
+++ b/tpu_inference/offload/tpu_offload_connector.py
@@ -133,6 +133,8 @@ from tpu_inference.offload.cpu_backend import LocalCPUBackend
 from tpu_inference.offload.offload_manager import (LRUCacheManager,
                                                    StagingBufferManager)
 from tpu_inference.offload.utils import (CpuChunkId, ReqId,
+                                         pure_jax_stack_kv_cache_cross_layers,
+                                         pure_jax_update_kv_caches_one,
                                          stack_kv_cache_cross_layers,
                                          update_kv_caches_one)
 from tpu_inference.runner.tpu_runner import TPUModelRunner
@@ -142,7 +144,7 @@ logger = init_logger(__name__)
 # kv cache layout needed by cpu offloading mechanism
 REQUIRED_KV_CACHE_LAYOUT = "NHD"
 
-BLOCK_SIZE_BUCKETS = [1, 2, 4, 8, 16, 32, 64]
+BLOCK_SIZE_BUCKETS = envs.TPU_OFFLOAD_BLOCK_SIZE_BUCKETS
 
 # we keep our operations at vllm's block granularity,
 # and want to provide the following three preferences when handling
@@ -349,6 +351,32 @@ class KVOffloadConnectorStats(KVConnectorStats):
         return self.num_finished_blocks == 0
 
     def aggregate(self, other: KVConnectorStats) -> KVConnectorStats:
+        """
+        Aggregates metrics from another KVConnectorStats instance into this one.
+
+        This method merges dynamically calculated data such as `finished_save_chunks` and 
+        `finished_load_chunks` from the `other.data` dict. Note that `num_finished_blocks` 
+        is not directly aggregated because it is exposed as a dynamically calculated property.
+
+        Args:
+            other (KVConnectorStats): The other metrics container to aggregate from.
+
+        Returns:
+            KVConnectorStats: The updated instance (self) containing the aggregated stats.
+        """
+        if isinstance(other, KVOffloadConnectorStats):
+            other_saves = other.data.get("finished_save_chunks", {})
+            for k, v in other_saves.items():
+                if k not in self.data["finished_save_chunks"]:
+                    self.data["finished_save_chunks"][k] = []
+                self.data["finished_save_chunks"][k].extend(v)
+
+            other_loads = other.data.get("finished_load_chunks", {})
+            for k, v in other_loads.items():
+                if k not in self.data["finished_load_chunks"]:
+                    self.data["finished_load_chunks"][k] = []
+                self.data["finished_load_chunks"][k].extend(v)
+
         return self
 
     def reduce(self) -> dict[str, int | float]:
@@ -373,8 +401,13 @@ class KVOffloadConnectorStats(KVConnectorStats):
 
     @property
     def num_finished_blocks(self) -> int:
-        return len(self.data["finished_save_chunks"]) + len(
-            self.data["finished_load_chunks"])
+        finished_saves = sum(
+            len(chunks)
+            for chunks in self.data.get("finished_save_chunks", {}).values())
+        finished_loads = sum(
+            len(chunks)
+            for chunks in self.data.get("finished_load_chunks", {}).values())
+        return finished_saves + finished_loads
 
 
 # The metadata used for communicating between scheduler and worker connectors.
@@ -965,6 +998,13 @@ class TPUOffloadConnectorScheduler():
                 )
                 continue
 
+            # Ensure any remaining decode tokens are flushed before cleanup
+            save_spec = self._prepare_save_spec(tracker, is_finished=True)
+            if save_spec:
+                req_meta = self._create_request_meta(tracker, save_spec, None)
+                if req_meta:
+                    metadata.requests_meta.append(req_meta)
+
             # Pop tracker and other state first.
             self._request_trackers.pop(finished_req_id, None)
             self._unfinished_requests.pop(finished_req_id, None)
@@ -1132,6 +1172,23 @@ class TPUOffloadConnectorScheduler():
             f"TPUOffloadConnectorScheduler: getting workers' output: finished_sending: {connector_output.finished_sending}, finished_recving: {connector_output.finished_recving}"
         )
 
+        # Filter out worker events for requests that have already been cleaned up.
+        # This prevents the vLLM engine from crashing on `assert req_id in self.requests`
+        # when processing the final decode save or lagging responses.
+        if connector_output.finished_sending:
+            connector_output.finished_sending = {
+                req_id
+                for req_id in connector_output.finished_sending
+                if req_id in self._unfinished_requests
+            }
+
+        if connector_output.finished_recving:
+            connector_output.finished_recving = {
+                req_id
+                for req_id in connector_output.finished_recving
+                if req_id in self._unfinished_requests
+            }
+
         # per iteration, update the finished staging blocks
         if connector_output.kv_connector_stats and connector_output.kv_connector_stats.data is not None:
             assert isinstance(connector_output.kv_connector_stats,
@@ -1141,6 +1198,8 @@ class TPUOffloadConnectorScheduler():
 
             for req_id, saved_chunk_ids in connector_output.kv_connector_stats.data[
                     "finished_save_chunks"].items():
+                if req_id not in self._reqs_being_saved:
+                    continue
                 num_saved_chunks = len(saved_chunk_ids)
                 logger.debug(
                     f"  finished_save_chunks for {req_id}: {saved_chunk_ids}")
@@ -1166,6 +1225,8 @@ class TPUOffloadConnectorScheduler():
 
             for req_id, loaded_chunk_ids in connector_output.kv_connector_stats.data[
                     "finished_load_chunks"].items():
+                if req_id not in self._reqs_being_loaded:
+                    continue
                 num_loaded_chunks = len(loaded_chunk_ids)
                 logger.debug(
                     f"  finished_load_chunks for {req_id}: {num_loaded_chunks}"
@@ -1386,6 +1447,26 @@ class TPUOffloadConnectorWorker:
                 raise ValueError("Could not decompose with given buckets.")
         return decomposed_blocks
 
+    def _do_stack(self, kv_caches, block_ids_arr, num_blocks):
+        if self.mesh.shape.get('attn_dp', 1) > 1:
+            return pure_jax_stack_kv_cache_cross_layers(
+                kv_caches, block_ids_arr, num_blocks)
+        else:
+            return stack_kv_cache_cross_layers(kv_caches, block_ids_arr,
+                                               num_blocks)
+
+    def _do_update(self, kv_caches, kv_cache_slices, dst_blocks, mesh,
+                   cached_kv_sharding_spec, indices_sharding):
+        if self.mesh.shape.get('attn_dp', 1) > 1:
+            return pure_jax_update_kv_caches_one(kv_caches, kv_cache_slices,
+                                                 dst_blocks, mesh,
+                                                 cached_kv_sharding_spec,
+                                                 indices_sharding)
+        else:
+            return update_kv_caches_one(kv_caches, kv_cache_slices, dst_blocks,
+                                        mesh, cached_kv_sharding_spec,
+                                        indices_sharding)
+
     def _precompile_kv_swap_operations(self):
         """
         Pre-compiles the functions used for KV cache swapping
@@ -1409,7 +1490,7 @@ class TPUOffloadConnectorWorker:
                         dummy_block_ids_arr = jnp.array(dummy_block_ids)
 
                         # 1. gather / stack (for save)
-                        paged_kv_for_compilation, stacked_dummy_kv_caches_tpu = stack_kv_cache_cross_layers(
+                        paged_kv_for_compilation, stacked_dummy_kv_caches_tpu = self._do_stack(
                             paged_kv_for_compilation, dummy_block_ids_arr,
                             num_blocks)
                         stacked_dummy_kv_caches_tpu = [
@@ -1420,7 +1501,7 @@ class TPUOffloadConnectorWorker:
                         jax.block_until_ready(stacked_dummy_kv_caches_tpu)
 
                         # 2. update / insert  kv (for load)
-                        updated_kv_caches = update_kv_caches_one(
+                        updated_kv_caches = self._do_update(
                             paged_kv_for_compilation,
                             stacked_dummy_kv_caches_tpu, dummy_block_ids,
                             self.mesh, self.cached_kv_sharding_spec,
@@ -1453,8 +1534,7 @@ class TPUOffloadConnectorWorker:
             return kv_caches, []
         if num_blocks in BLOCK_SIZE_BUCKETS:
             block_ids_arr = jnp.array(block_ids)
-            return stack_kv_cache_cross_layers(kv_caches, block_ids_arr,
-                                               num_blocks)
+            return self._do_stack(kv_caches, block_ids_arr, num_blocks)
 
         # 2. Report the latency of decomposed_block_sizes
         decomposed_block_buckets = self._decompose_into_buckets(block_ids)
@@ -1473,7 +1553,7 @@ class TPUOffloadConnectorWorker:
             _num_blocks = len(decomposed_block_bucket)
             block_slice = decomposed_block_slice_arr[i]
             # Update current_kv_caches with the latest valid handle
-            current_kv_caches, gathered_chunk = stack_kv_cache_cross_layers(
+            current_kv_caches, gathered_chunk = self._do_stack(
                 current_kv_caches, block_slice, len(decomposed_block_bucket))
             gathered_chunks.extend(gathered_chunk)
 
@@ -1492,10 +1572,9 @@ class TPUOffloadConnectorWorker:
         if num_blocks == 0:
             return kv_caches
         if num_blocks in BLOCK_SIZE_BUCKETS:
-            return update_kv_caches_one(kv_caches, kv_cache_slices, dst_blocks,
-                                        self.mesh,
-                                        self.cached_kv_sharding_spec,
-                                        self.indices_sharding)
+            return self._do_update(kv_caches, kv_cache_slices, dst_blocks,
+                                   self.mesh, self.cached_kv_sharding_spec,
+                                   self.indices_sharding)
 
         decomposed_block_buckets = self._decompose_into_buckets(dst_blocks)
         logger.debug(
@@ -1508,7 +1587,7 @@ class TPUOffloadConnectorWorker:
             bucket_size = len(decomposed_block_bucket)
             next_offset = block_offset + bucket_size
             slices_for_bucket = kv_cache_slices[block_offset:next_offset]
-            updated_kv_caches = update_kv_caches_one(
+            updated_kv_caches = self._do_update(
                 updated_kv_caches, slices_for_bucket, decomposed_block_bucket,
                 self.mesh, self.cached_kv_sharding_spec, self.indices_sharding)
             block_offset = next_offset
@@ -1617,7 +1696,7 @@ class TPUOffloadConnectorWorker:
                 self.runner.kv_caches, blocks_to_save)
         else:
             blocks_to_save_arr = jnp.array(blocks_to_save)
-            kv_caches, gathered_kv_caches_tpu = stack_kv_cache_cross_layers(
+            kv_caches, gathered_kv_caches_tpu = self._do_stack(
                 self.runner.kv_caches, blocks_to_save_arr, num_blocks_to_save)
         self.runner.kv_caches = kv_caches
 
@@ -1701,7 +1780,7 @@ class TPUOffloadConnectorWorker:
                 self.runner.kv_caches, all_src_blocks)
         else:
             all_src_blocks_arr = jnp.array(all_src_blocks)
-            kv_caches, gathered_kv_caches_tpu = stack_kv_cache_cross_layers(
+            kv_caches, gathered_kv_caches_tpu = self._do_stack(
                 self.runner.kv_caches, all_src_blocks_arr,
                 total_num_blocks_to_save)
         self.runner.kv_caches = kv_caches
@@ -2116,7 +2195,7 @@ class TPUOffloadConnectorWorker:
                     dst_blocks,
                 )
             else:
-                self.runner.kv_caches = update_kv_caches_one(
+                self.runner.kv_caches = self._do_update(
                     self.runner.kv_caches,
                     raw_chunked_kv_on_tpu,
                     dst_blocks,
@@ -2157,6 +2236,7 @@ class TPUOffloadConnectorWorker:
         """
         Get the KV transfer stats for the connector.
         """
+        self._process_completed_saves()
         # Clear stats for next iteration
         if not self.offload_stats.is_empty():
             return self.offload_stats.clone_and_reset()

--- a/tpu_inference/offload/utils.py
+++ b/tpu_inference/offload/utils.py
@@ -267,3 +267,110 @@ def update_kv_caches(kv_caches: List[jax.Array],
         dest_sharding_spec=dest_sharding_spec,
         replicated_sharding_spec=replicated_sharding_spec)
     return output
+
+
+@functools.partial(
+    jax.jit,
+    static_argnames=['num_blocks'],
+    donate_argnames=('kv_caches', ),
+)
+def pure_jax_stack_kv_cache_cross_layers(
+        kv_caches: List[jax.Array], block_ids: jax.Array,
+        num_blocks: int) -> Tuple[List[jax.Array], List[jax.Array]]:
+    """
+    Gathers KV cache blocks across all layers for offloading, using pure JAX operations.
+    
+    This function extracts the specified blocks from each layer's KV cache,
+    stacks them along the layer dimension, and then splits them back into 
+    individual blocks. It returns the original (but donated/barriered) caches 
+    and a list of the gathered block tensors.
+
+    Args:
+        kv_caches: List of original KV caches for each layer.
+        block_ids: Array of block indices to extract.
+        num_blocks: Total number of blocks to gather (used for static dimensioning).
+
+    Returns:
+        A tuple containing:
+          - The original list of KV caches (passed through an optimization barrier).
+          - A list of extracted block tensors, each shaped (1, num_layers, ...).
+    """
+
+    def _gather_blocks(layer_kv_cache):
+        return layer_kv_cache.at[block_ids].get()
+
+    gathered_kv_layers = jax.tree.map(_gather_blocks, kv_caches)
+    stacked_blocks = jnp.stack(gathered_kv_layers, axis=1)
+
+    split_blocks = jnp.split(stacked_blocks,
+                             indices_or_sections=num_blocks,
+                             axis=0)
+
+    kv_caches = jax.lax.optimization_barrier(kv_caches)
+    return kv_caches, split_blocks
+
+
+@functools.partial(
+    jax.jit,
+    static_argnames=("mesh", "cached_kv_sharding_spec", "indices_sharding"),
+    donate_argnames=("kv_caches", ),
+)
+def pure_jax_update_kv_caches_one(
+    kv_caches: List[jax.Array],
+    stacked_blocks: List[jax.Array],
+    block_indices: List[int],
+    mesh: Mesh,
+    cached_kv_sharding_spec: PartitionSpec | None = None,
+    indices_sharding: PartitionSpec | None = None,
+) -> List[jax.Array]:
+    """
+    Updates the physical KV cache by inserting stacked blocks into specified 
+    indices using pure JAX scatter.
+    
+    This function shards the target block indices onto the provided device mesh, 
+    concatenates and un-stacks the provided source blocks back into per-layer arrays, 
+    and then scatters these slices into the physical KV cache tensors at the 
+    specified indices.
+
+    Args:
+        kv_caches: List of physical KV caches for each layer.
+        stacked_blocks: List of block tensors to insert, typically retrieved from offload storage.
+        block_indices: List of destination block indices in the physical cache.
+        mesh: JAX Mesh object used for sharding operations.
+        cached_kv_sharding_spec: Pre-cached sharding spec (unused in this pure JAX 
+                                 impl, kept for signature compatibility).
+        indices_sharding: Optional NamedSharding or PartitionSpec to place the indices 
+                            array on the device mesh.
+
+    Returns:
+        List of updated KV caches for each layer.
+    """
+    indices_arr = jnp.array(block_indices, dtype=jnp.int32)
+
+    if indices_sharding is None:
+        sharding = jax.sharding.NamedSharding(mesh,
+                                              jax.sharding.PartitionSpec(),
+                                              memory_kind='device')
+    elif isinstance(indices_sharding, jax.sharding.PartitionSpec):
+        sharding = jax.sharding.NamedSharding(mesh,
+                                              indices_sharding,
+                                              memory_kind='device')
+    else:
+        # It's already a NamedSharding (passed by tpu_offload_connector)
+        sharding = indices_sharding
+
+    indices_arr = jax.device_put(indices_arr, sharding)
+    indices_arr = indices_arr[:, None]
+
+    concatenated_blocks = jnp.concatenate(stacked_blocks, axis=0)
+    layer_slices_tuple = jnp.unstack(concatenated_blocks, axis=1)
+    layer_slices_list = list(layer_slices_tuple)
+
+    def _update_layer(cache_layer, slices):
+        dim_nums = jax.lax.ScatterDimensionNumbers(
+            update_window_dims=tuple(range(1, len(slices.shape))),
+            inserted_window_dims=(0, ),
+            scatter_dims_to_operand_dims=(0, ))
+        return jax.lax.scatter(cache_layer, indices_arr, slices, dim_nums)
+
+    return jax.tree.map(_update_layer, kv_caches, layer_slices_list)


### PR DESCRIPTION
# Description

This PR enables KV Cache Offloading support when Attention Data Parallelism (`enable_dp_attention: true`) is enabled.

**Context & Problem:**
Previously, when KV offloading was used alongside Attention DP, the system relied on custom Pallas ops (`stack_kv_cache_cross_layers` and `update_kv_caches_one`) that did not support the `attn_dp` sharding layout. This led to errors during the save/load chunk operations. 

**Error:**
```bash
(EngineCore pid=533) WARNING 06-04 15:37:02 [tpu_offload_connector.py:1433]     - Failed to pre-compile for 1 blocks: shard_map applied to the function '_start_chunked_copy_kernel' was given argument arrays with axis sizes that are not evenly divisible by the corresponding mesh axis sizes:
(EngineCore pid=533) WARNING 06-04 15:37:02 [tpu_offload_connector.py:1433] 
(EngineCore pid=533) WARNING 06-04 15:37:02 [tpu_offload_connector.py:1433] The mesh given has shape (1, 8, 1, 1, 1, 1) with corresponding axis names ('data', 'attn_dp', 'attn_dp_expert', 'expert', 'model', 'dcp').
(EngineCore pid=533) WARNING 06-04 15:37:02 [tpu_offload_connector.py:1433] 
(EngineCore pid=533) WARNING 06-04 15:37:02 [tpu_offload_connector.py:1433] the passed args[4] of shape float8_e4m3fn[1,256,4,640], where args[4] is bound to _start_chunked_copy_kernel's parameter 'src_array: jax.Array', corresponds to in_specs[4] of value P(('data', 'attn_dp', 'attn_dp_expert'), 'dcp'), which maps array axis 0 (of size 1) to mesh axes ('data', 'attn_dp', 'attn_dp_expert') (of total size 8), but 8 does not evenly divide 1
(EngineCore pid=533) WARNING 06-04 15:37:02 [tpu_offload_connector.py:1433] 
(EngineCore pid=533) WARNING 06-04 15:37:02 [tpu_offload_connector.py:1433] Array arguments' axis sizes must be evenly divisible by the mesh axis or axes indicated by the corresponding elements of the argument's in_specs entry. Consider checking that in_specs are correct, and if so consider changing the mesh axis sizes or else padding the input and adapting '_start_chunked_copy_kernel' appropriately.
```

# Solution
- **Pure JAX Fallbacks:** Added pure JAX implementations (`pure_jax_stack_kv_cache_cross_layers` and `pure_jax_update_kv_caches_one`) in `offload/utils.py` using `jax.lax.scatter`.
- **Dynamic Dispatch:** Updated `TPUOffloadConnectorWorker` to conditionally route to these pure JAX implementations via `_do_stack` and `_do_update` when DP attention is enabled.
- **Metrics Fixes:** 
  - Fixed a bug in `KVOffloadConnectorStats.aggregate()` where it returned without accumulating the nested chunk dictionaries, permanently dropping metrics.
  - Fixed `TPUOffloadConnector.get_kv_connector_stats()` to correctly delegate to `self.connector_worker` when executing in the worker role, restoring metrics logging for DeepSeek.
- **DeepSeek V4 Sync:** Reconciled integration conflicts with upstream DeepSeek V4 changes in `kv_cache_manager.py` and `deepseek_v4_attention.py`.

# Tests
- Verified that KV cache offloading executes successfully without sharding crashes when `--additional_config='{"sharding": {"sharding_strategy": {"enable_dp_attention": true}}}'` is passed.
- Verified that `KV Transfer metrics` are now correctly aggregated and printed in the logs for DeepSeek inference runs.

**Tested Configuration Example:**
```bash
--additional_config='{"sharding": {"sharding_strategy": {"enable_dp_attention": true}}}' \
--kv-transfer-config='{"kv_connector": "TPUOffloadConnector", "kv_connector_module_path": "tpu_inference.offload.tpu_offload_connector", "kv_role": "kv_both", "kv_connector_extra_config": {"cpu_bytes_to_use": 107374182400, "lazy_offload": true}}'
```

**Deepseek V3.1 671b - Server command:**
```bash
python3 -m vllm.entrypoints.openai.api_server \
  --host=0.0.0.0 \
  --port=8000 \
  --download-dir=/data \
  --kv-cache-dtype=fp8 \
  --max-model-len=20480 \
  --gpu-memory-utilization=0.98 \
  --tensor-parallel-size=8 \
  --max-num-seqs=128 \
  --max-num-batched-tokens=512 \
  --enable-prefix-caching \
  --enable-expert-parallel \
  --async-scheduling \
  --model=deepseek-ai/DeepSeek-V3.1 \
  --served-model-name=deepseek-ai/DeepSeek-V3.1 \
  --load-format=runai_streamer \
  --additional_config='{"sharding": {"sharding_strategy": {"enable_dp_attention": true}}}' \
  --kv-transfer-config='{"kv_connector": "TPUOffloadConnector", "kv_connector_module_path": "tpu_inference.offload.tpu_offload_connector","kv_role": "kv_both", "kv_connector_extra_config": {"cpu_bytes_to_use": 107374182400, "lazy_offload": false}}' || true
```

**Deepseek V3.1 671b - Benchmark command:**
```bash
vllm bench serve \
  --backend=openai \
  --model=deepseek-ai/DeepSeek-V3.1 \
  --dataset-name=prefix_repetition \
  --host=localhost \
  --port=8000 \
  --seed=123 \
  --num-prompts=32 \
  --max-concurrency=32 \
  --prefix-repetition-prefix-len=19424 \
  --prefix-repetition-suffix-len=32 \
  --prefix-repetition-output-len=1024 \
  --prefix-repetition-num-prefixes=4 \
  --percentile-metrics='ttft,tpot,itl,e2el' \
  --ignore-eos
```

# Results

| Metric | With KV Offloading | Without KV Offloading |
| :--- | :--- | :--- |
| **Output Token Throughput (tok/s)** | 506.75 (+67.4%) | 302.68 |
| **Total Token Throughput (tok/s)** | 10134.95 (+67.4%) | 6053.55 |
| **Mean TTFT (ms)** | 2958.56 (-86.8%) | 22472.25 |
| **Mean TPOT (ms)** | 39.41 (+7.7%) | 36.59 |
| **Mean ITL (ms)** | 39.64 (+8.3%) | 36.59 |
| **Mean E2EL (ms)** | 43269.93 (-27.8%) | 59907.64 |

# Checklist
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have made or will make corresponding changes to any relevant documentation.