### PR TITLE
Build image once as we were just building the same image for N pipelines

### DIFF
--- a/.buildkite/benchmark/scripts/generate_bk_pipeline.py
+++ b/.buildkite/benchmark/scripts/generate_bk_pipeline.py
@@ -223,7 +223,10 @@ def create_benchmark_steps(case_data: Dict[str, Any],
     mlcompass_select_tests = _get_mlcompass_select_tests()
     for agent in ci_queues:
         # Build the environment for this specific step
-        step_env = {**combined_env, "ci_queue": agent}
+        step_env = {
+            **combined_env, "ci_queue": agent,
+            "USE_PREBUILT_IMAGE": "1"
+        }
 
         step_env["TARGET_CASE_NAME"] = case_name
         # Include parent_dir in label for uniqueness
@@ -345,6 +348,7 @@ def main():
         "steps": [{
             "group": group_display_name,
             "key": group_key,
+            "depends_on": "build_docker",
             "steps": all_steps
         }]
     }

--- a/.buildkite/pipeline_build.yml
+++ b/.buildkite/pipeline_build.yml
@@ -1,0 +1,37 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+.docker_build_template: &docker_build_template
+  agents:
+    queue: cpu_64_core
+  commands:
+    - bash -c 'source .buildkite/scripts/setup_docker_env.sh && setup_environment "vllm-tpu" "false" "true"'
+
+steps:
+  - group: "Build Docker Images"
+    key: "build_docker"
+    steps:
+      - label: ":docker: Build and Push Base Image (tpu6e)"
+        key: "build_docker_tpu6e"
+        <<: *docker_build_template
+        env:
+          BM_INFRA: "true"
+          TPU_VERSION: "tpu6e"
+
+      - label: ":docker: Build and Push Base Image (tpu7x)"
+        key: "build_docker_tpu7x"
+        <<: *docker_build_template
+        env:
+          BM_INFRA: "true"
+          TPU_VERSION: "tpu7x"

--- a/.buildkite/pipeline_dev.yml
+++ b/.buildkite/pipeline_dev.yml
@@ -37,17 +37,6 @@
 
 steps:
 
-  # -----------------------------------------------------------------
-  # Build Step (required by all demo steps below)
-  # -----------------------------------------------------------------
-  - label: ":docker: Build and Push Base Image (tpu7x)"
-    key: tpu7x_build_docker
-    agents:
-      queue: cpu_64_core
-    env:
-      TPU_VERSION: "tpu7x"
-    commands:
-      - bash -c 'source .buildkite/scripts/setup_docker_env.sh && setup_environment "vllm-tpu" "false" "true"'
 
   # -----------------------------------------------------------------
   # Demo 1: offline_inference.py
@@ -56,7 +45,6 @@ steps:
   # -----------------------------------------------------------------
   - label: "tpu7x [demo] offline_inference.py"
     key: tpu7x_demo_offline_inference
-    depends_on: tpu7x_build_docker
     env:
       USE_PREBUILT_IMAGE: "1"
       TPU_VERSION: "tpu7x"
@@ -81,7 +69,6 @@ steps:
   # -----------------------------------------------------------------
   - label: "tpu7x [demo] vllm serve + vllm bench serve"
     key: tpu7x_demo_serve_bench
-    depends_on: tpu7x_build_docker
     env:
       USE_PREBUILT_IMAGE: "1"
       TPU_VERSION: "tpu7x"
@@ -101,7 +88,6 @@ steps:
   # -----------------------------------------------------------------
   - label: "tpu7x [demo] E2E disaggregation (DCN P/D)"
     key: tpu7x_demo_disagg
-    depends_on: tpu7x_build_docker
     env:
       USE_PREBUILT_IMAGE: "1"
       TPU_VERSION: "tpu7x"

--- a/.buildkite/pipeline_jax.yml
+++ b/.buildkite/pipeline_jax.yml
@@ -14,26 +14,14 @@
 
 steps:
   - group: "${TESTS_GROUP_LABEL:-[jax] TPU6e Tests Group}"
+    depends_on: "build_docker"
     steps:
-
-      # -----------------------------------------------------------------
-      # Centralized Build Step (Runs on the CPU queue)
-      # -----------------------------------------------------------------
-      - label: ":docker: Build and Push Base Image (${TPU_VERSION:-tpu6e})"
-        key: "${TPU_VERSION:-tpu6e}_build_docker"
-        agents:
-          queue: cpu_64_core
-        env:
-          TPU_VERSION: "${TPU_VERSION:-tpu6e}"
-        commands:
-          - bash -c 'source .buildkite/scripts/setup_docker_env.sh && setup_environment "vllm-tpu" "false" "true"'
 
       # -----------------------------------------------------------------
       # TEST STEPS - Calling wrapper
       # -----------------------------------------------------------------
       - label: "${TPU_VERSION:-tpu6e} E2E MLPerf tests for JAX models"
         key: "${TPU_VERSION:-tpu6e}_test_0"
-        depends_on: "${TPU_VERSION:-tpu6e}_build_docker"
         soft_fail: true
         env:
           USE_PREBUILT_IMAGE: "1"
@@ -69,7 +57,6 @@ steps:
 
       - label: "${TPU_VERSION:-tpu6e} E2E MLPerf tests for JAX + vLLM models on single chip"
         key: ${TPU_VERSION:-tpu6e}_test_3
-        depends_on: "${TPU_VERSION:-tpu6e}_build_docker"
         soft_fail: true
         env:
           USE_PREBUILT_IMAGE: "1"
@@ -95,7 +82,6 @@ steps:
 
       - label: "${TPU_VERSION:-tpu6e} E2E speculative decoding test"
         key: ${TPU_VERSION:-tpu6e}_test_6
-        depends_on: "${TPU_VERSION:-tpu6e}_build_docker"
         soft_fail: true
         env:
           USE_PREBUILT_IMAGE: "1"
@@ -109,7 +95,6 @@ steps:
 
       - label: "${TPU_VERSION:-tpu6e} JAX unit tests part1"
         key: ${TPU_VERSION:-tpu6e}_test_7_1
-        depends_on: "${TPU_VERSION:-tpu6e}_build_docker"
         soft_fail: true
         artifact_paths: ".coverage.part1.${TPU_VERSION:-tpu6e}"
         env:
@@ -125,7 +110,6 @@ steps:
 
       - label: "${TPU_VERSION:-tpu6e} JAX unit tests part2"
         key: ${TPU_VERSION:-tpu6e}_test_7_2
-        depends_on: "${TPU_VERSION:-tpu6e}_build_docker"
         soft_fail: true
         artifact_paths: ".coverage.part2.${TPU_VERSION:-tpu6e}"
         env:
@@ -166,7 +150,6 @@ steps:
 
       - label: "${TPU_VERSION:-tpu6e} JAX unit tests - kernels"
         key: ${TPU_VERSION:-tpu6e}_test_8
-        depends_on: "${TPU_VERSION:-tpu6e}_build_docker"
         soft_fail: true
         env:
           USE_PREBUILT_IMAGE: "1"
@@ -187,7 +170,6 @@ steps:
 
       - label: "${TPU_VERSION:-tpu6e} JAX unit tests - collective kernels"
         key: ${TPU_VERSION:-tpu6e}_test_9
-        depends_on: "${TPU_VERSION:-tpu6e}_build_docker"
         soft_fail: true
         env:
           USE_PREBUILT_IMAGE: "1"
@@ -226,7 +208,6 @@ steps:
       # TODO (jacobplatin): re-enable this after b/467105149 is fixed
       - label: "${TPU_VERSION:-tpu6e} E2E MLperf tests for DeepSeek-R1 (no accuracy, 5-decoder layers only)"
         key: ${TPU_VERSION:-tpu6e}_test_12
-        depends_on: "${TPU_VERSION:-tpu6e}_build_docker"
         soft_fail: true
         env:
           USE_PREBUILT_IMAGE: "1"
@@ -247,7 +228,6 @@ steps:
 
       - label: "${TPU_VERSION:-tpu6e} E2E MMLU for DeepSeek-R1 torchax backend"
         key: ${TPU_VERSION:-tpu6e}_test_14
-        depends_on: "${TPU_VERSION:-tpu6e}_build_docker"
         soft_fail: true
         env:
           USE_PREBUILT_IMAGE: "1"
@@ -267,7 +247,6 @@ steps:
 
       - label: "${TPU_VERSION:-tpu6e} lora e2e tests for JAX + vLLM models multi chips"
         key: ${TPU_VERSION:-tpu6e}_test_13
-        depends_on: "${TPU_VERSION:-tpu6e}_build_docker"
         soft_fail: true
         env:
           USE_PREBUILT_IMAGE: "1"
@@ -281,7 +260,6 @@ steps:
 
       - label: "${TPU_VERSION:-tpu6e} lora unit tests on single chip"
         key: ${TPU_VERSION:-tpu6e}_test_15
-        depends_on: "${TPU_VERSION:-tpu6e}_build_docker"
         soft_fail: true
         env:
           USE_PREBUILT_IMAGE: "1"
@@ -296,7 +274,6 @@ steps:
 
       - label: "${TPU_VERSION:-tpu6e} lora unit tests on multi chips"
         key: ${TPU_VERSION:-tpu6e}_test_16
-        depends_on: "${TPU_VERSION:-tpu6e}_build_docker"
         soft_fail: true
         env:
           USE_PREBUILT_IMAGE: "1"
@@ -310,7 +287,6 @@ steps:
 
       - label: "${TPU_VERSION:-tpu6e} E2E lm_eval accuracy check qwen3 coder with fused moe."
         key: ${TPU_VERSION:-tpu6e}_test_17
-        depends_on: "${TPU_VERSION:-tpu6e}_build_docker"
         soft_fail: true
         env:
           USE_PREBUILT_IMAGE: "1"
@@ -324,7 +300,6 @@ steps:
 
       - label: "${TPU_VERSION:-tpu6e} E2E lm_eval accuracy check qwen3 coder with gmm kernel."
         key: ${TPU_VERSION:-tpu6e}_test_18
-        depends_on: "${TPU_VERSION:-tpu6e}_build_docker"
         soft_fail: true
         env:
           USE_PREBUILT_IMAGE: "1"
@@ -338,7 +313,6 @@ steps:
 
       - label: "${TPU_VERSION:-tpu6e} E2E lm_eval accuracy check gpt oss."
         key: ${TPU_VERSION:-tpu6e}_test_19
-        depends_on: "${TPU_VERSION:-tpu6e}_build_docker"
         soft_fail: true
         env:
           USE_PREBUILT_IMAGE: "1"
@@ -366,7 +340,6 @@ steps:
 
       - label: "${TPU_VERSION:-tpu6e} Perf regression test for qwen3 coder 8k 1k with fused moe kernel."
         key: ${TPU_VERSION:-tpu6e}_test_21
-        depends_on: "${TPU_VERSION:-tpu6e}_build_docker"
         soft_fail: true
         env:
           USE_PREBUILT_IMAGE: "1"
@@ -392,7 +365,6 @@ steps:
 
       - label: "${TPU_VERSION:-tpu6e} Perf regression test for qwen3 coder 8k 1k with gmm kernel."
         key: ${TPU_VERSION:-tpu6e}_test_23
-        depends_on: "${TPU_VERSION:-tpu6e}_build_docker"
         soft_fail: true
         env:
           USE_PREBUILT_IMAGE: "1"
@@ -406,7 +378,6 @@ steps:
 
       - label: "${TPU_VERSION:-tpu6e} Test EP recompilation."
         key: ${TPU_VERSION:-tpu6e}_test_24
-        depends_on: "${TPU_VERSION:-tpu6e}_build_docker"
         soft_fail: true
         env:
           USE_PREBUILT_IMAGE: "1"
@@ -420,7 +391,6 @@ steps:
 
       - label: "${TPU_VERSION:-tpu6e} E2E test for Multihost DCN-based P/D disaggregation"
         key: ${TPU_VERSION:-tpu6e}_test_25
-        depends_on: "${TPU_VERSION:-tpu6e}_build_docker"
         soft_fail: true
         env:
           USE_PREBUILT_IMAGE: "1"
@@ -469,7 +439,6 @@ steps:
 
       - label: "${TPU_VERSION:-tpu6e} Correctness Test | Runai Model Streamer JAX UniProcExecutor"
         key: "${TPU_VERSION:-tpu6e}_test_27"
-        depends_on: "${TPU_VERSION:-tpu6e}_build_docker"
         soft_fail: true
         env:
           USE_PREBUILT_IMAGE: "1"
@@ -481,7 +450,6 @@ steps:
 
       - label: "${TPU_VERSION:-tpu6e} Correctness Test | Runai Model Streamer Torchax UniProcExecutor"
         key: "${TPU_VERSION:-tpu6e}_test_28"
-        depends_on: "${TPU_VERSION:-tpu6e}_build_docker"
         soft_fail: true
         env:
           USE_PREBUILT_IMAGE: "1"
@@ -493,7 +461,6 @@ steps:
 
       - label: "${TPU_VERSION:-tpu6e} Correctness Test | Runai Model Streamer Torchax RayDistributedExecutor"
         key: "${TPU_VERSION:-tpu6e}_test_29"
-        depends_on: "${TPU_VERSION:-tpu6e}_build_docker"
         soft_fail: true
         env:
           USE_PREBUILT_IMAGE: "1"
@@ -505,7 +472,6 @@ steps:
 
       - label: "${TPU_VERSION:-tpu6e} E2E lm_eval accuracy check Qwen3.5-397B-A17B with gmm kernel."
         key: ${TPU_VERSION:-tpu6e}_test_30
-        depends_on: "${TPU_VERSION:-tpu6e}_build_docker"
         soft_fail: true
         env:
           USE_PREBUILT_IMAGE: "1"
@@ -537,7 +503,6 @@ steps:
 
       - label: "${TPU_VERSION:-tpu6e} Perf regression test for Qwen3.5-397B-A17B 8k 1k with gmm kernel."
         key: ${TPU_VERSION:-tpu6e}_test_32
-        depends_on: "${TPU_VERSION:-tpu6e}_build_docker"
         soft_fail: true
         env:
           USE_PREBUILT_IMAGE: "1"
@@ -554,7 +519,6 @@ steps:
 
       - label: "${TPU_VERSION:-tpu6e} Accuracy for Qwen/Qwen2.5-VL-7B-Instruct"
         key: ${TPU_VERSION:-tpu6e}_test_33
-        depends_on: "${TPU_VERSION:-tpu6e}_build_docker"
         agents:
           queue: ${TPU_QUEUE_SINGLE:-tpu_v6e_queue}          
         soft_fail: true
@@ -568,7 +532,6 @@ steps:
 
       - label: "${TPU_VERSION:-tpu6e} E2E test for Single Host DCN-based P/D disaggregation"
         key: ${TPU_VERSION:-tpu6e}_test_34
-        depends_on: "${TPU_VERSION:-tpu6e}_build_docker"
         soft_fail: true
         env:
           USE_PREBUILT_IMAGE: "1"
@@ -586,7 +549,6 @@ steps:
 
       - label: "${TPU_VERSION:-tpu6e} E2E test for MPMD data parallelism"
         key: ${TPU_VERSION:-tpu6e}_test_35
-        depends_on: "${TPU_VERSION:-tpu6e}_build_docker"
         soft_fail: true
         env:
           USE_PREBUILT_IMAGE: "1"
@@ -621,7 +583,6 @@ steps:
 
       - label: "${TPU_VERSION:-tpu6e} Test Kernel Tuner Runner"
         key: ${TPU_VERSION:-tpu6e}_test_36
-        depends_on: "${TPU_VERSION:-tpu6e}_build_docker"
         env:
           USE_PREBUILT_IMAGE: "1"
           TPU_VERSION: "${TPU_VERSION:-tpu6e}"

--- a/.buildkite/pipeline_kernel_tuning.yml
+++ b/.buildkite/pipeline_kernel_tuning.yml
@@ -32,23 +32,12 @@
 
 steps:
 
-  # -----------------------------------------------------------------
-  # Build Step
-  # -----------------------------------------------------------------
-  - label: ":docker: Build and Push Base Image (${TPU_VERSION:-tpu6e})"
-    key: ${TPU_VERSION:-tpu6e}_build_docker
-    agents:
-      queue: cpu_64_core 
-    env:
-      TPU_VERSION: "${TPU_VERSION:-tpu6e}"
-    commands:
-      - bash -c 'source .buildkite/scripts/setup_docker_env.sh && setup_environment "vllm-tpu" "false" "true"'
 
   # -----------------------------------------------------------------
   # -----------------------------------------------------------------
   - label: ":docker: Tuning Cases Generation and Pipeline Upload (${TPU_VERSION:-tpu6e})"
     key: generate_tuning_cases_and_yml
-    depends_on: ${TPU_VERSION:-tpu6e}_build_docker
+    depends_on: build_docker
     env:
       USE_PREBUILT_IMAGE: "1"
       TPU_VERSION: "${TPU_VERSION:-tpu6e}"

--- a/.buildkite/pipeline_pypi.yml
+++ b/.buildkite/pipeline_pypi.yml
@@ -13,40 +13,43 @@
 # limitations under the License.
 
 steps:
-   - label: "PyPI Test Performance benchmarks for meta-llama/Llama-3.1-8B-Instruct"
-     key: "pypi_meta-llama_Llama-3_1-8B-Instruct_Benchmark"
-     if: build.env("NIGHTLY") == "1"
-     agents:
-      queue: tpu_v6e_queue
-     env:
-      TEST_MODEL: meta-llama/Llama-3.1-8B-Instruct
-      TENSOR_PARALLEL_SIZE: 1
-      MINIMUM_THROUGHPUT_THRESHOLD: 10.77
-      INPUT_LEN: 1800
-      OUTPUT_LEN: 128
-      PREFIX_LEN: 0
-      MAX_MODEL_LEN: 2048
-      MAX_NUM_SEQS: 256
-      MAX_NUM_BATCHED_TOKENS: 1024
-     commands:
-      - |
-        .buildkite/scripts/run_with_pypi.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/benchmark.sh
+  - group: "PyPI Nightly Tests"
+    depends_on: "build_docker"
+    steps:
+      - label: "PyPI Test Performance benchmarks for meta-llama/Llama-3.1-8B-Instruct"
+        key: "pypi_meta-llama_Llama-3_1-8B-Instruct_Benchmark"
+        if: build.env("NIGHTLY") == "1"
+        agents:
+          queue: tpu_v6e_queue
+        env:
+          TEST_MODEL: meta-llama/Llama-3.1-8B-Instruct
+          TENSOR_PARALLEL_SIZE: 1
+          MINIMUM_THROUGHPUT_THRESHOLD: 10.77
+          INPUT_LEN: 1800
+          OUTPUT_LEN: 128
+          PREFIX_LEN: 0
+          MAX_MODEL_LEN: 2048
+          MAX_NUM_SEQS: 256
+          MAX_NUM_BATCHED_TOKENS: 1024
+        commands:
+          - |
+            .buildkite/scripts/run_with_pypi.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/benchmark.sh
 
-   - label: "PyPI Test Performance benchmarks for Qwen/Qwen3-4B"
-     key: "pypi_Qwen_Qwen3-4B_Benchmark"
-     if: build.env("NIGHTLY") == "1"
-     agents:
-      queue: tpu_v6e_queue
-     env:
-      TEST_MODEL: Qwen/Qwen3-4B
-      TENSOR_PARALLEL_SIZE: 1
-      MINIMUM_THROUGHPUT_THRESHOLD: 11.00
-      INPUT_LEN: 1800
-      OUTPUT_LEN: 128
-      PREFIX_LEN: 0
-      MAX_MODEL_LEN: 2048
-      MAX_NUM_SEQS: 94
-      MAX_NUM_BATCHED_TOKENS: 4096
-     commands:
-      - |
-       .buildkite/scripts/run_with_pypi.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/benchmark.sh
+      - label: "PyPI Test Performance benchmarks for Qwen/Qwen3-4B"
+        key: "pypi_Qwen_Qwen3-4B_Benchmark"
+        if: build.env("NIGHTLY") == "1"
+        agents:
+          queue: tpu_v6e_queue
+        env:
+          TEST_MODEL: Qwen/Qwen3-4B
+          TENSOR_PARALLEL_SIZE: 1
+          MINIMUM_THROUGHPUT_THRESHOLD: 11.00
+          INPUT_LEN: 1800
+          OUTPUT_LEN: 128
+          PREFIX_LEN: 0
+          MAX_MODEL_LEN: 2048
+          MAX_NUM_SEQS: 94
+          MAX_NUM_BATCHED_TOKENS: 4096
+        commands:
+          - |
+            .buildkite/scripts/run_with_pypi.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/benchmark.sh

--- a/.buildkite/pipeline_torch.yml
+++ b/.buildkite/pipeline_torch.yml
@@ -13,141 +13,144 @@
 # limitations under the License.
 
 steps:
-  # -----------------------------------------------------------------
-  # TEST STEPS - Calling wrapper, using python3 -m pytest
-  # -----------------------------------------------------------------
-   - label: "TPU Test 0: test_perf.py"
-     key: tpu_test_0
-     soft_fail: true
-     agents:
-       queue: tpu_v6e_queue
-     commands:
-       - .buildkite/scripts/run_in_docker.sh python3 -m pytest -s -v /workspace/vllm/tests/v1/tpu/test_perf.py
+  - group: "Torch Tests"
+    depends_on: "build_docker"
+    steps:
+      # -----------------------------------------------------------------
+      # TEST STEPS - Calling wrapper, using python3 -m pytest
+      # -----------------------------------------------------------------
+       - label: "TPU Test 0: test_perf.py"
+         key: tpu_test_0
+         soft_fail: true
+         agents:
+           queue: tpu_v6e_queue
+         commands:
+           - .buildkite/scripts/run_in_docker.sh python3 -m pytest -s -v /workspace/vllm/tests/v1/tpu/test_perf.py
 
-   - label: "TPU Test 1: test_compilation.py"
-     key: tpu_test_1
-     soft_fail: true
-     agents:
-       queue: tpu_v6e_queue
-     commands:
-       - .buildkite/scripts/run_in_docker.sh python3 -m pytest -s -v /workspace/vllm/tests/tpu/test_compilation.py
+       - label: "TPU Test 1: test_compilation.py"
+         key: tpu_test_1
+         soft_fail: true
+         agents:
+           queue: tpu_v6e_queue
+         commands:
+           - .buildkite/scripts/run_in_docker.sh python3 -m pytest -s -v /workspace/vllm/tests/tpu/test_compilation.py
 
-   - label: "TPU Test 2: test_basic.py"
-     key: tpu_test_2
-     soft_fail: true
-     agents:
-       queue: tpu_v6e_queue
-     commands:
-       - .buildkite/scripts/run_in_docker.sh python3 -m pytest -s -v /workspace/vllm/tests/v1/tpu/test_basic.py
+       - label: "TPU Test 2: test_basic.py"
+         key: tpu_test_2
+         soft_fail: true
+         agents:
+           queue: tpu_v6e_queue
+         commands:
+           - .buildkite/scripts/run_in_docker.sh python3 -m pytest -s -v /workspace/vllm/tests/v1/tpu/test_basic.py
 
-   - label: "TPU Test 3: test_accuracy.py (v1)"
-     key: tpu_test_3
-     soft_fail: true
-     agents:
-       queue: tpu_v6e_queue
-     commands:
-       - .buildkite/scripts/run_in_docker.sh python3 -m pytest -s -v /workspace/vllm/tests/entrypoints/llm/test_accuracy.py::test_lm_eval_accuracy_v1_engine
+       - label: "TPU Test 3: test_accuracy.py (v1)"
+         key: tpu_test_3
+         soft_fail: true
+         agents:
+           queue: tpu_v6e_queue
+         commands:
+           - .buildkite/scripts/run_in_docker.sh python3 -m pytest -s -v /workspace/vllm/tests/entrypoints/llm/test_accuracy.py::test_lm_eval_accuracy_v1_engine
 
-   - label: "TPU Test 4: test_quantization_accuracy.py"
-     key: tpu_test_4
-     soft_fail: true
-     agents:
-       queue: tpu_v6e_queue
-     commands:
-       - .buildkite/scripts/run_in_docker.sh python3 -m pytest -s -v /workspace/vllm/tests/tpu/test_quantization_accuracy.py
+       - label: "TPU Test 4: test_quantization_accuracy.py"
+         key: tpu_test_4
+         soft_fail: true
+         agents:
+           queue: tpu_v6e_queue
+         commands:
+           - .buildkite/scripts/run_in_docker.sh python3 -m pytest -s -v /workspace/vllm/tests/tpu/test_quantization_accuracy.py
 
-   - label: "TPU Test 5: examples/offline_inference/tpu.py"
-     key: tpu_test_5
-     soft_fail: true
-     agents:
-       queue: tpu_v6e_queue
-     commands:
-       - .buildkite/scripts/run_in_docker.sh python3 /workspace/vllm/examples/offline_inference/tpu.py
+       - label: "TPU Test 5: examples/offline_inference/tpu.py"
+         key: tpu_test_5
+         soft_fail: true
+         agents:
+           queue: tpu_v6e_queue
+         commands:
+           - .buildkite/scripts/run_in_docker.sh python3 /workspace/vllm/examples/offline_inference/tpu.py
 
-   - label: "TPU Test 6: test_tpu_model_runner.py"
-     key: tpu_test_6
-     soft_fail: true
-     agents:
-       queue: tpu_v6e_queue
-     commands:
-       - .buildkite/scripts/run_in_docker.sh python3 -m pytest -s -v /workspace/vllm/tests/v1/tpu/worker/test_tpu_model_runner.py
+       - label: "TPU Test 6: test_tpu_model_runner.py"
+         key: tpu_test_6
+         soft_fail: true
+         agents:
+           queue: tpu_v6e_queue
+         commands:
+           - .buildkite/scripts/run_in_docker.sh python3 -m pytest -s -v /workspace/vllm/tests/v1/tpu/worker/test_tpu_model_runner.py
 
-   - label: "TPU Test 7: test_sampler.py"
-     key: tpu_test_7
-     soft_fail: true
-     agents:
-       queue: tpu_v6e_queue
-     commands:
-       - .buildkite/scripts/run_in_docker.sh python3 -m pytest -s -v /workspace/vllm/tests/v1/tpu/test_sampler.py
+       - label: "TPU Test 7: test_sampler.py"
+         key: tpu_test_7
+         soft_fail: true
+         agents:
+           queue: tpu_v6e_queue
+         commands:
+           - .buildkite/scripts/run_in_docker.sh python3 -m pytest -s -v /workspace/vllm/tests/v1/tpu/test_sampler.py
 
-   - label: "TPU Test 8: test_topk_topp_sampler.py"
-     key: tpu_test_8
-     soft_fail: true
-     agents:
-       queue: tpu_v6e_queue
-     commands:
-       - .buildkite/scripts/run_in_docker.sh python3 -m pytest -s -v /workspace/vllm/tests/v1/tpu/test_topk_topp_sampler.py
+       - label: "TPU Test 8: test_topk_topp_sampler.py"
+         key: tpu_test_8
+         soft_fail: true
+         agents:
+           queue: tpu_v6e_queue
+         commands:
+           - .buildkite/scripts/run_in_docker.sh python3 -m pytest -s -v /workspace/vllm/tests/v1/tpu/test_topk_topp_sampler.py
 
-   - label: "TPU Test 9: test_multimodal.py"
-     # TODO: test_multimodal.py has been removed from the upstream; to re-enable this pipeline, a new torchax test needs to be added.
-     key: tpu_test_9
-     soft_fail: true
-     agents:
-       queue: tpu_v6e_queue
-     commands:
-       - .buildkite/scripts/run_in_docker.sh python3 -m pytest -s -v /workspace/vllm/tests/v1/tpu/test_multimodal.py
+       - label: "TPU Test 9: test_multimodal.py"
+         # TODO: test_multimodal.py has been removed from the upstream; to re-enable this pipeline, a new torchax test needs to be added.
+         key: tpu_test_9
+         soft_fail: true
+         agents:
+           queue: tpu_v6e_queue
+         commands:
+           - .buildkite/scripts/run_in_docker.sh python3 -m pytest -s -v /workspace/vllm/tests/v1/tpu/test_multimodal.py
 
-   - label: "TPU Test 10: test_pallas.py"
-     key: tpu_test_10
-     soft_fail: true
-     agents:
-       queue: tpu_v6e_queue
-     commands:
-       - .buildkite/scripts/run_in_docker.sh python3 -m pytest -s -v /workspace/vllm/tests/v1/tpu/test_pallas.py
+       - label: "TPU Test 10: test_pallas.py"
+         key: tpu_test_10
+         soft_fail: true
+         agents:
+           queue: tpu_v6e_queue
+         commands:
+           - .buildkite/scripts/run_in_docker.sh python3 -m pytest -s -v /workspace/vllm/tests/v1/tpu/test_pallas.py
 
-   - label: "TPU Test 11: test_struct_output_generate.py"
-     key: tpu_test_11
-     soft_fail: true
-     agents:
-       queue: tpu_v6e_queue
-     commands:
-       - .buildkite/scripts/run_in_docker.sh python3 -m pytest -s -v /workspace/vllm/tests/v1/entrypoints/llm/test_struct_output_generate.py
+       - label: "TPU Test 11: test_struct_output_generate.py"
+         key: tpu_test_11
+         soft_fail: true
+         agents:
+           queue: tpu_v6e_queue
+         commands:
+           - .buildkite/scripts/run_in_docker.sh python3 -m pytest -s -v /workspace/vllm/tests/v1/entrypoints/llm/test_struct_output_generate.py
 
-   - label: "TPU Test 12: test_moe_pallas.py"
-     key: tpu_test_12
-     soft_fail: true
-     agents:
-       queue: tpu_v6e_queue
-     commands:
-      - .buildkite/scripts/run_in_docker.sh python3 -m pytest -s -v /workspace/vllm/tests/tpu/test_moe_pallas.py
+       - label: "TPU Test 12: test_moe_pallas.py"
+         key: tpu_test_12
+         soft_fail: true
+         agents:
+           queue: tpu_v6e_queue
+         commands:
+          - .buildkite/scripts/run_in_docker.sh python3 -m pytest -s -v /workspace/vllm/tests/tpu/test_moe_pallas.py
 
-   - label: "TPU Test 13: ragged_paged_attention_test.py"
-     key: tpu_test_13
-     soft_fail: true
-     agents:
-       queue: tpu_v6e_queue
-     commands:
-       - .buildkite/scripts/run_in_docker.sh python3 -m pytest -s -v /workspace/tpu_inference/tests/ragged_paged_attention_test.py
+       - label: "TPU Test 13: ragged_paged_attention_test.py"
+         key: tpu_test_13
+         soft_fail: true
+         agents:
+           queue: tpu_v6e_queue
+         commands:
+           - .buildkite/scripts/run_in_docker.sh python3 -m pytest -s -v /workspace/tpu_inference/tests/ragged_paged_attention_test.py
 
-  # -----------------------------------------------------------------
-  # NOTIFICATION STEP
-  # -----------------------------------------------------------------
-   - label: "TPU V1 Test Notification"
-     depends_on:
-       - tpu_test_0
-       - tpu_test_1
-       - tpu_test_2
-       - tpu_test_3
-       - tpu_test_4
-       - tpu_test_5
-       - tpu_test_6
-       - tpu_test_7
-       - tpu_test_8
-       - tpu_test_9
-       - tpu_test_10
-       - tpu_test_11
-       - tpu_test_12
-       - tpu_test_13
-     agents:
-       queue: cpu
-     commands: "bash .buildkite/scripts/check_results.sh 'TPU V1 Tests Failed' tpu_test_0 tpu_test_1 tpu_test_2 tpu_test_3 tpu_test_4 tpu_test_5 tpu_test_6 tpu_test_7 tpu_test_8 tpu_test_9 tpu_test_10 tpu_test_11 tpu_test_12 tpu_test_13"
+      # -----------------------------------------------------------------
+      # NOTIFICATION STEP
+      # -----------------------------------------------------------------
+       - label: "TPU V1 Test Notification"
+         depends_on:
+           - tpu_test_0
+           - tpu_test_1
+           - tpu_test_2
+           - tpu_test_3
+           - tpu_test_4
+           - tpu_test_5
+           - tpu_test_6
+           - tpu_test_7
+           - tpu_test_8
+           - tpu_test_9
+           - tpu_test_10
+           - tpu_test_11
+           - tpu_test_12
+           - tpu_test_13
+         agents:
+           queue: cpu
+         commands: "bash .buildkite/scripts/check_results.sh 'TPU V1 Tests Failed' tpu_test_0 tpu_test_1 tpu_test_2 tpu_test_3 tpu_test_4 tpu_test_5 tpu_test_6 tpu_test_7 tpu_test_8 tpu_test_9 tpu_test_10 tpu_test_11 tpu_test_12 tpu_test_13"

--- a/.buildkite/rl/rl_integration.yml
+++ b/.buildkite/rl/rl_integration.yml
@@ -67,7 +67,6 @@ steps:
 
   - label: "${TPU_VERSION:-tpu6e} E2E MMLU for Llama-3.1-8B continue_decode"
     key: "${TPU_VERSION:-tpu6e}_rl_integration_continue_decode_mmlu"
-    depends_on: "${TPU_VERSION:-tpu6e}_build_docker"
     soft_fail: true
     env:
       USE_PREBUILT_IMAGE: "1"

--- a/.buildkite/scripts/bootstrap.sh
+++ b/.buildkite/scripts/bootstrap.sh
@@ -195,6 +195,7 @@ upload_pipeline() {
 }
 
 upload_benchmark_pipeline() {
+    export BM_INFRA="true"
     VLLM_COMMIT_HASH=$(buildkite-agent meta-data get "VLLM_COMMIT_HASH")
     TPU_COMMIT_HASH=$(git rev-parse HEAD)
     CODE_HASH="${VLLM_COMMIT_HASH}-${TPU_COMMIT_HASH}-"
@@ -336,5 +337,8 @@ else
   fi
 fi
 
+# Since Buildkite inserts steps in reverse order, uploading this last 
+# ensures the Docker build steps appear at the very top of the UI.
+upload_with_priority .buildkite/pipeline_build.yml "$JOB_PRIORITY"
 
 echo "--- Buildkite Bootstrap Finished"

--- a/.buildkite/scripts/bootstrap_dev.sh
+++ b/.buildkite/scripts/bootstrap_dev.sh
@@ -41,4 +41,7 @@ echo "Using vllm commit hash: $(buildkite-agent meta-data get "VLLM_COMMIT_HASH"
 echo "--- :pipeline: Uploading pipeline_dev.yml"
 buildkite-agent pipeline upload .buildkite/pipeline_dev.yml
 
+echo "--- :pipeline: Uploading pipeline_build.yml"
+buildkite-agent pipeline upload .buildkite/pipeline_build.yml
+
 echo "--- Buildkite Dev Bootstrap Finished"

--- a/.buildkite/scripts/bootstrap_kernel_tuning.sh
+++ b/.buildkite/scripts/bootstrap_kernel_tuning.sh
@@ -107,4 +107,6 @@ set_jax_envs "${TPU_VERSION}" "${TPU_CORES}"
 buildkite-agent pipeline upload .buildkite/pipeline_kernel_tuning.yml
 set_jax_envs "unset" ""
 
+buildkite-agent pipeline upload .buildkite/pipeline_build.yml
+
 echo "--- Buildkite Kernel Tuning Bootstrap Finished"

--- a/.buildkite/scripts/run_in_docker.sh
+++ b/.buildkite/scripts/run_in_docker.sh
@@ -20,6 +20,11 @@
 # Exit on error, exit on unset variable, fail on pipe errors.
 set -euo pipefail
 
+# Centrally default to using prebuilt image when running in Buildkite CI
+if [ -n "${BUILDKITE:-}" ]; then
+  export USE_PREBUILT_IMAGE="${USE_PREBUILT_IMAGE:-1}"
+fi
+
 if [ "$#" -eq 0 ]; then
   echo "ERROR: Usage: $0 <command_and_args_to_run_in_docker...>"
   exit 1
@@ -64,6 +69,7 @@ ENV_VARS=(
   -e KERNEL_TUNING_JOB_PRIORITY="${PRIORITY_KERNEL_TUNING:--10}"
   -e KERNEL_TUNING_MAX_EXECUTION_MINUTES="${KERNEL_TUNING_MAX_EXECUTION_MINUTES:-20}"
   -e HOST_NAME="${HOST_NAME:-}"
+  -e GCS_BUCKET="${GCS_BUCKET:-}"
 )
 
 if [ -z "${MODEL_IMPL_TYPE:-}" ]; then

--- a/.buildkite/scripts/upload_models_and_features.sh
+++ b/.buildkite/scripts/upload_models_and_features.sh
@@ -163,6 +163,7 @@ if [[ "${#pipeline_v6e_fragments[@]}" -gt 0 ]]; then
     echo "steps:"
     echo "  - group: \"TPU v6e nightly Tests (${MODEL_IMPL_TYPE:-auto})\""
     echo "    key: \"v6e-group\""
+    echo "    depends_on: \"build_docker\""
     echo "    steps:"
     printf "%s\n" "${pipeline_v6e_fragments[@]}" | sed 's/^/      /'
   } | buildkite-agent pipeline upload
@@ -185,6 +186,7 @@ if [[ "${#pipeline_v7x_fragments[@]}" -gt 0 ]]; then
     echo "steps:"
     echo "  - group: \"TPU v7x nightly Tests (${MODEL_IMPL_TYPE:-auto})\""
     echo "    key: \"v7x-group\""
+    echo "    depends_on: \"build_docker\""
     echo "    steps:"
     printf "%s\n" "${pipeline_v7x_fragments[@]}" | sed 's/^/      /'
   } | buildkite-agent pipeline upload


### PR DESCRIPTION
# Description

I noticed that we are rebuilding the same docker images every time we start a new pipeline or in some scenarios when running nightly tests, we build that every step. 
We can reduce the overall time by building the image only once as each build time is around 8 mins.

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [ ] I have performed a self-review of my code.
- [ ] I have necessary comments in my code, particularly in hard-to-understand areas.
- [ ] I have made or will make corresponding changes to any relevant documentation.
- [ ] I have reviewed the uLLM modeling code checklist: https://docs.google.com/document/d/1DGQBVvr2bh4G8tBUO1YH8pO7Dd_myw5rfEMfVDymEk8/edit?resourcekey=0-V7MGHu3aQjJH6YrI3-y8Hg&tab=t.t91cyovog2mr#heading=h.cqdzv8mlszca
- [ ] I have received at least 1 readability approval and 1 correctness approval.
