### PR TITLE
perf: restore dimension_semantics to batched RPA compiler inner loop

### DIFF
--- a/tpu_inference/kernels/experimental/batched_rpa/kernel.py
+++ b/tpu_inference/kernels/experimental/batched_rpa/kernel.py
@@ -421,6 +421,7 @@ def rpa_kernel(
                 kv_lens_ref=kv_lens_ref,
             ),
             grid=(safe_steps, ),
+            dimension_semantics=("arbitrary", ),
             in_specs=(q_alloc.spec, kv_cache_alloc.spec),
             out_specs=(o_alloc.spec, ),
         )


### PR DESCRIPTION
# Description

Fix the regression with `batched_rpa` from commit 97ea4295. In that commit, the `pl.pallas_call`  grid was refactored & the parameter dimension_semantics=("arbitrary", ) was deleted from the outer `CompilerParams`

 Reran benchmarks on that commit with this change on Qwen/Qwen3-32B to restore performance: 

  Metric      | Before Fix | After
-------------|--------|--------
 Output Token Throughput     | 6,049  | 6,707 
 