### PR TITLE
clean up x_q_dtype in sharded_quantized_matmul

### DIFF
--- a/tpu_inference/layers/common/linear.py
+++ b/tpu_inference/layers/common/linear.py
@@ -90,19 +90,6 @@ def xla_quantized_matmul(
     return out.astype(x.dtype)
 
 
-def _get_x_q_dtype(w_q_dtype: jnp.dtype) -> jnp.dtype:
-    """Return 8-bit float or integer dtype depending on w_q_dtype."""
-    if jnp.issubdtype(w_q_dtype, jnp.integer):
-        return jnp.int8
-    elif jnp.issubdtype(w_q_dtype, jnp.floating):
-        return jnp.float8_e4m3fn
-    # TODO: we need a new flag for 4bit activation later such as w4a4.
-    else:
-        raise ValueError(
-            f"Unsupported quantized dtype: {w_q_dtype}, it should be integer or float"
-        )
-
-
 def sharded_matmul(x: jax.Array,
                    w: jax.Array,
                    weight_sharding: P | NamedSharding,
@@ -147,7 +134,6 @@ def sharded_quantized_matmul(x: jax.Array,
                              weight_sharding: P | NamedSharding,
                              *,
                              mesh: Mesh | None = None,
-                             x_q_dtype: jnp.dtype | None = None,
                              defer_all_reduce: bool = False) -> jax.Array:
     """
     Wrapper around the quantized matmul kernel.
@@ -158,7 +144,6 @@ def sharded_quantized_matmul(x: jax.Array,
         w_s: Weight quantization scale. [n_output_features] for xla quantized matmul, [n_blocks, 1, n_output_features] for quantized matmul kernel
         weight_sharding: PartitionSpec or NamedSharding for the weight tensor.
         mesh: (Optional) Mesh to shard on. If None, mesh from current context is used, similar to jax.shard_map().
-        x_q_dtype: (Optional) Quantized dtype for the activation. If None, inferred from w_q dtype (int -> int8, float -> float8).
         defer_all_reduce: (Optional) If True, defer the all-reduce (psum) over
             the contracting (in) axis: it is not performed here even when that
             axis is sharded. The output then holds per-shard partial sums; the
@@ -200,8 +185,6 @@ def sharded_quantized_matmul(x: jax.Array,
             scale_sharding = P(out_axis, )
     out_sharding = P(ShardingAxisName.ATTN_DATA, out_axis)
 
-    if x_q_dtype is None:
-        x_q_dtype = _get_x_q_dtype(w_q.dtype)
     x = jax.lax.with_sharding_constraint(
         x,
         NamedSharding(mesh, x_sharding) if mesh else x_sharding)

--- a/tpu_inference/layers/vllm/quantization/compressed_tensors/schemes/compressed_tensors_w4a8_fp8.py
+++ b/tpu_inference/layers/vllm/quantization/compressed_tensors/schemes/compressed_tensors_w4a8_fp8.py
@@ -246,7 +246,6 @@ class VllmCompressedTensorsW4A8Fp8(CompressedTensorsW4A8Fp8):
             weight_scale_jax,
             self.linear_config.weight_sharding,
             mesh=self.linear_config.mesh,
-            x_q_dtype=jnp.float8_e4m3fn,
             defer_all_reduce=self.linear_config.defer_all_reduce)
 
         if bias is not None and not layer.skip_bias_add:
@@ -272,8 +271,6 @@ class VllmCompressedTensorsW4A8Fp8(CompressedTensorsW4A8Fp8):
                 weight_scale_jax,
                 self.linear_config.weight_sharding,
                 mesh=self.linear_config.mesh,
-                x_q_dtype=jnp.float8_e4m3fn,
-                acc_dtype=jnp.float32,
                 defer_all_reduce=self.linear_config.defer_all_reduce,
             )
 


### PR DESCRIPTION
# Description
Remove `x_q_dtype` argument from `sharded_quantized_matmul` because it has no effect on actual matmul computation. The argument created a wrong illusion of caller being able to directly control quantization of activation when calling this function

# Tests

Relevant unit tests passed

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
