### PR TITLE
Explicit shutdown server instead of deleting reference and wait

### DIFF
--- a/tests/e2e/test_runai_model_streamer_loader.py
+++ b/tests/e2e/test_runai_model_streamer_loader.py
@@ -34,8 +34,6 @@
 
 from __future__ import annotations
 
-import time
-
 import pytest
 from vllm import LLM, SamplingParams
 
@@ -77,8 +75,7 @@ def test_correctness_jax_uni_proc_executor(
                   max_num_batched_tokens=256)
     gcs_outputs = gcs_llm.generate([prompt], sampling_config)
     gcs_output_text = gcs_outputs[0].outputs[0].text
-    del gcs_llm
-    time.sleep(10)  # Wait for TPUs to be released
+    gcs_llm.llm_engine.engine_core.shutdown()
 
     # Test with Hugging Face model
     hf_llm = LLM(model=hf_model_name,
@@ -87,8 +84,7 @@ def test_correctness_jax_uni_proc_executor(
                  max_num_batched_tokens=256)
     hf_outputs = hf_llm.generate([prompt], sampling_config)
     hf_output_text = hf_outputs[0].outputs[0].text
-    del hf_llm
-    time.sleep(10)  # Wait for TPUs to be released
+    hf_llm.llm_engine.engine_core.shutdown()
 
     assert gcs_output_text == hf_output_text, (
         f"Outputs do not match! "
@@ -128,8 +124,7 @@ def test_correctness_torchax_uni_proc_executor(
                   max_num_batched_tokens=256)
     gcs_outputs = gcs_llm.generate([prompt], sampling_config)
     gcs_output_text = gcs_outputs[0].outputs[0].text
-    del gcs_llm
-    time.sleep(10)  # Wait for TPUs to be released
+    gcs_llm.llm_engine.engine_core.shutdown()
 
     # Test with Hugging Face model
     hf_llm = LLM(model=hf_model_name,
@@ -138,8 +133,7 @@ def test_correctness_torchax_uni_proc_executor(
                  max_num_batched_tokens=256)
     hf_outputs = hf_llm.generate([prompt], sampling_config)
     hf_output_text = hf_outputs[0].outputs[0].text
-    del hf_llm
-    time.sleep(10)  # Wait for TPUs to be released
+    hf_llm.llm_engine.engine_core.shutdown()
 
     assert gcs_output_text == hf_output_text, (
         f"Outputs do not match! "
@@ -180,8 +174,7 @@ def test_correctness_torchax_ray_distributed_executor(
                   max_num_batched_tokens=256)
     gcs_outputs = gcs_llm.generate([prompt], sampling_config)
     gcs_output_text = gcs_outputs[0].outputs[0].text
-    del gcs_llm
-    time.sleep(10)  # Wait for TPUs to be released
+    gcs_llm.llm_engine.engine_core.shutdown()
 
     # Test with Hugging Face model
     hf_llm = LLM(model=hf_model_name,
@@ -191,8 +184,7 @@ def test_correctness_torchax_ray_distributed_executor(
                  max_num_batched_tokens=256)
     hf_outputs = hf_llm.generate([prompt], sampling_config)
     hf_output_text = hf_outputs[0].outputs[0].text
-    del hf_llm
-    time.sleep(10)  # Wait for TPUs to be released
+    hf_llm.llm_engine.engine_core.shutdown()
 
     assert gcs_output_text == hf_output_text, (
         f"Outputs do not match! "

--- a/tests/e2e/test_speculative_decoding.py
+++ b/tests/e2e/test_speculative_decoding.py
@@ -147,10 +147,7 @@ def _get_baseline_results(
         ref_llm = LLM(model=model_name, **kwargs)
         ref_outputs = ref_llm.generate(test_prompts, sampling_config)
 
-        del ref_llm
-
-        # Waiting for TPUs to be released.
-        time.sleep(10)
+        ref_llm.llm_engine.engine_core.shutdown()
         return ref_outputs
 
 
@@ -224,10 +221,7 @@ def _test_correctness_helper(
         print(
             f"All {matches} outputs match between reference LLM and speculative LLM."
         )
-        del spec_llm
-
-        # Waiting for TPUs to be released.
-        time.sleep(10)
+        spec_llm.llm_engine.engine_core.shutdown()
 
 
 def test_ngram_correctness_greedy(


### PR DESCRIPTION
# Description

<img width="1224" height="646" alt="Screenshot 2026-06-13 at 11 48 53 PM" src="https://github.com/user-attachments/assets/a373b89b-1bc4-4ac0-9d49-105390407e6f" />
Seeing lots of test failures for ones that start one server immediately after another and the failures are TPU being occupied by another process. Explicit shutdown server instead of deleting reference and wait

The rest of the description includes relevant details and context, examples:
- why is this change being made,
- the problem being solved and any relevant context,
- why this is a good solution,
- some information about the specific implementation,
- shortcomings of the solution and possible future improvements.

If the change fixes a Github issue, please include a link, e.g.,:
FIXES: #123456

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [ ] I have performed a self-review of my code.
- [ ] I have necessary comments in my code, particularly in hard-to-understand areas.
- [ ] I have made or will make corresponding changes to any relevant documentation.
- [ ] I have reviewed the uLLM modeling code checklist: https://docs.google.com/document/d/1DGQBVvr2bh4G8tBUO1YH8pO7Dd_myw5rfEMfVDymEk8/edit?resourcekey=0-V7MGHu3aQjJH6YrI3-y8Hg&tab=t.t91cyovog2mr#heading=h.cqdzv8mlszca
- [ ] I have received at least 1 readability approval and 1 correctness approval.
