### PR TITLE
[Fix] Pass num_tokens to set_forward_context in model wrapper

### DIFF
--- a/tpu_inference/models/vllm/vllm_model_wrapper.py
+++ b/tpu_inference/models/vllm/vllm_model_wrapper.py
@@ -419,13 +419,18 @@ class VllmModelWrapper:
                 List[jax.Array], jax.Array, List[jax.Array], jax.Array]:
             layer_name_to_kvcache_index = dict(layer_name_to_kvcache_index)
             lora_metadata = torch_view(lora_metadata)
+            # Fix for MoE models under DP > 1: extract num_tokens to prevent
+            # AssertionError in set_forward_context.
+            num_tokens = input_ids.shape[0] if input_ids is not None else (
+                input_embeds.shape[0] if input_embeds is not None else None)
             with torchax.default_env(), set_vllm_model_wrapper_context(
                     kv_caches=kv_caches,
                     mesh=self.mesh,
                     layer_name_to_kvcache_index=layer_name_to_kvcache_index,
                     vllm_config=self.vllm_config), set_forward_context(
                         attn_metadata=attn_metadata,
-                        vllm_config=self.vllm_config):
+                        vllm_config=self.vllm_config,
+                        num_tokens=num_tokens):
                 # We need to wrap args from jax land into TorchValue with
                 # torch_view in order to call the Torch function.
                 original_lora_metadata = replace_lora_metadata(
@@ -480,12 +485,16 @@ class VllmModelWrapper:
         ) -> Tuple[List[jax.Array], jax.Array, List[jax.Array],
                    Optional[jax.Array]]:
             layer_name_to_kvcache_index = dict(layer_name_to_kvcache_index)
+            # Fix for MoE models under DP > 1: extract num_tokens to prevent
+            # AssertionError in set_forward_context.
+            num_tokens = input_ids.shape[0] if input_ids is not None else None
             with torchax.default_env(), set_vllm_model_wrapper_context(
                     kv_caches=kv_caches,
                     mesh=self.mesh,
                     layer_name_to_kvcache_index=layer_name_to_kvcache_index
             ), set_forward_context(attn_metadata=attn_metadata,
-                                   vllm_config=self.vllm_config):
+                                   vllm_config=self.vllm_config,
+                                   num_tokens=num_tokens):
                 kwargs = {
                     "input_ids": torch_view(input_ids),
                     "positions": torch_view(attn_metadata.input_positions),


### PR DESCRIPTION
# Description
FIXES: #3026 

This PR resolves an AssertionError that occurs during the AOT precompilation and warm-up phase of Mixture-of-Experts (MoE) models when running on a multi-host Data Parallel (DP > 1) TPU configuration.

The Problem
When data_parallel_size > 1 and the model is an MoE, vLLM's set_forward_context (in vllm/forward_context.py) attempts to coordinate token distributions across DP ranks. To do this, it enters a block that asserts num_tokens is not None:

```python
if (
    vllm_config.parallel_config.data_parallel_size > 1
    and vllm_config.parallel_config.is_moe_model is not False
    and (attn_metadata is not None or num_tokens is not None)
):
    if num_tokens_across_dp is None:
        assert ubatch_slices is None
        assert num_tokens is not None  # <-- CRASH POINT

```
Currently, VllmModelWrapper's step functions (step_fun_impl and draft_step_fun_impl) invoke set_forward_context but omit the num_tokens parameter, causing it to default to None and triggering the crash on MoE models under DP > 1. (For dense models, is_moe_model is False, so this block is bypassed and no crash occurs).

The Fix
We extract num_tokens from input_ids or input_embeds in both step_fun_impl and draft_step_fun_impl, and explicitly pass it into the set_forward_context calls.

# Tests

This fix was verified by:

1. Deploying a Qwen MoE model on a TPU v6e-8 host with TP=4 and DP=2 to ensure that AOT precompilation completes successfully without throwing the AssertionError in set_forward_context.
2. Verifying that the change is a no-op for dense models and DP=1 runs.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
