### PR TITLE
Normalize offload boolean env parsing

### DIFF
--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -151,6 +151,30 @@ def test_boolean_env_vars_string_values(monkeypatch: pytest.MonkeyPatch):
     assert envs.USE_MOE_EP_KERNEL is False
 
 
+@pytest.mark.parametrize("env_name", [
+    "TPU_OFFLOAD_SKIP_JAX_PRECOMPILE",
+    "TPU_OFFLOAD_DECODE_SAVE",
+    "TPU_OFFLOAD_BATCHED_SAVE",
+    "TPU_OFFLOAD_USE_UNPINNED_HOST",
+])
+def test_offload_boolean_env_vars_use_bool_parser(
+        monkeypatch: pytest.MonkeyPatch, env_name: str):
+    monkeypatch.setenv(env_name, "true")
+    assert getattr(envs, env_name) is True
+
+    monkeypatch.setenv(env_name, "False")
+    assert getattr(envs, env_name) is False
+
+    monkeypatch.setenv(env_name, "")
+    assert getattr(envs, env_name) is False
+
+    monkeypatch.setenv(env_name, "enabled")
+    with pytest.raises(
+            ValueError,
+            match=f"Invalid boolean value 'enabled' for {env_name}"):
+        getattr(envs, env_name)
+
+
 def test_boolean_env_vars_invalid_values(monkeypatch: pytest.MonkeyPatch):
     """Test that boolean env vars raise errors for invalid values"""
 

--- a/tpu_inference/envs.py
+++ b/tpu_inference/envs.py
@@ -330,10 +330,10 @@ environment_variables: dict[str, Callable[[], Any]] = {
     lambda: os.getenv("MOE_ALL_GATHER_ACTIVATION_DTYPE", ""),
     # kv offload to dram: skip pre-compiling swap-related jax functions
     "TPU_OFFLOAD_SKIP_JAX_PRECOMPILE":
-    lambda: bool(int(os.getenv("TPU_OFFLOAD_SKIP_JAX_PRECOMPILE", "0"))),
+    env_bool("TPU_OFFLOAD_SKIP_JAX_PRECOMPILE", default=False),
     # kv offload to dram: save kv in the decode phase
     "TPU_OFFLOAD_DECODE_SAVE":
-    lambda: bool(int(os.getenv("TPU_OFFLOAD_DECODE_SAVE", "0"))),
+    env_bool("TPU_OFFLOAD_DECODE_SAVE", default=False),
     # kv offload to dram: dram space size in # of chunks / blocks
     "TPU_OFFLOAD_NUM_CPU_CHUNKS":
     lambda: int(os.getenv("TPU_OFFLOAD_NUM_CPU_CHUNKS", "1024")),
@@ -345,13 +345,13 @@ environment_variables: dict[str, Callable[[], Any]] = {
     lambda: int(os.getenv("TPU_OFFLOAD_SAVE_THREADS", "1")),
     # kv offload to dram: batch multiple requests' save operations into a single swap call
     "TPU_OFFLOAD_BATCHED_SAVE":
-    lambda: bool(int(os.getenv("TPU_OFFLOAD_BATCHED_SAVE", "0"))),
+    env_bool("TPU_OFFLOAD_BATCHED_SAVE", default=False),
     # kv offload to dram: prometheus metrics log interval in seconds
     "TPU_OFFLOAD_METRICS_LOG_INTERVAL":
     lambda: int(os.getenv("TPU_OFFLOAD_METRICS_LOG_INTERVAL", "10")),
     # kv offload to dram: Whether to use unpinned_host for KV cache tensors on host dram.
     "TPU_OFFLOAD_USE_UNPINNED_HOST":
-    lambda: bool(int(os.getenv("TPU_OFFLOAD_USE_UNPINNED_HOST", "0"))),
+    env_bool("TPU_OFFLOAD_USE_UNPINNED_HOST", default=False),
     "AGGREGATED_STATS_DIR":
     lambda: os.getenv("AGGREGATED_STATS_DIR", ""),
     # kv offload to dram: buckets of sizes for pre-compilation


### PR DESCRIPTION
## Summary
- normalize offload-related boolean environment variable parsing
- accept common false-like string values instead of treating every non-empty string as true
- add tests covering enabled, disabled, unset, and invalid boolean env values

## Tests
- Not run (local python3 environment does not have pytest installed).