### PR TITLE
[Test][Jax] Fix flaky Qwen3-MoE weight-loading memory test on tpu6e

### DIFF
--- a/tests/models/jax/test_qwen3_moe.py
+++ b/tests/models/jax/test_qwen3_moe.py
@@ -88,11 +88,19 @@ class TestQwen3MoeForCausalLM:
             loader = get_model_loader(vllm_config.load_config)
             # Monitor device memory during weight loading to catch
             # regressions.
+            # The 4GB floor is sized off the observed load-time transient.
+            # On tpu6e the heaviest pp shard (pp_rank=3, world=4) peaks at a
+            # ~3.00GB delta during MoE expert-weight processing, so a 3GB
+            # floor left zero headroom and flaked (peak_delta=3.000 GB >
+            # max=3.000 GB) on sub-MB run-to-run allocation jitter while
+            # still passing on tpu7x. 4GB gives ~1GB (~33%) headroom over the
+            # real transient and still catches a gross regression (e.g.
+            # holding the weights twice).
             with assert_weight_loading_memory_bounded(
                     model,
                     description=f"load_weights({model_name})",
                     threshold_multiplier=0.3,
-                    min_threshold_bytes=3 *
+                    min_threshold_bytes=4 *
                     GBYTES), set_current_vllm_config(vllm_config):
                 loader.load_weights(model, model_config)
 


### PR DESCRIPTION
## Summary

`tests/models/jax/test_qwen3_moe.py::TestQwen3MoeForCausalLM::test_model_loading[Qwen/Qwen3-30B-A3B-Instruct-2507-3-4-skip_layers_model_loader_for_test]` is flaky on **tpu6e** (the `JAX unit tests part2` step), failing with:

```
Peak device memory during load_weights(Qwen/Qwen3-30B-A3B-Instruct-2507) exceeded threshold:
peak_delta=3.000 GB > max=3.000 GB
```

## Root cause — proven by commit-vs-parent A/B (not inferred)

The flake was introduced by #2974 ("Remove `jax.clear_caches()` from `assign_and_shard_param`"). Proven by running the **full `part2` suite 10× on v6e** (recreating the device pre-occupancy from prior model loads) at #2974 vs its parent, with the **same vLLM LKG** on both so #2974 is the only variable:

| Commit | qwen3moe `3-4-skip_layers` over 10 runs | flake rate | proving run |
|---|---|---|---|
| `455f99882` (with #2974) | **3 FAIL / 7 PASS** (`peak_delta=3.000 > max=3.000`, `before=11.695 GB`) | 30% | https://buildkite.com/tpu-commons/tpu-inference-dev/builds/590 |
| `455f99882^` (parent) | **10 PASS / 0 FAIL** | 0% | https://buildkite.com/tpu-commons/tpu-inference-dev/builds/591 |

The parent passes 10/10 even though its floor is the *tighter* 2 GB default — so its load transient is comfortably under 2 GB. #2974 moved `clear_caches()` out of the per-param loop (a deliberate load-speed win), which raised the weight-loading transient by ~1 GB to **~3.0 GB**. #2974 bumped the test floor 2 GB → 3 GB to compensate but under-shot, leaving the transient sitting exactly on the line → sub-MB run-to-run jitter flips pass/fail on tpu6e (tpu7x lands just under).

This is a genuine (and intended) memory/speed tradeoff that landed at the threshold, not a measurement artifact — so the right fix is to give the floor real margin above the true ~3 GB transient, not to revert #2974's optimization.

## Fix

Raise `min_threshold_bytes` 3 GB → **4 GB**: ~1 GB (~33%) headroom over the observed ~3.0 GB transient, while still catching a gross regression (e.g. holding the weights twice).

## Verification

Same 10× full-`part2` v6e harness (recreating the device pre-occupancy), run at this branch with the 4 GB floor: **10/10 PASS** on `test_model_loading[...-3-4-skip_layers...]` — the same configuration that flaked 3/10 with the 3 GB floor (see A/B above). The fix holds.

Verification run: https://buildkite.com/tpu-commons/tpu-inference-dev/builds/592

## Testing

- One-line threshold change in test config; no production code touched.
- Pre-commit hooks pass.
