### PR TITLE
[RL] Add vLLM-native weight transfer API for RL weight sync

### DIFF
--- a/tests/worker/tpu_worker_test.py
+++ b/tests/worker/tpu_worker_test.py
@@ -15,6 +15,7 @@
 from unittest.mock import MagicMock, patch
 
 import pytest
+import vllm.envs as vllm_envs
 from vllm.config import ModelConfig
 from vllm.v1.kv_cache_interface import KVCacheConfig
 from vllm.v1.outputs import DraftTokenIds
@@ -667,3 +668,55 @@ class TestTPUWorker:
             assert os.environ["TPU_PROCESS_ADDRESSES"] == "localhost:9999"
             assert os.environ["TPU_PROCESS_PORT"] == "9999"
             assert os.environ["CLOUD_TPU_TASK_ID"] == "0"
+
+    #
+    # --- Weight Update Tests ---
+    #
+
+    def _weight_update_worker(self, mock_vllm_config, monkeypatch):
+        """A worker with a stub model runner, on the Pathways transport."""
+        monkeypatch.setattr(vllm_envs, "VLLM_TPU_USING_PATHWAYS", True)
+        worker = TPUWorker(vllm_config=mock_vllm_config,
+                           local_rank=0,
+                           rank=0,
+                           distributed_init_method="test_method",
+                           devices=['tpu:0'])
+        worker.model_runner = MagicMock()
+        worker.model_runner.state_leaves = ()
+        return worker
+
+    def test_full_update_cycle(self, mock_vllm_config, monkeypatch):
+        """Tests a weight update applying weights and cycling the KV cache."""
+        worker = self._weight_update_worker(mock_vllm_config, monkeypatch)
+        runner = worker.model_runner
+
+        worker.start_weight_update()
+        worker.update_weights({"weights": "STATE"})
+        worker.finish_weight_update()
+
+        runner._sync_weights.assert_called_once_with(updated_weights="STATE",
+                                                     mappings={},
+                                                     transpose_keys={},
+                                                     reshard_fn=None)
+        runner.delete_kv_cache.assert_called_once()
+        runner.reinitialize_kv_cache.assert_called_once()
+        assert worker._weight_update_active is False
+
+    def test_failed_sync_ends_session_and_finish_restores_kv(
+            self, mock_vllm_config, monkeypatch):
+        """Tests that a failed update ends the session and restores HBM."""
+        worker = self._weight_update_worker(mock_vllm_config, monkeypatch)
+        runner = worker.model_runner
+        runner._sync_weights.side_effect = RuntimeError("sync boom")
+
+        worker.start_weight_update()
+        with pytest.raises(RuntimeError, match="sync boom"):
+            worker.update_weights({"weights": "STATE"})
+        assert worker._weight_update_active is False
+
+        # Further chunks are refused rather than silently applied.
+        with pytest.raises(RuntimeError, match="start_weight_update must be"):
+            worker.update_weights({"weights": "STATE"})
+
+        worker.finish_weight_update()
+        runner.reinitialize_kv_cache.assert_called_once()

--- a/tests/worker/tpu_worker_test.py
+++ b/tests/worker/tpu_worker_test.py
@@ -695,12 +695,6 @@ class TestTPUWorker:
         runner.reinitialize_kv_cache.assert_called_once()
         assert worker._weight_update_active is False
 
-    def test_update_without_start_raises(self, mock_vllm_config):
-        """Tests that weights cannot be applied outside a session."""
-        worker = self._weight_update_worker(mock_vllm_config)
-        with pytest.raises(RuntimeError, match="start_weight_update must be"):
-            worker.update_weights({})
-
     def test_kv_cache_untouched_when_not_freed(self, mock_vllm_config):
         """Tests that free_kv_cache=False leaves the KV cache alone."""
         worker = self._weight_update_worker(mock_vllm_config)

--- a/tests/worker/tpu_worker_test.py
+++ b/tests/worker/tpu_worker_test.py
@@ -15,7 +15,6 @@
 from unittest.mock import MagicMock, patch
 
 import pytest
-import vllm.envs as vllm_envs
 from vllm.config import ModelConfig
 from vllm.v1.kv_cache_interface import KVCacheConfig
 from vllm.v1.outputs import DraftTokenIds
@@ -673,50 +672,47 @@ class TestTPUWorker:
     # --- Weight Update Tests ---
     #
 
-    def _weight_update_worker(self, mock_vllm_config, monkeypatch):
-        """A worker with a stub model runner, on the Pathways transport."""
-        monkeypatch.setattr(vllm_envs, "VLLM_TPU_USING_PATHWAYS", True)
+    def _weight_update_worker(self, mock_vllm_config):
+        """A worker with a stub model runner."""
         worker = TPUWorker(vllm_config=mock_vllm_config,
                            local_rank=0,
                            rank=0,
                            distributed_init_method="test_method",
                            devices=['tpu:0'])
         worker.model_runner = MagicMock()
-        worker.model_runner.state_leaves = ()
         return worker
 
-    def test_full_update_cycle(self, mock_vllm_config, monkeypatch):
-        """Tests a weight update applying weights and cycling the KV cache."""
-        worker = self._weight_update_worker(mock_vllm_config, monkeypatch)
+    def test_full_update_cycle(self, mock_vllm_config):
+        """Tests that a weight update cycles the KV cache and closes cleanly."""
+        worker = self._weight_update_worker(mock_vllm_config)
         runner = worker.model_runner
 
         worker.start_weight_update()
-        worker.update_weights({"weights": "STATE"})
+        worker.update_weights({})
         worker.finish_weight_update()
 
-        runner._sync_weights.assert_called_once_with(updated_weights="STATE",
-                                                     mappings={},
-                                                     transpose_keys={},
-                                                     reshard_fn=None)
         runner.delete_kv_cache.assert_called_once()
         runner.reinitialize_kv_cache.assert_called_once()
         assert worker._weight_update_active is False
 
-    def test_failed_sync_ends_session_and_finish_restores_kv(
-            self, mock_vllm_config, monkeypatch):
-        """Tests that a failed update ends the session and restores HBM."""
-        worker = self._weight_update_worker(mock_vllm_config, monkeypatch)
-        runner = worker.model_runner
-        runner._sync_weights.side_effect = RuntimeError("sync boom")
-
-        worker.start_weight_update()
-        with pytest.raises(RuntimeError, match="sync boom"):
-            worker.update_weights({"weights": "STATE"})
-        assert worker._weight_update_active is False
-
-        # Further chunks are refused rather than silently applied.
+    def test_update_without_start_raises(self, mock_vllm_config):
+        """Tests that weights cannot be applied outside a session."""
+        worker = self._weight_update_worker(mock_vllm_config)
         with pytest.raises(RuntimeError, match="start_weight_update must be"):
-            worker.update_weights({"weights": "STATE"})
+            worker.update_weights({})
 
+    def test_kv_cache_untouched_when_not_freed(self, mock_vllm_config):
+        """Tests that free_kv_cache=False leaves the KV cache alone."""
+        worker = self._weight_update_worker(mock_vllm_config)
+        runner = worker.model_runner
+
+        # Also exercised after a session that did free it.
+        worker.start_weight_update()
         worker.finish_weight_update()
-        runner.reinitialize_kv_cache.assert_called_once()
+        runner.reset_mock()
+
+        worker.start_weight_update(free_kv_cache=False)
+        worker.finish_weight_update()
+
+        runner.delete_kv_cache.assert_not_called()
+        runner.reinitialize_kv_cache.assert_not_called()

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -18,11 +18,10 @@ import random
 import sys
 from contextlib import nullcontext
 from dataclasses import dataclass
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union, cast
+from typing import Any, Dict, List, Optional, Tuple, Union, cast
 
 import jax
 import jax.numpy as jnp
-import jaxtyping
 import numpy as np
 import torch
 import vllm.lora.utils as lora_utils_mod
@@ -70,8 +69,6 @@ from tpu_inference.logger import init_logger
 from tpu_inference.models.common.model_loader import get_model
 from tpu_inference.models.jax.jax_intermediate_tensor import \
     JaxIntermediateTensors
-from tpu_inference.models.jax.utils.weight_utils import (
-    shard_put, transfer_state_with_mappings)
 from tpu_inference.runner import utils as runner_utils
 from tpu_inference.runner.compilation_manager import CompilationManager
 from tpu_inference.runner.decode_loop import TpuSamplingState, continue_decode
@@ -3052,35 +3049,6 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
     ):
         return self.kv_cache_manager.insert_request_with_kv_cache(
             request, kv_cache_slices, block_ids)
-
-    ###### RL framework integration ######
-
-    def _sync_weights(
-        self,
-        updated_weights: jaxtyping.PyTree,
-        mappings: Dict[str, Tuple[str, Tuple[str]]],
-        transpose_keys: Dict[str, Tuple[int]],
-        reshard_fn: Callable[[jaxtyping.PyTree, jaxtyping.PyTree],
-                             jaxtyping.PyTree] = None
-    ) -> None:
-        """For RL framework integration."""
-        if reshard_fn is not None:
-            updated_weights = reshard_fn(updated_weights, self.state)
-            shard = None
-        else:
-            shard = functools.partial(shard_put, mesh=self.mesh)
-        self.state = transfer_state_with_mappings(
-            src_state=updated_weights,
-            tgt_state=self.state,
-            mappings=mappings,
-            transpose_keys=transpose_keys,
-            shard=shard)
-        # Keep the dispatch-side view in sync with the updated state so
-        # subsequent jit dispatches see the new weights.
-        if isinstance(self.state, nnx.State):
-            self.state_leaves = tuple(jax.tree_util.tree_leaves(self.state))
-        else:
-            self.state_leaves = self.state
 
     def _get_padded_total_tokens(
             self, scheduler_output: "VllmSchedulerOutput") -> int:

--- a/tpu_inference/worker/tpu_worker.py
+++ b/tpu_inference/worker/tpu_worker.py
@@ -10,6 +10,7 @@ from typing import Any, Callable, Dict, Optional, Tuple
 import jax
 import jaxlib
 import jaxtyping
+import vllm.envs as vllm_envs
 from vllm.config import VllmConfig, set_current_vllm_config
 from vllm.distributed.kv_transfer import (ensure_kv_transfer_initialized,
                                           has_kv_transfer_group)
@@ -177,6 +178,9 @@ def _parse_profile_options(
 
 
 class TPUWorker(WorkerBase):
+
+    _weight_update_active: bool = False
+    _kv_cache_freed: bool = False
 
     def __init__(
         self,
@@ -732,6 +736,64 @@ class TPUWorker(WorkerBase):
                                                mappings=mappings,
                                                transpose_keys=transpose_keys,
                                                reshard_fn=reshard_fn)
+
+    def init_weight_transfer_engine(self, init_info: Dict[str, Any]) -> None:
+        """Prepare the transport.
+
+        No setup is needed today; Raiden will build its `WeightSynchronizer`
+        here.
+        """
+        logger.info("init_weight_transfer_engine: %s", sorted(init_info or {}))
+
+    def start_weight_update(self, free_kv_cache: bool = True) -> None:
+        """Open a weight update session.
+
+        Freeing the KV cache is on by default: an incoming set of weights
+        roughly doubles peak HBM, and decoding from KV computed under the old
+        weights is incorrect. `finish_weight_update` reallocates it.
+
+        The prefix cache is scheduler-side and cannot be dropped here, so
+        callers must `reset_prefix_cache()` first -- otherwise the scheduler
+        serves hits from blocks this frees.
+        """
+        if self._weight_update_active:
+            raise RuntimeError(
+                "start_weight_update called while an update is already "
+                "active. Call finish_weight_update first.")
+        if free_kv_cache:
+            self.model_runner.delete_kv_cache()
+            self._kv_cache_freed = True
+        self._weight_update_active = True
+
+    def update_weights(self, update_info: Dict[str, Any]) -> None:
+        """Under Pathways the trainer shares a JAX client and hands over a live
+        pytree. Otherwise it pushed into HBM over Raiden, whose receiver
+        already H2D'd, and this is a no-op.
+        """
+        if not self._weight_update_active:
+            raise RuntimeError(
+                "start_weight_update must be called before update_weights.")
+
+        if not vllm_envs.VLLM_TPU_USING_PATHWAYS:
+            return
+
+        try:
+            self.model_runner._sync_weights(
+                updated_weights=update_info["weights"],
+                mappings=update_info.get("mappings") or {},
+                transpose_keys=update_info.get("transpose_keys") or {},
+                reshard_fn=update_info.get("reshard_fn"))
+            jax.block_until_ready(self.model_runner.state_leaves)
+        except BaseException:
+            self._weight_update_active = False
+            raise
+
+    def finish_weight_update(self) -> None:
+        """Close the session and restore serving state."""
+        self._weight_update_active = False
+        if self._kv_cache_freed:
+            self.model_runner.reinitialize_kv_cache()
+            self._kv_cache_freed = False
 
     def delete_kv_cache(self) -> None:
         self.model_runner.delete_kv_cache()

--- a/tpu_inference/worker/tpu_worker.py
+++ b/tpu_inference/worker/tpu_worker.py
@@ -5,12 +5,10 @@ import os
 import re
 import tempfile
 from dataclasses import dataclass, field
-from typing import Any, Callable, Dict, Optional, Tuple
+from typing import Any, Dict, Optional, Tuple
 
 import jax
 import jaxlib
-import jaxtyping
-import vllm.envs as vllm_envs
 from vllm.config import VllmConfig, set_current_vllm_config
 from vllm.distributed.kv_transfer import (ensure_kv_transfer_initialized,
                                           has_kv_transfer_group)
@@ -723,20 +721,6 @@ class TPUWorker(WorkerBase):
         port = get_kv_transfer_port()
         return (int(self.topology_order_id), ip, int(port))
 
-    def sync_weights(
-        self,
-        updated_weights: jaxtyping.PyTree,
-        mappings: Dict[str, Tuple[str, Tuple[str]]],
-        transpose_keys: Dict[str, Tuple[int]],
-        reshard_fn: Callable[[jaxtyping.PyTree, jaxtyping.PyTree],
-                             jaxtyping.PyTree] = None
-    ) -> None:
-        """Sync the updated weights to the model runner."""
-        return self.model_runner._sync_weights(updated_weights=updated_weights,
-                                               mappings=mappings,
-                                               transpose_keys=transpose_keys,
-                                               reshard_fn=reshard_fn)
-
     def init_weight_transfer_engine(self, init_info: Dict[str, Any]) -> None:
         """Prepare the transport.
 
@@ -762,31 +746,17 @@ class TPUWorker(WorkerBase):
                 "active. Call finish_weight_update first.")
         if free_kv_cache:
             self.model_runner.delete_kv_cache()
-            self._kv_cache_freed = True
+        self._kv_cache_freed = free_kv_cache
         self._weight_update_active = True
 
     def update_weights(self, update_info: Dict[str, Any]) -> None:
-        """Under Pathways the trainer shares a JAX client and hands over a live
-        pytree. Otherwise it pushed into HBM over Raiden, whose receiver
-        already H2D'd, and this is a no-op.
+        """No-op. Tunix writes into the exposed vLLM model weights directly, and
+        Raiden's receiver auto-H2Ds on receipt. The phase is kept because
+        vLLM's contract has it.
         """
-        if not self._weight_update_active:
-            raise RuntimeError(
-                "start_weight_update must be called before update_weights.")
-
-        if not vllm_envs.VLLM_TPU_USING_PATHWAYS:
-            return
-
-        try:
-            self.model_runner._sync_weights(
-                updated_weights=update_info["weights"],
-                mappings=update_info.get("mappings") or {},
-                transpose_keys=update_info.get("transpose_keys") or {},
-                reshard_fn=update_info.get("reshard_fn"))
-            jax.block_until_ready(self.model_runner.state_leaves)
-        except BaseException:
-            self._weight_update_active = False
-            raise
+        logger.info(
+            "update_weights is a no-op on TPU; weights are applied "
+            "out-of-band (%s).", sorted(update_info or {}))
 
     def finish_weight_update(self) -> None:
         """Close the session and restore serving state."""


### PR DESCRIPTION
# Description

This PR adds weight-update API vLLM standardized on: `init_weight_transfer_engine`, `start_weight_update`, `update_weights`, `finish_weight_update` to `TPUWorker`, so RL frameworks and orchestrators can drive a TPU sampler through a standard interface instead of a bespoke entry point.

## Usage

```python
llm.reset_prefix_cache()                      # scheduler-side; caller's job
llm.start_weight_update()                     # frees the KV cache
llm.update_weights()    
llm.finish_weight_update()                    # reallocates the KV cache
```

On TPU, update_weights is currently an no-op. Under Raiden, RL trainer transfers weights directly into the sampler's PJRT buffer (push mode). Under Pathways reshard, RL trainer directly modifies sampler weights. 


# Tests

Added unit tests.

# Checklist

Before submitting this PR, please make sure:
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have made or will make corresponding changes to any relevant documentation.
