### PR TITLE
[CI] Split JAX unit tests part2 into per-push BVT subset vs nightly full

### DIFF
--- a/.buildkite/pipeline_jax.yml
+++ b/.buildkite/pipeline_jax.yml
@@ -114,6 +114,11 @@ steps:
             .buildkite/scripts/run_in_docker.sh bash -c "python3 -m pytest -s -v -x /workspace/tpu_inference/tests/layers/vllm/backends/test_flash_attn.py /workspace/tpu_inference/tests/layers/vllm/test_awq.py /workspace/tpu_inference/tests/layers/vllm/test_compressed_tensors_moe.py /workspace/tpu_inference/tests/layers/vllm/test_compressed_tensors_w8a8_fp8.py /workspace/tpu_inference/tests/layers/vllm/test_compressed_tensors_w8a8_int8.py --cov-config=/workspace/tpu_inference/.coveragerc --cov tpu_inference; if [ -f .coverage ]; then cp .coverage /tmp/hf_home/.coverage.part1.${TPU_VERSION:-tpu6e}; else exit 1; fi"
           - cp /mnt/disks/persist/models/.coverage.part1.${TPU_VERSION:-tpu6e} ./
 
+      # Per-push runs the BVT smoke subset (single-host model-loading combos);
+      # nightly (NIGHTLY=1) runs the full pp-shard matrix. The conftest gate
+      # narrows model-test files to @pytest.mark.bvt cases only when BVT_ONLY=1,
+      # so set BVT_ONLY=1 iff this is NOT a nightly build. Files without any bvt
+      # marker always run in full.
       - label: "${TPU_VERSION:-tpu6e} JAX unit tests part2"
         key: ${TPU_VERSION:-tpu6e}_test_7_2
         soft_fail: true
@@ -126,6 +131,7 @@ steps:
         commands:
           - rm -f .coverage.part2.${TPU_VERSION:-tpu6e}
           - |
+            if [ "$${NIGHTLY:-0}" = "1" ]; then export BVT_ONLY=; else export BVT_ONLY=1; fi
             .buildkite/scripts/run_in_docker.sh bash -c "python3 -m pytest -s -v -x /workspace/tpu_inference/tests/ --ignore=/workspace/tpu_inference/tests/layers/vllm/backends/test_flash_attn.py --ignore=/workspace/tpu_inference/tests/layers/vllm/test_awq.py --ignore=/workspace/tpu_inference/tests/layers/vllm/test_compressed_tensors_moe.py --ignore=/workspace/tpu_inference/tests/layers/vllm/test_compressed_tensors_w8a8_fp8.py --ignore=/workspace/tpu_inference/tests/layers/vllm/test_compressed_tensors_w8a8_int8.py --ignore=/workspace/tpu_inference/tests/kernels --ignore=/workspace/tpu_inference/tests/lora --ignore=/workspace/tpu_inference/tests/e2e --ignore=/workspace/tpu_inference/tpu_inference/mock --ignore=/workspace/tpu_inference/tests/models/jax/test_deepseek_v3.py --ignore=/workspace/tpu_inference/tests/offload/tpu_offload_multi_request_accuracy_test.py --ignore=/workspace/tpu_inference/tests/offload/tpu_offload_accuracy_test.py --ignore=/workspace/tpu_inference/tests/offload/tpu_offload_performance_test.py --ignore=/workspace/tpu_inference/tests/core/test_dp_group_sampling_prefix_cache.py --ignore=/workspace/tpu_inference/tests/runner/test_async_logprobs.py --ignore=/workspace/tpu_inference/tests/runner/test_processed_logprobs.py --ignore=/workspace/tpu_inference/tests/runner/test_moe_expert_ids.py --cov-config=/workspace/tpu_inference/.coveragerc --cov tpu_inference; if [ -f .coverage ]; then cp .coverage /tmp/hf_home/.coverage.part2.${TPU_VERSION:-tpu6e}; else exit 1; fi"
           - cp /mnt/disks/persist/models/.coverage.part2.${TPU_VERSION:-tpu6e} ./
 

--- a/tests/models/jax/test_gemma4.py
+++ b/tests/models/jax/test_gemma4.py
@@ -127,12 +127,16 @@ class TestGemma4ForConditionalGeneration:
             )
         assert jax_output is not None
 
+    # BVT: per-push CI sets BVT_ONLY=1, narrowing this file to @pytest.mark.bvt
+    # cases (see tests/conftest.py). Only the single-host (0,1) pp combo is
+    # marked; nightly runs the full pp-shard matrix.
     @pytest.mark.parametrize("model_name", [
         "google/gemma-4-31B-it",
         "google/gemma-4-26B-A4B-it",
     ])
-    @pytest.mark.parametrize("pp_rank,pp_world_size", [(0, 1), (0, 4), (1, 4),
-                                                       (3, 4)])
+    @pytest.mark.parametrize(
+        "pp_rank,pp_world_size",
+        [pytest.param(0, 1, marks=pytest.mark.bvt), (0, 4), (1, 4), (3, 4)])
     @pytest.mark.parametrize(
         "load_format", ["skip_layers_model_loader_for_test", "jax_dummy"])
     def test_model_loading(
@@ -160,6 +164,7 @@ class TestGemma4ForConditionalGeneration:
             mock_vllm_config=mock_vllm_config,
         )
 
+    @pytest.mark.bvt
     @pytest.mark.parametrize("model_name", [
         "google/gemma-4-E2B-it",
         "google/gemma-4-E4B-it",

--- a/tests/models/jax/test_gemma4_mtp.py
+++ b/tests/models/jax/test_gemma4_mtp.py
@@ -70,11 +70,15 @@ class DummyDraftConfig:
 
 class TestGemma4MTPForCausalLM:
 
+    # BVT: per-push CI sets BVT_ONLY=1, narrowing this file to @pytest.mark.bvt
+    # cases (see tests/conftest.py). Only the single-host (0,1) pp combo is
+    # marked; nightly runs the full pp-shard matrix.
     @pytest.mark.parametrize("model_name", [
         "google/gemma-4-31B-it",
     ])
-    @pytest.mark.parametrize("pp_rank,pp_world_size", [(0, 1), (0, 4), (1, 4),
-                                                       (3, 4)])
+    @pytest.mark.parametrize(
+        "pp_rank,pp_world_size",
+        [pytest.param(0, 1, marks=pytest.mark.bvt), (0, 4), (1, 4), (3, 4)])
     @pytest.mark.parametrize(
         "load_format", ["skip_layers_model_loader_for_test", "jax_dummy"])
     @pytest.mark.parametrize("use_ordered_embeddings", [True, False])

--- a/tests/models/jax/test_qwen3.py
+++ b/tests/models/jax/test_qwen3.py
@@ -108,6 +108,12 @@ def mock_get_pp_group():
         yield
 
 
+# BVT convention: per-push CI sets BVT_ONLY=1, which makes the conftest
+# collection gate (tests/conftest.py) keep only @pytest.mark.bvt cases in any
+# file that marks at least one. The pipeline-parallel shard variants
+# (0,4)/(1,4)/(3,4) are the expensive part of these model tests, so only the
+# single-host (0,1) combo is marked bvt; nightly (BVT_ONLY unset) runs the full
+# pp matrix.
 class TestQwen3ForCausalLM:
 
     @pytest.mark.parametrize("model_name", ["Qwen/Qwen3-0.6B"])
@@ -120,8 +126,9 @@ class TestQwen3ForCausalLM:
             "act_qtype": "float8_e4m3fn"
         }]
     ])
-    @pytest.mark.parametrize("pp_rank,pp_world_size", [(0, 1), (0, 4), (1, 4),
-                                                       (3, 4)])
+    @pytest.mark.parametrize(
+        "pp_rank,pp_world_size",
+        [pytest.param(0, 1, marks=pytest.mark.bvt), (0, 4), (1, 4), (3, 4)])
     def test_qwen3_600M(self, model_name, kv_cache_type, qwix_rules, rng, mesh,
                         mock_model_inputs, pp_rank, pp_world_size):
         """Tests model init and model forward for the 0.6B model variant."""
@@ -217,6 +224,7 @@ class TestQwen3ForCausalLM:
         logits = model.compute_logits(hidden_states)
         assert logits.shape == (1, hf_config.vocab_size)
 
+    @pytest.mark.bvt
     def test_expected_error_with_tight_threshold(
             self, rng, mesh, mock_vllm_config,
             assert_weight_loading_memory_bounded):
@@ -253,8 +261,9 @@ class TestQwen3ForCausalLM:
 
     @pytest.mark.parametrize("model_name",
                              ["Qwen/Qwen3-0.6B", "Qwen/Qwen3-0.6B-FP8"])
-    @pytest.mark.parametrize("pp_rank,pp_world_size", [(0, 1), (0, 4), (1, 4),
-                                                       (3, 4)])
+    @pytest.mark.parametrize(
+        "pp_rank,pp_world_size",
+        [pytest.param(0, 1, marks=pytest.mark.bvt), (0, 4), (1, 4), (3, 4)])
     @pytest.mark.parametrize(
         "load_format", ["skip_layers_model_loader_for_test", "jax_dummy"])
     def test_model_loading(self, model_name, pp_rank, pp_world_size,
@@ -355,6 +364,7 @@ class TestQwen3ForCausalLM:
                 atol=1e-2,
             )
 
+    @pytest.mark.bvt
     def test_vocab_padding_for_sharding(self, rng, mesh):
         """Verify that embed_tokens shape is rounded up when tensor_parallel_size > 1."""
         from tpu_inference.distributed.jax_parallel_state import \

--- a/tests/models/jax/test_qwen3_moe.py
+++ b/tests/models/jax/test_qwen3_moe.py
@@ -31,14 +31,18 @@ from tpu_inference.models.jax.qwen3_moe import Qwen3MoeForCausalLM
 
 class TestQwen3MoeForCausalLM:
 
-    @pytest.mark.parametrize(
-        "model_name,pp_rank,pp_world_size,load_format",
-        [(model, rank, world, fmt) for model in [
+    # BVT: per-push CI sets BVT_ONLY=1, narrowing this file to @pytest.mark.bvt
+    # cases (see tests/conftest.py). Only the single-host (world==1) combos are
+    # marked; nightly runs the full pp-shard matrix.
+    @pytest.mark.parametrize("model_name,pp_rank,pp_world_size,load_format", [
+        pytest.param(model, rank, world, fmt, marks=pytest.mark.bvt)
+        if world == 1 else (model, rank, world, fmt) for model in [
             "Qwen/Qwen3-30B-A3B-Instruct-2507",
             "Qwen/Qwen3-30B-A3B-Instruct-2507-FP8",
         ] for rank, world in [(0, 1), (0, 4), (1, 4), (3, 4)]
-         for fmt in ["skip_layers_model_loader_for_test", "jax_dummy"]
-         if not (world == 1 and fmt == "jax_dummy")])
+        for fmt in ["skip_layers_model_loader_for_test", "jax_dummy"]
+        if not (world == 1 and fmt == "jax_dummy")
+    ])
     def test_model_loading(
             self,
             model_name,


### PR DESCRIPTION
## Purpose

`JAX unit tests part2` (`*_test_7_2`) is the single largest consumer of the
shared single-host TPU CI queue (~90 min/run). One-month wall-clock analysis
shows its cost is **not from added tests** (test count is flat ~2080) — it's
dominated by a handful of model test files that load a real model and run
load/forward across a 4-way pipeline-parallel shard matrix (pp world sizes
1/4/4/4):

| file | ~min/run | cases |
|---|---|---|
| `tests/models/jax/test_qwen3.py` | 21 | 34 |
| `tests/models/jax/test_gemma4.py` | 9 | 18 |
| `tests/models/jax/test_qwen3_moe.py` | 5 | 14 |
| `tests/models/jax/test_gemma4_mtp.py` | 4 | 16 |

Together ~40 of the ~88 measured minutes.

## Change

Reuse the `BVT_ONLY` collection gate already added for the spec-decode step
(`tests/conftest.py`): mark only the **single-host (pp world size 1)** combos
of these model tests `@pytest.mark.bvt`, plus the cheap standalone smoke tests.

- **Per-push CI** sets `BVT_ONLY=1` → runs the smoke subset (single-host
  load/forward coverage for every model).
- **Nightly** (`NIGHTLY=1`) leaves `BVT_ONLY` unset → runs the full pp-shard
  matrix, unchanged.
- Files **without** any `bvt` marker are unaffected and always run in full, so
  the rest of part2 is identical per-push.

This trims ~24–27 min off the per-push part2 step while keeping full coverage
on nightly, reducing agent-hours on the contended queue.

## Validation

- Collection narrowing verified locally (`--collect-only`): the gate keeps
  exactly the single-host combos + standalone bvt tests, and a full run
  (`BVT_ONLY` unset) collects everything.
- The selected subset is a strict subset of already-passing cases; nightly
  continues to exercise the full matrix.

Follow-up to #2939 (same mechanism, applied to part2).
