### PR TITLE
Use tree reduction in dense gather reduce

### DIFF
--- a/tpu_inference/kernels/sparse_core/dense_gather_reduce.py
+++ b/tpu_inference/kernels/sparse_core/dense_gather_reduce.py
@@ -199,8 +199,7 @@ def _sc_gather_reduce(
                 def _(col_base):
                     accs = []
                     for reduce_group in range(out_rows_per_step):
-                        acc = jnp.zeros((unpack_col_chunk, ),
-                                        dtype=jnp.float32)
+                        row_datas = []
                         for row_in_group in range(reduce_group_size):
                             row = reduce_group * reduce_group_size + row_in_group
                             row_data = gather_ref[
@@ -211,12 +210,9 @@ def _sc_gather_reduce(
                                 row_data = row_data[0]
                             else:
                                 assert packing == 2
-                                # For dtypes narrower than 32-bit, we end up gathering multiple
-                                # rows (since we had to bitcast to int32 before the gather).
-                                # This uses the remainder of the packing to choose the only row
-                                # we actually care about.
                                 row_data = jnp.where(
-                                    lax.rem(subchunk_idxs[row], 2) == 0,
+                                    lax.bitwise_and(subchunk_idxs[row],
+                                                    1) == 0,
                                     row_data[0],
                                     row_data[1],
                                 )
@@ -226,8 +222,19 @@ def _sc_gather_reduce(
                                     row_data = jnp.where(
                                         weights[row] == 0.0,
                                         jnp.zeros_like(row_data), row_data)
-                            acc += row_data
-                        accs.append(acc)
+                            row_datas.append(row_data)
+
+                        # Tree reduction to reduce critical path and stalls
+                        while len(row_datas) > 1:
+                            next_level = []
+                            for i in range(0, len(row_datas), 2):
+                                if i + 1 < len(row_datas):
+                                    next_level.append(row_datas[i] +
+                                                      row_datas[i + 1])
+                                else:
+                                    next_level.append(row_datas[i])
+                            row_datas = next_level
+                        accs.append(row_datas[0])
                     out = jnp.stack(accs, axis=0).astype(op.dtype)
                     out_ref[:, pl.ds(col_base, unpack_col_chunk)] = out
 


### PR DESCRIPTION
# Description

Previously, we created a sequential dependency chain of vector additions of length reduce_group_size - 1 (which is topk - 1). For topk = 4, it was 3 dependent additions; for topk = 8, it was 7. The Vector ALU had to wait for the previous addition to finish before starting the next one, causing pipeline stalls.

By replacing this with a tree-structured reduction (generating additions in a binary tree shape, like (a + b) + (c + d)), we shortened the critical path of dependent additions to log2(topk):

For topk = 4: Critical path reduced from 3 to 2 additions (~1.2% speedup). For topk = 8: Critical path reduced from 7 to 3 additions (~4.2% speedup).

This optimization reduces stalls and scales well as the topk value increases.

# Tests

To test the correctness of the changes, we ran the dense gather-reduce kernel unit tests on the TPU VM inside the `node` Docker container:

```bash
pytest tests/kernels/dense_gather_reduce_test.py
```
All 54 test cases ran and verified the mathematical correctness of the tree-structured reduction logic.

# Checklist

Before submitting this PR, please make sure:
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have made or will make corresponding changes to any relevant documentation.
