### PR TITLE
Make non ready pipeline steps run on cpu as opposed to tpu

### DIFF
--- a/.buildkite/excluded/meta-llama_Llama-4-Maverick-17B-128E-Instruct_multimodal.yml
+++ b/.buildkite/excluded/meta-llama_Llama-4-Maverick-17B-128E-Instruct_multimodal.yml
@@ -16,7 +16,7 @@ steps:
   - label: "${TPU_VERSION:-tpu6e} Unit tests for meta-llama/Llama-4-Maverick-17B-128E-Instruct/multimodal"
     key: "${TPU_VERSION:-tpu6e}_meta-llama_Llama-4-Maverick-17B-128E-Instruct_multimodal_UnitTest"
     agents:
-      queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}")
     soft_fail: true
     commands:
       - |
@@ -39,7 +39,7 @@ steps:
     key: "${TPU_VERSION:-tpu6e}_meta-llama_Llama-4-Maverick-17B-128E-Instruct_multimodal_Accuracy"
     depends_on: "${TPU_VERSION:-tpu6e}_record_meta-llama_Llama-4-Maverick-17B-128E-Instruct_multimodal_UnitTest"
     agents:
-      queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}")
     soft_fail: true
     commands:
       - |
@@ -62,7 +62,7 @@ steps:
     key: "${TPU_VERSION:-tpu6e}_meta-llama_Llama-4-Maverick-17B-128E-Instruct_multimodal_Benchmark"
     depends_on: "${TPU_VERSION:-tpu6e}_record_meta-llama_Llama-4-Maverick-17B-128E-Instruct_multimodal_Accuracy"
     agents:
-      queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}")
     soft_fail: true
     commands:
       - |

--- a/.buildkite/features/Collective_Communication_Matmul.yml
+++ b/.buildkite/features/Collective_Communication_Matmul.yml
@@ -39,7 +39,7 @@ steps:
     depends_on: "${TPU_VERSION:-tpu6e}_record_Collective_Communication_Matmul_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_Collective_Communication_Matmul_PerformanceTest" "unverified"

--- a/.buildkite/features/MLA.yml
+++ b/.buildkite/features/MLA.yml
@@ -17,7 +17,7 @@ steps:
     key: "${TPU_VERSION:-tpu6e}_MLA_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_MLA_CorrectnessTest" "unverified"
@@ -40,7 +40,7 @@ steps:
     depends_on: "${TPU_VERSION:-tpu6e}_record_MLA_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_MLA_PerformanceTest" "unverified"

--- a/.buildkite/features/MoE.yml
+++ b/.buildkite/features/MoE.yml
@@ -17,7 +17,7 @@ steps:
     key: "${TPU_VERSION:-tpu6e}_MoE_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_MoE_CorrectnessTest" "unverified"
@@ -40,7 +40,7 @@ steps:
     depends_on: "${TPU_VERSION:-tpu6e}_record_MoE_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_MoE_PerformanceTest" "unverified"

--- a/.buildkite/features/Quantized_Attention.yml
+++ b/.buildkite/features/Quantized_Attention.yml
@@ -17,7 +17,7 @@ steps:
     key: "${TPU_VERSION:-tpu6e}_Quantized_Attention_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_Quantized_Attention_CorrectnessTest" "unverified"
@@ -40,7 +40,7 @@ steps:
     depends_on: "${TPU_VERSION:-tpu6e}_record_Quantized_Attention_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_Quantized_Attention_PerformanceTest" "unverified"

--- a/.buildkite/features/Quantized_KV_Cache.yml
+++ b/.buildkite/features/Quantized_KV_Cache.yml
@@ -17,7 +17,7 @@ steps:
     key: "${TPU_VERSION:-tpu6e}_Quantized_KV_Cache_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_Quantized_KV_Cache_CorrectnessTest" "unverified"
@@ -40,7 +40,7 @@ steps:
     depends_on: "${TPU_VERSION:-tpu6e}_record_Quantized_KV_Cache_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_Quantized_KV_Cache_PerformanceTest" "unverified"

--- a/.buildkite/features/Quantized_Matmul.yml
+++ b/.buildkite/features/Quantized_Matmul.yml
@@ -17,7 +17,7 @@ steps:
     key: "${TPU_VERSION:-tpu6e}_Quantized_Matmul_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_Quantized_Matmul_CorrectnessTest" "unverified"
@@ -40,7 +40,7 @@ steps:
     depends_on: "${TPU_VERSION:-tpu6e}_record_Quantized_Matmul_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_Quantized_Matmul_PerformanceTest" "unverified"

--- a/.buildkite/features/Step_Pooling_Embedding.yml
+++ b/.buildkite/features/Step_Pooling_Embedding.yml
@@ -39,7 +39,7 @@ steps:
     depends_on: "${TPU_VERSION:-tpu6e}_record_Step_Pooling_Embedding_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_Step_Pooling_Embedding_PerformanceTest" "unverified"

--- a/.buildkite/kernel_microbenchmarks/all_gather_matmul/w16a16.yml
+++ b/.buildkite/kernel_microbenchmarks/all_gather_matmul/w16a16.yml
@@ -17,7 +17,7 @@ steps:
     key: "${TPU_VERSION:-tpu6e}_all-gather-matmul-w16a16_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_all-gather-matmul-w16a16_CorrectnessTest" "unverified"
@@ -40,7 +40,7 @@ steps:
     depends_on: "${TPU_VERSION:-tpu6e}_record_all-gather-matmul-w16a16_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_all-gather-matmul-w16a16_PerformanceTest" "unverified"

--- a/.buildkite/kernel_microbenchmarks/all_gather_matmul/w4a16.yml
+++ b/.buildkite/kernel_microbenchmarks/all_gather_matmul/w4a16.yml
@@ -17,7 +17,7 @@ steps:
     key: "${TPU_VERSION:-tpu6e}_all-gather-matmul-w4a16_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_all-gather-matmul-w4a16_CorrectnessTest" "unverified"
@@ -40,7 +40,7 @@ steps:
     depends_on: "${TPU_VERSION:-tpu6e}_record_all-gather-matmul-w4a16_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_all-gather-matmul-w4a16_PerformanceTest" "unverified"

--- a/.buildkite/kernel_microbenchmarks/all_gather_matmul/w4a4.yml
+++ b/.buildkite/kernel_microbenchmarks/all_gather_matmul/w4a4.yml
@@ -17,7 +17,7 @@ steps:
     key: "${TPU_VERSION:-tpu6e}_all-gather-matmul-w4a4_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_all-gather-matmul-w4a4_CorrectnessTest" "unverified"
@@ -40,7 +40,7 @@ steps:
     depends_on: "${TPU_VERSION:-tpu6e}_record_all-gather-matmul-w4a4_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_all-gather-matmul-w4a4_PerformanceTest" "unverified"

--- a/.buildkite/kernel_microbenchmarks/all_gather_matmul/w4a8.yml
+++ b/.buildkite/kernel_microbenchmarks/all_gather_matmul/w4a8.yml
@@ -17,7 +17,7 @@ steps:
     key: "${TPU_VERSION:-tpu6e}_all-gather-matmul-w4a8_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_all-gather-matmul-w4a8_CorrectnessTest" "unverified"
@@ -40,7 +40,7 @@ steps:
     depends_on: "${TPU_VERSION:-tpu6e}_record_all-gather-matmul-w4a8_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_all-gather-matmul-w4a8_PerformanceTest" "unverified"

--- a/.buildkite/kernel_microbenchmarks/all_gather_matmul/w8a16.yml
+++ b/.buildkite/kernel_microbenchmarks/all_gather_matmul/w8a16.yml
@@ -17,7 +17,7 @@ steps:
     key: "${TPU_VERSION:-tpu6e}_all-gather-matmul-w8a16_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_all-gather-matmul-w8a16_CorrectnessTest" "unverified"
@@ -40,7 +40,7 @@ steps:
     depends_on: "${TPU_VERSION:-tpu6e}_record_all-gather-matmul-w8a16_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_all-gather-matmul-w8a16_PerformanceTest" "unverified"

--- a/.buildkite/kernel_microbenchmarks/all_gather_matmul/w8a8.yml
+++ b/.buildkite/kernel_microbenchmarks/all_gather_matmul/w8a8.yml
@@ -17,7 +17,7 @@ steps:
     key: "${TPU_VERSION:-tpu6e}_all-gather-matmul-w8a8_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_all-gather-matmul-w8a8_CorrectnessTest" "unverified"
@@ -40,7 +40,7 @@ steps:
     depends_on: "${TPU_VERSION:-tpu6e}_record_all-gather-matmul-w8a8_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_all-gather-matmul-w8a8_PerformanceTest" "unverified"

--- a/.buildkite/kernel_microbenchmarks/fused_moe/w16a16.yml
+++ b/.buildkite/kernel_microbenchmarks/fused_moe/w16a16.yml
@@ -17,7 +17,7 @@ steps:
     key: "${TPU_VERSION:-tpu6e}_fused_moe-w16a16_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_fused_moe-w16a16_CorrectnessTest" "unverified"
@@ -40,7 +40,7 @@ steps:
     depends_on: "${TPU_VERSION:-tpu6e}_record_fused_moe-w16a16_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_fused_moe-w16a16_PerformanceTest" "unverified"

--- a/.buildkite/kernel_microbenchmarks/fused_moe/w4a16.yml
+++ b/.buildkite/kernel_microbenchmarks/fused_moe/w4a16.yml
@@ -17,7 +17,7 @@ steps:
     key: "${TPU_VERSION:-tpu6e}_fused_moe-w4a16_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_fused_moe-w4a16_CorrectnessTest" "unverified"
@@ -40,7 +40,7 @@ steps:
     depends_on: "${TPU_VERSION:-tpu6e}_record_fused_moe-w4a16_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_fused_moe-w4a16_PerformanceTest" "unverified"

--- a/.buildkite/kernel_microbenchmarks/fused_moe/w4a4.yml
+++ b/.buildkite/kernel_microbenchmarks/fused_moe/w4a4.yml
@@ -17,7 +17,7 @@ steps:
     key: "${TPU_VERSION:-tpu6e}_fused_moe-w4a4_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_fused_moe-w4a4_CorrectnessTest" "unverified"
@@ -40,7 +40,7 @@ steps:
     depends_on: "${TPU_VERSION:-tpu6e}_record_fused_moe-w4a4_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_fused_moe-w4a4_PerformanceTest" "unverified"

--- a/.buildkite/kernel_microbenchmarks/fused_moe/w4a8.yml
+++ b/.buildkite/kernel_microbenchmarks/fused_moe/w4a8.yml
@@ -17,7 +17,7 @@ steps:
     key: "${TPU_VERSION:-tpu6e}_fused_moe-w4a8_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_fused_moe-w4a8_CorrectnessTest" "unverified"
@@ -40,7 +40,7 @@ steps:
     depends_on: "${TPU_VERSION:-tpu6e}_record_fused_moe-w4a8_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_fused_moe-w4a8_PerformanceTest" "unverified"

--- a/.buildkite/kernel_microbenchmarks/fused_moe/w8a16.yml
+++ b/.buildkite/kernel_microbenchmarks/fused_moe/w8a16.yml
@@ -17,7 +17,7 @@ steps:
     key: "${TPU_VERSION:-tpu6e}_fused_moe-w8a16_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_fused_moe-w8a16_CorrectnessTest" "unverified"
@@ -40,7 +40,7 @@ steps:
     depends_on: "${TPU_VERSION:-tpu6e}_record_fused_moe-w8a16_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_fused_moe-w8a16_PerformanceTest" "unverified"

--- a/.buildkite/kernel_microbenchmarks/fused_moe/w8a8.yml
+++ b/.buildkite/kernel_microbenchmarks/fused_moe/w8a8.yml
@@ -17,7 +17,7 @@ steps:
     key: "${TPU_VERSION:-tpu6e}_fused_moe-w8a8_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_fused_moe-w8a8_CorrectnessTest" "unverified"
@@ -40,7 +40,7 @@ steps:
     depends_on: "${TPU_VERSION:-tpu6e}_record_fused_moe-w8a8_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_fused_moe-w8a8_PerformanceTest" "unverified"

--- a/.buildkite/kernel_microbenchmarks/generic_ragged_paged_attention_v3/w16a16.yml
+++ b/.buildkite/kernel_microbenchmarks/generic_ragged_paged_attention_v3/w16a16.yml
@@ -17,7 +17,7 @@ steps:
     key: "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w16a16_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w16a16_CorrectnessTest" "unverified"
@@ -40,7 +40,7 @@ steps:
     depends_on: "${TPU_VERSION:-tpu6e}_record_generic_ragged_paged_attention_v3-w16a16_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w16a16_PerformanceTest" "unverified"

--- a/.buildkite/kernel_microbenchmarks/generic_ragged_paged_attention_v3/w4a16.yml
+++ b/.buildkite/kernel_microbenchmarks/generic_ragged_paged_attention_v3/w4a16.yml
@@ -17,7 +17,7 @@ steps:
     key: "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w4a16_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w4a16_CorrectnessTest" "unverified"
@@ -40,7 +40,7 @@ steps:
     depends_on: "${TPU_VERSION:-tpu6e}_record_generic_ragged_paged_attention_v3-w4a16_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w4a16_PerformanceTest" "unverified"

--- a/.buildkite/kernel_microbenchmarks/generic_ragged_paged_attention_v3/w4a4.yml
+++ b/.buildkite/kernel_microbenchmarks/generic_ragged_paged_attention_v3/w4a4.yml
@@ -17,7 +17,7 @@ steps:
     key: "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w4a4_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w4a4_CorrectnessTest" "unverified"
@@ -40,7 +40,7 @@ steps:
     depends_on: "${TPU_VERSION:-tpu6e}_record_generic_ragged_paged_attention_v3-w4a4_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w4a4_PerformanceTest" "unverified"

--- a/.buildkite/kernel_microbenchmarks/generic_ragged_paged_attention_v3/w4a8.yml
+++ b/.buildkite/kernel_microbenchmarks/generic_ragged_paged_attention_v3/w4a8.yml
@@ -17,7 +17,7 @@ steps:
     key: "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w4a8_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w4a8_CorrectnessTest" "unverified"
@@ -40,7 +40,7 @@ steps:
     depends_on: "${TPU_VERSION:-tpu6e}_record_generic_ragged_paged_attention_v3-w4a8_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w4a8_PerformanceTest" "unverified"

--- a/.buildkite/kernel_microbenchmarks/generic_ragged_paged_attention_v3/w8a16.yml
+++ b/.buildkite/kernel_microbenchmarks/generic_ragged_paged_attention_v3/w8a16.yml
@@ -17,7 +17,7 @@ steps:
     key: "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w8a16_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w8a16_CorrectnessTest" "unverified"
@@ -40,7 +40,7 @@ steps:
     depends_on: "${TPU_VERSION:-tpu6e}_record_generic_ragged_paged_attention_v3-w8a16_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w8a16_PerformanceTest" "unverified"

--- a/.buildkite/kernel_microbenchmarks/generic_ragged_paged_attention_v3/w8a8.yml
+++ b/.buildkite/kernel_microbenchmarks/generic_ragged_paged_attention_v3/w8a8.yml
@@ -17,7 +17,7 @@ steps:
     key: "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w8a8_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w8a8_CorrectnessTest" "unverified"
@@ -40,7 +40,7 @@ steps:
     depends_on: "${TPU_VERSION:-tpu6e}_record_generic_ragged_paged_attention_v3-w8a8_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_generic_ragged_paged_attention_v3-w8a8_PerformanceTest" "unverified"

--- a/.buildkite/kernel_microbenchmarks/gmm/w16a16.yml
+++ b/.buildkite/kernel_microbenchmarks/gmm/w16a16.yml
@@ -17,7 +17,7 @@ steps:
     key: "${TPU_VERSION:-tpu6e}_gmm-w16a16_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_gmm-w16a16_CorrectnessTest" "unverified"
@@ -40,7 +40,7 @@ steps:
     depends_on: "${TPU_VERSION:-tpu6e}_record_gmm-w16a16_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_gmm-w16a16_PerformanceTest" "unverified"

--- a/.buildkite/kernel_microbenchmarks/gmm/w4a16.yml
+++ b/.buildkite/kernel_microbenchmarks/gmm/w4a16.yml
@@ -17,7 +17,7 @@ steps:
     key: "${TPU_VERSION:-tpu6e}_gmm-w4a16_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_gmm-w4a16_CorrectnessTest" "unverified"
@@ -40,7 +40,7 @@ steps:
     depends_on: "${TPU_VERSION:-tpu6e}_record_gmm-w4a16_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_gmm-w4a16_PerformanceTest" "unverified"

--- a/.buildkite/kernel_microbenchmarks/gmm/w4a4.yml
+++ b/.buildkite/kernel_microbenchmarks/gmm/w4a4.yml
@@ -17,7 +17,7 @@ steps:
     key: "${TPU_VERSION:-tpu6e}_gmm-w4a4_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_gmm-w4a4_CorrectnessTest" "unverified"
@@ -40,7 +40,7 @@ steps:
     depends_on: "${TPU_VERSION:-tpu6e}_record_gmm-w4a4_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_gmm-w4a4_PerformanceTest" "unverified"

--- a/.buildkite/kernel_microbenchmarks/gmm/w4a8.yml
+++ b/.buildkite/kernel_microbenchmarks/gmm/w4a8.yml
@@ -17,7 +17,7 @@ steps:
     key: "${TPU_VERSION:-tpu6e}_gmm-w4a8_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_gmm-w4a8_CorrectnessTest" "unverified"
@@ -40,7 +40,7 @@ steps:
     depends_on: "${TPU_VERSION:-tpu6e}_record_gmm-w4a8_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_gmm-w4a8_PerformanceTest" "unverified"

--- a/.buildkite/kernel_microbenchmarks/gmm/w8a16.yml
+++ b/.buildkite/kernel_microbenchmarks/gmm/w8a16.yml
@@ -17,7 +17,7 @@ steps:
     key: "${TPU_VERSION:-tpu6e}_gmm-w8a16_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_gmm-w8a16_CorrectnessTest" "unverified"
@@ -40,7 +40,7 @@ steps:
     depends_on: "${TPU_VERSION:-tpu6e}_record_gmm-w8a16_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_gmm-w8a16_PerformanceTest" "unverified"

--- a/.buildkite/kernel_microbenchmarks/gmm/w8a8.yml
+++ b/.buildkite/kernel_microbenchmarks/gmm/w8a8.yml
@@ -17,7 +17,7 @@ steps:
     key: "${TPU_VERSION:-tpu6e}_gmm-w8a8_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_gmm-w8a8_CorrectnessTest" "unverified"
@@ -40,7 +40,7 @@ steps:
     depends_on: "${TPU_VERSION:-tpu6e}_record_gmm-w8a8_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_gmm-w8a8_PerformanceTest" "unverified"

--- a/.buildkite/kernel_microbenchmarks/mla/w16a16.yml
+++ b/.buildkite/kernel_microbenchmarks/mla/w16a16.yml
@@ -17,7 +17,7 @@ steps:
     key: "${TPU_VERSION:-tpu6e}_mla-w16a16_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_mla-w16a16_CorrectnessTest" "unverified"
@@ -40,7 +40,7 @@ steps:
     depends_on: "${TPU_VERSION:-tpu6e}_record_mla-w16a16_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_mla-w16a16_PerformanceTest" "unverified"

--- a/.buildkite/kernel_microbenchmarks/mla/w4a16.yml
+++ b/.buildkite/kernel_microbenchmarks/mla/w4a16.yml
@@ -17,7 +17,7 @@ steps:
     key: "${TPU_VERSION:-tpu6e}_mla-w4a16_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_mla-w4a16_CorrectnessTest" "unverified"
@@ -40,7 +40,7 @@ steps:
     depends_on: "${TPU_VERSION:-tpu6e}_record_mla-w4a16_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_mla-w4a16_PerformanceTest" "unverified"

--- a/.buildkite/kernel_microbenchmarks/mla/w4a4.yml
+++ b/.buildkite/kernel_microbenchmarks/mla/w4a4.yml
@@ -17,7 +17,7 @@ steps:
     key: "${TPU_VERSION:-tpu6e}_mla-w4a4_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_mla-w4a4_CorrectnessTest" "unverified"
@@ -40,7 +40,7 @@ steps:
     depends_on: "${TPU_VERSION:-tpu6e}_record_mla-w4a4_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_mla-w4a4_PerformanceTest" "unverified"

--- a/.buildkite/kernel_microbenchmarks/mla/w4a8.yml
+++ b/.buildkite/kernel_microbenchmarks/mla/w4a8.yml
@@ -17,7 +17,7 @@ steps:
     key: "${TPU_VERSION:-tpu6e}_mla-w4a8_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_mla-w4a8_CorrectnessTest" "unverified"
@@ -40,7 +40,7 @@ steps:
     depends_on: "${TPU_VERSION:-tpu6e}_record_mla-w4a8_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_mla-w4a8_PerformanceTest" "unverified"

--- a/.buildkite/kernel_microbenchmarks/mla/w8a16.yml
+++ b/.buildkite/kernel_microbenchmarks/mla/w8a16.yml
@@ -17,7 +17,7 @@ steps:
     key: "${TPU_VERSION:-tpu6e}_mla-w8a16_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_mla-w8a16_CorrectnessTest" "unverified"
@@ -40,7 +40,7 @@ steps:
     depends_on: "${TPU_VERSION:-tpu6e}_record_mla-w8a16_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_mla-w8a16_PerformanceTest" "unverified"

--- a/.buildkite/kernel_microbenchmarks/mla/w8a8.yml
+++ b/.buildkite/kernel_microbenchmarks/mla/w8a8.yml
@@ -17,7 +17,7 @@ steps:
     key: "${TPU_VERSION:-tpu6e}_mla-w8a8_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_mla-w8a8_CorrectnessTest" "unverified"
@@ -40,7 +40,7 @@ steps:
     depends_on: "${TPU_VERSION:-tpu6e}_record_mla-w8a8_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_mla-w8a8_PerformanceTest" "unverified"

--- a/.buildkite/kernel_microbenchmarks/ragged_paged_attention_v3_head_dim_64/w16a16.yml
+++ b/.buildkite/kernel_microbenchmarks/ragged_paged_attention_v3_head_dim_64/w16a16.yml
@@ -17,7 +17,7 @@ steps:
     key: "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w16a16_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w16a16_CorrectnessTest" "unverified"
@@ -40,7 +40,7 @@ steps:
     depends_on: "${TPU_VERSION:-tpu6e}_record_ragged_paged_attention_v3_head_dim_64-w16a16_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w16a16_PerformanceTest" "unverified"

--- a/.buildkite/kernel_microbenchmarks/ragged_paged_attention_v3_head_dim_64/w4a16.yml
+++ b/.buildkite/kernel_microbenchmarks/ragged_paged_attention_v3_head_dim_64/w4a16.yml
@@ -17,7 +17,7 @@ steps:
     key: "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w4a16_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w4a16_CorrectnessTest" "unverified"
@@ -40,7 +40,7 @@ steps:
     depends_on: "${TPU_VERSION:-tpu6e}_record_ragged_paged_attention_v3_head_dim_64-w4a16_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w4a16_PerformanceTest" "unverified"

--- a/.buildkite/kernel_microbenchmarks/ragged_paged_attention_v3_head_dim_64/w4a4.yml
+++ b/.buildkite/kernel_microbenchmarks/ragged_paged_attention_v3_head_dim_64/w4a4.yml
@@ -17,7 +17,7 @@ steps:
     key: "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w4a4_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w4a4_CorrectnessTest" "unverified"
@@ -40,7 +40,7 @@ steps:
     depends_on: "${TPU_VERSION:-tpu6e}_record_ragged_paged_attention_v3_head_dim_64-w4a4_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w4a4_PerformanceTest" "unverified"

--- a/.buildkite/kernel_microbenchmarks/ragged_paged_attention_v3_head_dim_64/w4a8.yml
+++ b/.buildkite/kernel_microbenchmarks/ragged_paged_attention_v3_head_dim_64/w4a8.yml
@@ -17,7 +17,7 @@ steps:
     key: "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w4a8_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w4a8_CorrectnessTest" "unverified"
@@ -40,7 +40,7 @@ steps:
     depends_on: "${TPU_VERSION:-tpu6e}_record_ragged_paged_attention_v3_head_dim_64-w4a8_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w4a8_PerformanceTest" "unverified"

--- a/.buildkite/kernel_microbenchmarks/ragged_paged_attention_v3_head_dim_64/w8a16.yml
+++ b/.buildkite/kernel_microbenchmarks/ragged_paged_attention_v3_head_dim_64/w8a16.yml
@@ -17,7 +17,7 @@ steps:
     key: "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w8a16_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w8a16_CorrectnessTest" "unverified"
@@ -40,7 +40,7 @@ steps:
     depends_on: "${TPU_VERSION:-tpu6e}_record_ragged_paged_attention_v3_head_dim_64-w8a16_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w8a16_PerformanceTest" "unverified"

--- a/.buildkite/kernel_microbenchmarks/ragged_paged_attention_v3_head_dim_64/w8a8.yml
+++ b/.buildkite/kernel_microbenchmarks/ragged_paged_attention_v3_head_dim_64/w8a8.yml
@@ -17,7 +17,7 @@ steps:
     key: "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w8a8_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w8a8_CorrectnessTest" "unverified"
@@ -40,7 +40,7 @@ steps:
     depends_on: "${TPU_VERSION:-tpu6e}_record_ragged_paged_attention_v3_head_dim_64-w8a8_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_ragged_paged_attention_v3_head_dim_64-w8a8_PerformanceTest" "unverified"

--- a/.buildkite/models/Qwen_Qwen3-Embedding-8B.yml
+++ b/.buildkite/models/Qwen_Qwen3-Embedding-8B.yml
@@ -65,7 +65,7 @@ steps:
     depends_on: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen3-Embedding-8B_Accuracy"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     env:
       TEST_MODEL: Qwen/Qwen3-Embedding-8B
       TENSOR_PARALLEL_SIZE: "${TENSOR_PARALLEL_SIZE_SINGLE:-1}"

--- a/.buildkite/models/Qwen_Qwen3-Omni-30B-A3B-Instruct.yml
+++ b/.buildkite/models/Qwen_Qwen3-Omni-30B-A3B-Instruct.yml
@@ -16,7 +16,7 @@ steps:
   - label: "${TPU_VERSION:-tpu6e} Unit tests for Qwen/Qwen3-Omni-30B-A3B-Instruct"
     key: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-Omni-30B-A3B-Instruct_UnitTest"
     agents:
-      queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}")
     soft_fail: true
     commands:
       - |
@@ -39,7 +39,7 @@ steps:
     key: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-Omni-30B-A3B-Instruct_Accuracy"
     depends_on: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen3-Omni-30B-A3B-Instruct_UnitTest"
     agents:
-      queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}")
     soft_fail: true
     commands:
       - |
@@ -62,7 +62,7 @@ steps:
     key: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-Omni-30B-A3B-Instruct_Benchmark"
     depends_on: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen3-Omni-30B-A3B-Instruct_Accuracy"
     agents:
-      queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}")
     soft_fail: true
     commands:
       - |

--- a/.buildkite/models/deepseek-ai_DeepSeek-V3.1.yml
+++ b/.buildkite/models/deepseek-ai_DeepSeek-V3.1.yml
@@ -16,7 +16,7 @@ steps:
   - label: "${TPU_VERSION:-tpu6e} Unit tests for deepseek-ai/DeepSeek-V3.1"
     key: "${TPU_VERSION:-tpu6e}_deepseek-ai_DeepSeek-V3_1_UnitTest"
     agents:
-      queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}")
     soft_fail: true
     commands:
       - |
@@ -39,7 +39,7 @@ steps:
     key: "${TPU_VERSION:-tpu6e}_deepseek-ai_DeepSeek-V3_1_Accuracy"
     depends_on: "${TPU_VERSION:-tpu6e}_record_deepseek-ai_DeepSeek-V3_1_UnitTest"
     agents:
-      queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}")
     soft_fail: true
     commands:
       - |
@@ -62,7 +62,7 @@ steps:
     key: "${TPU_VERSION:-tpu6e}_deepseek-ai_DeepSeek-V3_1_Benchmark"
     depends_on: "${TPU_VERSION:-tpu6e}_record_deepseek-ai_DeepSeek-V3_1_Accuracy"
     agents:
-      queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}")
     soft_fail: true
     commands:
       - |

--- a/.buildkite/models/moonshotai_Kimi-K2-Thinking.yml
+++ b/.buildkite/models/moonshotai_Kimi-K2-Thinking.yml
@@ -16,7 +16,7 @@ steps:
   - label: "${TPU_VERSION:-tpu6e} Unit tests for moonshotai/Kimi-K2-Thinking"
     key: "${TPU_VERSION:-tpu6e}_moonshotai_Kimi-K2-Thinking_UnitTest"
     agents:
-      queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}")
     soft_fail: true
     commands:
       - |
@@ -39,7 +39,7 @@ steps:
     key: "${TPU_VERSION:-tpu6e}_moonshotai_Kimi-K2-Thinking_Accuracy"
     depends_on: "${TPU_VERSION:-tpu6e}_record_moonshotai_Kimi-K2-Thinking_UnitTest"
     agents:
-      queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}")
     soft_fail: true
     commands:
       - |
@@ -62,7 +62,7 @@ steps:
     key: "${TPU_VERSION:-tpu6e}_moonshotai_Kimi-K2-Thinking_Benchmark"
     depends_on: "${TPU_VERSION:-tpu6e}_record_moonshotai_Kimi-K2-Thinking_Accuracy"
     agents:
-      queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}")
     soft_fail: true
     commands:
       - |

--- a/.buildkite/parallelism/CP.yml
+++ b/.buildkite/parallelism/CP.yml
@@ -17,7 +17,7 @@ steps:
     key: "${TPU_VERSION:-tpu6e}_CP_CorrectnessTest_Single_Host"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_CP_CorrectnessTest_Single_Host" "unverified"
@@ -40,7 +40,7 @@ steps:
     depends_on: "${TPU_VERSION:-tpu6e}_record_CP_CorrectnessTest_Single_Host"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_CP_PerformanceTest_Single_Host" "unverified"
@@ -62,7 +62,7 @@ steps:
     key: "${TPU_VERSION:-tpu6e}_CP_CorrectnessTest_Multi_Host"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_CP_CorrectnessTest_Multi_Host" "unverified"
@@ -84,7 +84,7 @@ steps:
     depends_on: "${TPU_VERSION:-tpu6e}_record_CP_CorrectnessTest_Multi_Host"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_CP_PerformanceTest_Multi_Host" "unverified"

--- a/.buildkite/parallelism/DP.yml
+++ b/.buildkite/parallelism/DP.yml
@@ -70,7 +70,7 @@ steps:
     env:
       NEW_MODEL_DESIGN: "1"
     agents:
-      queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}")
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_DP_CorrectnessTest_Multi_Host" "unverified"
@@ -95,7 +95,7 @@ steps:
     env:
       NEW_MODEL_DESIGN: "1"
     agents:
-      queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}")
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_DP_PerformanceTest_Multi_Host" "unverified"

--- a/.buildkite/parallelism/EP.yml
+++ b/.buildkite/parallelism/EP.yml
@@ -67,7 +67,7 @@ steps:
     key: "${TPU_VERSION:-tpu6e}_EP_CorrectnessTest_Multi_Host"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_MULTI:-tpu_v7x_8_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_MULTI:-tpu_v7x_8_queue}")
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_EP_CorrectnessTest_Multi_Host" "unverified"
@@ -89,7 +89,7 @@ steps:
     depends_on: "${TPU_VERSION:-tpu6e}_record_EP_CorrectnessTest_Multi_Host"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_MULTI:-tpu_v7x_8_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_MULTI:-tpu_v7x_8_queue}")
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_EP_PerformanceTest_Multi_Host" "unverified"

--- a/.buildkite/parallelism/SP.yml
+++ b/.buildkite/parallelism/SP.yml
@@ -41,7 +41,7 @@ steps:
     depends_on: "${TPU_VERSION:-tpu6e}_record_SP_CorrectnessTest_Single_Host"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_SP_PerformanceTest_Single_Host" "unverified"
@@ -63,7 +63,7 @@ steps:
     key: "${TPU_VERSION:-tpu6e}_SP_CorrectnessTest_Multi_Host"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_MULTI:-tpu_v7x_8_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_MULTI:-tpu_v7x_8_queue}")
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_SP_CorrectnessTest_Multi_Host" "unverified"
@@ -85,7 +85,7 @@ steps:
     depends_on: "${TPU_VERSION:-tpu6e}_record_SP_CorrectnessTest_Multi_Host"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_SP_PerformanceTest_Multi_Host" "unverified"

--- a/.buildkite/parallelism/TP.yml
+++ b/.buildkite/parallelism/TP.yml
@@ -64,7 +64,7 @@ steps:
     key: "${TPU_VERSION:-tpu6e}_TP_CorrectnessTest_Multi_Host"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}")
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_TP_CorrectnessTest_Multi_Host" "unverified"
@@ -87,7 +87,7 @@ steps:
     depends_on: "${TPU_VERSION:-tpu6e}_record_TP_CorrectnessTest_Multi_Host"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}")
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_TP_PerformanceTest_Multi_Host" "unverified"

--- a/.buildkite/pipeline_generation/feature_template.yml
+++ b/.buildkite/pipeline_generation/feature_template.yml
@@ -17,7 +17,7 @@ steps:
     key: "${{TPU_VERSION:-tpu6e}}_{SANITIZED_FEATURE_NAME}_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: "{QUEUE}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "{QUEUE}")
     commands:
       - echo "placeholder"  # TODO : replace with your correctness test command
   - label: "${{TPU_VERSION:-tpu6e}} Record correctness test result for {FEATURE_NAME}"
@@ -39,7 +39,7 @@ steps:
     depends_on: "${{TPU_VERSION:-tpu6e}}_record_{SANITIZED_FEATURE_NAME}_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: "{QUEUE}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "{QUEUE}")
     commands:
       - echo "placeholder"  # TODO : replace with your performance test command
   - label: "${{TPU_VERSION:-tpu6e}} Record performance test result for {FEATURE_NAME}"

--- a/.buildkite/pipeline_generation/parallelism_template.yml
+++ b/.buildkite/pipeline_generation/parallelism_template.yml
@@ -18,7 +18,7 @@ steps:
     key: "${{TPU_VERSION:-tpu6e}}_{SANITIZED_FEATURE_NAME}_CorrectnessTest_Single_Host"
     soft_fail: true
     agents:
-      queue: "{QUEUE}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "{QUEUE}")
     commands:
       - echo "placeholder" # TODO : replace with your single-host correctness test command
 
@@ -41,7 +41,7 @@ steps:
     depends_on: "${{TPU_VERSION:-tpu6e}}_record_{SANITIZED_FEATURE_NAME}_CorrectnessTest_Single_Host"
     soft_fail: true
     agents:
-      queue: "{QUEUE}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "{QUEUE}")
     commands:
       - echo "placeholder" # TODO : replace with your single-host performance test command
 
@@ -64,7 +64,7 @@ steps:
     key: "${{TPU_VERSION:-tpu6e}}_{SANITIZED_FEATURE_NAME}_CorrectnessTest_Multi_Host"
     soft_fail: true
     agents:
-      queue: "{QUEUE}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "{QUEUE}")
     commands:
       - echo "placeholder" # TODO : replace with your multi-host correctness test command
 
@@ -87,7 +87,7 @@ steps:
     depends_on: "${{TPU_VERSION:-tpu6e}}_record_{SANITIZED_FEATURE_NAME}_CorrectnessTest_Multi_Host"
     soft_fail: true
     agents:
-      queue: "{QUEUE}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "{QUEUE}")
     commands:
       - echo "placeholder" # TODO : replace with your multi-host performance test command
 

--- a/.buildkite/pipeline_generation/tpu_optimized_model_template.yml
+++ b/.buildkite/pipeline_generation/tpu_optimized_model_template.yml
@@ -17,7 +17,7 @@ steps:
     key: "${{TPU_VERSION:-tpu6e}}_{SANITIZED_MODEL_NAME}_{CATEGORY}_UnitTest"
     soft_fail: true
     agents:
-      queue: "{QUEUE}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "{QUEUE}")
     commands:
       - echo "placeholder"  # TODO: replace with your unit test command
   - label: "${{TPU_VERSION:-tpu6e}} Record unit test result for {MODEL_NAME}/{CATEGORY}"

--- a/.buildkite/pipeline_generation/vllm_native_model_template.yml
+++ b/.buildkite/pipeline_generation/vllm_native_model_template.yml
@@ -16,7 +16,7 @@ steps:
   - label: "${{TPU_VERSION:-tpu6e}} Unit tests for {MODEL_NAME}/{CATEGORY}"
     key: "${{TPU_VERSION:-tpu6e}}_{SANITIZED_MODEL_NAME}_{CATEGORY}_UnitTest"
     agents:
-      queue: "{QUEUE}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "{QUEUE}")
     soft_fail: true
     commands:
       - echo "placeholder"  # TODO: replace with your unit test command

--- a/.buildkite/quantization/FP4_W4A16.yml
+++ b/.buildkite/quantization/FP4_W4A16.yml
@@ -17,7 +17,7 @@ steps:
     key: "${TPU_VERSION:-tpu6e}_FP4_W4A16_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_FP4_W4A16_CorrectnessTest" "unverified"
@@ -40,7 +40,7 @@ steps:
     depends_on: "${TPU_VERSION:-tpu6e}_record_FP4_W4A16_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_FP4_W4A16_PerformanceTest" "unverified"

--- a/.buildkite/quantization/FP8_W8A16.yml
+++ b/.buildkite/quantization/FP8_W8A16.yml
@@ -17,7 +17,7 @@ steps:
     key: "${TPU_VERSION:-tpu6e}_FP8_W8A16_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_FP8_W8A16_CorrectnessTest" "unverified"
@@ -40,7 +40,7 @@ steps:
     depends_on: "${TPU_VERSION:-tpu6e}_record_FP8_W8A16_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_FP8_W8A16_PerformanceTest" "unverified"

--- a/.buildkite/quantization/FP8_W8A8.yml
+++ b/.buildkite/quantization/FP8_W8A8.yml
@@ -17,7 +17,7 @@ steps:
     key: "${TPU_VERSION:-tpu6e}_FP8_W8A8_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_FP8_W8A8_CorrectnessTest" "unverified"
@@ -40,7 +40,7 @@ steps:
     depends_on: "${TPU_VERSION:-tpu6e}_record_FP8_W8A8_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_FP8_W8A8_PerformanceTest" "unverified"

--- a/.buildkite/quantization/INT4_W4A16.yml
+++ b/.buildkite/quantization/INT4_W4A16.yml
@@ -17,7 +17,7 @@ steps:
     key: "${TPU_VERSION:-tpu6e}_INT4_W4A16_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_INT4_W4A16_CorrectnessTest" "unverified"
@@ -40,7 +40,7 @@ steps:
     depends_on: "${TPU_VERSION:-tpu6e}_record_INT4_W4A16_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_INT4_W4A16_PerformanceTest" "unverified"

--- a/.buildkite/quantization/INT8_W8A8.yml
+++ b/.buildkite/quantization/INT8_W8A8.yml
@@ -17,7 +17,7 @@ steps:
     key: "${TPU_VERSION:-tpu6e}_INT8_W8A8_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_INT8_W8A8_CorrectnessTest" "unverified"
@@ -40,7 +40,7 @@ steps:
     depends_on: "${TPU_VERSION:-tpu6e}_record_INT8_W8A8_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_INT8_W8A8_PerformanceTest" "unverified"

--- a/.buildkite/quantization/NVFP4_W4A16.yml
+++ b/.buildkite/quantization/NVFP4_W4A16.yml
@@ -17,7 +17,7 @@ steps:
     key: "${TPU_VERSION:-tpu6e}_NVFP4_W4A16_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_NVFP4_W4A16_CorrectnessTest" "unverified"
@@ -40,7 +40,7 @@ steps:
     depends_on: "${TPU_VERSION:-tpu6e}_record_NVFP4_W4A16_CorrectnessTest"
     soft_fail: true
     agents:
-      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+      queue: cpu  # TODO: replace with execution environment (e.g. "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}")
     commands:
       - |
         buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_NVFP4_W4A16_PerformanceTest" "unverified"


### PR DESCRIPTION
Currently there are lots of performance and accuracy steps in nightly steps is basically doing a simple thing like, set the result to unverifed because we bootstrapped the pipeline but havent started working on it.
Let's move that works to cpu instead and also update our onboarding template to make them on cpu with a TODO comment.

Signed-off-by: Ming Huang <mhhua@google.com>

# Description

Start with a short description of what the PR does and how this is a change from
the past.

The rest of the description includes relevant details and context, examples:
- why is this change being made,
- the problem being solved and any relevant context,
- why this is a good solution,
- some information about the specific implementation,
- shortcomings of the solution and possible future improvements.

If the change fixes a Github issue, please include a link, e.g.,:
FIXES: #123456

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
