### PR TITLE
rpa_v3_cp: support head_dim>128 

### DIFF
--- a/tpu_inference/kernels/experimental/rpa_v3_cp/kernel.py
+++ b/tpu_inference/kernels/experimental/rpa_v3_cp/kernel.py
@@ -1835,6 +1835,12 @@ def get_default_block_sizes(
     max_q = next_power_of_2(max_num_tokens)
     max_kv = pages_per_seq * page_size
 
+    # The KV compute/prefetch buffers scale with head_dim, but the default
+    # bkv_sz below is tuned for head_dim=128. For larger head_dim shrink the
+    # prefetch block proportionally so VMEM scratch stays within budget
+    # (head_dim=128 -> factor 1, so this is a no-op there).
+    hd_blocks = max(1, head_dim // 128)
+
     min_bkv_sz_to_peak = (16 * 1024 * 1024 * kv_packing // 4 // head_dim //
                           num_kv_heads_x2)
 
@@ -1858,7 +1864,7 @@ def get_default_block_sizes(
                 bkv_csz = min(min_bkv_sz_to_peak, max_kv)
             else:
                 bq_sz = min(2048 // num_q_heads_per_kv_head, max_q // 2)
-                bkv_sz = min(2048, max_kv // 2)
+                bkv_sz = min(2048 // hd_blocks, max_kv // 2)
                 bq_csz = min(1024 // num_q_heads_per_kv_head, max_q // 2)
                 bkv_csz = min(512, align_to(max_kv // 2, page_size))
         case _:

--- a/tpu_inference/kernels/experimental/rpa_v3_cp/kernel.py
+++ b/tpu_inference/kernels/experimental/rpa_v3_cp/kernel.py
@@ -869,23 +869,20 @@ def _ragged_paged_attention_kernel_loop(
             # dst_u32 shape: [bkv_sz, num_kv_heads_x2_per_kv_packing, head_dim] in uint32
 
             # Mosaic strided loads require the (base memref's) lane dim to be
-            # exactly 128. After the uint32 bitcast the lane dim is head_dim, so
-            # for head_dim > 128 (e.g. 256) reshape head_dim -> (head_dim//128,
-            # 128) so the strided load's base memref has a 128-wide lane dim.
+            # exactly 128. After the uint32 bitcast the lane dim is head_dim,
+            # which is always align_to(.., 128), so split it into
+            # (head_dim // 128, 128) unconditionally: the strided load then
+            # always sees a 128-wide lane dim, and head_dim == 128 just gets a
+            # degenerate leading 1.
             lane = 128
-            hd_u32 = src_u32.shape[-1]
-            if hd_u32 > lane:
-                src_r = src_u32.reshape(*src_u32.shape[:-1], hd_u32 // lane, lane)
-                dst_r = dst_u32.reshape(*dst_u32.shape[:-1], hd_u32 // lane, lane)
-                dst_r[pl.ds(0, n_strided)] = src_r[
-                    pl.ds(src_start, n_strided, cp_group_size),
-                    :num_kv_heads_x2_per_kv_packing,
-                ]
-            else:
-                dst_u32[pl.ds(0, n_strided)] = src_u32[
-                    pl.ds(src_start, n_strided, cp_group_size),
-                    :num_kv_heads_x2_per_kv_packing,
-                ]
+            src_r = src_u32.reshape(*src_u32.shape[:-1],
+                                    src_u32.shape[-1] // lane, lane)
+            dst_r = dst_u32.reshape(*dst_u32.shape[:-1],
+                                    dst_u32.shape[-1] // lane, lane)
+            dst_r[pl.ds(0, n_strided)] = src_r[
+                pl.ds(src_start, n_strided, cp_group_size),
+                :num_kv_heads_x2_per_kv_packing,
+            ]
 
             def loop_body(i, states):
                 remaining_sz, ignore = states

--- a/tpu_inference/kernels/experimental/rpa_v3_cp/kernel.py
+++ b/tpu_inference/kernels/experimental/rpa_v3_cp/kernel.py
@@ -868,10 +868,24 @@ def _ragged_paged_attention_kernel_loop(
             dst_u32 = kv_shuffle_vmem_ref.bitcast(jnp.uint32)
             # dst_u32 shape: [bkv_sz, num_kv_heads_x2_per_kv_packing, head_dim] in uint32
 
-            dst_u32[pl.ds(0, n_strided)] = src_u32[
-                pl.ds(src_start, n_strided, cp_group_size),
-                :num_kv_heads_x2_per_kv_packing,
-            ]
+            # Mosaic strided loads require the (base memref's) lane dim to be
+            # exactly 128. After the uint32 bitcast the lane dim is head_dim, so
+            # for head_dim > 128 (e.g. 256) reshape head_dim -> (head_dim//128,
+            # 128) so the strided load's base memref has a 128-wide lane dim.
+            lane = 128
+            hd_u32 = src_u32.shape[-1]
+            if hd_u32 > lane:
+                src_r = src_u32.reshape(*src_u32.shape[:-1], hd_u32 // lane, lane)
+                dst_r = dst_u32.reshape(*dst_u32.shape[:-1], hd_u32 // lane, lane)
+                dst_r[pl.ds(0, n_strided)] = src_r[
+                    pl.ds(src_start, n_strided, cp_group_size),
+                    :num_kv_heads_x2_per_kv_packing,
+                ]
+            else:
+                dst_u32[pl.ds(0, n_strided)] = src_u32[
+                    pl.ds(src_start, n_strided, cp_group_size),
+                    :num_kv_heads_x2_per_kv_packing,
+                ]
 
             def loop_body(i, states):
                 remaining_sz, ignore = states


### PR DESCRIPTION
## Summary
`rpa_v3_cp` fails to compile at `head_dim=256`; this makes it work. Two independent fixes, both no-ops at `head_dim=128`:

1. **Strided KV-cache write (`_update_kv_cache_partial`)** — the strided store bitcasts packed KV to uint32 and issues a strided vector load whose lane (last) dim is `head_dim`. Mosaic requires the base memref's lane dim to be exactly 128, so `head_dim=256` failed with:
   ```
   Not Implemented: The last dim size is not 128 in original base memref
   ```
   Fix: `head_dim` is always `align_to(.., 128)`, so reshape it to `(head_dim // 128, 128)` unconditionally — the strided load always sees a 128-wide lane dim, and `head_dim == 128` just gets a degenerate leading `1` and takes the same path (one code path for all head_dims).

2. **VMEM block sizing (`get_default_block_sizes`)** — the heuristic ignored `head_dim`, so the `head_dim=128`-tuned `bkv_sz=2048` overflowed VMEM at 256 (`Ran out of memory in memory space vmem. Used 65.71M of 63.94M`) for configs with several local KV heads. Fix: scale `bkv_sz` by `head_dim // 128` (factor 1 at 128).

## Testing — please read
These fixes were developed and validated against the **PCP** version of this kernel (on the `wxd-pcp` branch), where:
- the full PCP kernel suite passes at **both hd=128 and hd=256** (24/24 each), including the exact-equality strided/merged cache-write tests and PCP-vs-TP equivalence;
- `examples/offline_inference.py` on `Qwen/Qwen3-8B-Base` at tp=4 / pcp=2 produces correct outputs;
- a context sweep (16k->2M, chunk 16k, tp4/tp8/pcp2_tp4/pcp8_tp1) shows **no perf change at hd=128** (all configs within run-to-run noise; `tp4`/`tp8` don't touch this kernel and served as the noise control).

