### PR TITLE
Support advanced JAX Profiler options passed via profile_prefix in vLLM

### DIFF
--- a/docs/profiling.md
+++ b/docs/profiling.md
@@ -103,3 +103,26 @@ In order to use this approach, you can do the following:
 5. Click `Capture Profile` and, in the `Profile Service URL(s) or TPU name` box, enter `localhost:XXXX` where `XXXX` is your `JAX_PROFILER_SERVER_PORT` (default is `9999`)
 
 6. Enter the desired amount of time (in ms)
+
+## Configuring Profiler Options
+
+Users can customize the JAX profiler settings by passing a configuration string via the `profile_prefix` parameter from upstream.
+
+### Syntax Format
+
+Options are specified as a semicolon-separated string of key:value pairs:
+
+* **Key-Value Separator**: A colon (`:`) must be used to separate keys and values (e.g. `host_tracer_level:3`). Using `=` (e.g. `host_tracer_level=3`) will raise a `ValueError`.
+* **Types**:
+  * Values matching `true` or `false` (case-insensitive) are parsed as Python booleans.
+  * Integer values are parsed as Python `int`.
+  * Other values are parsed as strings.
+* **Validation & Safety Rules**:
+  * Only ASCII characters are allowed.
+  * Option values can only contain safe alphanumeric and basic special characters (`^[a-zA-Z0-9_./,:-]*$`). Using quotes, backslashes, or other special characters will fail validation.
+
+### Options Mapping
+
+* **Standard JAX Options**: Option keys matching standard JAX general options (such as `host_tracer_level`, `device_tracer_level`, or `python_tracer_level`) are set directly on the JAX `ProfileOptions` object. For more details, refer to the [General options in JAX Profiling Documentation](https://docs.jax.dev/en/latest/profiling.html#general-options).
+* **Advanced & Experimental Options**: Any other custom keys (such as `tpu_power_trace_level`, `tpu_perf_counters`, etc.) are forwarded directly to JAX's `advanced_configuration` dictionary. For more details, refer to the [Advanced options in JAX Profiling Documentation](https://docs.jax.dev/en/latest/profiling.html#advanced-configuration-options).
+  * By default, strict validation of experimental options is enabled (`check_experimental_options:true`). If an unrecognized configuration key is passed, JAX/libtpu will raise a runtime initialization error. You can disable this strict check by passing `check_experimental_options:false` in the `profile_prefix` string.

--- a/tests/worker/tpu_worker_test.py
+++ b/tests/worker/tpu_worker_test.py
@@ -420,16 +420,21 @@ class TestTPUWorker:
     # --- Profiling and Health Check Tests ---
     #
 
-    @patch('tpu_inference.worker.tpu_worker.jax')
-    @patch.dict('os.environ', {"PYTHON_TRACER_LEVEL": "1"}, clear=True)
-    def test_profile_start(self, mock_jax, mock_vllm_config):
-        """Tests starting the JAX profiler."""
+    def _create_worker(self,
+                       mock_vllm_config,
+                       profile_dir="/tmp/profile_dir") -> TPUWorker:
         worker = TPUWorker(vllm_config=mock_vllm_config,
                            local_rank=0,
                            rank=0,
                            distributed_init_method="test")
-        worker.profile_dir = "/tmp/profile_dir"
+        worker.profile_dir = profile_dir
+        return worker
 
+    @patch('tpu_inference.worker.tpu_worker.jax')
+    @patch.dict('os.environ', {"PYTHON_TRACER_LEVEL": "1"}, clear=True)
+    def test_profile_start(self, mock_jax, mock_vllm_config):
+        """Tests starting the JAX profiler."""
+        worker = self._create_worker(mock_vllm_config)
         worker.profile(is_start=True)
 
         mock_jax.profiler.ProfileOptions.assert_called_once()
@@ -440,21 +445,110 @@ class TestTPUWorker:
         assert kwargs['profiler_options'].python_tracer_level == 1
 
     @patch('tpu_inference.worker.tpu_worker.jax')
+    def test_profile_with_prefix_options(self, mock_jax, mock_vllm_config):
+        """Tests that profile_prefix options are correctly parsed and applied."""
+        worker = self._create_worker(mock_vllm_config)
+
+        mock_options = MagicMock()
+        mock_options.advanced_configuration = {}
+        mock_jax.profiler.ProfileOptions.return_value = mock_options
+
+        prefix = ("host_tracer_level:3;tpu_power_trace_level:2;"
+                  "tpu_perf_counters:true;enable_hlo_proto:false")
+        worker.profile(is_start=True, profile_prefix=prefix)
+
+        assert mock_options.host_tracer_level == 3
+        assert mock_options.advanced_configuration == {
+            "check_experimental_options": True,
+            "tpu_power_trace_level": 2,
+            "tpu_perf_counters": True,
+            "enable_hlo_proto": False,
+        }
+
+    @patch('tpu_inference.worker.tpu_worker.jax')
+    def test_profile_with_prefix_complex_options(self, mock_jax,
+                                                 mock_vllm_config):
+        """Tests that advanced options with commas (sub-lists) and colons are correctly parsed."""
+        worker = self._create_worker(mock_vllm_config)
+
+        mock_options = MagicMock()
+        mock_options.advanced_configuration = {}
+        mock_jax.profiler.ProfileOptions.return_value = mock_options
+
+        prefix = ("host_tracer_level:2;"
+                  "tpu_cpu_perf_counter_profile_events:event1,event2;"
+                  "tpu_cpu_perf_counter_configs:101:3:cpu_event")
+        worker.profile(is_start=True, profile_prefix=prefix)
+
+        assert mock_options.host_tracer_level == 2
+        assert mock_options.advanced_configuration == {
+            "check_experimental_options": True,
+            "tpu_cpu_perf_counter_profile_events": "event1,event2",
+            "tpu_cpu_perf_counter_configs": "101:3:cpu_event",
+        }
+
+    @patch('tpu_inference.worker.tpu_worker.jax')
+    def test_profile_with_prefix_options_invalid(self, mock_jax,
+                                                 mock_vllm_config):
+        """Tests that invalid options (e.g. containing special characters) throw ValueError."""
+        worker = self._create_worker(mock_vllm_config)
+
+        prefix = "invalid_opt:\"bad_val\""
+        with pytest.raises(ValueError,
+                           match="Invalid characters in option value"):
+            worker.profile(is_start=True, profile_prefix=prefix)
+
+    @patch('tpu_inference.worker.tpu_worker.jax')
+    def test_profile_with_prefix_options_malformed(self, mock_jax,
+                                                   mock_vllm_config):
+        """Tests that malformed options (without colons) throw ValueError."""
+        worker = self._create_worker(mock_vllm_config)
+
+        prefix = "host_tracer_level=5;another_option"
+        with pytest.raises(ValueError, match="Expected 'key:value' format"):
+            worker.profile(is_start=True, profile_prefix=prefix)
+
+    @patch('tpu_inference.worker.tpu_worker.jax')
+    def test_profile_with_prefix_options_non_ascii(self, mock_jax,
+                                                   mock_vllm_config):
+        """Tests that profile_prefix containing non-ascii characters throws ValueError."""
+        worker = self._create_worker(mock_vllm_config)
+
+        prefix = "host_tracer_level:3;test_option:🌟"
+        with pytest.raises(
+                ValueError,
+                match="profile_prefix contains non-ASCII characters"):
+            worker.profile(is_start=True, profile_prefix=prefix)
+
+    @patch('tpu_inference.worker.tpu_worker.jax')
+    def test_profile_with_prefix_options_empty_parts(self, mock_jax,
+                                                     mock_vllm_config):
+        """Tests that empty parts and extra semicolons are ignored gracefully."""
+        worker = self._create_worker(mock_vllm_config)
+
+        mock_options = MagicMock()
+        mock_options.advanced_configuration = {}
+        mock_jax.profiler.ProfileOptions.return_value = mock_options
+
+        prefix = "host_tracer_level:3;;tpu_power_trace_level:2;"
+        worker.profile(is_start=True, profile_prefix=prefix)
+
+        assert mock_options.host_tracer_level == 3
+        assert mock_options.advanced_configuration == {
+            "check_experimental_options": True,
+            "tpu_power_trace_level": 2,
+        }
+
+    @patch('tpu_inference.worker.tpu_worker.jax')
     def test_profile_stop(self, mock_jax, mock_vllm_config):
         """Tests stopping the JAX profiler."""
-        worker = TPUWorker(vllm_config=mock_vllm_config,
-                           local_rank=0,
-                           rank=0,
-                           distributed_init_method="test")
+        worker = self._create_worker(mock_vllm_config)
         worker.profile(is_start=False)
         mock_jax.profiler.stop_trace.assert_called_once()
 
     def test_check_health(self, mock_vllm_config):
         """Tests that check_health runs without error."""
-        worker = TPUWorker(vllm_config=mock_vllm_config,
-                           local_rank=0,
-                           rank=0,
-                           distributed_init_method="test")
+        worker = self._create_worker(mock_vllm_config)
         try:
             worker.check_health()
         except Exception as e:
@@ -476,10 +570,7 @@ class TestTPUWorker:
                                         runner_method_name, method_args,
                                         mock_vllm_config):
         """Tests methods that are simple pass-throughs to the TPUModelRunner."""
-        worker = TPUWorker(vllm_config=mock_vllm_config,
-                           local_rank=0,
-                           rank=0,
-                           distributed_init_method="test")
+        worker = self._create_worker(mock_vllm_config)
         worker.model_runner = MagicMock()
 
         # Call the worker method and assert the underlying runner method was called

--- a/tpu_inference/worker/tpu_worker.py
+++ b/tpu_inference/worker/tpu_worker.py
@@ -2,6 +2,7 @@
 
 import math
 import os
+import re
 import tempfile
 from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, Optional, Tuple
@@ -87,6 +88,92 @@ class PPConfig:
 
                 # Set bounds to match the visible chips exactly.
                 self.default_tpu_chips_per_process_bounds = f"1,{chips_per_stage},1"
+
+
+_STANDARD_KEYS = frozenset({
+    "host_tracer_level",
+    "device_tracer_level",
+    "python_tracer_level",
+})
+
+_ALLOWED_VALUE_CHARS = re.compile(r'^[a-zA-Z0-9_./,:-]*$')
+_OPTION_PATTERN = re.compile(r'^([a-zA-Z_][a-zA-Z0-9_]*)\s*:\s*(.+)$')
+
+
+def _parse_option_value(key: str, val: str) -> Any:
+    """Parses and infers the type of an option value string.
+
+    Tries to parse the value as a boolean (true/false) or integer. If those fail,
+    verifies that the string contains only safe whitelisted characters and returns
+    it as-is.
+    """
+    val_lower = val.lower()
+    if val_lower == "true":
+        return True
+    if val_lower == "false":
+        return False
+    try:
+        return int(val)
+    except ValueError:
+        if not _ALLOWED_VALUE_CHARS.match(val):
+            raise ValueError(f"Invalid characters in option value '{val}' "
+                             f"for key '{key}'")
+        return val
+
+
+def _parse_profile_options(
+        profile_prefix: Optional[str]
+) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+    """Parses profile options from a semicolon-separated profile_prefix string.
+
+    This function extracts profiling parameters from the provided profile_prefix
+    string and splits them into standard options (which map directly to native
+    jax.profiler.ProfileOptions attributes) and advanced/custom options
+    (which map to JAX's advanced_configuration dictionary).
+
+    Args:
+        profile_prefix: A semicolon-separated string of key-value pairs.
+          E.g., "host_tracer_level:3;tpu_num_chips_to_profile_per_task:2;my_custom_option:true"
+
+    Returns:
+        A tuple containing two dictionaries:
+          1. standard_opts: Dictionaries of parsed option keys and their typed
+             values (e.g. bool, int, or str) that match standard JAX options
+             (host_tracer_level, device_tracer_level, python_tracer_level).
+          2. advanced_opts: Dictionaries of parsed custom option keys and their
+             typed values to be passed to JAX's advanced_configuration dictionary.
+          E.g., ({"host_tracer_level": 3}, {"tpu_num_chips_to_profile_per_task": 2, "my_custom_option": True})
+    """
+    if not profile_prefix or not profile_prefix.strip():
+        return {}, {}
+
+    if not profile_prefix.isascii():
+        raise ValueError("profile_prefix contains non-ASCII characters")
+
+    standard_opts = {}
+    advanced_opts = {}
+
+    parts = profile_prefix.split(';')
+
+    for part in parts:
+        part = part.strip()
+        if not part:
+            continue
+        match = _OPTION_PATTERN.match(part)
+        if not match:
+            raise ValueError(f"Invalid profile option format in '{part}'. "
+                             "Expected 'key:value' format.")
+        key = match.group(1)
+        val = match.group(2)
+
+        parsed_val = _parse_option_value(key, val)
+
+        if key in _STANDARD_KEYS:
+            standard_opts[key] = parsed_val
+        else:
+            advanced_opts[key] = parsed_val
+
+    return standard_opts, advanced_opts
 
 
 class TPUWorker(WorkerBase):
@@ -535,15 +622,35 @@ class TPUWorker(WorkerBase):
                 is_start: bool = True,
                 profile_prefix: str | None = None):
         if is_start:
+            standard_opts, advanced_opts = _parse_profile_options(
+                profile_prefix)
             options = jax.profiler.ProfileOptions()
             # default: https://docs.jax.dev/en/latest/profiling.html#general-options
             options.python_tracer_level = envs.PYTHON_TRACER_LEVEL
+
+            # Enable strict validation of experimental options by default. If an
+            # unrecognized configuration is passed, JAX/libtpu will raise a
+            # runtime initialization error instead of silently ignoring it.
+            # Users can opt-out by passing 'check_experimental_options:false'.
+            advanced_config = {
+                "check_experimental_options": True,
+            }
             if envs.PROFILE_SINGLE_DEVICE:
-                options.advanced_configuration = {
+                advanced_config.update({
                     "tpu_num_chips_to_profile_per_task": 1,
                     "tpu_num_sparse_cores_to_trace": 1,
                     "tpu_num_sparse_core_tiles_to_trace": 1,
-                }
+                })
+
+            # Override with parsed options
+            for key, val in standard_opts.items():
+                if hasattr(options, key):
+                    setattr(options, key, val)
+
+            advanced_config.update(advanced_opts)
+            if advanced_config:
+                options.advanced_configuration = advanced_config
+
             jax.profiler.start_trace(self.profile_dir,
                                      profiler_options=options)
         else:


### PR DESCRIPTION
Signed-off-by: Mudit Gokhale <muditgokhale@google.com>

Support advanced JAX Profiler options passed via profile_prefix in vLLM

### Description
Currently, vLLM on TPU only supports starting and stopping profiler traces without custom options, or relies entirely on static environment variables. This limits user control over profiling detail (e.g., host vs device levels) and prevents passing advanced accelerator flags. This PR implements dynamic parsing and mapping of advanced profiler options passed via the `profile_prefix` string in `TPUWorker.profile()`.

**Why do we need this?**
Profiling options are needed to enable advanced profiling knobs.

**Why is this a good solution?**
It provides an interface consistent with existing PyTorch profiling patterns while remaining flexible enough to pass arbitrary experimental JAX/compiler config variables directly to `libtpu`. It avoids hardcoding option keys, enabling users to immediately leverage new compiler options.

**Implementation Details:**
1. Parsing Algorithm:
- The parser splits the semicolon-separated (`;`) prefix string into individual configuration parts to avoid delimiter collisions with options containing inner commas or colons (e.g. lists).
- Each part is stripped of surrounding whitespace and matched against a strict regex pattern: `^([a-zA-Z_][a-zA-Z0-9_]*)\s*:\s*(.+)$`
- Keys matching the pattern are categorized as standard options if they are present in the stable keys set `_STANDARD_KEYS` (`host_tracer_level`, `device_tracer_level`, `python_tracer_level`) and are mapped directly as attributes on JAX's `ProfileOptions` class.
- All other keys are categorized as experimental options and are added directly to JAX's `advanced_configuration` dictionary.
- The parser infers value types: `true`/`false` (case-insensitive) are mapped to Python booleans, integers are parsed as `int`s, and all other strings are retained. String values are strictly validated against a safe whitelist pattern (`^[a-zA-Z0-9_./,:-]*$`) to prevent injection vulnerabilities.

2. Rules for prefix strings:
- Must contain only ASCII characters.
- Must be formatted as semicolon-separated key-value pairs where key and value are separated by a colon, e.g., `host_tracer_level:3;tpu_num_chips_to_profile_per_task:2;my_custom_option:true`
- Option values can contain inner commas or colons (e.g., lists of configs), which are preserved.
- Refer to the OpenXLA XProf documentation for the list of supported advanced profiling options: https://github.com/openxla/xprof/blob/master/docs/advanced_profiler_options.md

3. Invalid Case Handling and Errors:
- Non-ASCII inputs: Raises a `ValueError` if any non-ASCII characters are detected.
- Syntax / Colon-less strings (e.g., missing delimiter or using `=`): Raises a `ValueError` stating the invalid format.
- Unsafe characters: Raises a `ValueError` if an option value contains characters outside the safe whitelist.
- Unknown / Unrecognized Experimental Flags: Set `check_experimental_options` to `True` by default in the advanced configuration. This causes JAX/libtpu backend to fail with a runtime initialization error (rather than silently ignoring them) if a key is not recognized. Users can opt-out of this strict check by explicitly passing `check_experimental_options:false`.

4. Test Setup Refactoring:
- Factored out the initialization of `TPUWorker` test instances into a shared private helper method `_create_worker()` in `tests/worker/tpu_worker_test.py` to reduce code duplication across the unit test suite, addressing code review feedback.

### Tests
Tested this change using two approaches:
1. Unit Tests: Added a comprehensive test suite in `tests/worker/tpu_worker_test.py` covering:
   - Default tracer startup/shutdown behaviour.
   - Parsing of standard `ProfileOptions`.
   - Parsing of advanced custom options (with commas and colons).
   - Malformed/invalid configuration handling (invalid symbols, non-ASCII inputs, colon-less segments).
   Run commands:
   `pytest tests/worker/tpu_worker_test.py`

2. Physical Hardware Validation: Successfully ran JAX-native Qwen2.5-0.5B model on physical TPU v6e-4 VM (tensor_parallel_size=2) and collected traces using custom JAX options. Verified that host metadata (`*.trace.json.gz`) and accelerator hardware traces (`*.xplane.pb`) were generated successfully.
   - Specifically verified that passing custom firmware throttling and power events dynamically via `profile_prefix`:
     `e2e_enable_fw_throttle_event:true;e2e_enable_fw_power_level_event:true;e2e_enable_fw_thermal_event:true`
     successfully captures the HLO/timeline execution trace.

   **Xprof snipit:**
   https://screenshot.googleplex.com/8iSboAJzFWoXY7y

Signed-off-by: Mudit Gokhale <muditgokhale@google.com>

