### PR TITLE
[Qwen3-VL] Chunk vision encoder over video frames to bound VMEM

### DIFF
--- a/tests/runner/test_multimodal_manager.py
+++ b/tests/runner/test_multimodal_manager.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import jax
@@ -647,3 +649,218 @@ class TestMultiModalManager:
         np.testing.assert_array_equal(
             self.runner.mrope_positions_cpu[:, 16:24], mrope_b)
         assert np.all(self.runner.mrope_positions_cpu[:, 24:32] == -7)
+
+    # ---- Vision-encoder temporal chunking (MM_ENCODER_FRAME_CHUNK) ----
+
+    def _set_temporal_patch_size(self, tps: int = 2):
+        """Give the runner a minimal hf_config with the vision temporal patch
+        size the chunking helper reads to convert frames -> temporal patches."""
+        self.runner.model_config.hf_config = SimpleNamespace(
+            vision_config=SimpleNamespace(temporal_patch_size=tps))
+
+    def _make_video_group(self, t, h, w, feat=5):
+        """Build an mm_kwargs_group dict shaped like the one execute_mm_encoder
+        passes for a single video item: flat pixels [t*h*w, feat], grid [1,3],
+        per-temporal-patch timestamps [t]."""
+        import torch
+        rows = t * h * w
+        pixels = torch.arange(rows * feat,
+                              dtype=torch.float32).reshape(rows, feat)
+        grid = torch.tensor([[t, h, w]], dtype=torch.int64)
+        timestamps = torch.arange(t, dtype=torch.float32)
+        return {
+            "pixel_values_videos": pixels,
+            "video_grid_thw": grid,
+            "timestamps": timestamps,
+        }, pixels, timestamps
+
+    def test_video_encoder_chunking_splits_and_concats(self):
+        """With chunking on, a large video is encoded in temporal chunks and the
+        per-chunk outputs are concatenated on the token axis in order."""
+        import torch
+        self._set_temporal_patch_size(tps=2)
+        self.runner.state_leaves = MagicMock()
+
+        t, h, w = 8, 2, 2  # rows_per_temporal_patch = h*w = 4
+        group, pixels, timestamps = self._make_video_group(t, h, w)
+
+        H_out = 6  # visual_dim + deepstack levels, packed on hidden axis
+        calls = []
+
+        def fake_embed(state_leaves, modality, **kwargs):
+            assert state_leaves is self.runner.state_leaves
+            assert modality == "video"
+            calls.append(kwargs)
+            idx = len(calls) - 1
+            ct = int(kwargs["video_grid_thw"].tolist()[0][0])
+            # one item -> length-1 tuple; mark rows with the chunk index.
+            return (jnp.full((ct, H_out), float(idx), dtype=jnp.float32), )
+
+        self.runner.embed_multimodal_fn = fake_embed
+
+        # frame_chunk=4, tps=2 -> chunk_t=2 temporal patches -> 4 chunks.
+        with patch.dict(os.environ, {"MM_ENCODER_FRAME_CHUNK": "4"}):
+            out = self.runner.mm_manager._embed_multimodal_maybe_chunked(
+                "video", 1, group)
+
+        # 4 chunks of 2 temporal patches each.
+        assert len(calls) == 4
+        rows_per_t = h * w
+        for i, kw in enumerate(calls):
+            g = kw["video_grid_thw"].tolist()[0]
+            assert g == [2, h, w]  # temporal count reduced to the chunk size
+            # pixels sliced to this chunk's rows, matching the original slab.
+            expected_pixels = pixels[i * 2 * rows_per_t:(i + 1) * 2 *
+                                     rows_per_t]
+            assert torch.equal(kw["pixel_values_videos"], expected_pixels)
+            # timestamps sliced to the chunk's temporal extent.
+            assert torch.equal(kw["timestamps"], timestamps[i * 2:(i + 1) * 2])
+
+        # Output: single item, concatenation of the 4 chunk outputs (8 tokens).
+        assert isinstance(out, list) and len(out) == 1
+        result = np.asarray(out[0])
+        assert result.shape == (t, H_out)
+        expected = np.concatenate(
+            [np.full((2, H_out), float(i)) for i in range(4)], axis=0)
+        np.testing.assert_array_equal(result, expected)
+
+    def test_video_encoder_no_chunk_when_disabled(self):
+        """MM_ENCODER_FRAME_CHUNK=0 -> single un-chunked call, passthrough."""
+        self._set_temporal_patch_size(tps=2)
+        self.runner.state_leaves = MagicMock()
+        group, _, _ = self._make_video_group(8, 2, 2)
+
+        sentinel = (jnp.ones((32, 6), dtype=jnp.float32), )
+        mock = MagicMock(return_value=sentinel)
+        self.runner.embed_multimodal_fn = mock
+
+        with patch.dict(os.environ, {"MM_ENCODER_FRAME_CHUNK": "0"}):
+            out = self.runner.mm_manager._embed_multimodal_maybe_chunked(
+                "video", 1, group)
+
+        mock.assert_called_once()
+        assert out is sentinel  # returned as-is, not re-wrapped
+
+    def test_video_encoder_no_chunk_when_fits_one_chunk(self):
+        """A video smaller than one chunk is encoded in a single call."""
+        self._set_temporal_patch_size(tps=2)
+        self.runner.state_leaves = MagicMock()
+        group, _, _ = self._make_video_group(4, 2, 2)  # t=4 temporal patches
+
+        mock = MagicMock(return_value=(jnp.ones((16, 6), dtype=jnp.float32), ))
+        self.runner.embed_multimodal_fn = mock
+
+        # chunk_t = 100//2 = 50 >= t=4 -> no split.
+        with patch.dict(os.environ, {"MM_ENCODER_FRAME_CHUNK": "100"}):
+            self.runner.mm_manager._embed_multimodal_maybe_chunked(
+                "video", 1, group)
+
+        mock.assert_called_once()
+
+    def test_video_encoder_no_chunk_when_pruning_enabled(self):
+        """EVS video-token pruning selects tokens across the whole video, so
+        chunking is skipped to stay lossless."""
+        self._set_temporal_patch_size(tps=2)
+        self.runner.model_config.multimodal_config = SimpleNamespace(
+            video_pruning_rate=0.5)
+        self.runner.state_leaves = MagicMock()
+        group, _, _ = self._make_video_group(8, 2, 2)
+
+        mock = MagicMock(return_value=(jnp.ones((16, 6), dtype=jnp.float32), ))
+        self.runner.embed_multimodal_fn = mock
+
+        with patch.dict(os.environ, {"MM_ENCODER_FRAME_CHUNK": "4"}):
+            self.runner.mm_manager._embed_multimodal_maybe_chunked(
+                "video", 1, group)
+
+        mock.assert_called_once()
+
+    def test_video_encoder_no_chunk_for_image_modality(self):
+        """Chunking only applies to video; images are never split."""
+        import torch
+        self._set_temporal_patch_size(tps=2)
+        self.runner.state_leaves = MagicMock()
+        group = {
+            "pixel_values":
+            torch.arange(32 * 5, dtype=torch.float32).reshape(32, 5),
+            "image_grid_thw":
+            torch.tensor([[8, 2, 2]], dtype=torch.int64),
+        }
+
+        mock = MagicMock(return_value=(jnp.ones((32, 6), dtype=jnp.float32), ))
+        self.runner.embed_multimodal_fn = mock
+
+        with patch.dict(os.environ, {"MM_ENCODER_FRAME_CHUNK": "4"}):
+            self.runner.mm_manager._embed_multimodal_maybe_chunked(
+                "image", 1, group)
+
+        mock.assert_called_once()
+
+    def test_video_encoder_no_chunk_multiple_items(self):
+        """A batched multi-item group is not chunked (only single video item)."""
+        self._set_temporal_patch_size(tps=2)
+        self.runner.state_leaves = MagicMock()
+        group, _, _ = self._make_video_group(8, 2, 2)
+
+        mock = MagicMock(return_value=(jnp.ones((16, 6), dtype=jnp.float32),
+                                       jnp.ones((16, 6), dtype=jnp.float32)))
+        self.runner.embed_multimodal_fn = mock
+
+        with patch.dict(os.environ, {"MM_ENCODER_FRAME_CHUNK": "4"}):
+            self.runner.mm_manager._embed_multimodal_maybe_chunked(
+                "video", 2, group)
+
+        mock.assert_called_once()
+
+    def test_video_encoder_chunking_ragged_last_chunk(self):
+        """When t is not a multiple of chunk_t, the last chunk is smaller and
+        the concatenated length still matches the full video."""
+        import torch
+        self._set_temporal_patch_size(tps=2)
+        self.runner.state_leaves = MagicMock()
+
+        t, h, w = 7, 1, 3  # 7 temporal patches, chunk_t=2 -> [2,2,2,1]
+        group, pixels, timestamps = self._make_video_group(t, h, w)
+        H_out = 4
+        calls = []
+
+        def fake_embed(state_leaves, modality, **kwargs):
+            calls.append(kwargs)
+            ct = int(kwargs["video_grid_thw"].tolist()[0][0])
+            return (jnp.full((ct, H_out), float(len(calls)),
+                             dtype=jnp.float32), )
+
+        self.runner.embed_multimodal_fn = fake_embed
+
+        with patch.dict(os.environ, {"MM_ENCODER_FRAME_CHUNK": "4"}):
+            out = self.runner.mm_manager._embed_multimodal_maybe_chunked(
+                "video", 1, group)
+
+        cts = [int(kw["video_grid_thw"].tolist()[0][0]) for kw in calls]
+        assert cts == [2, 2, 2, 1]
+        # last chunk pixels/timestamps cover the ragged tail.
+        rows_per_t = h * w
+        assert torch.equal(calls[-1]["pixel_values_videos"],
+                           pixels[6 * rows_per_t:7 * rows_per_t])
+        assert torch.equal(calls[-1]["timestamps"], timestamps[6:7])
+        assert np.asarray(out[0]).shape == (t, H_out)
+
+    def test_slice_timestamps_variants(self):
+        """_slice_timestamps handles 1D/2D tensors, lists, nested lists and
+        passes through non-sliceable values."""
+        import torch
+        slc = self.runner.mm_manager._slice_timestamps
+
+        # 1D tensor
+        r = slc(torch.arange(10), 2, 5)
+        assert torch.equal(r, torch.tensor([2, 3, 4]))
+        # 2D [1, T] tensor -> slice last axis
+        r = slc(torch.arange(10).reshape(1, 10), 2, 5)
+        assert r.shape == (1, 3)
+        assert torch.equal(r, torch.tensor([[2, 3, 4]]))
+        # flat list
+        assert slc(list(range(10)), 2, 5) == [2, 3, 4]
+        # nested single-item list
+        assert slc([list(range(10))], 2, 5) == [[2, 3, 4]]
+        # non-sliceable -> passthrough
+        assert slc(None, 2, 5) is None

--- a/tpu_inference/envs.py
+++ b/tpu_inference/envs.py
@@ -254,6 +254,14 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Enable new experimental model design
     "NEW_MODEL_DESIGN":
     env_bool("NEW_MODEL_DESIGN", default=False),
+    # Chunk the (Qwen3-VL) vision encoder over video frames to bound peak VMEM:
+    # encode at most this many frames per vision forward, then concatenate the
+    # per-chunk outputs. 0 disables (encode the whole video in one batch).
+    # Qwen3-VL vision attention is segmented per frame with spatial-only
+    # position embeddings, so chunking is bit-exact lossless (deepstack
+    # preserved); it auto-disables when EVS video-token pruning is on.
+    "MM_ENCODER_FRAME_CHUNK":
+    lambda: int(os.getenv("MM_ENCODER_FRAME_CHUNK") or "0"),
     # Directory to store phased profiling output
     "PHASED_PROFILING_DIR":
     lambda: os.getenv("PHASED_PROFILING_DIR", ""),

--- a/tpu_inference/runner/multimodal_manager.py
+++ b/tpu_inference/runner/multimodal_manager.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import jax
 import jax.numpy as jnp
@@ -22,6 +22,7 @@ from vllm.multimodal.inputs import MultiModalKwargsItem, PlaceholderRange
 from vllm.multimodal.utils import group_and_batch_mm_kwargs
 from vllm.v1.core.sched.output import SchedulerOutput as VllmSchedulerOutput
 
+from tpu_inference import envs
 from tpu_inference.logger import init_logger
 from tpu_inference.models.jax.utils.multi_modal_utils import \
     sanity_check_mm_encoder_outputs
@@ -144,8 +145,8 @@ class MultiModalManager:
             # 2. A list or tuple (length: num_items) of tensors, each of shape
             # (feature_size, hidden_size) in case the feature size is dynamic
             # depending on the input multimodal items.
-            curr_group_outputs = self.runner.embed_multimodal_fn(
-                self.runner.state_leaves, modality=modality, **mm_kwargs_group)
+            curr_group_outputs = self._embed_multimodal_maybe_chunked(
+                modality, num_items, mm_kwargs_group)
 
             sanity_check_mm_encoder_outputs(
                 curr_group_outputs,
@@ -162,6 +163,130 @@ class MultiModalManager:
         ):
 
             self.runner.encoder_cache[mm_hash] = output
+
+    def _embed_multimodal_maybe_chunked(self, modality: str, num_items: int,
+                                        mm_kwargs_group: dict):
+        """Run the vision encoder, splitting a single large video over temporal
+        chunks when ``MM_ENCODER_FRAME_CHUNK`` is set.
+
+        Encoding a long video in one shot makes the vision flash-attention
+        kernel process all ``t*h*w`` patches in a single call, which can
+        exhaust TPU VMEM. Qwen3-VL vision attention is segmented per frame
+        (``cu_seqlens`` has one entry per frame) and its position embeddings
+        are spatial-only, so a frame never attends across frame boundaries.
+        Splitting the video into temporal chunks and concatenating the
+        per-chunk outputs on the token axis is therefore bit-exact -- each
+        frame is encoded identically regardless of chunking. Deepstack
+        features ride on the hidden axis (dim=-1) and are preserved by the
+        token-axis concat.
+
+        The one cross-frame exception is EVS video-token pruning
+        (``video_pruning_rate``), which selects tokens across the whole video;
+        we fall back to a single un-chunked call when it is on to stay lossless.
+
+        Falls back to a single un-chunked call unless all of: the knob is on,
+        it's a single video item larger than one chunk, and pruning is off.
+        """
+
+        def _encode(kwargs: dict):
+            return self.runner.embed_multimodal_fn(self.runner.state_leaves,
+                                                   modality=modality,
+                                                   **kwargs)
+
+        frame_chunk = envs.MM_ENCODER_FRAME_CHUNK
+        grid_key = next(
+            (k for k in ("video_grid_thw", "image_grid_thw", "grid_thw")
+             if k in mm_kwargs_group), None)
+        pixel_key = next((k for k in ("pixel_values_videos", "pixel_values")
+                          if k in mm_kwargs_group), None)
+        # EVS pruning selects tokens across the whole video; chunking would
+        # prune each chunk independently, so skip it to stay lossless.
+        mm_config = getattr(self.runner.model_config, "multimodal_config",
+                            None)
+        pruning_on = bool(getattr(mm_config, "video_pruning_rate", None))
+
+        if (frame_chunk <= 0 or modality != "video" or num_items != 1
+                or grid_key is None or pixel_key is None or pruning_on):
+            return _encode(mm_kwargs_group)
+
+        grid = mm_kwargs_group[grid_key]
+        grid_list = grid.tolist() if hasattr(grid, "tolist") else list(grid)
+        if len(grid_list) != 1:
+            return _encode(mm_kwargs_group)
+        t, h, w = (int(x) for x in grid_list[0])
+
+        vision_config = getattr(self.runner.model_config.hf_config,
+                                "vision_config",
+                                self.runner.model_config.hf_config)
+        tps = int(getattr(vision_config, "temporal_patch_size", 2))
+        # frame_chunk is in raw frames; the grid temporal dim is in
+        # temporal-patches (each = tps frames).
+        chunk_t = max(1, frame_chunk // tps)
+        if t <= chunk_t:
+            return _encode(mm_kwargs_group)
+
+        pixels = mm_kwargs_group[pixel_key]
+        rows_per_t = h * w
+        timestamps = mm_kwargs_group.get("timestamps")
+
+        num_chunks = (t + chunk_t - 1) // chunk_t
+        logger.info(
+            "[mm_encoder chunk] video grid=(t=%d,h=%d,w=%d) %d patches -> "
+            "%d chunks of <=%d temporal-patches (<=%d frames)", t, h, w,
+            t * rows_per_t, num_chunks, chunk_t, chunk_t * tps)
+
+        chunk_outs = []
+        for t_start in range(0, t, chunk_t):
+            ct = min(chunk_t, t - t_start)
+            row_start = t_start * rows_per_t
+            row_end = (t_start + ct) * rows_per_t
+
+            chunk_grid = grid[:1].clone()
+            chunk_grid[0, 0] = ct
+
+            chunk_kwargs = dict(mm_kwargs_group)
+            chunk_kwargs[pixel_key] = pixels[row_start:row_end]
+            chunk_kwargs[grid_key] = chunk_grid
+            if timestamps is not None:
+                chunk_kwargs["timestamps"] = self._slice_timestamps(
+                    timestamps, t_start, t_start + ct)
+
+            out = _encode(chunk_kwargs)
+            # Each call returns per-item outputs; single item -> length 1.
+            # Pull to host immediately so device chunk buffers can be freed and
+            # aren't all held alongside the final concat.
+            chunk_outs.append(jax.device_get(out[0]))
+
+        # Concatenate on host (numpy) to avoid a per-shape XLA recompile of the
+        # concat and holding every chunk + the result in HBM at once, then move
+        # the assembled item back to device with the same sharding.
+        sharding = getattr(out[0], "sharding", None)
+        concatenated = np.concatenate(chunk_outs, axis=0)
+        if sharding is not None:
+            item = jax.device_put(concatenated, sharding)
+        else:
+            item = jnp.asarray(concatenated)
+        return [item]
+
+    @staticmethod
+    def _slice_timestamps(timestamps: Any, start: int, end: int) -> Any:
+        """Slice a per-temporal-patch timestamps field to [start, end).
+
+        The vision encoder itself ignores timestamps, but the input schema may
+        carry/validate them, so keep the length consistent with each chunk's
+        temporal extent. Handles a 1D tensor, a batched [1, T] tensor, and
+        (nested) python lists; passes anything else through unchanged.
+        """
+        if hasattr(timestamps, "ndim"):  # torch/np tensor
+            if timestamps.ndim == 1:
+                return timestamps[start:end]
+            return timestamps[..., start:end]
+        if isinstance(timestamps, (list, tuple)):
+            if len(timestamps) == 1 and isinstance(timestamps[0],
+                                                   (list, tuple)):
+                return type(timestamps)([timestamps[0][start:end]])
+            return timestamps[start:end]
+        return timestamps
 
     def gather_mm_embeddings(
         self,


### PR DESCRIPTION
## Problem

Encoding a long video runs the Qwen3-VL vision flash-attention kernel over
all `t*h*w` patches in a single call (43008 for a 384x8x14 clip),
overflowing TPU VMEM and killing EngineCore:

```
jax.errors.JaxRuntimeError: RESOURCE_EXHAUSTED: E1001: CompileTimeScopedVmemOom:
Ran out of memory in memory space vmem while allocating on stack for
%flash_attention.1 = bf16[1,2,43008,72] custom-call(...),
custom_call_target="tpu_custom_call".
Scoped allocation with size 42.25M and limit 32.00M exceeded scoped vmem limit by 10.25M.
```

Origin: vision `_forward_sdpa` -> flash_attention, inside
`_process_video_input` (`self.visual(pixel_values_videos, grid_thw)`).

## Fix

Add an opt-in `MM_ENCODER_FRAME_CHUNK` env knob (0 = off, current
behavior). When set, `execute_mm_encoder` slices a single large video into
temporal chunks of at most N frames, encodes each chunk via the existing
`embed_multimodal_fn`, and concatenates the per-chunk outputs on the token
axis. The concat is done on host then moved back to device with the
chunks' sharding, avoiding a per-shape XLA recompile and holding every
chunk buffer in HBM at once.

Lossless: Qwen3-VL vision attention is segmented per frame (`cu_seqlens`
has one entry per frame; there are no window / full-attention blocks) and
its position embeddings are spatial-only, so a frame never attends across
frame boundaries -- chunking is bit-exact. Deepstack features ride the
hidden axis and are preserved by the token-axis concat. Auto-disables when
EVS video-token pruning (`video_pruning_rate`) is on, since that selects
tokens across the whole video.

Falls back to a single un-chunked call unless: the knob is on, it's a
single video item larger than one chunk, and pruning is off.


## Tests

Tests cover split/concat, the ragged last chunk, all fallback paths
(disabled, fits-one-chunk, image modality, multi-item, pruning-enabled),
and the timestamps-slicing helper.

```
root@j-9947fd6b-15fa-4fd4-9d35-vllm-node-0-0:/workspace/tpu_inference# bash test_video.sh 
Sending 1 video request -> http://localhost:47903/v1/chat/completions
  model : Qwen/Qwen3-VL-8B-Instruct
  video : file:///datasets/videomme/data/sxrx7oCrb3A.mp4
  prompt: Describe what happens in this video in a few sentences.

HTTP 200
=== answer ===
This video features a series of basketball-themed challenges and games between two players, Jesser and his opponent, often set on an outdoor court with a luxurious mansion in the background. The games include timed shooting contests, rebounding challenges, and guessing games where players must identify NBA players based on hints. The video also incorporates playful elements like a “Hall of Fame” game, a “Dunk Contest,” and a “2K NBA Season Simulation” where they simulate a basketball season using a video game. Throughout, the players banter, react to each other’s performances, and celebrate wins with humor and excitement, creating a fun, competitive, and lighthearted atmosphere.
root@j-9947fd6b-15fa-4fd4-9d35-vllm-node-0-0:/workspace/tpu_inference# bash test_video.sh 
Sending 1 video request -> http://localhost:47903/v1/chat/completions
  model : Qwen/Qwen3-VL-8B-Instruct
  video : file:///datasets/videomme/data/sxrx7oCrb3A.mp4
  prompt: Describe what happens in this video in a few sentences.
```