### PR TITLE
[skip ci] Make tpu-inference-dev self-contained again (stop uploading pipeline_build.yml)

### DIFF
--- a/.buildkite/pipeline_dev.yml
+++ b/.buildkite/pipeline_dev.yml
@@ -37,6 +37,17 @@
 
 steps:
 
+  # -----------------------------------------------------------------
+  # Build Step (required by all demo steps below)
+  # -----------------------------------------------------------------
+  - label: ":docker: Build and Push Base Image (tpu7x)"
+    key: tpu7x_build_docker
+    agents:
+      queue: cpu_64_core
+    env:
+      TPU_VERSION: "tpu7x"
+    commands:
+      - bash -c 'source .buildkite/scripts/setup_docker_env.sh && setup_environment "vllm-tpu" "false" "true"'
 
   # -----------------------------------------------------------------
   # Demo 1: offline_inference.py
@@ -45,6 +56,7 @@ steps:
   # -----------------------------------------------------------------
   - label: "tpu7x [demo] offline_inference.py"
     key: tpu7x_demo_offline_inference
+    depends_on: tpu7x_build_docker
     env:
       USE_PREBUILT_IMAGE: "1"
       TPU_VERSION: "tpu7x"
@@ -69,6 +81,7 @@ steps:
   # -----------------------------------------------------------------
   - label: "tpu7x [demo] vllm serve + vllm bench serve"
     key: tpu7x_demo_serve_bench
+    depends_on: tpu7x_build_docker
     env:
       USE_PREBUILT_IMAGE: "1"
       TPU_VERSION: "tpu7x"
@@ -88,6 +101,7 @@ steps:
   # -----------------------------------------------------------------
   - label: "tpu7x [demo] E2E disaggregation (DCN P/D)"
     key: tpu7x_demo_disagg
+    depends_on: tpu7x_build_docker
     env:
       USE_PREBUILT_IMAGE: "1"
       TPU_VERSION: "tpu7x"

--- a/.buildkite/scripts/bootstrap_dev.sh
+++ b/.buildkite/scripts/bootstrap_dev.sh
@@ -45,7 +45,4 @@ DEV_PIPELINE_FILE="${DEV_PIPELINE_FILE:-.buildkite/pipeline_dev.yml}"
 echo "--- :pipeline: Uploading ${DEV_PIPELINE_FILE}"
 buildkite-agent pipeline upload "${DEV_PIPELINE_FILE}"
 
-echo "--- :pipeline: Uploading pipeline_build.yml"
-buildkite-agent pipeline upload .buildkite/pipeline_build.yml
-
 echo "--- Buildkite Dev Bootstrap Finished"


### PR DESCRIPTION
## Problem
#2883 ("Build image once …") centralized image builds into a shared `pipeline_build.yml` and made `bootstrap_dev.sh` upload it (and removed the build step from `pipeline_dev.yml`). For the **dev** pipeline this backfires:
- `pipeline_build.yml` builds **both** `tpu6e` and `tpu7x` unconditionally, so every dev build pays for an extra image build it doesn't need (dev runs are typically scoped to one TPU version in a custom `pipeline_dev.yml`).
- If a user's `pipeline_dev.yml` defines its own build step (the documented pattern), it now **duplicates** the `pipeline_build.yml` `build_docker_tpu7x` build.

## Fix
Restore the pre-#2883 dev flow, scoped to the dev pipeline only:
- `bootstrap_dev.sh`: stop uploading `pipeline_build.yml` (upload only `pipeline_dev.yml`).
- `pipeline_dev.yml`: re-add its own build step and the demos' `depends_on: tpu7x_build_docker`.

`pipeline_build.yml` is **left untouched** — main CI (`bootstrap.sh`) and kernel-tuning (`bootstrap_kernel_tuning.sh`) still use it, so #2883's "build once" optimization stays in place for those. This only decouples the dev pipeline.

## Test
Verified on the dev pipeline (build #568): with `bootstrap_dev.sh` no longer uploading `pipeline_build.yml`, the build has a single `tpu7x` image build (no redundant `tpu6e`/duplicate `tpu7x`), and the downstream test steps run against it.