### PR TITLE
[Spec Decoding] Allocate mamba state slots in per-request groups for spec decoding (MTP)

### DIFF
--- a/tests/runner/test_input_batch.py
+++ b/tests/runner/test_input_batch.py
@@ -623,3 +623,134 @@ def test_dp_mamba_global_to_local_conversion():
     assert (7 * local_slots + 1) % local_slots == 1
     # Boundary: rank 1 last slot = 595 → local 297
     assert 595 % local_slots == 297
+
+
+# --------------- Speculative-decoding slot-group tests ---------------
+
+NUM_SPEC_TOKENS = 4
+SLOT_STRIDE = NUM_SPEC_TOKENS + 1
+
+
+@pytest.fixture
+def spec_input_batch():
+    """InputBatch with speculative decoding enabled (slot groups of 5)."""
+    return InputBatch(
+        max_num_reqs=MAX_NUM_REQS,
+        max_model_len=MAX_MODEL_LEN,
+        max_num_batched_tokens=MAX_NUM_BATCHED_TOKENS,
+        pin_memory=False,
+        vocab_size=VOCAB_SIZE,
+        block_sizes=BLOCK_SIZES,
+        is_spec_decode=True,
+        num_speculative_tokens=NUM_SPEC_TOKENS,
+    )
+
+
+@pytest.fixture
+def dp_spec_input_batch():
+    """InputBatch with dp_size=4 and speculative decoding enabled."""
+    return InputBatch(
+        max_num_reqs=DP_MAX_NUM_REQS,
+        max_model_len=MAX_MODEL_LEN,
+        max_num_batched_tokens=MAX_NUM_BATCHED_TOKENS,
+        pin_memory=False,
+        vocab_size=VOCAB_SIZE,
+        block_sizes=BLOCK_SIZES,
+        is_spec_decode=True,
+        num_speculative_tokens=NUM_SPEC_TOKENS,
+        dp_size=DP_SIZE,
+    )
+
+
+def test_mamba_slot_stride_one_matches_legacy(input_batch: InputBatch):
+    """Without spec decode the stride is 1 and the pool is the legacy
+    layout: every slot in (0, local_slots) is a valid base."""
+    assert input_batch.mamba_slot_stride == 1
+    local_slots = input_batch._mamba_local_slots
+    assert local_slots == MAX_NUM_REQS + 1
+    pool = input_batch._free_mamba_slots_per_rank[0]
+    assert sorted(pool) == list(range(1, MAX_NUM_REQS + 1))
+
+
+def test_mamba_slot_groups_stride_allocation(spec_input_batch: InputBatch):
+    """Group bases are handed out with stride num_spec + 1, leaving room
+    for one state checkpoint per speculative window position."""
+    assert spec_input_batch.mamba_slot_stride == SLOT_STRIDE
+    # One group per request plus the null slot.
+    assert (spec_input_batch._mamba_local_slots == MAX_NUM_REQS * SLOT_STRIDE +
+            1)
+    bases = []
+    for i in range(MAX_NUM_REQS):
+        req = create_dummy_request(f"req_{i}")
+        spec_input_batch.add_request(req)
+        base = int(spec_input_batch.mamba_state_indices_cpu[
+            spec_input_batch.req_id_to_index[f"req_{i}"]])
+        assert spec_input_batch.is_valid_mamba_slot_base(base)
+        bases.append(base)
+    assert bases == [1 + i * SLOT_STRIDE for i in range(MAX_NUM_REQS)]
+    # Groups cover disjoint slot ranges within the shard.
+    covered = set()
+    for base in bases:
+        group = set(range(base, base + SLOT_STRIDE))
+        assert not (group & covered)
+        assert max(group) < spec_input_batch._mamba_local_slots
+        covered |= group
+
+
+def test_mamba_slot_groups_release_and_reuse(spec_input_batch: InputBatch):
+    """A removed request's group base returns to the pool and is reused."""
+    for i in range(MAX_NUM_REQS):
+        spec_input_batch.add_request(create_dummy_request(f"req_{i}"))
+    assert not spec_input_batch._free_mamba_slots_per_rank[0]
+
+    victim_base = int(spec_input_batch.mamba_state_indices_cpu[
+        spec_input_batch.req_id_to_index["req_3"]])
+    removed_idx = spec_input_batch.remove_request("req_3")
+    spec_input_batch.condense([removed_idx])
+    assert victim_base in spec_input_batch._free_mamba_slots_per_rank[0]
+
+    spec_input_batch.add_request(create_dummy_request("req_new"))
+    new_base = int(spec_input_batch.mamba_state_indices_cpu[
+        spec_input_batch.req_id_to_index["req_new"]])
+    assert new_base == victim_base
+    spec_input_batch.assert_mamba_state_invariants()
+
+
+def test_mamba_slot_release_rejects_unaligned(spec_input_batch: InputBatch):
+    """Releasing a slot id that is not a group base must fail loudly:
+    a misaligned id in the free pool would corrupt a later request."""
+    spec_input_batch.add_request(create_dummy_request("req_0"))
+    base = int(spec_input_batch.mamba_state_indices_cpu[0])
+    with pytest.raises(AssertionError):
+        spec_input_batch.release_mamba_slot(base + 2)
+    # Null slot ids are silently ignored, as before.
+    spec_input_batch.release_mamba_slot(0)
+
+
+def test_mamba_slot_groups_init_pools_resize(spec_input_batch: InputBatch):
+    """init_mamba_pools re-derives group bases from the actual device
+    block count."""
+    # 3 groups of 5 + null = 16 slots.
+    spec_input_batch.init_mamba_pools(16)
+    assert spec_input_batch._mamba_local_slots == 16
+    pool = spec_input_batch._free_mamba_slots_per_rank[0]
+    assert sorted(pool) == [1, 6, 11]
+
+
+def test_dp_mamba_slot_groups_partitioned_by_rank(
+        dp_spec_input_batch: InputBatch):
+    """Group bases stay within their rank's shard and keep the stride,
+    so a group never straddles a DP-rank boundary."""
+    local_slots = dp_spec_input_batch._mamba_local_slots
+    reqs_per_rank = DP_MAX_NUM_REQS // DP_SIZE
+    assert local_slots == reqs_per_rank * SLOT_STRIDE + 1
+    for rank in range(DP_SIZE):
+        rank_base = rank * local_slots
+        pool = dp_spec_input_batch._free_mamba_slots_per_rank[rank]
+        assert sorted(pool) == [
+            rank_base + 1 + g * SLOT_STRIDE for g in range(reqs_per_rank)
+        ]
+        for slot in pool:
+            assert dp_spec_input_batch.is_valid_mamba_slot_base(slot)
+            # The whole group fits inside this rank's shard.
+            assert slot + SLOT_STRIDE - 1 < rank_base + local_slots

--- a/tpu_inference/runner/input_batch.py
+++ b/tpu_inference/runner/input_batch.py
@@ -158,6 +158,16 @@ class InputBatch:
         # physical slot. Indexing the cache by the moving `req_idx` would
         # read stale state; indexing by `mamba_state_indices_cpu[req_idx]`
         # reads the slot that actually holds this request's state.
+        #
+        # With speculative decoding, each request owns a *group* of
+        # `num_speculative_tokens + 1` consecutive slots; the tracked slot id
+        # is the group's base. During a verify step the GDN kernel writes one
+        # state checkpoint per window position into `base + t`, and the next
+        # step reads its initial state from `base + (num_accepted - 1)`.
+        # Rejected drafts are thus rolled back by *selection*, never by
+        # copying. Without spec decode the stride is 1 (one slot per
+        # request), matching the original layout.
+        #
         # Initial pool size is based on max_num_reqs rounded up to dp_size;
         # init_mamba_pools() resizes after KV cache allocation is known.
         self.mamba_state_indices_cpu = np.zeros(max_num_reqs, dtype=np.int32)
@@ -165,18 +175,33 @@ class InputBatch:
         # get slots within that rank's shard of the device-side state array.
         # Matches the sharding in kv_cache_manager: mamba_num_blocks is
         # rounded up to dp_size, then split evenly across ranks.
-        mamba_num_blocks = ((max_num_reqs + dp_size) // dp_size) * dp_size
-        self._mamba_local_slots = mamba_num_blocks // dp_size
+        self.mamba_slot_stride = num_speculative_tokens + 1
+        max_num_reqs_per_rank = (max_num_reqs + dp_size - 1) // dp_size
+        self._mamba_local_slots = (
+            max_num_reqs_per_rank * self.mamba_slot_stride + 1)
         self._free_mamba_slots_per_rank: list[list[int]] = []
-        for k in range(dp_size):
-            base = k * self._mamba_local_slots
-            self._free_mamba_slots_per_rank.append(
-                list(range(base + self._mamba_local_slots - 1, base, -1)))
+        self._build_mamba_pools()
 
         # for pooling models
         self.pooling_params: dict[str, PoolingParams] = {}
         self.pooling_states: dict[str, PoolingStates] = {}
         self.has_mamba_layers = False
+
+    def _build_mamba_pools(self) -> None:
+        """Build the per-rank free pools of slot-group base ids.
+
+        Within each rank's `_mamba_local_slots` shard, slot 0 is the null
+        block and groups of `mamba_slot_stride` consecutive slots follow.
+        The pool holds group *bases*; `.pop()` returns the lowest free base
+        first (matching the original ascending hand-out order).
+        """
+        stride = self.mamba_slot_stride
+        num_groups = (self._mamba_local_slots - 1) // stride
+        self._free_mamba_slots_per_rank = []
+        for k in range(self.dp_size):
+            base = k * self._mamba_local_slots
+            self._free_mamba_slots_per_rank.append(
+                [base + 1 + g * stride for g in reversed(range(num_groups))])
 
     def init_mamba_pools(self, mamba_num_blocks: int) -> None:
         """Reinitialize mamba slot pools with the actual device block count.
@@ -186,11 +211,12 @@ class InputBatch:
         default estimate based on max_num_reqs).
         """
         self._mamba_local_slots = mamba_num_blocks // self.dp_size
-        self._free_mamba_slots_per_rank = []
-        for k in range(self.dp_size):
-            base = k * self._mamba_local_slots
-            self._free_mamba_slots_per_rank.append(
-                list(range(base + self._mamba_local_slots - 1, base, -1)))
+        self._build_mamba_pools()
+
+    def is_valid_mamba_slot_base(self, slot: int) -> bool:
+        """True iff `slot` is a valid group base (not a null block)."""
+        local = slot % self._mamba_local_slots
+        return local != 0 and (local - 1) % self.mamba_slot_stride == 0
 
     def release_mamba_slot(self, slot: Optional[int]) -> None:
         if slot is None:
@@ -198,6 +224,10 @@ class InputBatch:
         slot = int(slot)
         if slot == 0 or slot % self._mamba_local_slots == 0:
             return
+        assert self.is_valid_mamba_slot_base(slot), (
+            f"Released mamba slot {slot} is not a group base "
+            f"(local_slots={self._mamba_local_slots}, "
+            f"stride={self.mamba_slot_stride})")
         rank = slot // self._mamba_local_slots
         pool = self._free_mamba_slots_per_rank[rank]
         if slot not in pool:
@@ -226,9 +256,11 @@ class InputBatch:
                     f"Active mamba batch has a hole at index {req_index}")
             slot = int(self.mamba_state_indices_cpu[req_index])
             active_slots.append(slot)
-            if slot <= 0 or slot % self._mamba_local_slots == 0:
+            if slot <= 0 or not self.is_valid_mamba_slot_base(slot):
                 raise AssertionError(
-                    f"Request {req_id} has invalid mamba slot {slot}")
+                    f"Request {req_id} has invalid mamba slot {slot} "
+                    f"(local_slots={self._mamba_local_slots}, "
+                    f"stride={self.mamba_slot_stride})")
             if slot in free_slots:
                 raise AssertionError(
                     f"Active request {req_id} uses free mamba slot {slot}")

--- a/tpu_inference/runner/kv_cache_manager.py
+++ b/tpu_inference/runner/kv_cache_manager.py
@@ -380,11 +380,20 @@ class KVCacheManager:
         # defensive against an empty mesh shape that produces 0.
         divisor = max(divisor, 1)
 
-        # Mamba slot budget: one per persistent-batch slot plus the null
-        # block, rounded up to the sharding divisor. `runner.max_num_reqs`
-        # already includes the DP multiplier
+        # Mamba slot budget: one slot *group* per persistent-batch slot plus
+        # the null block, rounded up to the sharding divisor.
+        # `runner.max_num_reqs` already includes the DP multiplier
         # (= `dp_size × scheduler_config.max_num_seqs`).
-        mamba_num_blocks = self.runner.max_num_reqs + 1
+        # With speculative decoding each request owns `num_spec + 1`
+        # consecutive slots so the GDN kernel can checkpoint the state after
+        # every speculative window position (see
+        # `InputBatch.mamba_state_indices_cpu` for the rollback scheme).
+        num_spec = 0
+        if self.runner.vllm_config.speculative_config is not None:
+            num_spec = (self.runner.vllm_config.speculative_config.
+                        num_speculative_tokens)
+        mamba_slot_stride = num_spec + 1
+        mamba_num_blocks = self.runner.max_num_reqs * mamba_slot_stride + 1
         mamba_num_blocks = (
             (mamba_num_blocks + divisor - 1) // divisor) * divisor
 


### PR DESCRIPTION
# Description

Makes the compact-mamba slot pool allocate state slots in per-request *groups* of `num_speculative_tokens + 1` consecutive slots — the allocation half of Mamba state rollback for speculative decoding (MTP) on hybrid models.

**Why:** rollback works by checkpoint-and-select: during a verify step the GDN kernel writes one state checkpoint per window position to `base_slot + t`, and the next step resumes from `base_slot + num_accepted − 1` (the checkpoint of the last accepted token). That requires each request to own `num_spec + 1` consecutive physical slots instead of one. The kernel-side SPEC mode is in #3189; the runner wiring that connects the two follows in a final PR.

**What changes:**
- `InputBatch` free pools hold group *bases* with stride `mamba_slot_stride = num_speculative_tokens + 1`, still partitioned by DP rank; a group never straddles a rank shard.
- `release_mamba_slot` / `assert_mamba_state_invariants` validate group-base alignment, so a misaligned slot id fails loudly instead of silently corrupting a later request's state.
- `KVCacheManager._maybe_set_compact_mamba_num_blocks_override` sizes the pool as `max_num_reqs × stride + 1` and accounts for it in the HBM split.

**Behavior:** without spec decode the stride is 1 and layout/sizing/invariants are byte-identical to today. With spec decode enabled the extra slots are reserved but unused until the follow-up wiring lands — note this grows the mamba pool HBM reservation by `(num_spec+1)×` for spec-enabled hybrid configs. Since MTP on hybrid TPU models currently generates from corrupted state anyway, no working configuration regresses.

# Tests

All 23 existing pool tests pass unchanged (stride-1 no-op proof). Six new unit tests in `tests/runner/test_input_batch.py` cover:

- group bases handed out with the correct stride, and group slot ranges disjoint within the shard;
- release and reuse of a removed request's group base, with invariants intact;
- rejection (loud AssertionError) of releasing an unaligned slot id;
- `init_mamba_pools` re-deriving group bases from the actual device block count;
- DP-rank partitioning: bases stay in their rank's shard and whole groups fit inside it;
- legacy layout equivalence when `num_speculative_tokens = 0`.

Reproduce: `pytest tests/runner/test_input_batch.py -q` (CPU-only, no TPU required).

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
