### PR TITLE
[MLA] Pass vmem_limit_bytes to xpose_pipeline instead of relying on LIBTPU_INIT_ARGS

### DIFF
--- a/tests/kernels/mla_tuned_vs_baseline_test.py
+++ b/tests/kernels/mla_tuned_vs_baseline_test.py
@@ -12,19 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-
-# MLA-kernel-only vmem budget. Two constraints (see #3011 / #3159):
-# 1. Must run before libtpu/TPU backend initialization (module top,
-#    before the jax import below).
-# 2. Must NOT move into tests/conftest.py: a global setting changes XLA
-#    codegen for every e2e test in the suite (that is exactly how #3011
-#    caused a deterministic multimodal output drift and e2e slowdowns).
-if "--xla_tpu_scoped_vmem_limit_kib" not in os.environ.get(
-        "LIBTPU_INIT_ARGS", ""):
-    os.environ["LIBTPU_INIT_ARGS"] = (os.environ.get("LIBTPU_INIT_ARGS", "") +
-                                      " --xla_tpu_scoped_vmem_limit_kib=65536")
-
 import time
 
 import jax

--- a/tests/kernels/mla_v2_test.py
+++ b/tests/kernels/mla_v2_test.py
@@ -12,19 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-
-# MLA-kernel-only vmem budget. Two constraints (see #3011 / #3159):
-# 1. Must run before libtpu/TPU backend initialization (module top,
-#    before the jax import below).
-# 2. Must NOT move into tests/conftest.py: a global setting changes XLA
-#    codegen for every e2e test in the suite (that is exactly how #3011
-#    caused a deterministic multimodal output drift and e2e slowdowns).
-if "--xla_tpu_scoped_vmem_limit_kib" not in os.environ.get(
-        "LIBTPU_INIT_ARGS", ""):
-    os.environ["LIBTPU_INIT_ARGS"] = (os.environ.get("LIBTPU_INIT_ARGS", "") +
-                                      " --xla_tpu_scoped_vmem_limit_kib=65536")
-
 import jax
 import jax.numpy as jnp
 import numpy as np

--- a/tests/kernels/transpose_test.py
+++ b/tests/kernels/transpose_test.py
@@ -242,6 +242,26 @@ class TestXposePipelineTiling(parameterized.TestCase):
         expected = jnp.transpose(input_data, (1, 0, 2))
         self.assertTrue(jnp.allclose(result, expected))
 
+    def test_vmem_limit_bytes_allows_large_tiles(self):
+        # Regression test: compiling this bf16 384x128x512 transpose with
+        # n_tile=128, m_tile=64 needs ~33.6 MiB of scoped VMEM, which exceeds
+        # XLA's 32 MiB default (--xla_tpu_scoped_vmem_limit_kib) and fails
+        # compilation with E1001 CompileTimeScopedVmemOom. This is the exact
+        # shape the MLA v2 kernel's prepare_outputs transpose produces.
+        # vmem_limit_bytes raises the limit for this pallas_call only, without
+        # any global XLA flag.
+        shape = (384, 128, 512)
+        input_data = jax.random.normal(jax.random.PRNGKey(0),
+                                       shape,
+                                       dtype=jnp.bfloat16)
+        result = xpose_pipeline(input_data,
+                                transpose_axes=(1, 0, 2),
+                                n_tile=128,
+                                m_tile=64,
+                                vmem_limit_bytes=64 * 1024 * 1024)[0]
+        expected = jnp.transpose(input_data, (1, 0, 2))
+        self.assertTrue(jnp.allclose(result, expected))
+
 
 class TestPrevClosestDivisor(parameterized.TestCase):
 

--- a/tpu_inference/kernels/mla/v2/kernel.py
+++ b/tpu_inference/kernels/mla/v2/kernel.py
@@ -2042,7 +2042,8 @@ def prepare_q_inputs(
 
 
 def prepare_q_nope_inputs(
-        q: jax.Array,  # [actual_num_q_heads, max_num_tokens, actual_head_dim]
+    q: jax.Array,  # [actual_num_q_heads, max_num_tokens, actual_head_dim]
+    vmem_limit_bytes: int | None = None,
 ):
     """Packs and physically transposes q_nope to the layout expected by the MLA kernel.
 
@@ -2070,8 +2071,11 @@ def prepare_q_nope_inputs(
     )
     # Physical transpose: (N, T, D) -> (T, N, D), pipelined over T.
     try:
-        q = xpose_pipeline(q, transpose_axes=(1, 0, 2), n_tile=128,
-                           m_tile=32)[0]
+        q = xpose_pipeline(q,
+                           transpose_axes=(1, 0, 2),
+                           n_tile=128,
+                           m_tile=32,
+                           vmem_limit_bytes=vmem_limit_bytes)[0]
     except ValueError as e:
         logger.warning(
             f"xpose_pipeline failed for shape={q.shape} dtype={q.dtype} "
@@ -2116,6 +2120,7 @@ def prepare_outputs(
     actual_num_q_heads: int,
     actual_max_num_tokens: int,
     actual_head_dim: int,
+    vmem_limit_bytes: int | None = None,
 ):
     # Physical transpose: (T, N, D) -> (N, T, D), pipelined over T.
     try:
@@ -2125,7 +2130,8 @@ def prepare_outputs(
         out = xpose_pipeline(out,
                              transpose_axes=(1, 0, 2),
                              n_tile=_XPOSE_N_TILE_SIZE,
-                             m_tile=64)[0]
+                             m_tile=64,
+                             vmem_limit_bytes=vmem_limit_bytes)[0]
     except ValueError as e:
         sublane_multiple = get_dtype_packing(out.dtype) * 8
         logger.warning(
@@ -2292,7 +2298,9 @@ def mla_ragged_paged_attention(
     actual_num_q_heads, actual_max_num_tokens, actual_lkv_dim = ql_nope.shape
 
     ql_nope = prepare_q_nope_inputs(
-        ql_nope)  # [max_num_tokens, num_q_heads, lkv_dim]
+        ql_nope,
+        vmem_limit_bytes=vmem_limit_bytes,
+    )  # [max_num_tokens, num_q_heads, lkv_dim]
     q_pe = prepare_q_inputs(q_pe)  # [max_num_tokens, num_q_heads, r_dim]
     if not transpose_kv_cache:
         _, _, kv_packing, _ = cache_kv.shape
@@ -2601,7 +2609,11 @@ def mla_ragged_paged_attention(
         case=MlaCase.MIXED,
     )
     output = prepare_outputs(
-        ql_nope, actual_num_q_heads, actual_max_num_tokens,
-        actual_lkv_dim)  # [actual_num_q_heads, max_num_tokens, actual_lkv_dim]
+        ql_nope,
+        actual_num_q_heads,
+        actual_max_num_tokens,
+        actual_lkv_dim,
+        vmem_limit_bytes=vmem_limit_bytes,
+    )  # [actual_num_q_heads, max_num_tokens, actual_lkv_dim]
 
     return output, updated_kv

--- a/tpu_inference/kernels/mla/v2/transpose.py
+++ b/tpu_inference/kernels/mla/v2/transpose.py
@@ -136,7 +136,8 @@ def pin_vmem_custom_call(input_tensor: jax.Array, num_scalars: int = 0):
 
 
 @jax.jit(static_argnames=[
-    'transpose_axes', 'n_tile', 'm_tile', 'parallel_axis', 'pipeline_axis'
+    'transpose_axes', 'n_tile', 'm_tile', 'parallel_axis', 'pipeline_axis',
+    'vmem_limit_bytes'
 ])
 def xpose_pipeline(input: jax.Array,
                    *,
@@ -144,7 +145,8 @@ def xpose_pipeline(input: jax.Array,
                    n_tile: int = 128,
                    m_tile: int = 128,
                    parallel_axis: int = 0,
-                   pipeline_axis: int = 1):
+                   pipeline_axis: int = 1,
+                   vmem_limit_bytes: int | None = None):
     """
     Double buffer transpose custom call implementation.
     n_tile is used to tile the parallel dimension while m_tile is used to tile the pipeline dimension.
@@ -155,6 +157,10 @@ def xpose_pipeline(input: jax.Array,
       m_tile: tile amount for the pipelined axis
       parallel_axis: index of the parallel axis
       pipeline_axis: index of the pipeline axis
+      vmem_limit_bytes: the vmem limit for the pallas kernel. With the default
+        (None), the kernel is subject to XLA's global scoped-vmem limit
+        (--xla_tpu_scoped_vmem_limit_kib, 32 MiB by default), which large
+        tile shapes can exceed at compile time.
     """
 
     def xpose_kernel(input_ref, output_ref):
@@ -247,7 +253,8 @@ def xpose_pipeline(input: jax.Array,
     return pl.pallas_call(xpose_kernel,
                           grid=grid,
                           compiler_params=pltpu.CompilerParams(
-                              dimension_semantics=("parallel", "arbitrary")),
+                              dimension_semantics=("parallel", "arbitrary"),
+                              vmem_limit_bytes=vmem_limit_bytes),
                           in_specs=input_specs,
                           out_specs=output_specs,
                           out_shape=[


### PR DESCRIPTION
## Problem

The MLA v2 kernel's q_nope and output transposes (`xpose_pipeline` pallas_call) need ~33.3–33.6 MiB of scoped VMEM, which exceeds XLA's 32 MiB default (`--xla_tpu_scoped_vmem_limit_kib`) and fails compilation with `E1001: CompileTimeScopedVmemOom` on every cold-cache run. This is the "tpu7x/tpu6e JAX unit tests - kernels" failure on main builds 22345 and 22385 (`mla_v2_test.py::test_ragged_paged_attention_basic`, 33.56M vs 32.00M limit).

The previous mitigation (#3159, before that #3011's conftest setting) appended `--xla_tpu_scoped_vmem_limit_kib=65536` to `LIBTPU_INIT_ARGS` at MLA-test-module import. That is **order-dependent**: under `pytest tests/kernels`, `deepseek_v4/compressor_test.py` evaluates `jax.devices()` at import inside its `skipif` decorator, and `deepseek_v4/` collects alphabetically before `mla_*`, so libtpu initializes **before** the env var is appended and the flag is silently dropped. Whether the kernels CI job passed then depended purely on JAX compilation-cache warmth — warm cache skips the compile (no OOM), cold cache always fails. A 10x A/B/C stress matrix at the pre-#3134, #3134, and #3028 commits showed a flat ~2/10 cold-failure rate at all three, confirming the flake is environmental and none of those PRs caused it.

## Fix

`mla_ragged_paged_attention` already resolves `vmem_limit_bytes` (`None` → full VMEM capacity via `pltpu.get_tpu_info().vmem_capacity_bytes`, [kernel.py#L2268-L2269](https://github.com/vllm-project/tpu-inference/blob/589c3f9ea2b68c598bc5b4a7e2017b1184a0e11e/tpu_inference/kernels/mla/v2/kernel.py#L2268-L2269) — 64 MiB on tpu7x) and applies it to the main pallas_call through Mosaic `CompilerParams`. This PR threads the same value through `prepare_q_nope_inputs` / `prepare_outputs` into `xpose_pipeline`'s `CompilerParams`. The per-kernel Mosaic limit overrides the global XLA flag for that custom call only, so:

- no environment variable is needed at all (the fragile `LIBTPU_INIT_ARGS` blocks in `mla_v2_test.py` / `mla_tuned_vs_baseline_test.py` are removed), and
- nothing changes for any other compiled program (the #3159 concern — a global flag altering XLA codegen for unrelated e2e tests — cannot recur).

Both OOM-ing call sites are covered: `prepare_outputs` (384x128x512 bf16, 33.56M) and `prepare_q_nope_inputs` (128x352x512 f32, 33.30M).

## Verification

On a tpu7x-8 host, libtpu 0.0.43, with the JAX compilation cache disabled (`JAX_ENABLE_COMPILATION_CACHE=false`) to force cold compiles, over `tests/kernels/{mla_v2_test,mla_tuned_vs_baseline_test,transpose_test,deepseek_v4}`:

| | result |
|---|---|
| before, no flag | **8 failed** (all `CompileTimeScopedVmemOom` in `xpose_pipeline`: basic, basic_with_small_page_size, deepseekv3_batch_decode, mixed, prefill_only, sliding_window0/1/2), 173 passed |
| after (this PR) | **182 passed, 0 failed** |

A regression test is added in `transpose_test.py` with the exact failing shape (384x128x512 bf16, n_tile=128, m_tile=64) and `vmem_limit_bytes` set.

Follow-up (separate change): `deepseek_v4/compressor_test.py`'s import-time `jax.devices()` remains a collection-order trap for any future module-level env configuration; it should move to a lazily-evaluated skip condition.
