### PR TITLE
[not ready for review] kernels/sparse_core: support arbitrary hidden sizes in dense_gather_reduce

### DIFF
--- a/tests/kernels/dense_gather_reduce_test.py
+++ b/tests/kernels/dense_gather_reduce_test.py
@@ -89,17 +89,15 @@ class DenseGatherReduceTest(jtu.JaxTestCase):
                 [10],
                 [False],
             ),
-            # Hidden sizes that are not a multiple of the 128-wide lane tile.
-            # gpt-oss uses hidden_size=2880, for which no tile-aligned column
-            # chunk exists, so dense_gather_reduce must fall back to the JAX
-            # path instead of emitting an unaligned tpu.memref_slice that fails
-            # Mosaic verification ("Slice sizes along tiled dimensions must be
-            # aligned to tiles"). 2944 is a multiple of 128 but only admits a
-            # 128-wide chunk; both must still produce correct results.
+            # Non-128-aligned hidden sizes — gpt-oss-120b-BF16 uses K=2880.
+            # The kernel pads x to K_pad (the next multiple of col_chunk) then
+            # slices the output back to [:, :K].  Both dtypes and
+            # topk_wgt_zero_nan variants must produce correct results and must
+            # run on the SC kernel (not silently fall through to _jax_fallback).
             itertools.product(
                 [32768],
-                [2880, 2944],
-                [jnp.bfloat16],
+                [2880, 2944, 2816, 3000],
+                [jnp.bfloat16, jnp.float32],
                 [4],
                 [False, True],
             ),
@@ -212,6 +210,49 @@ class DenseGatherReduceTest(jtu.JaxTestCase):
         )
         self.assertTrue(jnp.isnan(actual_with_nan).any())
 
+    @parameterized.named_parameters(
+        ("k2880_bf16", 2880, jnp.bfloat16),
+        ("k3000_bf16", 3000, jnp.bfloat16),
+        ("k2944_bf16", 2944, jnp.bfloat16),
+        ("k2816_bf16", 2816, jnp.bfloat16),
+        ("k2880_f32", 2880, jnp.float32),
+    )
+    def test_sc_path_taken_for_arbitrary_hidden_size(self, hidden_size, dtype):
+        """SC kernel is used (not _jax_fallback) for these hidden sizes.
+
+        Uses out_size=65536 (not in _test_cases, so the JIT cache is cold) and
+        monkeypatches _jax_fallback to raise under NORMAL JIT (no disable_jit
+        — Pallas kernels require JIT and crash under disable_jit). A re-traced
+        call that routes to _jax_fallback would raise AssertionError, proving
+        the SC kernel is always selected for compatible inputs.
+        """
+        # out_size=65536 is a multiple of row_wave_size=32768 and is NOT used
+        # in _test_cases, so dense_gather_reduce re-traces for this shape.
+        out_size = 65536
+        reduce_group_size = 4
+        key = jax.random.key(0)
+        x = jax.random.normal(key, (out_size, hidden_size),
+                              jnp.float32).astype(dtype)
+        indices = jax.random.permutation(key, out_size)
+        topk_weights = jax.random.normal(
+            key, (out_size // reduce_group_size, reduce_group_size),
+            jnp.bfloat16)
+
+        orig = dgr_mod._jax_fallback
+        dgr_mod._jax_fallback = lambda *a, **kw: (_ for _ in ()).throw(
+            AssertionError(
+                f"_jax_fallback called for hidden_size={hidden_size}; "
+                "expected SC kernel path (is_compatible should be True)"))
+        try:
+            actual = dense_gather_reduce(x, indices, topk_weights,
+                                         reduce_group_size)
+        finally:
+            dgr_mod._jax_fallback = orig
+
+        desired = reference_dense_gather_reduce(x, indices, topk_weights,
+                                                reduce_group_size)
+        np.testing.assert_allclose(actual, desired, atol=1e-2, rtol=1e-2)
+
     def test_debug_layout(self):
         out_size = 520
         hidden_size = 8192
@@ -280,6 +321,64 @@ class IsCompatibleTest(parameterized.TestCase):
             self.assertEqual(
                 is_compatible(op, idx, reduce_group_size=reduce_group_size),
                 expected)
+
+
+class ColChunkComputationTest(parameterized.TestCase):
+    """Hardware-independent tests for the _choose_col_chunk policy.
+
+    Exercises the production _choose_col_chunk() directly (no TPU needed) over
+    representative model hidden sizes and structural invariants. The 128-aligned
+    cases pin the pre-change behavior (same col_chunk, K_pad == K, no padding) so
+    a future policy edit that regresses an existing model fails here; the
+    non-128-aligned cases pin the new padded fast path (e.g. gpt-oss K=2880).
+    """
+
+    # (K, expected_col_chunk, expected_K_pad).
+    # 128-aligned K: OLD while-loop col_chunk, K_pad == K (zero padding).
+    # Non-128-aligned K: new align_to/cdiv policy, K_pad > K.
+    _cases = [
+        (128, 128, 128),  # 128-aligned, unchanged
+        (512, 512, 512),  # 128-aligned, unchanged
+        (2816, 1408, 2816),  # 128-aligned, unchanged (while-loop: 1408)
+        (2944, 128, 2944),  # 128-aligned, unchanged (while-loop: 128)
+        (3072, 1536, 3072),  # 128-aligned, unchanged
+        (4096, 2048, 4096),  # 128-aligned, unchanged
+        (5120, 1280, 5120),  # 128-aligned, unchanged (while-loop: 1280)
+        (6144, 2048, 6144),  # 128-aligned, unchanged
+        (7168, 1792, 7168),  # 128-aligned, unchanged
+        (8192, 2048, 8192),  # 128-aligned, unchanged
+        (11008, 256, 11008),  # 128-aligned, unchanged (while-loop: 256)
+        (13824, 1536, 13824),  # 128-aligned, unchanged (while-loop: 1536)
+        (2880, 1536, 3072),  # non-128-aligned: pad 192 — gpt-oss-120b-BF16
+        (3000, 1536, 3072),  # non-128-aligned: pad 72
+    ]
+
+    @parameterized.named_parameters(
+        (f"k{K}", K, cc, kp) for K, cc, kp in _cases)
+    def test_col_chunk_policy(self, K, expected_col_chunk, expected_K_pad):
+        col_chunk, K_pad = dgr_mod._choose_col_chunk(K)
+        self.assertEqual(
+            col_chunk, expected_col_chunk,
+            f"K={K}: col_chunk={col_chunk}, want {expected_col_chunk}")
+        self.assertEqual(K_pad, expected_K_pad,
+                         f"K={K}: K_pad={K_pad}, want {expected_K_pad}")
+
+    def test_invariants_for_all_k(self):
+        """Structural invariants hold for all K in 1..16384."""
+        for K in range(1, 16385):
+            col_chunk, K_pad = dgr_mod._choose_col_chunk(K)
+            self.assertGreaterEqual(K_pad, K, f"K={K}: K_pad={K_pad} < K")
+            self.assertEqual(col_chunk % 128, 0,
+                             f"K={K}: col_chunk={col_chunk} not 128-aligned")
+            self.assertEqual(
+                K_pad % col_chunk, 0,
+                f"K={K}: K_pad={K_pad} not divisible by col_chunk={col_chunk}")
+            self.assertGreater(col_chunk, 0,
+                               f"K={K}: col_chunk=0 (no valid chunk found)")
+            # For 128-aligned K, the surgical fix guarantees K_pad == K.
+            if K % 128 == 0:
+                self.assertEqual(
+                    K_pad, K, f"K={K} is 128-aligned but K_pad={K_pad} != K")
 
 
 if __name__ == "__main__":

--- a/tpu_inference/kernels/sparse_core/dense_gather_reduce.py
+++ b/tpu_inference/kernels/sparse_core/dense_gather_reduce.py
@@ -28,6 +28,11 @@ from jax.experimental.pallas import tpu as pltpu
 from jax.experimental.pallas import tpu_sc as plsc
 
 
+def align_to(x, a):
+    """Ceiling-align x to a multiple of a (mirrors gmm_v2.align_to)."""
+    return ((x + a - 1) // a) * a
+
+
 def is_compatible(
     op: jax.Array,
     idx: jax.Array,
@@ -267,6 +272,37 @@ def _jax_fallback(x,
     return out.astype(x.dtype)
 
 
+def _choose_col_chunk(hidden_size: int) -> tuple[int, int]:
+    """Pick the SC column-chunk width and padded hidden size for the kernel.
+
+    The kernel slices the operand along the hidden (column) dimension, which
+    carries a 128-wide lane tile in the HBM layout (#tpu.tiled<(4, 128)>).
+    Mosaic requires every column chunk to be a multiple of that 128 tile, else
+    it rejects the tpu.memref_slice at compile time with "Slice sizes along
+    tiled dimensions must be aligned to tiles".
+
+    Returns (col_chunk, hidden_pad):
+    - hidden_size % 128 == 0: pick the largest 128-multiple <= min(2048,
+      hidden_size) that divides hidden_size exactly. No padding
+      (hidden_pad == hidden_size). This reproduces the original selection for
+      every 128-aligned model, so existing models see no behavior change.
+    - hidden_size % 128 != 0 (e.g. gpt-oss-120b-BF16 hidden_size=2880): no
+      128-multiple divides it, so pad up to hidden_pad = num_chunks * col_chunk
+      (col_chunk a 128-multiple). The caller runs the kernel over hidden_pad
+      columns then slices the output back to [:, :hidden_size]; padded columns
+      are zero and, since columns are independent in the gather-reduce, do not
+      affect the real columns.
+    """
+    if hidden_size % 128 == 0:
+        col_chunk = (min(2048, hidden_size) // 128) * 128
+        while hidden_size % col_chunk != 0:
+            col_chunk -= 128
+        return col_chunk, hidden_size
+    num_chunks = align_to(hidden_size, 2048) // 2048  # cdiv(hidden_size, 2048)
+    col_chunk = align_to((hidden_size + num_chunks - 1) // num_chunks, 128)
+    return col_chunk, num_chunks * col_chunk
+
+
 @jax.jit(static_argnames=("reduce_group_size", "topk_wgt_zero_nan"))
 def dense_gather_reduce(
     x: jax.Array,
@@ -290,31 +326,19 @@ def dense_gather_reduce(
   """
     if is_compatible(x, indices, reduce_group_size):
         K = x.shape[-1]
-        # The kernel slices the operand along the hidden (column) dimension,
-        # which carries a 128-wide lane tile in the HBM layout
-        # (#tpu.tiled<(4, 128)>). A column chunk that is not a multiple of 128
-        # produces a tpu.memref_slice whose size along the tiled dimension is
-        # not tile-aligned, which Mosaic rejects at compile time with
-        # "Slice sizes along tiled dimensions must be aligned to tiles" (e.g.
-        # hidden_size=2880 -> chunk 1440, and 1440 % 128 = 32). Require the
-        # chunk to be a multiple of the 128 lane tile; when 128 does not divide
-        # hidden_size (as for gpt-oss's 2880) no valid chunk exists and we fall
-        # back to the JAX implementation below.
-        col_chunk_size = (min(2048, K) // 128) * 128
-        while col_chunk_size > 0:
-            if K % col_chunk_size == 0:
-                break
-            col_chunk_size -= 128
-        if col_chunk_size > 0:
-            # Pallas kernel expects 1D weights
-            return _sc_gather_reduce(
-                x,
-                indices,
-                topk_weights.reshape(-1),
-                reduce_group_size=reduce_group_size,
-                col_chunk_size=col_chunk_size,
-                topk_wgt_zero_nan=topk_wgt_zero_nan,
-            )
+        # Pick a 128-tile-aligned column chunk; pad the hidden dim up to K_pad
+        # only when K itself is not 128-aligned (see _choose_col_chunk).
+        col_chunk, K_pad = _choose_col_chunk(K)
+        x_in = jnp.pad(x, ((0, 0), (0, K_pad - K))) if K_pad > K else x
+        out = _sc_gather_reduce(
+            x_in,
+            indices,
+            topk_weights.reshape(-1),
+            reduce_group_size=reduce_group_size,
+            col_chunk_size=col_chunk,
+            topk_wgt_zero_nan=topk_wgt_zero_nan,
+        )
+        return out[:, :K]
     # Fallback to JAX baseline
     return _jax_fallback(x, indices, topk_weights, reduce_group_size,
                          topk_wgt_zero_nan)


### PR DESCRIPTION
## Summary
`dense_gather_reduce` (the SparseCore MoE gather-reduce kernel) requires the hidden size `K` to admit a 128-tile-aligned column chunk. When none exists — e.g. **gpt-oss-120b-BF16** with `K=2880` — #3038 made it fall back to the slower JAX baseline, because Mosaic rejects a non-128-aligned column chunk with `Slice sizes along tiled dimensions must be aligned to tiles`.

This PR keeps the SparseCore fast path for those sizes by **padding the hidden dimension** up to the next multiple of the column chunk, running the kernel over `K_pad` columns, then slicing the output back to `[:, :K]`. Padded columns are zero and, because columns are independent in the gather-reduce (`out[:, k] = Σ_group op[idx, k]·w`), they do not affect the real columns — the result is exact.

## No regression for existing models
The column-chunk policy is **surgical**: for 128-aligned `K` it reproduces the previous chunk selection exactly with **zero padding**, so every existing model is byte-for-byte unchanged. Padding applies *only* to sizes that previously fell back (non-128-aligned `K`).

Verified on tpu7x-8 (jax 0.10.2) by intercepting the kernel call for a sweep of real hidden sizes — 3072 / 4096 / **5120** / 6144 / 7168 / 8192 / **11008** / **13824** / 18944 / 2944 / 2816 all keep their original `col_chunk` and `K_pad == K` (no padding); only 2880 / 3000 pad.

## Validation
- **Correctness (exact):** `K=2880` (bf16 + f32) runs on the SparseCore kernel — with `_jax_fallback` patched to raise, proving the kernel path is taken (not a silent fallback) — and `max|Δ vs reference| = 0`.
- **Latency (vs the JAX fallback it replaces):** `K=2880` 0.77 ms vs 1.23 ms → **1.6× faster** (median of 40 iters, out_size=32768).
- **Unit tests:** new non-128-aligned shape cases assert the SparseCore path is taken; a hardware-independent policy test pins both the preserved 128-aligned selections and the new padded sizes. Full suite: **94 passed**.

## Relationship to #3038
#3038 added the `% 128` JAX fallback so these cases stop erroring. This PR supersedes that fallback for non-128-aligned `K` by keeping them on the SparseCore kernel.
