### PR TITLE
[Qwen3.5/InferenceX] Benchmark and Optimizations (2/N) 

### DIFF
--- a/tests/e2e/benchmarking/inferencex/qwen3.5/server.sh
+++ b/tests/e2e/benchmarking/inferencex/qwen3.5/server.sh
@@ -57,6 +57,8 @@ export ONEHOT_MOE_PERMUTE_THRESHOLD=32768
 export VLLM_MOE_CHUNK_SIZE=256
 export RAGGED_GATED_DELTA_RULE_IMPL=chunked_kernel_p_recurrent_kernel_d
 export NEW_MODEL_DESIGN=1
+# Slice rope cache to max_model_len (envs.SLICE_ROPE_CACHE is off by default).
+export SLICE_ROPE_CACHE=1
 # Disable DP-scheduler batched prefill, which is for variable isl and osl.
 export DP_SCHED_BATCH_PREFILL=false
 export LIBTPU_INIT_ARGS=' --xla_tpu_use_minor_sharding_for_major_trivial_input=true --xla_tpu_enable_sparse_core_collective_offload_reduce_scatter=false --xla_tpu_ars_combiner_threshold_in_bytes=0 --xla_tpu_enable_async_collective_merger=false'

--- a/tests/e2e/benchmarking/inferencex/qwen3.5/server.sh
+++ b/tests/e2e/benchmarking/inferencex/qwen3.5/server.sh
@@ -47,12 +47,14 @@ esac
 MAX_MODEL_LEN=$((ISL + OSL + MAX_MODEL_LEN_BUFFER))
 # Floor at 1024 so 1k isl with dp8 doesn't cause the per rank seq len to be too small.
 MAX_NUM_BATCHED_TOKENS=$(( ISL / DP_SIZE > 1024 ? ISL / DP_SIZE : 1024 ))
+MAX_NUM_SEQS=$((CONC * 2 / DP_SIZE))
+[ "$MAX_NUM_SEQS" -lt 1 ] && MAX_NUM_SEQS=1
 
 set -x
 export MODEL_IMPL_TYPE=vllm
 export USE_MOE_EP_KERNEL=0
 export ATTN_BUCKETIZED_NUM_REQS=true
-export ATTN_CUSTOM_NUM_REQS_BUCKETS=8,16,32,64
+export ATTN_CUSTOM_NUM_REQS_BUCKETS=4,8,16,32,64
 export ONEHOT_MOE_PERMUTE_THRESHOLD=32768
 export VLLM_MOE_CHUNK_SIZE=256
 export RAGGED_GATED_DELTA_RULE_IMPL=chunked_kernel_p_recurrent_kernel_d
@@ -67,7 +69,7 @@ args=(
   Qwen/Qwen3.5-397B-A17B-FP8
   --max-model-len="$MAX_MODEL_LEN"
   --max-num-batched-tokens="$MAX_NUM_BATCHED_TOKENS"
-  --max-num-seqs=64
+  --max-num-seqs="$MAX_NUM_SEQS"
   --no-enable-prefix-caching
   --gpu-memory-utilization=0.9
   --tensor-parallel-size=8

--- a/tpu_inference/envs.py
+++ b/tpu_inference/envs.py
@@ -73,6 +73,7 @@ if TYPE_CHECKING:
     PROFILE_SINGLE_DEVICE: bool = False
     LORA_MODULE_PATH: str = ""
     SC_ALLREDUCE_ALLGATHER_OFFLOAD_MIN_BYTES: str = "auto"
+    SLICE_ROPE_CACHE: bool = False
 
 
 def env_with_choices(
@@ -415,6 +416,12 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # use VMEM size as the threshold.
     "SC_ALLREDUCE_ALLGATHER_OFFLOAD_MIN_BYTES":
     lambda: os.getenv("SC_ALLREDUCE_ALLGATHER_OFFLOAD_MIN_BYTES", "auto"),
+    # Slice the rotary cos_sin_cache to max_model_len at load (saves HBM and a
+    # per-step layout copy of the full max_position_embeddings table). Applies
+    # to text / 1-D RoPE only; ignored for MRoPE models, whose (video)
+    # positions can exceed max_model_len.
+    "SLICE_ROPE_CACHE":
+    env_bool("SLICE_ROPE_CACHE", default=False),
     "MLA_TRANSPOSE_KV_CACHE":
     env_bool("MLA_TRANSPOSE_KV_CACHE", default=False),
 }

--- a/tpu_inference/models/vllm/vllm_model_wrapper.py
+++ b/tpu_inference/models/vllm/vllm_model_wrapper.py
@@ -352,6 +352,25 @@ class VllmModelWrapper:
         self.model = _VllmRunner(vllm_model)
         params_and_buffers = shard_model_to_tpu(self.model, self.mesh)
 
+        # Slice rotary cos_sin_cache buffers to max_model_len to save HBM usage
+        # and reduce the per-step overhead of the XLA layout copy. Assumes rope
+        # positions are 1-D and bounded by max_model_len (standard text RoPE);
+        # MRoPE video positions are structural and can exceed max_model_len, so
+        # skip the slice there to avoid an out-of-bounds cos_sin_cache gather.
+        if envs.SLICE_ROPE_CACHE and \
+                not self.vllm_config.model_config.uses_mrope:
+            max_len = self.vllm_config.model_config.max_model_len
+            for key, val in list(params_and_buffers.items()):
+                if key.endswith("rotary_emb.cos_sin_cache"):
+                    arr = jax_view(val)
+                    if arr.shape[0] > max_len:
+                        params_and_buffers[key] = torch_view(arr[:max_len])
+                        logger.info(
+                            "Sliced rope cache %s rows %d -> %d. Assumes "
+                            "positions are 1-D and bounded by max_model_len "
+                            "(%d); MRoPE (video) can exceed it and is excluded",
+                            key, arr.shape[0], max_len, max_len)
+
         self._pooler: Pooler | None = self.model.pooler
 
         if self.vllm_config.model_config.is_multimodal_model:


### PR DESCRIPTION
# Why 
A set of changes to optimize performance for comparing Qwen3.5 TPU against published GPU numbers in InferenceX.

# What 
(see details in each individual commit message) 
- **[Qwen3.5/InferenceX] R6: shrink rotary cos_sin_cache to max_model_len at load**
- **[Qwen3.5/InferenceX] R7: size max-num-seqs per DP rank + add the concurrency 4 attn bucket**

There is an R5 optimization that reduces host overhead—primarily for low concurrency workloads (4 and 8 clients). 
However, the change is somewhat involved and non-trivial to gate behind an environment variable. Since the host is not yet a bottleneck in this PR, deferring the change to a later PR.

# Results (before vs after)
  | isl | osl | concurrency | before | after | Δ |
  |---:|---:|---:|---:|---:|---:|
  | 8192 | 1024 | 4 | 2717.4 | 3079.3 | +13.3% |
  | 8192 | 1024 | 8 | 4860.2 | 5401.2 | +11.1% |
  | 8192 | 1024 | 16 | 8348.7 | 9036.7 | +8.2% |
  | 8192 | 1024 | 32 | 12504.3 | 12983.1 | +3.8% |
  | 8192 | 1024 | 64 | 17825.2 | 18322.8 | +2.8% |
  | 8192 | 1024 | 128 | 24904.6 | 25437.0 | +2.1% |
  | 8192 | 1024 | 256 | 32584.8 | 32643.9 | +0.2% |
  | 1024 | 1024 | 4 | 666.3 | 769.9 | +15.5% |
  | 1024 | 1024 | 8 | 1213.1 | 1388.7 | +14.5% |
  | 1024 | 1024 | 16 | 2229.0 | 2424.2 | +8.8% |
  | 1024 | 1024 | 32 | 3659.5 | 3881.5 | +6.1% |
  | 1024 | 1024 | 64 | 5988.5 | 5959.5 | -0.5% |
  | 1024 | 1024 | 128 | 9146.1 | 9283.0 | +1.5% |
  | 1024 | 1024 | 256 | 13523.5 | 13186.0 | -2.5% |

See individual commit messages for the performance delta and before/after metrics of each specific change.

Baseline is based on
- tpu-inference `53d20239446c6dfe04cc0428d4bda8906886af37` 
- vllm `8ad4a01825ef941e785b2bc305ac7a6b5ca9c530`

