### PR TITLE
Complete the raiden kv cache manager import path

### DIFF
--- a/tpu_inference/distributed/tpu_raiden_connector.py
+++ b/tpu_inference/distributed/tpu_raiden_connector.py
@@ -81,7 +81,7 @@ if TYPE_CHECKING:
     from vllm.v1.request import Request
 
 try:
-    from api.jax.kv_cache_manager import KVCacheManager as KVCacheManager
+    from tpu_raiden.api.jax.kv_cache_manager import KVCacheManager as KVCacheManager
     _RAIDEN_IMPORT_ERROR = None
 except Exception as _exc:  # pylint: disable=broad-except
     KVCacheManager = None
@@ -494,8 +494,8 @@ class TPUConnectorWorker:
     def register_runner(self, runner: TPUModelRunner):
         if KVCacheManager is None:
             raise ImportError(
-                "KVCacheManager is not importable. Add the tpu-raiden "
-                "export to PYTHONPATH so 'api.jax.kv_cache_manager' resolves "
+                "KVCacheManager is not importable. Ensure tpu-raiden is correctly "
+                "installed or added to PYTHONPATH so 'tpu_raiden.api.jax.kv_cache_manager' resolves "
                 "(and set RAIDEN_PRELOAD_ENGINE=1 so sitecustomize.py preloads "
                 f"the kv_cache_manager .so first). Original error: {_RAIDEN_IMPORT_ERROR}"
             )

--- a/tpu_inference/distributed/tpu_raiden_connector.py
+++ b/tpu_inference/distributed/tpu_raiden_connector.py
@@ -81,8 +81,7 @@ if TYPE_CHECKING:
     from vllm.v1.request import Request
 
 try:
-    from tpu_raiden.api.jax.kv_cache_manager import \
-        KVCacheManager as KVCacheManager
+    from tpu_raiden.api.jax.kv_cache_manager import KVCacheManager
     _RAIDEN_IMPORT_ERROR = None
 except Exception as _exc:  # pylint: disable=broad-except
     KVCacheManager = None

--- a/tpu_inference/distributed/tpu_raiden_connector.py
+++ b/tpu_inference/distributed/tpu_raiden_connector.py
@@ -81,7 +81,8 @@ if TYPE_CHECKING:
     from vllm.v1.request import Request
 
 try:
-    from tpu_raiden.api.jax.kv_cache_manager import KVCacheManager as KVCacheManager
+    from tpu_raiden.api.jax.kv_cache_manager import \
+        KVCacheManager as KVCacheManager
     _RAIDEN_IMPORT_ERROR = None
 except Exception as _exc:  # pylint: disable=broad-except
     KVCacheManager = None


### PR DESCRIPTION
[Feat][Disagg] Standardize tpu_raiden package imports to prevent ModuleNotFoundError 

### Description

Currently,  `tpu_raiden_connector.py`  imports  KVCacheManager  via a non-standard top-level import:

```
from api.jax.kv_cache_manager import KVCacheManager
```

This import style was introduced in the initial integration as a quick development setup. When testing locally from source and checkout on TPU VMs, we are expected to add the nested package directory (tpu-raiden/tpu_raiden/) directly to the PYTHONPATH . This allowed `api` to resolve as a top-level module in Python.

However, this breaks standard packaging. Once  `tpu-raiden`  is packaged and installed as a standard python wheel (e.g.  pip install tpu-raiden-jax ), all of its modules are namespaced under `tpu_raiden/` in  site-packages . Keeping the old import results in a fatal  `ModuleNotFoundError`

### How to Setup / Install Local Environment

  • Wheel Installation (Soon): Simply run  pip install tpu-raiden-jax . No  PYTHONPATH  hacks are required.
  • Build-from-Source (Now): Run  `./build.sh jax`  inside  tpu-raiden  repository, and export the repository root to  PYTHONPATH  (without nesting into the  tpu_raiden/  subdirectory):

```
export PYTHONPATH="/path/to/tpu-raiden:${PYTHONPATH:-}"
```
### Test

Verified by building  tpu-raiden  from source(via ./build), configuring the  PYTHONPATH  to point to the repository root, and running the connector import check inside the virtual environment:

```
# Run import verification
python -c "import tpu_inference.distributed.tpu_raiden_connector"
```

No ModuleNotFoundError  is raised. The import resolves the namespaces successfully and proceeds to runtime initialization, where it currently `aborts with  free(): invalid pointer` as expected due to the unhandled bugs at the HEAD of tpu-raiden.
