### PR TITLE
Split test dependencies from runtime requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,5 @@
 tpu-info==0.7.1
 yapf==0.43.0
-pytest
-pytest-mock
 absl-py
 numpy
 google-cloud-storage
@@ -9,7 +7,7 @@ jax==0.10.2
 jaxlib==0.10.2
 libtpu==0.0.42.1
 jaxtyping
-# Temporarily restrict fastapi version due to https://github.com/vllm-project/vllm/pull/45629
+# Temporarily restrict fastapi version due https://github.com/vllm-project/vllm/pull/45629
 # TODO(lk-chen): remove once LKG moves past above commit
 fastapi[standard]<0.137.0
 flax==0.12.4
@@ -17,11 +15,8 @@ torchax==0.0.13
 qwix==0.1.2
 torchvision==0.25.0
 pathwaysutils
-parameterized
 numba==0.62.1
 runai-model-streamer[s3,gcs]==0.15.9
 gcsfs==2026.1.0
-hypothesis==6.151.9
-sortedcontainers==2.4.0
-# Upstream pins to 5.5.3 https://github.com/vllm-project/vllm/blob/de3fe8dc62f3d77eb8dab8125ca90436f606bccb/requirements/test/nightly-torch.txt#L32
+# Upstream pins 5.5.3 https://github.com/vllm-project/vllm/blob/de3fe8dc62f3d77eb8dab8125ca90436f606bccb/requirements/test/nightly-torch.txt#L32
 transformers>=5.8.0

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,2 +1,7 @@
 buildkite-test-collector
 hf_transfer
+pytest
+pytest-mock
+parameterized
+hypothesis==6.151.9
+sortedcontainers==2.4.0


### PR DESCRIPTION
Addresses #1483 by moving test-only packages out of requirements.txt and into requirements_test.txt.

Validation:
- git diff --check
- verified pytest-related packages are no longer in requirements.txt
- verified pytest-related packages are present in requirements_test.txt