### PR TITLE
Fix GPT-OSS model rope config, Triton sinks type mismatch, and DP scheduler multiprocessing deadlocks

### DIFF
--- a/tests/layers/jax/attention/test_gpt_oss_attention.py
+++ b/tests/layers/jax/attention/test_gpt_oss_attention.py
@@ -1,0 +1,131 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from unittest.mock import patch
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+from flax import nnx
+from jax.sharding import Mesh
+
+from tpu_inference.layers.common.attention_interface import get_kv_cache_shape
+from tpu_inference.layers.common.attention_metadata import AttentionMetadata
+from tpu_inference.layers.jax.attention.gpt_oss_attention import \
+    GptOssAttention
+
+
+class TestGptOssAttention(unittest.TestCase):
+    """Unit tests for GptOssAttention JAX layer."""
+
+    def setUp(self):
+        self.mesh = Mesh(
+            np.array(jax.devices()[:1]).reshape(1, 1, 1, -1),
+            axis_names=(
+                "data",
+                "attn_dp",
+                "expert",
+                "model",
+            ),
+        )
+
+    @patch(
+        "tpu_inference.layers.jax.attention.gpt_oss_attention.ragged_paged_attention_hd64"
+    )
+    def test_sinks_cast_to_float32(self, mock_kernel):
+        """Verify that sinks array is cast to float32 when calling attention."""
+        hidden_size = 512
+        num_attention_heads = 8
+        num_key_value_heads = 2
+        head_dim = 64
+
+        # Mock kernel return: output_TNH, kv_cache
+        # We need to construct output shape matching sharding spec (data, model, None)
+        # and kv_cache.
+        def mock_impl(*args, **kwargs):
+            q = args[0]
+            kv_cache = args[3]
+            sinks = args[8]
+
+            # Verify that sinks is indeed float32
+            self.assertEqual(sinks.dtype, jnp.float32)
+
+            output = jnp.zeros_like(q)
+            return output, kv_cache
+
+        mock_kernel.side_effect = mock_impl
+
+        with jax.set_mesh(self.mesh):
+            attention = GptOssAttention(
+                hidden_size=hidden_size,
+                num_attention_heads=num_attention_heads,
+                num_key_value_heads=num_key_value_heads,
+                head_dim=head_dim,
+                dtype=jnp.bfloat16,
+                kv_cache_dtype="auto",
+                rope_theta=10000.0,
+                initial_context_length=2048,
+                rope_scaling_factor=1.0,
+                rope_ntk_alpha=1.0,
+                rope_ntk_beta=1.0,
+                rngs=nnx.Rngs(42),
+                random_init=True,
+                mesh=self.mesh,
+            )
+
+            seq_len = 16
+            q_TNH = jnp.ones((seq_len, num_attention_heads, head_dim),
+                             dtype=jnp.bfloat16)
+            k_SKH = jnp.ones((seq_len, num_key_value_heads, head_dim),
+                             dtype=jnp.bfloat16)
+            v_SKH = jnp.ones((seq_len, num_key_value_heads, head_dim),
+                             dtype=jnp.bfloat16)
+
+            # Sinks are initialized as bfloat16 to verify it gets cast to float32
+            sinks = jnp.ones((4, ), dtype=jnp.bfloat16)
+
+            block_size = 16
+            num_blocks = 2
+            cache_shape = get_kv_cache_shape(num_blocks, block_size,
+                                             num_key_value_heads, head_dim,
+                                             jnp.bfloat16)
+            kv_cache = jnp.zeros(cache_shape, dtype=jnp.bfloat16)
+
+            attention_metadata = AttentionMetadata(
+                input_positions=jnp.arange(seq_len, dtype=jnp.int32),
+                block_tables=jnp.zeros((1, 2), dtype=jnp.int32).reshape(-1),
+                seq_lens=jnp.array([seq_len], dtype=jnp.int32),
+                query_start_loc=jnp.array([0, seq_len], dtype=jnp.int32),
+                request_distribution=jnp.array([0, 0, 1], dtype=jnp.int32),
+            )
+            attention_metadata.sliding_window = None
+
+            # Call the attention method
+            new_kv_cache, output = attention.attention(
+                kv_cache=kv_cache,
+                q_TNH=q_TNH,
+                k_SKH=k_SKH,
+                v_SKH=v_SKH,
+                sinks=sinks,
+                attention_metadata=attention_metadata,
+                mesh=self.mesh,
+            )
+
+            self.assertEqual(output.shape, q_TNH.shape)
+            self.assertTrue(mock_kernel.called)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/models/jax/test_gpt_oss.py
+++ b/tests/models/jax/test_gpt_oss.py
@@ -1,0 +1,135 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from unittest.mock import MagicMock
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+from jax.sharding import Mesh
+
+from tpu_inference.models.jax.gpt_oss import GptOss
+
+
+class MockHFConfigDirectTheta:
+
+    def __init__(self):
+        self.num_hidden_layers = 1
+        self.num_local_experts = 2
+        self.vocab_size = 1000
+        self.num_attention_heads = 8
+        self.num_key_value_heads = 2
+        self.head_dim = 64
+        self.hidden_size = 512
+        self.intermediate_size = 1024
+        self.num_experts_per_tok = 1
+        self.rms_norm_eps = 1e-5
+        self.swiglu_limit = 1.0
+        self.sliding_window = None
+        self.rope_theta = 10000.0
+        self.rope_scaling = {
+            "factor": 1.0,
+            "beta_slow": 1.0,
+            "beta_fast": 1.0,
+            "original_max_position_embeddings": 2048
+        }
+
+
+class MockHFConfigScalingTheta:
+
+    def __init__(self):
+        self.num_hidden_layers = 1
+        self.num_local_experts = 2
+        self.vocab_size = 1000
+        self.num_attention_heads = 8
+        self.num_key_value_heads = 2
+        self.head_dim = 64
+        self.hidden_size = 512
+        self.intermediate_size = 1024
+        self.num_experts_per_tok = 1
+        self.rms_norm_eps = 1e-5
+        self.swiglu_limit = 1.0
+        self.sliding_window = None
+        # No self.rope_theta attribute here
+        self.rope_scaling = {
+            "rope_theta": 20000.0,
+            "factor": 1.0,
+            "beta_slow": 1.0,
+            "beta_fast": 1.0,
+            "original_max_position_embeddings": 2048
+        }
+
+
+class MockVllmConfig:
+
+    def __init__(self, hf_config):
+        self.model_config = MagicMock()
+        self.model_config.dtype = jnp.bfloat16
+        self.model_config.enable_return_routed_experts = False
+        self.model_config.hf_config = hf_config
+        self.cache_config = MagicMock(cache_dtype="auto")
+        self.additional_config = {}
+
+
+class TestGptOssModel(unittest.TestCase):
+    """Unit tests for GptOss JAX model."""
+
+    def setUp(self):
+        self.mesh = Mesh(
+            np.array(jax.devices()[:1]).reshape(1, 1, 1, -1),
+            axis_names=(
+                "data",
+                "attn_dp",
+                "expert",
+                "model",
+            ),
+        )
+
+    def test_model_init_with_direct_rope_theta(self):
+        """Tests that GptOss initializes correctly when rope_theta is directly in hf_config."""
+        hf_config = MockHFConfigDirectTheta()
+        vllm_config = MockVllmConfig(hf_config)
+
+        with jax.set_mesh(self.mesh):
+            model = GptOss(
+                vllm_config=vllm_config,
+                rng=jax.random.PRNGKey(42),
+                mesh=self.mesh,
+                force_random_weights=True,
+            )
+
+        # Retrieve the first layer's self-attention block
+        first_layer_attn = model.layers[0].attn
+        self.assertEqual(first_layer_attn.rope_theta, 10000.0)
+
+    def test_model_init_with_scaling_rope_theta(self):
+        """Tests that GptOss initializes correctly when rope_theta is in rope_scaling."""
+        hf_config = MockHFConfigScalingTheta()
+        vllm_config = MockVllmConfig(hf_config)
+
+        with jax.set_mesh(self.mesh):
+            model = GptOss(
+                vllm_config=vllm_config,
+                rng=jax.random.PRNGKey(42),
+                mesh=self.mesh,
+                force_random_weights=True,
+            )
+
+        first_layer_attn = model.layers[0].attn
+        self.assertEqual(first_layer_attn.rope_theta, 20000.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tpu_inference/core/sched/dp_scheduler.py
+++ b/tpu_inference/core/sched/dp_scheduler.py
@@ -144,6 +144,10 @@ def _scheduler_worker_process(
     original_scheduler_cls: type,
 ):
     """Worker process that manages a single scheduler instance."""
+    import atexit
+    import gc
+    atexit._clear()
+    gc.enable()
     # Initialize the scheduler in this process
     import inspect
     sig = inspect.signature(original_scheduler_cls)
@@ -439,6 +443,11 @@ class DPScheduler(SchedulerInterface):
         self.output_conns: List[Connection] = []  # child writes, parent reads
         self.processes: List[Process] = []
 
+        gc_was_enabled = gc.isenabled()
+        if gc_was_enabled:
+            gc.disable()
+        gc.freeze()
+
         for rank in range(self.dp_size):
             # Each pipe gives (parent_end, child_end)
             # Input pipe: parent sends commands, child receives
@@ -471,6 +480,9 @@ class DPScheduler(SchedulerInterface):
             input_child_conn.close()
             output_child_conn.close()
             self.processes.append(process)
+
+        if gc_was_enabled:
+            gc.enable()
 
         # Reverse mapping from output connection to rank for wait()-based collection.
         self._output_conn_to_rank: Dict[int, int] = {

--- a/tpu_inference/layers/jax/attention/gpt_oss_attention.py
+++ b/tpu_inference/layers/jax/attention/gpt_oss_attention.py
@@ -171,6 +171,7 @@ class GptOssAttention(nnx.Module):
         v_scale: float | None = None,
     ) -> Tuple[KVCache, jax.Array]:
         """Performs scaled dot-product attention by calling the ragged_paged_attention kernel."""
+        sinks = jnp.asarray(sinks, jnp.float32)
         md = attention_metadata
         kv_cache_spec = P("data", None, "model")
 

--- a/tpu_inference/models/jax/gpt_oss.py
+++ b/tpu_inference/models/jax/gpt_oss.py
@@ -77,7 +77,9 @@ class GptOss(nnx.Module):
         rms_norm_eps: float = self.hf_config.rms_norm_eps
         swiglu_limit: float = self.hf_config.swiglu_limit
 
-        rope_theta: float = self.hf_config.rope_theta
+        rope_theta: float = getattr(
+            self.hf_config, "rope_theta",
+            None) or self.hf_config.rope_scaling["rope_theta"]
         rope_scaling_factor: float = self.hf_config.rope_scaling["factor"]
         rope_ntk_alpha: float = self.hf_config.rope_scaling["beta_slow"]
         rope_ntk_beta: float = self.hf_config.rope_scaling["beta_fast"]


### PR DESCRIPTION
# Description

Start with a short description of what the PR does and how this is a change from
the past.

 When running the GPT-OSS model in tpu-inference for RL rollout generation, we met three bugs:

1. RoPE Config Fallback Crash (`gpt_oss.py`)
This is an architectural configuration lookup crash. It occurs during model weight loading because the HuggingFace checkpoint/config for `gpt-oss-20b` has `rope_theta` nested under `rope_scaling` instead of at the root level. This occurs regardless of any data-parallel or attention configurations.

2. Triton Sinks Dtype Mismatch (`gpt_oss_attention.py`)
The Triton paged attention kernel requires the `sinks` tensor to be `float32`. Since we still execute attention decoding (even without attention DP), the sinks tensor must be cast to `float32` to avoid compilation dtype mismatches (e.g. when inputs are in `bfloat16`).

3. DP scheduler multiprocessing deadlocks


If the change fixes a Github issue, please include a link, e.g.,:
FIXES: b/526733953

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

Test the GPT-OSS 20B vllm path on GCP. [LOG](https://pantheon.corp.google.com/logs/query;query=resource.type%3D%22k8s_container%22%0Aresource.labels.project_id%3D%22cloud-tpu-multipod-dev%22%0Aresource.labels.location%3D%22europe-west4%22%0Aresource.labels.cluster_name%3D%22mlperf-v5p%22%0Aresource.labels.namespace_name%3D%22default%22%0Aresource.labels.pod_name:%22sb-rl-gpt-5506%22%20severity%3E%3DDEFAULT%0Aresource.labels.container_name%3D%22jax-tpu%22;storageScope=project;startTime=2026-06-23T23:00:00Z;endTime=2026-06-24T00:20:00Z?project=cloud-tpu-multipod-dev&e=13803378)

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.