### PR TITLE
Fix & Optimize GCS JAX Compilation Cache Syncing in CI

### DIFF
--- a/.buildkite/scripts/run_in_docker.sh
+++ b/.buildkite/scripts/run_in_docker.sh
@@ -138,7 +138,14 @@ fi
 echo "[INFO] Pulling JAX Cache from GCS to local directory..."
 # Parallel CI builds‘ pushes are safe because JAX's compilation cache 
 # entries are content-addressed. Concurrent pushes are thus idempotent;
-gcloud storage rsync --recursive --delete-unmatched-destination-objects "$FINAL_CACHE_PATH" "$LOCAL_JAX_CACHE_DIR" --no-user-output-enabled || echo "[WARN] Failed to pull JAX Cache from GCS. Proceeding with cold start."
+gcloud storage rsync \
+  --recursive \
+  --no-clobber \
+  --delete-unmatched-destination-objects \
+  --exclude=".*_.gstmp$" \
+  --no-user-output-enabled \
+  "$FINAL_CACHE_PATH" "$LOCAL_JAX_CACHE_DIR" || \
+  echo "[WARN] Failed to pull JAX Cache from GCS. Proceeding with cold start."
 
 # ==========================================
 # 2. Run Docker Container
@@ -202,7 +209,13 @@ echo "[INFO] Docker finished with exit code ${DOCKER_EXIT_CODE}."
 
 if [ $DOCKER_EXIT_CODE -eq 0 ]; then
   echo "[INFO] Syncing local JAX Cache back to GCS..."
-  gcloud storage rsync --recursive "$LOCAL_JAX_CACHE_DIR" "$FINAL_CACHE_PATH" --no-user-output-enabled || echo "[WARN] Failed to sync JAX Cache back to GCS."
+  gcloud storage rsync \
+    --recursive \
+    --no-clobber \
+    --exclude=".*_.gstmp$" \
+    --no-user-output-enabled \
+    "$LOCAL_JAX_CACHE_DIR" "$FINAL_CACHE_PATH" || \
+    echo "[WARN] Failed to sync JAX Cache back to GCS."
 else
   echo "[WARN] Docker exited with non-zero code ${DOCKER_EXIT_CODE}. Skipping syncing local JAX Cache back to GCS to avoid potential cache corruption."
 fi


### PR DESCRIPTION
Previously, CI builds experienced occasional [Errno 2] file-not-found errors and thread contention during gcloud storage rsync:

1. Temporary File Collisions: When a CI build timed out or was interrupted mid-download, orphaned temporary download files (ending in _.gstmp) remained on local persistent disks and were subsequently uploaded to GCS. 
2. During future CI runs, gcloud storage rsync attempted to download these garbage .gstmp objects in parallel, triggering multi-threaded filename collisions during atomic file renaming (os.replace).
Redundant Metadata Checks: Because JAX compilation cache entries are immutable, content-addressed SHA hashes, performing generation and timestamp comparisons on existing files added unnecessary overhead.


## Fixes:
1. Add --no-clobber (-n): Added to both pull and push rsync commands. Since JAX cache artifacts are immutable, existing files are instantly skipped without performing timestamp or generation diffs, boosting transfer performance and making concurrent pushes completely idempotent.
2. Add --exclude=".*_.gstmp$": Added regex exclusion to prevent temporary download files (_.gstmp) from ever being synced to or from GCS. This permanently eliminates [Errno 2] thread collisions in gcloud storage's parallel worker pool and stops temporary file leaks into GCS.




Signed-off-by: Ming Huang <mhhua@google.com>

# Description

Start with a short description of what the PR does and how this is a change from
the past.

The rest of the description includes relevant details and context, examples:
- why is this change being made,
- the problem being solved and any relevant context,
- why this is a good solution,
- some information about the specific implementation,
- shortcomings of the solution and possible future improvements.

If the change fixes a Github issue, please include a link, e.g.,:
FIXES: #123456

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
