### PR TITLE
Fix script: cleanup whenever exit in middle

### DIFF
--- a/.buildkite/scripts/daily_run_gke_disagg.sh
+++ b/.buildkite/scripts/daily_run_gke_disagg.sh
@@ -21,6 +21,9 @@ PROXY_LABEL="app=vllm-proxy"
 INTERVAL=5
 TIMEOUT_SECONDS=7200
 
+# Cleanup whenever exit
+trap cleanup_1p1d EXIT
+
 init_env() {
     # Get credentials to GKE cluster
     echo "gcloud container clusters get-credentials $CLUSTER_NAME --zone $ZONE --project $PROJECT_NAME"
@@ -212,7 +215,3 @@ for RESULT_FILE in "1024_8192.json" "8192_1024.json"; do
     done
 done
 
-
-
-# Cleanup
-cleanup_1p1d


### PR DESCRIPTION
# Description

Cleanup cluster while exiting.  The benchmark failed due to stale status not cleared.  After manual cleanup the scripts can run without issue, move cleanup function to trap exiting. 

# Tests

manual run scripts

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
