### PR TITLE
Support combining KV connector metadata and rank-slicing in DPScheduler

### DIFF
--- a/tests/core/test_dp_scheduler.py
+++ b/tests/core/test_dp_scheduler.py
@@ -22,7 +22,7 @@ from vllm.v1.core.sched.output import CachedRequestData, SchedulerOutput
 from vllm.v1.core.sched.scheduler import Scheduler
 from vllm.v1.kv_cache_interface import KVCacheConfig
 from vllm.v1.metrics.stats import PrefixCacheStats, SchedulerStats
-from vllm.v1.outputs import LogprobsLists, ModelRunnerOutput
+from vllm.v1.outputs import KVConnectorOutput, LogprobsLists, ModelRunnerOutput
 from vllm.v1.request import Request
 
 from tpu_inference.core.sched.dp_scheduler import (
@@ -851,7 +851,7 @@ class TestDPScheduler:
             prompt_logprobs_dict={"req2": MagicMock()},
             pooler_output=None,
             num_nans_in_logits=None,
-            kv_connector_output=MagicMock(),
+            kv_connector_output=MagicMock(invalid_block_ids=set()),
         )
 
         outputs = scheduler._split_model_output_by_rank(
@@ -996,6 +996,142 @@ class TestDPScheduler:
                                       np.array([1, 2, 6]))
         assert sliced.cu_num_generated_tokens == [0, 2, 3]
 
+    def test_split_model_output_by_rank_with_kv_connector(
+            self, mock_vllm_config, mock_kv_cache_config,
+            mock_structured_output_manager):
+        """Test _split_model_output_by_rank correctly filters kv_connector_output by rank."""
+        scheduler = self._create_scheduler(mock_vllm_config,
+                                           mock_kv_cache_config,
+                                           mock_structured_output_manager)
+
+        scheduler.assigned_dp_rank = {"req1": 0, "req2": 1, "req3": 0}
+
+        scheduler_output = DPSchedulerOutput(
+            scheduled_new_reqs=[],
+            scheduled_cached_reqs=CachedRequestData.make_empty(),
+            num_scheduled_tokens={
+                "req1": 5,
+                "req2": 10,
+                "req3": 3
+            },
+            total_num_scheduled_tokens=18,
+            scheduled_spec_decode_tokens={},
+            scheduled_encoder_inputs={},
+            num_common_prefix_blocks=[],
+            finished_req_ids=set(),
+            free_encoder_mm_hashes=set(),
+            assigned_dp_rank={
+                "req1": 0,
+                "req2": 1,
+                "req3": 0
+            },
+            max_num_scheduled_tokens_per_dp_rank=10,
+            req_ids_per_rank={
+                0: ["req1", "req3"],
+                1: ["req2"]
+            },
+        )
+
+        kv_connector_output = KVConnectorOutput(
+            finished_sending={"req1", "req2"},
+            finished_recving={"req2", "req3"},
+            invalid_block_ids=set(),
+        )
+
+        model_runner_output = ModelRunnerOutput(
+            req_ids=["req1", "req2", "req3"],
+            req_id_to_index={
+                "req1": 0,
+                "req2": 1,
+                "req3": 2
+            },
+            sampled_token_ids=[[42], [99], [77]],
+            logprobs=None,
+            prompt_logprobs_dict={},
+            pooler_output=None,
+            num_nans_in_logits=None,
+            kv_connector_output=kv_connector_output,
+        )
+
+        outputs = scheduler._split_model_output_by_rank(
+            scheduler_output, model_runner_output)
+
+        assert len(outputs) == 2
+
+        # Rank 0 should have req1, req3
+        assert outputs[0].kv_connector_output is not None
+        assert outputs[0].kv_connector_output.finished_sending == {"req1"}
+        assert outputs[0].kv_connector_output.finished_recving == {"req3"}
+
+        # Rank 1 should have req2
+        assert outputs[1].kv_connector_output is not None
+        assert outputs[1].kv_connector_output.finished_sending == {"req2"}
+        assert outputs[1].kv_connector_output.finished_recving == {"req2"}
+
+    def test_split_model_output_by_rank_with_invalid_blocks_raises_assertion_error(
+            self, mock_vllm_config, mock_kv_cache_config,
+            mock_structured_output_manager):
+        """Test _split_model_output_by_rank raises AssertionError if invalid_block_ids is not empty in DP mode."""
+        scheduler = self._create_scheduler(mock_vllm_config,
+                                           mock_kv_cache_config,
+                                           mock_structured_output_manager)
+
+        scheduler.assigned_dp_rank = {"req1": 0, "req2": 1, "req3": 0}
+
+        scheduler_output = DPSchedulerOutput(
+            scheduled_new_reqs=[],
+            scheduled_cached_reqs=CachedRequestData.make_empty(),
+            num_scheduled_tokens={
+                "req1": 5,
+                "req2": 10,
+                "req3": 3
+            },
+            total_num_scheduled_tokens=18,
+            scheduled_spec_decode_tokens={},
+            scheduled_encoder_inputs={},
+            num_common_prefix_blocks=[],
+            finished_req_ids=set(),
+            free_encoder_mm_hashes=set(),
+            assigned_dp_rank={
+                "req1": 0,
+                "req2": 1,
+                "req3": 0
+            },
+            max_num_scheduled_tokens_per_dp_rank=10,
+            req_ids_per_rank={
+                0: ["req1", "req3"],
+                1: ["req2"]
+            },
+        )
+
+        kv_connector_output = KVConnectorOutput(
+            finished_sending={"req1", "req2"},
+            finished_recving={"req2", "req3"},
+            invalid_block_ids={1, 2},  # Non-empty, should trigger assertion
+        )
+
+        model_runner_output = ModelRunnerOutput(
+            req_ids=["req1", "req2", "req3"],
+            req_id_to_index={
+                "req1": 0,
+                "req2": 1,
+                "req3": 2
+            },
+            sampled_token_ids=[[42], [99], [77]],
+            logprobs=None,
+            prompt_logprobs_dict={},
+            pooler_output=None,
+            num_nans_in_logits=None,
+            kv_connector_output=kv_connector_output,
+        )
+
+        with pytest.raises(AssertionError) as exc_info:
+            scheduler._split_model_output_by_rank(scheduler_output,
+                                                  model_runner_output)
+
+        assert "invalid_block_ids is not supported in DP mode" in str(
+            exc_info.value)
+
     def test_shutdown(self, mock_vllm_config, mock_kv_cache_config,
                       mock_structured_output_manager):
         """Test shutdown sends SHUTDOWN command to all workers."""
@@ -1021,6 +1157,145 @@ class TestDPScheduler:
         # Verify processes were joined
         mock_process_0.join.assert_called()
         mock_process_1.join.assert_called()
+
+    def test_combine_scheduler_outputs_combines_kv_connector_metadata(
+        self,
+        mock_vllm_config,
+        mock_kv_cache_config,
+        mock_structured_output_manager,
+    ):
+        """Test that _combine_scheduler_outputs combines kv_connector_metadata."""
+        scheduler = self._create_scheduler(
+            mock_vllm_config,
+            mock_kv_cache_config,
+            mock_structured_output_manager,
+        )
+
+        from tpu_inference.distributed.tpu_connector import (
+            LoadMeta, SendMeta, TPUConnectorMetadata)
+
+        # Rank 0 metadata
+        meta_0 = TPUConnectorMetadata(
+            reqs_to_send={
+                "req1":
+                SendMeta(uuid="uuid1", local_block_ids=[], expiration_time=0.0)
+            },
+            reqs_to_load={
+                "req2":
+                LoadMeta(uuid="uuid2",
+                         local_block_ids=[],
+                         remote_block_ids=[],
+                         remote_host="localhost",
+                         remote_port=1234)
+            },
+        )
+        output_0 = MagicMock(spec=SchedulerOutput)
+        output_0.kv_connector_metadata = meta_0
+        output_0.num_scheduled_tokens = {"req1": 10}
+        output_0.total_num_scheduled_tokens = 10
+        output_0.scheduled_new_reqs = []
+        output_0.scheduled_spec_decode_tokens = {}
+        output_0.scheduled_encoder_inputs = {}
+        output_0.finished_req_ids = set()
+        output_0.scheduled_cached_reqs = CachedRequestData.make_empty()
+        output_0.num_common_prefix_blocks = []
+
+        # Rank 1 metadata
+        meta_1 = TPUConnectorMetadata(
+            reqs_to_send={
+                "req3":
+                SendMeta(uuid="uuid3", local_block_ids=[], expiration_time=0.0)
+            },
+            reqs_to_load={
+                "req4":
+                LoadMeta(uuid="uuid4",
+                         local_block_ids=[],
+                         remote_block_ids=[],
+                         remote_host="localhost",
+                         remote_port=1234)
+            },
+        )
+        output_1 = MagicMock(spec=SchedulerOutput)
+        output_1.kv_connector_metadata = meta_1
+        output_1.num_scheduled_tokens = {"req2": 20}
+        output_1.total_num_scheduled_tokens = 20
+        output_1.scheduled_new_reqs = []
+        output_1.scheduled_spec_decode_tokens = {}
+        output_1.scheduled_encoder_inputs = {}
+        output_1.finished_req_ids = set()
+        output_1.scheduled_cached_reqs = CachedRequestData.make_empty()
+        output_1.num_common_prefix_blocks = []
+
+        scheduler.assigned_dp_rank = {"req1": 0, "req2": 1}
+
+        combined = scheduler._combine_scheduler_outputs([output_0, output_1])
+
+        # Verify combined metadata
+        combined_meta = combined.kv_connector_metadata
+        assert isinstance(combined_meta, TPUConnectorMetadata)
+        assert "req1" in combined_meta.reqs_to_send
+        assert "req3" in combined_meta.reqs_to_send
+        assert "req2" in combined_meta.reqs_to_load
+        assert "req4" in combined_meta.reqs_to_load
+        assert combined_meta.reqs_to_send["req1"].uuid == "uuid1"
+        assert combined_meta.reqs_to_send["req3"].uuid == "uuid3"
+
+    def test_combine_scheduler_outputs_combines_tpu_offload_metadata(
+        self,
+        mock_vllm_config,
+        mock_kv_cache_config,
+        mock_structured_output_manager,
+    ):
+        """Test that _combine_scheduler_outputs combines TPUOffloadConnectorMetadata."""
+        scheduler = self._create_scheduler(
+            mock_vllm_config,
+            mock_kv_cache_config,
+            mock_structured_output_manager,
+        )
+
+        from tpu_inference.offload.tpu_offload_connector import (
+            TPUOffloadConnectorMetadata, TPUReqMeta)
+
+        # Rank 0 metadata
+        meta_0 = TPUOffloadConnectorMetadata(requests_meta=[
+            TPUReqMeta(req_id="req1", token_ids=[], local_block_ids=[])
+        ])
+        output_0 = MagicMock(spec=SchedulerOutput)
+        output_0.kv_connector_metadata = meta_0
+        output_0.num_scheduled_tokens = {"req1": 10}
+        output_0.total_num_scheduled_tokens = 10
+        output_0.scheduled_new_reqs = []
+        output_0.scheduled_spec_decode_tokens = {}
+        output_0.scheduled_encoder_inputs = {}
+        output_0.finished_req_ids = set()
+        output_0.scheduled_cached_reqs = CachedRequestData.make_empty()
+        output_0.num_common_prefix_blocks = []
+
+        # Rank 1 metadata
+        meta_1 = TPUOffloadConnectorMetadata(requests_meta=[
+            TPUReqMeta(req_id="req2", token_ids=[], local_block_ids=[])
+        ])
+        output_1 = MagicMock(spec=SchedulerOutput)
+        output_1.kv_connector_metadata = meta_1
+        output_1.num_scheduled_tokens = {"req2": 20}
+        output_1.total_num_scheduled_tokens = 20
+        output_1.scheduled_new_reqs = []
+        output_1.scheduled_spec_decode_tokens = {}
+        output_1.scheduled_encoder_inputs = {}
+        output_1.finished_req_ids = set()
+        output_1.scheduled_cached_reqs = CachedRequestData.make_empty()
+        output_1.num_common_prefix_blocks = []
+
+        scheduler.assigned_dp_rank = {"req1": 0, "req2": 1}
+
+        combined = scheduler._combine_scheduler_outputs([output_0, output_1])
+
+        # Verify combined metadata
+        combined_meta = combined.kv_connector_metadata
+        assert isinstance(combined_meta, TPUOffloadConnectorMetadata)
+        assert len(combined_meta.requests_meta) == 2
+        assert combined_meta.requests_meta[0].req_id == "req1"
+        assert combined_meta.requests_meta[1].req_id == "req2"
 
 
 class TestUpdateVllmConfigForDPScheduler:

--- a/tests/distributed/test_tpu_connector.py
+++ b/tests/distributed/test_tpu_connector.py
@@ -473,7 +473,7 @@ class TestTPUConnectorWorker(unittest.TestCase):
         worker.process_send_load(meta)
 
         self.all_mocks['insert_kv_chunks'].assert_called_once_with(
-            original_kv_caches, "kv_data", [1], "mock_mesh", "mock_spec")
+            original_kv_caches, "kv_data", [1], "mock_mesh", "mock_spec", None, 0)
         self.assertEqual(worker.runner.kv_caches, "new_kv_caches")
         self.assertNotIn("req1", worker.reqs_pulling)
         worker._maybe_build_notif_socket.assert_called_once_with(load_meta)

--- a/tests/distributed/test_tpu_connector.py
+++ b/tests/distributed/test_tpu_connector.py
@@ -39,6 +39,9 @@ class MockVllmConfig:
         self.cache_config = MagicMock()
         self.cache_config.block_size = 16
         self.parallel_config = MagicMock()
+        self.parallel_config.data_parallel_rank = 0
+        self.sharding_config = MagicMock()
+        self.sharding_config.total_dp_size = 1
 
 
 @patch("tpu_inference.distributed.tpu_connector.TPUConnectorWorker")
@@ -53,10 +56,12 @@ class TestTPUConnector(unittest.TestCase):
         Tests that TPUConnector initializes the scheduler connector for the
         SCHEDULER role.
         """
+        kv_cache_config = _make_test_kv_cache_config()
         connector = tpu_connector.TPUConnector(self.vllm_config,
                                                KVConnectorRole.SCHEDULER,
-                                               _make_test_kv_cache_config())
-        mock_scheduler_cls.assert_called_once_with(self.vllm_config)
+                                               kv_cache_config)
+        mock_scheduler_cls.assert_called_once_with(self.vllm_config, kv_cache_config)
+
         mock_worker_cls.assert_not_called()
         self.assertIsNotNone(connector.connector_scheduler)
         self.assertIsNone(connector.connector_worker)
@@ -512,6 +517,7 @@ class TestTPUConnectorWorker(unittest.TestCase):
 
 class TestTPUConnectorUtils(unittest.TestCase):
 
+    @patch("tpu_inference.distributed.tpu_connector.jnp.array", np.array)
     @patch("tpu_inference.distributed.tpu_connector.multi_layer_copy")
     def test_insert_kv_chunks_unmocked_contiguous(self, mock_multi_layer_copy):
         """
@@ -704,5 +710,242 @@ class TestTPUConnectorStats(unittest.TestCase):
         assert counter._value.get() == 3.0
 
 
+class TestTPUConnectorHostMapping(unittest.TestCase):
+
+    def setUp(self):
+        import os
+        self.env_patcher = patch.dict(os.environ, {"NEW_MODEL_DESIGN": "True"})
+        self.env_patcher.start()
+
+    def tearDown(self):
+        self.env_patcher.stop()
+
+    def _create_vllm_config(self, tensor_parallel_size, data_parallel_size, enable_dp_attention, attn_dp_size, expert_parallelism):
+        vllm_config = MagicMock()
+        vllm_config.parallel_config = MagicMock()
+        vllm_config.parallel_config.tensor_parallel_size = tensor_parallel_size
+        vllm_config.parallel_config.data_parallel_size = data_parallel_size
+        vllm_config.parallel_config.enable_dp_attention = enable_dp_attention
+        vllm_config.parallel_config.attn_dp_size = attn_dp_size
+        vllm_config.parallel_config.expert_parallelism = expert_parallelism
+        vllm_config.parallel_config.data_parallel_rank = 0
+        vllm_config.sharding_config = MagicMock()
+        vllm_config.sharding_config.total_dp_size = 1
+
+        vllm_config.model_config = MagicMock()
+        vllm_config.model_config.max_model_len = 2048
+        vllm_config.model_config.dtype = 'bfloat16'
+        vllm_config.cache_config = MagicMock()
+        vllm_config.cache_config.cache_dtype = 'auto'
+        vllm_config.lora_config = None
+
+        vllm_config.additional_config = {
+            "sharding": {
+                "tensor_parallel_size": tensor_parallel_size,
+                "data_parallel_size": data_parallel_size,
+                "enable_dp_attention": enable_dp_attention,
+                "attn_dp_size": attn_dp_size,
+                "expert_parallelism": expert_parallelism
+            }
+        }
+        
+        if enable_dp_attention:
+            vllm_config.sharding_config.total_dp_size = attn_dp_size * expert_parallelism
+        else:
+            vllm_config.sharding_config.total_dp_size = data_parallel_size * expert_parallelism
+            
+        return vllm_config
+
+    @patch("tpu_inference.distributed.tpu_connector.start_transfer_server")
+    @patch("tpu_inference.distributed.tpu_connector.zmq")
+    def test_host_mapping_dp_size_8_two_hosts(self, mock_zmq, mock_start_transfer_server):
+        # Case 1: dp_size = 8, 2 hosts (ranks_per_host = 4)
+        vllm_config = self._create_vllm_config(
+            tensor_parallel_size=4,
+            data_parallel_size=1,
+            enable_dp_attention=True,
+            attn_dp_size=8,
+            expert_parallelism=1
+        )
+        self.assertEqual(vllm_config.sharding_config.total_dp_size, 8)
+
+        worker = tpu_connector.TPUConnectorWorker(vllm_config)
+        worker.pull_conns = {}
+        worker.kv_transfer_server = MagicMock()
+
+        def check_mapping(node_id, consumer_dp_rank, producer_dp_rank, expected_host_idx):
+            worker.node_id = node_id
+            req_meta = tpu_connector.LoadMeta(
+                uuid=1,
+                local_block_ids=[],
+                remote_block_ids=[],
+                remote_host=["1.1.1.1", "2.2.2.2"],
+                remote_port=[1000, 2000],
+                producer_dp_rank=producer_dp_rank,
+                consumer_dp_rank=consumer_dp_rank
+            )
+            conn = worker._maybe_build_kv_connection(req_meta)
+            expected_addr = f"{req_meta.remote_host[expected_host_idx]}:{req_meta.remote_port[expected_host_idx]}"
+            worker.kv_transfer_server.connect.assert_called_with(expected_addr)
+
+        # Worker 0 (Host 0), consumer rank 5, producer rank 1 -> maps to host 0
+        # 1 // 4 = 0
+        check_mapping(node_id=0, consumer_dp_rank=5, producer_dp_rank=1, expected_host_idx=0)
+
+        # Worker 1 (Host 1), consumer rank 5, producer rank 1 -> maps to host 0
+        # 1 // 4 = 0
+        check_mapping(node_id=1, consumer_dp_rank=5, producer_dp_rank=1, expected_host_idx=0)
+
+        # Worker 0 (Host 0), consumer rank 0, producer rank 2 -> maps to host 0
+        # 2 // 4 = 0
+        check_mapping(node_id=0, consumer_dp_rank=0, producer_dp_rank=2, expected_host_idx=0)
+
+        # Worker 1 (Host 1), consumer rank 0, producer rank 2 -> maps to host 0
+        # 2 // 4 = 0
+        check_mapping(node_id=1, consumer_dp_rank=0, producer_dp_rank=2, expected_host_idx=0)
+
+        # Worker 0 (Host 0), consumer rank 6, producer rank 7 -> maps to host 1
+        # 7 // 4 = 1
+        check_mapping(node_id=0, consumer_dp_rank=6, producer_dp_rank=7, expected_host_idx=1)
+
+        # Worker 1 (Host 1), consumer rank 6, producer rank 7 -> maps to host 1
+        # 7 // 4 = 1
+        check_mapping(node_id=1, consumer_dp_rank=6, producer_dp_rank=7, expected_host_idx=1)
+
+        # Worker 0 (Host 0), consumer rank 2, producer rank 7 -> maps to host 1
+        # 7 // 4 = 1
+        check_mapping(node_id=0, consumer_dp_rank=2, producer_dp_rank=7, expected_host_idx=1)
+
+        # Worker 1 (Host 1), consumer rank 2, producer rank 7 -> maps to host 1
+        # 7 // 4 = 1
+        check_mapping(node_id=1, consumer_dp_rank=2, producer_dp_rank=7, expected_host_idx=1)
+
+        # Worker 0 (Host 0), consumer rank 3, producer rank 4 -> maps to host 1
+        # 4 // 4 = 1
+        check_mapping(node_id=0, consumer_dp_rank=3, producer_dp_rank=4, expected_host_idx=1)
+
+        # Worker 1 (Host 1), consumer rank 3, producer rank 4 -> maps to host 1
+        # 4 // 4 = 1
+        check_mapping(node_id=1, consumer_dp_rank=3, producer_dp_rank=4, expected_host_idx=1)
+
+    @patch("tpu_inference.distributed.tpu_connector.start_transfer_server")
+    @patch("tpu_inference.distributed.tpu_connector.zmq")
+    def test_host_mapping_dp_size_2_two_hosts(self, mock_zmq, mock_start_transfer_server):
+        # Case 2: dp_size = 2, 2 hosts (ranks_per_host = 1)
+        vllm_config = self._create_vllm_config(
+            tensor_parallel_size=4,
+            data_parallel_size=1,
+            enable_dp_attention=True,
+            attn_dp_size=2,
+            expert_parallelism=1
+        )
+        self.assertEqual(vllm_config.sharding_config.total_dp_size, 2)
+        worker = tpu_connector.TPUConnectorWorker(vllm_config)
+        worker.pull_conns = {}
+        worker.kv_transfer_server = MagicMock()
+
+        def check_mapping(node_id, consumer_dp_rank, producer_dp_rank, expected_host_idx):
+            worker.node_id = node_id
+            req_meta = tpu_connector.LoadMeta(
+                uuid=2,
+                local_block_ids=[],
+                remote_block_ids=[],
+                remote_host=["1.1.1.1", "2.2.2.2"],
+                remote_port=[1000, 2000],
+                producer_dp_rank=producer_dp_rank,
+                consumer_dp_rank=consumer_dp_rank
+            )
+            conn = worker._maybe_build_kv_connection(req_meta)
+            expected_addr = f"{req_meta.remote_host[expected_host_idx]}:{req_meta.remote_port[expected_host_idx]}"
+            worker.kv_transfer_server.connect.assert_called_with(expected_addr)
+
+        # Worker 1 (Host 1), consumer rank 1, producer rank 0 -> maps to host 0
+        # (ranks_per_host=1)
+        check_mapping(node_id=1, consumer_dp_rank=1, producer_dp_rank=0, expected_host_idx=0)
+
+        # Worker 0 (Host 0), consumer rank 0, producer rank 1 -> maps to host 1 (ranks_per_host=1)
+        check_mapping(node_id=0, consumer_dp_rank=0, producer_dp_rank=1, expected_host_idx=1)
+
+    @patch("tpu_inference.distributed.tpu_connector.start_transfer_server")
+    @patch("tpu_inference.distributed.tpu_connector.zmq")
+    def test_host_mapping_dp_size_4_two_hosts(self, mock_zmq, mock_start_transfer_server):
+        # Case: dp_size = 4, 2 hosts (ranks_per_host = 2)
+        vllm_config = self._create_vllm_config(
+            tensor_parallel_size=4,
+            data_parallel_size=1,
+            enable_dp_attention=True,
+            attn_dp_size=2,
+            expert_parallelism=2
+        )
+        self.assertEqual(vllm_config.sharding_config.total_dp_size, 4)
+        worker = tpu_connector.TPUConnectorWorker(vllm_config)
+        worker.pull_conns = {}
+        worker.kv_transfer_server = MagicMock()
+
+        def check_mapping(node_id, consumer_dp_rank, producer_dp_rank, expected_host_idx):
+            worker.node_id = node_id
+            req_meta = tpu_connector.LoadMeta(
+                uuid=4,
+                local_block_ids=[],
+                remote_block_ids=[],
+                remote_host=["1.1.1.1", "2.2.2.2"],
+                remote_port=[1000, 2000],
+                producer_dp_rank=producer_dp_rank,
+                consumer_dp_rank=consumer_dp_rank
+            )
+            conn = worker._maybe_build_kv_connection(req_meta)
+            expected_addr = f"{req_meta.remote_host[expected_host_idx]}:{req_meta.remote_port[expected_host_idx]}"
+            worker.kv_transfer_server.connect.assert_called_with(expected_addr)
+
+        # Worker 0 (Host 0), consumer rank 0, producer rank 1 -> maps to host 0
+        check_mapping(node_id=0, consumer_dp_rank=0, producer_dp_rank=1, expected_host_idx=0)
+
+        # Worker 1 (Host 1), consumer rank 0, producer rank 1 -> maps to host 0
+        check_mapping(node_id=1, consumer_dp_rank=0, producer_dp_rank=1, expected_host_idx=0)
+
+        # Worker 0 (Host 0), consumer rank 3, producer rank 1 -> maps to host 0
+        check_mapping(node_id=0, consumer_dp_rank=3, producer_dp_rank=1, expected_host_idx=0)
+
+        # Worker 1 (Host 1), consumer rank 3, producer rank 1 -> maps to host 0
+        check_mapping(node_id=1, consumer_dp_rank=3, producer_dp_rank=1, expected_host_idx=0)
+
+    @patch("tpu_inference.distributed.tpu_connector.start_transfer_server")
+    @patch("tpu_inference.distributed.tpu_connector.zmq")
+    def test_host_mapping_dp_off_two_hosts(self, mock_zmq, mock_start_transfer_server):
+        # Case 3: dp_size = 1, 2 hosts (DP OFF)
+        vllm_config = self._create_vllm_config(
+            tensor_parallel_size=16,
+            data_parallel_size=1,
+            enable_dp_attention=False,
+            attn_dp_size=1,
+            expert_parallelism=1
+        )
+        self.assertEqual(vllm_config.sharding_config.total_dp_size, 1)
+        worker = tpu_connector.TPUConnectorWorker(vllm_config)
+        worker.pull_conns = {}
+        worker.kv_transfer_server = MagicMock()
+
+        def check_mapping(node_id, expected_host_idx):
+            worker.node_id = node_id
+            req_meta = tpu_connector.LoadMeta(
+                uuid=3,
+                local_block_ids=[],
+                remote_block_ids=[],
+                remote_host=["1.1.1.1", "2.2.2.2"],
+                remote_port=[1000, 2000],
+                producer_dp_rank=0,
+                consumer_dp_rank=0
+            )
+            conn = worker._maybe_build_kv_connection(req_meta)
+            expected_addr = f"{req_meta.remote_host[expected_host_idx]}:{req_meta.remote_port[expected_host_idx]}"
+            worker.kv_transfer_server.connect.assert_called_with(expected_addr)
+
+        # Worker 0 (Host 0) -> maps to host 0
+        check_mapping(node_id=0, expected_host_idx=0)
+        # Worker 1 (Host 1) -> maps to host 1
+        check_mapping(node_id=1, expected_host_idx=1)
+
+
 if __name__ == "__main__":
     unittest.main()
+

--- a/tpu_inference/core/sched/dp_scheduler.py
+++ b/tpu_inference/core/sched/dp_scheduler.py
@@ -40,8 +40,8 @@ from vllm.v1.core.sched.scheduler import Scheduler
 from vllm.v1.engine import EngineCoreOutputs
 from vllm.v1.kv_cache_interface import KVCacheConfig
 from vllm.v1.metrics.stats import PrefixCacheStats, SchedulerStats
-from vllm.v1.outputs import (DraftTokenIds, LogprobsLists, ModelRunnerOutput,
-                             RoutedExpertsLists)
+from vllm.v1.outputs import (DraftTokenIds, KVConnectorOutput, LogprobsLists,
+                             ModelRunnerOutput, RoutedExpertsLists)
 from vllm.v1.request import Request
 from vllm.v1.spec_decode.metrics import SpecDecodingStats
 from vllm.v1.structured_output import StructuredOutputManager
@@ -876,6 +876,9 @@ class DPScheduler(SchedulerInterface):
         for rank, output in enumerate(rank_outputs):
             req_ids_per_rank[rank] = list(output.num_scheduled_tokens.keys())
 
+        combined_kv_connector_metadata = self._combine_kv_connector_metadata(
+            rank_outputs)
+
         return DPSchedulerOutput(
             scheduled_new_reqs=all_new_reqs,
             scheduled_cached_reqs=combined_cached_data,
@@ -889,7 +892,70 @@ class DPScheduler(SchedulerInterface):
             assigned_dp_rank=assigned_dp_rank,
             max_num_scheduled_tokens_per_dp_rank=max_scheduled_tokens_per_rank,
             req_ids_per_rank=req_ids_per_rank,
+            kv_connector_metadata=combined_kv_connector_metadata,
         )
+
+    def _combine_kv_connector_metadata(
+            self, rank_outputs: List[SchedulerOutput]) -> Any:
+        """Combine KV connector metadata from all DP rank schedulers."""
+        metadata_list = [
+            out.kv_connector_metadata for out in rank_outputs
+            if out.kv_connector_metadata is not None
+        ]
+        if not metadata_list:
+            return None
+
+        if len(metadata_list) == 1:
+            return metadata_list[0]
+
+        first = metadata_list[0]
+
+        try:
+            from tpu_inference.distributed.tpu_connector import \
+                TPUConnectorMetadata
+        except ImportError:
+            TPUConnectorMetadata = None
+
+        try:
+            from tpu_inference.offload.tpu_offload_connector import \
+                TPUOffloadConnectorMetadata
+        except ImportError:
+            TPUOffloadConnectorMetadata = None
+
+        if TPUConnectorMetadata is not None and isinstance(
+                first, TPUConnectorMetadata):
+            combined_reqs_to_send = {}
+            combined_reqs_to_load = {}
+            for m in metadata_list:
+                if not isinstance(m, TPUConnectorMetadata):
+                    logger.warning(
+                        "Mixing metadata types in DP merge: %s and %s",
+                        type(first), type(m))
+                    continue
+                combined_reqs_to_send.update(m.reqs_to_send)
+                combined_reqs_to_load.update(m.reqs_to_load)
+            return TPUConnectorMetadata(
+                reqs_to_send=combined_reqs_to_send,
+                reqs_to_load=combined_reqs_to_load,
+            )
+        elif TPUOffloadConnectorMetadata is not None and isinstance(
+                first, TPUOffloadConnectorMetadata):
+            combined_requests_meta = []
+            for m in metadata_list:
+                if not isinstance(m, TPUOffloadConnectorMetadata):
+                    logger.warning(
+                        "Mixing metadata types in DP merge: %s and %s",
+                        type(first), type(m))
+                    continue
+                combined_requests_meta.extend(m.requests_meta)
+            return TPUOffloadConnectorMetadata(
+                requests_meta=combined_requests_meta, )
+        else:
+            logger.warning(
+                "Unknown or unmergeable KVConnectorMetadata type: %s",
+                type(first),
+            )
+            return first
 
     def _combine_cached_request_data(
             self, rank_outputs: List[SchedulerOutput]) -> CachedRequestData:
@@ -1171,12 +1237,49 @@ class DPScheduler(SchedulerInterface):
                 current_token_offset = end_idx
                 req_id_to_routed_experts_range[req_id] = (start_idx, end_idx)
 
+        if g.kv_connector_output is not None:
+            assert not g.kv_connector_output.invalid_block_ids, (
+                "invalid_block_ids is not supported in DP mode because block IDs "
+                "are not globally unique and can collide across ranks. "
+                "The driver cannot filter them by rank without block allocation tables."
+            )
+
         for rank in range(self.dp_size):
             req_ids = scheduler_output.req_ids_per_rank.get(rank, [])
 
             # Map each rank-local index to the corresponding global index.
             global_indices = [g.req_id_to_index[rid] for rid in req_ids]
             rank_req_id_to_index = {rid: i for i, rid in enumerate(req_ids)}
+            # Filter KV connector output for this rank
+            global_kv = g.kv_connector_output
+            rank_kv_connector_output = None
+            if global_kv is not None:
+                finished_sending = None
+                if global_kv.finished_sending is not None:
+                    finished_sending = {
+                        rid
+                        for rid in global_kv.finished_sending
+                        if self.assigned_dp_rank.get(rid) == rank
+                    }
+
+                finished_recving = None
+                if global_kv.finished_recving is not None:
+                    finished_recving = {
+                        rid
+                        for rid in global_kv.finished_recving
+                        if self.assigned_dp_rank.get(rid) == rank
+                    }
+
+                rank_kv_connector_output = KVConnectorOutput(
+                    finished_sending=finished_sending,
+                    finished_recving=finished_recving,
+                    kv_connector_stats=global_kv.kv_connector_stats,
+                    kv_cache_events=global_kv.kv_cache_events,
+                    kv_connector_worker_meta=global_kv.
+                    kv_connector_worker_meta,
+                    invalid_block_ids=global_kv.invalid_block_ids,
+                    expected_finished_count=global_kv.expected_finished_count,
+                )
 
             rank_model_runner_output = ModelRunnerOutput(
                 req_ids=req_ids,
@@ -1196,7 +1299,7 @@ class DPScheduler(SchedulerInterface):
                     rid: g.num_nans_in_logits[rid]
                     for rid in req_ids if rid in g.num_nans_in_logits
                 } if g.num_nans_in_logits else None),
-                kv_connector_output=g.kv_connector_output,
+                kv_connector_output=rank_kv_connector_output,
             )
 
             if routed_experts is not None:

--- a/tpu_inference/core/sched/dp_scheduler.py
+++ b/tpu_inference/core/sched/dp_scheduler.py
@@ -145,6 +145,9 @@ def _scheduler_worker_process(
 ):
     """Worker process that manages a single scheduler instance."""
     # Initialize the scheduler in this process
+    vllm_config = copy.deepcopy(vllm_config)
+    vllm_config.parallel_config.data_parallel_rank = rank
+    logger.info(f"[multihost-dp-debug] _scheduler_worker_process: initialized worker configuration with parallel_config.data_parallel_rank={rank}")
     import inspect
     sig = inspect.signature(original_scheduler_cls)
     scheduler_kwargs = {
@@ -394,6 +397,15 @@ class DPScheduler(SchedulerInterface):
         self.hash_block_size = hash_block_size if hash_block_size is not None else block_size
         self.log_stats = log_stats
         self.connector = None
+        if self.vllm_config.kv_transfer_config is not None:
+            from vllm.distributed.kv_transfer.kv_connector.factory import KVConnectorFactory
+            from vllm.distributed.kv_transfer.kv_connector.v1.base import KVConnectorRole
+            self.connector = KVConnectorFactory.create_connector(
+                config=self.vllm_config,
+                role=KVConnectorRole.SCHEDULER,
+                kv_cache_config=kv_cache_config,
+            )
+            logger.info(f"[multihost-dp-debug] DPScheduler: created SCHEDULER connector on DP rank={self.vllm_config.parallel_config.data_parallel_rank}")
         self.structured_output_manager = structured_output_manager
 
         # DP state
@@ -1586,6 +1598,9 @@ class DPScheduler(SchedulerInterface):
 
         # Restore original pickle
         _disable_cloudpickle()
+
+    def get_kv_connector(self) -> Any:
+        return self.connector
 
 
 def update_vllm_config_for_dp_scheduler(vllm_config: Any) -> None:

--- a/tpu_inference/distributed/tpu_connector.py
+++ b/tpu_inference/distributed/tpu_connector.py
@@ -1080,24 +1080,24 @@ def insert_kv_chunks(kv_caches: list[jax.Array], kv_slices: list[jax.Array],
         owner_dp_rank = block_numbers[0] // local_blocks_per_rank
         local_block_numbers = [b % local_blocks_per_rank for b in block_numbers]
         
-        # Select current cache values collectively to prevent JAX deadlock
-        from tpu_inference.utils import device_array
-        indices_arr = device_array(mesh, np.array(local_block_numbers, dtype=np.int32))
-        backup_slices = select_from_kv_caches(kv_caches, indices_arr)
-        
         if node_id != owner_dp_rank:
             from jax.sharding import PartitionSpec as P
             if src_spec is not None and isinstance(src_spec, P):
                 src_sharding = jax.sharding.NamedSharding(mesh, src_spec)
-                global_backup = []
-                for x in backup_slices:
-                    global_x = jax.make_array_from_single_device_arrays(
-                        x.shape, src_sharding,
-                        [shard.data for shard in x.addressable_shards]
+                backup_slices = []
+                for cache in kv_caches:
+                    local_selected_shards = []
+                    for shard in cache.addressable_shards:
+                        local_device_indices = jax.device_put(jnp.array(local_block_numbers, dtype=jnp.int32), shard.device)
+                        selected_local = shard.data[local_device_indices]
+                        local_selected_shards.append(selected_local)
+                    
+                    global_backup_layer = jax.make_array_from_single_device_arrays(
+                        (len(local_block_numbers), *cache.shape[1:]),
+                        src_sharding,
+                        local_selected_shards
                     )
-                    global_backup.append(global_x)
-                kv_slices = global_backup
-            else:
+                    backup_slices.append(global_backup_layer)
                 kv_slices = backup_slices
     else:
         local_block_numbers = block_numbers

--- a/tpu_inference/distributed/tpu_connector.py
+++ b/tpu_inference/distributed/tpu_connector.py
@@ -506,6 +506,7 @@ class TPUConnectorWorker:
         self.vllm_config = vllm_config
         self.config = vllm_config.kv_transfer_config
         self.is_producer = self.config.is_kv_producer
+        self.dp_size = vllm_config.sharding_config.total_dp_size
 
         self.runner: TPUModelRunner = None
         self.mesh: Mesh = None
@@ -581,8 +582,22 @@ class TPUConnectorWorker:
         self.shape = list(kv_layer.shape)
         self.dtype = kv_layer.dtype
         self.sharding = kv_layer.sharding
+        
+        # Build local sub-mesh for host-local JAX P2P transfers
+        dp_rank = self.node_id
+        import numpy as np
+        from tpu_inference.layers.common.sharding import MESH_AXIS_NAMES
+        
+        if hasattr(self.mesh, "devices") and not isinstance(self.mesh, str):
+            local_devices_np = np.asarray(self.mesh.devices)[:, dp_rank:dp_rank+1, :, :, :, :]
+            self.local_mesh = jax.sharding.Mesh(local_devices_np, MESH_AXIS_NAMES)
+            self.local_sharding = jax.sharding.NamedSharding(self.local_mesh, self.sharding.spec)
+        else:
+            self.local_mesh = self.mesh
+            self.local_sharding = self.sharding
+
         self.host_sharding = jax.sharding.NamedSharding(
-            self.sharding.mesh,
+            self.local_mesh,
             self.sharding.spec,
             memory_kind='pinned_host',
         )
@@ -665,6 +680,9 @@ class TPUConnectorWorker:
         This is called in runner before calling model forward,
         whenever the scheduler_output.total_num_scheduled_tokens is empty or not.
         """
+        logger.info(
+            f"[multihost-dp-debug] Worker {self.node_id} process_send_load: metadata.reqs_to_send={metadata.reqs_to_send if metadata else None} | metadata.reqs_to_load={metadata.reqs_to_load if metadata else None}"
+        )
         reqs = metadata.reqs_to_send
         if reqs:
             assert self.is_producer
@@ -700,11 +718,28 @@ class TPUConnectorWorker:
                 if req_id in self.reqs_pulling:
                     assert self.reqs_pulling[req_id][1] is not None
                     _, kv, block_numbers = self.reqs_pulling.pop(req_id)
+                    insert_src_spec = None
+                    if self.dp_size > 1:
+                        global_kv = []
+                        from jax.sharding import PartitionSpec as P
+                        # Create a sharding spec where the DP axis is not sharded (replicated)
+                        src_spec = P(None, *self.sharding.spec[1:])
+                        src_sharding = jax.sharding.NamedSharding(self.mesh, src_spec)
+                        for x in kv:
+                            global_x = jax.make_array_from_single_device_arrays(
+                                x.shape, src_sharding,
+                                [shard.data for shard in x.addressable_shards]
+                            )
+                            global_kv.append(global_x)
+                        kv = global_kv
+                        insert_src_spec = src_spec
+
                     if len(block_numbers) > 0:
                         start_time = time.perf_counter()
                         self.runner.kv_caches = insert_kv_chunks(
                             self.runner.kv_caches, kv, block_numbers,
-                            self.mesh, self.sharding.spec)
+                            self.mesh, self.sharding.spec, insert_src_spec,
+                            self.node_id)
                         end_time = time.perf_counter()
                         logger.info(
                             f"TPUConnector Worker {self.node_id} --> req_id={req_id}, takes {(end_time - start_time)*1000:.2f}ms for insert_kv_chunks"
@@ -732,6 +767,18 @@ class TPUConnectorWorker:
         # TODO(xiang): pad block_ids to avoid recompilation
         indices = device_array(self.mesh, np.array(local_block_ids))
         kv = select_from_kv_caches(self.runner.kv_caches, indices)
+        dp_size = self.vllm_config.sharding_config.total_dp_size
+        # Convert kv to local mesh sharding
+        if dp_size > 1:
+            local_kv = []
+            for x in kv:
+                local_x = jax.make_array_from_single_device_arrays(
+                    x.shape, self.local_sharding,
+                    [shard.data for shard in x.addressable_shards]
+                )
+                local_kv.append(local_x)
+            kv = local_kv
+
         if dist_utils.get_enable_d2h_transfer() and not self.multi_host:
             self.kv_d2h_executor.submit(self._async_d2h_and_transfer, req_id,
                                         req_meta, kv, len(local_block_ids))
@@ -782,7 +829,7 @@ class TPUConnectorWorker:
         for src_layer, dest_layer in zip(kv_src, sliced_dest_buffer):
             updated_dest = copy_to_host(src=src_layer,
                                         dest=dest_layer,
-                                        mesh=self.mesh,
+                                        mesh=self.local_mesh,
                                         sharding_spec=self.sharding.spec)
             updated_dest_buffer.append(updated_dest)
 
@@ -865,6 +912,19 @@ class TPUConnectorWorker:
         # if partial prefix cache hit now.
         assert len(local_block_ids) == len(remote_block_ids)
 
+        if self.node_id != req_meta.consumer_dp_rank:
+            import jax.numpy as jnp
+            shape = copy.copy(self.shape)
+            shape[0] = len(remote_block_ids)
+            kv = [
+                jax.device_put(jnp.zeros(shape, dtype=self.dtype), self.local_sharding)
+                for _ in range(self.num_layers)
+            ]
+            logger.info(
+                f"Worker {self.node_id} --> kv transfer | non-assigned rank skipped pull and created dummy arrays | req_id={req_id}"
+            )
+            return kv
+
         kv_spec = self._get_kv_spec(len(remote_block_ids))
         logger.info(
             f"Worker {self.node_id} --> kv transfer | start pull req_id={req_id} | uuid={req_meta.uuid}"
@@ -923,7 +983,7 @@ class TPUConnectorWorker:
         shape = copy.copy(self.shape)
         shape[0] = num_blocks
         return [
-            jax.ShapeDtypeStruct(shape, self.dtype, sharding=self.sharding)
+            jax.ShapeDtypeStruct(shape, self.dtype, sharding=self.local_sharding)
         ] * self.num_layers
 
     def _maybe_build_notif_socket(self, req_meta: LoadMeta) -> zmq.Socket:
@@ -1011,16 +1071,33 @@ def select_from_kv_caches(kv_caches: list[jax.Array],
 
 def insert_kv_chunks(kv_caches: list[jax.Array], kv_slices: list[jax.Array],
                      block_numbers: list[int], mesh: jax.sharding.Mesh,
-                     spec) -> list[jax.Array]:
+                     dest_spec, src_spec=None, node_id: int = 0) -> list[jax.Array]:
+    if src_spec is None:
+        src_spec = dest_spec
+    
+    local_blocks_per_rank = kv_caches[0].shape[0]
+    if isinstance(local_blocks_per_rank, int):
+        owner_dp_rank = block_numbers[0] // local_blocks_per_rank
+        local_block_numbers = [b % local_blocks_per_rank for b in block_numbers]
+        
+        # Select current cache values collectively to prevent JAX deadlock
+        from tpu_inference.utils import device_array
+        indices_arr = device_array(mesh, np.array(local_block_numbers, dtype=np.int32))
+        backup_slices = select_from_kv_caches(kv_caches, indices_arr)
+        
+        if node_id != owner_dp_rank:
+            kv_slices = backup_slices
+    else:
+        local_block_numbers = block_numbers
+
     src_offsets = []
     dest_offsets = []
     chunk_sizes = []
 
     start_idx = 0
-    for i in range(1, len(block_numbers) + 1):
-        if i == len(block_numbers) or block_numbers[i] != block_numbers[i -
-                                                                        1] + 1:
-            start_block = block_numbers[start_idx]
+    for i in range(1, len(local_block_numbers) + 1):
+        if i == len(local_block_numbers) or local_block_numbers[i] != local_block_numbers[i - 1] + 1:
+            start_block = local_block_numbers[start_idx]
             chunk_size = i - start_idx
 
             src_offsets.append(start_idx)
@@ -1030,7 +1107,7 @@ def insert_kv_chunks(kv_caches: list[jax.Array], kv_slices: list[jax.Array],
             start_idx = i
 
     num_chunks = len(src_offsets)
-    total_len = len(block_numbers)
+    total_len = len(local_block_numbers)
 
     # Pad to total_len to avoid recompilation
     while len(src_offsets) < total_len:
@@ -1053,7 +1130,7 @@ def insert_kv_chunks(kv_caches: list[jax.Array], kv_slices: list[jax.Array],
         chunk_sizes=chunk_sizes_arr,
         num_chunks=num_chunks_arr,
         mesh=mesh,
-        src_sharding_spec=spec,
-        dest_sharding_spec=spec,
+        src_sharding_spec=src_spec,
+        dest_sharding_spec=dest_spec,
         replicated_sharding_spec=replicated_spec,
     )

--- a/tpu_inference/distributed/tpu_connector.py
+++ b/tpu_inference/distributed/tpu_connector.py
@@ -1069,6 +1069,14 @@ def select_from_kv_caches(kv_caches: list[jax.Array],
     return selected
 
 
+@jax.jit
+def select_local_backup_slices(kv_caches: list[jax.Array],
+                               global_indices: jax.Array) -> list[jax.Array]:
+    # global_indices has shape (dp_size, num_blocks), sharded on DP axis.
+    # cache has shape (total_blocks, ...), sharded on DP axis.
+    return [cache[global_indices] for cache in kv_caches]
+
+
 def insert_kv_chunks(kv_caches: list[jax.Array], kv_slices: list[jax.Array],
                      block_numbers: list[int], mesh: jax.sharding.Mesh,
                      dest_spec, src_spec=None, node_id: int = 0) -> list[jax.Array]:
@@ -1083,21 +1091,32 @@ def insert_kv_chunks(kv_caches: list[jax.Array], kv_slices: list[jax.Array],
         if node_id != owner_dp_rank:
             from jax.sharding import PartitionSpec as P
             if src_spec is not None and isinstance(src_spec, P):
+                dp_axis = dest_spec[0]
+                dp_size = mesh.shape[dp_axis]
+                
+                my_global_indices = [b + node_id * local_blocks_per_rank for b in local_block_numbers]
+                indices_sharding = jax.sharding.NamedSharding(mesh, dest_spec[:1])
+                local_indices_shards = []
+                for device in mesh.local_devices:
+                    local_indices_shards.append(jax.device_put(np.array(my_global_indices, dtype=np.int32), device))
+                
+                global_indices = jax.make_array_from_single_device_arrays(
+                    (dp_size, len(local_block_numbers)),
+                    indices_sharding,
+                    local_indices_shards
+                )
+                
+                backup_layers = select_local_backup_slices(kv_caches, global_indices)
+                
                 src_sharding = jax.sharding.NamedSharding(mesh, src_spec)
                 backup_slices = []
-                for cache in kv_caches:
-                    local_selected_shards = []
-                    for shard in cache.addressable_shards:
-                        local_device_indices = jax.device_put(jnp.array(local_block_numbers, dtype=jnp.int32), shard.device)
-                        selected_local = shard.data[local_device_indices]
-                        local_selected_shards.append(selected_local)
-                    
-                    global_backup_layer = jax.make_array_from_single_device_arrays(
-                        (len(local_block_numbers), *cache.shape[1:]),
+                for x in backup_layers:
+                    global_x = jax.make_array_from_single_device_arrays(
+                        (len(local_block_numbers), *x.shape[2:]),
                         src_sharding,
-                        local_selected_shards
+                        [shard.data for shard in x.addressable_shards]
                     )
-                    backup_slices.append(global_backup_layer)
+                    backup_slices.append(global_x)
                 kv_slices = backup_slices
     else:
         local_block_numbers = block_numbers

--- a/tpu_inference/distributed/tpu_connector.py
+++ b/tpu_inference/distributed/tpu_connector.py
@@ -1086,7 +1086,19 @@ def insert_kv_chunks(kv_caches: list[jax.Array], kv_slices: list[jax.Array],
         backup_slices = select_from_kv_caches(kv_caches, indices_arr)
         
         if node_id != owner_dp_rank:
-            kv_slices = backup_slices
+            from jax.sharding import PartitionSpec as P
+            if src_spec is not None and isinstance(src_spec, P):
+                src_sharding = jax.sharding.NamedSharding(mesh, src_spec)
+                global_backup = []
+                for x in backup_slices:
+                    global_x = jax.make_array_from_single_device_arrays(
+                        x.shape, src_sharding,
+                        [shard.data for shard in x.addressable_shards]
+                    )
+                    global_backup.append(global_x)
+                kv_slices = global_backup
+            else:
+                kv_slices = backup_slices
     else:
         local_block_numbers = block_numbers
 

--- a/tpu_inference/distributed/tpu_connector.py
+++ b/tpu_inference/distributed/tpu_connector.py
@@ -117,6 +117,7 @@ class SendMeta:
     # `list[list[int]]` used for HMA connector (per-kv-cache-group)
     local_block_ids: list[int] | list[list[int]]
     expiration_time: float
+    producer_dp_rank: int = 0
 
 
 @dataclass
@@ -128,6 +129,9 @@ class LoadMeta:
     remote_block_ids: list[int] | list[list[int]] | None
     remote_host: str | list[str]
     remote_port: int | list[int]
+    producer_dp_rank: int = 0
+    consumer_dp_rank: int = 0
+
 
 
 # The metadata used for communicating between scheduler and worker connectors.
@@ -147,7 +151,7 @@ class TPUConnector(KVConnectorBase_V1):
 
         if role == KVConnectorRole.SCHEDULER:
             self.connector_scheduler = \
-                TPUConnectorScheduler(vllm_config)
+                TPUConnectorScheduler(vllm_config, kv_cache_config)
             self.connector_worker = None
         elif role == KVConnectorRole.WORKER:
             self.connector_scheduler = None
@@ -261,7 +265,7 @@ class TPUConnector(KVConnectorBase_V1):
 
 class TPUConnectorScheduler():
 
-    def __init__(self, vllm_config: "VllmConfig"):
+    def __init__(self, vllm_config: "VllmConfig", kv_cache_config: "KVCacheConfig" = None):
         self.vllm_config = vllm_config
         self.config = vllm_config.kv_transfer_config
         self.is_producer = self.config.is_kv_producer
@@ -278,9 +282,27 @@ class TPUConnectorScheduler():
 
         self.kv_ip = dist_utils.get_kv_ips()
         self.kv_port = dist_utils.get_kv_ports()
+
+        self.dp_rank = vllm_config.parallel_config.data_parallel_rank
+        self.dp_size = vllm_config.sharding_config.total_dp_size
+        self.num_blocks_per_rank = 0
+        if kv_cache_config is not None:
+            self.num_blocks_per_rank = kv_cache_config.num_blocks
+
         logger.info(
-            f"TPUConnectorScheduler --> kv_ip={self.kv_ip} | kv_port={self.kv_port}"
+            f"[multihost-dp-debug] TPUConnectorScheduler [Rank {self.dp_rank}/{self.dp_size}] --> kv_ip={self.kv_ip} | kv_port={self.kv_port} | blocks_per_rank={self.num_blocks_per_rank}"
         )
+
+    def _to_global_block_ids(self, block_ids: list[int] | list[list[int]]) -> list[int] | list[list[int]]:
+        if not block_ids:
+            return block_ids
+        offset = self.dp_rank * self.num_blocks_per_rank
+        logger.info(f"[multihost-dp-debug] _to_global_block_ids: rank={self.dp_rank}, offset={offset}, inputs={block_ids[:10]}")
+        if isinstance(block_ids[0], list):
+            return [[b + offset for b in sublist] for sublist in block_ids]
+        else:
+            return [b + offset for b in block_ids]
+
 
     def get_num_new_matched_tokens(
         self,
@@ -342,9 +364,11 @@ class TPUConnectorScheduler():
             return
 
         params = request.kv_transfer_params
+        producer_dp_rank = params.get("producer_dp_rank", 0)
         if num_external_tokens > 0:
             # We need to load KV-cache from remote (partial prefix cache hit).
             local_block_ids = blocks.get_block_ids()[0]
+            global_local_block_ids = self._to_global_block_ids(local_block_ids)
 
             # NOTE(xiang): D needs to pull the whole prefill blocks from the remote
             # regardless how much ratio the prefix cache hits.
@@ -358,30 +382,39 @@ class TPUConnectorScheduler():
 
             self.reqs_to_load[request.request_id] = LoadMeta(
                 uuid=params["uuid"],
-                local_block_ids=local_block_ids,
+                local_block_ids=global_local_block_ids,
                 remote_block_ids=params["remote_block_ids"],
                 remote_host=params["remote_host"],
                 remote_port=params["remote_port"],
+                producer_dp_rank=producer_dp_rank,
+                consumer_dp_rank=self.dp_rank,
             )
+            logger.info(f"[multihost-dp-debug] Scheduler: added load metadata for req_id={request.request_id} (partial prefix cache hit): load_meta={self.reqs_to_load[request.request_id]}")
         else:
             # This branch means two cases:
             # 1. We don't need to load KV-cache from remote because of full local cache.
             # 2. The async pulling is done.
             # In both cases we need to send notification to let P free memory.
+            local_block_ids = blocks.get_block_ids()[0]
+            global_local_block_ids = self._to_global_block_ids(local_block_ids)
             self.reqs_to_load[request.request_id] = LoadMeta(
                 uuid=params["uuid"],
-                local_block_ids=blocks.get_block_ids()[0],
+                local_block_ids=global_local_block_ids,
                 remote_block_ids=None,
                 remote_host=params["remote_host"],
                 remote_port=params["remote_port"],
+                producer_dp_rank=producer_dp_rank,
+                consumer_dp_rank=self.dp_rank,
             )
+            logger.info(f"[multihost-dp-debug] Scheduler: added load metadata for req_id={request.request_id} (no load or done): load_meta={self.reqs_to_load[request.request_id]}")
 
         # Only trigger 1 KV transfer per request.
         params["do_remote_prefill"] = False
 
         logger.info(
-            f"TPUConnector Scheduler update_state_after_alloc -->  reqs_to_load={self.reqs_to_load}"
+            f"[multihost-dp-debug] TPUConnector Scheduler update_state_after_alloc -->  reqs_to_load={self.reqs_to_load}"
         )
+
 
     def build_connector_meta(self) -> TPUConnectorMetadata:
         """
@@ -446,19 +479,23 @@ class TPUConnectorScheduler():
             uuid = get_uuid()
             expiration_time = time.perf_counter(
             ) + dist_utils.get_p2p_wait_pull_timeout()
+            global_computed_block_ids = self._to_global_block_ids(computed_block_ids)
             self.reqs_to_send[request.request_id] = SendMeta(
                 uuid=uuid,
-                local_block_ids=computed_block_ids,
-                expiration_time=expiration_time)
+                local_block_ids=global_computed_block_ids,
+                expiration_time=expiration_time,
+                producer_dp_rank=self.dp_rank)
             kv_transfer_params = dict(uuid=uuid,
-                                      remote_block_ids=computed_block_ids,
+                                      remote_block_ids=global_computed_block_ids,
                                       remote_host=self.kv_ip,
-                                      remote_port=self.kv_port)
+                                      remote_port=self.kv_port,
+                                      producer_dp_rank=self.dp_rank)
             logger.info(
-                f"TPUConnector Scheduler ---->  generated reqs_to_send={self.reqs_to_send} | "
+                f"[multihost-dp-debug] TPUConnector Scheduler request_finished ---->  generated reqs_to_send={self.reqs_to_send} | "
                 f"kv_transfer_params={kv_transfer_params}")
         else:
             kv_transfer_params = {}
+
 
         return delay_free_blocks, kv_transfer_params
 
@@ -788,10 +825,23 @@ class TPUConnectorWorker:
             self.kv_transfer_server.await_pull(req_meta.uuid,
                                                updated_dest_buffer)
 
+    def _get_target_prefill_host_index(self, req_meta: LoadMeta) -> int:
+        num_hosts = len(req_meta.remote_host)
+        dp_size = self.vllm_config.sharding_config.total_dp_size
+        if dp_size < num_hosts:
+            logger.info(f"[multihost-dp-debug] _get_target_prefill_host_index: dp_size ({dp_size}) < num_hosts ({num_hosts}), returning self.node_id ({self.node_id})")
+            return self.node_id
+        ranks_per_host = dp_size // num_hosts
+        target_idx = req_meta.producer_dp_rank // ranks_per_host
+        logger.info(f"[multihost-dp-debug] _get_target_prefill_host_index: producer_dp_rank={req_meta.producer_dp_rank}, ranks_per_host={ranks_per_host}, target_host_index={target_idx}")
+        return target_idx
+
+
     def _maybe_build_kv_connection(self, req_meta: LoadMeta) -> Any:
         if isinstance(req_meta.remote_host, list):
             assert len(req_meta.remote_host) == len(req_meta.remote_port)
-            remote_addr = f"{req_meta.remote_host[self.node_id]}:{req_meta.remote_port[self.node_id]}"
+            target_prefill_host_index = self._get_target_prefill_host_index(req_meta)
+            remote_addr = f"{req_meta.remote_host[target_prefill_host_index]}:{req_meta.remote_port[target_prefill_host_index]}"
         else:
             remote_addr = f"{req_meta.remote_host}:{req_meta.remote_port}"
 
@@ -801,9 +851,10 @@ class TPUConnectorWorker:
             conn = self.kv_transfer_server.connect(remote_addr)
             self.pull_conns[remote_addr] = conn
             logger.info(
-                f"Worker {self.node_id} --> kv transfer | connect={remote_addr}"
+                f"[multihost-dp-debug] Worker {self.node_id} (consumer_dp_rank={req_meta.consumer_dp_rank}) --> building connection | remote_addr={remote_addr} (target_host_idx={target_prefill_host_index if isinstance(req_meta.remote_host, list) else 0}, producer_dp_rank={req_meta.producer_dp_rank})"
             )
         return conn
+
 
     def _pull_kv(self, req_id: str, conn: Any, req_meta: LoadMeta):
         # The local allocated blocks which don't hit prefix caching.
@@ -878,7 +929,8 @@ class TPUConnectorWorker:
     def _maybe_build_notif_socket(self, req_meta: LoadMeta) -> zmq.Socket:
         remote_host = req_meta.remote_host
         if isinstance(req_meta.remote_host, list):
-            remote_host = req_meta.remote_host[self.node_id]
+            target_prefill_host_index = self._get_target_prefill_host_index(req_meta)
+            remote_host = req_meta.remote_host[target_prefill_host_index]
 
         sock_path = make_zmq_path("tcp", remote_host, self.side_channel_port)
         if sock_path in self.notif_sockets:
@@ -890,13 +942,13 @@ class TPUConnectorWorker:
                                    bind=False)
             self.notif_sockets[sock_path] = sock
             logger.info(
-                f"Worker {self.node_id} --> notify make_zmq_socket | sock_path={sock_path}"
+                f"[multihost-dp-debug] Worker {self.node_id} (consumer_dp_rank={req_meta.consumer_dp_rank}) --> building notification socket | remote_host={remote_host} (target_host_idx={target_prefill_host_index if isinstance(req_meta.remote_host, list) else 0}, producer_dp_rank={req_meta.producer_dp_rank}) | sock_path={sock_path}"
             )
         return sock
 
     def _notify_pull_done(self, sock: zmq.Socket, req_id: str, uuid: int):
         logger.info(
-            f"Worker {self.node_id} --> zmq notify | req_id={req_id} | uuid={uuid}"
+            f"[multihost-dp-debug] Worker {self.node_id} --> zmq notify | req_id={req_id} | uuid={uuid}"
         )
         sock.send_string(str(uuid))
         # The response is not really needed.


### PR DESCRIPTION
# Description
This PR adds support in `DPScheduler` for combining KV connector metadata across Data Parallel (DP) ranks and slicing the global KV connector output back to rank-local outputs.
*   **Problem**: In DP mode (`attn_dp_size > 1`), disaggregated serving (using `TPUConnector`) failed because `kv_connector_metadata` from different ranks was not merged, and execution outputs were not sliced per rank.
*   **Changes**:
    *   Added `_combine_kv_connector_metadata` to merge `reqs_to_send`/`reqs_to_load` (for TPUConnector) and `requests_meta` (for OffloadConnector) from all ranks.
    *   Updated `slice_model_runner_output` to slice `finished_sending` and `finished_recving` outputs based on the request's `assigned_dp_rank`.
    *   Asserted that `invalid_block_ids` is empty in DP mode (failure recovery is not yet supported in DP due to block ID collisions across ranks).
# Tests
Added unit tests in `tests/core/test_dp_scheduler.py` covering:
*   Metadata merging for both `TPUConnector` and `TPUOffloadConnector`.
*   Rank-based slicing of `kv_connector_output`.
*   Assertion behavior for `invalid_block_ids` in DP mode.
Run tests:
```bash
pytest tests/core/test_dp_scheduler.py