### PR TITLE
Fix RaidenOffloadConnector for single-RaidenBlockID KVCacheStore API

### DIFF
--- a/tests/offload/test_raiden_offload_connector.py
+++ b/tests/offload/test_raiden_offload_connector.py
@@ -87,13 +87,17 @@ def create_request(request_id: str, num_tokens: int,
 
 
 def make_matched(num_blocks: int, start_chunk: int = 100):
-    """Build a kv_store.lookup() result: list[(hash_bytes, [RaidenId])]."""
-    return [(f"hash_{i}".encode(), [
-        MockRaidenId(job_name="tpu_inference",
-                     job_replica_id="0",
-                     data_name="kv_cache",
-                     data_replica_idx=start_chunk + i)
-    ]) for i in range(num_blocks)]
+    """Build a kv_store.lookup() result: list[(hash_bytes, RaidenBlockID)].
+
+    KVCacheStore maps a single RaidenBlockID per block hash (not a list of
+    replicas), so each entry's second element is one id, not a list.
+    """
+    return [(f"hash_{i}".encode(),
+             MockRaidenId(job_name="tpu_inference",
+                          job_replica_id="0",
+                          data_name="kv_cache",
+                          data_replica_idx=start_chunk + i))
+            for i in range(num_blocks)]
 
 
 def make_scheduler(lookup_result=None, insert_result=None):
@@ -345,8 +349,9 @@ def test_request_finished_releases_pins():
 # --------------------------------------------------------------------------- #
 def test_update_connector_output_inserts_and_stages_evictions():
     evicted = MockRaidenId(data_replica_idx=99)
+    # insert() returns evicted entries as (hash, single RaidenBlockID).
     scheduler, store = make_scheduler(insert_result=(True, [(b"old_hash",
-                                                             [evicted])]))
+                                                             evicted)]))
     scheduler._pending_save_hashes["req_s"] = [b"h0", b"h1"]
 
     stats = KVRaidenConnectorStats()

--- a/tpu_inference/offload/raiden_offload_connector.py
+++ b/tpu_inference/offload/raiden_offload_connector.py
@@ -379,8 +379,10 @@ class RaidenOffloadConnectorScheduler:
 
             for i in range(load_start_idx,
                            load_start_idx + num_blocks_to_load):
-                _, raiden_ids = matched[i]
-                r_id = raiden_ids[0]
+                # lookup() returns a single RaidenBlockID per hash; its
+                # job_name/replica/data_name/data_replica_idx convenience
+                # properties delegate to the wrapped RaidenId.
+                _, r_id = matched[i]
                 src_chunk_ids.append(r_id.data_replica_idx)
                 src_locators.append(
                     RaidenLocator(r_id.job_name, r_id.job_replica_id,
@@ -608,25 +610,25 @@ class RaidenOffloadConnectorScheduler:
                         locator = RaidenLocator(self.job_name,
                                                 self.job_replica_id,
                                                 self.data_name, cid)
-                        # 1. Insert into C++ metadata lookup store
-                        # 1. Insert into C++ logical store and process evictions
+                        # 1. Insert into C++ logical store and process evictions.
+                        # KVCacheStore maps a single RaidenBlockID per block
+                        # hash, so slices is a flat list (one id per hash) and
+                        # each evicted entry is a single RaidenBlockID.
                         all_inserted, evicted = self.kv_store.insert(
-                            [h], [[locator.to_raiden_id()]], on_host=True)
+                            [h], [locator.to_raiden_id()], on_host=True)
                         if all_inserted:
                             self.metrics_collector.record_insertion(1)
 
                             # Handle C++ LRU evictions immediately
                             if evicted:
-                                for evict_hash, evict_slices in evicted:
-                                    for slice_id in evict_slices:
-                                        evict_cid = slice_id.data_replica_idx
-                                        self._pending_unlocks_to_send.append(
-                                            evict_cid)
-                                        self.metrics_collector.record_eviction(
-                                            1)
-                                        logger.debug(
-                                            f"[RaidenOffload] C++ Eviction: Staging physical unlock for chunk {evict_cid} (hash {evict_hash})"
-                                        )
+                                for evict_hash, evict_slice in evicted:
+                                    evict_cid = evict_slice.data_replica_idx
+                                    self._pending_unlocks_to_send.append(
+                                        evict_cid)
+                                    self.metrics_collector.record_eviction(1)
+                                    logger.debug(
+                                        f"[RaidenOffload] C++ Eviction: Staging physical unlock for chunk {evict_cid} (hash {evict_hash})"
+                                    )
 
                 if not pending_hashes:
                     self._pending_save_hashes.pop(req_id, None)


### PR DESCRIPTION
Fix RaidenOffloadConnector for single-RaidenBlockID KVCacheStore API
  
## Summary
`tpu_raiden`'s `KVCacheStore` was updated to map a **single** `RaidenBlockID` per block hash (previously a `list[list[RaidenBlockID]]`, one hash → many replicas; a single record now carries both host and device residency). The `RaidenOffloadConnector` was still written against the old list-of-list API, so the offload path crashed at runtime as soon as a save completed:
 
```
  File ".../tpu_raiden/api/jax/kv_cache_store.py", in insert 
      raw_slices.append(s._impl)
  AttributeError: 'list' object has no attribute '_impl'
```
The crash killed EngineCore, which surfaced downstream as the benchmark client failing to connect to the server. And this is the reason why we see following error in our daily release test against HEAD.

```
Traceback (most recent call last):
 ...
  File "/home/yiweiw_google_com/raiden_release_test/tpu-raiden/.venv312/lib/python3.12/site-packages/aiohttp/connector.py", line 1324, in _wrap_create_connection
    raise client_error(req.connection_key, exc) from exc
aiohttp.client_exceptions.ClientConnectorError: Cannot connect to host [127.0.0.1:8000](http://127.0.0.1:8000/) ssl:default [Connect call failed ('127.0.0.1', 8000)]
```

## Changes

Aligned the three call sites that consumed the old nested shape:
  
- **`insert()`**: pass a flat `[locator.to_raiden_id()]` (one id per hash) instead of the nested `[[...]]`.
- **eviction handling**: each evicted entry is now `(hash, RaidenBlockID)`, so drop the inner per-slice loop and read the chunk id off the single `RaidenBlockID` (its `data_replica_idx` convenience property delegates to the wrapped `RaidenId`).
- **`lookup()` load path**: `matched[i]` now yields a single `RaidenBlockID`, so unpack it directly instead of indexing `[0]`.

## Testing
Ran the `kv_host_offloading` example end-to-end on tpu7x-8 (Qwen3-32B, tp=8) against `tpu_raiden` built from current `main`:

- **Before**: first request → `AttributeError` → EngineCore dead → 500s.
- **After**: 275 requests across two runs, **0 failures**, no `AttributeError`, clean shutdown. The offload store is populated and lookups hit (metrics show hundreds of successful inserts), confirming the fixed insert path runs repeatedly.