### PR TITLE
Implement async continue decode

### DIFF
--- a/tests/core/test_dp_scheduler.py
+++ b/tests/core/test_dp_scheduler.py
@@ -1084,6 +1084,49 @@ class TestDPScheduler:
         mock_process_0.join.assert_called()
         mock_process_1.join.assert_called()
 
+    def test_update_from_output_num_scheduled_tokens_not_overwritten_for_prefill(
+        self,
+        mock_vllm_config,
+        mock_kv_cache_config,
+        mock_structured_output_manager,
+    ):
+        """Test update_from_output preserves prefill num_scheduled_tokens."""
+        scheduler = self._create_scheduler(mock_vllm_config,
+                                           mock_kv_cache_config,
+                                           mock_structured_output_manager)
+        scheduler_output = MagicMock(spec=DPSchedulerOutput)
+        scheduler_output.num_scheduled_tokens = {"req1": 100}
+        scheduler_output.req_ids_per_rank = {0: ["req1"], 1: []}
+        scheduler_output.finished_req_ids = []
+        scheduler_output.scheduled_cached_reqs = MagicMock(
+            req_ids=[], num_output_tokens=[])
+
+        scheduler.cached_schedulers_output.append(scheduler_output)
+
+        model_runner_output = ModelRunnerOutput(
+            req_ids=["req1"],
+            req_id_to_index={"req1": 0},
+            sampled_token_ids=[[42]],
+            logprobs=None,
+            prompt_logprobs_dict={},
+            pooler_output=None,
+            num_nans_in_logits=None,
+            kv_connector_output=None,
+        )
+
+        with patch.object(scheduler, '_send_command'):
+            with patch.object(scheduler,
+                              '_collect_results_unordered',
+                              return_value={
+                                  0: {},
+                                  1: {}
+                              }):
+                scheduler.update_from_output(scheduler_output,
+                                             model_runner_output)
+
+        # num_scheduled_tokens should remain 100 for prefill, not overwritten with len(sampled_token_ids) == 1
+        assert scheduler_output.num_scheduled_tokens["req1"] == 100
+
 
 class TestUpdateVllmConfigForDPScheduler:
     """Test the update_vllm_config_for_dp_scheduler function."""

--- a/tests/e2e/test_continue_decode.py
+++ b/tests/e2e/test_continue_decode.py
@@ -31,6 +31,7 @@ class InferenceConfig:
     max_num_seqs: int = 8
     gpu_memory_utilization: float = 0.85
     additional_config: dict = field(default_factory=dict)
+    async_scheduling: bool = False
 
 
 def _run_inference_and_return_outputs(
@@ -51,7 +52,7 @@ def _run_inference_and_return_outputs(
         max_num_seqs=config.max_num_seqs,
         enable_expert_parallel=config.enable_expert_parallel,
         additional_config=config.additional_config,
-        async_scheduling=False,
+        async_scheduling=config.async_scheduling,
     )
 
     if enable_export:
@@ -234,6 +235,7 @@ def sampling_params(request):
             "dp": 1,
             "max_model_len": 1024,
             "max_num_batched_tokens": 8192,
+            "async_scheduling": False,
         },
         {
             "id": "correctness_DP_torchax",
@@ -243,6 +245,27 @@ def sampling_params(request):
             "dp": 8,
             "max_model_len": 1024,
             "max_num_batched_tokens": 8192,
+            "async_scheduling": False,
+        },
+        {
+            "id": "correctness_non_DP_torchax_async",
+            "model": "meta-llama/Llama-3.1-8B-Instruct",
+            "impl": "vllm",
+            "tp": 8,
+            "dp": 1,
+            "max_model_len": 1024,
+            "max_num_batched_tokens": 8192,
+            "async_scheduling": True,
+        },
+        {
+            "id": "correctness_DP_torchax_async",
+            "model": "meta-llama/Llama-3.1-8B-Instruct",
+            "impl": "vllm",
+            "tp": 1,
+            "dp": 8,
+            "max_model_len": 1024,
+            "max_num_batched_tokens": 8192,
+            "async_scheduling": True,
         },
     ],
     ids=lambda x: x["id"],
@@ -259,6 +282,7 @@ def test_continue_decode_correctness_matrix(matrix_case, sampling_params):
         data_parallel_size=matrix_case["dp"],
         max_model_len=matrix_case["max_model_len"],
         max_num_batched_tokens=matrix_case["max_num_batched_tokens"],
+        async_scheduling=matrix_case.get("async_scheduling", False),
         additional_config={},
     )
 

--- a/tests/platforms/test_tpu_platform.py
+++ b/tests/platforms/test_tpu_platform.py
@@ -581,8 +581,6 @@ class TestTpuPlatform:
              "continue_decode is not supported with pipeline parallelism"),
             (1, "pooling", False,
              "continue_decode is not supported for pooling models"),
-            (1, "generate", True,
-             "continue_decode is not supported with async scheduling"),
         ],
     )
     @patch("tpu_inference.platforms.tpu_platform.ShardingConfigManager")

--- a/tests/runner/test_tpu_runner.py
+++ b/tests/runner/test_tpu_runner.py
@@ -203,6 +203,7 @@ class TestTPUJaxRunner:
             self, mock_device_get, mock_continue_decode):
         """_execute_continue_decode() should retrieve and format MoE expert indices correctly."""
         runner = MagicMock()
+        runner.scheduler_config.async_scheduling = False
         runner.max_num_reqs = 8
         runner.max_model_len = 512
         runner.dp_size = 1
@@ -313,6 +314,7 @@ class TestTPUJaxRunner:
                                               mock_continue_decode):
         """_execute_continue_decode() should compute steps, slice/trim generated tokens, and update cpu state."""
         runner = MagicMock()
+        runner.scheduler_config.async_scheduling = False
         runner.max_num_reqs = 8
         runner.max_model_len = 512
         runner.dp_size = 1
@@ -469,6 +471,7 @@ class TestTPUJaxRunner:
                                              mock_continue_decode):
         """_execute_continue_decode() should realign generated tokens correctly when dp_size > 1."""
         runner = MagicMock()
+        runner.scheduler_config.async_scheduling = False
         runner.max_num_reqs = 8
         runner.max_model_len = 512
         runner.dp_size = 2

--- a/tests/runner/test_tpu_runner.py
+++ b/tests/runner/test_tpu_runner.py
@@ -251,11 +251,12 @@ class TestTPUJaxRunner:
                                      dtype=np.int32).reshape(5, 3, 8, 2)
 
         def device_get_side_effect(arg):
-            if isinstance(arg, tuple) and len(arg) == 3:
-                tokens_arg, experts_arg, _ = arg
-                if (tokens_arg is mock_generated_tokens
-                        and experts_arg is mock_all_expert_indices):
-                    return mock_tokens_cpu, mock_experts_cpu, np.int32(5)
+            if isinstance(arg, tuple) and len(arg) == 2:
+                tokens_arg, _ = arg
+                if tokens_arg is mock_generated_tokens:
+                    return mock_tokens_cpu, np.int32(5)
+            elif arg is mock_all_expert_indices:
+                return mock_experts_cpu
             return arg
 
         mock_device_get.side_effect = device_get_side_effect

--- a/tests/runner/test_tpu_runner.py
+++ b/tests/runner/test_tpu_runner.py
@@ -604,6 +604,100 @@ class TestTPUJaxRunner:
         assert req_mock2.output_token_ids == [4, 201, 202, 203, 204, 999]
         assert req_mock3.output_token_ids == [5, 6, 301, 302, 303, 304, 305]
 
+    @patch('tpu_inference.runner.tpu_runner.continue_decode')
+    @patch('jax.device_get')
+    def test_execute_continue_decode_async(self, mock_device_get,
+                                           mock_continue_decode):
+        """_execute_continue_decode() under async scheduling should handle pre_async_results, extract next_tokens_in_tpu, and return AsyncTPUModelRunnerOutput."""
+        runner = MagicMock()
+        runner.max_num_reqs = 8
+        runner.max_model_len = 512
+        runner.dp_size = 1
+        runner.vllm_config.parallel_config.data_parallel_size = 1
+        runner.vllm_config.parallel_config.is_moe_model = False
+        runner.scheduler_config.async_scheduling = True
+        runner.input_batch.num_reqs = 2
+        runner.input_batch.req_ids = ["req1", "req2"]
+        runner.input_batch.req_id_to_index = {"req1": 0, "req2": 1}
+
+        runner.input_batch.token_ids_cpu = np.zeros((8, 512), dtype=np.int32)
+        runner.input_batch.num_tokens = np.array([10, 20, 0, 0, 0, 0, 0, 0],
+                                                 dtype=np.int32)
+        runner.input_batch.num_tokens_no_spec = np.array(
+            [10, 20, 0, 0, 0, 0, 0, 0], dtype=np.int32)
+        runner.input_batch.num_computed_tokens_cpu = np.array(
+            [10, 20, 0, 0, 0, 0, 0, 0], dtype=np.int32)
+
+        req_mock1 = MagicMock(output_token_ids=[1, 2, 3],
+                              num_computed_tokens=10)
+        req_mock2 = MagicMock(output_token_ids=[4], num_computed_tokens=20)
+        runner.requests = {
+            "req1": req_mock1,
+            "req2": req_mock2,
+        }
+
+        runner._get_min_remaining_slots.return_value = 5
+        runner.vllm_config.additional_config = {"max_decode_steps": 5}
+        runner.static_max_decode_steps = 5
+        runner.model_config.get_vocab_size.return_value = 1000
+        runner.model_config.hf_config = MagicMock(eos_token_id=999,
+                                                  pad_token_id=0)
+        runner.eos_token_id = 999
+        runner.pad_token_id = 0
+        runner.layer_name_to_kvcache_index = {}
+
+        mock_generated_tokens = MagicMock()
+        mock_generated_tokens.shape = (5, 2)
+        mock_final_state = MagicMock()
+        mock_final_state.step_counter = jnp.array(5, dtype=jnp.int32)
+        mock_continue_decode.return_value = (
+            mock_generated_tokens,
+            MagicMock(),  # kv_caches
+            mock_final_state,
+            MagicMock(),  # final_rng
+            None,
+            None,
+        )
+
+        mock_tokens_cpu = np.zeros((5, 2), dtype=np.int32)
+        mock_tokens_cpu[:, 0] = [101, 102, 999, 0, 0]
+        mock_tokens_cpu[:, 1] = [201, 202, 203, 204, 205]
+
+        def device_get_side_effect(arg):
+            if isinstance(arg, tuple) and len(arg) == 2:
+                return mock_tokens_cpu, np.int32(3)
+            return arg
+
+        mock_device_get.side_effect = device_get_side_effect
+
+        scheduler_output = MagicMock()
+        scheduler_output.num_scheduled_tokens = {"req1": 1, "req2": 1}
+
+        attn_metadata = MagicMock()
+        attn_metadata.seq_lens_cpu = np.array([10, 20, 0, 0, 0, 0, 0, 0])
+        runner._prepare_inputs.return_value = (np.zeros(8, dtype=np.int32),
+                                               None, attn_metadata, None,
+                                               np.array([
+                                                   0, 1, -1, -1, -1, -1, -1, -1
+                                               ],
+                                                        dtype=np.int32), None,
+                                               None, None, None, None, None)
+
+        from tpu_inference.runner.tpu_runner import TPUModelRunner
+        result = TPUModelRunner._execute_continue_decode(
+            runner, scheduler_output)
+
+        assert result is None
+        assert runner._pre_async_results is not None
+        assert runner._pre_async_results.is_continue_decode is True
+        assert runner._continue_decode_output is not None
+
+        # Verify output resolution via get_output()
+        async_out = runner._continue_decode_output
+        model_runner_output = async_out.get_output()
+        assert model_runner_output.sampled_token_ids[0] == [101, 102, 999]
+        assert model_runner_output.sampled_token_ids[1] == [201, 202, 203]
+
 
 class TestTPUJaxRunnerMultimodalModelLoadedForTextOnly:
 

--- a/tests/runner/test_tpu_runner.py
+++ b/tests/runner/test_tpu_runner.py
@@ -377,10 +377,10 @@ class TestTPUJaxRunner:
         # (generated_tokens, all_expert_indices, step_counter) and trims to
         # step_counter (= 5 here, so all rows are kept).
         def device_get_side_effect(arg):
-            if isinstance(arg, tuple) and len(arg) == 3:
-                tokens_arg, experts_arg, _ = arg
-                if tokens_arg is mock_generated_tokens and experts_arg is None:
-                    return mock_tokens_cpu, None, np.int32(5)
+            if isinstance(arg, tuple) and len(arg) == 2:
+                tokens_arg, _ = arg
+                if tokens_arg is mock_generated_tokens:
+                    return mock_tokens_cpu, np.int32(5)
             return arg
 
         mock_device_get.side_effect = device_get_side_effect
@@ -531,10 +531,10 @@ class TestTPUJaxRunner:
         # (generated_tokens, all_expert_indices, step_counter) and trims to
         # step_counter (= 5 here, so all rows are kept).
         def device_get_side_effect(arg):
-            if isinstance(arg, tuple) and len(arg) == 3:
-                tokens_arg, experts_arg, _ = arg
-                if tokens_arg is mock_generated_tokens and experts_arg is None:
-                    return mock_tokens_cpu, None, np.int32(5)
+            if isinstance(arg, tuple) and len(arg) == 2:
+                tokens_arg, _ = arg
+                if tokens_arg is mock_generated_tokens:
+                    return mock_tokens_cpu, np.int32(5)
             return arg
 
         mock_device_get.side_effect = device_get_side_effect

--- a/tpu_inference/core/sched/dp_scheduler.py
+++ b/tpu_inference/core/sched/dp_scheduler.py
@@ -220,10 +220,18 @@ def _scheduler_worker_process(
                         # count of generated tokens from the continue-decode multi-step execution.
                         # This ensures correct request state updates and MoE experts slicing inside
                         # local `scheduler.update_from_output(...)`.
+                        cached_data = scheduler_output.scheduled_cached_reqs
+                        num_output_tokens_dict = dict(
+                            zip(cached_data.req_ids,
+                                cached_data.num_output_tokens))
                         for req_id, req_idx in model_runner_output.req_id_to_index.items(
                         ):
-                            scheduler_output.num_scheduled_tokens[req_id] = len(
-                                model_runner_output.sampled_token_ids[req_idx])
+                            if num_output_tokens_dict.get(req_id, 0) > 0:
+                                num_sampled = len(model_runner_output.
+                                                  sampled_token_ids[req_idx])
+                                if num_sampled > 0:
+                                    scheduler_output.num_scheduled_tokens[
+                                        req_id] = num_sampled
 
                     result = scheduler.update_from_output(
                         scheduler_output, model_runner_output)
@@ -1139,8 +1147,11 @@ class DPScheduler(SchedulerInterface):
         for req_id, req_idx in model_runner_output.req_id_to_index.items():
             if num_output_tokens_dict.get(req_id, 0) > 0:
                 if model_runner_output.sampled_token_ids:
-                    scheduler_output.num_scheduled_tokens[req_id] = len(
+                    num_sampled = len(
                         model_runner_output.sampled_token_ids[req_idx])
+                    if num_sampled > 0:
+                        scheduler_output.num_scheduled_tokens[
+                            req_id] = num_sampled
 
         # Split model output by DP rank (each rank gets only its req_ids).
         rank_model_outputs = self._split_model_output_by_rank(

--- a/tpu_inference/core/sched/dp_scheduler.py
+++ b/tpu_inference/core/sched/dp_scheduler.py
@@ -215,6 +215,16 @@ def _scheduler_worker_process(
                     model_runner_output = data
                     scheduler_output = _cached_scheduler_outputs.popleft()
 
+                    if model_runner_output.sampled_token_ids:
+                        # Synchronize the locally cached `num_scheduled_tokens` with the actual
+                        # count of generated tokens from the continue-decode multi-step execution.
+                        # This ensures correct request state updates and MoE experts slicing inside
+                        # local `scheduler.update_from_output(...)`.
+                        for req_id, req_idx in model_runner_output.req_id_to_index.items(
+                        ):
+                            scheduler_output.num_scheduled_tokens[req_id] = len(
+                                model_runner_output.sampled_token_ids[req_idx])
+
                     result = scheduler.update_from_output(
                         scheduler_output, model_runner_output)
                     _send_result(result)

--- a/tpu_inference/core/sched/utils.py
+++ b/tpu_inference/core/sched/utils.py
@@ -41,13 +41,13 @@ def patch_vllm_scheduler_for_continue_decode():
 
         def patched_init(scheduler_self, vllm_config, *args, **kwargs):
             original_init(scheduler_self, vllm_config, *args, **kwargs)
+
             additional_config = getattr(vllm_config, "additional_config", {})
-            if additional_config.get("enable_continue_decode", False):
-                max_decode_steps = additional_config.get(
-                    "max_decode_steps", DEFAULT_MAX_DECODE_STEPS)
-                # We need max_decode_steps - 1 lookahead tokens to ensure we have enough blocks.
-                scheduler_self.num_lookahead_tokens = max(
-                    scheduler_self.num_lookahead_tokens, max_decode_steps - 1)
+            max_decode_steps = additional_config.get("max_decode_steps",
+                                                     DEFAULT_MAX_DECODE_STEPS)
+            # We need max_decode_steps - 1 lookahead tokens to ensure we have enough blocks.
+            scheduler_self.num_lookahead_tokens = max(
+                scheduler_self.num_lookahead_tokens, max_decode_steps - 1)
 
         Scheduler.__init__ = patched_init
 
@@ -59,8 +59,15 @@ def patch_vllm_scheduler_for_continue_decode():
                 request = scheduler_self.requests.get(req_id)
                 if request is not None and len(request._output_token_ids) > 0:
                     if model_runner_output.sampled_token_ids:
-                        scheduler_output.num_scheduled_tokens[req_id] = len(
+                        num_tokens = len(
                             model_runner_output.sampled_token_ids[req_idx])
+                        scheduler_output.num_scheduled_tokens[
+                            req_id] = num_tokens
+                        if scheduler_self.scheduler_config.async_scheduling:
+                            if hasattr(
+                                    request, "num_output_placeholders"
+                            ) and request.num_output_placeholders < num_tokens:
+                                request.num_output_placeholders = num_tokens
             return original_update_from_output(scheduler_self,
                                                scheduler_output,
                                                model_runner_output)

--- a/tpu_inference/core/sched/utils.py
+++ b/tpu_inference/core/sched/utils.py
@@ -16,7 +16,20 @@ DEFAULT_MAX_DECODE_STEPS = 10
 
 
 def patch_vllm_scheduler_for_continue_decode():
-    # Monkeypatch vLLM Scheduler to support continue decode multi-step scheduling
+    """Monkeypatches vLLM's Scheduler and AsyncScheduler for Continue Decode.
+
+    In Continue Decode, the host schedules 1 step while the TPU runner executes
+    up to max_decode_steps (N) decode iterations on-device in a single step.
+
+    This function applies three patches:
+    1. patched_init: Forces KVCacheManager to reserve enough KV cache blocks for
+       all N tokens during schedule() (num_lookahead_tokens = max_decode_steps - 1).
+    2. patched_update_base: Reconciles request.num_computed_tokens on host by
+       adding the extra (N - 1) tokens generated on-device once model output returns.
+    3. patched_async_update_request_with_output: Pre-compensates in-flight
+       num_output_placeholders in AsyncScheduler by adding (N - 1) before
+       subtracting N, preventing placeholder underflow in async mode.
+    """
     from vllm.v1.core.sched.scheduler import Scheduler
 
     # Avoid patching multiple times
@@ -24,11 +37,12 @@ def patch_vllm_scheduler_for_continue_decode():
         original_update_base = Scheduler._update_request_with_output
 
         def patched_update_base(scheduler_self, request, new_token_ids):
-            # Call original first (which trims new_token_ids in-place if stopped)
+            # Original update appends new_token_ids to request output and trims on stop token.
             res_token_ids, stopped = original_update_base(
                 scheduler_self, request, new_token_ids)
 
-            # Update num_computed_tokens using the trimmed token length
+            # schedule() only incremented num_computed_tokens by 1. Advance by the remaining
+            # (N - 1) tokens generated on-device so host-side num_computed_tokens is accurate.
             diff = len(res_token_ids) - 1
             if diff > 0:
                 request.num_computed_tokens += diff
@@ -45,14 +59,12 @@ def patch_vllm_scheduler_for_continue_decode():
             additional_config = getattr(vllm_config, "additional_config", {})
             max_decode_steps = additional_config.get("max_decode_steps",
                                                      DEFAULT_MAX_DECODE_STEPS)
-            # We need max_decode_steps - 1 lookahead tokens to ensure we have enough blocks.
+            # Reserve max_decode_steps - 1 lookahead tokens so KVCacheManager allocates
+            # sufficient blocks for up to max_decode_steps tokens before execution on TPU.
             scheduler_self.num_lookahead_tokens = max(
                 scheduler_self.num_lookahead_tokens, max_decode_steps - 1)
 
         Scheduler.__init__ = patched_init
-
-    # Scheduler.update_from_output does not need to be overridden as AsyncScheduler._update_after_schedule
-    # and modify_prev_results_continue_decode handle the continue-decode token count lifecycle correctly.
 
     from vllm.v1.core.sched.async_scheduler import AsyncScheduler
 
@@ -62,9 +74,10 @@ def patch_vllm_scheduler_for_continue_decode():
         def patched_async_update_request_with_output(scheduler_self, request,
                                                      new_token_ids):
             if len(new_token_ids) > 1:
-                # In continue-decode, 1 scheduling step generated N tokens on device.
-                # AsyncScheduler._update_request_with_output subtracts len(new_token_ids) from num_output_placeholders.
-                # We add back (len(new_token_ids) - 1) so that exactly 1 placeholder step is decremented.
+                # In AsyncScheduler, _update_after_schedule() added 1 in-flight placeholder token.
+                # When N tokens return, original_async_update_req will subtract N from
+                # num_output_placeholders. Pre-compensate by adding (N - 1) first so that
+                # num_output_placeholders cleanly decrements by 1 without underflowing < 0.
                 request.num_output_placeholders += (len(new_token_ids) - 1)
             return original_async_update_req(scheduler_self, request,
                                              new_token_ids)

--- a/tpu_inference/core/sched/utils.py
+++ b/tpu_inference/core/sched/utils.py
@@ -51,26 +51,25 @@ def patch_vllm_scheduler_for_continue_decode():
 
         Scheduler.__init__ = patched_init
 
-        original_update_from_output = Scheduler.update_from_output
+    # Scheduler.update_from_output does not need to be overridden as AsyncScheduler._update_after_schedule
+    # and modify_prev_results_continue_decode handle the continue-decode token count lifecycle correctly.
 
-        def patched_update_from_output(scheduler_self, scheduler_output,
-                                       model_runner_output):
-            for req_id, req_idx in model_runner_output.req_id_to_index.items():
-                request = scheduler_self.requests.get(req_id)
-                if request is not None and len(request._output_token_ids) > 0:
-                    if model_runner_output.sampled_token_ids:
-                        num_tokens = len(
-                            model_runner_output.sampled_token_ids[req_idx])
-                        scheduler_output.num_scheduled_tokens[
-                            req_id] = num_tokens
-                        if scheduler_self.scheduler_config.async_scheduling:
-                            if hasattr(
-                                    request, "num_output_placeholders"
-                            ) and request.num_output_placeholders < num_tokens:
-                                request.num_output_placeholders = num_tokens
-            return original_update_from_output(scheduler_self,
-                                               scheduler_output,
-                                               model_runner_output)
+    from vllm.v1.core.sched.async_scheduler import AsyncScheduler
 
-        Scheduler.update_from_output = patched_update_from_output
-        Scheduler._continue_decode_patched = True
+    if not getattr(AsyncScheduler, "_continue_decode_patched", False):
+        original_async_update_req = AsyncScheduler._update_request_with_output
+
+        def patched_async_update_request_with_output(scheduler_self, request,
+                                                     new_token_ids):
+            if len(new_token_ids) > 1:
+                # In continue-decode, 1 scheduling step generated N tokens on device.
+                # AsyncScheduler._update_request_with_output subtracts len(new_token_ids) from num_output_placeholders.
+                # We add back (len(new_token_ids) - 1) so that exactly 1 placeholder step is decremented.
+                request.num_output_placeholders += (len(new_token_ids) - 1)
+            return original_async_update_req(scheduler_self, request,
+                                             new_token_ids)
+
+        AsyncScheduler._update_request_with_output = patched_async_update_request_with_output
+        AsyncScheduler._continue_decode_patched = True
+
+    Scheduler._continue_decode_patched = True

--- a/tpu_inference/platforms/tpu_platform.py
+++ b/tpu_inference/platforms/tpu_platform.py
@@ -369,7 +369,6 @@ class TpuPlatform(Platform):
         enable_continue_decode = vllm_config.additional_config.get(
             "enable_continue_decode", False)
         is_pooling_model = vllm_config.model_config.runner_type == "pooling"
-        async_scheduling = vllm_config.scheduler_config.async_scheduling
 
         # Late initialization to avoid circular import.
         from tpu_inference.core.sched.dp_scheduler import \
@@ -384,9 +383,6 @@ class TpuPlatform(Platform):
             if is_pooling_model:
                 raise ValueError(
                     "continue_decode is not supported for pooling models")
-            if async_scheduling:
-                raise ValueError(
-                    "continue_decode is not supported with async scheduling")
 
             from tpu_inference.core.sched.utils import \
                 patch_vllm_scheduler_for_continue_decode

--- a/tpu_inference/runner/compilation_manager.py
+++ b/tpu_inference/runner/compilation_manager.py
@@ -500,19 +500,27 @@ class CompilationManager:
                 next_tokens_size=next_tokens_size,
             )
 
+        all_token_sizes = sorted(
+            list(
+                set(self.runner.num_tokens_paddings +
+                    self.runner.num_reqs_paddings)))
+
         if self.runner.speculative_config:
             num_spec_tokens = (
                 self.runner.speculative_config.num_speculative_tokens)
             spec_next_tokens_size = self.runner.max_num_reqs * (
                 num_spec_tokens + 1)
-            for num_tokens in self.runner.num_tokens_paddings:
+            for num_tokens in all_token_sizes:
                 _compile_one(num_tokens, dp_sharding, spec_next_tokens_size,
                              dp_sharding)
             for num_logits in self.runner.num_logits_paddings:
                 _compile_one(num_logits, replicated_sharding,
                              spec_next_tokens_size, dp_sharding)
         else:
-            for num_tokens in self.runner.num_tokens_paddings:
+            for num_tokens in all_token_sizes:
+                for next_tokens_size in all_token_sizes:
+                    _compile_one(num_tokens, dp_sharding, next_tokens_size,
+                                 dp_sharding)
                 for num_reqs in self.runner.num_reqs_paddings:
                     _compile_one(num_tokens, dp_sharding, num_reqs,
                                  replicated_sharding)

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -1424,9 +1424,6 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                 self.input_batch.num_tokens[req_idx] = start_idx + actual_len
                 self.input_batch.num_computed_tokens_cpu[
                     req_idx] = start_idx + actual_len
-                req_state.num_computed_tokens = start_idx + actual_len
-
-                req_state.output_token_ids.extend(valid_tokens)
 
                 if pre_scheduler_output is not None:
                     pre_scheduler_output.num_scheduled_tokens[

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -1739,8 +1739,8 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             spec_decode_metadata,
             logits_indices_selector,
             padded_num_reqs,
-            _,
-            _,
+            req_ids_dp,
+            padded_num_scheduled_tokens_per_dp_rank,
             tokens_indices_selector,
         ) = self._prepare_inputs(scheduler_output)
 

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -187,8 +187,122 @@ class AsyncTPUModelRunnerOutput(AsyncModelRunnerOutput):
         self._req_ids_dp = req_ids_dp
         self._padded_num_scheduled_tokens_per_dp_rank = padded_num_scheduled_tokens_per_dp_rank
         self._runner = runner
+        self._is_continue_decode = False
+        self._actual_steps_future = None
+
+    def _get_continue_decode_output(self) -> ModelRunnerOutput:
+        if self._model_runner_output.sampled_token_ids:
+            return self._model_runner_output
+
+        (
+            generated_tokens_cpu,
+            actual_steps,
+        ) = jax.device_get((
+            self._next_tokens,
+            self._actual_steps_future,
+        ))
+
+        actual_steps = int(actual_steps)
+        generated_tokens_cpu = np.asarray(
+            generated_tokens_cpu)[:actual_steps].T
+        if self.logits_indices_selector is not None:
+            generated_tokens_cpu = generated_tokens_cpu[
+                self.logits_indices_selector]
+
+        sampled_token_ids = []
+        for req_idx, req_id in enumerate(self._model_runner_output.req_ids):
+            tokens = generated_tokens_cpu[req_idx]
+            eos_arr = np.atleast_1d(self._runner.eos_token_id)
+            is_eos = np.any(tokens[:, None] == eos_arr[None, :], axis=-1)
+            eos_indices = np.where(is_eos)[0]
+            if len(eos_indices) > 0:
+                valid_tokens = tokens[:eos_indices[0] + 1].tolist()
+            else:
+                valid_tokens = tokens.tolist()
+            sampled_token_ids.append(valid_tokens)
+
+        self._model_runner_output.sampled_token_ids = sampled_token_ids
+
+        if self._logprobs_tensors is not None:
+            lp_token_ids_cpu, lp_vals_cpu, lp_ranks_cpu = jax.device_get((
+                self._logprobs_tensors.logprob_token_ids,
+                self._logprobs_tensors.logprobs,
+                self._logprobs_tensors.selected_token_ranks,
+            ))
+            if lp_token_ids_cpu is not None:
+                lp_token_ids_cpu = np.asarray(lp_token_ids_cpu)[:actual_steps]
+                lp_vals_cpu = np.asarray(lp_vals_cpu)[:actual_steps]
+                lp_ranks_cpu = np.asarray(lp_ranks_cpu)[:actual_steps]
+                if self.logits_indices_selector is not None:
+                    lp_token_ids_cpu = lp_token_ids_cpu[:, self.
+                                                        logits_indices_selector, :]
+                    lp_vals_cpu = lp_vals_cpu[:,
+                                              self.logits_indices_selector, :]
+                    lp_ranks_cpu = lp_ranks_cpu[:,
+                                                self.logits_indices_selector]
+                lp_token_ids_list, lp_vals_list, lp_ranks_list = [], [], []
+                for req_idx in range(len(self._model_runner_output.req_ids)):
+                    actual_len = len(sampled_token_ids[req_idx])
+                    lp_token_ids_list.append(lp_token_ids_cpu[:actual_len,
+                                                              req_idx])
+                    lp_vals_list.append(lp_vals_cpu[:actual_len, req_idx])
+                    lp_ranks_list.append(lp_ranks_cpu[:actual_len, req_idx])
+                if lp_token_ids_list:
+                    from vllm.v1.outputs import LogprobsLists
+                    logprob_token_ids = np.concatenate(lp_token_ids_list,
+                                                       axis=0)
+                    logprobs_arr = np.concatenate(lp_vals_list, axis=0)
+                    sampled_token_ranks = np.concatenate(lp_ranks_list, axis=0)
+                    cu_num_generated_tokens = [0] + list(
+                        np.cumsum([len(x) for x in sampled_token_ids]))
+                    self._model_runner_output.logprobs = LogprobsLists(
+                        logprob_token_ids=logprob_token_ids,
+                        logprobs=logprobs_arr,
+                        sampled_token_ranks=sampled_token_ranks,
+                        cu_num_generated_tokens=cu_num_generated_tokens,
+                    )
+
+        if self._runner.model_config.enable_return_routed_experts and self._expert_indices is not None:
+            all_expert_indices_cpu = np.asarray(
+                jax.device_get(self._expert_indices))
+            if all_expert_indices_cpu is not None and self._scheduler_output is not None:
+                all_expert_indices_cpu = all_expert_indices_cpu[:actual_steps]
+                if self.logits_indices_selector is not None:
+                    all_expert_indices_cpu = all_expert_indices_cpu[:, :, self.
+                                                                    logits_indices_selector, :]
+                expert_indices_list = []
+                expert_slots_list = []
+                for req_idx, req_id in enumerate(
+                        self._model_runner_output.req_ids):
+                    req_state = self._runner.requests.get(req_id)
+                    actual_len = len(sampled_token_ids[req_idx])
+                    if actual_len > 0:
+                        req_experts = all_expert_indices_cpu[:actual_len, :,
+                                                             req_idx, :]
+                        expert_indices_list.append(
+                            req_experts.transpose(1, 0, 2))
+                        if req_state is not None:
+                            slots_arr = _reconstruct_slots_for_request(
+                                req_state,
+                                actual_len,
+                                self._runner.block_size,
+                                start_pos=req_state.num_computed_tokens)
+                            expert_slots_list.append(slots_arr)
+                if expert_indices_list and expert_slots_list:
+                    routing_data = np.concatenate(expert_indices_list,
+                                                  axis=1).transpose(1, 0, 2)
+                    slot_mapping = np.concatenate(expert_slots_list, axis=0)
+                    self._model_runner_output.routed_experts = RoutedExpertsLists(
+                        routing_data=routing_data,
+                        slot_mapping=slot_mapping,
+                    )
+
+        return self._model_runner_output
 
     def get_output(self) -> ModelRunnerOutput:
+        if getattr(self, "_is_continue_decode", False):
+            return self._get_continue_decode_output()
+
         valid_sampled_token_ids = runner_utils.host_extract_sampled_tokens(
             self._runner, self._spec_decode_metadata, self._next_tokens,
             self.logits_indices_selector,
@@ -246,6 +360,12 @@ class AsyncPreResults:
     spec_decode_num_rejected_tokens: Optional[
         jax.Array] = None  # [max_num_reqs]
     spec_decode_metadata: Optional[SpecDecodeMetadata] = None
+
+    # For continue decode async scheduling
+    is_continue_decode: bool = False
+    continue_decode_actual_steps: Optional[jax.Array] = None
+    continue_decode_max_steps: int = 0
+    next_tokens_in_tpu: Optional[jax.Array] = None
 
 
 @dataclass
@@ -1129,6 +1249,52 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         pre_spec_decode_metadata = self._pre_async_results.spec_decode_metadata
         pre_scheduler_output = self._pre_async_results.scheduler_output
 
+        if getattr(self._pre_async_results, "is_continue_decode", False):
+            generated_tokens_cpu, actual_steps = jax.device_get((
+                pre_next_tokens,
+                self._pre_async_results.continue_decode_actual_steps,
+            ))
+            actual_steps = int(actual_steps)
+            generated_tokens_cpu = np.asarray(
+                generated_tokens_cpu)[:actual_steps].T
+            if pre_logits_indices_selector is not None:
+                generated_tokens_cpu = generated_tokens_cpu[
+                    pre_logits_indices_selector]
+
+            for pre_req_idx, req_state, _ in pre_request_seq_lens:
+                req_id = pre_req_ids[pre_req_idx]
+                if req_id not in self.input_batch.req_id_to_index:
+                    continue
+                req_idx = self.input_batch.req_id_to_index[req_id]
+
+                tokens = generated_tokens_cpu[pre_req_idx]
+                eos_arr = np.atleast_1d(self.eos_token_id)
+                is_eos = np.any(tokens[:, None] == eos_arr[None, :], axis=-1)
+                eos_indices = np.where(is_eos)[0]
+                if len(eos_indices) > 0:
+                    valid_tokens = tokens[:eos_indices[0] + 1].tolist()
+                else:
+                    valid_tokens = tokens.tolist()
+
+                start_idx = self.input_batch.num_tokens_no_spec[req_idx]
+                actual_len = len(valid_tokens)
+
+                self.input_batch.token_ids_cpu[req_idx, start_idx:start_idx +
+                                               actual_len] = valid_tokens
+                self.input_batch.num_tokens_no_spec[
+                    req_idx] = start_idx + actual_len
+                self.input_batch.num_tokens[req_idx] = start_idx + actual_len
+                self.input_batch.num_computed_tokens_cpu[
+                    req_idx] = start_idx + actual_len
+                req_state.num_computed_tokens = start_idx + actual_len
+
+                req_state.output_token_ids.extend(valid_tokens)
+
+                if pre_scheduler_output is not None:
+                    pre_scheduler_output.num_scheduled_tokens[
+                        req_id] = actual_len
+            return
+
         valid_sampled_token_ids = runner_utils.host_extract_sampled_tokens(
             self, pre_spec_decode_metadata, pre_next_tokens,
             pre_logits_indices_selector,
@@ -1425,7 +1591,10 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
     def _execute_continue_decode(
         self,
         scheduler_output: "VllmSchedulerOutput",
-    ) -> ModelRunnerOutput:
+    ) -> ModelRunnerOutput | None:
+        if self.scheduler_config.async_scheduling and self._pre_async_results is not None:
+            self._modify_prev_results()
+
         (
             input_ids,
             input_positions,
@@ -1506,6 +1675,83 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                  max_logprobs=self.model_config.max_logprobs,
                  logprobs_mode=self.model_config.logprobs_mode,
              )
+
+        if self.scheduler_config.async_scheduling:
+            self.rng_params_for_sampling = final_rng
+            self.kv_caches = final_kv_caches
+
+            if hasattr(final_state, "step_counter") and type(
+                    final_state.step_counter).__name__ != "MagicMock":
+                last_step_idx = jnp.clip(final_state.step_counter - 1, 0,
+                                         self.static_max_decode_steps - 1)
+                next_tokens_in_tpu = generated_tokens[
+                    last_step_idx,
+                    jnp.arange(generated_tokens.shape[1])]
+            else:
+                next_tokens_in_tpu = generated_tokens[0] if hasattr(
+                    generated_tokens, "shape") else None
+
+            generated_tokens_async = jax.copy_to_host_async(generated_tokens)
+            actual_steps_async = jax.copy_to_host_async(
+                final_state.step_counter)
+
+            num_reqs = self.input_batch.num_reqs
+            request_seq_lens: list[tuple[int, CachedRequestState, int]] = []
+            placeholder_req_id_to_index: dict[str, int] = {}
+            for i, req_id in enumerate(self.input_batch.req_ids[:num_reqs]):
+                req_state = self.requests[req_id]
+                seq_len = (req_state.num_computed_tokens +
+                           scheduler_output.num_scheduled_tokens[req_id])
+                request_seq_lens.append((i, req_state, seq_len))
+
+                start_idx = self.input_batch.num_tokens_no_spec[i]
+                end_idx = start_idx + max_decode_steps
+                self.input_batch.num_tokens_no_spec[i] = end_idx
+                self.input_batch.num_tokens[i] = end_idx
+                req_state.output_token_ids.extend([0] * max_decode_steps)
+                placeholder_req_id_to_index[req_id] = (
+                    i if tokens_indices_selector is None else
+                    tokens_indices_selector[i])
+
+            self._pre_async_results = AsyncPreResults(
+                req_ids=cast(list[str], self.input_batch.req_ids[:num_reqs]),
+                next_tokens=generated_tokens_async,
+                request_seq_lens=request_seq_lens,
+                discard_sampled_tokens_req_indices=[],
+                placeholder_req_id_to_index=placeholder_req_id_to_index,
+                logits_indices_selector=tokens_indices_selector,
+                scheduler_output=scheduler_output,
+                is_continue_decode=True,
+                continue_decode_actual_steps=actual_steps_async,
+                continue_decode_max_steps=max_decode_steps,
+            )
+            self._pre_async_results.next_tokens_in_tpu = next_tokens_in_tpu
+
+            model_runner_output = ModelRunnerOutput(
+                req_ids=cast(list[str], self.input_batch.req_ids[:num_reqs]),
+                req_id_to_index=self.input_batch.req_id_to_index.copy(),
+                sampled_token_ids=[],
+                logprobs=None,
+                prompt_logprobs_dict={},
+                pooler_output=[],
+                kv_connector_output=kv_connector_output,
+            )
+
+            async_output = AsyncTPUModelRunnerOutput(
+                model_runner_output,
+                generated_tokens_async,
+                num_reqs,
+                [],
+                logits_indices_selector=tokens_indices_selector,
+                logprobs_tensors=logprobs_tensors,
+                expert_indices=all_expert_indices,
+                scheduler_output=scheduler_output,
+                runner=self,
+            )
+            async_output._is_continue_decode = True
+            async_output._actual_steps_future = actual_steps_async
+            self._continue_decode_output = async_output
+            return None
         self.rng_params_for_sampling = final_rng
 
         self.kv_caches = final_kv_caches
@@ -2697,19 +2943,21 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                 all_token_indices_to_substitute.extend(cur_indices)
                 all_pre_next_tokens_indices.extend(pre_indices)
 
-            if self.scheduler_config.async_scheduling and self._pre_async_results:
-                if self.speculative_config:
-                    next_tokens = self._pre_async_results.spec_decode_next_tokens
-                else:
-                    next_tokens = self._pre_async_results.next_tokens
-                token_in_tpu_cur_input_indices = np.array(
-                    all_token_indices_to_substitute)
-                token_in_tpu_pre_next_tokens_indices = np.array(
-                    all_pre_next_tokens_indices)
+            if self.speculative_config:
+                next_tokens = self._pre_async_results.spec_decode_next_tokens
+            elif getattr(self._pre_async_results, "next_tokens_in_tpu",
+                         None) is not None:
+                next_tokens = self._pre_async_results.next_tokens_in_tpu
+            else:
+                next_tokens = self._pre_async_results.next_tokens
+            token_in_tpu_cur_input_indices = np.array(
+                all_token_indices_to_substitute)
+            token_in_tpu_pre_next_tokens_indices = np.array(
+                all_pre_next_tokens_indices)
 
-                input_ids = self._apply_async_token_substitution(
-                    input_ids, next_tokens, token_in_tpu_cur_input_indices,
-                    token_in_tpu_pre_next_tokens_indices)
+            input_ids = self._apply_async_token_substitution(
+                input_ids, next_tokens, token_in_tpu_cur_input_indices,
+                token_in_tpu_pre_next_tokens_indices)
 
         num_scheduled_tokens_per_req = np.concatenate([
             np.array(scheduled_tokens_per_dp_rank[dp_rank], dtype=np.int32)

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -150,12 +150,18 @@ def _extract_valid_tokens_host(
     eos_token_id: Union[int, List[int], np.ndarray],
 ) -> List[int]:
     """Trim 1D array of generated token IDs at the first EOS token (inclusive)."""
-    eos_arr = np.atleast_1d(eos_token_id)
-    is_eos = np.any(tokens[:, None] == eos_arr[None, :], axis=-1)
+    is_eos = np.isin(tokens, eos_token_id)
     eos_indices = np.where(is_eos)[0]
     if len(eos_indices) > 0:
         return tokens[:eos_indices[0] + 1].tolist()
     return tokens.tolist()
+
+
+REASON_EOS_HIT = "eos_hit"
+REASON_MAX_STEPS = "max_steps"
+REASON_MAX_DECODE_STEPS_LIMIT = "max_decode_steps_limit"
+REASON_KV_CACHE_LIMIT = "kv_cache_limit"
+REASON_UNKNOWN = "unknown"
 
 
 def _log_continue_decode_summary(
@@ -167,16 +173,16 @@ def _log_continue_decode_summary(
     num_eos_hits: int,
 ) -> None:
     """Log debug summary for continue_decode completion."""
-    termination_reason = "unknown"
+    termination_reason = REASON_UNKNOWN
     if actual_steps < max_decode_steps:
-        termination_reason = "eos_hit"
+        termination_reason = REASON_EOS_HIT
     elif actual_steps == max_decode_steps:
         reasons = []
         if max_decode_steps == static_max_decode_steps:
-            reasons.append("max_decode_steps_limit")
+            reasons.append(REASON_MAX_DECODE_STEPS_LIMIT)
         if max_decode_steps == min_remaining or min_remaining <= 0:
-            reasons.append("kv_cache_limit")
-        termination_reason = "_".join(reasons) if reasons else "max_steps"
+            reasons.append(REASON_KV_CACHE_LIMIT)
+        termination_reason = "_".join(reasons) if reasons else REASON_MAX_STEPS
 
     logger.debug(
         "continue_decode finished: actual steps: %d, reason: %s, initial_active_reqs: %d (max_steps: %d, EOS hits: %d)",
@@ -194,7 +200,7 @@ def _process_continue_decode_outputs(
     expert_indices: Optional[jax.Array] = None,
     enable_return_routed_experts: bool = False,
     requests: Optional[Dict[str, Any]] = None,
-    block_size: Optional[int] = None,
+    block_size: int = 0,
     scheduler_output: Optional["VllmSchedulerOutput"] = None,
     input_batch: Optional[Any] = None,
     max_num_reqs: int = 0,
@@ -209,43 +215,32 @@ def _process_continue_decode_outputs(
     updates input_batch, scheduler_output, and attn_metadata for synchronous
     runs.
     """
+    generated_tokens_cpu, actual_steps_cpu = jax.device_get(
+        (generated_tokens, actual_steps))
+
+    all_expert_indices_cpu = None
+    if expert_indices is not None:
+        all_expert_indices_cpu = jax.device_get(expert_indices)
+
+    lp_token_ids_cpu = None
+    lp_vals_cpu = None
+    lp_ranks_cpu = None
     if logprobs_tensors is not None:
         (
-            generated_tokens_cpu,
-            all_expert_indices_cpu,
-            actual_steps_cpu,
             lp_token_ids_cpu,
             lp_vals_cpu,
             lp_ranks_cpu,
         ) = jax.device_get((
-            generated_tokens,
-            expert_indices,
-            actual_steps,
             logprobs_tensors.logprob_token_ids,
             logprobs_tensors.logprobs,
             logprobs_tensors.selected_token_ranks,
         ))
-    elif expert_indices is not None:
-        generated_tokens_cpu, all_expert_indices_cpu, actual_steps_cpu = jax.device_get(
-            (generated_tokens, expert_indices, actual_steps))
-        lp_token_ids_cpu = None
-        lp_vals_cpu = None
-        lp_ranks_cpu = None
-    else:
-        generated_tokens_cpu, actual_steps_cpu = jax.device_get(
-            (generated_tokens, actual_steps))
-        all_expert_indices_cpu = None
-        lp_token_ids_cpu = None
-        lp_vals_cpu = None
-        lp_ranks_cpu = None
 
     actual_steps_int = int(actual_steps_cpu)
     generated_tokens_cpu = np.asarray(generated_tokens_cpu)[:actual_steps_int]
     if all_expert_indices_cpu is not None and enable_return_routed_experts:
         all_expert_indices_cpu = np.asarray(
             all_expert_indices_cpu)[:actual_steps_int]
-    else:
-        all_expert_indices_cpu = None
 
     if lp_token_ids_cpu is not None:
         lp_token_ids_cpu = np.asarray(lp_token_ids_cpu)[:actual_steps_int]
@@ -271,10 +266,12 @@ def _process_continue_decode_outputs(
     lp_ranks_list = []
     num_eos_hits = 0
     eos_arr = np.atleast_1d(eos_token_id)
+    requests_dict = requests if requests is not None and hasattr(
+        requests, "get") else None
 
     for req_idx, req_id in enumerate(req_ids):
-        req_state = requests.get(req_id) if (
-            requests is not None and hasattr(requests, "get")) else None
+        req_state = requests_dict.get(
+            req_id) if requests_dict is not None else None
         tokens = generated_tokens_cpu[req_idx]
 
         valid_tokens = _extract_valid_tokens_host(tokens, eos_token_id)
@@ -292,7 +289,15 @@ def _process_continue_decode_outputs(
             req_experts = all_expert_indices_cpu[:actual_len, :, req_idx, :]
             expert_indices_list.append(req_experts.transpose(1, 0, 2))
 
-            if req_state is not None and actual_len > 0 and block_size is not None:
+        if lp_token_ids_cpu is not None:
+            lp_token_ids_list.append(lp_token_ids_cpu[:actual_len, req_idx])
+            lp_vals_list.append(lp_vals_cpu[:actual_len, req_idx])
+            lp_ranks_list.append(lp_ranks_cpu[:actual_len, req_idx])
+
+        if req_state is not None:
+            req_state.output_token_ids.extend(valid_tokens)
+
+            if (all_expert_indices_cpu is not None and actual_len > 0):
                 slots_arr = _reconstruct_slots_for_request(
                     req_state,
                     actual_len,
@@ -300,20 +305,14 @@ def _process_continue_decode_outputs(
                     start_pos=req_state.num_computed_tokens)
                 expert_slots_list.append(slots_arr)
 
-        if lp_token_ids_cpu is not None:
-            lp_token_ids_list.append(lp_token_ids_cpu[:actual_len, req_idx])
-            lp_vals_list.append(lp_vals_cpu[:actual_len, req_idx])
-            lp_ranks_list.append(lp_ranks_cpu[:actual_len, req_idx])
-
-        if input_batch is not None and req_state is not None:
-            start_idx = input_batch.num_tokens_no_spec[req_idx]
-            end_idx = start_idx + actual_len
-            if req_idx < max_num_reqs and end_idx <= max_model_len:
-                input_batch.token_ids_cpu[req_idx,
-                                          start_idx:end_idx] = valid_tokens
-                input_batch.num_tokens_no_spec[req_idx] = end_idx
-                input_batch.num_tokens[req_idx] = end_idx
-                req_state.output_token_ids.extend(valid_tokens)
+            if input_batch is not None:
+                start_idx = input_batch.num_tokens_no_spec[req_idx]
+                end_idx = start_idx + actual_len
+                if req_idx < max_num_reqs and end_idx <= max_model_len:
+                    input_batch.token_ids_cpu[req_idx,
+                                              start_idx:end_idx] = valid_tokens
+                    input_batch.num_tokens_no_spec[req_idx] = end_idx
+                    input_batch.num_tokens[req_idx] = end_idx
 
         if (attn_metadata is not None
                 and hasattr(attn_metadata, "seq_lens_cpu")
@@ -419,7 +418,7 @@ class AsyncTPUModelRunnerOutput(AsyncModelRunnerOutput):
                 self._runner.model_config, "enable_return_routed_experts",
                 False) if self._runner else False,
             requests=getattr(self._runner, "requests", None),
-            block_size=getattr(self._runner, "block_size", None),
+            block_size=getattr(self._runner, "block_size", 0),
             is_async=True,
         )
 

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -18,7 +18,7 @@ import random
 import sys
 from contextlib import nullcontext
 from dataclasses import dataclass
-from typing import Any, Callable, Dict, List, Optional, Tuple, cast
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union, cast
 
 import jax
 import jax.numpy as jnp
@@ -145,6 +145,213 @@ def _compute_active_mask(
     return active_mask
 
 
+def _extract_valid_tokens_host(
+    tokens: np.ndarray,
+    eos_token_id: Union[int, List[int], np.ndarray],
+) -> List[int]:
+    """Trim 1D array of generated token IDs at the first EOS token (inclusive)."""
+    eos_arr = np.atleast_1d(eos_token_id)
+    is_eos = np.any(tokens[:, None] == eos_arr[None, :], axis=-1)
+    eos_indices = np.where(is_eos)[0]
+    if len(eos_indices) > 0:
+        return tokens[:eos_indices[0] + 1].tolist()
+    return tokens.tolist()
+
+
+def _log_continue_decode_summary(
+    actual_steps: int,
+    max_decode_steps: int,
+    static_max_decode_steps: int,
+    min_remaining: int,
+    num_reqs: int,
+    num_eos_hits: int,
+) -> None:
+    """Log debug summary for continue_decode completion."""
+    termination_reason = "unknown"
+    if actual_steps < max_decode_steps:
+        termination_reason = "eos_hit"
+    elif actual_steps == max_decode_steps:
+        reasons = []
+        if max_decode_steps == static_max_decode_steps:
+            reasons.append("max_decode_steps_limit")
+        if max_decode_steps == min_remaining or min_remaining <= 0:
+            reasons.append("kv_cache_limit")
+        termination_reason = "_".join(reasons) if reasons else "max_steps"
+
+    logger.debug(
+        "continue_decode finished: actual steps: %d, reason: %s, initial_active_reqs: %d (max_steps: %d, EOS hits: %d)",
+        actual_steps, termination_reason, num_reqs, max_decode_steps,
+        num_eos_hits)
+
+
+def _process_continue_decode_outputs(
+    generated_tokens: jax.Array,
+    actual_steps: Union[jax.Array, int],
+    req_ids: List[str],
+    eos_token_id: Union[int, List[int], np.ndarray],
+    indices_selector: Optional[List[int]] = None,
+    logprobs_tensors: Optional[LogprobsTensors] = None,
+    expert_indices: Optional[jax.Array] = None,
+    enable_return_routed_experts: bool = False,
+    requests: Optional[Dict[str, Any]] = None,
+    block_size: Optional[int] = None,
+    scheduler_output: Optional["VllmSchedulerOutput"] = None,
+    input_batch: Optional[Any] = None,
+    max_num_reqs: int = 0,
+    max_model_len: int = 0,
+    attn_metadata: Optional[Any] = None,
+    is_async: bool = False,
+) -> Tuple[List[List[int]], Optional[Any], Optional[Any], int, int]:
+    """Process continue_decode TPU outputs into CPU data structures.
+
+    Performs host transfers, realigns physical rows by indices_selector, trims
+    tokens at EOS, and builds LogprobsLists and RoutedExpertsLists. Optionally
+    updates input_batch, scheduler_output, and attn_metadata for synchronous
+    runs.
+    """
+    if logprobs_tensors is not None:
+        (
+            generated_tokens_cpu,
+            all_expert_indices_cpu,
+            actual_steps_cpu,
+            lp_token_ids_cpu,
+            lp_vals_cpu,
+            lp_ranks_cpu,
+        ) = jax.device_get((
+            generated_tokens,
+            expert_indices,
+            actual_steps,
+            logprobs_tensors.logprob_token_ids,
+            logprobs_tensors.logprobs,
+            logprobs_tensors.selected_token_ranks,
+        ))
+    elif not is_async or expert_indices is not None:
+        generated_tokens_cpu, all_expert_indices_cpu, actual_steps_cpu = jax.device_get(
+            (generated_tokens, expert_indices, actual_steps))
+        lp_token_ids_cpu = None
+        lp_vals_cpu = None
+        lp_ranks_cpu = None
+    else:
+        generated_tokens_cpu, actual_steps_cpu = jax.device_get(
+            (generated_tokens, actual_steps))
+        all_expert_indices_cpu = None
+        lp_token_ids_cpu = None
+        lp_vals_cpu = None
+        lp_ranks_cpu = None
+
+    actual_steps_int = int(actual_steps_cpu)
+    generated_tokens_cpu = np.asarray(generated_tokens_cpu)[:actual_steps_int]
+    if all_expert_indices_cpu is not None and enable_return_routed_experts:
+        all_expert_indices_cpu = np.asarray(
+            all_expert_indices_cpu)[:actual_steps_int]
+    else:
+        all_expert_indices_cpu = None
+
+    if lp_token_ids_cpu is not None:
+        lp_token_ids_cpu = np.asarray(lp_token_ids_cpu)[:actual_steps_int]
+        lp_vals_cpu = np.asarray(lp_vals_cpu)[:actual_steps_int]
+        lp_ranks_cpu = np.asarray(lp_ranks_cpu)[:actual_steps_int]
+
+    generated_tokens_cpu = generated_tokens_cpu.T
+    if indices_selector is not None:
+        generated_tokens_cpu = generated_tokens_cpu[indices_selector]
+        if all_expert_indices_cpu is not None:
+            all_expert_indices_cpu = all_expert_indices_cpu[:, :,
+                                                            indices_selector, :]
+        if lp_token_ids_cpu is not None:
+            lp_token_ids_cpu = lp_token_ids_cpu[:, indices_selector, :]
+            lp_vals_cpu = lp_vals_cpu[:, indices_selector, :]
+            lp_ranks_cpu = lp_ranks_cpu[:, indices_selector]
+
+    sampled_token_ids: List[List[int]] = []
+    expert_indices_list = []
+    expert_slots_list = []
+    lp_token_ids_list = []
+    lp_vals_list = []
+    lp_ranks_list = []
+    num_eos_hits = 0
+    eos_arr = np.atleast_1d(eos_token_id)
+
+    for req_idx, req_id in enumerate(req_ids):
+        req_state = requests.get(req_id) if (
+            requests is not None and hasattr(requests, "get")) else None
+        tokens = generated_tokens_cpu[req_idx]
+
+        valid_tokens = _extract_valid_tokens_host(tokens, eos_token_id)
+        if len(valid_tokens) < len(tokens) or (valid_tokens and
+                                               valid_tokens[-1] in eos_arr):
+            num_eos_hits += 1
+
+        actual_len = len(valid_tokens)
+        sampled_token_ids.append(valid_tokens)
+
+        if scheduler_output is not None:
+            scheduler_output.num_scheduled_tokens[req_id] = actual_len
+
+        if all_expert_indices_cpu is not None:
+            req_experts = all_expert_indices_cpu[:actual_len, :, req_idx, :]
+            expert_indices_list.append(req_experts.transpose(1, 0, 2))
+
+            if req_state is not None and actual_len > 0 and block_size is not None:
+                slots_arr = _reconstruct_slots_for_request(
+                    req_state,
+                    actual_len,
+                    block_size,
+                    start_pos=req_state.num_computed_tokens)
+                expert_slots_list.append(slots_arr)
+
+        if lp_token_ids_cpu is not None:
+            lp_token_ids_list.append(lp_token_ids_cpu[:actual_len, req_idx])
+            lp_vals_list.append(lp_vals_cpu[:actual_len, req_idx])
+            lp_ranks_list.append(lp_ranks_cpu[:actual_len, req_idx])
+
+        if input_batch is not None and req_state is not None:
+            start_idx = input_batch.num_tokens_no_spec[req_idx]
+            end_idx = start_idx + actual_len
+            if req_idx < max_num_reqs and end_idx <= max_model_len:
+                input_batch.token_ids_cpu[req_idx,
+                                          start_idx:end_idx] = valid_tokens
+                input_batch.num_tokens_no_spec[req_idx] = end_idx
+                input_batch.num_tokens[req_idx] = end_idx
+                req_state.output_token_ids.extend(valid_tokens)
+
+        if (attn_metadata is not None
+                and hasattr(attn_metadata, "seq_lens_cpu")
+                and attn_metadata.seq_lens_cpu is not None):
+            attn_metadata.seq_lens_cpu[req_idx] += actual_len
+
+    expert_indices_cpu = None
+    if expert_indices_list:
+        expert_indices_cpu = np.concatenate(expert_indices_list, axis=1)
+
+    routed_experts = None
+    if expert_indices_cpu is not None and expert_slots_list:
+        routing_data = expert_indices_cpu.transpose(1, 0, 2)
+        slot_mapping = np.concatenate(expert_slots_list, axis=0)
+        routed_experts = RoutedExpertsLists(
+            routing_data=routing_data,
+            slot_mapping=slot_mapping,
+        )
+
+    logprobs_lists = None
+    if lp_token_ids_list:
+        from vllm.v1.outputs import LogprobsLists
+        logprob_token_ids = np.concatenate(lp_token_ids_list, axis=0)
+        logprobs_arr = np.concatenate(lp_vals_list, axis=0)
+        sampled_token_ranks = np.concatenate(lp_ranks_list, axis=0)
+        cu_num_generated_tokens = [0] + list(
+            np.cumsum([len(x) for x in sampled_token_ids]))
+
+        logprobs_lists = LogprobsLists(
+            logprob_token_ids=logprob_token_ids,
+            logprobs=logprobs_arr,
+            sampled_token_ranks=sampled_token_ranks,
+            cu_num_generated_tokens=cu_num_generated_tokens,
+        )
+
+    return sampled_token_ids, logprobs_lists, routed_experts, actual_steps_int, num_eos_hits
+
+
 class AsyncTPUModelRunnerOutput(AsyncModelRunnerOutput):
     """Holds asynchronous model output specifically from a TPU runner.
 
@@ -195,107 +402,43 @@ class AsyncTPUModelRunnerOutput(AsyncModelRunnerOutput):
             return self._model_runner_output
 
         (
-            generated_tokens_cpu,
+            sampled_token_ids,
+            logprobs,
+            routed_experts,
             actual_steps,
-        ) = jax.device_get((
-            self._next_tokens,
-            self._actual_steps_future,
-        ))
+            num_eos_hits,
+        ) = _process_continue_decode_outputs(
+            generated_tokens=self._next_tokens,
+            actual_steps=self._actual_steps_future,
+            req_ids=self._model_runner_output.req_ids,
+            eos_token_id=self._runner.eos_token_id if self._runner else 0,
+            indices_selector=self.logits_indices_selector,
+            logprobs_tensors=self._logprobs_tensors,
+            expert_indices=self._expert_indices,
+            enable_return_routed_experts=getattr(
+                self._runner.model_config, "enable_return_routed_experts",
+                False) if self._runner else False,
+            requests=getattr(self._runner, "requests", None),
+            block_size=getattr(self._runner, "block_size", None),
+            is_async=True,
+        )
 
-        actual_steps = int(actual_steps)
-        generated_tokens_cpu = np.asarray(
-            generated_tokens_cpu)[:actual_steps].T
-        if self.logits_indices_selector is not None:
-            generated_tokens_cpu = generated_tokens_cpu[
-                self.logits_indices_selector]
-
-        sampled_token_ids = []
-        for req_idx, req_id in enumerate(self._model_runner_output.req_ids):
-            tokens = generated_tokens_cpu[req_idx]
-            eos_arr = np.atleast_1d(self._runner.eos_token_id)
-            is_eos = np.any(tokens[:, None] == eos_arr[None, :], axis=-1)
-            eos_indices = np.where(is_eos)[0]
-            if len(eos_indices) > 0:
-                valid_tokens = tokens[:eos_indices[0] + 1].tolist()
-            else:
-                valid_tokens = tokens.tolist()
-            sampled_token_ids.append(valid_tokens)
+        _log_continue_decode_summary(
+            actual_steps=actual_steps,
+            max_decode_steps=getattr(self, "_max_decode_steps", 0),
+            static_max_decode_steps=getattr(self._runner,
+                                            "static_max_decode_steps", 0)
+            if self._runner else 0,
+            min_remaining=getattr(self, "_min_remaining", 0),
+            num_reqs=len(self._model_runner_output.req_ids),
+            num_eos_hits=num_eos_hits,
+        )
 
         self._model_runner_output.sampled_token_ids = sampled_token_ids
-
-        if self._logprobs_tensors is not None:
-            lp_token_ids_cpu, lp_vals_cpu, lp_ranks_cpu = jax.device_get((
-                self._logprobs_tensors.logprob_token_ids,
-                self._logprobs_tensors.logprobs,
-                self._logprobs_tensors.selected_token_ranks,
-            ))
-            if lp_token_ids_cpu is not None:
-                lp_token_ids_cpu = np.asarray(lp_token_ids_cpu)[:actual_steps]
-                lp_vals_cpu = np.asarray(lp_vals_cpu)[:actual_steps]
-                lp_ranks_cpu = np.asarray(lp_ranks_cpu)[:actual_steps]
-                if self.logits_indices_selector is not None:
-                    lp_token_ids_cpu = lp_token_ids_cpu[:, self.
-                                                        logits_indices_selector, :]
-                    lp_vals_cpu = lp_vals_cpu[:,
-                                              self.logits_indices_selector, :]
-                    lp_ranks_cpu = lp_ranks_cpu[:,
-                                                self.logits_indices_selector]
-                lp_token_ids_list, lp_vals_list, lp_ranks_list = [], [], []
-                for req_idx in range(len(self._model_runner_output.req_ids)):
-                    actual_len = len(sampled_token_ids[req_idx])
-                    lp_token_ids_list.append(lp_token_ids_cpu[:actual_len,
-                                                              req_idx])
-                    lp_vals_list.append(lp_vals_cpu[:actual_len, req_idx])
-                    lp_ranks_list.append(lp_ranks_cpu[:actual_len, req_idx])
-                if lp_token_ids_list:
-                    from vllm.v1.outputs import LogprobsLists
-                    logprob_token_ids = np.concatenate(lp_token_ids_list,
-                                                       axis=0)
-                    logprobs_arr = np.concatenate(lp_vals_list, axis=0)
-                    sampled_token_ranks = np.concatenate(lp_ranks_list, axis=0)
-                    cu_num_generated_tokens = [0] + list(
-                        np.cumsum([len(x) for x in sampled_token_ids]))
-                    self._model_runner_output.logprobs = LogprobsLists(
-                        logprob_token_ids=logprob_token_ids,
-                        logprobs=logprobs_arr,
-                        sampled_token_ranks=sampled_token_ranks,
-                        cu_num_generated_tokens=cu_num_generated_tokens,
-                    )
-
-        if self._runner.model_config.enable_return_routed_experts and self._expert_indices is not None:
-            all_expert_indices_cpu = np.asarray(
-                jax.device_get(self._expert_indices))
-            if all_expert_indices_cpu is not None and self._scheduler_output is not None:
-                all_expert_indices_cpu = all_expert_indices_cpu[:actual_steps]
-                if self.logits_indices_selector is not None:
-                    all_expert_indices_cpu = all_expert_indices_cpu[:, :, self.
-                                                                    logits_indices_selector, :]
-                expert_indices_list = []
-                expert_slots_list = []
-                for req_idx, req_id in enumerate(
-                        self._model_runner_output.req_ids):
-                    req_state = self._runner.requests.get(req_id)
-                    actual_len = len(sampled_token_ids[req_idx])
-                    if actual_len > 0:
-                        req_experts = all_expert_indices_cpu[:actual_len, :,
-                                                             req_idx, :]
-                        expert_indices_list.append(
-                            req_experts.transpose(1, 0, 2))
-                        if req_state is not None:
-                            slots_arr = _reconstruct_slots_for_request(
-                                req_state,
-                                actual_len,
-                                self._runner.block_size,
-                                start_pos=req_state.num_computed_tokens)
-                            expert_slots_list.append(slots_arr)
-                if expert_indices_list and expert_slots_list:
-                    routing_data = np.concatenate(expert_indices_list,
-                                                  axis=1).transpose(1, 0, 2)
-                    slot_mapping = np.concatenate(expert_slots_list, axis=0)
-                    self._model_runner_output.routed_experts = RoutedExpertsLists(
-                        routing_data=routing_data,
-                        slot_mapping=slot_mapping,
-                    )
+        if logprobs is not None:
+            self._model_runner_output.logprobs = logprobs
+        if routed_experts is not None:
+            self._model_runner_output.routed_experts = routed_experts
 
         return self._model_runner_output
 
@@ -1268,13 +1411,8 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                 req_idx = self.input_batch.req_id_to_index[req_id]
 
                 tokens = generated_tokens_cpu[pre_req_idx]
-                eos_arr = np.atleast_1d(self.eos_token_id)
-                is_eos = np.any(tokens[:, None] == eos_arr[None, :], axis=-1)
-                eos_indices = np.where(is_eos)[0]
-                if len(eos_indices) > 0:
-                    valid_tokens = tokens[:eos_indices[0] + 1].tolist()
-                else:
-                    valid_tokens = tokens.tolist()
+                valid_tokens = _extract_valid_tokens_host(
+                    tokens, self.eos_token_id)
 
                 start_idx = self.input_batch.num_tokens_no_spec[req_idx]
                 actual_len = len(valid_tokens)
@@ -1750,8 +1888,11 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             )
             async_output._is_continue_decode = True
             async_output._actual_steps_future = actual_steps_async
+            async_output._max_decode_steps = max_decode_steps
+            async_output._min_remaining = min_remaining
             self._continue_decode_output = async_output
             return None
+
         self.rng_params_for_sampling = final_rng
 
         self.kv_caches = final_kv_caches
@@ -1759,179 +1900,41 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         # continue_decode now returns fixed-size stacked buffers plus the
         # number of steps actually executed (early EOS exit can stop before
         # the cap). This is the single, end-of-run host transfer.
-        if logprobs_tensors is not None:
-            (
-                generated_tokens_cpu,
-                all_expert_indices_cpu,
-                actual_steps,
-                lp_token_ids_cpu,
-                lp_vals_cpu,
-                lp_ranks_cpu,
-            ) = jax.device_get((
-                generated_tokens,
-                all_expert_indices,
-                final_state.step_counter,
-                logprobs_tensors.logprob_token_ids,
-                logprobs_tensors.logprobs,
-                logprobs_tensors.selected_token_ranks,
-            ))
-        else:
-            generated_tokens_cpu, all_expert_indices_cpu, actual_steps = jax.device_get(
-                (generated_tokens, all_expert_indices,
-                 final_state.step_counter))
-            lp_token_ids_cpu = None
-            lp_vals_cpu = None
-            lp_ranks_cpu = None
-
-        actual_steps = int(actual_steps)
-        generated_tokens_cpu = np.asarray(generated_tokens_cpu)[:actual_steps]
-        if all_expert_indices_cpu is not None:
-            all_expert_indices_cpu = np.asarray(
-                all_expert_indices_cpu)[:actual_steps]
-
-        if lp_token_ids_cpu is not None:
-            lp_token_ids_cpu = np.asarray(lp_token_ids_cpu)[:actual_steps]
-            lp_vals_cpu = np.asarray(lp_vals_cpu)[:actual_steps]
-            lp_ranks_cpu = np.asarray(lp_ranks_cpu)[:actual_steps]
-
-        # Expose request dimension as axis 0 after transpose: shape (batch_size, actual_steps)
-        generated_tokens_cpu = generated_tokens_cpu.T
-        if tokens_indices_selector is not None:
-            # Realign physical rows back to logical input batch order upfront
-            generated_tokens_cpu = generated_tokens_cpu[
-                tokens_indices_selector]
-
-            if all_expert_indices_cpu is not None:
-                # Shape: (steps, layers, batch, top_k) -> realign batch dimension
-                all_expert_indices_cpu = all_expert_indices_cpu[:, :,
-                                                                tokens_indices_selector, :]
-
-            if lp_token_ids_cpu is not None:
-                lp_token_ids_cpu = lp_token_ids_cpu[:,
-                                                    tokens_indices_selector, :]
-                lp_vals_cpu = lp_vals_cpu[:, tokens_indices_selector, :]
-                lp_ranks_cpu = lp_ranks_cpu[:, tokens_indices_selector]
+        (
+            sampled_token_ids,
+            logprobs_lists,
+            routed_experts,
+            actual_steps,
+            num_eos_hits,
+        ) = _process_continue_decode_outputs(
+            generated_tokens=generated_tokens,
+            actual_steps=final_state.step_counter,
+            req_ids=self.input_batch.req_ids[:self.input_batch.num_reqs],
+            eos_token_id=self.eos_token_id,
+            indices_selector=tokens_indices_selector,
+            logprobs_tensors=logprobs_tensors,
+            expert_indices=all_expert_indices,
+            enable_return_routed_experts=getattr(
+                self.vllm_config.model_config, "enable_return_routed_experts",
+                False),
+            requests=self.requests,
+            block_size=self.block_size,
+            scheduler_output=scheduler_output,
+            input_batch=self.input_batch,
+            max_num_reqs=self.max_num_reqs,
+            max_model_len=self.max_model_len,
+            attn_metadata=attn_metadata,
+        )
 
         num_reqs = self.input_batch.num_reqs
-        sampled_token_ids = []
-        expert_indices_list = []
-        expert_slots_list = []
-        lp_token_ids_list = []
-        lp_vals_list = []
-        lp_ranks_list = []
-        num_eos_hits = 0
-
-        for req_idx, req_id in enumerate(self.input_batch.req_ids[:num_reqs]):
-            req_state = self.requests.get(req_id)
-            tokens = generated_tokens_cpu[req_idx]
-
-            eos_arr = np.atleast_1d(self.eos_token_id)
-            is_eos = np.any(tokens[:, None] == eos_arr[None, :], axis=-1)
-            eos_indices = np.where(is_eos)[0]
-            if len(eos_indices) > 0:
-                num_eos_hits += 1
-                first_eos_idx = eos_indices[0]
-                valid_tokens = tokens[:first_eos_idx + 1].tolist()
-            else:
-                valid_tokens = tokens.tolist()
-
-            actual_len = len(valid_tokens)
-            sampled_token_ids.append(valid_tokens)
-
-            # 2. Update scheduler_output directly to the true trimmed length
-            scheduler_output.num_scheduled_tokens[req_id] = actual_len
-
-            # 3. Extract exact valid expert indices for this request
-            if all_expert_indices_cpu is not None:
-                # Slice to (actual_len, layers, top_k)
-                req_experts = all_expert_indices_cpu[:actual_len, :,
-                                                     req_idx, :]
-                # Transpose to (layers, actual_len, top_k) and collect
-                expert_indices_list.append(req_experts.transpose(1, 0, 2))
-
-                # Reconstruct slots for this request. The on-device decode
-                # burst length (actual_len) is decided on-device via EOS
-                # early-exit and is not reflected in num_computed_tokens, so the
-                # burst's tokens begin at num_computed_tokens.
-                if req_state is not None and actual_len > 0:
-                    slots_arr = _reconstruct_slots_for_request(
-                        req_state,
-                        actual_len,
-                        self.block_size,
-                        start_pos=req_state.num_computed_tokens)
-                    expert_slots_list.append(slots_arr)
-
-            if lp_token_ids_cpu is not None:
-                # Shape: [actual_len, max_logprobs + 1]
-                req_lp_token_ids = lp_token_ids_cpu[:actual_len, req_idx]
-                req_lp_vals = lp_vals_cpu[:actual_len, req_idx]
-                # Shape: [actual_len]
-                req_lp_ranks = lp_ranks_cpu[:actual_len, req_idx]
-
-                lp_token_ids_list.append(req_lp_token_ids)
-                lp_vals_list.append(req_lp_vals)
-                lp_ranks_list.append(req_lp_ranks)
-
-            if req_state is not None:
-                start_idx = self.input_batch.num_tokens_no_spec[req_idx]
-                end_idx = start_idx + len(valid_tokens)
-                if req_idx < self.max_num_reqs and end_idx <= self.max_model_len:
-                    self.input_batch.token_ids_cpu[
-                        req_idx, start_idx:end_idx] = valid_tokens
-                    self.input_batch.num_tokens_no_spec[req_idx] = end_idx
-                    self.input_batch.num_tokens[req_idx] = end_idx
-                    req_state.output_token_ids.extend(valid_tokens)
-
-            if hasattr(
-                    attn_metadata,
-                    "seq_lens_cpu") and attn_metadata.seq_lens_cpu is not None:
-                attn_metadata.seq_lens_cpu[req_idx] += len(valid_tokens)
-
-        # 4. Concatenate along the token dimension (axis 1)
-        expert_indices_cpu = None
-        if expert_indices_list:
-            expert_indices_cpu = np.concatenate(expert_indices_list, axis=1)
-
-        routed_experts = None
-        if expert_indices_cpu is not None and expert_slots_list:
-            routing_data = expert_indices_cpu.transpose(1, 0, 2)
-            slot_mapping = np.concatenate(expert_slots_list, axis=0)
-            routed_experts = RoutedExpertsLists(
-                routing_data=routing_data,
-                slot_mapping=slot_mapping,
-            )
-
-        logprobs_lists = None
-        if lp_token_ids_list:
-            logprob_token_ids = np.concatenate(lp_token_ids_list, axis=0)
-            logprobs_arr = np.concatenate(lp_vals_list, axis=0)
-            sampled_token_ranks = np.concatenate(lp_ranks_list, axis=0)
-            cu_num_generated_tokens = [0] + list(
-                np.cumsum([len(x) for x in sampled_token_ids]))
-
-            from vllm.v1.outputs import LogprobsLists
-            logprobs_lists = LogprobsLists(
-                logprob_token_ids=logprob_token_ids,
-                logprobs=logprobs_arr,
-                sampled_token_ranks=sampled_token_ranks,
-                cu_num_generated_tokens=cu_num_generated_tokens,
-            )
-
-        termination_reason = "unknown"
-        if actual_steps < max_decode_steps:
-            termination_reason = "eos_hit"
-        elif actual_steps == max_decode_steps:
-            reasons = []
-            if max_decode_steps == self.static_max_decode_steps:
-                reasons.append("max_decode_steps_limit")
-            if max_decode_steps == min_remaining or min_remaining <= 0:
-                reasons.append("kv_cache_limit")
-            termination_reason = "_".join(reasons) if reasons else "max_steps"
-
-        logger.debug(
-            "continue_decode finished: actual steps: %d, reason: %s, initial_active_reqs: %d (max_steps: %d, EOS hits: %d)",
-            actual_steps, termination_reason, num_reqs, max_decode_steps,
-            num_eos_hits)
+        _log_continue_decode_summary(
+            actual_steps=actual_steps,
+            max_decode_steps=max_decode_steps,
+            static_max_decode_steps=self.static_max_decode_steps,
+            min_remaining=min_remaining,
+            num_reqs=num_reqs,
+            num_eos_hits=num_eos_hits,
+        )
 
         output = ModelRunnerOutput(
             req_ids=self.input_batch.req_ids[:num_reqs],

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -1815,16 +1815,11 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             self.rng_params_for_sampling = final_rng
             self.kv_caches = final_kv_caches
 
-            if hasattr(final_state, "step_counter") and type(
-                    final_state.step_counter).__name__ != "MagicMock":
-                last_step_idx = jnp.clip(final_state.step_counter - 1, 0,
-                                         self.static_max_decode_steps - 1)
-                next_tokens_in_tpu = generated_tokens[
-                    last_step_idx,
-                    jnp.arange(generated_tokens.shape[1])]
-            else:
-                next_tokens_in_tpu = generated_tokens[0] if hasattr(
-                    generated_tokens, "shape") else None
+            last_step_idx = jnp.clip(final_state.step_counter - 1, 0,
+                                     self.static_max_decode_steps - 1)
+            next_tokens_in_tpu = generated_tokens[
+                last_step_idx,
+                jnp.arange(generated_tokens.shape[1])]
 
             generated_tokens_async = jax.copy_to_host_async(generated_tokens)
             actual_steps_async = jax.copy_to_host_async(

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -225,7 +225,7 @@ def _process_continue_decode_outputs(
             logprobs_tensors.logprobs,
             logprobs_tensors.selected_token_ranks,
         ))
-    elif not is_async or expert_indices is not None:
+    elif expert_indices is not None:
         generated_tokens_cpu, all_expert_indices_cpu, actual_steps_cpu = jax.device_get(
             (generated_tokens, expert_indices, actual_steps))
         lp_token_ids_cpu = None


### PR DESCRIPTION
# Description

## Summary & Motivation

### Problem Statement & Motivation
While the synchronous multi-step `continue_decode` mechanism (PR #2507) reduced host-device sync round-trips by running up to `max_decode_steps` inside a compiled JAX loop on TPU, it still required synchronous blocking calls (`jax.device_get`) on the main thread at the end of each multi-step batch. 

When vLLM's **async scheduling** (`AsyncScheduler` / `--async-scheduling`) is enabled, host-side CPU execution (scheduling next batches, processing ZMQ IPC) and TPU-side device execution should run in parallel without blocking the main execution thread. Previously, `continue_decode` was restricted to synchronous scheduler mode.

### Technical Solution (`Async Continue Decode`)
This PR extends `continue_decode` multi-step execution to support vLLM's `AsyncScheduler`. It enables **asynchronous, non-blocking execution of multi-step decode loops**, allowing the host CPU to schedule subsequent engine iterations while TPU device execution and output transfers proceed asynchronously in the background.

```
[Sync Continue Decode]
Host:    [Schedule Multi-Step] ──(IPC)──> TPU: [Execute Step Loop] ──(Blocking Sync)──> Host: [Process Outputs]

[Async Continue Decode]
Host:    [Schedule Multi-Step] ──(IPC)──> TPU: [Execute Step Loop Async]
Host:    [Schedule Next Batch Concurrent] ──> TPU: [Process Outputs Deferred when needed]
```

## Key Technical Changes

### 1. Extended Asynchronous Model Runner Output (`AsyncTPUModelRunnerOutput` & `AsyncPreResults`)
- Extends existing `AsyncTPUModelRunnerOutput` in `tpu_runner.py` with `_is_continue_decode`, `_actual_steps_future`, and `_get_continue_decode_output()`.
- Updates `AsyncPreResults` to carry continue-decode async state (`is_continue_decode`, `continue_decode_actual_steps`, `continue_decode_max_steps`, `next_tokens_in_tpu`).
- Replaces synchronous host waiting (`jax.device_get`) with non-blocking device array futures (`generated_tokens_async`, `actual_steps_async`, `logprobs_tensors`, `all_expert_indices`).
- Defers host-side output slicing, token array transposition, and MoE expert reconstruction until `get_output()` is explicitly invoked by the engine.

### 2. Refactored Output Post-Processing (`tpu_runner.py`)
- Modularizes continue-decode output handling into `_process_continue_decode_outputs()` and `_log_continue_decode_summary()`.
- Supports deferred extraction of sampled token IDs, logprobs lists (`LogprobsLists`), and MoE routed experts lists (`RoutedExpertsLists`) for both sync and async execution paths.

### 3. Asynchronous Token Substitution & Async Scheduler Patching (`dp_scheduler.py` & `utils.py`)
- Updates `patch_vllm_scheduler_for_continue_decode()` in `tpu_inference/core/sched/utils.py` to seamlessly handle `AsyncScheduler` and `AsyncSchedulerOutput`.
- Updates `DPScheduler` (`tpu_inference/core/sched/dp_scheduler.py`) to correctly route and synchronize multi-step tokens across DP ranks when running under async scheduling mode.
- Adapts `_apply_async_token_substitution` in `TPUModelRunner` to handle token replacements when async results contain TPU device arrays (`next_tokens_in_tpu`).

# Tests

https://xprof.corp.google.com/trace_viewer/piv-14319787097360448698

Added comprehensive unit and integration tests:
  - `tests/core/test_dp_scheduler.py`: Tests `DPScheduler` handling under async continue-decode.
  - `tests/runner/test_tpu_runner.py`: Tests `AsyncTPUModelRunnerOutput` deferred continuation output extraction under `TPUModelRunner`.
  - `tests/e2e/test_continue_decode.py`: Validates end-to-end multi-step decode under async scheduling mode.

## Benchmarking

```
Standard decode 

To replicate server manually, run:
  VLLM_LOGGING_LEVEL=DEBUG TPU_MULTIPROCESS_DP=0 VLLM_XLA_CHECK_RECOMPILATION=1 MODEL_IMPL_TYPE=vllm vllm serve Qwen/Qwen3-0.6B --max-model-len=2048 --max-num-batched-tokens 2048 --max-num-seqs 256 --tensor-parallel-size 2 --data-parallel-size 4 --additional-config='{"enable_continue_decode": false, "max_decode_steps": 10}'

To replicate client manually, run:
  python /home/piv_google_com/tpu/tpu-inference/scripts/vllm/benchmarking/benchmark_serving.py --backend vllm --model Qwen/Qwen3-0.6B --dataset-name random --num-prompts 1000 --random-input-len 512 --random-output-len 512 --random-range-ratio=0.8

============ Serving Benchmark Result ============
Successful requests:                     1000
Benchmark duration (s):                  19.98
Total input tokens:                      510958
Total generated tokens:                  469103
Request throughput (req/s):              50.04
Output token throughput (tok/s):         23473.26
Total token throughput (tok/s):          49040.88
---------------Time to First Token----------------
Mean TTFT (ms):                          1940.88
Median TTFT (ms):                        1867.59
P99 TTFT (ms):                           2488.16
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          15.59
Median TPOT (ms):                        15.65
P99 TPOT (ms):                           17.85
---------------Inter-token Latency----------------
Mean ITL (ms):                           15.03
Median ITL (ms):                         14.47
P99 ITL (ms):                            27.62
----------------End-to-end Latency----------------
Mean E2EL (ms):                          8976.11
Median E2EL (ms):                        9225.61
P99 E2EL (ms):                           14330.23
==================================================


Continue decode

To replicate server manually, run:
  VLLM_LOGGING_LEVEL=DEBUG TPU_MULTIPROCESS_DP=0 VLLM_XLA_CHECK_RECOMPILATION=1 MODEL_IMPL_TYPE=vllm vllm serve Qwen/Qwen3-0.6B --max-model-len=2048 --max-num-batched-tokens 2048 --max-num-seqs 256 --tensor-parallel-size 2 --data-parallel-size 4 --additional-config='{"enable_continue_decode": true, "max_decode_steps": 10}'

To replicate client manually, run:
  python /home/piv_google_com/tpu/tpu-inference/scripts/vllm/benchmarking/benchmark_serving.py --backend vllm --model Qwen/Qwen3-0.6B --dataset-name random --num-prompts 1000 --random-input-len 512 --random-output-len 512 --random-range-ratio=0.8

============ Serving Benchmark Result ============
Successful requests:                     1000
Benchmark duration (s):                  11.32
Total input tokens:                      510958
Total generated tokens:                  468961
Request throughput (req/s):              88.30
Output token throughput (tok/s):         41409.80
Total token throughput (tok/s):          86527.98
---------------Time to First Token----------------
Mean TTFT (ms):                          2064.52
Median TTFT (ms):                        2039.03
P99 TTFT (ms):                           2678.12
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          12.73
Median TPOT (ms):                        12.39
P99 TPOT (ms):                           18.98
---------------Inter-token Latency----------------
Mean ITL (ms):                           70.60
Median ITL (ms):                         66.15
P99 ITL (ms):                            276.38
----------------End-to-end Latency----------------
Mean E2EL (ms):                          7530.71
Median E2EL (ms):                        7869.21
P99 E2EL (ms):                           11040.79
==================================================


Continue Decode, max 20 steps

To replicate server manually, run:
  VLLM_LOGGING_LEVEL=DEBUG TPU_MULTIPROCESS_DP=0 VLLM_XLA_CHECK_RECOMPILATION=1 MODEL_IMPL_TYPE=vllm vllm serve Qwen/Qwen3-0.6B --max-model-len=2048 --max-num-batched-tokens 2048 --max-num-seqs 256 --tensor-parallel-size 2 --data-parallel-size 4 --additional-config='{"enable_continue_decode": true, "max_decode_steps": 20}'

To replicate client manually, run:
  python /home/piv_google_com/tpu/tpu-inference/scripts/vllm/benchmarking/benchmark_serving.py --backend vllm --model Qwen/Qwen3-0.6B --dataset-name random --num-prompts 1000 --random-input-len 512 --random-output-len 512 --random-range-ratio=0.8

============ Serving Benchmark Result ============                                                                                                                                                                                      [ 5.20 6.28 6.25 ][ 2026-07-13 21:39 ]
Successful requests:                     1000
Benchmark duration (s):                  15.95
Total input tokens:                      510958
Total generated tokens:                  467168
Request throughput (req/s):              62.71
Output token throughput (tok/s):         29294.34
Total token throughput (tok/s):          61334.58
---------------Time to First Token----------------
Mean TTFT (ms):                          2816.65
Median TTFT (ms):                        2718.37
P99 TTFT (ms):                           3608.35
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          15.05
Median TPOT (ms):                        14.08
P99 TPOT (ms):                           26.14
---------------Inter-token Latency----------------
Mean ITL (ms):                           103.74
Median ITL (ms):                         38.72
P99 ITL (ms):                            892.19
----------------End-to-end Latency----------------
Mean E2EL (ms):                          9131.45
Median E2EL (ms):                        9105.38
P99 E2EL (ms):                           14876.07
==================================================
```


# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
