### PR TITLE
Profile for limited step count to avoid xProf 2GB hard limitation

### DIFF
--- a/tests/worker/tpu_worker_test.py
+++ b/tests/worker/tpu_worker_test.py
@@ -373,6 +373,7 @@ class TestTPUWorker:
                            local_rank=0,
                            rank=0,
                            distributed_init_method="test")
+        worker.is_profiling = True
         worker.profile(is_start=False)
         mock_jax.profiler.stop_trace.assert_called_once()
 

--- a/tests/worker/tpu_worker_test.py
+++ b/tests/worker/tpu_worker_test.py
@@ -373,7 +373,7 @@ class TestTPUWorker:
                            local_rank=0,
                            rank=0,
                            distributed_init_method="test")
-        worker.is_profiling = True
+        
         worker.profile(is_start=False)
         mock_jax.profiler.stop_trace.assert_called_once()
 

--- a/tpu_inference/envs.py
+++ b/tpu_inference/envs.py
@@ -72,6 +72,7 @@ if TYPE_CHECKING:
     VLLM_MOE_CHUNK_SIZE: int = 0
     ONEHOT_MOE_PERMUTE_THRESHOLD: int = 0
     PROFILE_SINGLE_DEVICE: bool = False
+    VLLM_ACTIVE_PROFILER_STEPS: int = -1
     LORA_MODULE_PATH: str = ""
     SC_ALLREDUCE_ALLGATHER_OFFLOAD_MIN_BYTES: str = "auto"
 
@@ -416,6 +417,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Profile a single device instead of all devices.
     "PROFILE_SINGLE_DEVICE":
     env_bool("PROFILE_SINGLE_DEVICE", default=False),
+    # Number of active profiling steps to capture.
+    "VLLM_ACTIVE_PROFILER_STEPS":
+    lambda: int(os.getenv("VLLM_ACTIVE_PROFILER_STEPS") or "-1"),
     "LORA_MODULE_PATH":
     lambda: os.getenv("LORA_MODULE_PATH", ""),
     "MLA_KV_PACKING_SIZE":

--- a/tpu_inference/worker/tpu_worker.py
+++ b/tpu_inference/worker/tpu_worker.py
@@ -490,14 +490,13 @@ class TPUWorker(WorkerBase):
                                                  intermediate_tensors)
 
         if self.is_profiling:
-            self.profile_step_counter += 1
-            active_profiler_steps = envs.VLLM_ACTIVE_PROFILER_STEPS
-            if active_profiler_steps > 0 and self.profile_step_counter >= active_profiler_steps:
+            if self.active_profiler_steps > 0 and self.profile_step_counter >= self.active_profiler_steps:
                 logger.info(
                     "Stopping profiler automatically after %d steps.",
                     self.profile_step_counter,
                 )
                 self.profile(is_start=False)
+            self.profile_step_counter += 1
 
         if isinstance(output, JaxIntermediateTensors):
             assert self.parallel_config.pipeline_parallel_size > 1
@@ -549,6 +548,7 @@ class TPUWorker(WorkerBase):
                                      profiler_options=options)
             self.is_profiling = True
             self.profile_step_counter = 0
+            self.active_profiler_steps = envs.VLLM_ACTIVE_PROFILER_STEPS
         else:
             if self.is_profiling:
                 try:

--- a/tpu_inference/worker/tpu_worker.py
+++ b/tpu_inference/worker/tpu_worker.py
@@ -551,9 +551,15 @@ class TPUWorker(WorkerBase):
             self.profile_step_counter = 0
         else:
             if self.is_profiling:
-                logger.info("Stopping JAX profiler trace.")
-                jax.profiler.stop_trace()
-                self.is_profiling = False
+                try:
+                    logger.info("Stopping JAX profiler trace.")
+                    jax.profiler.stop_trace()
+                except Exception as e:
+                    logger.warning("Failed to stop JAX profiler trace: %s", e)
+                finally:
+                    self.is_profiling = False
+            else:
+                logger.info("Profiler is already stopped (likely due to step-wise capture limit). Bypassing.")
 
     def load_model(self) -> None:
         self.model_runner.load_model()

--- a/tpu_inference/worker/tpu_worker.py
+++ b/tpu_inference/worker/tpu_worker.py
@@ -171,6 +171,8 @@ class TPUWorker(WorkerBase):
 
         # step_counter is used to calculate uuid to transfer intermediate tensors.
         self.step_counter = 0
+        self.is_profiling = False
+        self.profile_step_counter = 0
 
     def initialize_cache(self, num_gpu_blocks: int,
                          num_cpu_blocks: int) -> None:
@@ -487,6 +489,16 @@ class TPUWorker(WorkerBase):
         output = self.model_runner.execute_model(scheduler_output,
                                                  intermediate_tensors)
 
+        if self.is_profiling:
+            self.profile_step_counter += 1
+            active_profiler_steps = envs.VLLM_ACTIVE_PROFILER_STEPS
+            if active_profiler_steps > 0 and self.profile_step_counter >= active_profiler_steps:
+                logger.info(
+                    "Stopping profiler automatically after %d steps.",
+                    self.profile_step_counter,
+                )
+                self.profile(is_start=False)
+
         if isinstance(output, JaxIntermediateTensors):
             assert self.parallel_config.pipeline_parallel_size > 1
             assert not get_pp_group().is_last_rank
@@ -523,6 +535,7 @@ class TPUWorker(WorkerBase):
                 is_start: bool = True,
                 profile_prefix: str | None = None):
         if is_start:
+            logger.info("Starting JAX profiler trace, saving to %s", self.profile_dir)
             options = jax.profiler.ProfileOptions()
             # default: https://docs.jax.dev/en/latest/profiling.html#general-options
             options.python_tracer_level = envs.PYTHON_TRACER_LEVEL
@@ -534,8 +547,13 @@ class TPUWorker(WorkerBase):
                 }
             jax.profiler.start_trace(self.profile_dir,
                                      profiler_options=options)
+            self.is_profiling = True
+            self.profile_step_counter = 0
         else:
-            jax.profiler.stop_trace()
+            if self.is_profiling:
+                logger.info("Stopping JAX profiler trace.")
+                jax.profiler.stop_trace()
+                self.is_profiling = False
 
     def load_model(self) -> None:
         self.model_runner.load_model()


### PR DESCRIPTION
## Motivation:

Today, vllm provides a few options to profile it on tpus. In all cases, it captures the entire prefill and decode stages all the way to the last token.

This gets problematic as for long context profile captures even for small model and a single prompt, you quickly hit the 2GB xProf limitation reported in this bug ([b/528711430](b/528711430)).

## To reproduce:
```
VLLM_TORCH_PROFILER_DIR=/tmp/tpu_logs/qwen-06b VLLM_ENGINE_READY_TIMEOUT_S=60000 USE_BATCHED_RPA_KERNEL=1 MODEL_IMPL_TYPE=flax_nnx vllm serve Qwen/Qwen3-0.6B \
        --max-model-len=24576 \
        --max-num-seqs=512 \
        --data-parallel-size 4 \
        --tensor-parallel-size 2 \
        --no-enable-prefix-caching \
        --gpu-memory-utilization=0.9 \
        --async-scheduling \
        --block-size=256 \
        --profiler-config '{"profiler": "torch", "torch_profiler_dir": "/tmp/tpu_logs/qwen-06b"}'
```

This leads to xProf drop the trace and creates 0MB xplane file:

```
ls -lah /tmp/tpu_logs/qwen-06b/plugins/profile/2026_06_28_03_38_57
total 19M
drwxr-xr-x 2 root root  80 Jun 28 03:40 .
drwxr-xr-x 4 root root  80 Jun 28 03:38 ..
-rw-r--r-- 1 root root 19M Jun 28 03:40 vllm-single-node-qwen-06b.trace.json.gz
-rw-r--r-- 1 root root   0 Jun 28 03:39 vllm-single-node-qwen-06b.xplane.pb
```

Once the `random-output-len` is reduced to something smaller like 512, you can avoid this limitation.

This can be problematic as you might need this profile capture as part of an RL pipeline and changing this can lead to changing the way the pipeline operates.

This PR allows to pass an env variable `VLLM_ACTIVE_PROFILER_STEPS` that stops the capture after reaching the value provided, for example `VLLM_ACTIVE_PROFILER_STEPS=100`.

## How to use it:

```
VLLM_TORCH_PROFILER_DIR=/tmp/tpu_logs/qwen-06b VLLM_ACTIVE_PROFILER_STEPS=100 USE_BATCHED_RPA_KERNEL=1 VLLM_XLA_CHECK_RECOMPILATION=1 MODEL_IMPL_TYPE=flax_nnx vllm serve Qwen/Qwen3-0.6B \
        --max-model-len=24576 \
        --max-num-seqs=512 \
        --data-parallel-size 4 \
        --tensor-parallel-size 2 \
        --no-enable-prefix-caching \
        --gpu-memory-utilization=0.9 \
        --async-scheduling \
        --block-size=256 \
        --profiler-config '{"profiler": "torch", "torch_profiler_dir": "/tmp/tpu_logs/qwen-06b"}'
```

Now I can run benchmark at any output length and avoid the 2GB xProf hard limit.