### PR TITLE
[Gemma 4][Jax] Enable usage of Jax QKV fusion in Gemma 4

### DIFF
--- a/tpu_inference/models/jax/gemma4.py
+++ b/tpu_inference/models/jax/gemma4.py
@@ -33,7 +33,8 @@ from tpu_inference.layers.common.sharding import ShardingAxisName
 from tpu_inference.layers.jax import JaxModule
 from tpu_inference.layers.jax.embed import JaxEmbed
 from tpu_inference.layers.jax.linear import (JaxEinsum, JaxLinear, JaxLmHead,
-                                             JaxMergedColumnParallelLinear)
+                                             JaxMergedColumnParallelLinear,
+                                             JaxQKVParallelLinear)
 from tpu_inference.layers.jax.moe.moe import JaxMoE
 from tpu_inference.layers.jax.norm import JaxRmsNorm
 from tpu_inference.layers.jax.pp_utils import PPMissingLayer, make_layers
@@ -335,47 +336,23 @@ class Gemma4Attention(JaxModule):
                            None) if _shard_kv_on_k else (None, None, "model")
         _kv_bias_spec = ("model", None) if _shard_kv_on_k else (None, "model")
 
-        self.q_proj = JaxEinsum(
-            "TD,DNH->TNH",
-            (self.hidden_size, self.num_heads, self.head_dim),
-            bias_shape=(self.num_heads,
-                        self.head_dim) if config.attention_bias else None,
-            param_dtype=dtype,
-            kernel_init=nnx.with_partitioning(init_fn, (None, "model", None)),
-            bias_init=nnx.with_partitioning(init_fn, ("model", None))
-            if config.attention_bias else None,
-            rngs=rng,
-            quant_config=quant_config,
-            prefix=prefix + ".q_proj",
-        )
-        self.q_norm = JaxRmsNorm(
-            self.head_dim,
-            epsilon=self.rms_norm_eps,
-            param_dtype=dtype,
-            scale_init=nnx.with_partitioning(init_fn, (None, )),
-            rngs=rng,
-            quant_config=quant_config,
-            prefix=prefix + ".q_norm",
-        )
-
-        self.k_proj = JaxEinsum(
-            "TD,DKH->TKH",
-            (self.hidden_size, self.num_kv_heads, self.head_dim),
-            bias_shape=(self.num_kv_heads,
-                        self.head_dim) if config.attention_bias else None,
-            param_dtype=dtype,
-            kernel_init=nnx.with_partitioning(init_fn, _kv_kernel_spec),
-            bias_init=nnx.with_partitioning(init_fn, _kv_bias_spec)
-            if config.attention_bias else None,
-            rngs=rng,
-            quant_config=quant_config,
-            prefix=prefix + ".k_proj",
-        )
-        # --- Shared KV Projection Logic ---
-        if use_k_eq_v:
-            self.v_proj = None
-        else:
-            self.v_proj = JaxEinsum(
+        if use_k_eq_v:  # TODO: Add QKV fusion logic for k == v case.
+            self.qkv_proj = None
+            self.q_proj = JaxEinsum(
+                "TD,DNH->TNH",
+                (self.hidden_size, self.num_heads, self.head_dim),
+                bias_shape=(self.num_heads,
+                            self.head_dim) if config.attention_bias else None,
+                param_dtype=dtype,
+                kernel_init=nnx.with_partitioning(init_fn,
+                                                  (None, "model", None)),
+                bias_init=nnx.with_partitioning(init_fn, ("model", None))
+                if config.attention_bias else None,
+                rngs=rng,
+                quant_config=quant_config,
+                prefix=prefix + ".q_proj",
+            )
+            self.k_proj = JaxEinsum(
                 "TD,DKH->TKH",
                 (self.hidden_size, self.num_kv_heads, self.head_dim),
                 bias_shape=(self.num_kv_heads,
@@ -386,8 +363,34 @@ class Gemma4Attention(JaxModule):
                 if config.attention_bias else None,
                 rngs=rng,
                 quant_config=quant_config,
-                prefix=prefix + ".v_proj",
+                prefix=prefix + ".k_proj",
             )
+            self.v_proj = None
+        else:
+            self.qkv_proj = JaxQKVParallelLinear(
+                hidden_size=self.hidden_size,
+                num_heads=self.num_heads,
+                num_kv_heads=self.num_kv_heads,
+                head_dim=self.head_dim,
+                use_bias=config.attention_bias,
+                dtype=dtype,
+                rngs=rng,
+                quant_config=quant_config,
+                prefix=prefix,
+            )
+            self.q_proj = None
+            self.k_proj = None
+            self.v_proj = None
+
+        self.q_norm = JaxRmsNorm(
+            self.head_dim,
+            epsilon=self.rms_norm_eps,
+            param_dtype=dtype,
+            scale_init=nnx.with_partitioning(init_fn, (None, )),
+            rngs=rng,
+            quant_config=quant_config,
+            prefix=prefix + ".q_norm",
+        )
 
         self.k_norm = JaxRmsNorm(
             self.head_dim,
@@ -452,13 +455,13 @@ class Gemma4Attention(JaxModule):
         attention_metadata: AttentionMetadata,
     ) -> Tuple[jax.Array, jax.Array]:
         md = attention_metadata
-        k = self.k_proj(x)
-        if self.v_proj is None:
-            v = k
+        if self.qkv_proj is not None:
+            q, k, v = self.qkv_proj(x)
         else:
-            v = self.v_proj(x)
-        # q: (T, N, H)
-        q = self.q_proj(x)
+            k = self.k_proj(x)
+            v = k
+            # q: (T, N, H)
+            q = self.q_proj(x)
         # Q norm (always applied)
         q = self.q_norm(q)
 
@@ -1032,7 +1035,17 @@ class Gemma4Model(JaxModule):
 
 
 class Gemma4ForCausalLM(JaxModule, LoadableWithIterator):
-    packed_modules_mapping = {"gate_up_proj": ["gate_proj", "up_proj"]}
+    packed_modules_mapping = {
+        "qkv_proj": [
+            "q_proj",
+            "k_proj",
+            "v_proj",
+        ],
+        "gate_up_proj": [
+            "gate_proj",
+            "up_proj",
+        ],
+    }
     WeightLoader = StandardWeightLoader
 
     def __init__(self, vllm_config: VllmConfig, rng_key: jax.Array,

--- a/tpu_inference/models/jax/gemma4_mm.py
+++ b/tpu_inference/models/jax/gemma4_mm.py
@@ -678,7 +678,6 @@ class Gemma4ForConditionalGeneration(JaxModule, LoadableWithIterator):
                         )):
                     continue
 
-                # TODO: verify the correctness of the changes below. Seems right, but not entirely sure.
                 # Handle packed QKV weights for the text tower when the model uses separate projections (e.g. k_eq_v layers)
                 if "qkv_proj" in mapped_name and "model.layers." in mapped_name:
                     m = re.search(r"layers\.(\d+)\.", mapped_name)
@@ -688,26 +687,6 @@ class Gemma4ForConditionalGeneration(JaxModule, LoadableWithIterator):
                             jax_attn = self.model.layers[layer_idx].self_attn
 
                             if jax_attn.qkv_proj is None:
-                                q_size = jax_attn.num_heads * jax_attn.head_dim_original
-                                kv_size = jax_attn.num_kv_heads * jax_attn.head_dim_original
-
-                                q_weight = weight[:q_size]
-                                k_weight = weight[q_size:q_size + kv_size]
-                                v_weight = weight[q_size + kv_size:q_size +
-                                                  2 * kv_size]
-
-                                yield mapped_name.replace(
-                                    "qkv_proj", "q_proj"), process_tensor(
-                                        mapped_name.replace(
-                                            "qkv_proj", "q_proj"), q_weight)
-                                yield mapped_name.replace(
-                                    "qkv_proj", "k_proj"), process_tensor(
-                                        mapped_name.replace(
-                                            "qkv_proj", "k_proj"), k_weight)
-                                yield mapped_name.replace(
-                                    "qkv_proj", "v_proj"), process_tensor(
-                                        mapped_name.replace(
-                                            "qkv_proj", "v_proj"), v_weight)
                                 continue
 
                 yield mapped_name, process_tensor(mapped_name, weight)

--- a/tpu_inference/models/jax/gemma4_mm.py
+++ b/tpu_inference/models/jax/gemma4_mm.py
@@ -678,40 +678,37 @@ class Gemma4ForConditionalGeneration(JaxModule, LoadableWithIterator):
                         )):
                     continue
 
-                # Handle packed QKV weights for the text tower.
-                # Note: KV-shared layers DO have full Q/K/V weights in the
-                # checkpoint — vllm-pytorch's Gemma4Attention constructs
-                # qkv_proj unconditionally. K/V are still computed and used
-                # for the current step's attention; the kernel skips writing
-                # them to the cache via update_kv_cache=False.
-                if "qkv_proj" in mapped_name:
+                # TODO: verify the correctness of the changes below. Seems right, but not entirely sure.
+                # Handle packed QKV weights for the text tower when the model uses separate projections (e.g. k_eq_v layers)
+                if "qkv_proj" in mapped_name and "model.layers." in mapped_name:
                     m = re.search(r"layers\.(\d+)\.", mapped_name)
                     if m:
                         layer_idx = int(m.group(1))
                         if self.model.start_layer <= layer_idx < self.model.end_layer:
-                            jax_attn = self.model.layers[
-                                layer_idx - self.model.start_layer].self_attn
-                            q_size = jax_attn.num_heads * jax_attn.head_dim_original
-                            kv_size = jax_attn.num_kv_heads * jax_attn.head_dim_original
+                            jax_attn = self.model.layers[layer_idx].self_attn
 
-                            q_weight = weight[:q_size]
-                            k_weight = weight[q_size:q_size + kv_size]
-                            v_weight = weight[q_size + kv_size:q_size +
-                                              2 * kv_size]
+                            if jax_attn.qkv_proj is None:
+                                q_size = jax_attn.num_heads * jax_attn.head_dim_original
+                                kv_size = jax_attn.num_kv_heads * jax_attn.head_dim_original
 
-                            yield mapped_name.replace(
-                                "qkv_proj", "q_proj"), process_tensor(
-                                    mapped_name.replace("qkv_proj", "q_proj"),
-                                    q_weight)
-                            yield mapped_name.replace(
-                                "qkv_proj", "k_proj"), process_tensor(
-                                    mapped_name.replace("qkv_proj", "k_proj"),
-                                    k_weight)
-                            yield mapped_name.replace(
-                                "qkv_proj", "v_proj"), process_tensor(
-                                    mapped_name.replace("qkv_proj", "v_proj"),
-                                    v_weight)
-                            continue
+                                q_weight = weight[:q_size]
+                                k_weight = weight[q_size:q_size + kv_size]
+                                v_weight = weight[q_size + kv_size:q_size +
+                                                  2 * kv_size]
+
+                                yield mapped_name.replace(
+                                    "qkv_proj", "q_proj"), process_tensor(
+                                        mapped_name.replace(
+                                            "qkv_proj", "q_proj"), q_weight)
+                                yield mapped_name.replace(
+                                    "qkv_proj", "k_proj"), process_tensor(
+                                        mapped_name.replace(
+                                            "qkv_proj", "k_proj"), k_weight)
+                                yield mapped_name.replace(
+                                    "qkv_proj", "v_proj"), process_tensor(
+                                        mapped_name.replace(
+                                            "qkv_proj", "v_proj"), v_weight)
+                                continue
 
                 yield mapped_name, process_tensor(mapped_name, weight)
 


### PR DESCRIPTION
Enabling the QKV Fusion from #2865 module in Gemma 4

# Tests

- `google/gemma-4-31B-it` boots healthy with `MODEL_IMPL_TYPE=flax_nnx`

```
SKIP_JAX_PRECOMPILE=1 USE_BATCHED_RPA_KERNEL=1 MODEL_IMPL_TYPE=flax_nnx vllm \
    serve google/gemma-4-31B-it \
    --max-model-len=1524 \
    --max-num-seqs=256 \
    --data-parallel-size 4 \
    --tensor-parallel-size 2 \
    --max-num-batched-tokens 16384 \
    --no-enable-prefix-caching \
    --additional_config='{"quantization": { "qwix": { "rules": [{ "module_path": ".*", "weight_qtype": "float8_e4m3fn", "act_qtype": "float8_e4m3fn"}]}}}' \
    --kv-cache-dtype=fp8 \
    --gpu-memory-utilization=0.9 \
    --async-scheduling \
    --limit-mm-per-prompt '{"image": 0, "video": 0, "audio": 0}' \
    --block-size=256
```
Accuracy is [0.9714](https://paste.googleplex.com/5303231449268224): `{'accuracy': 0.9714, 'gen_num': 140}`

```
python scripts/vllm/benchmarking/benchmark_serving.py \
      --backend vllm \
      --model google/gemma-4-31B-it \
      --dataset-name mmlu \
      --dataset-path /mnt/disks/jiries-disk_data/mmlu/data/test \
      --mmlu-use-chat-template \
      --chat-template-system-prompt "Reasoning effort: high, skip thinking process and must only give short answer in something
  like A, B, C, D." \
      --mmlu-output-len=16 \
      --run-eval \
      --num-prompts 140
```




