### PR TITLE
feat(rpa-v3): tuned 4-tuple block-size table (make the +48% decode split the default)

### DIFF
--- a/tests/kernels/ragged_paged_attention_v3_tuned_block_sizes_test.py
+++ b/tests/kernels/ragged_paged_attention_v3_tuned_block_sizes_test.py
@@ -1,0 +1,161 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Device-free tests for the RPA v3 tuned 4-tuple block-size table.
+
+These run on any host (including CPU CI): the table and its lookup are pure
+Python. Two things are guaranteed here:
+
+  1. Every entry satisfies the SAME constraints the kernel's caller-side
+     validator (`_validate_block_sizes`) enforces on operator overrides, so a
+     malformed tuned entry is caught at test time, never on silicon.
+  2. A miss returns None so the kernel falls back to the heuristic (an untuned
+     shape is never regressed), and the one seeded shape resolves to its
+     measured 4-tuple under the exact production lookup key.
+"""
+
+from unittest import mock
+
+import jax.numpy as jnp
+from absl.testing import absltest, parameterized
+from jax._src import test_util as jtu
+
+from tpu_inference.kernels.ragged_paged_attention.v3 import (
+    tuned_block_sizes_v3 as tb3)
+
+_VALID_CASES = ("decode", "prefill", "mixed")
+
+
+def _iter_entries():
+    """Yield (device, page_size, dtypes, heads, extra, case_name, value)."""
+    for device, by_page in tb3.TUNED_BLOCK_SIZES_V3.items():
+        for page_size, by_dtype in by_page.items():
+            for dtypes, by_heads in by_dtype.items():
+                for heads, by_len in by_heads.items():
+                    for extra, by_case in by_len.items():
+                        for case_name, value in by_case.items():
+                            yield (device, page_size, dtypes, heads, extra,
+                                   case_name, value)
+
+
+class TunedBlockSizesV3TableTest(parameterized.TestCase):
+    """Structural / self-consistency checks on the table itself."""
+
+    def test_every_entry_is_a_valid_four_tuple(self):
+        entries = list(_iter_entries())
+        self.assertGreater(len(entries), 0, "table must not be empty")
+        for (device, page_size, dtypes, heads, extra, case_name,
+             value) in entries:
+            ctx = f"{device}/{page_size}/{dtypes}/{heads}/{extra}/{case_name}"
+            self.assertIn(case_name, _VALID_CASES, ctx)
+            self.assertLen(value, 4, f"{ctx}: expected (bq,bkv,bqc,bkvc)")
+            for v in value:
+                self.assertIsInstance(v, int, ctx)
+                self.assertGreater(v, 0, ctx)
+
+    def test_every_entry_passes_caller_validator_constraints(self):
+        # Mirror kernel._validate_block_sizes exactly. The page_size used by
+        # the validator is the runtime page_size; the table key's page_size is
+        # the same value (next_power_of_2), so use it as the divisor.
+        for (device, page_size, dtypes, heads, extra, case_name,
+             value) in _iter_entries():
+            bq_sz, bkv_sz, bq_csz, bkv_csz = value
+            ctx = f"{device}/{page_size}/{dtypes}/{heads}/{extra}/{case_name}"
+            self.assertTrue(0 < bq_csz and bq_sz % bq_csz == 0,
+                            f"{ctx}: bq_sz % bq_csz != 0")
+            self.assertTrue(0 < bkv_csz and bkv_sz % bkv_csz == 0,
+                            f"{ctx}: bkv_sz % bkv_csz != 0")
+            self.assertEqual(bkv_sz % page_size, 0,
+                             f"{ctx}: bkv_sz not page-aligned")
+            self.assertEqual(bkv_csz % page_size, 0,
+                             f"{ctx}: bkv_csz not page-aligned")
+
+    def test_decode_entries_use_fetch_compute_split(self):
+        # The whole reason this table exists: decode entries decouple fetch
+        # (bkv_sz) from compute (bkv_csz). If they were equal the heuristic
+        # would already produce them and the entry would be pointless.
+        saw_decode = False
+        for (_d, _p, _dt, _h, _e, case_name, value) in _iter_entries():
+            if case_name == "decode":
+                saw_decode = True
+                _, bkv_sz, _, bkv_csz = value
+                self.assertGreaterEqual(
+                    bkv_sz, bkv_csz,
+                    "decode fetch block should be >= compute block")
+        self.assertTrue(saw_decode, "expected at least one decode entry")
+
+
+class TunedBlockSizesV3LookupTest(parameterized.TestCase):
+    """Lookup behaviour: hit resolves, miss returns None (heuristic fallback)."""
+
+    def setUp(self):
+        super().setUp()
+        # get_device_name() reads jax.devices(); pin it so the lookup runs on
+        # any host (CPU CI included).
+        p = mock.patch(
+            "tpu_inference.kernels.ragged_paged_attention.v3."
+            "tuned_block_sizes.get_device_name",
+            return_value="TPU v7")
+        p.start()
+        self.addCleanup(p.stop)
+
+    def test_seeded_qwen3_decode_shape_resolves(self):
+        # Qwen3-0.6B, DP16xTP4 per-shard: q_head=4, kv_head=2, head_dim=128,
+        # page_size=128, max_model_len=16384 -> the measured +48% decode tuple.
+        value = tb3.get_tuned_block_sizes_v3(
+            q_dtype=jnp.bfloat16,
+            kv_dtype=jnp.bfloat16,
+            actual_num_q_heads=4,
+            actual_num_kv_heads=2,
+            head_dim=128,
+            page_size=128,
+            max_num_tokens=64,
+            pages_per_seq=128,  # 128 * 128 = 16384 max_model_len
+            case_name="decode",
+        )
+        self.assertEqual(value, (1, 16384, 1, 4096))
+
+    def test_untuned_shape_returns_none(self):
+        # A head config not in the table must miss -> None -> heuristic.
+        value = tb3.get_tuned_block_sizes_v3(
+            q_dtype=jnp.bfloat16,
+            kv_dtype=jnp.bfloat16,
+            actual_num_q_heads=32,
+            actual_num_kv_heads=8,
+            head_dim=128,
+            page_size=128,
+            max_num_tokens=64,
+            pages_per_seq=64,
+            case_name="decode",
+        )
+        self.assertIsNone(value)
+
+    def test_untuned_case_returns_none(self):
+        # The seeded shape has only a decode entry; prefill/mixed must miss.
+        for case_name in ("prefill", "mixed"):
+            value = tb3.get_tuned_block_sizes_v3(
+                q_dtype=jnp.bfloat16,
+                kv_dtype=jnp.bfloat16,
+                actual_num_q_heads=4,
+                actual_num_kv_heads=2,
+                head_dim=128,
+                page_size=128,
+                max_num_tokens=64,
+                pages_per_seq=64,
+                case_name=case_name,
+            )
+            self.assertIsNone(value, f"{case_name} should miss")
+
+
+if __name__ == "__main__":
+    absltest.main(testLoader=jtu.JaxTestLoader())

--- a/tpu_inference/kernels/ragged_paged_attention/v3/kernel.py
+++ b/tpu_inference/kernels/ragged_paged_attention/v3/kernel.py
@@ -28,6 +28,8 @@ from jax import lax
 from jax.experimental import pallas as pl
 from jax.experimental.pallas import tpu as pltpu
 
+from tpu_inference.kernels.ragged_paged_attention.v3.tuned_block_sizes_v3 import (
+    get_tuned_block_sizes_v3)
 from tpu_inference.kernels.ragged_paged_attention.v3.util import (
     align_to, cdiv, get_dtype_packing, get_tpu_version, next_power_of_2)
 
@@ -1882,8 +1884,13 @@ def ragged_paged_attention(
         return run(scalar_prefetches, q, kv, kv_cache)
 
     def _prepare_block_sizes(block_sizes, case):
+        # Precedence: caller override -> v3 tuned table -> heuristic default.
+        # The tuned table (tuned_block_sizes_v3) holds on-silicon-measured
+        # 4-tuples for specific shapes and returns None on any miss, so an
+        # untuned shape always falls through to the heuristic and is never
+        # regressed.
         if block_sizes is None:
-            return get_default_block_sizes(
+            tuned = get_tuned_block_sizes_v3(
                 q.dtype,
                 kv_cache.dtype,
                 actual_num_q_heads,
@@ -1891,10 +1898,24 @@ def ragged_paged_attention(
                 head_dim,
                 page_size,
                 max_num_tokens,
-                max_num_seqs,
                 pages_per_seq,
-                case=case,
+                case.name.lower(),
+                sliding_window,
             )
+            if tuned is None:
+                return get_default_block_sizes(
+                    q.dtype,
+                    kv_cache.dtype,
+                    actual_num_q_heads,
+                    actual_num_kv_heads,
+                    head_dim,
+                    page_size,
+                    max_num_tokens,
+                    max_num_seqs,
+                    pages_per_seq,
+                    case=case,
+                )
+            block_sizes = tuned
         return {
             "bq_sz": block_sizes[0],
             "bkv_sz": block_sizes[1],

--- a/tpu_inference/kernels/ragged_paged_attention/v3/tuned_block_sizes_v3.py
+++ b/tpu_inference/kernels/ragged_paged_attention/v3/tuned_block_sizes_v3.py
@@ -1,0 +1,132 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tuned 4-tuple block sizes for the RPA v3 (head_dim>=128) kernel.
+
+This table is the v3-native complement to the legacy 2-tuple
+``tuned_block_sizes.TUNED_BLOCK_SIZES`` (which stores ``(num_kv_pages_per_blk,
+num_queries_per_blk)`` and is consumed by the v2 / hd64 kernels). The main v3
+kernel does not size blocks in *pages*; it sizes four independent block dims:
+
+    (bq_sz, bkv_sz, bq_csz, bkv_csz)
+
+where ``*_sz`` is the *fetch* (DMA / prefetch) block and ``*_csz`` is the
+*compute* block. Decoupling fetch from compute is exactly what lets the decode
+case use a deep KV prefetch (double-buffering) with a small compute block --
+the lever the ``get_default_block_sizes`` heuristic cannot express because it
+sets ``bkv_sz == bkv_csz`` for the v7 DECODE case.
+
+Lookup precedence in ``kernel.py``:
+
+    caller override (d/p/m_block_sizes)  ->  THIS table  ->  heuristic default
+
+A miss falls through to ``get_default_block_sizes`` (returns ``None`` here), so
+adding or omitting an entry can never regress an untuned shape: it only ever
+*replaces* the heuristic for a shape we have measured on real silicon.
+
+Key format mirrors ``tuned_block_sizes.get_lookup_keys`` so the two tables stay
+searchable with the same helper. The leaf value is the 4-tuple above (in
+*tokens*, aligned to ``page_size`` for the kv dims by the caller's validator).
+"""
+
+from tpu_inference.kernels.ragged_paged_attention.v3.tuned_block_sizes import (
+    get_lookup_keys)
+from tpu_inference.logger import init_logger
+
+logger = init_logger(__name__)
+
+# key (same nesting as the legacy table):
+#   device_name
+#     page_size
+#       q_{q_dtype}_kv_{kv_dtype}
+#         q_head-{Hq}_kv_head-{Hkv}_head-{D}
+#           max_model_len-{L}-sw-{sw}
+#             case ("decode" | "prefill" | "mixed")
+# value: (bq_sz, bkv_sz, bq_csz, bkv_csz)   -- fetch/compute split, in tokens.
+#
+# Provenance for every entry lives in the comment next to it: hardware, model,
+# mesh, and the measured throughput delta vs. the heuristic default. Entries
+# without an on-silicon measurement do NOT belong here -- a miss is free.
+TUNED_BLOCK_SIZES_V3 = {
+    'TPU v7': {
+        128: {
+            'q_bfloat16_kv_bfloat16': {
+                # Qwen3-0.6B, DP16xTP4 -> per-shard q_head=4, kv_head=2, D=128.
+                'q_head-4_kv_head-2_head-128': {
+                    # tpu7x 4x4x4, DAPO GRPO decode (ignore_eos), mds=64/128.
+                    # The v7 DECODE heuristic sets bkv_sz==bkv_csz==16384 (it
+                    # clamps min_bkv_sz_to_peak=16384 to max_kv), which starves
+                    # Pallas double-buffering. A deep 16384 fetch with a 4096
+                    # compute block gives fetch/compute overlap:
+                    #   64,929 -> 96,292 tok/s (+48%), reproduced 4x (+/-0.5%).
+                    # Inverted-U sweep: 2048:85.3k 4096:90.3k 8192(split):95.4k
+                    #   16384(split):96.3k(PEAK) 32768:VMEM-OOM.
+                    #
+                    # Keyed at the 16384 max_model_len bucket: the entry needs
+                    # max_kv >= bkv_sz(16384), and the heuristic default of
+                    # 16384 already implies max_kv >= 16384 for this run. Larger
+                    # context buckets (24576/32768) are expected to behave the
+                    # same (decode is bkv-fetch-bound, not context-bound) but
+                    # have not been separately measured -- they miss and fall
+                    # back to the heuristic until measured.
+                    'max_model_len-16384-sw-None': {
+                        'decode': (1, 16384, 1, 4096),
+                    },
+                },
+            },
+        },
+    },
+}
+
+
+def get_tuned_block_sizes_v3(
+    q_dtype,
+    kv_dtype,
+    actual_num_q_heads,
+    actual_num_kv_heads,
+    head_dim,
+    page_size,
+    max_num_tokens,
+    pages_per_seq,
+    case_name,
+    sliding_window=None,
+):
+    """Look up the tuned 4-tuple ``(bq_sz, bkv_sz, bq_csz, bkv_csz)``.
+
+    Returns ``None`` on any miss so the caller falls back to the heuristic
+    ``get_default_block_sizes`` -- an untuned shape is never regressed.
+
+    Args:
+      case_name: one of ``"decode"``, ``"prefill"``, ``"mixed"``.
+      (all other args mirror ``get_tuned_block_sizes`` / ``get_lookup_keys``.)
+    """
+    device, page_size_key, dtypes, head_dims, extra = get_lookup_keys(
+        page_size,
+        q_dtype,
+        kv_dtype,
+        actual_num_q_heads,
+        actual_num_kv_heads,
+        head_dim,
+        page_size * pages_per_seq,
+        sliding_window,
+    )
+    try:
+        value = TUNED_BLOCK_SIZES_V3[device][page_size_key][dtypes][head_dims][
+            extra][case_name]
+    except KeyError:
+        return None
+
+    logger.info_once(
+        'RPA v3 kernel tuned 4-tuple block sizes for %s case=%s: %s',
+        (device, page_size_key, dtypes, head_dims, extra), case_name, value)
+    return value


### PR DESCRIPTION
## Summary

Follow-up to #3102. Adds the **tuned block-size entry** kyuyeunk asked for, in the form that can actually hold the win.

#3102 exposes the decode fetch/compute split via an env override (self-contained kernel, no kernel changes). This PR makes the measured value the **default** — no env needed — by adding a v3-native tuned table and seeding it with the shape we measured on real tpu7x.

## Why a new table instead of an entry in `tuned_block_sizes.py`

The existing `tuned_block_sizes.py` stores a **2-tuple** `(num_kv_pages_per_block, num_queries_per_block)`, from which the kernel derives `bkv_sz == bkv_csz`. The +49% decode win comes precisely from a **fetch≠compute split** — a deep KV *fetch* block (`bkv_sz`) with a *smaller* compute block (`bkv_csz`) for deeper Pallas double-buffering. A 2-tuple entry has no slot for that; it would just reproduce today's default.

So this adds `tuned_block_sizes_v3.py`, a v3-native table keyed identically (reuses `get_lookup_keys`) but storing the full **4-tuple** `(bq_sz, bkv_sz, bq_csz, bkv_csz)`. The legacy 2-tuple table (consumed by the v2 / hd64 kernels) is **untouched**.

## Behavior

Lookup precedence in `get_default_block_sizes`:

```
caller override (d/p/m_block_sizes)  ->  v3 tuned table  ->  heuristic default
```

A table **miss returns `None`** and falls through to the existing heuristic, so no untuned shape is ever regressed — the table only ever *replaces* the heuristic for a shape measured on silicon.

## Seed entry

Qwen3-0.6B, DP16xTP4 (per-shard `q_head=4, kv_head=2, head_dim=128`, bf16 KV), tpu7x 4x4x4 decode:

| block sizes | tok/s | vs heuristic |
|---|---|---|
| heuristic default (`bkv_sz == bkv_csz == 16384`) | 64,929 | — |
| **`(1, 16384, 1, 4096)`** (deep fetch / small compute) | **96,292** | **+48%** |

Reproduced 4x (±0.5%); full inverted-U sweep confirms 4096 as the compute-block optimum.

## Testing

Device-free (runs on CPU CI). Asserts:
- every table entry passes the kernel's own `_validate_block_sizes` constraints (a malformed entry is caught at test time, not on silicon),
- a miss returns `None` (heuristic fallback),
- the seeded shape resolves under the exact production lookup key.

## Relationship to #3102

Independent — this touches `kernel.py` + the new table + a new test; #3102 touches `envs.py` + the attention layer + a different test. They don't overlap and can land in either order. #3102 is the minimal, self-contained exposure of the knob and is ready now; this PR is the "bake the proven value in as the default" step, split out so the small in-kernel table lookup can be weighed on its own.

---
_— drafted via [Navi](https://navibot.dev?utm_source=github&utm_medium=pr_description&utm_campaign=tpu-inference&ref=lokic233) on behalf of @lokic233_
