### PR TITLE
[Benchmark][Qwen3.5] Turn on cudagraph MM encoder in benchmark

### DIFF
--- a/.buildkite/benchmark/cases/daily/daily_qwen3_5_397b_fp8_tpu7x_8.json
+++ b/.buildkite/benchmark/cases/daily/daily_qwen3_5_397b_fp8_tpu7x_8.json
@@ -195,7 +195,8 @@
           "limit-mm-per-prompt": "{\"image\":8,\"video\":0}",
           "allowed-local-media-path": "/workspace/tpu_inference/artifacts/dataset",
           "disable-chunked-mm-input": true,
-          "mm-processor-kwargs": "{\"size\": {\"longest_edge\": 262144, \"shortest_edge\": 3136}}"
+          "mm-processor-kwargs": "{\"size\": {\"longest_edge\": 262144, \"shortest_edge\": 3136}}",
+          "compilation-config": "{\"cudagraph_mm_encoder\": true}"
         }
       },
       "client_command_options": {


### PR DESCRIPTION
# Description

new throughput [3.05 req/s](https://buildkite.com/tpu-commons/tpu-inference-benchmark/builds/1404#019ebcf4-f2b4-466e-8064-0bcf176a35ab/L2176)
before: 0.78 req/s

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
