### PR TITLE
Fix the dependsOn for the notify_test_result step

### DIFF
--- a/.buildkite/nightly_verify.yml
+++ b/.buildkite/nightly_verify.yml
@@ -85,7 +85,10 @@ steps:
    - label: "Notify test results"
      <<: *run-on-nightly-or-tag
      key: notify_test_results
-     depends_on: commit_support_matrices
+     depends_on: 
+       - "commit_support_matrices"
+       - "v6_generate_matrices"
+       - "v7_generate_matrices"
      agents:
        queue: cpu
      commands:

--- a/.buildkite/scripts/generate_support_matrices.sh
+++ b/.buildkite/scripts/generate_support_matrices.sh
@@ -305,7 +305,7 @@ if [ ${#metadata_feature_list[@]} -gt 0 ]; then
     process_features "METADATA" "${metadata_feature_list[@]}"
 fi
 
-buildkite-agent meta-data set "CI_TESTS_FAILED" "${ANY_FAILED}"
+buildkite-agent meta-data set "${TPU_METADATA_PREFIX}_CI_TESTS_FAILED" "${ANY_FAILED}"
 
 # Model support matrices
 for csv_file in "${model_csv_files[@]:-}"; do

--- a/.buildkite/scripts/notify_test_results.sh
+++ b/.buildkite/scripts/notify_test_results.sh
@@ -15,12 +15,13 @@
 
 set -e
 
-ANY_FAILED=$(buildkite-agent meta-data get "CI_TESTS_FAILED")
+V6_ANY_FAILED=$(buildkite-agent meta-data get "v6_CI_TESTS_FAILED")
+V7_ANY_FAILED=$(buildkite-agent meta-data get "v7_CI_TESTS_FAILED")
 FAILURE_LABEL="Not all models and/or features passed"
 
 echo "--- Checking test outcomes"
 
-if [ "${ANY_FAILED}" = "true" ] ; then
+if [ "${V6_ANY_FAILED}" = "true" ] || [ "${V7_ANY_FAILED}" = "true" ] ; then
   echo "${FAILURE_LABEL}"
   exit 1
 else


### PR DESCRIPTION
# Description

Add `v6_generate_matrices` and `v7_generate_matrices` as `dependsOn` for `notify_test_result` so that it won't execute immediately when `commit_support_matrices` is not triggered.

Additionally, set `CI_TESTS_FAILED` separately for v6 and v7 to prevent potential overwriting issues.

# Tests

[Buildkite Test Build](https://buildkite.com/tpu-commons/tpu-inference-ci/builds/21471)

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
