### PR TITLE
Add MoE unpermute pipelining with collectives via VLLM_MOE_CHUNK_SIZE

### DIFF
--- a/tpu_inference/envs.py
+++ b/tpu_inference/envs.py
@@ -69,6 +69,7 @@ if TYPE_CHECKING:
     NUM_PRECOMPILE_WORKERS: int = 1
     DP_SCHED_BATCH_PREFILL: bool = False
     DP_SCHED_BATCH_PREFILL_FLUSH_TIMEOUT_MS: int = 10000
+    VLLM_MOE_CHUNK_SIZE: int = 0
     ONEHOT_MOE_PERMUTE_THRESHOLD: int = 0
     PROFILE_SINGLE_DEVICE: bool = False
     LORA_MODULE_PATH: str = ""
@@ -405,6 +406,8 @@ environment_variables: dict[str, Callable[[], Any]] = {
     lambda: int(os.getenv("DP_SCHED_BATCH_PREFILL_FLUSH_TIMEOUT_MS", "30000")),
     "MLA_XPOSE_N_TILE_SIZE":
     lambda: int(os.getenv("MLA_XPOSE_N_TILE_SIZE", "160")),
+    "VLLM_MOE_CHUNK_SIZE":
+    lambda: int(os.getenv("VLLM_MOE_CHUNK_SIZE", "0")),
     # Use Onehot+Matmul for permute and unpermute before and after moe
     # when the batch size <= this threshold. When set to 0, this feature
     # is effectively disabled.

--- a/tpu_inference/envs.py
+++ b/tpu_inference/envs.py
@@ -60,6 +60,7 @@ if TYPE_CHECKING:
     NUM_PRECOMPILE_WORKERS: int = 1
     DP_SCHED_BATCH_PREFILL: bool = False
     DP_SCHED_BATCH_PREFILL_FLUSH_TIMEOUT_MS: int = 10000
+    VLLM_MOE_CHUNK_SIZE: int = 0
     ONEHOT_MOE_PERMUTE_THRESHOLD: int = 0
     PROFILE_SINGLE_DEVICE: bool = False
     LORA_MODULE_PATH: str = ""
@@ -382,6 +383,8 @@ environment_variables: dict[str, Callable[[], Any]] = {
     lambda: int(os.getenv("DP_SCHED_BATCH_PREFILL_FLUSH_TIMEOUT_MS", "30000")),
     "MLA_XPOSE_N_TILE_SIZE":
     lambda: int(os.getenv("MLA_XPOSE_N_TILE_SIZE", "160")),
+    "VLLM_MOE_CHUNK_SIZE":
+    lambda: int(os.getenv("VLLM_MOE_CHUNK_SIZE", "0")),
     # Use Onehot+Matmul for permute and unpermute before and after moe
     # when the batch size <= this threshold. When set to 0, this feature
     # is effectively disabled.

--- a/tpu_inference/kernels/sparse_core/ragged_gather_reduce.py
+++ b/tpu_inference/kernels/sparse_core/ragged_gather_reduce.py
@@ -52,7 +52,7 @@ def _pad_inputs_if_needed(
     num_simd_lanes: int,
 ) -> tuple[jax.Array, jax.Array, jax.Array, jax.Array]:
     """Pads inputs if needed."""
-    input_size = x.shape[0]
+    input_size = indices.shape[0]
     hidden_size = x.shape[1]
     aligned_hidden_size = _align_to(hidden_size, 128 * num_column_partitions)
     row_tile_size = num_simd_lanes
@@ -64,7 +64,7 @@ def _pad_inputs_if_needed(
 
     x = jnp.pad(
         x,
-        ((0, pad_input_size), (0, aligned_hidden_size - hidden_size)),
+        ((0, 0), (0, aligned_hidden_size - hidden_size)),
         constant_values=0,
     )
     indices = jnp.pad(indices, (0, pad_input_size), constant_values=0)
@@ -141,7 +141,7 @@ def main_kernel(
     )
     def inner_kernel():
         core_id = pl.program_id(0)
-        row_partition_size = in_hbm_ref.shape[0] // num_row_partitions
+        row_partition_size = indices_hbm_ref.shape[0] // num_row_partitions
         row_partition_id = core_id // num_column_partitions
         col_partition_id = core_id % num_column_partitions
 
@@ -494,6 +494,7 @@ def ragged_gather_reduce(
     hidden_size = x.shape[-1]
     input_size = indices.size
     num_simd_lanes = sc_info.num_lanes
+
     num_cores = sc_info.num_cores * sc_info.num_subcores
 
     # This kernel partitions the output's columns into `num_column_partitions` and
@@ -554,7 +555,7 @@ def ragged_gather_reduce(
             num_column_partitions=num_column_partitions,
         ),
         out_type=jax.ShapeDtypeStruct(
-            (x.shape[0] // reduce_group_size, x.shape[1]),
+            (indices.shape[0] // reduce_group_size, x.shape[1]),
             jnp.float32,
         ),
         compiler_params=pltpu.CompilerParams(

--- a/tpu_inference/kernels/sparse_core/ragged_gather_reduce.py
+++ b/tpu_inference/kernels/sparse_core/ragged_gather_reduce.py
@@ -54,7 +54,7 @@ def _pad_inputs_if_needed(
     num_simd_lanes: int,
 ) -> tuple[jax.Array, jax.Array, jax.Array, jax.Array]:
     """Pads inputs if needed."""
-    input_size = x.shape[0]
+    input_size = indices.shape[0]
     hidden_size = x.shape[1]
     aligned_hidden_size = _align_to(hidden_size, 128 * num_column_partitions)
     row_tile_size = num_simd_lanes
@@ -66,7 +66,7 @@ def _pad_inputs_if_needed(
 
     x = jnp.pad(
         x,
-        ((0, pad_input_size), (0, aligned_hidden_size - hidden_size)),
+        ((0, 0), (0, aligned_hidden_size - hidden_size)),
         constant_values=0,
     )
     indices = jnp.pad(indices, (0, pad_input_size), constant_values=0)
@@ -143,7 +143,7 @@ def main_kernel(
     )
     def inner_kernel():
         core_id = pl.program_id(0)
-        row_partition_size = in_hbm_ref.shape[0] // num_row_partitions
+        row_partition_size = indices_hbm_ref.shape[0] // num_row_partitions
         row_partition_id = core_id // num_column_partitions
         col_partition_id = core_id % num_column_partitions
 
@@ -556,7 +556,7 @@ def ragged_gather_reduce(
             num_column_partitions=num_column_partitions,
         ),
         out_type=jax.ShapeDtypeStruct(
-            (x.shape[0] // reduce_group_size, x.shape[1]),
+            (indices.shape[0] // reduce_group_size, x.shape[1]),
             jnp.float32,
         ),
         compiler_params=pltpu.CompilerParams(

--- a/tpu_inference/layers/common/fused_moe_gmm.py
+++ b/tpu_inference/layers/common/fused_moe_gmm.py
@@ -154,12 +154,12 @@ def valid_rows_mask(batch_size: int, group_sizes: jax.Array,
                      True, False)
 
 
-def _permute_tokens_for_tiled_rs(x: jax.Array, dp_size: int,
-                                 num_chunks: int) -> jax.Array:
-    """Permutes tokens along the first dimension to correct for tiled reduce-scatter.
+def _permute_tokens_for_chunked_rs(x: jax.Array, dp_size: int,
+                                   num_chunks: int) -> jax.Array:
+    """Permutes tokens to correct for chunked reduce-scatter.
 
     This reordering ensures that when we slice the tokens into chunks and run
-    tiled reduce-scatter on each chunk locally, the resulting scattered outputs
+    reduce-scatter on each chunk locally, the resulting scattered outputs
     end up in the correct non-interleaved global sequence order after concatenation.
     """
     num_tokens = x.shape[0]
@@ -266,15 +266,15 @@ def moe_gmm_local(x: jax.Array,
         actual_chunk_size = num_tokens
 
     is_pipelined = actual_chunk_size < num_tokens
-    if is_pipelined:
+    if is_pipelined and scatter_axis_size > 1:
         num_chunks = num_tokens // actual_chunk_size
-        topk_weights = _permute_tokens_for_tiled_rs(topk_weights,
-                                                    scatter_axis_size,
-                                                    num_chunks)
+        topk_weights = _permute_tokens_for_chunked_rs(topk_weights,
+                                                      scatter_axis_size,
+                                                      num_chunks)
 
         revert_indices_2d = topk_argsort_revert_indices.reshape(
             num_tokens, topk)
-        revert_indices_2d = _permute_tokens_for_tiled_rs(
+        revert_indices_2d = _permute_tokens_for_chunked_rs(
             revert_indices_2d, scatter_axis_size, num_chunks)
         topk_argsort_revert_indices = revert_indices_2d.flatten()
 

--- a/tpu_inference/layers/common/fused_moe_gmm.py
+++ b/tpu_inference/layers/common/fused_moe_gmm.py
@@ -151,7 +151,8 @@ def moe_gmm_local(x: jax.Array,
                   parallelism: Literal["tp", "ep"],
                   enable_rs_kernel: bool = False,
                   onehot_moe_permute_threshold: int = 0,
-                  scatter_results: bool = False) -> jax.Array:
+                  scatter_results: bool = False,
+                  moe_chunk_size: int = 0) -> jax.Array:
     """Main MoE logic on a local shard can run in TP or EP mode.
 
     Set parallelism for "tp" or "ep"
@@ -184,6 +185,43 @@ def moe_gmm_local(x: jax.Array,
     batch_size = gmm2_res.shape[0]
     local_group_size = w1.shape[0]
 
+    reduction_axis = (ShardingAxisName.MLP_TENSOR
+                      if parallelism == "tp" else ShardingAxisName.EXPERT)
+
+    scatter_axis_size = 1
+    reduce_axes = ()
+    scatter_axes = ()
+
+    if enable_rs_kernel:
+        reduction_axes = reduction_axis if isinstance(
+            reduction_axis, tuple) else (reduction_axis, )
+        for axis in reduction_axes:
+            scatter_axis_size *= jax.lax.axis_size(axis)
+    elif scatter_results:
+        dp_axes = ShardingAxisName.ATTN_DATA
+        if not isinstance(dp_axes, tuple):
+            dp_axes = (dp_axes, )
+        if isinstance(reduction_axis, tuple):
+            reduce_axes = tuple(a for a in reduction_axis if a not in dp_axes)
+            scatter_axes = tuple(a for a in reduction_axis if a in dp_axes)
+        else:
+            reduce_axes = () if reduction_axis in dp_axes else (
+                reduction_axis, )
+            scatter_axes = (
+                reduction_axis, ) if reduction_axis in dp_axes else ()
+        for a in scatter_axes:
+            scatter_axis_size *= jax.lax.axis_size(a)
+
+    # Chunk Size Resolution
+    num_tokens = batch_size // topk
+    is_onehot = (local_group_size < group_sizes.size) and (
+        onehot_moe_permute_threshold > 0
+        and batch_size <= onehot_moe_permute_threshold)
+    if moe_chunk_size > 0 and num_tokens > moe_chunk_size * scatter_axis_size and not is_onehot:
+        actual_chunk_size = moe_chunk_size * scatter_axis_size
+    else:
+        actual_chunk_size = num_tokens
+
     if local_group_size < group_sizes.size:
         mask = valid_rows_mask(
             gmm1_res.shape[0],
@@ -194,89 +232,81 @@ def moe_gmm_local(x: jax.Array,
     else:
         mask = jnp.full((batch_size, ), True).reshape(-1, topk, 1)
 
-    reduction_axis = (ShardingAxisName.MLP_TENSOR
-                      if parallelism == "tp" else ShardingAxisName.EXPERT)
+    out_list = []
 
-    if local_group_size < group_sizes.size:
-        if batch_size <= onehot_moe_permute_threshold:
-            # Use onehot + matmul for unpermutation, which can be faster
-            # for small batch size.
-            assert batch_size % topk == 0, (
-                f"batch_size ({batch_size}) should be a multiple of topk "
-                f"({topk})")
-            num_tokens = batch_size // topk
-            revert_indices = topk_argsort_revert_indices.reshape(
-                num_tokens, topk)
-            onehot = jax.nn.one_hot(revert_indices,
-                                    batch_size,
-                                    dtype=gmm2_res.dtype)
-            combine = (onehot * topk_weights[..., None] * mask).sum(axis=1)
-            out = combine @ gmm2_res
+    # Pipelining Loop
+    for start_tok in range(0, num_tokens, actual_chunk_size):
+        end_tok = min(num_tokens, start_tok + actual_chunk_size)
+        start_idx = start_tok * topk
+        end_idx = end_tok * topk
+
+        cur_indices = topk_argsort_revert_indices[start_idx:end_idx]
+        cur_weights = topk_weights[start_tok:end_tok]
+        cur_mask = mask[start_tok:end_tok]
+
+        if local_group_size < group_sizes.size:
+            if onehot_moe_permute_threshold > 0 and batch_size <= onehot_moe_permute_threshold:
+                revert_indices = cur_indices.reshape(-1, topk)
+                onehot = jax.nn.one_hot(revert_indices,
+                                        batch_size,
+                                        dtype=gmm2_res.dtype)
+                combine = (onehot * cur_weights[..., None] *
+                           cur_mask).sum(axis=1)
+                chunk_hidden = combine @ gmm2_res
+            else:
+                chunk_hidden = ragged_gather_reduce(gmm2_res, cur_indices,
+                                                    cur_weights.reshape(-1),
+                                                    cur_mask.reshape(-1), topk)
         else:
-            out = ragged_gather_reduce(gmm2_res, topk_argsort_revert_indices,
-                                       topk_weights.reshape(-1),
-                                       mask.reshape(-1), topk)
-    else:
-        token_hidden_full = gmm2_res[topk_argsort_revert_indices]
-        cur_sorted = token_hidden_full.reshape((-1, topk, gmm2_res.shape[-1]))
-        cur_topk_weights = jnp.expand_dims(topk_weights, axis=-1)
-        cur_weighted = cur_sorted * cur_topk_weights
-        cur_masked = jnp.where(mask, cur_weighted, 0.0)
-        out = cur_masked.sum(axis=-2)
+            token_hidden_full = gmm2_res[cur_indices]
+            cur_sorted = token_hidden_full.reshape(
+                (-1, topk, gmm2_res.shape[-1]))
+            cur_topk_weights = jnp.expand_dims(cur_weights, axis=-1)
+            cur_weighted = cur_sorted * cur_topk_weights
+            cur_masked = jnp.where(cur_mask, cur_weighted, 0.0)
+            chunk_hidden = cur_masked.sum(axis=-2)
 
-    # Then global reduction on all ranks for all tokens and all experts
-    if enable_rs_kernel:
-        reduction_axes = reduction_axis if isinstance(
-            reduction_axis, tuple) else (reduction_axis, )
-        num_devices = 1
-        for axis in reduction_axes:
-            num_devices *= jax.lax.axis_size(axis)
-
-        # Fallback to psum-scatter for small token sizes to avoid Mosaic compilation.
-        # The threshold is chosen based on the tile dimension (8) in the
-        # hierarchical reduce-scatter kernel.
-        if out.shape[0] // num_devices < 8:
-            out = jax.lax.psum_scatter(out,
-                                       axis_name=reduction_axis,
-                                       scatter_dimension=0,
-                                       tiled=True).astype(x.dtype)
+        if enable_rs_kernel:
+            # Fallback to psum-scatter for small token sizes to avoid Mosaic compilation.
+            # The threshold is chosen based on the tile dimension (8) in the
+            # hierarchical reduce-scatter kernel.
+            if chunk_hidden.shape[0] // scatter_axis_size < 8:
+                out = jax.lax.psum_scatter(chunk_hidden,
+                                           axis_name=reduction_axis,
+                                           scatter_dimension=0,
+                                           tiled=True).astype(x.dtype)
+            else:
+                # Determine the number of micro-batches
+                # Use 4 for large inputs to improve efficiency by maximizing the number of
+                # concurrent reduction streams, and 2 for smaller inputs to fit in ~32MB VMEM
+                num_mb = 2
+                if chunk_hidden.shape[0] // scatter_axis_size > 600:
+                    num_mb = 4
+                rs_out = hier_rs.hierarchical_reduce_scatter_local(
+                    chunk_hidden,
+                    num_devices=scatter_axis_size,
+                    num_micro_batches=num_mb,
+                    axis_name=reduction_axis)
+                out = rs_out.astype(x.dtype)
+        elif scatter_results:
+            if reduce_axes:
+                chunk_hidden = jax.lax.psum(chunk_hidden,
+                                            axis_name=reduce_axes)
+            if scatter_axes:
+                out = jax.lax.psum_scatter(chunk_hidden,
+                                           axis_name=scatter_axes,
+                                           scatter_dimension=0,
+                                           tiled=True).astype(x.dtype)
+            else:
+                out = chunk_hidden.astype(x.dtype)
         else:
-            # Determine the number of micro-batches
-            # Use 4 for large inputs to improve efficiency by maximizing the number of
-            # concurrent reduction streams, and 2 for smaller inputs to fit in ~32MB VMEM
-            num_mb = 2
-            if out.shape[0] // num_devices > 600:
-                num_mb = 4
-            rs_out = hier_rs.hierarchical_reduce_scatter_local(
-                out,
-                num_devices=num_devices,
-                num_micro_batches=num_mb,
-                axis_name=reduction_axis)
-            out = rs_out.astype(x.dtype)
-    elif scatter_results:
-        dp_axes = ShardingAxisName.ATTN_DATA
-        if isinstance(reduction_axis, tuple):
-            reduce_axes = tuple(a for a in reduction_axis if a not in dp_axes)
-            scatter_axes = tuple(a for a in reduction_axis if a in dp_axes)
-        else:
-            reduce_axes = () if reduction_axis in dp_axes else (
-                reduction_axis, )
-            scatter_axes = (
-                reduction_axis, ) if reduction_axis in dp_axes else ()
+            out = jax.lax.psum(chunk_hidden,
+                               axis_name=reduction_axis).astype(x.dtype)
 
-        if reduce_axes:
-            out = jax.lax.psum(out, axis_name=reduce_axes)
+        out_list.append(out)
 
-        if scatter_axes:
-            out = jax.lax.psum_scatter(out,
-                                       axis_name=scatter_axes,
-                                       scatter_dimension=0,
-                                       tiled=True).astype(x.dtype)
-        else:
-            out = out.astype(x.dtype)
-    else:
-        out = jax.lax.psum(out, axis_name=reduction_axis).astype(x.dtype)
-    return out
+    return jnp.concatenate(out_list,
+                           axis=0) if len(out_list) > 1 else out_list[0]
 
 
 def tensor_parallel_gmm(
@@ -297,6 +327,7 @@ def tensor_parallel_gmm(
     enable_rs_kernel: bool = False,
     onehot_moe_permute_threshold: int = 0,
     scatter_results: bool = False,
+    moe_chunk_size: int = 0,
 ) -> jax.Array:
     data_p_spec = P(ShardingAxisName.MLP_DATA)
     attn_data_p_spec = P(ShardingAxisName.ATTN_DATA)
@@ -329,6 +360,7 @@ def tensor_parallel_gmm(
             enable_rs_kernel=False,
             onehot_moe_permute_threshold=onehot_moe_permute_threshold,
             scatter_results=scatter_results,
+            moe_chunk_size=moe_chunk_size,
         ),
         mesh=mesh,
         in_specs=(
@@ -378,6 +410,7 @@ def expert_parallel_gmm(
     mesh: Mesh,
     enable_rs_kernel: bool = False,
     onehot_moe_permute_threshold: int = 0,
+    moe_chunk_size: int = 0,
     scatter_results: bool = False,
 ) -> jax.Array:
     ep_size = get_mesh_shape_product(mesh, ShardingAxisName.EXPERT)
@@ -410,6 +443,7 @@ def expert_parallel_gmm(
             onehot_moe_permute_threshold=onehot_moe_permute_threshold,
             enable_rs_kernel=enable_rs_kernel,
             scatter_results=scatter_results,
+            moe_chunk_size=moe_chunk_size,
         ),
         mesh=mesh,
         in_specs=(
@@ -476,6 +510,7 @@ def _apply_all_gather_fp8(hidden_states: jax.Array, mesh: Mesh,
     "enable_rs_kernel",
     "onehot_moe_permute_threshold",
     "scatter_results",
+    "moe_chunk_size",
 ))
 def fused_moe_func(
     hidden_states: jax.Array,
@@ -498,6 +533,7 @@ def fused_moe_func(
     scatter_results: bool = False,
     hash_based_topk_indices: jax.Array | None = None,
     expert_score_correction_bias: jax.Array | None = None,
+    moe_chunk_size: int = 0,
 ) -> jax.Array:
     """Route tokens in hidden_states into each experts based on routing.
 
@@ -663,6 +699,7 @@ def fused_moe_func(
             enable_rs_kernel=actual_enable_rs_kernel,
             onehot_moe_permute_threshold=onehot_moe_permute_threshold,
             scatter_results=scatter_results,
+            moe_chunk_size=moe_chunk_size,
         )
     else:
         x = tensor_parallel_gmm(
@@ -682,6 +719,7 @@ def fused_moe_func(
             enable_rs_kernel=actual_enable_rs_kernel,
             onehot_moe_permute_threshold=onehot_moe_permute_threshold,
             scatter_results=scatter_results,
+            moe_chunk_size=moe_chunk_size,
         )
 
     return x[:num_tokens, :hidden_size]

--- a/tpu_inference/layers/common/fused_moe_gmm.py
+++ b/tpu_inference/layers/common/fused_moe_gmm.py
@@ -154,6 +154,29 @@ def valid_rows_mask(batch_size: int, group_sizes: jax.Array,
                      True, False)
 
 
+def _permute_tokens_for_tiled_rs(x: jax.Array, dp_size: int,
+                                 num_chunks: int) -> jax.Array:
+    """Permutes tokens along the first dimension to correct for tiled reduce-scatter.
+
+    This reordering ensures that when we slice the tokens into chunks and run
+    tiled reduce-scatter on each chunk locally, the resulting scattered outputs
+    end up in the correct non-interleaved global sequence order after concatenation.
+    """
+    num_tokens = x.shape[0]
+    chunk_size_per_device = num_tokens // (num_chunks * dp_size)
+
+    # Reshape to split the token dimension into (dp_size, num_chunks, chunk_size_per_device)
+    new_shape = (dp_size, num_chunks, chunk_size_per_device) + x.shape[1:]
+    x_reshaped = x.reshape(new_shape)
+
+    # Transpose the dp_size and num_chunks axes (axes 0 and 1)
+    transpose_axes = (1, 0, 2) + tuple(range(3, x_reshaped.ndim))
+    x_transposed = jnp.transpose(x_reshaped, transpose_axes)
+
+    # Flatten the first 3 dimensions back to num_tokens
+    return x_transposed.reshape(x.shape)
+
+
 def moe_gmm_local(x: jax.Array,
                   w1: jax.Array,
                   w1_scale: jax.Array | None,
@@ -171,7 +194,8 @@ def moe_gmm_local(x: jax.Array,
                   parallelism: Literal["tp", "ep"],
                   enable_rs_kernel: bool = False,
                   onehot_moe_permute_threshold: int = 0,
-                  scatter_results: bool = False) -> jax.Array:
+                  scatter_results: bool = False,
+                  moe_chunk_size: int = 0) -> jax.Array:
     """Main MoE logic on a local shard can run in TP or EP mode.
 
     Set parallelism for "tp" or "ep"
@@ -204,6 +228,56 @@ def moe_gmm_local(x: jax.Array,
     batch_size = gmm2_res.shape[0]
     local_group_size = w1.shape[0]
 
+    reduction_axis = (ShardingAxisName.MLP_TENSOR
+                      if parallelism == "tp" else ShardingAxisName.EXPERT)
+
+    scatter_axis_size = 1
+    reduce_axes = ()
+    scatter_axes = ()
+
+    if enable_rs_kernel:
+        reduction_axes = reduction_axis if isinstance(
+            reduction_axis, tuple) else (reduction_axis, )
+        for axis in reduction_axes:
+            scatter_axis_size *= jax.lax.axis_size(axis)
+    elif scatter_results:
+        dp_axes = ShardingAxisName.ATTN_DATA
+        if not isinstance(dp_axes, tuple):
+            dp_axes = (dp_axes, )
+        if isinstance(reduction_axis, tuple):
+            reduce_axes = tuple(a for a in reduction_axis if a not in dp_axes)
+            scatter_axes = tuple(a for a in reduction_axis if a in dp_axes)
+        else:
+            reduce_axes = () if reduction_axis in dp_axes else (
+                reduction_axis, )
+            scatter_axes = (
+                reduction_axis, ) if reduction_axis in dp_axes else ()
+        for a in scatter_axes:
+            scatter_axis_size *= jax.lax.axis_size(a)
+
+    # Chunk Size Resolution
+    num_tokens = batch_size // topk
+    is_onehot = (local_group_size < group_sizes.size) and (
+        onehot_moe_permute_threshold > 0
+        and batch_size <= onehot_moe_permute_threshold)
+    if moe_chunk_size > 0 and num_tokens > moe_chunk_size * scatter_axis_size and not is_onehot:
+        actual_chunk_size = moe_chunk_size * scatter_axis_size
+    else:
+        actual_chunk_size = num_tokens
+
+    is_pipelined = actual_chunk_size < num_tokens
+    if is_pipelined:
+        num_chunks = num_tokens // actual_chunk_size
+        topk_weights = _permute_tokens_for_tiled_rs(topk_weights,
+                                                    scatter_axis_size,
+                                                    num_chunks)
+
+        revert_indices_2d = topk_argsort_revert_indices.reshape(
+            num_tokens, topk)
+        revert_indices_2d = _permute_tokens_for_tiled_rs(
+            revert_indices_2d, scatter_axis_size, num_chunks)
+        topk_argsort_revert_indices = revert_indices_2d.flatten()
+
     if local_group_size < group_sizes.size:
         mask = valid_rows_mask(
             gmm1_res.shape[0],
@@ -214,89 +288,81 @@ def moe_gmm_local(x: jax.Array,
     else:
         mask = jnp.full((batch_size, ), True).reshape(-1, topk, 1)
 
-    reduction_axis = (ShardingAxisName.MLP_TENSOR
-                      if parallelism == "tp" else ShardingAxisName.EXPERT)
+    out_list = []
 
-    if local_group_size < group_sizes.size:
-        if batch_size <= onehot_moe_permute_threshold:
-            # Use onehot + matmul for unpermutation, which can be faster
-            # for small batch size.
-            assert batch_size % topk == 0, (
-                f"batch_size ({batch_size}) should be a multiple of topk "
-                f"({topk})")
-            num_tokens = batch_size // topk
-            revert_indices = topk_argsort_revert_indices.reshape(
-                num_tokens, topk)
-            onehot = jax.nn.one_hot(revert_indices,
-                                    batch_size,
-                                    dtype=gmm2_res.dtype)
-            combine = (onehot * topk_weights[..., None] * mask).sum(axis=1)
-            out = combine @ gmm2_res
+    # Pipelining Loop
+    for start_tok in range(0, num_tokens, actual_chunk_size):
+        end_tok = min(num_tokens, start_tok + actual_chunk_size)
+        start_idx = start_tok * topk
+        end_idx = end_tok * topk
+
+        cur_indices = topk_argsort_revert_indices[start_idx:end_idx]
+        cur_weights = topk_weights[start_tok:end_tok]
+        cur_mask = mask[start_tok:end_tok]
+
+        if local_group_size < group_sizes.size:
+            if onehot_moe_permute_threshold > 0 and batch_size <= onehot_moe_permute_threshold:
+                revert_indices = cur_indices.reshape(-1, topk)
+                onehot = jax.nn.one_hot(revert_indices,
+                                        batch_size,
+                                        dtype=gmm2_res.dtype)
+                combine = (onehot * cur_weights[..., None] *
+                           cur_mask).sum(axis=1)
+                chunk_hidden = combine @ gmm2_res
+            else:
+                chunk_hidden = ragged_gather_reduce(gmm2_res, cur_indices,
+                                                    cur_weights.reshape(-1),
+                                                    cur_mask.reshape(-1), topk)
         else:
-            out = ragged_gather_reduce(gmm2_res, topk_argsort_revert_indices,
-                                       topk_weights.reshape(-1),
-                                       mask.reshape(-1), topk)
-    else:
-        token_hidden_full = gmm2_res[topk_argsort_revert_indices]
-        cur_sorted = token_hidden_full.reshape((-1, topk, gmm2_res.shape[-1]))
-        cur_topk_weights = jnp.expand_dims(topk_weights, axis=-1)
-        cur_weighted = cur_sorted * cur_topk_weights
-        cur_masked = jnp.where(mask, cur_weighted, 0.0)
-        out = cur_masked.sum(axis=-2)
+            token_hidden_full = gmm2_res[cur_indices]
+            cur_sorted = token_hidden_full.reshape(
+                (-1, topk, gmm2_res.shape[-1]))
+            cur_topk_weights = jnp.expand_dims(cur_weights, axis=-1)
+            cur_weighted = cur_sorted * cur_topk_weights
+            cur_masked = jnp.where(cur_mask, cur_weighted, 0.0)
+            chunk_hidden = cur_masked.sum(axis=-2)
 
-    # Then global reduction on all ranks for all tokens and all experts
-    if enable_rs_kernel:
-        reduction_axes = reduction_axis if isinstance(
-            reduction_axis, tuple) else (reduction_axis, )
-        num_devices = 1
-        for axis in reduction_axes:
-            num_devices *= jax.lax.axis_size(axis)
-
-        # Fallback to psum-scatter for small token sizes to avoid Mosaic compilation.
-        # The threshold is chosen based on the tile dimension (8) in the
-        # hierarchical reduce-scatter kernel.
-        if out.shape[0] // num_devices < 8:
-            out = jax.lax.psum_scatter(out,
-                                       axis_name=reduction_axis,
-                                       scatter_dimension=0,
-                                       tiled=True).astype(x.dtype)
+        if enable_rs_kernel:
+            # Fallback to psum-scatter for small token sizes to avoid Mosaic compilation.
+            # The threshold is chosen based on the tile dimension (8) in the
+            # hierarchical reduce-scatter kernel.
+            if chunk_hidden.shape[0] // scatter_axis_size < 8:
+                out = jax.lax.psum_scatter(chunk_hidden,
+                                           axis_name=reduction_axis,
+                                           scatter_dimension=0,
+                                           tiled=True).astype(x.dtype)
+            else:
+                # Determine the number of micro-batches
+                # Use 4 for large inputs to improve efficiency by maximizing the number of
+                # concurrent reduction streams, and 2 for smaller inputs to fit in ~32MB VMEM
+                num_mb = 2
+                if chunk_hidden.shape[0] // scatter_axis_size > 600:
+                    num_mb = 4
+                rs_out = hier_rs.hierarchical_reduce_scatter_local(
+                    chunk_hidden,
+                    num_devices=scatter_axis_size,
+                    num_micro_batches=num_mb,
+                    axis_name=reduction_axis)
+                out = rs_out.astype(x.dtype)
+        elif scatter_results:
+            if reduce_axes:
+                chunk_hidden = jax.lax.psum(chunk_hidden,
+                                            axis_name=reduce_axes)
+            if scatter_axes:
+                out = jax.lax.psum_scatter(chunk_hidden,
+                                           axis_name=scatter_axes,
+                                           scatter_dimension=0,
+                                           tiled=True).astype(x.dtype)
+            else:
+                out = chunk_hidden.astype(x.dtype)
         else:
-            # Determine the number of micro-batches
-            # Use 4 for large inputs to improve efficiency by maximizing the number of
-            # concurrent reduction streams, and 2 for smaller inputs to fit in ~32MB VMEM
-            num_mb = 2
-            if out.shape[0] // num_devices > 600:
-                num_mb = 4
-            rs_out = hier_rs.hierarchical_reduce_scatter_local(
-                out,
-                num_devices=num_devices,
-                num_micro_batches=num_mb,
-                axis_name=reduction_axis)
-            out = rs_out.astype(x.dtype)
-    elif scatter_results:
-        dp_axes = ShardingAxisName.ATTN_DATA
-        if isinstance(reduction_axis, tuple):
-            reduce_axes = tuple(a for a in reduction_axis if a not in dp_axes)
-            scatter_axes = tuple(a for a in reduction_axis if a in dp_axes)
-        else:
-            reduce_axes = () if reduction_axis in dp_axes else (
-                reduction_axis, )
-            scatter_axes = (
-                reduction_axis, ) if reduction_axis in dp_axes else ()
+            out = jax.lax.psum(chunk_hidden,
+                               axis_name=reduction_axis).astype(x.dtype)
 
-        if reduce_axes:
-            out = jax.lax.psum(out, axis_name=reduce_axes)
+        out_list.append(out)
 
-        if scatter_axes:
-            out = jax.lax.psum_scatter(out,
-                                       axis_name=scatter_axes,
-                                       scatter_dimension=0,
-                                       tiled=True).astype(x.dtype)
-        else:
-            out = out.astype(x.dtype)
-    else:
-        out = jax.lax.psum(out, axis_name=reduction_axis).astype(x.dtype)
-    return out
+    return jnp.concatenate(out_list,
+                           axis=0) if len(out_list) > 1 else out_list[0]
 
 
 def tensor_parallel_gmm(
@@ -317,6 +383,7 @@ def tensor_parallel_gmm(
     enable_rs_kernel: bool = False,
     onehot_moe_permute_threshold: int = 0,
     scatter_results: bool = False,
+    moe_chunk_size: int = 0,
 ) -> jax.Array:
     data_p_spec = P(ShardingAxisName.MLP_DATA)
     attn_data_p_spec = P(ShardingAxisName.ATTN_DATA)
@@ -349,6 +416,7 @@ def tensor_parallel_gmm(
             enable_rs_kernel=False,
             onehot_moe_permute_threshold=onehot_moe_permute_threshold,
             scatter_results=scatter_results,
+            moe_chunk_size=moe_chunk_size,
         ),
         mesh=mesh,
         in_specs=(
@@ -398,6 +466,7 @@ def expert_parallel_gmm(
     mesh: Mesh,
     enable_rs_kernel: bool = False,
     onehot_moe_permute_threshold: int = 0,
+    moe_chunk_size: int = 0,
     scatter_results: bool = False,
 ) -> jax.Array:
     ep_size = get_mesh_shape_product(mesh, ShardingAxisName.EXPERT)
@@ -430,6 +499,7 @@ def expert_parallel_gmm(
             onehot_moe_permute_threshold=onehot_moe_permute_threshold,
             enable_rs_kernel=enable_rs_kernel,
             scatter_results=scatter_results,
+            moe_chunk_size=moe_chunk_size,
         ),
         mesh=mesh,
         in_specs=(
@@ -496,6 +566,7 @@ def _apply_all_gather_fp8(hidden_states: jax.Array, mesh: Mesh,
     "enable_rs_kernel",
     "onehot_moe_permute_threshold",
     "scatter_results",
+    "moe_chunk_size",
 ))
 def fused_moe_func(
     hidden_states: jax.Array,
@@ -518,6 +589,7 @@ def fused_moe_func(
     scatter_results: bool = False,
     hash_based_topk_indices: jax.Array | None = None,
     expert_score_correction_bias: jax.Array | None = None,
+    moe_chunk_size: int = 0,
 ) -> jax.Array:
     """Route tokens in hidden_states into each experts based on routing.
 
@@ -683,6 +755,7 @@ def fused_moe_func(
             enable_rs_kernel=actual_enable_rs_kernel,
             onehot_moe_permute_threshold=onehot_moe_permute_threshold,
             scatter_results=scatter_results,
+            moe_chunk_size=moe_chunk_size,
         )
     else:
         x = tensor_parallel_gmm(
@@ -702,6 +775,7 @@ def fused_moe_func(
             enable_rs_kernel=actual_enable_rs_kernel,
             onehot_moe_permute_threshold=onehot_moe_permute_threshold,
             scatter_results=scatter_results,
+            moe_chunk_size=moe_chunk_size,
         )
 
     return x[:num_tokens, :hidden_size]

--- a/tpu_inference/layers/common/moe.py
+++ b/tpu_inference/layers/common/moe.py
@@ -82,6 +82,7 @@ def moe_apply(
     extra_backend_kwargs = dict(
         extra_backend_kwargs) if extra_backend_kwargs else {}
     scatter_results = extra_backend_kwargs.pop("scatter_results", False)
+    moe_chunk_size = extra_backend_kwargs.pop("moe_chunk_size", 0)
 
     with jax.named_scope(layer._get_name()):
         activation = layer.activation if isinstance(
@@ -161,6 +162,7 @@ def moe_apply(
                         "hash_based_topk_indices", None),
                     expert_score_correction_bias=extra_backend_kwargs.get(
                         "e_score_correction_bias", None),
+                    moe_chunk_size=moe_chunk_size,
                 )
             case MoEBackend.DENSE_MAT:
                 # NOTE: circular import avoidance

--- a/tpu_inference/layers/vllm/interface/moe.py
+++ b/tpu_inference/layers/vllm/interface/moe.py
@@ -111,6 +111,7 @@ def vllm_moe_apply(layer: RoutedExperts,
 
     extra_kwargs = dict(quant_method_instance.extra_backend_kwargs)
     extra_kwargs["scatter_results"] = is_dp
+    extra_kwargs["moe_chunk_size"] = envs.VLLM_MOE_CHUNK_SIZE
 
     if getattr(layer, "hash_indices_table", None) is not None:
         assert input_ids is not None, "input_ids must be provided when hash_indices_table is present in the layer"


### PR DESCRIPTION
# Description

4 Way pipeline with MoE combine-reduce using SC kernel + psum_scatter on TC, this is on prefill only. I created a new configurable VLLM_MOE_CHUNK_SIZE, which is set to 256 in our case. I have tested 2 way as well, but 4 way performed better. I'm running against 6/2's commit, so
baseline: http://xprof.corp.google.com/trace_viewer/hning-9120565002754914291. After: https://xprof.corp.google.com/trace_viewer/zhangamy-5070159141590755285?view_start=809.465&view_end=811.451

Improvement: 17-18% reduction in latency for 8k prefill 4 Layer (3 GDN+1GQA) E2E latency
baseline: average 20ms;    median 19.4ms.
after:       average 16.2ms; median 16.1ms.
This is based on 34*4 complete layers.

Post MoE ragged_gather_reduce + ReduceScatter + post reduce f32->bf16 convert_select_fusion total time: baseline median: 1409us.
after median: 1008us. only a small portion of the 1st ragged_gather_reduce is exposed, followed by 4 ReduceScatters. Using median over average here since the impact of expert imbalance on 1 vs. 4 gather_reduce/RS per layer makes average not really apples to apples comparison.

Key notes:
xla_tpu_enable_sparse_core_collective_offload_reduce_scatter=false --xla_tpu_ars_combiner_threshold_in_bytes=0 --xla_tpu_enable_async_collective_merger=false are required to make the pipelined ReduceScatter work on TC.

Start with a short description of what the PR does and how this is a change from
the past.

Quality: ran mmlu_pro eval, got 0.8343 stderr 0.0138, on par with latest values