### PR TITLE
[CI] Migrate multi-host benchmark

### DIFF
--- a/.buildkite/benchmark/README.md
+++ b/.buildkite/benchmark/README.md
@@ -41,7 +41,7 @@ The `run_bm.sh` script is designed to be environment-aware. When running locally
 ```
 
 ***There are two more modifications that need to be made here:***
-1. [`REMOTE_LOG_ROOT`](scripts/report_result.sh#L49) needs to be changed to use `$GSC_BUCKET` as the bucket for storing logs.
+1. [`REMOTE_LOG_ROOT`](scripts/report_result.sh#L49) needs to be changed to use `$GCS_BUCKET` as the bucket for storing logs.
 2. The migration file [`vllm_bm_20260410.ddl`](sql/vllm_bm_20260410.ddl) needs to be executed in `vllm-bm-runs` (Production Spanner DB).
 
 ## 3. Configuration Guide (JSON Cases)
@@ -56,6 +56,8 @@ The framework is driven by JSON configuration files. Each file defines one or mo
   * `EXPECTED_ETEL`: The target goal for End-to-End Latency (P99 in ms). The script adjusts the request rate via binary search to stay within this limit.
   * `EXPECTED_THROUGHPUT`: Target throughput. Evaluated in `report_result.sh` to flag performance regressions.
   * `INPUT_LEN`, `OUTPUT_LEN`, `PREFIX_LEN`: Metadata representing sequence lengths. Used primarily for database tagging.
+  * `IS_MULTI_HOST_BENCH`: (Boolean) Used to distinguish whether the case is a multihost benchmark.
+  * `BK_TIMEOUT_IN_MINUTES`: (Integer) Sets a timeout limit in minutes for the generated Buildkite YAML (e.g., 180).
 * `ci_queue`: Array of strings defining which Buildkite agent queues should pick up this case.
 * `server_command_options`: Controls the vLLM backend.
   * `command_type`: Must be `vllm_serve`.
@@ -65,6 +67,9 @@ The framework is driven by JSON configuration files. Each file defines one or mo
   * `command_type`: Typically `vllm_bench_serve`. Can also be `lm_eval` for accuracy evaluations. When it is `lm_eval`, the dataset must be specified in the `args`, a specific shell script will be executed based on the dataset configuration, and `server_command_options` does not need to be set.
   * `args`: Client-side CLI flags (e.g., `num-prompts`, `request-rate`).
   * `env`: Client-command-specific environment variables.
+* `accuracy_command_options`: Used specifically for Accuracy benchmarks.
+  * `command_type`: Should be set to local_benchmark_serving to execute the built-in `vllm/benchmarking/benchmark_serving.py`.
+  * `args`: Key-value pairs for the accuracy benchmark arguments.
 
 ### Critical Considerations & Advanced Features
 
@@ -103,6 +108,18 @@ Additionally, the `case_name` defined in the JSON will be extracted and reported
 > * **For new cases:** You can define and modify the `case_name` freely during initial development. (Please make it similar to current cases name convention as possible)
 > * **For established cases:** If a case has been running for a long time and has historical data in the database, **strongly recommend NOT to modify its `case_name`**.
 > * **Data Migration:** If a name change is strictly necessary for an established case, you must coordinate and execute a data migration in the database to link the old records to the new name. Modifying the name without migration will cause the dashboard to treat it as a brand-new entity, breaking historical performance tracking.
+
+#### E. Multihost Benchmark Configurations
+When configuring a Multihost benchmark, you can use specific parameters to control the execution environment and model loading behavior. Note that current multihost benchmarks are all configured to use the `runai_streamer` format, which streams model weights directly from GCS.
+
+```json
+"server_command_options": {
+  "args": {
+    "model-path": "gs://tpu-commons-ci/deepseek/r1",
+    "load-format": "runai_streamer"
+  }
+}
+```
 
 ## 4. **Test Case File Hierarchy**
 

--- a/.buildkite/benchmark/README.md
+++ b/.buildkite/benchmark/README.md
@@ -62,6 +62,9 @@ The framework is driven by JSON configuration files. Each file defines one or mo
 * `server_command_options`: Controls the vLLM backend.
   * `command_type`: Must be `vllm_serve`.
   * `args`: Key-value pairs translated into CLI flags (e.g., `model`, `seed`, `max-model-len`).
+    * **`model` vs. `model-path` Resolution:** You can decouple a model's reporting name from its physical storage location by specifying both keys within `args`:
+      * **`model`**: Acts as the display name used *only* for metrics, logging, and database tracking (e.g., `"model": "deepseek-ai/DeepSeek-R1"`). *Note: If `model-path` is not provided, this value is passed normally as the `--model` flag.*
+      * **`model-path`**: The actual URI or local directory used to load the model weights. When this key is present, the script automatically overrides the execution command, passing this value as the `--model` CLI flag instead (e.g., `"model-path": "gs://tpu-commons-ci/deepseek/r1"`).
   * `env`: Server-command-specific environment variables.
 * `client_command_options`: Controls the workload generator.
   * `command_type`: Typically `vllm_bench_serve`. Can also be `lm_eval` for accuracy evaluations. When it is `lm_eval`, the dataset must be specified in the `args`, a specific shell script will be executed based on the dataset configuration, and `server_command_options` does not need to be set.

--- a/.buildkite/benchmark/cases/daily/run_jax_deepseek_v3_1k_8k.json
+++ b/.buildkite/benchmark/cases/daily/run_jax_deepseek_v3_1k_8k.json
@@ -1,0 +1,97 @@
+{
+  "global_env": {
+    "GCP_PROJECT_ID": "cloud-tpu-inference-test",
+    "GCS_BUCKET": "vllm-cb-storage2",
+    "GCP_INSTANCE_ID": "vllm-bm-inst",
+    "GCP_DATABASE_ID": "vllm-bm-bk-runs",
+    "RUN_ONCE": "true",
+    "IS_MULTI_HOST_BENCH": true,
+    "BK_TIMEOUT_IN_MINUTES": 240
+  },
+  "benchmark_cases": [
+    {
+      "case_name": "run_jax_deepseek_v3_1k_8k",
+      "ci_queue": [
+        "tpu_v7x_16_queue"
+      ],
+      "env": {
+        "RUN_TYPE": "DAILY",
+        "INPUT_LEN": 1024,
+        "OUTPUT_LEN": 8192,
+        "PREFIX_LEN": 0,
+        "MODEL_NAME": "DeepSeek-R1",
+        "DEVICE": "tpu7x-16",
+        "BENCHMARK_TIMEOUT": "3h"
+      },
+      "server_command_options": {
+        "command_type": "vllm_serve",
+        "env": {
+          "VLLM_DISABLE_SHARED_EXPERTS_STREAM": "0",
+          "NEW_MODEL_DESIGN": "1",
+          "VLLM_MLA_DISABLE": "0",
+          "MOE_REQUANTIZE_BLOCK_SIZE": "512",
+          "MOE_REQUANTIZE_WEIGHT_DTYPE": "fp4",
+          "MODEL_IMPL_TYPE": "flax_nnx",
+          "USE_UNFUSED_MEGABLOCKS": "0",
+          "MOE_ALL_GATHER_ACTIVATION_DTYPE": "fp8",
+          "TPU_BACKEND_TYPE": "jax",
+          "VLLM_ENGINE_READY_TIMEOUT_S": "10800",
+          "RAY_LOG_TO_STDERR": "1",
+          "AUTOSCALER_UPDATE_INTERVAL_S": "300"
+        },
+        "args": {
+          "model-path": "gs://tpu-commons-ci/deepseek/r1",
+          "model": "deepseek-ai/DeepSeek-R1",
+          "served-model-name": "deepseek-ai/DeepSeek-R1",
+          "tokenizer": "deepseek-ai/DeepSeek-R1",
+          "load-format": "runai_streamer",
+          "seed": 42,
+          "max-num-seqs": 160,
+          "max-num-batched-tokens": 512,
+          "tensor-parallel-size": {
+            "v7x-16": 16
+          },
+          "max-model-len": 9216,
+          "kv-cache-dtype": "fp8",
+          "gpu-memory-utilization": 0.95,
+          "enable-expert-parallel": true,
+          "no-enable-prefix-caching": true,
+          "async-scheduling": true,
+          "additional-config": "{\"sharding\": {\"sharding_strategy\": {\"enable_dp_attention\": true, \"expert_parallelism\": 16, \"tensor_parallelism\": 1}}, \"replicate_attn_weights\": \"True\", \"sparse_matmul\": \"True\", \"compilation_sizes\": [2560]}",
+          "generation-config": "gs://tpu-commons-ci/deepseek/multi-host-bench/DeepSeek-R1",
+          "trust-remote-code": true,
+          "hf-config-path": "deepseek-ai/DeepSeek-R1"
+        }
+      },
+      "client_command_options": {
+        "command_type": "vllm_bench_serve",
+        "args": {
+          "model": "deepseek-ai/DeepSeek-R1",
+          "backend": "vllm",
+          "request-rate": "inf",
+          "dataset-name": "random",
+          "random-input-len": 1024,
+          "random-output-len": 8192,
+          "num-prompts": 2560,
+          "ignore-eos": true,
+          "trust-remote-code": true,
+          "percentile-metrics": "ttft,tpot,itl,e2el"
+        }
+      },
+      "accuracy_command_options": {
+        "command_type": "local_benchmark_serving",
+        "args": {
+          "backend": "vllm",
+          "model": "deepseek-ai/DeepSeek-R1",
+          "dataset-name": "mmlu",
+          "dataset-path": "/workspace/mmlu/data/test",
+          "num-prompts": 14000,
+          "run-eval": true,
+          "temperature": 0,
+          "mmlu-output-len": 4,
+          "trust-remote-code": true
+        }
+      }
+    }
+  ]
+}

--- a/.buildkite/benchmark/scripts/generate_bk_pipeline.py
+++ b/.buildkite/benchmark/scripts/generate_bk_pipeline.py
@@ -233,6 +233,8 @@ def create_benchmark_steps(case_data: Dict[str, Any],
             "TPU_VERSION": tpu_version,
         }
 
+        timeout_in_minutes = step_env.pop("BK_TIMEOUT_IN_MINUTES", None)
+
         step_env["TARGET_CASE_NAME"] = case_name
         # Include parent_dir in label for uniqueness
         step_label = f"[{parent_dir}] {agent} {file_basename} {case_name}"
@@ -251,10 +253,14 @@ def create_benchmark_steps(case_data: Dict[str, Any],
         used_keys.add(step_safe_key)
 
         step = {
-            "label":
-            step_label,
-            "key":
-            step_safe_key,
+            "label": step_label,
+            "key": step_safe_key,
+        }
+
+        if timeout_in_minutes is not None:
+            step["timeout_in_minutes"] = timeout_in_minutes
+
+        step.update({
             "env":
             step_env,
             "agents": {
@@ -262,7 +268,7 @@ def create_benchmark_steps(case_data: Dict[str, Any],
             },
             "command":
             f"bash .buildkite/benchmark/scripts/run_job.sh {case_parameter}",
-        }
+        })
 
         # Add dependency on global case name validation if it was uploaded in bootstrap
         if os.environ.get("BENCHMARK_VALIDATION_UPLOADED") == "true":

--- a/.buildkite/benchmark/scripts/parse_benchmark_log.py
+++ b/.buildkite/benchmark/scripts/parse_benchmark_log.py
@@ -1,0 +1,107 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import ast
+import json
+import re
+import sys
+
+
+def parse_benchmark_log(log_path, result_path):
+    # Mapping of what vllm prints vs what Spanner column expects
+    METRIC_MAPPING = {
+        "request throughput": "Throughput",
+        "output token throughput": "OutputTokenThroughput",
+        "total token throughput": "TotalTokenThroughput",
+        "median ttft": "MedianTTFT",
+        "p99 ttft": "P99TTFT",
+        "median tpot": "MedianTPOT",
+        "p99 tpot": "P99TPOT",
+        "median itl": "MedianITL",
+        "p99 itl": "P99ITL",
+        "median e2el": "MedianETEL",
+        "p99 e2el": "P99ETEL"
+    }
+
+    results = {}
+    in_results = False
+
+    try:
+        with open(log_path, "r") as f:
+            lines_generator = f
+            recent_lines = []
+
+            for line in lines_generator:
+                line = line.strip()
+
+                # Keep a sliding window of the last 10 lines
+                recent_lines.append(line)
+                if len(recent_lines) > 10:
+                    recent_lines.pop(0)
+
+                if "============ Serving Benchmark Result ============" in line:
+                    in_results = True
+                    continue
+                if "==================================================" in line and in_results:
+                    in_results = False
+
+                if in_results and ":" in line:
+                    key, val = line.split(":", 1)
+                    val = val.strip()
+
+                    # Remove units like (ms) or (tok/s) or (req/s)
+                    clean_key = re.sub(r"\(.*?\)", "", key).strip().lower()
+
+                    if clean_key in METRIC_MAPPING and METRIC_MAPPING[
+                            clean_key] not in results:
+                        if val != "N/A":
+                            results[METRIC_MAPPING[clean_key]] = val
+
+                # Handle explicit AccuracyMetrics: json (used by some benchmark wrappers)
+                if line.startswith("AccuracyMetrics:"):
+                    try:
+                        json_str = line.split("AccuracyMetrics:")[1].strip()
+                        # Verify it is valid JSON
+                        json.loads(json_str)
+                        results["AccuracyMetrics"] = json_str
+                    except Exception:
+                        pass
+
+                # Fallback: Parse legacy Accuracy result dict printed by benchmark_serving.py
+                if "Results" in recent_lines and line.startswith("{"):
+                    try:
+                        acc_dict = ast.literal_eval(line)
+                        if isinstance(acc_dict,
+                                      dict) and "accuracy" in acc_dict:
+                            results["AccuracyMetrics"] = json.dumps(
+                                {"accuracy": acc_dict["accuracy"]})
+                    except Exception:
+                        pass
+
+    except FileNotFoundError:
+        print(f"Warning: log file {log_path} not found.")
+
+    with open(result_path, "w") as out:
+        for k, v in results.items():
+            out.write(f"{k}={v}\n")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 3:
+        print(f"Usage: {sys.argv[0]} <log_file_path> <result_file_path>")
+        sys.exit(1)
+
+    log_file = sys.argv[1]
+    result_file = sys.argv[2]
+    parse_benchmark_log(log_file, result_file)

--- a/.buildkite/benchmark/scripts/parser_case.py
+++ b/.buildkite/benchmark/scripts/parser_case.py
@@ -20,7 +20,8 @@ import sys
 CMD_MAP = {
     "vllm_serve": "vllm serve",
     "vllm_bench_serve": "vllm bench serve",
-    "lm_eval": "lm_eval"
+    "lm_eval": "lm_eval",
+    "local_benchmark_serving": "python3 scripts/vllm/benchmarking/benchmark_serving.py"
 }
 
 # Helper function to print export statement only if value is valid
@@ -29,12 +30,27 @@ def export_env_if_valid(opts_dict, json_key, env_var_name):
 
     # Validate value: allow 0, but exclude None, empty dict, or empty string
     if val not in (None, {}, ""):
-        print(f"export {env_var_name}=\"{val}\"")
+        val_str = str(val).lower() if isinstance(val, bool) else val
+        print(f"export {env_var_name}=\"{val_str}\"")
 
-def get_current_machine_type():
+def normalize_device_name(device_name):
+    """
+    Normalizes device name from cases config (e.g., 'tpu7x-16' -> 'v7x-16')
+    """
+    if not device_name:
+        return None
+    normalized = device_name.lower()
+    if normalized.startswith("tpu"):
+        normalized = normalized[3:]
+    if not normalized.startswith("v") and len(normalized) > 0:
+        normalized = f"v{normalized}"
+    return normalized
+
+
+def get_current_machine_type(fallback_device=None):
     """
     Returns the current machine type string (e.g., 'v6e-8', 'v7x-2') 
-    using the tpu_info library.
+    using the tpu_info library, falling back to the case config if needed.
     """
     try:
         from tpu_info import device
@@ -54,14 +70,29 @@ def get_current_machine_type():
                 num_devices = num_chips * chip_type.value.devices_per_chip
 
             machine_type = f"{name}-{num_devices}"
-            print(f"echo '[DEBUG] Detected machine type: {machine_type}' >&2")
+            print(f"echo '[DEBUG] Detected local machine type via tpu_info: {machine_type}' >&2")
+
+            # Check if fallback_device matches the detected family but specifies a larger cluster count (multi-host setup)
+            if fallback_device and fallback_device.startswith(name):
+                try:
+                    fallback_count = int(fallback_device.split("-")[1])
+                    if fallback_count > num_devices:
+                        print(f"echo '[DEBUG] Multi-host TPU cluster detected. Local chips: {num_devices}, Cluster chips: {fallback_count}. Using cluster device: {fallback_device}' >&2")
+                        return fallback_device
+                except (ValueError, IndexError):
+                    pass
+
             return machine_type
         else:
             print(f"echo '[WARNING] No TPU chips detected: chip_type={chip_type}, num_chips={num_chips}' >&2")
     except ImportError:
-        print("echo '[WARNING] tpu_info library not found. Cannot determine machine type.' >&2")
+        print("echo '[WARNING] tpu_info library not found. Cannot determine machine type via library.' >&2")
     except Exception as e:
-        print(f"echo '[WARNING] Failed to determine machine type: {e}' >&2")
+        print(f"echo '[WARNING] Failed to determine machine type via library: {e}' >&2")
+
+    if fallback_device:
+        print(f"echo '[DEBUG] Falling back to case config device: {fallback_device}' >&2")
+        return fallback_device
     return None
 
 
@@ -99,11 +130,16 @@ def build_command(cmd_type, args_dict):
         return shlex.join(cmd_parts)
 
     for key, value in args_dict.items():
+        if key == "model" and "model-path" in args_dict:
+            continue
+
+        output_key = "model" if key == "model-path" else key
+
         if isinstance(value, bool):
             if value:
-                cmd_parts.append(f"--{key}")
+                cmd_parts.append(f"--{output_key}")
         else:
-            cmd_parts.append(f"--{key}")
+            cmd_parts.append(f"--{output_key}")
             cmd_parts.append(str(value))
 
     return shlex.join(cmd_parts)
@@ -116,9 +152,6 @@ def main():
 
     config_file = sys.argv[1]
     target_case = sys.argv[2] if len(sys.argv) > 2 else None
-
-    # Determine current machine type from tpu_info
-    current_machine = get_current_machine_type()
 
     try:
         with open(config_file, 'r') as f:
@@ -142,6 +175,15 @@ def main():
             f"echo 'Error: Case \"{target_case}\" not found in \"{config_file}\".' >&2; exit 1")
         sys.exit(1)
 
+    # Resolve fallback device from config
+    device_env = case_data.get("env", {}).get("DEVICE")
+    if not device_env:
+        device_env = data.get("global_env", {}).get("DEVICE")
+    fallback_machine = normalize_device_name(device_env)
+
+    # Determine current machine type
+    current_machine = get_current_machine_type(fallback_machine)
+
     merged_env = data.get("global_env", {}).copy()
     merged_env.update(case_data.get("env", {}))
 
@@ -153,7 +195,8 @@ def main():
 
     # Export environment variables securely
     for k, v in merged_env.items():
-        print(f"export {k}={shlex.quote(str(v))}")
+        v_str = str(v).lower() if isinstance(v, bool) else str(v)
+        print(f"export {k}={shlex.quote(v_str)}")
 
     srv_opts = case_data.get("server_command_options", {})
     cli_opts = case_data.get("client_command_options", {})
@@ -170,18 +213,17 @@ def main():
     export_env_if_valid(srv_opts, "max-num-seqs", "MAX_NUM_SEQS")
     export_env_if_valid(srv_opts, "max-num-batched-tokens", "MAX_NUM_BATCHED_TOKENS")
     export_env_if_valid(srv_opts, "max-model-len", "MAX_MODEL_LEN")
-    cli_env = cli_opts.get("env", {})
-    cli_env_parts = [f"{k}={v}" for k, v in cli_env.items()]
+    cli_cmd_type = cli_opts.get("command_type", "vllm_bench_serve")
+    cli_env = cli_opts.get("env", {}).copy()
+    cli_env_parts = [f"{k}={str(v).lower() if isinstance(v, bool) else v}" for k, v in cli_env.items()]
     quoted_cli_env = ' '.join(shlex.quote(p) for p in cli_env_parts)
     print(f"CLIENT_CMD_ENVS=({quoted_cli_env})")
     # CLIENT_CMD_ENVS_STR for lm_eval
     print(f"export CLIENT_CMD_ENVS_STR={shlex.quote(quoted_cli_env)}")
     srv_env = srv_opts.get("env", {})
-    srv_env_list = [f"{k}={v}" for k, v in srv_env.items()]
+    srv_env_list = [f"{k}={str(v).lower() if isinstance(v, bool) else v}" for k, v in srv_env.items()]
     srv_env_str = ' '.join(shlex.quote(item) for item in srv_env_list)
     print(f"SERVER_CMD_ENVS=({srv_env_str})")
-
-    cli_cmd_type = cli_opts.get("command_type", "vllm_bench_serve")
 
     # Output execution strategy based on command_type
     if cli_cmd_type == "lm_eval":
@@ -212,6 +254,16 @@ def main():
         quoted_cli_cmd = ' '.join(
             shlex.quote(arg) for arg in shlex.split(cli_cmd))
         print(f"CLIENT_CMD=({quoted_cli_cmd})")
+
+        acc_opts = case_data.get("accuracy_command_options")
+        if acc_opts:
+            acc_cmd_type = acc_opts.get("command_type", "local_benchmark_serving")
+            acc_resolved_args = resolve_device_args(acc_opts.get("args", {}), current_machine)
+
+            acc_cmd = build_command(acc_cmd_type, acc_resolved_args)
+            quoted_acc_cmd = ' '.join(
+                shlex.quote(arg) for arg in shlex.split(acc_cmd))
+            print(f"ACCURACY_CMD=({quoted_acc_cmd})")
 
         tensor_parallel_size = srv_resolved_args.get("tensor-parallel-size", {})
         print(f"export TENSOR_PARALLEL_SIZE=\"{tensor_parallel_size}\"")

--- a/.buildkite/benchmark/scripts/report_result.sh
+++ b/.buildkite/benchmark/scripts/report_result.sh
@@ -24,7 +24,7 @@ on_crash() {
     local line_no=$1
     local command="$2"
     
-    # Ignore normal exits (Fixed SC2086 by adding double quotes)
+    # Ignore normal exits
     if [ "$exit_code" -eq 0 ]; then
         return
     fi
@@ -143,6 +143,14 @@ if [[ -n "${GCS_BUCKET:-}" ]]; then
   # For now, it is hardcoded to use the `vllm-bm-bk-storage` bucket.
   # REMOTE_LOG_ROOT="gs://$GCS_BUCKET/job_logs/$RECORD_ID/"
   REMOTE_LOG_ROOT="gs://vllm-bm-bk-storage/job_logs/$RECORD_ID/"
+  if command -v gsutil &> /dev/null; then
+    echo "--- Uploading $LOG_FOLDER to unified GCS: $REMOTE_LOG_ROOT"
+    gsutil cp -r "$LOG_FOLDER"/* "$REMOTE_LOG_ROOT" || echo "Warning: Failed to upload log folder to GCS."
+  else
+    echo "Warning: gsutil not found. Skipping log upload to GCS."
+  fi
+else
+  echo "Warning: GCS_BUCKET is not set. Skipping log upload to GCS."
 fi
 
 (
@@ -159,50 +167,38 @@ fi
   printf "[INFO] LOG_FOLDER=\n%s\n" "$LOG_FOLDER"
 
   # Handle log file
-  
-  if [[ -n "${GCS_BUCKET:-}" ]]; then
-    if command -v gsutil &> /dev/null; then
-      echo "gsutil cp $LOG_FOLDER/* $REMOTE_LOG_ROOT"
-      gsutil cp -r "$LOG_FOLDER"/* "$REMOTE_LOG_ROOT"
-    else
-      echo "Warning: gsutil not found. Skipping log upload to GCS."
-    fi
-  else
-    echo "Warning: GCS_BUCKET is not set. Skipping log upload to GCS."
-  fi
 
   # Metric data extraction from log file
   BM_LOG="$LOG_FOLDER/bm_log.txt"
 
+  # Use unified Python script to parse all metrics from the log
+  python3 "$(dirname "$0")/parse_benchmark_log.py" "$BM_LOG" "$RESULT_FILE" || true
+
+  if [ "$EXIT_CODE" -eq 0 ]; then
+
   if [[ "$RUN_TYPE" == *"ACCURACY"* ]]; then
-    # Accuracy run logic
-    echo "Accuracy run ($RUN_TYPE) detected. Parsing accuracy metrics."
-    AccuracyMetricsJSON=$(grep -a "AccuracyMetrics:" "$BM_LOG" | sed 's/AccuracyMetrics: //' || true)
-    echo "AccuracyMetricsJSON: $AccuracyMetricsJSON"
-    if [ -n "$AccuracyMetricsJSON" ]; then
-      echo "AccuracyMetrics=$AccuracyMetricsJSON" > "$RESULT_FILE"
-    else
-      echo "Error: Accuracy run but no AccuracyMetrics found."
+    # Accuracy run logic validation
+    if ! grep -q "AccuracyMetrics" "$RESULT_FILE"; then
+      echo "Error: Accuracy run ($RUN_TYPE) but no AccuracyMetrics found."
       exit 1
     fi
   else
-    # Performance run logic
-    throughput=$(grep -i "^Request throughput (req/s):" "$BM_LOG" | sed 's/[^0-9.]//g' || true)
-    echo "throughput: $throughput"
-
-    output_token_throughput=$(grep -i "^Output token throughput (tok/s):" "$BM_LOG" | sed 's/[^0-9.]//g' || true)
-    total_token_throughput=$(grep -i "^Total Token throughput (tok/s):" "$BM_LOG" | sed 's/[^0-9.]//g' || true)
-
+    # Performance run logic validation
+    # Extract Throughput from RESULT_FILE to check against EXPECTED_THROUGHPUT
+    throughput=$(grep "^Throughput=" "$RESULT_FILE" | cut -d "=" -f 2 || true)
+    
     if [[ -z "$throughput" || ! "$throughput" =~ ^[0-9]+([.][0-9]+)?$ ]]; then
       echo "Failed to get the throughput and this is not an accuracy run."
       exit 1
     fi
 
+    output_token_throughput=$(grep "^OutputTokenThroughput=" "$RESULT_FILE" | cut -d "=" -f 2 || true)
     if [[ -z "$output_token_throughput" || ! "$output_token_throughput" =~ ^[0-9]+([.][0-9]+)?$ ]]; then
       echo "Failed to get output_token_throughput."
       exit 1
     fi
 
+    total_token_throughput=$(grep "^TotalTokenThroughput=" "$RESULT_FILE" | cut -d "=" -f 2 || true)
     if [[ -z "$total_token_throughput" || ! "$total_token_throughput" =~ ^[0-9]+([.][0-9]+)?$ ]]; then
       echo "Failed to get total_token_throughput."
       exit 1
@@ -214,51 +210,14 @@ fi
     if [ "$IS_LOW_THROUGHPUT" -eq 1 ]; then
       echo "Error: throughput($throughput) is less than expected($EXPECTED_THROUGHPUT_VAL) or is 0"
     fi
-    echo "Throughput=$throughput" > "$RESULT_FILE"
-
-    extract_value() {
-      local section="$1"
-      local label="$2"  # Mean, Median, or P99
-      grep "$section (ms):" "$BM_LOG" | \
-      awk -v label="$label" '$0 ~ label { print $NF }' || true
-    }
-
-    # Median values
-    MedianITL=$(extract_value "ITL" "Median")
-    MedianTPOT=$(extract_value "TPOT" "Median")
-    MedianTTFT=$(extract_value "TTFT" "Median")
-    MedianETEL=$(extract_value "E2EL" "Median")
-
-    # P99 values
-    P99ITL=$(extract_value "ITL" "P99")
-    P99TPOT=$(extract_value "TPOT" "P99")
-    P99TTFT=$(extract_value "TTFT" "P99")
-    P99ETEL=$(extract_value "E2EL" "P99")
-
-    # Write results to file
-    (
-      printf '%s=%s\n' \
-      "MedianITL" "$MedianITL" \
-      "MedianTPOT" "$MedianTPOT" \
-      "MedianTTFT" "$MedianTTFT" \
-      "MedianETEL" "$MedianETEL" \
-      "P99ITL" "$P99ITL" \
-      "P99TPOT" "$P99TPOT" \
-      "P99TTFT" "$P99TTFT" \
-      "P99ETEL" "$P99ETEL" \
-      "OutputTokenThroughput" "$output_token_throughput" \
-      "TotalTokenThroughput" "$total_token_throughput"
-    ) >> "$RESULT_FILE"
+  fi
+  else
+    echo "--- Skipping metric validation because EXIT_CODE ($EXIT_CODE) indicates failure."
   fi
 )
 
 # Database Reporting Logic (ON CONFLICT (RecordId) DO UPDATE SET)
 if [[ "${UPLOAD_DB:-true}" == "true" && -n "${GCP_DATABASE_ID:-}" && -n "${GCP_PROJECT_ID:-}" && -n "${GCP_INSTANCE_ID:-}" ]]; then
-  if [ "$EXIT_CODE" -ne 0 ]; then
-    echo "--- run_bm.sh failed with exit code $EXIT_CODE. Skipping DB reporting."
-    exit 0
-  fi
-
   MANDATORY_VARS=(
     "RECORD_ID"
     "DEVICE"
@@ -322,7 +281,9 @@ if [[ "${UPLOAD_DB:-true}" == "true" && -n "${GCP_DATABASE_ID:-}" && -n "${GCP_P
           insert_vals+=", $val_str"
           # Use excluded keyword to refer to the proposed insert value
           update_metrics+=", ${key}=excluded.${key}"
-          FINAL_STATUS="COMPLETED"
+          if [ "$EXIT_CODE" -eq 0 ]; then
+              FINAL_STATUS="COMPLETED"
+          fi
       done < "$RESULT_FILE"
   fi
 
@@ -340,7 +301,7 @@ if [[ "${UPLOAD_DB:-true}" == "true" && -n "${GCP_DATABASE_ID:-}" && -n "${GCP_P
   SQL_JOB_REFERENCE=$(prepare_sql_val "${JOB_REFERENCE:-}" "''")
   SQL_AGENT_NAME=$(prepare_sql_val "${BUILDKITE_AGENT_NAME:-}" "''")
   SQL_DEVICE=$(prepare_sql_val "${DEVICE:-}" "''")
-  SQL_MODEL=$(prepare_sql_val "${MODEL:-}" "''")
+  SQL_MODEL=$(prepare_sql_val "${MODEL_NAME:-${MODEL:-}}" "''")
   SQL_RUN_TYPE=$(prepare_sql_val "${RUN_TYPE:-DAILY}" "DAILY")
   SQL_CODE_HASH=$(prepare_sql_val "${CODE_HASH:-}" "''")
   SQL_CASE_NAME=$(prepare_sql_val "${TARGET_CASE_NAME:-}" "''")

--- a/.buildkite/benchmark/scripts/run_bm.sh
+++ b/.buildkite/benchmark/scripts/run_bm.sh
@@ -54,6 +54,7 @@ CASE_FILE="$1"
 TARGET_CASE_NAME=${2:-""}
 VLLM_PID=""
 CLEANUP_DONE="false"
+BENCHMARK_TIMEOUT="${BENCHMARK_TIMEOUT:-2h}"
 
 if [ -z "$CASE_FILE" ] || [ -z "$TARGET_CASE_NAME" ]; then
     echo "Usage: $0 <case.json> <TARGET_CASE_NAME>"
@@ -66,6 +67,12 @@ echo "TARGET_CASE_NAME: $TARGET_CASE_NAME"
 # shellcheck disable=SC2317
 cleanup() {
     local exit_code=$?
+
+    # Do not kill the server if it was started externally
+    if [[ "${SERVER_ALREADY_RUNNING:-false}" == "true" ]]; then
+        echo "[INFO] Multi-host server runs externally. Skipping local cleanup."
+        return
+    fi
 
     # Only perform cleanup if NOT in Buildkite (Local only)
     if [[ "${BUILDKITE:-false}" == "true" ]]; then
@@ -135,10 +142,72 @@ export ARTIFACT_FOLDER
 export LOG_FOLDER
 export VLLM_TORCH_PROFILER_DIR
 
+
+run_accuracy_if_needed() {
+  # If an accuracy command was configured in JSON, execute it sequentially after throughput is completed
+  if [[ ${#ACCURACY_CMD[@]} -gt 0 ]]; then
+    echo ""
+    echo "====================================================================="
+    echo "[INFO] Executing Accuracy Verification Phase"
+    echo "====================================================================="
+
+    local needs_mmlu=false
+    for arg in "${ACCURACY_CMD[@]}"; do
+      if [[ "$arg" == *"mmlu"* ]]; then
+        needs_mmlu=true
+        break
+      fi
+    done
+
+    if [[ "$needs_mmlu" == "true" ]]; then
+      # Download dataset using wget if it is not present in the workspace
+      DATASET_DIR="/workspace/mmlu"
+      if [ ! -d "$DATASET_DIR/data/test" ]; then
+        echo "MMLU dataset test folder not found, downloading via wget..."
+        mkdir -p "$DATASET_DIR"
+        cd "$DATASET_DIR" || report_and_exit 1
+        if [ ! -f data.tar ]; then
+          echo "Downloading data.tar..."
+          wget --tries=3 --timeout=15 https://people.eecs.berkeley.edu/~hendrycks/data.tar -P . || report_and_exit 1
+        fi
+        if [ ! -d "data/test" ]; then
+          echo "Extracting data.tar..."
+          tar -xf data.tar || report_and_exit 1
+        fi
+        # Return to previous directory
+        cd - > /dev/null
+      fi
+    fi
+
+    echo "Running accuracy benchmark using JSON configured ACCURACY_CMD..."
+    set +e
+    timeout "$BENCHMARK_TIMEOUT" "${ACCURACY_CMD[@]}" >> "$BM_LOG" 2>&1
+    local accuracy_exit_code=$?
+    set -e
+
+    if [[ "$accuracy_exit_code" -eq 124 ]]; then
+      echo "[ERROR] Accuracy benchmark timed out after $BENCHMARK_TIMEOUT."
+      echo "--- Dumping BM_LOG for debugging ---"
+      tail -n 100 "$BM_LOG"
+      report_and_exit 1
+    elif [[ "$accuracy_exit_code" -ne 0 ]]; then
+      echo "[ERROR] Accuracy benchmark failed during execution."
+      echo "--- Dumping BM_LOG for debugging ---"
+      tail -n 100 "$BM_LOG"
+      report_and_exit 1 
+    fi
+  fi
+}
+
 report_and_exit() {
   local exit_code=${1:-0}
   local record_id="${RECORD_ID:-local}"
   
+  if [[ "${SERVER_ALREADY_RUNNING:-false}" == "true" ]]; then
+    echo "--- Copying server log from /root/vllm_serve.log to $VLLM_LOG"
+    cp /root/vllm_serve.log "$VLLM_LOG" || true
+  fi
+
   echo "--- Calling report_result.sh for RECORD_ID=${record_id} with exit_code=${exit_code}"
   bash "$SCRIPT_DIR/report_result.sh" "$record_id" "$exit_code" || exit $?
   
@@ -150,6 +219,12 @@ echo "--- Preparing Local Artifacts Folder"
 mkdir -p "$ARTIFACT_FOLDER"
 mkdir -p "$LOG_FOLDER"
 mkdir -p "$VLLM_TORCH_PROFILER_DIR"
+
+ACCURACY_CMD=()
+SERVER_CMD=()
+CLIENT_CMD=()
+CLIENT_CMD_ENVS=()
+SERVER_CMD_ENVS=()
 
 PYTHON_PARSER="$SCRIPT_DIR/parser_case.py"
 # Evaluate the Python output to set variables in the current shell context
@@ -177,6 +252,30 @@ contains_element () {
   for e; do [[ "$e" == "$match" ]] && return 0; done
   return 1
 }
+
+# ---------------------------------------------------------
+# Dynamic Port Injection (Single & Multi-Host)
+# ---------------------------------------------------------
+# If VLLM_PORT wasn't provided by the environment, try to extract it from SERVER_CMD
+if [[ -z "${VLLM_PORT:-}" ]]; then
+  SERVER_CMD_STR="${SERVER_CMD[*]:-}"
+  if [[ "${SERVER_CMD_STR}" =~ --port[=\ ]+([0-9]+) ]]; then
+    VLLM_PORT="${BASH_REMATCH[1]}"
+    echo "--- Extracted VLLM_PORT=${VLLM_PORT} from SERVER_CMD locally"
+  fi
+fi
+
+if [[ -n "${VLLM_PORT:-}" ]]; then
+  echo "--- Injecting VLLM_PORT=${VLLM_PORT} into client commands"
+  
+  if [[ ${#CLIENT_CMD[@]} -gt 0 ]] && ! contains_element "--port" "${CLIENT_CMD[@]}"; then
+    CLIENT_CMD+=("--port" "$VLLM_PORT")
+  fi
+  
+  if [[ ${#ACCURACY_CMD[@]} -gt 0 ]] && ! contains_element "--port" "${ACCURACY_CMD[@]}"; then
+    ACCURACY_CMD+=("--port" "$VLLM_PORT")
+  fi
+fi
 
 # ---------------------------------------------------------
 # DECODE_ONLY Mode Configuration Validation & Dataset Injection
@@ -312,12 +411,12 @@ if contains_element "$DATASET" "${DATASETS[@]}"; then
 fi
 
 # Prep specialized configurations (DeepSeek)
-if [[ "$MODEL" == "deepseek-ai/DeepSeek-R1" ]]; then
+if [[ "$MODEL" == "deepseek-ai/DeepSeek-R1" && "${IS_MULTI_HOST_BENCH:-false}" == "false" ]]; then
   if command -v gsutil &> /dev/null; then
     echo "Syncing generation configs for DeepSeek-R1"
     GENERATION_CONFIG_FOLDER="$ARTIFACT_FOLDER/generation_configs"
     mkdir -p "$GENERATION_CONFIG_FOLDER"
-    gsutil -m cp -r gs://gpolovets-inference/deepseek/generation_configs/* "$GENERATION_CONFIG_FOLDER" || echo "Warning: failed to sync generation configs ${DATASET}"
+    gsutil -m cp -r gs://tpu-commons-ci/deepseek/* "$GENERATION_CONFIG_FOLDER" || echo "Warning: failed to sync generation configs ${DATASET}"
   else
     echo "Warning: gsutil not found. Skipping DeepSeek-R1 generation configs download from GCS."
   fi
@@ -351,127 +450,143 @@ echo "lanching vllm..."
 echo "logging to $VLLM_LOG"
 echo
 
-# Command from parser case json
-echo "[INFO] Starting vLLM Server in background..."
+SERVER_ALREADY_RUNNING="${SERVER_ALREADY_RUNNING:-false}"
+# In Single-Host mode, run_bm.sh is responsible for starting and monitoring the vLLM server.
+# In Multi-Host mode, run_multihost.sh has already started the server via Ray and sets this flag to "true",
+# so we skip the local background startup and wait logic here.
+if [[ "$SERVER_ALREADY_RUNNING" == "false" ]]; then
+  # Command from parser case json
+  echo "[INFO] Starting vLLM Server in background..."
 
-echo "Printing the vllm serve command used to start the server:"
-printf "[DEBUG] Executing server_cmd: %s %s > \"%s\" 2>&1 &\n" "${SERVER_CMD_ENVS[*]}" "${SERVER_CMD[*]}" "$VLLM_LOG"
+  echo "Printing the vllm serve command used to start the server:"
+  printf "[DEBUG] Executing server_cmd: %s %s > \"%s\" 2>&1 &\n" "${SERVER_CMD_ENVS[*]}" "${SERVER_CMD[*]}" "$VLLM_LOG"
 
-# Start the server and capture its PID
-env "${SERVER_CMD_ENVS[@]}" "${SERVER_CMD[@]}" > "$VLLM_LOG" 2>&1 &
-VLLM_PID=$!
+  # Start the server and capture its PID
+  env "${SERVER_CMD_ENVS[@]}" "${SERVER_CMD[@]}" > "$VLLM_LOG" 2>&1 &
+  VLLM_PID=$!
 
-# Immediate check to see if it crashed on startup
-sleep 2
-if ! kill -0 "$VLLM_PID" 2>/dev/null; then
-    echo "[ERROR] vLLM Server failed to start immediately. Check log: $VLLM_LOG"
-    exit 1
+  # Immediate check to see if it crashed on startup
+  sleep 2
+  if ! kill -0 "$VLLM_PID" 2>/dev/null; then
+      echo "[ERROR] vLLM Server failed to start immediately. Check log: $VLLM_LOG"
+      exit 1
+  fi
+
+  # ---------------------------------------------------------
+  # Server startup wait logic
+  # ---------------------------------------------------------
+  SERVER_WAIT_MINS=${SERVER_WAIT_MINS:-60}
+
+  MAX_WAIT_SECONDS=$((SERVER_WAIT_MINS * 60))
+  WAIT_START_TIME=$(date +%s)
+  ELAPSED=0
+
+  echo "Waiting up to ${SERVER_WAIT_MINS} minutes for server to start (PID: ${VLLM_PID})..."
+
+  # Initial state set to not started
+  SERVER_STARTED="false"
+
+  # Loop continues as long as elapsed time is within the maximum allowed
+  while (( ELAPSED <= MAX_WAIT_SECONDS )); do
+      
+      # 1. [Fail-Fast Check] Ask the OS if the process is still alive
+      if ! kill -0 "$VLLM_PID" 2>/dev/null; then
+          echo "[ERROR] vLLM process (PID=$VLLM_PID) has exited unexpectedly!"
+          echo "--- Dumping VLLM_LOG for debugging ---"
+          cat "$VLLM_LOG"
+          exit 1
+      fi
+
+      # 2. [Success Check] Look for the startup completion flag
+      if grep -Fq "Application startup complete" "$VLLM_LOG"; then
+          echo "Application started successfully."
+          SERVER_STARTED="true"
+          break
+      fi
+
+      # 3. Print progress approximately every 1 minute (every 6 iterations) to keep logs clean
+      ITERATION=$((ELAPSED / 10))
+      if (( ITERATION % 6 == 0 )); then
+          ELAPSED_MIN=$((ELAPSED / 60))
+          ELAPSED_SEC=$((ELAPSED % 60))
+          printf "Still waiting... Elapsed: %02d:%02d / %02d:00\n" "$ELAPSED_MIN" "$ELAPSED_SEC" "$SERVER_WAIT_MINS"
+      fi
+
+      # 4. Wait 10 seconds before the next check
+      sleep 10
+
+      # 5. Update elapsed time for the next while loop condition evaluation
+      CURRENT_TIME=$(date +%s)
+      ELAPSED=$((CURRENT_TIME - WAIT_START_TIME))
+  done
+
+  # Direct exit if server is not started to prevent fetching the dirty bm result
+  if [[ "$SERVER_STARTED" == "false" ]]; then
+      echo "[ERROR] Server failed to start within ${SERVER_WAIT_MINS} minutes! Timeout reached."
+      echo "--- Dumping VLLM_LOG for debugging ---"
+      cat "$VLLM_LOG"
+      exit 1
+  fi
+
+  # ---------------------------------------------------------
+  # DECODE_ONLY Warmup Execution (Cache Seeding)
+  # ---------------------------------------------------------
+  if [[ "${DECODE_ONLY:-false}" == "true" ]]; then
+      echo "====================================================================="
+      echo "[INFO] DECODE_ONLY: Executing Warmup Phase"
+      echo "====================================================================="
+      echo "Warming up HBM Cache with exactly $MAX_NUM_SEQS distinct requests to prevent Cache Eviction..."
+      
+      # Copy the array for safe modification
+      WARMUP_CMD=("${CLIENT_CMD[@]}")
+      
+      found_prompts=false
+      
+      # In-place modification of existing flags
+      for i in "${!WARMUP_CMD[@]}"; do
+          arg="${WARMUP_CMD[$i]}"
+          if [[ "$arg" == "--num-prompts" ]]; then
+              WARMUP_CMD[i+1]="$MAX_NUM_SEQS"
+              found_prompts=true
+          elif [[ "$arg" == --num-prompts=* ]]; then
+              WARMUP_CMD[i]="--num-prompts=$MAX_NUM_SEQS"
+              found_prompts=true
+          fi
+      done
+      
+      # Append the flags if they were not found in the original command
+      if [[ "$found_prompts" == false ]]; then
+          WARMUP_CMD+=( "--num-prompts" "$MAX_NUM_SEQS" )
+      fi
+      
+      echo "[DEBUG] WARMUP_CMD: ${CLIENT_CMD_ENVS[*]} ${WARMUP_CMD[*]}"
+      set +e
+      timeout "$BENCHMARK_TIMEOUT" env "${CLIENT_CMD_ENVS[@]}" "${WARMUP_CMD[@]}" > "$LOG_FOLDER/warmup_log.txt" 2>&1
+      warmup_exit_code=$?
+      set -e
+      
+      if [[ "$warmup_exit_code" -eq 124 ]]; then
+          echo "[ERROR] Warmup phase timed out after $BENCHMARK_TIMEOUT!"
+          echo "--- Dumping Warmup Log ---"
+          cat "$LOG_FOLDER/warmup_log.txt"
+          exit 1
+      elif [[ "$warmup_exit_code" -ne 0 ]]; then
+          echo "[ERROR] Warmup phase failed with exit code $warmup_exit_code!"
+          echo "--- Dumping Warmup Log ---"
+          cat "$LOG_FOLDER/warmup_log.txt"
+          exit 1
+      fi
+      
+      echo "[INFO] Warmup Phase Completed Successfully. Cache is strictly seeded."
+      echo "[INFO] Proceeding to Decode-Only concurrency stress testing."
+      echo "====================================================================="
+  fi
+else
+    echo "[INFO] Server is managed externally (Multi-Host). Skipping startup and wait logic."
+    SERVER_STARTED="true"
+    VLLM_PID=""
 fi
 
-# ---------------------------------------------------------
-# Server startup wait logic
-# ---------------------------------------------------------
-SERVER_WAIT_MINS=${SERVER_WAIT_MINS:-60}
-
-MAX_WAIT_SECONDS=$((SERVER_WAIT_MINS * 60))
-WAIT_START_TIME=$(date +%s)
-ELAPSED=0
-
-echo "Waiting up to ${SERVER_WAIT_MINS} minutes for server to start (PID: ${VLLM_PID})..."
-
-# Initial state set to not started
-SERVER_STARTED="false"
-
-# Loop continues as long as elapsed time is within the maximum allowed
-while (( ELAPSED <= MAX_WAIT_SECONDS )); do
-    
-    # 1. [Fail-Fast Check] Ask the OS if the process is still alive
-    if ! kill -0 "$VLLM_PID" 2>/dev/null; then
-        echo "[ERROR] vLLM process (PID=$VLLM_PID) has exited unexpectedly!"
-        echo "--- Dumping VLLM_LOG for debugging ---"
-        cat "$VLLM_LOG"
-        exit 1
-    fi
-
-    # 2. [Success Check] Look for the startup completion flag
-    if grep -Fq "Application startup complete" "$VLLM_LOG"; then
-        echo "Application started successfully."
-        SERVER_STARTED="true"
-        break
-    fi
-
-    # 3. Print progress approximately every 1 minute (every 6 iterations) to keep logs clean
-    ITERATION=$((ELAPSED / 10))
-    if (( ITERATION % 6 == 0 )); then
-        ELAPSED_MIN=$((ELAPSED / 60))
-        ELAPSED_SEC=$((ELAPSED % 60))
-        printf "Still waiting... Elapsed: %02d:%02d / %02d:00\n" "$ELAPSED_MIN" "$ELAPSED_SEC" "$SERVER_WAIT_MINS"
-    fi
-
-    # 4. Wait 10 seconds before the next check
-    sleep 10
-
-    # 5. Update elapsed time for the next while loop condition evaluation
-    CURRENT_TIME=$(date +%s)
-    ELAPSED=$((CURRENT_TIME - WAIT_START_TIME))
-done
-
-# Direct exit if server is not started to prevent fetching the dirty bm result
-if [[ "$SERVER_STARTED" == "false" ]]; then
-    echo "[ERROR] Server failed to start within ${SERVER_WAIT_MINS} minutes! Timeout reached."
-    echo "--- Dumping VLLM_LOG for debugging ---"
-    cat "$VLLM_LOG"
-    exit 1
-fi
-
-# ---------------------------------------------------------
-# DECODE_ONLY Warmup Execution (Cache Seeding)
-# ---------------------------------------------------------
-if [[ "${DECODE_ONLY:-false}" == "true" ]]; then
-    echo "====================================================================="
-    echo "[INFO] DECODE_ONLY: Executing Warmup Phase"
-    echo "====================================================================="
-    echo "Warming up HBM Cache with exactly $MAX_NUM_SEQS distinct requests to prevent Cache Eviction..."
-    
-    # Copy the array for safe modification
-    WARMUP_CMD=("${CLIENT_CMD[@]}")
-    
-    found_prompts=false
-    
-    # In-place modification of existing flags
-    for i in "${!WARMUP_CMD[@]}"; do
-        arg="${WARMUP_CMD[$i]}"
-        if [[ "$arg" == "--num-prompts" ]]; then
-            WARMUP_CMD[i+1]="$MAX_NUM_SEQS"
-            found_prompts=true
-        elif [[ "$arg" == --num-prompts=* ]]; then
-            WARMUP_CMD[i]="--num-prompts=$MAX_NUM_SEQS"
-            found_prompts=true
-        fi
-    done
-    
-    # Append the flags if they were not found in the original command
-    if [[ "$found_prompts" == false ]]; then
-        WARMUP_CMD+=( "--num-prompts" "$MAX_NUM_SEQS" )
-    fi
-    
-    echo "[DEBUG] WARMUP_CMD: ${CLIENT_CMD_ENVS[*]} ${WARMUP_CMD[*]}"
-    set +e
-    env "${CLIENT_CMD_ENVS[@]}" "${WARMUP_CMD[@]}" > "$LOG_FOLDER/warmup_log.txt" 2>&1
-    warmup_exit_code=$?
-    set -e
-    
-    if [[ "$warmup_exit_code" -ne 0 ]]; then
-        echo "[ERROR] Warmup phase failed with exit code $warmup_exit_code!"
-        echo "--- Dumping Warmup Log ---"
-        cat "$LOG_FOLDER/warmup_log.txt"
-        exit 1
-    fi
-    
-    echo "[INFO] Warmup Phase Completed Successfully. Cache is strictly seeded."
-    echo "[INFO] Proceeding to Decode-Only concurrency stress testing."
-    echo "====================================================================="
-fi
 
 # Set Default
 EXPECTED_ETEL=${EXPECTED_ETEL:-3600000}
@@ -516,11 +631,16 @@ run_benchmark(){
   echo "[DEBUG] Executing client_cmd: ${CLIENT_CMD_ENVS[*]} ${CLIENT_CMD[*]} > $BM_LOG" >&2
   set +e
   # Execute the array directly, preserving strict argument boundaries
-  env "${CLIENT_CMD_ENVS[@]}" "${CLIENT_CMD[@]}" > "$BM_LOG" 2>&1
+  timeout "$BENCHMARK_TIMEOUT" env "${CLIENT_CMD_ENVS[@]}" "${CLIENT_CMD[@]}" > "$BM_LOG" 2>&1
   local client_exit_code=$?
   set -e
 
-  if [ $client_exit_code -ne 0 ]; then
+  if [ $client_exit_code -eq 124 ]; then
+    echo "[ERROR] Client command timed out after $BENCHMARK_TIMEOUT." >&2
+    echo "--- Dumping BM_LOG for debugging ---" >&2
+    cat "$BM_LOG" >&2
+    return $client_exit_code
+  elif [ $client_exit_code -ne 0 ]; then
     echo "[ERROR] An error occurred while executing client_cmd." >&2
     return $client_exit_code
   fi
@@ -608,66 +728,68 @@ echo "p99_e2el:$p99_e2el"
 p99_int=$(printf "%.0f" "$p99_e2el")
 goal_int=$(printf "%.0f" "$EXPECTED_ETEL")
 
-if (( p99_int <= goal_int )); then
-  echo "Initial run: P99 E2EL ($p99_e2el ms) <= EXPECTED_ETEL ($EXPECTED_ETEL ms), good enough. Exiting 0."
-  report_and_exit 0
-fi
+if [[ "${RUN_ONCE:-false}" == "true" ]]; then
+  echo "[INFO] RUN_ONCE is enabled. Skipping binary search and reporting results."
+elif (( p99_int <= goal_int )); then
+  echo "Initial run: P99 E2EL ($p99_e2el ms) <= EXPECTED_ETEL ($EXPECTED_ETEL ms), good enough. Skipping sweep."
+else
+  echo "Initial run failed: P99 E2EL ($p99_e2el ms) > EXPECTED_ETEL ($EXPECTED_ETEL ms)"
+  echo "Starting binary search to lower request rate..."
 
-echo "Initial run failed: P99 E2EL ($p99_e2el ms) > EXPECTED_ETEL ($EXPECTED_ETEL ms)"
-echo "Starting binary search to lower request rate..."
+  # Step 2: Binary search
+  low=0
+  high=$(printf "%.0f" "$throughput")
+  goal=$EXPECTED_ETEL
 
-# Step 2: Binary search
-low=0
-high=$(printf "%.0f" "$throughput")
-goal=$EXPECTED_ETEL
+  # Round goal to nearest int
+  goal_int=$(printf "%.0f" "$goal")
 
-# Round goal to nearest int
-goal_int=$(printf "%.0f" "$goal")
+  best_rate=0
+  best_throughput=0
+  best_e2el=0
 
-best_rate=0
-best_throughput=0
-best_e2el=0
+  while (( high - low > 0 )); do
+    mid=$(( (low + high + 1) / 2 ))
+    echo "Trying request_rate=$mid"
 
-while (( high - low > 0 )); do
-  mid=$(( (low + high + 1) / 2 ))
-  echo "Trying request_rate=$mid"
+    # Single function call with double-layer defense (exit code interception + regex validation)
+    execute_benchmark_safely "$mid"
+    throughput="$VALID_THROUGHPUT"
+    p99_e2el="$VALID_P99_E2EL"
 
-  # Single function call with double-layer defense (exit code interception + regex validation)
-  execute_benchmark_safely "$mid"
-  throughput="$VALID_THROUGHPUT"
-  p99_e2el="$VALID_P99_E2EL"
+    # Convert p99_e2el to integer
+    p99_int=$(printf "%.0f" "$p99_e2el")
 
-  # Convert p99_e2el to integer
-  p99_int=$(printf "%.0f" "$p99_e2el")
+    if (( p99_int <= goal_int )); then
+      echo "PASS: p99_e2el=$p99_e2el <= $goal"
+      best_rate=$mid
+      best_throughput=$throughput
+      best_e2el=$p99_e2el
+      low=$mid
 
-  if (( p99_int <= goal_int )); then
-    echo "PASS: p99_e2el=$p99_e2el <= $goal"
-    best_rate=$mid
-    best_throughput=$throughput
-    best_e2el=$p99_e2el
-    low=$mid
+      # Backup best log
+      cp "$BM_LOG" "$BEST_BM_LOG"
+    else
+      echo "FAIL: p99_e2el=$p99_e2el > $goal"
+      high=$((mid - 1))
+    fi
+  done
 
-    # Backup best log
-    cp "$BM_LOG" "$BEST_BM_LOG"
-  else
-    echo "FAIL: p99_e2el=$p99_e2el > $goal"
-    high=$((mid - 1))
+  if (( best_rate == 0 )); then
+    echo "Could not find a valid request_rate >= 1 that meets EXPECTED_ETEL=$EXPECTED_ETEL" | tee -a "$BM_LOG"
+    report_and_exit 1
   fi
-done
 
-if (( best_rate == 0 )); then
-  echo "Could not find a valid request_rate >= 1 that meets EXPECTED_ETEL=$EXPECTED_ETEL" | tee -a "$BM_LOG"
-  report_and_exit 1
+  # Restore the best log to BM_LOG
+  cp "$BEST_BM_LOG" "$BM_LOG"
+
+  echo
+  echo "======================================"
+  echo "✓ Final best request_rate: $best_rate"
+  echo "✓ Throughput: $best_throughput"
+  echo "✓ P99 E2EL: $best_e2el"
+  echo "======================================"
 fi
 
-# Restore the best log to BM_LOG
-cp "$BEST_BM_LOG" "$BM_LOG"
-
-echo
-echo "======================================"
-echo "✓ Final best request_rate: $best_rate"
-echo "✓ Throughput: $best_throughput"
-echo "✓ P99 E2EL: $best_e2el"
-echo "======================================"
-
+run_accuracy_if_needed
 report_and_exit 0

--- a/.buildkite/benchmark/scripts/run_job.sh
+++ b/.buildkite/benchmark/scripts/run_job.sh
@@ -77,6 +77,10 @@ PROFILE_FOLDER="${LOG_FOLDER}/profile"
 
 # Do cleanup before create config
 cleanup_artifact_log() {
+  if [ -d "$ARTIFACT_FOLDER" ]; then
+    echo "--- Reclaiming artifact folder ownership for CI cleanup..."
+    sudo -n chown -R "$(id -u):$(id -g)" "$ARTIFACT_FOLDER" || true
+  fi
   echo "deleting artifacts: $ARTIFACT_FOLDER"
   rm -rf "$ARTIFACT_FOLDER"
 }
@@ -122,29 +126,83 @@ declare -a BENCHMARK_DOCKER_ARGS=(
 BENCHMARK_DOCKER_ARGS_STR="$(printf '%s\n' "${BENCHMARK_DOCKER_ARGS[@]}")"
 export BENCHMARK_DOCKER_ARGS_STR
 
-echo "--- Running job in docker via run_in_docker.sh"
-BM_JOB_STATUS=$EXIT_SUCCESS
+# Determine if it is a multi-host run.
+IS_MULTI_HOST_BENCH="${IS_MULTI_HOST_BENCH:-false}"
+if [[ ( "${VERSION:-}" == "7x" && ${COUNT:-0} -gt 8 ) || "${TPU_MULTIHOST_BACKEND:-}" == "ray" ]]; then
+    IS_MULTI_HOST_BENCH="true"
+fi
+export IS_MULTI_HOST_BENCH
 
+BM_JOB_STATUS=$EXIT_SUCCESS
 export BM_INFRA="true"
 
-.buildkite/scripts/run_in_docker.sh bash -c "
-  if [[ \"${KERNEL_AUTOTUNE_STAGE:-}\" == \"PRE_KERNEL_AUTOTUNE_CASES_COLLECTION\" ]]; then
-    pip install --upgrade -r tools/kernel/tuner/v1/storage_management/requirements.txt && \
-    source .buildkite/benchmark/scripts/kernel_autotune.sh && \
-    update_all_tuned_params_py || exit 1
-  fi && \
-  if [[ \"${KERNEL_AUTOTUNE_STAGE:-}\" == \"POST_KERNEL_AUTOTUNE_BM_RERUN\" ]]; then
-    pip install --upgrade -r tools/kernel/tuner/v1/storage_management/requirements.txt && \
-    source .buildkite/benchmark/scripts/kernel_autotune.sh && \
-    checkout_updated_tuned_params_py_branch || exit 1
-  fi && \
-  echo always > /sys/kernel/mm/transparent_hugepage/enabled && \
-  chmod +x .buildkite/benchmark/scripts/run_bm.sh && \
-  .buildkite/benchmark/scripts/run_bm.sh $CASE_FILE $TARGET_CASE_NAME" || {
-    echo "Error running benchmark job in docker."
-    BM_JOB_STATUS=$EXIT_FAILURE
-}
+if [[ "${IS_MULTI_HOST_BENCH:-false}" == "true" ]]; then
+    echo "--- Multi-host environment detected. Running via run_multihost.sh on host..."
 
+    export EXTRA_DOCKER_ARGS="-v $ARTIFACT_FOLDER:/workspace/tpu_inference/artifacts \
+      -v /etc/boto.cfg:/etc/boto.cfg \
+      -e ARTIFACT_FOLDER=/workspace/tpu_inference/artifacts \
+      -e DEVICE=$DEVICE \
+      -e RECORD_ID=$RECORD_ID \
+      -e RUN_TYPE=$RUN_TYPE \
+      -e CODE_HASH=${CODE_HASH} \
+      -e JOB_REFERENCE=${JOB_REFERENCE} \
+      -e GCP_PROJECT_ID=${GCP_PROJECT_ID:-} \
+      -e GCP_INSTANCE_ID=${GCP_INSTANCE_ID:-} \
+      -e GCP_DATABASE_ID=${GCP_DATABASE_ID:-} \
+      -e GCP_REGION=${GCP_REGION:-} \
+      -e GCS_BUCKET=${GCS_BUCKET:-} \
+      -e UPLOAD_DB=${UPLOAD_DB:-true} \
+      -e BUILDKITE=${BUILDKITE:-} \
+      -e BUILDKITE_AGENT_NAME=${BUILDKITE_AGENT_NAME:-} \
+      -e BUILDKITE_AGENT_META_DATA_QUEUE=${BUILDKITE_AGENT_META_DATA_QUEUE:-} \
+      -e BUILDKITE_BUILD_NUMBER=${BUILDKITE_BUILD_NUMBER:-} \
+      -e BUILDKITE_JOB_ID=${BUILDKITE_JOB_ID:-} \
+      -e MLCOMPASS_EXECUTION_MODE=${MLCOMPASS_EXECUTION_MODE:-} \
+      -e MLCOMPASS_EXPORT_ENABLED=${MLCOMPASS_EXPORT_ENABLED:-} \
+      -e MLCOMPASS_TEST_NAME=${MLCOMPASS_TEST_NAME:-} \
+      -e MLCOMPASS_TRACKING_ID=${MLCOMPASS_TRACKING_ID:-} \
+      -e MLCOMPASS_SPONGE_ID=${MLCOMPASS_SPONGE_ID:-} \
+      -e IS_MULTI_HOST_BENCH=true"
+
+    echo "Executing run_multihost.sh on host..."
+    .buildkite/scripts/run_multihost.sh "$CASE_FILE" "$TARGET_CASE_NAME" || {
+        echo "Error running multihost benchmark."
+        BM_JOB_STATUS=$EXIT_FAILURE
+    }
+
+    # Source the environment variables resolved inside the container from the metadata file
+    METADATA_FILE="/tmp/multihost_run_metadata.sh"
+    if [ -f "$METADATA_FILE" ]; then
+        # shellcheck source=/dev/null
+        source "$METADATA_FILE"
+        rm -f "$METADATA_FILE"
+    fi
+
+    # Move the server log from /tmp (saved by run_multihost.sh) to artifacts folder
+    if [ -f /tmp/vllm_serve.log ]; then
+        mv -f /tmp/vllm_serve.log "$LOG_FOLDER/vllm_log.txt"
+    fi
+else
+    echo "--- Running job in docker via run_in_docker.sh (Single-Host Mode)"
+    .buildkite/scripts/run_in_docker.sh bash -c "
+      if [[ \"${KERNEL_AUTOTUNE_STAGE:-}\" == \"PRE_KERNEL_AUTOTUNE_CASES_COLLECTION\" ]]; then
+        pip install --upgrade -r tools/kernel/tuner/v1/storage_management/requirements.txt && \
+        source .buildkite/benchmark/scripts/kernel_autotune.sh && \
+        update_all_tuned_params_py || exit 1
+      fi && \
+      if [[ \"${KERNEL_AUTOTUNE_STAGE:-}\" == \"POST_KERNEL_AUTOTUNE_BM_RERUN\" ]]; then
+        pip install --upgrade -r tools/kernel/tuner/v1/storage_management/requirements.txt && \
+        source .buildkite/benchmark/scripts/kernel_autotune.sh && \
+        checkout_updated_tuned_params_py_branch || exit 1
+      fi && \
+      echo always > /sys/kernel/mm/transparent_hugepage/enabled && \
+      chmod +x .buildkite/benchmark/scripts/run_bm.sh && \
+      .buildkite/benchmark/scripts/run_bm.sh $CASE_FILE $TARGET_CASE_NAME" || {
+        echo "Error running benchmark job in docker."
+        BM_JOB_STATUS=$EXIT_FAILURE
+    }
+fi
 
 (
   # Handle log file

--- a/.buildkite/benchmark/scripts/test_parse_benchmark_log.py
+++ b/.buildkite/benchmark/scripts/test_parse_benchmark_log.py
@@ -1,0 +1,159 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import os
+import tempfile
+
+from parse_benchmark_log import parse_benchmark_log
+
+
+def test_parse_benchmark_log_standard():
+    log_content = """
+tip: install termplotlib and gnuplot to plot the metrics
+============ Serving Benchmark Result ============
+Successful requests:                     1024      
+Failed requests:                         0         
+Benchmark duration (s):                  441.67    
+Total input tokens:                      8388608   
+Total generated tokens:                  1048576   
+Request throughput (req/s):              2.32      
+Output token throughput (tok/s):         2374.10   
+Peak output token throughput (tok/s):    5918.00   
+Peak concurrent requests:                1024.00   
+Total token throughput (tok/s):          21366.87  
+---------------Time to First Token----------------
+Mean TTFT (ms):                          164004.30 
+Median TTFT (ms):                        145423.02 
+P99 TTFT (ms):                           364320.86 
+-----Time per Output Token (excl. 1st token)------
+Mean TPOT (ms):                          210.93    
+Median TPOT (ms):                        241.14    
+P99 TPOT (ms):                           273.17    
+---------------Inter-token Latency----------------
+Mean ITL (ms):                           210.95    
+Median ITL (ms):                         238.27    
+P99 ITL (ms):                            349.54    
+----------------End-to-end Latency----------------
+Mean E2EL (ms):                          379782.45 
+Median E2EL (ms):                        392323.66 
+P99 E2EL (ms):                           441251.24 
+==================================================
+"""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        log_file = os.path.join(temp_dir, "bench.log")
+        result_file = os.path.join(temp_dir, "result.txt")
+
+        with open(log_file, "w") as f:
+            f.write(log_content)
+
+        parse_benchmark_log(log_file, result_file)
+
+        with open(result_file, "r") as f:
+            lines = f.read().splitlines()
+
+        results = dict(line.split("=") for line in lines)
+        assert results["Throughput"] == "2.32"
+        assert results["OutputTokenThroughput"] == "2374.10"
+        assert results["TotalTokenThroughput"] == "21366.87"
+        assert results["MedianTTFT"] == "145423.02"
+        assert results["P99TTFT"] == "364320.86"
+        assert results["MedianTPOT"] == "241.14"
+        assert results["P99TPOT"] == "273.17"
+        assert results["MedianITL"] == "238.27"
+        assert results["P99ITL"] == "349.54"
+        assert results["MedianETEL"] == "392323.66"
+        assert results["P99ETEL"] == "441251.24"
+
+
+def test_parse_benchmark_log_accuracy_json():
+    log_content = """
+AccuracyMetrics: {"accuracy": 0.95, "f1": 0.9}
+"""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        log_file = os.path.join(temp_dir, "bench.log")
+        result_file = os.path.join(temp_dir, "result.txt")
+
+        with open(log_file, "w") as f:
+            f.write(log_content)
+
+        parse_benchmark_log(log_file, result_file)
+
+        with open(result_file, "r") as f:
+            lines = f.read().splitlines()
+
+        results = dict(line.split("=", 1) for line in lines)
+        assert "AccuracyMetrics" in results
+        parsed_json = json.loads(results["AccuracyMetrics"])
+        assert parsed_json["accuracy"] == 0.95
+
+
+def test_parse_benchmark_log_accuracy_legacy():
+    log_content = """
+Some random log before
+Results
+{'accuracy': 0.88, 'other_metric': 0.5}
+"""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        log_file = os.path.join(temp_dir, "bench.log")
+        result_file = os.path.join(temp_dir, "result.txt")
+
+        with open(log_file, "w") as f:
+            f.write(log_content)
+
+        parse_benchmark_log(log_file, result_file)
+
+        with open(result_file, "r") as f:
+            lines = f.read().splitlines()
+
+        results = dict(line.split("=", 1) for line in lines)
+        assert "AccuracyMetrics" in results
+        parsed_json = json.loads(results["AccuracyMetrics"])
+        assert parsed_json["accuracy"] == 0.88
+
+
+def test_parse_benchmark_log_case_insensitive():
+    log_content = """
+Some random log before
+============ Serving Benchmark Result ============
+REQUEST THROUGHPUT (req/s):              15.00     
+OuTpUt ToKeN tHrOuGhPuT (tok/s):         250.00    
+MeDiAn TTFT (ms):                        95.00     
+==================================================
+"""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        log_file = os.path.join(temp_dir, "bench.log")
+        result_file = os.path.join(temp_dir, "result.txt")
+
+        with open(log_file, "w") as f:
+            f.write(log_content)
+
+        parse_benchmark_log(log_file, result_file)
+
+        with open(result_file, "r") as f:
+            lines = f.read().splitlines()
+
+        results = dict(line.split("=") for line in lines)
+        assert results["Throughput"] == "15.00"
+        assert results["OutputTokenThroughput"] == "250.00"
+        assert results["MedianTTFT"] == "95.00"
+
+
+if __name__ == "__main__":
+    print("Running tests without pytest...")
+    for name, func in list(globals().items()):
+        if name.startswith("test_") and callable(func):
+            print(f"Executing {name}...")
+            func()
+    print("All tests passed successfully!")

--- a/.buildkite/benchmark/scripts/test_parser_case.py
+++ b/.buildkite/benchmark/scripts/test_parser_case.py
@@ -1,0 +1,90 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+import unittest.mock as mock
+
+from parser_case import (build_command, get_current_machine_type,
+                         normalize_device_name)
+
+
+def test_normalize_device_name():
+    assert normalize_device_name("tpu7x-16") == "v7x-16"
+    assert normalize_device_name("7x-16") == "v7x-16"
+    assert normalize_device_name("v6e-8") == "v6e-8"
+    assert normalize_device_name(None) is None
+    assert normalize_device_name("") is None
+    assert normalize_device_name("tpu6e-8") == "v6e-8"
+
+
+@mock.patch.dict(sys.modules, {'tpu_info': mock.MagicMock()})
+def test_get_current_machine_type_fallback():
+    # Mock tpu_info to simulate v7x-16 locally but fallback says v7x-32
+    tpu_info = sys.modules['tpu_info']
+    mock_chip_type = mock.MagicMock()
+    mock_chip_type.value.name = "7x"
+    # Local chips = 16
+    tpu_info.device.get_local_chips.return_value = (mock_chip_type, 16)
+
+    assert get_current_machine_type("v7x-32") == "v7x-32"
+    assert get_current_machine_type("v7x-16") == "v7x-16"
+    assert get_current_machine_type(
+        "v7x-8") == "v7x-16"  # local is larger, so local is used
+
+
+@mock.patch.dict(sys.modules, {'tpu_info': mock.MagicMock()})
+def test_get_current_machine_type_fallback_v6e():
+    # Mock tpu_info to simulate v6e-4 locally but fallback says v6e-8
+    tpu_info = sys.modules['tpu_info']
+    mock_chip_type = mock.MagicMock()
+    mock_chip_type.value.name = "v6e"
+    mock_chip_type.value.devices_per_chip = 1
+    # Local chips = 4
+    tpu_info.device.get_local_chips.return_value = (mock_chip_type, 4)
+
+    assert get_current_machine_type("v6e-8") == "v6e-8"
+
+
+def test_get_current_machine_type_no_library():
+    # When library is not present
+    with mock.patch.dict('sys.modules', {'tpu_info': None}):
+        assert get_current_machine_type("v6e-8") == "v6e-8"
+        assert get_current_machine_type(None) is None
+
+
+def test_build_command_model_mapping():
+    # If key is "model-path" it should output "--model" instead.
+    args_dict = {"model-path": "/my/model/path", "tensor-parallel-size": 4}
+    cmd = build_command("vllm_serve", args_dict)
+    assert "--model /my/model/path" in cmd
+    assert "--model-path" not in cmd
+    assert "--tensor-parallel-size 4" in cmd
+
+    # If both "model" and "model-path" exist, "model" is skipped in favor of "model-path".
+    args_dict_both = {
+        "model": "meta-llama/Llama-2",
+        "model-path": "/my/model/path"
+    }
+    cmd_both = build_command("vllm_serve", args_dict_both)
+    assert "--model /my/model/path" in cmd_both
+    assert "meta-llama/Llama-2" not in cmd_both
+
+
+if __name__ == "__main__":
+    print("Running tests without pytest...")
+    for name, func in list(globals().items()):
+        if name.startswith("test_") and callable(func):
+            print(f"Executing {name}...")
+            func()
+    print("All tests passed successfully!")

--- a/.buildkite/scripts/run_multihost.sh
+++ b/.buildkite/scripts/run_multihost.sh
@@ -102,30 +102,41 @@ SSH_OPTS=(-o StrictHostKeyChecking=no -o BatchMode=yes -o UserKnownHostsFile=/de
 
 # Cleanup function that runs on exit to tear down the Ray cluster
 cleanup() {
+  if [[ "${CLEANUP_DONE:-}" == "true" ]]; then return; fi
+  CLEANUP_DONE="true"
+  set +e
   echo "🧹 Cleaning up containers on head and workers..."
   IFS=',' read -r -a WORKER_IPS_ARRAY <<< "${WORKER_IPS:-}"
   
   echo "   -> Cleaning workers..."
   if [[ ${#WORKER_IPS_ARRAY[@]} -gt 0 && -n "${WORKER_IPS_ARRAY[0]}" ]]; then
     for worker_ip in "${WORKER_IPS_ARRAY[@]}"; do
-      ssh "${SSH_OPTS[@]}" "${SSH_USER}@${worker_ip}" "docker stop node >/dev/null 2>&1 || true; docker rm -f node >/dev/null 2>&1 || true" || true
+      echo "==================== Ray Worker logs from worker node ${worker_ip} ===================="
+      if [[ -f "/tmp/worker_${worker_ip}.log" ]]; then
+        tail -n 50 "/tmp/worker_${worker_ip}.log" || true
+        rm -f "/tmp/worker_${worker_ip}.log"
+      fi
+      ssh "${SSH_OPTS[@]}" "${SSH_USER}@${worker_ip}" "docker stop node >/dev/null 2>&1 || true; docker rm -f node >/dev/null 2>&1 || true; sudo -n rm -rf /tmp/ray/* /tmp/vllm/* >/dev/null 2>&1 || true" || true
     done
   fi
 
   echo "   -> Cleaning Head Node..."
+  rm -f /tmp/vllm_serve.log
   docker cp node:/root/vllm_serve.log /tmp/vllm_serve.log >/dev/null 2>&1 || true
   if [[ -f /tmp/vllm_serve.log ]]; then
     echo "==================== START OF VLLM SERVE LOG ===================="
     cat /tmp/vllm_serve.log || true
     echo "==================== END OF VLLM SERVE LOG ===================="
   fi
+  rm -f "${TEMP_EXPORT_FILE:-}" >/dev/null 2>&1 || true
   docker stop node >/dev/null 2>&1 || true
   docker rm -f node >/dev/null 2>&1 || true
-  rm -f /root/vllm_serve.log || true
+  sudo -n rm -rf /tmp/ray/* /tmp/vllm/* >/dev/null 2>&1 || true
 
   echo "✅ Cleanup complete."
+  set -e
 }
-trap cleanup EXIT
+trap cleanup EXIT SIGINT SIGTERM
 
 wait_for_server() {
   local port=$1
@@ -156,9 +167,12 @@ wait_for_server() {
   echo "   -> Found PID: $pid"
 
   local end_time=$((SECONDS + timeout))
+  local loop_count=0
   while [[ $SECONDS -lt $end_time ]]; do
     # 2. Check health
-    if curl -fs "localhost:${port}/health" > /dev/null; then
+    # max-time 10 is crucial to prevent curl from hanging indefinitely if the server 
+    # accepts the TCP connection but is deadlocked or blocked from sending an HTTP response.
+    if curl -fs --max-time 10 "localhost:${port}/health" > /dev/null; then
       echo "===== $service_name is healthy on port: $port. ==="
       return 0
     fi
@@ -171,7 +185,18 @@ wait_for_server() {
       return 1
     fi
 
+    # 4. Fast-fail if EngineCore crashed but left the API server zombie-ing
+    if [[ $((loop_count % 3)) -eq 0 ]]; then
+      if docker exec "$container_name" grep -q -E "EngineCore failed to start|ActorDiedError" "$log_path" 2>/dev/null; then
+        echo "Error: Fatal vLLM engine crash detected in logs (e.g. EngineCore failed to start). Aborting."
+        echo "Displaying logs from $container_name:$log_path"
+        docker exec "$container_name" cat "$log_path" || true
+        return 1
+      fi
+    fi
+
     sleep 5
+    loop_count=$((loop_count + 1))
   done
 
   echo "Error: $service_name on $port failed to become healthy within ${timeout}s."
@@ -182,7 +207,6 @@ wait_for_server() {
 
 PROJECT="$(gcloud config get-value project)"
 GCR_REPO="us-central1-docker.pkg.dev/${PROJECT}/tpu-inference"
-IMAGE_NAME="${GCR_REPO}/vllm-tpu"
 
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 TOP_DIR=$(dirname "$(dirname "$SCRIPT_DIR")")
@@ -199,15 +223,132 @@ source "$SCRIPT_DIR/setup_docker_env.sh"
 # progress, so the trace adds nothing; xtrace is on for this whole script, so
 # turn it off across the call and back on after.
 { set +x; } 2>/dev/null
-# Pass "true" to enable pushing to GCR
-setup_environment "${IMAGE_NAME}" "true"
+# Determine the Docker image name and registry path.
+# Use the local image for multi-host benchmarks; otherwise, default to the remote GCR image.
+if [[ "${IS_MULTI_HOST_BENCH:-false}" == "true" ]]; then
+  IMAGE_NAME='vllm-tpu'
+  setup_environment "$IMAGE_NAME"
+  # Use the exported CI cache image path so Worker Nodes can pull it directly
+  DOCKER_IMAGE="${EXPORTED_CI_CACHE_IMAGE:-$IMAGE_NAME:latest}"
+else
+  IMAGE_NAME="${GCR_REPO}/vllm-tpu"
+  # Pass "true" to enable pushing to GCR
+  setup_environment "${IMAGE_NAME}" "true"
+  DOCKER_IMAGE="${IMAGE_NAME}:${BUILDKITE_COMMIT:-latest}"
+fi
 set -x
 
-DOCKER_IMAGE="${IMAGE_NAME}:${BUILDKITE_COMMIT:-latest}"
+# Resolve server / client commands and environment variables early
+MODEL="${TEST_MODEL:-gs://tpu-commons-ci/qwen/models--Qwen--Qwen3-30B-A3B/snapshots/ad44e777bcd18fa416d9da3bd8f70d33ebb85d39}"
+VLLM_PORT="8000"
+VLLM_SERVE_CMD=""
+CLIENT_BENCH_CMD=""
+DOCKER_ENV_ARGS=()
+DOCKER_ENV_STR=""
+
+if [ "$#" -ge 1 ]; then
+    if [[ "$1" == *.json ]]; then
+        # JSON configuration mode (multihost benchmark)
+        CASE_FILE="$1"
+        TARGET_CASE_NAME="$2"
+        echo "--- Multi-host JSON case configuration detected: $CASE_FILE ($TARGET_CASE_NAME)"
+        
+        TEMP_EXPORT_FILE="/tmp/temp_env_exports.sh"
+        rm -f "$TEMP_EXPORT_FILE"
+
+        # Run parser_case.py inside the container to resolve server/client commands
+        docker run --rm \
+          --privileged \
+          --net host \
+          -v "$(pwd):/workspace" \
+          -w /workspace \
+          "${DOCKER_IMAGE}" \
+          python3 .buildkite/benchmark/scripts/parser_case.py "$CASE_FILE" "$TARGET_CASE_NAME" > "$TEMP_EXPORT_FILE" || {
+              echo "Error running parser_case.py inside container."
+              if [[ -f "$TEMP_EXPORT_FILE" ]]; then
+                  echo "===== Content of $TEMP_EXPORT_FILE ====="
+                  cat "$TEMP_EXPORT_FILE"
+                  echo "========================================"
+              fi
+              exit 1
+          }
+          
+        # shellcheck source=/dev/null
+        source "$TEMP_EXPORT_FILE"
+        rm -f "$TEMP_EXPORT_FILE"
+        
+        # Write GCS upload metadata variables to a temp file for run_job.sh
+        METADATA_FILE="/tmp/multihost_run_metadata.sh"
+        rm -f "$METADATA_FILE"
+        if [[ -n "${SERVER_CMD_ENVS:-}" ]]; then
+          {
+            echo "export MODEL_NAME='${MODEL_NAME:-}'"
+            echo "export INPUT_LEN='${INPUT_LEN:-}'"
+            echo "export OUTPUT_LEN='${OUTPUT_LEN:-}'"
+            echo "declare -a SERVER_CMD_ENVS=()"
+            for env_item in "${SERVER_CMD_ENVS[@]}"; do
+                echo "SERVER_CMD_ENVS+=('$(printf '%q' "$env_item")')"
+            done
+          } >> "$METADATA_FILE"
+        fi
+
+        # Convert SERVER_CMD array to a single string VLLM_SERVE_CMD
+        for env_item in "${SERVER_CMD_ENVS[@]}"; do
+            VLLM_SERVE_CMD+="$(printf '%q ' "$env_item")"
+            DOCKER_ENV_ARGS+=("-e" "$env_item")
+        done
+        for cmd_item in "${SERVER_CMD[@]}"; do
+            VLLM_SERVE_CMD+="$(printf '%q ' "$cmd_item")"
+        done
+        
+        # Set client benchmark command from CLIENT_CMD resolved by parser
+        CLIENT_BENCH_CMD=""
+        for env_item in "${CLIENT_CMD_ENVS[@]}"; do
+            CLIENT_BENCH_CMD+="$(printf '%q ' "$env_item")"
+        done
+        for cmd_item in "${CLIENT_CMD[@]}"; do
+            CLIENT_BENCH_CMD+="$(printf '%q ' "$cmd_item")"
+        done
+        
+    else
+        # Direct CLI configuration mode
+        # If the first argument is not a .json file, the script directly assigns 
+        # $1 as the server command and the remaining arguments ($*) as the client command.
+        if [ "$#" -gt 0 ]; then
+            VLLM_SERVE_CMD="$1"
+            echo "Using provided VLLM_SERVE_CMD: $VLLM_SERVE_CMD"
+            # Shift so that remaining args are treated as the benchmark command
+            shift
+            if [ "$#" -gt 0 ]; then
+                CLIENT_BENCH_CMD="${*:-}"
+            fi
+        else
+            VLLM_SERVE_CMD=""
+            CLIENT_BENCH_CMD=""
+        fi
+    fi
+fi
+
+# Extract port from VLLM_SERVE_CMD if present (e.g., --port 8080 or --port=8080)
+if [[ "${VLLM_SERVE_CMD}" =~ --port[=\ ]+([0-9]+) ]]; then
+    VLLM_PORT="${BASH_REMATCH[1]}"
+    echo "--- Extracted VLLM_PORT=${VLLM_PORT} from JSON server command"
+fi
 
 # Clean up potential leftovers from previous runs
 echo "--- Cleaning up previous cluster state..."
 cleanup
+CLEANUP_DONE="false"
+
+# Safely parse EXTRA_DOCKER_ARGS into an array to prevent word-splitting on spaces
+eval "declare -a EXTRA_DOCKER_ARGS_ARRAY=(${EXTRA_DOCKER_ARGS:-})"
+
+# Serialize DOCKER_ENV_ARGS safely for SSH injection to Worker Nodes.
+if [ ${#DOCKER_ENV_ARGS[@]} -gt 0 ]; then
+    DOCKER_ENV_STR=$(printf '%q ' "${DOCKER_ENV_ARGS[@]}")
+else
+    DOCKER_ENV_STR=""
+fi
 
 # 1. Start Ray Head Node locally
 echo "--- Starting Ray Head Node Locally"
@@ -224,13 +365,16 @@ bash "${TOP_DIR}/scripts/multihost/run_cluster.sh" \
   -e TPU_MULTIHOST_BACKEND=ray \
   -e JAX_PLATFORMS='' \
   -e TPU_BACKEND_TYPE=jax \
-  -e MODEL_IMPL_TYPE=vllm \
+  -e MODEL_IMPL_TYPE="${MODEL_IMPL_TYPE:-vllm}" \
   -e VLLM_DISABLE_SHARED_EXPERTS_STREAM="${VLLM_DISABLE_SHARED_EXPERTS_STREAM:-1}" \
   -e NEW_MODEL_DESIGN="${NEW_MODEL_DESIGN:-0}" \
   -e MOE_REQUANTIZE_BLOCK_SIZE="${MOE_REQUANTIZE_BLOCK_SIZE:-}" \
   -e MOE_REQUANTIZE_WEIGHT_DTYPE="${MOE_REQUANTIZE_WEIGHT_DTYPE:-}" \
   -e MOE_ALL_GATHER_ACTIVATION_DTYPE="${MOE_ALL_GATHER_ACTIVATION_DTYPE:-}" \
-  -e FORCE_MOE_RANDOM_ROUTING="${FORCE_MOE_RANDOM_ROUTING:-}" &
+  -e FORCE_MOE_RANDOM_ROUTING="${FORCE_MOE_RANDOM_ROUTING:-}" \
+  -e IS_MULTI_HOST_BENCH="${IS_MULTI_HOST_BENCH:-}" \
+  ${DOCKER_ENV_ARGS[@]:+"${DOCKER_ENV_ARGS[@]}"} \
+  ${EXTRA_DOCKER_ARGS_ARRAY[@]:+"${EXTRA_DOCKER_ARGS_ARRAY[@]}"} &
 set -x
 
 sleep 60
@@ -250,19 +394,22 @@ for worker_ip in "${WORKER_IPS_ARRAY[@]}"; do
     
     # shellcheck disable=SC2087
     # shellcheck disable=SC2029
-    ssh "${SSH_OPTS[@]}" "${SSH_USER}@${worker_ip}" << EOF &
-bash ~/tpu-inference/scripts/multihost/run_cluster.sh '${DOCKER_IMAGE}' '${HEAD_INTERNAL_IP}' --worker '${HOST_HF_HOME}' \
+    # Redirect output to a temp file so it doesn't flood the Buildkite console with mixed logs.
+    ssh "${SSH_OPTS[@]}" "${SSH_USER}@${worker_ip}" > "/tmp/worker_${worker_ip}.log" 2>&1 << EOF &
+IS_MULTI_HOST_BENCH="${IS_MULTI_HOST_BENCH:-false}" bash ~/tpu-inference/scripts/multihost/run_cluster.sh '${DOCKER_IMAGE}' '${HEAD_INTERNAL_IP}' --worker '${HOST_HF_HOME}' \
   -e HF_TOKEN='${HF_TOKEN:-}' \
   -e TPU_MULTIHOST_BACKEND=ray \
   -e JAX_PLATFORMS='' \
   -e TPU_BACKEND_TYPE=jax \
-  -e MODEL_IMPL_TYPE=vllm \
+  -e MODEL_IMPL_TYPE='${MODEL_IMPL_TYPE:-vllm}' \
   -e VLLM_DISABLE_SHARED_EXPERTS_STREAM='${VLLM_DISABLE_SHARED_EXPERTS_STREAM:-1}' \
   -e NEW_MODEL_DESIGN='${NEW_MODEL_DESIGN:-0}' \
   -e MOE_REQUANTIZE_BLOCK_SIZE='${MOE_REQUANTIZE_BLOCK_SIZE:-}' \
   -e MOE_REQUANTIZE_WEIGHT_DTYPE='${MOE_REQUANTIZE_WEIGHT_DTYPE:-}' \
   -e MOE_ALL_GATHER_ACTIVATION_DTYPE='${MOE_ALL_GATHER_ACTIVATION_DTYPE:-}' \
-  -e FORCE_MOE_RANDOM_ROUTING='${FORCE_MOE_RANDOM_ROUTING:-}'
+  -e FORCE_MOE_RANDOM_ROUTING='${FORCE_MOE_RANDOM_ROUTING:-}' \
+  -e IS_MULTI_HOST_BENCH='${IS_MULTI_HOST_BENCH:-}' \
+  ${DOCKER_ENV_STR}
 EOF
 done
 
@@ -273,25 +420,27 @@ sleep 120
 
 # 3. Start vLLM server on the head node
 echo "--- Starting vLLM server on head node"
-MODEL="${TEST_MODEL:-gs://tpu-commons-ci/qwen/models--Qwen--Qwen3-30B-A3B/snapshots/ad44e777bcd18fa416d9da3bd8f70d33ebb85d39}"
-VLLM_PORT="8000"
 
-VLLM_SERVE_CMD="vllm serve ${MODEL} \
-  --port ${VLLM_PORT} \
-  --tensor-parallel-size ${TENSOR_PARALLEL_SIZE:-16} \
-  --trust-remote-code \
-  --no-enable-prefix-caching \
-  --kv_cache_dtype=fp8 \
-  --async-scheduling \
-  --load-format=runai_streamer \
-  --max-model-len 1024"
+if [ -z "${VLLM_SERVE_CMD}" ]; then
+    echo "Error: VLLM_SERVE_CMD cannot be empty! Please provide a JSON config or a command string."
+    exit 1
+fi
 
-# Override VLLM_SERVE_CMD if provided as the first argument
-if [ "$#" -ge 1 ]; then
-    VLLM_SERVE_CMD="$1"
-    echo "Using provided VLLM_SERVE_CMD: $VLLM_SERVE_CMD"
-    # Shift so that remaining args are treated as the benchmark command
-    shift
+# Pre-download generation config from GCS into the container workspace and rewrite the server command
+if [[ "${VLLM_SERVE_CMD}" =~ --generation-config[=\ ]+gs://([^ ]+) ]]; then
+    gcs_path="gs://${BASH_REMATCH[1]}"
+    config_url="${gcs_path%/*}"
+    config_dir_name=$(basename "${config_url}")
+    config_file_name=$(basename "${gcs_path}")
+
+    echo "--- Detected GCS generation-config: $gcs_path"
+    echo "--- Pre-downloading config to workspace inside container..."
+
+    download_cmd="mkdir -p /workspace && gsutil -m cp -r ${config_url} /workspace/ && "
+    
+    VLLM_SERVE_CMD=$(echo "${VLLM_SERVE_CMD}" | sed -E "s|--generation-config[=\ ]+gs://[^ ]+|--generation-config /workspace/${config_dir_name}/${config_file_name}|g")
+    VLLM_SERVE_CMD="${download_cmd}${VLLM_SERVE_CMD}"
+    echo "Rewritten VLLM_SERVE_CMD: $VLLM_SERVE_CMD"
 fi
 
 # Launch vllm serve in the background inside the local 'node' container
@@ -301,16 +450,33 @@ docker exec \
   node bash -c "${VLLM_SERVE_CMD} > /root/vllm_serve.log 2>&1"
 
 # 4. Wait for the server to be healthy
-wait_for_server "$VLLM_PORT" "node" "vllm serve" "/root/vllm_serve.log"
+SERVER_TIMEOUT=""
+if [[ -n "${SERVER_CMD_ENVS:-}" ]]; then
+    for env_item in "${SERVER_CMD_ENVS[@]}"; do
+        if [[ "$env_item" == VLLM_ENGINE_READY_TIMEOUT_S=* ]]; then
+            SERVER_TIMEOUT="${env_item#*=}"
+        fi
+    done
+fi
+wait_for_server "$VLLM_PORT" "node" "vllm serve" "/root/vllm_serve.log" "$SERVER_TIMEOUT"
 
 # 5. Run Benchmarks / Validation
-if [ "$#" -gt 0 ]; then
-  echo "--- Running provided Benchmark Command on Head Node"
-  COMMAND_ARGS=("$@")
-  
+if [[ "${CASE_FILE:-}" == *.json ]]; then
+  # JSON (.json): Delegates to run_bm.sh for advanced benchmark logic.
+  echo "--- Invoking run_bm.sh for advanced benchmark logic on Head Node..."
   docker exec \
     -e HF_HOME=/root/.cache/huggingface \
-    node bash -c "${COMMAND_ARGS[*]}"
+    -e SERVER_ALREADY_RUNNING="true" \
+    -e VLLM_PORT="${VLLM_PORT}" \
+    -e GCS_BUCKET="${GCS_BUCKET:-}" \
+    -e RECORD_ID="${RECORD_ID:-}" \
+    node bash -c "cd /workspace/tpu_inference && chmod +x .buildkite/benchmark/scripts/run_bm.sh && .buildkite/benchmark/scripts/run_bm.sh $CASE_FILE $TARGET_CASE_NAME"
+elif [ -n "${CLIENT_BENCH_CMD}" ]; then
+  # Legacy string: Executes CLIENT_BENCH_CMD directly as a raw bash command.
+  echo "--- Running Benchmark Command on Head Node"
+  docker exec \
+    -e HF_HOME=/root/.cache/huggingface \
+    node bash -c "cd /workspace/tpu_inference && ${CLIENT_BENCH_CMD}"
 else
   # Default: Run the curl test to verify the endpoint
   echo "--- Running default curl test"
@@ -323,3 +489,4 @@ else
 fi
 
 echo "--- Tests completed successfully"
+

--- a/.buildkite/scripts/setup_docker_env.sh
+++ b/.buildkite/scripts/setup_docker_env.sh
@@ -205,6 +205,8 @@ setup_environment() {
     verify_image_vllm "${CI_IMAGE_REPO}:${CACHE_TAG}" "${VLLM_COMMIT_HASH}"
     docker tag "${CI_IMAGE_REPO}:${CACHE_TAG}" "${IMAGE_NAME}:${TPU_INFERENCE_HASH}"
     docker tag "${CI_IMAGE_REPO}:${CACHE_TAG}" "${IMAGE_NAME}:latest"
+    # Export the computed CI cache image name so calling scripts can use it.
+    export EXPORTED_CI_CACHE_IMAGE="${CI_IMAGE_REPO}:${CACHE_TAG}"
     return 0
   fi
 
@@ -229,6 +231,7 @@ setup_environment() {
     echo "Pushing Docker image to CI Image Registry..."
     docker tag "${IMAGE_NAME}:${CACHE_TAG}" "${CI_IMAGE_REPO}:${CACHE_TAG}"
     docker push "${CI_IMAGE_REPO}:${CACHE_TAG}"
+    export EXPORTED_CI_CACHE_IMAGE="${CI_IMAGE_REPO}:${CACHE_TAG}"
   fi
 
   # Push logic if requested

--- a/scripts/multihost/run_cluster.sh
+++ b/scripts/multihost/run_cluster.sh
@@ -120,9 +120,13 @@ fi
 # -v HF_HOME: Mounts HuggingFace cache to avoid re-downloading models
 
 # Force cleanup of the image to ensure we pull the absolute latest
-echo "Ensuring we have the latest image for ${DOCKER_IMAGE}..."
-docker rmi "${DOCKER_IMAGE}" > /dev/null 2>&1 || true
-docker pull "${DOCKER_IMAGE}"
+if [[ "${IS_MULTI_HOST_BENCH:-false}" != "true" ]]; then
+    echo "Ensuring we have the latest image for ${DOCKER_IMAGE}..."
+    docker rmi "${DOCKER_IMAGE}" > /dev/null 2>&1 || true
+    docker pull "${DOCKER_IMAGE}"
+else
+    echo "IS_MULTI_HOST_BENCH is true, skipping image pull to use prebuilt image ${DOCKER_IMAGE}."
+fi
  
 
 # Default to no gcloud mount
@@ -139,14 +143,21 @@ if [ -d "/mnt/disks/checkpoint" ]; then
     CHECKPOINT_MOUNT_ARGS+=(-v "/mnt/disks/checkpoint:/mnt/disks/checkpoint")
 fi
 
+# -----------------------------------------------------------------------------
+# Docker Options Explanation:
+# - log-opt: Limits log file size and count to prevent excessive logging 
+#   from Ray/vLLM from exhausting VM disk space and causing node failures.
+# -----------------------------------------------------------------------------
 docker run \
     --privileged \
     --entrypoint /bin/bash \
     --network host \
     --shm-size=16G \
+    --log-opt max-size=50m \
+    --log-opt max-file=2 \
     --name "${CONTAINER_NAME}" \
     -v "${PATH_TO_HF_HOME}:/root/.cache/huggingface" \
     "${GCLOUD_MOUNT_ARGS[@]}" \
     "${CHECKPOINT_MOUNT_ARGS[@]}" \
     "${ADDITIONAL_ARGS[@]}" \
-    "${DOCKER_IMAGE}" -c "${RAY_START_CMD}"
+    "${DOCKER_IMAGE}" -c "echo always > /sys/kernel/mm/transparent_hugepage/enabled && ${RAY_START_CMD}"


### PR DESCRIPTION
# Description

This PR migrates the legacy scripts/multihost/nightly_benchmarking.sh logic into the new .buildkite/benchmark unified structure. By consolidating the multi-host benchmarking flow into run_multihost.sh and run_job.sh. 
Additionally, it updates the configurations and execution commands for the Multihost benchmark, adds corresponding parameter explanations to the README, and includes specific usage instructions for  the Accuracy benchmark.

**1. Migration Plan & Legacy Scripts**
The rest of the legacy cases will be migrated in a follow-up PR very soon. Specifically, we will be porting the following cases next:
* `run_torchax_deepseek_v3_1k_8k`
* `run_torchax_deepseek_v3_1k_8k_random_routing`
* `run_torchax_deepseek_v3_8k_1k`
* `run_torchax_qwen3_coder_480b_1k_8k`
* `xprof_torchax_deepseek_v3_1k_1k`
* `xprof_torchax_deepseek_v3_1k_8k`
* `xprof_torchax_deepseek_v3_1k_8k_random_routing`
* `xprof_torchax_deepseek_v3_8k_1k`
* `run_jax_deepseek_v3_1k_8k`
* `run_jax_deepseek_v3_8k_1k`
* `xprof_deepseek_v3_1k_8k`

Once all of these cases are added and validated, we will completely delete the legacy `scripts/multihost/benchmarks/*` scripts. 

For the GCS log naming scheme: The new framework is already updated to use `REMOTE_LOG_ROOT="gs://vllm-bm-bk-storage/job_logs/$RECORD_ID/"`. This naming format aligns perfectly with our other standard benchmarks. Meanwhile, the legacy wrappers will continue to use their original naming scheme so there won't be any conflicts or drifting between the two parallel flows. When we are ready to flip to production, it will just be a single switch of the bucket variables without any naming conflicts.

**2. Performance Gate Intent (Daily Cases):**
*Note:* It is completely intentional that the new `daily` cases operate without a performance gate (`RUN_ONCE=true` and no `EXPECTED_THROUGHPUT`). These cases act as report-only metrics to monitor daily trends without blocking the CI, which perfectly matches the existing legacy cron behavior.


# Tests

[BuildKite(multihost/benchmarks/jax/run_deepseek_v3_1k_8k.sh)](https://buildkite.com/tpu-commons/tpu-inference-benchmark/builds/1824/canvas)

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
