### PR TITLE
Remove some decode sampling dispatch overheads

### DIFF
--- a/tests/layers/jax/sample/test_sampling.py
+++ b/tests/layers/jax/sample/test_sampling.py
@@ -198,9 +198,12 @@ class TestProcessedLogprobs:
             jnp.sum(jnp.exp(logits / temperature), axis=-1, keepdims=True))
         assert np.allclose(processed, expected, atol=1e-5)
 
-    def test_processed_logprobs_with_topk(self):
-        """After top-k masking, tokens outside top-k should get -inf logprobs."""
-        logits = jnp.array([[1.0, 5.0, 3.0, 2.0, 4.0]], dtype=jnp.float32)
+    @pytest.mark.parametrize("dtype", [jnp.float32, jnp.bfloat16])
+    def test_processed_logprobs_with_topk(self, dtype):
+        """After top-k masking, tokens outside top-k should get -inf logprobs.
+        Also runs with model-dtype (bf16) logits, since the runner forwards
+        compute_logits' bf16 output to sample() without an eager fp32 cast."""
+        logits = jnp.array([[1.0, 5.0, 3.0, 2.0, 4.0]], dtype=dtype)
 
         metadata = self._make_sampling_metadata(1, temperature=1.0, top_k=2)
         _, processed_logits = sample(jax.random.PRNGKey(0),

--- a/tests/layers/jax/sample/test_sampling.py
+++ b/tests/layers/jax/sample/test_sampling.py
@@ -16,6 +16,7 @@
 import jax
 import jax.numpy as jnp
 import numpy as np
+import pytest
 from jax.experimental import mesh_utils
 from jax.sharding import Mesh
 from vllm.v1.outputs import LogprobsTensors
@@ -177,16 +178,19 @@ class TestProcessedLogprobs:
         # The max logprob should be closer to 0 (more confident).
         assert float(jnp.max(processed[0])) > float(jnp.max(raw_logprobs[0]))
 
-    def test_processed_logprobs_matches_manual_temperature(self):
+    @pytest.mark.parametrize("step", [None, 5])
+    def test_processed_logprobs_matches_manual_temperature(self, step):
         """Verify processed_logprobs produces the same result as manually
-        dividing by temperature then computing log_softmax."""
+        dividing by temperature then computing log_softmax. Passing a
+        per-step key counter must not perturb the processed logits, which
+        depend only on the deterministic temperature/top-k/top-p transforms."""
         logits = jnp.array([[1.0, 2.0, 3.0, 0.5]], dtype=jnp.float32)
         temperature = 0.8
 
         metadata = self._make_sampling_metadata(1, temperature=temperature)
         fake_mesh = self._get_fake_mesh()
         _, processed_logits = sample(jax.random.PRNGKey(0), fake_mesh, logits,
-                                     metadata)
+                                     metadata, step)
         processed = compute_logprobs(processed_logits)
 
         expected = jnp.log(

--- a/tests/runner/test_tpu_runner_dp.py
+++ b/tests/runner/test_tpu_runner_dp.py
@@ -1352,10 +1352,12 @@ class TestSamplingMetadataPassthrough:
     @patch('tpu_inference.runner.tpu_runner.sample')
     @patch('tpu_inference.runner.tpu_runner.runner_utils')
     @patch('jax.device_get', return_value=np.zeros(8, dtype=np.int32))
-    def test_sample_from_logits_does_not_call_from_input_batch(
+    def test_sample_from_logits_uses_metadata_arg_and_skips_logit_cast(
             self, mock_jax_device_get, mock_runner_utils, mock_sample,
             mock_sampling_metadata):
-        """_sample_from_logits() should use its tpu_sampling_metadata argument, not create one internally."""
+        """_sample_from_logits() should use its tpu_sampling_metadata argument
+        (not create one internally), and with logprobs disabled it must not
+        upcast the raw logits to fp32 -- nothing consumes them past sampling."""
         runner = MagicMock()
         runner.input_batch.num_reqs = 0  # empty batch keeps the loop trivial
         runner.speculative_config = None
@@ -1366,8 +1368,10 @@ class TestSamplingMetadataPassthrough:
         mock_tpu_sampling_metadata.logprobs = False
 
         mock_runner_utils.get_padded_num_reqs_with_upper_limit.return_value = 8
-        mock_sample.return_value = np.zeros(8, dtype=np.int32)
+        # sample() returns (next_tokens, processed_logits).
+        mock_sample.return_value = (MagicMock(), MagicMock())
 
+        logits = MagicMock()
         try:
             TPUModelRunner._sample_from_logits(
                 runner,
@@ -1376,16 +1380,17 @@ class TestSamplingMetadataPassthrough:
                 mock_tpu_sampling_metadata,
                 None,  # input_ids
                 MagicMock(),  # hidden_states
-                MagicMock(),  # logits
+                logits,
                 None,  # aux_hidden_states
                 None,  # spec_decode_metadata
                 None,  # kv_connector_output
                 padded_num_reqs=8,
             )
         except Exception:
-            pass  # only care that from_input_batch was never called
+            pass  # only care about the calls asserted below
 
         mock_sampling_metadata.from_input_batch.assert_not_called()
+        logits.astype.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/tpu_inference/layers/jax/sample/sampling.py
+++ b/tpu_inference/layers/jax/sample/sampling.py
@@ -108,6 +108,7 @@ def sample(
     mesh: Mesh,
     logits: jax.Array,
     tpu_sampling_metadata: TPUSupportedSamplingMetadata,
+    step: Optional[jax.Array] = None,
 ) -> jax.Array:
     # (B, vocab_size)
     if tpu_sampling_metadata._cache_collision_dummy is not None:
@@ -116,6 +117,11 @@ def sample(
             tpu_sampling_metadata._cache_collision_dummy)
 
     if tpu_sampling_metadata.do_sampling:
+        if step is not None:
+            # `rng` is a long-lived base key; fold the decode-step counter
+            # into it so each step draws a distinct key. Callers that
+            # already hold a per-step key pass step=None.
+            rng = jax.random.fold_in(rng, step)
         # Unshard the logits explicity to avoid latency increase.
         # TODO(gxd3): revisit if the 2nd dimension of the logits can be sharded
         # instead of being replicated.

--- a/tpu_inference/runner/compilation_manager.py
+++ b/tpu_inference/runner/compilation_manager.py
@@ -932,6 +932,9 @@ class CompilationManager:
                         self.runner.mesh,
                         logits,
                         sampling_metadata,
+                        # Match the serving-time signature: an int step
+                        # counter when sampling, None otherwise.
+                        0 if do_sampling else None,
                         num_reqs=num_reqs,
                         do_sampling=do_sampling,
                         logprobs=logprobs,

--- a/tpu_inference/runner/compilation_manager.py
+++ b/tpu_inference/runner/compilation_manager.py
@@ -892,7 +892,9 @@ class CompilationManager:
             # function.
             sampling_metadata_sharding = NamedSharding(
                 self.runner.mesh, PartitionSpec(ShardingAxisName.ATTN_DATA))
-            logits = self._create_dummy_tensor((num_reqs, hsize), jnp.float32,
+            # bf16 to match the model-dtype logits sample() receives at
+            # serving time; sample() upcasts to fp32 internally.
+            logits = self._create_dummy_tensor((num_reqs, hsize), jnp.bfloat16,
                                                logits_sharding)
             for do_sampling in (True, False):
                 for logprobs in (True, False):

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -2035,7 +2035,10 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                 key=rejection_rng,
             )
 
-        logits = logits.astype(jnp.float32)
+        if tpu_sampling_metadata.logprobs:
+            # Only the logprobs computation below reads the raw logits, so
+            # upcast them only when logprobs are requested.
+            logits = logits.astype(jnp.float32)
         if full_logits is not None:
             full_logits = full_logits.astype(jnp.float32)
         with self.maybe_forbid_compile:

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -1221,6 +1221,9 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                                                     sharding=NamedSharding(
                                                         self.mesh,
                                                         PartitionSpec()))
+        # Monotonic decode-step counter folded into the sampling key inside
+        # sample() so each step draws a distinct key (see _sample_from_logits).
+        self._sampling_step = 0
         # This allows a multi-modal model to be used as text-only, assuming the user
         # passes the following to vLLM (on the CLI):
         # --limit-mm-per-prompt '{"image": 0, "video": 0}'
@@ -1981,26 +1984,32 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             padded_num_reqs = runner_utils.get_padded_num_reqs_with_upper_limit(
                 self.input_batch.num_reqs, self.max_num_reqs)
 
-        if tpu_sampling_metadata.do_sampling:
-            self.rng_params_for_sampling, step_rng = jax.random.split(
-                self.rng_params_for_sampling)
-        else:
-            step_rng = self.rng_params_for_sampling
-
         processed_bonus_logits = None
         if spec_decode_metadata is None:
+            # Let sample() derive the per-step key on device from the base
+            # key and a host-side step counter, rather than splitting the
+            # key on the host every step.
+            step = None
+            if tpu_sampling_metadata.do_sampling:
+                # Weak int32 scalar -> new values don't grow the jit cache.
+                step = self._sampling_step % (1 << 31)
+                self._sampling_step += 1
             logits = logits.astype(jnp.float32)
             with self.maybe_forbid_compile:
                 next_tokens, processed_logits = sample(
-                    step_rng,
+                    self.rng_params_for_sampling,
                     self.mesh,
                     logits,
                     tpu_sampling_metadata,
+                    step,
                 )
         else:
             if tpu_sampling_metadata.do_sampling:
+                self.rng_params_for_sampling, step_rng = jax.random.split(
+                    self.rng_params_for_sampling)
                 bonus_rng, rejection_rng = jax.random.split(step_rng)
             else:
+                step_rng = self.rng_params_for_sampling
                 bonus_rng = step_rng
                 rejection_rng = step_rng
             bonus_logits = self._select_from_array_fn(

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -1994,7 +1994,6 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                 # Weak int32 scalar -> new values don't grow the jit cache.
                 step = self._sampling_step % (1 << 31)
                 self._sampling_step += 1
-            logits = logits.astype(jnp.float32)
             with self.maybe_forbid_compile:
                 next_tokens, processed_logits = sample(
                     self.rng_params_for_sampling,


### PR DESCRIPTION
# Description

This PR removes several small, serialized device programs that were dispatched
on the host critical path **every decode step** without doing any useful math.
On the single-sequence / small-model decode path, where per-step compute is
small and host dispatch is the bottleneck, this pure launch overhead was a
measurable fraction of step time. It is eliminated in three independent
micro-optimizations, with **no change to sampled or greedy outputs**.

Previously, each decode step:
1. Split the sampling RNG key on the host (`jax.random.split`), which lowers to
   two tiny serialized device programs (a `threefry` split + an unstack).
2. Upcast the logits to fp32 on the host **before** `sample()` (one `convert`
   program), even though `sample()` already upcasts internally.
3. Upcast the raw logits to fp32 **after** sampling (another `convert` program),
   unconditionally, even when log-probs were not requested.

None of these produced results that differed from computing them inside the
sampling program, so they were pure host-dispatch overhead.

## What changed

1. **Fold the decode-step counter into the RNG key on device instead of
   splitting on the host.** `sample()` now accepts an optional `step` argument
   and does `jax.random.fold_in(base_key, step)` on device to derive a distinct
   per-step key. The runner keeps a long-lived base key resident and passes a
   host-side `int32` step counter (kept as a weak scalar so new values don't grow
   the jit cache). This removes the per-step host `jax.random.split`. The
   speculative-decoding path keeps its own key-split chain unchanged; greedy is
   unaffected (no RNG).
2. **Stop pre-casting logits to fp32 before `sample()`.** `sample()` already
   upcasts to fp32 internally for the sampling transforms, and
   `argmax(bf16 logits) == argmax(fp32 upcast of those logits)`, so the runner
   now forwards the model-dtype (bf16) logits straight in and the upcast fuses
   into the sample program. The sampling precompilation dummy is switched to bf16
   to keep hitting the precompiled program.
3. **Only upcast the raw logits to fp32 when log-probs are requested.** The one
   remaining consumer of the post-sample raw logits is the log-probs
   computation, so this cast is now gated on whether log-probs are enabled.

Net effect: up to ~3–4 fewer host-dispatched device programs per decode step,
all off the critical path.

## Why this is a good solution

The change removes some extra overhead and leads to an improvement in throughput for small models without affecting quality.

## Shortcomings / future improvements

- The win is only visible when decoding is host-dispatch-bound; on compute-bound
  workloads (large models, large batch) the improvement is within noise. This is
  expected as the change removes dispatch overhead, not compute.

# Tests

- **Unit tests** (updated in this PR):
  - `test_sampling.py` is parametrized over `step ∈ {None, 5}` and
    `dtype ∈ {float32, bfloat16}` to lock in that the processed log-probs are
    invariant to the step counter (it only feeds the RNG) and that the bf16 and
    fp32 sampling paths agree.
  - `test_tpu_runner_dp.py` asserts the raw logits are **not** upcast to fp32
    when log-probs are disabled.

- **Throughput A/B** on a single accelerator, single sequence, sampling enabled,
  long outputs (a decode-bound workload):
  - Small model (~0.5B params), bs=1: **+5.65% decode throughput**,
    **+6.14% end-to-end throughput**, **−5.3% per-token decode latency**, with
    clean non-overlapping run-to-run separation across repetitions.

# Checklist

Before submitting this PR, please make sure:
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have made or will make corresponding changes to any relevant documentation.