### PR TITLE
Profile per concurrency per phase

### DIFF
--- a/tests/runner/test_utils.py
+++ b/tests/runner/test_utils.py
@@ -528,7 +528,8 @@ def test_phased_profiler_full_cycle(profiler_fixture):
     mock_start.assert_called_once()
     assert profiler.profiling_n_steps_left == PHASED_PROFILER_NUM_STEPS_TO_PROFILE_FOR
     assert profiler.current_phase == "prefill_heavy_concur_2"
-    assert (InferencePhase.PREFILL_HEAVY, 2) in profiler.inference_phases_profiled
+    assert (InferencePhase.PREFILL_HEAVY,
+            2) in profiler.inference_phases_profiled
     assert mock_file().write.call_count == 1  # Wrote stats on start
 
     # 2. Step profiling (N-1 steps)
@@ -618,12 +619,14 @@ def test_phased_profiler_skips_decode_steps_before_profiling(profiler_fixture):
         profiler.step(stats)
         assert profiler.decode_steps_skipped == i + 1
         mock_start.assert_not_called()
-        assert (InferencePhase.DECODE_HEAVY, 2) not in profiler.inference_phases_profiled
+        assert (InferencePhase.DECODE_HEAVY,
+                2) not in profiler.inference_phases_profiled
 
     # The next step should actually start profiling
     profiler.step(stats)
     mock_start.assert_called_once()
-    assert (InferencePhase.DECODE_HEAVY, 2) in profiler.inference_phases_profiled
+    assert (InferencePhase.DECODE_HEAVY,
+            2) in profiler.inference_phases_profiled
     assert profiler.current_phase == "decode_heavy_concur_2"
     assert profiler.profiling_n_steps_left == PHASED_PROFILER_NUM_STEPS_TO_PROFILE_FOR
 
@@ -649,7 +652,8 @@ def test_phased_profiler_skip_only_affects_decode_heavy(profiler_fixture):
     mock_determine_phase.return_value = InferencePhase.PREFILL_HEAVY
     profiler.step(stats)
     mock_start.assert_called_once()
-    assert (InferencePhase.PREFILL_HEAVY, 2) in profiler.inference_phases_profiled
+    assert (InferencePhase.PREFILL_HEAVY,
+            2) in profiler.inference_phases_profiled
     assert profiler.decode_steps_skipped == 0  # Not incremented
 
     # Complete the PREFILL_HEAVY profiling cycle
@@ -693,13 +697,15 @@ def test_phased_profiler_skips_decode_only_steps_based_on_kv_len(
     # Should be skipped as min_kv_len (5) < threshold (10)
     profiler.step(stats)
     mock_start.assert_not_called()
-    assert (InferencePhase.DECODE_ONLY, 2) not in profiler.inference_phases_profiled
+    assert (InferencePhase.DECODE_ONLY,
+            2) not in profiler.inference_phases_profiled
 
     # Should start profiling as min_kv_len (10) >= threshold (10)
     stats["min_kv_len"] = 10
     profiler.step(stats)
     mock_start.assert_called_once()
-    assert (InferencePhase.DECODE_ONLY, 2) in profiler.inference_phases_profiled
+    assert (InferencePhase.DECODE_ONLY,
+            2) in profiler.inference_phases_profiled
     assert profiler.current_phase == "decode_only_concur_2"
     assert profiler.profiling_n_steps_left == PHASED_PROFILER_NUM_STEPS_TO_PROFILE_FOR
 

--- a/tests/runner/test_utils.py
+++ b/tests/runner/test_utils.py
@@ -501,6 +501,7 @@ def profiler_fixture(tmp_path):
         mock_datetime.datetime.now.return_value = mock_now
 
         profiler = PhasedBasedProfiler(profile_dir=str(tmp_path))
+        profiler.track_concurrency = True
         profiler.num_steps_to_profile_for = PHASED_PROFILER_NUM_STEPS_TO_PROFILE_FOR
 
         yield {
@@ -719,6 +720,22 @@ def test_phased_profiler_skips_decode_only_steps_based_on_kv_len(
         profiler.step(stats)
     mock_stop.assert_called_once()
     assert profiler.current_phase == ""
+
+
+def test_phased_profiler_track_concurrency_disabled(profiler_fixture):
+    """Tests that when track_concurrency is False, phase names omit concurrency suffix."""
+    profiler = profiler_fixture["profiler"]
+    profiler.track_concurrency = False
+    mock_start = profiler_fixture["mock_start"]
+    mock_determine_phase = profiler_fixture["mock_determine_phase"]
+
+    stats = {"num_reqs": 2, "total_num_scheduled_tokens": 100}
+    mock_determine_phase.return_value = InferencePhase.PREFILL_HEAVY
+
+    profiler.step(stats)
+    mock_start.assert_called_once()
+    assert profiler.current_phase == "prefill_heavy"
+    assert InferencePhase.PREFILL_HEAVY in profiler.inference_phases_profiled
 
 
 def _stage_dp_rank_capture(rank_dir, ts_name, filename, content):

--- a/tests/runner/test_utils.py
+++ b/tests/runner/test_utils.py
@@ -527,8 +527,8 @@ def test_phased_profiler_full_cycle(profiler_fixture):
     profiler.step(stats)
     mock_start.assert_called_once()
     assert profiler.profiling_n_steps_left == PHASED_PROFILER_NUM_STEPS_TO_PROFILE_FOR
-    assert profiler.current_phase == "prefill_heavy"
-    assert profiler.inference_phase_seen[InferencePhase.PREFILL_HEAVY]
+    assert profiler.current_phase == "prefill_heavy_concur_2"
+    assert (InferencePhase.PREFILL_HEAVY, 2) in profiler.inference_phases_profiled
     assert mock_file().write.call_count == 1  # Wrote stats on start
 
     # 2. Step profiling (N-1 steps)
@@ -584,8 +584,8 @@ def test_phased_profiler_handles_all_phases(profiler_fixture):
         mock_determine_phase.return_value = phase
         profiler.step(stats)
         assert mock_start.call_count == i + 1
-        assert profiler.current_phase == phase.name.lower()
-        assert profiler.inference_phase_seen[phase]
+        assert profiler.current_phase == f"{phase.name.lower()}_concur_2"
+        assert (phase, 2) in profiler.inference_phases_profiled
 
         # Step until profiling stops for this phase
         for _ in range(PHASED_PROFILER_NUM_STEPS_TO_PROFILE_FOR):
@@ -618,13 +618,13 @@ def test_phased_profiler_skips_decode_steps_before_profiling(profiler_fixture):
         profiler.step(stats)
         assert profiler.decode_steps_skipped == i + 1
         mock_start.assert_not_called()
-        assert not profiler.inference_phase_seen[InferencePhase.DECODE_HEAVY]
+        assert (InferencePhase.DECODE_HEAVY, 2) not in profiler.inference_phases_profiled
 
     # The next step should actually start profiling
     profiler.step(stats)
     mock_start.assert_called_once()
-    assert profiler.inference_phase_seen[InferencePhase.DECODE_HEAVY]
-    assert profiler.current_phase == "decode_heavy"
+    assert (InferencePhase.DECODE_HEAVY, 2) in profiler.inference_phases_profiled
+    assert profiler.current_phase == "decode_heavy_concur_2"
     assert profiler.profiling_n_steps_left == PHASED_PROFILER_NUM_STEPS_TO_PROFILE_FOR
 
     # Complete the profiling cycle
@@ -649,7 +649,7 @@ def test_phased_profiler_skip_only_affects_decode_heavy(profiler_fixture):
     mock_determine_phase.return_value = InferencePhase.PREFILL_HEAVY
     profiler.step(stats)
     mock_start.assert_called_once()
-    assert profiler.inference_phase_seen[InferencePhase.PREFILL_HEAVY]
+    assert (InferencePhase.PREFILL_HEAVY, 2) in profiler.inference_phases_profiled
     assert profiler.decode_steps_skipped == 0  # Not incremented
 
     # Complete the PREFILL_HEAVY profiling cycle
@@ -661,7 +661,7 @@ def test_phased_profiler_skip_only_affects_decode_heavy(profiler_fixture):
     mock_determine_phase.return_value = InferencePhase.BALANCED
     profiler.step(stats)
     assert mock_start.call_count == 2
-    assert profiler.inference_phase_seen[InferencePhase.BALANCED]
+    assert (InferencePhase.BALANCED, 2) in profiler.inference_phases_profiled
     assert profiler.decode_steps_skipped == 0  # Still not incremented
 
     # Complete the BALANCED profiling cycle
@@ -693,14 +693,14 @@ def test_phased_profiler_skips_decode_only_steps_based_on_kv_len(
     # Should be skipped as min_kv_len (5) < threshold (10)
     profiler.step(stats)
     mock_start.assert_not_called()
-    assert not profiler.inference_phase_seen[InferencePhase.DECODE_ONLY]
+    assert (InferencePhase.DECODE_ONLY, 2) not in profiler.inference_phases_profiled
 
     # Should start profiling as min_kv_len (10) >= threshold (10)
     stats["min_kv_len"] = 10
     profiler.step(stats)
     mock_start.assert_called_once()
-    assert profiler.inference_phase_seen[InferencePhase.DECODE_ONLY]
-    assert profiler.current_phase == "decode_only"
+    assert (InferencePhase.DECODE_ONLY, 2) in profiler.inference_phases_profiled
+    assert profiler.current_phase == "decode_only_concur_2"
     assert profiler.profiling_n_steps_left == PHASED_PROFILER_NUM_STEPS_TO_PROFILE_FOR
 
     # Profiling continues

--- a/tpu_inference/runner/utils.py
+++ b/tpu_inference/runner/utils.py
@@ -114,6 +114,7 @@ PHASED_PROFILER_NUM_DECODE_STEPS_TO_SKIP = 0
 # For decode only batches, start capturing traces after all requests in the
 # batch has KV caches that have reached this length threshold
 PHASED_PROFILER_DECODE_ONLY_KV_LEN_THRESHOLD = -1
+PHASED_PROFILER_TRACK_CONCURRENCY = False
 
 logger = init_logger(__name__)
 
@@ -572,6 +573,9 @@ class PhasedBasedProfiler:
         self.decode_kv_len_threshold: int = int(
             os.getenv("PHASED_PROFILER_DECODE_ONLY_KV_LEN_THRESHOLD",
                       PHASED_PROFILER_DECODE_ONLY_KV_LEN_THRESHOLD))
+        self.track_concurrency: bool = os.getenv(
+            "PHASED_PROFILER_TRACK_CONCURRENCY",
+            str(PHASED_PROFILER_TRACK_CONCURRENCY)).lower() in ("1", "true")
         self.profile_dir: str = profile_dir
         # NOTE: we purposely don't have AMBIGUOUS here
         self.inference_phases_profiled: set = set()
@@ -638,7 +642,8 @@ class PhasedBasedProfiler:
         """
         current_determined_phase = determine_phase_from_batch_composition_stats(
             batch_composition_stats)
-        concurrency = batch_composition_stats.get("num_reqs", 0)
+        concurrency = (batch_composition_stats.get("num_reqs", 0)
+                       if self.track_concurrency else 0)
         for phase in InferencePhase:
             profile_key = (phase, concurrency) if concurrency > 0 else phase
             if (profile_key in self.inference_phases_profiled
@@ -851,7 +856,8 @@ class PhasedBasedProfiler:
         # We want to start profiling only after the first trial request
         is_past_initial_request = batch_composition_stats[
             "total_num_scheduled_tokens"] > 1
-        concurrency = batch_composition_stats.get("num_reqs", 0)
+        concurrency = (batch_composition_stats.get("num_reqs", 0)
+                       if self.track_concurrency else 0)
         if concurrency > 0:
             should_profile = is_past_initial_request
         else:

--- a/tpu_inference/runner/utils.py
+++ b/tpu_inference/runner/utils.py
@@ -574,13 +574,7 @@ class PhasedBasedProfiler:
                       PHASED_PROFILER_DECODE_ONLY_KV_LEN_THRESHOLD))
         self.profile_dir: str = profile_dir
         # NOTE: we purposely don't have AMBIGUOUS here
-        self.inference_phase_seen: dict = {
-            InferencePhase.PREFILL_ONLY: False,
-            InferencePhase.PREFILL_HEAVY: False,
-            InferencePhase.DECODE_ONLY: False,
-            InferencePhase.DECODE_HEAVY: False,
-            InferencePhase.BALANCED: False
-        }
+        self.inference_phases_profiled: set = set()
         self.default_profiling_options = jax.profiler.ProfileOptions()
         self.default_profiling_options.python_tracer_level = envs.PYTHON_TRACER_LEVEL
         self.default_profiling_options.advanced_configuration = {
@@ -644,8 +638,11 @@ class PhasedBasedProfiler:
         """
         current_determined_phase = determine_phase_from_batch_composition_stats(
             batch_composition_stats)
-        for phase, has_been_seen in self.inference_phase_seen.items():
-            if has_been_seen or phase != current_determined_phase:
+        concurrency = batch_composition_stats.get("num_reqs", 0)
+        for phase in InferencePhase:
+            profile_key = (phase, concurrency) if concurrency > 0 else phase
+            if (profile_key in self.inference_phases_profiled
+                    or phase != current_determined_phase):
                 continue
 
             # Skip a configurable number of decode-heavy steps before profiling
@@ -667,10 +664,13 @@ class PhasedBasedProfiler:
                         min_kv_len, self.decode_kv_len_threshold)
                     break
 
-            self.inference_phase_seen[phase] = True
+            self.inference_phases_profiled.add(profile_key)
             self.profiling_n_steps_left = self.num_steps_to_profile_for
 
-            self.current_phase = phase.name.lower()
+            if concurrency > 0:
+                self.current_phase = f"{phase.name.lower()}_concur_{concurrency}"
+            else:
+                self.current_phase = phase.name.lower()
 
             logger.info(f"Starting profiling for {self.current_phase} phase")
             logger.info(f"Batch composition stats: {batch_composition_stats}")
@@ -848,12 +848,20 @@ class PhasedBasedProfiler:
                     phase: The phase of the inference the batch is in.
         """
 
-        have_seen_all_phases = all(self.inference_phase_seen.values())
         # We want to start profiling only after the first trial request
         is_past_initial_request = batch_composition_stats[
             "total_num_scheduled_tokens"] > 1
-        if is_past_initial_request and (not have_seen_all_phases
-                                        or self.current_phase != ""):
+        concurrency = batch_composition_stats.get("num_reqs", 0)
+        if concurrency > 0:
+            should_profile = is_past_initial_request
+        else:
+            have_seen_all_phases = all(phase in self.inference_phases_profiled
+                                       for phase in InferencePhase
+                                       if phase != InferencePhase.AMBIGUOUS)
+            should_profile = is_past_initial_request and (
+                not have_seen_all_phases or self.current_phase != "")
+
+        if should_profile:
             # We haven't started profiling yet
             if self.profiling_n_steps_left <= 0:
                 self._start_profiling(batch_composition_stats)


### PR DESCRIPTION
# Description

This PR updates `PhasedBasedProfiler` to support profiling and capturing separate traces for the same phase across multiple concurrency sizes during benchmark sweeps, while maintaining full backward compatibility.

### Why is this change being made?
Previously, `PhasedBasedProfiler` tracked profiled phases globally via a simple boolean map (`self.inference_phase_seen`). Once a phase (like `DECODE_ONLY`) was profiled once (typically during warm-up or the first sweep iteration), the profiler would never trigger trace collection for that phase again. During concurrency sweeps (e.g., testing batch sizes of 1, 2, 4, 8, 16, 32, 64 and 128), we want to profile the compile shapes and runtime traces for every concurrency size individually. Without this change, we had to start the server again for each concurrency.

### Specific Implementation:
1.  **Concurrency-Aware Phase Tracking**: Refactored the tracking map from a global dictionary of boolean flags to a set `self.inference_phases_profiled` containing `(phase, concurrency)` tuples.
2.  **Dynamic Directory Suffixes**: Suffixes the phase output directory with `_concur_{concurrency}` (e.g., `decode_only_concur_64/`) to prevent concurrency runs from overwriting each other's trace files.
3.  **Strict Backward Compatibility**: If the concurrency size `num_reqs` is absent or `0` (e.g. when executing standard, non-sweep profiling workloads):
    *   It falls back to tracking by `phase` only.
    *   It keeps the original directory name format (no `_concur` suffix).
    *   It re-enables the original "all phases seen" shutdown gate to terminate profiling after seeing every phase once.
---

# Tests

Tested this change in two scenarios on a 16-chip `v7x-16` cluster running Mistral 3 Large (FP8):

1.  **Multi-concurrency Sweep Run**:
    *   Ran a sweep with `CONCURRENCIES=[1, 2, 4, 8, 16, 32, 64, 128]`.
    *   Verified that distinct trace outputs were successfully written to separate folders (e.g., `decode_only_concur_16`, `decode_only_concur_32`, `decode_only_concur_64`).
2.  **Backward Compatibility Check**:
    *   Ran a benchmark without the `max_concurrency` dictionary key.
    *   Verified that traces compiled directly into `decode_only` and `prefill_heavy` without suffixes, and that the profiler shut down correctly once all phases were profiled.
    * list all profiles under default mode:
```
amandaliang@amandaliang:~/tpu-inference$ gcloud compute tpus tpu-vm ssh amandaliang-v7x-8 \
  --zone=us-central1-c \
  --project=cloud-tpu-inference-test \
  --command="find /mnt/pd/vllm-xprof/ -name '*.xplane.pb' | sort"
Using ssh batch size of 1. Attempting to SSH into 1 nodes with a total of 1 workers.
SSH: Attempting to connect to worker 0...
/mnt/pd/vllm-xprof/decode_only/plugins/profile/2026_07_22_00_49_43/t1v-n-9eb622fc-w-0.xplane.pb
/mnt/pd/vllm-xprof/prefill_heavy/plugins/profile/2026_07_22_00_48_23/t1v-n-9eb622fc-w-0.xplane.pb
/mnt/pd/vllm-xprof/prefill_only/plugins/profile/2026_07_22_00_45_14/t1v-n-9eb622fc-w-0.xplane.pb
```

---

# Checklist

Before submitting this PR, please make sure:
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have made or will make corresponding changes to any relevant documentation.