### PR TITLE
[GMMv2] Bind Weight Precision To LHS Dtype In GMM V2 Dequantize-Before-Matmul Path

### DIFF
--- a/tpu_inference/kernels/megablox/gmm_v2.py
+++ b/tpu_inference/kernels/megablox/gmm_v2.py
@@ -396,9 +396,10 @@ def inner_kernel(
         # the scales and thus we need to dequantize inside VMEM to avoid small
         # contracting dimmensions
         if cfgs.rhs_cfgs.should_dequantize_before_matmul:
-            tiled_rhs_scale = tiled_rhs_ref.get_scale().astype(acc_ref.dtype)
+            tiled_rhs_scale = tiled_rhs_ref.get_scale().astype(
+                cfgs.lhs_cfgs.dtype)
             num_blocks = cfgs.num_quant_blocks_per_tile_k
-            tiled_rhs_dequant = tiled_rhs.astype(acc_ref.dtype).reshape(
+            tiled_rhs_dequant = tiled_rhs.astype(cfgs.lhs_cfgs.dtype).reshape(
                 num_blocks, rhs_qbs, rhs_tile_n)
             tiled_rhs_dequant = tiled_rhs_dequant * tiled_rhs_scale
             tiled_rhs = tiled_rhs_dequant.reshape(cfgs.tiles.tile_k,


### PR DESCRIPTION
# Description

Brings over [these](https://critique.corp.google.com/cl/932461767) changes from Jordan, namely:

Updates the weight dequantization path in the GMM v2 serving kernel to perform the elementwise scale multiplication in the LHS activation precision (cfgs.lhs_cfgs.dtype) instead of the accumulator's precision (acc_ref.dtype).

Description & Hardware Motivation:
Previously, the kernel performed the elementwise dequantization multiplication (weight * scale) in the accumulator's precision (acc_ref.dtype). For unquantized serving paths (such as NVFP4), the accumulator defaults to FP32 to maintain high-precision summation across K-tiles.

Performing the elementwise dequantization multiplication directly in the LHS activation precision rather than FP32 significantly reduces VPU clock cycle pressure. While casting the weights and scales to the activation precision (e.g. BF16) before the multiplication is numerically distinct from performing the multiplication in FP32 and downcasting afterwards, empirical verification shows that the numerical difference between these two paths is negligible, while delivering a substantial reduction in VPU overhead.

The dequantized weights are passed directly to the Matrix Execution Unit (MXU), which only accepts low-precision inputs matching the LHS activation precision (such as bfloat16 or float8). Even if weights are dequantized to FP32 in VMEM, they must be downcast to the LHS precision before entering the MXU. Therefore, the dequantization precision is dictated entirely by the MXU's input type (the LHS activation precision, cfgs.lhs_cfgs.dtype).

Additionally, this design naturally supports future TPU-friendly formats that dequantize before the MXU into FP8. By simply quantizing the LHS to FP8, the weights will automatically dequantize to FP8 in VMEM to match, without requiring any changes to the kernel.



# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
