### PR TITLE
Fix tensor parallelism (model>1) for MLA models (Kimi K2.6)

### DIFF
--- a/tpu_inference/layers/common/attention_interface.py
+++ b/tpu_inference/layers/common/attention_interface.py
@@ -525,12 +525,11 @@ def mla_attention(
     """
     in_specs = (
         query_nth_sharding
-        or P(None, ShardingAxisName.MLP_TENSOR, None),  # q (head-major)
+        or P(None, ShardingAxisName.ATTN_DATA, None),  # q (head-major)
         query_tnh_sharding
-        or P(ShardingAxisName.MLP_TENSOR, None, None),  # q_rope (token-major)
-        keyvalue_skh_sharding or P(ShardingAxisName.MLP_TENSOR, None),  # k
-        keyvalue_skh_sharding
-        or P(ShardingAxisName.MLP_TENSOR, None),  # k_rope
+        or P(ShardingAxisName.ATTN_DATA, None, None),  # q_rope (token-major)
+        keyvalue_skh_sharding or P(ShardingAxisName.ATTN_DATA, None),  # k
+        keyvalue_skh_sharding or P(ShardingAxisName.ATTN_DATA, None),  # k_rope
         P(ShardingAxisName.BATCH),  # kv_cache
         P(ShardingAxisName.ATTN_DATA),  # md.seq_lens
         P(ShardingAxisName.ATTN_DATA),  # md.page_indices_flat
@@ -540,7 +539,7 @@ def mla_attention(
     out_specs = (
         P(ShardingAxisName.BATCH),  # kv cache
         attn_o_nth_sharding
-        or P(None, ShardingAxisName.MLP_TENSOR, None)  # attn output
+        or P(None, ShardingAxisName.ATTN_DATA, None)  # attn output
     )
 
     def _mla_ragged_paged_attention(q, q_rope, k, k_rope, cache, *args):

--- a/tpu_inference/layers/vllm/custom_ops/mla_attention.py
+++ b/tpu_inference/layers/vllm/custom_ops/mla_attention.py
@@ -145,9 +145,15 @@ class VllmMLAAttention(MLAAttention):
             self.W_UV, self.W_UV_scale = quantize_tensor(
                 self.kv_cache_quantized_dtype, jax_view(self.W_UV), axis=1)
             self.W_UV = torch_view(general_device_put(self.W_UV, sharding))
+            # W_UV_scale is laid out (1, num_heads, v_head_dim) so it broadcasts
+            # against the "bnv" einsum output in forward(); its head axis is dim 1,
+            # not dim 0. Shard ATTN_HEAD where the head axis actually lives,
+            # otherwise we try to split the leading size-1 dim under TP.
+            wuv_scale_sharding = NamedSharding(
+                mesh, P(None, ShardingAxisName.ATTN_HEAD))
             self.W_UV_scale = torch_view(
                 general_device_put(jnp.expand_dims(self.W_UV_scale, 0),
-                                   sharding))
+                                   wuv_scale_sharding))
 
             self.W_UK_T = Parameter(self.W_UK_T, requires_grad=False)
             self.W_UK_T_scale = Parameter(self.W_UK_T_scale,


### PR DESCRIPTION
# Description

Two latent sharding bugs blocked TP on MLA models; both are no-ops at
model=1, so the default attention-DP config is byte-for-byte unchanged.

1. mla_attention.py: W_UV_scale was sharded P(ATTN_HEAD,) on axis 0, but
   after expand_dims(...,0) axis 0 is a size-1 dummy and the head dim is
   axis 1 -> IndivisibleError at load when model>1. Shard the real head
   axis: P(None, ATTN_HEAD).

2. attention_interface.py: the MLA kernel's q/q_rope/k/k_rope/output were
   sharded on MLP_TENSOR (includes `model`) while the metadata
   (cu_q_lens/seq_lens/page_indices) and KV cache use ATTN_DATA (attn_dp
   only). When model>1, tokens split more ways than the metadata, so the
   kernel sliced q[cu_q_lens[i]:cu_q_lens[i+1]] past each device's local
   buffer -> out-of-bounds DMA -> TPU core halt on prefill. Shard tokens
   on ATTN_DATA to match (attention is data-parallel over attn_dp,
   replicated over `model`; correct for MLA). ATTN_DATA == MLP_TENSOR at
   model=1, so no change to the default path.

Verified on gf2x2 / tpu7x-8 (tp=2/attn_dp=4, util=0.80): loads, serves,
64/64 at 8k-in/1k-out.

# reproduce script:

## vllm serve — TP config (attn_dp_size=4 → tp=2/attn_dp=4)

QUANTIZE_ON_LOAD_PREFIXES="self_attn" DP_SCHED_BATCH_PREFILL=0 \
MOE_ALL_GATHER_ACTIVATION_DTYPE=fp8 MOE_REQUANTIZE_WEIGHT_DTYPE=fp4 \
MOE_REQUANTIZE_BLOCK_SIZE=512 NEW_MODEL_DESIGN=1 MODEL_IMPL_TYPE=vllm \
vllm serve --seed 42 --model "gs://tpu-commons-ci/moonshootai/kimi/2.6" \
  --served-model-name moonshotai/Kimi-K2.6 \
  --max-model-len=9216 --max-num-batched-tokens=1024 --max-num-seqs=61 \
  --kv-cache-dtype=fp8 --no-enable-prefix-caching --gpu-memory-utilization=0.80 \
  --tensor-parallel-size=8 --enable-expert-parallel \
  --additional-config '{"compilation_sizes": [488], "sharding": {"sharding_strategy": {"enable_dp_attention": true, "attn_dp_size": 4}}}' \
  --generation-config="vllm" \
  --override-generation-config='{"do_sample": false, "temperature": 0.0, "model": "moonshotai/Kimi-K2.6"}' \
  --limit-mm-per-prompt='{"image": 0, "video": 0, "vision_chunk": 0}' \
  --trust_remote_code 2>&1 | tee ~/kimi_tp.log

For the DP baseline: drop "attn_dp_size": 4 from the additional-config (→ attn_dp=8, tp=1), keep --gpu-memory-utilization=0.80 for a fair comparison:
--additional-config '{"compilation_sizes": [488], "sharding": {"sharding_strategy": {"enable_dp_attention": true}}}'

## vllm bench — 8k/1k

vllm bench serve --model moonshotai/Kimi-K2.6 --dataset-name random \
  --random-input-len 8192 --random-output-len 1024 \
  --num-prompts 64 --max-concurrency 16 \
  --temperature 0 --ignore-eos --skip-chat-template --trust-remote-code
  
  ## Test result
  ============ Serving Benchmark Result ============
  Successful requests:                     64
  Failed requests:                         0
  Maximum request concurrency:             16
  Benchmark duration (s):                  140.68
  Total input tokens:                      524288
  Total generated tokens:                  65536
  Request throughput (req/s):              0.45
  Output token throughput (tok/s):         465.85
  Peak output token throughput (tok/s):    624.00
  Peak concurrent requests:                20.00
  Total token throughput (tok/s):          4192.66
  ---------------Time to First Token----------------
  Mean TTFT (ms):                          3589.27
  Median TTFT (ms):                        3045.41
  P99 TTFT (ms):                           8815.27
  -----Time per Output Token (excl. 1st token)------
  Mean TPOT (ms):                          30.77
  Median TPOT (ms):                        31.22
  P99 TPOT (ms):                           32.04
  ---------------Inter-token Latency----------------
  Mean ITL (ms):                           30.77
  Median ITL (ms):                         26.24
  P99 ITL (ms):                            251.95                                                                                                                                                ==================================================