### PR TITLE
[benchmark] Skip empty metric values in mlcompass_export

### DIFF
--- a/.buildkite/benchmark/scripts/mlcompass_export.py
+++ b/.buildkite/benchmark/scripts/mlcompass_export.py
@@ -59,8 +59,15 @@ def read_metrics_file(file_path: str) -> dict[str, float]:
                 key = key.strip()
                 if key == 'AccuracyMetrics':
                     continue
+                # An empty value means the metric was absent from the benchmark
+                # log (e.g. ITL/TPOT are not emitted for output_len=1 prefill
+                # runs). Skip it rather than crashing on float('') or recording
+                # a misleading 0.
+                value = value.strip()
+                if not value:
+                    continue
                 # Strip extra spaces from key/value and convert value to float
-                metrics_dict[key] = float(value.strip())
+                metrics_dict[key] = float(value)
     return metrics_dict
 
 


### PR DESCRIPTION
## Problem

The daily benchmark `Qwen3.5-397B-Prefill` cases (all GBS variants) fail at the MLCompass export step with:

```
File ".buildkite/benchmark/scripts/mlcompass_export.py", line 63, in read_metrics_file
    metrics_dict[key] = float(value.strip())
ValueError: could not convert string to float: ''
```

even though the benchmark run itself **succeeds** — the server log shows `1000/1000` successful requests with valid TTFT/E2EL/throughput.

## Root cause

`read_metrics_file()` calls `float(value)` on every `key=value` line of the `.result` file written by `report_result.sh`.

These are **prefill-only** cases (`output_len=1`). With a single output token there is no inter-token gap and no second output token, so vLLM's benchmark prints no **ITL** (Inter-Token Latency) or **TPOT** (Time-Per-Output-Token) sections. `report_result.sh`'s `extract_value()` greps for `ITL (ms):` / `TPOT (ms):`, finds nothing, and (via a trailing `|| true`) returns an empty string. Those empties are written as bare lines:

```
MedianITL=
MedianTPOT=
P99ITL=
P99TPOT=
```

and `float("")` then raises, failing the export of an otherwise-passing benchmark.

## Fix

Skip lines whose value is empty in `read_metrics_file()`. The metric is genuinely **absent** (not zero) for these runs, so we omit it rather than recording a misleading `0.0` that would skew any lower-is-better tracking on ITL/TPOT. Non-empty metrics (TTFT, E2EL, throughput, etc.) are exported as before, so `succeeded = bool(metrics)` stays true.