### PR TITLE
Merge shared expert all-reduce with FusedMoE all-reduce

### DIFF
--- a/tests/layers/vllm/test_fused_moe.py
+++ b/tests/layers/vllm/test_fused_moe.py
@@ -154,6 +154,7 @@ class TestMaybeReduceSharedExpertOutput:
         with patch.object(fm.VllmMoERunner, "_fused_output_is_reduced",
                           new_callable=PropertyMock, return_value=True), \
              patch.object(fm, "_get_mesh", return_value=mesh), \
+             patch.object(fm, "is_attn_dp", return_value=False), \
              patch.object(fm, "_all_reduce_over_tp",
                           return_value=reduced) as reduce:
             out = runner._maybe_reduce_shared_expert_output(shared)
@@ -174,9 +175,8 @@ class TestMaybeReduceSharedExpertOutput:
              patch.object(fm, "is_attn_dp", return_value=True), \
              patch.object(fm, "_all_reduce_over_tp",
                           return_value=reduced) as reduce:
-            out = runner._maybe_reduce_shared_expert_output(shared)
-        reduce.assert_called_once_with(shared, mesh)
-        assert out is reduced
+            runner._maybe_reduce_shared_expert_output(shared)
+        reduce.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/layers/vllm/test_fused_moe.py
+++ b/tests/layers/vllm/test_fused_moe.py
@@ -11,52 +11,15 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Unit tests for ``tpu_inference.layers.vllm.custom_ops.fused_moe``.
-
-The module under test resolves *where* the tensor-parallel all-reduce for an
-MoE layer happens: either the GMM kernel reduces its own output (and the
-shared-expert output is reduced separately, the "early" path), or the kernel
-skips its reduce and the summed shared + fused output is reduced by a single
-collective (the "late" path). Most of the logic is the branching that picks
-between those two paths, so the bulk of the tests pin that decision tree.
-
-The ``_all_reduce_over_tp`` helper builds a real ``shard_map`` and is tested
-against a real JAX mesh, with a stub ``ShardingAxisName`` so its axis names
-line up with the mesh regardless of the active env config.
-"""
 
 from types import SimpleNamespace
 from unittest.mock import PropertyMock, patch
 
-import jax
-import numpy as np
 import pytest
 import torch
-import torchax
-from jax.sharding import Mesh
-from torchax.interop import torch_view
-from torchax.ops.mappings import j2t, t2j
 
 from tpu_inference.layers.common.moe import MoEBackend
 from tpu_inference.layers.vllm.custom_ops import fused_moe as fm
-
-# A stub for ``_all_reduce_over_tp`` whose axes ("data" for the sharded leading
-# dim, "model" for the psum) line up with a 2D (data, model) mesh -- the
-# all-reduce builds a real shard_map, so every referenced axis must actually
-# exist on the mesh.
-STUB_AXES_2D = SimpleNamespace(ATTN_DATA="data", MLP_TENSOR="model")
-
-
-def _make_mesh(**axis_sizes: int) -> Mesh:
-    """Build a JAX mesh with the given named axes and sizes.
-
-    The product of the sizes must not exceed the available device count.
-    """
-    names = tuple(axis_sizes.keys())
-    shape = tuple(axis_sizes.values())
-    n = int(np.prod(shape))
-    devices = np.array(jax.devices())[:n].reshape(shape)
-    return Mesh(devices, names)
 
 
 def _make_runner(*,
@@ -76,38 +39,6 @@ def _make_runner(*,
     return runner
 
 
-# ---------------------------------------------------------------------------
-# _all_reduce_over_tp
-# ---------------------------------------------------------------------------
-class TestAllReduceOverTp:
-
-    def test_noop_when_model_axis_is_one(self):
-        # psum over a size-1 axis leaves the values untouched.
-        mesh = _make_mesh(data=1, model=1)
-        original = torch.arange(6, dtype=torch.float32).reshape(2, 3)
-        with patch.object(fm, "ShardingAxisName", STUB_AXES_2D), \
-             torchax.default_env(), mesh:
-            t = torch_view(t2j(original, use_dlpack=False))
-            out = j2t(fm._all_reduce_over_tp(t, mesh).to(torch.float32))
-        torch.testing.assert_close(out, original)
-
-    @pytest.mark.skipif(jax.device_count() < 2,
-                        reason="needs >=2 devices for a size-2 model axis")
-    def test_sums_partials_across_model_shards(self):
-        # The feature dim is replicated across the model axis, so each of the
-        # two shards holds the same values; psum collapses them -> values * 2.
-        mesh = _make_mesh(data=1, model=2)
-        ones = torch.ones(1, 4, dtype=torch.float32)
-        with patch.object(fm, "ShardingAxisName", STUB_AXES_2D), \
-             torchax.default_env(), mesh:
-            t = torch_view(t2j(ones, use_dlpack=False))
-            out = j2t(fm._all_reduce_over_tp(t, mesh).to(torch.float32))
-        torch.testing.assert_close(out, ones * 2)
-
-
-# ---------------------------------------------------------------------------
-# VllmMoERunner._fused_output_is_reduced  (the core decision tree)
-# ---------------------------------------------------------------------------
 class TestFusedOutputIsReduced:
 
     def test_true_when_no_shared_expert(self):
@@ -120,6 +51,22 @@ class TestFusedOutputIsReduced:
         runner = _make_runner(shared_experts=object())
         with patch.object(fm, "_get_mesh", return_value=object()), \
              patch.object(fm, "is_attn_dp", return_value=True):
+            assert runner._fused_output_is_reduced is True
+
+    @pytest.mark.parametrize("backend", [MoEBackend.GMM_EP, MoEBackend.GMM_TP])
+    def test_attention_dp_overrides_gmm_defer(self, backend):
+        # attention-DP takes precedence over the GMM defer: even in the one
+        # scenario that would otherwise return False (a GMM backend whose
+        # reduction axes match the shared expert's), DP resolves the reduction
+        # separately so the kernel must still reduce its own output. Guards the
+        # order of the checks -- the DP short-circuit must precede the GMM ones.
+        runner = _make_runner(shared_experts=object())
+        with patch.object(fm, "_get_mesh", return_value=object()), \
+             patch.object(fm, "is_attn_dp", return_value=True), \
+             patch.object(fm, "select_moe_backend_from_fused_moe_config",
+                          return_value=backend), \
+             patch.object(fm, "_gmm_and_shared_reduce_over_same_axes",
+                          return_value=True):
             assert runner._fused_output_is_reduced is True
 
     def test_true_when_no_mesh(self):
@@ -139,14 +86,29 @@ class TestFusedOutputIsReduced:
             assert runner._fused_output_is_reduced is True
 
     @pytest.mark.parametrize("backend", [MoEBackend.GMM_EP, MoEBackend.GMM_TP])
+    def test_true_when_gmm_reduces_different_axes(self, backend):
+        runner = _make_runner(shared_experts=object())
+        with patch.object(fm, "is_attn_dp", return_value=False), \
+             patch.object(fm, "_get_mesh", return_value=object()), \
+             patch.object(fm, "select_moe_backend_from_fused_moe_config",
+                          return_value=backend), \
+             patch.object(fm, "_gmm_and_shared_reduce_over_same_axes",
+                          return_value=False):
+            # The GMM's reduction can't be folded into the single MLP_TENSOR
+            # all-reduce, so the kernel must reduce itself.
+            assert runner._fused_output_is_reduced is True
+
+    @pytest.mark.parametrize("backend", [MoEBackend.GMM_EP, MoEBackend.GMM_TP])
     def test_false_when_all_conditions_met(self, backend):
         runner = _make_runner(shared_experts=object())
         with patch.object(fm, "is_attn_dp", return_value=False), \
              patch.object(fm, "_get_mesh", return_value=object()), \
              patch.object(fm, "select_moe_backend_from_fused_moe_config",
-                          return_value=backend):
-            # Shared expert present, no DP, GMM backend -> the kernel skips its
-            # reduce and the late single collective handles it.
+                          return_value=backend), \
+             patch.object(fm, "_gmm_and_shared_reduce_over_same_axes",
+                          return_value=True):
+            # Shared expert present, no DP, GMM backend, matching axes -> the
+            # kernel skips its reduce and the late single collective handles it.
             assert runner._fused_output_is_reduced is False
 
 
@@ -184,17 +146,6 @@ class TestMaybeReduceSharedExpertOutput:
         reduce.assert_not_called()
         assert out is shared
 
-    def test_passthrough_when_no_mesh(self):
-        runner = _make_runner()
-        shared = torch.ones(2, 3)
-        with patch.object(fm.VllmMoERunner, "_fused_output_is_reduced",
-                          new_callable=PropertyMock, return_value=True), \
-             patch.object(fm, "_get_mesh", return_value=None), \
-             patch.object(fm, "_all_reduce_over_tp") as reduce:
-            out = runner._maybe_reduce_shared_expert_output(shared)
-        reduce.assert_not_called()
-        assert out is shared
-
     def test_reduces_shared_output_on_early_path(self):
         runner = _make_runner()
         shared = torch.ones(2, 3)
@@ -203,6 +154,24 @@ class TestMaybeReduceSharedExpertOutput:
         with patch.object(fm.VllmMoERunner, "_fused_output_is_reduced",
                           new_callable=PropertyMock, return_value=True), \
              patch.object(fm, "_get_mesh", return_value=mesh), \
+             patch.object(fm, "_all_reduce_over_tp",
+                          return_value=reduced) as reduce:
+            out = runner._maybe_reduce_shared_expert_output(shared)
+        reduce.assert_called_once_with(shared, mesh)
+        assert out is reduced
+
+    def test_reduces_shared_output_under_attention_dp(self):
+        # Under attention DP the fused kernel reduces its own output, so the
+        # shared-expert output is reduced separately on the early path. Unlike
+        # the test above this drives the real ``_fused_output_is_reduced``
+        # property (via ``is_attn_dp``) instead of mocking it, exercising the
+        # attn-DP -> early-reduce routing end to end.
+        runner = _make_runner(shared_experts=object())
+        shared = torch.ones(2, 3)
+        reduced = torch.full((2, 3), 7.0)
+        mesh = object()
+        with patch.object(fm, "_get_mesh", return_value=mesh), \
+             patch.object(fm, "is_attn_dp", return_value=True), \
              patch.object(fm, "_all_reduce_over_tp",
                           return_value=reduced) as reduce:
             out = runner._maybe_reduce_shared_expert_output(shared)
@@ -248,18 +217,6 @@ class TestMaybeReduceFinalOutput:
              patch.object(fm, "is_attn_dp", return_value=False), \
              patch.object(fm.VllmMoERunner, "_fused_output_is_reduced",
                           new_callable=PropertyMock, return_value=True), \
-             patch.object(fm, "_all_reduce_over_tp") as reduce:
-            out = runner._maybe_reduce_final_output(states, trunc_size=2)
-        reduce.assert_not_called()
-        torch.testing.assert_close(out, states[..., :2])
-
-    def test_only_truncates_when_no_mesh(self):
-        runner = _make_runner()
-        states = torch.arange(8, dtype=torch.float32).reshape(2, 4)
-        with patch.object(fm, "is_attn_dp", return_value=False), \
-             patch.object(fm.VllmMoERunner, "_fused_output_is_reduced",
-                          new_callable=PropertyMock, return_value=False), \
-             patch.object(fm, "_get_mesh", return_value=None), \
              patch.object(fm, "_all_reduce_over_tp") as reduce:
             out = runner._maybe_reduce_final_output(states, trunc_size=2)
         reduce.assert_not_called()

--- a/tests/layers/vllm/test_fused_moe.py
+++ b/tests/layers/vllm/test_fused_moe.py
@@ -20,10 +20,9 @@ skips its reduce and the summed shared + fused output is reduced by a single
 collective (the "late" path). Most of the logic is the branching that picks
 between those two paths, so the bulk of the tests pin that decision tree.
 
-The pure mesh/axis helpers are tested against real JAX meshes. Helpers that
-read ``ShardingAxisName`` (whose values depend on env config -- 2D vs base)
-are tested against a stub axis namespace so the expectations are independent
-of the environment the tests happen to run in.
+The ``_all_reduce_over_tp`` helper builds a real ``shard_map`` and is tested
+against a real JAX mesh, with a stub ``ShardingAxisName`` so its axis names
+line up with the mesh regardless of the active env config.
 """
 
 from types import SimpleNamespace
@@ -41,23 +40,10 @@ from torchax.ops.mappings import j2t, t2j
 from tpu_inference.layers.common.moe import MoEBackend
 from tpu_inference.layers.vllm.custom_ops import fused_moe as fm
 
-# A stub standing in for ``ShardingAxisName`` so axis-name-dependent helpers can
-# be tested with fixed, known axis names regardless of the active env config.
-# ``MLP_TENSOR`` and ``EXPERT`` deliberately differ here so the "same reduction
-# axes" check can be exercised in both directions (the real configs happen to
-# define them identically, which would only ever exercise the True branch).
-STUB_AXES = SimpleNamespace(
-    ATTN_DATA=("data", "attn_dp"),
-    MLP_DATA="data",
-    MLP_TENSOR="model",
-    EXPERT="expert",
-    MODEL="model",
-)
-
-# A simpler stub for ``_all_reduce_over_model`` whose axes ("data" for the
-# sharded leading dim, "model" for the psum) line up with a 2D (data, model)
-# mesh -- the all-reduce builds a real shard_map, so every referenced axis must
-# actually exist on the mesh.
+# A stub for ``_all_reduce_over_tp`` whose axes ("data" for the sharded leading
+# dim, "model" for the psum) line up with a 2D (data, model) mesh -- the
+# all-reduce builds a real shard_map, so every referenced axis must actually
+# exist on the mesh.
 STUB_AXES_2D = SimpleNamespace(ATTN_DATA="data", MLP_TENSOR="model")
 
 
@@ -91,39 +77,9 @@ def _make_runner(*,
 
 
 # ---------------------------------------------------------------------------
-# _gmm_and_shared_reduce_over_same_axes
+# _all_reduce_over_tp
 # ---------------------------------------------------------------------------
-class TestGmmAndSharedReduceOverSameAxes:
-
-    def test_gmm_tp_always_matches_shared_axis(self):
-        # GMM_TP reduces over MLP_TENSOR -- the same axis the shared expert
-        # reduces over -- so it always collapses the same axes.
-        mesh = _make_mesh(model=2, expert=2)
-        with patch.object(fm, "ShardingAxisName", STUB_AXES):
-            assert fm._gmm_and_shared_reduce_over_same_axes(
-                mesh, MoEBackend.GMM_TP) is True
-
-    def test_gmm_ep_true_when_effective_axes_coincide(self):
-        # EXPERT ("expert") is size 1 and MLP_TENSOR ("model") is size 1 -> both
-        # reduce to the empty set -> they match.
-        mesh = _make_mesh(model=1, expert=1)
-        with patch.object(fm, "ShardingAxisName", STUB_AXES):
-            assert fm._gmm_and_shared_reduce_over_same_axes(
-                mesh, MoEBackend.GMM_EP) is True
-
-    def test_gmm_ep_false_when_axes_differ(self):
-        # GMM_EP reduces over "expert" while the shared expert reduces over
-        # "model"; with both sized > 1 the sets differ.
-        mesh = _make_mesh(model=2, expert=2)
-        with patch.object(fm, "ShardingAxisName", STUB_AXES):
-            assert fm._gmm_and_shared_reduce_over_same_axes(
-                mesh, MoEBackend.GMM_EP) is False
-
-
-# ---------------------------------------------------------------------------
-# _all_reduce_over_model
-# ---------------------------------------------------------------------------
-class TestAllReduceOverModel:
+class TestAllReduceOverTp:
 
     def test_noop_when_model_axis_is_one(self):
         # psum over a size-1 axis leaves the values untouched.
@@ -157,54 +113,40 @@ class TestFusedOutputIsReduced:
     def test_true_when_no_shared_expert(self):
         runner = _make_runner(shared_experts=None)
         # Nothing to fuse with -> the kernel reduces its own output.
-        assert runner._fused_output_is_reduced is True
+        with patch.object(fm, "_get_mesh", return_value=object()):
+            assert runner._fused_output_is_reduced is True
 
     def test_true_under_attention_dp(self):
         runner = _make_runner(shared_experts=object())
-        with patch.object(fm, "_is_attn_dp", return_value=True):
+        with patch.object(fm, "_get_mesh", return_value=object()), \
+             patch.object(fm, "is_attn_dp", return_value=True):
             assert runner._fused_output_is_reduced is True
 
     def test_true_when_no_mesh(self):
         runner = _make_runner(shared_experts=object())
-        with patch.object(fm, "_is_attn_dp", return_value=False), \
-             patch.object(fm, "_get_mesh", return_value=None):
+        with patch.object(fm, "_get_mesh", return_value=None):
             assert runner._fused_output_is_reduced is True
 
     @pytest.mark.parametrize("backend",
                              [MoEBackend.FUSED_MOE, MoEBackend.DENSE_MAT])
     def test_true_for_non_gmm_backends(self, backend):
-        # Only GMM_EP / GMM_TP honor defer_all_reduce; others always reduce.
+        # Only GMM_EP / GMM_TP defer the all-reduce; others always reduce.
         runner = _make_runner(shared_experts=object())
-        with patch.object(fm, "_is_attn_dp", return_value=False), \
+        with patch.object(fm, "is_attn_dp", return_value=False), \
              patch.object(fm, "_get_mesh", return_value=object()), \
              patch.object(fm, "select_moe_backend_from_fused_moe_config",
                           return_value=backend):
             assert runner._fused_output_is_reduced is True
 
     @pytest.mark.parametrize("backend", [MoEBackend.GMM_EP, MoEBackend.GMM_TP])
-    def test_true_when_gmm_reduces_different_axes(self, backend):
-        runner = _make_runner(shared_experts=object())
-        with patch.object(fm, "_is_attn_dp", return_value=False), \
-             patch.object(fm, "_get_mesh", return_value=object()), \
-             patch.object(fm, "select_moe_backend_from_fused_moe_config",
-                          return_value=backend), \
-             patch.object(fm, "_gmm_and_shared_reduce_over_same_axes",
-                          return_value=False):
-            # The GMM's reduction can't be folded into the single MODEL
-            # all-reduce, so the kernel must reduce itself.
-            assert runner._fused_output_is_reduced is True
-
-    @pytest.mark.parametrize("backend", [MoEBackend.GMM_EP, MoEBackend.GMM_TP])
     def test_false_when_all_conditions_met(self, backend):
         runner = _make_runner(shared_experts=object())
-        with patch.object(fm, "_is_attn_dp", return_value=False), \
+        with patch.object(fm, "is_attn_dp", return_value=False), \
              patch.object(fm, "_get_mesh", return_value=object()), \
              patch.object(fm, "select_moe_backend_from_fused_moe_config",
-                          return_value=backend), \
-             patch.object(fm, "_gmm_and_shared_reduce_over_same_axes",
-                          return_value=True):
-            # Shared expert present, no DP, GMM backend, matching axes -> the
-            # kernel skips its reduce and the late single collective handles it.
+                          return_value=backend):
+            # Shared expert present, no DP, GMM backend -> the kernel skips its
+            # reduce and the late single collective handles it.
             assert runner._fused_output_is_reduced is False
 
 
@@ -215,7 +157,7 @@ class TestMaybeReduceSharedExpertOutput:
 
     def test_passthrough_when_shared_output_none(self):
         runner = _make_runner()
-        with patch.object(fm, "_all_reduce_over_model") as reduce:
+        with patch.object(fm, "_all_reduce_over_tp") as reduce:
             assert runner._maybe_reduce_shared_expert_output(None) is None
         reduce.assert_not_called()
 
@@ -225,7 +167,7 @@ class TestMaybeReduceSharedExpertOutput:
         shared = torch.ones(2, 3)
         with patch.object(fm.VllmMoERunner, "_fused_output_is_reduced",
                           new_callable=PropertyMock, return_value=True), \
-             patch.object(fm, "_all_reduce_over_model") as reduce:
+             patch.object(fm, "_all_reduce_over_tp") as reduce:
             out = runner._maybe_reduce_shared_expert_output(shared)
         reduce.assert_not_called()
         assert out is shared
@@ -237,7 +179,7 @@ class TestMaybeReduceSharedExpertOutput:
         shared = torch.ones(2, 3)
         with patch.object(fm.VllmMoERunner, "_fused_output_is_reduced",
                           new_callable=PropertyMock, return_value=False), \
-             patch.object(fm, "_all_reduce_over_model") as reduce:
+             patch.object(fm, "_all_reduce_over_tp") as reduce:
             out = runner._maybe_reduce_shared_expert_output(shared)
         reduce.assert_not_called()
         assert out is shared
@@ -248,7 +190,7 @@ class TestMaybeReduceSharedExpertOutput:
         with patch.object(fm.VllmMoERunner, "_fused_output_is_reduced",
                           new_callable=PropertyMock, return_value=True), \
              patch.object(fm, "_get_mesh", return_value=None), \
-             patch.object(fm, "_all_reduce_over_model") as reduce:
+             patch.object(fm, "_all_reduce_over_tp") as reduce:
             out = runner._maybe_reduce_shared_expert_output(shared)
         reduce.assert_not_called()
         assert out is shared
@@ -261,7 +203,7 @@ class TestMaybeReduceSharedExpertOutput:
         with patch.object(fm.VllmMoERunner, "_fused_output_is_reduced",
                           new_callable=PropertyMock, return_value=True), \
              patch.object(fm, "_get_mesh", return_value=mesh), \
-             patch.object(fm, "_all_reduce_over_model",
+             patch.object(fm, "_all_reduce_over_tp",
                           return_value=reduced) as reduce:
             out = runner._maybe_reduce_shared_expert_output(shared)
         reduce.assert_called_once_with(shared, mesh)
@@ -278,8 +220,9 @@ class TestMaybeReduceFinalOutput:
         # model; here only the padding is stripped.
         runner = _make_runner()
         states = torch.arange(8, dtype=torch.float32).reshape(2, 4)
-        with patch.object(fm, "_is_attn_dp", return_value=True), \
-             patch.object(fm, "_all_reduce_over_model") as reduce:
+        with patch.object(fm, "_get_mesh", return_value=object()), \
+             patch.object(fm, "is_attn_dp", return_value=True), \
+             patch.object(fm, "_all_reduce_over_tp") as reduce:
             out = runner._maybe_reduce_final_output(states, trunc_size=3)
         reduce.assert_not_called()
         torch.testing.assert_close(out, states[..., :3])
@@ -287,10 +230,11 @@ class TestMaybeReduceFinalOutput:
     def test_sequence_parallel_only_truncates(self):
         runner = _make_runner(is_sequence_parallel=True)
         states = torch.arange(8, dtype=torch.float32).reshape(2, 4)
-        with patch.object(fm, "_is_attn_dp", return_value=False), \
+        with patch.object(fm, "_get_mesh", return_value=object()), \
+             patch.object(fm, "is_attn_dp", return_value=False), \
              patch.object(fm.VllmMoERunner, "_fused_output_is_reduced",
                           new_callable=PropertyMock, return_value=False), \
-             patch.object(fm, "_all_reduce_over_model") as reduce:
+             patch.object(fm, "_all_reduce_over_tp") as reduce:
             out = runner._maybe_reduce_final_output(states, trunc_size=2)
         reduce.assert_not_called()
         torch.testing.assert_close(out, states[..., :2])
@@ -300,10 +244,11 @@ class TestMaybeReduceFinalOutput:
         # so no late collective is needed.
         runner = _make_runner()
         states = torch.arange(8, dtype=torch.float32).reshape(2, 4)
-        with patch.object(fm, "_is_attn_dp", return_value=False), \
+        with patch.object(fm, "_get_mesh", return_value=object()), \
+             patch.object(fm, "is_attn_dp", return_value=False), \
              patch.object(fm.VllmMoERunner, "_fused_output_is_reduced",
                           new_callable=PropertyMock, return_value=True), \
-             patch.object(fm, "_all_reduce_over_model") as reduce:
+             patch.object(fm, "_all_reduce_over_tp") as reduce:
             out = runner._maybe_reduce_final_output(states, trunc_size=2)
         reduce.assert_not_called()
         torch.testing.assert_close(out, states[..., :2])
@@ -311,11 +256,11 @@ class TestMaybeReduceFinalOutput:
     def test_only_truncates_when_no_mesh(self):
         runner = _make_runner()
         states = torch.arange(8, dtype=torch.float32).reshape(2, 4)
-        with patch.object(fm, "_is_attn_dp", return_value=False), \
+        with patch.object(fm, "is_attn_dp", return_value=False), \
              patch.object(fm.VllmMoERunner, "_fused_output_is_reduced",
                           new_callable=PropertyMock, return_value=False), \
              patch.object(fm, "_get_mesh", return_value=None), \
-             patch.object(fm, "_all_reduce_over_model") as reduce:
+             patch.object(fm, "_all_reduce_over_tp") as reduce:
             out = runner._maybe_reduce_final_output(states, trunc_size=2)
         reduce.assert_not_called()
         torch.testing.assert_close(out, states[..., :2])
@@ -325,11 +270,11 @@ class TestMaybeReduceFinalOutput:
         states = torch.arange(8, dtype=torch.float32).reshape(2, 4)
         reduced = torch.arange(100, 108, dtype=torch.float32).reshape(2, 4)
         mesh = object()
-        with patch.object(fm, "_is_attn_dp", return_value=False), \
+        with patch.object(fm, "_get_mesh", return_value=mesh), \
+             patch.object(fm, "is_attn_dp", return_value=False), \
              patch.object(fm.VllmMoERunner, "_fused_output_is_reduced",
                           new_callable=PropertyMock, return_value=False), \
-             patch.object(fm, "_get_mesh", return_value=mesh), \
-             patch.object(fm, "_all_reduce_over_model",
+             patch.object(fm, "_all_reduce_over_tp",
                           return_value=reduced) as reduce:
             out = runner._maybe_reduce_final_output(states, trunc_size=3)
         reduce.assert_called_once_with(states, mesh)

--- a/tests/layers/vllm/test_fused_moe.py
+++ b/tests/layers/vllm/test_fused_moe.py
@@ -1,0 +1,337 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for ``tpu_inference.layers.vllm.custom_ops.fused_moe``.
+
+The module under test resolves *where* the tensor-parallel all-reduce for an
+MoE layer happens: either the GMM kernel reduces its own output (and the
+shared-expert output is reduced separately, the "early" path), or the kernel
+skips its reduce and the summed shared + fused output is reduced by a single
+collective (the "late" path). Most of the logic is the branching that picks
+between those two paths, so the bulk of the tests pin that decision tree.
+
+The pure mesh/axis helpers are tested against real JAX meshes. Helpers that
+read ``ShardingAxisName`` (whose values depend on env config -- 2D vs base)
+are tested against a stub axis namespace so the expectations are independent
+of the environment the tests happen to run in.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import PropertyMock, patch
+
+import jax
+import numpy as np
+import pytest
+import torch
+import torchax
+from jax.sharding import Mesh
+from torchax.interop import torch_view
+from torchax.ops.mappings import j2t, t2j
+
+from tpu_inference.layers.common.moe import MoEBackend
+from tpu_inference.layers.vllm.custom_ops import fused_moe as fm
+
+# A stub standing in for ``ShardingAxisName`` so axis-name-dependent helpers can
+# be tested with fixed, known axis names regardless of the active env config.
+# ``MLP_TENSOR`` and ``EXPERT`` deliberately differ here so the "same reduction
+# axes" check can be exercised in both directions (the real configs happen to
+# define them identically, which would only ever exercise the True branch).
+STUB_AXES = SimpleNamespace(
+    ATTN_DATA=("data", "attn_dp"),
+    MLP_DATA="data",
+    MLP_TENSOR="model",
+    EXPERT="expert",
+    MODEL="model",
+)
+
+# A simpler stub for ``_all_reduce_over_model`` whose axes ("data" for the
+# sharded leading dim, "model" for the psum) line up with a 2D (data, model)
+# mesh -- the all-reduce builds a real shard_map, so every referenced axis must
+# actually exist on the mesh.
+STUB_AXES_2D = SimpleNamespace(ATTN_DATA="data", MLP_TENSOR="model")
+
+
+def _make_mesh(**axis_sizes: int) -> Mesh:
+    """Build a JAX mesh with the given named axes and sizes.
+
+    The product of the sizes must not exceed the available device count.
+    """
+    names = tuple(axis_sizes.keys())
+    shape = tuple(axis_sizes.values())
+    n = int(np.prod(shape))
+    devices = np.array(jax.devices())[:n].reshape(shape)
+    return Mesh(devices, names)
+
+
+def _make_runner(*,
+                 shared_experts=None,
+                 is_sequence_parallel=False,
+                 moe_config=None) -> fm.VllmMoERunner:
+    """A ``VllmMoERunner`` with only the attributes the tested methods touch.
+
+    ``__init__`` pulls in a full vLLM MoE config, so the runner is built via
+    ``__new__`` and the handful of attributes used by the reduction logic are
+    set directly (mirroring ``test_gdn_attention_op.py``).
+    """
+    runner = fm.VllmMoERunner.__new__(fm.VllmMoERunner)
+    runner._shared_experts = shared_experts
+    runner.moe_config = moe_config or SimpleNamespace(
+        is_sequence_parallel=is_sequence_parallel)
+    return runner
+
+
+# ---------------------------------------------------------------------------
+# _gmm_and_shared_reduce_over_same_axes
+# ---------------------------------------------------------------------------
+class TestGmmAndSharedReduceOverSameAxes:
+
+    def test_gmm_tp_always_matches_shared_axis(self):
+        # GMM_TP reduces over MLP_TENSOR -- the same axis the shared expert
+        # reduces over -- so it always collapses the same axes.
+        mesh = _make_mesh(model=2, expert=2)
+        with patch.object(fm, "ShardingAxisName", STUB_AXES):
+            assert fm._gmm_and_shared_reduce_over_same_axes(
+                mesh, MoEBackend.GMM_TP) is True
+
+    def test_gmm_ep_true_when_effective_axes_coincide(self):
+        # EXPERT ("expert") is size 1 and MLP_TENSOR ("model") is size 1 -> both
+        # reduce to the empty set -> they match.
+        mesh = _make_mesh(model=1, expert=1)
+        with patch.object(fm, "ShardingAxisName", STUB_AXES):
+            assert fm._gmm_and_shared_reduce_over_same_axes(
+                mesh, MoEBackend.GMM_EP) is True
+
+    def test_gmm_ep_false_when_axes_differ(self):
+        # GMM_EP reduces over "expert" while the shared expert reduces over
+        # "model"; with both sized > 1 the sets differ.
+        mesh = _make_mesh(model=2, expert=2)
+        with patch.object(fm, "ShardingAxisName", STUB_AXES):
+            assert fm._gmm_and_shared_reduce_over_same_axes(
+                mesh, MoEBackend.GMM_EP) is False
+
+
+# ---------------------------------------------------------------------------
+# _all_reduce_over_model
+# ---------------------------------------------------------------------------
+class TestAllReduceOverModel:
+
+    def test_noop_when_model_axis_is_one(self):
+        # psum over a size-1 axis leaves the values untouched.
+        mesh = _make_mesh(data=1, model=1)
+        original = torch.arange(6, dtype=torch.float32).reshape(2, 3)
+        with patch.object(fm, "ShardingAxisName", STUB_AXES_2D), \
+             torchax.default_env(), mesh:
+            t = torch_view(t2j(original, use_dlpack=False))
+            out = j2t(fm._all_reduce_over_tp(t, mesh).to(torch.float32))
+        torch.testing.assert_close(out, original)
+
+    @pytest.mark.skipif(jax.device_count() < 2,
+                        reason="needs >=2 devices for a size-2 model axis")
+    def test_sums_partials_across_model_shards(self):
+        # The feature dim is replicated across the model axis, so each of the
+        # two shards holds the same values; psum collapses them -> values * 2.
+        mesh = _make_mesh(data=1, model=2)
+        ones = torch.ones(1, 4, dtype=torch.float32)
+        with patch.object(fm, "ShardingAxisName", STUB_AXES_2D), \
+             torchax.default_env(), mesh:
+            t = torch_view(t2j(ones, use_dlpack=False))
+            out = j2t(fm._all_reduce_over_tp(t, mesh).to(torch.float32))
+        torch.testing.assert_close(out, ones * 2)
+
+
+# ---------------------------------------------------------------------------
+# VllmMoERunner._fused_output_is_reduced  (the core decision tree)
+# ---------------------------------------------------------------------------
+class TestFusedOutputIsReduced:
+
+    def test_true_when_no_shared_expert(self):
+        runner = _make_runner(shared_experts=None)
+        # Nothing to fuse with -> the kernel reduces its own output.
+        assert runner._fused_output_is_reduced is True
+
+    def test_true_under_attention_dp(self):
+        runner = _make_runner(shared_experts=object())
+        with patch.object(fm, "_is_attn_dp", return_value=True):
+            assert runner._fused_output_is_reduced is True
+
+    def test_true_when_no_mesh(self):
+        runner = _make_runner(shared_experts=object())
+        with patch.object(fm, "_is_attn_dp", return_value=False), \
+             patch.object(fm, "_get_mesh", return_value=None):
+            assert runner._fused_output_is_reduced is True
+
+    @pytest.mark.parametrize("backend",
+                             [MoEBackend.FUSED_MOE, MoEBackend.DENSE_MAT])
+    def test_true_for_non_gmm_backends(self, backend):
+        # Only GMM_EP / GMM_TP honor defer_all_reduce; others always reduce.
+        runner = _make_runner(shared_experts=object())
+        with patch.object(fm, "_is_attn_dp", return_value=False), \
+             patch.object(fm, "_get_mesh", return_value=object()), \
+             patch.object(fm, "select_moe_backend_from_fused_moe_config",
+                          return_value=backend):
+            assert runner._fused_output_is_reduced is True
+
+    @pytest.mark.parametrize("backend", [MoEBackend.GMM_EP, MoEBackend.GMM_TP])
+    def test_true_when_gmm_reduces_different_axes(self, backend):
+        runner = _make_runner(shared_experts=object())
+        with patch.object(fm, "_is_attn_dp", return_value=False), \
+             patch.object(fm, "_get_mesh", return_value=object()), \
+             patch.object(fm, "select_moe_backend_from_fused_moe_config",
+                          return_value=backend), \
+             patch.object(fm, "_gmm_and_shared_reduce_over_same_axes",
+                          return_value=False):
+            # The GMM's reduction can't be folded into the single MODEL
+            # all-reduce, so the kernel must reduce itself.
+            assert runner._fused_output_is_reduced is True
+
+    @pytest.mark.parametrize("backend", [MoEBackend.GMM_EP, MoEBackend.GMM_TP])
+    def test_false_when_all_conditions_met(self, backend):
+        runner = _make_runner(shared_experts=object())
+        with patch.object(fm, "_is_attn_dp", return_value=False), \
+             patch.object(fm, "_get_mesh", return_value=object()), \
+             patch.object(fm, "select_moe_backend_from_fused_moe_config",
+                          return_value=backend), \
+             patch.object(fm, "_gmm_and_shared_reduce_over_same_axes",
+                          return_value=True):
+            # Shared expert present, no DP, GMM backend, matching axes -> the
+            # kernel skips its reduce and the late single collective handles it.
+            assert runner._fused_output_is_reduced is False
+
+
+# ---------------------------------------------------------------------------
+# VllmMoERunner._maybe_reduce_shared_expert_output  (early path)
+# ---------------------------------------------------------------------------
+class TestMaybeReduceSharedExpertOutput:
+
+    def test_passthrough_when_shared_output_none(self):
+        runner = _make_runner()
+        with patch.object(fm, "_all_reduce_over_model") as reduce:
+            assert runner._maybe_reduce_shared_expert_output(None) is None
+        reduce.assert_not_called()
+
+    def test_passthrough_under_sequence_parallel(self):
+        # SP defers the reduction to a separate all-gather in the model.
+        runner = _make_runner(is_sequence_parallel=True)
+        shared = torch.ones(2, 3)
+        with patch.object(fm.VllmMoERunner, "_fused_output_is_reduced",
+                          new_callable=PropertyMock, return_value=True), \
+             patch.object(fm, "_all_reduce_over_model") as reduce:
+            out = runner._maybe_reduce_shared_expert_output(shared)
+        reduce.assert_not_called()
+        assert out is shared
+
+    def test_passthrough_when_fused_output_not_reduced(self):
+        # The late path will reduce shared + fused together, so don't reduce
+        # the shared output on its own here.
+        runner = _make_runner()
+        shared = torch.ones(2, 3)
+        with patch.object(fm.VllmMoERunner, "_fused_output_is_reduced",
+                          new_callable=PropertyMock, return_value=False), \
+             patch.object(fm, "_all_reduce_over_model") as reduce:
+            out = runner._maybe_reduce_shared_expert_output(shared)
+        reduce.assert_not_called()
+        assert out is shared
+
+    def test_passthrough_when_no_mesh(self):
+        runner = _make_runner()
+        shared = torch.ones(2, 3)
+        with patch.object(fm.VllmMoERunner, "_fused_output_is_reduced",
+                          new_callable=PropertyMock, return_value=True), \
+             patch.object(fm, "_get_mesh", return_value=None), \
+             patch.object(fm, "_all_reduce_over_model") as reduce:
+            out = runner._maybe_reduce_shared_expert_output(shared)
+        reduce.assert_not_called()
+        assert out is shared
+
+    def test_reduces_shared_output_on_early_path(self):
+        runner = _make_runner()
+        shared = torch.ones(2, 3)
+        reduced = torch.full((2, 3), 7.0)
+        mesh = object()
+        with patch.object(fm.VllmMoERunner, "_fused_output_is_reduced",
+                          new_callable=PropertyMock, return_value=True), \
+             patch.object(fm, "_get_mesh", return_value=mesh), \
+             patch.object(fm, "_all_reduce_over_model",
+                          return_value=reduced) as reduce:
+            out = runner._maybe_reduce_shared_expert_output(shared)
+        reduce.assert_called_once_with(shared, mesh)
+        assert out is reduced
+
+
+# ---------------------------------------------------------------------------
+# VllmMoERunner._maybe_reduce_final_output  (late path)
+# ---------------------------------------------------------------------------
+class TestMaybeReduceFinalOutput:
+
+    def test_attention_dp_only_truncates(self):
+        # Under attention DP the reduction is a separate reduce-scatter in the
+        # model; here only the padding is stripped.
+        runner = _make_runner()
+        states = torch.arange(8, dtype=torch.float32).reshape(2, 4)
+        with patch.object(fm, "_is_attn_dp", return_value=True), \
+             patch.object(fm, "_all_reduce_over_model") as reduce:
+            out = runner._maybe_reduce_final_output(states, trunc_size=3)
+        reduce.assert_not_called()
+        torch.testing.assert_close(out, states[..., :3])
+
+    def test_sequence_parallel_only_truncates(self):
+        runner = _make_runner(is_sequence_parallel=True)
+        states = torch.arange(8, dtype=torch.float32).reshape(2, 4)
+        with patch.object(fm, "_is_attn_dp", return_value=False), \
+             patch.object(fm.VllmMoERunner, "_fused_output_is_reduced",
+                          new_callable=PropertyMock, return_value=False), \
+             patch.object(fm, "_all_reduce_over_model") as reduce:
+            out = runner._maybe_reduce_final_output(states, trunc_size=2)
+        reduce.assert_not_called()
+        torch.testing.assert_close(out, states[..., :2])
+
+    def test_only_truncates_when_kernel_already_reduced(self):
+        # The kernel reduced its output (early path handled the shared expert),
+        # so no late collective is needed.
+        runner = _make_runner()
+        states = torch.arange(8, dtype=torch.float32).reshape(2, 4)
+        with patch.object(fm, "_is_attn_dp", return_value=False), \
+             patch.object(fm.VllmMoERunner, "_fused_output_is_reduced",
+                          new_callable=PropertyMock, return_value=True), \
+             patch.object(fm, "_all_reduce_over_model") as reduce:
+            out = runner._maybe_reduce_final_output(states, trunc_size=2)
+        reduce.assert_not_called()
+        torch.testing.assert_close(out, states[..., :2])
+
+    def test_only_truncates_when_no_mesh(self):
+        runner = _make_runner()
+        states = torch.arange(8, dtype=torch.float32).reshape(2, 4)
+        with patch.object(fm, "_is_attn_dp", return_value=False), \
+             patch.object(fm.VllmMoERunner, "_fused_output_is_reduced",
+                          new_callable=PropertyMock, return_value=False), \
+             patch.object(fm, "_get_mesh", return_value=None), \
+             patch.object(fm, "_all_reduce_over_model") as reduce:
+            out = runner._maybe_reduce_final_output(states, trunc_size=2)
+        reduce.assert_not_called()
+        torch.testing.assert_close(out, states[..., :2])
+
+    def test_reduces_then_truncates_on_late_path(self):
+        runner = _make_runner()
+        states = torch.arange(8, dtype=torch.float32).reshape(2, 4)
+        reduced = torch.arange(100, 108, dtype=torch.float32).reshape(2, 4)
+        mesh = object()
+        with patch.object(fm, "_is_attn_dp", return_value=False), \
+             patch.object(fm.VllmMoERunner, "_fused_output_is_reduced",
+                          new_callable=PropertyMock, return_value=False), \
+             patch.object(fm, "_get_mesh", return_value=mesh), \
+             patch.object(fm, "_all_reduce_over_model",
+                          return_value=reduced) as reduce:
+            out = runner._maybe_reduce_final_output(states, trunc_size=3)
+        reduce.assert_called_once_with(states, mesh)
+        # Reduction happens first, then the padding is stripped.
+        torch.testing.assert_close(out, reduced[..., :3])

--- a/tpu_inference/layers/common/fused_moe_gmm.py
+++ b/tpu_inference/layers/common/fused_moe_gmm.py
@@ -357,32 +357,12 @@ def moe_gmm_local(x: jax.Array,
                                            tiled=True).astype(x.dtype)
             else:
                 out = chunk_hidden.astype(x.dtype)
-    # Then global reduction on all ranks for all tokens and all experts
-    if defer_all_reduce:
-        # The caller defers the tensor-/expert-parallel all-reduce (e.g. to
-        # fuse it with a shared-expert reduction downstream). Return the
-        # per-shard partial sums; the output spec leaves the reduction axis
-        # replicated, matching the unreduced representation the caller expects.
-        out = out.astype(x.dtype)
-    elif enable_rs_kernel:
-        reduction_axes = reduction_axis if isinstance(
-            reduction_axis, tuple) else (reduction_axis, )
-        num_devices = 1
-        for axis in reduction_axes:
-            num_devices *= jax.lax.axis_size(axis)
-
-        # Fallback to psum-scatter for small token sizes to avoid Mosaic compilation.
-        # The threshold is chosen based on the tile dimension (8) in the
-        # hierarchical reduce-scatter kernel.
-        if out.shape[0] // num_devices < 8:
-            out = jax.lax.psum_scatter(out,
-                                       axis_name=reduction_axis,
-                                       scatter_dimension=0,
-                                       tiled=True).astype(x.dtype)
         else:
-            out = jax.lax.psum(chunk_hidden,
-                               axis_name=reduction_axis).astype(x.dtype)
-
+            if not defer_all_reduce:
+                out = jax.lax.psum(chunk_hidden,
+                                   axis_name=reduction_axis).astype(x.dtype)
+            else:
+                out = chunk_hidden.astype(x.dtype)
         out_list.append(out)
 
     return jnp.concatenate(out_list,

--- a/tpu_inference/layers/common/fused_moe_gmm.py
+++ b/tpu_inference/layers/common/fused_moe_gmm.py
@@ -197,7 +197,8 @@ def moe_gmm_local(x: jax.Array,
                   enable_rs_kernel: bool = False,
                   onehot_moe_permute_threshold: int = 0,
                   scatter_results: bool = False,
-                  moe_chunk_size: int = 0) -> jax.Array:
+                  moe_chunk_size: int = 0,
+                  defer_all_reduce: bool = False) -> jax.Array:
     """Main MoE logic on a local shard can run in TP or EP mode.
 
     Set parallelism for "tp" or "ep"
@@ -356,6 +357,28 @@ def moe_gmm_local(x: jax.Array,
                                            tiled=True).astype(x.dtype)
             else:
                 out = chunk_hidden.astype(x.dtype)
+    # Then global reduction on all ranks for all tokens and all experts
+    if defer_all_reduce:
+        # The caller defers the tensor-/expert-parallel all-reduce (e.g. to
+        # fuse it with a shared-expert reduction downstream). Return the
+        # per-shard partial sums; the output spec leaves the reduction axis
+        # replicated, matching the unreduced representation the caller expects.
+        out = out.astype(x.dtype)
+    elif enable_rs_kernel:
+        reduction_axes = reduction_axis if isinstance(
+            reduction_axis, tuple) else (reduction_axis, )
+        num_devices = 1
+        for axis in reduction_axes:
+            num_devices *= jax.lax.axis_size(axis)
+
+        # Fallback to psum-scatter for small token sizes to avoid Mosaic compilation.
+        # The threshold is chosen based on the tile dimension (8) in the
+        # hierarchical reduce-scatter kernel.
+        if out.shape[0] // num_devices < 8:
+            out = jax.lax.psum_scatter(out,
+                                       axis_name=reduction_axis,
+                                       scatter_dimension=0,
+                                       tiled=True).astype(x.dtype)
         else:
             out = jax.lax.psum(chunk_hidden,
                                axis_name=reduction_axis).astype(x.dtype)
@@ -385,6 +408,7 @@ def tensor_parallel_gmm(
     onehot_moe_permute_threshold: int = 0,
     scatter_results: bool = False,
     moe_chunk_size: int = 0,
+    defer_all_reduce: bool = False,
 ) -> jax.Array:
     data_p_spec = P(ShardingAxisName.MLP_DATA)
     attn_data_p_spec = P(ShardingAxisName.ATTN_DATA)
@@ -418,6 +442,7 @@ def tensor_parallel_gmm(
             onehot_moe_permute_threshold=onehot_moe_permute_threshold,
             scatter_results=scatter_results,
             moe_chunk_size=moe_chunk_size,
+            defer_all_reduce=defer_all_reduce,
         ),
         mesh=mesh,
         in_specs=(
@@ -469,6 +494,7 @@ def expert_parallel_gmm(
     onehot_moe_permute_threshold: int = 0,
     moe_chunk_size: int = 0,
     scatter_results: bool = False,
+    defer_all_reduce: bool = False,
 ) -> jax.Array:
     ep_size = get_mesh_shape_product(mesh, ShardingAxisName.EXPERT)
     ep_p_spec = P(ShardingAxisName.EXPERT)
@@ -501,6 +527,7 @@ def expert_parallel_gmm(
             enable_rs_kernel=enable_rs_kernel,
             scatter_results=scatter_results,
             moe_chunk_size=moe_chunk_size,
+            defer_all_reduce=defer_all_reduce,
         ),
         mesh=mesh,
         in_specs=(
@@ -568,6 +595,7 @@ def _apply_all_gather_fp8(hidden_states: jax.Array, mesh: Mesh,
     "onehot_moe_permute_threshold",
     "scatter_results",
     "moe_chunk_size",
+    "defer_all_reduce",
 ))
 def fused_moe_func(
     hidden_states: jax.Array,
@@ -588,6 +616,7 @@ def fused_moe_func(
     enable_rs_kernel: bool = False,
     onehot_moe_permute_threshold: int = 0,
     scatter_results: bool = False,
+    defer_all_reduce: bool = False,
     hash_based_topk_indices: jax.Array | None = None,
     expert_score_correction_bias: jax.Array | None = None,
     moe_chunk_size: int = 0,
@@ -757,6 +786,7 @@ def fused_moe_func(
             onehot_moe_permute_threshold=onehot_moe_permute_threshold,
             scatter_results=scatter_results,
             moe_chunk_size=moe_chunk_size,
+            defer_all_reduce=defer_all_reduce,
         )
     else:
         x = tensor_parallel_gmm(
@@ -777,6 +807,7 @@ def fused_moe_func(
             onehot_moe_permute_threshold=onehot_moe_permute_threshold,
             scatter_results=scatter_results,
             moe_chunk_size=moe_chunk_size,
+            defer_all_reduce=defer_all_reduce,
         )
 
     return x[:num_tokens, :hidden_size]

--- a/tpu_inference/layers/common/fused_moe_gmm.py
+++ b/tpu_inference/layers/common/fused_moe_gmm.py
@@ -151,7 +151,8 @@ def moe_gmm_local(x: jax.Array,
                   parallelism: Literal["tp", "ep"],
                   enable_rs_kernel: bool = False,
                   onehot_moe_permute_threshold: int = 0,
-                  scatter_results: bool = False) -> jax.Array:
+                  scatter_results: bool = False,
+                  defer_all_reduce: bool = False) -> jax.Array:
     """Main MoE logic on a local shard can run in TP or EP mode.
 
     Set parallelism for "tp" or "ep"
@@ -225,7 +226,13 @@ def moe_gmm_local(x: jax.Array,
         out = cur_masked.sum(axis=-2)
 
     # Then global reduction on all ranks for all tokens and all experts
-    if enable_rs_kernel:
+    if defer_all_reduce:
+        # The caller defers the tensor-/expert-parallel all-reduce (e.g. to
+        # fuse it with a shared-expert reduction downstream). Return the
+        # per-shard partial sums; the output spec leaves the reduction axis
+        # replicated, matching the unreduced representation the caller expects.
+        out = out.astype(x.dtype)
+    elif enable_rs_kernel:
         reduction_axes = reduction_axis if isinstance(
             reduction_axis, tuple) else (reduction_axis, )
         num_devices = 1
@@ -297,6 +304,7 @@ def tensor_parallel_gmm(
     enable_rs_kernel: bool = False,
     onehot_moe_permute_threshold: int = 0,
     scatter_results: bool = False,
+    defer_all_reduce: bool = False,
 ) -> jax.Array:
     data_p_spec = P(ShardingAxisName.MLP_DATA)
     attn_data_p_spec = P(ShardingAxisName.ATTN_DATA)
@@ -329,6 +337,7 @@ def tensor_parallel_gmm(
             enable_rs_kernel=False,
             onehot_moe_permute_threshold=onehot_moe_permute_threshold,
             scatter_results=scatter_results,
+            defer_all_reduce=defer_all_reduce,
         ),
         mesh=mesh,
         in_specs=(
@@ -379,6 +388,7 @@ def expert_parallel_gmm(
     enable_rs_kernel: bool = False,
     onehot_moe_permute_threshold: int = 0,
     scatter_results: bool = False,
+    defer_all_reduce: bool = False,
 ) -> jax.Array:
     ep_size = get_mesh_shape_product(mesh, ShardingAxisName.EXPERT)
     ep_p_spec = P(ShardingAxisName.EXPERT)
@@ -410,6 +420,7 @@ def expert_parallel_gmm(
             onehot_moe_permute_threshold=onehot_moe_permute_threshold,
             enable_rs_kernel=enable_rs_kernel,
             scatter_results=scatter_results,
+            defer_all_reduce=defer_all_reduce,
         ),
         mesh=mesh,
         in_specs=(
@@ -476,6 +487,7 @@ def _apply_all_gather_fp8(hidden_states: jax.Array, mesh: Mesh,
     "enable_rs_kernel",
     "onehot_moe_permute_threshold",
     "scatter_results",
+    "defer_all_reduce",
 ))
 def fused_moe_func(
     hidden_states: jax.Array,
@@ -496,6 +508,7 @@ def fused_moe_func(
     enable_rs_kernel: bool = False,
     onehot_moe_permute_threshold: int = 0,
     scatter_results: bool = False,
+    defer_all_reduce: bool = False,
     hash_based_topk_indices: jax.Array | None = None,
     expert_score_correction_bias: jax.Array | None = None,
 ) -> jax.Array:
@@ -663,6 +676,7 @@ def fused_moe_func(
             enable_rs_kernel=actual_enable_rs_kernel,
             onehot_moe_permute_threshold=onehot_moe_permute_threshold,
             scatter_results=scatter_results,
+            defer_all_reduce=defer_all_reduce,
         )
     else:
         x = tensor_parallel_gmm(
@@ -682,6 +696,7 @@ def fused_moe_func(
             enable_rs_kernel=actual_enable_rs_kernel,
             onehot_moe_permute_threshold=onehot_moe_permute_threshold,
             scatter_results=scatter_results,
+            defer_all_reduce=defer_all_reduce,
         )
 
     return x[:num_tokens, :hidden_size]

--- a/tpu_inference/layers/common/linear.py
+++ b/tpu_inference/layers/common/linear.py
@@ -109,7 +109,8 @@ def sharded_quantized_matmul(x: jax.Array,
                              weight_sharding: P | NamedSharding,
                              *,
                              mesh: Mesh | None = None,
-                             x_q_dtype: jnp.dtype | None = None) -> jax.Array:
+                             x_q_dtype: jnp.dtype | None = None,
+                             defer_all_reduce: bool = False) -> jax.Array:
     """
     Wrapper around the quantized matmul kernel.
 
@@ -120,6 +121,11 @@ def sharded_quantized_matmul(x: jax.Array,
         weight_sharding: PartitionSpec or NamedSharding for the weight tensor.
         mesh: (Optional) Mesh to shard on. If None, mesh from current context is used, similar to jax.shard_map().
         x_q_dtype: (Optional) Quantized dtype for the activation. If None, inferred from w_q dtype (int -> int8, float -> float8).
+        defer_all_reduce: (Optional) If True, defer the all-reduce (psum) over
+            the contracting (in) axis: it is not performed here even when that
+            axis is sharded. The output then holds per-shard partial sums; the
+            caller is responsible for reducing them later (e.g. to fuse the
+            reduction with a subsequent collective).
 
     Returns:
         Output of the quantized matmul.
@@ -177,7 +183,7 @@ def sharded_quantized_matmul(x: jax.Array,
             )
         else:
             output = xla_quantized_matmul(x, w_q, w_s)
-        if in_axis:
+        if in_axis and not defer_all_reduce:
             output = jax.lax.psum(output, axis_name=in_axis)
         return output
 

--- a/tpu_inference/layers/common/moe.py
+++ b/tpu_inference/layers/common/moe.py
@@ -84,6 +84,16 @@ def moe_apply(
         extra_backend_kwargs) if extra_backend_kwargs else {}
     scatter_results = extra_backend_kwargs.pop("scatter_results", False)
     moe_chunk_size = extra_backend_kwargs.pop("moe_chunk_size", 0)
+    # When set, the GMM backends skip their tensor-/expert-parallel all-reduce
+    # and return per-shard partial sums, so the reduction can be deferred and
+    # fused with a later collective (e.g. a shared-expert all-reduce).
+    defer_all_reduce = extra_backend_kwargs.pop("defer_all_reduce", False)
+
+    if defer_all_reduce and moe_backend not in {
+            MoEBackend.GMM_EP, MoEBackend.GMM_TP
+    }:
+        raise ValueError(
+            "defer_all_reduce can only be True for GMM_EP and GMM_TP backends")
 
     with jax.named_scope(layer._get_name()):
         activation = layer.activation if isinstance(
@@ -159,6 +169,7 @@ def moe_apply(
                     onehot_moe_permute_threshold=envs.
                     ONEHOT_MOE_PERMUTE_THRESHOLD,
                     scatter_results=scatter_results,
+                    defer_all_reduce=defer_all_reduce,
                     hash_based_topk_indices=extra_backend_kwargs.get(
                         "hash_based_topk_indices", None),
                     expert_score_correction_bias=extra_backend_kwargs.get(

--- a/tpu_inference/layers/common/moe.py
+++ b/tpu_inference/layers/common/moe.py
@@ -82,6 +82,16 @@ def moe_apply(
     extra_backend_kwargs = dict(
         extra_backend_kwargs) if extra_backend_kwargs else {}
     scatter_results = extra_backend_kwargs.pop("scatter_results", False)
+    # When set, the GMM backends skip their tensor-/expert-parallel all-reduce
+    # and return per-shard partial sums, so the reduction can be deferred and
+    # fused with a later collective (e.g. a shared-expert all-reduce).
+    defer_all_reduce = extra_backend_kwargs.pop("defer_all_reduce", False)
+
+    if defer_all_reduce and moe_backend not in {
+            MoEBackend.GMM_EP, MoEBackend.GMM_TP
+    }:
+        raise ValueError(
+            "defer_all_reduce can only be True for GMM_EP and GMM_TP backends")
 
     with jax.named_scope(layer._get_name()):
         activation = layer.activation if isinstance(
@@ -157,6 +167,7 @@ def moe_apply(
                     onehot_moe_permute_threshold=envs.
                     ONEHOT_MOE_PERMUTE_THRESHOLD,
                     scatter_results=scatter_results,
+                    defer_all_reduce=defer_all_reduce,
                     hash_based_topk_indices=extra_backend_kwargs.get(
                         "hash_based_topk_indices", None),
                     expert_score_correction_bias=extra_backend_kwargs.get(

--- a/tpu_inference/layers/common/quantization/configs.py
+++ b/tpu_inference/layers/common/quantization/configs.py
@@ -25,7 +25,7 @@ class QuantLinearConfig:
                  *,
                  enable_sp: bool,
                  output_sizes: list[int],
-                 weight_sharding: P | None = None
+                 weight_sharding: P | None = None,
                  defer_all_reduce: bool = False):
         # Output size across all TP ranks.
         self.output_sizes = output_sizes

--- a/tpu_inference/layers/common/quantization/configs.py
+++ b/tpu_inference/layers/common/quantization/configs.py
@@ -25,7 +25,8 @@ class QuantLinearConfig:
                  *,
                  enable_sp: bool,
                  output_sizes: list[int],
-                 weight_sharding: P | None = None):
+                 weight_sharding: P | None = None
+                 defer_all_reduce: bool = False):
         # Output size across all TP ranks.
         self.output_sizes = output_sizes
         self.weight_sharding = weight_sharding if weight_sharding is not None else P(
@@ -35,6 +36,13 @@ class QuantLinearConfig:
         self.input_sharding = None
         self.output_sharding = None
         self.mesh = None
+
+        # If True, defer the all-reduce (psum) over the contracting (in) axis of
+        # the matmul: it is not performed here even when that axis is sharded.
+        # The matmul then returns per-shard partial sums and the caller is
+        # responsible for reducing them later (e.g. fusing the reduction with a
+        # downstream collective).
+        self.defer_all_reduce = defer_all_reduce
 
         self.bias_sharding = P(self.weight_sharding[1])
         # n_shards is always the TP degree for the weight's output axis, derived

--- a/tpu_inference/layers/common/quantization/configs.py
+++ b/tpu_inference/layers/common/quantization/configs.py
@@ -20,7 +20,11 @@ from tpu_inference.utils import to_jax_dtype
 
 class QuantLinearConfig:
 
-    def __init__(self, *, enable_sp: bool, output_sizes: list[int]):
+    def __init__(self,
+                 *,
+                 enable_sp: bool,
+                 output_sizes: list[int],
+                 defer_all_reduce: bool = False):
         # Output size across all TP ranks.
         self.output_sizes = output_sizes
         self.weight_sharding = P(None, None)
@@ -29,6 +33,13 @@ class QuantLinearConfig:
         self.input_sharding = None
         self.output_sharding = None
         self.mesh = None
+
+        # If True, defer the all-reduce (psum) over the contracting (in) axis of
+        # the matmul: it is not performed here even when that axis is sharded.
+        # The matmul then returns per-shard partial sums and the caller is
+        # responsible for reducing them later (e.g. fusing the reduction with a
+        # downstream collective).
+        self.defer_all_reduce = defer_all_reduce
 
         self.bias_sharding = P(self.weight_sharding[1])
         self.n_shards = len(output_sizes)

--- a/tpu_inference/layers/common/quantization/fp8.py
+++ b/tpu_inference/layers/common/quantization/fp8.py
@@ -46,11 +46,14 @@ class Fp8LinearMethod:
     def _apply_fused(self, x: jax.Array, weight_jax: jax.Array,
                      weight_scale_jax: jax.Array,
                      bias: Optional[jax.Array]) -> jax.Array:
-        outs = sharded_quantized_matmul(x,
-                                        weight_jax,
-                                        weight_scale_jax,
-                                        self.linear_config.weight_sharding,
-                                        mesh=self.linear_config.mesh)
+
+        outs = sharded_quantized_matmul(
+            x,
+            weight_jax,
+            weight_scale_jax,
+            self.linear_config.weight_sharding,
+            mesh=self.linear_config.mesh,
+            defer_all_reduce=self.linear_config.defer_all_reduce)
 
         if bias is not None:
             outs += bias
@@ -67,11 +70,13 @@ class Fp8LinearMethod:
         outs = []
         for i, (weight, weight_scale) in enumerate(weight_and_scale):
 
-            out = sharded_quantized_matmul(x,
-                                           weight,
-                                           weight_scale,
-                                           self.linear_config.weight_sharding,
-                                           mesh=mesh)
+            out = sharded_quantized_matmul(
+                x,
+                weight,
+                weight_scale,
+                self.linear_config.weight_sharding,
+                mesh=mesh,
+                defer_all_reduce=self.linear_config.defer_all_reduce)
 
             if bias is not None:
                 out += bias[i]

--- a/tpu_inference/layers/common/sharding.py
+++ b/tpu_inference/layers/common/sharding.py
@@ -133,6 +133,19 @@ class LazyShardingAxisName:
 ShardingAxisName = LazyShardingAxisName()
 
 
+def is_attn_dp(mesh: Mesh) -> bool:
+    """Whether attention data-parallelism is active on ``mesh``.
+
+    True when the attention-data axes carry a factor beyond plain data
+    parallelism (i.e. ``attn_dp`` * ``attn_dp_expert`` > 1), meaning attention
+    is replicated over more data-parallel shards than the MLP/data axis alone.
+    """
+    attn_dp_size = utils.get_mesh_shape_product(mesh,
+                                                ShardingAxisName.ATTN_DATA)
+    dp_size = utils.get_mesh_shape_product(mesh, ShardingAxisName.MLP_DATA)
+    return (attn_dp_size // dp_size) > 1
+
+
 @dataclass
 class ShardingStrategy:
     """Defines the high-level parallelism strategy.

--- a/tpu_inference/layers/vllm/custom_ops/fused_moe.py
+++ b/tpu_inference/layers/vllm/custom_ops/fused_moe.py
@@ -21,12 +21,11 @@ from vllm.logger import init_logger
 from vllm.model_executor.layers.fused_moe.runner.moe_runner import MoERunner
 
 from tpu_inference.layers.common.moe import MoEBackend
-from tpu_inference.layers.common.sharding import ShardingAxisName
+from tpu_inference.layers.common.sharding import ShardingAxisName, is_attn_dp
 from tpu_inference.layers.vllm.interface.moe import \
     select_moe_backend_from_fused_moe_config
 from tpu_inference.models.vllm.vllm_model_wrapper_context import \
     get_vllm_model_wrapper_context
-from tpu_inference.utils import get_mesh_shape_product
 
 logger = init_logger(__name__)
 
@@ -37,16 +36,6 @@ def _get_mesh() -> Mesh | None:
         return get_vllm_model_wrapper_context().mesh
     except AssertionError:
         return None
-
-
-def _is_attn_dp() -> bool:
-    """Whether attention data-parallelism is enabled on the active mesh."""
-    mesh = _get_mesh()
-    if mesh is None:
-        return False
-    attn_dp_size = get_mesh_shape_product(mesh, ShardingAxisName.ATTN_DATA)
-    dp_size = get_mesh_shape_product(mesh, ShardingAxisName.MLP_DATA)
-    return (attn_dp_size // dp_size) > 1
 
 
 def _all_reduce_over_tp(t: torch.Tensor, mesh: Mesh) -> torch.Tensor:
@@ -60,22 +49,6 @@ def _all_reduce_over_tp(t: torch.Tensor, mesh: Mesh) -> torch.Tensor:
     return torch_view(_reduce(jax_view(t)))
 
 
-def _effective_reduce_axes(mesh: Mesh, axes) -> frozenset:
-    """The subset of the given mesh axis names that actually shard (size > 1)."""
-    if isinstance(axes, str):
-        axes = (axes, )
-    return frozenset(a for a in axes if get_mesh_shape_product(mesh, a) > 1)
-
-
-def _gmm_and_shared_reduce_over_same_axes(mesh: Mesh,
-                                          moe_backend: MoEBackend) -> bool:
-    """Whether the GMM's reduction collapses exactly the shared-expert's TP axis."""
-    gmm_axis = (ShardingAxisName.EXPERT if moe_backend == MoEBackend.GMM_EP
-                else ShardingAxisName.MLP_TENSOR)
-    return (_effective_reduce_axes(mesh, gmm_axis) == _effective_reduce_axes(
-        mesh, ShardingAxisName.MLP_TENSOR))
-
-
 @MoERunner.register_oot
 class VllmMoERunner(MoERunner):
 
@@ -86,25 +59,19 @@ class VllmMoERunner(MoERunner):
         # ``_maybe_reduce_final_output`` -- ONLY when every condition below
         # holds. Otherwise the fused output is reduced by the kernel itself.
         #
-        #   1. a shared expert is present (else there is nothing to fuse with),
-        #   2. attention-DP is disabled (DP resolves the reduction separately),
+        #   1. a shared expert is present (else there is nothing to fuse with)
+        #   2. attention-DP is disabled (DP resolves the reduction separately)
         #   3. the backend is GMM_EP / GMM_TP (only those honor defer_all_reduce;
-        #      e.g. the FUSED_MOE kernel always reduces), and
-        #   4. the GMM reduction collapses the same mesh axes as the shared
-        #      expert (MODEL) -- otherwise one all-reduce over MODEL cannot
-        #      stand in for the GMM's reduction.
-        if self._shared_experts is None or _is_attn_dp():
-            return True
-
+        #      e.g. the FUSED_MOE kernel always reduces)
         mesh = _get_mesh()
         if mesh is None:
             return True
 
-        moe_backend = select_moe_backend_from_fused_moe_config(self.moe_config)
-        if moe_backend not in (MoEBackend.GMM_EP, MoEBackend.GMM_TP):
+        if self._shared_experts is None or is_attn_dp(mesh):
             return True
 
-        if not _gmm_and_shared_reduce_over_same_axes(mesh, moe_backend):
+        moe_backend = select_moe_backend_from_fused_moe_config(self.moe_config)
+        if moe_backend not in (MoEBackend.GMM_EP, MoEBackend.GMM_TP):
             return True
 
         return False
@@ -142,12 +109,14 @@ class VllmMoERunner(MoERunner):
         reduction is handled by a separate reduce-scatter pass in the model, so
         only the padding is stripped here.
         """
-        if _is_attn_dp():
+        mesh = _get_mesh()
+        if mesh is None:
             return states[..., :trunc_size]
 
-        if (not self.moe_config.is_sequence_parallel
-                and not self._fused_output_is_reduced):
-            mesh = _get_mesh()
-            if mesh is not None:
-                states = _all_reduce_over_tp(states, mesh)
+        is_dp = is_attn_dp(mesh)
+        is_sequence_parallel = self.moe_config.is_sequence_parallel
+        is_fused_output_reduced = self._fused_output_is_reduced
+
+        if not is_dp and not is_sequence_parallel and not is_fused_output_reduced:
+            states = _all_reduce_over_tp(states, mesh)
         return states[..., :trunc_size]

--- a/tpu_inference/layers/vllm/custom_ops/fused_moe.py
+++ b/tpu_inference/layers/vllm/custom_ops/fused_moe.py
@@ -12,34 +12,142 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import jax
 import torch
+from jax.sharding import Mesh
+from jax.sharding import PartitionSpec as P
+from torchax.interop import jax_view, shard_map, torch_view
+from vllm.logger import init_logger
 from vllm.model_executor.layers.fused_moe.runner.moe_runner import MoERunner
 
+from tpu_inference.layers.common.moe import MoEBackend
 from tpu_inference.layers.common.sharding import ShardingAxisName
+from tpu_inference.layers.vllm.interface.moe import \
+    select_moe_backend_from_fused_moe_config
 from tpu_inference.models.vllm.vllm_model_wrapper_context import \
     get_vllm_model_wrapper_context
 from tpu_inference.utils import get_mesh_shape_product
+
+logger = init_logger(__name__)
+
+
+def _get_mesh() -> Mesh | None:
+    """The active JAX device mesh, or ``None`` outside a model context."""
+    try:
+        return get_vllm_model_wrapper_context().mesh
+    except AssertionError:
+        return None
+
+
+def _is_attn_dp() -> bool:
+    """Whether attention data-parallelism is enabled on the active mesh."""
+    mesh = _get_mesh()
+    if mesh is None:
+        return False
+    attn_dp_size = get_mesh_shape_product(mesh, ShardingAxisName.ATTN_DATA)
+    dp_size = get_mesh_shape_product(mesh, ShardingAxisName.MLP_DATA)
+    return (attn_dp_size // dp_size) > 1
+
+
+def _all_reduce_over_tp(t: torch.Tensor, mesh: Mesh) -> torch.Tensor:
+    """All-reduce an unreduced local sum over the TP axis."""
+    spec = P(ShardingAxisName.ATTN_DATA, None)
+
+    @shard_map(mesh=mesh, in_specs=spec, out_specs=spec, check_vma=False)
+    def _reduce(x):
+        return jax.lax.psum(x, axis_name=ShardingAxisName.MLP_TENSOR)
+
+    return torch_view(_reduce(jax_view(t)))
+
+
+def _effective_reduce_axes(mesh: Mesh, axes) -> frozenset:
+    """The subset of the given mesh axis names that actually shard (size > 1)."""
+    if isinstance(axes, str):
+        axes = (axes, )
+    return frozenset(a for a in axes if get_mesh_shape_product(mesh, a) > 1)
+
+
+def _gmm_and_shared_reduce_over_same_axes(mesh: Mesh,
+                                          moe_backend: MoEBackend) -> bool:
+    """Whether the GMM's reduction collapses exactly the shared-expert's TP axis."""
+    gmm_axis = (ShardingAxisName.EXPERT if moe_backend == MoEBackend.GMM_EP
+                else ShardingAxisName.MLP_TENSOR)
+    return (_effective_reduce_axes(mesh, gmm_axis) == _effective_reduce_axes(
+        mesh, ShardingAxisName.MLP_TENSOR))
 
 
 @MoERunner.register_oot
 class VllmMoERunner(MoERunner):
 
-    def _maybe_reduce_final_output(self, states: torch.Tensor,
-                                   trunc_size: int) -> torch.Tensor:
-        try:
-            context = get_vllm_model_wrapper_context()
-            mesh = context.mesh
-        except AssertionError:
-            mesh = None
+    @property
+    def _fused_output_is_reduced(self) -> bool:
+        # Returns False -- i.e. the GMM kernel skips its own all-reduce and the
+        # shared + fused outputs are reduced together by a single collective in
+        # ``_maybe_reduce_final_output`` -- ONLY when every condition below
+        # holds. Otherwise the fused output is reduced by the kernel itself.
+        #
+        #   1. a shared expert is present (else there is nothing to fuse with),
+        #   2. attention-DP is disabled (DP resolves the reduction separately),
+        #   3. the backend is GMM_EP / GMM_TP (only those honor defer_all_reduce;
+        #      e.g. the FUSED_MOE kernel always reduces), and
+        #   4. the GMM reduction collapses the same mesh axes as the shared
+        #      expert (MODEL) -- otherwise one all-reduce over MODEL cannot
+        #      stand in for the GMM's reduction.
+        if self._shared_experts is None or _is_attn_dp():
+            return True
 
-        is_dp = False
-        if mesh is not None:
-            attn_dp_size = get_mesh_shape_product(mesh,
-                                                  ShardingAxisName.ATTN_DATA)
-            dp_size = get_mesh_shape_product(mesh, ShardingAxisName.MLP_DATA)
-            is_dp = (attn_dp_size // dp_size) > 1
+        mesh = _get_mesh()
+        if mesh is None:
+            return True
 
-        if is_dp:
+        moe_backend = select_moe_backend_from_fused_moe_config(self.moe_config)
+        if moe_backend not in (MoEBackend.GMM_EP, MoEBackend.GMM_TP):
+            return True
+
+        if not _gmm_and_shared_reduce_over_same_axes(mesh, moe_backend):
+            return True
+
+        return False
+
+    def _maybe_reduce_shared_expert_output(
+        self,
+        shared_output: torch.Tensor | None,
+    ) -> torch.Tensor | None:
+        """Early all-reduce path: reduce the shared-expert output on its own.
+
+        When the fused kernel already reduced its output, the shared-expert
+        output (produced unreduced by its RowParallelLinear, whose all-reduce
+        was skipped via ``reduce_results=False``) must be reduced separately so the
+        two match before being summed downstream. Under sequence parallelism a
+        separate all-gather step in the model handles this instead.
+        """
+        if (shared_output is not None
+                and not self.moe_config.is_sequence_parallel
+                and self._fused_output_is_reduced):
+            mesh = _get_mesh()
+            if mesh is not None:
+                shared_output = _all_reduce_over_tp(shared_output, mesh)
+        return shared_output
+
+    def _maybe_reduce_final_output(
+        self,
+        states: torch.Tensor,
+        trunc_size: int,
+    ) -> torch.Tensor:
+        """Late all-reduce path: reduce the combined (shared + fused) output.
+
+        When the fused kernel did not reduce its output, the shared and fused
+        outputs were summed while still unreduced and the combined result is
+        all-reduced here in a single collective instead of two. Under attention-DP the
+        reduction is handled by a separate reduce-scatter pass in the model, so
+        only the padding is stripped here.
+        """
+        if _is_attn_dp():
             return states[..., :trunc_size]
 
-        return super()._maybe_reduce_final_output(states, trunc_size)
+        if (not self.moe_config.is_sequence_parallel
+                and not self._fused_output_is_reduced):
+            mesh = _get_mesh()
+            if mesh is not None:
+                states = _all_reduce_over_tp(states, mesh)
+        return states[..., :trunc_size]

--- a/tpu_inference/layers/vllm/custom_ops/fused_moe.py
+++ b/tpu_inference/layers/vllm/custom_ops/fused_moe.py
@@ -118,12 +118,15 @@ class VllmMoERunner(MoERunner):
         two match before being summed downstream. Under sequence parallelism a
         separate all-gather step in the model handles this instead.
         """
-        if (shared_output is not None
+        mesh = _get_mesh()
+
+        if mesh is None:
+            return shared_output
+
+        if (shared_output is not None and self._fused_output_is_reduced
                 and not self.moe_config.is_sequence_parallel
-                and self._fused_output_is_reduced):
-            mesh = _get_mesh()
-            if mesh is not None:
-                shared_output = _all_reduce_over_tp(shared_output, mesh)
+                and not is_attn_dp(mesh)):
+            shared_output = _all_reduce_over_tp(shared_output, mesh)
         return shared_output
 
     def _maybe_reduce_final_output(

--- a/tpu_inference/layers/vllm/custom_ops/fused_moe.py
+++ b/tpu_inference/layers/vllm/custom_ops/fused_moe.py
@@ -26,6 +26,7 @@ from tpu_inference.layers.vllm.interface.moe import \
     select_moe_backend_from_fused_moe_config
 from tpu_inference.models.vllm.vllm_model_wrapper_context import \
     get_vllm_model_wrapper_context
+from tpu_inference.utils import get_mesh_shape_product
 
 logger = init_logger(__name__)
 
@@ -49,6 +50,24 @@ def _all_reduce_over_tp(t: torch.Tensor, mesh: Mesh) -> torch.Tensor:
     return torch_view(_reduce(jax_view(t)))
 
 
+def _gmm_and_shared_reduce_over_same_axes(mesh: Mesh,
+                                          moe_backend: MoEBackend) -> bool:
+    """Whether the GMM reduction collapses exactly the shared expert's TP axes.
+
+    Only axes that actually shard (size > 1) on ``mesh`` count, so axis-name
+    tuples that differ only in size-1 axes still match.
+    """
+    gmm_axis = (ShardingAxisName.EXPERT if moe_backend == MoEBackend.GMM_EP
+                else ShardingAxisName.MLP_TENSOR)
+
+    def effective(axes):
+        axes = (axes, ) if isinstance(axes, str) else axes
+        return frozenset(a for a in axes
+                         if get_mesh_shape_product(mesh, a) > 1)
+
+    return effective(gmm_axis) == effective(ShardingAxisName.MLP_TENSOR)
+
+
 @MoERunner.register_oot
 class VllmMoERunner(MoERunner):
 
@@ -63,6 +82,9 @@ class VllmMoERunner(MoERunner):
         #   2. attention-DP is disabled (DP resolves the reduction separately)
         #   3. the backend is GMM_EP / GMM_TP (only those honor defer_all_reduce;
         #      e.g. the FUSED_MOE kernel always reduces)
+        #   4. the GMM reduction collapses the same mesh axes as the shared
+        #      expert (MLP_TENSOR) -- else one all-reduce over MLP_TENSOR cannot
+        #      stand in for the GMM's reduction
         mesh = _get_mesh()
         if mesh is None:
             return True
@@ -72,6 +94,14 @@ class VllmMoERunner(MoERunner):
 
         moe_backend = select_moe_backend_from_fused_moe_config(self.moe_config)
         if moe_backend not in (MoEBackend.GMM_EP, MoEBackend.GMM_TP):
+            return True
+
+        # The late path folds the GMM's reduction into a single all-reduce over
+        # MLP_TENSOR (the shared expert's TP axis). That is only valid when the
+        # GMM effectively reduces the same axes; otherwise fall back to the
+        # kernel reducing its own output. (GMM_TP always reduces over
+        # MLP_TENSOR; GMM_EP reduces over EXPERT, which may differ.)
+        if not _gmm_and_shared_reduce_over_same_axes(mesh, moe_backend):
             return True
 
         return False

--- a/tpu_inference/layers/vllm/custom_ops/fused_moe.py
+++ b/tpu_inference/layers/vllm/custom_ops/fused_moe.py
@@ -12,38 +12,146 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import jax
 import torch
+from jax.sharding import Mesh
+from jax.sharding import PartitionSpec as P
+from torchax.interop import jax_view, shard_map, torch_view
+from vllm.logger import init_logger
 from vllm.model_executor.layers.fused_moe import FusedMoE
 from vllm.model_executor.layers.fused_moe.runner.moe_runner import MoERunner
 
+from tpu_inference.layers.common.moe import MoEBackend
 from tpu_inference.layers.common.sharding import ShardingAxisName
+from tpu_inference.layers.vllm.interface.moe import \
+    select_moe_backend_from_fused_moe_config
 from tpu_inference.models.vllm.vllm_model_wrapper_context import \
     get_vllm_model_wrapper_context
 from tpu_inference.utils import get_mesh_shape_product
+
+logger = init_logger(__name__)
+
+
+def _get_mesh() -> Mesh | None:
+    """The active JAX device mesh, or ``None`` outside a model context."""
+    try:
+        return get_vllm_model_wrapper_context().mesh
+    except AssertionError:
+        return None
+
+
+def _is_attn_dp() -> bool:
+    """Whether attention data-parallelism is enabled on the active mesh."""
+    mesh = _get_mesh()
+    if mesh is None:
+        return False
+    attn_dp_size = get_mesh_shape_product(mesh, ShardingAxisName.ATTN_DATA)
+    dp_size = get_mesh_shape_product(mesh, ShardingAxisName.MLP_DATA)
+    return (attn_dp_size // dp_size) > 1
+
+
+def _all_reduce_over_tp(t: torch.Tensor, mesh: Mesh) -> torch.Tensor:
+    """All-reduce an unreduced local sum over the TP axis."""
+    spec = P(ShardingAxisName.ATTN_DATA, None)
+
+    @shard_map(mesh=mesh, in_specs=spec, out_specs=spec, check_vma=False)
+    def _reduce(x):
+        return jax.lax.psum(x, axis_name=ShardingAxisName.MLP_TENSOR)
+
+    return torch_view(_reduce(jax_view(t)))
+
+
+def _effective_reduce_axes(mesh: Mesh, axes) -> frozenset:
+    """The subset of the given mesh axis names that actually shard (size > 1)."""
+    if isinstance(axes, str):
+        axes = (axes, )
+    return frozenset(a for a in axes if get_mesh_shape_product(mesh, a) > 1)
+
+
+def _gmm_and_shared_reduce_over_same_axes(mesh: Mesh,
+                                          moe_backend: MoEBackend) -> bool:
+    """Whether the GMM's reduction collapses exactly the shared-expert's TP axis."""
+    gmm_axis = (ShardingAxisName.EXPERT if moe_backend == MoEBackend.GMM_EP
+                else ShardingAxisName.MLP_TENSOR)
+    return (_effective_reduce_axes(mesh, gmm_axis) == _effective_reduce_axes(
+        mesh, ShardingAxisName.MLP_TENSOR))
 
 
 @MoERunner.register_oot
 class VllmMoERunner(MoERunner):
 
-    def _maybe_reduce_final_output(self, states: torch.Tensor,
-                                   trunc_size: int) -> torch.Tensor:
-        try:
-            context = get_vllm_model_wrapper_context()
-            mesh = context.mesh
-        except AssertionError:
-            mesh = None
+    @property
+    def _fused_output_is_reduced(self) -> bool:
+        # Returns False -- i.e. the GMM kernel skips its own all-reduce and the
+        # shared + fused outputs are reduced together by a single collective in
+        # ``_maybe_reduce_final_output`` -- ONLY when every condition below
+        # holds. Otherwise the fused output is reduced by the kernel itself.
+        #
+        #   1. a shared expert is present (else there is nothing to fuse with),
+        #   2. attention-DP is disabled (DP resolves the reduction separately),
+        #   3. the backend is GMM_EP / GMM_TP (only those honor defer_all_reduce;
+        #      e.g. the FUSED_MOE kernel always reduces), and
+        #   4. the GMM reduction collapses the same mesh axes as the shared
+        #      expert (MODEL) -- otherwise one all-reduce over MODEL cannot
+        #      stand in for the GMM's reduction.
+        if self._shared_experts is None or _is_attn_dp():
+            return True
 
-        is_dp = False
-        if mesh is not None:
-            attn_dp_size = get_mesh_shape_product(mesh,
-                                                  ShardingAxisName.ATTN_DATA)
-            dp_size = get_mesh_shape_product(mesh, ShardingAxisName.MLP_DATA)
-            is_dp = (attn_dp_size // dp_size) > 1
+        mesh = _get_mesh()
+        if mesh is None:
+            return True
 
-        if is_dp:
+        moe_backend = select_moe_backend_from_fused_moe_config(self.moe_config)
+        if moe_backend not in (MoEBackend.GMM_EP, MoEBackend.GMM_TP):
+            return True
+
+        if not _gmm_and_shared_reduce_over_same_axes(mesh, moe_backend):
+            return True
+
+        return False
+
+    def _maybe_reduce_shared_expert_output(
+        self,
+        shared_output: torch.Tensor | None,
+    ) -> torch.Tensor | None:
+        """Early all-reduce path: reduce the shared-expert output on its own.
+
+        When the fused kernel already reduced its output, the shared-expert
+        output (produced unreduced by its RowParallelLinear, whose all-reduce
+        was skipped via ``reduce_results=False``) must be reduced separately so the
+        two match before being summed downstream. Under sequence parallelism a
+        separate all-gather step in the model handles this instead.
+        """
+        if (shared_output is not None
+                and not self.moe_config.is_sequence_parallel
+                and self._fused_output_is_reduced):
+            mesh = _get_mesh()
+            if mesh is not None:
+                shared_output = _all_reduce_over_tp(shared_output, mesh)
+        return shared_output
+
+    def _maybe_reduce_final_output(
+        self,
+        states: torch.Tensor,
+        trunc_size: int,
+    ) -> torch.Tensor:
+        """Late all-reduce path: reduce the combined (shared + fused) output.
+
+        When the fused kernel did not reduce its output, the shared and fused
+        outputs were summed while still unreduced and the combined result is
+        all-reduced here in a single collective instead of two. Under attention-DP the
+        reduction is handled by a separate reduce-scatter pass in the model, so
+        only the padding is stripped here.
+        """
+        if _is_attn_dp():
             return states[..., :trunc_size]
 
-        return super()._maybe_reduce_final_output(states, trunc_size)
+        if (not self.moe_config.is_sequence_parallel
+                and not self._fused_output_is_reduced):
+            mesh = _get_mesh()
+            if mesh is not None:
+                states = _all_reduce_over_tp(states, mesh)
+        return states[..., :trunc_size]
 
 
 @FusedMoE.register_oot

--- a/tpu_inference/layers/vllm/custom_ops/linear.py
+++ b/tpu_inference/layers/vllm/custom_ops/linear.py
@@ -34,6 +34,13 @@ from tpu_inference.utils import get_mesh_shape_product
 @RowParallelLinear.register_oot
 class VllmRowParallelLinear(RowParallelLinear):
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        linear_config = getattr(self.quant_method, "linear_config", None)
+        if linear_config is not None:
+            linear_config.defer_all_reduce = not self.reduce_results
+
     def forward(
         self,
         input_,

--- a/tpu_inference/layers/vllm/interface/moe.py
+++ b/tpu_inference/layers/vllm/interface/moe.py
@@ -112,6 +112,13 @@ def vllm_moe_apply(layer: RoutedExperts,
     extra_kwargs = dict(quant_method_instance.extra_backend_kwargs)
     extra_kwargs["scatter_results"] = is_dp
     extra_kwargs["moe_chunk_size"] = envs.VLLM_MOE_CHUNK_SIZE
+    # Defer the tensor-parallel all-reduce inside the GMM kernel exactly when the
+    # runner does NOT expect the fused output to be reduced -- the deferred path
+    # where the shared and fused outputs are summed and reduced together in a
+    # single collective downstream. This is the inverse of (and tied to)
+    # ``VllmMoERunner._fused_output_is_reduced`` so the two never drift.
+    extra_kwargs[
+        "defer_all_reduce"] = not layer.runner._fused_output_is_reduced
 
     if getattr(layer, "hash_indices_table", None) is not None:
         assert input_ids is not None, "input_ids must be provided when hash_indices_table is present in the layer"

--- a/tpu_inference/layers/vllm/interface/moe.py
+++ b/tpu_inference/layers/vllm/interface/moe.py
@@ -16,6 +16,8 @@ from torchax.interop import jax_view, torch_view
 from vllm.model_executor.layers.fused_moe import (FusedMoEMethodBase,
                                                   RoutedExperts)
 from vllm.model_executor.layers.fused_moe.config import FusedMoEConfig
+from vllm.model_executor.layers.fused_moe.runner.moe_runner import \
+    get_layer_from_name
 
 from tpu_inference import envs
 from tpu_inference.layers.common.moe import MoEBackend, moe_apply
@@ -112,13 +114,17 @@ def vllm_moe_apply(layer: RoutedExperts,
     extra_kwargs = dict(quant_method_instance.extra_backend_kwargs)
     extra_kwargs["scatter_results"] = is_dp
     extra_kwargs["moe_chunk_size"] = envs.VLLM_MOE_CHUNK_SIZE
+    # ``apply_monolithic`` hands us the ``RoutedExperts`` submodule, but the
+    # reduction decision lives on its parent runner. Both are built with the
+    # same ``layer_name`` and the runner registers itself in the forward context
+    # under that name, so we resolve it from there.
+    runner = get_layer_from_name(layer.layer_name)
     # Defer the tensor-parallel all-reduce inside the GMM kernel exactly when the
     # runner does NOT expect the fused output to be reduced -- the deferred path
     # where the shared and fused outputs are summed and reduced together in a
     # single collective downstream. This is the inverse of (and tied to)
     # ``VllmMoERunner._fused_output_is_reduced`` so the two never drift.
-    extra_kwargs[
-        "defer_all_reduce"] = not layer.runner._fused_output_is_reduced
+    extra_kwargs["defer_all_reduce"] = not runner._fused_output_is_reduced
 
     if getattr(layer, "hash_indices_table", None) is not None:
         assert input_ids is not None, "input_ids must be provided when hash_indices_table is present in the layer"

--- a/tpu_inference/layers/vllm/interface/moe.py
+++ b/tpu_inference/layers/vllm/interface/moe.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import torch
 from torchax.interop import jax_view, torch_view
+from vllm.forward_context import is_forward_context_available
 from vllm.model_executor.layers.fused_moe import (FusedMoEMethodBase,
                                                   RoutedExperts)
 from vllm.model_executor.layers.fused_moe.config import FusedMoEConfig
@@ -23,9 +24,8 @@ from tpu_inference import envs
 from tpu_inference.layers.common.moe import MoEBackend, moe_apply
 from tpu_inference.layers.common.process_weights.moe_weights import \
     FusedMoEWeights
-from tpu_inference.layers.common.sharding import ShardingAxisName
+from tpu_inference.layers.common.sharding import is_attn_dp
 from tpu_inference.logger import init_logger
-from tpu_inference.utils import get_mesh_shape_product
 
 logger = init_logger(__name__)
 
@@ -107,24 +107,20 @@ def vllm_moe_apply(layer: RoutedExperts,
                 pass
 
     mesh = quant_method_instance.mesh
-    attn_dp_size = get_mesh_shape_product(mesh, ShardingAxisName.ATTN_DATA)
-    dp_size = get_mesh_shape_product(mesh, ShardingAxisName.MLP_DATA)
-    is_dp = (attn_dp_size // dp_size) > 1
+    is_dp = is_attn_dp(mesh)
 
     extra_kwargs = dict(quant_method_instance.extra_backend_kwargs)
     extra_kwargs["scatter_results"] = is_dp
     extra_kwargs["moe_chunk_size"] = envs.VLLM_MOE_CHUNK_SIZE
-    # ``apply_monolithic`` hands us the ``RoutedExperts`` submodule, but the
-    # reduction decision lives on its parent runner. Both are built with the
-    # same ``layer_name`` and the runner registers itself in the forward context
-    # under that name, so we resolve it from there.
-    runner = get_layer_from_name(layer.layer_name)
+
     # Defer the tensor-parallel all-reduce inside the GMM kernel exactly when the
     # runner does NOT expect the fused output to be reduced -- the deferred path
     # where the shared and fused outputs are summed and reduced together in a
     # single collective downstream. This is the inverse of (and tied to)
     # ``VllmMoERunner._fused_output_is_reduced`` so the two never drift.
-    extra_kwargs["defer_all_reduce"] = not runner._fused_output_is_reduced
+    if is_forward_context_available():
+        runner = get_layer_from_name(layer.layer_name)
+        extra_kwargs["defer_all_reduce"] = not runner._fused_output_is_reduced
 
     if getattr(layer, "hash_indices_table", None) is not None:
         assert input_ids is not None, "input_ids must be provided when hash_indices_table is present in the layer"

--- a/tpu_inference/layers/vllm/interface/moe.py
+++ b/tpu_inference/layers/vllm/interface/moe.py
@@ -110,6 +110,13 @@ def vllm_moe_apply(layer: FusedMoE,
 
     extra_kwargs = dict(quant_method_instance.extra_backend_kwargs)
     extra_kwargs["scatter_results"] = is_dp
+    # Defer the tensor-parallel all-reduce inside the GMM kernel exactly when the
+    # runner does NOT expect the fused output to be reduced -- the deferred path
+    # where the shared and fused outputs are summed and reduced together in a
+    # single collective downstream. This is the inverse of (and tied to)
+    # ``VllmMoERunner._fused_output_is_reduced`` so the two never drift.
+    extra_kwargs[
+        "defer_all_reduce"] = not layer.runner._fused_output_is_reduced
 
     if getattr(layer, "hash_indices_table", None) is not None:
         assert input_ids is not None, "input_ids must be provided when hash_indices_table is present in the layer"

--- a/tpu_inference/layers/vllm/quantization/compressed_tensors/schemes/compressed_tensors_w4a8_fp8.py
+++ b/tpu_inference/layers/vllm/quantization/compressed_tensors/schemes/compressed_tensors_w4a8_fp8.py
@@ -240,12 +240,14 @@ class VllmCompressedTensorsW4A8Fp8(CompressedTensorsW4A8Fp8):
         weight_jax = jax_view(layer.weight)
         weight_scale_jax = jax_view(layer.weight_scale)
 
-        outs = sharded_quantized_matmul(x_jax,
-                                        weight_jax,
-                                        weight_scale_jax,
-                                        self.linear_config.weight_sharding,
-                                        mesh=self.linear_config.mesh,
-                                        x_q_dtype=jnp.float8_e4m3fn)
+        outs = sharded_quantized_matmul(
+            x_jax,
+            weight_jax,
+            weight_scale_jax,
+            self.linear_config.weight_sharding,
+            mesh=self.linear_config.mesh,
+            x_q_dtype=jnp.float8_e4m3fn,
+            defer_all_reduce=self.linear_config.defer_all_reduce)
 
         if bias is not None and not layer.skip_bias_add:
             outs += jax_view(bias)
@@ -272,6 +274,7 @@ class VllmCompressedTensorsW4A8Fp8(CompressedTensorsW4A8Fp8):
                 mesh=self.linear_config.mesh,
                 x_q_dtype=jnp.float8_e4m3fn,
                 acc_dtype=jnp.float32,
+                defer_all_reduce=self.linear_config.defer_all_reduce,
             )
 
             if bias is not None and not layer.skip_bias_add:

--- a/tpu_inference/layers/vllm/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_fp8.py
+++ b/tpu_inference/layers/vllm/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_fp8.py
@@ -248,11 +248,13 @@ class VllmCompressedTensorsW8A8Fp8(CompressedTensorsW8A8Fp8):
             outs *= weight_scale_jax
             outs = outs.astype(x_jax.dtype)
         else:
-            outs = sharded_quantized_matmul(x_jax,
-                                            weight_jax,
-                                            weight_scale_jax,
-                                            self.linear_config.weight_sharding,
-                                            mesh=self.linear_config.mesh)
+            outs = sharded_quantized_matmul(
+                x_jax,
+                weight_jax,
+                weight_scale_jax,
+                self.linear_config.weight_sharding,
+                mesh=self.linear_config.mesh,
+                defer_all_reduce=self.linear_config.defer_all_reduce)
 
         if bias is not None and not layer.skip_bias_add:
             outs += jax_view(bias)
@@ -296,7 +298,8 @@ class VllmCompressedTensorsW8A8Fp8(CompressedTensorsW8A8Fp8):
                     weight_jax,
                     weight_scale_jax,
                     self.linear_config.weight_sharding,
-                    mesh=self.linear_config.mesh)
+                    mesh=self.linear_config.mesh,
+                    defer_all_reduce=self.linear_config.defer_all_reduce)
 
             if bias is not None and not layer.skip_bias_add:
                 out += jax_view(bias[i])

--- a/tpu_inference/layers/vllm/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_fp8.py
+++ b/tpu_inference/layers/vllm/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_fp8.py
@@ -238,11 +238,13 @@ class VllmCompressedTensorsW8A8Fp8(CompressedTensorsW8A8Fp8):
             outs *= weight_scale_jax
             outs = outs.astype(x_jax.dtype)
         else:
-            outs = sharded_quantized_matmul(x_jax,
-                                            weight_jax,
-                                            weight_scale_jax,
-                                            self.linear_config.weight_sharding,
-                                            mesh=self.linear_config.mesh)
+            outs = sharded_quantized_matmul(
+                x_jax,
+                weight_jax,
+                weight_scale_jax,
+                self.linear_config.weight_sharding,
+                mesh=self.linear_config.mesh,
+                defer_all_reduce=self.linear_config.defer_all_reduce)
 
         if bias is not None and not layer.skip_bias_add:
             outs += jax_view(bias)
@@ -286,7 +288,8 @@ class VllmCompressedTensorsW8A8Fp8(CompressedTensorsW8A8Fp8):
                     weight_jax,
                     weight_scale_jax,
                     self.linear_config.weight_sharding,
-                    mesh=self.linear_config.mesh)
+                    mesh=self.linear_config.mesh,
+                    defer_all_reduce=self.linear_config.defer_all_reduce)
 
             if bias is not None and not layer.skip_bias_add:
                 out += jax_view(bias[i])

--- a/tpu_inference/layers/vllm/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_int8.py
+++ b/tpu_inference/layers/vllm/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_int8.py
@@ -201,6 +201,7 @@ class VllmCompressedTensorsW8A8Int8(CompressedTensorsW8A8Int8):
             weight_scale_jax,
             self.linear_config.weight_sharding,
             mesh=self.linear_config.mesh,
+            defer_all_reduce=self.linear_config.defer_all_reduce,
         )
         if bias is not None and not layer.skip_bias_add:
             outs += jax_view(bias)
@@ -227,6 +228,7 @@ class VllmCompressedTensorsW8A8Int8(CompressedTensorsW8A8Int8):
                 weight_scale_jax,
                 self.linear_config.weight_sharding,
                 mesh=self.linear_config.mesh,
+                defer_all_reduce=self.linear_config.defer_all_reduce,
             )
             if bias is not None and not layer.skip_bias_add:
                 out += jax_view(bias[i])

--- a/tpu_inference/layers/vllm/quantization/nvfp4.py
+++ b/tpu_inference/layers/vllm/quantization/nvfp4.py
@@ -260,11 +260,13 @@ class VllmNvfp4LinearMethod(VllmUnquantizedLinearMethod):
                      weight_scale_jax: jax.Array,
                      bias: Optional[jax.Array] = None) -> jax.Array:
 
-        outs = sharded_quantized_matmul(x,
-                                        weight_jax,
-                                        weight_scale_jax,
-                                        self.linear_config.weight_sharding,
-                                        mesh=self.linear_config.mesh)
+        outs = sharded_quantized_matmul(
+            x,
+            weight_jax,
+            weight_scale_jax,
+            self.linear_config.weight_sharding,
+            mesh=self.linear_config.mesh,
+            defer_all_reduce=self.linear_config.defer_all_reduce)
 
         if bias is not None:
             outs += bias
@@ -281,11 +283,13 @@ class VllmNvfp4LinearMethod(VllmUnquantizedLinearMethod):
         outs = []
         for i, (weight, weight_scale) in enumerate(weight_and_scale):
 
-            out = sharded_quantized_matmul(x,
-                                           weight,
-                                           weight_scale,
-                                           self.linear_config.weight_sharding,
-                                           mesh=mesh)
+            out = sharded_quantized_matmul(
+                x,
+                weight,
+                weight_scale,
+                self.linear_config.weight_sharding,
+                mesh=mesh,
+                defer_all_reduce=self.linear_config.defer_all_reduce)
 
             if bias is not None:
                 out += bias[i]

--- a/tpu_inference/layers/vllm/quantization/nvfp4.py
+++ b/tpu_inference/layers/vllm/quantization/nvfp4.py
@@ -246,11 +246,13 @@ class VllmNvfp4LinearMethod(VllmUnquantizedLinearMethod):
                      weight_scale_jax: jax.Array,
                      bias: Optional[jax.Array] = None) -> jax.Array:
 
-        outs = sharded_quantized_matmul(x,
-                                        weight_jax,
-                                        weight_scale_jax,
-                                        self.linear_config.weight_sharding,
-                                        mesh=self.linear_config.mesh)
+        outs = sharded_quantized_matmul(
+            x,
+            weight_jax,
+            weight_scale_jax,
+            self.linear_config.weight_sharding,
+            mesh=self.linear_config.mesh,
+            defer_all_reduce=self.linear_config.defer_all_reduce)
 
         if bias is not None:
             outs += bias
@@ -267,11 +269,13 @@ class VllmNvfp4LinearMethod(VllmUnquantizedLinearMethod):
         outs = []
         for i, (weight, weight_scale) in enumerate(weight_and_scale):
 
-            out = sharded_quantized_matmul(x,
-                                           weight,
-                                           weight_scale,
-                                           self.linear_config.weight_sharding,
-                                           mesh=mesh)
+            out = sharded_quantized_matmul(
+                x,
+                weight,
+                weight_scale,
+                self.linear_config.weight_sharding,
+                mesh=mesh,
+                defer_all_reduce=self.linear_config.defer_all_reduce)
 
             if bias is not None:
                 out += bias[i]


### PR DESCRIPTION
# Description

When a shared expert is sharded via TP, we can reduce communication overhead by merging its all-reduce with the FusedMoE all-reduce.

Before: `out = allreduce(shared_out) * shared_weight + allreduce(fused_out)`
After:  `out = allreduce(shared_out * shared_weight + fused_out)`

Implementation:
- `RowParallelLinear`: Wired a `reduce_results` flag to quantization method to optionally skip the all-reduce on sharded contracting axes.
- `moe_apply`: Plumbed a `defer_all_reduce` flag for FusedMoE EP/TP backends.
- `MoERunner`: Overridden to accumulate partial sums of `fused_out` and `shared_out` and defer all-reduce to after summation than initiate a combined all-reduce

# Tests

- Added new unit test `test_fused_moe.py`
- Conducted e2e profiling and correctness smoke test with `Qwen/Qwen3.5-35B-A3B-FP8`. 
  - After-fix: there are one all-reduce and all-reduce is initiated after local summation.
<img width="3024" height="1480" alt="image" src="https://github.com/user-attachments/assets/0ba603f4-cc12-4fbc-a5d4-7892e18495bf" />

# Todo 

Will conduct e2e benchmark and evaluation on `Qwen/Qwen3.5-397B-A17B-FP8`



