### PR TITLE
[Feature] Support compressed-tensors quantization for the JAX path

### DIFF
--- a/tests/layers/jax/quantization/test_compressed_tensors.py
+++ b/tests/layers/jax/quantization/test_compressed_tensors.py
@@ -1,0 +1,176 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for the JAX-native compressed-tensors config (issue #2261).
+
+These tests exercise the *dispatch* logic (`get_quant_method`): given a
+compressed-tensors `quantization_config`, does each layer get routed to the
+right JAX quant method (or skipped)? They mirror `test_fp8.py::TestFp8Config`,
+which asserts `layer.quant_method` types rather than running a forward pass.
+"""
+
+import jax
+import numpy as np
+import pytest
+from flax import nnx
+from jax.sharding import Mesh
+
+from tpu_inference.layers.common.sharding import MESH_AXIS_NAMES
+from tpu_inference.layers.jax.linear import JaxLinear
+from tpu_inference.layers.jax.quantization.compressed_tensors import \
+    CompressedTensorsConfig
+from tpu_inference.layers.jax.quantization.fp8 import (
+    Fp8BlockwiseLinearMethod, Fp8TensorwiseLinearMethod)
+from tpu_inference.layers.jax.quantization.unquantized import \
+    UnquantizedLinearMethod
+
+
+# A compressed-tensors `quantization_config` modeled on
+# RedHatAI/gemma-4-31B-it-FP8-block: fp8 block-quantized weights (128x128) +
+# dynamic fp8 activations, applied to Linear layers, with an ignore regex.
+# NOTE(verify): exact field values (esp. input-activation strategy) should be
+# reconciled with the real checkpoint's config.json when running on a TPU VM.
+def _fp8_block_config(ignore=None):
+    return {
+        "quant_method": "compressed-tensors",
+        "format": "float-quantized",
+        "config_groups": {
+            "group_0": {
+                "targets": ["Linear"],
+                "weights": {
+                    "num_bits": 8,
+                    "type": "float",
+                    "symmetric": True,
+                    "strategy": "block",
+                    "block_structure": [128, 128],
+                    "dynamic": False,
+                },
+                "input_activations": {
+                    "num_bits": 8,
+                    "type": "float",
+                    "symmetric": True,
+                    "strategy": "token",
+                    "dynamic": True,
+                },
+            }
+        },
+        "ignore": ignore or [],
+    }
+
+
+# Same as above but per-tensor weights (no block_structure) -> should route to
+# the tensorwise method instead of the blockwise one.
+def _fp8_tensor_config():
+    cfg = _fp8_block_config()
+    cfg["config_groups"]["group_0"]["weights"] = {
+        "num_bits": 8,
+        "type": "float",
+        "symmetric": True,
+        "strategy": "tensor",
+        "dynamic": False,
+    }
+    return cfg
+
+
+@pytest.fixture(scope="module")
+def mesh():
+    if not jax.devices():
+        pytest.skip("No JAX devices available for mesh creation.")
+    devices = np.array(jax.local_devices()[:1])
+    device_mesh = devices.reshape((1, ) * len(MESH_AXIS_NAMES))
+    with Mesh(device_mesh, axis_names=MESH_AXIS_NAMES) as m:
+        yield m
+
+
+@pytest.fixture
+def rngs():
+    return nnx.Rngs(42)
+
+
+class _MLP(nnx.Module):
+    """Two linear layers, so we can test per-layer routing / skipping."""
+
+    def __init__(self,
+                 in_features,
+                 out_features,
+                 rngs,
+                 quant_config,
+                 prefix=''):
+        # NOTE: blockwise fp8 create_weights runs `kernel_init` on an fp8 dtype
+        # at construction. The default variance-scaling init uses
+        # truncated_normal -> chlo.erf, which TPU cannot legalize on fp8. Pass
+        # `uniform` (erf-free) like test_fp8's blockwise tests do.
+        kernel_init = nnx.initializers.uniform()
+        self.proj1 = JaxLinear(in_features,
+                               out_features,
+                               rngs=rngs,
+                               quant_config=quant_config,
+                               kernel_init=kernel_init,
+                               prefix=prefix + ".proj1")
+        self.proj2 = JaxLinear(in_features,
+                               out_features,
+                               rngs=rngs,
+                               quant_config=quant_config,
+                               kernel_init=kernel_init,
+                               prefix=prefix + ".proj2")
+
+    def __call__(self, x):
+        return self.proj2(self.proj1(x))
+
+
+class TestCompressedTensorsConfig:
+
+    def test_parses_config_without_error(self):
+        """Smoke test: upstream parsing yields a non-empty target_scheme_map."""
+        config = CompressedTensorsConfig(_fp8_block_config())
+        assert config._target_scheme_map  # parsed something
+        assert "Linear" in config._target_scheme_map
+
+    def test_fp8_block_routes_to_blockwise_method(self, rngs, mesh):
+        """A Linear layer under an fp8-block group -> Fp8BlockwiseLinearMethod."""
+        config = CompressedTensorsConfig(_fp8_block_config())
+        with jax.set_mesh(mesh):
+            mlp = _MLP(16, 16, rngs, config, prefix="mlp")
+        assert isinstance(mlp.proj1.quant_method, Fp8BlockwiseLinearMethod)
+        assert isinstance(mlp.proj2.quant_method, Fp8BlockwiseLinearMethod)
+
+    def test_fp8_block_scale_param_uses_ct_name(self, rngs, mesh):
+        """The blockwise scale param must be named `weight_scale`.
+
+        compressed-tensors checkpoints serialize the dequant scale as
+        `weight_scale`; the method's default name (`weight_scale_inv`,
+        DeepSeek convention) would leave the checkpoint scales with no
+        matching param and weight loading would never complete.
+        """
+        config = CompressedTensorsConfig(_fp8_block_config())
+        with jax.set_mesh(mesh):
+            mlp = _MLP(16, 16, rngs, config, prefix="mlp")
+        assert hasattr(mlp.proj1, "weight_scale")
+        assert not hasattr(mlp.proj1, "weight_scale_inv")
+
+    def test_fp8_tensor_routes_to_tensorwise_method(self, rngs, mesh):
+        """Per-tensor fp8 (no block_structure) -> Fp8TensorwiseLinearMethod."""
+        config = CompressedTensorsConfig(_fp8_tensor_config())
+        with jax.set_mesh(mesh):
+            mlp = _MLP(16, 16, rngs, config, prefix="mlp")
+        assert isinstance(mlp.proj1.quant_method, Fp8TensorwiseLinearMethod)
+
+    def test_ignored_layer_is_skipped(self, rngs, mesh):
+        """A layer matched by the ignore regex -> UnquantizedLinearMethod."""
+        config = CompressedTensorsConfig(
+            _fp8_block_config(ignore=["re:.*proj1"]))
+        with jax.set_mesh(mesh):
+            mlp = _MLP(16, 16, rngs, config, prefix="mlp")
+        # proj1 ignored, proj2 still quantized.
+        assert isinstance(mlp.proj1.quant_method, UnquantizedLinearMethod)
+        assert isinstance(mlp.proj2.quant_method, Fp8BlockwiseLinearMethod)

--- a/tpu_inference/layers/jax/quantization/__init__.py
+++ b/tpu_inference/layers/jax/quantization/__init__.py
@@ -22,7 +22,10 @@ from tpu_inference.layers.jax import JaxModule
 
 
 def get_tpu_quantization_config(vllm_config: VllmConfig):
-    from tpu_inference.layers.common.quant_methods import FP8
+    from tpu_inference.layers.common.quant_methods import (COMPRESSED_TENSORS,
+                                                           FP8)
+    from tpu_inference.layers.jax.quantization.compressed_tensors import \
+        CompressedTensorsConfig
     from tpu_inference.layers.jax.quantization.fp8 import Fp8Config
     from tpu_inference.layers.jax.quantization.unquantized import \
         UnquantizedConfig
@@ -31,6 +34,7 @@ def get_tpu_quantization_config(vllm_config: VllmConfig):
     method_to_config: dict[str | None, type] = {
         None: UnquantizedConfig,
         FP8: Fp8Config,
+        COMPRESSED_TENSORS: CompressedTensorsConfig,
     }
 
     if model_config.quantization not in method_to_config:

--- a/tpu_inference/layers/jax/quantization/compressed_tensors.py
+++ b/tpu_inference/layers/jax/quantization/compressed_tensors.py
@@ -1,0 +1,124 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""JAX-native ``compressed-tensors`` quantization config (issue #2261).
+
+Composes (does not subclass) the upstream vLLM ``CompressedTensorsConfig`` to
+reuse its config-group parsing and scheme detection, then dispatches each layer
+to the existing JAX fp8 quant methods.
+"""
+
+from types import MappingProxyType
+from typing import Optional
+
+from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tensors import \
+    CompressedTensorsConfig as VllmUpstreamCTConfig
+from vllm.model_executor.layers.quantization.compressed_tensors.utils import (
+    check_equal_or_regex_match, should_ignore_layer)
+
+from tpu_inference.layers.jax import JaxModule
+from tpu_inference.layers.jax.linear import JaxEinsum
+from tpu_inference.layers.jax.quantization import QuantizeMethodBase
+from tpu_inference.layers.jax.quantization.configs import (QuantizationConfig,
+                                                           QuantLinearConfig)
+from tpu_inference.layers.jax.quantization.fp8 import (
+    Fp8BlockwiseLinearMethod, Fp8TensorwiseLinearMethod)
+from tpu_inference.layers.jax.quantization.unquantized import \
+    UnquantizedLinearMethod
+
+
+class _Fp8BlockConfigShim:
+    """Stand-in for Fp8Config passed to Fp8BlockwiseLinearMethod.
+
+    That method only reads ``quant_config.weight_block_size``, so exposing that
+    single attribute avoids fabricating a full Fp8Config.
+    """
+
+    def __init__(self, weight_block_size):
+        self.weight_block_size = weight_block_size
+
+
+def _weight_block_size(weight_quant) -> Optional[list[int]]:
+    """Return [block_n, block_k], or None if the weights are not block-quantized."""
+    block = getattr(weight_quant, "block_structure", None)
+    return list(block) if block is not None else None
+
+
+class CompressedTensorsConfig(QuantizationConfig):
+    """JAX-native ``compressed-tensors`` config; registered in the quant map."""
+
+    def __init__(self, hf_quant_config: dict):
+        # Reuse upstream parsing of config_groups -> target_scheme_map + ignore.
+        self._ct = VllmUpstreamCTConfig.from_config(hf_quant_config)
+        self._target_scheme_map = self._ct.target_scheme_map
+        self._ignore = self._ct.ignore
+        # packed_modules_mapping drives fused-layer (gate_up/qkv) ignore
+        # semantics; not yet wired for the JAX path, so match on plain names.
+        self._fused_mapping = getattr(self._ct, "packed_modules_mapping",
+                                      MappingProxyType({}))
+
+    def _match_target(self, layer: JaxModule, prefix: str) -> Optional[dict]:
+        """Return the config-group scheme for ``layer``, or None if unmatched.
+
+        Match priority mirrors upstream ``find_matched_target``: the layer path
+        first, then the module class name.
+        """
+        for target in self._target_scheme_map:
+            if check_equal_or_regex_match(prefix, [target]):
+                return self._target_scheme_map[target]
+        # compressed-tensors also targets layers by module class name (e.g.
+        # "Linear"). Upstream matches on module.__class__.__name__; our JAX
+        # layers are named differently, so map JaxEinsum onto "Linear".
+        if isinstance(layer,
+                      JaxEinsum) and "Linear" in self._target_scheme_map:
+            return self._target_scheme_map["Linear"]
+        return None
+
+    def get_quant_method(self, layer: JaxModule,
+                         prefix: str) -> Optional[QuantizeMethodBase]:
+        if not isinstance(layer, JaxEinsum):
+            return None
+
+        linear_config = QuantLinearConfig(layer, enable_sp=False)
+
+        if should_ignore_layer(prefix,
+                               ignore=self._ignore,
+                               fused_mapping=self._fused_mapping):
+            return UnquantizedLinearMethod(linear_config)
+
+        scheme = self._match_target(layer, prefix)
+        if scheme is None:
+            return UnquantizedLinearMethod(linear_config)
+
+        weight_quant = scheme.get("weights")
+        input_quant = scheme.get("input_activations")
+        # _is_fp8_w8a8 is a private upstream helper; reused deliberately to keep
+        # scheme detection identical to vLLM (accepted coupling risk).
+        if self._ct._is_fp8_w8a8(weight_quant, input_quant):
+            block = _weight_block_size(weight_quant)
+            if block is not None:
+                # compressed-tensors serializes the dequant scale as
+                # "weight_scale" (DeepSeek-style checkpoints, the method's
+                # default, use "weight_scale_inv"), so create the param under
+                # the name the checkpoint will look up.
+                return Fp8BlockwiseLinearMethod(
+                    _Fp8BlockConfigShim(block),
+                    layer,
+                    linear_config,
+                    weight_scale_name="weight_scale")
+            return Fp8TensorwiseLinearMethod(layer, linear_config)
+
+        # TODO: w4a8 / wNa16 schemes need their own JAX methods (not yet ported).
+        raise NotImplementedError(
+            f"compressed-tensors scheme for layer '{prefix}' is not yet "
+            "supported in the JAX path.")

--- a/tpu_inference/layers/jax/quantization/fp8.py
+++ b/tpu_inference/layers/jax/quantization/fp8.py
@@ -166,10 +166,18 @@ class Fp8TensorwiseLinearMethod(QuantizeMethodBase,
 class Fp8BlockwiseLinearMethod(QuantizeMethodBase, common_fp8.Fp8LinearMethod):
     """Block-wise Fp8 method for JAX Linear layer."""
 
-    def __init__(self, quant_config: "Fp8Config", layer: JaxEinsum,
-                 linear_config: QuantLinearConfig):
+    def __init__(self,
+                 quant_config: "Fp8Config",
+                 layer: JaxEinsum,
+                 linear_config: QuantLinearConfig,
+                 weight_scale_name: str = "weight_scale_inv"):
         common_fp8.Fp8LinearMethod.__init__(self, linear_config)
         self.quant_config = quant_config
+        # Checkpoint-dependent name of the dequant scale: DeepSeek-style fp8
+        # checkpoints serialize "weight_scale_inv" while compressed-tensors
+        # uses "weight_scale". Both are the same quantity (the multiplier in
+        # x ~= q * scale); only the serialized name differs.
+        self.weight_scale_name = weight_scale_name
         self.einsum_str = layer.einsum_str
 
         self.out_features = linear_config.out_features
@@ -208,15 +216,17 @@ class Fp8BlockwiseLinearMethod(QuantizeMethodBase, common_fp8.Fp8LinearMethod):
             layer.weight.set_metadata('sharding', self.weight_sharding)
 
             # Per-output-channel scale (1D, covers the free weight dim).
-            layer.weight_scale_inv = nnx.Param(
-                jnp.ones((out_features, ), dtype=layer.dtype),
-                weight_loader=partial(
-                    load_nnx_param_from_reshaped_torch,
-                    permute_dims=None,
-                    param_name=layer.prefix + ".weight_scale_inv",
-                ),
-                eager_sharding=False)
-            layer.weight_scale_inv.set_metadata('sharding', ())
+            scale_param = nnx.Param(jnp.ones((out_features, ),
+                                             dtype=layer.dtype),
+                                    weight_loader=partial(
+                                        load_nnx_param_from_reshaped_torch,
+                                        permute_dims=None,
+                                        param_name=layer.prefix + "." +
+                                        self.weight_scale_name,
+                                    ),
+                                    eager_sharding=False)
+            scale_param.set_metadata('sharding', ())
+            setattr(layer, self.weight_scale_name, scale_param)
             return
 
         # Follow upstream limitation that only float8_e4m3 is supported.
@@ -233,25 +243,26 @@ class Fp8BlockwiseLinearMethod(QuantizeMethodBase, common_fp8.Fp8LinearMethod):
         # Block-wise quantization scale
         block_n, block_k = self.quant_config.weight_block_size[
             0], self.quant_config.weight_block_size[1]
-        layer.weight_scale_inv = nnx.Param(
-            kernel_init(
-                rngs.params(),
-                [(self.in_features + block_k - 1) // block_k,
-                 (out_features + block_n - 1) // block_n],
-                layer.dtype,
-            ),
-            weight_loader=partial(
-                load_nnx_param_from_reshaped_torch,
-                permute_dims=(1, 0),
-                param_name=layer.prefix + ".weight_scale_inv",
-            ),
-            eager_sharding=False)
-        layer.weight_scale_inv.set_metadata('sharding', self.weight_sharding)
+        scale_param = nnx.Param(kernel_init(
+            rngs.params(),
+            [(self.in_features + block_k - 1) // block_k,
+             (out_features + block_n - 1) // block_n],
+            layer.dtype,
+        ),
+                                weight_loader=partial(
+                                    load_nnx_param_from_reshaped_torch,
+                                    permute_dims=(1, 0),
+                                    param_name=layer.prefix + "." +
+                                    self.weight_scale_name,
+                                ),
+                                eager_sharding=False)
+        scale_param.set_metadata('sharding', self.weight_sharding)
+        setattr(layer, self.weight_scale_name, scale_param)
 
         # Force the parameters to be loaded onto CPU, such that in `process_weights_after_loading`
         # we can process the weights on CPU to avoid OOM on device.
         layer.weight.set_metadata('mesh', cpu_mesh())
-        layer.weight_scale_inv.set_metadata('mesh', cpu_mesh())
+        scale_param.set_metadata('mesh', cpu_mesh())
         if layer.bias is not None:
             layer.bias.set_metadata('mesh', cpu_mesh())
 
@@ -264,9 +275,9 @@ class Fp8BlockwiseLinearMethod(QuantizeMethodBase, common_fp8.Fp8LinearMethod):
             # needed — the batched matmul uses dot_general with FP8 natively.
             return True
 
+        scale_param = getattr(layer, self.weight_scale_name)
         if not layer.weight.get_metadata(
-                "_is_loaded",
-                False) or not layer.weight_scale_inv.get_metadata(
+                "_is_loaded", False) or not scale_param.get_metadata(
                     "_is_loaded", False):
             # Weight and scale could spread across multiple files,
             # so we only process once both of them are loaded.
@@ -275,7 +286,7 @@ class Fp8BlockwiseLinearMethod(QuantizeMethodBase, common_fp8.Fp8LinearMethod):
         # Do the re-quant process on CPU to avoid OOM on device.
         with cpu_mesh_context():
             weight = layer.weight[...]
-            weight_scale_inv = layer.weight_scale_inv[...]
+            weight_scale_inv = scale_param[...]
             bias = layer.bias[...] if getattr(layer, 'bias',
                                               None) is not None else None
             if bias is not None:
@@ -293,7 +304,7 @@ class Fp8BlockwiseLinearMethod(QuantizeMethodBase, common_fp8.Fp8LinearMethod):
                 enable_kernel=self.linear_config.enable_quantized_matmul_kernel
             )
             delattr(layer, 'weight')
-            delattr(layer, 'weight_scale_inv')
+            delattr(layer, self.weight_scale_name)
             delattr(layer, 'bias')
 
         # Put onto the device.
@@ -305,7 +316,8 @@ class Fp8BlockwiseLinearMethod(QuantizeMethodBase, common_fp8.Fp8LinearMethod):
         )
         if self.linear_config.fuse_matmuls:
             layer.weight = nnx.Param(weights.weight)
-            layer.weight_scale_inv = nnx.Param(weights.weight_scale)
+            setattr(layer, self.weight_scale_name,
+                    nnx.Param(weights.weight_scale))
             layer.bias = nnx.Param(weights.bias) if bias is not None else None
         else:
             raise NotImplementedError(
@@ -319,7 +331,7 @@ class Fp8BlockwiseLinearMethod(QuantizeMethodBase, common_fp8.Fp8LinearMethod):
             out = sharded_quantized_batched_matmul(
                 x,
                 layer.weight[...],
-                layer.weight_scale_inv[...],
+                getattr(layer, self.weight_scale_name)[...],
                 einsum_str=self.einsum_str,
                 weight_sharding=self.weight_sharding,
                 mesh=self.linear_config.mesh)
@@ -328,7 +340,8 @@ class Fp8BlockwiseLinearMethod(QuantizeMethodBase, common_fp8.Fp8LinearMethod):
         if not self.linear_config.fuse_matmuls:
             raise NotImplementedError(
                 "Fp8 block-wise linear method only supports fuse_matmuls.")
-        weight, scale = layer.weight[...], layer.weight_scale_inv[...]
+        weight = layer.weight[...]
+        scale = getattr(layer, self.weight_scale_name)[...]
         bias = layer.bias[...] if layer.bias is not None else None
         if len(x.shape) > 2:
             x = x.reshape(-1, self.in_features)


### PR DESCRIPTION
# Description

Registers a JAX-native `compressed-tensors` quantization config so that fp8 compressed-tensors checkpoints (e.g. `RedHatAI/gemma-4-31B-it-FP8-block` / `-FP8-Dynamic`) can be loaded through the JAX path instead of a hand-written Qwix patch.

Previously the JAX quantization delegation map (`layers/jax/quantization/__init__.py`) only knew about `fp8` and unquantized checkpoints; a compressed-tensors checkpoint had no config to dispatch to. This PR adds that config and wires it into the map.

The new `CompressedTensorsConfig` holds a parsed upstream vLLM `CompressedTensorsConfig` and reuses its `config_groups` parsing (`target_scheme_map` / `ignore`) and scheme detection. `get_quant_method` then does a JAX-native per-layer dispatch: matched fp8 w8a8 layers are routed to the existing `Fp8BlockwiseLinearMethod` / `Fp8TensorwiseLinearMethod`, which already run fp8×fp8 on the MXU, so no new build/quantize/apply code is introduced.

Notable details:

- `Fp8BlockwiseLinearMethod` gains a `weight_scale_name` parameter, following the existing `Fp8FusedMoEMethod.weight_scale_name` pattern. The default (`"weight_scale_inv"`) keeps DeepSeek-style fp8 checkpoints unchanged; the compressed-tensors path passes `"weight_scale"`, which is the name those checkpoints serialize (verified against the gemma-4 FP8-block safetensors index). Without this, the block scales find no matching param and weight loading never completes. Both names are the same quantity (the dequant multiplier), so this is a pure rename — no reciprocal involved.
- Upstream `find_matched_target` needs a torch module (it matches on `module.__class__.__name__`), so per-layer matching is reimplemented with the upstream pure-string regex helpers plus a `JaxEinsum -> "Linear"` mapping.
- A small shim supplies `weight_block_size` to `Fp8BlockwiseLinearMethod` instead of fabricating a full `Fp8Config`.

**Scope / shortcomings (follow-ups):**

- Only fp8 w8a8 is supported (block-wise and per-tensor/channel weights, both with dynamic activations — matching the two target checkpoints). w4a8 / wNa16 schemes raise `NotImplementedError` and are left to a follow-up.
- Dense models only. Both named target checkpoints are dense (`enable_moe_block: false`, `num_experts: null` in their configs); MoE dispatch is intentionally deferred and will land with its own tests when there is a compressed-tensors MoE target.
- End-to-end loading/serving of the named checkpoints is not yet validated (the 31B models need a multi-chip slice). Two known unknowns remain for e2e: the per-channel scale shape on the FP8-Dynamic variant (`[out, 1]` in the checkpoint vs `(out,)` param), and fused-layer (gate_up/qkv) ignore semantics — `packed_modules_mapping` is not yet wired for the JAX path.
- Scheme detection reuses the private upstream `_is_fp8_w8a8` helper (deliberate coupling, kept identical to the torch path's behavior).

Related issue: #2261

# Tests

Added `tests/layers/jax/quantization/test_compressed_tensors.py` (mirrors `test_fp8.py::TestFp8Config`), asserting per-layer routing from a compressed-tensors `quantization_config`:

- fp8 block group -> `Fp8BlockwiseLinearMethod`
- fp8 per-tensor group -> `Fp8TensorwiseLinearMethod`
- `ignore` regex -> `UnquantizedLinearMethod` (per-layer: one layer skipped while its sibling stays quantized)
- blockwise scale param is created under the compressed-tensors name (`weight_scale`, not `weight_scale_inv`)
- upstream config parsing smoke test

Run:

```
pytest tests/layers/jax/quantization/test_compressed_tensors.py -v
```

The first four tests were validated on a v5e TPU VM (4 passed). The scale-name test was added afterwards together with the `weight_scale_name` change and has only been checked locally (syntax/lint); it will be exercised by CI. Existing `test_fp8.py` coverage guards the default-name (DeepSeek-style) path.

# Checklist

Before submitting this PR, please make sure:

- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [ ] I have made or will make corresponding changes to any relevant documentation. (No user-facing docs affected; internal quantization dispatch only.)