### PR TITLE
[DP] Fix PHASED_PROFILING_DIR collision in run_dp_external_lb.sh

### DIFF
--- a/examples/external_lb/rr_proxy.py
+++ b/examples/external_lb/rr_proxy.py
@@ -73,7 +73,10 @@ def main() -> None:
     app.router.add_route("*", "/{path:.*}", round_robin)
     app.on_startup.append(on_startup)
     app.on_cleanup.append(on_cleanup)
-    web.run_app(app, host="0.0.0.0", port=port, print=None)
+    # Default backlog (128) is far too small for thousands of concurrent
+    # benchmark connections; the kernel clamps this to net.core.somaxconn
+    # anyway, so request more than we'd ever expect to need.
+    web.run_app(app, host="0.0.0.0", port=port, print=None, backlog=10000)
 
 
 if __name__ == "__main__":

--- a/examples/external_lb/run_dp_external_lb.sh
+++ b/examples/external_lb/run_dp_external_lb.sh
@@ -188,6 +188,18 @@ for ((rank = 0; rank < DP_SIZE; rank++)); do
   chip_end=$((chip_start + CHIPS_PER_RANK - 1))
   visible_chips=$(seq -s, "$chip_start" "$chip_end")
 
+  # Each rank is a fully independent process (not an MPMD worker), so
+  # without this every rank would write the same default xplane/trace
+  # filename into the shared PHASED_PROFILING_DIR -- later ranks overwriting
+  # earlier ones. Give each rank its own subdirectory instead. Always set
+  # (even to "" when PHASED_PROFILING_DIR is unset) to override whatever
+  # this script's own environment would otherwise pass through unchanged.
+  rank_phased_profiling_dir=""
+  if [ -n "${PHASED_PROFILING_DIR:-}" ]; then
+    rank_phased_profiling_dir="${PHASED_PROFILING_DIR%/}/dp_rank_${rank}"
+  fi
+
+  PHASED_PROFILING_DIR="${rank_phased_profiling_dir}" \
   TPU_VISIBLE_CHIPS="${visible_chips}" \
   TPU_CHIPS_PER_PROCESS_BOUNDS="1,${CHIPS_PER_RANK},1" \
   TPU_PROCESS_BOUNDS=1,1,1 \


### PR DESCRIPTION
## Summary
- Each rank under `run_dp_external_lb.sh` (external LB) is a fully independent `vllm serve` process, not an MPMD worker. Without a per-rank subdirectory, every rank writes the same default xplane/trace filename into the shared `PHASED_PROFILING_DIR`, and later ranks silently overwrite earlier ones.
- Gives each rank its own `dp_rank_<i>` subdirectory instead, always setting `PHASED_PROFILING_DIR` per-rank (even to `""` when unset) to override whatever the script's own environment would otherwise pass through unchanged. `""` is equivalent to unset (`tpu_runner.py`'s `_init_phased_profiling` does a truthy check), so this is a no-op when profiling isn't requested.

## Test plan
- [x] `bash -n` + `shellcheck` (via pre-commit) pass
- [x] Phase-profiled both `google/gemma-4-26B-A4B-it` and `google/gemma-4-31B-it` at 1k/500 with `--data-parallel-size 4` through `run_dp_external_lb.sh` with `PHASED_PROFILING_DIR` set — all 4 ranks × 3 phases (`prefill_only`, `prefill_heavy`, `decode_only`) captured cleanly with no collisions, versus only 1–2 surviving captures per phase before this fix