### PR TITLE
docs(dflash): add Speculative Decoding: DFlash to feature support matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,12 @@ Below is the live status of our supported models, features, and kernels. Click o
       <td><span title="✅&nbsp;Passing">✅</span></td>
     </tr>
     <tr>
+      <td>Speculative Decoding: DFlash</td>
+      <td><span title="✅&nbsp;Passing">✅</span></td>
+      <td><span title="✅&nbsp;Passing">✅</span></td>
+      <td><span title="✅&nbsp;Passing">✅</span></td>
+    </tr>
+    <tr>
       <td>Speculative Decoding: Ngram</td>
       <td><span title="✅&nbsp;Passing">✅</span></td>
       <td><span title="✅&nbsp;Passing">✅</span></td>
@@ -633,6 +639,12 @@ Below is the live status of our supported models, features, and kernels. Click o
     </tr>
     <tr>
       <td>Speculative Decoding: Eagle3</td>
+      <td><span title="✅&nbsp;Passing">✅</span></td>
+      <td><span title="✅&nbsp;Passing">✅</span></td>
+      <td><span title="✅&nbsp;Passing">✅</span></td>
+    </tr>
+    <tr>
+      <td>Speculative Decoding: DFlash</td>
       <td><span title="✅&nbsp;Passing">✅</span></td>
       <td><span title="✅&nbsp;Passing">✅</span></td>
       <td><span title="✅&nbsp;Passing">✅</span></td>

--- a/docs/includes/core_features.md
+++ b/docs/includes/core_features.md
@@ -69,6 +69,12 @@
       <td><span title="✅&nbsp;Passing">✅</span></td>
     </tr>
     <tr>
+      <td>Speculative Decoding: DFlash</td>
+      <td><span title="✅&nbsp;Passing">✅</span></td>
+      <td><span title="✅&nbsp;Passing">✅</span></td>
+      <td><span title="✅&nbsp;Passing">✅</span></td>
+    </tr>
+    <tr>
       <td>Speculative Decoding: Ngram</td>
       <td><span title="✅&nbsp;Passing">✅</span></td>
       <td><span title="✅&nbsp;Passing">✅</span></td>

--- a/docs/includes/nightly_core_features.md
+++ b/docs/includes/nightly_core_features.md
@@ -69,6 +69,12 @@
       <td><span title="✅&nbsp;Passing">✅</span></td>
     </tr>
     <tr>
+      <td>Speculative Decoding: DFlash</td>
+      <td><span title="✅&nbsp;Passing">✅</span></td>
+      <td><span title="✅&nbsp;Passing">✅</span></td>
+      <td><span title="✅&nbsp;Passing">✅</span></td>
+    </tr>
+    <tr>
       <td>Speculative Decoding: Ngram</td>
       <td><span title="✅&nbsp;Passing">✅</span></td>
       <td><span title="✅&nbsp;Passing">✅</span></td>

--- a/support_matrices/nightly/v6e/default/feature_support_matrix.csv
+++ b/support_matrices/nightly/v6e/default/feature_support_matrix.csv
@@ -8,6 +8,7 @@ Feature,CorrectnessTest,PerformanceTest
 "Prefix Caching",✅ Passing,✅ Passing
 "Single Program Multi Data",✅ Passing,✅ Passing
 "Speculative Decoding: Eagle3",✅ Passing,✅ Passing
+"Speculative Decoding: DFlash",✅ Passing,✅ Passing
 "Speculative Decoding: Ngram",✅ Passing,✅ Passing
 "Step Pooling (Embedding)",✅ Passing,❓ Untested
 "async scheduler",✅ Passing,✅ Passing

--- a/support_matrices/nightly/v6e/flax_nnx/feature_support_matrix.csv
+++ b/support_matrices/nightly/v6e/flax_nnx/feature_support_matrix.csv
@@ -8,6 +8,7 @@ Feature,CorrectnessTest,PerformanceTest
 "Prefix Caching",✅ Passing,✅ Passing
 "Single Program Multi Data",✅ Passing,✅ Passing
 "Speculative Decoding: Eagle3",✅ Passing,✅ Passing
+"Speculative Decoding: DFlash",✅ Passing,✅ Passing
 "Speculative Decoding: Ngram",✅ Passing,✅ Passing
 "Step Pooling (Embedding)",✅ Passing,❓ Untested
 "async scheduler",✅ Passing,✅ Passing

--- a/support_matrices/nightly/v6e/vllm/feature_support_matrix.csv
+++ b/support_matrices/nightly/v6e/vllm/feature_support_matrix.csv
@@ -8,6 +8,7 @@ Feature,CorrectnessTest,PerformanceTest
 "Prefix Caching",✅ Passing,✅ Passing
 "Single Program Multi Data",✅ Passing,✅ Passing
 "Speculative Decoding: Eagle3",✅ Passing,✅ Passing
+"Speculative Decoding: DFlash",✅ Passing,✅ Passing
 "Speculative Decoding: Ngram",✅ Passing,✅ Passing
 "Step Pooling (Embedding)",✅ Passing,❓ Untested
 "async scheduler",✅ Passing,✅ Passing

--- a/support_matrices/nightly/v7x/default/feature_support_matrix.csv
+++ b/support_matrices/nightly/v7x/default/feature_support_matrix.csv
@@ -8,6 +8,7 @@ Feature,CorrectnessTest,PerformanceTest
 "Prefix Caching",✅ Passing,✅ Passing
 "Single Program Multi Data",✅ Passing,✅ Passing
 "Speculative Decoding: Eagle3",✅ Passing,✅ Passing
+"Speculative Decoding: DFlash",✅ Passing,✅ Passing
 "Speculative Decoding: Ngram",✅ Passing,✅ Passing
 "Step Pooling (Embedding)",✅ Passing,❓ Untested
 "async scheduler",✅ Passing,✅ Passing

--- a/support_matrices/nightly/v7x/flax_nnx/feature_support_matrix.csv
+++ b/support_matrices/nightly/v7x/flax_nnx/feature_support_matrix.csv
@@ -8,6 +8,7 @@ Feature,CorrectnessTest,PerformanceTest
 "Prefix Caching",✅ Passing,✅ Passing
 "Single Program Multi Data",✅ Passing,✅ Passing
 "Speculative Decoding: Eagle3",✅ Passing,✅ Passing
+"Speculative Decoding: DFlash",✅ Passing,✅ Passing
 "Speculative Decoding: Ngram",✅ Passing,✅ Passing
 "Step Pooling (Embedding)",✅ Passing,❓ Untested
 "async scheduler",✅ Passing,✅ Passing

--- a/support_matrices/nightly/v7x/vllm/feature_support_matrix.csv
+++ b/support_matrices/nightly/v7x/vllm/feature_support_matrix.csv
@@ -8,6 +8,7 @@ Feature,CorrectnessTest,PerformanceTest
 "Prefix Caching",✅ Passing,✅ Passing
 "Single Program Multi Data",✅ Passing,✅ Passing
 "Speculative Decoding: Eagle3",✅ Passing,✅ Passing
+"Speculative Decoding: DFlash",✅ Passing,✅ Passing
 "Speculative Decoding: Ngram",✅ Passing,✅ Passing
 "Step Pooling (Embedding)",✅ Passing,❓ Untested
 "async scheduler",✅ Passing,✅ Passing

--- a/support_matrices/release/v6e/default/feature_support_matrix.csv
+++ b/support_matrices/release/v6e/default/feature_support_matrix.csv
@@ -8,6 +8,7 @@ Feature,CorrectnessTest,PerformanceTest
 "Prefix Caching",✅ Passing,✅ Passing
 "Single Program Multi Data",✅ Passing,✅ Passing
 "Speculative Decoding: Eagle3",✅ Passing,✅ Passing
+"Speculative Decoding: DFlash",✅ Passing,✅ Passing
 "Speculative Decoding: Ngram",✅ Passing,✅ Passing
 "Step Pooling (Embedding)",✅ Passing,❓ Untested
 "async scheduler",✅ Passing,✅ Passing

--- a/support_matrices/release/v6e/flax_nnx/feature_support_matrix.csv
+++ b/support_matrices/release/v6e/flax_nnx/feature_support_matrix.csv
@@ -8,6 +8,7 @@ Feature,CorrectnessTest,PerformanceTest
 "Prefix Caching",✅ Passing,✅ Passing
 "Single Program Multi Data",✅ Passing,✅ Passing
 "Speculative Decoding: Eagle3",✅ Passing,✅ Passing
+"Speculative Decoding: DFlash",✅ Passing,✅ Passing
 "Speculative Decoding: Ngram",✅ Passing,✅ Passing
 "Step Pooling (Embedding)",✅ Passing,❓ Untested
 "async scheduler",✅ Passing,✅ Passing

--- a/support_matrices/release/v6e/vllm/feature_support_matrix.csv
+++ b/support_matrices/release/v6e/vllm/feature_support_matrix.csv
@@ -8,6 +8,7 @@ Feature,CorrectnessTest,PerformanceTest
 "Prefix Caching",✅ Passing,✅ Passing
 "Single Program Multi Data",✅ Passing,✅ Passing
 "Speculative Decoding: Eagle3",✅ Passing,✅ Passing
+"Speculative Decoding: DFlash",✅ Passing,✅ Passing
 "Speculative Decoding: Ngram",✅ Passing,✅ Passing
 "Step Pooling (Embedding)",✅ Passing,❓ Untested
 "async scheduler",✅ Passing,✅ Passing

--- a/support_matrices/release/v7x/default/feature_support_matrix.csv
+++ b/support_matrices/release/v7x/default/feature_support_matrix.csv
@@ -8,6 +8,7 @@ Feature,CorrectnessTest,PerformanceTest
 "Prefix Caching",✅ Passing,✅ Passing
 "Single Program Multi Data",✅ Passing,✅ Passing
 "Speculative Decoding: Eagle3",✅ Passing,✅ Passing
+"Speculative Decoding: DFlash",✅ Passing,✅ Passing
 "Speculative Decoding: Ngram",✅ Passing,✅ Passing
 "Step Pooling (Embedding)",✅ Passing,❓ Untested
 "async scheduler",✅ Passing,✅ Passing

--- a/support_matrices/release/v7x/flax_nnx/feature_support_matrix.csv
+++ b/support_matrices/release/v7x/flax_nnx/feature_support_matrix.csv
@@ -8,6 +8,7 @@ Feature,CorrectnessTest,PerformanceTest
 "Prefix Caching",✅ Passing,✅ Passing
 "Single Program Multi Data",✅ Passing,✅ Passing
 "Speculative Decoding: Eagle3",✅ Passing,✅ Passing
+"Speculative Decoding: DFlash",✅ Passing,✅ Passing
 "Speculative Decoding: Ngram",✅ Passing,✅ Passing
 "Step Pooling (Embedding)",✅ Passing,❓ Untested
 "async scheduler",✅ Passing,✅ Passing

--- a/support_matrices/release/v7x/vllm/feature_support_matrix.csv
+++ b/support_matrices/release/v7x/vllm/feature_support_matrix.csv
@@ -8,6 +8,7 @@ Feature,CorrectnessTest,PerformanceTest
 "Prefix Caching",✅ Passing,✅ Passing
 "Single Program Multi Data",✅ Passing,✅ Passing
 "Speculative Decoding: Eagle3",✅ Passing,✅ Passing
+"Speculative Decoding: DFlash",✅ Passing,✅ Passing
 "Speculative Decoding: Ngram",✅ Passing,✅ Passing
 "Step Pooling (Embedding)",✅ Passing,❓ Untested
 "async scheduler",✅ Passing,✅ Passing


### PR DESCRIPTION
## Summary
This PR adds **`Speculative Decoding: DFlash`** to the feature support matrices and documentation