### PR TITLE
[releases/v0.25.0] Cherry-pick #3202: Fix lm-eval accuracy jobs hanging on exit

### DIFF
--- a/scripts/vllm/integration/lm_eval_accuracy.py
+++ b/scripts/vllm/integration/lm_eval_accuracy.py
@@ -1,0 +1,110 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Run lm-eval with explicit ownership of the vLLM engine."""
+
+import argparse
+import json
+from typing import Any
+
+
+def _create_vllm_model(model_args: str | dict[str, Any], batch_size: str | int,
+                       max_batch_size: int | None, device: str | None):
+    from lm_eval.models.vllm_causallms import VLLM
+
+    additional_config = {
+        "batch_size": batch_size,
+        "max_batch_size": max_batch_size,
+        "device": device,
+    }
+    if isinstance(model_args, str):
+        return VLLM.create_from_arg_string(model_args, additional_config)
+    return VLLM.create_from_arg_obj(model_args, additional_config)
+
+
+def evaluate_with_vllm(
+    *,
+    model_args: str | dict[str, Any],
+    tasks: str | list[str],
+    batch_size: str | int = "auto",
+    max_batch_size: int | None = None,
+    device: str | None = None,
+    **evaluation_args: Any,
+):
+    """Evaluate with lm-eval and shut down its vLLM EngineCore on every exit."""
+    import lm_eval
+
+    model = _create_vllm_model(model_args, batch_size, max_batch_size, device)
+    try:
+        return lm_eval.simple_evaluate(
+            model=model,
+            tasks=tasks,
+            batch_size=batch_size,
+            max_batch_size=max_batch_size,
+            device=device,
+            **evaluation_args,
+        )
+    finally:
+        # vLLM's synchronous LLM client relies on garbage collection to stop
+        # EngineCore. Reference cycles can defer collection indefinitely and
+        # leave the CI container alive after evaluation has completed.
+        model.model.llm_engine.engine_core.shutdown()
+
+
+def _parse_model_args(value: str) -> str | dict[str, Any]:
+    if not value.lstrip().startswith("{"):
+        return value
+    parsed = json.loads(value)
+    if not isinstance(parsed, dict):
+        raise ValueError("--model_args JSON must be an object")
+    return parsed
+
+
+def main() -> None:
+    from lm_eval.utils import setup_logging
+
+    setup_logging()
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model", choices=["vllm"], default="vllm")
+    parser.add_argument("--model_args", required=True)
+    parser.add_argument("--tasks", required=True)
+    parser.add_argument("--batch_size", default="auto")
+    parser.add_argument("--max_batch_size", type=int)
+    parser.add_argument("--device")
+    parser.add_argument("--num_fewshot", type=int)
+    parser.add_argument("--limit", type=float)
+    parser.add_argument("--apply_chat_template", action="store_true")
+    args = parser.parse_args()
+
+    results = evaluate_with_vllm(
+        model_args=_parse_model_args(args.model_args),
+        tasks=args.tasks,
+        batch_size=args.batch_size,
+        max_batch_size=args.max_batch_size,
+        device=args.device,
+        num_fewshot=args.num_fewshot,
+        limit=args.limit,
+        apply_chat_template=args.apply_chat_template,
+    )
+    if results is None:
+        return
+
+    from lm_eval.utils import make_table
+
+    print(make_table(results))
+    if "groups" in results:
+        print(make_table(results, "groups"))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/vllm/integration/test_accuracy.py
+++ b/scripts/vllm/integration/test_accuracy.py
@@ -14,8 +14,8 @@ AsyncLLMEngine are working correctly.
 import os
 import threading
 
-import lm_eval
 import pytest
+from lm_eval_accuracy import evaluate_with_vllm
 from vllm.platforms import current_platform
 
 MODEL_NAMES = []
@@ -50,8 +50,7 @@ def run_test(model_name, expected_value, more_args=None):
               "fewshot_as_multiturn for lm_eval. Required for instruction-"
               "tuned BOS-sensitive models like gemma-4-it.")
 
-    results = lm_eval.simple_evaluate(
-        model="vllm",
+    results = evaluate_with_vllm(
         model_args=model_args,
         tasks="gsm8k",
         batch_size="auto",

--- a/tests/e2e/check_lm_eval.sh
+++ b/tests/e2e/check_lm_eval.sh
@@ -119,7 +119,8 @@ if [ -n "$LIMIT" ]; then
     lm_eval_args+=(--limit "$LIMIT")
 fi
 
-output=$(VLLM_XLA_CHECK_RECOMPILATION=0 USE_MOE_EP_KERNEL=${USE_MOE_EP_KERNEL} MODEL_IMPL_TYPE=vllm lm_eval "${lm_eval_args[@]}")
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+output=$(VLLM_XLA_CHECK_RECOMPILATION=0 USE_MOE_EP_KERNEL=${USE_MOE_EP_KERNEL} MODEL_IMPL_TYPE=vllm python "${script_dir}/../../scripts/vllm/integration/lm_eval_accuracy.py" "${lm_eval_args[@]}")
 
 echo "Evaluation output:"
 echo "$output"

--- a/tests/scripts/test_lm_eval_accuracy.py
+++ b/tests/scripts/test_lm_eval_accuracy.py
@@ -1,0 +1,59 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+_MODULE_PATH = (Path(__file__).parents[2] / "scripts" / "vllm" /
+                "integration" / "lm_eval_accuracy.py")
+_SPEC = importlib.util.spec_from_file_location("lm_eval_accuracy",
+                                               _MODULE_PATH)
+assert _SPEC is not None and _SPEC.loader is not None
+_MODULE = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_MODULE)
+
+
+@pytest.mark.parametrize("evaluation_fails", [False, True])
+def test_evaluate_with_vllm_always_shuts_down(monkeypatch, evaluation_fails):
+    shutdown_calls = []
+    engine_core = types.SimpleNamespace(
+        shutdown=lambda: shutdown_calls.append(True))
+    model = types.SimpleNamespace(model=types.SimpleNamespace(
+        llm_engine=types.SimpleNamespace(engine_core=engine_core)))
+    monkeypatch.setattr(_MODULE, "_create_vllm_model",
+                        lambda *args, **kwargs: model)
+
+    fake_lm_eval = types.ModuleType("lm_eval")
+
+    def simple_evaluate(**kwargs):
+        if evaluation_fails:
+            raise RuntimeError("evaluation failed")
+        return {"results": {}}
+
+    fake_lm_eval.simple_evaluate = simple_evaluate
+    monkeypatch.setitem(sys.modules, "lm_eval", fake_lm_eval)
+
+    if evaluation_fails:
+        with pytest.raises(RuntimeError, match="evaluation failed"):
+            _MODULE.evaluate_with_vllm(model_args={}, tasks="task")
+    else:
+        assert _MODULE.evaluate_with_vllm(model_args={}, tasks="task") == {
+            "results": {}
+        }
+
+    assert shutdown_calls == [True]


### PR DESCRIPTION
# Description

Cherry-pick of #3202 (merged to main as 407675977) onto releases/v0.25.0.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
