### PR TITLE
pcp attention: avoid f32 promotion in the cache-phase LSE all-reduce

### DIFF
--- a/tpu_inference/layers/common/attention_interface.py
+++ b/tpu_inference/layers/common/attention_interface.py
@@ -782,8 +782,16 @@ def _lse_all_reduce(o: jax.Array, lse: jax.Array, axis: str):
     m_safe = jnp.where(jnp.isinf(m), 0.0, m)
     w = jnp.exp(lse - m_safe)
     denom = lax.psum(w, axis)
-    o_merged = (lax.psum(o * w[..., None], axis) /
-                jnp.where(denom == 0.0, 1.0, denom)[..., None])
+    # `o` comes back from the kernel in bf16 while `w`/`lse` are f32. Letting the
+    # product promote to f32 costs a bf16->f32 convert of the whole `o` and
+    # doubles the all-reduced payload, purely as a side effect of type
+    # promotion. Weight in `o`'s dtype and widen only after the collective, so
+    # the f32 exp/subtract that build the weights are preserved and only the
+    # final per-rank weight is rounded to bf16.
+    w_o = w[..., None].astype(o.dtype)
+    o_w_sum = lax.psum(o * w_o, axis)
+    denom_safe = jnp.where(denom == 0.0, 1.0, denom)[..., None]
+    o_merged = o_w_sum.astype(denom.dtype) / denom_safe
     lse_merged = jnp.where(denom == 0.0, -jnp.inf, m_safe + jnp.log(denom))
     return o_merged, lse_merged
 


### PR DESCRIPTION
## Summary
`_lse_all_reduce` (the cache-phase LSE merge in PCP attention) weighted the **bf16** kernel output `o` by the **f32** softmax weight `w`, so `o * w` promoted the entire `o` to f32 as a side effect of type promotion.

On the profiled config (ctx=64k, pcp2/tp4, head_dim=256) that cost, per chunk:
- a ~82us bf16->f32 convert of `o` (the `[1,T,2,2,hd] -> f32[T,H,hd]` "reshape" in the trace),
- a 2x-larger all-reduce payload (`all-reduce.5`: **190us -> 98us**),
- a doubled broadcast-multiply.

Fix: weight in `o`'s dtype and widen only after the collective. The f32 `exp`/subtract that build the weights are preserved; only the final per-rank weight is rounded to bf16 before the reduce.

## Impact
- Removes **~218us of device work** per chunk and **halves the LSE collective**.
- **Wall clock unchanged** — the merge is off the critical path (measured -25us, inside run-to-run noise). So this is a device-work / bandwidth / power cleanup, **not** a latency win.

## Testing
- `tests/layers/common/test_pcp_attention_interface.py`: **8/8 pass**.
- gsm8k, Qwen3-8B-Base, tp4/pcp2, 200 samples: **0.845** (bf16) vs **0.860** (f32 control) — within one stderr (~0.025), no measurable degradation.

## Caveat
The all-reduce now accumulates in bf16. At pcp=2 (validated) this is a 2-way sum; at larger pcp the bf16 accumulation spans more ranks and could lose more precision — worth re-checking accuracy if this is used at higher pcp. The final TPU test re-run after cosmetic cleanup could not be executed (the jax env on the box was wiped mid-session); the committed logic is identical to the tested state, and the file compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
