### PR TITLE
[CI] Multimodal test: release TPU between parametrizations

### DIFF
--- a/tests/e2e/test_multi_modal_inference.py
+++ b/tests/e2e/test_multi_modal_inference.py
@@ -120,8 +120,8 @@ def test_multi_modal_inference(monkeypatch, enable_dynamic_image_sizes):
 
         # Check output against the closest known-good caption.
         similarity_score = max(
-            difflib.SequenceMatcher(None, generated_text, expected,
-                                    autojunk=False).ratio()
+            difflib.SequenceMatcher(
+                None, generated_text, expected, autojunk=False).ratio()
             for expected in EXPECTED_TEXTS)
         print(f"Similarity Score: {similarity_score:.4f}")
         assert similarity_score >= 0.85, (

--- a/tests/e2e/test_multi_modal_inference.py
+++ b/tests/e2e/test_multi_modal_inference.py
@@ -5,6 +5,7 @@
 # compares the output to a known-good output.
 
 import difflib
+import gc
 import os
 from dataclasses import asdict
 
@@ -91,37 +92,47 @@ def test_multi_modal_inference(monkeypatch, enable_dynamic_image_sizes):
 
     llm = LLM(**engine_args)
 
-    sampling_params = SamplingParams(
-        temperature=temperature,
-        max_tokens=max_tokens,
-    )
+    try:
+        sampling_params = SamplingParams(
+            temperature=temperature,
+            max_tokens=max_tokens,
+        )
 
-    inputs = {
-        "prompt": prompt,
-        "multi_modal_data": {
-            "image": image
-        },
-    }
+        inputs = {
+            "prompt": prompt,
+            "multi_modal_data": {
+                "image": image
+            },
+        }
 
-    # --- Run Inference ---
-    print("Running inference...")
-    outputs = llm.generate(inputs, sampling_params)
+        # --- Run Inference ---
+        print("Running inference...")
+        outputs = llm.generate(inputs, sampling_params)
 
-    # --- Verification ---
-    generated_text = outputs[0].outputs[0].text.strip()
+        # --- Verification ---
+        generated_text = outputs[0].outputs[0].text.strip()
 
-    print("-" * 50)
-    print("Generated Text:")
-    print(generated_text)
-    print("-" * 50)
+        print("-" * 50)
+        print("Generated Text:")
+        print(generated_text)
+        print("-" * 50)
 
-    # Check output against the closest known-good caption.
-    similarity_score = max(
-        difflib.SequenceMatcher(None, generated_text, expected,
-                                autojunk=False).ratio()
-        for expected in EXPECTED_TEXTS)
-    print(f"Similarity Score: {similarity_score:.4f}")
-    assert similarity_score >= 0.85, (
-        f"Text similarity too low ({similarity_score:.2f}).\n"
-        f"Expected one of: {EXPECTED_TEXTS}\n"
-        f"Actual:   {generated_text}")
+        # Check output against the closest known-good caption.
+        similarity_score = max(
+            difflib.SequenceMatcher(None, generated_text, expected,
+                                    autojunk=False).ratio()
+            for expected in EXPECTED_TEXTS)
+        print(f"Similarity Score: {similarity_score:.4f}")
+        assert similarity_score >= 0.85, (
+            f"Text similarity too low ({similarity_score:.2f}).\n"
+            f"Expected one of: {EXPECTED_TEXTS}\n"
+            f"Actual:   {generated_text}")
+    finally:
+        # Release the TPU before the next parametrization builds a new engine.
+        # This test is parametrized over enable_dynamic_image_sizes=[False, True]
+        # and pytest runs both in one process; without an explicit engine
+        # shutdown the first engine's worker keeps the TPU and the second
+        # LLM(...) fails with "TPU already in use by pid <first>". Mirrors the
+        # teardown in tests/e2e/test_continue_decode.py.
+        llm.llm_engine.engine_core.shutdown()
+        gc.collect()

--- a/tests/e2e/test_multi_modal_inference.py
+++ b/tests/e2e/test_multi_modal_inference.py
@@ -7,6 +7,7 @@
 import difflib
 import gc
 import os
+import traceback
 from dataclasses import asdict
 
 import pytest
@@ -134,5 +135,14 @@ def test_multi_modal_inference(monkeypatch, enable_dynamic_image_sizes):
         # shutdown the first engine's worker keeps the TPU and the second
         # LLM(...) fails with "TPU already in use by pid <first>". Mirrors the
         # teardown in tests/e2e/test_continue_decode.py.
-        llm.llm_engine.engine_core.shutdown()
+        #
+        # Guard the shutdown so a teardown failure cannot mask a body
+        # AssertionError (the similarity check) -- surface it loudly instead of
+        # swallowing it.
+        try:
+            llm.llm_engine.engine_core.shutdown()
+        except Exception:
+            print("[multimodal-test] engine_core.shutdown() failed during "
+                  "teardown (non-fatal):")
+            traceback.print_exc()
         gc.collect()


### PR DESCRIPTION
## Problem
`tpu6e/tpu7x Correctness tests for Multimodal Inputs` have failed on **main** since ~Jun 25. The `enable_dynamic_image_sizes=True` case fails at engine init:
```
jax.errors.JaxRuntimeError: ABORTED: The TPU is already in use by process with pid <N>.
RuntimeError: Engine core initialization failed.
FAILED tests/e2e/test_multi_modal_inference.py::test_multi_modal_inference[True]
```

## Root cause
`test_multi_modal_inference` is parametrized over `enable_dynamic_image_sizes=[False, True]` and pytest runs both in one process. The test never tore down the first `LLM`, relying on GC/process-exit to free the TPU. A vLLM change altered engine-shutdown timing so the first engine's worker keeps the TPU when the second `LLM(...)` starts -> "TPU already in use".

Bisected on the dev pipeline by holding tpu-inference code fixed and moving only the pinned vLLM LKG: the multimodal test passes at LKG `0bc479e6` and fails at LKG `e7df2322` (the bump in `[skip ci] Update vLLM LKG` commit `678e023ed`). The regression is therefore in vLLM range `0bc479e6..e7df2322` (15 commits); a separate vLLM-side follow-up can pin the exact commit. The prior multimodal test fixes (#2782, #2630, #2443, #2371) were all about expected-text/similarity, not teardown -- this is a new failure mode.

## Fix
Wrap the run in `try/finally` and explicitly release the TPU after each parametrization via `llm.llm_engine.engine_core.shutdown()` + `gc.collect()`, mirroring `tests/e2e/test_continue_decode.py`. The shutdown is itself wrapped in `try/except` (+ traceback) so a teardown failure cannot mask the body's similarity assertion.

## Test evidence
Full multimodal test (both `enable_dynamic_image_sizes` parametrizations) on the dev pipeline against `main`'s current vLLM LKG (which includes the upstream regression), current PR HEAD:
- **v6e**: https://buildkite.com/tpu-commons/tpu-inference-dev/builds/615 — green.
- **v7x** (tp=2): https://buildkite.com/tpu-commons/tpu-inference-dev/builds/619 — green.

## Backport
Targets `main`. The same failure is on `releases/v0.24.0`; will cherry-pick there after this merges.
