### PR TITLE
Patch _patch_jax_pallas_fori_lowering

### DIFF
--- a/tpu_inference/env_override.py
+++ b/tpu_inference/env_override.py
@@ -41,3 +41,55 @@ except ImportError:
 # upstream vLLM (e.g. DeepSeek V4 ops), but only actually invoked on NVIDIA GPUs.
 if "cutlass" not in sys.modules:
     sys.modules["cutlass"] = types.ModuleType("cutlass")
+
+def _patch_jax_pallas_fori_lowering() -> None:
+    """Elide the dead remainder ``scf.for`` from Pallas ``fori_loop`` lowering.
+
+    JAX Pallas' Mosaic lowering unconditionally emits a remainder loop for
+    dynamic-bound ``jax.lax.fori_loop`` even when ``unroll=1`` (the default),
+    where the main loop already covers the full range and the remainder is a
+    no-op. libtpu still lowers the empty remainder to device code, which
+    materially grows the emitted Mosaic body and slows decode-heavy MoE
+    workloads that rely on ``fori_loop`` in Pallas scheduler kernels.
+
+    Rewrites ``_lower_jaxpr_to_for_loop`` in place to gate the remainder
+    emission on ``unroll != 1``. Applied at import so it takes effect before
+    any Pallas kernel is traced. No-op if the source no longer contains the
+    exact needle (upstream fix landed, or the file was refactored), so it
+    remains safe across JAX bumps.
+    """
+    try:
+        from jax._src.pallas.mosaic import lowering as _lowering
+    except Exception:
+        return
+    if getattr(_lowering, "_torchtpu_fori_patch_applied", False):
+        return
+    orig = getattr(_lowering, "_lower_jaxpr_to_for_loop", None)
+    if orig is None:
+        return
+
+    import inspect
+    import textwrap
+    try:
+        src = textwrap.dedent(inspect.getsource(orig))
+    except Exception:
+        return
+    needle = "elif has_dynamic_remainder:"
+    fix = "elif has_dynamic_remainder and unroll != 1:"
+    if needle not in src or fix in src:
+        return
+    patched_src = src.replace(needle, fix, 1)
+    ns: dict = {"__name__": _lowering.__name__}
+    try:
+        exec(compile(patched_src, _lowering.__file__, "exec"),
+             _lowering.__dict__, ns)
+    except Exception:
+        return
+    new_fn = ns.get("_lower_jaxpr_to_for_loop")
+    if new_fn is None:
+        return
+    _lowering._lower_jaxpr_to_for_loop = new_fn
+    _lowering._torchtpu_fori_patch_applied = True
+
+
+_patch_jax_pallas_fori_lowering()


### PR DESCRIPTION
# Description

Patch _patch_jax_pallas_fori_lowering()
Tested: USE_BATCHED_RPA_KERNEL=1 SKIP_JAX_PRECOMPILE=0 MODEL_IMPL_TYPE=vllm USE_MOE_EP_KERNEL=0 ATTN_BUCKETIZED_NUM_REQS=true ATTN_CUSTOM_NUM_REQS_BUCKETS=8,16,32,64 ONEHOT_MOE_PERMUTE_THRESHOLD=32768 VLLM_MOE_CHUNK_SIZE=256 NEW_MODEL_DESIGN=1 LIBTPU_INIT_ARGS=' --xla_tpu_use_minor_sharding_for_major_trivial_input=true --xla_tpu_enable_sparse_core_collective_offload_reduce_scatter=false --xla_tpu_ars_combiner_threshold_in_bytes=0 --xla_tpu_enable_async_collective_merger=false --xla_tpu_check_legacy_constraints_in_reduce_scatter_legalizer=false' vllm serve Qwen/Qwen3.5-397B-A17B-FP8 --max-model-len=9216 --max-num-batched-tokens=1024 --max-num-seqs=64 --no-enable-prefix-caching --gpu-memory-utilization=0.88 --tensor-parallel-size=8 --async-scheduling --port=8000 --language-model-only --enable-auto-tool-choice --tool-call-parser=qwen3_coder --reasoning-parser=qwen3 '--limit-mm-per-prompt={"image": 0, "video": 0}' --kv-cache-dtype=fp8 --enable-expert-parallel '--additional_config={"sharding": {"sharding_strategy": {"enable_dp_attention": true}}}' --block-size=256

python ./bench_serving/benchmark_serving.py --model Qwen/Qwen3.5-397B-A17B-FP8 --dataset-name random --backend vllm --random-input-len=8192 --random-output-len=1024 --num-prompts=640 --random-range-ratio=0.8 --ignore-eos --save-result --result-dir /tmp/vllm_bench_nvtapz5v --max-concurrency=64

****Does not improve throughput over RPAv3*********

============ Serving Benchmark Result ============
Successful requests:                     640       
Benchmark duration (s):                  399.76    
Total input tokens:                      4727544   
Total generated tokens:                  589927    
Request throughput (req/s):              1.60      
Output token throughput (tok/s):         1475.71   
Total Token throughput (tok/s):          13301.68  
---------------Time to First Token----------------
Mean TTFT (ms):                          2896.09   
Median TTFT (ms):                        2134.04   
P99 TTFT (ms):                           19856.93  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          38.22     
Median TPOT (ms):                        38.63     
P99 TPOT (ms):                           43.34     
---------------Inter-token Latency----------------
Mean ITL (ms):                           38.27     
Median ITL (ms):                         29.68     
P99 ITL (ms):                            173.19    
==================================================


# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
