### PR TITLE
[releases/v0.23.0] Cherry-pick #2882: Explicit shutdown server instead of deleting reference and wait

### DIFF
--- a/tests/e2e/test_runai_model_streamer_loader.py
+++ b/tests/e2e/test_runai_model_streamer_loader.py
@@ -34,8 +34,6 @@
 
 from __future__ import annotations
 
-import time
-
 import pytest
 from vllm import LLM, SamplingParams
 
@@ -77,8 +75,7 @@ def test_correctness_jax_uni_proc_executor(
                   max_num_batched_tokens=256)
     gcs_outputs = gcs_llm.generate([prompt], sampling_config)
     gcs_output_text = gcs_outputs[0].outputs[0].text
-    del gcs_llm
-    time.sleep(10)  # Wait for TPUs to be released
+    gcs_llm.llm_engine.engine_core.shutdown()
 
     # Test with Hugging Face model
     hf_llm = LLM(model=hf_model_name,
@@ -87,8 +84,7 @@ def test_correctness_jax_uni_proc_executor(
                  max_num_batched_tokens=256)
     hf_outputs = hf_llm.generate([prompt], sampling_config)
     hf_output_text = hf_outputs[0].outputs[0].text
-    del hf_llm
-    time.sleep(10)  # Wait for TPUs to be released
+    hf_llm.llm_engine.engine_core.shutdown()
 
     assert gcs_output_text == hf_output_text, (
         f"Outputs do not match! "
@@ -128,8 +124,7 @@ def test_correctness_torchax_uni_proc_executor(
                   max_num_batched_tokens=256)
     gcs_outputs = gcs_llm.generate([prompt], sampling_config)
     gcs_output_text = gcs_outputs[0].outputs[0].text
-    del gcs_llm
-    time.sleep(10)  # Wait for TPUs to be released
+    gcs_llm.llm_engine.engine_core.shutdown()
 
     # Test with Hugging Face model
     hf_llm = LLM(model=hf_model_name,
@@ -138,8 +133,7 @@ def test_correctness_torchax_uni_proc_executor(
                  max_num_batched_tokens=256)
     hf_outputs = hf_llm.generate([prompt], sampling_config)
     hf_output_text = hf_outputs[0].outputs[0].text
-    del hf_llm
-    time.sleep(10)  # Wait for TPUs to be released
+    hf_llm.llm_engine.engine_core.shutdown()
 
     assert gcs_output_text == hf_output_text, (
         f"Outputs do not match! "
@@ -180,8 +174,7 @@ def test_correctness_torchax_ray_distributed_executor(
                   max_num_batched_tokens=256)
     gcs_outputs = gcs_llm.generate([prompt], sampling_config)
     gcs_output_text = gcs_outputs[0].outputs[0].text
-    del gcs_llm
-    time.sleep(10)  # Wait for TPUs to be released
+    gcs_llm.llm_engine.engine_core.shutdown()
 
     # Test with Hugging Face model
     hf_llm = LLM(model=hf_model_name,
@@ -191,8 +184,7 @@ def test_correctness_torchax_ray_distributed_executor(
                  max_num_batched_tokens=256)
     hf_outputs = hf_llm.generate([prompt], sampling_config)
     hf_output_text = hf_outputs[0].outputs[0].text
-    del hf_llm
-    time.sleep(10)  # Wait for TPUs to be released
+    hf_llm.llm_engine.engine_core.shutdown()
 
     assert gcs_output_text == hf_output_text, (
         f"Outputs do not match! "

--- a/tests/e2e/test_speculative_decoding.py
+++ b/tests/e2e/test_speculative_decoding.py
@@ -147,10 +147,7 @@ def _get_baseline_results(
         ref_llm = LLM(model=model_name, **kwargs)
         ref_outputs = ref_llm.generate(test_prompts, sampling_config)
 
-        del ref_llm
-
-        # Waiting for TPUs to be released.
-        time.sleep(10)
+        ref_llm.llm_engine.engine_core.shutdown()
         return ref_outputs
 
 
@@ -224,10 +221,7 @@ def _test_correctness_helper(
         print(
             f"All {matches} outputs match between reference LLM and speculative LLM."
         )
-        del spec_llm
-
-        # Waiting for TPUs to be released.
-        time.sleep(10)
+        spec_llm.llm_engine.engine_core.shutdown()
 
 
 def test_ngram_correctness_greedy(


### PR DESCRIPTION
Cherry-pick of #2882 (https://github.com/vllm-project/tpu-inference/pull/2882) onto `releases/v0.23.0`.

#2882 landed on `main` after the v0.23.0 cut, so it was missing from the release branch. It makes the e2e tests explicitly shut down the server instead of deleting the reference and waiting, improving teardown reliability for the Runai model-streamer and speculative-decoding e2e tests.

Clean cherry-pick; touches only `tests/e2e/test_runai_model_streamer_loader.py` and `tests/e2e/test_speculative_decoding.py` (8 insertions, 22 deletions).