### PR TITLE
Add a test to reproduce sharding error

### DIFF
--- a/tests/models/common/test_model_loader.py
+++ b/tests/models/common/test_model_loader.py
@@ -21,9 +21,11 @@ import jax.numpy as jnp
 import numpy as np
 import pytest
 import torch
-from jax.sharding import Mesh
+from flax import nnx
+from jax.sharding import AxisType, Mesh, PartitionSpec
 from transformers import PretrainedConfig
-from vllm.config import (ModelConfig, ParallelConfig, VllmConfig,
+from vllm.config import (CacheConfig, LoadConfig, ModelConfig, ParallelConfig,
+                         PoolerConfig, SchedulerConfig, VllmConfig,
                          set_current_vllm_config)
 from vllm.distributed.parallel_state import (ensure_model_parallel_initialized,
                                              init_distributed_environment)
@@ -32,6 +34,7 @@ from vllm.model_executor.models.registry import ModelRegistry
 
 from tpu_inference.distributed.jax_parallel_state import \
     init_pp_distributed_environment
+from tpu_inference.layers.common.sharding import ShardingConfigManager
 from tpu_inference.models.common import model_loader
 from tpu_inference.models.jax.qwen3 import Qwen3ForCausalLM
 
@@ -282,10 +285,92 @@ def test_get_flax_model(vllm_config, mesh, tie_word_embeddings):
     assert hasattr(model.model, "named_modules")
 
 
+@pytest.mark.parametrize("enforce_device_order", [True, False])
+def test_get_flax_model_dummy_with_explicit_mesh(vllm_config, rng,
+                                                 mock_get_pp_group,
+                                                 enforce_device_order):
+    """
+    Regression test verifying that get_flax_model correctly handles native models
+    (`LlamaForCausalLM`) initialized with `load_format = "dummy"` (`model_loader.py:232`)
+    when an explicit device mesh (`AxisType.Explicit`) is used (`enforce_device_order = True`).
+
+    When enforce_device_order is True (or explicit `jax.make_mesh` is used without
+    `AxisType.Auto`), all mesh axes have `AxisType.Explicit`. When tensor_parallel_size = 1
+    (where `'model'` axis size is `1`), JAX abstract evaluation inside `@jax.jit`
+    normalizes and drops size-1 axis shardings from uncommitted/replicated state arrays
+    to `P(None, None)` (while `pspecs` expects `P(("data", "model"), None)` or `P("model", None)`).
+    In an Explicit mesh, `jax.lax.with_sharding_constraint(state, pspecs)` inside
+    `create_sharded_model()` then acts as an assertion and raises `AssertionError:
+    with_sharding_constraint acts as an assert when all axes of mesh are of type Explicit...`.
+    When enforce_device_order is False (`AxisType.Auto`), `with_sharding_constraint`
+    does not act as an assert and completes cleanly.
+    """
+    vllm_config.model_config = ModelConfig("meta-llama/Llama-3.1-8B")
+    vllm_config.model_config.dtype = jnp.bfloat16
+    vllm_config.model_config.hf_config.num_hidden_layers = 1
+    vllm_config.load_config.load_format = "dummy"
+    vllm_config.lora_config = None
+    vllm_config.cache_config = CacheConfig(block_size=16,
+                                           gpu_memory_utilization=0.9,
+                                           cache_dtype="auto")
+    devices = jax.devices()
+    tp_size = 1
+    dp_size = len(devices)
+
+    vllm_config.additional_config = {
+        "sharding": {
+            "sharding_strategy": {
+                "expert_parallelism": 1,
+                "device_indexes": list(range(dp_size)),
+                "enable_dp_attention": False,
+            }
+        }
+    }
+    vllm_config.parallel_config = ParallelConfig(pipeline_parallel_size=1,
+                                                 tensor_parallel_size=tp_size,
+                                                 data_parallel_size=dp_size)
+    vllm_config.sharding_config = ShardingConfigManager.from_vllm_config(
+        vllm_config)
+    vllm_config.parallel_config.data_parallel_size = dp_size
+    vllm_config.parallel_config.data_parallel_size_local = dp_size
+
+    # Construct a 2D mesh over ("data", "model") with tp_size=1 ('model' axis size 1)
+    # and data_parallel_size=len(devices).
+    mesh_shape = (dp_size, tp_size)
+    axis_types = (AxisType.Explicit,
+                  AxisType.Explicit) if enforce_device_order else (
+                      AxisType.Auto, AxisType.Auto)
+    device_mesh = jax.make_mesh(
+        mesh_shape,
+        ("data", "model"),
+        devices=devices,
+        axis_types=axis_types,
+    )
+
+    init_pp_distributed_environment(ip="",
+                                    rank=0,
+                                    world_size=1,
+                                    device=devices[0],
+                                    need_pp=False)
+
+    # Match MaxText runtime setting where eager sharding of variables is disabled
+    with jax.set_mesh(device_mesh), set_current_vllm_config(
+            vllm_config), nnx.use_eager_sharding(False):
+        model = model_loader.get_flax_model(vllm_config, rng, device_mesh)
+        for leaf in jax.tree.leaves(model.state):
+            if isinstance(leaf, jax.Array):
+                leaf.block_until_ready()
+
+        assert model is not None
+        assert callable(model.model_fn)
+        assert callable(model.compute_logits_fn)
+        assert model.model is not None
+        assert model.state is not None
+
+
 def test_get_flax_model_with_pooling(vllm_config, mesh, rng):
     """Tests that get_flax_model correctly instantiates a pooler when runner_type is 'pooling'."""
     vllm_config.model_config.runner_type = "pooling"
-    from vllm.config import PoolerConfig
     vllm_config.model_config.pooler_config = PoolerConfig(
         task="embed", tok_pooling_type="STEP", seq_pooling_type="CLS")
 

--- a/tests/runner/test_tpu_runner_mesh.py
+++ b/tests/runner/test_tpu_runner_mesh.py
@@ -15,8 +15,17 @@
 import os
 from unittest.mock import Mock, patch
 
+import jax
+import jax.numpy as jnp
 import pytest
+from flax import nnx
+from jax.sharding import PartitionSpec
+from vllm.config import (CacheConfig, LoadConfig, ModelConfig, ParallelConfig,
+                         SchedulerConfig, VllmConfig)
 
+from tpu_inference.distributed.jax_parallel_state import \
+    init_pp_distributed_environment
+from tpu_inference.layers.common.sharding import ShardingConfigManager
 from tpu_inference.runner.tpu_runner import TPUModelRunner
 
 
@@ -202,3 +211,98 @@ class TestTPUModelRunnerMeshInit:
 
             # First dimension of intra_node_shape should be dp_inner
             assert intra_node_shape[0] == expected_dp_inner
+
+
+class TestTPUModelRunnerMeshSharding:
+    """Test suite verifying TPUModelRunner sharding constraint behavior when loading native models."""
+
+    @pytest.mark.parametrize("enforce_device_order", [True, False])
+    @staticmethod
+    def test_load_model_dummy_with_enforced_device_order(enforce_device_order):
+        """
+        Regression test ensuring `TPUModelRunner.load_model()` reproduces the exact sharding
+        problem (`AssertionError: with_sharding_constraint acts as an assert when all axes of mesh
+        are of type Explicit...`) when enforce_device_order=True (`device_indexes` specified,
+        producing `AxisType.Explicit`) AND tensor_parallel_size=1 (`load_format="dummy"`).
+
+        When `device_indexes` is non-empty, `_create_2d_mesh()` calls `jax.make_mesh`
+        without `AxisType.Auto`, producing a Mesh where all axes are of type `Explicit`.
+        When tensor_parallel_size = 1 (where `'model'` axis size is `1`), initializing a
+        native model (e.g. LlamaForCausalLM) with `load_format = "dummy"` triggers
+        `create_sharded_model()` (`model_loader.py:232`). Because `'model'` axis size is 1,
+        JAX abstract evaluation normalizes and drops size-1 axis shardings to `P(None, None)`,
+        causing `with_sharding_constraint` under Explicit axes to raise `AssertionError`.
+        When enforce_device_order is False (`AxisType.Auto`), `with_sharding_constraint`
+        does not act as an assert and completes cleanly.
+        """
+        devices = jax.devices()
+        tp_size = 1
+        dp_size = len(devices)
+
+        model_config = ModelConfig("meta-llama/Llama-3.1-8B",
+                                   seed=0,
+                                   dtype="bfloat16")
+        model_config.hf_config.num_hidden_layers = 1
+        cache_config = CacheConfig(block_size=16,
+                                   gpu_memory_utilization=0.9,
+                                   cache_dtype="auto")
+        scheduler_config = SchedulerConfig(max_num_seqs=4,
+                                           max_model_len=128,
+                                           is_encoder_decoder=False)
+        parallel_config = ParallelConfig(pipeline_parallel_size=1,
+                                         tensor_parallel_size=tp_size,
+                                         data_parallel_size=dp_size)
+        load_config = LoadConfig(load_format="dummy")
+
+        sharding_strategy = {"tensor_parallelism": tp_size}
+        if enforce_device_order:
+            sharding_strategy["device_indexes"] = list(range(dp_size *
+                                                             tp_size))
+
+        vllm_config = VllmConfig(
+            model_config=model_config,
+            cache_config=cache_config,
+            scheduler_config=scheduler_config,
+            parallel_config=parallel_config,
+            load_config=load_config,
+            observability_config={},
+            additional_config={
+                "sharding": {
+                    "sharding_strategy": sharding_strategy
+                }
+            },
+        )
+        vllm_config.parallel_config.data_parallel_size = dp_size
+        vllm_config.parallel_config.data_parallel_size_local = dp_size
+
+        init_pp_distributed_environment(ip="",
+                                        rank=0,
+                                        world_size=1,
+                                        device=devices[0],
+                                        need_pp=False)
+
+        mock_pp_group = Mock(is_first_rank=True,
+                             is_last_rank=True,
+                             rank_in_group=0,
+                             world_size=1)
+        from tpu_inference.platforms.tpu_platform import TpuPlatform
+
+        with patch("tpu_inference.distributed.jax_parallel_state.get_pp_group", return_value=mock_pp_group), \
+             patch.object(TpuPlatform, "_initialize_sharding_config"), \
+             nnx.use_eager_sharding(False):
+            runner = TPUModelRunner(vllm_config,
+                                    devices=devices[:dp_size * tp_size])
+            if enforce_device_order:
+                assert runner.mesh.axis_types == (
+                    jax.sharding.AxisType.Explicit,
+                    jax.sharding.AxisType.Explicit)
+            else:
+                assert runner.mesh.axis_types == (jax.sharding.AxisType.Auto,
+                                                  jax.sharding.AxisType.Auto)
+            runner.load_model()
+            for leaf in jax.tree.leaves(runner.state):
+                if isinstance(leaf, jax.Array):
+                    leaf.block_until_ready()
+            assert runner.model is not None
+            assert callable(runner.model_fn)
+            assert callable(runner.compute_logits_fn)


### PR DESCRIPTION
# Description

## Summary

This PR introduces two tests in `test_model_loader.py` and `test_tpu_runner_mesh.py` to evaluate and reproduce JAX sharding constraint failures when initializing native models (`load_format = "dummy"`) under explicit device meshes.

## Problem Description & Root Cause

When `enforce_device_order = True` (or when custom `device_indexes` are configured), `_create_2d_mesh()` constructs a JAX device mesh where all axes default to `AxisType.Explicit`.
When initializing native models (e.g., `LlamaForCausalLM`, `Qwen3ForCausalLM`) with `load_format = "dummy"` and `tensor_parallel_size = 1` (where the `'model'` axis size is `1` and `'data'` axis > 1):
1. JAX abstract evaluation inside `@jax.jit` normalizes and drops size-1 axis shardings from initial unconstrained state arrays, resolving `aval.sharding.spec` to `P(None, None)`.
2. Under `Explicit` mesh axes, `jax.lax.with_sharding_constraint(state, pspecs)` (`model_loader.py:232`) acts as an assertion rather than a resharding operation.
3. Because `aval.sharding.spec` (`P(None, None)`) mismatches the non-trivial target partition specification (`P(('data', 'model'), None)` or `P('data', None)`), JAX compilation raises:
   ```text
   AssertionError: `with_sharding_constraint` acts as an assert when all axes of mesh are of type `Explicit`. The array sharding: P(None, None) did not match the sharding provided: P(('data', 'model'), None). Please use `jax.sharding.reshard` to shard your input to the sharding you want.

# Tests

Manual invocation of the tests above. They are currently expected to fail until the underlying issue is fixed.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
