### PR TITLE
fix: Correct block size calculation for context parallelism

### DIFF
--- a/tpu_inference/runner/kv_cache.py
+++ b/tpu_inference/runner/kv_cache.py
@@ -54,10 +54,17 @@ def get_kv_cache_shape_with_mesh(mesh: Mesh,
                                  actual_head_dim: int,
                                  kv_dtype: any,
                                  use_mla: bool = False):
-    """Gets the KV cache shape based on the mesh configuration."""
+    """Gets the KV cache shape based on the mesh configuration.
+
+    This function scales block_size by the CONTEXT (DCP) axis and num_heads by duplicate kv heads.
+
+    """
 
     model_cnt = utils.get_mesh_shape_product(mesh,
                                              ShardingAxisName.KV_CACHE_HEAD)
+
+    context_cnt = utils.get_mesh_shape_product(mesh, ShardingAxisName.CONTEXT)
+    physical_block_size = block_size * context_cnt
 
     # NOTE(chengjiyao): Currently, the attention kernel is tailored to the
     # specific model, rather than being determined by the head_dim. If new
@@ -70,7 +77,7 @@ def get_kv_cache_shape_with_mesh(mesh: Mesh,
         shape = list(
             get_kv_cache_shape_fn(
                 total_num_pages,
-                block_size,
+                physical_block_size,
                 actual_head_dim,
                 kv_dtype,
                 envs.MLA_KV_PACKING_SIZE,
@@ -82,7 +89,7 @@ def get_kv_cache_shape_with_mesh(mesh: Mesh,
                 else rpa.get_kv_cache_shape
         )
         shape = list(
-            get_kv_cache_shape_fn(total_num_pages, block_size,
+            get_kv_cache_shape_fn(total_num_pages, physical_block_size,
                                   actual_num_kv_heads // model_cnt,
                                   actual_head_dim, kv_dtype))
         shape[2] *= model_cnt

--- a/tpu_inference/runner/kv_cache_manager.py
+++ b/tpu_inference/runner/kv_cache_manager.py
@@ -441,8 +441,10 @@ class KVCacheManager:
 
     def get_kv_cache_spec(self):
         # TODO(xiang): this hack tricks engine core to init successfully
+
+        # NOTE(weiyu0824): Pass raw block_size (size before any parallelization).
+        # vLLM applies dcp_size scaling internally; pre-multiplying block size causes a dcp_size miscalculation.
         block_size = self.runner.cache_config.block_size
-        block_size *= self.runner.vllm_config.parallel_config.decode_context_parallel_size
         kv_cache_spec: dict[str, KVCacheSpec] = {}
 
         tp_axis_name = ShardingAxisName.ATTN_HEAD
@@ -671,8 +673,14 @@ class KVCacheManager:
 
     def maybe_reinitialize_input_batch(self,
                                        kv_cache_config: KVCacheConfig) -> None:
+        # kv_cache_spec.block_size is the raw block size.
+        # The block table must use the physical size: one page covers block_size * dcp_size
+        # tokens globally.
+        # Read dcp_size from the mesh (CONTEXT axis) to stay consistent with get_kv_cache_shape_with_mesh.
+        context_cnt = utils.get_mesh_shape_product(self.runner.mesh,
+                                                   ShardingAxisName.CONTEXT)
         block_sizes = [
-            kv_cache_group.kv_cache_spec.block_size
+            kv_cache_group.kv_cache_spec.block_size * context_cnt
             for kv_cache_group in kv_cache_config.kv_cache_groups
         ]
         if block_sizes != [self.runner.cache_config.block_size]:


### PR DESCRIPTION
# Description
This PR corrects the block size calculation for CP. 

In vLLM's `SingleTypeKVCacheManager`, it internally scales the `block_size` by the `dcp_size`. Previously, we pre-multiplying the block_size before passing it to `kv_cache_spec`, which led to an incorrect `dcp_size * dcp_size` calculation

In this PR, we make sure block_size inside kv_cache_spec is always logical block size(pre-parallelization) to match vllm, and only scale it on  actual TPU-inference kv caches initialization. 

# Tests

- Before this change, vllm serve commands and the prefix caching mechanism for context parallelism would fail, even though offline_inference.py would pass.

- After integrating with the upcoming PR in [#3108](https://github.com/vllm-project/tpu-inference/pull/3108), we verified the fix using lmeval.  

