### PR TITLE
[releases/v0.25.0] Cherry-pick #3157: Fix Llama-Guard-4 JAX path (five breakages)

### DIFF
--- a/tests/models/jax/test_llama_guard_4.py
+++ b/tests/models/jax/test_llama_guard_4.py
@@ -86,6 +86,27 @@ class MockVllmConfig:
         text_config_mock.num_attention_heads = 4
         text_config_mock.num_key_value_heads = 2
         text_config_mock.head_dim = 32
+        # Explicit numeric values: MagicMock auto-attrs are Mock objects and
+        # blow up only at forward time inside jitted math.
+        text_config_mock.num_layers = 2
+        text_config_mock.rms_norm_eps = 1e-5
+        text_config_mock.intermediate_size = 256
+        text_config_mock.hidden_act = "silu"
+        # transformers >= 5.6 layout: rope_theta lives in rope_parameters,
+        # the flat rope_theta attribute no longer exists, and rope_scaling
+        # is a property alias of rope_parameters. Llama-Guard-4 ships
+        # llama3-style scaling keys, so mirror that faithfully.
+        llama3_rope_parameters = {
+            "rope_type": "llama3",
+            "rope_theta": 500000.0,
+            "factor": 8.0,
+            "low_freq_factor": 1.0,
+            "high_freq_factor": 4.0,
+            "original_max_position_embeddings": 8192,
+        }
+        text_config_mock.rope_parameters = llama3_rope_parameters
+        text_config_mock.rope_scaling = llama3_rope_parameters
+        del text_config_mock.rope_theta
 
         hf_config_mock = MagicMock()
         hf_config_mock.text_config = text_config_mock
@@ -95,7 +116,11 @@ class MockVllmConfig:
         vision_config_mock.patch_size = 14
         vision_config_mock.hidden_size = 1408
         vision_config_mock.num_attention_heads = 16
-        vision_config_mock.rope_theta = 10000.0
+        vision_config_mock.rope_parameters = {
+            "rope_theta": 10000.0,
+            "rope_type": "default"
+        }
+        del vision_config_mock.rope_theta
         vision_config_mock.intermediate_size = 5632
         vision_config_mock.projector_input_dim = 4096
         vision_config_mock.projector_output_dim = 4096
@@ -270,3 +295,74 @@ class TestLlamaGuard4WeightLoader:
 
             # Check if the shape of the array passed to shard_put matches the model's expected shape.
             assert called_with_weight.shape == mock_param.value.shape
+
+
+class TestLlamaGuard4ForwardContract:
+    """Pins the forward-return contract expected by run_model's jit
+    out_shardings (kv_caches, hidden, aux_hidden_states, expert_ids)."""
+
+    def test_forward_returns_4_tuple(self, mock_vllm_config_llama_guard_4,
+                                     rng):
+        from tpu_inference.layers.common.attention_metadata import \
+            AttentionMetadata
+        from tpu_inference.runner.kv_cache import create_kv_caches
+
+        # Single-device mesh: the ragged-attention shard_map requires the
+        # tiny request metadata to divide the data axis evenly.
+        if not jax.devices():
+            pytest.skip("No JAX devices available for mesh creation.")
+        device_mesh = np.array(jax.local_devices()[:1]).reshape((1, 1, 1, 1))
+        mesh = Mesh(device_mesh,
+                    axis_names=('data', 'attn_dp', 'model', 'expert'))
+
+        with jax.set_mesh(mesh):
+            model = LlamaGuard4ForCausalLM(
+                vllm_config=mock_vllm_config_llama_guard_4,
+                rng=rng,
+                mesh=mesh,
+                force_random_weights=True)
+
+            # num_blocks must be divisible by the mesh's data-axis size
+            # (this file's mesh fixture uses all local devices).
+            kv_caches = create_kv_caches(
+                num_blocks=16,
+                block_size=32,
+                num_kv_heads=model.num_key_value_heads,
+                head_size=model.head_dim,
+                mesh=mesh,
+                layer_names=["layer"] * len(model.layers),
+                cache_dtype=jnp.bfloat16)
+
+            num_tokens = 8
+            num_reqs = 1
+            input_ids = jnp.ones((num_tokens, ), dtype=jnp.int32)
+            attention_metadata = AttentionMetadata(
+                input_positions=jnp.ones((num_tokens, ), dtype=jnp.int32),
+                block_tables=jnp.zeros((num_reqs, 4),
+                                       dtype=jnp.int32).reshape(-1),
+                seq_lens=jnp.ones((num_reqs, ), dtype=jnp.int32),
+                query_start_loc=jnp.ones((num_reqs + 1, ), dtype=jnp.int32),
+                request_distribution=jnp.array([0, 0, 0], dtype=jnp.int32),
+            )
+
+            out = model(kv_caches, input_ids, attention_metadata)
+
+        assert len(out) == 4
+        new_kv_caches, hidden, aux_hidden, expert_ids = out
+        assert len(new_kv_caches) == len(kv_caches)
+        assert hidden.shape == (num_tokens, model.hidden_size)
+        assert aux_hidden == []
+        assert expert_ids is None
+
+    def test_vision_rope_call_returns_jax_array(self):
+        from tpu_inference.layers.jax.rope import Llama4VisionRotaryEmbedding
+        rope = Llama4VisionRotaryEmbedding(image_size=336,
+                                           patch_size=14,
+                                           hidden_size=1408,
+                                           num_attention_heads=16,
+                                           rope_theta=10000.0,
+                                           dtype=jnp.bfloat16)
+        out = rope()
+        # Must be a concrete array, not an nnx.Param: newer JAX no longer
+        # implicitly converts nnx.Param via __jax_array__ inside jit.
+        assert isinstance(out, jax.Array)

--- a/tests/models/jax/utils/test_multi_modal_utils.py
+++ b/tests/models/jax/utils/test_multi_modal_utils.py
@@ -276,3 +276,39 @@ def test_flatten_pad_mm_embeds_exact_length():
 
     expected = np.concatenate([np.ones((2, 128)), np.ones((3, 128)) * 2])
     np.testing.assert_array_equal(result, expected)
+
+
+# --- Tests for convert_torch_tensor_to_jax ---
+
+
+def test_convert_torch_bf16_tensor_is_bit_exact():
+    """torch bf16 -> jax bf16 must be a bit-exact reinterpretation."""
+    import torch
+
+    from tpu_inference.models.jax.utils.multi_modal_utils import \
+        convert_torch_tensor_to_jax
+
+    t = torch.randn(2, 3, 14, 14, dtype=torch.float32).to(torch.bfloat16)
+    # Non-contiguous input must be handled too.
+    t_nc = t.transpose(1, 2)
+
+    out = convert_torch_tensor_to_jax(t_nc)
+
+    assert out.dtype == jnp.bfloat16
+    assert out.shape == tuple(t_nc.shape)
+    np.testing.assert_array_equal(np.asarray(out.view(jnp.int16)),
+                                  t_nc.contiguous().view(torch.int16).numpy())
+
+
+def test_convert_torch_f32_tensor():
+    import torch
+
+    from tpu_inference.models.jax.utils.multi_modal_utils import \
+        convert_torch_tensor_to_jax
+
+    t = torch.arange(12, dtype=torch.float32).reshape(3, 4)
+    out = convert_torch_tensor_to_jax(t)
+    assert out.dtype == jnp.bfloat16
+    np.testing.assert_allclose(np.asarray(out.astype(jnp.float32)),
+                               t.numpy(),
+                               rtol=1e-2)

--- a/tpu_inference/layers/jax/rope.py
+++ b/tpu_inference/layers/jax/rope.py
@@ -364,4 +364,6 @@ class Llama4VisionRotaryEmbedding(nnx.Module):
         self.freqs_cis_stacked.value = freqs_cis_stacked.astype(jnp.float32)
 
     def __call__(self) -> jax.Array:
-        return self.freqs_cis_stacked
+        # Return the underlying array: newer JAX no longer implicitly
+        # converts nnx.Param via __jax_array__ during abstractification.
+        return self.freqs_cis_stacked.value

--- a/tpu_inference/models/jax/llama_guard_4.py
+++ b/tpu_inference/models/jax/llama_guard_4.py
@@ -35,6 +35,8 @@ from tpu_inference.layers.jax.constants import KVCacheType
 from tpu_inference.layers.jax.layers import DenseFFW, Embedder, LMhead, RMSNorm
 from tpu_inference.layers.jax.rope import \
     Llama4VisionRotaryEmbedding
+from tpu_inference.layers.jax.rope_interface import (get_rope_scaling,
+                                                     get_rope_theta)
 from tpu_inference.layers.jax.misc import shard_put
 from tpu_inference.layers.jax.pp_utils import (PPMissingLayer,
                                                get_start_end_layer)
@@ -42,8 +44,8 @@ from tpu_inference.layers.jax.transformer_block import TransformerBlock
 from tpu_inference.logger import init_logger
 from tpu_inference.models.jax.llama4 import (JAXLlama4MultiModalProjector,
                                              JAXLlama4VisionModel)
-from tpu_inference.models.jax.utils.multi_modal_utils import \
-    merge_multimodal_embeddings
+from tpu_inference.models.jax.utils.multi_modal_utils import (
+    convert_torch_tensor_to_jax, merge_multimodal_embeddings)
 from tpu_inference.models.jax.jax_intermediate_tensor import \
     JaxIntermediateTensors
 from tpu_inference.models.jax.utils.weight_utils import (
@@ -372,9 +374,12 @@ class LlamaGuard4ForCausalLM(nnx.Module):
         intermediate_size = getattr(self.text_config, "intermediate_size",
                                     8192)
 
-        self.rope_theta_text = getattr(self.text_config, "rope_theta",
-                                       500000.0)
-        self.rope_scaling = getattr(self.text_config, "rope_scaling")
+        # transformers >= 5.6 moved rope_theta into the rope_parameters dict;
+        # get_rope_theta handles both layouts.
+        self.rope_theta_text = get_rope_theta(self.text_config, 500000.0)
+        # Normalized dict (factor -> scale_factor) or None; handles both the
+        # legacy rope_scaling attribute and the >=5.6 rope_parameters layout.
+        self.rope_scaling = get_rope_scaling(self.text_config)
 
         self.image_token_id = getattr(self.model_config.hf_config,
                                       "image_token_index")
@@ -402,7 +407,7 @@ class LlamaGuard4ForCausalLM(nnx.Module):
             patch_size=self.vision_config.patch_size,
             hidden_size=self.vision_config.hidden_size,
             num_attention_heads=self.vision_config.num_attention_heads,
-            rope_theta=self.vision_config.rope_theta,
+            rope_theta=get_rope_theta(self.vision_config, 10000.0),
             dtype=self.dtype,
         )
 
@@ -452,16 +457,7 @@ class LlamaGuard4ForCausalLM(nnx.Module):
                 num_key_value_heads=self.num_key_value_heads,
                 head_dim=self.head_dim,
                 rope_theta=self.rope_theta_text,
-                rope_scaling={
-                    "scale_factor":
-                    self.rope_scaling["factor"],
-                    "low_freq_factor":
-                    self.rope_scaling["low_freq_factor"],
-                    "high_freq_factor":
-                    self.rope_scaling["high_freq_factor"],
-                    "original_max_position_embeddings":
-                    self.rope_scaling["original_max_position_embeddings"]
-                },
+                rope_scaling=self.rope_scaling,
                 rngs=self.rng,
                 rope_input_ordering="interleaved",
                 # TODO (jacobplatin): we should refactor this to pass a dtype (or config) directly
@@ -594,7 +590,8 @@ class LlamaGuard4ForCausalLM(nnx.Module):
         attention_metadata: AttentionMetadata,
         inputs_embeds: Optional[jax.Array] = None,
         *args,
-    ) -> Tuple[List[KVCacheType], jax.Array]:
+    ) -> Tuple[List[KVCacheType], jax.Array, List[jax.Array],
+               Optional[jax.Array]]:
         is_prefill = False
 
         if self.is_first_rank:
@@ -607,23 +604,31 @@ class LlamaGuard4ForCausalLM(nnx.Module):
                     "Cannot run forward pass: Both input_ids and inputs_embeds are None."
                 )
         else:
-            # For pipeline parallelism (not active here, but good practice)
-            # x_TD would come from intermediate_tensors
-            pass
+            # Pipeline parallelism is not wired up for this model: __call__
+            # takes no intermediate_tensors, so x_TD would be unbound here.
+            raise NotImplementedError(
+                "[llama_guard_4] pipeline parallelism (is_first_rank=False) "
+                "is not supported; forward has no intermediate_tensors input."
+            )
 
         for (i, block) in enumerate(
                 islice(self.layers, self.start_layer, self.end_layer)):
             kv_cache = kv_caches[i]
-            new_kv_cache, x_TD = block(x_TD, is_prefill, kv_cache,
-                                       attention_metadata)
+            # TransformerBlock returns (kv_cache, hidden, expert_ids); the
+            # routed-experts output is unused here.
+            new_kv_cache, x_TD, _ = block(x_TD, is_prefill, kv_cache,
+                                          attention_metadata)
             jax.block_until_ready(x_TD)
             kv_caches[i] = new_kv_cache
 
+        # run_model jits the forward with a 4-tuple out_shardings:
+        # (kv_caches, hidden, aux_hidden_states, expert_ids).
         if not self.is_last_rank:
-            return kv_caches, JaxIntermediateTensors({"hidden_states": x_TD}), []
+            return kv_caches, JaxIntermediateTensors({"hidden_states":
+                                                      x_TD}), [], None
 
         final_activation_TD = self.final_norm(x_TD)
-        return kv_caches, final_activation_TD, []
+        return kv_caches, final_activation_TD, [], None
 
     def compute_logits(self, hidden_states: jax.Array) -> jax.Array:
         logits_TV = jnp.dot(hidden_states,
@@ -659,8 +664,11 @@ class LlamaGuard4ForCausalLM(nnx.Module):
         if pixel_values is None:
             return []
 
-        # Ensure JAX handling
-        pixel_values = jnp.asarray(pixel_values, dtype=jnp.bfloat16)
+        # Ensure JAX handling (torch bf16 cannot pass through numpy).
+        if isinstance(pixel_values, torch.Tensor):
+            pixel_values = convert_torch_tensor_to_jax(pixel_values)
+        else:
+            pixel_values = jnp.asarray(pixel_values, dtype=jnp.bfloat16)
 
         # 1. Transpose Input from NCHW to NHWC
         # vLLM/HF loaders typically give NCHW (Channels First)

--- a/tpu_inference/models/jax/utils/multi_modal_utils.py
+++ b/tpu_inference/models/jax/utils/multi_modal_utils.py
@@ -17,6 +17,7 @@ from typing import Optional, Union
 import jax
 import jax.numpy as jnp
 import numpy as np
+import torch
 from typing_extensions import TypeAlias
 from vllm.logger import init_logger
 
@@ -134,6 +135,22 @@ def normalize_mm_grid_thw(
     raise ValueError(
         "Incorrect type/shape of grid_thw. Expected (3,), (N, 3), or (B, N, 3)."
     )
+
+
+def convert_torch_tensor_to_jax(tensor: torch.Tensor,
+                                dtype: jnp.dtype = jnp.bfloat16) -> jax.Array:
+    """Convert a torch tensor (e.g. pixel_values) to a JAX array.
+
+    torch bfloat16 tensors cannot pass through numpy (unsupported
+    ScalarType), so reinterpret the bits via int16 and view back as
+    bfloat16; other dtypes go through float32.
+    """
+    if tensor.dtype == torch.bfloat16:
+        converted = tensor.contiguous().view(torch.int16).numpy().view(
+            jnp.bfloat16)
+    else:
+        converted = tensor.contiguous().float().numpy()
+    return jnp.asarray(converted, dtype=dtype)
 
 
 def reshape_mm_tensor(mm_input: object, name: str) -> jax.Array:


### PR DESCRIPTION
Cherry-pick of #3157 (merged to `main` as `9e818a308`) onto `releases/v0.25.0`.

## Why
The v0.25.0 release nightly ([build 22159](https://buildkite.com/tpu-commons/tpu-inference-ci/builds/22159)) fails all four Llama-Guard-4-12B accuracy jobs (text-only + multimodal, tpu6e + tpu7x) — five stacked breakages on a path re-exposed by #3142. Full root-cause write-up in #3157.

## Validation (already done on the release base)
- [tpu-inference-dev 667](https://buildkite.com/tpu-commons/tpu-inference-dev/builds/667): both nightly accuracy jobs (text-only + multimodal, tpu7x TP=2) green with the fix rebased on `releases/v0.25.0`.
- [tpu-inference-dev 669](https://buildkite.com/tpu-commons/tpu-inference-dev/builds/669): re-validation after review-feedback changes — both jobs green again.
- Unit tests: 35/35 locally on a TPU host.

Cherry-pick applied clean (the release branch head is the fork point of the fix branch, so this is byte-identical to what was validated).
