### PR TITLE
[Feat][KV Cache] Unified block-major KV cache for Qwen2/3: block id as the major dim for O(1) block transfer

### DIFF
--- a/tests/distributed/test_kv_transfer.py
+++ b/tests/distributed/test_kv_transfer.py
@@ -251,6 +251,106 @@ class KVTransferTest(jtu.JaxTestCase):
                     np.testing.assert_array_equal(
                         np.asarray(y[layer_idx])[p_d_off], 0)
 
+    def test_async_copy_unified_single_pool_donates_in_place(self):
+        """A single-element dest list (the unified pool) is the case that
+        needs the optimization_barrier in _async_copy_jit: the copy must
+        compile (no aliasing-verifier crash), land whole blocks at the right
+        dim0 offsets, and keep the donation in place (same per-shard buffer
+        pointers, i.e. the barrier adds no whole-pool copy)."""
+        num_devices = jax.device_count()
+        axis_shapes = (1, num_devices)
+        axis_names = ('data', 'model')
+        mesh = create_mesh(axis_shapes, axis_names)
+
+        num_blocks, num_layers = 32, 4
+        # kv-heads dim sized to the device count so the 'model' shard always
+        # divides evenly.
+        pool_shape = (num_blocks, num_layers, 16, num_devices, 2, 128)
+        dtype = jnp.bfloat16
+        partition_spec = jax.sharding.PartitionSpec(None, None, None, 'model',
+                                                    None, None)
+        device_sharding = jax.sharding.NamedSharding(mesh,
+                                                     partition_spec,
+                                                     memory_kind='device')
+        replicated_sharding = jax.sharding.NamedSharding(mesh,
+                                                         P(),
+                                                         memory_kind='device')
+
+        src_offsets_list = [0, 1, 3]
+        dest_offsets_list = [5, 9, 20]
+        chunk_sizes_list = [1, 2, 1]
+        num_copy_blocks = sum(chunk_sizes_list)
+
+        src_offsets = jax.device_put(
+            jnp.array(src_offsets_list, dtype=jnp.int32), replicated_sharding)
+        dest_offsets = jax.device_put(
+            jnp.array(dest_offsets_list, dtype=jnp.int32), replicated_sharding)
+        chunk_sizes = jax.device_put(
+            jnp.array(chunk_sizes_list, dtype=jnp.int32), replicated_sharding)
+        num_chunks = jax.device_put(
+            jnp.array([len(chunk_sizes_list)], dtype=jnp.int32),
+            replicated_sharding)
+
+        dest_pool = create_single_layer_kv_cache(
+            pool_shape,
+            dtype,
+            device_sharding,
+            init_zeros=True,
+        )
+        src_blocks = create_single_layer_kv_cache(
+            (num_copy_blocks, ) + pool_shape[1:],
+            dtype,
+            device_sharding,
+            init_zeros=False,
+        )
+        jax.block_until_ready([dest_pool, src_blocks])
+        src_np = np.asarray(src_blocks.astype(jnp.float32))
+
+        # Per-device buffer pointers of the (about to be donated) dest.
+        ptrs_before = {
+            shard.device: shard.data.unsafe_buffer_pointer()
+            for shard in dest_pool.addressable_shards
+        }
+
+        y = multi_layer_copy(
+            src_array=[src_blocks],
+            dest_array=[dest_pool],
+            src_offsets=src_offsets,
+            dest_offsets=dest_offsets,
+            chunk_sizes=chunk_sizes,
+            num_chunks=num_chunks,
+            mesh=mesh,
+            src_sharding_spec=partition_spec,
+            dest_sharding_spec=partition_spec,
+            replicated_sharding_spec=P(),
+        )
+        self.assertEqual(len(y), 1)
+        out = y[0]
+        out.block_until_ready()
+
+        self.assertEqual(out.sharding.memory_kind, 'device')
+        self.assertEqual(out.shape, pool_shape)
+
+        # Donation held: same buffer, no extra whole-pool copy from the
+        # optimization_barrier.
+        ptrs_after = {
+            shard.device: shard.data.unsafe_buffer_pointer()
+            for shard in out.addressable_shards
+        }
+        self.assertEqual(ptrs_before, ptrs_after)
+
+        # Data correctness: each chunk of whole blocks (all layers at once)
+        # landed at its destination block offset; everything else is zero.
+        out_np = np.asarray(out.astype(jnp.float32))
+        copied_rows = set()
+        for s_off, d_off, c_size in zip(src_offsets_list, dest_offsets_list,
+                                        chunk_sizes_list):
+            np.testing.assert_array_equal(out_np[d_off:d_off + c_size],
+                                          src_np[s_off:s_off + c_size])
+            copied_rows.update(range(d_off, d_off + c_size))
+        untouched = [b for b in range(num_blocks) if b not in copied_rows]
+        self.assertFalse(out_np[untouched].any())
+
     def test_hbm_to_host_dma(self):
         self._run_copy_to_host_test('device', 'pinned_host')
 

--- a/tests/layers/common/test_attention_interface.py
+++ b/tests/layers/common/test_attention_interface.py
@@ -490,3 +490,75 @@ def test_mla_attention(monkeypatch, mesh):
     assert kernel_kwargs["num_kv_pages_per_block"] == (3, 1, 1)
     assert kernel_kwargs["num_queries_per_block"] == (1, 16, 16)
     assert kernel_kwargs["sm_scale"] == 0.1
+
+
+# ---- Test for the unified 6D block-major KV cache path ----
+
+
+def test_attention_unified_6d_folds_and_redirects_pages(monkeypatch, mesh):
+    """With a 6D block-major kv_cache and layer_idx/num_layers, `attention`
+    must hand the kernel the pool folded to its 5D layout with page
+    addressing redirected to flat page block*num_layers + layer_idx, and
+    return the updated pool unfolded back to 6D."""
+    head_dim = 128
+    num_layers, layer_idx = 4, 2
+    dtype = jnp.float32
+
+    q = jnp.ones((TOTAL_TOKENS, NUM_HEADS, head_dim), dtype=dtype)
+    k = jnp.ones((TOTAL_TOKENS, NUM_KV_HEADS, head_dim), dtype=dtype)
+    v = jnp.ones((TOTAL_TOKENS, NUM_KV_HEADS, head_dim), dtype=dtype)
+
+    single_layer_shape = get_kv_cache_shape_with_mesh(mesh, NUM_BLOCKS,
+                                                      BLOCK_SIZE, NUM_KV_HEADS,
+                                                      head_dim, dtype)
+    pool = jnp.zeros(
+        (single_layer_shape[0], num_layers, *single_layer_shape[1:]),
+        dtype=dtype)
+
+    captured = {}
+
+    def fake_kernel(q_in, k_in, v_in, kv_cache_in, kv_lens_in, page_indices_in,
+                    *_args, **_kwargs):
+        captured["kv_cache_shape"] = kv_cache_in.shape
+        captured["page_indices"] = page_indices_in
+        return jnp.ones((TOTAL_TOKENS, NUM_HEADS, head_dim)), kv_cache_in
+
+    monkeypatch.setattr(
+        "tpu_inference.layers.common.attention_interface.ragged_paged_attention",
+        fake_kernel,
+    )
+    # Passthrough shard_map so the closure executes on concrete arrays.
+    monkeypatch.setattr("jax.shard_map", lambda inner_fn, **_: inner_fn)
+
+    # Distinct nonzero block ids so the flat-page redirection is visible.
+    block_tables = jnp.arange(MAX_NUM_SEQS * MAX_BLOCKS_PER_SEQ,
+                              dtype=jnp.int32)
+    attention_metadata = AttentionMetadata(
+        input_positions=jnp.arange(TOTAL_TOKENS, dtype=jnp.int32),
+        block_tables=block_tables,
+        seq_lens=jnp.array([5, 5, 0, 0], dtype=jnp.int32),
+        query_start_loc=jnp.array([0, 5, 10, 10, 10], dtype=jnp.int32),
+        request_distribution=jnp.array([0, 0, NUM_SEQS], dtype=jnp.int32),
+    )
+
+    final_kv_cache, output = attention(
+        kv_cache=pool,
+        q=q,
+        k=k,
+        v=v,
+        attention_metadata=attention_metadata,
+        mesh=mesh,
+        head_dim_original=head_dim,
+        layer_idx=layer_idx,
+        num_layers=num_layers,
+    )
+
+    # The kernel saw the folded 5D cache and the redirected flat pages.
+    assert captured["kv_cache_shape"] == (single_layer_shape[0] * num_layers,
+                                          *single_layer_shape[1:])
+    np.testing.assert_array_equal(
+        np.asarray(captured["page_indices"]),
+        np.asarray(block_tables) * num_layers + layer_idx)
+    # The updated pool comes back unfolded to the original 6D shape.
+    assert final_kv_cache.shape == pool.shape
+    assert output.shape == q.shape

--- a/tests/models/jax/test_qwen2.py
+++ b/tests/models/jax/test_qwen2.py
@@ -180,12 +180,32 @@ class TestQwen2ForCausalLM:
             cache_dtype=jnp.float8_e4m3fn
             if mock_vllm_config.cache_config.cache_dtype == "fp8" else
             jnp.bfloat16)
+        # Snapshot the fresh caches as a 6D block-major pool for the unified
+        # path check below (the per-layer forward consumes kv_caches).
+        unified_pool = jnp.stack(kv_caches, axis=1)
+
         # 1 seq with 16 tokens
         input_ids, attention_metadata, indices_do_sample = mock_model_inputs
         kv_caches, hidden_states, aux_hidden_states, _ = model(
             kv_caches, input_ids, attention_metadata)
         assert hidden_states.shape == (8, hidden_size)
         assert len(aux_hidden_states) == 0
+
+        # Unified block-major KV cache path: the same forward on the single
+        # 6D pool must match the per-layer path exactly, both the hidden
+        # states and every layer's updated cache contents (pool dim1 slices).
+        unified_caches, unified_hidden, unified_aux, _ = model(
+            [unified_pool], input_ids, attention_metadata)
+        assert len(unified_caches) == 1
+        assert len(unified_aux) == 0
+        np.testing.assert_array_equal(
+            np.asarray(unified_hidden.astype(jnp.float32)),
+            np.asarray(hidden_states.astype(jnp.float32)))
+        for i, layer_cache in enumerate(kv_caches):
+            np.testing.assert_array_equal(
+                np.asarray(unified_caches[0][:, i].astype(jnp.float32)),
+                np.asarray(layer_cache.astype(jnp.float32)),
+                err_msg=f"kv cache mismatch at layer {i}")
 
         hidden_states = hidden_states[indices_do_sample]
         assert hidden_states.shape == (1, hidden_size)

--- a/tests/models/jax/test_qwen3.py
+++ b/tests/models/jax/test_qwen3.py
@@ -205,12 +205,41 @@ class TestQwen3ForCausalLM:
             cache_dtype=jnp.float8_e4m3fn
             if mock_vllm_config.cache_config.cache_dtype == "fp8" else
             jnp.bfloat16)
+        # Snapshot the fresh caches as a 6D block-major pool for the unified
+        # path check below (the per-layer forward consumes kv_caches), and
+        # collect aux hidden states so both dispatch branches exercise it.
+        unified_pool = jnp.stack(kv_caches, axis=1)
+        model.model.aux_hidden_state_layers = [0, 2]
+
         # 1 seq with 16 tokens
         input_ids, attention_metadata, indices_do_sample = mock_model_inputs
         kv_caches, hidden_states, aux_hidden_states, _ = model(
             kv_caches, input_ids, attention_metadata)
         assert hidden_states.shape == (8, hidden_size)
-        assert len(aux_hidden_states) == 0
+        assert len(aux_hidden_states) == 2
+
+        # Unified block-major KV cache path: the same forward on the single
+        # 6D pool must match the per-layer path exactly (hidden states, aux
+        # hidden states, and every layer's cache = pool dim1 slice).
+        # Regression: this call raised IndexError while Qwen3Model's
+        # __call__ override lacked the unified branch.
+        if pp_world_size == 1:
+            unified_caches, unified_hidden, unified_aux, _ = model(
+                [unified_pool], input_ids, attention_metadata)
+            assert len(unified_caches) == 1
+            np.testing.assert_array_equal(
+                np.asarray(unified_hidden.astype(jnp.float32)),
+                np.asarray(hidden_states.astype(jnp.float32)))
+            assert len(unified_aux) == 2
+            for unified_x, ref_x in zip(unified_aux, aux_hidden_states):
+                np.testing.assert_array_equal(
+                    np.asarray(unified_x.astype(jnp.float32)),
+                    np.asarray(ref_x.astype(jnp.float32)))
+            for i, layer_cache in enumerate(kv_caches):
+                np.testing.assert_array_equal(
+                    np.asarray(unified_caches[0][:, i].astype(jnp.float32)),
+                    np.asarray(layer_cache.astype(jnp.float32)),
+                    err_msg=f"kv cache mismatch at layer {i}")
 
         hidden_states = hidden_states[indices_do_sample]
         assert hidden_states.shape == (1, hidden_size)

--- a/tests/runner/test_kv_cache.py
+++ b/tests/runner/test_kv_cache.py
@@ -23,8 +23,10 @@ from jax.sharding import Mesh, NamedSharding, PartitionSpec
 
 from tpu_inference.layers.common.sharding import ShardingAxisName
 from tpu_inference.runner.kv_cache import (create_kv_caches,
+                                           create_unified_kv_cache,
                                            get_attention_page_size_bytes,
-                                           get_kv_cache_shape_with_mesh)
+                                           get_kv_cache_shape_with_mesh,
+                                           model_uses_unified_kv_cache)
 from tpu_inference.utils import get_dtype_packing
 
 
@@ -260,3 +262,130 @@ def test_create_kv_caches_batch_equivalence(mesh: Mesh):
             assert b_cache.sharding == i_cache.sharding
             # Note: Content is empty/uninitialized, so we don't compare values,
             # just the metadata and allocation properties.
+
+
+# ---- Tests for the unified block-major KV cache path ----
+
+
+def _make_vllm_config(architectures, speculative_config=None):
+    """Minimal config mock exposing exactly what the gate reads."""
+    config = MagicMock()
+    config.speculative_config = speculative_config
+    config.model_config.architectures = architectures
+    return config
+
+
+@pytest.mark.parametrize("architectures,speculative_config,expected", [
+    (["Qwen2ForCausalLM"], None, True),
+    (["Qwen3ForCausalLM"], None, True),
+    (["SomeVisionEncoder", "Qwen2ForCausalLM"], None, True),
+    (["LlamaForCausalLM"], None, False),
+    (["Qwen2_5_VLForConditionalGeneration"], None, False),
+    (["Qwen3MoeForCausalLM"], None, False),
+    ([], None, False),
+    (["Qwen3ForCausalLM"], "draft", False),
+])
+def test_model_uses_unified_kv_cache(architectures, speculative_config,
+                                     expected):
+    """Allowlisted archs (anywhere in the list) take the unified path;
+    other archs and speculative decoding keep the per-layer path."""
+    config = _make_vllm_config(architectures,
+                               speculative_config=speculative_config)
+    assert model_uses_unified_kv_cache(config) is expected
+
+
+@pytest.mark.parametrize("num_layers", [1, 4])
+@pytest.mark.parametrize("cache_dtype", [jnp.bfloat16, jnp.float8_e4m3fn])
+def test_create_unified_kv_cache(mesh: Mesh, num_layers, cache_dtype):
+    """6D block-major pool: (num_blocks, num_layers, *per_layer_dims),
+    sharded rank-6 with ATTN_HEAD on dim3 (kv heads)."""
+    num_blocks = 16
+    block_size = 16
+    num_kv_heads = 8
+    head_size = 128
+
+    single_layer_shape = get_kv_cache_shape_with_mesh(mesh, num_blocks,
+                                                      block_size, num_kv_heads,
+                                                      head_size, cache_dtype)
+
+    cache = create_unified_kv_cache(
+        num_blocks=num_blocks,
+        block_size=block_size,
+        num_kv_heads=num_kv_heads,
+        head_size=head_size,
+        mesh=mesh,
+        num_layers=num_layers,
+        cache_dtype=cache_dtype,
+    )
+
+    assert isinstance(cache, jax.Array)
+    assert cache.ndim == 6
+    assert cache.shape == (single_layer_shape[0], num_layers,
+                           *single_layer_shape[1:])
+    assert cache.dtype == cache_dtype
+
+    expected_sharding = NamedSharding(
+        mesh,
+        PartitionSpec(ShardingAxisName.ATTN_DATA, None, None,
+                      ShardingAxisName.ATTN_HEAD, None, None),
+    )
+    assert cache.sharding == expected_sharding
+
+
+def test_create_unified_kv_cache_matches_model_loader_pin(mesh: Mesh):
+    """model_loader's out_shardings pin must be layout-equivalent to the
+    allocated sharding, or every run_model call would reshard the pool."""
+    cache = create_unified_kv_cache(
+        num_blocks=8,
+        block_size=16,
+        num_kv_heads=8,
+        head_size=128,
+        mesh=mesh,
+        num_layers=2,
+    )
+    loader_pin = NamedSharding(
+        mesh,
+        PartitionSpec(ShardingAxisName.ATTN_DATA, None, None,
+                      ShardingAxisName.ATTN_HEAD),
+    )
+    assert loader_pin.is_equivalent_to(cache.sharding, cache.ndim)
+
+
+def test_create_unified_kv_cache_tp_shards_kv_head_dim():
+    """At TP>1 the pool is sharded on dim3 (kv heads); the legacy rank-3
+    spec would land ATTN_HEAD on dim2 and must NOT be equivalent."""
+    num_model_devices = 2
+    if jax.device_count() < num_model_devices:
+        pytest.skip(f"requires >= {num_model_devices} devices")
+
+    devices = np.array(jax.devices()[:num_model_devices]).reshape(
+        (1, 1, 1, 1, num_model_devices, 1))
+    mesh = Mesh(devices,
+                axis_names=("data", "attn_dp", "attn_dp_expert", "expert",
+                            "model", "dcp"))
+
+    num_blocks = 8
+    num_layers = 3
+    cache = create_unified_kv_cache(
+        num_blocks=num_blocks,
+        block_size=16,
+        num_kv_heads=8,
+        head_size=128,
+        mesh=mesh,
+        num_layers=num_layers,
+    )
+
+    shard_shape = cache.addressable_shards[0].data.shape
+    # dim0 (blocks) and dim1 (layers) are replicated across the model axis;
+    # dim3 (kv heads) is split.
+    assert shard_shape[0] == cache.shape[0]
+    assert shard_shape[1] == num_layers
+    assert shard_shape[2] == cache.shape[2]
+    assert shard_shape[3] == cache.shape[3] // num_model_devices
+
+    legacy_rank3_pin = NamedSharding(
+        mesh,
+        PartitionSpec(ShardingAxisName.ATTN_DATA, None,
+                      ShardingAxisName.ATTN_HEAD),
+    )
+    assert not legacy_rank3_pin.is_equivalent_to(cache.sharding, cache.ndim)

--- a/tests/runner/test_kv_cache_manager.py
+++ b/tests/runner/test_kv_cache_manager.py
@@ -579,12 +579,16 @@ class TestKVCacheManager:
         # assert kv cache config with multiple kv cache groups will reinit
         # input batch.
         assert original_input_batch != self.runner.input_batch
-        assert len(self.runner.kv_caches) == 10
+        # Qwen3 is a unified-KV-cache arch: the 10 shared tensors live in one
+        # 6D block-major pool with num_layers as dim1.
+        assert len(self.runner.kv_caches) == 1
+        assert self.runner.kv_caches[0].shape == (num_blocks, 10, block_size,
+                                                  num_kv_heads * 2 //
+                                                  kv_packing, kv_packing,
+                                                  head_size)
+        assert self.runner.kv_cache_manager.attn_flat_indices == tuple(
+            range(10))
         for i in range(10):
-            assert self.runner.kv_caches[i].shape == (num_blocks, block_size,
-                                                      num_kv_heads * 2 //
-                                                      kv_packing, kv_packing,
-                                                      head_size)
             assert self.runner.layer_name_to_kvcache_index[f'layer.{i}'] == i
             assert self.runner.layer_name_to_kvcache_index[
                 f'layer.{i + 10}'] == i
@@ -626,10 +630,11 @@ class TestKVCacheManager:
         self.runner.initialize_kv_cache(kv_cache_config)
 
         # Assert that the allocated KV cache has size equal to override_blocks, not num_blocks!
+        # Unified 6D pool: (num_blocks, num_layers=1, page, heads, packing, hd).
         assert len(self.runner.kv_caches) == 1
-        assert self.runner.kv_caches[0].shape == (override_blocks, block_size,
-                                                  num_kv_heads * 2 //
-                                                  kv_packing, kv_packing,
+        assert self.runner.kv_caches[0].shape == (override_blocks, 1,
+                                                  block_size, num_kv_heads *
+                                                  2 // kv_packing, kv_packing,
                                                   head_size)
 
     def test_get_kv_cache_spec_with_eagle3(self):
@@ -782,7 +787,8 @@ class TestKVCacheManager:
         )
 
         self.runner.initialize_kv_cache(kv_cache_config)
-        assert len(self.runner.kv_caches) == 10
+        # Unified pool: 10 attention layers in one 6D array.
+        assert len(self.runner.kv_caches) == 1
         assert len(self.runner.layer_name_to_kvcache_index) == 10
 
         # Now reset.
@@ -848,19 +854,20 @@ class TestKVCacheManager:
         )
 
         self.runner.initialize_kv_cache(kv_cache_config)
-        assert len(self.runner.kv_caches) == 10
+        # Unified pool: 10 attention layers in one 6D array.
+        assert len(self.runner.kv_caches) == 1
 
         # Reset and then reinitialize.
         self.runner.delete_kv_cache()
         assert len(self.runner.kv_caches) == 0
 
         self.runner.reinitialize_kv_cache()
-        assert len(self.runner.kv_caches) == 10
+        assert len(self.runner.kv_caches) == 1
+        assert self.runner.kv_caches[0].shape == (num_blocks, 10, block_size,
+                                                  num_kv_heads * 2 //
+                                                  kv_packing, kv_packing,
+                                                  head_size)
         for i in range(10):
-            assert self.runner.kv_caches[i].shape == (num_blocks, block_size,
-                                                      num_kv_heads * 2 //
-                                                      kv_packing, kv_packing,
-                                                      head_size)
             assert self.runner.layer_name_to_kvcache_index[f'layer.{i}'] == i
 
     def test_reinitialize_kv_cache_without_init_raises(self):
@@ -970,9 +977,10 @@ class TestKVCacheManager:
         self.runner.initialize_kv_cache(kv_cache_config)
 
         # it should initialize 1 KV cache shared by all 4 layers
+        # (one shared group == one slot in the unified 6D pool).
         assert len(self.runner.kv_caches) == 1
 
-        assert self.runner.kv_caches[0].shape == (num_blocks, block_size,
+        assert self.runner.kv_caches[0].shape == (num_blocks, 1, block_size,
                                                   num_kv_heads * 2 //
                                                   kv_packing, kv_packing,
                                                   head_size)

--- a/tests/runner/test_kv_cache_manager.py
+++ b/tests/runner/test_kv_cache_manager.py
@@ -1455,3 +1455,434 @@ class TestKVCacheManager:
                 assert cache.shape[0] == num_blocks, (
                     f"layer {name} attn cache has {cache.shape[0]} blocks "
                     f"but vLLM pool has {num_blocks}")
+
+    # ---- Unified block-major KV cache path ----
+    # The setup fixture's arch resolves to Qwen3ForCausalLM (allowlisted),
+    # so initialize_kv_cache takes the unified path unless a test flips a
+    # gate.
+
+    def _make_full_attn_kv_cache_config(self,
+                                        num_layers,
+                                        num_blocks,
+                                        num_kv_heads=8,
+                                        head_size=128):
+        """One full-attention group, one KVCacheTensor per layer."""
+        block_size = self.runner.vllm_config.cache_config.block_size
+        spec = FullAttentionSpec(
+            block_size=block_size,
+            num_kv_heads=num_kv_heads,
+            head_size=head_size,
+            dtype=torch.bfloat16,
+        )
+        kv_cache_groups = [
+            KVCacheGroupSpec(
+                layer_names=[f'layer.{i}' for i in range(num_layers)],
+                kv_cache_spec=spec),
+        ]
+        kv_cache_tensors = [
+            KVCacheTensor(
+                size=num_blocks * spec.page_size_bytes,
+                shared_by=[f'layer.{i}'],
+            ) for i in range(num_layers)
+        ]
+        return KVCacheConfig(
+            num_blocks=num_blocks,
+            kv_cache_tensors=kv_cache_tensors,
+            kv_cache_groups=kv_cache_groups,
+        )
+
+    def test_initialize_kv_cache_unified_metadata(self):
+        """Unified path: single 6D pool + flat indices + layer mapping."""
+        num_layers, num_blocks = 4, 32
+        kv_cache_config = self._make_full_attn_kv_cache_config(
+            num_layers, num_blocks)
+
+        self.runner.initialize_kv_cache(kv_cache_config)
+
+        manager = self.runner.kv_cache_manager
+        assert len(self.runner.kv_caches) == 1
+        pool = self.runner.kv_caches[0]
+        assert pool.ndim == 6
+        # Block-major: dim0 = blocks, dim1 = layers.
+        assert pool.shape[0] == num_blocks
+        assert pool.shape[1] == num_layers
+        assert manager.attn_flat_indices == tuple(range(num_layers))
+        assert manager.num_total_caches == num_layers
+        assert self.runner.layer_name_to_kvcache_index == {
+            f'layer.{i}': i
+            for i in range(num_layers)
+        }
+
+    def test_initialize_kv_cache_per_layer_for_non_unified_arch(self):
+        """Non-allowlisted arch: per-layer allocation, empty metadata."""
+        self.runner.vllm_config.model_config.model_arch_config.architectures \
+            = ["LlamaForCausalLM"]
+        num_layers, num_blocks = 4, 32
+        kv_cache_config = self._make_full_attn_kv_cache_config(
+            num_layers, num_blocks)
+
+        self.runner.initialize_kv_cache(kv_cache_config)
+
+        manager = self.runner.kv_cache_manager
+        assert len(self.runner.kv_caches) == num_layers
+        for cache in self.runner.kv_caches:
+            assert cache.ndim == 5
+            assert cache.shape[0] == num_blocks
+        assert manager.attn_flat_indices == ()
+        assert manager.num_total_caches == 0
+        assert self.runner.layer_name_to_kvcache_index == {
+            f'layer.{i}': i
+            for i in range(num_layers)
+        }
+
+    def test_initialize_kv_cache_per_layer_with_spec_decode(self):
+        """Speculative decoding keeps the per-layer path."""
+        self.runner.vllm_config.speculative_config = MagicMock(
+            num_speculative_tokens=0)
+        num_layers, num_blocks = 4, 32
+        kv_cache_config = self._make_full_attn_kv_cache_config(
+            num_layers, num_blocks)
+
+        self.runner.initialize_kv_cache(kv_cache_config)
+
+        manager = self.runner.kv_cache_manager
+        assert len(self.runner.kv_caches) == num_layers
+        for cache in self.runner.kv_caches:
+            assert cache.ndim == 5
+        assert manager.attn_flat_indices == ()
+        assert manager.num_total_caches == 0
+
+    def test_initialize_kv_cache_mamba_keeps_per_layer_metadata(self):
+        """Mamba layers force the per-layer path even for an allowlisted
+        arch."""
+        num_blocks = 100
+        page_size_bytes = 16 * 1024
+        layer_names = ['layer.0', 'layer.1']
+        kv_cache_config = self._create_mamba_kv_cache_config(
+            num_blocks, page_size_bytes, layer_names)
+
+        if not hasattr(self.runner.vllm_config, 'sharding_config'
+                       ) or self.runner.vllm_config.sharding_config is None:
+            self.runner.vllm_config.sharding_config = MagicMock()
+            self.runner.vllm_config.sharding_config.total_dp_size = 1
+
+        with patch('dataclasses.replace') as mock_replace:
+            mock_replaced_spec = MagicMock()
+            mock_replaced_spec.page_size_bytes = page_size_bytes
+            mock_replace.return_value = mock_replaced_spec
+            self.runner.initialize_kv_cache(kv_cache_config)
+
+        assert len(self.runner.kv_caches) == 2
+        manager = self.runner.kv_cache_manager
+        assert manager.attn_flat_indices == ()
+        assert manager.num_total_caches == 0
+
+    @pytest.mark.parametrize("mismatch",
+                             ["dtype", "head_size", "num_kv_heads"])
+    def test_initialize_kv_cache_unified_heterogeneous_asserts(self, mismatch):
+        """Per-layer spec divergence must fail the homogeneity check."""
+        block_size = self.runner.vllm_config.cache_config.block_size
+        num_blocks = 32
+        base = dict(
+            block_size=block_size,
+            num_kv_heads=8,
+            head_size=128,
+            dtype=torch.bfloat16,
+        )
+        other = dict(base)
+        if mismatch == "dtype":
+            other["dtype"] = torch.float32
+        elif mismatch == "head_size":
+            other["head_size"] = 64
+        else:
+            other["num_kv_heads"] = 16
+
+        spec_a = FullAttentionSpec(**base)
+        spec_b = FullAttentionSpec(**other)
+        kv_cache_groups = [
+            KVCacheGroupSpec(layer_names=['layer.0'], kv_cache_spec=spec_a),
+            KVCacheGroupSpec(layer_names=['layer.1'], kv_cache_spec=spec_b),
+        ]
+        kv_cache_tensors = [
+            KVCacheTensor(size=num_blocks * spec_a.page_size_bytes,
+                          shared_by=['layer.0']),
+            KVCacheTensor(size=num_blocks * spec_b.page_size_bytes,
+                          shared_by=['layer.1']),
+        ]
+        kv_cache_config = KVCacheConfig(
+            num_blocks=num_blocks,
+            kv_cache_tensors=kv_cache_tensors,
+            kv_cache_groups=kv_cache_groups,
+        )
+
+        with pytest.raises(AssertionError):
+            self.runner.initialize_kv_cache(kv_cache_config)
+
+    def test_unpack_kv_caches(self):
+        """Per-layer views are dim1 slices; empty metadata is a no-op."""
+        from tpu_inference.runner.kv_cache_manager import _unpack_kv_caches
+
+        num_blocks, num_layers = 4, 3
+        pool = jnp.arange(num_blocks * num_layers * 2 * 2 * 2 * 2,
+                          dtype=jnp.float32).reshape(num_blocks, num_layers, 2,
+                                                     2, 2, 2)
+
+        unpacked = _unpack_kv_caches([pool], tuple(range(num_layers)),
+                                     num_layers)
+        assert len(unpacked) == num_layers
+        for i in range(num_layers):
+            np.testing.assert_array_equal(np.asarray(unpacked[i]),
+                                          np.asarray(pool[:, i]))
+
+        # No unified metadata -> no-op (same list object, untouched).
+        per_layer_caches = [jnp.zeros((2, 2)), jnp.ones((2, 2))]
+        assert _unpack_kv_caches(per_layer_caches, (), 0) is per_layer_caches
+
+    def test_jitted_insert_continuous_unified_matches_per_layer(self):
+        """The unified insert branch must match the per-layer branch's
+        result for every layer."""
+        from tpu_inference.runner.kv_cache_manager import KVCacheManager
+
+        block_size, num_blocks, num_layers = 4, 8, 3
+        tail = (4, 2, 8)  # (num_kv_heads*2 // packing, packing, head_dim)
+        chunk_size, start_block, token_start = 2, 3, 0
+
+        rng = np.random.default_rng(0)
+        per_layer_np = [
+            rng.standard_normal((num_blocks, block_size) + tail).astype(
+                np.float32) for _ in range(num_layers)
+        ]
+        slices_np = [
+            rng.standard_normal((chunk_size * block_size, ) + tail).astype(
+                np.float32) for _ in range(num_layers)
+        ]
+
+        # Legacy per-layer path (kv_caches donated -> rebuild fresh inputs).
+        legacy_out = KVCacheManager._jitted_insert_continuous_kv_cache_from_slice(
+            block_size,
+            chunk_size,
+            [jnp.asarray(a) for a in per_layer_np],
+            [jnp.asarray(s) for s in slices_np],
+            token_start,
+            start_block,
+            (),
+        )
+
+        # Unified path on the equivalent 6D block-major pool.
+        pool = jnp.stack([jnp.asarray(a) for a in per_layer_np], axis=1)
+        unified_out = KVCacheManager._jitted_insert_continuous_kv_cache_from_slice(
+            block_size,
+            chunk_size,
+            [pool],
+            [jnp.asarray(s) for s in slices_np],
+            token_start,
+            start_block,
+            tuple(range(num_layers)),
+        )
+
+        assert len(legacy_out) == num_layers
+        assert len(unified_out) == 1
+        assert unified_out[0].ndim == 6
+        for i in range(num_layers):
+            np.testing.assert_array_equal(np.asarray(unified_out[0][:, i]),
+                                          np.asarray(legacy_out[i]))
+
+    def test_get_kv_cache_for_block_ids_unified(self):
+        """Extraction must unpack the pool into per-layer slices, for both
+        continuous and scattered block ids."""
+        block_size = 4
+        num_blocks, num_layers = 8, 3
+        tail = (4, 2, 8)
+        self.runner.block_size = block_size
+
+        rng = np.random.default_rng(1)
+        pool_np = rng.standard_normal((num_blocks, num_layers, block_size) +
+                                      tail).astype(np.float32)
+        self.runner.kv_caches = [jnp.asarray(pool_np)]
+        manager = self.runner.kv_cache_manager
+        manager.attn_flat_indices = tuple(range(num_layers))
+        manager.num_total_caches = num_layers
+
+        # Continuous block ids.
+        got = self.runner.get_kv_cache_for_block_ids([2, 3])
+        assert len(got) == num_layers
+        for i in range(num_layers):
+            expected = pool_np[2:4, i].reshape((2 * block_size, ) + tail)
+            np.testing.assert_array_equal(np.asarray(got[i]), expected)
+
+        # Scattered block ids.
+        got = self.runner.get_kv_cache_for_block_ids([5, 2])
+        for i in range(num_layers):
+            expected = pool_np[[5, 2], i].reshape((2 * block_size, ) + tail)
+            np.testing.assert_array_equal(np.asarray(got[i]), expected)
+
+    def test_insert_request_with_kv_cache_unified_round_trip(self):
+        """Prefill->decode hand-off: extract a block from a source pool,
+        insert into a zeroed pool, data lands at pool[dest_block, layer]."""
+        block_size = 64
+        num_layers = 2
+        num_kv_heads = 16
+        head_size = 128
+        num_blocks = 20
+        prompt_len = 64  # exactly one block, no padding ambiguity
+
+        self.runner.block_size = block_size
+        self.runner.vllm_config.cache_config.num_gpu_blocks = num_blocks
+
+        pool_shape = (num_blocks, num_layers, block_size,
+                      2 * num_kv_heads // 2, 2, head_size)
+        prod_val = int(np.prod(pool_shape))
+        source_pool = jnp.arange(prod_val,
+                                 dtype=jnp.bfloat16).reshape(pool_shape)
+        self.runner.kv_caches = [source_pool]
+        manager = self.runner.kv_cache_manager
+        manager.attn_flat_indices = tuple(range(num_layers))
+        manager.num_total_caches = num_layers
+
+        src_block = 5
+        extracted = self.runner.get_kv_cache_for_block_ids([src_block])
+        assert len(extracted) == num_layers
+        extracted = [layer_cache[:prompt_len] for layer_cache in extracted]
+
+        # Fresh destination runner state with a zeroed unified pool.
+        self.runner.requests = {}
+        self.runner.kv_caches = [jnp.zeros(pool_shape, dtype=jnp.bfloat16)]
+
+        decode_request = self._make_decode_request_mock(
+            prompt_len, request_id="unified_req")
+
+        dest_block = 10
+        self.runner.insert_request_with_kv_cache(decode_request, extracted,
+                                                 [[dest_block]])
+
+        assert len(self.runner.kv_caches) == 1
+        new_pool = self.runner.kv_caches[0]
+        assert new_pool.shape == pool_shape
+        source_pool_np = np.asarray(source_pool)
+        new_pool_np = np.asarray(new_pool)
+        for layer in range(num_layers):
+            np.testing.assert_array_equal(
+                new_pool_np[dest_block, layer],
+                source_pool_np[src_block, layer],
+            )
+        # Every other block stays zero.
+        untouched = np.delete(new_pool_np, dest_block, axis=0)
+        assert not untouched.any()
+
+    @staticmethod
+    def _make_decode_request_mock(prompt_len, request_id="noncontig_req"):
+        mock_sampling_params = MagicMock()
+        mock_sampling_params.sampling_type = SamplingType.GREEDY
+        mock_sampling_params.temperature = 0.0
+        mock_sampling_params.top_p = 1.0
+        mock_sampling_params.top_k = -1
+        mock_sampling_params.min_tokens = 0
+        mock_sampling_params.logprobs = None
+        mock_sampling_params.logit_bias = None
+        mock_sampling_params.allowed_token_ids = set()
+        mock_sampling_params.bad_words_token_ids = None
+        mock_sampling_params.all_stop_token_ids = set()
+
+        decode_request = MagicMock(spec=Request)
+        decode_request.request_id = request_id
+        decode_request.num_tokens = prompt_len + 1
+        decode_request.num_computed_tokens = prompt_len
+        decode_request.prompt_token_ids = list(range(prompt_len))
+        decode_request.all_token_ids = [123, 232, 908]
+        decode_request.output_token_ids = [100]
+        decode_request.sampling_params = mock_sampling_params
+        decode_request.lora_request = None
+        decode_request.mm_kwargs, decode_request.mm_positions = [], []
+        decode_request.pooling_params, decode_request.generator = None, None
+        return decode_request
+
+    def _run_insert_non_contiguous(self, unified):
+        """Non-contiguous dest block ids go through _jitted_insert_kv_cache
+        (contiguous-run splitting); chunk k must land at dest_blocks[k]."""
+        block_size = 64
+        num_layers = 2
+        num_kv_heads = 16
+        head_size = 128
+        num_blocks = 20
+        src_blocks = [4, 5, 6]
+        # Two contiguous runs: [2, 3] and [7].
+        dest_blocks = [2, 3, 7]
+        prompt_len = len(src_blocks) * block_size  # exact blocks, no padding
+
+        self.runner.block_size = block_size
+        self.runner.vllm_config.cache_config.num_gpu_blocks = num_blocks
+
+        pool_shape = (num_blocks, num_layers, block_size,
+                      2 * num_kv_heads // 2, 2, head_size)
+        prod_val = int(np.prod(pool_shape))
+        source_pool = jnp.arange(prod_val,
+                                 dtype=jnp.bfloat16).reshape(pool_shape)
+        manager = self.runner.kv_cache_manager
+        if unified:
+            self.runner.kv_caches = [source_pool]
+            manager.attn_flat_indices = tuple(range(num_layers))
+            manager.num_total_caches = num_layers
+        else:
+            self.runner.kv_caches = [
+                jnp.asarray(source_pool[:, i]) for i in range(num_layers)
+            ]
+            manager.attn_flat_indices = ()
+            manager.num_total_caches = 0
+
+        extracted = self.runner.get_kv_cache_for_block_ids(src_blocks)
+        assert len(extracted) == num_layers
+        assert extracted[0].shape[0] == prompt_len
+
+        # Fresh destination runner state with zeroed caches.
+        self.runner.requests = {}
+        if unified:
+            self.runner.kv_caches = [jnp.zeros(pool_shape, dtype=jnp.bfloat16)]
+        else:
+            self.runner.kv_caches = [
+                jnp.zeros((num_blocks, ) + pool_shape[2:], dtype=jnp.bfloat16)
+                for _ in range(num_layers)
+            ]
+
+        decode_request = self._make_decode_request_mock(prompt_len)
+        self.runner.insert_request_with_kv_cache(decode_request, extracted,
+                                                 [dest_blocks])
+
+        source_pool_np = np.asarray(source_pool)
+        if unified:
+            assert len(self.runner.kv_caches) == 1
+            new_np = np.asarray(self.runner.kv_caches[0])
+
+            def per_layer_view(blk, layer):
+                return new_np[blk, layer]
+        else:
+            assert len(self.runner.kv_caches) == num_layers
+            new_np = [np.asarray(c) for c in self.runner.kv_caches]
+
+            def per_layer_view(blk, layer):
+                return new_np[layer][blk]
+
+        for k, dest_block in enumerate(dest_blocks):
+            for layer in range(num_layers):
+                np.testing.assert_array_equal(
+                    per_layer_view(dest_block, layer),
+                    source_pool_np[src_blocks[k], layer],
+                    err_msg=(f"chunk {k}: dest block {dest_block} layer "
+                             f"{layer} does not match source block "
+                             f"{src_blocks[k]}"),
+                )
+        untouched_blocks = [
+            b for b in range(num_blocks) if b not in dest_blocks
+        ]
+        for b in untouched_blocks:
+            for layer in range(num_layers):
+                assert not per_layer_view(b, layer).any(), (
+                    f"untouched block {b} layer {layer} was written")
+
+    def test_insert_request_with_kv_cache_unified_non_contiguous_blocks(self):
+        """Regression: this path once dropped the unified metadata and
+        crashed on a pytree arity mismatch against the single 6D pool."""
+        self._run_insert_non_contiguous(unified=True)
+
+    def test_insert_request_with_kv_cache_per_layer_non_contiguous_blocks(
+            self):
+        self._run_insert_non_contiguous(unified=False)

--- a/tpu_inference/distributed/kv_transfer.py
+++ b/tpu_inference/distributed/kv_transfer.py
@@ -289,6 +289,13 @@ def _async_copy_jit(
     if was_padded:
         dest_out_list = [x[..., :orig_shape[-1]] for x in dest_out_list]
 
+    if len(dest_out_list) == 1:
+        # With a single cache (the unified block-major pool), the donated dest
+        # would flow from the DMA kernels straight to the jit output with a
+        # mismatched memory space, failing XLA's aliasing verifier. The
+        # barrier keeps the donation in place (same buffer, no copy).
+        dest_out_list = [jax.lax.optimization_barrier(dest_out_list[0])]
+
     return dest_out_list
 
 

--- a/tpu_inference/layers/common/attention_interface.py
+++ b/tpu_inference/layers/common/attention_interface.py
@@ -403,8 +403,17 @@ def sharded_ragged_paged_attention(
             v = jnp.repeat(v, factor, axis=1)
 
     qkv_spec = P(ShardingAxisName.ATTN_DATA, ShardingAxisName.ATTN_HEAD, None)
-    kv_cache_spec = P(ShardingAxisName.ATTN_DATA, None,
-                      ShardingAxisName.ATTN_HEAD, None, None)
+    # The unified pool arrives as a 6D block-major array; per-layer caches
+    # stay 5D. The fold to the kernel's 5D layout must happen inside the
+    # shard_map body, where it is a per-device bitcast; folding it in
+    # GSPMD-traced code results in an extra all-to-all causing OOM.
+    unified_6d = kv_cache.ndim == 6
+    if unified_6d:
+        kv_cache_spec = P(ShardingAxisName.ATTN_DATA, None, None,
+                          ShardingAxisName.ATTN_HEAD, None, None)
+    else:
+        kv_cache_spec = P(ShardingAxisName.ATTN_DATA, None,
+                          ShardingAxisName.ATTN_HEAD, None, None)
     in_specs = (
         qkv_spec,  # q
         qkv_spec,  # k
@@ -452,6 +461,14 @@ def sharded_ragged_paged_attention(
         if not use_hd64:
             kwargs["update_kv_cache"] = update_kv_cache
             kwargs["use_causal_mask"] = use_causal_mask
+        if unified_6d:
+            # Per-device fold (NB, NL, ...) -> (NB*NL, ...), unfold on the way
+            # out: bitcasts. Block b's layer-L page is flat page
+            # b*num_layers + L, matching page_indices from attention().
+            q, k, v, kv6, *rest = args
+            kv5 = kv6.reshape((kv6.shape[0] * kv6.shape[1], ) + kv6.shape[2:])
+            out, kv5_new = func(q, k, v, kv5, *rest, **kwargs)
+            return out, kv5_new.reshape(kv6.shape)
         return func(*args, **kwargs)
 
     return jax.shard_map(
@@ -479,6 +496,9 @@ def attention(
     sinks: jax.Array | None = None,
     update_kv_cache: bool = True,
     use_causal_mask: bool = True,
+    # Unified-cache path: this layer's slot and the total layer count.
+    layer_idx: int | None = None,
+    num_layers: int | None = None,
 ) -> Tuple[jax.Array, jax.Array]:
     # T: seq_len
     # N: num_heads
@@ -500,15 +520,26 @@ def attention(
 
     md = attention_metadata
 
+    if layer_idx is not None:
+        # kv_cache is the unified 6D block-major cache: redirect page
+        # addressing to this layer (block b, layer L -> flat page
+        # b*num_layers + L); the 6D->5D fold happens inside
+        # sharded_ragged_paged_attention's shard_map.
+        assert num_layers is not None, (
+            "num_layers is required for the unified KV cache path")
+        page_indices = md.block_tables * num_layers + layer_idx
+    else:
+        page_indices = md.block_tables
+
     # (T, N, H)
-    output, kv_cache = sharded_ragged_paged_attention(
+    output, new_kv_cache = sharded_ragged_paged_attention(
         mesh,
         q,
         k,
         v,
         kv_cache,
         md.seq_lens,
-        md.block_tables,
+        page_indices,
         md.query_start_loc,
         md.request_distribution,
         sinks,
@@ -521,7 +552,7 @@ def attention(
         use_causal_mask=use_causal_mask,
     )
 
-    return kv_cache, output
+    return new_kv_cache, output
 
 
 def mla_attention(

--- a/tpu_inference/layers/vllm/backends/flash_attn.py
+++ b/tpu_inference/layers/vllm/backends/flash_attn.py
@@ -245,7 +245,21 @@ class PallasAttentionBackendImpl(AttentionImpl):
 
                 kv_cache_index = vllm_model_wrapper_context.layer_name_to_kvcache_index[
                     layer.layer_name]
-                kv_cache = vllm_model_wrapper_context.kv_caches[kv_cache_index]
+
+                # Unified pool: all attention layers share kv_caches[0];
+                # hybrid (attention+Mamba) models keep the per-layer path.
+                attn_flat_indices = vllm_model_wrapper_context.attn_flat_indices
+                is_unified = kv_cache_index in attn_flat_indices
+
+                if is_unified:
+                    kv_cache = vllm_model_wrapper_context.kv_caches[0]
+                    layer_idx = attn_flat_indices.index(kv_cache_index)
+                    num_layers = len(attn_flat_indices)
+                else:
+                    kv_cache = vllm_model_wrapper_context.kv_caches[
+                        kv_cache_index]
+                    layer_idx = None
+                    num_layers = None
 
                 q_scale = k_scale = v_scale = None
                 if self.kv_cache_quantized_dtype:
@@ -275,9 +289,14 @@ class PallasAttentionBackendImpl(AttentionImpl):
                     k_scale,
                     v_scale,
                     self.sliding_window,
+                    layer_idx=layer_idx,
+                    num_layers=num_layers,
                 )
-                vllm_model_wrapper_context.kv_caches[
-                    kv_cache_index] = new_kv_cache
+                if is_unified:
+                    vllm_model_wrapper_context.kv_caches[0] = new_kv_cache
+                else:
+                    vllm_model_wrapper_context.kv_caches[
+                        kv_cache_index] = new_kv_cache
             case _:
                 raise NotImplementedError(
                     f"Unsupported attention type: {self.attn_type}")
@@ -330,6 +349,8 @@ def _format_attention_output(
         "k_scale",
         "v_scale",
         "sliding_window",
+        "layer_idx",
+        "num_layers",
     ),
     donate_argnames=("kv_cache"),
 )
@@ -349,6 +370,8 @@ def _jax_attn_func(
     k_scale: float | None = None,
     v_scale: float | None = None,
     sliding_window: int | None = None,
+    layer_idx: int | None = None,
+    num_layers: int | None = None,
 ) -> Tuple[jax.Array, jax.Array]:
     q_len = q.shape[0]
     q, k, v = _prepare_qkv_layout(q, k, v, num_heads, num_kv_heads, head_size)
@@ -366,6 +389,8 @@ def _jax_attn_func(
         v_scale=v_scale,
         sinks=sinks,
         attention_chunk_size=sliding_window,
+        layer_idx=layer_idx,
+        num_layers=num_layers,
     )
 
     formatted_outputs = _format_attention_output(outputs, q_len, num_heads,

--- a/tpu_inference/models/common/model_loader.py
+++ b/tpu_inference/models/common/model_loader.py
@@ -43,6 +43,7 @@ from tpu_inference.models.jax.utils.qwix.qwix_utils import (
     update_vllm_config_for_qwix_quantization)
 from tpu_inference.models.jax.utils.weight_utils import (BaseWeightLoader,
                                                          LoadableWithIterator)
+from tpu_inference.runner.kv_cache import model_uses_unified_kv_cache
 from tpu_inference.runner.mm_encoder_jit_manager import \
     maybe_create_mm_encoder_jit_manager
 from tpu_inference.utils import to_jax_dtype, to_torch_dtype
@@ -352,10 +353,22 @@ def get_flax_model(
                                pooler=pooler,
                                is_draft_model=is_draft_model)
     vllm_config.model_config.dtype = original_dtype
-    kv_cache_sharding = NamedSharding(
-        mesh,
-        PartitionSpec(ShardingAxisName.ATTN_DATA, None,
-                      ShardingAxisName.ATTN_HEAD))
+    # The kv cache out_shardings must be pinned: each step feeds the previous
+    # step's cache outputs back in, and with out_shardings=None the inferred
+    # sharding is not stable across compiled entries, causing a serve-time
+    # recompile. The spec is rank-sensitive (right-pads with None), so the
+    # rank-6 unified pool needs its own pin with ATTN_HEAD on dim3 (kv
+    # heads); a mismatched pin results in an extra all-to-all causing OOM.
+    if model_uses_unified_kv_cache(vllm_config):
+        kv_cache_sharding = NamedSharding(
+            mesh,
+            PartitionSpec(ShardingAxisName.ATTN_DATA, None, None,
+                          ShardingAxisName.ATTN_HEAD))
+    else:
+        kv_cache_sharding = NamedSharding(
+            mesh,
+            PartitionSpec(ShardingAxisName.ATTN_DATA, None,
+                          ShardingAxisName.ATTN_HEAD))
     hidden_states_sharding = NamedSharding(mesh,
                                            PartitionSpec(
                                                ShardingAxisName.ATTN_DATA,

--- a/tpu_inference/models/jax/qwen2.py
+++ b/tpu_inference/models/jax/qwen2.py
@@ -187,6 +187,8 @@ class Qwen2Attention(JaxModule):
         kv_cache: Optional[jax.Array],
         x: jax.Array,
         attention_metadata: AttentionMetadata,
+        layer_idx: Optional[int] = None,
+        num_layers: Optional[int] = None,
     ) -> Tuple[jax.Array, jax.Array]:
         md = attention_metadata
         # q: (T, N, H)
@@ -221,6 +223,8 @@ class Qwen2Attention(JaxModule):
             q_scale=q_scale,
             k_scale=k_scale,
             v_scale=v_scale,
+            layer_idx=layer_idx,
+            num_layers=num_layers,
         )
         # (T, D)
         o = self.o_proj(outputs)
@@ -278,12 +282,16 @@ class Qwen2DecoderLayer(JaxModule):
         kv_cache: jax.Array,
         x: jax.Array,
         attention_metadata: AttentionMetadata,
+        layer_idx: Optional[int] = None,
+        num_layers: Optional[int] = None,
     ) -> Tuple[jax.Array, jax.Array]:
         hidden_states = self.input_layernorm(x)
         kv_cache, attn_output = self.self_attn(
             kv_cache,
             hidden_states,
             attention_metadata,
+            layer_idx=layer_idx,
+            num_layers=num_layers,
         )
         attn_output += x
 
@@ -365,17 +373,37 @@ class Qwen2Model(JaxModule):
         else:
             x = self.embed_tokens(input_ids)
 
-        for i, layer in enumerate(
-                islice(self.layers, self.start_layer, self.end_layer)):
-            kv_cache = kv_caches[i]
-            kv_cache, x = layer(
-                kv_cache,
-                x,
-                attention_metadata,
-            )
-            kv_caches[i] = kv_cache
+        # Check if we are using unified KV cache
+        is_unified = len(kv_caches) == 1 and (self.end_layer -
+                                              self.start_layer) > 1
+
+        if is_unified:
+            large_kv_cache = kv_caches[0]
+            num_layers = self.end_layer - self.start_layer
+            for i, layer in enumerate(
+                    islice(self.layers, self.start_layer, self.end_layer)):
+                large_kv_cache, x = layer(
+                    large_kv_cache,
+                    x,
+                    attention_metadata,
+                    layer_idx=i,
+                    num_layers=num_layers,
+                )
+            new_kv_caches = [large_kv_cache]
+        else:
+            for i, layer in enumerate(
+                    islice(self.layers, self.start_layer, self.end_layer)):
+                kv_cache = kv_caches[i]
+                kv_cache, x = layer(
+                    kv_cache,
+                    x,
+                    attention_metadata,
+                )
+                kv_caches[i] = kv_cache
+            new_kv_caches = kv_caches
+
         x = self.norm(x)
-        return kv_caches, x
+        return new_kv_caches, x
 
 
 class Qwen2ForCausalLM(JaxModule, LoadableWithIterator):

--- a/tpu_inference/models/jax/qwen3.py
+++ b/tpu_inference/models/jax/qwen3.py
@@ -166,6 +166,8 @@ class Qwen3Attention(JaxModule):
         kv_cache: Optional[jax.Array],
         x: jax.Array,
         attention_metadata: AttentionMetadata,
+        layer_idx: Optional[int] = None,
+        num_layers: Optional[int] = None,
     ) -> Tuple[jax.Array, jax.Array]:
         md = attention_metadata
         # q: (T, N, H)
@@ -203,6 +205,8 @@ class Qwen3Attention(JaxModule):
             q_scale=q_scale,
             k_scale=k_scale,
             v_scale=v_scale,
+            layer_idx=layer_idx,
+            num_layers=num_layers,
         )
         # (T, D)
         o = self.o_proj(outputs)
@@ -353,20 +357,41 @@ class Qwen3Model(Qwen2Model):
         else:
             x = self.embed_tokens(input_ids)
 
+        # Check if we are using unified KV cache
+        is_unified = len(kv_caches) == 1 and (self.end_layer -
+                                              self.start_layer) > 1
+
         aux_hidden_states = []
-        for i, layer in enumerate(
-                islice(self.layers, self.start_layer, self.end_layer)):
-            kv_cache = kv_caches[i]
-            kv_cache, x = layer(
-                kv_cache,
-                x,
-                attention_metadata,
-            )
-            kv_caches[i] = kv_cache
-            if i in self.aux_hidden_state_layers:
-                aux_hidden_states.append(x)
+        if is_unified:
+            large_kv_cache = kv_caches[0]
+            num_layers = self.end_layer - self.start_layer
+            for i, layer in enumerate(
+                    islice(self.layers, self.start_layer, self.end_layer)):
+                large_kv_cache, x = layer(
+                    large_kv_cache,
+                    x,
+                    attention_metadata,
+                    layer_idx=i,
+                    num_layers=num_layers,
+                )
+                if i in self.aux_hidden_state_layers:
+                    aux_hidden_states.append(x)
+            new_kv_caches = [large_kv_cache]
+        else:
+            for i, layer in enumerate(
+                    islice(self.layers, self.start_layer, self.end_layer)):
+                kv_cache = kv_caches[i]
+                kv_cache, x = layer(
+                    kv_cache,
+                    x,
+                    attention_metadata,
+                )
+                kv_caches[i] = kv_cache
+                if i in self.aux_hidden_state_layers:
+                    aux_hidden_states.append(x)
+            new_kv_caches = kv_caches
         x = self.norm(x)
-        return kv_caches, x, aux_hidden_states
+        return new_kv_caches, x, aux_hidden_states
 
 
 class Qwen3ForCausalLM(JaxModule, LoadableWithIterator):

--- a/tpu_inference/models/vllm/vllm_model_wrapper.py
+++ b/tpu_inference/models/vllm/vllm_model_wrapper.py
@@ -117,6 +117,7 @@ class VllmModelWrapper:
         self.mesh = mesh
         self.is_draft_model = is_draft_model
         self._mm_encoder_jit_manager: MMEncoderJITManager | None = None
+        self.attn_flat_indices: Tuple[int, ...] = ()
 
         self.vllm_config.quant_config = get_tpu_quantization_config(
             self.vllm_config, self.mesh)
@@ -136,6 +137,12 @@ class VllmModelWrapper:
             if module_name.startswith("vllm.model_executor.models"):
                 if hasattr(module, "get_pp_group"):
                     setattr(module, "get_pp_group", jax_get_pp_group)
+
+    def set_kv_cache_metadata(
+        self,
+        attn_flat_indices: Tuple[int, ...],
+    ):
+        self.attn_flat_indices = attn_flat_indices
 
     def load_weights(self,
                      shared_params: Optional[dict[str, jax.Array]] = None):
@@ -338,10 +345,11 @@ class VllmModelWrapper:
                     kv_caches=kv_caches,
                     mesh=self.mesh,
                     layer_name_to_kvcache_index=layer_name_to_kvcache_index,
-                    vllm_config=self.vllm_config), set_forward_context(
-                        attn_metadata=attn_metadata,
-                        vllm_config=self.vllm_config,
-                        num_tokens=num_tokens):
+                    vllm_config=self.vllm_config,
+                    attn_flat_indices=self.attn_flat_indices
+            ), set_forward_context(attn_metadata=attn_metadata,
+                                   vllm_config=self.vllm_config,
+                                   num_tokens=num_tokens):
                 # We need to wrap args from jax land into TorchValue with
                 # torch_view in order to call the Torch function.
                 original_lora_metadata = replace_lora_metadata(
@@ -402,7 +410,8 @@ class VllmModelWrapper:
             with torchax.default_env(), set_vllm_model_wrapper_context(
                     kv_caches=kv_caches,
                     mesh=self.mesh,
-                    layer_name_to_kvcache_index=layer_name_to_kvcache_index
+                    layer_name_to_kvcache_index=layer_name_to_kvcache_index,
+                    attn_flat_indices=self.attn_flat_indices
             ), set_forward_context(attn_metadata=attn_metadata,
                                    vllm_config=self.vllm_config,
                                    num_tokens=num_tokens):

--- a/tpu_inference/models/vllm/vllm_model_wrapper_context.py
+++ b/tpu_inference/models/vllm/vllm_model_wrapper_context.py
@@ -14,7 +14,7 @@
 
 from contextlib import contextmanager
 from dataclasses import dataclass, field
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Tuple
 
 import jax
 from jax.sharding import Mesh
@@ -28,6 +28,8 @@ class VllmModelWrapperContext:
     layer_name_to_kvcache_index: Dict[str, int]
     vllm_config: Optional[VllmConfig] = None
     expert_indices_list: List[jax.Array] = field(default_factory=list)
+    # Empty tuple means "no unified KV cache" (per-layer semantics).
+    attn_flat_indices: Tuple[int, ...] = ()
 
 
 _vllm_model_wrapper_context: Optional[VllmModelWrapperContext] = None
@@ -43,11 +45,12 @@ def get_vllm_model_wrapper_context() -> VllmModelWrapperContext:
 
 @contextmanager
 def set_vllm_model_wrapper_context(
-    *,
-    kv_caches: List[jax.Array],
-    mesh: Mesh,
-    layer_name_to_kvcache_index: Dict[str, int] = None,
-    vllm_config: Optional[VllmConfig] = None,
+        *,
+        kv_caches: List[jax.Array],
+        mesh: Mesh,
+        layer_name_to_kvcache_index: Dict[str, int] = None,
+        vllm_config: Optional[VllmConfig] = None,
+        attn_flat_indices: Tuple[int, ...] = (),
 ):
     global _vllm_model_wrapper_context
     prev_context = _vllm_model_wrapper_context
@@ -56,6 +59,7 @@ def set_vllm_model_wrapper_context(
         mesh=mesh,
         layer_name_to_kvcache_index=layer_name_to_kvcache_index,
         vllm_config=vllm_config,
+        attn_flat_indices=attn_flat_indices,
     )
 
     try:

--- a/tpu_inference/runner/compilation_manager.py
+++ b/tpu_inference/runner/compilation_manager.py
@@ -936,6 +936,7 @@ class CompilationManager:
                 kv_cache_slices,
                 0,
                 block_numbers[0],
+                self.runner.kv_cache_manager.attn_flat_indices,
             )
             for layer_cache in self.runner.kv_caches:
                 layer_cache.block_until_ready()

--- a/tpu_inference/runner/kv_cache.py
+++ b/tpu_inference/runner/kv_cache.py
@@ -33,6 +33,29 @@ logger = init_logger(__name__)
 
 DEFAULT_KV_CACHE_DTYPE = jnp.bfloat16
 
+# Architectures whose forward pass can consume the unified block-major KV
+# cache (detect the single-element `kv_caches` list and thread `layer_idx`
+# into `attention()`). All other architectures index `kv_caches` per layer
+# and must keep the per-layer allocation path.
+UNIFIED_KV_CACHE_SUPPORTED_ARCHS = (
+    "Qwen2ForCausalLM",
+    "Qwen3ForCausalLM",
+)
+
+
+def model_uses_unified_kv_cache(vllm_config) -> bool:
+    """Whether this config takes the unified block-major KV cache path.
+
+    Shared by the allocation gate (kv_cache_manager) and the model_loader's
+    kv cache out_shardings pin so the pin always matches the allocated
+    layout. Speculative decoding keeps the per-layer path (draft model
+    forwards index `kv_caches` per layer).
+    """
+    if vllm_config.speculative_config is not None:
+        return False
+    return any(arch in UNIFIED_KV_CACHE_SUPPORTED_ARCHS
+               for arch in vllm_config.model_config.architectures)
+
 
 @dataclass
 class KVCacheMetadata:
@@ -157,6 +180,55 @@ def create_kv_caches(
     for _ in layer_names:
         kv_caches.append(sharded_allocate())
     return kv_caches
+
+
+def create_unified_kv_cache(
+    num_blocks: int,
+    block_size: int,
+    num_kv_heads: int,
+    head_size: int,
+    mesh: Mesh,
+    num_layers: int,
+    cache_dtype: jnp.dtype = DEFAULT_KV_CACHE_DTYPE,
+) -> jax.Array:
+    """Creates a single unified KV cache array shared by all layers.
+
+    The array is block-major (num_blocks outermost, num_layers second), so a
+    block's all-layer data is contiguous and transfers with a single DMA:
+    dim0-slice b == one whole logical block.
+
+    The RPA kernel still consumes a 5D (num_pages, ...) cache; the fold of
+    (num_blocks, num_layers) into the flat page dim happens per-device inside
+    sharded_ragged_paged_attention's shard_map, where it is a bitcast. Do NOT
+    reshape this array in GSPMD-traced code: that results in an extra
+    all-to-all causing OOM.
+
+    Shape: (num_blocks, num_layers, block_size,
+    cdiv(num_kv_heads * 2, packing), packing, head_dim),
+    where packing = 32 // dtype bits.
+    """
+    single_layer_shape = get_kv_cache_shape_with_mesh(mesh, num_blocks,
+                                                      block_size, num_kv_heads,
+                                                      head_size, cache_dtype)
+    unified_shape = (single_layer_shape[0], num_layers,
+                     *single_layer_shape[1:])
+
+    # PartitionSpec right-pads with None, so spell out enough dims to land
+    # ATTN_HEAD on dim3 (kv heads).
+    sharding = NamedSharding(
+        mesh,
+        PartitionSpec(ShardingAxisName.ATTN_DATA, None, None,
+                      ShardingAxisName.ATTN_HEAD, None, None),
+    )
+
+    def _allocate() -> jax.Array:
+        return jnp.empty(
+            shape=unified_shape,
+            dtype=cache_dtype,
+        )
+
+    sharded_allocate = jax.jit(_allocate, out_shardings=sharding)
+    return sharded_allocate()
 
 
 def get_attention_page_size_bytes(mesh, block_size, num_kv_heads, head_size,

--- a/tpu_inference/runner/kv_cache_manager.py
+++ b/tpu_inference/runner/kv_cache_manager.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 import dataclasses
 import os
-from typing import TYPE_CHECKING, List
+from typing import TYPE_CHECKING, List, Tuple
 
 import jax
 import jax.numpy as jnp
@@ -46,7 +46,9 @@ from tpu_inference.offload.utils import get_kv_connector_cache_layout
 from tpu_inference.runner import utils as runner_utils
 from tpu_inference.runner.input_batch import CachedRequestState, InputBatch
 from tpu_inference.runner.kv_cache import (KVCacheMetadata, create_kv_caches,
-                                           get_attention_page_size_bytes)
+                                           create_unified_kv_cache,
+                                           get_attention_page_size_bytes,
+                                           model_uses_unified_kv_cache)
 
 if TYPE_CHECKING:
     from vllm.v1.request import Request
@@ -71,6 +73,25 @@ def is_ds_v4(vllm_config):
     return "DeepseekV4ForCausalLM" in (vllm_config.model_config.architectures)
 
 
+def _unpack_kv_caches(kv_caches: List[jax.Array],
+                      attn_flat_indices: Tuple[int, ...],
+                      num_total_caches: int) -> List[jax.Array]:
+    """Rebuild a per-layer KV cache list from the unified block-major array.
+
+    Compatibility path for consumers that still expect a per-layer list
+    (notably the in-engine JAX KV transfer). The dim1 slices are views, not
+    copies. No-op when attn_flat_indices is empty (per-layer allocation).
+    """
+    if not attn_flat_indices:
+        return kv_caches
+
+    large_attn_cache = kv_caches[0]
+    unpacked = [None] * num_total_caches
+    for i, flat_idx in enumerate(attn_flat_indices):
+        unpacked[flat_idx] = large_attn_cache[:, i]
+    return unpacked
+
+
 class KVCacheManager:
 
     def __init__(self, runner: "TPUModelRunner"):
@@ -81,6 +102,11 @@ class KVCacheManager:
         # from the KV cache of `shared_kv_cache_layers[layer_name]`.
         self.shared_kv_cache_layers: dict[str, str] = {}
         self.use_mla = self.runner.model_config.use_mla
+        # Unified block-major pool metadata, populated by initialize_kv_cache
+        # when the unified path is taken; empty defaults mean per-layer
+        # semantics.
+        self.attn_flat_indices: Tuple[int, ...] = ()
+        self.num_total_caches: int = 0
         # Set by `update_mamba_page_size_padded` for hybrid attention+mamba
         # models. When set, every attention layer spec reports this as its
         # `page_size_padded` so vLLM sees a uniform page size across groups
@@ -775,6 +801,22 @@ class KVCacheManager:
                             ) == num_shared_layers, f"Expected all non-MTP kv_cache_tensors to have the same number of shared layers {num_shared_layers}, but found {len(kv_cache_tensor.shared_by)}"
                     break
 
+        # Classify tensors and calculate flat indices
+        attn_specs = []
+        attn_flat_indices = []
+        flat_idx = 0
+
+        # Allocate the unified block-major KV cache only when the shared gate
+        # passes (allowlisted arch, no spec decode; model_loader uses the same
+        # helper to pick the matching out_shardings pin) AND all layers are
+        # regular attention -- the unified pool holds one homogeneous
+        # attention group, so Mamba/hybrid layouts keep the per-layer path.
+        has_mamba_layers = any(
+            isinstance(spec, MambaSpec)
+            for spec in layer_name_to_spec.values())
+        use_unified = (model_uses_unified_kv_cache(self.runner.vllm_config)
+                       and not has_mamba_layers)
+
         for i, kv_cache_tensor in enumerate(kv_cache_config.kv_cache_tensors):
             if duplicate_shared_layers:
                 total_group_page_size = 0
@@ -843,6 +885,17 @@ class KVCacheManager:
                 self.actual_mamba_num_blocks = mamba_num_blocks
 
             for j, layer_name in enumerate(kv_cache_tensor.shared_by):
+                if use_unified:
+                    # Record one flat index per shared group; the single
+                    # block-major array is allocated after this loop. All
+                    # layers sharing tensor i map to cache slot i.
+                    if j == 0:
+                        attn_specs.append(
+                            (layer_name_to_spec[layer_name], num_blocks))
+                        attn_flat_indices.append(flat_idx)
+                        flat_idx += 1
+                    self.runner.layer_name_to_kvcache_index[layer_name] = i
+                    continue
                 layer_spec = layer_name_to_spec[layer_name]
                 if isinstance(layer_spec, MambaSpec):
                     mamba_states = []
@@ -966,6 +1019,60 @@ class KVCacheManager:
                 layer_idx = (i * num_shared_layers
                              ) + j if duplicate_shared_layers else i
                 self.runner.layer_name_to_kvcache_index[layer_name] = layer_idx
+
+        if use_unified:
+            self.attn_flat_indices = tuple(attn_flat_indices)
+            self.num_total_caches = flat_idx
+
+            kv_caches = []
+            num_blocks_list = []
+
+            # Allocate unified attention cache if we have any
+            if attn_specs:
+                first_spec, first_num_blocks = attn_specs[0]
+                # Verify all attention layers have the same spec
+                for spec, nblocks in attn_specs:
+                    assert spec.block_size == first_spec.block_size
+                    assert spec.num_kv_heads == first_spec.num_kv_heads
+                    assert spec.head_size == first_spec.head_size
+                    assert spec.dtype == first_spec.dtype
+                    assert nblocks == first_num_blocks
+
+                logger.info(
+                    f"Allocating unified KV cache for {len(attn_specs)} "
+                    f"attention layers. "
+                    f"Shape: ({first_num_blocks}, {len(attn_specs)}, ...)")
+
+                unified_cache = create_unified_kv_cache(
+                    num_blocks=first_num_blocks,
+                    block_size=first_spec.block_size,
+                    num_kv_heads=first_spec.num_kv_heads,
+                    head_size=first_spec.head_size,
+                    mesh=self.runner.mesh,
+                    num_layers=len(attn_specs),
+                    cache_dtype=t2j_dtype(first_spec.dtype),
+                )
+                kv_caches.append(unified_cache)
+                num_blocks_list.append(first_num_blocks)
+
+                # Update Regular Attention Metadata
+                metadata["regular_attn"].count = len(attn_specs)
+                metadata["regular_attn"].shape = unified_cache.shape
+                metadata["regular_attn"].dtype = unified_cache.dtype
+                metadata["regular_attn"].sharding = unified_cache.sharding
+
+            # TODO: hybrid (attention+Mamba) support -- allocate per-Mamba
+            # caches after the unified array (kv_caches[1:]) and restore
+            # their flat-index mapping. For now hybrid models take the
+            # per-layer path via the use_unified gate.
+
+            self.runner.kv_caches = kv_caches
+        else:
+            # Per-layer allocation already populated everything in the loop
+            # above; empty flat-index metadata keeps downstream on the
+            # per-layer path.
+            self.attn_flat_indices = ()
+            self.num_total_caches = 0
         if self.shared_kv_cache_layers:
             for layer_name, target_layer_name in self.shared_kv_cache_layers.items(
             ):
@@ -1105,6 +1212,10 @@ class KVCacheManager:
         kv_caches: List[jax.Array],
         kv_cache_slices: List[jax.Array],
         block_numbers: List[int],
+        # Required (no default): a caller that forgets to thread the unified
+        # metadata would silently take the per-layer branch and crash on the
+        # unified pool.
+        attn_flat_indices: Tuple[int, ...],
     ) -> List[jax.Array]:
         """
         Iteratively call continuous KV cache insertion for each contiguous block sub-array.
@@ -1130,6 +1241,7 @@ class KVCacheManager:
                         kv_cache_slices,
                         token_start,
                         start_block,
+                        attn_flat_indices,
                     )
                 start_idx = i
 
@@ -1137,7 +1249,7 @@ class KVCacheManager:
 
     @staticmethod
     @jax.jit(
-        static_argnames=("block_size", "chunk_size"),
+        static_argnames=("block_size", "chunk_size", "attn_flat_indices"),
         donate_argnames=("kv_caches", ),
     )
     def _jitted_insert_continuous_kv_cache_from_slice(
@@ -1147,16 +1259,36 @@ class KVCacheManager:
         kv_cache_slices: List[jax.Array],
         token_start: int,
         start_block: int,
+        # Required (no default): see _jitted_insert_kv_cache.
+        attn_flat_indices: Tuple[int, ...],
     ) -> List[jax.Array]:
         """
         JIT-compiled function that dynamically slices the required tokens from KV cache
         slices and inserts them into continuous physical blocks.
         """
+        if not attn_flat_indices:
 
-        def _update_layer(cache, slices):
-            """The function to apply to each layer's cache and slices."""
+            def _update_layer(cache, slices):
+                extracted_slices = jax.lax.dynamic_slice_in_dim(slices,
+                                                                token_start,
+                                                                chunk_size *
+                                                                block_size,
+                                                                axis=0)
+                reshaped_slices = extracted_slices.reshape(
+                    -1, block_size, *slices.shape[1:])
+                return jax.lax.dynamic_update_slice_in_dim(cache,
+                                                           reshaped_slices,
+                                                           start_block,
+                                                           axis=0)
 
-            # Dynamically slice exactly chunk_size * block_size tokens starting at token_start
+            return jax.tree.map(_update_layer, kv_caches, kv_cache_slices)
+
+        # 6D block-major pool (num_blocks, num_layers, ...): a whole layer is
+        # addressed directly with [:, i].
+        new_large_attn_cache = kv_caches[0]
+
+        for i, flat_idx in enumerate(attn_flat_indices):
+            slices = kv_cache_slices[flat_idx]
             extracted_slices = jax.lax.dynamic_slice_in_dim(slices,
                                                             token_start,
                                                             chunk_size *
@@ -1164,13 +1296,13 @@ class KVCacheManager:
                                                             axis=0)
             reshaped_slices = extracted_slices.reshape(-1, block_size,
                                                        *slices.shape[1:])
+            current_slice = new_large_attn_cache[:, i, ...]
+            updated_slice = jax.lax.dynamic_update_slice_in_dim(
+                current_slice, reshaped_slices, start_block, axis=0)
+            new_large_attn_cache = new_large_attn_cache.at[:, i, ...].set(
+                updated_slice)
 
-            return jax.lax.dynamic_update_slice_in_dim(cache,
-                                                       reshaped_slices,
-                                                       start_block,
-                                                       axis=0)
-
-        return jax.tree.map(_update_layer, kv_caches, kv_cache_slices)
+        return [new_large_attn_cache]
 
     def get_kv_cache_for_block_ids(
         self,
@@ -1187,14 +1319,17 @@ class KVCacheManager:
             A list of JAX arrays, with each array representing the KV cache
             slices for a layer, concatenated for all blocks.
         """
+        unpacked_caches = _unpack_kv_caches(self.runner.kv_caches,
+                                            self.attn_flat_indices,
+                                            self.num_total_caches)
         if block_ids == list(range(block_ids[0],
                                    block_ids[0] + len(block_ids))):
             batched_kv_cache_per_layer = self._jitted_gather_continuous_kv_cache(
-                self.runner.kv_caches, block_ids[0], len(block_ids))
+                unpacked_caches, block_ids[0], len(block_ids))
 
         else:
             batched_kv_cache_per_layer = self._jitted_gather_kv_cache(
-                self.runner.kv_caches, jnp.array(block_ids))
+                unpacked_caches, jnp.array(block_ids))
         return batched_kv_cache_per_layer
 
     def transfer_kv_cache(self,
@@ -1284,6 +1419,7 @@ class KVCacheManager:
                     kv_cache_slices,
                     0,
                     start_block,
+                    self.attn_flat_indices,
                 )
                 jax.block_until_ready(self.runner.kv_caches)
         else:
@@ -1296,6 +1432,7 @@ class KVCacheManager:
                     self.runner.kv_caches,
                     kv_cache_slices,
                     block_numbers,
+                    self.attn_flat_indices,
                 )
                 jax.block_until_ready(self.runner.kv_caches)
 

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -1003,6 +1003,13 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         self.use_hybrid_kvcache = len(kv_cache_config.kv_cache_groups) > 1
         self.kv_cache_manager.initialize_kv_cache(kv_cache_config)
         self.input_batch.has_mamba_layers = kv_cache_config.has_mamba_layers
+        # The torchax model wrapper consumes the unified-pool layer mapping;
+        # `model` may be absent when kv caches are initialized without a
+        # loaded model (e.g. unit tests).
+        model = getattr(self, "model", None)
+        if model is not None and hasattr(model, "set_kv_cache_metadata"):
+            model.set_kv_cache_metadata(
+                self.kv_cache_manager.attn_flat_indices)
 
         if self.kv_cache_manager.actual_mamba_num_blocks is not None:
             self.input_batch.init_mamba_pools(


### PR DESCRIPTION
## Description

This PR stores the KV cache of Qwen2/Qwen3 models as **one unified block-major array** instead of one array per layer:

```
per-layer (before): num_layers x (num_blocks, block_size, num_kv_heads*2/packing, packing, head_dim)
unified   (this PR): (num_blocks, num_layers, block_size, num_kv_heads*2/packing, packing, head_dim)
```

With `num_blocks` as the major dim, a block's KV across **all layers is contiguous in memory** and dim0 slice `pool[b]` *is* logical block `b`. The KV transfer engine can move a whole block with a **single DMA**, addressed natively by block id, instead of issuing `num_layers` DMAs per block — cutting per-layer transfer overhead in P/D disaggregation.

### Key Changes 

- Scope is gated to Qwen2/Qwen3 (one homogeneous attention group) via `model_uses_unified_kv_cache`. Other archs, speculative decoding, and hybrid (attention+Mamba) models keep the per-layer path unchanged (regression-tested).
- The RPA kernel is unchanged and still consumes its 5D `(num_pages, ...)` cache: the 6D->5D fold happens per device inside the attention `shard_map`, where it compiles to a **bitcast** (verified in HLO: all folded 5D views alias the pool at offset 0, zero copy).
- Page addressing is redirected in `attention()`: block `b`, layer `L` maps to flat page `b * num_layers + L` in the folded pool (`page_indices = block_tables * num_layers + layer_idx`), so each layer reads/writes its own slot through the unchanged 5D kernel with no data movement.


## Changes along the KV cache lifecycle

**1. Allocation** — `runner/kv_cache.py`, `runner/kv_cache_manager.py`
`create_unified_kv_cache` allocates the 6D pool with rank-6 sharding `P(ATTN_DATA, None, None, ATTN_HEAD, None, None)` (kv heads on dim3). `initialize_kv_cache` takes the unified path when the gate passes and all layers are regular attention, and records `attn_flat_indices` (layer -> pool slot).

**2. Model forward — the JAX and torchax paths converge at `attention()`:**
- *JAX (flax_nnx)* `models/jax/qwen2.py` / `qwen3.py`: a single-element `kv_caches` list is the unified pool; the layer loop threads the one pool through every layer with `layer_idx` / `num_layers`.
- *torchax (vLLM models)* `layers/vllm/backends/flash_attn.py`: the Pallas backend detects unified layers via `attn_flat_indices` (threaded through the model-wrapper context) and derives `layer_idx` the same way — vLLM model code untouched.

**3. Attention** — `layers/common/attention_interface.py`
`attention()` redirects page addressing: block `b`, layer `L` -> flat page `b * num_layers + L`. `sharded_ragged_paged_attention` folds the pool 6D->5D **inside its shard_map body** (per-device bitcast) and unfolds on return.

**4. Output sharding** — `models/common/model_loader.py`
`run_model`'s kv cache `out_shardings` pin is now rank-aware, selected by the same shared gate, so the pin always matches the allocated layout(mentioned in the Tests section).

**5. KV transfer / P-D handoff** — `distributed/kv_transfer.py`, `runner/kv_cache_manager.py`
The connector DMAs dim0 slices directly off the pool. The in-engine JAX transfer helpers unpack per-layer *views* (`pool[:, i]`, no copy) for extraction, and insert through the unified write path. The chunked-DMA jit gets a `jax.lax.optimization_barrier` on its output for the single-array case so the dest donation stays inplace.

## Tests

Key findings while landing this (each one was an OOM), all root-caused and verified on the real `run_model` HLO:

1. **Fold placement.** Folding 6D->5D in GSPMD-traced code lets the SPMD partitioner implement the reshape as a whole-pool relayout (TP=1) or all-to-all reshard (TP>1), ~2x pool size -> OOM. Moving the fold **inside the shard_map body** makes it a bitcast — HLO buffer assignment shows the 6D param and all folded 5D views at offset 0 of a single allocation.
2. **Rank-sensitive out_shardings.** `PartitionSpec` right-pads with `None`, so the legacy rank-3 pin on the rank-6 pool landed `ATTN_HEAD` on the page_size dim -> whole-pool all-to-all at the graph root -> OOM. Fixed with the rank-aware pin. 
3. **Donation aliasing.** With a single donated dest array, XLA's aliasing verifier rejected the transfer jit (memory-space mismatch on the entry output). `optimization_barrier` keeps the donation in place — verified same per-shard buffer pointers before/after, no extra copy.
4. **Single-host P/D disaggregation e2e on the Raiden connector** (Ref to tpu-raiden/examples/single_host_disagg, prefill and decode on separate chips): Benchmark 10/10 requests (median TTFT 84 ms). Correctness check: a ~900-token prompt with a secret number in the first block and the question at the end — decode answers correctly

## Next steps

- **Mixed KV dtype**: support mixed/quantized per-layer cache dtypes in the unified layout.
- **Mamba state**: extend the unified path to hybrid attention+Mamba models (they currently keep the per-layer path via the gate).

