### PR TITLE
Add microbenchmarks for the collective-matmul kernels

### DIFF
--- a/scripts/benchmarking/kernels/benchmark_all_gather_matmul.py
+++ b/scripts/benchmarking/kernels/benchmark_all_gather_matmul.py
@@ -1,0 +1,56 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Benchmark the all-gather + matmul collective at Llama-70B TP shapes.
+
+For each token count M in the sweep this measures
+
+    all_gather(x[M // tp, K], axis=0) @ y[K, N // tp]
+
+Run on a TPU host:
+    python scripts/benchmarking/kernels/benchmark_all_gather_matmul.py \
+        --m 256,1024,8192
+"""
+
+import jax
+import jax.numpy as jnp
+from collective_bench_lib import AXIS, run
+from jax.sharding import NamedSharding
+from jax.sharding import PartitionSpec as P
+
+
+def make_inputs(mesh, m, k, n, dtype):
+    """x[M, K] token-sharded, y[K, N] column-sharded over the TP axis."""
+    key_x, key_y = jax.random.split(jax.random.key(0), 2)
+    x = jax.device_put(
+        jax.random.normal(key_x, (m, k), dtype) * 0.1,
+        NamedSharding(mesh, P(AXIS, None)))
+    y = jax.device_put(
+        jax.random.normal(key_y, (k, n), dtype) * 0.1,
+        NamedSharding(mesh, P(None, AXIS)))
+    return jax.block_until_ready((x, y))
+
+
+def build_xla_baseline(mesh, inputs):
+    """Auto-partitioned einsum: XLA inserts the all-gather from the shards."""
+    fn = jax.jit(lambda x, y: jnp.einsum("mk,kn->mn", x, y),
+                 out_shardings=NamedSharding(mesh, P(None, AXIS)))
+    return fn.lower(*inputs).compile()
+
+
+IMPLEMENTATIONS = {"xla": build_xla_baseline}
+
+if __name__ == "__main__":
+    run(make_inputs=make_inputs,
+        implementations=IMPLEMENTATIONS,
+        default_n=57344)  # N = fused gate+up FFN dim (2 x 28672)

--- a/scripts/benchmarking/kernels/benchmark_matmul_reduce_scatter.py
+++ b/scripts/benchmarking/kernels/benchmark_matmul_reduce_scatter.py
@@ -1,0 +1,56 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Benchmark the matmul + reduce-scatter collective at Llama-70B TP shapes.
+
+For each token count M in the sweep this measures
+
+    reduce_scatter(a[M, N // tp] @ w[N // tp, K], axis=0)
+
+Run on a TPU host:
+    python scripts/benchmarking/kernels/benchmark_matmul_reduce_scatter.py \
+        --m 256,1024,8192
+"""
+
+import jax
+import jax.numpy as jnp
+from collective_bench_lib import AXIS, run
+from jax.sharding import NamedSharding
+from jax.sharding import PartitionSpec as P
+
+
+def make_inputs(mesh, m, k, n, dtype):
+    """a[M, N] and w[N, K] both contraction-sharded over the TP axis."""
+    key_a, key_w = jax.random.split(jax.random.key(0), 2)
+    a = jax.device_put(
+        jax.random.normal(key_a, (m, n), dtype) * 0.1,
+        NamedSharding(mesh, P(None, AXIS)))
+    w = jax.device_put(
+        jax.random.normal(key_w, (n, k), dtype) * 0.1,
+        NamedSharding(mesh, P(AXIS, None)))
+    return jax.block_until_ready((a, w))
+
+
+def build_xla_baseline(mesh, inputs):
+    """Auto-partitioned einsum: XLA inserts the reduce-scatter from the shards."""
+    fn = jax.jit(lambda a, w: jnp.einsum("mn,nk->mk", a, w),
+                 out_shardings=NamedSharding(mesh, P(AXIS, None)))
+    return fn.lower(*inputs).compile()
+
+
+IMPLEMENTATIONS = {"xla": build_xla_baseline}
+
+if __name__ == "__main__":
+    run(make_inputs=make_inputs,
+        implementations=IMPLEMENTATIONS,
+        default_n=28672)  # N = FFN intermediate dim (the contraction axis)

--- a/scripts/benchmarking/kernels/collective_bench_lib.py
+++ b/scripts/benchmarking/kernels/collective_bench_lib.py
@@ -19,8 +19,11 @@ shardings, the einsum, and an IMPLEMENTATIONS registry. Not runnable on its own.
 """
 
 import argparse
-import contextlib
-import time
+import glob
+import os
+import shutil
+import statistics
+import tempfile
 
 import jax
 import jax.numpy as jnp
@@ -30,30 +33,64 @@ from jax.sharding import Mesh
 AXIS = "x"
 
 
-def build_mesh(order):
+def build_mesh():
     """Auto-axis mesh (not jax.make_mesh's explicit axes) so the auto-partitioner
-    inserts the collective for the sharded einsum, as the serving path does.
-    `order` is an optional device-index permutation for ring-sensitive kernels."""
-    devices = jax.devices()
-    if order:
-        devices = [devices[i] for i in order]
-    return Mesh(np.asarray(devices), (AXIS, ))
+    inserts the collective for the sharded einsum, as the serving path does."""
+    return Mesh(np.asarray(jax.devices()), (AXIS, ))
 
 
-def time_call(fn, inputs, *, reps, warmup):
-    """Mean per-call latency (ms): dispatch `reps` calls and block once. The
-    calls pipeline on device, so wall / reps tracks device time once the device
-    is the bottleneck — within ~7% of the profiler's module time at small M
-    (dispatch overhead), under 1% at large M; raise --reps to tighten."""
+def _event_dur_ps(event):
+    for name, value in event.stats:
+        if name == "device_duration_ps":
+            return value
+    return 0.0
+
+
+def _median_dur_ps(plane, line_name, event_name=None):
+    durs = [
+        _event_dur_ps(e) for line in plane.lines if line.name == line_name
+        for e in line.events if event_name is None or e.name == event_name
+    ]
+    return statistics.median(durs) if durs else 0.0
+
+
+def device_time(fn, inputs, *, reps, warmup, save_dir=None):
+    """Median per-call device time (ms) from the JAX profiler, minus the
+    `barrier-cores` span — the collective's cross-core wait for peers, not kernel
+    work. Traces `reps` calls into save_dir if given (kept for inspection), else
+    a temp dir; the per-call XLA-module time and barrier span are read back from
+    the /device:TPU:0 plane."""
     for _ in range(warmup):
         fn(*inputs)
     jax.block_until_ready(fn(*inputs))
-    start = time.perf_counter()
-    out = None
-    for _ in range(reps):
-        out = fn(*inputs)
-    jax.block_until_ready(out)
-    return (time.perf_counter() - start) / reps * 1e3
+    trace_dir = save_dir or tempfile.mkdtemp()
+    try:
+        with jax.profiler.trace(trace_dir):
+            out = None
+            for _ in range(reps):
+                out = fn(*inputs)
+            jax.block_until_ready(out)
+        pbs = glob.glob(os.path.join(trace_dir, "**", "*.xplane.pb"),
+                        recursive=True)
+        if not pbs:
+            raise RuntimeError("profiler wrote no trace")
+        newest = max(pbs,
+                     key=os.path.getmtime)  # this run's, if save_dir reused
+        plane = jax.profiler.ProfileData.from_file(
+            newest).find_plane_with_name("/device:TPU:0")
+        if plane is None:
+            raise RuntimeError("no /device:TPU:0 plane in the trace")
+        module = _median_dur_ps(plane, "XLA Modules")
+        if not module:
+            raise RuntimeError("no XLA-module device time in the profile")
+        barrier = _median_dur_ps(plane, "XLA TraceMe", "barrier-cores")
+        if barrier >= module:
+            raise RuntimeError("barrier-cores span >= module time: "
+                               "unexpected trace shape")
+        return (module - barrier) / 1e9  # ps -> ms
+    finally:
+        if save_dir is None:
+            shutil.rmtree(trace_dir, ignore_errors=True)
 
 
 def run(*, make_inputs, implementations, default_n):
@@ -72,77 +109,67 @@ def run(*, make_inputs, implementations, default_n):
     parser.add_argument("--dtype", default="bfloat16")
     parser.add_argument("--reps",
                         type=int,
-                        default=100,
-                        help="dispatched calls per cell (blocked once)")
+                        default=20,
+                        help="traced calls per cell (median)")
     parser.add_argument("--warmup", type=int, default=5)
-    parser.add_argument(
-        "--device-order",
-        default=None,
-        help="comma-separated device-index permutation for the "
-        "mesh; default is natural order (order-sensitive ring "
-        "kernels want a ring-friendly permutation)")
     parser.add_argument(
         "--profile-dir",
         default=None,
-        help="if set, capture a JAX/xprof trace of the sweep into "
-        "this dir and print the path; otherwise no profiling")
+        help="if set, keep each cell's xprof trace under this dir "
+        "(named <impl>_m<M>) for inspection; otherwise discarded")
     args = parser.parse_args()
 
     assert jax.devices()[0].platform == "tpu", "requires a TPU host"
     tp = jax.device_count()
     if args.n % tp != 0:
         parser.error(f"--n ({args.n}) must be divisible by {tp} devices")
-    order = ([int(i) for i in args.device_order.split(",")]
-             if args.device_order else None)
-    mesh = build_mesh(order)
+    mesh = build_mesh()
     dtype = jnp.dtype(args.dtype)
     names = list(implementations)
     ref = names[0]
 
     print(f"devices={tp} ({jax.devices()[0].device_kind}), k={args.k}, "
-          f"n={args.n} (n/tp={args.n // tp}), dtype={dtype.name}, "
-          f"order={args.device_order or 'natural'}")
+          f"n={args.n} (n/tp={args.n // tp}), dtype={dtype.name}")
     cols = (["M", "TFLOP/s/c"] + [f"{n} us" for n in names] +
             [f"{n} x" for n in names[1:]])
     print(" | ".join(f"{c:>9}" for c in cols))
 
-    prof = (jax.profiler.trace(args.profile_dir)
-            if args.profile_dir else contextlib.nullcontext())
-    with prof:
-        for m in [int(v) for v in args.m.split(",")]:
-            if m % tp != 0:
-                print(f"{m:>9} | (skip: not divisible by {tp} devices)")
-                continue
-            inputs = make_inputs(mesh, m, args.k, args.n, dtype)
-            times, errs = {}, {}
-            for name in names:
-                try:
-                    fn = implementations[name](mesh, inputs)
-                    times[name] = time_call(fn,
-                                            inputs,
-                                            reps=args.reps,
-                                            warmup=args.warmup)
-                except Exception as e:
-                    times[name], errs[name] = None, " ".join(
-                        str(e).split())[:70]
-            base = times[ref]
-            # Per-core matmul FLOPs = 2 * M * K * (N // tp), the same for both
-            # patterns (AG: [M, K] @ [K, N//tp]; RS: [M, N//tp] @ [N//tp, K]).
-            tflops = (2 * m * args.k * (args.n // tp) / (base * 1e-3) /
-                      1e12 if base else None)
-            cells = [f"{m:>9}", f"{tflops:>9.1f}" if tflops else f"{'--':>9}"]
-            cells += [
-                f"{times[n] * 1e3:>9.1f}" if times[n] else f"{'FAIL':>9}"
-                for n in names
-            ]
-            cells += [
-                f"{base / times[n]:>9.2f}"
-                if base and times[n] else f"{'--':>9}" for n in names[1:]
-            ]
-            line = " | ".join(cells)
-            if errs:
-                line += "  " + "; ".join(f"{n}: {errs[n]}" for n in errs)
-            print(line)
+    for m in [int(v) for v in args.m.split(",")]:
+        if m % tp != 0:
+            print(f"{m:>9} | (skip: not divisible by {tp} devices)")
+            continue
+        inputs = make_inputs(mesh, m, args.k, args.n, dtype)
+        times, errs = {}, {}
+        for name in names:
+            save_dir = (os.path.join(args.profile_dir, f"{name}_m{m}")
+                        if args.profile_dir else None)
+            try:
+                fn = implementations[name](mesh, inputs)
+                times[name] = device_time(fn,
+                                          inputs,
+                                          reps=args.reps,
+                                          warmup=args.warmup,
+                                          save_dir=save_dir)
+            except Exception as e:
+                times[name], errs[name] = None, " ".join(str(e).split())[:70]
+        base = times[ref]
+        # Per-core matmul FLOPs = 2 * M * K * (N // tp), the same for both
+        # patterns (AG: [M, K] @ [K, N//tp]; RS: [M, N//tp] @ [N//tp, K]).
+        tflops = (2 * m * args.k * (args.n // tp) / (base * 1e-3) /
+                  1e12 if base else None)
+        cells = [f"{m:>9}", f"{tflops:>9.1f}" if tflops else f"{'--':>9}"]
+        cells += [
+            f"{times[n] * 1e3:>9.1f}" if times[n] else f"{'FAIL':>9}"
+            for n in names
+        ]
+        cells += [
+            f"{base / times[n]:>9.2f}" if base and times[n] else f"{'--':>9}"
+            for n in names[1:]
+        ]
+        line = " | ".join(cells)
+        if errs:
+            line += "  " + "; ".join(f"{n}: {errs[n]}" for n in errs)
+        print(line)
 
     if args.profile_dir:
-        print(f"xprof trace written to {args.profile_dir}")
+        print(f"xprof traces kept under {args.profile_dir}")

--- a/scripts/benchmarking/kernels/collective_bench_lib.py
+++ b/scripts/benchmarking/kernels/collective_bench_lib.py
@@ -46,20 +46,21 @@ def _event_dur_ps(event):
     return 0.0
 
 
-def _median_dur_ps(plane, line_name, event_name=None):
-    durs = [
-        _event_dur_ps(e) for line in plane.lines if line.name == line_name
-        for e in line.events if event_name is None or e.name == event_name
-    ]
-    return statistics.median(durs) if durs else 0.0
+def _call_durs_ps(plane, line_name, event_name=None):
+    """Per-call durations (ps) in call order (sorted by event start time)."""
+    evs = [(e.start_ns, _event_dur_ps(e)) for line in plane.lines
+           if line.name == line_name for e in line.events
+           if event_name is None or e.name == event_name]
+    return [d for _, d in sorted(evs)]
 
 
 def device_time(fn, inputs, *, reps, warmup, save_dir=None):
-    """Median per-call device time (ms) from the JAX profiler, minus the
-    `barrier-cores` span — the collective's cross-core wait for peers, not kernel
-    work. Traces `reps` calls into save_dir if given (kept for inspection), else
-    a temp dir; the per-call XLA-module time and barrier span are read back from
-    the /device:TPU:0 plane."""
+    """Median per-call kernel latency (ms) from the JAX profiler: `barrier-cores`
+    (the collective's cross-core wait) is a sub-span of each call's module, so
+    subtract it from that same call's module device time before taking the median
+    — this cancels the sync jitter the wait absorbs. Traces `reps` calls into
+    save_dir if given (kept for inspection), else a temp dir; module time and
+    barrier span are read from the /device:TPU:0 plane."""
     for _ in range(warmup):
         fn(*inputs)
     jax.block_until_ready(fn(*inputs))
@@ -80,14 +81,22 @@ def device_time(fn, inputs, *, reps, warmup, save_dir=None):
             newest).find_plane_with_name("/device:TPU:0")
         if plane is None:
             raise RuntimeError("no /device:TPU:0 plane in the trace")
-        module = _median_dur_ps(plane, "XLA Modules")
+        module = _call_durs_ps(plane, "XLA Modules")
         if not module:
             raise RuntimeError("no XLA-module device time in the profile")
-        barrier = _median_dur_ps(plane, "XLA TraceMe", "barrier-cores")
-        if barrier >= module:
-            raise RuntimeError("barrier-cores span >= module time: "
-                               "unexpected trace shape")
-        return (module - barrier) / 1e9  # ps -> ms
+        barrier = _call_durs_ps(plane, "XLA TraceMe", "barrier-cores")
+        if not barrier:  # no cross-core sync (e.g. a barrier-free kernel)
+            per_call = module
+        elif len(barrier) == len(module):
+            per_call = [m - b for m, b in zip(module, barrier)]
+        else:
+            raise RuntimeError("module/barrier call-count mismatch "
+                               f"({len(module)} vs {len(barrier)})")
+        latency = statistics.median(per_call)
+        if latency <= 0:
+            raise RuntimeError("non-positive per-call latency (barrier span "
+                               ">= module, or empty module time)")
+        return latency / 1e9  # ps -> ms
     finally:
         if save_dir is None:
             shutil.rmtree(trace_dir, ignore_errors=True)

--- a/scripts/benchmarking/kernels/collective_bench_lib.py
+++ b/scripts/benchmarking/kernels/collective_bench_lib.py
@@ -1,0 +1,148 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Shared harness for the collective-matmul microbenchmarks.
+
+Holds what the benchmarks share — the mesh, per-call timing, and the sweep/
+report driver — so each benchmark script is just its own collective: input
+shardings, the einsum, and an IMPLEMENTATIONS registry. Not runnable on its own.
+"""
+
+import argparse
+import contextlib
+import time
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+from jax.sharding import Mesh
+
+AXIS = "x"
+
+
+def build_mesh(order):
+    """Auto-axis mesh (not jax.make_mesh's explicit axes) so the auto-partitioner
+    inserts the collective for the sharded einsum, as the serving path does.
+    `order` is an optional device-index permutation for ring-sensitive kernels."""
+    devices = jax.devices()
+    if order:
+        devices = [devices[i] for i in order]
+    return Mesh(np.asarray(devices), (AXIS, ))
+
+
+def time_call(fn, inputs, *, reps, warmup):
+    """Mean per-call latency (ms): dispatch `reps` calls and block once. The
+    calls pipeline on device, so wall / reps tracks device time once the device
+    is the bottleneck — within ~7% of the profiler's module time at small M
+    (dispatch overhead), under 1% at large M; raise --reps to tighten."""
+    for _ in range(warmup):
+        fn(*inputs)
+    jax.block_until_ready(fn(*inputs))
+    start = time.perf_counter()
+    out = None
+    for _ in range(reps):
+        out = fn(*inputs)
+    jax.block_until_ready(out)
+    return (time.perf_counter() - start) / reps * 1e3
+
+
+def run(*, make_inputs, implementations, default_n):
+    """Sweep M for one collective and print a per-M table.
+
+    make_inputs(mesh, m, k, n, dtype) -> operands; implementations maps
+    name -> builder(mesh, inputs) -> callable(*inputs), first entry the
+    reference; default_n is the --n default.
+    """
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--m",
+                        default="16,32,64,128,256,512,1024,2048,4096,8192",
+                        help="comma-separated token counts to sweep")
+    parser.add_argument("--k", type=int, default=8192, help="hidden dim")
+    parser.add_argument("--n", type=int, default=default_n)
+    parser.add_argument("--dtype", default="bfloat16")
+    parser.add_argument("--reps",
+                        type=int,
+                        default=100,
+                        help="dispatched calls per cell (blocked once)")
+    parser.add_argument("--warmup", type=int, default=5)
+    parser.add_argument(
+        "--device-order",
+        default=None,
+        help="comma-separated device-index permutation for the "
+        "mesh; default is natural order (order-sensitive ring "
+        "kernels want a ring-friendly permutation)")
+    parser.add_argument(
+        "--profile-dir",
+        default=None,
+        help="if set, capture a JAX/xprof trace of the sweep into "
+        "this dir and print the path; otherwise no profiling")
+    args = parser.parse_args()
+
+    assert jax.devices()[0].platform == "tpu", "requires a TPU host"
+    tp = jax.device_count()
+    if args.n % tp != 0:
+        parser.error(f"--n ({args.n}) must be divisible by {tp} devices")
+    order = ([int(i) for i in args.device_order.split(",")]
+             if args.device_order else None)
+    mesh = build_mesh(order)
+    dtype = jnp.dtype(args.dtype)
+    names = list(implementations)
+    ref = names[0]
+
+    print(f"devices={tp} ({jax.devices()[0].device_kind}), k={args.k}, "
+          f"n={args.n} (n/tp={args.n // tp}), dtype={dtype.name}, "
+          f"order={args.device_order or 'natural'}")
+    cols = (["M", "TFLOP/s/c"] + [f"{n} us" for n in names] +
+            [f"{n} x" for n in names[1:]])
+    print(" | ".join(f"{c:>9}" for c in cols))
+
+    prof = (jax.profiler.trace(args.profile_dir)
+            if args.profile_dir else contextlib.nullcontext())
+    with prof:
+        for m in [int(v) for v in args.m.split(",")]:
+            if m % tp != 0:
+                print(f"{m:>9} | (skip: not divisible by {tp} devices)")
+                continue
+            inputs = make_inputs(mesh, m, args.k, args.n, dtype)
+            times, errs = {}, {}
+            for name in names:
+                try:
+                    fn = implementations[name](mesh, inputs)
+                    times[name] = time_call(fn,
+                                            inputs,
+                                            reps=args.reps,
+                                            warmup=args.warmup)
+                except Exception as e:
+                    times[name], errs[name] = None, " ".join(
+                        str(e).split())[:70]
+            base = times[ref]
+            # Per-core matmul FLOPs = 2 * M * K * (N // tp), the same for both
+            # patterns (AG: [M, K] @ [K, N//tp]; RS: [M, N//tp] @ [N//tp, K]).
+            tflops = (2 * m * args.k * (args.n // tp) / (base * 1e-3) /
+                      1e12 if base else None)
+            cells = [f"{m:>9}", f"{tflops:>9.1f}" if tflops else f"{'--':>9}"]
+            cells += [
+                f"{times[n] * 1e3:>9.1f}" if times[n] else f"{'FAIL':>9}"
+                for n in names
+            ]
+            cells += [
+                f"{base / times[n]:>9.2f}"
+                if base and times[n] else f"{'--':>9}" for n in names[1:]
+            ]
+            line = " | ".join(cells)
+            if errs:
+                line += "  " + "; ".join(f"{n}: {errs[n]}" for n in errs)
+            print(line)
+
+    if args.profile_dir:
+        print(f"xprof trace written to {args.profile_dir}")


### PR DESCRIPTION
Two benchmark scripts under scripts/benchmarking/kernels/ measure the auto-partitioned XLA baseline for the Llama-70B tensor-parallel collective-matmul patterns —
all-gather + matmul and matmul + reduce-scatter — at the MLP projection shapes (K=8192, N=57344), sweeping the token dimension across the serving padding buckets. Each reports mean per-call latency and per-core TFLOP/s; timing is wall-clock over dispatched calls blocked once, which tracks the profiler's module device time within a few percent. Pass --profile-dir to capture an xprof trace.

A shared collective_bench_lib holds the mesh, per-call timing, and sweep/report driver, so each script is just its collective and an IMPLEMENTATIONS registry. A fused kernel plugs in with a single entry and is benchmarked against the baseline; this version registers only the baseline and depends on no kernel.

# Description

Start with a short description of what the PR does and how this is a change from
the past.

The rest of the description includes relevant details and context, examples:
- why is this change being made,
- the problem being solved and any relevant context,
- why this is a good solution,
- some information about the specific implementation,
- shortcomings of the solution and possible future improvements.

If the change fixes a Github issue, please include a link, e.g.,:
FIXES: #123456

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
