### PR TITLE
Temporarily disable Ray-based multi-host E2E test

### DIFF
--- a/.buildkite/pipeline_jax.yml
+++ b/.buildkite/pipeline_jax.yml
@@ -444,6 +444,12 @@ steps:
 
       - label: "${TPU_VERSION:-tpu6e} E2E test for Ray-based multi-host"
         key: "${TPU_VERSION:-tpu6e}_test_26"
+        # Temporarily disabled: consistently times out (~2h) and squats the
+        # scarce tpu_v7x_16_queue. Two independent causes -- (1) the multi-host
+        # image tag omitted the vLLM commit so workers could pull a clobbered
+        # image (fixed separately), and (2) a bad multi-host machine whose Runai
+        # weight-streamer stalls at ~50%. Re-enable once both are resolved.
+        skip: "Times out ~2h; re-enable after #3121 + bad-machine fix"
         soft_fail: true
         agents:
           queue: tpu_v7x_16_queue


### PR DESCRIPTION
## Summary
Skip the `tpu7x E2E test for Ray-based multi-host` step. It consistently times out (~2h) and squats the scarce `tpu_v7x_16_queue` on every run.

## Why
Two independent causes:
1. **Image-tag collision** — the multi-host distributes `IMAGE_NAME:${BUILDKITE_COMMIT}` (a tpu-inference-commit-only tag, no vLLM component), so workers can pull an image another build clobbered with a different vLLM. Fixed separately in #3121.
2. **Bad multi-host machine** — `tpu-multi-host-t1v-n-f7fd5789-w-0`'s Runai weight-streamer stalls at ~50% during weight load, hanging the cluster to the 2h timeout.

Until both are resolved, the step wastes the multi-host queue and adds red-but-soft-fail noise. Using Buildkite `skip:` (not deletion) keeps the step documented and trivially re-enableable.

## Re-enable criteria
- #3121 merged (vLLM-qualified multi-host image), and
- `f7fd5789` drained/fixed (or the Runai-streamer stall root-caused).

## Testing
`skip:` short-circuits the step; YAML parses cleanly. No behavior change to other steps.