### PR TITLE
[BATCHED_RPA] Add SEQ_ON_LANE kv cache layout to remove padding when kv_heads = 1, kv d_type = fp8

### DIFF
--- a/tpu_inference/envs.py
+++ b/tpu_inference/envs.py
@@ -41,6 +41,7 @@ if TYPE_CHECKING:
     USE_JAX_PROFILER_SERVER: bool = False
     JAX_PROFILER_SERVER_PORT: int = 9999
     USE_BATCHED_RPA_KERNEL: bool = False
+    USE_BATCHED_RPA_SEQ_ON_LANE: bool = False
     FORCE_MOE_RANDOM_ROUTING: bool = False
     JITTED_MM_MODULE_KEYS: list[str] = []
     REGISTER_MM_MODULE_CUSTOM_PYTREE_CLASSES: list[str] = []
@@ -319,6 +320,8 @@ environment_variables: dict[str, Callable[[], Any]] = {
     lambda: int(os.getenv("JAX_PROFILER_SERVER_PORT") or "9999"),
     "USE_BATCHED_RPA_KERNEL":
     env_bool("USE_BATCHED_RPA_KERNEL"),
+    "USE_BATCHED_RPA_SEQ_ON_LANE":
+    env_bool("USE_BATCHED_RPA_SEQ_ON_LANE"),
     # Force random expert routing in MoE layers (for testing purposes only)
     "FORCE_MOE_RANDOM_ROUTING":
     env_bool("FORCE_MOE_RANDOM_ROUTING", default=False),

--- a/tpu_inference/kernels/experimental/batched_rpa/bref_override.py
+++ b/tpu_inference/kernels/experimental/batched_rpa/bref_override.py
@@ -35,8 +35,8 @@ class _BypassRef(pltpu.BufferedRef):
 
 @jax.tree_util.register_dataclass
 @dataclasses.dataclass(frozen=True)
-class KVBufferedRef(_BypassRef):
-    """Handles fetching and updating KV cache using precomputed metadata."""
+class KVBufferedRefSeqAlongLane(_BypassRef):
+    """Handles fetching/updating KV cache using SEQ_ALONG_LANE memory layout."""
 
     cfgs: configs.RpaConfigs = dataclasses.field(default=None,
                                                  metadata=dict(static=True))
@@ -46,7 +46,185 @@ class KVBufferedRef(_BypassRef):
         cls,
         spec: pl.BlockSpec,
         dtype_or_type: jax.Array,
-        buffer_type,  # pltpu.BufferType,
+        buffer_type: pltpu.BufferType,
+        buffer_count: int,
+        use_lookahead: bool,
+        cfgs: configs.RpaConfigs,
+    ):
+        assert buffer_type == pltpu.BufferType.INPUT_OUTPUT
+
+        standard_ref = _BypassRef.create(
+            spec=spec,
+            dtype_or_type=dtype_or_type,
+            buffer_type=buffer_type,
+            buffer_count=buffer_count,
+            grid_rank=1,
+            use_lookahead=use_lookahead,
+        )
+        return cls(
+            cfgs=cfgs,
+            **{
+                f.name: getattr(standard_ref, f.name)
+                for f in dataclasses.fields(pltpu.BufferedRef)
+            },
+        )
+
+    def copy_in(
+        self,
+        src_ref: tuple[jax.Ref, jax.Ref, schedule.RpaSchedule, jax.Ref],
+        grid_indices: tuple[int | jax.Array, ...],
+    ):
+        # src_ref: (kv_cache_hbm, new_kv_hbm, schedule_ref, page_indices_ref)
+        kv_cache_hbm, new_kv_hbm, schedule_ref, page_indices_ref = src_ref
+        slot = self.current_copy_in_slot
+        sem = self.sem_recvs.at[slot]
+        block_idx = jnp.maximum(grid_indices[0], 0)
+
+        vmem_dst_lane = self.window_ref.at[slot]
+        for b in range(self.cfgs.batch_size):
+            for i in range(self.cfgs.bkv_p_cache):
+                p_idx, dst_off, dma_valid = schedule_ref.get_dma_kv_cache(
+                    block_idx, b, i)
+                hbm_p_idx = page_indices_ref[p_idx]
+                sz = dma_valid * self.cfgs.serve.page_size
+                num_lanes = pltpu.get_tpu_info().num_lanes
+                dst_off = pl.multiple_of(dst_off, num_lanes)
+                sz = pl.multiple_of(sz, num_lanes)
+                # kv_cache_hbm: (num_pages, num_kv_heads * 2, kv_head_dim // packing, packing, page_size)
+                # vmem_dst_lane: (batch_size, num_kv_heads * 2, kv_head_dim // packing, packing, page_size)
+                pltpu.make_async_copy(
+                    kv_cache_hbm.at[hbm_p_idx, :, :, :,
+                                    pl.ds(0, sz)],
+                    vmem_dst_lane.at[b, :, :, :,
+                                     pl.ds(dst_off, sz)],
+                    sem,
+                ).start()
+
+            for i in range(self.cfgs.bkv_p_new):
+                dma_entry = schedule_ref.dma_kv_new[block_idx, b, i]
+                src_new_off = dma_entry.fetch_hbm[...]
+                dst_vmem_off = dma_entry.fetch_vmem[...]
+                dma_valid = dma_entry.fetch_val
+                sz = dma_valid * self.cfgs.serve.page_size
+                src_new_off = pl.multiple_of(src_new_off, 128)
+                dst_vmem_off = pl.multiple_of(dst_vmem_off, 128)
+                sz = pl.multiple_of(sz, 128)
+                # new_kv_hbm: (num_kv_heads * 2, kv_head_dim // packing, packing, total_new_tokens)
+                # vmem_dst_lane: (batch_size, num_kv_heads * 2, kv_head_dim // packing, packing, page_size)
+                pltpu.make_async_copy(
+                    new_kv_hbm.at[:, :, :, pl.ds(src_new_off, sz)],
+                    vmem_dst_lane.at[b, :, :, :,
+                                     pl.ds(dst_vmem_off, sz)],
+                    sem,
+                ).start()
+
+    def copy_out(
+        self,
+        dst_ref: tuple[jax.Ref, jax.Ref, schedule.RpaSchedule, jax.Ref],
+        grid_indices: tuple[int | jax.Array, ...],
+    ):
+        kv_out_ref, _, schedule_ref, page_indices_ref = dst_ref
+        slot = self.current_copy_out_slot
+        sem = self.sem_sends.at[slot]
+        block_idx = grid_indices[0]
+
+        vmem_src_lane = self.window_ref.at[slot]
+        for b in range(self.cfgs.batch_size):
+            do_writeback = schedule_ref.do_writeback[block_idx, b] == 1
+            for i in range(self.cfgs.bkv_p_new):
+                dma_entry = schedule_ref.dma_kv_new[block_idx, b, i]
+                dst_hbm_p = dma_entry.wb_hbm[...]
+                src_vmem_off = dma_entry.wb_vmem[...]
+                dma_valid = dma_entry.wb_val
+                hbm_p_idx = page_indices_ref[dst_hbm_p]
+                sz = jnp.where(do_writeback,
+                               dma_valid * self.cfgs.serve.page_size, 0)
+                src_vmem_off = pl.multiple_of(src_vmem_off, 128)
+                sz = pl.multiple_of(sz, 128)
+                pltpu.make_async_copy(
+                    vmem_src_lane.at[b, :, :, :,
+                                     pl.ds(src_vmem_off, sz)],
+                    kv_out_ref.at[hbm_p_idx, :, :, :,
+                                  pl.ds(0, sz)],
+                    sem,
+                ).start()
+
+    def wait_in(
+        self,
+        src_ref: tuple[jax.Ref, jax.Ref, schedule.RpaSchedule, jax.Ref],
+        grid_indices: tuple[int | jax.Array, ...],
+    ):
+        _, _, schedule_ref, _ = src_ref
+        slot = self.current_wait_in_slot
+        sem = self.sem_recvs.at[slot]
+        vmem_dst = self.window_ref.at[slot]
+        block_idx = grid_indices[0]
+
+        for b in range(self.cfgs.batch_size):
+            total_pages_b = 0
+            for i in range(self.cfgs.bkv_p_cache):
+                _, _, dma_valid = schedule_ref.get_dma_kv_cache(
+                    block_idx, b, i)
+                total_pages_b += dma_valid
+            for i in range(self.cfgs.bkv_p_new):
+                dma_entry = schedule_ref.dma_kv_new[block_idx, b, i]
+                dma_valid = dma_entry.fetch_val
+                total_pages_b += jnp.where(dma_valid > 0, 1, 0)
+
+            sz = total_pages_b * self.cfgs.serve.page_size
+            sz = pl.multiple_of(sz, 128)
+            pltpu.make_async_copy(
+                vmem_dst.at[b, :, :, :, pl.ds(0, sz)],
+                vmem_dst.at[b, :, :, :, pl.ds(0, sz)],
+                sem,
+            ).wait()
+
+    def wait_out(
+        self,
+        dst_ref: tuple[jax.Ref, jax.Ref, schedule.RpaSchedule, jax.Ref],
+        grid_indices: tuple[int | jax.Array, ...],
+    ):
+        kv_out_ref, _, schedule_ref, page_indices_ref = dst_ref
+        slot = self.current_wait_out_slot
+        sem = self.sem_sends.at[slot]
+        block_idx = grid_indices[0]
+
+        for b in range(self.cfgs.batch_size):
+            do_writeback = schedule_ref.do_writeback[block_idx, b] == 1
+            total_pages_b = 0
+            for i in range(self.cfgs.bkv_p_new):
+                dma_entry = schedule_ref.dma_kv_new[block_idx, b, i]
+                dma_valid = dma_entry.wb_val
+                total_pages_b += jnp.where(do_writeback, dma_valid, 0)
+
+            sz = total_pages_b * self.cfgs.serve.page_size
+            sz = pl.multiple_of(sz, 128)
+            dma_entry_0 = schedule_ref.dma_kv_new[block_idx, b, 0]
+            dst_hbm_p = dma_entry_0.wb_hbm[...]
+            hbm_p_idx = page_indices_ref[dst_hbm_p]
+            pltpu.make_async_copy(
+                kv_out_ref.at[hbm_p_idx, :, :, :,
+                              pl.ds(0, sz)],
+                kv_out_ref.at[hbm_p_idx, :, :, :,
+                              pl.ds(0, sz)],
+                sem,
+            ).wait()
+
+
+@jax.tree_util.register_dataclass
+@dataclasses.dataclass(frozen=True)
+class KVBufferedRefHeadAlongSublane(_BypassRef):
+    """Handles fetching and updating KV cache using HEAD_ALONG_SUBLANE memory layout."""
+
+    cfgs: configs.RpaConfigs = dataclasses.field(default=None,
+                                                 metadata=dict(static=True))
+
+    @classmethod
+    def create(
+        cls,
+        spec: pl.BlockSpec,
+        dtype_or_type: jax.Array,
+        buffer_type: pltpu.BufferType,
         buffer_count: int,
         use_lookahead: bool,
         cfgs: configs.RpaConfigs,
@@ -79,9 +257,11 @@ class KVBufferedRef(_BypassRef):
         kv_cache_hbm, new_kv_hbm, schedule_ref, page_indices_ref = src_ref
         slot = self.current_copy_in_slot
         sem = self.sem_recvs.at[slot]
-        vmem_dst = self.window_ref.at[slot, :, :, :self.cfgs.kv_hbm_stride]
         block_idx = jnp.maximum(grid_indices[0], 0)
 
+        vmem_dst = self.window_ref.at[slot, :, :, :self.cfgs.kv_hbm_stride]
+        # kv_cache_hbm: (num_pages, num_kv_heads * 2, kv_head_dim // packing, packing, page_size)
+        # kv_cache_hbm_flat: (num_pages * num_kv_heads * 2, kv_head_dim // packing, packing, page_size)
         kv_cache_hbm_flat = kv_cache_hbm.reshape(-1, *kv_cache_hbm.shape[2:])
 
         dma_list_cache = []
@@ -95,12 +275,13 @@ class KVBufferedRef(_BypassRef):
                 dma_list_cache.append((src_off, dst_off, sz, b))
 
             # Contiguous fetch for new KV
-            _, src_new_off, dst_vmem_off, _ = schedule_ref.get_dma_kv_new(
-                block_idx, b, 0)
+            dma_entry_0 = schedule_ref.dma_kv_new[block_idx, b, 0]
+            src_new_off = dma_entry_0.fetch_hbm[...]
+            dst_vmem_off = dma_entry_0.fetch_vmem[...]
             total_new_sz = 0
             for i in range(self.cfgs.bkv_p_new):
-                _, _, _, sz = schedule_ref.get_dma_kv_new(block_idx, b, i)
-                total_new_sz += sz
+                dma_entry = schedule_ref.dma_kv_new[block_idx, b, i]
+                total_new_sz += dma_entry.fetch_val
             dma_list_new.append((src_new_off, dst_vmem_off, total_new_sz, b))
 
         for i in range(len(dma_list_cache)):
@@ -125,17 +306,20 @@ class KVBufferedRef(_BypassRef):
         grid_indices: tuple[int | jax.Array, ...],
     ):
         kv_out_ref, _, schedule_ref, page_indices_ref = dst_ref
-        kv_out_ref_flat = kv_out_ref.reshape(-1, *kv_out_ref.shape[2:])
         slot = self.current_copy_out_slot
         sem = self.sem_sends.at[slot]
-        vmem_src = self.window_ref.at[slot, :, :, :self.cfgs.kv_hbm_stride]
         block_idx = grid_indices[0]
+
+        kv_out_ref_flat = kv_out_ref.reshape(-1, *kv_out_ref.shape[2:])
+        vmem_src = self.window_ref.at[slot, :, :, :self.cfgs.kv_hbm_stride]
 
         for b in range(self.cfgs.batch_size):
             do_writeback = schedule_ref.do_writeback[block_idx, b] == 1
             for i in range(self.cfgs.bkv_p_new):
-                encoded_dst_hbm_off, _, src_vmem_off, new_sz = (
-                    schedule_ref.get_dma_kv_new(block_idx, b, i))
+                dma_entry = schedule_ref.dma_kv_new[block_idx, b, i]
+                encoded_dst_hbm_off = dma_entry.wb_hbm[...]
+                src_vmem_off = dma_entry.wb_vmem[...]
+                new_sz = dma_entry.wb_val
                 global_p_idx = encoded_dst_hbm_off >> self.cfgs.serve.page_size_log2
                 p_off = encoded_dst_hbm_off & self.cfgs.serve.page_size_mask
                 dst_hbm_off = (page_indices_ref[global_p_idx] <<
@@ -166,8 +350,8 @@ class KVBufferedRef(_BypassRef):
 
             # Contiguous wait for new KV
             for i in range(self.cfgs.bkv_p_new):
-                _, _, _, sz = schedule_ref.get_dma_kv_new(block_idx, b, i)
-                total_sz += sz
+                dma_entry = schedule_ref.dma_kv_new[block_idx, b, i]
+                total_sz += dma_entry.fetch_val
 
         # Flatten the first two dimensions (Batch, Seq) to create a 1D view.
         flat_vmem = vmem_dst.reshape((-1, *vmem_dst.shape[2:]))
@@ -182,7 +366,7 @@ class KVBufferedRef(_BypassRef):
         dst_ref: tuple[jax.Ref, jax.Ref, schedule.RpaSchedule, jax.Ref],
         grid_indices: tuple[int | jax.Array, ...],
     ):
-        kv_out_ref, _, schedule_ref, _ = dst_ref
+        kv_out_ref, _, schedule_ref, page_indices_ref = dst_ref
         slot = self.current_wait_out_slot
         sem = self.sem_sends.at[slot]
         block_idx = grid_indices[0]
@@ -191,7 +375,8 @@ class KVBufferedRef(_BypassRef):
         for b in range(self.cfgs.batch_size):
             do_writeback = schedule_ref.do_writeback[block_idx, b] == 1
             for i in range(self.cfgs.bkv_p_new):
-                _, _, _, new_sz = schedule_ref.get_dma_kv_new(block_idx, b, i)
+                dma_entry = schedule_ref.dma_kv_new[block_idx, b, i]
+                new_sz = dma_entry.wb_val
                 sz = jnp.where(do_writeback, new_sz, 0)
                 total_sz += sz
 

--- a/tpu_inference/kernels/experimental/batched_rpa/configs.py
+++ b/tpu_inference/kernels/experimental/batched_rpa/configs.py
@@ -51,6 +51,17 @@ class ModelConfigs:
         return self.num_q_heads // self.num_kv_heads
 
 
+class KVLayout(enum.StrEnum):
+    """Represents the different layouts for KV cache.
+
+  - HEAD_ALONG_SUBLANE: Number of heads on sublane, head_dim on lane.
+  - SEQ_ALONG_LANE: Sequence is packed along the lane, head_dim on sublane.
+  """
+
+    HEAD_ALONG_SUBLANE = enum.auto()
+    SEQ_ALONG_LANE = enum.auto()
+
+
 @dataclasses.dataclass(frozen=True)
 class ServingConfigs:
     """Serving config that can change depending on use cases."""
@@ -65,6 +76,7 @@ class ServingConfigs:
     scale_q: int | None = None
     scale_k: int | None = None
     scale_v: int | None = None
+    kv_layout: KVLayout = KVLayout.HEAD_ALONG_SUBLANE
 
     @property
     def pages_per_seq(self) -> int:
@@ -101,10 +113,10 @@ class ServingConfigs:
 class RpaCase(enum.StrEnum):
     """Represents the different cases for Ragged Paged Attention.
 
-    - DECODE: Sequences are in decode-only mode (q_len = 1).
-    - PREFILL: Sequences are in prefill-only mode (q_len > 1, static).
-    - MIXED: Sequences can be a mix of prefill and decode (q_len > 1, dynamic).
-    """
+  - DECODE: Sequences are in decode-only mode (q_len = 1).
+  - PREFILL: Sequences are in prefill-only mode (q_len > 1, static).
+  - MIXED: Sequences can be a mix of prefill and decode (q_len > 1, dynamic).
+  """
 
     DECODE = enum.auto()
     PREFILL = enum.auto()
@@ -170,7 +182,8 @@ class RpaConfigs:
         fixed_bytes = 0
         fixed_bytes += self.serve.num_seqs  # kv_lens
         fixed_bytes += self.serve.num_seqs + 1  # cu_q_lens
-        fixed_bytes += self.serve.num_seqs * self.serve.pages_per_seq  # page_indices
+        fixed_bytes += (self.serve.num_seqs * self.serve.pages_per_seq
+                        )  # page_indices
         fixed_bytes += 3  # distribution
         fixed_bytes += self.block.batch_size  # lane_lengths
         fixed_bytes += 1  # actual_steps
@@ -185,8 +198,9 @@ class RpaConfigs:
         # s_idx, q_idx, k_idx, is_last_k, do_writeback: 5 * 4 = 20
         # dma_q: 2 * 4 = 8
         # dma_kv_cache: bkv_p_cache * 3 * 4 = 12 * bkv_p_cache
-        # dma_kv_new: bkv_p_new * 4 * 4 = 16 * bkv_p_new
-        bytes_per_step = 28 + 12 * self.bkv_p_cache + 16 * self.bkv_p_new
+        # dma_kv_new: bkv_p_new * self.dma_kv_new_size * 4
+        bytes_per_step = (28 + 12 * self.bkv_p_cache +
+                          4 * self.dma_kv_new_size * self.bkv_p_new)
         bytes_per_step *= self.block.batch_size
 
         max_steps_ub = available_bytes // bytes_per_step
@@ -209,6 +223,8 @@ class RpaConfigs:
     def bkv_p_new(self) -> int:
         if self.mode == RpaCase.DECODE:
             return 1
+        if self.serve.kv_layout == KVLayout.SEQ_ALONG_LANE:
+            return self.bkv_p + 1
         return self.bkv_p
 
     @property
@@ -221,8 +237,18 @@ class RpaConfigs:
         return bkv_stride
 
     @property
-    def aligned_head_dim(self) -> int:
+    def aligned_q_head_dim(self) -> int:
         num_lanes = pltpu.get_tpu_info().num_lanes
+        return utils.align_to(self.model.head_dim, num_lanes)
+
+    @property
+    def aligned_kv_head_dim(self) -> int:
+        num_lanes = pltpu.get_tpu_info().num_lanes
+        num_sublanes = pltpu.get_tpu_info().num_sublanes
+        kv_packing = utils.get_dtype_packing(self.serve.dtype_kv)
+        if self.serve.kv_layout == KVLayout.SEQ_ALONG_LANE:
+            return utils.align_to(self.model.head_dim,
+                                  num_sublanes * kv_packing)
         return utils.align_to(self.model.head_dim, num_lanes)
 
     @property
@@ -237,6 +263,8 @@ class RpaConfigs:
 
     @property
     def kv_hbm_stride(self) -> int:
+        if self.serve.kv_layout == KVLayout.SEQ_ALONG_LANE:
+            return self.model.num_kv_heads * 2
         kv_packing = utils.get_dtype_packing(self.serve.dtype_kv)
         return utils.align_to(self.model.num_kv_heads * 2,
                               kv_packing) // kv_packing
@@ -247,7 +275,7 @@ class RpaConfigs:
 
     @property
     def q_vmem_shape(self):
-        q_per_kv_packing = (self.model.num_q_heads_per_kv_head //
+        q_per_kv_packing = (self.aligned_num_q_heads_per_kv_head //
                             self.serve.packing_q)
         return (
             self.block.batch_size,
@@ -255,18 +283,32 @@ class RpaConfigs:
             self.block.bq_sz,
             q_per_kv_packing,
             self.serve.packing_q,
-            self.model.head_dim,
+            self.aligned_q_head_dim,
         )
 
     @property
     def kv_vmem_shape(self):
+        if self.serve.kv_layout == KVLayout.SEQ_ALONG_LANE:
+            return (
+                self.block.batch_size,
+                self.model.num_kv_heads * 2,
+                self.aligned_kv_head_dim // self.serve.packing_kv,
+                self.serve.packing_kv,
+                self.block.bkv_sz + 2 * self.serve.page_size,
+            )
         return (
             self.block.batch_size,
             self.block.bkv_sz,
             self.bkv_stride,
             self.serve.packing_kv,
-            self.model.head_dim,
+            self.aligned_kv_head_dim,
         )
+
+    @property
+    def dma_kv_new_size(self) -> int:
+        if self.serve.kv_layout == KVLayout.SEQ_ALONG_LANE:
+            return 5
+        return 4
 
     @property
     def lm_scratch_shape(self):
@@ -274,7 +316,7 @@ class RpaConfigs:
         return (
             self.block.batch_size,
             self.model.num_kv_heads,
-            self.block.bq_sz * self.model.num_q_heads_per_kv_head,
+            self.block.bq_sz * self.aligned_num_q_heads_per_kv_head,
             num_lanes,
         )
 
@@ -283,8 +325,8 @@ class RpaConfigs:
         return (
             self.block.batch_size,
             self.model.num_kv_heads,
-            self.block.bq_sz * self.model.num_q_heads_per_kv_head,
-            self.model.head_dim,
+            self.block.bq_sz * self.aligned_num_q_heads_per_kv_head,
+            self.aligned_kv_head_dim,
         )
 
     def validate_inputs(
@@ -314,13 +356,26 @@ class RpaConfigs:
                 "Expected number of head dimensions in Q, K, and V to be the same,"
                 f" but got {q.shape[2]=}, {k.shape[2]=}, and {v.shape[2]=}")
 
-        expected_kv_cache_shape = (
-            kv_cache.shape[0],
-            self.serve.page_size,
-            self.aligned_num_kv_heads_x2 // self.serve.packing_kv,
-            self.serve.packing_kv,
-            self.aligned_head_dim,
-        )
+        if self.serve.kv_layout == KVLayout.SEQ_ALONG_LANE:
+            if self.serve.page_size != 128:
+                raise ValueError(
+                    "Expected page_size=128 for SEQ_ALONG_LANE tile alignment, but got"
+                    f" {self.serve.page_size=}")
+            expected_kv_cache_shape = (
+                kv_cache.shape[0],
+                self.model.num_kv_heads * 2,
+                self.aligned_kv_head_dim // self.serve.packing_kv,
+                self.serve.packing_kv,
+                self.serve.page_size,
+            )
+        else:
+            expected_kv_cache_shape = (
+                kv_cache.shape[0],
+                self.serve.page_size,
+                self.aligned_num_kv_heads_x2 // self.serve.packing_kv,
+                self.serve.packing_kv,
+                self.aligned_kv_head_dim,
+            )
 
         if kv_cache.shape != expected_kv_cache_shape:
             raise ValueError(f"Expected {kv_cache.shape=} to be equal to"

--- a/tpu_inference/kernels/experimental/batched_rpa/flash_attention.py
+++ b/tpu_inference/kernels/experimental/batched_rpa/flash_attention.py
@@ -21,7 +21,7 @@ from tpu_inference.kernels.experimental.batched_rpa import configs, utils
 
 def flash_attention_qk_softmax(
     q: jax.Array,  # [B, KV, TQ, H]
-    k: jax.Array,  # [B, KV, S, H]
+    k: jax.Array,  # [B, KV, S, H] or [B, KV, H, S]
     m_prev: jax.Array,  # [B, KV, TQ, 128]
     l_prev: jax.Array,  # [B, KV, TQ, 128]
     *,
@@ -33,7 +33,6 @@ def flash_attention_qk_softmax(
 ):
     """Flash attention kernel."""
     b, k_heads, tq, h_size = q.shape
-    s = k.shape[2]
 
     if cfgs.serve.scale_q is not None:
         q = q / cfgs.serve.scale_q
@@ -44,13 +43,23 @@ def flash_attention_qk_softmax(
             q = jnp.clip(q, min=minval, max=maxval)
         q = q.astype(k.dtype)
 
-    qk = lax.dot(
-        q.reshape(-1, tq, h_size),
-        k.reshape(-1, s, h_size),
-        dimension_numbers=(([2], [2]), ([0], [0])),
-        preferred_element_type=jnp.float32,
-    ).astype(cfgs.serve.dtype_out)
-    qk = qk.reshape(b, k_heads, tq, s)
+    if cfgs.serve.kv_layout == configs.KVLayout.SEQ_ALONG_LANE:
+        s = k.shape[-1]
+        qk = lax.dot(
+            q.reshape(-1, tq, h_size),
+            k.reshape(-1, h_size, s),
+            dimension_numbers=(([2], [1]), ([0], [0])),
+            preferred_element_type=jnp.float32,
+        )
+    else:
+        s = k.shape[-2]
+        qk = lax.dot(
+            q.reshape(b, tq, h_size),
+            k.reshape(b, s, h_size),
+            dimension_numbers=(([2], [2]), ([0], [0])),
+            preferred_element_type=jnp.float32,
+        )
+    qk = qk.astype(cfgs.serve.dtype_out).reshape(b, k_heads, tq, s)
 
     qk *= cfgs.model.sm_scale
     if cfgs.serve.scale_k is not None:
@@ -69,7 +78,7 @@ def flash_attention_qk_softmax(
         kv_idx_b = (lax.broadcasted_iota(int_ty, (k_heads, tq, s), 2) +
                     processed_kv_len[b_idx])
         q_idx_b = (lax.broadcasted_iota(jnp.int32, (k_heads, tq, s), 1) //
-                   cfgs.model.num_q_heads_per_kv_head +
+                   cfgs.aligned_num_q_heads_per_kv_head +
                    bq_start).astype(int_ty) + processed_q_len[b_idx]
 
         eff_kv_len_b = effective_kv_len[b_idx]
@@ -96,21 +105,31 @@ def flash_attention_qk_softmax(
 
 def flash_attention_pv(
     p: jax.Array,  # [B, KV, TQ, S]
-    v: jax.Array,  # [B, KV, S, H]
+    v: jax.Array,  # [B, KV, S, H] or [B, KV, H, S]
     alpha: jax.Array,  # [B, KV, TQ, 128]
     o_prev: jax.Array,  # [B, KV, TQ, H]
     cfgs: configs.RpaConfigs,
 ):
     """Flash attention kernel."""
     b, k_heads, tq, s = p.shape
-    h_size = v.shape[-1]
-    pv = lax.dot(
-        p.reshape(-1, tq, s),
-        v.reshape(-1, s, h_size),
-        dimension_numbers=(([2], [1]), ([0], [0])),
-        preferred_element_type=jnp.float32,
-    ).astype(cfgs.serve.dtype_out)
-    pv = pv.reshape(b, k_heads, tq, h_size)
+
+    if cfgs.serve.kv_layout == configs.KVLayout.SEQ_ALONG_LANE:
+        h_size = v.shape[-2]
+        pv = lax.dot(
+            p.reshape(-1, tq, s),
+            v.reshape(-1, h_size, s),
+            dimension_numbers=(([2], [2]), ([0], [0])),
+            preferred_element_type=jnp.float32,
+        )
+    else:
+        h_size = v.shape[-1]
+        pv = lax.dot(
+            p.reshape(-1, tq, s),
+            v.reshape(-1, s, h_size),
+            dimension_numbers=(([2], [1]), ([0], [0])),
+            preferred_element_type=jnp.float32,
+        )
+    pv = pv.astype(cfgs.serve.dtype_out).reshape(b, k_heads, tq, h_size)
 
     if cfgs.serve.scale_v is not None:
         pv *= cfgs.serve.scale_v

--- a/tpu_inference/kernels/experimental/batched_rpa/kernel.py
+++ b/tpu_inference/kernels/experimental/batched_rpa/kernel.py
@@ -348,7 +348,8 @@ def create_allocs(
     kv_cache_hbm_ref: jax.Ref, o_hbm_ref: jax.Ref, cfgs: configs.RpaConfigs
 ) -> tuple[
         bref_override.BatchingQRef,
-        bref_override.KVBufferedRef,
+        bref_override.KVBufferedRefSeqAlongLane
+        | bref_override.KVBufferedRefHeadAlongSublane,
         bref_override.BatchingORef,
 ]:
     kv_cache_spec = pl.BlockSpec(
@@ -435,31 +436,32 @@ def rpa_kernel(
 ) -> tuple[jax.Array, jax.Array]:
     """Perform batched ragged paged attention with scheduler data.
 
-  Args:
-    cu_q_lens: [max_num_seqs + 1]. Cumulative sum of each sequence's query
-      length. queries[a:b], keys[a:b], and values[a:b] where a=cu_q_lens[i] and
-      b=cu_q_lens[i+1] represents q/k/v of sequence i.
-    kv_lens: [max_num_seqs]. Existing kv cache length of each sequence.
-    page_indices: [max_num_seqs * pages_per_seqs]. kv cache page table of each
-      sequence.
-    schedule_hbm: Output of scheduler kernel. It informs which: 1. seqs 2. q
-      block 3. kv block that should be processed at a given step.
-    q_hbm: [max_num_tokens, num_q_heads_per_kv_heads, cdiv(num_kv_heads,
-      q_packing), q_packing, head_dim]. Output of q projection that has been
-      pre-processed to align with existing kv cache data layout.
-    new_kv_hbm: [max_num_tokens, cdiv(num_kv_heads * 2, kv_packing), kv_packing,
-      head_dim]. Output of k & v projection that has been pre-processed to align
-      with existing kv cache data layout.
-    kv_cache_hbm: [num_pages, page_size, cdiv(num_kv_heads * 2, kv_packing),
-      kv_packing, head_dim]. Stores existing kv cache data where k & vs are
-      concatenated along num kv heads dim.
-    cfgs: Configuration of the kernel.
+    Args:
+        cu_q_lens: [max_num_seqs + 1]. Cumulative sum of each sequence's query
+            length. queries[a:b], keys[a:b], and values[a:b] where a=cu_q_lens[i] and
+            b=cu_q_lens[i+1] represents q/k/v of sequence i.
+        kv_lens: [max_num_seqs]. Existing kv cache length of each sequence.
+        page_indices: [max_num_seqs * pages_per_seqs]. kv cache page table of each
+            sequence.
+        schedule_hbm: Output of scheduler kernel. It informs which: 1. seqs 2. q
+            block 3. kv block that should be processed at a given step.
+        q_hbm: [max_num_tokens, num_q_heads_per_kv_heads, cdiv(num_kv_heads,
+            q_packing), q_packing, head_dim]. Output of q projection that has been
+            pre-processed to align with existing kv cache data layout.
+        new_kv_hbm: [max_num_tokens, cdiv(num_kv_heads * 2, kv_packing), kv_packing,
+            head_dim]. Output of k & v projection that has been pre-processed to align
+            with existing kv cache data layout.
+        kv_cache_hbm: [num_pages, page_size, cdiv(num_kv_heads * 2, kv_packing),
+            kv_packing, head_dim]. Stores existing kv cache data where k & vs are
+            concatenated along num kv heads dim.
+        cfgs: Configuration of the kernel.
 
-  Returns:
-    out: [max_num_tokens, num_q_heads, head_dim]. Output of self attention.
-    new_kv_cache: [num_pages, page_size, num_kv_heads // kv_packing, kv_packing,
-      head_dim]. Result of new kv cache.
-  """
+    Returns:
+        out: [max_num_tokens, num_q_heads, head_dim]. Output of self attention.
+        new_kv_cache: [num_pages, page_size, num_kv_heads // kv_packing, kv_packing,
+            head_dim]. Result of new kv cache where k & vs are
+            concatenated along num kv heads dim.
+    """
 
     def ragged_paged_attention_pipeline(
         # Scalar prefetch.

--- a/tpu_inference/kernels/experimental/batched_rpa/kernel.py
+++ b/tpu_inference/kernels/experimental/batched_rpa/kernel.py
@@ -21,10 +21,15 @@ import jax.experimental.pallas.tpu as pltpu
 import jax.numpy as jnp
 from jax import lax
 
+# yapf: disable
 from tpu_inference.kernels.experimental.batched_rpa import (bref_override,
                                                             configs,
                                                             flash_attention,
-                                                            schedule, utils)
+                                                            schedule,
+                                                            stitch_utils,
+                                                            utils)
+
+# yapf: enable
 
 # Define inner kernel.
 
@@ -39,7 +44,7 @@ def strided_load_bkv(
     assert start % cfgs.serve.packing_kv == 0
     start //= cfgs.serve.packing_kv
     kv_u32_ref = kv_in_vref.at[b_idx].bitcast(jnp.uint32)
-    kv_ref = kv_u32_ref.reshape(-1, cfgs.model.head_dim)
+    kv_ref = kv_u32_ref.reshape(-1, cfgs.aligned_kv_head_dim)
 
     if cfgs.serve.packing_kv == 1:
         k = utils.strided_load(
@@ -90,7 +95,17 @@ def calculate_and_store_out(
         out = result.astype(cfgs.serve.dtype_out)
 
         o_u32_vref = o_vref.at[b_idx].bitcast(jnp.uint32)
-        out_ref = o_u32_vref.reshape(-1, cfgs.model.head_dim)
+        out_ref = o_u32_vref.reshape(-1, cfgs.aligned_q_head_dim)
+        if cfgs.aligned_q_head_dim != cfgs.aligned_kv_head_dim:
+            out = jnp.pad(
+                out,
+                (
+                    (0, 0),
+                    (0, 0),
+                    (0, cfgs.aligned_q_head_dim - cfgs.aligned_kv_head_dim),
+                ),
+                constant_values=0,
+            )
         out = pltpu.bitcast(out, out_ref.dtype).reshape(out_ref.shape)
         utils.strided_store(out_ref, 0, out_ref.shape[0], 1, out)
 
@@ -132,6 +147,9 @@ def rpa_body(
     processed_q_len = []
     processed_kv_len = []
     effective_kv_len = []
+    # Lists to hold the 2 variables needed for stitching
+    bkv_sz_frm_cache_list = []
+    new_kv_len_start_list = []
     int_ty = cfgs.serve.int_ty
     for b_idx in range(cfgs.batch_size):
         s_idx = schedule_ref.s_idx[step, b_idx]
@@ -154,6 +172,17 @@ def rpa_body(
         processed_kv_len.append(k_id.astype(int_ty))
         effective_kv_len.append(kv_len.astype(int_ty))
 
+        # Stitching metadata
+        kv_left = jnp.maximum(kv_len - k_id, 0)
+        kv_left_frm_cache = jnp.maximum(kv_left - q_len, 0)
+        kv_left_frm_new = jnp.maximum(kv_left - kv_left_frm_cache, 0)
+
+        bkv_sz_frm_cache = jnp.minimum(kv_left_frm_cache, cfgs.bkv_sz)
+        new_kv_len_start = q_end - kv_left_frm_new
+
+        bkv_sz_frm_cache_list.append(bkv_sz_frm_cache.astype(int_ty))
+        new_kv_len_start_list.append(new_kv_len_start.astype(int_ty))
+
         start_k_idx = 0
         if (sliding_window := cfgs.model.sliding_window) is not None:
             sw_start_idx = kv_len - q_len + q_idx * cfgs.bq_sz - sliding_window + 1
@@ -169,7 +198,7 @@ def rpa_body(
 
     # Step 2: Fetch inputs.
     q_p = cfgs.aligned_num_q_heads_per_kv_head // cfgs.serve.packing_q
-    q_ref = q_vref.bitcast(jnp.uint32).reshape(-1, cfgs.model.head_dim)
+    q_ref = q_vref.bitcast(jnp.uint32).reshape(-1, cfgs.aligned_q_head_dim)
     q_loaded = utils.strided_load(
         q_ref,
         0,
@@ -181,8 +210,10 @@ def rpa_body(
         cfgs.batch_size,
         cfgs.model.num_kv_heads,
         cfgs.bq_sz * cfgs.aligned_num_q_heads_per_kv_head,
-        cfgs.model.head_dim,
+        cfgs.aligned_q_head_dim,
     )
+    if cfgs.aligned_q_head_dim != cfgs.aligned_kv_head_dim:
+        q = q[..., :cfgs.aligned_kv_head_dim]
 
     # We want to load k, v from (batch, bkv_sz, bkv_stride, kv_packing, d)
     # where bkv_stride ~= num_kv_heads * 2 // kv_packing
@@ -190,27 +221,61 @@ def rpa_body(
     # We use strided_load to avoid the expensive transpose.
     k_b = []
     v_b = []
-    for b_idx in range(cfgs.batch_size):
-        heads_per_load = pl.cdiv(cfgs.serve.packing_kv, 2)
-        ks = []
-        vs = []
-        for kv_head_start in range(0, cfgs.model.num_kv_heads, heads_per_load):
-            bkv_lst = strided_load_bkv(
+
+    if cfgs.serve.kv_layout == configs.KVLayout.SEQ_ALONG_LANE:
+        stitch_results = []
+        for b_idx in range(cfgs.batch_size):
+            res = stitch_utils.stitch_new_kv_lane(
                 kv_in_vref,
                 b_idx,
-                kv_head_start * 2,
+                bkv_sz_frm_cache_list[b_idx],
+                new_kv_len_start_list[b_idx],
                 cfgs=cfgs,
             )
-            ks.append(jnp.stack([k for k, _ in bkv_lst], axis=0))
-            vs.append(jnp.stack([v for _, v in bkv_lst], axis=0))
-        k, v = jnp.concat(ks, axis=0), jnp.concat(vs, axis=0)
-        k = k.reshape(-1, cfgs.bkv_sz, cfgs.model.head_dim)
-        v = v.reshape(-1, cfgs.bkv_sz, cfgs.model.head_dim)
+            stitch_results.append(res)
+        for b_idx in range(cfgs.batch_size):
+            stitch_utils.store_new_kv_lane(
+                kv_in_vref,
+                b_idx,
+                stitch_results[b_idx],
+                cfgs=cfgs,
+            )
+        for b_idx in range(cfgs.batch_size):
+            ks = []
+            vs = []
+            for kv_head in range(cfgs.model.num_kv_heads):
+                k_head = kv_in_vref[b_idx, kv_head * 2, :, :, 0:cfgs.bkv_sz]
+                v_head = kv_in_vref[b_idx, kv_head * 2 + 1, :, :,
+                                    0:cfgs.bkv_sz]
+                ks.append(k_head.reshape(cfgs.aligned_kv_head_dim,
+                                         cfgs.bkv_sz))
+                vs.append(v_head.reshape(cfgs.aligned_kv_head_dim,
+                                         cfgs.bkv_sz))
+            k_b.append(jnp.stack(ks, axis=0))
+            v_b.append(jnp.stack(vs, axis=0))
+    else:
+        for b_idx in range(cfgs.batch_size):
+            heads_per_load = pl.cdiv(cfgs.serve.packing_kv, 2)
+            ks = []
+            vs = []
+            for kv_head_start in range(0, cfgs.model.num_kv_heads,
+                                       heads_per_load):
+                bkv_lst = strided_load_bkv(
+                    kv_in_vref,
+                    b_idx,
+                    kv_head_start * 2,
+                    cfgs=cfgs,
+                )
+                ks.append(jnp.stack([k for k, _ in bkv_lst], axis=0))
+                vs.append(jnp.stack([v for _, v in bkv_lst], axis=0))
+            k, v = jnp.concat(ks, axis=0), jnp.concat(vs, axis=0)
+            k = k.reshape(-1, cfgs.bkv_sz, cfgs.aligned_kv_head_dim)
+            v = v.reshape(-1, cfgs.bkv_sz, cfgs.aligned_kv_head_dim)
 
-        k = k[:cfgs.model.num_kv_heads]
-        v = v[:cfgs.model.num_kv_heads]
-        k_b.append(k)
-        v_b.append(v)
+            k = k[:cfgs.model.num_kv_heads]
+            v = v[:cfgs.model.num_kv_heads]
+            k_b.append(k)
+            v_b.append(v)
     # Stack to (batch, num_heads, bkv_sz, num_lanes)
     k = jnp.stack(k_b, axis=0)
     v = jnp.stack(v_b, axis=0)
@@ -223,8 +288,8 @@ def rpa_body(
     prev_p = prev_alpha = prev_q_slice = None
     for bq_start in range(0, cfgs.bq_sz, cfgs.bq_c_sz):
         bq_end = min(bq_start + cfgs.bq_c_sz, cfgs.bq_sz)
-        q_start = bq_start * cfgs.model.num_q_heads_per_kv_head
-        q_end = bq_end * cfgs.model.num_q_heads_per_kv_head
+        q_start = bq_start * cfgs.aligned_num_q_heads_per_kv_head
+        q_end = bq_end * cfgs.aligned_num_q_heads_per_kv_head
         q_slice = slice(q_start, q_end)
 
         p, alpha, m_next, l_next = flash_attention.flash_attention_qk_softmax(
@@ -307,7 +372,12 @@ def create_allocs(
         pipeline_mode=pl.Buffered(buffer_count=2, use_lookahead=False),
     )
 
-    kv_cache_alloc = bref_override.KVBufferedRef.input_output(
+    if cfgs.serve.kv_layout == configs.KVLayout.SEQ_ALONG_LANE:
+        kv_cache_alloc_cls = bref_override.KVBufferedRefSeqAlongLane
+    else:
+        kv_cache_alloc_cls = bref_override.KVBufferedRefHeadAlongSublane
+
+    kv_cache_alloc = kv_cache_alloc_cls.input_output(
         spec=kv_cache_spec,
         dtype_or_type=kv_cache_hbm_ref,
         buffer_count=cfgs.n_buffer,
@@ -365,31 +435,31 @@ def rpa_kernel(
 ) -> tuple[jax.Array, jax.Array]:
     """Perform batched ragged paged attention with scheduler data.
 
-    Args:
-        cu_q_lens: [max_num_seqs + 1]. Cumulative sum of each sequence's query
-            length. queries[a:b], keys[a:b], and values[a:b] where a=cu_q_lens[i] and
-            b=cu_q_lens[i+1] represents q/k/v of sequence i.
-        kv_lens: [max_num_seqs]. Existing kv cache length of each sequence.
-        page_indices: [max_num_seqs * pages_per_seqs]. kv cache page table of each
-            sequence.
-        schedule: Output of scheduler kernel. It informs which: 1. seqs 2. q block
-            3. kv block that should be processed at a given step.
-        q_hbm: [max_num_tokens, num_q_heads_per_kv_heads, cdiv(num_kv_heads,
-            q_packing), q_packing, head_dim]. Output of q projection that has been
-            pre-processed to align with existing kv cache data layout.
-        new_kv_hbm: [max_num_tokens, cdiv(num_kv_heads * 2, kv_packing), kv_packing,
-            head_dim]. Output of k & v projection that has been pre-processed to align
-            with existing kv cache data layout.
-        kv_cache_hbm: [num_pages, page_size, cdiv(num_kv_heads * 2, kv_packing),
-            kv_packing, head_dim]. Stores existing kv cache data where k & vs are
-            concatenated along num kv heads dim.
-        cfgs: Configuration of the kernel.
+  Args:
+    cu_q_lens: [max_num_seqs + 1]. Cumulative sum of each sequence's query
+      length. queries[a:b], keys[a:b], and values[a:b] where a=cu_q_lens[i] and
+      b=cu_q_lens[i+1] represents q/k/v of sequence i.
+    kv_lens: [max_num_seqs]. Existing kv cache length of each sequence.
+    page_indices: [max_num_seqs * pages_per_seqs]. kv cache page table of each
+      sequence.
+    schedule_hbm: Output of scheduler kernel. It informs which: 1. seqs 2. q
+      block 3. kv block that should be processed at a given step.
+    q_hbm: [max_num_tokens, num_q_heads_per_kv_heads, cdiv(num_kv_heads,
+      q_packing), q_packing, head_dim]. Output of q projection that has been
+      pre-processed to align with existing kv cache data layout.
+    new_kv_hbm: [max_num_tokens, cdiv(num_kv_heads * 2, kv_packing), kv_packing,
+      head_dim]. Output of k & v projection that has been pre-processed to align
+      with existing kv cache data layout.
+    kv_cache_hbm: [num_pages, page_size, cdiv(num_kv_heads * 2, kv_packing),
+      kv_packing, head_dim]. Stores existing kv cache data where k & vs are
+      concatenated along num kv heads dim.
+    cfgs: Configuration of the kernel.
 
-    Returns:
-        out: [max_num_tokens, num_q_heads, head_dim]. Output of self attention.
-        new_kv_cache: [num_pages, page_size, num_kv_heads // kv_packing, kv_packing,
-            head_dim]. Result of new kv cache.
-    """
+  Returns:
+    out: [max_num_tokens, num_q_heads, head_dim]. Output of self attention.
+    new_kv_cache: [num_pages, page_size, num_kv_heads // kv_packing, kv_packing,
+      head_dim]. Result of new kv cache.
+  """
 
     def ragged_paged_attention_pipeline(
         # Scalar prefetch.

--- a/tpu_inference/kernels/experimental/batched_rpa/schedule.py
+++ b/tpu_inference/kernels/experimental/batched_rpa/schedule.py
@@ -25,6 +25,82 @@ from jax.experimental.pallas import tpu as pltpu
 from tpu_inference.kernels.experimental.batched_rpa import configs, utils
 
 
+class FieldOffset:
+    """A Python descriptor that generates the `.at[pos + offset]` lazy lookup.
+
+  This is necessary because JAX does not support dynamically slicing a 
+  range (e.g. `data.at[pos:pos+4]`) using traced indices inside a loop,
+  but it natively supports retrieving/updating single dynamically-indexed 
+  elements (e.g. `data.at[pos+1]`).
+  """
+
+    def __init__(self, offset: int):
+        self.offset = offset
+
+    def __get__(self, obj, objtype=None):
+        return obj.data.at[obj.pos + self.offset]
+
+
+@jax.tree_util.register_dataclass
+@dataclasses.dataclass(frozen=True)
+class SeqAlongLaneDmaNew:
+    data: Any
+    pos: Any
+
+    # HBM address to fetch new KV tokens from
+    fetch_hbm = FieldOffset(0)
+    # VMEM offset within the block where new tokens are placed
+    fetch_vmem = FieldOffset(1)
+    # HBM address to write the updated KV cache block back to
+    wb_hbm = FieldOffset(2)
+    # VMEM offset of the cache block to write back
+    wb_vmem = FieldOffset(3)
+    # Bitpacked: Flags for whether to fetch or write back new tokens.
+    flags = FieldOffset(4)
+
+    @property
+    def fetch_val(self):
+        return self.flags[...] & 1
+
+    @property
+    def wb_val(self):
+        return (self.flags[...] >> 1) & 1
+
+    def set_flags(self, fetch_val, wb_val):
+        self.flags[...] = fetch_val | (wb_val << 1)
+
+
+@jax.tree_util.register_dataclass
+@dataclasses.dataclass(frozen=True)
+class HeadAlongSublaneDmaNew:
+    data: Any
+    pos: Any
+
+    # HBM address to write the updated KV cache block back to
+    wb_hbm = FieldOffset(0)
+    # HBM address to fetch new KV tokens from
+    fetch_hbm = FieldOffset(1)
+    # VMEM offset within the block where new tokens are placed
+    fetch_vmem = FieldOffset(2)
+    # Fetch and writeback are the same flag here.
+    _flags = FieldOffset(3)
+
+    @property
+    def fetch_val(self):
+        return self._flags[...]
+
+    @property
+    def wb_val(self):
+        return self._flags[...]
+
+    @property
+    def wb_vmem(self):
+        return self.fetch_vmem
+
+    def set_flags(self, fetch_val, wb_val):
+        self._flags[...] = fetch_val
+
+
 @jax.tree_util.register_dataclass
 @dataclasses.dataclass(frozen=True)
 class SmemWrapper:
@@ -56,6 +132,38 @@ class SmemWrapper:
 
 @jax.tree_util.register_dataclass
 @dataclasses.dataclass(frozen=True)
+class SmemArrayOfStructs(SmemWrapper):
+    """Maps physical 1-D data into logical Array of Structs."""
+
+    struct_cls: type = dataclasses.field(metadata=dict(static=True))
+    struct_size: int = dataclasses.field(metadata=dict(static=True))
+
+    @classmethod
+    def create_shape_dtype(cls, shape, struct_cls, struct_size):
+        return cls(
+            data=jax.ShapeDtypeStruct((np.prod(shape) * struct_size, ),
+                                      jnp.int32),
+            shape=shape,
+            struct_cls=struct_cls,
+            struct_size=struct_size,
+        )
+
+    def _get_pos(self, indices):
+        strides = pl.strides_from_shape(self.shape)
+        assert len(strides) == len(indices)
+
+        pos = 0
+        for stride, idx in zip(strides, indices):
+            pos += stride * idx
+        return pos * self.struct_size
+
+    def __getitem__(self, indices):
+        pos_start = self._get_pos(indices)
+        return self.struct_cls(self.data, pos_start)
+
+
+@jax.tree_util.register_dataclass
+@dataclasses.dataclass(frozen=True)
 class RpaSchedule:
     """Container for metadata arrays with integrated shape/spec logic."""
 
@@ -66,7 +174,7 @@ class RpaSchedule:
     do_writeback: SmemWrapper  # [steps, batch]
     dma_q: SmemWrapper  # [steps, batch, 2]
     dma_kv_cache: SmemWrapper  # [steps, batch, bkv_p_cache, 3]
-    dma_kv_new: SmemWrapper  # [steps, batch, bkv_p_new, 4]
+    dma_kv_new: SmemArrayOfStructs  # [steps, batch, bkv_p_new]
     actual_steps: Any  # [1]
 
     cfgs: configs.RpaConfigs = dataclasses.field(metadata=dict(static=True))
@@ -87,8 +195,17 @@ class RpaSchedule:
                 (cfgs.max_steps_ub, cfgs.batch_size, 2)),
             dma_kv_cache=SmemWrapper.create_shape_dtype(
                 (cfgs.max_steps_ub, cfgs.batch_size, cfgs.bkv_p_cache, 3)),
-            dma_kv_new=SmemWrapper.create_shape_dtype(
-                (cfgs.max_steps_ub, cfgs.batch_size, cfgs.bkv_p_new, 4), ),
+            dma_kv_new=SmemArrayOfStructs.create_shape_dtype(
+                (
+                    cfgs.max_steps_ub,
+                    cfgs.batch_size,
+                    cfgs.bkv_p_new,
+                ),
+                struct_cls=(SeqAlongLaneDmaNew if cfgs.serve.kv_layout
+                            == configs.KVLayout.SEQ_ALONG_LANE else
+                            HeadAlongSublaneDmaNew),
+                struct_size=cfgs.dma_kv_new_size,
+            ),
             actual_steps=jax.ShapeDtypeStruct((1, ), jnp.int32),
             cfgs=cfgs,
         )
@@ -104,19 +221,6 @@ class RpaSchedule:
         dst_off = self.dma_kv_cache[step, batch_idx, page_idx, 1]
         sz = self.dma_kv_cache[step, batch_idx, page_idx, 2]
         return src_off, dst_off, sz
-
-    def get_dma_kv_new(
-        self,
-        step: jax.typing.ArrayLike,
-        batch_idx: jax.typing.ArrayLike,
-        page_idx: jax.typing.ArrayLike,
-    ) -> tuple[jax.Array, jax.Array, jax.Array, jax.Array]:
-        # 0: dst_hbm, 1: src_hbm, 2: dst_vmem, 3: size
-        dst_hbm = self.dma_kv_new[step, batch_idx, page_idx, 0]
-        src_hbm = self.dma_kv_new[step, batch_idx, page_idx, 1]
-        dst_vmem = self.dma_kv_new[step, batch_idx, page_idx, 2]
-        sz = self.dma_kv_new[step, batch_idx, page_idx, 3]
-        return dst_hbm, src_hbm, dst_vmem, sz
 
     def get_dma_q(
             self, step: jax.typing.ArrayLike,
@@ -225,9 +329,15 @@ def compute_metadata(
             src_hbm = jnp.minimum(p_offset + i,
                                   cfgs.serve.num_page_indices - 1)
 
-            schedule.dma_kv_cache[step, target_lane, i, 0] = src_hbm
-            schedule.dma_kv_cache[step, target_lane, i, 1] = dst_vmem
-            schedule.dma_kv_cache[step, target_lane, i, 2] = dma_sz
+            if cfgs.serve.kv_layout == configs.KVLayout.SEQ_ALONG_LANE:
+                dma_valid = jnp.where(dma_sz > 0, 1, 0)
+                schedule.dma_kv_cache[step, target_lane, i, 0] = src_hbm
+                schedule.dma_kv_cache[step, target_lane, i, 1] = dst_vmem
+                schedule.dma_kv_cache[step, target_lane, i, 2] = dma_valid
+            else:
+                schedule.dma_kv_cache[step, target_lane, i, 0] = src_hbm
+                schedule.dma_kv_cache[step, target_lane, i, 1] = dst_vmem
+                schedule.dma_kv_cache[step, target_lane, i, 2] = dma_sz
 
         kv_left_frm_new = kv_left - kv_left_frm_cache
         bkv_sz_cache = jnp.minimum(kv_left_frm_cache, cfgs.bkv_sz)
@@ -241,41 +351,71 @@ def compute_metadata(
         schedule.do_writeback[step, target_lane] = do_writeback
         src_hbm = q_end - kv_left_frm_new
 
+        def fill_dma_kv_new(i, dst_vmem, dma_sz, slot_start):
+            dma_entry = schedule.dma_kv_new[step, target_lane, i]
+            if cfgs.serve.kv_layout == configs.KVLayout.SEQ_ALONG_LANE:
+                cache_pages = pl.cdiv(bkv_sz_cache, cfgs.serve.page_size)
+                hbm_token_idx_base = q_end - kv_left_frm_new
+                new_tok_offset = hbm_token_idx_base % cfgs.serve.page_size
+                # If new_sz = 150, new_tok_offset = 120, page_size = 128.
+                # The new tokens occupy indices 120 through 269 relative to the HBM page boundaries.
+                # This spans 3 pages: [120-127], [128-255], and [256-269].
+                # (120 + 150 - 1) // 128 + 1 = 269 // 128 + 1 = 3 pages.
+                num_pages_to_fetch = jnp.where(
+                    new_sz > 0,
+                    (new_tok_offset + new_sz - 1) // cfgs.serve.page_size + 1,
+                    0,
+                )
+                fetch_val = jnp.where(i < num_pages_to_fetch, 1, 0)
+                new_page_start = (hbm_token_idx_base -
+                                  new_tok_offset) + i * cfgs.serve.page_size
+                # Fetched pages of new tokens are placed sequentially in VMEM immediately following
+                # the existing cached pages. E.g., if cache_pages=2, new pages go to offsets 2*page_size,
+                # 3*page_size, etc.
+                fetch_vmem = (cache_pages + i) * cfgs.serve.page_size
+                p_idx = jnp.minimum(
+                    (kv_len_start + slot_start) >> cfgs.serve.page_size_log2,
+                    cfgs.serve.pages_per_seq - 1,
+                )
+                dst_hbm = s_idx * cfgs.serve.pages_per_seq + p_idx
+                wb_val = jnp.where(dma_sz > 0, 1, 0)
+
+                dma_entry.fetch_hbm[...] = new_page_start
+                dma_entry.fetch_vmem[...] = fetch_vmem
+                dma_entry.wb_hbm[...] = dst_hbm
+                dma_entry.wb_vmem[...] = slot_start
+                dma_entry.set_flags(fetch_val, wb_val)
+            else:
+                p_idx = jnp.minimum(
+                    (kv_len_start + dst_vmem) >> cfgs.serve.page_size_log2,
+                    cfgs.serve.pages_per_seq - 1,
+                )
+                p_off = (kv_len_start + dst_vmem) & cfgs.serve.page_size_mask
+                dst_hbm = ((s_idx * cfgs.serve.pages_per_seq + p_idx) <<
+                           cfgs.serve.page_size_log2) | p_off
+
+                dma_entry.fetch_hbm[...] = src_hbm
+                dma_entry.fetch_vmem[...] = dst_vmem
+                dma_entry.wb_hbm[...] = dst_hbm
+                dma_entry.set_flags(dma_sz, dma_sz)
+
         if cfgs.bkv_p_new < cfgs.bkv_p:
-            # Special case where we only need to write back one page.
+            # Decode path
             assert cfgs.bkv_p_new == 1
-            dst_vmem = bkv_sz_cache
-            dma_sz = new_sz
-
-            p_idx = (kv_len_start + dst_vmem) >> cfgs.serve.page_size_log2
-            p_idx = jnp.minimum(p_idx, cfgs.serve.pages_per_seq - 1)
-            p_off = (kv_len_start + dst_vmem) & cfgs.serve.page_size_mask
-            global_p_idx = s_idx * cfgs.serve.pages_per_seq + p_idx
-
-            dst_hbm = (global_p_idx << cfgs.serve.page_size_log2) | p_off
-            schedule.dma_kv_new[step, target_lane, 0, 0] = dst_hbm
-            schedule.dma_kv_new[step, target_lane, 0, 1] = src_hbm
-            schedule.dma_kv_new[step, target_lane, 0, 2] = dst_vmem
-            schedule.dma_kv_new[step, target_lane, 0, 3] = dma_sz
+            slot_start = (bkv_sz_cache //
+                          cfgs.serve.page_size) * cfgs.serve.page_size
+            fill_dma_kv_new(0, bkv_sz_cache, new_sz, slot_start)
         else:
-            for i in range(cfgs.bkv_p):
-                slot_start = i << cfgs.serve.page_size_log2
-                slot_end = (i + 1) << cfgs.serve.page_size_log2
+            iters = max(cfgs.bkv_p, cfgs.bkv_p_new)
+            for i in range(iters):
+                slot_start = i * cfgs.serve.page_size
+                slot_end = slot_start + cfgs.serve.page_size
 
                 dst_vmem = jnp.maximum(slot_start, bkv_sz_cache)
                 end_in_slot = jnp.minimum(slot_end, bkv_sz_cache + new_sz)
                 dma_sz = jnp.maximum(0, end_in_slot - dst_vmem)
 
-                p_idx = (kv_len_start + dst_vmem) >> cfgs.serve.page_size_log2
-                p_idx = jnp.minimum(p_idx, cfgs.serve.pages_per_seq - 1)
-                p_off = (kv_len_start + dst_vmem) & cfgs.serve.page_size_mask
-                global_p_idx = s_idx * cfgs.serve.pages_per_seq + p_idx
-
-                dst_hbm = (global_p_idx << cfgs.serve.page_size_log2) | p_off
-                schedule.dma_kv_new[step, target_lane, i, 0] = dst_hbm
-                schedule.dma_kv_new[step, target_lane, i, 1] = src_hbm
-                schedule.dma_kv_new[step, target_lane, i, 2] = dst_vmem
-                schedule.dma_kv_new[step, target_lane, i, 3] = dma_sz
+                fill_dma_kv_new(i, dst_vmem, dma_sz, slot_start)
 
         return step + 1
 
@@ -359,32 +499,32 @@ def rpa_metadata_schedule_kernel(
 ):
     """Generates the HBM-to-VMEM DMA schedule.
 
-    This kernel:
-    1. Iterates through each (potentially ragged) sequence
-    2. Breaks Queries (Q) and Key-Values (KV) into blocks (bq_sz, bkv_sz).
-    3. Assigns tasks to 'lanes' (TPU batch items) based on current lane occupancy
-        to ensure balanced execution across the batch dimension.
-    4. Encodes DMA offsets:
-        - dma_q: HBM start index and size for Query blocks.
-        - dma_kv_cache: Paged indices for existing KV tokens.
-        - dma_kv_new: offsets for new tokens being added to the cache.
-        - do_writeback: boolean flag indicating if a block should be flushed to
-        HBM (ie does this block contain new tokens to add to KV cache).
+  This kernel:
+  1. Iterates through each (potentially ragged) sequence
+  2. Breaks Queries (Q) and Key-Values (KV) into blocks (bq_sz, bkv_sz).
+  3. Assigns tasks to 'lanes' (TPU batch items) based on current lane occupancy
+    to ensure balanced execution across the batch dimension.
+  4. Encodes DMA offsets:
+    - dma_q: HBM start index and size for Query blocks.
+    - dma_kv_cache: Paged indices for existing KV tokens.
+    - dma_kv_new: offsets for new tokens being added to the cache.
+    - do_writeback: boolean flag indicating if a block should be flushed to
+      HBM (ie does this block contain new tokens to add to KV cache).
 
-    Args:
-        cu_q_lens_ref: [max_num_seqs + 1]. Cumulative sum of each sequence's query
-            length. queries[a:b], keys[a:b], and values[a:b] where a=cu_q_lens[i] and
-            b=cu_q_lens[i+1] represents q/k/v of sequence i.
-        kv_lens_ref: [max_num_seqs]. Existing kv cache length of each sequence.
-            distribution_ref: [3]. Cumulative sum of number of decode, prefill, and
-            mixed
-        schedule_hbm_ref: HBM memory that will store output of the kernel.
-        schedule_ref: Scratch memory where schedule results gets written.
-        lane_lengths_ref: Scratch memory that keeps track of number of steps for
-            each batch lane.
-        dma_sem: Semaphore used for writing scheduler output to HBM.
-        cfgs: Configuration of the kernel.
-    """
+  Args:
+    cu_q_lens_ref: [max_num_seqs + 1]. Cumulative sum of each sequence's query
+      length. queries[a:b], keys[a:b], and values[a:b] where a=cu_q_lens[i] and
+      b=cu_q_lens[i+1] represents q/k/v of sequence i.
+    kv_lens_ref: [max_num_seqs]. Existing kv cache length of each sequence.
+    distribution_ref: [3]. Cumulative sum of number of decode, prefill, and
+      mixed
+    schedule_hbm_ref: HBM memory that will store output of the kernel.
+    schedule_ref: Scratch memory where schedule results gets written.
+    lane_lengths_ref: Scratch memory that keeps track of number of steps for
+      each batch lane.
+    dma_sem: Semaphore used for writing scheduler output to HBM.
+    cfgs: Configuration of the kernel.
+  """
 
     for b_idx in range(cfgs.batch_size):
         lane_lengths_ref[b_idx] = 0
@@ -404,6 +544,12 @@ def rpa_metadata_schedule_kernel(
     max_steps = 0
     for b_idx in range(cfgs.batch_size):
         max_steps = jnp.maximum(max_steps, lane_lengths_ref[b_idx])
+
+    pl.debug_check(
+        max_steps <= cfgs.max_steps_ub,
+        f"Max steps exceeded SMEM capacity limit! {max_steps} vs"
+        f" {cfgs.max_steps_ub}",
+    )
     schedule_ref.actual_steps[0] = max_steps
 
     safe_max_steps = jnp.minimum(max_steps + cfgs.n_buffer + 1,
@@ -427,10 +573,15 @@ def rpa_metadata_schedule_kernel(
             schedule_ref.dma_kv_cache[step, b_idx, i, 2] = 0
 
         for i in range(cfgs.bkv_p_new):
-            schedule_ref.dma_kv_new[step, b_idx, i, 0] = 0
-            schedule_ref.dma_kv_new[step, b_idx, i, 1] = 0
-            schedule_ref.dma_kv_new[step, b_idx, i, 2] = 0
-            schedule_ref.dma_kv_new[step, b_idx, i, 3] = 0
+            dma_entry = schedule_ref.dma_kv_new[step, b_idx, i]
+            dma_entry.fetch_hbm[...] = 0
+            dma_entry.fetch_vmem[...] = 0
+            dma_entry.wb_hbm[...] = 0
+            if cfgs.serve.kv_layout == configs.KVLayout.SEQ_ALONG_LANE:
+                dma_entry.wb_vmem[...] = 0
+                dma_entry.flags[...] = 0
+            else:
+                dma_entry.set_flags(0, 0)
 
     for b_idx in range(cfgs.batch_size):
         start_step = lane_lengths_ref[b_idx]

--- a/tpu_inference/kernels/experimental/batched_rpa/stitch_utils.py
+++ b/tpu_inference/kernels/experimental/batched_rpa/stitch_utils.py
@@ -125,9 +125,9 @@ def stitch_new_kv_lane(
 ):
     """Fetches and computes stitched KV tokens (separated to avoid RAW hazards).
 
-  Expects vmem_ref shape: [batch, 2*kv, head_dim / packing, packing, bkv_sz + 2
-  * page_size]
-  """
+    Expects vmem_ref shape: [batch, 2*kv, head_dim / packing, packing, bkv_sz + 2
+    * page_size]
+    """
     bkv_sz_cache = bkv_sz_frm_cache.astype(jnp.int32)
     new_tok_offset = (new_kv_len_start.astype(jnp.int32) %
                       cfgs.serve.page_size)

--- a/tpu_inference/kernels/experimental/batched_rpa/stitch_utils.py
+++ b/tpu_inference/kernels/experimental/batched_rpa/stitch_utils.py
@@ -1,0 +1,152 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import jax
+import jax.numpy as jnp
+from jax.experimental import pallas as pl
+from jax.experimental.pallas import tpu as pltpu
+
+from tpu_inference.kernels.experimental.batched_rpa import configs
+
+
+def _stitch_decode_lane(
+    vmem_u32_ref: jax.Array,
+    bkv_sz_cache: jax.Array,
+    cache_pages: jax.Array,
+    new_tok_offset: jax.Array,
+    v_len: int,
+):
+    """O(1) Decode Path: Target exactly the VREG containing the stitch boundary."""
+    num_lanes = pltpu.get_tpu_info().num_lanes
+    lanes_per_col = v_len // num_lanes
+    strided_vmem_ref = vmem_u32_ref.reshape(-1, num_lanes)
+    outer_dim = strided_vmem_ref.shape[0] // lanes_per_col
+
+    dst_chunk_idx = bkv_sz_cache // num_lanes
+
+    # Load just the destination and source chunks.
+    dst_vreg = strided_vmem_ref[pl.ds(dst_chunk_idx, outer_dim, lanes_per_col)]
+    src_vreg = strided_vmem_ref[pl.ds(cache_pages, outer_dim, lanes_per_col)]
+
+    dst_rel = bkv_sz_cache % num_lanes
+    rolled_src_vreg = pltpu.roll(src_vreg, dst_rel - new_tok_offset, axis=1)
+
+    lane_idx = jax.lax.broadcasted_iota(jnp.int32, dst_vreg.shape, 1)
+    merged_dst_vreg = jax.lax.select(lane_idx >= dst_rel, rolled_src_vreg,
+                                     dst_vreg)
+
+    return dst_chunk_idx, outer_dim, lanes_per_col, merged_dst_vreg
+
+
+def _stitch_prefill_lane(
+    vmem_u32_ref: jax.Array,
+    bkv_sz_cache: jax.Array,
+    cache_pages: jax.Array,
+    new_tok_offset: jax.Array,
+    v_len: int,
+    *,
+    cfgs: configs.RpaConfigs,
+):
+    """O(N) Prefill Path: Roll the entire new tokens buffer into place."""
+    total_head_words = (cfgs.model.num_kv_heads * 2 *
+                        cfgs.aligned_kv_head_dim // cfgs.serve.packing_kv)
+    num_sublanes = pltpu.get_tpu_info().num_sublanes
+    words_per_sublane = total_head_words // num_sublanes
+    vmem_u32_reshaped = vmem_u32_ref.reshape(words_per_sublane, num_sublanes,
+                                             v_len)
+
+    roll_shift = (
+        bkv_sz_cache -
+        (cache_pages * cfgs.serve.page_size + new_tok_offset)) % v_len
+    rolled_u32 = pltpu.roll(vmem_u32_reshaped[...], roll_shift, axis=2)
+
+    lane_idx = jax.lax.broadcasted_iota(jnp.int32,
+                                        rolled_u32[..., :cfgs.bkv_sz].shape, 2)
+    merged_cache_u32 = jax.lax.select(
+        lane_idx >= bkv_sz_cache,
+        rolled_u32[..., :cfgs.bkv_sz],
+        vmem_u32_reshaped[..., :cfgs.bkv_sz],
+    )
+
+    return merged_cache_u32
+
+
+def store_new_kv_lane(
+    vmem_ref: jax.Ref,
+    b_idx: int,
+    stitch_result,
+    *,
+    cfgs: configs.RpaConfigs,
+):
+    """Stores the result of stitch_new_kv_lane back into memory."""
+    v_len = cfgs.bkv_sz + 2 * cfgs.serve.page_size
+    vmem_u32_ref = vmem_ref.at[b_idx].bitcast(jnp.uint32)
+
+    if cfgs.block.bq_sz == 1:
+        dst_chunk_idx, outer_dim, lanes_per_col, merged_dst_vreg = stitch_result
+        num_lanes = pltpu.get_tpu_info().num_lanes
+        strided_vmem_ref = vmem_u32_ref.reshape(-1, num_lanes)
+
+        # Store the merged chunk directly back into memory.
+        strided_vmem_ref[pl.ds(dst_chunk_idx, outer_dim,
+                               lanes_per_col)] = (merged_dst_vreg)
+
+    else:
+        merged_cache_u32 = stitch_result
+        total_head_words = (cfgs.model.num_kv_heads * 2 *
+                            cfgs.aligned_kv_head_dim // cfgs.serve.packing_kv)
+        num_sublanes = pltpu.get_tpu_info().num_sublanes
+        words_per_sublane = total_head_words // num_sublanes
+        vmem_u32_reshaped = vmem_u32_ref.reshape(words_per_sublane,
+                                                 num_sublanes, v_len)
+
+        # Store the fully stitched sequence back.
+        vmem_u32_reshaped[..., :cfgs.bkv_sz] = merged_cache_u32
+
+
+def stitch_new_kv_lane(
+    vmem_ref: jax.Ref,
+    b_idx: int,
+    bkv_sz_frm_cache: jax.Array,
+    new_kv_len_start: jax.Array,
+    *,
+    cfgs: configs.RpaConfigs,
+):
+    """Fetches and computes stitched KV tokens (separated to avoid RAW hazards).
+
+  Expects vmem_ref shape: [batch, 2*kv, head_dim / packing, packing, bkv_sz + 2
+  * page_size]
+  """
+    bkv_sz_cache = bkv_sz_frm_cache.astype(jnp.int32)
+    new_tok_offset = (new_kv_len_start.astype(jnp.int32) %
+                      cfgs.serve.page_size)
+    cache_pages = pl.cdiv(bkv_sz_cache, cfgs.serve.page_size)
+
+    v_len = cfgs.bkv_sz + 2 * cfgs.serve.page_size
+    vmem_u32_ref = vmem_ref.at[b_idx].bitcast(jnp.uint32)
+
+    # If bq_sz == 1, there is only 1 kv token from new, so we only need one 128
+    # sized register to be rolled (compared to rolling the entire bkv_sz).
+    if cfgs.block.bq_sz == 1:
+        return _stitch_decode_lane(vmem_u32_ref, bkv_sz_cache, cache_pages,
+                                   new_tok_offset, v_len)
+    else:
+        return _stitch_prefill_lane(
+            vmem_u32_ref,
+            bkv_sz_cache,
+            cache_pages,
+            new_tok_offset,
+            v_len,
+            cfgs=cfgs,
+        )

--- a/tpu_inference/kernels/experimental/batched_rpa/utils.py
+++ b/tpu_inference/kernels/experimental/batched_rpa/utils.py
@@ -33,7 +33,7 @@ def broadcast_minor(src, shape):
     assert src.shape[-1] % num_lanes == 0
     target_minor = align_to(shape[-1], src.shape[-1])
     # no-op concatenation.
-    broadcasted = jnp.concat([src] * (target_minor // src.shape[-1]), axis=-1)
+    broadcasted = jnp.tile(src, (target_minor // src.shape[-1], ))
     return broadcasted[..., :shape[-1]]
 
 

--- a/tpu_inference/kernels/experimental/batched_rpa/wrapper.py
+++ b/tpu_inference/kernels/experimental/batched_rpa/wrapper.py
@@ -34,6 +34,7 @@ import jax.numpy as jnp
 from jax.experimental import pallas as pl
 from jax.experimental.pallas import tpu as pltpu
 
+from tpu_inference import envs
 from tpu_inference.kernels.experimental.batched_rpa import (configs, kernel,
                                                             schedule, utils)
 
@@ -143,8 +144,13 @@ def get_kv_cache_shape(
     actual_num_kv_heads,
     actual_head_dim,
     kv_dtype,
-    kv_layout: configs.KVLayout = configs.KVLayout.HEAD_ALONG_SUBLANE,
+    kv_layout: configs.KVLayout | None = None,
 ):
+    if kv_layout is None:
+        if envs.USE_BATCHED_RPA_SEQ_ON_LANE:
+            kv_layout = configs.KVLayout.SEQ_ALONG_LANE
+        else:
+            kv_layout = configs.KVLayout.HEAD_ALONG_SUBLANE
     num_lanes = pltpu.get_tpu_info().num_lanes
     num_sublanes = pltpu.get_tpu_info().num_sublanes
     kv_packing = utils.get_dtype_packing(kv_dtype)
@@ -403,50 +409,56 @@ def ragged_paged_attention(
     out_dtype: jnp.dtype | None = None,
     use_causal_mask: bool = True,
     update_kv_cache: bool = True,
-    kv_layout: configs.KVLayout = configs.KVLayout.HEAD_ALONG_SUBLANE,
+    kv_layout: configs.KVLayout | None = None,
 ) -> tuple[jax.Array, jax.Array]:
     """Perform batched ragged paged attention.
 
-  Args:
-    queries: [max_num_tokens, num_q_heads, head_dim]. Output of q projection.
-    keys: [max_num_tokens, num_kv_heads, head_dim]. Output of k projection.
-    values: [max_num_tokens, num_kv_heads, head_dim]. Output of v projection.
-    kv_cache: [num_pages, page_size, cdiv(num_kv_heads * 2, kv_packing),
-      kv_packing, head_dim]. Stores existing kv cache data where k & vs are
-      concatenated along num kv heads dim.
-    kv_lens: [max_num_seqs]. Existing kv cache length of each sequence.
-    page_indices: [max_num_seqs * pages_per_seqs]. kv cache page table of each
-      sequence.
-    cu_q_lens: [max_num_seqs + 1]. Cumulative sum of each sequence's query
-      length. queries[a:b], keys[a:b], and values[a:b] where a=cu_q_lens[i] and
-      b=cu_q_lens[i+1] represents q/k/v of sequence i.
-    distribution: [3]. Cumulative sum of number of decode, prefill, and mixed
-      sequences. distribution[2] represents total number of sequences.
-    sm_scale: Softmax scale value.
-    sliding_window: Size of sliding window (also known as local attention). kvs
-      outside of the window is not fetched from hbm and masked out during
-      computation.
-    soft_cap: Cap values of softmax inputs.
-    mask_value: Value to use for causal masking. Defaults to smallest
-      representable value of the activation dtype.
-    q_scale: Quantization scale value of queries.
-    k_scale: Quantization scale value of keys.
-    v_scale: Quantization scale value of values.
-    chunk_prefill_size: Not used.
-    decode_block_sizes: Kernel block size to use during decode.
-    prefill_block_sizes: Kernel block size to use during prefill.
-    vmem_limit_bytes: VMEM size limit of the kernel. Defaults to maximum VMEM
-      size of the hardware.
-    debug_mode: Not used.
-    out_dtype: Dtype of output. Defaults to dtype of queries.
-    use_causal_mask: Not used.
+    Args:
+        queries: [max_num_tokens, num_q_heads, head_dim]. Output of q projection.
+        keys: [max_num_tokens, num_kv_heads, head_dim]. Output of k projection.
+        values: [max_num_tokens, num_kv_heads, head_dim]. Output of v projection.
+        kv_cache: [num_pages, page_size, cdiv(num_kv_heads * 2, kv_packing),
+            kv_packing, head_dim]. Stores existing kv cache data where k & vs are
+            concatenated along num kv heads dim.
+        kv_lens: [max_num_seqs]. Existing kv cache length of each sequence.
+        page_indices: [max_num_seqs * pages_per_seqs]. kv cache page table of each
+            sequence.
+        cu_q_lens: [max_num_seqs + 1]. Cumulative sum of each sequence's query
+            length. queries[a:b], keys[a:b], and values[a:b] where a=cu_q_lens[i] and
+            b=cu_q_lens[i+1] represents q/k/v of sequence i.
+        distribution: [3]. Cumulative sum of number of decode, prefill, and mixed
+            sequences. distribution[2] represents total number of sequences.
+        sm_scale: Softmax scale value.
+        sliding_window: Size of sliding window (also known as local attention). kvs
+            outside of the window is not fetched from hbm and masked out during
+            computation.
+        soft_cap: Cap values of softmax inputs.
+        mask_value: Value to use for causal masking. Defaults to smallest
+            representable value of the activation dtype.
+        q_scale: Quantization scale value of queries.
+        k_scale: Quantization scale value of keys.
+        v_scale: Quantization scale value of values.
+        chunk_prefill_size: Not used.
+        decode_block_sizes: Kernel block size to use during decode.
+        prefill_block_sizes: Kernel block size to use during prefill.
+        vmem_limit_bytes: VMEM size limit of the kernel. Defaults to maximum VMEM
+            size of the hardware.
+        debug_mode: Not used.
+        out_dtype: Dtype of output. Defaults to dtype of queries.
+        use_causal_mask: Not used.
 
-  Returns:
-    out: [max_num_tokens, num_q_heads, head_dim]. Output of self attention.
-    new_kv_cache: [num_pages, page_size, cdiv(num_kv_heads * 2, kv_packing),
-      kv_packing, head_dim]. Result of new kv cache where k & vs are
-      concatenated along num kv heads dim.
-  """
+    Returns:
+        out: [max_num_tokens, num_q_heads, head_dim]. Output of self attention.
+        new_kv_cache: [num_pages, page_size, cdiv(num_kv_heads * 2, kv_packing),
+            kv_packing, head_dim]. Result of new kv cache where k & vs are
+            concatenated along num kv heads dim.
+    """
+
+    if kv_layout is None:
+        if envs.USE_BATCHED_RPA_SEQ_ON_LANE:
+            kv_layout = configs.KVLayout.SEQ_ALONG_LANE
+        else:
+            kv_layout = configs.KVLayout.HEAD_ALONG_SUBLANE
 
     if not use_causal_mask:
         raise ValueError("Only causal attention is supported.")

--- a/tpu_inference/kernels/experimental/batched_rpa/wrapper.py
+++ b/tpu_inference/kernels/experimental/batched_rpa/wrapper.py
@@ -44,6 +44,7 @@ def prepare_inputs(
     v: jax.Array,
     q_dtype: jnp.dtype,
     kv_dtype: jnp.dtype,
+    kv_layout: configs.KVLayout = configs.KVLayout.HEAD_ALONG_SUBLANE,
 ) -> tuple[jax.Array, jax.Array]:
 
     total_q_tokens, actual_num_q_heads, actual_head_dim = q.shape
@@ -56,7 +57,13 @@ def prepare_inputs(
     aligned_num_q_heads_per_kv_head = utils.align_to(num_q_heads_per_kv_head,
                                                      q_packing)
     num_lanes = pltpu.get_tpu_info().num_lanes
-    aligned_head_dim = utils.align_to(actual_head_dim, num_lanes)
+    num_sublanes = pltpu.get_tpu_info().num_sublanes
+    aligned_q_head_dim = utils.align_to(actual_head_dim, num_lanes)
+    if kv_layout == configs.KVLayout.SEQ_ALONG_LANE:
+        aligned_kv_head_dim = utils.align_to(actual_head_dim,
+                                             num_sublanes * kv_packing)
+    else:
+        aligned_kv_head_dim = utils.align_to(actual_head_dim, num_lanes)
 
     # queries: (T, H, D) -> (T, H_kv, G, D)
     o_hbm_alias_q_hbm = (jnp.pad(
@@ -70,7 +77,7 @@ def prepare_inputs(
             (0, 0),
             (0, 0),
             (0, aligned_num_q_heads_per_kv_head - num_q_heads_per_kv_head),
-            (0, aligned_head_dim - actual_head_dim),
+            (0, aligned_q_head_dim - actual_head_dim),
         ),
         constant_values=0,
     ).reshape(
@@ -78,33 +85,50 @@ def prepare_inputs(
         actual_num_kv_heads,
         aligned_num_q_heads_per_kv_head // q_packing,
         q_packing,
-        aligned_head_dim,
+        aligned_q_head_dim,
     ).swapaxes(0, 1))
 
     # Pad keys and values head_dim
     actual_num_kv_heads_x2 = actual_num_kv_heads * 2
     num_kv_heads_x2_aligned = utils.align_to(actual_num_kv_heads_x2,
                                              kv_packing)
-    assert num_kv_heads_x2_aligned % 2 == 0, (
-        f"kv_packing={kv_packing} produces an odd aligned head count "
-        f"{num_kv_heads_x2_aligned}")
-    new_kv_hbm = jnp.pad(
-        jnp.concatenate([k, v], axis=-1).reshape(total_q_tokens,
-                                                 actual_num_kv_heads_x2,
-                                                 actual_head_dim),
-        (
-            (0, 0),
-            (0, num_kv_heads_x2_aligned - actual_num_kv_heads_x2),
-            (0, aligned_head_dim - actual_head_dim),
-        ),
-        constant_values=0,
-    ).reshape(
-        total_q_tokens,
-        num_kv_heads_x2_aligned // kv_packing,
-        kv_packing,
-        aligned_head_dim,
-    )
 
+    if kv_layout == configs.KVLayout.SEQ_ALONG_LANE:
+        num_lanes = pltpu.get_tpu_info().num_lanes
+        padded_total_tokens = utils.align_to(total_q_tokens, num_lanes)
+        new_kv_hbm = (jnp.pad(
+            jnp.concatenate([k, v], axis=-1).reshape(total_q_tokens,
+                                                     actual_num_kv_heads_x2,
+                                                     actual_head_dim),
+            (
+                (0, padded_total_tokens - total_q_tokens),
+                (0, 0),
+                (0, aligned_kv_head_dim - actual_head_dim),
+            ),
+            constant_values=0,
+        ).reshape(
+            padded_total_tokens,
+            actual_num_kv_heads_x2,
+            aligned_kv_head_dim // kv_packing,
+            kv_packing,
+        ).transpose(1, 2, 3, 0))
+    else:
+        new_kv_hbm = jnp.pad(
+            jnp.concatenate([k, v], axis=-1).reshape(total_q_tokens,
+                                                     actual_num_kv_heads_x2,
+                                                     actual_head_dim),
+            (
+                (0, 0),
+                (0, num_kv_heads_x2_aligned - actual_num_kv_heads_x2),
+                (0, aligned_kv_head_dim - actual_head_dim),
+            ),
+            constant_values=0,
+        ).reshape(
+            total_q_tokens,
+            num_kv_heads_x2_aligned // kv_packing,
+            kv_packing,
+            aligned_kv_head_dim,
+        )
     return o_hbm_alias_q_hbm, new_kv_hbm
 
 
@@ -119,9 +143,20 @@ def get_kv_cache_shape(
     actual_num_kv_heads,
     actual_head_dim,
     kv_dtype,
+    kv_layout: configs.KVLayout = configs.KVLayout.HEAD_ALONG_SUBLANE,
 ):
     num_lanes = pltpu.get_tpu_info().num_lanes
+    num_sublanes = pltpu.get_tpu_info().num_sublanes
     kv_packing = utils.get_dtype_packing(kv_dtype)
+    if kv_layout == configs.KVLayout.SEQ_ALONG_LANE:
+        return (
+            total_num_pages,
+            actual_num_kv_heads * 2,
+            utils.align_to(actual_head_dim, num_sublanes * kv_packing) //
+            kv_packing,
+            kv_packing,
+            page_size,
+        )
     return (
         total_num_pages,
         page_size,
@@ -166,7 +201,11 @@ def calculate_block_sizes(
 
         # Calculate size bq & bkv arrays for a single buffer.
         bq_array_size = bq_sz * aligned_num_q_heads * aligned_head_dim
-        bkv_array_size = bkv_sz * aligned_num_kv_heads_x2 * aligned_head_dim
+        if serve_cfgs.kv_layout == configs.KVLayout.SEQ_ALONG_LANE:
+            bkv_array_size = ((bkv_sz + 2 * serve_cfgs.page_size) *
+                              aligned_num_kv_heads_x2 * aligned_head_dim)
+        else:
+            bkv_array_size = bkv_sz * aligned_num_kv_heads_x2 * aligned_head_dim
 
         # Get output buffer size as well - which has same size as query size.
         bo_array_size = bq_array_size
@@ -244,8 +283,9 @@ def calculate_block_sizes(
 
         # If current batch size triggers OOM, decrease batch size until the kernel
         # fits within VMEM limit.
-        while (calculate_vmem_usage(batch_size, n_buffer, bq_sz, bkv_sz)
-               > capped_vmem_limit_bytes):
+        while (batch_size > 1
+               and calculate_vmem_usage(batch_size, n_buffer, bq_sz,
+                                        bkv_sz) > capped_vmem_limit_bytes):
             batch_size -= 1
 
         # As a last resort, attempt to decrease number of buffers to avoid OOM.
@@ -334,6 +374,7 @@ def calculate_block_sizes(
         "out_dtype",
         "use_causal_mask",
         "update_kv_cache",
+        "kv_layout",
     ),
     donate_argnames=("queries", "keys", "values", "kv_cache"),
 )
@@ -362,49 +403,50 @@ def ragged_paged_attention(
     out_dtype: jnp.dtype | None = None,
     use_causal_mask: bool = True,
     update_kv_cache: bool = True,
+    kv_layout: configs.KVLayout = configs.KVLayout.HEAD_ALONG_SUBLANE,
 ) -> tuple[jax.Array, jax.Array]:
     """Perform batched ragged paged attention.
 
-    Args:
-        queries: [max_num_tokens, num_q_heads, head_dim]. Output of q projection.
-        keys: [max_num_tokens, num_kv_heads, head_dim]. Output of k projection.
-        values: [max_num_tokens, num_kv_heads, head_dim]. Output of v projection.
-        kv_cache: [num_pages, page_size, cdiv(num_kv_heads * 2, kv_packing),
-            kv_packing, head_dim]. Stores existing kv cache data where k & vs are
-            concatenated along num kv heads dim.
-        kv_lens: [max_num_seqs]. Existing kv cache length of each sequence.
-            page_indices: [max_num_seqs * pages_per_seqs]. kv cache page table of each
-            sequence.
-        cu_q_lens: [max_num_seqs + 1]. Cumulative sum of each sequence's query
-            length. queries[a:b], keys[a:b], and values[a:b] where a=cu_q_lens[i] and
-            b=cu_q_lens[i+1] represents q/k/v of sequence i.
-        distribution: [3]. Cumulative sum of number of decode, prefill, and mixed
-            sequences. distribution[2] represents total number of sequences.
-        sm_scale: Softmax scale value.
-        sliding_window: Size of sliding window (also known as local attention). kvs
-            outside of the window is not fetched from hbm and masked out during
-            computation.
-        soft_cap: Cap values of softmax inputs.
-        mask_value: Value to use for causal masking. Defaults to smallest
-            representable value of the activation dtype.
-        q_scale: Quantization scale value of queries.
-        k_scale: Quantization scale value of keys.
-        v_scale: Quantization scale value of values.
-        chunk_prefill_size: Not used.
-        decode_block_sizes: Kernel block size to use during decode.
-        prefill_block_sizes: Kernel block size to use during prefill.
-        vmem_limit_bytes: VMEM size limit of the kernel. Defaults to maximum VMEM
-            size of the hardware.
-        debug_mode: Not used.
-        out_dtype: Dtype of output. Defaults to dtype of queries.
-        use_causal_mask: Not used.
+  Args:
+    queries: [max_num_tokens, num_q_heads, head_dim]. Output of q projection.
+    keys: [max_num_tokens, num_kv_heads, head_dim]. Output of k projection.
+    values: [max_num_tokens, num_kv_heads, head_dim]. Output of v projection.
+    kv_cache: [num_pages, page_size, cdiv(num_kv_heads * 2, kv_packing),
+      kv_packing, head_dim]. Stores existing kv cache data where k & vs are
+      concatenated along num kv heads dim.
+    kv_lens: [max_num_seqs]. Existing kv cache length of each sequence.
+    page_indices: [max_num_seqs * pages_per_seqs]. kv cache page table of each
+      sequence.
+    cu_q_lens: [max_num_seqs + 1]. Cumulative sum of each sequence's query
+      length. queries[a:b], keys[a:b], and values[a:b] where a=cu_q_lens[i] and
+      b=cu_q_lens[i+1] represents q/k/v of sequence i.
+    distribution: [3]. Cumulative sum of number of decode, prefill, and mixed
+      sequences. distribution[2] represents total number of sequences.
+    sm_scale: Softmax scale value.
+    sliding_window: Size of sliding window (also known as local attention). kvs
+      outside of the window is not fetched from hbm and masked out during
+      computation.
+    soft_cap: Cap values of softmax inputs.
+    mask_value: Value to use for causal masking. Defaults to smallest
+      representable value of the activation dtype.
+    q_scale: Quantization scale value of queries.
+    k_scale: Quantization scale value of keys.
+    v_scale: Quantization scale value of values.
+    chunk_prefill_size: Not used.
+    decode_block_sizes: Kernel block size to use during decode.
+    prefill_block_sizes: Kernel block size to use during prefill.
+    vmem_limit_bytes: VMEM size limit of the kernel. Defaults to maximum VMEM
+      size of the hardware.
+    debug_mode: Not used.
+    out_dtype: Dtype of output. Defaults to dtype of queries.
+    use_causal_mask: Not used.
 
-    Returns:
-        out: [max_num_tokens, num_q_heads, head_dim]. Output of self attention.
-        new_kv_cache: [num_pages, page_size, cdiv(num_kv_heads * 2, kv_packing),
-            kv_packing, head_dim]. Result of new kv cache where k & vs are
-            concatenated along num kv heads dim.
-    """
+  Returns:
+    out: [max_num_tokens, num_q_heads, head_dim]. Output of self attention.
+    new_kv_cache: [num_pages, page_size, cdiv(num_kv_heads * 2, kv_packing),
+      kv_packing, head_dim]. Result of new kv cache where k & vs are
+      concatenated along num kv heads dim.
+  """
 
     if not use_causal_mask:
         raise ValueError("Only causal attention is supported.")
@@ -421,7 +463,10 @@ def ragged_paged_attention(
         vmem_limit_bytes = pltpu.get_tpu_info().vmem_capacity_bytes
 
     max_num_seqs = kv_lens.shape[0]
-    page_size = kv_cache.shape[1]
+    if kv_layout == configs.KVLayout.SEQ_ALONG_LANE:
+        page_size = kv_cache.shape[4]
+    else:
+        page_size = kv_cache.shape[1]
 
     num_q_heads = queries.shape[1]
     head_dim = queries.shape[2]
@@ -448,10 +493,17 @@ def ragged_paged_attention(
         scale_q=q_scale,
         scale_k=k_scale,
         scale_v=v_scale,
+        kv_layout=kv_layout,
     )
 
-    q_hbm, new_kv_hbm = prepare_inputs(queries, keys, values, queries.dtype,
-                                       kv_cache.dtype)
+    q_hbm, new_kv_hbm = prepare_inputs(
+        queries,
+        keys,
+        values,
+        queries.dtype,
+        kv_cache.dtype,
+        kv_layout=kv_layout,
+    )
 
     default_decode, default_prefill = calculate_block_sizes(
         model_cfgs, serve_cfgs, vmem_limit_bytes)

--- a/tpu_inference/layers/common/sharding.py
+++ b/tpu_inference/layers/common/sharding.py
@@ -251,8 +251,11 @@ class ShardingConfigManager:
             # Use attention DP instead to reduce per-device num_kv_heads and
             # eliminate this waste.
 
-            num_kv_heads_per_device_in_kv_cache = max(1, (num_kv_heads * 2) /
-                                                      packing)
+            if envs.USE_BATCHED_RPA_KERNEL and envs.USE_BATCHED_RPA_SEQ_ON_LANE:
+                num_kv_heads_per_device_in_kv_cache = max(1, num_kv_heads * 2)
+            else:
+                num_kv_heads_per_device_in_kv_cache = max(
+                    1, (num_kv_heads * 2) / packing)
             attn_dp_size = sharding_strategy.get("attn_dp_size", None)
             if attn_dp_size is None:
                 attn_dp = max(

--- a/tpu_inference/runner/kv_cache.py
+++ b/tpu_inference/runner/kv_cache.py
@@ -23,8 +23,13 @@ from jax.sharding import Mesh, NamedSharding, PartitionSpec
 
 import tpu_inference.envs as envs
 import tpu_inference.kernels.mla.v2.kernel as mla
-import tpu_inference.kernels.ragged_paged_attention.v3.kernel as rpa
 import tpu_inference.kernels.ragged_paged_attention.v3.kernel_hd64 as rpa_hd64
+
+if envs.USE_BATCHED_RPA_KERNEL:
+    import tpu_inference.kernels.experimental.batched_rpa.wrapper as rpa
+else:
+    import tpu_inference.kernels.ragged_paged_attention.v3.kernel as rpa
+
 from tpu_inference import utils
 from tpu_inference.layers.common.sharding import ShardingAxisName
 from tpu_inference.logger import init_logger


### PR DESCRIPTION
# Description

In RPA, the kv_cache layout is packed along the number of KV heads. Thus, when `num_kv_heads = 1`, and kv dtype = fp8, we have to waste half the KV cache with padding. (k + v = 2, but 2 < kv_packing = 4). 

We allow the option to keep the cache in a layout -- seq_along_lane, with minimal performance degradation. In this layout, we put page_size on the last dimension (lane), and the head dimension on the sublane dimension.

Feature in progress to remove any overhead introduced by using `SEQ_ON_LANE` 

You can enable this via flag: `USE_BATCHED_RPA_SEQ_ON_LANE=1`

# Features 

With `SEQ_ALONG_LANE` enabled: 

1. You can now use `batched_rpa` with models that have`head_dim = 64`, since we no longer have to pad the head dimension up to 128. To be specific, SEQ_ALONG_LANE relaxes the constraint of having a head dimension that must be a multiple of 128 to only a multiple of 32. 
2. KV cache utilization is halved in models with the above characteristics (kv_heads per device = 1, kv_packing = 4)

# Constraints 

Since PAGE_SIZE is now on the last dimension of our cache, the configured block size must be 128 (for now). 

# Tests

All tests are run on Qwen-Coder. But any model that uses `BATCHED_RPA` should benefit. 

KV Cache capacity is doubled: 

`USE_BATCHED_RPA_SEQ_ON_LANE=0`:
```text
(EngineCore pid=2929407)   0.1.0: Array(shape=(5141, 128, 8, 4, 128), dtype=float8_e4m3fn, sharding=NamedSharding(mesh=Mesh('data': 1, 'model': 8, axis_types=(Auto, Auto)), spec=P(None, None, 'model'), memory_kind=device) [NamedSharding, id=123473401299648])
```

`USE_BATCHED_RPA_SEQ_ON_LANE=1`:
```text
(EngineCore pid=3053252)   0.1.0: Array(shape=(10283, 2, 256, 4, 128), dtype=float8_e4m3fn, sharding=NamedSharding(mesh=Mesh('data': 1, 'model': 8, axis_types=(Auto, Auto)), spec=P(None, None, 'model'), memory_kind=device) [NamedSharding, id=128670224217152])
```

SEQ_ON_LANE adds some overhead at low concurrency, but this layout unlocks double the physical KV cache capacity, allowing higher concurrency / throughput. 

### `1024_1024` @ Concurrency 64 vs 512

| Metric | c=64 (Before) | c=64 (After) | Delta % (c=64) | c=512 (Before) | c=512 (After) | Delta % (c=512) |
| :--- | :---: | :---: | :---: | :---: | :---: | :---: |
| **Max HBM Pages** | 5,141 pages | 10,283 pages | **+100.0%** | 5,141 pages | 10,283 pages | **+100.0%** |
| **Req Throughput (req/s)** | 2.21 | 2.15 | -2.7% | 4.70 | 4.93 | **+4.9%** |
| **Out Throughput (tok/s)** | 2,044.11 | 1,984.88 | -2.9% | 4,328.69 | 4,535.48 | **+4.8%** |
| **Total Throughput (tok/s)** | 4,081.76 | 3,963.48 | -2.9% | 8,672.27 | 9,086.55 | **+4.8%** |
| **Mean TTFT (ms)** | 553.46 | 550.99 | -0.4% | 12,735.95 | 8,876.18 | **-30.3%** |
| **Median TTFT (ms)** | 134.04 | 133.62 | -0.3% | 12,142.22 | 6,099.26 | **-49.8%**|
| **Mean TPOT (ms)** | 29.36 | 30.29 | +3.1% | 90.20 | 86.11 | **-4.5%** |

###  `8192_1024` @ Concurrency 64 vs 128

| Metric | c=64 (Before) | c=64 (After) | Delta % (c=64) | c=128 (Before) | c=128 (After) | Delta % (c=128) |
| :--- | :---: | :---: | :---: | :---: | :---: | :---: |
| **Max HBM Pages** | 5,141 pages | 10,283 pages | **+100.0%** | 5,141 pages | 10,283 pages | **+100.0%** |
| **Req Throughput (req/s)** | 1.17 | 1.14 | -2.5% | 1.14 | 1.33 | **+16.7%** |
| **Out Throughput (tok/s)** | 1,083.89 | 1,053.41 | -2.8% | 1,054.81 | 1,228.44 | **+16.5%** |
| **Total Throughput (tok/s)** | 9,692.46 | 9,419.93 | -2.8% | 9,432.43 | 10,985.13 | **+16.5%** |
| **Mean TTFT (ms)** | 3,396.50 | 3,375.75 | -0.6% | 37,775.69 | 11,604.02 | **-69.3%**|
| **Median TTFT (ms)** | 934.04 | 933.62 | -0.0% | 27,715.05 | 1,431.48 | **-94.8%**|
| **Mean TPOT (ms)** | 53.53 | 55.25 | +3.2% | 71.09 | 84.59 | +19.0% |


Specific Results: 

#### `1024 Input / 1024 Output `

Before: 
```text
============ Serving Benchmark Result ============
Successful requests:                     320       
Benchmark duration (s):                  144.60    
Total input tokens:                      294646    
Total generated tokens:                  295581    
Request throughput (req/s):              2.21      
Output token throughput (tok/s):         2044.11   
Total Token throughput (tok/s):          4081.76   
---------------Time to First Token----------------
Mean TTFT (ms):                          553.46    
Median TTFT (ms):                        176.17    
P99 TTFT (ms):                           3311.63   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          29.36     
Median TPOT (ms):                        29.60     
P99 TPOT (ms):                           31.61     
---------------Inter-token Latency----------------
Mean ITL (ms):                           29.38     
Median ITL (ms):                         25.77     
P99 ITL (ms):                            119.51    
----------------End-to-end Latency----------------
Mean E2EL (ms):                          27662.70  
Median E2EL (ms):                        27490.51  
P99 E2EL (ms):                           33041.31  
==================================================
```
After: 
```text
============ Serving Benchmark Result ============
Successful requests:                     320       
Benchmark duration (s):                  148.92    
Total input tokens:                      294646    
Total generated tokens:                  295581    
Request throughput (req/s):              2.15      
Output token throughput (tok/s):         1984.88   
Total Token throughput (tok/s):          3963.48   
---------------Time to First Token----------------
Mean TTFT (ms):                          550.99    
Median TTFT (ms):                        177.89    
P99 TTFT (ms):                           3315.58   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          30.29     
Median TPOT (ms):                        30.51     
P99 TPOT (ms):                           32.56     
---------------Inter-token Latency----------------
Mean ITL (ms):                           30.31     
Median ITL (ms):                         26.70     
P99 ITL (ms):                            119.64    
----------------End-to-end Latency----------------
Mean E2EL (ms):                          28514.83  
Median E2EL (ms):                        28339.38  
P99 E2EL (ms):                           34189.75  
==================================================
```

#### `8192 Input / 1024 Output`
Before:
```text
============ Serving Benchmark Result ============
Successful requests:                     320       
Benchmark duration (s):                  273.22    
Total input tokens:                      2352062   
Total generated tokens:                  296143    
Request throughput (req/s):              1.17      
Output token throughput (tok/s):         1083.89   
Total Token throughput (tok/s):          9692.46   
---------------Time to First Token----------------
Mean TTFT (ms):                          3396.50   
Median TTFT (ms):                        934.04    
P99 TTFT (ms):                           25554.56  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          53.53     
Median TPOT (ms):                        55.90     
P99 TPOT (ms):                           69.81     
---------------Inter-token Latency----------------
Mean ITL (ms):                           53.71     
Median ITL (ms):                         27.89     
P99 ITL (ms):                            468.04    
----------------End-to-end Latency----------------
Mean E2EL (ms):                          53049.98  
Median E2EL (ms):                        52897.64  
P99 E2EL (ms):                           79638.25  
==================================================
```
After: 
```text
============ Serving Benchmark Result ============
Successful requests:                     320       
Benchmark duration (s):                  281.13    
Total input tokens:                      2352062   
Total generated tokens:                  296143    
Request throughput (req/s):              1.14      
Output token throughput (tok/s):         1053.41   
Total Token throughput (tok/s):          9419.93   
---------------Time to First Token----------------
Mean TTFT (ms):                          3375.75   
Median TTFT (ms):                        933.62    
P99 TTFT (ms):                           25479.34  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          55.25     
Median TPOT (ms):                        57.41     
P99 TPOT (ms):                           72.21     
---------------Inter-token Latency----------------
Mean ITL (ms):                           55.43     
Median ITL (ms):                         29.67     
P99 ITL (ms):                            469.01    
----------------End-to-end Latency----------------
Mean E2EL (ms):                          54622.23  
Median E2EL (ms):                        54366.01  
P99 E2EL (ms):                           82103.39  
==================================================
```

#### `1024 Input / 8192 Output`
Before:
```text
============ Serving Benchmark Result ============
Successful requests:                     320       
Benchmark duration (s):                  1054.34   
Total input tokens:                      294646    
Total generated tokens:                  2373111   
Request throughput (req/s):              0.30      
Output token throughput (tok/s):         2250.80   
Total Token throughput (tok/s):          2530.25   
---------------Time to First Token----------------
Mean TTFT (ms):                          504.15    
Median TTFT (ms):                        133.44    
P99 TTFT (ms):                           3373.71   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          27.12     
Median TPOT (ms):                        27.22     
P99 TPOT (ms):                           27.55     
---------------Inter-token Latency----------------
Mean ITL (ms):                           27.13     
Median ITL (ms):                         26.65     
P99 ITL (ms):                            29.85     
----------------End-to-end Latency----------------
Mean E2EL (ms):                          201638.65 
Median E2EL (ms):                        202321.14 
P99 E2EL (ms):                           224372.04 
==================================================
```
After:
```text
============ Serving Benchmark Result ============
Successful requests:                     320       
Benchmark duration (s):                  1107.31   
Total input tokens:                      294646    
Total generated tokens:                  2373111   
Request throughput (req/s):              0.29      
Output token throughput (tok/s):         2143.13   
Total Token throughput (tok/s):          2409.22   
---------------Time to First Token----------------
Mean TTFT (ms):                          516.61    
Median TTFT (ms):                        138.87    
P99 TTFT (ms):                           3250.53   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          28.52     
Median TPOT (ms):                        28.50     
P99 TPOT (ms):                           29.21     
---------------Inter-token Latency----------------
Mean ITL (ms):                           28.53     
Median ITL (ms):                         28.15     
P99 ITL (ms):                            31.48     
----------------End-to-end Latency----------------
Mean E2EL (ms):                          212048.70 
Median E2EL (ms):                        212200.40 
P99 E2EL (ms):                           235744.64 
==================================================
```

# Checklist

