### PR TITLE
Incremental weight loading and sharding for FP8 MoE models

### DIFF
--- a/tests/layers/vllm/test_fp8.py
+++ b/tests/layers/vllm/test_fp8.py
@@ -14,6 +14,7 @@
 
 import math
 import tempfile
+from unittest.mock import MagicMock, patch
 
 import jax
 import pytest
@@ -29,6 +30,7 @@ from vllm.distributed.parallel_state import (ensure_model_parallel_initialized,
                                              init_distributed_environment)
 from vllm.engine.arg_utils import EngineArgs
 from vllm.forward_context import set_forward_context
+from vllm.model_executor.layers import linear as vllm_linear
 from vllm.model_executor.layers.fused_moe import FusedMoE
 from vllm.model_executor.layers.linear import (ColumnParallelLinear,
                                                LinearBase,
@@ -37,6 +39,7 @@ from vllm.model_executor.layers.linear import (ColumnParallelLinear,
                                                RowParallelLinear)
 
 from tests.layers.common import utils as test_utils
+from tpu_inference import envs
 from tpu_inference.layers.common.moe import MoEBackend
 from tpu_inference.layers.common.quantization.configs import QuantLinearConfig
 from tpu_inference.layers.vllm.quantization import get_tpu_quantization_config
@@ -582,3 +585,132 @@ def test_unaligned_block_quantization(model, input_size, output_size):
     initialize_layer_weights(linear_layer)
     ref_output, layer_output = return_ref_and_layer_output(linear_layer)
     torch.testing.assert_close(ref_output, layer_output)
+
+
+def test_fp8_incremental_loading_trigger():
+    """Test that maybe_process_weights tracks shards and triggers sharding on exact last shard."""
+    mesh = test_utils.get_spmd_mesh(1)
+    engine_args = EngineArgs(model=MODELS[0], max_model_len=64)
+    vllm_config = engine_args.create_engine_config()
+    quant_config = get_tpu_quantization_config(vllm_config, mesh)
+
+    with set_current_vllm_config(vllm_config):
+        mock_linear_config = MagicMock()
+        mock_linear_config.num_proj = 1
+        method = VllmFp8LinearMethod(quant_config, mock_linear_config)
+
+    layer = MagicMock(spec=vllm_linear.ColumnParallelLinear)
+    layer.named_parameters.return_value = [("weight", MagicMock()),
+                                           ("weight_scale", MagicMock())]
+    layer._loaded_weights = set()
+
+    with patch.object(method, "process_weights_after_loading") as mock_process:
+        with patch.object(envs, "VLLM_INCREMENTAL_FP8_LOADING", True):
+            # First shard: weight
+            method.maybe_process_weights(layer, "weight", (), {})
+            assert mock_process.call_count == 0
+            assert "weight" in layer._loaded_weights
+
+            # Second shard: weight_scale (last shard)
+            method.maybe_process_weights(layer, "weight_scale", (), {})
+            assert mock_process.call_count == 1
+
+
+def test_fp8_incremental_loading_already_processed_noop():
+    """Test that process_weights_after_loading is a no-op if weight is no longer in CPU or missing."""
+    mesh = test_utils.get_spmd_mesh(1)
+    engine_args = EngineArgs(model=MODELS[0], max_model_len=64)
+    vllm_config = engine_args.create_engine_config()
+    quant_config = get_tpu_quantization_config(vllm_config, mesh)
+
+    with set_current_vllm_config(vllm_config):
+        layer = ColumnParallelLinear(
+            input_size=128,
+            output_size=256,
+            bias=False,
+            quant_config=quant_config,
+        )
+
+    method = layer.quant_method
+    delattr(layer, "weight")
+    # Should safely return without error when weight is missing
+    method.process_weights_after_loading(layer)
+
+
+def test_fp8_e8m0_scale_parameter_conversion():
+    """Test that float8_e8m0fnu scale conversion converts to float32 and retains Parameter type."""
+    mesh = test_utils.get_spmd_mesh(1)
+    engine_args = EngineArgs(model=MODELS[0], max_model_len=64)
+    vllm_config = engine_args.create_engine_config()
+    quant_config = get_tpu_quantization_config(vllm_config, mesh)
+
+    with set_current_vllm_config(vllm_config):
+        layer = ColumnParallelLinear(
+            input_size=128,
+            output_size=256,
+            bias=False,
+            quant_config=quant_config,
+        )
+
+    method = layer.quant_method
+    method.block_quant = False
+    initialize_layer_weights(layer)
+
+    layer.weight_scale = torch.nn.Parameter(torch.tensor(
+        1.0, dtype=torch.float8_e8m0fnu),
+                                            requires_grad=False)
+
+    method.process_weights_after_loading(layer)
+
+    assert isinstance(layer.weight_scale, torch.nn.Parameter)
+    assert layer.weight_scale.dtype == torch.float32
+
+
+def test_fp8_moe_incremental_loading_trigger():
+    """Test that VllmFp8MoEMethod triggers sharding only when expected 6E shards arrive."""
+    mesh = test_utils.get_spmd_mesh(1)
+    mock_moe_config = MagicMock()
+    mock_moe_config.num_experts = 4
+    layer = MagicMock()
+    layer.moe_config = mock_moe_config
+    layer.global_num_experts = 4
+    layer._loaded_weights = set()
+
+    fp8_config = MagicMock()
+    fp8_config.weight_block_size = [128, 128]
+
+    with patch(
+            "tpu_inference.layers.vllm.quantization.fp8.select_moe_backend_from_fused_moe_config"
+    ):
+        method = VllmFp8MoEMethod(fp8_config, layer, mesh)
+
+    with patch.object(method, "process_weights_after_loading") as mock_process:
+        with patch.object(envs, "VLLM_INCREMENTAL_FP8_LOADING", True):
+            # Load 23 shards (1 short of expected 24)
+            for expert_id in range(4):
+                for shard_id in range(5):
+                    method.maybe_process_weights(layer, "w13_weight", (), {
+                        "expert_id": expert_id,
+                        "shard_id": shard_id
+                    })
+            method.maybe_process_weights(layer, "w2_weight", (), {
+                "expert_id": 0,
+                "shard_id": 5
+            })
+            method.maybe_process_weights(layer, "w2_weight", (), {
+                "expert_id": 1,
+                "shard_id": 5
+            })
+            method.maybe_process_weights(layer, "w2_weight", (), {
+                "expert_id": 2,
+                "shard_id": 5
+            })
+
+            assert mock_process.call_count == 0
+
+            # 24th shard triggers process_weights_after_loading
+            method.maybe_process_weights(layer, "w2_weight", (), {
+                "expert_id": 3,
+                "shard_id": 5
+            })
+            assert mock_process.call_count == 1

--- a/tpu_inference/envs.py
+++ b/tpu_inference/envs.py
@@ -71,6 +71,7 @@ if TYPE_CHECKING:
     MIN_TOKEN_BUCKET: int = 16
     MOE_ROUTE_PADDING_TO_EXPERT0: bool = False
     VLLM_TPU_BUCKET_PADDING_GAP: int = 0
+    VLLM_INCREMENTAL_FP8_LOADING: bool = False
     TPU_MESH_SORT_BY_COORDS: bool = False
 
 
@@ -440,6 +441,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Currently, it only supports a single host set up.
     "TPU_MESH_SORT_BY_COORDS":
     env_bool("TPU_MESH_SORT_BY_COORDS", default=False),
+    # Controls whether FP8 layers perform incremental weight loading and sharding.
+    "VLLM_INCREMENTAL_FP8_LOADING":
+    env_bool("VLLM_INCREMENTAL_FP8_LOADING", default=False),
 }
 
 

--- a/tpu_inference/envs.py
+++ b/tpu_inference/envs.py
@@ -441,7 +441,12 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Currently, it only supports a single host set up.
     "TPU_MESH_SORT_BY_COORDS":
     env_bool("TPU_MESH_SORT_BY_COORDS", default=False),
-    # Controls whether FP8 layers perform incremental weight loading and sharding.
+    # Controls whether FP8 linear and MoE layers perform incremental weight
+    # loading, sharding, and immediate host RAM cleanup. When enabled, weights
+    # are sharded and transferred to TPU device memory layer-by-layer (or per
+    # MoE expert shard), freeing PyTorch CPU storage and trimming glibc malloc
+    # arenas after each layer. This prevents host CPU memory exhaustion (OOM)
+    # when initializing large FP8 models on smaller RAM TPUs such as TPU8i.
     "VLLM_INCREMENTAL_FP8_LOADING":
     env_bool("VLLM_INCREMENTAL_FP8_LOADING", default=False),
 }

--- a/tpu_inference/layers/vllm/quantization/base.py
+++ b/tpu_inference/layers/vllm/quantization/base.py
@@ -19,7 +19,50 @@ import torch
 
 class VllmQuantizationMethod(ABC):
 
+    def maybe_process_linear_weights(
+        self,
+        layer: torch.nn.Module,
+        param_name: str,
+        args,
+        kwargs,
+        num_proj: int,
+        log_prefix: str = "",
+    ):
+        """Shared tracking logic for incremental sharding of linear layers."""
+        if isinstance(layer, vllm_linear.QKVParallelLinear):
+            if len(args) == 1:
+                shard_id = args[0]
+                layer._loaded_weights.add((param_name, shard_id))
+            else:
+                layer._loaded_weights.add((param_name, "q"))
+                layer._loaded_weights.add((param_name, "k"))
+                layer._loaded_weights.add((param_name, "v"))
+        elif isinstance(layer, vllm_linear.MergedColumnParallelLinear):
+            if len(args) == 1:
+                shard_id = args[0]
+                layer._loaded_weights.add((param_name, shard_id))
+            else:
+                for i in range(len(layer.output_sizes)):
+                    layer._loaded_weights.add((param_name, i))
+        else:
+            layer._loaded_weights.add(param_name)
+
+        expected_count = num_proj * len(
+            dict(layer.named_parameters(recurse=False)))
+        if len(layer._loaded_weights) == expected_count:
+            prefix_str = f"[{log_prefix}] " if log_prefix else ""
+            logger.debug(
+                f"{prefix_str}Start sharding weights for layer {type(layer)}")
+            self.process_weights_after_loading(layer)
+            logger.debug(
+                f"{prefix_str}Complete sharding weights for layer {type(layer)}"
+            )
+
     @abstractmethod
     def maybe_process_weights(self, layer: torch.nn.Module, param_name: str,
                               args, kwargs):
+        raise NotImplementedError
+
+    @abstractmethod
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
         raise NotImplementedError

--- a/tpu_inference/layers/vllm/quantization/base.py
+++ b/tpu_inference/layers/vllm/quantization/base.py
@@ -15,6 +15,10 @@
 from abc import ABC, abstractmethod
 
 import torch
+from vllm.logger import init_logger
+from vllm.model_executor.layers import linear as vllm_linear
+
+logger = init_logger(__name__)
 
 
 class VllmQuantizationMethod(ABC):

--- a/tpu_inference/layers/vllm/quantization/fp8.py
+++ b/tpu_inference/layers/vllm/quantization/fp8.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import ctypes
 import gc
 from typing import Optional, Union
 
@@ -59,6 +60,39 @@ from tpu_inference.logger import init_logger
 P = PartitionSpec
 
 logger = init_logger(__name__)
+
+
+def _free_torch_storage(tensor: Optional[torch.Tensor]) -> None:
+    """Safely frees the underlying CPU memory storage of a PyTorch tensor.
+
+    Tries `untyped_storage().resize_(0)` first, with fallback to `set_(torch.storage.UntypedStorage())`
+    for 0-dim scalars or float8 dtypes that cannot be resized in-place.
+    """
+    if tensor is None:
+        return
+    try:
+        tensor.untyped_storage().resize_(0)
+    except Exception:
+        tensor.set_(torch.storage.UntypedStorage())
+
+
+try:
+    _libc = ctypes.CDLL("libc.so.6")
+except Exception:
+    _libc = None
+
+
+def _release_host_memory() -> None:
+    """Frees CPU host memory and trims malloc arena if incremental FP8 loading is enabled."""
+    if not envs.VLLM_INCREMENTAL_FP8_LOADING:
+        return
+    gc.collect()
+    jax.effects_barrier()
+    if _libc is not None and hasattr(_libc, "malloc_trim"):
+        try:
+            _libc.malloc_trim(0)
+        except Exception as e:
+            logger.debug(f"[fp8-incremental] malloc_trim failed: {e}")
 
 
 @register_quantization_config(FP8)
@@ -144,27 +178,17 @@ class VllmFp8LinearMethod(
         if not envs.VLLM_INCREMENTAL_FP8_LOADING:
             return
 
-        if isinstance(layer, vllm_linear.QKVParallelLinear):
-            if len(args) == 1:
-                shard_id = args[0]
-                layer._loaded_weights.add((param_name, shard_id))
-            else:
-                layer._loaded_weights.add((param_name, "q"))
-                layer._loaded_weights.add((param_name, "k"))
-                layer._loaded_weights.add((param_name, "v"))
-        elif isinstance(layer, vllm_linear.MergedColumnParallelLinear):
-            if len(args) == 1:
-                shard_id = args[0]
-                layer._loaded_weights.add((param_name, shard_id))
-            else:
-                for i in range(len(layer.output_sizes)):
-                    layer._loaded_weights.add((param_name, i))
-        else:
-            layer._loaded_weights.add(param_name)
+        logger.info_once(
+            "[fp8-incremental] VLLM_INCREMENTAL_FP8_LOADING is enabled")
 
-        if len(layer._loaded_weights) == self.linear_config.num_proj * len(
-                dict(layer.named_parameters(recurse=False))):
-            self.process_weights_after_loading(layer)
+        self.maybe_process_linear_weights(
+            layer,
+            param_name,
+            args,
+            kwargs,
+            self.linear_config.num_proj,
+            log_prefix="fp8-incremental",
+        )
 
     def create_weights(
         self,
@@ -197,13 +221,10 @@ class VllmFp8LinearMethod(
         )
 
         p_weight = layer.weight
-        p_scale = getattr(
-            layer, "weight_scale_inv" if self.block_quant else "weight_scale",
-            None)
 
         weight = _load_weight_for_layer(layer, "weight", loading_sharding)
         weight = jnp.transpose(weight)
-        p_weight.set_(torch.storage.UntypedStorage())
+        _free_torch_storage(p_weight)
         delattr(layer, "weight")
 
         if self.block_quant:
@@ -211,22 +232,24 @@ class VllmFp8LinearMethod(
             # Float8_e8m0fnu (ue8m0) scales cannot be converted via numpy in t2j.
             # TODO: consider get rid of the f32 conversion, to optimize the HBM usage.
             if weight_scale_inv.dtype == torch.float8_e8m0fnu:
-                layer.weight_scale_inv = weight_scale_inv.to(torch.float32)
+                layer.weight_scale_inv = Parameter(
+                    weight_scale_inv.to(torch.float32), requires_grad=False
+                )
             weight_scale = _load_weight_for_layer(layer, "weight_scale_inv",
                                                   loading_sharding)
             weight_scale = jnp.transpose(weight_scale)
-            if p_scale is not None:
-                p_scale.set_(torch.storage.UntypedStorage())
+            _free_torch_storage(layer.weight_scale_inv)
             delattr(layer, "weight_scale_inv")
         else:
             weight_scale_tensor = layer.weight_scale
             if weight_scale_tensor.dtype == torch.float8_e8m0fnu:
-                layer.weight_scale = weight_scale_tensor.to(torch.float32)
+                layer.weight_scale = Parameter(
+                    weight_scale_tensor.to(torch.float32), requires_grad=False
+                )
             scale_sharding = NamedSharding(self.linear_config.mesh, P(None))
             weight_scale = _load_weight_for_layer(layer, "weight_scale",
                                                   scale_sharding)
-            if p_scale is not None:
-                p_scale.set_(torch.storage.UntypedStorage())
+            _free_torch_storage(layer.weight_scale)
             delattr(layer, "weight_scale")
 
         if layer.bias is not None and not layer.skip_bias_add:
@@ -287,59 +310,42 @@ class VllmFp8LinearMethod(
                 per_tensor=not self.block_quant,
             ))
 
-        scale_name = "weight_scale_inv" if self.block_quant else "weight_scale"
         if self.linear_config.fuse_matmuls:
             layer.weight = Parameter(weights.weight, requires_grad=False)
-            setattr(
-                layer,
-                scale_name,
-                Parameter(weights.weight_scale, requires_grad=False),
+            layer.weight_scale = Parameter(
+                weights.weight_scale, requires_grad=False
             )
             if has_bias:
                 layer.bias = Parameter(weights.bias, requires_grad=False)
         else:
             layer.weight = to_parameter_list(weights.weight)
-            setattr(
-                layer,
-                scale_name,
-                to_parameter_list(weights.weight_scale),
-            )
+            layer.weight_scale = to_parameter_list(weights.weight_scale)
             if has_bias:
                 layer.bias = to_parameter_list(weights.bias)
 
-        import ctypes
-
-        gc.collect()
-        jax.effects_barrier()
-        try:
-            ctypes.CDLL("libc.so.6").malloc_trim(0)
-        except Exception:
-            pass
+        _release_host_memory()
 
     def apply(self,
               layer: torch.nn.Module,
               x: torch.Tensor,
               bias: Optional[torch.Tensor] = None) -> torch.Tensor:
-        scale_name = "weight_scale_inv" if self.block_quant else "weight_scale"
         with jax.named_scope(layer._get_name()):
             x_jax = jax_view(x)
             bias_jax = jax_view(
                 bias) if bias is not None and not layer.skip_bias_add else None
             if self.linear_config.fuse_matmuls:
                 weight_jax = jax_view(layer.weight)
-                weight_scale_jax = jax_view(getattr(layer, scale_name))
+                weight_scale_jax = jax_view(layer.weight_scale)
                 out = self._apply_fused(x_jax, weight_jax, weight_scale_jax,
                                         bias_jax)
             else:
                 assert isinstance(layer.weight, torch.nn.ParameterList)
-                scale_params = getattr(layer, scale_name)
-                assert isinstance(scale_params, torch.nn.ParameterList)
+                assert isinstance(layer.weight_scale, torch.nn.ParameterList)
                 # jax_view cannot handle ParameterList directly, so we explicitly
                 # convert them to list of jax.Array.
-                weight_and_scale = [
-                    (jax_view(w), jax_view(s))
-                    for w, s in zip(layer.weight, scale_params)
-                ]
+                weight_and_scale = [(jax_view(w), jax_view(s))
+                                    for w, s in zip(layer.weight, layer.weight_scale)
+                                    ]
                 if bias is not None and not layer.skip_bias_add:
                     assert isinstance(bias, torch.nn.ParameterList)
                     bias_jax = [jax_view(b) for b in bias]
@@ -382,21 +388,30 @@ class VllmFp8MoEMethod(vllm_fp8.Fp8MoEMethod, VllmQuantizationMethod):
         if not envs.VLLM_INCREMENTAL_FP8_LOADING:
             return
 
+        logger.info_once(
+            "[fp8-incremental] VLLM_INCREMENTAL_FP8_LOADING is enabled")
+
+        if not self.block_quant:
+            raise NotImplementedError(
+                "Incremental loading for non-block FP8 MoE is not supported.")
+
         expert_id = kwargs.get("expert_id")
         shard_id = kwargs.get("shard_id")
-        if expert_id is not None and shard_id is not None:
-            layer._loaded_weights.add((param_name, expert_id, shard_id))
-        else:
-            layer._loaded_weights.add(param_name)
+        assert expert_id is not None, "Expecting expert_id argument"
+        assert shard_id is not None, "Expecting shard_id argument"
 
-        num_experts = getattr(layer, "global_num_experts", 0)
-        scale_w13_expected = num_experts * 2 if self.block_quant else 1
-        scale_w2_expected = num_experts * 1 if self.block_quant else 1
-        expected_shards = ((num_experts * 2) + (num_experts * 1) +
-                           scale_w13_expected + scale_w2_expected)
+        layer._loaded_weights.add((param_name, expert_id, shard_id))
+
+        expected_shards = 6 * layer.global_num_experts
 
         if len(layer._loaded_weights) >= expected_shards:
+            logger.debug(
+                f"[fp8-incremental] Start sharding weights for MoE layer {type(layer)}"
+            )
             self.process_weights_after_loading(layer)
+            logger.debug(
+                f"[fp8-incremental] Complete sharding weights for MoE layer {type(layer)}"
+            )
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
         if not hasattr(layer, "w13_weight") or not _tensor_is_in_cpu(
@@ -443,10 +458,10 @@ class VllmFp8MoEMethod(vllm_fp8.Fp8MoEMethod, VllmQuantizationMethod):
         )
 
         # Free CPU memory now that weights have been safely transferred to TPU
-        layer.w13_weight.untyped_storage().resize_(0)
-        layer.w2_weight.untyped_storage().resize_(0)
-        p_w13_scale.set_(torch.storage.UntypedStorage())
-        p_w2_scale.set_(torch.storage.UntypedStorage())
+        _free_torch_storage(layer.w13_weight)
+        _free_torch_storage(layer.w2_weight)
+        _free_torch_storage(p_w13_scale)
+        _free_torch_storage(p_w2_scale)
         delattr(layer, "w13_weight")
         delattr(layer, "w2_weight")
         delattr(layer, scale_w13_name)
@@ -473,14 +488,7 @@ class VllmFp8MoEMethod(vllm_fp8.Fp8MoEMethod, VllmQuantizationMethod):
             scale_w2_name,
             Parameter(weights.w2_weight_scale, requires_grad=False),
         )
-        import ctypes
-
-        gc.collect()
-        jax.effects_barrier()
-        try:
-            ctypes.CDLL("libc.so.6").malloc_trim(0)
-        except Exception:
-            pass
+        _release_host_memory()
 
     def apply_monolithic(
         self,

--- a/tpu_inference/layers/vllm/quantization/fp8.py
+++ b/tpu_inference/layers/vllm/quantization/fp8.py
@@ -12,12 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import gc
 from typing import Optional, Union
 
 import jax
 import jax.numpy as jnp
 import torch
-from jax.sharding import Mesh, PartitionSpec
+from jax.sharding import Mesh, NamedSharding, PartitionSpec
 from torch.nn.parameter import Parameter
 from torchax.interop import jax_view, torch_view
 from vllm.model_executor.layers import linear as vllm_linear
@@ -32,6 +33,7 @@ from vllm.model_executor.layers.quantization.base_config import \
 from vllm.model_executor.layers.quantization.utils.quant_utils import \
     is_layer_skipped
 
+from tpu_inference import envs
 from tpu_inference.layers.common.moe import \
     FusedMoEMethodBase as TpuFusedMoEMethodBase
 from tpu_inference.layers.common.process_weights.linear_weights import (
@@ -41,14 +43,18 @@ from tpu_inference.layers.common.process_weights.moe_weights import (
     FusedMoEWeights, process_quantized_moe_weights, shard_moe_weights)
 from tpu_inference.layers.common.quant_methods import FP8
 from tpu_inference.layers.common.quantization import fp8 as common_fp8
+from tpu_inference.layers.common.sharding import ShardingAxisName
 from tpu_inference.layers.vllm.interface.moe import (
     select_moe_backend_from_fused_moe_config, vllm_moe_apply)
+from tpu_inference.layers.vllm.process_weights.cleanup_sharding import \
+    _tensor_is_in_cpu
+from tpu_inference.layers.vllm.quantization.base import VllmQuantizationMethod
 from tpu_inference.layers.vllm.quantization.configs import (
     VllmQuantConfig, VllmQuantLinearConfig)
 from tpu_inference.layers.vllm.quantization.unquantized import (
-    VllmUnquantizedFusedMoEMethod, VllmUnquantizedLinearMethod)
+    VllmUnquantizedFusedMoEMethod, VllmUnquantizedLinearMethod,
+    _load_weight_for_layer)
 from tpu_inference.logger import init_logger
-from tpu_inference.utils import t2j
 
 P = PartitionSpec
 
@@ -96,8 +102,11 @@ class VllmFp8Config(vllm_fp8.Fp8Config, VllmQuantConfig):
                 return None
 
 
-class VllmFp8LinearMethod(vllm_fp8.Fp8LinearMethod,
-                          common_fp8.Fp8LinearMethod):
+class VllmFp8LinearMethod(
+        vllm_fp8.Fp8LinearMethod,
+        common_fp8.Fp8LinearMethod,
+        VllmQuantizationMethod,
+):
 
     # Dynamically register this method to support weight_loader_v2 in vLLM.
     # This avoids hardcoding TPU-specific methods in the upstream vLLM repository.
@@ -130,6 +139,33 @@ class VllmFp8LinearMethod(vllm_fp8.Fp8LinearMethod,
                 "Blockwise quantization is supported by quantized matmul kernel. Please enable quantized_matmul_kernel or unset the quantize block size to trigger XLA per-channel quantization."
             )
 
+    def maybe_process_weights(self, layer: torch.nn.Module, param_name: str,
+                              args, kwargs):
+        if not envs.VLLM_INCREMENTAL_FP8_LOADING:
+            return
+
+        if isinstance(layer, vllm_linear.QKVParallelLinear):
+            if len(args) == 1:
+                shard_id = args[0]
+                layer._loaded_weights.add((param_name, shard_id))
+            else:
+                layer._loaded_weights.add((param_name, "q"))
+                layer._loaded_weights.add((param_name, "k"))
+                layer._loaded_weights.add((param_name, "v"))
+        elif isinstance(layer, vllm_linear.MergedColumnParallelLinear):
+            if len(args) == 1:
+                shard_id = args[0]
+                layer._loaded_weights.add((param_name, shard_id))
+            else:
+                for i in range(len(layer.output_sizes)):
+                    layer._loaded_weights.add((param_name, i))
+        else:
+            layer._loaded_weights.add(param_name)
+
+        if len(layer._loaded_weights) == self.linear_config.num_proj * len(
+                dict(layer.named_parameters(recurse=False))):
+            self.process_weights_after_loading(layer)
+
     def create_weights(
         self,
         layer: torch.nn.Module,
@@ -151,10 +187,23 @@ class VllmFp8LinearMethod(vllm_fp8.Fp8LinearMethod,
         self.use_marlin = True
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        if not hasattr(layer, "weight") or not _tensor_is_in_cpu(layer.weight):
+            return
         assert isinstance(layer, vllm_linear.LinearBase)
 
-        weight = t2j(layer.weight, use_dlpack=False)
+        loading_sharding = NamedSharding(
+            self.linear_config.mesh,
+            PartitionSpec(*self.linear_config.weight_sharding[::-1]),
+        )
+
+        p_weight = layer.weight
+        p_scale = getattr(
+            layer, "weight_scale_inv" if self.block_quant else "weight_scale",
+            None)
+
+        weight = _load_weight_for_layer(layer, "weight", loading_sharding)
         weight = jnp.transpose(weight)
+        p_weight.set_(torch.storage.UntypedStorage())
         delattr(layer, "weight")
 
         if self.block_quant:
@@ -162,15 +211,22 @@ class VllmFp8LinearMethod(vllm_fp8.Fp8LinearMethod,
             # Float8_e8m0fnu (ue8m0) scales cannot be converted via numpy in t2j.
             # TODO: consider get rid of the f32 conversion, to optimize the HBM usage.
             if weight_scale_inv.dtype == torch.float8_e8m0fnu:
-                weight_scale_inv = weight_scale_inv.to(torch.float32)
-            weight_scale = t2j(weight_scale_inv, use_dlpack=False)
+                layer.weight_scale_inv = weight_scale_inv.to(torch.float32)
+            weight_scale = _load_weight_for_layer(layer, "weight_scale_inv",
+                                                  loading_sharding)
             weight_scale = jnp.transpose(weight_scale)
+            if p_scale is not None:
+                p_scale.set_(torch.storage.UntypedStorage())
             delattr(layer, "weight_scale_inv")
         else:
-            weight_scale = layer.weight_scale
-            if weight_scale.dtype == torch.float8_e8m0fnu:
-                weight_scale = weight_scale.to(torch.float32)
-            weight_scale = t2j(weight_scale, use_dlpack=False)
+            weight_scale_tensor = layer.weight_scale
+            if weight_scale_tensor.dtype == torch.float8_e8m0fnu:
+                layer.weight_scale = weight_scale_tensor.to(torch.float32)
+            scale_sharding = NamedSharding(self.linear_config.mesh, P(None))
+            weight_scale = _load_weight_for_layer(layer, "weight_scale",
+                                                  scale_sharding)
+            if p_scale is not None:
+                p_scale.set_(torch.storage.UntypedStorage())
             delattr(layer, "weight_scale")
 
         if layer.bias is not None and not layer.skip_bias_add:
@@ -219,6 +275,9 @@ class VllmFp8LinearMethod(vllm_fp8.Fp8LinearMethod,
                 per_tensor=weight_scale.ndim == 0,
             )
 
+        has_bias = bias is not None
+        del weight, weight_scale, bias
+
         weights = torch_view(
             shard_linear_weights(
                 weights,
@@ -228,39 +287,58 @@ class VllmFp8LinearMethod(vllm_fp8.Fp8LinearMethod,
                 per_tensor=not self.block_quant,
             ))
 
+        scale_name = "weight_scale_inv" if self.block_quant else "weight_scale"
         if self.linear_config.fuse_matmuls:
             layer.weight = Parameter(weights.weight, requires_grad=False)
-            layer.weight_scale = Parameter(weights.weight_scale,
-                                           requires_grad=False)
-            if bias is not None:
+            setattr(
+                layer,
+                scale_name,
+                Parameter(weights.weight_scale, requires_grad=False),
+            )
+            if has_bias:
                 layer.bias = Parameter(weights.bias, requires_grad=False)
         else:
             layer.weight = to_parameter_list(weights.weight)
-            layer.weight_scale = to_parameter_list(weights.weight_scale)
-            if bias is not None:
+            setattr(
+                layer,
+                scale_name,
+                to_parameter_list(weights.weight_scale),
+            )
+            if has_bias:
                 layer.bias = to_parameter_list(weights.bias)
+
+        import ctypes
+
+        gc.collect()
+        jax.effects_barrier()
+        try:
+            ctypes.CDLL("libc.so.6").malloc_trim(0)
+        except Exception:
+            pass
 
     def apply(self,
               layer: torch.nn.Module,
               x: torch.Tensor,
               bias: Optional[torch.Tensor] = None) -> torch.Tensor:
+        scale_name = "weight_scale_inv" if self.block_quant else "weight_scale"
         with jax.named_scope(layer._get_name()):
             x_jax = jax_view(x)
             bias_jax = jax_view(
                 bias) if bias is not None and not layer.skip_bias_add else None
             if self.linear_config.fuse_matmuls:
                 weight_jax = jax_view(layer.weight)
-                weight_scale_jax = jax_view(layer.weight_scale)
+                weight_scale_jax = jax_view(getattr(layer, scale_name))
                 out = self._apply_fused(x_jax, weight_jax, weight_scale_jax,
                                         bias_jax)
             else:
                 assert isinstance(layer.weight, torch.nn.ParameterList)
-                assert isinstance(layer.weight_scale, torch.nn.ParameterList)
+                scale_params = getattr(layer, scale_name)
+                assert isinstance(scale_params, torch.nn.ParameterList)
                 # jax_view cannot handle ParameterList directly, so we explicitly
                 # convert them to list of jax.Array.
                 weight_and_scale = [
                     (jax_view(w), jax_view(s))
-                    for w, s in zip(layer.weight, layer.weight_scale)
+                    for w, s in zip(layer.weight, scale_params)
                 ]
                 if bias is not None and not layer.skip_bias_add:
                     assert isinstance(bias, torch.nn.ParameterList)
@@ -272,7 +350,7 @@ class VllmFp8LinearMethod(vllm_fp8.Fp8LinearMethod,
             return torch_view(out)
 
 
-class VllmFp8MoEMethod(vllm_fp8.Fp8MoEMethod):
+class VllmFp8MoEMethod(vllm_fp8.Fp8MoEMethod, VllmQuantizationMethod):
 
     def __init__(self,
                  quant_config: vllm_fp8.Fp8Config,
@@ -295,23 +373,53 @@ class VllmFp8MoEMethod(vllm_fp8.Fp8MoEMethod):
     def is_monolithic(self) -> bool:
         return True
 
-    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
-        assert isinstance(layer, RoutedExperts)
+    def maybe_process_weights(self, layer: torch.nn.Module, param_name: str,
+                              args, kwargs):
+        """Check if all weights are loaded for the MoE layer.
 
+        If so, process and shard the weights.
+        """
+        if not envs.VLLM_INCREMENTAL_FP8_LOADING:
+            return
+
+        expert_id = kwargs.get("expert_id")
+        shard_id = kwargs.get("shard_id")
+        if expert_id is not None and shard_id is not None:
+            layer._loaded_weights.add((param_name, expert_id, shard_id))
+        else:
+            layer._loaded_weights.add(param_name)
+
+        num_experts = getattr(layer, "global_num_experts", 0)
+        scale_w13_expected = num_experts * 2 if self.block_quant else 1
+        scale_w2_expected = num_experts * 1 if self.block_quant else 1
+        expected_shards = ((num_experts * 2) + (num_experts * 1) +
+                           scale_w13_expected + scale_w2_expected)
+
+        if len(layer._loaded_weights) >= expected_shards:
+            self.process_weights_after_loading(layer)
+
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        if not hasattr(layer, "w13_weight") or not _tensor_is_in_cpu(
+                layer.w13_weight):
+            return
+        assert isinstance(layer, RoutedExperts)
         assert not self.moe.has_bias
 
-        w13_weight = t2j(layer.w13_weight, use_dlpack=False)
-        w2_weight = t2j(layer.w2_weight, use_dlpack=False)
+        ep_sharding = NamedSharding(self.mesh, P(ShardingAxisName.EXPERT))
 
-        if self.block_quant:
-            w13_weight_scale = t2j(layer.w13_weight_scale_inv,
-                                   use_dlpack=False)
-            w2_weight_scale = t2j(layer.w2_weight_scale_inv, use_dlpack=False)
-        else:
-            w13_weight_scale = t2j(layer.w13_weight_scale, use_dlpack=False)
-            w2_weight_scale = t2j(layer.w2_weight_scale, use_dlpack=False)
+        w13_weight = _load_weight_for_layer(layer, "w13_weight", ep_sharding)
+        w2_weight = _load_weight_for_layer(layer, "w2_weight", ep_sharding)
 
-        # TODO: do we need to support bias?
+        scale_w13_name = f"w13_{self.weight_scale_name}"
+        scale_w2_name = f"w2_{self.weight_scale_name}"
+        w13_weight_scale = _load_weight_for_layer(layer, scale_w13_name,
+                                                  ep_sharding)
+        w2_weight_scale = _load_weight_for_layer(layer, scale_w2_name,
+                                                 ep_sharding)
+
+        p_w13_scale = getattr(layer, scale_w13_name)
+        p_w2_scale = getattr(layer, scale_w2_name)
+
         input_weights = FusedMoEWeights(
             w13_weight=w13_weight,
             w13_weight_scale=w13_weight_scale,
@@ -333,6 +441,19 @@ class VllmFp8MoEMethod(vllm_fp8.Fp8MoEMethod):
             # Convert to tuple so jax jit can hash it
             weight_block_size=weight_block_size,
         )
+
+        # Free CPU memory now that weights have been safely transferred to TPU
+        layer.w13_weight.untyped_storage().resize_(0)
+        layer.w2_weight.untyped_storage().resize_(0)
+        p_w13_scale.set_(torch.storage.UntypedStorage())
+        p_w2_scale.set_(torch.storage.UntypedStorage())
+        delattr(layer, "w13_weight")
+        delattr(layer, "w2_weight")
+        delattr(layer, scale_w13_name)
+        delattr(layer, scale_w2_name)
+
+        del w13_weight, w2_weight, w13_weight_scale, w2_weight_scale, input_weights
+
         weights = torch_view(
             shard_moe_weights(weights, self.moe_backend, self.mesh))
 
@@ -342,10 +463,24 @@ class VllmFp8MoEMethod(vllm_fp8.Fp8MoEMethod):
         # Use setattr to dynamically assign the correct scale parameter name
         # based on the quantization type. vLLM uses 'weight_scale_inv' for
         # block-quantized scales and 'weight_scale' for per-tensor/per-channel scales.
-        setattr(layer, f"w13_{self.weight_scale_name}",
-                Parameter(weights.w13_weight_scale, requires_grad=False))
-        setattr(layer, f"w2_{self.weight_scale_name}",
-                Parameter(weights.w2_weight_scale, requires_grad=False))
+        setattr(
+            layer,
+            scale_w13_name,
+            Parameter(weights.w13_weight_scale, requires_grad=False),
+        )
+        setattr(
+            layer,
+            scale_w2_name,
+            Parameter(weights.w2_weight_scale, requires_grad=False),
+        )
+        import ctypes
+
+        gc.collect()
+        jax.effects_barrier()
+        try:
+            ctypes.CDLL("libc.so.6").malloc_trim(0)
+        except Exception:
+            pass
 
     def apply_monolithic(
         self,

--- a/tpu_inference/layers/vllm/quantization/fp8.py
+++ b/tpu_inference/layers/vllm/quantization/fp8.py
@@ -22,6 +22,7 @@ import torch
 from jax.sharding import Mesh, NamedSharding, PartitionSpec
 from torch.nn.parameter import Parameter
 from torchax.interop import jax_view, torch_view
+from torchax.ops.mappings import t2j
 from vllm.model_executor.layers import linear as vllm_linear
 from vllm.model_executor.layers.attention import Attention
 from vllm.model_executor.layers.fused_moe import (FusedMoEMethodBase,
@@ -232,9 +233,9 @@ class VllmFp8LinearMethod(
             # Float8_e8m0fnu (ue8m0) scales cannot be converted via numpy in t2j.
             # TODO: consider get rid of the f32 conversion, to optimize the HBM usage.
             if weight_scale_inv.dtype == torch.float8_e8m0fnu:
-                layer.weight_scale_inv = Parameter(
-                    weight_scale_inv.to(torch.float32), requires_grad=False
-                )
+                layer.weight_scale_inv = Parameter(weight_scale_inv.to(
+                    torch.float32),
+                                                   requires_grad=False)
             weight_scale = _load_weight_for_layer(layer, "weight_scale_inv",
                                                   loading_sharding)
             weight_scale = jnp.transpose(weight_scale)
@@ -243,9 +244,9 @@ class VllmFp8LinearMethod(
         else:
             weight_scale_tensor = layer.weight_scale
             if weight_scale_tensor.dtype == torch.float8_e8m0fnu:
-                layer.weight_scale = Parameter(
-                    weight_scale_tensor.to(torch.float32), requires_grad=False
-                )
+                layer.weight_scale = Parameter(weight_scale_tensor.to(
+                    torch.float32),
+                                               requires_grad=False)
             scale_sharding = NamedSharding(self.linear_config.mesh, P(None))
             weight_scale = _load_weight_for_layer(layer, "weight_scale",
                                                   scale_sharding)
@@ -312,9 +313,8 @@ class VllmFp8LinearMethod(
 
         if self.linear_config.fuse_matmuls:
             layer.weight = Parameter(weights.weight, requires_grad=False)
-            layer.weight_scale = Parameter(
-                weights.weight_scale, requires_grad=False
-            )
+            layer.weight_scale = Parameter(weights.weight_scale,
+                                           requires_grad=False)
             if has_bias:
                 layer.bias = Parameter(weights.bias, requires_grad=False)
         else:
@@ -343,9 +343,10 @@ class VllmFp8LinearMethod(
                 assert isinstance(layer.weight_scale, torch.nn.ParameterList)
                 # jax_view cannot handle ParameterList directly, so we explicitly
                 # convert them to list of jax.Array.
-                weight_and_scale = [(jax_view(w), jax_view(s))
-                                    for w, s in zip(layer.weight, layer.weight_scale)
-                                    ]
+                weight_and_scale = [
+                    (jax_view(w), jax_view(s))
+                    for w, s in zip(layer.weight, layer.weight_scale)
+                ]
                 if bias is not None and not layer.skip_bias_add:
                     assert isinstance(bias, torch.nn.ParameterList)
                     bias_jax = [jax_view(b) for b in bias]

--- a/tpu_inference/layers/vllm/quantization/fp8.py
+++ b/tpu_inference/layers/vllm/quantization/fp8.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import ctypes
+import ctypes.util
 import gc
 from typing import Optional, Union
 
@@ -63,6 +64,8 @@ P = PartitionSpec
 logger = init_logger(__name__)
 
 
+# TODO: Use custom op with overriding weight loading class so we will have a better
+# and cleaner interface.
 def _free_torch_storage(tensor: Optional[torch.Tensor]) -> None:
     """Safely frees the underlying CPU memory storage of a PyTorch tensor.
 
@@ -77,23 +80,20 @@ def _free_torch_storage(tensor: Optional[torch.Tensor]) -> None:
         tensor.set_(torch.storage.UntypedStorage())
 
 
-try:
-    _libc = ctypes.CDLL("libc.so.6")
-except Exception:
-    _libc = None
-
-
 def _release_host_memory() -> None:
     """Frees CPU host memory and trims malloc arena if incremental FP8 loading is enabled."""
     if not envs.VLLM_INCREMENTAL_FP8_LOADING:
         return
     gc.collect()
     jax.effects_barrier()
-    if _libc is not None and hasattr(_libc, "malloc_trim"):
-        try:
-            _libc.malloc_trim(0)
-        except Exception as e:
-            logger.debug(f"[fp8-incremental] malloc_trim failed: {e}")
+    try:
+        # Dynamically locate the system standard C library (e.g. libc.so.6 on Linux)
+        # to invoke glibc's malloc_trim(0) and return freed CPU pages to the kernel.
+        libc_name = ctypes.util.find_library("c")
+        if libc_name:
+            ctypes.CDLL(libc_name).malloc_trim(0)
+    except Exception as e:
+        logger.debug(f"[fp8-incremental] malloc_trim failed: {e}")
 
 
 @register_quantization_config(FP8)
@@ -403,6 +403,9 @@ class VllmFp8MoEMethod(vllm_fp8.Fp8MoEMethod, VllmQuantizationMethod):
 
         layer._loaded_weights.add((param_name, expert_id, shard_id))
 
+        # For block-quantized FP8 MoE, each expert has 6 parameter shards:
+        # w1_weight, w1_weight_scale_inv, w3_weight, w3_weight_scale_inv,
+        # w2_weight, and w2_weight_scale_inv.
         expected_shards = 6 * layer.global_num_experts
 
         if len(layer._loaded_weights) >= expected_shards:

--- a/tpu_inference/layers/vllm/quantization/unquantized.py
+++ b/tpu_inference/layers/vllm/quantization/unquantized.py
@@ -212,9 +212,8 @@ class VllmUnquantizedLinearMethod(vllm_linear.UnquantizedLinearMethod,
     def maybe_process_weights(self, layer: torch.nn.Module, param_name: str,
                               args, kwargs):
         """Check if all weights are loaded for the layer. If so, process and shard the weights."""
-        self.maybe_process_linear_weights(
-            layer, param_name, args, kwargs, self.linear_config.num_proj
-        )
+        self.maybe_process_linear_weights(layer, param_name, args, kwargs,
+                                          self.linear_config.num_proj)
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
         if not _tensor_is_in_cpu(layer.weight):

--- a/tpu_inference/layers/vllm/quantization/unquantized.py
+++ b/tpu_inference/layers/vllm/quantization/unquantized.py
@@ -211,46 +211,10 @@ class VllmUnquantizedLinearMethod(vllm_linear.UnquantizedLinearMethod,
 
     def maybe_process_weights(self, layer: torch.nn.Module, param_name: str,
                               args, kwargs):
-        """Check if all weights are loaded for the layer. If so, process and shard the weights.
-
-        Note on Fused Weight Loading (e.g., Qwen3-VL / Qwen3-VL-MoE / Qwen2.5-VL Vision Encoder):
-        Historically, LLMs stored attention Q/K/V weights separately in HuggingFace checkpoints,
-        and vLLM loaded them per shard (passing shard_id in `args`).
-        However, newer multimodal models like Qwen3-VL / Qwen3-VL-MoE store vision attention weights
-        already fused on disk (e.g., `attn.qkv.weight`). In such cases, vLLM's weight loader is invoked
-        without a shard_id (`args` is empty), and vLLM internally slices and copies the fused weight.
-        To support TPU incremental sharding for these fused weights, we detect when `args` is empty
-        and immediately register all underlying shards ('q', 'k', 'v') as loaded to satisfy the sharding trigger.
-        """
-        if isinstance(layer, vllm_linear.QKVParallelLinear):
-            if len(args) == 1:
-                shard_id = args[0]
-                layer._loaded_weights.add((param_name, shard_id))
-            else:
-                # Fused weight loaded in one go (e.g., Qwen3-VL / Qwen3-VL-MoE vision encoder `attn.qkv.weight`).
-                # vLLM's QKVParallelLinear.weight_loader internally slices the weight into q, k, v.
-                # We register all 3 shards to immediately trigger process_weights_after_loading.
-                layer._loaded_weights.add((param_name, 'q'))
-                layer._loaded_weights.add((param_name, 'k'))
-                layer._loaded_weights.add((param_name, 'v'))
-        elif isinstance(layer, vllm_linear.MergedColumnParallelLinear):
-            if len(args) == 1:
-                shard_id = args[0]
-                layer._loaded_weights.add((param_name, shard_id))
-            else:
-                # Fused weight loaded in one go (e.g., MLP gate_up_proj fused on disk).
-                # Register all output partitions to immediately trigger process_weights_after_loading.
-                for i in range(len(layer.output_sizes)):
-                    layer._loaded_weights.add((param_name, i))
-        else:
-            # Keep track of loaded weights for other linear layers, e.g. ('weight', 'bias')
-            layer._loaded_weights.add(param_name)
-
-        if len(layer._loaded_weights) == self.linear_config.num_proj * len(
-                dict(layer.named_parameters(recurse=False))):
-            logger.debug(f"Start sharding weights for layer {type(layer)}")
-            self.process_weights_after_loading(layer)
-            logger.debug(f"Complete sharding weights for layer {type(layer)}")
+        """Check if all weights are loaded for the layer. If so, process and shard the weights."""
+        self.maybe_process_linear_weights(
+            layer, param_name, args, kwargs, self.linear_config.num_proj
+        )
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
         if not _tensor_is_in_cpu(layer.weight):

--- a/tpu_inference/models/vllm/vllm_model_loader.py
+++ b/tpu_inference/models/vllm/vllm_model_loader.py
@@ -44,7 +44,8 @@ def attach_incremental_weight_loader(model: torch.nn.Module) -> None:
             res = original_loader(param, loaded_weight, *args, **kwargs)
 
             # Processing and sharding
-            # For now, only handle unquantized linear and moe layers.
+            # Incremental processing and sharding for supported layers.
+            # Currently only unquantized and fp8 linear and moe layers supported.
             quant_method = getattr(layer, "quant_method", None)
             if isinstance(quant_method, VllmQuantizationMethod):
                 quant_method.maybe_process_weights(layer, param_name, args,


### PR DESCRIPTION
# Description

This PR introduces an **Incremental FP8 Weight Streaming Loader** (`VLLM_INCREMENTAL_FP8_LOADING`) for FP8 MoE models.

### Context & Problem
Under standard loading for FP8 models, vLLM loads and retains all checkpoint shards in host memory simultaneously and then shard them to TPUs. 

TPU8i has strict host RAM limits (**~384 GB RAM limit**). As a result, standard loading triggers host Out-Of-Memory (OOM) crashes or severe memory pressure when initializing large FP8 MoE models.

### Solution & Implementation
This PR adds support for layer-by-layer incremental weight processing and sharding in FP8 MoE layers (`VllmFp8MoEMethod`):
- `VllmFp8MoEMethod` now inherits from `VllmQuantizationMethod` and implements `maybe_process_weights` and `process_weights_after_loading`.
- Weight parameters for each MoE layer are converted into JAX arrays as soon as their respective safetensor shards finish loading.
- PyTorch CPU tensor storage for each layer is immediately freed via `untyped_storage().resize_(0)`, `delattr`, `gc.collect()`, and `malloc_trim(0)`.
- Drops PyTorch CPU tensor memory usage, keeping peak host RAM safely beneath the host RAM limit.

---

# Tests

Verified on TPU VM (TPU v7x-8, 4 TPU chips) using `Qwen/Qwen3.5-397B-A17B-FP8`:

### 1. Host Memory & Weight Load Time Benchmarks
| Metric / Resource | Standard Baseline (`VLLM_INCREMENTAL_FP8_LOADING=False`) | Incremental FP8 Streaming (`VLLM_INCREMENTAL_FP8_LOADING=True`) | Trade-off / Savings |
| :--- | :--- | :--- | :--- |
| **Peak Host RAM (RSS)** | **418.95 GB** *(Exceeds 384GB limit)* | **219.40 GB** *(Safely within host RAM)* |  **~200 GB RAM Savings (~47.6% Peak Reduction)** |
| **Max PyTorch CPU Memory** | **314.40 GB** | **12.8 GB** | **-301.6 GB PyTorch CPU Storage Saved** |
| **Model Weight Load Time** | **431.77 s** (~7.2 min) | **652.11 s** (~10.8 min) |  **+3.6 min overhead for layer-by-layer CPU freeing** |

### 2. Quality & Accuracy Evaluation Results
| Benchmark | Standard Baseline (VLLM_INCREMENTAL_FP8_LOADING=0) | Incremental FP8 Streaming (VLLM_INCREMENTAL_FP8_LOADING=1) |
| :--- | :--- | :--- |
| GPQA Diamond (CoT 0-shot) | 7.58% (0.0758 ± 0.0189) | 8.59% (0.0859 ± 0.0200) |
| MMLU-Pro (5-shot, 700 sample) | 80.14% (0.8014 ± 0.0147) | 81.29% (0.8129 ± 0.0144) |
---
# Checklist
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have made or will make corresponding changes to any relevant documentation.

