### PR TITLE
Avoid retracing by replacing einshape

### DIFF
--- a/tpu_inference/kernels/experimental/batched_rpa/flash_attention.py
+++ b/tpu_inference/kernels/experimental/batched_rpa/flash_attention.py
@@ -15,7 +15,6 @@
 import jax
 import jax.numpy as jnp
 from jax import lax
-from jax.experimental.pallas import tpu as pltpu
 
 from tpu_inference.kernels.experimental.batched_rpa import configs, utils
 
@@ -33,7 +32,7 @@ def flash_attention_qk_softmax(
     bq_start: int,
 ):
     """Flash attention kernel."""
-    b, k_heads, tq, _ = q.shape
+    b, k_heads, tq, h_size = q.shape
     s = k.shape[2]
 
     if cfgs.serve.scale_q is not None:
@@ -45,13 +44,13 @@ def flash_attention_qk_softmax(
             q = jnp.clip(q, min=minval, max=maxval)
         q = q.astype(k.dtype)
 
-    qk = lax.dot_general(
-        pltpu.einshape("bkth->(bk)th", q, True),
-        pltpu.einshape("bksh->(bk)sh", k, True),
+    qk = lax.dot(
+        q.reshape(-1, tq, h_size),
+        k.reshape(-1, s, h_size),
         dimension_numbers=(([2], [2]), ([0], [0])),
         preferred_element_type=jnp.float32,
     ).astype(cfgs.serve.dtype_out)
-    qk = pltpu.einshape("(bk)ts->bkts", qk, True, b=b)
+    qk = qk.reshape(b, k_heads, tq, s)
 
     qk *= cfgs.model.sm_scale
     if cfgs.serve.scale_k is not None:
@@ -103,14 +102,15 @@ def flash_attention_pv(
     cfgs: configs.RpaConfigs,
 ):
     """Flash attention kernel."""
-    b = p.shape[0]
-    pv = lax.dot_general(
-        pltpu.einshape("bkts->(bk)ts", p, True),
-        pltpu.einshape("bksh->(bk)sh", v, True),
+    b, k_heads, tq, s = p.shape
+    h_size = v.shape[-1]
+    pv = lax.dot(
+        p.reshape(-1, tq, s),
+        v.reshape(-1, s, h_size),
         dimension_numbers=(([2], [1]), ([0], [0])),
         preferred_element_type=jnp.float32,
     ).astype(cfgs.serve.dtype_out)
-    pv = pltpu.einshape("(bk)th->bkth", pv, True, b=b)
+    pv = pv.reshape(b, k_heads, tq, h_size)
 
     if cfgs.serve.scale_v is not None:
         pv *= cfgs.serve.scale_v


### PR DESCRIPTION
# Description
Work done in collaboration with @a1yssan13 and @pritha90 

- `pl.einshape` is a hijax op
  - https://github.com/jax-ml/jax/blob/0b9e4166c22e19c03dd6c2909c2c898c0f7dc12c/jax/_src/pallas/einshape.py#L357
- when there's a hijax op, pjit does not cache executable result
  - https://github.com/jax-ml/jax/blob/deabe657dccfa2200b27b2b282a1bc404dd25bd0/jax/_src/pjit.py#L261-L262
  - https://github.com/jax-ml/jax/blob/deabe657dccfa2200b27b2b282a1bc404dd25bd0/jax/_src/pjit.py#L137-L147
- this means it won't take fastpath and always fall back to slow python path
  - https://github.com/jax-ml/jax/blob/0b9e4166c22e19c03dd6c2909c2c898c0f7dc12c/jax/_src/pjit.py#L264-L266
  - https://github.com/jax-ml/jax/blob/0b9e4166c22e19c03dd6c2909c2c898c0f7dc12c/jaxlib/pjit.cc#L945-L953
 - so every time a function is executed, it will perform slow python based tracing

# Tests

This 10 line code change improved performance by 1.6x:
- before: 292 ms 
<img width="1436" height="1332" alt="image" src="https://github.com/user-attachments/assets/eca00a93-e704-472e-88b3-1bfaa6c58b24" />

- after: 185 ms 
<img width="1740" height="1264" alt="image" src="https://github.com/user-attachments/assets/dbcc821e-5ba7-4104-bb6f-a624d93da132" />


# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
