### PR TITLE
Fix continue decode compilation

### DIFF
--- a/tpu_inference/runner/compilation_manager.py
+++ b/tpu_inference/runner/compilation_manager.py
@@ -264,6 +264,7 @@ class CompilationManager:
                     self._flush_compilations()
                 if self.runner.enable_continue_decode:
                     self._precompile_continue_decode()
+                    self._flush_compilations()
         finally:
             self._finalize_compilation()
         elapsed = time.perf_counter() - compilation_start_time
@@ -1740,6 +1741,11 @@ class CompilationManager:
                 self.runner.kv_caches = final_kv_caches
                 return generated_tokens
 
+            def continue_decode_warmup(_fn, _args, _call_kwargs):
+                new_args = list(_args)
+                new_args[7] = self.runner.kv_caches
+                return _fn(*new_args, **_call_kwargs)
+
             self._run_compilation(
                 f"worker{self.runner.rank} continue_decode_steps_{user_max_decode_steps}_reqs_{num_reqs}",
                 continue_decode_wrapper,
@@ -1764,4 +1770,5 @@ class CompilationManager:
                 self.runner.dp_size,
                 getattr(self.runner.vllm_config.model_config,
                         "enable_return_routed_experts", False),
+                warmup_handler=continue_decode_warmup,
             )


### PR DESCRIPTION
# Description

Follow up to https://github.com/vllm-project/tpu-inference/pull/2507. Add missing `flush_compilation` call and warm up handler for continue decode precompilation

# Tests

Before:
```
To replicate server manually, run:
  VLLM_LOGGING_LEVEL=DEBUG LLM_XLA_CHECK_RECOMPILATION=1 MODEL_IMPL_TYPE=vllm vllm serve Qwen/Qwen1.5-MoE-A2.7B --max-model-len=2048 --max-num-batched-tokens 2048 --max-num-seqs 256 --tensor-parallel-size 4 --data-parallel-size 2 --no-async-scheduling --additional-config='{"enable_continue_decode": true, "max_decode_steps": 10}'

To replicate client manually, run:
  python /home/piv_google_com/tpu/tpu-inference/scripts/vllm/benchmarking/benchmark_serving.py --backend vllm --model Qwen/Qwen1.5-MoE-A2.7B --dataset-name random --num-prompts 1000 --random-input-len 512 --random-output-len 512 --random-range-ratio=0.8

============ Serving Benchmark Result ============
Successful requests:                     1000
Benchmark duration (s):                  59.72
Total input tokens:                      509234
Total generated tokens:                  487415
Request throughput (req/s):              16.74
Output token throughput (tok/s):         8161.29
Total token throughput (tok/s):          16687.92
---------------Time to First Token----------------
Mean TTFT (ms):                          19422.70
Median TTFT (ms):                        21131.46
P99 TTFT (ms):                           42731.61
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          30.77
Median TPOT (ms):                        23.12
P99 TPOT (ms):                           126.96
---------------Inter-token Latency----------------
Mean ITL (ms):                           114.29
Median ITL (ms):                         40.44
P99 ITL (ms):                            2889.53
----------------End-to-end Latency----------------
Mean E2EL (ms):                          32943.63
Median E2EL (ms):                        33800.95
P99 E2EL (ms):                           58751.23
==================================================
Actual Steps Statistics (Total runs: 676):
  Average steps: 9.81
  Distribution:
    1 steps: 5 times (0.74%) | Avg active reqs: 230.2 | Latency: avg 16.7ms, min 15.7ms, max 17.8ms, std 0.8ms, p99 17.8ms | Reasons: eos_hit: 5
    2 steps: 4 times (0.59%) | Avg active reqs: 230.8 | Latency: avg 31.2ms, min 28.2ms, max 33.1ms, std 1.9ms, p99 33.1ms | Reasons: eos_hit: 4
    3 steps: 4 times (0.59%) | Avg active reqs: 223.0 | Latency: avg 44.4ms, min 41.0ms, max 48.3ms, std 3.2ms, p99 48.3ms | Reasons: eos_hit: 4
    4 steps: 1 times (0.15%) | Avg active reqs: 256.0 | Latency: avg 63.1ms, min 63.1ms, max 63.1ms, std 0.0ms, p99 63.1ms | Reasons: eos_hit: 1
    5 steps: 1 times (0.15%) | Avg active reqs: 256.0 | Latency: avg 79.4ms, min 79.4ms, max 79.4ms, std 0.0ms, p99 79.4ms | Reasons: eos_hit: 1
    7 steps: 2 times (0.30%) | Avg active reqs: 252.0 | Latency: avg 108.3ms, min 108.0ms, max 108.6ms, std 0.3ms, p99 108.6ms | Reasons: eos_hit: 2
    8 steps: 2 times (0.30%) | Avg active reqs: 256.0 | Latency: avg 124.1ms, min 122.2ms, max 125.9ms, std 1.8ms, p99 125.9ms | Reasons: eos_hit: 2
    9 steps: 1 times (0.15%) | Avg active reqs: 256.0 | Latency: avg 139.6ms, min 139.6ms, max 139.6ms, std 0.0ms, p99 139.6ms | Reasons: eos_hit: 1
    10 steps: 656 times (97.04%) | Avg active reqs: 61.4 | Latency: avg 105.7ms, min 31.0ms, max 2986.9ms, std 344.4ms, p99 2826.3ms | Reasons: max_decode_steps_limit: 656
-----------------------------------------------------------
```
After:
```
============ Serving Benchmark Result ============
Successful requests:                     1000
Benchmark duration (s):                  39.34
Total input tokens:                      509234
Total generated tokens:                  484999
Request throughput (req/s):              25.42
Output token throughput (tok/s):         12328.22
Total token throughput (tok/s):          25272.47
---------------Time to First Token----------------
Mean TTFT (ms):                          12109.10
Median TTFT (ms):                        9246.85
P99 TTFT (ms):                           30849.09
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          22.12
Median TPOT (ms):                        20.81
P99 TPOT (ms):                           51.98
---------------Inter-token Latency----------------
Mean ITL (ms):                           82.50
Median ITL (ms):                         39.95
P99 ITL (ms):                            171.04
----------------End-to-end Latency----------------
Mean E2EL (ms):                          21966.68
Median E2EL (ms):                        22820.75
P99 E2EL (ms):                           38641.78
==================================================
Actual Steps Statistics (Total runs: 668):
  Average steps: 9.76
  Distribution:
    1 steps: 3 times (0.45%) | Avg active reqs: 256.0 | Latency: avg 17.2ms, min 17.0ms, max 17.5ms, std 0.2ms, p99 17.5ms | Reasons: eos_hit: 3
    2 steps: 5 times (0.75%) | Avg active reqs: 256.0 | Latency: avg 32.8ms, min 32.6ms, max 33.0ms, std 0.1ms, p99 33.0ms | Reasons: eos_hit: 5
    3 steps: 7 times (1.05%) | Avg active reqs: 249.3 | Latency: avg 47.2ms, min 43.6ms, max 48.9ms, std 1.7ms, p99 48.9ms | Reasons: eos_hit: 7
    4 steps: 3 times (0.45%) | Avg active reqs: 232.3 | Latency: avg 59.6ms, min 57.7ms, max 62.6ms, std 2.2ms, p99 62.6ms | Reasons: eos_hit: 3
    6 steps: 3 times (0.45%) | Avg active reqs: 242.3 | Latency: avg 90.6ms, min 84.1ms, max 94.6ms, std 4.6ms, p99 94.6ms | Reasons: eos_hit: 3
    7 steps: 2 times (0.30%) | Avg active reqs: 239.5 | Latency: avg 104.4ms, min 99.5ms, max 109.3ms, std 4.9ms, p99 109.3ms | Reasons: eos_hit: 2
    8 steps: 1 times (0.15%) | Avg active reqs: 162.0 | Latency: avg 97.9ms, min 97.9ms, max 97.9ms, std 0.0ms, p99 97.9ms | Reasons: eos_hit: 1
    9 steps: 4 times (0.60%) | Avg active reqs: 256.0 | Latency: avg 139.1ms, min 138.2ms, max 139.9ms, std 0.6ms, p99 139.9ms | Reasons: eos_hit: 4
    10 steps: 640 times (95.81%) | Avg active reqs: 60.6 | Latency: avg 62.8ms, min 30.9ms, max 157.3ms, std 47.1ms, p99 157.0ms | Reasons: max_decode_steps_limit: 640
-----------------------------------------------------------
```

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
