### PR TITLE
Optional block-diffusion (masked-diffusion) decode path

### DIFF
--- a/tests/layers/common/test_use_causal_mask_plumbing.py
+++ b/tests/layers/common/test_use_causal_mask_plumbing.py
@@ -1,0 +1,247 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Verifies that ``use_causal_mask`` is threaded through the attention stack.
+
+Actually executing the ragged-paged-attention (RPA) kernel requires a TPU
+(the Pallas kernel does not run on CPU), so these tests do NOT invoke the
+kernel. Instead they assert the flag is correctly threaded through every layer
+of the attention stack:
+
+  * declared as a parameter on the public entry points, and
+  * forwarded into the next call in the chain.
+
+The core checks parse the source with ``ast`` and therefore run on CPU without
+importing the heavy (TPU-only) dependency graph. An additional
+``inspect.signature`` check imports the real modules when possible and is
+skipped otherwise (e.g. when the TPU/vLLM deps are unavailable on CPU).
+"""
+
+import ast
+import inspect
+import pathlib
+
+import pytest
+
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
+_ATTENTION_INTERFACE = (_REPO_ROOT / "tpu_inference" / "layers" / "common" /
+                        "attention_interface.py")
+_JAX_ATTENTION = (_REPO_ROOT / "tpu_inference" / "layers" / "jax" /
+                  "attention" / "attention.py")
+_ATTENTION_METADATA = (_REPO_ROOT / "tpu_inference" / "layers" / "common" /
+                       "attention_metadata.py")
+_QWEN3 = (_REPO_ROOT / "tpu_inference" / "models" / "jax" / "qwen3.py")
+_TPU_RUNNER = (_REPO_ROOT / "tpu_inference" / "runner" / "tpu_runner.py")
+
+
+def _parse(path: pathlib.Path) -> ast.Module:
+    return ast.parse(path.read_text())
+
+
+def _find_function(module: ast.Module, name: str) -> ast.FunctionDef:
+    """Find a top-level function by name."""
+    for node in module.body:
+        if isinstance(node, ast.FunctionDef) and node.name == name:
+            return node
+    raise AssertionError(f"function {name!r} not found")
+
+
+def _find_method(module: ast.Module, cls_name: str,
+                 method_name: str) -> ast.FunctionDef:
+    """Find a method by name inside a named class."""
+    for node in module.body:
+        if isinstance(node, ast.ClassDef) and node.name == cls_name:
+            for sub in node.body:
+                if (isinstance(sub, ast.FunctionDef)
+                        and sub.name == method_name):
+                    return sub
+    raise AssertionError(f"method {cls_name}.{method_name!r} not found")
+
+
+def _param_names(func: ast.FunctionDef) -> set[str]:
+    a = func.args
+    names = set()
+    for arg in (*a.posonlyargs, *a.args, *a.kwonlyargs):
+        names.add(arg.arg)
+    if a.vararg:
+        names.add(a.vararg.arg)
+    if a.kwarg:
+        names.add(a.kwarg.arg)
+    return names
+
+
+def _has_default_true(func: ast.FunctionDef, param: str) -> bool:
+    """Return True if ``param`` has a literal default of True."""
+    a = func.args
+    # kwonlyargs pair 1:1 with kw_defaults (None => no default).
+    for arg, default in zip(a.kwonlyargs, a.kw_defaults):
+        if arg.arg == param and default is not None:
+            return isinstance(default, ast.Constant) and default.value is True
+    # positional/pos-only args: defaults align with the tail of the arg list.
+    pos = [*a.posonlyargs, *a.args]
+    defaults = a.defaults
+    if defaults:
+        tail = pos[len(pos) - len(defaults):]
+        for arg, default in zip(tail, defaults):
+            if arg.arg == param:
+                return (isinstance(default, ast.Constant)
+                        and default.value is True)
+    return False
+
+
+class TestUseCausalMaskPlumbing:
+    """AST-level checks (CPU-safe, no imports of the TPU dependency graph)."""
+
+    def test_sharded_rpa_declares_and_forwards_flag(self):
+        module = _parse(_ATTENTION_INTERFACE)
+        func = _find_function(module, "sharded_ragged_paged_attention")
+
+        # Declared as a parameter defaulting to True.
+        assert "use_causal_mask" in _param_names(func)
+        assert _has_default_true(func, "use_causal_mask")
+
+        # Forwarded into the kernel-call kwargs (v3 default / batched path).
+        src = ast.get_source_segment(_ATTENTION_INTERFACE.read_text(), func)
+        assert 'kwargs["use_causal_mask"] = use_causal_mask' in src
+
+    def test_attention_declares_and_forwards_flag(self):
+        module = _parse(_ATTENTION_INTERFACE)
+        func = _find_function(module, "attention")
+
+        assert "use_causal_mask" in _param_names(func)
+        assert _has_default_true(func, "use_causal_mask")
+
+        # Forwarded into the sharded_ragged_paged_attention call.
+        src = ast.get_source_segment(_ATTENTION_INTERFACE.read_text(), func)
+        assert "use_causal_mask=use_causal_mask" in src
+
+    def test_jax_attention_method_declares_and_forwards_flag(self):
+        module = _parse(_JAX_ATTENTION)
+        method = _find_method(module, "Attention", "attention")
+
+        assert "use_causal_mask" in _param_names(method)
+        assert _has_default_true(method, "use_causal_mask")
+
+        # Forwarded into the ragged_paged_attention kernel call.
+        src = ast.get_source_segment(_JAX_ATTENTION.read_text(), method)
+        assert "use_causal_mask=use_causal_mask" in src
+
+    def test_attention_metadata_declares_static_meta_field(self):
+        # The flag rides on AttentionMetadata as a STATIC meta_field (not a data
+        # leaf), so it threads through model.__call__ unchanged and True/False
+        # compile as separate programs.
+        text = _ATTENTION_METADATA.read_text()
+        module = ast.parse(text)
+        fields = set()
+        for node in module.body:
+            if isinstance(node,
+                          ast.ClassDef) and node.name == "AttentionMetadata":
+                for sub in node.body:
+                    if isinstance(sub, ast.AnnAssign) and isinstance(
+                            sub.target, ast.Name):
+                        fields.add(sub.target.id)
+        assert "use_causal_mask" in fields, "must be a dataclass field"
+        meta = text.split("meta_fields=")[1].split("]")[0]
+        assert '"use_causal_mask"' in meta, "must be a register_dataclass meta_field"
+
+    def test_qwen3_attention_forwards_flag_from_metadata(self):
+        module = _parse(_QWEN3)
+        method = _find_method(module, "Qwen3Attention", "__call__")
+        src = ast.get_source_segment(_QWEN3.read_text(), method)
+        assert "use_causal_mask=attention_metadata.use_causal_mask" in src, (
+            "Qwen3Attention.__call__ must forward the metadata flag into attention()"
+        )
+
+    def test_runner_requests_bidirectional_for_diffusion_canvas(self):
+        # The block-diffusion canvas forward must request bidirectional attention.
+        assert "use_causal_mask=False" in _TPU_RUNNER.read_text(), (
+            "the diffusion forward_fn must set use_causal_mask=False on the canvas"
+        )
+
+
+class TestUseCausalMaskMetaFieldRuntime:
+    """Runtime pytree behaviour of the meta_field (jax-only, CPU-safe).
+
+    Loads ``attention_metadata.py`` by file path so it does not import the
+    (TPU/vLLM-only) ``tpu_inference`` package ``__init__``. Skipped if jax or the
+    standalone module load is unavailable on this host.
+    """
+
+    def test_meta_field_is_static_and_defaults_true(self):
+        try:
+            import importlib.util
+            from dataclasses import replace
+
+            import jax
+            import jax.numpy as jnp
+        except Exception as exc:  # pragma: no cover - depends on host deps
+            pytest.skip(f"jax unavailable on this host: {exc}")
+
+        spec = importlib.util.spec_from_file_location("_am_ucm",
+                                                      str(_ATTENTION_METADATA))
+        am = importlib.util.module_from_spec(spec)
+        try:
+            spec.loader.exec_module(am)
+        except Exception as exc:  # pragma: no cover
+            pytest.skip(f"attention_metadata not loadable standalone: {exc}")
+
+        def mk(use_causal_mask=True):
+            return am.AttentionMetadata(
+                input_positions=jnp.arange(4, dtype=jnp.int32),
+                block_tables=jnp.zeros((4, ), jnp.int32),
+                seq_lens=jnp.ones((2, ), jnp.int32),
+                query_start_loc=jnp.array([0, 4], jnp.int32),
+                request_distribution=jnp.zeros((3, ), jnp.int32),
+                padded_num_reqs=2,
+                use_causal_mask=use_causal_mask,
+            )
+
+        # AR default is unchanged.
+        assert mk().use_causal_mask is True
+        # Static -> not a data leaf.
+        leaves, td_true = jax.tree_util.tree_flatten(mk(True))
+        assert all(not isinstance(leaf, bool) for leaf in leaves)
+        # True vs False -> distinct treedefs -> separate compiled programs.
+        _, td_false = jax.tree_util.tree_flatten(mk(False))
+        assert td_true != td_false
+        # The runner's replace() path flips it.
+        assert replace(mk(), use_causal_mask=False).use_causal_mask is False
+
+
+class TestUseCausalMaskSignatureImport:
+    """Import-based signature check.
+
+    This imports the real modules and inspects live signatures. It is skipped
+    when the modules cannot be imported on this host (the attention stack pulls
+    in TPU/Pallas and vLLM dependencies that are not always present on CPU).
+    """
+
+    def test_live_signatures_expose_flag(self):
+        try:
+            from tpu_inference.layers.common import attention_interface
+            from tpu_inference.layers.jax.attention import \
+                attention as jax_attention
+        except Exception as exc:  # pragma: no cover - depends on host deps
+            pytest.skip(
+                f"attention modules not importable on this host: {exc}")
+
+        for fn in (attention_interface.attention,
+                   attention_interface.sharded_ragged_paged_attention):
+            params = inspect.signature(fn).parameters
+            assert "use_causal_mask" in params
+            assert params["use_causal_mask"].default is True
+
+        method_params = inspect.signature(
+            jax_attention.Attention.attention).parameters
+        assert "use_causal_mask" in method_params
+        assert method_params["use_causal_mask"].default is True

--- a/tests/layers/jax/sample/test_diffusion_commit.py
+++ b/tests/layers/jax/sample/test_diffusion_commit.py
@@ -1,0 +1,148 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import jax.numpy as jnp
+import numpy as np
+
+from tpu_inference.layers.jax.sample.sampling import diffusion_commit
+
+
+class TestDiffusionCommit:
+    """Unit tests for the block-diffusion threshold-commit sampler.
+
+    All cases run on CPU (pure JAX, no TPU kernels involved).
+    """
+
+    def test_threshold_and_progress_and_untouched(self):
+        # Two rows, 3 positions, vocab size 4.
+        # Row 0:
+        #   pos0: peaked on token 2 -> top_prob ~0.9999 (> threshold), masked.
+        #   pos1: mild on token 1  -> top_prob ~0.475 (< threshold), masked.
+        #   pos2: peaked on token 0 -> top_prob ~0.980 but ALREADY committed
+        #         (mask False) -> must stay committed and never be re-selected.
+        # Row 1 (progress guarantee): nothing exceeds the threshold, so only
+        #   the single highest-confidence masked position (pos1) may commit.
+        logits = jnp.array(
+            [
+                [[0.0, 0.0, 10.0, 0.0], [0.0, 1.0, 0.0, 0.0],
+                 [5.0, 0.0, 0.0, 0.0]],
+                [[0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 2.0, 0.0],
+                 [0.5, 0.0, 0.0, 0.0]],
+            ],
+            dtype=jnp.float32,
+        )
+        mask = jnp.array([[True, True, False], [True, True, True]])
+
+        tokens, new_mask = diffusion_commit(logits,
+                                            mask,
+                                            threshold=0.9,
+                                            temperature=0.0)
+        tokens = np.array(tokens)
+        new_mask = np.array(new_mask)
+
+        # ---- Threshold commit correctness (row 0) ----
+        # pos0 exceeds threshold and is masked -> commits (mask flips to False).
+        assert new_mask[0, 0] == False  # noqa: E712
+        # pos1 is below threshold and is not the forced position -> stays masked.
+        assert new_mask[0, 1] == True  # noqa: E712
+        # Committed token at pos0 is the argmax (token 2).
+        assert tokens[0, 0] == 2
+
+        # ---- Already-committed positions are untouched (row 0, pos2) ----
+        # pos2 started committed (mask False); it stays committed and, despite
+        # having a high top_prob, is never re-selected as the forced position.
+        assert new_mask[0, 2] == False  # noqa: E712
+        # Exactly one position newly commits in row 0 (only pos0).
+        newly_committed_row0 = mask[0] & ~jnp.asarray(new_mask[0])
+        assert int(np.array(newly_committed_row0).sum()) == 1
+
+        # ---- Progress guarantee (row 1) ----
+        # No position exceeds the threshold, yet exactly one commits: the
+        # highest-confidence masked position, which is pos1 (top_prob ~0.711).
+        assert new_mask[1, 0] == True  # noqa: E712
+        assert new_mask[1, 1] == False  # noqa: E712
+        assert new_mask[1, 2] == True  # noqa: E712
+        assert tokens[1, 1] == 2
+        newly_committed_row1 = mask[1] & ~jnp.asarray(new_mask[1])
+        assert int(np.array(newly_committed_row1).sum()) == 1
+
+    def test_new_mask_is_subset_of_old_mask(self):
+        # The returned mask must only ever clear bits, never set them.
+        logits = jnp.array(
+            [[[0.0, 0.0, 3.0, 0.0], [1.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 4.0]]
+             ],
+            dtype=jnp.float32,
+        )
+        mask = jnp.array([[True, True, True]])
+        _, new_mask = diffusion_commit(logits, mask, threshold=0.5)
+        new_mask = np.array(new_mask)
+        old_mask = np.array(mask)
+        # new_mask implies old_mask everywhere (strict subset of True entries).
+        assert np.all(~new_mask | old_mask)
+        # At least one position committed (progress guarantee).
+        assert int(new_mask.sum()) < int(old_mask.sum())
+
+    def test_fully_committed_row_forces_nothing(self):
+        # A row with no masked positions must be left entirely untouched: the
+        # progress guarantee must NOT force a commit when nothing is masked.
+        logits = jnp.array([[[0.0, 0.0, 10.0, 0.0], [10.0, 0.0, 0.0, 0.0]]],
+                           dtype=jnp.float32)
+        mask = jnp.array([[False, False]])
+        _, new_mask = diffusion_commit(logits, mask, threshold=0.9)
+        new_mask = np.array(new_mask)
+        assert new_mask[0, 0] == False  # noqa: E712
+        assert new_mask[0, 1] == False  # noqa: E712
+
+    def test_temperature_affects_threshold_commits(self):
+        # Single row, two masked positions, threshold 0.9.
+        #   posA: logits favor token 2, plain top_prob ~0.711.
+        #   posB: logits favor token 1, plain top_prob ~0.870.
+        logits = jnp.array([[[0.0, 0.0, 2.0, 0.0], [0.0, 3.0, 0.0, 0.0]]],
+                           dtype=jnp.float32)
+        mask = jnp.array([[True, True]])
+
+        # temperature=0.0 (raw logits): neither exceeds 0.9, so only the forced
+        # (highest-confidence) position, posB, commits.
+        _, nm_plain = diffusion_commit(logits,
+                                       mask,
+                                       threshold=0.9,
+                                       temperature=0.0)
+        nm_plain = np.array(nm_plain)
+        assert nm_plain[0, 0] == True  # posA still masked  # noqa: E712
+        assert nm_plain[0, 1] == False  # posB forced-committed  # noqa: E712
+        committed_plain = int((np.array(mask)[0] & ~nm_plain[0]).sum())
+        assert committed_plain == 1
+
+        # temperature=0.5 sharpens (divide by 0.5 == multiply logits by 2), so
+        # BOTH positions now exceed 0.9 and commit via the threshold path.
+        _, nm_sharp = diffusion_commit(logits,
+                                       mask,
+                                       threshold=0.9,
+                                       temperature=0.5)
+        nm_sharp = np.array(nm_sharp)
+        committed_sharp = int((np.array(mask)[0] & ~nm_sharp[0]).sum())
+        assert committed_sharp == 2
+
+    def test_accepts_2d_single_row(self):
+        # A bare (L, V) input (single implicit row) is supported.
+        logits = jnp.array([[0.0, 0.0, 5.0, 0.0], [0.0, 1.0, 0.0, 0.0]],
+                           dtype=jnp.float32)
+        mask = jnp.array([True, True])
+        tokens, new_mask = diffusion_commit(logits, mask, threshold=0.9)
+        tokens = np.array(tokens)
+        new_mask = np.array(new_mask)
+        # pos0 is peaked -> commits; pos1 mild and not forced -> stays masked.
+        assert new_mask[0] == False  # noqa: E712
+        assert new_mask[1] == True  # noqa: E712
+        assert tokens[0] == 2

--- a/tests/runner/test_diffusion_config_knobs.py
+++ b/tests/runner/test_diffusion_config_knobs.py
@@ -1,0 +1,81 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Checks the block-diffusion config knobs are parsed from additional_config.
+
+``TPUModelRunner`` cannot be instantiated on CPU (it needs a TPU mesh and the
+full vLLM config), so this test parses ``tpu_runner.py`` with ``ast`` and
+asserts each knob is read from ``additional_config.get(<key>, <default>)`` with
+the correct key and default. This runs on CPU with no heavy imports.
+"""
+
+import ast
+import pathlib
+
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+_TPU_RUNNER = _REPO_ROOT / "tpu_inference" / "runner" / "tpu_runner.py"
+
+# attr name -> (config key, expected default)
+_EXPECTED = {
+    "enable_diffusion_decode": ("enable_diffusion_decode", False),
+    "diffusion_block_size": ("diffusion_block_size", 32),
+    "diffusion_commit_threshold": ("diffusion_commit_threshold", 0.9),
+    "diffusion_max_denoise_steps": ("diffusion_max_denoise_steps", 0),
+}
+
+
+def _collect_config_assignments() -> dict:
+    """Map ``self.<attr>`` -> (key, default) for additional_config.get calls."""
+    module = ast.parse(_TPU_RUNNER.read_text())
+    found = {}
+    for node in ast.walk(module):
+        if not isinstance(node, ast.Assign):
+            continue
+        # Target must be exactly `self.<attr>`.
+        if len(node.targets) != 1:
+            continue
+        target = node.targets[0]
+        if not (isinstance(target, ast.Attribute) and isinstance(
+                target.value, ast.Name) and target.value.id == "self"):
+            continue
+        # Value must be a call to `...additional_config.get(<key>, <default>)`.
+        call = node.value
+        if not (isinstance(call, ast.Call) and isinstance(
+                call.func, ast.Attribute) and call.func.attr == "get"
+                and isinstance(call.func.value, ast.Attribute)
+                and call.func.value.attr == "additional_config"):
+            continue
+        if len(call.args) != 2:
+            continue
+        key_node, default_node = call.args
+        if not (isinstance(key_node, ast.Constant)
+                and isinstance(default_node, ast.Constant)):
+            continue
+        found[target.attr] = (key_node.value, default_node.value)
+    return found
+
+
+class TestDiffusionConfigKnobs:
+
+    def test_all_knobs_parsed_with_correct_keys_and_defaults(self):
+        found = _collect_config_assignments()
+        for attr, (key, default) in _EXPECTED.items():
+            assert attr in found, f"self.{attr} not assigned from additional_config"
+            got_key, got_default = found[attr]
+            assert got_key == key, (f"self.{attr} reads key {got_key!r}, "
+                                    f"expected {key!r}")
+            # Compare by type and value so False vs 0 and 0 vs 0.9 don't alias.
+            same_type = type(got_default) is type(default)
+            assert same_type and got_default == default, (
+                f"self.{attr} default is {got_default!r}, expected {default!r}"
+            )

--- a/tests/runner/test_diffusion_decode.py
+++ b/tests/runner/test_diffusion_decode.py
@@ -1,0 +1,388 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""CPU unit tests for the block-diffusion denoising decode loop.
+
+The whole seed -> forward -> shifted-logit -> threshold-commit -> advance loop
+is exercised end-to-end on CPU with a *stub* ``forward_fn`` that returns
+deterministic, position-addressed logits. No TPU, real model, RPA kernel, or
+paged KV cache is involved (those pieces are marked TPU-required and covered by
+AST/inspection checks instead).
+
+The behavioral tests use the REAL ``diffusion_commit`` (the foundation's
+threshold-commit sampler). On a full-dependency host they import
+``tpu_inference.runner.diffusion_decode`` directly; on a minimal ``jax[cpu]``
+venv (no vllm / heavy tpu_inference deps) they fall back to loading the
+pure-logic module standalone with the real ``diffusion_commit`` extracted from
+source, so the loop still runs for real on CPU.
+"""
+
+import ast
+import pathlib
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+_TPU_RUNNER = _REPO_ROOT / "tpu_inference" / "runner" / "tpu_runner.py"
+_DIFFUSION_DECODE = (_REPO_ROOT / "tpu_inference" / "runner" /
+                     "diffusion_decode.py")
+_SAMPLING = (_REPO_ROOT / "tpu_inference" / "layers" / "jax" / "sample" /
+             "sampling.py")
+
+
+def _load_diffusion_decode_standalone():
+    """Load diffusion_decode.py without the heavy tpu_inference import chain.
+
+    Extracts the REAL ``diffusion_commit`` from ``sampling.py`` source (it is
+    pure jax/jnp) and injects a stub ``sampling`` module so the standalone load
+    of ``diffusion_decode.py`` binds the real commit function.
+    """
+    import importlib.util
+    import sys
+    import types
+
+    # 1. Extract + exec the real diffusion_commit (pure jax/jnp, no deps).
+    mod_ast = ast.parse(_SAMPLING.read_text())
+    fn = next(
+        n for n in mod_ast.body
+        if isinstance(n, ast.FunctionDef) and n.name == "diffusion_commit")
+    ns = {"jax": jax, "jnp": jnp}
+    exec(  # noqa: S102 - executing our own repo source under test
+        compile(ast.Module(body=[fn], type_ignores=[]), str(_SAMPLING),
+                "exec"), ns)
+
+    # 2. Inject stub parent packages + a sampling module exposing the real fn.
+    for pkg in ("tpu_inference", "tpu_inference.layers",
+                "tpu_inference.layers.jax", "tpu_inference.layers.jax.sample"):
+        if pkg not in sys.modules:
+            m = types.ModuleType(pkg)
+            m.__path__ = []  # mark as package
+            sys.modules[pkg] = m
+    samp = types.ModuleType("tpu_inference.layers.jax.sample.sampling")
+    samp.diffusion_commit = ns["diffusion_commit"]
+    sys.modules["tpu_inference.layers.jax.sample.sampling"] = samp
+
+    # 3. Load diffusion_decode.py standalone; its top-level import resolves to
+    #    the stub sampling module above.
+    spec = importlib.util.spec_from_file_location(
+        "diffusion_decode_under_test", _DIFFUSION_DECODE)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+try:
+    from tpu_inference.runner.diffusion_decode import (  # noqa: F401
+        DiffusionDecodeResult, denoise_block, diffusion_decode)
+except Exception:  # pragma: no cover - minimal CPU venv path
+    _dd = _load_diffusion_decode_standalone()
+    DiffusionDecodeResult = _dd.DiffusionDecodeResult
+    denoise_block = _dd.denoise_block
+    diffusion_decode = _dd.diffusion_decode
+
+# ---- Test constants ---------------------------------------------------------
+VOCAB = 16
+MASK_ID = 15  # out of the normal token range so leaks are detectable
+EOS_ID = 14  # never produced by the normal position->token map below
+
+
+def _target_array(n: int) -> np.ndarray:
+    """Deterministic absolute-position -> token map in [0, VOCAB-3]."""
+    return np.array([p % (VOCAB - 2) for p in range(n)], dtype=np.int32)
+
+
+def _make_stub_forward(global_target: np.ndarray, logit_scale: float):
+    """A pure-JAX stub forward_fn addressed by ABSOLUTE position.
+
+    ``full_logits[j]`` peaks on ``global_target[positions[j]]`` with confidence
+    controlled by ``logit_scale`` (large -> commits via threshold in one step;
+    small -> below threshold so only the forced-argmax position commits).
+    The stub ignores the canvas so the per-position argmax is stable, which lets
+    the tests assert exact committed values.
+    """
+    g = jnp.asarray(global_target)
+
+    def forward_fn(canvas, positions, kv_caches):
+        target = g[positions]
+        logits = jax.nn.one_hot(target, VOCAB, dtype=jnp.float32) * logit_scale
+        return logits, kv_caches
+
+    return forward_fn
+
+
+class TestDenoiseBlock:
+    """Direct on-device single-block tests (a, b, c + step-cap cleanup)."""
+
+    def test_a_block_fully_commits_in_one_step_high_confidence(self):
+        block_size = 4
+        prefix = 10
+        g = _target_array(256)
+        fwd = _make_stub_forward(g, logit_scale=30.0)
+        positions = jnp.arange(block_size, dtype=jnp.int32) + prefix
+
+        canvas, next_seed, steps, _ = denoise_block(
+            fwd,
+            jnp.array(7, dtype=jnp.int32),
+            positions,
+            None,
+            block_size=block_size,
+            mask_id=MASK_ID,
+            threshold=0.9,
+            temperature=0.0,
+            max_denoise_steps=block_size,
+        )
+        canvas = np.asarray(canvas)
+        # High confidence -> everything commits via threshold in a single step.
+        assert int(steps) == 1
+        # No masked positions leak into the output.
+        assert not np.any(canvas == MASK_ID)
+
+    def test_b_forced_argmax_guarantees_one_commit_per_step(self):
+        block_size = 4
+        prefix = 3
+        g = _target_array(256)
+        # Below-threshold confidence: only the forced (highest-confidence
+        # masked) position commits each iteration -> one commit per step.
+        fwd = _make_stub_forward(g, logit_scale=0.05)
+        positions = jnp.arange(block_size, dtype=jnp.int32) + prefix
+
+        canvas, _, steps, _ = denoise_block(
+            fwd,
+            jnp.array(1, dtype=jnp.int32),
+            positions,
+            None,
+            block_size=block_size,
+            mask_id=MASK_ID,
+            threshold=0.9,
+            temperature=0.0,
+            max_denoise_steps=block_size,
+        )
+        canvas = np.asarray(canvas)
+        # 3 initially-masked positions, one commit per step -> exactly 3 steps.
+        assert int(steps) == block_size - 1
+        assert not np.any(canvas == MASK_ID)
+
+    def test_c_shifted_logit_indexing_is_i_from_i_minus_1(self):
+        block_size = 4
+        prefix = 10
+        seed = 7
+        g = _target_array(256)
+        fwd = _make_stub_forward(g, logit_scale=30.0)
+        positions = jnp.arange(block_size, dtype=jnp.int32) + prefix
+
+        canvas, next_seed, _, _ = denoise_block(
+            fwd,
+            jnp.array(seed, dtype=jnp.int32),
+            positions,
+            None,
+            block_size=block_size,
+            mask_id=MASK_ID,
+            threshold=0.9,
+            temperature=0.0,
+            max_denoise_steps=block_size,
+        )
+        canvas = np.asarray(canvas)
+        # Position 0 is the given seed (committed, never overwritten).
+        assert int(canvas[0]) == seed
+        # Shifted convention: canvas[i] is predicted from hidden i-1, i.e.
+        # equals the stub target at ABSOLUTE position (prefix + i - 1).
+        assert int(canvas[1]) == int(g[prefix + 0])
+        assert int(canvas[2]) == int(g[prefix + 1])
+        assert int(canvas[3]) == int(g[prefix + 2])
+        # Next block's seed = argmax of the last (unshifted) position's logits
+        # = target at the final absolute position.
+        assert int(next_seed) == int(g[prefix + block_size - 1])
+
+    def test_step_cap_forces_fill_no_mask_leak(self):
+        # Cap denoise steps below what full commitment needs; the post-loop
+        # force-fill must still leave no mask_id in the canvas.
+        block_size = 4
+        prefix = 20
+        g = _target_array(256)
+        fwd = _make_stub_forward(g, logit_scale=0.05)
+        positions = jnp.arange(block_size, dtype=jnp.int32) + prefix
+
+        canvas, _, steps, _ = denoise_block(
+            fwd,
+            jnp.array(2, dtype=jnp.int32),
+            positions,
+            None,
+            block_size=block_size,
+            mask_id=MASK_ID,
+            threshold=0.9,
+            temperature=0.0,
+            max_denoise_steps=1,  # far fewer than the 3 needed
+        )
+        canvas = np.asarray(canvas)
+        assert int(steps) == 1
+        assert not np.any(canvas == MASK_ID)
+        # Force-filled values still follow the shifted convention.
+        assert int(canvas[1]) == int(g[prefix + 0])
+        assert int(canvas[2]) == int(g[prefix + 1])
+        assert int(canvas[3]) == int(g[prefix + 2])
+
+
+class TestDiffusionDecodeMultiBlock:
+    """Host-side multi-block progression tests (d + truncation + EOS)."""
+
+    def test_d_multi_block_seeds_next_block_first_token(self):
+        block_size = 4
+        prefix = 5
+        first_token = 9
+        max_tokens = 10
+        g = _target_array(256)
+        fwd = _make_stub_forward(g, logit_scale=30.0)
+
+        res = diffusion_decode(
+            fwd,
+            first_token=first_token,
+            prefix_len=prefix,
+            kv_caches=None,
+            block_size=block_size,
+            mask_id=MASK_ID,
+            max_tokens=max_tokens,
+            threshold=0.9,
+            temperature=0.0,
+            max_denoise_steps=0,  # -> block_size
+            eos_token_id=(),
+        )
+        tokens = res.tokens
+        assert len(tokens) == max_tokens
+        # Multiple blocks were needed (block_size=4, max_tokens=10 -> 3 blocks).
+        assert res.num_blocks == 3
+        # The stream is fully contiguous across block boundaries: token 0 is the
+        # seed, and every subsequent token follows the shifted convention
+        # token[k] == g[prefix + k - 1]. Contiguity AT k == block_size proves the
+        # next block was seeded with the previous block's next_seed.
+        assert tokens[0] == first_token
+        for k in range(1, len(tokens)):
+            assert tokens[k] == int(g[prefix + k - 1]), f"mismatch at {k}"
+        # Explicit boundary check: block 2's first token (index block_size).
+        assert tokens[block_size] == int(g[prefix + block_size - 1])
+        assert res.hit_eos is False
+
+    def test_max_tokens_truncation(self):
+        block_size = 4
+        g = _target_array(256)
+        fwd = _make_stub_forward(g, logit_scale=30.0)
+        for max_tokens in (1, 3, 5, 7):
+            res = diffusion_decode(
+                fwd,
+                first_token=8,
+                prefix_len=2,
+                kv_caches=None,
+                block_size=block_size,
+                mask_id=MASK_ID,
+                max_tokens=max_tokens,
+                eos_token_id=(),
+            )
+            assert len(res.tokens) == max_tokens
+
+    def test_eos_truncates_stream_inclusive(self):
+        block_size = 4
+        prefix = 2
+        first_token = 8
+        g = _target_array(256)
+        # Plant an EOS at a known absolute position; it surfaces at stream index
+        # k where (prefix + k - 1) == that position.
+        eos_pos = prefix + 5
+        g[eos_pos] = EOS_ID
+        fwd = _make_stub_forward(g, logit_scale=30.0)
+
+        res = diffusion_decode(
+            fwd,
+            first_token=first_token,
+            prefix_len=prefix,
+            kv_caches=None,
+            block_size=block_size,
+            mask_id=MASK_ID,
+            max_tokens=100,
+            eos_token_id=(EOS_ID, ),
+        )
+        assert res.hit_eos is True
+        # EOS at stream index 6 (k with prefix + k - 1 == prefix + 5 -> k = 6).
+        assert res.tokens[-1] == EOS_ID
+        assert len(res.tokens) == 7
+        assert EOS_ID not in res.tokens[:-1]
+
+    def test_disabled_is_noop_zero_tokens(self):
+        # max_tokens == 0 -> the loop never runs (the runner-level gate keeps the
+        # whole path off when enable_diffusion_decode is False; see AST tests).
+        g = _target_array(64)
+        fwd = _make_stub_forward(g, logit_scale=30.0)
+        res = diffusion_decode(
+            fwd,
+            first_token=3,
+            prefix_len=0,
+            kv_caches=None,
+            block_size=4,
+            mask_id=MASK_ID,
+            max_tokens=0,
+            eos_token_id=(),
+        )
+        assert res.tokens == []
+        assert res.num_blocks == 0
+
+
+class TestOnDeviceLoopStructure:
+    """AST checks that the denoise loop is on-device and reuses the foundation."""
+
+    def test_denoise_uses_lax_while_loop(self):
+        src = _DIFFUSION_DECODE.read_text()
+        assert "jax.lax.while_loop" in src
+
+    def test_reuses_diffusion_commit(self):
+        src = _DIFFUSION_DECODE.read_text()
+        assert ("from tpu_inference.layers.jax.sample.sampling import "
+                "diffusion_commit") in src
+        assert "diffusion_commit(" in src
+
+
+class TestRunnerDispatchGating:
+    """AST checks for the gated runner dispatch (path is a no-op when off)."""
+
+    def _runner_ast(self):
+        return ast.parse(_TPU_RUNNER.read_text())
+
+    def _find_method(self, module, cls, name):
+        for node in module.body:
+            if isinstance(node, ast.ClassDef):
+                for sub in ast.walk(node):
+                    if isinstance(sub, ast.FunctionDef) and sub.name == name:
+                        return sub
+        return None
+
+    def test_execute_model_has_gated_diffusion_branch(self):
+        src = _TPU_RUNNER.read_text()
+        # Gated exactly on the (default-False) enable_diffusion_decode flag, so
+        # AR decode is untouched unless the flag is explicitly enabled.
+        assert "is_decode_only and self.enable_diffusion_decode" in src
+        assert ("return self._execute_diffusion_decode(scheduler_output)"
+                in src)
+
+    def test_execute_diffusion_decode_method_exists(self):
+        module = self._runner_ast()
+        method = self._find_method(module, "TPUModelRunner",
+                                   "_execute_diffusion_decode")
+        assert method is not None, "_execute_diffusion_decode not defined"
+
+    def test_mask_id_not_hardcoded_to_151665(self):
+        # The Fast_dLLM_Qwen release uses 151669; 151665 is the wrong constant.
+        src = _TPU_RUNNER.read_text()
+        assert "151665" not in src
+        # mask id is read from config, not hardcoded.
+        method = self._find_method(self._runner_ast(), "TPUModelRunner",
+                                   "_get_diffusion_mask_id")
+        assert method is not None, "_get_diffusion_mask_id not defined"

--- a/tpu_inference/core/sched/utils.py
+++ b/tpu_inference/core/sched/utils.py
@@ -57,12 +57,23 @@ def patch_vllm_scheduler_for_continue_decode():
             original_init(scheduler_self, vllm_config, *args, **kwargs)
 
             additional_config = getattr(vllm_config, "additional_config", {})
-            max_decode_steps = additional_config.get("max_decode_steps",
-                                                     DEFAULT_MAX_DECODE_STEPS)
-            # Reserve max_decode_steps - 1 lookahead tokens so KVCacheManager allocates
-            # sufficient blocks for up to max_decode_steps tokens before execution on TPU.
-            scheduler_self.num_lookahead_tokens = max(
-                scheduler_self.num_lookahead_tokens, max_decode_steps - 1)
+            if additional_config.get("enable_continue_decode", False):
+                max_decode_steps = additional_config.get(
+                    "max_decode_steps", DEFAULT_MAX_DECODE_STEPS)
+                # Reserve max_decode_steps - 1 lookahead tokens so KVCacheManager
+                # allocates sufficient blocks for up to max_decode_steps tokens
+                # before execution on TPU.
+                scheduler_self.num_lookahead_tokens = max(
+                    scheduler_self.num_lookahead_tokens, max_decode_steps - 1)
+            if additional_config.get("enable_diffusion_decode", False):
+                # Block-diffusion generates the WHOLE completion in ONE decode step
+                # (up to diffusion_max_new_tokens), so the scheduler must reserve
+                # that many KV pages ahead -- not just one block -- or the one-shot
+                # block chain overflows the request's allocated slots.
+                diffusion_budget = additional_config.get(
+                    "diffusion_max_new_tokens", 256)
+                scheduler_self.num_lookahead_tokens = max(
+                    scheduler_self.num_lookahead_tokens, diffusion_budget)
 
         Scheduler.__init__ = patched_init
 

--- a/tpu_inference/layers/common/attention_interface.py
+++ b/tpu_inference/layers/common/attention_interface.py
@@ -440,6 +440,14 @@ def sharded_ragged_paged_attention(
             "update_kv_cache=False (KV-share) is not supported on the "
             "head_dim==64 RPA kernel.")
 
+    # use_causal_mask=False (bidirectional attention, used by block-diffusion
+    # denoising) is accepted by the v3 default and batched RPA kernels but not
+    # by the hd64 path; fail loud rather than silently attending causally.
+    if use_hd64 and not use_causal_mask:
+        raise NotImplementedError(
+            "use_causal_mask=False (bidirectional attention) is not supported "
+            "on the head_dim==64 RPA kernel.")
+
     def _ragged_paged_attention(*args):
         kwargs = dict(
             sm_scale=sm_scale,
@@ -448,9 +456,10 @@ def sharded_ragged_paged_attention(
             k_scale=k_scale,
             v_scale=v_scale,
         )
-        # update_kv_cache is supported by both the v3 default and batched
-        # RPA kernels; only the hd64 path doesn't accept it. Default True
-        # is a no-op so we don't forward it to the hd64 signature.
+        # update_kv_cache and use_causal_mask are supported by both the v3
+        # default and batched RPA kernels; only the hd64 path doesn't accept
+        # them. Their defaults (True) are a no-op so we don't forward them to
+        # the hd64 signature.
         if not use_hd64:
             kwargs["update_kv_cache"] = update_kv_cache
             kwargs["use_causal_mask"] = use_causal_mask

--- a/tpu_inference/layers/common/attention_metadata.py
+++ b/tpu_inference/layers/common/attention_metadata.py
@@ -28,7 +28,7 @@ import jax
         "request_distribution",
         "mamba_state_indices",
     ],
-    meta_fields=["padded_num_reqs"],
+    meta_fields=["padded_num_reqs", "use_causal_mask"],
 )
 @dataclass
 class AttentionMetadata(object):
@@ -58,6 +58,12 @@ class AttentionMetadata(object):
     # power of 2 between min and max requests.
     # Env var ATTN_CUSTOM_NUM_REQS_BUCKETS can manually override the buckets.
     padded_num_reqs: int = -1
+
+    # Static (meta) flag: when False the attention kernel runs FULLY bidirectional
+    # instead of causal, so block-diffusion decode attends over the whole canvas.
+    # A meta_field (not a data leaf) so True/False compile as separate programs and
+    # the default True leaves every existing (autoregressive) call path unchanged.
+    use_causal_mask: bool = True
 
 
 @functools.partial(

--- a/tpu_inference/layers/jax/attention/attention.py
+++ b/tpu_inference/layers/jax/attention/attention.py
@@ -198,6 +198,7 @@ class Attention(nnx.Module):
         q_scale: float | None = None,
         k_scale: float | None = None,
         v_scale: float | None = None,
+        use_causal_mask: bool = True,
     ) -> Tuple[KVCache, jax.Array]:
         """Performs scaled dot-product attention and updates the KV cache.
 
@@ -218,6 +219,9 @@ class Attention(nnx.Module):
             q_scale: Quantization scale for q.
             k_scale: Quantization scale for k.
             v_scale: Quantization scale for v.
+            use_causal_mask: If True (default), apply a causal mask. Set to
+                False to request bidirectional attention (e.g. for
+                block-diffusion denoising).
 
         Returns:
             A tuple containing:
@@ -247,6 +251,7 @@ class Attention(nnx.Module):
                 q_scale=q_scale,
                 k_scale=k_scale,
                 v_scale=v_scale,
+                use_causal_mask=use_causal_mask,
             )
 
         output_TNH, kv_cache = jax.jit(

--- a/tpu_inference/layers/jax/sample/sampling.py
+++ b/tpu_inference/layers/jax/sample/sampling.py
@@ -147,6 +147,72 @@ def sample(
     return next_tokens, ret_logits
 
 
+def diffusion_commit(
+    logits: jax.Array,
+    mask: jax.Array,
+    threshold: float,
+    temperature: float = 0.0,
+) -> tuple[jax.Array, jax.Array]:
+    """Per-position, threshold-based commit step for block-diffusion decode.
+
+    Given per-position vocab logits and a boolean mask marking the positions
+    that are still "masked" (i.e. not yet committed), greedily commit the
+    positions whose top-1 probability exceeds ``threshold``. To guarantee
+    forward progress, the single highest-confidence still-masked position in
+    each row is always committed even if it is below ``threshold`` (unless the
+    row has no masked positions left).
+
+    Args:
+        logits: (..., L, V) float logits, where ``L`` is the number of
+            positions per row and ``V`` is the vocab size. Any number of
+            leading batch/row dims is supported (e.g. (B, L, V) or (L, V)).
+        mask: (..., L) boolean array; ``True`` marks positions that are still
+            masked and therefore eligible to be committed this step.
+        threshold: scalar confidence threshold in [0, 1]. A masked position
+            commits when its top-1 softmax probability is strictly greater than
+            this value.
+        temperature: optional softmax temperature. When ``> 0`` the logits are
+            divided by it before the softmax (sharpening for ``< 1``, flattening
+            for ``> 1``); when ``0`` (default) the raw logits are used.
+
+    Returns:
+        A tuple ``(committed_token_ids, new_mask)`` where:
+            - ``committed_token_ids``: (..., L) int32 array holding the argmax
+              (top-1) token id for every position. Values at positions that
+              commit this step (``mask & ~new_mask``) are the tokens to write;
+              values at still-masked positions should be ignored by the caller.
+            - ``new_mask``: (..., L) boolean array equal to ``mask`` with the
+              newly-committed positions cleared (a strictly shrinking mask).
+    """
+    if temperature > 0.0:
+        logits = logits / temperature
+    probs = jax.nn.softmax(logits.astype(jnp.float32), axis=-1)
+
+    # Top-1 probability and token id per position -> (..., L).
+    top_prob = jnp.max(probs, axis=-1)
+    top_tok = jnp.argmax(probs, axis=-1).astype(jnp.int32)
+
+    mask_bool = mask.astype(bool)
+
+    # Threshold commit: only masked positions confident enough are committed.
+    commit = (top_prob > threshold) & mask_bool
+
+    # Progress guarantee: force the single highest-confidence still-masked
+    # position in each row to commit. Non-masked positions are excluded from
+    # the argmax so an already-committed position can never be re-selected, and
+    # rows with no masked positions left force nothing.
+    neg_inf = jnp.array(-jnp.inf, dtype=top_prob.dtype)
+    masked_conf = jnp.where(mask_bool, top_prob, neg_inf)
+    forced_idx = jnp.argmax(masked_conf, axis=-1)
+    row_has_mask = jnp.any(mask_bool, axis=-1)
+    forced_onehot = jax.nn.one_hot(forced_idx, mask_bool.shape[-1], dtype=bool)
+    forced_onehot = forced_onehot & jnp.expand_dims(row_has_mask, axis=-1)
+    commit = commit | forced_onehot
+
+    new_mask = mask_bool & (~commit)
+    return top_tok, new_mask
+
+
 def compute_logprobs(logits: jax.Array) -> jax.Array:
     return jax.nn.log_softmax(logits, axis=-1)
 

--- a/tpu_inference/models/jax/qwen3.py
+++ b/tpu_inference/models/jax/qwen3.py
@@ -203,6 +203,7 @@ class Qwen3Attention(JaxModule):
             q_scale=q_scale,
             k_scale=k_scale,
             v_scale=v_scale,
+            use_causal_mask=attention_metadata.use_causal_mask,
         )
         # (T, D)
         o = self.o_proj(outputs)

--- a/tpu_inference/platforms/tpu_platform.py
+++ b/tpu_inference/platforms/tpu_platform.py
@@ -368,6 +368,14 @@ class TpuPlatform(Platform):
 
         enable_continue_decode = vllm_config.additional_config.get(
             "enable_continue_decode", False)
+        # Block-diffusion decode ALSO emits multiple tokens (a whole denoised
+        # block) per decode step, so it needs the SAME multi-step scheduler
+        # handling as continue_decode: the async scheduler's num_output_
+        # placeholders bookkeeping assumes 1 token/step and asserts otherwise,
+        # and the sync scheduler needs num_computed_tokens bumped by the block.
+        enable_diffusion_decode = vllm_config.additional_config.get(
+            "enable_diffusion_decode", False)
+        multi_step_decode = enable_continue_decode or enable_diffusion_decode
         is_pooling_model = vllm_config.model_config.runner_type == "pooling"
 
         # Late initialization to avoid circular import.
@@ -375,14 +383,21 @@ class TpuPlatform(Platform):
             update_vllm_config_for_dp_scheduler
         update_vllm_config_for_dp_scheduler(vllm_config)
 
-        if enable_continue_decode:
+        if multi_step_decode:
+            mode = ("continue_decode"
+                    if enable_continue_decode else "diffusion_decode")
             if parallel_config.pipeline_parallel_size > 1:
                 raise ValueError(
-                    "continue_decode is not supported with pipeline parallelism"
-                )
+                    f"{mode} is not supported with pipeline parallelism")
             if is_pooling_model:
+                raise ValueError(f"{mode} is not supported for pooling models")
+            if enable_diffusion_decode and \
+                    vllm_config.scheduler_config.async_scheduling:
+                # Block-diffusion emits a whole block per decode step; async
+                # multi-step scheduling for it is untested, so require it OFF
+                # (the serving entrypoint sets async_scheduling=False).
                 raise ValueError(
-                    "continue_decode is not supported for pooling models")
+                    "diffusion_decode is not supported with async scheduling")
 
             from tpu_inference.core.sched.utils import \
                 patch_vllm_scheduler_for_continue_decode

--- a/tpu_inference/runner/diffusion_decode.py
+++ b/tpu_inference/runner/diffusion_decode.py
@@ -1,0 +1,285 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Block-diffusion denoising decode loop (Fast_dLLM / Diffusion-GR2).
+
+This implements a *standalone* block-diffusion decode path that is fully gated
+behind ``enable_diffusion_decode`` (see ``tpu_runner.py``); the existing
+autoregressive (AR) decode path is unchanged when the flag is off.
+
+Reference semantics (SGLang / HF ``Fast_dLLM``):
+
+  * A *canvas* of ``block_size`` positions is seeded with the first AR token at
+    index 0 and ``mask_id`` everywhere else.
+  * Each denoise iteration forwards the model over the canvas, attending to the
+    cached prompt prefix + canvas *bidirectionally* (``use_causal_mask=False``),
+    then commits the high-confidence positions (plus one forced-argmax position
+    to guarantee progress) via
+    :func:`tpu_inference.layers.jax.sample.sampling.diffusion_commit`.
+  * Logits use the *shifted* convention: the token at canvas position ``i`` is
+    predicted from hidden ``i-1`` (clamped ``>= 0``), matching the AR next-token
+    training objective.
+  * Iterate until the block is fully committed or ``max_denoise_steps`` is
+    reached, then advance to the next block whose first token is the argmax of
+    the *last* committed position (i.e. the model's next-token prediction from
+    the final canvas hidden state).
+
+Loop design
+-----------
+The **inner** denoise iterations for a single block run as an on-device
+``jax.lax.while_loop`` (see :func:`denoise_block`) — mirroring
+``runner.decode_loop.continue_decode`` — so the per-iteration model forward +
+threshold commit do not each incur a separate Pathways dispatch. The **outer**
+block-advancement loop (:func:`diffusion_decode`) runs host-side because block
+count is inherently dynamic (bounded by ``max_tokens`` / EOS) and each block is
+a separate fused on-device program invocation, exactly like how the runner calls
+``continue_decode`` once per scheduler step.
+
+Model coupling is via an injected ``forward_fn`` (dependency injection) so the
+whole seed -> forward -> shift -> commit -> advance loop is exercisable on CPU
+with a stub, without the real model, RPA kernel, or paged KV cache:
+
+    forward_fn(canvas_tokens, canvas_positions, kv_caches)
+        -> (full_logits, kv_caches)
+
+where ``canvas_tokens`` is ``(block_size,) int32``, ``canvas_positions`` is the
+matching ``(block_size,) int32`` absolute positions, ``full_logits`` is the
+*unshifted* per-position logits ``(block_size, vocab)``, and ``kv_caches`` is an
+opaque pytree threaded through the loop (may be ``None`` for the stub/tests).
+"""
+
+import functools
+from dataclasses import dataclass
+from typing import Any, Callable, List, Tuple
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from tpu_inference.layers.jax.sample.sampling import diffusion_commit
+
+# forward_fn(canvas_tokens, canvas_positions, kv_caches) -> (full_logits, kv_caches)
+ForwardFn = Callable[[jax.Array, jax.Array, Any], Tuple[jax.Array, Any]]
+
+
+@dataclass
+class DiffusionDecodeResult:
+    """Result of a host-side block-diffusion decode run for one request."""
+    # Flat generated token stream. ``tokens[0]`` == the seeding ``first_token``;
+    # the remainder are the denoised / block-chained tokens in emission order.
+    tokens: List[int]
+    # Number of blocks actually denoised.
+    num_blocks: int
+    # Denoise iterations used per block (len == num_blocks).
+    steps_per_block: List[int]
+    # The next block's seed token (argmax of the last committed position of the
+    # final block); useful if the caller wants to continue decoding.
+    next_seed: int
+    # Threaded KV caches (unchanged pytree structure; ``None`` for the stub).
+    kv_caches: Any
+    # True if an EOS token was committed (decode stopped early).
+    hit_eos: bool
+
+
+def _shifted_logit_indices(block_size: int) -> jax.Array:
+    """Indices implementing the shifted-logit convention.
+
+    ``shifted[i] = full_logits[max(i - 1, 0)]`` so the token at canvas position
+    ``i`` is predicted from hidden ``i-1`` (clamped ``>= 0`` for position 0).
+    """
+    return jnp.maximum(jnp.arange(block_size, dtype=jnp.int32) - 1, 0)
+
+
+@functools.partial(
+    jax.jit,
+    static_argnames=(
+        "forward_fn",
+        "block_size",
+        "mask_id",
+        "threshold",
+        "temperature",
+        "max_denoise_steps",
+    ),
+)
+def denoise_block(
+    forward_fn: ForwardFn,
+    seed_token: jax.Array,
+    positions: jax.Array,
+    kv_caches: Any = None,
+    *,
+    block_size: int,
+    mask_id: int,
+    threshold: float,
+    temperature: float,
+    max_denoise_steps: int,
+) -> Tuple[jax.Array, jax.Array, jax.Array, Any]:
+    """Denoise a single block on-device via ``jax.lax.while_loop``.
+
+    Args:
+        forward_fn: Injected model forward. See module docstring for signature.
+        seed_token: Scalar int token placed at canvas index 0 (already committed).
+        positions: ``(block_size,)`` int32 absolute positions for the canvas.
+        kv_caches: Opaque KV-cache pytree threaded through the loop (may be None).
+        block_size: Canvas length (static).
+        mask_id: Token id used to mark not-yet-committed positions (static).
+        threshold: Confidence threshold forwarded to ``diffusion_commit``.
+        temperature: Softmax temperature forwarded to ``diffusion_commit``.
+        max_denoise_steps: Static upper bound on denoise iterations.
+
+    Returns:
+        ``(canvas, next_seed, steps_used, kv_caches)`` where ``canvas`` is the
+        fully-committed ``(block_size,)`` int32 block (index 0 == ``seed_token``),
+        ``next_seed`` is the scalar argmax of the last committed position, and
+        ``steps_used`` is the scalar iteration count.
+    """
+    shift_idx = _shifted_logit_indices(block_size)
+
+    canvas0 = jnp.full((block_size, ), mask_id, dtype=jnp.int32)
+    canvas0 = canvas0.at[0].set(seed_token.astype(jnp.int32))
+    # Index 0 is the given AR seed (already committed); the rest start masked.
+    mask0 = jnp.arange(block_size, dtype=jnp.int32) > 0
+
+    # carry = (canvas, mask, step, next_seed, last_committed, kv_caches)
+    init = (
+        canvas0,
+        mask0,
+        jnp.array(0, dtype=jnp.int32),
+        jnp.array(0, dtype=jnp.int32),
+        canvas0,
+        kv_caches,
+    )
+
+    def cond_fn(carry):
+        _, mask, step, _, _, _ = carry
+        under_cap = step < max_denoise_steps
+        # Force at least one forward (step 0) so ``next_seed`` is always set,
+        # even in the degenerate block_size == 1 case; otherwise stop once the
+        # block is fully committed.
+        more_work = jnp.logical_or(step == 0, jnp.any(mask))
+        return jnp.logical_and(under_cap, more_work)
+
+    def body_fn(carry):
+        canvas, mask, step, _, _, kv = carry
+        full_logits, kv = forward_fn(canvas, positions, kv)
+        full_logits = full_logits.astype(jnp.float32)
+        shifted = full_logits[shift_idx]
+        committed_tok, new_mask = diffusion_commit(shifted, mask, threshold,
+                                                   temperature)
+        newly = jnp.logical_and(mask, jnp.logical_not(new_mask))
+        canvas = jnp.where(newly, committed_tok, canvas)
+        # Next block's first token = model's next-token prediction from the
+        # final canvas position's hidden state (unshifted logits at the tail).
+        next_seed = jnp.argmax(full_logits[block_size - 1]).astype(jnp.int32)
+        return (canvas, new_mask, step + 1, next_seed, committed_tok, kv)
+
+    canvas, mask, steps, next_seed, last_committed, kv_caches = jax.lax.while_loop(
+        cond_fn, body_fn, init)
+
+    # If the step cap was hit before full commitment, force-fill any still-masked
+    # positions with their argmax so ``mask_id`` never leaks into the output.
+    canvas = jnp.where(mask, last_committed, canvas)
+    return canvas, next_seed, steps, kv_caches
+
+
+def diffusion_decode(
+        forward_fn: ForwardFn,
+        first_token: int,
+        prefix_len: int,
+        kv_caches: Any = None,
+        *,
+        block_size: int,
+        mask_id: int,
+        max_tokens: int,
+        threshold: float = 0.9,
+        temperature: float = 0.0,
+        max_denoise_steps: int = 0,
+        eos_token_id: Tuple[int, ...] = (),
+) -> DiffusionDecodeResult:
+    """Host-side block-diffusion decode: iterate blocks until done.
+
+    Seeds block 0 with ``first_token`` at canvas index 0, denoises it on-device
+    via :func:`denoise_block`, then advances to the next block whose first token
+    is the previous block's ``next_seed``. The returned ``tokens`` stream is the
+    concatenation of the committed block canvases (so ``tokens[0] ==
+    first_token``), truncated at ``max_tokens`` or the first committed EOS.
+
+    Args:
+        forward_fn: Injected model forward (see module docstring).
+        first_token: The AR token (e.g. from prefill) that seeds block 0.
+        prefix_len: Number of cached prompt tokens preceding block 0.
+        kv_caches: Opaque KV-cache pytree threaded through decode (may be None).
+        block_size: Canvas length per block.
+        mask_id: Token id marking not-yet-committed canvas positions.
+        max_tokens: Cap on the number of generated tokens.
+        threshold: Confidence threshold for committing a position.
+        temperature: Softmax temperature for the commit step.
+        max_denoise_steps: Per-block denoise iteration cap; ``<= 0`` means use
+            ``block_size`` (which fully commits since the forced-argmax progress
+            guarantee commits >= 1 masked position per iteration).
+        eos_token_id: EOS token id(s); decode stops after the first is committed.
+
+    Returns:
+        A :class:`DiffusionDecodeResult`.
+    """
+    if block_size < 1:
+        raise ValueError(f"{block_size=} must be >= 1")
+
+    eff_max_steps = block_size if max_denoise_steps <= 0 else int(
+        max_denoise_steps)
+    eos_set = set(
+        int(t) for t in np.atleast_1d(np.asarray(
+            eos_token_id)).ravel()) if len(eos_token_id) else set()
+
+    tokens: List[int] = []
+    steps_per_block: List[int] = []
+    seed = int(first_token)
+    prefix = int(prefix_len)
+    hit_eos = False
+
+    while len(tokens) < max_tokens and not hit_eos:
+        positions = jnp.arange(block_size, dtype=jnp.int32) + jnp.array(
+            prefix, dtype=jnp.int32)
+        canvas, next_seed, steps, kv_caches = denoise_block(
+            forward_fn,
+            jnp.array(seed, dtype=jnp.int32),
+            positions,
+            kv_caches,
+            block_size=block_size,
+            mask_id=mask_id,
+            threshold=threshold,
+            temperature=temperature,
+            max_denoise_steps=eff_max_steps,
+        )
+        canvas_host = np.asarray(canvas).tolist()
+        steps_per_block.append(int(steps))
+
+        for tok in canvas_host:
+            tokens.append(int(tok))
+            if int(tok) in eos_set:
+                hit_eos = True
+                break
+            if len(tokens) >= max_tokens:
+                break
+
+        seed = int(next_seed)
+        prefix += block_size
+
+    tokens = tokens[:max_tokens]
+    return DiffusionDecodeResult(
+        tokens=tokens,
+        num_blocks=len(steps_per_block),
+        steps_per_block=steps_per_block,
+        next_seed=seed,
+        kv_caches=kv_caches,
+        hit_eos=hit_eos,
+    )

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -17,7 +17,7 @@ import logging
 import random
 import sys
 from contextlib import nullcontext
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union, cast
 
 import jax
@@ -75,6 +75,7 @@ from tpu_inference.models.jax.utils.weight_utils import (
 from tpu_inference.runner import utils as runner_utils
 from tpu_inference.runner.compilation_manager import CompilationManager
 from tpu_inference.runner.decode_loop import TpuSamplingState, continue_decode
+from tpu_inference.runner.diffusion_decode import diffusion_decode
 from tpu_inference.runner.input_batch import CachedRequestState, InputBatch
 from tpu_inference.runner.kv_cache_manager import KVCacheManager
 from tpu_inference.runner.lora_utils import LoraUtils
@@ -860,6 +861,29 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             "continue_decode_eos_check_interval", 1)
         self.static_max_decode_steps = self.vllm_config.additional_config.get(
             "max_decode_steps", DEFAULT_MAX_DECODE_STEPS)
+        # Block-diffusion decode knobs. Fully gated behind
+        # enable_diffusion_decode (default False) so AR decode is unchanged.
+        self.enable_diffusion_decode = self.vllm_config.additional_config.get(
+            "enable_diffusion_decode", False)
+        self.diffusion_block_size = self.vllm_config.additional_config.get(
+            "diffusion_block_size", 32)
+        self.diffusion_commit_threshold = (
+            self.vllm_config.additional_config.get(
+                "diffusion_commit_threshold", 0.9))
+        self.diffusion_max_denoise_steps = (
+            self.vllm_config.additional_config.get(
+                "diffusion_max_denoise_steps", 0))
+        # Explicit override for the diffusion MASK token id; None means resolve
+        # from the model's hf_config (see _get_diffusion_mask_id, which raises if
+        # no id can be resolved -- no hardcoded model-specific default).
+        self.diffusion_mask_id = self.vllm_config.additional_config.get(
+            "diffusion_mask_id", None)
+        # Completion budget: ONE _execute_diffusion_decode call generates the whole
+        # completion (up to this many new tokens) so diffusion_decode's internal
+        # next_seed block chain runs. A per-step budget < block_size truncates to a
+        # partial block and never chains (-> incoherent output).
+        self.diffusion_max_new_tokens = self.vllm_config.additional_config.get(
+            "diffusion_max_new_tokens", 256)
         self.eos_token_id = runner_utils.get_eos_token_id(self.model_config)
         self.pad_token_id = runner_utils.get_pad_token_id(self.model_config)
 
@@ -1559,6 +1583,8 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             0] == self.input_batch.num_reqs
         if is_decode_only and self.enable_continue_decode:
             return self._execute_continue_decode(scheduler_output)
+        if is_decode_only and self.enable_diffusion_decode:
+            return self._execute_diffusion_decode(scheduler_output)
 
         # TODO(pooyam): I guess we can remove returning sampling_metadata in `_prepare_inputs` after https://github.com/njhill/vllm/commit/b7433ca1a47732394b1bdea4099d98389515954b
         (
@@ -1949,6 +1975,231 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         if routed_experts is not None:
             output.routed_experts = routed_experts
 
+        self._continue_decode_output = output
+        return None
+
+    def _get_diffusion_mask_id(self) -> int:
+        """Resolve the block-diffusion MASK token id from model/additional config.
+
+        Precedence: an explicit ``additional_config['diffusion_mask_id']``
+        override, then the model's ``hf_config`` (``mask_token_id`` /
+        ``diffusion_mask_token_id`` / ``dflash_config['mask_token_id']``). If none
+        is set, RAISES -- no hardcoded model-specific guess (keeps decode
+        model-agnostic).
+        """
+        if self.diffusion_mask_id is not None:
+            return int(self.diffusion_mask_id)
+        hf_config = getattr(self.model_config, "hf_config", None)
+        for attr in ("mask_token_id", "diffusion_mask_token_id"):
+            val = getattr(hf_config, attr, None)
+            if val is not None:
+                return int(val)
+        dflash_cfg = getattr(hf_config, "dflash_config", None) or {}
+        if isinstance(dflash_cfg,
+                      dict) and dflash_cfg.get("mask_token_id") is not None:
+            return int(dflash_cfg["mask_token_id"])
+        raise ValueError(
+            "block-diffusion decode requires a MASK token id but none was found: "
+            "set additional_config['diffusion_mask_id'], or provide the model's "
+            "hf_config mask_token_id / diffusion_mask_token_id / "
+            "dflash_config['mask_token_id'].")
+
+    def _build_diffusion_forward_fn(
+        self,
+        attn_metadata: AttentionMetadata,
+        lora_metadata,
+        prefix_len: int,
+        block_size: int,
+    ):
+        """Build the on-device forward callable for block-diffusion denoise.
+
+        Returns ``forward_fn(canvas, positions, kv_caches) -> (full_logits,
+        kv_caches)``: it runs the model over the ``block_size`` canvas positions
+        attending to the cached prompt prefix + canvas, then computes the
+        unshifted per-position logits.
+
+        TPU-ONLY. Two pieces are validated only on TPU (the Pallas RPA kernel and
+        paged KV cache do not run on CPU):
+
+          1. Bidirectional attention over ``[prefix + canvas]``: the model is
+             invoked with ``use_causal_mask=False``, carried as a static
+             ``AttentionMetadata`` meta_field from this ``replace()`` through
+             ``model.__call__`` down to ``attention()``. Correct while exactly one
+             block is on the canvas (fully bidirectional == the block-causal mask
+             for a single block); multi-block canvases would need a custom mask.
+          2. The merge_state-free simplification: the canvas K/V is appended to
+             the paged-cache tail and OVERWRITTEN each denoise iteration (so
+             ``seq_lens == prefix_len + block_size`` every call).
+        """
+        layer_index = tuple(self.layer_name_to_kvcache_index.items())
+        # Single active request: req 0 holds the block_size-token canvas attending
+        # to prefix + canvas; the other (padded) request slots are empty. BOTH arrays
+        # keep attn_metadata's BUCKETED shape -- the RPA kernel is compiled for
+        # padded_num_reqs, so a bare 2-element query_start_loc fails its cu_q_lens
+        # shape check ("Expected cu_q_lens.shape=(2,) to be (padded_num_reqs+1,)").
+        # cu_q_lens: req 0 has block_size query tokens, all other reqs have 0 ->
+        # [0, block_size, block_size, ..., block_size] over (padded_num_reqs+1,).
+        query_start_loc = jnp.full_like(attn_metadata.query_start_loc,
+                                        block_size).at[0].set(0)
+
+        def forward_fn(canvas, positions, kv_caches):
+            # seq_lens is PREFIX-AWARE: diffusion_decode advances the block across
+            # the whole completion, so positions[0] is the CURRENT block's start.
+            # Only req 0 is active; its K/V spans [0, positions[0] + block_size)
+            # (the prompt prefix + the current trailing block). A closure-hoisted
+            # seq_lens would pin the window to block 0 and corrupt every later
+            # block; the other (padded) request slots stay 0 (inactive).
+            seq_lens = jnp.zeros_like(
+                attn_metadata.seq_lens).at[0].set(positions[0] + block_size)
+            canvas_md = replace(
+                attn_metadata,
+                input_positions=positions,
+                seq_lens=seq_lens,
+                query_start_loc=query_start_loc,
+                use_causal_mask=False,
+                # Route the block_size-token canvas through the RPA kernel's MIXED
+                # case (dynamic q_len>1), NOT DECODE. The DECODE case is compiled
+                # with static_q_len=1 -> num_bq=1, so it attends+writes ONLY query
+                # position 0 and leaves canvas positions 1..block_size-1 as aliased
+                # raw-query garbage (the gibberish). request_distribution is
+                # [decode_end, prefill_end, mixed_end]; zeroing the first two empties
+                # DECODE/PREFILL so slot 0 falls in MIXED [prefill_end, mixed_end) --
+                # the same proven multi-token path AR prefill uses. Traced data_field
+                # -> runtime-only value change, no recompile.
+                request_distribution=attn_metadata.request_distribution.at[0].
+                set(0).at[1].set(0),
+            )
+            # use_causal_mask=False -> the canvas attends bidirectionally over
+            # [prefix + block]. Threaded via AttentionMetadata (a static meta_field)
+            # through model.__call__ down to attention() in the attention layer.
+            kv_caches, hidden_states, _, _ = self.model_fn(
+                self.state_leaves,
+                kv_caches,
+                canvas,
+                canvas_md,
+                None,
+                positions,
+                layer_index,
+                lora_metadata,
+                None,
+                self.is_first_rank,
+                self.is_last_rank,
+            )
+            full_logits = self.compute_logits_fn(
+                self.state_leaves,
+                hidden_states,
+                lora_metadata,
+            )
+            return full_logits.astype(jnp.float32), kv_caches
+
+        return forward_fn
+
+    def _execute_diffusion_decode(
+        self,
+        scheduler_output: "VllmSchedulerOutput",
+    ) -> None:
+        """Block-diffusion denoising decode (Fast_dLLM / Diffusion-GR2).
+
+        Gated behind ``enable_diffusion_decode`` (default False); mirrors
+        ``_execute_continue_decode``'s input prep and output bookkeeping. Runs
+        :func:`tpu_inference.runner.diffusion_decode.diffusion_decode` per
+        active request (a host-side loop over blocks whose per-block denoise
+        iterations run on-device). The on-device forward is TPU-only (see
+        ``_build_diffusion_forward_fn``).
+        """
+        (
+            input_ids,
+            input_positions,
+            attn_metadata,
+            _sampling_metadata,
+            _logits_indices,
+            _spec_decode_metadata,
+            _logits_indices_selector,
+            _padded_num_reqs,
+            _,
+            _,
+        ) = self._prepare_inputs(scheduler_output)
+
+        mask_id = self._get_diffusion_mask_id()
+        block_size = int(self.diffusion_block_size)
+        threshold = float(self.diffusion_commit_threshold)
+        max_denoise_steps = int(self.diffusion_max_denoise_steps)
+
+        # Per-request seed token + prefix length (host-side control).
+        input_ids_cpu = np.asarray(jax.device_get(input_ids))
+        input_positions_cpu = np.asarray(jax.device_get(input_positions))
+
+        lora_metadata = self.lora_utils.extract_lora_metadata()
+        min_remaining = self._get_min_remaining_slots()
+        max_new = min(self.static_max_decode_steps, min_remaining)
+        if max_new <= 0:
+            max_new = 1
+
+        num_reqs = self.input_batch.num_reqs
+        sampled_token_ids: list[list[int]] = []
+
+        with self.maybe_forbid_compile, \
+             set_forward_context(None, self.vllm_config), \
+             self.maybe_get_kv_connector_output(
+                 scheduler_output) as kv_connector_output:
+            for req_idx, req_id in enumerate(
+                    self.input_batch.req_ids[:num_reqs]):
+                first_token = int(input_ids_cpu[req_idx])
+                prefix_len = int(input_positions_cpu[req_idx])
+                forward_fn = self._build_diffusion_forward_fn(
+                    attn_metadata, lora_metadata, prefix_len, block_size)
+                # Generate the WHOLE completion in ONE call (up to
+                # diffusion_max_new_tokens, capped by remaining KV) so
+                # diffusion_decode's internal next_seed chain advances each block
+                # on the block_size grid. A per-step budget < block_size truncates
+                # to a partial block and never chains -> incoherent output. +1
+                # accounts for the seed at index 0, which is dropped below.
+                result = diffusion_decode(
+                    forward_fn,
+                    first_token=first_token,
+                    prefix_len=prefix_len,
+                    kv_caches=self.kv_caches,
+                    block_size=block_size,
+                    mask_id=mask_id,
+                    max_tokens=min(self.diffusion_max_new_tokens + 1,
+                                   int(min_remaining)),
+                    threshold=threshold,
+                    temperature=0.0,
+                    max_denoise_steps=max_denoise_steps,
+                    eos_token_id=self.eos_token_id,
+                )
+                self.kv_caches = result.kv_caches
+                # Drop the seed (already emitted last step); keep the new tokens.
+                new_tokens = result.tokens[1:]
+                logger.info(
+                    "block-diffusion decode FIRED req=%s: num_blocks=%d "
+                    "steps_per_block=%s hit_eos=%s n_new_tokens=%d", req_id,
+                    result.num_blocks, result.steps_per_block, result.hit_eos,
+                    len(new_tokens))
+                sampled_token_ids.append(new_tokens)
+
+                req_state = self.requests.get(req_id)
+                if req_state is not None:
+                    start_idx = self.input_batch.num_tokens_no_spec[req_idx]
+                    end_idx = start_idx + len(new_tokens)
+                    if (req_idx < self.max_num_reqs
+                            and end_idx <= self.max_model_len):
+                        self.input_batch.token_ids_cpu[
+                            req_idx, start_idx:end_idx] = new_tokens
+                        self.input_batch.num_tokens_no_spec[req_idx] = end_idx
+                        self.input_batch.num_tokens[req_idx] = end_idx
+                        req_state.output_token_ids.extend(new_tokens)
+                scheduler_output.num_scheduled_tokens[req_id] = len(new_tokens)
+
+        output = ModelRunnerOutput(
+            req_ids=self.input_batch.req_ids[:num_reqs],
+            req_id_to_index=self.input_batch.req_id_to_index.copy(),
+            sampled_token_ids=sampled_token_ids,
+            logprobs=None,
+            prompt_logprobs_dict={},
+            pooler_output=[],
+            kv_connector_output=kv_connector_output,
+        )
         self._continue_decode_output = output
         return None
 


### PR DESCRIPTION
  ## Summary

  Adds an optional **block-diffusion** (a.k.a. masked-diffusion / discrete-diffusion) decode path to the
  TPU engine, alongside the existing autoregressive (AR) decode.

  Block-diffusion LMs (e.g. Fast-dLLM, BD3-LM) generate a block of positions in parallel rather than one
  token at a time: the block is seeded with masked tokens and iteratively denoised, committing the
  high-confidence positions on each pass until the block is filled. Because multiple positions are
  committed per forward pass, far fewer *sequential* forward passes are needed for a given output length
  — the main latency win on decode-bound workloads.

  This PR is the **inference side only**. It is fully gated behind `enable_diffusion_decode` and is **off
  by default**; the AR decode path is unchanged.

  ## What's in this PR

  - **`use_causal_mask` plumbing** — an optional `use_causal_mask: bool = True` kwarg so a caller can
  request bidirectional (within-block) attention:
    - threaded through `attention()` / `sharded_ragged_paged_attention`
  (`layers/common/attention_interface.py`) and `Attention.attention`
  (`layers/jax/attention/attention.py`);
    - carried into the model `__call__` as a static `AttentionMetadata` field (default `True`), so the AR
  path stays byte-identical and only the diffusion caller flips it to `False` on the canvas;
    - the v3 ragged-paged-attention kernel already accepts the flag — this just forwards it. The hd64
  path (which lacks the param) keeps a guard.
  - **Threshold-commit sampler** — `diffusion_commit(logits, mask, threshold, temperature)` in
  `layers/jax/sample/sampling.py`: softmax → per-position top-token probability → commit positions above
  `threshold`, plus a forced arg-max of the highest-confidence still-masked position to guarantee forward
  progress. Pure JAX.
  - **Denoising decode loop** — `runner/diffusion_decode.py`: seeds a canvas (first token + `mask_id`),
  runs an on-device `jax.lax.while_loop` inner denoise per block and a host-side outer loop across blocks
  (block count is EOS/length-bounded), using the shifted-logit convention (token `i` predicted from
  hidden `i-1`). The model is injected as a `forward_fn`, so the loop is testable independently of the
  kernel.
  - **Config + dispatch** — `enable_diffusion_decode` / `diffusion_block_size` /
  `diffusion_commit_threshold` / `diffusion_max_denoise_steps` in the runner's `additional_config`, and a
  gated branch in `_execute_model` → `_execute_diffusion_decode`. `mask_id` is read from model config
  (not hardcoded).

  ## Design notes (TPU)

  - Bidirectional-within-block attention is expressed by running the v3 RPA kernel with
  `use_causal_mask=False` over `[prefix + canvas]`, so no log-sum-exp / `merge_state` combine is needed
  (unlike a paged-prefix + ragged-canvas FlashInfer path on GPU).
  - Injecting the model as a `forward_fn` keeps the denoise loop independent of both the specific model
  and the Pallas kernel — which is what makes the CPU stub tests possible.

  ## Back-compat / gating

  Entirely gated behind `enable_diffusion_decode` (default `False`). No change to the autoregressive
  decode path.

  ## Testing

  - **CPU unit tests**
    - `diffusion_commit`: threshold + forced-argmax progress + already-committed positions untouched (5
  tests).
    - Full denoise loop end-to-end with a stub `forward_fn`: full-commit, progress guarantee,
  shifted-logit indexing, multi-block seed chaining, EOS/max-len truncation (17 tests).
    - `use_causal_mask` threading and the config knobs verified via signature/AST checks.
  - **End-to-end on TPU** — with `use_causal_mask` threaded through the model `__call__`, the full path
  (bidirectional attention on the RPA kernel + on-device `_execute_diffusion_decode`) runs end-to-end on
  a real TPU against a block-diffusion Qwen3-0.6B checkpoint and produces coherent, on-topic output.
  Automated CI tests stay CPU-only because the RPA Pallas kernel and a checkpoint require TPU hardware
  not available in CI.

  ## Limitations / follow-ups

  - **Throughput** — the outer block loop is currently host-driven (one dispatch per denoise pass);
  fusing the block loop on-device into a single dispatch is a performance follow-up.
  - **Paged-cache K/V reuse** — denoise iterations currently overwrite the canvas K/V in the paged-cache
  tail each pass; writing K/V once per committed block (via an `update_kv_cache` flag threaded the same
  way) is a perf follow-up.
  - **Multi-block canvases** — `use_causal_mask=False` is fully bidirectional over `[prefix + canvas]`,
  which matches block-causal semantics only when exactly one block is on the canvas; multi-block canvases
  need a custom mask the binary flag can't express.
  - **Production serving throughput** — batched multi-request serving and the v1 scheduler/block-manager
  changes to reserve `block_size` KV slots per diffusion step (and advance `seq_len` by `block_size`) are
  tracked separately.