### PR TITLE
[CI] Fix nightly build failing on Record verified commit hashes

### DIFF
--- a/.buildkite/nightly_verify.yml
+++ b/.buildkite/nightly_verify.yml
@@ -93,8 +93,6 @@ steps:
      key: record_verified_commit_hashes
      depends_on:
        - notify_test_results
-       - tpu6e_tpu_test_notification
-       - tpu7x_tpu_test_notification
      agents:
        queue: cpu
      secrets:


### PR DESCRIPTION
This is to fix a nightly failure like:
https://buildkite.com/tpu-commons/tpu-inference-ci/builds/20734/canvas


The `record_verified_commit_hashes` step in nightly_verify.yml depended on `tpu6e_tpu_test_notification` and `tpu7x_tpu_test_notification`. Those step keys are defined only in pipeline_jax.yml, which is not part of the nightly build, so the dependency could never be satisfied. Buildkite left the step permanently in `waiting_failed` (missing dependency), which marked the whole nightly build as failed even though every test, benchmark, and support-matrix job passed.

Gate the step only on `notify_test_results`, which already transitively depends on the rest of the nightly chain.

