### PR TITLE
Include vLLM commit in CI image tag + verify image vLLM (fix LKG mis-promotion)

### DIFF
--- a/.buildkite/scripts/setup_docker_env.sh
+++ b/.buildkite/scripts/setup_docker_env.sh
@@ -78,6 +78,34 @@ cleanup_docker_resource() {
   echo "Cleanup complete."
 }
 
+# Verify a built or pulled image actually contains the expected vLLM commit.
+# Guards against tag/image mismatches -- e.g. when the CI (LKG vLLM) and
+# integration (HEAD vLLM) pipelines build the same tpu-inference commit
+# concurrently, they previously shared a vLLM-agnostic tag and could clobber
+# each other's image in the registry. No-op when the expected hash is empty
+# (local/dev builds that clone vLLM HEAD) or for PyPI builds (no
+# /workspace/vllm git checkout to inspect).
+verify_image_vllm() {
+  local image_ref="$1"
+  local expected_vllm="${2:-}"
+  if [[ -z "${expected_vllm}" ]]; then
+    return 0
+  fi
+  if [[ "${RUN_WITH_PYPI:-false}" == "true" ]]; then
+    echo "[verify-vllm] RUN_WITH_PYPI=true; skipping vLLM commit verification."
+    return 0
+  fi
+  local actual_vllm
+  actual_vllm=$(docker run --rm --entrypoint git "${image_ref}" \
+    -C /workspace/vllm rev-parse HEAD 2>/dev/null || echo "unknown")
+  if [[ "${actual_vllm}" != "${expected_vllm}" ]]; then
+    echo "[FATAL][verify-vllm] Image ${image_ref} contains vLLM ${actual_vllm}, but expected ${expected_vllm}."
+    echo "[FATAL][verify-vllm] Aborting to avoid testing or promoting the wrong vLLM."
+    exit 1
+  fi
+  echo "[verify-vllm] OK: ${image_ref} contains expected vLLM ${expected_vllm}."
+}
+
 setup_environment() {
   local image_name_param=${1:-"vllm-tpu"}
   local should_push=${2:-"false"}
@@ -135,7 +163,15 @@ setup_environment() {
       TPU_INFERENCE_HASH="$BUILDKITE_COMMIT"
   fi
  
+  # Include the vLLM commit in the cache tag so an image is uniquely identified
+  # by BOTH its tpu-inference commit and its vLLM commit. Without this, the CI
+  # pipeline (LKG vLLM) and the integration pipeline (HEAD vLLM) produce the same
+  # tag for the same tpu-inference commit and can overwrite each other's image in
+  # the registry -- a test could then silently run a different vLLM than intended.
   local CACHE_TAG="${TPU_INFERENCE_HASH}-${LOCAL_TPU_VERSION}"
+  if [[ -n "${VLLM_COMMIT_HASH}" ]]; then
+    CACHE_TAG="${TPU_INFERENCE_HASH}-${VLLM_COMMIT_HASH}-${LOCAL_TPU_VERSION}"
+  fi
 
   # ==========================================
   # Pull-Only Mode for TPU execution nodes
@@ -143,6 +179,7 @@ setup_environment() {
   if [[ "${USE_PREBUILT_IMAGE:-0}" == "1" ]]; then
     echo "Pulling pre-built Docker image: ${CI_IMAGE_REPO}:${CACHE_TAG} ..."
     docker pull "${CI_IMAGE_REPO}:${CACHE_TAG}"
+    verify_image_vllm "${CI_IMAGE_REPO}:${CACHE_TAG}" "${VLLM_COMMIT_HASH}"
     docker tag "${CI_IMAGE_REPO}:${CACHE_TAG}" "${IMAGE_NAME}:${TPU_INFERENCE_HASH}"
     docker tag "${CI_IMAGE_REPO}:${CACHE_TAG}" "${IMAGE_NAME}:latest"
     return 0
@@ -157,6 +194,10 @@ setup_environment() {
       -t "${IMAGE_NAME}:${TPU_INFERENCE_HASH}" \
       -t "${IMAGE_NAME}:latest" \
       -t "${IMAGE_NAME}:${CACHE_TAG}" .
+
+  # Fail fast if the freshly built image does not contain the expected vLLM
+  # commit (guards against a mis-set VLLM_COMMIT_HASH build-arg).
+  verify_image_vllm "${IMAGE_NAME}:${CACHE_TAG}" "${VLLM_COMMIT_HASH}"
 
   # ==========================================
   # Push to CI Image Registry (Executed by dedicate CPU builder)

--- a/.buildkite/scripts/setup_docker_env.sh
+++ b/.buildkite/scripts/setup_docker_env.sh
@@ -95,9 +95,22 @@ verify_image_vllm() {
     echo "[verify-vllm] RUN_WITH_PYPI=true; skipping vLLM commit verification."
     return 0
   fi
-  local actual_vllm
+  # Read the vLLM commit baked into the image. Capture the exit code separately
+  # so an infra failure to *read* the commit (git missing, /workspace/vllm
+  # absent, safe.directory "dubious ownership", etc.) is reported as such
+  # instead of masquerading as a vLLM mismatch. -c safe.directory pre-empts the
+  # most common trip: the container running git as a non-owner user.
+  local actual_vllm rc=0 err
+  err=$(mktemp)
   actual_vllm=$(docker run --rm --entrypoint git "${image_ref}" \
-    -C /workspace/vllm rev-parse HEAD 2>/dev/null || echo "unknown")
+    -C /workspace/vllm -c safe.directory=/workspace/vllm rev-parse HEAD 2>"${err}") || rc=$?
+  if [[ ${rc} -ne 0 ]]; then
+    echo "[FATAL][verify-vllm] Could not read the vLLM commit from ${image_ref} (git exit ${rc}):" >&2
+    cat "${err}" >&2
+    rm -f "${err}"
+    exit 1
+  fi
+  rm -f "${err}"
   if [[ "${actual_vllm}" != "${expected_vllm}" ]]; then
     echo "[FATAL][verify-vllm] Image ${image_ref} contains vLLM ${actual_vllm}, but expected ${expected_vllm}."
     echo "[FATAL][verify-vllm] Aborting to avoid testing or promoting the wrong vLLM."
@@ -171,6 +184,16 @@ setup_environment() {
   local CACHE_TAG="${TPU_INFERENCE_HASH}-${LOCAL_TPU_VERSION}"
   if [[ -n "${VLLM_COMMIT_HASH}" ]]; then
     CACHE_TAG="${TPU_INFERENCE_HASH}-${VLLM_COMMIT_HASH}-${LOCAL_TPU_VERSION}"
+  elif [[ -n "${BUILDKITE:-}" && "${RUN_WITH_PYPI:-false}" != "true" ]]; then
+    # In a real pipeline an empty VLLM_COMMIT_HASH is a bug (bootstrap didn't set
+    # the metadata, or the Dockerfile will clone vLLM HEAD non-deterministically).
+    # Falling back to the vLLM-agnostic tag here would silently re-introduce the
+    # cross-pipeline clobber this change eliminates, so fail loudly instead.
+    echo "[FATAL][setup_docker_env] VLLM_COMMIT_HASH is empty in a Buildkite build." >&2
+    echo "[FATAL][setup_docker_env] Refusing the vLLM-agnostic tag '${CACHE_TAG}' (can collide" >&2
+    echo "[FATAL][setup_docker_env] across CI/integration). Ensure bootstrap set the" >&2
+    echo "[FATAL][setup_docker_env] VLLM_COMMIT_HASH metadata (LKG or HEAD)." >&2
+    exit 1
   fi
 
   # ==========================================


### PR DESCRIPTION
## Problem
The CI cache image is tagged `vllm-tpu:<tpu_inference_sha>-<tpu_version>` (`setup_docker_env.sh`), which **omits the vLLM commit**. Two pipelines push that same tag:
- `tpu-inference-ci` builds with the **pinned LKG** vLLM (`.buildkite/vllm_lkg.version`)
- `tpu-vllm-integration` builds with **vLLM HEAD**

When both run on the same tpu-inference commit at the same time, they build the **same tag** and overwrite each other's image. A test then pulls whichever image landed last — potentially a different vLLM than intended.

## This actually happened (with timestamps)
On 2026-07-06, both fired on tpu-inference commit `27688e35` at `10:00:04`:

| time (UTC) | pipeline | action | vLLM |
|---|---|---|---|
| 10:08:30 | integration #1794 build | push `vllm-tpu:27688e35-tpu7x` | `ba221520` (HEAD) |
| 10:09:39 | CI #21628 build | **push (overwrite)** same tag | `fa4321de` (LKG) |
| ≥10:10:12 | integration #1794 test | **pull** same tag → got | `fa4321de` |

So integration validated `fa4321de` but its promote step wrote **`ba221520`** to LKG — shipping a vLLM its tests never ran. That vLLM (`ba221520`, via vllm-project/vllm#47070) then turned `main` red with `assert num_tokens is not None` during backbone compile. Confirmed by pulling the current tag: `vllm-tpu:27688e35…-tpu7x` today contains yet a *third* vLLM (`40cc2e83`), proving the tag is mutable and does not pin the vLLM.

## Fix
1. **Include `VLLM_COMMIT_HASH` in the cache tag** → `vllm-tpu:<tpu_inference_sha>-<vllm_sha>-<tpu_version>`. CI-LKG and integration-HEAD images no longer share a tag, so they can't clobber each other. (Falls back to the old format when the hash is empty, e.g. local/dev builds.)
2. **`verify_image_vllm()`** — after pulling and after building, assert the image's actual `/workspace/vllm` HEAD equals the expected `VLLM_COMMIT_HASH`; abort on mismatch. No-op for empty hash (local/dev) or PyPI builds.

Precedent: `nightly_releases.yml` already includes `$VLLM_SHORT_COMMIT` in its image tag.

## Notes / follow-ups (out of scope here)
- The affected integration tests are `soft_fail: true`, so the promote gate (`wait: ~`) treats a red test as a pass. Even with correct images, a genuinely-failing integration test can still promote. Recommend a separate change to make the promote gate respect real test results (or drop `soft_fail` on the gating jobs).
- A promote-time image check could be added to `integration_promote.yml` for defense in depth; with fix #1 the promoted vLLM now equals the tested vLLM by construction.

## Testing
- `shellcheck` + `bash -n` clean; all pre-commit hooks pass.
- The tag change is self-contained: every build/pull path goes through `setup_environment`, which computes `CACHE_TAG` once, so build and pull stay consistent.