### PR TITLE
Propagate sharding metadata from Flax NNX correctly.

### DIFF
--- a/tpu_inference/layers/jax/quantization/configs.py
+++ b/tpu_inference/layers/jax/quantization/configs.py
@@ -190,7 +190,7 @@ class QuantLinearConfig(CommonQuantLinearConfig):
         # Update weight_sharding and bias_sharding for 2D matmul compatibility
         if self.batch_features:
             self.weight_sharding = _to_partition_spec(
-                weight.get_metadata().get("sharding", ()))
+                weight.get_metadata().get("out_sharding", ()))
         else:
             self.weight_sharding = jax.sharding.PartitionSpec(
                 *(self.in_features_sharding + self.out_features_sharding))

--- a/tpu_inference/layers/jax/quantization/unquantized.py
+++ b/tpu_inference/layers/jax/quantization/unquantized.py
@@ -357,7 +357,7 @@ class UnquantizedConfig(QuantizationConfig):
         if isinstance(layer, JaxMergedColumnParallelLinear):
             # Read the weight's partition spec so n_shards = get_mesh_shape_product
             # picks up the TP degree from the active mesh automatically.
-            sharding = layer.weight.get_metadata().get("sharding", None)
+            sharding = layer.weight.get_metadata().get("out_sharding", None)
             weight_sharding = P(*sharding) if sharding is not None else None
             linear_config = QuantLinearConfig(enable_sp=False,
                                               output_sizes=list(

--- a/tpu_inference/models/common/pathways_dummy_loader.py
+++ b/tpu_inference/models/common/pathways_dummy_loader.py
@@ -89,7 +89,7 @@ def load_dummy_weights_jax(model, mesh: Mesh) -> None:
     t0 = time.perf_counter()
 
     for param_name, param in model.named_parameters():
-        spec = param.get_metadata().get("sharding", ())
+        spec = param.get_metadata().get("out_sharding", ())
         if isinstance(spec, NamedSharding):
             spec = spec.spec
         elif isinstance(spec, SingleDeviceSharding):


### PR DESCRIPTION
This PR fixes the propagation of sharding metadata from Flax NNX to weight loaders and quantization configurations in the JAX path.

Flax NNX deprecated the `"sharding"` metadata key in favor of `"out_sharding"`. While `weight_utils.py` was updated to use `"out_sharding"` in #3004, several other files still attempt to read from `"sharding"`, which returns empty and causes weights to be replicated during loading (leading to TPU HBM OOMs).

This PR updates the remaining occurrences to read from `"out_sharding"`.

**Affected files:**
*   `tpu_inference/models/common/pathways_dummy_loader.py`: Fixes dummy weight loading via Pathways.
*   `tpu_inference/layers/jax/quantization/configs.py`: Fixes quantization config weight sharding.
*   `tpu_inference/layers/jax/quantization/unquantized.py`: Fixes merged linear layers sharding retrieval.
