### PR TITLE
[skip ci] [benchmark] Force SPMD DP for gpt_oss_120b DP>1 cases

### DIFF
--- a/.buildkite/benchmark/cases/daily/gpt_oss_120b.json
+++ b/.buildkite/benchmark/cases/daily/gpt_oss_120b.json
@@ -24,7 +24,8 @@
         "env": {
           "VLLM_USE_V1": "1",
           "MODEL_IMPL_TYPE": "vllm",
-          "USE_MOE_EP_KERNEL": "0"
+          "USE_MOE_EP_KERNEL": "0",
+          "TPU_MULTIPROCESS_DP": "0"
         },
         "args": {
           "model": "unsloth/gpt-oss-120b-BF16",
@@ -175,7 +176,8 @@
         "env": {
           "VLLM_USE_V1": "1",
           "MODEL_IMPL_TYPE": "vllm",
-          "USE_MOE_EP_KERNEL": "0"
+          "USE_MOE_EP_KERNEL": "0",
+          "TPU_MULTIPROCESS_DP": "0"
         },
         "args": {
           "model": "openai/gpt-oss-120b",
@@ -227,7 +229,8 @@
         "env": {
           "VLLM_USE_V1": "1",
           "MODEL_IMPL_TYPE": "vllm",
-          "USE_MOE_EP_KERNEL": "0"
+          "USE_MOE_EP_KERNEL": "0",
+          "TPU_MULTIPROCESS_DP": "0"
         },
         "args": {
           "model": "openai/gpt-oss-120b",


### PR DESCRIPTION
## Problem

The daily `gpt_oss_120b` benchmark cases that request `data-parallel-size > 1` (the `BF16` dp=2 case and the two `C2` dp=4 cases) fail at server startup:

```
File ".../tpu_inference/models/vllm/vllm_model_wrapper.py", line 426, in step_fun_impl
    ... set_forward_context(...)
File ".../vllm/forward_context.py", line 289, in set_forward_context
    assert num_tokens is not None
AssertionError
RuntimeError: Engine core initialization failed.
```

The `C1`/no-DP cases pass; only the DP>1 cases are red.

## Root cause

These are MoE models on the `MODEL_IMPL_TYPE=vllm` path served online (`vllm serve`) with DP>1. When `TPU_MULTIPROCESS_DP` is unset, `TpuPlatform._resolve_multiprocess_dp` auto-enables vLLM-native **multi-process DP (MPMD)** for online serving — so each rank is a real vLLM DP engine and `parallel_config.data_parallel_size > 1` reaches vLLM.

vLLM's `set_forward_context` then enters its MoE-DP coordination branch (`data_parallel_size > 1 and is_moe_model`) and requires `num_tokens` to build `DPMetadata`. The tpu-inference vLLM wrapper calls `set_forward_context(attn_metadata=...)` without `num_tokens`, so the `assert num_tokens is not None` fires during compile warmup. tpu-inference doesn't consume vLLM's `DPMetadata` anyway (it shards MoE via the JAX mesh), so the vLLM-wrapper MoE path does not support MPMD DP.

## Fix

Set `TPU_MULTIPROCESS_DP=0` on these three cases to force single-process **SPMD DP**. In SPMD mode the sharding layer folds DP into the JAX mesh and overrides vLLM's `parallel_config.data_parallel_size` to 1, so the MoE-DP branch (and the assertion) is never reached. This is the path these cases used before MPMD DP became the default for online serving.

## Verification

Reproduced and verified on a **TPU7x-8** host with gpt-oss (MoE, `MODEL_IMPL_TYPE=vllm`, TP=2, DP=4 — same config family as the `C2` cases):

- **Default (MPMD)** → `Resolved TPU_MULTIPROCESS_DP=1`, runs as `EngineCore_DP0/1/2/3`, and fails with the exact `assert num_tokens is not None` at `vllm_model_wrapper.py:426`.
- **`TPU_MULTIPROCESS_DP=0`** → engine initializes with `data_parallel_size=1` and a single `EngineCore`, clearing the assertion and proceeding through weight load, warmup and backbone compilation.

## Note

This is a targeted benchmark-config mitigation. The broader fix would be to make `_resolve_multiprocess_dp` keep MoE models on SPMD by default (so no per-case override is needed) or to support MoE under MPMD DP in the wrapper; this PR unblocks the benchmark without changing runtime behavior for other models.