### PR TITLE
[CI] Fix Kimi-K2.6 nightly: lower gpu-memory-utilization (OOM) + mmlu client --trust-remote-code

### DIFF
--- a/tests/e2e/benchmarking/mlperf.sh
+++ b/tests/e2e/benchmarking/mlperf.sh
@@ -324,7 +324,7 @@ for model_name in $model_list; do
             max_batched_tokens=1024
             if [[ "${model_name,,}" == *"kimi"* ]]; then
                 served_name=moonshotai/Kimi-K2.6
-                current_serve_args+=(--kv-cache-dtype=fp8 --gpu-memory-utilization 0.977 --limit-mm-per-prompt='{"image": 0, "video": 0, "vision_chunk": 0}' )
+                current_serve_args+=(--kv-cache-dtype=fp8 --gpu-memory-utilization 0.95 --limit-mm-per-prompt='{"image": 0, "video": 0, "vision_chunk": 0}' )
                 current_serve_args+=(--served-model-name "${served_name}"  --load-format=runai_streamer --enable-expert-parallel  --trust-remote-code --kv-cache-dtype=fp8 --additional-config '{"sharding": {"sharding_strategy": {"enable_dp_attention": true, "tensor_parallelism": '"${DEVICE_COUNT}"'}}}')
             else
                 served_name=deepseek-ai/DeepSeek-R1

--- a/tests/e2e/benchmarking/mmlu.sh
+++ b/tests/e2e/benchmarking/mmlu.sh
@@ -332,6 +332,7 @@ for model_name in $model_list; do
     --dataset-path "$dataset_path" \
     --num-prompts "$num_prompts" \
     --mmlu-output-len "${mmlu_output_len}" \
+    --trust-remote-code \
     --run-eval 2>&1 | tee -a "$BENCHMARK_LOG_FILE"
 
     checkThroughputAndAccuracy

--- a/tests/e2e/benchmarking/mmlu.sh
+++ b/tests/e2e/benchmarking/mmlu.sh
@@ -304,7 +304,7 @@ for model_name in $model_list; do
             max_batched_tokens=1024
             served_name=moonshotai/Kimi-K2.6
             TARGET_ACCURACY="0.87"
-            current_serve_args+=(--kv-cache-dtype=fp8 --gpu-memory-utilization 0.977 --limit-mm-per-prompt='{"image": 0, "video": 0, "vision_chunk": 0}' )
+            current_serve_args+=(--kv-cache-dtype=fp8 --gpu-memory-utilization 0.95 --limit-mm-per-prompt='{"image": 0, "video": 0, "vision_chunk": 0}' )
             current_serve_args+=(--served-model-name "${served_name}" --load-format=runai_streamer --enable-expert-parallel --trust-remote-code --kv-cache-dtype=fp8 --additional-config '{"sharding": {"sharding_strategy": {"enable_dp_attention": true, "tensor_parallelism": '"${current_device_count}"'}}}')
         fi
     fi


### PR DESCRIPTION
## Summary
Fixes both failures on the `tpu7x` Kimi-K2.6 nightly jobs:
1. **OOM** in the Unit test (`mlperf.sh`) — `CompileTimeHbmOom`.
2. **trust_remote_code** error in the Accuracy test (`mmlu.sh`) — benchmark-client tokenizer load.

Because the Kimi jobs are chained (Unit test -> Accuracy -> Performance), the OOM in the Unit test was also skipping the Accuracy/Performance jobs.

## Changes
- `tests/e2e/benchmarking/mmlu.sh` + `tests/e2e/benchmarking/mlperf.sh`: lower the Kimi-K2.6 serve arg `--gpu-memory-utilization` from `0.977` -> `0.95`.
- `tests/e2e/benchmarking/mmlu.sh`: pass `--trust-remote-code` to the `benchmark_serving.py` client.

---

## Fix 1 — OOM (`gpu-memory-utilization 0.977 -> 0.95`)
**Symptom:** `jax.errors.JaxRuntimeError: RESOURCE_EXHAUSTED: CompileTimeHbmOom — Used 94.78G of 94.75G hbm. Exceeded hbm capacity by 35.55M.` The XLA compile needed ~36 MB more than the leftover HBM after the KV pool (which `0.977` reserves). Lowering `gpu-memory-utilization` frees HBM for the compile scratch; KV stays ample for the MMLU batch.

**Root cause bisected to #2836** ("Add SparseCore ragged_gather_v2 + ragged_gather_reduce_v2 MoE kernels"), which raised peak HBM enough to tip Kimi over the `0.977` ceiling. vLLM version was ruled out (held constant during the bisect). Evidence on the dev pipeline (Kimi Unit test `mlperf.sh`, identical config):
- Commit before #2836 — **FIT**: https://buildkite.com/tpu-commons/tpu-inference-dev/builds/575
- Commit at #2836 — **OOM**: https://buildkite.com/tpu-commons/tpu-inference-dev/builds/576

## Fix 2 — `--trust-remote-code` on the mmlu benchmark client
**Symptom:** `ValueError: The repository moonshotai/Kimi-K2.6 contains custom code which must be executed ... Please pass trust_remote_code=True` (transformers `resolve_trust_remote_code`). `mmlu.sh` passed `--trust-remote-code` to the vLLM server but not to the `benchmark_serving.py` client (whose `get_tokenizer` defaults `trust_remote_code=False`). `mlperf.sh`'s client already passes it; `mmlu.sh` was the gap.

---

## Verification (dev pipeline, current main vLLM)
Combined fix verified on a branch = current `main` + both changes, built against main's current vLLM LKG (newer than the rev that first OOM'd), running both Kimi jobs:
**https://buildkite.com/tpu-commons/tpu-inference-dev/builds/578** — build PASSED:
- `tpu7x Kimi-K2.6 UNIT test (mlperf.sh)` -> **PASSED**, no `CompileTimeHbmOom`.
- `tpu7x Kimi-K2.6 ACCURACY (mmlu.sh)` -> **PASSED**, accuracy **0.911 >= 0.87**, no trust_remote_code error.