### PR TITLE
Pin gemma-4 E2B/E4B nightly tests to the JAX path (MODEL_IMPL_TYPE=flax_nnx)

### DIFF
--- a/.buildkite/models/google_gemma-4-E2B-it.yml
+++ b/.buildkite/models/google_gemma-4-E2B-it.yml
@@ -16,6 +16,17 @@
 # gemma-4-it is BOS-sensitive — raw prompts produce token-repetition
 # garbage on both GPU vllm-pytorch and JAX (model property, not a
 # correctness bug in our path).
+#
+# MODEL_IMPL_TYPE is pinned to flax_nnx on every TPU step: only the JAX
+# implementation is enabled for the gemma-4 E-series. The vllm/torchax
+# path is not supported — vLLM's Gemma4ForConditionalGeneration caches
+# per-layer embeddings in a plain-attribute tensor via in-place copy_()
+# (gemma4_mm.py embed_input_ids), which torchax cannot dispatch during
+# the JAX precompile (AttributeError: 'Tensor' object has no attribute
+# '_elem'), and the torchax attention backend does not plumb
+# update_kv_cache=False for the E-series KV-shared layers. Without the
+# pin, the nightly MODEL_IMPL_TYPE=vllm variant inherits the build-level
+# env and fails.
 
 steps:
   - label: "${TPU_VERSION:-tpu6e} Unit tests for google/gemma-4-E2B-it"
@@ -23,6 +34,8 @@ steps:
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "flax_nnx"
     # Default RPA v3 is the production attention path for E2B (fully
     # deterministic gsm8k across runs). To exercise the experimental batched
     # RPA kernel locally or on a dev pipeline, set:
@@ -56,6 +69,7 @@ steps:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     soft_fail: true
     env:
+      MODEL_IMPL_TYPE: "flax_nnx"
       TEST_MODEL: google/gemma-4-E2B-it
       TENSOR_PARALLEL_SIZE: 1
       # USE_CHAT_TEMPLATE=1 routes lm_eval through apply_chat_template +
@@ -90,6 +104,7 @@ steps:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     soft_fail: true
     env:
+      MODEL_IMPL_TYPE: "flax_nnx"
       TEST_MODEL: google/gemma-4-E2B-it
       TENSOR_PARALLEL_SIZE: 1
       # BENCH_DATASET unset -> mm_bench_recipe.sh defaults to the random-mm

--- a/.buildkite/models/google_gemma-4-E4B-it.yml
+++ b/.buildkite/models/google_gemma-4-E4B-it.yml
@@ -19,6 +19,17 @@
 # (TENSOR_PARALLEL_SIZE_SINGLE=1 for v6e, =2 for v7x).
 # Uses --use-chat-template because gemma-4-it is BOS-sensitive — raw
 # prompts produce token-repetition garbage on both GPU vllm-pytorch and JAX.
+#
+# MODEL_IMPL_TYPE is pinned to flax_nnx on every TPU step: only the JAX
+# implementation is enabled for the gemma-4 E-series. The vllm/torchax
+# path is not supported — vLLM's Gemma4ForConditionalGeneration caches
+# per-layer embeddings in a plain-attribute tensor via in-place copy_()
+# (gemma4_mm.py embed_input_ids), which torchax cannot dispatch during
+# the JAX precompile (AttributeError: 'Tensor' object has no attribute
+# '_elem'), and the torchax attention backend does not plumb
+# update_kv_cache=False for the E-series KV-shared layers. Without the
+# pin, the nightly MODEL_IMPL_TYPE=vllm variant inherits the build-level
+# env and fails.
 
 steps:
   - label: "${TPU_VERSION:-tpu6e} Unit tests for google/gemma-4-E4B-it"
@@ -26,6 +37,8 @@ steps:
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     soft_fail: true
+    env:
+      MODEL_IMPL_TYPE: "flax_nnx"
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh \
@@ -52,6 +65,7 @@ steps:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     soft_fail: true
     env:
+      MODEL_IMPL_TYPE: "flax_nnx"
       TEST_MODEL: google/gemma-4-E4B-it
       TENSOR_PARALLEL_SIZE: "${TENSOR_PARALLEL_SIZE_SINGLE:-1}"
       # USE_CHAT_TEMPLATE=1 routes lm_eval through apply_chat_template +
@@ -88,6 +102,7 @@ steps:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     soft_fail: true
     env:
+      MODEL_IMPL_TYPE: "flax_nnx"
       TEST_MODEL: google/gemma-4-E4B-it
       TENSOR_PARALLEL_SIZE: "${TENSOR_PARALLEL_SIZE_SINGLE:-1}"
       # BENCH_DATASET unset -> mm_bench_recipe.sh defaults to the random-mm


### PR DESCRIPTION
## Problem

Every nightly `MODEL_IMPL_TYPE=vllm` build fails on the gemma-4 E2B/E4B Accuracy steps, on both tpu6e and tpu7x (e.g. [build 22240](https://buildkite.com/tpu-commons/tpu-inference-ci/builds/22240#019f5a99-3e6d-47ae-a9d6-8fcef978e05f), and all 11 prior vllm-variant nightlies). The same tests are green in the default (JAX-path) nightly.

The E-series models were enabled for the JAX implementation only, but the vllm-variant nightly sweeps all `.buildkite/models` ymls with a build-level `MODEL_IMPL_TYPE=vllm`, pushing them through the unsupported vllm/torchax path.

## Root cause of the crash

During the JAX precompile (`capture_model` → `embed_input_ids_func`):

```
File "vllm/model_executor/models/gemma4_mm.py", line 1557, in embed_input_ids
  self.per_layer_embeddings[: per_layer_inputs.shape[0]].copy_(
...
File "torchax/ops/jaten.py", line 90, in _aten_copy
  x._elem = y._elem.astype(x._elem.dtype)
AttributeError: 'Tensor' object has no attribute '_elem'
```

vLLM's `Gemma4ForConditionalGeneration` pre-allocates `per_layer_embeddings` as a plain (unregistered) tensor attribute and fills it with an in-place `copy_()` inside `embed_input_ids`. The torchax bridge converts registered params/buffers to torchax tensors but not plain attributes, so the precompile crashes mixing the two tensor types. Separately, the torchax attention backend doesn't plumb `update_kv_cache=False` for the E-series KV-shared layers, so even without the crash the path would corrupt shared KV caches.

The Unit-test steps "pass" under the vllm variant only because they set `SKIP_JAX_PRECOMPILE=1` and `offline_inference.py` doesn't verify output content.

The larger gemma-4 variants (26B-A4B, 31B) are unaffected: they have no per-layer embeddings (`hidden_size_per_layer_input` unset → `per_layer_embeddings = None`), which is why they stay green on the vllm variant.

## Fix

Pin `MODEL_IMPL_TYPE: "flax_nnx"` on every TPU-executing step (UnitTest, Accuracy, Benchmark) of the two E-series ymls, so both nightly variants run the supported JAX implementation. Step-level env overrides the build-level env — same pattern as `deepseek-ai_DeepSeek-R1.yml`. The default (auto) nightly is unaffected since `auto` already resolves gemma-4 to `flax_nnx`.

Enabling the vllm/torchax path for the E-series (handling the PLE caching pattern + KV-share plumbing) is a separate bringup effort, out of scope here.

## Test

- `yaml.safe_load` parses both files; pins verified present on all 6 TPU steps and absent on record steps.
- CI-only change (nightly model ymls); the pinned value on the default nightly reproduces today's passing configuration.