### PR TITLE
[FIX][Raiden] Fix endpoints and parallelism settings in KVCacheManager

### DIFF
--- a/tpu_inference/distributed/tpu_raiden_connector.py
+++ b/tpu_inference/distributed/tpu_raiden_connector.py
@@ -528,6 +528,9 @@ class TPUConnectorWorker:
             num_slots=num_slots,
             timeout_s=float(dist_utils.get_p2p_wait_pull_timeout()),
             unsafe_skip_buffer_lock=skip_lock,
+            # The PUSH (producer H2hWrite) fans out across the manager's ctor
+            # `parallelism` (default 4!)
+            parallelism=parallelism,
         )
         logger.info(
             f"TPUConnector Worker {self.node_id} --> Raiden kv_cache_manager ready | "
@@ -537,13 +540,38 @@ class TPUConnectorWorker:
             f"max_blocks={max_blocks} | num_slots={num_slots} | "
             f"parallelism={parallelism}")
 
-    def _remote_endpoint(self, req_meta: "LoadMeta") -> str:
+    def _remote_endpoint(self, req_meta: "LoadMeta"):
+        """Resolve the producer endpoint(s) for start_read.
+
+        The producer's KVCacheManager binds one control port per NUMA
+        sub-manager, consecutively from the advertised base port
+        (TPU_KV_TRANSFER_PORT); each sub-manager serves a distinct shard set.
+        With >1 sub-manager we MUST route each local sub-manager to the producer
+        sub-manager that holds its shards. Passing a single "host:base" string
+        instead hits start_read's broadcast overload, so every local sub-manager
+        pulls from the base port (sub-manager 0) and the non-base sockets receive
+        the wrong shards -- silent ~50% KV corruption.
+
+        Returns a list of structured {endpoint, shards} descriptors when there is
+        more than one sub-manager (so start_read does shard-matched routing), and
+        a plain "host:port" string for the single-sub-manager case (unchanged).
+        Both prefill and decode run identical hardware, so producer sub-manager i
+        (port base+i) serves the same shards as our local sub-manager i.
+        """
         host = req_meta.remote_host
         port = req_meta.remote_port
         if isinstance(host, list):
             assert isinstance(port, list) and len(host) == len(port)
-            return f"{host[self.node_id]}:{port[self.node_id]}"
-        return f"{host}:{port}"
+            host = host[self.node_id]
+            port = port[self.node_id]
+        base = int(port)
+        local_eps = self.kv_manager.get_local_endpoints()
+        if len(local_eps) <= 1:
+            return f"{host}:{base}"
+        return [{
+            "endpoint": f"{host}:{base + i}",
+            "shards": list(ep["shards"])
+        } for i, ep in enumerate(local_eps)]
 
     def process_send_load(self, metadata: TPUConnectorMetadata):
         """
@@ -556,8 +584,6 @@ class TPUConnectorWorker:
             logger.info(
                 f"TPUConnector Worker {self.node_id} -->  reqs_to_send={reqs}")
         for req_id, req_meta in reqs.items():
-            # Producer: register the prefilled blocks so D can pull them.
-            # Replaces select_from_kv_caches + kv_transfer_server.await_pull.
             self.kv_manager.register_read(req_id, req_meta.uuid,
                                           req_meta.local_block_ids)
 


### PR DESCRIPTION
# Description

Support multiple endpoints of sub-managers in Raiden's KV cache manager (for NUMA) and add the missing `parallelism` argument.

# Tests

This change is Raiden only.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
