### PR TITLE
Scope xla_tpu_scoped_vmem_limit_kib to MLA kernel tests (fixes Multimodal Inputs similarity + e2e slowdown from #3011)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,9 +38,6 @@ Example Usage:
 import os
 from unittest.mock import patch
 
-os.environ["LIBTPU_INIT_ARGS"] = (os.environ.get("LIBTPU_INIT_ARGS", "") +
-                                  " --xla_tpu_scoped_vmem_limit_kib=65536")
-
 import jax
 import pytest
 

--- a/tests/kernels/mla_tuned_vs_baseline_test.py
+++ b/tests/kernels/mla_tuned_vs_baseline_test.py
@@ -14,8 +14,16 @@
 
 import os
 
-os.environ["LIBTPU_INIT_ARGS"] = (os.environ.get("LIBTPU_INIT_ARGS", "") +
-                                  " --xla_tpu_scoped_vmem_limit_kib=65536")
+# MLA-kernel-only vmem budget. Two constraints (see #3011 / #3159):
+# 1. Must run before libtpu/TPU backend initialization (module top,
+#    before the jax import below).
+# 2. Must NOT move into tests/conftest.py: a global setting changes XLA
+#    codegen for every e2e test in the suite (that is exactly how #3011
+#    caused a deterministic multimodal output drift and e2e slowdowns).
+if "--xla_tpu_scoped_vmem_limit_kib" not in os.environ.get(
+        "LIBTPU_INIT_ARGS", ""):
+    os.environ["LIBTPU_INIT_ARGS"] = (os.environ.get("LIBTPU_INIT_ARGS", "") +
+                                      " --xla_tpu_scoped_vmem_limit_kib=65536")
 
 import time
 

--- a/tests/kernels/mla_tuned_vs_baseline_test.py
+++ b/tests/kernels/mla_tuned_vs_baseline_test.py
@@ -12,6 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+
+os.environ["LIBTPU_INIT_ARGS"] = (os.environ.get("LIBTPU_INIT_ARGS", "") +
+                                  " --xla_tpu_scoped_vmem_limit_kib=65536")
+
 import time
 
 import jax

--- a/tests/kernels/mla_v2_test.py
+++ b/tests/kernels/mla_v2_test.py
@@ -12,6 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+
+os.environ["LIBTPU_INIT_ARGS"] = (os.environ.get("LIBTPU_INIT_ARGS", "") +
+                                  " --xla_tpu_scoped_vmem_limit_kib=65536")
+
 import jax
 import jax.numpy as jnp
 import numpy as np

--- a/tests/kernels/mla_v2_test.py
+++ b/tests/kernels/mla_v2_test.py
@@ -14,8 +14,16 @@
 
 import os
 
-os.environ["LIBTPU_INIT_ARGS"] = (os.environ.get("LIBTPU_INIT_ARGS", "") +
-                                  " --xla_tpu_scoped_vmem_limit_kib=65536")
+# MLA-kernel-only vmem budget. Two constraints (see #3011 / #3159):
+# 1. Must run before libtpu/TPU backend initialization (module top,
+#    before the jax import below).
+# 2. Must NOT move into tests/conftest.py: a global setting changes XLA
+#    codegen for every e2e test in the suite (that is exactly how #3011
+#    caused a deterministic multimodal output drift and e2e slowdowns).
+if "--xla_tpu_scoped_vmem_limit_kib" not in os.environ.get(
+        "LIBTPU_INIT_ARGS", ""):
+    os.environ["LIBTPU_INIT_ARGS"] = (os.environ.get("LIBTPU_INIT_ARGS", "") +
+                                      " --xla_tpu_scoped_vmem_limit_kib=65536")
 
 import jax
 import jax.numpy as jnp


### PR DESCRIPTION
## What
Fixes `tpu7x Correctness tests for Multimodal Inputs` (`test_multi_modal_inference[False]`, Qwen2.5-VL-3B) failing with text similarity 0.8385 vs the 0.85 gate in the v0.25.0 release nightly ([build 22159](https://buildkite.com/tpu-commons/tpu-inference-ci/builds/22159)) and in main nightlies since Jul 7 (21709, 21954, 22076).

## Root cause (proven by single-commit A/B)
#3011 moved `LIBTPU_INIT_ARGS += --xla_tpu_scoped_vmem_limit_kib=65536` from `tests/kernels/mla_v2_test.py` into the **global** `tests/conftest.py`. Every pytest-driven e2e test — full engine runs included — now executes under a 64MB scoped-vmem limit, which changes XLA codegen for unrelated models and deterministically shifts Qwen2.5-VL-3B decoded text (similarity 0.985 → 0.8385, identical digits on every run).

A/B on `tpu-inference-dev` (same forced vLLM `fa4321de` on all sides, exact nightly test, tpu7x):
- parent `8bad85bed` (#2880): **PASS 3/3** (build 661)
- `0bbffcecb` (#3011): **FAIL 3/3, identical 0.8385** (build 663)
- also exonerated by A/B: #2977 (builds 657/658), Jul-6 control green (build 660)

## Fix
Move the env setting back into the two MLA kernel test modules that need it (`mla_v2_test.py`, `mla_tuned_vs_baseline_test.py`), before the `jax` import. `tests/conftest.py` no longer mutates `LIBTPU_INIT_ARGS` globally.

## Validation
Dev build on this branch running the exact nightly Multimodal Inputs job (3x) is in flight; results will be posted here.

The same fix applies to `main` (this PR targets the release branch per the release-blocker process).

Do not merge until validation is posted and the release owner approves.
