### PR TITLE
[DP] Add example of using external (round robin) LB

### DIFF
--- a/examples/external_lb/rr_proxy.py
+++ b/examples/external_lb/rr_proxy.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Minimal round-robin HTTP reverse proxy across a fixed set of backend ports.
+Stands in for an external LB (nginx/haproxy) in front of vLLM's
+--data-parallel-external-lb child servers, which don't include one.
+
+See b/525257493 for more context.
+"""
+
+import itertools
+import os
+import sys
+
+from aiohttp import ClientSession, ClientTimeout, TCPConnector, web
+
+BACKEND_BASE_PORT = int(os.environ.get("BACKEND_BASE_PORT", "8000"))
+BACKEND_COUNT = int(os.environ.get("BACKEND_COUNT", "4"))
+BACKENDS = [
+    f"http://127.0.0.1:{BACKEND_BASE_PORT + i}" for i in range(BACKEND_COUNT)
+]
+_cycle = itertools.cycle(BACKENDS)
+_session: ClientSession | None = None
+
+
+async def round_robin(request: web.Request) -> web.StreamResponse:
+    backend = next(_cycle)
+    url = backend + request.path_qs
+    body = await request.read()
+    assert _session is not None
+    async with _session.request(request.method,
+                                url,
+                                headers=request.headers.copy(),
+                                data=body) as resp:
+        stream_resp = web.StreamResponse(status=resp.status,
+                                         headers=resp.headers.copy())
+        await stream_resp.prepare(request)
+        async for chunk in resp.content.iter_any():
+            await stream_resp.write(chunk)
+        await stream_resp.write_eof()
+        return stream_resp
+
+
+async def on_startup(app: web.Application) -> None:
+    global _session
+    connector = TCPConnector(limit=0, limit_per_host=0)
+    _session = ClientSession(timeout=ClientTimeout(total=None),
+                             connector=connector)
+
+
+async def on_cleanup(app: web.Application) -> None:
+    if _session is not None:
+        await _session.close()
+
+
+def main() -> None:
+    port = int(sys.argv[1]) if len(sys.argv) > 1 else 8080
+    app = web.Application()
+    app.router.add_route("*", "/{path:.*}", round_robin)
+    app.on_startup.append(on_startup)
+    app.on_cleanup.append(on_cleanup)
+    web.run_app(app, host="0.0.0.0", port=port, print=None)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/external_lb/rr_proxy.py
+++ b/examples/external_lb/rr_proxy.py
@@ -66,7 +66,10 @@ async def on_cleanup(app: web.Application) -> None:
 
 def main() -> None:
     port = int(sys.argv[1]) if len(sys.argv) > 1 else 8080
-    app = web.Application()
+    # Default aiohttp client_max_size is 1MB; multimodal (image) request
+    # bodies can exceed that and get reset mid-benchmark. Disable the cap --
+    # this proxy only ever forwards trusted local benchmark traffic.
+    app = web.Application(client_max_size=0)
     app.router.add_route("*", "/{path:.*}", round_robin)
     app.on_startup.append(on_startup)
     app.on_cleanup.append(on_cleanup)

--- a/examples/external_lb/run_dp_external_lb.sh
+++ b/examples/external_lb/run_dp_external_lb.sh
@@ -13,8 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Launch vLLM with --data-parallel-external-lb: one independent vllm-serve
-# process per DP rank (ports BASE_PORT..BASE_PORT+DP_SIZE-1), plus
+# Launch N fully independent vllm-serve instances (ports BASE_PORT..
+# BASE_PORT+DP_SIZE-1), each pinned to its own slice of TPU chips, plus
 # rr_proxy.py as a pure round-robin reverse proxy on top (PROXY_PORT,
 # default 8080).
 #
@@ -26,16 +26,18 @@
 # context.
 #
 # Usage:
+#   [ENV_VAR=...] ./run_dp_external_lb.sh [serve] <model> [extra vllm serve flags...]
+# Example (Gemma-4 26B-A4B MoE):
 #   MOE_REQUANTIZE_WEIGHT_DTYPE=float8_e4m3fn \
 #   VLLM_ENGINE_READY_TIMEOUT_S=6000 \
 #   USE_BATCHED_RPA_KERNEL=1 \
 #   MODEL_IMPL_TYPE=flax_nnx \
 #   ./run_dp_external_lb.sh google/gemma-4-26B-A4B-it \
-#       --max-model-len=1524 --max-num-seqs=1024
-# Any env vars set before the command are inherited as-is (this script does
-# not hardcode model-specific ones like USE_BATCHED_RPA_KERNEL --
-# only TPU_MULTIPROCESS_DP=1 is forced, since that's required for
-# --data-parallel-external-lb itself, not model-specific).
+#       --max-model-len=1524 --max-num-seqs=1024 --data-parallel-size 4 \
+#       --tensor-parallel-size 2
+# --data-parallel-size is read to know how many ranks to launch, then
+# stripped (along with any other --data-parallel-* flag) before forwarding
+# to vllm serve.
 
 set -ue
 
@@ -55,32 +57,83 @@ fi
 
 MODEL=$1
 shift
-EXTRA_ARGS=("$@")
+RAW_ARGS=("$@")
 
-# Pull --data-parallel-size out of the passed-through flags (this script
-# needs it to know how many ranks to launch); falls back to DP_SIZE env var
-# / 4 if the caller didn't pass it explicitly.
+# Pull --data-parallel-size and --tensor-parallel-size out of the passed
+# flags: DP_SIZE tells this script how many ranks to launch, TP_SIZE feeds
+# the chip-pinning math below. Both fall back to env-var / hardcoded
+# defaults if the caller didn't pass them explicitly.
 DP_SIZE=${DP_SIZE:-4}
-for ((i = 0; i < ${#EXTRA_ARGS[@]}; i++)); do
-  arg=${EXTRA_ARGS[$i]}
+TP_SIZE=${TP_SIZE:-2}
+for ((i = 0; i < ${#RAW_ARGS[@]}; i++)); do
+  arg=${RAW_ARGS[$i]}
   case "$arg" in
     --data-parallel-size=*)
       DP_SIZE=${arg#--data-parallel-size=}
       ;;
     --data-parallel-size)
-      DP_SIZE=${EXTRA_ARGS[$((i + 1))]}
+      DP_SIZE=${RAW_ARGS[$((i + 1))]}
+      ;;
+    --tensor-parallel-size=*)
+      TP_SIZE=${arg#--tensor-parallel-size=}
+      ;;
+    --tensor-parallel-size)
+      TP_SIZE=${RAW_ARGS[$((i + 1))]}
       ;;
   esac
 done
 
-BASE_PORT=${BASE_PORT:-8000}
-PROXY_PORT=${PROXY_PORT:-8080}
+# Strip every --data-parallel-* flag (and its value, if space-separated) --
+# each rank below is a fully independent, non-DP-aware vllm serve instance.
+# See "Why no --data-parallel-* flags" above. Also strip
+# --tensor-parallel-size since it's re-added explicitly below (already
+# parsed into TP_SIZE above) -- stripping just avoids passing it twice.
+EXTRA_ARGS=()
+skip_next=false
+for arg in "${RAW_ARGS[@]}"; do
+  if $skip_next; then
+    skip_next=false
+    continue
+  fi
+  case "$arg" in
+    # Boolean (store_true) data-parallel flags take no value -- don't skip
+    # the next arg for these.
+    --data-parallel-hybrid-lb | --data-parallel-external-lb | \
+    --data-parallel-multi-port-external-lb)
+      ;;
+    --data-parallel-*=*)
+      ;;
+    --data-parallel-*)
+      skip_next=true
+      ;;
+    --tensor-parallel-size=*)
+      ;;
+    --tensor-parallel-size)
+      skip_next=true
+      ;;
+    *)
+      EXTRA_ARGS+=("$arg")
+      ;;
+  esac
+done
+
+# Physical TPU cores per chip (v7x = 2). Each rank needs
+# ceil(TP_SIZE / CORES_PER_CHIP) whole chips; with TP_SIZE=2 and
+# CORES_PER_CHIP=2 that's exactly 1 chip per rank.
+CORES_PER_CHIP=${CORES_PER_CHIP:-2}
+CHIPS_PER_RANK=$(( (TP_SIZE + CORES_PER_CHIP - 1) / CORES_PER_CHIP ))
+
+# PROXY_PORT defaults to 8000 (vllm bench serve's own default --port) so
+# benchmark clients need no extra --port flag; rank servers start above it.
+BASE_PORT=${BASE_PORT:-8100}
+PROXY_PORT=${PROXY_PORT:-8000}
 STAGGER_S=${STAGGER_S:-20}
 
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 LOG_DIR=${LOG_DIR:-dp_external_lb_$(date +%Y%m%d_%H%M%S)}
 mkdir -p "$LOG_DIR"
 echo "--- Logs -> $LOG_DIR ---"
+echo "--- DP_SIZE=${DP_SIZE} TP_SIZE=${TP_SIZE} CORES_PER_CHIP=${CORES_PER_CHIP} CHIPS_PER_RANK=${CHIPS_PER_RANK} ---"
 
 RANK_PORTS=()
 RANK_PIDS=()
@@ -128,27 +181,25 @@ trap print_logs_on_exit EXIT
 
 cleanup_instances
 
-echo "--- Starting ${DP_SIZE} external-LB ranks (staggered ${STAGGER_S}s apart) ---"
+echo "--- Starting ${DP_SIZE} independent ranks (staggered ${STAGGER_S}s apart) ---"
 for ((rank = 0; rank < DP_SIZE; rank++)); do
   port=$((BASE_PORT + rank))
+  chip_start=$((rank * CHIPS_PER_RANK))
+  chip_end=$((chip_start + CHIPS_PER_RANK - 1))
+  visible_chips=$(seq -s, "$chip_start" "$chip_end")
 
-  # Requires TPU_MULTIPROCESS_DP=1 forced per child -- without it,
-  # tpu_inference's tpu_worker.py::_setup_dp_chip_isolation never runs
-  # (because dp_supervisor-style external-lb children never get
-  # _api_process_rank=-1, so TpuPlatform._resolve_multiprocess_dp's
-  # online_serving heuristic resolves to False) and the processes either
-  # collide on /tmp/libtpu_lockfile or hit a chip-topology mismatch.
-  TPU_MULTIPROCESS_DP=1 \
+  TPU_VISIBLE_CHIPS="${visible_chips}" \
+  TPU_CHIPS_PER_PROCESS_BOUNDS="1,${CHIPS_PER_RANK},1" \
+  TPU_PROCESS_BOUNDS=1,1,1 \
   vllm serve "${MODEL}" \
     "${EXTRA_ARGS[@]}" \
     --port "${port}" \
-    --data-parallel-rank "${rank}" \
-    --data-parallel-external-lb \
+    --tensor-parallel-size "${TP_SIZE}" \
     > "$LOG_DIR/rank${rank}.txt" 2>&1 &
 
   RANK_PORTS+=("$port")
   RANK_PIDS+=("$!")
-  echo "rank=${rank} port=${port} pid=$!"
+  echo "rank=${rank} port=${port} chips=${visible_chips} pid=$!"
 
   if ((rank < DP_SIZE - 1)); then
     sleep "${STAGGER_S}"

--- a/examples/external_lb/run_dp_external_lb.sh
+++ b/examples/external_lb/run_dp_external_lb.sh
@@ -1,0 +1,197 @@
+#!/usr/bin/env bash
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Launch vLLM with --data-parallel-external-lb: one independent vllm-serve
+# process per DP rank (ports BASE_PORT..BASE_PORT+DP_SIZE-1), plus
+# rr_proxy.py as a pure round-robin reverse proxy on top (PROXY_PORT,
+# default 8080).
+#
+# Why this exists: vLLM's internal DP load balancer scores ranks off
+# waiting/running counts that a coordinator only refreshes every 100ms
+# (hardcoded). Under bursty/symmetric load this snowballs into uneven
+# per-rank request counts. external-lb + a real round-robin proxy removes
+# the coordinator from the critical path entirely. See b/525257493 for more
+# context.
+#
+# Usage:
+#   MOE_REQUANTIZE_WEIGHT_DTYPE=float8_e4m3fn \
+#   VLLM_ENGINE_READY_TIMEOUT_S=6000 \
+#   USE_BATCHED_RPA_KERNEL=1 \
+#   MODEL_IMPL_TYPE=flax_nnx \
+#   ./run_dp_external_lb.sh google/gemma-4-26B-A4B-it \
+#       --max-model-len=1524 --max-num-seqs=1024
+# Any env vars set before the command are inherited as-is (this script does
+# not hardcode model-specific ones like USE_BATCHED_RPA_KERNEL --
+# only TPU_MULTIPROCESS_DP=1 is forced, since that's required for
+# --data-parallel-external-lb itself, not model-specific).
+
+set -ue
+
+usage() {
+  echo "Usage: [ENV_VAR=...] $0 [serve] <model> [extra vllm serve flags...]" >&2
+  exit 1
+}
+
+[ $# -lt 1 ] && usage
+
+# Accept (and ignore) a leading "serve" token so the invocation can mirror
+# plain `vllm serve <model> ...` -- this script always runs serve mode.
+if [ "$1" = "serve" ]; then
+  shift
+fi
+[ $# -lt 1 ] && usage
+
+MODEL=$1
+shift
+EXTRA_ARGS=("$@")
+
+# Pull --data-parallel-size out of the passed-through flags (this script
+# needs it to know how many ranks to launch); falls back to DP_SIZE env var
+# / 4 if the caller didn't pass it explicitly.
+DP_SIZE=${DP_SIZE:-4}
+for ((i = 0; i < ${#EXTRA_ARGS[@]}; i++)); do
+  arg=${EXTRA_ARGS[$i]}
+  case "$arg" in
+    --data-parallel-size=*)
+      DP_SIZE=${arg#--data-parallel-size=}
+      ;;
+    --data-parallel-size)
+      DP_SIZE=${EXTRA_ARGS[$((i + 1))]}
+      ;;
+  esac
+done
+
+BASE_PORT=${BASE_PORT:-8000}
+PROXY_PORT=${PROXY_PORT:-8080}
+STAGGER_S=${STAGGER_S:-20}
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+LOG_DIR=${LOG_DIR:-dp_external_lb_$(date +%Y%m%d_%H%M%S)}
+mkdir -p "$LOG_DIR"
+echo "--- Logs -> $LOG_DIR ---"
+
+RANK_PORTS=()
+RANK_PIDS=()
+PROXY_PID=
+
+wait_for_server() {
+  local port=$1
+  local pid=$2
+  timeout 1200 bash -c "
+    until curl -s localhost:${port}/health > /dev/null; do
+      if ! kill -0 $pid 2>/dev/null; then
+        echo \"Error: vLLM server on port $port (PID $pid) crashed or failed to start!\" >&2
+        exit 1
+      fi
+      sleep 1
+    done" && return 0 || return 1
+}
+
+cleanup_instances() {
+  echo "Cleaning up any running vLLM/proxy instances..."
+  pkill -f "rr_proxy.py" || true
+  pkill -f "vllm serve ${MODEL}" || true
+  sleep 5
+  pkill -9 -f "rr_proxy.py" || true
+  pkill -9 -f "vllm serve ${MODEL}" || true
+  fuser -k -9 /dev/vfio/* || true
+  fuser -k -9 /dev/accel* || true
+  rm -rf /tmp/jax_cache_* || true
+  rm -f /tmp/libtpu_lockfile || true
+}
+
+print_logs_on_exit() {
+  echo "--- Script exiting, displaying logs ---"
+  for i in "${!RANK_PORTS[@]}"; do
+    f="$LOG_DIR/rank${i}.txt"
+    echo "--- Tail of $f ---"
+    [ -f "$f" ] && tail -n 30 "$f" || echo "File not found."
+  done
+  echo "--- Tail of $LOG_DIR/proxy.txt ---"
+  [ -f "$LOG_DIR/proxy.txt" ] && tail -n 30 "$LOG_DIR/proxy.txt" || echo "File not found."
+  echo "--- End of logs ---"
+  cleanup_instances
+}
+trap print_logs_on_exit EXIT
+
+cleanup_instances
+
+echo "--- Starting ${DP_SIZE} external-LB ranks (staggered ${STAGGER_S}s apart) ---"
+for ((rank = 0; rank < DP_SIZE; rank++)); do
+  port=$((BASE_PORT + rank))
+
+  # Requires TPU_MULTIPROCESS_DP=1 forced per child -- without it,
+  # tpu_inference's tpu_worker.py::_setup_dp_chip_isolation never runs
+  # (because dp_supervisor-style external-lb children never get
+  # _api_process_rank=-1, so TpuPlatform._resolve_multiprocess_dp's
+  # online_serving heuristic resolves to False) and the processes either
+  # collide on /tmp/libtpu_lockfile or hit a chip-topology mismatch.
+  TPU_MULTIPROCESS_DP=1 \
+  vllm serve "${MODEL}" \
+    "${EXTRA_ARGS[@]}" \
+    --port "${port}" \
+    --data-parallel-rank "${rank}" \
+    --data-parallel-external-lb \
+    > "$LOG_DIR/rank${rank}.txt" 2>&1 &
+
+  RANK_PORTS+=("$port")
+  RANK_PIDS+=("$!")
+  echo "rank=${rank} port=${port} pid=$!"
+
+  if ((rank < DP_SIZE - 1)); then
+    sleep "${STAGGER_S}"
+  fi
+done
+
+for i in "${!RANK_PORTS[@]}"; do
+  port=${RANK_PORTS[$i]}
+  echo "Waiting for rank $i on port $port to start..."
+  wait_for_server "$port" "${RANK_PIDS[$i]}" || exit 1
+done
+
+echo "--- Starting round-robin proxy on port ${PROXY_PORT} ---"
+BACKEND_BASE_PORT="${BASE_PORT}" BACKEND_COUNT="${DP_SIZE}" \
+  python3 "$SCRIPT_DIR/rr_proxy.py" "${PROXY_PORT}" \
+  > "$LOG_DIR/proxy.txt" 2>&1 &
+PROXY_PID=$!
+wait_for_server "${PROXY_PORT}" "${PROXY_PID}" || exit 1
+echo "Proxy healthy on port ${PROXY_PORT} (pid=${PROXY_PID})"
+
+cat <<EOF
+
+The round-robin proxy is listening on: 127.0.0.1:${PROXY_PORT}
+
+>> Send an example request:
+
+curl http://localhost:${PROXY_PORT}/v1/chat/completions \
+    -X POST \
+    -H "Content-Type: application/json" \
+    -d '{
+        "model": "${MODEL}",
+        "messages": [
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "Who won the world series in 2020?"}
+        ]
+        "max_tokens": 25,
+        "temperature": 0.0
+}'
+
+>> Stop the proxy and all rank servers:
+
+pkill -f "vllm serve ${MODEL}" && pkill -f "rr_proxy.py"
+EOF
+
+echo "Press Ctrl-C to stop everything (trap will clean up)."
+wait


### PR DESCRIPTION
# Description

Example LB to reduce overhead during benchmark (where requests come in all at once, and vLLM's DP scheduler causes overhead)

# Tests

```
SKIP_JAX_PRECOMPILE=1 MOE_REQUANTIZE_WEIGHT_DTYPE=float8_e4m3fn \
VLLM_ENGINE_READY_TIMEOUT_S=1800 \
USE_BATCHED_RPA_KERNEL=1 \
MODEL_IMPL_TYPE=flax_nnx \
./examples/external_lb/run_dp_external_lb.sh \
    serve google/gemma-4-26B-A4B-it \
    --max-model-len=1524 \
    --max-num-seqs=1024 \
    --data-parallel-size 4 \
    --tensor-parallel-size 2 \
    --max-num-batched-tokens 16384 \
    --no-enable-prefix-caching \
    --additional_config='{"quantization": { "qwix": { "rules": [{ "module_path": ".*", "weight_qtype": "float8_e4m3fn", "act_qtype": "float8_e4m3fn"}]}}}' \
    --kv-cache-dtype=fp8 \
    --gpu-memory-utilization=0.9 \
    --async-scheduling \
    --limit-mm-per-prompt '{"image": 0, "video": 0, "audio": 0}' \
    --block-size=256
```

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.

b/525257493