### PR TITLE
[Kimi-K2.6] Add correctness tests for LM only

### DIFF
--- a/.buildkite/models/moonshotai_Kimi-K2_6.yml
+++ b/.buildkite/models/moonshotai_Kimi-K2_6.yml
@@ -54,14 +54,27 @@ steps:
     depends_on: "${TPU_VERSION:-tpu6e}_record_moonshotai_Kimi-K2_6_UnitTest"
     soft_fail: true
     agents:
-      queue: cpu  # TODO: replace with execution environment
+      queue: ${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}
     env:
-      TEST_MODEL: moonshotai/Kimi-K2.6
-      TENSOR_PARALLEL_SIZE: "${TENSOR_PARALLEL_SIZE_SINGLE:-1}"
-      MINIMUM_ACCURACY_THRESHOLD: 0  # TODO : replace 0 with your accuracy threshold
+      NEW_MODEL_DESIGN: "1"
+      USE_V6E8_QUEUE: "False"
+      TPU_VERSION: "tpu7x"
+      SKIP_ACCURACY_TESTS: "False"
+      VLLM_MLA_DISABLE: "0"
+      MOE_REQUANTIZE_BLOCK_SIZE: "512"
+      MOE_REQUANTIZE_WEIGHT_DTYPE: "fp4"
+      DEVICE_COUNT: "8"
+      MODEL_IMPL_TYPE: "vllm"
+      USE_V7X8_QUEUE: "True"
+      MINIMUM_ACCURACY_THRESHOLD: "0.86"
     commands:
       - |
-        buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_moonshotai_Kimi-K2_6_Accuracy" "unverified"
+        if [ "${TPU_VERSION:-tpu6e}" = "tpu6e" ]; then
+          buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_moonshotai_Kimi-K2_6_Accuracy" "not enough HBM"
+        else
+          .buildkite/scripts/run_in_docker.sh \
+            bash /workspace/tpu_inference/tests/e2e/benchmarking/mmlu.sh -m  "gs://tpu-commons-ci/moonshootai/kimi/2.6" -n 14042 -l 4
+        fi
   - label: "${TPU_VERSION:-tpu6e} Record accuracy result for moonshotai/Kimi-K2_6"
     key: "${TPU_VERSION:-tpu6e}_record_moonshotai_Kimi-K2_6_Accuracy"
     depends_on: "${TPU_VERSION:-tpu6e}_moonshotai_Kimi-K2_6_Accuracy"

--- a/tests/e2e/benchmarking/mmlu.sh
+++ b/tests/e2e/benchmarking/mmlu.sh
@@ -263,8 +263,8 @@ for model_name in $model_list; do
         elif [ "$TPU_VERSION" == "tpu7x" ]; then
             # Set the default value to 2 for tpu v7x for most models
             current_device_count=2
-            # If using large model (e.g. DeepSeek, then set the count to 8)
-            if [[ "${model_name,,}" == *"deepseek"* ]]; then
+            # If using large model (e.g. DeepSeek or Kimi, then set the count to 8)
+            if [[ "${model_name,,}" == *"deepseek"* ]] || [[ "${model_name,,}" == *"kimi"* ]]; then
                 current_device_count=8
             fi
         else
@@ -303,7 +303,7 @@ for model_name in $model_list; do
             export TIMEOUT_SECONDS=3600 # Kimi needs a longer timeout
             max_batched_tokens=1024
             served_name=moonshotai/Kimi-K2.6
-            TARGET_ACCURACY="0.84"
+            TARGET_ACCURACY="0.87"
             current_serve_args+=(--kv-cache-dtype=fp8 --gpu-memory-utilization 0.977 --limit-mm-per-prompt='{"image": 0, "video": 0, "vision_chunk": 0}' )
             current_serve_args+=(--served-model-name "${served_name}" --load-format=runai_streamer --enable-expert-parallel --trust-remote-code --kv-cache-dtype=fp8 --additional-config '{"sharding": {"sharding_strategy": {"enable_dp_attention": true, "tensor_parallelism": '"${current_device_count}"'}}}')
         fi

--- a/tests/e2e/benchmarking/mmlu.sh
+++ b/tests/e2e/benchmarking/mmlu.sh
@@ -295,10 +295,17 @@ for model_name in $model_list; do
                 current_serve_args+=(--enable-expert-parallel)
                 current_serve_args+=(--additional_config '{"sharding": {"sharding_strategy": {"enable_dp_attention": true}}}')
             elif [ "$MODEL_IMPL_TYPE" == "flax_nnx" ]; then
-                current_serve_args+=(--additional_config '{"sharding": {"sharding_strategy": 
+                current_serve_args+=(--additional_config '{"sharding": {"sharding_strategy":
                     {"enable_dp_attention": true, "expert_parallelism": '"${current_device_count}"', "tensor_parallelism": 1}},
                         "replicate_attn_weights": "True", "sparse_matmul": "True"}')
             fi
+        elif [[ "${model_name,,}" == *"kimi"* ]]; then
+            export TIMEOUT_SECONDS=3600 # Kimi needs a longer timeout
+            max_batched_tokens=1024
+            served_name=moonshotai/Kimi-K2.6
+            TARGET_ACCURACY="0.84"
+            current_serve_args+=(--kv-cache-dtype=fp8 --gpu-memory-utilization 0.977 --limit-mm-per-prompt='{"image": 0, "video": 0, "vision_chunk": 0}' )
+            current_serve_args+=(--served-model-name "${served_name}" --load-format=runai_streamer --enable-expert-parallel --trust-remote-code --kv-cache-dtype=fp8 --additional-config '{"sharding": {"sharding_strategy": {"enable_dp_attention": true, "tensor_parallelism": '"${current_device_count}"'}}}')
         fi
     fi
 


### PR DESCRIPTION
# Description

Adds a correctness test for Kimi-K2.6 text-only

# Tests

Tested here: https://buildkite.com/tpu-commons/tpu-inference-dev/builds/548#019eaad4-97c5-49d0-bdeb-deaa9bacd7e2

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
