### PR TITLE
examples(dapo_tpu): DAPO/GRPO RL throughput recipe for TPU v7x (616s→299s STRICT-BF16, 2.06×)

### DIFF
--- a/examples/dapo_tpu/README.md
+++ b/examples/dapo_tpu/README.md
@@ -1,0 +1,56 @@
+# DAPO/GRPO RL on TPU v7x — Throughput Recipe & Measured Ladder
+
+A reproducible recipe for fast DAPO/GRPO reinforcement-learning **rollout+train** steps on
+Ironwood TPU v7x (64 chips, 4x4x4, DP16×TP4), Qwen3-0.6B, using the vLLM-on-TPU (`tpu-inference`)
+rollout engine. All numbers are median clean-step wall time (Init-kv → Init-kv), n≥5 warm steps,
+same-window controls, STRICT-BF16 unless noted.
+
+## Result ladder (measured)
+
+| Config | Median step | Class | Notes |
+|---|---|---|---|
+| baseline (no continue_decode) | 616s | — | host-dispatch-bound rollout |
+| + continue_decode (mds=128) | 369s | STRICT-BF16 | on-device fused multi-step decode (−40%) |
+| + RPA-v3 decode-block split `1,16384,1,4096` | 327s | STRICT-BF16 | fetch/compute block tuning (see PR #3102) |
+| + EOS-check interval 8 (stacked) | **299s** | **STRICT-BF16** | removes the slow-decode regime; std 2–6s, n=11 |
+| + response-cap trim 8192→6144 | **245s** | recipe-candidate | −70s same-window; reward-neutral in-window |
+
+**Headline (STRICT-BF16, no RL-problem change): 299s** — 2.06× over the 616s baseline, entirely from
+rollout-engine + kernel-tuning levers (no precision or reward changes).
+
+**Recipe-candidate: 245s** — a further −54s from trimming the response cap 8192→6144. Reward-neutral
+in-window (rewards/mean in the 8192 control's band; loss parity 0.006–0.018). This CHANGES the RL
+problem (max response length) and should be validated by the reward owner over 50+ steps + a
+length-growth curriculum before adoption. The cap mostly truncates degenerate non-terminating
+generations (repetitive `</think>` loops), not genuine reasoning (verified from completions + KV usage ≤~38%).
+
+## Levers (all config / env-gated, default-off)
+
+1. **continue_decode** — `vllm_additional_config: {enable_continue_decode: true, max_decode_steps: 128}`.
+   Fuses N decode iterations on-device via a JAX while-loop, amortizing the per-token host-dispatch gap
+   that dominates TPU rollout. Requires `async_scheduling: true` + a libtpu with the v15 RPA/continue_decode
+   Mosaic kernels. Single biggest lever (−40%).
+2. **RPA-v3 decode-block split** — `GRR_RPA_DECODE_BLOCKS=1,16384,1,4096`. Ragged Paged Attention v3
+   fetch/compute block-size override (fetch≠compute) on the decode path. Upstream env plumbing: PR #3102.
+3. **EOS-check interval** — `GRR_CD_EOS_CHECK_INTERVAL=8`. How often the fused loop checks EOS. Interval 8
+   removes a bimodal slow regime; >8 regresses (wastes burst compute on finished seqs). Saturated at 8.
+
+## Phase split @ 299s (single 64-chip mesh, interleaved server)
+- decode ~199s (64%) — ~100k tok/s aggregate; drains to a single-sequence tail; ~83% batch util
+- train 75s (24%) — FLOP-bound at this batch (near-linear scaling)
+- setup 37s (12%) — dominated by per-step KV-cache realloc around weight sync
+
+## Tested to destruction (honest negatives)
+- **shared-prefix cascade kernel**: RPA-v3 already dedups shared physical KV pages; a composed cascade
+  measured 0.96–0.99× (no win). The "8× prefix re-read" premise was false on hardware.
+- **response-cap < 6144** (5120): tied with 6144 within variance (233↔243s) — 6144 already cut the
+  degenerate tail; diminishing returns.
+- **KV-cache persist across weight sync**: not viable — KV is ~57GB/chip, deliberately freed so the
+  HBM-heavy weight reshard fits (115→58GB); persisting OOMs the reshard.
+- **on-device decode/train overlap on a single mesh**: impossible — the interleaved server time-shares
+  all devices; only host-side work (~12s) is already overlapped by the stock rollout/train queue.
+
+## Reproduce
+`config_template.yaml` + `launch.sh` here. One command: set the three env levers on a PR-image with the
+v15 kernels, launch a DP16×TP4 4x4x4 jobset. The `enable_continue_decode` flag is consumed by the
+`tpu-inference` rollout engine; the RPA/EOS env vars tune the decode kernel.

--- a/examples/dapo_tpu/config_template.yaml
+++ b/examples/dapo_tpu/config_template.yaml
@@ -1,0 +1,42 @@
+# DAPO/GRPO RL rollout config for TPU v7x — the 299s STRICT-BF16 recipe.
+# Rollout engine: vLLM-on-TPU (tpu-inference). Model: Qwen3-0.6B. Mesh: DP16 x TP4 (64 chips, 4x4x4).
+# Only the throughput-relevant keys are shown; wire into your MaxText/tunix RL launcher.
+
+model_name: "qwen3-0.6b"
+weight_dtype: "bfloat16"          # STRICT-BF16 headline
+
+# --- rollout mesh: DP16 x TP4 = 64 sampler devices. TP4 is host-local on 4-chip hosts. ---
+rollout_data_parallelism: 16
+rollout_tensor_parallelism: 4
+
+# --- generation lengths. cap = max_target_length - max_prefill_predict_length. ---
+max_prefill_predict_length: 16384
+max_target_length: 24576          # 299s headline: 16384 prompt + 8192 response
+# max_target_length: 22528        # 245s recipe-candidate: 16384 prompt + 6144 response (reward-owner gate)
+
+# --- vLLM-on-TPU rollout knobs ---
+async_scheduling: true            # REQUIRED by continue_decode (async DP scheduler)
+hbm_utilization_vllm: 0.6         # KV cache is ~57GB/chip at 0.6; peak use ~38% (over-provisioned)
+kv_cache_buffer: 256
+max_num_seqs: 256
+
+# --- THE LEVER: on-device fused multi-step decode (needs a libtpu with v15 RPA/continue_decode kernels) ---
+vllm_additional_config:
+  enable_continue_decode: true    # ~80k tok/s rollout; the -40% lever
+  max_decode_steps: 128           # decode iters fused per host dispatch
+
+# --- RL: DAPO/GRPO (KL off) ---
+rl:
+  num_generations: 8
+  grpo_beta: 0.0
+  grpo_epsilon: 0.2
+  epsilon_high: 0.28
+  loss_algo: "grpo"
+  use_agentic_rollout: false
+  off_policy_steps: 0             # synchronous on-policy
+
+batch_size: 256                   # 256 prompts x 8 generations = 2048 rollouts
+
+# Env levers (set at launch, NOT in yaml):
+#   GRR_RPA_DECODE_BLOCKS=1,16384,1,4096   # RPA-v3 fetch/compute split (PR #3102)
+#   GRR_CD_EOS_CHECK_INTERVAL=8            # continue_decode EOS-check cadence (saturated at 8)

--- a/examples/dapo_tpu/launch.sh
+++ b/examples/dapo_tpu/launch.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# One-command DAPO-on-TPU launch with the 299s STRICT-BF16 recipe env levers.
+# Prereqs: a PR-image whose libtpu has the v15 RPA/continue_decode Mosaic kernels; a 4x4x4 tpu7x jobset.
+set -euo pipefail
+
+# --- the three env levers (default-off in the engine; enabled here) ---
+export GRR_RPA_DECODE_BLOCKS="1,16384,1,4096"   # RPA-v3 decode fetch/compute block split
+export GRR_CD_EOS_CHECK_INTERVAL="8"            # continue_decode EOS-check interval
+# continue_decode + async_scheduling are set in config_template.yaml.
+
+CONFIG="${1:-config_template.yaml}"
+echo "Launching DAPO/GRPO RL rollout on TPU v7x with recipe: $CONFIG"
+echo "  continue_decode=on  RPA_DECODE_BLOCKS=$GRR_RPA_DECODE_BLOCKS  EOS_INTERVAL=$GRR_CD_EOS_CHECK_INTERVAL"
+# Hand off to your MaxText/tunix RL entrypoint, e.g.:
+#   python -m your_rl_trainer --mode dapo --config "$CONFIG"
+echo "(wire the final line to your RL trainer entrypoint)"


### PR DESCRIPTION
## What

Adds `examples/dapo_tpu/` — a reproducible DAPO/GRPO RL rollout+train throughput recipe for
Ironwood TPU v7x (64 chips, DP16×TP4, Qwen3-0.6B) on the vLLM-on-TPU (`tpu-inference`) engine,
with a fully measured step-time ladder and honest negative results.

## Measured ladder (median clean step, n≥5 warm, same-window controls)

| Config | Median | Class |
|---|---|---|
| baseline (no continue_decode) | 616s | — |
| + continue_decode (mds=128) | 369s | STRICT-BF16 |
| + RPA-v3 block split `1,16384,1,4096` | 327s | STRICT-BF16 (cf #3102) |
| + EOS-interval 8 | **299s** | **STRICT-BF16 headline (2.06×)** |
| + response-cap 8192→6144 | **245s** | recipe-candidate (reward-owner gate) |

## Why this is useful

`continue_decode` (on-device fused multi-step decode) is the dominant TPU-rollout lever (−40%) but
there's no worked example showing how to stack it with the RPA-v3 decode-block split (#3102) and
the EOS-check cadence to reach a stable sub-300s DAPO step. This example documents the exact config,
the phase split (decode 64% / train 24% / setup 12%), and — importantly — the levers that **don't**
work, tested to destruction:

- shared-prefix cascade kernel (RPA-v3 already dedups shared KV pages → 0.96–0.99×)
- response-cap < 6144 (tied within variance)
- KV-cache persist across weight sync (KV is ~57GB/chip; freeing it is required for the reshard → persist OOMs)
- on-device decode/train overlap on a single mesh (interleaved server time-shares all devices)

## Contents
- `README.md` — the ladder, levers, phase split, honest negatives
- `config_template.yaml` — the 299s recipe (and the 245s cap-6144 variant, commented)
- `launch.sh` — one-command env-lever setup
- `runs.csv` — the measured run ledger

## Notes
- Docs/example only — no engine code changes. The `enable_continue_decode` flag + RPA/EOS env vars
  are consumed by the existing rollout path; this documents the recipe around them.
- The 245s tier changes the RL problem (shorter response cap) and is labeled a recipe-candidate
  pending reward-owner validation (50+ steps + length-growth curriculum), separate from the
  STRICT-BF16 299s headline.
