### PR TITLE
Have all lm_eval run uses our own script

### DIFF
--- a/.buildkite/benchmark/lm_eval/math500/run.sh
+++ b/.buildkite/benchmark/lm_eval/math500/run.sh
@@ -35,7 +35,9 @@ unset MODEL_IMPL_TYPE VLLM_XLA_CHECK_RECOMPILATION
 mkdir -p "$LOG_DIR"
 
 CMD=(
-    lm_eval
+    python3
+    -m
+    scripts.vllm.integration.lm_eval_accuracy
     --model vllm
     --model_args "pretrained=$MODEL_NAME,tensor_parallel_size=${TENSOR_PARALLEL_SIZE:-8},dtype=auto,max_model_len=$MAX_MODEL_LEN,gpu_memory_utilization=0.98"
     --tasks "$TASK_NAME"

--- a/.buildkite/benchmark/lm_eval/mlperf/run.sh
+++ b/.buildkite/benchmark/lm_eval/mlperf/run.sh
@@ -35,7 +35,9 @@ unset MODEL_IMPL_TYPE VLLM_XLA_CHECK_RECOMPILATION
 mkdir -p "$LOG_DIR"
 
 CMD=(
-    lm_eval
+    python3
+    -m
+    scripts.vllm.integration.lm_eval_accuracy
     --model vllm
     --model_args "pretrained=$MODEL_NAME,tensor_parallel_size=${TENSOR_PARALLEL_SIZE:-8},dtype=auto,max_model_len=$MAX_MODEL_LEN,gpu_memory_utilization=0.98"
     --tasks "$TASK_NAME"

--- a/.buildkite/benchmark/lm_eval/mmlu/run.sh
+++ b/.buildkite/benchmark/lm_eval/mmlu/run.sh
@@ -46,7 +46,9 @@ if [[ "$DEVICE" == tpu7x-8 ]]; then
 fi
 
 CMD=(
-    lm_eval
+    python3
+    -m
+    scripts.vllm.integration.lm_eval_accuracy
     --model vllm
     --model_args "$MODEL_ARGS"
     --tasks mmlu_llama

--- a/scripts/vllm/integration/lm_eval_accuracy.py
+++ b/scripts/vllm/integration/lm_eval_accuracy.py
@@ -84,7 +84,23 @@ def main() -> None:
     parser.add_argument("--num_fewshot", type=int)
     parser.add_argument("--limit", type=float)
     parser.add_argument("--apply_chat_template", action="store_true")
-    args = parser.parse_args()
+    parser.add_argument("--output_path")
+    parser.add_argument("--include_path")
+    parser.add_argument("--log_samples", action="store_true")
+    args, unknown = parser.parse_known_args()
+
+    if args.include_path:
+        import lm_eval.tasks
+        lm_eval.tasks.include_path(args.include_path)
+
+    evaluation_tracker = None
+    if args.output_path or args.log_samples:
+        from lm_eval.loggers import EvaluationTracker
+
+        evaluation_tracker = EvaluationTracker(
+            output_path=args.output_path,
+            log_samples=args.log_samples,
+        )
 
     results = evaluate_with_vllm(
         model_args=_parse_model_args(args.model_args),
@@ -95,6 +111,7 @@ def main() -> None:
         num_fewshot=args.num_fewshot,
         limit=args.limit,
         apply_chat_template=args.apply_chat_template,
+        evaluation_tracker=evaluation_tracker,
     )
     if results is None:
         return

--- a/tests/scripts/test_lm_eval_accuracy.py
+++ b/tests/scripts/test_lm_eval_accuracy.py
@@ -57,3 +57,103 @@ def test_evaluate_with_vllm_always_shuts_down(monkeypatch, evaluation_fails):
         }
 
     assert shutdown_calls == [True]
+
+
+def test_main_parses_arguments(monkeypatch):
+    captured_args = {}
+
+    def fake_evaluate_with_vllm(**kwargs):
+        captured_args.update(kwargs)
+        return {"results": {}}
+
+    monkeypatch.setattr(_MODULE, "evaluate_with_vllm", fake_evaluate_with_vllm)
+    fake_lm_eval = types.ModuleType("lm_eval")
+    fake_lm_eval.utils = types.SimpleNamespace(
+        setup_logging=lambda: None,
+        make_table=lambda res: "table",
+    )
+    monkeypatch.setitem(sys.modules, "lm_eval", fake_lm_eval)
+    monkeypatch.setitem(sys.modules, "lm_eval.utils", fake_lm_eval.utils)
+
+    test_argv = [
+        "lm_eval_accuracy.py",
+        "--model_args",
+        "pretrained=test-model",
+        "--tasks",
+        "gsm8k",
+        "--apply_chat_template",
+    ]
+    monkeypatch.setattr(sys, "argv", test_argv)
+
+    _MODULE.main()
+
+    assert captured_args.get("apply_chat_template") is True
+
+
+def test_main_output_path_and_include_path(monkeypatch, tmp_path):
+    shutdown_calls = []
+    engine_core = types.SimpleNamespace(
+        shutdown=lambda: shutdown_calls.append(True))
+    model = types.SimpleNamespace(model=types.SimpleNamespace(
+        llm_engine=types.SimpleNamespace(engine_core=engine_core)))
+    monkeypatch.setattr(_MODULE, "_create_vllm_model",
+                        lambda *args, **kwargs: model)
+
+    received_kwargs = {}
+
+    def simple_evaluate(**kwargs):
+        received_kwargs.update(kwargs)
+        return {"results": {"acc": 0.95}}
+
+    included_paths = []
+    fake_lm_eval = types.ModuleType("lm_eval")
+    fake_lm_eval.simple_evaluate = simple_evaluate
+    fake_tasks = types.SimpleNamespace(
+        include_path=lambda path: included_paths.append(path))
+    fake_lm_eval.tasks = fake_tasks
+    fake_lm_eval.utils = types.SimpleNamespace(
+        setup_logging=lambda: None,
+        make_table=lambda res: "table",
+    )
+
+    class FakeEvaluationTracker:
+
+        def __init__(self, output_path, log_samples):
+            self.output_path = output_path
+            self.log_samples = log_samples
+
+    fake_loggers = types.SimpleNamespace(
+        EvaluationTracker=FakeEvaluationTracker)
+    fake_lm_eval.loggers = fake_loggers
+
+    monkeypatch.setitem(sys.modules, "lm_eval", fake_lm_eval)
+    monkeypatch.setitem(sys.modules, "lm_eval.tasks", fake_tasks)
+    monkeypatch.setitem(sys.modules, "lm_eval.utils", fake_lm_eval.utils)
+    monkeypatch.setitem(sys.modules, "lm_eval.loggers", fake_loggers)
+
+    out_json = tmp_path / "test_output.json"
+    test_argv = [
+        "lm_eval_accuracy.py",
+        "--model_args",
+        "pretrained=test-model",
+        "--tasks",
+        "gsm8k",
+        "--apply_chat_template",
+        "--output_path",
+        str(out_json),
+        "--include_path",
+        str(tmp_path),
+        "--log_samples",
+    ]
+    monkeypatch.setattr(sys, "argv", test_argv)
+
+    _MODULE.main()
+
+    assert included_paths == [str(tmp_path)]
+    assert "output_path" not in received_kwargs
+    assert "include_path" not in received_kwargs
+    tracker = received_kwargs.get("evaluation_tracker")
+    assert tracker is not None
+    assert tracker.output_path == str(out_json)
+    assert tracker.log_samples is True
+    assert shutdown_calls == [True]


### PR DESCRIPTION
Similar to #3202 but for the rest of the lm_eval run.

For example, https://buildkite.com/tpu-commons/tpu-inference-benchmark/builds/1778/canvas?sid=019f7a23-ff4b-41c7-a6eb-e89ff272ef37&tab=output this stuck for 1 day

Signed-off-by: Ming Huang <mhhua@google.com>

# Description

Start with a short description of what the PR does and how this is a change from
the past.

The rest of the description includes relevant details and context, examples:
- why is this change being made,
- the problem being solved and any relevant context,
- why this is a good solution,
- some information about the specific implementation,
- shortcomings of the solution and possible future improvements.

If the change fixes a Github issue, please include a link, e.g.,:
FIXES: #123456

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
