### PR TITLE
[releases/v0.23.0] Cherry-pick #2897: Revert "Read/Write JAX cache to GCS"

### DIFF
--- a/.buildkite/pipeline_jax.yml
+++ b/.buildkite/pipeline_jax.yml
@@ -93,11 +93,10 @@ steps:
         commands:
           - .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/mlperf.sh
 
-      - label: "${TPU_VERSION:-tpu6e} E2E speculative decoding test (Ngram)"
-        key: ${TPU_VERSION:-tpu6e}_test_6_ngram
+      - label: "${TPU_VERSION:-tpu6e} E2E speculative decoding test"
+        key: ${TPU_VERSION:-tpu6e}_test_6
         depends_on: "${TPU_VERSION:-tpu6e}_build_docker"
         soft_fail: true
-        timeout_in_minutes: 240
         env:
           USE_PREBUILT_IMAGE: "1"
           TPU_VERSION: "${TPU_VERSION:-tpu6e}"
@@ -106,52 +105,7 @@ steps:
         commands:
           - |
               .buildkite/scripts/run_in_docker.sh \
-                bash -c 'python3 -m pytest -s -v -x /workspace/tpu_inference/tests/e2e/test_speculative_decoding.py -k "ngram"'
-
-      - label: "${TPU_VERSION:-tpu6e} E2E speculative decoding test (Eagle3)"
-        key: ${TPU_VERSION:-tpu6e}_test_6_eagle3
-        depends_on: "${TPU_VERSION:-tpu6e}_build_docker"
-        soft_fail: true
-        timeout_in_minutes: 240
-        env:
-          USE_PREBUILT_IMAGE: "1"
-          TPU_VERSION: "${TPU_VERSION:-tpu6e}"
-        agents:
-          queue: ${TPU_QUEUE_SINGLE:-tpu_v6e_queue}
-        commands:
-          - |
-              .buildkite/scripts/run_in_docker.sh \
-                bash -c 'python3 -m pytest -s -v -x /workspace/tpu_inference/tests/e2e/test_speculative_decoding.py -k "eagle3"'
-
-      - label: "${TPU_VERSION:-tpu6e} E2E speculative decoding test (MTP)"
-        key: ${TPU_VERSION:-tpu6e}_test_6_mtp
-        depends_on: "${TPU_VERSION:-tpu6e}_build_docker"
-        soft_fail: true
-        timeout_in_minutes: 240
-        env:
-          USE_PREBUILT_IMAGE: "1"
-          TPU_VERSION: "${TPU_VERSION:-tpu6e}"
-        agents:
-          queue: ${TPU_QUEUE_SINGLE:-tpu_v6e_queue}
-        commands:
-          - |
-              .buildkite/scripts/run_in_docker.sh \
-                bash -c 'python3 -m pytest -s -v -x /workspace/tpu_inference/tests/e2e/test_speculative_decoding.py -k "mtp"'
-
-      - label: "${TPU_VERSION:-tpu6e} E2E speculative decoding test (Catch-all)"
-        key: ${TPU_VERSION:-tpu6e}_test_6_catchall
-        depends_on: "${TPU_VERSION:-tpu6e}_build_docker"
-        soft_fail: true
-        timeout_in_minutes: 240
-        env:
-          USE_PREBUILT_IMAGE: "1"
-          TPU_VERSION: "${TPU_VERSION:-tpu6e}"
-        agents:
-          queue: ${TPU_QUEUE_SINGLE:-tpu_v6e_queue}
-        commands:
-          - |
-              .buildkite/scripts/run_in_docker.sh \
-                bash -c 'python3 -m pytest -s -v -x /workspace/tpu_inference/tests/e2e/test_speculative_decoding.py -k "not ngram and not eagle3 and not mtp" || [[ $? -eq 5 ]]'
+                bash -c 'python3 -m pytest -s -v -x /workspace/tpu_inference/tests/e2e/test_speculative_decoding.py'
 
       - label: "${TPU_VERSION:-tpu6e} JAX unit tests part1"
         key: ${TPU_VERSION:-tpu6e}_test_7_1
@@ -173,7 +127,6 @@ steps:
         key: ${TPU_VERSION:-tpu6e}_test_7_2
         depends_on: "${TPU_VERSION:-tpu6e}_build_docker"
         soft_fail: true
-        timeout_in_minutes: 240
         artifact_paths: ".coverage.part2.${TPU_VERSION:-tpu6e}"
         env:
           USE_PREBUILT_IMAGE: "1"
@@ -743,10 +696,7 @@ steps:
           - ${TPU_VERSION:-tpu6e}_test_2
           - ${TPU_VERSION:-tpu6e}_test_3
           - ${TPU_VERSION:-tpu6e}_test_4
-          - ${TPU_VERSION:-tpu6e}_test_6_ngram
-          - ${TPU_VERSION:-tpu6e}_test_6_eagle3
-          - ${TPU_VERSION:-tpu6e}_test_6_mtp
-          - ${TPU_VERSION:-tpu6e}_test_6_catchall
+          - ${TPU_VERSION:-tpu6e}_test_6
           - ${TPU_VERSION:-tpu6e}_test_7_1
           - ${TPU_VERSION:-tpu6e}_test_7_2
           - ${TPU_VERSION:-tpu6e}_test_7_3
@@ -784,4 +734,4 @@ steps:
         commands:
           - |
             .buildkite/scripts/check_results.sh \
-              "TPU JAX Tests Failed" ${TPU_VERSION:-tpu6e}_test_0 ${TPU_VERSION:-tpu6e}_test_1 ${TPU_VERSION:-tpu6e}_test_2 ${TPU_VERSION:-tpu6e}_test_3 ${TPU_VERSION:-tpu6e}_test_4 ${TPU_VERSION:-tpu6e}_test_6_ngram ${TPU_VERSION:-tpu6e}_test_6_eagle3 ${TPU_VERSION:-tpu6e}_test_6_mtp ${TPU_VERSION:-tpu6e}_test_6_catchall ${TPU_VERSION:-tpu6e}_test_7_1 ${TPU_VERSION:-tpu6e}_test_7_2 ${TPU_VERSION:-tpu6e}_test_7_3 ${TPU_VERSION:-tpu6e}_test_8 ${TPU_VERSION:-tpu6e}_test_9 ${TPU_VERSION:-tpu6e}_test_10 ${TPU_VERSION:-tpu6e}_test_11 ${TPU_VERSION:-tpu6e}_test_12 ${TPU_VERSION:-tpu6e}_test_13 ${TPU_VERSION:-tpu6e}_test_14 ${TPU_VERSION:-tpu6e}_test_15 ${TPU_VERSION:-tpu6e}_test_16 ${TPU_VERSION:-tpu6e}_test_17 ${TPU_VERSION:-tpu6e}_test_18 ${TPU_VERSION:-tpu6e}_test_19 ${TPU_VERSION:-tpu6e}_test_20 ${TPU_VERSION:-tpu6e}_test_21 ${TPU_VERSION:-tpu6e}_test_22 ${TPU_VERSION:-tpu6e}_test_23 ${TPU_VERSION:-tpu6e}_test_24 ${TPU_VERSION:-tpu6e}_test_25 ${TPU_VERSION:-tpu6e}_test_26 ${TPU_VERSION:-tpu6e}_test_27 ${TPU_VERSION:-tpu6e}_test_28 ${TPU_VERSION:-tpu6e}_test_29 ${TPU_VERSION:-tpu6e}_test_30 ${TPU_VERSION:-tpu6e}_test_31 ${TPU_VERSION:-tpu6e}_test_32 ${TPU_VERSION:-tpu6e}_test_33 ${TPU_VERSION:-tpu6e}_test_34 ${TPU_VERSION:-tpu6e}_test_35
+              "TPU JAX Tests Failed" ${TPU_VERSION:-tpu6e}_test_0 ${TPU_VERSION:-tpu6e}_test_1 ${TPU_VERSION:-tpu6e}_test_2 ${TPU_VERSION:-tpu6e}_test_3 ${TPU_VERSION:-tpu6e}_test_4 ${TPU_VERSION:-tpu6e}_test_6 ${TPU_VERSION:-tpu6e}_test_7_1 ${TPU_VERSION:-tpu6e}_test_7_2 ${TPU_VERSION:-tpu6e}_test_7_3 ${TPU_VERSION:-tpu6e}_test_8 ${TPU_VERSION:-tpu6e}_test_9 ${TPU_VERSION:-tpu6e}_test_10 ${TPU_VERSION:-tpu6e}_test_11 ${TPU_VERSION:-tpu6e}_test_12 ${TPU_VERSION:-tpu6e}_test_13 ${TPU_VERSION:-tpu6e}_test_14 ${TPU_VERSION:-tpu6e}_test_15 ${TPU_VERSION:-tpu6e}_test_16 ${TPU_VERSION:-tpu6e}_test_17 ${TPU_VERSION:-tpu6e}_test_18 ${TPU_VERSION:-tpu6e}_test_19 ${TPU_VERSION:-tpu6e}_test_20 ${TPU_VERSION:-tpu6e}_test_21 ${TPU_VERSION:-tpu6e}_test_22 ${TPU_VERSION:-tpu6e}_test_23 ${TPU_VERSION:-tpu6e}_test_24 ${TPU_VERSION:-tpu6e}_test_25 ${TPU_VERSION:-tpu6e}_test_26 ${TPU_VERSION:-tpu6e}_test_27 ${TPU_VERSION:-tpu6e}_test_28 ${TPU_VERSION:-tpu6e}_test_29 ${TPU_VERSION:-tpu6e}_test_30 ${TPU_VERSION:-tpu6e}_test_31 ${TPU_VERSION:-tpu6e}_test_32 ${TPU_VERSION:-tpu6e}_test_33 ${TPU_VERSION:-tpu6e}_test_34 ${TPU_VERSION:-tpu6e}_test_35

--- a/.buildkite/scripts/run_in_docker.sh
+++ b/.buildkite/scripts/run_in_docker.sh
@@ -116,41 +116,25 @@ KERNEL_TUNING_TMP_DIR="/tmp/kernel_tuning"
 mkdir -p "$KERNEL_TUNING_TMP_DIR"
 
 # Try to cache the JAX compilations.
-declare -a JAX_CACHE_ARGS=()
-FUSE_MOUNT_DIR="/mnt/disks/persist/tpu_jax_cache"
-
-# Probe JAX version from docker image (needed for both FUSE and direct GCS mode to separate namespaces)
+GCS_CACHE_BASE="gs://ullm-ci-cache/jax_cache"
 echo "[INFO] Probing JAX version from docker image..."
 JAX_VERSION=$(docker run --rm "$FULL_IMAGE_TAG" python3 -c "import jax; print(jax.__version__)")
 echo "[INFO] Detected JAX Version: ${JAX_VERSION}"
 
-# Centralized namespace path
+# Centralized GCS cache path
 CACHE_NAMESPACE="jax${JAX_VERSION}_tpu${TPU_VERSION:-tpu6e}"
+FINAL_CACHE_PATH="${GCS_CACHE_BASE}/${CACHE_NAMESPACE}"
 
-if [ "${CI_CACHE_FUSE_MOUNTED:-0}" = "1" ] && mountpoint -q "$FUSE_MOUNT_DIR"; then
-  # FUSE Mode: Use the host gcsfuse mount directly
-  FUSE_CACHE_DIR="${FUSE_MOUNT_DIR}/jax_cache/${CACHE_NAMESPACE}"
-  
-  # Ensure the subdirectory exists in GCS (FUSE creates folders dynamically)
-  mkdir -p "$FUSE_CACHE_DIR"
+LOCAL_JAX_CACHE_DIR="/mnt/disks/persist/tpu_jax_cache/${CACHE_NAMESPACE}"
 
-  echo "[INFO] Using GCS FUSE cache path: ${FUSE_CACHE_DIR}"
-  JAX_CACHE_ARGS+=(
-    -v "$FUSE_MOUNT_DIR":"$FUSE_MOUNT_DIR"
-    -e VLLM_XLA_CACHE_PATH="$FUSE_CACHE_DIR"
-    -e JAX_COMPILATION_CACHE_DIR="$FUSE_CACHE_DIR"
-  )
-else
-  # Direct GCS Mode: Write directly to GCS via gs:// bucket paths
-  GCS_CACHE_BASE="gs://ullm-ci-cache/jax_cache"
-  FINAL_CACHE_PATH="${GCS_CACHE_BASE}/${CACHE_NAMESPACE}"
-
-  echo "[INFO] Direct GCS JAX cache path configured: ${FINAL_CACHE_PATH}"
-  JAX_CACHE_ARGS+=(
-    -e VLLM_XLA_CACHE_PATH="${FINAL_CACHE_PATH}"
-    -e JAX_COMPILATION_CACHE_DIR="${FINAL_CACHE_PATH}"
-  )
+if ! mkdir -p "$LOCAL_JAX_CACHE_DIR"; then
+  echo "[ERROR] Failed to create $LOCAL_JAX_CACHE_DIR on persistent disk."
+  exit 1
 fi
+echo "[INFO] Pulling JAX Cache from GCS to local directory..."
+# Parallel CI builds‘ pushes are safe because JAX's compilation cache 
+# entries are content-addressed. Concurrent pushes are thus idempotent;
+gsutil -m rsync -d -r "$FINAL_CACHE_PATH" "$LOCAL_JAX_CACHE_DIR" || echo "[WARN] Failed to pull JAX Cache from GCS. Proceeding with cold start."
 
 # ==========================================
 # 2. Run Docker Container
@@ -178,7 +162,7 @@ docker run \
   --shm-size=16G \
   --rm \
   -v "$LOCAL_HF_HOME":"$DOCKER_HF_HOME" \
-  "${JAX_CACHE_ARGS[@]}" \
+  -v "$LOCAL_JAX_CACHE_DIR":"$LOCAL_JAX_CACHE_DIR" \
   -v "$KERNEL_TUNING_TMP_DIR":"$KERNEL_TUNING_TMP_DIR" \
   "${DEV_MOUNT[@]}" \
   "${ENV_VARS[@]}" \
@@ -186,6 +170,8 @@ docker run \
   -e HF_HOME="$DOCKER_HF_HOME" \
   -e MODEL_IMPL_TYPE="$MODEL_IMPL_TYPE" \
   -e HF_TOKEN="$HF_TOKEN" \
+  -e VLLM_XLA_CACHE_PATH="$LOCAL_JAX_CACHE_DIR" \
+  -e JAX_COMPILATION_CACHE_DIR="$LOCAL_JAX_CACHE_DIR" \
   -e VLLM_XLA_CHECK_RECOMPILATION=1 \
   ${QUANTIZATION:+-e QUANTIZATION="$QUANTIZATION"} \
   ${NEW_MODEL_DESIGN:+-e NEW_MODEL_DESIGN="$NEW_MODEL_DESIGN"} \
@@ -208,5 +194,8 @@ set -e
 # 3. Post-Docker Actions
 # ==========================================
 echo "[INFO] Docker finished with exit code ${DOCKER_EXIT_CODE}."
+
+echo "[INFO] Syncing local JAX Cache back to GCS..."
+gsutil -m rsync -r "$LOCAL_JAX_CACHE_DIR" "$FINAL_CACHE_PATH" || echo "[WARN] Failed to sync JAX Cache back to GCS."
 
 exit $DOCKER_EXIT_CODE


### PR DESCRIPTION
Cherry-pick of #2897 (https://github.com/vllm-project/tpu-inference/pull/2897) onto `releases/v0.23.0`.

Reverts #2875 ("Read/Write JAX cache to GCS"), which is currently the HEAD of `releases/v0.23.0`. This restores the prior JAX-cache behavior on the release branch.

Note: #2897 is the equivalent revert for `main` (open at time of cherry-pick). This brings the same revert to `releases/v0.23.0`. Clean cherry-pick of the revert commit `c447da37`; touches only `.buildkite/pipeline_jax.yml` and `.buildkite/scripts/run_in_docker.sh`.