### PR TITLE
Add attention sink support for ragged paged attention

### DIFF
--- a/tests/layers/common/test_attention_interface.py
+++ b/tests/layers/common/test_attention_interface.py
@@ -62,8 +62,7 @@ def mesh():
 
 
 def _test_attention(monkeypatch, mesh, head_dim, use_sinks=False):
-    """
-    Tests the main `attention` function.
+    """Tests the main `attention` function.
 
     Verifies that:
     1. It calls the `sharded_ragged_paged_attention` kernel with correct metadata.
@@ -150,12 +149,8 @@ def test_attention_sink(monkeypatch, mesh):
     _test_attention(monkeypatch, mesh, 64, True)
 
 
-def test_attention_sink_no_64_raises_error(monkeypatch, mesh):
-    with pytest.raises(
-            NotImplementedError,
-            match="Attention sink support is only available when head_dim==64"
-    ):
-        _test_attention(monkeypatch, mesh, 128, True)
+def test_attention_sink_hd128(monkeypatch, mesh):
+    _test_attention(monkeypatch, mesh, 128, True)
 
 
 # ---- Tests for `sharded_ragged_paged_attention` ----
@@ -184,8 +179,7 @@ def gqa_mesh():
 
 
 def test_sharded_ragged_paged_attention_gqa_replication(monkeypatch, gqa_mesh):
-    """
-    Tests that K and V heads are correctly replicated for GQA in
+    """Tests that K and V heads are correctly replicated for GQA in
     `sharded_ragged_paged_attention`.
     """
     # 1. Arrange
@@ -262,9 +256,8 @@ def test_sharded_ragged_paged_attention_gqa_replication(monkeypatch, gqa_mesh):
 
 
 def test_sharded_ragged_paged_attention_gqa_incompatible_raises_error(
-    gqa_mesh, ):
-    """
-    Tests that a ValueError is raised for GQA when tp_size is not divisible
+        gqa_mesh):
+    """Tests that a ValueError is raised for GQA when tp_size is not divisible
     by num_kv_heads.
     """
     # 1. Arrange
@@ -363,13 +356,15 @@ def test_sharded_rpa_forwards_update_kv_cache_when_not_hd64(
     """`sharded_ragged_paged_attention` must forward `update_kv_cache`
     to the underlying kernel on the non-hd64 path. Both kernels (v3 and
     batched) accept the kwarg after this fix; the wrapper forwards it
-    unconditionally for non-hd64 head sizes."""
+    unconditionally for non-hd64 head sizes.
+    """
     captured = _run_sharded_rpa_capturing_kwargs(monkeypatch,
                                                  gqa_mesh,
                                                  update_kv_cache=False)
 
-    assert captured.get("update_kv_cache") is False, (
-        f"non-hd64 path must forward update_kv_cache=False; got {captured!r}")
+    assert (
+        captured.get("update_kv_cache") is False
+    ), f"non-hd64 path must forward update_kv_cache=False; got {captured!r}"
 
 
 def test_batched_rpa_wrapper_accepts_update_kv_cache():
@@ -379,16 +374,18 @@ def test_batched_rpa_wrapper_accepts_update_kv_cache():
     always forwards the kwarg on the non-hd64 path; without this
     signature, that forwarding crashed at trace time with
     `TypeError: ragged_paged_attention() got an unexpected keyword
-    argument 'update_kv_cache'`."""
+    argument 'update_kv_cache'`.
+    """
     import inspect
 
     from tpu_inference.kernels.experimental.batched_rpa import wrapper
+
     params = inspect.signature(wrapper.ragged_paged_attention).parameters
     assert "update_kv_cache" in params, (
-        f"batched RPA wrapper must accept update_kv_cache as a kwarg; "
+        "batched RPA wrapper must accept update_kv_cache as a kwarg; "
         f"got params: {list(params.keys())}")
     assert params["update_kv_cache"].default is True, (
-        f"update_kv_cache should default to True (no-op for non-KV-share "
+        "update_kv_cache should default to True (no-op for non-KV-share "
         f"callers); got default={params['update_kv_cache'].default!r}")
 
 
@@ -396,7 +393,8 @@ def test_sharded_rpa_rejects_update_kv_cache_false_on_hd64(gqa_mesh):
     """The hd64 RPA kernel doesn't support KV-share; passing
     update_kv_cache=False must raise rather than silently writing to
     cache. (Currently no model uses head_dim=64 + KV-share, but the
-    guard is cheap insurance.)"""
+    guard is cheap insurance.)
+    """
     head_dim = 64
     num_kv_heads = 4
     q = jnp.ones((TOTAL_TOKENS, NUM_HEADS, head_dim))
@@ -427,8 +425,7 @@ def test_sharded_rpa_rejects_update_kv_cache_false_on_hd64(gqa_mesh):
 
 
 def test_mla_attention(monkeypatch, mesh):
-    """
-    Tests the `mla_attention` function.
+    """Tests the `mla_attention` function.
 
     Verifies that:
     1. It correctly calculates block sizes using `get_tuned_block_sizes`
@@ -465,7 +462,8 @@ def test_mla_attention(monkeypatch, mesh):
                                               expected_new_cache))
     monkeypatch.setattr(
         "tpu_inference.layers.common.attention_interface.mla_ragged_paged_attention",
-        mock_mla_kernel)
+        mock_mla_kernel,
+    )
 
     final_kv_cache, output = mla_attention(
         q_NTA=q_NTA,

--- a/tests/layers/vllm/backends/test_flash_attn.py
+++ b/tests/layers/vllm/backends/test_flash_attn.py
@@ -399,19 +399,21 @@ class TestPallasAttentionBackendImpl:
             assert impl.sinks is not None
             impl.forward(layer, query, key, value, torch.tensor([]), metadata)
 
-    def test_forward_with_attention_sink_head_dim_128_raises_error(self, mesh):
+    def test_forward_with_attention_sink_head_dim_128(self, mesh):
         head_dim = 128
         sinks = torch.rand([NUM_HEADS], dtype=torch.float32)
 
-        impl = PallasAttentionBackendImpl(num_heads=NUM_HEADS,
-                                          head_size=head_dim,
-                                          scale=0.088,
-                                          num_kv_heads=NUM_KV_HEADS,
-                                          alibi_slopes=None,
-                                          sliding_window=None,
-                                          kv_cache_dtype="auto",
-                                          attn_type=AttentionType.DECODER,
-                                          sinks=sinks)
+        impl = PallasAttentionBackendImpl(
+            num_heads=NUM_HEADS,
+            head_size=head_dim,
+            scale=0.088,
+            num_kv_heads=NUM_KV_HEADS,
+            alibi_slopes=None,
+            sliding_window=None,
+            kv_cache_dtype="auto",
+            attn_type=AttentionType.DECODER,
+            sinks=sinks,
+        )
         impl.process_weights_after_loading(torch.bfloat16)
 
         layer = MagicMock()
@@ -423,11 +425,7 @@ class TestPallasAttentionBackendImpl:
         with torchax.default_env(), set_vllm_model_wrapper_context(
                 kv_caches=[kv_cache],
                 mesh=mesh,
-                layer_name_to_kvcache_index={'0': 0}
-        ), pytest.raises(
-                NotImplementedError,
-                match=
-                "Attention sink support is only available when head_dim==64"):
+                layer_name_to_kvcache_index={"0": 0}):
             assert impl.sinks is not None
             impl.forward(layer, query, key, value, torch.tensor([]), metadata)
 

--- a/tpu_inference/kernels/ragged_paged_attention/v3/kernel.py
+++ b/tpu_inference/kernels/ragged_paged_attention/v3/kernel.py
@@ -18,6 +18,7 @@ specifically designed for TPU and compatible with a wide range of model
 specifications. It supports mixed prefill and decoding, enhancing throughput
 during inference.
 """
+
 import functools
 from enum import Enum
 from typing import Any
@@ -39,6 +40,7 @@ class RpaCase(Enum):
   - PREFILL: Sequences are in prefill-only mode (q_len > 1, static).
   - MIXED: Sequences can be a mix of prefill and decode (q_len > 1, dynamic).
   """
+
     DECODE = 0
     PREFILL = 1
     MIXED = 2
@@ -76,6 +78,7 @@ def ref_ragged_paged_attention(
     cu_q_lens: jax.Array,  # i32[max_num_seqs + 1]
     distribution: jax.Array,  # i32[3]
     *,
+    attention_sink: jax.Array | None = None,  # f32[actual_num_q_heads]
     use_causal_mask: bool = True,
     skip_kv_mask: bool = False,
     sm_scale: float = 1.0,
@@ -102,6 +105,7 @@ def ref_ragged_paged_attention(
         page_indices,
         cu_q_lens,
         distribution,
+        attention_sink=attention_sink,
         use_causal_mask=use_causal_mask,
         skip_kv_mask=skip_kv_mask,
         sm_scale=sm_scale,
@@ -133,6 +137,9 @@ def ref_ragged_paged_attention(
     assert num_page_indices % max_num_seqs == 0
     pages_per_seq = num_page_indices // max_num_seqs
     outputs = []
+
+    if attention_sink is not None:
+        attention_sink = attention_sink.reshape(actual_num_q_heads, 1, 1)
 
     for i in range(distribution[-1]):
         q_start = cu_q_lens[i]
@@ -193,7 +200,14 @@ def ref_ragged_paged_attention(
             if sliding_window is not None:
                 mask = jnp.logical_and(mask, q_span < kv_span + sliding_window)
             attn = jnp.where(mask, attn, mask_value)
-        attn = jax.nn.softmax(attn, axis=-1).astype(v.dtype)
+        if attention_sink is not None:
+            sink_logits = jnp.repeat(attention_sink, q_len, axis=1)
+            sink_logits = sink_logits.astype(attn.dtype)
+            attn = jnp.concat([sink_logits, attn], axis=2)
+            attn = jax.nn.softmax(attn, axis=-1).astype(v.dtype)
+            attn = attn[..., 1:]
+        else:
+            attn = jax.nn.softmax(attn, axis=-1).astype(v.dtype)
 
         out = jnp.einsum("hqk,khd->qhd", attn, v).astype(out_dtype)
         if v_scale is not None:
@@ -303,6 +317,7 @@ def _ragged_paged_attention_kernel_loop(
     q_hbm_ref,  # [actual_num_kv_heads, max_num_tokens, num_q_heads_per_kv_head // q_packing, q_packing, head_dim]
     kv_hbm_ref,  # [max_num_tokens, num_kv_heads_x2 // kv_packing, kv_packing, head_dim]
     kv_cache_hbm_ref,  # [total_num_pages, page_size, num_kv_heads_x2 // kv_packing, kv_packing, head_dim]
+    attention_sink_ref,  # None | [actual_num_kv_heads, num_q_heads_per_kv_head, 128]
     # Output
     o_hbm_ref,  # [actual_num_kv_heads, max_num_tokens, num_q_heads_per_kv_head // q_packing, q_packing, head_dim]
     updated_kv_cache_hbm_ref,  # [total_num_pages, page_size, num_kv_heads_x2 // kv_packing, kv_packing, head_dim]
@@ -925,9 +940,14 @@ def _ragged_paged_attention_kernel_loop(
 
         @pl.loop(0, num_bq, unroll=False)
         def compute_with_bq(bq_idx):
-            # Re-initialize l, m, acc to 0 before bkv loop.
-            l_ref[...] = jnp.full_like(l_ref, 0.0)
-            m_ref[...] = jnp.full_like(m_ref, -jnp.inf)
+            if attention_sink_ref is not None:
+                sinks = attention_sink_ref[...]
+                m_seed = jnp.concat([sinks] * bq_sz, axis=1)
+                m_ref[...] = m_seed.astype(m_ref.dtype)
+                l_ref[...] = jnp.full_like(l_ref, 1.0)
+            else:
+                l_ref[...] = jnp.full_like(l_ref, 0.0)
+                m_ref[...] = jnp.full_like(m_ref, -jnp.inf)
             acc_ref[...] = jnp.full_like(acc_ref, 0.0)
 
             bq_sem_idx = sem_ids_ref[0]
@@ -1157,12 +1177,12 @@ def merge_kv(
 
 
 def prepare_inputs(
-        q: jax.Array,  # [max_num_tokens, actual_num_q_heads, actual_head_dim],
-        k: jax.
-    Array,  # [max_num_tokens, actual_num_kv_heads, actual_head_dim],
-        v: jax.
-    Array,  # [max_num_tokens, actual_num_kv_heads, actual_head_dim],
-):
+    q: jax.Array,  # [max_num_tokens, actual_num_q_heads, actual_head_dim],
+    k: jax.Array,  # [max_num_tokens, actual_num_kv_heads, actual_head_dim],
+    v: jax.Array,  # [max_num_tokens, actual_num_kv_heads, actual_head_dim],
+    attention_sink=None,  # None | [actual_num_q_heads]
+) -> tuple[jax.Array, jax.Array, jax.Array | None]:
+    """Prepares inputs for the RPA kernel."""
     max_num_tokens, actual_num_q_heads, actual_head_dim = q.shape
     actual_num_kv_heads = k.shape[1]
     assert actual_num_q_heads % actual_num_kv_heads == 0
@@ -1197,14 +1217,25 @@ def prepare_inputs(
         .swapaxes(0, 1))
     # TODO(kyuyeunk, chengjiyao): Add kv quantization here.
     kv = merge_kv(k, v)
-    return q, kv
+
+    if attention_sink is not None:
+        attention_sink = jnp.pad(
+            attention_sink.reshape(actual_num_kv_heads,
+                                   actual_num_q_heads_per_kv_head),
+            ((0, 0),
+             (0, num_q_heads_per_kv_head - actual_num_q_heads_per_kv_head)),
+            constant_values=0,
+        )[..., None]
+        attention_sink = jnp.repeat(attention_sink, 128, -1)
+
+    return q, kv, attention_sink
 
 
 def prepare_outputs(
     out,  # [actual_num_kv_heads, max_num_tokens, num_q_heads_per_kv_head // q_packing, q_packing, head_dim]
     actual_num_q_heads_per_kv_head: int,
     actual_head_dim: int,
-):
+) -> jax.Array:
     (
         actual_num_kv_heads,
         max_num_tokens,
@@ -1236,6 +1267,7 @@ def dynamic_validate_inputs(
     cu_q_lens: jax.Array,  # i32[max_num_seqs + 1]
     distribution: jax.Array,  # i32[3]
     *,
+    attention_sink: jax.Array | None = None,  # f32[actual_num_q_heads]
     use_causal_mask: bool = True,
     skip_kv_mask: bool = False,
     sm_scale: float = 1.0,
@@ -1264,6 +1296,7 @@ def dynamic_validate_inputs(
         page_indices,
         cu_q_lens,
         distribution,
+        attention_sink=attention_sink,
         use_causal_mask=use_causal_mask,
         skip_kv_mask=skip_kv_mask,
         sm_scale=sm_scale,
@@ -1331,6 +1364,7 @@ def static_validate_inputs(
     cu_q_lens: jax.Array,  # i32[max_num_seqs + 1]
     distribution: jax.Array,  # i32[3]
     *,
+    attention_sink: jax.Array | None = None,  # f32[actual_num_q_heads]
     use_causal_mask: bool = True,
     skip_kv_mask: bool = False,
     sm_scale: float = 1.0,
@@ -1372,6 +1406,15 @@ def static_validate_inputs(
     actual_head_dim = q.shape[2]
     actual_num_q_heads = q.shape[1]
     actual_num_kv_heads = k.shape[1]
+    if attention_sink is not None:
+        if attention_sink.shape != (actual_num_q_heads, ):
+            raise ValueError(
+                f"Expected {attention_sink.shape=} to be ({actual_num_q_heads},)."
+            )
+        if attention_sink.dtype != jnp.float32:
+            raise ValueError(
+                f"Expected {attention_sink.dtype=} to be equal to {jnp.float32=}."
+            )
 
     if actual_num_q_heads % actual_num_kv_heads != 0:
         raise ValueError(f"Expected {actual_num_q_heads=} to be divisible by"
@@ -1508,8 +1551,8 @@ def get_default_block_sizes(
 ):
     """Get (bq, bkv_sz, bq_csz, bkv_csz) by some heuristic formulas.
 
-    Note the default block sizes are not necessarily optimal.
-    """
+  Note the default block sizes are not necessarily optimal.
+  """
     tpu_version = get_tpu_version()
 
     kv_packing = get_dtype_packing(kv_dtype)
@@ -1595,6 +1638,7 @@ def ragged_paged_attention(
     page_indices: jax.Array,  # i32[max_num_seqs * pages_per_seq]
     cu_q_lens: jax.Array,  # i32[max_num_seqs + 1]
     distribution: jax.Array,  # i32[3]
+    attention_sink: jax.Array | None = None,  # f32[actual_num_q_heads]
     *,
     use_causal_mask: bool = True,
     update_kv_cache: bool = True,
@@ -1623,7 +1667,7 @@ def ragged_paged_attention(
     debug_mode: bool = False,
     disable_bounds_checks: bool = True,
     disable_semaphore_checks: bool = True,
-):
+) -> tuple[jax.Array, jax.Array]:
     """Ragged paged attention that supports mixed prefill and decode.
 
   Args:
@@ -1638,15 +1682,16 @@ def ragged_paged_attention(
     distribution: (i, j, k) represents that sequences[0:i] are decode-only,
       sequences[i:j] are chunked-prefill-only, and sequences[j:k] are mixed. The
       k is also the total number of sequences.
+    attention_sink: optional attention sink logit for each query head.
     use_causal_mask: if true, use causal mask.
     skip_kv_mask: only set to true if use_causal_mask=False and each dynamic
       kv_len % bkv_csz == 0. Set to true can improve performance.
     sm_scale: the softmax scale which will be applied to the Q@K^T.
     sliding_window: the sliding window size for the attention.
     soft_cap: the logit soft cap for the attention.
-    out_dtype: the dtype of the output and the accumulator for matmul. Set
-      lower for better performance, set higher for better accuracy. If None, it
-      uses q.dtype.
+    out_dtype: the dtype of the output and the accumulator for matmul. Set lower
+      for better performance, set higher for better accuracy. If None, it uses
+      q.dtype.
     mask_value: mask value for causal mask.
     q_scale: the scale for the query.
     k_scale: the scale for the key.
@@ -1688,6 +1733,7 @@ def ragged_paged_attention(
         page_indices,
         cu_q_lens,
         distribution,
+        attention_sink=attention_sink,
         use_causal_mask=use_causal_mask,
         skip_kv_mask=skip_kv_mask,
         sm_scale=sm_scale,
@@ -1710,7 +1756,7 @@ def ragged_paged_attention(
     actual_num_kv_heads = k.shape[1]
 
     actual_num_q_heads_per_kv_head = actual_num_q_heads // actual_num_kv_heads
-    q, kv = prepare_inputs(q, k, v)
+    q, kv, attention_sink = prepare_inputs(q, k, v, attention_sink)
     (
         _,
         max_num_tokens,
@@ -1748,6 +1794,8 @@ def ragged_paged_attention(
             pl.BlockSpec(memory_space=pltpu.HBM),
             pl.BlockSpec(memory_space=pltpu.HBM),
             pl.BlockSpec(memory_space=pltpu.HBM),
+            None if attention_sink is None else pl.BlockSpec(
+                memory_space=pltpu.VMEM),
         ]
 
         out_specs = [
@@ -1866,19 +1914,22 @@ def ragged_paged_attention(
         if tpu_version >= 7:
             # jit to color the memory since the q, kv are just preprocessed.
             @jax.jit
-            def run(scalar_prefetches, q, kv, kv_cache):
+            def run(scalar_prefetches, q, kv, kv_cache, attention_sink):
                 return kernel(
                     *scalar_prefetches,
                     pltpu.with_memory_space_constraint(q, pltpu.HBM),
                     pltpu.with_memory_space_constraint(kv, pltpu.HBM),
                     pltpu.with_memory_space_constraint(kv_cache, pltpu.HBM),
+                    attention_sink,
                 )
+
         else:
             # TODO(b/494285697): v6 has issues with pinning aliased memory.
-            def run(scalar_prefetches, q, kv, kv_cache):
-                return kernel(*scalar_prefetches, q, kv, kv_cache)
+            def run(scalar_prefetches, q, kv, kv_cache, attention_sink):
+                return kernel(*scalar_prefetches, q, kv, kv_cache,
+                              attention_sink)
 
-        return run(scalar_prefetches, q, kv, kv_cache)
+        return run(scalar_prefetches, q, kv, kv_cache, attention_sink)
 
     def _prepare_block_sizes(block_sizes, case):
         if block_sizes is None:

--- a/tpu_inference/kernels/ragged_paged_attention/v3/kernel_hd64.py
+++ b/tpu_inference/kernels/ragged_paged_attention/v3/kernel_hd64.py
@@ -48,8 +48,8 @@ def ref_ragged_paged_attention_hd64(
     page_indices: jax.Array,  # i32[max_num_seqs * pages_per_seq]
     cu_q_lens: jax.Array,  # i32[max_num_seqs + 1]
     distribution: jax.Array,  # i32[3]
-    attention_sink: jax.Array | None = None,  # f32[actual_num_q_heads]
     *,
+    attention_sink: jax.Array | None = None,  # f32[actual_num_q_heads]
     sm_scale: float = 1.0,
     sliding_window: int | None = None,
     soft_cap: float | None = None,
@@ -69,7 +69,7 @@ def ref_ragged_paged_attention_hd64(
         page_indices,
         cu_q_lens,
         distribution,
-        attention_sink,
+        attention_sink=attention_sink,
         sm_scale=sm_scale,
         sliding_window=sliding_window,
         soft_cap=soft_cap,
@@ -104,6 +104,9 @@ def ref_ragged_paged_attention_hd64(
     merged_kv = merge_kv(keys, values)
     queries = jnp.pad(queries, ((0, 0), (0, 0), (0, 64)), constant_values=0.0)
     outputs = []
+
+    if attention_sink is not None:
+        attention_sink = attention_sink.reshape(actual_num_q_heads, 1, 1)
 
     for i in range(distribution[-1]):
         q_start = cu_q_lens[i]
@@ -160,11 +163,7 @@ def ref_ragged_paged_attention_hd64(
         attn = jnp.where(mask, mask_value, attn)
 
         if attention_sink is not None:
-            reshaped_attention_sink = attention_sink.reshape(
-                actual_num_q_heads, 1, 1)
-            reshaped_attention_sink = jnp.repeat(reshaped_attention_sink,
-                                                 q_len,
-                                                 axis=1)
+            reshaped_attention_sink = jnp.repeat(attention_sink, q_len, axis=1)
             attn = jnp.concat([reshaped_attention_sink, attn], axis=2)
             attn = jax.nn.softmax(attn, axis=-1).astype(kv.dtype)
             attn = attn[..., 1:]
@@ -1050,8 +1049,13 @@ def prepare_inputs(
     kv = merge_kv(k, v)
 
     if attention_sink is not None:
-        attention_sink = attention_sink.reshape(
-            (-1, num_q_heads_per_kv_head, 1))
+        attention_sink = jnp.pad(
+            attention_sink.reshape(actual_num_kv_heads,
+                                   actual_num_q_heads_per_kv_head),
+            ((0, 0),
+             (0, num_q_heads_per_kv_head - actual_num_q_heads_per_kv_head)),
+            constant_values=0,
+        )[..., None]
         attention_sink = jnp.repeat(attention_sink, 128, -1)
 
     return q, kv, attention_sink
@@ -1093,8 +1097,8 @@ def dynamic_validate_inputs(
     page_indices: jax.Array,  # i32[max_num_seqs * pages_per_seq]
     cu_q_lens: jax.Array,  # i32[max_num_seqs + 1]
     distribution: jax.Array,  # i32[3]
-    attention_sink: jax.Array | None = None,  # f32[actual_num_q_heads]
     *,
+    attention_sink: jax.Array | None = None,  # f32[actual_num_q_heads]
     sm_scale: float = 1.0,
     sliding_window: int | None = None,
     soft_cap: float | None = None,
@@ -1121,7 +1125,7 @@ def dynamic_validate_inputs(
         page_indices,
         cu_q_lens,
         distribution,
-        attention_sink,
+        attention_sink=attention_sink,
         sm_scale=sm_scale,
         sliding_window=sliding_window,
         soft_cap=soft_cap,
@@ -1185,8 +1189,8 @@ def static_validate_inputs(
     page_indices: jax.Array,  # i32[max_num_seqs * pages_per_seq]
     cu_q_lens: jax.Array,  # i32[max_num_seqs + 1]
     distribution: jax.Array,  # i32[3]
-    attention_sink: jax.Array | None = None,  # f32[actual_num_q_heads]
     *,
+    attention_sink: jax.Array | None = None,  # f32[actual_num_q_heads]
     sm_scale: float = 1.0,
     sliding_window: int | None = None,
     soft_cap: float | None = None,
@@ -1413,7 +1417,7 @@ def ragged_paged_attention_hd64(
         page_indices,
         cu_q_lens,
         distribution,
-        attention_sink,
+        attention_sink=attention_sink,
         sm_scale=sm_scale,
         sliding_window=sliding_window,
         soft_cap=soft_cap,

--- a/tpu_inference/kernels/ragged_paged_attention/v3/tuned_block_sizes.py
+++ b/tpu_inference/kernels/ragged_paged_attention/v3/tuned_block_sizes.py
@@ -22,6 +22,9 @@ from tpu_inference.utils import get_device_name
 
 logger = init_logger(__name__)
 
+_MAX_FALLBACK_BKV_P = 32
+_MAX_SLIDING_WINDOW_FALLBACK_BKV_P = 1
+
 # key
 #   - device_name
 #     - page_size
@@ -3146,11 +3149,11 @@ TUNED_BLOCK_SIZES = {
                 },
                 'q_head-16_kv_head-1_head-128': {
                     'max_model_len-2048-sw-None': (8, 64),
-                    512: (4, 64)
+                    512: (4, 64),
                 },
                 'q_head-16_kv_head-1_head-256': {
                     'max_model_len-128-sw-None': (1, 32),
-                    256: (2, 8)
+                    256: (2, 8),
                 },
                 'q_head-16_kv_head-2_head-128': {
                     'max_model_len-128-sw-None': (1, 128),
@@ -4380,6 +4383,13 @@ def get_tuned_block_sizes(
                 bkv_p, bq = (4096 // page_size, 32)
             case _:
                 bkv_p, bq = (2048 // page_size, 32)
+        # Fallback values are guesses for untuned shapes. Keep them bounded so
+        # missing entries, especially sliding-window entries, do not spill VMEM.
+        bkv_p = min(
+            bkv_p,
+            _MAX_SLIDING_WINDOW_FALLBACK_BKV_P
+            if sliding_window is not None else _MAX_FALLBACK_BKV_P,
+        )
 
     # We should consider the actual page_per_seq and max_num_tokens.
     # If page_per_seq < bkv_p or max_num_tokens < bq, using the bkv_p or bq may

--- a/tpu_inference/layers/common/attention_interface.py
+++ b/tpu_inference/layers/common/attention_interface.py
@@ -423,10 +423,6 @@ def sharded_ragged_paged_attention(
     func = ragged_paged_attention_hd64 if use_hd64 else ragged_paged_attention
 
     if attention_sink is not None:
-        if not use_hd64:
-            raise NotImplementedError(
-                "Attention sink support is only available when head_dim==64")
-
         in_specs += (P(ShardingAxisName.ATTN_HEAD), )
         args += (attention_sink, )
 


### PR DESCRIPTION

# Description

- Add attention sink support to the default RPA v3 kernel path.
- Allow head_dim=128 attention sinks through common and vLLM attention paths instead of treating sinks as head_dim=64 only.
- Fix sink preparation for padded GQA head groups by padding sinks consistently with query head packing.
- Add VMEM-safe fallback caps for untuned RPA v3 block sizes:
- bkv_p <= 1 when sliding_window is active
- bkv_p <= 32 otherwise

# Tests

Added coresponded unit test.


# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
