### PR TITLE
[CI] Fix spec decoding test after updating gemma4 weight loading

### DIFF
--- a/tpu_inference/spec_decode/jax/eagle3.py
+++ b/tpu_inference/spec_decode/jax/eagle3.py
@@ -130,6 +130,8 @@ class Eagle3Proposer:
             # 2. Resolve target embed param in target_model (which is already the target state)
             target_embed_param = None
             for path in [
+                    "model.language_model.embed_tokens.weight",
+                    "language_model.embed_tokens.weight",
                     "model.embed_tokens.weight", "model.embed.embedding",
                     "model.embed_tokens.embedding"
             ]:


### PR DESCRIPTION
# Description

Fix the CI test after updating gemma4 namings for weight loading: https://github.com/vllm-project/tpu-inference/pull/3107.

# Tests

Tested locally with `pytest tests/e2e/test_speculative_decoding.py -k "test_gemma4_mtp_correctness and False-False" -s -v`.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
