### PR TITLE
A few improvements for jax/xla cache

### DIFF
--- a/.buildkite/scripts/run_in_docker.sh
+++ b/.buildkite/scripts/run_in_docker.sh
@@ -138,7 +138,7 @@ fi
 echo "[INFO] Pulling JAX Cache from GCS to local directory..."
 # Parallel CI builds‘ pushes are safe because JAX's compilation cache 
 # entries are content-addressed. Concurrent pushes are thus idempotent;
-gsutil -m rsync -d -r "$FINAL_CACHE_PATH" "$LOCAL_JAX_CACHE_DIR" || echo "[WARN] Failed to pull JAX Cache from GCS. Proceeding with cold start."
+gcloud storage rsync --recursive --delete-unmatched-destination-objects "$FINAL_CACHE_PATH" "$LOCAL_JAX_CACHE_DIR" --no-user-output-enabled || echo "[WARN] Failed to pull JAX Cache from GCS. Proceeding with cold start."
 
 # ==========================================
 # 2. Run Docker Container
@@ -200,7 +200,11 @@ set -e
 # ==========================================
 echo "[INFO] Docker finished with exit code ${DOCKER_EXIT_CODE}."
 
-echo "[INFO] Syncing local JAX Cache back to GCS..."
-gsutil -m rsync -r "$LOCAL_JAX_CACHE_DIR" "$FINAL_CACHE_PATH" || echo "[WARN] Failed to sync JAX Cache back to GCS."
+if [ $DOCKER_EXIT_CODE -eq 0 ]; then
+  echo "[INFO] Syncing local JAX Cache back to GCS..."
+  gcloud storage rsync --recursive "$LOCAL_JAX_CACHE_DIR" "$FINAL_CACHE_PATH" --no-user-output-enabled || echo "[WARN] Failed to sync JAX Cache back to GCS."
+else
+  echo "[WARN] Docker exited with non-zero code ${DOCKER_EXIT_CODE}. Skipping syncing local JAX Cache back to GCS to avoid potential cache corruption."
+fi
 
 exit $DOCKER_EXIT_CODE


### PR DESCRIPTION
1. When trying to debug an issue, I noticed our buildkite logs has been spammed with 
```
Copying file:///mnt/disks/persist/tpu_jax_cache/jax0.10.2_tputpu7x/jit_stage-92bc67b5d2f2741355ad0edab5ca06b6307d29f71ea09ef7949a2197a8318a8d-cache [Content-Type=application/octet-stream]...
--
  | Copying file:///mnt/disks/persist/tpu_jax_cache/jax0.10.2_tputpu7x/jit_stage-6e37b1b2dde5c0b40e46f92109af3a3a9b9961cf5406fcc5167d1908a02a1fd6-cache [Content-Type=application/octet-stream]...
  | Copying file:///mnt/disks/persist/tpu_jax_cache/jax0.10.2_tputpu7x/jit_stage-93f6bdb35e43349a324ef78ed91ca28b9c070c47e83230108976486e486f5845-cache [Content-Type=application/octet-stream]...
  | Copying file:///mnt/disks/persist/tpu_jax_cache/jax0.10.2_tputpu7x/jit_stage-95531097535d3e1e084ff56e8309426b7af4215d7b8dedbdab42b37a0f125a2a-cache [Content-Type=application/octet-stream]...
```
This is because when doing an rsync, it will output a log for every successful file sync and we have tens of thousands of them. Let's disable that as it's unlikely we will read through them

2. As we do this, taking the opportunity to migrate to `gcloud storage` which is claimed to be faster for multiple smaller files.
3. Don't sync bad the cache if the docker run failed as the cache compile in this process could be corrupted. 

Signed-off-by: Ming Huang <mhhua@google.com>

# Description

Start with a short description of what the PR does and how this is a change from
the past.

The rest of the description includes relevant details and context, examples:
- why is this change being made,
- the problem being solved and any relevant context,
- why this is a good solution,
- some information about the specific implementation,
- shortcomings of the solution and possible future improvements.

If the change fixes a Github issue, please include a link, e.g.,:
FIXES: #123456

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
