### PR TITLE
[do not review ]Distribute vLLM-qualified image to multi-host workers (fix Ray hang)

### DIFF
--- a/.buildkite/scripts/run_multihost.sh
+++ b/.buildkite/scripts/run_multihost.sh
@@ -197,7 +197,13 @@ source "$SCRIPT_DIR/setup_docker_env.sh"
 # Pass "true" to enable pushing to GCR
 setup_environment "${IMAGE_NAME}" "true"
 
-DOCKER_IMAGE="${IMAGE_NAME}:${BUILDKITE_COMMIT:-latest}"
+# Distribute the vLLM-qualified image (CACHE_TAG, set by setup_environment:
+# <tpu_inference_commit>-<vllm_commit>-<tpu_version>) rather than the
+# tpu-inference-commit-only tag. The commit-only tag is shared by every build on
+# the same tpu-inference commit regardless of vLLM, so another build (e.g. a
+# different LKG/HEAD vLLM) can overwrite it in the registry between our push and
+# the workers' pull -- causing the cluster to run a vLLM we never built/verified.
+DOCKER_IMAGE="${IMAGE_NAME}:${CACHE_TAG:-${BUILDKITE_COMMIT:-latest}}"
 
 # Clean up potential leftovers from previous runs
 echo "--- Cleaning up previous cluster state..."

--- a/.buildkite/scripts/setup_docker_env.sh
+++ b/.buildkite/scripts/setup_docker_env.sh
@@ -181,7 +181,11 @@ setup_environment() {
   # pipeline (LKG vLLM) and the integration pipeline (HEAD vLLM) produce the same
   # tag for the same tpu-inference commit and can overwrite each other's image in
   # the registry -- a test could then silently run a different vLLM than intended.
-  local CACHE_TAG="${TPU_INFERENCE_HASH}-${LOCAL_TPU_VERSION}"
+  # Exposed as a shell global (not `local`) so callers that source this script --
+  # notably run_multihost.sh -- can distribute the exact vLLM-qualified image
+  # instead of a tpu-inference-commit-only tag that another build (different
+  # vLLM) may have clobbered in the registry.
+  CACHE_TAG="${TPU_INFERENCE_HASH}-${LOCAL_TPU_VERSION}"
   if [[ -n "${VLLM_COMMIT_HASH}" ]]; then
     CACHE_TAG="${TPU_INFERENCE_HASH}-${VLLM_COMMIT_HASH}-${LOCAL_TPU_VERSION}"
   elif [[ -n "${BUILDKITE:-}" && "${RUN_WITH_PYPI:-false}" != "true" ]]; then
@@ -237,5 +241,9 @@ setup_environment() {
     gcloud auth configure-docker us-central1-docker.pkg.dev
     docker push "${IMAGE_NAME}:${TPU_INFERENCE_HASH}"
     docker push "${IMAGE_NAME}:latest"
+    # Also push the vLLM-qualified tag so consumers (e.g. run_multihost.sh) can
+    # pull an image that cannot be clobbered by another build on the same
+    # tpu-inference commit built against a different vLLM.
+    docker push "${IMAGE_NAME}:${CACHE_TAG}"
   fi
 }


### PR DESCRIPTION
## Problem
The `tpu7x E2E test for Ray-based multi-host` flipped from occasionally-flaky to **consistently timing out** (~#21825, 2026-07-08 02:49), while the *same code* passed in pre-commit — pointing at environment, not code or a bad machine.

Root cause: the multi-host test builds its image at the pinned vLLM (`VLLM_COMMIT_HASH`), but distributes it to worker nodes via `IMAGE_NAME:${BUILDKITE_COMMIT}` (`run_multihost.sh:200`) — a **tpu-inference-commit-only tag with no vLLM component**. Every build on the same tpu-inference commit pushes that tag regardless of which vLLM it built, so another build (different LKG/HEAD vLLM) can overwrite it in the registry between the head node's push and the workers' pull. The workers then run a vLLM the head node never built or verified.

Evidence — the vLLM the multi-host actually ran vs the pinned LKG:

| Run | pinned LKG | vLLM actually run | result |
|---|---|---|---|
| #21819 (pre-commit) | `fa4321de` | `fa4321de` ✓ | PASS |
| #21825 (main) | `b6cc46ec` | `11b56b2f` (a 3-week-old commit!) | FAIL |
| #21850 (main) | `98e4726a` | `2afa3f7e` | FAIL |

Those mismatched vLLM commits hang at Ray worker init (`ray.get(init_worker_refs)` in `ray_distributed_executor_v2.py:52`), which is the 2-hour timeout. Failures span **all three** multi-host agents, and `c8e7ce54` passed then failed on itself — so not a bad machine.

## Why #3093 didn't cover this
#3093 made `CACHE_TAG` vLLM-qualified (`<tpu_inference>-<vllm>-<tpu_version>`) — but only for the CI-cache (`push_to_ci_cache`) path. The `should_push` path that the multi-host uses still pushed/consumed the commit-only tag.

## Fix
- `setup_docker_env.sh`: expose `CACHE_TAG` as a shell global and also push it in the `should_push` path.
- `run_multihost.sh`: distribute `IMAGE_NAME:${CACHE_TAG}` so the workers pull the exact tpu-inference + vLLM image this build produced (falls back to the old tag if `CACHE_TAG` is unset).

Note: the *underlying* hang in the newer vLLM is a separate matter; this PR makes the multi-host test deterministically run the vLLM it pins (the LKG), which is what it's supposed to validate.

## Testing
`bash -n` + `shellcheck` clean on both files. CI's Ray-multi-host job will now build and distribute the LKG-matched image.