### PR TITLE
[Spec Decoding] Override timeout to 180 mins for e2e spec decoding test

### DIFF
--- a/.buildkite/pipeline_jax.yml
+++ b/.buildkite/pipeline_jax.yml
@@ -88,6 +88,8 @@ steps:
       - label: "${TPU_VERSION:-tpu6e} E2E speculative decoding test"
         key: ${TPU_VERSION:-tpu6e}_test_6
         soft_fail: true
+        # TODO: Look into the latency of precompilation of the e2e spec decoding test
+        timeout_in_minutes: 180
         env:
           USE_PREBUILT_IMAGE: "1"
           TPU_VERSION: "${TPU_VERSION:-tpu6e}"


### PR DESCRIPTION
# Description

The speculative decoding e2e tests have many variants. For each variant, we need to restart the server engine. The precompilation latency is long. Added a TODO to look into that.

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
