### PR TITLE
Refactor DFlash to support cross-request paged KV caching and dynamic batching

### DIFF
--- a/tests/models/jax/test_dflash.py
+++ b/tests/models/jax/test_dflash.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Unit tests for the DFlash speculative decoding draft model on JAX/TPU."""
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import jax
 import jax.numpy as jnp
@@ -22,9 +22,25 @@ from flax import nnx
 from jax.sharding import Mesh
 from transformers import Qwen3Config
 
+from tpu_inference.layers.common.attention_metadata import AttentionMetadata
 from tpu_inference.models.jax.dflash import (DFlashAttention,
                                              DFlashDecoderLayer,
                                              DFlashForCausalLM, DFlashMLP)
+
+
+def _make_attention_metadata(query_start_loc: list[int],
+                             total_tokens: int) -> AttentionMetadata:
+    """Helper to construct dummy AttentionMetadata."""
+    query_start_loc = np.asarray(query_start_loc, dtype=np.int32)
+    seq_lens = np.diff(query_start_loc)
+    return AttentionMetadata(
+        input_positions=jnp.arange(total_tokens, dtype=jnp.int32),
+        block_tables=jnp.zeros((max(1, total_tokens), ), dtype=jnp.int32),
+        seq_lens=jnp.asarray(seq_lens, dtype=jnp.int32),
+        query_start_loc=jnp.asarray(query_start_loc, dtype=jnp.int32),
+        request_distribution=jnp.asarray([0, 0, len(seq_lens)],
+                                         dtype=jnp.int32),
+    )
 
 
 @pytest.fixture(scope="module")
@@ -95,35 +111,44 @@ class MockVllmConfig:
 
         class MockModelConfig:
 
-            def __init__(self):
+            def __init__(self, hf_config):
+                self.hf_config = hf_config
                 self.seed = 42
                 self.model = "mock-model"
+
+            def get_vocab_size(self):
+                return self.hf_config.vocab_size
+
+            def get_hidden_size(self):
+                return self.hf_config.hidden_size
 
         class MockLoadConfig:
 
             def __init__(self):
                 self.download_dir = None
 
+        class MockParallelConfig:
+
+            def __init__(self):
+                self.tensor_parallel_size = 1
+
         self.speculative_config = MockSpeculativeConfig(hf_config)
-        self.model_config = MockModelConfig()
+        self.model_config = MockModelConfig(hf_config)
         self.load_config = MockLoadConfig()
+        self.parallel_config = MockParallelConfig()
 
 
-def dummy_ragged_paged_attention(queries, keys, values, kv_cache, kv_lens,
-                                 page_indices, cu_q_lens, distribution,
-                                 **kwargs):
-    """Dummy replacement for ragged_paged_attention to allow CPU-only unit testing."""
-    attn_out = jnp.zeros(
-        (queries.shape[0], queries.shape[1], queries.shape[2]),
-        dtype=queries.dtype)
-    return attn_out, kv_cache
+def dummy_attention(kv_cache, q, k, v, *args, **kwargs):
+    """Dummy replacement for attention to allow CPU-only unit testing."""
+    del k, v, args, kwargs
+    return kv_cache, q
 
 
 @patch(
-    "tpu_inference.models.jax.dflash.ragged_paged_attention",
-    side_effect=dummy_ragged_paged_attention,
+    "tpu_inference.models.jax.dflash.attention",
+    side_effect=dummy_attention,
 )
-def test_dflash_attention(mock_rpa, hf_config, mesh):
+def test_dflash_attention(mock_attn, hf_config, mesh):
     """Verifies that DFlashAttention runs correctly and writes to the KV cache."""
     rng = nnx.Rngs(42)
     dtype = jnp.bfloat16
@@ -142,14 +167,7 @@ def test_dflash_attention(mock_rpa, hf_config, mesh):
     target_query_start_loc = jnp.array([0, T_padded], dtype=jnp.int32)
     target_positions = jnp.arange(T_padded, dtype=jnp.int32)
     # Mock attention metadata
-    attention_metadata = MagicMock()
-    attention_metadata.seq_lens = jnp.array([10], dtype=jnp.int32)
-    attention_metadata.block_tables = jnp.array([[0, 1]], dtype=jnp.int32)
-    attention_metadata.query_start_loc = jnp.array([0, T_noise],
-                                                   dtype=jnp.int32)
-    attention_metadata.input_positions = jnp.arange(T_noise, dtype=jnp.int32)
-    attention_metadata.request_distribution = jnp.array([0, 0, 1],
-                                                        dtype=jnp.int32)
+    attention_metadata = _make_attention_metadata([0, T_noise], T_noise)
     # kv_cache shape: [total_num_pages, page_size, num_kv_heads_x2 // kv_packing, kv_packing, head_dim]
     kv_cache = jnp.zeros((10, 16, 4, 1, attn.head_dim), dtype=dtype)
     with jax.set_mesh(mesh):
@@ -163,7 +181,7 @@ def test_dflash_attention(mock_rpa, hf_config, mesh):
         )
     assert output.shape == (T_noise, hidden_size)
     assert new_kv_cache.shape == kv_cache.shape
-    assert mock_rpa.call_count == 2  # Step 1 (target) and Step 2 (noise)
+    assert mock_attn.call_count == 2  # Step 1 (target) and Step 2 (noise)
 
 
 def test_dflash_mlp(hf_config, mesh):
@@ -179,10 +197,10 @@ def test_dflash_mlp(hf_config, mesh):
 
 
 @patch(
-    "tpu_inference.models.jax.dflash.ragged_paged_attention",
-    side_effect=dummy_ragged_paged_attention,
+    "tpu_inference.models.jax.dflash.attention",
+    side_effect=dummy_attention,
 )
-def test_dflash_decoder_layer(mock_rpa, hf_config, mesh):
+def test_dflash_decoder_layer(mock_attn, hf_config, mesh):
     """Verifies that the DFlashDecoderLayer forward pass completes successfully."""
     rng = nnx.Rngs(42)
     dtype = jnp.bfloat16
@@ -200,14 +218,7 @@ def test_dflash_decoder_layer(mock_rpa, hf_config, mesh):
     target_hidden = jnp.ones((T_padded, hidden_size), dtype=dtype)
     target_query_start_loc = jnp.array([0, T_padded], dtype=jnp.int32)
     target_positions = jnp.arange(T_padded, dtype=jnp.int32)
-    attention_metadata = MagicMock()
-    attention_metadata.seq_lens = jnp.array([10], dtype=jnp.int32)
-    attention_metadata.block_tables = jnp.array([[0, 1]], dtype=jnp.int32)
-    attention_metadata.query_start_loc = jnp.array([0, T_noise],
-                                                   dtype=jnp.int32)
-    attention_metadata.input_positions = jnp.arange(T_noise, dtype=jnp.int32)
-    attention_metadata.request_distribution = jnp.array([0, 0, 1],
-                                                        dtype=jnp.int32)
+    attention_metadata = _make_attention_metadata([0, T_noise], T_noise)
     kv_cache = jnp.zeros((10, 16, 4, 1, layer.self_attn.head_dim), dtype=dtype)
     with jax.set_mesh(mesh):
         output, new_kv_cache = layer(
@@ -220,14 +231,14 @@ def test_dflash_decoder_layer(mock_rpa, hf_config, mesh):
         )
     assert output.shape == (T_noise, hidden_size)
     assert new_kv_cache.shape == kv_cache.shape
-    assert mock_rpa.call_count == 2
+    assert mock_attn.call_count == 2
 
 
 @patch(
-    "tpu_inference.models.jax.dflash.ragged_paged_attention",
-    side_effect=dummy_ragged_paged_attention,
+    "tpu_inference.models.jax.dflash.attention",
+    side_effect=dummy_attention,
 )
-def test_dflash_for_causal_lm(mock_rpa, hf_config, mesh):
+def test_dflash_for_causal_lm(mock_attn, hf_config, mesh):
     """Validates the full draft model's forward pass, logits calculation, and state projection."""
     vllm_config = MockVllmConfig(hf_config)
     rng_key = jax.random.PRNGKey(0)
@@ -252,21 +263,14 @@ def test_dflash_for_causal_lm(mock_rpa, hf_config, mesh):
     target_positions = jnp.arange(T_padded, dtype=jnp.int32)
     target_hidden_states = (ctx_hidden, target_query_start_loc,
                             target_positions)
-    attention_metadata = MagicMock()
-    attention_metadata.seq_lens = jnp.array([10], dtype=jnp.int32)
-    attention_metadata.block_tables = jnp.array([[0, 1]], dtype=jnp.int32)
-    attention_metadata.query_start_loc = jnp.array([0, T_noise],
-                                                   dtype=jnp.int32)
-    attention_metadata.input_positions = jnp.arange(T_noise, dtype=jnp.int32)
-    attention_metadata.request_distribution = jnp.array([0, 0, 1],
-                                                        dtype=jnp.int32)
+    attention_metadata = _make_attention_metadata([0, T_noise], T_noise)
     # List of kv_cache tensors, one per layer
     kv_caches = [
         jnp.zeros((10, 16, 4, 1, head_dim), dtype=jnp.bfloat16)
         for _ in range(hf_config.num_hidden_layers)
     ]
     with jax.set_mesh(mesh):
-        new_kv_caches, hidden_states, extra = model(
+        new_kv_caches, hidden_states, extra, _ = model(
             kv_caches=kv_caches,
             input_ids=input_ids,
             target_hidden_states=target_hidden_states,

--- a/tests/models/jax/test_dflash.py
+++ b/tests/models/jax/test_dflash.py
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Unit tests for the DFlash speculative decoding draft model on JAX/TPU."""
-
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import jax
 import jax.numpy as jnp
@@ -33,12 +32,10 @@ def mesh():
     """Creates a mesh with 1 device for testing."""
     if not jax.devices():
         pytest.skip("No JAX devices available for mesh creation.")
-
     devices = np.array(jax.local_devices()[:1])
     num_devices = len(devices)
     assert num_devices == 1
     device_mesh = devices.reshape((num_devices, 1, 1, 1))
-
     with Mesh(device_mesh,
               axis_names=('data', 'attn_dp', 'expert', 'model')) as m:
         yield m
@@ -64,8 +61,6 @@ def hf_config():
             "target_layer_ids": [0, 1],
         },
     )
-    # Explicitly set rope_theta and rope_scaling on the config object to satisfy
-    # direct attribute accesses in dflash.py.
     config.rope_theta = 10000.0
     config.rope_scaling = None
     return config
@@ -114,30 +109,24 @@ class MockVllmConfig:
         self.load_config = MockLoadConfig()
 
 
-def dummy_flash_attention(
-    q,
-    k,
-    v,
-    segment_ids=None,
-    causal=False,
-    sm_scale=1.0,
-    block_sizes=None,
-    vmem_limit_bytes=None,
-):
-    """Dummy replacement for flash_attention to allow CPU-only unit testing."""
-    del k, v, segment_ids, causal, sm_scale, block_sizes, vmem_limit_bytes
-    return jnp.zeros_like(q)
+def dummy_ragged_paged_attention(queries, keys, values, kv_cache, kv_lens,
+                                 page_indices, cu_q_lens, distribution,
+                                 **kwargs):
+    """Dummy replacement for ragged_paged_attention to allow CPU-only unit testing."""
+    attn_out = jnp.zeros(
+        (queries.shape[0], queries.shape[1], queries.shape[2]),
+        dtype=queries.dtype)
+    return attn_out, kv_cache
 
 
 @patch(
-    "tpu_inference.models.jax.dflash.flash_attention",
-    side_effect=dummy_flash_attention,
+    "tpu_inference.models.jax.dflash.ragged_paged_attention",
+    side_effect=dummy_ragged_paged_attention,
 )
-def test_dflash_attention(mock_fa, hf_config, mesh):
+def test_dflash_attention(mock_rpa, hf_config, mesh):
     """Verifies that DFlashAttention runs correctly and writes to the KV cache."""
     rng = nnx.Rngs(42)
     dtype = jnp.bfloat16
-
     with jax.set_mesh(mesh):
         attn = DFlashAttention(
             config=hf_config,
@@ -145,65 +134,58 @@ def test_dflash_attention(mock_fa, hf_config, mesh):
             rng=rng,
             mesh=mesh,
         )
-
     T_noise = 4
     T_padded = 8
     hidden_size = hf_config.hidden_size
-    num_heads = attn.num_heads
-    head_dim = attn.head_dim
-    max_kv_len = 32
-
     x_noise = jnp.ones((T_noise, hidden_size), dtype=dtype)
     target_hidden = jnp.ones((T_padded, hidden_size), dtype=dtype)
-    noise_positions = jnp.arange(T_noise, dtype=jnp.int32)
-    ctx_positions = jnp.arange(T_padded, dtype=jnp.int32)
-    kv_cache_k = jnp.zeros((1, num_heads, max_kv_len, head_dim), dtype=dtype)
-    kv_cache_v = jnp.zeros((1, num_heads, max_kv_len, head_dim), dtype=dtype)
-    cache_len = jnp.array(0, dtype=jnp.int32)
-    actual_ctx_count = jnp.array(6, dtype=jnp.int32)
-
+    target_query_start_loc = jnp.array([0, T_padded], dtype=jnp.int32)
+    target_positions = jnp.arange(T_padded, dtype=jnp.int32)
+    # Mock attention metadata
+    attention_metadata = MagicMock()
+    attention_metadata.seq_lens = jnp.array([10], dtype=jnp.int32)
+    attention_metadata.block_tables = jnp.array([[0, 1]], dtype=jnp.int32)
+    attention_metadata.query_start_loc = jnp.array([0, T_noise],
+                                                   dtype=jnp.int32)
+    attention_metadata.input_positions = jnp.arange(T_noise, dtype=jnp.int32)
+    attention_metadata.request_distribution = jnp.array([0, 0, 1],
+                                                        dtype=jnp.int32)
+    # kv_cache shape: [total_num_pages, page_size, num_kv_heads_x2 // kv_packing, kv_packing, head_dim]
+    kv_cache = jnp.zeros((10, 16, 4, 1, attn.head_dim), dtype=dtype)
     with jax.set_mesh(mesh):
-        output, new_k, new_v = attn(
+        output, new_kv_cache = attn(
             x_noise=x_noise,
             target_hidden=target_hidden,
-            noise_positions=noise_positions,
-            ctx_positions=ctx_positions,
-            kv_cache_k=kv_cache_k,
-            kv_cache_v=kv_cache_v,
-            cache_len=cache_len,
-            actual_ctx_count=actual_ctx_count,
+            attention_metadata=attention_metadata,
+            target_query_start_loc=target_query_start_loc,
+            target_positions=target_positions,
+            kv_cache=kv_cache,
         )
-
     assert output.shape == (T_noise, hidden_size)
-    assert new_k.shape == (1, num_heads, max_kv_len, head_dim)
-    assert new_v.shape == (1, num_heads, max_kv_len, head_dim)
-    mock_fa.assert_called_once()
+    assert new_kv_cache.shape == kv_cache.shape
+    assert mock_rpa.call_count == 2  # Step 1 (target) and Step 2 (noise)
 
 
 def test_dflash_mlp(hf_config, mesh):
     """Tests the DFlashMLP layer's output shape and forward pass."""
     rng = nnx.Rngs(42)
     dtype = jnp.bfloat16
-
     with jax.set_mesh(mesh):
         mlp = DFlashMLP(config=hf_config, dtype=dtype, rng=rng)
-
         T = 5
         x = jnp.ones((T, hf_config.hidden_size), dtype=dtype)
         output = mlp(x)
-
     assert output.shape == (T, hf_config.hidden_size)
 
 
 @patch(
-    "tpu_inference.models.jax.dflash.flash_attention",
-    side_effect=dummy_flash_attention,
+    "tpu_inference.models.jax.dflash.ragged_paged_attention",
+    side_effect=dummy_ragged_paged_attention,
 )
-def test_dflash_decoder_layer(mock_fa, hf_config, mesh):
+def test_dflash_decoder_layer(mock_rpa, hf_config, mesh):
     """Verifies that the DFlashDecoderLayer forward pass completes successfully."""
     rng = nnx.Rngs(42)
     dtype = jnp.bfloat16
-
     with jax.set_mesh(mesh):
         layer = DFlashDecoderLayer(
             config=hf_config,
@@ -211,100 +193,91 @@ def test_dflash_decoder_layer(mock_fa, hf_config, mesh):
             rng=rng,
             mesh=mesh,
         )
-
     T_noise = 4
     T_padded = 8
     hidden_size = hf_config.hidden_size
-    num_heads = layer.self_attn.num_heads
-    head_dim = layer.self_attn.head_dim
-    max_kv_len = 32
-
     x_noise = jnp.ones((T_noise, hidden_size), dtype=dtype)
     target_hidden = jnp.ones((T_padded, hidden_size), dtype=dtype)
-    noise_positions = jnp.arange(T_noise, dtype=jnp.int32)
-    ctx_positions = jnp.arange(T_padded, dtype=jnp.int32)
-    kv_cache_k = jnp.zeros((1, num_heads, max_kv_len, head_dim), dtype=dtype)
-    kv_cache_v = jnp.zeros((1, num_heads, max_kv_len, head_dim), dtype=dtype)
-    cache_len = jnp.array(0, dtype=jnp.int32)
-    actual_ctx_count = jnp.array(6, dtype=jnp.int32)
-
+    target_query_start_loc = jnp.array([0, T_padded], dtype=jnp.int32)
+    target_positions = jnp.arange(T_padded, dtype=jnp.int32)
+    attention_metadata = MagicMock()
+    attention_metadata.seq_lens = jnp.array([10], dtype=jnp.int32)
+    attention_metadata.block_tables = jnp.array([[0, 1]], dtype=jnp.int32)
+    attention_metadata.query_start_loc = jnp.array([0, T_noise],
+                                                   dtype=jnp.int32)
+    attention_metadata.input_positions = jnp.arange(T_noise, dtype=jnp.int32)
+    attention_metadata.request_distribution = jnp.array([0, 0, 1],
+                                                        dtype=jnp.int32)
+    kv_cache = jnp.zeros((10, 16, 4, 1, layer.self_attn.head_dim), dtype=dtype)
     with jax.set_mesh(mesh):
-        output, new_k, new_v = layer(
+        output, new_kv_cache = layer(
             x=x_noise,
             target_hidden=target_hidden,
-            noise_positions=noise_positions,
-            ctx_positions=ctx_positions,
-            kv_cache_k=kv_cache_k,
-            kv_cache_v=kv_cache_v,
-            cache_len=cache_len,
-            actual_ctx_count=actual_ctx_count,
+            attention_metadata=attention_metadata,
+            target_query_start_loc=target_query_start_loc,
+            target_positions=target_positions,
+            kv_cache=kv_cache,
         )
-
     assert output.shape == (T_noise, hidden_size)
-    assert new_k.shape == (1, num_heads, max_kv_len, head_dim)
-    assert new_v.shape == (1, num_heads, max_kv_len, head_dim)
-    mock_fa.assert_called_once()
+    assert new_kv_cache.shape == kv_cache.shape
+    assert mock_rpa.call_count == 2
 
 
 @patch(
-    "tpu_inference.models.jax.dflash.flash_attention",
-    side_effect=dummy_flash_attention,
+    "tpu_inference.models.jax.dflash.ragged_paged_attention",
+    side_effect=dummy_ragged_paged_attention,
 )
-def test_dflash_for_causal_lm(mock_fa, hf_config, mesh):
+def test_dflash_for_causal_lm(mock_rpa, hf_config, mesh):
     """Validates the full draft model's forward pass, logits calculation, and state projection."""
     vllm_config = MockVllmConfig(hf_config)
     rng_key = jax.random.PRNGKey(0)
-
     with jax.set_mesh(mesh):
         model = DFlashForCausalLM(
             vllm_config=vllm_config,
             rng_key=rng_key,
             mesh=mesh,
         )
-
-    # Check structure
     assert model.model.embed_tokens.embedding.shape == (
         hf_config.vocab_size,
         hf_config.hidden_size,
     )
     assert len(model.model.layers) == hf_config.num_hidden_layers
-
-    # Run forward pass
     T_noise = 3
     T_padded = 6
     hidden_size = hf_config.hidden_size
-    num_heads = model.model.layers[0].self_attn.num_heads
     head_dim = model.model.layers[0].self_attn.head_dim
-    max_kv_len = 16
-
     input_ids = jnp.ones((T_noise, ), dtype=jnp.int32)
     ctx_hidden = jnp.ones((T_padded, hidden_size), dtype=jnp.bfloat16)
-    cache_len_arr = jnp.array([2], dtype=jnp.int32)
-    actual_ctx_count_arr = jnp.array([4], dtype=jnp.int32)
-
-    target_hidden_states = (ctx_hidden, cache_len_arr, actual_ctx_count_arr)
-
+    target_query_start_loc = jnp.array([0, T_padded], dtype=jnp.int32)
+    target_positions = jnp.arange(T_padded, dtype=jnp.int32)
+    target_hidden_states = (ctx_hidden, target_query_start_loc,
+                            target_positions)
+    attention_metadata = MagicMock()
+    attention_metadata.seq_lens = jnp.array([10], dtype=jnp.int32)
+    attention_metadata.block_tables = jnp.array([[0, 1]], dtype=jnp.int32)
+    attention_metadata.query_start_loc = jnp.array([0, T_noise],
+                                                   dtype=jnp.int32)
+    attention_metadata.input_positions = jnp.arange(T_noise, dtype=jnp.int32)
+    attention_metadata.request_distribution = jnp.array([0, 0, 1],
+                                                        dtype=jnp.int32)
+    # List of kv_cache tensors, one per layer
     kv_caches = [
-        jnp.zeros((1, num_heads, max_kv_len, head_dim), dtype=jnp.bfloat16)
-        for _ in range(2 * hf_config.num_hidden_layers)
+        jnp.zeros((10, 16, 4, 1, head_dim), dtype=jnp.bfloat16)
+        for _ in range(hf_config.num_hidden_layers)
     ]
-
     with jax.set_mesh(mesh):
         new_kv_caches, hidden_states, extra = model(
             kv_caches=kv_caches,
             input_ids=input_ids,
             target_hidden_states=target_hidden_states,
-            attention_metadata=None,
+            attention_metadata=attention_metadata,
         )
-
-    assert len(new_kv_caches) == 2 * hf_config.num_hidden_layers
+    assert len(new_kv_caches) == hf_config.num_hidden_layers
     assert hidden_states.shape == (T_noise, hidden_size)
     assert extra == []
-
     # Test compute_logits
     logits = model.compute_logits(hidden_states)
     assert logits.shape == (T_noise, hf_config.vocab_size)
-
     # Test combine_hidden_states
     combined_input = jnp.ones(
         (
@@ -322,14 +295,12 @@ def test_dflash_weight_loader(hf_config, mesh):
     """Verifies that the DFlashWeightLoader maps and delegates weight loading correctly."""
     vllm_config = MockVllmConfig(hf_config)
     rng_key = jax.random.PRNGKey(0)
-
     with jax.set_mesh(mesh):
         model = DFlashForCausalLM(
             vllm_config=vllm_config,
             rng_key=rng_key,
             mesh=mesh,
         )
-
     with patch(
             "tpu_inference.models.jax.dflash.load_hf_weights"
     ) as mock_load_hf, patch(
@@ -339,8 +310,6 @@ def test_dflash_weight_loader(hf_config, mesh):
             model.load_weights(rng_key)
         mock_load_hf.assert_called_once()
         mock_generator.assert_called_once()
-
-        # Verify loader config propagation
         called_args, called_kwargs = mock_load_hf.call_args
         assert called_kwargs["vllm_config"] == vllm_config
         assert called_kwargs["model"] == model

--- a/tests/models/jax/test_qwen3_dflash.py
+++ b/tests/models/jax/test_qwen3_dflash.py
@@ -174,12 +174,6 @@ def dummy_attention(kv_cache, q, k, v, *args, **kwargs):
     return kv_cache, q
 
 
-def dummy_dflash_concat_attention(q, *args, **kwargs):
-    """Dummy replacement for dflash_concat_attention."""
-    del args, kwargs
-    return q
-
-
 def _make_attention_metadata(query_start_loc: list[int]) -> AttentionMetadata:
     """Helper to construct dummy AttentionMetadata."""
     query_start_loc = np.asarray(query_start_loc, dtype=np.int32)
@@ -198,15 +192,10 @@ def _make_attention_metadata(query_start_loc: list[int]) -> AttentionMetadata:
 # ----- Component tests -----
 @pytest.mark.parametrize("dflash_impl", ["concat_dense", "additive_legacy"])
 @patch(
-    "tpu_inference.models.jax.qwen3_dflash.dflash_concat_attention",
-    side_effect=dummy_dflash_concat_attention,
-)
-@patch(
     "tpu_inference.models.jax.qwen3_dflash.attention",
     side_effect=dummy_attention,
 )
-def test_qwen3_dflash_attention(mock_attn, mock_concat, dflash_impl,
-                                hf_configs, mesh):
+def test_qwen3_dflash_attention(mock_attn, dflash_impl, hf_configs, mesh):
     """Verifies Qwen3DFlashAttention forward pass under different attention implementations."""
     draft_cfg, _ = hf_configs
     rng = nnx.Rngs(42)
@@ -241,28 +230,24 @@ def test_qwen3_dflash_attention(mock_attn, mock_concat, dflash_impl,
             hidden_states=hidden_states,
             target_hidden_states=target_hidden,
             attention_metadata=attention_metadata,
+            target_query_start_loc=attention_metadata.query_start_loc,
+            target_positions=attention_metadata.input_positions,
         )
 
     assert output.shape == (T, hidden_size)
     assert new_kv_cache.shape == (T, num_heads, max_kv_len, head_dim)
 
     if dflash_impl == "concat_dense":
-        mock_concat.assert_called_once()
-        mock_attn.assert_called_once()
+        assert mock_attn.call_count == 2
     else:
-        mock_concat.assert_not_called()
-        mock_attn.assert_called_once()
+        assert mock_attn.call_count == 1
 
 
-@patch(
-    "tpu_inference.models.jax.qwen3_dflash.dflash_concat_attention",
-    side_effect=dummy_dflash_concat_attention,
-)
 @patch(
     "tpu_inference.models.jax.qwen3_dflash.attention",
     side_effect=dummy_attention,
 )
-def test_qwen3_dflash_decoder_layer(mock_attn, mock_concat, hf_configs, mesh):
+def test_qwen3_dflash_decoder_layer(mock_attn, hf_configs, mesh):
     """Verifies Qwen3DFlashDecoderLayer integrates attention and MLP blocks."""
     draft_cfg, _ = hf_configs
     rng = nnx.Rngs(42)
@@ -292,26 +277,25 @@ def test_qwen3_dflash_decoder_layer(mock_attn, mock_concat, hf_configs, mesh):
     attention_metadata = _make_attention_metadata([0, T])
 
     with jax.set_mesh(mesh):
-        new_kv_cache, output = layer(
+        new_kv_cache, output, extra = layer(
             kv_cache=kv_cache,
             hidden_states=hidden_states,
             target_hidden_states=target_hidden,
             attention_metadata=attention_metadata,
+            target_query_start_loc=attention_metadata.query_start_loc,
+            target_positions=attention_metadata.input_positions,
         )
 
     assert output.shape == (T, hidden_size)
     assert new_kv_cache.shape == (T, num_heads, max_kv_len, head_dim)
+    assert mock_attn.call_count == 2
 
 
-@patch(
-    "tpu_inference.models.jax.qwen3_dflash.dflash_concat_attention",
-    side_effect=dummy_dflash_concat_attention,
-)
 @patch(
     "tpu_inference.models.jax.qwen3_dflash.attention",
     side_effect=dummy_attention,
 )
-def test_qwen3_dflash_for_causal_lm(mock_attn, mock_concat, hf_configs, mesh):
+def test_qwen3_dflash_for_causal_lm(mock_attn, hf_configs, mesh):
     """Validates full draft model's forward pass, logits calculation, and combined projection."""
     draft_cfg, target_cfg = hf_configs
     vllm_config = MockVllmConfig(draft_cfg, target_cfg)
@@ -348,17 +332,20 @@ def test_qwen3_dflash_for_causal_lm(mock_attn, mock_concat, hf_configs, mesh):
     ]
 
     with jax.set_mesh(mesh):
-        new_kv_caches, hidden_states, extra = model(
+        new_kv_caches, hidden_states, extra, _ = model(
             kv_caches=kv_caches,
             input_ids=input_ids,
             target_hidden_states=target_hidden,
             attention_metadata=attention_metadata,
+            target_query_start_loc=attention_metadata.query_start_loc,
+            target_positions=attention_metadata.input_positions,
         )
 
     assert len(new_kv_caches) == draft_cfg.num_hidden_layers
     assert hidden_states.shape == (T, hidden_size)
-    assert len(extra) == 1
+    assert len(extra) == 2
     assert extra[0].shape == (T, hidden_size)
+    assert mock_attn.call_count == 4
 
     # Test compute_logits
     logits = model.compute_logits(hidden_states)

--- a/tests/models/jax/test_qwen3_dflash_attention.py
+++ b/tests/models/jax/test_qwen3_dflash_attention.py
@@ -62,6 +62,8 @@ def _build_stub_attention(impl: str) -> Qwen3DFlashAttention:
     _set("v_proj", lambda x: x)
     _set("o_proj", lambda x: x)
     _set("head_dim_original", 1)
+    _set("head_dim", 1)
+    _set("num_heads", 1)
     _set("rope_theta", 10000.0)
     _set("rope_scaling", None)
     _set("mesh", object())
@@ -89,6 +91,7 @@ def test_dflash_concat_attention_matches_concat_reference():
         v_ctx,
         v_noise,
         md,
+        md.query_start_loc,
         max_query_len=2,
         sm_scale=sm_scale,
     )
@@ -129,6 +132,7 @@ def test_dflash_concat_attention_repeats_kv_heads_for_gqa():
         v_ctx,
         v_noise,
         md,
+        md.query_start_loc,
         max_query_len=2,
         sm_scale=1.0,
     )
@@ -156,28 +160,7 @@ def test_qwen3_dflash_attention_concat_impl(monkeypatch):
     target_hidden_states = jnp.array([[[3.0]], [[4.0]]], dtype=jnp.float32)
     kv_cache = jnp.array([0.0], dtype=jnp.float32)
 
-    concat_calls = {}
-    cache_update_calls = {}
-
-    def fake_concat_attention(
-        q,
-        k_ctx,
-        k_noise,
-        v_ctx,
-        v_noise,
-        _md,
-        *,
-        max_query_len,
-        sm_scale,
-    ):
-        concat_calls["q"] = np.asarray(q)
-        concat_calls["k_ctx"] = np.asarray(k_ctx)
-        concat_calls["k_noise"] = np.asarray(k_noise)
-        concat_calls["v_ctx"] = np.asarray(v_ctx)
-        concat_calls["v_noise"] = np.asarray(v_noise)
-        concat_calls["max_query_len"] = max_query_len
-        concat_calls["sm_scale"] = sm_scale
-        return jnp.full_like(q, 7.0)
+    attention_calls = []
 
     def fake_attention(
         kv_cache,
@@ -189,16 +172,25 @@ def test_qwen3_dflash_attention_concat_impl(monkeypatch):
         _head_dim_original,
         **_kwargs,
     ):
-        cache_update_calls["q"] = np.asarray(q)
-        cache_update_calls["k"] = np.asarray(k)
-        cache_update_calls["v"] = np.asarray(v)
-        return kv_cache + 1.0, jnp.full_like(q, -5.0)
+        attention_calls.append({
+            "q":
+            np.asarray(q),
+            "k":
+            np.asarray(k),
+            "v":
+            np.asarray(v),
+            "update_kv_cache":
+            _kwargs.get("update_kv_cache", True),
+            "use_causal_mask":
+            _kwargs.get("use_causal_mask", True),
+        })
+        if len(attention_calls) == 1:
+            return kv_cache + 1.0, jnp.full_like(q, -5.0)
+        else:
+            return kv_cache + 2.0, jnp.full_like(q, 7.0)
 
     monkeypatch.setattr("tpu_inference.models.jax.qwen3_dflash.apply_rope",
                         lambda x, *_args, **_kwargs: x)
-    monkeypatch.setattr(
-        "tpu_inference.models.jax.qwen3_dflash.dflash_concat_attention",
-        fake_concat_attention)
     monkeypatch.setattr("tpu_inference.models.jax.qwen3_dflash.attention",
                         fake_attention)
 
@@ -208,19 +200,33 @@ def test_qwen3_dflash_attention_concat_impl(monkeypatch):
         hidden_states=hidden_states,
         target_hidden_states=target_hidden_states,
         attention_metadata=md,
+        target_query_start_loc=md.query_start_loc,
+        target_positions=jnp.array([1, 2], dtype=jnp.int32),
     )
 
     np.testing.assert_allclose(np.asarray(output), np.full((2, 1, 1), 7.0))
-    np.testing.assert_allclose(np.asarray(new_kv_cache), np.array([1.0]))
-    np.testing.assert_allclose(concat_calls["k_ctx"],
+    np.testing.assert_allclose(np.asarray(new_kv_cache), np.array([3.0]))
+    assert len(attention_calls) == 2
+
+    # Step 1 Target write assertions
+    np.testing.assert_allclose(attention_calls[0]["q"],
+                               np.zeros_like(hidden_states))
+    np.testing.assert_allclose(attention_calls[0]["k"],
                                np.asarray(target_hidden_states))
-    np.testing.assert_allclose(concat_calls["k_noise"],
+    np.testing.assert_allclose(attention_calls[0]["v"],
+                               np.asarray(target_hidden_states))
+    assert attention_calls[0]["update_kv_cache"] is True
+    assert attention_calls[0]["use_causal_mask"] is True
+
+    # Step 2 Noise attention assertions
+    np.testing.assert_allclose(attention_calls[1]["q"],
                                np.asarray(hidden_states))
-    np.testing.assert_allclose(cache_update_calls["k"],
+    np.testing.assert_allclose(attention_calls[1]["k"],
                                np.asarray(hidden_states))
-    np.testing.assert_allclose(cache_update_calls["v"],
+    np.testing.assert_allclose(attention_calls[1]["v"],
                                np.asarray(hidden_states))
-    assert concat_calls["max_query_len"] == 2
+    assert attention_calls[1]["update_kv_cache"] is True
+    assert attention_calls[1]["use_causal_mask"] is False
 
 
 def test_qwen3_dflash_attention_additive_legacy_impl(monkeypatch):
@@ -251,9 +257,6 @@ def test_qwen3_dflash_attention_additive_legacy_impl(monkeypatch):
 
     monkeypatch.setattr("tpu_inference.models.jax.qwen3_dflash.apply_rope",
                         lambda x, *_args, **_kwargs: x)
-    monkeypatch.setattr(
-        "tpu_inference.models.jax.qwen3_dflash.dflash_concat_attention",
-        fail_concat)
     monkeypatch.setattr("tpu_inference.models.jax.qwen3_dflash.attention",
                         fake_attention)
 
@@ -263,6 +266,8 @@ def test_qwen3_dflash_attention_additive_legacy_impl(monkeypatch):
         hidden_states=hidden_states,
         target_hidden_states=target_hidden_states,
         attention_metadata=md,
+        target_query_start_loc=md.query_start_loc,
+        target_positions=jnp.array([1, 2], dtype=jnp.int32),
     )
 
     expected_k = np.asarray(target_hidden_states + hidden_states)
@@ -288,4 +293,6 @@ def test_qwen3_dflash_attention_unknown_impl_raises(monkeypatch):
             hidden_states=hidden_states,
             target_hidden_states=target_hidden_states,
             attention_metadata=md,
+            target_query_start_loc=md.query_start_loc,
+            target_positions=jnp.array([1, 2], dtype=jnp.int32),
         )

--- a/tests/spec_decode/test_dflash.py
+++ b/tests/spec_decode/test_dflash.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 """Unit tests for the JAX DFlash speculative decoding proposer."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import jax
 import jax.numpy as jnp
@@ -220,4 +220,3 @@ def test_build_noise_block_batched():
     np.testing.assert_array_equal(
         np.asarray(noise_positions),
         np.array([10, 11, 12, 20, 21, 22], dtype=np.int32))
-

--- a/tests/spec_decode/test_dflash.py
+++ b/tests/spec_decode/test_dflash.py
@@ -111,39 +111,44 @@ def test_sample_block_draft_tokens_uses_target_model_logits():
     proposer = object.__new__(DFlashProposer)
     proposer.mesh = _make_single_device_mesh()
     proposer.num_speculative_tokens = 2
+    proposer.block_size = proposer.num_speculative_tokens + 1
 
     call_record = {}
     target_state = jnp.array(0)
 
     def fake_compute_logits_fn(state, hidden_states, lora_metadata):
         call_record["shape"] = hidden_states.shape
-        return jnp.array([[0.0, 2.0, 1.0], [4.0, 1.0, 0.0]], dtype=jnp.float32)
+        return jnp.array([[[0.0, 2.0, 1.0], [4.0, 1.0, 0.0]]],
+                         dtype=jnp.float32)
 
     proposer.compute_logits_fn = fake_compute_logits_fn
 
+    # hidden_states layout: [context_token, draft_token_0, draft_token_1, ...]
+    # _sample_block_draft_tokens slices [:, 1:1+num_speculative_tokens, :]
     hidden_states = jnp.ones((3, 8), dtype=jnp.bfloat16)
     draft_token_ids = proposer._sample_block_draft_tokens(
         target_state, hidden_states)
 
     np.testing.assert_array_equal(np.asarray(draft_token_ids),
-                                  np.array([1, 0], dtype=np.int32))
-    assert call_record["shape"] == (2, 8)
+                                  np.array([[1, 0]], dtype=np.int32))
+    assert call_record["shape"] == (1, 2, 8)
 
 
 def test_sample_block_draft_tokens_returns_1d_int_ids():
     proposer = object.__new__(DFlashProposer)
     proposer.mesh = _make_single_device_mesh()
     proposer.num_speculative_tokens = 2
+    proposer.block_size = proposer.num_speculative_tokens + 1
 
     proposer.compute_logits_fn = lambda _state, _hidden, _lora: jnp.array(
-        [[1.0, 0.0], [0.0, 1.0]], dtype=jnp.float32)
+        [[[1.0, 0.0], [0.0, 1.0]]], dtype=jnp.float32)
 
     hidden_states = jnp.ones((3, 4), dtype=jnp.bfloat16)
     draft_token_ids = proposer._sample_block_draft_tokens(
         jnp.array(0), hidden_states)
 
-    assert draft_token_ids.ndim == 1
-    assert draft_token_ids.shape == (2, )
+    assert draft_token_ids.ndim == 2
+    assert draft_token_ids.shape == (1, 2)
     assert jnp.issubdtype(draft_token_ids.dtype, jnp.integer)
 
 
@@ -190,136 +195,29 @@ def test_build_noise_block(mesh):
                                   np.array([10, 11, 12], dtype=np.int32))
 
 
-@patch("tpu_inference.spec_decode.jax.dflash.get_model")
-def test_dflash_proposer_multi_iteration_state_flow(mock_get_model, mesh):
-    """Verifies DFlashProposer's entire state-tracking, cache cropping, and padding flow across multiple speculative iterations."""
-    vllm_config = MockVllmConfig()
-    runner = MockRunner(mesh)
+def test_build_noise_block_batched():
+    proposer = object.__new__(DFlashProposer)
 
-    mock_mi = MockDraftModelInterface()
-    # combine_hidden_states_fn acts as identity for simplicity
-    mock_mi.combine_hidden_states_fn = lambda state, raw: raw
-    mock_get_model.return_value = mock_mi
+    # 2 requests in batch
+    seq_lens = jnp.array([10, 20], dtype=jnp.int32)
+    next_token_ids = jnp.array([100, 200], dtype=jnp.int32)
+    mask_token_id = 0
+    block_size = 3
 
-    proposer = DFlashProposer(vllm_config, runner)
+    noise_ids, noise_positions = proposer._build_noise_block(
+        seq_lens, next_token_ids, mask_token_id, block_size)
 
-    with jax.set_mesh(mesh):
-        proposer.load_model(target_model=None)
+    # The output is expected to be flattened across the batch.
+    assert noise_ids.shape == (6, )
+    assert noise_positions.shape == (6, )
 
-    # Initial proposer state
-    assert proposer._ctx_len == 0
-    assert proposer._cache_len == 0
-    assert proposer._prev_seq_len == 0
-
-    # ----------------- ITERATION 1: Initial prefix accepted up to length 10 -----------------
-    from tpu_inference.layers.common.attention_metadata import \
-        AttentionMetadata
-    attn_metadata_1 = AttentionMetadata(
-        input_positions=jnp.array([0]),
-        block_tables=jnp.array([0]),
-        seq_lens=jnp.array([10], dtype=jnp.int32),
-        query_start_loc=jnp.array([0]),
-        request_distribution=jnp.array([0]),
-    )
-
-    input_ids = jnp.array([0])
-    aux_hidden_states_1 = (jnp.ones((10, 32), dtype=jnp.bfloat16), )
-    next_token_ids_1 = jnp.array([42], dtype=jnp.int32)
-
-    with jax.set_mesh(mesh):
-        target_hidden_1, noise_ids_1, _, draft_metadata_1 = proposer.prepare_inputs(
-            attn_metadata_1,
-            input_ids,
-            aux_hidden_states_1,
-            next_token_ids_1,
-        )
-
-    # Check outputs of Iteration 1
-    new_ctx_1, cache_len_arr_1, actual_ctx_count_arr_1 = target_hidden_1
-    # Padding size for 10 is 16
-    assert new_ctx_1.shape == (16, 32)
-    assert int(cache_len_arr_1[0]) == 0
-    assert int(actual_ctx_count_arr_1[0]) == 10
-
-    # Check proposer state updates
-    assert proposer._ctx_len == 10
-    assert proposer._prev_seq_len == 10
-
-    # Check draft proposer attention metadata sharding positions
-    assert noise_ids_1.shape == (proposer.block_size, )
+    # Check input ids are padded with mask_token_id correctly
     np.testing.assert_array_equal(
-        np.asarray(draft_metadata_1.query_start_loc),
-        np.array([0, proposer.block_size], dtype=np.int32),
-    )
+        np.asarray(noise_ids), np.array([100, 0, 0, 200, 0, 0],
+                                        dtype=np.int32))
 
-    # Mock proposer model forward pass and logits sampler
-    dummy_kv = [
-        jnp.zeros((1, 4, 128, 16), dtype=jnp.bfloat16)
-        for _ in range(proposer.num_layers * 2)
-    ]
-    proposer._draft_kv_caches = dummy_kv
+    # Check absolute position assignments per request
+    np.testing.assert_array_equal(
+        np.asarray(noise_positions),
+        np.array([10, 11, 12, 20, 21, 22], dtype=np.int32))
 
-    # model_fn returns draft_kv_caches, hidden_states (5 tokens, 32 hidden_size), and None
-    mock_mi.model_fn.return_value = (
-        dummy_kv,
-        jnp.ones((5, 32), dtype=jnp.bfloat16),
-        None,
-    )
-    # compute_logits_fn returns logits for 4 speculative tokens, vocabulary size 1000
-    mock_mi.compute_logits_fn.return_value = jnp.ones((4, 1000),
-                                                      dtype=jnp.float32)
-
-    # Call propose for Iteration 1
-    with jax.set_mesh(mesh):
-        _, draft_token_ids_1 = proposer.propose(
-            kv_caches=[],
-            input_ids=input_ids,
-            attn_metadata=draft_metadata_1,
-            last_token_indices=jnp.zeros(1),
-            target_hidden_states=target_hidden_1,
-        )
-
-    assert draft_token_ids_1.shape == (1, 4)
-    # Cache length is updated to prefix (10) + block size (5) = 15
-    assert proposer._cache_len == 15
-
-    # ----------------- ITERATION 2: Speculative Rejection & Cache Cropping -----------------
-    # Suppose out of 4 proposed tokens, the target model accepts 3.
-    # Therefore, new accepted sequence length is 10 prefix + 3 accepted = 13.
-    attn_metadata_2 = AttentionMetadata(
-        input_positions=jnp.array([0]),
-        block_tables=jnp.array([0]),
-        seq_lens=jnp.array([13], dtype=jnp.int32),
-        query_start_loc=jnp.array([0]),
-        request_distribution=jnp.array([0]),
-    )
-
-    # Target model passes the accumulated auxiliary hidden states (now length 13)
-    aux_hidden_states_2 = (jnp.ones((13, 32), dtype=jnp.bfloat16), )
-    next_token_ids_2 = jnp.array([99], dtype=jnp.int32)
-
-    with jax.set_mesh(mesh):
-        target_hidden_2, noise_ids_2, _, _ = proposer.prepare_inputs(
-            attn_metadata_2,
-            input_ids,
-            aux_hidden_states_2,
-            next_token_ids_2,
-        )
-
-    # Check outputs of Iteration 2
-    new_ctx_2, cache_len_arr_2, actual_ctx_count_arr_2 = target_hidden_2
-
-    # CRITICAL: Verify cache cropping logic
-    # The cache length must be cropped back to the PREVIOUS sequence length (10),
-    # preserving the accepted prefix and discarding the rejected noise entries in [10, 15)
-    assert proposer._cache_len == 10
-    assert int(cache_len_arr_2[0]) == 10
-
-    # The proposer correctly identifies that 3 new context tokens need to be sharded
-    assert int(actual_ctx_count_arr_2[0]) == 3
-    # Padding size for 3 is 16
-    assert new_ctx_2.shape == (16, 32)
-
-    # Check proposer state updates
-    assert proposer._ctx_len == 13
-    assert proposer._prev_seq_len == 13

--- a/tests/spec_decode/test_dflash.py
+++ b/tests/spec_decode/test_dflash.py
@@ -26,7 +26,11 @@ from tpu_inference.spec_decode.jax.dflash import DFlashProposer
 
 def _make_single_device_mesh() -> jax.sharding.Mesh:
     devices = np.array(jax.devices()[:1])
-    m = jax.sharding.Mesh(devices, axis_names=("model", ))
+    device_mesh = devices.reshape((1, 1, 1, 1))
+    m = jax.sharding.Mesh(
+        device_mesh,
+        axis_names=('data', 'attn_dp', 'expert', 'model'),
+    )
     return m
 
 
@@ -107,45 +111,62 @@ class MockDraftModelInterface:
 
 
 # ----- Existing Minimal Tests -----
-def test_sample_block_draft_tokens_uses_target_model_logits():
+def test_propose_uses_target_model_logits():
     proposer = object.__new__(DFlashProposer)
     proposer.mesh = _make_single_device_mesh()
     proposer.num_speculative_tokens = 2
-    proposer.block_size = proposer.num_speculative_tokens + 1
+    proposer.block_size = proposer.num_speculative_tokens + 1  # 3
+
+    # mock model_fn to return a dummy hidden_states tensor
+    # shape: (num_reqs * block_size, hidden_size) = (1 * 3, 8) = (3, 8)
+    hidden_states = jnp.ones((3, 8), dtype=jnp.bfloat16)
+    proposer.model_fn = lambda state, kv_caches, input_ids, target_hidden_states, attn_metadata: (
+        kv_caches, hidden_states, None, None)
 
     call_record = {}
-    target_state = jnp.array(0)
 
     def fake_compute_logits_fn(state, hidden_states, lora_metadata):
         call_record["shape"] = hidden_states.shape
-        return jnp.array([[[0.0, 2.0, 1.0], [4.0, 1.0, 0.0]]],
-                         dtype=jnp.float32)
+        # return logits of shape (2, 3) (matching flattened 2 draft tokens, 3 vocab size)
+        return jnp.array([[0.0, 2.0, 1.0], [4.0, 1.0, 0.0]], dtype=jnp.float32)
 
     proposer.compute_logits_fn = fake_compute_logits_fn
 
-    # hidden_states layout: [context_token, draft_token_0, draft_token_1, ...]
-    # _sample_block_draft_tokens slices [:, 1:1+num_speculative_tokens, :]
-    hidden_states = jnp.ones((3, 8), dtype=jnp.bfloat16)
-    draft_token_ids = proposer._sample_block_draft_tokens(
-        target_state, hidden_states)
+    # Call JITted _propose
+    _, draft_token_ids = proposer._propose(
+        state_leaves=None,
+        kv_caches=[],
+        input_ids=None,
+        attn_metadata=None,
+        target_hidden_states=None,
+    )
 
     np.testing.assert_array_equal(np.asarray(draft_token_ids),
                                   np.array([[1, 0]], dtype=np.int32))
-    assert call_record["shape"] == (1, 2, 8)
+    assert call_record["shape"] == (2, 8)
 
 
-def test_sample_block_draft_tokens_returns_1d_int_ids():
+def test_propose_returns_2d_int_ids():
     proposer = object.__new__(DFlashProposer)
     proposer.mesh = _make_single_device_mesh()
     proposer.num_speculative_tokens = 2
-    proposer.block_size = proposer.num_speculative_tokens + 1
-
-    proposer.compute_logits_fn = lambda _state, _hidden, _lora: jnp.array(
-        [[[1.0, 0.0], [0.0, 1.0]]], dtype=jnp.float32)
+    proposer.block_size = proposer.num_speculative_tokens + 1  # 3
 
     hidden_states = jnp.ones((3, 4), dtype=jnp.bfloat16)
-    draft_token_ids = proposer._sample_block_draft_tokens(
-        jnp.array(0), hidden_states)
+    proposer.model_fn = lambda state, kv_caches, input_ids, target_hidden_states, attn_metadata: (
+        kv_caches, hidden_states, None, None)
+
+    proposer.compute_logits_fn = lambda _state, _hidden, _lora: jnp.array(
+        [[1.0, 0.0], [0.0, 1.0]], dtype=jnp.float32)
+
+    # Call _propose
+    _, draft_token_ids = proposer._propose(
+        state_leaves=None,
+        kv_caches=[],
+        input_ids=None,
+        attn_metadata=None,
+        target_hidden_states=None,
+    )
 
     assert draft_token_ids.ndim == 2
     assert draft_token_ids.shape == (1, 2)

--- a/tpu_inference/layers/common/attention_interface.py
+++ b/tpu_inference/layers/common/attention_interface.py
@@ -346,6 +346,7 @@ def sharded_ragged_paged_attention(
     k_scale: float | None = None,
     v_scale: float | None = None,
     update_kv_cache: bool = True,
+    use_causal_mask: bool = True,
 ):
     """Shards along KV heads."""
     # Handle GQA/MQA where num_kv_heads < tp_size
@@ -412,6 +413,7 @@ def sharded_ragged_paged_attention(
         # is a no-op so we don't forward it to the hd64 signature.
         if not use_hd64:
             kwargs["update_kv_cache"] = update_kv_cache
+            kwargs["use_causal_mask"] = use_causal_mask
         return func(*args, **kwargs)
 
     return jax.shard_map(
@@ -438,6 +440,7 @@ def attention(
     v_scale: float | None = None,
     sinks: jax.Array | None = None,
     update_kv_cache: bool = True,
+    use_causal_mask: bool = True,
 ) -> Tuple[jax.Array, jax.Array]:
     # T: seq_len
     # N: num_heads
@@ -477,6 +480,7 @@ def attention(
         k_scale=k_scale,
         v_scale=v_scale,
         update_kv_cache=update_kv_cache,
+        use_causal_mask=use_causal_mask,
     )
 
     return kv_cache, output

--- a/tpu_inference/layers/common/dflash_attention_interface.py
+++ b/tpu_inference/layers/common/dflash_attention_interface.py
@@ -32,6 +32,7 @@ def dflash_concat_attention(
     v_ctx: jax.Array,  # [T, K, H]
     v_noise: jax.Array,  # [T, K, H]
     attention_metadata: AttentionMetadata,
+    target_query_start_loc: jax.Array,
     *,
     max_query_len: int,
     sm_scale: float,
@@ -43,10 +44,13 @@ def dflash_concat_attention(
     """
     if max_query_len <= 0:
         raise ValueError(f"{max_query_len=} must be positive.")
-    if not (q.shape[0] == k_ctx.shape[0] == k_noise.shape[0] == v_ctx.shape[0]
-            == v_noise.shape[0]):
+    if not (q.shape[0] == k_noise.shape[0] == v_noise.shape[0]):
         raise ValueError(
-            "All DFlash attention streams must share the same token count.")
+            "Noise DFlash attention streams must share the same token count.")
+    if not (k_ctx.shape[0] == v_ctx.shape[0]):
+        raise ValueError(
+            "Context DFlash attention streams must share the same token count."
+        )
 
     num_tokens, num_heads, _ = q.shape
     num_kv_heads = k_ctx.shape[1]
@@ -94,9 +98,13 @@ def dflash_concat_attention(
         req_len = req_lens[i]
         req_len = jnp.clip(req_len, 0, max_query_len)
 
+        ctx_start = target_query_start_loc[i]
+        ctx_req_len = target_query_start_loc[i + 1] - target_query_start_loc[i]
+        ctx_req_len = jnp.clip(ctx_req_len, 0, max_query_len)
+
         q_blk = lax.dynamic_slice_in_dim(q, start, max_query_len, axis=0)
         k_ctx_blk = lax.dynamic_slice_in_dim(k_ctx,
-                                             start,
+                                             ctx_start,
                                              max_query_len,
                                              axis=0)
         k_noise_blk = lax.dynamic_slice_in_dim(k_noise,
@@ -104,7 +112,7 @@ def dflash_concat_attention(
                                                max_query_len,
                                                axis=0)
         v_ctx_blk = lax.dynamic_slice_in_dim(v_ctx,
-                                             start,
+                                             ctx_start,
                                              max_query_len,
                                              axis=0)
         v_noise_blk = lax.dynamic_slice_in_dim(v_noise,
@@ -118,8 +126,11 @@ def dflash_concat_attention(
 
         # Mask out padding positions for both Q and KV.
         q_valid = arange_q < req_len
-        kv_valid_len = jnp.maximum(2 * req_len, 1)
-        kv_valid = arange_kv < kv_valid_len
+        # Valid KV tokens: ctx_req_len context tokens + req_len noise tokens
+        # The first max_query_len tokens are context, the next max_query_len are noise.
+        kv_valid = (arange_kv
+                    < ctx_req_len) | ((arange_kv >= max_query_len) &
+                                      (arange_kv < max_query_len + req_len))
 
         logits = jnp.einsum("qnh,knh->nqk", q_blk.astype(jnp.float32),
                             k_blk.astype(jnp.float32))

--- a/tpu_inference/models/common/model_loader.py
+++ b/tpu_inference/models/common/model_loader.py
@@ -71,6 +71,7 @@ def _get_model_architecture(config: PretrainedConfig) -> nnx.Module:
     # would cause JAX init failure when using multi hosts with Ray.
 
     from tpu_inference.models.jax.deepseek_v3 import DeepseekV3ForCausalLM
+    from tpu_inference.models.jax.dflash import DFlashForCausalLM
     from tpu_inference.models.jax.gemma4_mm import \
         Gemma4ForConditionalGeneration
     from tpu_inference.models.jax.gemma4_mtp import Gemma4MTPForCausalLM
@@ -98,6 +99,7 @@ def _get_model_architecture(config: PretrainedConfig) -> nnx.Module:
     _MODEL_REGISTRY[
         "Gemma4ForConditionalGeneration"] = Gemma4ForConditionalGeneration
     _MODEL_REGISTRY["Gemma4MTPModel"] = Gemma4MTPForCausalLM
+    _MODEL_REGISTRY["DFlashForCausalLM"] = DFlashForCausalLM
 
     architectures = getattr(config, "architectures", [])
     for arch in architectures:

--- a/tpu_inference/models/jax/dflash.py
+++ b/tpu_inference/models/jax/dflash.py
@@ -13,20 +13,18 @@
 # limitations under the License.
 """DFlash draft model for speculative decoding on JAX/TPU."""
 
-from typing import List, Tuple
+from typing import Any, List, Tuple
 
 import jax
 import jax.numpy as jnp
 from flax import nnx
-from jax import lax
 from jax.sharding import Mesh
 from transformers import Qwen3Config
 from vllm.config import VllmConfig
 
 from tpu_inference import utils
-from tpu_inference.kernels.flash_attention.kernel import (BlockSizes,
-                                                          SegmentIds,
-                                                          flash_attention)
+from tpu_inference.kernels.ragged_paged_attention.v3.kernel import \
+    ragged_paged_attention
 from tpu_inference.layers.common.sharding import ShardingAxisName
 from tpu_inference.layers.jax.rope_interface import apply_rope
 from tpu_inference.logger import init_logger
@@ -135,123 +133,91 @@ class DFlashAttention(nnx.Module):
         self,
         x_noise: jax.Array,
         target_hidden: jax.Array,
-        noise_positions: jax.Array,
-        ctx_positions: jax.Array,
-        kv_cache_k: jax.Array,
-        kv_cache_v: jax.Array,
-        cache_len: jax.Array,
-        actual_ctx_count: jax.Array,
-    ) -> Tuple[jax.Array, jax.Array, jax.Array]:
-        """Non-causal attention with on-device KV cache.
-
-        Uses a two-phase cache write to handle padded context correctly:
-          Phase A: write context K/V (with padding zeroed) at ``cache_len``.
-          Phase B: write noise K/V at ``cache_len + actual_ctx_count``,
-                   overwriting any padding zeros from Phase A.
-
-        Args:
-            x_noise: (T_noise, D) noise hidden states.
-            target_hidden: (T_padded, D) padded context features.
-            noise_positions: (T_noise,) position ids for noise tokens.
-            ctx_positions: (T_padded,) position ids for context tokens.
-            kv_cache_k: (1, N_heads, max_kv_len, H) pre-allocated K cache.
-            kv_cache_v: (1, N_heads, max_kv_len, H) pre-allocated V cache.
-            cache_len: scalar int, valid entries already in cache.
-            actual_ctx_count: scalar int, real (non-padding) context tokens.
-
-        Returns:
-            (output, new_kv_cache_k, new_kv_cache_v)
-        """
+        attention_metadata: Any,
+        target_query_start_loc: jax.Array,
+        target_positions: jax.Array,
+        kv_cache: jax.Array,
+    ) -> Tuple[jax.Array, jax.Array]:
+        """Non-causal attention with on-device paged KV cache."""
+        md = attention_metadata
         T_noise = x_noise.shape[0]
-        T_padded = target_hidden.shape[0]
+        T_target = target_hidden.shape[0]
 
-        q = self.q_proj(x_noise)
-        q = self.q_norm(q)
-        q = apply_rope(
-            q,
-            noise_positions,
-            self.head_dim_original,
-            self.rope_theta,
-            self.rope_scaling,
-        )
+        q_noise = self.q_norm(self.q_proj(x_noise))
+        k_noise = self.k_norm(self.k_proj(x_noise))
+        v_noise = self.v_proj(x_noise)
 
-        x_new = jnp.concatenate([target_hidden, x_noise], axis=0)
-        k_new = self.k_proj(x_new)
-        v_new = self.v_proj(x_new)
-        k_new = self.k_norm(k_new)
-
-        new_positions = jnp.concatenate([ctx_positions, noise_positions],
-                                        axis=0)
-        k_new = apply_rope(
-            k_new,
-            new_positions,
-            self.head_dim_original,
-            self.rope_theta,
-            self.rope_scaling,
-        )
+        # Apply RoPE to noise K
+        k_noise = apply_rope(k_noise, md.input_positions,
+                             self.head_dim_original, self.rope_theta,
+                             self.rope_scaling)
 
         if self.num_kv_groups > 1:
-            k_new = jnp.repeat(k_new, self.num_kv_groups, axis=1)
-            v_new = jnp.repeat(v_new, self.num_kv_groups, axis=1)
+            k_noise = jnp.repeat(k_noise, self.num_kv_groups, axis=1)
+            v_noise = jnp.repeat(v_noise, self.num_kv_groups, axis=1)
 
-        k_ctx = k_new[:T_padded]
-        v_ctx = v_new[:T_padded]
-        k_noise = k_new[T_padded:]
-        v_noise = v_new[T_padded:]
+        q_noise = q_noise.reshape(T_noise, self.num_heads, self.head_dim)
+        k_noise = k_noise.reshape(T_noise, self.num_kv_heads, self.head_dim)
+        v_noise = v_noise.reshape(T_noise, self.num_kv_heads, self.head_dim)
 
-        ctx_mask = (jnp.arange(T_padded) < actual_ctx_count)  # (T_padded,)
-        ctx_mask_kv = ctx_mask[:, jnp.newaxis, jnp.newaxis]  # (T_padded, 1, 1)
-        k_ctx = jnp.where(ctx_mask_kv, k_ctx, 0.0)
-        v_ctx = jnp.where(ctx_mask_kv, v_ctx, 0.0)
+        # Process target hidden tokens (newly accepted tokens)
+        k_target = self.k_norm(self.k_proj(target_hidden))
+        v_target = self.v_proj(target_hidden)
 
-        k_ctx_4d = k_ctx.transpose(1, 0, 2)[jnp.newaxis, :, :, :]
-        v_ctx_4d = v_ctx.transpose(1, 0, 2)[jnp.newaxis, :, :, :]
-        kv_cache_k = lax.dynamic_update_slice(kv_cache_k, k_ctx_4d,
-                                              (0, 0, cache_len, 0))
-        kv_cache_v = lax.dynamic_update_slice(kv_cache_v, v_ctx_4d,
-                                              (0, 0, cache_len, 0))
+        # Apply RoPE to target K
+        k_target = apply_rope(k_target, target_positions,
+                              self.head_dim_original, self.rope_theta,
+                              self.rope_scaling)
 
-        noise_start = cache_len + actual_ctx_count
-        k_noise_4d = k_noise.transpose(1, 0, 2)[jnp.newaxis, :, :, :]
-        v_noise_4d = v_noise.transpose(1, 0, 2)[jnp.newaxis, :, :, :]
-        kv_cache_k = lax.dynamic_update_slice(kv_cache_k, k_noise_4d,
-                                              (0, 0, noise_start, 0))
-        kv_cache_v = lax.dynamic_update_slice(kv_cache_v, v_noise_4d,
-                                              (0, 0, noise_start, 0))
+        if self.num_kv_groups > 1:
+            k_target = jnp.repeat(k_target, self.num_kv_groups, axis=1)
+            v_target = jnp.repeat(v_target, self.num_kv_groups, axis=1)
 
-        new_cache_len = cache_len + actual_ctx_count + T_noise
-        max_kv_len = kv_cache_k.shape[2]
+        k_target = k_target.reshape(T_target, self.num_kv_heads, self.head_dim)
+        v_target = v_target.reshape(T_target, self.num_kv_heads, self.head_dim)
 
-        q_4d = q.transpose(1, 0, 2)[jnp.newaxis, :, :, :]
-        kv_ids = (jnp.arange(max_kv_len) < new_cache_len).astype(jnp.int32)
-        q_ids = jnp.ones(T_noise, dtype=jnp.int32)
-        seg_ids = SegmentIds(
-            q=q_ids[jnp.newaxis, :],
-            kv=kv_ids[jnp.newaxis, :],
+        q_target = jnp.zeros((T_target, self.num_heads, self.head_dim),
+                             dtype=q_noise.dtype)
+        # Step 1: Write target tokens to KV cache
+        # kv_lens is the length AFTER appending target tokens. This is EXACTLY md.seq_lens.
+        kv_cache = ragged_paged_attention(
+            queries=q_target,
+            keys=k_target,
+            values=v_target,
+            kv_cache=kv_cache,
+            kv_lens=md.seq_lens,
+            page_indices=md.block_tables,
+            cu_q_lens=target_query_start_loc,
+            distribution=md.request_distribution,
+            use_causal_mask=True,
+            update_kv_cache=True,
+            sm_scale=self.head_dim_original**-0.5,
         )
 
-        sm_scale = self.head_dim_original**-0.5
-        block_sizes = BlockSizes(
-            block_q=T_noise,
-            block_k_major=max_kv_len,
-            block_k=max_kv_len,
-            block_b=1,
-        )
-        attn_out = flash_attention(
-            q_4d,
-            kv_cache_k,
-            kv_cache_v,
-            segment_ids=seg_ids,
-            causal=False,
-            sm_scale=sm_scale,
-            block_sizes=block_sizes,
-            vmem_limit_bytes=_FA_VMEM_LIMIT,
+        # Step 2: Write noise tokens to KV cache and compute attention
+        # kv_lens is the length AFTER appending noise tokens.
+        num_reqs = md.seq_lens.shape[0]
+        block_size = T_noise // num_reqs
+        seq_lens_noise = md.seq_lens + block_size
+        attn_out, kv_cache = ragged_paged_attention(
+            queries=q_noise,
+            keys=k_noise,
+            values=v_noise,
+            kv_cache=kv_cache,
+            kv_lens=seq_lens_noise,
+            page_indices=md.block_tables,
+            cu_q_lens=md.query_start_loc,
+            distribution=md.request_distribution,
+            use_causal_mask=False,  # Noise tokens attend to all KV tokens
+            update_kv_cache=True,
+            sm_scale=self.head_dim_original**-0.5,
         )
 
-        attn_out = attn_out[0].transpose(1, 0, 2)
-        output = self.o_proj(attn_out)
+        # Reshape output back
+        attn_out = attn_out.reshape(T_noise, self.num_heads * self.head_dim)
+        out = self.o_proj(attn_out)
 
-        return output, kv_cache_k, kv_cache_v
+        return out, kv_cache
 
 
 class DFlashMLP(nnx.Module):
@@ -329,25 +295,21 @@ class DFlashDecoderLayer(nnx.Module):
         self,
         x: jax.Array,
         target_hidden: jax.Array,
-        noise_positions: jax.Array,
-        ctx_positions: jax.Array,
-        kv_cache_k: jax.Array,
-        kv_cache_v: jax.Array,
-        cache_len: jax.Array,
-        actual_ctx_count: jax.Array,
-    ) -> Tuple[jax.Array, jax.Array, jax.Array]:
-        """Returns (hidden_states, new_kv_cache_k, new_kv_cache_v)."""
+        attention_metadata: Any,
+        target_query_start_loc: jax.Array,
+        target_positions: jax.Array,
+        kv_cache: jax.Array,
+    ) -> Tuple[jax.Array, jax.Array]:
+        """Returns (hidden_states, new_kv_cache)."""
         residual = x
         x = self.input_layernorm(x)
-        x, kv_cache_k, kv_cache_v = self.self_attn(
-            x,
-            target_hidden,
-            noise_positions,
-            ctx_positions,
-            kv_cache_k,
-            kv_cache_v,
-            cache_len,
-            actual_ctx_count,
+        x, kv_cache = self.self_attn(
+            x_noise=x,
+            target_hidden=target_hidden,
+            attention_metadata=attention_metadata,
+            target_query_start_loc=target_query_start_loc,
+            target_positions=target_positions,
+            kv_cache=kv_cache,
         )
         x = residual + x
 
@@ -355,7 +317,7 @@ class DFlashDecoderLayer(nnx.Module):
         x = self.post_attention_layernorm(x)
         x = self.mlp(x)
         x = residual + x
-        return x, kv_cache_k, kv_cache_v
+        return x, kv_cache
 
 
 class DFlashModel(nnx.Module):
@@ -499,53 +461,30 @@ class DFlashForCausalLM(nnx.Module):
         self,
         kv_caches: List[jax.Array],
         input_ids: jax.Array,
-        target_hidden_states: jax.Array,
+        target_hidden_states: Any,
         attention_metadata,
     ) -> Tuple[List[jax.Array], jax.Array, List[jax.Array]]:
         """Forward pass for the DFlash draft model.
 
-        ``target_hidden_states`` is a 3-tuple:
-            (ctx_hidden, cache_len_arr, actual_ctx_count_arr)
-        where:
-            ctx_hidden: (T_padded, D) — padded context features.
-            cache_len_arr: (1,) int32 — valid entries already in KV cache.
-            actual_ctx_count_arr: (1,) int32 — real (non-padding) context count.
-
-        ``kv_caches`` is a flat list of length ``2 * num_layers``:
-            [k_cache_0, v_cache_0, k_cache_1, v_cache_1, ...]
-        Each cache has shape ``(1, num_heads, max_kv_len, head_dim)``.
-
-        Returns:
-            (kv_caches, hidden_states, [target_hidden_states])
+        ``target_hidden_states`` is a tuple (target_hidden, target_query_start_loc, target_positions).
+        ``kv_caches`` is the framework's global paged kv caches.
         """
-        ctx_hidden, cache_len_arr, actual_ctx_count_arr = target_hidden_states
-        cache_len = cache_len_arr[0]  # scalar
-        actual_ctx_count = actual_ctx_count_arr[0]  # scalar
+        target_hidden, target_query_start_loc, target_positions = target_hidden_states
 
         noise_emb = self.model.embed_tokens(input_ids)
-        pos_offset = cache_len if self._position_scheme == "incremental" else 0
-        T_padded = ctx_hidden.shape[0]
-        T_noise = input_ids.shape[0]
-        ctx_positions = jnp.arange(T_padded, dtype=jnp.int32) + pos_offset
-        noise_positions = (jnp.arange(T_noise, dtype=jnp.int32) + pos_offset +
-                           actual_ctx_count)
-
         x = noise_emb
+
         for i, layer in enumerate(self.model.layers):
-            kv_k = kv_caches[2 * i]
-            kv_v = kv_caches[2 * i + 1]
-            x, kv_k, kv_v = layer(
+            kv_cache = kv_caches[i]
+            x, kv_cache = layer(
                 x,
-                ctx_hidden,
-                noise_positions,
-                ctx_positions,
-                kv_k,
-                kv_v,
-                cache_len,
-                actual_ctx_count,
+                target_hidden=target_hidden,
+                attention_metadata=attention_metadata,
+                target_query_start_loc=target_query_start_loc,
+                target_positions=target_positions,
+                kv_cache=kv_cache,
             )
-            kv_caches[2 * i] = kv_k
-            kv_caches[2 * i + 1] = kv_v
+            kv_caches[i] = kv_cache
 
         x = self.model.norm(x)
 

--- a/tpu_inference/models/jax/dflash.py
+++ b/tpu_inference/models/jax/dflash.py
@@ -152,10 +152,6 @@ class DFlashAttention(nnx.Module):
                              self.head_dim_original, self.rope_theta,
                              self.rope_scaling)
 
-        if self.num_kv_groups > 1:
-            k_noise = jnp.repeat(k_noise, self.num_kv_groups, axis=1)
-            v_noise = jnp.repeat(v_noise, self.num_kv_groups, axis=1)
-
         q_noise = q_noise.reshape(T_noise, self.num_heads, self.head_dim)
         k_noise = k_noise.reshape(T_noise, self.num_kv_heads, self.head_dim)
         v_noise = v_noise.reshape(T_noise, self.num_kv_heads, self.head_dim)
@@ -169,10 +165,6 @@ class DFlashAttention(nnx.Module):
                               self.head_dim_original, self.rope_theta,
                               self.rope_scaling)
 
-        if self.num_kv_groups > 1:
-            k_target = jnp.repeat(k_target, self.num_kv_groups, axis=1)
-            v_target = jnp.repeat(v_target, self.num_kv_groups, axis=1)
-
         k_target = k_target.reshape(T_target, self.num_kv_heads, self.head_dim)
         v_target = v_target.reshape(T_target, self.num_kv_heads, self.head_dim)
 
@@ -180,7 +172,7 @@ class DFlashAttention(nnx.Module):
                              dtype=q_noise.dtype)
         # Step 1: Write target tokens to KV cache
         # kv_lens is the length AFTER appending target tokens. This is EXACTLY md.seq_lens.
-        kv_cache = ragged_paged_attention(
+        _, kv_cache = ragged_paged_attention(
             queries=q_target,
             keys=k_target,
             values=v_target,
@@ -213,8 +205,7 @@ class DFlashAttention(nnx.Module):
             sm_scale=self.head_dim_original**-0.5,
         )
 
-        # Reshape output back
-        attn_out = attn_out.reshape(T_noise, self.num_heads * self.head_dim)
+        # attn_out is already (T_noise, num_heads, head_dim)
         out = self.o_proj(attn_out)
 
         return out, kv_cache

--- a/tpu_inference/models/jax/dflash.py
+++ b/tpu_inference/models/jax/dflash.py
@@ -13,7 +13,8 @@
 # limitations under the License.
 """DFlash draft model for speculative decoding on JAX/TPU."""
 
-from typing import Any, List, Tuple
+from dataclasses import replace
+from typing import Any, List, Optional, Tuple
 
 import jax
 import jax.numpy as jnp
@@ -23,9 +24,10 @@ from transformers import Qwen3Config
 from vllm.config import VllmConfig
 
 from tpu_inference import utils
-from tpu_inference.kernels.ragged_paged_attention.v3.kernel import \
-    ragged_paged_attention
+from tpu_inference.layers.common.attention_interface import attention
 from tpu_inference.layers.common.sharding import ShardingAxisName
+from tpu_inference.layers.jax.linear import JaxLmHead
+from tpu_inference.layers.jax.pp_utils import PPMissingLayer
 from tpu_inference.layers.jax.rope_interface import apply_rope
 from tpu_inference.logger import init_logger
 from tpu_inference.models.jax.utils.weight_utils import (BaseWeightLoader,
@@ -63,9 +65,9 @@ class DFlashAttention(nnx.Module):
         self.hidden_size = config.hidden_size
         self.num_heads = config.num_attention_heads
         self.num_kv_heads = config.num_key_value_heads
-        self.rope_theta = config.rope_theta
+        self.rope_theta = getattr(config, "rope_theta", 1000000.0)
         self.rope_scaling = getattr(config, "rope_scaling", None)
-        self.rms_norm_eps = config.rms_norm_eps
+        self.rms_norm_eps = getattr(config, "rms_norm_eps", 1e-6)
 
         self.head_dim_original = getattr(config, "head_dim",
                                          self.hidden_size // self.num_heads)
@@ -147,14 +149,13 @@ class DFlashAttention(nnx.Module):
         k_noise = self.k_norm(self.k_proj(x_noise))
         v_noise = self.v_proj(x_noise)
 
-        # Apply RoPE to noise K
+        # Apply RoPE to noise Q and K
+        q_noise = apply_rope(q_noise, md.input_positions,
+                             self.head_dim_original, self.rope_theta,
+                             self.rope_scaling)
         k_noise = apply_rope(k_noise, md.input_positions,
                              self.head_dim_original, self.rope_theta,
                              self.rope_scaling)
-
-        q_noise = q_noise.reshape(T_noise, self.num_heads, self.head_dim)
-        k_noise = k_noise.reshape(T_noise, self.num_kv_heads, self.head_dim)
-        v_noise = v_noise.reshape(T_noise, self.num_kv_heads, self.head_dim)
 
         # Process target hidden tokens (newly accepted tokens)
         k_target = self.k_norm(self.k_proj(target_hidden))
@@ -165,25 +166,22 @@ class DFlashAttention(nnx.Module):
                               self.head_dim_original, self.rope_theta,
                               self.rope_scaling)
 
-        k_target = k_target.reshape(T_target, self.num_kv_heads, self.head_dim)
-        v_target = v_target.reshape(T_target, self.num_kv_heads, self.head_dim)
-
         q_target = jnp.zeros((T_target, self.num_heads, self.head_dim),
                              dtype=q_noise.dtype)
         # Step 1: Write target tokens to KV cache
         # kv_lens is the length AFTER appending target tokens. This is EXACTLY md.seq_lens.
-        _, kv_cache = ragged_paged_attention(
-            queries=q_target,
-            keys=k_target,
-            values=v_target,
+        kv_cache, _ = attention(
             kv_cache=kv_cache,
-            kv_lens=md.seq_lens,
-            page_indices=md.block_tables,
-            cu_q_lens=target_query_start_loc,
-            distribution=md.request_distribution,
+            q=q_target,
+            k=k_target,
+            v=v_target,
+            attention_metadata=replace(md,
+                                       query_start_loc=target_query_start_loc),
+            mesh=self.mesh,
+            head_dim_original=self.head_dim_original,
+            sm_scale=self.head_dim_original**-0.5,
             use_causal_mask=True,
             update_kv_cache=True,
-            sm_scale=self.head_dim_original**-0.5,
         )
 
         # Step 2: Write noise tokens to KV cache and compute attention
@@ -191,18 +189,17 @@ class DFlashAttention(nnx.Module):
         num_reqs = md.seq_lens.shape[0]
         block_size = T_noise // num_reqs
         seq_lens_noise = md.seq_lens + block_size
-        attn_out, kv_cache = ragged_paged_attention(
-            queries=q_noise,
-            keys=k_noise,
-            values=v_noise,
+        kv_cache, attn_out = attention(
             kv_cache=kv_cache,
-            kv_lens=seq_lens_noise,
-            page_indices=md.block_tables,
-            cu_q_lens=md.query_start_loc,
-            distribution=md.request_distribution,
+            q=q_noise,
+            k=k_noise,
+            v=v_noise,
+            attention_metadata=replace(md, seq_lens=seq_lens_noise),
+            mesh=self.mesh,
+            head_dim_original=self.head_dim_original,
+            sm_scale=self.head_dim_original**-0.5,
             use_causal_mask=False,  # Noise tokens attend to all KV tokens
             update_kv_cache=True,
-            sm_scale=self.head_dim_original**-0.5,
         )
 
         # attn_out is already (T_noise, num_heads, head_dim)
@@ -322,6 +319,16 @@ class DFlashModel(nnx.Module):
         spec_config = vllm_config.speculative_config
         assert spec_config is not None
         hf_config = spec_config.draft_model_config.hf_config
+
+        # Inherit RoPE settings from the target model if missing or different
+        target_hf_config = vllm_config.model_config.hf_config
+        hf_config.rope_theta = getattr(
+            target_hf_config, "rope_theta",
+            getattr(hf_config, "rope_theta", 1000000.0))
+        hf_config.rope_scaling = getattr(
+            target_hf_config, "rope_scaling",
+            getattr(hf_config, "rope_scaling", None))
+
         dtype = jnp.bfloat16
         hidden_size = hf_config.hidden_size
         rms_norm_eps = hf_config.rms_norm_eps
@@ -414,6 +421,13 @@ class DFlashWeightLoader(BaseWeightLoader):
                 dtype=model.model.embed_tokens.embedding.dtype,
             )
 
+        if hasattr(model, "lm_head") and hasattr(model.lm_head, "weight"):
+            if isinstance(model.lm_head.weight.value, jax.ShapeDtypeStruct):
+                model.lm_head.weight.value = jnp.zeros(
+                    model.lm_head.weight.shape,
+                    dtype=model.lm_head.weight.dtype,
+                )
+
 
 class DFlashForCausalLM(nnx.Module):
     """DFlash draft model for speculative decoding on TPU."""
@@ -448,13 +462,30 @@ class DFlashForCausalLM(nnx.Module):
             mesh=mesh,
         )
 
+        dtype = jnp.bfloat16
+        if getattr(self.hf_config, "tie_word_embeddings", False):
+            self.lm_head = self.model.embed_tokens
+        else:
+            vocab_size = vllm_config.model_config.get_vocab_size()
+            tp_size = vllm_config.parallel_config.tensor_parallel_size if vllm_config.parallel_config is not None else 1
+            padded_vocab_size = utils.align_to(vocab_size, tp_size)
+            self.lm_head = JaxLmHead(
+                hidden_size=self.hf_config.hidden_size,
+                vocab_size=padded_vocab_size,
+                dtype=dtype,
+                param_dtype=dtype,
+                rngs=self.rng,
+                prefix="lm_head",
+            )
+
     def __call__(
         self,
         kv_caches: List[jax.Array],
         input_ids: jax.Array,
         target_hidden_states: Any,
         attention_metadata,
-    ) -> Tuple[List[jax.Array], jax.Array, List[jax.Array]]:
+    ) -> Tuple[List[jax.Array], jax.Array, List[jax.Array],
+               Optional[jax.Array]]:
         """Forward pass for the DFlash draft model.
 
         ``target_hidden_states`` is a tuple (target_hidden, target_query_start_loc, target_positions).
@@ -462,40 +493,41 @@ class DFlashForCausalLM(nnx.Module):
         """
         target_hidden, target_query_start_loc, target_positions = target_hidden_states
 
-        noise_emb = self.model.embed_tokens(input_ids)
-        x = noise_emb
+        x = self.model.embed_tokens(input_ids)
+        num_draft_layers = len(self.model.layers)
 
         for i, layer in enumerate(self.model.layers):
-            kv_cache = kv_caches[i]
-            x, kv_cache = layer(
+            kv_cache_idx = -num_draft_layers + i
+            x, kv_caches[kv_cache_idx] = layer(
                 x,
                 target_hidden=target_hidden,
                 attention_metadata=attention_metadata,
                 target_query_start_loc=target_query_start_loc,
                 target_positions=target_positions,
-                kv_cache=kv_cache,
+                kv_cache=kv_caches[kv_cache_idx],
             )
-            kv_caches[i] = kv_cache
 
         x = self.model.norm(x)
 
-        return kv_caches, x, []
+        return kv_caches, x, [], None
 
     def compute_logits(self, hidden_states: jax.Array) -> jax.Array:
-        """Compute logits using tied embedding weights."""
+        if hasattr(self,
+                   'lm_head') and not isinstance(self.lm_head, PPMissingLayer):
+            if isinstance(self.lm_head, nnx.Linear) or isinstance(
+                    self.lm_head, JaxLmHead):
+                return self.lm_head(hidden_states)
+            else:
+                return jnp.dot(hidden_states, self.lm_head.embedding.value.T)
         return jnp.dot(hidden_states,
                        self.model.embed_tokens.embedding.value.T)
 
     def combine_hidden_states(self, hidden_states: jax.Array) -> jax.Array:
-        """Project concatenated target auxiliary hidden states.
+        """Project concatenated target auxiliary hidden states."""
+        fc_out = self.model.fc(hidden_states)
+        hidden_out = self.model.hidden_norm(fc_out)
 
-        Args:
-            hidden_states: (T, num_target_layers * target_hidden_size)
-
-        Returns:
-            (T, hidden_size) projected + normalised context features.
-        """
-        return self.model.hidden_norm(self.model.fc(hidden_states))
+        return hidden_out
 
     def load_weights(self, rng_key: jax.Array):
         self.rng = jax.random.key(self.vllm_config.model_config.seed)
@@ -520,9 +552,22 @@ class DFlashForCausalLM(nnx.Module):
             "layers.*.mlp.up_proj": "model.layers.*.mlp.up_proj.kernel",
             "layers.*.mlp.down_proj": "model.layers.*.mlp.down_proj.kernel",
             "fc": "model.fc.kernel",
+            "model.fc": "model.fc.kernel",
+            "fc.weight": "model.fc.kernel",
+            "model.fc.weight": "model.fc.kernel",
             "hidden_norm": "model.hidden_norm.scale",
+            "model.hidden_norm": "model.hidden_norm.scale",
+            "hidden_norm.weight": "model.hidden_norm.scale",
+            "model.hidden_norm.weight": "model.hidden_norm.scale",
             "norm": "model.norm.scale",
+            "model.norm": "model.norm.scale",
+            "norm.weight": "model.norm.scale",
+            "model.norm.weight": "model.norm.scale",
             "embed_tokens": "model.embed_tokens.embedding",
+            "model.embed_tokens.weight": "model.embed_tokens.embedding",
+            "embed_tokens.weight": "model.embed_tokens.embedding",
+            "lm_head": "lm_head.kernel",
+            "lm_head.weight": "lm_head.kernel",
         }
 
         loader = self.WeightLoader(self.vllm_config, self.mesh)

--- a/tpu_inference/models/jax/qwen3_dflash.py
+++ b/tpu_inference/models/jax/qwen3_dflash.py
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List, Tuple
+from dataclasses import replace
+from typing import Any, List, Tuple
 
 import jax
 import jax.numpy as jnp
@@ -24,8 +25,6 @@ from vllm.config import VllmConfig
 from tpu_inference import utils
 from tpu_inference.layers.common.attention_interface import attention
 from tpu_inference.layers.common.attention_metadata import AttentionMetadata
-from tpu_inference.layers.common.dflash_attention_interface import \
-    dflash_concat_attention
 from tpu_inference.layers.common.quantization import quantize_kv
 from tpu_inference.layers.jax.embed import JaxEmbed
 from tpu_inference.layers.jax.linear import JaxEinsum, JaxLinear
@@ -75,9 +74,9 @@ class Qwen3DFlashAttention(nnx.Module):
         self.hidden_size = config.hidden_size
         self.num_heads = config.num_attention_heads
         self.num_kv_heads = config.num_key_value_heads
-        self.rope_theta = config.rope_theta
+        self.rope_theta = getattr(config, "rope_theta", 1000000.0)
         self.rope_scaling = getattr(config, "rope_scaling", None)
-        self.rms_norm_eps = config.rms_norm_eps
+        self.rms_norm_eps = getattr(config, "rms_norm_eps", 1e-6)
 
         self.head_dim_original = getattr(config, "head_dim",
                                          self.hidden_size // self.num_heads)
@@ -158,6 +157,8 @@ class Qwen3DFlashAttention(nnx.Module):
         hidden_states: jax.Array,
         target_hidden_states: jax.Array,
         attention_metadata: AttentionMetadata,
+        target_query_start_loc: jax.Array,
+        target_positions: jax.Array,
     ) -> Tuple[jax.Array, jax.Array]:
         md = attention_metadata
         q = self.q_proj(hidden_states)
@@ -173,7 +174,7 @@ class Qwen3DFlashAttention(nnx.Module):
 
         k_ctx = self.k_proj(target_hidden_states)
         k_ctx = self.k_norm(k_ctx)
-        k_ctx = apply_rope(k_ctx, md.input_positions, self.head_dim_original,
+        k_ctx = apply_rope(k_ctx, target_positions, self.head_dim_original,
                            self.rope_theta, self.rope_scaling)
         v_ctx = self.v_proj(target_hidden_states)
 
@@ -195,53 +196,72 @@ class Qwen3DFlashAttention(nnx.Module):
                 k, v = quantize_kv(self.kv_cache_quantized_dtype, k, v,
                                    k_scale, v_scale)
 
+            num_reqs = md.seq_lens.shape[0]
+            block_size = q.shape[0] // num_reqs
+            seq_lens_noise = md.seq_lens + block_size
+
             new_kv_cache, outputs = attention(
                 kv_cache,
                 q,
                 k,
                 v,
-                attention_metadata,
+                replace(attention_metadata, seq_lens=seq_lens_noise),
                 self.mesh,
                 self.head_dim_original,
                 q_scale=q_scale,
                 k_scale=k_scale,
                 v_scale=v_scale,
+                use_causal_mask=False,
             )
         elif self.dflash_attention_impl == "concat_dense":
-            outputs = dflash_concat_attention(
-                q,
-                k_ctx,
-                k_noise,
-                v_ctx,
-                v_noise,
-                attention_metadata,
-                max_query_len=self.max_query_len,
-                sm_scale=self.head_dim_original**-0.5,
-            )
-
+            q_target = jnp.zeros(
+                (target_hidden_states.shape[0], self.num_heads, self.head_dim),
+                dtype=q.dtype)
             q_scale = k_scale = v_scale = None
-            k_for_cache = k_noise
-            v_for_cache = v_noise
             if self.kv_cache_quantized_dtype:
                 k_scale = self._k_scale
                 v_scale = self._v_scale
-                k_for_cache, v_for_cache = quantize_kv(
-                    self.kv_cache_quantized_dtype, k_for_cache, v_for_cache,
-                    k_scale, v_scale)
+                k_ctx, v_ctx = quantize_kv(self.kv_cache_quantized_dtype,
+                                           k_ctx, v_ctx, k_scale, v_scale)
+                k_noise, v_noise = quantize_kv(self.kv_cache_quantized_dtype,
+                                               k_noise, v_noise, k_scale,
+                                               v_scale)
 
-            # Keep existing draft KV-cache update behavior using the noise
-            # stream while computing DFlash outputs from concat K/V semantics.
+            # Step 1: Write target tokens to KV cache
             new_kv_cache, _ = attention(
                 kv_cache,
-                q,
-                k_for_cache,
-                v_for_cache,
-                attention_metadata,
+                q_target,
+                k_ctx,
+                v_ctx,
+                replace(attention_metadata,
+                        query_start_loc=target_query_start_loc),
                 self.mesh,
                 self.head_dim_original,
                 q_scale=q_scale,
                 k_scale=k_scale,
                 v_scale=v_scale,
+                use_causal_mask=True,
+                update_kv_cache=True,
+            )
+
+            # Step 2: Compute attention for noise tokens against the full global cache
+            num_reqs = md.seq_lens.shape[0]
+            block_size = q.shape[0] // num_reqs
+            seq_lens_noise = md.seq_lens + block_size
+
+            new_kv_cache, outputs = attention(
+                new_kv_cache,
+                q,
+                k_noise,
+                v_noise,
+                replace(attention_metadata, seq_lens=seq_lens_noise),
+                self.mesh,
+                self.head_dim_original,
+                q_scale=q_scale,
+                k_scale=k_scale,
+                v_scale=v_scale,
+                use_causal_mask=False,
+                update_kv_cache=True,
             )
         else:
             raise ValueError(
@@ -296,21 +316,26 @@ class Qwen3DFlashDecoderLayer(nnx.Module):
         hidden_states: jax.Array,
         target_hidden_states: jax.Array,
         attention_metadata: AttentionMetadata,
-    ) -> Tuple[jax.Array, jax.Array]:
+        target_query_start_loc: jax.Array,
+        target_positions: jax.Array,
+    ) -> Tuple[jax.Array, jax.Array, jax.Array]:
         residual = hidden_states
         hidden_states = self.input_layernorm(hidden_states)
-        kv_cache, attn_out = self.self_attn(
-            kv_cache,
-            hidden_states,
-            target_hidden_states,
-            attention_metadata,
+
+        new_kv_cache, attn_out = self.self_attn(
+            kv_cache=kv_cache,
+            hidden_states=hidden_states,
+            target_hidden_states=target_hidden_states,
+            attention_metadata=attention_metadata,
+            target_query_start_loc=target_query_start_loc,
+            target_positions=target_positions,
         )
         hidden_states = residual + attn_out
         residual = hidden_states
         hidden_states = self.post_attention_layernorm(hidden_states)
         hidden_states = self.mlp(hidden_states)
         hidden_states = residual + hidden_states
-        return kv_cache, hidden_states
+        return new_kv_cache, hidden_states, residual
 
 
 class Qwen3DFlashModel(nnx.Module):
@@ -388,24 +413,29 @@ class Qwen3DFlashModel(nnx.Module):
         input_ids: jax.Array,
         target_hidden_states: jax.Array,
         attention_metadata: AttentionMetadata,
+        target_query_start_loc: jax.Array,
+        target_positions: jax.Array,
     ) -> Tuple[List[jax.Array], jax.Array, List[jax.Array]]:
         hidden_states = self.embed_tokens(input_ids)
 
         num_draft_layers = len(self.layers)
         draft_kv_start = max(0, len(kv_caches) - num_draft_layers)
+        residuals = []
+
         for i, layer in enumerate(self.layers):
             kv_idx = draft_kv_start + i
-            kv_cache, hidden_states = layer(
+            kv_caches[kv_idx], hidden_states, residual = layer(
                 kv_caches[kv_idx],
                 hidden_states,
                 target_hidden_states,
                 attention_metadata,
+                target_query_start_loc,
+                target_positions,
             )
-            kv_caches[kv_idx] = kv_cache
+            residuals.append(residual)
 
-        residual = hidden_states
-        hidden_states = self.norm(hidden_states)
-        return kv_caches, hidden_states, [residual]
+        o = self.norm(hidden_states)
+        return kv_caches, o, residuals
 
     def combine_hidden_states(self, hidden_states: jax.Array) -> jax.Array:
         hidden_states = self.fc(hidden_states)
@@ -465,13 +495,19 @@ class Qwen3DFlashForCausalLM(nnx.Module):
         input_ids: jax.Array,
         target_hidden_states: jax.Array,
         attention_metadata: AttentionMetadata,
-    ) -> Tuple[List[jax.Array], jax.Array, List[jax.Array]]:
-        return self.model(
+        target_query_start_loc: jax.Array,
+        target_positions: jax.Array,
+        **kwargs,
+    ) -> Tuple[List[jax.Array], jax.Array, List[jax.Array], Any]:
+        kv_caches, hidden_states, residuals = self.model(
             kv_caches,
             input_ids,
             target_hidden_states,
             attention_metadata,
+            target_query_start_loc,
+            target_positions,
         )
+        return kv_caches, hidden_states, residuals, None
 
     def compute_logits(self, hidden_states: jax.Array) -> jax.Array:
         return self.model.embed_tokens.decode(hidden_states)

--- a/tpu_inference/spec_decode/jax/dflash.py
+++ b/tpu_inference/spec_decode/jax/dflash.py
@@ -25,11 +25,44 @@ from jax.sharding import NamedSharding, PartitionSpec
 from vllm.config import VllmConfig
 
 from tpu_inference.layers.common.attention_metadata import AttentionMetadata
+from tpu_inference.layers.common.sharding import ShardingAxisName
 from tpu_inference.logger import init_logger
 from tpu_inference.models.common.model_loader import get_model
 from tpu_inference.utils import device_array
 
 logger = init_logger(__name__)
+
+DRAFT_EMBED_PATHS = [
+    "model.embed_tokens.weight", "model.embed.embedding",
+    "model.embed_tokens.embedding", "lm_head.embedding", "lm_head.weight"
+]
+
+TARGET_EMBED_PATHS = [
+    "model.embed_tokens.weight", "model.embed_tokens.embedding",
+    "model.embed.embedding", "embed_tokens.embedding", "embed.embedding"
+]
+
+DRAFT_LM_HEAD_PATHS = [
+    "lm_head.weight", "lm_head.kernel", "model.embed_tokens.weight",
+    "model.embed.embedding", "model.embed_tokens.embedding",
+    "lm_head.embedding"
+]
+
+TARGET_LM_HEAD_PATHS = [
+    "model.lm_head", "lm_head", "lm_head.weight", "lm_head.kernel",
+    "model.embed_tokens.weight", "model.embed.embedding",
+    "model.embed_tokens.embedding", "embed.embedding", "embed_tokens.embedding"
+]
+
+
+def _find_param(state: Any, paths: list[str]) -> Optional[Any]:
+    from tpu_inference.models.jax.utils.weight_utils import get_param
+    for path in paths:
+        try:
+            return get_param(state, path)
+        except ValueError:
+            continue
+    return None
 
 
 class DFlashProposer:
@@ -69,6 +102,10 @@ class DFlashProposer:
 
     def load_model(self, target_model: Any) -> None:
         """Load the DFlash draft model and share embeddings from target."""
+        from tpu_inference import envs
+        from tpu_inference.models.common.model_loader import \
+            resolve_model_architecture
+
         draft_mi = get_model(self.vllm_config,
                              self.rng_key,
                              self.mesh,
@@ -78,33 +115,117 @@ class DFlashProposer:
         self.combine_hidden_states_fn = draft_mi.combine_hidden_states_fn
         self.state = draft_mi.state
 
-        # Share the target model's embedding with the draft model.
-        # Only applicable to flax_nnx state (has .model); vllm-impl state is
-        # a params dict, in which case the draft keeps its own embedding.
-        if hasattr(self.state, "model") and hasattr(target_model, "model"):
-            draft_embed = getattr(self.state.model, "embed_tokens", None)
-            target_embed = getattr(target_model.model, "embed_tokens", None)
-            if target_embed is None:
-                target_embed = getattr(target_model.model, "embed", None)
-            if target_embed is not None:
-                if draft_embed is None or not jnp.any(draft_embed.embedding):
+        draft_model_impl = envs.DRAFT_MODEL_IMPL_TYPE
+        target_model_impl = envs.MODEL_IMPL_TYPE
+        if draft_model_impl == 'auto':
+            draft_model_impl = resolve_model_architecture(
+                self.vllm_config, True)
+        if target_model_impl == 'auto':
+            target_model_impl = resolve_model_architecture(
+                self.vllm_config, False)
+        if draft_model_impl != target_model_impl:
+            raise ValueError(
+                "Draft model implementation must match target model.")
+
+        if draft_model_impl == "flax_nnx":
+
+            def get_target_value(target, paths):
+                # 1. Check PyTorch/vLLM backend
+                if (hasattr(self.runner, "model")
+                        and hasattr(self.runner.model, "model")
+                        and hasattr(self.runner.model.model, "vllm_model")):
+                    vllm_model = self.runner.model.model.vllm_model
+                    for name, param in vllm_model.named_parameters():
+                        full_name = f"vllm_model.{name}"
+                        for path in paths:
+                            if path == full_name or full_name.endswith(
+                                    path) or name == path or name.endswith(
+                                        path):
+                                from torchax.interop import jax_view
+                                return jax_view(param.data)
+
+                # 2. Check flat dict state lookup
+                if isinstance(target,
+                              dict) and not hasattr(target, "flat_state"):
+                    for path in paths:
+                        if path in target:
+                            val = target[path]
+                            return val.value if hasattr(val, "value") else val
+
+                # 3. Check JAX nnx.State
+                param = _find_param(target, paths)
+                return param.value if param is not None else None
+
+            # Resolve draft and target embeddings
+            draft_embed_param = _find_param(self.state, DRAFT_EMBED_PATHS)
+            target_embed_value = get_target_value(target_model,
+                                                  TARGET_EMBED_PATHS)
+
+            if draft_embed_param is not None and target_embed_value is not None:
+                try:
+                    if not jnp.any(draft_embed_param.value):
+                        logger.info(
+                            "Setting draft model embedding to target embedding."
+                        )
+                        draft_embed_param.value = target_embed_value
+                    elif jnp.array_equal(draft_embed_param.value,
+                                         target_embed_value):
+                        logger.info("Draft and target models share embedding.")
+                    else:
+                        logger.warning(
+                            "Draft and target models DO NOT share embedding.")
+                except Exception:
                     logger.info(
-                        "Sharing target model embedding with DFlash draft model."
+                        "Directly setting draft model embedding to target embedding."
                     )
-                    self.state.model.embed_tokens = target_embed
-                elif jnp.array_equal(draft_embed.embedding,
-                                     target_embed.embedding):
+                    draft_embed_param.value = target_embed_value
+            else:
+                logger.warning(
+                    "Failed to locate draft or target embedding parameter.")
+
+            # Resolve draft and target lm_head
+            draft_lm_head_param = _find_param(self.state, DRAFT_LM_HEAD_PATHS)
+            target_lm_head_value = get_target_value(target_model,
+                                                    TARGET_LM_HEAD_PATHS)
+
+            if draft_lm_head_param is not None and target_lm_head_value is not None:
+                try:
+                    if draft_lm_head_param.value.shape == target_lm_head_value.shape:
+                        logger.info(
+                            "Sharing target model lm_head via .value assignment."
+                        )
+                        draft_lm_head_param.value = target_lm_head_value
+                    elif draft_lm_head_param.value.shape == target_lm_head_value.T.shape:
+                        logger.info(
+                            "Sharing target model lm_head via transposed .value assignment."
+                        )
+                        draft_lm_head_param.value = target_lm_head_value.T
+                    else:
+                        logger.warning(
+                            f"Shape mismatch: draft {draft_lm_head_param.value.shape} vs target {target_lm_head_value.shape}."
+                        )
+                except Exception:
                     logger.info(
-                        "Draft embedding identical to target; sharing.")
-                    self.state.model.embed_tokens = target_embed
+                        "Directly setting draft model lm_head to target lm_head."
+                    )
+                    draft_lm_head_param.value = target_lm_head_value
+            else:
+                logger.warning(
+                    "Failed to locate draft or target lm_head parameter.")
+
+        if isinstance(self.state, nnx.State):
+            self.state_leaves = tuple(jax.tree_util.tree_leaves(self.state))
+        else:
+            self.state_leaves = self.state
+        draft_mi = replace(draft_mi, state_leaves=self.state_leaves)
+        self.draft_mi = draft_mi
 
     @functools.partial(jax.jit, static_argnums=(0, ))
-    def _project_aux_hidden(
-            self, state: nnx.State,
-            aux_hidden_states: tuple[jax.Array, ...]) -> jax.Array:
-        """Project and normalise auxiliary hidden states."""
-        raw = jnp.concatenate(aux_hidden_states, axis=-1)
-        return self.combine_hidden_states_fn(state, raw)
+    def _project_aux_hidden(self, state_leaves,
+                            aux_hidden_states: list[jax.Array]) -> jax.Array:
+        """Project auxiliary hidden states (JIT-compiled within prepare_inputs)."""
+        concat_hidden = jnp.concatenate(aux_hidden_states, axis=-1)
+        return self.combine_hidden_states_fn(state_leaves, concat_hidden)
 
     @staticmethod
     def _next_padded_size(n: int) -> int:
@@ -134,71 +255,294 @@ class DFlashProposer:
         noise_positions = seq_lens[:, jnp.newaxis] + offsets
         return noise_input_ids.flatten(), noise_positions.flatten()
 
+    @functools.partial(jax.jit, static_argnums=(0, ))
+    def _compute_token_indices_and_filter(
+        self,
+        is_in_prefill: jax.Array,
+        next_prompt_token_id: jax.Array,
+        last_sampled_token_id: jax.Array,
+        query_start_loc: jax.Array,
+        seq_lens: jax.Array,
+        num_reqs: jax.Array,
+        num_rejected_tokens: jax.Array,
+        input_ids: jax.Array,
+        aux_hidden_states: tuple[jax.Array, ...],
+        input_positions: jax.Array,
+    ):
+        """Computes query metadata after filtering out rejected draft tokens.
+
+        During speculative verification, some draft tokens might get rejected by the target model.
+        This function:
+        1. Compares sequence metadata and rolls back seq_lens based on rejected tokens.
+        2. Derives 1D flat indices (`token_indices`) corresponding ONLY to the accepted tokens.
+        3. Slices the target input IDs, position IDs, and target auxiliary hidden states
+           using these token indices to filter out states/tokens belonging to rejected draft positions.
+        """
+
+        def _compute_token_indices(is_in_prefill, next_prompt_token_id,
+                                   last_sampled_token_id, query_start_loc,
+                                   seq_lens, num_reqs, num_rejected_tokens,
+                                   input_ids):
+            # 1. Determine next token to start generation (prompt token if in prefill, last accepted token if decoding)
+            next_token_ids = jnp.where(is_in_prefill, next_prompt_token_id,
+                                       last_sampled_token_id)
+
+            # 2. Compute original query length and mask padded requests
+            query_len_per_req = (query_start_loc[1:] - query_start_loc[:-1])
+            query_len_per_req = jnp.where(
+                jnp.arange(query_len_per_req.shape[0]) < num_reqs,
+                query_len_per_req, 0)
+            num_rejected_tokens = jnp.where(
+                jnp.arange(num_rejected_tokens.shape[0]) < num_reqs,
+                num_rejected_tokens, 0)
+
+            # 3. Calculate number of accepted tokens per request and derive new query boundaries
+            # Example: query_len_per_req = [5, 5], num_rejected_tokens = [1, 2] -> num_tokens_per_req = [4, 3]
+            num_tokens_per_req = (query_len_per_req - num_rejected_tokens)
+            new_query_start_loc = jnp.cumsum(num_tokens_per_req)
+            new_query_start_loc = jnp.pad(
+                new_query_start_loc, (1, 0),
+                constant_values=0)  # Example: -> [0, 4, 7]
+
+            # 4. Map the new (filtered) token positions back to their original index locations in input_ids.
+            # This is a JAX-friendly vectorized mapping trick to avoid recompilations from dynamic shapes.
+            total_num_tokens = input_ids.shape[0]
+
+            # Repeat the new starting locations for each token in the accepted sequence.
+            # Example: repeat [0, 4] by [4, 3] -> [0, 0, 0, 0, 4, 4, 4, 0, 0, 0] (padded to total_num_tokens)
+            expanded_new_query_start_loc = jnp.repeat(
+                new_query_start_loc[:-1],
+                num_tokens_per_req,
+                total_repeat_length=total_num_tokens)
+
+            # Calculate offset/index within each new filtered segment.
+            # Example: [0..9] - [0,0,0,0,4,4,4,...] -> [0, 1, 2, 3, 0, 1, 2, ...]
+            token_offsets = jnp.arange(total_num_tokens, dtype=jnp.int32)
+            token_offsets -= expanded_new_query_start_loc
+
+            # Repeat the old query start locations.
+            # Example: repeat [0, 5] by [4, 3] -> [0, 0, 0, 0, 5, 5, 5, 0, 0, 0]
+            old_query_start_loc_expanded = jnp.repeat(
+                query_start_loc[:-1],
+                num_tokens_per_req,
+                total_repeat_length=total_num_tokens)
+
+            # Add relative offset to original start index to get absolute token index in the original sequence.
+            # Example: [0,1,2,3,0,1,2,...] + [0,0,0,0,5,5,5,...] -> [0, 1, 2, 3, 5, 6, 7, ...]
+            token_indices = token_offsets + old_query_start_loc_expanded
+
+            # 5. Rollback sequence lengths based on the number of rejected tokens
+            new_seq_lens = seq_lens - num_rejected_tokens
+
+            return (next_token_ids, token_indices, new_query_start_loc,
+                    new_seq_lens)
+
+        data_spec = PartitionSpec(ShardingAxisName.ATTN_DATA)
+        (next_token_ids, token_indices, new_query_start_loc,
+         new_seq_lens) = jax.shard_map(
+             _compute_token_indices,
+             mesh=self.mesh,
+             in_specs=(data_spec, ) * 8,
+             out_specs=(data_spec, ) * 4,
+         )(is_in_prefill, next_prompt_token_id, last_sampled_token_id,
+           query_start_loc, seq_lens, num_reqs, num_rejected_tokens, input_ids)
+
+        def _sharded_select_target_tokens_and_hidden_states(
+                input_ids, token_indices, input_positions, aux_hidden_states):
+            # Extract only the token IDs of accepted tokens
+            target_token_ids = input_ids[token_indices]
+
+            # Slice position IDs for accepted tokens (supporting both 2D and 1D position layouts)
+            if input_positions.ndim == 2:
+                input_positions = input_positions[:, token_indices]
+            else:
+                input_positions = input_positions[token_indices]
+
+            # Filter target auxiliary hidden states from target layers, keeping only accepted token steps
+            aux_states_processed = [
+                h[token_indices] for h in aux_hidden_states
+            ]
+            return target_token_ids, input_positions, aux_states_processed
+
+        positions_spec = (PartitionSpec(None, ShardingAxisName.ATTN_DATA)
+                          if input_positions.ndim == 2 else data_spec)
+
+        target_token_ids, new_input_positions, aux_states_processed = jax.shard_map(
+            _sharded_select_target_tokens_and_hidden_states,
+            mesh=self.mesh,
+            in_specs=(data_spec, data_spec, positions_spec, data_spec),
+            out_specs=(data_spec, positions_spec, data_spec),
+        )(input_ids, token_indices, input_positions, aux_hidden_states)
+
+        return (next_token_ids, new_query_start_loc, new_seq_lens,
+                target_token_ids, new_input_positions, aux_states_processed)
+
     def prepare_inputs(
         self,
         attn_metadata: AttentionMetadata,
         input_ids: jax.Array,
         aux_hidden_states: tuple[jax.Array, ...],
-        next_token_ids: jax.Array,
-        num_rejected_tokens: Optional[jax.Array] = None,
+        last_sampled_token_id: jax.Array,
+        next_prompt_token_id: jax.Array,
+        is_in_prefill: jax.Array,
+        num_rejected_tokens: jax.Array,
+        num_reqs_dp: jax.Array,
     ) -> tuple[jax.Array, jax.Array, jax.Array, AttentionMetadata]:
         """Prepare DFlash inputs with on-device KV cache."""
         assert aux_hidden_states is not None and len(aux_hidden_states) > 0
 
-        # Project new auxiliary hidden states (on-device, JIT'd)
-        # Target hidden states are no longer sliced manually because they contain
-        # only the newly accepted tokens computed in this forward pass.
-        projected = self._project_aux_hidden(self.state, aux_hidden_states)
-        target_hidden = projected.astype(jnp.bfloat16)
-
-        # Build noise block (vectorized for batching)
-        noise_input_ids, noise_positions = self._build_noise_block(
-            attn_metadata.seq_lens,
-            next_token_ids,
-            self.mask_token_id,
-            self.block_size,
-        )
-
-        # Build draft attention metadata
+        # The last KV cache group is for the draft model.
         num_kv_cache_groups = len(self.runner.kv_cache_config.kv_cache_groups)
         draft_kv_cache_group_id = num_kv_cache_groups - 1
         block_tables = (
             self.runner.input_batch.block_table[draft_kv_cache_group_id].
             get_cpu_tensor().reshape(-1))
+        block_tables = device_array(self.mesh,
+                                    block_tables,
+                                    sharding=PartitionSpec(
+                                        ShardingAxisName.ATTN_DATA))
+
+        return self._prepare_inputs(
+            self.state_leaves,
+            block_tables,
+            attn_metadata,
+            input_ids,
+            aux_hidden_states,
+            last_sampled_token_id,
+            next_prompt_token_id,
+            is_in_prefill,
+            num_rejected_tokens,
+            num_reqs_dp,
+        )
+
+    @functools.partial(
+        jax.jit,
+        static_argnums=(0, ),
+    )
+    def _prepare_inputs(
+        self,
+        state_leaves: Any,
+        block_tables: jax.Array,
+        attn_metadata: AttentionMetadata,
+        input_ids: jax.Array,
+        aux_hidden_states: tuple[jax.Array, ...],
+        last_sampled_token_id: jax.Array,
+        next_prompt_token_id: jax.Array,
+        is_in_prefill: jax.Array,
+        num_rejected_tokens: jax.Array,
+        num_reqs_dp: jax.Array,
+    ) -> tuple[jax.Array, jax.Array, jax.Array, AttentionMetadata]:
+        """JIT-compiled core logic for preparing inputs for the draft model.
+
+        Performs:
+        1. Filters out rejected token metadata via `_compute_token_indices_and_filter`.
+        2. Projects the accepted target hidden states into draft model input space.
+        3. Prepares a masked 'noise block' of token IDs and position IDs for generating 
+           speculative proposals.
+        4. Updates AttentionMetadata for the draft model forward pass.
+        """
+        (next_token_ids, new_query_start_loc, new_seq_lens, target_token_ids,
+         new_input_positions,
+         aux_states_processed) = self._compute_token_indices_and_filter(
+             is_in_prefill, next_prompt_token_id, last_sampled_token_id,
+             attn_metadata.query_start_loc, attn_metadata.seq_lens,
+             num_reqs_dp, num_rejected_tokens, input_ids, aux_hidden_states,
+             attn_metadata.input_positions)
+
+        # Project new auxiliary hidden states
+        projected = self._project_aux_hidden(state_leaves,
+                                             aux_states_processed)
+        target_hidden = projected.astype(jnp.bfloat16)
+
+        # Build noise block (vectorized for batching)
+        noise_input_ids, noise_positions = self._build_noise_block(
+            new_seq_lens,
+            next_token_ids,
+            self.mask_token_id,
+            self.block_size,
+        )
+
         num_reqs = attn_metadata.seq_lens.shape[0]
         draft_attn_metadata = replace(
             attn_metadata,
             input_positions=noise_positions,
+            seq_lens=new_seq_lens,
             query_start_loc=jnp.arange(num_reqs + 1, dtype=jnp.int32) *
             self.block_size,
-            block_tables=device_array(self.mesh, block_tables),
+            block_tables=block_tables,
         )
 
         dummy_last_indices = jnp.zeros(num_reqs, dtype=jnp.int32)
         return (
-            (target_hidden, attn_metadata.query_start_loc,
-             attn_metadata.input_positions),
+            (target_hidden, new_query_start_loc, new_input_positions),
             noise_input_ids,
             dummy_last_indices,
             draft_attn_metadata,
         )
 
-    @functools.partial(jax.jit, static_argnums=(0, ))
-    def _sample_block_draft_tokens(
+    @functools.partial(
+        jax.jit,
+        static_argnums=(0, ),
+        donate_argnames=("kv_caches", ),
+        out_shardings=(
+            None,  # kv_caches - keep original sharding
+            None,  # draft_token_ids
+        ),
+        compiler_options={
+            "xla_tpu_all_gather_collective_matmul_mode":
+            "post_spmd_conservative",
+            "xla_tpu_reduce_scatter_collective_matmul_mode":
+            "post_spmd_conservative"
+        },
+    )
+    def _propose(
         self,
-        state: nnx.State,
-        hidden_states: jax.Array,
-    ) -> jax.Array:
-        """Greedy-sample draft tokens from the block output."""
+        state_leaves: Any,
+        kv_caches: list[jax.Array],
+        input_ids: jax.Array,
+        attn_metadata: AttentionMetadata,
+        target_hidden_states: jax.Array,
+    ) -> tuple[list[jax.Array], jnp.ndarray]:
+        """JIT-compiled forward pass of the draft model.
+
+        1. Runs the draft model forward pass using the target model's projected hidden states.
+        2. Reshapes the output hidden states to locate the positions corresponding to the
+           new speculative tokens.
+        3. Computes vocabulary logits and greedily samples the token IDs.
+        4. Constrains the sharding of the drafted token IDs back to ATTN_DATA.
+        """
+        kv_caches, hidden_states, *_ = self.model_fn(
+            state_leaves,
+            kv_caches,
+            input_ids,
+            target_hidden_states,
+            attn_metadata,
+        )
+
         num_reqs = hidden_states.shape[0] // self.block_size
         hidden_states_batched = hidden_states.reshape(
             (num_reqs, self.block_size, -1))
         draft_hidden = hidden_states_batched[:, 1:1 +
                                              self.num_speculative_tokens, :]
-        logits = self.compute_logits_fn(state, draft_hidden, None)
+
+        # Flatten draft_hidden to 2D for compute_logits_fn which expects 2D
+        # shape to satisfy PartitionSpec('data', 'model') for the output logits
+        draft_hidden_flat = draft_hidden.reshape(-1, draft_hidden.shape[-1])
+        logits_flat = self.compute_logits_fn(state_leaves, draft_hidden_flat,
+                                             None)
+
+        logits = logits_flat.reshape(num_reqs, self.num_speculative_tokens, -1)
+
         draft_ids = jnp.argmax(logits, axis=-1)
-        return lax.with_sharding_constraint(
-            draft_ids, NamedSharding(self.mesh, PartitionSpec()))
+        draft_token_ids = lax.with_sharding_constraint(
+            draft_ids,
+            NamedSharding(self.mesh,
+                          PartitionSpec(ShardingAxisName.ATTN_DATA, None)))
+
+        if draft_token_ids.ndim == 1:
+            draft_token_ids = draft_token_ids[jnp.newaxis, :]
+
+        return kv_caches, draft_token_ids
 
     def propose(
         self,
@@ -209,18 +553,10 @@ class DFlashProposer:
         target_hidden_states,
     ) -> tuple[list[jax.Array], jnp.ndarray]:
         """Generate all draft tokens in one forward pass using paged KV cache."""
-        kv_caches, hidden_states, _ = self.model_fn(
-            self.state,
+        return self._propose(
+            self.state_leaves,
             kv_caches,
             input_ids,
-            target_hidden_states,
             attn_metadata,
+            target_hidden_states,
         )
-
-        draft_token_ids = self._sample_block_draft_tokens(
-            self.state, hidden_states)
-
-        if draft_token_ids.ndim == 1:
-            draft_token_ids = draft_token_ids[jnp.newaxis, :]
-
-        return kv_caches, draft_token_ids

--- a/tpu_inference/spec_decode/jax/dflash.py
+++ b/tpu_inference/spec_decode/jax/dflash.py
@@ -19,18 +19,15 @@ from typing import Any, Optional
 
 import jax
 import jax.numpy as jnp
-import numpy as np
 from flax import nnx
 from jax import lax
 from jax.sharding import NamedSharding, PartitionSpec
 from vllm.config import VllmConfig
 
-from tpu_inference import utils
 from tpu_inference.layers.common.attention_metadata import AttentionMetadata
-from tpu_inference.layers.common.sharding import ShardingAxisName
 from tpu_inference.logger import init_logger
 from tpu_inference.models.common.model_loader import get_model
-from tpu_inference.utils import device_array, get_mesh_shape_product
+from tpu_inference.utils import device_array
 
 logger = init_logger(__name__)
 
@@ -66,25 +63,9 @@ class DFlashProposer:
         self.max_num_tokens = runner.max_num_tokens
         self.max_model_len = runner.max_model_len
 
-        # Context length tracking (host-side counter)
-        self._ctx_len: int = 0
-
         # On-device KV caches (allocated in load_model)
         self._draft_kv_caches: Optional[list[jax.Array]] = None
-        self._cache_len: int = 0
         self._max_kv_len: int = 0
-
-        # Track previous seq_len for GPU-compatible crop semantics.
-        # GPU calls past_key_values_draft.crop(start) AFTER each forward
-        # pass, where start = beginning of the CURRENT iteration's block.
-        # This equals the seq_len from the PREVIOUS call to prepare_inputs.
-        # We must match this: cache_len = prev_seq_len, not current seq_len.
-        self._prev_seq_len: int = 0
-
-        # Track the request currently occupying the single proposer slot;
-        # state must be reset when it changes so the previous request's
-        # hidden states do not leak into the next request's prefix.
-        self._last_req_id: Optional[str] = None
 
     def load_model(self, target_model: Any) -> None:
         """Load the DFlash draft model and share embeddings from target."""
@@ -117,34 +98,6 @@ class DFlashProposer:
                         "Draft embedding identical to target; sharing.")
                     self.state.model.embed_tokens = target_embed
 
-        # Allocate on-device KV caches
-        hf_config = self.draft_model_config.hf_config
-
-        sharding_size = get_mesh_shape_product(self.mesh,
-                                               ShardingAxisName.MLP_TENSOR)
-        num_heads = utils.get_padded_num_heads(hf_config.num_attention_heads,
-                                               sharding_size)
-        head_dim_orig = getattr(
-            hf_config, "head_dim",
-            hf_config.hidden_size // hf_config.num_attention_heads)
-        head_dim = utils.get_padded_head_dim(head_dim_orig)
-
-        self._max_kv_len = self._next_padded_size(self.max_model_len)
-        cache_shape = (1, num_heads, self._max_kv_len, head_dim)
-        self._draft_kv_caches = []
-        for _ in range(self.num_layers):
-            k_cache = jnp.zeros(cache_shape, dtype=jnp.bfloat16)
-            v_cache = jnp.zeros(cache_shape, dtype=jnp.bfloat16)
-            self._draft_kv_caches.append(k_cache)
-            self._draft_kv_caches.append(v_cache)
-        self._cache_len = 0
-
-        logger.info(
-            "Allocated DFlash on-device KV caches: %d layers, shape %s",
-            self.num_layers,
-            cache_shape,
-        )
-
     @functools.partial(jax.jit, static_argnums=(0, ))
     def _project_aux_hidden(
             self, state: nnx.State,
@@ -166,20 +119,20 @@ class DFlashProposer:
     @functools.partial(jax.jit, static_argnums=(0, 3, 4))
     def _build_noise_block(
         self,
-        seq_len_arr: jax.Array,
+        seq_lens: jax.Array,
         next_token_ids: jax.Array,
         mask_token_id: int,
         block_size: int,
     ) -> tuple[jax.Array, jax.Array]:
-        """Build noise block and positions (JIT-compiled)."""
-        seq_len = seq_len_arr[0]
-        first_token = next_token_ids[0]
-        noise_input_ids = jnp.full((block_size, ),
+        """Build noise block and positions for a batch (JIT-compiled)."""
+        num_reqs = next_token_ids.shape[0]
+        noise_input_ids = jnp.full((num_reqs, block_size),
                                    mask_token_id,
                                    dtype=jnp.int32)
-        noise_input_ids = noise_input_ids.at[0].set(first_token)
-        noise_positions = jnp.arange(block_size, dtype=jnp.int32) + seq_len
-        return noise_input_ids, noise_positions
+        noise_input_ids = noise_input_ids.at[:, 0].set(next_token_ids)
+        offsets = jnp.arange(block_size, dtype=jnp.int32)[jnp.newaxis, :]
+        noise_positions = seq_lens[:, jnp.newaxis] + offsets
+        return noise_input_ids.flatten(), noise_positions.flatten()
 
     def prepare_inputs(
         self,
@@ -192,94 +145,21 @@ class DFlashProposer:
         """Prepare DFlash inputs with on-device KV cache."""
         assert aux_hidden_states is not None and len(aux_hidden_states) > 0
 
-        # Reset proposer state when the single slot's request changes.
-        req_ids = self.runner.input_batch.req_ids
-        current_req_id = req_ids[0] if req_ids else None
-        if current_req_id != self._last_req_id:
-            self._ctx_len = 0
-            self._cache_len = 0
-            self._prev_seq_len = 0
-            self._last_req_id = current_req_id
-
-        # 1. Current sequence length
-        seq_len_jax = attn_metadata.seq_lens[0]
-        seq_len = int(jax.device_get(seq_len_jax))
-
-        # 2. Crop cache to match GPU DynamicCache.crop(start) semantics.
-        #
-        # GPU reference (zhongyan_dev/dflash/model/dflash.py line 246):
-        #   past_key_values_draft.crop(start)
-        # where `start` = beginning of the CURRENT block = position of
-        # the first accepted token from the previous iteration.
-        #
-        # After crop, GPU cache_seq_len = start, which equals the seq_len
-        # from the PREVIOUS prepare_inputs call (not the current one).
-        # Context + noise are then written starting from this position.
-        #
-        # Bug was: self._cache_len = seq_len (CURRENT accepted position),
-        # which left stale noise K/V entries from the previous iteration
-        # in positions [prev_seq_len, seq_len) and shifted all subsequent
-        # RoPE positions, accumulating errors every iteration.
-        if self._prev_seq_len > 0:
-            self._cache_len = self._prev_seq_len
-
-        if seq_len < self._ctx_len:
-            self._ctx_len = seq_len
-        self._prev_seq_len = seq_len
-
-        # 3. Project new auxiliary hidden states (on-device, JIT'd)
+        # Project new auxiliary hidden states (on-device, JIT'd)
+        # Target hidden states are no longer sliced manually because they contain
+        # only the newly accepted tokens computed in this forward pass.
         projected = self._project_aux_hidden(self.state, aux_hidden_states)
+        target_hidden = projected.astype(jnp.bfloat16)
 
-        # 4. Compute context update — slicing and padding stay on device
-        #    to avoid host<->TPU transfer overhead.
-        num_new = seq_len - self._ctx_len
-        if num_new <= 0:
-            # Full rejection — trim context tracking, use zero placeholder.
-            # Noise writes at cache_len + 0, completely overwriting padding.
-            self._ctx_len = seq_len
-            self._cache_len = min(self._cache_len, seq_len)
-            actual_new_ctx_count = 0
-            new_ctx_jax = device_array(
-                self.mesh,
-                jnp.zeros((16, self.hidden_size), dtype=jnp.bfloat16),
-            )
-        else:
-            end = min(self._ctx_len + num_new, self.max_model_len)
-            n_copy = end - self._ctx_len
-            actual_new_ctx_count = n_copy
-            self._ctx_len = end
-
-            # 5. Slice and pad on device — no host<->TPU transfer.
-            # Padding to power-of-2 sizes (16/32/64/128) means JIT only
-            # traces ~4 unique shapes, eliminating per-token retracing.
-            ctx = projected[:n_copy].astype(jnp.bfloat16)
-            padded_size = self._next_padded_size(n_copy)
-            if padded_size > n_copy:
-                pad = jnp.zeros(
-                    (padded_size - n_copy, self.hidden_size),
-                    dtype=jnp.bfloat16,
-                )
-                ctx = jnp.concatenate([ctx, pad], axis=0)
-            new_ctx_jax = device_array(self.mesh, ctx)
-
-        # 6. Build noise block
-        seq_len_arr = device_array(self.mesh,
-                                   np.array([seq_len], dtype=np.int32))
+        # Build noise block (vectorized for batching)
         noise_input_ids, noise_positions = self._build_noise_block(
-            seq_len_arr,
+            attn_metadata.seq_lens,
             next_token_ids,
             self.mask_token_id,
             self.block_size,
         )
 
-        # 7. Pack target_hidden_states as 3-tuple (always same pytree shape)
-        cache_len_arr = device_array(
-            self.mesh, np.array([self._cache_len], dtype=np.int32))
-        actual_ctx_count_arr = device_array(
-            self.mesh, np.array([actual_new_ctx_count], dtype=np.int32))
-        target_hidden = (new_ctx_jax, cache_len_arr, actual_ctx_count_arr)
-
-        # 8. Build draft attention metadata
+        # Build draft attention metadata
         num_kv_cache_groups = len(self.runner.kv_cache_config.kv_cache_groups)
         draft_kv_cache_group_id = num_kv_cache_groups - 1
         block_tables = (
@@ -289,13 +169,15 @@ class DFlashProposer:
         draft_attn_metadata = replace(
             attn_metadata,
             input_positions=noise_positions,
-            query_start_loc=jnp.array([0, self.block_size], dtype=jnp.int32),
+            query_start_loc=jnp.arange(num_reqs + 1, dtype=jnp.int32) *
+            self.block_size,
             block_tables=device_array(self.mesh, block_tables),
         )
 
         dummy_last_indices = jnp.zeros(num_reqs, dtype=jnp.int32)
         return (
-            target_hidden,
+            (target_hidden, attn_metadata.query_start_loc,
+             attn_metadata.input_positions),
             noise_input_ids,
             dummy_last_indices,
             draft_attn_metadata,
@@ -308,7 +190,11 @@ class DFlashProposer:
         hidden_states: jax.Array,
     ) -> jax.Array:
         """Greedy-sample draft tokens from the block output."""
-        draft_hidden = hidden_states[1:1 + self.num_speculative_tokens]
+        num_reqs = hidden_states.shape[0] // self.block_size
+        hidden_states_batched = hidden_states.reshape(
+            (num_reqs, self.block_size, -1))
+        draft_hidden = hidden_states_batched[:, 1:1 +
+                                             self.num_speculative_tokens, :]
         logits = self.compute_logits_fn(state, draft_hidden, None)
         draft_ids = jnp.argmax(logits, axis=-1)
         return lax.with_sharding_constraint(
@@ -322,27 +208,14 @@ class DFlashProposer:
         last_token_indices: jax.Array,
         target_hidden_states,
     ) -> tuple[list[jax.Array], jnp.ndarray]:
-        """Generate all draft tokens in one forward pass."""
-        # Use our own on-device KV caches
-        draft_kv_caches, hidden_states, _ = self.model_fn(
+        """Generate all draft tokens in one forward pass using paged KV cache."""
+        kv_caches, hidden_states, _ = self.model_fn(
             self.state,
-            self._draft_kv_caches,
+            kv_caches,
             input_ids,
             target_hidden_states,
             attn_metadata,
         )
-
-        # Update cached references
-        self._draft_kv_caches = draft_kv_caches
-
-        # Update cache_len: model wrote actual_ctx_count + T_noise entries.
-        # This will be corrected at the start of the next prepare_inputs
-        # to match the actual accepted seq_len.
-        _, cache_len_arr, actual_ctx_count_arr = target_hidden_states
-        old_cache_len = int(jax.device_get(cache_len_arr)[0])
-        actual_ctx_count = int(jax.device_get(actual_ctx_count_arr)[0])
-        T_noise = self.block_size
-        self._cache_len = old_cache_len + actual_ctx_count + T_noise
 
         draft_token_ids = self._sample_block_draft_tokens(
             self.state, hidden_states)
@@ -350,5 +223,4 @@ class DFlashProposer:
         if draft_token_ids.ndim == 1:
             draft_token_ids = draft_token_ids[jnp.newaxis, :]
 
-        # Pass the FRAMEWORK kv_caches through unchanged
         return kv_caches, draft_token_ids


### PR DESCRIPTION
**Description**
This PR refactors the DFlash speculator/proposer and model layers to use the JAX/TPU framework's global paged kv_caches and block_tables instead of a local dense cache. It also vectorizes input preparation and model forward calls to support dynamic multi-request batching (num_reqs > 1).

**Why is this change being made / Context**
Previously, DFlash maintained a local, contiguous array for its KV cache, allocated as (1, num_heads, max_kv_len, head_dim). This design limited DFlash to a batch size of 1 (num_reqs == 1) and prevented cache sharing or persistence across different requests. When the inference runner swapped requests (e.g., due to continuous batching swaps or preemption), DFlash had to wipe its local state (resetting _ctx_len and _cache_len to 0) and reconstruct the context from scratch on the next forward pass.

**Why this is a good solution**
By refactoring DFlash to use the global paged memory structure already managed by the runner:

Multi-request dynamic batching is fully enabled, allowing the speculator to run concurrently across batched sequences.
Cross-request cache persistence is achieved naturally, as the framework's page-level memory manager handles swapping and page mapping across request IDs.
Stateless proposer: It eliminates fragile manual state tracking (_ctx_len, _cache_len, _prev_seq_len) in the proposer, reducing edge-case bugs around cache cropping and recompute.

**Implementation Details**
Proposer (`dflash.py` (spec_decode)): Removed all local state-tracking variables. prepare_inputs now handles dynamic batch sizes, computing target hidden states, and vectorizing noise block construction (_build_noise_block). It propagates the global block_tables as part of the attention metadata.

Model & Attention (`dflash.py` (models)): Modified DFlashForCausalLM and layers to accept the paged kv_caches and target token metadata, passing them through to the attention layers. Registered DFlashForCausalLM in model_loader.py.

Attention Kernel (`DFlashAttention`): Replaced the dense lax.dynamic_update_slice and flash_attention logic with a two-step execution using the optimized ragged_paged_attention kernel:

1. Writes the target accepted tokens to the paged KV cache (using a causal mask to prevent attention leakage).
2. Writes the draft noise tokens to the cache, performs a non-causal attention pass over the full context, and computes logits.

**Shortcomings & Future Improvements**
Currently, the two-step paged attention requires two successive invocations of ragged_paged_attention per forward pass because the first step writes the target tokens under a causal mask, and the second step writes and attends to the draft tokens non-causally. Combining these steps into a single unified pass if/when supported by the kernel could yield further speedups.

**Tests**
I have verified the correctness and batched behavior using the following:

Unit & Correctness Tests

1. Updated test_dflash.py to match the new batched tensor layouts.
2. Removed the obsolete stateful flow test (test_dflash_proposer_multi_iteration_state_flow) since DFlash is now stateless.
3. Added test_build_noise_block_batched to verify vectorized noise block construction across multiple requests.

Checklist
Before submitting this PR, please make sure:

- I have performed a self-review of my code.

- I have necessary comments in my code, particularly in hard-to-understand areas.

- I have made or will make corresponding changes to any relevant documentation.