### PR TITLE
Cache TPU KV cache zero allocator to avoid repeated JAX compile overhead

### DIFF
--- a/tpu_inference/runner/kv_cache.py
+++ b/tpu_inference/runner/kv_cache.py
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from dataclasses import dataclass
-from typing import List
+from functools import cache, partial
+from typing import Callable, List
 
 import jax
 import jax.numpy as jnp
@@ -96,6 +97,21 @@ def get_kv_cache_shape_with_mesh(mesh: Mesh,
     return tuple(shape)
 
 
+@cache
+def _get_kv_cache_allocator(
+        cache_shape: tuple, cache_dtype: jnp.dtype,
+        sharding: NamedSharding) -> Callable[[], jax.Array]:
+
+    @partial(jax.jit, out_shardings=sharding)
+    def _allocate() -> jax.Array:
+        return jnp.zeros(
+            shape=cache_shape,
+            dtype=cache_dtype,
+        )
+
+    return _allocate
+
+
 def create_kv_caches(
     num_blocks: int,
     block_size: int,
@@ -146,17 +162,9 @@ def create_kv_caches(
             PartitionSpec(ShardingAxisName.BATCH, ShardingAxisName.CONTEXT,
                           ShardingAxisName.KV_CACHE_HEAD))
 
-    def _allocate() -> jax.Array:
-        return jnp.zeros(
-            shape=cache_shape,
-            dtype=cache_dtype,
-        )
-
-    sharded_allocate = jax.jit(_allocate, out_shardings=sharding)
-    kv_caches = []
-    for _ in layer_names:
-        kv_caches.append(sharded_allocate())
-    return kv_caches
+    sharded_allocate = _get_kv_cache_allocator(cache_shape, cache_dtype,
+                                               sharding)
+    return [sharded_allocate() for _ in layer_names]
 
 
 def get_attention_page_size_bytes(mesh, block_size, num_kv_heads, head_size,


### PR DESCRIPTION
# Description

This PR caches the jitted TPU KV cache zero allocator used by `create_kv_caches()`. Previously, KV cache initialization created a fresh nested `jax.jit` allocator each time, which caused repeated compile/dispatch overhead when MaxText/Tunix reinitialized vLLM TPU KV caches during weight sync.

The issue was observed from the MaxText/Tunix RL training path:

`MaxText RL training -> Tunix RLLearner -> RLCluster.sync_weights() -> VllmSampler.update_params() -> collective_rpc("reinitialize_kv_cache")`

For Qwen3-4B GSM8K on `v6e-8`, `train/weight_sync_time` was dominated by KV cache reinitialization. Tunix-side profiling narrowed the issue to vllm cache reinit, which was about 100s initially and grew over training. TPU inference profiling then showed that `reinitialize_kv_cache()` spent almost all of its time in the KV cache allocation loop: 36 layer allocations, each paying roughly 2.8-3.2s in allocator dispatch/compile overhead.

The fix keeps the existing `jnp.zeros` behavior, so KV cache tensors are still zero-initialized, but reuses the compiled allocator for matching:

- mesh identity
- cache shape
- cache dtype
- sharding spec
- memory kind

This avoids rebuilding a fresh no-arg jitted allocator for each KV cache tensor and for each later reinitialization. In profiling, keeping `jnp.zeros` with allocator caching reduced a mid-training KV cache reinitialization from roughly 100s to about 0.016s.

This is intentionally a narrow fix. The allocator cache is process-local and does not include eviction. That should be fine for the current use case because the number of KV cache shapes/shardings is small, but a future improvement could add a bounded cache if this path starts supporting many dynamic cache layouts.

# Tests

Tested with TPU profiling in the MaxText/Tunix RL setup using Qwen3-4B GSM8K on `v6e-8`.

Before the fix:

- `reinitialize_kv_cache()` was about 100s+
- allocation loop dominated runtime
- each per-layer KV cache allocation took roughly 3s

After caching the allocator while keeping `jnp.zeros`:

- `reinitialize_kv_cache()` was about 0.016s in the profiled mid-training step
- per-layer allocation dispatch dropped to roughly 0.0001-0.0003s
- HBM usage after reinit matched the expected KV cache allocation footprint

# Checklist

- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have made or will make corresponding changes to any relevant documentation. Documentation changes are not needed for this internal allocation-path fix.
