### PR TITLE
[FIX] Enable processed_logprobs mode in test_processed_logprobs fixture

### DIFF
--- a/tests/runner/test_processed_logprobs.py
+++ b/tests/runner/test_processed_logprobs.py
@@ -49,6 +49,7 @@ def llm():
         model=MODEL_NAME,
         max_model_len=MAX_MODEL_LEN,
         max_num_seqs=MAX_NUM_SEQS,
+        logprobs_mode="processed_logprobs",
     )
     yield engine
     del engine


### PR DESCRIPTION
# Description

Enables logprobs_mode="processed_logprobs" in the test fixture of test_processed_logprobs.py to ensure returned logprobs are correctly scaled by temperature and pass the assertions.

Related Bug: b/525003422

# Tests

pytest tests/runner/test_processed_logprobs.py

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
