### PR TITLE
[Bench/InferenceX] add bench scripts for Qwen3.5-397B-A17B-FP8

### DIFF
--- a/tests/e2e/benchmarking/inferencex/qwen3.5/bench.sh
+++ b/tests/e2e/benchmarking/inferencex/qwen3.5/bench.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Run one fixed-sequence InferenceX benchmark point against an already-running
+# server. The client arguments mirror InferenceX's run_benchmark_serving helper.
+# Usage: ISL=8192 OSL=1024 CONC=256 bash bench.sh
+set -euo pipefail
+
+MODEL=Qwen/Qwen3.5-397B-A17B-FP8
+PORT="${PORT:-8000}"
+RANDOM_RANGE_RATIO="${RANDOM_RANGE_RATIO:-0.8}"
+if [ -z "${INFERENCEX_REPO:-}" ]; then
+  INFERENCEX_REPO=/tmp/InferenceX
+  if [ ! -d "$INFERENCEX_REPO/.git" ]; then
+    echo "INFERENCEX_REPO unset -> cloning InferenceX to $INFERENCEX_REPO"
+    git clone --depth 1 https://github.com/SemiAnalysisAI/InferenceX.git "$INFERENCEX_REPO"
+  fi
+fi
+BENCH_CLIENT="${INFERENCEX_REPO}/utils/bench_serving/benchmark_serving.py"
+RESULT_DIR="${RESULT_DIR:-/tmp/qwen3.5-inferencex-bench}"
+ISL="${ISL:-8192}"
+OSL="${OSL:-1024}"
+CONC="${CONC:-64}"
+
+num_prompts=$((CONC * 10))
+STAMP="$(date +%m%d-%H%M)"   # month-day-hour-minute
+
+mkdir -p "$RESULT_DIR"
+benchmark_cmd=(
+  python3 "$BENCH_CLIENT"
+  --model "$MODEL"
+  --backend vllm
+  --base-url "http://0.0.0.0:${PORT}"
+  --dataset-name random
+  --random-input-len "$ISL"
+  --random-output-len "$OSL"
+  --random-range-ratio "$RANDOM_RANGE_RATIO"
+  --num-prompts "$num_prompts"
+  --max-concurrency "$CONC"
+  --request-rate inf
+  --ignore-eos
+  --save-result
+  --num-warmups "$((2 * CONC))"
+  --percentile-metrics 'ttft,tpot,itl,e2el'
+  --result-dir "$RESULT_DIR"
+  --result-filename "qwen3.5_isl${ISL}_osl${OSL}_conc${CONC}_${STAMP}.json"
+  --use-chat-template
+)
+
+set -x
+"${benchmark_cmd[@]}"
+set +x

--- a/tests/e2e/benchmarking/inferencex/qwen3.5/server.sh
+++ b/tests/e2e/benchmarking/inferencex/qwen3.5/server.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Start the Qwen3.5-397B-A17B-FP8 vLLM-on-TPU server (sharding via SHARDING).
+# Usage:
+#   ISL=8192 OSL=1024 bash server.sh
+#   SHARDING=DP4TP2_EP ISL=8192 OSL=1024 bash server.sh
+set -euo pipefail
+
+PORT="${PORT:-8000}"
+SHARDING="${SHARDING:-DP8_EP}"
+ISL="${ISL:-8192}"
+OSL="${OSL:-1024}"
+
+case "$SHARDING" in
+  DP8_EP)
+    DP_SIZE=8
+    SHARDING_ARGS=(
+      --additional_config='{"sharding": {"sharding_strategy": {"enable_dp_attention": true}}}'
+      --enable-expert-parallel
+    ) ;;
+  DP4TP2_EP)
+    DP_SIZE=4
+    SHARDING_ARGS=(
+      --additional_config='{"sharding": {"sharding_strategy": {"enable_dp_attention": true, "attn_dp_size": 4}}}'
+      --enable-expert-parallel
+    ) ;;
+  *) echo "ERROR: unknown SHARDING='$SHARDING' (expected DP8_EP|DP4TP2_EP)" >&2; exit 1 ;;
+esac
+
+MAX_MODEL_LEN=$((ISL + OSL))
+MAX_NUM_BATCHED_TOKENS=$((ISL / DP_SIZE))
+
+set -x
+export MODEL_IMPL_TYPE=vllm
+export USE_MOE_EP_KERNEL=0
+export ATTN_BUCKETIZED_NUM_REQS=true
+export ATTN_CUSTOM_NUM_REQS_BUCKETS=8,16,32,64
+export ONEHOT_MOE_PERMUTE_THRESHOLD=32768
+export VLLM_MOE_CHUNK_SIZE=256
+export RAGGED_GATED_DELTA_RULE_IMPL=chunked_kernel_p_recurrent_kernel_d
+export NEW_MODEL_DESIGN=1
+export LIBTPU_INIT_ARGS=' --xla_tpu_use_minor_sharding_for_major_trivial_input=true --xla_tpu_enable_sparse_core_collective_offload_reduce_scatter=false --xla_tpu_ars_combiner_threshold_in_bytes=0 --xla_tpu_enable_async_collective_merger=false'
+
+args=(
+  Qwen/Qwen3.5-397B-A17B-FP8
+  --max-model-len="$MAX_MODEL_LEN"
+  --max-num-batched-tokens="$MAX_NUM_BATCHED_TOKENS"
+  --max-num-seqs=64
+  --no-enable-prefix-caching
+  --gpu-memory-utilization=0.9
+  --tensor-parallel-size=8
+  --async-scheduling
+  --port="$PORT"
+  --language-model-only
+  --enable-auto-tool-choice
+  --tool-call-parser=qwen3_coder
+  --reasoning-parser=qwen3
+  --limit-mm-per-prompt='{"image": 0, "video": 0}'
+  --kv-cache-dtype=fp8
+  --block-size=256
+  "${SHARDING_ARGS[@]}"
+)
+vllm serve "${args[@]}"
+set +x

--- a/tests/e2e/benchmarking/inferencex/qwen3.5/sweep.sh
+++ b/tests/e2e/benchmarking/inferencex/qwen3.5/sweep.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Sweep: restart the server per concurrency.
+# Usage: bash sweep.sh
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PORT="${PORT:-8000}"
+READY_TIMEOUT="${READY_TIMEOUT:-5400}"   # 90 min (covers a cold compile)
+
+WORKLOADS=("8192:1024" "1024:1024")
+CONC_SHARDING=(
+  "4:DP4TP2_EP"
+  "8:DP4TP2_EP"
+  "16:DP4TP2_EP"
+  "32:DP4TP2_EP"
+  "64:DP8_EP"
+  "128:DP8_EP"
+  "256:DP8_EP"
+)
+
+stop_server() {
+  pkill -TERM -f "vllm serve Qwen/Qwen3.5" 2>/dev/null || true
+  pkill -TERM -f "VLLM::EngineCore" 2>/dev/null || true
+  sleep 6
+  pkill -KILL -f "vllm serve Qwen/Qwen3.5" 2>/dev/null || true
+  pkill -KILL -f "VLLM::EngineCore" 2>/dev/null || true
+  for _ in $(seq 1 30); do
+    [ "$(curl -s -o /dev/null -w '%{http_code}' "http://0.0.0.0:${PORT}/health" 2>/dev/null)" = "200" ] || break
+    sleep 2
+  done
+}
+
+start_server() {  # $1 = SHARDING (CONC/ISL/OSL come from the exported env)
+  SERVER_LOG="/tmp/qwen3.5_sweep_server_isl${ISL}_osl${OSL}_conc${CONC}_$(date +%m%d-%H%M).log"
+  echo "--- starting server SHARDING=$1 ISL=$ISL OSL=$OSL CONC=$CONC (log: $SERVER_LOG) ---"
+  SHARDING="$1" bash "${SCRIPT_DIR}/server.sh" >> "$SERVER_LOG" 2>&1 &
+  SERVER_PID=$!
+  local waited=0
+  until grep -q "Application startup complete" "$SERVER_LOG" 2>/dev/null; do
+    kill -0 "$SERVER_PID" 2>/dev/null || { echo "ERROR: server exited during startup (see $SERVER_LOG)" >&2; return 1; }
+    sleep 5; waited=$((waited + 5))
+    [ "$waited" -ge "$READY_TIMEOUT" ] && { echo "ERROR: server not ready after ${READY_TIMEOUT}s" >&2; return 1; }
+  done
+  echo "--- server ready ---"
+}
+
+trap stop_server EXIT
+
+for wl in "${WORKLOADS[@]}"; do
+  export ISL="${wl%%:*}" OSL="${wl#*:}"
+  for cs in "${CONC_SHARDING[@]}"; do
+    export CONC="${cs%%:*}"
+    sharding="${cs#*:}"
+    stop_server
+    start_server "$sharding" || exit 1
+    echo "########## ISL=$ISL OSL=$OSL CONC=$CONC SHARDING=$sharding ##########"
+    bash "${SCRIPT_DIR}/bench.sh"
+  done
+done
+echo "########## sweep complete ##########"


### PR DESCRIPTION
## What

`tests/e2e/benchmarking/inferencex/qwen3.5/` — three scripts:
- `server.sh`: start the vLLM-on-TPU server using the most performant config.
- `bench.sh`: one benchmark point, mirroring the InferenceX benchmark client.
- `sweep.sh`: sweep across ISL/OSL and concurrency, using the most performant sharding for each concurrency.

## Why

- Create scripts that let us benchmark and reproduce performance on our stack.
## Benchmark results

Based on commit `b4169efd6` (06-19).

**8k:1k (isl=8192, osl=1024):**

| conc | sharding | total_tok_s | output_tok_s | total_tok_s/chip | output_tok_s/chip | median_tpot_ms |
|---|---|---|---|---|---|---|
| 4 | DP4TP2_EP | 2209 | 246 | 552 | 61 | 15.1 |
| 8 | DP4TP2_EP | 4406 | 495 | 1101 | 124 | 14.2 |
| 16 | DP4TP2_EP | 6975 | 773 | 1744 | 193 | 17.1 |
| 32 | DP4TP2_EP | 10397 | 1162 | 2599 | 291 | 23.9 |
| 64 | DP8_EP | 14812 | 1643 | 3703 | 411 | 33.6 |
| 128 | DP8_EP | 20842 | 2308 | 5210 | 577 | 51.5 |
| 256 | DP8_EP | 28445 | 3161 | 7111 | 790 | 75.4 |

**1k:1k (isl=1024, osl=1024):**

| conc | sharding | total_tok_s | output_tok_s | total_tok_s/chip | output_tok_s/chip | median_tpot_ms |
|---|---|---|---|---|---|---|
| 4 | DP4TP2_EP | 586 | 291 | 146 | 73 | 13.1 |
| 8 | DP4TP2_EP | 1015 | 509 | 254 | 127 | 13.5 |
| 16 | DP4TP2_EP | 1975 | 983 | 494 | 246 | 14.9 |
| 32 | DP4TP2_EP | 2985 | 1495 | 746 | 374 | 18.5 |
| 64 | DP8_EP | 4557 | 2276 | 1139 | 569 | 25.7 |
| 128 | DP8_EP | 8309 | 4147 | 2077 | 1037 | 26.9 |
| 256 | DP8_EP | 10876 | 5436 | 2719 | 1359 | 44.0 |