### PR TITLE
feat: Add E2E tests and Buildkite CI integration for Dflash

### DIFF
--- a/.buildkite/features/Speculative_Decoding-_DFlash.yml
+++ b/.buildkite/features/Speculative_Decoding-_DFlash.yml
@@ -1,0 +1,65 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+steps:
+  - label: "${TPU_VERSION:-tpu6e} Correctness tests for Speculative Decoding: DFlash"
+    key: "${TPU_VERSION:-tpu6e}_Speculative_Decoding-_DFlash_CorrectnessTest"
+    soft_fail: true
+    agents:
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      TPU_VERSION: "${TPU_VERSION:-tpu6e}"
+    commands:
+      - |
+        .buildkite/scripts/run_in_docker.sh \
+          python3 -m pytest -s -v /workspace/tpu_inference/tests/e2e/test_speculative_decoding.py::test_dflash_correctness
+  - label: "${TPU_VERSION:-tpu6e} Record correctness test result for Speculative Decoding: DFlash"
+    key: "${TPU_VERSION:-tpu6e}_record_Speculative_Decoding-_DFlash_CorrectnessTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_Speculative_Decoding-_DFlash_CorrectnessTest"
+    env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
+      CI_TARGET: "Speculative Decoding: DFlash"
+      CI_STAGE: "CorrectnessTest"
+      CI_CATEGORY: "feature support matrix"
+    agents:
+      queue: cpu
+    commands:
+      - |
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_Speculative_Decoding-_DFlash_CorrectnessTest
+
+  - label: "${TPU_VERSION:-tpu6e} Performance tests for Speculative Decoding: DFlash"
+    key: "${TPU_VERSION:-tpu6e}_Speculative_Decoding-_DFlash_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_record_Speculative_Decoding-_DFlash_CorrectnessTest"
+    soft_fail: true
+    agents:
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      TPU_VERSION: "${TPU_VERSION:-tpu6e}"
+    commands:
+      - |
+        .buildkite/scripts/run_in_docker.sh \
+          python3 -m pytest -s -v /workspace/tpu_inference/tests/e2e/test_speculative_decoding.py::test_dflash_performance
+  - label: "${TPU_VERSION:-tpu6e} Record performance test result for Speculative Decoding: DFlash"
+    key: "${TPU_VERSION:-tpu6e}_record_Speculative_Decoding-_DFlash_PerformanceTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_Speculative_Decoding-_DFlash_PerformanceTest"
+    env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
+      CI_TARGET: "Speculative Decoding: DFlash"
+      CI_STAGE: "PerformanceTest"
+      CI_CATEGORY: "feature support matrix"
+    agents:
+      queue: cpu
+    commands:
+      - |
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_Speculative_Decoding-_DFlash_PerformanceTest

--- a/tests/e2e/test_speculative_decoding.py
+++ b/tests/e2e/test_speculative_decoding.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -78,7 +78,8 @@ def get_eagle3_test_prompts():
 def get_test_prompts(speculative_config: dict):
     if speculative_config['method'] == 'ngram':
         return get_ngram_test_prompts()
-    elif speculative_config['method'] in ('eagle3', 'qwen3_next_mtp', 'mtp'):
+    elif speculative_config['method'] in ('eagle3', 'qwen3_next_mtp', 'mtp',
+                                          'dflash'):
         return get_eagle3_test_prompts()
     else:
         raise NotImplementedError(
@@ -505,6 +506,105 @@ def test_eagle3_performance(
             "draft_tensor_parallel_size": 1
         },
         min_acceptance_rate=0.75,
+        max_num_seqs=max_num_seqs,
+        async_scheduling=async_scheduling,
+        enable_dp_attention=enable_dp_attention,
+        model_name='meta-llama/Llama-3.1-8B-Instruct')
+
+
+@pytest.fixture(scope="module")
+def dflash_baseline():
+    """Compute the DFlash reference prompts and baseline outputs once."""
+    model_name = 'meta-llama/Llama-3.1-8B-Instruct'
+    sampling_config = SamplingParams(temperature=0,
+                                     max_tokens=32,
+                                     ignore_eos=True,
+                                     repetition_penalty=1,
+                                     frequency_penalty=0,
+                                     presence_penalty=0,
+                                     min_p=0,
+                                     logprobs=None)
+    test_prompts = get_eagle3_test_prompts()
+    with pytest.MonkeyPatch.context() as mp:
+        ref_outputs = _get_baseline_results(mp,
+                                            sampling_config,
+                                            model_name,
+                                            test_prompts,
+                                            max_num_seqs=10)
+    return test_prompts, ref_outputs
+
+
+@pytest.mark.parametrize(
+    "async_scheduling, enable_dp_attention",
+    [
+        pytest.param(False, False, marks=pytest.mark.bvt),
+        (False, True),
+        (True, False),
+        pytest.param(True, True, marks=pytest.mark.bvt),
+    ],
+)
+def test_dflash_correctness(
+    monkeypatch: pytest.MonkeyPatch,
+    sampling_config: SamplingParams,
+    async_scheduling: bool,
+    enable_dp_attention: bool,
+    dflash_baseline: tuple,
+):
+    """Compare the outputs of a original LLM and a speculative LLM.
+
+    Should be the same when using DFlash speculative decoding.
+    """
+    model_name = 'meta-llama/Llama-3.1-8B-Instruct'
+
+    model_impl = os.environ.get("MODEL_IMPL_TYPE", "flax_nnx")
+    monkeypatch.setenv("MODEL_IMPL_TYPE", model_impl)
+    monkeypatch.setenv("DRAFT_MODEL_IMPL_TYPE", model_impl)
+
+    speculative_config = {
+        'model': "z-lab/LLaMA3.1-8B-Instruct-DFlash-UltraChat",
+        "num_speculative_tokens": 9,
+        "method": "dflash",
+        "draft_tensor_parallel_size": 1
+    }
+    test_prompts, ref_outputs = dflash_baseline
+
+    _test_correctness_helper(monkeypatch,
+                             sampling_config,
+                             model_name,
+                             speculative_config,
+                             test_prompts,
+                             ref_outputs=ref_outputs,
+                             max_num_seqs=10,
+                             async_scheduling=async_scheduling,
+                             enable_dp_attention=enable_dp_attention)
+
+
+@pytest.mark.parametrize(
+    "max_num_seqs,async_scheduling, enable_dp_attention",
+    [(1, False, False), (20, True, False),
+     pytest.param(20, True, True, marks=pytest.mark.bvt)],
+)
+def test_dflash_performance(
+    monkeypatch: pytest.MonkeyPatch,
+    sampling_config: SamplingParams,
+    max_num_seqs: int,
+    async_scheduling: bool,
+    enable_dp_attention: bool,
+):
+    """Test that DFlash speculative decoding achieves the expected acceptance rate."""
+    model_impl = os.environ.get("MODEL_IMPL_TYPE", "flax_nnx")
+    monkeypatch.setenv("MODEL_IMPL_TYPE", model_impl)
+    monkeypatch.setenv("DRAFT_MODEL_IMPL_TYPE", model_impl)
+
+    _test_performance_helper(
+        monkeypatch,
+        sampling_config, {
+            "method": "dflash",
+            "model": "z-lab/LLaMA3.1-8B-Instruct-DFlash-UltraChat",
+            "num_speculative_tokens": 9,
+            "draft_tensor_parallel_size": 1
+        },
+        min_acceptance_rate=0.30,
         max_num_seqs=max_num_seqs,
         async_scheduling=async_scheduling,
         enable_dp_attention=enable_dp_attention,

--- a/tests/e2e/test_speculative_decoding.py
+++ b/tests/e2e/test_speculative_decoding.py
@@ -526,11 +526,13 @@ def dflash_baseline():
                                      logprobs=None)
     test_prompts = get_eagle3_test_prompts()
     with pytest.MonkeyPatch.context() as mp:
-        ref_outputs = _get_baseline_results(mp,
-                                            sampling_config,
-                                            model_name,
-                                            test_prompts,
-                                            max_num_seqs=10)
+        ref_outputs = _get_baseline_results(
+            mp,
+            sampling_config,
+            model_name,
+            test_prompts,
+            max_num_seqs=10,
+            extra_kwargs={"gpu_memory_utilization": 0.85})
     return test_prompts, ref_outputs
 
 
@@ -576,7 +578,8 @@ def test_dflash_correctness(
                              ref_outputs=ref_outputs,
                              max_num_seqs=10,
                              async_scheduling=async_scheduling,
-                             enable_dp_attention=enable_dp_attention)
+                             enable_dp_attention=enable_dp_attention,
+                             extra_kwargs={"gpu_memory_utilization": 0.85})
 
 
 @pytest.mark.parametrize(
@@ -604,11 +607,12 @@ def test_dflash_performance(
             "num_speculative_tokens": 9,
             "draft_tensor_parallel_size": 1
         },
-        min_acceptance_rate=0.30,
+        min_acceptance_rate=0.40,
         max_num_seqs=max_num_seqs,
         async_scheduling=async_scheduling,
         enable_dp_attention=enable_dp_attention,
-        model_name='meta-llama/Llama-3.1-8B-Instruct')
+        model_name='meta-llama/Llama-3.1-8B-Instruct',
+        extra_kwargs={"gpu_memory_utilization": 0.85})
 
 
 @pytest.fixture(scope="module")

--- a/tests/e2e/test_speculative_decoding.py
+++ b/tests/e2e/test_speculative_decoding.py
@@ -540,9 +540,7 @@ def dflash_baseline():
     "async_scheduling, enable_dp_attention",
     [
         pytest.param(False, False, marks=pytest.mark.bvt),
-        (False, True),
         (True, False),
-        pytest.param(True, True, marks=pytest.mark.bvt),
     ],
 )
 def test_dflash_correctness(
@@ -584,8 +582,8 @@ def test_dflash_correctness(
 
 @pytest.mark.parametrize(
     "max_num_seqs,async_scheduling, enable_dp_attention",
-    [(1, False, False), (20, True, False),
-     pytest.param(20, True, True, marks=pytest.mark.bvt)],
+    [(1, False, False),
+     pytest.param(20, True, False, marks=pytest.mark.bvt)],
 )
 def test_dflash_performance(
     monkeypatch: pytest.MonkeyPatch,

--- a/tpu_inference/spec_decode/jax/dflash.py
+++ b/tpu_inference/spec_decode/jax/dflash.py
@@ -81,6 +81,10 @@ class DFlashProposer:
 
         self.runner = runner
         self.mesh = runner.mesh
+        if self.mesh.shape.get(ShardingAxisName.ATTN_DATA, 1) > 1:
+            raise NotImplementedError(
+                "DFlash currently does not support Data Parallelism (DP) attention "
+                "(ATTN_DATA > 1).")
         self.num_speculative_tokens = (
             self.speculative_config.num_speculative_tokens)
 


### PR DESCRIPTION
# Description

This PR adds end-to-end (E2E) correctness and performance tests for DFlash speculative decoding on JAX TPUs, alongside the Buildkite CI feature configuration.

**Why is this change being made?**
To verify the functional correctness and capture performance acceptance metrics for JAX DFlash speculative decoding, ensuring that future updates do not regress the implementation.

---

# Tests

Tested end-to-end on TPU platforms to verify correct token matching and performance characteristics.

Commands used to reproduce:
```bash
pytest tests/e2e/test_speculative_decoding.py -k dflash -s -v
```

Before submitting this PR, please make sure:

 I have performed a self-review of my code.
 I have necessary comments in my code, particularly in hard-to-understand areas.
 I have made or will make corresponding changes to any relevant documentation.