### PR TITLE
Dflash paged proposer

### DIFF
--- a/tests/spec_decode/test_dflash.py
+++ b/tests/spec_decode/test_dflash.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 """Unit tests for the JAX DFlash speculative decoding proposer."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import jax
 import jax.numpy as jnp
@@ -26,7 +26,11 @@ from tpu_inference.spec_decode.jax.dflash import DFlashProposer
 
 def _make_single_device_mesh() -> jax.sharding.Mesh:
     devices = np.array(jax.devices()[:1])
-    m = jax.sharding.Mesh(devices, axis_names=("model", ))
+    device_mesh = devices.reshape((1, 1, 1, 1))
+    m = jax.sharding.Mesh(
+        device_mesh,
+        axis_names=('data', 'attn_dp', 'expert', 'model'),
+    )
     return m
 
 
@@ -107,43 +111,65 @@ class MockDraftModelInterface:
 
 
 # ----- Existing Minimal Tests -----
-def test_sample_block_draft_tokens_uses_target_model_logits():
+def test_propose_uses_target_model_logits():
     proposer = object.__new__(DFlashProposer)
     proposer.mesh = _make_single_device_mesh()
     proposer.num_speculative_tokens = 2
+    proposer.block_size = proposer.num_speculative_tokens + 1  # 3
+
+    # mock model_fn to return a dummy hidden_states tensor
+    # shape: (num_reqs * block_size, hidden_size) = (1 * 3, 8) = (3, 8)
+    hidden_states = jnp.ones((3, 8), dtype=jnp.bfloat16)
+    proposer.model_fn = lambda state, kv_caches, input_ids, target_hidden_states, attn_metadata: (
+        kv_caches, hidden_states, None, None)
 
     call_record = {}
-    target_state = jnp.array(0)
 
     def fake_compute_logits_fn(state, hidden_states, lora_metadata):
         call_record["shape"] = hidden_states.shape
+        # return logits of shape (2, 3) (matching flattened 2 draft tokens, 3 vocab size)
         return jnp.array([[0.0, 2.0, 1.0], [4.0, 1.0, 0.0]], dtype=jnp.float32)
 
     proposer.compute_logits_fn = fake_compute_logits_fn
 
-    hidden_states = jnp.ones((3, 8), dtype=jnp.bfloat16)
-    draft_token_ids = proposer._sample_block_draft_tokens(
-        target_state, hidden_states)
+    # Call JITted _propose
+    _, draft_token_ids = proposer._propose(
+        state_leaves=None,
+        kv_caches=[],
+        input_ids=None,
+        attn_metadata=None,
+        target_hidden_states=None,
+    )
 
     np.testing.assert_array_equal(np.asarray(draft_token_ids),
-                                  np.array([1, 0], dtype=np.int32))
+                                  np.array([[1, 0]], dtype=np.int32))
     assert call_record["shape"] == (2, 8)
 
 
-def test_sample_block_draft_tokens_returns_1d_int_ids():
+def test_propose_returns_2d_int_ids():
     proposer = object.__new__(DFlashProposer)
     proposer.mesh = _make_single_device_mesh()
     proposer.num_speculative_tokens = 2
+    proposer.block_size = proposer.num_speculative_tokens + 1  # 3
+
+    hidden_states = jnp.ones((3, 4), dtype=jnp.bfloat16)
+    proposer.model_fn = lambda state, kv_caches, input_ids, target_hidden_states, attn_metadata: (
+        kv_caches, hidden_states, None, None)
 
     proposer.compute_logits_fn = lambda _state, _hidden, _lora: jnp.array(
         [[1.0, 0.0], [0.0, 1.0]], dtype=jnp.float32)
 
-    hidden_states = jnp.ones((3, 4), dtype=jnp.bfloat16)
-    draft_token_ids = proposer._sample_block_draft_tokens(
-        jnp.array(0), hidden_states)
+    # Call _propose
+    _, draft_token_ids = proposer._propose(
+        state_leaves=None,
+        kv_caches=[],
+        input_ids=None,
+        attn_metadata=None,
+        target_hidden_states=None,
+    )
 
-    assert draft_token_ids.ndim == 1
-    assert draft_token_ids.shape == (2, )
+    assert draft_token_ids.ndim == 2
+    assert draft_token_ids.shape == (1, 2)
     assert jnp.issubdtype(draft_token_ids.dtype, jnp.integer)
 
 
@@ -190,136 +216,28 @@ def test_build_noise_block(mesh):
                                   np.array([10, 11, 12], dtype=np.int32))
 
 
-@patch("tpu_inference.spec_decode.jax.dflash.get_model")
-def test_dflash_proposer_multi_iteration_state_flow(mock_get_model, mesh):
-    """Verifies DFlashProposer's entire state-tracking, cache cropping, and padding flow across multiple speculative iterations."""
-    vllm_config = MockVllmConfig()
-    runner = MockRunner(mesh)
+def test_build_noise_block_batched():
+    proposer = object.__new__(DFlashProposer)
 
-    mock_mi = MockDraftModelInterface()
-    # combine_hidden_states_fn acts as identity for simplicity
-    mock_mi.combine_hidden_states_fn = lambda state, raw: raw
-    mock_get_model.return_value = mock_mi
+    # 2 requests in batch
+    seq_lens = jnp.array([10, 20], dtype=jnp.int32)
+    next_token_ids = jnp.array([100, 200], dtype=jnp.int32)
+    mask_token_id = 0
+    block_size = 3
 
-    proposer = DFlashProposer(vllm_config, runner)
+    noise_ids, noise_positions = proposer._build_noise_block(
+        seq_lens, next_token_ids, mask_token_id, block_size)
 
-    with jax.set_mesh(mesh):
-        proposer.load_model(target_model=None)
+    # The output is expected to be flattened across the batch.
+    assert noise_ids.shape == (6, )
+    assert noise_positions.shape == (6, )
 
-    # Initial proposer state
-    assert proposer._ctx_len == 0
-    assert proposer._cache_len == 0
-    assert proposer._prev_seq_len == 0
-
-    # ----------------- ITERATION 1: Initial prefix accepted up to length 10 -----------------
-    from tpu_inference.layers.common.attention_metadata import \
-        AttentionMetadata
-    attn_metadata_1 = AttentionMetadata(
-        input_positions=jnp.array([0]),
-        block_tables=jnp.array([0]),
-        seq_lens=jnp.array([10], dtype=jnp.int32),
-        query_start_loc=jnp.array([0]),
-        request_distribution=jnp.array([0]),
-    )
-
-    input_ids = jnp.array([0])
-    aux_hidden_states_1 = (jnp.ones((10, 32), dtype=jnp.bfloat16), )
-    next_token_ids_1 = jnp.array([42], dtype=jnp.int32)
-
-    with jax.set_mesh(mesh):
-        target_hidden_1, noise_ids_1, _, draft_metadata_1 = proposer.prepare_inputs(
-            attn_metadata_1,
-            input_ids,
-            aux_hidden_states_1,
-            next_token_ids_1,
-        )
-
-    # Check outputs of Iteration 1
-    new_ctx_1, cache_len_arr_1, actual_ctx_count_arr_1 = target_hidden_1
-    # Padding size for 10 is 16
-    assert new_ctx_1.shape == (16, 32)
-    assert int(cache_len_arr_1[0]) == 0
-    assert int(actual_ctx_count_arr_1[0]) == 10
-
-    # Check proposer state updates
-    assert proposer._ctx_len == 10
-    assert proposer._prev_seq_len == 10
-
-    # Check draft proposer attention metadata sharding positions
-    assert noise_ids_1.shape == (proposer.block_size, )
+    # Check input ids are padded with mask_token_id correctly
     np.testing.assert_array_equal(
-        np.asarray(draft_metadata_1.query_start_loc),
-        np.array([0, proposer.block_size], dtype=np.int32),
-    )
+        np.asarray(noise_ids), np.array([100, 0, 0, 200, 0, 0],
+                                        dtype=np.int32))
 
-    # Mock proposer model forward pass and logits sampler
-    dummy_kv = [
-        jnp.zeros((1, 4, 128, 16), dtype=jnp.bfloat16)
-        for _ in range(proposer.num_layers * 2)
-    ]
-    proposer._draft_kv_caches = dummy_kv
-
-    # model_fn returns draft_kv_caches, hidden_states (5 tokens, 32 hidden_size), and None
-    mock_mi.model_fn.return_value = (
-        dummy_kv,
-        jnp.ones((5, 32), dtype=jnp.bfloat16),
-        None,
-    )
-    # compute_logits_fn returns logits for 4 speculative tokens, vocabulary size 1000
-    mock_mi.compute_logits_fn.return_value = jnp.ones((4, 1000),
-                                                      dtype=jnp.float32)
-
-    # Call propose for Iteration 1
-    with jax.set_mesh(mesh):
-        _, draft_token_ids_1 = proposer.propose(
-            kv_caches=[],
-            input_ids=input_ids,
-            attn_metadata=draft_metadata_1,
-            last_token_indices=jnp.zeros(1),
-            target_hidden_states=target_hidden_1,
-        )
-
-    assert draft_token_ids_1.shape == (1, 4)
-    # Cache length is updated to prefix (10) + block size (5) = 15
-    assert proposer._cache_len == 15
-
-    # ----------------- ITERATION 2: Speculative Rejection & Cache Cropping -----------------
-    # Suppose out of 4 proposed tokens, the target model accepts 3.
-    # Therefore, new accepted sequence length is 10 prefix + 3 accepted = 13.
-    attn_metadata_2 = AttentionMetadata(
-        input_positions=jnp.array([0]),
-        block_tables=jnp.array([0]),
-        seq_lens=jnp.array([13], dtype=jnp.int32),
-        query_start_loc=jnp.array([0]),
-        request_distribution=jnp.array([0]),
-    )
-
-    # Target model passes the accumulated auxiliary hidden states (now length 13)
-    aux_hidden_states_2 = (jnp.ones((13, 32), dtype=jnp.bfloat16), )
-    next_token_ids_2 = jnp.array([99], dtype=jnp.int32)
-
-    with jax.set_mesh(mesh):
-        target_hidden_2, noise_ids_2, _, _ = proposer.prepare_inputs(
-            attn_metadata_2,
-            input_ids,
-            aux_hidden_states_2,
-            next_token_ids_2,
-        )
-
-    # Check outputs of Iteration 2
-    new_ctx_2, cache_len_arr_2, actual_ctx_count_arr_2 = target_hidden_2
-
-    # CRITICAL: Verify cache cropping logic
-    # The cache length must be cropped back to the PREVIOUS sequence length (10),
-    # preserving the accepted prefix and discarding the rejected noise entries in [10, 15)
-    assert proposer._cache_len == 10
-    assert int(cache_len_arr_2[0]) == 10
-
-    # The proposer correctly identifies that 3 new context tokens need to be sharded
-    assert int(actual_ctx_count_arr_2[0]) == 3
-    # Padding size for 3 is 16
-    assert new_ctx_2.shape == (16, 32)
-
-    # Check proposer state updates
-    assert proposer._ctx_len == 13
-    assert proposer._prev_seq_len == 13
+    # Check absolute position assignments per request
+    np.testing.assert_array_equal(
+        np.asarray(noise_positions),
+        np.array([10, 11, 12, 20, 21, 22], dtype=np.int32))

--- a/tpu_inference/spec_decode/jax/dflash.py
+++ b/tpu_inference/spec_decode/jax/dflash.py
@@ -19,20 +19,50 @@ from typing import Any, Optional
 
 import jax
 import jax.numpy as jnp
-import numpy as np
 from flax import nnx
 from jax import lax
 from jax.sharding import NamedSharding, PartitionSpec
 from vllm.config import VllmConfig
 
-from tpu_inference import utils
 from tpu_inference.layers.common.attention_metadata import AttentionMetadata
 from tpu_inference.layers.common.sharding import ShardingAxisName
 from tpu_inference.logger import init_logger
 from tpu_inference.models.common.model_loader import get_model
-from tpu_inference.utils import device_array, get_mesh_shape_product
+from tpu_inference.utils import device_array
 
 logger = init_logger(__name__)
+
+DRAFT_EMBED_PATHS = [
+    "model.embed_tokens.weight", "model.embed.embedding",
+    "model.embed_tokens.embedding", "lm_head.embedding", "lm_head.weight"
+]
+
+TARGET_EMBED_PATHS = [
+    "model.embed_tokens.weight", "model.embed_tokens.embedding",
+    "model.embed.embedding", "embed_tokens.embedding", "embed.embedding"
+]
+
+DRAFT_LM_HEAD_PATHS = [
+    "lm_head.weight", "lm_head.kernel", "model.embed_tokens.weight",
+    "model.embed.embedding", "model.embed_tokens.embedding",
+    "lm_head.embedding"
+]
+
+TARGET_LM_HEAD_PATHS = [
+    "model.lm_head", "lm_head", "lm_head.weight", "lm_head.kernel",
+    "model.embed_tokens.weight", "model.embed.embedding",
+    "model.embed_tokens.embedding", "embed.embedding", "embed_tokens.embedding"
+]
+
+
+def _find_param(state: Any, paths: list[str]) -> Optional[Any]:
+    from tpu_inference.models.jax.utils.weight_utils import get_param
+    for path in paths:
+        try:
+            return get_param(state, path)
+        except ValueError:
+            continue
+    return None
 
 
 class DFlashProposer:
@@ -66,28 +96,16 @@ class DFlashProposer:
         self.max_num_tokens = runner.max_num_tokens
         self.max_model_len = runner.max_model_len
 
-        # Context length tracking (host-side counter)
-        self._ctx_len: int = 0
-
         # On-device KV caches (allocated in load_model)
         self._draft_kv_caches: Optional[list[jax.Array]] = None
-        self._cache_len: int = 0
         self._max_kv_len: int = 0
-
-        # Track previous seq_len for GPU-compatible crop semantics.
-        # GPU calls past_key_values_draft.crop(start) AFTER each forward
-        # pass, where start = beginning of the CURRENT iteration's block.
-        # This equals the seq_len from the PREVIOUS call to prepare_inputs.
-        # We must match this: cache_len = prev_seq_len, not current seq_len.
-        self._prev_seq_len: int = 0
-
-        # Track the request currently occupying the single proposer slot;
-        # state must be reset when it changes so the previous request's
-        # hidden states do not leak into the next request's prefix.
-        self._last_req_id: Optional[str] = None
 
     def load_model(self, target_model: Any) -> None:
         """Load the DFlash draft model and share embeddings from target."""
+        from tpu_inference import envs
+        from tpu_inference.models.common.model_loader import \
+            resolve_model_architecture
+
         draft_mi = get_model(self.vllm_config,
                              self.rng_key,
                              self.mesh,
@@ -97,61 +115,117 @@ class DFlashProposer:
         self.combine_hidden_states_fn = draft_mi.combine_hidden_states_fn
         self.state = draft_mi.state
 
-        # Share the target model's embedding with the draft model.
-        # Only applicable to flax_nnx state (has .model); vllm-impl state is
-        # a params dict, in which case the draft keeps its own embedding.
-        if hasattr(self.state, "model") and hasattr(target_model, "model"):
-            draft_embed = getattr(self.state.model, "embed_tokens", None)
-            target_embed = getattr(target_model.model, "embed_tokens", None)
-            if target_embed is None:
-                target_embed = getattr(target_model.model, "embed", None)
-            if target_embed is not None:
-                if draft_embed is None or not jnp.any(draft_embed.embedding):
+        draft_model_impl = envs.DRAFT_MODEL_IMPL_TYPE
+        target_model_impl = envs.MODEL_IMPL_TYPE
+        if draft_model_impl == 'auto':
+            draft_model_impl = resolve_model_architecture(
+                self.vllm_config, True)
+        if target_model_impl == 'auto':
+            target_model_impl = resolve_model_architecture(
+                self.vllm_config, False)
+        if draft_model_impl != target_model_impl:
+            raise ValueError(
+                "Draft model implementation must match target model.")
+
+        if draft_model_impl == "flax_nnx":
+
+            def get_target_value(target, paths):
+                # 1. Check PyTorch/vLLM backend
+                if (hasattr(self.runner, "model")
+                        and hasattr(self.runner.model, "model")
+                        and hasattr(self.runner.model.model, "vllm_model")):
+                    vllm_model = self.runner.model.model.vllm_model
+                    for name, param in vllm_model.named_parameters():
+                        full_name = f"vllm_model.{name}"
+                        for path in paths:
+                            if path == full_name or full_name.endswith(
+                                    path) or name == path or name.endswith(
+                                        path):
+                                from torchax.interop import jax_view
+                                return jax_view(param.data)
+
+                # 2. Check flat dict state lookup
+                if isinstance(target,
+                              dict) and not hasattr(target, "flat_state"):
+                    for path in paths:
+                        if path in target:
+                            val = target[path]
+                            return val.value if hasattr(val, "value") else val
+
+                # 3. Check JAX nnx.State
+                param = _find_param(target, paths)
+                return param.value if param is not None else None
+
+            # Resolve draft and target embeddings
+            draft_embed_param = _find_param(self.state, DRAFT_EMBED_PATHS)
+            target_embed_value = get_target_value(target_model,
+                                                  TARGET_EMBED_PATHS)
+
+            if draft_embed_param is not None and target_embed_value is not None:
+                try:
+                    if not jnp.any(draft_embed_param.value):
+                        logger.info(
+                            "Setting draft model embedding to target embedding."
+                        )
+                        draft_embed_param.value = target_embed_value
+                    elif jnp.array_equal(draft_embed_param.value,
+                                         target_embed_value):
+                        logger.info("Draft and target models share embedding.")
+                    else:
+                        logger.warning(
+                            "Draft and target models DO NOT share embedding.")
+                except Exception:
                     logger.info(
-                        "Sharing target model embedding with DFlash draft model."
+                        "Directly setting draft model embedding to target embedding."
                     )
-                    self.state.model.embed_tokens = target_embed
-                elif jnp.array_equal(draft_embed.embedding,
-                                     target_embed.embedding):
+                    draft_embed_param.value = target_embed_value
+            else:
+                logger.warning(
+                    "Failed to locate draft or target embedding parameter.")
+
+            # Resolve draft and target lm_head
+            draft_lm_head_param = _find_param(self.state, DRAFT_LM_HEAD_PATHS)
+            target_lm_head_value = get_target_value(target_model,
+                                                    TARGET_LM_HEAD_PATHS)
+
+            if draft_lm_head_param is not None and target_lm_head_value is not None:
+                try:
+                    if draft_lm_head_param.value.shape == target_lm_head_value.shape:
+                        logger.info(
+                            "Sharing target model lm_head via .value assignment."
+                        )
+                        draft_lm_head_param.value = target_lm_head_value
+                    elif draft_lm_head_param.value.shape == target_lm_head_value.T.shape:
+                        logger.info(
+                            "Sharing target model lm_head via transposed .value assignment."
+                        )
+                        draft_lm_head_param.value = target_lm_head_value.T
+                    else:
+                        logger.warning(
+                            f"Shape mismatch: draft {draft_lm_head_param.value.shape} vs target {target_lm_head_value.shape}."
+                        )
+                except Exception:
                     logger.info(
-                        "Draft embedding identical to target; sharing.")
-                    self.state.model.embed_tokens = target_embed
+                        "Directly setting draft model lm_head to target lm_head."
+                    )
+                    draft_lm_head_param.value = target_lm_head_value
+            else:
+                logger.warning(
+                    "Failed to locate draft or target lm_head parameter.")
 
-        # Allocate on-device KV caches
-        hf_config = self.draft_model_config.hf_config
-
-        sharding_size = get_mesh_shape_product(self.mesh,
-                                               ShardingAxisName.MLP_TENSOR)
-        num_heads = utils.get_padded_num_heads(hf_config.num_attention_heads,
-                                               sharding_size)
-        head_dim_orig = getattr(
-            hf_config, "head_dim",
-            hf_config.hidden_size // hf_config.num_attention_heads)
-        head_dim = utils.get_padded_head_dim(head_dim_orig)
-
-        self._max_kv_len = self._next_padded_size(self.max_model_len)
-        cache_shape = (1, num_heads, self._max_kv_len, head_dim)
-        self._draft_kv_caches = []
-        for _ in range(self.num_layers):
-            k_cache = jnp.zeros(cache_shape, dtype=jnp.bfloat16)
-            v_cache = jnp.zeros(cache_shape, dtype=jnp.bfloat16)
-            self._draft_kv_caches.append(k_cache)
-            self._draft_kv_caches.append(v_cache)
-        self._cache_len = 0
-
-        logger.info(
-            "Allocated DFlash on-device KV caches: %d layers, shape %s",
-            self.num_layers,
-            cache_shape,
-        )
+        if isinstance(self.state, nnx.State):
+            self.state_leaves = tuple(jax.tree_util.tree_leaves(self.state))
+        else:
+            self.state_leaves = self.state
+        draft_mi = replace(draft_mi, state_leaves=self.state_leaves)
+        self.draft_mi = draft_mi
 
     @functools.partial(jax.jit, static_argnums=(0, ))
-    def _project_aux_hidden(
-            self, state: nnx.State,
-            aux_hidden_states: tuple[jax.Array, ...]) -> jax.Array:
-        """Project and normalise auxiliary hidden states."""
-        raw = jnp.concatenate(aux_hidden_states, axis=-1)
-        return self.combine_hidden_states_fn(state, raw)
+    def _project_aux_hidden(self, state_leaves,
+                            aux_hidden_states: list[jax.Array]) -> jax.Array:
+        """Project auxiliary hidden states (JIT-compiled within prepare_inputs)."""
+        concat_hidden = jnp.concatenate(aux_hidden_states, axis=-1)
+        return self.combine_hidden_states_fn(state_leaves, concat_hidden)
 
     @staticmethod
     def _next_padded_size(n: int) -> int:
@@ -166,153 +240,309 @@ class DFlashProposer:
     @functools.partial(jax.jit, static_argnums=(0, 3, 4))
     def _build_noise_block(
         self,
-        seq_len_arr: jax.Array,
+        seq_lens: jax.Array,
         next_token_ids: jax.Array,
         mask_token_id: int,
         block_size: int,
     ) -> tuple[jax.Array, jax.Array]:
-        """Build noise block and positions (JIT-compiled)."""
-        seq_len = seq_len_arr[0]
-        first_token = next_token_ids[0]
-        noise_input_ids = jnp.full((block_size, ),
+        """Build noise block and positions for a batch (JIT-compiled)."""
+        num_reqs = next_token_ids.shape[0]
+        noise_input_ids = jnp.full((num_reqs, block_size),
                                    mask_token_id,
                                    dtype=jnp.int32)
-        noise_input_ids = noise_input_ids.at[0].set(first_token)
-        noise_positions = jnp.arange(block_size, dtype=jnp.int32) + seq_len
-        return noise_input_ids, noise_positions
+        noise_input_ids = noise_input_ids.at[:, 0].set(next_token_ids)
+        offsets = jnp.arange(block_size, dtype=jnp.int32)[jnp.newaxis, :]
+        noise_positions = seq_lens[:, jnp.newaxis] + offsets
+        return noise_input_ids.flatten(), noise_positions.flatten()
+
+    @functools.partial(jax.jit, static_argnums=(0, ))
+    def _compute_token_indices_and_filter(
+        self,
+        is_in_prefill: jax.Array,
+        next_prompt_token_id: jax.Array,
+        last_sampled_token_id: jax.Array,
+        query_start_loc: jax.Array,
+        seq_lens: jax.Array,
+        num_reqs: jax.Array,
+        num_rejected_tokens: jax.Array,
+        input_ids: jax.Array,
+        aux_hidden_states: tuple[jax.Array, ...],
+        input_positions: jax.Array,
+    ):
+        """Computes query metadata after filtering out rejected draft tokens.
+
+        During speculative verification, some draft tokens might get rejected by the target model.
+        This function:
+        1. Compares sequence metadata and rolls back seq_lens based on rejected tokens.
+        2. Derives 1D flat indices (`token_indices`) corresponding ONLY to the accepted tokens.
+        3. Slices the target input IDs, position IDs, and target auxiliary hidden states
+           using these token indices to filter out states/tokens belonging to rejected draft positions.
+        """
+
+        def _compute_token_indices(is_in_prefill, next_prompt_token_id,
+                                   last_sampled_token_id, query_start_loc,
+                                   seq_lens, num_reqs, num_rejected_tokens,
+                                   input_ids):
+            # 1. Determine next token to start generation (prompt token if in prefill, last accepted token if decoding)
+            next_token_ids = jnp.where(is_in_prefill, next_prompt_token_id,
+                                       last_sampled_token_id)
+
+            # 2. Compute original query length and mask padded requests
+            query_len_per_req = (query_start_loc[1:] - query_start_loc[:-1])
+            query_len_per_req = jnp.where(
+                jnp.arange(query_len_per_req.shape[0]) < num_reqs,
+                query_len_per_req, 0)
+            num_rejected_tokens = jnp.where(
+                jnp.arange(num_rejected_tokens.shape[0]) < num_reqs,
+                num_rejected_tokens, 0)
+
+            # 3. Calculate number of accepted tokens per request and derive new query boundaries
+            # Example: query_len_per_req = [5, 5], num_rejected_tokens = [1, 2] -> num_tokens_per_req = [4, 3]
+            num_tokens_per_req = (query_len_per_req - num_rejected_tokens)
+            new_query_start_loc = jnp.cumsum(num_tokens_per_req)
+            new_query_start_loc = jnp.pad(
+                new_query_start_loc, (1, 0),
+                constant_values=0)  # Example: -> [0, 4, 7]
+
+            # 4. Map the new (filtered) token positions back to their original index locations in input_ids.
+            # This is a JAX-friendly vectorized mapping trick to avoid recompilations from dynamic shapes.
+            total_num_tokens = input_ids.shape[0]
+
+            # Repeat the new starting locations for each token in the accepted sequence.
+            # Example: repeat [0, 4] by [4, 3] -> [0, 0, 0, 0, 4, 4, 4, 0, 0, 0] (padded to total_num_tokens)
+            expanded_new_query_start_loc = jnp.repeat(
+                new_query_start_loc[:-1],
+                num_tokens_per_req,
+                total_repeat_length=total_num_tokens)
+
+            # Calculate offset/index within each new filtered segment.
+            # Example: [0..9] - [0,0,0,0,4,4,4,...] -> [0, 1, 2, 3, 0, 1, 2, ...]
+            token_offsets = jnp.arange(total_num_tokens, dtype=jnp.int32)
+            token_offsets -= expanded_new_query_start_loc
+
+            # Repeat the old query start locations.
+            # Example: repeat [0, 5] by [4, 3] -> [0, 0, 0, 0, 5, 5, 5, 0, 0, 0]
+            old_query_start_loc_expanded = jnp.repeat(
+                query_start_loc[:-1],
+                num_tokens_per_req,
+                total_repeat_length=total_num_tokens)
+
+            # Add relative offset to original start index to get absolute token index in the original sequence.
+            # Example: [0,1,2,3,0,1,2,...] + [0,0,0,0,5,5,5,...] -> [0, 1, 2, 3, 5, 6, 7, ...]
+            token_indices = token_offsets + old_query_start_loc_expanded
+
+            # 5. Rollback sequence lengths based on the number of rejected tokens
+            new_seq_lens = seq_lens - num_rejected_tokens
+
+            return (next_token_ids, token_indices, new_query_start_loc,
+                    new_seq_lens)
+
+        data_spec = PartitionSpec(ShardingAxisName.ATTN_DATA)
+        (next_token_ids, token_indices, new_query_start_loc,
+         new_seq_lens) = jax.shard_map(
+             _compute_token_indices,
+             mesh=self.mesh,
+             in_specs=(data_spec, ) * 8,
+             out_specs=(data_spec, ) * 4,
+         )(is_in_prefill, next_prompt_token_id, last_sampled_token_id,
+           query_start_loc, seq_lens, num_reqs, num_rejected_tokens, input_ids)
+
+        def _sharded_select_target_tokens_and_hidden_states(
+                input_ids, token_indices, input_positions, aux_hidden_states):
+            # Extract only the token IDs of accepted tokens
+            target_token_ids = input_ids[token_indices]
+
+            # Slice position IDs for accepted tokens (supporting both 2D and 1D position layouts)
+            if input_positions.ndim == 2:
+                input_positions = input_positions[:, token_indices]
+            else:
+                input_positions = input_positions[token_indices]
+
+            # Filter target auxiliary hidden states from target layers, keeping only accepted token steps
+            aux_states_processed = [
+                h[token_indices] for h in aux_hidden_states
+            ]
+            return target_token_ids, input_positions, aux_states_processed
+
+        positions_spec = (PartitionSpec(None, ShardingAxisName.ATTN_DATA)
+                          if input_positions.ndim == 2 else data_spec)
+
+        target_token_ids, new_input_positions, aux_states_processed = jax.shard_map(
+            _sharded_select_target_tokens_and_hidden_states,
+            mesh=self.mesh,
+            in_specs=(data_spec, data_spec, positions_spec, data_spec),
+            out_specs=(data_spec, positions_spec, data_spec),
+        )(input_ids, token_indices, input_positions, aux_hidden_states)
+
+        return (next_token_ids, new_query_start_loc, new_seq_lens,
+                target_token_ids, new_input_positions, aux_states_processed)
 
     def prepare_inputs(
         self,
         attn_metadata: AttentionMetadata,
         input_ids: jax.Array,
         aux_hidden_states: tuple[jax.Array, ...],
-        next_token_ids: jax.Array,
-        num_rejected_tokens: Optional[jax.Array] = None,
+        last_sampled_token_id: jax.Array,
+        next_prompt_token_id: jax.Array,
+        is_in_prefill: jax.Array,
+        num_rejected_tokens: jax.Array,
+        num_reqs_dp: jax.Array,
     ) -> tuple[jax.Array, jax.Array, jax.Array, AttentionMetadata]:
         """Prepare DFlash inputs with on-device KV cache."""
         assert aux_hidden_states is not None and len(aux_hidden_states) > 0
 
-        # Reset proposer state when the single slot's request changes.
-        req_ids = self.runner.input_batch.req_ids
-        current_req_id = req_ids[0] if req_ids else None
-        if current_req_id != self._last_req_id:
-            self._ctx_len = 0
-            self._cache_len = 0
-            self._prev_seq_len = 0
-            self._last_req_id = current_req_id
-
-        # 1. Current sequence length
-        seq_len_jax = attn_metadata.seq_lens[0]
-        seq_len = int(jax.device_get(seq_len_jax))
-
-        # 2. Crop cache to match GPU DynamicCache.crop(start) semantics.
-        #
-        # GPU reference (zhongyan_dev/dflash/model/dflash.py line 246):
-        #   past_key_values_draft.crop(start)
-        # where `start` = beginning of the CURRENT block = position of
-        # the first accepted token from the previous iteration.
-        #
-        # After crop, GPU cache_seq_len = start, which equals the seq_len
-        # from the PREVIOUS prepare_inputs call (not the current one).
-        # Context + noise are then written starting from this position.
-        #
-        # Bug was: self._cache_len = seq_len (CURRENT accepted position),
-        # which left stale noise K/V entries from the previous iteration
-        # in positions [prev_seq_len, seq_len) and shifted all subsequent
-        # RoPE positions, accumulating errors every iteration.
-        if self._prev_seq_len > 0:
-            self._cache_len = self._prev_seq_len
-
-        if seq_len < self._ctx_len:
-            self._ctx_len = seq_len
-        self._prev_seq_len = seq_len
-
-        # 3. Project new auxiliary hidden states (on-device, JIT'd)
-        projected = self._project_aux_hidden(self.state, aux_hidden_states)
-
-        # 4. Compute context update — slicing and padding stay on device
-        #    to avoid host<->TPU transfer overhead.
-        num_new = seq_len - self._ctx_len
-        if num_new <= 0:
-            # Full rejection — trim context tracking, use zero placeholder.
-            # Noise writes at cache_len + 0, completely overwriting padding.
-            self._ctx_len = seq_len
-            self._cache_len = min(self._cache_len, seq_len)
-            actual_new_ctx_count = 0
-            new_ctx_jax = device_array(
-                self.mesh,
-                jnp.zeros((16, self.hidden_size), dtype=jnp.bfloat16),
-            )
-        else:
-            end = min(self._ctx_len + num_new, self.max_model_len)
-            n_copy = end - self._ctx_len
-            actual_new_ctx_count = n_copy
-            self._ctx_len = end
-
-            # 5. Slice and pad on device — no host<->TPU transfer.
-            # Padding to power-of-2 sizes (16/32/64/128) means JIT only
-            # traces ~4 unique shapes, eliminating per-token retracing.
-            ctx = projected[:n_copy].astype(jnp.bfloat16)
-            padded_size = self._next_padded_size(n_copy)
-            if padded_size > n_copy:
-                pad = jnp.zeros(
-                    (padded_size - n_copy, self.hidden_size),
-                    dtype=jnp.bfloat16,
-                )
-                ctx = jnp.concatenate([ctx, pad], axis=0)
-            new_ctx_jax = device_array(self.mesh, ctx)
-
-        # 6. Build noise block
-        seq_len_arr = device_array(self.mesh,
-                                   np.array([seq_len], dtype=np.int32))
-        noise_input_ids, noise_positions = self._build_noise_block(
-            seq_len_arr,
-            next_token_ids,
-            self.mask_token_id,
-            self.block_size,
-        )
-
-        # 7. Pack target_hidden_states as 3-tuple (always same pytree shape)
-        cache_len_arr = device_array(
-            self.mesh, np.array([self._cache_len], dtype=np.int32))
-        actual_ctx_count_arr = device_array(
-            self.mesh, np.array([actual_new_ctx_count], dtype=np.int32))
-        target_hidden = (new_ctx_jax, cache_len_arr, actual_ctx_count_arr)
-
-        # 8. Build draft attention metadata
+        # The last KV cache group is for the draft model.
         num_kv_cache_groups = len(self.runner.kv_cache_config.kv_cache_groups)
         draft_kv_cache_group_id = num_kv_cache_groups - 1
         block_tables = (
             self.runner.input_batch.block_table[draft_kv_cache_group_id].
             get_cpu_tensor().reshape(-1))
+        block_tables = device_array(self.mesh,
+                                    block_tables,
+                                    sharding=PartitionSpec(
+                                        ShardingAxisName.ATTN_DATA))
+
+        return self._prepare_inputs(
+            self.state_leaves,
+            block_tables,
+            attn_metadata,
+            input_ids,
+            aux_hidden_states,
+            last_sampled_token_id,
+            next_prompt_token_id,
+            is_in_prefill,
+            num_rejected_tokens,
+            num_reqs_dp,
+        )
+
+    @functools.partial(
+        jax.jit,
+        static_argnums=(0, ),
+    )
+    def _prepare_inputs(
+        self,
+        state_leaves: Any,
+        block_tables: jax.Array,
+        attn_metadata: AttentionMetadata,
+        input_ids: jax.Array,
+        aux_hidden_states: tuple[jax.Array, ...],
+        last_sampled_token_id: jax.Array,
+        next_prompt_token_id: jax.Array,
+        is_in_prefill: jax.Array,
+        num_rejected_tokens: jax.Array,
+        num_reqs_dp: jax.Array,
+    ) -> tuple[jax.Array, jax.Array, jax.Array, AttentionMetadata]:
+        """JIT-compiled core logic for preparing inputs for the draft model.
+
+        Performs:
+        1. Filters out rejected token metadata via `_compute_token_indices_and_filter`.
+        2. Projects the accepted target hidden states into draft model input space.
+        3. Prepares a masked 'noise block' of token IDs and position IDs for generating 
+           speculative proposals.
+        4. Updates AttentionMetadata for the draft model forward pass.
+        """
+        (next_token_ids, new_query_start_loc, new_seq_lens, target_token_ids,
+         new_input_positions,
+         aux_states_processed) = self._compute_token_indices_and_filter(
+             is_in_prefill, next_prompt_token_id, last_sampled_token_id,
+             attn_metadata.query_start_loc, attn_metadata.seq_lens,
+             num_reqs_dp, num_rejected_tokens, input_ids, aux_hidden_states,
+             attn_metadata.input_positions)
+
+        # Project new auxiliary hidden states
+        projected = self._project_aux_hidden(state_leaves,
+                                             aux_states_processed)
+        target_hidden = projected.astype(jnp.bfloat16)
+
+        # Build noise block (vectorized for batching)
+        noise_input_ids, noise_positions = self._build_noise_block(
+            new_seq_lens,
+            next_token_ids,
+            self.mask_token_id,
+            self.block_size,
+        )
+
         num_reqs = attn_metadata.seq_lens.shape[0]
         draft_attn_metadata = replace(
             attn_metadata,
             input_positions=noise_positions,
-            query_start_loc=jnp.array([0, self.block_size], dtype=jnp.int32),
-            block_tables=device_array(self.mesh, block_tables),
+            seq_lens=new_seq_lens,
+            query_start_loc=jnp.arange(num_reqs + 1, dtype=jnp.int32) *
+            self.block_size,
+            block_tables=block_tables,
         )
 
         dummy_last_indices = jnp.zeros(num_reqs, dtype=jnp.int32)
         return (
-            target_hidden,
+            (target_hidden, new_query_start_loc, new_input_positions),
             noise_input_ids,
             dummy_last_indices,
             draft_attn_metadata,
         )
 
-    @functools.partial(jax.jit, static_argnums=(0, ))
-    def _sample_block_draft_tokens(
+    @functools.partial(
+        jax.jit,
+        static_argnums=(0, ),
+        donate_argnames=("kv_caches", ),
+        out_shardings=(
+            None,  # kv_caches - keep original sharding
+            None,  # draft_token_ids
+        ),
+        compiler_options={
+            "xla_tpu_all_gather_collective_matmul_mode":
+            "post_spmd_conservative",
+            "xla_tpu_reduce_scatter_collective_matmul_mode":
+            "post_spmd_conservative"
+        },
+    )
+    def _propose(
         self,
-        state: nnx.State,
-        hidden_states: jax.Array,
-    ) -> jax.Array:
-        """Greedy-sample draft tokens from the block output."""
-        draft_hidden = hidden_states[1:1 + self.num_speculative_tokens]
-        logits = self.compute_logits_fn(state, draft_hidden, None)
+        state_leaves: Any,
+        kv_caches: list[jax.Array],
+        input_ids: jax.Array,
+        attn_metadata: AttentionMetadata,
+        target_hidden_states: jax.Array,
+    ) -> tuple[list[jax.Array], jnp.ndarray]:
+        """JIT-compiled forward pass of the draft model.
+
+        1. Runs the draft model forward pass using the target model's projected hidden states.
+        2. Reshapes the output hidden states to locate the positions corresponding to the
+           new speculative tokens.
+        3. Computes vocabulary logits and greedily samples the token IDs.
+        4. Constrains the sharding of the drafted token IDs back to ATTN_DATA.
+        """
+        kv_caches, hidden_states, *_ = self.model_fn(
+            state_leaves,
+            kv_caches,
+            input_ids,
+            target_hidden_states,
+            attn_metadata,
+        )
+
+        num_reqs = hidden_states.shape[0] // self.block_size
+        hidden_states_batched = hidden_states.reshape(
+            (num_reqs, self.block_size, -1))
+        draft_hidden = hidden_states_batched[:, 1:1 +
+                                             self.num_speculative_tokens, :]
+
+        # Flatten draft_hidden to 2D for compute_logits_fn which expects 2D
+        # shape to satisfy PartitionSpec('data', 'model') for the output logits
+        draft_hidden_flat = draft_hidden.reshape(-1, draft_hidden.shape[-1])
+        logits_flat = self.compute_logits_fn(state_leaves, draft_hidden_flat,
+                                             None)
+
+        logits = logits_flat.reshape(num_reqs, self.num_speculative_tokens, -1)
+
         draft_ids = jnp.argmax(logits, axis=-1)
-        return lax.with_sharding_constraint(
-            draft_ids, NamedSharding(self.mesh, PartitionSpec()))
+        draft_token_ids = lax.with_sharding_constraint(
+            draft_ids,
+            NamedSharding(self.mesh,
+                          PartitionSpec(ShardingAxisName.ATTN_DATA, None)))
+
+        if draft_token_ids.ndim == 1:
+            draft_token_ids = draft_token_ids[jnp.newaxis, :]
+
+        return kv_caches, draft_token_ids
 
     def propose(
         self,
@@ -322,33 +552,11 @@ class DFlashProposer:
         last_token_indices: jax.Array,
         target_hidden_states,
     ) -> tuple[list[jax.Array], jnp.ndarray]:
-        """Generate all draft tokens in one forward pass."""
-        # Use our own on-device KV caches
-        draft_kv_caches, hidden_states, _ = self.model_fn(
-            self.state,
-            self._draft_kv_caches,
+        """Generate all draft tokens in one forward pass using paged KV cache."""
+        return self._propose(
+            self.state_leaves,
+            kv_caches,
             input_ids,
-            target_hidden_states,
             attn_metadata,
+            target_hidden_states,
         )
-
-        # Update cached references
-        self._draft_kv_caches = draft_kv_caches
-
-        # Update cache_len: model wrote actual_ctx_count + T_noise entries.
-        # This will be corrected at the start of the next prepare_inputs
-        # to match the actual accepted seq_len.
-        _, cache_len_arr, actual_ctx_count_arr = target_hidden_states
-        old_cache_len = int(jax.device_get(cache_len_arr)[0])
-        actual_ctx_count = int(jax.device_get(actual_ctx_count_arr)[0])
-        T_noise = self.block_size
-        self._cache_len = old_cache_len + actual_ctx_count + T_noise
-
-        draft_token_ids = self._sample_block_draft_tokens(
-            self.state, hidden_states)
-
-        if draft_token_ids.ndim == 1:
-            draft_token_ids = draft_token_ids[jnp.newaxis, :]
-
-        # Pass the FRAMEWORK kv_caches through unchanged
-        return kv_caches, draft_token_ids


### PR DESCRIPTION
# Description

This PR refactors the `DFlashProposer` (the speculator/proposer class) to integrate with the global paged KV cache mechanism and enables dynamic, multi-request batching.

> [!NOTE]
> This PR is stacked on top of PR #2977 .

### Why is this change being made?
Previously, the proposer was stateful and maintained local tracking variables (`self._ctx_len`, `self._cache_len`). This limited the speculator to single-request batch sizes and made preemption or continuous batching swaps extremely fragile. Refactoring the proposer to be stateless allows the framework's page-level scheduler to handle all cache management.

### The problem being solved and any relevant context
This PR fully enables multi-request dynamic batching (num_reqs > 1) and cross-request cache persistence during speculative decoding.

### Why this is a good solution
We vectorized the input preparation and token filtration logic (`_compute_token_indices_and_filter`) using a JAX-friendly vectorized indexing approach. This mapping trick allows the speculator to execute draft generation for multiple requests simultaneously and handle variable-length token rejections without triggering XLA recompilations.

### Specific implementation details
1. **Removed Stateful Tracking:** Eliminated `_ctx_len`, `_cache_len`, and obsolete caching fields from `DFlashProposer`.
2. **Vectorized Token Index Mapping:** Implemented `_compute_token_indices_and_filter` in `spec_decode/jax/dflash.py` to calculate accepted token positions and roll back sequence lengths dynamically.
3. **Vectorized Noise Block Construction:** Updated `_build_noise_block` to vectorize target/draft token layouts and position offsets across multiple batch items.
4. **Stateless Propose Flow:** Refactored the `propose` method to pass `block_tables` and updated `AttentionMetadata` through to the underlying paged JAX models.

# Tests

I have verified the speculator logic and the new vectorized layouts using the updated proposer unit tests:

```bash
python3 -m pytest tests/spec_decode/test_dflash.py