### PR TITLE
Gate MoE merged all-reduce on shared expert deferral capability

### DIFF
--- a/.buildkite/pipeline_dev.yml
+++ b/.buildkite/pipeline_dev.yml
@@ -12,8 +12,35 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Dev pipeline for tpu-inference-dev.
+# Demo/sample steps showing how to run custom tests on tpu7x.
+# Copy and adapt any step for your own experiments.
+#
+# HOW TO TRIGGER THIS PIPELINE
+# ─────────────────────────────
+# Option A — Buildkite UI:
+#   Go to https://buildkite.com/tpu-commons/tpu-inference-dev
+#   Click "New Build", set branch to your branch, click "Create Build".
+#
+# Option B — Buildkite API (requires BUILDKITE_API_TOKEN in your env):
+#   curl -s -X POST \
+#     -H "Authorization: Bearer $BUILDKITE_API_TOKEN" \
+#     -H "Content-Type: application/json" \
+#     "https://api.buildkite.com/v2/organizations/tpu-commons/pipelines/tpu-inference-dev/builds" \
+#     -d "{\"commit\": \"$(git rev-parse HEAD)\", \"branch\": \"$(git rev-parse --abbrev-ref HEAD)\", \"message\": \"my test\"}"
+#
+# HOW TO CUSTOMIZE
+# ─────────────────
+# 1. On your branch, edit this file — use any demo step below as a starting point.
+# 2. Change the command, model, env vars, or queue as needed.
+# 3. Trigger the pipeline — only your branch's file is used.
+
 steps:
-  - label: ":docker: Build base image (tpu7x)"
+
+  # -----------------------------------------------------------------
+  # Build Step (required by all demo steps below)
+  # -----------------------------------------------------------------
+  - label: ":docker: Build and Push Base Image (tpu7x)"
     key: tpu7x_build_docker
     agents:
       queue: cpu_64_core
@@ -22,18 +49,100 @@ steps:
     commands:
       - bash -c 'source .buildkite/scripts/setup_docker_env.sh && setup_environment "vllm-tpu" "false" "true"'
 
-  - label: "tpu7x EP correctness A/B (Qwen1.5-MoE-A2.7B)"
-    key: tpu7x_ep_ab
+  # -----------------------------------------------------------------
+  # Demo 1: offline_inference.py
+  # Shows the simplest pattern: run a Python script inside Docker.
+  # Use this as a starting point for any offline batch inference test.
+  # -----------------------------------------------------------------
+  - label: "tpu7x [demo] offline_inference.py"
+    key: tpu7x_demo_offline_inference
     depends_on: tpu7x_build_docker
-    agents:
-      queue: tpu_v7x_8_queue
     env:
       USE_PREBUILT_IMAGE: "1"
       TPU_VERSION: "tpu7x"
+    agents:
+      queue: tpu_v7x_2_queue
     commands:
       - |
-        .buildkite/scripts/run_in_docker.sh \
-          bash /workspace/tpu_inference/tests/e2e/check_lm_eval.sh --model_name "Qwen/Qwen1.5-MoE-A2.7B" --use_moe_ep_kernel 1 --tensor_parallel_size 4 --max_model_len 1024 --max_num_batched_tokens 128 --max_gen_toks 128 --enable_expert_parallel 1 --flex_threshold 0.37 --strict_threshold 0.06
+        # Run offline inference with a small model.
+        # --tensor-parallel-size 2: tp=1 is currently unsupported on tpu7x.
+        # Customize --model, --max-model-len, --max-tokens as needed.
+        .buildkite/scripts/run_in_docker.sh bash -c '
+          python3 examples/offline_inference.py \
+            --model Qwen/Qwen3-0.6B \
+            --tensor-parallel-size 2 \
+            --max-model-len 1024 \
+            --max-tokens 128'
+
+  # -----------------------------------------------------------------
+  # Demo 2: vllm serve + vllm bench serve
+  # Shows how to start a server and run a benchmark against it.
+  # Uses --dataset-name random so no dataset file is needed.
+  # -----------------------------------------------------------------
+  - label: "tpu7x [demo] vllm serve + vllm bench serve"
+    key: tpu7x_demo_serve_bench
+    depends_on: tpu7x_build_docker
+    env:
+      USE_PREBUILT_IMAGE: "1"
+      TPU_VERSION: "tpu7x"
+    agents:
+      queue: tpu_v7x_2_queue
+    commands:
       - |
-        .buildkite/scripts/run_in_docker.sh \
-          bash /workspace/tpu_inference/tests/e2e/check_lm_eval.sh --model_name "Qwen/Qwen1.5-MoE-A2.7B" --use_moe_ep_kernel 0 --tensor_parallel_size 4 --max_model_len 1024 --max_num_batched_tokens 128 --max_gen_toks 128 --enable_expert_parallel 1 --flex_threshold 0.37 --strict_threshold 0.06
+        # Customize behaviour via env vars: MODEL, PORT, TENSOR_PARALLEL_SIZE,
+        # MAX_MODEL_LEN, RANDOM_INPUT_LEN, RANDOM_OUTPUT_LEN, NUM_PROMPTS, NUM_WARMUPS.
+        .buildkite/scripts/run_in_docker.sh bash .buildkite/scripts/run_benchmark_demo.sh
+
+  # -----------------------------------------------------------------
+  # Demo 3: DCN-based P/D disaggregation
+  # Mirrors test_25 in pipeline_jax.yml.
+  # Uses run_disagg.sh which delegates to examples/disagg/.
+  # Requires a multi-chip queue (tpu_v7x_8_queue).
+  # -----------------------------------------------------------------
+  - label: "tpu7x [demo] E2E disaggregation (DCN P/D)"
+    key: tpu7x_demo_disagg
+    depends_on: tpu7x_build_docker
+    env:
+      USE_PREBUILT_IMAGE: "1"
+      TPU_VERSION: "tpu7x"
+      # Customize these to change the disagg benchmark behaviour.
+      MODEL: "Qwen/Qwen3-0.6B"
+      INPUT_LEN: 1024
+      OUTPUT_LEN: 128
+      NUM_PROMPTS: 5
+      RANDOM_SEED: 10
+      MAX_CONCURRENCY: 4
+      TEST_MODE: 1
+    agents:
+      queue: tpu_v7x_8_queue
+    commands:
+      - .buildkite/scripts/run_disagg.sh
+
+  # -----------------------------------------------------------------
+  # Demo 4: Ray-based multi-host inference
+  # Mirrors test_26 in pipeline_jax.yml.
+  # Uses run_multihost.sh to serve a large model across 16 chips (2 hosts).
+  # Requires a 16-chip queue (tpu_v7x_16_queue).
+  # -----------------------------------------------------------------
+  - label: "tpu7x [demo] Ray-based multi-host"
+    key: tpu7x_demo_multihost
+    env:
+      TPU_VERSION: "tpu7x"
+    agents:
+      queue: tpu_v7x_16_queue
+    commands:
+      - |
+        MODEL="gs://tpu-commons-ci/qwen/models--Qwen--Qwen3-30B-A3B/snapshots/ad44e777bcd18fa416d9da3bd8f70d33ebb85d39"
+        .buildkite/scripts/run_multihost.sh \
+          "vllm serve \${MODEL} \
+            --port 8000 \
+            --tensor-parallel-size 16 \
+            --trust-remote-code \
+            --max-model-len 1024 \
+            --no-async-scheduling \
+            --load-format=runai_streamer \
+            --no-enable-prefix-caching" \
+          "curl http://localhost:8000/v1/completions \
+            -X POST \
+            -H 'Content-Type: application/json' \
+            -d '{\"model\": \"${MODEL}\", \"prompt\": \"San Francisco is a\", \"max_tokens\": 50}'"

--- a/.buildkite/pipeline_dev.yml
+++ b/.buildkite/pipeline_dev.yml
@@ -12,35 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Dev pipeline for tpu-inference-dev.
-# Demo/sample steps showing how to run custom tests on tpu7x.
-# Copy and adapt any step for your own experiments.
-#
-# HOW TO TRIGGER THIS PIPELINE
-# ─────────────────────────────
-# Option A — Buildkite UI:
-#   Go to https://buildkite.com/tpu-commons/tpu-inference-dev
-#   Click "New Build", set branch to your branch, click "Create Build".
-#
-# Option B — Buildkite API (requires BUILDKITE_API_TOKEN in your env):
-#   curl -s -X POST \
-#     -H "Authorization: Bearer $BUILDKITE_API_TOKEN" \
-#     -H "Content-Type: application/json" \
-#     "https://api.buildkite.com/v2/organizations/tpu-commons/pipelines/tpu-inference-dev/builds" \
-#     -d "{\"commit\": \"$(git rev-parse HEAD)\", \"branch\": \"$(git rev-parse --abbrev-ref HEAD)\", \"message\": \"my test\"}"
-#
-# HOW TO CUSTOMIZE
-# ─────────────────
-# 1. On your branch, edit this file — use any demo step below as a starting point.
-# 2. Change the command, model, env vars, or queue as needed.
-# 3. Trigger the pipeline — only your branch's file is used.
-
 steps:
-
-  # -----------------------------------------------------------------
-  # Build Step (required by all demo steps below)
-  # -----------------------------------------------------------------
-  - label: ":docker: Build and Push Base Image (tpu7x)"
+  - label: ":docker: Build base image (tpu7x)"
     key: tpu7x_build_docker
     agents:
       queue: cpu_64_core
@@ -49,100 +22,18 @@ steps:
     commands:
       - bash -c 'source .buildkite/scripts/setup_docker_env.sh && setup_environment "vllm-tpu" "false" "true"'
 
-  # -----------------------------------------------------------------
-  # Demo 1: offline_inference.py
-  # Shows the simplest pattern: run a Python script inside Docker.
-  # Use this as a starting point for any offline batch inference test.
-  # -----------------------------------------------------------------
-  - label: "tpu7x [demo] offline_inference.py"
-    key: tpu7x_demo_offline_inference
+  - label: "tpu7x EP correctness A/B (Qwen1.5-MoE-A2.7B)"
+    key: tpu7x_ep_ab
     depends_on: tpu7x_build_docker
-    env:
-      USE_PREBUILT_IMAGE: "1"
-      TPU_VERSION: "tpu7x"
-    agents:
-      queue: tpu_v7x_2_queue
-    commands:
-      - |
-        # Run offline inference with a small model.
-        # --tensor-parallel-size 2: tp=1 is currently unsupported on tpu7x.
-        # Customize --model, --max-model-len, --max-tokens as needed.
-        .buildkite/scripts/run_in_docker.sh bash -c '
-          python3 examples/offline_inference.py \
-            --model Qwen/Qwen3-0.6B \
-            --tensor-parallel-size 2 \
-            --max-model-len 1024 \
-            --max-tokens 128'
-
-  # -----------------------------------------------------------------
-  # Demo 2: vllm serve + vllm bench serve
-  # Shows how to start a server and run a benchmark against it.
-  # Uses --dataset-name random so no dataset file is needed.
-  # -----------------------------------------------------------------
-  - label: "tpu7x [demo] vllm serve + vllm bench serve"
-    key: tpu7x_demo_serve_bench
-    depends_on: tpu7x_build_docker
-    env:
-      USE_PREBUILT_IMAGE: "1"
-      TPU_VERSION: "tpu7x"
-    agents:
-      queue: tpu_v7x_2_queue
-    commands:
-      - |
-        # Customize behaviour via env vars: MODEL, PORT, TENSOR_PARALLEL_SIZE,
-        # MAX_MODEL_LEN, RANDOM_INPUT_LEN, RANDOM_OUTPUT_LEN, NUM_PROMPTS, NUM_WARMUPS.
-        .buildkite/scripts/run_in_docker.sh bash .buildkite/scripts/run_benchmark_demo.sh
-
-  # -----------------------------------------------------------------
-  # Demo 3: DCN-based P/D disaggregation
-  # Mirrors test_25 in pipeline_jax.yml.
-  # Uses run_disagg.sh which delegates to examples/disagg/.
-  # Requires a multi-chip queue (tpu_v7x_8_queue).
-  # -----------------------------------------------------------------
-  - label: "tpu7x [demo] E2E disaggregation (DCN P/D)"
-    key: tpu7x_demo_disagg
-    depends_on: tpu7x_build_docker
-    env:
-      USE_PREBUILT_IMAGE: "1"
-      TPU_VERSION: "tpu7x"
-      # Customize these to change the disagg benchmark behaviour.
-      MODEL: "Qwen/Qwen3-0.6B"
-      INPUT_LEN: 1024
-      OUTPUT_LEN: 128
-      NUM_PROMPTS: 5
-      RANDOM_SEED: 10
-      MAX_CONCURRENCY: 4
-      TEST_MODE: 1
     agents:
       queue: tpu_v7x_8_queue
-    commands:
-      - .buildkite/scripts/run_disagg.sh
-
-  # -----------------------------------------------------------------
-  # Demo 4: Ray-based multi-host inference
-  # Mirrors test_26 in pipeline_jax.yml.
-  # Uses run_multihost.sh to serve a large model across 16 chips (2 hosts).
-  # Requires a 16-chip queue (tpu_v7x_16_queue).
-  # -----------------------------------------------------------------
-  - label: "tpu7x [demo] Ray-based multi-host"
-    key: tpu7x_demo_multihost
     env:
+      USE_PREBUILT_IMAGE: "1"
       TPU_VERSION: "tpu7x"
-    agents:
-      queue: tpu_v7x_16_queue
     commands:
       - |
-        MODEL="gs://tpu-commons-ci/qwen/models--Qwen--Qwen3-30B-A3B/snapshots/ad44e777bcd18fa416d9da3bd8f70d33ebb85d39"
-        .buildkite/scripts/run_multihost.sh \
-          "vllm serve \${MODEL} \
-            --port 8000 \
-            --tensor-parallel-size 16 \
-            --trust-remote-code \
-            --max-model-len 1024 \
-            --no-async-scheduling \
-            --load-format=runai_streamer \
-            --no-enable-prefix-caching" \
-          "curl http://localhost:8000/v1/completions \
-            -X POST \
-            -H 'Content-Type: application/json' \
-            -d '{\"model\": \"${MODEL}\", \"prompt\": \"San Francisco is a\", \"max_tokens\": 50}'"
+        .buildkite/scripts/run_in_docker.sh \
+          bash /workspace/tpu_inference/tests/e2e/check_lm_eval.sh --model_name "Qwen/Qwen1.5-MoE-A2.7B" --use_moe_ep_kernel 1 --tensor_parallel_size 4 --max_model_len 1024 --max_num_batched_tokens 128 --max_gen_toks 128 --enable_expert_parallel 1 --flex_threshold 0.37 --strict_threshold 0.06
+      - |
+        .buildkite/scripts/run_in_docker.sh \
+          bash /workspace/tpu_inference/tests/e2e/check_lm_eval.sh --model_name "Qwen/Qwen1.5-MoE-A2.7B" --use_moe_ep_kernel 0 --tensor_parallel_size 4 --max_model_len 1024 --max_num_batched_tokens 128 --max_gen_toks 128 --enable_expert_parallel 1 --flex_threshold 0.37 --strict_threshold 0.06

--- a/tests/layers/vllm/test_fused_moe.py
+++ b/tests/layers/vllm/test_fused_moe.py
@@ -17,9 +17,31 @@ from unittest.mock import PropertyMock, patch
 
 import pytest
 import torch
+from vllm.model_executor.layers.linear import RowParallelLinear
 
 from tpu_inference.layers.common.moe import MoEBackend
 from tpu_inference.layers.vllm.custom_ops import fused_moe as fm
+
+
+def _fake_row_parallel_linear(defer_all_reduce: bool) -> RowParallelLinear:
+    """A ``RowParallelLinear`` shell carrying only ``quant_method.linear_config``.
+
+    Built via ``__new__`` + ``torch.nn.Module.__init__`` so no distributed
+    state is needed; ``_shared_experts_defer_all_reduce`` only reads the
+    linear_config off the quant method.
+    """
+    fake = RowParallelLinear.__new__(RowParallelLinear)
+    torch.nn.Module.__init__(fake)
+    fake.quant_method = SimpleNamespace(linear_config=SimpleNamespace(
+        defer_all_reduce=defer_all_reduce))
+    return fake
+
+
+def _shared_experts(defer_all_reduce: bool = True) -> torch.nn.Module:
+    """A shared-experts module whose down proj does/doesn't defer its reduce."""
+    module = torch.nn.Module()
+    module.down_proj = _fake_row_parallel_linear(defer_all_reduce)
+    return module
 
 
 def _make_runner(*,
@@ -33,6 +55,9 @@ def _make_runner(*,
     set directly (mirroring ``test_gdn_attention_op.py``).
     """
     runner = fm.VllmMoERunner.__new__(fm.VllmMoERunner)
+    # Initialize the bare nn.Module machinery (skipping MoERunner.__init__)
+    # so module-valued attributes like ``_shared_experts`` can be assigned.
+    torch.nn.Module.__init__(runner)
     runner._shared_experts = shared_experts
     runner.moe_config = moe_config or SimpleNamespace(
         is_sequence_parallel=is_sequence_parallel)
@@ -48,7 +73,7 @@ class TestFusedOutputIsReduced:
             assert runner._fused_output_is_reduced is True
 
     def test_true_under_attention_dp(self):
-        runner = _make_runner(shared_experts=object())
+        runner = _make_runner(shared_experts=_shared_experts())
         with patch.object(fm, "_get_mesh", return_value=object()), \
              patch.object(fm, "is_attn_dp", return_value=True):
             assert runner._fused_output_is_reduced is True
@@ -60,7 +85,7 @@ class TestFusedOutputIsReduced:
         # reduction axes match the shared expert's), DP resolves the reduction
         # separately so the kernel must still reduce its own output. Guards the
         # order of the checks -- the DP short-circuit must precede the GMM ones.
-        runner = _make_runner(shared_experts=object())
+        runner = _make_runner(shared_experts=_shared_experts())
         with patch.object(fm, "_get_mesh", return_value=object()), \
              patch.object(fm, "is_attn_dp", return_value=True), \
              patch.object(fm, "select_moe_backend_from_fused_moe_config",
@@ -70,7 +95,7 @@ class TestFusedOutputIsReduced:
             assert runner._fused_output_is_reduced is True
 
     def test_true_when_no_mesh(self):
-        runner = _make_runner(shared_experts=object())
+        runner = _make_runner(shared_experts=_shared_experts())
         with patch.object(fm, "_get_mesh", return_value=None):
             assert runner._fused_output_is_reduced is True
 
@@ -78,7 +103,7 @@ class TestFusedOutputIsReduced:
                              [MoEBackend.FUSED_MOE, MoEBackend.DENSE_MAT])
     def test_true_for_non_gmm_backends(self, backend):
         # Only GMM_EP / GMM_TP defer the all-reduce; others always reduce.
-        runner = _make_runner(shared_experts=object())
+        runner = _make_runner(shared_experts=_shared_experts())
         with patch.object(fm, "is_attn_dp", return_value=False), \
              patch.object(fm, "_get_mesh", return_value=object()), \
              patch.object(fm, "select_moe_backend_from_fused_moe_config",
@@ -87,7 +112,7 @@ class TestFusedOutputIsReduced:
 
     @pytest.mark.parametrize("backend", [MoEBackend.GMM_EP, MoEBackend.GMM_TP])
     def test_true_when_gmm_reduces_different_axes(self, backend):
-        runner = _make_runner(shared_experts=object())
+        runner = _make_runner(shared_experts=_shared_experts())
         with patch.object(fm, "is_attn_dp", return_value=False), \
              patch.object(fm, "_get_mesh", return_value=object()), \
              patch.object(fm, "select_moe_backend_from_fused_moe_config",
@@ -100,7 +125,7 @@ class TestFusedOutputIsReduced:
 
     @pytest.mark.parametrize("backend", [MoEBackend.GMM_EP, MoEBackend.GMM_TP])
     def test_false_when_all_conditions_met(self, backend):
-        runner = _make_runner(shared_experts=object())
+        runner = _make_runner(shared_experts=_shared_experts())
         with patch.object(fm, "is_attn_dp", return_value=False), \
              patch.object(fm, "_get_mesh", return_value=object()), \
              patch.object(fm, "select_moe_backend_from_fused_moe_config",
@@ -110,6 +135,22 @@ class TestFusedOutputIsReduced:
             # Shared expert present, no DP, GMM backend, matching axes -> the
             # kernel skips its reduce and the late single collective handles it.
             assert runner._fused_output_is_reduced is False
+
+    @pytest.mark.parametrize("backend", [MoEBackend.GMM_EP, MoEBackend.GMM_TP])
+    def test_true_when_shared_expert_cannot_defer(self, backend):
+        # Regression test for the Qwen1.5-MoE EP accuracy collapse: the
+        # unquantized shared expert cannot skip its own all-reduce (its plain
+        # einsum is always reduced by GSPMD), so even when every other deferred
+        # -path condition holds the kernel must still reduce its own output.
+        runner = _make_runner(shared_experts=_shared_experts(
+            defer_all_reduce=False))
+        with patch.object(fm, "is_attn_dp", return_value=False), \
+             patch.object(fm, "_get_mesh", return_value=object()), \
+             patch.object(fm, "select_moe_backend_from_fused_moe_config",
+                          return_value=backend), \
+             patch.object(fm, "_gmm_and_shared_reduce_over_same_axes",
+                          return_value=True):
+            assert runner._fused_output_is_reduced is True
 
 
 # ---------------------------------------------------------------------------
@@ -147,7 +188,7 @@ class TestMaybeReduceSharedExpertOutput:
         assert out is shared
 
     def test_reduces_shared_output_on_early_path(self):
-        runner = _make_runner()
+        runner = _make_runner(shared_experts=_shared_experts())
         shared = torch.ones(2, 3)
         reduced = torch.full((2, 3), 7.0)
         mesh = object()
@@ -161,13 +202,30 @@ class TestMaybeReduceSharedExpertOutput:
         reduce.assert_called_once_with(shared, mesh)
         assert out is reduced
 
+    def test_passthrough_when_shared_expert_cannot_defer(self):
+        # Regression test for the Qwen1.5-MoE EP accuracy collapse: the shared
+        # output of an unquantized shared expert is ALREADY all-reduced by
+        # GSPMD, so the early path must not reduce it a second time (doing so
+        # multiplies it by the TP degree and garbles the model output).
+        runner = _make_runner(shared_experts=_shared_experts(
+            defer_all_reduce=False))
+        shared = torch.ones(2, 3)
+        with patch.object(fm.VllmMoERunner, "_fused_output_is_reduced",
+                          new_callable=PropertyMock, return_value=True), \
+             patch.object(fm, "_get_mesh", return_value=object()), \
+             patch.object(fm, "is_attn_dp", return_value=False), \
+             patch.object(fm, "_all_reduce_over_tp") as reduce:
+            out = runner._maybe_reduce_shared_expert_output(shared)
+        reduce.assert_not_called()
+        assert out is shared
+
     def test_reduces_shared_output_under_attention_dp(self):
         # Under attention DP the fused kernel reduces its own output, so the
         # shared-expert output is reduced separately on the early path. Unlike
         # the test above this drives the real ``_fused_output_is_reduced``
         # property (via ``is_attn_dp``) instead of mocking it, exercising the
         # attn-DP -> early-reduce routing end to end.
-        runner = _make_runner(shared_experts=object())
+        runner = _make_runner(shared_experts=_shared_experts())
         shared = torch.ones(2, 3)
         reduced = torch.full((2, 3), 7.0)
         mesh = object()

--- a/tpu_inference/layers/vllm/custom_ops/fused_moe.py
+++ b/tpu_inference/layers/vllm/custom_ops/fused_moe.py
@@ -19,6 +19,7 @@ from jax.sharding import PartitionSpec as P
 from torchax.interop import jax_view, shard_map, torch_view
 from vllm.logger import init_logger
 from vllm.model_executor.layers.fused_moe.runner.moe_runner import MoERunner
+from vllm.model_executor.layers.linear import RowParallelLinear
 
 from tpu_inference.layers.common.moe import MoEBackend
 from tpu_inference.layers.common.sharding import ShardingAxisName, is_attn_dp
@@ -71,6 +72,30 @@ def _gmm_and_shared_reduce_over_same_axes(mesh: Mesh,
 @MoERunner.register_oot
 class VllmMoERunner(MoERunner):
 
+    def _shared_experts_defer_all_reduce(self) -> bool:
+        """Whether the shared experts actually skip their own all-reduce.
+
+        True only if every ``RowParallelLinear`` inside ``_shared_experts`` is
+        configured with ``linear_config.defer_all_reduce`` -- i.e. its quant
+        method both supports deferral and was asked to defer. The unquantized
+        method computes a plain einsum under GSPMD, which the partitioner
+        always all-reduces, so it can never defer: for such layers the shared
+        output arrives already reduced, and reducing it again would multiply
+        it by the TP degree.
+        """
+        modules = getattr(self._shared_experts, "modules", None)
+        if modules is None:
+            return False
+
+        found = False
+        for module in modules():
+            if isinstance(module, RowParallelLinear):
+                found = True
+                cfg = getattr(module.quant_method, "linear_config", None)
+                if cfg is None or not getattr(cfg, "defer_all_reduce", False):
+                    return False
+        return found
+
     @property
     def _fused_output_is_reduced(self) -> bool:
         # Returns False -- i.e. the GMM kernel skips its own all-reduce and the
@@ -79,10 +104,13 @@ class VllmMoERunner(MoERunner):
         # holds. Otherwise the fused output is reduced by the kernel itself.
         #
         #   1. a shared expert is present (else there is nothing to fuse with)
-        #   2. attention-DP is disabled (DP resolves the reduction separately)
-        #   3. the backend is GMM_EP / GMM_TP (only those honor defer_all_reduce;
+        #   2. the shared expert's linears actually defer their all-reduce
+        #      (else the shared output is already reduced and cannot take part
+        #      in a merged late reduction)
+        #   3. attention-DP is disabled (DP resolves the reduction separately)
+        #   4. the backend is GMM_EP / GMM_TP (only those honor defer_all_reduce;
         #      e.g. the FUSED_MOE kernel always reduces)
-        #   4. the GMM reduction collapses the same mesh axes as the shared
+        #   5. the GMM reduction collapses the same mesh axes as the shared
         #      expert (MLP_TENSOR) -- else one all-reduce over MLP_TENSOR cannot
         #      stand in for the GMM's reduction
         mesh = _get_mesh()
@@ -90,6 +118,9 @@ class VllmMoERunner(MoERunner):
             return True
 
         if self._shared_experts is None:
+            return True
+
+        if not self._shared_experts_defer_all_reduce():
             return True
 
         if is_attn_dp(mesh) or self.moe_config.is_sequence_parallel:
@@ -127,6 +158,7 @@ class VllmMoERunner(MoERunner):
             return shared_output
 
         if (shared_output is not None and self._fused_output_is_reduced
+                and self._shared_experts_defer_all_reduce()
                 and not self.moe_config.is_sequence_parallel
                 and not is_attn_dp(mesh)):
             shared_output = _all_reduce_over_tp(shared_output, mesh)

--- a/tpu_inference/layers/vllm/custom_ops/linear.py
+++ b/tpu_inference/layers/vllm/custom_ops/linear.py
@@ -37,9 +37,17 @@ class VllmRowParallelLinear(RowParallelLinear):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
+        # Only defer the all-reduce when the quant method's matmul actually
+        # honors ``linear_config.defer_all_reduce``. Methods that don't (e.g.
+        # the unquantized method, whose plain einsum is always all-reduced by
+        # the GSPMD partitioner) would silently return an already-reduced
+        # output, and any downstream "merged" reduce would double-count it.
         linear_config = getattr(self.quant_method, "linear_config", None)
         if linear_config is not None:
-            linear_config.defer_all_reduce = not self.reduce_results
+            supports_defer = getattr(self.quant_method,
+                                     "supports_defer_all_reduce", False)
+            linear_config.defer_all_reduce = (not self.reduce_results
+                                              and supports_defer)
 
     def forward(
         self,

--- a/tpu_inference/layers/vllm/quantization/base.py
+++ b/tpu_inference/layers/vllm/quantization/base.py
@@ -19,6 +19,15 @@ import torch
 
 class VllmQuantizationMethod(ABC):
 
+    # Whether this method's matmul honors ``linear_config.defer_all_reduce``
+    # (skipping its own all-reduce over the contracting axis and returning
+    # per-shard partial sums for the caller to reduce later). Methods must NOT
+    # claim support unless their apply() actually threads the flag through:
+    # a plain einsum under GSPMD is always all-reduced by the partitioner, so
+    # deferral silently fails and downstream merged reduces double-count.
+    # Opt in per method class after validating end-to-end numerics.
+    supports_defer_all_reduce: bool = False
+
     @abstractmethod
     def maybe_process_weights(self, layer: torch.nn.Module, param_name: str,
                               args, kwargs):


### PR DESCRIPTION
## Problem

The nightly `EP correctness (Qwen/Qwen1.5-MoE-A2.7B)` test collapsed to garbage
(gsm8k flexible-extract **0.0038** / strict **0.0000** vs thresholds 0.37/0.06) on
both tpu7x and tpu6e, starting with #2849. Confirmed by commit-vs-parent A/B
(dev builds 633 fail @ `2d6977fac` vs 631 pass @ parent, same vLLM) and by
revert-on-main (dev 647 pass 0.42–0.45 vs 648 fail 0.0038, same vLLM).

## Root cause

#2849 merges the shared-expert all-reduce with the FusedMoE all-reduce by having
`RowParallelLinear` skip its own reduction (`linear_config.defer_all_reduce`) and
running a single collective in the MoE runner instead. But the **unquantized**
linear method never got the deferral wiring: its matmul is a plain `jnp.einsum`,
which the GSPMD partitioner always all-reduces. So for an unquantized model like
Qwen1.5-MoE the shared-expert output arrives **already reduced**, and the runner
reduces it a **second time**:

- `USE_MOE_EP_KERNEL=1` (FUSED_MOE backend): `_fused_output_is_reduced` is True →
  `_maybe_reduce_shared_expert_output` runs `_all_reduce_over_tp(shared_output)`
  on an already-reduced tensor → `shared_output × TP(=4)`.
- `USE_MOE_EP_KERNEL=0` (GMM_EP): mirrored — the GMM kernel defers, the late
  `_all_reduce_over_tp(shared + fused)` then multiplies the already-reduced
  shared component by TP.

Either way `hidden = 4·shared + fused` → near-random output. (Pre-#2849 the
runner-level collectives on this path were effectively no-ops, GSPMD handled all
reductions — which is why it used to pass.)

Only quantized methods were wired for deferral in #2849 (fp8, compressed-tensors
w4a8_fp8/w8a8_fp8/w8a8_int8, nvfp4 via `sharded_quantized_matmul`).

## Fix

Gate the merged-reduce feature on the shared expert's *actual* ability to defer:

- `VllmQuantizationMethod.supports_defer_all_reduce = False` (documented opt-in;
  methods must not claim support unless their `apply()` threads the flag through).
- `VllmRowParallelLinear.__init__` only sets `linear_config.defer_all_reduce`
  when the quant method supports it.
- `VllmMoERunner` gains `_shared_experts_defer_all_reduce()`;
  `_fused_output_is_reduced` returns True (kernel reduces its own output) unless
  every `RowParallelLinear` in the shared experts actually defers, and
  `_maybe_reduce_shared_expert_output` only reduces when the shared output was
  actually left unreduced.

Net effect: unquantized models get pre-#2849 semantics back (correct); the
merged-reduce optimization stays available and can be re-enabled per quant
method by setting `supports_defer_all_reduce = True` after validating numerics
end to end.

## Verification

- Dev build 650 (this branch): EP correctness passes with healthy scores —
  kernel=1: 0.4238/0.4466, kernel=0: 0.4458/0.4367 (identical to the revert
  baseline from dev 647; main fails at 0.0038, dev 648).
- Dev build 649: neutralizing only these two reduce decisions at `2d6977fac`
  restores the same scores — pinpointing the mechanism.
- `tests/layers/vllm/test_fused_moe.py`: 23/23 pass, including two new
  regression tests for the non-deferring shared expert (property + early path).

## Related PRs

- #3133 only affects the sequence-parallel/attn-DP branch — verified no effect on
  this failure (identical 0.0038 with/without).
- #3147 wires deferral into the unquantized matmul but still scores 0 on the EP
  test (dev 645). Suspected issue: `sharded_matmul` declares its unreduced
  partial-sum output as replicated (`out_specs=P(ATTN_DATA, None)`), which GSPMD
  may canonicalize across devices before the runner's later collective reads it.
  Once a validated unquantized deferral lands, flipping
  `supports_defer_all_reduce=True` on the unquantized method re-enables the
  optimization under this PR's gate.
