### PR TITLE
Fall back to JAX in dense_gather_reduce when hidden size is not 128-tile-aligned (gpt-oss BF16)

### DIFF
--- a/tests/kernels/dense_gather_reduce_test.py
+++ b/tests/kernels/dense_gather_reduce_test.py
@@ -89,6 +89,20 @@ class DenseGatherReduceTest(jtu.JaxTestCase):
                 [10],
                 [False],
             ),
+            # Hidden sizes that are not a multiple of the 128-wide lane tile.
+            # gpt-oss uses hidden_size=2880, for which no tile-aligned column
+            # chunk exists, so dense_gather_reduce must fall back to the JAX
+            # path instead of emitting an unaligned tpu.memref_slice that fails
+            # Mosaic verification ("Slice sizes along tiled dimensions must be
+            # aligned to tiles"). 2944 is a multiple of 128 but only admits a
+            # 128-wide chunk; both must still produce correct results.
+            itertools.product(
+                [32768],
+                [2880, 2944],
+                [jnp.bfloat16],
+                [4],
+                [False, True],
+            ),
         )
     ]
 

--- a/tpu_inference/kernels/sparse_core/dense_gather_reduce.py
+++ b/tpu_inference/kernels/sparse_core/dense_gather_reduce.py
@@ -290,11 +290,21 @@ def dense_gather_reduce(
   """
     if is_compatible(x, indices, reduce_group_size):
         K = x.shape[-1]
-        col_chunk_size = min(2048, K)
+        # The kernel slices the operand along the hidden (column) dimension,
+        # which carries a 128-wide lane tile in the HBM layout
+        # (#tpu.tiled<(4, 128)>). A column chunk that is not a multiple of 128
+        # produces a tpu.memref_slice whose size along the tiled dimension is
+        # not tile-aligned, which Mosaic rejects at compile time with
+        # "Slice sizes along tiled dimensions must be aligned to tiles" (e.g.
+        # hidden_size=2880 -> chunk 1440, and 1440 % 128 = 32). Require the
+        # chunk to be a multiple of the 128 lane tile; when 128 does not divide
+        # hidden_size (as for gpt-oss's 2880) no valid chunk exists and we fall
+        # back to the JAX implementation below.
+        col_chunk_size = (min(2048, K) // 128) * 128
         while col_chunk_size > 0:
-            if K % col_chunk_size == 0 and col_chunk_size % 32 == 0:
+            if K % col_chunk_size == 0:
                 break
-            col_chunk_size -= 32
+            col_chunk_size -= 128
         if col_chunk_size > 0:
             # Pallas kernel expects 1D weights
             return _sc_gather_reduce(


### PR DESCRIPTION
## Motivation

Fix the last failing **gpt-oss** case on the daily TPU benchmark
(`unsloth/gpt-oss-120b-BF16`, dp=2). The SPMD-DP part of the gpt-oss fix already
landed via **#3015** (`TPU_MULTIPROCESS_DP=0` in `gpt_oss_120b.json`), which
unblocked the MXFP4 dp=4 cases. This PR is the remaining piece: a Mosaic
tile-alignment failure in the `dense_gather_reduce` kernel that the **BF16** case
still hits.

## Problem

The SparseCore `dense_gather_reduce` kernel (#2979) lays its operand out with a
128-wide lane tile (`#tpu.tiled<(4, 128)>`) and slices it along the hidden
(column) dimension by `col_chunk_size`, which was only required to be a multiple
of 32. A chunk that is not a multiple of 128 produces a `tpu.memref_slice` whose
size along the tiled dim is not tile-aligned, which Mosaic rejects at compile
time:

    INTERNAL: Slice sizes along tiled dimensions must be aligned to tiles.
    Failed to verify that the size at dimension 1 is divisible by the tile
    dimension 128.
      %97 = "tpu.memref_slice"(...) :
        (memref<8192x2880xi32, #tpu.tiled<(4,128),[23,1]>, hbm>, i32, i32)
        -> memref<8192x1440xi32, ...>            # 1440 % 128 == 32

The **BF16** gpt-oss case hits this: BF16 weights keep the operand at hidden
**K=2880**, so the chunk is 1440 and compilation fails at `backbone
num_tokens=8192`. (The MXFP4 cases don't hit it — their operand is padded to
K=3072, chunk 1536, which is 128-aligned; that's why #3015 alone was enough for
them.)

## Fix

Require the column chunk to be a multiple of the 128 lane tile. When no
multiple-of-128 chunk divides K (2880 = 2^6·3^2·5 has none), `dense_gather_reduce`
falls back to the existing JAX implementation instead of crashing. K values that
are multiples of 128 keep using the kernel and select the same chunk as before
(no change for already-working models).

## Testing

- New regression cases in `dense_gather_reduce_test.py` for non-128-aligned
  hidden sizes (2880, 2944); the previous matrix only used 128-aligned sizes.
- WITH/WITHOUT on a TPU v7x-8: the hidden=2880 case fails to compile with the
  exact Mosaic error on the unpatched kernel and passes with the fix.
- Reproduced the failure with the real benchmark command
  (`vllm serve unsloth/gpt-oss-120b-BF16`, TP=4/DP=2, `TPU_MULTIPROCESS_DP=0`)
  on the pinned jax 0.10.2 — same `memref<8192x2880xi32> -> 8192x1440` error in
  `dense_gather_reduce._sc_gather_reduce`. Confirmed in benchmark build 1694:
  the MXFP4 dp=4 cases pass (post-#3015) while the BF16 dp=2 case fails with
  this error.
