### PR TITLE
Trying fix for scheduling expectation error when kv offloading

### DIFF
--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -1201,6 +1201,10 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         self.persistent_batch_manager.update_states(
             scheduler_output, self.get_mrope_input_positions_fn)
         if not scheduler_output.total_num_scheduled_tokens:
+            if self.scheduler_config.async_scheduling and self._pre_async_results is not None:
+                self._modify_prev_results()
+                self._pre_async_results = None
+
             if has_kv_transfer_group():
                 return self.kv_connector_no_forward(scheduler_output,
                                                     self.vllm_config)


### PR DESCRIPTION
# Description

**Clear stale async scheduling state in TPU worker on empty steps**

Ensures `_pre_async_results` is processed and cleared when `total_num_scheduled_tokens == 0` in `_execute_model`. This prevents stale placeholder mappings from leaking into subsequent steps and causing `AssertionError` when preempted requests are resumed for KV cache recomputation.

# Tests

Tried Qwen3-32B with KV offloading enabled and with benchmark which puts significant memory pressure, and do not get the assertion error anymore.

```bash
MODEL_IMPL_TYPE=flax_nnx vllm serve Qwen/Qwen3-32B \
    --tensor-parallel-size 4 \
    --max-model-len 21000 \
    --max-num-seqs 256 \
    --max-num-batched-tokens 4096 \
    --block-size 64 \
    --enable-chunked-prefill \
    --enable-prefix-caching \
    --gpu-memory-utilization 0.85 \
    --async-scheduling \
    --dtype bfloat16 \
    --kv-cache-dtype fp8 \
    --port 8000 \
    --kv-transfer-config '{"kv_connector":"TPUOffloadConnector","kv_role":"kv_both","kv_connector_module_path":"tpu_inference.offload.tpu_offload_connector"}'
````

```bash
vllm bench serve \
    --backend openai \
    --endpoint /v1/completions \
    --model Qwen/Qwen3-32B \
    --port 8000 \
    --dataset-name prefix_repetition \
    --ignore-eos \
    --prefix-repetition-num-prefixes 40 \
    --prefix-repetition-prefix-len 8192 \
    --prefix-repetition-suffix-len 1024 \
    --prefix-repetition-output-len 1024 \
    --request-rate inf \
    --max-concurrency 64 \
    --num-prompts 200
```

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
