### PR TITLE
fix general_device_put failing with no source_mesh

### DIFF
--- a/tests/layers/common/test_utils.py
+++ b/tests/layers/common/test_utils.py
@@ -95,6 +95,40 @@ class UtilsTest(jtu.JaxTestCase):
                 self.assertIsInstance(result, list)
                 self.assertEqual(len(result), 2)
 
+    def test_general_device_put_cpu_jax_array_no_source_mesh(self):
+        # A CPU-pinned jax.Array with source_mesh=None must be converted to
+        # numpy before the make_array_from_callback call so that indexing inside
+        # the callback does not dispatch through JAX in the TPU mesh JIT context
+        # (which would raise "incompatible devices" in multi-host mode).
+        cpu_array = jax.device_put(jnp.ones((self.num_devices, 1)),
+                                   jax.devices('cpu')[0])
+
+        with mock.patch.object(envs, 'TPU_MULTIHOST_BACKEND', 'ray'):
+            with mock.patch.object(jax, 'device_get',
+                                   wraps=jax.device_get) as mock_device_get:
+                result = general_device_put(cpu_array, self.sharding)
+
+        mock_device_get.assert_called_once_with(cpu_array)
+        self.assertIsInstance(result, jax.Array)
+        self.assertAllClose(result, np.ones((self.num_devices, 1)))
+
+    def test_general_device_put_jax_array_with_source_mesh_skips_numpy_conversion(
+            self):
+        # When source_mesh is provided the existing jax.set_mesh context handles
+        # dispatch correctly; converting to numpy would be unnecessary overhead.
+        tensor = jnp.ones((self.num_devices, 1))
+
+        with mock.patch.object(envs, 'TPU_MULTIHOST_BACKEND', 'ray'):
+            with mock.patch.object(jax, 'device_get',
+                                   wraps=jax.device_get) as mock_device_get:
+                result = general_device_put(tensor,
+                                            self.sharding,
+                                            source_mesh=self.mesh)
+
+        mock_device_get.assert_not_called()
+        self.assertIsInstance(result, jax.Array)
+        self.assertAllClose(result, np.ones((self.num_devices, 1)))
+
     def test_truncate_sharded_tensor(self):
         # Shape: (2, 20), n_shards=4, so each shard has size 5 on the last dim
         t = jnp.arange(40).reshape(2, 20)

--- a/tpu_inference/layers/common/utils.py
+++ b/tpu_inference/layers/common/utils.py
@@ -16,6 +16,7 @@ from contextlib import nullcontext
 
 import jax
 import jax.numpy as jnp
+import numpy as np
 from jax.experimental.layout import Format, Layout
 from jax.sharding import Mesh, Sharding
 
@@ -154,7 +155,11 @@ def general_device_put(tensor: jax.Array,
         ctx = nullcontext() if source_mesh is None else jax.set_mesh(
             source_mesh)
         # `t[i]` needs to be operated in the same mesh as `t`, which is provided as
-        # `source_mesh`.
+        # `source_mesh`. Without source_mesh, a CPU-placed jax.Array would dispatch
+        # through JAX inside the TPU mesh JIT context and raise "incompatible
+        # devices". Converting t to numpy keeps the callback in plain numpy land.
+        if source_mesh is None and isinstance(t, jax.Array):
+            t = np.asarray(jax.device_get(t))
         with ctx:
             global_array = jax.make_array_from_callback(
                 t.shape, sharding, lambda index: t[index])


### PR DESCRIPTION
# Description


See https://github.com/ray-project/ray/issues/63828

When serving certain models on multihost TPU configurations, initialization fails with 

`ValueError: Received incompatible devices for jitted computation. Got argument args[0] of dynamic_slice with shape float8_e4m3fn[3072,1024] and with device ids [0] on platform CPU and jit's context mesh with device ids [0, 1, 2, 3, 7, 6, 5, 9, 10, 11, 15, 14, 13, 12, 8, 4] on platform TPU`

When t is a CPU jax.Array and no source_mesh is given, that indexing dispatches through JAX inside the global TPU mesh JIT
 context, which fails.

To fix, t should be recast to a numpy array and stay on the CPU.

# Tests

Tested via runtime patch (see Ray issue)

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
