### PR TITLE
[releases/v0.23.0] Cherry-pick #2890: Fix compatibility by restricting fastAPI version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,9 @@ jax==0.10.1
 jaxlib==0.10.1
 libtpu==0.0.41
 jaxtyping
+# Temporarily restrict fastapi version due to https://github.com/vllm-project/vllm/pull/45629
+# TODO(lk-chen): remove once LKG moves past above commit
+fastapi[standard]<0.137.0
 flax==0.12.4
 torchax==0.0.11
 qwix==0.1.2


### PR DESCRIPTION
Cherry-pick of #2890 (https://github.com/vllm-project/tpu-inference/pull/2890) onto `releases/v0.23.0`.

## What it fixes
Pins `fastapi[standard]<0.137.0` in `requirements.txt`. Newer FastAPI/Starlette breaks `prometheus_fastapi_instrumentator`, which calls `route.path` on an `_IncludedRouter` object:

```
AttributeError: '_IncludedRouter' object has no attribute 'path'
```

This crashes the vLLM OpenAI server's Prometheus middleware, so every serving-based test (perf benchmarks, MLPerf, MPMD, P/D disaggregation, perf-regression) fails downstream with "All requests failed" / "Warmup failed - Internal Server Error". Confirmed as the dominant failure on the v0.23.0 nightly (#20109) and inherited from `main`.

## Why cherry-pick
#2890 landed the fix on `main`; this brings it to `releases/v0.23.0`. Clean cherry-pick (3-line addition to `requirements.txt`, no conflicts).