### PR TITLE
Short circuit step on Buildkite level so that we don't block on waiting for TPUs

### DIFF
--- a/.buildkite/pipeline_jax.yml
+++ b/.buildkite/pipeline_jax.yml
@@ -173,23 +173,17 @@ steps:
           TPU_VERSION: "${TPU_VERSION:-tpu6e}"
         agents:
           queue: ${TPU_QUEUE_SINGLE:-tpu_v6e_queue}
+        # Skips this step without provisioning TPUs unless NIGHTLY=1 or kernel-related files are modified.
+        # Check bootstrap.sh for the exact file regex.
+        if: build.env("NIGHTLY") == "1" || "${RUN_KERNEL_TESTS:-0}" == "1"
         commands:
           - |
-            echo "--- Fetching changed files from metadata"
-            FILES_CHANGED=$$(buildkite-agent meta-data get "changed_files" --default "" | tr ',' '\n')
-            echo "$${FILES_CHANGED}"
-
-            if [[ "$$NIGHTLY" == "1" ]] || echo "$$FILES_CHANGED" | grep -qE '^(tpu_inference/kernels|tests/kernels|tests/conftest.py|requirements.txt)'; then
-              .buildkite/scripts/run_in_docker.sh \
-                python3 -m pytest -s -v -x /workspace/tpu_inference/tests/kernels \
-                --ignore=/workspace/tpu_inference/tests/kernels/ragged_paged_attention_kernel_v2_test.py \
-                --ignore=/workspace/tpu_inference/tests/kernels/ragged_kv_cache_update_v2_test.py \
-                --ignore=/workspace/tpu_inference/tests/kernels/collectives \
-                --ignore=/workspace/tpu_inference/tests/kernels/spmm_v1_test.py
-            else
-              echo "Skipping: Step requires either a NIGHTLY build or changes in kernels, kernel tests, shared conftest, or requirements.txt."
-              exit 0
-            fi
+            .buildkite/scripts/run_in_docker.sh \
+              python3 -m pytest -s -v -x /workspace/tpu_inference/tests/kernels \
+              --ignore=/workspace/tpu_inference/tests/kernels/ragged_paged_attention_kernel_v2_test.py \
+              --ignore=/workspace/tpu_inference/tests/kernels/ragged_kv_cache_update_v2_test.py \
+              --ignore=/workspace/tpu_inference/tests/kernels/collectives \
+              --ignore=/workspace/tpu_inference/tests/kernels/spmm_v1_test.py
 
       - label: "${TPU_VERSION:-tpu6e} JAX unit tests - collective kernels"
         key: ${TPU_VERSION:-tpu6e}_test_9
@@ -200,19 +194,13 @@ steps:
           TPU_VERSION: "${TPU_VERSION:-tpu6e}"
         agents:
           queue: ${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}
+        # Skips this step without provisioning TPUs unless NIGHTLY=1 or collective kernel-related files are modified.
+        # Check bootstrap.sh for the exact file regex.
+        if: build.env("NIGHTLY") == "1" || "${RUN_KERNEL_COLLECTIVES_TESTS:-0}" == "1"
         commands:
           - |
-            echo "--- Fetching changed files from metadata"
-            FILES_CHANGED=$$(buildkite-agent meta-data get "changed_files" --default "" | tr ',' '\n')
-            echo "$${FILES_CHANGED}"
-
-            if [[ "$$NIGHTLY" == "1" ]] || echo "$$FILES_CHANGED" | grep -qE '^(tpu_inference/kernels/collectives|tests/kernels/collectives|tests/conftest.py|requirements.txt)'; then
-              .buildkite/scripts/run_in_docker.sh \
-                python3 -m pytest -s -v -x /workspace/tpu_inference/tests/kernels/collectives
-            else
-              echo "Skipping: Step requires either a NIGHTLY build or changes in kernels/collectives, tests, shared conftest, or requirements.txt."
-              exit 0
-            fi
+            .buildkite/scripts/run_in_docker.sh \
+              python3 -m pytest -s -v -x /workspace/tpu_inference/tests/kernels/collectives
 
       - label: "${TPU_VERSION:-tpu6e} lora e2e tests for JAX + vLLM models single chip"
         key: ${TPU_VERSION:-tpu6e}_test_10
@@ -252,14 +240,10 @@ steps:
           TPU_VERSION: "${TPU_VERSION:-tpu6e}"
         agents:
           queue: ${TPU_QUEUE_SINGLE:-tpu_v6e_queue}
+        if: '"${TPU_VERSION:-tpu6e}" == "tpu7x"'
         commands:
           - |
-            if [[ "$TPU_VERSION" == "tpu7x" ]]; then
-              .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/mlperf.sh -m "gs://tpu-commons-ci/deepseek/r1"
-            else
-              echo "Skipping: Step requires TPU v7x."
-              exit 0
-            fi
+            .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/mlperf.sh -m "gs://tpu-commons-ci/deepseek/r1"
 
       - label: "${TPU_VERSION:-tpu6e} E2E MMLU for DeepSeek-R1 torchax backend"
         key: ${TPU_VERSION:-tpu6e}_test_14
@@ -276,14 +260,10 @@ steps:
           TPU_VERSION: "${TPU_VERSION:-tpu6e}"
         agents:
           queue: ${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}
+        if: '"${TPU_VERSION:-tpu6e}" == "tpu7x"'
         commands:
           - |
-            if [[ "$TPU_VERSION" == "tpu7x" ]]; then
-              .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/mmlu.sh -m  "gs://tpu-commons-ci/deepseek/r1" -n 14042 -l 4
-            else
-              echo "Skipping: Step requires TPU v7x."
-              exit 0
-            fi
+            .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/mmlu.sh -m  "gs://tpu-commons-ci/deepseek/r1" -n 14042 -l 4
 
       - label: "${TPU_VERSION:-tpu6e} lora e2e tests for JAX + vLLM models multi chips"
         key: ${TPU_VERSION:-tpu6e}_test_13
@@ -337,14 +317,10 @@ steps:
           TPU_VERSION: "${TPU_VERSION:-tpu6e}"
         agents:
           queue: ${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}
+        if: '"${TPU_VERSION:-tpu6e}" == "tpu7x"'
         commands:
           - |
-            if [[ "$$TPU_VERSION" == "tpu7x" ]]; then
-              .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/check_lm_eval.sh  --model_name "Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8" --use_moe_ep_kernel 1 --tensor_parallel_size 8 --max_model_len 2048 --max_num_batched_tokens 2048 --max_gen_toks 256 --enable_expert_parallel 1 --flex_threshold 0.85 --strict_threshold 0.70
-            else
-              echo "Skipping: Step requires TPU v7x and either a NIGHTLY build or kernel/requirements changes."
-              exit 0
-            fi
+            .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/check_lm_eval.sh  --model_name "Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8" --use_moe_ep_kernel 1 --tensor_parallel_size 8 --max_model_len 2048 --max_num_batched_tokens 2048 --max_gen_toks 256 --enable_expert_parallel 1 --flex_threshold 0.85 --strict_threshold 0.70
 
       - label: "${TPU_VERSION:-tpu6e} E2E lm_eval accuracy check qwen3 coder with gmm kernel."
         key: ${TPU_VERSION:-tpu6e}_test_18
@@ -355,14 +331,10 @@ steps:
           TPU_VERSION: "${TPU_VERSION:-tpu6e}"
         agents:
           queue: ${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}
+        if: '"${TPU_VERSION:-tpu6e}" == "tpu7x"'
         commands:
           - |
-            if [[ "$$TPU_VERSION" == "tpu7x" ]]; then
-              .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/check_lm_eval.sh  --model_name "Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8" --use_moe_ep_kernel 0 --tensor_parallel_size 8 --max_model_len 2048 --max_num_batched_tokens 2048 --max_gen_toks 256 --enable_expert_parallel 1 --flex_threshold 0.85 --strict_threshold 0.70
-            else
-              echo "Skipping: Step requires TPU v7x and either a NIGHTLY build or kernel/requirements changes."
-              exit 0
-            fi
+            .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/check_lm_eval.sh  --model_name "Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8" --use_moe_ep_kernel 0 --tensor_parallel_size 8 --max_model_len 2048 --max_num_batched_tokens 2048 --max_gen_toks 256 --enable_expert_parallel 1 --flex_threshold 0.85 --strict_threshold 0.70
 
       - label: "${TPU_VERSION:-tpu6e} E2E lm_eval accuracy check gpt oss."
         key: ${TPU_VERSION:-tpu6e}_test_19
@@ -375,14 +347,10 @@ steps:
           queue: ${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}
         # The strict-match is failing due to pattern mismatch, see #2318 for details.
         # TODO(#2318): set proper strict-match threshold.
+        if: '"${TPU_VERSION:-tpu6e}" == "tpu7x"'
         commands:
           - |
-            if [[ "$$TPU_VERSION" == "tpu7x" ]]; then
-              .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/check_lm_eval.sh  --model_name "openai/gpt-oss-120b" --use_moe_ep_kernel 1 --tensor_parallel_size 8 --max_model_len 2048 --max_num_batched_tokens 2048 --max_gen_toks 256 --enable_expert_parallel 1 --flex_threshold 0.50 --strict_threshold 0.0
-            else
-              echo "Skipping: Step requires TPU v7x and either a NIGHTLY build or kernel/requirements changes."
-              exit 0
-            fi
+            .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/check_lm_eval.sh  --model_name "openai/gpt-oss-120b" --use_moe_ep_kernel 1 --tensor_parallel_size 8 --max_model_len 2048 --max_num_batched_tokens 2048 --max_gen_toks 256 --enable_expert_parallel 1 --flex_threshold 0.50 --strict_threshold 0.0
 
       - label: "${TPU_VERSION:-tpu6e} Perf regression test for qwen3 coder 1k 8k with fused moe kernel."
         key: ${TPU_VERSION:-tpu6e}_test_20
@@ -391,12 +359,10 @@ steps:
           TPU_VERSION: "${TPU_VERSION:-tpu6e}"
         agents:
           queue: ${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}
-        if: build.env("NIGHTLY") == "1"
+        if: build.env("NIGHTLY") == "1" && "${TPU_VERSION:-tpu6e}" == "tpu7x"
         commands:
           - |
-            if [[ "$$TPU_VERSION" == "tpu7x" ]]; then
-              .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/bm_qwen3_coder.sh --model Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8 --tp 8 --req_tput_limit 0.15  --output_token_tput_limit 1170 --total_token_tput_limit 1314 --input_len 1024 --output_len 8192 --use_moe_ep_kernel 1
-            fi
+            .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/bm_qwen3_coder.sh --model Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8 --tp 8 --req_tput_limit 0.15  --output_token_tput_limit 1170 --total_token_tput_limit 1314 --input_len 1024 --output_len 8192 --use_moe_ep_kernel 1
 
       - label: "${TPU_VERSION:-tpu6e} Perf regression test for qwen3 coder 8k 1k with fused moe kernel."
         key: ${TPU_VERSION:-tpu6e}_test_21
@@ -407,11 +373,10 @@ steps:
           TPU_VERSION: "${TPU_VERSION:-tpu6e}"
         agents:
           queue: ${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}
+        if: '"${TPU_VERSION:-tpu6e}" == "tpu7x"'
         commands:
           - |
-            if [[ "$$TPU_VERSION" == "tpu7x" ]]; then
-              .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/bm_qwen3_coder.sh --model Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8 --tp 8 --req_tput_limit 0.4  --output_token_tput_limit 381 --total_token_tput_limit 3421 --input_len 8192 --output_len 1024 --use_moe_ep_kernel 1
-            fi
+            .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/bm_qwen3_coder.sh --model Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8 --tp 8 --req_tput_limit 0.4  --output_token_tput_limit 381 --total_token_tput_limit 3421 --input_len 8192 --output_len 1024 --use_moe_ep_kernel 1
 
       - label: "${TPU_VERSION:-tpu6e} Perf regression test for qwen3 coder 1k 8k with gmm kernel."
         key: ${TPU_VERSION:-tpu6e}_test_22
@@ -420,12 +385,10 @@ steps:
           TPU_VERSION: "${TPU_VERSION:-tpu6e}"
         agents:
           queue: ${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}
-        if: build.env("NIGHTLY") == "1"
+        if: build.env("NIGHTLY") == "1" && "${TPU_VERSION:-tpu6e}" == "tpu7x"
         commands:
           - |
-            if [[ "$$TPU_VERSION" == "tpu7x" ]]; then
-              .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/bm_qwen3_coder.sh --model Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8 --tp 8 --req_tput_limit 0.16  --output_token_tput_limit 1673 --total_token_tput_limit 1881 --input_len 1024 --output_len 8192 --use_moe_ep_kernel 0
-            fi
+            .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/bm_qwen3_coder.sh --model Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8 --tp 8 --req_tput_limit 0.16  --output_token_tput_limit 1673 --total_token_tput_limit 1881 --input_len 1024 --output_len 8192 --use_moe_ep_kernel 0
 
       - label: "${TPU_VERSION:-tpu6e} Perf regression test for qwen3 coder 8k 1k with gmm kernel."
         key: ${TPU_VERSION:-tpu6e}_test_23
@@ -436,11 +399,10 @@ steps:
           TPU_VERSION: "${TPU_VERSION:-tpu6e}"
         agents:
           queue: ${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}
+        if: '"${TPU_VERSION:-tpu6e}" == "tpu7x"'
         commands:
           - |
-            if [[ "$$TPU_VERSION" == "tpu7x" ]]; then
-              .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/bm_qwen3_coder.sh --model Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8 --tp 8 --req_tput_limit 0.63  --output_token_tput_limit 645 --total_token_tput_limit 5781 --input_len 8192 --output_len 1024 --use_moe_ep_kernel 0
-            fi
+            .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/bm_qwen3_coder.sh --model Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8 --tp 8 --req_tput_limit 0.63  --output_token_tput_limit 645 --total_token_tput_limit 5781 --input_len 8192 --output_len 1024 --use_moe_ep_kernel 0
 
       - label: "${TPU_VERSION:-tpu6e} Test EP recompilation."
         key: ${TPU_VERSION:-tpu6e}_test_24
@@ -451,11 +413,10 @@ steps:
           TPU_VERSION: "${TPU_VERSION:-tpu6e}"
         agents:
           queue: ${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}
+        if: '"${TPU_VERSION:-tpu6e}" == "tpu7x"'
         commands:
           - |
-            if [[ "$$TPU_VERSION" == "tpu7x" ]]; then
-              .buildkite/scripts/run_in_docker.sh bash -c 'SKIP_JAX_PRECOMPILE=0 USE_MOE_EP_KERNEL=1 VLLM_XLA_CHECK_RECOMPILATION=1  MODEL_IMPL_TYPE=vllm python examples/offline_inference.py --model Qwen/Qwen1.5-MoE-A2.7B  --tensor-parallel-size 4 --enable-expert-parallel --no-async-scheduling --max-model-len 32 --max-num-batched-tokens 32 --max-num-seqs 8'
-            fi
+            .buildkite/scripts/run_in_docker.sh bash -c 'SKIP_JAX_PRECOMPILE=0 USE_MOE_EP_KERNEL=1 VLLM_XLA_CHECK_RECOMPILATION=1  MODEL_IMPL_TYPE=vllm python examples/offline_inference.py --model Qwen/Qwen1.5-MoE-A2.7B  --tensor-parallel-size 4 --enable-expert-parallel --no-async-scheduling --max-model-len 32 --max-num-batched-tokens 32 --max-num-seqs 8'
 
       - label: "${TPU_VERSION:-tpu6e} E2E test for Multihost DCN-based P/D disaggregation"
         key: ${TPU_VERSION:-tpu6e}_test_25
@@ -484,28 +445,27 @@ steps:
           queue: tpu_v7x_16_queue
         env:
           TPU_VERSION: "${TPU_VERSION:-tpu6e}"
+        if: '"${TPU_VERSION:-tpu6e}" == "tpu7x"'
         commands:
           # Correctness Test Example:
           # 1. Start vLLM with specific model and tensor parallel size
           # 2. Run curl commands against it
           - |
-            if [[ "$$TPU_VERSION" == "tpu7x" ]]; then
-              MODEL="gs://tpu-commons-ci/qwen/models--Qwen--Qwen3-30B-A3B/snapshots/ad44e777bcd18fa416d9da3bd8f70d33ebb85d39"
-              .buildkite/scripts/run_multihost.sh \
-                "vllm serve \${MODEL} \
-                  --port 8000 \
-                  --tensor-parallel-size 16 \
-                  --trust-remote-code \
-                  --max-model-len 1024 \
-                  --no-async-scheduling \
-                  --load-format=runai_streamer \
-                  --no-enable-prefix-caching" \
-                "curl http://localhost:8000/v1/completions \
-                  -X POST \
-                  -H 'Content-Type: application/json' \
-                  -d '{\"model\": \"${MODEL}\", \"prompt\": \"San Francisco is a\", \"max_tokens\": 50}'
-                "
-            fi
+            MODEL="gs://tpu-commons-ci/qwen/models--Qwen--Qwen3-30B-A3B/snapshots/ad44e777bcd18fa416d9da3bd8f70d33ebb85d39"
+            .buildkite/scripts/run_multihost.sh \
+              "vllm serve \${MODEL} \
+                --port 8000 \
+                --tensor-parallel-size 16 \
+                --trust-remote-code \
+                --max-model-len 1024 \
+                --no-async-scheduling \
+                --load-format=runai_streamer \
+                --no-enable-prefix-caching" \
+              "curl http://localhost:8000/v1/completions \
+                -X POST \
+                -H 'Content-Type: application/json' \
+                -d '{\"model\": \"${MODEL}\", \"prompt\": \"San Francisco is a\", \"max_tokens\": 50}'
+              "
 
       - label: "${TPU_VERSION:-tpu6e} Correctness Test | Runai Model Streamer JAX UniProcExecutor"
         key: "${TPU_VERSION:-tpu6e}_test_27"
@@ -555,14 +515,10 @@ steps:
         # TODO (jacobplatin): we should remove the limit when perf improvements are made
         # TODO (jacobplatin): the flex threshold is low, but the strict threshold should be
         # high enough to still make this test useful and representative
+        if: '"${TPU_VERSION:-tpu6e}" == "tpu7x"'
         commands:
           - |
-            if [[ "$$TPU_VERSION" == "tpu7x" ]]; then
-              .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/check_lm_eval.sh  --model_name "Qwen/Qwen3.5-397B-A17B-FP8" --use_moe_ep_kernel 0 --tensor_parallel_size 8 --max_model_len 4096 --max_num_batched_tokens 4096 --max_gen_toks 2048 --enable_expert_parallel 1 --flex_threshold 0.63 --strict_threshold 0.63 --limit_mm_per_prompt '{"image": 0, "video": 0}' --block_size 256 --limit 100 --enable_thinking false
-            else
-              echo "Skipping: Step requires TPU v7x and either a NIGHTLY build or kernel/requirements changes."
-              exit 0
-            fi
+            .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/check_lm_eval.sh  --model_name "Qwen/Qwen3.5-397B-A17B-FP8" --use_moe_ep_kernel 0 --tensor_parallel_size 8 --max_model_len 4096 --max_num_batched_tokens 4096 --max_gen_toks 2048 --enable_expert_parallel 1 --flex_threshold 0.63 --strict_threshold 0.63 --limit_mm_per_prompt '{"image": 0, "video": 0}' --block_size 256 --limit 100 --enable_thinking false
 
       - label: "${TPU_VERSION:-tpu6e} Perf regression test for Qwen3.5-397B-A17B 1k 8k with gmm kernel."
         key: ${TPU_VERSION:-tpu6e}_test_31
@@ -571,15 +527,13 @@ steps:
           TPU_VERSION: "${TPU_VERSION:-tpu6e}"
         agents:
           queue: ${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}
-        if: build.env("NIGHTLY") == "1"
+        if: build.env("NIGHTLY") == "1" && "${TPU_VERSION:-tpu6e}" == "tpu7x"
         # TODO (jacobplatin): we should remove the prompt limit when perf improvements are made
         # TODO (jacobplatin): the limits here are quite low and they should also be increased
         # once perf improvements are made
         commands:
           - |
-            if [[ "$$TPU_VERSION" == "tpu7x" ]]; then
-              .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/bm_qwen3_coder.sh --model Qwen/Qwen3.5-397B-A17B-FP8 --tp 8 --req_tput_limit 0.04  --output_token_tput_limit 300 --total_token_tput_limit 345 --input_len 1024 --output_len 8192 --use_moe_ep_kernel 0 --limit_mm_per_prompt '{"image": 0, "video": 0}' --block_size 256 --num_prompts 64 --gpu_memory_utilization 0.9
-            fi
+            .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/bm_qwen3_coder.sh --model Qwen/Qwen3.5-397B-A17B-FP8 --tp 8 --req_tput_limit 0.04  --output_token_tput_limit 300 --total_token_tput_limit 345 --input_len 1024 --output_len 8192 --use_moe_ep_kernel 0 --limit_mm_per_prompt '{"image": 0, "video": 0}' --block_size 256 --num_prompts 64 --gpu_memory_utilization 0.9
 
       - label: "${TPU_VERSION:-tpu6e} Perf regression test for Qwen3.5-397B-A17B 8k 1k with gmm kernel."
         key: ${TPU_VERSION:-tpu6e}_test_32
@@ -593,11 +547,10 @@ steps:
         # TODO (jacobplatin): we should remove the prompt limit when perf improvements are made
         # TODO (jacobplatin): the limits here are quite low and they should also be increased
         # once perf improvements are made
+        if: '"${TPU_VERSION:-tpu6e}" == "tpu7x"'
         commands:
           - |
-            if [[ "$$TPU_VERSION" == "tpu7x" ]]; then
-              .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/bm_qwen3_coder.sh --model Qwen/Qwen3.5-397B-A17B-FP8 --tp 8 --req_tput_limit 0.05  --output_token_tput_limit 70 --total_token_tput_limit 650 --input_len 8192 --output_len 1024 --use_moe_ep_kernel 0    --limit_mm_per_prompt '{"image": 0, "video": 0}' --block_size 256 --num_prompts 64 --gpu_memory_utilization 0.9
-            fi
+            .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/bm_qwen3_coder.sh --model Qwen/Qwen3.5-397B-A17B-FP8 --tp 8 --req_tput_limit 0.05  --output_token_tput_limit 70 --total_token_tput_limit 650 --input_len 8192 --output_len 1024 --use_moe_ep_kernel 0    --limit_mm_per_prompt '{"image": 0, "video": 0}' --block_size 256 --num_prompts 64 --gpu_memory_utilization 0.9
 
       - label: "${TPU_VERSION:-tpu6e} Accuracy for Qwen/Qwen2.5-VL-7B-Instruct"
         key: ${TPU_VERSION:-tpu6e}_test_33
@@ -675,15 +628,11 @@ steps:
           TPU_CORES: 2
         agents:
           queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+        if: '"${TPU_VERSION:-tpu6e}" == "tpu7x"'
         commands:
           - |
-            if [[ "$TPU_VERSION" == "tpu7x" ]]; then
-              .buildkite/scripts/run_in_docker.sh bash -c "
-                TPU_VERSION=\${TPU_VERSION} TPU_CORES=\${TPU_CORES} python -m pytest tools/kernel/tuner/v1/tests -v -rs"
-            else
-              echo "Skipping: Step only needs to run on TPU v7x."
-              exit 0
-            fi
+            .buildkite/scripts/run_in_docker.sh bash -c "
+              TPU_VERSION=\${TPU_VERSION} TPU_CORES=\${TPU_CORES} python -m pytest tools/kernel/tuner/v1/tests -v -rs"
 
       # -----------------------------------------------------------------
       # NOTIFICATION STEP

--- a/.buildkite/scripts/bootstrap.sh
+++ b/.buildkite/scripts/bootstrap.sh
@@ -129,6 +129,25 @@ fi
 # Store changed files in metadata for sub-pipelines (newlines to commas)
 echo "$FILES_CHANGED" | tr '\n' ',' | buildkite-agent meta-data set "changed_files"
 
+# Evaluate which file paths were changed in the PR to dynamically trigger kernel tests.
+# These variables are interpolated into pipeline_jax.yml to skip steps without provisioning TPUs.
+export RUN_KERNEL_TESTS=0
+export RUN_KERNEL_COLLECTIVES_TESTS=0
+
+# Trigger general kernel tests if any of the following are modified:
+# - tpu_inference/kernels/* or tests/kernels/*
+# - tests/conftest.py or requirements.txt
+if echo "$FILES_CHANGED" | grep -qE '^(tpu_inference/kernels|tests/kernels|tests/conftest.py|requirements.txt)'; then
+    export RUN_KERNEL_TESTS=1
+fi
+
+# Trigger collective-specific kernel tests if any of the following are modified:
+# - tpu_inference/kernels/collectives/* or tests/kernels/collectives/*
+# - tests/conftest.py or requirements.txt
+if echo "$FILES_CHANGED" | grep -qE '^(tpu_inference/kernels/collectives|tests/kernels/collectives|tests/conftest.py|requirements.txt)'; then
+    export RUN_KERNEL_COLLECTIVES_TESTS=1
+fi
+
 # Handles the environment state for different TPU generations.
 set_jax_envs() {
     case $1 in


### PR DESCRIPTION
Move the short circuit logics out of the script and do that at buildkite level.
If we do the check in the script, we still need to wait for a tpu to run it. Doing it at the buildkite level allow us to bypass it entirely.

For per pr ci run, this reduces the number of jobs performed from 64 to 48, saving 16 unnecessary dispatches to tpu.

# Description

Start with a short description of what the PR does and how this is a change from
the past.

The rest of the description includes relevant details and context, examples:
- why is this change being made,
- the problem being solved and any relevant context,
- why this is a good solution,
- some information about the specific implementation,
- shortcomings of the solution and possible future improvements.

If the change fixes a Github issue, please include a link, e.g.,:
FIXES: #123456

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
