### PR TITLE
[Qwen3.5/InferenceX] Fix random_range_ratio in the benchmark script

### DIFF
--- a/tests/e2e/benchmarking/inferencex/qwen3.5/bench.sh
+++ b/tests/e2e/benchmarking/inferencex/qwen3.5/bench.sh
@@ -20,8 +20,8 @@ set -euo pipefail
 
 MODEL=Qwen/Qwen3.5-397B-A17B-FP8
 PORT="${PORT:-8000}"
-# Fixed ISL/OSL per request, to match InferenceX setup.
-RANDOM_RANGE_RATIO="${RANDOM_RANGE_RATIO:-1.0}"
+# Matching InferenceX's Qwen3.5 benchmarks.
+RANDOM_RANGE_RATIO="${RANDOM_RANGE_RATIO:-0.8}"
 if [ -z "${INFERENCEX_REPO:-}" ]; then
   INFERENCEX_REPO=/tmp/InferenceX
   if [ ! -d "$INFERENCEX_REPO/.git" ]; then

--- a/tests/e2e/benchmarking/inferencex/qwen3.5/server.sh
+++ b/tests/e2e/benchmarking/inferencex/qwen3.5/server.sh
@@ -61,8 +61,8 @@ export RAGGED_GATED_DELTA_RULE_IMPL=chunked_kernel_p_recurrent_kernel_d
 export NEW_MODEL_DESIGN=1
 # Slice rope cache to max_model_len (envs.SLICE_ROPE_CACHE is off by default).
 export SLICE_ROPE_CACHE=1
-# Disable DP-scheduler batched prefill, which is for variable isl and osl.
-export DP_SCHED_BATCH_PREFILL=false
+# Enable DP-scheduler batched prefill, better performance for random range ratio.
+export DP_SCHED_BATCH_PREFILL=true
 export LIBTPU_INIT_ARGS=' --xla_tpu_use_minor_sharding_for_major_trivial_input=true --xla_tpu_enable_sparse_core_collective_offload_reduce_scatter=false --xla_tpu_ars_combiner_threshold_in_bytes=0 --xla_tpu_enable_async_collective_merger=false'
 
 args=(


### PR DESCRIPTION

InferenceX for Qwen3.5 defaults to random range ratio of 0.8. Fix the script. Also enabled DP_SCHED_BATCH_PREFILL which is needed to handle imbalance across ranks due to the randomness.
