### PR TITLE
Switch to deepseek continue decode MMLU test

### DIFF
--- a/.buildkite/rl/rl_integration.yml
+++ b/.buildkite/rl/rl_integration.yml
@@ -70,7 +70,7 @@ steps:
     depends_on: "${TPU_VERSION:-tpu6e}_record_deepseek-ai_DeepSeek-R1_UnitTest"
     soft_fail: true
     agents:
-      queue: ${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}
+      queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
     env:
       NEW_MODEL_DESIGN: "1"
       USE_V6E8_QUEUE: "False"
@@ -89,3 +89,5 @@ steps:
         else
           .buildkite/scripts/run_in_docker.sh \
             bash /workspace/tpu_inference/tests/e2e/benchmarking/mmlu.sh -m  "gs://tpu-commons-ci/deepseek/r1" -n 14042 -l 4
+        fi
+

--- a/.buildkite/rl/rl_integration.yml
+++ b/.buildkite/rl/rl_integration.yml
@@ -65,17 +65,27 @@ steps:
       - |
         .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_rl_integration_PerformanceTest
 
-  - label: "${TPU_VERSION:-tpu6e} E2E MMLU for Llama-3.1-8B continue_decode"
+  - label: "${TPU_VERSION:-tpu6e} Accuracy for deepseek-ai/DeepSeek-R1 continue_decode"
     key: "${TPU_VERSION:-tpu6e}_rl_integration_continue_decode_mmlu"
+    depends_on: "${TPU_VERSION:-tpu6e}_record_deepseek-ai_DeepSeek-R1_UnitTest"
     soft_fail: true
-    env:
-      USE_PREBUILT_IMAGE: "1"
-      NEW_MODEL_DESIGN: "1"
-      SKIP_ACCURACY_TESTS: "False"
-      MODEL_IMPL_TYPE: "vllm"
-      TPU_VERSION: "${TPU_VERSION:-tpu6e}"
-      EXTRA_SERVE_ARGS: "--additional-config='{\"enable_continue_decode\": true}'"
     agents:
-      queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
+      queue: ${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}
+    env:
+      NEW_MODEL_DESIGN: "1"
+      USE_V6E8_QUEUE: "False"
+      TPU_VERSION: "tpu7x"
+      SKIP_ACCURACY_TESTS: "False"
+      VLLM_MLA_DISABLE: "0"
+      MOE_REQUANTIZE_BLOCK_SIZE: "512"
+      MOE_REQUANTIZE_WEIGHT_DTYPE: "fp4"
+      MODEL_IMPL_TYPE: "vllm"
+      MINIMUM_ACCURACY_THRESHOLD: "0.84"  # TODO : replace 0 with your accuracy threshold
+      EXTRA_SERVE_ARGS: "--additional-config='{\"enable_continue_decode\": true}'"
     commands:
-      - .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/mmlu.sh -m "meta-llama/Llama-3.1-8B-Instruct" -n 1000 -l 4
+      - |
+        if [ "${TPU_VERSION:-tpu6e}" = "tpu6e" ]; then
+          buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_deepseek-ai_DeepSeek-R1_Accuracy" "not enough HBM"
+        else
+          .buildkite/scripts/run_in_docker.sh \
+            bash /workspace/tpu_inference/tests/e2e/benchmarking/mmlu.sh -m  "gs://tpu-commons-ci/deepseek/r1" -n 14042 -l 4


### PR DESCRIPTION
# Description

Try switching to use Deepseek instead since it has a MMLU test configured so we can use as baseline https://github.com/vllm-project/tpu-inference/blob/867e5a06cc8b57765404bcd90487f856afc69b10/.buildkite/models/deepseek-ai_DeepSeek-R1.yml#L75

# Tests

https://buildkite.com/tpu-commons/tpu-inference-ci/builds/20946/canvas?sid=019efd37-63a9-4315-9969-35f05ab83def&tab=output

deflake https://buildkite.com/tpu-commons/tpu-inference-ci/builds/20998/canvas?sid=019efff5-a175-48c0-a323-7a7a13d54d64

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
