### PR TITLE
[releases/v0.23.0] Cherry-pick #2915: Apply explicit shutdown to all other test files

### DIFF
--- a/tests/core/test_dp_group_sampling_prefix_cache.py
+++ b/tests/core/test_dp_group_sampling_prefix_cache.py
@@ -54,8 +54,7 @@ def llm():
         data_parallel_size=2,
     )
     yield engine
-    del engine
-    time.sleep(5)
+    engine.llm_engine.engine_core.shutdown()
 
 
 class TestGroupSamplingPrefixCache:

--- a/tests/e2e/test_async_scheduler.py
+++ b/tests/e2e/test_async_scheduler.py
@@ -99,9 +99,7 @@ def _test_performance_helper(monkeypatch: pytest.MonkeyPatch,
         _ = ref_llm.generate(test_prompts, sampling_config)
         ref_time = time.time() - start_time
 
-        del ref_llm
-        # Waiting for TPUs to be released
-        time.sleep(10)
+        ref_llm.llm_engine.engine_core.shutdown()
 
         # # Test async LLM timing with max_num_seqs=256
         async_llm = LLM(model=model_name,
@@ -115,9 +113,7 @@ def _test_performance_helper(monkeypatch: pytest.MonkeyPatch,
         _ = async_llm.generate(test_prompts, sampling_config)
         async_time = time.time() - start_time
 
-        del async_llm
-        # # Waiting for TPUs to be released
-        time.sleep(10)
+        async_llm.llm_engine.engine_core.shutdown()
 
         speedup = ref_time / async_time
         print(f"Reference LLM time: {ref_time:.2f}s")
@@ -168,10 +164,7 @@ def _test_correctness_helper(
                       async_scheduling=0)
         ref_outputs = ref_llm.generate(test_prompts, sampling_config)
 
-        del ref_llm
-
-        # Waiting for TPUs to be released.
-        time.sleep(10)
+        ref_llm.llm_engine.engine_core.shutdown()
 
         async_llm = LLM(model=model_name,
                         max_model_len=1024,
@@ -196,10 +189,7 @@ def _test_correctness_helper(
                 )
 
         assert misses <= 5  # Adjusted the performance thresholds for this specific test to better reflect the realities of the CI environment
-        del async_llm
-
-        # Waiting for TPUs to be released.
-        time.sleep(10)
+        async_llm.llm_engine.engine_core.shutdown()
 
 
 def test_async_correctness(

--- a/tests/e2e/test_continue_decode.py
+++ b/tests/e2e/test_continue_decode.py
@@ -62,9 +62,8 @@ def _run_inference_and_return_outputs(
         latency = time.time() - start_time
         return outputs, latency
     finally:
-        del llm
+        llm.llm_engine.engine_core.shutdown()
         gc.collect()
-        time.sleep(15)
 
 
 def _check_correctness(test_name: str, baseline_outputs: list,

--- a/tests/e2e/test_data_parallel.py
+++ b/tests/e2e/test_data_parallel.py
@@ -98,8 +98,7 @@ def _run_inference(
     outputs = llm.generate(test_prompts, sampling_params)
     elapsed_time = time.time() - start_time
 
-    del llm
-    time.sleep(15)
+    llm.llm_engine.engine_core.shutdown()
     return outputs, elapsed_time
 
 

--- a/tests/e2e/test_expert_parallel.py
+++ b/tests/e2e/test_expert_parallel.py
@@ -88,8 +88,7 @@ def _run_inference(
     outputs = llm.generate(test_prompts, sampling_params)
     elapsed_time = time.time() - start_time
 
-    del llm
-    time.sleep(10)
+    llm.llm_engine.engine_core.shutdown()
     return outputs, elapsed_time
 
 

--- a/tests/e2e/test_hybrid_kvcache.py
+++ b/tests/e2e/test_hybrid_kvcache.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import os
-import time
 
 import pytest
 from vllm import LLM, SamplingParams
@@ -68,9 +67,7 @@ def _run_inference_with_config(
         outputs = llm.generate(test_prompts, sampling_params)
         return outputs
     finally:
-        del llm
-        # Wait for TPUs to be released
-        time.sleep(10)
+        llm.llm_engine.engine_core.shutdown()
 
 
 def test_hybrid_kv_cache(

--- a/tests/e2e/test_pipeline_parallel.py
+++ b/tests/e2e/test_pipeline_parallel.py
@@ -2,7 +2,6 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import os
-import time
 
 import pytest
 from vllm import LLM, SamplingParams
@@ -72,9 +71,7 @@ def _run_inference_with_config(model_name: str,
         outputs = llm.generate(test_prompts, sampling_params)
         return outputs
     finally:
-        del llm
-        # Wait for TPUs to be released
-        time.sleep(15)
+        llm.llm_engine.engine_core.shutdown()
 
 
 @pytest.mark.parametrize(

--- a/tests/e2e/test_rl_integration.py
+++ b/tests/e2e/test_rl_integration.py
@@ -63,8 +63,7 @@ def llm():
         enable_prefix_caching=True,
     )
     yield engine
-    del engine
-    time.sleep(5)
+    engine.llm_engine.engine_core.shutdown()
 
 
 @pytest.fixture

--- a/tests/e2e/test_sequence_parallelism.py
+++ b/tests/e2e/test_sequence_parallelism.py
@@ -102,8 +102,7 @@ def _run_inference(
     outputs = llm.generate(test_prompts, sampling_params)
     elapsed_time = time.time() - start_time
 
-    del llm
-    time.sleep(10)  # Wait for TPUs to be released
+    llm.llm_engine.engine_core.shutdown()
     return outputs, elapsed_time
 
 

--- a/tests/e2e/test_speculative_decoding.py
+++ b/tests/e2e/test_speculative_decoding.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 import os
 import random
 import string
-import time
 
 import pytest
 from vllm import LLM, SamplingParams
@@ -352,9 +351,7 @@ def _test_performance_helper(
             print("num_accepted_tokens:" + str(num_accepted_tokens))
             print("num_draft_tokens:" + str(num_draft_tokens))
 
-        del spec_llm
-        # Waiting for TPUs to be released
-        time.sleep(30)
+        spec_llm.llm_engine.engine_core.shutdown()
 
         assert acceptance_rate >= min_acceptance_rate, f"Expected at least {min_acceptance_rate:.2%} acceptance rate for {speculative_config['method']}, got {acceptance_rate:.2%}"
 

--- a/tests/e2e/test_tensor_parallel.py
+++ b/tests/e2e/test_tensor_parallel.py
@@ -91,8 +91,7 @@ def _run_inference(
     outputs = llm.generate(test_prompts, sampling_params)
     elapsed_time = time.time() - start_time
 
-    del llm
-    time.sleep(10)
+    llm.llm_engine.engine_core.shutdown()
     return outputs, elapsed_time
 
 

--- a/tests/lora/test_lora.py
+++ b/tests/lora/test_lora.py
@@ -14,7 +14,6 @@
 
 # https://github.com/vllm-project/vllm/blob/ed10f3cea199a7a1f3532fbe367f5c5479a6cae9/tests/tpu/lora/test_lora.py
 import os
-import time
 
 import pytest
 import vllm
@@ -72,8 +71,7 @@ def test_single_lora(tp):
     assert answer.isdigit()
     assert int(answer) == 2
 
-    del llm
-    time.sleep(10)
+    llm.llm_engine.engine_core.shutdown()
 
 
 @pytest.mark.parametrize("tp", TP)
@@ -107,8 +105,7 @@ def test_lora_hotswapping(tp):
         assert answer.isdigit()
         assert int(answer) == i + 1, f"Expected {i + 1}, got {answer}"
 
-    del llm
-    time.sleep(10)
+    llm.llm_engine.engine_core.shutdown()
 
 
 @pytest.mark.parametrize("tp", TP)
@@ -144,5 +141,4 @@ def test_multi_lora(tp):
             output.strip()
             [0]) == i + 1, f"Expected {i + 1}, got {int(output.strip()[0])}"
 
-    del llm
-    time.sleep(10)
+    llm.llm_engine.engine_core.shutdown()

--- a/tests/lora/test_lora_perf.py
+++ b/tests/lora/test_lora_perf.py
@@ -39,9 +39,7 @@ def test_lora_performance(tp):
     )[0].outputs[0].text
     base_time = time.time() - start_time
 
-    del llm_without_lora
-    # Waiting for TPUs to be released
-    time.sleep(10)
+    llm_without_lora.llm_engine.engine_core.shutdown()
 
     llm_with_lora = vllm.LLM(model="Qwen/Qwen2.5-3B-Instruct",
                              max_model_len=256,
@@ -64,4 +62,4 @@ def test_lora_performance(tp):
     assert (base_time /
             lora_time) < 8, f"Base time: {base_time}, LoRA time: {lora_time}"
 
-    del llm_with_lora
+    llm_with_lora.llm_engine.engine_core.shutdown()

--- a/tests/offload/tpu_offload_accuracy_test.py
+++ b/tests/offload/tpu_offload_accuracy_test.py
@@ -142,9 +142,7 @@ def _test_kv_cache_cpu_offloading_accuracy(
             assert out_tokens1[i] == out_tokens2[
                 i], f"Token mismatch in request {i}"
 
-        del llm
-        # Waiting for TPUs to be released.
-        time.sleep(20)
+        llm.llm_engine.engine_core.shutdown()
         return pass1_time, pass2_time
 
 

--- a/tests/runner/test_async_logprobs.py
+++ b/tests/runner/test_async_logprobs.py
@@ -22,7 +22,6 @@
 from __future__ import annotations
 
 import os
-import time
 
 import pytest
 from vllm import LLM, SamplingParams
@@ -51,8 +50,7 @@ def llm():
         max_num_seqs=MAX_NUM_SEQS,
     )
     yield engine
-    del engine
-    time.sleep(5)
+    engine.llm_engine.engine_core.shutdown()
 
 
 class TestAsyncLogprobs:

--- a/tests/runner/test_moe_expert_ids.py
+++ b/tests/runner/test_moe_expert_ids.py
@@ -37,11 +37,9 @@ def llm_enabled():
         enable_return_routed_experts=True,
     )
     yield engine
-    del engine
+    engine.llm_engine.engine_core.shutdown()
     import gc
     gc.collect()
-    import time
-    time.sleep(10)
 
 
 @pytest.fixture(scope="function")
@@ -62,11 +60,9 @@ def llm_disabled():
         enable_return_routed_experts=False,
     )
     yield engine
-    del engine
+    engine.llm_engine.engine_core.shutdown()
     import gc
     gc.collect()
-    import time
-    time.sleep(10)
 
 
 class TestMoEExpertIds:

--- a/tests/runner/test_processed_logprobs.py
+++ b/tests/runner/test_processed_logprobs.py
@@ -22,7 +22,6 @@
 from __future__ import annotations
 
 import os
-import time
 
 import pytest
 from vllm import LLM, SamplingParams
@@ -51,8 +50,7 @@ def llm():
         max_num_seqs=MAX_NUM_SEQS,
     )
     yield engine
-    del engine
-    time.sleep(5)
+    engine.llm_engine.engine_core.shutdown()
 
 
 class TestProcessedLogprobs:


### PR DESCRIPTION
Cherry-pick of #2915 (https://github.com/vllm-project/tpu-inference/pull/2915) onto `releases/v0.23.0`.

## What it does
Extends #2882's fix to the remaining e2e/unit test files: replaces the `del llm; time.sleep(10)` teardown with an explicit `llm.llm_engine.engine_core.shutdown()`. The old pattern only drops a Python reference and waits a fixed time, hoping GC finalizes the EngineCore worker processes that hold the TPU — a race. When the workers outlive the sleep, the next `LLM(...)` fails to acquire the TPU:

```
jax.errors.JaxRuntimeError: ABORTED: The TPU is already in use by process with pid N
  (or) ABORTED: Internal error when accessing libtpu multi-process lockfile
  -> RuntimeError: Engine core initialization failed.
```

Explicit `shutdown()` deterministically terminates those workers before the next LLM starts.

## Why cherry-pick to v0.23.0
This `libtpu`-contention is the dominant infra failure on the v0.23.0 release nightly (and on `main`), hitting DP/EP/TP/SP/async-scheduler/LoRA correctness+perf jobs.

## Verification
Validated on the dev pipeline (build #566) against `releases/v0.23.0` + this change, running the affected tests on the queues matching the nightly (DP/EP/TP/SP on tpu_v7x_8, async + LoRA_Torch on tpu_v7x_2). All 6 passed with zero `libtpu lockfile` / "TPU already in use" errors.

Clean cherry-pick; touches only test files (no production code).