### PR TITLE
Introduce SC dense gather reduce kernel for MoE layers

### DIFF
--- a/tests/kernels/dense_gather_reduce_test.py
+++ b/tests/kernels/dense_gather_reduce_test.py
@@ -1,0 +1,228 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import itertools
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+from absl.testing import absltest, parameterized
+from jax._src import test_util as jtu
+from jax.experimental.pallas import tpu as pltpu
+
+from tpu_inference.kernels.sparse_core.dense_gather_reduce import \
+    dense_gather_reduce
+
+jax.config.parse_flags_with_absl()
+
+
+def reference_dense_gather_reduce(
+    x: jax.Array,
+    indices: jax.Array,
+    topk_weights: jax.Array,
+    reduce_group_size: int,
+    topk_wgt_zero_nan: bool = False,
+) -> jax.Array:
+    """Reference implementation of dense gather reduce."""
+    topk_weights_1d = topk_weights.reshape(-1)
+    weights_for_mul = topk_weights_1d[:, None].astype(jnp.float32)
+    gathered = x[indices].astype(jnp.float32)
+    if topk_wgt_zero_nan:
+        gathered = jnp.where(weights_for_mul == 0.0, 0.0,
+                             gathered * weights_for_mul)
+    else:
+        gathered = gathered * weights_for_mul
+    out = gathered.reshape(-1, reduce_group_size, gathered.shape[-1])
+    out = jnp.sum(out, axis=1).astype(x.dtype)
+    return out
+
+
+@jtu.with_config(jax_numpy_dtype_promotion="standard")
+class DenseGatherReduceTest(jtu.JaxTestCase):
+    _test_cases = [
+        dict(
+            out_size=o,
+            hidden_size=h,
+            dtype=d,
+            reduce_group_size=rg,
+            topk_wgt_zero_nan=wzn,
+        ) for o, h, d, rg, wzn in itertools.chain(
+            itertools.product(
+                [400, 840],
+                [128, 512, 8192],
+                [jnp.bfloat16, jnp.float32],
+                [8, 5],
+                [False, True],
+            ),
+            itertools.product(
+                [16384],
+                [7168],
+                [jnp.bfloat16],
+                [8],
+                [False, True],
+            ),
+            itertools.product(
+                [16384],
+                [6144],
+                [jnp.bfloat16],
+                [8],
+                [False],
+            ),
+            itertools.product(
+                [20480],
+                [4096],
+                [jnp.bfloat16],
+                [10],
+                [False],
+            ),
+        )
+    ]
+
+    def setUp(self):
+        super().setUp()
+        try:
+            tpu_info = pltpu.get_tpu_info()
+            sc_info = tpu_info.sparse_core
+        except ValueError:
+            tpu_info = None
+            sc_info = None
+        if sc_info is None:
+            self.skipTest("SparseCore is not available")
+        if tpu_info.generation == 6:
+            self.skipTest("dense_gather_reduce is not supported on TPUv6e")
+
+    @parameterized.parameters(*_test_cases)
+    def test_sc_dense_gather_reduce(self, out_size, hidden_size, dtype,
+                                    reduce_group_size, topk_wgt_zero_nan):
+        key = jax.random.key(0)
+        x = jax.random.normal(key, (out_size, hidden_size), jnp.float32)
+        x = x.astype(dtype)
+        indices = jax.random.permutation(key, out_size)
+        topk_weights = jax.random.normal(
+            key, (out_size // reduce_group_size, reduce_group_size),
+            jnp.bfloat16)
+
+        if topk_wgt_zero_nan:
+            mask = jax.random.bernoulli(key, 0.2, topk_weights.shape)
+            topk_weights = jnp.where(mask, 0.0, topk_weights)
+
+        actual = dense_gather_reduce(
+            x,
+            indices,
+            topk_weights,
+            reduce_group_size,
+            topk_wgt_zero_nan=topk_wgt_zero_nan,
+        )
+        # Correctness check.
+        desired = reference_dense_gather_reduce(
+            x,
+            indices,
+            topk_weights,
+            reduce_group_size,
+            topk_wgt_zero_nan=topk_wgt_zero_nan,
+        )
+        np.testing.assert_allclose(actual, desired, atol=1e-2, rtol=1e-2)
+
+    def test_nan_mitigation(self):
+        """Verifies that topk_wgt_zero_nan=True correctly zeroes out NaNs."""
+        try:
+            sc_info = pltpu.get_tpu_info().sparse_core
+        except ValueError:
+            sc_info = None
+
+        if sc_info is None:
+            self.skipTest("SparseCore is not available")
+
+        out_size = 16384
+        hidden_size = 128
+        reduce_group_size = 8
+
+        key = jax.random.key(0)
+        x = jax.random.normal(key, (out_size, hidden_size), jnp.float32)
+        nan_rows = [5, 12, 100, 500, 1000]
+        x = x.at[nan_rows, :].set(jnp.nan)
+        x = x.astype(jnp.bfloat16)
+
+        indices = jax.random.permutation(key, out_size)
+
+        topk_weights = jnp.ones(
+            (out_size // reduce_group_size, reduce_group_size),
+            dtype=jnp.bfloat16)
+
+        for nan_row in nan_rows:
+            gathered_indices = jnp.where(indices == nan_row)[0]
+            for idx_val in gathered_indices:
+                token_idx = idx_val // reduce_group_size
+                topk_idx = idx_val % reduce_group_size
+                topk_weights = topk_weights.at[token_idx, topk_idx].set(0.0)
+
+        actual = dense_gather_reduce(
+            x,
+            indices,
+            topk_weights,
+            reduce_group_size,
+            topk_wgt_zero_nan=True,
+        )
+
+        self.assertFalse(jnp.isnan(actual).any())
+
+        desired = reference_dense_gather_reduce(
+            x,
+            indices,
+            topk_weights,
+            reduce_group_size,
+            topk_wgt_zero_nan=True,
+        )
+        np.testing.assert_allclose(actual, desired, atol=1e-2, rtol=1e-2)
+
+        actual_with_nan = dense_gather_reduce(
+            x,
+            indices,
+            topk_weights,
+            reduce_group_size,
+            topk_wgt_zero_nan=False,
+        )
+        self.assertTrue(jnp.isnan(actual_with_nan).any())
+
+    def test_debug_layout(self):
+        out_size = 520
+        hidden_size = 8192
+        reduce_group_size = 8
+
+        # x[r, c] = 1 if r % 8 == c else 0
+        x = np.zeros((out_size, hidden_size), dtype=np.float32)
+        for r in range(out_size):
+            x[r, r % 8] = 1.0
+        x = jnp.array(x)
+
+        key = jax.random.key(0)
+        indices = jax.random.permutation(key, out_size)
+        # weights = arange(M)
+        topk_weights = jnp.arange(out_size, dtype=jnp.float32).reshape(
+            out_size // reduce_group_size, reduce_group_size)
+
+        actual = dense_gather_reduce(x, indices, topk_weights,
+                                     reduce_group_size)
+        desired = reference_dense_gather_reduce(x, indices, topk_weights,
+                                                reduce_group_size)
+        try:
+            np.testing.assert_allclose(actual, desired, atol=1e-2, rtol=1e-2)
+        except AssertionError as e:
+            print("DEBUG ACTUAL (first 32 rows):\n", actual[:32, :])
+            print("DEBUG DESIRED (first 32 rows):\n", desired[:32, :])
+            raise e
+
+
+if __name__ == "__main__":
+    absltest.main(testLoader=jtu.JaxTestLoader())

--- a/tpu_inference/kernels/sparse_core/dense_gather_reduce.py
+++ b/tpu_inference/kernels/sparse_core/dense_gather_reduce.py
@@ -1,0 +1,304 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""SparseCore gather-reduce kernel implementation using Pallas.
+
+This module contains a Pallas kernel implementation for performing a
+gather-reduce operation on TPU SparseCore. It groups rows of an operand
+based on provided indices, sums them up, and scatters the results.
+"""
+
+import functools
+
+import jax
+import jax.numpy as jnp
+from jax import lax
+from jax.experimental import pallas as pl
+from jax.experimental.pallas import tpu as pltpu
+from jax.experimental.pallas import tpu_sc as plsc
+
+
+def is_compatible(
+    op: jax.Array,
+    idx: jax.Array,
+    reduce_group_size: int,
+    row_chunk_size: int = 512,
+    single_sc: bool = False,
+) -> bool:
+    """Checks if the inputs are compatible with the SparseCore Pallas kernel."""
+    if op.dtype != jnp.bfloat16 and op.dtype != jnp.float32:
+        return False
+    if op.shape[0] % reduce_group_size != 0:
+        return False
+
+    sc_info = pltpu.get_tpu_info().sparse_core
+    if sc_info is None:
+        return False
+
+    if sc_info.num_lanes % reduce_group_size != 0:
+        return False
+
+    num_cores = 1 if single_sc else sc_info.num_cores
+    num_subcores = sc_info.num_subcores
+    row_wave_size = row_chunk_size * num_cores * num_subcores
+    if idx.size % row_wave_size != 0:
+        return False
+
+    return True
+
+
+def _sc_gather_reduce(
+    op: jax.Array,
+    idx: jax.Array,
+    topk_weights: jax.Array | None = None,
+    *,
+    reduce_group_size: int,
+    single_sc: bool = False,
+    col_chunk_size: int = int(3.5 * 1024),
+    row_chunk_size: int = 512,
+    topk_wgt_zero_nan: bool = False,
+) -> jax.Array:
+    """Performs a gather-reduce operation on SparseCore.
+
+  This kernel groups rows of the operand ``op`` based on ``idx``, sums them
+  up, and scatters the results. The gather and add operations are performed
+  in fp32, and the results are written back in bf16.
+
+  Equivalent JAX code::
+
+    gathered = op[idx, :]
+    if topk_weights is not None:
+      flat_weights = topk_weights.flatten()
+      gathered = gathered * flat_weights[:, None].astype(jnp.float32)
+    gathered = jnp.reshape(gathered, (-1, reduce_group_size, op.shape[1]))
+    output = jnp.sum(gathered.astype(jnp.float32), axis=1).astype(jnp.bfloat16)
+
+  Args:
+    op: The operand matrix [B, K] in f32 or bf16 to gather from and reduce.
+    idx: The indices [M,] in int32 guiding the gather.
+    topk_weights: Optional weights [M // 128, 128] in bf16 to apply to the
+      gathered rows before reduction.
+    reduce_group_size: The number of gathered rows to sum per output row.
+    single_sc: Whether to use a single SparseCore.
+    col_chunk_size: The size of column chunks to process.
+    row_chunk_size: The size of row chunks for internal processing. Must be ``2
+      * reduce_group_size``.
+    topk_wgt_zero_nan: If True, treat zero ``topk_weights`` as indicators of NaN
+      during multiplication, resulting in zero output.
+
+  Returns:
+    The reduced result as a bf16 matrix [M / reduce_group_size, K].
+  """
+
+    sc_info = pltpu.get_tpu_info().sparse_core
+    if sc_info is None:
+        raise RuntimeError("SparseCore is not available on this TPU version.")
+
+    [M] = idx.shape
+    _, K = op.shape
+    M_out = M // reduce_group_size
+
+    if topk_weights is not None:
+        topk_weights = topk_weights.flatten()
+
+    @jax.jit
+    @pl.kernel(
+        out_type=jax.ShapeDtypeStruct((M_out, K), op.dtype),
+        mesh=plsc.VectorSubcoreMesh(
+            core_axis_name="core",
+            subcore_axis_name="subcore",
+            num_cores=1 if single_sc else sc_info.num_cores,
+        ),
+        compiler_params=pltpu.CompilerParams(
+            use_tc_tiling_on_sc=True,
+            needs_layout_passes=True,
+        ),
+    )
+    def kernel(in_hbm_ref, idx_hbm_ref, weights_hbm_ref, out_hbm_ref):
+        row_wave_size = row_chunk_size * lax.axis_size(("core", "subcore"))
+        if M % row_wave_size:
+            raise NotImplementedError(
+                f"{M=} must be divisible by {row_chunk_size=} *"
+                f" num_cores={lax.axis_size('core')} *"
+                f" num_vector_subcores={lax.axis_size('subcore')} = {row_wave_size}"
+            )
+        num_row_chunks = M // row_wave_size
+        num_col_chunks = K // col_chunk_size
+        packing = 32 // jax.dtypes.itemsize_bits(op.dtype)
+
+        subcore_first_row_chunk = (lax.axis_index(
+            ("core", "subcore")) * num_row_chunks)
+
+        in_spec = pl.BlockSpec((row_chunk_size, ), lambda i:
+                               (subcore_first_row_chunk + i, ))
+        in_specs = (in_spec, ) * (1 + (weights_hbm_ref is not None))
+
+        @functools.partial(pltpu.emit_pipeline,
+                           grid=(num_row_chunks, ),
+                           in_specs=in_specs)
+        def idx_pipeline(idx_ref, weights_ref=None):
+            row_chunk_idx = subcore_first_row_chunk + pl.program_id(0)
+
+            row_subchunk_size = sc_info.num_lanes
+            out_rows_per_step = row_subchunk_size // reduce_group_size
+            assert reduce_group_size * out_rows_per_step == sc_info.num_lanes
+            num_row_subchunks = row_chunk_size // row_subchunk_size
+            if row_chunk_size % row_subchunk_size:
+                raise ValueError(
+                    f"row_chunk_size needs to be a multiple of {row_subchunk_size}, but"
+                    f" got {row_chunk_size}")
+
+            @functools.partial(
+                pltpu.emit_pipeline,
+                grid=(num_row_subchunks, num_col_chunks),
+                in_specs=pl.BlockSpec(
+                    (pl.Indirect(row_subchunk_size), col_chunk_size),
+                    lambda r, c: (
+                        lax.div(
+                            idx_ref[pl.ds(r * row_subchunk_size,
+                                          row_subchunk_size)],
+                            packing,
+                        ),
+                        c,
+                    ),
+                ),
+                out_specs=pl.BlockSpec(
+                    (out_rows_per_step // packing, col_chunk_size),
+                    lambda r, c: (row_chunk_idx * num_row_subchunks + r, c),
+                ),
+            )
+            def data_pipeline(gather_ref, out_ref):
+                gather_ref = gather_ref.bitcast(op.dtype)
+                out_ref = out_ref.bitcast(op.dtype)
+
+                row_slice = pl.ds(
+                    pl.program_id(0) * row_subchunk_size, row_subchunk_size)
+                subchunk_idxs = idx_ref[row_slice]
+                weights = (None if weights_ref is None else
+                           weights_ref[row_slice].astype(jnp.float32))
+
+                unpack_col_chunk = 32  # 32 seems to works best when tuning.
+
+                @plsc.parallel_loop(0, col_chunk_size, step=unpack_col_chunk)
+                def _(col_base):
+                    accs = []
+                    for reduce_group in range(out_rows_per_step):
+                        acc = jnp.zeros((unpack_col_chunk, ),
+                                        dtype=jnp.float32)
+                        for row_in_group in range(reduce_group_size):
+                            row = reduce_group * reduce_group_size + row_in_group
+                            row_data = gather_ref[
+                                pl.ds(row * packing, packing),
+                                pl.ds(col_base, unpack_col_chunk),
+                            ].astype(jnp.float32)
+                            if packing == 1:
+                                row_data = row_data[0]
+                            else:
+                                assert packing == 2
+                                # For dtypes narrower than 32-bit, we end up gathering multiple
+                                # rows (since we had to bitcast to int32 before the gather).
+                                # This uses the remainder of the packing to choose the only row
+                                # we actually care about.
+                                row_data = jnp.where(
+                                    lax.rem(subchunk_idxs[row], 2) == 0,
+                                    row_data[0],
+                                    row_data[1],
+                                )
+                            if weights is not None:
+                                row_data *= weights[row]
+                                if topk_wgt_zero_nan:
+                                    row_data = jnp.where(
+                                        weights[row] == 0.0,
+                                        jnp.zeros_like(row_data), row_data)
+                            acc += row_data
+                        accs.append(acc)
+                    out = jnp.stack(accs, axis=0).astype(op.dtype)
+                    out_ref[:, pl.ds(col_base, unpack_col_chunk)] = out
+
+            data_pipeline(in_hbm_ref.bitcast(jnp.int32),
+                          out_hbm_ref.bitcast(jnp.int32))
+
+        idx_pipeline(
+            idx_hbm_ref,
+            *([weights_hbm_ref] if weights_hbm_ref is not None else []))
+
+    return kernel(op, idx, topk_weights)  # pylint: disable=no-value-for-parameter
+
+
+def _jax_fallback(x,
+                  indices,
+                  topk_weights,
+                  reduce_group_size,
+                  topk_wgt_zero_nan=False):
+    token_hidden_full = x[indices]
+    cur_sorted = token_hidden_full.reshape(
+        (-1, reduce_group_size, x.shape[-1]))
+    # topk_weights is already 2D [tokens, reduce_group_size]
+    cur_topk_weights = jnp.expand_dims(topk_weights, axis=-1)
+    # Accumulate in float32 to match reference precision and Pallas kernel
+    # behavior.
+    if topk_wgt_zero_nan:
+        cur_weighted = jnp.where(
+            cur_topk_weights == 0.0,
+            0.0,
+            cur_sorted.astype(jnp.float32) *
+            cur_topk_weights.astype(jnp.float32),
+        )
+    else:
+        cur_weighted = cur_sorted.astype(
+            jnp.float32) * cur_topk_weights.astype(jnp.float32)
+    out = cur_weighted.sum(axis=-2)
+    return out.astype(x.dtype)
+
+
+@jax.jit(static_argnames=("reduce_group_size", "topk_wgt_zero_nan"))
+def dense_gather_reduce(
+    x: jax.Array,
+    indices: jax.Array,
+    topk_weights: jax.Array,
+    reduce_group_size: int,
+    topk_wgt_zero_nan: bool = False,
+) -> jax.Array:
+    """Wrapper that redirects to Pallas dense gather reduce kernel if constraints are met.
+
+  Otherwise, it falls back to the JAX baseline.
+
+  Args:
+    x: Input array [out_size, hidden_size].
+    indices: Gather indices [out_size].
+    topk_weights: 2D weights [tokens, reduce_group_size], where tokens *
+      reduce_group_size = out_size.
+    reduce_group_size: Group size for reduction (topk).
+    topk_wgt_zero_nan: If True, treat zero weights as indicators of NaN during
+      multiplication, resulting in zero output.
+  """
+    if is_compatible(x, indices, reduce_group_size):
+        K = x.shape[-1]
+        col_chunk_size = min(2048, K)
+        while col_chunk_size > 0:
+            if K % col_chunk_size == 0 and col_chunk_size % 32 == 0:
+                break
+            col_chunk_size -= 32
+        if col_chunk_size > 0:
+            # Pallas kernel expects 1D weights
+            return _sc_gather_reduce(
+                x,
+                indices,
+                topk_weights.reshape(-1),
+                reduce_group_size=reduce_group_size,
+                col_chunk_size=col_chunk_size,
+                topk_wgt_zero_nan=topk_wgt_zero_nan,
+            )
+    # Fallback to JAX baseline
+    return _jax_fallback(x, indices, topk_weights, reduce_group_size,
+                         topk_wgt_zero_nan)

--- a/tpu_inference/layers/common/fused_moe_gmm.py
+++ b/tpu_inference/layers/common/fused_moe_gmm.py
@@ -24,6 +24,8 @@ import tpu_inference.envs as envs
 from tpu_inference.kernels.collectives import \
     hierarchical_reduce_scatter as hier_rs
 from tpu_inference.kernels.megablox.gmm_v2 import gmm_v2
+from tpu_inference.kernels.sparse_core.dense_gather_reduce import \
+    dense_gather_reduce
 from tpu_inference.kernels.sparse_core.ragged_gather import \
     ragged_gather as ragged_gather_v1
 from tpu_inference.kernels.sparse_core.ragged_gather_reduce import \
@@ -314,13 +316,12 @@ def moe_gmm_local(x: jax.Array,
                                                     cur_weights.reshape(-1),
                                                     cur_mask.reshape(-1), topk)
         else:
-            token_hidden_full = gmm2_res[cur_indices]
-            cur_sorted = token_hidden_full.reshape(
-                (-1, topk, gmm2_res.shape[-1]))
-            cur_topk_weights = jnp.expand_dims(cur_weights, axis=-1)
-            cur_weighted = cur_sorted * cur_topk_weights
-            cur_masked = jnp.where(cur_mask, cur_weighted, 0.0)
-            chunk_hidden = cur_masked.sum(axis=-2)
+            chunk_hidden = dense_gather_reduce(
+                gmm2_res,
+                topk_argsort_revert_indices,
+                topk_weights,
+                topk,
+            )
 
         if enable_rs_kernel:
             # Fallback to psum-scatter for small token sizes to avoid Mosaic compilation.


### PR DESCRIPTION
# Description

This PR introduces a SparseCore Pallas kernel implementation for a **dense gather-reduce** in MoE.

### Details & Context
* **Problem**: Under pure TP, the gather-reduce step (which collects outputs from active experts and performs the top-k weighted reduction) was executed using a native JAX implementation. This native path is highly unperformant on TPU.
* **Solution**: Similar to what we did for EP, where we have ragged gather reduce kernel to offload the ops to SC, we introduce dense gather reduce kernel for TP.
* **Limitations / Future Work**:
  * Currently limited to hardware platforms equipped with TPU SparseCore.
  * Fusing the gather reduce ops into gmm kernel, which is agnostic to sharding.
  * Remove the sequential dependency chain of vector addtions.

# Tests

* Verified correctness and NaN-handling behavior against a JAX reference implementation across multiple shapes, dtypes (`bfloat16` and `float32`), and reduction group sizes (top-k).
* Ensured the unit tests gracefully fallback.

### Commands to Run:
```bash
PYTHONPATH=. .venv/bin/python -m unittest tests.kernels.dense_gather_reduce_test
