### PR TITLE
[TPU v8i] Support tpu v8i in RPA v3

### DIFF
--- a/tpu_inference/kernels/ragged_paged_attention/v3/kernel.py
+++ b/tpu_inference/kernels/ragged_paged_attention/v3/kernel.py
@@ -1537,7 +1537,8 @@ def get_default_block_sizes(
                 bkv_sz = min(1024, max_kv)
                 bq_csz = min(512 // num_q_heads_per_kv_head, max_q)
                 bkv_csz = min(512, align_to(max_kv // 2, page_size))
-        case 7:
+        # TODO(amandaliang): Update the default tiling for v8i.
+        case 7 | 8:
             if case == RpaCase.DECODE:
                 bq_sz = 1
                 bkv_sz = min(min_bkv_sz_to_peak, max_kv)

--- a/tpu_inference/kernels/ragged_paged_attention/v3/util.py
+++ b/tpu_inference/kernels/ragged_paged_attention/v3/util.py
@@ -56,9 +56,11 @@ def get_tpu_version() -> int:
         return -1
     if kind.endswith(' lite'):
         kind = kind[:-len(' lite')]
-    if kind.endswith('p') or kind.endswith('e'):
+    if kind.endswith('p') or kind.endswith('e') or kind.endswith('i'):
         kind = kind[:-1]
-    if kind == 'TPU7x':
+    if kind.startswith('TPU7'):
         return 7
+    if kind.startswith('TPU8'):
+        return 8
     assert kind[:-1] == 'TPU v', kind
     return int(kind[-1])


### PR DESCRIPTION
# Description

This PR adds support for TPU v8i hardware in Ragged Paged Attention (RPA) v3 by enabling TPU version parsing for `i`-suffixed device variants and mapping TPU v8i to standard default RPA v3 block sizes.

Currently it defaults to TPU v7 heuristics. Will update this in a followup.

# Tests

Tested internally on g3.

# Checklist

Before submitting this PR, please make sure:
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have made or will make corresponding changes to any relevant documentation.
