### PR TITLE
Transpose KV to reduce HBM footprint for KV cache.

### DIFF
--- a/tests/layers/vllm/backends/test_flash_attn_mla.py
+++ b/tests/layers/vllm/backends/test_flash_attn_mla.py
@@ -248,6 +248,57 @@ class TestPallasMLAttentionBackendImpl:
         assert outputs is not None
         assert new_kv_cache is not None
 
+    @patch("tpu_inference.envs.MLA_TRANSPOSE_KV_CACHE", True)
+    def test_forward_with_transpose_kv_cache(self, mesh):
+        impl = PallasMLAttentionBackendImpl(
+            num_heads=NUM_HEADS,
+            head_size=KV_LORA_RANK + QK_ROPE_HEAD_DIM,
+            scale=0.088,
+            num_kv_heads=1,
+            alibi_slopes=None,
+            sliding_window=None,
+            kv_cache_dtype="auto",
+            logits_soft_cap=None,
+            attn_type=AttentionType.DECODER,
+            kv_sharing_target_layer_name=None,
+            q_lora_rank=Q_LORA_RANK,
+            kv_lora_rank=KV_LORA_RANK,
+            qk_nope_head_dim=QK_NOPE_HEAD_DIM,
+            qk_rope_head_dim=QK_ROPE_HEAD_DIM,
+            qk_head_dim=QK_NOPE_HEAD_DIM + QK_ROPE_HEAD_DIM,
+            v_head_dim=V_HEAD_DIM,
+        )
+
+        layer = MagicMock()
+        layer.kv_cache_quantized_dtype = None
+
+        # block_size=128 is required for transpose_kv_cache to work.
+        q, kv_c_normed, k_pe, kv_cache, metadata = create_mla_inputs(
+            mesh, block_size=128)
+
+        with torchax.default_env():
+            key = jax.random.key(0)
+            layer.W_UK_T = torchax.tensor.Tensor(jax.random.normal(
+                key, (NUM_HEADS, QK_NOPE_HEAD_DIM, KV_LORA_RANK),
+                dtype=jnp.bfloat16),
+                                                 env=torchax.default_env())
+            layer.W_UV = torchax.tensor.Tensor(
+                jax.random.normal(key, (NUM_HEADS, KV_LORA_RANK, V_HEAD_DIM),
+                                  dtype=jnp.bfloat16),
+                env=torchax.default_env())
+            layer.W_UK_T_scale = torchax.tensor.Tensor(
+                jnp.ones((NUM_HEADS, 1, KV_LORA_RANK), dtype=jnp.float32),
+                env=torchax.default_env())
+            layer.W_UV_scale = torchax.tensor.Tensor(jnp.ones(
+                (1, NUM_HEADS, V_HEAD_DIM), dtype=jnp.float32),
+                                                     env=torchax.default_env())
+            outputs, new_kv_cache = impl.forward(q, kv_c_normed, k_pe,
+                                                 kv_cache, metadata, mesh,
+                                                 layer)
+
+        assert outputs is not None
+        assert new_kv_cache is not None
+
     def test_forward_with_fp8_kv_cache(self, mesh):
         impl = PallasMLAttentionBackendImpl(
             num_heads=NUM_HEADS,

--- a/tpu_inference/envs.py
+++ b/tpu_inference/envs.py
@@ -399,6 +399,8 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # use VMEM size as the threshold.
     "SC_ALLREDUCE_ALLGATHER_OFFLOAD_MIN_BYTES":
     lambda: os.getenv("SC_ALLREDUCE_ALLGATHER_OFFLOAD_MIN_BYTES", "auto"),
+    "MLA_TRANSPOSE_KV_CACHE":
+    env_bool("MLA_TRANSPOSE_KV_CACHE", default=False),
 }
 
 

--- a/tpu_inference/kernels/mla/v2/kernel.py
+++ b/tpu_inference/kernels/mla/v2/kernel.py
@@ -86,7 +86,16 @@ def get_kv_cache_shape(
     kv_dim,
     kv_dtype,
     kv_packing: int | None = None,
+    transpose_kv_cache: bool = False,
 ):
+    if transpose_kv_cache:
+        assert page_size % 128 == 0
+        return (
+            total_num_pages,
+            kv_dim,
+            page_size,
+        )
+
     if kv_packing is None:
         kv_packing = get_dtype_packing(kv_dtype)
     return (
@@ -206,10 +215,10 @@ def static_validate_inputs(
             kv_dim,
             _,
         ) = cache_kv.shape
-
-    if lkv_dim + r_dim != kv_dim:
+    aligned_kv_dim = align_to(kv_dim, 128)
+    if lkv_dim + r_dim != aligned_kv_dim:
         raise ValueError(
-            f"Expected {lkv_dim=} + {r_dim=} to be equal to {kv_dim=}")
+            f"Expected {lkv_dim=} + {r_dim=} to be equal to {aligned_kv_dim=}")
 
     if not (cache_kv.dtype == new_kv_c.dtype):
         raise ValueError(
@@ -347,7 +356,8 @@ def _mla_ragged_paged_attention_kernel(
         ) = cache_kv_hbm_ref.shape
         bkv_sz = bkv_p * page_size
         page_size_per_lane = page_size // 128
-    assert nope_dim + pe_dim == kv_dim
+    assert nope_dim + pe_dim == align_to(kv_dim, 128)
+    kv_r_dim = kv_dim - nope_dim
 
     max_num_seqs = kv_lens_ref.shape[0]
     num_page_indices = page_indices_ref.shape[0]
@@ -629,10 +639,13 @@ def _mla_ragged_paged_attention_kernel(
 
         if p_same_dtype_as_v:
             p = p.astype(v.dtype)
-        pv = jnp.einsum("nm,md->nd" if not transpose_kv_cache else "nm,dm->nd",
-                        p,
-                        v,
-                        preferred_element_type=jnp.float32)
+        if transpose_kv_cache:
+            v = v.transpose((1, 0))
+            # Bitcast trick to prevent transpose merge into vmatpush.xpose.
+            # It enforce transpose using XLUs (vxpose.xlu).
+            v = pltpu.bitcast(v, v.dtype)
+
+        pv = jnp.einsum("nm,md->nd", p, v, preferred_element_type=jnp.float32)
 
         if v_scale is not None:
             pv *= v_scale
@@ -754,7 +767,8 @@ def _mla_ragged_paged_attention_kernel(
                             nope_dim:,
                             pl.ds(0, copy_len),
                         ],
-                        bkvpe_vmem_ref.at[:, pl.ds(i * page_size, copy_len)],
+                        bkvpe_vmem_ref.at[:kv_r_dim,
+                                          pl.ds(i * page_size, copy_len)],
                         sem,
                         wait,
                     )
@@ -813,12 +827,12 @@ def _mla_ragged_paged_attention_kernel(
                     wait,
                 )
                 _async_copy(
-                    new_k_pe_hbm_ref.at[:,
+                    new_k_pe_hbm_ref.at[:kv_r_dim,
                                         pl.ds(
                                             aligned_new_kv_len_start,
                                             aligned_new_kv_len_size,
                                         )],
-                    bkvpe_vmem_ref.at[:,
+                    bkvpe_vmem_ref.at[:kv_r_dim,
                                       pl.ds(
                                           new_kv_start_idx,
                                           aligned_new_kv_len_size,
@@ -838,7 +852,7 @@ def _mla_ragged_paged_attention_kernel(
                     sem=sem,
                     wait=True,
                 )
-                dst_kvpe = bkvpe_vmem_ref.at[:, pl.ds(0, dma_sz)]
+                dst_kvpe = bkvpe_vmem_ref.at[:kv_r_dim, pl.ds(0, dma_sz)]
                 _async_copy(
                     src=dst_kvpe,
                     dst=dst_kvpe,
@@ -1310,7 +1324,7 @@ def _mla_ragged_paged_attention_kernel(
                 _async_copy(
                     # bkvpe_vmem_ref shape:
                     # [r_dim_per_kv_packing, kv_packing, bkv_sz]
-                    bkvpe_vmem_ref.at[...,
+                    bkvpe_vmem_ref.at[:kv_r_dim,
                                       pl.ds(curr_word_in_vmem * 128, sz_words *
                                             128)],
                     updated_cache_kv_hbm_ref.at[page_idx, nope_dim:,
@@ -1341,7 +1355,7 @@ def _mla_ragged_paged_attention_kernel(
                 sem=sem,
                 wait=True,
             )
-            dst_kv_pe = bkvpe_vmem_ref.at[..., pl.ds(0, dma_sz_words)]
+            dst_kv_pe = bkvpe_vmem_ref.at[:kv_r_dim, pl.ds(0, dma_sz_words)]
             _async_copy(
                 src=dst_kv_pe,
                 dst=dst_kv_pe,

--- a/tpu_inference/layers/common/attention_interface.py
+++ b/tpu_inference/layers/common/attention_interface.py
@@ -571,7 +571,8 @@ def mla_attention(
             decode_batch_size=decode_batch_size,
             q_scale=q_scale,
             k_scale=k_scale,
-            v_scale=v_scale)
+            v_scale=v_scale,
+            transpose_kv_cache=envs.MLA_TRANSPOSE_KV_CACHE)
 
         return new_cache, out
 

--- a/tpu_inference/runner/kv_cache.py
+++ b/tpu_inference/runner/kv_cache.py
@@ -68,8 +68,13 @@ def get_kv_cache_shape_with_mesh(mesh: Mesh,
         # so actual_num_kv_heads is never used in mla.get_kv_cache_shape().
         get_kv_cache_shape_fn = mla.get_kv_cache_shape
         shape = list(
-            get_kv_cache_shape_fn(total_num_pages, block_size, actual_head_dim,
-                                  kv_dtype, envs.MLA_KV_PACKING_SIZE))
+            get_kv_cache_shape_fn(
+                total_num_pages,
+                block_size,
+                actual_head_dim,
+                kv_dtype,
+                envs.MLA_KV_PACKING_SIZE,
+                transpose_kv_cache=envs.MLA_TRANSPOSE_KV_CACHE))
     else:
         assert actual_num_kv_heads % model_cnt == 0
         get_kv_cache_shape_fn = (

--- a/tpu_inference/runner/kv_cache_manager.py
+++ b/tpu_inference/runner/kv_cache_manager.py
@@ -35,6 +35,7 @@ from vllm.v1.kv_cache_interface import (FullAttentionSpec, KVCacheConfig,
                                         KVCacheSpec, MambaSpec,
                                         MLAAttentionSpec, SlidingWindowSpec)
 
+from tpu_inference import envs as tpu_envs
 from tpu_inference import utils
 from tpu_inference import utils as common_utils
 from tpu_inference.layers.common.sharding import ShardingAxisName
@@ -459,9 +460,12 @@ class KVCacheManager:
                 qk_rope_head_dim = getattr(text_config, "qk_rope_head_dim", 0)
                 padded_kv_lora_rank = common_utils.align_to(
                     text_config.kv_lora_rank, 128)
-                padded_qk_rope_head_dim = common_utils.align_to(
-                    qk_rope_head_dim, 128)
-                mla_head_size = padded_kv_lora_rank + padded_qk_rope_head_dim
+                if tpu_envs.MLA_TRANSPOSE_KV_CACHE:
+                    mla_qk_rope_head_dim = qk_rope_head_dim
+                else:
+                    mla_qk_rope_head_dim = common_utils.align_to(
+                        qk_rope_head_dim, 128)
+                mla_head_size = padded_kv_lora_rank + mla_qk_rope_head_dim
 
         if len(self.runner.vllm_config.compilation_config.
                static_forward_context) == 0:


### PR DESCRIPTION
# Description

Transpose KV cache and reduce KV cache footprint by removing paddings.
(512 + 128 (padded)) to (512 + 64).


# Tests

It enables bsz=128 per core 1k/8k benchmark for the single host without any preemption.

```
For 1k/8k benchmark:
(number of blocks required for bsz=112) = 1008 = (112 * 9)
(number of blocks required for bsz=128) = 1152 = (128 * 9)

(number of blocks with `--gpu-memory-utilization=0.98` on HEAD) = 1058
(number of blocks with `--gpu-memory-utilization=0.98` with transpose KV cache) = 1175
```

With this PR, bsz=128

```
============ Serving Benchmark Result ============
Successful requests:                     1024      
Failed requests:                         0         
Benchmark duration (s):                  645.23    
Total input tokens:                      1048576   
Total generated tokens:                  8388608   
Request throughput (req/s):              1.59      
Output token throughput (tok/s):         13000.88  
Peak output token throughput (tok/s):    16384.00  
Peak concurrent requests:                1024.00   
Total token throughput (tok/s):          14625.99  
---------------Time to First Token----------------
Mean TTFT (ms):                          24551.81  
Median TTFT (ms):                        24368.33  
P99 TTFT (ms):                           47316.72  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          75.17     
Median TPOT (ms):                        75.23     
P99 TPOT (ms):                           77.24     
---------------Inter-token Latency----------------
Mean ITL (ms):                           75.17     
Median ITL (ms):                         72.63     
P99 ITL (ms):                            159.60    
==================================================
```


Baseline (HEAD), bsz=112
```
============ Serving Benchmark Result ============
Successful requests:                     896       
Failed requests:                         0         
Benchmark duration (s):                  593.98    
Total input tokens:                      917504    
Total generated tokens:                  7340032   
Request throughput (req/s):              1.51      
Output token throughput (tok/s):         12357.43  
Peak output token throughput (tok/s):    15232.00  
Peak concurrent requests:                896.00    
Total token throughput (tok/s):          13902.11  
---------------Time to First Token----------------
Mean TTFT (ms):                          21200.68  
Median TTFT (ms):                        20761.58  
P99 TTFT (ms):                           40709.40  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          69.39     
Median TPOT (ms):                        69.47     
P99 TPOT (ms):                           71.20     
---------------Inter-token Latency----------------
Mean ITL (ms):                           69.39     
Median ITL (ms):                         67.27     
P99 ITL (ms):                            137.88    
==================================================
```