### PR TITLE
[Fix][Raiden] Load tpu raiden before jax to avoid XLA symbol crash

### DIFF
--- a/tpu_inference/__init__.py
+++ b/tpu_inference/__init__.py
@@ -17,6 +17,23 @@
 # other modules are imported.
 import tpu_inference.env_override  # noqa: F401
 from tpu_inference import envs
+
+# Engine-first XLA load (TPU_RAIDEN_IMPORT_FIRST, default on): import Raiden's engine
+# extension here -- the earliest tpu_inference entry point, before any submodule (e.g.
+# platforms/tpu_platform.py) runs `import jax` and loads jaxlib's libjax_common.so.
+if envs.TPU_RAIDEN_IMPORT_FIRST:
+    try:
+        import tpu_raiden.frameworks.jax._tpu_raiden_jax  # noqa: F401
+    except ModuleNotFoundError:
+        # Expected in processes without tpu_raiden on the path (e.g. the benchmark
+        # client). Only the EngineCore workers need the engine-first load; skip quietly.
+        pass
+    except Exception as _raiden_exc:  # pragma: no cover - best-effort preload
+        import sys as _sys
+        print(
+            f"[TPU_RAIDEN_IMPORT_FIRST] engine preload failed: {_raiden_exc}",
+            file=_sys.stderr)
+
 from tpu_inference import tpu_info as ti
 from tpu_inference.logger import init_logger
 

--- a/tpu_inference/__init__.py
+++ b/tpu_inference/__init__.py
@@ -18,21 +18,21 @@
 import tpu_inference.env_override  # noqa: F401
 from tpu_inference import envs
 
-# Engine-first XLA load (TPU_RAIDEN_IMPORT_FIRST, default on): import Raiden's engine
-# extension here -- the earliest tpu_inference entry point, before any submodule (e.g.
-# platforms/tpu_platform.py) runs `import jax` and loads jaxlib's libjax_common.so.
-if envs.TPU_RAIDEN_IMPORT_FIRST:
-    try:
-        import tpu_raiden.frameworks.jax._tpu_raiden_jax  # noqa: F401
-    except ModuleNotFoundError:
-        # Expected in processes without tpu_raiden on the path (e.g. the benchmark
-        # client). Only the EngineCore workers need the engine-first load; skip quietly.
-        pass
-    except Exception as _raiden_exc:  # pragma: no cover - best-effort preload
-        import sys as _sys
-        print(
-            f"[TPU_RAIDEN_IMPORT_FIRST] engine preload failed: {_raiden_exc}",
-            file=_sys.stderr)
+# Engine-first XLA load: import Raiden's engine extension here -- the earliest
+# tpu_inference entry point, before any submodule (e.g. platforms/tpu_platform.py)
+# runs `import jax` and loads jaxlib's libjax_common.so. This ensures Raiden's
+# embedded XLA runtime comes up before jaxlib's so the two XLA copies don't collide
+# in static initializers.
+try:
+    import tpu_raiden.frameworks.jax._tpu_raiden_jax  # noqa: F401
+except ModuleNotFoundError:
+    # Expected in processes without tpu_raiden on the path (e.g. the benchmark
+    # client). Only the EngineCore workers need the engine-first load; skip quietly.
+    pass
+except Exception as _raiden_exc:  # pragma: no cover - best-effort preload
+    import sys as _sys
+    print(f"[tpu_raiden] engine preload failed: {_raiden_exc}",
+          file=_sys.stderr)
 
 from tpu_inference import tpu_info as ti
 from tpu_inference.logger import init_logger

--- a/tpu_inference/envs.py
+++ b/tpu_inference/envs.py
@@ -74,6 +74,7 @@ if TYPE_CHECKING:
     PROFILE_SINGLE_DEVICE: bool = False
     LORA_MODULE_PATH: str = ""
     SC_ALLREDUCE_ALLGATHER_OFFLOAD_MIN_BYTES: str = "auto"
+    TPU_RAIDEN_IMPORT_FIRST: bool = True
 
 
 def env_with_choices(
@@ -427,6 +428,13 @@ environment_variables: dict[str, Callable[[], Any]] = {
     lambda: os.getenv("SC_ALLREDUCE_ALLGATHER_OFFLOAD_MIN_BYTES", "auto"),
     "MLA_TRANSPOSE_KV_CACHE":
     env_bool("MLA_TRANSPOSE_KV_CACHE", default=False),
+    # Engine-first XLA load: when true, tpu_inference/__init__.py imports the Raiden
+    # engine extension before the first `import jax`, so its embedded XLA runtime comes
+    # up before jaxlib's libjax_common.so and the two XLA copies don't collide in static
+    # initializers. Enabled by default;
+    # harmless when tpu_raiden is not installed (import is skipped quietly).
+    "TPU_RAIDEN_IMPORT_FIRST":
+    env_bool("TPU_RAIDEN_IMPORT_FIRST", default=True),
 }
 
 

--- a/tpu_inference/envs.py
+++ b/tpu_inference/envs.py
@@ -74,7 +74,6 @@ if TYPE_CHECKING:
     PROFILE_SINGLE_DEVICE: bool = False
     LORA_MODULE_PATH: str = ""
     SC_ALLREDUCE_ALLGATHER_OFFLOAD_MIN_BYTES: str = "auto"
-    TPU_RAIDEN_IMPORT_FIRST: bool = True
 
 
 def env_with_choices(
@@ -428,13 +427,6 @@ environment_variables: dict[str, Callable[[], Any]] = {
     lambda: os.getenv("SC_ALLREDUCE_ALLGATHER_OFFLOAD_MIN_BYTES", "auto"),
     "MLA_TRANSPOSE_KV_CACHE":
     env_bool("MLA_TRANSPOSE_KV_CACHE", default=False),
-    # Engine-first XLA load: when true, tpu_inference/__init__.py imports the Raiden
-    # engine extension before the first `import jax`, so its embedded XLA runtime comes
-    # up before jaxlib's libjax_common.so and the two XLA copies don't collide in static
-    # initializers. Enabled by default;
-    # harmless when tpu_raiden is not installed (import is skipped quietly).
-    "TPU_RAIDEN_IMPORT_FIRST":
-    env_bool("TPU_RAIDEN_IMPORT_FIRST", default=True),
 }
 
 


### PR DESCRIPTION
# Description

Make`tpu_inference/__init__.py` import the Raiden engine extension before the first `import jax`, so its embedded XLA runtime comes up before jaxlib's libjax_common.so and the two XLA copies don't collide in static initializers. harmless when tpu_raiden is not installed (import is skipped quietly).


# Tests

Verified by running `examples/offline_inference.py`. tpu-inference does not crash with or without tpu_raiden installed.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
