### PR TITLE
Remove explicit PAT from pipeline now that we have Github App

### DIFF
--- a/.buildkite/integration_promote.yml
+++ b/.buildkite/integration_promote.yml
@@ -21,8 +21,6 @@ steps:
     key: "promote_lkg"
     agents:
       queue: "cpu"
-    secrets:
-      - GITHUB_PAT
     commands:
       - |
         VLLM_LKG_HASH=$(buildkite-agent meta-data get "VLLM_COMMIT_HASH")

--- a/.buildkite/nightly_verify.yml
+++ b/.buildkite/nightly_verify.yml
@@ -68,8 +68,8 @@ steps:
   
    - label: "Commit support matrices if is nightly build or release tag specified"
      # commit_support_matrices and record_verified_commit_hashes push to the repo via
-     # GITHUB_PAT, which is only provisioned for main / release tags. Gate them off
-     # release-branch nightlies (branch != main, no tag) to avoid a "secrets" failure.
+     # GitHub App credentials, which are only provisioned for main / release tags. Gate
+     # them off release-branch nightlies (branch != main, no tag) to avoid a "secrets" failure.
      if: (build.env("NIGHTLY") == "1" && build.branch == "main") || build.tag =~ /^v?[0-9]+(\.[a-zA-Z0-9]+)*([a-zA-Z]+[0-9]*)?$/
      key: commit_support_matrices
      depends_on:
@@ -77,8 +77,6 @@ steps:
        - "v7_generate_matrices"
      agents:
        queue: cpu
-     secrets:
-      - GITHUB_PAT
      command:
        - bash .buildkite/scripts/commit_support_matrices.sh
 
@@ -95,7 +93,7 @@ steps:
        - bash .buildkite/scripts/notify_test_results.sh
 
    - label: "Record verified commit hashes"
-     # GITHUB_PAT is main/tag-only - see commit_support_matrices above.
+     # GitHub App credentials are main/tag-only - see commit_support_matrices above.
      if: build.env("NIGHTLY") == "1" && build.branch == "main" && "${MODEL_IMPL_TYPE:-auto}" == "auto"
      key: record_verified_commit_hashes
      depends_on:
@@ -104,7 +102,5 @@ steps:
        - tpu7x_tpu_test_notification
      agents:
        queue: cpu
-     secrets:
-      - GITHUB_PAT
      command:
        - bash .buildkite/scripts/commit_verified_commit_hashes.sh

--- a/.buildkite/scripts/commit_support_matrices.sh
+++ b/.buildkite/scripts/commit_support_matrices.sh
@@ -16,7 +16,6 @@
 set -e
 
 # --- Configuration ---
-REPO_URL="https://github.com/vllm-project/tpu-inference.git"
 TARGET_BRANCH="${BUILDKITE_BRANCH:-main}"
 
 # Conditional Configuration for Release vs. Nightly
@@ -40,18 +39,11 @@ else
   ARTIFACT_DOWNLOAD_PATH="support_matrices"
   COMMIT_MESSAGE="[skip ci] Update support matrices for ${COMMIT_TAG} (v6e/v7x)"
 fi
-# Construct the repository URL with the access token for authentication.
-AUTHENTICATED_REPO_URL="https://x-access-token:${GITHUB_PAT}@${REPO_URL#https://}"
 
-# Ensure the GITHUB_PAT is available before proceeding.
-if [ -z "${GITHUB_PAT:-}" ]; then
-  echo "--- ERROR: GITHUB_PAT secret not found. Cannot proceed."
-  exit 1
-fi
 
 echo "--- Configuring Git user details"
-git config user.name "Buildkite Bot"
-git config user.email "buildkite-bot@users.noreply.github.com"
+git config user.name "vllm-ci-bot[bot]"
+git config user.email "vllm-ci-bot[bot]@users.noreply.github.com"
 
 echo "--- Fetching and checking out the target branch"
 git fetch origin "${TARGET_BRANCH}"
@@ -116,5 +108,5 @@ else
   git commit -s -m "${COMMIT_MESSAGE}"
 
   echo "--- Pushing changes to '${TARGET_BRANCH}'"
-  git push "${AUTHENTICATED_REPO_URL}" "HEAD:${TARGET_BRANCH}"
+  git push origin "HEAD:${TARGET_BRANCH}"
 fi

--- a/.buildkite/scripts/commit_verified_commit_hashes.sh
+++ b/.buildkite/scripts/commit_verified_commit_hashes.sh
@@ -16,23 +16,13 @@
 set -e
 
 # --- Configuration ---
-REPO_URL="https://github.com/vllm-project/tpu-inference.git"
 TARGET_BRANCH="main"
 
 COMMIT_MESSAGE="Update verified commit hashes"
 
-# Construct the repository URL with the access token for authentication.
-AUTHENTICATED_REPO_URL="https://x-access-token:${GITHUB_PAT}@${REPO_URL#https://}"
-
-# Ensure the GITHUB_PAT is available before proceeding.
-if [ -z "${GITHUB_PAT:-}" ]; then
-  echo "--- ERROR: GITHUB_PAT secret not found. Cannot proceed."
-  exit 1
-fi
-
 echo "--- Configuring Git user details"
-git config user.name "Buildkite Bot"
-git config user.email "buildkite-bot@users.noreply.github.com"
+git config user.name "vllm-ci-bot[bot]"
+git config user.email "vllm-ci-bot[bot]@users.noreply.github.com"
 
 echo "--- Fetching and checking out the target branch"
 git fetch origin "${TARGET_BRANCH}"
@@ -67,5 +57,5 @@ else
   git commit -s -m "${COMMIT_MESSAGE}"
 
   echo "--- Pushing changes to '${TARGET_BRANCH}'"
-  git push "${AUTHENTICATED_REPO_URL}" "HEAD:${TARGET_BRANCH}"
+  git push origin "HEAD:${TARGET_BRANCH}"
 fi

--- a/.buildkite/scripts/update_lkg_version.sh
+++ b/.buildkite/scripts/update_lkg_version.sh
@@ -22,25 +22,15 @@ if [[ -z "$NEW_LKG_HASH" ]]; then
 fi
 
 # Configuration
-REPO_URL="https://github.com/vllm-project/tpu-inference.git"
 TARGET_BRANCH="main"
 
 NEW_LKG_HASH=$1
 VERSION_FILE=".buildkite/vllm_lkg.version"
 
-# Construct the repository URL with the access token for authentication
-AUTHENTICATED_REPO_URL="https://x-access-token:${GITHUB_PAT}@${REPO_URL#https://}"
-git remote set-url origin "${AUTHENTICATED_REPO_URL}"
-
-# Ensure the GITHUB_PAT is available before proceeding
-if [ -z "${GITHUB_PAT:-}" ]; then
-  echo "--- ERROR: GITHUB_PAT secret not found. Cannot proceed."
-  exit 1
-fi
 
 # Configure credentials
-git config user.name "Buildkite Bot"
-git config user.email "buildkite-bot@users.noreply.github.com"
+git config user.name "vllm-ci-bot[bot]"
+git config user.email "vllm-ci-bot[bot]@users.noreply.github.com"
 
 # Fetch and checkout
 git fetch origin "${TARGET_BRANCH}"


### PR DESCRIPTION
Recent main branch lkg and other matrices data are committed by github app. Let's remove the reference to GITHUB_PAT to make that explicit

Signed-off-by: Ming Huang <mhhua@google.com>

# Description

Start with a short description of what the PR does and how this is a change from
the past.

The rest of the description includes relevant details and context, examples:
- why is this change being made,
- the problem being solved and any relevant context,
- why this is a good solution,
- some information about the specific implementation,
- shortcomings of the solution and possible future improvements.

If the change fixes a Github issue, please include a link, e.g.,:
FIXES: #123456

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
