### PR TITLE
[releases/v0.23.0] Cherry-pick #2916: Enable processed_logprobs mode in test fixture

### DIFF
--- a/tests/runner/test_processed_logprobs.py
+++ b/tests/runner/test_processed_logprobs.py
@@ -48,6 +48,7 @@ def llm():
         model=MODEL_NAME,
         max_model_len=MAX_MODEL_LEN,
         max_num_seqs=MAX_NUM_SEQS,
+        logprobs_mode="processed_logprobs",
     )
     yield engine
     engine.llm_engine.engine_core.shutdown()


### PR DESCRIPTION
Cherry-pick of #2916 (https://github.com/vllm-project/tpu-inference/pull/2916) onto `releases/v0.23.0`.

## What it fixes
`tests/runner/test_processed_logprobs.py::test_processed_logprobs_reflect_temperature` fails on the v0.23.0 nightly (and on `main`) because the test fixture's `LLM(...)` did not set `logprobs_mode="processed_logprobs"`, so the engine returned raw (un-temperature-scaled) logprobs and the temperature-reflection assertion failed.

#2916 adds the single missing line `logprobs_mode="processed_logprobs"` to the fixture. Test-only config fix, no production code.

This is the genuine (non-infra) failure identified in the v0.23.0 nightly triage; it was confirmed inherited from `main`, and #2916 fixes it there.

Clean cherry-pick (1-line addition).