### PR TITLE
[releases/v0.24.0] Cherry-pick #3036 + #3037: Qwen3-30B-A3B accuracy + multimodal TPU teardown fixes

### DIFF
--- a/tests/e2e/test_multi_modal_inference.py
+++ b/tests/e2e/test_multi_modal_inference.py
@@ -5,7 +5,9 @@
 # compares the output to a known-good output.
 
 import difflib
+import gc
 import os
+import traceback
 from dataclasses import asdict
 
 import pytest
@@ -91,37 +93,56 @@ def test_multi_modal_inference(monkeypatch, enable_dynamic_image_sizes):
 
     llm = LLM(**engine_args)
 
-    sampling_params = SamplingParams(
-        temperature=temperature,
-        max_tokens=max_tokens,
-    )
+    try:
+        sampling_params = SamplingParams(
+            temperature=temperature,
+            max_tokens=max_tokens,
+        )
 
-    inputs = {
-        "prompt": prompt,
-        "multi_modal_data": {
-            "image": image
-        },
-    }
+        inputs = {
+            "prompt": prompt,
+            "multi_modal_data": {
+                "image": image
+            },
+        }
 
-    # --- Run Inference ---
-    print("Running inference...")
-    outputs = llm.generate(inputs, sampling_params)
+        # --- Run Inference ---
+        print("Running inference...")
+        outputs = llm.generate(inputs, sampling_params)
 
-    # --- Verification ---
-    generated_text = outputs[0].outputs[0].text.strip()
+        # --- Verification ---
+        generated_text = outputs[0].outputs[0].text.strip()
 
-    print("-" * 50)
-    print("Generated Text:")
-    print(generated_text)
-    print("-" * 50)
+        print("-" * 50)
+        print("Generated Text:")
+        print(generated_text)
+        print("-" * 50)
 
-    # Check output against the closest known-good caption.
-    similarity_score = max(
-        difflib.SequenceMatcher(None, generated_text, expected,
-                                autojunk=False).ratio()
-        for expected in EXPECTED_TEXTS)
-    print(f"Similarity Score: {similarity_score:.4f}")
-    assert similarity_score >= 0.85, (
-        f"Text similarity too low ({similarity_score:.2f}).\n"
-        f"Expected one of: {EXPECTED_TEXTS}\n"
-        f"Actual:   {generated_text}")
+        # Check output against the closest known-good caption.
+        similarity_score = max(
+            difflib.SequenceMatcher(
+                None, generated_text, expected, autojunk=False).ratio()
+            for expected in EXPECTED_TEXTS)
+        print(f"Similarity Score: {similarity_score:.4f}")
+        assert similarity_score >= 0.85, (
+            f"Text similarity too low ({similarity_score:.2f}).\n"
+            f"Expected one of: {EXPECTED_TEXTS}\n"
+            f"Actual:   {generated_text}")
+    finally:
+        # Release the TPU before the next parametrization builds a new engine.
+        # This test is parametrized over enable_dynamic_image_sizes=[False, True]
+        # and pytest runs both in one process; without an explicit engine
+        # shutdown the first engine's worker keeps the TPU and the second
+        # LLM(...) fails with "TPU already in use by pid <first>". Mirrors the
+        # teardown in tests/e2e/test_continue_decode.py.
+        #
+        # Guard the shutdown so a teardown failure cannot mask a body
+        # AssertionError (the similarity check) -- surface it loudly instead of
+        # swallowing it.
+        try:
+            llm.llm_engine.engine_core.shutdown()
+        except Exception:
+            print("[multimodal-test] engine_core.shutdown() failed during "
+                  "teardown (non-fatal):")
+            traceback.print_exc()
+        gc.collect()

--- a/tests/kernels/dense_gather_reduce_test.py
+++ b/tests/kernels/dense_gather_reduce_test.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 import itertools
+import types
+from unittest import mock
 
 import jax
 import jax.numpy as jnp
@@ -21,8 +23,9 @@ from absl.testing import absltest, parameterized
 from jax._src import test_util as jtu
 from jax.experimental.pallas import tpu as pltpu
 
-from tpu_inference.kernels.sparse_core.dense_gather_reduce import \
-    dense_gather_reduce
+from tpu_inference.kernels.sparse_core import dense_gather_reduce as dgr_mod
+from tpu_inference.kernels.sparse_core.dense_gather_reduce import (
+    dense_gather_reduce, is_compatible)
 
 jax.config.parse_flags_with_absl()
 
@@ -222,6 +225,47 @@ class DenseGatherReduceTest(jtu.JaxTestCase):
             print("DEBUG ACTUAL (first 32 rows):\n", actual[:32, :])
             print("DEBUG DESIRED (first 32 rows):\n", desired[:32, :])
             raise e
+
+
+class IsCompatibleTest(parameterized.TestCase):
+    """Hardware-independent tests for the is_compatible() fallback gate.
+
+    These mock get_tpu_info() so they run on any platform, unlike
+    DenseGatherReduceTest which needs SparseCore hardware. They target the
+    output-block packing gate: the kernel's output BlockSpec row dim is
+    (num_lanes // reduce_group_size) // packing, which must be >= 1.
+    """
+
+    def _fake_tpu_info(self, num_lanes, num_cores=1, num_subcores=1):
+        sparse_core = types.SimpleNamespace(num_lanes=num_lanes,
+                                            num_cores=num_cores,
+                                            num_subcores=num_subcores)
+        return types.SimpleNamespace(sparse_core=sparse_core)
+
+    # (num_lanes, dtype, reduce_group_size, expected_is_compatible)
+    @parameterized.named_parameters(
+        # v6e SparseCore (num_lanes=8). bf16 packing=2: 8//8//2 = 0 -> the
+        # Qwen3-30B-A3B crash -> must fall back.
+        ("v6e_bf16_topk8_degenerate", 8, jnp.bfloat16, 8, False),
+        # Same v6e lanes but f32 (packing=1): 8//8//1 = 1 -> kernel is valid,
+        # must NOT be blocked just because it is v6e.
+        ("v6e_f32_topk8_ok", 8, jnp.float32, 8, True),
+        # v6e lanes, bf16, smaller group: 8//4//2 = 1 -> valid.
+        ("v6e_bf16_topk4_ok", 8, jnp.bfloat16, 4, True),
+        # v7x-like (num_lanes=16), bf16: 16//8//2 = 1 -> valid.
+        ("v7x_bf16_topk8_ok", 16, jnp.bfloat16, 8, True),
+    )
+    def test_output_block_packing_gate(self, num_lanes, dtype,
+                                       reduce_group_size, expected):
+        op = jnp.zeros((4096, 128), dtype)
+        idx = jnp.zeros((4096, ), jnp.int32)
+        with mock.patch.object(
+                dgr_mod.pltpu,
+                "get_tpu_info",
+                return_value=self._fake_tpu_info(num_lanes=num_lanes)):
+            self.assertEqual(
+                is_compatible(op, idx, reduce_group_size=reduce_group_size),
+                expected)
 
 
 if __name__ == "__main__":

--- a/tpu_inference/kernels/sparse_core/dense_gather_reduce.py
+++ b/tpu_inference/kernels/sparse_core/dense_gather_reduce.py
@@ -48,6 +48,12 @@ def is_compatible(
     if sc_info.num_lanes % reduce_group_size != 0:
         return False
 
+    # The output block has (num_lanes // reduce_group_size) // packing rows;
+    # fall back to JAX when that is 0 (the kernel can't emit a zero-row block).
+    packing = 32 // jax.dtypes.itemsize_bits(op.dtype)
+    if (sc_info.num_lanes // reduce_group_size) // packing < 1:
+        return False
+
     num_cores = 1 if single_sc else sc_info.num_cores
     num_subcores = sc_info.num_subcores
     row_wave_size = row_chunk_size * num_cores * num_subcores


### PR DESCRIPTION
Cherry-picks two fixes from `main` onto `releases/v0.24.0`. Both address failures present on the v0.24.0 nightly that are inherited from `main` (not regressions from the cut).

## Commits
- **#3036** (`e11970b9`) — SC `dense_gather_reduce`: fall back when the output block packs to zero rows, fixing the `tpu6e Accuracy for Qwen/Qwen3-30B-A3B` AOT `swap` crash. `is_compatible()` now gates on `(num_lanes // reduce_group_size) // packing >= 1` so the degenerate v6e/bf16/topk=8 case uses `_jax_fallback` while valid configs keep the kernel.
- **#3037** (`9d525909`) — Multimodal test: release the TPU between parametrizations (`engine_core.shutdown()` + `gc.collect()` in `try/finally`), fixing the `Correctness tests for Multimodal Inputs` "TPU already in use" failure.

## Validation
Both merged to `main` after passing pre-commit CI and being validated on the dev pipeline on both v6e and v7x (see the original PRs #3036 / #3037). Cherry-picks applied cleanly (the touched files were unchanged between the v0.24.0 cut point and `main`).

Backport of #3036 and #3037.