### PR TITLE
Restore per-matrix clipping in MoE weight requantization

### DIFF
--- a/tpu_inference/layers/common/process_weights/moe_weights.py
+++ b/tpu_inference/layers/common/process_weights/moe_weights.py
@@ -913,18 +913,23 @@ def _requant_expert_batch_fn(
     w2_pad_widths = ((0, 0), (0, hidden_pad), (0, inter_pad))
     w2_fp32 = jnp.pad(w2_fp32, w2_pad_widths)
 
-    clip_pct = envs.MOE_REQUANTIZE_CLIP_PERCENTILE
+    if envs.MOE_REQUANTIZE_CLIP_PERCENTILE is not None:
+        percentile_val = envs.MOE_REQUANTIZE_CLIP_PERCENTILE
 
-    w13_q_b, w13_s_new_b = quantize_tensor(desired_quant_dtype,
-                                           w13_fp32,
-                                           2,
-                                           w13_block_size,
-                                           clip_percentile=clip_pct)
-    w2_q_b, w2_s_new_b = quantize_tensor(desired_quant_dtype,
-                                         w2_fp32,
-                                         2,
-                                         w2_block_size,
-                                         clip_percentile=clip_pct)
+        for arr_name in ('w13', 'w2'):
+            arr = w13_fp32 if arr_name == 'w13' else w2_fp32
+
+            clip_val = jnp.percentile(jnp.abs(arr), percentile_val)
+
+            if arr_name == 'w13':
+                w13_fp32 = jnp.clip(w13_fp32, -clip_val, clip_val)
+            else:
+                w2_fp32 = jnp.clip(w2_fp32, -clip_val, clip_val)
+
+    w13_q_b, w13_s_new_b = quantize_tensor(desired_quant_dtype, w13_fp32, 2,
+                                           w13_block_size)
+    w2_q_b, w2_s_new_b = quantize_tensor(desired_quant_dtype, w2_fp32, 2,
+                                         w2_block_size)
     return carry, (w13_q_b, w13_s_new_b, w2_q_b, w2_s_new_b)
 
 

--- a/tpu_inference/layers/common/quantization/__init__.py
+++ b/tpu_inference/layers/common/quantization/__init__.py
@@ -196,7 +196,6 @@ def quantize_tensor(
     tensor: jax.Array,
     axis: int | tuple | None = -1,
     block_size: int | None = None,
-    clip_percentile: float | None = None,
 ) -> tuple[jax.Array, jax.Array]:
     """Quantize tensor.
 
@@ -205,7 +204,6 @@ def quantize_tensor(
         tensor: Unquantized tensor
         axis: Axis to perform quantization. None denotes per-tensor.
         block_size: Specify block quantization size.
-        clip_percentile: If set, clip outliers per block before computing scale.
 
     Returns:
         Tensor quantized to dtype.
@@ -243,13 +241,6 @@ def quantize_tensor(
         # Flatten list of lists that contains (num_blocks, block).
         blocked_shape = list(itertools.chain(*blocked_shape))
         tensor = tensor.reshape(blocked_shape)
-
-    if clip_percentile is not None and block_size is not None:
-        clip_vals = jnp.percentile(jnp.abs(tensor),
-                                   clip_percentile,
-                                   axis=tuple(axis),
-                                   keepdims=True)
-        tensor = jnp.clip(tensor, -clip_vals, clip_vals)
 
     if jnp.issubdtype(dtype, jnp.integer):
         dtype_info = jnp.iinfo(dtype)


### PR DESCRIPTION
Restores per-matrix outlier clipping in MoE weight requantization, reverting the per-block clipping change (#2961).

When `MOE_REQUANTIZE_CLIP_PERCENTILE` is set, outliers are clipped over the full expert `w13`/`w2` tensor (one clip threshold per matrix) before computing the quantization scale, instead of per quantization block.

Changes:
- `moe_weights.py`: clip `w13`/`w2` per matrix (`jnp.percentile(|W|, pct)` over the whole tensor, then `jnp.clip`) prior to `quantize_tensor`.
- `quantization/__init__.py`: remove the now-unused `clip_percentile` parameter from `quantize_tensor`.
- `MOE_REQUANTIZE_CLIP_PERCENTILE` env knob is retained (unchanged).

No API change beyond dropping the internal `clip_percentile` kwarg (used only by the MoE requant path).
