### PR TITLE
[releases/v0.25.0] Cherry-pick #3159: scope vmem cap to MLA kernel tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,9 +38,6 @@ Example Usage:
 import os
 from unittest.mock import patch
 
-os.environ["LIBTPU_INIT_ARGS"] = (os.environ.get("LIBTPU_INIT_ARGS", "") +
-                                  " --xla_tpu_scoped_vmem_limit_kib=65536")
-
 import jax
 import pytest
 

--- a/tests/kernels/mla_tuned_vs_baseline_test.py
+++ b/tests/kernels/mla_tuned_vs_baseline_test.py
@@ -12,6 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+
+# MLA-kernel-only vmem budget. Two constraints (see #3011 / #3159):
+# 1. Must run before libtpu/TPU backend initialization (module top,
+#    before the jax import below).
+# 2. Must NOT move into tests/conftest.py: a global setting changes XLA
+#    codegen for every e2e test in the suite (that is exactly how #3011
+#    caused a deterministic multimodal output drift and e2e slowdowns).
+if "--xla_tpu_scoped_vmem_limit_kib" not in os.environ.get(
+        "LIBTPU_INIT_ARGS", ""):
+    os.environ["LIBTPU_INIT_ARGS"] = (os.environ.get("LIBTPU_INIT_ARGS", "") +
+                                      " --xla_tpu_scoped_vmem_limit_kib=65536")
+
 import time
 
 import jax

--- a/tests/kernels/mla_v2_test.py
+++ b/tests/kernels/mla_v2_test.py
@@ -12,6 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+
+# MLA-kernel-only vmem budget. Two constraints (see #3011 / #3159):
+# 1. Must run before libtpu/TPU backend initialization (module top,
+#    before the jax import below).
+# 2. Must NOT move into tests/conftest.py: a global setting changes XLA
+#    codegen for every e2e test in the suite (that is exactly how #3011
+#    caused a deterministic multimodal output drift and e2e slowdowns).
+if "--xla_tpu_scoped_vmem_limit_kib" not in os.environ.get(
+        "LIBTPU_INIT_ARGS", ""):
+    os.environ["LIBTPU_INIT_ARGS"] = (os.environ.get("LIBTPU_INIT_ARGS", "") +
+                                      " --xla_tpu_scoped_vmem_limit_kib=65536")
+
 import jax
 import jax.numpy as jnp
 import numpy as np


### PR DESCRIPTION
Cherry-pick of #3159 (merged to `main` as `ce0507e4a4`) onto `releases/v0.25.0`.

## Why
The v0.25.0 release nightly ([build 22159](https://buildkite.com/tpu-commons/tpu-inference-ci/builds/22159)) fails `tpu7x Correctness tests for Multimodal Inputs` and `tpu6e Performance tests for TP`, and both `E2E speculative decoding` jobs time out — all traced to #3011's global vmem cap in `tests/conftest.py`. Root cause and single-commit A/B proof in #3159.

## Validation (already done on the release base)
- [tpu-inference-dev 666](https://buildkite.com/tpu-commons/tpu-inference-dev/builds/666): exact nightly Multimodal Inputs job 3/3 green + TP perf recovered (1.03/1.05/1.05/1.06 vs 0/10 passing without the fix), with this change on `releases/v0.25.0`.

Cherry-pick applied clean.
