### PR TITLE
Support GCS URIs for profiler output directories

### DIFF
--- a/docs/profiling.md
+++ b/docs/profiling.md
@@ -31,7 +31,7 @@ python3 examples/tpu_profiling.py --model <your-model-name> [OPTIONS]
 * `--input-len`: The length of the input prompt tokens per request
 * `--output-len`: The number of tokens to generate per request.
 * `--batch-size`: The number of requests.
-* `--profile-result-dir`: The directory where the JAX profiler output will be saved.
+* `--profile-result-dir`: The directory where the JAX profiler output will be saved (local path or `gs://` GCS URI).
 * The script also accepts all standard vLLM `EngineArgs` (e.g., `--tensor-parallel-size`, `--dtype`).
 
 #### Examples
@@ -73,6 +73,8 @@ we will automatically capture profiles during three phases of your workload (ass
 3. Mixed (the quotient of prefill / total scheduled tokens for the given batch is between 0.4 and 0.6)
 
 To aid in your analysis, we will also log the batch composition for the profiled batches.
+
+`PHASED_PROFILING_DIR`, `AGGREGATED_STATS_DIR`, and the torch/JAX profiler output directory (`--profiler-config` / `--profile-result-dir` / `VLLM_TORCH_PROFILER_DIR`) all accept either a local path or a GCS URI (`gs://bucket/prefix`). For phased profiling, traces are staged on local disk (so multi-rank merge and marker coordination still work) and uploaded to the bucket after each phase completes. Direct `jax.profiler` captures (worker `profile()` and the TensorBoard capture UI) can write to `gs://` natively.
 
 ## Using `USE_JAX_PROFILER_SERVER`
 If you set the following environment variable:

--- a/tests/runner/test_utils.py
+++ b/tests/runner/test_utils.py
@@ -844,3 +844,44 @@ def test_merge_profile_directories_ignores_stale_prior_run_data(tmp_path):
     # New data lands in its own canonical dir.
     new_dst = phase_dir / "plugins" / "profile" / "2026_05_06_04_47_36"
     assert (new_dst / "new.xplane.pb").read_text() == "NEW"
+
+
+def test_phased_profiler_gcs_profile_dir_uses_local_staging():
+    """GCS profile_dir is staged locally; ranks with same URI share staging."""
+    gcs_uri = "gs://my-bucket/profiles/run1"
+    p0 = PhasedBasedProfiler(profile_dir=gcs_uri, worker_rank=0)
+    p1 = PhasedBasedProfiler(profile_dir=gcs_uri, worker_rank=1)
+
+    assert p0._gcs_profile_dir == gcs_uri
+    assert p1._gcs_profile_dir == gcs_uri
+    assert not p0.profile_dir.startswith("gs://")
+    assert p0.profile_dir == p1.profile_dir
+    assert os.path.isdir(p0.profile_dir)
+
+
+def test_merge_profile_directories_uploads_to_gcs(tmp_path, monkeypatch):
+    """After local merge, GCS targets trigger a recursive upload of the phase."""
+    uploaded = []
+
+    def fake_upload(local_dir, gcs_uri):
+        uploaded.append((local_dir, gcs_uri))
+
+    monkeypatch.setattr(
+        "tpu_inference.runner.utils._upload_dir_to_gcs", fake_upload)
+
+    gcs_uri = "gs://my-bucket/profiles"
+    profiler = PhasedBasedProfiler(profile_dir=gcs_uri, worker_rank=0)
+    phase_dir = Path(profiler.profile_dir) / "prefill_heavy"
+    rank_dir = phase_dir / "dp_rank_0"
+    rank_dir.mkdir(parents=True)
+    profiler.profile_dir_with_phase_suffix = str(rank_dir)
+    profiler._canonical_dst_ts = "2026_05_06_04_47_36"
+    _stage_dp_rank_capture(rank_dir, "jax_ts", "trace.xplane.pb", "DATA")
+
+    profiler._merge_profile_directories()
+
+    assert len(uploaded) == 1
+    assert uploaded[0][0] == str(phase_dir)
+    assert uploaded[0][1] == "gs://my-bucket/profiles/prefill_heavy"
+    dst = phase_dir / "plugins" / "profile" / "2026_05_06_04_47_36"
+    assert (dst / "trace.xplane.pb").read_text() == "DATA"

--- a/tests/worker/tpu_worker_test.py
+++ b/tests/worker/tpu_worker_test.py
@@ -186,6 +186,17 @@ class TestTPUWorker:
                            distributed_init_method="test_method")
         assert worker.profile_dir is None
 
+    def test_init_with_gcs_profiler_dir_on_rank_zero(self, mock_vllm_config):
+        """GCS profiler dirs are accepted without local mkdir."""
+        gcs_dir = "gs://my-bucket/profiles"
+        mock_vllm_config.profiler_config.profiler = "torch"
+        mock_vllm_config.profiler_config.torch_profiler_dir = gcs_dir
+        worker = TPUWorker(vllm_config=mock_vllm_config,
+                           local_rank=0,
+                           rank=0,
+                           distributed_init_method="test_method")
+        assert worker.profile_dir == gcs_dir
+
     #
     # --- Device and Cache Initialization Tests ---
     #

--- a/tpu_inference/runner/utils.py
+++ b/tpu_inference/runner/utils.py
@@ -6,6 +6,7 @@ import atexit
 import bisect
 import datetime
 import functools
+import hashlib
 import json
 import os
 import shutil
@@ -25,6 +26,41 @@ from vllm.v1.core.sched.output import SchedulerOutput as VllmSchedulerOutput
 from tpu_inference import envs
 from tpu_inference.logger import init_logger
 from tpu_inference.runner.input_batch import InputBatch
+
+
+def _is_gcs_path(path: str) -> bool:
+    return path.startswith("gs://")
+
+
+def _makedirs_local(path: str) -> None:
+    """Create directories only for local paths (no-op for gs:// URIs)."""
+    if not _is_gcs_path(path):
+        os.makedirs(path, exist_ok=True)
+
+
+def _upload_dir_to_gcs(local_dir: str, gcs_uri: str) -> None:
+    """Recursively upload files under ``local_dir`` to a ``gs://`` prefix."""
+    if not _is_gcs_path(gcs_uri) or not os.path.isdir(local_dir):
+        return
+    try:
+        from google.cloud import storage  # type: ignore
+        # gs://bucket/prefix -> ("bucket", "prefix") ; gs://bucket -> ("bucket", "")
+        rest = gcs_uri[5:]
+        bucket_name, _, prefix = rest.partition("/")
+        client = storage.Client()
+        bucket = client.bucket(bucket_name)
+        prefix = prefix.rstrip("/")
+        for root, _, files in os.walk(local_dir):
+            for fname in files:
+                local_path = os.path.join(root, fname)
+                rel = os.path.relpath(local_path, local_dir).replace(os.sep, "/")
+                blob_name = f"{prefix}/{rel}" if prefix else rel
+                bucket.blob(blob_name).upload_from_filename(local_path)
+        logger.info("Uploaded profile artifacts from %s to %s", local_dir,
+                    gcs_uri)
+    except Exception as e:
+        logger.error("Failed to upload %s to %s: %s", local_dir, gcs_uri, e,
+                     exc_info=True)
 
 
 def trim_request_id_suffix(request_id: str) -> str:
@@ -444,7 +480,7 @@ class AggregatedStatsLogger:
                                     filename: str) -> tuple[str, str]:
         """Helper to resolve local temp path vs final target path (e.g. for GCS)."""
         target = os.path.join(base_dir, filename)
-        if base_dir.startswith("gs://"):
+        if _is_gcs_path(base_dir):
             return os.path.join(tempfile.gettempdir(), filename), target
         os.makedirs(base_dir, exist_ok=True)
         return target, target
@@ -454,25 +490,25 @@ class AggregatedStatsLogger:
                      target_file: str,
                      blocking: bool = False) -> None:
         """Helper to sync local file to GCS using the Python SDK."""
-        if target_file.startswith("gs://") and os.path.exists(local_file):
+        if not (_is_gcs_path(target_file) and os.path.exists(local_file)):
+            return
 
-            def _upload():
-                try:
-                    from google.cloud import storage  # type: ignore
-                    client = storage.Client()
-                    # e.g., gs://my-bucket/path/to/file.txt -> ("my-bucket", "path/to/file.txt")
-                    bucket_name, blob_name = target_file[5:].split("/", 1)
-                    client.bucket(bucket_name).blob(
-                        blob_name).upload_from_filename(local_file)
-                except Exception as e:
-                    logger.error(
-                        f"Failed to upload {local_file} to {target_file}: {e}",
-                        exc_info=True)
+        def _upload():
+            try:
+                from google.cloud import storage  # type: ignore
+                rest = target_file[5:]
+                bucket_name, _, blob_name = rest.partition("/")
+                storage.Client().bucket(bucket_name).blob(
+                    blob_name).upload_from_filename(local_file)
+            except Exception as e:
+                logger.error(
+                    "Failed to upload %s to %s: %s", local_file, target_file,
+                    e, exc_info=True)
 
-            if blocking:
-                _upload()
-            else:
-                threading.Thread(target=_upload, daemon=True).start()
+        if blocking:
+            _upload()
+        else:
+            threading.Thread(target=_upload, daemon=True).start()
 
     def log(self, batch_composition_stats: dict) -> None:
         """
@@ -501,7 +537,7 @@ class AggregatedStatsLogger:
         """
         self._f_local.flush()
         self._f_tmp.flush()
-        if self.target_file.startswith("gs://") and os.path.exists(
+        if _is_gcs_path(self.target_file) and os.path.exists(
                 self.local_temp_file):
             logger.info(
                 f"Syncing continuous batch stats to {self.target_file} (Step {self.step_count})..."
@@ -518,7 +554,7 @@ class AggregatedStatsLogger:
         self.flush(blocking=True)
         self._f_local.close()
         self._f_tmp.close()
-        if self.profile_dir.startswith("gs://") and os.path.exists(
+        if _is_gcs_path(self.profile_dir) and os.path.exists(
                 self.local_temp_file):
             try:
                 os.remove(self.local_temp_file)
@@ -572,7 +608,22 @@ class PhasedBasedProfiler:
         self.decode_kv_len_threshold: int = int(
             os.getenv("PHASED_PROFILER_DECODE_ONLY_KV_LEN_THRESHOLD",
                       PHASED_PROFILER_DECODE_ONLY_KV_LEN_THRESHOLD))
-        self.profile_dir: str = profile_dir
+        # JAX can write traces to gs://, but merge / marker / stats I/O uses
+        # local FS APIs. Stage on a shared local path (keyed by GCS URI + parent
+        # PID so co-located DP ranks still coordinate via marker files) and
+        # upload after each phase completes.
+        self._gcs_profile_dir: str | None = (
+            profile_dir if _is_gcs_path(profile_dir) else None)
+        if self._gcs_profile_dir:
+            # Short stable hash avoids path-length issues and keeps ranks aligned.
+            gcs_key = hashlib.md5(
+                self._gcs_profile_dir.encode()).hexdigest()[:12]
+            self.profile_dir = os.path.join(
+                tempfile.gettempdir(), f"phased_profiler_{gcs_key}",
+                f"ppid_{os.getppid()}")
+            os.makedirs(self.profile_dir, exist_ok=True)
+        else:
+            self.profile_dir = profile_dir
         # NOTE: we purposely don't have AMBIGUOUS here
         self.inference_phase_seen: dict = {
             InferencePhase.PREFILL_ONLY: False,
@@ -600,9 +651,10 @@ class PhasedBasedProfiler:
         self.worker_rank = worker_rank
         self.aggregated_stats_logger = None
 
+        log_dest = self._gcs_profile_dir or self.profile_dir
         logger.info(
             "Phased-based profiler enabled. Traces will be saved to: %s",
-            self.profile_dir)
+            log_dest)
         if self.num_decode_steps_to_skip > 0:
             logger.info(
                 "Will skip %d decode-heavy steps before profiling decode_heavy phase.",
@@ -675,7 +727,7 @@ class PhasedBasedProfiler:
             logger.info(f"Starting profiling for {self.current_phase} phase")
             logger.info(f"Batch composition stats: {batch_composition_stats}")
             phase_dir = os.path.join(self.profile_dir, self.current_phase)
-            os.makedirs(phase_dir, exist_ok=True)
+            _makedirs_local(phase_dir)
 
             # Resolve the canonical destination ts before start_trace so all
             # DP ranks land in the same <phase>/plugins/profile/<ts>/ dir
@@ -684,7 +736,7 @@ class PhasedBasedProfiler:
 
             self.profile_dir_with_phase_suffix = os.path.join(
                 phase_dir, f"dp_rank_{self.worker_rank}")
-            os.makedirs(self.profile_dir_with_phase_suffix, exist_ok=True)
+            _makedirs_local(self.profile_dir_with_phase_suffix)
 
             # Write the batch composition stats to a file to make it easier to
             # align with the traces
@@ -829,6 +881,11 @@ class PhasedBasedProfiler:
                     pass
             logger.info(
                 f"Successfully merged profile directories into: {dst_ts_dir}")
+            if self._gcs_profile_dir:
+                # Upload this phase's artifacts (merged traces + batch stats).
+                rel_phase = os.path.relpath(phase_dir, self.profile_dir)
+                gcs_phase = f"{self._gcs_profile_dir.rstrip('/')}/{rel_phase}"
+                _upload_dir_to_gcs(phase_dir, gcs_phase)
         except Exception as e:
             logger.warning("Failed to merge profile directories: %s", e)
 

--- a/tpu_inference/worker/tpu_worker.py
+++ b/tpu_inference/worker/tpu_worker.py
@@ -157,7 +157,9 @@ class TPUWorker(WorkerBase):
                 profiler_config.torch_profiler_dir,
                 f"pprank_{self.rank}_ppworldsize_{self.pp_config.pp_world_size}"
             )
-            os.makedirs(self.profile_dir, exist_ok=True)
+            # jax.profiler supports gs:// log dirs; only mkdir for local paths.
+            if not self.profile_dir.startswith("gs://"):
+                os.makedirs(self.profile_dir, exist_ok=True)
 
         use_jax_profiler_server = envs.USE_JAX_PROFILER_SERVER
         # Only one instance of profiler is allowed


### PR DESCRIPTION
## Summary
- Accept `gs://` profile directories for phased profiling (`PHASED_PROFILING_DIR`), torch/JAX worker profiler dirs (including PP subdirs), alongside existing GCS support in `AggregatedStatsLogger`.
- For phased profiling, stage traces on a shared local path (keyed by GCS URI hash + parent PID so co-located DP ranks can still coordinate via marker files), then recursively upload after each successful phase merge via `google.cloud.storage`.
- Skip `os.makedirs` for GCS on the TPU worker path so `jax.profiler` can write to buckets natively; document GCS support in `docs/profiling.md` and add unit coverage.

## Approach
JAX can write traces to `gs://` directly, but `PhasedBasedProfiler` depends on local FS APIs for canonical-ts markers, `shutil.move` merges, and batch-stats files. Reimplementing all of that on GCS would be fragile and high-LOC. Local staging + post-merge upload preserves existing multi-rank behavior with minimal changes and matches the pattern already used by `AggregatedStatsLogger`.

## Test plan
- [x] Added unit tests for GCS staging path sharing across ranks and post-merge upload invocation
- [x] Added worker init test for `gs://` `torch_profiler_dir` on rank 0
- [ ] `pytest tests/runner/test_utils.py tests/worker/tpu_worker_test.py` on a vLLM-capable env
- [ ] Manual smoke: `PHASED_PROFILING_DIR=gs://<bucket>/profiles ...` and confirm phase prefixes appear in the bucket after profiling completes
- [ ] Manual smoke: profiler config / `examples/tpu_profiling.py --profile-result-dir gs://...` writes traces under the bucket