### PR TITLE
[releases/v0.23.0] Cherry-pick #2941: skip commit-back steps on release-branch nightlies

### DIFF
--- a/.buildkite/nightly_verify.yml
+++ b/.buildkite/nightly_verify.yml
@@ -67,7 +67,10 @@ steps:
       fi
   
    - label: "Commit support matrices if is nightly build or release tag specified"
-     <<: *run-on-nightly-or-tag
+     # commit_support_matrices and record_verified_commit_hashes push to the repo via
+     # GITHUB_PAT, which is only provisioned for main / release tags. Gate them off
+     # release-branch nightlies (branch != main, no tag) to avoid a "secrets" failure.
+     if: (build.env("NIGHTLY") == "1" && build.branch == "main") || build.tag =~ /^v?[0-9]+(\.[a-zA-Z0-9]+)*([a-zA-Z]+[0-9]*)?$/
      key: commit_support_matrices
      depends_on:
        - "v6_generate_matrices"
@@ -89,7 +92,8 @@ steps:
        - bash .buildkite/scripts/notify_test_results.sh
 
    - label: "Record verified commit hashes"
-     if: build.env("NIGHTLY") == "1"
+     # GITHUB_PAT is main/tag-only - see commit_support_matrices above.
+     if: build.env("NIGHTLY") == "1" && build.branch == "main"
      key: record_verified_commit_hashes
      depends_on:
        - notify_test_results


### PR DESCRIPTION
Cherry-pick of #2941 (https://github.com/vllm-project/tpu-inference/pull/2941) onto `releases/v0.23.0`.

## What it fixes
On the v0.23.0 nightly, `Commit support matrices …` (and the dependent `Notify test results` / `Record verified commit hashes`) fail at "Preparing secrets" — `GITHUB_PAT` (used to push results back to the repo) is only provisioned for `main`/release-tags, not release-branch nightlies. This was the lone real failure on https://buildkite.com/tpu-commons/tpu-inference-ci/builds/20540 (otherwise 999 passed).

Gates those commit-back steps to `(NIGHTLY && branch==main) || release-tag`, so they are cleanly **skipped** on release-branch nightlies instead of failing. Support-matrix generation / metadata-health steps are unaffected.