### PR TITLE
[CI] nightly_verify: skip commit-back steps on release-branch nightlies

### DIFF
--- a/.buildkite/nightly_verify.yml
+++ b/.buildkite/nightly_verify.yml
@@ -67,7 +67,10 @@ steps:
       fi
   
    - label: "Commit support matrices if is nightly build or release tag specified"
-     <<: *run-on-nightly-or-tag
+     # commit_support_matrices and record_verified_commit_hashes push to the repo via
+     # GITHUB_PAT, which is only provisioned for main / release tags. Gate them off
+     # release-branch nightlies (branch != main, no tag) to avoid a "secrets" failure.
+     if: (build.env("NIGHTLY") == "1" && build.branch == "main") || build.tag =~ /^v?[0-9]+(\.[a-zA-Z0-9]+)*([a-zA-Z]+[0-9]*)?$/
      key: commit_support_matrices
      depends_on:
        - "v6_generate_matrices"
@@ -89,7 +92,8 @@ steps:
        - bash .buildkite/scripts/notify_test_results.sh
 
    - label: "Record verified commit hashes"
-     if: build.env("NIGHTLY") == "1"
+     # GITHUB_PAT is main/tag-only - see commit_support_matrices above.
+     if: build.env("NIGHTLY") == "1" && build.branch == "main"
      key: record_verified_commit_hashes
      depends_on:
        - notify_test_results


### PR DESCRIPTION
## Problem
On a **release-branch nightly** (e.g. `releases/v0.23.0` with `NIGHTLY=1`), the `Commit support matrices …` job fails at **Preparing secrets**:
```
Error setting up job executor: failed to fetch secrets for job:
secret "GITHUB_PAT": 404 Not Found
```
`GITHUB_PAT` (used to push results back to the repo) is only provisioned for `main` (and release tags). The failure cascades to `Record verified commit hashes` (which also uses the PAT) and `Notify test results` (which depends on the commit step). This is the lone red on otherwise-green release-branch nightlies (seen on https://buildkite.com/tpu-commons/tpu-inference-ci/builds/20540).

These commit-back steps are inherently main-only — they push generated support matrices / verified commit hashes into the repo, which should not happen from a release branch.

## Fix
Gate **only the two steps that actually push via `GITHUB_PAT`** with inline `if:` conditions (no shared anchor — Buildkite anchors can't compose sub-expressions into the `&&`/`||` these need):

- **`commit_support_matrices`**: `(build.env("NIGHTLY") == "1" && build.branch == "main") || build.tag =~ /<release-tag>/`
  Runs on `main` nightlies and release tags (where the PAT exists); skipped on release-branch nightlies.
- **`record_verified_commit_hashes`**: `build.env("NIGHTLY") == "1" && build.branch == "main"`
  Main nightlies only. It never ran on tags — the pre-PR condition was `NIGHTLY == "1"`, which is exactly why it cascade-failed on release-branch nightlies. No tag clause is added.

`notify_test_results` is **intentionally left ungated** (`<<: *run-on-nightly-or-tag`). It uses **no** `GITHUB_PAT` — it only reads the `CI_TESTS_FAILED` metadata and exits non-zero if any test failed — so it must keep running on release-branch nightlies to surface real test failures as a red build.

So on a release-branch nightly (branch != main, no tag) the two commit-back steps are **skipped**, not failed, while test-failure reporting still works. Behavior is unchanged on `main` nightlies and release tags. The support-matrix **generation** and metadata-health steps still run everywhere (they don't push), so nothing else changes.
