### PR TITLE
[Multi-host] Temporarily disable Ray-based multi-host E2E test

### DIFF
--- a/.buildkite/pipeline_jax.yml
+++ b/.buildkite/pipeline_jax.yml
@@ -444,6 +444,12 @@ steps:
 
       - label: "${TPU_VERSION:-tpu6e} E2E test for Ray-based multi-host"
         key: "${TPU_VERSION:-tpu6e}_test_26"
+        # Temporarily disabled: consistently times out (~2h) and squats the
+        # scarce tpu_v7x_16_queue. Two independent causes -- (1) the multi-host
+        # image tag omitted the vLLM commit so workers could pull a clobbered
+        # image (fixed separately), and (2) a bad multi-host machine whose Runai
+        # weight-streamer stalls at ~50%. Re-enable once both are resolved.
+        skip: "Times out ~2h; re-enable after bad-machine fix"
         soft_fail: true
         agents:
           queue: tpu_v7x_16_queue


### PR DESCRIPTION
# Description

Skip the tpu7x E2E test for Ray-based multi-host step. It consistently times out (~2h) and squats the scarce tpu_v7x_16_queue on every run.

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
