### PR TITLE
Add Qwen3.6-35B-A3B model CI config + reasoning-model eval knobs

### DIFF
--- a/.buildkite/models/Qwen_Qwen3_6-35B-A3B.yml
+++ b/.buildkite/models/Qwen_Qwen3_6-35B-A3B.yml
@@ -1,0 +1,99 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+steps:
+  - label: "${TPU_VERSION:-tpu6e} Unit tests for Qwen/Qwen3.6-35B-A3B"
+    key: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3_6-35B-A3B_UnitTest"
+    agents:
+      queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
+    commands:
+      - |
+        .buildkite/scripts/run_in_docker.sh \
+          bash -c 'USE_BATCHED_RPA_KERNEL=1 SKIP_JAX_PRECOMPILE=1 VLLM_XLA_CHECK_RECOMPILATION=0 python /workspace/tpu_inference/examples/offline_inference.py --model Qwen/Qwen3.6-35B-A3B --tensor-parallel-size 8 --max-num-batched-tokens 4096 --max-model-len 4096'
+
+  - label: "${TPU_VERSION:-tpu6e} Record unit test result for Qwen/Qwen3.6-35B-A3B"
+    key: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen3_6-35B-A3B_UnitTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3_6-35B-A3B_UnitTest"
+    env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
+      CI_TARGET: "Qwen/Qwen3.6-35B-A3B"
+      CI_STAGE: "UnitTest"
+      CI_CATEGORY: "multimodal"
+    agents:
+      queue: cpu
+    commands:
+      - |
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_Qwen_Qwen3_6-35B-A3B_UnitTest
+
+  # Qwen3.6 is a hybrid-thinking reasoning model: GSM8K must run with the
+  # chat template, a reasoning-sized generation budget, and an <|im_end|>
+  # stop override (the stock "Question:" stop list truncates thinking-mode
+  # generations). EVAL_* knobs are set inline because run_in_docker.sh does
+  # not forward them. EVAL_LIMIT=100 keeps the job ~35 min; the 0.90
+  # threshold was calibrated on the same 100-example subset (measured 0.97).
+  - label: "${TPU_VERSION:-tpu6e} Accuracy for Qwen/Qwen3.6-35B-A3B"
+    key: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3_6-35B-A3B_Accuracy"
+    depends_on: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen3_6-35B-A3B_UnitTest"
+    agents:
+      queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
+    env:
+      TEST_MODEL: Qwen/Qwen3.6-35B-A3B
+      TENSOR_PARALLEL_SIZE: '8'
+      MINIMUM_ACCURACY_THRESHOLD: '0.90'
+      MODEL_IMPL_TYPE: vllm
+    commands:
+      - |
+        .buildkite/scripts/run_in_docker.sh bash -c 'USE_BATCHED_RPA_KERNEL=1 USE_CHAT_TEMPLATE=1 EVAL_MAX_MODEL_LEN=8192 EVAL_GEN_KWARGS="max_gen_toks=4096,until=<|im_end|>" EVAL_LIMIT=100 EVAL_GPU_MEMORY_UTILIZATION=0.85 bash /workspace/tpu_inference/tests/e2e/benchmarking/test_accuracy.sh'
+
+  - label: "${TPU_VERSION:-tpu6e} Record integration test result for Qwen/Qwen3.6-35B-A3B"
+    key: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen3_6-35B-A3B_Accuracy"
+    depends_on: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3_6-35B-A3B_Accuracy"
+    env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
+      CI_TARGET: "Qwen/Qwen3.6-35B-A3B"
+      CI_STAGE: "Accuracy/Correctness"
+      CI_CATEGORY: "multimodal"
+    agents:
+      queue: cpu
+    commands:
+      - |
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_Qwen_Qwen3_6-35B-A3B_Accuracy
+
+  - label: "${TPU_VERSION:-tpu6e} Performance benchmarks for Qwen/Qwen3.6-35B-A3B"
+    key: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3_6-35B-A3B_Benchmark"
+    depends_on: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen3_6-35B-A3B_Accuracy"
+    agents:
+      queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
+    env:
+      TEST_MODEL: Qwen/Qwen3.6-35B-A3B
+      TENSOR_PARALLEL_SIZE: '8'
+      MINIMUM_THROUGHPUT_THRESHOLD: 2
+      MODEL_IMPL_TYPE: vllm
+    commands:
+      - |
+        .buildkite/scripts/run_in_docker.sh bash -c 'TIMEOUT_SECONDS=960 USE_BATCHED_RPA_KERNEL=1 /workspace/tpu_inference/tests/e2e/benchmarking/mm_bench_recipe.sh'
+
+  - label: "${TPU_VERSION:-tpu6e} Record performance benchmark result for Qwen/Qwen3.6-35B-A3B"
+    key: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen3_6-35B-A3B_Benchmark"
+    depends_on: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3_6-35B-A3B_Benchmark"
+    env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
+      CI_TARGET: "Qwen/Qwen3.6-35B-A3B"
+      CI_STAGE: "Benchmark"
+      CI_CATEGORY: "multimodal"
+    agents:
+      queue: cpu
+    commands:
+      - |
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_Qwen_Qwen3_6-35B-A3B_Benchmark

--- a/scripts/vllm/integration/test_accuracy.py
+++ b/scripts/vllm/integration/test_accuracy.py
@@ -50,6 +50,24 @@ def run_test(model_name, expected_value, more_args=None):
               "fewshot_as_multiturn for lm_eval. Required for instruction-"
               "tuned BOS-sensitive models like gemma-4-it.")
 
+    # Eval-geometry overrides. Reasoning models (Qwen3.x hybrid-thinking)
+    # emit long chains of thought before the final answer; lm_eval's
+    # default max_gen_toks (256) truncates mid-thought and both gsm8k
+    # filters score ~0. EVAL_GEN_KWARGS lets CI raise the budget, e.g.
+    # EVAL_GEN_KWARGS="max_gen_toks=4096". EVAL_LIMIT caps the number of
+    # eval examples for faster diagnostic runs.
+    gen_kwargs = os.environ.get("EVAL_GEN_KWARGS") or None
+    if gen_kwargs:
+        print(f"EVAL_GEN_KWARGS={gen_kwargs}")
+    limit_env = os.environ.get("EVAL_LIMIT")
+    limit = int(limit_env) if limit_env else None
+    if limit:
+        print(f"EVAL_LIMIT={limit}: evaluating a subset, accuracy is an estimate")
+    # EVAL_LOG_SAMPLES=1: dump the first few prompt/generation pairs to the
+    # CI log so eval-config failures (template issues, truncation, format
+    # drift) are diagnosable without a local repro.
+    log_samples = os.environ.get("EVAL_LOG_SAMPLES", "0") == "1"
+
     results = lm_eval.simple_evaluate(
         model="vllm",
         model_args=model_args,
@@ -57,7 +75,29 @@ def run_test(model_name, expected_value, more_args=None):
         batch_size="auto",
         apply_chat_template=apply_chat_template,
         fewshot_as_multiturn=apply_chat_template,
+        gen_kwargs=gen_kwargs,
+        limit=limit,
+        log_samples=log_samples,
     )
+
+    if log_samples:
+        import json as _json
+        samples = (results.get("samples") or {}).get(TASK, [])
+        for i, s in enumerate(samples[:5]):
+            args = s.get("arguments") or []
+            ctx = ""
+            gen_args = {}
+            if args and isinstance(args[0], (list, tuple)):
+                ctx = str(args[0][0])
+                if len(args[0]) > 1:
+                    gen_args = args[0][1]
+            print(f"========== EVAL SAMPLE {i} ==========")
+            print("PROMPT_TAIL:", repr(ctx[-300:]))
+            print("GEN_ARGS:", _json.dumps(gen_args, default=str)[:600])
+            print("RESPS:", _json.dumps(s.get("resps"), default=str)[:2500])
+            print("FILTERED:", _json.dumps(s.get("filtered_resps"), default=str)[:300])
+            print("TARGET_TAIL:", repr(str(s.get("target"))[-80:]))
+            print(f"========== END SAMPLE {i} ==========")
 
     # gsm8k emits two filters: strict-match (default gate) and flexible-extract.
     # Print both so CI logs let reviewers compare across runs/kernels.
@@ -95,9 +135,22 @@ def test_lm_eval_accuracy_v1_engine(monkeypatch: pytest.MonkeyPatch,
     with monkeypatch.context() as _:
         more_args = None
         if current_platform.is_tpu():
-            more_args = "max_model_len=2048,max_num_seqs=64"
+            # EVAL_MAX_MODEL_LEN: chat-template multiturn fewshot prompts +
+            # reasoning-model thinking tokens don't fit the 2048 default.
+            max_model_len = os.environ.get("EVAL_MAX_MODEL_LEN", "2048")
+            more_args = f"max_model_len={max_model_len},max_num_seqs=64"
             tp_size_str = f"tensor_parallel_size={tp_size}"
             more_args += ",{}".format(tp_size_str)
+            # EVAL_GPU_MEMORY_UTILIZATION: opt-in HBM headroom knob. Large MoE
+            # models (e.g. Qwen3.6-35B-A3B) auto-size the KV cache to fill the
+            # default budget, leaving no room for the compiled step program
+            # (jit_step_fun_impl) and OOMing during warmup. Lowering the
+            # utilization shrinks the (heavily over-provisioned) KV cache to
+            # leave that headroom. Only applied when explicitly set so other
+            # models keep the vLLM default.
+            gpu_mem_util = os.environ.get("EVAL_GPU_MEMORY_UTILIZATION")
+            if gpu_mem_util:
+                more_args += f",gpu_memory_utilization={gpu_mem_util}"
 
         print(f"common args: {more_args}")
 


### PR DESCRIPTION
## What

- **`.buildkite/models/Qwen_Qwen3_6-35B-A3B.yml`** (new): UnitTest + Accuracy + Benchmark steps for `Qwen/Qwen3.6-35B-A3B` (multimodal MoE, TP=8 on the v6e-8 queue), each paired with a `record_step_result` step. Accuracy gates GSM8K at `MINIMUM_ACCURACY_THRESHOLD=0.90`.
- **`scripts/vllm/integration/test_accuracy.py`**: opt-in `EVAL_*` env knobs for reasoning/thinking models. All are backward-compatible — no effect unless explicitly set:
  - `EVAL_MAX_MODEL_LEN` — context length for multiturn chat-template fewshot prompts.
  - `EVAL_GEN_KWARGS` — lm_eval generation kwargs (e.g. `max_gen_toks`, `until`) so thinking-mode generations aren't truncated mid-thought or cut by stock stop strings.
  - `EVAL_GPU_MEMORY_UTILIZATION` — HBM headroom for large-MoE warmup (avoids the compiled step program OOMing against an over-provisioned KV cache).
  - `EVAL_LIMIT` / `EVAL_LOG_SAMPLES` — subset + prompt/generation dumps for eval-config diagnostics.

## Why

Qwen3.6-35B-A3B is a hybrid-thinking reasoning model. With the stock GSM8K eval config it scores ~0 (the chat template forces thinking mode; the default `max_gen_toks=256` and the stock `until: ["Question:"]` stop list truncate/cut every generation). With the chat template + a reasoning-sized generation budget + an `<|im_end|>` stop override, it scores as expected.

## Verification

GSM8K **strict 0.99** on v6e-8 TP=8 (100-example subset) with `USE_CHAT_TEMPLATE=1 EVAL_MAX_MODEL_LEN=8192 EVAL_GEN_KWARGS="max_gen_toks=4096,until=<|im_end|>" EVAL_GPU_MEMORY_UTILIZATION=0.85`.