### PR TITLE
Reduce fused output when sequence parallelism is applied

### DIFF
--- a/tpu_inference/layers/vllm/custom_ops/fused_moe.py
+++ b/tpu_inference/layers/vllm/custom_ops/fused_moe.py
@@ -89,7 +89,10 @@ class VllmMoERunner(MoERunner):
         if mesh is None:
             return True
 
-        if self._shared_experts is None or is_attn_dp(mesh):
+        if self._shared_experts is None:
+            return True
+
+        if is_attn_dp(mesh) or self.moe_config.is_sequence_parallel:
             return True
 
         moe_backend = select_moe_backend_from_fused_moe_config(self.moe_config)


### PR DESCRIPTION
# Description

When sequence parallelism is applied, fused output is already reduced with reduce scatter.
Therefore `_fused_output_is_reduced` should return True when sequence parallelism is applied.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
