### PR TITLE
[MoE] Fuse the MoE token permute into GMM1's gmm_v2 kernel

### DIFF
--- a/tests/kernels/gmm_v2_fuse_permute_test.py
+++ b/tests/kernels/gmm_v2_fuse_permute_test.py
@@ -1,0 +1,138 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for the fused-permute path of gmm_v2.
+
+`gmm_v2(..., gather_indices=idx)` gathers its LHS rows per-row from an
+un-permuted source pool instead of reading a pre-permuted contiguous block.
+We check it is (1) numerically identical to the unfused
+`gmm_v2(lhs[idx], ...)` and (2) within a reasonable perf range of a standalone
+permute + gmm_v2, benchmarked over a few representative GMM1 shapes (the
+timings are printed).
+"""
+import time
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+from absl.testing import absltest, parameterized
+from jax._src import test_util as jtu
+
+from tpu_inference.kernels.megablox.gmm_v2 import gmm_v2
+
+jax.config.parse_flags_with_absl()
+
+
+def _balanced_group_sizes(size_m: int, num_groups: int) -> jax.Array:
+    base = size_m // num_groups
+    sizes = [base] * num_groups
+    sizes[-1] += size_m - base * num_groups
+    return jnp.asarray(sizes, jnp.int32)
+
+
+def _make_inputs(size_m, k, n, num_groups, num_src, seed=0):
+    k0, k1, k2 = jax.random.split(jax.random.key(seed), 3)
+    # The gather needs an fp32 source pool (per-row addressability).
+    lhs = jax.random.normal(k0, (num_src, k), jnp.float32) * 0.5
+    rhs = jax.random.normal(k1, (num_groups, k, n), jnp.float32) * 0.05
+    group_sizes = _balanced_group_sizes(size_m, num_groups)
+    gather_idx = jax.random.randint(k2, (size_m, ), 0, num_src, jnp.int32)
+    return lhs, rhs, group_sizes, gather_idx
+
+
+def _median_us(fn, *args, warmup=3, iters=10):
+    for _ in range(warmup):
+        jax.block_until_ready(fn(*args))
+    samples = []
+    for _ in range(iters):
+        t0 = time.perf_counter()
+        jax.block_until_ready(fn(*args))
+        samples.append((time.perf_counter() - t0) * 1e6)
+    return float(np.median(samples))
+
+
+# Representative prefill GMM1 shapes: (size_m, k, n, num_groups, num_src).
+_PERF_CASES = [
+    (4096, 2048, 1536, 8, 1024),
+    (8192, 4096, 2048, 8, 2048),
+    (16384, 2048, 768, 16, 4096),
+]
+
+
+class GmmV2FusePermuteTest(jtu.JaxTestCase):
+
+    @parameterized.named_parameters(
+        ("no_act", None),
+        ("silu", "silu"),
+    )
+    def test_gather_matches_unfused(self, fuse_act):
+        lhs, rhs, group_sizes, idx = _make_inputs(512,
+                                                  256,
+                                                  512,
+                                                  4,
+                                                  num_src=512)
+        kw = dict(group_offset=jnp.array([0], jnp.int32),
+                  fuse_act=fuse_act,
+                  preferred_element_type=jnp.float32,
+                  maybe_quantize_lhs=False,
+                  zero_initialize=False)
+        fused = gmm_v2(lhs, rhs, group_sizes, gather_indices=idx, **kw)
+        unfused = gmm_v2(lhs[idx], rhs, group_sizes, **kw)
+        self.assertArraysEqual(fused, unfused)
+
+    def test_fused_permute_perf(self):
+        # Benchmark the fused gather against the two unfused permute paths at a few
+        # representative prefill GMM1 shapes (bf16 matmul, silu) and print the
+        # timings: an XLA gather (lhs[idx]) and the onehot matmul permute the MoE
+        # layer uses for small batches. The assertion only checks fused vs the XLA
+        # gather stay in the same ballpark -- this is a benchmark, not a win gate.
+        print("\n  fused permute vs unfused permute + gmm_v2 (bf16, silu):")
+        for size_m, k, n, num_groups, num_src in _PERF_CASES:
+            lhs, rhs, group_sizes, idx = _make_inputs(size_m,
+                                                      k,
+                                                      n,
+                                                      num_groups,
+                                                      num_src=num_src)
+            rhs = rhs.astype(jnp.bfloat16)
+            kw = dict(group_offset=jnp.array([0], jnp.int32),
+                      fuse_act="silu",
+                      preferred_element_type=jnp.bfloat16,
+                      maybe_quantize_lhs=False,
+                      zero_initialize=False)
+            fused = jax.jit(lambda src, i: gmm_v2(
+                src, rhs, group_sizes, gather_indices=i, **kw))
+            # XLA gather permute, then a contiguous gmm_v2.
+            gather = jax.jit(lambda src, i: gmm_v2(src[i].astype(jnp.bfloat16),
+                                                   rhs, group_sizes, **kw))
+
+            # Onehot matmul permute (one_hot(i, num_src) @ src), the path the MoE
+            # layer takes below onehot_moe_permute_threshold, then a contiguous gmm.
+            def onehot_permute(src, i):
+                oh = jax.nn.one_hot(i, src.shape[0], dtype=jnp.bfloat16)
+                return gmm_v2(oh @ src.astype(jnp.bfloat16), rhs, group_sizes,
+                              **kw)
+
+            onehot = jax.jit(onehot_permute)
+            t_fused = _median_us(fused, lhs, idx)
+            t_gather = _median_us(gather, lhs, idx)
+            t_onehot = _median_us(onehot, lhs, idx)
+            print(f"    m={size_m:>6} k={k} n={n} E={num_groups}:  "
+                  f"fused={t_fused:8.1f}  gather={t_gather:8.1f}  "
+                  f"onehot={t_onehot:8.1f} us  "
+                  f"(fused/gather={t_fused / t_gather:.2f}, "
+                  f"fused/onehot={t_fused / t_onehot:.2f})")
+            self.assertBetween(t_fused / t_gather, 0.5, 2.0)
+
+
+if __name__ == "__main__":
+    absltest.main()

--- a/tests/kernels/gmm_v2_fuse_permute_test.py
+++ b/tests/kernels/gmm_v2_fuse_permute_test.py
@@ -20,6 +20,7 @@ We check it is (1) numerically identical to the unfused
 permute + gmm_v2, benchmarked over a few representative GMM1 shapes (the
 timings are printed).
 """
+import os
 import time
 
 import jax
@@ -29,6 +30,7 @@ from absl.testing import absltest, parameterized
 from jax._src import test_util as jtu
 
 from tpu_inference.kernels.megablox.gmm_v2 import gmm_v2
+from tpu_inference.kernels.sparse_core.ragged_gather_v2 import ragged_gather_v2
 
 jax.config.parse_flags_with_absl()
 
@@ -69,6 +71,65 @@ _PERF_CASES = [
 ]
 
 
+def _bf16_silu_kw():
+    return dict(group_offset=jnp.array([0], jnp.int32),
+                fuse_act="silu",
+                preferred_element_type=jnp.bfloat16,
+                maybe_quantize_lhs=False,
+                zero_initialize=False)
+
+
+def _permute_methods(rhs, group_sizes, kw):
+    """The four GMM1 permute paths as jitted fns of (fp32 source pool, idx)."""
+    rhs = rhs.astype(jnp.bfloat16)
+
+    def tc_fused(src, i):  # gather fused into GMM1's LHS read (TensorCore)
+        return gmm_v2(src, rhs, group_sizes, gather_indices=i, **kw)
+
+    def tc_gather(src, i):  # XLA gather permute, then a contiguous gmm_v2 (TC)
+        return gmm_v2(src[i].astype(jnp.bfloat16), rhs, group_sizes, **kw)
+
+    def tc_onehot(src, i):  # onehot matmul permute (MoE small-batch path, TC)
+        oh = jax.nn.one_hot(i, src.shape[0], dtype=jnp.bfloat16)
+        return gmm_v2(oh @ src.astype(jnp.bfloat16), rhs, group_sizes, **kw)
+
+    def sc_gather(src, i):  # SparseCore ragged_gather_v2 permute (prod path)
+        # ragged_gather_v2 mixes int dtypes internally; allow standard dtype
+        # promotion (the test runs under jtu's strict mode).
+        with jax.numpy_dtype_promotion("standard"):
+            permuted = ragged_gather_v2(src.astype(jnp.bfloat16), i,
+                                        jnp.int32(0), jnp.int32(i.shape[0]))
+        return gmm_v2(permuted, rhs, group_sizes, **kw)
+
+    return {
+        name: jax.jit(fn)
+        for name, fn in (("tc_fused", tc_fused), ("tc_gather", tc_gather),
+                         ("tc_onehot", tc_onehot), ("sc_gather", sc_gather))
+    }
+
+
+def _capture_xprof(prof_dir, case=_PERF_CASES[1], iters=20):
+    """Trace each permute path into its own <prof_dir>/<method>/ subdir, so each
+    produces a separate xplane.pb (one xprof per method). The subdirs form the
+    phased layout the upload-profile-to-xprof helper expects."""
+    size_m, k, n, num_groups, num_src = case
+    lhs, rhs, group_sizes, idx = _make_inputs(size_m,
+                                              k,
+                                              n,
+                                              num_groups,
+                                              num_src=num_src)
+    for name, fn in _permute_methods(rhs, group_sizes,
+                                     _bf16_silu_kw()).items():
+        jax.block_until_ready(fn(lhs, idx))  # compile before tracing
+        method_dir = os.path.join(prof_dir, name)
+        jax.profiler.start_trace(method_dir)
+        for i in range(iters):
+            with jax.profiler.StepTraceAnnotation(name, step_num=i):
+                jax.block_until_ready(fn(lhs, idx))
+        jax.profiler.stop_trace()
+        print(f"  [xprof] {name} (m={size_m} k={k} n={n}) -> {method_dir}")
+
+
 class GmmV2FusePermuteTest(jtu.JaxTestCase):
 
     @parameterized.named_parameters(
@@ -91,11 +152,11 @@ class GmmV2FusePermuteTest(jtu.JaxTestCase):
         self.assertArraysEqual(fused, unfused)
 
     def test_fused_permute_perf(self):
-        # Benchmark the fused gather against the two unfused permute paths at a few
-        # representative prefill GMM1 shapes (bf16 matmul, silu) and print the
-        # timings: an XLA gather (lhs[idx]) and the onehot matmul permute the MoE
-        # layer uses for small batches. The assertion only checks fused vs the XLA
-        # gather stay in the same ballpark -- this is a benchmark, not a win gate.
+        # Benchmark the fused gather (tc_fused) against the three unfused permute
+        # paths at a few representative prefill GMM1 shapes (bf16 matmul, silu):
+        # tc_gather (XLA lhs[idx]), tc_onehot (onehot matmul), and sc_gather (the
+        # SparseCore ragged_gather). The assertion only checks tc_fused vs
+        # tc_gather stay in the same ballpark -- a benchmark, not a win gate.
         print("\n  fused permute vs unfused permute + gmm_v2 (bf16, silu):")
         for size_m, k, n, num_groups, num_src in _PERF_CASES:
             lhs, rhs, group_sizes, idx = _make_inputs(size_m,
@@ -103,35 +164,22 @@ class GmmV2FusePermuteTest(jtu.JaxTestCase):
                                                       n,
                                                       num_groups,
                                                       num_src=num_src)
-            rhs = rhs.astype(jnp.bfloat16)
-            kw = dict(group_offset=jnp.array([0], jnp.int32),
-                      fuse_act="silu",
-                      preferred_element_type=jnp.bfloat16,
-                      maybe_quantize_lhs=False,
-                      zero_initialize=False)
-            fused = jax.jit(lambda src, i: gmm_v2(
-                src, rhs, group_sizes, gather_indices=i, **kw))
-            # XLA gather permute, then a contiguous gmm_v2.
-            gather = jax.jit(lambda src, i: gmm_v2(src[i].astype(jnp.bfloat16),
-                                                   rhs, group_sizes, **kw))
-
-            # Onehot matmul permute (one_hot(i, num_src) @ src), the path the MoE
-            # layer takes below onehot_moe_permute_threshold, then a contiguous gmm.
-            def onehot_permute(src, i):
-                oh = jax.nn.one_hot(i, src.shape[0], dtype=jnp.bfloat16)
-                return gmm_v2(oh @ src.astype(jnp.bfloat16), rhs, group_sizes,
-                              **kw)
-
-            onehot = jax.jit(onehot_permute)
-            t_fused = _median_us(fused, lhs, idx)
-            t_gather = _median_us(gather, lhs, idx)
-            t_onehot = _median_us(onehot, lhs, idx)
+            m = _permute_methods(rhs, group_sizes, _bf16_silu_kw())
+            t = {name: _median_us(fn, lhs, idx) for name, fn in m.items()}
             print(f"    m={size_m:>6} k={k} n={n} E={num_groups}:  "
-                  f"fused={t_fused:8.1f}  gather={t_gather:8.1f}  "
-                  f"onehot={t_onehot:8.1f} us  "
-                  f"(fused/gather={t_fused / t_gather:.2f}, "
-                  f"fused/onehot={t_fused / t_onehot:.2f})")
-            self.assertBetween(t_fused / t_gather, 0.5, 2.0)
+                  f"tc_fused={t['tc_fused']:8.1f}  "
+                  f"tc_gather={t['tc_gather']:8.1f}  "
+                  f"tc_onehot={t['tc_onehot']:8.1f}  "
+                  f"sc_gather={t['sc_gather']:8.1f} us  "
+                  f"(tc_fused/tc_gather={t['tc_fused'] / t['tc_gather']:.2f}, "
+                  f"tc_fused/tc_onehot={t['tc_fused'] / t['tc_onehot']:.2f}, "
+                  f"tc_fused/sc_gather={t['tc_fused'] / t['sc_gather']:.2f})")
+            self.assertBetween(t["tc_fused"] / t["tc_gather"], 0.5, 2.0)
+        # Optional xprof capture (set FUSE_PERMUTE_XPROF_DIR) for kernel-level
+        # attribution of the perf differences between the three paths.
+        prof_dir = os.environ.get("FUSE_PERMUTE_XPROF_DIR")
+        if prof_dir:
+            _capture_xprof(prof_dir)
 
 
 if __name__ == "__main__":

--- a/tpu_inference/envs.py
+++ b/tpu_inference/envs.py
@@ -42,6 +42,14 @@ if TYPE_CHECKING:
     JAX_PROFILER_SERVER_PORT: int = 9999
     USE_BATCHED_RPA_KERNEL: bool = False
     FORCE_MOE_RANDOM_ROUTING: bool = False
+    # Fuse the MoE permute (token gather) into GMM1's LHS read instead of
+    # materializing the grouped activations with a standalone ragged_gather.
+    MOE_FUSE_PERMUTE: bool = False
+    # Only apply MOE_FUSE_PERMUTE at num_tokens >= MOE_FUSE_PERMUTE_MIN_TOKENS, so
+    # the fused gather is used only where prefill-size batches amortize its per-row
+    # overhead (avoids a small-batch decode regression).
+    MOE_FUSE_BATCH_GATED: bool = False
+    MOE_FUSE_PERMUTE_MIN_TOKENS: int = 768
     JITTED_MM_MODULE_KEYS: list[str] = []
     REGISTER_MM_MODULE_CUSTOM_PYTREE_CLASSES: list[str] = []
     RAGGED_GATED_DELTA_RULE_IMPL: str = "chunked_jax_pd"
@@ -327,6 +335,13 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Force random expert routing in MoE layers (for testing purposes only)
     "FORCE_MOE_RANDOM_ROUTING":
     env_bool("FORCE_MOE_RANDOM_ROUTING", default=False),
+    # Fuse the MoE permute (token gather) into GMM1's LHS read.
+    "MOE_FUSE_PERMUTE":
+    env_bool("MOE_FUSE_PERMUTE", default=False),
+    "MOE_FUSE_BATCH_GATED":
+    env_bool("MOE_FUSE_BATCH_GATED", default=False),
+    "MOE_FUSE_PERMUTE_MIN_TOKENS":
+    lambda: int(os.getenv("MOE_FUSE_PERMUTE_MIN_TOKENS", "768")),
     "JITTED_MM_MODULE_KEYS":
     env_str_list("JITTED_MM_MODULE_KEYS"),
     "REGISTER_MM_MODULE_CUSTOM_PYTREE_CLASSES":

--- a/tpu_inference/kernels/megablox/gmm_v2.py
+++ b/tpu_inference/kernels/megablox/gmm_v2.py
@@ -92,6 +92,10 @@ def align_to(x, a):
     return pl.cdiv(x, a) * a
 
 
+def idx_window_len(tile_m: int) -> int:
+    return align_to(127 + tile_m, 128)
+
+
 # Define data classes.
 
 
@@ -605,6 +609,133 @@ def inner_kernel(
     )
 
 
+def gathered_inner_kernel(
+    # In (pipelined)
+    tiled_rhs_ref: RhsRef,
+    # Out (pipelined)
+    tiled_out_ref: jax.Array,
+    # Scratch: the standard refs, plus the per-row gather double buffer
+    # (gather_buf [2, tile_m, tile_k] fp32 + sem) and its index window
+    # (gather_idx_smem int32[win_len] in SMEM + sem).
+    partial_out_ref: jax.Array,
+    acc_ref: jax.Array,
+    metadata_ref: MetadataRef,
+    gather_buf: jax.Array,
+    gather_sem: jax.Array,
+    gather_idx_smem: jax.Array,
+    gather_idx_sem: jax.Array,
+    *,
+    cfgs: GmmConfigs,
+    # Closed over (not pipelined): fp32 source pool [size_lhs_src, size_k]
+    # and the full int32[size_m] index array, both in HBM.
+    lhs_hbm: jax.Array,
+    gather_idx_hbm: jax.Array,
+):
+    """Inner kernel for the FUSED-PERMUTE path: the LHS tile is GATHERED row by
+    row from `lhs_hbm` using `gather_idx_hbm`, double-buffered behind the MXU,
+    instead of being read as a contiguous (already-permuted) block.
+
+    The gathered `[tile_m, tile_k]` VMEM buffer is handed to the *unchanged*
+    `inner_kernel` -- everything downstream (relayout, matmul, group mask,
+    partial_out accumulation, output write) is identical to the contiguous path.
+
+    Per-row f32 DMAs are the only option on the TC (no tiled indirect DMA); the
+    double buffer hides the next tile's gather behind this tile's matmul.
+    """
+
+    tile_m = cfgs.tiles.tile_m
+    tile_k = cfgs.tiles.tile_k
+    sublane = cfgs.dims.size_lhs_sublane
+    win_len = idx_window_len(tile_m)
+
+    n_id = pl.program_id(0)
+    gm_id = pl.program_id(1)
+    k_id = pl.program_id(2)
+    num_n = pl.num_programs(0)
+    num_gm = pl.num_programs(1)
+    num_k = pl.num_programs(2)
+
+    # Linear step in the (num_n, num_gm, num_k) row-major grid.
+    s = (n_id * num_gm + gm_id) * num_k + k_id
+    num_steps = num_n * num_gm * num_k
+    slot = lax.rem(s, 2)
+    nslot = lax.rem(s + 1, 2)
+
+    # Indices of the NEXT grid step (to prefetch its LHS rows). LHS depends only
+    # on (gm, k); n is irrelevant to which rows are gathered.
+    k1 = k_id + 1
+    carry_k = k1 == num_k
+    k1 = jnp.where(carry_k, 0, k1)
+    gm1 = jnp.where(carry_k, gm_id + 1, gm_id)
+    carry_gm = gm1 == num_gm
+    gm1 = jnp.where(carry_gm, 0, gm1)
+
+    def start_gather(buf_slot, sem, gm, k):
+        # Rows of this gm tile start at the sublane-aligned floor of m_start, to
+        # match the contiguous LHS index map; out-of-group rows are masked out
+        # downstream so gathering neighbouring indices is harmless.
+        m_start = metadata_ref.gm_id_to_m_offset[gm]
+        m_offset = m_start - m_start % sublane
+        # The full index array can be too large to scalar-prefetch into SMEM, so
+        # it stays in HBM and each tile streams in only its own window. The copy
+        # must start 128-aligned: floor m_offset to 128 (the window still covers
+        # the tile) and use `delta` to re-index the per-row reads.
+        aligned_start = (m_offset // 128) * 128
+        delta = m_offset - aligned_start
+        pltpu.make_async_copy(gather_idx_hbm.at[pl.ds(aligned_start, win_len)],
+                              gather_idx_smem, gather_idx_sem.at[0]).start()
+        pltpu.make_async_copy(gather_idx_hbm.at[pl.ds(aligned_start, win_len)],
+                              gather_idx_smem, gather_idx_sem.at[0]).wait()
+        k_base = k * tile_k
+        for r in range(tile_m):
+            pos = jnp.clip(delta + r, 0, win_len - 1)
+            row = gather_idx_smem[pos]
+            pltpu.make_async_copy(
+                lhs_hbm.at[row, pl.ds(k_base, tile_k)],
+                buf_slot.at[r],
+                sem,
+            ).start()
+
+    def wait_gather(buf_slot, sem):
+        for r in range(tile_m):
+            # Only the dst shape + sem matter for the wait; addresses are ignored.
+            pltpu.make_async_copy(
+                lhs_hbm.at[0, pl.ds(0, tile_k)],
+                buf_slot.at[r],
+                sem,
+            ).wait()
+
+    @pl.when(s == 0)
+    def _():
+        start_gather(gather_buf.at[0], gather_sem.at[0], gm_id, k_id)
+
+    @pl.when(s + 1 < num_steps)
+    def _():
+        start_gather(gather_buf.at[nslot], gather_sem.at[nslot], gm1, k1)
+
+    wait_gather(gather_buf.at[slot], gather_sem.at[slot])
+
+    # Hand the gathered tile to the shared compute path. gather_buf[slot] is a
+    # [tile_m, tile_k] array; inner_kernel's `reshape(-1, tile_k)` is a no-op.
+    lhs_tile = gather_buf[slot]
+
+    # Unquantized matmul: down-cast the gathered fp32 rows to the rhs dtype so the
+    # MXU runs e.g. bf16 x bf16. Lossless when the source rows were only widened
+    # to fp32 for per-row addressability. The quantized path quantizes from fp32.
+    if cfgs.lhs_cfgs.quant_dtype is None and not cfgs.rhs_cfgs.has_scale:
+        lhs_tile = lhs_tile.astype(cfgs.rhs_cfgs.dtype)
+
+    inner_kernel(
+        lhs_tile,
+        tiled_rhs_ref,
+        tiled_out_ref,
+        partial_out_ref,
+        acc_ref,
+        metadata_ref,
+        cfgs=cfgs,
+    )
+
+
 def fill_metadata(
     lhs_group_sizes_ref: jax.Array,  # int32[size_lhs_group]
     group_offset_ref: jax.Array,  # int32[1]
@@ -881,6 +1012,96 @@ def kernel_main(
         zero_out_end(out_ref, semaphore_ref, zero_size, dims=cfgs.dims)
 
 
+def kernel_main_gather(
+    # Scalar prefetch
+    lhs_group_sizes_ref: jax.Array,  # int32[size_lhs_group]
+    group_offset_ref: jax.Array,  # int32[1]
+    # In
+    lhs_ref: jax.Array,  # [size_lhs_src, size_k] fp32 source pool (HBM)
+    gather_idx_hbm: jax.Array,  # int32[size_m] full index array (HBM)
+    rhs_ref: WeightsRef,  # [size_group, size_k, size_n]
+    # Out
+    out_ref: jax.Array,  # [size_m, size_n]
+    # Scratch memory
+    partial_out_ref: jax.Array,
+    acc_ref: jax.Array,
+    metadata_ref: MetadataRef,
+    gather_buf: jax.Array,  # [2, tile_m, tile_k] fp32
+    gather_sem: jax.Array,  # DMA sem [2]
+    gather_idx_smem: jax.Array,  # int32[win_len] SMEM idx window
+    gather_idx_sem: jax.Array,  # DMA sem [1] for the idx-window copy
+    zero_ref: jax.Array | None,
+    semaphore_ref: jax.Array | None,
+    *,
+    cfgs: GmmConfigs,
+):
+    """Entry point for the FUSED-PERMUTE GMM kernel.
+
+    Mirrors `kernel_main` but the LHS is gathered per-row from `lhs_ref` (the
+    original, un-permuted source pool) using `gather_idx_hbm`, instead of being
+    pipelined as a contiguous block. `lhs_ref` and `gather_idx_hbm` are closed
+    over by the inner body, so the LHS is NOT an `emit_pipeline` input; the index
+    array stays in HBM and is chunked into SMEM per tile (see gathered_inner_kernel).
+    """
+
+    if cfgs.rhs_cfgs.should_bitcast:
+        rhs_weight = rhs_ref.weight.bitcast(jnp.uint32)
+        rhs_ref = dataclasses.replace(rhs_ref, weight=rhs_weight)
+
+    num_k = pl.cdiv(cfgs.dims.size_k, cfgs.tiles.tile_k)
+    num_n = pl.cdiv(cfgs.out_size_n, cfgs.tiles.tile_n)
+
+    num_gm = fill_metadata(
+        lhs_group_sizes_ref,
+        group_offset_ref,
+        metadata_ref,
+        cfgs=cfgs,
+    )
+
+    if cfgs.zero_init:
+        zero_size = zero_out_start(
+            out_ref,
+            zero_ref,
+            semaphore_ref,
+            metadata_ref,
+            num_gm,
+            dims=cfgs.dims,
+        )
+
+    # Only the rhs/out block specs are used; the lhs is gathered manually.
+    (_, rhs_spec), out_spec = generate_block_specs(metadata_ref, cfgs)
+
+    if cfgs.fuse_act is not None:
+        rhs_up_ref = jax.tree.map(lambda x: x.at[..., cfgs.out_size_n:],
+                                  rhs_ref)
+        rhs_ref = FusedWeightsRef(gate=rhs_ref, up=rhs_up_ref)
+        rhs_spec = FusedWeightsRef(gate=rhs_spec, up=rhs_spec)
+
+    body = functools.partial(
+        gathered_inner_kernel,
+        cfgs=cfgs,
+        lhs_hbm=lhs_ref,
+        gather_idx_hbm=gather_idx_hbm,
+    )
+
+    pipeline_fn = pltpu.emit_pipeline(
+        body,
+        grid=(num_n, num_gm, num_k),
+        in_specs=(rhs_spec, ),
+        out_specs=out_spec,
+    )
+
+    out_in = out_ref.reshape(-1, cfgs.dims.size_lhs_sublane, out_ref.shape[-1])
+    scratches = [
+        partial_out_ref, acc_ref, metadata_ref, gather_buf, gather_sem,
+        gather_idx_smem, gather_idx_sem
+    ]
+    pipeline_fn(rhs_ref, out_in, scratches=scratches)
+
+    if cfgs.zero_init:
+        zero_out_end(out_ref, semaphore_ref, zero_size, dims=cfgs.dims)
+
+
 def calculate_tiling(
     dims: Dimensions,
     lhs_cfgs: InputConfigs,
@@ -1002,15 +1223,28 @@ def validate_inputs(
     group_sizes: jax.Array,
     group_offset: jax.Array,
     fuse_act: str | None = None,
+    gather_indices: jax.Array | None = None,
 ) -> Dimensions:
     """Validates the inputs for the GMM kernel."""
 
-    size_m = lhs.shape[0]
     size_group, size_k, size_n = rhs.shape
     size_lhs_group = group_sizes.shape[0]
 
+    if gather_indices is not None:
+        # Fused permute: lhs is the un-permuted source pool [size_lhs_src, size_k];
+        # the number of (grouped) output rows is len(gather_indices). Per-row gather
+        # needs individually addressable fp32 rows.
+        assert lhs.dtype == jnp.float32, (
+            f"gather_indices requires fp32 lhs, got {lhs.dtype}")
+        assert gather_indices.ndim == 1
+        size_m = gather_indices.shape[0]
+        assert lhs.ndim == 2 and lhs.shape[1] == size_k, (
+            f"{lhs.shape=} must be [size_lhs_src, {size_k=}]")
+    else:
+        size_m = lhs.shape[0]
+        assert lhs.shape == (size_m, size_k)
+
     assert size_group <= size_lhs_group
-    assert lhs.shape == (size_m, size_k)
     assert rhs.shape == (size_group, size_k, size_n)
     if rhs_bias is not None:
         assert rhs_bias.shape == (size_group, 1, size_n)
@@ -1099,11 +1333,12 @@ def make_gmm_configs(
     maybe_quantize_lhs: bool,
     zero_initialize: bool,
     fuse_act: str | None = None,
+    gather_indices: jax.Array | None = None,
 ):
     """Fills the GMM config for the GMM kernel."""
 
     dims = validate_inputs(lhs, rhs, rhs_scale, rhs_bias, group_sizes,
-                           group_offset, fuse_act)
+                           group_offset, fuse_act, gather_indices)
 
     if rhs_scale is not None:
         has_scale = True
@@ -1208,6 +1443,7 @@ def gmm_v2(
     | None = None,  # [size_group, num_blocks, 1, out_size]
     rhs_bias: jax.Array | None = None,  # [size_group, 1, out_size]
     group_offset: jax.Array | None = None,  # int32[1]
+    gather_indices: jax.Array | None = None,  # int32[size_m]
     *,
     tile_info: TileSizes | TileFn = calculate_tiling,
     vmem_limit_bytes: int | None = None,
@@ -1225,12 +1461,21 @@ def gmm_v2(
     triple buffering on weights to better utilize memory.
 
     Args:
-        lhs: lhs with shape [size_m, size_k].
+        lhs: lhs with shape [size_m, size_k]. When ``gather_indices`` is given,
+            lhs is instead the un-permuted source pool [size_lhs_src, size_k]
+            (fp32) and the gather produces the [size_m, size_k] grouped LHS
+            on the fly -- see ``gather_indices``.
         rhs: rhs with shape [size_group, size_k, size_n].
         group_sizes: The group sizes of lhs rows of shape [size_lhs_group,].
         rhs_scale: The rhs scale of shape [size_group, num_blocks, 1, out_size].
         rhs_bias: The rhs bias of shape [size_group, 1, out_size].
         group_offset: Optional. The group offset of shape [1,].
+        gather_indices: Optional int32[size_m] (FUSED PERMUTE). When provided,
+            grouped output row ``j`` reads its LHS from ``lhs[gather_indices[j]]``
+            via per-row double-buffered DMAs hidden behind the MXU, instead of a
+            contiguous (pre-permuted) block. ``size_m == len(gather_indices)``;
+            requires fp32 lhs (per-row addressability). Equivalent to
+            ``gmm_v2(lhs[gather_indices], rhs, group_sizes, ...)``.
         tile_info: The tile sizes or tile function to use.
         vmem_limit_bytes: Optional vmem limit in bytes.
         precision: Unused. Exists for compatibility reasons.
@@ -1269,9 +1514,20 @@ def gmm_v2(
         maybe_quantize_lhs=maybe_quantize_lhs,
         zero_initialize=zero_initialize,
         fuse_act=fuse_act,
+        gather_indices=gather_indices,
     )
     dims = cfgs.dims
     tiles = cfgs.tiles
+
+    # Fused-permute fallback: the per-row gather re-reads the LHS once per n-tile
+    # (n is the outermost grid axis), so for num_n > 1 it loses to a single
+    # contiguous read -- fall back to an explicit permute. The gather path is taken
+    # only when the output fits a single n-tile (num_n == 1).
+    if gather_indices is not None:
+        num_n_tiles = pl.cdiv(cfgs.out_size_n, tiles.tile_n)
+        if num_n_tiles > 1:
+            lhs = lhs[gather_indices]
+            gather_indices = None
 
     # Prepare block specs.
     rhs_scale_spec = rhs_bias_spec = None
@@ -1285,7 +1541,7 @@ def gmm_v2(
     # Initialize scratch shapes.
     max_num_gm = dims.size_group + pl.cdiv(dims.size_m, tiles.tile_m) - 1
     acc_cols = 2 * tiles.tile_n if cfgs.fuse_act is not None else tiles.tile_n
-    scratch_shapes = [
+    base_scratch = [
         # partial_out_ref
         pltpu.VMEM((dims.size_lhs_sublane, tiles.tile_n), cfgs.out_dtype),
         # acc_ref
@@ -1316,33 +1572,23 @@ def gmm_v2(
         tile_zero_m = target_zero_ref_bytes // num_lanes // out_bytes
         tile_zero_m = min(tile_zero_m, dims.size_m)
 
-        scratch_shapes += [
+        zero_scratch = [
             pltpu.VMEM((tile_zero_m, num_lanes), cfgs.out_dtype),
             pltpu.SemaphoreType.DMA((1, )),
         ]
     else:
-        scratch_shapes += [None, None]
+        zero_scratch = [None, None]
 
     aligned_n = align_to(cfgs.out_size_n, num_lanes)
     out_init = jax.ShapeDtypeStruct((dims.size_m, aligned_n), cfgs.out_dtype)
     rhs_weights = WeightsRef(weight=rhs, scale=rhs_scale, bias=rhs_bias)
 
-    return pl.pallas_call(
-        functools.partial(kernel_main, cfgs=cfgs),
-        out_shape=out_init,
-        grid_spec=pltpu.PrefetchScalarGridSpec(
-            num_scalar_prefetch=2,
-            in_specs=[
-                pl.BlockSpec(memory_space=pltpu.HBM),
-                WeightsRef(
-                    weight=pl.BlockSpec(memory_space=pltpu.HBM),
-                    scale=rhs_scale_spec,
-                    bias=rhs_bias_spec,
-                ),
-            ],
-            out_specs=pl.BlockSpec(memory_space=pltpu.HBM),
-            scratch_shapes=scratch_shapes,
-        ),
+    rhs_in_spec = WeightsRef(
+        weight=pl.BlockSpec(memory_space=pltpu.HBM),
+        scale=rhs_scale_spec,
+        bias=rhs_bias_spec,
+    )
+    common_params = dict(
         compiler_params=pltpu.CompilerParams(
             vmem_limit_bytes=vmem_limit_bytes,
             disable_bounds_checks=True,
@@ -1350,4 +1596,54 @@ def gmm_v2(
         name=get_scope_name(cfgs),
         cost_estimate=get_cost_estimate(cfgs),
         metadata=get_metadata(cfgs),
+    )
+
+    if gather_indices is not None:
+        # Fused permute: extra (2, tile_m, tile_k) double buffer + DMA sems for the
+        # per-row gather, plus an SMEM window for this tile's index chunk (the index
+        # array is an HBM input, not scalar-prefetched).
+        gw_len = idx_window_len(tiles.tile_m)
+        gather_scratch = [
+            pltpu.VMEM((2, tiles.tile_m, tiles.tile_k), jnp.float32),
+            pltpu.SemaphoreType.DMA((2, )),
+            pltpu.SMEM((gw_len, ), jnp.int32),
+            pltpu.SemaphoreType.DMA((1, )),
+        ]
+        scratch_shapes = base_scratch + gather_scratch + zero_scratch
+        # Pad so the 128-aligned index window DMA never reads past the array end.
+        gather_idx = gather_indices.astype(jnp.int32)
+        pad_m = align_to(dims.size_m, 128) + gw_len - dims.size_m
+        if pad_m:
+            gather_idx = jnp.pad(gather_idx, (0, pad_m))
+        return pl.pallas_call(
+            functools.partial(kernel_main_gather, cfgs=cfgs),
+            out_shape=out_init,
+            grid_spec=pltpu.PrefetchScalarGridSpec(
+                num_scalar_prefetch=2,
+                in_specs=[
+                    pl.BlockSpec(memory_space=pltpu.HBM),  # lhs source pool
+                    pl.BlockSpec(memory_space=pltpu.HBM),  # gather_idx (HBM)
+                    rhs_in_spec,
+                ],
+                out_specs=pl.BlockSpec(memory_space=pltpu.HBM),
+                scratch_shapes=scratch_shapes,
+            ),
+            **common_params,
+        )(group_sizes, group_offset, lhs, gather_idx,
+          rhs_weights)[:, :cfgs.out_size_n]
+
+    scratch_shapes = base_scratch + zero_scratch
+    return pl.pallas_call(
+        functools.partial(kernel_main, cfgs=cfgs),
+        out_shape=out_init,
+        grid_spec=pltpu.PrefetchScalarGridSpec(
+            num_scalar_prefetch=2,
+            in_specs=[
+                pl.BlockSpec(memory_space=pltpu.HBM),
+                rhs_in_spec,
+            ],
+            out_specs=pl.BlockSpec(memory_space=pltpu.HBM),
+            scratch_shapes=scratch_shapes,
+        ),
+        **common_params,
     )(group_sizes, group_offset, lhs, rhs_weights)[:, :cfgs.out_size_n]

--- a/tpu_inference/layers/common/fused_moe_gmm.py
+++ b/tpu_inference/layers/common/fused_moe_gmm.py
@@ -125,7 +125,8 @@ def gmm_wrapper(lhs,
                 group_sizes,
                 group_offset,
                 fuse_act=None,
-                preferred_element_type=None):
+                preferred_element_type=None,
+                gather_indices=None):
     gmm_res = gmm_v2(
         lhs=lhs,
         rhs=rhs,
@@ -133,6 +134,7 @@ def gmm_wrapper(lhs,
         rhs_bias=rhs_bias,
         group_sizes=group_sizes,
         group_offset=group_offset[0],
+        gather_indices=gather_indices,
         zero_initialize=False,
         fuse_act=fuse_act,
         preferred_element_type=preferred_element_type,
@@ -188,32 +190,54 @@ def moe_gmm_local(x: jax.Array,
                   group_offset: jax.Array,
                   topk_argsort_revert_indices: jax.Array,
                   topk_weights: jax.Array,
+                  token_indices_sorted: jax.Array | None = None,
                   *,
                   activation: str,
                   topk: int,
                   parallelism: Literal["tp", "ep"],
                   enable_rs_kernel: bool = False,
+                  fuse_permute: bool = False,
                   onehot_moe_permute_threshold: int = 0,
                   scatter_results: bool = False,
                   moe_chunk_size: int = 0) -> jax.Array:
     """Main MoE logic on a local shard can run in TP or EP mode.
 
     Set parallelism for "tp" or "ep"
+
+    When ``fuse_permute`` is set, ``x`` is the un-permuted source activations and
+    ``token_indices_sorted`` selects each grouped LHS row -- GMM1 gathers its
+    input per-row (fused permute) instead of reading a pre-grouped buffer.
     """
 
     assert parallelism in ["tp", "ep"]
 
     # GMM1 computes x @ (W_up | W_gate) together and activation, output is [tokens,padded_intermediate_size]
-    gmm1_res = gmm_wrapper(
-        x,
-        w1,
-        w1_scale,
-        w1_bias,
-        group_sizes,
-        group_offset,
-        fuse_act=activation,
-        preferred_element_type=x.dtype,
-    )
+    if fuse_permute:
+        # Fused permute: GMM1 gathers its LHS rows by index from the fp32 source
+        # activations. preferred_element_type keeps gmm1_res in the activation
+        # dtype so the rest of the pipeline is unchanged.
+        gmm1_res = gmm_wrapper(
+            x.astype(jnp.float32),
+            w1,
+            w1_scale,
+            w1_bias,
+            group_sizes,
+            group_offset,
+            fuse_act=activation,
+            preferred_element_type=x.dtype,
+            gather_indices=token_indices_sorted,
+        )
+    else:
+        gmm1_res = gmm_wrapper(
+            x,
+            w1,
+            w1_scale,
+            w1_bias,
+            group_sizes,
+            group_offset,
+            fuse_act=activation,
+            preferred_element_type=x.dtype,
+        )
 
     # When the parallelism is TP since w2_bias is not sharded, we should only apply bias
     # once, not applying to every shard. So we set w2_bias to 0 to all shards other than
@@ -376,11 +400,13 @@ def tensor_parallel_gmm(
     group_sizes: jax.Array,
     topk_argsort_revert_indices: jax.Array,
     topk_weights: jax.Array,
+    token_indices_sorted: jax.Array,
     *,
     activation: str,
     topk: int,
     mesh: Mesh,
     enable_rs_kernel: bool = False,
+    fuse_permute: bool = False,
     onehot_moe_permute_threshold: int = 0,
     scatter_results: bool = False,
     moe_chunk_size: int = 0,
@@ -414,6 +440,7 @@ def tensor_parallel_gmm(
             topk=topk,
             parallelism="tp",
             enable_rs_kernel=False,
+            fuse_permute=fuse_permute,
             onehot_moe_permute_threshold=onehot_moe_permute_threshold,
             scatter_results=scatter_results,
             moe_chunk_size=moe_chunk_size,
@@ -431,6 +458,7 @@ def tensor_parallel_gmm(
             P(),
             data_p_spec,
             data_p_spec,
+            data_p_spec,
         ),
         out_specs=(final_out_specs),
         check_vma=False,
@@ -446,6 +474,7 @@ def tensor_parallel_gmm(
         group_offset,
         topk_argsort_revert_indices,
         topk_weights,
+        token_indices_sorted,
     )
 
 
@@ -460,11 +489,13 @@ def expert_parallel_gmm(
     group_sizes: jax.Array,
     topk_argsort_revert_indices: jax.Array,
     topk_weights: jax.Array,
+    token_indices_sorted: jax.Array,
     *,
     activation: str,
     topk: int,
     mesh: Mesh,
     enable_rs_kernel: bool = False,
+    fuse_permute: bool = False,
     onehot_moe_permute_threshold: int = 0,
     moe_chunk_size: int = 0,
     scatter_results: bool = False,
@@ -498,6 +529,7 @@ def expert_parallel_gmm(
             parallelism="ep",
             onehot_moe_permute_threshold=onehot_moe_permute_threshold,
             enable_rs_kernel=enable_rs_kernel,
+            fuse_permute=fuse_permute,
             scatter_results=scatter_results,
             moe_chunk_size=moe_chunk_size,
         ),
@@ -512,6 +544,7 @@ def expert_parallel_gmm(
             w2_bias_spec,
             data_p_spec,
             ep_p_spec,
+            data_p_spec,
             data_p_spec,
             data_p_spec,
         ),
@@ -529,6 +562,7 @@ def expert_parallel_gmm(
         group_offset,
         topk_argsort_revert_indices,
         topk_weights,
+        token_indices_sorted,
     )
 
 
@@ -617,6 +651,15 @@ def fused_moe_func(
     global_num_experts, padded_hidden_size, _ = w1.shape
     dtype = hidden_states.dtype
 
+    # Fuse the permute (token gather) into GMM1's LHS read. The gather buffer is
+    # fp32, so quantized w1 still composes (gather fp32 rows, then quantize in VMEM).
+    fuse_permute = envs.MOE_FUSE_PERMUTE
+    # Below MOE_FUSE_PERMUTE_MIN_TOKENS the fused gather's fixed per-row overhead
+    # outweighs the win, so MOE_FUSE_BATCH_GATED keeps small (decode) batches on the
+    # unfused path.
+    if envs.MOE_FUSE_BATCH_GATED and num_tokens < envs.MOE_FUSE_PERMUTE_MIN_TOKENS:
+        fuse_permute = False
+
     assert (num_tokens * topk) % 16 == 0, (
         "The kernel requires num_tokens * topk to be a multiple of "
         f"16 but got {num_tokens}*{topk}={num_tokens*topk}")
@@ -680,7 +723,12 @@ def fused_moe_func(
                                            dtype=jnp.int32).sum(axis=0)
         topk_argsort_revert_indices = jnp.argsort(topk_argsort_indices)
 
-        if use_ep:
+        if fuse_permute:
+            # Fused permute: skip materializing the grouped activations -- GMM1
+            # gathers its LHS rows from this un-permuted source, with the EP-shard
+            # window selected by its group_offset metadata.
+            x = hidden_states_local
+        elif use_ep:
             num_ep_shard = get_mesh_shape_product(mesh,
                                                   ShardingAxisName.EXPERT)
             local_num_experts = global_num_experts // num_ep_shard
@@ -710,25 +758,28 @@ def fused_moe_func(
         else:
             x = hidden_states_local[token_indices_sorted]
 
-        return x, group_sizes_local, topk_argsort_revert_indices
+        return (x, token_indices_sorted, group_sizes_local,
+                topk_argsort_revert_indices)
 
     if all_gather_fp8:
         hidden_states = _apply_all_gather_fp8(hidden_states, mesh, dtype)
 
-    x, group_sizes, topk_argsort_revert_indices = jax.shard_map(
-        _process_tokens_locally,
-        mesh=mesh,
-        in_specs=(
-            P(ShardingAxisName.MLP_DATA, None),
-            P(ShardingAxisName.MLP_DATA, None),
-        ),
-        out_specs=(
-            P(ShardingAxisName.MLP_DATA),
-            P(ShardingAxisName.MLP_DATA),
-            P(ShardingAxisName.MLP_DATA),
-        ),
-        check_vma=False,
-    )(hidden_states, topk_indices)
+    (x, token_indices_sorted, group_sizes,
+     topk_argsort_revert_indices) = jax.shard_map(
+         _process_tokens_locally,
+         mesh=mesh,
+         in_specs=(
+             P(ShardingAxisName.MLP_DATA, None),
+             P(ShardingAxisName.MLP_DATA, None),
+         ),
+         out_specs=(
+             P(ShardingAxisName.MLP_DATA),
+             P(ShardingAxisName.MLP_DATA),
+             P(ShardingAxisName.MLP_DATA),
+             P(ShardingAxisName.MLP_DATA),
+         ),
+         check_vma=False,
+     )(hidden_states, topk_indices)
 
     try:
         x = jnp.pad(x, ((0, 0), (0, padded_hidden_size - hidden_size)))
@@ -749,10 +800,12 @@ def fused_moe_func(
             group_sizes,
             topk_argsort_revert_indices,
             topk_weights,
+            token_indices_sorted,
             activation=activation,
             topk=topk,
             mesh=mesh,
             enable_rs_kernel=actual_enable_rs_kernel,
+            fuse_permute=fuse_permute,
             onehot_moe_permute_threshold=onehot_moe_permute_threshold,
             scatter_results=scatter_results,
             moe_chunk_size=moe_chunk_size,
@@ -769,10 +822,12 @@ def fused_moe_func(
             group_sizes,
             topk_argsort_revert_indices,
             topk_weights,
+            token_indices_sorted,
             activation=activation,
             topk=topk,
             mesh=mesh,
             enable_rs_kernel=actual_enable_rs_kernel,
+            fuse_permute=fuse_permute,
             onehot_moe_permute_threshold=onehot_moe_permute_threshold,
             scatter_results=scatter_results,
             moe_chunk_size=moe_chunk_size,


### PR DESCRIPTION
## [MoE] Fuse the MoE token permute (gather) into GMM1's gmm_v2 kernel

Adds `MOE_FUSE_PERMUTE`. Instead of materializing the expert-grouped activations with a standalone permute (ragged_gather / onehot matmul) before GMM1, `gmm_v2` gathers its LHS rows by index directly:

    gmm_v2(src, w1, gs, gather_indices=idx)   ==   gmm_v2(src[idx], w1, gs)

The permute is folded into the matmul's LHS read, as a result the grouped activations don't get written to / read back from HBM.

Correctness tested in `test_gather_matches_unfused`

Perf tested in `test_fused_permute_perf`:

| size_m | k | n | E | fused (us) | gather (us) | onehot (us) | fused/onehot |
|-------:|----:|----:|---:|------:|-------:|-------:|:---:|
|  4096 | 2048 | 1536 |  8 | 321.9 | 295.3 | 290.5 | 1.11 |
|  8192 | 4096 | 2048 |  8 | 544.5 | 743.3 | 632.4 | 0.86 |
| 16384 | 2048 |  768 | 16 | 469.8 | 461.6 | 655.3 | 0.72 |