### PR TITLE
Remove jax.clear_caches() from assign_and_shard_param to avoid re-compilation and slow weight loading

### DIFF
--- a/tests/models/jax/test_qwen3_moe.py
+++ b/tests/models/jax/test_qwen3_moe.py
@@ -28,6 +28,8 @@ from tpu_inference.layers.common.attention_metadata import AttentionMetadata
 from tpu_inference.layers.jax.quantization import get_tpu_quantization_config
 from tpu_inference.models.jax.qwen3_moe import Qwen3MoeForCausalLM
 
+GBYTES = 1024 * 1024 * 1024
+
 
 class TestQwen3MoeForCausalLM:
 
@@ -90,7 +92,8 @@ class TestQwen3MoeForCausalLM:
                     model,
                     description=f"load_weights({model_name})",
                     threshold_multiplier=0.3,
-            ), set_current_vllm_config(vllm_config):
+                    min_threshold_bytes=3 *
+                    GBYTES), set_current_vllm_config(vllm_config):
                 loader.load_weights(model, model_config)
 
         layer_idx = model.model.start_layer

--- a/tpu_inference/models/jax/utils/weight_utils.py
+++ b/tpu_inference/models/jax/utils/weight_utils.py
@@ -788,7 +788,6 @@ def assign_and_shard_param(jax_param: nnx.Param,
         jax_param.set_value(shard_put(jax_weight, spec, mesh=param_mesh))
         jax_param.set_metadata("_is_loaded", True)
         del jax_weight
-        jax.clear_caches()
     except Exception as e:
         raise RuntimeError(
             f"Failed to load weight '{param_name}' with shape {shape} into param with shape {jax_param.get_value().shape}"
@@ -981,6 +980,7 @@ class JaxAutoWeightsLoader(AutoWeightsLoader):
                     yield name, weight
 
         autoloaded = super().load_weights(_route(weights), **kwargs)
+        jax.clear_caches()
         return autoloaded | routed_loaded
 
     def _add_loadable_non_param_tensors(self, module: JaxModule,


### PR DESCRIPTION
# Description

jax.clear_caches() clear all compilation and staging caches. This will trigger re-compilation and slow down weight loading process.


# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
