### PR TITLE
Tiered FS offload extension to offload kv connector

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,5 +23,6 @@ runai-model-streamer[s3,gcs]==0.15.9
 gcsfs==2026.1.0
 hypothesis==6.151.9
 sortedcontainers==2.4.0
-# Upstream pins to 5.5.3 https://github.com/vllm-project/vllm/blob/de3fe8dc62f3d77eb8dab8125ca90436f606bccb/requirements/test/nightly-torch.txt#L32
 transformers>=5.8.0
+tensorstore>=0.1.50
+zarr>=2.16.0

--- a/tests/offload/tpu_offload_connector_scheduler_test.py
+++ b/tests/offload/tpu_offload_connector_scheduler_test.py
@@ -21,7 +21,7 @@ from vllm.v1.core.kv_cache_manager import KVCacheBlocks
 from vllm.v1.core.sched.output import CachedRequestData, SchedulerOutput
 from vllm.v1.request import Request
 
-from tests.offload.utils import EOS_TOKEN_ID, TPURequestRunner
+from tpu_inference.offload import fs_manager, EOS_TOKEN_ID, TPURequestRunner
 from tpu_inference.offload.tpu_offload_connector import (
     RequestTracker, TPUOffloadConnectorScheduler)
 
@@ -33,6 +33,7 @@ class MockVllmConfig:
     def __init__(self, block_size=_DEFAULT_BLOCK_SIZE):
         self.model_config = self.Model()
         self.cache_config = self.Cache(block_size)
+        self.kv_transfer_config = self.KVTransferConfig()
 
     class Model:
         model = "test-model"
@@ -41,6 +42,17 @@ class MockVllmConfig:
 
         def __init__(self, block_size):
             self.block_size = block_size
+            self.cache_dtype = 'torch.bfloat16'
+
+    class KVTransferConfig:
+
+        def __init__(self):
+            self.ip = "ip"
+            self.port = 1234
+            self.extra_config = {}
+
+        def get_from_extra_config(self, key, default):
+            return self.extra_config.get(key, default)
 
 
 def create_request(
@@ -72,14 +84,16 @@ def create_request(
 def scheduler_factory():
     """Provides a factory function for Scheduler instances."""
 
-    def _scheduler(
-        block_size: int = _DEFAULT_BLOCK_SIZE,
-        offload_decode_save: int = 0,
-        offload_num_staging_blocks: int = -1,
-        offload_num_cpu_chunks: int = -1,
-    ):
+    def _scheduler(block_size: int = _DEFAULT_BLOCK_SIZE,
+                   offload_decode_save: int = 0,
+                   offload_num_staging_blocks: int = -1,
+                   offload_num_cpu_chunks: int = -1,
+                   fs_offload: bool = False):
         # update config
         vllm_config = MockVllmConfig(block_size=block_size)
+        if fs_offload:
+            vllm_config.kv_transfer_config.extra_config[
+                fs_manager.BASE_PATH_CONFIG] = "mock/offload/directory"
         os.environ["TPU_OFFLOAD_DECODE_SAVE"] = str(offload_decode_save)
         if offload_num_staging_blocks >= 0:
             os.environ["TPU_OFFLOAD_NUM_STAGING_BLOCKS"] = str(
@@ -106,12 +120,13 @@ class TestTPUOffloadConnectorScheduler:
         assert num_matched == 0
         assert "req1" not in scheduler.load_specs
 
+    @pytest.mark.parametrize("fs_offload", [False, True])
     @pytest.mark.parametrize(
         "num_computed_blocks, num_matched_blocks, num_prompt_blocks, num_staging_blocks",
         [(0, 2, 4, 10), (1, 2, 4, 10), (0, 4, 4, 10), (1, 4, 4, 10),
          (1, 4, 4, 1), (1, 4, 4, 0)])
     def test_get_num_new_matched_tokens_hit(self, scheduler_factory,
-                                            num_computed_blocks,
+                                            fs_offload, num_computed_blocks,
                                             num_matched_blocks,
                                             num_prompt_blocks,
                                             num_staging_blocks):
@@ -126,7 +141,8 @@ class TestTPUOffloadConnectorScheduler:
         6. skip 1 block + full-hit + no staging block
         """
         scheduler = scheduler_factory(
-            offload_num_staging_blocks=num_staging_blocks)
+            offload_num_staging_blocks=num_staging_blocks,
+            fs_offload=fs_offload)
         prompt_len = scheduler.block_size * num_prompt_blocks
         num_computed_tokens = scheduler.block_size * num_computed_blocks
         num_blocks_to_load = num_matched_blocks - num_computed_blocks
@@ -165,6 +181,7 @@ class TestTPUOffloadConnectorScheduler:
             assert load_spec.num_matched_tokens == num_matched_tokens
             assert not load_spec.can_load
             assert len(load_spec.src_chunks) == num_blocks_to_load
+            assert len(load_spec.src_chunk_hashes) == num_blocks_to_load
             assert load_spec.num_skip_leading_tokens == num_computed_tokens
             assert len(load_spec.dst_blocks) == num_blocks_to_load
             # staging_buffer
@@ -177,11 +194,12 @@ class TestTPUOffloadConnectorScheduler:
             assert "req1" not in scheduler._pre_load_specs
             assert "req1" not in scheduler.staging_buffer_manager._blocks_for_load
 
-    def test_update_state_after_alloc(self, scheduler_factory):
+    @pytest.mark.parametrize("fs_offload", [False, True])
+    def test_update_state_after_alloc(self, scheduler_factory, fs_offload):
         """
         Tests that a LoadSpec is correctly updated after block allocation.
         """
-        scheduler = scheduler_factory()
+        scheduler = scheduler_factory(fs_offload=fs_offload)
         req_id = "req1"
         num_prompt_blocks = 4
         num_matched_blocks = 3
@@ -196,8 +214,7 @@ class TestTPUOffloadConnectorScheduler:
 
         # init offload_manager state
         matched_block_hashes = request.block_hashes[:num_matched_blocks]
-        allocated_chunks, _ = scheduler.offload_manager.allocate_for_save(
-            matched_block_hashes)
+        scheduler.offload_manager.allocate_for_save(matched_block_hashes)
         scheduler.offload_manager.complete_save(matched_block_hashes)
 
         # Setup a pending load
@@ -206,6 +223,9 @@ class TestTPUOffloadConnectorScheduler:
             num_skip_leading_tokens=num_computed_blocks * scheduler.block_size,
             dst_blocks=[-1] * num_blocks_to_load,
             src_chunks=[i for i in range(num_blocks_to_load)],
+            src_hashes=[
+                request.block_hashes[i] for i in range(num_blocks_to_load)
+            ],
             can_load=False)
 
         # Mock allocated blocks
@@ -218,18 +238,23 @@ class TestTPUOffloadConnectorScheduler:
 
         load_spec = scheduler.load_specs[req_id]
         assert load_spec.can_load
+        assert len(load_spec.src_chunks) == num_blocks_to_load
+        assert len(load_spec.src_hashes) == num_blocks_to_load
+        assert all(load_spec.src_hashes[i] == request.block_hashes[i]
+                   for i in range(num_blocks_to_load))
         assert load_spec.dst_blocks == allocated_block_ids[
             num_computed_blocks:num_matched_blocks]
         assert req_id in scheduler._reqs_being_loaded
         assert len(scheduler._reqs_being_loaded[req_id]) == num_blocks_to_load
 
+    @pytest.mark.parametrize("fs_offload", [False, True])
     @pytest.mark.parametrize(
         "num_computed_tokens, num_matched_tokens, num_prompt_tokens, num_staging_tokens",
         [(0, 0, 64, 160),
          (0, 32, 64, 160), (16, 32, 64, 160), (0, 64, 64, 160),
          (16, 64, 64, 160), (0, 32, 64, 48), (0, 32, 64, 16)])
     def test_build_connector_meta_new_prefill(self, scheduler_factory,
-                                              num_computed_tokens,
+                                              fs_offload, num_computed_tokens,
                                               num_matched_tokens,
                                               num_prompt_tokens,
                                               num_staging_tokens):
@@ -246,7 +271,8 @@ class TestTPUOffloadConnectorScheduler:
         num_staging_blocks = num_staging_tokens // _DEFAULT_BLOCK_SIZE
         scheduler = scheduler_factory(
             offload_num_staging_blocks=num_staging_blocks,
-            offload_num_cpu_chunks=100)
+            offload_num_cpu_chunks=100,
+            fs_offload=fs_offload)
 
         # calculate the groundtruth
         num_computed_blocks = num_computed_tokens // scheduler.block_size
@@ -335,6 +361,7 @@ class TestTPUOffloadConnectorScheduler:
                 assert req_meta.save_spec.src_blocks == request.block_ids[0][
                     num_matched_blocks:num_matched_blocks + num_blocks_to_save]
                 assert len(req_meta.save_spec.dst_chunks) == num_blocks_to_save
+                assert len(req_meta.save_spec.dst_hashes) == num_blocks_to_save
                 assert not req_meta.save_spec.is_final_save
                 assert "req1" in scheduler.staging_buffer_manager._blocks_for_save
                 assert scheduler.staging_buffer_manager._blocks_for_save[
@@ -348,12 +375,13 @@ class TestTPUOffloadConnectorScheduler:
         # after creating SaveSpec, we also update tracker.save_watermark
         assert tracker.save_watermark == num_tokens_in_cache
 
+    @pytest.mark.parametrize("fs_offload", [False, True])
     @pytest.mark.parametrize("prompt_len, seq_len, decode_save", [(63, 64, 1),
                                                                   (18, 64, 1),
                                                                   (18, 64, 0)])
     def test_build_connector_meta_decode_with_save(self, scheduler_factory,
-                                                   prompt_len, seq_len,
-                                                   decode_save):
+                                                   fs_offload, prompt_len,
+                                                   seq_len, decode_save):
         """
         Tests metadata generation for a decode step that triggers a save.
         1. the first decode (hit block boundary) + decode_save (save one block)
@@ -363,7 +391,8 @@ class TestTPUOffloadConnectorScheduler:
 
         scheduler = scheduler_factory(offload_decode_save=decode_save,
                                       offload_num_staging_blocks=10,
-                                      offload_num_cpu_chunks=10)
+                                      offload_num_cpu_chunks=10,
+                                      fs_offload=fs_offload)
 
         prompt_tokens = list(range(prompt_len))
         generated_tokens = list(range(prompt_len, seq_len))
@@ -426,6 +455,7 @@ class TestTPUOffloadConnectorScheduler:
             assert req_meta.save_spec.num_skip_leading_tokens == num_saved_tokens
             assert req_meta.save_spec.src_blocks == [num_blocks - 1]
             assert len(req_meta.save_spec.dst_chunks) == 1
+            assert len(req_meta.save_spec.dst_hashes) == 1
             assert not req_meta.save_spec.is_final_save
             # staging buffer
             assert "req1" in scheduler.staging_buffer_manager._blocks_for_save
@@ -437,7 +467,9 @@ class TestTPUOffloadConnectorScheduler:
 
             assert tracker.save_watermark == seq_len
 
-    def test_build_connector_meta_finished_request(self, scheduler_factory):
+    @pytest.mark.parametrize("fs_offload", [False, True])
+    def test_build_connector_meta_finished_request(self, scheduler_factory,
+                                                   fs_offload):
         """
         Tests metadata generation for a finished request.
         When using request's default block hash (fully-computed blocks only),
@@ -447,7 +479,8 @@ class TestTPUOffloadConnectorScheduler:
 
         """
 
-        scheduler = scheduler_factory(offload_decode_save=1)
+        scheduler = scheduler_factory(offload_decode_save=1,
+                                      fs_offload=fs_offload)
         prompt_len = scheduler.block_size + 4
         final_seq_len = scheduler.block_size * 2 + 3
         prompt_tokens = list(range(prompt_len))

--- a/tests/offload/tpu_offload_connector_worker_test.py
+++ b/tests/offload/tpu_offload_connector_worker_test.py
@@ -16,7 +16,9 @@ import functools
 import gc
 import os
 import random
+import shutil
 import time
+from pathlib import Path
 from typing import List
 from unittest import mock
 
@@ -29,16 +31,18 @@ from jax.sharding import Mesh, NamedSharding, PartitionSpec
 from vllm.distributed.kv_transfer.kv_connector.v1.base import KVConnectorRole
 
 from tpu_inference.logger import init_logger
+from tpu_inference.offload.cpu_backend import LocalCPUBackend
 from tpu_inference.offload.tpu_offload_connector import LoadSpec, SaveSpec
 from tpu_inference.offload.tpu_offload_connector import \
     TPUOffloadConnector as CPUOffloadingConnector
 from tpu_inference.offload.tpu_offload_connector import (
-    TPUOffloadConnectorMetadata, TPUReqMeta)
+    TPUOffloadConnectorMetadata, TPUReqMeta, fs_manager)
 from tpu_inference.runner.tpu_runner import TPUModelRunner
 
 logger = init_logger(__name__)
 
 _DEFAULT_BLOCK_SIZE = 128
+_FS_OFFLOAD_DIR = "/offload/cache"
 
 
 class MockTPUModelRunner(TPUModelRunner):
@@ -69,18 +73,31 @@ class MockVllmConfig:
 
         def __init__(self, block_size):
             self.block_size = block_size
+            self.cache_dtype = 'torch.bfloat16'
 
     class KVTransferConfig:
-        ip = "ip"
-        port = 1234
+
+        def __init__(self):
+            self.ip = "ip"
+            self.port = 1234
+            self.extra_config = {}
+
+        def get_from_extra_config(self, key, default):
+            return self.extra_config.get(key, default)
 
 
-class TestTPUOffloadConnectorWorker(jtu.JaxTestCase):
-    """Test the save functionality of the TPUOffloadConnectorWorker."""
+class TestTPUOffloadWorkerBase(jtu.JaxTestCase):
+    "Set up, tear down and common utiltities for offload worker tests"
+
+    fs_offload = False
 
     def setUp(self):
         super().setUp()
         self.vllm_config = MockVllmConfig(block_size=_DEFAULT_BLOCK_SIZE)
+        if self.fs_offload:
+            shutil.rmtree(_FS_OFFLOAD_DIR, ignore_errors=True)
+            self.vllm_config.kv_transfer_config.extra_config[
+                fs_manager.BASE_PATH_CONFIG] = _FS_OFFLOAD_DIR
         self.num_layers = 64
         self.num_blocks = 128
         self.num_cpu_chunks = 128
@@ -156,6 +173,10 @@ class TestTPUOffloadConnectorWorker(jtu.JaxTestCase):
                                          mesh=self.mesh)
         worker.register_runner(mock_runner)
         return connector
+
+
+class TestTPUOffloadConnectorWorker(TestTPUOffloadWorkerBase):
+    """Test the save functionality of the TPUOffloadConnectorWorker."""
 
     @parameterized.named_parameters(
         dict(testcase_name="_zero_blocks", num_blocks=0, expected_buckets=[]),
@@ -838,3 +859,271 @@ class TestTPUOffloadConnectorWorker(jtu.JaxTestCase):
             connector = self._create_connector()
             worker = connector.connector_worker
             self.assertEqual(worker.host_sharding.memory_kind, "pinned_host")
+
+
+class TestFSOffloadWorker(TestTPUOffloadWorkerBase):
+    """Test the save functionality of the TPUOffloadConnectorWorker."""
+
+    fs_offload = True
+
+    def cache_files(self):
+        base = (
+            Path(_FS_OFFLOAD_DIR) / self.vllm_config.model_config.model /
+            # The dtype is hardcoded in setUp.
+            'bfloat16')
+        files = list(base.glob("*/*/*.bin"))
+        return files
+
+    @parameterized.named_parameters(
+        dict(
+            testcase_name="_two",
+            num_blocks_to_save=2,
+            num_requests=2,
+        ),
+        dict(
+            testcase_name="_four",
+            num_blocks_to_save=4,
+            num_requests=2,
+        ),
+        dict(
+            testcase_name="_four_by_four",
+            num_blocks_to_save=4,
+            num_requests=4,
+        ),
+    )
+    def test_save(
+        self,
+        num_blocks_to_save,
+        num_requests,
+    ):
+        total_num_blocks_to_save = num_blocks_to_save * num_requests
+        all_block_ids = list(range(self.num_blocks))
+        all_chunk_ids = list(range(self.num_cpu_chunks))
+        src_block_ids = random.sample(all_block_ids, total_num_blocks_to_save)
+        dst_chunk_ids = random.sample(all_chunk_ids, total_num_blocks_to_save)
+
+        src_block_ids_split = np.array_split(src_block_ids, num_requests)
+        dst_chunk_ids_split = np.array_split(dst_chunk_ids, num_requests)
+
+        requests_meta = []
+        for i in range(num_requests):
+            req_id = f"save_req_{i}"
+            src_blocks = src_block_ids_split[i].tolist()
+            dst_chunks = dst_chunk_ids_split[i].tolist()
+
+            num_tokens_to_save_per_req = len(src_blocks) * self.block_size
+
+            save_spec = SaveSpec(
+                num_skip_leading_tokens=0,
+                num_total_tokens=num_tokens_to_save_per_req,
+                is_final_save=False,
+                skip_save=False,
+                src_blocks=src_blocks,
+                dst_chunks=dst_chunks,
+            )
+
+            total_token_ids = list(range(num_tokens_to_save_per_req))
+
+            req_meta = TPUReqMeta(
+                req_id=req_id,
+                token_ids=total_token_ids,
+                local_block_ids=src_blocks,
+                save_spec=save_spec,
+            )
+            requests_meta.append(req_meta)
+
+        logger.info(f"Starting test_tpu_connector_save with: "
+                    f"num_blocks_to_save={num_blocks_to_save}, "
+                    f"num_requests={num_requests};")
+
+        connector_metadata = TPUOffloadConnectorMetadata(
+            requests_meta=requests_meta)
+
+        connector = self._create_connector()
+        worker = connector.connector_worker
+        connector.bind_connector_metadata(connector_metadata)
+        logger.info(
+            "Connector metadata bound, calling worker.start_save_kv().")
+
+        worker.start_save_kv()
+        logger.info("Waiting for all save operations to complete...")
+        while worker._pending_save_futures:
+            worker._process_completed_saves()
+            time.sleep(0.01)
+        worker.cpu_backend.wait_for_add_background()
+
+        logger.info("Starting verification phase.")
+
+        assert total_num_blocks_to_save > 0
+        start = time.time()
+        while not self.cache_files() or len(
+                self.cache_files()) < total_num_blocks_to_save:
+            time.sleep(0.01)
+            assert time.time(
+            ) - start < 30, f"timeout waiting for cache files. Seeing {self.cache_files}"
+        logger.info(f"Detected cache after {time.time() - start}s.")
+
+    @parameterized.named_parameters(
+        # Pinned Host Cases
+        dict(
+            testcase_name="_single",
+            num_blocks_to_operate=1,
+            num_requests=1,
+        ),
+        dict(
+            testcase_name="_four",
+            num_blocks_to_operate=4,
+            num_requests=1,
+        ),
+        dict(
+            testcase_name="_four_by_two",
+            num_blocks_to_operate=4,
+            num_requests=2,
+        ),
+    )
+    def test_load(self, num_blocks_to_operate: int, num_requests: int = 1):
+        """
+        This test simulates a scenario where some amount of blocks get
+        offloaded, and then get loaded into tpu kv cache from the filesystem.
+        Both swap-out and swap-in are tested.
+
+        Steps:
+        1. Setup:
+        2. Simulate a save operation
+        3. Load the data
+        4. Verification
+        """
+        total_num_blocks_to_operate = num_blocks_to_operate * num_requests
+        if total_num_blocks_to_operate > self.num_blocks or total_num_blocks_to_operate > self.num_cpu_chunks:
+            self.skipTest(
+                f"num_blocks_to_save {total_num_blocks_to_operate} exceeds ModelRunner / OffloadConnectorWorker's capacity"
+            )
+
+        # 1. Setup
+        connector = self._create_connector()
+        worker = connector.connector_worker
+        # Ground truth cache. We copy it to host early because the save
+        # operation will donate via stack_kv_cache_cross_layers.
+        src_kv_cache_baseline = [
+            np.array(cache) for cache in worker.runner.kv_caches
+        ]
+        # Destination cache on TPU, should be modified by the load operation
+        dst_kv_cache = [
+            jax.device_put(jnp.zeros(self.cache_shape, dtype=self.cache_dtype),
+                           self.device_sharding)
+            for _ in range(self.num_layers)
+        ]
+        jax.block_until_ready(dst_kv_cache)
+
+        # 2. Simulate a save operation
+        all_block_ids = list(range(self.num_blocks))
+        all_chunk_ids = list(range(self.num_cpu_chunks))
+        src_block_ids = random.sample(all_block_ids,
+                                      total_num_blocks_to_operate)
+        dst_chunk_ids = random.sample(all_chunk_ids,
+                                      total_num_blocks_to_operate)
+
+        src_block_ids_split = np.array_split(src_block_ids, num_requests)
+        dst_chunk_ids_split = np.array_split(dst_chunk_ids, num_requests)
+
+        save_requests_meta = []
+        for i in range(num_requests):
+            req_id = f"save_req_{i}"
+            src_blocks = src_block_ids_split[i].tolist()
+            dst_chunks = dst_chunk_ids_split[i].tolist()
+            num_tokens_to_save_per_req = len(src_blocks) * self.block_size
+
+            save_spec = SaveSpec(
+                num_skip_leading_tokens=0,
+                num_total_tokens=num_tokens_to_save_per_req,
+                is_final_save=False,
+                skip_save=False,
+                src_blocks=src_blocks,
+                dst_chunks=dst_chunks,
+            )
+            total_token_ids = list(range(num_tokens_to_save_per_req))
+            req_meta = TPUReqMeta(
+                req_id=req_id,
+                token_ids=total_token_ids,
+                local_block_ids=src_blocks,
+                save_spec=save_spec,
+            )
+            save_requests_meta.append(req_meta)
+
+        connector_metadata = TPUOffloadConnectorMetadata(
+            requests_meta=save_requests_meta)
+        connector.bind_connector_metadata(connector_metadata)
+        logger.info(
+            "Connector metadata bound, calling worker.start_save_kv().")
+        worker.start_save_kv()
+        logger.info("Waiting for all save operations to complete...")
+        while worker._pending_save_futures:
+            worker._process_completed_saves()
+            time.sleep(0.01)
+        worker.cpu_backend.wait_for_add_background()
+
+        logger.info("worker save completed.")
+        # 3. Prepare and Execute Delta Load
+
+        # First clear out the memory cache to foce a filesytem load. This is
+        # brittle, but we don't want an explicit API for clearing out the cache
+        # since it's not used in production.
+        worker.cpu_backend.host_ram_backend = LocalCPUBackend(
+            self.num_cpu_chunks)
+
+        worker.runner.kv_caches = dst_kv_cache
+
+        load_requests_meta = []
+        for i in range(num_requests):
+            req_id = f"load_req_{i}"
+            src_blocks = src_block_ids_split[i].tolist()
+            dst_chunks = dst_chunk_ids_split[i].tolist()
+            num_tokens_to_load_per_req = len(src_blocks) * self.block_size
+
+            load_spec = LoadSpec(
+                num_matched_tokens=num_tokens_to_load_per_req,
+                dst_blocks=src_blocks,
+                src_chunks=dst_chunks,
+                can_load=True,
+                num_skip_leading_tokens=0,
+            )
+            total_token_ids = list(range(num_tokens_to_load_per_req))
+            req_meta = TPUReqMeta(
+                req_id=req_id,
+                token_ids=total_token_ids,
+                local_block_ids=src_blocks,
+                load_spec=load_spec,
+            )
+            load_requests_meta.append(req_meta)
+
+        connector_metadata = TPUOffloadConnectorMetadata(
+            requests_meta=load_requests_meta)
+        connector.bind_connector_metadata(connector_metadata)
+        logger.info("Connector metadata bound, calling start_load_kv.")
+        worker.start_load_kv(fwd_ctx=None)
+        jax.block_until_ready(worker.runner.kv_caches)
+        logger.info("start_load_kv completed and blocked until ready.")
+
+        # 4. Verification
+        # verify the data
+        dst_kv_cache = worker.runner.kv_caches
+        for i in range(num_requests):
+            src_blocks = src_block_ids_split[i].tolist()
+            for src_block_id in src_blocks:
+                for layer_idx in range(self.num_layers):
+                    self.assertArraysEqual(
+                        src_kv_cache_baseline[layer_idx][src_block_id],
+                        np.array(dst_kv_cache[layer_idx][src_block_id]))
+
+        # verify the loaded chunks
+        all_load_req_ids = {f"load_req_{i}" for i in range(num_requests)}
+        self.assertSetEqual(
+            all_load_req_ids,
+            set(worker.offload_stats.data["finished_load_chunks"].keys()))
+
+        for i in range(num_requests):
+            req_id = f"load_req_{i}"
+            dst_chunks = dst_chunk_ids_split[i].tolist()
+            self.assertListEqual(
+                dst_chunks,
+                worker.offload_stats.data["finished_load_chunks"][req_id])

--- a/tpu_inference/offload/cpu_backend.py
+++ b/tpu_inference/offload/cpu_backend.py
@@ -13,17 +13,38 @@
 # limitations under the License.
 
 import sys
+from abc import ABC, abstractmethod
 from collections import OrderedDict
 from typing import Any, Optional
 
 from tpu_inference.logger import init_logger
 from tpu_inference.offload.metrics import TPUKVCacheMetrics
+from tpu_inference.offload.offload_manager import ChunkHash
 from tpu_inference.offload.utils import CpuChunkId
 
 logger = init_logger(__name__)
 
 
-class LocalCPUBackend:
+class Backend(ABC):
+
+    @abstractmethod
+    def add(self, chunk_id: CpuChunkId, chunk_hash: ChunkHash,
+            value: Any) -> bool:
+        """
+        Adds a key-value pair to the cache.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def get(self, chunk_id: CpuChunkId,
+            chunk_hash: ChunkHash) -> Optional[Any]:
+        """
+        Gets the value for a given chunk_id
+        """
+        raise NotImplementedError
+
+
+class LocalCPUBackend(Backend):
     """
     An in-memory CPU backend for storing KV cache keys and values.
 
@@ -63,7 +84,7 @@ class LocalCPUBackend:
             size_in_bytes = sys.getsizeof(value)
         return size_in_bytes
 
-    def add(self, chunk_id: CpuChunkId, value: Any) -> bool:
+    def add(self, chunk_id: CpuChunkId, _: ChunkHash, value: Any) -> bool:
         """
         Adds a key-value pair to the cache.
 
@@ -95,7 +116,15 @@ class LocalCPUBackend:
             self.current_size_bytes)
         return True
 
-    def get(self, chunk_id: CpuChunkId) -> Optional[Any]:
+    def wait_for_add_background(self):
+        """
+        Waits for any background add() processing to finish (eg, FS writes).
+
+        By default does nothing; eg CPU offload has no background processing.
+        """
+        pass
+
+    def get(self, chunk_id: CpuChunkId, _: ChunkHash) -> Optional[Any]:
         """
         Gets the value for a given chunk_id and marks it as recently used.
         """

--- a/tpu_inference/offload/fs_manager.py
+++ b/tpu_inference/offload/fs_manager.py
@@ -1,0 +1,246 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import math
+import os
+import queue
+import threading
+import time
+from typing import Any, Literal, Optional, Tuple
+
+import tensorstore as ts
+
+from tpu_inference.logger import init_logger
+from tpu_inference.offload.cpu_backend import Backend, LocalCPUBackend
+from tpu_inference.offload.offload_manager import (CacheManager, ChunkHash,
+                                                   CPUChunk, LRUCacheManager)
+from tpu_inference.offload.utils import CpuChunkId, FileMapper
+
+logger = init_logger(__name__)
+
+BASE_PATH_CONFIG = 'fs_offload_base_path'
+
+
+class TieredCacheManager(CacheManager):
+    """Manages a logical tiering of CPU and filesystem offloaded KV cache.
+
+    Enable with fs_offload_base_path in kv_transfer_config.extra_config.
+
+    This wraps an LRUCacheManager to track if a cache entry is already
+    present in memory before doing the expensive lookup to storage.
+
+    Movement of chunks from storage to CPU is handled by the backend.
+
+    This lives in the scheduler of the TPUOffloadConnector, while the
+    TieredBackend lives in the worker process.
+
+    This manager tracks what blocks are availble, performing
+    filesystem lookups when necessary for determining if cached blocks
+    exist in the shared storage. Blocks passed back to vLLM are
+    eventually routed to the worker, where the TieredBackend will
+    assume that any blocks requested, exist in the cache. How this will
+    deal with eviction and such is TBD (we'll probably want some kind
+    of locking on the file names?)
+    """
+
+    def __init__(self, cpu_manager: LRUCacheManager, mapper: FileMapper):
+        self.cpu_manager = cpu_manager
+        self.mapper = mapper
+
+    def lookup(self, chunk_hashes: list[ChunkHash]) -> int:
+        """_summary_
+        return the number of cache hit starting from the first chunk
+        """
+        cpu_count = self.cpu_manager.lookup(chunk_hashes)
+
+        fs_count = 0
+        for chunk_hash in chunk_hashes[cpu_count:]:
+            # This should be async --- but in testing, this seemed to be called
+            # with a single hash rather than a list, so the async needs to
+            # happen further up.
+            filename = self.mapper.get_file_name(chunk_hash)
+            if not os.path.exists(filename):
+                break
+            fs_count += 1
+
+        logger.info(f'Found {cpu_count} chunks on cpu and {fs_count} on disk')
+        return cpu_count + fs_count
+
+    def touch(self, chunk_hashes: list[ChunkHash]) -> int:
+        """ access chunks for both save / load; and move them to the end."""
+        # The cpu manager will ignore any chunks that aren't in memory.
+        self.cpu_manager.touch(chunk_hashes)
+        # TODO: eviction for the filesystem
+
+    def allocate_for_save(
+        self, chunk_hashes: list[ChunkHash]
+    ) -> Tuple[list[CPUChunk], list[int]] | None:
+        chunks, ids = self.cpu_manager.allocate_for_save(chunk_hashes)
+        # There's nothing to allocate on the filesystem side, the
+        # backend will offload all hashes it sees.
+        return chunks, ids
+
+    def prepare_load(self, chunk_hashes: list[ChunkHash]) -> list[CPUChunk]:
+        fs_hashes = []
+        cpu_hashes = []
+        chunk_map = {}
+        for chunk_hash in chunk_hashes:
+            if not self.cpu_manager.lookup([chunk_hash]):
+                fs_hashes.append(chunk_hash)
+            else:
+                cpu_hashes.append(chunk_hash)
+        if cpu_hashes:
+            prepared = self.cpu_manager.prepare_load(cpu_hashes)
+            assert prepared
+            assert len(prepared) == len(cpu_hashes)
+            for hash, chunk in zip(cpu_hashes, prepared):
+                chunk_map[hash] = chunk
+
+        # todo: what if pulling in fs_chunks evicts cpu chunks?
+        if fs_hashes:
+            # The CPU manager silently ignores hashes that aren't in the cache. We'll do
+            # the same for fs hashes, even though the lookup is expensive.
+            fs_hashes = [hash for hash in fs_hashes if self.lookup([hash])]
+
+        if fs_hashes:
+            allocated = self.cpu_manager.allocate_for_save(fs_hashes)
+            if allocated is None:
+                raise Exception("yikes, couldn't prepare load")
+            fs_chunks, chunk_indices = allocated
+            self.cpu_manager.complete_save(fs_hashes)
+            self.cpu_manager.prepare_load(fs_hashes)
+            assert len(chunk_indices) == len(fs_hashes)
+            assert all(i in chunk_indices for i in range(len(fs_hashes)))
+            assert all(fs_chunks[i].chunk_hash == fs_hashes[i]
+                       for i in chunk_indices)
+            chunk_map.update((c.chunk_hash, c) for c in fs_chunks)
+        assert sum(hash in chunk_map
+                   for hash in chunk_hashes) == len(chunk_hashes)
+        return list(chunk_map[hash] for hash in chunk_hashes)
+
+    def complete_save(self, chunk_hashes: list[ChunkHash]) -> None:
+        # Like allocate_for_save, this affects in-memory chunks only. FS save is async
+        # and handled by the backend.
+        self.cpu_manager.complete_save(chunk_hashes)
+
+    def complete_load(self, chunk_hashes: list[ChunkHash]) -> None:
+        # The cpu_manager hash has been updated in prepare_load to contain all chunks that
+        # will eventually be loaded in. So this complete step is just passed through.
+        self.cpu_manager.complete_load(chunk_hashes)
+
+    def mark_completion(self, chunk_ids, operation: Literal['save',
+                                                            'load']) -> None:
+        # See the comments for complete_save and complete_load for why this is
+        # pass-through.
+        self.cpu_manager.mark_completion(chunk_ids, operation)
+
+
+class TieredBackend(Backend):
+    """
+    A tiered backend for storing KV caches.
+
+    Keeps chunks in memory, using a LocalCPUBackend. Offloads
+    asynchronously to a filesystem cache, transparently loads on get.
+    """
+
+    def __init__(self, mapper: FileMapper, cpu_backend: LocalCPUBackend):
+        self.mapper = mapper
+        self.host_ram_backend = cpu_backend
+        self.write_queue = queue.Queue(
+        )  # Store tensorstore write futures, no idea what type that is.
+
+        def write_queue_worker():
+            while True:
+                try:
+                    self.write_queue.get().result()
+                except Exception as e:
+                    logger.warning(f'write failed: {e}')
+                self.write_queue.task_done()
+
+        threading.Thread(target=write_queue_worker, daemon=True).start()
+
+    def add(self, chunk_id: CpuChunkId, chunk_hash: ChunkHash,
+            value: Any) -> bool:
+        """
+        Adds a key-value pair to the cache.
+        """
+        self.host_ram_backend.add(chunk_id, chunk_hash, value)
+        self._start_save_to_fs(chunk_hash, value)
+        return True
+
+    def get(self, chunk_id: CpuChunkId, hash: ChunkHash) -> Optional[Any]:
+        """
+        Gets the value for a given chunk_hash
+        """
+        chunk = self.host_ram_backend.get(chunk_id, hash)
+        if chunk is not None:
+            return chunk
+
+        chunk = self._load_from_fs(hash)
+        if chunk is not None:
+            self.host_ram_backend.add(chunk_id, hash, chunk)
+        return chunk
+
+    def wait_for_add_background(self):
+        self.write_queue.join()
+
+    def _load_from_fs(self, hash: ChunkHash) -> Optional[Any]:
+        """
+        Synchronous load from the filesystem
+
+        TODO: probably want this to be async so we can increase io depth.
+        """
+        # TODO: parametertize the spec
+        spec = {
+            'driver': 'zarr',
+            'kvstore': {
+                'driver': 'file',
+                'path': self.mapper.get_file_name(hash),
+            },
+        }
+        start = time.time()
+        dataset = ts.open(spec).result()
+        res = dataset.read().result()
+        return res
+
+    def _start_save_to_fs(self, chunk_hash: ChunkHash, chunk: Any):
+        """
+        Async save to the backend
+        """
+        # Set the chunk size to be like the input shape, but reduced to 0.5-1 Gb per
+        # chunk, if necessary.
+        chunk_bytes = math.prod(chunk.shape)
+        factor = 750 * 2**20 / chunk_bytes
+        if factor < 1:
+            chunking = [max(1, math.floor(c * factor)) for c in chunk.shape]
+        else:
+            chunking = chunk.shape
+
+        spec = {
+            'driver': 'zarr',
+            'kvstore': {
+                'driver': 'file',
+                'path': self.mapper.get_file_name(chunk_hash),
+            },
+            'metadata': {
+                'shape': chunk.shape,
+                'dtype': self.mapper.dtype,
+                'chunks': chunking,
+            },
+        }
+
+        tstore = ts.open(spec, create=True, delete_existing=True).result()
+        op = tstore.write(chunk)
+        op_start = time.time()
+        self.write_queue.put_nowait(op)

--- a/tpu_inference/offload/offload_manager.py
+++ b/tpu_inference/offload/offload_manager.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from abc import ABC, abstractmethod
 from collections import OrderedDict
 from dataclasses import dataclass
 from typing import Literal, Optional, Tuple
@@ -126,7 +127,45 @@ class CPUChunkPool:
         return True
 
 
-class LRUCacheManager:
+class CacheManager(ABC):
+
+    @abstractmethod
+    def lookup(self, chunk_hashes: list[ChunkHash]) -> int:
+        """_summary_
+        return the number of cache hit starting from the first chunk
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def touch(self, chunk_hashes: list[ChunkHash]) -> int:
+        """ access chunks for both save / load; and move them to the end."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def allocate_for_save(
+        self, chunk_hashes: list[ChunkHash]
+    ) -> Tuple[list[CPUChunk], list[int]] | None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def prepare_load(self, chunk_hashes: list[ChunkHash]) -> list[CPUChunk]:
+        raise NotImplementedError
+
+    @abstractmethod
+    def complete_save(self, chunk_hashes: list[ChunkHash]) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def complete_load(self, chunk_hashes: list[ChunkHash]) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def mark_completion(self, chunk_ids, operation: Literal['save',
+                                                            'load']) -> None:
+        raise NotImplementedError
+
+
+class LRUCacheManager(CacheManager):
     """
     Manages the logical mapping and eviction policy of the CPU KV cache.
 
@@ -174,7 +213,7 @@ class LRUCacheManager:
         num_new_chunks = len(new_chunk_idxs)
         if num_new_chunks == 0:
             logger.debug("No new chunks to allocate")
-            return None
+            return [], []
         num_chunks_to_evict = max(
             0, num_new_chunks - self.chunk_pool.num_free_chunks)
 
@@ -189,6 +228,9 @@ class LRUCacheManager:
                         break
             else:
                 # we could not evict enough chunks
+                logger.warning(
+                    f"Could not evict {num_chunks_to_evict} chunks after evicting {len(to_evict)}"
+                )
                 return None
 
         # evict chunks

--- a/tpu_inference/offload/tpu_offload_connector.py
+++ b/tpu_inference/offload/tpu_offload_connector.py
@@ -129,10 +129,11 @@ if TYPE_CHECKING:
 
 from tpu_inference import envs
 from tpu_inference.logger import init_logger
+from tpu_inference.offload import fs_manager
 from tpu_inference.offload.cpu_backend import LocalCPUBackend
-from tpu_inference.offload.offload_manager import (LRUCacheManager,
+from tpu_inference.offload.offload_manager import (ChunkHash, LRUCacheManager,
                                                    StagingBufferManager)
-from tpu_inference.offload.utils import (CpuChunkId, ReqId,
+from tpu_inference.offload.utils import (CpuChunkId, FileMapper, ReqId,
                                          pure_jax_stack_kv_cache_cross_layers,
                                          pure_jax_update_kv_caches_one,
                                          stack_kv_cache_cross_layers,
@@ -163,6 +164,7 @@ class SaveSpec:
     num_total_tokens: int
     src_blocks: list[int]
     dst_chunks: list[int]
+    dst_hashes: list[ChunkHash]
     # final save for the (newly) finished request
     is_final_save: bool = False
     # A direct signal to the worker to skip the data transfer but still
@@ -175,6 +177,7 @@ class LoadSpec:
     """Internal scheduler state for a potential load operation."""
     num_matched_tokens: int
     src_chunks: list[int]
+    src_chunk_hashes: list[ChunkHash]
     dst_blocks: list[int]
     can_load: bool = False
     num_skip_leading_tokens: int = 0
@@ -239,11 +242,13 @@ class SaveReqInfo:
             unstitching.
         dst_chunks: The specific CPU cache chunk IDs where these blocks must be
             registered.
+        dst_hashes: The chunk hash for each dst chunk.
         is_final_save: Signal to indicate if this is the last save for the request.
     """
     req_id: str
     num_blocks: int
     dst_chunks: list[int]
+    dst_hashes: list[ChunkHash]
     is_final_save: bool
 
 
@@ -576,8 +581,17 @@ class TPUOffloadConnectorScheduler():
 
         # offloading manager
         self.num_cpu_chunks = envs.TPU_OFFLOAD_NUM_CPU_CHUNKS
-        self.offload_manager = LRUCacheManager(
-            num_cpu_chunks=self.num_cpu_chunks)
+        cpu_manager = LRUCacheManager(num_cpu_chunks=self.num_cpu_chunks)
+        fs_base_path = vllm_config.kv_transfer_config.get_from_extra_config(
+            fs_manager.BASE_PATH_CONFIG, None)
+
+        if fs_base_path:
+            self.offload_manager = fs_manager.TieredCacheManager(
+                cpu_manager,
+                FileMapper(fs_base_path, vllm_config),
+            )
+        else:
+            self.offload_manager = cpu_manager
 
         self._request_trackers: dict[ReqId, RequestTracker] = {}
         # This dictionary holds the full vLLM Request object for all requests
@@ -689,10 +703,12 @@ class TPUOffloadConnectorScheduler():
                 # NOTE(jcgu): put dummy chunk / block ids;
                 # fill real ids later when the requests gets scheduled
                 src_chunk_ids = [-1] * num_blocks_to_load
+                src_chunk_hashes = [None] * num_blocks_to_load
                 dummy_dst_blocks = [-1] * num_blocks_to_load
                 self._pre_load_specs[request.request_id] = LoadSpec(
                     num_matched_tokens=num_matched_tokens,
                     src_chunks=src_chunk_ids,
+                    src_chunk_hashes=src_chunk_hashes,
                     dst_blocks=dummy_dst_blocks,
                     num_skip_leading_tokens=num_computed_tokens,
                 )
@@ -775,12 +791,14 @@ class TPUOffloadConnectorScheduler():
             chunks_to_load = self.offload_manager.prepare_load(
                 block_hashes_to_load)
             src_chunk_ids = [chunk.chunk_id for chunk in chunks_to_load]
+            src_chunk_hashes = [chunk.chunk_hash for chunk in chunks_to_load]
 
             # get dst block ids
             dst_blocks = all_blocks[skip_leading_blocks:num_matched_blocks]
 
             # update load spec
             load_spec.src_chunks = src_chunk_ids
+            load_spec.src_chunk_hashes = src_chunk_hashes
             load_spec.dst_blocks = dst_blocks
             load_spec.can_load = True
             self.load_specs[request.request_id] = load_spec
@@ -914,6 +932,9 @@ class TPUOffloadConnectorScheduler():
                         num_skip_leading_blocks:adjusted_num_total_blocks]
 
                     dst_chunks = [chunk.chunk_id for chunk in chunks_for_save]
+                    dst_hashes = [
+                        chunk.chunk_hash for chunk in chunks_for_save
+                    ]
                     src_blocks = [src_block_ids[idx] for idx in chunk_idxs]
 
                     # This is a real save operation.
@@ -924,6 +945,7 @@ class TPUOffloadConnectorScheduler():
                         skip_save=False,
                         src_blocks=src_blocks,
                         dst_chunks=dst_chunks,
+                        dst_hashes=dst_hashes,
                     )
                     self._reqs_being_saved[req_id] |= set(dst_chunks)
                     num_allocated_blocks = self.staging_buffer_manager.allocate(
@@ -948,6 +970,7 @@ class TPUOffloadConnectorScheduler():
                 num_total_tokens=tracker.save_watermark,
                 src_blocks=[],
                 dst_chunks=[],
+                dst_hashes=[],
                 is_final_save=True,
                 skip_save=True,
             )
@@ -1298,6 +1321,8 @@ class TPUOffloadConnectorWorker:
     def __init__(self, vllm_config: VllmConfig,
                  connector: "TPUOffloadConnector"):
         logger.info("TPUOffloadConnectorWorker: Entering __init__")
+        self.save_executor = None
+
         self.vllm_config = vllm_config
         self.connector = connector
         self.block_size = vllm_config.cache_config.block_size
@@ -1311,7 +1336,14 @@ class TPUOffloadConnectorWorker:
 
         # cpu cache
         self.num_cpu_chunks = envs.TPU_OFFLOAD_NUM_CPU_CHUNKS
-        self.cpu_backend = LocalCPUBackend(num_cpu_chunks=self.num_cpu_chunks)
+        cpu_backend = LocalCPUBackend(num_cpu_chunks=self.num_cpu_chunks)
+        fs_base_path = vllm_config.kv_transfer_config.get_from_extra_config(
+            fs_manager.BASE_PATH_CONFIG, None)
+        if fs_base_path:
+            mapper = FileMapper(fs_base_path, vllm_config)
+            self.cpu_backend = fs_manager.TieredBackend(mapper, cpu_backend)
+        else:
+            self.cpu_backend = cpu_backend
         model_name = self.vllm_config.model_config.model
         logger.debug(
             f"Model name is {model_name}, KV block_size={self.block_size}")
@@ -1338,7 +1370,8 @@ class TPUOffloadConnectorWorker:
 
     def __del__(self):
         logger.info("TPUOffloadConnectorWorker: Entering __del__")
-        self.save_executor.shutdown(wait=True)
+        if self.save_executor:
+            self.save_executor.shutdown(wait=True)
 
     def register_runner(self, runner: TPUModelRunner):
         logger.info("TPUOffloadConnectorWorker: Entering register_runner")
@@ -1597,18 +1630,20 @@ class TPUOffloadConnectorWorker:
     def _prepare_save_plan(
         self,
         meta: TPUReqMeta,
-    ) -> tuple[list[int], list[int]] | None:
+    ) -> tuple[list[int], list[int], list[ChunkHash]] | None:
         """
         Validate and plan the blocks for the save operation for the given request.
         Returns:
-            Optional[tuple[list[int], list[int]]]: A tuple containing the list of
-                source TPU blocks and destination CPU chunks if the save operation
-                is valid and contains data to be gathered. Returns None if the
+            Optional[tuple[list[int], list[int], list[ChunkHash]]: A tuple
+                containing the list of source TPU blocks, destination CPU
+                chunks, and corresponding chunk hashes if the save operation is
+                valid and contains data to be gathered. Returns None if the
                 request should be skipped or contains no new tokens to gather.
-        """
+                """
         save_spec = meta.save_spec
         blocks_to_save = save_spec.src_blocks
         dst_chunks = save_spec.dst_chunks
+        dst_hashes = save_spec.dst_hashes
         req_id = meta.req_id
         full_block_ids = meta.local_block_ids
         full_token_ids = meta.token_ids
@@ -1662,7 +1697,7 @@ class TPUOffloadConnectorWorker:
                 f"Request({req_id}): blocks_to_save {blocks_to_save} contains blocks not present in local_block_ids {full_block_ids}"
             )
 
-        return blocks_to_save, dst_chunks
+        return blocks_to_save, dst_chunks, dst_hashes
 
     def _gather_tpu_blocks(self, req_id: ReqId, full_block_ids: list[int],
                            full_token_ids: list[int],
@@ -1688,7 +1723,7 @@ class TPUOffloadConnectorWorker:
             # save plan is validate
             return None
 
-        blocks_to_save, dst_chunks = plan
+        blocks_to_save, dst_chunks, dst_hashes = plan
         num_blocks_to_save = len(blocks_to_save)
 
         if self.use_bucketed_swap_ops:
@@ -1706,7 +1741,7 @@ class TPUOffloadConnectorWorker:
             )
 
         # We return the data needed for the next phase
-        return gathered_kv_caches_tpu, num_blocks_to_save, dst_chunks, blocks_to_save
+        return gathered_kv_caches_tpu, num_blocks_to_save, dst_chunks, blocks_to_save, dst_hashes
 
     def _batched_gather_tpu_blocks(
         self, metadata: TPUOffloadConnectorMetadata
@@ -1753,7 +1788,7 @@ class TPUOffloadConnectorWorker:
             if plan is None:
                 continue
 
-            blocks_to_save, dst_chunks = plan
+            blocks_to_save, dst_chunks, dst_hashes = plan
             num_blocks_to_save = len(blocks_to_save)
 
             all_src_blocks.extend(blocks_to_save)
@@ -1761,6 +1796,7 @@ class TPUOffloadConnectorWorker:
                 SaveReqInfo(req_id=meta.req_id,
                             num_blocks=num_blocks_to_save,
                             dst_chunks=dst_chunks,
+                            dst_hashes=dst_hashes,
                             is_final_save=meta.save_spec.is_final_save))
 
             logger.debug(
@@ -1868,7 +1904,9 @@ class TPUOffloadConnectorWorker:
         for info in manifest:
             for i in range(info.num_blocks):
                 chunk_id = info.dst_chunks[i]
-                self.cpu_backend.add(chunk_id, chunks_on_cpu[block_offset + i])
+                chunk_hash = info.dst_hashes[i]
+                self.cpu_backend.add(chunk_id, chunk_hash,
+                                     chunks_on_cpu[block_offset + i])
                 logger.debug(f" Saving to CPU chunk: "
                              f"chunk_id={chunk_id}, "
                              f" local_chunk_idx={block_offset + i}")
@@ -2012,12 +2050,13 @@ class TPUOffloadConnectorWorker:
 
                 # Unpack results from the sync step
                 (flat_kv_caches_tpu, num_blocks_to_save, dst_chunks,
-                 blocks_to_save) = gather_result
+                 blocks_to_save, dst_hashes) = gather_result
 
                 # Create a single-item manifest for the unified transfer function
                 info = SaveReqInfo(req_id=meta.req_id,
                                    num_blocks=num_blocks_to_save,
                                    dst_chunks=dst_chunks,
+                                   dst_hashes=dst_hashes,
                                    is_final_save=meta.save_spec.is_final_save)
 
                 # Define a safe wrapper for the async part to ensure logging
@@ -2128,6 +2167,7 @@ class TPUOffloadConnectorWorker:
                 "TPUOffloadConnectorWorker: Starting KV cache load process.")
             dst_blocks = meta.load_spec.dst_blocks
             src_chunks = meta.load_spec.src_chunks
+            src_hashes = meta.load_spec.src_chunk_hashes
             num_blocks_to_load = len(dst_blocks)
             num_matched_tokens = meta.load_spec.num_matched_tokens
             num_skip_leading_tokens = meta.load_spec.num_skip_leading_tokens
@@ -2169,7 +2209,10 @@ class TPUOffloadConnectorWorker:
             assembled_kv_on_cpu = []
             for i in range(num_blocks_to_load):
                 src_chunk_id = src_chunks[i]
-                cached_value = self.cpu_backend.get(src_chunk_id)
+                src_chunk_hash = src_hashes[i]
+                # This should be made async so that FS loads can be async.
+                cached_value = self.cpu_backend.get(src_chunk_id,
+                                                    src_chunk_hash)
                 if cached_value is not None:
                     assembled_kv_on_cpu.append(cached_value)
                 else:

--- a/tpu_inference/offload/utils.py
+++ b/tpu_inference/offload/utils.py
@@ -18,7 +18,7 @@ from typing import List, Tuple
 import jax
 import jax.numpy as jnp
 from jax.sharding import Mesh, PartitionSpec
-from vllm.config import get_current_vllm_config
+from vllm.config import VllmConfig, get_current_vllm_config
 from vllm.distributed.kv_transfer.kv_connector.factory import \
     KVConnectorFactory
 
@@ -168,7 +168,7 @@ def update_kv_caches_one(
     replicated_sharding: PartitionSpec | None = None,
 ) -> List[jax.Array]:
     """Update KV caches using cached sharding spec to avoid recompilation.
-    
+
     Args:
         kv_caches: List of KV cache arrays
         stacked_blocks: List of stacked KV blocks
@@ -374,3 +374,62 @@ def pure_jax_update_kv_caches_one(
         return jax.lax.scatter(cache_layer, indices_arr, slices, dim_nums)
 
     return jax.tree.map(_update_layer, kv_caches, layer_slices_list)
+
+
+class FileMapper:
+    """
+    FileMapper maps KV blocks (given by their hash) to file names.
+
+    Inspired by llmd_fs_backend/file_mapper.py
+    """
+
+    def __init__(self, root_dir: str, vllm_config: VllmConfig):
+        """
+        Initialize the file mapper for a specific worker.
+        All KV data files will be nested under a unique base path.
+
+        Base path format:
+            <root_dir>
+            /<model_name>
+            /<dtype>
+
+        Args:
+            root_dir: the directory on shared storage under which
+              everything will be stored.
+            vllm_config: a VllmConfig. This is where details like the
+              model name will be found.
+        """
+        self._root_dir = root_dir
+        self._model_name = vllm_config.model_config.model
+        dtype = str(vllm_config.cache_config.cache_dtype).replace("torch.", "")
+        if dtype == 'auto':
+            dtype = str(vllm_config.model_config.dtype).split('.')[-1]
+
+        self._dtype = dtype
+        self._base_path = (f"{self._root_dir}"
+                           f"/{self._model_name}"
+                           f"/{self._dtype}")
+
+    @property
+    def dtype(self):
+        return self._dtype
+
+    def get_file_name(self, block_hash: int | bytes) -> str:
+        """
+        Return the file path for a KV block.
+        The path is built using hash-based subdirectories:
+        <base>/<hhh>/<hh>/<hash>.bin, to limit directory fan-out.
+
+        Args:
+            block_hash: Hash identifying the KV-cache block (int or bytes).
+
+        Returns:
+            Full file path for the given block.
+        """
+        if isinstance(block_hash, bytes):  # convert bytes to int
+            block_hash = int.from_bytes(block_hash, "big")
+        assert isinstance(block_hash, int)
+
+        block_hash_hex = f"{block_hash & ((1 << 64) - 1):016x}"
+        subfolder1, subfolder2 = block_hash_hex[:3], block_hash_hex[3:5]
+        return f"{self._base_path}/{subfolder1}/{subfolder2}/{block_hash_hex}.bin"


### PR DESCRIPTION
# Description

Add generic filesystem offloading.

This extends host memory offloading to a filesystem. Offloading is tiered: any chunk pushd from device to host memory is asynchronously copied to the filesystem. On lookup, if a chunk is not found in host memory, it is looked for in the filesystem. If found, it's copied to a host memory chunk and then loaded to the device.

The filesystem organization is inspired by https://github.com/llm-d/llm-d-kv-cache/tree/main/kv_connectors/llmd_fs_backend.

This has been tested on v6e to confirm functional correctness.  SGBench results are below, I can give the complete configuration on request.

### SGBench testing with Lustre

From [TPU KVCache Host Offload
benchmarks](https://docs.google.com/spreadsheets/d/12ul73Dn9TdTvS4E93GLxxe--wFuiB2XXpUzbiwDFwZo/edit?resourcekey=0-lb1vBRwpySO1tvw4NzAMNw&gid=1707653121#gid=1707653121)
and [vllm-experimental README](https://g3doc.corp.google.com/experimental/vllm-experimental/LMCache/benchmark/README.md?cl=head).

From `sglang/python`:

```
HF_TOKEN=$(< ~/.huggingface) \
python3 sglang/bench_serving.py \
  --host=localhost --port=8000 \
  --dataset-name=generated-shared-prefix \
  --model=Qwen/Qwen3-4B-Instruct-2507 --tokenizer=Qwen/Qwen3-4B-Instruct-2507 \
  --backend=vllm --gsp-num-groups=310 --gsp-prompts-per-group=40 \
  --gsp-system-prompt-len=1024 \
  --gsp-question-len=256 --gsp-output-len=256 \
  --request-rate=800 --max-concurrency=250 --seed 42
```

#### Results

fs offload, june 3 version: `--kv-transfer-config '{"kv_connector":"TPUOffloadConnector","kv_connector_module_path":"tpu_inference.offload.tpu_offload_connector","kv_role":"kv_both", "kv_connector_extra_config": {"fs_offload_base_path": "/offload"}}'`

```
============ Serving Benchmark Result ============
Backend:                                 vllm      
Traffic request rate:                    800.0     
Max request concurrency:                 250       
Successful requests:                     12400     
Benchmark duration (s):                  3729.74   
Total input tokens:                      16717720  
Total generated tokens:                  3174400   
Total generated tokens (retokenized):    3325440   
Request throughput (req/s):              3.32      
Input token throughput (tok/s):          4482.28   
Output token throughput (tok/s):         851.11    
Total token throughput (tok/s):          5333.38   
Concurrency:                             248.11    
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   74629.24  
Median E2E Latency (ms):                 60705.87  
---------------Time to First Token----------------
Mean TTFT (ms):                          72669.04  
Median TTFT (ms):                        58879.53  
P99 TTFT (ms):                           167567.69 
---------------Inter-Token Latency----------------
Mean ITL (ms):                           7.69      
Median ITL (ms):                         6.62      
P95 ITL (ms):                            12.20     
P99 ITL (ms):                            26.62     
Max ITL (ms):                            4709.72   
==================================================

(APIServer pid=8) INFO 06-03 21:54:29 [loggers.py:271] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 0.0 tokens/s, Running: 0 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.0%, Prefix cache hit rate: 70.6%, External prefix cache hit rate: 98.1%
```

Same version, no fs offload: fs offload, june 3 version: `--kv-transfer-config '{"kv_connector":"TPUOffloadConnector","kv_connector_module_path":"tpu_inference.offload.tpu_offload_connector","kv_role":"kv_both"}'`

```
============ Serving Benchmark Result ============
Backend:                                 vllm      
Traffic request rate:                    800.0     
Max request concurrency:                 250       
Successful requests:                     12400     
Benchmark duration (s):                  3192.83   
Total input tokens:                      16717720  
Total generated tokens:                  3174400   
Total generated tokens (retokenized):    3320686   
Request throughput (req/s):              3.88      
Input token throughput (tok/s):          5236.01   
Output token throughput (tok/s):         994.23    
Total token throughput (tok/s):          6230.24   
Concurrency:                             247.52    
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   63733.09  
Median E2E Latency (ms):                 63853.43  
---------------Time to First Token----------------
Mean TTFT (ms):                          61704.79  
Median TTFT (ms):                        61836.77  
P99 TTFT (ms):                           72822.00  
---------------Inter-Token Latency----------------
Mean ITL (ms):                           7.96      
Median ITL (ms):                         6.62      
P95 ITL (ms):                            12.22     
P99 ITL (ms):                            71.13     
Max ITL (ms):                            736.90    
==================================================
(APIServer pid=8) INFO 06-05 00:22:07 [loggers.py:271] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 0.0 tokens/s, Running: 0 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.0%, Prefix cache hit rate: 70.7%, External prefix cache hit rate: 30.1%
```

It's not in the numbers above, but lustre r/w throughput is in the 100M/s
range. I don't know if that's due to small block sizes or something, or actual
bad performance.
