### PR TITLE
Address issues for running MMLU benchmark against Kimi 2.6

### DIFF
--- a/scripts/vllm/benchmarking/benchmark_dataset.py
+++ b/scripts/vllm/benchmarking/benchmark_dataset.py
@@ -297,7 +297,11 @@ class MMLUDataset(BenchmarkDataset):
 
                 try:
                     prompt = tokenizer.apply_chat_template(
-                        messages, tokenize=False, add_generation_prompt=True)
+                        messages,
+                        tokenize=False,
+                        add_generation_prompt=True,
+                        **kwargs.get("chat_template_kwargs",
+                                     {}))  # consider turning on thinking=False
                 except Exception as e:
                     logger.error(f"Could not apply chat template: {e}. "
                                  "Falling back to raw prompt. "
@@ -516,7 +520,10 @@ Express your final answer as the corresponding option 'A', 'B', 'C', or 'D'."""
 
                 try:
                     prompt = tokenizer.apply_chat_template(
-                        messages, tokenize=False, add_generation_prompt=True)
+                        messages,
+                        tokenize=False,
+                        add_generation_prompt=True,
+                        **kwargs.get("chat_template_kwargs", {}))
                 except Exception as e:
                     logger.error(f"Could not apply chat template: {e}. "
                                  "Falling back to raw prompt.")
@@ -824,7 +831,10 @@ class SonnetDataset(BenchmarkDataset):
         base_msg = [{"role": "user", "content": base_prompt}]
         base_fmt = tokenizer.apply_chat_template(base_msg,
                                                  add_generation_prompt=True,
-                                                 tokenize=False)
+                                                 tokenize=False,
+                                                 **kwargs.get(
+                                                     "chat_template_kwargs",
+                                                     {}))
         base_offset = len(tokenizer(base_fmt).input_ids)
         if input_len <= base_offset:
             raise ValueError(
@@ -844,7 +854,10 @@ class SonnetDataset(BenchmarkDataset):
             prompt = f"{base_prompt}{''.join(prefix_lines + extra_lines)}"
             msg = [{"role": "user", "content": prompt}]
             prompt_formatted = tokenizer.apply_chat_template(
-                msg, add_generation_prompt=True, tokenize=False)
+                msg,
+                add_generation_prompt=True,
+                tokenize=False,
+                **kwargs.get("chat_template_kwargs", {}))
             prompt_len = len(tokenizer(prompt_formatted).input_ids)
 
             if prompt_len <= input_len:

--- a/scripts/vllm/benchmarking/benchmark_serving.py
+++ b/scripts/vllm/benchmarking/benchmark_serving.py
@@ -28,6 +28,7 @@ import argparse
 import asyncio
 import contextlib
 import gc
+import json
 import logging
 import random
 import time
@@ -522,6 +523,7 @@ def main(args: argparse.Namespace):
                 tokenizer=tokenizer,
                 return_prompt_formatted=False,
                 request_id_prefix=args.request_id_prefix,
+                chat_template_kwargs=json.loads(args.chat_template_kwargs),
             )
         else:
             assert tokenizer.chat_template or tokenizer.default_chat_template, (
@@ -535,6 +537,7 @@ def main(args: argparse.Namespace):
                 tokenizer=tokenizer,
                 return_prompt_formatted=True,
                 request_id_prefix=args.request_id_prefix,
+                chat_template_kwargs=json.loads(args.chat_template_kwargs),
             )
     else:
         # For datasets that follow a similar structure, use a mapping.
@@ -550,6 +553,7 @@ def main(args: argparse.Namespace):
                                     input_len=args.mmlu_input_len,
                                     output_len=args.mmlu_output_len,
                                     chat_template_system_prompt=args.chat_template_system_prompt,
+                                    chat_template_kwargs=json.loads(args.chat_template_kwargs),
                                     ),
             "mlperf":
             lambda: MLPerfDataset(random_seed=args.seed,
@@ -567,6 +571,7 @@ def main(args: argparse.Namespace):
                                     num_requests=args.num_prompts,
                                     output_len=args.gpqa_output_len,
                                     chat_template_system_prompt=args.chat_template_system_prompt,
+                                    chat_template_kwargs=json.loads(args.chat_template_kwargs),
                                     ),
             "mmmu_pro":
             lambda: MMMUProDataset(
@@ -823,6 +828,12 @@ if __name__ == "__main__":
         type=str,
         default="Reasoning effort: high",
         help="The system prompt to use when applying a chat template.",
+    )
+    parser.add_argument(
+        "--chat-template-kwargs",
+        type=str,
+        default="{}",
+        help="A JSON string containing kwargs to pass to apply_chat_template.",
     )
 
     # group for dataset specific arguments

--- a/scripts/vllm/benchmarking/benchmark_utils.py
+++ b/scripts/vllm/benchmarking/benchmark_utils.py
@@ -143,6 +143,12 @@ def postprocess_text_mmlu(preds: List[str],
         if match:
             return match.group(1).upper()
 
+        # To match: bare A, B, C, or D (e.g. from highly constrained system prompt)
+        re_str_fallback = r"^\s*(?:\*{1,2}|_{1,2})?([A-D])(?:\*{1,2}|_{1,2})?\s*[\.\)\-–:]?\s*$"
+        match = re.search(re_str_fallback, output, re.IGNORECASE)
+        if match:
+            return match.group(1).upper()
+
         return None
 
     preds = [choices.index(_parse_answer(pred.strip())) for pred in preds]


### PR DESCRIPTION
# Description
* Add option to pass in additional `chat_template_kwargs` when running `scripts/vllm/benchmarking/benchmark_serving.py` . This would allow us to explicitly turn off thinking. (see the test command below) instead of relying on system prompt
  - Traditionally we rely on system prompt to force the model to give an answer straight away instead of using a high number of thinking tokens.
  - However this does really work, for Kimi 2.6 because explicitly turning off thinking in `tokenizer.apply_chat_template` , a `<think>` control token will always be appended, which will result in the model not able to give the final answer within the often limited `mmlu-output-len` number of tokens.  The change in this CL would fix the issue.

* Introduce additional response parsing logic to deal with situations where the model just a single token answer to an MMLU question.


# Tests
After starting up a Kimi 2.6 instance with
```
MOE_REQUANTIZE_BLOCK_SIZE=512 \
MOE_REQUANTIZE_WEIGHT_DTYPE="fp4" \
NEW_MODEL_DESIGN=1 \
MODEL_IMPL_TYPE="vllm" \
vllm serve "gs://tpu-commons-ci/moonshootai/kimi/2.6" \
  --max-model-len 1024 \
  --max-num-batched-tokens 1024 \
  --tensor-parallel-size 8 \
  --kv-cache-dtype=fp8 \
  --gpu-memory-utilization 0.95 \
  --limit-mm-per-prompt='{"image": 0, "video": 0, "vision_chunk": 0}' \
  --served-model-name "moonshotai/Kimi-K2.6" \
  --load-format=runai_streamer \
  --enable-expert-parallel \
  --trust-remote-code \
  --kv-cache-dtype=fp8 \
  --additional-config '{"sharding": {"sharding_strategy": {"enable_dp_attention": true, "tensor_parallelism": 8}}}'
```

The benchmark can be started with
```
python scripts/vllm/benchmarking/benchmark_serving.py \
--backend vllm \
--model moonshotai/Kimi-K2.6 \
--dataset-name mmlu \
--dataset-path /mnt/disks/victorlxh_tpu_vm_2tb/dataset/mmlu/data/test \
--mmlu-use-chat-template \
--chat-template-system-prompt "Reasoning effort: high, skip thinking process and must only give short answer in something like A, B, C, D." \
--mmlu-output-len=16 \
--trust_remote_code \
--run-eval \
--chat-template-kwargs='{"thinking": false}' \
--num-prompts 14042
```
This would give an accuracy of `0.89`. 

Without the regex update, accuracy would be ~0.4.
Without the `--chat-template-kwargs='{"thinking": false}' `, accuracy would be <0.1


# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
