### PR TITLE
[Bugfix] Fix routed-experts slot mapping for prompt tokens

### DIFF
--- a/tests/e2e/test_continue_decode.py
+++ b/tests/e2e/test_continue_decode.py
@@ -8,6 +8,7 @@ import time
 from dataclasses import dataclass, field
 from typing import Union
 
+import numpy as np
 import pytest
 from vllm import LLM, SamplingParams
 
@@ -280,7 +281,7 @@ def test_continue_decode_correctness_matrix(matrix_case, sampling_params):
 
     # 5. Verify expert routing metadata for MoE architectures
     if "MoE" in config.model_name:
-        for cd_out in continue_decode_outputs:
+        for base_out, cd_out in zip(baseline_outputs, continue_decode_outputs):
             cd_req = cd_out.outputs[0]
             assert cd_req.routed_experts is not None, "routed_experts tensor must be populated for MoE models when enabled."
             assert len(
@@ -297,6 +298,27 @@ def test_continue_decode_correctness_matrix(matrix_case, sampling_params):
                 f"Exported expert IDs token dimension mismatch. Expected {expected_tokens_dim} "
                 f"(prompt len {num_prompt_tokens} + gen len {num_gen_tokens} - 1), got {actual_tokens_dim}"
             )
+
+            # Value-level check: continue_decode must return the *same* routed
+            # expert IDs as the single-step baseline (deterministic, temp=0).
+            # A shape-only check cannot catch a slot-mapping regression (e.g. a
+            # wrong start_pos that zero-fills the prompt experts), so compare the
+            # actual IDs against the baseline run.
+            base_req = base_out.outputs[0]
+            assert base_req.routed_experts is not None, (
+                "baseline routed_experts must be populated for MoE models")
+            cd_re = np.asarray(cd_req.routed_experts)
+            base_re = np.asarray(base_req.routed_experts)
+            assert cd_re.shape == base_re.shape, (
+                f"routed_experts shape mismatch: continue_decode {cd_re.shape} "
+                f"vs baseline {base_re.shape}")
+            np.testing.assert_array_equal(
+                cd_re,
+                base_re,
+                err_msg=
+                ("continue_decode routed experts differ from the single-step "
+                 "baseline; a slot-mapping regression can zero-fill or shift "
+                 "expert IDs while keeping the shape correct"))
 
 
 # Scenarios 5-6: Performance evaluation on MMLU workloads with Qwen/Qwen1.5-MoE-A2.7B

--- a/tests/e2e/test_continue_decode.py
+++ b/tests/e2e/test_continue_decode.py
@@ -299,26 +299,30 @@ def test_continue_decode_correctness_matrix(matrix_case, sampling_params):
                 f"(prompt len {num_prompt_tokens} + gen len {num_gen_tokens} - 1), got {actual_tokens_dim}"
             )
 
-            # Value-level check: continue_decode must return the *same* routed
-            # expert IDs as the single-step baseline (deterministic, temp=0).
-            # A shape-only check cannot catch a slot-mapping regression (e.g. a
-            # wrong start_pos that zero-fills the prompt experts), so compare the
-            # actual IDs against the baseline run.
+            # Value-level check on the PROMPT slice: continue_decode must return
+            # the same routed expert IDs as the single-step baseline for the
+            # prompt tokens (deterministic prefill, temp=0). A shape-only check
+            # cannot catch a slot-mapping regression (e.g. a wrong start_pos that
+            # zero-fills the prompt experts). We compare only the prompt slice
+            # [:num_prompt_tokens] -- it is identical across both runs regardless
+            # of any later generation divergence (which _check_correctness only
+            # bounds fuzzily), so this avoids false-fails on diverging tails.
             base_req = base_out.outputs[0]
             assert base_req.routed_experts is not None, (
                 "baseline routed_experts must be populated for MoE models")
             cd_re = np.asarray(cd_req.routed_experts)
             base_re = np.asarray(base_req.routed_experts)
-            assert cd_re.shape == base_re.shape, (
-                f"routed_experts shape mismatch: continue_decode {cd_re.shape} "
-                f"vs baseline {base_re.shape}")
+            p = num_prompt_tokens
+            assert cd_re.shape[1:] == base_re.shape[1:], (
+                f"routed_experts per-token shape mismatch: continue_decode "
+                f"{cd_re.shape} vs baseline {base_re.shape}")
             np.testing.assert_array_equal(
-                cd_re,
-                base_re,
+                cd_re[:p],
+                base_re[:p],
                 err_msg=
-                ("continue_decode routed experts differ from the single-step "
-                 "baseline; a slot-mapping regression can zero-fill or shift "
-                 "expert IDs while keeping the shape correct"))
+                ("continue_decode prompt routed experts differ from the "
+                 "single-step baseline; a slot-mapping regression can zero-fill "
+                 "or shift prompt expert IDs while keeping the shape correct"))
 
 
 # Scenarios 5-6: Performance evaluation on MMLU workloads with Qwen/Qwen1.5-MoE-A2.7B

--- a/tests/runner/test_moe_expert_ids.py
+++ b/tests/runner/test_moe_expert_ids.py
@@ -65,6 +65,39 @@ def llm_disabled():
     gc.collect()
 
 
+@pytest.fixture(scope="function")
+def llm_enabled_sync():
+    # async_scheduling=False routes generation through the sync sampler path
+    # (_sample_from_logits), which reconstructs routed experts differently than
+    # the async get_output path. continue_decode requires async_scheduling=False,
+    # so this also covers that use case. The default llm_enabled fixture runs on
+    # the async path, so this fixture is the only coverage of the sync path.
+    engine = LLM(
+        model="Qwen/Qwen1.5-MoE-A2.7B",
+        load_format="dummy",
+        trust_remote_code=True,
+        max_model_len=128,
+        max_num_batched_tokens=128,
+        max_num_seqs=16,
+        gpu_memory_utilization=0.95,
+        tensor_parallel_size=1,
+        pipeline_parallel_size=1,
+        enable_prefix_caching=False,
+        kv_cache_dtype="auto",
+        enable_expert_parallel=False,
+        enable_return_routed_experts=True,
+        async_scheduling=False,
+        additional_config={
+            "enable_continue_decode": True,
+            "max_decode_steps": 4
+        },
+    )
+    yield engine
+    engine.llm_engine.engine_core.shutdown()
+    import gc
+    gc.collect()
+
+
 class TestMoEExpertIds:
     """Verify that MoE routed experts are successfully returned when enabled,
     and not returned when disabled.
@@ -140,3 +173,26 @@ class TestMoEExpertIds:
                                       routed_experts_a)
         np.testing.assert_array_equal(routed_experts_batched_b,
                                       routed_experts_b)
+
+    def test_moe_expert_ids_sync_path_prompt_populated(self,
+                                                       llm_enabled_sync: LLM):
+        """Covers the sync sampler path (async_scheduling=False, used by
+        continue_decode). The slot start for routed experts must be the
+        request's pre-step computed-token count; deriving it as
+        num_computed_tokens - num_tokens underflowed to a negative value on this
+        path and crashed the engine on the first prefill. The prompt's routed
+        experts must be populated (not zero-filled)."""
+        prompt = "The capital of France is"
+        sampling_params = SamplingParams(temperature=0, max_tokens=8)
+        output = llm_enabled_sync.generate([prompt], sampling_params)[0]
+
+        routed_experts = output.outputs[0].routed_experts
+        assert routed_experts is not None, (
+            "routed_experts must be populated on the sync path")
+        re_arr = np.asarray(routed_experts)
+        num_prompt_tokens = len(output.prompt_token_ids)
+        # The prompt slice must not be all-zero (the slot bug zero-filled it).
+        prompt_slice = re_arr[:num_prompt_tokens]
+        assert not (prompt_slice == 0).all(), (
+            "prompt routed experts are all zero on the sync path -- slot "
+            "start_pos is misaligned with the scheduler-side read")

--- a/tests/runner/test_routed_experts_slots.py
+++ b/tests/runner/test_routed_experts_slots.py
@@ -1,0 +1,71 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for routed-experts physical slot reconstruction.
+
+``_reconstruct_slots_for_request`` produces the slot_mapping under which a
+step's routed experts are stored into the scheduler-side slot buffer
+(``RoutedExpertsManager``). The scheduler reads them back block-relative from
+position 0, so the slots must be derived from the chunk's *start* position
+(``num_computed_tokens - num_tokens``), since ``num_computed_tokens`` has
+already been advanced past the step's tokens by reconstruction time.
+"""
+from types import SimpleNamespace
+
+import numpy as np
+
+from tpu_inference.runner.tpu_runner import _reconstruct_slots_for_request
+
+
+def _req(num_computed_tokens, block_ids):
+    # Only num_computed_tokens and block_ids are read; CachedRequestState
+    # stores the per-attention-group block IDs as block_ids[0].
+    return SimpleNamespace(num_computed_tokens=num_computed_tokens,
+                           block_ids=[block_ids])
+
+
+class TestReconstructSlotsForRequest:
+
+    def test_prefill_slots_are_block_relative_from_zero(self):
+        # 5-token prompt prefill; num_computed_tokens has advanced to 5.
+        # Tokens occupy positions 0..4 in block 1 -> slots 16..20.
+        # (Using num_computed_tokens directly would give the wrong 21..25.)
+        slots = _reconstruct_slots_for_request(_req(5, [1]),
+                                               num_tokens=5,
+                                               block_size=16)
+        np.testing.assert_array_equal(
+            slots, np.array([16, 17, 18, 19, 20], dtype=np.int32))
+
+    def test_decode_step_slot(self):
+        # One decode token after a 5-token prompt; num_computed_tokens -> 6,
+        # so the token sits at absolute position 5 in block 1 -> slot 21.
+        slots = _reconstruct_slots_for_request(_req(6, [1]),
+                                               num_tokens=1,
+                                               block_size=16)
+        np.testing.assert_array_equal(slots, np.array([21], dtype=np.int32))
+
+    def test_prefill_spanning_multiple_blocks(self):
+        # 20-token prefill across two blocks [1, 2], block_size 16:
+        # positions 0..15 -> block 1, positions 16..19 -> block 2.
+        slots = _reconstruct_slots_for_request(_req(20, [1, 2]),
+                                               num_tokens=20,
+                                               block_size=16)
+        expected = np.concatenate(
+            [1 * 16 + np.arange(16), 2 * 16 + np.arange(4)]).astype(np.int32)
+        np.testing.assert_array_equal(slots, expected)
+
+    def test_zero_tokens_returns_empty(self):
+        slots = _reconstruct_slots_for_request(_req(5, [1]),
+                                               num_tokens=0,
+                                               block_size=16)
+        assert slots.size == 0

--- a/tests/runner/test_routed_experts_slots.py
+++ b/tests/runner/test_routed_experts_slots.py
@@ -13,18 +13,22 @@
 # limitations under the License.
 """Unit tests for routed-experts physical slot reconstruction.
 
-``_reconstruct_slots_for_request`` produces the slot_mapping under which a
-step's routed experts are stored into the scheduler-side slot buffer
-(``RoutedExpertsManager``). The scheduler reads them back block-relative from
-position 0, so the slots must be derived from the chunk's *start* position
-(``num_computed_tokens - num_tokens``), since ``num_computed_tokens`` has
-already been advanced past the step's tokens by reconstruction time.
+The routed experts of a step are stored into the scheduler-side slot buffer
+(``RoutedExpertsManager``) keyed by physical KV-cache slot, and read back
+block-relative from position 0. So the slot_mapping produced here must place a
+request's tokens at their true absolute positions. ``_reconstruct_slots_for_request``
+takes an explicit ``start_pos`` (the two call sites have different token
+contracts); ``_reconstruct_routed_experts`` derives it for the routed-experts
+path as ``num_computed_tokens - num_tokens`` (num_computed_tokens has already
+been advanced past the step's tokens by reconstruction time).
 """
 from types import SimpleNamespace
 
 import numpy as np
+import pytest
 
-from tpu_inference.runner.tpu_runner import _reconstruct_slots_for_request
+from tpu_inference.runner.tpu_runner import (_reconstruct_routed_experts,
+                                             _reconstruct_slots_for_request)
 
 
 def _req(num_computed_tokens, block_ids):
@@ -35,31 +39,31 @@ def _req(num_computed_tokens, block_ids):
 
 
 class TestReconstructSlotsForRequest:
+    """Slot math given an explicit absolute start position."""
 
-    def test_prefill_slots_are_block_relative_from_zero(self):
-        # 5-token prompt prefill; num_computed_tokens has advanced to 5.
-        # Tokens occupy positions 0..4 in block 1 -> slots 16..20.
-        # (Using num_computed_tokens directly would give the wrong 21..25.)
+    def test_slots_are_block_relative_from_start_pos(self):
+        # 5 tokens starting at absolute position 0 in block 1 -> slots 16..20.
         slots = _reconstruct_slots_for_request(_req(5, [1]),
                                                num_tokens=5,
-                                               block_size=16)
+                                               block_size=16,
+                                               start_pos=0)
         np.testing.assert_array_equal(
             slots, np.array([16, 17, 18, 19, 20], dtype=np.int32))
 
-    def test_decode_step_slot(self):
-        # One decode token after a 5-token prompt; num_computed_tokens -> 6,
-        # so the token sits at absolute position 5 in block 1 -> slot 21.
+    def test_single_token_at_offset(self):
+        # One token at absolute position 5 in block 1 -> slot 21.
         slots = _reconstruct_slots_for_request(_req(6, [1]),
                                                num_tokens=1,
-                                               block_size=16)
+                                               block_size=16,
+                                               start_pos=5)
         np.testing.assert_array_equal(slots, np.array([21], dtype=np.int32))
 
-    def test_prefill_spanning_multiple_blocks(self):
-        # 20-token prefill across two blocks [1, 2], block_size 16:
-        # positions 0..15 -> block 1, positions 16..19 -> block 2.
+    def test_spanning_multiple_blocks(self):
+        # 20 tokens from position 0 across blocks [1, 2], block_size 16.
         slots = _reconstruct_slots_for_request(_req(20, [1, 2]),
                                                num_tokens=20,
-                                               block_size=16)
+                                               block_size=16,
+                                               start_pos=0)
         expected = np.concatenate(
             [1 * 16 + np.arange(16), 2 * 16 + np.arange(4)]).astype(np.int32)
         np.testing.assert_array_equal(slots, expected)
@@ -67,5 +71,58 @@ class TestReconstructSlotsForRequest:
     def test_zero_tokens_returns_empty(self):
         slots = _reconstruct_slots_for_request(_req(5, [1]),
                                                num_tokens=0,
-                                               block_size=16)
+                                               block_size=16,
+                                               start_pos=0)
         assert slots.size == 0
+
+    def test_negative_start_pos_raises(self):
+        # A negative start_pos would silently produce wrong slots via numpy
+        # negative indexing; the helper must reject it loudly instead.
+        with pytest.raises(AssertionError):
+            _reconstruct_slots_for_request(_req(3, [1]),
+                                           num_tokens=5,
+                                           block_size=16,
+                                           start_pos=-2)
+
+
+class TestReconstructRoutedExperts:
+    """End-to-end slot derivation for the routed-experts reconstruction path
+    (the caller that had the off-by-num_tokens bug)."""
+
+    def test_prefill_slots_block_relative_and_routing_preserved(self):
+        req_id = "req0"
+        n = 5  # 5-token prompt prefill
+        block_size = 16
+        num_layers, top_k = 2, 4
+        # num_computed_tokens already advanced past the chunk (post-prefill = 5).
+        req_state = _req(num_computed_tokens=n, block_ids=[1])
+        runner = SimpleNamespace(block_size=block_size,
+                                 dp_size=1,
+                                 requests={req_id: req_state})
+        scheduler_output = SimpleNamespace(
+            num_scheduled_tokens={req_id: n},
+            total_num_scheduled_tokens=n,
+        )
+        # Distinct per-(layer, token) values to detect any mis-mapping.
+        expert_indices_cpu = np.arange(num_layers * n * top_k,
+                                       dtype=np.int32).reshape(
+                                           num_layers, n, top_k)
+
+        result = _reconstruct_routed_experts(
+            runner=runner,
+            scheduler_output=scheduler_output,
+            expert_indices_cpu=expert_indices_cpu,
+            req_ids=[req_id],
+            req_ids_dp={0: [req_id]},
+            padded_num_scheduled_tokens_per_dp_rank=n,
+        )
+
+        # The fix: prompt tokens at positions 0..4 in block 1 -> slots 16..20.
+        # (The pre-fix code produced 21..25, which the scheduler reads as zeros.)
+        np.testing.assert_array_equal(
+            result.slot_mapping, np.array([16, 17, 18, 19, 20],
+                                          dtype=np.int32))
+        # dp_size==1 -> identity reorder; routing_data is the model output
+        # transposed to (tokens, layers, top_k).
+        np.testing.assert_array_equal(result.routing_data,
+                                      expert_indices_cpu.transpose(1, 0, 2))

--- a/tests/runner/test_routed_experts_slots.py
+++ b/tests/runner/test_routed_experts_slots.py
@@ -18,9 +18,10 @@ The routed experts of a step are stored into the scheduler-side slot buffer
 block-relative from position 0. So the slot_mapping produced here must place a
 request's tokens at their true absolute positions. ``_reconstruct_slots_for_request``
 takes an explicit ``start_pos`` (the two call sites have different token
-contracts); ``_reconstruct_routed_experts`` derives it for the routed-experts
-path as ``num_computed_tokens - num_tokens`` (num_computed_tokens has already
-been advanced past the step's tokens by reconstruction time).
+contracts); ``_reconstruct_routed_experts`` sources it from ``scheduler_output``
+(the pre-step computed-token count), which is correct on both the sync and
+async output paths -- unlike ``req_state.num_computed_tokens``, whose
+advancement timing differs between them.
 """
 from types import SimpleNamespace
 
@@ -85,23 +86,37 @@ class TestReconstructSlotsForRequest:
                                            start_pos=-2)
 
 
+def _new_req_sched(req_id, num_computed_tokens):
+    return SimpleNamespace(req_id=req_id,
+                           num_computed_tokens=num_computed_tokens)
+
+
+def _empty_cached():
+    return SimpleNamespace(req_ids=[], num_computed_tokens=[])
+
+
 class TestReconstructRoutedExperts:
     """End-to-end slot derivation for the routed-experts reconstruction path
-    (the caller that had the off-by-num_tokens bug)."""
+    (the caller that had the slot-start bug). The chunk start is sourced from
+    scheduler_output (pre-step), NOT from req_state.num_computed_tokens, whose
+    advancement timing differs between the sync and async output paths."""
 
-    def test_prefill_slots_block_relative_and_routing_preserved(self):
+    def test_new_request_prefill_slots_block_relative(self):
         req_id = "req0"
         n = 5  # 5-token prompt prefill
         block_size = 16
         num_layers, top_k = 2, 4
-        # num_computed_tokens already advanced past the chunk (post-prefill = 5).
-        req_state = _req(num_computed_tokens=n, block_ids=[1])
+        # Set req_state.num_computed_tokens to a wrong sentinel: the result must
+        # be derived from scheduler_output (chunk start 0), not this field.
+        req_state = _req(num_computed_tokens=99999, block_ids=[1])
         runner = SimpleNamespace(block_size=block_size,
                                  dp_size=1,
                                  requests={req_id: req_state})
         scheduler_output = SimpleNamespace(
             num_scheduled_tokens={req_id: n},
             total_num_scheduled_tokens=n,
+            scheduled_new_reqs=[_new_req_sched(req_id, 0)],
+            scheduled_cached_reqs=_empty_cached(),
         )
         # Distinct per-(layer, token) values to detect any mis-mapping.
         expert_indices_cpu = np.arange(num_layers * n * top_k,
@@ -117,8 +132,10 @@ class TestReconstructRoutedExperts:
             padded_num_scheduled_tokens_per_dp_rank=n,
         )
 
-        # The fix: prompt tokens at positions 0..4 in block 1 -> slots 16..20.
-        # (The pre-fix code produced 21..25, which the scheduler reads as zeros.)
+        # Prompt tokens at positions 0..4 in block 1 -> slots 16..20.
+        # (The buggy num_computed_tokens-based code underflowed to -5 on the
+        # sync path and produced 21..25 on the async path; sourcing the chunk
+        # start from scheduler_output is correct for both.)
         np.testing.assert_array_equal(
             result.slot_mapping, np.array([16, 17, 18, 19, 20],
                                           dtype=np.int32))
@@ -126,3 +143,37 @@ class TestReconstructRoutedExperts:
         # transposed to (tokens, layers, top_k).
         np.testing.assert_array_equal(result.routing_data,
                                       expert_indices_cpu.transpose(1, 0, 2))
+
+    def test_cached_request_chunk_slots_use_pre_step_start(self):
+        # A cached/running request whose chunk starts at absolute position 20.
+        req_id = "reqC"
+        n = 1
+        block_size = 16
+        num_layers, top_k = 2, 4
+        req_state = _req(num_computed_tokens=99999, block_ids=[1, 2])
+        runner = SimpleNamespace(block_size=block_size,
+                                 dp_size=1,
+                                 requests={req_id: req_state})
+        scheduler_output = SimpleNamespace(
+            num_scheduled_tokens={req_id: n},
+            total_num_scheduled_tokens=n,
+            scheduled_new_reqs=[],
+            scheduled_cached_reqs=SimpleNamespace(req_ids=[req_id],
+                                                  num_computed_tokens=[20]),
+        )
+        expert_indices_cpu = np.arange(num_layers * n * top_k,
+                                       dtype=np.int32).reshape(
+                                           num_layers, n, top_k)
+
+        result = _reconstruct_routed_experts(
+            runner=runner,
+            scheduler_output=scheduler_output,
+            expert_indices_cpu=expert_indices_cpu,
+            req_ids=[req_id],
+            req_ids_dp={0: [req_id]},
+            padded_num_scheduled_tokens_per_dp_rank=n,
+        )
+
+        # Position 20 -> block_ids[20 // 16 = 1] = block 2 -> 2*16 + 20%16 = 36.
+        np.testing.assert_array_equal(result.slot_mapping,
+                                      np.array([36], dtype=np.int32))

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -367,20 +367,29 @@ def _reconstruct_slots_for_request(
     req_state: CachedRequestState,
     num_tokens: int,
     block_size: int,
+    start_pos: int,
 ) -> np.ndarray:
-    """Reconstructs physical slot mappings for a request using vectorized NumPy."""
-    # num_computed_tokens has already been advanced past this step's tokens by
-    # the time routed experts are reconstructed, so this step's tokens occupy
-    # absolute positions [num_computed_tokens - num_tokens, num_computed_tokens).
-    # Using num_computed_tokens directly shifts the slots forward by num_tokens,
-    # which misaligns with the scheduler-side slot read (RoutedExpertsManager.get,
-    # block-relative from position 0) and yields zero-filled routed experts for
-    # the prompt tokens.
-    start_pos = req_state.num_computed_tokens - num_tokens
-    block_ids = req_state.block_ids[0] if req_state.block_ids else []
+    """Reconstructs physical KV-cache slots for ``num_tokens`` tokens of a
+    request using vectorized NumPy.
 
+    ``start_pos`` is the absolute sequence position of the first of these
+    tokens and is supplied by the caller, because the two call sites have
+    different token contracts: the routed-experts reconstruction passes a
+    single scheduler chunk (whose tokens end at ``num_computed_tokens``, so it
+    passes ``num_computed_tokens - num_tokens``), while the continue_decode
+    path passes an on-device decode burst (not reflected in
+    ``num_computed_tokens``, so it passes ``num_computed_tokens``). The slots
+    must match the scheduler-side read (``RoutedExpertsManager.get``, which is
+    block-relative from position 0).
+    """
     if num_tokens <= 0:
         return np.array([], dtype=np.int32)
+
+    assert start_pos >= 0, (
+        f"[routed-experts] start_pos must be non-negative, got {start_pos} "
+        f"(num_tokens={num_tokens}); slots would be wrong via numpy negative "
+        f"indexing")
+    block_ids = req_state.block_ids[0] if req_state.block_ids else []
 
     pos = np.arange(start_pos, start_pos + num_tokens, dtype=np.int32)
     block_idx = pos // block_size
@@ -446,12 +455,20 @@ def _reconstruct_routed_experts(
                                                              dp_end,
                                                              dtype=np.int32)
 
-            # Reconstruct slots for this request using vectorized NumPy
+            # Reconstruct slots for this request using vectorized NumPy.
+            # num_computed_tokens has already been advanced past this chunk, so
+            # the chunk's tokens start at num_computed_tokens - n. Passing
+            # num_computed_tokens directly would shift slots forward by n and
+            # misalign with the scheduler-side block-relative read, yielding
+            # zero-filled routed experts for the prompt tokens.
             req_state = runner.requests[req_id]
             if n > 0:
                 global_slots[
                     global_start:global_end] = _reconstruct_slots_for_request(
-                        req_state, n, block_size)
+                        req_state,
+                        n,
+                        block_size,
+                        start_pos=req_state.num_computed_tokens - n)
 
     # 3. Perform global rank reordering and transpose in a single fancy indexing sweep!
     expert_indices_reordered = expert_indices_cpu[:, indices_map, :].transpose(
@@ -1485,10 +1502,16 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                 # Transpose to (layers, actual_len, top_k) and collect
                 expert_indices_list.append(req_experts.transpose(1, 0, 2))
 
-                # Reconstruct slots for this request
+                # Reconstruct slots for this request. The on-device decode
+                # burst length (actual_len) is decided on-device via EOS
+                # early-exit and is not reflected in num_computed_tokens, so the
+                # burst's tokens begin at num_computed_tokens.
                 if req_state is not None and actual_len > 0:
                     slots_arr = _reconstruct_slots_for_request(
-                        req_state, actual_len, self.block_size)
+                        req_state,
+                        actual_len,
+                        self.block_size,
+                        start_pos=req_state.num_computed_tokens)
                     expert_slots_list.append(slots_arr)
 
             if req_state is not None:

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -369,7 +369,14 @@ def _reconstruct_slots_for_request(
     block_size: int,
 ) -> np.ndarray:
     """Reconstructs physical slot mappings for a request using vectorized NumPy."""
-    start_pos = req_state.num_computed_tokens
+    # num_computed_tokens has already been advanced past this step's tokens by
+    # the time routed experts are reconstructed, so this step's tokens occupy
+    # absolute positions [num_computed_tokens - num_tokens, num_computed_tokens).
+    # Using num_computed_tokens directly shifts the slots forward by num_tokens,
+    # which misaligns with the scheduler-side slot read (RoutedExpertsManager.get,
+    # block-relative from position 0) and yields zero-filled routed experts for
+    # the prompt tokens.
+    start_pos = req_state.num_computed_tokens - num_tokens
     block_ids = req_state.block_ids[0] if req_state.block_ids else []
 
     if num_tokens <= 0:

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -422,6 +422,23 @@ def _reconstruct_routed_experts(
     total_active_tokens = scheduler_output.total_num_scheduled_tokens
     dp_size = runner.dp_size
 
+    # Absolute start position of each request's chunk = its PRE-step
+    # computed-token count, sourced from scheduler_output (not from
+    # req_state.num_computed_tokens). req_state.num_computed_tokens is advanced
+    # at different times across the two output paths that reach this function:
+    # it is already advanced past this step on the async get_output path, but is
+    # still the pre-step value on the sync _sample_from_logits path
+    # (async_scheduling=False, required by continue_decode). scheduler_output
+    # always carries the pre-step value, so it is correct for both; deriving
+    # start_pos as `num_computed_tokens - n` underflows to a negative value on a
+    # fresh prefill in the sync path.
+    chunk_start = {}
+    for new_req in scheduler_output.scheduled_new_reqs:
+        chunk_start[new_req.req_id] = new_req.num_computed_tokens
+    cached_reqs = scheduler_output.scheduled_cached_reqs
+    for i, rid in enumerate(cached_reqs.req_ids):
+        chunk_start[rid] = cached_reqs.num_computed_tokens[i]
+
     # 1. Compute global start offsets of every request in input batch order
     global_start_offsets = {}
     current_global_offset = 0
@@ -455,12 +472,10 @@ def _reconstruct_routed_experts(
                                                              dp_end,
                                                              dtype=np.int32)
 
-            # Reconstruct slots for this request using vectorized NumPy.
-            # num_computed_tokens has already been advanced past this chunk, so
-            # the chunk's tokens start at num_computed_tokens - n. Passing
-            # num_computed_tokens directly would shift slots forward by n and
-            # misalign with the scheduler-side block-relative read, yielding
-            # zero-filled routed experts for the prompt tokens.
+            # Reconstruct slots for this request using vectorized NumPy. Use the
+            # pre-step chunk start from scheduler_output (see chunk_start above);
+            # the slots must match the scheduler-side block-relative read
+            # (RoutedExpertsManager.get, from position 0).
             req_state = runner.requests[req_id]
             if n > 0:
                 global_slots[
@@ -468,7 +483,7 @@ def _reconstruct_routed_experts(
                         req_state,
                         n,
                         block_size,
-                        start_pos=req_state.num_computed_tokens - n)
+                        start_pos=chunk_start[req_id])
 
     # 3. Perform global rank reordering and transpose in a single fancy indexing sweep!
     expert_indices_reordered = expert_indices_cpu[:, indices_map, :].transpose(


### PR DESCRIPTION
## Summary

When MoE routed experts are returned (`enable_return_routed_experts=True`), per-token expert IDs are stored into the scheduler-side slot buffer (`RoutedExpertsManager`) keyed by physical KV-cache slot and read back block-relative from position 0. `_reconstruct_routed_experts` must place each request's tokens at their true absolute positions, i.e. the chunk's start = the request's **pre-step** `num_computed_tokens`.

It derived that start from `runner.requests[req_id].num_computed_tokens` — a per-request field that `update_states` **rewrites in place every step**. Reconstruction runs at a path-dependent time, so it read different values:

- **async path** (the default): reconstruction is deferred to `AsyncTPUModelRunnerOutput.get_output`, which runs *after* the next step's `update_states` has already advanced the field → it reads the **post-step** value. The prompt's experts were therefore stored `num_tokens` slots too far forward, and the scheduler read those slots back as zeros → **routed experts for prompt tokens came back zero-filled**.
- **sync path** reads the same field pre-step, so it was correct on main.

Root cause: deferred/async-reachable code read a **per-step-mutated field** (`runner.requests[...]`) instead of a per-step snapshot.

The bug was masked because the standalone and batched runs produced the same (wrong) prompt experts; it surfaced via `test_moe_expert_ids_batch_isolation` after the vLLM block-allocation change vllm-project/vllm#42656 changed the batched block layout and broke that symmetry.

## Fix

Source the chunk start from the per-step, immutable **`scheduler_output`** (`scheduled_new_reqs` / `scheduled_cached_reqs` `num_computed_tokens` — always the pre-step value) instead of the live `runner.requests` field. A fresh `scheduler_output` is created each step and never mutated, so it yields the correct start **regardless of when reconstruction runs** — making the async path (the reported bug) and the sync path agree. This follows the snapshot-don't-read-live-state pattern the rest of `AsyncTPUModelRunnerOutput` already uses (it captures `scheduler_output`, `next_tokens`, etc.). A non-negativity assert guards against a future regression producing silently-wrong slots.

Note: the sync path is required by `enable_continue_decode` (`async_scheduling=False`). A naive `num_computed_tokens - num_tokens` correction would fix async but underflow to a **negative** start on the sync path's first prefill (engine crash), so sourcing the pre-step value directly is what makes both paths correct at once.

For a 5-token prompt in block 1 (block_size 16), the slots are now `[16..20]` (positions 0–4) on both paths — matching the scheduler-side read — instead of `[21..25]` (async, zero-filled on read).

## Testing

- **Unit** (`tests/runner/test_routed_experts_slots.py`): `_reconstruct_slots_for_request` slot math (block-relative, multi-block, decode offset, empty, negative-start guard) and `_reconstruct_routed_experts` driven from `scheduler_output` for new-request and cached-request chunk starts (a sentinel `num_computed_tokens` asserts that field is no longer used). 7 passed.
- **TPU e2e** (`tests/runner/test_moe_expert_ids.py`): `test_moe_expert_ids_batch_isolation` (async) passes; new `test_moe_expert_ids_sync_path_prompt_populated` (`async_scheduling=False` + continue_decode) covers the sync path. 2 passed on tpu7x.
- **e2e** (`tests/e2e/test_continue_decode.py`): routed-experts value check against the single-step baseline, scoped to the deterministic prompt slice (avoids false-fails on generation divergence).
- Verified on tpu7x: the sync repro no longer crashes and returns populated prompt experts.
