### PR TITLE
Change o_proj sharding shard through num_heads rather than head_dim

### DIFF
--- a/tpu_inference/models/jax/gemma4.py
+++ b/tpu_inference/models/jax/gemma4.py
@@ -417,7 +417,7 @@ class Gemma4Attention(JaxModule):
             (self.num_heads, self.head_dim, self.hidden_size),
             bias_shape=(self.hidden_size, ) if config.attention_bias else None,
             param_dtype=dtype,
-            kernel_init=nnx.with_partitioning(init_fn, (None, "model", None)),
+            kernel_init=nnx.with_partitioning(init_fn, ("model", None, None)),
             bias_init=nnx.with_partitioning(init_fn, (None, ))
             if config.attention_bias else None,
             rngs=rng,


### PR DESCRIPTION
# Description

I've observed unexpected all-to-all after RPA kernel before o_proj.
This was result of wrong wrong sharding of `o_proj` which should be sharded across num_head rather than head_dim.

# Benchmark

Output token throughput improved from 26220.29 to 28255.31 (+7.7%)

```
============ Serving Benchmark Result ============
Successful requests:                     5120
Failed requests:                         0
Benchmark duration (s):                  90.60
Total input tokens:                      5242880
Total generated tokens:                  2560000
Request throughput (req/s):              56.51
Output token throughput (tok/s):         28255.31
Peak output token throughput (tok/s):    59256.00
Peak concurrent requests:                5120.00
Total token throughput (tok/s):          86122.20
---------------Time to First Token----------------
Mean TTFT (ms):                          24626.64
Median TTFT (ms):                        16412.03
P99 TTFT (ms):                           61891.64
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          85.65
Median TPOT (ms):                        85.57
P99 TPOT (ms):                           125.11
---------------Inter-token Latency----------------
Mean ITL (ms):                           85.70
Median ITL (ms):                         58.81
P99 ITL (ms):                            310.21
==================================================

```