### PR TITLE
[CI] Make DeepSeek-V4-Flash MMLU a nightly-only test

### DIFF
--- a/.buildkite/pipeline_jax.yml
+++ b/.buildkite/pipeline_jax.yml
@@ -274,7 +274,7 @@ steps:
           TPU_VERSION: "${TPU_VERSION:-tpu6e}"
         agents:
           queue: ${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}
-        if: '"${TPU_VERSION:-tpu6e}" == "tpu7x"'
+        if: build.env("NIGHTLY") == "1" && "${TPU_VERSION:-tpu6e}" == "tpu7x"
         commands:
           - |
             .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/mmlu.sh -m  "gs://tpu-commons-ci/deepseek-v4-flash" -n 14042 -l 4


### PR DESCRIPTION
## Problem
The `E2E MMLU for DeepSeek-V4-Flash torchax backend` step (`test_37` in `pipeline_jax.yml`) was added recently (#3109) and runs on **every tpu7x pre-commit build**. Its command runs a full 14042-question MMLU sweep:

```
mmlu.sh -m "gs://tpu-commons-ci/deepseek-v4-flash" -n 14042 -l 4
```

Measured over the last ~15 CI builds it averages **~37 min (up to 57 min)** on `tpu_v7x_8_queue` — the single **longest** job on that queue. `tpu_v7x_8_queue` has only 13 agents and is shared with other heavy accuracy/perf jobs, so a ~37-min pre-commit job on every PR is a large recurring draw and contributes to queue backlog/starvation.

## Fix
Gate the step behind `NIGHTLY=1`, matching the existing nightly-only heavy steps (`test_20`, `test_22`, `test_33`, `test_34`, `test_35`):

```yaml
-        if: '"${TPU_VERSION:-tpu6e}" == "tpu7x"'
+        if: build.env("NIGHTLY") == "1" && "${TPU_VERSION:-tpu6e}" == "tpu7x"
```

This keeps **full accuracy coverage in the nightly sweep** while removing the job from pre-commit, freeing `tpu_v7x_8_queue` capacity for PR builds.

## Safety
`test_37` remains listed in the notification step's `depends_on` and `check_results.sh` args — exactly like the other nightly-gated steps that are already in that list. Conditionally-excluded steps in `depends_on` are already tolerated on pre-commit today (the pipeline runs fine with `test_20/22/33/34/35` gated), so no notify-block changes are needed. YAML validated.