### PR TITLE
Fix allowed-token mask cleanup on request removal

### DIFF
--- a/tests/runner/test_input_batch.py
+++ b/tests/runner/test_input_batch.py
@@ -623,3 +623,22 @@ def test_dp_mamba_global_to_local_conversion():
     assert (7 * local_slots + 1) % local_slots == 1
     # Boundary: rank 1 last slot = 595 → local 297
     assert 595 % local_slots == 297
+def test_remove_request_with_allowed_token_ids_clears_mask(
+    input_batch: InputBatch,
+):
+    """Removing a request with allowed tokens should not crash."""
+    req = create_dummy_request(
+        "req-1",
+        sampling_params=SamplingParams(allowed_token_ids=[1, 2, 3]),
+    )
+    input_batch.add_request(req)
+
+    assert input_batch.allowed_token_ids_mask_cpu is not None
+    assert not input_batch.allowed_token_ids_mask_cpu[0][1]
+    assert not input_batch.allowed_token_ids_mask_cpu[0][2]
+    assert not input_batch.allowed_token_ids_mask_cpu[0][3]
+
+    removed_index = input_batch.remove_request("req-1")
+
+    assert removed_index == 0
+    assert not input_batch.allowed_token_ids_mask_cpu[0].any()

--- a/tpu_inference/runner/input_batch.py
+++ b/tpu_inference/runner/input_batch.py
@@ -414,11 +414,15 @@ class InputBatch:
                 if self.allowed_token_ids_mask_cpu is None:
                     # Lazy allocation for this tensor, which can be large.
                     # False means we don't fill with -inf.
-                    self.allowed_token_ids_mask = jnp.zeros(self.max_num_reqs,
-                                                            self.vocab_size,
-                                                            dtype=jnp.bool)
+                    shape = (self.max_num_reqs, self.vocab_size)
+                    self.allowed_token_ids_mask = jnp.zeros(
+                        shape,
+                        dtype=jnp.bool_,
+                    )
                     self.allowed_token_ids_mask_cpu = np.zeros(
-                        self.max_num_reqs, self.vocab_size, dtype=np.bool)
+                        shape,
+                        dtype=np.bool_,
+                    )
                 self.allowed_token_ids_mask_cpu[req_index] = True
                 # False means we don't fill with -inf.
                 self.allowed_token_ids_mask_cpu[req_index][
@@ -505,7 +509,7 @@ class InputBatch:
         self.has_allowed_token_ids.discard(req_id)
         if self.allowed_token_ids_mask_cpu is not None:
             # False means we don't fill with -inf.
-            self.allowed_token_ids_mask_cpu[req_index].fill_(False)
+            self.allowed_token_ids_mask_cpu[req_index].fill(False)
         self.bad_words_token_ids.pop(req_index, None)
         return req_index
 


### PR DESCRIPTION
Closes #3083.

Fix request cleanup for `allowed_token_ids`:
- reset the NumPy mask row with `fill(False)` instead of `fill_`
- use valid `(rows, cols)` shape tuples for mask allocation
- switch deprecated `np.bool` / `jnp.bool` usage to the non-deprecated boolean dtypes

Verification:
- `python3 -m py_compile tpu_inference/runner/input_batch.py tests/runner/test_input_batch.py`
- stubbed runtime check that adds a request with `allowed_token_ids`, then removes it and confirms the mask row is cleared
