### PR TITLE
[Bugfix] SC dense_gather_reduce: fall back when output block has zero rows (fixes Qwen3-30B-A3B accuracy)

### DIFF
--- a/tests/kernels/dense_gather_reduce_test.py
+++ b/tests/kernels/dense_gather_reduce_test.py
@@ -227,38 +227,44 @@ class DenseGatherReduceTest(jtu.JaxTestCase):
             raise e
 
 
-class IsCompatibleTest(absltest.TestCase):
+class IsCompatibleTest(parameterized.TestCase):
     """Hardware-independent tests for the is_compatible() fallback gate.
 
-    These mock get_tpu_info() so they run on any platform (incl. CPU/v6e),
-    unlike DenseGatherReduceTest which needs SparseCore hardware.
+    These mock get_tpu_info() so they run on any platform, unlike
+    DenseGatherReduceTest which needs SparseCore hardware. They target the
+    output-block packing gate: the kernel's output BlockSpec row dim is
+    (num_lanes // reduce_group_size) // packing, which must be >= 1.
     """
 
-    def _fake_tpu_info(self, generation, num_lanes=16, num_cores=1,
-                       num_subcores=1):
+    def _fake_tpu_info(self, num_lanes, num_cores=1, num_subcores=1):
         sparse_core = types.SimpleNamespace(num_lanes=num_lanes,
                                             num_cores=num_cores,
                                             num_subcores=num_subcores)
-        return types.SimpleNamespace(generation=generation,
-                                     sparse_core=sparse_core)
+        return types.SimpleNamespace(sparse_core=sparse_core)
 
-    def test_v6e_falls_back(self):
-        # Qwen3-30B-A3B-like inputs: out_size divisible by topk, bf16.
-        op = jnp.zeros((4096, 128), jnp.bfloat16)
+    # (num_lanes, dtype, reduce_group_size, expected_is_compatible)
+    @parameterized.named_parameters(
+        # v6e SparseCore (num_lanes=8). bf16 packing=2: 8//8//2 = 0 -> the
+        # Qwen3-30B-A3B crash -> must fall back.
+        ("v6e_bf16_topk8_degenerate", 8, jnp.bfloat16, 8, False),
+        # Same v6e lanes but f32 (packing=1): 8//8//1 = 1 -> kernel is valid,
+        # must NOT be blocked just because it is v6e.
+        ("v6e_f32_topk8_ok", 8, jnp.float32, 8, True),
+        # v6e lanes, bf16, smaller group: 8//4//2 = 1 -> valid.
+        ("v6e_bf16_topk4_ok", 8, jnp.bfloat16, 4, True),
+        # v7x-like (num_lanes=16), bf16: 16//8//2 = 1 -> valid.
+        ("v7x_bf16_topk8_ok", 16, jnp.bfloat16, 8, True),
+    )
+    def test_output_block_packing_gate(self, num_lanes, dtype,
+                                       reduce_group_size, expected):
+        op = jnp.zeros((4096, 128), dtype)
         idx = jnp.zeros((4096, ), jnp.int32)
-        # v6e (generation 6) must be rejected so the MoE path uses _jax_fallback
-        # instead of tripping the zero-height output-block "swap" crash.
-        with mock.patch.object(dgr_mod.pltpu, "get_tpu_info",
-                               return_value=self._fake_tpu_info(generation=6)):
-            self.assertFalse(is_compatible(op, idx, reduce_group_size=8))
-
-    def test_v7x_compatible(self):
-        op = jnp.zeros((4096, 128), jnp.bfloat16)
-        idx = jnp.zeros((4096, ), jnp.int32)
-        # generation 7 with a valid SparseCore config passes all gates.
-        with mock.patch.object(dgr_mod.pltpu, "get_tpu_info",
-                               return_value=self._fake_tpu_info(generation=7)):
-            self.assertTrue(is_compatible(op, idx, reduce_group_size=8))
+        with mock.patch.object(
+                dgr_mod.pltpu, "get_tpu_info",
+                return_value=self._fake_tpu_info(num_lanes=num_lanes)):
+            self.assertEqual(
+                is_compatible(op, idx, reduce_group_size=reduce_group_size),
+                expected)
 
 
 if __name__ == "__main__":

--- a/tests/kernels/dense_gather_reduce_test.py
+++ b/tests/kernels/dense_gather_reduce_test.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 import itertools
+import types
+from unittest import mock
 
 import jax
 import jax.numpy as jnp
@@ -21,8 +23,9 @@ from absl.testing import absltest, parameterized
 from jax._src import test_util as jtu
 from jax.experimental.pallas import tpu as pltpu
 
-from tpu_inference.kernels.sparse_core.dense_gather_reduce import \
-    dense_gather_reduce
+from tpu_inference.kernels.sparse_core import dense_gather_reduce as dgr_mod
+from tpu_inference.kernels.sparse_core.dense_gather_reduce import (
+    dense_gather_reduce, is_compatible)
 
 jax.config.parse_flags_with_absl()
 
@@ -222,6 +225,40 @@ class DenseGatherReduceTest(jtu.JaxTestCase):
             print("DEBUG ACTUAL (first 32 rows):\n", actual[:32, :])
             print("DEBUG DESIRED (first 32 rows):\n", desired[:32, :])
             raise e
+
+
+class IsCompatibleTest(absltest.TestCase):
+    """Hardware-independent tests for the is_compatible() fallback gate.
+
+    These mock get_tpu_info() so they run on any platform (incl. CPU/v6e),
+    unlike DenseGatherReduceTest which needs SparseCore hardware.
+    """
+
+    def _fake_tpu_info(self, generation, num_lanes=16, num_cores=1,
+                       num_subcores=1):
+        sparse_core = types.SimpleNamespace(num_lanes=num_lanes,
+                                            num_cores=num_cores,
+                                            num_subcores=num_subcores)
+        return types.SimpleNamespace(generation=generation,
+                                     sparse_core=sparse_core)
+
+    def test_v6e_falls_back(self):
+        # Qwen3-30B-A3B-like inputs: out_size divisible by topk, bf16.
+        op = jnp.zeros((4096, 128), jnp.bfloat16)
+        idx = jnp.zeros((4096, ), jnp.int32)
+        # v6e (generation 6) must be rejected so the MoE path uses _jax_fallback
+        # instead of tripping the zero-height output-block "swap" crash.
+        with mock.patch.object(dgr_mod.pltpu, "get_tpu_info",
+                               return_value=self._fake_tpu_info(generation=6)):
+            self.assertFalse(is_compatible(op, idx, reduce_group_size=8))
+
+    def test_v7x_compatible(self):
+        op = jnp.zeros((4096, 128), jnp.bfloat16)
+        idx = jnp.zeros((4096, ), jnp.int32)
+        # generation 7 with a valid SparseCore config passes all gates.
+        with mock.patch.object(dgr_mod.pltpu, "get_tpu_info",
+                               return_value=self._fake_tpu_info(generation=7)):
+            self.assertTrue(is_compatible(op, idx, reduce_group_size=8))
 
 
 if __name__ == "__main__":

--- a/tests/kernels/dense_gather_reduce_test.py
+++ b/tests/kernels/dense_gather_reduce_test.py
@@ -260,7 +260,8 @@ class IsCompatibleTest(parameterized.TestCase):
         op = jnp.zeros((4096, 128), dtype)
         idx = jnp.zeros((4096, ), jnp.int32)
         with mock.patch.object(
-                dgr_mod.pltpu, "get_tpu_info",
+                dgr_mod.pltpu,
+                "get_tpu_info",
                 return_value=self._fake_tpu_info(num_lanes=num_lanes)):
             self.assertEqual(
                 is_compatible(op, idx, reduce_group_size=reduce_group_size),

--- a/tpu_inference/kernels/sparse_core/dense_gather_reduce.py
+++ b/tpu_inference/kernels/sparse_core/dense_gather_reduce.py
@@ -41,24 +41,26 @@ def is_compatible(
     if op.shape[0] % reduce_group_size != 0:
         return False
 
-    tpu_info = pltpu.get_tpu_info()
-    # dense_gather_reduce is not supported on TPUv6e (matches the skip in
-    # tests/kernels/dense_gather_reduce_test.py). Concretely the kernel's output
-    # BlockSpec row dimension is (num_lanes // reduce_group_size) // packing (see
-    # out_rows_per_step / out_specs in _sc_gather_reduce); for sub-32-bit dtypes
-    # packing > 1 (bf16 -> 2), so v6e SparseCore with reduce_group_size close to
-    # num_lanes (e.g. Qwen3-30B-A3B topk=8) floors this to 0, yielding a
-    # zero-height output block and crashing AOT lowering with "Invalid shape for
-    # `swap`". Excluding v6e here routes those models through _jax_fallback (the
-    # pre-#2979 path) instead of the MoE GMM path tripping the crash.
-    if tpu_info.generation == 6:
-        return False
-
-    sc_info = tpu_info.sparse_core
+    sc_info = pltpu.get_tpu_info().sparse_core
     if sc_info is None:
         return False
 
     if sc_info.num_lanes % reduce_group_size != 0:
+        return False
+
+    # The kernel's output BlockSpec row dimension is
+    # (num_lanes // reduce_group_size) // packing (see out_rows_per_step and the
+    # out_specs in _sc_gather_reduce). For sub-32-bit dtypes packing > 1 (bf16 ->
+    # 2), so when num_lanes // reduce_group_size < packing this floors to 0,
+    # producing a zero-height output block that the kernel body (which still
+    # writes one row) cannot store into -> AOT lowering crashes with "Invalid
+    # shape for `swap`". This is exactly what regressed Qwen3-30B-A3B (topk=8,
+    # bf16) on v6e SparseCore (num_lanes=8 -> 8//8//2 = 0). Gate on the arithmetic
+    # rather than the TPU generation: configs that leave >=1 packed output row
+    # (larger num_lanes, smaller reduce_group_size, or f32 with packing=1) keep
+    # using the kernel; only the degenerate ones fall back to _jax_fallback.
+    packing = 32 // jax.dtypes.itemsize_bits(op.dtype)
+    if (sc_info.num_lanes // reduce_group_size) // packing < 1:
         return False
 
     num_cores = 1 if single_sc else sc_info.num_cores

--- a/tpu_inference/kernels/sparse_core/dense_gather_reduce.py
+++ b/tpu_inference/kernels/sparse_core/dense_gather_reduce.py
@@ -48,17 +48,8 @@ def is_compatible(
     if sc_info.num_lanes % reduce_group_size != 0:
         return False
 
-    # The kernel's output BlockSpec row dimension is
-    # (num_lanes // reduce_group_size) // packing (see out_rows_per_step and the
-    # out_specs in _sc_gather_reduce). For sub-32-bit dtypes packing > 1 (bf16 ->
-    # 2), so when num_lanes // reduce_group_size < packing this floors to 0,
-    # producing a zero-height output block that the kernel body (which still
-    # writes one row) cannot store into -> AOT lowering crashes with "Invalid
-    # shape for `swap`". This is exactly what regressed Qwen3-30B-A3B (topk=8,
-    # bf16) on v6e SparseCore (num_lanes=8 -> 8//8//2 = 0). Gate on the arithmetic
-    # rather than the TPU generation: configs that leave >=1 packed output row
-    # (larger num_lanes, smaller reduce_group_size, or f32 with packing=1) keep
-    # using the kernel; only the degenerate ones fall back to _jax_fallback.
+    # The output block has (num_lanes // reduce_group_size) // packing rows;
+    # fall back to JAX when that is 0 (the kernel can't emit a zero-row block).
     packing = 32 // jax.dtypes.itemsize_bits(op.dtype)
     if (sc_info.num_lanes // reduce_group_size) // packing < 1:
         return False

--- a/tpu_inference/kernels/sparse_core/dense_gather_reduce.py
+++ b/tpu_inference/kernels/sparse_core/dense_gather_reduce.py
@@ -41,7 +41,20 @@ def is_compatible(
     if op.shape[0] % reduce_group_size != 0:
         return False
 
-    sc_info = pltpu.get_tpu_info().sparse_core
+    tpu_info = pltpu.get_tpu_info()
+    # dense_gather_reduce is not supported on TPUv6e (matches the skip in
+    # tests/kernels/dense_gather_reduce_test.py). Concretely the kernel's output
+    # BlockSpec row dimension is (num_lanes // reduce_group_size) // packing (see
+    # out_rows_per_step / out_specs in _sc_gather_reduce); for sub-32-bit dtypes
+    # packing > 1 (bf16 -> 2), so v6e SparseCore with reduce_group_size close to
+    # num_lanes (e.g. Qwen3-30B-A3B topk=8) floors this to 0, yielding a
+    # zero-height output block and crashing AOT lowering with "Invalid shape for
+    # `swap`". Excluding v6e here routes those models through _jax_fallback (the
+    # pre-#2979 path) instead of the MoE GMM path tripping the crash.
+    if tpu_info.generation == 6:
+        return False
+
+    sc_info = tpu_info.sparse_core
     if sc_info is None:
         return False
 


### PR DESCRIPTION
## Problem
The nightly `tpu6e Accuracy for Qwen/Qwen3-30B-A3B` has failed on **main** for many nightlies. The engine fails to initialize during AOT lowering with:
```
ValueError: Invalid shape for `swap`. Ref shape: (2, 0, 2048). Expected shape: (0, 32). Value shape: (1, 32).
```

## Root cause
#2979 wired the SparseCore `dense_gather_reduce` kernel into the MoE GMM path (`fused_moe_gmm.py:moe_gmm_local`). The kernel's output `BlockSpec` row dimension is `(num_lanes // reduce_group_size) // packing` (see `out_rows_per_step` / `out_specs` in `_sc_gather_reduce`), where `packing = 32 // bits(dtype)` (bf16 -> 2, f32 -> 1). When `num_lanes // reduce_group_size < packing` this floors to **0**, producing a zero-height output block that the kernel body (which still writes one row) cannot store into.

Qwen3-30B-A3B has topk=8; on v6e SparseCore `num_lanes = 8`, so bf16 gives `8 // 8 // 2 = 0` -> crash. v7x has `num_lanes = 16` (`16 // 8 // 2 = 1`) and is unaffected (matches the tpu6e-only failure). Both `num_lanes` values were confirmed empirically (see Test evidence).

`is_compatible()` already gates a JAX fallback (`_jax_fallback`) but did not check this packing constraint.

Bisected to #2979 with a commit-vs-parent A/B (same vLLM LKG): the Qwen3-30B-A3B tpu6e accuracy test fails at `8f92c3098` and passes at its parent `455f99882`.

## Fix
Gate on the **arithmetic** condition `(num_lanes // reduce_group_size) // packing >= 1` rather than the TPU generation. This fixes the crash (the degenerate config falls back to `_jax_fallback`, the pre-#2979 path) while keeping the kernel for configs that leave >= 1 packed output row -- including valid v6e configs (e.g. f32 with packing=1, or smaller `reduce_group_size`). An earlier revision excluded all of v6e; that was broader than the defect (per review) and needlessly disabled the kernel where it works.

## Test evidence
All on the dev pipeline (full URLs):

**Empirical num_lanes** — https://buildkite.com/tpu-commons/tpu-inference-dev/builds/616
- v6e: `num_lanes=8` -> `8 // 8 // 2 = 0` (degenerate); v7x: `num_lanes=16` -> `16 // 8 // 2 = 1` (ok).

**v6e**
- https://buildkite.com/tpu-commons/tpu-inference-dev/builds/618 — `dense_gather_reduce` unit tests + `Qwen3-30B-A3B` accuracy (TP=8): green (model now falls back, no `swap` crash).
- https://buildkite.com/tpu-commons/tpu-inference-dev/builds/617 — `dense_gather_reduce` kernel correctness test run **on v6e** (guard-permitted configs exercise the real kernel and match the reference) + Qwen3-30B-A3B accuracy: green. Confirms the kernel is correct on v6e for permitted configs, so the precise guard (not a blanket v6e block) is the right boundary.

**v7x**
- https://buildkite.com/tpu-commons/tpu-inference-dev/builds/620 — `dense_gather_reduce` kernel correctness + `Qwen3-30B-A3B` accuracy (kernel path): green. Confirms the guard does not regress the kernel where it is valid.

## Tests
- `IsCompatibleTest` (hardware-independent, mocks `get_tpu_info`) covers the packing boundary: v6e-lanes+bf16+topk8 -> False; v6e-lanes+f32+topk8 -> True; v6e-lanes+bf16+topk4 -> True; v7x-lanes+bf16+topk8 -> True. Passes on CPU.

## Backport
Targets `main`. The same failure is on `releases/v0.24.0`; will cherry-pick there after this merges.
