### PR TITLE
Update JAX to 0.10.2

### DIFF
--- a/.buildkite/models/Qwen_Qwen3_5-397B-A17B.yml
+++ b/.buildkite/models/Qwen_Qwen3_5-397B-A17B.yml
@@ -82,7 +82,7 @@ steps:
         if [ "${TPU_VERSION:-tpu6e}" = "tpu6e" ]; then
           buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_Qwen_Qwen3_5-397B-A17B_Benchmark" "not enough HBM"
         else
-              .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/bm_qwen3_coder.sh --model Qwen/Qwen3.5-397B-A17B-FP8 --tp 8 --req_tput_limit 0.04  --output_token_tput_limit 300 --total_token_tput_limit 345 --input_len 1024 --output_len 8192 --use_moe_ep_kernel 0 --limit_mm_per_prompt '{"image": 0, "video": 0}' --block_size 256 --num_prompts 64 --timeout 52 --gpu-memory-utilization 0.9
+              .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/bm_qwen3_coder.sh --model Qwen/Qwen3.5-397B-A17B-FP8 --tp 8 --req_tput_limit 0.04  --output_token_tput_limit 300 --total_token_tput_limit 345 --input_len 1024 --output_len 8192 --use_moe_ep_kernel 0 --limit_mm_per_prompt '{"image": 0, "video": 0}' --block_size 256 --num_prompts 64 --timeout 52 --gpu-memory-utilization 0.88
         fi
 
   - label: "${TPU_VERSION:-tpu6e} Record performance benchmark result for Qwen/Qwen3.5-397B-A17B-FP8"

--- a/.buildkite/pipeline_jax.yml
+++ b/.buildkite/pipeline_jax.yml
@@ -505,7 +505,7 @@ steps:
         # once perf improvements are made
         commands:
           - |
-            .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/bm_qwen3_coder.sh --model Qwen/Qwen3.5-397B-A17B-FP8 --tp 8 --req_tput_limit 0.04  --output_token_tput_limit 300 --total_token_tput_limit 345 --input_len 1024 --output_len 8192 --use_moe_ep_kernel 0 --limit_mm_per_prompt '{"image": 0, "video": 0}' --block_size 256 --num_prompts 64 --gpu_memory_utilization 0.9
+            .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/bm_qwen3_coder.sh --model Qwen/Qwen3.5-397B-A17B-FP8 --tp 8 --req_tput_limit 0.04  --output_token_tput_limit 300 --total_token_tput_limit 345 --input_len 1024 --output_len 8192 --use_moe_ep_kernel 0 --limit_mm_per_prompt '{"image": 0, "video": 0}' --block_size 256 --num_prompts 64 --gpu_memory_utilization 0.88
 
       - label: "${TPU_VERSION:-tpu6e} Perf regression test for Qwen3.5-397B-A17B 8k 1k with gmm kernel."
         key: ${TPU_VERSION:-tpu6e}_test_32
@@ -521,7 +521,7 @@ steps:
         if: '"${TPU_VERSION:-tpu6e}" == "tpu7x"'
         commands:
           - |
-            .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/bm_qwen3_coder.sh --model Qwen/Qwen3.5-397B-A17B-FP8 --tp 8 --req_tput_limit 0.05  --output_token_tput_limit 70 --total_token_tput_limit 650 --input_len 8192 --output_len 1024 --use_moe_ep_kernel 0    --limit_mm_per_prompt '{"image": 0, "video": 0}' --block_size 256 --num_prompts 64 --gpu_memory_utilization 0.9
+            .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/bm_qwen3_coder.sh --model Qwen/Qwen3.5-397B-A17B-FP8 --tp 8 --req_tput_limit 0.05  --output_token_tput_limit 70 --total_token_tput_limit 650 --input_len 8192 --output_len 1024 --use_moe_ep_kernel 0    --limit_mm_per_prompt '{"image": 0, "video": 0}' --block_size 256 --num_prompts 64 --gpu_memory_utilization 0.88
 
       - label: "${TPU_VERSION:-tpu6e} Accuracy for Qwen/Qwen2.5-VL-7B-Instruct"
         key: ${TPU_VERSION:-tpu6e}_test_33

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,9 +5,9 @@ pytest-mock
 absl-py
 numpy
 google-cloud-storage
-jax==0.10.1
-jaxlib==0.10.1
-libtpu==0.0.41
+jax==0.10.2
+jaxlib==0.10.2
+libtpu==0.0.42.1
 jaxtyping
 # Temporarily restrict fastapi version due to https://github.com/vllm-project/vllm/pull/45629
 # TODO(lk-chen): remove once LKG moves past above commit

--- a/tpu_inference/kernels/ragged_paged_attention/v2/kernel.py
+++ b/tpu_inference/kernels/ragged_paged_attention/v2/kernel.py
@@ -474,10 +474,9 @@ def ragged_paged_attention_kernel(
             def masked_store(ref, val, start, end, group=1):
                 iota = lax.broadcasted_iota(jnp.int32, ref.shape, 0) // group
                 mask = jnp.logical_and(iota >= start, iota < end)
-                pl.store(ref,
-                         idx=tuple(slice(None) for _ in ref.shape),
-                         val=val,
-                         mask=mask)
+                # jax 0.10.2 removed pl.store; masked store becomes a
+                # read-modify-write with jnp.where over the full ref.
+                ref[...] = jnp.where(mask, val, ref[...])
 
             def load_with_init(ref, init_val):
                 return jnp.where(kv_blk_idx == 0, jnp.full_like(ref, init_val),
@@ -804,7 +803,7 @@ def ragged_paged_attention(
     )
     in_specs = [
         q_block_spec,
-        pl.BlockSpec(memory_space=pltpu.ANY),
+        pl.BlockSpec(memory_space=pl.MemorySpace.ANY),
     ]
     out_specs = q_block_spec
     lm_scratch = pltpu.VMEM(

--- a/tpu_inference/kernels/ragged_paged_attention/v2/ragged_kv_cache_update.py
+++ b/tpu_inference/kernels/ragged_paged_attention/v2/ragged_kv_cache_update.py
@@ -154,11 +154,11 @@ def _kv_cache_update(
                                  page_size, num_slices)
 
     in_specs = [
-        pl.BlockSpec(memory_space=pltpu.TPUMemorySpace.ANY),
-        pl.BlockSpec(memory_space=pltpu.TPUMemorySpace.ANY),
+        pl.BlockSpec(memory_space=pl.MemorySpace.ANY),
+        pl.BlockSpec(memory_space=pl.MemorySpace.ANY),
     ]
 
-    out_specs = [pl.BlockSpec(memory_space=pltpu.TPUMemorySpace.ANY)]
+    out_specs = [pl.BlockSpec(memory_space=pl.MemorySpace.ANY)]
     out_shape = [jax.ShapeDtypeStruct(kv_cache.shape, dtype=kv_cache.dtype)]
 
     scalar_prefetches = [slices, num_slices]

--- a/tpu_inference/kernels/sparse_core/ragged_gather_reduce.py
+++ b/tpu_inference/kernels/sparse_core/ragged_gather_reduce.py
@@ -562,6 +562,12 @@ def ragged_gather_reduce(
         compiler_params=pltpu.CompilerParams(
             use_tc_tiling_on_sc=True,
             disable_bounds_checks=True,
+            # SparseCore bitcast (i32<->f32) is rejected by Mosaic's
+            # apply-vector-layout pass; disable layout passes so it lowers, as
+            # the v2 kernel already does. jax flipped the CompilerParams default
+            # to needs_layout_passes=True (jax commit 7ca29680b, in 0.10.2),
+            # which broke this kernel's vector.bitcast.
+            needs_layout_passes=False,
         ),
         scratch_types=dict(
             num_rows_per_row_partition_vmem_ref=pltpu.VMEM((num_simd_lanes, ),


### PR DESCRIPTION
## Purpose

Bump `jax`/`jaxlib` `0.10.1 → 0.10.2` and `libtpu` `0.0.41 → 0.0.42.1`.

`jax[tpu]==0.10.2` pins `libtpu==0.0.42.*`, so libtpu is bumped in lockstep to
keep the pin set installable.

## Why

The `0.10.0 → 0.10.1` bump (#2711) introduced a front-end (trace/lower/dispatch)
slowdown that inflated the JAX unit-test CI steps (`part2` rose ~70→~90 min,
concentrated in the model tests). It was **not** a caching issue — the
persistent compilation cache hits identically across versions; the front-end
just got slower.

A/B on a TPU7x host (same model unit test, warm persistent cache, 2nd run):

| jax | warm run | vs 0.10.0 |
|---|---|---|
| 0.10.0 | 28.7 s | — |
| 0.10.1 (current pin) | 64.4 s | +124% |
| **0.10.2 (this PR)** | **45.4 s** | **+58%** |

0.10.2 recovers ~half of the 0.10.1 regression. (The residual gap vs 0.10.0
remains and is worth pursuing upstream, but this is a strict improvement over
the current pin.)

## Validation

On a TPU7x-8 host, `jax 0.10.2 + jaxlib 0.10.2 + libtpu 0.0.42.1` initializes all
8 chips and runs the qwen3 model unit test green.
