### PR TITLE
fix(attention): Support upstream vLLM linear_attn API change without pre-allocated output

### DIFF
--- a/tpu_inference/layers/vllm/custom_ops/gdn_attention_op.py
+++ b/tpu_inference/layers/vllm/custom_ops/gdn_attention_op.py
@@ -176,7 +176,7 @@ class VllmGatedDeltaNetAttention(QwenGatedDeltaNetAttention):
     def forward(
         self,
         hidden_states: torch.Tensor,
-        output: torch.Tensor,
+        output: torch.Tensor | None = None,
     ):
         """
         Implements the exact same logic as in vLLM (https://github.com/vllm-project/vllm/blob/9c81f35/vllm/model_executor/layers/mamba/gdn_linear_attn.py#L508)
@@ -247,4 +247,8 @@ class VllmGatedDeltaNetAttention(QwenGatedDeltaNetAttention):
         # ============================================================
         core_attn_out = self.norm(core_attn_out, z)
         core_attn_out = rearrange(core_attn_out, "... h d -> ... (h d)")
-        output[:num_tokens], _ = self.out_proj(core_attn_out)
+        if output is not None:
+            output[:num_tokens], _ = self.out_proj(core_attn_out)
+            return output
+        else:
+            return self.out_proj(core_attn_out)[0]


### PR DESCRIPTION
**What this PR does:**
This PR fixes a `TypeError` crash that occurs when running the engine with the latest upstream vLLM changes:
`TypeError: VllmGatedDeltaNetAttention.forward() missing 1 required positional argument: 'output'`

**Root Cause:**
Upstream vLLM PR [vllm-project/vllm#46998](https://github.com/vllm-project/vllm/pull/46998) overhauled the Attention layer APIs. Specifically, `linear_attn` and the various `forward` methods no longer take a pre-allocated `output` buffer as a positional argument. Instead, they are now expected to dynamically allocate and return the `hidden_states` tensor. Because our custom TPU op (`VllmGatedDeltaNetAttention`) still strictly required `output: torch.Tensor`, PyTorch threw a `TypeError` when vLLM attempted to call it under the new API.

**The Fix:**
- Updated the signature of `VllmGatedDeltaNetAttention.forward` to make `output` an optional parameter (`output: torch.Tensor | None = None`).
- If `output` is provided (older vLLM versions), we mutate it in-place to maintain backwards compatibility.
- If `output` is `None` (newer vLLM versions), we natively return the computed output tensor directly, satisfying the new upstream API expectations.

**Testing:**
- Verified that the `TypeError` no longer occurs and the model forward pass completes successfully with the new upstream vLLM signature.
