### PR TITLE
[Gemma4] Refactor MMEncoderJITManager and add support to use it in Jax path Gemma4

### DIFF
--- a/tests/runner/test_mm_encoder_jit_manager.py
+++ b/tests/runner/test_mm_encoder_jit_manager.py
@@ -262,7 +262,7 @@ class TestMMEncoderJITManagerInit:
     def test_jit_forward_is_callable(self):
         """_jit_forward is a callable built once at init (not per-call)."""
         manager = _make_manager()
-        assert callable(manager._jit_forward)
+        assert callable(manager.model._jit_forward)
 
 
 def _image_mm_kwargs(t=1, h=4, w=4):

--- a/tpu_inference/models/common/model_loader.py
+++ b/tpu_inference/models/common/model_loader.py
@@ -41,6 +41,8 @@ from tpu_inference.models.jax.utils.qwix.qwix_utils import (
     update_vllm_config_for_qwix_quantization)
 from tpu_inference.models.jax.utils.weight_utils import (BaseWeightLoader,
                                                          LoadableWithIterator)
+from tpu_inference.runner.mm_encoder_jit_manager import \
+    maybe_create_mm_encoder_jit_manager
 from tpu_inference.utils import to_jax_dtype, to_torch_dtype
 
 logger = init_logger(__name__)
@@ -462,8 +464,26 @@ def get_flax_model(
         return jitted_model_fn(*args, **kwargs)
 
     compute_logits_fn = run_compute_logits
-    embed_multimodal_fn = run_embed_multimodal
     embed_input_ids_fn = run_embed_input_ids
+
+    _mm_jit = maybe_create_mm_encoder_jit_manager(
+        vllm_config=vllm_config,
+        vllm_model=model,
+        vllm_runner=None,
+        params_and_buffers=None,
+    )
+    if _mm_jit is not None:
+        precompile_vision_encoder_fn = _mm_jit.precompile_vision_encoder
+
+        def embed_multimodal_fn(state_leaves, modality=None, **kwargs):
+            if modality is not None and _mm_jit.supports_modality(modality):
+                return _mm_jit.execute(kwargs)
+            return run_embed_multimodal(state_leaves,
+                                        modality=modality,
+                                        **kwargs)
+    else:
+        embed_multimodal_fn = run_embed_multimodal
+
     lora_manager, model = None, None
     combine_hidden_states_fn = combine_hidden_states
 

--- a/tpu_inference/models/common/model_loader.py
+++ b/tpu_inference/models/common/model_loader.py
@@ -482,6 +482,8 @@ def get_flax_model(
                                         modality=modality,
                                         **kwargs)
     else:
+        # TODO(kwang3939): implement SupportsEncoderCudaGraph for Qwen2.5-VL and enforce
+        # all JAX multimodal models to go through MMEncoderJITManager.
         embed_multimodal_fn = run_embed_multimodal
 
     lora_manager, model = None, None

--- a/tpu_inference/models/jax/gemma4_mm.py
+++ b/tpu_inference/models/jax/gemma4_mm.py
@@ -835,7 +835,7 @@ class Gemma4ForConditionalGeneration(JaxModule, LoadableWithIterator):
         return config
 
     def get_max_frames_per_video(self) -> int:
-        return 1  # images only
+        raise NotImplementedError("Video not yet supported.")
 
     def get_input_modality(self, mm_kwargs: dict[str, Any]) -> str:
         if "pixel_values_videos" in mm_kwargs:

--- a/tpu_inference/models/jax/gemma4_mm.py
+++ b/tpu_inference/models/jax/gemma4_mm.py
@@ -573,6 +573,7 @@ class Gemma4ForConditionalGeneration(JaxModule, LoadableWithIterator):
     WeightLoader = StandardWeightLoader
     supports_multimodal = True
     supports_encoder_tp_data = True
+    supports_encoder_cudagraph = True
     _processor_factory = getattr(PtGemma4MM, "_processor_factory", None)
 
     def __init__(self, vllm_config: VllmConfig, rng_key: jax.Array,
@@ -593,6 +594,9 @@ class Gemma4ForConditionalGeneration(JaxModule, LoadableWithIterator):
         vision_config = model_config.hf_config.vision_config
         self.image_token_id = getattr(model_config.hf_config, "image_token_id",
                                       258880)
+        self.pooling_kernel_size = vision_config.pooling_kernel_size
+        self.max_soft_tokens = vision_config.default_output_length
+        self.patch_pixels = vision_config.patch_size**2 * 3
 
         self.vision_tower = Gemma4VisionModel(
             config=vision_config,
@@ -807,6 +811,218 @@ class Gemma4ForConditionalGeneration(JaxModule, LoadableWithIterator):
             return []
 
         return self._process_image_input(image_input)
+
+    # -- SupportsEncoderCudaGraph protocol methods --
+
+    def get_encoder_cudagraph_config(self):
+        from vllm.v1.worker.encoder_cudagraph_defs import \
+            EncoderCudaGraphConfig
+
+        def pad_pixel_position_ids(dst: torch.Tensor,
+                                   src: torch.Tensor) -> None:
+            # pixel_position_ids uses -1 as the pad sentinel (POSITIONS_PAD_VALUE).
+            dst.fill_(POSITIONS_PAD_VALUE)
+            dst[:src.shape[0]].copy_(src)
+
+        text_hidden = self.vllm_config.model_config.hf_config.text_config.hidden_size
+        config = EncoderCudaGraphConfig(
+            modalities=["image"],
+            buffer_keys=["pixel_values", "pixel_position_ids"],
+            out_hidden_size=text_hidden,
+            max_frames_per_video=1,
+            padding_logics={"pixel_position_ids": pad_pixel_position_ids},
+        )
+        return config
+
+    def get_max_frames_per_video(self) -> int:
+        return 1  # images only
+
+    def get_input_modality(self, mm_kwargs: dict[str, Any]) -> str:
+        if "pixel_values_videos" in mm_kwargs:
+            raise NotImplementedError("Video not yet supported.")
+        else:
+            return "image"
+
+    def get_encoder_cudagraph_budget_range(self, vllm_config):
+        min_budget = self.max_soft_tokens
+        max_num_seqs = vllm_config.scheduler_config.max_num_seqs
+        text_dp_size = vllm_config.sharding_config.total_dp_size
+        max_budget = min(
+            self.max_soft_tokens * max_num_seqs * text_dp_size,
+            vllm_config.scheduler_config.max_num_batched_tokens * text_dp_size,
+        )
+        return min_budget, max_budget
+
+    def _get_pixel_values_by_modality(
+            self, mm_kwargs: dict[str, Any]) -> torch.Tensor:
+        if self.get_input_modality(mm_kwargs) == "image":
+            return mm_kwargs["pixel_values"]
+        raise NotImplementedError("Video not yet supported.")
+
+    def _get_pixel_position_ids_by_modality(
+            self, mm_kwargs: dict[str, Any]) -> torch.Tensor:
+        if self.get_input_modality(mm_kwargs) == "image":
+            return mm_kwargs["pixel_position_ids"]
+        raise NotImplementedError("Video not yet supported.")
+
+    def get_encoder_cudagraph_item_specs(self, mm_kwargs):
+        from vllm.v1.worker.encoder_cudagraph_defs import EncoderItemSpec
+        pixel_position_ids = self._get_pixel_position_ids_by_modality(
+            mm_kwargs)
+        if not isinstance(pixel_position_ids, torch.Tensor):
+            return []
+        k = self.pooling_kernel_size
+        specs = []
+        for i in range(pixel_position_ids.shape[0]):
+            pid = pixel_position_ids[i]  # (num_patches, 2)
+            valid_patches = int((pid[:, 0]
+                                 != POSITIONS_PAD_VALUE).sum().item())
+            output_tokens = min(max(valid_patches // k**2, 1),
+                                self.max_soft_tokens)
+            specs.append(
+                EncoderItemSpec(
+                    input_size=pixel_position_ids.shape[1],
+                    output_tokens=output_tokens,
+                ))
+        return specs
+
+    def select_encoder_cudagraph_items(
+        self,
+        mm_kwargs: dict[str, Any],
+        indices: list[int],
+    ) -> dict[str, Any]:
+        modality = self.get_input_modality(mm_kwargs)
+        pixel_values = self._get_pixel_values_by_modality(mm_kwargs)
+        pixel_position_ids = self._get_pixel_position_ids_by_modality(
+            mm_kwargs)
+
+        if len(indices) == 0:
+            if modality == "image":
+                return {
+                    "pixel_values": pixel_values[:0],
+                    "pixel_position_ids": pixel_position_ids[:0],
+                }
+            raise NotImplementedError("Video not yet supported.")
+
+        if modality == "image":
+            return {
+                "pixel_values": pixel_values[list(indices)],
+                "pixel_position_ids": pixel_position_ids[list(indices)],
+            }
+        raise NotImplementedError("Video not yet supported.")
+
+    def prepare_encoder_cudagraph_capture_inputs(
+        self,
+        token_budget: int,
+        max_batch_size: int,
+        max_frames_per_batch: int,
+        device: torch.device,
+        dtype: torch.dtype,
+    ):
+        from vllm.v1.worker.encoder_cudagraph_defs import \
+            EncoderCudaGraphCaptureInputs
+        num_patches = self.max_soft_tokens * self.pooling_kernel_size**2
+        dp_size = get_mesh_shape_product(self.mesh, ShardingAxisName.VIT_BATCH)
+        images_for_budget = max(
+            min(token_budget // self.max_soft_tokens, max_batch_size), 1)
+        batch_size = ((images_for_budget + dp_size - 1) // dp_size) * dp_size
+
+        pixel_values = torch.randn(batch_size,
+                                   num_patches,
+                                   self.patch_pixels,
+                                   dtype=dtype,
+                                   device=device)
+        pixel_position_ids = torch.full(
+            (batch_size, num_patches, 2),
+            POSITIONS_PAD_VALUE,
+            dtype=torch.int32,
+            device=device,
+        )
+        return EncoderCudaGraphCaptureInputs(
+            values={
+                "pixel_values": pixel_values,
+                "pixel_position_ids": pixel_position_ids,
+            })
+
+    def prepare_encoder_cudagraph_replay_buffers(
+        self,
+        mm_kwargs,
+        max_batch_size: int,
+        max_frames_per_batch: int,
+        path: str = "default",
+    ):
+        from vllm.v1.worker.encoder_cudagraph_defs import \
+            EncoderCudaGraphReplayBuffers
+        pv = self._get_pixel_values_by_modality(mm_kwargs)
+        ppid = self._get_pixel_position_ids_by_modality(mm_kwargs)
+        return EncoderCudaGraphReplayBuffers(values={
+            "pixel_values": pv,
+            "pixel_position_ids": ppid,
+        })
+
+    @jax.jit
+    def encoder_cudagraph_forward(self, inputs: dict) -> jax.Array:
+        """Run the vision encoder on fixed-shape inputs.
+
+        Args:
+            inputs: dict with "pixel_values" (B, NP, PP) and
+                "pixel_position_ids" (B, NP, 2) as jax.Arrays.
+
+        Returns:
+            jax.Array of shape (B, max_soft_tokens, hidden).
+        """
+        pixel_values = inputs["pixel_values"]
+        pixel_position_ids = inputs["pixel_position_ids"]
+
+        input_sharding = NamedSharding(
+            self.mesh, PartitionSpec(ShardingAxisName.VIT_BATCH, None, None))
+        pixel_values = jax.device_put(pixel_values, input_sharding)
+        pixel_position_ids = jax.device_put(pixel_position_ids, input_sharding)
+
+        input_mask = pixel_position_ids[..., 0] != POSITIONS_PAD_VALUE
+
+        vision_outputs = self.vision_tower(
+            pixel_values,
+            input_mask=input_mask,
+            pixel_position_ids=pixel_position_ids,
+        )
+        projected = vision_outputs[0][0]
+        pooler_mask = vision_outputs[0][1]
+        projected = self.embed_vision(projected)
+
+        seq_len = pooler_mask.shape[1]
+        sort_indices = jnp.arange(seq_len)
+        sort_key = jnp.where(pooler_mask, sort_indices, seq_len + sort_indices)
+        sort_idx = jnp.argsort(sort_key, axis=1)
+        projected = jnp.take_along_axis(projected,
+                                        jnp.expand_dims(sort_idx, axis=-1),
+                                        axis=1)
+        projected = jax.lax.with_sharding_constraint(
+            projected, NamedSharding(self.mesh,
+                                     PartitionSpec(None, None, None)))
+        return projected
+
+    def encoder_eager_forward(self, mm_kwargs: dict[str,
+                                                    Any]) -> list[jax.Array]:
+        """Fallback for inputs that exceed all budget sizes."""
+        return self.embed_multimodal(**mm_kwargs)
+
+    def postprocess_encoder_output(
+        self,
+        output,
+        indices,
+        per_item_out_tokens,
+        dest,
+        clone: bool = False,
+        batch_mm_kwargs=None,
+    ) -> None:
+        """Split batch encoder output into per-image entries in dest."""
+        for local_idx, global_idx in enumerate(indices):
+            n = per_item_out_tokens[global_idx]
+            feat = output[local_idx, :n]
+            if clone and hasattr(feat, 'clone'):
+                feat = feat.clone()
+            dest[global_idx] = feat
 
     def __call__(
         self,

--- a/tpu_inference/models/vllm/vllm_model_wrapper.py
+++ b/tpu_inference/models/vllm/vllm_model_wrapper.py
@@ -37,7 +37,6 @@ from vllm.lora.layers import BaseLayerWithLoRA
 from vllm.model_executor.layers.pooler import Pooler
 from vllm.model_executor.model_loader import get_model as vllm_get_model
 from vllm.model_executor.models import supports_lora, supports_multimodal
-from vllm.model_executor.models.interfaces import supports_encoder_cudagraph
 from vllm.model_executor.models.interfaces_base import is_pooling_model
 from vllm.platforms import current_platform
 from vllm.v1.outputs import PoolerOutput
@@ -67,7 +66,8 @@ from tpu_inference.models.vllm.experimental.vision_tower_jit import (
 from tpu_inference.models.vllm.vllm_model_wrapper_context import (
     get_vllm_model_wrapper_context, set_vllm_model_wrapper_context)
 from tpu_inference.runner.lora_utils import replace_lora_metadata
-from tpu_inference.runner.mm_encoder_jit_manager import MMEncoderJITManager
+from tpu_inference.runner.mm_encoder_jit_manager import (
+    MMEncoderJITManager, maybe_create_mm_encoder_jit_manager)
 
 logger = init_logger(__name__)
 
@@ -379,8 +379,12 @@ class VllmModelWrapper:
         )
         # Returning to the jax land, so we need to wrap it into a JaxValue.
         params = jax_view(params_and_buffers)
-        self._mm_encoder_jit_manager = self._maybe_create_mm_encoder_jit_manager(
-            params)
+        self._mm_encoder_jit_manager = maybe_create_mm_encoder_jit_manager(
+            vllm_config=self.vllm_config,
+            vllm_model=self.model.vllm_model,
+            vllm_runner=self.model,
+            params_and_buffers=params,
+        )
         return params, lora_manager
 
     def jit_step_func(self):
@@ -555,19 +559,6 @@ class VllmModelWrapper:
             self.step_fn_no_options = step_fun_no_options
             return step_fun_with_options
 
-    def _maybe_create_mm_encoder_jit_manager(
-            self, params) -> 'MMEncoderJITManager | None':
-        if not self.vllm_config.compilation_config.cudagraph_mm_encoder:
-            return None
-        if not supports_encoder_cudagraph(self.model.vllm_model):
-            return None
-        return MMEncoderJITManager(
-            vllm_config=self.vllm_config,
-            vllm_runner=self.model,
-            vllm_model=self.model.vllm_model,
-            params_and_buffers=params,
-        )
-
     def wrap_precompile_vision_encoder_fn(
         self,
         params: Any,
@@ -580,16 +571,7 @@ class VllmModelWrapper:
         if not self.vllm_config.model_config.is_multimodal_model:
             return None
         if self._mm_encoder_jit_manager is not None:
-
-            def jit_manager_precompile_fn(run_compilation):
-                for budget in self._mm_encoder_jit_manager.token_budgets:
-                    run_compilation(
-                        "mm_encoder_jit",
-                        self._mm_encoder_jit_manager._capture_budget_graph,
-                        budget,
-                        budget=budget)
-
-            return jit_manager_precompile_fn
+            return self._mm_encoder_jit_manager.precompile_vision_encoder
 
         embed_multimodal_fn = self.wrap_embed_multimodal_func()
         return maybe_precompile_vision_encoder_fn(params, embed_multimodal_fn,

--- a/tpu_inference/runner/mm_encoder_jit_manager.py
+++ b/tpu_inference/runner/mm_encoder_jit_manager.py
@@ -89,6 +89,50 @@ class _TorchaxEncoderModelAdapter:
         self._model = vllm_model
         self._runner = vllm_runner
         self._params = params_and_buffers
+        self._jit_forward = jax.jit(self._build_forward_fn())
+
+    # ----- JIT forward closure -----
+
+    def _build_forward_fn(self) -> Callable:
+        """Build the closure that gets ``jax.jit``-wrapped exactly once.
+
+        Inputs: ``params_jax`` (the model weights) + ``values_jax`` (the
+        full padded buffer dict including ``pixel_values``).
+
+        Inside: bridge jax -> torchax with ``torch_view``, dispatch via
+        ``functional_call(call_method="encoder_cudagraph_forward")``,
+        bridge torchax output back to jax with ``jax_view``.
+        """
+        vllm_runner = self._runner
+
+        def _forward(params_jax: Any, values_jax: dict[str, jax.Array]):
+            params_torchax = torch_view(params_jax)
+            values_torchax = {
+                k: jax.tree.map(torch_view, v)
+                for k, v in values_jax.items()
+            }
+            out_torch = torch.func.functional_call(
+                vllm_runner,
+                params_torchax,
+                kwargs={
+                    "call_method": "encoder_cudagraph_forward",
+                    "call_args": (values_torchax, ),
+                    "call_kwargs": {},
+                },
+                tie_weights=False,
+            )
+            return jax_view(out_torch)
+
+        return _forward
+
+    def run_budget_forward(self, padded_torch: dict[str, Any]) -> jax.Array:
+        # Convert + JIT — INSIDE the env (the closure bridges torchax<->jax).
+        with torchax.default_env(), enable_torch_wrap(False):
+            padded_jax = {
+                k: jax.tree.map(self._t2j_if_tensor, v)
+                for k, v in padded_torch.items()
+            }
+            return self._jit_forward(self._params, padded_jax)
 
     def encoder_eager_forward(self, mm_kwargs: dict[str, Any]) -> jax.Array:
         # Bridge plain-torch mm_kwargs -> torchax, dispatch the model's eager
@@ -99,7 +143,7 @@ class _TorchaxEncoderModelAdapter:
         # under the torchax dispatch).
         with torchax.default_env():
             torchax_kwargs = {
-                k: jax.tree.map(_torchax_view_if_torch, v)
+                k: jax.tree.map(self._torchax_view_if_torch, v)
                 for k, v in mm_kwargs.items()
             }
             out_torch = torch.func.functional_call(
@@ -131,6 +175,20 @@ class _TorchaxEncoderModelAdapter:
             dest[idx] = output[offset:offset + n]
             offset += n
 
+    @staticmethod
+    def _t2j_if_tensor(v: torch.Tensor | jax.Array) -> jax.Array:
+        """Tree-map helper — convert leaf torch.Tensors to jax.Array."""
+        if isinstance(v, torch.Tensor):
+            return t2j(v, use_dlpack=False)
+        return v
+
+    @staticmethod
+    def _torchax_view_if_torch(v):
+        """Tree-map helper for the eager path."""
+        if isinstance(v, torch.Tensor):
+            return torch_view(t2j(v, use_dlpack=False))
+        return v
+
     def __getattr__(self, name: str) -> Any:
         # Delegate all non-overridden protocol methods to the real model.
         return getattr(self._model, name)
@@ -142,7 +200,7 @@ class MMEncoderJITManager(EncoderCudaGraphManager):
     def __init__(
         self,
         vllm_config: "VllmConfig",
-        vllm_runner: torch.nn.Module,
+        vllm_runner: torch.nn.Module | None,
         vllm_model: Any,
         params_and_buffers: Any,
     ):
@@ -155,23 +213,27 @@ class MMEncoderJITManager(EncoderCudaGraphManager):
               ``encoder_cudagraph_max_frames_per_batch`` (same as GPU).
           vllm_runner: The torchax-wrapped ``_VllmRunner`` (provides
               ``forward(call_method=..., call_args=...)``-style dispatch
-              required by ``torch.func.functional_call``).
+              required by ``torch.func.functional_call``). Pass ``None``
+              for the JAX/flax path — selects ``JaxEncoderModelAdapter``.
           vllm_model: The underlying vllm model (e.g.
-              ``Qwen3VLForConditionalGeneration``). Must implement
-              ``SupportsEncoderCudaGraph``.
+              ``Qwen3VLForConditionalGeneration``) or a JAX flax model.
+              Must implement ``SupportsEncoderCudaGraph``.
           params_and_buffers: The model's loaded weights as a pytree of
               JAX arrays. Bound into ``functional_call`` per request.
+              Pass ``None`` for the JAX/flax path.
         """
-        self.vllm_runner = vllm_runner
-        self.params_and_buffers = params_and_buffers
-
         # The parent calls model.{get_encoder_cudagraph_config,
         # get_encoder_cudagraph_budget_range}; the inherited _execute_local
         # later calls model.{select_encoder_cudagraph_items,
         # encoder_eager_forward, postprocess_encoder_output}. Route eager
-        # forward through the torchax runner via the adapter.
-        adapter = _TorchaxEncoderModelAdapter(vllm_model, vllm_runner,
-                                              params_and_buffers)
+        # forward and budget execution through the appropriate adapter.
+        if vllm_runner is None:
+            # JAX/flax path
+            adapter = JaxEncoderModelAdapter(vllm_model)
+        else:
+            # torchax path: functional_call through the torchax runner.
+            adapter = _TorchaxEncoderModelAdapter(vllm_model, vllm_runner,
+                                                  params_and_buffers)
 
         # Reuse upstream budget derivation + validation. Capture inputs are
         # built on CPU; the JIT path moves them to TPU via t2j, so we never
@@ -182,10 +244,6 @@ class MMEncoderJITManager(EncoderCudaGraphManager):
             dtype=vllm_config.model_config.dtype,
             model=adapter,
         )
-        # Keep the raw model for the grid/pixel helper calls in the
-        # metadata-cache path (the adapter would delegate, but referencing
-        # the model directly is clearer).
-        self.vllm_model = vllm_model
 
         # Capture templates per budget — shape signature reference for
         # host-side padding. The values inside templates are dummy; only
@@ -194,7 +252,7 @@ class MMEncoderJITManager(EncoderCudaGraphManager):
         capture_dtype = vllm_config.model_config.dtype
         self.budget_templates: dict[int, dict[str, torch.Tensor]] = {}
         for budget in self.token_budgets:
-            capture = vllm_model.prepare_encoder_cudagraph_capture_inputs(
+            capture = self.model.prepare_encoder_cudagraph_capture_inputs(
                 budget, self.max_batch_size, self.max_frames_per_batch,
                 capture_device, capture_dtype)
             self.budget_templates[budget] = capture.values
@@ -204,44 +262,6 @@ class MMEncoderJITManager(EncoderCudaGraphManager):
             "max_frames_per_batch=%d template_keys=%s", self.token_budgets,
             self.max_batch_size, self.max_frames_per_batch,
             list(next(iter(self.budget_templates.values())).keys()))
-
-        # Hoist the JIT-wrap once (v7 cache-share fix — PjitFunction lives
-        # on this instance and accumulates per-shape entries from here).
-        self._jit_forward = jax.jit(self._build_forward_closure())
-
-    # ----- JIT forward closure -----
-
-    def _build_forward_closure(self) -> Callable:
-        """Build the closure that gets ``jax.jit``-wrapped exactly once.
-
-        Inputs: ``params_jax`` (the model weights) + ``values_jax`` (the
-        full padded buffer dict including ``pixel_values``).
-
-        Inside: bridge jax -> torchax with ``torch_view``, dispatch via
-        ``functional_call(call_method="encoder_cudagraph_forward")``,
-        bridge torchax output back to jax with ``jax_view``.
-        """
-        vllm_runner = self.vllm_runner
-
-        def _forward(params_jax: Any, values_jax: dict[str, jax.Array]):
-            params_torchax = torch_view(params_jax)
-            values_torchax = {
-                k: jax.tree.map(torch_view, v)
-                for k, v in values_jax.items()
-            }
-            out_torch = torch.func.functional_call(
-                vllm_runner,
-                params_torchax,
-                kwargs={
-                    "call_method": "encoder_cudagraph_forward",
-                    "call_args": (values_torchax, ),
-                    "call_kwargs": {},
-                },
-                tie_weights=False,
-            )
-            return jax_view(out_torch)
-
-        return _forward
 
     # ----- Padding (per-key) -----
 
@@ -320,13 +340,8 @@ class MMEncoderJITManager(EncoderCudaGraphManager):
         lazily on first ``execute``).
         """
         template = self.budget_templates[token_budget]
-        with torchax.default_env(), enable_torch_wrap(False):
-            values_jax = {
-                k: jax.tree.map(_t2j_if_tensor, v)
-                for k, v in template.items()
-            }
-            out = self._jit_forward(self.params_and_buffers, values_jax)
-            jax.block_until_ready(out)
+        out = self.model.run_budget_forward(template)
+        jax.block_until_ready(out)
         # Mark captured so inherited capture()/get_cumulative_stats count it.
         self.budget_graphs[token_budget] = template
 
@@ -338,11 +353,10 @@ class MMEncoderJITManager(EncoderCudaGraphManager):
         """XLA-cache analog of CUDA-graph replay.
 
         Host-pads the replay buffers to the budget template shape (plain
-        torch, outside the env) and calls the once-built ``jax.jit`` closure
-        inside a local ``torchax.default_env()``. Returns the encoder output
-        as a **jax.Array**, which the inherited ``_execute_local`` slices via
-        the adapter's jax-friendly ``postprocess_encoder_output`` — no outer
-        torchax env required.
+        torch, outside the env) and delegates to the adapter's
+        ``run_budget_forward``. Returns a **jax.Array** that the inherited
+        ``_execute_local`` slices via the adapter's jax-friendly
+        ``postprocess_encoder_output`` — no outer torchax env required.
         """
         num_items = len(self._get_item_specs(mm_kwargs))
         if token_budget not in self.budget_templates:
@@ -353,13 +367,7 @@ class MMEncoderJITManager(EncoderCudaGraphManager):
 
         # Prep in plain torch (touches model Parameters) — OUTSIDE the env.
         padded_torch = self._prepare_padded_torch(mm_kwargs, token_budget)
-        # Convert + JIT — INSIDE the env (the closure bridges torchax<->jax).
-        with torchax.default_env(), enable_torch_wrap(False):
-            padded_jax = {
-                k: jax.tree.map(_t2j_if_tensor, v)
-                for k, v in padded_torch.items()
-            }
-            out_jax = self._jit_forward(self.params_and_buffers, padded_jax)
+        out_jax = self.model.run_budget_forward(padded_torch)
         self.graph_hits += num_items
         return out_jax
 
@@ -377,17 +385,3 @@ class MMEncoderJITManager(EncoderCudaGraphManager):
         expects from ``runner.embed_multimodal_fn(...)``.
         """
         return self._execute_local(mm_kwargs)
-
-
-def _t2j_if_tensor(v: torch.Tensor | jax.Array) -> jax.Array:
-    """Tree-map helper — convert leaf torch.Tensors to jax.Array."""
-    if isinstance(v, torch.Tensor):
-        return t2j(v, use_dlpack=False)
-    return v
-
-
-def _torchax_view_if_torch(v):
-    """Tree-map helper for the eager path."""
-    if isinstance(v, torch.Tensor):
-        return torch_view(t2j(v, use_dlpack=False))
-    return v

--- a/tpu_inference/runner/mm_encoder_jit_manager.py
+++ b/tpu_inference/runner/mm_encoder_jit_manager.py
@@ -54,14 +54,17 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, Callable
 
 import jax
+import jax.numpy as jnp
 import torch
 import torchax
 from torchax.interop import jax_view, torch_view
 from torchax.ops.mappings import t2j
 from vllm.ir import enable_torch_wrap
+from vllm.model_executor.models.interfaces import supports_encoder_cudagraph
 from vllm.v1.worker.encoder_cudagraph import EncoderCudaGraphManager
 
 from tpu_inference.logger import init_logger
+from tpu_inference.utils import to_torch_dtype
 
 if TYPE_CHECKING:
     from vllm.config import VllmConfig
@@ -194,6 +197,46 @@ class _TorchaxEncoderModelAdapter:
         return getattr(self._model, name)
 
 
+class JaxEncoderModelAdapter:
+    """Wrap a JAX/flax SupportsEncoderCudaGraph model for MMEncoderJITManager.
+    Mirrors ``_TorchaxEncoderModelAdapter`` but routes budget execution and
+    eager fallback directly through the JAX model.
+    """
+
+    def __init__(self, jax_model: Any):
+        self._model = jax_model
+
+    def run_budget_forward(self, padded_torch: dict[str, Any]) -> jax.Array:
+        jax_inputs = {}
+        for k, v in padded_torch.items():
+            if isinstance(v, torch.Tensor):
+                if v.dtype == torch.bfloat16:
+                    jax_inputs[k] = jnp.asarray(v.contiguous().view(
+                        torch.int16).numpy().view(jnp.bfloat16))
+                else:
+                    jax_inputs[k] = jnp.asarray(v.numpy())
+            else:
+                jax_inputs[k] = v
+        return self._model.encoder_cudagraph_forward(jax_inputs)
+
+    def encoder_eager_forward(self, mm_kwargs: dict[str, Any]) -> jax.Array:
+        return self._model.encoder_eager_forward(mm_kwargs)
+
+    def postprocess_encoder_output(self,
+                                   output: jax.Array,
+                                   indices: list[int],
+                                   per_item_out_tokens: list[int],
+                                   dest,
+                                   clone: bool = False,
+                                   batch_mm_kwargs=None) -> None:
+        self._model.postprocess_encoder_output(output, indices,
+                                               per_item_out_tokens, dest,
+                                               clone, batch_mm_kwargs)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._model, name)
+
+
 class MMEncoderJITManager(EncoderCudaGraphManager):
     """Per-budget XLA-cache manager for the vision encoder forward."""
 
@@ -238,10 +281,11 @@ class MMEncoderJITManager(EncoderCudaGraphManager):
         # Reuse upstream budget derivation + validation. Capture inputs are
         # built on CPU; the JIT path moves them to TPU via t2j, so we never
         # run the encoder on a CUDA device.
+        torch_dtype = to_torch_dtype(vllm_config.model_config.dtype)
         super().__init__(
             vllm_config=vllm_config,
             device=torch.device("cpu"),
-            dtype=vllm_config.model_config.dtype,
+            dtype=torch_dtype,
             model=adapter,
         )
 
@@ -249,7 +293,7 @@ class MMEncoderJITManager(EncoderCudaGraphManager):
         # host-side padding. The values inside templates are dummy; only
         # tensor.shape / tensor.dtype matter (to us and to XLA's cache key).
         capture_device = torch.device("cpu")
-        capture_dtype = vllm_config.model_config.dtype
+        capture_dtype = torch_dtype
         self.budget_templates: dict[int, dict[str, torch.Tensor]] = {}
         for budget in self.token_budgets:
             capture = self.model.prepare_encoder_cudagraph_capture_inputs(
@@ -385,3 +429,30 @@ class MMEncoderJITManager(EncoderCudaGraphManager):
         expects from ``runner.embed_multimodal_fn(...)``.
         """
         return self._execute_local(mm_kwargs)
+
+    def precompile_vision_encoder(self, run_compilation: Callable) -> None:
+        for budget in self.token_budgets:
+            run_compilation(
+                "mm_encoder_jit",
+                self._capture_budget_graph,
+                budget,
+                budget=budget,
+            )
+
+
+def maybe_create_mm_encoder_jit_manager(
+    vllm_config: "VllmConfig",
+    vllm_model: Any,
+    vllm_runner: "torch.nn.Module | None",
+    params_and_buffers: Any,
+) -> "MMEncoderJITManager | None":
+    if not vllm_config.compilation_config.cudagraph_mm_encoder:
+        return None
+    if not supports_encoder_cudagraph(vllm_model):
+        return None
+    return MMEncoderJITManager(
+        vllm_config=vllm_config,
+        vllm_runner=vllm_runner,
+        vllm_model=vllm_model,
+        params_and_buffers=params_and_buffers,
+    )


### PR DESCRIPTION
# Description

Based on the enable of using [Vit Cuda Graph](https://docs.vllm.ai/en/v0.22.0/design/cuda_graphs_multimodal/) on torchax path: 
PR: https://github.com/vllm-project/tpu-inference/pull/2804
Refactor PR: https://github.com/vllm-project/tpu-inference/pull/2802

Refactor the MMEncoderJITManager to be shared by both paths. Add adapter and funcs needed for jax path Gemma4 to use it.

# Tests

Verified the correctness of jax path Gemma4: `{'accuracy': 0.7116, 'correct': 1231, 'total': 1730, 'gen_num': 1730}`
Verified the correctness of torchax path `Qwen/Qwen3.5-397B-A17B-FP8`.
Tested with `python3 -m pytest -s -v tests/runner/test_mm_encoder_jit_manager.py`.


# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
