### PR TITLE
Harden convert_torch_tensor_to_jax and LG4 forward test (post-#3157 review follow-up)

### DIFF
--- a/tests/models/jax/test_llama_guard_4.py
+++ b/tests/models/jax/test_llama_guard_4.py
@@ -309,8 +309,10 @@ class TestLlamaGuard4ForwardContract:
 
         # Single-device mesh: the ragged-attention shard_map requires the
         # tiny request metadata to divide the data axis evenly.
-        if not jax.devices():
-            pytest.skip("No JAX devices available for mesh creation.")
+        # (jax.devices() raises rather than returning [] when no backend
+        # exists, so check the platform explicitly.)
+        if jax.devices()[0].platform != "tpu":
+            pytest.skip("Forward pass requires a TPU device.")
         device_mesh = np.array(jax.local_devices()[:1]).reshape((1, 1, 1, 1))
         mesh = Mesh(device_mesh,
                     axis_names=('data', 'attn_dp', 'model', 'expert'))
@@ -341,7 +343,7 @@ class TestLlamaGuard4ForwardContract:
                 block_tables=jnp.zeros((num_reqs, 4),
                                        dtype=jnp.int32).reshape(-1),
                 seq_lens=jnp.ones((num_reqs, ), dtype=jnp.int32),
-                query_start_loc=jnp.ones((num_reqs + 1, ), dtype=jnp.int32),
+                query_start_loc=jnp.array([0, num_tokens], dtype=jnp.int32),
                 request_distribution=jnp.array([0, 0, 0], dtype=jnp.int32),
             )
 

--- a/tests/models/jax/utils/test_multi_modal_utils.py
+++ b/tests/models/jax/utils/test_multi_modal_utils.py
@@ -312,3 +312,18 @@ def test_convert_torch_f32_tensor():
     np.testing.assert_allclose(np.asarray(out.astype(jnp.float32)),
                                t.numpy(),
                                rtol=1e-2)
+
+
+def test_convert_torch_int_tensor_preserves_values():
+    """Integer payloads must not round-trip through float/bf16 (values
+    beyond the bf16 mantissa would silently corrupt)."""
+    import torch
+
+    from tpu_inference.models.jax.utils.multi_modal_utils import \
+        convert_torch_tensor_to_jax
+
+    t = torch.tensor([[0, 1, 257, 65537], [200092, -7, 1 << 20, 3]],
+                     dtype=torch.int64)
+    out = convert_torch_tensor_to_jax(t)
+    assert jnp.issubdtype(out.dtype, jnp.integer)
+    np.testing.assert_array_equal(np.asarray(out), t.numpy())

--- a/tpu_inference/models/jax/utils/multi_modal_utils.py
+++ b/tpu_inference/models/jax/utils/multi_modal_utils.py
@@ -143,13 +143,17 @@ def convert_torch_tensor_to_jax(tensor: torch.Tensor,
 
     torch bfloat16 tensors cannot pass through numpy (unsupported
     ScalarType), so reinterpret the bits via int16 and view back as
-    bfloat16; other dtypes go through float32.
+    bfloat16; other floating dtypes go through float32 and are cast to
+    `dtype`. Integer/bool tensors keep their own dtype — casting them to
+    a float dtype would silently corrupt values beyond the mantissa.
     """
     if tensor.dtype == torch.bfloat16:
         converted = tensor.contiguous().view(torch.int16).numpy().view(
             jnp.bfloat16)
-    else:
+    elif tensor.dtype.is_floating_point:
         converted = tensor.contiguous().float().numpy()
+    else:
+        return jnp.asarray(tensor.contiguous().numpy())
     return jnp.asarray(converted, dtype=dtype)
 
 


### PR DESCRIPTION
Follow-up from the #3157 review (round 2), three non-blocking hardening items:

1. **`convert_torch_tensor_to_jax` integer guard** — the shared helper routed every non-bf16 dtype through `.float()` and cast to the bf16 default, which silently corrupts integer payloads beyond the bf16 mantissa. Integer/bool tensors now keep their own dtype. This matters before `gemma4_mm.py` / `mm_encoder_jit_manager.py` migrate onto the helper (their inline copies convert int tensors like `pixel_position_ids`). Test with >2^16 values added.
2. **LG4 forward test skip-guard** — `if not jax.devices()` can never fire (it raises instead of returning empty); check `platform != "tpu"` so the test skips instead of failing on CPU-only hosts. Verified: skips under `JAX_PLATFORMS=cpu`, passes on TPU.
3. **Realistic `query_start_loc`** — `[0, num_tokens]` cumsum instead of degenerate all-ones metadata.

Remaining tracked follow-up: migrate the two inline bf16 bit-view copies (`gemma4_mm.py`, `mm_encoder_jit_manager.py`) onto the shared helper.
