### PR TITLE
MoE TP: hidden-dim (D) and hybrid (DF) sharding variants

### DIFF
--- a/tpu_inference/layers/common/fused_moe_gmm.py
+++ b/tpu_inference/layers/common/fused_moe_gmm.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import functools
+import os
 from typing import Literal
 
 import jax
@@ -23,7 +24,7 @@ from jax.sharding import PartitionSpec as P
 import tpu_inference.envs as envs
 from tpu_inference.kernels.collectives import \
     hierarchical_reduce_scatter as hier_rs
-from tpu_inference.kernels.megablox.gmm_v2 import gmm_v2
+from tpu_inference.kernels.megablox.gmm_v2 import apply_act_fn, gmm_v2
 from tpu_inference.kernels.sparse_core.dense_gather_reduce import \
     dense_gather_reduce
 from tpu_inference.kernels.sparse_core.ragged_gather_reduce_v2 import \
@@ -179,13 +180,28 @@ def moe_gmm_local(x: jax.Array,
                   onehot_moe_permute_threshold: int = 0,
                   scatter_results: bool = False,
                   moe_chunk_size: int = 0,
-                  defer_all_reduce: bool = False) -> jax.Array:
+                  defer_all_reduce: bool = False,
+                  tp_shard: str = "F") -> jax.Array:
     """Main MoE logic on a local shard can run in TP or EP mode.
 
-    Set parallelism for "tp" or "ep"
+    Set parallelism for "tp" or "ep". For TP, tp_shard selects which weight dim
+    is sharded: "F" (intermediate, standard column->row MLP, reduce after gmm2),
+    "D" (hidden, row->column MLP: reduce after gmm1, output H-sharded), or "DF"
+    (hybrid: hidden over the D axis + intermediate over the F axis).
     """
 
     assert parallelism in ["tp", "ep"]
+    # "D" and "DF" split the gmm1 contraction (hidden H), so gmm1 is partial and
+    # must be reduced before the activation; "F" (default) does not.
+    d_shard = (parallelism == "tp" and tp_shard in ("D", "DF"))
+
+    if parallelism == "tp" and tp_shard == "DF":
+        # per-device local shapes: expect x=[tok,H/D], w1=[E,H/D,2I/F],
+        # w2=[E,I/F,H/D] -> confirms H sharded over D and I over F.
+        logger.info("[MoE DF local] x=%s w1=%s w2=%s w1_scale=%s w2_scale=%s",
+                    x.shape, w1.shape, w2.shape,
+                    None if w1_scale is None else w1_scale.shape,
+                    None if w2_scale is None else w2_scale.shape)
 
     # GMM1 computes x @ (W_up | W_gate) together and activation, output is [tokens,padded_intermediate_size]
     gmm1_res = gmm_wrapper(
@@ -195,9 +211,18 @@ def moe_gmm_local(x: jax.Array,
         w1_bias,
         group_sizes,
         group_offset,
-        fuse_act=activation,
+        fuse_act=(None if d_shard else activation),
         preferred_element_type=x.dtype,
     )
+    if d_shard:
+        # D/DF split hidden H (gmm1's contraction), so gmm1 is a partial sum.
+        # Reduce across the shard axis BEFORE the activation, then apply swiglu.
+        # Pure "D" reduces over the full MLP_TENSOR; the "DF" hybrid splits H over
+        # the D axis alone (the small, exposed mid-layer all-reduce).
+        gmm1_reduce_axis = (_df_shard_axes()[0]
+                            if tp_shard == "DF" else ShardingAxisName.MLP_TENSOR)
+        gmm1_res = jax.lax.psum(gmm1_res, axis_name=gmm1_reduce_axis)
+        gmm1_res = apply_act_fn(gmm1_res, activation)
 
     # When the parallelism is TP since w2_bias is not sharded, we should only apply bias
     # once, not applying to every shard. So we set w2_bias to 0 to all shards other than
@@ -244,7 +269,9 @@ def moe_gmm_local(x: jax.Array,
     is_onehot = (local_group_size < group_sizes.size) and (
         onehot_moe_permute_threshold > 0
         and batch_size <= onehot_moe_permute_threshold)
-    if moe_chunk_size > 0 and num_tokens > moe_chunk_size * scatter_axis_size and not is_onehot:
+    # D/DF do their own output collectives (all-gather / all-to-all on the hidden
+    # dim), which the chunked unpermute path does not model -- keep them un-chunked.
+    if moe_chunk_size > 0 and num_tokens > moe_chunk_size * scatter_axis_size and not is_onehot and not d_shard:
         actual_chunk_size = moe_chunk_size * scatter_axis_size
     else:
         actual_chunk_size = num_tokens
@@ -305,7 +332,57 @@ def moe_gmm_local(x: jax.Array,
                 topk,
             )
 
-        if enable_rs_kernel:
+        if d_shard and tp_shard == "DF":
+            # Hybrid DF: gmm2 contracts the F-sharded intermediate I, so the output
+            # is partial over the F axes AND H-sharded over the D (attn_dp_expert)
+            # axis. (1) Reduce the F partials over attn_dp -- a reduce-scatter that
+            # also scatters tokens onto attn_dp under DP-attention (scatter_results),
+            # else a plain all-reduce. (2) Over the D axis (also carrying DP tokens):
+            # all-to-all to scatter tokens AND gather the H shards back to full
+            # width -> residual layout (token-sharded, H-full). With no DP-attention
+            # there are no tokens to scatter, so a plain all-gather.
+            d_axis, f_axis = _df_shard_axes()
+            if scatter_results:
+                dp_axes = ShardingAxisName.ATTN_DATA
+                df_reduce_axes = tuple(a for a in f_axis if a not in dp_axes)
+                df_scatter_axes = tuple(a for a in f_axis if a in dp_axes)
+                if df_reduce_axes:
+                    chunk_hidden = jax.lax.psum(chunk_hidden,
+                                                axis_name=df_reduce_axes)
+                if df_scatter_axes:
+                    chunk_hidden = jax.lax.psum_scatter(
+                        chunk_hidden,
+                        axis_name=df_scatter_axes,
+                        scatter_dimension=0,
+                        tiled=True)
+                out = jax.lax.all_to_all(chunk_hidden,
+                                         d_axis,
+                                         split_axis=0,
+                                         concat_axis=1,
+                                         tiled=True).astype(x.dtype)
+            else:
+                chunk_hidden = jax.lax.psum(chunk_hidden, axis_name=f_axis)
+                out = jax.lax.all_gather(chunk_hidden,
+                                         d_axis,
+                                         axis=1,
+                                         tiled=True).astype(x.dtype)
+        elif d_shard:
+            # Pure D: gmm2 output is H-sharded (no reduce needed). Reassemble to the
+            # residual layout. Under DP-attention (scatter_results) the residual is
+            # token-sharded + H-full, so all-to-all (split tokens, concat H);
+            # otherwise all-gather H to give token-full + H-full.
+            if scatter_results:
+                out = jax.lax.all_to_all(chunk_hidden,
+                                         ShardingAxisName.MLP_TENSOR,
+                                         split_axis=0,
+                                         concat_axis=1,
+                                         tiled=True).astype(x.dtype)
+            else:
+                out = jax.lax.all_gather(chunk_hidden,
+                                         ShardingAxisName.MLP_TENSOR,
+                                         axis=1,
+                                         tiled=True).astype(x.dtype)
+        elif enable_rs_kernel:
             # Fallback to psum-scatter for small token sizes to avoid Mosaic compilation.
             # The threshold is chosen based on the tile dimension (8) in the
             # hierarchical reduce-scatter kernel.
@@ -350,6 +427,24 @@ def moe_gmm_local(x: jax.Array,
                            axis=0) if len(out_list) > 1 else out_list[0]
 
 
+def _df_shard_axes():
+    """Mesh axes for the hybrid "DF" MoE sharding (MOE_TP_SHARD=DF).
+
+    Both axes are attention DATA-PARALLEL sub-axes, so attention stays a plain
+    8-way DP with full heads and MLA is NEVER TP-sharded (model stays 1):
+      D = 'attn_dp_expert' shards the hidden dim H (gives gmm2 a deeper K than
+          pure-F); its collectives are a 2-way all-reduce (mid) + all-to-all (end).
+      F = MLP_TENSOR minus attn_dp_expert (i.e. 'attn_dp') shards the intermediate.
+    With attn_dp_size=8 + attn_dp_expert_size=2 on TP=8 this is a 2-way D
+    (attn_dp_expert) x 4-way F (attn_dp) split. Returns ``(d_axis, f_axis)``.
+    """
+    d_axis = "attn_dp_expert"
+    mt = ShardingAxisName.MLP_TENSOR
+    mt = mt if isinstance(mt, tuple) else (mt, )
+    f_axis = tuple(a for a in mt if a != d_axis)
+    return d_axis, f_axis
+
+
 def tensor_parallel_gmm(
     x: jax.Array,
     w1: jax.Array,
@@ -371,22 +466,69 @@ def tensor_parallel_gmm(
     moe_chunk_size: int = 0,
     defer_all_reduce: bool = False,
 ) -> jax.Array:
+    tp_shard = os.getenv("MOE_TP_SHARD", "F")
+    MT = ShardingAxisName.MLP_TENSOR
     data_p_spec = P(ShardingAxisName.MLP_DATA)
     attn_data_p_spec = P(ShardingAxisName.ATTN_DATA)
     group_offset = jnp.array([0])
 
-    w1_spec = P(None, None, ShardingAxisName.MLP_TENSOR)
-    w2_spec = P(None, ShardingAxisName.MLP_TENSOR, None)
-
-    w1_scale_spec = (None if w1_scale is None else P(
-        None, None, None, ShardingAxisName.MLP_TENSOR))
-    w1_bias_spec = (None if w1_bias is None else P(
-        None, None, ShardingAxisName.MLP_TENSOR))
-
     num_blocks = 1 if w2_scale is None else w2_scale.shape[1]
-    w2_scale_spec = (None if num_blocks == 1 else P(
-        None, ShardingAxisName.MLP_TENSOR, None, None))
-    w2_bias_spec = None if w2_bias is None else P(None, None, None)
+    if tp_shard == "D":
+        # Shard hidden H: w1=[E,H,2I] dim1, w2=[E,I,H] dim2; x sharded on H so
+        # gmm1 contracts H/N (reduce after gmm1); gmm2 contracts full I (deep K).
+        x_in_spec = P(ShardingAxisName.MLP_DATA, MT)
+        w1_spec = P(None, MT, None)
+        w2_spec = P(None, None, MT)
+        w1_scale_spec = (None if w1_scale is None else P(None, MT, None, None))
+        w1_bias_spec = (None if w1_bias is None else P(None, None, None))
+        w2_scale_spec = (None if w2_scale is None else P(None, None, None, MT))
+        w2_bias_spec = None if w2_bias is None else P(None, None, MT)
+    elif tp_shard == "DF":
+        # Hybrid: shard hidden H over the D axis 'attn_dp_expert' AND intermediate
+        # 2I/I over the F axis 'attn_dp' (both attention DP axes, so model stays 1
+        # and MLA is untouched). w1=[E,H,2I], w2=[E,I,H]. gmm1 contracts H/D
+        # (reduce over D after gmm1); gmm2 contracts I/F (reduce over F after gmm2),
+        # giving K = I/F -- deeper than pure-F's I/8.
+        d_axis, f_axis = _df_shard_axes()
+        x_in_spec = P(ShardingAxisName.MLP_DATA, d_axis)
+        w1_spec = P(None, d_axis, f_axis)
+        w2_spec = P(None, f_axis, d_axis)
+        w1_scale_spec = (None if w1_scale is None else
+                         P(None, d_axis, None, f_axis))
+        w1_bias_spec = (None if w1_bias is None else P(None, None, f_axis))
+        if w2_scale is None:
+            w2_scale_spec = None
+        elif num_blocks == 1:
+            # per-channel along I: the I-block dim is size 1, not shardable over F.
+            w2_scale_spec = P(None, None, None, d_axis)
+        else:
+            w2_scale_spec = P(None, f_axis, None, d_axis)
+        w2_bias_spec = None if w2_bias is None else P(None, None, d_axis)
+        d_deg = get_mesh_shape_product(mesh, d_axis)
+        f_deg = get_mesh_shape_product(mesh, f_axis)
+        logger.info(
+            "[MoE DF] d_axis=%s(x%d) f_axis=%s(x%d) | global shapes: "
+            "x=%s w1=%s(H,2I) w2=%s(I,H) w1_scale=%s w2_scale=%s | "
+            "x_spec=%s w1_spec=%s w2_spec=%s", d_axis, d_deg, f_axis, f_deg,
+            x.shape, w1.shape, w2.shape,
+            None if w1_scale is None else w1_scale.shape,
+            None if w2_scale is None else w2_scale.shape, x_in_spec, w1_spec,
+            w2_spec)
+    else:
+        # F (default): shard intermediate 2I/I (standard column->row MLP).
+        x_in_spec = data_p_spec
+        w1_spec = P(None, None, MT)
+        w2_spec = P(None, MT, None)
+        w1_scale_spec = (None if w1_scale is None else P(None, None, None, MT))
+        w1_bias_spec = (None if w1_bias is None else P(None, None, MT))
+        w2_scale_spec = (None if num_blocks == 1 else P(None, MT, None, None))
+        w2_bias_spec = None if w2_bias is None else P(None, None, None)
+
+    if tp_shard in ("D", "DF") and x.shape[-1] != w1.shape[1]:
+        # w13's contraction (H) was padded for quant-block alignment; pad x to
+        # match so it shards to the same per-chip size as the weight. gmm2's
+        # output H (w2) is unpadded, so the result needs no un-padding.
+        x = jnp.pad(x, [(0, 0), (0, w1.shape[1] - x.shape[-1])])
 
     if scatter_results:
         final_out_specs = attn_data_p_spec
@@ -404,10 +546,11 @@ def tensor_parallel_gmm(
             scatter_results=scatter_results,
             moe_chunk_size=moe_chunk_size,
             defer_all_reduce=defer_all_reduce,
+            tp_shard=tp_shard,
         ),
         mesh=mesh,
         in_specs=(
-            data_p_spec,
+            x_in_spec,
             w1_spec,
             w1_scale_spec,
             w1_bias_spec,

--- a/tpu_inference/layers/common/process_weights/moe_weights.py
+++ b/tpu_inference/layers/common/process_weights/moe_weights.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import os
 from dataclasses import dataclass, fields
 from functools import partial
 
@@ -164,6 +165,36 @@ class W13PaddingConfig:
     padded_intermediate_size: int
 
 
+def _gmm_tp_w13_reorder_size(mesh) -> int:
+    """Number of chunks to reorder w13 into so each holds a contiguous [w1|w3].
+
+    This must equal how many ways the intermediate (2I) dim is sharded. For "F"
+    (default) and "D" that is the full MLP_TENSOR; for the "DF" hybrid the
+    intermediate is sharded only over MLP_TENSOR minus the D axis
+    ('attn_dp_expert'), so the reorder count is the F-degree
+    (= MLP_TENSOR product / attn_dp_expert product).
+    """
+    mt = get_mesh_shape_product(mesh, ShardingAxisName.MLP_TENSOR)
+    if os.getenv("MOE_TP_SHARD", "F") == "DF":
+        return mt // get_mesh_shape_product(mesh, "attn_dp_expert")
+    return mt
+
+
+def _gmm_tp_hidden_shard_size(mesh) -> int:
+    """How many ways the MoE hidden dim H is sharded (for quant-block H padding).
+
+    F does not shard H (returns 1); D shards H over the full MLP_TENSOR; DF shards
+    H over the D axis 'attn_dp_expert'. H must be padded so its per-shard quant-
+    block count is a whole number -> pad H to a multiple of (this * block).
+    """
+    shard = os.getenv("MOE_TP_SHARD", "F")
+    if shard == "D":
+        return get_mesh_shape_product(mesh, ShardingAxisName.MLP_TENSOR)
+    if shard == "DF":
+        return get_mesh_shape_product(mesh, "attn_dp_expert")
+    return 1
+
+
 def get_w13_padding_config(intermediate_size: int,
                            reorder_size: int,
                            align: int = 128,
@@ -272,6 +303,7 @@ def process_moe_weights(
     w13_reorder_size: int | None = None,
     w13_interleave: bool = False,
     disable_weight_requantization: bool = False,
+    w13_hidden_shard_size: int = 1,
 ) -> FusedMoEWeights:
     """Process fused moe weights to a layout that moe backend expects.
 
@@ -432,6 +464,13 @@ def process_moe_weights(
                 pad_config_weight.padded_intermediate_size,
                 pad_config_weight.padded_intermediate_size
             ]
+            # D-sharding shards hidden H (not 2I), so the 2I shard-interleave
+            # reorder is both unnecessary and harmful: it would break the
+            # contiguous [w1|w3] split that apply_act_fn relies on after the
+            # gmm1 all-reduce. Skip the reorder (keep pad/concat).
+            d_shard = os.getenv("MOE_TP_SHARD", "F") == "D"
+            if d_shard:
+                padded_output_sizes = None
 
             w13_weight = process_w13_for_gmm(
                 tensor=w13_weight,
@@ -450,6 +489,8 @@ def process_moe_weights(
                     pad_config_scale.padded_intermediate_size,
                     pad_config_scale.padded_intermediate_size
                 ]
+                if d_shard:
+                    padded_output_sizes_scales = None
                 w13_weight_scale = process_w13_for_gmm(
                     tensor=w13_weight_scale,
                     concat_dim=3,
@@ -478,6 +519,28 @@ def process_moe_weights(
                     w2_weight_scale = jnp.repeat(w2_weight_scale,
                                                  w2_outer_block_size,
                                                  axis=3)
+
+            if w13_hidden_shard_size > 1:
+                # D / DF sharding splits w13's hidden dim H (the gmm1 contraction)
+                # w13_hidden_shard_size ways. fp4 scales are block-quantized along
+                # H, so the per-chip H must be a whole number of quant blocks ->
+                # pad H up to a multiple of (shard_size * block) so the scale's
+                # block count divides the shard. (w2's H is the gmm2 output, a
+                # plain sharded dim, so it needs no padding.) For DF this is a
+                # no-op when the block count already divides (e.g. D2F4: 14/2=7).
+                h = w13_weight.shape[1]
+                blk = (h // w13_weight_scale.shape[1]
+                       if w13_weight_scale is not None else 1)
+                hpad = align_to(h, w13_hidden_shard_size * blk)
+                if hpad != h:
+                    w13_weight = jnp.pad(w13_weight,
+                                         [[0, 0], [0, hpad - h], [0, 0]])
+                    if w13_weight_scale is not None:
+                        nb = hpad // blk - w13_weight_scale.shape[1]
+                        w13_weight_scale = jnp.pad(
+                            w13_weight_scale,
+                            [[0, 0], [0, nb], [0, 0], [0, 0]],
+                            constant_values=1.0)
 
         case MoEBackend.GMM_EP:
             pad_config_weight = get_w13_padding_config(intermediate_size,
@@ -572,6 +635,46 @@ def _get_moe_weight_shardings(
                 w2_bias=ep_sharding,
             )
         case MoEBackend.GMM_TP:
+            if os.getenv("MOE_TP_SHARD", "F") == "D":
+                # D-sharding: shard hidden H instead of intermediate 2I.
+                # w13=[E,H,2I] -> shard dim1 (H); w2=[E,I,H] -> shard dim2 (H).
+                # Scales: w13=[E,H/subc,1,2I] shard dim1; w2=[E,I/subc,1,H] shard last.
+                MT = ShardingAxisName.MLP_TENSOR
+                return FusedMoEWeights(
+                    w13_weight=NamedSharding(mesh, P(None, MT, None)),
+                    w13_weight_scale=NamedSharding(mesh, P(None, MT, None,
+                                                           None)),
+                    w13_bias=NamedSharding(mesh, P(None, None, None)),
+                    w2_weight=NamedSharding(mesh, P(None, None, MT)),
+                    w2_weight_scale=NamedSharding(mesh, P(None, None, None,
+                                                          MT)),
+                    w2_bias=NamedSharding(mesh, P(None, None, None)),
+                )
+            if os.getenv("MOE_TP_SHARD", "F") == "DF":
+                # Hybrid: shard hidden H over the D axis 'attn_dp_expert' AND
+                # intermediate 2I/I over the F axis 'attn_dp' (both attention DP
+                # axes -> model=1, MLA untouched). Same partition strings as
+                # tensor_parallel_gmm's "DF" branch. w1=[E,H,2I] -> dim1 (H) over D,
+                # dim2 (2I) over F; w2=[E,I,H] -> dim1 (I) over F, dim2 (H) over D.
+                d_axis = "attn_dp_expert"
+                mt_axes = ShardingAxisName.MLP_TENSOR
+                mt_axes = mt_axes if isinstance(mt_axes, tuple) else (mt_axes, )
+                f_axis = tuple(a for a in mt_axes if a != d_axis)
+                w2_scale = weights.w2_weight_scale
+                if w2_scale is not None and w2_scale.shape[1] == 1:
+                    # per-channel along I: I-block dim is size 1, unshardable over F
+                    w2_scale_spec = P(None, None, None, d_axis)
+                else:
+                    w2_scale_spec = P(None, f_axis, None, d_axis)
+                return FusedMoEWeights(
+                    w13_weight=NamedSharding(mesh, P(None, d_axis, f_axis)),
+                    w13_weight_scale=NamedSharding(
+                        mesh, P(None, d_axis, None, f_axis)),
+                    w13_bias=NamedSharding(mesh, P(None, None, f_axis)),
+                    w2_weight=NamedSharding(mesh, P(None, f_axis, d_axis)),
+                    w2_weight_scale=NamedSharding(mesh, w2_scale_spec),
+                    w2_bias=NamedSharding(mesh, P(None, None, d_axis)),
+                )
             # When using per-channel, in_dim // block_size == 1. This means we
             # are unable to shard w2_weight_scale along 1st dim. Therefore, we
             # fully replicate it instead.
@@ -761,6 +864,7 @@ def _process_moe_weights_no_requant(
     w13_interleave: bool,
     disable_weight_requantization: bool,
     weight_block_size: tuple[int, ...] | None,
+    w13_hidden_shard_size: int = 1,
 ) -> FusedMoEWeights:
     """Process MoE weights without requantization.
 
@@ -817,6 +921,7 @@ def _process_moe_weights_no_requant(
         w13_reorder_size=w13_reorder_size,
         w13_interleave=w13_interleave,
         disable_weight_requantization=disable_weight_requantization,
+        w13_hidden_shard_size=w13_hidden_shard_size,
     )
 
     target_shardings = _get_moe_weight_shardings(out, moe_backend, mesh)
@@ -957,6 +1062,7 @@ def _requant_and_process_local_fn(
     clip_percentile: float | None,
     moe_backend: MoEBackend,
     w13_reorder_size: int,
+    w13_hidden_shard_size: int = 1,
 ):
     """Per-device requantization and processing of MoE weights.
 
@@ -1045,6 +1151,7 @@ def _requant_and_process_local_fn(
         moe_backend=moe_backend,
         w13_reorder_size=w13_reorder_size,
         w13_interleave=w13_interleave,
+        w13_hidden_shard_size=w13_hidden_shard_size,
     )
     return (
         out_local.w13_weight,
@@ -1086,8 +1193,8 @@ def _process_quantized_moe_weights_impl(
 
     w13_interleave = (activation == "swigluoai"
                       or activation == MoEActivation.SWIGLUOAI)
-    w13_reorder_size = get_mesh_shape_product(mesh,
-                                              ShardingAxisName.MLP_TENSOR)
+    w13_reorder_size = _gmm_tp_w13_reorder_size(mesh)
+    w13_hidden_shard_size = _gmm_tp_hidden_shard_size(mesh)
 
     if disable_weight_requantization:
         return _process_moe_weights_no_requant(
@@ -1098,6 +1205,7 @@ def _process_quantized_moe_weights_impl(
             w13_interleave=w13_interleave,
             disable_weight_requantization=disable_weight_requantization,
             weight_block_size=weight_block_size,
+            w13_hidden_shard_size=w13_hidden_shard_size,
         )
 
     # desired_quant_dtype and requant_block_size are handled by the wrapper.
@@ -1164,6 +1272,7 @@ def _process_quantized_moe_weights_impl(
         clip_percentile=clip_percentile,
         moe_backend=moe_backend,
         w13_reorder_size=w13_reorder_size,
+        w13_hidden_shard_size=w13_hidden_shard_size,
     )
 
     in_specs = (
@@ -1273,8 +1382,8 @@ def process_unquantized_moe_weights(
         )
 
     w13_interleave = activation == MoEActivation.SWIGLUOAI
-    w13_reorder_size = get_mesh_shape_product(mesh,
-                                              ShardingAxisName.MLP_TENSOR)
+    w13_reorder_size = _gmm_tp_w13_reorder_size(mesh)
+    w13_hidden_shard_size = _gmm_tp_hidden_shard_size(mesh)
 
     return process_moe_weights(
         weights,
@@ -1282,4 +1391,5 @@ def process_unquantized_moe_weights(
         w13_reorder_size=w13_reorder_size,
         w13_interleave=w13_interleave,
         disable_weight_requantization=envs.DISABLE_WEIGHT_REQUANTIZATION,
+        w13_hidden_shard_size=w13_hidden_shard_size,
     )

--- a/tpu_inference/layers/common/sharding.py
+++ b/tpu_inference/layers/common/sharding.py
@@ -280,9 +280,31 @@ class ShardingConfigManager:
                                      int(expert_parallelism // shard_divisor))
                 expert_parallelism //= attn_dp_expert
 
+            # MoE hybrid (DF) sharding knob: carve a data-parallel sub-axis
+            # (attn_dp_expert) out of attn_dp, WITHOUT taking any chips from the
+            # `model` axis. Attention shards over ATTN_DATA=(data,attn_dp,
+            # attn_dp_expert), so total attention-DP is unchanged (attn_dp *
+            # attn_dp_expert), model stays as-is, and MLA is never TP-sharded.
+            # Use with attn_dp_size = full DP degree so model=1.
+            moe_attn_dp_expert = sharding_strategy.get("attn_dp_expert_size",
+                                                       None)
+            if moe_attn_dp_expert is not None and moe_attn_dp_expert > 1:
+                assert attn_dp % moe_attn_dp_expert == 0, (
+                    f"attn_dp ({attn_dp}) must be divisible by "
+                    f"attn_dp_expert_size ({moe_attn_dp_expert})")
+                attn_dp = attn_dp // moe_attn_dp_expert
+                attn_dp_expert = moe_attn_dp_expert
+
         else:
             attn_dp = 1
             attn_dp_expert = 1
+
+        logger.info(
+            "[sharding] attn_dp=%s attn_dp_expert=%s model(tp)=%s expert=%s "
+            "data=%s dcp=%s (attention-DP=%s, MLA head-sharded=%s)", attn_dp,
+            attn_dp_expert, tensor_parallelism, expert_parallelism,
+            data_parallelism, decode_context_parallelism,
+            attn_dp * attn_dp_expert, tensor_parallelism > 1)
 
         sharding_strategy = ShardingStrategy(
             tensor_parallelism=tensor_parallelism,


### PR DESCRIPTION
Adds tensor-parallel MoE sharding over the hidden dim as an alternative to the default intermediate (F) sharding, selected at runtime by env/config with no code divergence between variants:

- MOE_TP_SHARD=D  : shard hidden H over the full MLP_TENSOR (pure D8).
- MOE_TP_SHARD=DF : hybrid - shard H over the attn_dp_expert axis and the intermediate I over attn_dp. Split degree set by attn_dp_expert_size (=2 -> D2/F4, =4 -> D4/F2). Both are attention data-parallel axes, so model=1 and MLA is never TP-sharded (attention stays 8-way DP, full heads).

sharding.py: new attn_dp_expert_size knob carves a DP sub-axis out of attn_dp without taking chips from the model axis.

DF collectives: all-reduce H-partials over attn_dp_expert after gmm1; reduce-scatter over attn_dp + all-to-all over attn_dp_expert after gmm2 to restore the token-sharded / H-full residual layout.

Weights: H quant-block padding is conditional on the shard degree (w13_hidden_shard_size) - no-op when the block count already divides (D2/F4), pads 7168->8192 when it doesn't (D4/F2, pure D).

Verified on gf2x2 (Kimi K2.6, 8k/1k): coherent output, per-device shard shapes confirmed via logs; D2/F4 ~+2.6% over F, D4/F2 loses to collective growth.

EP: http://xprof.corp.google.com/trace_viewer/dawnhan-7808190526743020650
TP: http://xprof.corp.google.com/trace_viewer/dawnhan-3423701083088464696
D2F4: https://xprof.corp.google.com/trace_viewer/dawnhan-14453928501497137182
D4F2: http://xprof.corp.google.com/trace_viewer/dawnhan-9772259569033992278