### PR TITLE
[releases/v0.23.0][CI] mmlu.sh: pass --trust-remote-code to benchmark client

### DIFF
--- a/tests/e2e/benchmarking/mmlu.sh
+++ b/tests/e2e/benchmarking/mmlu.sh
@@ -332,6 +332,7 @@ for model_name in $model_list; do
     --dataset-path "$dataset_path" \
     --num-prompts "$num_prompts" \
     --mmlu-output-len "${mmlu_output_len}" \
+    --trust-remote-code \
     --run-eval 2>&1 | tee -a "$BENCHMARK_LOG_FILE"
 
     checkThroughputAndAccuracy


### PR DESCRIPTION
## Problem
On the v0.23.0 nightly, `tpu7x Accuracy for moonshotai/Kimi-K2.6` fails because the **benchmark client** (`scripts/vllm/benchmarking/benchmark_serving.py`) loads the tokenizer via `get_tokenizer(..., trust_remote_code=args.trust_remote_code)`, which defaults to `False`. Kimi-K2.6's HF repo ships custom code, so the client-side tokenizer load raises:

```
ValueError: The repository moonshotai/Kimi-K2.6 contains custom code which must be
executed to correctly load the model. Please pass `trust_remote_code=True`.
```

`mmlu.sh` already passes `--trust-remote-code` to the vLLM **server**, but not to the **client**. (`mlperf.sh`'s client already passes it; `mmlu.sh` was the only gap.)

## Fix
Add `--trust-remote-code` to the `benchmark_serving.py` invocation in `mmlu.sh`. It's a `store_true` flag and a no-op for models without custom code.

## Verification (dev pipeline A/B on v0.23.0, identical LKG a30addc)
- **Without the fix** (build #569): reproduces the `ValueError … contains custom code` — job fails.
- **With the fix** (build #570): client loads cleanly, Kimi MMLU **accuracy = 0.923 (≥ 0.87) → PASSED**.

Only difference between the two builds was this one line, so the fix is confirmed and harmless to other models.