### PR TITLE
Add flag continue decode to not exit on EOS

### DIFF
--- a/tests/runner/test_decode_loop.py
+++ b/tests/runner/test_decode_loop.py
@@ -470,6 +470,7 @@ def test_continue_decode_exit_on_eos_interval():
         final_state,
         current_rng,
         all_expert_indices,
+        logprobs_tensors,
     ) = continue_decode(
         state={},
         model_fn=mock_model_fn,

--- a/tests/runner/test_decode_loop.py
+++ b/tests/runner/test_decode_loop.py
@@ -300,6 +300,7 @@ def test_continue_decode_with_experts():
     expected_experts[1] = 1
     expected_experts[2] = 2
 
+    assert np.array_equal(all_expert_indices, expected_experts)
     assert logprobs_tensors is None
 
 

--- a/tests/runner/test_decode_loop.py
+++ b/tests/runner/test_decode_loop.py
@@ -300,5 +300,107 @@ def test_continue_decode_with_experts():
     expected_experts[1] = 1
     expected_experts[2] = 2
 
-    assert np.array_equal(all_expert_indices, expected_experts)
     assert logprobs_tensors is None
+
+
+def test_continue_decode_no_exit_on_eos():
+    batch_size = 2
+    max_decode_steps = 5
+    static_max_decode_steps = 5
+
+    init_tokens = jnp.array([10, 20], dtype=jnp.int32)
+    active_mask = jnp.array([True, True], dtype=jnp.bool_)
+
+    attn_metadata = AttentionMetadata(
+        input_positions=jnp.array([0, 0], dtype=jnp.int32),
+        block_tables=jnp.zeros((2, 16), dtype=jnp.int32),
+        seq_lens=jnp.array([1, 1], dtype=jnp.int32),
+        query_start_loc=jnp.array([0, 1, 2], dtype=jnp.int32),
+        request_distribution=jnp.array([0, 0], dtype=jnp.int32),
+        mamba_state_indices=None,
+    )
+
+    init_state = TpuSamplingState(
+        current_tokens=init_tokens,
+        active_mask=active_mask,
+        attn_metadata=attn_metadata,
+        step_counter=jnp.array(0, dtype=jnp.int32),
+    )
+
+    kv_caches = [jnp.zeros((2, 10))]
+
+    def mock_model_fn(state, kv_caches, current_tokens, attn_metadata, *args):
+        hidden_states = attn_metadata.input_positions.astype(jnp.float32)[:,
+                                                                          None,
+                                                                          None]
+        return kv_caches, hidden_states, None, None
+
+    def mock_compute_logits_fn(state, hidden_states, _):
+        pos = hidden_states[:, 0, 0]
+        logits = jnp.zeros((batch_size, 100))
+        logits = logits.at[:, 0].set(pos)
+        return logits
+
+    def mock_sample_fn(rng, mesh, logits, sampling_metadata):
+        pos = logits[:, 0].astype(jnp.int32)
+        token_table = jnp.array(
+            [
+                [42, 43],  # pos 0
+                [44, 99],  # pos 1 (req 1 hits EOS)
+                [99, 50],  # pos 2 (req 0 hits EOS)
+                [60, 61],  # pos 3
+                [70, 71],  # pos 4
+            ],
+            dtype=jnp.int32,
+        )
+        batch_idx = jnp.arange(batch_size)
+        next_tokens = token_table[pos, batch_idx]
+        return next_tokens, None
+
+    rng = jax.random.PRNGKey(0)
+
+    (
+        token_buffer,
+        final_kv_caches,
+        final_state,
+        current_rng,
+        all_expert_indices,
+        logprobs_tensors,
+    ) = continue_decode(
+        state={},
+        model_fn=mock_model_fn,
+        compute_logits_fn=mock_compute_logits_fn,
+        sample_fn=mock_sample_fn,
+        init_state=init_state,
+        kv_caches=kv_caches,
+        max_decode_steps=max_decode_steps,
+        static_max_decode_steps=static_max_decode_steps,
+        eos_token_id=(99, ),
+        padding_token_id=-1,
+        rng=rng,
+        mesh=None,
+        sampling_metadata=None,
+        exit_on_eos=False,
+    )
+
+    # Verify loop ran all 5 steps despite EOS hit
+    assert int(final_state.step_counter) == 5
+
+    # Expected tokens:
+    # Step 0: [42, 43]
+    # Step 1: [44, 99] (req 1 hits EOS)
+    # Step 2: [99, -1] (req 0 hits EOS; req 1 inactive -> -1)
+    # Step 3: [-1, -1] (both inactive)
+    # Step 4: [-1, -1] (both inactive)
+    expected_tokens = np.array(
+        [
+            [42, 43],
+            [44, 99],
+            [99, -1],
+            [-1, -1],
+            [-1, -1],
+        ],
+        dtype=np.int32,
+    )
+    assert np.array_equal(token_buffer, expected_tokens)
+    assert np.array_equal(final_state.active_mask, [False, False])

--- a/tests/runner/test_decode_loop.py
+++ b/tests/runner/test_decode_loop.py
@@ -380,7 +380,7 @@ def test_continue_decode_no_exit_on_eos():
         rng=rng,
         mesh=None,
         sampling_metadata=None,
-        exit_on_eos=False,
+        continue_decode_eos_check_interval=-1,
     )
 
     # Verify loop ran all 5 steps despite EOS hit
@@ -404,3 +404,87 @@ def test_continue_decode_no_exit_on_eos():
     )
     assert np.array_equal(token_buffer, expected_tokens)
     assert np.array_equal(final_state.active_mask, [False, False])
+
+
+def test_continue_decode_exit_on_eos_interval():
+    batch_size = 2
+    max_decode_steps = 10
+    static_max_decode_steps = 10
+
+    init_tokens = jnp.array([10, 20], dtype=jnp.int32)
+    active_mask = jnp.array([True, True], dtype=jnp.bool_)
+
+    attn_metadata = AttentionMetadata(
+        input_positions=jnp.array([0, 0], dtype=jnp.int32),
+        block_tables=jnp.zeros((2, 16), dtype=jnp.int32),
+        seq_lens=jnp.array([1, 1], dtype=jnp.int32),
+        query_start_loc=jnp.array([0, 1, 2], dtype=jnp.int32),
+        request_distribution=jnp.array([0, 0], dtype=jnp.int32),
+        mamba_state_indices=None,
+    )
+
+    init_state = TpuSamplingState(
+        current_tokens=init_tokens,
+        active_mask=active_mask,
+        attn_metadata=attn_metadata,
+        step_counter=jnp.array(0, dtype=jnp.int32),
+    )
+
+    kv_caches = [jnp.zeros((2, 10))]
+
+    def mock_model_fn(state, kv_caches, current_tokens, attn_metadata, *args):
+        hidden_states = attn_metadata.input_positions.astype(jnp.float32)[:,
+                                                                          None,
+                                                                          None]
+        return kv_caches, hidden_states, None, None
+
+    def mock_compute_logits_fn(state, hidden_states, _):
+        pos = hidden_states[:, 0, 0]
+        logits = jnp.zeros((batch_size, 100))
+        logits = logits.at[:, 0].set(pos)
+        return logits
+
+    def mock_sample_fn(rng, mesh, logits, sampling_metadata):
+        pos = logits[:, 0].astype(jnp.int32)
+        # Token table: step 0 (pos 0) produces 99 (EOS) for req 1
+        token_table = jnp.array(
+            [
+                [42, 99],  # pos 0: req 1 hits EOS
+                [43, -1],  # pos 1
+                [44, -1],  # pos 2
+                [45, -1],  # pos 3
+                [46, -1],  # pos 4
+            ],
+            dtype=jnp.int32,
+        )
+        batch_idx = jnp.arange(batch_size)
+        next_tokens = token_table[pos, batch_idx]
+        return next_tokens, None
+
+    rng = jax.random.PRNGKey(0)
+
+    (
+        token_buffer,
+        final_kv_caches,
+        final_state,
+        current_rng,
+        all_expert_indices,
+    ) = continue_decode(
+        state={},
+        model_fn=mock_model_fn,
+        compute_logits_fn=mock_compute_logits_fn,
+        sample_fn=mock_sample_fn,
+        init_state=init_state,
+        kv_caches=kv_caches,
+        max_decode_steps=max_decode_steps,
+        static_max_decode_steps=static_max_decode_steps,
+        eos_token_id=(99, ),
+        padding_token_id=-1,
+        rng=rng,
+        mesh=None,
+        sampling_metadata=None,
+        continue_decode_eos_check_interval=3,  # Only check exit every 3 steps
+    )
+
+    # EOS hit at step 0. Step checks at i=1, i=2 do not exit. Step check at i=3 (3 % 3 == 0) exits.
+    assert int(final_state.step_counter) == 3

--- a/tests/runner/test_decode_loop.py
+++ b/tests/runner/test_decode_loop.py
@@ -330,7 +330,8 @@ def test_continue_decode_no_exit_on_eos():
 
     kv_caches = [jnp.zeros((2, 10))]
 
-    def mock_model_fn(state, kv_caches, current_tokens, attn_metadata, *args):
+    def mock_model_fn(state, kv_caches, current_tokens, attn_metadata, *args,
+                      **kwargs):
         hidden_states = attn_metadata.input_positions.astype(jnp.float32)[:,
                                                                           None,
                                                                           None]
@@ -433,7 +434,8 @@ def test_continue_decode_exit_on_eos_interval():
 
     kv_caches = [jnp.zeros((2, 10))]
 
-    def mock_model_fn(state, kv_caches, current_tokens, attn_metadata, *args):
+    def mock_model_fn(state, kv_caches, current_tokens, attn_metadata, *args,
+                      **kwargs):
         hidden_states = attn_metadata.input_positions.astype(jnp.float32)[:,
                                                                           None,
                                                                           None]

--- a/tests/runner/test_tpu_runner.py
+++ b/tests/runner/test_tpu_runner.py
@@ -542,6 +542,7 @@ class TestTPUJaxRunner:
             None,
             None,
             None,
+            None,
         )
 
         from tpu_inference.runner.tpu_runner import TPUModelRunner

--- a/tests/runner/test_tpu_runner.py
+++ b/tests/runner/test_tpu_runner.py
@@ -351,6 +351,7 @@ class TestTPUJaxRunner:
         runner.eos_token_id = 999
         runner.pad_token_id = 0
         runner.layer_name_to_kvcache_index = {}
+        runner.exit_on_eos_in_continue_decode = True
 
         # Mock continue_decode output
         mock_generated_tokens = MagicMock()
@@ -467,6 +468,81 @@ class TestTPUJaxRunner:
         assert attn_metadata.seq_lens_cpu[1] == 25
         # req3: 30 -> 35
         assert attn_metadata.seq_lens_cpu[2] == 35
+
+        # 6. Verify default exit_on_eos parameter passed to continue_decode
+        assert mock_continue_decode.call_args.kwargs["exit_on_eos"] is True
+
+    @patch('tpu_inference.runner.tpu_runner.continue_decode')
+    @patch('jax.device_get')
+    def test_execute_continue_decode_exit_on_eos_config(
+            self, mock_device_get, mock_continue_decode):
+        """_execute_continue_decode() should pass exit_on_eos=False when configured in additional_config."""
+        runner = MagicMock()
+        runner.max_num_reqs = 8
+        runner.max_model_len = 512
+        runner.dp_size = 1
+        runner.vllm_config.parallel_config.data_parallel_size = 1
+        runner.vllm_config.parallel_config.is_moe_model = False
+        runner.vllm_config.additional_config = {
+            "enable_continue_decode": True,
+            "exit_on_eos_in_continue_decode": False,
+            "max_decode_steps": 5,
+        }
+        runner.exit_on_eos_in_continue_decode = False
+        runner.static_max_decode_steps = 5
+        runner.input_batch.num_reqs = 1
+        runner.input_batch.req_ids = ["req1"]
+        runner.input_batch.req_id_to_index = {"req1": 0}
+        runner.input_batch.token_ids_cpu = np.zeros((8, 512), dtype=np.int32)
+        runner.requests = {"req1": MagicMock(output_token_ids=[])}
+        runner._get_min_remaining_slots.return_value = 5
+        runner.model_config.get_vocab_size.return_value = 1000
+        runner.eos_token_id = 999
+        runner.pad_token_id = 0
+        runner.layer_name_to_kvcache_index = {}
+
+        mock_generated_tokens = MagicMock()
+        mock_final_state = MagicMock()
+        mock_continue_decode.return_value = (
+            mock_generated_tokens,
+            MagicMock(),
+            mock_final_state,
+            MagicMock(),
+            None,
+        )
+
+        mock_tokens_cpu = np.zeros((5, 8), dtype=np.int32)
+        mock_tokens_cpu[:, 0] = [101, 999, 0, 0, 0]
+
+        mock_device_get.side_effect = lambda arg: (mock_tokens_cpu, None,
+                                                   np.int32(5)) if isinstance(
+                                                       arg, tuple) else arg
+
+        mock_seq_lens_cpu = np.array([10, 0, 0, 0, 0, 0, 0, 0])
+        runner.input_batch.num_tokens = mock_seq_lens_cpu.copy()
+        runner.input_batch.num_tokens_no_spec = mock_seq_lens_cpu.copy()
+
+        attn_metadata = MagicMock()
+        attn_metadata.seq_lens_cpu = mock_seq_lens_cpu
+        runner._prepare_inputs.return_value = (
+            np.zeros(8, dtype=np.int32),
+            None,
+            attn_metadata,
+            None,
+            np.array([0, -1, -1, -1, -1, -1, -1, -1], dtype=np.int32),
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+
+        from tpu_inference.runner.tpu_runner import TPUModelRunner
+        TPUModelRunner._execute_continue_decode(
+            runner, MagicMock(num_scheduled_tokens={"req1": 1}))
+
+        mock_continue_decode.assert_called_once()
+        assert mock_continue_decode.call_args.kwargs["exit_on_eos"] is False
 
     @patch('tpu_inference.runner.tpu_runner.continue_decode')
     @patch('jax.device_get')

--- a/tests/runner/test_tpu_runner.py
+++ b/tests/runner/test_tpu_runner.py
@@ -351,7 +351,7 @@ class TestTPUJaxRunner:
         runner.eos_token_id = 999
         runner.pad_token_id = 0
         runner.layer_name_to_kvcache_index = {}
-        runner.exit_on_eos_in_continue_decode = True
+        runner.continue_decode_eos_check_interval = 1
 
         # Mock continue_decode output
         mock_generated_tokens = MagicMock()
@@ -469,14 +469,15 @@ class TestTPUJaxRunner:
         # req3: 30 -> 35
         assert attn_metadata.seq_lens_cpu[2] == 35
 
-        # 6. Verify default exit_on_eos parameter passed to continue_decode
-        assert mock_continue_decode.call_args.kwargs["exit_on_eos"] is True
+        # 6. Verify default continue_decode_eos_check_interval parameter passed to continue_decode
+        assert mock_continue_decode.call_args.kwargs[
+            "continue_decode_eos_check_interval"] == 1
 
     @patch('tpu_inference.runner.tpu_runner.continue_decode')
     @patch('jax.device_get')
-    def test_execute_continue_decode_exit_on_eos_config(
+    def test_execute_continue_decode_eos_check_interval_config(
             self, mock_device_get, mock_continue_decode):
-        """_execute_continue_decode() should pass exit_on_eos=False when configured in additional_config."""
+        """_execute_continue_decode() should pass continue_decode_eos_check_interval when configured in additional_config."""
         runner = MagicMock()
         runner.max_num_reqs = 8
         runner.max_model_len = 512
@@ -485,10 +486,10 @@ class TestTPUJaxRunner:
         runner.vllm_config.parallel_config.is_moe_model = False
         runner.vllm_config.additional_config = {
             "enable_continue_decode": True,
-            "exit_on_eos_in_continue_decode": False,
+            "continue_decode_eos_check_interval": 5,
             "max_decode_steps": 5,
         }
-        runner.exit_on_eos_in_continue_decode = False
+        runner.continue_decode_eos_check_interval = 5
         runner.static_max_decode_steps = 5
         runner.input_batch.num_reqs = 1
         runner.input_batch.req_ids = ["req1"]
@@ -508,6 +509,7 @@ class TestTPUJaxRunner:
             MagicMock(),
             mock_final_state,
             MagicMock(),
+            None,
             None,
         )
 
@@ -535,6 +537,7 @@ class TestTPUJaxRunner:
             None,
             None,
             None,
+            None,
         )
 
         from tpu_inference.runner.tpu_runner import TPUModelRunner
@@ -542,7 +545,8 @@ class TestTPUJaxRunner:
             runner, MagicMock(num_scheduled_tokens={"req1": 1}))
 
         mock_continue_decode.assert_called_once()
-        assert mock_continue_decode.call_args.kwargs["exit_on_eos"] is False
+        assert mock_continue_decode.call_args.kwargs[
+            "continue_decode_eos_check_interval"] == 5
 
     @patch('tpu_inference.runner.tpu_runner.continue_decode')
     @patch('jax.device_get')

--- a/tests/runner/test_tpu_runner.py
+++ b/tests/runner/test_tpu_runner.py
@@ -484,6 +484,7 @@ class TestTPUJaxRunner:
         runner.dp_size = 1
         runner.vllm_config.parallel_config.data_parallel_size = 1
         runner.vllm_config.parallel_config.is_moe_model = False
+        runner.scheduler_config.async_scheduling = False
         runner.vllm_config.additional_config = {
             "enable_continue_decode": True,
             "continue_decode_eos_check_interval": 5,
@@ -516,9 +517,12 @@ class TestTPUJaxRunner:
         mock_tokens_cpu = np.zeros((5, 8), dtype=np.int32)
         mock_tokens_cpu[:, 0] = [101, 999, 0, 0, 0]
 
-        mock_device_get.side_effect = lambda arg: (mock_tokens_cpu, None,
-                                                   np.int32(5)) if isinstance(
-                                                       arg, tuple) else arg
+        def device_get_side_effect(arg):
+            if isinstance(arg, tuple) and len(arg) == 2:
+                return mock_tokens_cpu, np.int32(5)
+            return arg
+
+        mock_device_get.side_effect = device_get_side_effect
 
         mock_seq_lens_cpu = np.array([10, 0, 0, 0, 0, 0, 0, 0])
         runner.input_batch.num_tokens = mock_seq_lens_cpu.copy()
@@ -726,6 +730,7 @@ class TestTPUJaxRunner:
         runner._get_min_remaining_slots.return_value = 5
         runner.vllm_config.additional_config = {"max_decode_steps": 5}
         runner.static_max_decode_steps = 5
+        runner.continue_decode_eos_check_interval = 5
         runner.model_config.get_vocab_size.return_value = 1000
         runner.model_config.hf_config = MagicMock(eos_token_id=999,
                                                   pad_token_id=0)
@@ -776,6 +781,8 @@ class TestTPUJaxRunner:
         assert runner._pre_async_results.is_continue_decode is True
         assert runner._continue_decode_output is not None
 
+        assert mock_continue_decode.call_args.kwargs[
+            "continue_decode_eos_check_interval"] == runner.continue_decode_eos_check_interval
         # Verify output resolution via get_output()
         async_out = runner._continue_decode_output
         model_runner_output = async_out.get_output()

--- a/tpu_inference/runner/compilation_manager.py
+++ b/tpu_inference/runner/compilation_manager.py
@@ -1950,6 +1950,7 @@ class CompilationManager:
                 is_last_rank,
                 dp_size,
                 collect_expert_indices,
+                exit_on_eos,
             ):
                 (generated_tokens, final_kv_caches, final_state, final_rng,
                  all_expert_indices, logprobs_tensors) = continue_decode(
@@ -1974,6 +1975,7 @@ class CompilationManager:
                      collect_expert_indices=collect_expert_indices,
                      max_logprobs=self.runner.model_config.max_logprobs,
                      logprobs_mode=self.runner.model_config.logprobs_mode,
+                     exit_on_eos=exit_on_eos,
                  )
                 self.runner.kv_caches = final_kv_caches
                 return generated_tokens
@@ -2007,5 +2009,6 @@ class CompilationManager:
                 self.runner.dp_size,
                 getattr(self.runner.vllm_config.model_config,
                         "enable_return_routed_experts", False),
+                self.runner.exit_on_eos_in_continue_decode,
                 warmup_handler=continue_decode_warmup,
             )

--- a/tpu_inference/runner/compilation_manager.py
+++ b/tpu_inference/runner/compilation_manager.py
@@ -1950,7 +1950,7 @@ class CompilationManager:
                 is_last_rank,
                 dp_size,
                 collect_expert_indices,
-                exit_on_eos,
+                continue_decode_eos_check_interval,
             ):
                 (generated_tokens, final_kv_caches, final_state, final_rng,
                  all_expert_indices, logprobs_tensors) = continue_decode(
@@ -1975,7 +1975,8 @@ class CompilationManager:
                      collect_expert_indices=collect_expert_indices,
                      max_logprobs=self.runner.model_config.max_logprobs,
                      logprobs_mode=self.runner.model_config.logprobs_mode,
-                     exit_on_eos=exit_on_eos,
+                     continue_decode_eos_check_interval=
+                     continue_decode_eos_check_interval,
                  )
                 self.runner.kv_caches = final_kv_caches
                 return generated_tokens
@@ -2009,6 +2010,6 @@ class CompilationManager:
                 self.runner.dp_size,
                 getattr(self.runner.vllm_config.model_config,
                         "enable_return_routed_experts", False),
-                self.runner.exit_on_eos_in_continue_decode,
+                self.runner.continue_decode_eos_check_interval,
                 warmup_handler=continue_decode_warmup,
             )

--- a/tpu_inference/runner/decode_loop.py
+++ b/tpu_inference/runner/decode_loop.py
@@ -112,6 +112,7 @@ def _split_rngs(rng, static_size, dynamic_size):
         "is_last_rank",
         "max_logprobs",
         "logprobs_mode",
+        "exit_on_eos",
     ),
     donate_argnames=("kv_caches", ),
     # Hoisted here from the model's step_fun: JAX forbids compiler_options on
@@ -158,6 +159,7 @@ def _decode_core(
     is_last_rank,
     max_logprobs,
     logprobs_mode,
+    exit_on_eos: bool = True,
 ):
     has_logprobs = False if sampling_metadata is None else sampling_metadata.logprobs
 
@@ -281,7 +283,9 @@ def _decode_core(
         i = carry[0]
         eos_flag = carry[-1]
         not_done = i < max_decode_steps
-        return jnp.logical_and(not_done, jnp.logical_not(eos_flag))
+        if exit_on_eos:
+            return jnp.logical_and(not_done, jnp.logical_not(eos_flag))
+        return not_done
 
     def body_fn(carry):
         (i, ct, am, pos, sl, kvc, tb, eb, lp_ids_buf, lp_val_buf, lp_ranks_buf,
@@ -349,6 +353,7 @@ def continue_decode(
     collect_expert_indices: bool = False,
     max_logprobs: int = 0,
     logprobs_mode: str = "raw",
+    exit_on_eos: bool = True,
 ) -> tuple[jax.Array, Any, TpuSamplingState, jax.Array, jax.Array | None,
            Optional["LogprobsTensors"]]:
     """Run the TPU decode loop as one fused, kv-cache-donating program.
@@ -491,6 +496,7 @@ def continue_decode(
          is_last_rank=is_last_rank,
          max_logprobs=max_logprobs,
          logprobs_mode=logprobs_mode,
+         exit_on_eos=exit_on_eos,
      )
 
     final_state = TpuSamplingState(

--- a/tpu_inference/runner/decode_loop.py
+++ b/tpu_inference/runner/decode_loop.py
@@ -112,7 +112,7 @@ def _split_rngs(rng, static_size, dynamic_size):
         "is_last_rank",
         "max_logprobs",
         "logprobs_mode",
-        "exit_on_eos",
+        "continue_decode_eos_check_interval",
     ),
     donate_argnames=("kv_caches", ),
     # Hoisted here from the model's step_fun: JAX forbids compiler_options on
@@ -122,7 +122,7 @@ def _split_rngs(rng, static_size, dynamic_size):
         "xla_tpu_reduce_scatter_collective_matmul_mode":
         "post_spmd_conservative",
         "xla_tpu_use_minor_sharding_for_major_trivial_input": "true"
-    },
+    } if jax.default_backend() == "tpu" else None,
 )
 def _decode_core(
     *,
@@ -159,7 +159,7 @@ def _decode_core(
     is_last_rank,
     max_logprobs,
     logprobs_mode,
-    exit_on_eos: bool = True,
+    continue_decode_eos_check_interval: int = 1,
 ):
     has_logprobs = False if sampling_metadata is None else sampling_metadata.logprobs
 
@@ -283,9 +283,13 @@ def _decode_core(
         i = carry[0]
         eos_flag = carry[-1]
         not_done = i < max_decode_steps
-        if exit_on_eos:
-            return jnp.logical_and(not_done, jnp.logical_not(eos_flag))
-        return not_done
+        if continue_decode_eos_check_interval <= 0:
+            return not_done
+        should_check_eos = (i % continue_decode_eos_check_interval == 0)
+        return jnp.logical_and(
+            not_done,
+            jnp.logical_not(jnp.logical_and(eos_flag, should_check_eos)),
+        )
 
     def body_fn(carry):
         (i, ct, am, pos, sl, kvc, tb, eb, lp_ids_buf, lp_val_buf, lp_ranks_buf,
@@ -353,7 +357,7 @@ def continue_decode(
     collect_expert_indices: bool = False,
     max_logprobs: int = 0,
     logprobs_mode: str = "raw",
-    exit_on_eos: bool = True,
+    continue_decode_eos_check_interval: int = 1,
 ) -> tuple[jax.Array, Any, TpuSamplingState, jax.Array, jax.Array | None,
            Optional["LogprobsTensors"]]:
     """Run the TPU decode loop as one fused, kv-cache-donating program.
@@ -496,7 +500,7 @@ def continue_decode(
          is_last_rank=is_last_rank,
          max_logprobs=max_logprobs,
          logprobs_mode=logprobs_mode,
-         exit_on_eos=exit_on_eos,
+         continue_decode_eos_check_interval=continue_decode_eos_check_interval,
      )
 
     final_state = TpuSamplingState(

--- a/tpu_inference/runner/decode_loop.py
+++ b/tpu_inference/runner/decode_loop.py
@@ -122,7 +122,7 @@ def _split_rngs(rng, static_size, dynamic_size):
         "xla_tpu_reduce_scatter_collective_matmul_mode":
         "post_spmd_conservative",
         "xla_tpu_use_minor_sharding_for_major_trivial_input": "true"
-    } if jax.default_backend() == "tpu" else None,
+    },
 )
 def _decode_core(
     *,

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -856,6 +856,8 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         """Generative model or pooling model select different computations."""
         self.enable_continue_decode = self.vllm_config.additional_config.get(
             "enable_continue_decode", False)
+        self.exit_on_eos_in_continue_decode = self.vllm_config.additional_config.get(
+            "exit_on_eos_in_continue_decode", True)
         self.static_max_decode_steps = self.vllm_config.additional_config.get(
             "max_decode_steps", DEFAULT_MAX_DECODE_STEPS)
         self.eos_token_id = runner_utils.get_eos_token_id(self.model_config)
@@ -1813,6 +1815,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                      "enable_return_routed_experts", False),
                  max_logprobs=self.model_config.max_logprobs,
                  logprobs_mode=self.model_config.logprobs_mode,
+                 exit_on_eos=self.exit_on_eos_in_continue_decode,
              )
 
         if self.scheduler_config.async_scheduling:

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -856,8 +856,8 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         """Generative model or pooling model select different computations."""
         self.enable_continue_decode = self.vllm_config.additional_config.get(
             "enable_continue_decode", False)
-        self.exit_on_eos_in_continue_decode = self.vllm_config.additional_config.get(
-            "exit_on_eos_in_continue_decode", True)
+        self.continue_decode_eos_check_interval = self.vllm_config.additional_config.get(
+            "continue_decode_eos_check_interval", 1)
         self.static_max_decode_steps = self.vllm_config.additional_config.get(
             "max_decode_steps", DEFAULT_MAX_DECODE_STEPS)
         self.eos_token_id = runner_utils.get_eos_token_id(self.model_config)
@@ -1815,7 +1815,8 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                      "enable_return_routed_experts", False),
                  max_logprobs=self.model_config.max_logprobs,
                  logprobs_mode=self.model_config.logprobs_mode,
-                 exit_on_eos=self.exit_on_eos_in_continue_decode,
+                 continue_decode_eos_check_interval=self.
+                 continue_decode_eos_check_interval,
              )
 
         if self.scheduler_config.async_scheduling:


### PR DESCRIPTION
# Description

For large batch RL workloads it might be optimal to continue decode after EOS was reached for some requests. Add flag to control the check frequency.

usage:
- To check every 2 steps `--additional-config='{"enable_continue_decode": true, "continue_decode_eos_check_interval": 2}'`
- -1 for no checks `--additional-config='{"enable_continue_decode": true, "continue_decode_eos_check_interval": -1}'`

Default is set to 1

# Tests

Added tests and ran `examples/rl_inference.py`

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
