### PR TITLE
[releases/v0.25.0] Apply #3147: wire defer_all_reduce on unquantized linear (fixes EP MoE garbage from #2849)

### DIFF
--- a/tests/layers/vllm/test_unquantized.py
+++ b/tests/layers/vllm/test_unquantized.py
@@ -40,6 +40,7 @@ from vllm.model_executor.model_loader import get_model as vllm_get_model
 from tests.layers.common import utils as test_utils
 from tpu_inference.layers.common.moe import MoEBackend
 from tpu_inference.layers.common.quantization.configs import QuantLinearConfig
+from tpu_inference.layers.vllm.custom_ops.fused_moe import _all_reduce_over_tp
 from tpu_inference.layers.vllm.quantization import get_tpu_quantization_config
 from tpu_inference.layers.vllm.quantization.unquantized import (
     VllmUnquantizedConfig, VllmUnquantizedFusedMoEMethod,
@@ -205,6 +206,85 @@ def test_row_parallel_linear(model, bias, num_devices, enable_sp,
         jax_output = j2t(jax_output.to(torch.float32)).to(dtype)
 
     torch.testing.assert_close(output, jax_output)
+
+
+@pytest.mark.parametrize("model", MODELS)
+@pytest.mark.parametrize("num_devices", [1, jax.local_device_count()])
+def test_row_parallel_linear_defer_all_reduce(model, num_devices):
+    """reduce_results=False routes through sharded_matmul: the layer returns
+    per-shard partial sums (the psum is actually skipped, which a plain einsum
+    under GSPMD cannot do) and the caller's single deferred all-reduce
+    (VllmMoERunner._all_reduce_over_tp) reconstructs the full result.
+
+    No bias: vLLM's RowParallelLinear rejects reduce_results=False with an
+    in-layer bias."""
+    mesh = test_utils.get_spmd_mesh(num_devices)
+    dtype = torch.bfloat16
+
+    engine_args = EngineArgs(
+        model=model,
+        max_model_len=64,
+        max_num_batched_tokens=64,
+        max_num_seqs=4,
+    )
+    vllm_config = engine_args.create_engine_config()
+
+    # Reference: fully reduced output.
+    with set_current_vllm_config(vllm_config):
+        row_linear = RowParallelLinear(
+            input_size=4096,
+            output_size=8192,
+            bias=False,
+            params_dtype=dtype,
+            return_bias=False,
+        )
+
+    input_tensor = torch.rand(10, row_linear.input_size, dtype=dtype) / 10
+    input_tensor = input_tensor.to('cpu')
+
+    weight_data = torch.rand_like(row_linear.weight.data) / 10
+    row_linear.weight.data = weight_data
+    row_linear = row_linear.to('cpu')
+    row_linear.quant_method.process_weights_after_loading(row_linear)
+    expected = row_linear(input_tensor).to(dtype)
+
+    vllm_config.model_config.dtype = dtype
+    quant_config = get_tpu_quantization_config(vllm_config, mesh)
+    with set_current_vllm_config(vllm_config):
+        jax_row_linear = RowParallelLinear(
+            input_size=4096,
+            output_size=8192,
+            bias=False,
+            params_dtype=dtype,
+            reduce_results=False,
+            return_bias=False,
+            quant_config=quant_config,
+        )
+    # What VllmRowParallelLinear.__init__ derives from reduce_results=False.
+    jax_row_linear.quant_method.linear_config.defer_all_reduce = True
+
+    jax_row_linear.weight.data = weight_data
+
+    jax_input_tensor = torch_view(t2j(input_tensor, use_dlpack=False))
+    jax_input_tensor.apply_jax_(jax.device_put,
+                                NamedSharding(mesh, P(None, None)))
+    with torchax.default_env():
+        assert isinstance(jax_row_linear.quant_method,
+                          VllmUnquantizedLinearMethod)
+        jax_row_linear.quant_method.process_weights_after_loading(
+            jax_row_linear)
+        deferred = jax_row_linear(jax_input_tensor)
+
+        if num_devices > 1:
+            # The psum was actually skipped: pre-reduction output is partial,
+            # not the full matmul.
+            partial = j2t(deferred.to(torch.float32)).to(dtype)
+            assert not torch.allclose(partial, expected)
+
+        reduced = _all_reduce_over_tp(deferred, mesh)
+        jax_output = j2t(reduced.to(torch.float32)).to(dtype)
+
+    torch.testing.assert_close(expected, jax_output)
 
 
 @pytest.mark.parametrize("model", MODELS)

--- a/tpu_inference/layers/common/linear.py
+++ b/tpu_inference/layers/common/linear.py
@@ -103,6 +103,44 @@ def _get_x_q_dtype(w_q_dtype: jnp.dtype) -> jnp.dtype:
         )
 
 
+def sharded_matmul(x: jax.Array,
+                   w: jax.Array,
+                   weight_sharding: P | NamedSharding,
+                   *,
+                   mesh: Mesh | None = None,
+                   defer_all_reduce: bool = False) -> jax.Array:
+    """Matmul that can skip its all-reduce (``defer_all_reduce=True``).
+
+    A plain einsum under GSPMD is always all-reduced by the partitioner, so it
+    runs in shard_map. No bias: vLLM's RowParallelLinear rejects
+    reduce_results=False with an in-layer bias.
+    """
+    if isinstance(weight_sharding, NamedSharding):
+        mesh = mesh or weight_sharding.mesh
+        weight_sharding = weight_sharding.spec
+    in_axis, out_axis = weight_sharding
+    # x may have extra leading batch dims.
+    batch_dims = (None, ) * (x.ndim - 2)
+    x_spec = P(ShardingAxisName.ATTN_DATA, *batch_dims, in_axis)
+    x = jax.lax.with_sharding_constraint(
+        x,
+        NamedSharding(mesh, x_spec) if mesh else x_spec)
+
+    def wrapper(x, w):
+        out = x @ w
+        if in_axis and not defer_all_reduce:
+            out = jax.lax.psum(out, axis_name=in_axis)
+        return out
+
+    return jax.shard_map(
+        wrapper,
+        mesh=mesh,
+        in_specs=(x_spec, weight_sharding),
+        out_specs=P(ShardingAxisName.ATTN_DATA, *batch_dims, out_axis),
+        check_vma=False,
+    )(x, w)
+
+
 def sharded_quantized_matmul(x: jax.Array,
                              w_q: jax.Array,
                              w_s: jax.Array,

--- a/tpu_inference/layers/common/quantization/unquantized.py
+++ b/tpu_inference/layers/common/quantization/unquantized.py
@@ -17,6 +17,7 @@ from typing import Optional, Sequence
 import jax
 from jax import numpy as jnp
 
+from tpu_inference.layers.common.linear import sharded_matmul
 from tpu_inference.layers.common.quantization.configs import QuantLinearConfig
 from tpu_inference.layers.common.utils import \
     slice_sharded_tensor_for_concatenation
@@ -48,7 +49,7 @@ class UnquantizedLinearMethod:
                      x_jax: jax.Array,
                      weight_jax: jax.Array,
                      bias_jax: Optional[jax.Array] = None,
-                     einsum_str: str = "...k,kn->...n") -> jax.Array:
+                     einsum_str: str | None = None) -> jax.Array:
         """Applies fused linear operation.
 
         Operates on a single large weight matrix that combines multiple logical
@@ -58,15 +59,27 @@ class UnquantizedLinearMethod:
             x_jax: Input array of shape [..., hidden_dim].
             weight_jax: Weight array of shape [output_dim, hidden_dim].
             bias_jax: Optional bias array of shape [output_dim].
-            einsum_str: Einsum string for the operation.
+            einsum_str: Einsum string for the operation. If None, a standard matrix multiplication is performed.
 
         Returns:
             Output array of shape [..., total_output_dim].
         """
-        outs = jnp.einsum(einsum_str, x_jax, weight_jax)
+        if einsum_str:
+            assert not self.linear_config.defer_all_reduce, \
+                "Defer all-reduce is not compatible with custom einsum strings."
+            outs = jnp.einsum(einsum_str, x_jax, weight_jax)
+        else:
+            assert weight_jax.ndim == 2, "Weight must be 2D for sharded_matmul."
+            outs = sharded_matmul(
+                x_jax,
+                weight_jax,
+                self.linear_config.weight_sharding,
+                mesh=self.linear_config.mesh,
+                defer_all_reduce=self.linear_config.defer_all_reduce,
+            )
+
         if bias_jax is not None:
             outs += bias_jax
-
         outs = slice_sharded_tensor_for_concatenation(
             outs, self.linear_config.output_sizes, self.linear_config.n_shards)
         out = jnp.concatenate(outs, axis=-1)


### PR DESCRIPTION
## What
Applies the fix from #3147 (author: @wonpyo-park — commits cherry-picked with authorship preserved) onto `releases/v0.25.0`.

## Why
The first v0.25.0 release nightly ([build 22159](https://buildkite.com/tpu-commons/tpu-inference-ci/builds/22159)) fails `tpu7x Correctness tests for EP (single-host)` with garbage output (gsm8k flexible-extract 0.0038 vs threshold 0.37). Root cause is the regression introduced by #2849: the unquantized linear path ignores `defer_all_reduce`, so the shared-expert output is all-reduced twice (see discussion on #3147 / #3151). #3147 is the verified fix but is not yet merged to `main`, so the release branch needs it directly.

## Validation
- #3147 head (`c97b8b3d3`) was validated on `tpu-inference-dev` build 652 against the exact nightly EP test config: `Qwen/Qwen1.5-MoE-A2.7B`, TP=4, EP enabled, both `use_moe_ep_kernel=0/1` — scores 0.41–0.45 (control at the broken base: 0.0038).
- A dev-pipeline validation of THIS branch (fix rebased on `releases/v0.25.0`) is running; results will be posted here.

Do not merge until the release-branch validation is posted and the release owner approves.
