### PR TITLE
add gelu_tanh as supported activation type in gmm_v2

### DIFF
--- a/tpu_inference/kernels/megablox/gmm_v2.py
+++ b/tpu_inference/kernels/megablox/gmm_v2.py
@@ -78,6 +78,8 @@ def apply_act_fn(acc: jax.Array, fuse_act: str | None):
             return jax.nn.silu(acc_gate) * acc_up
         case "gelu":
             return jax.nn.gelu(acc_gate) * acc_up
+        case "gelu_tanh":
+            return jax.nn.gelu(acc_gate, approximate=True) * acc_up
         case "swigluoai":
             return swigluoai(acc_gate, acc_up)
         case "silu_and_mul_with_clamp":


### PR DESCRIPTION
# Description

Add gelu_tanh as a type of supported activation in gmm_v2. 

This is needed because [PR 41574](https://github.com/vllm-project/vllm/pull/41574) has updated the vllm implementation of Gemma 4 MOE to use gelu_tanh. Without this change, trying to start a Gemma 4 MOE through the vllm/torchax path would cause a crash with `NotImplementedError: Unsupported activation function: gelu_tanh`


# Tests

Tested model start up with
```
JITTED_MM_MODULE_KEYS="model.vision_tower.encoder" REGISTER_MM_MODULE_CUSTOM_PYTREE_CLASSES="transformers.modeling_outputs.BaseModelOutputWithPast" MODEL_IMPL_TYPE="vllm" \
vllm serve \
    --max-num-batched-tokens=4096 \
    --max-num-seqs=127 \
    --max-model-len=4096 \
    --no-enable-prefix-caching  \
    --model=google/gemma-4-26B-A4B-it \
    --limit-mm-per-prompt '{"image": 8, "video": 0}' \
    --tensor-parallel-size=8
```


# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
