### PR TITLE
[MTP] Mamba state rollback for speculative decoding

### DIFF
--- a/tests/runner/test_tpu_runner.py
+++ b/tests/runner/test_tpu_runner.py
@@ -861,8 +861,9 @@ class TestTPUJaxRunner:
         mock_sharding_config.expert_size = 1
         mock_sharding_config.tp_size = 1
         mock_sharding_config.decode_cp_size = 1
+        mock_sharding_config.prefill_cp_size = 1
         vllm_config.sharding_config = mock_sharding_config
-        mesh_shape = (8, 1, 1, 1, 1, 1)
+        mesh_shape = (8, 1, 1, 1, 1, 1, 1)
 
         # Case A: envs.NEW_MODEL_DESIGN = True and envs.TPU_MESH_SORT_BY_COORDS = True
         with patch('tpu_inference.runner.tpu_runner.envs.NEW_MODEL_DESIGN', True), \

--- a/tests/spec_decode/test_utils.py
+++ b/tests/spec_decode/test_utils.py
@@ -136,14 +136,19 @@ def test_extract_last_sampled_tokens_matches_parse_output(
 
     mesh = _make_mesh()
     with jax.set_mesh(mesh):
-        last_sampled, num_rejected = extract_last_sampled_tokens(
-            metadata, sampled, num_speculative, VOCAB_SIZE, max_num_seq, mesh)
+        (last_sampled, num_rejected,
+         mamba_read_offsets) = extract_last_sampled_tokens(
+             metadata, sampled, num_speculative, VOCAB_SIZE, max_num_seq, mesh)
 
     ref_last, ref_num_rej = _reference(sampled, num_draft_cpu, VOCAB_SIZE,
                                        max_num_seq)
 
     np.testing.assert_array_equal(np.asarray(last_sampled), ref_last)
     np.testing.assert_array_equal(np.asarray(num_rejected), ref_num_rej)
+    padded_num_draft = np.zeros(max_num_seq, dtype=np.int32)
+    padded_num_draft[:len(num_draft_cpu)] = num_draft_cpu
+    np.testing.assert_array_equal(np.asarray(mamba_read_offsets),
+                                  padded_num_draft - ref_num_rej)
 
 
 def test_filter_speculative_logprobs():

--- a/tpu_inference/layers/common/attention_metadata.py
+++ b/tpu_inference/layers/common/attention_metadata.py
@@ -55,26 +55,16 @@ class AttentionMetadata(object):
     # None for models without mamba layers; pure-mamba models would also
     # use this field, only hybrid models exercise it today.
     mamba_state_indices: jax.Array | None = None
-    # (mamba_num_blocks,) int32 — per-*slot* read offset for speculative
-    # decoding with mamba layers. `mamba_slot_read_offsets[base_slot]` is
-    # `num_accepted - 1` from the request's most recent verify step: the GDN
-    # kernel reads the request's initial state from
-    # `base_slot + offset` (the checkpoint of the last accepted token) and
-    # writes fresh checkpoints starting at `base_slot`. Indexed by physical
-    # slot (not batch position) so the value survives requests being
-    # rescheduled, condensed, or skipped for several steps. Updated on
-    # device after each rejection-sampling step; None unless the model has
-    # mamba layers *and* speculative decoding is enabled.
+    # (mamba_num_blocks,) int32 — mamba + spec decode only, else None. Per-slot
+    # state read offset (num_accepted - 1 from the last verify step): the GDN
+    # kernel resumes from checkpoint `base_slot + offset` and writes new
+    # checkpoints from `base_slot`. Indexed by physical slot so it survives
+    # rescheduling.
     mamba_slot_read_offsets: jax.Array | None = None
-    # (3 * dp_size,) int32 — GDN-specific request distribution, same
-    # 3-counters-per-rank format as `request_distribution` but with the
-    # first segment covering all *windowed* sequences (plain decodes and
-    # speculative verify windows of up to num_spec + 1 tokens) instead of
-    # only 1-token decodes. The persistent batch is ordered
-    # [decode][verify][prefill/mixed] so both segmentations hold at once:
-    # ragged paged attention keeps its 1-token decode front segment while
-    # the GDN kernel runs its windowed mode over the first two groups.
-    # None unless the model has mamba layers and spec decoding is enabled.
+    # (3 * dp_size,) int32 — mamba + spec decode only, else None. Like
+    # `request_distribution`, but its first segment counts all windowed
+    # sequences (decodes + verify windows), so the GDN kernel runs its windowed
+    # mode over the [decode][verify] prefix of the batch.
     mamba_request_distribution: jax.Array | None = None
 
     # (max_num_seqs, ) int32 — PCP only. For a single request, it is [rank*C, (2*pcp-1-rank)*C].

--- a/tpu_inference/layers/common/attention_metadata.py
+++ b/tpu_inference/layers/common/attention_metadata.py
@@ -27,6 +27,8 @@ import jax
         "query_start_loc",
         "request_distribution",
         "mamba_state_indices",
+        "mamba_slot_read_offsets",
+        "mamba_request_distribution",
         "pcp_q_pos_offsets",
         "pcp_kv_cache_lens",
     ],
@@ -53,6 +55,27 @@ class AttentionMetadata(object):
     # None for models without mamba layers; pure-mamba models would also
     # use this field, only hybrid models exercise it today.
     mamba_state_indices: jax.Array | None = None
+    # (mamba_num_blocks,) int32 — per-*slot* read offset for speculative
+    # decoding with mamba layers. `mamba_slot_read_offsets[base_slot]` is
+    # `num_accepted - 1` from the request's most recent verify step: the GDN
+    # kernel reads the request's initial state from
+    # `base_slot + offset` (the checkpoint of the last accepted token) and
+    # writes fresh checkpoints starting at `base_slot`. Indexed by physical
+    # slot (not batch position) so the value survives requests being
+    # rescheduled, condensed, or skipped for several steps. Updated on
+    # device after each rejection-sampling step; None unless the model has
+    # mamba layers *and* speculative decoding is enabled.
+    mamba_slot_read_offsets: jax.Array | None = None
+    # (3 * dp_size,) int32 — GDN-specific request distribution, same
+    # 3-counters-per-rank format as `request_distribution` but with the
+    # first segment covering all *windowed* sequences (plain decodes and
+    # speculative verify windows of up to num_spec + 1 tokens) instead of
+    # only 1-token decodes. The persistent batch is ordered
+    # [decode][verify][prefill/mixed] so both segmentations hold at once:
+    # ragged paged attention keeps its 1-token decode front segment while
+    # the GDN kernel runs its windowed mode over the first two groups.
+    # None unless the model has mamba layers and spec decoding is enabled.
+    mamba_request_distribution: jax.Array | None = None
 
     # (max_num_seqs, ) int32 — PCP only. For a single request, it is [rank*C, (2*pcp-1-rank)*C].
     pcp_q_pos_offsets: jax.Array | None = None

--- a/tpu_inference/layers/common/gdn_attention.py
+++ b/tpu_inference/layers/common/gdn_attention.py
@@ -15,7 +15,6 @@
 Bridge the torch gdn_attention_core op for gated deltanet attention TPU impl
 
 """
-import functools
 from typing import Optional, Tuple
 
 import jax
@@ -133,50 +132,50 @@ def run_jax_gdn_attention(
 
     tp_size = get_mesh_shape_product(mesh, ShardingAxisName.ATTN_HEAD)
 
-    kernel_kwargs = dict(
-        n_kq=n_kq // tp_size,
-        n_v=n_v // tp_size,
-        d_k=d_k,
-        d_v=d_v,
-        kernel_size=kernel_size,
-        num_spec_tokens=num_spec_tokens,
-    )
-
-    if slot_read_offsets is None:
-        p_run_jax_gdn_attention_local = functools.partial(
-            wrapper.fused_conv1d_gdn, **kernel_kwargs)
-        args = ()
-    else:
-
-        def p_run_jax_gdn_attention_local(j_mixed_qkv, j_b, j_a, conv_state,
-                                          recurrent_state, j_conv_weight,
-                                          j_conv_bias, j_A_log, j_dt_bias,
-                                          query_start_loc, state_indices,
-                                          distribution, seq_lens,
-                                          slot_read_offsets):
+    def p_run_jax_gdn_attention_local(j_mixed_qkv,
+                                      j_b,
+                                      j_a,
+                                      conv_state,
+                                      recurrent_state,
+                                      j_conv_weight,
+                                      j_conv_bias,
+                                      j_A_log,
+                                      j_dt_bias,
+                                      query_start_loc,
+                                      state_indices,
+                                      distribution,
+                                      seq_lens,
+                                      slot_read_offsets=None):
+        read_offsets = None
+        if slot_read_offsets is not None:
             # Per-sequence read offsets: `state_indices` holds rank-local
             # base slots, `slot_read_offsets` is the rank-local shard of the
             # per-slot offset buffer.
             read_offsets = slot_read_offsets[state_indices]
-            return wrapper.fused_conv1d_gdn(
-                j_mixed_qkv,
-                j_b,
-                j_a,
-                conv_state,
-                recurrent_state,
-                j_conv_weight,
-                j_conv_bias,
-                j_A_log,
-                j_dt_bias,
-                query_start_loc,
-                state_indices,
-                distribution,
-                seq_lens,
-                read_offsets,
-                **kernel_kwargs,
-            )
+        return wrapper.fused_conv1d_gdn(
+            j_mixed_qkv,
+            j_b,
+            j_a,
+            conv_state,
+            recurrent_state,
+            j_conv_weight,
+            j_conv_bias,
+            j_A_log,
+            j_dt_bias,
+            query_start_loc,
+            state_indices,
+            distribution,
+            seq_lens,
+            read_offsets,
+            n_kq=n_kq // tp_size,
+            n_v=n_v // tp_size,
+            d_k=d_k,
+            d_v=d_v,
+            kernel_size=kernel_size,
+            num_spec_tokens=num_spec_tokens,
+        )
 
-        args = (slot_read_offsets, )
+    args = () if slot_read_offsets is None else (slot_read_offsets, )
 
     mapped_fn = jax.shard_map(
         p_run_jax_gdn_attention_local,

--- a/tpu_inference/layers/common/gdn_attention.py
+++ b/tpu_inference/layers/common/gdn_attention.py
@@ -82,11 +82,9 @@ def run_jax_gdn_attention(
         kernel_size: Convolution kernel size.
         mesh: The device mesh for distributed computation.
         config: Configuration for implementation selection.
-        slot_read_offsets: Optional tensor of shape `(num_blocks,)` — per
-          physical slot mamba read offset for speculative decoding. Gathered
-          per sequence (`slot_read_offsets[state_indices]`) inside the shard
-          so the kernel resumes each verify window from the checkpoint of the
-          last accepted token. Required iff `num_spec_tokens > 0`.
+        slot_read_offsets: Optional `(num_blocks,)` per-slot mamba read offset
+          for spec decoding, gathered per request as
+          `slot_read_offsets[state_indices]`. Required iff `num_spec_tokens > 0`.
         num_spec_tokens: Number of speculative draft tokens (0 disables the
           spec-decode windowed mode).
 
@@ -148,9 +146,8 @@ def run_jax_gdn_attention(
                                       slot_read_offsets=None):
         read_offsets = None
         if slot_read_offsets is not None:
-            # Per-sequence read offsets: `state_indices` holds rank-local
-            # base slots, `slot_read_offsets` is the rank-local shard of the
-            # per-slot offset buffer.
+            # `state_indices` are rank-local base slots; `slot_read_offsets`
+            # is the rank-local shard of the per-slot offset buffer.
             read_offsets = slot_read_offsets[state_indices]
         return wrapper.fused_conv1d_gdn(
             j_mixed_qkv,

--- a/tpu_inference/layers/common/gdn_attention.py
+++ b/tpu_inference/layers/common/gdn_attention.py
@@ -114,9 +114,10 @@ def run_jax_gdn_attention(
         P(ShardingAxisName.ATTN_DATA),  # distribution
         P(ShardingAxisName.ATTN_DATA),  # seq_lens
     )
-    if slot_read_offsets is not None:
-        in_specs = in_specs + (P(ShardingAxisName.ATTN_DATA),
-                               )  # slot_read_offsets
+    # slot_read_offsets is an optional operand: when absent it is passed as
+    # None with a matching None spec (no sharded array).
+    in_specs = in_specs + (P(ShardingAxisName.ATTN_DATA) if slot_read_offsets
+                           is not None else None, )  # slot_read_offsets
 
     out_specs = (
         (
@@ -130,20 +131,12 @@ def run_jax_gdn_attention(
 
     tp_size = get_mesh_shape_product(mesh, ShardingAxisName.ATTN_HEAD)
 
-    def p_run_jax_gdn_attention_local(j_mixed_qkv,
-                                      j_b,
-                                      j_a,
-                                      conv_state,
-                                      recurrent_state,
-                                      j_conv_weight,
-                                      j_conv_bias,
-                                      j_A_log,
-                                      j_dt_bias,
-                                      query_start_loc,
-                                      state_indices,
-                                      distribution,
-                                      seq_lens,
-                                      slot_read_offsets=None):
+    def p_run_jax_gdn_attention_local(j_mixed_qkv, j_b, j_a, conv_state,
+                                      recurrent_state, j_conv_weight,
+                                      j_conv_bias, j_A_log, j_dt_bias,
+                                      query_start_loc, state_indices,
+                                      distribution, seq_lens,
+                                      slot_read_offsets):
         read_offsets = None
         if slot_read_offsets is not None:
             # `state_indices` are rank-local base slots; `slot_read_offsets`
@@ -172,8 +165,6 @@ def run_jax_gdn_attention(
             num_spec_tokens=num_spec_tokens,
         )
 
-    args = () if slot_read_offsets is None else (slot_read_offsets, )
-
     mapped_fn = jax.shard_map(
         p_run_jax_gdn_attention_local,
         mesh=mesh,
@@ -196,7 +187,7 @@ def run_jax_gdn_attention(
         state_indices,
         distribution,
         seq_lens,
-        *args,
+        slot_read_offsets,
     )
 
     return (new_conv_state, new_recurrent_state), output

--- a/tpu_inference/layers/common/gdn_attention.py
+++ b/tpu_inference/layers/common/gdn_attention.py
@@ -47,6 +47,8 @@ def run_jax_gdn_attention(
     d_v: int,
     kernel_size: int,
     mesh: jax.sharding.Mesh,
+    slot_read_offsets: Optional[jnp.ndarray] = None,
+    num_spec_tokens: int = 0,
 ) -> Tuple[Tuple[jnp.ndarray, jnp.ndarray], jnp.ndarray]:
     """Runs the Jax GDN attention mechanism.
 
@@ -81,6 +83,13 @@ def run_jax_gdn_attention(
         kernel_size: Convolution kernel size.
         mesh: The device mesh for distributed computation.
         config: Configuration for implementation selection.
+        slot_read_offsets: Optional tensor of shape `(num_blocks,)` — per
+          physical slot mamba read offset for speculative decoding. Gathered
+          per sequence (`slot_read_offsets[state_indices]`) inside the shard
+          so the kernel resumes each verify window from the checkpoint of the
+          last accepted token. Required iff `num_spec_tokens > 0`.
+        num_spec_tokens: Number of speculative draft tokens (0 disables the
+          spec-decode windowed mode).
 
     Returns:
         A tuple containing:
@@ -108,6 +117,9 @@ def run_jax_gdn_attention(
         P(ShardingAxisName.ATTN_DATA),  # distribution
         P(ShardingAxisName.ATTN_DATA),  # seq_lens
     )
+    if slot_read_offsets is not None:
+        in_specs = in_specs + (P(ShardingAxisName.ATTN_DATA),
+                               )  # slot_read_offsets
 
     out_specs = (
         (
@@ -121,14 +133,50 @@ def run_jax_gdn_attention(
 
     tp_size = get_mesh_shape_product(mesh, ShardingAxisName.ATTN_HEAD)
 
-    p_run_jax_gdn_attention_local = functools.partial(
-        wrapper.fused_conv1d_gdn,
+    kernel_kwargs = dict(
         n_kq=n_kq // tp_size,
         n_v=n_v // tp_size,
         d_k=d_k,
         d_v=d_v,
         kernel_size=kernel_size,
+        num_spec_tokens=num_spec_tokens,
     )
+
+    if slot_read_offsets is None:
+        p_run_jax_gdn_attention_local = functools.partial(
+            wrapper.fused_conv1d_gdn, **kernel_kwargs)
+        args = ()
+    else:
+
+        def p_run_jax_gdn_attention_local(j_mixed_qkv, j_b, j_a, conv_state,
+                                          recurrent_state, j_conv_weight,
+                                          j_conv_bias, j_A_log, j_dt_bias,
+                                          query_start_loc, state_indices,
+                                          distribution, seq_lens,
+                                          slot_read_offsets):
+            # Per-sequence read offsets: `state_indices` holds rank-local
+            # base slots, `slot_read_offsets` is the rank-local shard of the
+            # per-slot offset buffer.
+            read_offsets = slot_read_offsets[state_indices]
+            return wrapper.fused_conv1d_gdn(
+                j_mixed_qkv,
+                j_b,
+                j_a,
+                conv_state,
+                recurrent_state,
+                j_conv_weight,
+                j_conv_bias,
+                j_A_log,
+                j_dt_bias,
+                query_start_loc,
+                state_indices,
+                distribution,
+                seq_lens,
+                read_offsets,
+                **kernel_kwargs,
+            )
+
+        args = (slot_read_offsets, )
 
     mapped_fn = jax.shard_map(
         p_run_jax_gdn_attention_local,
@@ -152,6 +200,7 @@ def run_jax_gdn_attention(
         state_indices,
         distribution,
         seq_lens,
+        *args,
     )
 
     return (new_conv_state, new_recurrent_state), output

--- a/tpu_inference/layers/vllm/custom_ops/gdn_attention_op.py
+++ b/tpu_inference/layers/vllm/custom_ops/gdn_attention_op.py
@@ -68,6 +68,13 @@ def gdn_attention_core_tpu(
     query_start_loc = first_attn_metadata.query_start_loc
     seq_lens = first_attn_metadata.seq_lens
     state_indices = first_attn_metadata.mamba_state_indices
+    slot_read_offsets = first_attn_metadata.mamba_slot_read_offsets
+    if first_attn_metadata.mamba_request_distribution is not None:
+        # Spec decoding: the GDN windowed segment covers both 1-token
+        # decodes and speculative verify windows (the batch is ordered
+        # [decode][verify][prefill/mixed]); RPA keeps using
+        # `request_distribution` with its 1-token decode front segment.
+        request_distribution = first_attn_metadata.mamba_request_distribution
 
     layer_module = fc.no_compile_layers[layer_name]
     vllm_context = get_vllm_model_wrapper_context()
@@ -108,6 +115,20 @@ def gdn_attention_core_tpu(
         conv_state_in = conv_state[:, :kernel_size - 1, :]
     else:
         conv_state_in = conv_state
+
+    # Speculative decoding: vLLM's MambaSpec widens the conv state by
+    # `num_spec` columns, so the number of draft tokens is statically
+    # recoverable from the allocated shape. The extra columns themselves are
+    # unused on TPU (rollback keeps one full checkpoint per group slot
+    # instead of a rolling window); only the first kernel_size - 1 columns
+    # per slot hold data.
+    num_spec_tokens = 0
+    if slot_read_offsets is not None:
+        num_spec_tokens = state_len - (kernel_size - 1)
+        assert num_spec_tokens > 0, (
+            "mamba_slot_read_offsets is set but the conv state has no "
+            f"speculative columns (state_len={state_len}, "
+            f"kernel_size={kernel_size})")
 
     # Index mamba state by the per-request slot id from
     # `InputBatch.mamba_state_indices_cpu`, not by `block_tables[:, 0]`
@@ -156,6 +177,8 @@ def gdn_attention_core_tpu(
          d_v,
          kernel_size,
          mesh=mesh,
+         slot_read_offsets=slot_read_offsets,
+         num_spec_tokens=num_spec_tokens,
      )
     if state_len > kernel_size - 1:
         remaining_old_state = conv_state[:, kernel_size - 1:, :]

--- a/tpu_inference/runner/compilation_manager.py
+++ b/tpu_inference/runner/compilation_manager.py
@@ -407,6 +407,16 @@ class CompilationManager:
                                                sharding=metadata_attn_sharding)
         else:
             mamba_state_indices = None
+        # Match `_prepare_inputs`: the spec-decode mamba fields are set iff
+        # the model has mamba layers and spec decoding is enabled.
+        mamba_slot_read_offsets = self.runner.mamba_slot_read_offsets
+        if mamba_slot_read_offsets is not None:
+            mamba_request_distribution = device_array(
+                self.runner.mesh,
+                np.array([0, 0, 0] * dp_size, dtype=np.int32),
+                sharding=metadata_attn_sharding)
+        else:
+            mamba_request_distribution = None
 
         def build_block_table(kv_cache_gid: int) -> jax.Array:
             block_table_obj = self.runner.input_batch.block_table[kv_cache_gid]
@@ -427,6 +437,8 @@ class CompilationManager:
                 query_start_loc=query_start_loc,
                 request_distribution=request_distribution,
                 mamba_state_indices=mamba_state_indices,
+                mamba_slot_read_offsets=mamba_slot_read_offsets,
+                mamba_request_distribution=mamba_request_distribution,
                 padded_num_reqs=num_reqs,
                 pcp_kv_cache_lens=pcp_kv_cache_lens,
                 pcp_q_pos_offsets=pcp_q_pos_offsets,
@@ -1185,12 +1197,38 @@ class CompilationManager:
         self._precompile_process_and_extend_logits()
         self._precompile_extend_logits_simple()
         self._precompile_select_from_array_spec_decode()
+        self._precompile_update_mamba_slot_read_offsets()
         if self.runner.speculative_config.method == "eagle3":
             self._precompile_eagle3_helpers()
         elif self.runner.speculative_config.method == "dflash":
             self._precompile_dflash_helpers()
         elif self.runner.speculative_config.method == "mtp":
             self._precompile_mtp_helpers()
+
+    def _precompile_update_mamba_slot_read_offsets(self) -> None:
+        if self.runner.mamba_slot_read_offsets is None:
+            return
+        logger.info("Compiling _update_mamba_slot_read_offsets_fn.")
+        from tpu_inference.runner.tpu_runner import \
+            _update_mamba_slot_read_offsets_fn
+        data_parallel_attn_sharding = NamedSharding(
+            self.runner.mesh, PartitionSpec(ShardingAxisName.ATTN_DATA))
+        state_indices = self._create_dummy_tensor(
+            (self.runner.max_num_reqs, ),
+            jnp.int32,
+            sharding=data_parallel_attn_sharding)
+        read_offsets = self._create_dummy_tensor(
+            (self.runner.max_num_reqs, ),
+            jnp.int32,
+            sharding=data_parallel_attn_sharding)
+        self._run_compilation(
+            f"worker{self.runner.rank} _update_mamba_slot_read_offsets_fn",
+            _update_mamba_slot_read_offsets_fn,
+            self.runner.mamba_slot_read_offsets,
+            state_indices,
+            read_offsets,
+            self.runner.mesh,
+        )
 
     def _precompile_select_from_array_spec_decode(self) -> None:
         logger.info("Compiling select_from_array with different input shapes.")
@@ -1430,6 +1468,17 @@ class CompilationManager:
                 sharding=dp_sharding)
         else:
             eagle3_mamba_state_indices = None
+        # The drafter's metadata is derived from the target metadata via
+        # `dataclasses.replace`, so the spec-decode mamba fields (unused by
+        # the pure-attention drafter) are still part of its pytree signature.
+        eagle3_mamba_slot_read_offsets = self.runner.mamba_slot_read_offsets
+        if eagle3_mamba_slot_read_offsets is not None:
+            eagle3_mamba_request_distribution = device_array(
+                self.runner.mesh,
+                np.array([0, 0, 0] * dp_size, dtype=np.int32),
+                sharding=dp_sharding)
+        else:
+            eagle3_mamba_request_distribution = None
 
         num_reqs_dp = self._create_dummy_tensor((dp_size, ),
                                                 jnp.int32,
@@ -1447,6 +1496,9 @@ class CompilationManager:
                     query_start_loc=query_start_loc,
                     request_distribution=request_distribution,
                     mamba_state_indices=eagle3_mamba_state_indices,
+                    mamba_slot_read_offsets=eagle3_mamba_slot_read_offsets,
+                    mamba_request_distribution=(
+                        eagle3_mamba_request_distribution),
                     padded_num_reqs=num_reqs,
                 )
 
@@ -1566,6 +1618,17 @@ class CompilationManager:
                                                sharding=dp_sharding)
         else:
             mamba_state_indices = None
+        # See the eagle3 precompile above: the drafter metadata inherits the
+        # spec-decode mamba fields from the target metadata via `replace`.
+        mamba_slot_read_offsets = self.runner.mamba_slot_read_offsets
+        if mamba_slot_read_offsets is not None:
+            mamba_request_distribution = device_array(self.runner.mesh,
+                                                      np.array([0, 0, 0] *
+                                                               dp_size,
+                                                               dtype=np.int32),
+                                                      sharding=dp_sharding)
+        else:
+            mamba_request_distribution = None
 
         num_reqs_dp = self._create_dummy_tensor((dp_size, ),
                                                 jnp.int32,
@@ -1591,6 +1654,8 @@ class CompilationManager:
                     query_start_loc=query_start_loc,
                     request_distribution=request_distribution,
                     mamba_state_indices=mamba_state_indices,
+                    mamba_slot_read_offsets=mamba_slot_read_offsets,
+                    mamba_request_distribution=mamba_request_distribution,
                     padded_num_reqs=num_reqs,
                 )
 
@@ -1689,6 +1754,14 @@ class CompilationManager:
                 sharding=dp_sharding)
         else:
             dflash_mamba_state_indices = None
+        dflash_mamba_slot_read_offsets = self.runner.mamba_slot_read_offsets
+        if dflash_mamba_slot_read_offsets is not None:
+            dflash_mamba_request_distribution = device_array(
+                self.runner.mesh,
+                np.array([0, 0, 0] * dp_size, dtype=np.int32),
+                sharding=dp_sharding)
+        else:
+            dflash_mamba_request_distribution = None
 
         num_reqs_dp = self._create_dummy_tensor((dp_size, ),
                                                 jnp.int32,
@@ -1725,6 +1798,9 @@ class CompilationManager:
                     query_start_loc=query_start_loc,
                     request_distribution=request_distribution,
                     mamba_state_indices=dflash_mamba_state_indices,
+                    mamba_slot_read_offsets=dflash_mamba_slot_read_offsets,
+                    mamba_request_distribution=
+                    dflash_mamba_request_distribution,
                     padded_num_reqs=num_reqs,
                 )
 
@@ -1784,6 +1860,9 @@ class CompilationManager:
                     query_start_loc=query_start_loc,
                     request_distribution=request_distribution,
                     mamba_state_indices=dflash_mamba_state_indices,
+                    mamba_slot_read_offsets=dflash_mamba_slot_read_offsets,
+                    mamba_request_distribution=(
+                        dflash_mamba_request_distribution),
                     padded_num_reqs=num_reqs,
                 )
 

--- a/tpu_inference/runner/persistent_batch_manager.py
+++ b/tpu_inference/runner/persistent_batch_manager.py
@@ -41,6 +41,12 @@ class PersistentBatchManager:
         (decode_only, fixed_chunked_prefill_only, mixed) and set the request
         distribution accordingly.
 
+        With speculative decoding the order is three segments:
+        [1-token decodes][spec verify windows][prefill/mixed]. Ragged paged
+        attention keeps its 1-token decode front segment, while the GDN
+        kernel's windowed mode covers the first two segments contiguously
+        (see `AttentionMetadata.mamba_request_distribution`).
+
         Returns:
             The number of swaps in requests.
         """
@@ -57,30 +63,47 @@ class PersistentBatchManager:
                 num_decode, num_decode, num_reqs
             ]
             return swap_cnt
-        # Use two-pointer approach to reorder the decode requests to front.
-        i, j = 0, num_reqs - 1
-        while i < j:
-            i_req_id = self.input_batch.req_ids[i]
-            j_req_id = self.input_batch.req_ids[j]
 
-            if scheduler_output.num_scheduled_tokens[i_req_id] == 1:
-                # i is a decode request, move to the next one.
-                i += 1
-            elif scheduler_output.num_scheduled_tokens[j_req_id] > 1:
-                # j is a prefill request, move to the previous one.
-                j -= 1
-            else:
-                # Swap i and j.
-                self.input_batch.swap_states(i, j)
-                i += 1
-                j -= 1
-                swap_cnt += 1
+        spec_decode_tokens = scheduler_output.scheduled_spec_decode_tokens
 
-        num_decode = i + int(scheduler_output.num_scheduled_tokens[
-            self.input_batch.req_ids[i]] == 1)
+        def segment(req_id: str) -> int:
+            # 0: 1-token decode, 1: speculative verify window,
+            # 2: prefill/mixed.
+            if scheduler_output.num_scheduled_tokens[req_id] == 1:
+                return 0
+            if req_id in spec_decode_tokens:
+                return 1
+            return 2
+
+        def partition(start: int, end: int, bound: int) -> tuple[int, int]:
+            """Two-pointer partition of [start, end]: requests with
+            segment <= bound before the rest. Returns (first index of the
+            second part, swaps)."""
+            nonlocal swap_cnt
+            i, j = start, end
+            while i < j:
+                if segment(self.input_batch.req_ids[i]) <= bound:
+                    i += 1
+                elif segment(self.input_batch.req_ids[j]) > bound:
+                    j -= 1
+                else:
+                    self.input_batch.swap_states(i, j)
+                    i += 1
+                    j -= 1
+                    swap_cnt += 1
+            if i == j and segment(self.input_batch.req_ids[i]) <= bound:
+                i += 1
+            return i
+
+        # Pass 1: 1-token decode requests to the front.
+        num_decode = partition(0, num_reqs - 1, 0)
+        # Pass 2: speculative verify windows before prefill/mixed requests.
+        num_windowed = num_decode
+        if num_decode < num_reqs:
+            num_windowed = partition(num_decode, num_reqs - 1, 1)
 
         self.input_batch.request_distribution = [
-            num_decode, num_decode, num_reqs
+            num_decode, num_windowed, num_reqs
         ]
 
         return swap_cnt

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -591,6 +591,32 @@ def _subtract_num_rejected_tokens_fn(seq_lens: jax.Array, positions: jax.Array,
     return seq_lens, positions
 
 
+@jax.jit(static_argnames=["mesh"])
+def _update_mamba_slot_read_offsets_fn(slot_read_offsets: jax.Array,
+                                       mamba_state_indices: jax.Array,
+                                       read_offsets: jax.Array,
+                                       mesh: jax.sharding.Mesh) -> jax.Array:
+    """Scatter this step's mamba read offsets into the slot-indexed buffer.
+
+    `mamba_state_indices` (rank-local base slot per batch position) and
+    `read_offsets` (num_accepted - 1 per batch position, 0 for non-spec
+    sequences) share the per-DP-rank layout of the current step. Padded
+    positions carry slot 0 (the null block) and offset 0, so their writes
+    are harmless.
+    """
+
+    def _scatter(offsets, indices, values):
+        return offsets.at[indices].set(values)
+
+    data_spec = PartitionSpec(ShardingAxisName.ATTN_DATA)
+    return jax.shard_map(
+        _scatter,
+        mesh=mesh,
+        in_specs=(data_spec, data_spec, data_spec),
+        out_specs=data_spec,
+    )(slot_read_offsets, mamba_state_indices, read_offsets)
+
+
 def _jax_logprobs_materialize(
         logprobs_tensors: LogprobsTensors,
         logits_indices_selector: Optional[List[int]] = None,
@@ -822,6 +848,12 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         self._init_inputs()
         self._init_speculative_decoding()
 
+        # Slot-indexed mamba read offsets for speculative decoding with
+        # hybrid (attention + mamba) models; allocated in
+        # `initialize_kv_cache` once the mamba pool size is known. See
+        # `AttentionMetadata.mamba_slot_read_offsets`.
+        self.mamba_slot_read_offsets: Optional[jax.Array] = None
+
         # Delegate functions to specific manager classes.
         self.compilation_manager = CompilationManager(self)
         if self.is_last_rank:
@@ -855,6 +887,15 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             "enable_continue_decode", False)
         self.continue_decode_eos_check_interval = self.vllm_config.additional_config.get(
             "continue_decode_eos_check_interval", 1)
+        if self.enable_continue_decode and self.vllm_config.speculative_config:
+            # The continue-decode loop builds its own AttentionMetadata
+            # without the mamba spec-decode fields (slot read offsets), so a
+            # hybrid model could read a stale state checkpoint after a
+            # verify step. Spec decoding never takes the decode-only fast
+            # path on verify steps anyway.
+            logger.warning("Disabling enable_continue_decode: not supported "
+                           "with speculative decoding.")
+            self.enable_continue_decode = False
         self.static_max_decode_steps = self.vllm_config.additional_config.get(
             "max_decode_steps", DEFAULT_MAX_DECODE_STEPS)
         self.eos_token_id = runner_utils.get_eos_token_id(self.model_config)
@@ -1277,6 +1318,24 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         if self.kv_cache_manager.actual_mamba_num_blocks is not None:
             self.input_batch.init_mamba_pools(
                 self.kv_cache_manager.actual_mamba_num_blocks)
+
+        # For hybrid models with spec decoding, keep a per-slot device buffer
+        # of mamba read offsets (num_accepted - 1 from each request's last
+        # verify step). The GDN kernel reads a request's initial state from
+        # `base_slot + offset`, which is how rejected draft tokens are
+        # rolled back (by selecting the checkpoint of the last accepted
+        # token, never by copying state).
+        if (kv_cache_config.has_mamba_layers
+                and self.speculative_config is not None):
+            mamba_num_blocks = self.kv_cache_manager.actual_mamba_num_blocks
+            if mamba_num_blocks is None:
+                mamba_num_blocks = (self.input_batch._mamba_local_slots *
+                                    self.dp_size)
+            offsets_sharding = NamedSharding(
+                self.mesh, PartitionSpec(ShardingAxisName.ATTN_DATA))
+            self.mamba_slot_read_offsets = jax.jit(
+                lambda: jnp.zeros((mamba_num_blocks, ), dtype=jnp.int32),
+                out_shardings=offsets_sharding)()
 
         # This buffer grows dynamically to accommodate metadata and block tables.
         # We re-initialize with a precise capacity now that kv_cache_config is known.
@@ -2108,11 +2167,23 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         spec_decode_num_rejected_tokens = None
         if self.speculative_config:
             with self.maybe_forbid_compile, jax.set_mesh(self.mesh):
-                last_sampled_token_id, num_rejected_tokens = extract_last_sampled_tokens(
-                    spec_decode_metadata, next_tokens,
-                    self.speculative_config.num_speculative_tokens,
-                    self.input_batch.vocab_size,
-                    self.max_num_reqs // self.dp_size, self.mesh)
+                (last_sampled_token_id, num_rejected_tokens,
+                 mamba_read_offsets) = extract_last_sampled_tokens(
+                     spec_decode_metadata, next_tokens,
+                     self.speculative_config.num_speculative_tokens,
+                     self.input_batch.vocab_size,
+                     self.max_num_reqs // self.dp_size, self.mesh)
+                if self.mamba_slot_read_offsets is not None:
+                    if isinstance(attn_metadata, dict):
+                        _mamba_state_indices = next(
+                            iter(attn_metadata.values())).mamba_state_indices
+                    else:
+                        _mamba_state_indices = attn_metadata.mamba_state_indices
+                    assert _mamba_state_indices is not None
+                    self.mamba_slot_read_offsets = (
+                        _update_mamba_slot_read_offsets_fn(
+                            self.mamba_slot_read_offsets, _mamba_state_indices,
+                            mamba_read_offsets, self.mesh))
                 self.speculative_decoding_manager.propose_draft_token_ids(
                     next_tokens,
                     logits_indices_selector,
@@ -2803,18 +2874,33 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         mrope_positions = self.mrope_positions_cpu[:, :
                                                    padded_total_num_scheduled_tokens]
         _request_distribution = []
+        _mamba_request_distribution = []
         for dp_rank in range(dp_size):
             _num_reqs = num_req_per_dp_rank[dp_rank]
-            # The batch has been reordered by _reorder_batch so decode requests come first
-            # Count decode requests (those with num_scheduled_tokens == 1) in this DP rank
+            # The batch has been reordered by _reorder_batch into
+            # [decode][spec verify][prefill/mixed] segments. Count 1-token
+            # decode requests (the RPA decode segment) and windowed requests
+            # (decodes + speculative verify windows, the GDN windowed
+            # segment) in this DP rank.
             num_decode_in_dp_rank = 0
+            num_windowed_in_dp_rank = 0
             for req_id in req_ids_dp[dp_rank]:
                 if scheduler_output.num_scheduled_tokens[req_id] == 1:
                     num_decode_in_dp_rank += 1
+                    num_windowed_in_dp_rank += 1
+                elif req_id in scheduler_output.scheduled_spec_decode_tokens:
+                    num_windowed_in_dp_rank += 1
             _request_distribution.append(
                 [num_decode_in_dp_rank, num_decode_in_dp_rank, _num_reqs])
+            _mamba_request_distribution.append(
+                [num_windowed_in_dp_rank, num_windowed_in_dp_rank, _num_reqs])
         request_distribution = np.array(_request_distribution,
                                         dtype=np.int32).ravel()
+        use_mamba_spec_decode = (self.kv_cache_config.has_mamba_layers
+                                 and self.speculative_config is not None)
+        mamba_request_distribution_cpu = np.array(
+            _mamba_request_distribution,
+            dtype=np.int32).ravel() if use_mamba_spec_decode else None
 
         # Prefill context parallelism (single request, prefill only): head-tail
         # arrange this request's current tokens into rank order
@@ -2995,13 +3081,24 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                 mamba_state_indices_cpu[req_offset:req_offset +
                                         _num_reqs] = (global_slots %
                                                       local_slots)
-            (request_distribution, mamba_state_indices,
-             dev_arrays_payload) = device_array(
-                 self.mesh, (request_distribution, mamba_state_indices_cpu,
-                             metadata_blob),
-                 sharding=metadata_attn_sharding)
+            if mamba_request_distribution_cpu is not None:
+                (request_distribution, mamba_state_indices,
+                 mamba_request_distribution,
+                 dev_arrays_payload) = device_array(
+                     self.mesh,
+                     (request_distribution, mamba_state_indices_cpu,
+                      mamba_request_distribution_cpu, metadata_blob),
+                     sharding=metadata_attn_sharding)
+            else:
+                mamba_request_distribution = None
+                (request_distribution, mamba_state_indices,
+                 dev_arrays_payload) = device_array(
+                     self.mesh, (request_distribution, mamba_state_indices_cpu,
+                                 metadata_blob),
+                     sharding=metadata_attn_sharding)
         else:
             mamba_state_indices = None
+            mamba_request_distribution = None
             (request_distribution, dev_arrays_payload) = device_array(
                 self.mesh, (request_distribution, metadata_blob),
                 sharding=metadata_attn_sharding)
@@ -3029,6 +3126,8 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                 query_start_loc=query_start_loc,
                 request_distribution=request_distribution,
                 mamba_state_indices=mamba_state_indices,
+                mamba_slot_read_offsets=self.mamba_slot_read_offsets,
+                mamba_request_distribution=mamba_request_distribution,
                 padded_num_reqs=attn_padded_num_reqs,
                 pcp_kv_cache_lens=pcp_kv_cache_lens,
                 pcp_q_pos_offsets=pcp_q_pos_offsets,

--- a/tpu_inference/spec_decode/jax/utils.py
+++ b/tpu_inference/spec_decode/jax/utils.py
@@ -32,8 +32,8 @@ PLACEHOLDER_TOKEN_ID = -1
 def extract_last_sampled_tokens(
         spec_decode_metadata: SpecDecodeMetadata,
         sampled_token_ids: jnp.ndarray, num_speculative_tokens: int,
-        vocab_size: int, max_num_reqs_per_dp_rank: int,
-        mesh: jax.sharding.Mesh) -> tuple[jnp.ndarray, jnp.ndarray]:
+        vocab_size: int, max_num_reqs_per_dp_rank: int, mesh: jax.sharding.Mesh
+) -> tuple[jnp.ndarray, jnp.ndarray, jnp.ndarray]:
 
     def _body(draft_lengths, sampled_token_ids):
         return _extract_last_sampled_tokens(draft_lengths, sampled_token_ids,
@@ -45,7 +45,7 @@ def extract_last_sampled_tokens(
         _body,
         mesh=mesh,
         in_specs=(data_spec, data_spec),
-        out_specs=(data_spec, data_spec),
+        out_specs=(data_spec, data_spec, data_spec),
     )(spec_decode_metadata.draft_lengths, sampled_token_ids)
 
 
@@ -54,8 +54,9 @@ def extract_last_sampled_tokens(
 def _extract_last_sampled_tokens(
         draft_lengths: jnp.ndarray, sampled_token_ids: jnp.ndarray,
         num_speculative_tokens: int, vocab_size: int,
-        max_num_seq: int) -> tuple[jnp.ndarray, jnp.ndarray]:
-    """Extract the last sampled token and number rejected tokens per seq. """
+        max_num_seq: int) -> tuple[jnp.ndarray, jnp.ndarray, jnp.ndarray]:
+    """Extract the last sampled token, rejected count and mamba read offset
+    per seq."""
     # `sampled_token_ids` is the output of the rejection sampler.
     num_draft_tokens = draft_lengths
     batch_size = num_draft_tokens.shape[0]
@@ -93,7 +94,14 @@ def _extract_last_sampled_tokens(
     num_rejected_tokens = jnp.pad(num_rejected_per_seq,
                                   (0, max_num_seq - batch_size),
                                   constant_values=0)
-    return last_sampled_tokens, num_rejected_tokens
+    # Mamba state checkpoint the request must resume from next step:
+    # `num_draft - num_rejected` == number of accepted output tokens - 1.
+    # Zero for sequences that did not run spec decoding this step (prefill,
+    # decode without drafts), which also resets the offset after prefill.
+    mamba_read_offsets = jnp.pad(num_draft_tokens - num_rejected_per_seq,
+                                 (0, max_num_seq - batch_size),
+                                 constant_values=0)
+    return last_sampled_tokens, num_rejected_tokens, mamba_read_offsets
 
 
 @jax.jit


### PR DESCRIPTION
## Summary

Wires the GDN v3 windowed kernel (merged in #3189) into the runner and attention layers so hybrid mamba models can undo the linear-attention state advance of rejected draft tokens during MTP speculative decoding. Previously the kernel only produced the state after the last token of a verify window, so a sequence's mamba state silently kept the effect of rejected draft tokens. This PR keeps one state checkpoint per window position and resumes each request from the checkpoint of its last accepted token — rollback becomes pure slot selection, with no state copies.

This is the runner/layer integration half of the feature; the kernel half landed separately as #3189. It sits directly on top of `main` now that #3189 is merged.

## How it works

The data flow after each verify step is: rejection sampler → per-request read offset → attention metadata → persistent-batch ordering → GDN kernel.

- **Read offset.** `extract_last_sampled_tokens` now also returns `mamba_read_offsets = num_accepted - 1` per sequence. This is scattered into a per-*physical-slot* buffer on device so the value survives requests being rescheduled, condensed, or skipped across steps. The kernel reads a request's initial state from `state_indices[s] + read_offset[s]` (last accepted token's checkpoint) and writes fresh checkpoints starting at `state_indices[s]`.
- **Batch ordering.** The persistent batch is reordered into three contiguous segments `[1-token decodes][spec verify windows][prefill/mixed]`. Ragged paged attention keeps using its 1-token decode front segment via `request_distribution`, while the GDN kernel runs its windowed mode over the first two segments via the new `mamba_request_distribution` (same 3-counters-per-rank format, but the first segment covers all windowed sequences). Both segmentations hold at once, so RPA and GDN read the same batch without conflict.
- **Kernel call.** The GDN op gathers the per-slot offsets (`slot_read_offsets[state_indices]`) inside the shard and passes `read_offsets` / `num_spec_tokens` to `fused_conv1d_gdn`. `num_spec_tokens` is recovered statically from the vLLM MambaSpec conv-state width, so no new plumbing is needed to thread it through.

## Metadata additions

Two fields on `AttentionMetadata`, both `None` unless the model has mamba layers *and* speculative decoding is enabled:

| Field | Shape | Meaning |
|---|---|---|
| `mamba_slot_read_offsets` | `(mamba_num_blocks,)` | per-slot `num_accepted - 1` from the last verify step |
| `mamba_request_distribution` | `(3 * dp_size,)` | GDN request distribution whose first segment covers windowed sequences (decodes + verify windows) |

## Files

- `spec_decode/jax/utils.py` — third return value `mamba_read_offsets`.
- `layers/common/attention_metadata.py` — the two fields above.
- `runner/persistent_batch_manager.py` — three-segment `[decode][verify][prefill]` reorder.
- `layers/common/gdn_attention.py`, `layers/vllm/custom_ops/gdn_attention_op.py` — gather offsets, pass `read_offsets` / `num_spec_tokens` to the kernel.
- `runner/tpu_runner.py`, `runner/compilation_manager.py` — scatter offsets after rejection sampling, build `mamba_request_distribution`, precompile the new op.

## Tests

`tests/spec_decode/test_utils.py` — `extract_last_sampled_tokens` now checks the `mamba_read_offsets` output against a reference (6/6 pass).

### End-to-end

Verified serving `Qwen/Qwen3.5-4B` on v7x, TP=8, MTP `num_speculative_tokens=4`, with `VLLM_XLA_CHECK_RECOMPILATION=1` (so any un-precompiled shape hard-errors):

- Server starts with **no recompilation** — every runtime shape including the mamba scatter and windowed GDN precompiled cleanly.
- Counting prompt returns correct, unbroken output (`14 … 109`); single-prompt spec metrics 90.4% acceptance, per-position `1.0 / 1.0 / 0.938 / 0.677`.
- `spec_bench` summarization, 100 prompts: **100/100 successful, 0 failed, 0 errors**. Acceptance length 2.90 with ~18.5k of 35.3k draft tokens rejected — the rollback path ran on nearly every step and never corrupted output.
