### PR TITLE
[Model] Add NemotronH (hybrid Mamba2 + non-gated MoE) TPU support

### DIFF
--- a/tpu_inference/kernels/mamba2/__init__.py
+++ b/tpu_inference/kernels/mamba2/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tpu_inference/kernels/mamba2/jagged_ssd.py
+++ b/tpu_inference/kernels/mamba2/jagged_ssd.py
@@ -1,0 +1,343 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Single Pallas kernel for jagged (variable-length) Mamba2 SSD prefill on TPU.
+
+`ssd_candidate(x, dt, A_log, B, C, cu_seqlens) -> y` computes the chunked
+state-space-dual (SSD) scan for a packed batch of sequences in one pallas_call,
+fusing the three SSD phases (intra-chunk y, cross-chunk state carry, inter-chunk
+y from the carried state) so no (NumChunks, H, P, N) intermediates hit HBM.
+
+Algebra inside chunk c (h_init carries from the previous chunk):
+    M[i,j,h]   = exp(cum_log_a[i,h]-cum_log_a[j,h]) * dt[j,h]
+                 * 1[same sub-seq(i,j)] * 1[j<=i]
+    score[i,j] = sum_n C[i,h,n] * B[j,h,n]
+    y_intra    = sum_j M * score * x[j]
+    h_local    = sum_j M[CHUNK-1,j,h] * x[j] (x) B[j]
+    y_inter[t] = exp(cum_log_a[t]) * inter_valid[t] * sum_n C[t,h,n]*h_init[h,n]
+    h_init    <- carry_factor[c] * h_init + h_local
+
+Shapes: x (T,H,P) bf16, dt (T,H) bf16, A_log (H,) f32 (log(a)=A_log*dt),
+B/C (T,H,N) bf16, cu_seqlens (num_seqs+1,) i32; y (T,H,P) bf16. Hardcoded
+H=128, CHUNK=256, I_TILE=64; T is padded to a CHUNK multiple internally.
+"""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+from jax.experimental import pallas as pl
+from jax.experimental.pallas import tpu as pltpu
+
+
+CHUNK = 256
+I_TILE = 64
+NUM_I_TILES = CHUNK // I_TILE   # 4
+HBG_SIZE = 128
+
+# Bound exp arg in masked / outside-causal positions so exp doesn't
+# overflow. exp(-50) ≈ 2e-22 is well below the 5e-2 correctness gate.
+MASK_FILL = -50.0
+
+
+def _build_outer_kernel(NumChunks, NC_padded, H, P, N):
+
+    def _inner_body(
+        x_ref,         # bf16[1, HBG, P, CHUNK]
+        dt_v_ref,      # bf16[1, HBG, CHUNK]
+        clog_ref,      # f32 [1, HBG, CHUNK]
+        B_ref,         # bf16[1, HBG, CHUNK, N]
+        C_ref,         # bf16[1, HBG, CHUNK, N]
+        y_ref,         # bf16[1, HBG, P, CHUNK]    (combined y, written)
+        *,
+        local_seg_vmem,        # i32[NC_padded, CHUNK]
+        inter_valid_vmem,      # f32[NC_padded, CHUNK]
+        carry_factor_vmem,     # f32[NC_padded, HBG]
+        h_init_scratch,        # f32[HBG, P, N]    persists across iterations
+    ):
+        """One-chunk body: y_intra + y_inter + h_init update."""
+        c = pl.program_id(0)
+
+        # ----- per-chunk metadata (closed over VMEM refs) -----
+        ls_chunk          = local_seg_vmem[c, :]         # (CHUNK,) i32
+        inter_valid_chunk = inter_valid_vmem[c, :]       # (CHUNK,) f32
+        carry_factor_h    = carry_factor_vmem[c, :]      # (H,) f32
+
+        x_h_pj = x_ref[0]                                 # (H, P, CHUNK) bf16
+        B_h    = B_ref[0]                                 # (H, CHUNK, N) bf16
+        C_h    = C_ref[0]                                 # (H, CHUNK, N) bf16
+        dt_v_h = dt_v_ref[0].astype(jnp.float32)          # (H, CHUNK) f32
+        clog_h = clog_ref[0]                              # (H, CHUNK) f32
+
+        # ----- prepare h_init for y_inter; precompute decay·inter_valid -----
+        # y_inter is computed *per i-tile* (next loop) to keep the live VMEM
+        # footprint small. h_init is hoisted once.
+        h_init_f32 = h_init_scratch[...]                                   # (H, P, N) f32
+        h_init_bf  = h_init_f32.astype(jnp.bfloat16)                       # (H, P, N) bf16
+
+        decay_h = jnp.exp(clog_h)                                          # (H, CHUNK) f32
+        factor_h_t = decay_h * inter_valid_chunk[None, :]                  # (H, CHUNK) f32
+
+        # ----- Phase A part 1: h_local (state at end of chunk) -----
+        last_clog = clog_h[:, CHUNK - 1]                                  # (H,)
+        last_ls   = ls_chunk[CHUNK - 1]                                   # scalar i32
+
+        same_seg_end_bool = (ls_chunk == last_ls)                         # (CHUNK,) bool
+        log_diff_end = last_clog[:, None] - clog_h                        # (H, CHUNK) f32
+        log_diff_end_safe = jnp.where(
+            same_seg_end_bool[None, :], log_diff_end, jnp.float32(MASK_FILL)
+        )
+        w_end_h = jnp.exp(log_diff_end_safe) * dt_v_h                     # (H, CHUNK) f32
+
+        weighted_x_bf = (
+            w_end_h[:, None, :] * x_h_pj.astype(jnp.float32)
+        ).astype(jnp.bfloat16)                                            # (H, P, CHUNK) bf16
+
+        h_local = jnp.matmul(
+            weighted_x_bf,                                                # (H, P, CHUNK)
+            B_h,                                                          # (H, CHUNK, N)
+            preferred_element_type=jnp.float32,
+        )                                                                  # (H, P, N) f32
+
+        # ----- Phase A part 2: y_intra per i-tile, summed with y_inter -----
+        j_idx = jnp.arange(CHUNK, dtype=jnp.int32)
+
+        for it in range(NUM_I_TILES):
+            i_start  = it * I_TILE
+            C_i      = C_h[:, i_start:i_start + I_TILE, :]                # (H, I_TILE, N)
+            clog_i   = clog_h[:, i_start:i_start + I_TILE]                # (H, I_TILE)
+            ls_i     = ls_chunk[i_start:i_start + I_TILE]                 # (I_TILE,)
+            i_global = i_start + jnp.arange(I_TILE, dtype=jnp.int32)
+
+            score_bf = jnp.matmul(
+                C_i,                                                      # (H, I_TILE, N)
+                B_h.swapaxes(-1, -2),                                     # (H, N, CHUNK)
+                preferred_element_type=jnp.float32,
+            ).astype(jnp.bfloat16)                                        # (H, I_TILE, CHUNK)
+
+            mask_ij_bool = (
+                (ls_i[:, None] == ls_chunk[None, :])
+                & (j_idx[None, :] <= i_global[:, None])
+            )                                                              # (I_TILE, CHUNK) bool
+
+            log_diff_raw = clog_i[:, :, None] - clog_h[:, None, :]        # (H, I_TILE, CHUNK)
+            log_diff_safe = jnp.where(
+                mask_ij_bool[None, :, :], log_diff_raw, jnp.float32(MASK_FILL)
+            )
+
+            M_bf = (
+                jnp.exp(log_diff_safe) * dt_v_h[:, None, :]
+            ).astype(jnp.bfloat16)                                        # (H, I_TILE, CHUNK)
+
+            W_bf = M_bf * score_bf                                        # (H, I_TILE, CHUNK)
+
+            y_tile_intra = jax.lax.dot_general(
+                x_h_pj,                                                   # (H, P, CHUNK) bf16
+                W_bf,                                                     # (H, I_TILE, CHUNK) bf16
+                dimension_numbers=(((2,), (2,)), ((0,), (0,))),
+                preferred_element_type=jnp.float32,
+            )                                                              # (H, P, I_TILE) f32
+
+            # y_inter for this i-tile: (H, P, I_TILE) = matmul(h_init, C_i^T)
+            # Computed per-tile to keep live VMEM smaller than materialising
+            # the full (H, P, CHUNK) y_inter buffer upfront.
+            y_inter_tile = jnp.matmul(
+                h_init_bf,                                                # (H, P, N) bf16
+                C_i.swapaxes(-1, -2),                                     # (H, N, I_TILE) bf16
+                preferred_element_type=jnp.float32,
+            )                                                              # (H, P, I_TILE) f32
+            factor_tile = factor_h_t[:, i_start:i_start + I_TILE]         # (H, I_TILE) f32
+            y_inter_tile = y_inter_tile * factor_tile[:, None, :]         # (H, P, I_TILE)
+
+            y_tile = y_tile_intra + y_inter_tile
+            y_ref[0, :, :, i_start:i_start + I_TILE] = y_tile.astype(jnp.bfloat16)
+
+        # ----- Update h_init scratch for next chunk -----
+        # h_init ← carry_factor[c] * h_init + h_local
+        h_init_new = carry_factor_h[:, None, None] * h_init_f32 + h_local
+        h_init_scratch[...] = h_init_new
+
+    def _outer_kernel(
+        x_hbm, dt_v_hbm, clog_hbm, B_hbm, C_hbm,
+        local_seg_vmem, inter_valid_vmem, carry_factor_vmem,
+        y_hbm,
+        h_init_scratch,
+    ):
+        # Zero-initialize the cross-chunk h_init accumulator.
+        h_init_scratch[...] = jnp.zeros((HBG_SIZE, P, N), jnp.float32)
+
+        from functools import partial
+        body = partial(
+            _inner_body,
+            local_seg_vmem=local_seg_vmem,
+            inter_valid_vmem=inter_valid_vmem,
+            carry_factor_vmem=carry_factor_vmem,
+            h_init_scratch=h_init_scratch,
+        )
+
+        pltpu.emit_pipeline(
+            body,
+            grid=(NumChunks,),
+            in_specs=[
+                pl.BlockSpec((1, HBG_SIZE, P, CHUNK), lambda c: (c, 0, 0, 0)),    # x
+                pl.BlockSpec((1, HBG_SIZE, CHUNK),    lambda c: (c, 0, 0)),       # dt_v
+                pl.BlockSpec((1, HBG_SIZE, CHUNK),    lambda c: (c, 0, 0)),       # clog
+                pl.BlockSpec((1, HBG_SIZE, CHUNK, N), lambda c: (c, 0, 0, 0)),    # B
+                pl.BlockSpec((1, HBG_SIZE, CHUNK, N), lambda c: (c, 0, 0, 0)),    # C
+            ],
+            out_specs=[
+                pl.BlockSpec((1, HBG_SIZE, P, CHUNK), lambda c: (c, 0, 0, 0)),    # y
+            ],
+        )(
+            x_hbm, dt_v_hbm, clog_hbm, B_hbm, C_hbm, y_hbm,
+        )
+
+    return _outer_kernel
+
+
+def _single_pallas_kernel(
+    x_h, dt_v_h, cum_log_a_h, B_h, C_h,
+    local_seg_per_chunk, inter_valid_per_chunk, carry_factor_per_chunk,
+):
+    NumChunks, H, P, _CHUNK = x_h.shape
+    N = B_h.shape[-1]
+    NC_padded = local_seg_per_chunk.shape[0]
+    assert _CHUNK == CHUNK
+    assert H == HBG_SIZE, f"v6 expects full H={HBG_SIZE} per program; got H={H}"
+
+    out_shape = [jax.ShapeDtypeStruct((NumChunks, H, P, CHUNK), jnp.bfloat16)]
+
+    outer_kernel = _build_outer_kernel(NumChunks, NC_padded, H, P, N)
+
+    HBM  = pltpu.MemorySpace.HBM
+    VMEM = pltpu.MemorySpace.VMEM
+
+    return pl.pallas_call(
+        outer_kernel,
+        in_specs=[
+            pl.BlockSpec(memory_space=HBM),   # x
+            pl.BlockSpec(memory_space=HBM),   # dt_v
+            pl.BlockSpec(memory_space=HBM),   # cum_log_a
+            pl.BlockSpec(memory_space=HBM),   # B
+            pl.BlockSpec(memory_space=HBM),   # C
+            pl.BlockSpec(memory_space=VMEM),  # local_seg
+            pl.BlockSpec(memory_space=VMEM),  # inter_valid
+            pl.BlockSpec(memory_space=VMEM),  # carry_factor
+        ],
+        out_specs=[pl.BlockSpec(memory_space=HBM)],
+        out_shape=out_shape,
+        scratch_shapes=[pltpu.VMEM((HBG_SIZE, P, N), jnp.float32)],
+        compiler_params=pltpu.CompilerParams(vmem_limit_bytes=96 * 1024 * 1024),
+    )(
+        x_h, dt_v_h, cum_log_a_h, B_h, C_h,
+        local_seg_per_chunk, inter_valid_per_chunk, carry_factor_per_chunk,
+    )
+
+
+def _compute_chunk_metadata(cu_seqlens: jax.Array, T_pad: int, T_real: int):
+    """Per-token metadata. Compact (NumChunks, CHUNK) layout; leading dim
+    padded to multiple of 8 for VMEM dynamic-slice."""
+    NumChunks = T_pad // CHUNK
+    NC_padded = ((NumChunks + 7) // 8) * 8
+
+    idx = jnp.arange(T_pad, dtype=cu_seqlens.dtype)
+    valid_full = idx < jnp.asarray(T_real, dtype=cu_seqlens.dtype)
+    seg_real = jnp.searchsorted(cu_seqlens[1:], idx, side="right").astype(jnp.int32)
+    seg_pad_offset = (
+        jnp.arange(T_pad, dtype=jnp.int32) + jnp.int32(cu_seqlens.shape[0] + 1000)
+    )
+    seg_id = jnp.where(valid_full, seg_real, seg_pad_offset)
+
+    seg_id_c = seg_id.reshape(NumChunks, CHUNK)
+    valid_c  = valid_full.reshape(NumChunks, CHUNK).astype(jnp.int32)
+
+    seg_prev = jnp.concatenate([seg_id_c[:, :1], seg_id_c[:, :-1]], axis=1)
+    is_new = (seg_id_c != seg_prev).astype(jnp.int32)
+    is_new = is_new.at[:, 0].set(0)
+    local_seg = jnp.cumsum(is_new, axis=1).astype(jnp.int32)
+
+    chunk_first_seg = seg_id_c[:, 0]
+    chunk_last_seg  = seg_id_c[:, -1]
+    prev_last = jnp.concatenate(
+        [jnp.full((1,), -1, dtype=chunk_last_seg.dtype), chunk_last_seg[:-1]]
+    )
+    first_b = (chunk_first_seg != prev_last).astype(jnp.int32)
+
+    # Sublane-padded layouts.
+    local_seg_pad = jnp.zeros((NC_padded, CHUNK), dtype=jnp.int32).at[:NumChunks].set(local_seg)
+    return local_seg, valid_c, first_b, local_seg_pad, NumChunks, NC_padded
+
+
+def ssd_candidate(x, dt, A_log, B, C, cu_seqlens):
+    T, H, P = x.shape
+    _, _, N = B.shape
+
+    pad = (-T) % CHUNK
+    T_pad = T + pad
+    if pad > 0:
+        x  = jnp.pad(x,  ((0, pad), (0, 0), (0, 0)))
+        dt = jnp.pad(dt, ((0, pad), (0, 0)))
+        B  = jnp.pad(B,  ((0, pad), (0, 0), (0, 0)))
+        C  = jnp.pad(C,  ((0, pad), (0, 0), (0, 0)))
+
+    local_seg, valid_c, first_b, local_seg_pad, NumChunks, NC_padded = (
+        _compute_chunk_metadata(cu_seqlens, T_pad, T)
+    )
+
+    # JAX-side cum_log_a (cumsum unimplemented in Pallas-TPU lowering).
+    dt_full = dt.astype(jnp.float32)
+    valid_full_f32 = valid_c.reshape(T_pad).astype(jnp.float32)
+    log_a   = (A_log[None, :] * dt_full) * valid_full_f32[:, None]                # (T_pad, H) f32
+    log_a_c = log_a.reshape(NumChunks, CHUNK, H)
+    cum_log_a_c = jnp.cumsum(log_a_c, axis=1)                                     # (NC, CHUNK, H) f32
+
+    # ----- Precompute small VMEM-resident tensors -----
+    # carry_factor[c, h] = exp(cum_log_a[c, -1, h]) * (1 if chunk has no reset else 0)
+    last_local_seg  = local_seg[:, -1]                                             # (NC,) i32
+    has_internal    = (last_local_seg > 0)
+    chunk_has_reset = (first_b != 0) | has_internal
+    no_reset_f32    = jnp.logical_not(chunk_has_reset).astype(jnp.float32)         # (NC,)
+    full_decay_end  = jnp.exp(cum_log_a_c[:, CHUNK - 1, :])                        # (NC, H)
+    carry_factor    = full_decay_end * no_reset_f32[:, None]                       # (NC, H) f32
+
+    # inter_valid[c, t] = (local_seg[c, t] == 0) AND (first_b[c] == 0) AND (valid[c, t] != 0)
+    inter_valid = (
+        (local_seg == 0) & (first_b[:, None] == 0) & (valid_c != 0)
+    ).astype(jnp.float32)                                                          # (NC, CHUNK) f32
+
+    # Pad leading axis to NC_padded for sublane-tile-aligned VMEM dynamic-slice.
+    carry_factor_pad = jnp.zeros((NC_padded, H), dtype=jnp.float32).at[:NumChunks].set(carry_factor)
+    inter_valid_pad  = jnp.zeros((NC_padded, CHUNK), dtype=jnp.float32).at[:NumChunks].set(inter_valid)
+
+    # Fold valid_j into dt; the kernel reads dt_v and never re-multiplies by valid.
+    dt_v_full = (dt_full * valid_full_f32[:, None]).astype(jnp.bfloat16)           # (T_pad, H)
+
+    # H-leading layout; x and y carry (NC, H, P, CHUNK).
+    x_h         = x.reshape(NumChunks, CHUNK, H, P).transpose(0, 2, 3, 1)          # (NC, H, P, CHUNK)
+    B_h         = B.reshape(NumChunks, CHUNK, H, N).transpose(0, 2, 1, 3)          # (NC, H, CHUNK, N)
+    C_h         = C.reshape(NumChunks, CHUNK, H, N).transpose(0, 2, 1, 3)          # (NC, H, CHUNK, N)
+    dt_v_h      = dt_v_full.reshape(NumChunks, CHUNK, H).transpose(0, 2, 1)        # (NC, H, CHUNK)
+    cum_log_a_h = cum_log_a_c.transpose(0, 2, 1)                                    # (NC, H, CHUNK)
+
+    (y_h_pj,) = _single_pallas_kernel(
+        x_h, dt_v_h, cum_log_a_h, B_h, C_h,
+        local_seg_pad, inter_valid_pad, carry_factor_pad,
+    )                                                                               # (NC, H, P, CHUNK) bf16
+
+    # Repack to (T_pad, H, P) then slice off padding.
+    y_full = y_h_pj.transpose(0, 3, 1, 2).reshape(T_pad, H, P)                      # (T_pad, H, P) bf16
+    return y_full[:T]
+
+
+ssd_candidate_jit = jax.jit(ssd_candidate)
+

--- a/tpu_inference/layers/common/fused_moe_gmm.py
+++ b/tpu_inference/layers/common/fused_moe_gmm.py
@@ -120,6 +120,22 @@ def apply_scoring_fn(scoring_fn: str, x: jax.Array) -> jax.Array:
                 f"FusedMoE does not support {scoring_fn} scoring function")
 
 
+def apply_nongated_act(activation: str, x: jax.Array) -> jax.Array:
+    base = (activation[:-len("_no_mul")] if activation.endswith("_no_mul") else activation)
+    match base:
+        case "relu2":
+            return jax.nn.relu(x)**2
+        case "silu":
+            return jax.nn.silu(x)
+        case "gelu":
+            return jax.nn.gelu(x, approximate=False)
+        case "gelu_tanh":
+            return jax.nn.gelu(x, approximate=True)
+        case _:
+            raise NotImplementedError(
+                f"Unsupported non-gated activation: {activation}")
+
+
 def gmm_wrapper(lhs,
                 rhs,
                 rhs_scale,
@@ -205,7 +221,10 @@ def moe_gmm_local(x: jax.Array,
 
     assert parallelism in ["tp", "ep"]
 
-    # GMM1 computes x @ (W_up | W_gate) together and activation, output is [tokens,padded_intermediate_size]
+    # GMM1: gated activations fuse act(gate) * up inside the kernel (w1 is the
+    # W_up | W_gate concat, intermediate x 2). Non-gated activations (is_act_and_mul=False) do a plain
+    # up-projection (fuse_act=None, intermediate x 1) and apply act() in JAX.
+    is_gated = not activation.endswith("_no_mul")
     gmm1_res = gmm_wrapper(
         x,
         w1,
@@ -213,9 +232,11 @@ def moe_gmm_local(x: jax.Array,
         w1_bias,
         group_sizes,
         group_offset,
-        fuse_act=activation,
+        fuse_act=activation if is_gated else None,
         preferred_element_type=x.dtype,
     )
+    if not is_gated:
+        gmm1_res = apply_nongated_act(activation, gmm1_res)
 
     # When the parallelism is TP since w2_bias is not sharded, we should only apply bias
     # once, not applying to every shard. So we set w2_bias to 0 to all shards other than

--- a/tpu_inference/layers/common/mamba2_ssd.py
+++ b/tpu_inference/layers/common/mamba2_ssd.py
@@ -31,6 +31,7 @@ import jax
 import jax.numpy as jnp
 from jax.sharding import PartitionSpec as P
 
+from tpu_inference.kernels.mamba2.jagged_ssd import HBG_SIZE, ssd_candidate
 from tpu_inference.layers.common.ragged_conv1d_jax import ragged_conv1d
 from tpu_inference.layers.common.sharding import ShardingAxisName
 
@@ -107,6 +108,56 @@ def ragged_mamba2_ssd(
     return new_state, y  # (num_blocks, H, P, N), (num_tokens, H, P)
 
 
+def prefill_ssd_jagged(x, B_g, C_g, dt, A, dt_bias, D, cu_seqlens, *, n_groups):
+    """Fresh-state prefill via the jagged chunked SSD Pallas kernel.
+
+    Much faster than the token-by-token scan for prefill (the kernel is chunked /
+    parallel; the scan is O(T) serial). The kernel emits only y, so the
+    per-sequence final ssm_state is computed in closed form (no scan):
+        state_s = sum_{t in seq s} exp(cumA_last_s - cumA_t) * dt_t * (x_t (x) B_t)
+    where cumA is the per-segment cumulative sum of log(a), a = exp(dt * A).
+
+    Only valid for fresh prefill (no initial state). Returns
+    (y (T,H,P), final_states (num_seqs,H,P,N)).
+    """
+    T, H, P_dim = x.shape
+    hpg = H // n_groups
+    B = jnp.repeat(B_g, hpg, axis=1)  # (T,H,N)
+    C = jnp.repeat(C_g, hpg, axis=1)
+    A_f = A.astype(jnp.float32)
+    dt_sp = jax.nn.softplus(dt.astype(jnp.float32) + dt_bias[None, :])  # (T,H)
+
+    # y via the kernel (pad heads H -> HBG_SIZE; the kernel hardcodes H=128).
+    # The kernel's A_log arg is the coefficient in log(a)=A_log*dt, i.e. A itself
+    # (already -exp(A_log_ckpt), negative) — pass A directly. Padded heads carry
+    # x=B=0 so they contribute 0; sliced off afterwards.
+    hp = HBG_SIZE - H
+    xk = jnp.pad(x, ((0, 0), (0, hp), (0, 0)))
+    dtk = jnp.pad(dt_sp.astype(jnp.bfloat16), ((0, 0), (0, hp)))
+    Bk = jnp.pad(B, ((0, 0), (0, hp), (0, 0)))
+    Ck = jnp.pad(C, ((0, 0), (0, hp), (0, 0)))
+    A_log_k = jnp.pad(A_f, ((0, hp), ), constant_values=-1.0)
+    yk = ssd_candidate(xk, dtk, A_log_k, Bk, Ck, cu_seqlens)  # (T,128,P)
+    y = yk[:, :H, :].astype(jnp.float32) + D[None, :, None] * x.astype(
+        jnp.float32)  # + D skip
+
+    # Per-sequence final state, closed form (segment-wise weighted sum).
+    log_a = dt_sp * A_f  # (T,H)
+    idx = jnp.arange(T)
+    seg = jnp.searchsorted(cu_seqlens[1:], idx, side="right")  # token -> seg id
+    S = cu_seqlens.shape[0] - 1
+    seg_start = cu_seqlens[seg]
+    pref = jnp.cumsum(log_a, axis=0)  # global inclusive prefix
+    start_pref = (pref - log_a)[seg_start]  # exclusive prefix at segment start
+    cumA = pref - start_pref  # per-segment inclusive cumsum
+    cumA_last = cumA[cu_seqlens[1:] - 1]  # (S,H) at each segment's last token
+    w = jnp.exp(cumA_last[seg] - cumA) * dt_sp  # (T,H)
+    wx = w[:, :, None] * x.astype(jnp.float32)  # (T,H,P)
+    onehot = (seg[:, None] == jnp.arange(S)[None, :]).astype(jnp.float32)
+    states = jnp.einsum("ts,thp,thn->shpn", onehot, wx, B.astype(jnp.float32))
+    return y.astype(x.dtype), states
+
+
 def _run_local(x_l, B_l, C_l, dt, conv_state, ssm_state, cw_x, cw_B, cw_C, cb_x,
                cb_B, cb_C, A, dt_bias, D, query_start_loc, state_indices,
                distribution, seq_lens, *, n_groups, n_heads, head_dim, ssm_n,
@@ -146,19 +197,46 @@ def _run_local(x_l, B_l, C_l, dt, conv_state, ssm_state, cw_x, cw_B, cw_C, cb_x,
     B = out_xBC[:, inter:inter + groups_ssm].reshape(-1, n_groups, ssm_n)
     C = out_xBC[:, inter + groups_ssm:].reshape(-1, n_groups, ssm_n)
 
-    new_ssm, y = ragged_mamba2_ssd(x,
-                                   B,
-                                   C,
-                                   dt,
-                                   ssm_state,
-                                   A,
-                                   dt_bias,
-                                   D,
-                                   query_start_loc,
-                                   state_indices,
-                                   distribution,
-                                   has_initial_state,
-                                   n_groups=n_groups)
+    # Pure fresh prefill (no decode tokens, no prior state) takes the chunked
+    # jagged kernel; decode / mixed / continuation batches take the token scan.
+    num_valid = distribution[2]
+    valid_seq = jnp.arange(seq_lens.shape[0]) < num_valid
+    use_jagged = (distribution[0] == 0) & jnp.logical_not(
+        jnp.where(valid_seq, has_initial_state, False).any())
+
+    def _jagged():
+        y_j, states = prefill_ssd_jagged(x,
+                                         B,
+                                         C,
+                                         dt,
+                                         A,
+                                         dt_bias,
+                                         D,
+                                         query_start_loc,
+                                         n_groups=n_groups)
+        # Write final states for valid sequences only (padding reqs keep theirs).
+        cur = ssm_state[state_indices]
+        new_ssm_j = ssm_state.at[state_indices].set(
+            jnp.where(valid_seq[:, None, None, None],
+                      states.astype(ssm_state.dtype), cur))
+        return new_ssm_j, y_j
+
+    def _scan():
+        return ragged_mamba2_ssd(x,
+                                 B,
+                                 C,
+                                 dt,
+                                 ssm_state,
+                                 A,
+                                 dt_bias,
+                                 D,
+                                 query_start_loc,
+                                 state_indices,
+                                 distribution,
+                                 has_initial_state,
+                                 n_groups=n_groups)
+
+    new_ssm, y = jax.lax.cond(use_jagged, _jagged, _scan)
     y = y.reshape(-1, n_heads * head_dim)
     return (new_conv_state, new_ssm), y
 

--- a/tpu_inference/layers/common/mamba2_ssd.py
+++ b/tpu_inference/layers/common/mamba2_ssd.py
@@ -1,0 +1,217 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""JAX Mamba2 SSD for the vLLM Mamba2 mixer on TPU.
+
+Mamba2 is a linear-recurrent + conv1d sequence mixer (like GDN). This module
+provides the SSD core: a ragged token-by-token scan that handles a mixed
+prefill+decode batch in one compiled graph (mirrors ragged_gated_delta_rule),
+plus the per-shard conv1d + SSD body and its shard_map wrapper.
+
+Per-token recurrence (selective_state_update semantics):
+    dt    = softplus(dt + dt_bias)
+    dA    = exp(dt * A),  A = -exp(A_log) (already negated in the layer)
+    state = dA * state + dt * (x ⊗ B)
+    y     = <state, C> + D * x
+B/C are grouped (n_groups < n_heads) and expanded per head.
+"""
+import functools
+
+import jax
+import jax.numpy as jnp
+from jax.sharding import PartitionSpec as P
+
+from tpu_inference.layers.common.ragged_conv1d_jax import ragged_conv1d
+from tpu_inference.layers.common.sharding import ShardingAxisName
+
+
+def ragged_mamba2_ssd(
+    hidden_states,  # (num_tokens, H, P) post-conv x
+    B,  # (num_tokens, n_groups, N)
+    C,  # (num_tokens, n_groups, N)
+    dt,  # (num_tokens, H)
+    recurrent_state,  # (num_blocks, H, P, N) f32 paged cache
+    A,  # (H,) f32, already -exp(A_log)
+    dt_bias,  # (H,) f32
+    D,  # (H,) f32
+    query_start_loc,  # (max_reqs + 1,) i32
+    state_indices,  # (max_reqs,) i32
+    distribution,  # (3,) i32 (decode_end, prefill_end, mixed_end)
+    has_initial_state,  # (max_reqs,) bool
+    *,
+    n_groups: int,
+):
+    """Ragged Mamba2 SSD recurrence over a mixed prefill+decode batch.
+
+    Token-by-token scan: handles prefill (state builds across a sequence) and
+    decode (single token) identically, indexed into the paged ssm_state cache by
+    `state_indices`. Mirrors `ragged_gated_delta_rule`.
+    """
+    num_tokens, H, P_dim = hidden_states.shape
+    heads_per_group = H // n_groups
+    A = A.astype(jnp.float32)
+    max_reqs = state_indices.shape[0]
+    token_idx = jnp.arange(num_tokens)
+
+    num_valid_seqs = distribution[2]
+    valid_loc_mask = jnp.arange(query_start_loc.shape[0]) <= num_valid_seqs
+    last_valid_loc = query_start_loc[num_valid_seqs]
+    eff_qsl = jnp.where(valid_loc_mask, query_start_loc, last_valid_loc)
+    req_indices = jnp.clip(
+        jnp.sum(token_idx[:, None] >= eff_qsl[None, :], axis=1) - 1, 0,
+        max_reqs - 1)
+    valid_mask = token_idx < last_valid_loc
+
+    # Zero the carry state for brand-new prefills (no prior context), once up
+    # front, so the scan body can stay a simple per-token read of the cache.
+    gathered = recurrent_state[state_indices]
+    recurrent_state = recurrent_state.at[state_indices].set(
+        jnp.where(has_initial_state[:, None, None, None], gathered,
+                  jnp.zeros_like(gathered)))
+
+    def expand(bc_t):  # (n_groups, N) -> (H, N)
+        return jnp.repeat(bc_t, heads_per_group, axis=0)
+
+    def scan_fn(state_all, xs):
+        x_t, B_t, C_t, dt_t, req_i, is_valid = xs
+        si = state_indices[req_i]
+        st = state_all[si]  # (H, P, N) f32
+
+        x32 = x_t.astype(jnp.float32)
+        Be = expand(B_t).astype(jnp.float32)
+        Ce = expand(C_t).astype(jnp.float32)
+        dt_sp = jax.nn.softplus(dt_t.astype(jnp.float32) + dt_bias)
+        dA = jnp.exp(dt_sp * A)
+
+        dBx = dt_sp[:, None, None] * x32[:, :, None] * Be[:, None, :]
+        new_st = dA[:, None, None] * st + dBx
+        y = jnp.einsum("hpn,hn->hp", new_st, Ce) + D[:, None] * x32
+
+        state_all = jnp.where(
+            is_valid, state_all.at[si].set(new_st.astype(state_all.dtype)),
+            state_all)
+        return state_all, y.astype(x_t.dtype)
+
+    xs = (hidden_states, B, C, dt, req_indices, valid_mask)
+    new_state, y = jax.lax.scan(scan_fn, recurrent_state, xs)
+    return new_state, y  # (num_blocks, H, P, N), (num_tokens, H, P)
+
+
+def _run_local(x_l, B_l, C_l, dt, conv_state, ssm_state, cw_x, cw_B, cw_C, cb_x,
+               cb_B, cb_C, A, dt_bias, D, query_start_loc, state_indices,
+               distribution, seq_lens, *, n_groups, n_heads, head_dim, ssm_n,
+               kernel_size):
+    """Per-shard conv1d + SSD on a TP shard.
+
+    x/B/C arrive as SEPARATE per-shard tensors (x head-sharded, B/C group-
+    sharded) so this shard's heads and groups correspond; we re-concatenate them
+    into this shard's [x_r | B_r | C_r] for the conv. See `mamba2_core_tpu` for
+    why the concatenated [x|B|C] cannot be sharded as one P(ATTN_HEAD) split.
+    """
+    max_reqs = seq_lens.shape[0]
+    query_lens = query_start_loc[1:max_reqs + 1] - query_start_loc[:max_reqs]
+    has_initial_state = (seq_lens - query_lens) > 0
+
+    mixed_xBC = jnp.concatenate([x_l, B_l, C_l], axis=-1)
+    conv_weight = jnp.concatenate([cw_x, cw_B, cw_C], axis=0)
+    conv_bias = (jnp.concatenate([cb_x, cb_B, cb_C], axis=0)
+                 if cb_x is not None else None)
+
+    out_xBC, new_conv_state = ragged_conv1d(mixed_xBC,
+                                            conv_state,
+                                            conv_weight,
+                                            conv_bias,
+                                            query_start_loc,
+                                            state_indices,
+                                            distribution,
+                                            has_initial_state,
+                                            kernel_size=kernel_size)
+    # vLLM's causal_conv1d_fn applies activation="silu" to the conv output;
+    # ragged_conv1d does not, so apply it here (GDN does the same separately).
+    out_xBC = jax.nn.silu(out_xBC)
+
+    inter = n_heads * head_dim
+    groups_ssm = n_groups * ssm_n
+    x = out_xBC[:, :inter].reshape(-1, n_heads, head_dim)
+    B = out_xBC[:, inter:inter + groups_ssm].reshape(-1, n_groups, ssm_n)
+    C = out_xBC[:, inter + groups_ssm:].reshape(-1, n_groups, ssm_n)
+
+    new_ssm, y = ragged_mamba2_ssd(x,
+                                   B,
+                                   C,
+                                   dt,
+                                   ssm_state,
+                                   A,
+                                   dt_bias,
+                                   D,
+                                   query_start_loc,
+                                   state_indices,
+                                   distribution,
+                                   has_initial_state,
+                                   n_groups=n_groups)
+    y = y.reshape(-1, n_heads * head_dim)
+    return (new_conv_state, new_ssm), y
+
+
+def run_jax_mamba2(x_l, B_l, C_l, j_dt, conv_state, ssm_state, cw_x, cw_B, cw_C,
+                   cb_x, cb_B, cb_C, j_A, j_dt_bias, j_D, query_start_loc,
+                   state_indices, distribution, seq_lens, *, n_groups, n_heads,
+                   head_dim, ssm_n, kernel_size, mesh):
+    """shard_map wrapper over `_run_local` (ATTN_DATA x ATTN_HEAD)."""
+    H = P(ShardingAxisName.ATTN_HEAD)
+    DH = P(ShardingAxisName.ATTN_DATA, ShardingAxisName.ATTN_HEAD)
+    D_ = P(ShardingAxisName.ATTN_DATA)
+    cb_spec = H if cb_x is not None else None
+    in_specs = (
+        DH,
+        DH,
+        DH,  # x_l, B_l, C_l
+        DH,  # dt
+        P(ShardingAxisName.ATTN_DATA, None,
+          ShardingAxisName.ATTN_HEAD),  # conv_state
+        P(ShardingAxisName.ATTN_DATA, ShardingAxisName.ATTN_HEAD, None,
+          None),  # ssm_state
+        P(ShardingAxisName.ATTN_HEAD, None, None),  # cw_x
+        P(ShardingAxisName.ATTN_HEAD, None, None),  # cw_B
+        P(ShardingAxisName.ATTN_HEAD, None, None),  # cw_C
+        cb_spec,
+        cb_spec,
+        cb_spec,  # cb_x/B/C
+        H,
+        H,
+        H,  # A, dt_bias, D
+        D_,
+        D_,
+        D_,
+        D_,  # qsl, state_indices, distribution, seq_lens
+    )
+    out_specs = (
+        (P(ShardingAxisName.ATTN_DATA, None, ShardingAxisName.ATTN_HEAD),
+         P(ShardingAxisName.ATTN_DATA, ShardingAxisName.ATTN_HEAD, None, None)),
+        DH,
+    )
+    local = functools.partial(_run_local,
+                              n_groups=n_groups,
+                              n_heads=n_heads,
+                              head_dim=head_dim,
+                              ssm_n=ssm_n,
+                              kernel_size=kernel_size)
+    return jax.shard_map(local,
+                         mesh=mesh,
+                         in_specs=in_specs,
+                         out_specs=out_specs,
+                         check_vma=False)(x_l, B_l, C_l, j_dt, conv_state,
+                                          ssm_state, cw_x, cw_B, cw_C, cb_x,
+                                          cb_B, cb_C, j_A, j_dt_bias, j_D,
+                                          query_start_loc, state_indices,
+                                          distribution, seq_lens)

--- a/tpu_inference/layers/common/process_weights/moe_weights.py
+++ b/tpu_inference/layers/common/process_weights/moe_weights.py
@@ -249,6 +249,11 @@ def process_w13_for_gmm(tensor,
 
     # Apply padding
     padded_w1 = _pad_tensor(w1)
+    # Non-gated MoE (is_act_and_mul=False, e.g. Nemotron-H ReLU²): w13 holds only
+    # w1 (up projection), so the w3 (gate) half is empty. Return the padded w1
+    # alone — there is no gate half to pad, concatenate, or reorder.
+    if w3.shape[-1] == 0:
+        return padded_w1
     padded_w3 = _pad_tensor(w3)
 
     logger.info(f"{name}_w1 shape after padding: {padded_w1.shape}")

--- a/tpu_inference/layers/vllm/custom_ops/__init__.py
+++ b/tpu_inference/layers/vllm/custom_ops/__init__.py
@@ -17,6 +17,8 @@ from tpu_inference.layers.vllm.custom_ops import fused_moe as fused_moe
 from tpu_inference.layers.vllm.custom_ops import \
     gdn_attention_op as gdn_attention_op
 from tpu_inference.layers.vllm.custom_ops import linear as linear
+from tpu_inference.layers.vllm.custom_ops import \
+    mamba2_mixer_op as mamba2_mixer_op
 from tpu_inference.layers.vllm.custom_ops import mhc as mhc
 from tpu_inference.layers.vllm.custom_ops import mla_attention as mla_attention
 from tpu_inference.layers.vllm.custom_ops import rope as rope

--- a/tpu_inference/layers/vllm/custom_ops/mamba2_mixer_op.py
+++ b/tpu_inference/layers/vllm/custom_ops/mamba2_mixer_op.py
@@ -1,0 +1,168 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""TPU lowering for vLLM's Mamba2 mixer (MambaMixer2).
+
+vLLM's MambaMixer2.forward calls `torch.ops.vllm.mamba_mixer2`, a custom op with
+no torchax lowering. We OOT-override the layer (same mechanism as the GDN op) so
+its forward runs conv1d + SSD in JAX. Importing this module registers the
+override; it is imported from `custom_ops/__init__.py`.
+
+Used by hybrid Mamba2-Transformer-MoE models such as Nemotron-H.
+"""
+import jax
+import jax.numpy as jnp
+import torch
+from torchax.interop import jax_view, torch_view
+from vllm.forward_context import get_forward_context
+from vllm.model_executor.layers.mamba.mamba_mixer2 import MambaMixer2
+
+from tpu_inference.layers.common.mamba2_ssd import run_jax_mamba2
+from tpu_inference.layers.common.sharding import ShardingAxisName
+from tpu_inference.logger import init_logger
+from tpu_inference.models.vllm.vllm_model_wrapper_context import \
+    get_vllm_model_wrapper_context
+from tpu_inference.utils import get_mesh_shape_product
+
+logger = init_logger(__name__)
+
+
+def mamba2_core_tpu(mixed_xBC: torch.Tensor, dt: torch.Tensor,
+                    output: torch.Tensor, layer_name: str,
+                    mesh: jax.sharding.Mesh) -> None:
+    """Bridge between PyTorch (torchax) and JAX for the Mamba2 conv1d + SSD core.
+
+    Reads the ragged mamba metadata and the paged conv/ssm caches, runs conv1d +
+    the SSD scan under shard_map, writes the caches back, and copies the result
+    into `output` (an in-place update, mirroring the GDN core op).
+    """
+    fc = get_forward_context()
+    md = fc.attn_metadata[layer_name]
+    layer = fc.no_compile_layers[layer_name]
+    vctx = get_vllm_model_wrapper_context()
+
+    tp = get_mesh_shape_product(mesh, ShardingAxisName.ATTN_HEAD)
+    n_heads = layer.num_heads // tp
+    head_dim = layer.head_dim
+    n_groups = layer.n_groups // tp
+    ssm_n = layer.ssm_state_size
+    kernel_size = layer.conv_kernel_size
+    inter = layer.intermediate_size  # full
+    groups_ssm = layer.groups_ssm_state_size  # full
+    conv_dim = inter + 2 * groups_ssm
+
+    # Split [x | B | C] at the x/B/C boundaries and feed them to the SSD as
+    # SEPARATE shard_map args. The concatenated mixed_xBC has layout
+    # [x_full | B_full | C_full] where x is head-sharded but B/C are group-
+    # sharded; handing the concat to one P(ATTN_HEAD) split would slice it into
+    # contiguous chunks that cross the x/B/C boundaries, so a shard's x-heads and
+    # B/C-groups would belong to different logical quarters. Splitting first
+    # (each part contiguously shardable) and re-concatenating per shard inside
+    # `_run_local` keeps each shard's heads and groups aligned. Split by a
+    # fraction of each tensor's own dim so it works whether the dim is logical-
+    # full (conv_dim) or per-shard (conv_dim / tp).
+    def _split3(t, axis):
+        d = t.shape[axis]
+        n1 = d * inter // conv_dim
+        n2 = d * groups_ssm // conv_dim
+        sl = [slice(None)] * t.ndim
+
+        def part(a, b):
+            sl[axis] = slice(a, b)
+            return t[tuple(sl)]
+
+        return part(0, n1), part(n1, n1 + n2), part(n1 + n2, d)
+
+    xb, bb, cb_xbc = _split3(mixed_xBC, -1)
+    x_l, B_l, C_l = jax_view(xb), jax_view(bb), jax_view(cb_xbc)
+    j_dt = jax_view(dt)
+    cwx, cwb, cwc = _split3(layer.conv1d.weight, 0)  # (conv_dim/tp, 1, kernel)
+    cw_x, cw_B, cw_C = jax_view(cwx), jax_view(cwb), jax_view(cwc)
+    if layer.conv1d.bias is not None:
+        cbx, cbb, cbc = _split3(layer.conv1d.bias, 0)
+        cb_x, cb_B, cb_C = jax_view(cbx), jax_view(cbb), jax_view(cbc)
+    else:
+        cb_x = cb_B = cb_C = None
+    j_A = jax_view(layer.A)  # already -exp(A_log)
+    j_dt_bias = jax_view(layer.dt_bias)
+    j_D = jax_view(layer.D)
+
+    layer_idx = vctx.layer_name_to_kvcache_index[layer_name]
+    conv_state, ssm_state = vctx.kv_caches[layer_idx]
+
+    pad = md.padded_num_reqs
+    dp = get_mesh_shape_product(mesh, ShardingAxisName.ATTN_DATA)
+    state_indices = md.mamba_state_indices.astype(jnp.int32)[:pad]
+    qsl = md.query_start_loc[:pad + dp]
+    seq_lens = md.seq_lens[:pad]
+
+    (new_conv, new_ssm), y = run_jax_mamba2(x_l,
+                                            B_l,
+                                            C_l,
+                                            j_dt,
+                                            conv_state,
+                                            ssm_state,
+                                            cw_x,
+                                            cw_B,
+                                            cw_C,
+                                            cb_x,
+                                            cb_B,
+                                            cb_C,
+                                            j_A,
+                                            j_dt_bias,
+                                            j_D,
+                                            qsl,
+                                            state_indices,
+                                            md.request_distribution,
+                                            seq_lens,
+                                            n_groups=n_groups,
+                                            n_heads=n_heads,
+                                            head_dim=head_dim,
+                                            ssm_n=ssm_n,
+                                            kernel_size=kernel_size,
+                                            mesh=mesh)
+
+    vctx.kv_caches[layer_idx] = (new_conv, new_ssm)
+    output.copy_(torch_view(y.reshape(output.shape)))
+
+
+@MambaMixer2.register_oot
+class VllmMambaMixer2(MambaMixer2):
+
+    def forward(self, hidden_states: torch.Tensor,
+                mup_vector: torch.Tensor | None = None) -> torch.Tensor:
+        mesh = get_vllm_model_wrapper_context().mesh
+
+        # 1. in_proj, then split [gate | x|B|C | dt] (per-shard local sizes).
+        projected_states, _ = self.in_proj(hidden_states)
+        if mup_vector is not None:
+            projected_states = projected_states * mup_vector
+        gate = projected_states[..., :self.tped_intermediate_size]
+        rest = projected_states[..., self.tped_intermediate_size:]
+        mixed_xBC = rest[..., :self.tped_conv_size]
+        dt = rest[..., self.tped_conv_size:]
+
+        # 2. conv1d + SSD core (custom op).
+        ssm_out = torch.zeros(
+            (hidden_states.shape[0], self.tped_intermediate_size),
+            dtype=hidden_states.dtype,
+            device=hidden_states.device)
+        mamba2_core_tpu(mixed_xBC, dt, ssm_out, self.prefix, mesh)
+
+        # 3. gated RMSNorm (applies SiLU to the gate internally) + out_proj.
+        hidden_states = self.norm(ssm_out, gate)
+        out, _ = self.out_proj(hidden_states)
+        return out
+
+
+logger.info_once("Registered TPU OOT MambaMixer2 (Mamba2 mixer JAX lowering)")

--- a/tpu_inference/layers/vllm/quantization/unquantized.py
+++ b/tpu_inference/layers/vllm/quantization/unquantized.py
@@ -381,8 +381,11 @@ class VllmUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod,
         assert shard_id is not None, "Expecting shard_id argument"
         # Keep track of loaded weights for MoE layers, e.g. (('0', 'w1'), ('0', 'w2'), ('0', 'w3'), ('1', 'w1'), ...)
         layer._loaded_weights.add((expert_id, shard_id))
-        if len(layer._loaded_weights) == layer.global_num_experts * len(
-            ('w1', 'w2', 'w3')):
+
+        # Non-gated MoE (is_act_and_mul=False)
+        # loads only w1 (up) and w2 (down) per expert; gated SwiGLU loads w1, w2, w3.
+        num_shards = 3 if layer.moe_config.is_act_and_mul else 2
+        if len(layer._loaded_weights) == layer.global_num_experts * num_shards:
             logger.debug(f"Start sharding weights for layer {type(layer)}")
             self.process_weights_after_loading(layer)
             logger.debug(f"Complete sharding weights for layer {type(layer)}")

--- a/tpu_inference/runner/kv_cache_manager.py
+++ b/tpu_inference/runner/kv_cache_manager.py
@@ -767,7 +767,7 @@ class KVCacheManager:
                         if len(group_sizes) > 1:
                             logger.warning_once(
                                 "Non-uniform KV-cache group sizes %s (hybrid model with irregular attention spacing); "
-                                "handled via per-group sizing.", sorted(group_sizes))
+                                "handled via per-group sizing.", tuple(sorted(group_sizes)))
                     break
 
         flat_layer_idx = 0

--- a/tpu_inference/runner/kv_cache_manager.py
+++ b/tpu_inference/runner/kv_cache_manager.py
@@ -757,13 +757,20 @@ class KVCacheManager:
                     if non_mtp_tensors:
                         # assert that each kv_cache_tensor in kv_cache_config.kv_cache_tensors has the same number of shared layers
                         # This is needed for models like Qwen3.5 where every 4 layers share the same KV cache (3 linear attn and 1 full attn)
-                        num_shared_layers = len(non_mtp_tensors[0].shared_by)
-                        for kv_cache_tensor in non_mtp_tensors:
-                            assert len(
-                                kv_cache_tensor.shared_by
-                            ) == num_shared_layers, f"Expected all non-MTP kv_cache_tensors to have the same number of shared layers {num_shared_layers}, but found {len(kv_cache_tensor.shared_by)}"
+                        # Uniform groups are the common case, but hybrid models with irregular attention spacing (e.g. Nemotron-H: MEMEM*EMEMEM*...)
+                        # produce non-uniform groups. That is supported: each tensor's num_blocks is sized from its own shared_by
+                        # below, and layer indices use a running counter (not i * group_size), so both cases work.
+                        group_sizes = {
+                            len(t.shared_by)
+                            for t in non_mtp_tensors
+                        }
+                        if len(group_sizes) > 1:
+                            logger.warning_once(
+                                "Non-uniform KV-cache group sizes %s (hybrid model with irregular attention spacing); "
+                                "handled via per-group sizing.", sorted(group_sizes))
                     break
 
+        flat_layer_idx = 0
         for i, kv_cache_tensor in enumerate(kv_cache_config.kv_cache_tensors):
             if duplicate_shared_layers:
                 total_group_page_size = 0
@@ -952,8 +959,13 @@ class KVCacheManager:
                 if j == 0 or duplicate_shared_layers:
                     num_blocks_list.append(mamba_num_blocks if isinstance(
                         layer_spec, MambaSpec) else num_blocks)
-                layer_idx = (i * num_shared_layers
-                             ) + j if duplicate_shared_layers else i
+                if duplicate_shared_layers:
+                    # one kv_caches entry was appended per layer above, in order;
+                    # the running counter matches that position (works for both uniform and non-uniform group sizes).
+                    layer_idx = flat_layer_idx
+                    flat_layer_idx += 1
+                else:
+                    layer_idx = i
                 self.runner.layer_name_to_kvcache_index[layer_name] = layer_idx
         if self.shared_kv_cache_layers:
             for layer_name, target_layer_name in self.shared_kv_cache_layers.items(


### PR DESCRIPTION
## Summary

Adds TPU support for NVIDIA Nemotron-H, a hybrid model interleaving Mamba2, GQA attention, and non-gated squared-ReLU MoE layers. This PR validates `nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16` end-to-end on TPU v6e-4 with correct output.

The implementation follows the existing GDN integration pattern: unsupported PyTorch/vLLM ops are traced through torchax where possible and replaced with explicit JAX/OOT implementations where torchax has no lowering.

This depends on the companion vLLM-core change that allows `is_act_and_mul=False` on TPU. (vllm-project/vllm#46795)

## Changes

* Adds non-gated MoE support on the TPU GMM path: non-gated experts use `w1/w2`, skip the `w3` split, run plain GMM, and apply squared-ReLU in JAX.
* Supports non-uniform hybrid KV-cache groups produced by irregular attention spacing in Nemotron-H.
* Adds a TPU/JAX lowering for `torch.ops.vllm.mamba_mixer2`, including conv1d, SSD recurrence, cache read/write, gated RMSNorm, and output projection.
* Adds a jagged chunked SSD fresh-prefill kernel, with decode, mixed batches, prefix caching, and continuation prefill falling back to the token-scan path.
* Fixes `warning_once` on non-uniform KV-cache groups by passing a hashable tuple instead of a list.

## Review focus

The most important correctness point is TP sharding of `x/B/C`.

`in_proj` emits `[gate | x | B | C | dt]`, but `x` is head-sharded while `B/C` are group-sharded. Passing concatenated `[x|B|C]` into one `shard_map P(ATTN_HEAD)` slices across tensor boundaries and mismatches `x` heads with `B/C` groups, producing incorrect SSD output.

The fix splits `x`, `B`, and `C` into separate `shard_map` arguments, shards each by its own logical dimension, and re-concatenates them inside the per-shard core.

## Validation

Validated against an HF transformers CPU reference and end-to-end TPU generation:

* Per-shard post-conv `x/B/C` align with the corresponding HF shard after the TP sharding fix.
* Jagged SSD prefill matches the token-scan path for both `y` and final `ssm_state`.
* End-to-end generation on TPU v6e-4 (`tp=4`, bf16, `enforce_eager`) produces expected outputs, including:

  * `The capital of France is` → ` Paris`
  * `The largest planet in our solar system is` → ` Jupiter.`
  * `The opposite of hot is` → ` cold.`

The jagged SSD kernel speeds up isolated fresh prefill substantially versus token-scan; non-fresh-prefill cases remain on the conservative scan path.

## AI assistance

Developed with AI assistance. Every changed line has been reviewed by the submitter.

## Acknowledgements

This work is part of the effort from the [medusa-compute](https://github.com/medusa-compute) team.

Special thanks to @Raphael-Hao for his substantial help and guidance throughout this work.