### PR TITLE
Fix it to ensure that the metadata is updated correctly

### DIFF
--- a/.buildkite/scripts/notify_test_results.sh
+++ b/.buildkite/scripts/notify_test_results.sh
@@ -15,8 +15,22 @@
 
 set -e
 
-V6_ANY_FAILED=$(buildkite-agent meta-data get "v6_CI_TESTS_FAILED")
-V7_ANY_FAILED=$(buildkite-agent meta-data get "v7_CI_TESTS_FAILED")
+V6_ANY_FAILED=$(buildkite-agent meta-data get "v6_CI_TESTS_FAILED" --default "false")
+V7_ANY_FAILED=$(buildkite-agent meta-data get "v7_CI_TESTS_FAILED" --default "false")
+
+# If previously marked as failed, re-run matrix generation to pick up any retried test results
+if [ "${V6_ANY_FAILED}" = "true" ] && [ "$(buildkite-agent meta-data get run_v6_matrix --default 'false')" = "true" ]; then
+  echo "--- Re-evaluating v6 test outcomes (picking up possible retries)"
+  TPU_VERSION="v6e" bash .buildkite/scripts/generate_support_matrices.sh
+  V6_ANY_FAILED=$(buildkite-agent meta-data get "v6_CI_TESTS_FAILED" --default "false")
+fi
+
+if [ "${V7_ANY_FAILED}" = "true" ] && [ "$(buildkite-agent meta-data get run_v7_matrix --default 'false')" = "true" ]; then
+  echo "--- Re-evaluating v7 test outcomes (picking up possible retries)"
+  TPU_VERSION="v7x" bash .buildkite/scripts/generate_support_matrices.sh
+  V7_ANY_FAILED=$(buildkite-agent meta-data get "v7_CI_TESTS_FAILED" --default "false")
+fi
+
 FAILURE_LABEL="Not all models and/or features passed"
 
 echo "--- Checking test outcomes"


### PR DESCRIPTION
# Description

**Root Cause:**
The test results for all models and features are only checked within `generate_support_matrices.sh`. If a previously failed test is successfully retried, the system does not recheck or update the metadata value.

**Fix:**
When notify_test_results.sh detects an error, it runs generate_support_matrices.sh again to recheck the metadata of the relevant tests and regenerate the latest support matrices files.

**This is also related to the [support matrices refactoring PR](https://github.com/vllm-project/tpu-inference/pull/2801), and conflicts will need to be resolved after merging.**

# Tests

The test focuses on ensuring that `notify_test_results.sh` re-runs `generate_support_matrices.sh` when there is a failed job.
[Buildkite CI](https://buildkite.com/tpu-commons/tpu-inference-ci/builds/22574#019f6f00-7813-426e-9c64-bbaf65c9fa71)

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
