### PR TITLE
[DeepSeek V4]Add Deepseek v4 indexer

### DIFF
--- a/tests/kernels/deepseek_v4/test_streamindex_topk.py
+++ b/tests/kernels/deepseek_v4/test_streamindex_topk.py
@@ -1,0 +1,313 @@
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+try:
+  from google3.experimental.users.hwanginho.deepseek_v4.streamindex_topk.streamindex_topk import streamindex_topk
+except ImportError:
+  from tpu_inference.layers.vllm.custom_ops.streamindex_topk import streamindex_topk
+
+pytestmark = pytest.mark.filterwarnings("ignore::DeprecationWarning")
+
+
+@pytest.mark.parametrize(
+    "B, num_tokens, page_size, max_blocks, H_I, H_KV, D, k, compression_ratio,"
+    " bq_sz, bkv_p, seq_lens_list, cu_q_lens_list",
+    [
+        # Small standard case
+        (2, 6, 16, 8, 4, 1, 64, 512, 2, 32, 2, [4, 6], [0, 3, 6]),
+        # # Single token batch (Decode Phase)
+        (1, 1, 16, 4, 2, 1, 32, 512, 1, 16, 1, [10], [0, 1]),
+        # Large batch, multiple tokens per sequence (Prefill Phase)
+        (
+            4,
+            20,
+            32,
+            16,
+            8,
+            1,
+            128,
+            512,
+            4,
+            64,
+            4,
+            [10, 20, 30, 40],
+            [0, 5, 10, 15, 20],
+        ),
+        # Odd chunk sizes
+        (2, 5, 8, 6, 4, 1, 16, 512, 1, 16, 3, [8, 12], [0, 2, 5]),
+        # Single head for KV but multiple heads for Queries (MQA/GQA pattern)
+        (2, 10, 16, 8, 8, 1, 64, 512, 2, 32, 4, [16, 24], [0, 4, 10]),
+        # # High D, High K
+        (1, 8, 16, 4, 2, 1, 256, 512, 1, 32, 4, [60], [0, 8]),
+        # Mixed batch: sequence 0 has 1 token (decode), sequence 1 has 5 tokens
+        # (prefill)
+        (2, 6, 16, 8, 4, 1, 64, 512, 2, 32, 2, [4, 6], [0, 1, 6]),
+    ],
+)
+def test_streamindex_topk_shape(
+    B,
+    num_tokens,
+    page_size,
+    max_blocks,
+    H_I,
+    H_KV,
+    D,
+    k,
+    compression_ratio,
+    bq_sz,
+    bkv_p,
+    seq_lens_list,
+    cu_q_lens_list,
+):
+  """Tests the shape and basic execution bounds of streamindex_topk."""
+  print(f"\n{'-'*60}")
+  print(f"SHAPE TEST: B={B}, Tokens={num_tokens}, k={k}")
+  print(f"{'-'*60}")
+
+  query_projection = jnp.zeros((num_tokens, H_I, D), dtype=jnp.float32)
+  indexer_weights = jnp.zeros((num_tokens, H_I), dtype=jnp.float32)
+
+  num_pages = max_blocks * B
+  kv_cache = jnp.zeros((num_pages, page_size, H_KV, D), dtype=jnp.float32)
+
+  block_table = jnp.zeros((B, max_blocks), dtype=jnp.int32)
+  page_indices = block_table.flatten()
+  cu_q_lens = jnp.array(cu_q_lens_list, dtype=jnp.int32)
+
+  print("Inputs:")
+  print(f"  - query_projection: {query_projection.shape}")
+  print(f"  - kv_cache:         {kv_cache.shape}")
+  print(f"  - seq_lens:         {seq_lens_list}")
+  print(f"  - cu_q_lens:        {cu_q_lens_list}")
+
+  # Count number of decode sequences (T == 1) at the beginning of the batch
+  num_decodes = 0
+  while (
+      num_decodes < B
+      and (cu_q_lens_list[num_decodes + 1] - cu_q_lens_list[num_decodes]) == 1
+  ):
+    num_decodes += 1
+  distribution = (num_decodes, num_decodes, B)
+  expected_shape = (num_tokens, k)
+
+  seq_lens = jnp.array(seq_lens_list, dtype=jnp.int32)
+
+  out_shape_idxs = jax.eval_shape(
+      streamindex_topk,
+      query_projection,
+      indexer_weights,
+      kv_cache,
+      seq_lens,
+      page_indices,
+      cu_q_lens,
+      distribution,
+      k=k,
+      compression_ratio=compression_ratio,
+      num_kv_pages_per_block=bkv_p,
+      num_queries_per_block=bq_sz,
+  )
+
+  print("\nOutputs:")
+  print(f"  - Expected shape: {expected_shape}, dtype: int32")
+  print(
+      f"  - Actual shape:   {out_shape_idxs.shape}, dtype:"
+      f" {out_shape_idxs.dtype}"
+  )
+
+  assert out_shape_idxs.shape == expected_shape
+  assert out_shape_idxs.dtype == jnp.int32
+  print("Result: PASS")
+
+
+@pytest.mark.parametrize(
+    "B, T_list, S_list, page_size, H_I, H_KV, D, k, comp_ratio, bq_sz, bkv_p,"
+    " block_table_list",
+    [
+        # 1. Single sequence, highly fragmented block table
+        (1, [4], [16], 8, 4, 1, 16, 1024, 2, 8, 2, [[2, 0]]),
+        # 2. Batched Decode (T=1, B=2)
+        (2, [1, 1], [12, 16], 8, 4, 1, 16, 1024, 1, 8, 1, [[1, 3], [0, 2]]),
+        # 3. High GQA (8 Query Heads, 2 KV Heads)
+        (1, [6], [20], 4, 8, 1, 16, 1024, 1, 8, 2, [[4, 1, 3, 0, 2]]),
+        # 4. Multi-Batch Prefill with variable query/sequence lengths
+        (2, [5, 3], [16, 16], 8, 4, 1, 16, 1024, 1, 8, 4, [[3, 1], [2, 4]]),
+        # 5. Dummy sequences / Padding (B=3, but sequence 1 has 0 tokens)
+        (
+            3,
+            [2, 0, 3],
+            [16, 0, 8],
+            8,
+            4,
+            1,
+            16,
+            1024,
+            1,
+            8,
+            2,
+            [[1, 2], [0, 0], [4, 3]],
+        ),
+        # 6. Mixed batch: sequence 0 has 1 token, sequence 1 has 5 tokens
+        (2, [1, 5], [12, 16], 8, 4, 1, 16, 1024, 2, 8, 2, [[1, 3], [2, 0]]),
+    ],
+)
+def test_streamindex_topk_numerical_correctness(
+    B,
+    T_list,
+    S_list,
+    page_size,
+    H_I,
+    H_KV,
+    D,
+    k,
+    comp_ratio,
+    bq_sz,
+    bkv_p,
+    block_table_list,
+):
+  """Executes randomized input data against a naive NumPy ground truth."""
+  print(f"\n{'='*60}")
+  print(f"BATCHED NUMERICAL TEST (B={B})")
+  print(f"{'='*60}")
+
+  np.random.seed(42)
+
+  # 1. Setup Random Tensors
+  num_tokens = sum(T_list)
+  q = np.random.randn(num_tokens, H_I, D).astype(np.float32)
+  weights = np.random.uniform(-1.5, 1.5, size=(num_tokens, H_I)).astype(
+      np.float32
+  )
+
+  # Create a unified physical KV Cache pool large enough for all block indices
+  max_physical_page = np.max(block_table_list)
+  kv = np.random.randn(max_physical_page + 1, page_size, H_KV, D).astype(
+      np.float32
+  )
+
+  block_table = np.array(block_table_list, dtype=np.int32)
+  page_indices = block_table.flatten()
+  seq_lens = np.array(S_list, dtype=np.int32)
+  cu_q_lens = np.concatenate([[0], np.cumsum(T_list)]).astype(np.int32)
+
+  print("Configuration:")
+  print(f"  - Tokens total: {num_tokens}, Sequences(B): {B}, K: {k}")
+  print(f"  - GQA: {H_I} Query Heads -> {H_KV} KV Heads")
+  print(f"  - Compression Ratio: {comp_ratio}")
+
+  print("\nInputs Generated:")
+  print(f"  - Query Tensor: {q.shape}")
+  print(f"  - KV Cache:     {kv.shape}")
+  print(f"  - Block Table:  {block_table.tolist()}")
+
+  # =====================================================================
+  # 2. NAIVE COMPUTATION (The Ground Truth)
+  # =====================================================================
+  print("\n[1/3] Computing exact ground-truth using naive NumPy loops...")
+  expected_topk = np.full((num_tokens, k), -1, dtype=np.int32)
+
+  for b in range(B):
+    T_seq = T_list[b]
+    S_total = S_list[b]
+    q_start = cu_q_lens[b]
+
+    if T_seq == 0:
+      continue  # Skip dummy padded sequences
+
+    S_valid = S_total // comp_ratio
+
+    # Manually reconstruct this sequence's physical contiguous cache
+    seq_blocks = block_table[b]
+    seq_kv = np.concatenate([kv[p] for p in seq_blocks], axis=0)
+
+    # Ensure naive_scores has at least K columns for sorting bounds
+    naive_scores = np.full((T_seq, max(S_valid, k)), -np.inf, dtype=np.float32)
+
+    for t_idx in range(T_seq):
+      global_t = q_start + t_idx
+      q_abs_pos = (S_total - T_seq) + t_idx
+
+      for s_idx in range(S_valid):
+        # Causal Mask
+        if s_idx * comp_ratio > q_abs_pos:
+          continue
+
+        score = 0.0
+        for h in range(H_I):
+          h_kv = h // (H_I // H_KV)
+          inner = np.dot(q[global_t, h], seq_kv[s_idx, h_kv])
+          score += max(0.0, inner) * weights[global_t, h]
+
+        naive_scores[t_idx, s_idx] = score
+
+    # Get expected top-k indices
+    seq_expected = np.argsort(-naive_scores, axis=-1)[:, :k]
+
+    # Overwrite masked (-inf) positions with -1
+    for t_idx in range(T_seq):
+      for i in range(k):
+        idx = seq_expected[t_idx, i]
+        if naive_scores[t_idx, idx] == -np.inf:
+          expected_topk[q_start + t_idx, i] = -1
+        else:
+          expected_topk[q_start + t_idx, i] = idx
+
+  print("\nGROUND TRUTH (Naive NumPy):")
+  print(expected_topk)
+
+  # =====================================================================
+  # 3. Pallas KERNEL COMPUTATION
+  # =====================================================================
+  print("\n[2/3] Executing optimized JAX Kernel (streamindex_pallas_topk)...")
+  # Count number of decode sequences (T == 1) at the beginning of the batch
+  num_decodes = 0
+  while num_decodes < B and T_list[num_decodes] == 1:
+    num_decodes += 1
+  distribution = (num_decodes, num_decodes, B)
+
+  actual_topk = streamindex_topk(
+      q=jnp.array(q),
+      indexer_weights=jnp.array(weights),
+      cache_kv=jnp.array(kv),
+      seq_lens=jnp.array(seq_lens),
+      page_indices=jnp.array(page_indices),
+      cu_q_lens=jnp.array(cu_q_lens),
+      distribution=distribution,
+      k=k,
+      compression_ratio=comp_ratio,
+      num_kv_pages_per_block=bkv_p,
+      num_queries_per_block=bq_sz,
+  )
+
+  actual_topk_np = np.array(actual_topk)
+
+  print("\nACTUAL OUTPUT (JAX/XLA Kernel):")
+  print(actual_topk_np)
+
+  # =====================================================================
+  # 4. VERIFY
+  # =====================================================================
+  print("\n[3/3] Verifying absolute correctness...")
+  np.testing.assert_array_equal(
+      np.sort(actual_topk_np, axis=-1),
+      np.sort(expected_topk, axis=-1),
+      err_msg="JAX Pallas Kernel Top-K math did not match Naive Ground Truth",
+  )
+  print(
+      "MATCH VERIFIED! JAX kernel handles batches, fragmentation, and dummy"
+      " padding.\n"
+  )
+
+
+def main(argv):
+  del argv
+  import sys
+
+  raise SystemExit(pytest.main([__file__, "-p", "no:cacheprovider"]))
+
+
+if __name__ == "__main__":
+  from absl import app
+
+  app.run(main)

--- a/tests/kernels/deepseek_v4/test_streamindex_topk.py
+++ b/tests/kernels/deepseek_v4/test_streamindex_topk.py
@@ -1,14 +1,121 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for Deepseek V4 StreamIndex Top-K kernel."""
+
 import jax
 import jax.numpy as jnp
 import numpy as np
 import pytest
 
 try:
-  from google3.experimental.users.hwanginho.deepseek_v4.streamindex_topk.streamindex_topk import streamindex_topk
+    from google3.experimental.users.hwanginho.deepseek_v4.streamindex_topk.streamindex_topk import \
+        streamindex_topk
 except ImportError:
-  from tpu_inference.layers.vllm.custom_ops.streamindex_topk import streamindex_topk
+    from tpu_inference.kernels.experimental.deepseek_v4.streamindex_topk import \
+        streamindex_topk
+
+
+# =====================================================================
+# Helper functions from the compressor implementation
+# =====================================================================
+def _to_byte_lane(x: jax.Array) -> jax.Array:
+    """Reinterpret each element of ``x``'s trailing dim as raw bytes."""
+    b = jax.lax.bitcast_convert_type(x, jnp.uint8)
+    if b.ndim > x.ndim:
+        b = b.reshape(*x.shape[:-1], -1)
+    return b
+
+
+def quantize_fp8_ue8m0(x: jax.Array, block_size: int):
+    """Block fp8 quantization with UE8M0 (power-of-two) block scales."""
+    fp8_max = float(jnp.finfo(jnp.float8_e4m3fn).max)
+    *lead, dim = x.shape
+    blocked = x.reshape(*lead, dim // block_size, block_size)
+    amax = jnp.clip(jnp.max(jnp.abs(blocked), axis=-1, keepdims=True), 1e-4,
+                    None)
+    scale = jnp.exp2(jnp.ceil(jnp.log2(amax / fp8_max)))
+    q = (blocked * (1.0 / scale)).astype(jnp.float8_e4m3fn).reshape(x.shape)
+    scale = jnp.squeeze(scale, -1).astype(jnp.float8_e8m0fnu)
+    return q, scale
+
+
+# =====================================================================
 
 pytestmark = pytest.mark.filterwarnings("ignore::DeprecationWarning")
+
+
+def streamindex_topk_ref(
+    q,
+    weights,
+    kv,
+    block_table,
+    T_list,
+    S_list,
+    cu_q_lens,
+    k,
+    comp_ratio,
+    H_I,
+    H_KV,
+):
+    """Naive NumPy reference implementation for StreamIndex Top-K."""
+    num_tokens = q.shape[0]
+    expected_topk = np.full((num_tokens, k), -1, dtype=np.int32)
+    B = len(T_list)
+
+    for b in range(B):
+        T_seq = T_list[b]
+        S_total = S_list[b]
+        q_start = cu_q_lens[b]
+
+        if T_seq == 0:
+            continue
+
+        S_valid = S_total // comp_ratio
+        seq_blocks = block_table[b]
+        seq_kv = np.concatenate([kv[p] for p in seq_blocks], axis=0)
+
+        naive_scores = np.full((T_seq, max(S_valid, k)),
+                               -np.inf,
+                               dtype=np.float32)
+
+        for t_idx in range(T_seq):
+            global_t = q_start + t_idx
+            q_abs_pos = (S_total - T_seq) + t_idx
+
+            for s_idx in range(S_valid):
+                if s_idx * comp_ratio > q_abs_pos:
+                    continue
+
+                score = 0.0
+                for h in range(H_I):
+                    h_kv = h // (H_I // H_KV)
+                    inner = np.dot(q[global_t, h], seq_kv[s_idx, h_kv])
+                    score += max(0.0, inner) * weights[global_t, h]
+
+                naive_scores[t_idx, s_idx] = score
+
+        seq_expected = np.argsort(-naive_scores, axis=-1)[:, :k]
+
+        for t_idx in range(T_seq):
+            for i in range(k):
+                idx = seq_expected[t_idx, i]
+                if naive_scores[t_idx, idx] == -np.inf:
+                    expected_topk[q_start + t_idx, i] = -1
+                else:
+                    expected_topk[q_start + t_idx, i] = idx
+
+    return expected_topk
 
 
 @pytest.mark.parametrize(
@@ -61,64 +168,66 @@ def test_streamindex_topk_shape(
     seq_lens_list,
     cu_q_lens_list,
 ):
-  """Tests the shape and basic execution bounds of streamindex_topk."""
-  print(f"\n{'-'*60}")
-  print(f"SHAPE TEST: B={B}, Tokens={num_tokens}, k={k}")
-  print(f"{'-'*60}")
+    """Tests the shape and basic execution bounds of streamindex_topk."""
+    _ = H_KV
+    print(f"\n{'-'*60}")
+    print(f"SHAPE TEST: B={B}, Tokens={num_tokens}, k={k}")
+    print(f"{'-'*60}")
 
-  query_projection = jnp.zeros((num_tokens, H_I, D), dtype=jnp.float32)
-  indexer_weights = jnp.zeros((num_tokens, H_I), dtype=jnp.float32)
+    query_projection = jnp.zeros((num_tokens, H_I, D), dtype=jnp.float32)
+    indexer_weights = jnp.zeros((num_tokens, H_I), dtype=jnp.float32)
 
-  num_pages = max_blocks * B
-  kv_cache = jnp.zeros((num_pages, page_size, H_KV, D), dtype=jnp.float32)
+    num_pages = max_blocks * B
+    q_lkv_dim = ((D + 127) // 128) * 128
+    record_width = q_lkv_dim + (q_lkv_dim // 128)
+    width = ((record_width + 127) // 128) * 128
+    kv_cache = jnp.zeros((num_pages, page_size // 4, 4, width),
+                         dtype=jnp.uint8)
 
-  block_table = jnp.zeros((B, max_blocks), dtype=jnp.int32)
-  page_indices = block_table.flatten()
-  cu_q_lens = jnp.array(cu_q_lens_list, dtype=jnp.int32)
+    block_table = jnp.zeros((B, max_blocks), dtype=jnp.int32)
+    page_indices = block_table.flatten()
+    cu_q_lens = jnp.array(cu_q_lens_list, dtype=jnp.int32)
 
-  print("Inputs:")
-  print(f"  - query_projection: {query_projection.shape}")
-  print(f"  - kv_cache:         {kv_cache.shape}")
-  print(f"  - seq_lens:         {seq_lens_list}")
-  print(f"  - cu_q_lens:        {cu_q_lens_list}")
+    print("Inputs:")
+    print(f"  - query_projection: {query_projection.shape}")
+    print(f"  - kv_cache:         {kv_cache.shape}")
+    print(f"  - seq_lens:         {seq_lens_list}")
+    print(f"  - cu_q_lens:        {cu_q_lens_list}")
 
-  # Count number of decode sequences (T == 1) at the beginning of the batch
-  num_decodes = 0
-  while (
-      num_decodes < B
-      and (cu_q_lens_list[num_decodes + 1] - cu_q_lens_list[num_decodes]) == 1
-  ):
-    num_decodes += 1
-  distribution = (num_decodes, num_decodes, B)
-  expected_shape = (num_tokens, k)
+    # Count number of decode sequences (T == 1) at the beginning of the batch
+    num_decodes = 0
+    while (num_decodes < B
+           and (cu_q_lens_list[num_decodes + 1] - cu_q_lens_list[num_decodes])
+           == 1):
+        num_decodes += 1
+    distribution = (num_decodes, num_decodes, B)
+    expected_shape = (num_tokens, k)
 
-  seq_lens = jnp.array(seq_lens_list, dtype=jnp.int32)
+    seq_lens = jnp.array(seq_lens_list, dtype=jnp.int32)
 
-  out_shape_idxs = jax.eval_shape(
-      streamindex_topk,
-      query_projection,
-      indexer_weights,
-      kv_cache,
-      seq_lens,
-      page_indices,
-      cu_q_lens,
-      distribution,
-      k=k,
-      compression_ratio=compression_ratio,
-      num_kv_pages_per_block=bkv_p,
-      num_queries_per_block=bq_sz,
-  )
+    out_shape_idxs = jax.eval_shape(
+        streamindex_topk,
+        query_projection,
+        indexer_weights,
+        kv_cache,
+        seq_lens,
+        page_indices,
+        cu_q_lens,
+        distribution,
+        k=k,
+        compression_ratio=compression_ratio,
+        num_kv_pages_per_block=bkv_p,
+        num_queries_per_block=bq_sz,
+    )
 
-  print("\nOutputs:")
-  print(f"  - Expected shape: {expected_shape}, dtype: int32")
-  print(
-      f"  - Actual shape:   {out_shape_idxs.shape}, dtype:"
-      f" {out_shape_idxs.dtype}"
-  )
+    print("\nOutputs:")
+    print(f"  - Expected shape: {expected_shape}, dtype: int32")
+    print(f"  - Actual shape:   {out_shape_idxs.shape}, dtype:"
+          f" {out_shape_idxs.dtype}")
 
-  assert out_shape_idxs.shape == expected_shape
-  assert out_shape_idxs.dtype == jnp.int32
-  print("Result: PASS")
+    assert out_shape_idxs.shape == expected_shape
+    assert out_shape_idxs.dtype == jnp.int32
+    print("Result: PASS")
 
 
 @pytest.mark.parametrize(
@@ -166,148 +275,238 @@ def test_streamindex_topk_numerical_correctness(
     bkv_p,
     block_table_list,
 ):
-  """Executes randomized input data against a naive NumPy ground truth."""
-  print(f"\n{'='*60}")
-  print(f"BATCHED NUMERICAL TEST (B={B})")
-  print(f"{'='*60}")
+    """Executes randomized input data against a naive NumPy ground truth."""
+    print(f"\n{'='*60}")
+    print(f"BATCHED NUMERICAL TEST (B={B})")
+    print(f"{'='*60}")
 
-  np.random.seed(42)
+    np.random.seed(42)
 
-  # 1. Setup Random Tensors
-  num_tokens = sum(T_list)
-  q = np.random.randn(num_tokens, H_I, D).astype(np.float32)
-  weights = np.random.uniform(-1.5, 1.5, size=(num_tokens, H_I)).astype(
-      np.float32
-  )
+    # 1. Setup Random Tensors
+    num_tokens = sum(T_list)
+    q = np.random.randn(num_tokens, H_I, D).astype(np.float32)
+    weights = np.random.uniform(-1.5, 1.5,
+                                size=(num_tokens, H_I)).astype(np.float32)
 
-  # Create a unified physical KV Cache pool large enough for all block indices
-  max_physical_page = np.max(block_table_list)
-  kv = np.random.randn(max_physical_page + 1, page_size, H_KV, D).astype(
-      np.float32
-  )
+    # Create a unified physical KV Cache pool large enough for all block indices
+    max_physical_page = np.max(block_table_list)
+    float32_kv = np.random.randn(max_physical_page + 1, page_size, H_KV,
+                                 D).astype(np.float32)
 
-  block_table = np.array(block_table_list, dtype=np.int32)
-  page_indices = block_table.flatten()
-  seq_lens = np.array(S_list, dtype=np.int32)
-  cu_q_lens = np.concatenate([[0], np.cumsum(T_list)]).astype(np.int32)
+    # Pack cache using compressor's quantize_fp8_ue8m0 and _to_byte_lane
+    q_lkv_dim = ((D + 127) // 128) * 128
+    record_width = q_lkv_dim + (q_lkv_dim // 128)
+    width = ((record_width + 127) // 128) * 128
 
-  print("Configuration:")
-  print(f"  - Tokens total: {num_tokens}, Sequences(B): {B}, K: {k}")
-  print(f"  - GQA: {H_I} Query Heads -> {H_KV} KV Heads")
-  print(f"  - Compression Ratio: {comp_ratio}")
+    cache_kv = np.zeros((max_physical_page + 1, page_size // 4, 4, width),
+                        dtype=np.uint8)
+    dequantized_kv = np.zeros_like(float32_kv)
 
-  print("\nInputs Generated:")
-  print(f"  - Query Tensor: {q.shape}")
-  print(f"  - KV Cache:     {kv.shape}")
-  print(f"  - Block Table:  {block_table.tolist()}")
+    for p in range(max_physical_page + 1):
+        for s in range(page_size):
+            for h in range(H_KV):
+                row_kv = float32_kv[p, s, h]
+                # Quantize using D as block size (each head query key has dimension D)
+                q_jax, scale_jax = quantize_fp8_ue8m0(jnp.array(row_kv), D)
+                q_bytes = np.array(_to_byte_lane(q_jax))
+                scale_bytes = np.array(_to_byte_lane(scale_jax))
+                dq = np.array(q_jax).astype(np.float32)
+                dequantized_kv[p, s, h] = dq * float(scale_jax[0])
+                record = np.concatenate([q_bytes, scale_bytes], axis=-1)
+                record = np.pad(record, (0, width - record.shape[-1]))
 
-  # =====================================================================
-  # 2. NAIVE COMPUTATION (The Ground Truth)
-  # =====================================================================
-  print("\n[1/3] Computing exact ground-truth using naive NumPy loops...")
-  expected_topk = np.full((num_tokens, k), -1, dtype=np.int32)
+                w_idx = s // 4
+                lane_idx = s % 4
+                cache_kv[p, w_idx, lane_idx] = record
 
-  for b in range(B):
-    T_seq = T_list[b]
-    S_total = S_list[b]
-    q_start = cu_q_lens[b]
+    block_table = np.array(block_table_list, dtype=np.int32)
+    page_indices = block_table.flatten()
+    seq_lens = np.array(S_list, dtype=np.int32)
+    cu_q_lens = np.concatenate([[0], np.cumsum(T_list)]).astype(np.int32)
 
-    if T_seq == 0:
-      continue  # Skip dummy padded sequences
+    print("Configuration:")
+    print(f"  - Tokens total: {num_tokens}, Sequences(B): {B}, K: {k}")
+    print(f"  - GQA: {H_I} Query Heads -> {H_KV} KV Heads")
+    print(f"  - Compression Ratio: {comp_ratio}")
 
-    S_valid = S_total // comp_ratio
+    print("\nInputs Generated:")
+    print(f"  - Query Tensor: {q.shape}")
+    print(f"  - KV Cache:     {cache_kv.shape}")
+    print(f"  - Block Table:  {block_table.tolist()}")
 
-    # Manually reconstruct this sequence's physical contiguous cache
-    seq_blocks = block_table[b]
-    seq_kv = np.concatenate([kv[p] for p in seq_blocks], axis=0)
+    # =====================================================================
+    # 2. NAIVE COMPUTATION (The Ground Truth)
+    # =====================================================================
+    print("\n[1/3] Computing exact ground-truth using naive NumPy loops...")
+    expected_topk = streamindex_topk_ref(
+        q=q,
+        weights=weights,
+        kv=dequantized_kv,
+        block_table=block_table,
+        T_list=T_list,
+        S_list=S_list,
+        cu_q_lens=cu_q_lens,
+        k=k,
+        comp_ratio=comp_ratio,
+        H_I=H_I,
+        H_KV=H_KV,
+    )
 
-    # Ensure naive_scores has at least K columns for sorting bounds
+    print("\nGROUND TRUTH (Naive NumPy):")
+    print(expected_topk)
+
+    # =====================================================================
+    # 3. Pallas KERNEL COMPUTATION
+    # =====================================================================
+    print(
+        "\n[2/3] Executing optimized JAX Kernel (streamindex_pallas_topk)...")
+    # Count number of decode sequences (T == 1) at the beginning of the batch
+    num_decodes = 0
+    while num_decodes < B and T_list[num_decodes] == 1:
+        num_decodes += 1
+    distribution = (num_decodes, num_decodes, B)
+
+    actual_topk = streamindex_topk(
+        q=jnp.array(q),
+        indexer_weights=jnp.array(weights),
+        cache_kv=jnp.array(cache_kv),
+        seq_lens=jnp.array(seq_lens),
+        page_indices=jnp.array(page_indices),
+        cu_q_lens=jnp.array(cu_q_lens),
+        distribution=distribution,
+        k=k,
+        compression_ratio=comp_ratio,
+        num_kv_pages_per_block=bkv_p,
+        num_queries_per_block=bq_sz,
+    )
+
+    actual_topk_np = np.array(actual_topk)
+
+    print("\nACTUAL OUTPUT (JAX/XLA Kernel):")
+    print(actual_topk_np)
+
+    # =====================================================================
+    # 4. VERIFY
+    # =====================================================================
+    print("\n[3/3] Verifying absolute correctness...")
+    np.testing.assert_array_equal(
+        np.sort(actual_topk_np, axis=-1),
+        np.sort(expected_topk, axis=-1),
+        err_msg="JAX Pallas Kernel Top-K math did not match Naive Ground Truth",
+    )
+    print(
+        "MATCH VERIFIED! JAX kernel handles batches, fragmentation, and dummy"
+        " padding.\n")
+
+
+def test_streamindex_topk_quantized():
+    """Verifies correctness of streamindex_topk on FP8 packed cache."""
+    np.random.seed(42)
+
+    T_seq = 4
+    S_seq = 512
+    page_size = 16
+    H_I = 2
+    H_KV = 1
+    D = 128
+    k = 512
+    comp_ratio = 4
+    bkv_p = 1
+    bq_sz = 1
+
+    q = np.random.randn(T_seq, H_I, D).astype(np.float32)
+    weights = np.random.uniform(0.5, 1.5, size=(T_seq, H_I)).astype(np.float32)
+
+    S_valid = S_seq // comp_ratio
+    # We need enough pages to hold S_valid compressed tokens.
+    num_pages = (S_valid + page_size - 1) // page_size
+    float32_kv = np.random.randn(num_pages, page_size, H_KV,
+                                 D).astype(np.float32)
+
+    # Pack cache using compressor's quantize_fp8_ue8m0 and _to_byte_lane
+    width = 256
+    cache_kv = np.zeros((num_pages, page_size // 4, 4, width), dtype=np.uint8)
+
+    # Dequantized KV for naive ground truth
+    dequantized_kv = np.zeros_like(float32_kv)
+
+    for p in range(num_pages):
+        for s in range(page_size):
+            for h_kv in range(H_KV):
+                row_kv = float32_kv[p, s, h_kv]
+
+                # Quantize using compressor helper
+                # block_size = 128 since we want 1 scale factor for D=128
+                q_jax, scale_jax = quantize_fp8_ue8m0(jnp.array(row_kv), 128)
+
+                # Convert to bytes
+                q_bytes = np.array(_to_byte_lane(q_jax))
+                scale_bytes = np.array(_to_byte_lane(scale_jax))
+
+                # Store dequantized version exactly as hardware sees it for accurate
+                # validation
+                dq = np.array(q_jax).astype(np.float32)
+                dequantized_kv[p, s, h_kv] = dq * float(scale_jax[0])
+
+                record = np.concatenate([q_bytes, scale_bytes], axis=-1)
+                record = np.pad(record, (0, width - record.shape[-1]))
+
+                w_idx = s // 4
+                lane_idx = s % 4
+                cache_kv[p, w_idx, lane_idx] = record
+
+    # Compute expected top-k using exact dequantized keys
+    seq_kv = np.concatenate([dequantized_kv[p] for p in range(num_pages)],
+                            axis=0)
+
     naive_scores = np.full((T_seq, max(S_valid, k)), -np.inf, dtype=np.float32)
 
     for t_idx in range(T_seq):
-      global_t = q_start + t_idx
-      q_abs_pos = (S_total - T_seq) + t_idx
+        for s_idx in range(S_valid):
+            score = 0.0
+            for h in range(H_I):
+                h_kv = h // (H_I // H_KV)
+                inner = np.dot(q[t_idx, h], seq_kv[s_idx, h_kv])
+                score += max(0.0, inner) * weights[t_idx, h]
+            naive_scores[t_idx, s_idx] = score
 
-      for s_idx in range(S_valid):
-        # Causal Mask
-        if s_idx * comp_ratio > q_abs_pos:
-          continue
-
-        score = 0.0
-        for h in range(H_I):
-          h_kv = h // (H_I // H_KV)
-          inner = np.dot(q[global_t, h], seq_kv[s_idx, h_kv])
-          score += max(0.0, inner) * weights[global_t, h]
-
-        naive_scores[t_idx, s_idx] = score
-
-    # Get expected top-k indices
-    seq_expected = np.argsort(-naive_scores, axis=-1)[:, :k]
-
-    # Overwrite masked (-inf) positions with -1
+    expected_topk = np.argsort(-naive_scores, axis=-1)[:, :k]
     for t_idx in range(T_seq):
-      for i in range(k):
-        idx = seq_expected[t_idx, i]
-        if naive_scores[t_idx, idx] == -np.inf:
-          expected_topk[q_start + t_idx, i] = -1
-        else:
-          expected_topk[q_start + t_idx, i] = idx
+        for i in range(k):
+            idx = expected_topk[t_idx, i]
+            if naive_scores[t_idx, idx] == -np.inf:
+                expected_topk[t_idx, i] = -1
 
-  print("\nGROUND TRUTH (Naive NumPy):")
-  print(expected_topk)
+    # Pallas parameters
+    actual_topk = streamindex_topk(
+        q=jnp.array(q),
+        indexer_weights=jnp.array(weights),
+        cache_kv=jnp.array(cache_kv),
+        seq_lens=jnp.array([S_seq], dtype=jnp.int32),
+        page_indices=jnp.arange(num_pages, dtype=jnp.int32),
+        cu_q_lens=jnp.array([0, T_seq], dtype=jnp.int32),
+        distribution=jnp.array([0, 0, 1], dtype=jnp.int32),
+        k=k,
+        compression_ratio=comp_ratio,
+        num_kv_pages_per_block=bkv_p,
+        num_queries_per_block=bq_sz,
+    )
 
-  # =====================================================================
-  # 3. Pallas KERNEL COMPUTATION
-  # =====================================================================
-  print("\n[2/3] Executing optimized JAX Kernel (streamindex_pallas_topk)...")
-  # Count number of decode sequences (T == 1) at the beginning of the batch
-  num_decodes = 0
-  while num_decodes < B and T_list[num_decodes] == 1:
-    num_decodes += 1
-  distribution = (num_decodes, num_decodes, B)
+    actual_topk_np = np.array(actual_topk)
 
-  actual_topk = streamindex_topk(
-      q=jnp.array(q),
-      indexer_weights=jnp.array(weights),
-      cache_kv=jnp.array(kv),
-      seq_lens=jnp.array(seq_lens),
-      page_indices=jnp.array(page_indices),
-      cu_q_lens=jnp.array(cu_q_lens),
-      distribution=distribution,
-      k=k,
-      compression_ratio=comp_ratio,
-      num_kv_pages_per_block=bkv_p,
-      num_queries_per_block=bq_sz,
-  )
-
-  actual_topk_np = np.array(actual_topk)
-
-  print("\nACTUAL OUTPUT (JAX/XLA Kernel):")
-  print(actual_topk_np)
-
-  # =====================================================================
-  # 4. VERIFY
-  # =====================================================================
-  print("\n[3/3] Verifying absolute correctness...")
-  np.testing.assert_array_equal(
-      np.sort(actual_topk_np, axis=-1),
-      np.sort(expected_topk, axis=-1),
-      err_msg="JAX Pallas Kernel Top-K math did not match Naive Ground Truth",
-  )
-  print(
-      "MATCH VERIFIED! JAX kernel handles batches, fragmentation, and dummy"
-      " padding.\n"
-  )
+    np.testing.assert_array_equal(
+        np.sort(actual_topk_np, axis=-1),
+        np.sort(expected_topk, axis=-1),
+    )
 
 
 def main(argv):
-  del argv
-  import sys
+    del argv
 
-  raise SystemExit(pytest.main([__file__, "-p", "no:cacheprovider"]))
+    raise SystemExit(pytest.main([__file__, "-p", "no:cacheprovider"]))
 
 
 if __name__ == "__main__":
-  from absl import app
+    from absl import app
 
-  app.run(main)
+    app.run(main)

--- a/tpu_inference/kernels/experimental/deepseek_v4/__init__.py
+++ b/tpu_inference/kernels/experimental/deepseek_v4/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tpu_inference/kernels/experimental/deepseek_v4/streamindex_topk.py
+++ b/tpu_inference/kernels/experimental/deepseek_v4/streamindex_topk.py
@@ -1,55 +1,68 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """TPU-Friendly StreamIndex Top-K kernel."""
 
-from enum import Enum
+import enum
 import functools
-import math
 
 import jax
+import jax.numpy as jnp
 from jax import lax
 from jax.experimental import pallas as pl
 from jax.experimental.pallas import tpu as pltpu
-import jax.numpy as jnp
 
+Enum = enum.Enum
 DEFAULT_VMEM_LIMIT_BYTES = 100 * 1024 * 1024
 
 
 def cdiv(a, b):
-  assert b != 0
-  return (a + b - 1) // b
+    assert b != 0
+    return (a + b - 1) // b
 
 
 def align_to(x, a):
-  return cdiv(x, a) * a
+    return cdiv(x, a) * a
 
 
 def get_dtype_bitwidth(dtype):
-  return jax.dtypes.itemsize_bits(dtype)
+    return jax.dtypes.itemsize_bits(dtype)
 
 
 def get_dtype_packing(dtype):
-  bits = get_dtype_bitwidth(dtype)
-  return 32 // bits
+    bits = get_dtype_bitwidth(dtype)
+    return 32 // bits
 
 
 class MlaCase(Enum):
-  """Represents the different cases for MLA.
+    """Represents the different cases for MLA.
 
   - DECODE: Sequences are in decode-only mode (q_len = 1).
   - PREFILL: Sequences are in prefill-only mode (q_len > 1, static).
   - MIXED: Sequences can be a mix of prefill and decode (q_len > 1, dynamic).
   """
 
-  DECODE = 0
-  PREFILL = 1
-  MIXED = 2
+    DECODE = 0
+    PREFILL = 1
+    MIXED = 2
 
-  @property
-  def symbol(self):
-    return {
-        MlaCase.DECODE: "d",
-        MlaCase.PREFILL: "p",
-        MlaCase.MIXED: "m",
-    }[self]
+    @property
+    def symbol(self):
+        return {
+            MlaCase.DECODE: "d",
+            MlaCase.PREFILL: "p",
+            MlaCase.MIXED: "m",
+        }[self]
 
 
 def _streamindex_topk_kernel(
@@ -61,14 +74,14 @@ def _streamindex_topk_kernel(
     sem_ids_ref,  # [3] (bq_sem_idx, bkv_sem_idx, bo_sem_idx)
     bo_ids_ref,  # [4] (bo_sem_0_seq_idx, bo_sem_1_seq_idx, bo_sem_0_bo_idx, bo_sem_1_bo_idx)
     # Input
-    q_hbm_ref,  # [max_num_tokens, num_q_heads, lkv_dim]
+    q_hbm_ref,  # [max_num_tokens, num_q_heads, head_dim]
     indexer_weights_hbm_ref,  # [max_num_tokens, num_q_heads]
     cache_kv_hbm_ref,  # [total_num_pages, page_size_per_kv_packing, kv_packing, lkv_dim]
     # Output
     topk_idxs_hbm_ref,  # [max_num_tokens, k]
     # Scratch
     bkv_x2_ref,  # [2, bkv_buf_sz_per_kv_packing, kv_packing, lkv_dim]
-    bq_x2_ref,  # [2, bq_sz, num_q_heads, q_packing, lkv_dim]
+    bq_x2_ref,  # [2, bq_sz, num_q_heads, q_packing, head_dim]
     bq_weights_x2_ref,  # [2, bq_sz, num_q_heads]
     bo_idxs_x2_ref,  # [2, bq_sz, k]
     sems,  # [4, 2]
@@ -84,426 +97,434 @@ def _streamindex_topk_kernel(
     actual_head_dim: int,
     kv_packing: int,
 ):
-  _, num_q_heads, q_lkv_dim = q_hbm_ref.shape
+    _, num_q_heads, head_dim = q_hbm_ref.shape
 
-  total_num_pages, page_size_per_kv_packing, _, _ = cache_kv_hbm_ref.shape
+    total_num_pages, page_size_per_kv_packing, _, _ = cache_kv_hbm_ref.shape
 
-  max_num_seqs = seq_lens_ref.shape[0]
-  num_page_indices = page_indices_ref.shape[0]
+    max_num_seqs = seq_lens_ref.shape[0]
+    num_page_indices = page_indices_ref.shape[0]
 
-  assert num_page_indices % max_num_seqs == 0
-  pages_per_seq = num_page_indices // max_num_seqs
-  q_dtype = q_hbm_ref.dtype
-  # Validate against the KV dtype.
-  kv_dtype = cache_kv_hbm_ref.dtype
-  assert get_dtype_packing(kv_dtype) == kv_packing
-  assert q_lkv_dim % 128 == 0
+    assert num_page_indices % max_num_seqs == 0
+    pages_per_seq = num_page_indices // max_num_seqs
 
-  bkv_sz_per_kv_packing = bkv_p * page_size_per_kv_packing
-  bkv_sz = bkv_sz_per_kv_packing * kv_packing
+    # Validate against the KV dtype.
+    kv_dtype = cache_kv_hbm_ref.dtype
+    assert get_dtype_packing(kv_dtype) == kv_packing
+    assert head_dim % 128 == 0
 
-  start_seq_idx = start_end_seq_idx_ref[0]
-  end_seq_idx = start_end_seq_idx_ref[1]
-  seq_idx = pl.program_id(0) + start_seq_idx
+    bkv_sz_per_kv_packing = bkv_p * page_size_per_kv_packing
+    bkv_sz = bkv_sz_per_kv_packing * kv_packing
 
-  q_start = cu_q_lens_ref[seq_idx]
-  q_end = cu_q_lens_ref[seq_idx + 1]
-  q_len = q_end - q_start
+    start_seq_idx = start_end_seq_idx_ref[0]
+    end_seq_idx = start_end_seq_idx_ref[1]
+    seq_idx = pl.program_id(0) + start_seq_idx
 
-  seq_len = seq_lens_ref[seq_idx]
-  kv_len = seq_len // compression_ratio
+    q_start = cu_q_lens_ref[seq_idx]
+    q_end = cu_q_lens_ref[seq_idx + 1]
+    q_len = q_end - q_start
 
-  def compute_topk(
-      q,
-      kv,
-      *,
-      bkv_idx,
-      bq_pos_compressed,
-      bq_weights,
-  ):
-    head_vals_ref = topk_vals_scratch.at[:bq_sz]
-    head_idxs_ref = topk_idxs_scratch.at[:bq_sz]
+    seq_len = seq_lens_ref[seq_idx]
+    kv_len = seq_len // compression_ratio
 
-    q_flat = q.reshape(
-        bq_sz * actual_num_q_heads,
-        actual_head_dim,
-    )
-    s = jnp.einsum(
-        "nd,md->nm",
-        q_flat,
+    def compute_topk(
+        q,
         kv,
-        preferred_element_type=jnp.float32,
-    )
-    s = s.reshape(bq_sz, actual_num_q_heads, s.shape[-1])
-    s = jnp.maximum(s, 0.0)
-    s = s * bq_weights.astype(jnp.float32)[:, :, None]
-    s_summed = s.sum(axis=1)
+        scale_val,
+        *,
+        bkv_idx,
+        bq_pos_compressed,
+        bq_weights,
+    ):
+        head_vals_ref = topk_vals_scratch.at[:bq_sz]
+        head_idxs_ref = topk_idxs_scratch.at[:bq_sz]
 
-    k_span = bkv_idx * bkv_sz + lax.broadcasted_iota(
-        jnp.int32, s_summed.shape, 1
-    )
+        q_flat = q.reshape(
+            bq_sz * actual_num_q_heads,
+            head_dim,
+        )
+        s = jnp.einsum(
+            "nd,md->nm",
+            q_flat,
+            kv,
+            preferred_element_type=jnp.float32,
+        )
+        s = s.reshape(bq_sz, actual_num_q_heads, s.shape[-1])
+        s = s * scale_val.reshape(1, 1, -1)
+        s = jnp.maximum(s, 0.0)
+        s = s * bq_weights.astype(jnp.float32)[:, :, None]
+        s_summed = s.sum(axis=1)
 
-    valid_mask = k_span < kv_len
-    causal_mask = k_span <= bq_pos_compressed[:, None]
-    mask = jnp.logical_and(valid_mask, causal_mask)
+        k_span = bkv_idx * bkv_sz + lax.broadcasted_iota(
+            jnp.int32, s_summed.shape, 1)
 
-    s_summed = jnp.where(mask, s_summed, -jnp.inf)
+        valid_mask = k_span < kv_len
+        causal_mask = k_span <= bq_pos_compressed[:, None]
+        mask = jnp.logical_and(valid_mask, causal_mask)
 
-    prev_vals = head_vals_ref[...]
-    prev_idxs = head_idxs_ref[...]
+        s_summed = jnp.where(mask, s_summed, -jnp.inf)
 
-    k_span_bcast = jnp.broadcast_to(k_span, s_summed.shape)
-    k_span_bcast = jnp.where(mask, k_span_bcast, -1)
+        prev_vals = head_vals_ref[...]
+        prev_idxs = head_idxs_ref[...]
 
-    concat_s = jnp.concatenate([prev_vals, s_summed], axis=1)
-    concat_i = jnp.concatenate([prev_idxs, k_span_bcast], axis=1)
+        k_span_bcast = jnp.broadcast_to(k_span, s_summed.shape)
+        k_span_bcast = jnp.where(mask, k_span_bcast, -1)
 
-    col_indices = lax.broadcasted_iota(jnp.int32, concat_s.shape, 1)
-    s_work = concat_s
+        concat_s = jnp.concatenate([prev_vals, s_summed], axis=1)
+        concat_i = jnp.concatenate([prev_idxs, k_span_bcast], axis=1)
 
-    new_vals_list = []
-    new_idxs_list = []
+        col_indices = lax.broadcasted_iota(jnp.int32, concat_s.shape, 1)
+        s_work = concat_s
 
-    for _ in range(k):
-      max_val = jnp.max(s_work, axis=1, keepdims=True)
-      is_max = s_work == max_val
-      idx = jnp.min(
-          jnp.where(is_max, col_indices, jnp.iinfo(jnp.int32).max),
-          axis=1,
-          keepdims=True,
-      )
+        new_vals_list = []
+        new_idxs_list = []
 
-      is_chosen = col_indices == idx
-      orig_idx = jnp.max(
-          jnp.where(is_chosen, concat_i, -1), axis=1, keepdims=True
-      )
+        for _ in range(k):
+            max_val = jnp.max(s_work, axis=1, keepdims=True)
+            is_max = s_work == max_val
+            idx = jnp.min(
+                jnp.where(is_max, col_indices,
+                          jnp.iinfo(jnp.int32).max),
+                axis=1,
+                keepdims=True,
+            )
 
-      orig_idx = jnp.where(max_val <= -jnp.inf, -1, orig_idx)
-      max_val = jnp.where(max_val <= -jnp.inf, -jnp.inf, max_val)
+            is_chosen = col_indices == idx
+            orig_idx = jnp.max(jnp.where(is_chosen, concat_i, -1),
+                               axis=1,
+                               keepdims=True)
 
-      new_vals_list.append(max_val)
-      new_idxs_list.append(orig_idx)
+            orig_idx = jnp.where(max_val <= -jnp.inf, -1, orig_idx)
+            max_val = jnp.where(max_val <= -jnp.inf, -jnp.inf, max_val)
 
-      s_work = jnp.where(is_chosen, -jnp.inf, s_work)
+            new_vals_list.append(max_val)
+            new_idxs_list.append(orig_idx)
 
-    new_vals = jnp.concatenate(new_vals_list, axis=1)
-    new_idxs = jnp.concatenate(new_idxs_list, axis=1)
+            s_work = jnp.where(is_chosen, -jnp.inf, s_work)
 
-    head_vals_ref[...] = new_vals
-    head_idxs_ref[...] = new_idxs
+        new_vals = jnp.concatenate(new_vals_list, axis=1)
+        new_idxs = jnp.concatenate(new_idxs_list, axis=1)
 
-  def _async_copy(src, dst, sem, wait):
-    cp = pltpu.make_async_copy(src, dst, sem)
-    if wait:
-      cp.wait()
-    else:
-      cp.start()
+        head_vals_ref[...] = new_vals
+        head_idxs_ref[...] = new_idxs
 
-  def _fetch_bkv(seq_idx, bkv_idx, bkv_sem_idx, *, wait=False):
-    sem = sems.at[0, bkv_sem_idx]
-    bkv_vmem_ref = bkv_x2_ref.at[bkv_sem_idx]
+    def _async_copy(src, dst, sem, wait):
+        cp = pltpu.make_async_copy(src, dst, sem)
+        if wait:
+            cp.wait()
+        else:
+            cp.start()
 
-    reshaped_cache_hbm_ref = cache_kv_hbm_ref.reshape(
-        total_num_pages * page_size_per_kv_packing,
-        kv_packing,
-        actual_head_dim,
-    )
+    def _fetch_bkv(seq_idx, bkv_idx, bkv_sem_idx, *, wait=False):
+        sem = sems.at[0, bkv_sem_idx]
+        bkv_vmem_ref = bkv_x2_ref.at[bkv_sem_idx]
 
-    kv_p_start = bkv_idx * bkv_p
-    page_indices_offset = seq_idx * pages_per_seq + kv_p_start
-
-    if not wait:
-      for i in range(bkv_p):
-        sz_per_kv_packing = page_size_per_kv_packing
-        page_idx = jnp.minimum(page_indices_offset + i, num_page_indices - 1)
-
-        max_hbm_pages = reshaped_cache_hbm_ref.shape[0]
-        safe_page_offset = jnp.minimum(
-            page_indices_ref[page_idx] * page_size_per_kv_packing,
-            jnp.maximum(0, max_hbm_pages - page_size_per_kv_packing),
+        reshaped_cache_hbm_ref = cache_kv_hbm_ref.reshape(
+            total_num_pages * page_size_per_kv_packing,
+            kv_packing,
+            actual_head_dim,
         )
 
-        _async_copy(
-            reshaped_cache_hbm_ref.at[
-                pl.ds(safe_page_offset, sz_per_kv_packing)
-            ],
-            bkv_vmem_ref.at[
-                pl.ds(i * page_size_per_kv_packing, sz_per_kv_packing)
-            ],
-            sem,
-            wait=False,
-        )
-    else:
-      dma_bkv_sz = bkv_p * page_size_per_kv_packing
-      dst_kv = bkv_vmem_ref.at[pl.ds(0, dma_bkv_sz)]
-      _async_copy(src=dst_kv, dst=dst_kv, sem=sem, wait=True)
+        kv_p_start = bkv_idx * bkv_p
+        page_indices_offset = seq_idx * pages_per_seq + kv_p_start
 
-  def _fetch_bq(seq_idx, bq_idx, bq_sem_idx, *, wait=False):
-    sem = sems.at[1, bq_sem_idx]
-    weights_sem = sems.at[3, bq_sem_idx]
-    bq_vmem_ref = bq_x2_ref.at[bq_sem_idx]
-    bq_weights_vmem_ref = bq_weights_x2_ref.at[bq_sem_idx]
+        if not wait:
+            for i in range(bkv_p):
+                sz_per_kv_packing = page_size_per_kv_packing
+                page_idx = jnp.minimum(page_indices_offset + i,
+                                       num_page_indices - 1)
 
-    q_len_start = cu_q_lens_ref[seq_idx] + bq_idx * bq_sz
-    curr_q_end = cu_q_lens_ref[seq_idx + 1]
+                max_hbm_pages = reshaped_cache_hbm_ref.shape[0]
+                safe_page_offset = jnp.minimum(
+                    page_indices_ref[page_idx] * page_size_per_kv_packing,
+                    jnp.maximum(0, max_hbm_pages - page_size_per_kv_packing),
+                )
 
-    sz = jnp.maximum(0, jnp.minimum(bq_sz, curr_q_end - q_len_start))
-    safe_q_start = jnp.minimum(
-        q_len_start, jnp.maximum(0, q_hbm_ref.shape[0] - jnp.maximum(1, sz))
-    )
+                _async_copy(
+                    reshaped_cache_hbm_ref.at[pl.ds(safe_page_offset,
+                                                    sz_per_kv_packing)],
+                    bkv_vmem_ref.at[pl.ds(i * page_size_per_kv_packing,
+                                          sz_per_kv_packing)],
+                    sem,
+                    wait=False,
+                )
+        else:
+            dma_bkv_sz = bkv_p * page_size_per_kv_packing
+            dst_kv = bkv_vmem_ref.at[pl.ds(0, dma_bkv_sz)]
+            _async_copy(src=dst_kv, dst=dst_kv, sem=sem, wait=True)
 
-    if not wait:
-      _async_copy(
-          q_hbm_ref.at[pl.ds(safe_q_start, sz)],
-          bq_vmem_ref.at[pl.ds(0, sz)],
-          sem,
-          wait=False,
-      )
-      _async_copy(
-          indexer_weights_hbm_ref.at[pl.ds(safe_q_start, sz)],
-          bq_weights_vmem_ref.at[pl.ds(0, sz)],
-          weights_sem,
-          wait=False,
-      )
-    else:
-      dst = bq_vmem_ref.at[pl.ds(0, sz)]
-      _async_copy(dst, dst, sem, wait=True)
-      dst_w = bq_weights_vmem_ref.at[pl.ds(0, sz)]
-      _async_copy(dst_w, dst_w, weights_sem, wait=True)
+    def _fetch_bq(seq_idx, bq_idx, bq_sem_idx, *, wait=False):
+        sem = sems.at[1, bq_sem_idx]
+        weights_sem = sems.at[3, bq_sem_idx]
+        bq_vmem_ref = bq_x2_ref.at[bq_sem_idx]
+        bq_weights_vmem_ref = bq_weights_x2_ref.at[bq_sem_idx]
 
-  def _send_bo(seq_idx, bo_idx, bo_sem_idx, *, wait=False):
-    sem_idxs = sems.at[2, bo_sem_idx]
+        q_len_start = cu_q_lens_ref[seq_idx] + bq_idx * bq_sz
+        curr_q_end = cu_q_lens_ref[seq_idx + 1]
 
-    q_len_start = cu_q_lens_ref[seq_idx] + bo_idx * bq_sz
-    curr_q_end = cu_q_lens_ref[seq_idx + 1]
+        sz = jnp.maximum(0, jnp.minimum(bq_sz, curr_q_end - q_len_start))
+        safe_q_start = jnp.minimum(
+            q_len_start, jnp.maximum(0,
+                                     q_hbm_ref.shape[0] - jnp.maximum(1, sz)))
 
-    sz = jnp.maximum(0, jnp.minimum(bq_sz, curr_q_end - q_len_start))
-    safe_q_start = jnp.minimum(
-        q_len_start,
-        jnp.maximum(0, topk_idxs_hbm_ref.shape[0] - jnp.maximum(1, sz)),
-    )
+        if not wait:
+            _async_copy(
+                q_hbm_ref.at[pl.ds(safe_q_start, sz)],
+                bq_vmem_ref.at[pl.ds(0, sz)],
+                sem,
+                wait=False,
+            )
+            _async_copy(
+                indexer_weights_hbm_ref.at[pl.ds(safe_q_start, sz)],
+                bq_weights_vmem_ref.at[pl.ds(0, sz)],
+                weights_sem,
+                wait=False,
+            )
+        else:
+            dst = bq_vmem_ref.at[pl.ds(0, sz)]
+            _async_copy(dst, dst, sem, wait=True)
+            dst_w = bq_weights_vmem_ref.at[pl.ds(0, sz)]
+            _async_copy(dst_w, dst_w, weights_sem, wait=True)
 
-    if not wait:
-      _async_copy(
-          bo_idxs_x2_ref.at[bo_sem_idx, pl.ds(0, sz)],
-          topk_idxs_hbm_ref.at[pl.ds(safe_q_start, sz)],
-          sem_idxs,
-          wait=False,
-      )
-    else:
-      dst_i = bo_idxs_x2_ref.at[bo_sem_idx, pl.ds(0, sz)]
-      _async_copy(dst_i, dst_i, sem_idxs, wait=True)
+    def _send_bo(seq_idx, bo_idx, bo_sem_idx, *, wait=False):
+        sem_idxs = sems.at[2, bo_sem_idx]
 
-  def start_fetch_bkv(seq_idx, bkv_idx, bkv_sem_idx):
-    _fetch_bkv(seq_idx, bkv_idx, bkv_sem_idx)
+        q_len_start = cu_q_lens_ref[seq_idx] + bo_idx * bq_sz
+        curr_q_end = cu_q_lens_ref[seq_idx + 1]
 
-  def wait_fetch_bkv(seq_idx, bkv_idx, bkv_sem_idx):
-    _fetch_bkv(seq_idx, bkv_idx, bkv_sem_idx, wait=True)
-
-  def start_fetch_bq(seq_idx, bq_idx, bq_sem_idx):
-    return _fetch_bq(seq_idx, bq_idx, bq_sem_idx)
-
-  def wait_fetch_bq(seq_idx, bq_idx, bq_sem_idx):
-    return _fetch_bq(seq_idx, bq_idx, bq_sem_idx, wait=True)
-
-  def start_send_bo(seq_idx, bo_idx, bo_sem_idx):
-    bo_ids_ref[bo_sem_idx] = seq_idx
-    bo_ids_ref[bo_sem_idx + 2] = bo_idx
-    _send_bo(seq_idx, bo_idx, bo_sem_idx)
-
-  def wait_send_bo(bo_sem_idx):
-    old_seq_idx = bo_ids_ref[bo_sem_idx]
-    old_bo_idx = bo_ids_ref[bo_sem_idx + 2]
-
-    @pl.when(jnp.logical_and(0 <= old_seq_idx, old_seq_idx <= seq_idx))
-    def _():
-      _send_bo(old_seq_idx, old_bo_idx, bo_sem_idx, wait=True)
-
-  def load_bq(bq_sem_idx):
-    q = bq_x2_ref.at[bq_sem_idx, :bq_sz][...]
-    q = q.reshape(bq_sz, num_q_heads, q_lkv_dim)
-    return q[:, :actual_num_q_heads, :actual_head_dim]
-
-  def load_bq_weights(bq_sem_idx):
-    w = bq_weights_x2_ref.at[bq_sem_idx, :bq_sz][...]
-    return w[:, :actual_num_q_heads]
-
-  def load_bkv(bkv_sem_idx):
-    bkv = bkv_x2_ref.at[bkv_sem_idx, :bkv_sz_per_kv_packing][...]
-    # TODO(hwanginho): Handle DSv4 FP8 index cache format.
-    # If `bkv` is in FP8, we need to upcast it to f32/bf16 and multiply it
-    # by the corresponding scale factors.
-    return bkv.reshape(bkv_sz, actual_head_dim)
-
-  # --- KERNEL PROCESS LOOP ---
-
-  def process():
-    num_bkv = jnp.maximum(1, cdiv(kv_len, bkv_sz))
-    if static_q_len is None:
-      num_bq = jnp.maximum(1, cdiv(q_len, bq_sz))
-    else:
-      num_bq = jnp.maximum(1, cdiv(static_q_len, bq_sz))
-
-    def get_next_bq_ids(seq_idx, bq_idx, bq_sem_idx):
-      next_bq_idx = bq_idx + 1
-      is_last_bq = next_bq_idx == num_bq
-      next_bq_idx = lax.select(is_last_bq, 0, next_bq_idx)
-      next_seq_idx = lax.select(is_last_bq, seq_idx + 1, seq_idx)
-      next_bq_sem_idx = lax.select(bq_sem_idx == 0, 1, 0)
-      return next_seq_idx, next_bq_idx, next_bq_sem_idx
-
-    def get_next_bkv_ids(seq_idx, bq_idx, bkv_idx, bkv_sem_idx):
-      next_bkv_idx = bkv_idx + 1
-      is_last_bkv = next_bkv_idx == num_bkv
-      next_bkv_idx = lax.select(is_last_bkv, 0, next_bkv_idx)
-      next_bq_idx = lax.select(is_last_bkv, bq_idx + 1, bq_idx)
-      is_last_bq = next_bq_idx == num_bq
-      next_bq_idx = lax.select(is_last_bq, 0, next_bq_idx)
-      next_seq_idx = lax.select(is_last_bq, seq_idx + 1, seq_idx)
-      next_bkv_sem_idx = lax.select(bkv_sem_idx == 0, 1, 0)
-      return next_seq_idx, next_bq_idx, next_bkv_idx, next_bkv_sem_idx
-
-    def compute_with_bq(bq_idx, _):
-      bq_sem_idx = sem_ids_ref[0]
-      next_seq_idx, next_bq_idx, next_bq_sem_idx = get_next_bq_ids(
-          seq_idx, bq_idx, bq_sem_idx
-      )
-
-      # Prefetch next bq
-      @pl.when(next_seq_idx < end_seq_idx)
-      def prefetch_next_bq():
-        sem_ids_ref[0] = next_bq_sem_idx
-        start_fetch_bq(next_seq_idx, next_bq_idx, next_bq_sem_idx)
-
-      # Initialize scratch space for top-K values and indices.
-      # TODO(hwanginho): Use b16 or fp8 format for top-K values scratch if
-      # possible.
-      topk_vals_scratch[...] = jnp.full((bq_sz, k), -jnp.inf, dtype=jnp.float32)
-      topk_idxs_scratch[...] = jnp.full((bq_sz, k), -1, dtype=jnp.int32)
-
-      q_pos = (
-          seq_len - q_len + bq_idx * bq_sz + jnp.arange(bq_sz, dtype=jnp.int32)
-      )
-      bq_pos_compressed = q_pos // compression_ratio
-
-      def compute_with_bkv(bkv_idx, _):
-        bkv_sem_idx = sem_ids_ref[1]
-        next_seq_idx, _, next_bkv_idx, next_bkv_sem_idx = get_next_bkv_ids(
-            seq_idx, bq_idx, bkv_idx, bkv_sem_idx
+        sz = jnp.maximum(0, jnp.minimum(bq_sz, curr_q_end - q_len_start))
+        safe_q_start = jnp.minimum(
+            q_len_start,
+            jnp.maximum(0, topk_idxs_hbm_ref.shape[0] - jnp.maximum(1, sz)),
         )
 
-        # Prefetch next bkv
-        @pl.when(next_seq_idx < end_seq_idx)
-        def prefetch_next_bkv():
-          sem_ids_ref[1] = next_bkv_sem_idx
-          start_fetch_bkv(next_seq_idx, next_bkv_idx, next_bkv_sem_idx)
+        if not wait:
+            _async_copy(
+                bo_idxs_x2_ref.at[bo_sem_idx, pl.ds(0, sz)],
+                topk_idxs_hbm_ref.at[pl.ds(safe_q_start, sz)],
+                sem_idxs,
+                wait=False,
+            )
+        else:
+            dst_i = bo_idxs_x2_ref.at[bo_sem_idx, pl.ds(0, sz)]
+            _async_copy(dst_i, dst_i, sem_idxs, wait=True)
 
-        # Wait for cur bq if not ready yet
-        @pl.when(bkv_idx == 0)
-        def wait_cur_bq():
-          wait_fetch_bq(seq_idx, bq_idx, bq_sem_idx)
+    def start_fetch_bkv(seq_idx, bkv_idx, bkv_sem_idx):
+        _fetch_bkv(seq_idx, bkv_idx, bkv_sem_idx)
 
-        # Wait for cur bkv
-        wait_fetch_bkv(seq_idx, bkv_idx, bkv_sem_idx)
+    def wait_fetch_bkv(seq_idx, bkv_idx, bkv_sem_idx):
+        _fetch_bkv(seq_idx, bkv_idx, bkv_sem_idx, wait=True)
 
-        bkv = load_bkv(bkv_sem_idx)
-        bq = load_bq(bq_sem_idx)
-        bq_weights = load_bq_weights(bq_sem_idx)
+    def start_fetch_bq(seq_idx, bq_idx, bq_sem_idx):
+        return _fetch_bq(seq_idx, bq_idx, bq_sem_idx)
 
-        compute_topk(
-            bq,
-            bkv,
-            bkv_idx=bkv_idx,
-            bq_pos_compressed=bq_pos_compressed,
-            bq_weights=bq_weights,
-        )
+    def wait_fetch_bq(seq_idx, bq_idx, bq_sem_idx):
+        return _fetch_bq(seq_idx, bq_idx, bq_sem_idx, wait=True)
 
-      lax.fori_loop(0, num_bkv, compute_with_bkv, None, unroll=False)
+    def start_send_bo(seq_idx, bo_idx, bo_sem_idx):
+        bo_ids_ref[bo_sem_idx] = seq_idx
+        bo_ids_ref[bo_sem_idx + 2] = bo_idx
+        _send_bo(seq_idx, bo_idx, bo_sem_idx)
 
-      out_idxs = topk_idxs_scratch[...]
+    def wait_send_bo(bo_sem_idx):
+        old_seq_idx = bo_ids_ref[bo_sem_idx]
+        old_bo_idx = bo_ids_ref[bo_sem_idx + 2]
 
-      bo_sem_idx = sem_ids_ref[2]
-      sem_ids_ref[2] = lax.select(bo_sem_idx == 0, jnp.int32(1), jnp.int32(0))
+        @pl.when(jnp.logical_and(0 <= old_seq_idx, old_seq_idx <= seq_idx))
+        def _():
+            _send_bo(old_seq_idx, old_bo_idx, bo_sem_idx, wait=True)
 
-      wait_send_bo(bo_sem_idx)
+    def load_bq(bq_sem_idx):
+        q = bq_x2_ref.at[bq_sem_idx, :bq_sz][...]
+        q = q.reshape(bq_sz, num_q_heads, head_dim)
+        return q[:, :actual_num_q_heads, :actual_head_dim]
 
-      bo_idxs_x2_ref[bo_sem_idx, ...] = out_idxs.reshape(
-          bo_idxs_x2_ref[bo_sem_idx].shape
-      )
+    def load_bq_weights(bq_sem_idx):
+        w = bq_weights_x2_ref.at[bq_sem_idx, :bq_sz][...]
+        return w[:, :actual_num_q_heads]
 
-      start_send_bo(seq_idx, bq_idx, bo_sem_idx)
+    def load_bkv(bkv_sem_idx):
+        bkv = bkv_x2_ref.at[bkv_sem_idx, :bkv_sz_per_kv_packing][...]
+        # Quantized FP8 index cache path: unpack keys and scale factors locally.
+        flat_bkv = bkv.reshape(-1, bkv.shape[-1])
+        fp8_val = flat_bkv[:, :head_dim]
+        fp8_val = jax.lax.bitcast_convert_type(fp8_val, jnp.float8_e4m3fn)
 
-    lax.fori_loop(0, num_bq, compute_with_bq, None, unroll=False)
+        scale_val = flat_bkv[:, head_dim:head_dim + 1]
+        scale_val = jax.lax.bitcast_convert_type(
+            scale_val, jnp.float8_e8m0fnu).astype(jnp.float32)
 
-  ### ------- Kernel start ------- ###
+        # NOTE: Do NOT multiply the scales here. Return them separately.
+        return fp8_val.reshape(bkv_sz, head_dim), scale_val.reshape(bkv_sz, 1)
 
-  @pl.when(seq_idx == start_seq_idx)
-  def prologue():
-    start_fetch_bq(start_seq_idx, 0, 0)
+    # --- KERNEL PROCESS LOOP ---
 
-    # Initialize bkv_x2_ref to zeros to avoid NaN issues from accessing
-    # uninitialized memory. Bitcast into int32 to avoid tiling issues.
-    bkv_x2_int32_ref = bkv_x2_ref.bitcast(jnp.int32).reshape(
-        (2, -1, actual_head_dim)
-    )
-    bkv_zeros = jnp.zeros(bkv_x2_int32_ref.shape[1:], jnp.int32)
+    def process():
+        num_bkv = jnp.maximum(1, cdiv(kv_len, bkv_sz))
+        if static_q_len is None:
+            num_bq = jnp.maximum(1, cdiv(q_len, bq_sz))
+        else:
+            num_bq = jnp.maximum(1, cdiv(static_q_len, bq_sz))
 
-    # To pipeline VST and DMA, we divide the initialization into two steps.
-    bkv_x2_int32_ref[0] = bkv_zeros
-    start_fetch_bkv(start_seq_idx, 0, 0)
-    bkv_x2_int32_ref[1] = bkv_zeros
+        def get_next_bq_ids(seq_idx, bq_idx, bq_sem_idx):
+            next_bq_idx = bq_idx + 1
+            is_last_bq = next_bq_idx == num_bq
+            next_bq_idx = lax.select(is_last_bq, 0, next_bq_idx)
+            next_seq_idx = lax.select(is_last_bq, seq_idx + 1, seq_idx)
+            next_bq_sem_idx = lax.select(bq_sem_idx == 0, 1, 0)
+            return next_seq_idx, next_bq_idx, next_bq_sem_idx
 
-  process()
+        def get_next_bkv_ids(seq_idx, bq_idx, bkv_idx, bkv_sem_idx):
+            next_bkv_idx = bkv_idx + 1
+            is_last_bkv = next_bkv_idx == num_bkv
+            next_bkv_idx = lax.select(is_last_bkv, 0, next_bkv_idx)
+            next_bq_idx = lax.select(is_last_bkv, bq_idx + 1, bq_idx)
+            is_last_bq = next_bq_idx == num_bq
+            next_bq_idx = lax.select(is_last_bq, 0, next_bq_idx)
+            next_seq_idx = lax.select(is_last_bq, seq_idx + 1, seq_idx)
+            next_bkv_sem_idx = lax.select(bkv_sem_idx == 0, 1, 0)
+            return next_seq_idx, next_bq_idx, next_bkv_idx, next_bkv_sem_idx
 
-  @pl.when(seq_idx == end_seq_idx - 1)
-  def epilogue():
-    for i in range(2):
-      wait_send_bo(i)
+        def compute_with_bq(bq_idx, _):
+            bq_sem_idx = sem_ids_ref[0]
+            next_seq_idx, next_bq_idx, next_bq_sem_idx = get_next_bq_ids(
+                seq_idx, bq_idx, bq_sem_idx)
 
-  ### ------- Kernel end ------- ###
+            # Prefetch next bq
+            @pl.when(next_seq_idx < end_seq_idx)
+            def prefetch_next_bq():
+                sem_ids_ref[0] = next_bq_sem_idx
+                start_fetch_bq(next_seq_idx, next_bq_idx, next_bq_sem_idx)
+
+            # Initialize scratch space for top-K values and indices.
+            # TODO(hwanginho): Use b16 or fp8 format for top-K values scratch if
+            # possible.
+            topk_vals_scratch[...] = jnp.full((bq_sz, k),
+                                              -jnp.inf,
+                                              dtype=jnp.float32)
+            topk_idxs_scratch[...] = jnp.full((bq_sz, k), -1, dtype=jnp.int32)
+
+            q_pos = (seq_len - q_len + bq_idx * bq_sz +
+                     jnp.arange(bq_sz, dtype=jnp.int32))
+            bq_pos_compressed = q_pos // compression_ratio
+
+            def compute_with_bkv(bkv_idx, _):
+                bkv_sem_idx = sem_ids_ref[1]
+                next_seq_idx, _, next_bkv_idx, next_bkv_sem_idx = get_next_bkv_ids(
+                    seq_idx, bq_idx, bkv_idx, bkv_sem_idx)
+
+                # Prefetch next bkv
+                @pl.when(next_seq_idx < end_seq_idx)
+                def prefetch_next_bkv():
+                    sem_ids_ref[1] = next_bkv_sem_idx
+                    start_fetch_bkv(next_seq_idx, next_bkv_idx,
+                                    next_bkv_sem_idx)
+
+                # Wait for cur bq if not ready yet
+                @pl.when(bkv_idx == 0)
+                def wait_cur_bq():
+                    wait_fetch_bq(seq_idx, bq_idx, bq_sem_idx)
+
+                # Wait for cur bkv
+                wait_fetch_bkv(seq_idx, bkv_idx, bkv_sem_idx)
+
+                bkv, scale_val = load_bkv(bkv_sem_idx)
+                bq = load_bq(bq_sem_idx)
+                bq_weights = load_bq_weights(bq_sem_idx)
+
+                compute_topk(
+                    bq,
+                    bkv,
+                    scale_val,
+                    bkv_idx=bkv_idx,
+                    bq_pos_compressed=bq_pos_compressed,
+                    bq_weights=bq_weights,
+                )
+
+            lax.fori_loop(0, num_bkv, compute_with_bkv, None, unroll=False)
+
+            out_idxs = topk_idxs_scratch[...]
+
+            bo_sem_idx = sem_ids_ref[2]
+            sem_ids_ref[2] = lax.select(bo_sem_idx == 0, jnp.int32(1),
+                                        jnp.int32(0))
+
+            wait_send_bo(bo_sem_idx)
+
+            bo_idxs_x2_ref[bo_sem_idx, ...] = out_idxs.reshape(
+                bo_idxs_x2_ref[bo_sem_idx].shape)
+
+            start_send_bo(seq_idx, bq_idx, bo_sem_idx)
+
+        lax.fori_loop(0, num_bq, compute_with_bq, None, unroll=False)
+
+    ### ------- Kernel start ------- ###
+
+    @pl.when(seq_idx == start_seq_idx)
+    def prologue():
+        start_fetch_bq(start_seq_idx, 0, 0)
+
+        # Initialize bkv_x2_ref to zeros to avoid NaN issues from accessing
+        # uninitialized memory. Bitcast into int32 to avoid tiling issues.
+        bkv_x2_int32_ref = bkv_x2_ref.bitcast(jnp.int32).reshape(
+            (2, -1, actual_head_dim))
+        bkv_zeros = jnp.zeros(bkv_x2_int32_ref.shape[1:], jnp.int32)
+
+        # To pipeline VST and DMA, we divide the initialization into two steps.
+        bkv_x2_int32_ref[0] = bkv_zeros
+        start_fetch_bkv(start_seq_idx, 0, 0)
+        bkv_x2_int32_ref[1] = bkv_zeros
+
+    process()
+
+    @pl.when(seq_idx == end_seq_idx - 1)
+    def epilogue():
+        for i in range(2):
+            wait_send_bo(i)
+
+    ### ------- Kernel end ------- ###
 
 
 def prepare_q_inputs(
-    q: jax.Array,  # [max_num_tokens, actual_num_q_heads, actual_head_dim],
+        q: jax.Array,  # [max_num_tokens, actual_num_q_heads, actual_head_dim],
 ):
-  _, actual_num_q_heads, actual_head_dim = q.shape
-  q_packing = get_dtype_packing(q.dtype)
-  num_q_heads = align_to(actual_num_q_heads, q_packing)
-  head_dim = align_to(actual_head_dim, 128)
-  q = jnp.pad(
-      q,
-      (
-          (0, 0),
-          (0, num_q_heads - actual_num_q_heads),
-          (0, head_dim - actual_head_dim),
-      ),
-      constant_values=0,
-  )
-  return q
+    _, actual_num_q_heads, actual_head_dim = q.shape
+    q_packing = get_dtype_packing(q.dtype)
+    num_q_heads = align_to(actual_num_q_heads, q_packing)
+    head_dim = align_to(actual_head_dim, 128)
+    q = jnp.pad(
+        q,
+        (
+            (0, 0),
+            (0, num_q_heads - actual_num_q_heads),
+            (0, head_dim - actual_head_dim),
+        ),
+        constant_values=0,
+    )
+    return q
 
 
 def prepare_index_weights(
     index_weights: jax.Array,  # [max_num_tokens, actual_num_q_heads],
     q_dtype,
 ):
-  _, actual_num_q_heads = index_weights.shape
-  index_weights = index_weights.astype(jnp.float32)
-  num_q_heads = align_to(actual_num_q_heads, get_dtype_packing(q_dtype))
-  index_weights = jnp.pad(
-      index_weights,
-      (
-          (0, 0),
-          (0, num_q_heads - actual_num_q_heads),
-      ),
-      constant_values=0,
-  )
-  return index_weights
+    _, actual_num_q_heads = index_weights.shape
+    index_weights = index_weights.astype(jnp.float32)
+    num_q_heads = align_to(actual_num_q_heads, get_dtype_packing(q_dtype))
+    index_weights = jnp.pad(
+        index_weights,
+        (
+            (0, 0),
+            (0, num_q_heads - actual_num_q_heads),
+        ),
+        constant_values=0,
+    )
+    return index_weights
 
 
 def prepare_outputs(out):
-  if out.ndim == 3:
-    out = out.reshape(out.shape[0], -1)
-  return out
+    if out.ndim == 3:
+        out = out.reshape(out.shape[0], -1)
+    return out
 
 
 @functools.partial(
@@ -519,7 +540,8 @@ def prepare_outputs(out):
 def streamindex_topk(
     q: jax.Array,  # [max_num_tokens, actual_num_q_heads, actual_head_dim]
     indexer_weights: jax.Array,  # [max_num_tokens, actual_num_q_heads]
-    cache_kv: jax.Array,  # [total_num_pages, page_size_per_kv_packing, kv_packing, head_dim]
+    cache_kv: jax.
+    Array,  # [total_num_pages, page_size_per_kv_packing, kv_packing, head_dim]
     seq_lens: jax.Array,  # i32[max_num_seqs]
     page_indices: jax.Array,  # i32[max_num_seqs * pages_per_seq]
     cu_q_lens: jax.Array,  # i32[max_num_seqs + 1]
@@ -531,7 +553,7 @@ def streamindex_topk(
     num_queries_per_block: tuple[int, int, int] | int | None = None,
     vmem_limit_bytes: int = DEFAULT_VMEM_LIMIT_BYTES,
 ) -> jax.Array:
-  """StreamIndex Top-K retrieval.
+    """StreamIndex Top-K retrieval.
 
   Args:
     q: concatenated all sequences' queries.
@@ -555,138 +577,131 @@ def streamindex_topk(
   Returns:
     Top-K indices (in compressed space).
   """
-  # TODO(hwanginho): Support DSv4 FP8 index cache format.
-  # This will require scale factors, handling FP8
-  # dtypes, and dequantizing inside the Pallas kernel before the einsum. Need
-  # to align with alynie@ on
-  # https://github.com/vllm-project/tpu-inference/pull/2858, whether the
-  # scales is a separate jax.Array, or packed into the same jax.Array as
-  # `cache_kv`.
+    # Scale factors for the FP8 index cache format are packed directly inside
+    # `cache_kv` along the width dimension, keeping HBM transactions fused.
 
-  if num_kv_pages_per_block is None or num_queries_per_block is None:
-    raise ValueError(
-        "num_kv_pages_per_block and num_queries_per_block must be specified."
-    )
+    if num_kv_pages_per_block is None or num_queries_per_block is None:
+        raise ValueError(
+            "num_kv_pages_per_block and num_queries_per_block must be specified."
+        )
 
-  if isinstance(num_kv_pages_per_block, int):
-    num_kv_pages_per_blocks = [num_kv_pages_per_block for _ in range(3)]
-  else:
-    num_kv_pages_per_blocks = num_kv_pages_per_block
-
-  if isinstance(num_queries_per_block, int):
-    num_queries_per_blocks = [num_queries_per_block for _ in range(3)]
-  else:
-    num_queries_per_blocks = num_queries_per_block
-
-  max_num_seqs = seq_lens.shape[0]
-
-  original_dtype = q.dtype
-
-  prepared_indexer_weights = prepare_index_weights(
-      indexer_weights.astype(original_dtype), original_dtype
-  )
-
-  actual_num_q_heads = q.shape[1]
-  q = prepare_q_inputs(q)
-  actual_head_dim = cache_kv.shape[-1]
-
-  def run_topk_kernel(
-      q,
-      prepared_indexer_weights,
-      cache_kv,
-      seq_lens,
-      page_indices,
-      cu_q_lens,
-      start_seq_idx,
-      end_seq_idx,
-      static_q_len,
-      num_kv_pages_per_block,
-      num_queries_per_block,
-      case=MlaCase.MIXED,
-  ):
-    # Dynamically extract parameters for the DMA mapping from the RAW tensor
-    _, page_size_per_kv_packing, kv_packing, _ = cache_kv.shape
-
-    _, num_q_heads, q_lkv_dim = q.shape
-
-    bkv_p = num_kv_pages_per_block
-    if static_q_len is not None:
-      bq_sz = min(num_queries_per_block, static_q_len)
+    if isinstance(num_kv_pages_per_block, int):
+        num_kv_pages_per_blocks = [num_kv_pages_per_block for _ in range(3)]
     else:
-      bq_sz = num_queries_per_block
-    bkv_sz_per_kv_packing = bkv_p * page_size_per_kv_packing
-    bkv_buf_sz_per_kv_packing = bkv_sz_per_kv_packing
+        num_kv_pages_per_blocks = num_kv_pages_per_block
 
-    grid = (end_seq_idx - start_seq_idx,)
+    if isinstance(num_queries_per_block, int):
+        num_queries_per_blocks = [num_queries_per_block for _ in range(3)]
+    else:
+        num_queries_per_blocks = num_queries_per_block
 
-    in_specs = [
-        pl.BlockSpec(memory_space=pltpu.HBM),  # q
-        pl.BlockSpec(memory_space=pltpu.HBM),  # prepared_indexer_weights
-        pl.BlockSpec(memory_space=pltpu.HBM),  # cache_kv
-    ]
-    out_specs = pl.BlockSpec(memory_space=pltpu.HBM)  # out_idxs
-    assert k % 128 == 0
-    topk_shape = (k // 128, 128)
+    max_num_seqs = seq_lens.shape[0]
 
-    # Group VMEM layout securely by keeping physical shapes separated!
-    bkv_double_buf = pltpu.VMEM(
-        (
-            2,
-            bkv_buf_sz_per_kv_packing,
-            kv_packing,
-            actual_head_dim,
-        ),
-        cache_kv.dtype,
-    )
-    bq_double_bufq = pltpu.VMEM(
-        (
-            2,
-            bq_sz,
-            num_q_heads,
-            q_lkv_dim,
-        ),
-        q.dtype,
-    )
-    bq_weights_double_buf = pltpu.VMEM(
-        (
-            2,
-            bq_sz,
-            num_q_heads,
-        ),
-        prepared_indexer_weights.dtype,
-    )
-    bo_idxs_double_buf = pltpu.VMEM(
-        (
-            2,
-            bq_sz,
-            *topk_shape,
-        ),
-        jnp.int32,
-    )
+    original_dtype = q.dtype
 
-    scratch_shapes = [
-        bkv_double_buf,
-        bq_double_bufq,
-        bq_weights_double_buf,
-        bo_idxs_double_buf,
-        pltpu.SemaphoreType.DMA((4, 2)),
-        pltpu.VMEM((bq_sz, k), jnp.float32),
-        pltpu.VMEM((bq_sz, k), jnp.int32),
-    ]
+    prepared_indexer_weights = prepare_index_weights(
+        indexer_weights.astype(original_dtype), original_dtype)
 
-    scalar_prefetches = (
+    actual_num_q_heads = q.shape[1]
+    q = prepare_q_inputs(q)
+    actual_head_dim = cache_kv.shape[-1]
+
+    def run_topk_kernel(
+        q,
+        prepared_indexer_weights,
+        cache_kv,
         seq_lens,
         page_indices,
         cu_q_lens,
-        jnp.array([start_seq_idx, end_seq_idx], jnp.int32),
-        jnp.zeros((3,), jnp.int32),
-        jnp.full((4,), -1, jnp.int32),
-    )
+        start_seq_idx,
+        end_seq_idx,
+        static_q_len,
+        num_kv_pages_per_block,
+        num_queries_per_block,
+        case=MlaCase.MIXED,
+    ):
+        # Dynamically extract parameters for the DMA mapping from the RAW tensor
+        _, page_size_per_kv_packing, kv_packing, _ = cache_kv.shape
 
-    scope_name = f"StreamIdxTopK-{case.symbol}-bq_{bq_sz}-bkvp_{bkv_p}"
+        _, num_q_heads, head_dim = q.shape
 
-    kernel = jax.named_scope(scope_name)(
-        pl.pallas_call(
+        bkv_p = num_kv_pages_per_block
+        if static_q_len is not None:
+            bq_sz = min(num_queries_per_block, static_q_len)
+        else:
+            bq_sz = num_queries_per_block
+        bkv_sz_per_kv_packing = bkv_p * page_size_per_kv_packing
+        bkv_buf_sz_per_kv_packing = bkv_sz_per_kv_packing
+
+        grid = (end_seq_idx - start_seq_idx, )
+
+        in_specs = [
+            pl.BlockSpec(memory_space=pltpu.HBM),  # q
+            pl.BlockSpec(memory_space=pltpu.HBM),  # prepared_indexer_weights
+            pl.BlockSpec(memory_space=pltpu.HBM),  # cache_kv
+        ]
+        out_specs = pl.BlockSpec(memory_space=pltpu.HBM)  # out_idxs
+        assert k % 128 == 0
+        topk_shape = (k // 128, 128)
+
+        # Group VMEM layout securely by keeping physical shapes separated!
+        bkv_double_buf = pltpu.VMEM(
+            (
+                2,
+                bkv_buf_sz_per_kv_packing,
+                kv_packing,
+                actual_head_dim,
+            ),
+            cache_kv.dtype,
+        )
+        bq_double_bufq = pltpu.VMEM(
+            (
+                2,
+                bq_sz,
+                num_q_heads,
+                head_dim,
+            ),
+            q.dtype,
+        )
+        bq_weights_double_buf = pltpu.VMEM(
+            (
+                2,
+                bq_sz,
+                num_q_heads,
+            ),
+            prepared_indexer_weights.dtype,
+        )
+        bo_idxs_double_buf = pltpu.VMEM(
+            (
+                2,
+                bq_sz,
+                *topk_shape,
+            ),
+            jnp.int32,
+        )
+
+        scratch_shapes = [
+            bkv_double_buf,
+            bq_double_bufq,
+            bq_weights_double_buf,
+            bo_idxs_double_buf,
+            pltpu.SemaphoreType.DMA((4, 2)),
+            pltpu.VMEM((bq_sz, k), jnp.float32),
+            pltpu.VMEM((bq_sz, k), jnp.int32),
+        ]
+
+        scalar_prefetches = (
+            seq_lens,
+            page_indices,
+            cu_q_lens,
+            jnp.array([start_seq_idx, end_seq_idx], jnp.int32),
+            jnp.zeros((3, ), jnp.int32),
+            jnp.full((4, ), -1, jnp.int32),
+        )
+
+        scope_name = f"StreamIdxTopK-{case.symbol}-bq_{bq_sz}-bkvp_{bkv_p}"
+
+        kernel = jax.named_scope(scope_name)(pl.pallas_call(
             functools.partial(
                 _streamindex_topk_kernel,
                 k=k,
@@ -706,63 +721,61 @@ def streamindex_topk(
                 scratch_shapes=scratch_shapes,
             ),
             compiler_params=pltpu.CompilerParams(
-                dimension_semantics=("arbitrary",),
+                dimension_semantics=("arbitrary", ),
                 vmem_limit_bytes=vmem_limit_bytes,
                 disable_bounds_checks=True,
             ),
-            out_shape=jax.ShapeDtypeStruct(
-                shape=(q.shape[0], *topk_shape), dtype=jnp.int32
-            ),
+            out_shape=jax.ShapeDtypeStruct(shape=(q.shape[0], *topk_shape),
+                                           dtype=jnp.int32),
             name=scope_name,
+        ))
+        return kernel(
+            *scalar_prefetches,
+            q,
+            prepared_indexer_weights,
+            cache_kv,
         )
-    )
-    return kernel(
-        *scalar_prefetches,
+
+    decode_end = jnp.minimum(max_num_seqs, jnp.maximum(0, distribution[0]))
+
+    q_idxs_decode = run_topk_kernel(
         q,
         prepared_indexer_weights,
         cache_kv,
+        seq_lens,
+        page_indices,
+        cu_q_lens,
+        num_kv_pages_per_block=num_kv_pages_per_blocks[0],
+        num_queries_per_block=num_queries_per_blocks[0],
+        start_seq_idx=jnp.array(0),
+        end_seq_idx=distribution[0],
+        static_q_len=1,
+        case=MlaCase.DECODE,
     )
 
-  decode_end = jnp.minimum(max_num_seqs, jnp.maximum(0, distribution[0]))
+    q_idxs_mixed = run_topk_kernel(
+        q,
+        prepared_indexer_weights,
+        cache_kv,
+        seq_lens,
+        page_indices,
+        cu_q_lens,
+        num_kv_pages_per_block=num_kv_pages_per_blocks[2],
+        num_queries_per_block=num_queries_per_blocks[2],
+        start_seq_idx=distribution[1],
+        end_seq_idx=distribution[2],
+        static_q_len=None,
+        case=MlaCase.MIXED,
+    )
 
-  q_idxs_decode = run_topk_kernel(
-      q,
-      prepared_indexer_weights,
-      cache_kv,
-      seq_lens,
-      page_indices,
-      cu_q_lens,
-      num_kv_pages_per_block=num_kv_pages_per_blocks[0],
-      num_queries_per_block=num_queries_per_blocks[0],
-      start_seq_idx=jnp.array(0),
-      end_seq_idx=distribution[0],
-      static_q_len=1,
-      case=MlaCase.DECODE,
-  )
+    decode_tokens_end = cu_q_lens[decode_end]
 
-  q_idxs_mixed = run_topk_kernel(
-      q,
-      prepared_indexer_weights,
-      cache_kv,
-      seq_lens,
-      page_indices,
-      cu_q_lens,
-      num_kv_pages_per_block=num_kv_pages_per_blocks[2],
-      num_queries_per_block=num_queries_per_blocks[2],
-      start_seq_idx=distribution[1],
-      end_seq_idx=distribution[2],
-      static_q_len=None,
-      case=MlaCase.MIXED,
-  )
+    topk_idxs_decode = prepare_outputs(q_idxs_decode)
+    topk_idxs_mixed = prepare_outputs(q_idxs_mixed)
 
-  decode_tokens_end = cu_q_lens[decode_end]
+    token_indices = jnp.arange(topk_idxs_decode.shape[0])[:, None]
+    mask = token_indices < decode_tokens_end
 
-  topk_idxs_decode = prepare_outputs(q_idxs_decode)
-  topk_idxs_mixed = prepare_outputs(q_idxs_mixed)
+    topk_idxs = jnp.where(mask, topk_idxs_decode, topk_idxs_mixed)
 
-  token_indices = jnp.arange(topk_idxs_decode.shape[0])[:, None]
-  mask = token_indices < decode_tokens_end
-
-  topk_idxs = jnp.where(mask, topk_idxs_decode, topk_idxs_mixed)
-
-  return topk_idxs
+    return topk_idxs

--- a/tpu_inference/kernels/experimental/deepseek_v4/streamindex_topk.py
+++ b/tpu_inference/kernels/experimental/deepseek_v4/streamindex_topk.py
@@ -1,0 +1,768 @@
+"""TPU-Friendly StreamIndex Top-K kernel."""
+
+from enum import Enum
+import functools
+import math
+
+import jax
+from jax import lax
+from jax.experimental import pallas as pl
+from jax.experimental.pallas import tpu as pltpu
+import jax.numpy as jnp
+
+DEFAULT_VMEM_LIMIT_BYTES = 100 * 1024 * 1024
+
+
+def cdiv(a, b):
+  assert b != 0
+  return (a + b - 1) // b
+
+
+def align_to(x, a):
+  return cdiv(x, a) * a
+
+
+def get_dtype_bitwidth(dtype):
+  return jax.dtypes.itemsize_bits(dtype)
+
+
+def get_dtype_packing(dtype):
+  bits = get_dtype_bitwidth(dtype)
+  return 32 // bits
+
+
+class MlaCase(Enum):
+  """Represents the different cases for MLA.
+
+  - DECODE: Sequences are in decode-only mode (q_len = 1).
+  - PREFILL: Sequences are in prefill-only mode (q_len > 1, static).
+  - MIXED: Sequences can be a mix of prefill and decode (q_len > 1, dynamic).
+  """
+
+  DECODE = 0
+  PREFILL = 1
+  MIXED = 2
+
+  @property
+  def symbol(self):
+    return {
+        MlaCase.DECODE: "d",
+        MlaCase.PREFILL: "p",
+        MlaCase.MIXED: "m",
+    }[self]
+
+
+def _streamindex_topk_kernel(
+    # Prefetch
+    seq_lens_ref,  # [max_num_seqs]
+    page_indices_ref,  # [max_num_seqs * pages_per_seq]
+    cu_q_lens_ref,  # [max_num_seqs + 1]
+    start_end_seq_idx_ref,  # [2] (start_seq_idx, end_seq_idx)
+    sem_ids_ref,  # [3] (bq_sem_idx, bkv_sem_idx, bo_sem_idx)
+    bo_ids_ref,  # [4] (bo_sem_0_seq_idx, bo_sem_1_seq_idx, bo_sem_0_bo_idx, bo_sem_1_bo_idx)
+    # Input
+    q_hbm_ref,  # [max_num_tokens, num_q_heads, lkv_dim]
+    indexer_weights_hbm_ref,  # [max_num_tokens, num_q_heads]
+    cache_kv_hbm_ref,  # [total_num_pages, page_size_per_kv_packing, kv_packing, lkv_dim]
+    # Output
+    topk_idxs_hbm_ref,  # [max_num_tokens, k]
+    # Scratch
+    bkv_x2_ref,  # [2, bkv_buf_sz_per_kv_packing, kv_packing, lkv_dim]
+    bq_x2_ref,  # [2, bq_sz, num_q_heads, q_packing, lkv_dim]
+    bq_weights_x2_ref,  # [2, bq_sz, num_q_heads]
+    bo_idxs_x2_ref,  # [2, bq_sz, k]
+    sems,  # [4, 2]
+    topk_vals_scratch,  # [bq_sz, k]
+    topk_idxs_scratch,  # [bq_sz, k]
+    *,
+    k: int,
+    compression_ratio: int,
+    static_q_len: int,
+    bkv_p: int,
+    bq_sz: int,
+    actual_num_q_heads: int,
+    actual_head_dim: int,
+    kv_packing: int,
+):
+  _, num_q_heads, q_lkv_dim = q_hbm_ref.shape
+
+  total_num_pages, page_size_per_kv_packing, _, _ = cache_kv_hbm_ref.shape
+
+  max_num_seqs = seq_lens_ref.shape[0]
+  num_page_indices = page_indices_ref.shape[0]
+
+  assert num_page_indices % max_num_seqs == 0
+  pages_per_seq = num_page_indices // max_num_seqs
+  q_dtype = q_hbm_ref.dtype
+  # Validate against the KV dtype.
+  kv_dtype = cache_kv_hbm_ref.dtype
+  assert get_dtype_packing(kv_dtype) == kv_packing
+  assert q_lkv_dim % 128 == 0
+
+  bkv_sz_per_kv_packing = bkv_p * page_size_per_kv_packing
+  bkv_sz = bkv_sz_per_kv_packing * kv_packing
+
+  start_seq_idx = start_end_seq_idx_ref[0]
+  end_seq_idx = start_end_seq_idx_ref[1]
+  seq_idx = pl.program_id(0) + start_seq_idx
+
+  q_start = cu_q_lens_ref[seq_idx]
+  q_end = cu_q_lens_ref[seq_idx + 1]
+  q_len = q_end - q_start
+
+  seq_len = seq_lens_ref[seq_idx]
+  kv_len = seq_len // compression_ratio
+
+  def compute_topk(
+      q,
+      kv,
+      *,
+      bkv_idx,
+      bq_pos_compressed,
+      bq_weights,
+  ):
+    head_vals_ref = topk_vals_scratch.at[:bq_sz]
+    head_idxs_ref = topk_idxs_scratch.at[:bq_sz]
+
+    q_flat = q.reshape(
+        bq_sz * actual_num_q_heads,
+        actual_head_dim,
+    )
+    s = jnp.einsum(
+        "nd,md->nm",
+        q_flat,
+        kv,
+        preferred_element_type=jnp.float32,
+    )
+    s = s.reshape(bq_sz, actual_num_q_heads, s.shape[-1])
+    s = jnp.maximum(s, 0.0)
+    s = s * bq_weights.astype(jnp.float32)[:, :, None]
+    s_summed = s.sum(axis=1)
+
+    k_span = bkv_idx * bkv_sz + lax.broadcasted_iota(
+        jnp.int32, s_summed.shape, 1
+    )
+
+    valid_mask = k_span < kv_len
+    causal_mask = k_span <= bq_pos_compressed[:, None]
+    mask = jnp.logical_and(valid_mask, causal_mask)
+
+    s_summed = jnp.where(mask, s_summed, -jnp.inf)
+
+    prev_vals = head_vals_ref[...]
+    prev_idxs = head_idxs_ref[...]
+
+    k_span_bcast = jnp.broadcast_to(k_span, s_summed.shape)
+    k_span_bcast = jnp.where(mask, k_span_bcast, -1)
+
+    concat_s = jnp.concatenate([prev_vals, s_summed], axis=1)
+    concat_i = jnp.concatenate([prev_idxs, k_span_bcast], axis=1)
+
+    col_indices = lax.broadcasted_iota(jnp.int32, concat_s.shape, 1)
+    s_work = concat_s
+
+    new_vals_list = []
+    new_idxs_list = []
+
+    for _ in range(k):
+      max_val = jnp.max(s_work, axis=1, keepdims=True)
+      is_max = s_work == max_val
+      idx = jnp.min(
+          jnp.where(is_max, col_indices, jnp.iinfo(jnp.int32).max),
+          axis=1,
+          keepdims=True,
+      )
+
+      is_chosen = col_indices == idx
+      orig_idx = jnp.max(
+          jnp.where(is_chosen, concat_i, -1), axis=1, keepdims=True
+      )
+
+      orig_idx = jnp.where(max_val <= -jnp.inf, -1, orig_idx)
+      max_val = jnp.where(max_val <= -jnp.inf, -jnp.inf, max_val)
+
+      new_vals_list.append(max_val)
+      new_idxs_list.append(orig_idx)
+
+      s_work = jnp.where(is_chosen, -jnp.inf, s_work)
+
+    new_vals = jnp.concatenate(new_vals_list, axis=1)
+    new_idxs = jnp.concatenate(new_idxs_list, axis=1)
+
+    head_vals_ref[...] = new_vals
+    head_idxs_ref[...] = new_idxs
+
+  def _async_copy(src, dst, sem, wait):
+    cp = pltpu.make_async_copy(src, dst, sem)
+    if wait:
+      cp.wait()
+    else:
+      cp.start()
+
+  def _fetch_bkv(seq_idx, bkv_idx, bkv_sem_idx, *, wait=False):
+    sem = sems.at[0, bkv_sem_idx]
+    bkv_vmem_ref = bkv_x2_ref.at[bkv_sem_idx]
+
+    reshaped_cache_hbm_ref = cache_kv_hbm_ref.reshape(
+        total_num_pages * page_size_per_kv_packing,
+        kv_packing,
+        actual_head_dim,
+    )
+
+    kv_p_start = bkv_idx * bkv_p
+    page_indices_offset = seq_idx * pages_per_seq + kv_p_start
+
+    if not wait:
+      for i in range(bkv_p):
+        sz_per_kv_packing = page_size_per_kv_packing
+        page_idx = jnp.minimum(page_indices_offset + i, num_page_indices - 1)
+
+        max_hbm_pages = reshaped_cache_hbm_ref.shape[0]
+        safe_page_offset = jnp.minimum(
+            page_indices_ref[page_idx] * page_size_per_kv_packing,
+            jnp.maximum(0, max_hbm_pages - page_size_per_kv_packing),
+        )
+
+        _async_copy(
+            reshaped_cache_hbm_ref.at[
+                pl.ds(safe_page_offset, sz_per_kv_packing)
+            ],
+            bkv_vmem_ref.at[
+                pl.ds(i * page_size_per_kv_packing, sz_per_kv_packing)
+            ],
+            sem,
+            wait=False,
+        )
+    else:
+      dma_bkv_sz = bkv_p * page_size_per_kv_packing
+      dst_kv = bkv_vmem_ref.at[pl.ds(0, dma_bkv_sz)]
+      _async_copy(src=dst_kv, dst=dst_kv, sem=sem, wait=True)
+
+  def _fetch_bq(seq_idx, bq_idx, bq_sem_idx, *, wait=False):
+    sem = sems.at[1, bq_sem_idx]
+    weights_sem = sems.at[3, bq_sem_idx]
+    bq_vmem_ref = bq_x2_ref.at[bq_sem_idx]
+    bq_weights_vmem_ref = bq_weights_x2_ref.at[bq_sem_idx]
+
+    q_len_start = cu_q_lens_ref[seq_idx] + bq_idx * bq_sz
+    curr_q_end = cu_q_lens_ref[seq_idx + 1]
+
+    sz = jnp.maximum(0, jnp.minimum(bq_sz, curr_q_end - q_len_start))
+    safe_q_start = jnp.minimum(
+        q_len_start, jnp.maximum(0, q_hbm_ref.shape[0] - jnp.maximum(1, sz))
+    )
+
+    if not wait:
+      _async_copy(
+          q_hbm_ref.at[pl.ds(safe_q_start, sz)],
+          bq_vmem_ref.at[pl.ds(0, sz)],
+          sem,
+          wait=False,
+      )
+      _async_copy(
+          indexer_weights_hbm_ref.at[pl.ds(safe_q_start, sz)],
+          bq_weights_vmem_ref.at[pl.ds(0, sz)],
+          weights_sem,
+          wait=False,
+      )
+    else:
+      dst = bq_vmem_ref.at[pl.ds(0, sz)]
+      _async_copy(dst, dst, sem, wait=True)
+      dst_w = bq_weights_vmem_ref.at[pl.ds(0, sz)]
+      _async_copy(dst_w, dst_w, weights_sem, wait=True)
+
+  def _send_bo(seq_idx, bo_idx, bo_sem_idx, *, wait=False):
+    sem_idxs = sems.at[2, bo_sem_idx]
+
+    q_len_start = cu_q_lens_ref[seq_idx] + bo_idx * bq_sz
+    curr_q_end = cu_q_lens_ref[seq_idx + 1]
+
+    sz = jnp.maximum(0, jnp.minimum(bq_sz, curr_q_end - q_len_start))
+    safe_q_start = jnp.minimum(
+        q_len_start,
+        jnp.maximum(0, topk_idxs_hbm_ref.shape[0] - jnp.maximum(1, sz)),
+    )
+
+    if not wait:
+      _async_copy(
+          bo_idxs_x2_ref.at[bo_sem_idx, pl.ds(0, sz)],
+          topk_idxs_hbm_ref.at[pl.ds(safe_q_start, sz)],
+          sem_idxs,
+          wait=False,
+      )
+    else:
+      dst_i = bo_idxs_x2_ref.at[bo_sem_idx, pl.ds(0, sz)]
+      _async_copy(dst_i, dst_i, sem_idxs, wait=True)
+
+  def start_fetch_bkv(seq_idx, bkv_idx, bkv_sem_idx):
+    _fetch_bkv(seq_idx, bkv_idx, bkv_sem_idx)
+
+  def wait_fetch_bkv(seq_idx, bkv_idx, bkv_sem_idx):
+    _fetch_bkv(seq_idx, bkv_idx, bkv_sem_idx, wait=True)
+
+  def start_fetch_bq(seq_idx, bq_idx, bq_sem_idx):
+    return _fetch_bq(seq_idx, bq_idx, bq_sem_idx)
+
+  def wait_fetch_bq(seq_idx, bq_idx, bq_sem_idx):
+    return _fetch_bq(seq_idx, bq_idx, bq_sem_idx, wait=True)
+
+  def start_send_bo(seq_idx, bo_idx, bo_sem_idx):
+    bo_ids_ref[bo_sem_idx] = seq_idx
+    bo_ids_ref[bo_sem_idx + 2] = bo_idx
+    _send_bo(seq_idx, bo_idx, bo_sem_idx)
+
+  def wait_send_bo(bo_sem_idx):
+    old_seq_idx = bo_ids_ref[bo_sem_idx]
+    old_bo_idx = bo_ids_ref[bo_sem_idx + 2]
+
+    @pl.when(jnp.logical_and(0 <= old_seq_idx, old_seq_idx <= seq_idx))
+    def _():
+      _send_bo(old_seq_idx, old_bo_idx, bo_sem_idx, wait=True)
+
+  def load_bq(bq_sem_idx):
+    q = bq_x2_ref.at[bq_sem_idx, :bq_sz][...]
+    q = q.reshape(bq_sz, num_q_heads, q_lkv_dim)
+    return q[:, :actual_num_q_heads, :actual_head_dim]
+
+  def load_bq_weights(bq_sem_idx):
+    w = bq_weights_x2_ref.at[bq_sem_idx, :bq_sz][...]
+    return w[:, :actual_num_q_heads]
+
+  def load_bkv(bkv_sem_idx):
+    bkv = bkv_x2_ref.at[bkv_sem_idx, :bkv_sz_per_kv_packing][...]
+    # TODO(hwanginho): Handle DSv4 FP8 index cache format.
+    # If `bkv` is in FP8, we need to upcast it to f32/bf16 and multiply it
+    # by the corresponding scale factors.
+    return bkv.reshape(bkv_sz, actual_head_dim)
+
+  # --- KERNEL PROCESS LOOP ---
+
+  def process():
+    num_bkv = jnp.maximum(1, cdiv(kv_len, bkv_sz))
+    if static_q_len is None:
+      num_bq = jnp.maximum(1, cdiv(q_len, bq_sz))
+    else:
+      num_bq = jnp.maximum(1, cdiv(static_q_len, bq_sz))
+
+    def get_next_bq_ids(seq_idx, bq_idx, bq_sem_idx):
+      next_bq_idx = bq_idx + 1
+      is_last_bq = next_bq_idx == num_bq
+      next_bq_idx = lax.select(is_last_bq, 0, next_bq_idx)
+      next_seq_idx = lax.select(is_last_bq, seq_idx + 1, seq_idx)
+      next_bq_sem_idx = lax.select(bq_sem_idx == 0, 1, 0)
+      return next_seq_idx, next_bq_idx, next_bq_sem_idx
+
+    def get_next_bkv_ids(seq_idx, bq_idx, bkv_idx, bkv_sem_idx):
+      next_bkv_idx = bkv_idx + 1
+      is_last_bkv = next_bkv_idx == num_bkv
+      next_bkv_idx = lax.select(is_last_bkv, 0, next_bkv_idx)
+      next_bq_idx = lax.select(is_last_bkv, bq_idx + 1, bq_idx)
+      is_last_bq = next_bq_idx == num_bq
+      next_bq_idx = lax.select(is_last_bq, 0, next_bq_idx)
+      next_seq_idx = lax.select(is_last_bq, seq_idx + 1, seq_idx)
+      next_bkv_sem_idx = lax.select(bkv_sem_idx == 0, 1, 0)
+      return next_seq_idx, next_bq_idx, next_bkv_idx, next_bkv_sem_idx
+
+    def compute_with_bq(bq_idx, _):
+      bq_sem_idx = sem_ids_ref[0]
+      next_seq_idx, next_bq_idx, next_bq_sem_idx = get_next_bq_ids(
+          seq_idx, bq_idx, bq_sem_idx
+      )
+
+      # Prefetch next bq
+      @pl.when(next_seq_idx < end_seq_idx)
+      def prefetch_next_bq():
+        sem_ids_ref[0] = next_bq_sem_idx
+        start_fetch_bq(next_seq_idx, next_bq_idx, next_bq_sem_idx)
+
+      # Initialize scratch space for top-K values and indices.
+      # TODO(hwanginho): Use b16 or fp8 format for top-K values scratch if
+      # possible.
+      topk_vals_scratch[...] = jnp.full((bq_sz, k), -jnp.inf, dtype=jnp.float32)
+      topk_idxs_scratch[...] = jnp.full((bq_sz, k), -1, dtype=jnp.int32)
+
+      q_pos = (
+          seq_len - q_len + bq_idx * bq_sz + jnp.arange(bq_sz, dtype=jnp.int32)
+      )
+      bq_pos_compressed = q_pos // compression_ratio
+
+      def compute_with_bkv(bkv_idx, _):
+        bkv_sem_idx = sem_ids_ref[1]
+        next_seq_idx, _, next_bkv_idx, next_bkv_sem_idx = get_next_bkv_ids(
+            seq_idx, bq_idx, bkv_idx, bkv_sem_idx
+        )
+
+        # Prefetch next bkv
+        @pl.when(next_seq_idx < end_seq_idx)
+        def prefetch_next_bkv():
+          sem_ids_ref[1] = next_bkv_sem_idx
+          start_fetch_bkv(next_seq_idx, next_bkv_idx, next_bkv_sem_idx)
+
+        # Wait for cur bq if not ready yet
+        @pl.when(bkv_idx == 0)
+        def wait_cur_bq():
+          wait_fetch_bq(seq_idx, bq_idx, bq_sem_idx)
+
+        # Wait for cur bkv
+        wait_fetch_bkv(seq_idx, bkv_idx, bkv_sem_idx)
+
+        bkv = load_bkv(bkv_sem_idx)
+        bq = load_bq(bq_sem_idx)
+        bq_weights = load_bq_weights(bq_sem_idx)
+
+        compute_topk(
+            bq,
+            bkv,
+            bkv_idx=bkv_idx,
+            bq_pos_compressed=bq_pos_compressed,
+            bq_weights=bq_weights,
+        )
+
+      lax.fori_loop(0, num_bkv, compute_with_bkv, None, unroll=False)
+
+      out_idxs = topk_idxs_scratch[...]
+
+      bo_sem_idx = sem_ids_ref[2]
+      sem_ids_ref[2] = lax.select(bo_sem_idx == 0, jnp.int32(1), jnp.int32(0))
+
+      wait_send_bo(bo_sem_idx)
+
+      bo_idxs_x2_ref[bo_sem_idx, ...] = out_idxs.reshape(
+          bo_idxs_x2_ref[bo_sem_idx].shape
+      )
+
+      start_send_bo(seq_idx, bq_idx, bo_sem_idx)
+
+    lax.fori_loop(0, num_bq, compute_with_bq, None, unroll=False)
+
+  ### ------- Kernel start ------- ###
+
+  @pl.when(seq_idx == start_seq_idx)
+  def prologue():
+    start_fetch_bq(start_seq_idx, 0, 0)
+
+    # Initialize bkv_x2_ref to zeros to avoid NaN issues from accessing
+    # uninitialized memory. Bitcast into int32 to avoid tiling issues.
+    bkv_x2_int32_ref = bkv_x2_ref.bitcast(jnp.int32).reshape(
+        (2, -1, actual_head_dim)
+    )
+    bkv_zeros = jnp.zeros(bkv_x2_int32_ref.shape[1:], jnp.int32)
+
+    # To pipeline VST and DMA, we divide the initialization into two steps.
+    bkv_x2_int32_ref[0] = bkv_zeros
+    start_fetch_bkv(start_seq_idx, 0, 0)
+    bkv_x2_int32_ref[1] = bkv_zeros
+
+  process()
+
+  @pl.when(seq_idx == end_seq_idx - 1)
+  def epilogue():
+    for i in range(2):
+      wait_send_bo(i)
+
+  ### ------- Kernel end ------- ###
+
+
+def prepare_q_inputs(
+    q: jax.Array,  # [max_num_tokens, actual_num_q_heads, actual_head_dim],
+):
+  _, actual_num_q_heads, actual_head_dim = q.shape
+  q_packing = get_dtype_packing(q.dtype)
+  num_q_heads = align_to(actual_num_q_heads, q_packing)
+  head_dim = align_to(actual_head_dim, 128)
+  q = jnp.pad(
+      q,
+      (
+          (0, 0),
+          (0, num_q_heads - actual_num_q_heads),
+          (0, head_dim - actual_head_dim),
+      ),
+      constant_values=0,
+  )
+  return q
+
+
+def prepare_index_weights(
+    index_weights: jax.Array,  # [max_num_tokens, actual_num_q_heads],
+    q_dtype,
+):
+  _, actual_num_q_heads = index_weights.shape
+  index_weights = index_weights.astype(jnp.float32)
+  num_q_heads = align_to(actual_num_q_heads, get_dtype_packing(q_dtype))
+  index_weights = jnp.pad(
+      index_weights,
+      (
+          (0, 0),
+          (0, num_q_heads - actual_num_q_heads),
+      ),
+      constant_values=0,
+  )
+  return index_weights
+
+
+def prepare_outputs(out):
+  if out.ndim == 3:
+    out = out.reshape(out.shape[0], -1)
+  return out
+
+
+@functools.partial(
+    jax.jit,
+    static_argnames=(
+        "k",
+        "compression_ratio",
+        "num_kv_pages_per_block",
+        "num_queries_per_block",
+        "vmem_limit_bytes",
+    ),
+)
+def streamindex_topk(
+    q: jax.Array,  # [max_num_tokens, actual_num_q_heads, actual_head_dim]
+    indexer_weights: jax.Array,  # [max_num_tokens, actual_num_q_heads]
+    cache_kv: jax.Array,  # [total_num_pages, page_size_per_kv_packing, kv_packing, head_dim]
+    seq_lens: jax.Array,  # i32[max_num_seqs]
+    page_indices: jax.Array,  # i32[max_num_seqs * pages_per_seq]
+    cu_q_lens: jax.Array,  # i32[max_num_seqs + 1]
+    distribution: jax.Array,  # i32[3]
+    *,
+    k: int,
+    compression_ratio: int,
+    num_kv_pages_per_block: tuple[int, int, int] | int | None = None,
+    num_queries_per_block: tuple[int, int, int] | int | None = None,
+    vmem_limit_bytes: int = DEFAULT_VMEM_LIMIT_BYTES,
+) -> jax.Array:
+  """StreamIndex Top-K retrieval.
+
+  Args:
+    q: concatenated all sequences' queries.
+    indexer_weights: concatenated all sequences' indexer weights.
+    cache_kv: the current kv cache.
+    seq_lens: the length of each sequence in the kv cache (uncompressed).
+    page_indices: flattened page indices look-up table by (seq_id, page_id).
+    cu_q_lens: the cumulative sum of the effective query lengths. Similar to
+      kv_lens, only the first num_seqs+1 values are valid.
+    distribution: (i, j, k) represents that sequences[0:i] are decode-only,
+      sequences[i:j] are chunked-prefill-only, and sequences[j:k] are mixed. The
+      k is also the total number of sequences.
+    k: Number of top-K elements to retrieve.
+    compression_ratio: KV cache compression ratio.
+    num_kv_pages_per_block: number of kv pages to be processed in one block in
+      the pallas kernel. This is a tuple of (decode, prefill, mixed) cases.
+    num_queries_per_block: number of queries to be processed in one block in the
+      pallas kernel. This is a tuple of (decode, prefill, mixed) cases.
+    vmem_limit_bytes: the vmem limit for the pallas kernel.
+
+  Returns:
+    Top-K indices (in compressed space).
+  """
+  # TODO(hwanginho): Support DSv4 FP8 index cache format.
+  # This will require scale factors, handling FP8
+  # dtypes, and dequantizing inside the Pallas kernel before the einsum. Need
+  # to align with alynie@ on
+  # https://github.com/vllm-project/tpu-inference/pull/2858, whether the
+  # scales is a separate jax.Array, or packed into the same jax.Array as
+  # `cache_kv`.
+
+  if num_kv_pages_per_block is None or num_queries_per_block is None:
+    raise ValueError(
+        "num_kv_pages_per_block and num_queries_per_block must be specified."
+    )
+
+  if isinstance(num_kv_pages_per_block, int):
+    num_kv_pages_per_blocks = [num_kv_pages_per_block for _ in range(3)]
+  else:
+    num_kv_pages_per_blocks = num_kv_pages_per_block
+
+  if isinstance(num_queries_per_block, int):
+    num_queries_per_blocks = [num_queries_per_block for _ in range(3)]
+  else:
+    num_queries_per_blocks = num_queries_per_block
+
+  max_num_seqs = seq_lens.shape[0]
+
+  original_dtype = q.dtype
+
+  prepared_indexer_weights = prepare_index_weights(
+      indexer_weights.astype(original_dtype), original_dtype
+  )
+
+  actual_num_q_heads = q.shape[1]
+  q = prepare_q_inputs(q)
+  actual_head_dim = cache_kv.shape[-1]
+
+  def run_topk_kernel(
+      q,
+      prepared_indexer_weights,
+      cache_kv,
+      seq_lens,
+      page_indices,
+      cu_q_lens,
+      start_seq_idx,
+      end_seq_idx,
+      static_q_len,
+      num_kv_pages_per_block,
+      num_queries_per_block,
+      case=MlaCase.MIXED,
+  ):
+    # Dynamically extract parameters for the DMA mapping from the RAW tensor
+    _, page_size_per_kv_packing, kv_packing, _ = cache_kv.shape
+
+    _, num_q_heads, q_lkv_dim = q.shape
+
+    bkv_p = num_kv_pages_per_block
+    if static_q_len is not None:
+      bq_sz = min(num_queries_per_block, static_q_len)
+    else:
+      bq_sz = num_queries_per_block
+    bkv_sz_per_kv_packing = bkv_p * page_size_per_kv_packing
+    bkv_buf_sz_per_kv_packing = bkv_sz_per_kv_packing
+
+    grid = (end_seq_idx - start_seq_idx,)
+
+    in_specs = [
+        pl.BlockSpec(memory_space=pltpu.HBM),  # q
+        pl.BlockSpec(memory_space=pltpu.HBM),  # prepared_indexer_weights
+        pl.BlockSpec(memory_space=pltpu.HBM),  # cache_kv
+    ]
+    out_specs = pl.BlockSpec(memory_space=pltpu.HBM)  # out_idxs
+    assert k % 128 == 0
+    topk_shape = (k // 128, 128)
+
+    # Group VMEM layout securely by keeping physical shapes separated!
+    bkv_double_buf = pltpu.VMEM(
+        (
+            2,
+            bkv_buf_sz_per_kv_packing,
+            kv_packing,
+            actual_head_dim,
+        ),
+        cache_kv.dtype,
+    )
+    bq_double_bufq = pltpu.VMEM(
+        (
+            2,
+            bq_sz,
+            num_q_heads,
+            q_lkv_dim,
+        ),
+        q.dtype,
+    )
+    bq_weights_double_buf = pltpu.VMEM(
+        (
+            2,
+            bq_sz,
+            num_q_heads,
+        ),
+        prepared_indexer_weights.dtype,
+    )
+    bo_idxs_double_buf = pltpu.VMEM(
+        (
+            2,
+            bq_sz,
+            *topk_shape,
+        ),
+        jnp.int32,
+    )
+
+    scratch_shapes = [
+        bkv_double_buf,
+        bq_double_bufq,
+        bq_weights_double_buf,
+        bo_idxs_double_buf,
+        pltpu.SemaphoreType.DMA((4, 2)),
+        pltpu.VMEM((bq_sz, k), jnp.float32),
+        pltpu.VMEM((bq_sz, k), jnp.int32),
+    ]
+
+    scalar_prefetches = (
+        seq_lens,
+        page_indices,
+        cu_q_lens,
+        jnp.array([start_seq_idx, end_seq_idx], jnp.int32),
+        jnp.zeros((3,), jnp.int32),
+        jnp.full((4,), -1, jnp.int32),
+    )
+
+    scope_name = f"StreamIdxTopK-{case.symbol}-bq_{bq_sz}-bkvp_{bkv_p}"
+
+    kernel = jax.named_scope(scope_name)(
+        pl.pallas_call(
+            functools.partial(
+                _streamindex_topk_kernel,
+                k=k,
+                compression_ratio=compression_ratio,
+                static_q_len=static_q_len,
+                bq_sz=bq_sz,
+                bkv_p=bkv_p,
+                actual_num_q_heads=actual_num_q_heads,
+                actual_head_dim=actual_head_dim,
+                kv_packing=kv_packing,
+            ),
+            grid_spec=pltpu.PrefetchScalarGridSpec(
+                num_scalar_prefetch=len(scalar_prefetches),
+                in_specs=in_specs,
+                out_specs=out_specs,
+                grid=grid,
+                scratch_shapes=scratch_shapes,
+            ),
+            compiler_params=pltpu.CompilerParams(
+                dimension_semantics=("arbitrary",),
+                vmem_limit_bytes=vmem_limit_bytes,
+                disable_bounds_checks=True,
+            ),
+            out_shape=jax.ShapeDtypeStruct(
+                shape=(q.shape[0], *topk_shape), dtype=jnp.int32
+            ),
+            name=scope_name,
+        )
+    )
+    return kernel(
+        *scalar_prefetches,
+        q,
+        prepared_indexer_weights,
+        cache_kv,
+    )
+
+  decode_end = jnp.minimum(max_num_seqs, jnp.maximum(0, distribution[0]))
+
+  q_idxs_decode = run_topk_kernel(
+      q,
+      prepared_indexer_weights,
+      cache_kv,
+      seq_lens,
+      page_indices,
+      cu_q_lens,
+      num_kv_pages_per_block=num_kv_pages_per_blocks[0],
+      num_queries_per_block=num_queries_per_blocks[0],
+      start_seq_idx=jnp.array(0),
+      end_seq_idx=distribution[0],
+      static_q_len=1,
+      case=MlaCase.DECODE,
+  )
+
+  q_idxs_mixed = run_topk_kernel(
+      q,
+      prepared_indexer_weights,
+      cache_kv,
+      seq_lens,
+      page_indices,
+      cu_q_lens,
+      num_kv_pages_per_block=num_kv_pages_per_blocks[2],
+      num_queries_per_block=num_queries_per_blocks[2],
+      start_seq_idx=distribution[1],
+      end_seq_idx=distribution[2],
+      static_q_len=None,
+      case=MlaCase.MIXED,
+  )
+
+  decode_tokens_end = cu_q_lens[decode_end]
+
+  topk_idxs_decode = prepare_outputs(q_idxs_decode)
+  topk_idxs_mixed = prepare_outputs(q_idxs_mixed)
+
+  token_indices = jnp.arange(topk_idxs_decode.shape[0])[:, None]
+  mask = token_indices < decode_tokens_end
+
+  topk_idxs = jnp.where(mask, topk_idxs_decode, topk_idxs_mixed)
+
+  return topk_idxs

--- a/tpu_inference/kernels/experimental/deepseek_v4/streamindex_topk.py
+++ b/tpu_inference/kernels/experimental/deepseek_v4/streamindex_topk.py
@@ -347,11 +347,28 @@ def _streamindex_topk_kernel(
         # Quantized FP8 index cache path: unpack keys and scale factors locally.
         flat_bkv = bkv.reshape(-1, bkv.shape[-1])
         fp8_val = flat_bkv[:, :head_dim]
-        fp8_val = jax.lax.bitcast_convert_type(fp8_val, jnp.float8_e4m3fn)
+        fp8_val = pltpu.bitcast(fp8_val, jnp.float8_e4m3fn)
 
         scale_val = flat_bkv[:, head_dim:head_dim + 1]
-        scale_val = jax.lax.bitcast_convert_type(
-            scale_val, jnp.float8_e8m0fnu).astype(jnp.float32)
+
+        # Force exact unsigned extraction to bypass negative int8 overflow.
+        scale_val_u32 = scale_val.astype(jnp.int32) & 0xFF
+
+        # Map standard values (1 to 254) using exact bitshifting.
+        scale_val_shifted = scale_val_u32 << 23
+
+        # Handle the 0 byte edge case: f8E8M0FNU spec maps 0 to 2^-127
+        # The exact IEEE-754 float32 bits for the subnormal 2^-127 is 0x00400000.
+        scale_val_shifted = jnp.where(scale_val_u32 == 0,
+                                      jnp.int32(0x00400000), scale_val_shifted)
+
+        # Handle the 255 byte edge case: f8E8M0FNU spec maps 255 to NaN
+        # The standard float32 bits for NaN is 0x7FC00000.
+        scale_val_shifted = jnp.where(scale_val_u32 == 255,
+                                      jnp.int32(0x7FC00000), scale_val_shifted)
+
+        # Bitcast the strictly reconstructed bits directly to float32
+        scale_val = pltpu.bitcast(scale_val_shifted, jnp.float32)
 
         # NOTE: Do NOT multiply the scales here. Return them separately.
         return fp8_val.reshape(bkv_sz, head_dim), scale_val.reshape(bkv_sz, 1)

--- a/tpu_inference/layers/vllm/custom_ops/experimental/__init__.py
+++ b/tpu_inference/layers/vllm/custom_ops/experimental/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tpu_inference/layers/vllm/custom_ops/experimental/deepseek_v4/__init__.py
+++ b/tpu_inference/layers/vllm/custom_ops/experimental/deepseek_v4/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tpu_inference/layers/vllm/custom_ops/experimental/deepseek_v4/deepseek_v4_indexer.py
+++ b/tpu_inference/layers/vllm/custom_ops/experimental/deepseek_v4/deepseek_v4_indexer.py
@@ -1,0 +1,180 @@
+# pytype: skip-file
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""TPU-compatible DeepSeek-V4 Lightning Indexer."""
+
+from typing import Optional, Tuple
+
+import jax.numpy as jnp
+import torch
+import torch.nn as nn
+from torchax.interop import jax_view, torch_view
+from vllm.forward_context import get_forward_context
+from vllm.models.deepseek_v4.attention import DeepseekV4Indexer
+
+# =====================================================================
+# IMPORT TPU CUSTOM OPS TO TRIGGER vLLM @register_oot DECORATORS
+# =====================================================================
+from tpu_inference.kernels.experimental.deepseek_v4.compressor import \
+    compressor_forward_indexer
+from tpu_inference.kernels.experimental.deepseek_v4.streamindex_topk import \
+    streamindex_topk
+from tpu_inference.layers.common import quantization
+
+
+def fused_indexer_q_rope_quant(
+    q: torch.Tensor,
+    positions: torch.Tensor,
+    rotary_emb: torch.nn.Module,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Applies RoPE and dynamically quantizes the queries
+
+  Args:
+      q: Un-rotated query tensor of shape [num_tokens, num_heads, head_dim]
+      positions: Token positions of shape [num_tokens]
+      rotary_emb: The vLLM RoPE CustomOp module (Intercepted by TPU rope.py)
+
+  Returns:
+      q_quant: Int8 quantized, RoPE-applied queries
+      q_scales: Quantization scales
+  """
+
+    # Apply the custom rotary embedding op directly in-place on the query tensor.
+    q, _ = rotary_emb(positions, q)
+
+    # Bridge to JAX, call JAX quantize_tensor, and bridge back to PyTorch
+    q_jax = jax_view(q)
+    q_quant_jax, q_scales_jax = quantization.quantize_tensor(
+        q_jax, jnp.float8_e4m3fn)
+    q_quant = torch_view(q_quant_jax)
+    q_scales = torch_view(q_scales_jax)
+
+    # Note: vLLM's implementation rounds the scale factors up to the
+    # next power of 2, but the standard division scale returned by quantize_tensor
+    # is sufficient here.
+    return q_quant, q_scales.squeeze(-1)
+
+
+class VllmDeepseekV4Indexer(DeepseekV4Indexer):
+    """TPU-compatible DeepSeek-V4 Lightning Indexer with StreamIndex.
+
+  This class overrides the forward method of DeepseekV4Indexer to provide a
+  TPU-compatible implementation using JAX interop. It uses
+  `streamindex_topk` to compute top-k token indices over a
+  PagedAttention KV cache.
+  """
+
+    # pylint: disable=unused-argument
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        query: torch.Tensor,
+        compressed_kv_score: torch.Tensor,
+        indexer_weights: torch.Tensor,
+        positions: torch.Tensor,
+        rotary_emb: nn.Module,
+        slot_mapping: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+
+        actual_num_tokens = hidden_states.shape[0]
+
+        q, _ = self.wq_b(query)
+        q = q.view(-1, self.n_head, self.head_dim)
+
+        q_quant, q_scales = fused_indexer_q_rope_quant(q, positions,
+                                                       rotary_emb)
+
+        # Fold the query quantization scales into the weights
+        weights = (indexer_weights.to(q.dtype) * self.softmax_scale *
+                   (self.head_dim**-0.5) * q_scales)
+
+        attn_metadata_dict = get_forward_context().attn_metadata
+        attn_metadata = attn_metadata_dict[self.k_cache.prefix]
+
+        # ---------------------------------------------------------
+        # 1. EXECUTE COMPRESSOR & SCATTER TO KV CACHE
+        # ---------------------------------------------------------
+        # Project, norm, rope, and store states using the indexer's compressor.
+        wkv_wgate = torch.cat([self.kv_proj.weight, self.gate_proj.weight],
+                              dim=0)
+
+        # Compute request index mapping for each token in the batch.
+        token_to_req_indices = (
+            torch.bucketize(
+                torch.arange(actual_num_tokens, device=hidden_states.device),
+                attn_metadata.cu_seq_lens,  # pytype: disable=attribute-error
+                right=True,
+            ) - 1).to(torch.int32)
+
+        current_slot_mapping = (
+            slot_mapping if slot_mapping is not None else
+            attn_metadata.slot_mapping.flatten()  # pytype: disable=attribute-error
+        ).to(torch.int32)
+        # Key slots in compressed KV space (downsampled by compress_ratio).
+        kv_slot_mapping = (current_slot_mapping[:actual_num_tokens] //
+                           self.compress_ratio).to(torch.int32)
+
+        # Pack the state cache and write back to self.k_cache.kv_cache.
+        updated_cache_jax = compressor_forward_indexer(
+            hidden_states=jax_view(hidden_states),
+            wkv_wgate=jax_view(wkv_wgate),
+            ape=jax_view(self.position_bias),
+            norm_weight=jax_view(self.kv_norm.weight),
+            cos_sin_cache=jax_view(self.rotary_emb.cos_sin_cache),
+            positions=jax_view(positions),
+            slot_mapping=jax_view(current_slot_mapping[:actual_num_tokens]),
+            block_table=jax_view(attn_metadata.block_table),  # pytype: disable=attribute-error
+            token_to_req_indices=jax_view(token_to_req_indices),
+            kv_slot_mapping=jax_view(kv_slot_mapping),
+            cache=jax_view(self.k_cache.kv_cache),
+            state_block_size=self.k_cache.block_size,
+            head_dim=self.head_dim,
+            rope_head_dim=getattr(self.rotary_emb, "rotary_dim", 64),
+            compress_ratio=self.compress_ratio,
+            overlap=True,  # Overlap is True for CSA path.
+            rms_eps=self.kv_norm.eps,
+            quant_block=128,  # Indexer path FP8 block size is 128.
+        )
+
+        # Write back in-place to the cache tensor before read-after-write logic.
+        self.k_cache.kv_cache.copy_(torch_view(updated_cache_jax))
+
+        # ---------------------------------------------------------
+        # 2. EXTRACT KV CACHE FOR JAX KERNEL
+        # ---------------------------------------------------------
+        kv_cache_tensor = self.k_cache.kv_cache
+        # Scale factors are packed straight into kv_cache.
+
+        # ---------------------------------------------------------
+        # 3. DIRECT JAX KERNEL CALL
+        # ---------------------------------------------------------
+        bt_slice = attn_metadata.block_table  # pytype: disable=attribute-error
+        sl_slice = attn_metadata.seq_lens  # pytype: disable=attribute-error
+        csl_slice = attn_metadata.cu_seq_lens  # pytype: disable=attribute-error
+
+        topk_indices = streamindex_topk(
+            query_projection=q_quant[:actual_num_tokens],
+            kv_cache=kv_cache_tensor,
+            page_indices=bt_slice,
+            seq_lens=sl_slice,
+            cu_q_lens=csl_slice,
+            indexer_weights=weights,
+            k=self.topk_tokens,
+            compression_ratio=self.compress_ratio,
+            # TODO(hwanginho): Tune these block configurations later for performance
+            num_kv_pages_per_block=1,
+            num_queries_per_block=1,
+        )
+
+        return topk_indices

--- a/tpu_inference/layers/vllm/custom_ops/experimental/deepseek_v4/deepseek_v4_indexer.py
+++ b/tpu_inference/layers/vllm/custom_ops/experimental/deepseek_v4/deepseek_v4_indexer.py
@@ -1,0 +1,168 @@
+# pytype: skip-file
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""TPU-compatible DeepSeek-V4 Lightning Indexer."""
+
+from typing import Optional, Tuple
+
+import jax.numpy as jnp
+import torch
+import torch.nn as nn
+from torchax.interop import jax_view
+from torchax.interop import torch_view
+from tpu_inference.kernels.experimental.deepseek_v4.streamindex_topk import streamindex_topk
+from tpu_inference.layers.common import quantization
+
+# =====================================================================
+# IMPORT TPU CUSTOM OPS TO TRIGGER vLLM @register_oot DECORATORS
+# =====================================================================
+import tpu_inference.layers.vllm.custom_ops.rope
+from vllm.forward_context import get_forward_context
+from vllm.models.deepseek_v4.attention import DeepseekV4Indexer
+
+
+def fused_indexer_q_rope_quant(
+    q: torch.Tensor,
+    positions: torch.Tensor,
+    rotary_emb: torch.nn.Module,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+  """Applies RoPE and dynamically quantizes the queries
+
+  Args:
+      q: Un-rotated query tensor of shape [num_tokens, num_heads, head_dim]
+      positions: Token positions of shape [num_tokens]
+      rotary_emb: The vLLM RoPE CustomOp module (Intercepted by TPU rope.py)
+
+  Returns:
+      q_quant: Int8 quantized, RoPE-applied queries
+      q_scales: Quantization scales
+  """
+
+  # Apply the custom rotary embedding op directly in-place on the query tensor.
+  q, _ = rotary_emb(positions, q)
+
+  # Bridge to JAX, call JAX quantize_tensor, and bridge back to PyTorch
+  q_jax = jax_view(q)
+  q_quant_jax, q_scales_jax = quantization.quantize_tensor(
+      q_jax, jnp.float8_e4m3fn
+  )
+  q_quant = torch_view(q_quant_jax)
+  q_scales = torch_view(q_scales_jax)
+
+  # Note: vLLM's implementation rounds the scale factors up to the
+  # next power of 2, but the standard division scale returned by quantize_tensor
+  # is sufficient here.
+  return q_quant, q_scales.squeeze(-1)
+
+
+class VllmDeepseekV4Indexer(DeepseekV4Indexer):
+  """TPU-compatible DeepSeek-V4 Lightning Indexer with StreamIndex.
+
+  This class overrides the forward method of DeepseekV4Indexer to provide a
+  TPU-compatible implementation using JAX interop. It uses
+  `streamindex_topk` to compute top-k token indices over a
+  PagedAttention KV cache.
+  """
+
+  def __init__(self, *args, **kwargs):
+    super().__init__(*args, **kwargs)
+
+    # TODO(hwanginho): Attach TPU-native compressor here when needed.
+    self.compressor = getattr(self, "compressor", None)  # Placeholder
+
+  # pylint: disable=unused-argument
+  def forward(
+      self,
+      hidden_states: torch.Tensor,
+      query: torch.Tensor,
+      compressed_kv_score: torch.Tensor,
+      indexer_weights: torch.Tensor,
+      positions: torch.Tensor,
+      rotary_emb: nn.Module,
+      slot_mapping: Optional[torch.Tensor] = None,
+  ) -> torch.Tensor:
+
+    actual_num_tokens = hidden_states.shape[0]
+
+    q, _ = self.wq_b(query)
+    q = q.view(-1, self.n_head, self.head_dim)
+
+    q_quant, q_scales = fused_indexer_q_rope_quant(q, positions, rotary_emb)
+
+    # Fold the query quantization scales into the weights
+    weights = (
+        indexer_weights.to(q.dtype)
+        * self.softmax_scale
+        * (self.head_dim**-0.5)
+        * q_scales
+    )
+
+    attn_metadata_dict = get_forward_context().attn_metadata
+    attn_metadata = attn_metadata_dict[self.k_cache.prefix]
+
+    # ---------------------------------------------------------
+    # 1. EXECUTE COMPRESSOR & SCATTER TO KV CACHE
+    # ---------------------------------------------------------
+    # TODO(hwanginho): Execute the TPU-Native Compressor to compute the current
+    # token's keys, and write a native TPU scatter kernel to save those keys
+    # into `self.k_cache.kv_cache`.
+    # (Note: MUST happen before jax_view to guarantee XLA read-after-write ordering!)
+
+    # if self.compressor is not None:
+    #   if slot_mapping is None:
+    #     current_slot_mapping = (
+    #         attn_metadata.slot_mapping.flatten()
+    #     )  # pytype: disable=file-attribute-error
+    #   else:
+    #     current_slot_mapping = slot_mapping
+    #
+    #   active_slot_mapping = current_slot_mapping[:actual_num_tokens]
+    #   self.compressor(...) # Uncomment when compressor is attached
+
+    # ---------------------------------------------------------
+    # 2. EXTRACT KV CACHE FOR JAX KERNEL
+    # ---------------------------------------------------------
+    kv_cache_tensor = self.k_cache.kv_cache
+
+    # TODO(hwanginho): Support DSv4 FP8 index cache format.
+    # Once vLLM's FP8 cache is enabled, extract the scale tensor here if it
+    # is a separate tensor, or pack it with cache_kv. Need to align with
+    # alynie@ on https://github.com/vllm-project/tpu-inference/pull/2858
+    # (The exact attribute name depends on vLLM's FP8 implementation, e.g., `kv_scale`)
+    # kv_scales_tensor = self.k_cache.kv_scale
+    # assert kv_scales_tensor.is_contiguous(), "Scales must be contiguous"
+    # kv_scales_jax = jax_view(kv_scales_tensor)
+
+    # ---------------------------------------------------------
+    # 3. DIRECT JAX KERNEL CALL
+    # ---------------------------------------------------------
+    bt_slice = attn_metadata.block_table  # pytype: disable=attribute-error
+    sl_slice = attn_metadata.seq_lens  # pytype: disable=attribute-error
+    csl_slice = attn_metadata.cu_seq_lens  # pytype: disable=attribute-error
+
+    topk_indices = streamindex_topk(
+        query_projection=q_quant[:actual_num_tokens],
+        kv_cache=kv_cache_tensor,
+        page_indices=bt_slice,
+        seq_lens=sl_slice,
+        cu_q_lens=csl_slice,
+        indexer_weights=weights,
+        k=self.topk_tokens,
+        compression_ratio=self.compress_ratio,
+        # TODO(hwanginho): Tune these block configurations later for performance
+        num_kv_pages_per_block=1,
+        num_queries_per_block=1,
+    )
+
+    return topk_indices


### PR DESCRIPTION
# DeepSeek-V4 Lightning Indexer: TPU StreamIndex Top-K Kernel & Indexer

## Overview
  This design implements the **streamindex_topk** custom kernel and its PyTorch/vLLM integration module **VllmDeepseekV4Indexer** for the **DeepSeek-V4 Lightning Indexer**.
  
  The integration operates across three main components:
  1. **PyTorch Indexer Layer (`deepseek_v4_indexer.py`)**: A vLLM-compatible indexer module that intercepts forward passes, structures and buckets metadata (batch, token, block dimensions) to avoid compilation overhead, and performs JAX interop using TorchAX.
  2. **JAX Pallas Kernel (`streamindex_topk.py`)**: A hardware-optimized custom kernel on TPUs mapping sequences directly to hardware program grids (`pl.program_id`). It performs running Top-K computations fully on-chip in Vector Memory scratchpads.
  3. **Mocks & Tests (`test_streamindex_topk.py`)**: Validates shape constraints and verifies batched numerical correctness against a naive NumPy implementation.
