### PR TITLE
feat(dflash): Update JAX models and attention to support paged KV caching

### DIFF
--- a/tests/models/jax/test_dflash.py
+++ b/tests/models/jax/test_dflash.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Unit tests for the DFlash speculative decoding draft model on JAX/TPU."""
-
 from unittest.mock import patch
 
 import jax
@@ -23,9 +22,25 @@ from flax import nnx
 from jax.sharding import Mesh
 from transformers import Qwen3Config
 
+from tpu_inference.layers.common.attention_metadata import AttentionMetadata
 from tpu_inference.models.jax.dflash import (DFlashAttention,
                                              DFlashDecoderLayer,
                                              DFlashForCausalLM, DFlashMLP)
+
+
+def _make_attention_metadata(query_start_loc: list[int],
+                             total_tokens: int) -> AttentionMetadata:
+    """Helper to construct dummy AttentionMetadata."""
+    query_start_loc = np.asarray(query_start_loc, dtype=np.int32)
+    seq_lens = np.diff(query_start_loc)
+    return AttentionMetadata(
+        input_positions=jnp.arange(total_tokens, dtype=jnp.int32),
+        block_tables=jnp.zeros((max(1, total_tokens), ), dtype=jnp.int32),
+        seq_lens=jnp.asarray(seq_lens, dtype=jnp.int32),
+        query_start_loc=jnp.asarray(query_start_loc, dtype=jnp.int32),
+        request_distribution=jnp.asarray([0, 0, len(seq_lens)],
+                                         dtype=jnp.int32),
+    )
 
 
 @pytest.fixture(scope="module")
@@ -33,12 +48,10 @@ def mesh():
     """Creates a mesh with 1 device for testing."""
     if not jax.devices():
         pytest.skip("No JAX devices available for mesh creation.")
-
     devices = np.array(jax.local_devices()[:1])
     num_devices = len(devices)
     assert num_devices == 1
     device_mesh = devices.reshape((num_devices, 1, 1, 1))
-
     with Mesh(device_mesh,
               axis_names=('data', 'attn_dp', 'expert', 'model')) as m:
         yield m
@@ -64,8 +77,6 @@ def hf_config():
             "target_layer_ids": [0, 1],
         },
     )
-    # Explicitly set rope_theta and rope_scaling on the config object to satisfy
-    # direct attribute accesses in dflash.py.
     config.rope_theta = 10000.0
     config.rope_scaling = None
     return config
@@ -100,44 +111,47 @@ class MockVllmConfig:
 
         class MockModelConfig:
 
-            def __init__(self):
+            def __init__(self, hf_config):
+                self.hf_config = hf_config
                 self.seed = 42
                 self.model = "mock-model"
+
+            def get_vocab_size(self):
+                return self.hf_config.vocab_size
+
+            def get_hidden_size(self):
+                return self.hf_config.hidden_size
 
         class MockLoadConfig:
 
             def __init__(self):
                 self.download_dir = None
 
+        class MockParallelConfig:
+
+            def __init__(self):
+                self.tensor_parallel_size = 1
+
         self.speculative_config = MockSpeculativeConfig(hf_config)
-        self.model_config = MockModelConfig()
+        self.model_config = MockModelConfig(hf_config)
         self.load_config = MockLoadConfig()
+        self.parallel_config = MockParallelConfig()
 
 
-def dummy_flash_attention(
-    q,
-    k,
-    v,
-    segment_ids=None,
-    causal=False,
-    sm_scale=1.0,
-    block_sizes=None,
-    vmem_limit_bytes=None,
-):
-    """Dummy replacement for flash_attention to allow CPU-only unit testing."""
-    del k, v, segment_ids, causal, sm_scale, block_sizes, vmem_limit_bytes
-    return jnp.zeros_like(q)
+def dummy_attention(kv_cache, q, k, v, *args, **kwargs):
+    """Dummy replacement for attention to allow CPU-only unit testing."""
+    del k, v, args, kwargs
+    return kv_cache, q
 
 
 @patch(
-    "tpu_inference.models.jax.dflash.flash_attention",
-    side_effect=dummy_flash_attention,
+    "tpu_inference.models.jax.dflash.attention",
+    side_effect=dummy_attention,
 )
-def test_dflash_attention(mock_fa, hf_config, mesh):
+def test_dflash_attention(mock_attn, hf_config, mesh):
     """Verifies that DFlashAttention runs correctly and writes to the KV cache."""
     rng = nnx.Rngs(42)
     dtype = jnp.bfloat16
-
     with jax.set_mesh(mesh):
         attn = DFlashAttention(
             config=hf_config,
@@ -145,65 +159,51 @@ def test_dflash_attention(mock_fa, hf_config, mesh):
             rng=rng,
             mesh=mesh,
         )
-
     T_noise = 4
     T_padded = 8
     hidden_size = hf_config.hidden_size
-    num_heads = attn.num_heads
-    head_dim = attn.head_dim
-    max_kv_len = 32
-
     x_noise = jnp.ones((T_noise, hidden_size), dtype=dtype)
     target_hidden = jnp.ones((T_padded, hidden_size), dtype=dtype)
-    noise_positions = jnp.arange(T_noise, dtype=jnp.int32)
-    ctx_positions = jnp.arange(T_padded, dtype=jnp.int32)
-    kv_cache_k = jnp.zeros((1, num_heads, max_kv_len, head_dim), dtype=dtype)
-    kv_cache_v = jnp.zeros((1, num_heads, max_kv_len, head_dim), dtype=dtype)
-    cache_len = jnp.array(0, dtype=jnp.int32)
-    actual_ctx_count = jnp.array(6, dtype=jnp.int32)
-
+    target_query_start_loc = jnp.array([0, T_padded], dtype=jnp.int32)
+    target_positions = jnp.arange(T_padded, dtype=jnp.int32)
+    # Mock attention metadata
+    attention_metadata = _make_attention_metadata([0, T_noise], T_noise)
+    # kv_cache shape: [total_num_pages, page_size, num_kv_heads_x2 // kv_packing, kv_packing, head_dim]
+    kv_cache = jnp.zeros((10, 16, 4, 1, attn.head_dim), dtype=dtype)
     with jax.set_mesh(mesh):
-        output, new_k, new_v = attn(
+        output, new_kv_cache = attn(
             x_noise=x_noise,
             target_hidden=target_hidden,
-            noise_positions=noise_positions,
-            ctx_positions=ctx_positions,
-            kv_cache_k=kv_cache_k,
-            kv_cache_v=kv_cache_v,
-            cache_len=cache_len,
-            actual_ctx_count=actual_ctx_count,
+            attention_metadata=attention_metadata,
+            target_query_start_loc=target_query_start_loc,
+            target_positions=target_positions,
+            kv_cache=kv_cache,
         )
-
     assert output.shape == (T_noise, hidden_size)
-    assert new_k.shape == (1, num_heads, max_kv_len, head_dim)
-    assert new_v.shape == (1, num_heads, max_kv_len, head_dim)
-    mock_fa.assert_called_once()
+    assert new_kv_cache.shape == kv_cache.shape
+    assert mock_attn.call_count == 2  # Step 1 (target) and Step 2 (noise)
 
 
 def test_dflash_mlp(hf_config, mesh):
     """Tests the DFlashMLP layer's output shape and forward pass."""
     rng = nnx.Rngs(42)
     dtype = jnp.bfloat16
-
     with jax.set_mesh(mesh):
         mlp = DFlashMLP(config=hf_config, dtype=dtype, rng=rng)
-
         T = 5
         x = jnp.ones((T, hf_config.hidden_size), dtype=dtype)
         output = mlp(x)
-
     assert output.shape == (T, hf_config.hidden_size)
 
 
 @patch(
-    "tpu_inference.models.jax.dflash.flash_attention",
-    side_effect=dummy_flash_attention,
+    "tpu_inference.models.jax.dflash.attention",
+    side_effect=dummy_attention,
 )
-def test_dflash_decoder_layer(mock_fa, hf_config, mesh):
+def test_dflash_decoder_layer(mock_attn, hf_config, mesh):
     """Verifies that the DFlashDecoderLayer forward pass completes successfully."""
     rng = nnx.Rngs(42)
     dtype = jnp.bfloat16
-
     with jax.set_mesh(mesh):
         layer = DFlashDecoderLayer(
             config=hf_config,
@@ -211,100 +211,77 @@ def test_dflash_decoder_layer(mock_fa, hf_config, mesh):
             rng=rng,
             mesh=mesh,
         )
-
     T_noise = 4
     T_padded = 8
     hidden_size = hf_config.hidden_size
-    num_heads = layer.self_attn.num_heads
-    head_dim = layer.self_attn.head_dim
-    max_kv_len = 32
-
     x_noise = jnp.ones((T_noise, hidden_size), dtype=dtype)
     target_hidden = jnp.ones((T_padded, hidden_size), dtype=dtype)
-    noise_positions = jnp.arange(T_noise, dtype=jnp.int32)
-    ctx_positions = jnp.arange(T_padded, dtype=jnp.int32)
-    kv_cache_k = jnp.zeros((1, num_heads, max_kv_len, head_dim), dtype=dtype)
-    kv_cache_v = jnp.zeros((1, num_heads, max_kv_len, head_dim), dtype=dtype)
-    cache_len = jnp.array(0, dtype=jnp.int32)
-    actual_ctx_count = jnp.array(6, dtype=jnp.int32)
-
+    target_query_start_loc = jnp.array([0, T_padded], dtype=jnp.int32)
+    target_positions = jnp.arange(T_padded, dtype=jnp.int32)
+    attention_metadata = _make_attention_metadata([0, T_noise], T_noise)
+    kv_cache = jnp.zeros((10, 16, 4, 1, layer.self_attn.head_dim), dtype=dtype)
     with jax.set_mesh(mesh):
-        output, new_k, new_v = layer(
+        output, new_kv_cache = layer(
             x=x_noise,
             target_hidden=target_hidden,
-            noise_positions=noise_positions,
-            ctx_positions=ctx_positions,
-            kv_cache_k=kv_cache_k,
-            kv_cache_v=kv_cache_v,
-            cache_len=cache_len,
-            actual_ctx_count=actual_ctx_count,
+            attention_metadata=attention_metadata,
+            target_query_start_loc=target_query_start_loc,
+            target_positions=target_positions,
+            kv_cache=kv_cache,
         )
-
     assert output.shape == (T_noise, hidden_size)
-    assert new_k.shape == (1, num_heads, max_kv_len, head_dim)
-    assert new_v.shape == (1, num_heads, max_kv_len, head_dim)
-    mock_fa.assert_called_once()
+    assert new_kv_cache.shape == kv_cache.shape
+    assert mock_attn.call_count == 2
 
 
 @patch(
-    "tpu_inference.models.jax.dflash.flash_attention",
-    side_effect=dummy_flash_attention,
+    "tpu_inference.models.jax.dflash.attention",
+    side_effect=dummy_attention,
 )
-def test_dflash_for_causal_lm(mock_fa, hf_config, mesh):
+def test_dflash_for_causal_lm(mock_attn, hf_config, mesh):
     """Validates the full draft model's forward pass, logits calculation, and state projection."""
     vllm_config = MockVllmConfig(hf_config)
     rng_key = jax.random.PRNGKey(0)
-
     with jax.set_mesh(mesh):
         model = DFlashForCausalLM(
             vllm_config=vllm_config,
             rng_key=rng_key,
             mesh=mesh,
         )
-
-    # Check structure
     assert model.model.embed_tokens.embedding.shape == (
         hf_config.vocab_size,
         hf_config.hidden_size,
     )
     assert len(model.model.layers) == hf_config.num_hidden_layers
-
-    # Run forward pass
     T_noise = 3
     T_padded = 6
     hidden_size = hf_config.hidden_size
-    num_heads = model.model.layers[0].self_attn.num_heads
     head_dim = model.model.layers[0].self_attn.head_dim
-    max_kv_len = 16
-
     input_ids = jnp.ones((T_noise, ), dtype=jnp.int32)
     ctx_hidden = jnp.ones((T_padded, hidden_size), dtype=jnp.bfloat16)
-    cache_len_arr = jnp.array([2], dtype=jnp.int32)
-    actual_ctx_count_arr = jnp.array([4], dtype=jnp.int32)
-
-    target_hidden_states = (ctx_hidden, cache_len_arr, actual_ctx_count_arr)
-
+    target_query_start_loc = jnp.array([0, T_padded], dtype=jnp.int32)
+    target_positions = jnp.arange(T_padded, dtype=jnp.int32)
+    target_hidden_states = (ctx_hidden, target_query_start_loc,
+                            target_positions)
+    attention_metadata = _make_attention_metadata([0, T_noise], T_noise)
+    # List of kv_cache tensors, one per layer
     kv_caches = [
-        jnp.zeros((1, num_heads, max_kv_len, head_dim), dtype=jnp.bfloat16)
-        for _ in range(2 * hf_config.num_hidden_layers)
+        jnp.zeros((10, 16, 4, 1, head_dim), dtype=jnp.bfloat16)
+        for _ in range(hf_config.num_hidden_layers)
     ]
-
     with jax.set_mesh(mesh):
-        new_kv_caches, hidden_states, extra = model(
+        new_kv_caches, hidden_states, extra, _ = model(
             kv_caches=kv_caches,
             input_ids=input_ids,
             target_hidden_states=target_hidden_states,
-            attention_metadata=None,
+            attention_metadata=attention_metadata,
         )
-
-    assert len(new_kv_caches) == 2 * hf_config.num_hidden_layers
+    assert len(new_kv_caches) == hf_config.num_hidden_layers
     assert hidden_states.shape == (T_noise, hidden_size)
     assert extra == []
-
     # Test compute_logits
     logits = model.compute_logits(hidden_states)
     assert logits.shape == (T_noise, hf_config.vocab_size)
-
     # Test combine_hidden_states
     combined_input = jnp.ones(
         (
@@ -322,14 +299,12 @@ def test_dflash_weight_loader(hf_config, mesh):
     """Verifies that the DFlashWeightLoader maps and delegates weight loading correctly."""
     vllm_config = MockVllmConfig(hf_config)
     rng_key = jax.random.PRNGKey(0)
-
     with jax.set_mesh(mesh):
         model = DFlashForCausalLM(
             vllm_config=vllm_config,
             rng_key=rng_key,
             mesh=mesh,
         )
-
     with patch(
             "tpu_inference.models.jax.dflash.load_hf_weights"
     ) as mock_load_hf, patch(
@@ -339,8 +314,6 @@ def test_dflash_weight_loader(hf_config, mesh):
             model.load_weights(rng_key)
         mock_load_hf.assert_called_once()
         mock_generator.assert_called_once()
-
-        # Verify loader config propagation
         called_args, called_kwargs = mock_load_hf.call_args
         assert called_kwargs["vllm_config"] == vllm_config
         assert called_kwargs["model"] == model

--- a/tests/models/jax/test_qwen3_dflash.py
+++ b/tests/models/jax/test_qwen3_dflash.py
@@ -174,12 +174,6 @@ def dummy_attention(kv_cache, q, k, v, *args, **kwargs):
     return kv_cache, q
 
 
-def dummy_dflash_concat_attention(q, *args, **kwargs):
-    """Dummy replacement for dflash_concat_attention."""
-    del args, kwargs
-    return q
-
-
 def _make_attention_metadata(query_start_loc: list[int]) -> AttentionMetadata:
     """Helper to construct dummy AttentionMetadata."""
     query_start_loc = np.asarray(query_start_loc, dtype=np.int32)
@@ -198,15 +192,10 @@ def _make_attention_metadata(query_start_loc: list[int]) -> AttentionMetadata:
 # ----- Component tests -----
 @pytest.mark.parametrize("dflash_impl", ["concat_dense", "additive_legacy"])
 @patch(
-    "tpu_inference.models.jax.qwen3_dflash.dflash_concat_attention",
-    side_effect=dummy_dflash_concat_attention,
-)
-@patch(
     "tpu_inference.models.jax.qwen3_dflash.attention",
     side_effect=dummy_attention,
 )
-def test_qwen3_dflash_attention(mock_attn, mock_concat, dflash_impl,
-                                hf_configs, mesh):
+def test_qwen3_dflash_attention(mock_attn, dflash_impl, hf_configs, mesh):
     """Verifies Qwen3DFlashAttention forward pass under different attention implementations."""
     draft_cfg, _ = hf_configs
     rng = nnx.Rngs(42)
@@ -241,28 +230,24 @@ def test_qwen3_dflash_attention(mock_attn, mock_concat, dflash_impl,
             hidden_states=hidden_states,
             target_hidden_states=target_hidden,
             attention_metadata=attention_metadata,
+            target_query_start_loc=attention_metadata.query_start_loc,
+            target_positions=attention_metadata.input_positions,
         )
 
     assert output.shape == (T, hidden_size)
     assert new_kv_cache.shape == (T, num_heads, max_kv_len, head_dim)
 
     if dflash_impl == "concat_dense":
-        mock_concat.assert_called_once()
-        mock_attn.assert_called_once()
+        assert mock_attn.call_count == 2
     else:
-        mock_concat.assert_not_called()
-        mock_attn.assert_called_once()
+        assert mock_attn.call_count == 1
 
 
-@patch(
-    "tpu_inference.models.jax.qwen3_dflash.dflash_concat_attention",
-    side_effect=dummy_dflash_concat_attention,
-)
 @patch(
     "tpu_inference.models.jax.qwen3_dflash.attention",
     side_effect=dummy_attention,
 )
-def test_qwen3_dflash_decoder_layer(mock_attn, mock_concat, hf_configs, mesh):
+def test_qwen3_dflash_decoder_layer(mock_attn, hf_configs, mesh):
     """Verifies Qwen3DFlashDecoderLayer integrates attention and MLP blocks."""
     draft_cfg, _ = hf_configs
     rng = nnx.Rngs(42)
@@ -292,26 +277,25 @@ def test_qwen3_dflash_decoder_layer(mock_attn, mock_concat, hf_configs, mesh):
     attention_metadata = _make_attention_metadata([0, T])
 
     with jax.set_mesh(mesh):
-        new_kv_cache, output = layer(
+        new_kv_cache, output, extra = layer(
             kv_cache=kv_cache,
             hidden_states=hidden_states,
             target_hidden_states=target_hidden,
             attention_metadata=attention_metadata,
+            target_query_start_loc=attention_metadata.query_start_loc,
+            target_positions=attention_metadata.input_positions,
         )
 
     assert output.shape == (T, hidden_size)
     assert new_kv_cache.shape == (T, num_heads, max_kv_len, head_dim)
+    assert mock_attn.call_count == 2
 
 
-@patch(
-    "tpu_inference.models.jax.qwen3_dflash.dflash_concat_attention",
-    side_effect=dummy_dflash_concat_attention,
-)
 @patch(
     "tpu_inference.models.jax.qwen3_dflash.attention",
     side_effect=dummy_attention,
 )
-def test_qwen3_dflash_for_causal_lm(mock_attn, mock_concat, hf_configs, mesh):
+def test_qwen3_dflash_for_causal_lm(mock_attn, hf_configs, mesh):
     """Validates full draft model's forward pass, logits calculation, and combined projection."""
     draft_cfg, target_cfg = hf_configs
     vllm_config = MockVllmConfig(draft_cfg, target_cfg)
@@ -348,17 +332,20 @@ def test_qwen3_dflash_for_causal_lm(mock_attn, mock_concat, hf_configs, mesh):
     ]
 
     with jax.set_mesh(mesh):
-        new_kv_caches, hidden_states, extra = model(
+        new_kv_caches, hidden_states, extra, _ = model(
             kv_caches=kv_caches,
             input_ids=input_ids,
             target_hidden_states=target_hidden,
             attention_metadata=attention_metadata,
+            target_query_start_loc=attention_metadata.query_start_loc,
+            target_positions=attention_metadata.input_positions,
         )
 
     assert len(new_kv_caches) == draft_cfg.num_hidden_layers
     assert hidden_states.shape == (T, hidden_size)
-    assert len(extra) == 1
+    assert len(extra) == 2
     assert extra[0].shape == (T, hidden_size)
+    assert mock_attn.call_count == 4
 
     # Test compute_logits
     logits = model.compute_logits(hidden_states)

--- a/tests/models/jax/test_qwen3_dflash_attention.py
+++ b/tests/models/jax/test_qwen3_dflash_attention.py
@@ -62,6 +62,8 @@ def _build_stub_attention(impl: str) -> Qwen3DFlashAttention:
     _set("v_proj", lambda x: x)
     _set("o_proj", lambda x: x)
     _set("head_dim_original", 1)
+    _set("head_dim", 1)
+    _set("num_heads", 1)
     _set("rope_theta", 10000.0)
     _set("rope_scaling", None)
     _set("mesh", object())
@@ -89,6 +91,7 @@ def test_dflash_concat_attention_matches_concat_reference():
         v_ctx,
         v_noise,
         md,
+        md.query_start_loc,
         max_query_len=2,
         sm_scale=sm_scale,
     )
@@ -129,6 +132,7 @@ def test_dflash_concat_attention_repeats_kv_heads_for_gqa():
         v_ctx,
         v_noise,
         md,
+        md.query_start_loc,
         max_query_len=2,
         sm_scale=1.0,
     )
@@ -156,28 +160,7 @@ def test_qwen3_dflash_attention_concat_impl(monkeypatch):
     target_hidden_states = jnp.array([[[3.0]], [[4.0]]], dtype=jnp.float32)
     kv_cache = jnp.array([0.0], dtype=jnp.float32)
 
-    concat_calls = {}
-    cache_update_calls = {}
-
-    def fake_concat_attention(
-        q,
-        k_ctx,
-        k_noise,
-        v_ctx,
-        v_noise,
-        _md,
-        *,
-        max_query_len,
-        sm_scale,
-    ):
-        concat_calls["q"] = np.asarray(q)
-        concat_calls["k_ctx"] = np.asarray(k_ctx)
-        concat_calls["k_noise"] = np.asarray(k_noise)
-        concat_calls["v_ctx"] = np.asarray(v_ctx)
-        concat_calls["v_noise"] = np.asarray(v_noise)
-        concat_calls["max_query_len"] = max_query_len
-        concat_calls["sm_scale"] = sm_scale
-        return jnp.full_like(q, 7.0)
+    attention_calls = []
 
     def fake_attention(
         kv_cache,
@@ -189,16 +172,25 @@ def test_qwen3_dflash_attention_concat_impl(monkeypatch):
         _head_dim_original,
         **_kwargs,
     ):
-        cache_update_calls["q"] = np.asarray(q)
-        cache_update_calls["k"] = np.asarray(k)
-        cache_update_calls["v"] = np.asarray(v)
-        return kv_cache + 1.0, jnp.full_like(q, -5.0)
+        attention_calls.append({
+            "q":
+            np.asarray(q),
+            "k":
+            np.asarray(k),
+            "v":
+            np.asarray(v),
+            "update_kv_cache":
+            _kwargs.get("update_kv_cache", True),
+            "use_causal_mask":
+            _kwargs.get("use_causal_mask", True),
+        })
+        if len(attention_calls) == 1:
+            return kv_cache + 1.0, jnp.full_like(q, -5.0)
+        else:
+            return kv_cache + 2.0, jnp.full_like(q, 7.0)
 
     monkeypatch.setattr("tpu_inference.models.jax.qwen3_dflash.apply_rope",
                         lambda x, *_args, **_kwargs: x)
-    monkeypatch.setattr(
-        "tpu_inference.models.jax.qwen3_dflash.dflash_concat_attention",
-        fake_concat_attention)
     monkeypatch.setattr("tpu_inference.models.jax.qwen3_dflash.attention",
                         fake_attention)
 
@@ -208,19 +200,33 @@ def test_qwen3_dflash_attention_concat_impl(monkeypatch):
         hidden_states=hidden_states,
         target_hidden_states=target_hidden_states,
         attention_metadata=md,
+        target_query_start_loc=md.query_start_loc,
+        target_positions=jnp.array([1, 2], dtype=jnp.int32),
     )
 
     np.testing.assert_allclose(np.asarray(output), np.full((2, 1, 1), 7.0))
-    np.testing.assert_allclose(np.asarray(new_kv_cache), np.array([1.0]))
-    np.testing.assert_allclose(concat_calls["k_ctx"],
+    np.testing.assert_allclose(np.asarray(new_kv_cache), np.array([3.0]))
+    assert len(attention_calls) == 2
+
+    # Step 1 Target write assertions
+    np.testing.assert_allclose(attention_calls[0]["q"],
+                               np.zeros_like(hidden_states))
+    np.testing.assert_allclose(attention_calls[0]["k"],
                                np.asarray(target_hidden_states))
-    np.testing.assert_allclose(concat_calls["k_noise"],
+    np.testing.assert_allclose(attention_calls[0]["v"],
+                               np.asarray(target_hidden_states))
+    assert attention_calls[0]["update_kv_cache"] is True
+    assert attention_calls[0]["use_causal_mask"] is True
+
+    # Step 2 Noise attention assertions
+    np.testing.assert_allclose(attention_calls[1]["q"],
                                np.asarray(hidden_states))
-    np.testing.assert_allclose(cache_update_calls["k"],
+    np.testing.assert_allclose(attention_calls[1]["k"],
                                np.asarray(hidden_states))
-    np.testing.assert_allclose(cache_update_calls["v"],
+    np.testing.assert_allclose(attention_calls[1]["v"],
                                np.asarray(hidden_states))
-    assert concat_calls["max_query_len"] == 2
+    assert attention_calls[1]["update_kv_cache"] is True
+    assert attention_calls[1]["use_causal_mask"] is False
 
 
 def test_qwen3_dflash_attention_additive_legacy_impl(monkeypatch):
@@ -251,9 +257,6 @@ def test_qwen3_dflash_attention_additive_legacy_impl(monkeypatch):
 
     monkeypatch.setattr("tpu_inference.models.jax.qwen3_dflash.apply_rope",
                         lambda x, *_args, **_kwargs: x)
-    monkeypatch.setattr(
-        "tpu_inference.models.jax.qwen3_dflash.dflash_concat_attention",
-        fail_concat)
     monkeypatch.setattr("tpu_inference.models.jax.qwen3_dflash.attention",
                         fake_attention)
 
@@ -263,6 +266,8 @@ def test_qwen3_dflash_attention_additive_legacy_impl(monkeypatch):
         hidden_states=hidden_states,
         target_hidden_states=target_hidden_states,
         attention_metadata=md,
+        target_query_start_loc=md.query_start_loc,
+        target_positions=jnp.array([1, 2], dtype=jnp.int32),
     )
 
     expected_k = np.asarray(target_hidden_states + hidden_states)
@@ -288,4 +293,6 @@ def test_qwen3_dflash_attention_unknown_impl_raises(monkeypatch):
             hidden_states=hidden_states,
             target_hidden_states=target_hidden_states,
             attention_metadata=md,
+            target_query_start_loc=md.query_start_loc,
+            target_positions=jnp.array([1, 2], dtype=jnp.int32),
         )

--- a/tpu_inference/layers/common/attention_interface.py
+++ b/tpu_inference/layers/common/attention_interface.py
@@ -346,6 +346,7 @@ def sharded_ragged_paged_attention(
     k_scale: float | None = None,
     v_scale: float | None = None,
     update_kv_cache: bool = True,
+    use_causal_mask: bool = True,
 ):
     """Shards along KV heads."""
     # Handle GQA/MQA where num_kv_heads < tp_size
@@ -412,6 +413,7 @@ def sharded_ragged_paged_attention(
         # is a no-op so we don't forward it to the hd64 signature.
         if not use_hd64:
             kwargs["update_kv_cache"] = update_kv_cache
+            kwargs["use_causal_mask"] = use_causal_mask
         return func(*args, **kwargs)
 
     return jax.shard_map(
@@ -438,6 +440,7 @@ def attention(
     v_scale: float | None = None,
     sinks: jax.Array | None = None,
     update_kv_cache: bool = True,
+    use_causal_mask: bool = True,
 ) -> Tuple[jax.Array, jax.Array]:
     # T: seq_len
     # N: num_heads
@@ -477,6 +480,7 @@ def attention(
         k_scale=k_scale,
         v_scale=v_scale,
         update_kv_cache=update_kv_cache,
+        use_causal_mask=use_causal_mask,
     )
 
     return kv_cache, output

--- a/tpu_inference/layers/common/dflash_attention_interface.py
+++ b/tpu_inference/layers/common/dflash_attention_interface.py
@@ -32,6 +32,7 @@ def dflash_concat_attention(
     v_ctx: jax.Array,  # [T, K, H]
     v_noise: jax.Array,  # [T, K, H]
     attention_metadata: AttentionMetadata,
+    target_query_start_loc: jax.Array,
     *,
     max_query_len: int,
     sm_scale: float,
@@ -43,10 +44,13 @@ def dflash_concat_attention(
     """
     if max_query_len <= 0:
         raise ValueError(f"{max_query_len=} must be positive.")
-    if not (q.shape[0] == k_ctx.shape[0] == k_noise.shape[0] == v_ctx.shape[0]
-            == v_noise.shape[0]):
+    if not (q.shape[0] == k_noise.shape[0] == v_noise.shape[0]):
         raise ValueError(
-            "All DFlash attention streams must share the same token count.")
+            "Noise DFlash attention streams must share the same token count.")
+    if not (k_ctx.shape[0] == v_ctx.shape[0]):
+        raise ValueError(
+            "Context DFlash attention streams must share the same token count."
+        )
 
     num_tokens, num_heads, _ = q.shape
     num_kv_heads = k_ctx.shape[1]
@@ -94,9 +98,13 @@ def dflash_concat_attention(
         req_len = req_lens[i]
         req_len = jnp.clip(req_len, 0, max_query_len)
 
+        ctx_start = target_query_start_loc[i]
+        ctx_req_len = target_query_start_loc[i + 1] - target_query_start_loc[i]
+        ctx_req_len = jnp.clip(ctx_req_len, 0, max_query_len)
+
         q_blk = lax.dynamic_slice_in_dim(q, start, max_query_len, axis=0)
         k_ctx_blk = lax.dynamic_slice_in_dim(k_ctx,
-                                             start,
+                                             ctx_start,
                                              max_query_len,
                                              axis=0)
         k_noise_blk = lax.dynamic_slice_in_dim(k_noise,
@@ -104,7 +112,7 @@ def dflash_concat_attention(
                                                max_query_len,
                                                axis=0)
         v_ctx_blk = lax.dynamic_slice_in_dim(v_ctx,
-                                             start,
+                                             ctx_start,
                                              max_query_len,
                                              axis=0)
         v_noise_blk = lax.dynamic_slice_in_dim(v_noise,
@@ -118,8 +126,11 @@ def dflash_concat_attention(
 
         # Mask out padding positions for both Q and KV.
         q_valid = arange_q < req_len
-        kv_valid_len = jnp.maximum(2 * req_len, 1)
-        kv_valid = arange_kv < kv_valid_len
+        # Valid KV tokens: ctx_req_len context tokens + req_len noise tokens
+        # The first max_query_len tokens are context, the next max_query_len are noise.
+        kv_valid = (arange_kv
+                    < ctx_req_len) | ((arange_kv >= max_query_len) &
+                                      (arange_kv < max_query_len + req_len))
 
         logits = jnp.einsum("qnh,knh->nqk", q_blk.astype(jnp.float32),
                             k_blk.astype(jnp.float32))

--- a/tpu_inference/models/common/model_loader.py
+++ b/tpu_inference/models/common/model_loader.py
@@ -71,6 +71,7 @@ def _get_model_architecture(config: PretrainedConfig) -> nnx.Module:
     # would cause JAX init failure when using multi hosts with Ray.
 
     from tpu_inference.models.jax.deepseek_v3 import DeepseekV3ForCausalLM
+    from tpu_inference.models.jax.dflash import DFlashForCausalLM
     from tpu_inference.models.jax.gemma4_mm import \
         Gemma4ForConditionalGeneration
     from tpu_inference.models.jax.gemma4_mtp import Gemma4MTPForCausalLM
@@ -98,6 +99,7 @@ def _get_model_architecture(config: PretrainedConfig) -> nnx.Module:
     _MODEL_REGISTRY[
         "Gemma4ForConditionalGeneration"] = Gemma4ForConditionalGeneration
     _MODEL_REGISTRY["Gemma4MTPModel"] = Gemma4MTPForCausalLM
+    _MODEL_REGISTRY["DFlashForCausalLM"] = DFlashForCausalLM
 
     architectures = getattr(config, "architectures", [])
     for arch in architectures:

--- a/tpu_inference/models/jax/dflash.py
+++ b/tpu_inference/models/jax/dflash.py
@@ -13,21 +13,21 @@
 # limitations under the License.
 """DFlash draft model for speculative decoding on JAX/TPU."""
 
-from typing import List, Tuple
+from dataclasses import replace
+from typing import Any, List, Optional, Tuple
 
 import jax
 import jax.numpy as jnp
 from flax import nnx
-from jax import lax
 from jax.sharding import Mesh
 from transformers import Qwen3Config
 from vllm.config import VllmConfig
 
 from tpu_inference import utils
-from tpu_inference.kernels.flash_attention.kernel import (BlockSizes,
-                                                          SegmentIds,
-                                                          flash_attention)
+from tpu_inference.layers.common.attention_interface import attention
 from tpu_inference.layers.common.sharding import ShardingAxisName
+from tpu_inference.layers.jax.linear import JaxLmHead
+from tpu_inference.layers.jax.pp_utils import PPMissingLayer
 from tpu_inference.layers.jax.rope_interface import apply_rope
 from tpu_inference.logger import init_logger
 from tpu_inference.models.jax.utils.weight_utils import (BaseWeightLoader,
@@ -65,9 +65,9 @@ class DFlashAttention(nnx.Module):
         self.hidden_size = config.hidden_size
         self.num_heads = config.num_attention_heads
         self.num_kv_heads = config.num_key_value_heads
-        self.rope_theta = config.rope_theta
+        self.rope_theta = getattr(config, "rope_theta", 1000000.0)
         self.rope_scaling = getattr(config, "rope_scaling", None)
-        self.rms_norm_eps = config.rms_norm_eps
+        self.rms_norm_eps = getattr(config, "rms_norm_eps", 1e-6)
 
         self.head_dim_original = getattr(config, "head_dim",
                                          self.hidden_size // self.num_heads)
@@ -135,123 +135,77 @@ class DFlashAttention(nnx.Module):
         self,
         x_noise: jax.Array,
         target_hidden: jax.Array,
-        noise_positions: jax.Array,
-        ctx_positions: jax.Array,
-        kv_cache_k: jax.Array,
-        kv_cache_v: jax.Array,
-        cache_len: jax.Array,
-        actual_ctx_count: jax.Array,
-    ) -> Tuple[jax.Array, jax.Array, jax.Array]:
-        """Non-causal attention with on-device KV cache.
-
-        Uses a two-phase cache write to handle padded context correctly:
-          Phase A: write context K/V (with padding zeroed) at ``cache_len``.
-          Phase B: write noise K/V at ``cache_len + actual_ctx_count``,
-                   overwriting any padding zeros from Phase A.
-
-        Args:
-            x_noise: (T_noise, D) noise hidden states.
-            target_hidden: (T_padded, D) padded context features.
-            noise_positions: (T_noise,) position ids for noise tokens.
-            ctx_positions: (T_padded,) position ids for context tokens.
-            kv_cache_k: (1, N_heads, max_kv_len, H) pre-allocated K cache.
-            kv_cache_v: (1, N_heads, max_kv_len, H) pre-allocated V cache.
-            cache_len: scalar int, valid entries already in cache.
-            actual_ctx_count: scalar int, real (non-padding) context tokens.
-
-        Returns:
-            (output, new_kv_cache_k, new_kv_cache_v)
-        """
+        attention_metadata: Any,
+        target_query_start_loc: jax.Array,
+        target_positions: jax.Array,
+        kv_cache: jax.Array,
+    ) -> Tuple[jax.Array, jax.Array]:
+        """Non-causal attention with on-device paged KV cache."""
+        md = attention_metadata
         T_noise = x_noise.shape[0]
-        T_padded = target_hidden.shape[0]
+        T_target = target_hidden.shape[0]
 
-        q = self.q_proj(x_noise)
-        q = self.q_norm(q)
-        q = apply_rope(
-            q,
-            noise_positions,
-            self.head_dim_original,
-            self.rope_theta,
-            self.rope_scaling,
+        q_noise = self.q_norm(self.q_proj(x_noise))
+        k_noise = self.k_norm(self.k_proj(x_noise))
+        v_noise = self.v_proj(x_noise)
+
+        # Apply RoPE to noise Q and K
+        q_noise = apply_rope(q_noise, md.input_positions,
+                             self.head_dim_original, self.rope_theta,
+                             self.rope_scaling)
+        k_noise = apply_rope(k_noise, md.input_positions,
+                             self.head_dim_original, self.rope_theta,
+                             self.rope_scaling)
+
+        # Process target hidden tokens (newly accepted tokens)
+        k_target = self.k_norm(self.k_proj(target_hidden))
+        v_target = self.v_proj(target_hidden)
+
+        # Apply RoPE to target K
+        k_target = apply_rope(k_target, target_positions,
+                              self.head_dim_original, self.rope_theta,
+                              self.rope_scaling)
+
+        q_target = jnp.zeros((T_target, self.num_heads, self.head_dim),
+                             dtype=q_noise.dtype)
+        # Step 1: Write target tokens to KV cache
+        # kv_lens is the length AFTER appending target tokens. This is EXACTLY md.seq_lens.
+        kv_cache, _ = attention(
+            kv_cache=kv_cache,
+            q=q_target,
+            k=k_target,
+            v=v_target,
+            attention_metadata=replace(md,
+                                       query_start_loc=target_query_start_loc),
+            mesh=self.mesh,
+            head_dim_original=self.head_dim_original,
+            sm_scale=self.head_dim_original**-0.5,
+            use_causal_mask=True,
+            update_kv_cache=True,
         )
 
-        x_new = jnp.concatenate([target_hidden, x_noise], axis=0)
-        k_new = self.k_proj(x_new)
-        v_new = self.v_proj(x_new)
-        k_new = self.k_norm(k_new)
-
-        new_positions = jnp.concatenate([ctx_positions, noise_positions],
-                                        axis=0)
-        k_new = apply_rope(
-            k_new,
-            new_positions,
-            self.head_dim_original,
-            self.rope_theta,
-            self.rope_scaling,
+        # Step 2: Write noise tokens to KV cache and compute attention
+        # kv_lens is the length AFTER appending noise tokens.
+        num_reqs = md.seq_lens.shape[0]
+        block_size = T_noise // num_reqs
+        seq_lens_noise = md.seq_lens + block_size
+        kv_cache, attn_out = attention(
+            kv_cache=kv_cache,
+            q=q_noise,
+            k=k_noise,
+            v=v_noise,
+            attention_metadata=replace(md, seq_lens=seq_lens_noise),
+            mesh=self.mesh,
+            head_dim_original=self.head_dim_original,
+            sm_scale=self.head_dim_original**-0.5,
+            use_causal_mask=False,  # Noise tokens attend to all KV tokens
+            update_kv_cache=True,
         )
 
-        if self.num_kv_groups > 1:
-            k_new = jnp.repeat(k_new, self.num_kv_groups, axis=1)
-            v_new = jnp.repeat(v_new, self.num_kv_groups, axis=1)
+        # attn_out is already (T_noise, num_heads, head_dim)
+        out = self.o_proj(attn_out)
 
-        k_ctx = k_new[:T_padded]
-        v_ctx = v_new[:T_padded]
-        k_noise = k_new[T_padded:]
-        v_noise = v_new[T_padded:]
-
-        ctx_mask = (jnp.arange(T_padded) < actual_ctx_count)  # (T_padded,)
-        ctx_mask_kv = ctx_mask[:, jnp.newaxis, jnp.newaxis]  # (T_padded, 1, 1)
-        k_ctx = jnp.where(ctx_mask_kv, k_ctx, 0.0)
-        v_ctx = jnp.where(ctx_mask_kv, v_ctx, 0.0)
-
-        k_ctx_4d = k_ctx.transpose(1, 0, 2)[jnp.newaxis, :, :, :]
-        v_ctx_4d = v_ctx.transpose(1, 0, 2)[jnp.newaxis, :, :, :]
-        kv_cache_k = lax.dynamic_update_slice(kv_cache_k, k_ctx_4d,
-                                              (0, 0, cache_len, 0))
-        kv_cache_v = lax.dynamic_update_slice(kv_cache_v, v_ctx_4d,
-                                              (0, 0, cache_len, 0))
-
-        noise_start = cache_len + actual_ctx_count
-        k_noise_4d = k_noise.transpose(1, 0, 2)[jnp.newaxis, :, :, :]
-        v_noise_4d = v_noise.transpose(1, 0, 2)[jnp.newaxis, :, :, :]
-        kv_cache_k = lax.dynamic_update_slice(kv_cache_k, k_noise_4d,
-                                              (0, 0, noise_start, 0))
-        kv_cache_v = lax.dynamic_update_slice(kv_cache_v, v_noise_4d,
-                                              (0, 0, noise_start, 0))
-
-        new_cache_len = cache_len + actual_ctx_count + T_noise
-        max_kv_len = kv_cache_k.shape[2]
-
-        q_4d = q.transpose(1, 0, 2)[jnp.newaxis, :, :, :]
-        kv_ids = (jnp.arange(max_kv_len) < new_cache_len).astype(jnp.int32)
-        q_ids = jnp.ones(T_noise, dtype=jnp.int32)
-        seg_ids = SegmentIds(
-            q=q_ids[jnp.newaxis, :],
-            kv=kv_ids[jnp.newaxis, :],
-        )
-
-        sm_scale = self.head_dim_original**-0.5
-        block_sizes = BlockSizes(
-            block_q=T_noise,
-            block_k_major=max_kv_len,
-            block_k=max_kv_len,
-            block_b=1,
-        )
-        attn_out = flash_attention(
-            q_4d,
-            kv_cache_k,
-            kv_cache_v,
-            segment_ids=seg_ids,
-            causal=False,
-            sm_scale=sm_scale,
-            block_sizes=block_sizes,
-            vmem_limit_bytes=_FA_VMEM_LIMIT,
-        )
-
-        attn_out = attn_out[0].transpose(1, 0, 2)
-        output = self.o_proj(attn_out)
-
-        return output, kv_cache_k, kv_cache_v
+        return out, kv_cache
 
 
 class DFlashMLP(nnx.Module):
@@ -329,25 +283,21 @@ class DFlashDecoderLayer(nnx.Module):
         self,
         x: jax.Array,
         target_hidden: jax.Array,
-        noise_positions: jax.Array,
-        ctx_positions: jax.Array,
-        kv_cache_k: jax.Array,
-        kv_cache_v: jax.Array,
-        cache_len: jax.Array,
-        actual_ctx_count: jax.Array,
-    ) -> Tuple[jax.Array, jax.Array, jax.Array]:
-        """Returns (hidden_states, new_kv_cache_k, new_kv_cache_v)."""
+        attention_metadata: Any,
+        target_query_start_loc: jax.Array,
+        target_positions: jax.Array,
+        kv_cache: jax.Array,
+    ) -> Tuple[jax.Array, jax.Array]:
+        """Returns (hidden_states, new_kv_cache)."""
         residual = x
         x = self.input_layernorm(x)
-        x, kv_cache_k, kv_cache_v = self.self_attn(
-            x,
-            target_hidden,
-            noise_positions,
-            ctx_positions,
-            kv_cache_k,
-            kv_cache_v,
-            cache_len,
-            actual_ctx_count,
+        x, kv_cache = self.self_attn(
+            x_noise=x,
+            target_hidden=target_hidden,
+            attention_metadata=attention_metadata,
+            target_query_start_loc=target_query_start_loc,
+            target_positions=target_positions,
+            kv_cache=kv_cache,
         )
         x = residual + x
 
@@ -355,7 +305,7 @@ class DFlashDecoderLayer(nnx.Module):
         x = self.post_attention_layernorm(x)
         x = self.mlp(x)
         x = residual + x
-        return x, kv_cache_k, kv_cache_v
+        return x, kv_cache
 
 
 class DFlashModel(nnx.Module):
@@ -369,6 +319,16 @@ class DFlashModel(nnx.Module):
         spec_config = vllm_config.speculative_config
         assert spec_config is not None
         hf_config = spec_config.draft_model_config.hf_config
+
+        # Inherit RoPE settings from the target model if missing or different
+        target_hf_config = vllm_config.model_config.hf_config
+        hf_config.rope_theta = getattr(
+            target_hf_config, "rope_theta",
+            getattr(hf_config, "rope_theta", 1000000.0))
+        hf_config.rope_scaling = getattr(
+            target_hf_config, "rope_scaling",
+            getattr(hf_config, "rope_scaling", None))
+
         dtype = jnp.bfloat16
         hidden_size = hf_config.hidden_size
         rms_norm_eps = hf_config.rms_norm_eps
@@ -461,6 +421,13 @@ class DFlashWeightLoader(BaseWeightLoader):
                 dtype=model.model.embed_tokens.embedding.dtype,
             )
 
+        if hasattr(model, "lm_head") and hasattr(model.lm_head, "weight"):
+            if isinstance(model.lm_head.weight.value, jax.ShapeDtypeStruct):
+                model.lm_head.weight.value = jnp.zeros(
+                    model.lm_head.weight.shape,
+                    dtype=model.lm_head.weight.dtype,
+                )
+
 
 class DFlashForCausalLM(nnx.Module):
     """DFlash draft model for speculative decoding on TPU."""
@@ -495,77 +462,72 @@ class DFlashForCausalLM(nnx.Module):
             mesh=mesh,
         )
 
+        dtype = jnp.bfloat16
+        if getattr(self.hf_config, "tie_word_embeddings", False):
+            self.lm_head = self.model.embed_tokens
+        else:
+            vocab_size = vllm_config.model_config.get_vocab_size()
+            tp_size = vllm_config.parallel_config.tensor_parallel_size if vllm_config.parallel_config is not None else 1
+            padded_vocab_size = utils.align_to(vocab_size, tp_size)
+            self.lm_head = JaxLmHead(
+                hidden_size=self.hf_config.hidden_size,
+                vocab_size=padded_vocab_size,
+                dtype=dtype,
+                param_dtype=dtype,
+                rngs=self.rng,
+                prefix="lm_head",
+            )
+
     def __call__(
         self,
         kv_caches: List[jax.Array],
         input_ids: jax.Array,
-        target_hidden_states: jax.Array,
+        target_hidden_states: Any,
         attention_metadata,
-    ) -> Tuple[List[jax.Array], jax.Array, List[jax.Array]]:
+    ) -> Tuple[List[jax.Array], jax.Array, List[jax.Array],
+               Optional[jax.Array]]:
         """Forward pass for the DFlash draft model.
 
-        ``target_hidden_states`` is a 3-tuple:
-            (ctx_hidden, cache_len_arr, actual_ctx_count_arr)
-        where:
-            ctx_hidden: (T_padded, D) — padded context features.
-            cache_len_arr: (1,) int32 — valid entries already in KV cache.
-            actual_ctx_count_arr: (1,) int32 — real (non-padding) context count.
-
-        ``kv_caches`` is a flat list of length ``2 * num_layers``:
-            [k_cache_0, v_cache_0, k_cache_1, v_cache_1, ...]
-        Each cache has shape ``(1, num_heads, max_kv_len, head_dim)``.
-
-        Returns:
-            (kv_caches, hidden_states, [target_hidden_states])
+        ``target_hidden_states`` is a tuple (target_hidden, target_query_start_loc, target_positions).
+        ``kv_caches`` is the framework's global paged kv caches.
         """
-        ctx_hidden, cache_len_arr, actual_ctx_count_arr = target_hidden_states
-        cache_len = cache_len_arr[0]  # scalar
-        actual_ctx_count = actual_ctx_count_arr[0]  # scalar
+        target_hidden, target_query_start_loc, target_positions = target_hidden_states
 
-        noise_emb = self.model.embed_tokens(input_ids)
-        pos_offset = cache_len if self._position_scheme == "incremental" else 0
-        T_padded = ctx_hidden.shape[0]
-        T_noise = input_ids.shape[0]
-        ctx_positions = jnp.arange(T_padded, dtype=jnp.int32) + pos_offset
-        noise_positions = (jnp.arange(T_noise, dtype=jnp.int32) + pos_offset +
-                           actual_ctx_count)
+        x = self.model.embed_tokens(input_ids)
+        num_draft_layers = len(self.model.layers)
 
-        x = noise_emb
         for i, layer in enumerate(self.model.layers):
-            kv_k = kv_caches[2 * i]
-            kv_v = kv_caches[2 * i + 1]
-            x, kv_k, kv_v = layer(
+            kv_cache_idx = -num_draft_layers + i
+            x, kv_caches[kv_cache_idx] = layer(
                 x,
-                ctx_hidden,
-                noise_positions,
-                ctx_positions,
-                kv_k,
-                kv_v,
-                cache_len,
-                actual_ctx_count,
+                target_hidden=target_hidden,
+                attention_metadata=attention_metadata,
+                target_query_start_loc=target_query_start_loc,
+                target_positions=target_positions,
+                kv_cache=kv_caches[kv_cache_idx],
             )
-            kv_caches[2 * i] = kv_k
-            kv_caches[2 * i + 1] = kv_v
 
         x = self.model.norm(x)
 
-        return kv_caches, x, []
+        return kv_caches, x, [], None
 
     def compute_logits(self, hidden_states: jax.Array) -> jax.Array:
-        """Compute logits using tied embedding weights."""
+        if hasattr(self,
+                   'lm_head') and not isinstance(self.lm_head, PPMissingLayer):
+            if isinstance(self.lm_head, nnx.Linear) or isinstance(
+                    self.lm_head, JaxLmHead):
+                return self.lm_head(hidden_states)
+            else:
+                return jnp.dot(hidden_states, self.lm_head.embedding.value.T)
         return jnp.dot(hidden_states,
                        self.model.embed_tokens.embedding.value.T)
 
     def combine_hidden_states(self, hidden_states: jax.Array) -> jax.Array:
-        """Project concatenated target auxiliary hidden states.
+        """Project concatenated target auxiliary hidden states."""
+        fc_out = self.model.fc(hidden_states)
+        hidden_out = self.model.hidden_norm(fc_out)
 
-        Args:
-            hidden_states: (T, num_target_layers * target_hidden_size)
-
-        Returns:
-            (T, hidden_size) projected + normalised context features.
-        """
-        return self.model.hidden_norm(self.model.fc(hidden_states))
+        return hidden_out
 
     def load_weights(self, rng_key: jax.Array):
         self.rng = jax.random.key(self.vllm_config.model_config.seed)
@@ -590,9 +552,22 @@ class DFlashForCausalLM(nnx.Module):
             "layers.*.mlp.up_proj": "model.layers.*.mlp.up_proj.kernel",
             "layers.*.mlp.down_proj": "model.layers.*.mlp.down_proj.kernel",
             "fc": "model.fc.kernel",
+            "model.fc": "model.fc.kernel",
+            "fc.weight": "model.fc.kernel",
+            "model.fc.weight": "model.fc.kernel",
             "hidden_norm": "model.hidden_norm.scale",
+            "model.hidden_norm": "model.hidden_norm.scale",
+            "hidden_norm.weight": "model.hidden_norm.scale",
+            "model.hidden_norm.weight": "model.hidden_norm.scale",
             "norm": "model.norm.scale",
+            "model.norm": "model.norm.scale",
+            "norm.weight": "model.norm.scale",
+            "model.norm.weight": "model.norm.scale",
             "embed_tokens": "model.embed_tokens.embedding",
+            "model.embed_tokens.weight": "model.embed_tokens.embedding",
+            "embed_tokens.weight": "model.embed_tokens.embedding",
+            "lm_head": "lm_head.kernel",
+            "lm_head.weight": "lm_head.kernel",
         }
 
         loader = self.WeightLoader(self.vllm_config, self.mesh)

--- a/tpu_inference/models/jax/qwen3_dflash.py
+++ b/tpu_inference/models/jax/qwen3_dflash.py
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List, Tuple
+from dataclasses import replace
+from typing import Any, List, Tuple
 
 import jax
 import jax.numpy as jnp
@@ -24,8 +25,6 @@ from vllm.config import VllmConfig
 from tpu_inference import utils
 from tpu_inference.layers.common.attention_interface import attention
 from tpu_inference.layers.common.attention_metadata import AttentionMetadata
-from tpu_inference.layers.common.dflash_attention_interface import \
-    dflash_concat_attention
 from tpu_inference.layers.common.quantization import quantize_kv
 from tpu_inference.layers.jax.embed import JaxEmbed
 from tpu_inference.layers.jax.linear import JaxEinsum, JaxLinear
@@ -75,9 +74,9 @@ class Qwen3DFlashAttention(nnx.Module):
         self.hidden_size = config.hidden_size
         self.num_heads = config.num_attention_heads
         self.num_kv_heads = config.num_key_value_heads
-        self.rope_theta = config.rope_theta
+        self.rope_theta = getattr(config, "rope_theta", 1000000.0)
         self.rope_scaling = getattr(config, "rope_scaling", None)
-        self.rms_norm_eps = config.rms_norm_eps
+        self.rms_norm_eps = getattr(config, "rms_norm_eps", 1e-6)
 
         self.head_dim_original = getattr(config, "head_dim",
                                          self.hidden_size // self.num_heads)
@@ -158,6 +157,8 @@ class Qwen3DFlashAttention(nnx.Module):
         hidden_states: jax.Array,
         target_hidden_states: jax.Array,
         attention_metadata: AttentionMetadata,
+        target_query_start_loc: jax.Array,
+        target_positions: jax.Array,
     ) -> Tuple[jax.Array, jax.Array]:
         md = attention_metadata
         q = self.q_proj(hidden_states)
@@ -173,7 +174,7 @@ class Qwen3DFlashAttention(nnx.Module):
 
         k_ctx = self.k_proj(target_hidden_states)
         k_ctx = self.k_norm(k_ctx)
-        k_ctx = apply_rope(k_ctx, md.input_positions, self.head_dim_original,
+        k_ctx = apply_rope(k_ctx, target_positions, self.head_dim_original,
                            self.rope_theta, self.rope_scaling)
         v_ctx = self.v_proj(target_hidden_states)
 
@@ -195,53 +196,72 @@ class Qwen3DFlashAttention(nnx.Module):
                 k, v = quantize_kv(self.kv_cache_quantized_dtype, k, v,
                                    k_scale, v_scale)
 
+            num_reqs = md.seq_lens.shape[0]
+            block_size = q.shape[0] // num_reqs
+            seq_lens_noise = md.seq_lens + block_size
+
             new_kv_cache, outputs = attention(
                 kv_cache,
                 q,
                 k,
                 v,
-                attention_metadata,
+                replace(attention_metadata, seq_lens=seq_lens_noise),
                 self.mesh,
                 self.head_dim_original,
                 q_scale=q_scale,
                 k_scale=k_scale,
                 v_scale=v_scale,
+                use_causal_mask=False,
             )
         elif self.dflash_attention_impl == "concat_dense":
-            outputs = dflash_concat_attention(
-                q,
-                k_ctx,
-                k_noise,
-                v_ctx,
-                v_noise,
-                attention_metadata,
-                max_query_len=self.max_query_len,
-                sm_scale=self.head_dim_original**-0.5,
-            )
-
+            q_target = jnp.zeros(
+                (target_hidden_states.shape[0], self.num_heads, self.head_dim),
+                dtype=q.dtype)
             q_scale = k_scale = v_scale = None
-            k_for_cache = k_noise
-            v_for_cache = v_noise
             if self.kv_cache_quantized_dtype:
                 k_scale = self._k_scale
                 v_scale = self._v_scale
-                k_for_cache, v_for_cache = quantize_kv(
-                    self.kv_cache_quantized_dtype, k_for_cache, v_for_cache,
-                    k_scale, v_scale)
+                k_ctx, v_ctx = quantize_kv(self.kv_cache_quantized_dtype,
+                                           k_ctx, v_ctx, k_scale, v_scale)
+                k_noise, v_noise = quantize_kv(self.kv_cache_quantized_dtype,
+                                               k_noise, v_noise, k_scale,
+                                               v_scale)
 
-            # Keep existing draft KV-cache update behavior using the noise
-            # stream while computing DFlash outputs from concat K/V semantics.
+            # Step 1: Write target tokens to KV cache
             new_kv_cache, _ = attention(
                 kv_cache,
-                q,
-                k_for_cache,
-                v_for_cache,
-                attention_metadata,
+                q_target,
+                k_ctx,
+                v_ctx,
+                replace(attention_metadata,
+                        query_start_loc=target_query_start_loc),
                 self.mesh,
                 self.head_dim_original,
                 q_scale=q_scale,
                 k_scale=k_scale,
                 v_scale=v_scale,
+                use_causal_mask=True,
+                update_kv_cache=True,
+            )
+
+            # Step 2: Compute attention for noise tokens against the full global cache
+            num_reqs = md.seq_lens.shape[0]
+            block_size = q.shape[0] // num_reqs
+            seq_lens_noise = md.seq_lens + block_size
+
+            new_kv_cache, outputs = attention(
+                new_kv_cache,
+                q,
+                k_noise,
+                v_noise,
+                replace(attention_metadata, seq_lens=seq_lens_noise),
+                self.mesh,
+                self.head_dim_original,
+                q_scale=q_scale,
+                k_scale=k_scale,
+                v_scale=v_scale,
+                use_causal_mask=False,
+                update_kv_cache=True,
             )
         else:
             raise ValueError(
@@ -296,21 +316,26 @@ class Qwen3DFlashDecoderLayer(nnx.Module):
         hidden_states: jax.Array,
         target_hidden_states: jax.Array,
         attention_metadata: AttentionMetadata,
-    ) -> Tuple[jax.Array, jax.Array]:
+        target_query_start_loc: jax.Array,
+        target_positions: jax.Array,
+    ) -> Tuple[jax.Array, jax.Array, jax.Array]:
         residual = hidden_states
         hidden_states = self.input_layernorm(hidden_states)
-        kv_cache, attn_out = self.self_attn(
-            kv_cache,
-            hidden_states,
-            target_hidden_states,
-            attention_metadata,
+
+        new_kv_cache, attn_out = self.self_attn(
+            kv_cache=kv_cache,
+            hidden_states=hidden_states,
+            target_hidden_states=target_hidden_states,
+            attention_metadata=attention_metadata,
+            target_query_start_loc=target_query_start_loc,
+            target_positions=target_positions,
         )
         hidden_states = residual + attn_out
         residual = hidden_states
         hidden_states = self.post_attention_layernorm(hidden_states)
         hidden_states = self.mlp(hidden_states)
         hidden_states = residual + hidden_states
-        return kv_cache, hidden_states
+        return new_kv_cache, hidden_states, residual
 
 
 class Qwen3DFlashModel(nnx.Module):
@@ -388,24 +413,29 @@ class Qwen3DFlashModel(nnx.Module):
         input_ids: jax.Array,
         target_hidden_states: jax.Array,
         attention_metadata: AttentionMetadata,
+        target_query_start_loc: jax.Array,
+        target_positions: jax.Array,
     ) -> Tuple[List[jax.Array], jax.Array, List[jax.Array]]:
         hidden_states = self.embed_tokens(input_ids)
 
         num_draft_layers = len(self.layers)
         draft_kv_start = max(0, len(kv_caches) - num_draft_layers)
+        residuals = []
+
         for i, layer in enumerate(self.layers):
             kv_idx = draft_kv_start + i
-            kv_cache, hidden_states = layer(
+            kv_caches[kv_idx], hidden_states, residual = layer(
                 kv_caches[kv_idx],
                 hidden_states,
                 target_hidden_states,
                 attention_metadata,
+                target_query_start_loc,
+                target_positions,
             )
-            kv_caches[kv_idx] = kv_cache
+            residuals.append(residual)
 
-        residual = hidden_states
-        hidden_states = self.norm(hidden_states)
-        return kv_caches, hidden_states, [residual]
+        o = self.norm(hidden_states)
+        return kv_caches, o, residuals
 
     def combine_hidden_states(self, hidden_states: jax.Array) -> jax.Array:
         hidden_states = self.fc(hidden_states)
@@ -465,13 +495,19 @@ class Qwen3DFlashForCausalLM(nnx.Module):
         input_ids: jax.Array,
         target_hidden_states: jax.Array,
         attention_metadata: AttentionMetadata,
-    ) -> Tuple[List[jax.Array], jax.Array, List[jax.Array]]:
-        return self.model(
+        target_query_start_loc: jax.Array,
+        target_positions: jax.Array,
+        **kwargs,
+    ) -> Tuple[List[jax.Array], jax.Array, List[jax.Array], Any]:
+        kv_caches, hidden_states, residuals = self.model(
             kv_caches,
             input_ids,
             target_hidden_states,
             attention_metadata,
+            target_query_start_loc,
+            target_positions,
         )
+        return kv_caches, hidden_states, residuals, None
 
     def compute_logits(self, hidden_states: jax.Array) -> jax.Array:
         return self.model.embed_tokens.decode(hidden_states)


### PR DESCRIPTION
# Description

This PR refactors the JAX DFlash draft models and their attention layers to support the framework's global paged KV cache structure, removing the previous local dense cache allocation.

### Why is this change being made?
Previously, the JAX DFlash draft models assumed a static, local contiguous KV cache buffer. This design limited the draft model to a batch size of 1 and prevented integration with the JAX/TPU framework's page-level memory manager (which handles swapping and page mapping across request IDs).

### The problem being solved and any relevant context
This PR establishes the core model-level and layer-level architecture changes needed to enable multi-request dynamic batching (num_reqs > 1) and cross-request cache persistence for JAX DFlash speculative decoding.

### Why this is a good solution
By leveraging the unified `attention()` helper in `attention_interface.py` to write directly to the global paged KV caches, the draft models are now fully compatible with continuous batching. Additionally, we exposed the keyword option `use_causal_mask` to the high-level `attention()` interface, allowing DFlash's Step 2 attention pass (noise tokens) to perform non-causal attention, while keeping the Step 1 pass (target tokens write) causal.

### Specific implementation details
1. **Exposed Causal Mask Control:** Added `use_causal_mask` (default `True`) to `attention()` and `sharded_ragged_paged_attention()` in `attention_interface.py`.
2. **Refactored Attention Layers:** Updated `DFlashAttention` (in `dflash.py`) and `Qwen3DFlashAttention` (in `qwen3_dflash.py`) to run paged KV cache writes using the high-level `attention()` helper.
3. **Updated Fallback Dense Attention:** Refactored `dflash_concat_attention` (in `dflash_attention_interface.py`) to accept different token counts for target context and noise streams to support dynamic batching.
4. **RoPE Settings Inheritance:** Configured JAX DFlash models to inherit RoPE scaling parameters from the target model's configuration to prevent position representation mismatches.

# Tests

I have verified the correctness of the model structure and layouts using the updated unit tests:

1. **JAX DFlash unit tests and Qwen3 JAX DFlash unit tests:**
   ```bash
   python3 -m pytest tests/models/jax/test_dflash.py
   python3 -m pytest tests/models/jax/test_qwen3_dflash.py tests/models/jax/test_qwen3_dflash_attention.py  


Before submitting this PR, please make sure:

-  I have performed a self-review of my code.
-  I have necessary comments in my code, particularly in hard-to-understand areas.
-  I have made or will make corresponding changes to any relevant documentation.