### PR TITLE
[offload] Optional LMCache host-backend spill tier behind TPUOffloadConnector

### DIFF
--- a/docs/offload/lmcache_host_backend.md
+++ b/docs/offload/lmcache_host_backend.md
@@ -1,0 +1,86 @@
+# LMCache host backend for TPUOffloadConnector
+
+Use [LMCache](https://github.com/lmcache/lmcache) as a persistent, tiered host-side
+KV storage layer **behind** the native `TPUOffloadConnector`, without rewriting
+LMCache's CUDA/XPU/HPU GPU connectors for JAX.
+
+## Why this design
+
+`TPUOffloadConnector` already owns the TPU-specific hard part: moving KV blocks
+between HBM (JAX device arrays) and host memory, staging/scatter/gather, and the
+scheduler-side content hashing (`LRUCacheManager`). Its host store is
+`LocalCPUBackend` — a bounded in-memory `OrderedDict`.
+
+This integration keeps that exact store interface but backs it with LMCache:
+
+```
+vLLM engine
+  └─ TPUOffloadConnector           (owns HBM<->host JAX-array movement)
+       └─ host store               (add/get/reclaim by chunk_id)
+            ├─ hot CPU tier         (OrderedDict, == LocalCPUBackend)
+            └─ LMCache tier         (disk today; remote/P2P/cross-instance next)
+                 via kv_bridge (jax.Array <-> raw bytes, bit-exact incl. bf16)
+```
+
+Two alternatives were rejected:
+1. **LMCache as a TPU `KVConnector`** — `tpu_platform.py` hard-allowlists the
+   connector to `{TPUConnector, TPUConnectorHMA, TPUOffloadConnector,
+   RaidenOffloadConnector}`, and LMCache's device detection has no `torch_xla`
+   branch (all its connectors move torch tensors out of paged CUDA/XPU/HPU
+   memory). TPU KV lives as JAX arrays in an XLA mesh.
+2. Reimplementing LMCache's GPU connector for JAX — large surface, duplicates
+   the movement `TPUOffloadConnector` already does correctly.
+
+## Enabling it
+
+All flags are off by default → **identical behavior to upstream** (stock
+`LocalCPUBackend`).
+
+| Env var | Default | Meaning |
+|---|---|---|
+| `TPU_OFFLOAD_LMCACHE` | `0` | `1` enables the LMCache host backend |
+| `TPU_OFFLOAD_LMCACHE_BACKEND` | `file` | `file` / `memory` (reference) or `lmcache` (real StorageManager tiers) |
+| `TPU_OFFLOAD_LMCACHE_HOT_CHUNKS` | `0` | Host-RAM hot-tier capacity in chunks; `0` = `TPU_OFFLOAD_NUM_CPU_CHUNKS` |
+| `TPU_OFFLOAD_LMCACHE_PATH` | `/tmp/tpu_lmcache_kv` | Filesystem root for `file` / `lmcache` disk tier |
+
+Example (single-host disk spill, no LMCache install required):
+
+```bash
+export TPU_OFFLOAD_LMCACHE=1
+export TPU_OFFLOAD_LMCACHE_BACKEND=file
+export TPU_OFFLOAD_LMCACHE_HOT_CHUNKS=2048
+vllm serve <model> \
+  --kv-transfer-config '{"kv_connector":"TPUOffloadConnector","kv_connector_module_path":"tpu_inference.offload.tpu_offload_connector.TPUOffloadConnector","kv_role":"kv_both"}'
+```
+
+For the real LMCache tier (`TPU_OFFLOAD_LMCACHE_BACKEND=lmcache`), install the
+LMCache fork with the TPU integration (`lmcache.integration.tpu`).
+
+## Components
+
+| File | Role |
+|---|---|
+| `tpu_inference/offload/kv_bridge.py` | Bit-exact `jax.Array` (host) ⟷ raw bytes, incl. bfloat16 |
+| `tpu_inference/offload/lmcache_host_backend.py` | `LMCacheHostBackend`: drop-in for `LocalCPUBackend` + spill tier + Depth-2 content-hash hook |
+| `tpu_inference/offload/lmcache_kv_store.py` | Raw-bytes KV store protocol + reference `File`/`Memory` stores |
+| `tpu_inference/offload/host_backend_factory.py` | Env-gated selection (default = stock `LocalCPUBackend`) |
+
+## Correctness
+
+- The value bridge is **bit-exact** for float32/float16/bfloat16/int8/int32
+  (raw byte view; no lossy cast — bfloat16 survives via `ml_dtypes`).
+- `LMCacheHostBackend` preserves `LocalCPUBackend`'s `add`/`get`/
+  `reclaim_unoccupied_chunks`/`num_saved_cpu_chunks` contract, including the
+  invalid-`chunk_id` `ValueError`.
+- Tests (`tests/offload/kv_bridge_test.py`,
+  `tests/offload/lmcache_host_backend_test.py`) run on `jax[cpu]` — no TPU.
+
+## Roadmap
+
+- **Depth 1 (this change):** persistent disk spill keyed by `chunk_id`. KV
+  survives beyond hot-tier RAM.
+- **Depth 2:** thread the scheduler's `BlockHash` to the worker
+  (`set_chunk_hash_hint` is the hook) → content-addressed `CacheEngineKey` →
+  cross-replica prefix sharing (e.g. a DP rollout fleet), remote backends
+  (Redis / Mooncake / NIXL), and reuse across restarts.
+- **Depth 3:** CacheBlend on TPU (out of scope; blend forward is separate work).

--- a/docs/offload/lmcache_host_backend.md
+++ b/docs/offload/lmcache_host_backend.md
@@ -84,3 +84,13 @@ LMCache fork with the TPU integration (`lmcache.integration.tpu`).
   cross-replica prefix sharing (e.g. a DP rollout fleet), remote backends
   (Redis / Mooncake / NIXL), and reuse across restarts.
 - **Depth 3:** CacheBlend on TPU (out of scope; blend forward is separate work).
+
+## Validated on real hardware
+
+Bit-for-bit correctness confirmed on a **tpu7x 2x2x1** slice via
+`examples/offload/offline_inference_kv_cache_verification.py`:
+- stock (`TPU_OFFLOAD_LMCACHE=0`) → all runs passed, exit 0;
+- LMCache enabled (`backend=file`, `hot_chunks=2`, forced spill) → all runs passed,
+  exit 0, backend confirmed live in the worker log;
+- direct probe: 5 chunks / hot=2 → 3 evicted + reloaded from disk, all bit-exact
+  (incl. bfloat16).

--- a/tests/offload/kv_bridge_test.py
+++ b/tests/offload/kv_bridge_test.py
@@ -1,0 +1,63 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Bit-exact roundtrip tests for the LMCache-on-TPU value bridge.
+
+Runs on jax[cpu]; no TPU required.
+"""
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from tpu_inference.offload.kv_bridge import (bytes_to_jax_block,
+                                             jax_block_to_bytes)
+
+KV_SHAPE = (1, 4, 16, 8, 2, 32)  # (1, num_layers, block, num_head, 2, head_dim)
+
+
+def _bytes(x):
+    return np.asarray(jax.device_get(x)).tobytes()
+
+
+@pytest.mark.parametrize("dtype", ["float32", "float16", "bfloat16", "int8", "int32"])
+def test_roundtrip_bit_exact(dtype):
+    jdt = jnp.dtype(dtype)
+    key = jax.random.PRNGKey(0)
+    if jdt in (jnp.int8, jnp.int32):
+        x = jax.random.randint(key, KV_SHAPE, -100, 100).astype(jdt)
+    else:
+        x = jax.random.normal(key, KV_SHAPE).astype(jdt)
+    raw, spec = jax_block_to_bytes(x)
+    y = bytes_to_jax_block(raw, spec)
+    assert y.shape == x.shape
+    assert jnp.dtype(y.dtype) == jnp.dtype(x.dtype)
+    assert _bytes(y) == _bytes(x), f"bytes differ for {dtype}"
+
+
+def test_bfloat16_edge_values():
+    vals = jnp.array(
+        [0.0, -0.0, 1.0, -1.0, float("inf"), float("-inf"), 3.14159, 0.333333],
+        dtype=jnp.bfloat16,
+    )
+    x = jnp.broadcast_to(vals.reshape(1, 1, 4, 1, 2, 1), (1, 2, 4, 2, 2, 8)).astype(jnp.bfloat16)
+    raw, spec = jax_block_to_bytes(x)
+    y = bytes_to_jax_block(raw, spec)
+    assert _bytes(y) == _bytes(x)
+
+
+def test_spec_serialization():
+    from tpu_inference.offload.kv_bridge import KVBlockSpec
+    s = KVBlockSpec(shape=(1, 4, 16, 8, 2, 32), dtype_str="bfloat16")
+    s2 = KVBlockSpec.from_dict(s.to_dict())
+    assert s2 == s

--- a/tests/offload/lmcache_host_backend_test.py
+++ b/tests/offload/lmcache_host_backend_test.py
@@ -1,0 +1,112 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for LMCacheHostBackend (drop-in for LocalCPUBackend with LMCache spill).
+
+Runs on jax[cpu]; no TPU required. Uses the reference File/Memory KV stores so
+no LMCache install is needed to run these.
+"""
+import tempfile
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from tpu_inference.offload.lmcache_host_backend import LMCacheHostBackend
+from tpu_inference.offload.lmcache_kv_store import (FileKVStore,
+                                                    InMemoryKVStore)
+
+KV_SHAPE = (1, 4, 16, 8, 2, 32)
+
+
+def _blk(seed, dtype=jnp.bfloat16, shape=KV_SHAPE):
+    return jax.random.normal(jax.random.PRNGKey(seed), shape).astype(dtype)
+
+
+def _eq(a, b):
+    return np.asarray(jax.device_get(a)).tobytes() == np.asarray(jax.device_get(b)).tobytes()
+
+
+def test_parity_no_store():
+    """No LMCache tier -> behaves like LocalCPUBackend (in-memory only)."""
+    be = LMCacheHostBackend(num_cpu_chunks=8, lmcache_store=None)
+    blocks = {i: _blk(i) for i in range(5)}
+    for i, b in blocks.items():
+        assert be.add(i, b)
+    assert be.num_saved_cpu_chunks == 5
+    for i, b in blocks.items():
+        assert _eq(be.get(i), b)
+    assert be.get(99) is None
+
+
+def test_invalid_chunk_id():
+    be = LMCacheHostBackend(num_cpu_chunks=4, lmcache_store=None)
+    with pytest.raises(ValueError):
+        be.add(4, _blk(0))
+    with pytest.raises(ValueError):
+        be.add(-1, _blk(0))
+
+
+def test_disk_spill_bit_exact(tmp_path):
+    store = FileKVStore(str(tmp_path))
+    be = LMCacheHostBackend(num_cpu_chunks=64, lmcache_store=store, hot_capacity=2)
+    blocks = {i: _blk(100 + i) for i in range(6)}
+    for i, b in blocks.items():
+        be.add(i, b)
+    assert len(be.cache) <= 2
+    for i, b in blocks.items():
+        got = be.get(i)
+        assert got is not None and _eq(got, b)
+
+
+def test_list_of_layers_spill():
+    store = InMemoryKVStore()
+    be = LMCacheHostBackend(num_cpu_chunks=64, lmcache_store=store, hot_capacity=1)
+    layers_by_chunk = {
+        i: [_blk(200 + i * 10 + L, shape=(1, 1, 16, 8, 2, 32)) for L in range(4)]
+        for i in range(3)
+    }
+    for i, layers in layers_by_chunk.items():
+        be.add(i, layers)
+    for i, layers in layers_by_chunk.items():
+        got = be.get(i)
+        assert got is not None and len(got) == 4
+        for L in range(4):
+            assert _eq(got[L], layers[L])
+
+
+def test_reclaim_unoccupied():
+    store = InMemoryKVStore()
+    be = LMCacheHostBackend(num_cpu_chunks=8, lmcache_store=store)
+    for i in range(6):
+        be.add(i, _blk(300 + i))
+    be.reclaim_unoccupied_chunks([0, 1, 2])
+    for i in range(6):
+        got = be.get(i)
+        if i in (0, 1, 2):
+            assert got is not None
+        else:
+            assert got is None
+
+
+def test_content_hash_hint(tmp_path):
+    store = FileKVStore(str(tmp_path))
+    be = LMCacheHostBackend(num_cpu_chunks=64, lmcache_store=store, hot_capacity=1)
+    b = _blk(400)
+    be.set_chunk_hash_hint(0, "deadbeefhash")
+    be.add(0, b)
+    be.add(1, _blk(401))  # forces hot eviction of chunk 0
+    got = be.get(0)
+    assert got is not None and _eq(got, b)
+    assert store.contains("h:deadbeefhash")

--- a/tpu_inference/envs.py
+++ b/tpu_inference/envs.py
@@ -62,6 +62,22 @@ if TYPE_CHECKING:
     TPU_OFFLOAD_METRICS_LOG_INTERVAL: int = 5
     TPU_OFFLOAD_USE_UNPINNED_HOST: bool = False
     TPU_OFFLOAD_BLOCK_SIZE_BUCKETS: list[int] = []
+    # LMCache host-backend integration (Path B): use LMCache as a persistent
+    # storage tier BEHIND the TPUOffloadConnector's host store. When enabled,
+    # host KV blocks that overflow the hot CPU tier spill to LMCache
+    # (disk/remote/P2P) instead of being dropped, and (with content-hash keying)
+    # can be shared across TPU replicas / survive restarts. Default off ->
+    # identical behavior to the stock LocalCPUBackend.
+    TPU_OFFLOAD_LMCACHE: bool = False
+    # Host RAM hot-tier capacity (in chunks) when LMCache spill is enabled. 0 =
+    # use TPU_OFFLOAD_NUM_CPU_CHUNKS (no explicit spill, LMCache mirrors only).
+    TPU_OFFLOAD_LMCACHE_HOT_CHUNKS: int = 0
+    # LMCache backend selector: "file" (reference filesystem spill),
+    # "memory" (reference in-process), or "lmcache" (real LMCache StorageManager
+    # via the lmcache fork's LMCacheStorageKVStore adapter).
+    TPU_OFFLOAD_LMCACHE_BACKEND: str = "file"
+    # Filesystem root for the "file" reference backend.
+    TPU_OFFLOAD_LMCACHE_PATH: str = "/tmp/tpu_lmcache_kv"
     MOE_APPROX_TOPK: bool = False
     MOE_APPROX_TOPK_RECALL_TARGET: float | None = None
     VLLM_TPU_PATCH_MM_EMBEDDINGS: bool = False
@@ -388,6 +404,14 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # kv offload to dram: Whether to use unpinned_host for KV cache tensors on host dram.
     "TPU_OFFLOAD_USE_UNPINNED_HOST":
     lambda: bool(int(os.getenv("TPU_OFFLOAD_USE_UNPINNED_HOST", "0"))),
+    "TPU_OFFLOAD_LMCACHE":
+    lambda: bool(int(os.getenv("TPU_OFFLOAD_LMCACHE", "0"))),
+    "TPU_OFFLOAD_LMCACHE_HOT_CHUNKS":
+    lambda: int(os.getenv("TPU_OFFLOAD_LMCACHE_HOT_CHUNKS", "0")),
+    "TPU_OFFLOAD_LMCACHE_BACKEND":
+    lambda: os.getenv("TPU_OFFLOAD_LMCACHE_BACKEND", "file"),
+    "TPU_OFFLOAD_LMCACHE_PATH":
+    lambda: os.getenv("TPU_OFFLOAD_LMCACHE_PATH", "/tmp/tpu_lmcache_kv"),
     "AGGREGATED_STATS_DIR":
     lambda: os.getenv("AGGREGATED_STATS_DIR", ""),
     # kv offload to dram: buckets of sizes for pre-compilation

--- a/tpu_inference/models/jax/qwen2.py
+++ b/tpu_inference/models/jax/qwen2.py
@@ -396,9 +396,13 @@ class Qwen2ForCausalLM(JaxModule, LoadableWithIterator):
         model_config = vllm_config.model_config
         if not model_config.hf_config.tie_word_embeddings:
             vocab_size = model_config.get_vocab_size()
-            hidden_size = getattr(
-                model_config.hf_config, 'hidden_size',
-                model_config.hf_config.text_config.hidden_size)
+            # transformers v5 nests language attrs under text_config for VL
+            # configs; plain Qwen2Config exposes hidden_size directly. Resolve
+            # the language config first (mirrors Qwen2Model above) so we never
+            # eagerly touch a missing `.text_config` on untied-embedding models.
+            lang_config = getattr(model_config.hf_config, 'text_config',
+                                  model_config.hf_config)
+            hidden_size = lang_config.hidden_size
             self.lm_head = JaxLmHead(
                 hidden_size=hidden_size,
                 vocab_size=vocab_size,

--- a/tpu_inference/offload/host_backend_factory.py
+++ b/tpu_inference/offload/host_backend_factory.py
@@ -1,0 +1,77 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Factory that selects the TPUOffloadConnector host store.
+
+Default (TPU_OFFLOAD_LMCACHE=0): the stock in-memory ``LocalCPUBackend`` — zero
+behavior change. When TPU_OFFLOAD_LMCACHE=1: an ``LMCacheHostBackend`` with a
+persistent spill tier selected by TPU_OFFLOAD_LMCACHE_BACKEND:
+  * "file"    -> FileKVStore (reference filesystem spill, no LMCache install)
+  * "memory"  -> InMemoryKVStore (reference, single-process)
+  * "lmcache" -> LMCacheStorageKVStore (real LMCache StorageManager: disk/remote/
+                 P2P/cross-instance) from the lmcache fork. Imported lazily so
+                 tpu-inference has no hard dependency on lmcache.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from tpu_inference import envs
+from tpu_inference.logger import init_logger
+
+logger = init_logger(__name__)
+
+
+def build_host_backend(num_cpu_chunks: int, model_name: str = "") -> Any:
+    """Return the host KV store for the TPUOffloadConnector worker."""
+    if not envs.TPU_OFFLOAD_LMCACHE:
+        # Stock path: identical to upstream.
+        from tpu_inference.offload.cpu_backend import LocalCPUBackend
+        return LocalCPUBackend(num_cpu_chunks=num_cpu_chunks)
+
+    from tpu_inference.offload.lmcache_host_backend import LMCacheHostBackend
+
+    backend = envs.TPU_OFFLOAD_LMCACHE_BACKEND
+    hot_chunks = envs.TPU_OFFLOAD_LMCACHE_HOT_CHUNKS or num_cpu_chunks
+
+    store = _build_store(backend, model_name=model_name)
+    logger.info(
+        "TPU_OFFLOAD_LMCACHE enabled: backend=%s hot_chunks=%d chunk_id_space=%d",
+        backend, hot_chunks, num_cpu_chunks)
+    return LMCacheHostBackend(
+        num_cpu_chunks=num_cpu_chunks,
+        lmcache_store=store,
+        hot_capacity=hot_chunks,
+    )
+
+
+def _build_store(backend: str, model_name: str = "") -> Any:
+    from tpu_inference.offload.lmcache_kv_store import (FileKVStore,
+                                                        InMemoryKVStore)
+    if backend == "memory":
+        return InMemoryKVStore()
+    if backend == "file":
+        return FileKVStore(root=envs.TPU_OFFLOAD_LMCACHE_PATH)
+    if backend == "lmcache":
+        # Real LMCache StorageManager (disk/remote/P2P/cross-instance). Lazy
+        # import so lmcache is only required when this backend is selected.
+        try:
+            from lmcache.integration.tpu.lmcache_storage_kv_store import (
+                LMCacheStorageKVStore)
+        except Exception as e:  # pragma: no cover - optional dependency
+            raise RuntimeError(
+                "TPU_OFFLOAD_LMCACHE_BACKEND=lmcache requires the lmcache fork "
+                "with the TPU integration (lmcache.integration.tpu). "
+                f"Import failed: {e}")
+        return LMCacheStorageKVStore.from_env(model_name=model_name)
+    raise ValueError(f"Unknown TPU_OFFLOAD_LMCACHE_BACKEND: {backend!r}")

--- a/tpu_inference/offload/kv_bridge.py
+++ b/tpu_inference/offload/kv_bridge.py
@@ -1,0 +1,40 @@
+# Copyright 2026
+# LMCache-on-TPU value bridge: jax.Array (host) <-> flat bytes buffer.
+from __future__ import annotations
+import dataclasses
+from typing import Any
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+
+@dataclasses.dataclass(frozen=True)
+class KVBlockSpec:
+    """Everything needed to reconstruct a JAX KV block from raw bytes."""
+    shape: tuple
+    dtype_str: str
+
+    def to_dict(self) -> dict:
+        return {"shape": list(self.shape), "dtype_str": self.dtype_str}
+
+    @staticmethod
+    def from_dict(d: dict) -> "KVBlockSpec":
+        return KVBlockSpec(shape=tuple(d["shape"]), dtype_str=d["dtype_str"])
+
+
+def jax_block_to_bytes(arr: Any):
+    """Serialize a host jax.Array KV block to raw bytes + reconstruct spec.
+    Raw byte view -> bfloat16/float16/int8/fp8 all roundtrip bit-exactly."""
+    host = np.asarray(jax.device_get(arr))
+    spec = KVBlockSpec(shape=tuple(host.shape), dtype_str=jnp.dtype(arr.dtype).name)
+    raw = host.tobytes()
+    return raw, spec
+
+
+def bytes_to_jax_block(raw: bytes, spec: KVBlockSpec):
+    """Reconstruct a host jax.Array from raw bytes + spec (bit-exact)."""
+    jdt = jnp.dtype(spec.dtype_str)
+    np_dt = np.dtype(jdt)
+    flat = np.frombuffer(raw, dtype=np_dt)
+    host = flat.reshape(spec.shape)
+    return jnp.asarray(host)

--- a/tpu_inference/offload/lmcache_host_backend.py
+++ b/tpu_inference/offload/lmcache_host_backend.py
@@ -1,0 +1,254 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""LMCacheHostBackend: a drop-in replacement for ``LocalCPUBackend`` that adds
+LMCache-backed storage tiers (disk spill today; remote/P2P/cross-instance next)
+BEHIND the native ``TPUOffloadConnector``.
+
+Rationale
+---------
+``TPUOffloadConnector`` already owns the TPU-specific hard part: moving KV blocks
+between HBM (JAX device arrays) and host memory (host-sharded JAX arrays), the
+scatter/gather staging, and the scheduler-side content hashing. Its host store is
+``LocalCPUBackend`` — an in-memory ``OrderedDict`` capped at ``num_cpu_chunks``.
+
+This class keeps that exact interface (``add`` / ``get`` /
+``reclaim_unoccupied_chunks`` / ``num_saved_cpu_chunks``) so it is a one-line swap
+in the connector worker, but backs it with:
+  * a bounded hot CPU tier (identical semantics to LocalCPUBackend), and
+  * an LMCache storage tier (local_disk today) that persists evicted blocks and
+    serves them back on miss — so KV survives beyond RAM and (with a content-hash
+    key, Depth 2) can be shared across TPU replicas / restarts.
+
+The value bridge (``kv_bridge``) serializes the host JAX array to raw bytes
+bit-exactly (incl. bfloat16) and reconstructs it on load. No CUDA. Runs on
+jax[cpu] for local development and on real TPU unchanged.
+
+Design notes
+------------
+* Depth-1 keying is by the connector's ephemeral ``chunk_id`` (an int slot). The
+  connector guarantees a given content maps to a stable chunk_id for its lifetime
+  via the scheduler ``LRUCacheManager``; within a process this is a correct cache.
+* Depth-2 (cross-instance) requires threading the ``BlockHash`` to the worker so
+  the LMCache key is content-addressed. ``set_chunk_hash_hint`` is the forward-
+  compatible hook for that; when unset we fall back to chunk_id keying.
+* All LMCache tiers are optional. With ``lmcache_backend=None`` this class behaves
+  exactly like ``LocalCPUBackend`` (pure in-memory), which makes it safe to enable
+  by default and lets tests run without any LMCache install.
+"""
+from __future__ import annotations
+
+import sys
+import threading
+from collections import OrderedDict
+from typing import Any, Optional
+
+from tpu_inference.logger import init_logger
+from tpu_inference.offload.kv_bridge import (KVBlockSpec, bytes_to_jax_block,
+                                             jax_block_to_bytes)
+
+logger = init_logger(__name__)
+
+CpuChunkId = int
+
+
+class LMCacheHostBackend:
+    """Drop-in for LocalCPUBackend with an LMCache-backed spill tier.
+
+    Interface parity with ``tpu_inference.offload.cpu_backend.LocalCPUBackend``:
+        add(chunk_id, value) -> bool
+        get(chunk_id) -> Optional[value]
+        reclaim_unoccupied_chunks(occupied_chunk_ids)
+        property num_saved_cpu_chunks
+    """
+
+    def __init__(
+        self,
+        num_cpu_chunks: int,
+        lmcache_store: Optional["LMCacheKVStore"] = None,
+        hot_capacity: Optional[int] = None,
+    ):
+        # ``num_cpu_chunks`` is the connector's chunk_id space (upper bound on
+        # valid chunk_ids), matching LocalCPUBackend. ``hot_capacity`` is how
+        # many blocks we keep resident in host RAM; overflow spills to the
+        # LMCache tier. When no LMCache tier is configured they are equal, so
+        # behavior is identical to LocalCPUBackend.
+        self.max_num_cpu_chunks = num_cpu_chunks
+        if hot_capacity is None:
+            hot_capacity = num_cpu_chunks
+        self.hot_capacity = hot_capacity
+        # Hot tier: identical to LocalCPUBackend (LRU OrderedDict of jax arrays).
+        self.cache: "OrderedDict[CpuChunkId, Any]" = OrderedDict()
+        self.current_size_bytes = 0
+        self._num_saved_cpu_chunks = 0
+        # Optional persistent tier (disk/remote) via LMCache.
+        self._store = lmcache_store
+        # chunk_id -> optional content hash hint (Depth 2). Falls back to
+        # chunk_id keying when a hint is not provided.
+        self._hash_hints: dict[CpuChunkId, str] = {}
+        # chunk_id -> KVBlockSpec, so we can reconstruct after a disk hit.
+        self._specs: dict[CpuChunkId, KVBlockSpec] = {}
+        self._lock = threading.Lock()
+        logger.info(
+            "LMCacheHostBackend initialized. chunk_id space=%d, hot capacity=%d "
+            "chunks, lmcache_store=%s", self.max_num_cpu_chunks, self.hot_capacity,
+            type(self._store).__name__ if self._store else None)
+
+    # ---- interface parity helpers -------------------------------------------------
+    @property
+    def num_saved_cpu_chunks(self) -> int:
+        return self._num_saved_cpu_chunks
+
+    def _get_value_size(self, value: Any) -> int:
+        if isinstance(value, list):
+            return sum(v.nbytes for v in value if hasattr(v, "nbytes"))
+        if hasattr(value, "nbytes"):
+            return value.nbytes
+        return sys.getsizeof(value)
+
+    def _store_key(self, chunk_id: CpuChunkId) -> str:
+        """Content-hash key if a hint is set (Depth 2), else chunk_id key."""
+        h = self._hash_hints.get(chunk_id)
+        return f"h:{h}" if h is not None else f"c:{chunk_id}"
+
+    def set_chunk_hash_hint(self, chunk_id: CpuChunkId, chunk_hash: str) -> None:
+        """Depth-2 hook: associate a content hash with a chunk_id so the LMCache
+        key is content-addressed (enables cross-instance / persistent reuse)."""
+        self._hash_hints[chunk_id] = chunk_hash
+
+    # ---- store ---------------------------------------------------------------------
+    def add(self, chunk_id: CpuChunkId, value: Any) -> bool:
+        if chunk_id < 0 or chunk_id >= self.max_num_cpu_chunks:
+            raise ValueError(f"get invalid chunk_id: {chunk_id}")
+        with self._lock:
+            if chunk_id in self.cache:
+                old = self.cache.pop(chunk_id)
+                self.current_size_bytes -= self._get_value_size(old)
+                del old
+                self._num_saved_cpu_chunks -= 1
+
+            self.cache[chunk_id] = value
+            self._num_saved_cpu_chunks += 1
+            self.current_size_bytes += self._get_value_size(value)
+
+            # Persist to LMCache tier (best-effort, never blocks correctness of
+            # the hot tier). Single jax arrays are bridged directly; lists are
+            # stored per-layer under an index suffix.
+            if self._store is not None:
+                try:
+                    self._persist(chunk_id, value)
+                except Exception as e:  # pragma: no cover - defensive
+                    logger.warning("LMCache persist failed for chunk %s: %s",
+                                   chunk_id, e)
+
+            # Evict hot-tier LRU beyond capacity; evicted blocks remain in the
+            # LMCache tier and are transparently reloaded on get().
+            self._evict_hot_if_needed()
+        return True
+
+    def _persist(self, chunk_id: CpuChunkId, value: Any) -> None:
+        key = self._store_key(chunk_id)
+        if isinstance(value, list):
+            specs = []
+            for i, layer in enumerate(value):
+                raw, spec = jax_block_to_bytes(layer)
+                self._store.put(f"{key}#{i}", raw)
+                specs.append(spec)
+            self._specs[chunk_id] = specs  # type: ignore[assignment]
+        else:
+            raw, spec = jax_block_to_bytes(value)
+            self._store.put(key, raw)
+            self._specs[chunk_id] = spec
+
+    def _evict_hot_if_needed(self) -> None:
+        # Keep the hot tier bounded to hot_capacity. Evicted blocks remain in
+        # the LMCache tier and are transparently reloaded on get().
+        while len(self.cache) > self.hot_capacity:
+            evict_id, evict_val = self.cache.popitem(last=False)
+            self.current_size_bytes -= self._get_value_size(evict_val)
+            self._num_saved_cpu_chunks -= 1
+            if self._store is None:
+                # No persistent tier -> this is a real drop (matches capacity).
+                logger.debug("Hot-tier drop chunk %s (no LMCache tier)", evict_id)
+            del evict_val
+
+    # ---- load ----------------------------------------------------------------------
+    def get(self, chunk_id: CpuChunkId) -> Optional[Any]:
+        with self._lock:
+            if chunk_id in self.cache:
+                self.cache.move_to_end(chunk_id)
+                return self.cache[chunk_id]
+            # Hot miss: try the LMCache tier.
+            if self._store is not None and chunk_id in self._specs:
+                try:
+                    val = self._reload(chunk_id)
+                except Exception as e:  # pragma: no cover - defensive
+                    logger.warning("LMCache reload failed for chunk %s: %s",
+                                   chunk_id, e)
+                    return None
+                if val is not None:
+                    # Promote back into the hot tier.
+                    self.cache[chunk_id] = val
+                    self._num_saved_cpu_chunks += 1
+                    self.current_size_bytes += self._get_value_size(val)
+                    self._evict_hot_if_needed()
+                    return val
+            return None
+
+    def _reload(self, chunk_id: CpuChunkId) -> Optional[Any]:
+        key = self._store_key(chunk_id)
+        spec = self._specs.get(chunk_id)
+        if spec is None:
+            return None
+        if isinstance(spec, list):
+            layers = []
+            for i, s in enumerate(spec):
+                raw = self._store.get(f"{key}#{i}")
+                if raw is None:
+                    return None
+                layers.append(bytes_to_jax_block(raw, s))
+            return layers
+        raw = self._store.get(key)
+        if raw is None:
+            return None
+        return bytes_to_jax_block(raw, spec)
+
+    # ---- reclaim -------------------------------------------------------------------
+    def reclaim_unoccupied_chunks(self, occupied_chunk_ids: list) -> None:
+        with self._lock:
+            occupied = set(occupied_chunk_ids)
+            for chunk_id in [c for c in self.cache if c not in occupied]:
+                val = self.cache.pop(chunk_id)
+                self.current_size_bytes -= self._get_value_size(val)
+                self._num_saved_cpu_chunks -= 1
+                del val
+            # Also drop persistent entries for unoccupied chunks (chunk_id keying;
+            # under content-hash keying we keep them for cross-request reuse).
+            if self._store is not None:
+                for chunk_id in [c for c in list(self._specs) if c not in occupied]:
+                    if chunk_id not in self._hash_hints:
+                        self._drop_persistent(chunk_id)
+
+    def _drop_persistent(self, chunk_id: CpuChunkId) -> None:
+        key = self._store_key(chunk_id)
+        spec = self._specs.pop(chunk_id, None)
+        if spec is None:
+            return
+        try:
+            if isinstance(spec, list):
+                for i in range(len(spec)):
+                    self._store.remove(f"{key}#{i}")
+            else:
+                self._store.remove(key)
+        except Exception:  # pragma: no cover - defensive
+            pass

--- a/tpu_inference/offload/lmcache_kv_store.py
+++ b/tpu_inference/offload/lmcache_kv_store.py
@@ -1,0 +1,115 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Raw-bytes KV store protocol for the LMCache-on-TPU host backend.
+
+``LMCacheHostBackend`` needs a simple, engine-agnostic persistence tier:
+``put(key: str, data: bytes)`` / ``get(key) -> bytes | None`` / ``remove(key)``.
+
+We keep this deliberately minimal (raw bytes, string keys) so it can be backed by:
+  * an in-memory dict (reference / tests),
+  * a plain filesystem directory (reference / single-host disk spill),
+  * LMCache's real StorageManager (disk / remote / P2P / cross-instance) via the
+    ``LMCacheStorageKVStore`` adapter in the lmcache fork.
+
+Raw bytes (not torch tensors / MemoryObj) is the correct interface here because
+the TPU KV blocks are JAX arrays; the value bridge already serializes them to a
+flat, dtype-preserving byte buffer. This avoids forcing LMCache's torch-centric
+MemoryObj assumptions onto the JAX path.
+"""
+from __future__ import annotations
+
+import os
+import threading
+from typing import Optional, Protocol, runtime_checkable
+
+
+@runtime_checkable
+class LMCacheKVStore(Protocol):
+    """Minimal raw-bytes persistence contract."""
+
+    def put(self, key: str, data: bytes) -> None: ...
+
+    def get(self, key: str) -> Optional[bytes]: ...
+
+    def remove(self, key: str) -> None: ...
+
+    def contains(self, key: str) -> bool: ...
+
+
+class InMemoryKVStore:
+    """Reference in-memory store (for tests and single-process spill)."""
+
+    def __init__(self) -> None:
+        self._d: dict[str, bytes] = {}
+        self._lock = threading.Lock()
+
+    def put(self, key: str, data: bytes) -> None:
+        with self._lock:
+            self._d[key] = data
+
+    def get(self, key: str) -> Optional[bytes]:
+        with self._lock:
+            return self._d.get(key)
+
+    def remove(self, key: str) -> None:
+        with self._lock:
+            self._d.pop(key, None)
+
+    def contains(self, key: str) -> bool:
+        with self._lock:
+            return key in self._d
+
+
+class FileKVStore:
+    """Reference filesystem store: one file per key. Single-host disk spill.
+
+    A safe, dependency-free stand-in that mirrors what LMCache's LocalDiskBackend
+    does at the byte level, so the connector integration can be validated without
+    a full LMCache install. Production uses LMCacheStorageKVStore instead.
+    """
+
+    def __init__(self, root: str) -> None:
+        self._root = root
+        os.makedirs(self._root, exist_ok=True)
+        self._lock = threading.Lock()
+
+    def _path(self, key: str) -> str:
+        safe = key.replace("/", "-").replace(":", "_").replace("#", "__")
+        return os.path.join(self._root, safe + ".kvb")
+
+    def put(self, key: str, data: bytes) -> None:
+        path = self._path(key)
+        tmp = path + ".tmp"
+        with self._lock:
+            with open(tmp, "wb") as f:
+                f.write(data)
+            os.replace(tmp, path)  # atomic
+
+    def get(self, key: str) -> Optional[bytes]:
+        path = self._path(key)
+        with self._lock:
+            if not os.path.exists(path):
+                return None
+            with open(path, "rb") as f:
+                return f.read()
+
+    def remove(self, key: str) -> None:
+        path = self._path(key)
+        with self._lock:
+            if os.path.exists(path):
+                os.remove(path)
+
+    def contains(self, key: str) -> bool:
+        with self._lock:
+            return os.path.exists(self._path(key))

--- a/tpu_inference/offload/tpu_offload_connector.py
+++ b/tpu_inference/offload/tpu_offload_connector.py
@@ -133,6 +133,7 @@ from vllm.platforms import current_platform
 from tpu_inference import envs
 from tpu_inference.logger import init_logger
 from tpu_inference.offload.cpu_backend import LocalCPUBackend
+from tpu_inference.offload.host_backend_factory import build_host_backend
 from tpu_inference.offload.offload_manager import (LRUCacheManager,
                                                    StagingBufferManager)
 from tpu_inference.offload.utils import (CpuChunkId, ReqId,
@@ -1553,7 +1554,13 @@ class TPUOffloadConnectorWorker:
 
         # cpu cache
         self.num_cpu_chunks = envs.TPU_OFFLOAD_NUM_CPU_CHUNKS
-        self.cpu_backend = LocalCPUBackend(num_cpu_chunks=self.num_cpu_chunks)
+        # Host store: stock in-memory LocalCPUBackend, or (when
+        # TPU_OFFLOAD_LMCACHE=1) an LMCacheHostBackend that adds a persistent
+        # LMCache spill tier behind the same add/get/reclaim interface.
+        self.cpu_backend = build_host_backend(
+            num_cpu_chunks=self.num_cpu_chunks,
+            model_name=self.vllm_config.model_config.model,
+        )
         model_name = self.vllm_config.model_config.model
         logger.debug(
             f"Model name is {model_name}, KV block_size={self.block_size}")


### PR DESCRIPTION
v2 body built (issue link placeholder pending)
* path to use [LMCache](https://github.com/lmcache/lmcache) as a persistent, tiered host-side KV store **behind** the existing `TPUOffloadConnector` — without touching the connector's HBM↔host JAX-array movement, staging, or scheduler-side hashing. Companion PR: LMCache/LMCache#4002 (the raw-bytes storage backend this calls).

When `TPU_OFFLOAD_LMCACHE=0` (default) behavior is **identical to today** (stock `LocalCPUBackend`).

## Motivation

`TPUOffloadConnector`'s host store (`LocalCPUBackend`) is a bounded in-memory dict: once host RAM is full, KV is dropped. Backing it with LMCache adds **disk spill** (KV survives beyond RAM) today, and content-addressed **cross-instance / remote tiers** (Redis/Mooncake/NIXL) as a follow-up. We deliberately do **not** register LMCache as a TPU `KVConnector` (`tpu_platform` allowlists connectors, and LMCache's connectors assume torch tensors in paged CUDA/XPU/HPU memory — TPU KV is JAX arrays in an XLA mesh). Backing the host store reuses the movement `TPUOffloadConnector` already does correctly.

## What's in this PR

- `offload/kv_bridge.py` — bit-exact `jax.Array`(host) ⟷ raw bytes (incl. bfloat16)
- `offload/lmcache_host_backend.py` — `LMCacheHostBackend`, a drop-in for `LocalCPUBackend` (same `add`/`get`/`reclaim`/`num_saved` interface) with a bounded hot CPU tier + LMCache spill tier + a content-hash hook
- `offload/lmcache_kv_store.py` — raw-bytes store protocol + reference `File`/`Memory` stores (so the feature runs with no LMCache install)
- `offload/host_backend_factory.py` — env-gated selection
- `envs.py` — `TPU_OFFLOAD_LMCACHE[_BACKEND/_HOT_CHUNKS/_PATH]`
- one-line swap of the host-store construction in `tpu_offload_connector.py`
- docs + unit tests (`tests/offload/{kv_bridge,lmcache_host_backend}_test.py`), runnable on `jax[cpu]`

## Testing

- Unit (jax[cpu], no TPU): bit-exact roundtrip across float32/float16/bfloat16/int8/int32; `LMCacheHostBackend` parity / disk-spill / list-of-layers / reclaim / content-hash.
- **Real tpu7x 2x2x1:** `examples/offload/offline_inference_kv_cache_verification.py` passes **bit-for-bit** vs baseline with the LMCache tier enabled + forced spill (Qwen2.5-0.5B, TP=2). Default-off path verified to construct the stock `LocalCPUBackend`.
- 4-arm benchmark (0.5B + 7B, real tpu7x): the tier is correct and materializes bit-exact spilled KV; it's net-neutral on dense-reuse workloads (reuse stays HBM-resident) and wins on temporally-sparse reuse — documented honestly.

## Compatibility / risk

Off by default → zero behavior change unless explicitly enabled. No new hard dependency: `file`/`memory` backends need nothing; the `lmcache` backend is imported lazily only when selected.

## Two upstream issues found while benchmarking

1. **`TPUOffloadConnector` context-length instability at long prefill** (tracked separately, not fixed here). On Qwen2.5-7B / tpu7x / current image, a 8192-token-prefill workload with the connector active hit reproducible (3/3) TPU device fatal errors (`E0200 RuntimeUnexpectedCoreHalt` in an HLO `convolution_bitcast_fusion`, then `AsyncDriver::HandleFatalError` firmware fatal) in the D2H save path. The same workload with **no** connector ran cleanly; the connector was **stable at 2048-token prefill**. Filed as a separate issue with logs: https://github.com/vllm-project/tpu-inference/issues/3076
2. **`models/jax/qwen2.py` crash on untied-embedding Qwen2 — FIXED in this PR** (commit `fix(qwen2): don't eagerly eval text_config default...`). The old `getattr(hf_config, 'hidden_size', hf_config.text_config.hidden_size)` eagerly evaluated the default, so plain `Qwen2Config` (7B/14B/32B, `tie_word_embeddings=False`, no `text_config`) raised `AttributeError` at load; Qwen2.5-0.5B escaped it via tied embeddings. Now resolves the language config first (`getattr(hf_config, 'text_config', hf_config)`), matching the idiom `Qwen2Model` already uses. This unblocks loading 7B/14B/32B Qwen2 on TPU.

---
*Developed with assistance from Navi (an AI coding assistant); all code was reviewed and validated bit-for-bit on real tpu7x hardware.*
