### PR TITLE
[Torchax] Add compressed_tensor w4a4_nvfp4 support

### DIFF
--- a/tests/layers/vllm/nvfp4_utils.py
+++ b/tests/layers/vllm/nvfp4_utils.py
@@ -1,0 +1,98 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import torch
+from torchax.ops.mappings import t2j
+
+# NVFP4 block size (elements per scale group).
+NVFP4_GROUP_SIZE = 16
+
+
+def quantize_to_nvfp4(weight: torch.Tensor,
+                      group_size: int = NVFP4_GROUP_SIZE):
+    """Quantize a float32 weight to NVFP4 format (packed uint8 + scales).
+
+    Returns:
+        weight_packed: uint8 [out, in//2]
+        weight_scale: float8_e4m3fn [out, in//group_size]
+        weight_global_scale: float32 scalar
+    """
+    assert weight.ndim == 2
+    out_size, in_size = weight.shape
+    assert in_size % group_size == 0
+
+    # Use JAX for FP4 quantization since torch doesn't have native FP4.
+    w_jax = t2j(weight.float())
+
+    # Compute per-block scales.
+    num_blocks = in_size // group_size
+    w_blocked = w_jax.reshape(out_size, num_blocks, group_size)
+    block_abs_max = jnp.max(jnp.abs(w_blocked), axis=2, keepdims=True)
+
+    fp4_max = float(jnp.finfo(jnp.float4_e2m1fn).max)
+    block_scale = block_abs_max / fp4_max  # [out, num_blocks, 1]
+    block_scale = jnp.where(block_scale == 0, 1.0, block_scale)
+
+    # Compute global scale: max of all block scales.
+    global_scale = jnp.max(block_scale)
+
+    # Effective block scale = block_scale / global_scale (stored as FP8).
+    effective_scale = (block_scale / global_scale).astype(jnp.float8_e4m3fn)
+
+    # Quantize to FP4.
+    scale_inv = jnp.where(block_scale == 0, 0.0, 1.0 / block_scale)
+    w_q = jnp.clip(w_blocked * scale_inv, -fp4_max,
+                   fp4_max).astype(jnp.float4_e2m1fn)
+    w_q = w_q.reshape(out_size, in_size)
+
+    # Pack FP4 into uint8 (2 values per byte).
+    w_packed = w_q.reshape(out_size, in_size // 2, 2)
+    w_packed = jax.lax.bitcast_convert_type(w_packed, jnp.uint8)
+
+    effective_scale = effective_scale.reshape(out_size, num_blocks)
+
+    # Convert via numpy to avoid j2t FP8 dtype issues.
+    w_packed_t = torch.from_numpy(np.asarray(w_packed))
+    scale_t = torch.from_numpy(np.asarray(effective_scale).view(
+        np.uint8)).view(torch.float8_e4m3fn)
+    global_t = torch.tensor(float(global_scale), dtype=torch.float32)
+    return (w_packed_t, scale_t, global_t)
+
+
+def ref_dequant_nvfp4(weight_packed, weight_scale, global_scale, group_size):
+    """Reference dequantization: unpack → float32 using block_scale * global."""
+    w_jax = jnp.array(weight_packed.numpy())
+    # FP8 scale: go through uint8 view to avoid dtype conversion issues.
+    s_np = weight_scale.view(torch.uint8).numpy()
+    s_jax = jax.lax.bitcast_convert_type(jnp.array(s_np), jnp.float8_e4m3fn)
+    g_jax = jnp.float32(global_scale.item())
+
+    # Unpack uint8 → float4_e2m1fn.
+    e2m1 = jax.lax.bitcast_convert_type(w_jax, jnp.float4_e2m1fn)
+    fp4 = jnp.reshape(e2m1, e2m1.shape[:-2] + (-1, ))
+
+    # Fold scales.
+    eff_scale = s_jax.astype(jnp.float32) * g_jax
+    out_size = fp4.shape[0]
+    in_size = fp4.shape[1]
+    num_blocks = in_size // group_size
+
+    fp4_blocked = fp4.reshape(out_size, num_blocks, group_size)
+    scale_expanded = eff_scale.reshape(out_size, num_blocks, 1)
+    deq = (fp4_blocked.astype(jnp.float32) * scale_expanded).reshape(
+        out_size, in_size)
+    return torch.from_numpy(np.asarray(deq))

--- a/tests/layers/vllm/test_compressed_tensors_w4a4_nvfp4.py
+++ b/tests/layers/vllm/test_compressed_tensors_w4a4_nvfp4.py
@@ -1,0 +1,387 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import tempfile
+from unittest.mock import MagicMock, patch
+
+import jax
+import pytest
+import torch
+import torchax
+from jax.sharding import PartitionSpec
+from torchax.interop import torch_view
+from torchax.ops.mappings import j2t, t2j
+from vllm.config import set_current_vllm_config
+from vllm.distributed.parallel_state import (ensure_model_parallel_initialized,
+                                             init_distributed_environment)
+from vllm.engine.arg_utils import EngineArgs
+from vllm.model_executor.layers.linear import (ColumnParallelLinear,
+                                               LinearBase,
+                                               MergedColumnParallelLinear,
+                                               QKVParallelLinear,
+                                               RowParallelLinear)
+from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tensors import \
+    CompressedTensorsLinearMethod
+
+from tests.layers.common import utils as test_utils
+from tests.layers.vllm.nvfp4_utils import (NVFP4_GROUP_SIZE, quantize_to_nvfp4,
+                                           ref_dequant_nvfp4)
+from tpu_inference.layers.vllm.quantization import get_tpu_quantization_config
+from tpu_inference.layers.vllm.quantization.compressed_tensors.schemes.compressed_tensors_w4a4_nvfp4 import \
+    VllmCompressedTensorsW4A4Fp4
+from tpu_inference.layers.vllm.quantization.configs import \
+    VllmQuantLinearConfig
+
+P = PartitionSpec
+
+torch.manual_seed(42)
+
+MODELS = [
+    "nm-testing/SmolLM-1.7B-Instruct-quantized.w4a16",
+]
+
+
+def override_activation_quant_config(vllm_config):
+    vllm_config.model_config.hf_config.quantization_config = {
+        "quant_method": "compressed-tensors",
+        "format": "float-quantized",
+        "config_groups": {
+            "group_0": {
+                "targets": ["Linear"],
+                "weights": {
+                    "num_bits": 4,
+                    "type": "float",
+                    "symmetric": True,
+                    "strategy": "tensor_group",
+                    "group_size": 16,
+                },
+                "input_activations": {
+                    "num_bits": 4,
+                    "type": "float",
+                    "symmetric": True,
+                    "strategy": "tensor_group",
+                    "group_size": 16,
+                    "dynamic": True,
+                }
+            }
+        }
+    }
+    vllm_config.model_config.hf_text_config.quantization_config = vllm_config.model_config.hf_config.quantization_config
+
+
+def initialize_layer_weights(layer: torch.nn.Module,
+                             use_a16: bool = True) -> torch.Tensor:
+    assert isinstance(layer, LinearBase)
+    scheme = layer.scheme
+    assert isinstance(scheme, VllmCompressedTensorsW4A4Fp4)
+    quant_config = scheme.linear_config
+    assert isinstance(quant_config, VllmQuantLinearConfig)
+
+    group_size = getattr(scheme, "group_size", NVFP4_GROUP_SIZE)
+
+    weight_list = []
+    weight_ref_list = []
+    weight_scale_list = []
+    weight_global_scale_list = []
+
+    for output_size in quant_config.output_sizes:
+        weight = torch.randn(
+            (output_size, layer.input_size), dtype=torch.float32) / 10
+
+        packed_weight, scale_t, global_scale = quantize_to_nvfp4(
+            weight, group_size=group_size)
+
+        weight_list.append(packed_weight)
+        weight_scale_list.append(scale_t)
+        # Note: the scheme expects 1/global_scale since it computes 1/layer.weight_global_scale.max()
+        weight_global_scale_list.append(
+            torch.tensor([1.0 / global_scale], dtype=torch.float32))
+
+        weight_ref = ref_dequant_nvfp4(packed_weight, scale_t, global_scale,
+                                       group_size)
+        weight_ref_list.append(weight_ref)
+
+    weight_packed = torch.cat(weight_list)
+    weight_ref = torch.cat(weight_ref_list)
+    weight_scale = torch.cat(weight_scale_list)
+    weight_global_scale = torch.cat(weight_global_scale_list)
+
+    layer.weight_packed = torch.nn.Parameter(weight_packed,
+                                             requires_grad=False)
+    layer.weight_scale = torch.nn.Parameter(weight_scale, requires_grad=False)
+    layer.weight_global_scale = torch.nn.Parameter(weight_global_scale,
+                                                   requires_grad=False)
+
+    if not use_a16:
+        layer.input_global_scale = torch.nn.Parameter(torch.tensor(
+            [1.0], dtype=torch.float32),
+                                                      requires_grad=False)
+
+    if layer.bias is not None:
+        layer.bias.data = torch.rand_like(layer.bias.data)
+    return weight_ref
+
+
+def return_ref_and_layer_output(layer: torch.nn.Module,
+                                use_a16: bool = True,
+                                batch_size: int = 16):
+
+    weight_ref = initialize_layer_weights(layer, use_a16=use_a16)
+    assert isinstance(layer, LinearBase)
+    scheme = layer.scheme
+    assert isinstance(scheme, VllmCompressedTensorsW4A4Fp4)
+    quant_config = scheme.linear_config
+    assert isinstance(quant_config, VllmQuantLinearConfig)
+    quant_method = layer.quant_method
+    assert isinstance(quant_method, CompressedTensorsLinearMethod)
+
+    input_tensor = torch.randn(
+        batch_size, layer.input_size, dtype=torch.bfloat16) / 10
+    input_tensor = input_tensor.to('cpu')
+
+    # Run reference implementation
+    if not use_a16:
+        # Quantize activation to FP4
+        # Since use_a16=False tests FP4xFP4, we need to quantize the activation
+        # However, TPU does not natively support FP4xFP4 and raises an error
+        # So we skip actual activation quantization in reference for now
+        pass
+
+    # Just do a bfloat16 matmul with dequantized weights for reference
+    ref_output = torch.einsum('bd,fd->bf', input_tensor.to(torch.float32),
+                              weight_ref)
+    if layer.bias is not None:
+        ref_output += layer.bias.float()
+    ref_output = ref_output.to(torch.bfloat16)
+
+    # Run torchax/jax function
+    with torchax.default_env():
+        quant_method.process_weights_after_loading(layer)
+
+        jax_input_tensor = torch_view(t2j(input_tensor, use_dlpack=False))
+        layer_output = layer(jax_input_tensor)
+        layer_output = j2t(layer_output.to(torch.float32)).to(torch.bfloat16)
+
+    return ref_output, layer_output
+
+
+@pytest.fixture(autouse=True)
+def mock_get_pp_group():
+    with patch("tpu_inference.distributed.jax_parallel_state.get_pp_group",
+               return_value=MagicMock(is_first_rank=True,
+                                      is_last_rank=True,
+                                      rank_in_group=0,
+                                      world_size=1)):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def setup_environment():
+    # This is a fake config used for init dist env.
+    engine_args = EngineArgs(
+        model=MODELS[0],
+        max_model_len=64,
+        max_num_batched_tokens=64,
+        max_num_seqs=4,
+    )
+
+    vllm_config = engine_args.create_engine_config()
+
+    with set_current_vllm_config(vllm_config):
+        temp_file = tempfile.mkstemp()[1]
+        init_distributed_environment(
+            1,
+            0,
+            local_rank=0,
+            distributed_init_method=f"file://{temp_file}",
+            backend="gloo")
+        ensure_model_parallel_initialized(1, 1)
+
+
+@pytest.mark.parametrize("bias", [False, True])
+@pytest.mark.parametrize("num_devices", [1, min(4, jax.local_device_count())])
+@pytest.mark.parametrize("enable_sp", [False, True])
+@pytest.mark.parametrize("enable_attn_dp", [False, True])
+@pytest.mark.parametrize("model", MODELS)
+@pytest.mark.parametrize("use_a16", [True])
+def test_row_parallel_linear(model, bias, num_devices, enable_sp,
+                             enable_attn_dp, use_a16):
+    if enable_attn_dp and num_devices < 2:
+        pytest.skip("enable_attn_dp requires at least 2 devices")
+
+    mesh = test_utils.get_spmd_mesh(num_devices, enable_attn_dp)
+    dtype = torch.bfloat16
+
+    engine_args = EngineArgs(
+        model=model,
+        max_model_len=64,
+        max_num_batched_tokens=64,
+        max_num_seqs=4,
+    )
+    vllm_config = engine_args.create_engine_config()
+    vllm_config.compilation_config.pass_config.enable_sp = enable_sp
+
+    override_activation_quant_config(vllm_config)
+
+    vllm_config.model_config.dtype = dtype
+    quant_config = get_tpu_quantization_config(vllm_config, mesh)
+    with set_current_vllm_config(vllm_config):
+        linear_layer = RowParallelLinear(
+            input_size=2048,
+            output_size=4096,
+            bias=bias,
+            params_dtype=dtype,
+            return_bias=False,
+            quant_config=quant_config,
+        )
+        linear_layer.scheme.use_a16 = use_a16
+
+    ref_output, layer_output = return_ref_and_layer_output(linear_layer,
+                                                           use_a16=use_a16)
+    torch.testing.assert_close(ref_output, layer_output, rtol=0.1, atol=0.35)
+
+
+@pytest.mark.parametrize("bias", [False, True])
+@pytest.mark.parametrize("num_devices", [1, min(4, jax.local_device_count())])
+@pytest.mark.parametrize("enable_sp", [False, True])
+@pytest.mark.parametrize("enable_attn_dp", [False, True])
+@pytest.mark.parametrize("model", MODELS)
+@pytest.mark.parametrize("use_a16", [True])
+def test_column_parallel_linear(model, bias, num_devices, enable_sp,
+                                enable_attn_dp, use_a16):
+    if enable_attn_dp and num_devices < 2:
+        pytest.skip("enable_attn_dp requires at least 2 devices")
+
+    mesh = test_utils.get_spmd_mesh(num_devices, enable_attn_dp)
+    dtype = torch.bfloat16
+
+    engine_args = EngineArgs(
+        model=model,
+        max_model_len=64,
+        max_num_batched_tokens=64,
+        max_num_seqs=4,
+    )
+    vllm_config = engine_args.create_engine_config()
+    vllm_config.compilation_config.pass_config.enable_sp = enable_sp
+
+    override_activation_quant_config(vllm_config)
+
+    vllm_config.model_config.dtype = torch.bfloat16
+    quant_config = get_tpu_quantization_config(vllm_config, mesh)
+    with set_current_vllm_config(vllm_config):
+        linear_layer = ColumnParallelLinear(
+            input_size=2048,
+            output_size=4096,
+            bias=bias,
+            params_dtype=dtype,
+            return_bias=False,
+            quant_config=quant_config,
+        )
+        linear_layer.scheme.use_a16 = use_a16
+
+    ref_output, layer_output = return_ref_and_layer_output(linear_layer,
+                                                           use_a16=use_a16)
+    torch.testing.assert_close(ref_output, layer_output, rtol=0.1, atol=0.35)
+
+
+@pytest.mark.parametrize("bias", [False, True])
+@pytest.mark.parametrize("num_devices", [1, min(4, jax.local_device_count())])
+@pytest.mark.parametrize("enable_sp", [False, True])
+@pytest.mark.parametrize("fuse_matmuls", [False, True])
+@pytest.mark.parametrize("enable_attn_dp", [False, True])
+@pytest.mark.parametrize("model", MODELS)
+@pytest.mark.parametrize("use_a16", [True])
+def test_qkv_parallel_linear(model, bias, num_devices, enable_sp, fuse_matmuls,
+                             enable_attn_dp, use_a16):
+    if enable_attn_dp and num_devices < 2:
+        pytest.skip("enable_attn_dp requires at least 2 devices")
+
+    mesh = test_utils.get_spmd_mesh(num_devices, enable_attn_dp)
+    dtype = torch.bfloat16
+
+    engine_args = EngineArgs(
+        model=model,
+        max_model_len=64,
+        max_num_batched_tokens=64,
+        max_num_seqs=4,
+    )
+    vllm_config = engine_args.create_engine_config()
+    vllm_config.compilation_config.pass_config.enable_sp = enable_sp
+
+    override_activation_quant_config(vllm_config)
+
+    vllm_config.model_config.dtype = torch.bfloat16
+    quant_config = get_tpu_quantization_config(vllm_config, mesh)
+    with set_current_vllm_config(vllm_config):
+        linear_layer = QKVParallelLinear(
+            hidden_size=2048,
+            head_size=128,
+            total_num_heads=16,
+            total_num_kv_heads=4,
+            bias=bias,
+            params_dtype=dtype,
+            return_bias=False,
+            quant_config=quant_config,
+        )
+        linear_layer.quant_method.fuse_matmuls = fuse_matmuls
+        linear_layer.scheme.use_a16 = use_a16
+
+    ref_output, layer_output = return_ref_and_layer_output(linear_layer,
+                                                           use_a16=use_a16)
+    torch.testing.assert_close(ref_output, layer_output, rtol=0.1, atol=0.35)
+
+
+@pytest.mark.parametrize("bias", [False, True])
+@pytest.mark.parametrize("num_devices", [1, min(4, jax.local_device_count())])
+@pytest.mark.parametrize("fuse_matmuls", [False, True])
+@pytest.mark.parametrize("enable_sp", [False, True])
+@pytest.mark.parametrize("enable_attn_dp", [False, True])
+@pytest.mark.parametrize("model", MODELS)
+@pytest.mark.parametrize("use_a16", [True])
+def test_merged_column_parallel_linear(model, bias, num_devices, fuse_matmuls,
+                                       enable_sp, enable_attn_dp, use_a16):
+    if enable_attn_dp and num_devices < 2:
+        pytest.skip("enable_attn_dp requires at least 2 devices")
+
+    mesh = test_utils.get_spmd_mesh(num_devices, enable_attn_dp)
+    dtype = torch.bfloat16
+
+    engine_args = EngineArgs(
+        model=model,
+        max_model_len=64,
+        max_num_batched_tokens=64,
+        max_num_seqs=4,
+    )
+    vllm_config = engine_args.create_engine_config()
+    vllm_config.compilation_config.pass_config.enable_sp = enable_sp
+
+    override_activation_quant_config(vllm_config)
+
+    vllm_config.model_config.dtype = dtype
+    quant_config = get_tpu_quantization_config(vllm_config, mesh)
+    with set_current_vllm_config(vllm_config):
+        linear_layer = MergedColumnParallelLinear(
+            input_size=2048,
+            output_sizes=[7168] * 2,
+            bias=bias,
+            params_dtype=dtype,
+            return_bias=False,
+            quant_config=quant_config,
+        )
+        linear_layer.quant_method.fuse_matmuls = fuse_matmuls
+        linear_layer.scheme.use_a16 = use_a16
+
+    ref_output, layer_output = return_ref_and_layer_output(linear_layer,
+                                                           use_a16=use_a16)
+    torch.testing.assert_close(ref_output, layer_output, rtol=0.1, atol=0.15)

--- a/tests/layers/vllm/test_nvfp4.py
+++ b/tests/layers/vllm/test_nvfp4.py
@@ -15,8 +15,6 @@
 
 import tempfile
 
-import jax
-import jax.numpy as jnp
 import numpy as np
 import pytest
 import torch
@@ -36,6 +34,8 @@ from vllm.model_executor.layers.linear import (ColumnParallelLinear,
                                                RowParallelLinear)
 
 from tests.layers.common import utils as test_utils
+from tests.layers.vllm.nvfp4_utils import (NVFP4_GROUP_SIZE, quantize_to_nvfp4,
+                                           ref_dequant_nvfp4)
 from tpu_inference.layers.common.quant_methods import NVFP4
 from tpu_inference.layers.vllm.quantization.nvfp4 import (VllmNvfp4Config,
                                                           VllmNvfp4MoEMethod)
@@ -45,85 +45,6 @@ P = PartitionSpec
 # NVFP4 uses FP4 MoE kernels only available on v7+.
 if not jtu.is_device_tpu_at_least(version=7):
     pytest.skip(allow_module_level=True, reason="Expected TPUv7+")
-
-# NVFP4 block size (elements per scale group).
-NVFP4_GROUP_SIZE = 16
-
-
-def quantize_to_nvfp4(weight: torch.Tensor,
-                      group_size: int = NVFP4_GROUP_SIZE):
-    """Quantize a float32 weight to NVFP4 format (packed uint8 + scales).
-
-    Returns:
-        weight_packed: uint8 [out, in//2]
-        weight_scale: float8_e4m3fn [out, in//group_size]
-        weight_global_scale: float32 scalar
-    """
-    assert weight.ndim == 2
-    out_size, in_size = weight.shape
-    assert in_size % group_size == 0
-
-    # Use JAX for FP4 quantization since torch doesn't have native FP4.
-    w_jax = t2j(weight.float())
-
-    # Compute per-block scales.
-    num_blocks = in_size // group_size
-    w_blocked = w_jax.reshape(out_size, num_blocks, group_size)
-    block_abs_max = jnp.max(jnp.abs(w_blocked), axis=2, keepdims=True)
-
-    fp4_max = float(jnp.finfo(jnp.float4_e2m1fn).max)
-    block_scale = block_abs_max / fp4_max  # [out, num_blocks, 1]
-    block_scale = jnp.where(block_scale == 0, 1.0, block_scale)
-
-    # Compute global scale: max of all block scales.
-    global_scale = jnp.max(block_scale)
-
-    # Effective block scale = block_scale / global_scale (stored as FP8).
-    effective_scale = (block_scale / global_scale).astype(jnp.float8_e4m3fn)
-
-    # Quantize to FP4.
-    scale_inv = jnp.where(block_scale == 0, 0.0, 1.0 / block_scale)
-    w_q = jnp.clip(w_blocked * scale_inv, -fp4_max,
-                   fp4_max).astype(jnp.float4_e2m1fn)
-    w_q = w_q.reshape(out_size, in_size)
-
-    # Pack FP4 into uint8 (2 values per byte).
-    w_packed = w_q.reshape(out_size, in_size // 2, 2)
-    w_packed = jax.lax.bitcast_convert_type(w_packed, jnp.uint8)
-
-    effective_scale = effective_scale.reshape(out_size, num_blocks)
-
-    # Convert via numpy to avoid j2t FP8 dtype issues.
-    w_packed_t = torch.from_numpy(np.asarray(w_packed))
-    scale_t = torch.from_numpy(np.asarray(effective_scale).view(
-        np.uint8)).view(torch.float8_e4m3fn)
-    global_t = torch.tensor(float(global_scale), dtype=torch.float32)
-    return (w_packed_t, scale_t, global_t)
-
-
-def ref_dequant_nvfp4(weight_packed, weight_scale, global_scale, group_size):
-    """Reference dequantization: unpack → float32 using block_scale * global."""
-    w_jax = jnp.array(weight_packed.numpy())
-    # FP8 scale: go through uint8 view to avoid dtype conversion issues.
-    s_np = weight_scale.view(torch.uint8).numpy()
-    s_jax = jax.lax.bitcast_convert_type(jnp.array(s_np), jnp.float8_e4m3fn)
-    g_jax = jnp.float32(global_scale.item())
-
-    # Unpack uint8 → float4_e2m1fn.
-    e2m1 = jax.lax.bitcast_convert_type(w_jax, jnp.float4_e2m1fn)
-    fp4 = jnp.reshape(e2m1, e2m1.shape[:-2] + (-1, ))
-
-    # Fold scales.
-    eff_scale = s_jax.astype(jnp.float32) * g_jax
-    out_size = fp4.shape[0]
-    in_size = fp4.shape[1]
-    num_blocks = in_size // group_size
-
-    fp4_blocked = fp4.reshape(out_size, num_blocks, group_size)
-    scale_expanded = eff_scale.reshape(out_size, num_blocks, 1)
-    deq = (fp4_blocked.astype(jnp.float32) * scale_expanded).reshape(
-        out_size, in_size)
-    return torch.from_numpy(np.asarray(deq))
 
 
 def create_nvfp4_config(mesh):

--- a/tpu_inference/layers/vllm/quantization/compressed_tensors/compressed_tensors.py
+++ b/tpu_inference/layers/vllm/quantization/compressed_tensors/compressed_tensors.py
@@ -32,6 +32,8 @@ from vllm.model_executor.layers.quantization.compressed_tensors.utils import (
 from tpu_inference.layers.common.quant_methods import COMPRESSED_TENSORS
 from tpu_inference.layers.vllm.quantization.compressed_tensors.compressed_tensors_moe import \
     VllmCompressedTensorsMoEMethod
+from tpu_inference.layers.vllm.quantization.compressed_tensors.schemes.compressed_tensors_w4a4_nvfp4 import \
+    VllmCompressedTensorsW4A4Fp4
 from tpu_inference.layers.vllm.quantization.compressed_tensors.schemes.compressed_tensors_w4a8_fp8 import \
     VllmCompressedTensorsW4A8Fp8
 from tpu_inference.layers.vllm.quantization.compressed_tensors.schemes.compressed_tensors_w8a8_fp8 import \
@@ -99,6 +101,24 @@ class VllmCompressedTensorsConfig(CompressedTensorsConfig, VllmQuantConfig):
             # TODO(dmolitor): Handle unpacked weights or propagate a guard here based on the quantization config format.
             return VllmCompressedTensorsW4A8Fp8(
                 weight_quant=weight_quant,
+                is_static_input_scheme=input_quant and not input_quant.dynamic,
+                linear_config=linear_config,
+            )
+
+        if self._is_nvfp4_format(weight_quant):
+            if input_quant is None:
+                return VllmCompressedTensorsW4A4Fp4(
+                    use_a16=True,
+                    is_static_input_scheme=False,
+                    linear_config=linear_config,
+                )
+            if not self._is_nvfp4_format(input_quant):
+                raise ValueError(
+                    "For NVFP4 weights, input quantization must also be NVFP4 format, ",
+                    "None for NVFP4A16",
+                )
+            return VllmCompressedTensorsW4A4Fp4(
+                use_a16=False,
                 is_static_input_scheme=input_quant and not input_quant.dynamic,
                 linear_config=linear_config,
             )

--- a/tpu_inference/layers/vllm/quantization/compressed_tensors/schemes/compressed_tensors_w4a4_nvfp4.py
+++ b/tpu_inference/layers/vllm/quantization/compressed_tensors/schemes/compressed_tensors_w4a4_nvfp4.py
@@ -51,6 +51,7 @@ class VllmCompressedTensorsW4A4Fp4(CompressedTensorsW4A4Fp4):
             raise NotImplementedError(
                 "Static input scheme is not yet supported for W4A4 NVFP4.")
 
+        # TODO(lxhfirenking): Add native support for nvfp4 activation.
         if not use_a16:
             logger.warning(
                 "fp4xfp4 multiplications are not natively supported by TPU hardware, so activations are always kept at bf16 for now."

--- a/tpu_inference/layers/vllm/quantization/compressed_tensors/schemes/compressed_tensors_w4a4_nvfp4.py
+++ b/tpu_inference/layers/vllm/quantization/compressed_tensors/schemes/compressed_tensors_w4a4_nvfp4.py
@@ -53,7 +53,7 @@ class VllmCompressedTensorsW4A4Fp4(CompressedTensorsW4A4Fp4):
 
         if not use_a16:
             logger.warning(
-                "fp4 x fp4 mmu is not natively supported by TPU hardware, so activations are always kept at bf16 for now."
+                "fp4xfp4 multiplications are not natively supported by TPU hardware, so activations are always kept at bf16 for now."
             )
 
         # We need to monkeypatch expose_input_quant_key to handle None kernel

--- a/tpu_inference/layers/vllm/quantization/compressed_tensors/schemes/compressed_tensors_w4a4_nvfp4.py
+++ b/tpu_inference/layers/vllm/quantization/compressed_tensors/schemes/compressed_tensors_w4a4_nvfp4.py
@@ -51,6 +51,11 @@ class VllmCompressedTensorsW4A4Fp4(CompressedTensorsW4A4Fp4):
             raise NotImplementedError(
                 "Static input scheme is not yet supported for W4A4 NVFP4.")
 
+        if not use_a16:
+            logger.warning(
+                "fp4 x fp4 mmu is not natively supported by TPU hardware, so activations are always kept at bf16 for now."
+            )
+
         # We need to monkeypatch expose_input_quant_key to handle None kernel
         # because init_nvfp4_linear_kernel is being called in super.__init__()
         from vllm.model_executor.layers.quantization.compressed_tensors.schemes import \
@@ -182,24 +187,13 @@ class VllmCompressedTensorsW4A4Fp4(CompressedTensorsW4A4Fp4):
         weight_jax = jax_view(layer.weight)
         weight_scale_jax = jax_view(layer.weight_scale)
 
-        if not self.use_a16:
-            x_deq = x_jax
-
-            outs = sharded_quantized_matmul(
-                x_deq,
-                weight_jax,
-                weight_scale_jax,
-                self.linear_config.weight_sharding,
-                mesh=self.linear_config.mesh,
-            )
-        else:
-            outs = sharded_quantized_matmul(
-                x_jax,
-                weight_jax,
-                weight_scale_jax,
-                self.linear_config.weight_sharding,
-                mesh=self.linear_config.mesh,
-            )
+        outs = sharded_quantized_matmul(
+            x_jax,
+            weight_jax,
+            weight_scale_jax,
+            self.linear_config.weight_sharding,
+            mesh=self.linear_config.mesh,
+        )
 
         if bias is not None and not layer.skip_bias_add:
             outs += jax_view(bias)
@@ -218,24 +212,13 @@ class VllmCompressedTensorsW4A4Fp4(CompressedTensorsW4A4Fp4):
             weight_jax = jax_view(weight)
             weight_scale_jax = jax_view(weight_scale)
 
-            if not self.use_a16:
-                x_deq = x_jax
-
-                out = sharded_quantized_matmul(
-                    x_deq,
-                    weight_jax,
-                    weight_scale_jax,
-                    self.linear_config.weight_sharding,
-                    mesh=self.linear_config.mesh,
-                )
-            else:
-                out = sharded_quantized_matmul(
-                    x_jax,
-                    weight_jax,
-                    weight_scale_jax,
-                    self.linear_config.weight_sharding,
-                    mesh=self.linear_config.mesh,
-                )
+            out = sharded_quantized_matmul(
+                x_jax,
+                weight_jax,
+                weight_scale_jax,
+                self.linear_config.weight_sharding,
+                mesh=self.linear_config.mesh,
+            )
 
             if bias is not None and not layer.skip_bias_add:
                 out += jax_view(bias[i])

--- a/tpu_inference/layers/vllm/quantization/compressed_tensors/schemes/compressed_tensors_w4a4_nvfp4.py
+++ b/tpu_inference/layers/vllm/quantization/compressed_tensors/schemes/compressed_tensors_w4a4_nvfp4.py
@@ -1,0 +1,243 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Optional
+
+import jax
+import jax.numpy as jnp
+import torch
+from jax.sharding import PartitionSpec
+from torch.nn.parameter import Parameter
+from torchax.interop import jax_view, torch_view
+from vllm.model_executor.layers.quantization.compressed_tensors.schemes.compressed_tensors_w4a4_nvfp4 import \
+    CompressedTensorsW4A4Fp4
+
+from tpu_inference.layers.common.linear import sharded_quantized_matmul
+from tpu_inference.layers.common.process_weights.linear_weights import (
+    LinearWeights, process_linear_weights, shard_linear_weights,
+    to_parameter_list)
+from tpu_inference.layers.common.quantization import u8_unpack_e2m1
+from tpu_inference.layers.common.utils import \
+    slice_sharded_tensor_for_concatenation
+from tpu_inference.layers.vllm.quantization.configs import \
+    VllmQuantLinearConfig
+from tpu_inference.logger import init_logger
+from tpu_inference.utils import t2j
+
+P = PartitionSpec
+logger = init_logger(__name__)
+
+
+class VllmCompressedTensorsW4A4Fp4(CompressedTensorsW4A4Fp4):
+
+    def __init__(
+        self,
+        use_a16: bool,
+        is_static_input_scheme: bool,
+        linear_config: VllmQuantLinearConfig,
+    ):
+        if is_static_input_scheme:
+            raise NotImplementedError(
+                "Static input scheme is not yet supported for W4A4 NVFP4.")
+
+        # We need to monkeypatch expose_input_quant_key to handle None kernel
+        # because init_nvfp4_linear_kernel is being called in super.__init__()
+        from vllm.model_executor.layers.quantization.compressed_tensors.schemes import \
+            compressed_tensors_w4a4_nvfp4 as vllm_ct_w4a4
+
+        # Disable kernel initialization
+        vllm_ct_w4a4.init_nvfp4_linear_kernel = lambda *args, **kwargs: None
+
+        original_expose = vllm_ct_w4a4.expose_input_quant_key
+
+        def safe_expose_input_quant_key(layer, kernel):
+            if kernel is None:
+                return
+            original_expose(layer, kernel)
+
+        vllm_ct_w4a4.expose_input_quant_key = safe_expose_input_quant_key
+
+        super().__init__(use_a16=use_a16)
+
+        self.linear_config = linear_config
+
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        # Standardize weight names
+        layer.weight = layer.weight_packed
+        del layer.weight_packed
+
+        # Process weight global scale
+        weight_global_scale = layer.weight_global_scale.max().to(torch.float32)
+        weight_global_scale = 1.0 / weight_global_scale
+
+        if not self.use_a16:
+            input_global_scale_inv = layer.input_global_scale.max().to(
+                torch.float32)
+            input_global_scale = 1.0 / input_global_scale_inv
+
+        # TPU Specific loading
+        weight_packed = t2j(layer.weight, use_dlpack=False)
+        weight_scale = t2j(layer.weight_scale, use_dlpack=False)
+
+        # Convert to single elements as it's per tensor scale
+        weight_global_scale_jax = t2j(weight_global_scale, use_dlpack=False)
+
+        for attr in ('weight', 'weight_scale', 'weight_global_scale',
+                     'input_global_scale', 'input_global_scale_inv', 'alpha'):
+            if hasattr(layer, attr):
+                delattr(layer, attr)
+
+        if getattr(layer, "bias",
+                   None) is not None and not layer.skip_bias_add:
+            bias = t2j(layer.bias, use_dlpack=False)
+            delattr(layer, "bias")
+        else:
+            bias = None
+
+        @jax.jit
+        def process_nvfp4_linear_weights(
+            weight_packed: jax.Array,
+            weight_scale: jax.Array,
+            weight_global_scale: jax.Array,
+            bias: jax.Array | None,
+        ) -> LinearWeights:
+            # Unpack uint8 to FP4
+            fp4 = u8_unpack_e2m1(weight_packed)  # [out, in]
+            fp4 = jnp.transpose(fp4)  # [in, out]
+
+            # Combine FP8 block scale & FP32 global scale
+            # weight_scale is [out, in // group_size]
+            block_scale = weight_scale.astype(
+                jnp.float32) * weight_global_scale
+            block_scale = jnp.transpose(block_scale)  # [in // group_size, out]
+
+            return process_linear_weights(
+                LinearWeights(
+                    weight=fp4,
+                    weight_scale=block_scale,
+                    zero_point=None,
+                    bias=bias,
+                ),
+                fused=self.linear_config.fuse_matmuls,
+                output_sizes=self.linear_config.output_sizes,
+                reorder_size=self.linear_config.n_shards,
+                enable_kernel=self.linear_config.
+                enable_quantized_matmul_kernel,
+            )
+
+        weights = process_nvfp4_linear_weights(weight_packed, weight_scale,
+                                               weight_global_scale_jax, bias)
+
+        weights = torch_view(
+            shard_linear_weights(
+                weights,
+                mesh=self.linear_config.mesh,
+                weight_p_spec=self.linear_config.weight_sharding,
+                bias_p_spec=self.linear_config.bias_sharding,
+            ))
+
+        if self.linear_config.fuse_matmuls:
+            layer.weight = Parameter(weights.weight, requires_grad=False)
+            layer.weight_scale = Parameter(weights.weight_scale,
+                                           requires_grad=False)
+            if bias is not None:
+                layer.bias = Parameter(weights.bias, requires_grad=False)
+        else:
+            layer.weight = to_parameter_list(weights.weight)
+            layer.weight_scale = to_parameter_list(weights.weight_scale)
+            if bias is not None:
+                layer.bias = to_parameter_list(weights.bias)
+
+        if not self.use_a16:
+            # Note: input_scale should be jax sharded tensor for split
+            input_global_scale_j = jax.device_put(
+                t2j(input_global_scale, use_dlpack=False),
+                jax.sharding.NamedSharding(self.linear_config.mesh,
+                                           PartitionSpec()))
+            layer.input_scale = Parameter(torch_view(input_global_scale_j),
+                                          requires_grad=False)
+
+    def apply_weights(self, layer: torch.nn.Module, x: torch.Tensor,
+                      bias: Optional[torch.Tensor]) -> torch.Tensor:
+        with jax.named_scope(layer._get_name()):
+            if self.linear_config.fuse_matmuls:
+                return self._apply_fused(layer, x, bias)
+            else:
+                return self._apply_split(layer, x, bias)
+
+    def _apply_fused(self, layer: torch.nn.Module, x: torch.Tensor,
+                     bias: Optional[torch.Tensor]) -> torch.Tensor:
+        x_jax = jax_view(x)
+        weight_jax = jax_view(layer.weight)
+        weight_scale_jax = jax_view(layer.weight_scale)
+
+        if not self.use_a16:
+            x_deq = x_jax
+
+            outs = sharded_quantized_matmul(
+                x_deq,
+                weight_jax,
+                weight_scale_jax,
+                self.linear_config.weight_sharding,
+                mesh=self.linear_config.mesh,
+            )
+        else:
+            outs = sharded_quantized_matmul(
+                x_jax,
+                weight_jax,
+                weight_scale_jax,
+                self.linear_config.weight_sharding,
+                mesh=self.linear_config.mesh,
+            )
+
+        if bias is not None and not layer.skip_bias_add:
+            outs += jax_view(bias)
+        outs = slice_sharded_tensor_for_concatenation(
+            outs, self.linear_config.output_sizes, self.linear_config.n_shards)
+        return torch_view(jnp.concatenate(outs, axis=-1))
+
+    def _apply_split(self, layer: torch.nn.Module, x: torch.Tensor,
+                     bias: Optional[torch.Tensor]) -> torch.Tensor:
+        assert isinstance(layer.weight, torch.nn.ParameterList)
+
+        x_jax = jax_view(x)
+        outs = []
+        for i, (weight, weight_scale) in enumerate(
+                zip(layer.weight, layer.weight_scale)):
+            weight_jax = jax_view(weight)
+            weight_scale_jax = jax_view(weight_scale)
+
+            if not self.use_a16:
+                x_deq = x_jax
+
+                out = sharded_quantized_matmul(
+                    x_deq,
+                    weight_jax,
+                    weight_scale_jax,
+                    self.linear_config.weight_sharding,
+                    mesh=self.linear_config.mesh,
+                )
+            else:
+                out = sharded_quantized_matmul(
+                    x_jax,
+                    weight_jax,
+                    weight_scale_jax,
+                    self.linear_config.weight_sharding,
+                    mesh=self.linear_config.mesh,
+                )
+
+            if bias is not None and not layer.skip_bias_add:
+                out += jax_view(bias[i])
+            outs.append(out)
+        return torch_view(jnp.concatenate(outs, axis=-1))


### PR DESCRIPTION
# Description

Add compressed tensor w4a4_nvfp4 support to the torchax path. 

The rationale is mainly to enable tpu-inference to load fp4 quantization checkpoints produced by LLM Compressor. 

In the original VLLM implementation, `compressed_tensors_w4a4_nvfp4.py` supports two cases: 
 - both weights and activation being nvfp4
 - weights are in nvfp4, but activations are unquantized bf16 (so it is really w4a16)

In this initial implementation, we do not try to quantize the activation, given how native fp4 x fp4 matmul is not yet supported on TPUs. A warning is produced if a nvfp4 compressed tensor contains config for activation quantization, which will then be ignored. 

Unit tests are added for the new method, along with utils method refactoring to avoid code duplication with existing test_nvfp4.py

# Tests

Unit test
```
pytest tests/layers/vllm/test_compressed_tensors_w4a4_nvfp4.py
```

Loading nvfp4 compressed_tensor checkpoint
```
USE_BATCHED_RPA_KERNEL=1 \
JITTED_MM_MODULE_KEYS="model.vision_tower.encoder" \
REGISTER_MM_MODULE_CUSTOM_PYTREE_CLASSES="transformers.modeling_outputs.BaseModelOutputWithPast" \
MODEL_IMPL_TYPE="vllm" \
vllm serve \
    --max-num-batched-tokens=4096 \
    --max-num-seqs=127 \
    --max-model-len=4096 \
    --no-enable-prefix-caching  \
    --model=RedHatAI/gemma-4-31B-it-NVFP4 \
    --limit-mm-per-prompt '{"image": 8, "video": 0}' \
    --tensor-parallel-size=2 \
    --kv-cache-dtype=fp8
```
Benchmark was run against the launched model instance to verify that accuracy was as expected
```
python scripts/vllm/benchmarking/benchmark_serving.py \
    --backend vllm-chat \
    --endpoint /v1/chat/completions \
    --model RedHatAI/gemma-4-31B-it-NVFP4 \
    --dataset-name mmmu_pro \
    --mmmu-pro-subset 'standard (10 options)' \
    --mmmu-pro-output-len=2000 \
    --run-eval \
    --num-prompts 1730 \
    --max-concurrency 32
```

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
