### PR TITLE
[releases/v0.23.0] Cherry-pick #2931: Fix num tokens in mmlu test for continue decode

### DIFF
--- a/.buildkite/rl/rl_integration.yml
+++ b/.buildkite/rl/rl_integration.yml
@@ -79,4 +79,4 @@ steps:
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
     commands:
-      - .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/mmlu.sh -m "meta-llama/Llama-3.1-8B-Instruct" -n 1000 -l 1
+      - .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/mmlu.sh -m "meta-llama/Llama-3.1-8B-Instruct" -n 1000 -l 4


### PR DESCRIPTION
Cherry-pick of #2931 (https://github.com/vllm-project/tpu-inference/pull/2931) onto `releases/v0.23.0`.

## What it fixes
`E2E MMLU for Llama-3.1-8B continue_decode` scores `accuracy=0.0` on the nightly (born broken since #2507 added the test). Root cause: the job ran `mmlu.sh ... -l 1` (mmlu-output-len = 1 token), too short for the MMLU answer to be parsed. This bumps it to `-l 4`.

v0.23.0 includes #2507 (merged 6/9, before the v0.23.0 cut), so the broken test is present on the release branch too.

## Verification
On main, #2931 took the continue_decode MMLU jobs from `accuracy=0.0` to passing (tpu7x 0.744, tpu6e 0.775, threshold 0.6) in tpu-inference-ci build https://buildkite.com/tpu-commons/tpu-inference-ci/builds/20510.

Clean cherry-pick (1-line change to `.buildkite/rl/rl_integration.yml`).