### PR TITLE
Don't shrink the TP run's batch in the TP performance test

### DIFF
--- a/tests/e2e/test_tensor_parallel.py
+++ b/tests/e2e/test_tensor_parallel.py
@@ -135,9 +135,6 @@ def _test_tensor_parallelism_performance(
         tensor_parallel_size=tensor_parallel_size,
         pipeline_parallel_size=pipeline_parallel_size,
         max_model_len=cfg.max_model_len,
-        # These are global scheduler limits, not per-device ones, so they must
-        # match the baseline. Dividing them by the TP size gave the TP run half
-        # the decode batch and handed back the throughput TP had won.
         max_num_batched_tokens=cfg.max_num_batched_tokens,
         max_num_seqs=cfg.max_num_seqs,
         additional_config=additional_config or {},

--- a/tests/e2e/test_tensor_parallel.py
+++ b/tests/e2e/test_tensor_parallel.py
@@ -135,9 +135,11 @@ def _test_tensor_parallelism_performance(
         tensor_parallel_size=tensor_parallel_size,
         pipeline_parallel_size=pipeline_parallel_size,
         max_model_len=cfg.max_model_len,
-        max_num_batched_tokens=cfg.max_num_batched_tokens //
-        tensor_parallel_size,
-        max_num_seqs=cfg.max_num_seqs // tensor_parallel_size,
+        # These are global scheduler limits, not per-device ones, so they must
+        # match the baseline. Dividing them by the TP size gave the TP run half
+        # the decode batch and handed back the throughput TP had won.
+        max_num_batched_tokens=cfg.max_num_batched_tokens,
+        max_num_seqs=cfg.max_num_seqs,
         additional_config=additional_config or {},
     )
     _, tp_time = _run_inference(tp_config, test_prompts, sampling_params)


### PR DESCRIPTION
## Problem

`_test_tensor_parallelism_performance` divided `max_num_batched_tokens` and `max_num_seqs` by the TP size for the tensor-parallel run, while the baseline kept the full values:

```python
max_num_batched_tokens=cfg.max_num_batched_tokens // tensor_parallel_size,  # 2048 -> 1024
max_num_seqs=cfg.max_num_seqs // tensor_parallel_size,                      # 2048 -> 1024
```

Both are *global* scheduler limits, not per-device ones, so dividing them doesn't compensate for anything — it just gives the TP run half the decode batch (1024 vs 2048 concurrent seqs) and half the prefill chunk. Decode is weight-bandwidth bound, so the smaller batch hands back throughput TP had won, shrinking the measured speedup against the test's `min_speedup=1.05` gate.

## Change

Use the same scheduler limits for the TP run as for the baseline.
