### PR TITLE
Apply fp8 on ragged gather

### DIFF
--- a/tests/kernels/gmm_test.py
+++ b/tests/kernels/gmm_test.py
@@ -66,6 +66,24 @@ def quantize_tensor(x: jax.Array,
     return x_q, scale
 
 
+def pack_lhs_scale(lhs_q: jax.Array, lhs_scale: jax.Array) -> jax.Array:
+    """Appends a per-token bf16 scale to lhs as fp8-typed transport bytes.
+
+    Mirrors what the fp8 MoE path builds before its SparseCore permute: the
+    scale's two bytes land at columns ``size_k`` and ``size_k + 1``, and the
+    row is padded up to a multiple of the lane width.
+    """
+    scale_f8 = jax.lax.bitcast_convert_type(lhs_scale.astype(jnp.bfloat16),
+                                            jnp.float8_e4m3fn)
+    scale_f8 = scale_f8.reshape(lhs_scale.shape[0], -1)
+    combined = jnp.concatenate([lhs_q, scale_f8], axis=1)
+    width = combined.shape[-1]
+    aligned_width = ((width + 127) // 128) * 128
+    if aligned_width != width:
+        combined = jnp.pad(combined, ((0, 0), (0, aligned_width - width)))
+    return combined
+
+
 def reference_gmm(
     lhs: jax.Array,
     rhs: jax.Array,
@@ -745,6 +763,103 @@ class GmmTest(jtu.JaxTestCase):
             atol, rtol = 5e-2, 5e-2  # Unquantized Path (bfloat16 precision diffs)
 
         self.assertArraysAllClose(actual, expected, atol=atol, rtol=rtol)
+
+    @parameterized.product(
+        # batch_size >= 512 grows tile_m past bucket_base, so the kernel runs
+        # several row buckets per tile and the scale slice has to track them.
+        batch_size=[128, 256, 512, 1024],
+        in_size=[512, 1024],
+        out_size=[512, 1024],
+        num_groups=[8, 16],
+        group_offset=[0, 2],
+        out_dtype=[jnp.float32, jnp.bfloat16],
+    )
+    def test_gmm_lhs_scale_packed(self, batch_size, in_size, out_size,
+                                  num_groups, group_offset, out_dtype):
+        """An fp8 lhs carrying its per-token scale in its trailing columns.
+
+        The kernel contracts the first size_k columns, reads the scale out of
+        the trailing lane tile, and applies it to the accumulator -- so the
+        result must match a matmul on the dequantized activations.
+        """
+        num_local_groups = num_groups - group_offset
+        key = jax.random.key(0)
+
+        lhs = jax.random.uniform(key, (batch_size, in_size), jnp.bfloat16, -1,
+                                 1)
+        rhs = jax.random.uniform(key, (num_local_groups, in_size, out_size),
+                                 jnp.bfloat16, -1, 1)
+        group_sizes = get_group_sizes(batch_size, num_groups)
+        group_offset = jnp.array([group_offset], dtype=jnp.int32)
+
+        # Quantize per token, the way the fp8 MoE path does.
+        lhs_q, lhs_scale = quantize_tensor(lhs,
+                                           jnp.float8_e4m3fn,
+                                           axis=1,
+                                           block_size=in_size)
+        lhs_scale = lhs_scale.astype(jnp.bfloat16)
+
+        # The kernel dequantizes after the matmul; the scale is constant across
+        # k, so scaling the codes before it is equivalent.
+        lhs_dq = lhs_q.astype(jnp.float32) * lhs_scale.astype(jnp.float32)
+        expected = reference_gmm(lhs_dq,
+                                 rhs,
+                                 group_sizes,
+                                 group_offset=group_offset)
+
+        actual = gmm_v2(
+            pack_lhs_scale(lhs_q, lhs_scale),
+            rhs,
+            group_sizes,
+            group_offset=group_offset,
+            preferred_element_type=out_dtype,
+            lhs_scale_packed=True,
+        )
+
+        self.assertEqual(actual.shape, (batch_size, out_size))
+        self.assertEqual(actual.dtype, out_dtype)
+        # fp8 activation codes plus a bf16 accumulator; scaled to the output
+        # magnitude rather than absolute.
+        tol = 0.05 * float(jnp.abs(expected).max())
+        self.assertArraysAllClose(actual.astype(jnp.float32),
+                                  expected.astype(jnp.float32),
+                                  atol=tol,
+                                  rtol=5e-2)
+
+    @parameterized.product(
+        batch_size=[128],
+        in_size=[512],
+        out_size=[512],
+        num_groups=[16],
+        extra_cols=[128, 256],
+    )
+    def test_gmm_ignores_lhs_columns_past_size_k(self, batch_size, in_size,
+                                                 out_size, num_groups,
+                                                 extra_cols):
+        """An lhs wider than size_k contracts only its first size_k columns.
+
+        This is what lets the MoE path hand the kernel one buffer carrying both
+        the activations and the packed scale, with no slice on the host.
+        """
+        key = jax.random.key(0)
+
+        lhs = jax.random.uniform(key, (batch_size, in_size), jnp.bfloat16, -1,
+                                 1)
+        rhs = jax.random.uniform(key, (num_groups, in_size, out_size),
+                                 jnp.bfloat16, -1, 1)
+        group_sizes = get_group_sizes(batch_size, num_groups)
+
+        narrow = gmm_v2(lhs, rhs, group_sizes, maybe_quantize_lhs=False)
+        # Garbage in the trailing columns must not reach the output.
+        padding = jax.random.uniform(jax.random.key(1),
+                                     (batch_size, extra_cols), jnp.bfloat16,
+                                     -1, 1)
+        wide = gmm_v2(jnp.concatenate([lhs, padding], axis=1),
+                      rhs,
+                      group_sizes,
+                      maybe_quantize_lhs=False)
+
+        self.assertArraysEqual(wide, narrow)
 
 
 if __name__ == "__main__":

--- a/tpu_inference/envs.py
+++ b/tpu_inference/envs.py
@@ -46,6 +46,7 @@ if TYPE_CHECKING:
     JITTED_MM_MODULE_KEYS: list[str] = []
     REGISTER_MM_MODULE_CUSTOM_PYTREE_CLASSES: list[str] = []
     MOE_ALL_GATHER_ACTIVATION_DTYPE: str = ""
+    MOE_RAGGED_GATHER_FP8: bool = False
     TPU_OFFLOAD_SKIP_JAX_PRECOMPILE: bool = False
     TPU_OFFLOAD_DECODE_SAVE: bool = False
     TPU_OFFLOAD_NUM_CPU_CHUNKS: int = 1024
@@ -333,6 +334,12 @@ environment_variables: dict[str, Callable[[], Any]] = {
     env_str_list("REGISTER_MM_MODULE_CUSTOM_PYTREE_CLASSES"),
     "MOE_ALL_GATHER_ACTIVATION_DTYPE":
     lambda: os.getenv("MOE_ALL_GATHER_ACTIVATION_DTYPE", ""),
+    # Keep MoE activations in fp8 across the ragged gather (EP permute) instead
+    # of dequantizing right after the fp8 all-gather. Halves the bytes the
+    # SparseCore gather moves; the per-token scale is carried alongside and the
+    # dequant happens after the gather. Requires MOE_ALL_GATHER_ACTIVATION_DTYPE=fp8.
+    "MOE_RAGGED_GATHER_FP8":
+    lambda: bool(int(os.getenv("MOE_RAGGED_GATHER_FP8", "0"))),
     # kv offload to dram: skip pre-compiling swap-related jax functions
     "TPU_OFFLOAD_SKIP_JAX_PRECOMPILE":
     lambda: bool(int(os.getenv("TPU_OFFLOAD_SKIP_JAX_PRECOMPILE", "0"))),

--- a/tpu_inference/kernels/megablox/gmm_v2.py
+++ b/tpu_inference/kernels/megablox/gmm_v2.py
@@ -23,6 +23,11 @@ from jax import lax
 from jax.experimental import pallas as pl
 from jax.experimental.pallas import tpu as pltpu
 
+# Lane width of the tile the packed lhs scale is read from. A block narrower
+# than the lane width is not expressible, so the packed path loads this many
+# columns and slices the two transport bytes out in-register.
+_SCALE_TILE_LANES = 128
+
 # Util.
 
 
@@ -185,6 +190,26 @@ class FusedWeightsRef(RhsRef):
 
 @jax.tree_util.register_dataclass
 @dataclasses.dataclass(frozen=True)
+class LhsRef:
+    """Dataclass for lhs, optionally carrying a per-token dequant scale.
+
+    When ``scale`` is None, ``data`` is the (unquantized) lhs and the kernel
+    quantizes it internally, exactly as before. When ``scale`` is not None,
+    ``data`` is assumed to already be quantized (e.g. to fp8) and ``scale``
+    holds the per-token multiplier applied to the accumulator after the matmul
+    (the scale is constant across k, so it factors out of the k reduction).
+    """
+
+    data: Any
+    scale: Any | None = None
+
+    def get_scale(self) -> jax.Array:
+        assert self.scale is not None
+        return self.scale[...]
+
+
+@jax.tree_util.register_dataclass
+@dataclasses.dataclass(frozen=True)
 class MetadataRef:
     gm_id_to_group_id: jax.Array
     gm_id_to_m_offset: jax.Array
@@ -215,6 +240,11 @@ class InputConfigs:
     dtype: jnp.dtype
     has_bias: bool = False
     has_scale: bool = False
+    # lhs only: data is already quantized and its per-token scale rides in the
+    # lhs buffer's trailing columns (two fp8-typed transport bytes at column
+    # size_k). Skip internal quantization, read the scale from the buffer the
+    # kernel already holds, and apply it after the matmul.
+    prequantized: bool = False
 
     @property
     def should_dequantize_before_matmul(self) -> bool:
@@ -280,6 +310,20 @@ class IndexMaps:
 
         return (pl.ds(row_start, row_size), 0, k_id)
 
+    def lhs_scale_index_map(self, _: jax.Array, gm_id: jax.Array,
+                            __: jax.Array):
+        # Scale rides in the lhs buffer itself, in the lane tile that starts at
+        # column size_k. Same row tiling as lhs; independent of k.
+        m_start = self.metadata_ref.gm_id_to_m_offset[gm_id]
+        m_end = self.metadata_ref.gm_id_to_m_offset[gm_id + 1]
+
+        row_start = m_start // self.cfgs.dims.size_lhs_sublane
+        row_end = pl.cdiv(m_end, self.cfgs.dims.size_lhs_sublane)
+        row_size = row_end - row_start
+
+        return (pl.ds(row_start,
+                      row_size), 0, self.cfgs.dims.size_k // _SCALE_TILE_LANES)
+
     def rhs_weight_index_map(self, n_id: jax.Array, gm_id: jax.Array,
                              k_id: jax.Array):
         group_id = self.metadata_ref.gm_id_to_group_id[gm_id]
@@ -323,10 +367,21 @@ def generate_block_specs(
     bounded_slice_gm = pl.BoundedSlice(cfgs.tiles.tile_m //
                                        cfgs.dims.size_lhs_sublane)
 
-    lhs_block_spec = pl.BlockSpec(
+    lhs_data_block_spec = pl.BlockSpec(
         (bounded_slice_gm, cfgs.dims.size_lhs_sublane, cfgs.tiles.tile_k),
         index_map.lhs_index_map,
     )
+    lhs_scale_block_spec = None
+    if cfgs.lhs_cfgs.prequantized:
+        # A block narrower than the lane width is not expressible, so this
+        # pulls the whole trailing lane tile and slices the two transport
+        # bytes out in-register.
+        lhs_scale_block_spec = pl.BlockSpec(
+            (bounded_slice_gm, cfgs.dims.size_lhs_sublane, _SCALE_TILE_LANES),
+            index_map.lhs_scale_index_map,
+        )
+    lhs_block_spec = LhsRef(data=lhs_data_block_spec,
+                            scale=lhs_scale_block_spec)
 
     rhs_weight_spec = pl.BlockSpec(
         (None, cfgs.tiles.tile_k, cfgs.tiles.tile_n),
@@ -364,8 +419,9 @@ def generate_block_specs(
 
 def inner_kernel(
     # In
-    tiled_lhs_ref: jax.Array,
-    # [tile_m // size_lhs_sublane, size_lhs_sublane, tile_k]
+    tiled_lhs_ref: LhsRef,
+    # data [tile_m // size_lhs_sublane, size_lhs_sublane, tile_k],
+    # optional scale [tile_m // size_lhs_sublane, size_lhs_sublane, 1]
     tiled_rhs_ref: RhsRef,  # [tile_k, tile_n]
     # Out
     tiled_out_ref: jax.Array,
@@ -410,7 +466,8 @@ def inner_kernel(
         mxu_size = tpu_info.mxu_column_size
 
         # Step 1: Input pre-processing.
-        tiled_lhs = tiled_lhs_ref.reshape(-1, cfgs.tiles.tile_k)[:bucket_m]
+        tiled_lhs = tiled_lhs_ref.data.reshape(-1,
+                                               cfgs.tiles.tile_k)[:bucket_m]
         tiled_rhs = tiled_rhs_ref.get_weight()
 
         # This should only be taken in the case where we don't requantize
@@ -491,22 +548,28 @@ def inner_kernel(
                     block_lhs = tiled_lhs[:, start_k:end_k]
                     block_rhs = tiled_rhs[start_k:end_k, start_n:end_n]
 
-                    # Perform lhs quantization. Note that for every block_lhs,
-                    # same computation will be performed tiles_n//mxu_size times.
-                    # But we can let compiler perform CSE and avoid recomputation.
-                    block_abs_max = jnp.max(jnp.abs(block_lhs),
-                                            axis=1,
-                                            keepdims=True)
-                    block_scale = block_abs_max / dtype_max
+                    if cfgs.lhs_cfgs.prequantized:
+                        # lhs is already quantized; its per-token scale is
+                        # applied once after the full k reduction (below), so no
+                        # per-block quantization or scaling happens here.
+                        block_lhs_q = block_lhs
+                    else:
+                        # Perform lhs quantization. Note that for every block_lhs,
+                        # same computation will be performed tiles_n//mxu_size times.
+                        # But we can let compiler perform CSE and avoid recomputation.
+                        block_abs_max = jnp.max(jnp.abs(block_lhs),
+                                                axis=1,
+                                                keepdims=True)
+                        block_scale = block_abs_max / dtype_max
 
-                    # If block_scale=0, it will cause division by zero and return either
-                    # NaN or Inf. Since this can cause numeric issue when downcasting to
-                    # quantized value, we convert them into 0.
-                    block_scale_inv = jnp.where(block_scale == 0, 0,
-                                                1 / block_scale)
-                    # Convert lhs into quantized dtype.
-                    block_lhs_q = (block_lhs *
-                                   block_scale_inv).astype(lhs_q_dtype)
+                        # If block_scale=0, it will cause division by zero and return
+                        # either NaN or Inf. Since this can cause numeric issue when
+                        # downcasting to quantized value, we convert them into 0.
+                        block_scale_inv = jnp.where(block_scale == 0, 0,
+                                                    1 / block_scale)
+                        # Convert lhs into quantized dtype.
+                        block_lhs_q = (block_lhs *
+                                       block_scale_inv).astype(lhs_q_dtype)
 
                     # Unlike unquantized path, compiler may not perform implicit type
                     # conversion due to numeric concerns. As this can cause unsupported
@@ -521,7 +584,8 @@ def inner_kernel(
                         preferred_element_type=preferred_element_type,
                     ).astype(acc_ref.dtype)
 
-                    block_acc *= block_scale.astype(acc_ref.dtype)
+                    if not cfgs.lhs_cfgs.prequantized:
+                        block_acc *= block_scale.astype(acc_ref.dtype)
 
                     # Apply rhs subchannel scale per quant block.
                     if cfgs.rhs_cfgs.should_dequantize_after_matmul:
@@ -542,6 +606,40 @@ def inner_kernel(
         acc_m = acc.shape[0]
 
         if is_last_k_step:
+            if cfgs.lhs_cfgs.prequantized:
+                # Dequantize with the per-token scale. It is constant across k
+                # so applying it once to the fully reduced accumulator is exact,
+                # and must happen before the (post-matmul) bias and activation.
+                #
+                # Rebuild the scale from its two fp8 transport bytes, which ride
+                # in the trailing lane tile of the lhs buffer.
+                #
+                # Done in int32: Mosaic cannot legalize arith.shli on 16-bit
+                # vectors. bf16 is exactly the high half of an f32, so shifting
+                # the reassembled bf16 pattern up by 16 gives the f32 bit
+                # pattern directly -- which also skips a widening convert, since
+                # the accumulator is f32 anyway.
+                #
+                # Slice to bucket_m the same way tiled_lhs is sliced, and do it
+                # BEFORE the recombine so the unpack only touches the rows this
+                # bucket actually computes.
+                scale_bytes = tiled_lhs_ref.scale.reshape(
+                    -1, _SCALE_TILE_LANES)[:bucket_m]
+                packed = jax.lax.bitcast_convert_type(scale_bytes, jnp.uint8)
+                lo = packed[..., 0:1].astype(jnp.int32)
+                hi = packed[..., 1:2].astype(jnp.int32)
+                bits = (lo | (hi << 8)) << 16
+                tiled_lhs_scale = jax.lax.bitcast_convert_type(
+                    bits, jnp.float32).reshape(-1, 1)
+                if acc_m != bucket_m:
+                    # acc was front-padded up to tile_m to accumulate against
+                    # acc_ref. Pad the scale to match, with 1.0 so the rows
+                    # carried over from earlier k steps are left untouched.
+                    tiled_lhs_scale = jnp.pad(tiled_lhs_scale,
+                                              ((acc_m - bucket_m, 0), (0, 0)),
+                                              constant_values=1.0)
+                acc *= tiled_lhs_scale.astype(acc.dtype)
+
             if cfgs.rhs_cfgs.has_bias:
                 tiled_rhs_bias = tiled_rhs_ref.get_bias()
                 acc += tiled_rhs_bias.astype(acc.dtype)
@@ -813,7 +911,7 @@ def kernel_main(
     lhs_group_sizes_ref: jax.Array,  # int32[size_lhs_group]
     group_offset_ref: jax.Array,  # int32[1]
     # In
-    lhs_ref: jax.Array,  # [size_m, size_k]
+    lhs_ref: LhsRef,  # data [size_m, size_k], optional scale [size_m, 1]
     rhs_ref: WeightsRef,  # [size_group, size_k, size_n]
     # Out
     out_ref: jax.Array,  # [size_m, size_n]
@@ -896,7 +994,11 @@ def kernel_main(
 
     # Bounded slice requires second last dim to be aligned to the sublane size.
     # rhs_ref uses static tiling thus reshape is not needed.
-    lhs_in = lhs_ref.reshape(-1, cfgs.dims.size_lhs_sublane, lhs_ref.shape[-1])
+    lhs_data_in = lhs_ref.data.reshape(-1, cfgs.dims.size_lhs_sublane,
+                                       lhs_ref.data.shape[-1])
+    # Same buffer as the data; the block spec picks the trailing tile out of it.
+    lhs_scale_in = lhs_data_in if lhs_ref.scale is not None else None
+    lhs_in = LhsRef(data=lhs_data_in, scale=lhs_scale_in)
     out_in = out_ref.reshape(-1, cfgs.dims.size_lhs_sublane, out_ref.shape[-1])
     scratches = [partial_out_ref, acc_ref, metadata_ref]
     pipeline_fn(lhs_in, rhs_ref, out_in, scratches=scratches)
@@ -1055,7 +1157,13 @@ def validate_inputs(
     size_lhs_group = group_sizes.shape[0]
 
     assert size_group <= size_lhs_group
-    assert lhs.shape == (size_m, size_k)
+    # lhs may be physically wider than size_k: callers can pack extra trailing
+    # columns (e.g. a per-token scale) into the lhs buffer. The kernel contracts
+    # only the first size_k columns (num_k = cdiv(size_k, tile_k) tiles), so the
+    # trailing columns are never read.
+    assert lhs.shape[0] == size_m, f"{lhs.shape=} vs {size_m=}"
+    assert lhs.shape[1] >= size_k, (
+        f"lhs width {lhs.shape[1]} must be >= size_k {size_k}")
     assert rhs.shape == (size_group, size_k, size_n)
     if rhs_bias is not None:
         assert rhs_bias.shape == (size_group, 1, size_n)
@@ -1144,6 +1252,7 @@ def make_gmm_configs(
     maybe_quantize_lhs: bool,
     zero_initialize: bool,
     fuse_act: str | None = None,
+    lhs_prequantized: bool = False,
 ):
     """Fills the GMM config for the GMM kernel."""
 
@@ -1169,7 +1278,11 @@ def make_gmm_configs(
     )
 
     lhs_q_dtype = None
-    if maybe_quantize_lhs and rhs_cfgs.should_dequantize_after_matmul:
+    if lhs_prequantized:
+        # lhs already carries quantized values in its own dtype; skip the
+        # hardware-based dtype selection and internal quantization entirely.
+        lhs_q_dtype = lhs.dtype
+    elif maybe_quantize_lhs and rhs_cfgs.should_dequantize_after_matmul:
         # Choose lhs quantization dtype based on TPU hardware support.
         is_rhs_float = jnp.issubdtype(rhs_quant_dtype, jnp.floating)
         tpu_info = pltpu.get_tpu_info()
@@ -1193,6 +1306,7 @@ def make_gmm_configs(
         # enough to minimize compute overhead of quantization.
         quant_block_size=512,
         dtype=lhs.dtype,
+        prequantized=lhs_prequantized,
     )
 
     if out_dtype is None:
@@ -1244,6 +1358,7 @@ def get_metadata(cfgs: GmmConfigs) -> dict[str, str | int | float]:
     "maybe_quantize_lhs",
     "zero_initialize",
     "fuse_act",
+    "lhs_scale_packed",
 ])
 def gmm_v2(
     lhs: jax.Array,  # [size_m, size_k]
@@ -1262,6 +1377,7 @@ def gmm_v2(
     maybe_quantize_lhs: bool = True,
     zero_initialize: bool = True,
     fuse_act: str | None = None,
+    lhs_scale_packed: bool = False,
 ) -> jax.Array:
     """GMM kernel implemented with emit_pipeline.
 
@@ -1284,6 +1400,10 @@ def gmm_v2(
         maybe_quantize_lhs: Quantize lhs if set to True and rhs is quantized.
         zero_initialize: Whether to initialize unvisited output elements to zero.
         fuse_act: Activation function to fuse with GMM, None if no fusion.
+        lhs_scale_packed: Treat lhs as already quantized, carrying its per-token
+            dequant scale as two fp8-typed transport bytes at column size_k.
+            The kernel contracts only the first size_k columns and applies the
+            scale to the accumulator, skipping internal lhs quantization.
 
     Returns:
         Output of shape [size_m, size_n].
@@ -1300,6 +1420,12 @@ def gmm_v2(
     if vmem_limit_bytes is None:
         vmem_limit_bytes = int(pltpu.get_tpu_info().vmem_capacity_bytes * 0.9)
 
+    # The scale rides in lhs's trailing lane tile. Bind it HERE, inside the jit:
+    # object identity does not survive jit argument tracing (passing the same
+    # array twice yields two distinct tracers), so the caller cannot hand us
+    # "the same buffer" -- it has to be bound in-function.
+    lhs_scale = lhs if lhs_scale_packed else None
+
     cfgs = make_gmm_configs(
         lhs,
         rhs,
@@ -1314,6 +1440,7 @@ def gmm_v2(
         maybe_quantize_lhs=maybe_quantize_lhs,
         zero_initialize=zero_initialize,
         fuse_act=fuse_act,
+        lhs_prequantized=lhs_scale_packed,
     )
     dims = cfgs.dims
     tiles = cfgs.tiles
@@ -1326,6 +1453,18 @@ def gmm_v2(
     if rhs_bias is not None:
         rhs_bias = rhs_bias.astype(jnp.float32)
         rhs_bias_spec = pl.BlockSpec(memory_space=pltpu.HBM)
+
+    lhs_scale_spec = None
+    if lhs_scale is not None:
+        # The scale rides in lhs itself: same buffer, two fp8-typed transport
+        # bytes at column size_k, inside the trailing lane tile.
+        assert dims.size_k % _SCALE_TILE_LANES == 0, (
+            f"{dims.size_k=} must be a multiple of {_SCALE_TILE_LANES} "
+            "for the packed scale tile index to be exact")
+        assert lhs.shape[1] >= dims.size_k + 2, (
+            f"{lhs.shape=} must have >= size_k+2 ({dims.size_k + 2}) "
+            "columns to carry the packed scale")
+        lhs_scale_spec = pl.BlockSpec(memory_space=pltpu.HBM)
 
     # Initialize scratch shapes.
     max_num_gm = dims.size_group + pl.cdiv(dims.size_m, tiles.tile_m) - 1
@@ -1371,6 +1510,7 @@ def gmm_v2(
     aligned_n = align_to(cfgs.out_size_n, num_lanes)
     out_init = jax.ShapeDtypeStruct((dims.size_m, aligned_n), cfgs.out_dtype)
     rhs_weights = WeightsRef(weight=rhs, scale=rhs_scale, bias=rhs_bias)
+    lhs_in = LhsRef(data=lhs, scale=lhs_scale)
 
     return pl.pallas_call(
         functools.partial(kernel_main, cfgs=cfgs),
@@ -1378,7 +1518,10 @@ def gmm_v2(
         grid_spec=pltpu.PrefetchScalarGridSpec(
             num_scalar_prefetch=2,
             in_specs=[
-                pl.BlockSpec(memory_space=pltpu.HBM),
+                LhsRef(
+                    data=pl.BlockSpec(memory_space=pltpu.HBM),
+                    scale=lhs_scale_spec,
+                ),
                 WeightsRef(
                     weight=pl.BlockSpec(memory_space=pltpu.HBM),
                     scale=rhs_scale_spec,
@@ -1395,4 +1538,4 @@ def gmm_v2(
         name=get_scope_name(cfgs),
         cost_estimate=get_cost_estimate(cfgs),
         metadata=get_metadata(cfgs),
-    )(group_sizes, group_offset, lhs, rhs_weights)[:, :cfgs.out_size_n]
+    )(group_sizes, group_offset, lhs_in, rhs_weights)[:, :cfgs.out_size_n]

--- a/tpu_inference/layers/common/fused_moe_gmm.py
+++ b/tpu_inference/layers/common/fused_moe_gmm.py
@@ -107,7 +107,8 @@ def gmm_wrapper(lhs,
                 group_sizes,
                 group_offset,
                 fuse_act=None,
-                preferred_element_type=None):
+                preferred_element_type=None,
+                lhs_scale_packed=False):
     gmm_res = gmm_v2(
         lhs=lhs,
         rhs=rhs,
@@ -115,6 +116,7 @@ def gmm_wrapper(lhs,
         rhs_bias=rhs_bias,
         group_sizes=group_sizes,
         group_offset=group_offset[0],
+        lhs_scale_packed=lhs_scale_packed,
         zero_initialize=False,
         fuse_act=fuse_act,
         preferred_element_type=preferred_element_type,
@@ -171,6 +173,8 @@ def moe_gmm_local(x: jax.Array,
                   topk_argsort_revert_indices: jax.Array,
                   topk_weights: jax.Array,
                   *,
+                  lhs_scale_packed: bool = False,
+                  lhs_scale_dtype: jnp.dtype | None = None,
                   activation: str,
                   topk: int,
                   parallelism: Literal["tp", "ep"],
@@ -182,9 +186,22 @@ def moe_gmm_local(x: jax.Array,
     """Main MoE logic on a local shard can run in TP or EP mode.
 
     Set parallelism for "tp" or "ep"
+
+    When lhs_scale_packed is set, x is already quantized (e.g. fp8) and carries
+    its per-token dequant scale in its trailing columns; GMM1 reads the scale
+    from x and dequantizes internally.
     """
 
     assert parallelism in ["tp", "ep"]
+
+    # Output/compute dtype. With a packed scale there is no scale array to read
+    # the original (bf16) dtype off, so it must be supplied explicitly.
+    if lhs_scale_packed:
+        assert lhs_scale_dtype is not None, (
+            "lhs_scale_packed=True requires lhs_scale_dtype")
+        compute_dtype = lhs_scale_dtype
+    else:
+        compute_dtype = x.dtype
 
     # GMM1 computes x @ (W_up | W_gate) together and activation, output is [tokens,padded_intermediate_size]
     gmm1_res = gmm_wrapper(
@@ -195,7 +212,8 @@ def moe_gmm_local(x: jax.Array,
         group_sizes,
         group_offset,
         fuse_act=activation,
-        preferred_element_type=x.dtype,
+        preferred_element_type=compute_dtype,
+        lhs_scale_packed=lhs_scale_packed,
     )
 
     # When the parallelism is TP since w2_bias is not sharded, we should only apply bias
@@ -308,7 +326,9 @@ def moe_gmm_local(x: jax.Array,
                 chunk_hidden,
                 num_devices=scatter_axis_size,
                 axis_name=reduction_axis)
-            out = rs_out.astype(x.dtype)
+            # compute_dtype (not x.dtype): on the fp8 path x is fp8, so the
+            # reduce-scatter output must be cast to the compute (bf16) dtype.
+            out = rs_out.astype(compute_dtype)
         elif scatter_results:
             if reduce_axes:
                 chunk_hidden = jax.lax.psum(chunk_hidden,
@@ -317,15 +337,16 @@ def moe_gmm_local(x: jax.Array,
                 out = jax.lax.psum_scatter(chunk_hidden,
                                            axis_name=scatter_axes,
                                            scatter_dimension=0,
-                                           tiled=True).astype(x.dtype)
+                                           tiled=True).astype(compute_dtype)
             else:
-                out = chunk_hidden.astype(x.dtype)
+                out = chunk_hidden.astype(compute_dtype)
         else:
             if not defer_all_reduce:
-                out = jax.lax.psum(chunk_hidden,
-                                   axis_name=reduction_axis).astype(x.dtype)
+                out = jax.lax.psum(
+                    chunk_hidden,
+                    axis_name=reduction_axis).astype(compute_dtype)
             else:
-                out = chunk_hidden.astype(x.dtype)
+                out = chunk_hidden.astype(compute_dtype)
         out_list.append(out)
 
     return jnp.concatenate(out_list,
@@ -438,6 +459,8 @@ def expert_parallel_gmm(
     moe_chunk_size: int = 0,
     scatter_results: bool = False,
     defer_all_reduce: bool = False,
+    lhs_scale_packed: bool = False,
+    lhs_scale_dtype: jnp.dtype | None = None,
 ) -> jax.Array:
     ep_size = get_mesh_shape_product(mesh, ShardingAxisName.EXPERT)
     ep_p_spec = P(ShardingAxisName.EXPERT)
@@ -471,6 +494,8 @@ def expert_parallel_gmm(
             scatter_results=scatter_results,
             moe_chunk_size=moe_chunk_size,
             defer_all_reduce=defer_all_reduce,
+            lhs_scale_packed=lhs_scale_packed,
+            lhs_scale_dtype=lhs_scale_dtype,
         ),
         mesh=mesh,
         in_specs=(
@@ -648,8 +673,7 @@ def fused_moe_func(
         topk_indices = _override_token_indices_for_random_routing(
             topk_indices, global_num_experts)
 
-    def _process_tokens_locally(hidden_states_local, topk_indices_local):
-        num_tokens_local = hidden_states_local.shape[0]
+    def _sort_tokens_by_expert(topk_indices_local, num_tokens_local):
         topk_indices_flat = topk_indices_local.flatten()
         topk_argsort_indices = jnp.argsort(topk_indices_flat)
         token_indices = jnp.arange(num_tokens_local,
@@ -661,7 +685,12 @@ def fused_moe_func(
                                            global_num_experts,
                                            dtype=jnp.int32).sum(axis=0)
         topk_argsort_revert_indices = jnp.argsort(topk_argsort_indices)
+        return (token_indices_sorted, group_sizes_local,
+                topk_argsort_revert_indices)
 
+    def _permute_tokens_by_expert(hidden_states_local, token_indices_sorted,
+                                  group_sizes_local):
+        """Gather tokens into expert-sorted order, preserving input dtype."""
         if use_ep:
             num_ep_shard = get_mesh_shape_product(mesh,
                                                   ShardingAxisName.EXPERT)
@@ -681,36 +710,134 @@ def fused_moe_func(
                 onehot = jax.nn.one_hot(token_indices_sorted,
                                         hidden_states_local.shape[0],
                                         dtype=hidden_states_local.dtype)
-                x = onehot @ hidden_states_local
-            else:
-                x = ragged_gather(
-                    hidden_states_local,
-                    token_indices_sorted,
-                    shard_output_start,
-                    shard_output_end,
-                )
-        else:
-            x = hidden_states_local[token_indices_sorted]
+                return onehot @ hidden_states_local
+            return ragged_gather(
+                hidden_states_local,
+                token_indices_sorted,
+                shard_output_start,
+                shard_output_end,
+            )
+        return hidden_states_local[token_indices_sorted]
 
+    def _process_tokens_locally(hidden_states_local, topk_indices_local):
+        num_tokens_local = hidden_states_local.shape[0]
+        (token_indices_sorted, group_sizes_local,
+         topk_argsort_revert_indices) = _sort_tokens_by_expert(
+             topk_indices_local, num_tokens_local)
+        x = _permute_tokens_by_expert(hidden_states_local,
+                                      token_indices_sorted, group_sizes_local)
         return x, group_sizes_local, topk_argsort_revert_indices
 
-    if all_gather_fp8:
-        hidden_states = _apply_all_gather_fp8(hidden_states, mesh, dtype)
+    def _process_tokens_locally_fp8(combined_local, topk_indices_local):
+        # fp8 ragged-gather path: pack the per-token scale into fp8-typed
+        # transport bytes appended to the fp8 activations and permute both in a
+        # SINGLE SparseCore gather. The gather is row-bound, so the few extra
+        # columns are ~free, and one gather avoids serializing a second gather
+        # on the SparseCore.
+        #
+        # Crucially, the FULL gathered buffer is handed to GMM1 as its lhs --
+        # GMM1 contracts only the first hidden_size columns (size_k comes from
+        # w1), so the trailing scale/pad columns are never read. That means NO
+        # unpack slice/re-tile of the [expanded, hidden] tensor (slicing the
+        # codes back out forced a T(8,128)->T(32,128) re-layout copy) AND no
+        # second gather. GMM1 reads the scale from the trailing columns and
+        # dequantizes internally.
+        #
+        # The combined [tokens, hidden + scale + pad] buffer is built by the
+        # CALLER, before the P(MLP_DATA) reshard. Building it here instead cost
+        # 48us per MoE call: the reshard all-gathers to a replicated
+        # [8192, hidden] first, so the concat+pad copy ran on the full replicated
+        # tensor (~118MB touched) rather than on the local token shard.
+        #
+        # GMM1 unpacks the scale itself from the trailing lane tile of this same
+        # buffer (lhs_scale_packed), so nothing is extracted here: the host-side
+        # slice+or that used to rebuild a [P, 1] bf16 scale cost 18.9us per MoE
+        # call and is gone.
+        num_tokens_local = combined_local.shape[0]
+        (token_indices_sorted, group_sizes_local,
+         topk_argsort_revert_indices) = _sort_tokens_by_expert(
+             topk_indices_local, num_tokens_local)
+        gathered = _permute_tokens_by_expert(combined_local,
+                                             token_indices_sorted,
+                                             group_sizes_local)
+        # Pass the full buffer to GMM1 (it reads only [:, :hidden] for the
+        # contraction and the trailing lane tile for the scale); no slice.
+        return gathered, group_sizes_local, topk_argsort_revert_indices
 
-    x, group_sizes, topk_argsort_revert_indices = jax.shard_map(
-        _process_tokens_locally,
-        mesh=mesh,
-        in_specs=(
-            P(ShardingAxisName.MLP_DATA, None),
-            P(ShardingAxisName.MLP_DATA, None),
-        ),
-        out_specs=(
-            P(ShardingAxisName.MLP_DATA),
-            P(ShardingAxisName.MLP_DATA),
-            P(ShardingAxisName.MLP_DATA),
-        ),
-        check_vma=False,
-    )(hidden_states, topk_indices)
+    ragged_gather_fp8 = (all_gather_fp8 and envs.MOE_RAGGED_GATHER_FP8
+                         and use_ep)
+
+    if ragged_gather_fp8:
+        # Quantize once; the fp8 all-gather is folded into the shard_map reshard
+        # below (the P(MLP_DATA) in-spec), and the fp8 activations flow straight
+        # into GMM1 with their per-token scale (no intermediate dequant).
+        logger.info("Keep fp8 across ragged gather (MOE_RAGGED_GATHER_FP8)")
+        hidden_states_q, scale = quantize_tensor(jnp.float8_e4m3fn,
+                                                 hidden_states,
+                                                 axis=-1)
+        # quantize_tensor squeezes the scale when axis is int; expand it back.
+        # Cast to the compute dtype so it also drives GMM1's output dtype.
+        scale = jnp.expand_dims(scale, -1).astype(dtype)
+        # Build the combined [tokens, hidden + scale + pad] buffer HERE, before
+        # the P(MLP_DATA) reshard below all-gathers to a replicated tensor.
+        # Doing it inside the shard_map meant the concat+pad copy ran on the
+        # full replicated [8192, hidden] (~118MB touched, 48us per MoE call);
+        # here it runs on the local token shard and the reshard then moves the
+        # already-wide buffer in a single all-gather (1.8% more bytes) instead
+        # of all-gathering the codes and the scale separately.
+        # bf16 scale -> fp8-typed transport bytes (the gather only moves bits).
+        scale_f8 = jax.lax.bitcast_convert_type(scale,
+                                                jnp.float8_e4m3fn).reshape(
+                                                    scale.shape[0], -1)
+        # GMM1's packed-scale unpack assumes exactly two transport bytes
+        # (bf16); a wider compute dtype would need the kernel updated too.
+        assert scale_f8.shape[-1] == 2, (
+            f"packed scale expects 2 fp8 transport bytes, got "
+            f"{scale_f8.shape[-1]} (compute dtype {dtype})")
+        combined = jnp.concatenate([hidden_states_q, scale_f8], axis=1)
+        # ragged_gather needs a 128-multiple-divisor width; pad up to 128.
+        w = combined.shape[-1]
+        aligned_w = ((w + 127) // 128) * 128
+        if aligned_w != w:
+            combined = jnp.pad(combined, ((0, 0), (0, aligned_w - w)))
+        # Pin it to the token-sharded input layout so the copy happens on the
+        # local shard rather than after the reshard.
+        if get_mesh_shape_product(mesh, ShardingAxisName.ATTN_DATA) > 1:
+            combined = jax.lax.with_sharding_constraint(
+                combined,
+                NamedSharding(mesh, P(ShardingAxisName.ATTN_DATA, None)))
+        (x, group_sizes, topk_argsort_revert_indices) = jax.shard_map(
+            _process_tokens_locally_fp8,
+            mesh=mesh,
+            in_specs=(
+                P(ShardingAxisName.MLP_DATA, None),
+                P(ShardingAxisName.MLP_DATA, None),
+            ),
+            out_specs=(
+                P(ShardingAxisName.MLP_DATA),
+                P(ShardingAxisName.MLP_DATA),
+                P(ShardingAxisName.MLP_DATA),
+            ),
+            check_vma=False,
+        )(combined, topk_indices)
+    else:
+        if all_gather_fp8:
+            hidden_states = _apply_all_gather_fp8(hidden_states, mesh, dtype)
+
+        x, group_sizes, topk_argsort_revert_indices = jax.shard_map(
+            _process_tokens_locally,
+            mesh=mesh,
+            in_specs=(
+                P(ShardingAxisName.MLP_DATA, None),
+                P(ShardingAxisName.MLP_DATA, None),
+            ),
+            out_specs=(
+                P(ShardingAxisName.MLP_DATA),
+                P(ShardingAxisName.MLP_DATA),
+                P(ShardingAxisName.MLP_DATA),
+            ),
+            check_vma=False,
+        )(hidden_states, topk_indices)
 
     try:
         x = jnp.pad(x, ((0, 0), (0, padded_hidden_size - hidden_size)))
@@ -739,6 +866,8 @@ def fused_moe_func(
             scatter_results=scatter_results,
             moe_chunk_size=moe_chunk_size,
             defer_all_reduce=defer_all_reduce,
+            lhs_scale_packed=ragged_gather_fp8,
+            lhs_scale_dtype=dtype if ragged_gather_fp8 else None,
         )
     else:
         x = tensor_parallel_gmm(

--- a/tpu_inference/platforms/tpu_platform.py
+++ b/tpu_inference/platforms/tpu_platform.py
@@ -134,6 +134,7 @@ class TpuPlatform(Platform):
         "JAX_PROFILER_SERVER_PORT",
         "ENABLE_RS_KERNEL",
         "MOE_ALL_GATHER_ACTIVATION_DTYPE",
+        "MOE_RAGGED_GATHER_FP8",
     ]
 
     @classmethod


### PR DESCRIPTION
# Description

Keep MoE activations in fp8 through the expert-parallel ragged gather

Why this change is being made

On the expert-parallel MoE path, activations are quantized to fp8 for the ICI all-gather (MOE_ALL_GATHER_ACTIVATION_DTYPE=fp8), but then dequantized back to bf16 right after the `all-gather` — before the SparseCore ragged gather (the expert permute) — and GMM1 subsequently re-quantizes the top-k-expanded activations to fp8 internally. That's two conversions that cancel, plus a ragged gather that moves bf16 (2 bytes/elem) instead of fp8 (1 byte/elem).

This change keeps activations in fp8 all the way into GMM1, deleting both the dequant and GMM1's internal re-quant.

The problem being solved, and why it's non-trivial

An fp8 tensor is two things: the codes and a per-token scale. To defer dequant past the ragged gather, the scale has to stay aligned with its row through the permute. The obvious implementations all cost more than the fp8 conversion saves:
- a second gather for the scale serializes against the activation gather on SparseCore;
- a separate scale array forces layout/re-tile copies that outweigh the arithmetic.

The whole engineering problem is getting the scale to ride along for free.

Why this is a good solution

Pack the scale into the codes' trailing columns, permute both in one gather, and let the kernel read the scale out of the buffer it already holds. Four properties make it cheap:

- A bf16 is two fp8-typed bytes. bitcast_convert_type reinterprets the bits; nothing is converted. The gather moves bytes and doesn't care what they mean.
- The gather is row-bound, not byte-bound. Widening each row from hidden to the next 128-multiple costs ~nothing, so the scale rides inside the same permute.
- GMM1 contracts size_k (which comes from the weights), so handing it a physically wider lhs is free — it never reads past the codes. No slice, no re-tile.
- The scale is constant across k, so applying it once to the fully-reduced accumulator is exact. It lands before the bias and activation (scaling across a nonlinearity is not equivalent).

Result: one all-gather instead of two, one ragged gather instead of two, no host-side dequant, no re-tile.

# Test 

Measured on Kimi-K2.6 (MLA attention, fp4 MoE), tpu7x-8, 8-way expert parallel, 544 prompts / 8192 in / 1024 out:

- +1.87% total throughput vs the same commit with the flag off (2 interleaved pairs: +1.98%, +1.76%; baseline reproduced across sessions to 0.04%).
- Quality unchanged: greedy output bit-identical, MMLU indistinguishable (0.87675 both arms).

Serve:
QUANTIZE_ON_LOAD_PREFIXES="self_attn" DP_SCHED_BATCH_PREFILL=0 \
MOE_REQUANTIZE_WEIGHT_DTYPE=fp4 MOE_ALL_GATHER_ACTIVATION_DTYPE=fp8 \
MOE_REQUANTIZE_BLOCK_SIZE=512 MODEL_IMPL_TYPE=vllm \
MLA_TRANSPOSE_KV_CACHE=1 NEW_MODEL_DESIGN=1 \
MOE_RAGGED_GATHER_FP8=1 \
vllm serve \
  --model "gs://tpu-commons-ci/moonshootai/kimi/2.6" \
  --served-model-name="moonshotai/Kimi-K2.6" \
  --max-model-len=9216 --max-num-batched-tokens=1024 --max-num-seqs=68 \
  --no-enable-prefix-caching --gpu-memory-utilization=0.98 \
  --tensor-parallel-size=8 --async-scheduling --enable-expert-parallel \
  --kv-cache-dtype=fp8 --seed=42 \
  --limit-mm-per-prompt='{"image": 0, "video": 0, "vision_chunk": 0}' \
  --additional-config '{"compilation_sizes": [544], "sharding": {"sharding_strategy": {"enable_dp_attention": true}}}' \
  --generation-config="vllm" \
  --override-generation-config='{"do_sample": false, "temperature": 0.0, "model": "moonshotai/Kimi-K2.6"}' \
  --trust_remote_code 2>&1 | tee ~/kimi_tp_moe.log

Baseline (original path — flag OFF)

Identical, just flip the one flag:

... MOE_RAGGED_GATHER_FP8=0 ...

Bench:

vllm bench serve --model moonshotai/Kimi-K2.6 --dataset-name random \
  --random-input-len 8192 --random-output-len 1024 \
  --num-prompts 544 --ignore-eos --skip-chat-template --trust-remote-code


variant (fp8 — flag ON) — MOE_RAGGED_GATHER_FP8=1

## Serving Benchmark Result 
Successful requests:                     544
Failed requests:                         0
Benchmark duration (s):                  254.41
Total input tokens:                      4456448
Total generated tokens:                  557056
Request throughput (req/s):              2.14
Output token throughput (tok/s):         2189.63
Peak output token throughput (tok/s):    7600.00
Peak concurrent requests:                544.00
Total token throughput (tok/s):          19706.65
---------------Time to First Token----------------
Mean TTFT (ms):                          97389.12
Median TTFT (ms):                        87410.16
P99 TTFT (ms):                           209323.15
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          116.54
Median TPOT (ms):                        125.44
P99 TPOT (ms):                           155.22
---------------Inter-token Latency----------------
Mean ITL (ms):                           116.54
Median ITL (ms):                         54.63
P99 ITL (ms):                            329.23

http://xprof.corp.google.com/trace_viewer/dawnhan-5437574570183876168


baseline (original — flag OFF) — MOE_RAGGED_GATHER_FP8=0

## Serving Benchmark Result 
Successful requests:                     544
Failed requests:                         0
Benchmark duration (s):                  259.46
Total input tokens:                      4456448
Total generated tokens:                  557056
Request throughput (req/s):              2.10
Output token throughput (tok/s):         2147.01
Peak output token throughput (tok/s):    7200.00
Peak concurrent requests:                544.00
Total token throughput (tok/s):          19323.12
---------------Time to First Token----------------
Mean TTFT (ms):                          99238.52
Median TTFT (ms):                        89022.10
P99 TTFT (ms):                           213407.45
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          118.82
Median TPOT (ms):                        128.02
P99 TPOT (ms):                           158.32
---------------Inter-token Latency----------------
Mean ITL (ms):                           118.82
Median ITL (ms):                         55.84
P99 ITL (ms):                            334.95

http://xprof.corp.google.com/trace_viewer/dawnhan-18152971302305309911