### PR TITLE
[Qwen3.5/InferenceX] Benchmark and Optimizations (1/N)

### DIFF
--- a/tests/e2e/benchmarking/inferencex/qwen3.5/bench.sh
+++ b/tests/e2e/benchmarking/inferencex/qwen3.5/bench.sh
@@ -20,7 +20,8 @@ set -euo pipefail
 
 MODEL=Qwen/Qwen3.5-397B-A17B-FP8
 PORT="${PORT:-8000}"
-RANDOM_RANGE_RATIO="${RANDOM_RANGE_RATIO:-0.8}"
+# Fixed ISL/OSL per request, to match InferenceX setup.
+RANDOM_RANGE_RATIO="${RANDOM_RANGE_RATIO:-1.0}"
 if [ -z "${INFERENCEX_REPO:-}" ]; then
   INFERENCEX_REPO=/tmp/InferenceX
   if [ ! -d "$INFERENCEX_REPO/.git" ]; then

--- a/tests/e2e/benchmarking/inferencex/qwen3.5/server.sh
+++ b/tests/e2e/benchmarking/inferencex/qwen3.5/server.sh
@@ -57,6 +57,8 @@ export ONEHOT_MOE_PERMUTE_THRESHOLD=32768
 export VLLM_MOE_CHUNK_SIZE=256
 export RAGGED_GATED_DELTA_RULE_IMPL=chunked_kernel_p_recurrent_kernel_d
 export NEW_MODEL_DESIGN=1
+# Disable DP-scheduler batched prefill, which is for variable isl and osl.
+export DP_SCHED_BATCH_PREFILL=false
 export LIBTPU_INIT_ARGS=' --xla_tpu_use_minor_sharding_for_major_trivial_input=true --xla_tpu_enable_sparse_core_collective_offload_reduce_scatter=false --xla_tpu_ars_combiner_threshold_in_bytes=0 --xla_tpu_enable_async_collective_merger=false'
 
 args=(

--- a/tests/e2e/benchmarking/inferencex/qwen3.5/server.sh
+++ b/tests/e2e/benchmarking/inferencex/qwen3.5/server.sh
@@ -23,6 +23,7 @@ PORT="${PORT:-8000}"
 SHARDING="${SHARDING:-DP8_EP}"
 ISL="${ISL:-8192}"
 OSL="${OSL:-1024}"
+CONC="${CONC:-64}"
 # Headroom over ISL+OSL (matches InferenceX qwen3.5 sglang: ISL+OSL+20). Without it, fixed-length
 # (ratio 1.0) requests hit max_model_len exactly and get 400 Bad Request.
 MAX_MODEL_LEN_BUFFER="${MAX_MODEL_LEN_BUFFER:-20}"

--- a/tests/e2e/benchmarking/inferencex/qwen3.5/server.sh
+++ b/tests/e2e/benchmarking/inferencex/qwen3.5/server.sh
@@ -44,7 +44,8 @@ case "$SHARDING" in
 esac
 
 MAX_MODEL_LEN=$((ISL + OSL + MAX_MODEL_LEN_BUFFER))
-MAX_NUM_BATCHED_TOKENS=$((ISL / DP_SIZE))
+# Floor at 1024 so 1k isl with dp8 doesn't cause the per rank seq len to be too small.
+MAX_NUM_BATCHED_TOKENS=$(( ISL / DP_SIZE > 1024 ? ISL / DP_SIZE : 1024 ))
 
 set -x
 export MODEL_IMPL_TYPE=vllm

--- a/tests/e2e/benchmarking/inferencex/qwen3.5/server.sh
+++ b/tests/e2e/benchmarking/inferencex/qwen3.5/server.sh
@@ -23,6 +23,9 @@ PORT="${PORT:-8000}"
 SHARDING="${SHARDING:-DP8_EP}"
 ISL="${ISL:-8192}"
 OSL="${OSL:-1024}"
+# Headroom over ISL+OSL (matches InferenceX qwen3.5 sglang: ISL+OSL+20). Without it, fixed-length
+# (ratio 1.0) requests hit max_model_len exactly and get 400 Bad Request.
+MAX_MODEL_LEN_BUFFER="${MAX_MODEL_LEN_BUFFER:-20}"
 
 case "$SHARDING" in
   DP8_EP)
@@ -40,7 +43,7 @@ case "$SHARDING" in
   *) echo "ERROR: unknown SHARDING='$SHARDING' (expected DP8_EP|DP4TP2_EP)" >&2; exit 1 ;;
 esac
 
-MAX_MODEL_LEN=$((ISL + OSL))
+MAX_MODEL_LEN=$((ISL + OSL + MAX_MODEL_LEN_BUFFER))
 MAX_NUM_BATCHED_TOKENS=$((ISL / DP_SIZE))
 
 set -x

--- a/tests/e2e/benchmarking/inferencex/qwen3.5/sweep.sh
+++ b/tests/e2e/benchmarking/inferencex/qwen3.5/sweep.sh
@@ -22,14 +22,23 @@ PORT="${PORT:-8000}"
 READY_TIMEOUT="${READY_TIMEOUT:-5400}"   # 90 min (covers a cold compile)
 
 WORKLOADS=("8192:1024" "1024:1024")
-CONC_SHARDING=(
-  "4:DP4TP2_EP"
-  "8:DP4TP2_EP"
-  "16:DP4TP2_EP"
-  "32:DP4TP2_EP"
-  "64:DP8_EP"
-  "128:DP8_EP"
-  "256:DP8_EP"
+CONCS=(4 8 16 32 64 128 256)
+# Sharding per swept point, keyed by "ISL,OSL,CONC" (every point listed).
+declare -A SHARDING_TABLE=(
+  [8192,1024,4]=DP4TP2_EP
+  [8192,1024,8]=DP4TP2_EP
+  [8192,1024,16]=DP4TP2_EP
+  [8192,1024,32]=DP4TP2_EP
+  [8192,1024,64]=DP8_EP
+  [8192,1024,128]=DP8_EP
+  [8192,1024,256]=DP8_EP
+  [1024,1024,4]=DP4TP2_EP
+  [1024,1024,8]=DP4TP2_EP
+  [1024,1024,16]=DP4TP2_EP
+  [1024,1024,32]=DP4TP2_EP
+  [1024,1024,64]=DP4TP2_EP
+  [1024,1024,128]=DP4TP2_EP
+  [1024,1024,256]=DP4TP2_EP
 )
 
 stop_server() {
@@ -62,9 +71,10 @@ trap stop_server EXIT
 
 for wl in "${WORKLOADS[@]}"; do
   export ISL="${wl%%:*}" OSL="${wl#*:}"
-  for cs in "${CONC_SHARDING[@]}"; do
-    export CONC="${cs%%:*}"
-    sharding="${cs#*:}"
+  for CONC in "${CONCS[@]}"; do
+    export CONC
+    sharding="${SHARDING_TABLE[$ISL,$OSL,$CONC]:-}"
+    [ -n "$sharding" ] || { echo "ERROR: no sharding in SHARDING_TABLE for ISL=$ISL OSL=$OSL CONC=$CONC" >&2; exit 1; }
     stop_server
     start_server "$sharding" || exit 1
     echo "########## ISL=$ISL OSL=$OSL CONC=$CONC SHARDING=$sharding ##########"


### PR DESCRIPTION
# Why 
A set of changes to align benchmark methodology and optimize performance for comparing Qwen3.5 TPU performance against published GPU numbers in InferenceX.

# What 
(see details in each individual commit message) 
- **[Qwen3.5/InferenceX] R1: align bench setup with InferenceX (fixed_seq_len methodology)**
- **[Qwen3.5/InferenceX] R2: set max-num-batched-tokens to max(ISL/DP_SIZE, 1024)**
- **[Qwen3.5/InferenceX] R3: drive the sweep from a per-point SHARDING_TABLE**
- **[Qwen3.5/InferenceX] R4: disable DP-scheduler batched prefill**

# Results (before vs after)
  | isl | osl | concurrency | baseline | After | Delta |
  |---:|---:|---:|---:|---:|---:|
  | 8192 | 1024 | 4 | 1702.1 | 2717.4 | +59.6% |
  | 8192 | 1024 | 8 | 2857.9 | 4860.2 | +70.1% |
  | 8192 | 1024 | 16 | 6193.6 | 8348.7 | +34.8% |
  | 8192 | 1024 | 32 | 10323.8 | 12504.3 | +21.1% |
  | 8192 | 1024 | 64 | 15877.0 | 17825.2 | +12.3% |
  | 8192 | 1024 | 128 | 23048.8 | 24904.6 | +8.1% |
  | 8192 | 1024 | 256 | 29131.0 | 32584.8 | +11.9% |
  | 1024 | 1024 | 4 | 450.9 | 666.3 | +47.8% |
  | 1024 | 1024 | 8 | 857.6 | 1213.1 | +41.4% |
  | 1024 | 1024 | 16 | 1645.2 | 2229.0 | +35.5% |
  | 1024 | 1024 | 32 | 2701.0 | 3659.5 | +35.5% |
  | 1024 | 1024 | 64 | 4519.3 | 5988.5 | +32.5% |
  | 1024 | 1024 | 128 | 7194.4 | 9146.1 | +27.1% |
  | 1024 | 1024 | 256 | 10689.1 | 13523.5 | +26.5% |

See individual commit messages for the performance delta and before/after metrics of each specific change.

Baseline is based on
- tpu-inference `53d20239446c6dfe04cc0428d4bda8906886af37` 
- vllm `8ad4a01825ef941e785b2bc305ac7a6b5ca9c530`

