### PR TITLE
feat(dflash): add end-to-end support for DFlash speculative decoding 

### DIFF
--- a/tests/models/jax/test_qwen3.py
+++ b/tests/models/jax/test_qwen3.py
@@ -47,6 +47,7 @@ class MockVllmConfig:
         self.quant_config = None
         self.additional_config = {}
         self.parallel_config = None
+        self.speculative_config = None
 
 
 @pytest.fixture(scope="module")

--- a/tests/runner/test_speculative_decoding_manager.py
+++ b/tests/runner/test_speculative_decoding_manager.py
@@ -401,3 +401,73 @@ class TestSpeculativeDecodingManager:
         assert result == [[10, 11], [20, 21]]
         self.runner.drafter.prepare_inputs.assert_called_once()
         self.runner.drafter.propose.assert_called_once()
+
+    def test_propose_dflash_draft_token_ids(self):
+        """Tests the logic for proposing DFlash draft tokens."""
+        # 1. ===== Setup =====
+        from tpu_inference.spec_decode.jax.dflash import DFlashProposer
+        self.runner.drafter = MagicMock(spec=DFlashProposer)
+        self.runner.speculative_config.method = "dflash"
+
+        # Mock TPUModelRunner attributes
+        self.runner.input_batch = MagicMock()
+        self.runner.input_batch.req_ids = ["req-1", "req-2"]
+        self.runner.requests = {
+            "req-1": MagicMock(),
+            "req-2": MagicMock(),
+        }
+        self.runner.mesh = self.mock_mesh
+        self.runner.kv_caches = MagicMock()
+
+        # Mock drafter methods
+        mock_attn_metadata = MagicMock()
+        mock_target_token_ids = MagicMock()
+        mock_last_token_indices = MagicMock()
+        mock_target_hidden_states = MagicMock()
+        self.runner.drafter.prepare_inputs.return_value = (
+            mock_target_hidden_states,
+            mock_target_token_ids,
+            mock_last_token_indices,
+            mock_attn_metadata,
+        )
+        mock_draft_token_ids = [[10, 11], [20, 21]]
+        self.runner.drafter.propose.return_value = (
+            self.runner.kv_caches,
+            mock_draft_token_ids,
+        )
+
+        # Inputs
+        aux_hidden_states = MagicMock()
+        attn_metadata = MagicMock()
+        attn_metadata.seq_lens.shape = [2]
+        spec_decode_metadata = MagicMock(spec=SpecDecodeMetadata)
+        spec_decode_metadata.req_indices_dp = {0: [0, 1]}
+        spec_decode_metadata.draft_lengths_cpu = np.array([2, 3])
+        last_sampled_token_id = MagicMock()
+        num_rejected_tokens = MagicMock()
+        discard_sampled_tokens_req_indices = []
+        scheduler_output = MagicMock()
+        input_ids = MagicMock()
+        hidden_states = MagicMock()
+
+        # 2. ===== Act =====
+        with patch(
+                "tpu_inference.runner.speculative_decoding_manager.device_array",
+                side_effect=lambda mesh, x, **kwargs: x):
+            result = self.runner.speculative_decoding_manager.propose_dflash_draft_token_ids(
+                spec_decode_metadata,
+                last_sampled_token_id,
+                num_rejected_tokens,
+                discard_sampled_tokens_req_indices,
+                aux_hidden_states,
+                attn_metadata,
+                scheduler_output,
+                input_ids,
+                async_scheduling=False,
+                hidden_states=hidden_states,
+            )
+
+        # 3. ===== Assert =====
+        assert result == [[10, 11], [20, 21]]
+        self.runner.drafter.prepare_inputs.assert_called_once()
+        self.runner.drafter.propose.assert_called_once()

--- a/tpu_inference/models/common/model_loader.py
+++ b/tpu_inference/models/common/model_loader.py
@@ -104,6 +104,7 @@ def _get_model_architecture(config: PretrainedConfig) -> nnx.Module:
     _MODEL_REGISTRY["Gemma4ForCausalLM"] = Gemma4ForCausalLM
     _MODEL_REGISTRY["Gemma4MTPModel"] = Gemma4MTPForCausalLM
     _MODEL_REGISTRY["DFlashForCausalLM"] = DFlashForCausalLM
+    _MODEL_REGISTRY["DFlashDraftModel"] = DFlashForCausalLM
 
     architectures = getattr(config, "architectures", [])
     for arch in architectures:

--- a/tpu_inference/models/jax/llama3.py
+++ b/tpu_inference/models/jax/llama3.py
@@ -310,9 +310,30 @@ class LlamaModel(nnx.Module):
             self.lm_head = PPMissingLayer()
 
         self.aux_hidden_state_layers = []
-        if vllm_config.speculative_config and vllm_config.speculative_config.method == "eagle3":
-            self.aux_hidden_state_layers = self.get_eagle3_aux_hidden_state_layers(
-            )
+        self.spec_method = None
+        if vllm_config.speculative_config:
+            self.spec_method = vllm_config.speculative_config.method
+            if self.spec_method == "eagle3":
+                self.aux_hidden_state_layers = self.get_eagle3_aux_hidden_state_layers(
+                )
+            elif self.spec_method == "dflash":
+                self.aux_hidden_state_layers = self.get_dflash_aux_hidden_state_layers(
+                    vllm_config)
+
+    def get_dflash_aux_hidden_state_layers(self, vllm_config):
+        spec_config = vllm_config.speculative_config
+        if spec_config is None or spec_config.draft_model_config is None:
+            return []
+        draft_hf_config = spec_config.draft_model_config.hf_config
+        dflash_config = getattr(draft_hf_config, "dflash_config", {})
+        target_layer_ids = dflash_config.get("target_layer_ids", None)
+        if target_layer_ids is not None:
+            return [i for i in target_layer_ids]
+        hf_config = vllm_config.model_config.hf_config
+        num_target_layers = getattr(draft_hf_config, "num_target_layers",
+                                    hf_config.num_hidden_layers)
+        num_layers = hf_config.num_hidden_layers
+        return list(range(num_layers - num_target_layers, num_layers))
 
     def get_eagle3_aux_hidden_state_layers(self):
         num_layers = len(self.layers)
@@ -335,7 +356,7 @@ class LlamaModel(nnx.Module):
         aux_hidden_states = []
         for i, layer in enumerate(
                 islice(self.layers, self.start_layer, self.end_layer)):
-            if i in self.aux_hidden_state_layers:
+            if i in self.aux_hidden_state_layers and self.spec_method == "eagle3":
                 aux_hidden_states.append(x)
             kv_cache = kv_caches[i]
             kv_cache, x = layer(
@@ -344,6 +365,8 @@ class LlamaModel(nnx.Module):
                 attention_metadata,
             )
             kv_caches[i] = kv_cache
+            if i in self.aux_hidden_state_layers and self.spec_method == "dflash":
+                aux_hidden_states.append(x)
         if not self.is_last_rank:
             # Note: add aux_hidden_states to make the output spec consistent.
             return kv_caches, JaxIntermediateTensors({"hidden_states":

--- a/tpu_inference/models/jax/qwen3.py
+++ b/tpu_inference/models/jax/qwen3.py
@@ -320,12 +320,13 @@ class Qwen3Model(Qwen2Model):
             self.norm = PPMissingLayer()
 
         self.aux_hidden_state_layers = []
-        if vllm_config.speculative_config and vllm_config.speculative_config.method == "dflash":
+        spec_config = getattr(vllm_config, "speculative_config", None)
+        if spec_config and spec_config.method == "dflash":
             self.aux_hidden_state_layers = self.get_dflash_aux_hidden_state_layers(
                 vllm_config)
 
     def get_dflash_aux_hidden_state_layers(self, vllm_config):
-        spec_config = vllm_config.speculative_config
+        spec_config = getattr(vllm_config, "speculative_config", None)
         if spec_config is None or spec_config.draft_model_config is None:
             return []
         draft_hf_config = spec_config.draft_model_config.hf_config

--- a/tpu_inference/models/jax/qwen3.py
+++ b/tpu_inference/models/jax/qwen3.py
@@ -319,6 +319,54 @@ class Qwen3Model(Qwen2Model):
         else:
             self.norm = PPMissingLayer()
 
+        self.aux_hidden_state_layers = []
+        if vllm_config.speculative_config and vllm_config.speculative_config.method == "dflash":
+            self.aux_hidden_state_layers = self.get_dflash_aux_hidden_state_layers(
+                vllm_config)
+
+    def get_dflash_aux_hidden_state_layers(self, vllm_config):
+        spec_config = vllm_config.speculative_config
+        if spec_config is None or spec_config.draft_model_config is None:
+            return []
+        draft_hf_config = spec_config.draft_model_config.hf_config
+        dflash_config = getattr(draft_hf_config, "dflash_config", {})
+        target_layer_ids = dflash_config.get("target_layer_ids", None)
+        if target_layer_ids is not None:
+            return [i for i in target_layer_ids]
+        hf_config = vllm_config.model_config.hf_config
+        num_target_layers = getattr(draft_hf_config, "num_target_layers",
+                                    hf_config.num_hidden_layers)
+        num_layers = hf_config.num_hidden_layers
+        return list(range(num_layers - num_target_layers, num_layers))
+
+    def __call__(
+        self,
+        kv_caches: List[jax.Array],
+        input_ids: Optional[jax.Array],
+        attention_metadata: AttentionMetadata,
+        inputs_embeds: Optional[jax.Array] = None,
+    ) -> Tuple[List[jax.Array], jax.Array, List[jax.Array]]:
+        from itertools import islice
+        if inputs_embeds is not None:
+            x = inputs_embeds
+        else:
+            x = self.embed_tokens(input_ids)
+
+        aux_hidden_states = []
+        for i, layer in enumerate(
+                islice(self.layers, self.start_layer, self.end_layer)):
+            kv_cache = kv_caches[i]
+            kv_cache, x = layer(
+                kv_cache,
+                x,
+                attention_metadata,
+            )
+            kv_caches[i] = kv_cache
+            if i in self.aux_hidden_state_layers:
+                aux_hidden_states.append(x)
+        x = self.norm(x)
+        return kv_caches, x, aux_hidden_states
+
 
 class Qwen3ForCausalLM(JaxModule, LoadableWithIterator):
 
@@ -373,7 +421,7 @@ class Qwen3ForCausalLM(JaxModule, LoadableWithIterator):
         if not is_first_rank:
             assert intermediate_tensors is not None
             inputs_embeds = intermediate_tensors["hidden_states"]
-        kv_caches, x = self.model(
+        kv_caches, x, aux_hidden_states = self.model(
             kv_caches,
             input_ids,
             attention_metadata,
@@ -381,7 +429,7 @@ class Qwen3ForCausalLM(JaxModule, LoadableWithIterator):
         )
         if not is_last_rank:
             x = JaxIntermediateTensors(tensors={"hidden_states": x}, )
-        return kv_caches, x, [], None
+        return kv_caches, x, aux_hidden_states, None
 
     def compute_logits(self, hidden_states: jax.Array) -> jax.Array:
         # Only use lm_head if it's a real projection layer (not a PPMissingLayer placeholder)

--- a/tpu_inference/runner/compilation_manager.py
+++ b/tpu_inference/runner/compilation_manager.py
@@ -754,15 +754,11 @@ class CompilationManager:
 
                 self._run_compilation(
                     f"select_from_array [{name}]",
-                    self.runner._select_from_array_fn,
-                    self.runner,
-                    input_tensor,
-                    indices_to_select,
-                    **{
+                    self.runner._select_from_array_fn, input_tensor,
+                    indices_to_select, self.runner.mesh, **{
                         "array_size": array_size,
                         "index_size": indices_count
-                    },
-                    warmup_handler=self._skip_self_arg_warmup_handler)
+                    })
 
     def _skip_self_arg_warmup_handler(self, fn, args, call_kwargs):
         """Warmup handler for methods compiled with an explicit `self` as the
@@ -1135,10 +1131,51 @@ class CompilationManager:
         self._precompile_extract_draft_token_ids()
         self._precompile_process_and_extend_logits()
         self._precompile_extend_logits_simple()
+        self._precompile_select_from_array_spec_decode()
         if self.runner.speculative_config.method == "eagle3":
             self._precompile_eagle3_helpers()
-        if self.runner.speculative_config.method == "mtp":
+        elif self.runner.speculative_config.method == "dflash":
+            self._precompile_dflash_helpers()
+        elif self.runner.speculative_config.method == "mtp":
             self._precompile_mtp_helpers()
+
+    def _precompile_select_from_array_spec_decode(self) -> None:
+        logger.info("Compiling select_from_array with different input shapes.")
+        vocab_size = self.runner.vocab_size
+        sharding = NamedSharding(
+            self.runner.mesh, PartitionSpec(ShardingAxisName.ATTN_DATA, None))
+        indices_sharding = NamedSharding(
+            self.runner.mesh, PartitionSpec(ShardingAxisName.ATTN_DATA))
+
+        for num_logits in self.runner.num_logits_paddings:
+            for num_reqs in self.runner.num_reqs_paddings:
+                # Case 1: Select bonus logits (indices shape (num_reqs, ))
+                array = self._create_dummy_tensor(
+                    (num_logits, vocab_size), self.runner.model_config.dtype,
+                    sharding)
+                indices_bonus = self._create_dummy_tensor(
+                    (num_reqs, ), jnp.int32, indices_sharding)
+                self._run_compilation(
+                    f"worker{self.runner.rank} select_bonus_logits",
+                    self.runner._select_from_array_fn,
+                    array,
+                    indices_bonus,
+                    self.runner.mesh,
+                    num_logits=num_logits,
+                    num_reqs=num_reqs,
+                )
+
+                # Case 2: Select target logits (indices shape (num_logits, ))
+                indices_target = self._create_dummy_tensor(
+                    (num_logits, ), jnp.int32, indices_sharding)
+                self._run_compilation(
+                    f"worker{self.runner.rank} select_target_logits",
+                    self.runner._select_from_array_fn,
+                    array,
+                    indices_target,
+                    self.runner.mesh,
+                    num_logits=num_logits,
+                )
 
     def _precompile_extract_draft_token_ids(self) -> None:
         logger.info(
@@ -1238,7 +1275,8 @@ class CompilationManager:
                     PartitionSpec(ShardingAxisName.MLP_DATA,
                                   ShardingAxisName.MLP_TENSOR))
                 target_probs = self._create_dummy_tensor(
-                    (num_logits, vocab_size), jnp.float32, sharding)
+                    (num_logits, vocab_size), self.runner.model_config.dtype,
+                    sharding)
                 draft_token_ids = self._create_dummy_tensor((num_logits, ),
                                                             jnp.int32)
                 num_draft_tokens = self._create_dummy_tensor((num_reqs, ),
@@ -1560,6 +1598,173 @@ class CompilationManager:
                     num_tokens=num_tokens,
                 )
 
+    def _precompile_dflash_helpers(self) -> None:
+        logger.info("Compiling dflash jitted helpers.")
+        target_hidden_size = self.runner.model_config.get_hidden_size()
+        dtype = self.runner.model_config.dtype
+        dp_size = self.runner.dp_size
+
+        num_kv_cache_groups = len(self.runner.kv_cache_config.kv_cache_groups)
+        draft_kv_cache_group_id = num_kv_cache_groups - 1
+        block_tables = self.runner.input_batch.block_table[
+            draft_kv_cache_group_id].get_cpu_tensor().reshape(-1)
+        dp_spec = PartitionSpec(ShardingAxisName.ATTN_DATA, )
+        dp_spec_2d = PartitionSpec(ShardingAxisName.ATTN_DATA, None)
+
+        dp_sharding = NamedSharding(self.runner.mesh, dp_spec)
+        block_tables = device_array(self.runner.mesh,
+                                    block_tables,
+                                    sharding=dp_sharding)
+
+        seq_lens = self._create_dummy_tensor((self.runner.max_num_reqs, ),
+                                             jnp.int32, dp_sharding)
+        query_start_loc = self._create_dummy_tensor(
+            (self.runner.max_num_reqs + dp_size, ), jnp.int32, dp_sharding)
+
+        request_distribution = np.array([0, 0, 0] * dp_size, dtype=np.int32)
+        request_distribution = device_array(self.runner.mesh,
+                                            request_distribution,
+                                            sharding=dp_sharding)
+
+        if self.runner.kv_cache_config.has_mamba_layers:
+            dflash_mamba_state_indices = device_array(
+                self.runner.mesh,
+                np.zeros(self.runner.max_num_reqs, dtype=np.int32),
+                sharding=dp_sharding)
+        else:
+            dflash_mamba_state_indices = None
+
+        num_reqs_dp = self._create_dummy_tensor((dp_size, ),
+                                                jnp.int32,
+                                                sharding=dp_sharding)
+        last_token_indices = self._create_dummy_tensor(
+            (self.runner.max_num_reqs, ), jnp.int32, dp_sharding)
+
+        # Get number of auxiliary layers configured for dflash target features
+        hf_config = self.runner.speculative_config.draft_model_config.hf_config
+        dflash_config = getattr(hf_config, "dflash_config", {})
+        target_layer_ids = dflash_config.get("target_layer_ids", None)
+        if target_layer_ids is not None:
+            num_aux_states = len(target_layer_ids)
+        else:
+            num_aux_states = getattr(hf_config, "num_target_layers",
+                                     hf_config.num_hidden_layers)
+
+        block_size = self.runner.drafter.block_size
+
+        # -------------------------------------------------------------
+        # Part 1: Compile drafter_propose (loops over target num_tokens)
+        # -------------------------------------------------------------
+        # input_ids always has constant shape (max_num_reqs * block_size)
+        num_tokens_propose = self.runner.max_num_reqs * block_size
+        input_ids_propose = self._create_dummy_tensor((num_tokens_propose, ),
+                                                      jnp.int32, dp_sharding)
+
+        for num_tokens in self.runner.num_tokens_paddings:
+            positions_propose = self._create_dummy_tensor(
+                (num_tokens_propose, ), jnp.int32, dp_sharding)
+            attention_metadata_propose = AttentionMetadata(
+                input_positions=positions_propose,
+                block_tables=block_tables,
+                seq_lens=seq_lens,
+                query_start_loc=query_start_loc,
+                request_distribution=request_distribution,
+                mamba_state_indices=dflash_mamba_state_indices,
+                padded_num_reqs=self.runner.max_num_reqs,
+            )
+
+            def drafter_propose_warmup(_fn,
+                                       _args,
+                                       _call_kwargs,
+                                       num_tokens=num_tokens):
+                new_args = (self.runner.kv_caches, ) + _args[1:]
+                logger.info("Warmup drafter_propose: num_tokens=%d",
+                            num_tokens)
+                kv_caches, draft_token_ids = self.runner.drafter.propose(
+                    *new_args, **_call_kwargs)
+                self.runner.kv_caches = kv_caches
+                return draft_token_ids
+
+            draft_hidden_size = hf_config.hidden_size
+            target_hidden_propose = self._create_dummy_tensor(
+                (num_tokens, draft_hidden_size), dtype,
+                NamedSharding(self.runner.mesh,
+                              PartitionSpec(None,
+                                            ShardingAxisName.MLP_TENSOR)))
+            new_query_start_loc = self._create_dummy_tensor(
+                (self.runner.max_num_reqs + dp_size, ), jnp.int32,
+                NamedSharding(self.runner.mesh, PartitionSpec()))
+            new_input_positions = self._create_dummy_tensor(
+                (num_tokens, ), jnp.int32,
+                NamedSharding(self.runner.mesh, PartitionSpec()))
+            target_hidden_states_propose = (target_hidden_propose,
+                                            new_query_start_loc,
+                                            new_input_positions)
+
+            self._run_compilation(
+                "drafter_propose",
+                self.runner.drafter.propose,
+                self.runner.kv_caches,
+                input_ids_propose,
+                attention_metadata_propose,
+                last_token_indices,
+                target_hidden_states_propose,
+                num_tokens=num_tokens,
+                warmup_handler=drafter_propose_warmup,
+            )
+
+        # -------------------------------------------------------------
+        # Part 2: Compile drafter_prepare_inputs (loops over target shapes)
+        # -------------------------------------------------------------
+        for num_tokens in self.runner.num_tokens_paddings:
+            for num_reqs in self.runner.attn_num_reqs_paddings:
+                positions = self._create_dummy_tensor((num_tokens, ),
+                                                      jnp.int32, dp_sharding)
+                attention_metadata = AttentionMetadata(
+                    input_positions=positions,
+                    block_tables=block_tables,
+                    seq_lens=seq_lens,
+                    query_start_loc=query_start_loc,
+                    request_distribution=request_distribution,
+                    mamba_state_indices=dflash_mamba_state_indices,
+                    padded_num_reqs=num_reqs,
+                )
+
+                aux_hidden_states = [
+                    self._create_dummy_tensor(
+                        (num_tokens, target_hidden_size), jnp.bfloat16,
+                        NamedSharding(self.runner.mesh, dp_spec_2d))
+                    for _ in range(num_aux_states)
+                ]
+                last_sampled_token_id = self._create_dummy_tensor(
+                    (self.runner.max_num_reqs, ), jnp.int32, dp_sharding)
+                next_prompt_token_id = self._create_dummy_tensor(
+                    (self.runner.max_num_reqs, ),
+                    jnp.int32,
+                    sharding=dp_sharding)
+                is_in_prefill = self._create_dummy_tensor(
+                    (self.runner.max_num_reqs, ),
+                    jnp.int32,
+                    sharding=dp_sharding)
+                num_rejected_tokens = self._create_dummy_tensor(
+                    (self.runner.max_num_reqs, ), jnp.int32, dp_sharding)
+                input_ids = self._create_dummy_tensor((num_tokens, ),
+                                                      jnp.int32, dp_sharding)
+
+                self._run_compilation(
+                    "drafter_prepare_inputs",
+                    self.runner.drafter.prepare_inputs,
+                    attention_metadata,
+                    input_ids,
+                    aux_hidden_states,
+                    last_sampled_token_id,
+                    next_prompt_token_id,
+                    is_in_prefill,
+                    num_rejected_tokens,
+                    num_reqs_dp,
+                    num_tokens=num_tokens,
+                )
+
     def _precompile_structured_decoding(self) -> None:
         logger.info(
             "Compiling structured_decoding with different input shapes.")
@@ -1596,8 +1801,8 @@ class CompilationManager:
     def _precompile_continue_decode(self) -> None:
         logger.info("Precompiling continue_decode loop.")
         dp_size = self.runner.vllm_config.sharding_config.total_dp_size
-        dp_sharding = NamedSharding(
-            self.runner.mesh, PartitionSpec(ShardingAxisName.ATTN_DATA, ))
+        dp_spec = PartitionSpec(ShardingAxisName.ATTN_DATA, )
+        dp_sharding = NamedSharding(self.runner.mesh, dp_spec)
 
         user_max_decode_steps = self.runner.vllm_config.additional_config.get(
             "max_decode_steps", DEFAULT_MAX_DECODE_STEPS)

--- a/tpu_inference/runner/kv_cache_manager.py
+++ b/tpu_inference/runner/kv_cache_manager.py
@@ -549,14 +549,17 @@ class KVCacheManager:
                         draft_hf_config, text_config)
                     for draft_layer, target_layer in redirects.items():
                         self.shared_kv_cache_layers[draft_layer] = target_layer
-                elif method == "eagle3":
+                elif method in ("eagle3", "dflash"):
+                    draft_num_layers = getattr(draft_hf_config,
+                                               'num_hidden_layers', 1)
+                    if method == "eagle3":
+                        draft_num_layers = 1
                     num_kv_heads = common_utils.get_padded_num_heads(
                         draft_hf_config.num_key_value_heads, model_cnt)
                     head_size = common_utils.get_padded_head_dim(
                         draft_hf_config.hidden_size //
                         draft_hf_config.num_attention_heads)
-                    # Eagle3 has only 1 layer
-                    for i in range(1):
+                    for i in range(draft_num_layers):
                         if self.use_mla:
                             kv_cache_spec[
                                 f"draft_layer.{i}"] = self._create_attention_spec(

--- a/tpu_inference/runner/speculative_decoding_manager.py
+++ b/tpu_inference/runner/speculative_decoding_manager.py
@@ -98,25 +98,126 @@ class SpeculativeDecodingManager:
                 valid_sampled_token_ids[:self.runner.input_batch.num_reqs],
                 self.runner.input_batch.num_tokens_no_spec,
                 self.runner.input_batch.token_ids_cpu)
-        elif self.runner.speculative_config.use_eagle():
+        elif self.runner.speculative_config.use_eagle(
+        ) or self.runner.speculative_config.method == "dflash":
             assert input_ids is not None
-            self._draft_token_ids = self.propose_eagle3_draft_token_ids(
-                spec_decode_metadata,
-                last_sampled_token_id,
-                num_rejected_tokens,
-                discard_sampled_tokens_req_indices,
-                aux_hidden_states,
-                attn_metadata,
-                scheduler_output,
-                input_ids,
-                async_scheduling,
-                hidden_states,
-            )
+            if self.runner.speculative_config.method == "dflash":
+                self._draft_token_ids = self.propose_dflash_draft_token_ids(
+                    spec_decode_metadata,
+                    last_sampled_token_id,
+                    num_rejected_tokens,
+                    discard_sampled_tokens_req_indices,
+                    aux_hidden_states,
+                    attn_metadata,
+                    scheduler_output,
+                    input_ids,
+                    async_scheduling,
+                    hidden_states,
+                )
+            else:
+                self._draft_token_ids = self.propose_eagle3_draft_token_ids(
+                    spec_decode_metadata,
+                    last_sampled_token_id,
+                    num_rejected_tokens,
+                    discard_sampled_tokens_req_indices,
+                    aux_hidden_states,
+                    attn_metadata,
+                    scheduler_output,
+                    input_ids,
+                    async_scheduling,
+                    hidden_states,
+                )
             self._req_indices_dp = spec_decode_metadata.req_indices_dp
         else:
             raise NotImplementedError(
                 f"Speculative decoding method "
                 f"'{self.runner.speculative_config.method}' is not supported.")
+
+    def propose_dflash_draft_token_ids(
+        self,
+        spec_decode_metadata: SpecDecodeMetadata,
+        last_sampled_token_id: jnp.ndarray,
+        num_rejected_tokens: jnp.ndarray,
+        discard_sampled_tokens_req_indices: list[int],
+        aux_hidden_states: Optional[tuple[jnp.ndarray, ...]],
+        attn_metadata: AttentionMetadata | dict[str, AttentionMetadata],
+        scheduler_output: VllmSchedulerOutput,
+        input_ids: jnp.ndarray,
+        async_scheduling: bool,
+        hidden_states: jnp.ndarray,
+    ) -> list[list[int]] | jnp.ndarray:
+        from tpu_inference.spec_decode.jax.dflash import DFlashProposer
+        assert isinstance(self.runner.drafter, DFlashProposer)
+        if isinstance(attn_metadata, dict):
+            attn_key = None
+            for key in attn_metadata.keys():
+                if ".self_attn." in key:
+                    attn_key = key
+                    break
+            if attn_key is not None:
+                attn_metadata = attn_metadata[attn_key]
+            else:
+                attn_metadata = next(iter(attn_metadata.values()))
+
+        req_ids = self.runner.input_batch.req_ids
+        max_num_seqs = attn_metadata.seq_lens.shape[0]
+        next_prompt_token_id = np.zeros(max_num_seqs, dtype=np.int32)
+        is_in_prefill = np.zeros(max_num_seqs, dtype=np.int32)
+
+        discard_sampled_tokens_req_indices_set = set(
+            discard_sampled_tokens_req_indices)
+        dp_size = self.runner.dp_size
+        max_num_reqs_per_dp_rank = self.runner.max_num_reqs // dp_size
+        num_reqs_dp = np.zeros((dp_size, ), dtype=np.int32)
+        for rank in range(dp_size):
+            req_indices = spec_decode_metadata.req_indices_dp[rank]
+            num_reqs_dp[rank] = len(req_indices)
+            for j, req_idx in enumerate(req_indices):
+                if req_idx in discard_sampled_tokens_req_indices_set:
+                    req_id = req_ids[req_idx]
+                    req_state = self.runner.requests[req_id]
+                    seq_len = (req_state.num_computed_tokens +
+                               scheduler_output.num_scheduled_tokens[req_id])
+                    next_token_id = req_state.get_token_id(seq_len)
+                    next_prompt_token_id[
+                        j + rank * max_num_reqs_per_dp_rank] = next_token_id
+                    is_in_prefill[j + rank * max_num_reqs_per_dp_rank] = 1
+
+        next_prompt_token_id, is_in_prefill, num_reqs_dp = device_array(
+            self.runner.mesh,
+            (next_prompt_token_id, is_in_prefill, num_reqs_dp),
+            sharding=(PartitionSpec(ShardingAxisName.ATTN_DATA)))
+
+        aux_hidden_states_for_drafter = aux_hidden_states
+
+        target_hidden_states, input_ids, last_token_indices, attn_metadata = self.runner.drafter.prepare_inputs(
+            attn_metadata,
+            input_ids,
+            aux_hidden_states_for_drafter,
+            last_sampled_token_id,
+            next_prompt_token_id,
+            is_in_prefill,
+            num_rejected_tokens,
+            num_reqs_dp,
+        )
+
+        self.runner.kv_caches, draft_token_ids = self.runner.drafter.propose(
+            kv_caches=self.runner.kv_caches,
+            input_ids=input_ids,
+            attn_metadata=attn_metadata,
+            last_token_indices=last_token_indices,
+            target_hidden_states=target_hidden_states,
+        )
+
+        if async_scheduling:
+            if jnp.ndim(draft_token_ids) == 1:
+                draft_token_ids = jnp.expand_dims(draft_token_ids, 1)
+            return draft_token_ids
+        else:
+            draft_token_ids = np.array(draft_token_ids)
+            if draft_token_ids.ndim == 1:
+                draft_token_ids = np.expand_dims(draft_token_ids, axis=-1)
+            return draft_token_ids.tolist()
 
     def propose_eagle3_draft_token_ids(
         self,

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -85,6 +85,7 @@ from tpu_inference.runner.speculative_decoding_manager import (
     SpecDecodeMetadata, SpeculativeDecodingManager)
 from tpu_inference.runner.structured_decoding_manager import \
     StructuredDecodingManager
+from tpu_inference.spec_decode.jax.dflash import DFlashProposer
 from tpu_inference.spec_decode.jax.eagle3 import Eagle3Proposer
 from tpu_inference.spec_decode.jax.utils import (
     concat_last_sampled_tokens_and_draft_tokens, extend_logits_simple,
@@ -740,6 +741,8 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         if self.speculative_config:
             if self.speculative_config.method == "ngram":
                 self.drafter = NgramProposer(self.vllm_config)
+            elif self.speculative_config.method == "dflash":
+                self.drafter = DFlashProposer(self.vllm_config, self)
             elif self.speculative_config.use_eagle():
                 self.drafter = Eagle3Proposer(self.vllm_config, self)
             else:
@@ -918,6 +921,8 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                 logger.debug("Universal StepPooler pre-warming successful.")
 
             self.state = model.state
+            self.model = model.model
+            self.state_leaves = model.state_leaves
 
             if self.drafter is not None:
                 logger.info("Loading drafter model...")
@@ -931,9 +936,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         # tuple of array leaves and reconstructs the nnx.State inside the
         # jit. Pre-flatten here so subsequent dispatches skip the per-call
         # walk of `nnx.Variable` wrappers
-        self.state_leaves = model.state_leaves
         self.lora_manager = model.lora_manager
-        self.model = model.model
 
         self.precompile_vision_encoder_fn = model.multimodal_fns.precompile_vision_encoder_fn
         self.embed_multimodal_fn = model.multimodal_fns.embed_multimodal_fn
@@ -1376,11 +1379,13 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                 full_hidden_states,
                 lora_metadata,
             )
-            logits = self._select_from_array_fn(full_logits, logits_indices)
+            logits = self._select_from_array_fn(full_logits, logits_indices,
+                                                self.mesh)
         else:
             full_logits = None
             hidden_states = self._select_from_array_fn(hidden_states,
-                                                       logits_indices)
+                                                       logits_indices,
+                                                       self.mesh)
             logits = self.compute_logits_fn(
                 self.state_leaves,
                 hidden_states,
@@ -1743,7 +1748,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                 bonus_rng = step_rng
                 rejection_rng = step_rng
             bonus_logits = self._select_from_array_fn(
-                logits, spec_decode_metadata.bonus_logits_indices)
+                logits, spec_decode_metadata.bonus_logits_indices, self.mesh)
             bonus_token_ids, processed_bonus_logits = sample(
                 bonus_rng,
                 self.mesh,
@@ -1751,7 +1756,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                 tpu_sampling_metadata,
             )
             target_logits = self._select_from_array_fn(
-                logits, spec_decode_metadata.target_logits_indices)
+                logits, spec_decode_metadata.target_logits_indices, self.mesh)
             assert input_ids is not None
             draft_token_ids = self._extract_draft_token_ids(
                 input_ids, spec_decode_metadata.final_logits_indices,
@@ -1867,6 +1872,14 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                 spec_decode_last_sampled_token_id = last_sampled_token_id
                 spec_decode_num_rejected_tokens = num_rejected_tokens
 
+        spec_decode_next_tokens = None
+        if self.speculative_config and self.scheduler_config.async_scheduling:
+            assert spec_decode_last_sampled_token_id is not None
+            with self.maybe_forbid_compile, jax.set_mesh(self.mesh):
+                spec_decode_next_tokens = concat_last_sampled_tokens_and_draft_tokens(
+                    spec_decode_last_sampled_token_id,
+                    self.speculative_decoding_manager._draft_token_ids)
+
         # If async scheduler enabled
         if self.scheduler_config.async_scheduling:
             # Get previous results from TPU and replace the placeholder.
@@ -1879,14 +1892,6 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                     discard_sampled_tokens_req_indices, request_seq_lens,
                     scheduler_output, logits_indices_selector,
                     spec_decode_metadata)
-
-            spec_decode_next_tokens = None
-            if self.speculative_config:
-                assert spec_decode_last_sampled_token_id is not None
-                with self.maybe_forbid_compile, jax.set_mesh(self.mesh):
-                    spec_decode_next_tokens = concat_last_sampled_tokens_and_draft_tokens(
-                        spec_decode_last_sampled_token_id,
-                        self.speculative_decoding_manager._draft_token_ids)
 
             # Save the previous results
             next_tokens = jax.copy_to_host_async(next_tokens)
@@ -1996,15 +2001,16 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
 
         return model_runner_output
 
-    @jax.jit(static_argnums=(0, ))
-    def _select_from_array_fn(self, array, indices_to_select):
+    @staticmethod
+    @functools.partial(jax.jit, static_argnums=(2, ))
+    def _select_from_array_fn(array, indices_to_select, mesh):
 
         def select_local_fn(local_array, local_indices):
             return local_array[local_indices]
 
         ret = jax.shard_map(
             select_local_fn,
-            mesh=self.mesh,
+            mesh=mesh,
             in_specs=(PartitionSpec(ShardingAxisName.ATTN_DATA),
                       PartitionSpec(ShardingAxisName.ATTN_DATA)),
             out_specs=PartitionSpec(ShardingAxisName.ATTN_DATA))(


### PR DESCRIPTION
# Description

This PR integrates the `DFlashProposer` (speculator/proposer class) with the global paged KV cache mechanism, enabling stateless multi-request dynamic batching and proposer coordination.

**Why is this change being made?**
Previously, the DFlash speculator was stateful and tracked execution variables internally. Refactoring the proposer to be stateless allows the framework's page-level scheduler to handle all cache management, enabling continuous batching and multi-request speculator execution.

**Information about the specific implementation:**
* `tpu_inference/models/common/model_loader.py`: Registers `DFlashDraftModel` in the model registry.
* `tpu_inference/models/jax/qwen3.py`: Collects `aux_hidden_states` from target layers during the target model's forward pass, which are required by the DFlash proposer to inject target context into the draft model.
* `tpu_inference/runner/tpu_runner.py`: Configures the runner to initialize `DFlashProposer` when `method="dflash"`.
* `tpu_inference/runner/speculative_decoding_manager.py`: Implements the proposer dispatch logic and `propose_dflash_draft_token_ids` to coordinate draft generation using `accepted_attn_metadata` with correctly computed sequence lengths for the drafter.
* `tpu_inference/runner/kv_cache_manager.py`: Configures and extends draft KV cache allocation to support the DFlash drafter.

---

# Tests

Tested using the speculative decoding manager unit test suite.

Commands used to reproduce:
```bash
pytest tests/runner/test_speculative_decoding_manager.py.
```

Before submitting this PR, please make sure:

-  I have performed a self-review of my code.
-  I have necessary comments in my code, particularly in hard-to-understand areas.
-  I have made or will make corresponding changes to any relevant documentation.