### PR TITLE
[tpu-inference] Fix nested data-parallel queue shape mismatches and host sharding specs

### DIFF
--- a/tpu_inference/core/sched/dp_scheduler.py
+++ b/tpu_inference/core/sched/dp_scheduler.py
@@ -144,9 +144,6 @@ def _scheduler_worker_process(
     original_scheduler_cls: type,
 ):
     """Worker process that manages a single scheduler instance."""
-    import atexit, gc
-    atexit._clear()
-    gc.disable()
     # Initialize the scheduler in this process
     import inspect
     sig = inspect.signature(original_scheduler_cls)

--- a/tpu_inference/core/sched/dp_scheduler.py
+++ b/tpu_inference/core/sched/dp_scheduler.py
@@ -144,6 +144,9 @@ def _scheduler_worker_process(
     original_scheduler_cls: type,
 ):
     """Worker process that manages a single scheduler instance."""
+    import atexit, gc
+    atexit._clear()
+    gc.disable()
     # Initialize the scheduler in this process
     import inspect
     sig = inspect.signature(original_scheduler_cls)

--- a/tpu_inference/core/sched/dp_scheduler.py
+++ b/tpu_inference/core/sched/dp_scheduler.py
@@ -397,7 +397,7 @@ class DPScheduler(SchedulerInterface):
         self.structured_output_manager = structured_output_manager
 
         # DP state
-        self.dp_size = vllm_config.sharding_config.total_dp_size
+        self.dp_size = vllm_config.sharding_config.model_dp_size
         self.assigned_dp_rank: Dict[str, int] = {}  # req_id -> dp_rank
         self.cached_schedulers_output = deque()
         self._create_per_rank_configs(kv_cache_config)
@@ -1489,7 +1489,7 @@ def update_vllm_config_for_dp_scheduler(vllm_config: Any) -> None:
     """
     Update vLLM configuration to use DPScheduler when DP size > 1.
     """
-    dp_size = vllm_config.sharding_config.total_dp_size
+    dp_size = vllm_config.sharding_config.model_dp_size
 
     if dp_size > 1:
         if vllm_config.scheduler_config.async_scheduling:

--- a/tpu_inference/layers/common/sharding.py
+++ b/tpu_inference/layers/common/sharding.py
@@ -36,12 +36,8 @@ MESH_AXIS_NAMES_2D = ('data', 'model')
 
 class ShardingAxisNameBase:
     """Base class for sharding axis names."""
-    SEQUENCE = (
-        'data',
-        'attn_dp',
-        'attn_dp_expert',
-    )
-    ATTN_DATA = ('data', 'attn_dp', 'attn_dp_expert')
+    SEQUENCE = 'data'
+    ATTN_DATA = 'data'
     ATTN_DATA_EXPERT = ('attn_dp_expert', 'expert')
     MLP_DATA = 'data'
     ATTN_HEAD = ('model', 'expert', 'dcp')
@@ -59,7 +55,7 @@ class ShardingAxisNameBase:
     MODEL = 'model'
 
     # These axes are used in KV caches management.
-    BATCH = ('data', 'attn_dp', 'attn_dp_expert')
+    BATCH = 'data'
     CONTEXT = 'dcp'
     KV_CACHE_HEAD = ('model', 'expert')
 

--- a/tpu_inference/layers/jax/attention/gpt_oss_attention.py
+++ b/tpu_inference/layers/jax/attention/gpt_oss_attention.py
@@ -171,6 +171,7 @@ class GptOssAttention(nnx.Module):
         v_scale: float | None = None,
     ) -> Tuple[KVCache, jax.Array]:
         """Performs scaled dot-product attention by calling the ragged_paged_attention kernel."""
+        sinks = jnp.asarray(sinks, jnp.float32)
         md = attention_metadata
         kv_cache_spec = P("data", None, "model")
 

--- a/tpu_inference/models/jax/gpt_oss.py
+++ b/tpu_inference/models/jax/gpt_oss.py
@@ -77,7 +77,7 @@ class GptOss(nnx.Module):
         rms_norm_eps: float = self.hf_config.rms_norm_eps
         swiglu_limit: float = self.hf_config.swiglu_limit
 
-        rope_theta: float = self.hf_config.rope_theta
+        rope_theta: float = getattr(self.hf_config, "rope_theta", None) or self.hf_config.rope_scaling["rope_theta"]
         rope_scaling_factor: float = self.hf_config.rope_scaling["factor"]
         rope_ntk_alpha: float = self.hf_config.rope_scaling["beta_slow"]
         rope_ntk_beta: float = self.hf_config.rope_scaling["beta_fast"]

--- a/tpu_inference/runner/compilation_manager.py
+++ b/tpu_inference/runner/compilation_manager.py
@@ -356,7 +356,7 @@ class CompilationManager:
             num_tokens = inputs_embeds.shape[0]
         assert num_tokens is not None
 
-        dp_size = self.runner.vllm_config.sharding_config.total_dp_size
+        dp_size = self.runner.vllm_config.sharding_config.model_dp_size
         dp_sharding = NamedSharding(
             self.runner.mesh, PartitionSpec(ShardingAxisName.ATTN_DATA, ))
 
@@ -1560,7 +1560,7 @@ class CompilationManager:
     def _precompile_structured_decoding(self) -> None:
         logger.info(
             "Compiling structured_decoding with different input shapes.")
-        if self.runner.vllm_config.sharding_config.total_dp_size > 1:
+        if self.runner.vllm_config.sharding_config.model_dp_size > 1:
             logger.warning(
                 "Structured decoding precompilation skipped since structured decoding is not supported with DP."
             )
@@ -1592,7 +1592,7 @@ class CompilationManager:
 
     def _precompile_continue_decode(self) -> None:
         logger.info("Precompiling continue_decode loop.")
-        dp_size = self.runner.vllm_config.sharding_config.total_dp_size
+        dp_size = self.runner.vllm_config.sharding_config.model_dp_size
         dp_sharding = NamedSharding(
             self.runner.mesh, PartitionSpec(ShardingAxisName.ATTN_DATA, ))
 

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -482,7 +482,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         self.dtype = self.model_config.dtype
         self.maybe_forbid_compile = runner_utils.ForbidCompile(
         ) if envs.VLLM_XLA_CHECK_RECOMPILATION else nullcontext()
-        self.dp_size = self.vllm_config.sharding_config.total_dp_size
+        self.dp_size = self.vllm_config.sharding_config.model_dp_size
         self.rank = rank
         self.is_first_rank = is_first_rank
         self.is_last_rank = is_last_rank


### PR DESCRIPTION
This PR resolves the shape mismatch and indivisible sharding issues encountered when running data-parallel rollouts with `data_parallel_size > 1` under attention DP.

### 1. Fix shape mismatch between CPU scheduler packing size and attention block sharding.
- The CPU scheduler and precompilation logic were using `total_dp_size` (the product of data and attention-data parallelism, e.g. 4), but the actual attention block sharded batch dimensions only by the outer data-parallel dimension `model_dp_size` (e.g. 2).
- This mismatch caused sequence padding shape differences (e.g. `cu_q_lens` local size 514 vs `seq_lens` local size 512, expected 513), leading to attention kernel wrapper runtime errors.
- Changed the logic in `tpu_runner.py`, `dp_scheduler.py`, and `compilation_manager.py` to use `model_dp_size` for scheduler logical queues, rank tracking, and precompilation shapes.

### 2. Map host-to-device sharding specs to the outer data parallel dimension.
- Changed `ShardingAxisNameBase` axes (`ATTN_DATA`, `BATCH`, `SEQUENCE`) in `sharding.py` to map directly to `'data'` instead of a multidimensional tuple including `attn_dp` and `attn_dp_expert`.
- This ensures host-to-device metadata arrays (like `request_distribution` and `metadata_blob`) are sharded using the Outer Data Parallel axis (size 2), avoiding `IndivisibleError` when shape dimensions aren't divisible by 4.
