### PR TITLE
Add more variables in the TuningKey

### DIFF
--- a/tpu_inference/layers/common/attention_interface.py
+++ b/tpu_inference/layers/common/attention_interface.py
@@ -544,12 +544,20 @@ def mla_attention(
     )
 
     def _mla_ragged_paged_attention(q, q_rope, k, k_rope, cache, *args):
+        dp_size = get_mesh_shape_product(mesh, ShardingAxisName.ATTN_DATA)
         batched_decode_tuning_key = TuningKey(
             case="batched_decode",
             max_num_tokens=q.shape[1],
             actual_num_q_heads=q.shape[0],
             actual_lkv_dim=q.shape[2],
             actual_r_dim=q_rope.shape[2],
+            kv_dtype=cache.dtype.name,
+            q_dtype=q.dtype.name,
+            total_num_pages=cache.shape[0],
+            page_size_per_kv_packing=cache.shape[1],
+            kv_packing=cache.shape[2],
+            max_num_seqs=md.padded_num_reqs // dp_size,
+            pages_per_seq=args[1].shape[0] // args[0].shape[0],
         )
         batched_decode_tuned_params = get_tuned_params(
             batched_decode_tuning_key)


### PR DESCRIPTION
# Description

This PR adds more parameters to the  `TuningKey` in `mla_attention`. 

### Why is this change being made?
These fields are needed for more models and configurations to uniquely identify a tuning key, as key-value cache dtype, sizes, block structures, and sequencing layout vary across different configs. Without these parameters, different model architectures can collide on the same tuning key, leading to suboptimal block size selection or lookup failures.

### Specific Implementation
The values are computed dynamically inside `_mla_ragged_paged_attention` from the cache array characteristics, mesh batch axis size (`dp_size`).

---

# Tests

The changes were tested by running the end-to-end Mistral-Large-3 Serving benchmark on a Cloud TPU v7x-16 cluster with Hybrid MoE:
1. Checked out the change.
2. Verified that the `TuningKey` is printed with the new parameters in the serving logs (e.g. `TuningKey(case='batched_decode', max_num_tokens=1024, actual_num_q_heads=128, ..., kv_dtype='float8_e4m3fn', q_dtype='float8_e4m3fn')`).
3. Verified that the server successfully warm-up compiles and runs benchmarks under the updated tuning key structure.

---

# Checklist

Before submitting this PR, please make sure:
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have made or will make corresponding changes to any relevant documentation.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vllm-project/codesmith/tpu-inference/pr/3006"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785014246&installation_id=142609222&pr_number=3006&repository=vllm-project%2Ftpu-inference&return_to=https%3A%2F%2Fgithub.com%2Fvllm-project%2Ftpu-inference%2Fpull%2F3006&signature=780bd86b0c3d5b1f4974143996bc20cc687a3a1c959a4935215de46f01e756c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->