### PR TITLE
[Qwen3-VL] End-to-end M-RoPE + spec-decode + multimodal + DP-attention serving

### DIFF
--- a/tests/runner/test_mm_encoder_jit_manager.py
+++ b/tests/runner/test_mm_encoder_jit_manager.py
@@ -69,7 +69,8 @@ class _DummyModel:
     def get_encoder_cudagraph_config(self):
         return EncoderCudaGraphConfig(
             modalities=["image"],
-            buffer_keys=["pixel_values"],
+            input_key_by_modality={"image": "pixel_values"},
+            buffer_keys=[],
             out_hidden_size=64,
         )
 
@@ -83,8 +84,11 @@ class _DummyModel:
                                                  max_batch_size,
                                                  max_frames_per_batch, device,
                                                  dtype):
-        return EncoderCudaGraphCaptureInputs(
-            values={"pixel_values": torch.zeros(token_budget, 4, dtype=dtype)})
+        return EncoderCudaGraphCaptureInputs(mm_kwargs={
+            "pixel_values":
+            torch.zeros(token_budget, 4, dtype=dtype)
+        },
+                                             buffers={})
 
     def get_encoder_cudagraph_item_specs(self, mm_kwargs):
         return []
@@ -95,7 +99,7 @@ class _DummyModel:
     def prepare_encoder_cudagraph_replay_buffers(self, mm_kwargs,
                                                  max_batch_size,
                                                  max_frames_per_batch):
-        return EncoderCudaGraphReplayBuffers(values={})
+        return EncoderCudaGraphReplayBuffers(buffers={})
 
     def postprocess_encoder_output(self,
                                    output,
@@ -181,22 +185,22 @@ class TestAdapterPostprocessEncoderOutput:
 
 
 class TestPadToTemplate:
-    """Test MMEncoderJITManager._pad_to_template — zero-padding, slicing, and dtype-casting.
+    """Test MMEncoderJITManager._pad_dict_to_template — zero-padding,
+    slicing, and dtype-casting.
 
     Pure torch logic — tested without a full manager init by constructing a
-    bare instance via object.__new__ and setting only budget_templates.
+    bare instance via object.__new__.
     """
 
-    def _manager(self, template: dict) -> MMEncoderJITManager:
-        m = object.__new__(MMEncoderJITManager)
-        m.budget_templates = {256: template}
-        return m
+    def _manager(self) -> MMEncoderJITManager:
+        return object.__new__(MMEncoderJITManager)
 
     def test_general_case_zeros_then_copies(self):
         """src smaller than template: zero the buffer and slice-copy src."""
         tmpl = torch.zeros(10, 4)
         src = torch.ones(4, 4)
-        result = self._manager({"pv": tmpl})._pad_to_template({"pv": src}, 256)
+        result = self._manager()._pad_dict_to_template({"pv": src},
+                                                       {"pv": tmpl})
         assert result["pv"].shape == (10, 4)
         assert torch.all(result["pv"][:4] == 1.0)
         assert torch.all(result["pv"][4:] == 0.0)
@@ -205,29 +209,30 @@ class TestPadToTemplate:
         """src already has the template shape: returned as-is (no allocation)."""
         tmpl = torch.zeros(8, 4)
         src = torch.ones(8, 4)
-        result = self._manager({"pv": tmpl})._pad_to_template({"pv": src}, 256)
+        result = self._manager()._pad_dict_to_template({"pv": src},
+                                                       {"pv": tmpl})
         assert result["pv"] is src
 
     def test_scalar_uses_template_value(self):
         """0-dim scalars (e.g. max_seqlen): always use the budget-fixed template."""
         tmpl = torch.tensor(256)
         src = torch.tensor(64)
-        result = self._manager({
-            "max_seqlen": tmpl
-        })._pad_to_template({"max_seqlen": src}, 256)
+        result = self._manager()._pad_dict_to_template({"max_seqlen": src},
+                                                       {"max_seqlen": tmpl})
         assert result["max_seqlen"] is tmpl
 
     def test_none_src_uses_template(self):
         """Key absent from replay_values (or explicitly None): use template."""
         tmpl = torch.zeros(8, 4)
-        result = self._manager({"optional": tmpl})._pad_to_template({}, 256)
+        result = self._manager()._pad_dict_to_template({}, {"optional": tmpl})
         assert result["optional"] is tmpl
 
     def test_dtype_cast_on_copy(self):
         """src dtype differs from template: cast to template dtype during copy."""
         tmpl = torch.zeros(10, 4, dtype=torch.bfloat16)
         src = torch.ones(4, 4, dtype=torch.float32)
-        result = self._manager({"pv": tmpl})._pad_to_template({"pv": src}, 256)
+        result = self._manager()._pad_dict_to_template({"pv": src},
+                                                       {"pv": tmpl})
         assert result["pv"].dtype == torch.bfloat16
         assert torch.all(result["pv"][:4] == 1.0)
 
@@ -253,9 +258,11 @@ class TestMMEncoderJITManagerInit:
     def test_budget_templates_keyed_by_budget(self):
         """One template entry per budget, shape matches the budget size."""
         manager = _make_manager()
-        assert set(manager.budget_templates.keys()) == set(
+        assert set(manager.mm_kwargs_templates.keys()) == set(
             manager.token_budgets)
-        for budget, tmpl in manager.budget_templates.items():
+        assert set(manager.buffers_templates.keys()) == set(
+            manager.token_budgets)
+        for budget, tmpl in manager.mm_kwargs_templates.items():
             assert "pixel_values" in tmpl
             assert tmpl["pixel_values"].shape[0] == budget
 
@@ -343,22 +350,32 @@ class TestMMEncoderJITManagerIntegration:
     """
 
     def test_prepare_padded_torch_real_model(self, qwen35_mm_encoder):
-        """_prepare_padded_torch produces correctly-shaped outputs for every
-        template key when driven by the real model's replay-buffer method."""
+        """_prepare_padded_torch produces correctly-shaped mm_kwargs and
+        buffers dicts when driven by the real model's replay-buffer method.
+        """
         manager, _ = qwen35_mm_encoder
         mm_kwargs = _image_mm_kwargs()
         smallest_budget = manager.token_budgets[0]
-        padded = manager._prepare_padded_torch(mm_kwargs, smallest_budget)
+        padded_mm, padded_buffers = manager._prepare_padded_torch(
+            mm_kwargs, replay_buffers=None, token_budget=smallest_budget)
 
-        template = manager.budget_templates[smallest_budget]
-        assert set(padded.keys()) == set(template.keys())
-        for key, tmpl in template.items():
+        mm_template = manager.mm_kwargs_templates[smallest_budget]
+        buffers_template = manager.buffers_templates[smallest_budget]
+        assert set(padded_mm.keys()) == set(mm_template.keys())
+        assert set(padded_buffers.keys()) == set(buffers_template.keys())
+        for key, tmpl in mm_template.items():
             if hasattr(tmpl, "shape"):
-                assert padded[key].shape == tmpl.shape, (
-                    f"key={key}: padded {padded[key].shape} != tmpl {tmpl.shape}"
+                assert padded_mm[key].shape == tmpl.shape, (
+                    f"mm key={key}: padded {padded_mm[key].shape} != tmpl {tmpl.shape}"
                 )
+        for key, tmpl in buffers_template.items():
+            if tmpl is None or not hasattr(tmpl, "shape"):
+                continue
+            assert padded_buffers[key].shape == tmpl.shape, (
+                f"buffer key={key}: padded {padded_buffers[key].shape} != tmpl {tmpl.shape}"
+            )
         n_patches = _image_mm_kwargs()["pixel_values"].shape[0]
-        assert padded["pixel_values"].shape[0] >= n_patches
+        assert padded_mm["pixel_values"].shape[0] >= n_patches
 
     def test_capture_budget_graph(self, qwen35_mm_encoder):
         """_capture_budget_graph primes the XLA cache for the smallest budget

--- a/tests/spec_decode/test_eagle3.py
+++ b/tests/spec_decode/test_eagle3.py
@@ -368,3 +368,61 @@ def test_update_inputs_for_loop_speculation_mrope():
     assert new_seq_lens[0] == 6
     assert new_block_tables[0] == 1
     assert new_block_tables[1] == 2
+
+
+@pytest.mark.parametrize("method", ["eagle3", "mtp"])
+def test_select_inputs_for_loop_speculation_mrope(method):
+    """Regression for the (16,)-vs-(128,) broadcasting bug that appeared on
+    Qwen3-VL + Eagle3 under DP-attention.
+
+    Before the fix, the Eagle3 branch of `_select` did
+    ``positions[last_token_indices]`` unconditionally. For 2D M-RoPE positions
+    of shape ``(3, N)`` that indexed axis 0 with a length-B index array and
+    produced ``(B, N)`` instead of ``(3, B)``. The wrongly shaped positions
+    were then fed into ``_update_inputs_for_loop_speculation``, whose
+    ``jnp.where(exceeds_max_model_len_reduced, 1, new_seq_lens)`` failed with
+    "Incompatible shapes for broadcasting" on the first serving request.
+
+    Only the ``method="eagle3"`` case hit the bug in production. But since
+    ``SpeculativeConfig(model=<eagle3_dir>, method="mtp")`` auto-normalises
+    to ``"eagle3"`` internally, we force ``proposer.method`` after construction
+    so each parametrisation actually exercises the branch it names.
+    """
+    proposer = _create_proposer(method, 2)
+    proposer.method = method
+    proposer.runner.max_model_len = 32
+
+    # Mock draft-token selection so we do not need a real model.
+    proposer._select_draft_token_ids = mock.MagicMock(
+        return_value=jnp.zeros(2, dtype=jnp.int32))
+
+    num_reqs = 2
+    total_tokens = 8
+    hidden_size = 4
+
+    # 2D M-RoPE positions: (3, total_tokens).
+    positions = jnp.stack([jnp.arange(total_tokens)] * 3, axis=0)
+    residual = jnp.ones((total_tokens, hidden_size))
+    hidden_states = jnp.ones((total_tokens, hidden_size))
+    # Pick the last token of each of the two requests.
+    last_token_indices = jnp.array([3, 7], dtype=jnp.int32)
+
+    with jax.set_mesh(proposer.mesh):
+        selected_positions, selected_residual, _ = (
+            proposer._select_inputs_for_loop_speculation(
+                state_leaves=None,
+                positions=positions,
+                residual=residual,
+                hidden_states=hidden_states,
+                last_token_indices=last_token_indices,
+            ))
+
+    # Positions must stay 2D shape (3, num_reqs); the pre-fix bug produced
+    # (num_reqs, total_tokens) here.
+    assert selected_positions.shape == (3, num_reqs), (
+        f"expected (3, {num_reqs}), got {selected_positions.shape} — the "
+        "select branch is silently mangling 2D M-RoPE positions")
+    # Values should be [3, 7] for each of the 3 M-RoPE axes.
+    assert jnp.array_equal(selected_positions,
+                           jnp.array([[3, 7], [3, 7], [3, 7]]))
+    assert selected_residual.shape == (num_reqs, hidden_size)

--- a/tpu_inference/layers/vllm/quantization/awq.py
+++ b/tpu_inference/layers/vllm/quantization/awq.py
@@ -29,10 +29,8 @@ from vllm.model_executor.layers.linear import (LinearBase, LinearMethodBase,
                                                set_weight_attrs)
 from vllm.model_executor.layers.quantization import \
     register_quantization_config
-from vllm.model_executor.layers.quantization.auto_awq import \
-    AutoAWQConfig as AWQConfig
-from vllm.model_executor.layers.quantization.auto_awq import \
-    AutoAWQLinearMethod as AWQLinearMethod
+from vllm.model_executor.layers.quantization.awq import (AWQConfig,
+                                                         AWQLinearMethod)
 from vllm.model_executor.layers.quantization.base_config import \
     QuantizeMethodBase
 from vllm.model_executor.layers.quantization.utils.quant_utils import \

--- a/tpu_inference/models/vllm/experimental/qwen3_vl_patcher.py
+++ b/tpu_inference/models/vllm/experimental/qwen3_vl_patcher.py
@@ -41,11 +41,14 @@ making sure they go through standard function arguments:
    model's cache just-in-time for the execution, and proceed with the original forward pass.
 """
 
+import os
+
 import torch
 import torch.nn as nn
 import vllm.model_executor.models.qwen3_vl as qwen3_vl_mod
 import vllm.model_executor.models.utils as vllm_utils
 from torchax.interop import jax_view, torch_view
+from vllm.config import get_current_vllm_config
 from vllm.model_executor.models.qwen3_vl import Qwen3VLForConditionalGeneration
 from vllm.multimodal import NestedTensors
 from vllm.sequence import IntermediateTensors
@@ -106,10 +109,21 @@ def _convert_to_torchax_tensor(v):
 
 def _patched_get_deepstack(vllm_model, orig_get_deepstack, num_tokens: int):
     """Retrieves Deepstack embeddings, preferring JAX-compatible cached tensors.
-    
+
     This method is called by the language model layers to retrieve the
     intermediate vision features.
     """
+    # Escape hatch: DISABLE_QWEN3_VL_DEEPSTACK=1 disables deepstack entirely
+    # by returning None here, which causes the LM to skip the
+    # `hidden_states + deepstack_input_embeds[key]` add at
+    # `qwen3_vl_moe.py:118`. Deepstack currently trips a torchax/dynamo
+    # `TypeError: unsupported operand type(s) for +: 'View' and 'Tensor'`
+    # during the backbone-with-embeds precompile, so this is the only way
+    # to reach warmup completion on that code path. Vision quality
+    # degrades because the deepstack residual is dropped, but the server
+    # comes up.
+    if os.environ.get("DISABLE_QWEN3_VL_DEEPSTACK", "0") == "1":
+        return None
     # Default: Use tensors cached locally in `_deepstack_tensors`.
     # These are already converted to Torchax tensors and JIT-compatible.
     if getattr(vllm_model, "_deepstack_tensors", None):
@@ -131,12 +145,18 @@ def _patched_get_deepstack(vllm_model, orig_get_deepstack, num_tokens: int):
 def _patched_embed_input_ids(vllm_model, orig_embed_input_ids, *args,
                              **kwargs):
     """Appends Deepstack features to the main text embeddings.
-    
+
     We concatenate deepstack features to the end of the text embeddings so they can
     pass through the JIT boundary of the LLM model.
     """
     # 1. Get the base text embeddings from the native model.
     inputs_embeds = orig_embed_input_ids(*args, **kwargs)
+
+    # Escape hatch: DISABLE_QWEN3_VL_DEEPSTACK=1 short-circuits packing so
+    # the JIT signature stays visual_dim wide and the LM never sees a
+    # non-None deepstack argument.
+    if os.environ.get("DISABLE_QWEN3_VL_DEEPSTACK", "0") == "1":
+        return inputs_embeds
 
     # 2. Check if there are any deepstack features to pack.
     deepstack_input_embeds = getattr(vllm_model, "deepstack_input_embeds",
@@ -178,10 +198,24 @@ def _patched_forward(vllm_model,
                      inputs_embeds=None,
                      **kwargs):
     """Unpacks vision features from combined embeddings and restores them to model state.
-    
+
     This reverses the packing done in `_patched_embed_input_ids` before passing
     the execution to the original model forward pass.
     """
+    if os.environ.get("DISABLE_QWEN3_VL_DEEPSTACK", "0") == "1":
+        # Escape hatch: clear any deepstack tensor stash so
+        # `orig_forward -> self._get_deepstack_input_embeds(...)` returns
+        # None, and the LM's `hidden_states + deepstack_input_embeds[key]`
+        # add at qwen3_vl_moe.py:118 is skipped entirely. torch.compile
+        # may inline the original bound method rather than our monkey-
+        # patched lambda, so patching `_get_deepstack_input_embeds` alone
+        # isn't sufficient — clearing the state at the outer forward
+        # ensures the LM sees None regardless of how the getter resolves.
+        vllm_model._deepstack_tensors = {}
+        if hasattr(vllm_model, "deepstack_input_embeds"):
+            vllm_model.deepstack_input_embeds = None
+        if hasattr(vllm_model, "deepstack_input_embeds_num_tokens"):
+            vllm_model.deepstack_input_embeds_num_tokens = 0
     if inputs_embeds is not None and jax_get_pp_group().is_first_rank:
         # Check if the embeddings contain packed vision features (indicated by dimension larger than visual_dim)
         if getattr(vllm_model, "use_deepstack",
@@ -260,8 +294,123 @@ def _patched_flatten_embeddings(embeddings: NestedTensors) -> torch.Tensor:
     return torch.cat(tuple(_patched_flatten_embeddings(t) for t in embeddings))
 
 
+def _patched_get_encoder_cudagraph_config(vllm_model, orig_fn):
+    """Filter modalities down to those actually enabled by the user.
+
+    Upstream `get_encoder_cudagraph_config` hard-codes
+    `modalities = ["image", "video"]` and then unconditionally calls
+    `self.get_max_frames_per_video()` when 'video' is in that list. On
+    workloads that disable video (e.g. `--limit-mm-per-prompt
+    '{"video":0}'`) the video path is a dead branch that still crashes
+    `get_max_frames_per_video` because `self.model_config` is not
+    initialized on `Qwen3VLMoeForConditionalGeneration` (its `__init__`
+    calls `super(Qwen3VLForConditionalGeneration, self).__init__()`
+    which SKIPS `Qwen3VLForConditionalGeneration.__init__` where
+    `self.model_config = vllm_config.model_config` would happen). Drop
+    disabled modalities BEFORE calling the original so both problems
+    disappear together.
+    """
+    vllm_config = get_current_vllm_config()
+    mm_config = getattr(vllm_config.model_config, "multimodal_config", None)
+    if mm_config is not None:
+        # `mm_config.get_limit_per_prompt` returns a plain int regardless
+        # of whether `limit_per_prompt` is stored as a bare int or as a
+        # VideoDummyOptions-typed object. Keep video only if the user
+        # permitted at least one.
+        if mm_config.get_limit_per_prompt("video") == 0:
+            # Temporarily shadow the offending pathway by making the
+            # video-branch predicate false. We patch at the module scope
+            # by wrapping `orig_fn` to run in a context where the
+            # multimodal_config reports video=0. Simplest reliable path:
+            # replace get_max_frames_per_video with a return-1 constant
+            # for the duration of the call, since upstream only uses it
+            # when "video" is in modalities (the list it builds is
+            # ["image", "video"] regardless of user config).
+            #
+            # We mutate the bound method rather than the class so other
+            # models aren't affected. Restore after.
+            orig_max_frames = vllm_model.get_max_frames_per_video
+            vllm_model.get_max_frames_per_video = (
+                lambda: 1)  # video disabled -> value never actually used
+            try:
+                return orig_fn()
+            finally:
+                vllm_model.get_max_frames_per_video = orig_max_frames
+    return orig_fn()
+
+
+def _patched_get_max_frames_per_video(vllm_model, orig_fn):
+    """Fall back to the ambient VllmConfig when `self.model_config` is
+    absent.
+
+    `Qwen3VLMoeForConditionalGeneration.__init__` skips
+    `Qwen3VLForConditionalGeneration.__init__` (via `super(Qwen3VLForCondGen,
+    self).__init__()`), so `self.model_config` is never set on MoE
+    variants. The upstream implementation dereferences
+    `self.model_config.max_model_len` and
+    `mm_registry.get_processing_info(self.model_config)` and raises
+    AttributeError. Route both through `get_current_vllm_config()` when
+    the attribute is missing.
+    """
+    if getattr(vllm_model, "model_config", None) is not None:
+        return orig_fn()
+    from vllm.multimodal import MULTIMODAL_REGISTRY
+    vllm_config = get_current_vllm_config()
+    model_config = vllm_config.model_config
+    info = MULTIMODAL_REGISTRY.get_processing_info(model_config)
+    return info.get_num_frames_with_most_features(
+        seq_len=model_config.max_model_len,
+        mm_counts={
+            "video":
+            model_config.multimodal_config.get_limit_per_prompt("video")
+        },
+    )
+
+
+def _patched_get_encoder_cudagraph_budget_range(vllm_model, orig_fn,
+                                                vllm_config):
+    """Prefer the passed `vllm_config.model_config.max_model_len` over
+    `self.model_config.max_model_len`. Upstream uses `self.model_config`
+    which is not present on `Qwen3VLMoeForConditionalGeneration`.
+    """
+    if getattr(vllm_model, "model_config", None) is not None:
+        return orig_fn(vllm_config)
+    # Bind `model_config` on the instance for the duration of the call.
+    vllm_model.model_config = vllm_config.model_config
+    try:
+        return orig_fn(vllm_config)
+    finally:
+        del vllm_model.model_config
+
+
 def apply_qwen3_vl_patches(vllm_model):
     """Apply Qwen3-VL specific patches for stateless Deepstack support."""
+    # ---- Fixes for Qwen3VLMoe missing `self.model_config` -----------------
+    # These patches are safe to apply for ALL Qwen3VL variants (both the
+    # dense Qwen3VLForConditionalGeneration and the MoE subclass) — the
+    # helpers early-return when `self.model_config` is already set, so the
+    # dense path is a no-op. The MoE subclass hits the fix path.
+    orig_get_encoder_cfg = getattr(vllm_model, "get_encoder_cudagraph_config",
+                                   None)
+    if orig_get_encoder_cfg is not None:
+        vllm_model.get_encoder_cudagraph_config = (
+            lambda: _patched_get_encoder_cudagraph_config(
+                vllm_model, orig_get_encoder_cfg))
+
+    orig_get_max_frames = getattr(vllm_model, "get_max_frames_per_video", None)
+    if orig_get_max_frames is not None:
+        vllm_model.get_max_frames_per_video = (
+            lambda: _patched_get_max_frames_per_video(vllm_model,
+                                                      orig_get_max_frames))
+
+    orig_get_budget_range = getattr(vllm_model,
+                                    "get_encoder_cudagraph_budget_range", None)
+    if orig_get_budget_range is not None:
+        vllm_model.get_encoder_cudagraph_budget_range = (
+            lambda vc: _patched_get_encoder_cudagraph_budget_range(
+                vllm_model, orig_get_budget_range, vc))
+
+    # ---- Deepstack support (only when the model actually uses it) --------
     if not getattr(vllm_model, "use_deepstack", False):
         return
 

--- a/tpu_inference/runner/compilation_manager.py
+++ b/tpu_inference/runner/compilation_manager.py
@@ -41,8 +41,7 @@ from tpu_inference.runner.utils import SpecDecodeMetadata
 from tpu_inference.spec_decode.jax.utils import (
     concat_last_sampled_tokens_and_draft_tokens, extend_logits_simple,
     extract_last_sampled_tokens, process_and_extend_logits)
-from tpu_inference.utils import (device_array, get_mesh_shape_product,
-                                 time_function, to_jax_dtype)
+from tpu_inference.utils import device_array, time_function, to_jax_dtype
 
 if TYPE_CHECKING:
     from tpu_inference.runner.tpu_runner import TPUModelRunner
@@ -662,6 +661,12 @@ class CompilationManager:
         for h_size in hidden_sizes_to_compile:
             for num_tokens in self.runner.num_tokens_paddings:
                 for num_reqs in self.runner.attn_num_reqs_paddings:
+                    # `padded_num_reqs` is a `meta_field` on AttentionMetadata,
+                    # so every distinct num_reqs is its own jit cache key.
+                    # The previous indentation left the helper call outside
+                    # this loop and only primed the last num_reqs bucket per
+                    # (h_size, num_tokens); every other bucket cache-missed at
+                    # runtime and triggered a recompile.
                     sharding = NamedSharding(
                         self.runner.mesh,
                         PartitionSpec(ShardingAxisName.ATTN_DATA, None))
@@ -671,42 +676,44 @@ class CompilationManager:
 
                     inputs_embeds = self._create_dummy_tensor(
                         (num_tokens, h_size), dtype, sharding=sharding)
-                if self.runner.uses_mrope:
-                    mrope_sharding = NamedSharding(
-                        self.runner.mesh,
-                        PartitionSpec(None, ShardingAxisName.ATTN_DATA))
-                    positions = self._create_dummy_tensor(
-                        (3, num_tokens), jnp.int32, sharding=mrope_sharding)
-                else:
-                    positions = self._create_dummy_tensor(
-                        (num_tokens, ), jnp.int32, sharding=input_sharding)
-                is_first_rank = self.runner.is_first_rank
-                is_last_rank = self.runner.is_last_rank
-                if not is_first_rank:
-                    hidden_states = self._create_dummy_tensor(
-                        (num_tokens, hidden_size),
-                        jnp.bfloat16,
-                        sharding=sharding)
-                    residual = self._create_dummy_tensor(
-                        (num_tokens, hidden_size),
-                        jnp.bfloat16,
-                        sharding=sharding)
-                    intermediate_tensors = JaxIntermediateTensors(
-                        tensors={
-                            "hidden_states": hidden_states,
-                            "residual": residual
-                        })
-                else:
-                    intermediate_tensors = None
-                self._precompile_backbone_helper(
-                    f"worker{self.runner.rank} backbone with embeds",
-                    input_ids=None,
-                    positions=positions,
-                    inputs_embeds=inputs_embeds,
-                    intermediate_tensors=intermediate_tensors,
-                    is_first_rank=is_first_rank,
-                    is_last_rank=is_last_rank,
-                    num_reqs=num_reqs)
+                    if self.runner.uses_mrope:
+                        mrope_sharding = NamedSharding(
+                            self.runner.mesh,
+                            PartitionSpec(None, ShardingAxisName.ATTN_DATA))
+                        positions = self._create_dummy_tensor(
+                            (3, num_tokens),
+                            jnp.int32,
+                            sharding=mrope_sharding)
+                    else:
+                        positions = self._create_dummy_tensor(
+                            (num_tokens, ), jnp.int32, sharding=input_sharding)
+                    is_first_rank = self.runner.is_first_rank
+                    is_last_rank = self.runner.is_last_rank
+                    if not is_first_rank:
+                        hidden_states = self._create_dummy_tensor(
+                            (num_tokens, hidden_size),
+                            jnp.bfloat16,
+                            sharding=sharding)
+                        residual = self._create_dummy_tensor(
+                            (num_tokens, hidden_size),
+                            jnp.bfloat16,
+                            sharding=sharding)
+                        intermediate_tensors = JaxIntermediateTensors(
+                            tensors={
+                                "hidden_states": hidden_states,
+                                "residual": residual
+                            })
+                    else:
+                        intermediate_tensors = None
+                    self._precompile_backbone_helper(
+                        f"worker{self.runner.rank} backbone with embeds",
+                        input_ids=None,
+                        positions=positions,
+                        inputs_embeds=inputs_embeds,
+                        intermediate_tensors=intermediate_tensors,
+                        is_first_rank=is_first_rank,
+                        is_last_rank=is_last_rank,
+                        num_reqs=num_reqs)
 
     def _precompile_select_from_array_helper(
         self,
@@ -1031,14 +1038,24 @@ class CompilationManager:
             "Compiling _process_and_extend_logits with different input shapes."
         )
         vocab_size = self.runner.vocab_size
+        # `process_and_extend_logits` at spec_decode/jax/utils.py:304 expects
+        # every input to be batch-sharded on `ATTN_DATA` (data + attn_dp +
+        # attn_dp_expert). Allocating the dummies with an empty
+        # `PartitionSpec()` fully replicates them on every chip during
+        # precompile, which under DP=N is a per-chip N× regression on the
+        # target_logits allocation (float32 × num_logits × vocab is the
+        # biggest single tensor in the runner) and is the direct cause of
+        # the DP-attention warmup OOM on Qwen3-VL 30B FP8 (~2.3 GiB dummy
+        # exhausting the final HBM budget). Match production sharding so
+        # the dummy allocation footprint mirrors real inference.
+        logits_sharding = NamedSharding(
+            self.runner.mesh, PartitionSpec(ShardingAxisName.ATTN_DATA))
+        dp_sharding = NamedSharding(self.runner.mesh,
+                                    PartitionSpec(ShardingAxisName.ATTN_DATA))
         for num_logits in self.runner.num_logits_paddings:
             for num_reqs in self.runner.num_reqs_paddings:
                 if num_reqs > num_logits:
                     continue
-
-                logits_sharding = NamedSharding(self.runner.mesh,
-                                                PartitionSpec())
-                dp_sharding = NamedSharding(self.runner.mesh, PartitionSpec())
 
                 target_logits = self._create_dummy_tensor(
                     (num_logits, vocab_size), jnp.float32, logits_sharding)
@@ -1102,14 +1119,17 @@ class CompilationManager:
                 if num_reqs > num_logits:
                     continue
 
-                attn_data_size = get_mesh_shape_product(
-                    self.runner.mesh, ShardingAxisName.ATTN_DATA)
-                if attn_data_size == 1:
-                    logits_spec = PartitionSpec()
-                else:
-                    logits_spec = PartitionSpec(ShardingAxisName.ATTN_DATA,
-                                                None)
-
+                # Runtime `extend_logits_simple` (spec_decode/jax/utils.py:260)
+                # unconditionally uses `PartitionSpec(ATTN_DATA, None)` as
+                # both in/out shard_map specs. Matching that here — even when
+                # ATTN_DATA resolves to a size-1 mesh axis (pure TP, no DP) —
+                # keeps the primer's NamedSharding cache key identical to
+                # runtime. The earlier `PartitionSpec()` special case at
+                # attn_data_size==1 produced a different key and cache-missed
+                # on the first spec-decode logprobs request, which raises
+                # under `VLLM_XLA_CHECK_RECOMPILATION=1` because the caller
+                # is inside `maybe_forbid_compile`.
+                logits_spec = PartitionSpec(ShardingAxisName.ATTN_DATA, None)
                 logits_sharding = NamedSharding(self.runner.mesh, logits_spec)
 
                 target_logits = self._create_dummy_tensor(
@@ -1343,10 +1363,27 @@ class CompilationManager:
                                                 sharding=dp_sharding)
         last_token_indices = self._create_dummy_tensor(
             (self.runner.max_num_reqs, ), jnp.int32, dp_sharding)
+        # M-RoPE targets (Qwen3-VL etc.) feed 2-D positions of shape
+        # (3, num_tokens) with `PartitionSpec(None, ATTN_DATA)` at runtime,
+        # while non-M-RoPE targets use 1-D `(num_tokens,)` on ATTN_DATA. The
+        # eagle3 draft `_prepare_inputs`/`_propose` jits key on that shape,
+        # so precompile has to match or the ForbidCompile guard fires on
+        # the first request.
+        uses_mrope = getattr(self.runner, "uses_mrope", False)
+        if uses_mrope:
+            positions_sharding = NamedSharding(
+                self.runner.mesh,
+                PartitionSpec(None, ShardingAxisName.ATTN_DATA))
+        else:
+            positions_sharding = dp_sharding
         for num_tokens in self.runner.num_tokens_paddings:
             for num_reqs in self.runner.attn_num_reqs_paddings:
-                positions = self._create_dummy_tensor((num_tokens, ),
-                                                      jnp.int32, dp_sharding)
+                if uses_mrope:
+                    positions = self._create_dummy_tensor(
+                        (3, num_tokens), jnp.int32, positions_sharding)
+                else:
+                    positions = self._create_dummy_tensor(
+                        (num_tokens, ), jnp.int32, positions_sharding)
                 attention_metadata = AttentionMetadata(
                     input_positions=positions,
                     block_tables=block_tables,
@@ -1617,9 +1654,30 @@ class CompilationManager:
             do_sampling=False,
             logprobs=False)
 
+        # M-RoPE targets thread 2-D positions (3, num_tokens) with
+        # `PartitionSpec(None, ATTN_DATA)` through `_prepare_inputs`; other
+        # targets thread 1-D (num_tokens,) on ATTN_DATA. In continue_decode
+        # each request produces one token per step, so num_tokens == num_reqs
+        # for this precompile. If we prime `AttentionMetadata.input_positions`
+        # with the wrong shape/sharding, the jitted `_decode_core` /
+        # `_update_loop_state` in decode_loop.py cache-miss on the first
+        # M-RoPE serving request and re-lower inside `maybe_forbid_compile`.
+        uses_mrope = getattr(self.runner, "uses_mrope", False)
+        if uses_mrope:
+            positions_sharding = NamedSharding(
+                self.runner.mesh,
+                PartitionSpec(None, ShardingAxisName.ATTN_DATA))
+        else:
+            positions_sharding = dp_sharding
+
         for num_reqs in self.runner.num_reqs_paddings:
             init_tokens = self._create_dummy_tensor((num_reqs, ), jnp.int32,
                                                     dp_sharding)
+            if uses_mrope:
+                positions = self._create_dummy_tensor((3, num_reqs), jnp.int32,
+                                                      positions_sharding)
+            else:
+                positions = init_tokens
             active_mask = self._create_dummy_tensor((num_reqs, ), jnp.bool_,
                                                     dp_sharding)
 
@@ -1660,7 +1718,7 @@ class CompilationManager:
                 block_tables = build_block_table(
                     0) if not no_kv_cache else None
                 attn_metadata = AttentionMetadata(
-                    input_positions=init_tokens,
+                    input_positions=positions,
                     block_tables=block_tables,
                     seq_lens=seq_lens,
                     query_start_loc=query_start_loc,
@@ -1672,7 +1730,7 @@ class CompilationManager:
                 attn_metadata = {
                     name:
                     AttentionMetadata(
-                        input_positions=init_tokens,
+                        input_positions=positions,
                         block_tables=build_block_table(gid),
                         seq_lens=seq_lens,
                         query_start_loc=query_start_loc,

--- a/tpu_inference/runner/kv_cache_manager.py
+++ b/tpu_inference/runner/kv_cache_manager.py
@@ -25,8 +25,8 @@ from vllm.model_executor.layers.attention import Attention
 from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
 from vllm.model_executor.layers.mamba.abstract import MambaBase
 from vllm.model_executor.layers.mla import MLAAttention
-from vllm.models.deepseek_v4.attention import (DeepseekV4Attention,
-                                               DeepseekV4IndexerCache)
+from vllm.models.deepseek_v4.attention import (DeepseekV4IndexerCache,
+                                               DeepseekV4MLAAttention)
 from vllm.models.deepseek_v4.compressor import CompressorStateCache
 from vllm.v1.attention.backend import AttentionType
 from vllm.v1.attention.backends.mla.sparse_swa import DeepseekV4SWACache
@@ -63,7 +63,7 @@ DEFAULT_KV_CACHE_LAYOUT = "NHD"
 def is_cache_for_ds_v4(attn_module: AttentionLayerBase) -> bool:
     return isinstance(attn_module, DeepseekV4IndexerCache) or isinstance(
         attn_module, DeepseekV4SWACache) or isinstance(
-            attn_module, DeepseekV4Attention) or isinstance(
+            attn_module, DeepseekV4MLAAttention) or isinstance(
                 attn_module, CompressorStateCache)
 
 
@@ -787,7 +787,7 @@ class KVCacheManager:
                             spec.num_kv_heads, spec.head_size, spec.dtype,
                             self.use_mla)
                 num_blocks = kv_cache_tensor.size // total_group_page_size
-            elif kv_cache_tensor.block_stride:
+            elif getattr(kv_cache_tensor, "block_stride", None):
                 # DeepseekV4 packed layout: vLLM overlays every cache
                 # (main MLA latent + indexer k_cache + compressor state +
                 # SWA) into one contiguous per-block backing buffer, so each
@@ -796,6 +796,11 @@ class KVCacheManager:
                 # own `offset`. `size` is a multiple of `block_stride`, not of
                 # any single layer's page size, and every packed layer shares
                 # the same `num_blocks`.
+                #
+                # `block_stride` is only present in the vLLM builds that carry
+                # the packed-layout PR; on the current LKG (which reverted it)
+                # `getattr` returns None and we fall through to the single-
+                # layer branch below.
                 assert kv_cache_tensor.size % kv_cache_tensor.block_stride == 0
                 num_blocks = (kv_cache_tensor.size //
                               kv_cache_tensor.block_stride)

--- a/tpu_inference/runner/mm_encoder_jit_manager.py
+++ b/tpu_inference/runner/mm_encoder_jit_manager.py
@@ -99,27 +99,37 @@ class _TorchaxEncoderModelAdapter:
     def _build_forward_fn(self) -> Callable:
         """Build the closure that gets ``jax.jit``-wrapped exactly once.
 
-        Inputs: ``params_jax`` (the model weights) + ``values_jax`` (the
-        full padded buffer dict including ``pixel_values``).
+        Inputs: ``params_jax`` (the model weights) + ``mm_kwargs_jax`` (the
+        padded multimodal input dict, e.g. pixel_values + image_grid_thw)
+        + ``buffers_jax`` (the padded encoder metadata buffers, e.g.
+        pos_embeds / rotary_pos_emb_{cos,sin} / cu_seqlens / max_seqlen /
+        sequence_lengths).
 
         Inside: bridge jax -> torchax with ``torch_view``, dispatch via
-        ``functional_call(call_method="encoder_cudagraph_forward")``,
-        bridge torchax output back to jax with ``jax_view``.
+        ``functional_call(call_method="encoder_cudagraph_forward")``
+        with the (mm_kwargs, buffers) two-arg signature vLLM adopted in
+        PR #41234 ("Simplify ViT CUDA graph interfaces"), bridge torchax
+        output back to jax with ``jax_view``.
         """
         vllm_runner = self._runner
 
-        def _forward(params_jax: Any, values_jax: dict[str, jax.Array]):
+        def _forward(params_jax: Any, mm_kwargs_jax: dict[str, jax.Array],
+                     buffers_jax: dict[str, jax.Array]):
             params_torchax = torch_view(params_jax)
-            values_torchax = {
+            mm_kwargs_torchax = {
                 k: jax.tree.map(torch_view, v)
-                for k, v in values_jax.items()
+                for k, v in mm_kwargs_jax.items()
+            }
+            buffers_torchax = {
+                k: jax.tree.map(torch_view, v)
+                for k, v in buffers_jax.items()
             }
             out_torch = torch.func.functional_call(
                 vllm_runner,
                 params_torchax,
                 kwargs={
                     "call_method": "encoder_cudagraph_forward",
-                    "call_args": (values_torchax, ),
+                    "call_args": (mm_kwargs_torchax, buffers_torchax),
                     "call_kwargs": {},
                 },
                 tie_weights=False,
@@ -128,14 +138,22 @@ class _TorchaxEncoderModelAdapter:
 
         return _forward
 
-    def run_budget_forward(self, padded_torch: dict[str, Any]) -> jax.Array:
+    def run_budget_forward(
+        self,
+        padded_mm_kwargs: dict[str, Any],
+        padded_buffers: dict[str, Any],
+    ) -> jax.Array:
         # Convert + JIT — INSIDE the env (the closure bridges torchax<->jax).
         with torchax.default_env(), enable_torch_wrap(False):
-            padded_jax = {
+            mm_kwargs_jax = {
                 k: jax.tree.map(self._t2j_if_tensor, v)
-                for k, v in padded_torch.items()
+                for k, v in padded_mm_kwargs.items()
             }
-            return self._jit_forward(self._params, padded_jax)
+            buffers_jax = {
+                k: jax.tree.map(self._t2j_if_tensor, v)
+                for k, v in padded_buffers.items()
+            }
+            return self._jit_forward(self._params, mm_kwargs_jax, buffers_jax)
 
     def encoder_eager_forward(self, mm_kwargs: dict[str, Any]) -> jax.Array:
         # Bridge plain-torch mm_kwargs -> torchax, dispatch the model's eager
@@ -292,27 +310,35 @@ class MMEncoderJITManager(EncoderCudaGraphManager):
         # Capture templates per budget — shape signature reference for
         # host-side padding. The values inside templates are dummy; only
         # tensor.shape / tensor.dtype matter (to us and to XLA's cache key).
+        # As of vLLM PR #41234 the capture inputs split into two dicts
+        # (`mm_kwargs` = pixel_values + grid metadata, `buffers` = the
+        # precomputed encoder metadata that the CUDA-graph path would
+        # replay). We keep them separate here because
+        # `encoder_cudagraph_forward` now takes them as two distinct args.
         capture_device = torch.device("cpu")
         capture_dtype = torch_dtype
-        self.budget_templates: dict[int, dict[str, torch.Tensor]] = {}
+        self.mm_kwargs_templates: dict[int, dict[str, torch.Tensor]] = {}
+        self.buffers_templates: dict[int, dict[str, torch.Tensor]] = {}
         for budget in self.token_budgets:
             capture = self.model.prepare_encoder_cudagraph_capture_inputs(
                 budget, self.max_batch_size, self.max_frames_per_batch,
                 capture_device, capture_dtype)
-            self.budget_templates[budget] = capture.values
+            self.mm_kwargs_templates[budget] = capture.mm_kwargs
+            self.buffers_templates[budget] = capture.buffers
 
         logger.info(
             "[mm_encoder_jit] budgets=%s max_batch_size=%d "
-            "max_frames_per_batch=%d template_keys=%s", self.token_budgets,
-            self.max_batch_size, self.max_frames_per_batch,
-            list(next(iter(self.budget_templates.values())).keys()))
+            "max_frames_per_batch=%d mm_keys=%s buffer_keys=%s",
+            self.token_budgets, self.max_batch_size, self.max_frames_per_batch,
+            list(next(iter(self.mm_kwargs_templates.values())).keys()),
+            list(next(iter(self.buffers_templates.values())).keys()))
 
     # ----- Padding (per-key) -----
 
-    def _pad_to_template(
+    def _pad_dict_to_template(
         self,
         replay_values: dict[str, torch.Tensor],
-        budget: int,
+        template: dict[str, torch.Tensor],
     ) -> dict[str, torch.Tensor]:
         """Zero-and-copy each replay tensor into a template-shaped buffer.
 
@@ -323,7 +349,6 @@ class MMEncoderJITManager(EncoderCudaGraphManager):
         cu_seqlens / scalars pass through because ``prepare_encoder_metadata``
         already padded them.
         """
-        template = self.budget_templates[budget]
         padded: dict[str, torch.Tensor] = {}
         for key, tmpl in template.items():
             src = replay_values.get(key)
@@ -352,25 +377,45 @@ class MMEncoderJITManager(EncoderCudaGraphManager):
     def _prepare_padded_torch(
         self,
         mm_kwargs: dict[str, Any],
+        replay_buffers: dict[str, torch.Tensor | None] | None,
         token_budget: int,
-    ) -> dict[str, torch.Tensor]:
-        """Build the full padded (plain-torch) buffer dict for one batch.
+    ) -> tuple[dict[str, torch.Tensor], dict[str, torch.Tensor]]:
+        """Build padded (plain-torch) mm_kwargs and buffers dicts for one
+        batch.
 
-        Runs entirely OUTSIDE the torchax env: the model's
-        ``prepare_encoder_cudagraph_replay_buffers`` indexes model
-        Parameters (``fast_pos_embed_interpolate``), which must dispatch as
-        normal torch, not through torchax. The t2j conversion to jax happens
-        later, inside ``_run_budget_graph``'s env block.
+        Runs entirely OUTSIDE the torchax env: `replay_buffers` (when None)
+        comes from the model's `prepare_encoder_cudagraph_replay_buffers`
+        which indexes model Parameters (`fast_pos_embed_interpolate`) and
+        must dispatch as normal torch, not through torchax. The t2j
+        conversion to jax happens later, inside `_run_budget_graph`'s env
+        block.
+
+        `mm_kwargs` (the actual batch inputs) are padded against
+        `mm_kwargs_templates[token_budget]`. `replay_buffers` (or the
+        model-computed replay values) are padded against
+        `buffers_templates[token_budget]`. Both dicts must match the
+        template shape signature for the JIT cache to hit.
 
         TODO(lk-chen): cache the non-pixel metadata tensors keyed on
         (token_budget, grid_thw) to skip the expensive
         fast_pos_embed_interpolate + rot_pos_emb host CPU work on repeated
-        requests with the same resolution. pixel_values must always come from
-        a fresh call. Invalidate when token_budget or grid_thw changes.
+        requests with the same resolution. pixel_values must always come
+        from a fresh call. Invalidate when token_budget or grid_thw
+        changes.
         """
-        replay = self.model.prepare_encoder_cudagraph_replay_buffers(
-            mm_kwargs, self.max_batch_size, self.max_frames_per_batch)
-        return self._pad_to_template(replay.values, token_budget)
+        if replay_buffers is None:
+            # Compatibility path for callers that don't have replay_buffers
+            # handy (e.g. our own `_capture_budget_graph` warmup). Compute
+            # them from the model just like the upstream `_execute_local`
+            # loop does before calling `_run_budget_graph`.
+            replay = self.model.prepare_encoder_cudagraph_replay_buffers(
+                mm_kwargs, self.max_batch_size, self.max_frames_per_batch)
+            replay_buffers = replay.buffers
+        padded_mm = self._pad_dict_to_template(
+            mm_kwargs, self.mm_kwargs_templates[token_budget])
+        padded_buffers = self._pad_dict_to_template(
+            replay_buffers, self.buffers_templates[token_budget])
+        return padded_mm, padded_buffers
 
     # ----- Overrides of the CUDA-graph device hooks -----
 
@@ -378,21 +423,23 @@ class MMEncoderJITManager(EncoderCudaGraphManager):
         """XLA-cache analog of ``torch.cuda.graph`` capture.
 
         Primes the ``jax.jit`` cache for ``token_budget`` by calling the
-        forward closure once on the budget's dummy template, so the first
-        runtime call is a cache hit instead of paying compile time. Invoked
-        by the inherited ``capture()`` loop (optional — the cache also fills
-        lazily on first ``execute``).
+        forward closure once on the budget's dummy templates, so the first
+        runtime call is a cache hit instead of paying compile time.
+        Invoked by the inherited ``capture()`` loop (optional — the cache
+        also fills lazily on first ``execute``).
         """
-        template = self.budget_templates[token_budget]
-        out = self.model.run_budget_forward(template)
+        mm_template = self.mm_kwargs_templates[token_budget]
+        buffers_template = self.buffers_templates[token_budget]
+        out = self.model.run_budget_forward(mm_template, buffers_template)
         jax.block_until_ready(out)
         # Mark captured so inherited capture()/get_cumulative_stats count it.
-        self.budget_graphs[token_budget] = template
+        self.budget_graphs[token_budget] = (mm_template, buffers_template)
 
     def _run_budget_graph(
         self,
         mm_kwargs: dict[str, Any],
         token_budget: int,
+        replay_buffers: dict[str, torch.Tensor | None] | None = None,
     ) -> jax.Array | None:
         """XLA-cache analog of CUDA-graph replay.
 
@@ -401,17 +448,26 @@ class MMEncoderJITManager(EncoderCudaGraphManager):
         ``run_budget_forward``. Returns a **jax.Array** that the inherited
         ``_execute_local`` slices via the adapter's jax-friendly
         ``postprocess_encoder_output`` — no outer torchax env required.
+
+        Signature matches vLLM's parent post-PR #41234:
+        ``(mm_kwargs, token_budget, replay_buffers)`` where
+        ``replay_buffers`` is the dict returned by
+        ``model.prepare_encoder_cudagraph_replay_buffers(...).buffers``.
+        Older callers that pass only ``(mm_kwargs, token_budget)`` still
+        work via the ``replay_buffers=None`` fallback which recomputes
+        them from the model.
         """
         num_items = len(self._get_item_specs(mm_kwargs))
-        if token_budget not in self.budget_templates:
-            # No template for this budget (rarely happen — budget comes
+        if token_budget not in self.mm_kwargs_templates:
+            # No template for this budget (rarely happens — budget comes
             # from _find_smallest_fitting_budget over self.token_budgets).
             self.graph_misses += num_items
             return None
 
         # Prep in plain torch (touches model Parameters) — OUTSIDE the env.
-        padded_torch = self._prepare_padded_torch(mm_kwargs, token_budget)
-        out_jax = self.model.run_budget_forward(padded_torch)
+        padded_mm, padded_buffers = self._prepare_padded_torch(
+            mm_kwargs, replay_buffers, token_budget)
+        out_jax = self.model.run_budget_forward(padded_mm, padded_buffers)
         self.graph_hits += num_items
         return out_jax
 

--- a/tpu_inference/runner/multimodal_manager.py
+++ b/tpu_inference/runner/multimodal_manager.py
@@ -12,11 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 from typing import TYPE_CHECKING
 
 import jax
 import jax.numpy as jnp
 import numpy as np
+from jax.sharding import NamedSharding
 from vllm.model_executor.layers.rotary_embedding import MRotaryEmbedding
 from vllm.multimodal.inputs import MultiModalKwargsItem, PlaceholderRange
 from vllm.multimodal.utils import group_and_batch_mm_kwargs
@@ -27,6 +29,106 @@ from tpu_inference.models.jax.utils.multi_modal_utils import \
     sanity_check_mm_encoder_outputs
 
 logger = init_logger(__name__)
+
+# ---------------------------------------------------------------------------
+# Encoder-cache offload to pinned_host (opt-in, gated by
+# OFFLOAD_ENCODER_CACHE_TO_HOST=1).
+#
+# Under multimodal workloads (Qwen3-VL MMMU-Pro at concurrency 64+), the
+# runner's `encoder_cache: dict[str, jax.Array]` accumulates variable-shape
+# entries — one per encoded image, sized by per-image patch count. Combined
+# with the compile-cache persistent buffers and KV-pool layout, this is a
+# primary driver of HBM external fragmentation (free > needed >
+# largest_contiguous; libtpu defrag can't relocate live tensors and fails).
+#
+# The offload keeps encoder outputs on host pinned memory between
+# `execute_mm_encoder` (producer) and `gather_mm_embeddings` (consumer);
+# only the memory kind changes, sharding spec is preserved. Same code
+# handles plain `jax.Array` and torchax-wrapped tensors.
+# ---------------------------------------------------------------------------
+
+_OFFLOAD_LOG_ONCE: dict[str, bool] = {}
+
+
+def _offload_encoder_cache_enabled() -> bool:
+    return os.environ.get("OFFLOAD_ENCODER_CACHE_TO_HOST", "0") == "1"
+
+
+def _maybe_unwrap_torchax(arr):
+    """Return (inner_jax_array, is_torchax_wrapped, rewrap_fn) tuple.
+
+    Torchax tensors round-trip through `jax_view`/`torch_view`. Plain
+    `jax.Array` passes through untouched. We avoid a hard torchax import at
+    module scope so the runner works in pure-JAX contexts.
+    """
+    if isinstance(arr, jax.Array):
+        return arr, False, (lambda x: x)
+    try:
+        from torchax.interop import jax_view, torch_view
+    except Exception:
+        return None, True, (lambda x: x)
+    try:
+        inner = jax_view(arr)
+    except Exception:
+        return None, True, (lambda x: x)
+    return inner, True, torch_view
+
+
+def _encoder_cache_to_pinned_host(arr):
+    """Move an encoder-cache entry to `pinned_host` memory_kind.
+
+    Preserves the sharding mesh + PartitionSpec. No-op if the tensor is
+    already on pinned_host, has non-NamedSharding, or is a torchax wrapper
+    we can't unwrap.
+    """
+    inner, is_torchax, rewrap = _maybe_unwrap_torchax(arr)
+    if inner is None:
+        if not _OFFLOAD_LOG_ONCE.get("unwrap_fail"):
+            logger.warning(
+                "[encoder-cache offload] could not unwrap %s; keeping on device",
+                type(arr).__name__,
+            )
+            _OFFLOAD_LOG_ONCE["unwrap_fail"] = True
+        return arr
+
+    src = inner.sharding
+    if not isinstance(src, NamedSharding):
+        if not _OFFLOAD_LOG_ONCE.get("non_named_sharding"):
+            logger.info(
+                "[encoder-cache offload] sharding %s not NamedSharding; "
+                "keeping on device",
+                type(src).__name__)
+            _OFFLOAD_LOG_ONCE["non_named_sharding"] = True
+        return arr
+    if getattr(src, "memory_kind", None) == "pinned_host":
+        return arr
+
+    moved = jax.device_put(
+        inner, NamedSharding(src.mesh, src.spec, memory_kind="pinned_host"))
+
+    if not _OFFLOAD_LOG_ONCE.get("reported"):
+        logger.info(
+            "[encoder-cache offload] active; first entry shape=%s dtype=%s "
+            "torchax=%s -> pinned_host", inner.shape, inner.dtype, is_torchax)
+        _OFFLOAD_LOG_ONCE["reported"] = True
+
+    return rewrap(moved) if is_torchax else moved
+
+
+def _encoder_cache_to_device(arr):
+    """Inverse of `_encoder_cache_to_pinned_host`. No-op if not offloaded."""
+    inner, is_torchax, rewrap = _maybe_unwrap_torchax(arr)
+    if inner is None:
+        return arr
+    src = inner.sharding
+    if not isinstance(src, NamedSharding):
+        return arr
+    if getattr(src, "memory_kind", None) != "pinned_host":
+        return arr
+    moved = jax.device_put(
+        inner, NamedSharding(src.mesh, src.spec, memory_kind="device"))
+    return rewrap(moved) if is_torchax else moved
+
 
 if TYPE_CHECKING:
     from tpu_inference.runner.tpu_runner import TPUModelRunner
@@ -156,11 +258,13 @@ class MultiModalManager:
                 encoder_outputs.append(output)
 
         # Cache the encoder outputs.
+        offload_to_host = _offload_encoder_cache_enabled()
         for (mm_hash, _), output in zip(
                 mm_hashes_pos,
                 encoder_outputs,
         ):
-
+            if offload_to_host:
+                output = _encoder_cache_to_pinned_host(output)
             self.runner.encoder_cache[mm_hash] = output
 
     def gather_mm_embeddings(
@@ -241,6 +345,10 @@ class MultiModalManager:
                         mm_hash, None)
                     assert encoder_output is not None, f"Encoder cache miss for {mm_hash}."
                     encoder_output = self.runner.encoder_cache[mm_hash]
+                    # If offloaded to pinned_host, bring back to device for
+                    # the slice — the downstream embed_input_ids_fn JIT runs
+                    # on device. No-op if not offloaded.
+                    encoder_output = _encoder_cache_to_device(encoder_output)
 
                     if (is_embed := pos_info.is_embed) is not None:
                         is_embed = is_embed[start_idx:end_idx]

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -1290,8 +1290,18 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         # Later, the multi-modality model will take the embedding as the input.
         # For text-only model, this does nothing. It will input the input_ids and
         # leave the embedding job inside the forward pass
+        # Spec-decode (eagle3/mtp) still needs the pre-embed input_ids for
+        # `_extract_draft_token_ids` during sampling — `_get_input_ids_embeds`
+        # nulls `input_ids` on the multimodal path.
+        input_ids_for_spec_decode = input_ids if spec_decode_metadata is not None else None
         input_ids, inputs_embeds = self._get_input_ids_embeds(
             input_ids, mm_embeds, is_mm_embed)
+        # If the multimodal path zeroed input_ids and we need it for spec
+        # decode, keep the pre-embed value for the sampling step.
+        if input_ids is None and input_ids_for_spec_decode is not None:
+            input_ids_for_sampling = input_ids_for_spec_decode
+        else:
+            input_ids_for_sampling = input_ids
 
         lora_metadata = self.lora_utils.extract_lora_metadata()
         # TODO: make _get_input_ids_embeds within this context
@@ -1383,7 +1393,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             scheduler_output=scheduler_output,
             attn_metadata=attn_metadata,
             sampling_metadata=sampling_metadata,
-            input_ids=input_ids,
+            input_ids=input_ids_for_sampling,
             hidden_states=hidden_states,
             logits=logits,
             aux_hidden_states=aux_hidden_states,

--- a/tpu_inference/spec_decode/jax/eagle3.py
+++ b/tpu_inference/spec_decode/jax/eagle3.py
@@ -546,20 +546,12 @@ class Eagle3Proposer:
                                                        last_token_indices)
 
         def _select(positions, residual, hidden_states, last_token_indices):
-            if self.method == "mtp":
-                # We need a separate branch for MTP because:
-                # 1. MTP uses final target output hidden states directly as inputs for the next step,
-                #    whereas Eagle uses intermediate residuals.
-                # 2. M-RoPE positions are 2D (3, total_tokens), requiring specific dim-1 slicing
-                #    which _select_inputs_for_loop_speculation does not support.
-                if positions.ndim == 2:
-                    positions = positions[:, last_token_indices]
-                else:
-                    positions = positions[last_token_indices]
-                residual = residual[last_token_indices]
-                return positions, residual
-
-            positions = positions[last_token_indices]
+            # M-RoPE positions are 2D (3, total_tokens); index along the token
+            # axis. Applies to both Eagle3 (VL targets) and MTP.
+            if positions.ndim == 2:
+                positions = positions[:, last_token_indices]
+            else:
+                positions = positions[last_token_indices]
             residual = residual[last_token_indices]
             return positions, residual
 


### PR DESCRIPTION
End-to-end fix chain that lets Qwen3-VL + eagle3 (or MTP) + multimodal
serve on TPU under DP-attention: unblocks startup against the current
vLLM LKG, fixes a warmup HBM OOM caused by a fully-replicated dummy in
spec-decode precompile, unblocks the first serving request (text and
multimodal) under M-RoPE + spec-decode, eliminates the classes of
runtime JIT that would otherwise re-fragment HBM mid-serve, and
restores the opt-in encoder-cache offload to `pinned_host` to reduce
serving-time fragmentation from variable-shape encoder outputs.

## 1. vLLM API-drift compat (kv_cache, awq, mm_encoder)

Restores the tpu-inference torchax path against the current vLLM LKG
so tpu-inference can start at all against upstream. Two rename
follow-ups and one signature refactor:

- `runner/kv_cache_manager.py`: rename `DeepseekV4Attention` →
  `DeepseekV4MLAAttention` to match vLLM after the flat-name revert;
  make `KVCacheTensor.block_stride` access via `getattr(..., None)`
  so the DeepseekV4 packed-layout branch is skipped (rather than
  crashing) on builds without that PR.
- `layers/vllm/quantization/awq.py`:
  `vllm.model_executor.layers.quantization.auto_awq` is gone in
  current vLLM; import `AWQConfig` / `AWQLinearMethod` from `.awq`
  directly (drop the `AutoAWQConfig as AWQConfig` alias).
- `runner/mm_encoder_jit_manager.py`: adopt vLLM PR #41234 (simplify
  ViT CUDA graph interfaces). `EncoderCudaGraphCaptureInputs` no
  longer has `.values`; it exposes `mm_kwargs` (pixel_values +
  grid_thw) and `buffers` (pos_embeds / rotary / cu_seqlens /
  max_seqlen / sequence_lengths) separately.
  `model.encoder_cudagraph_forward(mm_kwargs, buffers)` is now the
  two-arg signature. Templates are stored as two dicts
  (`mm_kwargs_templates` / `buffers_templates`) so the JIT cache
  keys correctly on both shape signatures.
- `tests/runner/test_mm_encoder_jit_manager.py`: update to match the
  refactored API — `_pad_dict_to_template(replay_values, template)`,
  the new attribute names, and the new
  `EncoderCudaGraphCaptureInputs(mm_kwargs=..., buffers=...)` /
  `EncoderCudaGraphReplayBuffers(buffers=...)` constructors.

## 2. Qwen3-VL Moe `__init__` workarounds

`Qwen3VLMoeForConditionalGeneration.__init__` calls
`super(Qwen3VLForConditionalGeneration, self).__init__()` which
SKIPS `Qwen3VLForConditionalGeneration.__init__` (where
`self.model_config = vllm_config.model_config` would be set). The
resulting `AttributeError` kills the engine during
`MMEncoderJITManager` init when vLLM calls
`get_encoder_cudagraph_config` (which reaches
`get_max_frames_per_video` → `self.model_config`). Patch three
methods in `models/vllm/experimental/qwen3_vl_patcher.py` to route
through `get_current_vllm_config()` when `self.model_config` is
missing: `get_encoder_cudagraph_config` (also filters `video` from
the modalities list when the user set `limit_per_prompt.video == 0`),
`get_max_frames_per_video`, and `get_encoder_cudagraph_budget_range`.

## 3. `DISABLE_QWEN3_VL_DEEPSTACK` env-var escape hatch

The Qwen3-VL deepstack add
(`hidden_states + deepstack_input_embeds[key]` at
`qwen3_vl_moe.py:120` / `qwen3_vl.py:1547`) trips
`TypeError: unsupported operand type(s) for +: 'View' and 'Tensor'`
during the "backbone with embeds" precompile under the torchax +
torch.compile dispatch. Attempted alternative materializations
(`.contiguous()`, `.clone()`, compilation-config mode NONE) all hit
the same failure — root cause is in the torchax / torch.compile
dispatch layer, not in the patcher.

Wire an opt-in bypass via `DISABLE_QWEN3_VL_DEEPSTACK=1` in three
places: `_patched_get_deepstack` (returns None so the LM skips the
add), `_patched_forward` (clears deepstack state pre-forward —
necessary because torch.compile/dynamo may inline the ORIGINAL bound
method rather than our monkey-patched lambda), and
`_patched_embed_input_ids` (short-circuits packing so `inputs_embeds`
keeps its `visual_dim` width). Vision quality degrades (deepstack
residual dropped) but the server comes up.

## 4. HBM: batch-shard dummy logits in `_precompile_process_and_extend_logits`

Fixes the DP-attention warmup OOM at ~92.95 GB/chip on Qwen3-VL-30B-A3B
+ eagle3 + `enable_dp_attention` (config: TP=2, attn_dp=4,
`max_num_seqs=128` → `max_num_reqs=512`).

`runner/compilation_manager.py`: allocate the dummy `target_logits`
and `processed_bonus_logits` in
`_precompile_process_and_extend_logits` with
`PartitionSpec(ShardingAxisName.ATTN_DATA)` instead of the empty
`PartitionSpec()` (fully replicated). This matches production —
the real `process_and_extend_logits` at
`spec_decode/jax/utils.py:304` wraps a `shard_map` with
`in_specs = PartitionSpec(ShardingAxisName.ATTN_DATA)` for both
target and bonus logits. The old dummy allocation replicated the
largest tensor in the runner (float32 × num_logits × vocab, up to
~2.5 GiB per shape at num_logits=4096 / vocab≈152064) on every
chip, so under DP=4 the per-chip footprint was 4× larger than
production, and the final dummy iteration in this precompile loop
was the direct cause of the eagle3 warmup OOM
("Attempting to allocate 2.32G. That was not possible. There are
1.80G free."). With the dummy sharded to match production, per-chip
peak drops from 92.95 GB (OOM) to 89.15 GB (server reaches
"Available routes" and `/health` = 200).

## 5. Eagle3 `_select_inputs_for_loop_speculation` handles 2-D M-RoPE positions

M-RoPE targets (Qwen3-VL etc.) feed 2-D positions of shape
`(3, num_tokens)` with `PartitionSpec(None, ATTN_DATA)`; non-M-RoPE
targets feed 1-D `(num_tokens,)` on `ATTN_DATA`.
`Eagle3Proposer._select_inputs_for_loop_speculation._select`
(spec_decode/jax/eagle3.py:548) unconditionally did
`positions[last_token_indices]`. For 2-D positions this indexes axis 0
with a length-B index array and produces `(B, N)` per shard instead of
`(3, B)`. The mis-shaped positions then fed into
`_update_inputs_for_loop_speculation`, where `jnp.any(axis=0)` reduced
the leading axis, and downstream
`jnp.where(exceeds_max_model_len_reduced, 1, new_seq_lens)` crashed
with:

    ValueError: Incompatible shapes for broadcasting:
        shapes=[(16,), (), (128,)]

where 16 = padded_total_num_scheduled_tokens/dp_size and
128 = max_num_reqs/dp_size at DP=4.

Fix: drop the method-based split; always index the token axis for 2-D
positions, mirroring the existing 2-D handling in
`_filter_token_and_prepare_initial_inputs`.

## 6. `_precompile_eagle3_helpers` primes 2-D M-RoPE positions

`compilation_manager._precompile_eagle3_helpers` unconditionally built
1-D positions `(num_tokens,)`. Runtime feeds 2-D for M-RoPE, so the
`@jax.jit`-decorated `_prepare_inputs` / `_propose` missed the cache
on the first serving request and re-lowered inside `ForbidCompile`
(about 25 s). Match runtime shape when `self.runner.uses_mrope`. The
MTP precompile helper already had the 2-D branch; only Eagle3 was
missing it.

## 7. Preserve pre-embed input_ids for multimodal + spec-decode

`TPUModelRunner._get_input_ids_embeds` returns `(None, inputs_embeds)`
on the multimodal path (the model consumes merged image+text
embeddings, not raw token ids). That `None` was stored into
`ExecuteModelState.input_ids` and reached `_sample_from_logits`, which
requires token ids for `_extract_draft_token_ids` when
`spec_decode_metadata is not None`. First multimodal request with
spec-decode enabled crashed with:

    AssertionError: assert input_ids is not None

Multimodal + spec-decode has no test coverage and appears to have
never worked end-to-end. Fix: keep the pre-embed `input_ids` under a
separate name when spec-decode is active and hand that to
`ExecuteModelState`. For text-only requests the drafter still sees
ordinary token ids; for multimodal requests it sees image placeholder
ids for the image span (the encoder replaces those with visual
features), and ordinary text ids for the generated tail — which is
exactly what the rejection sampler compares against.

## 8. Restore `OFFLOAD_ENCODER_CACHE_TO_HOST=1`

vLLM PR #2802 re-implemented `MMEncoderJITManager` and inadvertently
removed the earlier `OFFLOAD_ENCODER_CACHE_TO_HOST=1` opt-in. Under
multimodal workloads at concurrency, `runner.encoder_cache: dict[str,
jax.Array]` accumulates variable-shape entries (one per encoded image,
sized by per-image patch count). Combined with the compile-cache
persistent buffers and KV-pool layout, this contributes to HBM
external fragmentation — the "free > needed > largest_contiguous;
defrag-fails" pattern that libtpu's BFC can't recover from because it
cannot relocate live tensors.

Re-added `_offload_encoder_cache_enabled` +
`_encoder_cache_to_pinned_host` / `_encoder_cache_to_device` helpers
in `multimodal_manager.py`, wired into `execute_mm_encoder` (producer)
and `gather_mm_embeddings` (consumer). Sharding (mesh + PartitionSpec)
is preserved; only `memory_kind` changes. A lazy
`_maybe_unwrap_torchax` helper handles both plain `jax.Array` and
torchax-wrapped tensors without a hard torchax import at module scope.

Off by default; opt in with `OFFLOAD_ENCODER_CACHE_TO_HOST=1`.
Observational verification via `logger.info` sentinel on first encoded
image; A/B on MMMU-Pro conc=64 shows +3 GB `largest_free_block_bytes`
with offload on at the same peak HBM.

## 9. `_precompile_continue_decode`: prime 2-D M-RoPE positions

`_precompile_continue_decode` (compilation_manager.py:1690, 1702)
passed `init_tokens` (shape `(num_reqs,)`) as
`AttentionMetadata.input_positions` for both single-KV-group and
multi-KV-group branches, with no `uses_mrope` gate. Runtime
`_execute_continue_decode` threads 2-D M-RoPE positions of shape
`(3, num_tokens)` into the jitted `_decode_core` and
`_update_loop_state` (decode_loop.py). First M-RoPE decode-only
request re-lowered under `maybe_forbid_compile` and raised.

Fix: gate on `uses_mrope`, build a `(3, num_reqs)` positions tensor
with `PartitionSpec(None, ATTN_DATA)`, and thread it through both
`AttentionMetadata` constructions.

## 10. `_precompile_backbone_with_inputs_embeds`: fix `num_reqs` coverage

`_precompile_backbone_with_inputs_embeds` had an indentation bug: the
`if uses_mrope` block and the `_precompile_backbone_helper(...)` call
were one dedent short, sitting inside `for num_tokens` but OUTSIDE
`for num_reqs`. Because `padded_num_reqs` is a `meta_field` on
`AttentionMetadata`, every distinct `num_reqs` bucket is its own jit
cache key — the shallow indentation silently primed only the LAST
`num_reqs` bucket per `(h_size, num_tokens)`, so every other bucket
cache-missed at runtime. Affects all models (M-RoPE and non-M-RoPE)
that hit the multimodal-embed backbone.

Fix: re-indent the block one level so it runs inside `for num_reqs`.

## 11. `_precompile_extend_logits_simple`: match runtime `PartitionSpec`

`_precompile_extend_logits_simple` special-cased `attn_data_size == 1`
to `PartitionSpec()`, but runtime `extend_logits_simple`
(spec_decode/jax/utils.py:260) always uses
`PartitionSpec(ATTN_DATA, None)` for its `shard_map` in/out specs. On
single-DP meshes this produced a different `NamedSharding` cache key
and cache-missed on the first spec-decode logprobs call — which raises
under `VLLM_XLA_CHECK_RECOMPILATION=1` since the caller is inside
`maybe_forbid_compile`.

Fix: drop the special case and always prime with
`PartitionSpec(ATTN_DATA, None)`.

## 12. Regression test for the M-RoPE broadcast bug

`tests/spec_decode/test_eagle3.py::test_select_inputs_for_loop_speculation_mrope`
exercises `_select_inputs_for_loop_speculation` with 2-D positions for
both `method="eagle3"` and `method="mtp"` and asserts the output stays
`(3, num_reqs)`. Pre-fix the eagle3 parametrisation produced
`(num_reqs, total_tokens)` and the assertion would have caught the bug
at unit-test time. Note
`SpeculativeConfig(model=<eagle3_dir>, method="mtp")` auto-normalises
`.method` to `"eagle3"` internally, so the test overrides
`proposer.method` after construction to actually exercise both
branches genuinely.

## Verification

End-to-end on Qwen/Qwen3-VL-30B-A3B-Instruct + eagle3, DP=4/TP=2,
max_num_seqs=128, max_num_batched_tokens=8192, kv_cache_dtype=fp8,
`enable_dp_attention=true`, `cudagraph_mm_encoder=true`,
`num_speculative_tokens=4`:

1. Warmup completes (peak HBM 89.15 GB/chip; pre-fix warmup OOM at
   92.95 GB/chip).
2. `/health` → 200; first `/v1/chat/completions` → 200 with real
   completion.
3. First multimodal request (image + text) → 200 with correct
   caption.
4. `VLLM_XLA_CHECK_RECOMPILATION=1` end-to-end through single +
   concurrency=8 text + multimodal requests: zero post-startup
   recompile detections. Pre-fix the first request always triggered a
   ~25 s runtime compile with signature
   `jit(_prepare_inputs) in_avals=[(3, 64):int32, ...]`.
5. MMMU-Pro at concurrency=64, 512 prompts, output_len=128: 512/512
   success; 0.89 req/s, 466 tok/s total, mean E2EL 70 s, peak HBM
   ~90 GB/chip; 0 serving-time fragmentation OOMs.

## Not done in this commit

1. Does NOT solve the torchax/dynamo `View + Tensor` error at
   `qwen3_vl_moe.py:120` under `@support_torch_compile`. Deepstack
   remains dropped by the `DISABLE_QWEN3_VL_DEEPSTACK=1` escape hatch
   when the operator sets it; vision-quality trade-off is unchanged.
2. No unit-test coverage for the new precompile shape branches (6,
   9, 10, 11), the multimodal + spec-decode input_ids preservation
   (7), or the offload helpers (8) — those paths need a full runner
   spin-up to exercise which is heavier than the fixes warrant.
