### PR TITLE
[releases/v0.25.0] [Fix] Explicit EngineCore Shutdown for TPU Resource Management

### DIFF
--- a/tests/e2e/test_sampling_params.py
+++ b/tests/e2e/test_sampling_params.py
@@ -33,12 +33,20 @@ from vllm import LLM, SamplingParams
 @pytest.fixture(scope="module")
 def llm():
     """Create a shared LLM instance for all tests in this module."""
-    return LLM(
+    instance = LLM(
         model='meta-llama/Llama-3.2-1B-Instruct',
         max_model_len=1024,
         max_num_seqs=4,
         enable_prefix_caching=False,
     )
+    try:
+        yield instance
+    finally:
+        # vLLM's synchronous LLM client stops EngineCore from a weakref
+        # finalizer, so a reference cycle can defer it indefinitely and leave
+        # the worker subprocess holding the container open until the CI job
+        # times out. Shut the engine down explicitly instead.
+        instance.llm_engine.engine_core.shutdown()
 
 
 class TestTemperature:

--- a/tests/e2e/test_step_pooling.py
+++ b/tests/e2e/test_step_pooling.py
@@ -64,3 +64,9 @@ def test_step_pooling_e2e():
 
     except Exception as e:
         pytest.fail(f"Embedding execution failed during chunked prefill: {e}")
+    finally:
+        # vLLM's synchronous LLM client stops EngineCore from a weakref
+        # finalizer, so a reference cycle can defer it indefinitely and leave
+        # the worker subprocess holding the container open until the CI job
+        # times out. Shut the engine down explicitly instead.
+        llm.llm_engine.engine_core.shutdown()

--- a/tests/e2e/test_structured_decoding.py
+++ b/tests/e2e/test_structured_decoding.py
@@ -35,12 +35,19 @@ def test_structured_decoding():
               max_num_seqs=1,
               enable_prefix_caching=False)
 
-    choices = ['Positive', 'Negative']
-    structured_outputs_params = StructuredOutputsParams(choice=choices)
-    sampling_params = SamplingParams(
-        structured_outputs=structured_outputs_params)
-    outputs = llm.generate(
-        prompts="Classify this sentiment: tpu-inference is wonderful!",
-        sampling_params=sampling_params,
-    )
-    assert outputs[0].outputs[0].text in choices
+    try:
+        choices = ['Positive', 'Negative']
+        structured_outputs_params = StructuredOutputsParams(choice=choices)
+        sampling_params = SamplingParams(
+            structured_outputs=structured_outputs_params)
+        outputs = llm.generate(
+            prompts="Classify this sentiment: tpu-inference is wonderful!",
+            sampling_params=sampling_params,
+        )
+        assert outputs[0].outputs[0].text in choices
+    finally:
+        # vLLM's synchronous LLM client stops EngineCore from a weakref
+        # finalizer, so a reference cycle can defer it indefinitely and leave
+        # the worker subprocess holding the container open until the CI job
+        # times out. Shut the engine down explicitly instead.
+        llm.llm_engine.engine_core.shutdown()

--- a/tests/e2e/test_tensor_parallel.py
+++ b/tests/e2e/test_tensor_parallel.py
@@ -74,25 +74,32 @@ def _run_inference(
     sampling_params: SamplingParams,
 ) -> tuple[list, float]:
     """Run inference with the given configuration."""
-    llm = LLM(
-        model=config.model_name,
-        max_model_len=config.max_model_len,
-        tensor_parallel_size=config.tensor_parallel_size,
-        pipeline_parallel_size=config.pipeline_parallel_size,
-        gpu_memory_utilization=config.gpu_memory_utilization,
-        max_num_batched_tokens=config.max_num_batched_tokens,
-        max_num_seqs=config.max_num_seqs,
-        additional_config=config.additional_config,
-        kv_cache_dtype=config.kv_cache_dtype,
-        enable_prefix_caching=config.enable_prefix_caching,
-    )
+    llm = None
+    try:
+        llm = LLM(
+            model=config.model_name,
+            max_model_len=config.max_model_len,
+            tensor_parallel_size=config.tensor_parallel_size,
+            pipeline_parallel_size=config.pipeline_parallel_size,
+            gpu_memory_utilization=config.gpu_memory_utilization,
+            max_num_batched_tokens=config.max_num_batched_tokens,
+            max_num_seqs=config.max_num_seqs,
+            additional_config=config.additional_config,
+            kv_cache_dtype=config.kv_cache_dtype,
+            enable_prefix_caching=config.enable_prefix_caching,
+        )
 
-    start_time = time.time()
-    outputs = llm.generate(test_prompts, sampling_params)
-    elapsed_time = time.time() - start_time
-
-    llm.llm_engine.engine_core.shutdown()
-    return outputs, elapsed_time
+        start_time = time.time()
+        outputs = llm.generate(test_prompts, sampling_params)
+        elapsed_time = time.time() - start_time
+        return outputs, elapsed_time
+    finally:
+        # vLLM's synchronous LLM client stops EngineCore from a weakref
+        # finalizer, so a reference cycle can defer it indefinitely and leave
+        # the worker subprocess holding the container open until the CI job
+        # times out. Shut the engine down explicitly instead.
+        if llm:
+            llm.llm_engine.engine_core.shutdown()
 
 
 def _check_performance(


### PR DESCRIPTION
# Description

Mirrors https://github.com/vllm-project/tpu-inference/pull/3226 and https://github.com/vllm-project/tpu-inference/pull/3229 on the release branch.

## Problem

Several Buildkite steps finish all their work but never exit — pytest prints its summary, then the container sits until the job timeout and the step is marked failed regardless of the test outcome. 

This is the failure mode described in #3202: vLLM's synchronous `LLM` client stops its `EngineCore` subprocess from a weakref finalizer, so if the model stays reachable through a reference cycle the finalizer never runs and the worker keeps the container alive.

# Summary

This PR enforces explicit EngineCore shutdown across multiple E2E test suites. By wrapping LLM instances in try...finally blocks or using pytest fixture teardowns, we ensure that TPU resources and background worker processes are released even if a test fails.

# Architectural Reasoning
In TPU environments, the EngineCore often manages hardware locks and distributed processes. Relying on implicit garbage collection for LLM instances is unreliable and frequently leads to:

1. TPU Device Lockup: Subsequent tests failing with "Resource busy" or "Device already initialized" errors.
2. Orphaned Processes: Background workers remaining alive, consuming memory and TPU slices.

# Tests

[buildkite](https://buildkite.com/tpu-commons/tpu-inference-ci/builds/22827/canvas) (Only test those with issues.)

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
