### PR TITLE
[WIP] Serve externally-registered torch.nn.Module models on TPU (KerasHub adapter) 

### DIFF
--- a/tpu_inference/layers/common/attention_interface.py
+++ b/tpu_inference/layers/common/attention_interface.py
@@ -383,6 +383,7 @@ def sharded_ragged_paged_attention(
     q_scale: float | None = None,
     k_scale: float | None = None,
     v_scale: float | None = None,
+    soft_cap: float | None = None,
     update_kv_cache: bool = True,
 ):
     """Shards along KV heads."""
@@ -441,6 +442,7 @@ def sharded_ragged_paged_attention(
         kwargs = dict(
             sm_scale=sm_scale,
             sliding_window=attention_chunk_size,
+            soft_cap=soft_cap,
             q_scale=q_scale,
             k_scale=k_scale,
             v_scale=v_scale,
@@ -475,6 +477,7 @@ def attention(
     k_scale: float | None = None,
     v_scale: float | None = None,
     sinks: jax.Array | None = None,
+    soft_cap: float | None = None,
     update_kv_cache: bool = True,
 ) -> Tuple[jax.Array, jax.Array]:
     # T: seq_len
@@ -514,6 +517,7 @@ def attention(
         q_scale=q_scale,
         k_scale=k_scale,
         v_scale=v_scale,
+        soft_cap=soft_cap,
         update_kv_cache=update_kv_cache,
     )
 

--- a/tpu_inference/layers/vllm/backends/flash_attn.py
+++ b/tpu_inference/layers/vllm/backends/flash_attn.py
@@ -330,6 +330,7 @@ def _format_attention_output(
         "k_scale",
         "v_scale",
         "sliding_window",
+        "soft_cap",
     ),
     donate_argnames=("kv_cache"),
 )
@@ -349,6 +350,7 @@ def _jax_attn_func(
     k_scale: float | None = None,
     v_scale: float | None = None,
     sliding_window: int | None = None,
+    soft_cap: float | None = None,
 ) -> Tuple[jax.Array, jax.Array]:
     q_len = q.shape[0]
     q, k, v = _prepare_qkv_layout(q, k, v, num_heads, num_kv_heads, head_size)
@@ -366,6 +368,7 @@ def _jax_attn_func(
         v_scale=v_scale,
         sinks=sinks,
         attention_chunk_size=sliding_window,
+        soft_cap=soft_cap,
     )
 
     formatted_outputs = _format_attention_output(outputs, q_len, num_heads,

--- a/tpu_inference/models/common/model_loader.py
+++ b/tpu_inference/models/common/model_loader.py
@@ -105,6 +105,10 @@ def _get_model_architecture(config: PretrainedConfig) -> nnx.Module:
     for arch in architectures:
         if arch in _MODEL_REGISTRY:
             return _MODEL_REGISTRY[arch]
+        if arch == "KerasVLLMAdapter":
+            from keras_hub.src.vllm.adapter import KerasVLLMAdapter
+            _MODEL_REGISTRY[arch] = KerasVLLMAdapter
+            return KerasVLLMAdapter
     raise UnsupportedArchitectureError(
         f"Model architectures {architectures} not "
         "registered in tpu-inference. Falling back to vLLM-native "

--- a/tpu_inference/models/vllm/vllm_model_wrapper.py
+++ b/tpu_inference/models/vllm/vllm_model_wrapper.py
@@ -436,6 +436,14 @@ class VllmModelWrapper:
                     self.model, lora_metadata, self.vllm_config.lora_config)
                 if not is_first_rank:
                     intermediate_tensors = intermediate_tensors.to_torch()
+
+                # Inject the Pallas Paged Attention kernel into the metadata so
+                # the KerasHub adapter can extract it dynamically.
+                if not hasattr(attn_metadata, "paged_attention_func"):
+                    from tpu_inference.layers.vllm.backends.flash_attn import \
+                        _jax_attn_func
+                    attn_metadata.paged_attention_func = _jax_attn_func
+
                 output_from_torch = torch.func.functional_call(
                     self.model,
                     torch_view(params_and_buffers),


### PR DESCRIPTION
# Description

Adds three minimal, **additive** hooks so `tpu-inference` can serve an externally registered `torch.nn.Module` model, specifically KerasHub's `KerasVLLMAdapter`, on the vLLM/torchax path, and forward an optional logit `soft_cap` to the RPA kernels. 

- **Why / problem:** the TPU model loader only recognizes built-in architectures, so an externally registered model can't be served without forking the loader; and the RPA dispatch drops `soft_cap`, so soft-capped models (Gemma 2/3) can't be run correctly through it.
- **Why this is a good solution:** all three changes are additive and **no-ops for existing models** (`soft_cap` defaults to `None`; the registry branch only fires for the `KerasVLLMAdapter` architecture name). (1)/(2) make the backend extensible to *any* vLLM-registered model; (3) is a general fix , the dispatch should forward `soft_cap` for any soft-capped model.
- **Implementation:**
  | File | Δ | Adds |
  |---|---|---|
  | `models/common/model_loader.py` | +4 | recognize architecture `"KerasVLLMAdapter"` and return it (skip the HF/PyTorch fallback) |
  | `models/vllm/vllm_model_wrapper.py` | +8 | inject the Pallas attention fn (`_jax_attn_func`) onto attn metadata before forward |
  | `layers/common/attention_interface.py` | +4 | thread optional `soft_cap` through `attention()` |
  | `layers/vllm/backends/flash_attn.py` | +3 | forward `soft_cap` into `sharded_ragged_paged_attention` (Gemma 2/3) |

Roadmap:
- [x] Recognize `KerasVLLMAdapter` architecture in the model loader
- [x] Inject the Pallas paged-attention kernel (`_jax_attn_func`) into attn metadata
- [x] Thread `soft_cap` through the RPA dispatch (Gemma 2/3)

Companion model-side PR: `keras-team/keras-hub` adding `keras_hub/src/vllm/` (adapter, context, bridge, registry, guarded attention hooks).

# Tests

- **End-to-end on TPU v6e:** KerasHub `gpt2_large_en` / `gemma_2b_en` served through these hooks via vLLM's native paged attention, coherent output, next-token-exact vs native KerasHub (bf16). Reproduce:`colab_test.ipynb`.
- **A/B/C benchmarks** (`colab_benchmark.ipynb`, `gpt2_large_en`, TPU v6e, bf16): the integration (C) matches vLLM-native (B) on throughput/latency/TTFT (**C/B ≈ 0.98–1.00×**, i.e. no measurable overhead from serving a KerasHub model through these hooks) and beats pure Keras (A) under concurrent/long-context load (2.4–9×, and serves loads where pure Keras OOMs).
- **No regression for existing models:** changes are guarded (`soft_cap=None`, arch-name-gated registry branch), so built-in flax/native and vLLM-path models are unaffected.

# Checklist

Before submitting this PR, please make sure:
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have made or will make corresponding changes to any relevant documentation.
