### PR TITLE
[Feat][Raiden]Implement high-performance KV Cache Offloading using Raiding

### DIFF
--- a/tests/offload/test_raiden_offload_connector.py
+++ b/tests/offload/test_raiden_offload_connector.py
@@ -1,0 +1,182 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+from vllm.distributed.kv_transfer.kv_connector.v1.base import KVConnectorRole
+from vllm.v1.core.sched.output import SchedulerOutput
+from vllm.v1.request import Request
+
+from tpu_inference.offload.raiden_offload_connector import (
+    RaidenConnectorMetadata, RaidenLoadSpec, RaidenLocator,
+    RaidenOffloadConnector, RaidenOffloadConnectorScheduler,
+    RaidenOffloadConnectorWorker, RaidenSaveSpec)
+
+# Mock tpu_raiden module before importing connector to avoid strict ImportError
+mock_raiden = MagicMock()
+mock_raiden.KVCacheManager = MagicMock()
+mock_raiden.KVCacheStore = MagicMock()
+
+
+# Configure Mock RaidenId to have standard locator properties
+class MockRaidenId:
+
+    def __init__(self,
+                 job_name="",
+                 job_replica_id="",
+                 data_name="",
+                 data_replica_idx=0):
+        self.job_name = job_name
+        self.job_replica_id = job_replica_id
+        self.data_name = data_name
+        self.data_replica_idx = data_replica_idx
+
+
+mock_raiden.RaidenId = MockRaidenId
+sys.modules['tpu_raiden'] = mock_raiden
+
+_DEFAULT_BLOCK_SIZE = 16
+
+
+class MockVllmConfig:
+
+    def __init__(self, block_size=_DEFAULT_BLOCK_SIZE):
+        self.model_config = MagicMock()
+        self.model_config.model = "test-raiden-model"
+        self.cache_config = MagicMock()
+        self.cache_config.block_size = block_size
+        self.kv_transfer_config = MagicMock()
+
+
+def create_request(request_id: str, num_tokens: int,
+                   block_size: int) -> Request:
+    req = MagicMock(spec=Request)
+    req.request_id = request_id
+    req.req_id = request_id
+    req.prompt_token_ids = list(range(num_tokens))
+    req.all_token_ids = list(range(num_tokens))
+    req.num_computed_tokens = 0
+    req.block_size = block_size
+    num_blocks = num_tokens // block_size
+    req.block_ids = [list(range(num_blocks))]
+    req.block_hashes = [f"hash_{i}".encode() for i in range(num_blocks)]
+    req.num_tokens = num_tokens
+    return req
+
+
+def test_instantiation():
+    vllm_config = MockVllmConfig()
+
+    sched_conn = RaidenOffloadConnector(vllm_config, KVConnectorRole.SCHEDULER)
+    assert sched_conn.connector_scheduler is not None
+    assert isinstance(sched_conn.connector_scheduler,
+                      RaidenOffloadConnectorScheduler)
+
+    worker_conn = RaidenOffloadConnector(vllm_config, KVConnectorRole.WORKER)
+    assert worker_conn.connector_worker is not None
+    assert isinstance(worker_conn.connector_worker,
+                      RaidenOffloadConnectorWorker)
+
+
+def test_scheduler_no_hit():
+    vllm_config = MockVllmConfig()
+
+    mock_store_inst = MagicMock()
+    mock_store_inst.lookup.return_value = []
+    mock_raiden.KVCacheStore.return_value = mock_store_inst
+
+    scheduler = RaidenOffloadConnectorScheduler(vllm_config)
+    req = create_request("req_1", num_tokens=32, block_size=16)
+
+    num_matched, _ = scheduler.get_num_new_matched_tokens(req, 0)
+    assert num_matched == 0
+
+
+def test_scheduler_build_meta():
+    vllm_config = MockVllmConfig()
+
+    mock_store_inst = MagicMock()
+    mock_store_inst.lookup.return_value = []
+    mock_raiden.KVCacheStore.return_value = mock_store_inst
+
+    scheduler = RaidenOffloadConnectorScheduler(vllm_config)
+    req = create_request("req_1", num_tokens=32, block_size=16)
+
+    scheduler.update_state_after_alloc(req, MagicMock(), 0)
+
+    sched_output = MagicMock(spec=SchedulerOutput)
+    sched_output.finished_req_ids = set()
+    sched_output.scheduled_new_reqs = [req]
+    sched_output.scheduled_cached_reqs = MagicMock(req_ids=[],
+                                                   new_block_ids=[],
+                                                   resumed_req_ids=set())
+    sched_output.num_scheduled_tokens = {"req_1": 32}
+
+    meta: RaidenConnectorMetadata = scheduler.build_connector_meta(
+        sched_output)
+
+    assert len(meta.requests_meta) == 1
+    req_meta = meta.requests_meta[0]
+    assert req_meta.req_id == "req_1"
+
+    assert req_meta.save_spec is not None
+    assert isinstance(req_meta.save_spec, RaidenSaveSpec)
+    assert req_meta.save_spec.num_total_tokens == 32
+    assert len(req_meta.save_spec.src_blocks) == 2
+
+    # Verify that destination locators/chunks are empty (allocated dynamically by the worker)
+    assert len(req_meta.save_spec.dst_locators) == 0
+    assert len(req_meta.save_spec.dst_chunks) == 0
+
+
+def test_worker_register_and_load():
+    vllm_config = MockVllmConfig()
+    conn = RaidenOffloadConnector(vllm_config, KVConnectorRole.WORKER)
+    worker = conn.connector_worker
+    assert worker is not None
+
+    runner = MagicMock()
+    runner.kv_caches = [MagicMock()]
+
+    worker.register_runner(runner)
+    assert worker.raiden_manager is not None
+
+    # Provide explicit full locator info in LoadSpec
+    loc = RaidenLocator(job_name="tpu_inference",
+                        job_replica_id="0",
+                        data_name="kv_cache",
+                        data_replica_idx=10)
+    load_spec = RaidenLoadSpec(num_matched_tokens=16,
+                               src_chunks=[10],
+                               dst_blocks=[1],
+                               src_locators=[loc],
+                               can_load=True)
+    req_meta = MagicMock(req_id="req_load",
+                         load_spec=load_spec,
+                         save_spec=None)
+    conn._connector_metadata = RaidenConnectorMetadata(
+        requests_meta=[req_meta])
+
+    worker.start_load_kv(MagicMock())
+
+    stats = worker.get_kv_connector_stats()
+    assert stats is not None
+    assert "req_load" in stats.data["finished_load_chunks"]
+    assert stats.data["finished_load_chunks"]["req_load"] == [10]
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/tests/offload/test_raiden_offload_connector.py
+++ b/tests/offload/test_raiden_offload_connector.py
@@ -12,26 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import importlib.util
 import sys
 from unittest.mock import MagicMock
 
-import pytest
-from vllm.distributed.kv_transfer.kv_connector.v1.base import KVConnectorRole
-from vllm.v1.core.sched.output import SchedulerOutput
-from vllm.v1.request import Request
-
-# Skip the whole module if tpu_raiden is not available in this environment.
-# `find_spec` only locates the package (it does NOT import it / load the engine
-# .so), so this is a safe availability check.
-if importlib.util.find_spec("tpu_raiden") is None:
-    pytest.skip(
-        "tpu_raiden is not importable; skipping Raiden offload connector tests",
-        allow_module_level=True)
-
-# Mock tpu_raiden module BEFORE importing the connector so its module-level
-# `from tpu_raiden import ...` resolves to these mocks instead of being cached as
-# None (which makes the connector raise ImportError at use time).
+# Install a mock `tpu_raiden` in sys.modules BEFORE importing pytest / vllm /
+# tpu_inference / the connector. This lets the tests run even when the real
+# tpu_raiden is NOT installed, and is intentionally done first because:
+#   - the connector's module-level `from tpu_raiden import ...` resolves to these
+#     mocks (otherwise it caches None and raises ImportError at use time), and
+#   - tpu_inference's engine-first `import tpu_raiden.frameworks.jax._tpu_raiden_jax`
+#     resolves through this mock (submodule import -> ModuleNotFoundError, which
+#     tpu_inference swallows) instead of loading the real engine .so -- which would
+#     crash on a standalone import. So the mock also shadows a real install.
 mock_raiden = MagicMock()
 mock_raiden.KVCacheManager = MagicMock()
 mock_raiden.KVCacheStore = MagicMock()
@@ -53,6 +45,12 @@ class MockRaidenId:
 
 mock_raiden.RaidenId = MockRaidenId
 sys.modules['tpu_raiden'] = mock_raiden
+
+import pytest  # noqa: E402
+from vllm.distributed.kv_transfer.kv_connector.v1.base import \
+    KVConnectorRole  # noqa: E402
+from vllm.v1.core.sched.output import SchedulerOutput  # noqa: E402
+from vllm.v1.request import Request  # noqa: E402
 
 from tpu_inference.offload.raiden_offload_connector import (  # noqa: E402
     RaidenConnectorMetadata, RaidenLoadSpec, RaidenLocator,

--- a/tests/offload/test_raiden_offload_connector.py
+++ b/tests/offload/test_raiden_offload_connector.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import sys
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 # Install a mock `tpu_raiden` in sys.modules BEFORE importing pytest / vllm /
 # tpu_inference / the connector. This lets the tests run even when the real
@@ -53,8 +53,8 @@ from vllm.v1.core.sched.output import SchedulerOutput  # noqa: E402
 from vllm.v1.request import Request  # noqa: E402
 
 from tpu_inference.offload.raiden_offload_connector import (  # noqa: E402
-    RaidenConnectorMetadata, RaidenLoadSpec, RaidenLocator,
-    RaidenOffloadConnector, RaidenOffloadConnectorScheduler,
+    KVRaidenConnectorStats, RaidenConnectorMetadata, RaidenLoadSpec,
+    RaidenLocator, RaidenOffloadConnector, RaidenOffloadConnectorScheduler,
     RaidenOffloadConnectorWorker, RaidenSaveSpec)
 
 _DEFAULT_BLOCK_SIZE = 16
@@ -84,6 +84,27 @@ def create_request(request_id: str, num_tokens: int,
     req.block_hashes = [f"hash_{i}".encode() for i in range(num_blocks)]
     req.num_tokens = num_tokens
     return req
+
+
+def make_matched(num_blocks: int, start_chunk: int = 100):
+    """Build a kv_store.lookup() result: list[(hash_bytes, [RaidenId])]."""
+    return [(f"hash_{i}".encode(), [
+        MockRaidenId(job_name="tpu_inference",
+                     job_replica_id="0",
+                     data_name="kv_cache",
+                     data_replica_idx=start_chunk + i)
+    ]) for i in range(num_blocks)]
+
+
+def make_scheduler(lookup_result=None, insert_result=None):
+    """Create a scheduler whose KVCacheStore mock returns the given results."""
+    store = MagicMock()
+    store.lookup.return_value = [] if lookup_result is None else lookup_result
+    if insert_result is not None:
+        store.insert.return_value = insert_result
+    mock_raiden.KVCacheStore.return_value = store
+    scheduler = RaidenOffloadConnectorScheduler(MockVllmConfig())
+    return scheduler, store
 
 
 def test_instantiation():
@@ -185,6 +206,240 @@ def test_worker_register_and_load():
     assert stats is not None
     assert "req_load" in stats.data["finished_load_chunks"]
     assert stats.data["finished_load_chunks"]["req_load"] == [10]
+
+
+# --------------------------------------------------------------------------- #
+# Connector-level helpers / pure-Python classes
+# --------------------------------------------------------------------------- #
+def test_get_required_kvcache_layout():
+    assert RaidenOffloadConnector.get_required_kvcache_layout(
+        MockVllmConfig()) == "NHD"
+
+
+def test_build_kv_connector_stats():
+    empty = RaidenOffloadConnector.build_kv_connector_stats()
+    assert isinstance(empty, KVRaidenConnectorStats)
+    assert empty.is_empty()
+
+    primed = RaidenOffloadConnector.build_kv_connector_stats(data={
+        "finished_save_chunks": {
+            "r": [1]
+        },
+        "finished_load_chunks": {}
+    })
+    assert isinstance(primed, KVRaidenConnectorStats)
+    assert not primed.is_empty()
+
+
+def test_raiden_locator_to_raiden_id():
+    loc = RaidenLocator(job_name="job",
+                        job_replica_id="rep",
+                        data_name="data",
+                        data_replica_idx=7)
+    rid = loc.to_raiden_id()
+    assert rid.job_name == "job"
+    assert rid.job_replica_id == "rep"
+    assert rid.data_name == "data"
+    assert rid.data_replica_idx == 7
+
+
+def test_connector_stats_record_aggregate_reduce():
+    stats = KVRaidenConnectorStats()
+    assert stats.is_empty()
+
+    stats.record_save("r1", [1, 2])
+    stats.record_load("r1", [3])
+    assert not stats.is_empty()
+    assert stats.reduce() == {"saves": 2, "loads": 1}
+    # num_finished_blocks counts request keys in both maps (1 + 1).
+    assert stats.num_finished_blocks == 2
+
+    other = KVRaidenConnectorStats()
+    other.record_save("r2", [9])
+    merged = stats.aggregate(other)
+    assert merged.data["finished_save_chunks"]["r1"] == [1, 2]
+    assert merged.data["finished_save_chunks"]["r2"] == [9]
+
+    # clone_and_reset returns the old snapshot and empties the live object.
+    snapshot = stats.clone_and_reset()
+    assert snapshot.data["finished_save_chunks"]["r1"] == [1, 2]
+    assert stats.is_empty()
+
+
+# --------------------------------------------------------------------------- #
+# Scheduler: cache-hit / load path
+# --------------------------------------------------------------------------- #
+def test_scheduler_cache_hit():
+    scheduler, store = make_scheduler(lookup_result=make_matched(2))
+    req = create_request("req_hit", num_tokens=48, block_size=16)  # 3 blocks
+
+    num_to_load, load_async = scheduler.get_num_new_matched_tokens(req, 0)
+
+    # 2 blocks hit * 16 = 32 tokens; not a full-prefix hit (48), so load all 32.
+    assert num_to_load == 32
+    assert load_async is False
+    store.pin.assert_called_once_with([b"hash_0", b"hash_1"])
+
+    pre = scheduler._pre_load_specs["req_hit"]
+    assert pre.src_chunks == [100, 101]
+    assert pre.num_matched_tokens == 32
+    assert pre.num_skip_leading_tokens == 0
+
+
+def test_scheduler_full_prefix_hit_reserves_one_token():
+    scheduler, _ = make_scheduler(lookup_result=make_matched(2))
+    req = create_request("req_full", num_tokens=32, block_size=16)  # 2 blocks
+
+    # All blocks hit => matched == num_tokens; must leave >=1 token to compute.
+    num_to_load, _ = scheduler.get_num_new_matched_tokens(req, 0)
+    assert num_to_load == 31
+
+
+def test_scheduler_partial_computed_loads_remainder():
+    scheduler, _ = make_scheduler(lookup_result=make_matched(3))
+    req = create_request("req_part", num_tokens=64, block_size=16)  # 4 blocks
+
+    # 3 blocks matched, 1 block (16 tok) already computed locally => load 2 blocks.
+    num_to_load, _ = scheduler.get_num_new_matched_tokens(req, 16)
+    assert num_to_load == 32  # (3*16) - 16
+    pre = scheduler._pre_load_specs["req_part"]
+    # load starts at the first uncomputed matched block -> chunks 101,102.
+    assert pre.src_chunks == [101, 102]
+
+
+def test_update_state_after_alloc_promotes_load():
+    scheduler, _ = make_scheduler(lookup_result=make_matched(2))
+    req = create_request("req_hit", num_tokens=48, block_size=16)
+    scheduler.get_num_new_matched_tokens(req, 0)  # populates _pre_load_specs
+
+    blocks = MagicMock()
+    blocks.get_block_ids.return_value = ([10, 11, 12], )
+    scheduler.update_state_after_alloc(req, blocks, num_external_tokens=32)
+
+    assert "req_hit" not in scheduler._pre_load_specs  # consumed
+    ls = scheduler.load_specs["req_hit"]
+    assert ls.can_load is True
+    assert ls.dst_blocks == [10, 11]  # skip_leading=0, 2 matched blocks
+    assert scheduler._reqs_being_loaded["req_hit"] == {100, 101}
+
+
+def test_update_state_after_alloc_no_external_is_noop():
+    scheduler, _ = make_scheduler()
+    req = create_request("req_x", num_tokens=32, block_size=16)
+    scheduler.update_state_after_alloc(req, MagicMock(), num_external_tokens=0)
+    assert "req_x" not in scheduler.load_specs
+    assert scheduler._unfinished_requests["req_x"] is req
+
+
+def test_request_finished_releases_pins():
+    scheduler, store = make_scheduler()
+    req = create_request("req_done", num_tokens=32, block_size=16)
+    delay_free, params = scheduler.request_finished(req, [0, 1])
+    assert delay_free is False
+    assert params is None
+    store.release.assert_called_once_with([b"hash_0", b"hash_1"])
+
+
+# --------------------------------------------------------------------------- #
+# Scheduler: reconcile worker output -> store insert + eviction
+# --------------------------------------------------------------------------- #
+def test_update_connector_output_inserts_and_stages_evictions():
+    evicted = MockRaidenId(data_replica_idx=99)
+    scheduler, store = make_scheduler(insert_result=(True, [(b"old_hash",
+                                                             [evicted])]))
+    scheduler._pending_save_hashes["req_s"] = [b"h0", b"h1"]
+
+    stats = KVRaidenConnectorStats()
+    stats.record_save("req_s", [50, 51])
+    output = MagicMock()
+    output.kv_connector_stats = stats
+
+    scheduler.update_connector_output(output)
+
+    # One insert per (hash, chunk) pair.
+    assert store.insert.call_count == 2
+    # Each insert evicted chunk 99 -> staged for physical unlock.
+    assert scheduler._pending_unlocks_to_send.count(99) == 2
+    # Pending hashes fully consumed.
+    assert "req_s" not in scheduler._pending_save_hashes
+
+
+# --------------------------------------------------------------------------- #
+# Worker: save path (d2h_auto_allocate + get_finished)
+# --------------------------------------------------------------------------- #
+def make_worker():
+    conn = RaidenOffloadConnector(MockVllmConfig(), KVConnectorRole.WORKER)
+    worker = conn.connector_worker
+    runner = MagicMock()
+    runner.kv_caches = [MagicMock()]
+    worker.register_runner(runner)
+    # raiden_manager is the shared KVCacheManager mock instance; clear call
+    # history (not return values) so per-test call assertions are isolated.
+    worker.raiden_manager.reset_mock()
+    return conn, worker
+
+
+def test_worker_save_flow():
+    conn, worker = make_worker()
+    future = MagicMock()
+    worker.raiden_manager.d2h_auto_allocate.return_value = ([5, 6], future)
+
+    save_spec = RaidenSaveSpec(num_skip_leading_tokens=0,
+                               num_total_tokens=32,
+                               src_blocks=[0, 1],
+                               block_hashes=[b"h0", b"h1"])
+    req_meta = MagicMock(req_id="req_save",
+                         save_spec=save_spec,
+                         load_spec=None)
+    conn._connector_metadata = RaidenConnectorMetadata(
+        requests_meta=[req_meta])
+
+    worker.wait_for_save()
+    worker.raiden_manager.d2h_auto_allocate.assert_called_once_with([0, 1])
+    assert len(worker._pending_saves) == 1
+
+    worker.get_finished(set())
+    future.Await.assert_called_once()
+    assert worker._pending_saves == []
+
+    stats = worker.get_kv_connector_stats()
+    assert stats.data["finished_save_chunks"]["req_save"] == [5, 6]
+
+
+def test_worker_skip_save_does_not_transfer():
+    conn, worker = make_worker()
+    save_spec = RaidenSaveSpec(num_skip_leading_tokens=0,
+                               num_total_tokens=0,
+                               src_blocks=[],
+                               is_final_save=True,
+                               skip_save=True)
+    req_meta = MagicMock(req_id="req_skip",
+                         save_spec=save_spec,
+                         load_spec=None)
+    conn._connector_metadata = RaidenConnectorMetadata(
+        requests_meta=[req_meta])
+
+    worker.wait_for_save()
+    worker.raiden_manager.d2h_auto_allocate.assert_not_called()
+    assert worker._pending_saves == []
+
+
+def test_worker_get_finished_unlocks_on_save_failure():
+    conn, worker = make_worker()
+    failing = MagicMock()
+    failing.Await.side_effect = RuntimeError("save boom")
+    worker._pending_saves = [(failing, "req_fail", [7, 8], [b"h"], [])]
+
+    # The failure path logs logger.error(...); patch the logger so the expected
+    # error message doesn't pollute test output, and assert it was emitted.
+    with patch("tpu_inference.offload.raiden_offload_connector.logger") \
+            as mock_logger:
+        worker.get_finished(set())
+    mock_logger.error.assert_called_once()
+
+    worker.raiden_manager.unlock_blocks.assert_called_once_with([7, 8])
+    assert worker._pending_saves == []  # cleared even on failure
+    assert "req_fail" not in worker.offload_stats.data["finished_save_chunks"]
 
 
 if __name__ == "__main__":

--- a/tests/offload/test_raiden_offload_connector.py
+++ b/tests/offload/test_raiden_offload_connector.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import importlib.util
 import sys
 from unittest.mock import MagicMock
 
@@ -20,12 +21,17 @@ from vllm.distributed.kv_transfer.kv_connector.v1.base import KVConnectorRole
 from vllm.v1.core.sched.output import SchedulerOutput
 from vllm.v1.request import Request
 
-from tpu_inference.offload.raiden_offload_connector import (
-    RaidenConnectorMetadata, RaidenLoadSpec, RaidenLocator,
-    RaidenOffloadConnector, RaidenOffloadConnectorScheduler,
-    RaidenOffloadConnectorWorker, RaidenSaveSpec)
+# Skip the whole module if tpu_raiden is not available in this environment.
+# `find_spec` only locates the package (it does NOT import it / load the engine
+# .so), so this is a safe availability check.
+if importlib.util.find_spec("tpu_raiden") is None:
+    pytest.skip(
+        "tpu_raiden is not importable; skipping Raiden offload connector tests",
+        allow_module_level=True)
 
-# Mock tpu_raiden module before importing connector to avoid strict ImportError
+# Mock tpu_raiden module BEFORE importing the connector so its module-level
+# `from tpu_raiden import ...` resolves to these mocks instead of being cached as
+# None (which makes the connector raise ImportError at use time).
 mock_raiden = MagicMock()
 mock_raiden.KVCacheManager = MagicMock()
 mock_raiden.KVCacheStore = MagicMock()
@@ -47,6 +53,11 @@ class MockRaidenId:
 
 mock_raiden.RaidenId = MockRaidenId
 sys.modules['tpu_raiden'] = mock_raiden
+
+from tpu_inference.offload.raiden_offload_connector import (  # noqa: E402
+    RaidenConnectorMetadata, RaidenLoadSpec, RaidenLocator,
+    RaidenOffloadConnector, RaidenOffloadConnectorScheduler,
+    RaidenOffloadConnectorWorker, RaidenSaveSpec)
 
 _DEFAULT_BLOCK_SIZE = 16
 

--- a/tpu_inference/layers/vllm/custom_ops/__init__.py
+++ b/tpu_inference/layers/vllm/custom_ops/__init__.py
@@ -14,12 +14,8 @@
 
 from tpu_inference.layers.vllm.custom_ops import embedding as embedding
 from tpu_inference.layers.vllm.custom_ops import fused_moe as fused_moe
-
-try:
-    from tpu_inference.layers.vllm.custom_ops import \
-        gdn_attention_op as gdn_attention_op
-except ModuleNotFoundError:
-    pass
+from tpu_inference.layers.vllm.custom_ops import \
+    gdn_attention_op as gdn_attention_op
 from tpu_inference.layers.vllm.custom_ops import linear as linear
 from tpu_inference.layers.vllm.custom_ops import mhc as mhc
 from tpu_inference.layers.vllm.custom_ops import mla_attention as mla_attention

--- a/tpu_inference/layers/vllm/custom_ops/__init__.py
+++ b/tpu_inference/layers/vllm/custom_ops/__init__.py
@@ -14,8 +14,12 @@
 
 from tpu_inference.layers.vllm.custom_ops import embedding as embedding
 from tpu_inference.layers.vllm.custom_ops import fused_moe as fused_moe
-from tpu_inference.layers.vllm.custom_ops import \
-    gdn_attention_op as gdn_attention_op
+
+try:
+    from tpu_inference.layers.vllm.custom_ops import \
+        gdn_attention_op as gdn_attention_op
+except ModuleNotFoundError:
+    pass
 from tpu_inference.layers.vllm.custom_ops import linear as linear
 from tpu_inference.layers.vllm.custom_ops import mhc as mhc
 from tpu_inference.layers.vllm.custom_ops import mla_attention as mla_attention

--- a/tpu_inference/offload/metrics.py
+++ b/tpu_inference/offload/metrics.py
@@ -56,6 +56,8 @@ class TPUKVCacheStats:
     host_memory_usage_bytes: int = 0
     staging_buffer_usage_blocks: int = 0
     staging_buffer_free_blocks: int = 0
+    evictions: int = 0
+    insertions: int = 0
 
 
 class TPUKVCacheMetrics:
@@ -76,6 +78,12 @@ class TPUKVCacheMetrics:
         self._lookup_requests: int = 0
         self._lookup_hits: int = 0
         self._lookup_miss: int = 0
+        self._interval_evictions: int = 0
+        self._cumulative_lookup_requests: int = 0
+        self._cumulative_lookup_hits: int = 0
+        self._cumulative_lookup_miss: int = 0
+        self._cumulative_evictions: int = 0
+        self._cumulative_insertions: int = 0
         self._d2h_operations: int = 0
         self._d2h_bytes: List[int] = []
         self._d2h_transfer_latencies: List[float] = []
@@ -106,14 +114,26 @@ class TPUKVCacheMetrics:
     def record_lookup_request(self):
         with self._instance_lock:
             self._lookup_requests += 1
+            self._cumulative_lookup_requests += 1
 
     def record_cache_hit(self, tokens: int):
         with self._instance_lock:
             self._lookup_hits += tokens
+            self._cumulative_lookup_hits += tokens
 
     def record_cache_miss(self, tokens: int):
         with self._instance_lock:
             self._lookup_miss += tokens
+            self._cumulative_lookup_miss += tokens
+
+    def record_eviction(self, count: int):
+        with self._instance_lock:
+            self._interval_evictions += count
+            self._cumulative_evictions += count
+
+    def record_insertion(self, count: int = 1):
+        with self._instance_lock:
+            self._cumulative_insertions += count
 
     def record_d2h_operation(self):
         with self._instance_lock:
@@ -163,6 +183,7 @@ class TPUKVCacheMetrics:
         self._lookup_requests = 0
         self._lookup_hits = 0
         self._lookup_miss = 0
+        self._interval_evictions = 0
         self._d2h_operations = 0
         self._d2h_bytes.clear()
         self._d2h_transfer_latencies.clear()
@@ -175,12 +196,35 @@ class TPUKVCacheMetrics:
         self._staging_buffer_usage_blocks = 0
         self._staging_buffer_free_blocks = 0
 
+    def get_cumulative_stats(self) -> TPUKVCacheStats:
+        with self._instance_lock:
+            stats = TPUKVCacheStats(
+                lookup_requests=self._cumulative_lookup_requests,
+                lookup_hits=self._cumulative_lookup_hits,
+                lookup_miss=self._cumulative_lookup_miss,
+                evictions=self._cumulative_evictions,
+                insertions=self._cumulative_insertions,
+                d2h_operations=self._d2h_operations,
+                d2h_bytes=list(self._d2h_bytes),
+                d2h_transfer_latencies=list(self._d2h_transfer_latencies),
+                d2h_transfer_bw=list(self._d2h_transfer_bw),
+                h2d_operations=self._h2d_operations,
+                h2d_bytes=list(self._h2d_bytes),
+                h2d_transfer_latencies=list(self._h2d_transfer_latencies),
+                h2d_transfer_bw=list(self._h2d_transfer_bw),
+                host_memory_usage_bytes=self._host_memory_usage_bytes,
+                staging_buffer_usage_blocks=self._staging_buffer_usage_blocks,
+                staging_buffer_free_blocks=self._staging_buffer_free_blocks,
+            )
+        return stats
+
     def get_stats_and_clear(self) -> TPUKVCacheStats:
         with self._instance_lock:
             stats = TPUKVCacheStats(
                 lookup_requests=self._lookup_requests,
                 lookup_hits=self._lookup_hits,
                 lookup_miss=self._lookup_miss,
+                evictions=self._interval_evictions,
                 d2h_operations=self._d2h_operations,
                 d2h_bytes=list(self._d2h_bytes),
                 d2h_transfer_latencies=list(self._d2h_transfer_latencies),
@@ -379,6 +423,9 @@ class TPUKVCacheStatsLogger:
     def log_worker(self):
         while not self.shutdown_event.is_set():
             stats = self.metrics.get_stats_and_clear()
+            logger.info(
+                f"Offload Metrics Snapshot: requests={stats.lookup_requests}, hits={stats.lookup_hits}, miss={stats.lookup_miss}, d2h={stats.d2h_operations}, h2d={stats.h2d_operations}"
+            )
             self.prometheus_logger.log_stats(stats)
             # wait returns True if the flag is set, False if timeout
             if self.shutdown_event.wait(self.log_interval):

--- a/tpu_inference/offload/raiden_offload_connector.py
+++ b/tpu_inference/offload/raiden_offload_connector.py
@@ -24,7 +24,6 @@ from vllm.distributed.kv_transfer.kv_connector.v1.base import (
     KVConnectorBase_V1, KVConnectorMetadata, KVConnectorRole)
 from vllm.distributed.kv_transfer.kv_connector.v1.metrics import \
     KVConnectorStats
-from vllm.v1.core.kv_cache_utils import BlockHash
 from vllm.v1.core.sched.output import SchedulerOutput
 from vllm.v1.kv_cache_interface import KVCacheConfig
 from vllm.v1.outputs import KVConnectorOutput
@@ -57,18 +56,6 @@ except ImportError:
         KVCacheStore = None
         RaidenId = None
         _RAIDEN_IMPORT_ERROR = _exc
-
-
-def to_raiden_hash(block_hash: BlockHash) -> bytes:
-    """Converts vLLM BlockHash to a bytes representation for C++ KVCacheStore."""
-    if isinstance(block_hash, bytes):
-        return block_hash
-    elif isinstance(block_hash, int):
-        return (block_hash % (2**64)).to_bytes(8, byteorder='big')
-    elif isinstance(block_hash, str):
-        return block_hash.encode('utf-8')
-    else:
-        return (hash(block_hash) % (2**64)).to_bytes(8, byteorder='big')
 
 
 @dataclass
@@ -324,8 +311,9 @@ class RaidenOffloadConnectorScheduler:
             )
         self.vllm_config = vllm_config
         self.block_size = vllm_config.cache_config.block_size
-        self.num_cpu_chunks = int(
-            os.getenv("TPU_OFFLOAD_NUM_CPU_CHUNKS", 65536))
+        # Must match the worker's host_blocks_to_allocate (which reads the same
+        # envs value) so the logical store and physical host pool stay in sync.
+        self.num_cpu_chunks = envs.TPU_OFFLOAD_NUM_CPU_CHUNKS
 
         self.job_name = os.getenv("RAIDEN_JOB_NAME", "tpu_inference")
         self.job_replica_id = os.getenv("CLOUD_TPU_TASK_ID", "0")
@@ -362,7 +350,7 @@ class RaidenOffloadConnectorScheduler:
 
         self.metrics_collector.record_lookup_request()
 
-        raiden_hashes = [to_raiden_hash(h) for h in request.block_hashes]
+        raiden_hashes = list(request.block_hashes)
         matched = self.kv_store.lookup(raiden_hashes)
         num_hits = len(matched)
         num_misses = len(raiden_hashes) - num_hits
@@ -463,7 +451,7 @@ class RaidenOffloadConnectorScheduler:
         adjusted_num_total_tokens = num_full_blocks * self.block_size
 
         block_hashes = _request.block_hashes
-        raiden_hashes = [to_raiden_hash(h) for h in block_hashes]
+        raiden_hashes = list(block_hashes)
 
         # C++ KVCacheStore manages LRU order authoritatively on access.
 
@@ -596,7 +584,7 @@ class RaidenOffloadConnectorScheduler:
             self, request: "Request",
             block_ids: list[int]) -> tuple[bool, Optional[dict[str, Any]]]:
         if self.kv_store is not None:
-            raiden_hashes = [to_raiden_hash(h) for h in request.block_hashes]
+            raiden_hashes = list(request.block_hashes)
             # Release logical pins in C++ KVCacheStore
             self.kv_store.release(raiden_hashes)
         return False, None

--- a/tpu_inference/offload/raiden_offload_connector.py
+++ b/tpu_inference/offload/raiden_offload_connector.py
@@ -1,0 +1,804 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""RaidenOffloadConnector manages KV cache data transfer using Raiden libraries."""
+
+import copy
+import os
+from collections import defaultdict
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Optional
+
+from vllm.config import VllmConfig
+from vllm.distributed.kv_transfer.kv_connector.v1.base import (
+    KVConnectorBase_V1, KVConnectorMetadata, KVConnectorRole)
+from vllm.distributed.kv_transfer.kv_connector.v1.metrics import \
+    KVConnectorStats
+from vllm.v1.core.kv_cache_utils import BlockHash
+from vllm.v1.core.sched.output import SchedulerOutput
+from vllm.v1.kv_cache_interface import KVCacheConfig
+from vllm.v1.outputs import KVConnectorOutput
+
+if TYPE_CHECKING:
+    from vllm.v1.core.kv_cache_manager import KVCacheBlocks
+    from vllm.v1.request import Request
+    from vllm.forward_context import ForwardContext
+    from tpu_inference.runner.tpu_runner import TPUModelRunner
+
+from tpu_inference import envs
+from tpu_inference.logger import init_logger
+from tpu_inference.offload.metrics import TPUKVCacheMetrics
+from tpu_inference.offload.utils import CpuChunkId, ReqId
+
+logger = init_logger(__name__)
+
+try:
+    from tpu_raiden.api.jax.kv_cache_manager import \
+        KVCacheManager as RaidenKVCacheManager
+    from tpu_raiden.api.jax.kv_cache_store import KVCacheStore, RaidenId
+    _RAIDEN_IMPORT_ERROR = None
+except ImportError:
+    try:
+        from tpu_raiden import KVCacheManager as RaidenKVCacheManager
+        from tpu_raiden import KVCacheStore, RaidenId
+        _RAIDEN_IMPORT_ERROR = None
+    except Exception as _exc:  # pylint: disable=broad-except
+        RaidenKVCacheManager = None
+        KVCacheStore = None
+        RaidenId = None
+        _RAIDEN_IMPORT_ERROR = _exc
+
+
+def to_raiden_hash(block_hash: BlockHash) -> bytes:
+    """Converts vLLM BlockHash to a bytes representation for C++ KVCacheStore."""
+    if isinstance(block_hash, bytes):
+        return block_hash
+    elif isinstance(block_hash, int):
+        return (block_hash % (2**64)).to_bytes(8, byteorder='big')
+    elif isinstance(block_hash, str):
+        return block_hash.encode('utf-8')
+    else:
+        return (hash(block_hash) % (2**64)).to_bytes(8, byteorder='big')
+
+
+@dataclass
+class RaidenLocator:
+    """Pure-Python, Ray-serializable container holding Raiden data locator info."""
+    job_name: str
+    job_replica_id: str
+    data_name: str
+    data_replica_idx: int
+
+    def to_raiden_id(self) -> "RaidenId":
+        if RaidenId is None:
+            raise ImportError("RaidenId is not available.")
+        return RaidenId(self.job_name, self.job_replica_id, self.data_name,
+                        self.data_replica_idx)
+
+
+@dataclass
+class RaidenSaveSpec:
+    num_skip_leading_tokens: int
+    num_total_tokens: int
+    src_blocks: list[int]
+    dst_chunks: list[int] = field(
+        default_factory=list)  # Filled on worker via auto-allocate
+    dst_locators: list[RaidenLocator] = field(default_factory=list)
+    block_hashes: list[bytes] = field(default_factory=list)
+    is_final_save: bool = False
+    skip_save: bool = False
+
+
+@dataclass
+class RaidenLoadSpec:
+    num_matched_tokens: int
+    src_chunks: list[int]
+    dst_blocks: list[int]
+    src_locators: list[RaidenLocator] = field(default_factory=list)
+    can_load: bool = False
+    num_skip_leading_tokens: int = 0
+
+
+@dataclass
+class RaidenReqMeta:
+    req_id: str
+    token_ids: list[int]
+    local_block_ids: list[int]
+    save_spec: Optional[RaidenSaveSpec] = None
+    load_spec: Optional[RaidenLoadSpec] = None
+
+
+@dataclass
+class RaidenConnectorMetadata(KVConnectorMetadata):
+    requests_meta: list[RaidenReqMeta] = field(default_factory=list)
+    pending_unlocks: list[int] = field(
+        default_factory=list)  # Physical chunks to unlock in C++
+
+
+@dataclass
+class KVRaidenConnectorStats(KVConnectorStats):
+
+    def __post_init__(self):
+        if not self.data:
+            self.reset()
+
+    def reset(self):
+        self.data: dict[str, dict[str, list[int]]] = {
+            "finished_save_chunks": dict(),
+            "finished_load_chunks": dict(),
+        }
+
+    def record_save(self, req: ReqId, saved_chunk_ids: list[int]):
+        if req not in self.data["finished_save_chunks"]:
+            self.data["finished_save_chunks"][req] = []
+        self.data["finished_save_chunks"][req].extend(
+            copy.deepcopy(saved_chunk_ids))
+
+    def record_load(self, req: ReqId, loaded_chunk_ids: list[int]):
+        if req not in self.data["finished_load_chunks"]:
+            self.data["finished_load_chunks"][req] = []
+        self.data["finished_load_chunks"][req].extend(
+            copy.deepcopy(loaded_chunk_ids))
+
+    def clone_and_reset(self) -> "KVRaidenConnectorStats":
+        old = copy.copy(self)
+        self.reset()
+        return old
+
+    @property
+    def num_finished_blocks(self) -> int:
+        return len(self.data["finished_save_chunks"]) + len(
+            self.data["finished_load_chunks"])
+
+    def aggregate(self, other: "KVConnectorStats") -> "KVConnectorStats":
+        res = KVRaidenConnectorStats()
+        res.data["finished_save_chunks"] = copy.deepcopy(
+            self.data["finished_save_chunks"])
+        res.data["finished_load_chunks"] = copy.deepcopy(
+            self.data["finished_load_chunks"])
+        if isinstance(other, KVRaidenConnectorStats) and other.data:
+            for req, chunks in other.data.get("finished_save_chunks",
+                                              {}).items():
+                if req not in res.data["finished_save_chunks"]:
+                    res.data["finished_save_chunks"][req] = []
+                res.data["finished_save_chunks"][req].extend(
+                    copy.deepcopy(chunks))
+            for req, chunks in other.data.get("finished_load_chunks",
+                                              {}).items():
+                if req not in res.data["finished_load_chunks"]:
+                    res.data["finished_load_chunks"][req] = []
+                res.data["finished_load_chunks"][req].extend(
+                    copy.deepcopy(chunks))
+        return res
+
+    def reduce(self) -> dict[str, int | float]:
+        return {
+            "saves":
+            sum(len(c) for c in self.data["finished_save_chunks"].values()),
+            "loads":
+            sum(len(c) for c in self.data["finished_load_chunks"].values()),
+        }
+
+    def is_empty(self) -> bool:
+        return not self.data["finished_save_chunks"] and not self.data[
+            "finished_load_chunks"]
+
+
+@dataclass
+class RaidenRequestTracker:
+    req_id: str
+    prompt_len: int
+    block_ids: list[int]
+    token_ids: list[int]
+    save_watermark: int = 0
+    is_decode_phase: bool = False
+
+    def update(self, new_block_ids: list[int], new_token_ids: list[int]):
+        if new_block_ids is None:
+            new_block_ids = []
+        elif isinstance(new_block_ids, tuple):
+            new_block_ids = new_block_ids[0]
+        self.block_ids.extend(new_block_ids)
+        self.token_ids.extend(new_token_ids)
+        if len(new_token_ids) == 1:
+            self.is_decode_phase = True
+
+    def reset_after_preempt(self):
+        self.block_ids = []
+        self.token_ids = []
+        self.is_decode_phase = False
+
+
+class RaidenOffloadConnector(KVConnectorBase_V1):
+    """Manages KV cache offloading via Raiden libraries."""
+
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        role: KVConnectorRole,
+        kv_cache_config: KVCacheConfig | None = None,
+    ):
+        super().__init__(vllm_config, role, kv_cache_config)
+        logger.info("RaidenOffloadConnector: Entering __init__")
+        if role == KVConnectorRole.SCHEDULER:
+            self.connector_scheduler = RaidenOffloadConnectorScheduler(
+                vllm_config)
+            self.connector_worker = None
+        elif role == KVConnectorRole.WORKER:
+            self.connector_scheduler = None
+            self.connector_worker = RaidenOffloadConnectorWorker(
+                vllm_config, self)
+
+    @classmethod
+    def get_required_kvcache_layout(cls, vllm_config: VllmConfig):
+        return "NHD"
+
+    @classmethod
+    def build_kv_connector_stats(
+        cls,
+        data: dict[str, dict[str, int]] | None = None
+    ) -> KVConnectorStats | None:
+        return KVRaidenConnectorStats(
+            data=data) if data is not None else KVRaidenConnectorStats()
+
+    def get_num_new_matched_tokens(
+            self, request: "Request",
+            num_computed_tokens: int) -> tuple[int, bool]:
+        assert self.connector_scheduler is not None
+        return self.connector_scheduler.get_num_new_matched_tokens(
+            request, num_computed_tokens)
+
+    def update_state_after_alloc(self, request: "Request",
+                                 blocks: "KVCacheBlocks",
+                                 num_external_tokens: int):
+        assert self.connector_scheduler is not None
+        return self.connector_scheduler.update_state_after_alloc(
+            request, blocks, num_external_tokens)
+
+    def build_connector_meta(
+        self,
+        scheduler_output: SchedulerOutput,
+    ) -> RaidenConnectorMetadata:
+        assert self.connector_scheduler is not None
+        return self.connector_scheduler.build_connector_meta(scheduler_output)
+
+    def request_finished(
+        self,
+        request: "Request",
+        block_ids: list[int],
+    ) -> tuple[bool, Optional[dict[str, Any]]]:
+        assert self.connector_scheduler is not None
+        return self.connector_scheduler.request_finished(request, block_ids)
+
+    def register_runner(self, runner: "TPUModelRunner") -> None:
+        assert self.connector_worker is not None
+        self.connector_worker.register_runner(runner)
+
+    def start_load_kv(self, fwd_ctx: "ForwardContext") -> None:
+        assert self.connector_worker is not None
+        self.connector_worker.start_load_kv(fwd_ctx)
+
+    def wait_for_layer_load(self, layer_name: str) -> None:
+        pass
+
+    def save_kv_layer(self, **kwargs) -> None:
+        pass
+
+    def wait_for_save(self):
+        assert self.connector_worker is not None
+        self.connector_worker.wait_for_save()
+
+    def get_finished(self,
+                     finished_req_ids: set[str]) -> tuple[set[str], set[str]]:
+        assert self.connector_worker is not None
+        return self.connector_worker.get_finished(finished_req_ids)
+
+    def update_connector_output(self, connector_output: KVConnectorOutput):
+        assert self.connector_scheduler is not None
+        self.connector_scheduler.update_connector_output(connector_output)
+
+    def get_kv_connector_stats(self) -> KVConnectorStats | None:
+        if self.connector_worker is None:
+            return None
+        return self.connector_worker.get_kv_connector_stats()
+
+
+class RaidenOffloadConnectorScheduler:
+    """Coordinates logical state of Raiden KV cache offloading utilizing authoritative Raiden KVCacheStore."""
+
+    def __init__(self, vllm_config: VllmConfig):
+        if KVCacheStore is None:
+            raise ImportError(
+                "KVCacheStore is not importable from tpu_raiden. Please check your "
+                f"PYTHONPATH and Raiden installation. Original error: {_RAIDEN_IMPORT_ERROR}"
+            )
+        self.vllm_config = vllm_config
+        self.block_size = vllm_config.cache_config.block_size
+        self.num_cpu_chunks = int(
+            os.getenv("TPU_OFFLOAD_NUM_CPU_CHUNKS", 65536))
+
+        self.job_name = os.getenv("RAIDEN_JOB_NAME", "tpu_inference")
+        self.job_replica_id = os.getenv("CLOUD_TPU_TASK_ID", "0")
+        self.data_name = os.getenv("RAIDEN_DATA_NAME", "kv_cache")
+        logger.info(
+            f"Raiden Scheduler Locator baseline: job={self.job_name}, replica={self.job_replica_id}, data={self.data_name}"
+        )
+
+        # Authoritative logical C++ metadata store
+        self.kv_store = KVCacheStore(capacity=self.num_cpu_chunks)
+
+        # Track pending physical unlocks to send to workers
+        self._pending_unlocks_to_send: list[int] = []
+
+        self._request_trackers: dict[ReqId, RaidenRequestTracker] = {}
+        self._unfinished_requests: dict[ReqId, "Request"] = {}
+        self.load_specs: dict[ReqId, RaidenLoadSpec] = {}
+        self._pre_load_specs: dict[ReqId, RaidenLoadSpec] = {}
+        self._external_cache_hits: dict[ReqId, int] = {}
+
+        # Map ReqId -> list(Hash) for active in-flight save tracking
+        self._pending_save_hashes: dict[ReqId, list[bytes]] = defaultdict(list)
+
+        self._reqs_being_saved = defaultdict[ReqId, set[CpuChunkId]](set)
+        self._reqs_being_loaded = defaultdict[ReqId, set[CpuChunkId]](set)
+        self.metrics_collector = TPUKVCacheMetrics.get_or_create()
+        self._recorded_metrics_reqs: set[ReqId] = set()
+
+    def get_num_new_matched_tokens(
+            self, request: "Request",
+            num_computed_tokens: int) -> tuple[int, bool]:
+        if self.kv_store is None:
+            return 0, False
+
+        self.metrics_collector.record_lookup_request()
+
+        raiden_hashes = [to_raiden_hash(h) for h in request.block_hashes]
+        matched = self.kv_store.lookup(raiden_hashes)
+        num_hits = len(matched)
+        num_misses = len(raiden_hashes) - num_hits
+        logger.debug(
+            f"Raiden KVCacheStore lookup result for {request.request_id}: Block Hits={num_hits}, Block Misses={num_misses}"
+        )
+        if num_computed_tokens == 0:
+            print(
+                f"[RaidenOffload] Lookup snapshot for {request.request_id}: Block Hits={num_hits}, Block Misses={num_misses}",
+                flush=True)
+
+        if num_hits > 0:
+            matched_hashes = [m[0] for m in matched]
+            # Pin in C++ store
+            self.kv_store.pin(matched_hashes)
+
+        num_matched_blocks = num_hits
+        num_matched_tokens = num_matched_blocks * self.block_size
+        num_computed_blocks = num_computed_tokens // self.block_size
+        num_blocks_to_load = max(num_matched_blocks - num_computed_blocks, 0)
+
+        if num_blocks_to_load > 0:
+            src_chunk_ids = []
+            src_locators = []
+            load_start_idx = num_computed_blocks
+
+            for i in range(load_start_idx,
+                           load_start_idx + num_blocks_to_load):
+                _, raiden_ids = matched[i]
+                r_id = raiden_ids[0]
+                src_chunk_ids.append(r_id.data_replica_idx)
+                src_locators.append(
+                    RaidenLocator(r_id.job_name, r_id.job_replica_id,
+                                  r_id.data_name, r_id.data_replica_idx))
+
+            dummy_dst_blocks = [-1] * num_blocks_to_load
+            self._pre_load_specs[request.request_id] = RaidenLoadSpec(
+                num_matched_tokens=num_matched_tokens,
+                src_chunks=src_chunk_ids,
+                dst_blocks=dummy_dst_blocks,
+                src_locators=src_locators,
+                num_skip_leading_tokens=num_computed_tokens,
+            )
+
+        self._external_cache_hits[request.request_id] = num_matched_tokens
+
+        if request.request_id not in self._recorded_metrics_reqs:
+            self._recorded_metrics_reqs.add(request.request_id)
+            total_hits = num_matched_tokens
+            total_misses = max(0, request.num_tokens - total_hits)
+            self.metrics_collector.record_cache_hit(total_hits)
+            self.metrics_collector.record_cache_miss(total_misses)
+
+            stats = self.metrics_collector.get_cumulative_stats()
+            total_tokens = stats.lookup_hits + stats.lookup_miss
+            hit_rate = (stats.lookup_hits / total_tokens *
+                        100.0) if total_tokens > 0 else 0.0
+            logger.debug(
+                f"Cumulative Host Cache Hit Rate: {hit_rate:.2f}% (Hits: {stats.lookup_hits}, Miss: {stats.lookup_miss}, Inserts: {stats.insertions}, Evictions: {stats.evictions}, Queries: {stats.lookup_requests})"
+            )
+
+        num_matched_for_scheduler = num_matched_tokens
+        if num_matched_tokens > 0 and num_matched_tokens == request.num_tokens:
+            num_matched_for_scheduler = num_matched_tokens - 1
+
+        num_to_load = max(0, num_matched_for_scheduler - num_computed_tokens)
+        return num_to_load, False
+
+    def update_state_after_alloc(self, request: "Request",
+                                 blocks: "KVCacheBlocks",
+                                 num_external_tokens: int):
+        self._unfinished_requests[request.request_id] = request
+        if num_external_tokens == 0:
+            return
+        load_spec = self._pre_load_specs.pop(request.request_id, None)
+        if load_spec:
+            skip_leading_blocks = load_spec.num_skip_leading_tokens // self.block_size
+            num_blocks_to_load = len(load_spec.src_chunks)
+            num_matched_blocks = num_blocks_to_load + skip_leading_blocks
+
+            all_blocks = blocks.get_block_ids()[0]
+            dst_blocks = all_blocks[skip_leading_blocks:num_matched_blocks]
+
+            load_spec.dst_blocks = dst_blocks
+            load_spec.can_load = True
+            self.load_specs[request.request_id] = load_spec
+            self._reqs_being_loaded[request.request_id] |= set(
+                load_spec.src_chunks)
+
+    def _prepare_save_spec(self, tracker: RaidenRequestTracker,
+                           is_finished: bool) -> Optional[RaidenSaveSpec]:
+        req_id = tracker.req_id
+        _request = self._unfinished_requests[req_id]
+
+        num_tracked_tokens = len(tracker.token_ids)
+        num_full_blocks = num_tracked_tokens // self.block_size
+        adjusted_num_total_blocks = num_full_blocks
+        adjusted_num_total_tokens = num_full_blocks * self.block_size
+
+        block_hashes = _request.block_hashes
+        raiden_hashes = [to_raiden_hash(h) for h in block_hashes]
+
+        # C++ KVCacheStore manages LRU order authoritatively on access.
+
+        has_new_tokens = adjusted_num_total_tokens > tracker.save_watermark
+        should_save = False
+        if has_new_tokens:
+            if not tracker.is_decode_phase:
+                should_save = True
+            elif envs.TPU_OFFLOAD_DECODE_SAVE:
+                if is_finished:
+                    should_save = True
+                else:
+                    next_block_boundary = (
+                        tracker.save_watermark // self.block_size +
+                        1) * self.block_size
+                    if adjusted_num_total_tokens == next_block_boundary:
+                        should_save = True
+
+        save_spec = None
+        if should_save:
+            num_skip_leading_blocks = tracker.save_watermark // self.block_size
+            num_skip_leading_tokens = num_skip_leading_blocks * self.block_size
+            num_blocks_to_save = adjusted_num_total_blocks - num_skip_leading_blocks
+
+            if num_blocks_to_save > 0:
+                hashes_to_save = raiden_hashes[
+                    num_skip_leading_blocks:adjusted_num_total_blocks]
+                self._pending_save_hashes[req_id].extend(hashes_to_save)
+
+                src_block_ids = tracker.block_ids[
+                    num_skip_leading_blocks:adjusted_num_total_blocks]
+
+                save_spec = RaidenSaveSpec(
+                    num_skip_leading_tokens=num_skip_leading_tokens,
+                    num_total_tokens=adjusted_num_total_tokens,
+                    is_final_save=is_finished,
+                    src_blocks=src_block_ids,
+                    dst_chunks=
+                    [],  # Physical chunks are automatically allocated on the worker!
+                    dst_locators=[],
+                    block_hashes=hashes_to_save,
+                )
+                tracker.save_watermark = adjusted_num_total_tokens
+
+        if is_finished and save_spec is None:
+            save_spec = RaidenSaveSpec(
+                num_skip_leading_tokens=tracker.save_watermark,
+                num_total_tokens=tracker.save_watermark,
+                src_blocks=[],
+                dst_chunks=[],
+                dst_locators=[],
+                is_final_save=True,
+                skip_save=True,
+            )
+        return save_spec
+
+    def build_connector_meta(
+            self,
+            scheduler_output: SchedulerOutput) -> RaidenConnectorMetadata:
+        metadata = RaidenConnectorMetadata(
+            pending_unlocks=copy.deepcopy(self._pending_unlocks_to_send))
+        self._pending_unlocks_to_send.clear()
+
+        for finished_req_id in scheduler_output.finished_req_ids:
+            self._request_trackers.pop(finished_req_id, None)
+            self._unfinished_requests.pop(finished_req_id, None)
+            self.load_specs.pop(finished_req_id, None)
+            self._recorded_metrics_reqs.discard(finished_req_id)
+
+        for request in scheduler_output.scheduled_new_reqs:
+            req_id = request.req_id
+            _request = self._unfinished_requests.get(req_id, None)
+            if not _request:
+                continue
+            num_new_tokens = scheduler_output.num_scheduled_tokens[req_id]
+            num_external_hits = self._external_cache_hits.pop(req_id, 0)
+
+            num_total = min(request.num_computed_tokens + num_new_tokens,
+                            _request.num_tokens)
+            tokens_for_tracker = request.prompt_token_ids[:num_total]
+            initial_save = max(request.num_computed_tokens, num_external_hits)
+
+            tracker = RaidenRequestTracker(
+                req_id=req_id,
+                prompt_len=len(request.prompt_token_ids),
+                block_ids=copy.deepcopy(request.block_ids[0]),
+                token_ids=tokens_for_tracker,
+                save_watermark=initial_save,
+            )
+            self._request_trackers[req_id] = tracker
+
+            load_spec = self.load_specs.pop(req_id, None)
+            save_spec = self._prepare_save_spec(tracker, is_finished=False)
+            if save_spec or (load_spec and load_spec.can_load):
+                metadata.requests_meta.append(
+                    RaidenReqMeta(req_id, tracker.token_ids, tracker.block_ids,
+                                  save_spec, load_spec))
+
+        cached_reqs = scheduler_output.scheduled_cached_reqs
+        for i, req_id in enumerate(cached_reqs.req_ids):
+            _request = self._unfinished_requests.get(req_id, None)
+            if _request is None:
+                continue
+            tracker = self._request_trackers[req_id]
+            if req_id in cached_reqs.resumed_req_ids:
+                tracker.reset_after_preempt()
+
+            num_new = scheduler_output.num_scheduled_tokens[req_id]
+            cur_total = min(_request.num_computed_tokens + num_new,
+                            _request.num_tokens)
+            num_tracked = len(tracker.token_ids)
+            new_tokens = _request.all_token_ids[
+                num_tracked:cur_total] if cur_total > num_tracked else []
+            new_blocks = cached_reqs.new_block_ids[i] or []
+
+            tracker.update(new_blocks, new_tokens)
+
+            load_spec = self.load_specs.pop(req_id, None)
+            save_spec = self._prepare_save_spec(tracker, is_finished=False)
+            if save_spec or (load_spec and load_spec.can_load):
+                metadata.requests_meta.append(
+                    RaidenReqMeta(req_id, tracker.token_ids, tracker.block_ids,
+                                  save_spec, load_spec))
+
+        self._pre_load_specs.clear()
+        self._external_cache_hits.clear()
+        return metadata
+
+    def request_finished(
+            self, request: "Request",
+            block_ids: list[int]) -> tuple[bool, Optional[dict[str, Any]]]:
+        if self.kv_store is not None:
+            raiden_hashes = [to_raiden_hash(h) for h in request.block_hashes]
+            # Release logical pins in C++ KVCacheStore
+            self.kv_store.release(raiden_hashes)
+        return False, None
+
+    def update_connector_output(self, connector_output: KVConnectorOutput):
+        if connector_output.kv_connector_stats and connector_output.kv_connector_stats.data is not None:
+            stats = connector_output.kv_connector_stats
+
+            for req_id, saved_chunks in stats.data[
+                    "finished_save_chunks"].items():
+                pending_hashes = self._pending_save_hashes.get(req_id, [])
+                num_completed = len(saved_chunks)
+
+                # Retrieve the corresponding block hashes in order
+                completed_hashes = [
+                    pending_hashes.pop(0) for _ in range(num_completed)
+                ] if len(pending_hashes) >= num_completed else []
+
+                for h, cid in zip(completed_hashes, saved_chunks):
+                    if RaidenId is not None and self.kv_store is not None:
+                        locator = RaidenLocator(self.job_name,
+                                                self.job_replica_id,
+                                                self.data_name, cid)
+                        # 1. Insert into C++ metadata lookup store
+                        # 1. Insert into C++ logical store and process evictions
+                        all_inserted, evicted = self.kv_store.insert(
+                            [h], [[locator.to_raiden_id()]], on_host=True)
+                        if all_inserted:
+                            self.metrics_collector.record_insertion(1)
+
+                            # Handle C++ LRU evictions immediately
+                            if evicted:
+                                for evict_hash, evict_slices in evicted:
+                                    for slice_id in evict_slices:
+                                        evict_cid = slice_id.data_replica_idx
+                                        self._pending_unlocks_to_send.append(
+                                            evict_cid)
+                                        self.metrics_collector.record_eviction(
+                                            1)
+                                        logger.debug(
+                                            f"[RaidenOffload] C++ Eviction: Staging physical unlock for chunk {evict_cid} (hash {evict_hash})"
+                                        )
+
+                if not pending_hashes:
+                    self._pending_save_hashes.pop(req_id, None)
+
+                for chunk_id in saved_chunks:
+                    self._reqs_being_saved[req_id].discard(chunk_id)
+                if not self._reqs_being_saved[req_id]:
+                    self._reqs_being_saved.pop(req_id, None)
+
+            for req_id, loaded_chunks in stats.data[
+                    "finished_load_chunks"].items():
+                for chunk_id in loaded_chunks:
+                    self._reqs_being_loaded[req_id].discard(chunk_id)
+                if not self._reqs_being_loaded[req_id]:
+                    self._reqs_being_loaded.pop(req_id, None)
+
+
+class RaidenOffloadConnectorWorker:
+    """Executes physical KV cache transfers via Raiden KVCacheManager."""
+
+    def __init__(self, vllm_config: VllmConfig,
+                 connector: RaidenOffloadConnector):
+        self.vllm_config = vllm_config
+        self.connector = connector
+        self.block_size = vllm_config.cache_config.block_size
+        self.num_cpu_chunks = envs.TPU_OFFLOAD_NUM_CPU_CHUNKS
+
+        self.job_replica_id = os.getenv("CLOUD_TPU_TASK_ID", "0")
+        self.raiden_manager: Optional[RaidenKVCacheManager] = None
+        self.offload_stats = KVRaidenConnectorStats()
+        self._pending_saves: list[Any] = []
+
+    def register_runner(self, runner: "TPUModelRunner"):
+        if RaidenKVCacheManager is None:
+            raise ImportError(
+                "RaidenKVCacheManager is not importable from tpu_raiden. Please check your "
+                f"PYTHONPATH and Raiden installation. Original error: {_RAIDEN_IMPORT_ERROR}"
+            )
+
+        kv_caches = runner.kv_caches
+        if not kv_caches:
+            raise ValueError("No KV caches registered in Runner.")
+
+        logger.info(
+            f"Initializing Raiden KVCacheManager on worker. host_blocks_to_allocate={self.num_cpu_chunks}, block_size={self.block_size}"
+        )
+        self.raiden_manager = RaidenKVCacheManager(
+            kv_caches=kv_caches,
+            local_control_port=0,
+            host_blocks_to_allocate=self.num_cpu_chunks,
+            unsafe_skip_buffer_lock=True)
+        logger.info("Raiden Worker: C++ KVCacheManager Initialized.")
+
+    def start_load_kv(self, fwd_ctx: "ForwardContext"):
+        if not self.raiden_manager:
+            return
+        meta: RaidenConnectorMetadata = self.connector._connector_metadata  # type: ignore
+        if not meta:
+            return
+
+        # 1. Execute physical block unlocking before load
+        if meta.pending_unlocks:
+            logger.debug(
+                f"Raiden Worker: Unlocking {len(meta.pending_unlocks)} physical Host RAM blocks in C++: {meta.pending_unlocks}"
+            )
+            self.raiden_manager.unlock_blocks(meta.pending_unlocks)
+
+        if not meta.requests_meta:
+            return
+
+        for req_meta in meta.requests_meta:
+            load_spec = req_meta.load_spec
+            if load_spec and load_spec.can_load:
+                logger.debug(
+                    f"Raiden Worker: Loading {len(load_spec.src_chunks)} chunks for {req_meta.req_id} "
+                    f"from locators: {load_spec.src_locators}")
+
+                remote_src_chunks = []
+                local_src_chunks = []
+                local_dst_blocks = []
+
+                for idx, loc in enumerate(load_spec.src_locators):
+                    if loc.job_replica_id != self.job_replica_id:
+                        remote_src_chunks.append(
+                            (loc, load_spec.dst_blocks[idx]))
+                    else:
+                        local_src_chunks.append(loc.data_replica_idx)
+                        local_dst_blocks.append(load_spec.dst_blocks[idx])
+
+                if remote_src_chunks:
+                    logger.info(
+                        f"Raiden Worker: Found {len(remote_src_chunks)} remote chunks to fetch over network! (E.g., {remote_src_chunks[0]})"
+                    )
+
+                if local_src_chunks:
+                    self.raiden_manager.h2d(local_src_chunks, local_dst_blocks)
+
+                self.offload_stats.record_load(req_meta.req_id,
+                                               load_spec.src_chunks)
+
+    def wait_for_save(self):
+        if not self.raiden_manager:
+            return
+        meta: RaidenConnectorMetadata = self.connector._connector_metadata  # type: ignore
+        if not meta or not meta.requests_meta:
+            return
+
+        for req_meta in meta.requests_meta:
+            save_spec = req_meta.save_spec
+            if save_spec and not save_spec.skip_save and save_spec.src_blocks:
+                req_id = req_meta.req_id
+                src_blocks = save_spec.src_blocks
+                logger.debug(
+                    f"Raiden Worker: Calling d2h_auto_allocate for {len(src_blocks)} blocks for {req_id}."
+                )
+
+                # Delegate physical allocation to C++ using d2h_auto_allocate!
+                # This automatically allocates locked physical chunk IDs and issues the async copy.
+                try:
+                    allocated_chunks, future = self.raiden_manager.d2h_auto_allocate(
+                        src_blocks)
+                except Exception as e:
+                    logger.error(
+                        f"Raiden Worker: d2h_auto_allocate failed for {req_id}: {e}"
+                    )
+                    continue
+
+                # Reconstruct dst_locators now that physical chunk IDs are allocated
+                job_name = self.connector.connector_scheduler.job_name if self.connector.connector_scheduler else "tpu_inference"
+                dst_locators = [
+                    RaidenLocator(job_name, self.job_replica_id, "kv_cache",
+                                  cid) for cid in allocated_chunks
+                ]
+
+                self._pending_saves.append(
+                    (future, req_id, allocated_chunks, save_spec.block_hashes,
+                     dst_locators))
+
+    def get_finished(self,
+                     finished_req_ids: set[str]) -> tuple[set[str], set[str]]:
+        completed = []
+        finished_saves = set()
+        for item in self._pending_saves:
+            future, req_id, chunks, hashes, locators = item
+            try:
+                future.Await()  # Synchronous wait for the JAX FFI future
+
+                self.offload_stats.record_save(req_id, chunks)
+                finished_saves.add(req_id)
+                logger.debug(f"Raiden Worker: Save complete for {req_id}.")
+            except Exception as e:
+                logger.error(f"Failed to save Raiden chunks for {req_id}: {e}")
+                # CRITICAL: Unlock the physically allocated blocks so they can be reused!
+                self.raiden_manager.unlock_blocks(chunks)
+            completed.append(item)
+
+        for item in completed:
+            self._pending_saves.remove(item)
+
+        return set(), set()
+
+    def get_kv_connector_stats(self) -> KVConnectorStats | None:
+        return self.offload_stats.clone_and_reset()

--- a/tpu_inference/platforms/tpu_platform.py
+++ b/tpu_inference/platforms/tpu_platform.py
@@ -359,7 +359,7 @@ class TpuPlatform(Platform):
         kv_transfer_config = vllm_config.kv_transfer_config
         if kv_transfer_config is not None:
             allowed = ("TPUConnector", "TPUConnectorHMA",
-                       "TPUOffloadConnector")
+                       "TPUOffloadConnector", "RaidenOffloadConnector")
             if kv_transfer_config.kv_connector not in allowed:
                 raise ValueError(
                     f"Unsupported kv_connector "

--- a/tpu_inference/worker/tpu_worker.py
+++ b/tpu_inference/worker/tpu_worker.py
@@ -389,9 +389,14 @@ class TPUWorker(WorkerBase):
         self.stats_logger = None
         if self.vllm_config.kv_transfer_config is not None:
             kv_transfer_config = self.vllm_config.kv_transfer_config
-            if (kv_transfer_config.kv_connector == "TPUOffloadConnector"
+            is_offload_connector = (
+                (kv_transfer_config.kv_connector == "TPUOffloadConnector"
+                 and kv_transfer_config.kv_connector_module_path
+                 == "tpu_inference.offload.tpu_offload_connector")
+                or (kv_transfer_config.kv_connector == "RaidenOffloadConnector"
                     and kv_transfer_config.kv_connector_module_path
-                    == "tpu_inference.offload.tpu_offload_connector"):
+                    == "tpu_inference.offload.raiden_offload_connector"))
+            if is_offload_connector:
 
                 # Start the background thread (logging every TPU_OFFLOAD_METRICS_LOG_INTERVAL seconds)
                 self.stats_logger = TPUKVCacheStatsLogger(
@@ -425,8 +430,14 @@ class TPUWorker(WorkerBase):
 
         if self.vllm_config.kv_transfer_config is not None:
             kv_transfer_config = self.vllm_config.kv_transfer_config
-            if kv_transfer_config.kv_connector == "TPUOffloadConnector" and \
-               kv_transfer_config.kv_connector_module_path == "tpu_inference.offload.tpu_offload_connector":
+            is_offload_connector = (
+                (kv_transfer_config.kv_connector == "TPUOffloadConnector"
+                 and kv_transfer_config.kv_connector_module_path
+                 == "tpu_inference.offload.tpu_offload_connector")
+                or (kv_transfer_config.kv_connector == "RaidenOffloadConnector"
+                    and kv_transfer_config.kv_connector_module_path
+                    == "tpu_inference.offload.raiden_offload_connector"))
+            if is_offload_connector:
                 # If kv offloading is enabled, we need to account for the memory used by the KV transfer buffer.
                 staging_buffer_pages = envs.TPU_OFFLOAD_NUM_STAGING_BLOCKS
 


### PR DESCRIPTION
## Summary
This PR implements high-performance Raiden KV Cache Offloading to host CPU memory for JAX TPUs in vLLM. It integrates the authoritative C++ `KVCacheStore` and `RaidenKVCacheManager` to handle physical block allocation, locking, and LRU evictions.
## Key Changes
* **C++ Allocation & Management**: Delegated physical Host RAM block allocation to C++ via `d2h_auto_allocate()`, removing redundant worker-side python cache/executor components.
* **LRU & Lifecycle Integration**: Integrated physical block unlocking and LRU promotion directly into the load/save lifecycle to ensure correct host buffer evictability.
* **Robust Metrics & Accounting**: Implemented incremental prefix cache token accounting across chunked prefill steps and robust metrics tracking in `KVRaidenConnectorStats`.
* **Resilience**: Wrapped experimental imports in resilient try/except blocks to prevent import failures.
