### PR TITLE
[Gemma4] Add mm-encoder-tp-mode to gemma4 recipes

### DIFF
--- a/.buildkite/benchmark/cases/daily/Gemma4-26B-dataset_custom-inlen_1024-outlen_500.json
+++ b/.buildkite/benchmark/cases/daily/Gemma4-26B-dataset_custom-inlen_1024-outlen_500.json
@@ -100,7 +100,7 @@
           "kv-cache-dtype": "fp8",
           "gpu-memory-utilization": 0.9,
           "async-scheduling": true,
-          "additional-config": "{\"quantization\": { \"qwix\": { \"rules\": [{ \"module_path\": \".*\", \"weight_qtype\": \"float8_e4m3fn\", \"act_qtype\": \"float8_e4m3fn\"}]}}}"
+          "additional-config": "{\"quantization\": { \"qwix\": { \"rules\": [{ \"module_path\": \".*\", \"weight_qtype\": \"float8_e4m3fn\", \"act_qtype\": \"float8_e4m3fn\"}]}}, \"mm-encoder-tp-mode\": \"data\"}"
         }
       },
       "client_command_options": {

--- a/.buildkite/benchmark/cases/daily/Gemma4-31B-dataset_custom-inlen_1024-outlen_500.json
+++ b/.buildkite/benchmark/cases/daily/Gemma4-31B-dataset_custom-inlen_1024-outlen_500.json
@@ -25,7 +25,7 @@
           "VLLM_USE_V1": "1",
           "MODEL_IMPL_TYPE": "flax_nnx",
           "USE_BATCHED_RPA_KERNEL": "1",
-          "VLLM_ENGINE_READY_TIMEOUT_S": "1800"
+          "VLLM_ENGINE_READY_TIMEOUT_S": "3600"
         },
         "args": {
           "model": "google/gemma-4-31B-it",
@@ -82,7 +82,7 @@
           "VLLM_USE_V1": "1",
           "MODEL_IMPL_TYPE": "flax_nnx",
           "USE_BATCHED_RPA_KERNEL": "1",
-          "VLLM_ENGINE_READY_TIMEOUT_S": "1800"
+          "VLLM_ENGINE_READY_TIMEOUT_S": "3600"
         },
         "args": {
           "model": "google/gemma-4-31B-it",

--- a/.buildkite/benchmark/cases/daily/Gemma4-31B-dataset_custom-inlen_1024-outlen_500.json
+++ b/.buildkite/benchmark/cases/daily/Gemma4-31B-dataset_custom-inlen_1024-outlen_500.json
@@ -102,7 +102,7 @@
           "kv-cache-dtype": "fp8",
           "gpu-memory-utilization": 0.9,
           "async-scheduling": true,
-          "additional-config": "{\"quantization\": { \"qwix\": { \"rules\": [{ \"module_path\": \".*\", \"weight_qtype\": \"float8_e4m3fn\", \"act_qtype\": \"float8_e4m3fn\"}]}}}"
+          "additional-config": "{\"quantization\": { \"qwix\": { \"rules\": [{ \"module_path\": \".*\", \"weight_qtype\": \"float8_e4m3fn\", \"act_qtype\": \"float8_e4m3fn\"}]}}, \"mm-encoder-tp-mode\": \"data\"}"
         }
       },
       "client_command_options": {


### PR DESCRIPTION
# Description

Update the `additional_config` of gemma4 models to use `mm-encoder-tp-mode=data`.

# Tests

Tested locally with `--additional_config='{"quantization": { "qwix": { "rules": [{ "module_path": ".*", "weight_qtype": "float8_e4m3fn", "act_qtype": "float8_e4m3fn"}]}}, "mm-encoder-tp-mode": "data"}' \`.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
