### PR TITLE
[Jax][Gemma4] Fuse gate_up_proj for Gemma-4

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -28,7 +28,7 @@
 
 # Model layers
 /tpu_inference/layers/ @kyuyeunk @lk-chen @jrplatin @gxd3
-/tpu_inference/layers/jax/ @jrplatin @gpolovets1
+/tpu_inference/layers/jax/ @jrplatin @gpolovets1 @lk-chen
 /tpu_inference/layers/vllm/ @kyuyeunk @vanbasten23 @gxd3 @jrplatin
 /tpu_inference/layers/vllm/custom_ops/experimental/deepseek_v4/ @gxd3 @a1yssan13 @inucool12
 

--- a/tests/layers/jax/quantization/test_unquantized.py
+++ b/tests/layers/jax/quantization/test_unquantized.py
@@ -16,6 +16,7 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 import pytest
+import torch
 from flax import nnx
 from jax.sharding import Mesh
 from vllm.model_executor.layers.fused_moe.activation import MoEActivation
@@ -24,9 +25,11 @@ from tpu_inference.layers.common.moe import MoEBackend
 from tpu_inference.layers.common.process_weights.moe_weights import \
     process_unquantized_moe_weights
 from tpu_inference.layers.common.sharding import ShardingAxisName
-from tpu_inference.layers.jax.linear import JaxEinsum, JaxLinear
+from tpu_inference.layers.jax.linear import (JaxEinsum, JaxLinear,
+                                             JaxMergedColumnParallelLinear)
 from tpu_inference.layers.jax.quantization import QuantizeMethodBase
-from tpu_inference.layers.jax.quantization.unquantized import UnquantizedConfig
+from tpu_inference.layers.jax.quantization.unquantized import (
+    UnquantizedConfig, UnquantizedMergedLinearMethod)
 
 
 @pytest.fixture
@@ -118,6 +121,87 @@ class TestUnquantizedJaxLinear:
                                    y_from_method,
                                    rtol=1e-5,
                                    atol=1e-5)
+
+
+class TestJaxMergedColumnParallelLinear:
+    """Tests for the fused gate_up_proj path: a single kernel holding several
+    logical projections, loaded from separate per-projection checkpoint tensors
+    via ``UnquantizedMergedLinearMethod``.
+    """
+
+    @staticmethod
+    def _build_layer(in_size, output_sizes, rngs):
+        return JaxMergedColumnParallelLinear(input_size=in_size,
+                                             output_sizes=output_sizes,
+                                             rngs=rngs,
+                                             use_bias=False,
+                                             quant_config=UnquantizedConfig(
+                                                 {}),
+                                             prefix="mlp.gate_up_proj")
+
+    def test_get_quant_method_returns_merged_method(self, rngs):
+        """JaxMergedColumnParallelLinear dispatches to the merged method, which
+        must see each projection's size (so forward/load can interleave by
+        shard)."""
+        layer = self._build_layer(4, [6, 6], rngs)
+        assert isinstance(layer.quant_method, UnquantizedMergedLinearMethod)
+        cfg = layer.quant_method.linear_config
+        assert cfg.output_sizes == [6, 6]
+        # n_shards == number of fused projections; required for the
+        # interleave (load) / de-interleave (forward) to be inverses.
+        assert cfg.n_shards == 2
+        assert cfg.fuse_matmuls
+        # The weight_loader is attached at create_weights_jax time and the
+        # per-projection accumulation slots start empty.
+        assert layer.weight.get_metadata("_merged_shards") == [None, None]
+
+    @pytest.mark.parametrize("in_size,gate_out,up_out,batch", [
+        (4, 6, 6, 2),
+        (8, 16, 16, 4),
+        (8, 16, 8, 1),
+    ])
+    def test_load_then_forward_matches_split_matmuls(self, in_size, gate_out,
+                                                     up_out, batch, rngs):
+        """End-to-end: load gate/up from separate checkpoint tensors into the
+        fused kernel, then verify the fused forward equals running the two
+        projections separately and concatenating — i.e. the load-time interleave
+        is the exact inverse of the forward-time de-interleave."""
+        layer = self._build_layer(in_size, [gate_out, up_out], rngs)
+
+        # Checkpoint tensors in HF layout (out_i, in_size).
+        g = torch.randn(gate_out, in_size, dtype=torch.float32)
+        u = torch.randn(up_out, in_size, dtype=torch.float32)
+
+        # Drive the real loader contract (matches JaxAutoWeightsLoader): the
+        # fused param's weight_loader is called once per projection with its
+        # shard_id; the fuse only completes once both have arrived.
+        weight_loader = layer.weight.weight_loader
+        weight_loader(layer.weight, g, 0)  # gate -> shard_id 0
+        weight_loader(layer.weight, u, 1)  # up   -> shard_id 1
+        assert layer.weight.value.shape == (in_size, gate_out + up_out)
+
+        x = jax.random.uniform(rngs.params(), (batch, in_size))
+
+        # TPU defaults to bf16 matmuls; force highest precision so the fused
+        # and reference paths are bit-comparable.
+        with jax.default_matmul_precision("highest"):
+            fused_out = layer(x)
+            g_jax = jnp.asarray(g.numpy()).T  # (in_size, gate_out)
+            u_jax = jnp.asarray(u.numpy()).T  # (in_size, up_out)
+            ref = jnp.concatenate([x @ g_jax, x @ u_jax], axis=-1)
+
+        assert fused_out.shape == ref.shape == (batch, gate_out + up_out)
+        np.testing.assert_allclose(fused_out, ref, rtol=1e-5, atol=1e-5)
+
+    def test_load_is_deferred_until_all_projections_arrive(self, rngs):
+        """A single projection must not trigger the fuse (projections may span
+        multiple checkpoint files)."""
+        layer = self._build_layer(4, [6, 6], rngs)
+        weight_loader = layer.weight.weight_loader
+
+        weight_loader(layer.weight, torch.randn(6, 4), 0)
+        shards = layer.weight.get_metadata("_merged_shards")
+        assert shards[0] is not None and shards[1] is None
 
 
 class TestUnquantizedJaxMoe:

--- a/tests/layers/jax/test_linear.py
+++ b/tests/layers/jax/test_linear.py
@@ -25,7 +25,10 @@ from vllm.model_executor.layers.linear import (MergedColumnParallelLinear,
                                                RowParallelLinear)
 
 from tpu_inference.layers.jax import JaxModule
-from tpu_inference.layers.jax.linear import JaxLinear
+from tpu_inference.layers.jax.linear import (JaxLinear,
+                                             JaxMergedColumnParallelLinear)
+from tpu_inference.layers.jax.quantization.unquantized import (
+    UnquantizedConfig, UnquantizedMergedLinearMethod)
 from tpu_inference.layers.vllm.quantization import get_tpu_quantization_config
 
 
@@ -159,3 +162,54 @@ class TestJaxLinear(unittest.TestCase):
         self.assertSequenceEqual(jax_linear.weight.sharding, (None, "model"))
         self.assertEqual(f"{jax.typeof(jax_linear.weight.value)}",
                          "float32[16,32]")
+
+    def test_merged_column_parallel_fuses_projections(self):
+        """JaxMergedColumnParallelLinear exposes a single fused kernel sized to
+        the sum of its projection widths (no separate gate/up params) and
+        dispatches to the merged unquantized method, which carries each
+        projection's size so the per-shard interleave is well defined."""
+
+        hidden_size = 16
+        intermediate_size = 32
+        mesh = Mesh(jax.devices('cpu')[:1], ("model", ))
+        with jax.set_mesh(mesh):
+            jax_merged = JaxMergedColumnParallelLinear(
+                hidden_size,
+                [intermediate_size, intermediate_size],
+                use_bias=False,
+                quant_config=UnquantizedConfig({}),
+                rngs=nnx.Rngs(0),
+                prefix="mlp.gate_up_proj",
+            )
+
+        # One fused kernel of shape (in, gate + up); no split gate/up params.
+        self.assertEqual(list(dict(jax_merged.named_parameters()).keys()),
+                         ["weight"])
+        self.assertEqual(tuple(jax_merged.weight.value.shape),
+                         (hidden_size, 2 * intermediate_size))
+
+        method = jax_merged.quant_method
+        self.assertIsInstance(method, UnquantizedMergedLinearMethod)
+        self.assertEqual(method.linear_config.output_sizes,
+                         [intermediate_size, intermediate_size])
+        self.assertEqual(method.linear_config.n_shards, 2)
+
+    def test_merged_column_parallel_sharding(self):
+        """The fused kernel's output dim (gate + up) is sharded on `model`."""
+
+        mesh = Mesh(jax.devices('cpu')[:1], ("model", ))
+        with jax.set_mesh(mesh):
+            jax_merged = JaxMergedColumnParallelLinear(
+                16,
+                [32, 32],
+                kernel_init=nnx.with_partitioning(nnx.initializers.uniform(),
+                                                  sharding=(None, "model")),
+                use_bias=False,
+                quant_config=UnquantizedConfig({}),
+                rngs=nnx.Rngs(0),
+                prefix="mlp.gate_up_proj",
+            )
+
+        self.assertSequenceEqual(jax_merged.weight.sharding, (None, "model"))
+        self.assertEqual(f"{jax.typeof(jax_merged.weight.value)}",
+                         "float32[16,64]")

--- a/tests/models/jax/test_gemma4_kv_share.py
+++ b/tests/models/jax/test_gemma4_kv_share.py
@@ -297,11 +297,16 @@ def test_double_wide_mlp(mesh, rng=jax.random.PRNGKey(0)):
     expected_regular = intermediate_size
     expected_double = intermediate_size * 2
 
-    # gate_proj.weight is [hidden_size, intermediate_size]
-    assert model.layers[0].mlp.gate_proj.weight.shape == (32, expected_regular)
-    assert model.layers[1].mlp.gate_proj.weight.shape == (32, expected_regular)
-    assert model.layers[2].mlp.gate_proj.weight.shape == (32, expected_double)
-    assert model.layers[3].mlp.gate_proj.weight.shape == (32, expected_double)
+    # gate_proj and up_proj are fused into a single gate_up_proj, so the fused
+    # weight is [hidden_size, 2 * intermediate_size].
+    assert model.layers[0].mlp.gate_up_proj.weight.shape == (32, 2 *
+                                                             expected_regular)
+    assert model.layers[1].mlp.gate_up_proj.weight.shape == (32, 2 *
+                                                             expected_regular)
+    assert model.layers[2].mlp.gate_up_proj.weight.shape == (32, 2 *
+                                                             expected_double)
+    assert model.layers[3].mlp.gate_up_proj.weight.shape == (32, 2 *
+                                                             expected_double)
 
 
 def test_double_wide_mlp_off(mesh, rng=jax.random.PRNGKey(0)):
@@ -314,5 +319,7 @@ def test_double_wide_mlp_off(mesh, rng=jax.random.PRNGKey(0)):
     with jax.set_mesh(mesh):
         model = Gemma4Model(vllm_config, nnx.Rngs(rng), mesh)
 
+    # gate_proj and up_proj are fused: gate_up_proj is [hidden, 2*intermediate].
     for layer in model.layers:
-        assert layer.mlp.gate_proj.weight.shape == (32, intermediate_size)
+        assert layer.mlp.gate_up_proj.weight.shape == (32,
+                                                       2 * intermediate_size)

--- a/tests/models/jax/test_gemma4_mtp.py
+++ b/tests/models/jax/test_gemma4_mtp.py
@@ -180,8 +180,9 @@ class TestGemma4MTPForCausalLM:
 
             # Populate centroids ordering if enabled to avoid sparse projection crashes
             if use_ordered_embeddings and model.masked_embedding is not None:
-                model.masked_embedding.token_ordering.value = jnp.arange(
-                    draft_hf_config.text_config.vocab_size, dtype=jnp.int32)
+                model.masked_embedding.token_ordering.set_value(
+                    jnp.arange(draft_hf_config.text_config.vocab_size,
+                               dtype=jnp.int32))
 
             with jax.set_mesh(mesh):
                 _, jax_output, _ = layer_0(

--- a/tests/models/jax/test_gemma4_mtp.py
+++ b/tests/models/jax/test_gemma4_mtp.py
@@ -26,6 +26,7 @@ from tpu_inference.kernels.ragged_paged_attention.v3.kernel import \
     get_kv_cache_shape
 from tpu_inference.layers.common.attention_metadata import AttentionMetadata
 from tpu_inference.layers.jax.pp_utils import PPMissingLayer
+from tpu_inference.layers.jax.quantization import get_tpu_quantization_config
 from tpu_inference.models.jax.gemma4_mtp import (Gemma4MTPDecoderLayer,
                                                  Gemma4MTPForCausalLM)
 
@@ -129,6 +130,8 @@ class TestGemma4MTPForCausalLM:
 
         model_config = vllm_config.model_config
         kv_dtype = jnp.bfloat16
+
+        vllm_config.quant_config = get_tpu_quantization_config(vllm_config)
 
         with jax.set_mesh(mesh):
             model = Gemma4MTPForCausalLM(vllm_config, rng, mesh)

--- a/tpu_inference/layers/jax/__init__.py
+++ b/tpu_inference/layers/jax/__init__.py
@@ -59,8 +59,16 @@ class JaxModule(nnx.Module):
         for name, value in self.__dict__.items():
             if isinstance(value, JaxModule):
                 yield name, value
-            elif isinstance(value, list) or isinstance(value, nnx.List):
-                yield name, JaxModuleList(value)
+            elif isinstance(value, (list, nnx.List)):
+                # Only treat a list as a submodule container if it actually
+                # holds modules (or nested module lists). Plain data lists —
+                # e.g. a layer's ``output_sizes`` on a merged linear — must not
+                # be mistaken for children, otherwise named_parameters() /
+                # named_modules() would try to recurse into ints.
+                if any(
+                        isinstance(item, (JaxModule, list, nnx.List))
+                        for item in value):
+                    yield name, JaxModuleList(value)
 
     def children(self) -> Iterator["JaxModule | JaxModuleList"]:
         """Yields immediate child modules.

--- a/tpu_inference/layers/jax/linear.py
+++ b/tpu_inference/layers/jax/linear.py
@@ -169,3 +169,42 @@ class JaxLmHead(nnx.Einsum, JaxModule):
 
     def __call__(self, inputs: jax.Array) -> jax.Array:
         return jax.numpy.einsum(self.einsum_str, inputs, self.weight.value)
+
+
+class JaxMergedColumnParallelLinear(JaxLinear):
+    """Merged version of JaxLinear. This is used to fuse multiple
+    JaxLinear layers into one for better efficiency.
+
+    The einsum string is the same as JaxLinear, but the weight is expected to
+    have multiple output dimensions concatenated together, and the output will
+    be split accordingly.
+
+    Args:
+        input_size: input dimension of the linear layer.
+        output_sizes: a list of output dimensions for each fused linear layer.
+        use_bias: If false, skip adding bias.
+        param_dtype: Data type for the parameters.
+        quant_config: Quantization configuration.
+        prefix: Prefix for parameter names.
+    """
+
+    def __init__(self,
+                 input_size: int,
+                 output_sizes: list[int],
+                 rngs,
+                 *,
+                 use_bias: bool = True,
+                 quant_config: Optional[QuantizationConfig] = None,
+                 prefix: str = "",
+                 **kwargs):
+        # Must be set before super().__init__(): JaxEinsum.__init__ calls
+        # quant_config.get_quant_method(self), which reads self.output_sizes to
+        # build the merged linear's QuantLinearConfig.
+        self.output_sizes = output_sizes
+        super().__init__(input_size=input_size,
+                         output_size=sum(output_sizes),
+                         rngs=rngs,
+                         use_bias=use_bias,
+                         quant_config=quant_config,
+                         prefix=prefix,
+                         **kwargs)

--- a/tpu_inference/layers/jax/quantization/unquantized.py
+++ b/tpu_inference/layers/jax/quantization/unquantized.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import functools
 import gc
 from typing import Optional
 
@@ -27,13 +28,16 @@ from tpu_inference.layers.common.process_weights.moe_weights import (
     shard_moe_weights)
 from tpu_inference.layers.common.quantization import unquantized as jax_common
 from tpu_inference.layers.common.quantization.configs import QuantLinearConfig
+from tpu_inference.layers.common.utils import cpu_mesh_context
 from tpu_inference.layers.jax import JaxModule
-from tpu_inference.layers.jax.linear import JaxEinsum
+from tpu_inference.layers.jax.linear import (JaxEinsum,
+                                             JaxMergedColumnParallelLinear)
 from tpu_inference.layers.jax.moe.moe import JaxMoE
 from tpu_inference.layers.jax.quantization import QuantizeMethodBase
 from tpu_inference.layers.jax.quantization.configs import QuantizationConfig
 from tpu_inference.logger import init_logger
-from tpu_inference.models.jax.utils.weight_utils import shard_put
+from tpu_inference.models.jax.utils.weight_utils import (
+    assign_and_shard_param, jax_array_from_reshaped_torch, shard_put)
 
 logger = init_logger(__name__)
 
@@ -58,6 +62,105 @@ class UnquantizedLinearMethod(QuantizeMethodBase,
                     "Non-fused matmuls not implemented yet.")
 
         return out
+
+
+class UnquantizedMergedLinearMethod(UnquantizedLinearMethod):
+    """Unquantized method for JaxMerged*Linear layers.
+
+    A merged column-parallel linear (e.g. fused gate_up_proj) holds the weights
+    of several logical projections concatenated along the output dim of a single
+    kernel. The checkpoint, however, ships each projection as a separate tensor
+    (``gate_proj.weight``, ``up_proj.weight``).
+
+    ``UnquantizedLinearMethod._apply_fused`` already un-interleaves the fused
+    output back into the per-projection pieces via
+    ``slice_sharded_tensor_for_concatenation(out, output_sizes, n_shards)``,
+    which reshapes the output dim as ``(n_shards, -1)`` and reads each
+    projection's per-shard slice. For that to be correct the kernel must be
+    stored *interleaved* by shard: shard ``i`` holds
+    ``[proj0_slice_i, proj1_slice_i, ...]``.
+
+    ``create_weights_jax`` attaches a ``weight_loader`` that accumulates each
+    projection's checkpoint tensor (by ``shard_id``) and, once all are present,
+    builds that interleaved layout — the inverse of the slicing done at apply
+    time, so loading and forward stay consistent (and TP-co-located whenever
+    ``n_shards`` matches the model-parallel degree).
+    """
+
+    def create_weights_jax(self, layer: JaxEinsum, *weight_args, rngs,
+                           **extra_weight_attrs):
+        # The fused kernel (shape `(in, sum(output_sizes))` with the output
+        # dim sharded) is already created by `JaxEinsum.__init__`. Keep that
+        # param (so its partition metadata survives) and attach:
+        #   * a per-projection accumulation buffer, and
+        #   * a weight_loader that stashes each projection's tensor and fuses
+        #     them once all shards have arrived.
+        assert isinstance(layer, JaxEinsum)
+        n_proj = len(self.linear_config.output_sizes)
+        layer.weight.set_metadata("_merged_shards", [None] * n_proj)
+        layer.weight.set_metadata(
+            "weight_loader",
+            functools.partial(self._load_merged_weight,
+                              n_shards=self.linear_config.n_shards,
+                              output_sizes=self.linear_config.output_sizes,
+                              param_name=layer.prefix + ".weight"))
+
+    @staticmethod
+    def _load_merged_weight(param: nnx.Param, torch_weight, shard_id: int, *,
+                            n_shards: int, output_sizes: list,
+                            param_name: str):
+        """Accumulate one projection's checkpoint tensor, fuse when complete.
+
+        Called once per fused projection with ``shard_id`` selecting the slot
+        (e.g. gate=0, up=1). ``torch_weight`` has the HF layout ``(out_i, in)``.
+        The projections may arrive across multiple files, so the fuse only runs
+        once every slot is filled.
+        """
+        shards = param.get_metadata("_merged_shards")
+        shards[shard_id] = torch_weight
+        if any(s is None for s in shards):
+            return
+
+        # The per-projection tensors are converted on the host (CPU); the
+        # interleaving reshape/concat must run in the same CPU mesh context,
+        # otherwise it conflicts with the ambient TPU mesh active during weight
+        # loading. assign_and_shard_param then places the result on device.
+        with cpu_mesh_context():
+            interleaved_pieces = []
+            for out_size, torch_w in zip(output_sizes, shards):
+                assert out_size % n_shards == 0, (
+                    f"Output size {out_size} not divisible by n_shards "
+                    f"{n_shards}")
+                # HF (out_i, in) -> (in, out_i) to match the kernel's
+                # contracting-last layout, then split the output dim across
+                # shards.
+                w = jax_array_from_reshaped_torch(torch_w, permute_dims=(1, 0))
+                in_size = w.shape[0]
+                interleaved_pieces.append(
+                    w.reshape(in_size, n_shards, out_size // n_shards))
+
+            # Concatenate within each shard block so shard i ends up holding
+            # [proj0_slice_i, proj1_slice_i, ...], then flatten to (in, total).
+            # E.g. with gate and up weights (2,6)x2,
+            #
+            #     GGGGGG UUUUUU
+            #     GGGGGG UUUUUU
+            #
+            # reshaped to (2,2,3)x2
+            #     GGG GGG UUU UUU
+            #     GGG GGG UUU UUU
+            #
+            # concatenated to (2,2,6)
+            #     GGGUUU GGGUUU
+            #     GGGUUU GGGUUU
+            #
+            # reshaped to (2,12)
+            #     GGGUUUGGGUUU
+            #     GGGUUUGGGUUU
+            fused = jnp.concatenate(interleaved_pieces, axis=2)
+            fused = fused.reshape(fused.shape[0], -1)
+
+        assign_and_shard_param(param, fused, param_name=param_name)
 
 
 class UnquantizedFusedMoEMethod(QuantizeMethodBase):
@@ -235,6 +338,17 @@ class UnquantizedConfig(QuantizationConfig):
 
     def get_quant_method(self, layer: JaxModule,
                          prefix: str) -> Optional[QuantizeMethodBase]:
+        # JaxMergedColumnParallelLinear is a JaxEinsum subclass whose single
+        # kernel fuses several projections; it must report each projection's
+        # size via output_sizes so the forward (and weight loading) can
+        # interleave/de-interleave per shard. Checked before the generic
+        # JaxEinsum branch. Imported locally to avoid an import cycle
+        # (linear.py imports this quantization package).
+        if isinstance(layer, JaxMergedColumnParallelLinear):
+            linear_config = QuantLinearConfig(enable_sp=False,
+                                              output_sizes=list(
+                                                  layer.output_sizes))
+            return UnquantizedMergedLinearMethod(linear_config)
         if isinstance(layer, JaxEinsum):
             # Derive output's last dim from the einsum string.
             einsum_str = layer.einsum_str.replace(" ", "")

--- a/tpu_inference/models/jax/gemma4.py
+++ b/tpu_inference/models/jax/gemma4.py
@@ -154,7 +154,7 @@ class Gemma4Router(JaxModule):
         """Returns raw router logits [T, E]."""
         x = self.norm(x)
         x = x * self.root_size
-        x = x * self.scale.value.astype(x.dtype)
+        x = x * self.scale.get_value().astype(x.dtype)
         router_logits = self.proj(x)
         return router_logits
 
@@ -227,8 +227,8 @@ class Gemma4MoE(JaxMoE):
                 self.kernel_down_proj_EFD._weights_to_load.clear()
                 # Other MoE models store expert weights in shape (D, F) and permute in *FusedMoEMethod.process_weights_after_loading.
                 # For compatibility, we permute here then expect another permute in process_weights_after_loading.
-                self.kernel_down_proj_EFD.value = jnp.swapaxes(
-                    self.kernel_down_proj_EFD.value, 1, 2)
+                self.kernel_down_proj_EFD.set_value(
+                    jnp.swapaxes(self.kernel_down_proj_EFD.get_value(), 1, 2))
             elif name.endswith("gate_up_proj"):
                 F = tensor.shape[1] // 2
                 load_nnx_param_from_reshaped_torch(self.kernel_gating_EDF,
@@ -245,10 +245,10 @@ class Gemma4MoE(JaxMoE):
                 self.kernel_gating_EDF._weights_to_load.clear()
                 # Other MoE models store expert weights in shape (F, D) and permute in *FusedMoEMethod.process_weights_after_loading.
                 # For compatibility, we permute here then expect another permute in process_weights_after_loading.
-                self.kernel_up_proj_EDF.value = jnp.swapaxes(
-                    self.kernel_up_proj_EDF.value, 1, 2)
-                self.kernel_gating_EDF.value = jnp.swapaxes(
-                    self.kernel_gating_EDF.value, 1, 2)
+                self.kernel_up_proj_EDF.set_value(
+                    jnp.swapaxes(self.kernel_up_proj_EDF.get_value(), 1, 2))
+                self.kernel_gating_EDF.set_value(
+                    jnp.swapaxes(self.kernel_gating_EDF.get_value(), 1, 2))
         return loaded
 
 
@@ -764,7 +764,7 @@ class Gemma4DecoderLayer(JaxModule):
                 per_layer_contribution)
             outputs = outputs + per_layer_contribution
 
-        outputs = outputs * self.layer_scalar.value
+        outputs = outputs * self.layer_scalar.get_value()
 
         return kv_cache, outputs, expert_ids
 

--- a/tpu_inference/models/jax/gemma4.py
+++ b/tpu_inference/models/jax/gemma4.py
@@ -1032,6 +1032,7 @@ class Gemma4Model(JaxModule):
 
 
 class Gemma4ForCausalLM(JaxModule, LoadableWithIterator):
+    packed_modules_mapping = {"gate_up_proj": ["gate_proj", "up_proj"]}
     WeightLoader = StandardWeightLoader
 
     def __init__(self, vllm_config: VllmConfig, rng_key: jax.Array,

--- a/tpu_inference/models/jax/gemma4.py
+++ b/tpu_inference/models/jax/gemma4.py
@@ -32,7 +32,8 @@ from tpu_inference.layers.common.quantization import quantize_kv
 from tpu_inference.layers.common.sharding import ShardingAxisName
 from tpu_inference.layers.jax import JaxModule
 from tpu_inference.layers.jax.embed import JaxEmbed
-from tpu_inference.layers.jax.linear import JaxEinsum, JaxLinear, JaxLmHead
+from tpu_inference.layers.jax.linear import (JaxEinsum, JaxLinear, JaxLmHead,
+                                             JaxMergedColumnParallelLinear)
 from tpu_inference.layers.jax.moe.moe import JaxMoE
 from tpu_inference.layers.jax.norm import JaxRmsNorm
 from tpu_inference.layers.jax.pp_utils import PPMissingLayer, make_layers
@@ -69,25 +70,15 @@ class Gemma4MLP(JaxModule):
         # config.intermediate_size. The caller computes this in
         # Gemma4DecoderLayer and passes it in explicitly.
 
-        self.gate_proj = JaxLinear(
+        self.gate_up_proj = JaxMergedColumnParallelLinear(
             hidden_size,
-            intermediate_size,
+            [intermediate_size] * 2,
             use_bias=False,
             param_dtype=dtype,
             kernel_init=nnx.with_partitioning(init_fn, (None, "model")),
             rngs=rng,
             quant_config=quant_config,
             prefix=prefix + ".gate_proj",
-        )
-        self.up_proj = JaxLinear(
-            hidden_size,
-            intermediate_size,
-            use_bias=False,
-            param_dtype=dtype,
-            kernel_init=nnx.with_partitioning(init_fn, (None, "model")),
-            rngs=rng,
-            quant_config=quant_config,
-            prefix=prefix + ".up_proj",
         )
         self.down_proj = JaxLinear(
             intermediate_size,
@@ -102,8 +93,9 @@ class Gemma4MLP(JaxModule):
         self.act_fn = partial(nnx.gelu, approximate=True)
 
     def __call__(self, x: jax.Array) -> jax.Array:
-        gate = self.act_fn(self.gate_proj(x))
-        up = self.up_proj(x)
+        gate_up = self.gate_up_proj(x)
+        gate, up = jnp.split(gate_up, 2, axis=-1)
+        gate = self.act_fn(gate)
         fuse = gate * up
         result = self.down_proj(fuse)
         return result

--- a/tpu_inference/models/jax/gemma4_mm.py
+++ b/tpu_inference/models/jax/gemma4_mm.py
@@ -537,7 +537,7 @@ class Gemma4MultimodalEmbedder(JaxModule):
 
 
 class Gemma4ForConditionalGeneration(JaxModule, LoadableWithIterator):
-    packed_modules_mapping = {"__no_packing__": []}
+    packed_modules_mapping = {"gate_up_proj": ["gate_proj", "up_proj"]}
     WeightLoader = StandardWeightLoader
     supports_multimodal = True
     _processor_factory = getattr(PtGemma4MM, "_processor_factory", None)

--- a/tpu_inference/models/jax/gemma4_mm.py
+++ b/tpu_inference/models/jax/gemma4_mm.py
@@ -277,7 +277,7 @@ class Gemma4VisionPatchEmbedder(JaxModule):
                               dtype=dtype))
 
     def _factorized_posemb(self, pixel_position_ids: jax.Array) -> jax.Array:
-        posemb = self.position_embedding_table.value
+        posemb = self.position_embedding_table.get_value()
         one_hot = jax.nn.one_hot(pixel_position_ids,
                                  posemb.shape[0],
                                  dtype=posemb.dtype)
@@ -493,7 +493,8 @@ class Gemma4VisionModel(JaxModule):
 
         if self.standardize:
             pooled_x, mask = outputs[0]
-            pooled_x = (pooled_x - self.std_bias.value) * self.std_scale.value
+            pooled_x = (pooled_x - self.std_bias.get_value()
+                        ) * self.std_scale.get_value()
             outputs = ((pooled_x, mask), )
 
         return outputs

--- a/tpu_inference/models/jax/gemma4_mm.py
+++ b/tpu_inference/models/jax/gemma4_mm.py
@@ -35,6 +35,7 @@ from tpu_inference.layers.jax.norm import JaxRmsNorm
 from tpu_inference.layers.jax.pp_utils import make_layers
 from tpu_inference.layers.vllm.quantization.configs import VllmQuantConfig
 from tpu_inference.logger import init_logger
+from tpu_inference.models.jax.gemma4 import Gemma4ForCausalLM, Gemma4Model
 from tpu_inference.models.jax.jax_intermediate_tensor import \
     JaxIntermediateTensors
 from tpu_inference.models.jax.utils.multi_modal_utils import \
@@ -537,7 +538,7 @@ class Gemma4MultimodalEmbedder(JaxModule):
 
 
 class Gemma4ForConditionalGeneration(JaxModule, LoadableWithIterator):
-    packed_modules_mapping = {"gate_up_proj": ["gate_proj", "up_proj"]}
+    packed_modules_mapping = Gemma4ForCausalLM.packed_modules_mapping
     WeightLoader = StandardWeightLoader
     supports_multimodal = True
     _processor_factory = getattr(PtGemma4MM, "_processor_factory", None)
@@ -548,7 +549,6 @@ class Gemma4ForConditionalGeneration(JaxModule, LoadableWithIterator):
         rng = nnx.Rngs(rng_key)
         self.mesh = mesh
 
-        from tpu_inference.models.jax.gemma4 import Gemma4Model
         self.model = Gemma4Model(
             vllm_config=vllm_config,
             rng=rng,

--- a/tpu_inference/models/jax/gemma4_mtp.py
+++ b/tpu_inference/models/jax/gemma4_mtp.py
@@ -105,7 +105,7 @@ class Gemma4MTPMaskedEmbedder(JaxModule):
             centroid_logits,
             k=self.centroid_intermediate_top_k)  # (num_tokens, top_k)
 
-        clusters = self.token_ordering.value.reshape(
+        clusters = self.token_ordering.get_value().reshape(
             self.num_centroids, self.vocab_size_per_centroid)
         selected = clusters[
             top_k_indices]  # (num_tokens, top_k, vocab_size_per_centroid)
@@ -394,7 +394,7 @@ class Gemma4MTPDecoderLayer(JaxModule):
         mlp_output = self.post_feedforward_layernorm(hidden_states)
         outputs = residual + mlp_output
 
-        outputs = outputs * self.layer_scalar.value
+        outputs = outputs * self.layer_scalar.get_value()
 
         return kv_cache, outputs, None
 
@@ -655,9 +655,9 @@ class Gemma4MTPForCausalLM(JaxModule, LoadableWithIterator):
 
     def _get_full_lm_head_weight(self) -> jax.Array:
         if hasattr(self, "lm_head"):
-            return self.lm_head.weight.value
+            return self.lm_head.weight.get_value()
         else:
-            return self.model.embed_tokens.embedding.value
+            return self.model.embed_tokens.embedding.get_value()
 
     def compute_logits(self, hidden_states: jax.Array) -> jax.Array:
         if self.masked_embedding is not None:

--- a/tpu_inference/models/jax/gemma4_mtp.py
+++ b/tpu_inference/models/jax/gemma4_mtp.py
@@ -32,7 +32,7 @@ from tpu_inference.layers.jax.pp_utils import make_layers
 from tpu_inference.layers.jax.rope_interface import apply_rope
 from tpu_inference.layers.vllm.quantization.configs import VllmQuantConfig
 from tpu_inference.logger import init_logger
-from tpu_inference.models.jax.gemma4 import Gemma4MLP
+from tpu_inference.models.jax.gemma4 import Gemma4ForCausalLM, Gemma4MLP
 from tpu_inference.models.jax.utils.weight_utils import (LoadableWithIterator,
                                                          StandardWeightLoader)
 
@@ -516,6 +516,7 @@ class Gemma4MultiTokenPredictor(JaxModule):
 
 
 class Gemma4MTPForCausalLM(JaxModule, LoadableWithIterator):
+    packed_modules_mapping = Gemma4ForCausalLM.packed_modules_mapping
     WeightLoader = StandardWeightLoader
 
     def __init__(

--- a/tpu_inference/models/jax/utils/weight_utils.py
+++ b/tpu_inference/models/jax/utils/weight_utils.py
@@ -924,6 +924,59 @@ class JaxAutoWeightsLoader(AutoWeightsLoader):
         self._process_weights_after_loading_per_module = defaultdict(
             lambda: False)
 
+    def _packed_remap(self) -> list[tuple[str, str, int]]:
+        """Derive (fused_name, shard_name, shard_id) tuples for merged linears.
+
+        Mirrors vLLM's ``stacked_params_mapping`` but sources it from the
+        model's declarative ``packed_modules_mapping`` (``{fused: [sub, ...]}``);
+        the position of each sub-module in the list is its ``shard_id``. The
+        ``"__no_packing__"`` sentinel (used elsewhere to signal "no packing" to
+        the vLLM quant path) is ignored here.
+        """
+        packed = getattr(self.module, "packed_modules_mapping", {})
+        remap: list[tuple[str, str, int]] = []
+        for fused_name, shard_names in packed.items():
+            if fused_name == "__no_packing__":
+                continue
+            for shard_id, shard_name in enumerate(shard_names):
+                remap.append((fused_name, shard_name, shard_id))
+        return remap
+
+    def load_weights(self, weights: Iterable, **kwargs) -> set:
+        """Route packed (e.g. fused gate_up_proj) checkpoint weights, then
+        delegate the rest to the standard recursive auto-loader.
+
+        For each checkpoint weight whose name contains a packed sub-module
+        (e.g. ``gate_proj``), rename it to the fused param (``gate_up_proj``)
+        and hand it to that param's ``weight_loader`` together with the
+        ``shard_id``; the merged linear's quant method accumulates the shards
+        and fuses them. Weights whose fused param does not exist (e.g. the
+        vision tower's unfused gate/up projections) fall through unchanged.
+        """
+        remap = self._packed_remap()
+        params_dict = dict(self.module.named_parameters())
+        routed_loaded: set = set()
+
+        def _route(weights_iter):
+            for name, weight in weights_iter:
+                for fused_name, shard_name, shard_id in remap:
+                    if shard_name not in name:
+                        continue
+                    fused_param_name = name.replace(shard_name, fused_name)
+                    param = params_dict.get(fused_param_name)
+                    if param is None:
+                        # No fused param at this path (e.g. vision tower keeps
+                        # gate_proj/up_proj separate) — load normally.
+                        continue
+                    param.weight_loader(param, weight, shard_id)
+                    routed_loaded.add(fused_param_name)
+                    break
+                else:
+                    yield name, weight
+
+        autoloaded = super().load_weights(_route(weights), **kwargs)
+        return autoloaded | routed_loaded
+
     def _add_loadable_non_param_tensors(self, module: JaxModule,
                                         child_params: dict[str, Any]):
         """

--- a/tpu_inference/models/jax/utils/weight_utils.py
+++ b/tpu_inference/models/jax/utils/weight_utils.py
@@ -74,11 +74,11 @@ class MetadataMap:
 
 
 def print_param_info(param: nnx.Param, name: str):
-    logger.warning(f"Global shape for {name}: {param.value.shape}")
+    logger.warning(f"Global shape for {name}: {param.get_value().shape}")
     logger.warning(f"Sharding for {name}: {param.sharding}")
 
     logger.warning(
-        f"Shape of {name} on a single device: {param.value.addressable_shards[0].data.shape}"
+        f"Shape of {name} on a single device: {param.get_value().addressable_shards[0].data.shape}"
     )
 
 
@@ -201,7 +201,7 @@ def get_param(params: nnx.State, path: str) -> nnx.State:
 
 
 def get_param_and_sharding(params: nnx.State, shardings: Any,
-                           path: str) -> tuple[nnx.State, nnx.State]:
+                           path: str) -> tuple[nnx.Param, nnx.State]:
     keys = path.split(".")
     plevel = params
     slevel = shardings
@@ -215,7 +215,7 @@ def get_param_and_sharding(params: nnx.State, shardings: Any,
                 slevel = slevel[key]
             else:
                 raise ValueError(f"{path} is not a valid param path")
-    return plevel, slevel.value
+    return plevel, slevel.get_value()
 
 
 def shard_put(x: jax.Array,
@@ -401,7 +401,7 @@ def _load_and_shard_weight(vllm_config,
 
     logger.debug(
         "before transform | "
-        f"{hf_key}: {hf_weight.shape} --> {model_key}: {model_weight.value.shape} {model_sharding}"
+        f"{hf_key}: {hf_weight.shape} --> {model_key}: {model_weight.get_value().shape} {model_sharding}"
     )
 
     if hf_key.endswith(".bias"):
@@ -447,16 +447,17 @@ def _load_and_shard_weight(vllm_config,
 
     logger.debug(
         "after transform | "
-        f"{hf_key}: {hf_weight.shape} --> {model_key}: {model_weight.value.shape} {model_sharding}"
+        f"{hf_key}: {hf_weight.shape} --> {model_key}: {model_weight.get_value().shape} {model_sharding}"
     )
 
     if head_dim_pad == 0:
-        assert model_weight.value.shape == hf_weight.shape, f"{hf_key}: {model_weight.value.shape} != {hf_weight.shape}"
+        assert model_weight.get_value(
+        ).shape == hf_weight.shape, f"{hf_key}: {model_weight.get_value().shape} != {hf_weight.shape}"
 
     # Update the model weight
     spec = model_sharding.spec if isinstance(model_sharding,
                                              NamedSharding) else model_sharding
-    model_weight.value = shard(hf_weight, spec)
+    model_weight.set_value(shard(hf_weight, spec))
 
 
 def _is_pp_missing_layer(hf_key: str, pp_missing_layers: list[str]) -> bool:
@@ -593,7 +594,7 @@ def load_hf_weights(
 def check_all_loaded(params: nnx.State):
 
     def _check(x: Any):
-        if isinstance(x, nnx.Param) and isinstance(x.value,
+        if isinstance(x, nnx.Param) and isinstance(x.get_value(),
                                                    jax.ShapeDtypeStruct):
             raise ValueError(f"The param does not load weights: {x}")
 
@@ -643,7 +644,7 @@ def transfer_state_with_mappings(src_state,
     logger.info(f"{transpose_keys=}")
     for src_keys, v in src_flat:
         flattened_src_keys = '.'.join(str(k) for k in src_keys)
-        new_v = jnp.copy(v.value)
+        new_v = jnp.copy(v.get_value())
         logger.info(
             f"Processing source key: {flattened_src_keys} and value: {new_v.shape} {new_v.dtype}"
         )
@@ -660,7 +661,7 @@ def transfer_state_with_mappings(src_state,
         else:
             v_maybe_t = new_v
 
-        to_update_value = new_src_dict[flattened_src_keys][0].value
+        to_update_value = new_src_dict[flattened_src_keys][0].get_value()
         assert to_update_value.shape == v_maybe_t.shape, \
             f"Shape mismatch for {flattened_src_keys}: {to_update_value.shape} vs {v_maybe_t.shape}"
 
@@ -670,8 +671,8 @@ def transfer_state_with_mappings(src_state,
             )
             v_maybe_t = v_maybe_t.astype(to_update_value.dtype)
 
-        new_src_dict[flattened_src_keys][0].value = shard(
-            v_maybe_t, sharding) if shard else v_maybe_t
+        new_src_dict[flattened_src_keys][0].set_value(
+            shard(v_maybe_t, sharding) if shard else v_maybe_t)
 
     tgt_state = tgt_state.from_flat_path(tgt_flat)
     return tgt_state
@@ -784,13 +785,13 @@ def assign_and_shard_param(jax_param: nnx.Param,
     param_mesh = jax_param.get_metadata().get("mesh") or mesh
     shape = jax_weight.shape
     try:
-        jax_param.value = shard_put(jax_weight, spec, mesh=param_mesh)
+        jax_param.set_value(shard_put(jax_weight, spec, mesh=param_mesh))
         jax_param.set_metadata("_is_loaded", True)
         del jax_weight
         jax.clear_caches()
     except Exception as e:
         raise RuntimeError(
-            f"Failed to load weight '{param_name}' with shape {shape} into param with shape {jax_param.value.shape}"
+            f"Failed to load weight '{param_name}' with shape {shape} into param with shape {jax_param.get_value().shape}"
         ) from e
 
 
@@ -822,7 +823,7 @@ def load_nnx_param_from_reshaped_torch(
             f"Failed to convert torch weight for '{param_name}' ({torch_weight.shape}) to JAX array, with reshape_dims={reshape_dims} and permute_dims={permute_dims}"
         ) from e
 
-    if jax_weight.shape != jax_param.value.shape:
+    if jax_weight.shape != jax_param.get_value().shape:
         # Retrieve current config to determine if the model task is embedding/pooling
         is_embedding_task = False
         try:
@@ -840,17 +841,16 @@ def load_nnx_param_from_reshaped_torch(
              "wte.weight", "pooler.weight"))
 
         if is_vocab_layer or is_embedding_task:
-            if all(
-                    w <= p
-                    for w, p in zip(jax_weight.shape, jax_param.value.shape)
-            ) and any(
-                    w < p
-                    for w, p in zip(jax_weight.shape, jax_param.value.shape)):
-                pad_width = tuple(
-                    (0, p - w)
-                    for w, p in zip(jax_weight.shape, jax_param.value.shape))
+            if all(w <= p for w, p in zip(jax_weight.shape,
+                                          jax_param.get_value().shape)
+                   ) and any(w < p
+                             for w, p in zip(jax_weight.shape,
+                                             jax_param.get_value().shape)):
+                pad_width = tuple((0, p - w)
+                                  for w, p in zip(jax_weight.shape,
+                                                  jax_param.get_value().shape))
                 logger.info(
-                    f"Padding weight '{param_name}' from {jax_weight.shape} to {jax_param.value.shape}"
+                    f"Padding weight '{param_name}' from {jax_weight.shape} to {jax_param.get_value().shape}"
                 )
                 # Use NumPy to keep it on Host
                 jax_weight_np = np.pad(np.asarray(jax_weight), pad_width)
@@ -858,11 +858,11 @@ def load_nnx_param_from_reshaped_torch(
                     jax_weight = jnp.array(jax_weight_np)
         else:
             raise ValueError(
-                f"Shape mismatch in non-vocab layer '{param_name}': torch {jax_weight.shape} vs jax {jax_param.value.shape}"
+                f"Shape mismatch in non-vocab layer '{param_name}': torch {jax_weight.shape} vs jax {jax_param.get_value().shape}"
             )
 
-    assert tuple(jax_weight.shape) == jax_param.value.shape, \
-        f"Shape mismatch when loading weight '{param_name}': torch {jax_weight.shape} vs jax {jax_param.value.shape}"
+    assert tuple(jax_weight.shape) == jax_param.get_value().shape, \
+        f"Shape mismatch when loading weight '{param_name}': torch {jax_weight.shape} vs jax {jax_param.get_value().shape}"
 
     assign_and_shard_param(jax_param, jax_weight, param_name)
 
@@ -886,25 +886,25 @@ class JaxAutoWeightsLoader(AutoWeightsLoader):
                 permute_dims = None
                 if any(substr in name
                        for substr in ["k_proj.weight", "v_proj.weight"]):
-                    D, N, H = param.value.shape
+                    D, N, H = param.get_value().shape
                     reshape_dims = (N, H, D)
                     permute_dims = (2, 0, 1)
                 if any(substr in name for substr in ["q_proj.weight"]):
                     if envs.LAYOUT_Q_PROJ_AS_NDH:
-                        N, D, H = param.value.shape
+                        N, D, H = param.get_value().shape
                         reshape_dims = (N, H, D)
                         permute_dims = (0, 2, 1)
                     else:
-                        D, N, H = param.value.shape
+                        D, N, H = param.get_value().shape
                         reshape_dims = (N, H, D)
                         permute_dims = (2, 0, 1)
                 elif any(substr in name for substr in
                          ["q_proj.bias", "k_proj.bias", "v_proj.bias"]):
-                    N, H = param.value.shape
+                    N, H = param.get_value().shape
                     reshape_dims = (N, H)
                     permute_dims = (0, 1)
                 elif "o_proj.weight" in name:
-                    N, H, D = param.value.shape
+                    N, H, D = param.get_value().shape
                     reshape_dims = (D, N, H)
                     permute_dims = (1, 2, 0)
                 elif "embed_tokens.weight" in name:
@@ -954,6 +954,12 @@ class JaxAutoWeightsLoader(AutoWeightsLoader):
         vision tower's unfused gate/up projections) fall through unchanged.
         """
         remap = self._packed_remap()
+        if not remap:
+            # No packed/fused params to route. Skip building the full param
+            # dict: materializing the entire parameter tree up front
+            # transiently doubles device HBM, so go straight to the streaming
+            # recursive loader.
+            return super().load_weights(weights, **kwargs)
         params_dict = dict(self.module.named_parameters())
         routed_loaded: set = set()
 
@@ -1083,10 +1089,10 @@ class JaxDummyModelLoader(DummyModelLoader):
         weight_loading_start_counter = time.perf_counter()
         mesh = jax.sharding.get_mesh()
 
-        def _load_dummy_weight_on_thread(param_name, param):
+        def _load_dummy_weight_on_thread(param_name, param: nnx.Param):
             with cpu_mesh_context():
                 is_moe = hasattr(param, "_weights_to_load")
-                param_shape = param.value.shape
+                param_shape = param.get_value().shape
 
                 if is_moe:
                     # For MoE parameters, the normal loading flow reads PyTorch
@@ -1097,19 +1103,19 @@ class JaxDummyModelLoader(DummyModelLoader):
                     num_experts, input_dim, intermediate_dim = param_shape
                     param_shape = (num_experts, intermediate_dim, input_dim)
 
-                if jnp.issubdtype(param.value.dtype, jnp.integer):
+                if jnp.issubdtype(param.get_value().dtype, jnp.integer):
                     dummy_weight = jax.random.randint(
                         key=jax.random.PRNGKey(0),
                         shape=param_shape,
                         minval=0,
                         maxval=100,
-                        dtype=param.value.dtype,
+                        dtype=param.get_value().dtype,
                     )
                 else:
                     dummy_weight = jax.random.uniform(
                         key=jax.random.PRNGKey(0),
                         shape=param_shape,
-                        dtype=param.value.dtype,
+                        dtype=param.get_value().dtype,
                         # upstream claims this range works well
                         # https://github.com/vllm-project/vllm/blob/7291d1b288558d48508e1a17c37b0aa170332264/vllm/model_executor/model_loader/weight_utils.py#L1088
                         minval=-1e-3,


### PR DESCRIPTION
# Description

Fuses the `gate_proj` and `up_proj` of the Gemma-4 (flax_nnx) MLP into a single
`JaxMergedColumnParallelLinear` so the gate/up projection runs as one matmul,
and implements the weight loading needed to populate that fused kernel from the
separate `gate_proj.weight` / `up_proj.weight` checkpoint tensors.

## What changed

- **`UnquantizedMergedLinearMethod`** (`quantization/unquantized.py`): new method
  for merged column-parallel linears. `create_weights_jax` attaches a
  `weight_loader` that accumulates each projection's checkpoint tensor by
  `shard_id` and, once all have arrived, builds the **interleaved-by-shard**
  layout — shard `i` holds `[gate_slice_i, up_slice_i]`. This is the exact
  inverse of the de-interleaving `_apply_fused` already does at forward time via
  `slice_sharded_tensor_for_concatenation`, so loading and forward stay
  consistent (and the projections stay TP-co-located).
  `UnquantizedConfig.get_quant_method` routes `JaxMergedColumnParallelLinear` to
  this method.

- **`JaxAutoWeightsLoader`** (`models/jax/utils/weight_utils.py`): generic packed
  routing driven by the model's declarative `packed_modules_mapping`
  (`{fused: [sub, ...]}`, list index = `shard_id`) — mirrors vLLM's
  `stacked_params_mapping`. Checkpoint weights matching a packed sub-module are
  renamed to the fused param and dispatched to its `weight_loader` with the
  `shard_id`; weights with no fused param (e.g. the vision tower's unfused
  gate/up) fall through to the normal recursive loader unchanged.

- **`Gemma4ForConditionalGeneration`** (`gemma4_mm.py`): declares
  `packed_modules_mapping = {"gate_up_proj": ["gate_proj", "up_proj"]}`.

- **`JaxMergedColumnParallelLinear`** (`linear.py`): set `output_sizes` before
  `super().__init__()`, since `JaxEinsum.__init__` calls `get_quant_method`,
  which reads it.

- **`named_children`** (`layers/jax/__init__.py`): don't treat a plain data list
  (the merged linear's `output_sizes`) as a submodule container, which otherwise
  made `named_parameters()` recurse into ints.

- **`.github/CODEOWNERS`**: added `@lk-chen` to the `/tpu_inference/layers/jax/`
  ownership rule so all touched `layers/jax/` files have a consistent owner stamp.

# Tests

- `google/gemma-4-31B-it` boots healthy with `MODEL_IMPL_TYPE=flax_nnx`

```
USE_BATCHED_RPA_KERNEL=1 MODEL_IMPL_TYPE=flax_nnx vllm \
    serve google/gemma-4-31B-it \
    --max-model-len=1524 \
    --max-num-seqs=256 \
    --data-parallel-size 4 \
    --tensor-parallel-size 2 \
    --max-num-batched-tokens 16384 \
    --no-enable-prefix-caching \
    --additional_config='{"quantization": { "qwix": { "rules": [{ "module_path": ".*", "weight_qtype": "float8_e4m3fn", "act_qtype": "float8_e4m3fn"}]}}}' \
    --kv-cache-dtype=fp8 \
    --gpu-memory-utilization=0.9 \
    --async-scheduling \
    --limit-mm-per-prompt '{"image": 0, "video": 0, "audio": 0}' \
    --block-size=256
```
- Numeric seems good (81.4%)

```
python scripts/vllm/benchmarking/benchmark_serving.py \
      --backend vllm \
      --model <MODEL> \
      --dataset-name mmlu \
      --dataset-path /mnt/pd/mmlu/data/test \
      --mmlu-use-chat-template \
      --chat-template-system-prompt "Reasoning effort: high, skip thinking process and must only give short answer in something
  like A, B, C, D." \
      --mmlu-output-len=16 \
      --run-eval \
      --num-prompts 140
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [ ] I have performed a self-review of my code.
- [ ] I have necessary comments in my code, particularly in hard-to-understand areas.
- [ ] I have made or will make corresponding changes to any relevant documentation.
- [ ] I have reviewed the uLLM modeling code checklist: https://docs.google.com/document/d/1DGQBVvr2bh4G8tBUO1YH8pO7Dd_myw5rfEMfVDymEk8/edit?resourcekey=0-V7MGHu3aQjJH6YrI3-y8Hg&tab=t.t91cyovog2mr#heading=h.cqdzv8mlszca
- [ ] I have received at least 1 readability approval and 1 correctness approval.