### PR TITLE
Thread the attention soft cap through the vLLM attention wrappers

### DIFF
--- a/tpu_inference/layers/common/attention_interface.py
+++ b/tpu_inference/layers/common/attention_interface.py
@@ -387,6 +387,7 @@ def sharded_ragged_paged_attention(
     v_scale: float | None = None,
     update_kv_cache: bool = True,
     use_causal_mask: bool = True,
+    attn_logits_soft_cap: float | None = None,
 ):
     """Shards along KV heads."""
     # Handle GQA/MQA where num_kv_heads < tp_size
@@ -444,6 +445,7 @@ def sharded_ragged_paged_attention(
         kwargs = dict(
             sm_scale=sm_scale,
             sliding_window=attention_chunk_size,
+            soft_cap=attn_logits_soft_cap,
             q_scale=q_scale,
             k_scale=k_scale,
             v_scale=v_scale,
@@ -482,6 +484,7 @@ def attention(
     update_kv_cache: bool = True,
     use_causal_mask: bool = True,
     shared_attention_metadata: SharedAttentionMetadata | None = None,
+    attn_logits_soft_cap: float | None = None,
 ) -> Tuple[jax.Array, jax.Array]:
     # T: seq_len
     # N: num_heads
@@ -555,6 +558,7 @@ def attention(
         v_scale=v_scale,
         update_kv_cache=update_kv_cache,
         use_causal_mask=use_causal_mask,
+        attn_logits_soft_cap=attn_logits_soft_cap,
     )
 
     return kv_cache, output

--- a/tpu_inference/layers/vllm/backends/flash_attn.py
+++ b/tpu_inference/layers/vllm/backends/flash_attn.py
@@ -333,6 +333,7 @@ def _format_attention_output(
         "k_scale",
         "v_scale",
         "sliding_window",
+        "soft_cap",
     ),
     donate_argnames=("kv_cache"),
 )
@@ -353,6 +354,7 @@ def _jax_attn_func(
     k_scale: float | None = None,
     v_scale: float | None = None,
     sliding_window: int | None = None,
+    soft_cap: float | None = None,
 ) -> Tuple[jax.Array, jax.Array]:
     q_len = q.shape[0]
     q, k, v = _prepare_qkv_layout(q, k, v, num_heads, num_kv_heads, head_size)
@@ -370,6 +372,7 @@ def _jax_attn_func(
         v_scale=v_scale,
         sinks=sinks,
         attention_chunk_size=sliding_window,
+        attn_logits_soft_cap=soft_cap,
         shared_attention_metadata=shared_attention_metadata,
     )
 


### PR DESCRIPTION
# Description

Threads the RPA kernel's attention-logit soft cap through the wrapper layers, which is what serving Gemma 2 needs.

The kernel already implements `soft_cap`, but `_jax_attn_func` and `attention` did not expose it. This adds an optional `soft_cap` parameter (default `None`) passed `_jax_attn_func` -> `attention` -> `sharded_ragged_paged_attention` -> kernel, and adds it to `_jax_attn_func`'s jit `static_argnames` alongside `sliding_window`. Two files, seven lines, no behaviour change when it is `None`.

This PR previously also registered KerasHub's serving pieces from `layers/vllm/__init__.py`. Per review, that moved to keras-hub, which now registers itself through a `vllm.general_plugins` entry point: keras-team/keras-hub#2930. `layers/vllm/__init__.py` is back to matching main, and this repo no longer imports keras_hub.

KerasHub serving itself lives entirely in keras-hub (keras-team/keras-hub#2794, merged): the serving model class, the serving context, the paged-attention bridge, the per-model attention routes, and the vLLM tokenizer. 

# Tests

Ran on TPU v6e across every routed family: `gpt2_base_en`, `gpt2_large_en`, `llama3.2_instruct_1b`, `gemma_2b_en`, `gemma2_2b_en` (exercises this soft-cap plumbing and sliding windows), `gemma3_instruct_1b`, and `qwen2.5_coder_0.5b`. All produce coherent output, and in float32 the served tokens are identical to KerasHub's own `generate()` on every prompt.

Existing models are unaffected: `soft_cap` defaults to `None`, which is the current behaviour.

# Checklist

Before submitting this PR, please make sure:
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have made or will make corresponding changes to any relevant documentation.
