### PR TITLE
[Fix] Explicit EngineCore Shutdown for TPU Resource Management

### DIFF
--- a/tests/e2e/test_tensor_parallel.py
+++ b/tests/e2e/test_tensor_parallel.py
@@ -74,25 +74,32 @@ def _run_inference(
     sampling_params: SamplingParams,
 ) -> tuple[list, float]:
     """Run inference with the given configuration."""
-    llm = LLM(
-        model=config.model_name,
-        max_model_len=config.max_model_len,
-        tensor_parallel_size=config.tensor_parallel_size,
-        pipeline_parallel_size=config.pipeline_parallel_size,
-        gpu_memory_utilization=config.gpu_memory_utilization,
-        max_num_batched_tokens=config.max_num_batched_tokens,
-        max_num_seqs=config.max_num_seqs,
-        additional_config=config.additional_config,
-        kv_cache_dtype=config.kv_cache_dtype,
-        enable_prefix_caching=config.enable_prefix_caching,
-    )
+    llm = None
+    try:
+        llm = LLM(
+            model=config.model_name,
+            max_model_len=config.max_model_len,
+            tensor_parallel_size=config.tensor_parallel_size,
+            pipeline_parallel_size=config.pipeline_parallel_size,
+            gpu_memory_utilization=config.gpu_memory_utilization,
+            max_num_batched_tokens=config.max_num_batched_tokens,
+            max_num_seqs=config.max_num_seqs,
+            additional_config=config.additional_config,
+            kv_cache_dtype=config.kv_cache_dtype,
+            enable_prefix_caching=config.enable_prefix_caching,
+        )
 
-    start_time = time.time()
-    outputs = llm.generate(test_prompts, sampling_params)
-    elapsed_time = time.time() - start_time
-
-    llm.llm_engine.engine_core.shutdown()
-    return outputs, elapsed_time
+        start_time = time.time()
+        outputs = llm.generate(test_prompts, sampling_params)
+        elapsed_time = time.time() - start_time
+        return outputs, elapsed_time
+    finally:
+        # vLLM's synchronous LLM client stops EngineCore from a weakref
+        # finalizer, so a reference cycle can defer it indefinitely and leave
+        # the worker subprocess holding the container open until the CI job
+        # times out. Shut the engine down explicitly instead.
+        if llm:
+            llm.llm_engine.engine_core.shutdown()
 
 
 def _check_performance(


### PR DESCRIPTION
# Summary

Similar to #3202 and #3229 
This PR enforces explicit EngineCore shutdown across multiple E2E test suites. By wrapping LLM instances in try...finally blocks or using pytest fixture teardowns, we ensure that TPU resources and background worker processes are released even if a test fails.

# Architectural Reasoning
In TPU environments, the EngineCore often manages hardware locks and distributed processes. Relying on implicit garbage collection for LLM instances is unreliable and frequently leads to:

1. TPU Device Lockup: Subsequent tests failing with "Resource busy" or "Device already initialized" errors.
2. Orphaned Processes: Background workers remaining alive, consuming memory and TPU slices.

# Tests

[buildkite](https://buildkite.com/tpu-commons/tpu-inference-ci/builds/22827/canvas) (Only test those with issues.)

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
