### PR TITLE
[Spec Decoding] Fix scoped-VMEM OOM in spec-decode logits gather

### DIFF
--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -2007,7 +2007,19 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
     def _select_from_array_fn(array, indices_to_select, mesh):
 
         def select_local_fn(local_array, local_indices):
-            return local_array[local_indices]
+            # XLA keeps the whole row-gather output in scoped VMEM, so one
+            # gather of [n, vocab_shard] logits rows exceeds the 32M scoped
+            # limit once n grows (e.g. spec decode with max_num_seqs=16:
+            # [128, 62080] bf16 = 37.9M -> CompileTimeScopedVmemOom).
+            # Gather in fixed-size row chunks so each gather stays small.
+            chunk = 32
+            n = local_indices.shape[0]
+            if n <= chunk or local_array.ndim < 2:
+                return local_array[local_indices]
+            num_pads = (-n) % chunk
+            idx = jnp.pad(local_indices, (0, num_pads)).reshape(-1, chunk)
+            out = jax.lax.map(lambda ix: local_array[ix], idx)
+            return out.reshape(-1, *local_array.shape[1:])[:n]
 
         ret = jax.shard_map(
             select_local_fn,


### PR DESCRIPTION


# Description

With speculative decoding, `_select_from_array_fn` gathers up to `max_num_seqs * (num_speculative_tokens + 1)` logits rows in one XLA gather, whose output is buffered entirely in scoped VMEM. Once the padded row count crosses ~64 (e.g. --max-num-seqs=16 with num_speculative_tokens=4 -> 128 rows x 62080 vocab shard in bf16 = 37.9M), compilation fails with:

  jax.errors.JaxRuntimeError: RESOURCE_EXHAUSTED: E1001:
  CompileTimeScopedVmemOom ... exceeded scoped vmem limit (32.00M)

and the engine core dies mid-serving.

Gather in fixed 32-row chunks via lax.map so each gather's output stays small; small batches keep the original single-gather path. 

# Tests

Verified with a standalone repro of the failing [128, 62080] shape (fails before, passes after) and a full 100-prompt spec_bench run at --max-num-seqs=16 with qwen3_next_mtp (previously 53/100 requests failed; now 100/100 with no engine tracebacks).

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
