### PR TITLE
Add correctness e2e for mistral small 4

### DIFF
--- a/.buildkite/models/mistralai_Mistral-Small-4-119B-2603_text-only.yml
+++ b/.buildkite/models/mistralai_Mistral-Small-4-119B-2603_text-only.yml
@@ -30,7 +30,7 @@ steps:
         else
           # 1. Run the fast correctness test first to catch basic integration bugs quickly (TP=8)
           .buildkite/scripts/run_in_docker.sh \
-            bash -c 'export RUN_MISTRAL_SMALL_4_CORRECTNESS_TEST=1 && python3 -m pytest -s -v -x /workspace/tpu_inference/tests/models/vllm/test_mistral_small_4.py -k test_mistral_small_4_correctness'
+            bash -c 'python3 /workspace/tpu_inference/tests/e2e/mistral_small_4_correctness.py'
           # 2. Run the heavy accuracy evaluation
           .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/test_accuracy.sh
         fi

--- a/.buildkite/models/mistralai_Mistral-Small-4-119B-2603_text-only.yml
+++ b/.buildkite/models/mistralai_Mistral-Small-4-119B-2603_text-only.yml
@@ -1,0 +1,51 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+steps:
+  - label: "${TPU_VERSION:-tpu6e} Accuracy for mistralai/Mistral-Small-4-119B-2603/text-only"
+    key: "${TPU_VERSION:-tpu6e}_mistralai_Mistral-Small-4-119B-2603_text-only_Accuracy"
+    soft_fail: true
+    agents:
+      queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
+    env:
+      TEST_MODEL: mistralai/Mistral-Small-4-119B-2603
+      # The default values are for tpu6e. For tpu7x, the CI procedure will export TENSOR_PARALLEL_SIZE_SINGLE=2, TENSOR_PARALLEL_SIZE_MULTI=8 automatically
+      TENSOR_PARALLEL_SIZE: "${TENSOR_PARALLEL_SIZE_MULTI:-8}"
+      MINIMUM_ACCURACY_THRESHOLD: 0  # TODO : replace 0 with your accuracy threshold
+    commands:
+      - |
+        if [ "${TPU_VERSION:-tpu6e}" = "tpu6e" ]; then
+          buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_mistralai_Mistral-Small-4-119B-2603_text-only_Accuracy" "not enough HBM"
+        else
+          # 1. Run the fast correctness test first to catch basic integration bugs quickly (TP=8)
+          .buildkite/scripts/run_in_docker.sh \
+            bash -c 'export RUN_MISTRAL_SMALL_4_CORRECTNESS_TEST=1 && python3 -m pytest -s -v -x /workspace/tpu_inference/tests/models/vllm/test_mistral_small_4.py -k test_mistral_small_4_correctness'
+          # 2. Run the heavy accuracy evaluation
+          .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/test_accuracy.sh
+        fi
+  - label: "${TPU_VERSION:-tpu6e} Record accuracy result for mistralai/Mistral-Small-4-119B-2603/text-only"
+    key: "${TPU_VERSION:-tpu6e}_record_mistralai_Mistral-Small-4-119B-2603_text-only_Accuracy"
+    depends_on: "${TPU_VERSION:-tpu6e}_mistralai_Mistral-Small-4-119B-2603_text-only_Accuracy"
+    env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
+      CI_TARGET: "mistralai/Mistral-Small-4-119B-2603/text-only"
+      CI_STAGE: "Accuracy/Correctness"
+      CI_CATEGORY: "text-only"
+    agents:
+      queue: cpu
+    commands:
+      - |
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_mistralai_Mistral-Small-4-119B-2603_text-only_Accuracy
+
+

--- a/tests/e2e/mistral_small_4_correctness.py
+++ b/tests/e2e/mistral_small_4_correctness.py
@@ -13,16 +13,19 @@
 # limitations under the License.
 
 import os
-import pytest
+
 from vllm import LLM, SamplingParams
+
 from tpu_inference import tpu_info
 
 MODEL_ID = "mistralai/Mistral-Small-4-119B-2603"
 
+
 def set_env_vars():
     """Sets the environment variables required for running Mistral Small 4 on TPU."""
     os.environ['MODEL_IMPL_TYPE'] = 'vllm'
-    os.environ['SKIP_JAX_PRECOMPILE'] = '1'  # Set to '1' to skip expensive multi-shape precompilation in unit tests
+    os.environ[
+        'SKIP_JAX_PRECOMPILE'] = '1'  # Set to '1' to skip expensive multi-shape precompilation in unit tests
     os.environ['VLLM_TPU_PATCH_MM_EMBEDDINGS'] = '1'
     os.environ['VLLM_DISABLE_SHARED_EXPERTS_STREAM'] = '0'
     os.environ['MOE_REQUANTIZE_BLOCK_SIZE'] = '512'
@@ -38,34 +41,33 @@ def get_num_tpu_cores() -> int:
     except Exception:
         return 0
 
-num_tpu_cores = get_num_tpu_cores()
-run_correctness = os.environ.get("RUN_MISTRAL_SMALL_4_CORRECTNESS_TEST") == "1"
 
-@pytest.mark.skipif(not run_correctness or num_tpu_cores < 8,
-                    reason=f"Correctness test is skipped unless RUN_MISTRAL_SMALL_4_CORRECTNESS_TEST=1 is set. It also requires at least 8 TPU cores (TP=8) but only {num_tpu_cores} available.")
-def test_mistral_small_4_correctness():
+num_tpu_cores = get_num_tpu_cores()
+
+
+def run_mistral_small_4_correctness():
     """Correctness test using real weights on TPU, matching user's production config."""
     set_env_vars()
-    
+
     # Match user's config exactly
-    tensor_parallel_size = 8 
+    tensor_parallel_size = 8
     max_model_len = 3072
     max_num_batched_tokens = 2048
     max_num_seqs = 16
     kv_cache_dtype = "fp8"
     gpu_memory_utilization = 0.90
-    
+
     prompts = [
         "Hello, my name is",
         "The capital of France is",
         "Write a short poem about artificial intelligence on TPUs.",
     ]
-    
+
     sampling_params = SamplingParams(
         temperature=0.0,
         max_tokens=64,
     )
-    
+
     additional_config = {
         "sharding": {
             "sharding_strategy": {
@@ -73,7 +75,7 @@ def test_mistral_small_4_correctness():
             }
         }
     }
-    
+
     print(f"Initializing LLM with model {MODEL_ID}...")
     llm = LLM(
         model=MODEL_ID,
@@ -87,24 +89,27 @@ def test_mistral_small_4_correctness():
         enable_expert_parallel=True,  # Match user's --enable-expert-parallel
         trust_remote_code=True,
     )
-    
+
     print("Generating outputs...")
     outputs = llm.generate(prompts, sampling_params)
-    
+
     assert len(outputs) == len(prompts)
-    
+
     for i, output in enumerate(outputs):
         prompt = output.prompt
         generated_text = output.outputs[0].text
         print(f"\n--- Prompt: {prompt} ---")
         print(f"Generated: {generated_text}")
-        assert len(generated_text) > 0, f"Generated text for prompt '{prompt}' is empty"
-        
+        assert len(generated_text
+                   ) > 0, f"Generated text for prompt '{prompt}' is empty"
+
         # Simple sanity check for correctness
         if i == 1:
             assert "Paris" in generated_text, f"Expected 'Paris' in response to France capital, got: {generated_text}"
 
 
 if __name__ == "__main__":
-    import sys
-    pytest.main([__file__] + sys.argv[1:])
+    if num_tpu_cores < 8:
+        print(f"Skipping because we have {num_tpu_cores} cores (< 8)")
+    else:
+        run_mistral_small_4_correctness()

--- a/tests/models/vllm/test_mistral_small_4.py
+++ b/tests/models/vllm/test_mistral_small_4.py
@@ -1,0 +1,110 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import pytest
+from vllm import LLM, SamplingParams
+from tpu_inference import tpu_info
+
+MODEL_ID = "mistralai/Mistral-Small-4-119B-2603"
+
+def set_env_vars():
+    """Sets the environment variables required for running Mistral Small 4 on TPU."""
+    os.environ['MODEL_IMPL_TYPE'] = 'vllm'
+    os.environ['SKIP_JAX_PRECOMPILE'] = '1'  # Set to '1' to skip expensive multi-shape precompilation in unit tests
+    os.environ['VLLM_TPU_PATCH_MM_EMBEDDINGS'] = '1'
+    os.environ['VLLM_DISABLE_SHARED_EXPERTS_STREAM'] = '0'
+    os.environ['MOE_REQUANTIZE_BLOCK_SIZE'] = '512'
+    os.environ['NEW_MODEL_DESIGN'] = '1'
+    os.environ['TPU_BACKEND_TYPE'] = 'jax'
+    os.environ['VLLM_USE_V1'] = '0'  # Force V0 engine for diagnostics
+
+
+def get_num_tpu_cores() -> int:
+    """Safely get the number of TPU cores without initializing JAX."""
+    try:
+        return tpu_info.get_num_chips() * tpu_info.get_num_cores_per_chip()
+    except Exception:
+        return 0
+
+num_tpu_cores = get_num_tpu_cores()
+run_correctness = os.environ.get("RUN_MISTRAL_SMALL_4_CORRECTNESS_TEST") == "1"
+
+@pytest.mark.skipif(not run_correctness or num_tpu_cores < 8,
+                    reason=f"Correctness test is skipped unless RUN_MISTRAL_SMALL_4_CORRECTNESS_TEST=1 is set. It also requires at least 8 TPU cores (TP=8) but only {num_tpu_cores} available.")
+def test_mistral_small_4_correctness():
+    """Correctness test using real weights on TPU, matching user's production config."""
+    set_env_vars()
+    
+    # Match user's config exactly
+    tensor_parallel_size = 8 
+    max_model_len = 3072
+    max_num_batched_tokens = 2048
+    max_num_seqs = 16
+    kv_cache_dtype = "fp8"
+    gpu_memory_utilization = 0.90
+    
+    prompts = [
+        "Hello, my name is",
+        "The capital of France is",
+        "Write a short poem about artificial intelligence on TPUs.",
+    ]
+    
+    sampling_params = SamplingParams(
+        temperature=0.0,
+        max_tokens=64,
+    )
+    
+    additional_config = {
+        "sharding": {
+            "sharding_strategy": {
+                "enable_dp_attention": True
+            }
+        }
+    }
+    
+    print(f"Initializing LLM with model {MODEL_ID}...")
+    llm = LLM(
+        model=MODEL_ID,
+        tensor_parallel_size=tensor_parallel_size,
+        max_model_len=max_model_len,
+        max_num_batched_tokens=max_num_batched_tokens,
+        max_num_seqs=max_num_seqs,
+        kv_cache_dtype=kv_cache_dtype,
+        gpu_memory_utilization=gpu_memory_utilization,
+        additional_config=additional_config,
+        enable_expert_parallel=True,  # Match user's --enable-expert-parallel
+        trust_remote_code=True,
+    )
+    
+    print("Generating outputs...")
+    outputs = llm.generate(prompts, sampling_params)
+    
+    assert len(outputs) == len(prompts)
+    
+    for i, output in enumerate(outputs):
+        prompt = output.prompt
+        generated_text = output.outputs[0].text
+        print(f"\n--- Prompt: {prompt} ---")
+        print(f"Generated: {generated_text}")
+        assert len(generated_text) > 0, f"Generated text for prompt '{prompt}' is empty"
+        
+        # Simple sanity check for correctness
+        if i == 1:
+            assert "Paris" in generated_text, f"Expected 'Paris' in response to France capital, got: {generated_text}"
+
+
+if __name__ == "__main__":
+    import sys
+    pytest.main([__file__] + sys.argv[1:])


### PR DESCRIPTION
# Description

Adds a basic correctness test for `mistralai/Mistral-Small-4-119B-2603` (which was supported as of #2611).

# Tests

```

    Processed prompts: 100%|██████████| 3/3 [00:16<00:00,  5.49s/it, est. speed input: 1.46 toks/s, output: 11.65 toks/s]

    --- Prompt: Hello, my name is ---
    Generated:  Brenda and I am a student at the University of North Carolina at Chapel Hill. I am currently taking a class called "The History of the English Language" and I am working on a project about the history of the word "okay." I was wondering if you could help me with some information about the etymology

    --- Prompt: The capital of France is ---
    Generated:  Paris. Paris is the largest city in France and serves as its political, economic, and cultural center. It is known for its iconic landmarks such as the Eiffel Tower, Louvre Museum, and Notre-Dame Cathedral. Paris is also a major global city and a popular tourist destination.

    Rate this question:
    - 2

    --- Prompt: Write a short poem about artificial intelligence on TPUs. ---
    Generated:  (Tensor Processing Units)

    **Artificial minds in silicon bright,**
    **TPUs hum with logic’s light.**
    **Neural nets in parallel dance,**
    **Learning fast, they swiftly prance.**

    **Data flows like rivers wide,**
    **Through the circuits, they abide.**
    **Patterns deep in circuits spun

    PASSED

    ================== 1 passed, 19 warnings in 312.58s (0:05:12) ==================
```

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
