### PR TITLE
[CI] Make qwen3-coder 8k-1k perf regression tests nightly-only

### DIFF
--- a/.buildkite/pipeline_jax.yml
+++ b/.buildkite/pipeline_jax.yml
@@ -380,7 +380,7 @@ steps:
           TPU_VERSION: "${TPU_VERSION:-tpu6e}"
         agents:
           queue: ${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}
-        if: '"${TPU_VERSION:-tpu6e}" == "tpu7x"'
+        if: build.env("NIGHTLY") == "1" && "${TPU_VERSION:-tpu6e}" == "tpu7x"
         commands:
           - |
             .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/bm_qwen3_coder.sh --model Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8 --tp 8 --req_tput_limit 0.4  --output_token_tput_limit 381 --total_token_tput_limit 3421 --input_len 8192 --output_len 1024 --use_moe_ep_kernel 1
@@ -405,7 +405,7 @@ steps:
           TPU_VERSION: "${TPU_VERSION:-tpu6e}"
         agents:
           queue: ${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}
-        if: '"${TPU_VERSION:-tpu6e}" == "tpu7x"'
+        if: build.env("NIGHTLY") == "1" && "${TPU_VERSION:-tpu6e}" == "tpu7x"
         commands:
           - |
             .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/bm_qwen3_coder.sh --model Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8 --tp 8 --req_tput_limit 0.63  --output_token_tput_limit 645 --total_token_tput_limit 5781 --input_len 8192 --output_len 1024 --use_moe_ep_kernel 0


### PR DESCRIPTION
## Problem
Two `Perf regression test for qwen3 coder 8k 1k` steps run on **every tpu7x pre-commit build**:

- `test_21` — 8k 1k with **fused moe** kernel (`--use_moe_ep_kernel 1`)
- `test_23` — 8k 1k with **gmm** kernel (`--use_moe_ep_kernel 0`)

Measured over the last ~15 CI builds they average **~23 min** and **~17 min** respectively on `tpu_v7x_8_queue` (13 agents, shared with other heavy accuracy/perf jobs). Perf-regression benchmarks don't need to gate every PR, and their **1k 8k** counterparts (`test_20`, `test_22`) are **already** nightly-gated — so the current state is inconsistent.

## Fix
Gate both `8k 1k` perf steps behind `NIGHTLY=1`, matching `test_20`/`test_22`:

```yaml
-        if: '"${TPU_VERSION:-tpu6e}" == "tpu7x"'
+        if: build.env("NIGHTLY") == "1" && "${TPU_VERSION:-tpu6e}" == "tpu7x"
```

After this, all four qwen3-coder perf-regression variants (test_20/21/22/23) are nightly-only and consistent.

## Scope / safety
- The qwen3-coder **`lm_eval` accuracy checks** (`test_17`, `test_18`) are **intentionally left on pre-commit** — correctness stays gated on every PR; only the perf regressions move to nightly.
- Both steps remain in the notification `depends_on` / `check_results.sh` args, exactly like the already-nightly-gated steps (conditionally-excluded steps in `depends_on` are already tolerated on pre-commit today). No notify-block changes needed. YAML validated.