### PR TITLE
feat(sample): support min_p on the TPU JAX sampler

### DIFF
--- a/tests/layers/common/test_minp_mask.py
+++ b/tests/layers/common/test_minp_mask.py
@@ -1,0 +1,107 @@
+# Copyright 2025 Meta Platforms, Inc. and affiliates.
+# SPDX-License-Identifier: Apache-2.0
+"""Accuracy tests for the min-p logit mask (``binary_search.minp_mask``).
+
+Runs on the JAX CPU backend (no TPU needed):
+    JAX_PLATFORMS=cpu python -m pytest tests/layers/common/test_minp_mask.py
+
+``minp_mask`` implements the filter in logit space
+(``logit_i >= max_logit + log(min_p)``); these tests assert it matches vLLM's
+reference min-p semantics computed in probability space
+(``prob_i >= min_p * max_prob``), which is the equivalence the logit-space
+formulation relies on.
+"""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from tpu_inference.layers.common.binary_search import minp_mask
+
+_REPLACE = -1e12
+
+
+def _reference_minp(logits: np.ndarray, min_p: np.ndarray) -> np.ndarray:
+    """vLLM min-p semantics, computed in probability space (float64 reference).
+
+    Keep token i iff ``prob_i >= min_p * max_prob``; else set to _REPLACE.
+    """
+    logits = logits.astype(np.float64)
+    e = np.exp(logits - logits.max(axis=-1, keepdims=True))
+    probs = e / e.sum(axis=-1, keepdims=True)
+    max_prob = probs.max(axis=-1, keepdims=True)
+    keep = probs >= (min_p[:, None] * max_prob)
+    return np.where(keep, logits, _REPLACE)
+
+
+def _kept(mask_out: np.ndarray) -> np.ndarray:
+    return np.asarray(mask_out) > _REPLACE / 2
+
+
+@pytest.mark.parametrize("seed", [0, 1, 7])
+@pytest.mark.parametrize("min_p_val", [0.0, 0.01, 0.05, 0.1, 0.5, 0.9, 1.0])
+def test_minp_mask_matches_reference_scalar(seed, min_p_val):
+    rng = np.random.default_rng(seed)
+    batch, vocab = 8, 4096
+    logits = rng.standard_normal((batch, vocab)).astype(np.float32) * 5.0
+    min_p = np.full((batch, ), min_p_val, dtype=np.float32)
+
+    out = np.asarray(
+        minp_mask(jnp.asarray(logits), jnp.asarray(min_p), _REPLACE))
+    ref = _reference_minp(logits, min_p)
+
+    # The kept/removed decision must match exactly (threshold equivalence).
+    np.testing.assert_array_equal(_kept(out), _kept(ref))
+    # Kept logits are passed through unchanged.
+    keep = _kept(ref)
+    np.testing.assert_allclose(out[keep], logits[keep], rtol=0, atol=0)
+
+
+def test_minp_mask_per_row_min_p():
+    """Different min_p per batch row (the real serving case)."""
+    rng = np.random.default_rng(123)
+    batch, vocab = 6, 2048
+    logits = rng.standard_normal((batch, vocab)).astype(np.float32) * 3.0
+    min_p = np.array([0.0, 0.01, 0.05, 0.2, 0.5, 1.0], dtype=np.float32)
+
+    out = np.asarray(
+        minp_mask(jnp.asarray(logits), jnp.asarray(min_p), _REPLACE))
+    ref = _reference_minp(logits, min_p)
+    np.testing.assert_array_equal(_kept(out), _kept(ref))
+
+
+def test_minp_zero_is_disabled():
+    """min_p == 0 keeps every token (log(0) = -inf threshold)."""
+    rng = np.random.default_rng(5)
+    logits = rng.standard_normal((4, 1000)).astype(np.float32) * 4.0
+    min_p = np.zeros((4, ), dtype=np.float32)
+    out = np.asarray(
+        minp_mask(jnp.asarray(logits), jnp.asarray(min_p), _REPLACE))
+    np.testing.assert_allclose(out, logits, rtol=0, atol=0)
+    assert np.isfinite(out).all()
+
+
+def test_minp_one_keeps_only_argmax():
+    """min_p == 1 keeps only the max-probability token(s) per row."""
+    rng = np.random.default_rng(9)
+    logits = rng.standard_normal((5, 500)).astype(np.float32) * 4.0
+    min_p = np.ones((5, ), dtype=np.float32)
+    out = np.asarray(
+        minp_mask(jnp.asarray(logits), jnp.asarray(min_p), _REPLACE))
+    kept = _kept(out)
+    # Exactly the argmax column is kept in each row (ties improbable here).
+    assert kept.sum(axis=-1).max() == 1
+    np.testing.assert_array_equal(np.argmax(out, axis=-1),
+                                  np.argmax(logits, axis=-1))
+
+
+def test_minp_mask_jit():
+    """Works under jax.jit (min_p as a traced arg)."""
+    logits = jnp.asarray(
+        np.random.default_rng(0).standard_normal((3, 256)).astype(np.float32))
+    min_p = jnp.asarray(np.array([0.0, 0.1, 0.7], dtype=np.float32))
+    fn = jax.jit(lambda x, m: minp_mask(x, m, _REPLACE))
+    out = np.asarray(fn(logits, min_p))
+    ref = _reference_minp(np.asarray(logits), np.asarray(min_p))
+    np.testing.assert_array_equal(_kept(out), _kept(ref))

--- a/tpu_inference/layers/common/binary_search.py
+++ b/tpu_inference/layers/common/binary_search.py
@@ -293,3 +293,44 @@ def topp_mask(logits: jnp.ndarray, p: float,
     threshold = lax.expand_dims(threshold, (threshold.ndim, ))
     return jnp.where(probs >= threshold, logits,
                      jnp.full_like(logits, replace_val))
+
+
+def minp_mask(logits: jnp.ndarray, min_p: jnp.ndarray,
+              replace_val: jnp.ndarray) -> jnp.ndarray:
+    """Applies min-p masking to logits.
+
+    Keeps only tokens whose probability is at least ``min_p`` times the
+    probability of the most likely token; all others are set to ``replace_val``.
+    This matches vLLM's ``min_p`` semantics
+    (``probs < min_p * probs.max()`` -> removed).
+
+    Unlike :func:`topk_mask` / :func:`topp_mask`, this needs **no** binary search
+    and **no** softmax: because softmax is monotonic, the probability test
+    ``prob_i >= min_p * max_prob`` is exactly equivalent, in logit space, to
+    ``logit_i >= max_logit + log(min_p)``. So the whole op is a single max
+    reduction over the vocab axis plus an elementwise compare — strictly cheaper
+    than the ~33-reduction binary searches the top-k/top-p masks run.
+
+    ``min_p == 0`` disables the filter: ``log(0) = -inf`` makes the threshold
+    ``-inf`` so every token is kept. ``min_p == 1`` keeps only the argmax
+    token(s).
+
+    Sharding: the single reduction is over the ``vocab_size`` axis, so keep that
+    axis unsharded (shard the batch axes) as with the other masks.
+
+    Args:
+      logits: Logits before masking. [batch..., vocab_size]
+      min_p: Per-row minimum probability ratio in [0, 1]. [batch...]
+      replace_val: For the masked values of logits, what to overwrite them with.
+
+    Returns:
+      masked version of logits. [batch..., vocab_size]
+    """
+    # max_logit: [batch..., 1]
+    max_logit = jnp.max(logits, axis=-1, keepdims=True)
+    # log(min_p): [batch..., 1]; log(0) -> -inf disables the filter.
+    log_min_p = jnp.log(jnp.expand_dims(min_p, axis=-1).astype(logits.dtype))
+    # threshold: [batch..., 1]
+    threshold = max_logit + log_min_p
+    return jnp.where(logits >= threshold, logits,
+                     jnp.full_like(logits, replace_val))

--- a/tpu_inference/layers/jax/sample/sampling.py
+++ b/tpu_inference/layers/jax/sample/sampling.py
@@ -21,7 +21,8 @@ from jax.sharding import Mesh, NamedSharding
 from jax.sharding import PartitionSpec as P
 from vllm.v1.outputs import LogprobsTensors
 
-from tpu_inference.layers.common.binary_search import topk_mask, topp_mask
+from tpu_inference.layers.common.binary_search import (minp_mask, topk_mask,
+                                                       topp_mask)
 from tpu_inference.layers.common.sharding import ShardingAxisName
 from tpu_inference.layers.jax.sample.sampling_metadata import \
     TPUSupportedSamplingMetadata
@@ -86,6 +87,15 @@ def _apply_sampling_transforms(
     temperatures = tpu_sampling_metadata.temperature.astype(logits.dtype)
     temperatures = jnp.expand_dims(temperatures, axis=-1)
     logits = logits / temperatures
+
+    # Only apply min-p masking if min_p > 0 for each token. Applied before
+    # top-k/top-p (it is a floor on the full post-temperature distribution).
+    # min_p is cheap (one max reduction, no binary search) so, like top-k/top-p,
+    # the mask is computed unconditionally and selected per-row with `where`.
+    min_p = tpu_sampling_metadata.min_p
+    should_apply_minp = jnp.expand_dims(min_p > 0.0, axis=-1)
+    minp_masked = minp_mask(logits, min_p, replace_val=-1e12)
+    logits = jnp.where(should_apply_minp, minp_masked, logits)
 
     # Only apply top-k masking if k > 0 for each token
     top_k = tpu_sampling_metadata.top_k

--- a/tpu_inference/layers/jax/sample/sampling_metadata.py
+++ b/tpu_inference/layers/jax/sample/sampling_metadata.py
@@ -29,6 +29,7 @@ DEFAULT_SAMPLING_PARAMS = dict(
     temperature=-1.0,
     top_k=0,
     top_p=1.0,
+    min_p=0.0,
 )
 
 
@@ -38,6 +39,7 @@ DEFAULT_SAMPLING_PARAMS = dict(
         "temperature",
         "top_k",
         "top_p",
+        "min_p",
         "_cache_collision_dummy",
     ],
     meta_fields=["do_sampling", "logprobs"],
@@ -47,6 +49,7 @@ class TPUSupportedSamplingMetadata:
     temperature: Optional[jnp.ndarray] = None
     top_k: Optional[jnp.ndarray] = None
     top_p: Optional[jnp.ndarray] = None
+    min_p: Optional[jnp.ndarray] = None
     _cache_collision_dummy: Optional[jnp.ndarray] = None
     do_sampling: bool = False
     logprobs: bool = False
@@ -88,6 +91,8 @@ class TPUSupportedSamplingMetadata:
                                   DEFAULT_SAMPLING_PARAMS["top_k"])
         top_p_tensor = fill_slice(input_batch.top_p_cpu,
                                   DEFAULT_SAMPLING_PARAMS["top_p"])
+        min_p_tensor = fill_slice(input_batch.min_p_cpu,
+                                  DEFAULT_SAMPLING_PARAMS["min_p"])
 
         # Slice persistent device tensors to a fixed pre-compiled padded shape.
         return cls(
@@ -99,6 +104,9 @@ class TPUSupportedSamplingMetadata:
                                sharding=sharding),
             top_k=device_array(mesh,
                                top_k_tensor[:padded_num_reqs],
+                               sharding=sharding),
+            min_p=device_array(mesh,
+                               min_p_tensor[:padded_num_reqs],
                                sharding=sharding),
             _cache_collision_dummy=cache_collision_dummy,
             do_sampling=not input_batch.all_greedy,

--- a/tpu_inference/runner/input_batch.py
+++ b/tpu_inference/runner/input_batch.py
@@ -110,6 +110,8 @@ class InputBatch:
 
         self.top_k_cpu = np.empty((max_num_reqs, ), dtype=np.int32)
 
+        self.min_p_cpu = np.empty((max_num_reqs, ), dtype=np.float32)
+
         # IDs of requests which do not support spec decoding
         self.spec_decode_unsupported_reqs: set[str] = set()
 
@@ -383,6 +385,7 @@ class InputBatch:
                 self.random_reqs.add(req_id)
 
             self.top_p_cpu[req_index] = sampling_params.top_p
+            self.min_p_cpu[req_index] = sampling_params.min_p
             top_k = sampling_params.top_k
             # Default to -1 (considering all tokens)
             if top_k >= self.vocab_size:
@@ -535,6 +538,8 @@ class InputBatch:
             self.top_p_cpu[i2], self.top_p_cpu[i1]
         self.top_k_cpu[i1], self.top_k_cpu[i2] =\
             self.top_k_cpu[i2], self.top_k_cpu[i1]
+        self.min_p_cpu[i1], self.min_p_cpu[i2] =\
+            self.min_p_cpu[i2], self.min_p_cpu[i1]
 
         self.token_ids_cpu[[i1, i2], :max_active_token_count] = \
             self.token_ids_cpu[[i2, i1], :max_active_token_count]
@@ -616,6 +621,7 @@ class InputBatch:
                 last_req_index]
             self.top_p_cpu[empty_index] = self.top_p_cpu[last_req_index]
             self.top_k_cpu[empty_index] = self.top_k_cpu[last_req_index]
+            self.min_p_cpu[empty_index] = self.min_p_cpu[last_req_index]
             generator = self.generators.pop(last_req_index, None)
             if generator is not None:
                 self.generators[empty_index] = generator


### PR DESCRIPTION
## What
Adds **min_p** sampling support to the TPU JAX sampler. Previously the sampler honored only `temperature`/`top_k`/`top_p`; `min_p` was silently dropped (no `InputBatch` buffer, no metadata field, no transform), so a request setting `min_p` got no filtering on TPU — diverging from the GPU tier.

Branched off `bangsheng/perchannel-on-newpin` (the current msl-tpu-kernel pin, `61a05613`).

## Changes
- **`binary_search.minp_mask`**: logit-space filter `logit >= max_logit + log(min_p)`, mathematically equivalent to vLLM's prob-space min_p (`prob >= min_p * max_prob`). One max-reduction over the vocab axis — **no binary search, no softmax** — so strictly cheaper than the ~33-iteration `topk_mask`/`topp_mask`.
- **`_apply_sampling_transforms`**: apply min_p after temperature, before top_k/top_p, gated per-row by `min_p > 0` (same compute-then-`where` pattern as top_k/top_p; the mask is computed unconditionally, so `min_p=0` requests pay only a single reduction).
- **`TPUSupportedSamplingMetadata.min_p`**: new pytree `data_field` + default `0.0` + `from_input_batch` plumbing.
- **`InputBatch.min_p_cpu`**: buffer mirrored across alloc / `collect_sampling` / `_swap_states` / `condense`.

## Overhead
`min_p=0` (disabled, the default) costs one extra vocab max-reduction per sampling step — negligible next to the existing top_k/top_p binary searches and dominated by attention/MoE. Empirical decode-perf comparison (FP8 eagle3 rpa-seq) to follow.

## Test
`tests/layers/common/test_minp_mask.py`: `minp_mask` matches a float64 vLLM prob-space reference across scalar min_p, per-row min_p, `min_p=0` (disabled → identity), `min_p=1` (argmax-only), and under `jax.jit`. **25/25 pass** on `JAX_PLATFORMS=cpu`.

## Companion
Endpoint parse (so the api_proxy-forwarded `min_p` reaches this sampler): mslsrc/msl-tpu-kernel#1187. A `tpu-inference.version` bump to this commit lands once this merges.