### PR TITLE
Drive agentic benchmark from real R2E-Gym SWE content

### DIFF
--- a/scripts/vllm/benchmarking/agentic_benchmark/README.md
+++ b/scripts/vllm/benchmarking/agentic_benchmark/README.md
@@ -73,3 +73,52 @@ python benchmarks/benchmark_agentic.py \
     --env-len-max 20 \
     --concurrency 16
 ```
+
+---
+
+## 3. Running on Real SWE Task Content (R2E-Gym)
+
+By default the benchmark builds prompts and environment replies from random token IDs. That is fine for fixing token counts, but the content is meaningless. To drive the same workload from real agentic content, `prepare_r2e_dataset.py` converts [R2E-Gym](https://github.com/R2E-Gym/R2E-Gym) SWE tasks into a scripted multi-turn dataset.
+
+### Why a conversion step is needed
+
+R2E-Gym ships **task definitions, not trajectories** — every row's `input` field is empty, so there is nothing to replay. Each row does carry real content: a GitHub-issue style problem statement, the pre-fix source files, and the recorded stdout of the test suite before and after the fix. The converter assembles those into an agent prompt plus a fixed sequence of environment observations.
+
+Running the real environment instead would mean per-task containers, test execution, and a reward loop (NVIDIA measures ~20 min per training step, ~1 CPU core per task instance). That measures the harness, not the serving stack. Here the model still generates **every assistant turn live against the server**, so the generated token distribution is real; only the environment side is pre-baked.
+
+### Step 1: Build the dataset
+
+```bash
+python prepare_r2e_dataset.py \
+    --dataset hfilaretov/Benchmark-R2E-Gym-Easy \
+    --split val \
+    --model-path-or-id Qwen/Qwen3-4B \
+    --output r2e_easy_val.jsonl
+```
+
+The converter prints the resulting token distribution. For the `val` split with the Qwen3-4B tokenizer:
+
+| Metric | min | p50 | p99 | max |
+| --- | --- | --- | --- | --- |
+| Initial prompt tokens | 4,409 | 8,552 | — | 15,490 |
+| Env observation tokens | 17 | 410 | 2,181 | 2,407 |
+
+Use `--input-jsonl` to convert an already-downloaded file, and `--num-instances` to convert a subset.
+
+### Step 2: Run the benchmark against it
+
+```bash
+python benchmark_agentic.py \
+    --model-path-or-id Qwen/Qwen3-4B \
+    --model Qwen/Qwen3-4B \
+    --dataset r2e_easy_val.jsonl \
+    --num-groups 16 \
+    -g 16 \
+    --concurrency 16
+```
+
+One task instance backs one GRPO group, matching real RL where a group of rollouts shares a single task and therefore a single prefix. In this mode prompt lengths and turn counts come from the dataset, so `--initial-prompt-len-*`, `--turns-*` and `--env-len-*` are ignored. Omit `--dataset` for the original random-token workload.
+
+### What changes versus random tokens
+
+Real environment observations have a **p50 of ~410 tokens**, against the `10-20` the random-mode examples above use. Real observations are pytest output, file views, and traceback text — roughly 20-40x larger. Since every observation is prefilled on the next turn, this materially raises per-turn prefill cost and shifts the prefill/decode balance. Prompts also share a genuine long prefix (system prompt plus repo context) rather than random tokens, which is what prefix caching actually sees in production.

--- a/scripts/vllm/benchmarking/agentic_benchmark/README.md
+++ b/scripts/vllm/benchmarking/agentic_benchmark/README.md
@@ -96,14 +96,28 @@ python prepare_r2e_dataset.py \
     --output r2e_easy_val.jsonl
 ```
 
-The converter prints the resulting token distribution. For the `val` split with the Qwen3-4B tokenizer:
+The converter prints the resulting distributions. Measured over **all 977 instances** (721 train + 256 val) with the Qwen3-4B tokenizer, 0 skipped:
 
-| Metric | min | p50 | p99 | max |
-| --- | --- | --- | --- | --- |
-| Initial prompt tokens | 4,409 | 8,552 | — | 15,490 |
-| Env observation tokens | 17 | 410 | 2,181 | 2,407 |
+| Metric | min | p50 | p90 | p99 | max |
+| --- | --- | --- | --- | --- | --- |
+| Initial prompt tokens (val) | 4,158 | 10,537 | — | — | 15,977 |
+| Initial prompt tokens (train) | 4,072 | 10,184 | — | — | 15,985 |
+| Env observation tokens (val) | 21 | 398 | — | 2,813 | 4,269 |
+| Env observation tokens (train) | 39 | 398 | — | 2,749 | 4,265 |
+| Turns per instance (val) | 10 | 20 | 55 | — | 100 |
+| Turns per instance (train) | 10 | 19 | 54 | — | 100 |
 
-Use `--input-jsonl` to convert an already-downloaded file, and `--num-instances` to convert a subset.
+Both splits convert cleanly and their distributions agree closely, so either works; `val` (256 instances) is smaller and already gives 4,096 rollouts at `-g 16`. Use `--input-jsonl` to convert an already-downloaded file, and `--num-instances` for a subset.
+
+### Turn counts are an assumption, not data
+
+R2E-Gym has no trajectories, so it carries **no ground truth for how many turns a rollout takes** — any distribution here is a modelling choice. `--turns-dist skewed` (the default) is right-skewed like real SWE agent behavior: most instances resolve in 10-30 turns, with a long tail to the cap (p50 20, p90 55, mean ~28). `--turns-dist uniform` reproduces the flat 10-100 draw of the random-token mode (mean ~53).
+
+This choice matters: history is re-prefilled every turn, so weighting long conversations more heavily raises average prefill per turn substantially. A/B the two flags if you want to quantify that on your hardware.
+
+### Observation reuse is bounded by the source data
+
+A single instance carries a finite amount of real content — a handful of source files and two recorded test runs. A long conversation therefore *must* reuse observations: the converter reports `distinct observations per instance` (mean ~13 against mean ~28 turns) so this is visible rather than passing as more variety than exists. Raising `MAX_VIEWS_PER_FILE` lifts the ceiling at the cost of longer file views.
 
 ### Step 2: Run the benchmark against it
 
@@ -121,4 +135,4 @@ One task instance backs one GRPO group, matching real RL where a group of rollou
 
 ### What changes versus random tokens
 
-Real environment observations have a **p50 of ~410 tokens**, against the `10-20` the random-mode examples above use. Real observations are pytest output, file views, and traceback text — roughly 20-40x larger. Since every observation is prefilled on the next turn, this materially raises per-turn prefill cost and shifts the prefill/decode balance. Prompts also share a genuine long prefix (system prompt plus repo context) rather than random tokens, which is what prefix caching actually sees in production.
+Real environment observations have a **p50 of ~398 tokens** (p99 ~2.8k), against the `10-20` the random-mode examples above use. Real observations are pytest output, file views, and traceback text — roughly 20-40x larger. Since every observation is prefilled on the next turn, this materially raises per-turn prefill cost and shifts the prefill/decode balance. Prompts also share a genuine long prefix (system prompt plus repo context) rather than random tokens, which is what prefix caching actually sees in production.

--- a/scripts/vllm/benchmarking/agentic_benchmark/benchmark_agentic.py
+++ b/scripts/vllm/benchmarking/agentic_benchmark/benchmark_agentic.py
@@ -17,7 +17,7 @@ import os
 import random
 import sys
 import time
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 import aiohttp
 from transformers import AutoTokenizer
@@ -64,6 +64,47 @@ def generate_initial_prompt(tokenizer: AutoTokenizer,
     return tokenizer.decode(token_ids, skip_special_tokens=True)
 
 
+def load_dataset(path: str) -> List[Dict[str, Any]]:
+    """Loads a prepared multi-turn dataset produced by prepare_r2e_dataset.py.
+
+    Args:
+        path: Path to the prepared JSONL file.
+
+    Returns:
+        List[Dict[str, Any]]: Dataset records.
+    """
+    with open(path) as f:
+        records = [json.loads(line) for line in f if line.strip()]
+    if not records:
+        raise ValueError(f"No records found in {path}")
+    return records
+
+
+def generate_env_response(tokenizer: AutoTokenizer, args: argparse.Namespace,
+                          record: Optional[Dict[str, Any]], turn: int) -> str:
+    """Produces the environment observation appended after an assistant turn.
+
+    Args:
+        tokenizer: Tokenizer to decode tokens.
+        args: Parsed command line arguments.
+        record: Dataset record for this group, or None for random mode.
+        turn: 1-based index of the turn just completed.
+
+    Returns:
+        str: Environment response text.
+    """
+    if record is not None:
+        env_turns = record["env_turns"]
+        # Streams in a group may run past the scripted turn count when
+        # --turns-max exceeds the record's; cycle rather than truncate so the
+        # conversation keeps growing.
+        return env_turns[(turn - 1) % len(env_turns)]
+
+    env_len = random.randint(args.env_len_min, args.env_len_max)
+    env_token_ids = [random.randint(1000, 50000) for _ in range(env_len)]
+    return tokenizer.decode(env_token_ids, skip_special_tokens=True)
+
+
 async def run_grpo_stream(
     session: aiohttp.ClientSession,
     url: str,
@@ -73,6 +114,7 @@ async def run_grpo_stream(
     stream_idx: int,
     group_idx: int,
     args: argparse.Namespace,
+    record: Optional[Dict[str, Any]] = None,
 ) -> List[Dict[str, Any]]:
     """Runs a single GRPO stream as a multi-turn conversation.
 
@@ -85,15 +127,22 @@ async def run_grpo_stream(
         stream_idx: Index of the stream within the group.
         group_idx: Index of the group/request.
         args: Parsed command line arguments.
+        record: Dataset record backing this group, or None for random mode.
 
     Returns:
         List[Dict[str, Any]]: Statistics of each turn in the stream.
     """
-    num_turns = random.randint(args.turns_min, args.turns_max)
+    if record is not None:
+        num_turns = record["num_turns"]
+        system_prompt = record["system_prompt"]
+    else:
+        num_turns = random.randint(args.turns_min, args.turns_max)
+        system_prompt = "You are a helpful assistant."
+
     messages = [
         {
             "role": "system",
-            "content": "You are a helpful assistant."
+            "content": system_prompt
         },
         {
             "role": "user",
@@ -182,13 +231,9 @@ async def run_grpo_stream(
                 "success": True,
             }
 
-            # Simulate environment response of 10-100 tokens
-            env_len = random.randint(args.env_len_min, args.env_len_max)
-            env_token_ids = [
-                random.randint(1000, 50000) for _ in range(env_len)
-            ]
-            env_text = tokenizer.decode(env_token_ids,
-                                        skip_special_tokens=True)
+            # Simulate the environment's reply: real recorded tool output in
+            # dataset mode, otherwise 10-100 random tokens.
+            env_text = generate_env_response(tokenizer, args, record, turn)
 
             messages.append({"role": "user", "content": env_text})
             turn_stat["env_tokens"] = len(tokenizer.encode(env_text))
@@ -223,6 +268,7 @@ async def run_group(
     tokenizer: AutoTokenizer,
     group_idx: int,
     args: argparse.Namespace,
+    dataset: Optional[List[Dict[str, Any]]] = None,
 ) -> List[Dict[str, Any]]:
     """Runs a single GRPO group of G parallel streams.
 
@@ -233,13 +279,24 @@ async def run_group(
         tokenizer: Model tokenizer.
         group_idx: Index of this group.
         args: Parsed arguments.
+        dataset: Prepared multi-turn records, or None for random mode.
 
     Returns:
         List[Dict[str, Any]]: Accumulated stats of all streams in the group.
     """
-    initial_prompt = generate_initial_prompt(tokenizer, args)
+    if dataset is not None:
+        # One task instance per group, matching real RL where a group of
+        # rollouts shares a single task and therefore a single prefix.
+        record = dataset[(group_idx - 1) % len(dataset)]
+        initial_prompt = record["initial_prompt"]
+        label = f" [{record['instance_id']}]"
+    else:
+        record = None
+        initial_prompt = generate_initial_prompt(tokenizer, args)
+        label = ""
+
     initial_prompt_len = len(tokenizer.encode(initial_prompt))
-    print(f"Group {group_idx}: Starting {args.group_size} streams with "
+    print(f"Group {group_idx}{label}: Starting {args.group_size} streams with "
           f"shared initial prompt of {initial_prompt_len} tokens...")
 
     tasks = []
@@ -254,6 +311,7 @@ async def run_group(
                 stream_idx,
                 group_idx,
                 args,
+                record,
             ))
 
     results = await asyncio.gather(*tasks)
@@ -404,6 +462,14 @@ async def main_async(args: argparse.Namespace):
     tokenizer = AutoTokenizer.from_pretrained(args.model_path_or_id,
                                               trust_remote_code=True)
 
+    dataset = None
+    if args.dataset:
+        dataset = load_dataset(args.dataset)
+        print(
+            f"Loaded {len(dataset)} task instances from {args.dataset}. "
+            f"Prompt lengths and turn counts come from the dataset; "
+            f"--initial-prompt-len-*, --turns-* and --env-len-* are ignored.")
+
     url = f"http://{args.host}:{args.port}/v1/chat/completions"
     print(f"Connecting to vLLM server at {url}...")
 
@@ -427,7 +493,7 @@ async def main_async(args: argparse.Namespace):
     async def worker(group_idx: int, session: aiohttp.ClientSession):
         async with semaphore:
             return await run_group(session, url, args.model, tokenizer,
-                                   group_idx, args)
+                                   group_idx, args, dataset)
 
     start_time = time.perf_counter()
 
@@ -462,6 +528,14 @@ def main():
         type=str,
         default="Qwen/Qwen3-1.7B-base",
         help="Model name in OpenAI API requests.",
+    )
+    parser.add_argument(
+        "--dataset",
+        type=str,
+        default=None,
+        help="Prepared multi-turn JSONL from prepare_r2e_dataset.py. Drives "
+        "prompts and environment turns from real SWE task content instead of "
+        "random tokens. Omit for the original random-token workload.",
     )
     parser.add_argument("--host",
                         type=str,

--- a/scripts/vllm/benchmarking/agentic_benchmark/prepare_r2e_dataset.py
+++ b/scripts/vllm/benchmarking/agentic_benchmark/prepare_r2e_dataset.py
@@ -1,0 +1,510 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Builds a synthetic multi-turn dataset from R2E-Gym for benchmark_agentic.py.
+
+R2E-Gym ships SWE task definitions, not trajectories: every row has an empty
+`input` field, so there is nothing to replay. What each row does carry is real
+content -- a GitHub-issue style problem statement, the pre-fix source files, and
+the recorded stdout of the test suite before and after the fix.
+
+This script turns that content into a scripted multi-turn conversation per task:
+a realistic agent prompt, plus a fixed sequence of environment observations
+built from the recorded tool output. The model still generates every assistant
+turn live against the server, so the token distribution of the generated side is
+real; only the environment side is pre-baked. That is the point -- it exercises
+the serving stack under RL-shaped traffic without needing containers, test
+execution, or a reward loop.
+
+Usage:
+    python prepare_r2e_dataset.py \
+        --dataset hfilaretov/Benchmark-R2E-Gym-Easy \
+        --split val \
+        --model-path-or-id Qwen/Qwen3-4B \
+        --output r2e_easy_val.jsonl
+"""
+
+import argparse
+import json
+import os
+import random
+import sys
+from typing import Any, Dict, List, Optional
+
+from transformers import AutoTokenizer
+
+# Tool block mirroring the R2E-Gym agent scaffold. This is prompt ballast that
+# every real SWE rollout carries, so it belongs in the shared prefix.
+SYSTEM_PROMPT = """You are a programming agent who is provided a GitHub issue \
+and repository bash environment and is tasked to solve certain tasks (e.g., \
+file localization, testing, code repair, and editing) to resolve the issue.
+
+You have access to the following functions:
+
+---- BEGIN FUNCTION #1: file_editor ----
+Description: Custom editing tool for viewing, creating and editing files
+  *  State is persistent across command calls and discussions with the user
+  *  If `path` is a file, `view` displays the result of applying `cat -n`
+  *  The `create` command cannot be used if the specified `path` already exists
+  *  If a `command` generates a long output, it will be truncated
+  *  The `undo_edit` command will revert the last edit made to the file at `path`
+
+Parameters:
+  (1) command (string, required): The command to run. Allowed: `view`, `create`,
+      `str_replace`, `insert`, `undo_edit`.
+  (2) path (string, required): Absolute path to file or directory
+  (3) file_text (string, optional): Required for `create`
+  (4) old_str (string, optional): Required for `str_replace`
+  (5) new_str (string, optional): Replacement string
+  (6) insert_line (integer, optional): Required for `insert`
+  (7) view_range (array, optional): Line range to view
+---- END FUNCTION #1 ----
+
+---- BEGIN FUNCTION #2: execute_bash ----
+Description: Execute a bash command in the terminal.
+Parameters:
+  (1) cmd (string, required): The bash command to execute.
+---- END FUNCTION #2 ----
+
+---- BEGIN FUNCTION #3: search ----
+Description: Search for a term in a directory or a single file.
+Parameters:
+  (1) search_term (string, required): The term to search for.
+  (2) path (string, optional): The file or directory to search in.
+---- END FUNCTION #3 ----
+
+---- BEGIN FUNCTION #4: finish ----
+Description: Signals the completion of the current task.
+Parameters:
+  (1) command (string, required): The command to run: `submit`.
+---- END FUNCTION #4 ----
+
+Follow this format:
+<function=example_function_name>
+<parameter=example_parameter_1>value_1</parameter>
+</function>
+
+Your thinking should be thorough. Take the following steps:
+1. Explore the repository to familiarize yourself with its structure.
+2. Create a script to reproduce the issue and execute it.
+3. Edit the source code to resolve the issue.
+4. Rerun your reproduce script to confirm the fix.
+5. Consider edge cases and ensure your fix handles them.
+"""
+
+
+def load_rows(args: argparse.Namespace) -> List[Dict[str, Any]]:
+    """Loads raw R2E-Gym rows from a local JSONL file or the HF Hub.
+
+    Args:
+        args: Parsed command line arguments.
+
+    Returns:
+        List[Dict[str, Any]]: Raw dataset rows.
+    """
+    if args.input_jsonl:
+        with open(args.input_jsonl) as f:
+            return [json.loads(line) for line in f if line.strip()]
+
+    from huggingface_hub import hf_hub_download
+
+    split = "val" if args.split in ("val", "validation") else "train"
+    path = hf_hub_download(
+        repo_id=args.dataset,
+        filename=f"benchmark_r2e_gym_easy_{split}.jsonl",
+        repo_type="dataset",
+    )
+    with open(path) as f:
+        return [json.loads(line) for line in f if line.strip()]
+
+
+def source_files(instance: Dict[str, Any]) -> List[Dict[str, str]]:
+    """Extracts the pre-fix source files touched by an R2E-Gym instance.
+
+    Args:
+        instance: Decoded `instance_dict` for one task.
+
+    Returns:
+        List[Dict[str, str]]: File dicts with `path` and `content` keys.
+    """
+    try:
+        parsed = json.loads(instance["parsed_commit_content"])
+    except (KeyError, json.JSONDecodeError):
+        return []
+
+    files = []
+    for diff in parsed.get("file_diffs", []):
+        content = diff.get("old_file_content")
+        if not content:
+            continue
+        # `new_file_path` is unset in this dataset; the path lives on the diff
+        # header, with minus/plus as the a/ b/ prefixed fallbacks.
+        header = diff.get("header") or {}
+        path = (header.get("file") or {}).get("path")
+        if not path:
+            minus = diff.get("minus_file") or {}
+            path = (minus.get("path") or "").removeprefix("a/")
+        if path:
+            files.append({"path": path, "content": content})
+    return files
+
+
+def build_initial_prompt(
+    instance: Dict[str, Any],
+    tokenizer: AutoTokenizer,
+    target_tokens: int,
+) -> Optional[str]:
+    """Builds one realistic agent prompt padded to a target token length.
+
+    The problem statement alone is only ~250-700 tokens, far short of the 4k-16k
+    a real SWE rollout carries. Real agents reach that length by pulling repo
+    context into the prompt, so pad with the instance's own source files rather
+    than filler, then trim to the target.
+
+    Args:
+        instance: Decoded `instance_dict` for one task.
+        tokenizer: Tokenizer used to measure and trim the prompt.
+        target_tokens: Desired prompt length in tokens.
+
+    Returns:
+        Optional[str]: The prompt, or None if the instance has no usable source.
+    """
+    files = source_files(instance)
+    if not files:
+        return None
+
+    repo = instance.get("repo", "unknown/repo")
+    parts = [
+        f"I've uploaded a python code repository in the directory /testbed.\n"
+        f"Repository: {repo}\n\n"
+        f"Consider the following issue description:\n\n"
+        f"<issue_description>\n{instance.get('problem_statement', '')}\n"
+        f"</issue_description>\n\n"
+        f"Can you help me implement the necessary changes to the repository so "
+        f"that the requirements specified in the issue description are met?\n\n"
+        f"Here is the current state of the relevant files:\n"
+    ]
+
+    for f in files:
+        parts.append(f"\n<file path=\"/testbed/{f['path']}\">\n"
+                     f"{f['content']}\n</file>\n")
+
+    prompt = "".join(parts)
+    ids = tokenizer.encode(prompt)
+
+    # Repeat real repo context until the target is reached. Cycling the same
+    # files keeps the content real; a prompt that is short stays short rather
+    # than being padded with junk.
+    if len(ids) < target_tokens and files:
+        idx = 0
+        while len(ids) < target_tokens and idx < 200:
+            f = files[idx % len(files)]
+            prompt += (f"\n<file path=\"/testbed/{f['path']}\" "
+                       f"context_ref=\"{idx}\">\n{f['content']}\n</file>\n")
+            ids = tokenizer.encode(prompt)
+            idx += 1
+
+    if len(ids) > target_tokens:
+        prompt = tokenizer.decode(ids[:target_tokens],
+                                  skip_special_tokens=True)
+
+    return prompt
+
+
+# A real `file_editor view` returns a bounded line range and truncates beyond
+# it, so views stay roughly this size regardless of how large the file is.
+VIEW_LINES = 120
+MAX_VIEWS_PER_FILE = 4
+
+# Agent harnesses clip long command output before it reaches the model. Without
+# this, a recorded numpy run over 4k tests would feed back a single ~120k-token
+# observation -- far past anything a real rollout sees.
+MAX_BASH_OUTPUT_CHARS = 6000
+
+
+def clip_output(text: str) -> str:
+    """Clips command output the way an agent harness would.
+
+    Keeps the head and tail, which is where the run summary and the failure
+    report live, and drops the middle.
+
+    Args:
+        text: Raw recorded command output.
+
+    Returns:
+        str: Output clipped to roughly MAX_BASH_OUTPUT_CHARS.
+    """
+    if len(text) <= MAX_BASH_OUTPUT_CHARS:
+        return text
+    half = MAX_BASH_OUTPUT_CHARS // 2
+    omitted = len(text) - 2 * half
+    return (f"{text[:half]}\n\n<response clipped: {omitted} characters "
+            f"omitted>\n\n{text[-half:]}")
+
+
+def chunk_file(content: str) -> List[str]:
+    """Splits file content into view-sized chunks, as a real editor would.
+
+    Args:
+        content: Full file content.
+
+    Returns:
+        List[str]: Up to MAX_VIEWS_PER_FILE chunks of VIEW_LINES lines each,
+        rendered with line numbers like `cat -n`.
+    """
+    lines = content.splitlines()
+    if not lines:
+        return []
+
+    chunks = []
+    for start in range(0, len(lines), VIEW_LINES):
+        window = lines[start:start + VIEW_LINES]
+        body = "\n".join(f"{start + i + 1:6d}\t{line}"
+                         for i, line in enumerate(window))
+        remaining = len(lines) - (start + len(window))
+        if remaining > 0:
+            body += (f"\n<response clipped> {remaining} lines below. Use "
+                     f"`view_range` to see more.")
+        chunks.append(body)
+        if len(chunks) >= MAX_VIEWS_PER_FILE:
+            break
+    return chunks
+
+
+def build_env_turns(instance: Dict[str, Any], num_turns: int) -> List[str]:
+    """Builds a sequence of environment observations from recorded output.
+
+    Every observation is real recorded content: directory listings from the
+    instance's file list, file views from the pre-fix sources, and test output
+    captured from actual runs (failing before the fix, passing after). The
+    sequence follows the shape of a real SWE rollout -- explore, view, edit,
+    test, repeat -- and ends on the passing run.
+
+    Args:
+        instance: Decoded `instance_dict` for one task.
+        num_turns: Number of observations to emit.
+
+    Returns:
+        List[str]: One observation per turn.
+    """
+    files = source_files(instance)
+    try:
+        execution = json.loads(instance["execution_result_content"])
+    except (KeyError, json.JSONDecodeError):
+        execution = {}
+
+    failing = execution.get("old_commit_res_stdout", "")
+    passing = execution.get("new_commit_res_stdout", "")
+    setup = execution.get("setup_res_stderr", "")
+    modified = instance.get("modified_files") or []
+    if isinstance(modified, str):
+        modified = json.loads(modified.replace("'", '"'))
+
+    listing = "\n".join(f"/testbed/{p}" for p in modified) or "/testbed"
+    views = []
+    for f in files:
+        views.extend(chunk_file(f["content"]))
+    if not views:
+        views = ["(file is empty)"]
+
+    observations = []
+    for turn in range(num_turns):
+        # Cycle explore -> view -> edit -> test, the shape of a real rollout.
+        kind = turn % 4
+        if kind == 0:
+            observations.append(
+                f"Execution output of [execute_bash]:\n"
+                f"find /testbed -name '*.py' | head -50\n{listing}\n"
+                f"{setup[:600]}")
+        elif kind == 1:
+            observations.append("Execution output of [file_editor]:\n"
+                                f"{views[turn % len(views)]}")
+        elif kind == 2:
+            path = modified[0] if modified else "file.py"
+            observations.append(
+                f"Execution output of [file_editor]:\nThe file /testbed/{path} "
+                f"has been edited. Here's the result of running `cat -n` on a "
+                f"snippet:\n{views[(turn + 1) % len(views)][:800]}\n"
+                f"Review the changes and make sure they are correct.")
+        else:
+            # Real pytest output. Failing runs dominate a rollout; the last
+            # test turn lands on the recorded passing run.
+            is_last_test = turn >= num_turns - 2
+            out = passing if (is_last_test and passing) else failing
+            if not out:
+                out = passing or "(no test output recorded)"
+            observations.append(
+                f"Execution output of [execute_bash]:\n{clip_output(out)}")
+
+    return observations
+
+
+def main():
+    """Parses arguments and writes the converted dataset."""
+    parser = argparse.ArgumentParser(
+        description="Convert R2E-Gym task definitions into a synthetic "
+        "multi-turn dataset for benchmark_agentic.py.")
+    parser.add_argument(
+        "--dataset",
+        type=str,
+        default="hfilaretov/Benchmark-R2E-Gym-Easy",
+        help="Hugging Face dataset ID to download.",
+    )
+    parser.add_argument(
+        "--input-jsonl",
+        type=str,
+        default=None,
+        help="Local R2E-Gym JSONL to convert instead of downloading.",
+    )
+    parser.add_argument(
+        "--split",
+        type=str,
+        default="val",
+        choices=["train", "val", "validation"],
+        help="Dataset split to convert.",
+    )
+    parser.add_argument(
+        "--model-path-or-id",
+        type=str,
+        default="Qwen/Qwen3-4B",
+        help="Model path or HF ID for the tokenizer used to size prompts.",
+    )
+    parser.add_argument(
+        "--output",
+        type=str,
+        required=True,
+        help="Output JSONL path.",
+    )
+    parser.add_argument(
+        "--num-instances",
+        type=int,
+        default=None,
+        help="Convert only the first N instances.",
+    )
+    parser.add_argument(
+        "--initial-prompt-len-min",
+        type=int,
+        default=4000,
+        help="Minimum initial prompt length in tokens.",
+    )
+    parser.add_argument(
+        "--initial-prompt-len-max",
+        type=int,
+        default=16000,
+        help="Maximum initial prompt length in tokens.",
+    )
+    parser.add_argument(
+        "--turns-min",
+        type=int,
+        default=10,
+        help="Minimum conversation turns per instance.",
+    )
+    parser.add_argument(
+        "--turns-max",
+        type=int,
+        default=100,
+        help="Maximum conversation turns per instance.",
+    )
+    parser.add_argument(
+        "--env-len-max",
+        type=int,
+        default=0,
+        help="Truncate each environment observation to this many tokens. "
+        "0 keeps the real recorded length, which is what a real rollout "
+        "feeds back.",
+    )
+    parser.add_argument("--seed", type=int, default=42, help="Random seed.")
+    args = parser.parse_args()
+
+    rng = random.Random(args.seed)
+    print(f"Loading tokenizer from: {args.model_path_or_id}")
+    tokenizer = AutoTokenizer.from_pretrained(args.model_path_or_id,
+                                              trust_remote_code=True)
+
+    print("Loading R2E-Gym rows...")
+    rows = load_rows(args)
+    if args.num_instances:
+        rows = rows[:args.num_instances]
+    print(f"Converting {len(rows)} instances...")
+
+    written = 0
+    skipped = 0
+    prompt_lens = []
+    env_lens = []
+
+    with open(args.output, "w") as out:
+        for i, row in enumerate(rows):
+            params = row.get("responses_create_params", {})
+            metadata = params.get("metadata", {})
+
+            if params.get("input"):
+                # Nothing in this dataset has one, but if a future revision
+                # ships real trajectories, do not silently overwrite them.
+                print(f"  [{i}] has a real trajectory; converter would "
+                      f"discard it. Skipping.")
+                skipped += 1
+                continue
+
+            try:
+                instance = json.loads(metadata["instance_dict"])
+            except (KeyError, json.JSONDecodeError):
+                skipped += 1
+                continue
+
+            target = rng.randint(args.initial_prompt_len_min,
+                                 args.initial_prompt_len_max)
+            prompt = build_initial_prompt(instance, tokenizer, target)
+            if prompt is None:
+                skipped += 1
+                continue
+
+            num_turns = rng.randint(args.turns_min, args.turns_max)
+            env_turns = build_env_turns(instance, num_turns)
+
+            if args.env_len_max:
+                trimmed = []
+                for text in env_turns:
+                    ids = tokenizer.encode(text)
+                    if len(ids) > args.env_len_max:
+                        text = tokenizer.decode(ids[:args.env_len_max],
+                                                skip_special_tokens=True)
+                    trimmed.append(text)
+                env_turns = trimmed
+
+            prompt_tokens = len(tokenizer.encode(prompt))
+            prompt_lens.append(prompt_tokens)
+            env_lens.extend(len(tokenizer.encode(t)) for t in env_turns)
+
+            out.write(
+                json.dumps({
+                    "instance_id": instance.get("instance_id"),
+                    "repo": instance.get("repo"),
+                    "system_prompt": SYSTEM_PROMPT,
+                    "initial_prompt": prompt,
+                    "initial_prompt_tokens": prompt_tokens,
+                    "num_turns": num_turns,
+                    "env_turns": env_turns,
+                }) + "\n")
+            written += 1
+
+            if written % 25 == 0:
+                print(f"  converted {written}/{len(rows)}")
+
+    if not written:
+        print("No instances converted.", file=sys.stderr)
+        sys.exit(1)
+
+    def pct(values: List[int], p: float) -> int:
+        return sorted(values)[min(len(values) - 1, int(len(values) * p))]
+
+    size_mb = os.path.getsize(args.output) / (1024 * 1024)
+    print(f"\nWrote {written} instances ({skipped} skipped) to {args.output} "
+          f"({size_mb:.1f} MB)")
+    print(f"  initial prompt tokens: min {min(prompt_lens)} "
+          f"p50 {pct(prompt_lens, 0.5)} max {max(prompt_lens)}")
+    print(f"  env observation tokens: min {min(env_lens)} "
+          f"p50 {pct(env_lens, 0.5)} p99 {pct(env_lens, 0.99)} "
+          f"max {max(env_lens)}")
+    print(f"  total env observations: {len(env_lens)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/vllm/benchmarking/agentic_benchmark/prepare_r2e_dataset.py
+++ b/scripts/vllm/benchmarking/agentic_benchmark/prepare_r2e_dataset.py
@@ -24,6 +24,7 @@ Usage:
 
 import argparse
 import json
+import math
 import os
 import random
 import sys
@@ -212,12 +213,19 @@ def build_initial_prompt(
 # A real `file_editor view` returns a bounded line range and truncates beyond
 # it, so views stay roughly this size regardless of how large the file is.
 VIEW_LINES = 120
-MAX_VIEWS_PER_FILE = 4
+# An instance only carries so much real content, so distinct observations are
+# capped by what its files hold. Chunking further up each file raises that
+# ceiling and keeps long conversations from looping over a couple of views.
+MAX_VIEWS_PER_FILE = 16
 
 # Agent harnesses clip long command output before it reaches the model. Without
 # this, a recorded numpy run over 4k tests would feed back a single ~120k-token
 # observation -- far past anything a real rollout sees.
 MAX_BASH_OUTPUT_CHARS = 6000
+
+# Spread of the skewed turn-count draw; tuned so the default 10-100 range gives
+# p50 20, p90 55, mean ~28, with ~3% of instances reaching the cap.
+TURNS_SKEW_SIGMA = 1.174
 
 
 def clip_output(text: str) -> str:
@@ -269,6 +277,35 @@ def chunk_file(content: str) -> List[str]:
     return chunks
 
 
+def sample_turns(rng: random.Random, args: argparse.Namespace) -> int:
+    """Samples a turn count for one task instance.
+
+    R2E-Gym carries no trajectories, so it says nothing about how many turns a
+    real rollout takes -- any distribution here is an assumption, not data. A
+    uniform draw over 10-100 (mean ~53) is the flat default, but real SWE agent
+    rollouts are right-skewed: most resolve in 10-30 turns with a long tail up
+    to the cap. Because history is re-prefilled every turn, the choice moves
+    average prefill per turn a lot, so it is exposed as a flag.
+
+    The skewed draw is an offset log-normal whose median sits one ninth into
+    the range (20 turns for the default 10-100), with p90 ~55.
+
+    Args:
+        rng: Seeded RNG.
+        args: Parsed command line arguments.
+
+    Returns:
+        int: Turn count clamped to [turns_min, turns_max].
+    """
+    if args.turns_dist == "uniform":
+        return rng.randint(args.turns_min, args.turns_max)
+
+    span = max(1.0, (args.turns_max - args.turns_min) / 9.0)
+    value = args.turns_min + rng.lognormvariate(math.log(span),
+                                                TURNS_SKEW_SIGMA)
+    return int(min(args.turns_max, max(args.turns_min, round(value))))
+
+
 def build_env_turns(instance: Dict[str, Any], num_turns: int) -> List[str]:
     """Builds a sequence of environment observations from recorded output.
 
@@ -306,6 +343,9 @@ def build_env_turns(instance: Dict[str, Any], num_turns: int) -> List[str]:
         views = ["(file is empty)"]
 
     observations = []
+    # Walk the view chunks with their own counter. Indexing them by `turn`
+    # would stride by 4 and revisit the same two chunks forever.
+    view_idx = 0
     for turn in range(num_turns):
         # Cycle explore -> view -> edit -> test, the shape of a real rollout.
         kind = turn % 4
@@ -316,14 +356,16 @@ def build_env_turns(instance: Dict[str, Any], num_turns: int) -> List[str]:
                 f"{setup[:600]}")
         elif kind == 1:
             observations.append("Execution output of [file_editor]:\n"
-                                f"{views[turn % len(views)]}")
+                                f"{views[view_idx % len(views)]}")
+            view_idx += 1
         elif kind == 2:
             path = modified[0] if modified else "file.py"
             observations.append(
                 f"Execution output of [file_editor]:\nThe file /testbed/{path} "
                 f"has been edited. Here's the result of running `cat -n` on a "
-                f"snippet:\n{views[(turn + 1) % len(views)][:800]}\n"
+                f"snippet:\n{views[view_idx % len(views)][:800]}\n"
                 f"Review the changes and make sure they are correct.")
+            view_idx += 1
         else:
             # Real pytest output. Failing runs dominate a rollout; the last
             # test turn lands on the recorded passing run.
@@ -392,6 +434,16 @@ def main():
         help="Maximum initial prompt length in tokens.",
     )
     parser.add_argument(
+        "--turns-dist",
+        type=str,
+        default="skewed",
+        choices=["skewed", "uniform"],
+        help="Turn-count distribution. `skewed` (default) is right-skewed "
+        "(p50 20, p90 55) like real SWE rollouts; `uniform` draws flat over "
+        "[turns-min, turns-max] (mean ~53). R2E-Gym has no trajectories, so "
+        "neither is measured from the data.",
+    )
+    parser.add_argument(
         "--turns-min",
         type=int,
         default=10,
@@ -429,6 +481,8 @@ def main():
     skipped = 0
     prompt_lens = []
     env_lens = []
+    turn_counts = []
+    distinct_obs = []
 
     with open(args.output, "w") as out:
         for i, row in enumerate(rows):
@@ -456,7 +510,7 @@ def main():
                 skipped += 1
                 continue
 
-            num_turns = rng.randint(args.turns_min, args.turns_max)
+            num_turns = sample_turns(rng, args)
             env_turns = build_env_turns(instance, num_turns)
 
             if args.env_len_max:
@@ -472,6 +526,11 @@ def main():
             prompt_tokens = len(tokenizer.encode(prompt))
             prompt_lens.append(prompt_tokens)
             env_lens.extend(len(tokenizer.encode(t)) for t in env_turns)
+            turn_counts.append(num_turns)
+            # An instance holds a bounded amount of real content, so a long
+            # conversation necessarily reuses observations. Report it rather
+            # than let it pass as more variety than there is.
+            distinct_obs.append(len(set(env_turns)))
 
             out.write(
                 json.dumps({
@@ -503,6 +562,13 @@ def main():
     print(f"  env observation tokens: min {min(env_lens)} "
           f"p50 {pct(env_lens, 0.5)} p99 {pct(env_lens, 0.99)} "
           f"max {max(env_lens)}")
+    print(f"  turns per instance ({args.turns_dist}): min {min(turn_counts)} "
+          f"p50 {pct(turn_counts, 0.5)} p90 {pct(turn_counts, 0.9)} "
+          f"max {max(turn_counts)} "
+          f"mean {sum(turn_counts) / len(turn_counts):.1f}")
+    print(f"  distinct observations per instance: min {min(distinct_obs)} "
+          f"mean {sum(distinct_obs) / len(distinct_obs):.1f} "
+          f"max {max(distinct_obs)}")
     print(f"  total env observations: {len(env_lens)}")
 
 


### PR DESCRIPTION
# Description

Follow-up to #3195. That benchmark builds its prompts and environment replies from random token IDs — which fixes token counts, but the content is meaningless and real RL traffic doesn't look like it.

This adds `prepare_r2e_dataset.py`, converting [R2E-Gym](https://github.com/R2E-Gym/R2E-Gym) SWE tasks (via `hfilaretov/Benchmark-R2E-Gym-Easy`) into a scripted multi-turn dataset, plus a `--dataset` flag on `benchmark_agentic.py` to consume it. **Without the flag, behavior is unchanged.**

## Why a conversion step

R2E-Gym ships **task definitions, not trajectories** — every row's `input` is empty, so there's nothing to replay. But each row carries real content: an issue-style problem statement, the pre-fix sources, and recorded test stdout from before and after the fix. The converter assembles those into an agent prompt plus a sequence of environment observations.

Running the real environment instead means per-task containers, test execution, and a reward loop (NVIDIA reports ~20 min/training step, ~1 CPU core per instance) — that measures the harness, not the serving stack. Here the model still generates **every assistant turn live**, so the generated token distribution is real; only the environment side is pre-baked.

## Measured distributions

Over **all 977 instances** (721 train + 256 val), Qwen3-4B tokenizer, 0 skipped:

| Metric | min | p50 | p90 | p99 | max |
| --- | --- | --- | --- | --- | --- |
| Initial prompt tokens (val) | 4,158 | 10,537 | — | — | 15,977 |
| Initial prompt tokens (train) | 4,072 | 10,184 | — | — | 15,985 |
| Env observation tokens (val) | 21 | 398 | — | 2,813 | 4,269 |
| Env observation tokens (train) | 39 | 398 | — | 2,749 | 4,265 |
| Turns per instance (val) | 10 | 20 | 55 | — | 100 |
| Turns per instance (train) | 10 | 19 | 54 | — | 100 |

The headline: real observations (pytest output, file views, tracebacks) are **p50 ~398 tokens** against the `10-20` the random-mode examples use — roughly 20-40x more prefill per turn, since each is prefilled on the next turn. Prompts also share a genuine long prefix (system prompt + repo context) rather than random tokens, which is what prefix caching sees in production.

One task instance backs one GRPO group, matching real RL where a group of rollouts shares a task and therefore a prefix.

## Two things reviewers should push on

**Turn counts are an assumption, not data.** R2E-Gym has no trajectories, so it carries no ground truth for rollout length. Default is now an offset log-normal (p50 20, p90 55, mean ~28), right-skewed like real SWE agent behavior; `--turns-dist uniform` restores the flat 10-100 draw (mean ~53) that #3195 implies. Since history is re-prefilled every turn, this choice materially moves average prefill per turn — worth A/B-ing.

**Observation reuse is bounded by the source data.** One instance holds a handful of source files and two recorded test runs, so a long conversation *must* reuse observations (mean ~13 distinct against mean ~28 turns). The converter reports this rather than letting it pass as more variety than exists.

Command output is clipped head-and-tail the way an agent harness clips it. Without that, a recorded numpy run over 4k tests feeds back a single ~120k-token observation — past anything a real rollout sees.

# Tests

- Converted **both splits in full** — 977/977 instances, 0 skipped; distributions above, and the two splits agree closely.
- Ran `benchmark_agentic.py --dataset` against a mock OpenAI-compatible SSE server: 276/276 turns succeeded across 256 loaded instances, prefix cache hits registered, and the server received the real agent system prompt, real issue text, and real tool output with the conversation growing per turn.
- Ran without `--dataset` to confirm the random-token path is unchanged.
- **Not yet run against a real vLLM TPU server** — only the mock. Worth a sanity run before merge.

# Checklist

Before submitting this PR, please make sure:
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have made or will make corresponding changes to any relevant documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
