### PR TITLE
[1/N] Refactor MoE in jax path: Add JaxRoutedExperts

### DIFF
--- a/tpu_inference/layers/common/moe.py
+++ b/tpu_inference/layers/common/moe.py
@@ -18,7 +18,6 @@ from typing import TYPE_CHECKING, Tuple, Union
 import jax
 import jax.numpy as jnp
 from jax.sharding import Mesh
-from vllm.model_executor.layers.fused_moe import RoutedExperts
 
 from tpu_inference import envs
 from tpu_inference.kernels.fused_moe.v1.kernel import fused_ep_moe
@@ -71,7 +70,7 @@ class MoEBackend(Enum):
 
 
 def moe_apply(
-    layer: Union[RoutedExperts, JaxMoE],
+    layer,
     x: jax.Array,
     gating_output: Union[jax.Array, Tuple[jax.Array, jax.Array]],
     weights: Union[FusedMoEWeights, UnfusedMoEWeights],

--- a/tpu_inference/layers/common/moe.py
+++ b/tpu_inference/layers/common/moe.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING, Tuple, Union
 import jax
 import jax.numpy as jnp
 from jax.sharding import Mesh
+from vllm.model_executor.layers.fused_moe import RoutedExperts
 
 from tpu_inference import envs
 from tpu_inference.kernels.fused_moe.v1.kernel import fused_ep_moe
@@ -28,11 +29,12 @@ from tpu_inference.utils import to_jax_dtype
 if TYPE_CHECKING:
     from tpu_inference.layers.common.process_weights.moe_weights import (
         FusedMoEWeights, UnfusedMoEWeights)
-    from tpu_inference.layers.jax.moe.moe import JaxMoE
+    from tpu_inference.layers.jax.moe.moe import JaxMoE, JaxRoutedExperts
 else:
     FusedMoEWeights = None
     UnfusedMoEWeights = None
     JaxMoE = None
+    JaxRoutedExperts = None
 
 logger = init_logger(__name__)
 
@@ -70,7 +72,7 @@ class MoEBackend(Enum):
 
 
 def moe_apply(
-    layer,
+    layer: Union[RoutedExperts, JaxRoutedExperts, JaxMoE],
     x: jax.Array,
     gating_output: Union[jax.Array, Tuple[jax.Array, jax.Array]],
     weights: Union[FusedMoEWeights, UnfusedMoEWeights],

--- a/tpu_inference/layers/common/quantization/unquantized.py
+++ b/tpu_inference/layers/common/quantization/unquantized.py
@@ -22,6 +22,19 @@ from tpu_inference.layers.common.utils import \
     slice_sharded_tensor_for_concatenation
 
 
+class UnquantizedFusedMoEMethod:
+    """Shared base for jax and vllm unquantized fused-MoE methods.
+
+    Both paths track extra_backend_kwargs (e.g. ep_axis_name, block sizes)
+    that flow through to the kernel call.  Keeping this here avoids
+    duplicating the initialisation in each backend.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.extra_backend_kwargs = {}
+
+
 class UnquantizedLinearMethod:
     """Implements the forward method for unquantized linear layers.
 

--- a/tpu_inference/layers/jax/moe/moe.py
+++ b/tpu_inference/layers/jax/moe/moe.py
@@ -23,10 +23,12 @@ from jax.sharding import NamedSharding, PartitionSpec
 from jaxtyping import Float
 
 from tpu_inference.layers.common.moe import MoEBackend
+from tpu_inference.layers.common.sharding import ShardingAxisName
 from tpu_inference.layers.common.utils import cpu_mesh_context
 from tpu_inference.layers.jax import JaxModule
 from tpu_inference.layers.jax.base import create_param
 from tpu_inference.layers.jax.layers import FlaxUtils
+from tpu_inference.layers.jax.moe.utils import select_moe_backend
 from tpu_inference.layers.jax.quantization import QuantizeMethodBase
 from tpu_inference.layers.jax.quantization.configs import QuantizationConfig
 from tpu_inference.logger import init_logger
@@ -125,6 +127,7 @@ class Router(nnx.Module):
 
 
 # --- Main Class for MoE ---
+# TODO(#3041): Remove once we JaxRoutedExperts is fully ready.
 @dataclass(kw_only=True)
 class JaxMoE(JaxModule):
     """Mixture-of-Experts (MoE) Routed MLP Layer.
@@ -337,3 +340,125 @@ class JaxMoE(JaxModule):
                     ) from e
 
         return loaded_names
+
+
+class JaxRoutedExperts(JaxModule):
+    """Expert-only MoE module analogous to vllm's RoutedExperts.
+
+    Decouples expert computation from routing; the caller is responsible for
+    computing router_logits before calling __call__.  use_ep and moe_backend
+    are derived from the vLLM parallel config at init time so the EP/TP
+    backend selection matches the torchax path.
+
+    When quant_config is None, UnquantizedConfig is used so that
+    process_weights_after_loading (sharding/fusion) always runs.
+    """
+
+    def __init__(
+        self,
+        *,
+        dtype: jnp.dtype,
+        num_local_experts: int,
+        hidden_size: int,
+        intermediate_size_moe: int,
+        hidden_act: str,
+        rngs: nnx.Rngs,
+        mesh: jax.sharding.Mesh,
+        top_k: int,
+        scoring_func: str = "softmax",
+        renormalize: bool = True,
+        random_init: bool = False,
+        qwix_quantized_weight_dtype: Optional[jnp.dtype] = None,
+        quant_config: Optional[QuantizationConfig] = None,
+        prefix: str = "",
+        enable_return_routed_experts: bool = False,
+    ):
+        self.dtype = dtype
+        self.num_local_experts = num_local_experts
+        self.hidden_size = hidden_size
+        self.intermediate_size_moe = intermediate_size_moe
+        self.hidden_act = hidden_act
+        self.mesh = mesh
+        self.top_k = top_k
+        self.scoring_func = scoring_func
+        self.renormalize = renormalize
+        self.random_init = random_init
+        self.qwix_quantized_weight_dtype = qwix_quantized_weight_dtype
+        self.prefix = prefix
+        self.enable_return_routed_experts = enable_return_routed_experts
+
+        E = num_local_experts
+        D = hidden_size
+        F = intermediate_size_moe
+
+        # Weights are initially unsharded; quant method shards them in
+        # process_weights_after_loading via shard_moe_weights.
+        self.kernel_gating_EDF = create_param(rngs,
+                                              shape=(E, D, F),
+                                              dtype=dtype,
+                                              random_init=random_init)
+        self.kernel_gating_EDF.set_metadata(_weights_to_load=[None] * E)
+        self.kernel_up_proj_EDF = create_param(rngs,
+                                               shape=(E, D, F),
+                                               dtype=dtype,
+                                               random_init=random_init)
+        self.kernel_up_proj_EDF.set_metadata(_weights_to_load=[None] * E)
+        self.kernel_down_proj_EFD = create_param(rngs,
+                                                 shape=(E, F, D),
+                                                 dtype=dtype,
+                                                 random_init=random_init)
+        self.kernel_down_proj_EFD.set_metadata(_weights_to_load=[None] * E)
+
+        # Derive use_ep from the vLLM parallel config (same formula as torchax).
+        self.use_ep = self._compute_use_ep()
+        self.moe_backend = select_moe_backend(self.use_ep)
+        # Needed by apply_jax for the input sharding constraint.
+        self.activation = hidden_act
+        self.activation_ffw_td = (ShardingAxisName.MLP_DATA, None)
+        self.num_experts_per_tok = top_k
+
+        if quant_config is None:
+            # Imported locally to avoid an import cycle.
+            from tpu_inference.layers.jax.quantization.unquantized import \
+                UnquantizedConfig
+            quant_config = UnquantizedConfig({})
+        self.quant_config = quant_config
+
+        if (qm := quant_config.get_quant_method(self, prefix=prefix)):
+            assert isinstance(qm, QuantizeMethodBase)
+            self.quant_method = qm
+            self.quant_method.create_weights_jax(self, rngs=rngs)
+        else:
+            raise ValueError("Expected quant_method to be set!")
+
+    @staticmethod
+    def _compute_use_ep() -> bool:
+        # Replicate vLLM logic
+        # https://github.com/vllm-project/vllm/blob/36bbecd6436d0dd4c7a27fbb09a787e00534d647/vllm/model_executor/layers/fused_moe/config.py#L1190-L1193
+        from vllm.config import get_current_vllm_config
+        pc = get_current_vllm_config().parallel_config
+        return (pc.data_parallel_size * pc.prefill_context_parallel_size *
+                pc.tensor_parallel_size) > 1 and pc.enable_expert_parallel
+
+    def __call__(
+        self,
+        x_TD: jax.Array,
+        router_logits: jax.Array,
+    ) -> tuple[jax.Array, Optional[jax.Array]]:
+        assert self.quant_method is not None
+        x_TD = self.quant_method.apply_jax(self,
+                                           x_TD,
+                                           router_logits=router_logits)
+        if self.enable_return_routed_experts:
+            _, selected_experts_TX = jax.lax.top_k(router_logits, self.top_k)
+            return x_TD, selected_experts_TX
+        return x_TD, None
+
+    def load_weights(self, weights: Iterable):
+        """Used by JaxAutoWeightLoader to load HF weights into the layer."""
+        assert hasattr(self.quant_method, "load_weights")
+        return self.quant_method.load_weights(
+            layer=self,
+            original_load_weights_fn=lambda: NotImplementedError(
+                "JaxRoutedExperts does not implement _load_weights"),
+            weights=weights)

--- a/tpu_inference/layers/jax/quantization/fp8.py
+++ b/tpu_inference/layers/jax/quantization/fp8.py
@@ -34,7 +34,7 @@ from tpu_inference.layers.common.utils import cpu_mesh, cpu_mesh_context
 from tpu_inference.layers.jax import JaxModule
 from tpu_inference.layers.jax.base import create_param
 from tpu_inference.layers.jax.linear import JaxEinsum
-from tpu_inference.layers.jax.moe.moe import JaxMoE
+from tpu_inference.layers.jax.moe.moe import JaxMoE, JaxRoutedExperts
 from tpu_inference.layers.jax.quantization import QuantizeMethodBase
 from tpu_inference.layers.jax.quantization.configs import (QuantizationConfig,
                                                            QuantLinearConfig)
@@ -546,27 +546,16 @@ class Fp8FusedMoEMethod(QuantizeMethodBase):
             delattr(layer, gating_scale_name)
             delattr(layer, up_scale_name)
 
-            # TODO (jacobplatin): we probably want to make the sharding configurable
-            layer.kernel_gating_upproj_EDF = nnx.Param(
-                shard_put(weights.w13_weight, shardings=layer.edf_sharding))
-            layer.kernel_down_proj_EFD = nnx.Param(
-                shard_put(weights.w2_weight, shardings=layer.efd_sharding))
-            # gmm expects shape [num_groups, num_blocks, 1, n]
-            # TODO(gpolovets1): Make sure it works for gmm_v2 as well.
-            edf_scale_sharding = (layer.edf_sharding[0], ) + (None, ) * (
-                weights.w13_weight_scale.ndim - 2) + (layer.edf_sharding[-1], )
-            efd_scale_sharding = (layer.efd_sharding[0], ) + (None, ) * (
-                weights.w2_weight_scale.ndim - 2) + (layer.efd_sharding[-1], )
-            setattr(
-                layer, f"kernel_gating_upproj_EDF_{self.weight_scale_name}",
-                nnx.Param(
-                    shard_put(weights.w13_weight_scale,
-                              shardings=edf_scale_sharding)))
-            setattr(
-                layer, f"kernel_down_proj_EFD_{self.weight_scale_name}",
-                nnx.Param(
-                    shard_put(weights.w2_weight_scale,
-                              shardings=efd_scale_sharding)))
+            # process_quantized_moe_weights applies with_sharding_constraint via
+            # _get_moe_weight_shardings for all weight fields; the arrays are
+            # already correctly sharded on return — no shard_put needed.
+            layer.kernel_gating_upproj_EDF = nnx.Param(weights.w13_weight)
+            layer.kernel_down_proj_EFD = nnx.Param(weights.w2_weight)
+            setattr(layer,
+                    f"kernel_gating_upproj_EDF_{self.weight_scale_name}",
+                    nnx.Param(weights.w13_weight_scale))
+            setattr(layer, f"kernel_down_proj_EFD_{self.weight_scale_name}",
+                    nnx.Param(weights.w2_weight_scale))
         else:
             raise NotImplementedError(
                 f"Unsupported moe backend: {layer.moe_backend}! Currently supported: {FP8_QUANT_METHOD_SUPPORTED_MOE_BACKENDS}"
@@ -586,7 +575,7 @@ class Fp8FusedMoEMethod(QuantizeMethodBase):
         Returns:
             The MoE output.
         """
-        assert isinstance(layer, JaxMoE)
+        assert isinstance(layer, (JaxMoE, JaxRoutedExperts))
 
         x_TD = jnp.asarray(x, layer.dtype)
         x_TD = jax.lax.with_sharding_constraint(
@@ -680,7 +669,7 @@ class Fp8Config(QuantizationConfig):
                 return Fp8BlockwiseLinearMethod(self, layer, linear_config)
             else:
                 return Fp8TensorwiseLinearMethod(layer, linear_config)
-        elif isinstance(layer, JaxMoE):
+        elif isinstance(layer, (JaxRoutedExperts, JaxMoE)):
             if self.is_layer_skipped(prefix,
                                      ignored_layers=self.ignored_layers):
                 return UnquantizedFusedMoEMethod()

--- a/tpu_inference/layers/jax/quantization/unquantized.py
+++ b/tpu_inference/layers/jax/quantization/unquantized.py
@@ -33,7 +33,7 @@ from tpu_inference.layers.common.utils import (
 from tpu_inference.layers.jax import JaxModule
 from tpu_inference.layers.jax.linear import (JaxEinsum,
                                              JaxMergedColumnParallelLinear)
-from tpu_inference.layers.jax.moe.moe import JaxMoE
+from tpu_inference.layers.jax.moe.moe import JaxMoE, JaxRoutedExperts
 from tpu_inference.layers.jax.quantization import QuantizeMethodBase
 from tpu_inference.layers.jax.quantization.configs import QuantizationConfig
 from tpu_inference.logger import init_logger
@@ -166,18 +166,13 @@ class UnquantizedMergedLinearMethod(UnquantizedLinearMethod):
         assign_and_shard_param(param, fused, param_name=param_name)
 
 
-class UnquantizedFusedMoEMethod(QuantizeMethodBase):
+class UnquantizedFusedMoEMethod(QuantizeMethodBase,
+                                jax_common.UnquantizedFusedMoEMethod):
     """
-    Unquantized method for JAXMoE layer.
-
-    TODO (jacobplatin): support weight loading -- currently, model-dependent.
+    Unquantized method for JaxRoutedExperts layers.
     """
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.extra_backend_kwargs = {}
-
-    def process_weights_after_loading(self, layer: JaxMoE, *args,
+    def process_weights_after_loading(self, layer: JaxRoutedExperts, *args,
                                       **kwargs) -> bool:
         """
         Process weights after loading.
@@ -189,9 +184,13 @@ class UnquantizedFusedMoEMethod(QuantizeMethodBase):
             layer: The layer to process.
         """
         if layer.moe_backend == MoEBackend.FUSED_MOE:
-            if layer.edf_sharding:
-                e2df_sharding = (layer.edf_sharding[0], None,
-                                 layer.edf_sharding[1], layer.edf_sharding[2])
+            # TODO(#3041): Remove once we remove JaxMoe from code base.
+            edf_sharding = getattr(layer, 'edf_sharding', ())
+            if edf_sharding:
+                e2df_sharding = (edf_sharding[0], None, edf_sharding[1],
+                                 edf_sharding[2])
+            else:
+                e2df_sharding = (None, None, None, None)
             # fuse the weights into w13: [Gate, Up]
             w_gate = layer.kernel_gating_EDF.value
             w_up = layer.kernel_up_proj_EDF.value
@@ -205,7 +204,10 @@ class UnquantizedFusedMoEMethod(QuantizeMethodBase):
             del layer.kernel_gating_EDF
             del layer.kernel_up_proj_EDF
 
-            ep_axis_name = layer.efd_sharding[0]
+            # TODO(#3041): Remove once we remove JaxMoe from code base.
+            # VllmUnquantizedFusedMoEMethod passes ep_axis_name through __init__
+            efd_sharding = getattr(layer, 'efd_sharding', ())
+            ep_axis_name = efd_sharding[0] if efd_sharding else None
 
             self.extra_backend_kwargs = {
                 "ep_axis_name": ep_axis_name,
@@ -280,7 +282,7 @@ class UnquantizedFusedMoEMethod(QuantizeMethodBase):
 
         return True
 
-    def apply_jax(self, layer: JaxMoE, x: jax.Array, *,
+    def apply_jax(self, layer: JaxRoutedExperts, x: jax.Array, *,
                   router_logits: jax.Array) -> jax.Array:
         """Forward pass for MoE layer.
         Args:
@@ -367,6 +369,6 @@ class UnquantizedConfig(QuantizationConfig):
             linear_config = QuantLinearConfig(enable_sp=False,
                                               output_sizes=[out_size])
             return UnquantizedLinearMethod(linear_config)
-        if isinstance(layer, JaxMoE):
+        if isinstance(layer, (JaxRoutedExperts, JaxMoE)):
             return UnquantizedFusedMoEMethod()
         return None

--- a/tpu_inference/layers/vllm/quantization/unquantized.py
+++ b/tpu_inference/layers/vllm/quantization/unquantized.py
@@ -346,8 +346,9 @@ class VllmUnquantizedLinearMethod(vllm_linear.UnquantizedLinearMethod,
         return out
 
 
-class VllmUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod,
-                                    VllmQuantizationMethod):
+class VllmUnquantizedFusedMoEMethod(
+        UnquantizedFusedMoEMethod,
+        common_unquantized.UnquantizedFusedMoEMethod, VllmQuantizationMethod):
 
     def __init__(
         self,
@@ -355,7 +356,7 @@ class VllmUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod,
         mesh: Mesh,
         ep_axis_name: str = "model",
     ):
-        super().__init__(moe)
+        UnquantizedFusedMoEMethod.__init__(self, moe)
         self.mesh = mesh
         self.moe_backend = select_moe_backend_from_fused_moe_config(self.moe)
 


### PR DESCRIPTION
# Description

1st step of #3041 , Add `JaxRoutedExperts` which has its own `_compute_use_ep()` that has same logic as torchax path.

# Tests

rely on unit test

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
