### PR TITLE
[Jax] Wire blockwise fp8 merged linear into compressed-tensors dispatch

### DIFF
--- a/tests/layers/jax/quantization/test_compressed_tensors.py
+++ b/tests/layers/jax/quantization/test_compressed_tensors.py
@@ -26,11 +26,13 @@ from flax import nnx
 from jax.sharding import Mesh
 
 from tpu_inference.layers.common.sharding import MESH_AXIS_NAMES
-from tpu_inference.layers.jax.linear import JaxLinear
+from tpu_inference.layers.jax.linear import (JaxLinear,
+                                             JaxMergedColumnParallelLinear)
 from tpu_inference.layers.jax.quantization.compressed_tensors import \
     CompressedTensorsConfig
 from tpu_inference.layers.jax.quantization.fp8 import (
-    Fp8BlockwiseLinearMethod, Fp8TensorwiseLinearMethod)
+    Fp8BlockwiseLinearMethod, Fp8BlockwiseMergedLinearMethod,
+    Fp8TensorwiseLinearMethod)
 from tpu_inference.layers.jax.quantization.unquantized import \
     UnquantizedLinearMethod
 
@@ -157,6 +159,45 @@ class TestCompressedTensorsConfig:
             mlp = _MLP(16, 16, rngs, config, prefix="mlp")
         assert hasattr(mlp.proj1, "weight_scale")
         assert not hasattr(mlp.proj1, "weight_scale_inv")
+
+    def test_fp8_block_merged_routes_to_merged_method(self, rngs, mesh):
+        """A merged (fused gate_up-style) layer under an fp8-block group ->
+        Fp8BlockwiseMergedLinearMethod, with per-projection shard slots ready.
+        """
+        config = CompressedTensorsConfig(_fp8_block_config())
+        with jax.set_mesh(mesh):
+            layer = JaxMergedColumnParallelLinear(
+                32, [16, 16],
+                rngs,
+                use_bias=False,
+                quant_config=config,
+                kernel_init=nnx.initializers.uniform(),
+                prefix="mlp.gate_up_proj")
+        assert isinstance(layer.quant_method, Fp8BlockwiseMergedLinearMethod)
+        assert layer.weight.get_metadata("_merged_shards") == [None, None]
+
+    def test_fp8_block_merged_scale_param_uses_ct_name(self, rngs, mesh):
+        """The merged blockwise scale param must also be named `weight_scale`.
+
+        Guards against the merged method regressing to the hardcoded DeepSeek
+        name (`weight_scale_inv`): the scale loader is attached by looking the
+        param up via `weight_scale_name`, so a mismatch would either raise at
+        layer construction or leave checkpoint scales with no matching param.
+        """
+        config = CompressedTensorsConfig(_fp8_block_config())
+        with jax.set_mesh(mesh):
+            layer = JaxMergedColumnParallelLinear(
+                32, [16, 16],
+                rngs,
+                use_bias=False,
+                quant_config=config,
+                kernel_init=nnx.initializers.uniform(),
+                prefix="mlp.gate_up_proj")
+        assert hasattr(layer, "weight_scale")
+        assert not hasattr(layer, "weight_scale_inv")
+        assert layer.weight_scale.get_metadata("_merged_shards") == [
+            None, None
+        ]
 
     def test_fp8_tensor_routes_to_tensorwise_method(self, rngs, mesh):
         """Per-tensor fp8 (no block_structure) -> Fp8TensorwiseLinearMethod."""

--- a/tests/layers/jax/quantization/test_compressed_tensors.py
+++ b/tests/layers/jax/quantization/test_compressed_tensors.py
@@ -160,19 +160,25 @@ class TestCompressedTensorsConfig:
         assert hasattr(mlp.proj1, "weight_scale")
         assert not hasattr(mlp.proj1, "weight_scale_inv")
 
+    @staticmethod
+    def _build_merged_layer(config, rngs):
+        """Fused gate_up-style layer (two 16-wide projections) under
+        ``config``. Same erf-free ``uniform`` init as ``_MLP``."""
+        return JaxMergedColumnParallelLinear(
+            32, [16, 16],
+            rngs,
+            use_bias=False,
+            quant_config=config,
+            kernel_init=nnx.initializers.uniform(),
+            prefix="mlp.gate_up_proj")
+
     def test_fp8_block_merged_routes_to_merged_method(self, rngs, mesh):
         """A merged (fused gate_up-style) layer under an fp8-block group ->
         Fp8BlockwiseMergedLinearMethod, with per-projection shard slots ready.
         """
         config = CompressedTensorsConfig(_fp8_block_config())
         with jax.set_mesh(mesh):
-            layer = JaxMergedColumnParallelLinear(
-                32, [16, 16],
-                rngs,
-                use_bias=False,
-                quant_config=config,
-                kernel_init=nnx.initializers.uniform(),
-                prefix="mlp.gate_up_proj")
+            layer = self._build_merged_layer(config, rngs)
         assert isinstance(layer.quant_method, Fp8BlockwiseMergedLinearMethod)
         assert layer.weight.get_metadata("_merged_shards") == [None, None]
 
@@ -186,13 +192,7 @@ class TestCompressedTensorsConfig:
         """
         config = CompressedTensorsConfig(_fp8_block_config())
         with jax.set_mesh(mesh):
-            layer = JaxMergedColumnParallelLinear(
-                32, [16, 16],
-                rngs,
-                use_bias=False,
-                quant_config=config,
-                kernel_init=nnx.initializers.uniform(),
-                prefix="mlp.gate_up_proj")
+            layer = self._build_merged_layer(config, rngs)
         assert hasattr(layer, "weight_scale")
         assert not hasattr(layer, "weight_scale_inv")
         assert layer.weight_scale.get_metadata("_merged_shards") == [

--- a/tests/models/jax/test_gemma4.py
+++ b/tests/models/jax/test_gemma4.py
@@ -136,6 +136,7 @@ class TestGemma4ForConditionalGeneration:
         "google/gemma-4-26B-A4B-it",
         "RedHatAI/gemma-4-31B-it-FP8-Dynamic",
         "RedHatAI/gemma-4-26B-A4B-it-FP8-Dynamic",
+        "RedHatAI/gemma-4-31B-it-FP8-block",
     ])
     @pytest.mark.parametrize("pp_rank,pp_world_size", [(0, 1), (0, 4), (1, 4),
                                                        (3, 4)])

--- a/tpu_inference/layers/jax/quantization/compressed_tensors.py
+++ b/tpu_inference/layers/jax/quantization/compressed_tensors.py
@@ -34,7 +34,8 @@ from tpu_inference.layers.jax.quantization import QuantizeMethodBase
 from tpu_inference.layers.jax.quantization.configs import (QuantizationConfig,
                                                            QuantLinearConfig)
 from tpu_inference.layers.jax.quantization.fp8 import (
-    Fp8BlockwiseLinearMethod, Fp8FusedMoEMethod, Fp8TensorwiseLinearMethod,
+    Fp8BlockwiseLinearMethod, Fp8BlockwiseMergedLinearMethod,
+    Fp8FusedMoEMethod, Fp8TensorwiseLinearMethod,
     Fp8TensorwiseMergedLinearMethod)
 from tpu_inference.layers.jax.quantization.unquantized import (
     UnquantizedFusedMoEMethod, UnquantizedLinearMethod)
@@ -124,15 +125,16 @@ class CompressedTensorsConfig(QuantizationConfig):
         if self._ct._is_fp8_w8a8(weight_quant, input_quant):
             block = _weight_block_size(weight_quant)
             if block is not None:
-                if isinstance(layer, JaxMergedColumnParallelLinear):
-                    # TODO(#2261): need to implement blockwise fp8 for JaxMergedColumnParallelLinear
-                    raise NotImplementedError(
-                        "compressed-tensors blockwise fp8 is not yet supported "
-                        "for JaxMergedColumnParallelLinear layers.")
                 # compressed-tensors serializes the dequant scale as
                 # "weight_scale" (DeepSeek-style checkpoints, the method's
                 # default, use "weight_scale_inv"), so create the param under
                 # the name the checkpoint will look up.
+                if isinstance(layer, JaxMergedColumnParallelLinear):
+                    return Fp8BlockwiseMergedLinearMethod(
+                        _Fp8BlockConfigShim(block),
+                        layer,
+                        linear_config,
+                        weight_scale_name="weight_scale")
                 return Fp8BlockwiseLinearMethod(
                     _Fp8BlockConfigShim(block),
                     layer,

--- a/tpu_inference/layers/jax/quantization/fp8.py
+++ b/tpu_inference/layers/jax/quantization/fp8.py
@@ -403,7 +403,7 @@ class Fp8BlockwiseMergedLinearMethod(Fp8BlockwiseLinearMethod):
     each projection (``gate_proj``, ``up_proj``) as a separate tensor with
     its own block-wise scale. ``create_weights_jax`` attaches a
     ``weight_loader`` that accumulates each projection's ``weight`` and
-    ``weight_scale_inv`` tensor (by ``shard_id``) and, once all projections
+    dequant-scale tensor (by ``shard_id``) and, once all projections
     for a given param have arrived, concatenates them in declaration order.
 
     Unlike the unquantized merge loader, this does not interleave shards for
@@ -451,12 +451,17 @@ class Fp8BlockwiseMergedLinearMethod(Fp8BlockwiseLinearMethod):
             functools.partial(self._load_merged_shard,
                               permute_dims=(1, 0),
                               param_name=layer.prefix + ".weight"))
-        layer.weight_scale_inv.set_metadata("_merged_shards", [None] * n_proj)
-        layer.weight_scale_inv.set_metadata(
+        # The dequant scale's param name is checkpoint-dependent (see
+        # weight_scale_name in Fp8BlockwiseLinearMethod.__init__), so look the
+        # param up by that name instead of hardcoding the DeepSeek one.
+        scale_param = getattr(layer, self.weight_scale_name)
+        scale_param.set_metadata("_merged_shards", [None] * n_proj)
+        scale_param.set_metadata(
             "weight_loader",
             functools.partial(self._load_merged_shard,
                               permute_dims=(1, 0),
-                              param_name=layer.prefix + ".weight_scale_inv"))
+                              param_name=layer.prefix + "." +
+                              self.weight_scale_name))
 
 
 class Fp8FusedMoEMethod(QuantizeMethodBase):


### PR DESCRIPTION
## Summary

Part of #2261 (JAX-native compressed-tensors support). Completes the last cell of the linear dispatch matrix: a fused (merged column-parallel) layer under an fp8-block scheme now routes to `Fp8BlockwiseMergedLinearMethod` instead of raising `NotImplementedError`.

|             | plain `JaxEinsum`           | `JaxMergedColumnParallelLinear`      |
|-------------|-----------------------------|--------------------------------------|
| tensorwise  | `Fp8TensorwiseLinearMethod` | `Fp8TensorwiseMergedLinearMethod` (#3092) |
| blockwise   | `Fp8BlockwiseLinearMethod`  | **`Fp8BlockwiseMergedLinearMethod` (this PR)** |

This unblocks FP8-block checkpoints (e.g. `RedHatAI/gemma-4-31B-it-FP8-block`, 128x128 `block_structure`) on models with fused `gate_up_proj`/`qkv_proj` layers in the JAX path.

## Changes

**1. `fp8.py`: stop hardcoding the scale param name in the merged loader**

`Fp8BlockwiseMergedLinearMethod` (from #2940) attached its shard-merging loader to `layer.weight_scale_inv` directly. Its parent already threads the checkpoint-dependent name through `weight_scale_name` everywhere else (create/process/apply), so dispatching from the CT path with `weight_scale_name="weight_scale"` would raise `AttributeError` at layer construction — the param exists under the CT name. The loader is now attached via `getattr(layer, self.weight_scale_name)`.

The param name is a serialization contract with the checkpoint: vLLM streams safetensors entries by name, and `process_weights_after_loading` waits until both weight and scale are `_is_loaded` (they may live in different files). A name mismatch doesn't crash — loading silently never completes. The second test below guards exactly this.

No behavior change for the native DeepSeek-style path (`Fp8Config` dispatch, default `weight_scale_inv`): same param looked up under its default name.

**2. `compressed_tensors.py`: replace the `NotImplementedError`**

Mirror of the non-merged blockwise dispatch right below it, passing `weight_scale_name="weight_scale"` (compressed-tensors serialization; DeepSeek-style checkpoints use `weight_scale_inv` for the same quantity).

**3. Tests** (same dispatch/param-name contract as the rest of `test_compressed_tensors.py`, CI-runnable without TPU):

- merged layer + fp8-block group routes to `Fp8BlockwiseMergedLinearMethod`, with per-projection shard slots in place
- the merged scale param is created under `weight_scale` (not `weight_scale_inv`) and has the merge loader attached — guards against regressing to the hardcoded name

## Testing

On a TPU v5e VM (`v5litepod-1`, single chip):

- [x] `pytest tests/layers/jax/quantization/test_compressed_tensors.py -v` — **7 passed** (5 existing + the 2 new merged tests)
- [x] `pytest tests/layers/jax/quantization/test_fp8.py -v` (native-path regression) — **149 passed, 18 skipped** (skips are multi-device / multi-chip cases, expected on a single chip)
- [x] `pytest tests/models/jax/test_gemma4.py -k "FP8-block" -v` — **4 passed** on a v5e VM: real `RedHatAI/gemma-4-31B-it-FP8-block` checkpoint loading + one-layer forward, all pp variants
