### PR TITLE
Shut down EngineCore explicitly in e2e tests that leak it

### DIFF
--- a/tests/e2e/test_sampling_params.py
+++ b/tests/e2e/test_sampling_params.py
@@ -33,12 +33,20 @@ from vllm import LLM, SamplingParams
 @pytest.fixture(scope="module")
 def llm():
     """Create a shared LLM instance for all tests in this module."""
-    return LLM(
+    instance = LLM(
         model='meta-llama/Llama-3.2-1B-Instruct',
         max_model_len=1024,
         max_num_seqs=4,
         enable_prefix_caching=False,
     )
+    try:
+        yield instance
+    finally:
+        # vLLM's synchronous LLM client stops EngineCore from a weakref
+        # finalizer, so a reference cycle can defer it indefinitely and leave
+        # the worker subprocess holding the container open until the CI job
+        # times out. Shut the engine down explicitly instead.
+        instance.llm_engine.engine_core.shutdown()
 
 
 class TestTemperature:

--- a/tests/e2e/test_step_pooling.py
+++ b/tests/e2e/test_step_pooling.py
@@ -64,3 +64,9 @@ def test_step_pooling_e2e():
 
     except Exception as e:
         pytest.fail(f"Embedding execution failed during chunked prefill: {e}")
+    finally:
+        # vLLM's synchronous LLM client stops EngineCore from a weakref
+        # finalizer, so a reference cycle can defer it indefinitely and leave
+        # the worker subprocess holding the container open until the CI job
+        # times out. Shut the engine down explicitly instead.
+        llm.llm_engine.engine_core.shutdown()

--- a/tests/e2e/test_structured_decoding.py
+++ b/tests/e2e/test_structured_decoding.py
@@ -35,12 +35,19 @@ def test_structured_decoding():
               max_num_seqs=1,
               enable_prefix_caching=False)
 
-    choices = ['Positive', 'Negative']
-    structured_outputs_params = StructuredOutputsParams(choice=choices)
-    sampling_params = SamplingParams(
-        structured_outputs=structured_outputs_params)
-    outputs = llm.generate(
-        prompts="Classify this sentiment: tpu-inference is wonderful!",
-        sampling_params=sampling_params,
-    )
-    assert outputs[0].outputs[0].text in choices
+    try:
+        choices = ['Positive', 'Negative']
+        structured_outputs_params = StructuredOutputsParams(choice=choices)
+        sampling_params = SamplingParams(
+            structured_outputs=structured_outputs_params)
+        outputs = llm.generate(
+            prompts="Classify this sentiment: tpu-inference is wonderful!",
+            sampling_params=sampling_params,
+        )
+        assert outputs[0].outputs[0].text in choices
+    finally:
+        # vLLM's synchronous LLM client stops EngineCore from a weakref
+        # finalizer, so a reference cycle can defer it indefinitely and leave
+        # the worker subprocess holding the container open until the CI job
+        # times out. Shut the engine down explicitly instead.
+        llm.llm_engine.engine_core.shutdown()


### PR DESCRIPTION
## Problem

Several Buildkite steps finish all their work but never exit — pytest prints its summary, then the container sits until the job timeout and the step is marked failed regardless of the test outcome. 

This is the failure mode described in #3202: vLLM's synchronous `LLM` client stops its `EngineCore` subprocess from a weakref finalizer, so if the model stays reachable through a reference cycle the finalizer never runs and the worker keeps the container alive.

#3202 fixed the lm-eval entry points (`scripts/vllm/integration/lm_eval_accuracy.py`, `check_lm_eval.sh`). It did not cover the e2e tests that construct `LLM` directly.

## Change

Three e2e tests build an `LLM` and never shut its engine down:

| test | Buildkite step |
| --- | --- |
| `tests/e2e/test_step_pooling.py` | `.buildkite/features/Step_Pooling_Embedding.yml`, `.buildkite/models/Qwen_Qwen3-Embedding-8B.yml` |
| `tests/e2e/test_structured_decoding.py` | `.buildkite/features/Structured_Decoding.yml` |
| `tests/e2e/test_sampling_params.py` | `.buildkite/features/sampling_params.yml` |

Each now shuts the engine down explicitly, using the `try` / `finally` + `llm.llm_engine.engine_core.shutdown()` idiom already used by `test_continue_decode.py`, `test_hybrid_kvcache.py` and `test_multi_modal_inference.py`. For `test_sampling_params.py` the module-scoped `llm` fixture becomes a `yield` fixture so teardown runs after the last test in the module.

## Testing

-  [nightly run](https://buildkite.com/tpu-commons/tpu-inference-ci/builds/22859/list)