### PR TITLE
Implement mem_get_info for tpu_platform

### DIFF
--- a/tests/platforms/test_tpu_platform.py
+++ b/tests/platforms/test_tpu_platform.py
@@ -92,6 +92,25 @@ class TestTpuPlatform:
         with pytest.raises(NotImplementedError):
             TpuPlatform.get_device_total_memory()
 
+    @patch('tpu_inference.platforms.tpu_platform.jax.local_devices')
+    def test_mem_get_info(self, mock_local_devices):
+        mock_dev1 = MagicMock()
+        mock_dev1.memory_stats.return_value = {
+            'bytes_limit': 1000,
+            'bytes_in_use': 200
+        }
+        mock_dev2 = MagicMock()
+        mock_dev2.memory_stats.return_value = {
+            'bytes_limit': 1000,
+            'bytes_in_use': 300
+        }
+        mock_local_devices.return_value = [mock_dev1, mock_dev2]
+
+        free_mem, total_mem = TpuPlatform.mem_get_info()
+
+        assert total_mem == 2000
+        assert free_mem == 1500
+
     def test_get_infinity_values(self):
         min_val, max_val = TpuPlatform.get_infinity_values(jnp.float32)
         assert min_val == jnp.finfo(jnp.float32).min

--- a/tpu_inference/platforms/tpu_platform.py
+++ b/tpu_inference/platforms/tpu_platform.py
@@ -4,6 +4,7 @@ import os
 import random
 from typing import TYPE_CHECKING, Optional, Tuple, Union
 
+import jax
 import jax.numpy as jnp
 import numpy
 import torch
@@ -173,6 +174,25 @@ class TpuPlatform(Platform):
                 "Automatically using fp8_e5m2 for FP8 KV cache on TPU v6e.")
             return torch.float8_e5m2
         return torch.float8_e4m3fn
+
+    @classmethod
+    def mem_get_info(cls,
+                     device: Optional[torch.device] = None) -> Tuple[int, int]:
+        """
+        Returns (free_memory, total_memory) in bytes for the specified TPU device.
+        """
+        # Fetch TPU memory statistics via JAX
+        # On TPU SPMD, we need to aggregate both the limit and usage across all
+        # local devices because global tensor dimensions are used for budget calculations.
+        total_memory = 0
+        bytes_in_use = 0
+        for d in jax.local_devices():
+            stats = d.memory_stats()
+            total_memory += stats.get('bytes_limit', 0)
+            bytes_in_use += stats.get('bytes_in_use', 0)
+
+        free_memory = total_memory - bytes_in_use
+        return free_memory, total_memory
 
     @classmethod
     def get_device_total_memory(cls, device_id: int = 0) -> int:

--- a/tpu_inference/platforms/tpu_platform.py
+++ b/tpu_inference/platforms/tpu_platform.py
@@ -176,8 +176,7 @@ class TpuPlatform(Platform):
         return torch.float8_e4m3fn
 
     @classmethod
-    def mem_get_info(cls,
-                     device: Optional[torch.device] = None) -> Tuple[int, int]:
+    def mem_get_info(cls) -> Tuple[int, int]:
         """
         Returns (free_memory, total_memory) in bytes for the specified TPU device.
         """


### PR DESCRIPTION
# Description

Implement `mem_get_info` for tpu_platform . This is needed to support Gemma 4 torchax path to run multi modal benchmarks.

FIXES: #2853

# Tests

Launched gemma4 instance using torchax path and ran MMMU-pro benchmark according to commands in #2853 . No more instant crashes.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
