### PR TITLE
Add post-run Docker cleanup in build and run scripts

### DIFF
--- a/.buildkite/scripts/run_in_docker.sh
+++ b/.buildkite/scripts/run_in_docker.sh
@@ -222,4 +222,7 @@ else
   echo "[WARN] Docker exited with non-zero code ${DOCKER_EXIT_CODE}. Skipping syncing local JAX Cache back to GCS to avoid potential cache corruption."
 fi
 
+echo "--- Cleaning up Docker resources after run"
+cleanup_docker_resource "${IMAGE_NAME}"
+
 exit $DOCKER_EXIT_CODE

--- a/.buildkite/scripts/setup_docker_env.sh
+++ b/.buildkite/scripts/setup_docker_env.sh
@@ -238,4 +238,12 @@ setup_environment() {
     docker push "${IMAGE_NAME}:${TPU_INFERENCE_HASH}"
     docker push "${IMAGE_NAME}:latest"
   fi
+
+  # Only clean up resources in setup_environment after pushing to a remote registry
+  # (e.g., standalone builder jobs in CI). When building locally to run on the same machine
+  # (push_to_ci_cache=false and should_push=false), preserve the image so the caller can run it.
+  if [[ "$push_to_ci_cache" == "true" || "$should_push" == "true" ]]; then
+    echo "--- Cleaning up Docker resources after push..."
+    cleanup_docker_resource "${IMAGE_NAME}"
+  fi
 }


### PR DESCRIPTION
This PR extends the existing Docker image/container cleanup process by executing cleanup at the end of build and test executions (in addition to the existing pre-run cleanup safeguards). This ensures that shared builder VMs and TPU test runner VMs do not hold onto large Docker images when idle, preventing disk space accumulation across runs.

This become more of issue because our ci machines are shared by multiple repos.

1. Namespace Blindness
Cleanup scripts are targeted. The cleanup script for tpu-inference only knows to delete images matching vllm-tpu. The cleanup script for vllm-torchtpu only targets vllm-torchtpu.

When tpu-inference runs, it will not clean up any legacy vllm-torchtpu images left on the machine.
As more repositories or custom experiments share the same build queue, the VM accumulates the "latest" built image of every single repository that has ever run on it. If you have 5 different projects sharing the runner, you permanently hold $5 \times 15\text{GB} = 75\text{GB}$ of stale images in idle state.
2. Wasted Idle Space
On shared runner pools, VM instances are dynamically assigned to jobs. If a VM runs a build and is then released back to the pool (or sits idle), it remains cluttered with a huge 15GB image. If we clean up after the build, the VM is returned to the runner pool or left idle in a pristine state (0B occupied by images).

3. BuildKit Cache Growth
BuildKit's internal cache is shared globally on the VM. If we delete the built image (docker rmi) immediately after pushing it, all the intermediate build cache layers used for that image become "dangling" (unreferenced by any active local image). This allows Docker’s garbage collection or a subsequent docker builder prune to reclaim that space immediately, rather than keeping the layers locked by a tagged image sitting on the disk.

Signed-off-by: Ming Huang <mhhua@google.com>

# Description

Start with a short description of what the PR does and how this is a change from
the past.

The rest of the description includes relevant details and context, examples:
- why is this change being made,
- the problem being solved and any relevant context,
- why this is a good solution,
- some information about the specific implementation,
- shortcomings of the solution and possible future improvements.

If the change fixes a Github issue, please include a link, e.g.,:
FIXES: #123456

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
