### PR TITLE
[New Model] Add JAX-native Qwen3-Next support

### DIFF
--- a/.buildkite/models/Qwen_Qwen3-Next-80B-A3B-Instruct.yml
+++ b/.buildkite/models/Qwen_Qwen3-Next-80B-A3B-Instruct.yml
@@ -1,0 +1,40 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Unit tests only for now. The accuracy and benchmark stages need
+# thresholds measured on real TPU hardware for the 80B-A3B checkpoint,
+# which has not been run yet; add them once those numbers exist.
+steps:
+  - label: "${TPU_VERSION:-tpu6e} Unit tests for Qwen/Qwen3-Next-80B-A3B-Instruct"
+    key: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-Next-80B-A3B-Instruct_UnitTest"
+    agents:
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    soft_fail: true
+    commands:
+      - |
+        .buildkite/scripts/run_in_docker.sh \
+          bash -c 'python3 -m pytest -s -v -x /workspace/tpu_inference/tests/models/jax/test_qwen3_next.py'
+  - label: "${TPU_VERSION:-tpu6e} Record unit test result for Qwen/Qwen3-Next-80B-A3B-Instruct"
+    key: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen3-Next-80B-A3B-Instruct_UnitTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-Next-80B-A3B-Instruct_UnitTest"
+    env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
+      CI_TARGET: "Qwen/Qwen3-Next-80B-A3B-Instruct"
+      CI_STAGE: "UnitTest"
+      CI_CATEGORY: "text-only"
+    agents:
+      queue: cpu
+    commands:
+      - |
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_Qwen_Qwen3-Next-80B-A3B-Instruct_UnitTest

--- a/tests/models/jax/test_qwen3_next.py
+++ b/tests/models/jax/test_qwen3_next.py
@@ -361,7 +361,7 @@ class TestSparseMoeBlock:
                                                       prefix="mlp")
 
     def _copy_weights(self, block, hf):
-        block.gate.kernel_DE.value = jnp.asarray(
+        block.gate.weight.value = jnp.asarray(
             hf.gate.weight.detach().numpy().T)
         # HF stores fused 3D expert tensors: gate_up_proj (E, 2F, D) with
         # the gate rows first, down_proj (E, D, F).
@@ -373,11 +373,11 @@ class TestSparseMoeBlock:
             gate_up[:, intermediate:, :].transpose(0, 2, 1))
         block.experts.kernel_down_proj_EFD.value = jnp.asarray(
             hf.experts.down_proj.detach().numpy().transpose(0, 2, 1))
-        block.shared_expert_gate_proj.weight.value = jnp.asarray(
+        block.shared_expert.gate_proj.weight.value = jnp.asarray(
             hf.shared_expert.gate_proj.weight.detach().numpy().T)
-        block.shared_expert_up_proj.weight.value = jnp.asarray(
+        block.shared_expert.up_proj.weight.value = jnp.asarray(
             hf.shared_expert.up_proj.weight.detach().numpy().T)
-        block.shared_expert_down_proj.weight.value = jnp.asarray(
+        block.shared_expert.down_proj.weight.value = jnp.asarray(
             hf.shared_expert.down_proj.weight.detach().numpy().T)
         block.shared_expert_gate.weight.value = jnp.asarray(
             hf.shared_expert_gate.weight.detach().numpy().T)
@@ -410,3 +410,87 @@ class TestSparseMoeBlock:
                                    want[0].numpy(),
                                    rtol=2e-3,
                                    atol=2e-3)
+
+
+class TestCheckpointRoundTrip:
+
+    def test_tiny_checkpoint_load_and_forward(self, tmp_path, monkeypatch, rng,
+                                              mesh, mock_vllm_config):
+        """Saves a tiny random HF Qwen3-Next checkpoint, loads it through
+        the real vLLM loader path into the JAX model and compares logits
+        for a short prefill against HF transformers. This exercises every
+        weight mapping rule (zero centered norm folding, doubled q_proj,
+        GDN projections, fused 3D experts, shared expert, lm_head)."""
+        import jax as jax_module
+        from vllm.config import set_current_vllm_config
+        from vllm.model_executor.model_loader import get_model_loader
+
+        from tpu_inference.distributed.jax_parallel_state import \
+            init_pp_distributed_environment
+        from tpu_inference.layers.jax.quantization import \
+            get_tpu_quantization_config
+        from tpu_inference.models.jax.qwen3_next import Qwen3NextForCausalLM
+
+        monkeypatch.setattr(qwen3_next, "_gdn_core", reference_gdn_core)
+        monkeypatch.setattr(qwen3_next, "attention", fake_attention)
+        monkeypatch.setenv("USE_DENSE_MOE", "1")
+
+        from transformers.models.qwen3_next.modeling_qwen3_next import \
+            Qwen3NextForCausalLM as HFModel
+        cfg = tiny_config()
+        cfg._attn_implementation = "eager"
+        torch.manual_seed(4)
+        hf = HFModel(cfg).float().eval()
+        with torch.no_grad():
+            for layer in hf.model.layers:
+                layer.mlp.experts.gate_up_proj.normal_(0.0, 0.05)
+                layer.mlp.experts.down_proj.normal_(0.0, 0.05)
+                layer.mlp.gate.weight.normal_(0.0, 0.05)
+        hf.save_pretrained(tmp_path / "ckpt")
+
+        from unittest.mock import MagicMock
+        vllm_config = mock_vllm_config(str(tmp_path / "ckpt"), "auto")
+        vllm_config.model_config.dtype = jnp.float32
+        vllm_config.parallel_config = MagicMock()
+        vllm_config.parallel_config.tensor_parallel_size = 1
+        vllm_config.parallel_config.enable_expert_parallel = False
+        vllm_config.parallel_config.enable_ep_weight_filter = False
+        init_pp_distributed_environment(
+            ip="",
+            rank=0,
+            world_size=1,
+            device=jax_module.devices()[0],
+            need_pp=False,
+        )
+        vllm_config.quant_config = get_tpu_quantization_config(vllm_config)
+
+        with jax_module.set_mesh(mesh):
+            model = Qwen3NextForCausalLM(vllm_config, rng, mesh)
+            loader = get_model_loader(vllm_config.load_config)
+            with set_current_vllm_config(vllm_config):
+                loader.load_weights(model, vllm_config.model_config)
+
+        seq_len = 5
+        input_ids = torch.arange(seq_len)[None] % cfg.vocab_size
+        with torch.no_grad():
+            want_logits = hf(input_ids).logits[0]
+
+        kv_caches = []
+        for layer_type in cfg.layer_types:
+            if layer_type == "linear_attention":
+                kv_caches.append(empty_gdn_state(cfg))
+            else:
+                kv_caches.append(None)
+
+        with jax_module.set_mesh(mesh):
+            _, hidden, _, _ = model(
+                kv_caches,
+                jnp.asarray(input_ids[0].numpy()),
+                prefill_metadata(seq_len),
+            )
+            got_logits = model.compute_logits(hidden)
+        got = np.asarray(got_logits)[:, :cfg.vocab_size]
+        np.testing.assert_allclose(got,
+                                   want_logits.numpy(),
+                                   rtol=5e-3,
+                                   atol=5e-3)

--- a/tests/models/jax/test_qwen3_next.py
+++ b/tests/models/jax/test_qwen3_next.py
@@ -1,0 +1,250 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Numerics tests for the JAX native Qwen3-Next model against the HF
+transformers implementation. These run on CPU: the fused Pallas conv1d + GDN
+kernel is substituted with the pure JAX reference implementations."""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import torch
+from flax import nnx
+from transformers.models.qwen3_next.configuration_qwen3_next import \
+    Qwen3NextConfig
+from transformers.models.qwen3_next.modeling_qwen3_next import \
+    Qwen3NextGatedDeltaNet as HFGatedDeltaNet
+
+from tpu_inference.layers.common.attention_metadata import AttentionMetadata
+from tpu_inference.models.jax import qwen3_next
+
+
+def tiny_config() -> Qwen3NextConfig:
+    return Qwen3NextConfig(
+        hidden_size=64,
+        intermediate_size=128,
+        num_hidden_layers=4,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=32,
+        partial_rotary_factor=0.25,
+        rope_theta=10000000,
+        linear_num_key_heads=2,
+        linear_num_value_heads=4,
+        linear_key_head_dim=16,
+        linear_value_head_dim=16,
+        linear_conv_kernel_dim=4,
+        num_experts=8,
+        num_experts_per_tok=2,
+        moe_intermediate_size=32,
+        shared_expert_intermediate_size=32,
+        decoder_sparse_step=1,
+        norm_topk_prob=True,
+        vocab_size=128,
+        rms_norm_eps=1e-6,
+        full_attention_interval=4,
+        max_position_embeddings=256,
+    )
+
+
+def single_device_mesh() -> jax.sharding.Mesh:
+    devices = np.asarray(jax.devices()[:1])
+    return jax.sharding.Mesh(devices.reshape((1, 1, 1, 1)),
+                             ('data', 'attn_dp', 'model', 'expert'))
+
+
+def _silu(x):
+    return x / (1.0 + np.exp(-x))
+
+
+def _l2norm(x, eps=1e-6):
+    return x / np.sqrt((x * x).sum(-1, keepdims=True) + eps)
+
+
+def reference_gdn_core(mixed_qkv, b, a, conv_state, recurrent_state,
+                       conv_weight, conv_bias, a_log, dt_bias, state_indices,
+                       query_start_loc, distribution, seq_lens, *, n_kq, n_v,
+                       d_k, d_v, kernel_size, mesh):
+    """Token by token NumPy substitute for run_jax_gdn_attention, ported
+    directly from HF's torch_causal_conv1d_update and
+    torch_recurrent_gated_delta_rule (with qk l2 norm and query scaling)."""
+    del mesh
+    assert conv_bias is None
+    mixed = np.asarray(mixed_qkv, dtype=np.float32)
+    b = np.asarray(b, dtype=np.float32)
+    a = np.asarray(a, dtype=np.float32)
+    new_conv_state = np.array(conv_state, dtype=np.float32)
+    new_recurrent_state = np.array(recurrent_state, dtype=np.float32)
+    w = np.asarray(conv_weight, dtype=np.float32)[:, 0, :]  # (dim, K)
+    a_log = np.asarray(a_log, dtype=np.float32)
+    dt_bias = np.asarray(dt_bias, dtype=np.float32)
+    query_start_loc = np.asarray(query_start_loc)
+    seq_lens = np.asarray(seq_lens)
+    state_indices = np.asarray(state_indices)
+
+    key_dim = n_kq * d_k
+    r = n_v // n_kq
+    out = np.zeros((mixed.shape[0], n_v * d_v), dtype=np.float32)
+    num_seqs = int(np.asarray(distribution)[2])
+    for s in range(num_seqs):
+        start, end = int(query_start_loc[s]), int(query_start_loc[s + 1])
+        slot = int(state_indices[s])
+        state = new_recurrent_state[slot].copy()  # (n_v, d_k, d_v)
+        conv_buf = new_conv_state[slot].copy()  # (K - 1, dim)
+        if int(seq_lens[s]) - (end - start) == 0:
+            state[:] = 0.0
+            conv_buf[:] = 0.0
+        for t in range(start, end):
+            window = np.concatenate([conv_buf, mixed[t][None, :]], axis=0)
+            conv_out = (window * w.T).sum(axis=0)
+            conv_buf = window[1:]
+            h = _silu(conv_out)
+            q = h[:key_dim].reshape(n_kq, d_k)
+            k = h[key_dim:2 * key_dim].reshape(n_kq, d_k)
+            v = h[2 * key_dim:].reshape(n_v, d_v)
+            q = np.repeat(q, r, axis=0)
+            k = np.repeat(k, r, axis=0)
+            q = _l2norm(q) / np.sqrt(d_k)
+            k = _l2norm(k)
+            beta = 1.0 / (1.0 + np.exp(-b[t]))  # (n_v,)
+            g = -np.exp(a_log) * np.log1p(np.exp(a[t] + dt_bias))
+            state = state * np.exp(g)[:, None, None]
+            kv_mem = (state * k[:, :, None]).sum(axis=1)  # (n_v, d_v)
+            delta = (v - kv_mem) * beta[:, None]
+            state = state + k[:, :, None] * delta[:, None, :]
+            out[t] = (state * q[:, :, None]).sum(axis=1).reshape(-1)
+        new_recurrent_state[slot] = state
+        new_conv_state[slot] = conv_buf
+    return (jnp.asarray(new_conv_state),
+            jnp.asarray(new_recurrent_state)), jnp.asarray(out)
+
+
+def build_gdn_block(cfg, mesh) -> qwen3_next.Qwen3NextGatedDeltaNet:
+    with jax.set_mesh(mesh):
+        return qwen3_next.Qwen3NextGatedDeltaNet(config=cfg,
+                                                 dtype=jnp.float32,
+                                                 rng=nnx.Rngs(0),
+                                                 mesh=mesh,
+                                                 quant_config=None,
+                                                 prefix="linear_attn")
+
+
+def copy_hf_gdn_weights(block, hf):
+    block.in_proj_qkvz.weight.value = jnp.asarray(
+        hf.in_proj_qkvz.weight.detach().numpy().T)
+    block.in_proj_ba.weight.value = jnp.asarray(
+        hf.in_proj_ba.weight.detach().numpy().T)
+    block.conv1d.weight.value = jnp.asarray(hf.conv1d.weight.detach().numpy())
+    block.A_log.value = jnp.asarray(hf.A_log.detach().numpy())
+    block.dt_bias.value = jnp.asarray(hf.dt_bias.detach().numpy())
+    block.norm.scale.value = jnp.asarray(hf.norm.weight.detach().numpy())
+    block.out_proj.weight.value = jnp.asarray(
+        hf.out_proj.weight.detach().numpy().T)
+
+
+def prefill_metadata(seq_len, max_reqs=2):
+    query_start_loc = np.zeros(max_reqs + 1, dtype=np.int32)
+    query_start_loc[1:] = seq_len
+    seq_lens = np.zeros(max_reqs, dtype=np.int32)
+    seq_lens[0] = seq_len
+    state_indices = np.zeros(max_reqs, dtype=np.int32)
+    state_indices[0] = 1
+    return AttentionMetadata(
+        input_positions=jnp.arange(seq_len),
+        seq_lens=jnp.asarray(seq_lens),
+        query_start_loc=jnp.asarray(query_start_loc),
+        request_distribution=jnp.asarray([0, 1, 1], dtype=jnp.int32),
+        mamba_state_indices=jnp.asarray(state_indices),
+    )
+
+
+def decode_metadata(context_len, max_reqs=2):
+    query_start_loc = np.zeros(max_reqs + 1, dtype=np.int32)
+    query_start_loc[1:] = 1
+    seq_lens = np.zeros(max_reqs, dtype=np.int32)
+    seq_lens[0] = context_len + 1
+    state_indices = np.zeros(max_reqs, dtype=np.int32)
+    state_indices[0] = 1
+    return AttentionMetadata(
+        input_positions=jnp.asarray([context_len]),
+        seq_lens=jnp.asarray(seq_lens),
+        query_start_loc=jnp.asarray(query_start_loc),
+        request_distribution=jnp.asarray([1, 1, 1], dtype=jnp.int32),
+        mamba_state_indices=jnp.asarray(state_indices),
+    )
+
+
+def empty_gdn_state(cfg, num_blocks=3):
+    conv_dim = (2 * cfg.linear_num_key_heads * cfg.linear_key_head_dim +
+                cfg.linear_num_value_heads * cfg.linear_value_head_dim)
+    conv_state = jnp.zeros(
+        (num_blocks, cfg.linear_conv_kernel_dim - 1, conv_dim),
+        dtype=jnp.float32)
+    recurrent_state = jnp.zeros(
+        (num_blocks, cfg.linear_num_value_heads, cfg.linear_key_head_dim,
+         cfg.linear_value_head_dim),
+        dtype=jnp.float32)
+    return conv_state, recurrent_state
+
+
+class TestGatedDeltaNet:
+
+    def test_prefill_matches_hf(self, monkeypatch):
+        monkeypatch.setattr(qwen3_next, "_gdn_core", reference_gdn_core)
+        cfg = tiny_config()
+        torch.manual_seed(0)
+        hf = HFGatedDeltaNet(cfg, layer_idx=0).float().eval()
+        mesh = single_device_mesh()
+        block = build_gdn_block(cfg, mesh)
+        copy_hf_gdn_weights(block, hf)
+
+        seq_len = 6
+        x = torch.randn(1, seq_len, cfg.hidden_size)
+        with torch.no_grad():
+            want = hf(hidden_states=x)
+
+        state = empty_gdn_state(cfg)
+        _, got = block(state, jnp.asarray(x[0].numpy()),
+                       prefill_metadata(seq_len))
+        np.testing.assert_allclose(np.asarray(got),
+                                   want[0].numpy(),
+                                   rtol=2e-3,
+                                   atol=2e-3)
+
+    def test_decode_matches_hf_prefill_tail(self, monkeypatch):
+        """Runs prefill for T tokens then one decode step and checks the
+        decode output equals HF's output for position T when HF processes
+        all T+1 tokens in one pass. This exercises the recurrent and conv
+        state carry between calls."""
+        monkeypatch.setattr(qwen3_next, "_gdn_core", reference_gdn_core)
+        cfg = tiny_config()
+        torch.manual_seed(1)
+        hf = HFGatedDeltaNet(cfg, layer_idx=0).float().eval()
+        mesh = single_device_mesh()
+        block = build_gdn_block(cfg, mesh)
+        copy_hf_gdn_weights(block, hf)
+
+        seq_len = 6
+        x = torch.randn(1, seq_len + 1, cfg.hidden_size)
+        with torch.no_grad():
+            want_full = hf(hidden_states=x)
+
+        state = empty_gdn_state(cfg)
+        state, _ = block(state, jnp.asarray(x[0, :seq_len].numpy()),
+                         prefill_metadata(seq_len))
+        _, got_last = block(state, jnp.asarray(x[0, seq_len:].numpy()),
+                            decode_metadata(seq_len))
+        np.testing.assert_allclose(np.asarray(got_last),
+                                   want_full[0, seq_len:].numpy(),
+                                   rtol=2e-3,
+                                   atol=2e-3)

--- a/tests/models/jax/test_qwen3_next.py
+++ b/tests/models/jax/test_qwen3_next.py
@@ -550,10 +550,15 @@ class TestCheckpointRoundTrip:
 class TestTpuSmoke:
 
     def test_forward_with_real_kernels(self, rng, mesh, mock_vllm_config):
-        """Builds a shrunken Qwen3-Next (4 layers: 3 GDN + 1 full attention)
-        with dummy weights and runs one prefill through the real kernels,
-        checking output shapes and that the GDN states were written."""
+        """Loads the real Qwen3-Next config but only the first 4 layers
+        (full_attention_interval=4, so this covers 3 GDN + 1 full attention)
+        via the skip-layers loader, then runs one prefill through the fused
+        GDN and ragged paged attention kernels, checking output shapes and
+        that the linear attention states were written."""
         from unittest.mock import MagicMock
+
+        from vllm.config import set_current_vllm_config
+        from vllm.model_executor.model_loader import get_model_loader
 
         from tpu_inference.distributed.jax_parallel_state import \
             init_pp_distributed_environment
@@ -566,10 +571,12 @@ class TestTpuSmoke:
         vllm_config = mock_vllm_config("Qwen/Qwen3-Next-80B-A3B-Instruct",
                                        "auto")
         hf_config = vllm_config.model_config.hf_config
+        # No need to load the full model; the first 4 layers exercise both a
+        # GDN and a full-attention layer.
         hf_config.num_hidden_layers = 4
         hf_config.layer_types = hf_config.layer_types[:4]
-        hf_config.num_experts = 16
-        vllm_config.load_config.load_format = "jax_dummy"
+        vllm_config.load_config.load_format = "skip_layers_model_loader_for_test"
+        vllm_config.load_config.num_layers_to_load_for_test = 4
         vllm_config.parallel_config = MagicMock()
         vllm_config.parallel_config.tensor_parallel_size = 1
         vllm_config.parallel_config.enable_expert_parallel = False
@@ -584,11 +591,6 @@ class TestTpuSmoke:
 
         with jax.set_mesh(mesh):
             model = Qwen3NextForCausalLM(vllm_config, rng, mesh)
-            # The dummy loader fills every param and runs the per module
-            # post processing that fuses the MoE kernels for the GMM
-            # backend.
-            from vllm.config import set_current_vllm_config
-            from vllm.model_executor.model_loader import get_model_loader
             loader = get_model_loader(vllm_config.load_config)
             with set_current_vllm_config(vllm_config):
                 loader.load_weights(model, vllm_config.model_config)

--- a/tests/models/jax/test_qwen3_next.py
+++ b/tests/models/jax/test_qwen3_next.py
@@ -36,7 +36,9 @@ def tiny_config() -> Qwen3NextConfig:
         num_hidden_layers=4,
         num_attention_heads=4,
         num_key_value_heads=2,
-        head_dim=32,
+        # 128 so get_padded_head_dim is the identity and numerics line up
+        # with HF without padding effects.
+        head_dim=128,
         partial_rotary_factor=0.25,
         rope_theta=10000000,
         linear_num_key_heads=2,
@@ -246,5 +248,165 @@ class TestGatedDeltaNet:
                             decode_metadata(seq_len))
         np.testing.assert_allclose(np.asarray(got_last),
                                    want_full[0, seq_len:].numpy(),
+                                   rtol=2e-3,
+                                   atol=2e-3)
+
+
+def fake_attention(kv_cache, q, k, v, attention_metadata, mesh,
+                   head_dim_original, **kwargs):
+    """NumPy causal softmax attention with GQA, standing in for the ragged
+    paged attention TPU kernel."""
+    q_np = np.asarray(q, dtype=np.float32)
+    k_np = np.asarray(k, dtype=np.float32)
+    v_np = np.asarray(v, dtype=np.float32)
+    seq_len, num_heads, _ = q_np.shape
+    rep = num_heads // k_np.shape[1]
+    k_np = np.repeat(k_np, rep, axis=1)
+    v_np = np.repeat(v_np, rep, axis=1)
+    scores = np.einsum('tnh,snh->nts', q_np, k_np)
+    scores = scores * (head_dim_original**-0.5)
+    causal = np.triu(np.ones((seq_len, seq_len), dtype=bool), k=1)
+    scores = np.where(causal[None, :, :], -np.inf, scores)
+    scores = scores - scores.max(axis=-1, keepdims=True)
+    probs = np.exp(scores)
+    probs = probs / probs.sum(axis=-1, keepdims=True)
+    out = np.einsum('nts,snh->tnh', probs, v_np)
+    return kv_cache, jnp.asarray(out)
+
+
+class TestFullAttention:
+
+    def _build(self, cfg, mesh):
+        with jax.set_mesh(mesh):
+            return qwen3_next.Qwen3NextAttention(config=cfg,
+                                                 dtype=jnp.float32,
+                                                 rng=nnx.Rngs(0),
+                                                 mesh=mesh,
+                                                 kv_cache_dtype="auto",
+                                                 quant_config=None,
+                                                 prefix="self_attn")
+
+    def _copy_weights(self, block, hf, cfg):
+        num_heads = cfg.num_attention_heads
+        head_dim = cfg.head_dim
+        hidden = cfg.hidden_size
+        num_kv = cfg.num_key_value_heads
+        # HF q_proj weight is (num_heads * 2 * head_dim, hidden) with the
+        # query and gate halves fused per head.
+        q_w = hf.q_proj.weight.detach().numpy().reshape(
+            num_heads, 2 * head_dim, hidden)
+        block.q_proj.weight.value = jnp.asarray(q_w.transpose(2, 0, 1))
+        k_w = hf.k_proj.weight.detach().numpy().reshape(
+            num_kv, head_dim, hidden)
+        block.k_proj.weight.value = jnp.asarray(k_w.transpose(2, 0, 1))
+        v_w = hf.v_proj.weight.detach().numpy().reshape(
+            num_kv, head_dim, hidden)
+        block.v_proj.weight.value = jnp.asarray(v_w.transpose(2, 0, 1))
+        o_w = hf.o_proj.weight.detach().numpy().reshape(
+            hidden, num_heads, head_dim)
+        block.o_proj.weight.value = jnp.asarray(o_w.transpose(1, 2, 0))
+        # Zero centered norms: fold the +1 into the scale.
+        block.q_norm.scale.value = jnp.asarray(
+            hf.q_norm.weight.detach().numpy()) + 1.0
+        block.k_norm.scale.value = jnp.asarray(
+            hf.k_norm.weight.detach().numpy()) + 1.0
+
+    def test_matches_hf(self, monkeypatch):
+        from transformers.models.qwen3_next.modeling_qwen3_next import (
+            Qwen3NextAttention, Qwen3NextRotaryEmbedding)
+        monkeypatch.setattr(qwen3_next, "attention", fake_attention)
+        cfg = tiny_config()
+        cfg._attn_implementation = "eager"
+        torch.manual_seed(2)
+        hf = Qwen3NextAttention(cfg, layer_idx=3).float().eval()
+        mesh = single_device_mesh()
+        block = self._build(cfg, mesh)
+        self._copy_weights(block, hf, cfg)
+
+        seq_len = 5
+        x = torch.randn(1, seq_len, cfg.hidden_size)
+        rotary = Qwen3NextRotaryEmbedding(cfg)
+        position_ids = torch.arange(seq_len)[None]
+        cos, sin = rotary(x, position_ids)
+        causal_mask = torch.full((1, 1, seq_len, seq_len),
+                                 torch.finfo(torch.float32).min).triu(1)
+        with torch.no_grad():
+            want, _ = hf(x,
+                         position_embeddings=(cos, sin),
+                         attention_mask=causal_mask)
+
+        _, got = block(None, jnp.asarray(x[0].numpy()),
+                       prefill_metadata(seq_len))
+        np.testing.assert_allclose(np.asarray(got),
+                                   want[0].numpy(),
+                                   rtol=2e-3,
+                                   atol=2e-3)
+
+
+class TestSparseMoeBlock:
+
+    def _build(self, cfg, mesh):
+        from unittest.mock import MagicMock
+
+        from tpu_inference.layers.jax.quantization.unquantized import \
+            UnquantizedConfig
+        vllm_config = MagicMock()
+        vllm_config.model_config.hf_text_config = cfg
+        vllm_config.model_config.dtype = jnp.float32
+        vllm_config.quant_config = UnquantizedConfig({})
+        with jax.set_mesh(mesh):
+            return qwen3_next.Qwen3NextSparseMoeBlock(vllm_config=vllm_config,
+                                                      rng=nnx.Rngs(0),
+                                                      mesh=mesh,
+                                                      prefix="mlp")
+
+    def _copy_weights(self, block, hf):
+        block.gate.kernel_DE.value = jnp.asarray(
+            hf.gate.weight.detach().numpy().T)
+        # HF stores fused 3D expert tensors: gate_up_proj (E, 2F, D) with
+        # the gate rows first, down_proj (E, D, F).
+        gate_up = hf.experts.gate_up_proj.detach().numpy()
+        intermediate = gate_up.shape[1] // 2
+        block.experts.kernel_gating_EDF.value = jnp.asarray(
+            gate_up[:, :intermediate, :].transpose(0, 2, 1))
+        block.experts.kernel_up_proj_EDF.value = jnp.asarray(
+            gate_up[:, intermediate:, :].transpose(0, 2, 1))
+        block.experts.kernel_down_proj_EFD.value = jnp.asarray(
+            hf.experts.down_proj.detach().numpy().transpose(0, 2, 1))
+        block.shared_expert_gate_proj.weight.value = jnp.asarray(
+            hf.shared_expert.gate_proj.weight.detach().numpy().T)
+        block.shared_expert_up_proj.weight.value = jnp.asarray(
+            hf.shared_expert.up_proj.weight.detach().numpy().T)
+        block.shared_expert_down_proj.weight.value = jnp.asarray(
+            hf.shared_expert.down_proj.weight.detach().numpy().T)
+        block.shared_expert_gate.weight.value = jnp.asarray(
+            hf.shared_expert_gate.weight.detach().numpy().T)
+
+    def test_matches_hf(self, monkeypatch):
+        from transformers.models.qwen3_next.modeling_qwen3_next import \
+            Qwen3NextSparseMoeBlock
+        monkeypatch.setenv("USE_DENSE_MOE", "1")
+        cfg = tiny_config()
+        torch.manual_seed(3)
+        hf = Qwen3NextSparseMoeBlock(cfg).float().eval()
+        # The fused expert tensors are created with torch.empty and only
+        # initialized through from_pretrained; fill them explicitly.
+        with torch.no_grad():
+            hf.experts.gate_up_proj.normal_(0.0, 0.05)
+            hf.experts.down_proj.normal_(0.0, 0.05)
+            hf.gate.weight.normal_(0.0, 0.05)
+        mesh = single_device_mesh()
+        block = self._build(cfg, mesh)
+        self._copy_weights(block, hf)
+
+        x = torch.randn(6, cfg.hidden_size)
+        with torch.no_grad():
+            want = hf(x[None])
+
+        with jax.set_mesh(mesh):
+            got, expert_ids = block(jnp.asarray(x.numpy()))
+        assert expert_ids is not None
+        np.testing.assert_allclose(np.asarray(got),
+                                   want[0].numpy(),
                                    rtol=2e-3,
                                    atol=2e-3)

--- a/tests/models/jax/test_qwen3_next.py
+++ b/tests/models/jax/test_qwen3_next.py
@@ -61,9 +61,12 @@ def tiny_config() -> Qwen3NextConfig:
 
 
 def single_device_mesh() -> jax.sharding.Mesh:
+    # Axis order matches the `mesh` fixture in conftest.py so the block-level
+    # tests and the checkpoint round-trip test (which uses the fixture)
+    # exercise the same layout.
     devices = np.asarray(jax.devices()[:1])
     return jax.sharding.Mesh(devices.reshape((1, 1, 1, 1)),
-                             ('data', 'attn_dp', 'model', 'expert'))
+                             ('data', 'attn_dp', 'expert', 'model'))
 
 
 def _silu(x):
@@ -411,6 +414,50 @@ class TestSparseMoeBlock:
                                    want[0].numpy(),
                                    rtol=2e-3,
                                    atol=2e-3)
+
+    def test_fused_expert_weights_load(self, monkeypatch):
+        """The recursive loader hands the experts module relative names, so
+        a fused checkpoint arrives as bare "gate_up_proj" / "down_proj".
+        transformers 5.x stores experts this way, so drive that path
+        directly (save_pretrained in the round-trip test emits per-expert
+        tensors and never exercises it)."""
+        monkeypatch.setenv("USE_DENSE_MOE", "1")
+        cfg = tiny_config()
+        mesh = single_device_mesh()
+        block = self._build(cfg, mesh)
+        experts = block.experts
+
+        e = cfg.num_experts
+        d = cfg.hidden_size
+        f = cfg.moe_intermediate_size
+        rs = np.random.RandomState(0)
+        gate_up = rs.standard_normal((e, 2 * f, d)).astype(np.float32)
+        down = rs.standard_normal((e, d, f)).astype(np.float32)
+
+        with jax.set_mesh(mesh):
+            loaded = experts._load_weights([
+                ("gate_up_proj", torch.from_numpy(gate_up)),
+                ("down_proj", torch.from_numpy(down)),
+            ])
+
+        assert loaded == {
+            "kernel_gating_EDF", "kernel_up_proj_EDF", "kernel_down_proj_EFD"
+        }
+        # Dense backend orients kernels as (E, D, F) / (E, F, D).
+        np.testing.assert_allclose(np.asarray(experts.kernel_gating_EDF.value),
+                                   gate_up[:, :f, :].transpose(0, 2, 1),
+                                   rtol=1e-6,
+                                   atol=1e-6)
+        np.testing.assert_allclose(np.asarray(
+            experts.kernel_up_proj_EDF.value),
+                                   gate_up[:, f:, :].transpose(0, 2, 1),
+                                   rtol=1e-6,
+                                   atol=1e-6)
+        np.testing.assert_allclose(np.asarray(
+            experts.kernel_down_proj_EFD.value),
+                                   down.transpose(0, 2, 1),
+                                   rtol=1e-6,
+                                   atol=1e-6)
 
 
 class TestCheckpointRoundTrip:

--- a/tests/models/jax/test_qwen3_next.py
+++ b/tests/models/jax/test_qwen3_next.py
@@ -18,6 +18,7 @@ kernel is substituted with the pure JAX reference implementations."""
 import jax
 import jax.numpy as jnp
 import numpy as np
+import pytest
 import torch
 from flax import nnx
 from transformers.models.qwen3_next.configuration_qwen3_next import \
@@ -494,3 +495,107 @@ class TestCheckpointRoundTrip:
                                    want_logits.numpy(),
                                    rtol=5e-3,
                                    atol=5e-3)
+
+
+@pytest.mark.skipif(
+    jax.default_backend() != "tpu",
+    reason="exercises the fused GDN and ragged paged attention TPU kernels")
+class TestTpuSmoke:
+
+    def test_forward_with_real_kernels(self, rng, mesh, mock_vllm_config):
+        """Builds a shrunken Qwen3-Next (4 layers: 3 GDN + 1 full attention)
+        with dummy weights and runs one prefill through the real kernels,
+        checking output shapes and that the GDN states were written."""
+        from unittest.mock import MagicMock
+
+        from tpu_inference.distributed.jax_parallel_state import \
+            init_pp_distributed_environment
+        from tpu_inference.kernels.ragged_paged_attention.v3.kernel import \
+            get_kv_cache_shape
+        from tpu_inference.layers.jax.quantization import \
+            get_tpu_quantization_config
+        from tpu_inference.models.jax.qwen3_next import Qwen3NextForCausalLM
+
+        vllm_config = mock_vllm_config("Qwen/Qwen3-Next-80B-A3B-Instruct",
+                                       "auto")
+        hf_config = vllm_config.model_config.hf_config
+        hf_config.num_hidden_layers = 4
+        hf_config.layer_types = hf_config.layer_types[:4]
+        hf_config.num_experts = 16
+        vllm_config.load_config.load_format = "jax_dummy"
+        vllm_config.parallel_config = MagicMock()
+        vllm_config.parallel_config.tensor_parallel_size = 1
+        vllm_config.parallel_config.enable_expert_parallel = False
+        init_pp_distributed_environment(
+            ip="",
+            rank=0,
+            world_size=1,
+            device=jax.devices()[0],
+            need_pp=False,
+        )
+        vllm_config.quant_config = get_tpu_quantization_config(vllm_config)
+
+        with jax.set_mesh(mesh):
+            model = Qwen3NextForCausalLM(vllm_config, rng, mesh)
+            # The dummy loader fills every param and runs the per module
+            # post processing that fuses the MoE kernels for the GMM
+            # backend.
+            from vllm.config import set_current_vllm_config
+            from vllm.model_executor.model_loader import get_model_loader
+            loader = get_model_loader(vllm_config.load_config)
+            with set_current_vllm_config(vllm_config):
+                loader.load_weights(model, vllm_config.model_config)
+
+        seq_len = 16
+        max_reqs = 8
+        num_blocks = 8
+        block_size = 32
+        conv_dim = (
+            2 * hf_config.linear_num_key_heads * hf_config.linear_key_head_dim
+            +
+            hf_config.linear_num_value_heads * hf_config.linear_value_head_dim)
+        attn_cache_shape = get_kv_cache_shape(num_blocks, block_size,
+                                              hf_config.num_key_value_heads,
+                                              hf_config.head_dim, jnp.bfloat16)
+
+        kv_caches = []
+        for layer_type in hf_config.layer_types:
+            if layer_type == "linear_attention":
+                kv_caches.append((
+                    jnp.zeros((max_reqs + 1,
+                               hf_config.linear_conv_kernel_dim - 1, conv_dim),
+                              dtype=jnp.bfloat16),
+                    jnp.zeros((max_reqs + 1, hf_config.linear_num_value_heads,
+                               hf_config.linear_key_head_dim,
+                               hf_config.linear_value_head_dim),
+                              dtype=jnp.bfloat16),
+                ))
+            else:
+                kv_caches.append(
+                    jnp.zeros(attn_cache_shape, dtype=jnp.bfloat16))
+
+        query_start_loc = np.zeros(max_reqs + 1, dtype=np.int32)
+        query_start_loc[1:] = seq_len
+        seq_lens = np.zeros(max_reqs, dtype=np.int32)
+        seq_lens[0] = seq_len
+        state_indices = np.zeros(max_reqs, dtype=np.int32)
+        state_indices[0] = 1
+        metadata = AttentionMetadata(
+            input_positions=jnp.arange(seq_len),
+            block_tables=jnp.zeros(max_reqs * num_blocks, dtype=jnp.int32),
+            seq_lens=jnp.asarray(seq_lens),
+            query_start_loc=jnp.asarray(query_start_loc),
+            request_distribution=jnp.asarray([0, 1, 1], dtype=jnp.int32),
+            mamba_state_indices=jnp.asarray(state_indices),
+        )
+
+        input_ids = jnp.arange(seq_len, dtype=jnp.int32)
+        with jax.set_mesh(mesh):
+            new_kv_caches, hidden, _, _ = model(kv_caches, input_ids, metadata)
+            logits = model.compute_logits(hidden)
+
+        assert hidden.shape == (seq_len, hf_config.hidden_size)
+        assert logits.shape[0] == seq_len
+        new_conv_state, new_recurrent_state = new_kv_caches[0]
+        assert not np.allclose(np.asarray(new_recurrent_state[1]), 0.0)
+        assert not np.allclose(np.asarray(new_conv_state[1]), 0.0)

--- a/tests/runner/test_kv_cache_manager_jax_hybrid.py
+++ b/tests/runner/test_kv_cache_manager_jax_hybrid.py
@@ -1,0 +1,124 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for hybrid attention plus linear attention (GDN) kv cache specs on
+the JAX-native model path, where no vLLM attention modules are registered in
+the compilation config and specs are derived from the HF config."""
+
+import dataclasses
+from unittest.mock import MagicMock
+
+import jax
+import numpy as np
+import torch
+from vllm.v1.kv_cache_interface import FullAttentionSpec, MambaSpec
+
+from tpu_inference.runner.kv_cache_manager import KVCacheManager
+
+QWEN3_NEXT_LINEAR = "linear_attention"
+QWEN3_NEXT_FULL = "full_attention"
+
+
+def _mock_runner(layer_types):
+    runner = MagicMock()
+    devices = np.asarray(jax.devices()[:1])
+    runner.mesh = jax.sharding.Mesh(devices.reshape((1, 1, 1, 1)),
+                                    ('data', 'attn_dp', 'model', 'expert'))
+    runner.cache_config.block_size = 16
+    runner.cache_config.num_gpu_blocks_override = None
+    runner.cache_config.mamba_block_size = 1024
+    runner.cache_config.mamba_cache_dtype = "auto"
+    runner.cache_config.mamba_ssm_cache_dtype = "auto"
+    runner.cache_config.mamba_cache_mode = "none"
+    runner.cache_config.cache_dtype = "auto"
+    runner.kv_cache_dtype = torch.bfloat16
+    runner.speculative_config = None
+    runner.vllm_config.parallel_config.decode_context_parallel_size = 1
+    runner.vllm_config.compilation_config.static_forward_context = {}
+    runner.vllm_config.speculative_config = None
+
+    model_config = runner.model_config
+    model_config.use_mla = False
+    model_config.dtype = torch.bfloat16
+    model_config.get_num_layers.return_value = len(layer_types)
+    model_config.get_total_num_kv_heads.return_value = 2
+    model_config.get_head_size.return_value = 256
+
+    text_config = MagicMock()
+    text_config.layer_types = list(layer_types)
+    text_config.num_key_value_heads = 2
+    text_config.head_dim = 256
+    text_config.linear_num_key_heads = 16
+    text_config.linear_num_value_heads = 32
+    text_config.linear_key_head_dim = 128
+    text_config.linear_value_head_dim = 128
+    text_config.linear_conv_kernel_dim = 4
+    # Attributes probed with getattr(...) that must not exist on a real
+    # Qwen3-Next config.
+    del text_config.num_global_key_value_heads
+    del text_config.global_head_dim
+    del text_config.kv_sharing_target_layer_names
+    del text_config.mtp_kv_share
+    model_config.hf_text_config = text_config
+    model_config.hf_config = text_config
+    return runner
+
+
+def _conv_dim():
+    return 2 * 16 * 128 + 32 * 128
+
+
+class TestJaxHybridKVCacheSpec:
+
+    def test_mamba_spec_emitted_for_linear_attention_layers(self):
+        layer_types = [QWEN3_NEXT_LINEAR] * 3 + [QWEN3_NEXT_FULL]
+        manager = KVCacheManager(_mock_runner(layer_types))
+        spec = manager.get_kv_cache_spec()
+
+        assert set(spec.keys()) == {f"layer.{i}" for i in range(4)}
+        for i in range(3):
+            assert isinstance(spec[f"layer.{i}"], MambaSpec)
+        assert isinstance(spec["layer.3"], FullAttentionSpec)
+
+        mamba_spec = spec["layer.0"]
+        assert mamba_spec.shapes == ((3, _conv_dim()), (32, 128, 128))
+        assert mamba_spec.dtypes == (torch.bfloat16, torch.bfloat16)
+
+    def test_hybrid_uniform_page_size_applied_to_all_specs(self):
+        layer_types = [QWEN3_NEXT_LINEAR] * 3 + [QWEN3_NEXT_FULL]
+        manager = KVCacheManager(_mock_runner(layer_types))
+        spec = manager.get_kv_cache_spec()
+
+        mamba_spec = spec["layer.0"]
+        attn_spec = spec["layer.3"]
+        assert attn_spec.page_size_padded is not None
+        assert attn_spec.page_size_padded == mamba_spec.page_size_padded
+        unpadded_mamba = dataclasses.replace(
+            mamba_spec, page_size_padded=None).page_size_bytes
+        assert attn_spec.page_size_padded >= unpadded_mamba
+
+    def test_non_hybrid_model_unaffected(self):
+        layer_types = [QWEN3_NEXT_FULL] * 4
+        manager = KVCacheManager(_mock_runner(layer_types))
+        spec = manager.get_kv_cache_spec()
+
+        assert all(isinstance(s, FullAttentionSpec) for s in spec.values())
+        assert manager._hybrid_uniform_page_size_bytes is None
+
+    def test_model_without_layer_types_unaffected(self):
+        runner = _mock_runner([QWEN3_NEXT_FULL] * 2)
+        del runner.model_config.hf_text_config.layer_types
+        manager = KVCacheManager(runner)
+        spec = manager.get_kv_cache_spec()
+
+        assert all(isinstance(s, FullAttentionSpec) for s in spec.values())

--- a/tpu_inference/models/common/layer_types.py
+++ b/tpu_inference/models/common/layer_types.py
@@ -1,0 +1,24 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Shared string constants for HF `text_config.layer_types` entries.
+
+These values come from the HF model configs and are matched in several
+places (kv cache spec derivation, jit out-sharding selection, and the model
+decoder layer). Keeping them in one module avoids a rename or typo silently
+desyncing those sites, which would build a MambaSpec in one place and a
+plain attention sharding in another for the same layer."""
+
+FULL_ATTENTION = "full_attention"
+LINEAR_ATTENTION = "linear_attention"
+SLIDING_ATTENTION = "sliding_attention"

--- a/tpu_inference/models/common/model_loader.py
+++ b/tpu_inference/models/common/model_loader.py
@@ -59,8 +59,10 @@ _VLLM_PREFERRED_ARCHITECTURES: frozenset[str] = frozenset({
 })
 
 # List of architectures that don't have pipeline parallelism support in jax yet.
-_PP_DISABLED_MODELS: frozenset[str] = frozenset(
-    {"DeepseekV3ForCausalLM", "Eagle3LlamaForCausalLM", "GptOssForCausalLM"})
+_PP_DISABLED_MODELS: frozenset[str] = frozenset({
+    "DeepseekV3ForCausalLM", "Eagle3LlamaForCausalLM", "GptOssForCausalLM",
+    "Qwen3NextForCausalLM"
+})
 
 
 class UnsupportedArchitectureError(ValueError):
@@ -86,7 +88,9 @@ def _get_model_architecture(config: PretrainedConfig) -> nnx.Module:
         Qwen2_5_VLForConditionalGeneration
     from tpu_inference.models.jax.qwen3 import Qwen3ForCausalLM
     from tpu_inference.models.jax.qwen3_moe import Qwen3MoeForCausalLM
+    from tpu_inference.models.jax.qwen3_next import Qwen3NextForCausalLM
     _MODEL_REGISTRY["Llama4ForCausalLM"] = Llama4ForCausalLM
+    _MODEL_REGISTRY["Qwen3NextForCausalLM"] = Qwen3NextForCausalLM
     _MODEL_REGISTRY["DeepseekV3ForCausalLM"] = DeepseekV3ForCausalLM
     _MODEL_REGISTRY["LlamaForCausalLM"] = LlamaForCausalLM
     _MODEL_REGISTRY["Llama4ForConditionalGeneration"] = LlamaGuard4ForCausalLM
@@ -351,6 +355,28 @@ def get_flax_model(
         mesh,
         PartitionSpec(ShardingAxisName.ATTN_DATA, None,
                       ShardingAxisName.ATTN_HEAD))
+    # Hybrid models carry (conv_state, ssm_state) tuples for their linear
+    # attention layers, whose ranks differ from the paged attention cache.
+    # Build a per layer sharding tree in that case; a single sharding works
+    # as a pytree prefix for the uniform case.
+    if not is_draft_model:
+        text_config = getattr(vllm_config.model_config, "hf_text_config",
+                              vllm_config.model_config.hf_config)
+        layer_types = list(getattr(text_config, "layer_types", None) or [])
+        if "linear_attention" in layer_types:
+            conv_state_sharding = NamedSharding(
+                mesh,
+                PartitionSpec(ShardingAxisName.ATTN_DATA, None,
+                              ShardingAxisName.ATTN_HEAD))
+            ssm_state_sharding = NamedSharding(
+                mesh,
+                PartitionSpec(ShardingAxisName.ATTN_DATA,
+                              ShardingAxisName.ATTN_HEAD, None, None))
+            kv_cache_sharding = [
+                (conv_state_sharding, ssm_state_sharding)
+                if layer_type == "linear_attention" else kv_cache_sharding
+                for layer_type in layer_types
+            ]
     hidden_states_sharding = NamedSharding(mesh,
                                            PartitionSpec(
                                                ShardingAxisName.ATTN_DATA,

--- a/tpu_inference/models/common/model_loader.py
+++ b/tpu_inference/models/common/model_loader.py
@@ -57,6 +57,7 @@ _VLLM_PREFERRED_ARCHITECTURES: frozenset[str] = frozenset({
     "Qwen3MoeForCausalLM",
     "KimiK25ForConditionalGeneration",
     "Qwen3_5MoeForConditionalGeneration",
+    "Qwen3NextForCausalLM",
 })
 
 # List of architectures that don't have pipeline parallelism support in jax yet.

--- a/tpu_inference/models/common/model_loader.py
+++ b/tpu_inference/models/common/model_loader.py
@@ -31,6 +31,7 @@ from tpu_inference.layers.common.sharding import ShardingAxisName
 from tpu_inference.layers.jax import JaxModule
 from tpu_inference.layers.jax.quantization import get_tpu_quantization_config
 from tpu_inference.logger import init_logger
+from tpu_inference.models.common import layer_types as layer_type_names
 from tpu_inference.models.common.interface import (ModelInterface,
                                                    MultiModalInterface)
 from tpu_inference.models.jax.utils.multi_modal_utils import \
@@ -363,7 +364,7 @@ def get_flax_model(
         text_config = getattr(vllm_config.model_config, "hf_text_config",
                               vllm_config.model_config.hf_config)
         layer_types = list(getattr(text_config, "layer_types", None) or [])
-        if "linear_attention" in layer_types:
+        if layer_type_names.LINEAR_ATTENTION in layer_types:
             conv_state_sharding = NamedSharding(
                 mesh,
                 PartitionSpec(ShardingAxisName.ATTN_DATA, None,
@@ -373,8 +374,8 @@ def get_flax_model(
                 PartitionSpec(ShardingAxisName.ATTN_DATA,
                               ShardingAxisName.ATTN_HEAD, None, None))
             kv_cache_sharding = [
-                (conv_state_sharding, ssm_state_sharding)
-                if layer_type == "linear_attention" else kv_cache_sharding
+                (conv_state_sharding, ssm_state_sharding) if layer_type
+                == layer_type_names.LINEAR_ATTENTION else kv_cache_sharding
                 for layer_type in layer_types
             ]
     hidden_states_sharding = NamedSharding(mesh,

--- a/tpu_inference/models/jax/qwen3_next.py
+++ b/tpu_inference/models/jax/qwen3_next.py
@@ -14,23 +14,40 @@
 """JAX native implementation of Qwen3-Next (hybrid gated delta net linear
 attention + gated full attention, sparse MoE with a shared expert)."""
 
-from typing import Tuple
+from typing import List, Optional, Tuple
 
 import jax
 import jax.numpy as jnp
 from flax import nnx
 from jax.sharding import Mesh
+from jax.sharding import PartitionSpec as P
+from vllm.config import VllmConfig
 
+from tpu_inference import utils
+from tpu_inference.distributed.jax_parallel_state import get_pp_group
+from tpu_inference.layers.common.attention_interface import attention
 from tpu_inference.layers.common.attention_metadata import AttentionMetadata
 from tpu_inference.layers.common.gdn_attention import run_jax_gdn_attention
+from tpu_inference.layers.common.quantization import quantize_kv
 from tpu_inference.layers.common.sharding import ShardingAxisName
 from tpu_inference.layers.common.utils import \
     reorder_concatenated_tensor_for_sharding
 from tpu_inference.layers.jax import JaxModule
 from tpu_inference.layers.jax.base import create_param
-from tpu_inference.layers.jax.linear import JaxEinsum
+from tpu_inference.layers.jax.embed import JaxEmbed
+from tpu_inference.layers.jax.linear import JaxEinsum, JaxLinear, JaxLmHead
+from tpu_inference.layers.jax.moe.moe import JaxMoE, Router
+from tpu_inference.layers.jax.moe.utils import (get_expert_parallelism,
+                                                select_moe_backend)
 from tpu_inference.layers.jax.norm import JaxRmsNorm
+from tpu_inference.layers.jax.pp_utils import PPMissingLayer, make_layers
+from tpu_inference.layers.jax.rope_interface import (apply_rope,
+                                                     get_rope_scaling,
+                                                     get_rope_theta)
 from tpu_inference.logger import init_logger
+from tpu_inference.models.jax.jax_intermediate_tensor import \
+    JaxIntermediateTensors
+from tpu_inference.models.jax.utils.weight_utils import LoadableWithIterator
 from tpu_inference.utils import get_mesh_shape_product
 
 logger = init_logger(__name__)
@@ -208,3 +225,518 @@ class Qwen3NextGatedDeltaNet(JaxModule):
             z.astype(jnp.float32))
         out = self.out_proj(gated.reshape(t, self.value_dim).astype(x.dtype))
         return (new_conv_state, new_recurrent_state), out
+
+
+class Qwen3NextAttention(JaxModule):
+    """Gated full attention block. The q projection produces the query and
+    a per head sigmoid output gate in one fused kernel; rotary embedding is
+    partial (first partial_rotary_factor * head_dim dims)."""
+
+    def __init__(self,
+                 config,
+                 dtype: jnp.dtype,
+                 rng: nnx.Rngs,
+                 mesh: Mesh,
+                 kv_cache_dtype: str,
+                 quant_config,
+                 prefix: str = ""):
+        self.hidden_size = config.hidden_size
+        self.num_heads = config.num_attention_heads
+        self.num_kv_heads = config.num_key_value_heads
+        self.rope_theta = get_rope_theta(config, default=10000.0)
+        self.rope_scaling = get_rope_scaling(config)
+        self.rms_norm_eps = config.rms_norm_eps
+
+        self.head_dim_original = getattr(config, "head_dim",
+                                         self.hidden_size // self.num_heads)
+        self.head_dim = utils.get_padded_head_dim(self.head_dim_original)
+        self.rotary_dim = int(self.head_dim_original *
+                              getattr(config, "partial_rotary_factor", 1.0))
+
+        sharding_size = mesh.shape["model"]
+        self.num_heads = utils.get_padded_num_heads(self.num_heads,
+                                                    sharding_size)
+        self.num_kv_heads = utils.get_padded_num_heads(self.num_kv_heads,
+                                                       sharding_size)
+        self.mesh = mesh
+
+        # The gate halves live fused inside q_proj, so the kernel layout is
+        # fixed to DNH with a doubled head dim.
+        self.q_proj = JaxEinsum(
+            "TD,DNH->TNH",
+            (self.hidden_size, self.num_heads, 2 * self.head_dim),
+            dtype=dtype,
+            kernel_init=nnx.with_partitioning(init_fn, (None, "model", None)),
+            rngs=rng,
+            quant_config=quant_config,
+            prefix=prefix + ".q_proj",
+        )
+        self.q_norm = JaxRmsNorm(
+            self.head_dim,
+            epsilon=self.rms_norm_eps,
+            dtype=dtype,
+            param_dtype=dtype,
+            scale_init=nnx.with_partitioning(init_fn, (None, )),
+            rngs=rng,
+            quant_config=quant_config,
+            prefix=prefix + ".q_norm",
+        )
+        self.k_proj = JaxEinsum(
+            "TD,DKH->TKH",
+            (self.hidden_size, self.num_kv_heads, self.head_dim),
+            dtype=dtype,
+            kernel_init=nnx.with_partitioning(init_fn, (None, "model", None)),
+            rngs=rng,
+            quant_config=quant_config,
+            prefix=prefix + ".k_proj",
+        )
+        self.k_norm = JaxRmsNorm(
+            self.head_dim,
+            epsilon=self.rms_norm_eps,
+            dtype=dtype,
+            param_dtype=dtype,
+            scale_init=nnx.with_partitioning(init_fn, (None, )),
+            rngs=rng,
+            quant_config=quant_config,
+            prefix=prefix + ".k_norm",
+        )
+        self.v_proj = JaxEinsum(
+            "TD,DKH->TKH",
+            (self.hidden_size, self.num_kv_heads, self.head_dim),
+            dtype=dtype,
+            kernel_init=nnx.with_partitioning(init_fn, (None, "model", None)),
+            rngs=rng,
+            quant_config=quant_config,
+            prefix=prefix + ".v_proj",
+        )
+        self.o_proj = JaxEinsum(
+            "TNH,NHD->TD",
+            (self.num_heads, self.head_dim, self.hidden_size),
+            dtype=dtype,
+            kernel_init=nnx.with_partitioning(init_fn, ("model", None, None)),
+            rngs=rng,
+            quant_config=quant_config,
+            prefix=prefix + ".o_proj",
+        )
+
+        self._q_scale = 1.0
+        self._k_scale = 1.0
+        self._v_scale = 1.0
+        self.kv_cache_quantized_dtype = None
+        if kv_cache_dtype != "auto":
+            self.kv_cache_quantized_dtype = utils.get_jax_dtype_from_str_dtype(
+                kv_cache_dtype)
+
+    def _rope(self, x: jax.Array, positions: jax.Array) -> jax.Array:
+        # apply_rope zero pads its output past the head_dim argument, so it
+        # must only see the rotary slice; the remaining dims pass through.
+        rotated = apply_rope(x[..., :self.rotary_dim], positions,
+                             self.rotary_dim, self.rope_theta,
+                             self.rope_scaling)
+        return jnp.concatenate([rotated, x[..., self.rotary_dim:]], axis=-1)
+
+    def __call__(
+        self,
+        kv_cache: Optional[jax.Array],
+        x: jax.Array,
+        attention_metadata: AttentionMetadata,
+    ) -> Tuple[jax.Array, jax.Array]:
+        md = attention_metadata
+        # (T, N, 2H): query half and output gate half per head.
+        q, gate = jnp.split(self.q_proj(x), 2, axis=-1)
+        q = self._rope(self.q_norm(q), md.input_positions)
+        k = self._rope(self.k_norm(self.k_proj(x)), md.input_positions)
+        v = self.v_proj(x)
+
+        q_scale = k_scale = v_scale = None
+        if self.kv_cache_quantized_dtype:
+            k_scale = self._k_scale
+            v_scale = self._v_scale
+            k, v = quantize_kv(self.kv_cache_quantized_dtype, k, v, k_scale,
+                               v_scale)
+
+        new_kv_cache, o = attention(
+            kv_cache,
+            q,
+            k,
+            v,
+            attention_metadata,
+            self.mesh,
+            self.head_dim_original,
+            q_scale=q_scale,
+            k_scale=k_scale,
+            v_scale=v_scale,
+        )
+        o = o * jax.nn.sigmoid(gate)
+        return new_kv_cache, self.o_proj(o)
+
+
+class Qwen3NextSparseMoeBlock(JaxModule):
+    """Sparse MoE block with a sigmoid gated shared expert on top of the
+    routed experts."""
+
+    def __init__(self,
+                 vllm_config: VllmConfig,
+                 rng: nnx.Rngs,
+                 mesh: Mesh,
+                 prefix: str = ""):
+        config = vllm_config.model_config.hf_text_config
+        dtype = vllm_config.model_config.dtype
+        quant_config = vllm_config.quant_config
+        hidden_size = config.hidden_size
+
+        edf_sharding = (None, None, None)
+        expert_axis_name = edf_sharding[0]
+        num_expert_parallelism = get_expert_parallelism(expert_axis_name, mesh)
+        use_ep = num_expert_parallelism > 1
+        moe_backend = select_moe_backend(use_ep)
+
+        # The Router adapts its output to the backend: raw logits for the
+        # fused kernels, (weights, indices) for the unfused ones. Top-k
+        # followed by softmax over the selected logits is equivalent to
+        # HF's norm_topk_prob=True renormalization.
+        self.gate = Router(
+            dtype=dtype,
+            hidden_size=hidden_size,
+            num_experts=config.num_experts,
+            num_experts_per_tok=config.num_experts_per_tok,
+            router_act="softmax",
+            rngs=rng,
+            activation_ffw_td=(ShardingAxisName.MLP_DATA, None),
+            ed_sharding=(None, None),
+            moe_backend=moe_backend,
+            mesh=mesh,
+        )
+
+        self.enable_return_routed_experts = True
+        self.experts = JaxMoE(
+            dtype=dtype,
+            num_local_experts=config.num_experts,
+            hidden_size=hidden_size,
+            intermediate_size_moe=config.moe_intermediate_size,
+            hidden_act=config.hidden_act,
+            rngs=rng,
+            router=self.gate,
+            num_experts_per_tok=config.num_experts_per_tok,
+            mesh=mesh,
+            activation_ffw_td=P(ShardingAxisName.MLP_DATA, None),
+            activation_ffw_ted=P(ShardingAxisName.MLP_DATA, None, None),
+            edf_sharding=P(None, ),
+            efd_sharding=P(None, ),
+            apply_expert_weight_before_computation=False,
+            expert_axis_name=expert_axis_name,
+            num_expert_parallelism=num_expert_parallelism,
+            moe_backend=moe_backend,
+            quant_config=quant_config,
+            enable_return_routed_experts=self.enable_return_routed_experts,
+            prefix=prefix + ".experts")
+
+        shared_intermediate = config.shared_expert_intermediate_size
+        self.shared_expert_gate_proj = JaxLinear(
+            hidden_size,
+            shared_intermediate,
+            dtype=dtype,
+            rngs=rng,
+            use_bias=False,
+            quant_config=quant_config,
+            prefix=prefix + ".shared_expert.gate_proj",
+        )
+        self.shared_expert_up_proj = JaxLinear(
+            hidden_size,
+            shared_intermediate,
+            dtype=dtype,
+            rngs=rng,
+            use_bias=False,
+            quant_config=quant_config,
+            prefix=prefix + ".shared_expert.up_proj",
+        )
+        self.shared_expert_down_proj = JaxLinear(
+            shared_intermediate,
+            hidden_size,
+            dtype=dtype,
+            rngs=rng,
+            use_bias=False,
+            quant_config=quant_config,
+            prefix=prefix + ".shared_expert.down_proj",
+        )
+        self.shared_expert_gate = JaxLinear(
+            hidden_size,
+            1,
+            dtype=dtype,
+            rngs=rng,
+            use_bias=False,
+            quant_config=quant_config,
+            prefix=prefix + ".shared_expert_gate",
+        )
+
+    def __call__(self, x: jax.Array) -> Tuple[jax.Array, Optional[jax.Array]]:
+        out, expert_ids = self.experts(x)
+        shared = self.shared_expert_down_proj(
+            jax.nn.silu(self.shared_expert_gate_proj(x)) *
+            self.shared_expert_up_proj(x))
+        out = out + jax.nn.sigmoid(self.shared_expert_gate(x)) * shared
+        return out, expert_ids
+
+
+class Qwen3NextDecoderLayer(JaxModule):
+
+    def __init__(self,
+                 config,
+                 dtype: jnp.dtype,
+                 rng: nnx.Rngs,
+                 mesh: Mesh,
+                 kv_cache_dtype: str,
+                 quant_config,
+                 layer_idx: int,
+                 vllm_config: VllmConfig,
+                 prefix: str = ""):
+        rms_norm_eps = config.rms_norm_eps
+        hidden_size = config.hidden_size
+
+        self.layer_type = config.layer_types[layer_idx]
+
+        self.input_layernorm = JaxRmsNorm(
+            hidden_size,
+            epsilon=rms_norm_eps,
+            dtype=dtype,
+            param_dtype=dtype,
+            scale_init=nnx.with_partitioning(init_fn, (None, )),
+            rngs=rng,
+            quant_config=quant_config,
+            prefix=prefix + ".input_layernorm",
+        )
+        if self.layer_type == "linear_attention":
+            self.linear_attn = Qwen3NextGatedDeltaNet(
+                config=config,
+                dtype=dtype,
+                rng=rng,
+                mesh=mesh,
+                quant_config=quant_config,
+                prefix=prefix + ".linear_attn",
+            )
+        else:
+            self.self_attn = Qwen3NextAttention(
+                config=config,
+                dtype=dtype,
+                rng=rng,
+                mesh=mesh,
+                kv_cache_dtype=kv_cache_dtype,
+                quant_config=quant_config,
+                prefix=prefix + ".self_attn",
+            )
+        self.post_attention_layernorm = JaxRmsNorm(
+            hidden_size,
+            epsilon=rms_norm_eps,
+            dtype=dtype,
+            param_dtype=dtype,
+            scale_init=nnx.with_partitioning(init_fn, (None, )),
+            rngs=rng,
+            quant_config=quant_config,
+            prefix=prefix + ".post_attention_layernorm",
+        )
+
+        mlp_only_layers = getattr(config, "mlp_only_layers", [])
+        if (layer_idx not in mlp_only_layers) and (
+                config.num_experts > 0 and
+            (layer_idx + 1) % config.decoder_sparse_step == 0):
+            self.mlp = Qwen3NextSparseMoeBlock(vllm_config=vllm_config,
+                                               rng=rng,
+                                               mesh=mesh,
+                                               prefix=prefix + ".mlp")
+        else:
+            raise NotImplementedError(
+                "Dense MLP layers are not implemented; all Qwen3-Next "
+                f"checkpoints use MoE on every layer. Found {mlp_only_layers=}"
+                f", {config.num_experts=}, {config.decoder_sparse_step=}.")
+
+    def __call__(
+        self,
+        kv_cache,
+        x: jax.Array,
+        attention_metadata: AttentionMetadata,
+    ):
+        hidden_states = self.input_layernorm(x)
+        if self.layer_type == "linear_attention":
+            kv_cache, attn_output = self.linear_attn(kv_cache, hidden_states,
+                                                     attention_metadata)
+        else:
+            kv_cache, attn_output = self.self_attn(kv_cache, hidden_states,
+                                                   attention_metadata)
+        attn_output += x
+
+        residual = attn_output
+        attn_output = self.post_attention_layernorm(attn_output)
+        mlp_output, expert_ids = self.mlp(attn_output)
+        outputs = residual + mlp_output
+
+        return kv_cache, outputs, expert_ids
+
+
+class Qwen3NextModel(JaxModule):
+
+    def __init__(self,
+                 vllm_config: VllmConfig,
+                 rng: nnx.Rngs,
+                 mesh: Mesh,
+                 prefix: str = "") -> None:
+        model_config = vllm_config.model_config
+        hf_config = model_config.hf_text_config
+        vocab_size = model_config.get_vocab_size()
+        dtype = model_config.dtype
+        rms_norm_eps = hf_config.rms_norm_eps
+        hidden_size = hf_config.hidden_size
+
+        self.is_first_rank = get_pp_group().is_first_rank
+        self.is_last_rank = get_pp_group().is_last_rank
+
+        tp_size = (vllm_config.parallel_config.tensor_parallel_size
+                   if vllm_config.parallel_config is not None else 1)
+        padded_vocab_size = utils.align_to(vocab_size, tp_size)
+
+        if self.is_first_rank or (hf_config.tie_word_embeddings
+                                  and self.is_last_rank):
+            self.embed_tokens = JaxEmbed(
+                num_embeddings=padded_vocab_size,
+                features=hidden_size,
+                dtype=dtype,
+                param_dtype=dtype,
+                embedding_init=nnx.with_partitioning(init_fn, ("model", None)),
+                rngs=rng,
+                quant_config=vllm_config.quant_config,
+                prefix=prefix + ".embed_tokens",
+            )
+        else:
+            self.embed_tokens = PPMissingLayer()
+
+        self.start_layer, self.end_layer, self.layers = make_layers(
+            hf_config.num_hidden_layers,
+            lambda layer_index: Qwen3NextDecoderLayer(
+                config=hf_config,
+                dtype=dtype,
+                rng=rng,
+                mesh=mesh,
+                kv_cache_dtype=vllm_config.cache_config.cache_dtype,
+                quant_config=vllm_config.quant_config,
+                layer_idx=layer_index,
+                vllm_config=vllm_config,
+                prefix=f"{prefix}.layers.{layer_index}",
+            ))
+
+        if self.is_last_rank:
+            self.norm = JaxRmsNorm(
+                hidden_size,
+                epsilon=rms_norm_eps,
+                dtype=dtype,
+                param_dtype=dtype,
+                scale_init=nnx.with_partitioning(init_fn, (None, )),
+                rngs=rng,
+                quant_config=vllm_config.quant_config,
+                prefix=prefix + ".norm",
+            )
+        else:
+            self.norm = PPMissingLayer()
+
+    def __call__(
+        self,
+        kv_caches,
+        input_ids: jax.Array,
+        attention_metadata: AttentionMetadata,
+        inputs_embeds: Optional[jax.Array] = None,
+    ):
+        if self.is_first_rank:
+            assert inputs_embeds is None
+            inputs_embeds = self.embed_tokens(input_ids)
+        else:
+            assert inputs_embeds is not None
+
+        x = inputs_embeds
+        new_kv_caches = []
+        all_expert_ids = []
+        for i, layer in enumerate(self.layers):
+            if isinstance(layer, PPMissingLayer):
+                new_kv_caches.append(kv_caches[i])
+                continue
+            kv_cache, x, expert_ids = layer(kv_caches[i], x,
+                                            attention_metadata)
+            if expert_ids is not None:
+                all_expert_ids.append(expert_ids)
+            new_kv_caches.append(kv_cache)
+
+        if self.is_last_rank:
+            x = self.norm(x)
+
+        stacked_expert_ids = jnp.stack(all_expert_ids,
+                                       axis=0) if all_expert_ids else None
+        return new_kv_caches, x, stacked_expert_ids
+
+
+class Qwen3NextForCausalLM(JaxModule, LoadableWithIterator):
+
+    def __init__(self, vllm_config: VllmConfig, rng_key: jax.Array,
+                 mesh: Mesh) -> None:
+        self.vllm_config = vllm_config
+        rng = nnx.Rngs(rng_key)
+        self.mesh = mesh
+
+        self.model = Qwen3NextModel(
+            vllm_config=vllm_config,
+            rng=rng,
+            mesh=mesh,
+            prefix="model",
+        )
+        model_config = vllm_config.model_config
+        if not model_config.hf_config.tie_word_embeddings:
+            if self.model.is_last_rank:
+                vocab_size = model_config.get_vocab_size()
+                tp_size = (vllm_config.parallel_config.tensor_parallel_size
+                           if vllm_config.parallel_config is not None else 1)
+                padded_vocab_size = utils.align_to(vocab_size, tp_size)
+                hidden_size = model_config.hf_config.hidden_size
+                self.lm_head = JaxLmHead(
+                    hidden_size=hidden_size,
+                    vocab_size=padded_vocab_size,
+                    dtype=model_config.dtype,
+                    param_dtype=model_config.dtype,
+                    rngs=rng,
+                    prefix="lm_head",
+                )
+            else:
+                self.lm_head = PPMissingLayer()
+        else:
+            self.lm_head = PPMissingLayer()
+
+    def __call__(
+        self,
+        kv_caches,
+        input_ids: jax.Array,
+        attention_metadata: AttentionMetadata,
+        inputs_embeds: Optional[jax.Array] = None,
+        _input_positions=None,
+        _layer_name_to_kv_cache=None,
+        _lora_metadata=None,
+        intermediate_tensors: JaxIntermediateTensors | None = None,
+        is_first_rank: bool = True,
+        is_last_rank: bool = True,
+        *args,
+    ) -> Tuple[List[jax.Array], jax.Array | JaxIntermediateTensors,
+               List[jax.Array], Optional[jax.Array]]:
+        if not is_first_rank:
+            assert intermediate_tensors is not None
+            inputs_embeds = intermediate_tensors["hidden_states"]
+        kv_caches, x, expert_indices = self.model(
+            kv_caches,
+            input_ids,
+            attention_metadata,
+            inputs_embeds,
+        )
+        if not is_last_rank:
+            x = JaxIntermediateTensors(tensors={"hidden_states": x}, )
+        return kv_caches, x, [], expert_indices
+
+    def compute_logits(self, hidden_states: jax.Array) -> jax.Array:
+        if hasattr(self,
+                   'lm_head') and not isinstance(self.lm_head, PPMissingLayer):
+            return self.lm_head(hidden_states)
+
+        assert isinstance(self.model.embed_tokens, JaxEmbed)
+        return self.model.embed_tokens.decode(hidden_states)

--- a/tpu_inference/models/jax/qwen3_next.py
+++ b/tpu_inference/models/jax/qwen3_next.py
@@ -66,6 +66,32 @@ modeling_flax_utils = FlaxUtils()
 _gdn_core = run_jax_gdn_attention
 
 
+def _load_zero_centered_norm(jax_param: nnx.Param,
+                             torch_weight,
+                             *,
+                             param_name: str = "Unknown"):
+    """Qwen3NextRMSNorm is zero centered (`out = norm(x) * (1 + w)`); fold
+    the +1 into the scale at load time so the standard RMSNorm applies."""
+    folded = (torch_weight.float() + 1.0).to(torch_weight.dtype)
+    load_nnx_param_from_reshaped_torch(jax_param,
+                                       folded,
+                                       param_name=param_name)
+
+
+class JaxZeroCenteredRmsNorm(JaxRmsNorm):
+    """RMSNorm whose HF weight is zero centered (`out = norm(x) * (1 + w)`),
+    as in Qwen3NextRMSNorm. The `+1` is folded into the scale at load time so
+    the standard RMSNorm forward applies; the fold is wired here rather than
+    at the model level so every consumer gets it automatically."""
+
+    def __init__(self, *args, prefix: str = "", **kwargs):
+        super().__init__(*args, prefix=prefix, **kwargs)
+        self.weight.set_metadata(
+            "weight_loader",
+            functools.partial(_load_zero_centered_norm,
+                              param_name=prefix + ".weight"))
+
+
 class Conv1dWeight(JaxModule):
     """Holds the depthwise causal conv weight under a `weight` param so its
     parameter name lines up with the HF checkpoint (`...conv1d.weight`)."""
@@ -307,7 +333,7 @@ class Qwen3NextAttention(JaxModule):
             quant_config=quant_config,
             prefix=prefix + ".q_proj",
         )
-        self.q_norm = JaxRmsNorm(
+        self.q_norm = JaxZeroCenteredRmsNorm(
             self.head_dim,
             epsilon=self.rms_norm_eps,
             dtype=dtype,
@@ -326,7 +352,7 @@ class Qwen3NextAttention(JaxModule):
             quant_config=quant_config,
             prefix=prefix + ".k_proj",
         )
-        self.k_norm = JaxRmsNorm(
+        self.k_norm = JaxZeroCenteredRmsNorm(
             self.head_dim,
             epsilon=self.rms_norm_eps,
             dtype=dtype,
@@ -625,7 +651,7 @@ class Qwen3NextDecoderLayer(JaxModule):
 
         self.layer_type = config.layer_types[layer_idx]
 
-        self.input_layernorm = JaxRmsNorm(
+        self.input_layernorm = JaxZeroCenteredRmsNorm(
             hidden_size,
             epsilon=rms_norm_eps,
             dtype=dtype,
@@ -654,7 +680,7 @@ class Qwen3NextDecoderLayer(JaxModule):
                 quant_config=quant_config,
                 prefix=prefix + ".self_attn",
             )
-        self.post_attention_layernorm = JaxRmsNorm(
+        self.post_attention_layernorm = JaxZeroCenteredRmsNorm(
             hidden_size,
             epsilon=rms_norm_eps,
             dtype=dtype,
@@ -753,7 +779,7 @@ class Qwen3NextModel(JaxModule):
             ))
 
         if self.is_last_rank:
-            self.norm = JaxRmsNorm(
+            self.norm = JaxZeroCenteredRmsNorm(
                 hidden_size,
                 epsilon=rms_norm_eps,
                 dtype=dtype,
@@ -816,18 +842,6 @@ def _load_reordered_conv_weight(jax_param: nnx.Param,
     assign_and_shard_param(jax_param, jax_weight, param_name)
 
 
-def _load_zero_centered_norm(jax_param: nnx.Param,
-                             torch_weight,
-                             *,
-                             param_name: str = "Unknown"):
-    """Qwen3NextRMSNorm is zero centered (`out = norm(x) * (1 + w)`); fold
-    the +1 into the scale at load time so the standard RMSNorm applies."""
-    folded = (torch_weight.float() + 1.0).to(torch_weight.dtype)
-    load_nnx_param_from_reshaped_torch(jax_param,
-                                       folded,
-                                       param_name=param_name)
-
-
 def _load_float32_param(jax_param: nnx.Param,
                         torch_weight,
                         *,
@@ -837,16 +851,6 @@ def _load_float32_param(jax_param: nnx.Param,
     load_nnx_param_from_reshaped_torch(jax_param,
                                        torch_weight.float(),
                                        param_name=param_name)
-
-
-# Norms folded with +1 at load time. The gated norm inside linear_attn uses
-# a standard scale and is excluded.
-_ZERO_CENTERED_NORM_SUFFIXES = (
-    ".input_layernorm.weight",
-    ".post_attention_layernorm.weight",
-    ".q_norm.weight",
-    ".k_norm.weight",
-)
 
 
 class Qwen3NextForCausalLM(JaxModule, LoadableWithIterator):
@@ -884,14 +888,11 @@ class Qwen3NextForCausalLM(JaxModule, LoadableWithIterator):
         else:
             self.lm_head = PPMissingLayer()
 
+        # The zero-centered norm fold is wired inside JaxZeroCenteredRmsNorm.
+        # A_log/dt_bias stay float32; wire their loaders here since they are
+        # bare nnx.Params rather than a dedicated module.
         for name, param in self.named_parameters():
-            if (name.endswith(_ZERO_CENTERED_NORM_SUFFIXES)
-                    or name == "model.norm.weight"):
-                param.set_metadata(
-                    "weight_loader",
-                    functools.partial(_load_zero_centered_norm,
-                                      param_name=name))
-            elif name.endswith((".A_log", ".dt_bias")):
+            if name.endswith((".A_log", ".dt_bias")):
                 param.set_metadata(
                     "weight_loader",
                     functools.partial(_load_float32_param, param_name=name))

--- a/tpu_inference/models/jax/qwen3_next.py
+++ b/tpu_inference/models/jax/qwen3_next.py
@@ -14,6 +14,7 @@
 """JAX native implementation of Qwen3-Next (hybrid gated delta net linear
 attention + gated full attention, sparse MoE with a shared expert)."""
 
+import functools
 from typing import List, Optional, Tuple
 
 import jax
@@ -28,6 +29,7 @@ from tpu_inference.distributed.jax_parallel_state import get_pp_group
 from tpu_inference.layers.common.attention_interface import attention
 from tpu_inference.layers.common.attention_metadata import AttentionMetadata
 from tpu_inference.layers.common.gdn_attention import run_jax_gdn_attention
+from tpu_inference.layers.common.moe import MoEBackend
 from tpu_inference.layers.common.quantization import quantize_kv
 from tpu_inference.layers.common.sharding import ShardingAxisName
 from tpu_inference.layers.common.utils import \
@@ -36,7 +38,7 @@ from tpu_inference.layers.jax import JaxModule
 from tpu_inference.layers.jax.base import create_param
 from tpu_inference.layers.jax.embed import JaxEmbed
 from tpu_inference.layers.jax.linear import JaxEinsum, JaxLinear, JaxLmHead
-from tpu_inference.layers.jax.moe.moe import JaxMoE, Router
+from tpu_inference.layers.jax.moe.moe import JaxMoE
 from tpu_inference.layers.jax.moe.utils import (get_expert_parallelism,
                                                 select_moe_backend)
 from tpu_inference.layers.jax.norm import JaxRmsNorm
@@ -47,7 +49,9 @@ from tpu_inference.layers.jax.rope_interface import (apply_rope,
 from tpu_inference.logger import init_logger
 from tpu_inference.models.jax.jax_intermediate_tensor import \
     JaxIntermediateTensors
-from tpu_inference.models.jax.utils.weight_utils import LoadableWithIterator
+from tpu_inference.models.jax.utils.weight_utils import (
+    JaxAutoWeightsLoader, LoadableWithIterator,
+    load_nnx_param_from_reshaped_torch)
 from tpu_inference.utils import get_mesh_shape_product
 
 logger = init_logger(__name__)
@@ -371,6 +375,110 @@ class Qwen3NextAttention(JaxModule):
         return new_kv_cache, self.o_proj(o)
 
 
+class Qwen3NextRouter(JaxLinear):
+    """MoE router that adapts its output to the backend: raw logits for the
+    fused kernels (which route internally), (weights, indices) for the
+    unfused ones. Top-k followed by softmax over the selected logits equals
+    HF's softmax then top-k then renormalize (norm_topk_prob=True)."""
+
+    def __init__(self, *args, num_experts_per_tok: int,
+                 moe_backend: MoEBackend, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.num_experts_per_tok = num_experts_per_tok
+        self.moe_backend = moe_backend
+
+    def __call__(self, x: jax.Array):
+        logits = super().__call__(x)
+        if self.moe_backend in MoEBackend.fused_moe_backends():
+            return logits
+        weights, selected = jax.lax.top_k(logits, self.num_experts_per_tok)
+        return jax.nn.softmax(weights, axis=-1), selected
+
+
+class Qwen3NextMoeExperts(JaxMoE):
+    """JaxMoE that also accepts the fused 3D expert tensors some Qwen3-Next
+    checkpoints store (`experts.gate_up_proj` (E, 2F, D) with the gate rows
+    first, `experts.down_proj` (E, D, F)) next to the per expert layout the
+    base class handles. Fused tensors are expanded into per expert shards
+    and delegated so the fused kernel post processing sees the layout it
+    expects; for the unfused backends the kernels are transposed into the
+    (E, D, F) / (E, F, D) orientation the dense matmul consumes directly."""
+
+    def _load_weights(self, weights, *, mesh: Mesh | None = None):
+        expanded = []
+        for name, torch_weight in weights:
+            if name.endswith("experts.gate_up_proj"):
+                intermediate = torch_weight.shape[1] // 2
+                for expert_id in range(torch_weight.shape[0]):
+                    expanded.append(
+                        (f"{self.prefix}.{expert_id}.gate_proj.weight",
+                         torch_weight[expert_id, :intermediate, :]))
+                    expanded.append(
+                        (f"{self.prefix}.{expert_id}.up_proj.weight",
+                         torch_weight[expert_id, intermediate:, :]))
+            elif name.endswith("experts.down_proj"):
+                for expert_id in range(torch_weight.shape[0]):
+                    expanded.append(
+                        (f"{self.prefix}.{expert_id}.down_proj.weight",
+                         torch_weight[expert_id]))
+            else:
+                expanded.append((name, torch_weight))
+
+        loaded = super()._load_weights(expanded, mesh=mesh)
+
+        if self.moe_backend not in MoEBackend.fused_moe_backends():
+            # The base loader keeps the HF (out, in) orientation per expert,
+            # which the fused backends fix up in their weight post
+            # processing. The dense fallback consumes the kernels as is, so
+            # orient them here once all experts have arrived.
+            for param_name in loaded:
+                param = getattr(self, param_name)
+                param.set_value(jnp.transpose(param.get_value(), (0, 2, 1)))
+        return loaded
+
+
+class Qwen3NextMLP(JaxModule):
+    """Plain silu MLP used for the shared expert."""
+
+    def __init__(self,
+                 hidden_size: int,
+                 intermediate_size: int,
+                 dtype: jnp.dtype,
+                 rng: nnx.Rngs,
+                 quant_config,
+                 prefix: str = ""):
+        self.gate_proj = JaxLinear(
+            hidden_size,
+            intermediate_size,
+            dtype=dtype,
+            rngs=rng,
+            use_bias=False,
+            quant_config=quant_config,
+            prefix=prefix + ".gate_proj",
+        )
+        self.up_proj = JaxLinear(
+            hidden_size,
+            intermediate_size,
+            dtype=dtype,
+            rngs=rng,
+            use_bias=False,
+            quant_config=quant_config,
+            prefix=prefix + ".up_proj",
+        )
+        self.down_proj = JaxLinear(
+            intermediate_size,
+            hidden_size,
+            dtype=dtype,
+            rngs=rng,
+            use_bias=False,
+            quant_config=quant_config,
+            prefix=prefix + ".down_proj",
+        )
+
+    def __call__(self, x: jax.Array) -> jax.Array:
+        return self.down_proj(jax.nn.silu(self.gate_proj(x)) * self.up_proj(x))
+
+
 class Qwen3NextSparseMoeBlock(JaxModule):
     """Sparse MoE block with a sigmoid gated shared expert on top of the
     routed experts."""
@@ -391,25 +499,20 @@ class Qwen3NextSparseMoeBlock(JaxModule):
         use_ep = num_expert_parallelism > 1
         moe_backend = select_moe_backend(use_ep)
 
-        # The Router adapts its output to the backend: raw logits for the
-        # fused kernels, (weights, indices) for the unfused ones. Top-k
-        # followed by softmax over the selected logits is equivalent to
-        # HF's norm_topk_prob=True renormalization.
-        self.gate = Router(
+        self.gate = Qwen3NextRouter(
+            hidden_size,
+            config.num_experts,
             dtype=dtype,
-            hidden_size=hidden_size,
-            num_experts=config.num_experts,
-            num_experts_per_tok=config.num_experts_per_tok,
-            router_act="softmax",
             rngs=rng,
-            activation_ffw_td=(ShardingAxisName.MLP_DATA, None),
-            ed_sharding=(None, None),
+            use_bias=False,
+            quant_config=quant_config,
+            prefix=prefix + ".gate",
+            num_experts_per_tok=config.num_experts_per_tok,
             moe_backend=moe_backend,
-            mesh=mesh,
         )
 
         self.enable_return_routed_experts = True
-        self.experts = JaxMoE(
+        self.experts = Qwen3NextMoeExperts(
             dtype=dtype,
             num_local_experts=config.num_experts,
             hidden_size=hidden_size,
@@ -431,33 +534,13 @@ class Qwen3NextSparseMoeBlock(JaxModule):
             enable_return_routed_experts=self.enable_return_routed_experts,
             prefix=prefix + ".experts")
 
-        shared_intermediate = config.shared_expert_intermediate_size
-        self.shared_expert_gate_proj = JaxLinear(
+        self.shared_expert = Qwen3NextMLP(
             hidden_size,
-            shared_intermediate,
+            config.shared_expert_intermediate_size,
             dtype=dtype,
-            rngs=rng,
-            use_bias=False,
+            rng=rng,
             quant_config=quant_config,
-            prefix=prefix + ".shared_expert.gate_proj",
-        )
-        self.shared_expert_up_proj = JaxLinear(
-            hidden_size,
-            shared_intermediate,
-            dtype=dtype,
-            rngs=rng,
-            use_bias=False,
-            quant_config=quant_config,
-            prefix=prefix + ".shared_expert.up_proj",
-        )
-        self.shared_expert_down_proj = JaxLinear(
-            shared_intermediate,
-            hidden_size,
-            dtype=dtype,
-            rngs=rng,
-            use_bias=False,
-            quant_config=quant_config,
-            prefix=prefix + ".shared_expert.down_proj",
+            prefix=prefix + ".shared_expert",
         )
         self.shared_expert_gate = JaxLinear(
             hidden_size,
@@ -471,9 +554,7 @@ class Qwen3NextSparseMoeBlock(JaxModule):
 
     def __call__(self, x: jax.Array) -> Tuple[jax.Array, Optional[jax.Array]]:
         out, expert_ids = self.experts(x)
-        shared = self.shared_expert_down_proj(
-            jax.nn.silu(self.shared_expert_gate_proj(x)) *
-            self.shared_expert_up_proj(x))
+        shared = self.shared_expert(x)
         out = out + jax.nn.sigmoid(self.shared_expert_gate(x)) * shared
         return out, expert_ids
 
@@ -670,6 +751,39 @@ class Qwen3NextModel(JaxModule):
         return new_kv_caches, x, stacked_expert_ids
 
 
+def _load_zero_centered_norm(jax_param: nnx.Param,
+                             torch_weight,
+                             *,
+                             param_name: str = "Unknown"):
+    """Qwen3NextRMSNorm is zero centered (`out = norm(x) * (1 + w)`); fold
+    the +1 into the scale at load time so the standard RMSNorm applies."""
+    folded = (torch_weight.float() + 1.0).to(torch_weight.dtype)
+    load_nnx_param_from_reshaped_torch(jax_param,
+                                       folded,
+                                       param_name=param_name)
+
+
+def _load_float32_param(jax_param: nnx.Param,
+                        torch_weight,
+                        *,
+                        param_name: str = "Unknown"):
+    """A_log and dt_bias participate in exp/softplus and are kept in
+    float32 regardless of the checkpoint dtype."""
+    load_nnx_param_from_reshaped_torch(jax_param,
+                                       torch_weight.float(),
+                                       param_name=param_name)
+
+
+# Norms folded with +1 at load time. The gated norm inside linear_attn uses
+# a standard scale and is excluded.
+_ZERO_CENTERED_NORM_SUFFIXES = (
+    ".input_layernorm.weight",
+    ".post_attention_layernorm.weight",
+    ".q_norm.weight",
+    ".k_norm.weight",
+)
+
+
 class Qwen3NextForCausalLM(JaxModule, LoadableWithIterator):
 
     def __init__(self, vllm_config: VllmConfig, rng_key: jax.Array,
@@ -704,6 +818,26 @@ class Qwen3NextForCausalLM(JaxModule, LoadableWithIterator):
                 self.lm_head = PPMissingLayer()
         else:
             self.lm_head = PPMissingLayer()
+
+        for name, param in self.named_parameters():
+            if (name.endswith(_ZERO_CENTERED_NORM_SUFFIXES)
+                    or name == "model.norm.weight"):
+                param.set_metadata(
+                    "weight_loader",
+                    functools.partial(_load_zero_centered_norm,
+                                      param_name=name))
+            elif name.endswith((".A_log", ".dt_bias")):
+                param.set_metadata(
+                    "weight_loader",
+                    functools.partial(_load_float32_param, param_name=name))
+
+    def load_weights(self, weights) -> set:
+        # The checkpoint ships an MTP tower (`mtp.*`) that the base model
+        # does not use. Names get a `model.` prefix inside the loader when
+        # they do not start with one, so skip both spellings.
+        loader = JaxAutoWeightsLoader(self,
+                                      skip_prefixes=["mtp.", "model.mtp."])
+        return loader.load_weights(weights)
 
     def __call__(
         self,

--- a/tpu_inference/models/jax/qwen3_next.py
+++ b/tpu_inference/models/jax/qwen3_next.py
@@ -93,6 +93,14 @@ class Qwen3NextGatedDeltaNet(JaxModule):
         self.n_v = config.linear_num_value_heads
         self.d_k = config.linear_key_head_dim
         self.d_v = config.linear_value_head_dim
+        # The GDN kernel labels the recurrent state axes (n_v, d_k, d_v),
+        # while vLLM's state shape calculator (used for the kv cache spec)
+        # emits (n_v, d_v, d_k). They only agree when d_k == d_v, which holds
+        # for every released Qwen3-Next config; guard so an asymmetric-head
+        # variant fails loudly instead of corrupting recurrent state.
+        assert self.d_k == self.d_v, (
+            "GDN kernel assumes linear_key_head_dim == linear_value_head_dim, "
+            f"got d_k={self.d_k}, d_v={self.d_v}")
         self.kernel_size = config.linear_conv_kernel_dim
         self.key_dim = self.n_kq * self.d_k
         self.value_dim = self.n_v * self.d_v
@@ -180,6 +188,9 @@ class Qwen3NextGatedDeltaNet(JaxModule):
 
         # The kernel runs per TP shard; interleave the blocked [Q|K|V]
         # layout so each shard receives its own contiguous [Q|K|V] slice.
+        # TODO: the conv weight reorder is a function of static weights and
+        # could be hoisted to load time; kept here for now because the
+        # multi-chip path is not exercised by CPU tests.
         tp_size = get_mesh_shape_product(self.mesh, ShardingAxisName.ATTN_HEAD)
         split_sizes = [self.key_dim, self.key_dim, self.value_dim]
         if tp_size > 1:
@@ -254,6 +265,16 @@ class Qwen3NextAttention(JaxModule):
         self.head_dim_original = getattr(config, "head_dim",
                                          self.hidden_size // self.num_heads)
         self.head_dim = utils.get_padded_head_dim(self.head_dim_original)
+        # The fused q_proj kernel is (hidden, num_heads, 2 * head_dim) and is
+        # split in half to recover the query and the output gate; the per
+        # head q/k RMSNorm also runs over head_dim. Both assume no head_dim
+        # padding (padded == original), true for every released Qwen3-Next
+        # config (head_dim=256). Guard so a non-128-multiple head dim fails
+        # loudly rather than splitting query/gate at the wrong boundary or
+        # averaging padding into the norm.
+        assert self.head_dim == self.head_dim_original, (
+            "Qwen3-Next attention assumes an unpadded head_dim, got "
+            f"original={self.head_dim_original}, padded={self.head_dim}")
         self.rotary_dim = int(self.head_dim_original *
                               getattr(config, "partial_rotary_factor", 1.0))
 
@@ -405,22 +426,29 @@ class Qwen3NextMoeExperts(JaxMoE):
     (E, D, F) / (E, F, D) orientation the dense matmul consumes directly."""
 
     def _load_weights(self, weights, *, mesh: Mesh | None = None):
+        # The recursive loader delivers names relative to this experts
+        # module: fused tensors arrive as "gate_up_proj" / "down_proj",
+        # per-expert tensors as "<expert_id>.<proj>.weight". Expand a fused
+        # tensor into per-expert entries whose relative names the base
+        # loader parses (it splits on self.prefix then expects
+        # "<expert_id>.<proj>.weight"). Matching must be exact, not
+        # endswith, so a per-expert "0.down_proj.weight" is not mistaken
+        # for the fused "down_proj".
         expanded = []
         for name, torch_weight in weights:
-            if name.endswith("experts.gate_up_proj"):
+            if name == "gate_up_proj":
                 intermediate = torch_weight.shape[1] // 2
                 for expert_id in range(torch_weight.shape[0]):
                     expanded.append(
-                        (f"{self.prefix}.{expert_id}.gate_proj.weight",
+                        (f"{expert_id}.gate_proj.weight",
                          torch_weight[expert_id, :intermediate, :]))
-                    expanded.append(
-                        (f"{self.prefix}.{expert_id}.up_proj.weight",
-                         torch_weight[expert_id, intermediate:, :]))
-            elif name.endswith("experts.down_proj"):
+                    expanded.append((f"{expert_id}.up_proj.weight",
+                                     torch_weight[expert_id,
+                                                  intermediate:, :]))
+            elif name == "down_proj":
                 for expert_id in range(torch_weight.shape[0]):
-                    expanded.append(
-                        (f"{self.prefix}.{expert_id}.down_proj.weight",
-                         torch_weight[expert_id]))
+                    expanded.append((f"{expert_id}.down_proj.weight",
+                                     torch_weight[expert_id]))
             else:
                 expanded.append((name, torch_weight))
 

--- a/tpu_inference/models/jax/qwen3_next.py
+++ b/tpu_inference/models/jax/qwen3_next.py
@@ -1,0 +1,210 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""JAX native implementation of Qwen3-Next (hybrid gated delta net linear
+attention + gated full attention, sparse MoE with a shared expert)."""
+
+from typing import Tuple
+
+import jax
+import jax.numpy as jnp
+from flax import nnx
+from jax.sharding import Mesh
+
+from tpu_inference.layers.common.attention_metadata import AttentionMetadata
+from tpu_inference.layers.common.gdn_attention import run_jax_gdn_attention
+from tpu_inference.layers.common.sharding import ShardingAxisName
+from tpu_inference.layers.common.utils import \
+    reorder_concatenated_tensor_for_sharding
+from tpu_inference.layers.jax import JaxModule
+from tpu_inference.layers.jax.base import create_param
+from tpu_inference.layers.jax.linear import JaxEinsum
+from tpu_inference.layers.jax.norm import JaxRmsNorm
+from tpu_inference.logger import init_logger
+from tpu_inference.utils import get_mesh_shape_product
+
+logger = init_logger(__name__)
+
+init_fn = nnx.initializers.uniform()
+
+# Indirection over the fused Pallas conv1d + GDN kernel so CPU tests can
+# substitute a pure JAX reference implementation.
+_gdn_core = run_jax_gdn_attention
+
+
+class Conv1dWeight(JaxModule):
+    """Holds the depthwise causal conv weight under a `weight` param so its
+    parameter name lines up with the HF checkpoint (`...conv1d.weight`)."""
+
+    def __init__(self, conv_dim: int, kernel_size: int, dtype: jnp.dtype,
+                 rng: nnx.Rngs):
+        self.weight = create_param(rng, (conv_dim, 1, kernel_size),
+                                   ("model", None, None), dtype)
+
+
+class Qwen3NextGatedDeltaNet(JaxModule):
+    """Gated delta net linear attention block.
+
+    The projections, unpacking, output norm and gate run as plain JAX ops;
+    the depthwise causal conv1d and the gated delta rule scan run in the
+    fused GDN kernel, which also reads and writes the per request
+    (conv_state, recurrent_state) cache slots."""
+
+    def __init__(self,
+                 config,
+                 dtype: jnp.dtype,
+                 rng: nnx.Rngs,
+                 mesh: Mesh,
+                 quant_config,
+                 prefix: str = ""):
+        self.mesh = mesh
+        self.n_kq = config.linear_num_key_heads
+        self.n_v = config.linear_num_value_heads
+        self.d_k = config.linear_key_head_dim
+        self.d_v = config.linear_value_head_dim
+        self.kernel_size = config.linear_conv_kernel_dim
+        self.key_dim = self.n_kq * self.d_k
+        self.value_dim = self.n_v * self.d_v
+        self.conv_dim = 2 * self.key_dim + self.value_dim
+        hidden_size = config.hidden_size
+
+        self.in_proj_qkvz = JaxEinsum(
+            "TD,DP->TP",
+            (hidden_size, 2 * self.key_dim + 2 * self.value_dim),
+            dtype=dtype,
+            kernel_init=nnx.with_partitioning(init_fn, (None, "model")),
+            rngs=rng,
+            quant_config=quant_config,
+            prefix=prefix + ".in_proj_qkvz",
+        )
+        self.in_proj_ba = JaxEinsum(
+            "TD,DP->TP",
+            (hidden_size, 2 * self.n_v),
+            dtype=dtype,
+            kernel_init=nnx.with_partitioning(init_fn, (None, "model")),
+            rngs=rng,
+            quant_config=quant_config,
+            prefix=prefix + ".in_proj_ba",
+        )
+        self.conv1d = Conv1dWeight(self.conv_dim, self.kernel_size, dtype, rng)
+        self.A_log = create_param(rng, (self.n_v, ), ("model", ), jnp.float32)
+        self.dt_bias = create_param(rng, (self.n_v, ), ("model", ),
+                                    jnp.float32)
+        # Gated RMSNorm over d_v; standard scale (not the zero centered
+        # variant the rest of the model uses). The silu(z) gate is applied
+        # outside, matching HF's norm-before-gate ordering.
+        self.norm = JaxRmsNorm(
+            self.d_v,
+            epsilon=config.rms_norm_eps,
+            dtype=jnp.float32,
+            param_dtype=jnp.float32,
+            scale_init=nnx.with_partitioning(init_fn, (None, )),
+            rngs=rng,
+            quant_config=quant_config,
+            prefix=prefix + ".norm",
+        )
+        self.out_proj = JaxEinsum(
+            "TP,PD->TD",
+            (self.value_dim, hidden_size),
+            dtype=dtype,
+            kernel_init=nnx.with_partitioning(init_fn, ("model", None)),
+            rngs=rng,
+            quant_config=quant_config,
+            prefix=prefix + ".out_proj",
+        )
+
+    def _split_qkvz_ba(self, qkvz: jax.Array, ba: jax.Array):
+        """Unpacks the interleaved per key head projection layout, matching
+        HF's fix_query_key_value_ordering."""
+        t = qkvz.shape[0]
+        r = self.n_v // self.n_kq
+        qkvz = qkvz.reshape(t, self.n_kq, 2 * self.d_k + 2 * r * self.d_v)
+        q, k, v, z = jnp.split(
+            qkvz, [self.d_k, 2 * self.d_k, 2 * self.d_k + r * self.d_v],
+            axis=-1)
+        v = v.reshape(t, self.n_v, self.d_v)
+        z = z.reshape(t, self.n_v, self.d_v)
+        ba = ba.reshape(t, self.n_kq, 2 * r)
+        b, a = jnp.split(ba, [r], axis=-1)
+        b = b.reshape(t, self.n_v)
+        a = a.reshape(t, self.n_v)
+        return q, k, v, z, b, a
+
+    def __call__(
+        self,
+        kv_cache: Tuple[jax.Array, jax.Array],
+        x: jax.Array,
+        attention_metadata: AttentionMetadata,
+    ) -> Tuple[Tuple[jax.Array, jax.Array], jax.Array]:
+        md = attention_metadata
+        t = x.shape[0]
+        q, k, v, z, b, a = self._split_qkvz_ba(self.in_proj_qkvz(x),
+                                               self.in_proj_ba(x))
+        mixed_qkv = jnp.concatenate([
+            q.reshape(t, self.key_dim),
+            k.reshape(t, self.key_dim),
+            v.reshape(t, self.value_dim),
+        ],
+                                    axis=-1)
+
+        # The kernel runs per TP shard; interleave the blocked [Q|K|V]
+        # layout so each shard receives its own contiguous [Q|K|V] slice.
+        tp_size = get_mesh_shape_product(self.mesh, ShardingAxisName.ATTN_HEAD)
+        split_sizes = [self.key_dim, self.key_dim, self.value_dim]
+        if tp_size > 1:
+            mixed_qkv = reorder_concatenated_tensor_for_sharding(
+                mixed_qkv, split_sizes, tp_size, 1)
+            conv_weight = reorder_concatenated_tensor_for_sharding(
+                self.conv1d.weight.value, split_sizes, tp_size, 0)
+        else:
+            conv_weight = self.conv1d.weight.value
+
+        conv_state, recurrent_state = kv_cache
+        # With speculative decoding the conv cache carries extra rows; the
+        # kernel consumes exactly kernel_size - 1.
+        conv_state_tail = None
+        if conv_state.shape[1] > self.kernel_size - 1:
+            conv_state_tail = conv_state[:, self.kernel_size - 1:, :]
+            conv_state = conv_state[:, :self.kernel_size - 1, :]
+
+        (new_conv_state, new_recurrent_state), core_out = _gdn_core(
+            mixed_qkv,
+            b,
+            a,
+            conv_state,
+            recurrent_state,
+            conv_weight,
+            None,
+            self.A_log.value,
+            self.dt_bias.value,
+            md.mamba_state_indices,
+            md.query_start_loc,
+            md.request_distribution,
+            md.seq_lens,
+            n_kq=self.n_kq,
+            n_v=self.n_v,
+            d_k=self.d_k,
+            d_v=self.d_v,
+            kernel_size=self.kernel_size,
+            mesh=self.mesh,
+        )
+
+        if conv_state_tail is not None:
+            new_conv_state = jnp.concatenate([new_conv_state, conv_state_tail],
+                                             axis=1)
+
+        core_out = core_out.reshape(t, self.n_v, self.d_v)
+        gated = self.norm(core_out.astype(jnp.float32)) * jax.nn.silu(
+            z.astype(jnp.float32))
+        out = self.out_proj(gated.reshape(t, self.value_dim).astype(x.dtype))
+        return (new_conv_state, new_recurrent_state), out

--- a/tpu_inference/models/jax/qwen3_next.py
+++ b/tpu_inference/models/jax/qwen3_next.py
@@ -37,6 +37,7 @@ from tpu_inference.layers.common.utils import \
 from tpu_inference.layers.jax import JaxModule
 from tpu_inference.layers.jax.base import create_param
 from tpu_inference.layers.jax.embed import JaxEmbed
+from tpu_inference.layers.jax.layers import FlaxUtils
 from tpu_inference.layers.jax.linear import JaxEinsum, JaxLinear, JaxLmHead
 from tpu_inference.layers.jax.moe.moe import JaxMoE
 from tpu_inference.layers.jax.moe.utils import (get_expert_parallelism,
@@ -47,16 +48,18 @@ from tpu_inference.layers.jax.rope_interface import (apply_rope,
                                                      get_rope_scaling,
                                                      get_rope_theta)
 from tpu_inference.logger import init_logger
+from tpu_inference.models.common import layer_types as layer_type_names
 from tpu_inference.models.jax.jax_intermediate_tensor import \
     JaxIntermediateTensors
 from tpu_inference.models.jax.utils.weight_utils import (
-    JaxAutoWeightsLoader, LoadableWithIterator,
-    load_nnx_param_from_reshaped_torch)
+    JaxAutoWeightsLoader, LoadableWithIterator, assign_and_shard_param,
+    jax_array_from_reshaped_torch, load_nnx_param_from_reshaped_torch)
 from tpu_inference.utils import get_mesh_shape_product
 
 logger = init_logger(__name__)
 
 init_fn = nnx.initializers.uniform()
+modeling_flax_utils = FlaxUtils()
 
 # Indirection over the fused Pallas conv1d + GDN kernel so CPU tests can
 # substitute a pure JAX reference implementation.
@@ -126,6 +129,18 @@ class Qwen3NextGatedDeltaNet(JaxModule):
             prefix=prefix + ".in_proj_ba",
         )
         self.conv1d = Conv1dWeight(self.conv_dim, self.kernel_size, dtype, rng)
+        # Under TP the [Q|K|V] blocked conv weight is re-interleaved so each
+        # shard gets a contiguous [Q|K|V] slice. This is a function of static
+        # weights, so do it once at load time rather than every forward.
+        tp_size = get_mesh_shape_product(mesh, ShardingAxisName.ATTN_HEAD)
+        if tp_size > 1:
+            self.conv1d.weight.set_metadata(
+                "weight_loader",
+                functools.partial(
+                    _load_reordered_conv_weight,
+                    split_sizes=[self.key_dim, self.key_dim, self.value_dim],
+                    tp_size=tp_size,
+                    param_name=prefix + ".conv1d.weight"))
         self.A_log = create_param(rng, (self.n_v, ), ("model", ), jnp.float32)
         self.dt_bias = create_param(rng, (self.n_v, ), ("model", ),
                                     jnp.float32)
@@ -186,20 +201,16 @@ class Qwen3NextGatedDeltaNet(JaxModule):
         ],
                                     axis=-1)
 
-        # The kernel runs per TP shard; interleave the blocked [Q|K|V]
-        # layout so each shard receives its own contiguous [Q|K|V] slice.
-        # TODO: the conv weight reorder is a function of static weights and
-        # could be hoisted to load time; kept here for now because the
-        # multi-chip path is not exercised by CPU tests.
+        # The kernel runs per TP shard; interleave the activation's blocked
+        # [Q|K|V] layout so each shard receives its own contiguous [Q|K|V]
+        # slice. The conv weight is reordered to match once at load time
+        # (see _load_reordered_conv_weight), so it is read as-is here.
         tp_size = get_mesh_shape_product(self.mesh, ShardingAxisName.ATTN_HEAD)
-        split_sizes = [self.key_dim, self.key_dim, self.value_dim]
         if tp_size > 1:
+            split_sizes = [self.key_dim, self.key_dim, self.value_dim]
             mixed_qkv = reorder_concatenated_tensor_for_sharding(
                 mixed_qkv, split_sizes, tp_size, 1)
-            conv_weight = reorder_concatenated_tensor_for_sharding(
-                self.conv1d.weight.value, split_sizes, tp_size, 0)
-        else:
-            conv_weight = self.conv1d.weight.value
+        conv_weight = self.conv1d.weight.value
 
         conv_state, recurrent_state = kv_cache
         # With speculative decoding the conv cache carries extra rows; the
@@ -400,7 +411,14 @@ class Qwen3NextRouter(JaxLinear):
     """MoE router that adapts its output to the backend: raw logits for the
     fused kernels (which route internally), (weights, indices) for the
     unfused ones. Top-k followed by softmax over the selected logits equals
-    HF's softmax then top-k then renormalize (norm_topk_prob=True)."""
+    HF's softmax then top-k then renormalize (norm_topk_prob=True).
+
+    This mirrors the branch in layers/jax/moe/moe.py Router.__call__. It is a
+    JaxLinear subclass rather than that Router because the HF checkpoint ships
+    the gate as `mlp.gate.weight`, which JaxLinear's `weight` alias matches
+    for free; Router stores its projection as `kernel_DE` and would need a
+    name-remapping loader. Qwen3-Next also only ever uses plain softmax
+    routing, so the extra generality of Router is not needed here."""
 
     def __init__(self, *args, num_experts_per_tok: int,
                  moe_backend: MoEBackend, **kwargs):
@@ -466,7 +484,7 @@ class Qwen3NextMoeExperts(JaxMoE):
 
 
 class Qwen3NextMLP(JaxModule):
-    """Plain silu MLP used for the shared expert."""
+    """Gated MLP used for the shared expert."""
 
     def __init__(self,
                  hidden_size: int,
@@ -474,7 +492,9 @@ class Qwen3NextMLP(JaxModule):
                  dtype: jnp.dtype,
                  rng: nnx.Rngs,
                  quant_config,
+                 hidden_act: str = "silu",
                  prefix: str = ""):
+        self.act_fn = modeling_flax_utils.ACT2FN[hidden_act]
         self.gate_proj = JaxLinear(
             hidden_size,
             intermediate_size,
@@ -504,7 +524,7 @@ class Qwen3NextMLP(JaxModule):
         )
 
     def __call__(self, x: jax.Array) -> jax.Array:
-        return self.down_proj(jax.nn.silu(self.gate_proj(x)) * self.up_proj(x))
+        return self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))
 
 
 class Qwen3NextSparseMoeBlock(JaxModule):
@@ -568,6 +588,7 @@ class Qwen3NextSparseMoeBlock(JaxModule):
             dtype=dtype,
             rng=rng,
             quant_config=quant_config,
+            hidden_act=config.hidden_act,
             prefix=prefix + ".shared_expert",
         )
         self.shared_expert_gate = JaxLinear(
@@ -614,7 +635,7 @@ class Qwen3NextDecoderLayer(JaxModule):
             quant_config=quant_config,
             prefix=prefix + ".input_layernorm",
         )
-        if self.layer_type == "linear_attention":
+        if self.layer_type == layer_type_names.LINEAR_ATTENTION:
             self.linear_attn = Qwen3NextGatedDeltaNet(
                 config=config,
                 dtype=dtype,
@@ -665,7 +686,7 @@ class Qwen3NextDecoderLayer(JaxModule):
         attention_metadata: AttentionMetadata,
     ):
         hidden_states = self.input_layernorm(x)
-        if self.layer_type == "linear_attention":
+        if self.layer_type == layer_type_names.LINEAR_ATTENTION:
             kv_cache, attn_output = self.linear_attn(kv_cache, hidden_states,
                                                      attention_metadata)
         else:
@@ -777,6 +798,22 @@ class Qwen3NextModel(JaxModule):
         stacked_expert_ids = jnp.stack(all_expert_ids,
                                        axis=0) if all_expert_ids else None
         return new_kv_caches, x, stacked_expert_ids
+
+
+def _load_reordered_conv_weight(jax_param: nnx.Param,
+                                torch_weight,
+                                *,
+                                split_sizes: list,
+                                tp_size: int,
+                                param_name: str = "Unknown"):
+    """Reorder the depthwise conv weight's blocked [Q|K|V] channel axis so
+    each TP shard holds a contiguous [Q|K|V] slice, matching the activation
+    reorder the GDN block applies at forward time. Done once at load time
+    because the weight is static."""
+    jax_weight = jax_array_from_reshaped_torch(torch_weight)
+    jax_weight = reorder_concatenated_tensor_for_sharding(
+        jax_weight, split_sizes, tp_size, 0)
+    assign_and_shard_param(jax_param, jax_weight, param_name)
 
 
 def _load_zero_centered_norm(jax_param: nnx.Param,

--- a/tpu_inference/runner/kv_cache_manager.py
+++ b/tpu_inference/runner/kv_cache_manager.py
@@ -156,6 +156,12 @@ class KVCacheManager:
         speculative_config = self.runner.speculative_config
         num_spec = (speculative_config.num_speculative_tokens
                     if speculative_config else 0)
+        # Pass tp_size=1: the JAX side stores the full per-layer arrays and
+        # shards them through NamedSharding, unlike the torchax path which
+        # bakes the TP split into the shape. The temporal state comes back as
+        # (num_v_heads, head_v_dim, head_k_dim); the GDN kernel labels its
+        # axes (n_v, d_k, d_v), which matches only while head_k_dim ==
+        # head_v_dim (true for every released Qwen3-Next config).
         shapes = MambaStateShapeCalculator.gated_delta_net_state_shape(
             1, text_config.linear_num_key_heads,
             text_config.linear_num_value_heads,

--- a/tpu_inference/runner/kv_cache_manager.py
+++ b/tpu_inference/runner/kv_cache_manager.py
@@ -43,6 +43,7 @@ from tpu_inference import utils
 from tpu_inference import utils as common_utils
 from tpu_inference.layers.common.sharding import ShardingAxisName
 from tpu_inference.logger import init_logger
+from tpu_inference.models.common import layer_types as layer_type_names
 from tpu_inference.models.common.kv_share import compute_kv_share_map
 from tpu_inference.offload.utils import get_kv_connector_cache_layout
 from tpu_inference.runner import utils as runner_utils
@@ -539,7 +540,8 @@ class KVCacheManager:
             # GDN layer does and reuse the hybrid page size reconciliation.
             num_layers = model_config.get_num_layers(parallel_config)
             layer_types = list(getattr(text_config, "layer_types", None) or [])
-            num_linear_attn = layer_types.count("linear_attention")
+            num_linear_attn = layer_types.count(
+                layer_type_names.LINEAR_ATTENTION)
             jax_mamba_spec = None
             if num_linear_attn > 0:
                 jax_mamba_spec = self._create_jax_gdn_mamba_spec(text_config)
@@ -574,16 +576,17 @@ class KVCacheManager:
                     kv_cache_spec[f"layer.{i}"] = self._create_attention_spec(
                         block_size, 1, mla_head_size)
                 else:
-                    layer_type = "full_attention"
+                    layer_type = layer_type_names.FULL_ATTENTION
                     if i < len(layer_types):
                         layer_type = layer_types[i]
 
-                    if layer_type == "linear_attention":
+                    if layer_type == layer_type_names.LINEAR_ATTENTION:
                         assert jax_mamba_spec is not None
                         kv_cache_spec[f"layer.{i}"] = jax_mamba_spec
                         continue
 
-                    is_sliding = layer_type == "sliding_attention"
+                    is_sliding = (
+                        layer_type == layer_type_names.SLIDING_ATTENTION)
                     # Use `or` instead of getattr default so we also handle
                     # the case where the attribute is present but None
                     # (e.g. Gemma-4 E2B has num_global_key_value_heads=None).

--- a/tpu_inference/runner/kv_cache_manager.py
+++ b/tpu_inference/runner/kv_cache_manager.py
@@ -24,6 +24,8 @@ from vllm.config import get_layers_from_vllm_config, set_current_vllm_config
 from vllm.model_executor.layers.attention import Attention
 from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
 from vllm.model_executor.layers.mamba.abstract import MambaBase
+from vllm.model_executor.layers.mamba.mamba_utils import (
+    MambaStateDtypeCalculator, MambaStateShapeCalculator)
 from vllm.model_executor.layers.mla import MLAAttention
 from vllm.models.deepseek_v4.attention import (DeepseekV4Attention,
                                                DeepseekV4IndexerCache)
@@ -141,6 +143,42 @@ class KVCacheManager:
                                          dtype=self.runner.kv_cache_dtype,
                                          page_size_padded=page_size_padded)
 
+    def _create_jax_gdn_mamba_spec(self, text_config) -> MambaSpec:
+        """Build the MambaSpec for a GDN (gated delta net) linear attention
+        layer of a JAX-native model, mirroring what vLLM's
+        `QwenGatedDeltaNetAttention.get_kv_cache_spec` produces on the
+        torchax path (with tp_size=1; the JAX side shards the global arrays
+        through NamedSharding instead)."""
+        from vllm.v1.attention.backends.registry import \
+            MambaAttentionBackendEnum
+
+        cache_config = self.runner.cache_config
+        speculative_config = self.runner.speculative_config
+        num_spec = (speculative_config.num_speculative_tokens
+                    if speculative_config else 0)
+        shapes = MambaStateShapeCalculator.gated_delta_net_state_shape(
+            1, text_config.linear_num_key_heads,
+            text_config.linear_num_value_heads,
+            text_config.linear_key_head_dim, text_config.linear_value_head_dim,
+            text_config.linear_conv_kernel_dim, num_spec)
+        dtypes = MambaStateDtypeCalculator.gated_delta_net_state_dtype(
+            self.runner.model_config.dtype, cache_config.mamba_cache_dtype,
+            cache_config.mamba_ssm_cache_dtype)
+        # vLLM's hybrid config check sets mamba_block_size before layers are
+        # built; fall back to max_model_len (its non-prefix-caching default)
+        # in case the model was not recognized as hybrid.
+        mamba_block_size = (cache_config.mamba_block_size
+                            or self.runner.model_config.max_model_len)
+        return MambaSpec(
+            shapes=tuple(shapes),
+            dtypes=tuple(dtypes),
+            block_size=mamba_block_size,
+            page_size_padded=cache_config.mamba_page_size_padded,
+            mamba_type=MambaAttentionBackendEnum.GDN_ATTN,
+            mamba_cache_mode=cache_config.mamba_cache_mode,
+            num_speculative_blocks=num_spec,
+        )
+
     def update_mamba_page_size_padded(
             self, layers: dict[str, AttentionLayerBase]) -> None:
         """Pad attention and mamba page sizes so vLLM's num_blocks matches
@@ -227,6 +265,16 @@ class KVCacheManager:
         unpadded_mamba_page_size = dataclasses.replace(
             first_mamba_spec, page_size_padded=None).page_size_bytes
 
+        self._update_hybrid_page_size(attn_page_size_bytes,
+                                      int(unpadded_mamba_page_size),
+                                      num_attn=len(attn_modules),
+                                      num_mamba=len(mamba_modules))
+
+    def _update_hybrid_page_size(self, attn_page_size_bytes: int,
+                                 unpadded_mamba_page_size: int, num_attn: int,
+                                 num_mamba: int) -> None:
+        """Module-free core of `update_mamba_page_size_padded`, shared with
+        the JAX-native spec path where no vLLM modules exist."""
         # Derive vLLM's kv-cache group layout. vLLM splits each type into
         # equal-sized groups of `group_size` layers, then allocates
         # `group_size` `KVCacheTensor`s, each `shared_by` one layer from
@@ -252,8 +300,6 @@ class KVCacheManager:
         # spec creation depends on padding). Keep in sync if that
         # heuristic ever changes — it has been stable since the hybrid
         # allocator landed.
-        num_attn = len(attn_modules)
-        num_mamba = len(mamba_modules)
         min_count = min(num_attn, num_mamba)
         max_count = max(num_attn, num_mamba)
         # Match vLLM exactly: float comparison, no int() truncation (matters
@@ -481,7 +527,35 @@ class KVCacheManager:
             # the common case.
             kv_share_map = compute_kv_share_map(text_config)
 
-            for i in range(model_config.get_num_layers(parallel_config)):
+            # Hybrid attention + linear attention (GDN) models, e.g.
+            # Qwen3-Next. The JAX path has no vLLM MambaBase modules, so
+            # derive the MambaSpec from the HF config the same way vLLM's
+            # GDN layer does and reuse the hybrid page size reconciliation.
+            num_layers = model_config.get_num_layers(parallel_config)
+            layer_types = list(getattr(text_config, "layer_types", None) or [])
+            num_linear_attn = layer_types.count("linear_attention")
+            jax_mamba_spec = None
+            if num_linear_attn > 0:
+                jax_mamba_spec = self._create_jax_gdn_mamba_spec(text_config)
+                attn_page_size_bytes = get_attention_page_size_bytes(
+                    self.runner.mesh, block_size,
+                    common_utils.get_padded_num_heads(base_num_kv_heads,
+                                                      model_cnt),
+                    common_utils.get_padded_head_dim(base_head_size),
+                    self.runner.kv_cache_dtype, False)
+                self._update_hybrid_page_size(
+                    int(attn_page_size_bytes),
+                    int(
+                        dataclasses.replace(
+                            jax_mamba_spec,
+                            page_size_padded=None).page_size_bytes),
+                    num_attn=num_layers - num_linear_attn,
+                    num_mamba=num_linear_attn)
+                jax_mamba_spec = dataclasses.replace(
+                    jax_mamba_spec,
+                    page_size_padded=self._hybrid_uniform_page_size_bytes)
+
+            for i in range(num_layers):
                 # If this layer is KV-shared, register the redirect and skip
                 # spec creation (so no slot is allocated). The forward-time
                 # remap at line ~835 picks the source layer's slot.
@@ -494,11 +568,14 @@ class KVCacheManager:
                     kv_cache_spec[f"layer.{i}"] = self._create_attention_spec(
                         block_size, 1, mla_head_size)
                 else:
-                    # TODO(kwang3939): unify the hybrid kv cache of jax path and tochax path.
                     layer_type = "full_attention"
-                    if hasattr(text_config, "layer_types") and i < len(
-                            text_config.layer_types):
-                        layer_type = text_config.layer_types[i]
+                    if i < len(layer_types):
+                        layer_type = layer_types[i]
+
+                    if layer_type == "linear_attention":
+                        assert jax_mamba_spec is not None
+                        kv_cache_spec[f"layer.{i}"] = jax_mamba_spec
+                        continue
 
                     is_sliding = layer_type == "sliding_attention"
                     # Use `or` instead of getattr default so we also handle


### PR DESCRIPTION
Implements JAX-native (flax nnx) Qwen3-Next, closing #967.

Qwen3-Next is a hybrid model: three gated-delta-net (GDN) linear-attention layers per one gated full-attention layer, with a sparse MoE (512 experts, top-10) plus a sigmoid-gated shared expert on every layer. This adds the flax_nnx implementation; the torchax path already serves this model, so this follows CONTRIBUTING.md's preferred torchax then JAX-native progression.

## What's included

- `models/jax/qwen3_next.py`: GDN linear attention (reuses the existing v3 fused conv1d+GDN Pallas kernel via `run_jax_gdn_attention`), gated full attention with partial RoPE, sparse MoE with a shared expert.
- `runner/kv_cache_manager.py`: the JAX-native `get_kv_cache_spec` branch now emits `MambaSpec` for `linear_attention` layers, activating the existing backend-agnostic hybrid mamba runtime (tuple `(conv_state, ssm_state)` caches, `mamba_state_indices`, compact sizing). The module-independent core of the hybrid page-size reconciliation is split out of `update_mamba_page_size_padded` so both the torchax and JAX paths share it.
- HF checkpoint loading: zero-centered RMSNorm +1 folding, both fused-3D and per-expert MoE tensor layouts, `A_log`/`dt_bias` kept in float32, MTP tower skipped.
- Model registration plus per-layer jit out-shardings for the hybrid cache.
- Shared `models/common/layer_types.py` constants so the kv-cache spec, the jit out-sharding selection, and the decoder layer cannot silently desync on the HF layer-type strings.

## Testing

- CPU unit tests (`tests/models/jax/test_qwen3_next.py`) compare the GDN block, gated full attention, and the MoE block against HF transformers, and check end-to-end logits through a tiny checkpoint round-trip. Hybrid kv-cache spec tests live in `tests/runner/test_kv_cache_manager_jax_hybrid.py`.
- A TPU forward smoke test exercising the real GDN and ragged-paged-attention kernels is added and gated to run under the new `.buildkite/models` v6e CI entry.
- I have not run 80B-A3B accuracy or performance on real TPU hardware. The CI entry currently covers unit tests only; the accuracy and benchmark stages are left for follow-up once hardware thresholds are measured.

## Known follow-ups (not blocking)

- Promote the fused-3D expert handling into shared `JaxMoE` if other MoE models adopt that checkpoint layout.
- Derive the hybrid jit out-shardings from the kv-cache spec rather than re-scanning `layer_types`.
- Pipeline parallelism is disabled for this model for now (`_PP_DISABLED_MODELS`).
