### PR TITLE
Add condition before checking mamba slots

### DIFF
--- a/tests/runner/test_persistent_batch_manager.py
+++ b/tests/runner/test_persistent_batch_manager.py
@@ -186,6 +186,7 @@ class TestPersistentBatchManager(unittest.TestCase):
             vocab_size=128,
             block_sizes=[16],
         )
+        input_batch.has_mamba_layers = True
         input_batch.add_request(req)
         slot = int(input_batch.mamba_state_indices_cpu[0])
 
@@ -214,6 +215,7 @@ class TestPersistentBatchManager(unittest.TestCase):
             vocab_size=128,
             block_sizes=[16],
         )
+        input_batch.has_mamba_layers = True
         input_batch.add_request(req)
         slot = int(input_batch.mamba_state_indices_cpu[0])
 
@@ -243,6 +245,7 @@ class TestPersistentBatchManager(unittest.TestCase):
             vocab_size=128,
             block_sizes=[16],
         )
+        input_batch.has_mamba_layers = True
         input_batch.add_request(req)
         slot = int(input_batch.mamba_state_indices_cpu[0])
 
@@ -279,6 +282,7 @@ class TestPersistentBatchManager(unittest.TestCase):
             vocab_size=128,
             block_sizes=[16],
         )
+        input_batch.has_mamba_layers = True
         input_batch.add_request(req)
         slot = int(input_batch.mamba_state_indices_cpu[0])
 

--- a/tests/runner/test_persistent_batch_manager.py
+++ b/tests/runner/test_persistent_batch_manager.py
@@ -373,3 +373,47 @@ class TestPersistentBatchManager(unittest.TestCase):
 
         self.assertEqual(manager.input_batch.num_tokens[0], 3)
         self.assertEqual(manager.input_batch.num_tokens_no_spec[0], 3)
+
+    def test_assert_mamba_state_invariants_conditional_execution(self):
+        req = _create_cached_request("req-0")
+        requests = {req.req_id: req}
+        input_batch = InputBatch(
+            max_num_reqs=4,
+            max_model_len=16,
+            max_num_batched_tokens=16,
+            pin_memory=False,
+            vocab_size=128,
+            block_sizes=[16],
+        )
+        input_batch.add_request(req)
+
+        manager = PersistentBatchManager(requests,
+                                         input_batch,
+                                         encoder_cache={},
+                                         uses_mrope=False,
+                                         model_config=MagicMock(),
+                                         is_last_rank=True)
+
+        with patch.object(input_batch,
+                          "assert_mamba_state_invariants") as mock_assert:
+            # Case 1: has_mamba_layers is False
+            input_batch.has_mamba_layers = False
+            manager.update_states(
+                _make_scheduler_output(scheduled_req_ids=[req.req_id]), None)
+            mock_assert.assert_not_called()
+
+            # Case 2: has_mamba_layers is True, but batch did not change (batch_changed=False, swap_cnt=0)
+            input_batch.has_mamba_layers = True
+            scheduler_output = _make_scheduler_output(
+                scheduled_req_ids=[req.req_id], )
+            manager.update_states(scheduler_output, None)
+            mock_assert.assert_not_called()
+
+            # Case 3: has_mamba_layers is True, and batch changed (batch_changed=True)
+            scheduler_output_changed = _make_scheduler_output(
+                scheduled_req_ids=["new-req"], )
+            # Create request state for "new-req"
+            manager.requests["new-req"] = _create_cached_request("new-req")
+
+            manager.update_states(scheduler_output_changed, None)
+            mock_assert.assert_called_once()

--- a/tpu_inference/runner/input_batch.py
+++ b/tpu_inference/runner/input_batch.py
@@ -176,6 +176,7 @@ class InputBatch:
         # for pooling models
         self.pooling_params: dict[str, PoolingParams] = {}
         self.pooling_states: dict[str, PoolingStates] = {}
+        self.has_mamba_layers = False
 
     def init_mamba_pools(self, mamba_num_blocks: int) -> None:
         """Reinitialize mamba slot pools with the actual device block count.

--- a/tpu_inference/runner/persistent_batch_manager.py
+++ b/tpu_inference/runner/persistent_batch_manager.py
@@ -319,8 +319,10 @@ class PersistentBatchManager:
 
         batch_changed = len(unscheduled_req_ids) > 0 or len(req_ids_to_add) > 0
         # TODO(jevinjiang): I assume we do not need to set batch_changed to true if just swapping requests.
-        self._reorder_batch(scheduler_output)
-        if isinstance(self.input_batch, InputBatch):
+        swap_cnt = self._reorder_batch(scheduler_output)
+        if (isinstance(self.input_batch, InputBatch)
+                and self.input_batch.has_mamba_layers
+                and (batch_changed or swap_cnt > 0)):
             self.input_batch.assert_mamba_state_invariants(
                 self.requests, dp_rank_map)
         return batch_changed

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -934,6 +934,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         self.kv_cache_config = kv_cache_config
         self.use_hybrid_kvcache = len(kv_cache_config.kv_cache_groups) > 1
         self.kv_cache_manager.initialize_kv_cache(kv_cache_config)
+        self.input_batch.has_mamba_layers = kv_cache_config.has_mamba_layers
 
         if self.kv_cache_manager.actual_mamba_num_blocks is not None:
             self.input_batch.init_mamba_pools(


### PR DESCRIPTION
# Description

https://github.com/vllm-project/tpu-inference/pull/2779 added an assertion for mamba slots that can be very expensive on higher DP/context sizes. In qwen3-0.6b testing on larger clusters we ran into CPU bottlenecks, and upon profiling with TP=8 DP=8 we found 13ms out of the 27ms model step was spent on calculating this assertion. 

In this change we avoid this assertion if it is not a mamba model. And avoid recalculating the assertion if the batch hasn't changed.

# Tests

Small scale test since shared cluster is currently down
```
VLLM_DISABLE_COMPILE_CACHE=1  SKIP_JAX_PRECOMPILE=1 MODEL_IMPL_TYPE=vllm python3 examples/tpu_profiling.py --profile-result-dir=gs://piv-test/tpu-profile-vm/jun26/1/ --model=Qwen/Qwen3-0.6B --max-model-len=24576 --max-num-batched-tokens 24576 --max-num-seqs 480 --tensor-parallel-size 4 --data-parallel-size 2 --gpu-memory-utilization 0.4 --input-len 16384 --output-len 8192
```

Before: https://screenshot.googleplex.com/hBgrjF4gy6XtyR7, _process_engine_step 11.03ms

After: https://screenshot.googleplex.com/9gGA8eWhvyjJm6v, _process_engine_step 9.23ms


# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
