### PR TITLE
[Multihost] Use native vLLM flag VLLM_USE_RAY_V2_EXECUTOR_BACKEND to enable ray executor v2

### DIFF
--- a/tests/platforms/test_tpu_platform.py
+++ b/tests/platforms/test_tpu_platform.py
@@ -242,8 +242,12 @@ class TestTpuPlatform:
         "tpu_inference.core.sched.dp_scheduler.update_vllm_config_for_dp_scheduler"
     )
     def test_check_and_update_config_ray(self, mock_update, mock_sharding,
-                                         vllm_config):
+                                         vllm_config, monkeypatch):
         vllm_config.cache_config = None
+        monkeypatch.setattr(
+            "tpu_inference.platforms.tpu_platform.vllm_envs.VLLM_USE_RAY_V2_EXECUTOR_BACKEND",
+            False,
+        )
 
         with patch.dict(
                 'sys.modules',
@@ -252,6 +256,31 @@ class TestTpuPlatform:
                 RayDistributedExecutor
             TpuPlatform.check_and_update_config(vllm_config)
             assert vllm_config.parallel_config.distributed_executor_backend == RayDistributedExecutor
+
+    @patch("tpu_inference.platforms.tpu_platform.envs.TPU_MULTIHOST_BACKEND",
+           "ray")
+    @patch("tpu_inference.platforms.tpu_platform.ShardingConfigManager")
+    @patch(
+        "tpu_inference.core.sched.dp_scheduler.update_vllm_config_for_dp_scheduler"
+    )
+    def test_check_and_update_config_ray_v2(self, mock_update, mock_sharding,
+                                            vllm_config, monkeypatch):
+        vllm_config.cache_config = None
+        monkeypatch.setattr(
+            "tpu_inference.platforms.tpu_platform.vllm_envs.VLLM_USE_RAY_V2_EXECUTOR_BACKEND",
+            True,
+        )
+
+        with patch.dict(
+                'sys.modules', {
+                    'tpu_inference.executors.ray_distributed_executor_v2':
+                    MagicMock(),
+                    'vllm.v1.executor.ray_executor_v2': MagicMock()
+                }):
+            from tpu_inference.executors.ray_distributed_executor_v2 import \
+                RayDistributedExecutorV2
+            TpuPlatform.check_and_update_config(vllm_config)
+            assert vllm_config.parallel_config.distributed_executor_backend == RayDistributedExecutorV2
 
     @patch("tpu_inference.platforms.tpu_platform.envs.TPU_MULTIHOST_BACKEND",
            "unknown_backend")

--- a/tpu_inference/platforms/tpu_platform.py
+++ b/tpu_inference/platforms/tpu_platform.py
@@ -328,8 +328,7 @@ class TpuPlatform(Platform):
                 parallel_config.distributed_executor_backend = MultiprocExecutor
         elif multihost_backend == "ray":
             # Check if we should use Ray Executor V2 (V1-multiproc compatible)
-            use_v2 = os.getenv("TPU_RAY_EXECUTOR_V2", "0") == "1"
-            if use_v2:
+            if vllm_envs.VLLM_USE_RAY_V2_EXECUTOR_BACKEND:
                 from tpu_inference.executors.ray_distributed_executor_v2 import \
                     RayDistributedExecutorV2
                 parallel_config.distributed_executor_backend = RayDistributedExecutorV2


### PR DESCRIPTION
# Description

By default, VLLM_USE_RAY_V2_EXECUTOR_BACKEND is True.


# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
